### PR TITLE
Feat/calendar alignment

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+[feat]: add CalendarAligned budget field, GetCalendarPeriodStart and IsCalendarAlignableDuration helpers [@17jmumford](https://github.com/17jmumford)

--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -15,6 +15,10 @@ type TableBudget struct {
 	LastReset     time.Time `gorm:"index" json:"last_reset"`                         // Last time budget was reset
 	CurrentUsage  float64   `gorm:"default:0" json:"current_usage"`                  // Current usage in dollars
 
+	// CalendarAligned snaps LastReset to the start of the current calendar period (day, week, month, year)
+	// instead of the exact creation/update time, so budgets reset at clean calendar boundaries.
+	CalendarAligned bool `gorm:"default:false" json:"calendar_aligned"`
+
 	// Config hash is used to detect the changes synced from config.json file
 	// Every time we sync the config.json file, we will update the config hash
 	ConfigHash string `gorm:"type:varchar(255);null" json:"config_hash"`

--- a/framework/configstore/tables/utils.go
+++ b/framework/configstore/tables/utils.go
@@ -5,6 +5,54 @@ import (
 	"time"
 )
 
+// IsCalendarAlignableDuration reports whether the given duration string supports calendar-aligned resets.
+// Only day ("d"), week ("w"), month ("M"), and year ("Y") suffixes have natural calendar boundaries.
+// Sub-day durations like "1h", "30m" are not alignable.
+func IsCalendarAlignableDuration(duration string) bool {
+	if duration == "" {
+		return false
+	}
+	switch duration[len(duration)-1] {
+	case 'd', 'w', 'M', 'Y':
+		return true
+	default:
+		return false
+	}
+}
+
+// GetCalendarPeriodStart returns the start of the current calendar period for the given duration and time.
+// For calendar-scale durations (daily, weekly, monthly, yearly) it snaps to clean boundaries in UTC:
+//   - "Nd"  → midnight UTC on the current day
+//   - "Nw"  → midnight UTC on the most recent Monday
+//   - "NM"  → midnight UTC on the 1st of the current month
+//   - "NY"  → midnight UTC on Jan 1 of the current year
+//
+// For all other durations (e.g. "1h", "30m") the original time t is returned unchanged,
+// since sub-day periods don't have a natural calendar boundary.
+func GetCalendarPeriodStart(duration string, t time.Time) time.Time {
+	if duration == "" {
+		return t
+	}
+	t = t.UTC()
+	suffix := duration[len(duration)-1:]
+	switch suffix {
+	case "d":
+		return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+	case "w":
+		weekday := int(t.Weekday())
+		// Sunday = 0, so shift to Monday = 0
+		daysFromMonday := (weekday + 6) % 7
+		monday := t.AddDate(0, 0, -daysFromMonday)
+		return time.Date(monday.Year(), monday.Month(), monday.Day(), 0, 0, 0, 0, time.UTC)
+	case "M":
+		return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, time.UTC)
+	case "Y":
+		return time.Date(t.Year(), time.January, 1, 0, 0, 0, 0, time.UTC)
+	default:
+		return t
+	}
+}
+
 // ParseDuration function to parse duration strings
 func ParseDuration(duration string) (time.Duration, error) {
 	if duration == "" {

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,0 +1,1 @@
+[feat]: snap LastReset to calendar boundary for calendar-aligned budgets [@17jmumford](https://github.com/17jmumford)

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1469,7 +1469,11 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context)
 			copiedBudget := *budget
 			oldUsage := copiedBudget.CurrentUsage
 			copiedBudget.CurrentUsage = 0
-			copiedBudget.LastReset = now
+			if budget.CalendarAligned {
+				copiedBudget.LastReset = configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, now)
+			} else {
+				copiedBudget.LastReset = now
+			}
 			gs.LastDBUsagesBudgetsMu.Lock()
 			gs.LastDBUsagesBudgets[copiedBudget.ID] = 0
 			gs.LastDBUsagesBudgetsMu.Unlock()

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1458,22 +1458,38 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context)
 			return true // continue
 		}
 
-		duration, err := configstoreTables.ParseDuration(budget.ResetDuration)
-		if err != nil {
-			gs.logger.Error("invalid budget reset duration %s: %v", budget.ResetDuration, err)
-			return true // continue
+		// Determine whether the budget needs resetting
+		var shouldReset bool
+		var newLastReset time.Time
+
+		if budget.CalendarAligned {
+			// Calendar-aligned: reset when we've entered a genuinely new calendar period.
+			// This avoids the double-reset bug with rolling durations in months with
+			// more days than ParseDuration approximates (e.g. 31-day months with "1M" = 30 days).
+			currentPeriodStart := configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, now)
+			if currentPeriodStart.After(budget.LastReset) {
+				shouldReset = true
+				newLastReset = currentPeriodStart
+			}
+		} else {
+			// Rolling duration: reset after the configured duration has elapsed
+			duration, err := configstoreTables.ParseDuration(budget.ResetDuration)
+			if err != nil {
+				gs.logger.Error("invalid budget reset duration %s: %v", budget.ResetDuration, err)
+				return true // continue
+			}
+			if now.Sub(budget.LastReset) >= duration {
+				shouldReset = true
+				newLastReset = now
+			}
 		}
 
-		if now.Sub(budget.LastReset) >= duration {
+		if shouldReset {
 			// Create a copy to avoid data race (sync.Map is concurrent-safe for reads/writes but not mutations)
 			copiedBudget := *budget
 			oldUsage := copiedBudget.CurrentUsage
 			copiedBudget.CurrentUsage = 0
-			if budget.CalendarAligned {
-				copiedBudget.LastReset = configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, now)
-			} else {
-				copiedBudget.LastReset = now
-			}
+			copiedBudget.LastReset = newLastReset
 			gs.LastDBUsagesBudgetsMu.Lock()
 			gs.LastDBUsagesBudgets[copiedBudget.ID] = 0
 			gs.LastDBUsagesBudgetsMu.Unlock()

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1341,20 +1341,23 @@ func (h *GovernanceHandler) createTeam(ctx *fasthttp.RequestCtx) {
 			Name:       req.Name,
 			CustomerID: req.CustomerID,
 		}
-		if req.Budget != nil {
-			budget := configstoreTables.TableBudget{
-				ID:              uuid.NewString(),
-				MaxLimit:        req.Budget.MaxLimit,
-				ResetDuration:   req.Budget.ResetDuration,
-				CalendarAligned: req.Budget.CalendarAligned,
-				LastReset:       budgetLastReset(req.Budget.CalendarAligned, req.Budget.ResetDuration),
-				CurrentUsage:    0,
-			}
-			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-				return err
-			}
-			team.BudgetID = &budget.ID
+	if req.Budget != nil {
+		budget := configstoreTables.TableBudget{
+			ID:              uuid.NewString(),
+			MaxLimit:        req.Budget.MaxLimit,
+			ResetDuration:   req.Budget.ResetDuration,
+			CalendarAligned: req.Budget.CalendarAligned,
+			LastReset:       budgetLastReset(req.Budget.CalendarAligned, req.Budget.ResetDuration),
+			CurrentUsage:    0,
 		}
+		if err := validateBudget(&budget); err != nil {
+			return err
+		}
+		if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+			return err
+		}
+		team.BudgetID = &budget.ID
+	}
 		if req.RateLimit != nil {
 			rateLimit := configstoreTables.TableRateLimit{
 				ID:                   uuid.NewString(),
@@ -1463,8 +1466,8 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 		}
 		// Handle budget updates
 		if req.Budget != nil {
-			// Check if budget limit is empty - means remove budget (reset duration doesn't matter)
-			budgetIsEmpty := req.Budget.MaxLimit == nil
+			// Check if budget removal is requested (all fields nil)
+			budgetIsEmpty := isBudgetRemovalRequest(req.Budget)
 			if budgetIsEmpty {
 				// Mark budget for deletion after FK is removed
 				if team.BudgetID != nil {
@@ -1473,16 +1476,17 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 					team.Budget = nil
 				}
 			} else if team.BudgetID != nil {
-			// Update existing budget
-			if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-				return fmt.Errorf("both max_limit and reset_duration are required when updating a budget")
-			}
+			// Update existing budget — all fields are optional (partial update)
 			budget := configstoreTables.TableBudget{}
 			if err := tx.First(&budget, "id = ?", *team.BudgetID).Error; err != nil {
 				return err
 			}
-			budget.MaxLimit = *req.Budget.MaxLimit
-			budget.ResetDuration = *req.Budget.ResetDuration
+			if req.Budget.MaxLimit != nil {
+				budget.MaxLimit = *req.Budget.MaxLimit
+			}
+			if req.Budget.ResetDuration != nil {
+				budget.ResetDuration = *req.Budget.ResetDuration
+			}
 			if req.Budget.CalendarAligned != nil {
 				wasCalendarAligned := budget.CalendarAligned
 				budget.CalendarAligned = *req.Budget.CalendarAligned
@@ -1749,20 +1753,23 @@ func (h *GovernanceHandler) createCustomer(ctx *fasthttp.RequestCtx) {
 			Name: req.Name,
 		}
 
-		if req.Budget != nil {
-			budget := configstoreTables.TableBudget{
-				ID:              uuid.NewString(),
-				MaxLimit:        req.Budget.MaxLimit,
-				ResetDuration:   req.Budget.ResetDuration,
-				CalendarAligned: req.Budget.CalendarAligned,
-				LastReset:       budgetLastReset(req.Budget.CalendarAligned, req.Budget.ResetDuration),
-				CurrentUsage:    0,
-			}
-			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-				return err
-			}
-			customer.BudgetID = &budget.ID
+	if req.Budget != nil {
+		budget := configstoreTables.TableBudget{
+			ID:              uuid.NewString(),
+			MaxLimit:        req.Budget.MaxLimit,
+			ResetDuration:   req.Budget.ResetDuration,
+			CalendarAligned: req.Budget.CalendarAligned,
+			LastReset:       budgetLastReset(req.Budget.CalendarAligned, req.Budget.ResetDuration),
+			CurrentUsage:    0,
 		}
+		if err := validateBudget(&budget); err != nil {
+			return err
+		}
+		if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+			return err
+		}
+		customer.BudgetID = &budget.ID
+	}
 		if req.RateLimit != nil {
 			rateLimit := configstoreTables.TableRateLimit{
 				ID:                   uuid.NewString(),
@@ -1861,8 +1868,8 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 		}
 		// Handle budget updates
 		if req.Budget != nil {
-			// Check if budget limit is empty - means remove budget (reset duration doesn't matter)
-			budgetIsEmpty := req.Budget.MaxLimit == nil
+			// Check if budget removal is requested (all fields nil)
+			budgetIsEmpty := isBudgetRemovalRequest(req.Budget)
 			if budgetIsEmpty {
 				// Mark budget for deletion after FK is removed
 				if customer.BudgetID != nil {
@@ -1871,16 +1878,17 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 					customer.Budget = nil
 				}
 			} else if customer.BudgetID != nil {
-			// Update existing budget
-			if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-				return fmt.Errorf("both max_limit and reset_duration are required when updating a budget")
-			}
+			// Update existing budget — all fields are optional (partial update)
 			budget := configstoreTables.TableBudget{}
 			if err := tx.First(&budget, "id = ?", *customer.BudgetID).Error; err != nil {
 				return err
 			}
-			budget.MaxLimit = *req.Budget.MaxLimit
-			budget.ResetDuration = *req.Budget.ResetDuration
+			if req.Budget.MaxLimit != nil {
+				budget.MaxLimit = *req.Budget.MaxLimit
+			}
+			if req.Budget.ResetDuration != nil {
+				budget.ResetDuration = *req.Budget.ResetDuration
+			}
 			if req.Budget.CalendarAligned != nil {
 				wasCalendarAligned := budget.CalendarAligned
 				budget.CalendarAligned = *req.Budget.CalendarAligned
@@ -2388,8 +2396,8 @@ func (h *GovernanceHandler) updateModelConfig(ctx *fasthttp.RequestCtx) {
 		}
 		// Handle budget updates
 		if req.Budget != nil {
-			// Check if budget limit is empty - means remove budget (reset duration doesn't matter)
-			budgetIsEmpty := req.Budget.MaxLimit == nil
+			// Check if budget removal is requested (all fields nil)
+			budgetIsEmpty := isBudgetRemovalRequest(req.Budget)
 			if budgetIsEmpty {
 				// Mark budget for deletion after FK is removed
 				if mc.BudgetID != nil {
@@ -2398,18 +2406,17 @@ func (h *GovernanceHandler) updateModelConfig(ctx *fasthttp.RequestCtx) {
 					mc.Budget = nil
 				}
 			} else if mc.BudgetID != nil {
-			// Update existing budget
-			// Validate that both fields are present before dereferencing
-			if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-				return fmt.Errorf("both max_limit and reset_duration are required when updating a budget")
-			}
+			// Update existing budget — all fields are optional (partial update)
 			budget := configstoreTables.TableBudget{}
 			if err := tx.First(&budget, "id = ?", *mc.BudgetID).Error; err != nil {
 				return err
 			}
-			// Set all fields from request
-			budget.MaxLimit = *req.Budget.MaxLimit
-			budget.ResetDuration = *req.Budget.ResetDuration
+			if req.Budget.MaxLimit != nil {
+				budget.MaxLimit = *req.Budget.MaxLimit
+			}
+			if req.Budget.ResetDuration != nil {
+				budget.ResetDuration = *req.Budget.ResetDuration
+			}
 			if req.Budget.CalendarAligned != nil {
 				wasCalendarAligned := budget.CalendarAligned
 				budget.CalendarAligned = *req.Budget.CalendarAligned
@@ -2661,8 +2668,8 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 
 		// Handle budget updates
 		if req.Budget != nil {
-			// Check if budget limit is empty - means remove budget (reset duration doesn't matter)
-			budgetIsEmpty := req.Budget.MaxLimit == nil
+			// Check if budget removal is requested (all fields nil)
+			budgetIsEmpty := isBudgetRemovalRequest(req.Budget)
 			if budgetIsEmpty {
 				// Mark budget for deletion after FK is removed
 				if provider.BudgetID != nil {
@@ -2671,18 +2678,17 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 					provider.Budget = nil
 				}
 			} else if provider.BudgetID != nil {
-			// Update existing budget
-			// Validate that both fields are present before dereferencing
-			if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-				return fmt.Errorf("both max_limit and reset_duration are required when updating a budget")
-			}
+			// Update existing budget — all fields are optional (partial update)
 			budget := configstoreTables.TableBudget{}
 			if err := tx.First(&budget, "id = ?", *provider.BudgetID).Error; err != nil {
 				return err
 			}
-			// Set all fields from request
-			budget.MaxLimit = *req.Budget.MaxLimit
-			budget.ResetDuration = *req.Budget.ResetDuration
+			if req.Budget.MaxLimit != nil {
+				budget.MaxLimit = *req.Budget.MaxLimit
+			}
+			if req.Budget.ResetDuration != nil {
+				budget.ResetDuration = *req.Budget.ResetDuration
+			}
 			if req.Budget.CalendarAligned != nil {
 				wasCalendarAligned := budget.CalendarAligned
 				budget.CalendarAligned = *req.Budget.CalendarAligned

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -112,14 +112,16 @@ type UpdateVirtualKeyRequest struct {
 
 // CreateBudgetRequest represents the request body for creating a budget
 type CreateBudgetRequest struct {
-	MaxLimit      float64 `json:"max_limit" validate:"required"`      // Maximum budget in dollars
-	ResetDuration string  `json:"reset_duration" validate:"required"` // e.g., "30s", "5m", "1h", "1d", "1w", "1M"
+	MaxLimit        float64 `json:"max_limit" validate:"required"`      // Maximum budget in dollars
+	ResetDuration   string  `json:"reset_duration" validate:"required"` // e.g., "30s", "5m", "1h", "1d", "1w", "1M"
+	CalendarAligned bool    `json:"calendar_aligned,omitempty"`         // Snap resets to calendar boundaries (day/week/month/year)
 }
 
 // UpdateBudgetRequest represents the request body for updating a budget
 type UpdateBudgetRequest struct {
-	MaxLimit      *float64 `json:"max_limit,omitempty"`
-	ResetDuration *string  `json:"reset_duration,omitempty"`
+	MaxLimit        *float64 `json:"max_limit,omitempty"`
+	ResetDuration   *string  `json:"reset_duration,omitempty"`
+	CalendarAligned *bool    `json:"calendar_aligned,omitempty"` // When switching to true, current usage is reset to 0
 }
 
 // RoutingTarget represents a single weighted routing target within a rule.
@@ -177,7 +179,17 @@ type UpdateRateLimitRequest struct {
 }
 
 func isBudgetRemovalRequest(req *UpdateBudgetRequest) bool {
-	return req != nil && req.MaxLimit == nil && req.ResetDuration == nil
+	return req != nil && req.MaxLimit == nil && req.ResetDuration == nil && req.CalendarAligned == nil
+}
+
+// budgetLastReset returns the appropriate LastReset for a new budget.
+// When calendarAligned is true it snaps to the start of the current calendar period
+// (e.g. midnight on the 1st of the month for "1M"), otherwise it returns time.Now().
+func budgetLastReset(calendarAligned bool, resetDuration string) time.Time {
+	if calendarAligned {
+		return configstoreTables.GetCalendarPeriodStart(resetDuration, time.Now())
+	}
+	return time.Now()
 }
 
 func isRateLimitRemovalRequest(req *UpdateRateLimitRequest) bool {
@@ -446,11 +458,12 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 		}
 		if req.Budget != nil {
 			budget := configstoreTables.TableBudget{
-				ID:            uuid.NewString(),
-				MaxLimit:      req.Budget.MaxLimit,
-				ResetDuration: req.Budget.ResetDuration,
-				LastReset:     time.Now(),
-				CurrentUsage:  0,
+				ID:              uuid.NewString(),
+				MaxLimit:        req.Budget.MaxLimit,
+				ResetDuration:   req.Budget.ResetDuration,
+				CalendarAligned: req.Budget.CalendarAligned,
+				LastReset:       budgetLastReset(req.Budget.CalendarAligned, req.Budget.ResetDuration),
+				CurrentUsage:    0,
 			}
 			if err := validateBudget(&budget); err != nil {
 				return err
@@ -518,11 +531,12 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 				// Create budget for provider config if provided
 				if pc.Budget != nil {
 					budget := configstoreTables.TableBudget{
-						ID:            uuid.NewString(),
-						MaxLimit:      pc.Budget.MaxLimit,
-						ResetDuration: pc.Budget.ResetDuration,
-						LastReset:     time.Now(),
-						CurrentUsage:  0,
+						ID:              uuid.NewString(),
+						MaxLimit:        pc.Budget.MaxLimit,
+						ResetDuration:   pc.Budget.ResetDuration,
+						CalendarAligned: pc.Budget.CalendarAligned,
+						LastReset:       budgetLastReset(pc.Budget.CalendarAligned, pc.Budget.ResetDuration),
+						CurrentUsage:    0,
 					}
 					if err := validateBudget(&budget); err != nil {
 						return err
@@ -698,25 +712,33 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 					vk.Budget = nil
 				}
 			} else if vk.BudgetID != nil {
-				// Update existing budget
-				budget := configstoreTables.TableBudget{}
-				if err := tx.First(&budget, "id = ?", *vk.BudgetID).Error; err != nil {
-					return err
-				}
+			// Update existing budget
+			budget := configstoreTables.TableBudget{}
+			if err := tx.First(&budget, "id = ?", *vk.BudgetID).Error; err != nil {
+				return err
+			}
 
-				if req.Budget.MaxLimit != nil {
-					budget.MaxLimit = *req.Budget.MaxLimit
+			if req.Budget.MaxLimit != nil {
+				budget.MaxLimit = *req.Budget.MaxLimit
+			}
+			if req.Budget.ResetDuration != nil {
+				budget.ResetDuration = *req.Budget.ResetDuration
+			}
+			if req.Budget.CalendarAligned != nil {
+				wasCalendarAligned := budget.CalendarAligned
+				budget.CalendarAligned = *req.Budget.CalendarAligned
+				if *req.Budget.CalendarAligned && !wasCalendarAligned {
+					budget.LastReset = configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, time.Now())
+					budget.CurrentUsage = 0
 				}
-				if req.Budget.ResetDuration != nil {
-					budget.ResetDuration = *req.Budget.ResetDuration
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				vk.Budget = &budget
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			vk.Budget = &budget
 			} else {
 				// Create new budget
 				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
@@ -728,22 +750,23 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 				if _, err := configstoreTables.ParseDuration(*req.Budget.ResetDuration); err != nil {
 					return fmt.Errorf("invalid reset duration format: %s", *req.Budget.ResetDuration)
 				}
-				// Storing now
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     time.Now(),
-					CurrentUsage:  0,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				vk.BudgetID = &budget.ID
-				vk.Budget = &budget
+			calAligned := req.Budget.CalendarAligned != nil && *req.Budget.CalendarAligned
+			budget := configstoreTables.TableBudget{
+				ID:              uuid.NewString(),
+				MaxLimit:        *req.Budget.MaxLimit,
+				ResetDuration:   *req.Budget.ResetDuration,
+				CalendarAligned: calAligned,
+				LastReset:       budgetLastReset(calAligned, *req.Budget.ResetDuration),
+				CurrentUsage:    0,
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			vk.BudgetID = &budget.ID
+			vk.Budget = &budget
 			}
 		}
 		// Handle rate limit updates
@@ -852,23 +875,25 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 						AllowedModels: pc.AllowedModels,
 						Keys:          keys,
 					}
-					// Create budget for provider config if provided
-					if pc.Budget != nil {
-						budget := configstoreTables.TableBudget{
-							ID:            uuid.NewString(),
-							MaxLimit:      *pc.Budget.MaxLimit,
-							ResetDuration: *pc.Budget.ResetDuration,
-							LastReset:     time.Now(),
-							CurrentUsage:  0,
-						}
-						if err := validateBudget(&budget); err != nil {
-							return err
-						}
-						if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-							return err
-						}
-						providerConfig.BudgetID = &budget.ID
+				// Create budget for provider config if provided
+				if pc.Budget != nil {
+					pcCalAligned := pc.Budget.CalendarAligned != nil && *pc.Budget.CalendarAligned
+					budget := configstoreTables.TableBudget{
+						ID:              uuid.NewString(),
+						MaxLimit:        *pc.Budget.MaxLimit,
+						ResetDuration:   *pc.Budget.ResetDuration,
+						CalendarAligned: pcCalAligned,
+						LastReset:       budgetLastReset(pcCalAligned, *pc.Budget.ResetDuration),
+						CurrentUsage:    0,
 					}
+					if err := validateBudget(&budget); err != nil {
+						return err
+					}
+					if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+						return err
+					}
+					providerConfig.BudgetID = &budget.ID
+				}
 					// Create rate limit for provider config if provided
 					if pc.RateLimit != nil {
 						rateLimit := configstoreTables.TableRateLimit{
@@ -925,23 +950,31 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 								existing.Budget = nil
 							}
 						} else if existing.BudgetID != nil {
-							// Update existing budget
-							budget := configstoreTables.TableBudget{}
-							if err := tx.First(&budget, "id = ?", *existing.BudgetID).Error; err != nil {
-								return err
+						// Update existing budget
+						budget := configstoreTables.TableBudget{}
+						if err := tx.First(&budget, "id = ?", *existing.BudgetID).Error; err != nil {
+							return err
+						}
+						if pc.Budget.MaxLimit != nil {
+							budget.MaxLimit = *pc.Budget.MaxLimit
+						}
+						if pc.Budget.ResetDuration != nil {
+							budget.ResetDuration = *pc.Budget.ResetDuration
+						}
+						if pc.Budget.CalendarAligned != nil {
+							wasCalendarAligned := budget.CalendarAligned
+							budget.CalendarAligned = *pc.Budget.CalendarAligned
+							if *pc.Budget.CalendarAligned && !wasCalendarAligned {
+								budget.LastReset = configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, time.Now())
+								budget.CurrentUsage = 0
 							}
-							if pc.Budget.MaxLimit != nil {
-								budget.MaxLimit = *pc.Budget.MaxLimit
-							}
-							if pc.Budget.ResetDuration != nil {
-								budget.ResetDuration = *pc.Budget.ResetDuration
-							}
-							if err := validateBudget(&budget); err != nil {
-								return err
-							}
-							if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-								return err
-							}
+						}
+						if err := validateBudget(&budget); err != nil {
+							return err
+						}
+						if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
+							return err
+						}
 						} else {
 							// Create new budget for existing provider config
 							if pc.Budget.MaxLimit == nil || pc.Budget.ResetDuration == nil {
@@ -953,20 +986,22 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 							if _, err := configstoreTables.ParseDuration(*pc.Budget.ResetDuration); err != nil {
 								return fmt.Errorf("invalid provider config budget reset duration format: %s", *pc.Budget.ResetDuration)
 							}
-							budget := configstoreTables.TableBudget{
-								ID:            uuid.NewString(),
-								MaxLimit:      *pc.Budget.MaxLimit,
-								ResetDuration: *pc.Budget.ResetDuration,
-								LastReset:     time.Now(),
-								CurrentUsage:  0,
-							}
-							if err := validateBudget(&budget); err != nil {
-								return err
-							}
-							if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-								return err
-							}
-							existing.BudgetID = &budget.ID
+						pcExistCalAligned := pc.Budget.CalendarAligned != nil && *pc.Budget.CalendarAligned
+						budget := configstoreTables.TableBudget{
+							ID:              uuid.NewString(),
+							MaxLimit:        *pc.Budget.MaxLimit,
+							ResetDuration:   *pc.Budget.ResetDuration,
+							CalendarAligned: pcExistCalAligned,
+							LastReset:       budgetLastReset(pcExistCalAligned, *pc.Budget.ResetDuration),
+							CurrentUsage:    0,
+						}
+						if err := validateBudget(&budget); err != nil {
+							return err
+						}
+						if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+							return err
+						}
+						existing.BudgetID = &budget.ID
 						}
 					}
 					// Handle rate limit updates for provider config
@@ -1308,11 +1343,12 @@ func (h *GovernanceHandler) createTeam(ctx *fasthttp.RequestCtx) {
 		}
 		if req.Budget != nil {
 			budget := configstoreTables.TableBudget{
-				ID:            uuid.NewString(),
-				MaxLimit:      req.Budget.MaxLimit,
-				ResetDuration: req.Budget.ResetDuration,
-				LastReset:     time.Now(),
-				CurrentUsage:  0,
+				ID:              uuid.NewString(),
+				MaxLimit:        req.Budget.MaxLimit,
+				ResetDuration:   req.Budget.ResetDuration,
+				CalendarAligned: req.Budget.CalendarAligned,
+				LastReset:       budgetLastReset(req.Budget.CalendarAligned, req.Budget.ResetDuration),
+				CurrentUsage:    0,
 			}
 			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
 				return err
@@ -1437,23 +1473,31 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 					team.Budget = nil
 				}
 			} else if team.BudgetID != nil {
-				// Update existing budget
-				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-					return fmt.Errorf("both max_limit and reset_duration are required when updating a budget")
+			// Update existing budget
+			if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
+				return fmt.Errorf("both max_limit and reset_duration are required when updating a budget")
+			}
+			budget := configstoreTables.TableBudget{}
+			if err := tx.First(&budget, "id = ?", *team.BudgetID).Error; err != nil {
+				return err
+			}
+			budget.MaxLimit = *req.Budget.MaxLimit
+			budget.ResetDuration = *req.Budget.ResetDuration
+			if req.Budget.CalendarAligned != nil {
+				wasCalendarAligned := budget.CalendarAligned
+				budget.CalendarAligned = *req.Budget.CalendarAligned
+				if *req.Budget.CalendarAligned && !wasCalendarAligned {
+					budget.LastReset = configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, time.Now())
+					budget.CurrentUsage = 0
 				}
-				budget := configstoreTables.TableBudget{}
-				if err := tx.First(&budget, "id = ?", *team.BudgetID).Error; err != nil {
-					return err
-				}
-				budget.MaxLimit = *req.Budget.MaxLimit
-				budget.ResetDuration = *req.Budget.ResetDuration
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				team.Budget = &budget
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			team.Budget = &budget
 			} else {
 				// Create new budget
 				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
@@ -1465,21 +1509,23 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 				if _, err := configstoreTables.ParseDuration(*req.Budget.ResetDuration); err != nil {
 					return fmt.Errorf("invalid reset duration format: %s", *req.Budget.ResetDuration)
 				}
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     time.Now(),
-					CurrentUsage:  0,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				team.BudgetID = &budget.ID
-				team.Budget = &budget
+			teamCalAligned := req.Budget.CalendarAligned != nil && *req.Budget.CalendarAligned
+			budget := configstoreTables.TableBudget{
+				ID:              uuid.NewString(),
+				MaxLimit:        *req.Budget.MaxLimit,
+				ResetDuration:   *req.Budget.ResetDuration,
+				CalendarAligned: teamCalAligned,
+				LastReset:       budgetLastReset(teamCalAligned, *req.Budget.ResetDuration),
+				CurrentUsage:    0,
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			team.BudgetID = &budget.ID
+			team.Budget = &budget
 			}
 		}
 		// Handle rate limit updates
@@ -1705,11 +1751,12 @@ func (h *GovernanceHandler) createCustomer(ctx *fasthttp.RequestCtx) {
 
 		if req.Budget != nil {
 			budget := configstoreTables.TableBudget{
-				ID:            uuid.NewString(),
-				MaxLimit:      req.Budget.MaxLimit,
-				ResetDuration: req.Budget.ResetDuration,
-				LastReset:     time.Now(),
-				CurrentUsage:  0,
+				ID:              uuid.NewString(),
+				MaxLimit:        req.Budget.MaxLimit,
+				ResetDuration:   req.Budget.ResetDuration,
+				CalendarAligned: req.Budget.CalendarAligned,
+				LastReset:       budgetLastReset(req.Budget.CalendarAligned, req.Budget.ResetDuration),
+				CurrentUsage:    0,
 			}
 			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
 				return err
@@ -1824,23 +1871,31 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 					customer.Budget = nil
 				}
 			} else if customer.BudgetID != nil {
-				// Update existing budget
-				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-					return fmt.Errorf("both max_limit and reset_duration are required when updating a budget")
+			// Update existing budget
+			if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
+				return fmt.Errorf("both max_limit and reset_duration are required when updating a budget")
+			}
+			budget := configstoreTables.TableBudget{}
+			if err := tx.First(&budget, "id = ?", *customer.BudgetID).Error; err != nil {
+				return err
+			}
+			budget.MaxLimit = *req.Budget.MaxLimit
+			budget.ResetDuration = *req.Budget.ResetDuration
+			if req.Budget.CalendarAligned != nil {
+				wasCalendarAligned := budget.CalendarAligned
+				budget.CalendarAligned = *req.Budget.CalendarAligned
+				if *req.Budget.CalendarAligned && !wasCalendarAligned {
+					budget.LastReset = configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, time.Now())
+					budget.CurrentUsage = 0
 				}
-				budget := configstoreTables.TableBudget{}
-				if err := tx.First(&budget, "id = ?", *customer.BudgetID).Error; err != nil {
-					return err
-				}
-				budget.MaxLimit = *req.Budget.MaxLimit
-				budget.ResetDuration = *req.Budget.ResetDuration
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				customer.Budget = &budget
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			customer.Budget = &budget
 			} else {
 				// Create new budget
 				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
@@ -1852,21 +1907,23 @@ func (h *GovernanceHandler) updateCustomer(ctx *fasthttp.RequestCtx) {
 				if _, err := configstoreTables.ParseDuration(*req.Budget.ResetDuration); err != nil {
 					return fmt.Errorf("invalid reset duration format: %s", *req.Budget.ResetDuration)
 				}
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     time.Now(),
-					CurrentUsage:  0,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				customer.BudgetID = &budget.ID
-				customer.Budget = &budget
+			custCalAligned := req.Budget.CalendarAligned != nil && *req.Budget.CalendarAligned
+			budget := configstoreTables.TableBudget{
+				ID:              uuid.NewString(),
+				MaxLimit:        *req.Budget.MaxLimit,
+				ResetDuration:   *req.Budget.ResetDuration,
+				CalendarAligned: custCalAligned,
+				LastReset:       budgetLastReset(custCalAligned, *req.Budget.ResetDuration),
+				CurrentUsage:    0,
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			customer.BudgetID = &budget.ID
+			customer.Budget = &budget
 			}
 		}
 		// Handle rate limit updates
@@ -2081,6 +2138,9 @@ func validateBudget(budget *configstoreTables.TableBudget) error {
 	if _, err := configstoreTables.ParseDuration(budget.ResetDuration); err != nil {
 		return fmt.Errorf("invalid budget reset duration format: %s", budget.ResetDuration)
 	}
+	if budget.CalendarAligned && !configstoreTables.IsCalendarAlignableDuration(budget.ResetDuration) {
+		return fmt.Errorf("calendar_aligned is not supported for reset duration %q: only daily (d), weekly (w), monthly (M), and yearly (Y) periods support calendar alignment", budget.ResetDuration)
+	}
 	return nil
 }
 
@@ -2240,11 +2300,12 @@ func (h *GovernanceHandler) createModelConfig(ctx *fasthttp.RequestCtx) {
 		// Create budget if provided
 		if req.Budget != nil {
 			budget := configstoreTables.TableBudget{
-				ID:            uuid.NewString(),
-				MaxLimit:      req.Budget.MaxLimit,
-				ResetDuration: req.Budget.ResetDuration,
-				LastReset:     time.Now(),
-				CurrentUsage:  0,
+				ID:              uuid.NewString(),
+				MaxLimit:        req.Budget.MaxLimit,
+				ResetDuration:   req.Budget.ResetDuration,
+				CalendarAligned: req.Budget.CalendarAligned,
+				LastReset:       budgetLastReset(req.Budget.CalendarAligned, req.Budget.ResetDuration),
+				CurrentUsage:    0,
 			}
 			if err := validateBudget(&budget); err != nil {
 				return err
@@ -2337,25 +2398,33 @@ func (h *GovernanceHandler) updateModelConfig(ctx *fasthttp.RequestCtx) {
 					mc.Budget = nil
 				}
 			} else if mc.BudgetID != nil {
-				// Update existing budget
-				// Validate that both fields are present before dereferencing
-				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-					return fmt.Errorf("both max_limit and reset_duration are required when updating a budget")
+			// Update existing budget
+			// Validate that both fields are present before dereferencing
+			if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
+				return fmt.Errorf("both max_limit and reset_duration are required when updating a budget")
+			}
+			budget := configstoreTables.TableBudget{}
+			if err := tx.First(&budget, "id = ?", *mc.BudgetID).Error; err != nil {
+				return err
+			}
+			// Set all fields from request
+			budget.MaxLimit = *req.Budget.MaxLimit
+			budget.ResetDuration = *req.Budget.ResetDuration
+			if req.Budget.CalendarAligned != nil {
+				wasCalendarAligned := budget.CalendarAligned
+				budget.CalendarAligned = *req.Budget.CalendarAligned
+				if *req.Budget.CalendarAligned && !wasCalendarAligned {
+					budget.LastReset = configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, time.Now())
+					budget.CurrentUsage = 0
 				}
-				budget := configstoreTables.TableBudget{}
-				if err := tx.First(&budget, "id = ?", *mc.BudgetID).Error; err != nil {
-					return err
-				}
-				// Set all fields from request
-				budget.MaxLimit = *req.Budget.MaxLimit
-				budget.ResetDuration = *req.Budget.ResetDuration
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.Budget = &budget
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			mc.Budget = &budget
 			} else {
 				// Create new budget
 				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
@@ -2367,21 +2436,23 @@ func (h *GovernanceHandler) updateModelConfig(ctx *fasthttp.RequestCtx) {
 				if _, err := configstoreTables.ParseDuration(*req.Budget.ResetDuration); err != nil {
 					return fmt.Errorf("invalid reset duration format: %s", *req.Budget.ResetDuration)
 				}
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     time.Now(),
-					CurrentUsage:  0,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				mc.BudgetID = &budget.ID
-				mc.Budget = &budget
+			mcCalAligned := req.Budget.CalendarAligned != nil && *req.Budget.CalendarAligned
+			budget := configstoreTables.TableBudget{
+				ID:              uuid.NewString(),
+				MaxLimit:        *req.Budget.MaxLimit,
+				ResetDuration:   *req.Budget.ResetDuration,
+				CalendarAligned: mcCalAligned,
+				LastReset:       budgetLastReset(mcCalAligned, *req.Budget.ResetDuration),
+				CurrentUsage:    0,
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			mc.BudgetID = &budget.ID
+			mc.Budget = &budget
 			}
 		}
 		// Handle rate limit updates
@@ -2600,45 +2671,55 @@ func (h *GovernanceHandler) updateProviderGovernance(ctx *fasthttp.RequestCtx) {
 					provider.Budget = nil
 				}
 			} else if provider.BudgetID != nil {
-				// Update existing budget
-				// Validate that both fields are present before dereferencing
-				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-					return fmt.Errorf("both max_limit and reset_duration are required when updating a budget")
+			// Update existing budget
+			// Validate that both fields are present before dereferencing
+			if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
+				return fmt.Errorf("both max_limit and reset_duration are required when updating a budget")
+			}
+			budget := configstoreTables.TableBudget{}
+			if err := tx.First(&budget, "id = ?", *provider.BudgetID).Error; err != nil {
+				return err
+			}
+			// Set all fields from request
+			budget.MaxLimit = *req.Budget.MaxLimit
+			budget.ResetDuration = *req.Budget.ResetDuration
+			if req.Budget.CalendarAligned != nil {
+				wasCalendarAligned := budget.CalendarAligned
+				budget.CalendarAligned = *req.Budget.CalendarAligned
+				if *req.Budget.CalendarAligned && !wasCalendarAligned {
+					budget.LastReset = configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, time.Now())
+					budget.CurrentUsage = 0
 				}
-				budget := configstoreTables.TableBudget{}
-				if err := tx.First(&budget, "id = ?", *provider.BudgetID).Error; err != nil {
-					return err
-				}
-				// Set all fields from request
-				budget.MaxLimit = *req.Budget.MaxLimit
-				budget.ResetDuration = *req.Budget.ResetDuration
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				provider.Budget = &budget
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			provider.Budget = &budget
 			} else {
 				// Create new budget
 				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
 					return fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")
 				}
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     time.Now(),
-					CurrentUsage:  0,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				provider.BudgetID = &budget.ID
-				provider.Budget = &budget
+			provCalAligned := req.Budget.CalendarAligned != nil && *req.Budget.CalendarAligned
+			budget := configstoreTables.TableBudget{
+				ID:              uuid.NewString(),
+				MaxLimit:        *req.Budget.MaxLimit,
+				ResetDuration:   *req.Budget.ResetDuration,
+				CalendarAligned: provCalAligned,
+				LastReset:       budgetLastReset(provCalAligned, *req.Budget.ResetDuration),
+				CurrentUsage:    0,
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			provider.BudgetID = &budget.ID
+			provider.Budget = &budget
 			}
 		}
 		// Handle rate limit updates

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+[feat]: support calendar-aligned budget resets in VK and team governance; reject unsupported periods [@17jmumford](https://github.com/17jmumford)

--- a/ui/app/workspace/governance/views/teamDialog.tsx
+++ b/ui/app/workspace/governance/views/teamDialog.tsx
@@ -2,12 +2,23 @@
 
 import FormFooter from "@/components/formFooter"
 import { Badge } from "@/components/ui/badge"
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alertDialog"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import NumberAndSelect from "@/components/ui/numberAndSelect"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { resetDurationOptions } from "@/lib/constants/governance"
+import { Switch } from "@/components/ui/switch"
+import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants/governance"
 import { getErrorMessage, useCreateTeamMutation, useUpdateTeamMutation } from "@/lib/store"
 import { CreateTeamRequest, Customer, Team, UpdateTeamRequest } from "@/lib/types/governance"
 import { formatCurrency } from "@/lib/utils/governance"
@@ -31,6 +42,7 @@ interface TeamFormData {
 	// Budget (stored as string to allow intermediate decimal states like "1.")
 	budgetMaxLimit: string;
 	budgetResetDuration: string;
+	budgetCalendarAligned: boolean;
 	// Rate Limit
 	tokenMaxLimit: string;
 	tokenResetDuration: string;
@@ -47,6 +59,7 @@ const createInitialState = (team?: Team | null): Omit<TeamFormData, "isDirty"> =
 		// Budget (stored as string)
 		budgetMaxLimit: team?.budget ? String(team.budget.max_limit) : "",
 		budgetResetDuration: team?.budget?.reset_duration || "1M",
+		budgetCalendarAligned: team?.budget?.calendar_aligned ?? false,
 		// Rate Limit (stored as string)
 		tokenMaxLimit: team?.rate_limit?.token_max_limit ? String(team.rate_limit.token_max_limit) : "",
 		tokenResetDuration: team?.rate_limit?.token_reset_duration || "1h",
@@ -72,6 +85,16 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
   const [updateTeam, { isLoading: isUpdating }] = useUpdateTeamMutation()
   const loading = isCreating || isUpdating
 
+	const [showCalendarAlignWarning, setShowCalendarAlignWarning] = useState(false);
+
+	const handleCalendarAlignedChange = (checked: boolean) => {
+		if (checked && isEditing && team?.budget && !team.budget.calendar_aligned) {
+			setShowCalendarAlignWarning(true);
+		} else {
+			updateField("budgetCalendarAligned", checked);
+		}
+	};
+
 	// Track isDirty state
 	useEffect(() => {
 		const currentData = {
@@ -79,6 +102,7 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 			customerId: formData.customerId,
 			budgetMaxLimit: formData.budgetMaxLimit,
 			budgetResetDuration: formData.budgetResetDuration,
+			budgetCalendarAligned: formData.budgetCalendarAligned,
 			tokenMaxLimit: formData.tokenMaxLimit,
 			tokenResetDuration: formData.tokenResetDuration,
 			requestMaxLimit: formData.requestMaxLimit,
@@ -88,7 +112,7 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 			...prev,
 			isDirty: !isEqual(initialState, currentData),
 		}));
-	}, [formData.name, formData.customerId, formData.budgetMaxLimit, formData.budgetResetDuration, formData.tokenMaxLimit, formData.tokenResetDuration, formData.requestMaxLimit, formData.requestResetDuration, initialState]);
+	}, [formData.name, formData.customerId, formData.budgetMaxLimit, formData.budgetResetDuration, formData.budgetCalendarAligned, formData.tokenMaxLimit, formData.tokenResetDuration, formData.requestMaxLimit, formData.requestResetDuration, initialState]);
 
 	// Parse string values to numbers for validation and submission
 	const budgetMaxLimitNum = formData.budgetMaxLimit ? parseFloat(formData.budgetMaxLimit) : undefined;
@@ -152,17 +176,18 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 					customer_id: formData.customerId,
 				};
 
-				// Detect budget changes using had/has pattern
-				const hadBudget = !!team.budget;
-				const hasBudget = !!budgetMaxLimitNum;
-				if (hasBudget) {
-					updateData.budget = {
-						max_limit: budgetMaxLimitNum,
-						reset_duration: formData.budgetResetDuration,
-					};
-				} else if (hadBudget) {
-					updateData.budget = {} as UpdateTeamRequest["budget"];
-				}
+			// Detect budget changes using had/has pattern
+			const hadBudget = !!team.budget;
+			const hasBudget = !!budgetMaxLimitNum;
+			if (hasBudget) {
+				updateData.budget = {
+					max_limit: budgetMaxLimitNum,
+					reset_duration: formData.budgetResetDuration,
+					calendar_aligned: formData.budgetCalendarAligned,
+				};
+			} else if (hadBudget) {
+				updateData.budget = {} as UpdateTeamRequest["budget"];
+			}
 
 				// Detect rate limit changes using had/has pattern
 				const hadRateLimit = !!team.rate_limit;
@@ -187,13 +212,14 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 					customer_id: formData.customerId || undefined,
 				};
 
-				// Add budget if enabled
-				if (budgetMaxLimitNum) {
-					createData.budget = {
-						max_limit: budgetMaxLimitNum,
-						reset_duration: formData.budgetResetDuration,
-					};
-				}
+			// Add budget if enabled
+			if (budgetMaxLimitNum) {
+				createData.budget = {
+					max_limit: budgetMaxLimitNum,
+					reset_duration: formData.budgetResetDuration,
+					calendar_aligned: formData.budgetCalendarAligned,
+				};
+			}
 
 				// Add rate limit if enabled (token or request limits)
 				if (tokenMaxLimitNum || requestMaxLimitNum) {
@@ -266,19 +292,75 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 							)}
 						</div>
 
-						{/* Budget Configuration */}
-						<NumberAndSelect
-							id="budgetMaxLimit"
-							label="Maximum Spend (USD)"
-							value={formData.budgetMaxLimit}
-							selectValue={formData.budgetResetDuration}
-							onChangeNumber={(value) => updateField("budgetMaxLimit", value)}
-							onChangeSelect={(value) => updateField("budgetResetDuration", value)}
-							options={resetDurationOptions}
-							dataTestId="budget-max-limit-input"
-						/>
+					{/* Budget Configuration */}
+					<NumberAndSelect
+						id="budgetMaxLimit"
+						label="Maximum Spend (USD)"
+						value={formData.budgetMaxLimit}
+						selectValue={formData.budgetResetDuration}
+					onChangeNumber={(value) => updateField("budgetMaxLimit", value)}
+					onChangeSelect={(value) => {
+						updateField("budgetResetDuration", value);
+						if (!supportsCalendarAlignment(value)) {
+							updateField("budgetCalendarAligned", false);
+						}
+					}}
+					options={resetDurationOptions}
+					dataTestId="budget-max-limit-input"
+				/>
 
-						{/* Rate Limit Configuration - Token Limits */}
+			{/* Calendar alignment toggle — only shown when a budget is set and the period supports alignment */}
+			{formData.budgetMaxLimit && supportsCalendarAlignment(formData.budgetResetDuration) && (
+				<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
+					<div className="space-y-0.5">
+						<Label className="text-sm font-normal">Align to calendar cycle</Label>
+						<p className="text-muted-foreground text-xs">
+							Reset at the start of each period (e.g. 1st of month) instead of rolling from creation date
+						</p>
+					</div>
+					<Switch
+						checked={formData.budgetCalendarAligned}
+						onCheckedChange={handleCalendarAlignedChange}
+						data-testid="team-budget-calendar-aligned-toggle"
+					/>
+				</div>
+			)}
+
+					{/* Warning dialog shown when enabling calendar alignment on an existing budget */}
+					<AlertDialog open={showCalendarAlignWarning} onOpenChange={setShowCalendarAlignWarning}>
+						<AlertDialogContent>
+							<AlertDialogHeader>
+								<AlertDialogTitle>Reset budget usage?</AlertDialogTitle>
+								<AlertDialogDescription>
+									Enabling calendar alignment will immediately reset this budget&apos;s current usage to{" "}
+									<span className="font-semibold">$0.00</span> and snap the reset date to the start of the current{" "}
+									{formData.budgetResetDuration === "1d"
+										? "day"
+										: formData.budgetResetDuration === "1w"
+											? "week"
+											: formData.budgetResetDuration === "1M"
+												? "month"
+												: formData.budgetResetDuration === "1Y"
+													? "year"
+													: "period"}
+									. This cannot be undone.
+								</AlertDialogDescription>
+							</AlertDialogHeader>
+							<AlertDialogFooter>
+								<AlertDialogCancel>Cancel</AlertDialogCancel>
+								<AlertDialogAction
+									onClick={() => {
+										updateField("budgetCalendarAligned", true);
+										setShowCalendarAlignWarning(false);
+									}}
+								>
+									Enable Calendar Alignment
+								</AlertDialogAction>
+							</AlertDialogFooter>
+						</AlertDialogContent>
+					</AlertDialog>
+
+					{/* Rate Limit Configuration - Token Limits */}
 						<NumberAndSelect
 							id="tokenMaxLimit"
 							label="Maximum Tokens"

--- a/ui/app/workspace/governance/views/teamDialog.tsx
+++ b/ui/app/workspace/governance/views/teamDialog.tsx
@@ -1,7 +1,7 @@
-"use client"
+"use client";
 
-import FormFooter from "@/components/formFooter"
-import { Badge } from "@/components/ui/badge"
+import FormFooter from "@/components/formFooter";
+import { Badge } from "@/components/ui/badge";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -11,23 +11,23 @@ import {
 	AlertDialogFooter,
 	AlertDialogHeader,
 	AlertDialogTitle,
-} from "@/components/ui/alertDialog"
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import NumberAndSelect from "@/components/ui/numberAndSelect"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Switch } from "@/components/ui/switch"
-import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants/governance"
-import { getErrorMessage, useCreateTeamMutation, useUpdateTeamMutation } from "@/lib/store"
-import { CreateTeamRequest, Customer, Team, UpdateTeamRequest } from "@/lib/types/governance"
-import { formatCurrency } from "@/lib/utils/governance"
-import { Validator } from "@/lib/utils/validation"
-import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib"
-import { formatDistanceToNow } from "date-fns"
-import isEqual from "lodash.isequal"
-import { useEffect, useMemo, useState } from "react"
-import { toast } from "sonner"
+} from "@/components/ui/alertDialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import NumberAndSelect from "@/components/ui/numberAndSelect";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants/governance";
+import { getErrorMessage, useCreateTeamMutation, useUpdateTeamMutation } from "@/lib/store";
+import { CreateTeamRequest, Customer, Team, UpdateTeamRequest } from "@/lib/types/governance";
+import { formatCurrency } from "@/lib/utils/governance";
+import { Validator } from "@/lib/utils/validation";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { formatDistanceToNow } from "date-fns";
+import isEqual from "lodash.isequal";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 
 interface TeamDialogProps {
 	team?: Team | null;
@@ -69,21 +69,21 @@ const createInitialState = (team?: Team | null): Omit<TeamFormData, "isDirty"> =
 };
 
 export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDialogProps) {
-  const isEditing = !!team
-  const [initialState] = useState<Omit<TeamFormData, "isDirty">>(createInitialState(team))
-  const [formData, setFormData] = useState<TeamFormData>({
-    ...initialState,
-    isDirty: false,
-  })
+	const isEditing = !!team;
+	const [initialState] = useState<Omit<TeamFormData, "isDirty">>(createInitialState(team));
+	const [formData, setFormData] = useState<TeamFormData>({
+		...initialState,
+		isDirty: false,
+	});
 
-  const hasCreateAccess = useRbac(RbacResource.Teams, RbacOperation.Create)
-  const hasUpdateAccess = useRbac(RbacResource.Teams, RbacOperation.Update)
-  const hasPermission = isEditing ? hasUpdateAccess : hasCreateAccess
+	const hasCreateAccess = useRbac(RbacResource.Teams, RbacOperation.Create);
+	const hasUpdateAccess = useRbac(RbacResource.Teams, RbacOperation.Update);
+	const hasPermission = isEditing ? hasUpdateAccess : hasCreateAccess;
 
-  // RTK Query hooks
-  const [createTeam, { isLoading: isCreating }] = useCreateTeamMutation()
-  const [updateTeam, { isLoading: isUpdating }] = useUpdateTeamMutation()
-  const loading = isCreating || isUpdating
+	// RTK Query hooks
+	const [createTeam, { isLoading: isCreating }] = useCreateTeamMutation();
+	const [updateTeam, { isLoading: isUpdating }] = useUpdateTeamMutation();
+	const loading = isCreating || isUpdating;
 
 	const [showCalendarAlignWarning, setShowCalendarAlignWarning] = useState(false);
 
@@ -112,7 +112,18 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 			...prev,
 			isDirty: !isEqual(initialState, currentData),
 		}));
-	}, [formData.name, formData.customerId, formData.budgetMaxLimit, formData.budgetResetDuration, formData.budgetCalendarAligned, formData.tokenMaxLimit, formData.tokenResetDuration, formData.requestMaxLimit, formData.requestResetDuration, initialState]);
+	}, [
+		formData.name,
+		formData.customerId,
+		formData.budgetMaxLimit,
+		formData.budgetResetDuration,
+		formData.budgetCalendarAligned,
+		formData.tokenMaxLimit,
+		formData.tokenResetDuration,
+		formData.requestMaxLimit,
+		formData.requestResetDuration,
+		initialState,
+	]);
 
 	// Parse string values to numbers for validation and submission
 	const budgetMaxLimitNum = formData.budgetMaxLimit ? parseFloat(formData.budgetMaxLimit) : undefined;
@@ -176,18 +187,18 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 					customer_id: formData.customerId,
 				};
 
-			// Detect budget changes using had/has pattern
-			const hadBudget = !!team.budget;
-			const hasBudget = !!budgetMaxLimitNum;
-			if (hasBudget) {
-				updateData.budget = {
-					max_limit: budgetMaxLimitNum,
-					reset_duration: formData.budgetResetDuration,
-					calendar_aligned: formData.budgetCalendarAligned,
-				};
-			} else if (hadBudget) {
-				updateData.budget = {} as UpdateTeamRequest["budget"];
-			}
+				// Detect budget changes using had/has pattern
+				const hadBudget = !!team.budget;
+				const hasBudget = !!budgetMaxLimitNum;
+				if (hasBudget) {
+					updateData.budget = {
+						max_limit: budgetMaxLimitNum,
+						reset_duration: formData.budgetResetDuration,
+						calendar_aligned: formData.budgetCalendarAligned,
+					};
+				} else if (hadBudget) {
+					updateData.budget = {} as UpdateTeamRequest["budget"];
+				}
 
 				// Detect rate limit changes using had/has pattern
 				const hadRateLimit = !!team.rate_limit;
@@ -212,14 +223,14 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 					customer_id: formData.customerId || undefined,
 				};
 
-			// Add budget if enabled
-			if (budgetMaxLimitNum) {
-				createData.budget = {
-					max_limit: budgetMaxLimitNum,
-					reset_duration: formData.budgetResetDuration,
-					calendar_aligned: formData.budgetCalendarAligned,
-				};
-			}
+				// Add budget if enabled
+				if (budgetMaxLimitNum) {
+					createData.budget = {
+						max_limit: budgetMaxLimitNum,
+						reset_duration: formData.budgetResetDuration,
+						calendar_aligned: formData.budgetCalendarAligned,
+					};
+				}
 
 				// Add rate limit if enabled (token or request limits)
 				if (tokenMaxLimitNum || requestMaxLimitNum) {
@@ -279,7 +290,9 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 											<SelectValue placeholder="Select a customer" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="__none__" data-testid="team-customer-option-none">None</SelectItem>
+											<SelectItem value="__none__" data-testid="team-customer-option-none">
+												None
+											</SelectItem>
 											{customers.map((customer) => (
 												<SelectItem key={customer.id} value={customer.id} data-testid={`team-customer-option-${customer.id}`}>
 													{customer.name}
@@ -292,75 +305,80 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 							)}
 						</div>
 
-					{/* Budget Configuration */}
-					<NumberAndSelect
-						id="budgetMaxLimit"
-						label="Maximum Spend (USD)"
-						value={formData.budgetMaxLimit}
-						selectValue={formData.budgetResetDuration}
-					onChangeNumber={(value) => updateField("budgetMaxLimit", value)}
-					onChangeSelect={(value) => {
-						updateField("budgetResetDuration", value);
-						if (!supportsCalendarAlignment(value)) {
-							updateField("budgetCalendarAligned", false);
-						}
-					}}
-					options={resetDurationOptions}
-					dataTestId="budget-max-limit-input"
-				/>
+						{/* Budget Configuration */}
+						<NumberAndSelect
+							id="budgetMaxLimit"
+							label="Maximum Spend (USD)"
+							value={formData.budgetMaxLimit}
+							selectValue={formData.budgetResetDuration}
+							onChangeNumber={(value) => updateField("budgetMaxLimit", value)}
+							onChangeSelect={(value) => {
+								updateField("budgetResetDuration", value);
+								if (!supportsCalendarAlignment(value)) {
+									updateField("budgetCalendarAligned", false);
+								}
+							}}
+							options={resetDurationOptions}
+							dataTestId="budget-max-limit-input"
+						/>
 
-			{/* Calendar alignment toggle — only shown when a budget is set and the period supports alignment */}
-			{formData.budgetMaxLimit && supportsCalendarAlignment(formData.budgetResetDuration) && (
-				<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
-					<div className="space-y-0.5">
-						<Label className="text-sm font-normal">Align to calendar cycle</Label>
-						<p className="text-muted-foreground text-xs">
-							Reset at the start of each period (e.g. 1st of month) instead of rolling from creation date
-						</p>
-					</div>
-					<Switch
-						checked={formData.budgetCalendarAligned}
-						onCheckedChange={handleCalendarAlignedChange}
-						data-testid="team-budget-calendar-aligned-toggle"
-					/>
-				</div>
-			)}
+						{/* Calendar alignment toggle — only shown when a budget is set and the period supports alignment */}
+						{formData.budgetMaxLimit && supportsCalendarAlignment(formData.budgetResetDuration) && (
+							<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
+								<div className="space-y-0.5">
+									<Label htmlFor="team-budget-calendar-aligned-toggle" className="text-sm font-normal">
+										Align to calendar cycle
+									</Label>
+									<p id="team-budget-calendar-aligned-description" className="text-muted-foreground text-xs">
+										Reset at the start of each period (e.g. 1st of month) instead of rolling from creation date
+									</p>
+								</div>
+								<Switch
+									id="team-budget-calendar-aligned-toggle"
+									aria-describedby="team-budget-calendar-aligned-description"
+									checked={formData.budgetCalendarAligned}
+									onCheckedChange={handleCalendarAlignedChange}
+									data-testid="team-budget-calendar-aligned-toggle"
+								/>
+							</div>
+						)}
 
-					{/* Warning dialog shown when enabling calendar alignment on an existing budget */}
-					<AlertDialog open={showCalendarAlignWarning} onOpenChange={setShowCalendarAlignWarning}>
-						<AlertDialogContent>
-							<AlertDialogHeader>
-								<AlertDialogTitle>Reset budget usage?</AlertDialogTitle>
-								<AlertDialogDescription>
-									Enabling calendar alignment will immediately reset this budget&apos;s current usage to{" "}
-									<span className="font-semibold">$0.00</span> and snap the reset date to the start of the current{" "}
-									{formData.budgetResetDuration === "1d"
-										? "day"
-										: formData.budgetResetDuration === "1w"
-											? "week"
-											: formData.budgetResetDuration === "1M"
-												? "month"
-												: formData.budgetResetDuration === "1Y"
-													? "year"
-													: "period"}
-									. This cannot be undone.
-								</AlertDialogDescription>
-							</AlertDialogHeader>
-							<AlertDialogFooter>
-								<AlertDialogCancel>Cancel</AlertDialogCancel>
-								<AlertDialogAction
-									onClick={() => {
-										updateField("budgetCalendarAligned", true);
-										setShowCalendarAlignWarning(false);
-									}}
-								>
-									Enable Calendar Alignment
-								</AlertDialogAction>
-							</AlertDialogFooter>
-						</AlertDialogContent>
-					</AlertDialog>
+						{/* Warning dialog shown when enabling calendar alignment on an existing budget */}
+						<AlertDialog open={showCalendarAlignWarning} onOpenChange={setShowCalendarAlignWarning}>
+							<AlertDialogContent>
+								<AlertDialogHeader>
+									<AlertDialogTitle>Reset budget usage?</AlertDialogTitle>
+									<AlertDialogDescription>
+										Enabling calendar alignment will reset this budget&apos;s current usage to <span className="font-semibold">$0.00</span>{" "}
+										and snap the reset date to the start of the current{" "}
+										{formData.budgetResetDuration === "1d"
+											? "day"
+											: formData.budgetResetDuration === "1w"
+												? "week"
+												: formData.budgetResetDuration === "1M"
+													? "month"
+													: formData.budgetResetDuration === "1Y"
+														? "year"
+														: "period"}
+										. This will take effect when you save.
+									</AlertDialogDescription>
+								</AlertDialogHeader>
+								<AlertDialogFooter>
+									<AlertDialogCancel data-testid="team-calendar-align-cancel-btn">Cancel</AlertDialogCancel>
+									<AlertDialogAction
+										data-testid="team-calendar-align-enable-btn"
+										onClick={() => {
+											updateField("budgetCalendarAligned", true);
+											setShowCalendarAlignWarning(false);
+										}}
+									>
+										Enable Calendar Alignment
+									</AlertDialogAction>
+								</AlertDialogFooter>
+							</AlertDialogContent>
+						</AlertDialog>
 
-					{/* Rate Limit Configuration - Token Limits */}
+						{/* Rate Limit Configuration - Token Limits */}
 						<NumberAndSelect
 							id="tokenMaxLimit"
 							label="Maximum Tokens"
@@ -384,9 +402,9 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 
 						{/* Current Usage Section (only shown when editing with existing limits) */}
 						{isEditing && (team?.budget || team?.rate_limit) && (
-							<div className="rounded-lg border bg-muted/50 p-4 space-y-4">
+							<div className="bg-muted/50 space-y-4 rounded-lg border p-4">
 								<p className="text-sm font-medium">Current Usage</p>
-								<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+								<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
 									{team?.budget && (
 										<div className="space-y-1">
 											<p className="text-muted-foreground text-xs">Budget</p>
@@ -394,10 +412,7 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 												<span className="font-mono text-sm">
 													{formatCurrency(team.budget.current_usage)} / {formatCurrency(team.budget.max_limit)}
 												</span>
-												<Badge
-													variant={team.budget.current_usage >= team.budget.max_limit ? "destructive" : "default"}
-													className="text-xs"
-												>
+												<Badge variant={team.budget.current_usage >= team.budget.max_limit ? "destructive" : "default"} className="text-xs">
 													{Math.round((team.budget.current_usage / team.budget.max_limit) * 100)}%
 												</Badge>
 											</div>
@@ -449,7 +464,14 @@ export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDi
 						)}
 					</div>
 
-					<FormFooter validator={validator} label="Team" onCancel={onCancel} isLoading={loading} isEditing={isEditing} hasPermission={hasPermission} />
+					<FormFooter
+						validator={validator}
+						label="Team"
+						onCancel={onCancel}
+						isLoading={loading}
+						isEditing={isEditing}
+						hasPermission={hasPermission}
+					/>
 				</form>
 			</DialogContent>
 		</Dialog>

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -431,19 +431,19 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 					is_active: data.isActive,
 				};
 
-			// Add budget if enabled
-			const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
-			const hadBudget = !!virtualKey.budget;
-			const hasBudget = budgetMaxLimit !== undefined;
-			if (hasBudget) {
-				updateData.budget = {
-					max_limit: budgetMaxLimit,
-					reset_duration: data.budgetResetDuration || "1M",
-					calendar_aligned: data.budgetCalendarAligned,
-				};
-			} else if (hadBudget) {
-				updateData.budget = {};
-			}
+				// Add budget if enabled
+				const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
+				const hadBudget = !!virtualKey.budget;
+				const hasBudget = budgetMaxLimit !== undefined;
+				if (hasBudget) {
+					updateData.budget = {
+						max_limit: budgetMaxLimit,
+						reset_duration: data.budgetResetDuration || "1M",
+						calendar_aligned: data.budgetCalendarAligned,
+					};
+				} else if (hadBudget) {
+					updateData.budget = {};
+				}
 
 				// Add rate limit if enabled
 				const tokenMaxLimit = normalizeIntegerField(data.tokenMaxLimit);
@@ -477,15 +477,15 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 					is_active: data.isActive,
 				};
 
-			// Add budget if enabled
-			const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
-			if (budgetMaxLimit !== undefined) {
-				createData.budget = {
-					max_limit: budgetMaxLimit,
-					reset_duration: data.budgetResetDuration || "1M",
-					calendar_aligned: data.budgetCalendarAligned,
-				};
-			}
+				// Add budget if enabled
+				const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
+				if (budgetMaxLimit !== undefined) {
+					createData.budget = {
+						max_limit: budgetMaxLimit,
+						reset_duration: data.budgetResetDuration || "1M",
+						calendar_aligned: data.budgetCalendarAligned,
+					};
+				}
 
 				// Add rate limit if enabled
 				const tokenMaxLimit = normalizeIntegerField(data.tokenMaxLimit);
@@ -1058,98 +1058,97 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 								<div className="flex items-center justify-between gap-2">
 									<Label className="text-sm font-medium">Budget Configuration</Label>
 									{isEditing && (virtualKey?.budget || watchedBudgetMaxLimit) && (
-										<Button
-											type="button"
-											variant="ghost"
-											size="sm"
-											onClick={clearVirtualKeyBudget}
-											data-testid="vk-budget-reset-button"
-										>
+										<Button type="button" variant="ghost" size="sm" onClick={clearVirtualKeyBudget} data-testid="vk-budget-reset-button">
 											<RotateCcw className="h-4 w-4" />
 											Reset
 										</Button>
 									)}
 								</div>
-							<FormField
-								control={form.control}
-								name="budgetMaxLimit"
-								render={({ field }) => (
-									<FormItem>
-										<NumberAndSelect
-											id="budgetMaxLimit"
-											labelClassName="font-normal"
-											label="Maximum Spend (USD)"
-											value={field.value || ""}
-									selectValue={watchedBudgetResetDuration}
-										onChangeNumber={(value) => {
-											field.onChange(value);
-										}}
-										onChangeSelect={(value) => {
-											form.setValue("budgetResetDuration", value, { shouldDirty: true });
-											if (!supportsCalendarAlignment(value)) {
-												form.setValue("budgetCalendarAligned", false, { shouldDirty: true });
-											}
-										}}
-											options={resetDurationOptions}
+								<FormField
+									control={form.control}
+									name="budgetMaxLimit"
+									render={({ field }) => (
+										<FormItem>
+											<NumberAndSelect
+												id="budgetMaxLimit"
+												labelClassName="font-normal"
+												label="Maximum Spend (USD)"
+												value={field.value || ""}
+												selectValue={watchedBudgetResetDuration}
+												onChangeNumber={(value) => {
+													field.onChange(value);
+												}}
+												onChangeSelect={(value) => {
+													form.setValue("budgetResetDuration", value, { shouldDirty: true });
+													if (!supportsCalendarAlignment(value)) {
+														form.setValue("budgetCalendarAligned", false, { shouldDirty: true });
+													}
+												}}
+												options={resetDurationOptions}
+											/>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+
+								{/* Calendar alignment toggle — only shown when a budget is set and the period supports alignment */}
+								{watchedBudgetMaxLimit && supportsCalendarAlignment(watchedBudgetResetDuration) && (
+									<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
+										<div className="space-y-0.5">
+											<Label htmlFor="vk-budget-calendar-aligned-toggle" className="text-sm font-normal">
+												Align to calendar cycle
+											</Label>
+											<p id="vk-budget-calendar-aligned-description" className="text-muted-foreground text-xs">
+												Reset at the start of each period (e.g. 1st of month) instead of rolling from creation date
+											</p>
+										</div>
+										<Switch
+											id="vk-budget-calendar-aligned-toggle"
+											aria-describedby="vk-budget-calendar-aligned-description"
+											checked={form.watch("budgetCalendarAligned")}
+											onCheckedChange={handleCalendarAlignedChange}
+											data-testid="vk-budget-calendar-aligned-toggle"
 										/>
-										<FormMessage />
-									</FormItem>
+									</div>
 								)}
-							/>
 
-					{/* Calendar alignment toggle — only shown when a budget is set and the period supports alignment */}
-					{watchedBudgetMaxLimit && supportsCalendarAlignment(watchedBudgetResetDuration) && (
-						<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
-							<div className="space-y-0.5">
-								<Label className="text-sm font-normal">Align to calendar cycle</Label>
-								<p className="text-muted-foreground text-xs">
-									Reset at the start of each period (e.g. 1st of month) instead of rolling from creation date
-								</p>
+								{/* Warning dialog shown when enabling calendar alignment on an existing budget */}
+								<AlertDialog open={showCalendarAlignWarning} onOpenChange={setShowCalendarAlignWarning}>
+									<AlertDialogContent>
+										<AlertDialogHeader>
+											<AlertDialogTitle>Reset budget usage?</AlertDialogTitle>
+											<AlertDialogDescription>
+												Enabling calendar alignment will reset this budget&apos;s current usage to{" "}
+												<span className="font-semibold">$0.00</span> and snap the reset date to the start of the current{" "}
+												{watchedBudgetResetDuration === "1d"
+													? "day"
+													: watchedBudgetResetDuration === "1w"
+														? "week"
+														: watchedBudgetResetDuration === "1M"
+															? "month"
+															: watchedBudgetResetDuration === "1Y"
+																? "year"
+																: "period"}
+												. This will take effect when you save.
+											</AlertDialogDescription>
+										</AlertDialogHeader>
+										<AlertDialogFooter>
+											<AlertDialogCancel data-testid="vk-calendar-align-cancel-btn">Cancel</AlertDialogCancel>
+											<AlertDialogAction
+												data-testid="vk-calendar-align-enable-btn"
+												onClick={() => {
+													form.setValue("budgetCalendarAligned", true, { shouldDirty: true });
+													setShowCalendarAlignWarning(false);
+												}}
+											>
+												Enable Calendar Alignment
+											</AlertDialogAction>
+										</AlertDialogFooter>
+									</AlertDialogContent>
+								</AlertDialog>
 							</div>
-							<Switch
-								checked={form.watch("budgetCalendarAligned")}
-								onCheckedChange={handleCalendarAlignedChange}
-								data-testid="vk-budget-calendar-aligned-toggle"
-							/>
-						</div>
-					)}
 
-							{/* Warning dialog shown when enabling calendar alignment on an existing budget */}
-							<AlertDialog open={showCalendarAlignWarning} onOpenChange={setShowCalendarAlignWarning}>
-								<AlertDialogContent>
-									<AlertDialogHeader>
-										<AlertDialogTitle>Reset budget usage?</AlertDialogTitle>
-										<AlertDialogDescription>
-											Enabling calendar alignment will immediately reset this budget&apos;s current usage to{" "}
-											<span className="font-semibold">$0.00</span> and snap the reset date to the start of the current{" "}
-											{form.watch("budgetResetDuration") === "1d"
-												? "day"
-												: form.watch("budgetResetDuration") === "1w"
-													? "week"
-													: form.watch("budgetResetDuration") === "1M"
-														? "month"
-														: form.watch("budgetResetDuration") === "1Y"
-															? "year"
-															: "period"}
-											. This cannot be undone.
-										</AlertDialogDescription>
-									</AlertDialogHeader>
-									<AlertDialogFooter>
-										<AlertDialogCancel>Cancel</AlertDialogCancel>
-										<AlertDialogAction
-											onClick={() => {
-												form.setValue("budgetCalendarAligned", true, { shouldDirty: true });
-												setShowCalendarAlignWarning(false);
-											}}
-										>
-											Enable Calendar Alignment
-										</AlertDialogAction>
-									</AlertDialogFooter>
-								</AlertDialogContent>
-							</AlertDialog>
-						</div>
-
-						{/* Rate Limiting Configuration */}
+							{/* Rate Limiting Configuration */}
 							<div className="space-y-4">
 								<div className="flex items-center justify-between gap-2">
 									<Label className="text-sm font-medium">Rate Limiting Configuration</Label>

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -1,6 +1,16 @@
 "use client";
 
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alertDialog";
 import { AsyncMultiSelect } from "@/components/ui/asyncMultiselect";
 import { Button } from "@/components/ui/button";
 import { ConfigSyncAlert } from "@/components/ui/configSyncAlert";
@@ -16,10 +26,11 @@ import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import Toggle from "@/components/ui/toggle";
+import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/components/ui/utils";
 import { ModelPlaceholders } from "@/lib/constants/config";
-import { resetDurationOptions } from "@/lib/constants/governance";
+import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants/governance";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import {
@@ -94,6 +105,7 @@ const formSchema = z
 		// Budget
 		budgetMaxLimit: z.string().optional(),
 		budgetResetDuration: z.string().optional(),
+		budgetCalendarAligned: z.boolean(),
 		// Token limits
 		tokenMaxLimit: z.string().optional(),
 		tokenResetDuration: z.string().optional(),
@@ -192,6 +204,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 			isActive: virtualKey?.is_active ?? true,
 			budgetMaxLimit: virtualKey?.budget ? String(virtualKey.budget.max_limit) : "",
 			budgetResetDuration: virtualKey?.budget?.reset_duration || "1M",
+			budgetCalendarAligned: virtualKey?.budget?.calendar_aligned ?? false,
 			tokenMaxLimit: virtualKey?.rate_limit?.token_max_limit ? String(virtualKey.rate_limit.token_max_limit) : "",
 			tokenResetDuration: virtualKey?.rate_limit?.token_reset_duration || "1h",
 			requestMaxLimit: virtualKey?.rate_limit?.request_max_limit ? String(virtualKey.rate_limit.request_max_limit) : "",
@@ -247,6 +260,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 
 	// Watch budget/rate-limit fields for conditional rendering of reset buttons
 	const watchedBudgetMaxLimit = form.watch("budgetMaxLimit");
+	const watchedBudgetResetDuration = form.watch("budgetResetDuration") || "1M";
 	const watchedTokenMaxLimit = form.watch("tokenMaxLimit");
 	const watchedRequestMaxLimit = form.watch("requestMaxLimit");
 
@@ -310,9 +324,20 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 		form.setValue("mcpConfigs", updatedConfigs, { shouldDirty: true });
 	};
 
+	const [showCalendarAlignWarning, setShowCalendarAlignWarning] = useState(false);
+
 	const clearVirtualKeyBudget = () => {
 		form.setValue("budgetMaxLimit", "", { shouldDirty: true });
 		form.setValue("budgetResetDuration", "1M", { shouldDirty: true });
+		form.setValue("budgetCalendarAligned", false, { shouldDirty: true });
+	};
+
+	const handleCalendarAlignedChange = (checked: boolean) => {
+		if (checked && isEditing && virtualKey?.budget && !virtualKey.budget.calendar_aligned) {
+			setShowCalendarAlignWarning(true);
+		} else {
+			form.setValue("budgetCalendarAligned", checked, { shouldDirty: true });
+		}
 	};
 
 	const clearVirtualKeyRateLimits = () => {
@@ -406,18 +431,19 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 					is_active: data.isActive,
 				};
 
-				// Add budget if enabled
-				const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
-				const hadBudget = !!virtualKey.budget;
-				const hasBudget = budgetMaxLimit !== undefined;
-				if (hasBudget) {
-					updateData.budget = {
-						max_limit: budgetMaxLimit,
-						reset_duration: data.budgetResetDuration || "1M",
-					};
-				} else if (hadBudget) {
-					updateData.budget = {};
-				}
+			// Add budget if enabled
+			const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
+			const hadBudget = !!virtualKey.budget;
+			const hasBudget = budgetMaxLimit !== undefined;
+			if (hasBudget) {
+				updateData.budget = {
+					max_limit: budgetMaxLimit,
+					reset_duration: data.budgetResetDuration || "1M",
+					calendar_aligned: data.budgetCalendarAligned,
+				};
+			} else if (hadBudget) {
+				updateData.budget = {};
+			}
 
 				// Add rate limit if enabled
 				const tokenMaxLimit = normalizeIntegerField(data.tokenMaxLimit);
@@ -451,14 +477,15 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 					is_active: data.isActive,
 				};
 
-				// Add budget if enabled
-				const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
-				if (budgetMaxLimit !== undefined) {
-					createData.budget = {
-						max_limit: budgetMaxLimit,
-						reset_duration: data.budgetResetDuration || "1M",
-					};
-				}
+			// Add budget if enabled
+			const budgetMaxLimit = normalizeNumericField(data.budgetMaxLimit);
+			if (budgetMaxLimit !== undefined) {
+				createData.budget = {
+					max_limit: budgetMaxLimit,
+					reset_duration: data.budgetResetDuration || "1M",
+					calendar_aligned: data.budgetCalendarAligned,
+				};
+			}
 
 				// Add rate limit if enabled
 				const tokenMaxLimit = normalizeIntegerField(data.tokenMaxLimit);
@@ -1043,30 +1070,86 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 										</Button>
 									)}
 								</div>
-								<FormField
-									control={form.control}
-									name="budgetMaxLimit"
-									render={({ field }) => (
-										<FormItem>
-											<NumberAndSelect
-												id="budgetMaxLimit"
-												labelClassName="font-normal"
-												label="Maximum Spend (USD)"
-												value={field.value || ""}
-												selectValue={form.watch("budgetResetDuration") || "1M"}
-												onChangeNumber={(value) => {
-													field.onChange(value);
-												}}
-												onChangeSelect={(value) => form.setValue("budgetResetDuration", value, { shouldDirty: true })}
-												options={resetDurationOptions}
-											/>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-							</div>
+							<FormField
+								control={form.control}
+								name="budgetMaxLimit"
+								render={({ field }) => (
+									<FormItem>
+										<NumberAndSelect
+											id="budgetMaxLimit"
+											labelClassName="font-normal"
+											label="Maximum Spend (USD)"
+											value={field.value || ""}
+									selectValue={watchedBudgetResetDuration}
+										onChangeNumber={(value) => {
+											field.onChange(value);
+										}}
+										onChangeSelect={(value) => {
+											form.setValue("budgetResetDuration", value, { shouldDirty: true });
+											if (!supportsCalendarAlignment(value)) {
+												form.setValue("budgetCalendarAligned", false, { shouldDirty: true });
+											}
+										}}
+											options={resetDurationOptions}
+										/>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
 
-							{/* Rate Limiting Configuration */}
+					{/* Calendar alignment toggle — only shown when a budget is set and the period supports alignment */}
+					{watchedBudgetMaxLimit && supportsCalendarAlignment(watchedBudgetResetDuration) && (
+						<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
+							<div className="space-y-0.5">
+								<Label className="text-sm font-normal">Align to calendar cycle</Label>
+								<p className="text-muted-foreground text-xs">
+									Reset at the start of each period (e.g. 1st of month) instead of rolling from creation date
+								</p>
+							</div>
+							<Switch
+								checked={form.watch("budgetCalendarAligned")}
+								onCheckedChange={handleCalendarAlignedChange}
+								data-testid="vk-budget-calendar-aligned-toggle"
+							/>
+						</div>
+					)}
+
+							{/* Warning dialog shown when enabling calendar alignment on an existing budget */}
+							<AlertDialog open={showCalendarAlignWarning} onOpenChange={setShowCalendarAlignWarning}>
+								<AlertDialogContent>
+									<AlertDialogHeader>
+										<AlertDialogTitle>Reset budget usage?</AlertDialogTitle>
+										<AlertDialogDescription>
+											Enabling calendar alignment will immediately reset this budget&apos;s current usage to{" "}
+											<span className="font-semibold">$0.00</span> and snap the reset date to the start of the current{" "}
+											{form.watch("budgetResetDuration") === "1d"
+												? "day"
+												: form.watch("budgetResetDuration") === "1w"
+													? "week"
+													: form.watch("budgetResetDuration") === "1M"
+														? "month"
+														: form.watch("budgetResetDuration") === "1Y"
+															? "year"
+															: "period"}
+											. This cannot be undone.
+										</AlertDialogDescription>
+									</AlertDialogHeader>
+									<AlertDialogFooter>
+										<AlertDialogCancel>Cancel</AlertDialogCancel>
+										<AlertDialogAction
+											onClick={() => {
+												form.setValue("budgetCalendarAligned", true, { shouldDirty: true });
+												setShowCalendarAlignWarning(false);
+											}}
+										>
+											Enable Calendar Alignment
+										</AlertDialogAction>
+									</AlertDialogFooter>
+								</AlertDialogContent>
+							</AlertDialog>
+						</div>
+
+						{/* Rate Limiting Configuration */}
 							<div className="space-y-4">
 								<div className="flex items-center justify-between gap-2">
 									<Label className="text-sm font-medium">Rate Limiting Configuration</Label>

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -18,8 +18,11 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { getErrorMessage, useDeleteVirtualKeyMutation } from "@/lib/store"
 import { Customer, Team, VirtualKey } from "@/lib/types/governance"
+import { resetDurationLabels } from "@/lib/constants/governance"
 import { cn } from "@/lib/utils"
 import { formatCurrency } from "@/lib/utils/governance"
+
+const formatResetDuration = (duration: string) => resetDurationLabels[duration] || duration;
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib"
 import { ChevronLeft, ChevronRight, Copy, Edit, Eye, EyeOff, Plus, Search, Trash2 } from "lucide-react"
 import { useMemo, useState } from "react"
@@ -295,15 +298,21 @@ export default function VirtualKeysTable({
 													</Button>
 												</div>
 											</TableCell>
-											<TableCell>
-												{vk.budget ? (
+										<TableCell>
+											{vk.budget ? (
+												<div className="flex flex-col gap-0.5">
 													<span className={cn("font-mono text-sm", vk.budget.current_usage >= vk.budget.max_limit && "text-red-400")}>
 														{formatCurrency(vk.budget.current_usage)} / {formatCurrency(vk.budget.max_limit)}
 													</span>
-												) : (
-													<span className="text-muted-foreground text-sm">-</span>
-												)}
-											</TableCell>
+													<span className="text-muted-foreground text-xs">
+														Resets {formatResetDuration(vk.budget.reset_duration)}
+														{vk.budget.calendar_aligned && " (calendar)"}
+													</span>
+												</div>
+											) : (
+												<span className="text-muted-foreground text-sm">-</span>
+											)}
+										</TableCell>
 											<TableCell>
 												<Badge variant={vk.is_active ? (isExhausted ? "destructive" : "default") : "secondary"}>
 													{vk.is_active ? (isExhausted ? "Exhausted" : "Active") : "Inactive"}

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -21,8 +21,6 @@ import { Customer, Team, VirtualKey } from "@/lib/types/governance"
 import { resetDurationLabels } from "@/lib/constants/governance"
 import { cn } from "@/lib/utils"
 import { formatCurrency } from "@/lib/utils/governance"
-
-const formatResetDuration = (duration: string) => resetDurationLabels[duration] || duration;
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib"
 import { ChevronLeft, ChevronRight, Copy, Edit, Eye, EyeOff, Plus, Search, Trash2 } from "lucide-react"
 import { useMemo, useState } from "react"
@@ -30,6 +28,8 @@ import { toast } from "sonner"
 import VirtualKeyDetailSheet from "./virtualKeyDetailsSheet"
 import { VirtualKeysEmptyState } from "./virtualKeysEmptyState"
 import VirtualKeySheet from "./virtualKeySheet"
+
+const formatResetDuration = (duration: string) => resetDurationLabels[duration] || duration
 
 interface VirtualKeysTableProps {
 	virtualKeys: VirtualKey[];

--- a/ui/lib/constants/governance.ts
+++ b/ui/lib/constants/governance.ts
@@ -19,6 +19,11 @@ export const budgetDurationOptions = [
 	{ label: "Monthly", value: "1M" },
 ];
 
+// Durations that support calendar-aligned resets (snap to day/week/month/year boundaries).
+// Must stay in sync with IsCalendarAlignableDuration in framework/configstore/tables/utils.go.
+export const supportsCalendarAlignment = (duration: string): boolean =>
+	duration.length > 0 && /[dwMY]$/.test(duration)
+
 // Map of duration values to short labels for display
 export const resetDurationLabels: Record<string, string> = {
 	"1m": "Every Minute",

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -8,6 +8,7 @@ export interface Budget {
 	reset_duration: string; // e.g., "30s", "5m", "1h", "1d", "1w", "1M"
 	current_usage: number; // In dollars
 	last_reset: string; // ISO timestamp
+	calendar_aligned?: boolean; // When true, resets at clean calendar boundaries (day/week/month/year start)
 }
 
 export interface RateLimit {
@@ -201,11 +202,13 @@ export interface UpdateCustomerRequest {
 export interface CreateBudgetRequest {
 	max_limit: number; // In dollars
 	reset_duration: string; // e.g., "30s", "5m", "1h", "1d", "1w", "1M"
+	calendar_aligned?: boolean; // Snap resets to calendar boundaries (day/week/month/year)
 }
 
 export interface UpdateBudgetRequest {
 	max_limit?: number;
 	reset_duration?: string;
+	calendar_aligned?: boolean; // When switching to true, current usage is reset to 0
 }
 
 export interface CreateRateLimitRequest {


### PR DESCRIPTION
By @17jmumford 

## Summary

Organizations seeking standardization around budget time periods will benefit from this new budget calendar alignment option. The default behavior of budget reset periods is based on rolling periods from the time of budget creation. Moving forward, users can opt in to aligning their budget periods to calendar periods for month, week, and day. This means that a budget would restart at exactly the start of the month, instead of the datetime of the month the budget was set.

To reduce cognitive load on users, the option to align budgets to calendars only appears if a user has typed in a budget and has selected a valid time period (month/week/day). I've also added a warning for modifying existing budgets to align that this will reset the budget. Finally, I added a hint on the virtual key page displaying what time period the budget is set to.


THOUGHTS/QUESTIONS FOR MAINTAINERS:
I'm also open to thoughts on the terminology here, if we want to call it something besides "calendar alignment".

Additionally, you could take a much more high level approach 🤔 , and have it be a system wide setting you toggle on and off. Then you don't have to muck around with each key, you just set your preference across the entire and system and you are done.  Its "cleaner", but you lose fine grained control and it might be quite a bit messier on the backend. You'd probably get trapped having to nuke the budgets for everyone if you wanted to make the change. 

## Changes

- Virtual key UI now displays budget time period
- Virtual key and team budget time periods for month, week, and day can now be 'aligned', snapping them to the start of those time periods rather than the time of budget creation
- Budget alignment option off by default for backwards compatability
- Budget alignment option only appears when entering a budget on a valid time period
- Users receive a pop-up warning when changing calendar alignment on existing keys, explaining it will reset the budget

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Create a virtual key or team, and enter a budget. If monthly, weekly, or daily is selected, a 'calendar alignment' modal will pop up.  

## Screenshots/Recordings

<img width="661" height="617" alt="image" src="https://github.com/user-attachments/assets/8a7ab19a-f52a-412a-83da-fc0718b7c70a" />
<img width="674" height="406" alt="image" src="https://github.com/user-attachments/assets/4e6d1be0-793c-4be7-a571-c4699c63c122" />
<img width="1345" height="541" alt="image" src="https://github.com/user-attachments/assets/0438845a-a339-4b96-ba18-78bb23160c60" />


## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Closes https://github.com/maximhq/bifrost/issues/2079.

## Security considerations

No security risks associated with this. 

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


