### PR TITLE
adds claude for office docs

### DIFF
--- a/docs/cli-agents/claude-code.mdx
+++ b/docs/cli-agents/claude-code.mdx
@@ -6,6 +6,10 @@ icon: "star-of-life"
 
 [Claude Code](https://www.claude.com/product/claude-code) brings AI-powered coding capabilities directly to your terminal.
 
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with Claude Code, try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+</Note>
+
 ## To install Claude code
 
 ```bash

--- a/docs/cli-agents/claude-for-office.mdx
+++ b/docs/cli-agents/claude-for-office.mdx
@@ -1,0 +1,82 @@
+---
+title: "Claude for Office"
+description: "Use Claude for Office (Microsoft 365 add-in) with Bifrost to route requests through any provider with virtual keys, budget controls, and observability."
+icon: "file-word"
+---
+
+[Claude for Office](https://marketplace.microsoft.com/en-us/product/saas/wa200009404?tab=overview) is Anthropic's Microsoft 365 add-in that brings Claude directly into Word, Excel, PowerPoint, and Outlook. By routing Claude for Office through Bifrost, you get governance features like virtual keys, budget controls, rate limits, and built-in observability for all office-based AI usage across your organization.
+
+![Claude for Office with Bifrost](/media/cli/claude-office-image-1.png)
+
+## Setup
+
+### 1. Install the Add-in
+
+Install the [Claude for Office add-in](https://marketplace.microsoft.com/en-us/product/saas/wa200009404?tab=overview) from the Microsoft AppSource marketplace within any Office application (Word, Excel, PowerPoint, or Outlook). Organization admins can also deploy it centrally via the Microsoft 365 admin center.
+
+### 2. Log in and Select Enterprise Gateway
+
+Open the Claude for Office add-in and log in to your account. On the login screen, select **Enterprise Gateway** as your connection method.
+
+### 3. Configure the API Endpoint
+
+Enter your Bifrost endpoint as the **Base URL**:
+
+```
+https://bifrost.example.com/anthropic
+```
+
+For local development:
+
+```
+http://localhost:8080/anthropic
+```
+
+### 4. Set Your API Key
+
+Enter your Bifrost [virtual key](/features/governance/virtual-keys) or Anthropic API key in the **API Key** field.
+
+### 5. Whitelist Required Headers
+
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this step.
+</Note>
+
+Claude for Office requires the following headers to be in the Allowed Headers list. Go to **Settings > Client Settings** and add them as a comma-separated list:
+
+```
+anthropic-dangerous-direct-browser-access, anthropic-version, content-type, user-agent, x-api-key, x-stainless-arch, x-stainless-helper-method, x-stainless-lang, x-stainless-os, x-stainless-package-version, x-stainless-retry-count, x-stainless-runtime, x-stainless-runtime-version, x-stainless-timeout
+```
+
+You're all set — Claude for Office will now route all requests through Bifrost.
+
+## How It Works
+
+Claude for Office uses the Anthropic Messages API natively. Bifrost exposes a fully compatible Anthropic API at the `/anthropic` path, so the add-in works without any additional configuration beyond pointing it at your Bifrost instance.
+
+Bifrost automatically handles:
+
+- **Model routing** — requests are routed to the correct provider based on the model name
+- **Tool stripping** — server-side tools like `code_execution`, `web_search`, and `web_fetch` are automatically stripped to prevent API conflicts
+- **Model metadata** — token limits and capabilities are returned in list models responses for proper model selection in the add-in
+
+## Using Virtual Keys
+
+Bifrost [Virtual Keys](/features/governance/virtual-keys) can be used as the API key in Claude for Office. This lets you:
+
+- Enforce per-user or per-team budgets and rate limits
+- Control which models and providers each user can access
+- Track usage and costs across your organization
+- Rotate credentials without updating every user's add-in configuration
+
+For organization-wide deployments, create separate virtual keys for each team or department to manage AI spend independently.
+
+## Observability
+
+All Claude for Office requests through Bifrost are logged. Monitor them at `http://localhost:8080/logs` — filter by provider, model, or search through conversation content to track usage patterns across your organization.
+
+## Next Steps
+
+- [Provider Configuration](/quickstart/gateway/provider-configuration) — Configure AI providers in Bifrost
+- [Virtual Keys](/features/governance/virtual-keys) — Set up usage limits and access control
+- [Built-in Observability](/features/observability/default) — Monitor all AI traffic

--- a/docs/cli-agents/codex-cli.mdx
+++ b/docs/cli-agents/codex-cli.mdx
@@ -6,6 +6,10 @@ icon: "openai"
 
 [Codex CLI](https://developers.openai.com/codex/cli/) provides powerful code generation and completion capabilities directly in your terminal.
 
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with Codex CLI, try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+</Note>
+
 ## To install Codex CLI
 
 ```bash

--- a/docs/cli-agents/cursor.mdx
+++ b/docs/cli-agents/cursor.mdx
@@ -8,6 +8,10 @@ icon: "arrow-pointer"
 
 ![Setting up Bifrost for Cursor](/media/ides/cursor-add-custom-model-1.png)
 
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with Cursor, try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+</Note>
+
 ## Setup
 
 1. **Open Cursor Settings**
@@ -22,9 +26,9 @@ icon: "arrow-pointer"
 
    Toggle **Override OpenAI Base URL** to ON and enter your Bifrost endpoint:
 
-   ```
-   http://localhost:8080/cursor
-   ```
+   <Note>
+      For cursor you need publicly accessible link for Bifrost.
+   </Note>
 
    For deployed instances, use your Bifrost deployment URL (e.g., `https://bifrost.example.com/cursor`).
 

--- a/docs/cli-agents/gemini-cli.mdx
+++ b/docs/cli-agents/gemini-cli.mdx
@@ -6,6 +6,11 @@ icon: "diamond"
 
 [Gemini CLI](https://github.com/google-gemini/gemini-cli) is Google's powerful coding assistant with advanced reasoning capabilities.
 
+
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with Gemini CLI, try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+</Note>
+
 ## To install Gemini CLI
 
 ```bash

--- a/docs/cli-agents/librechat.mdx
+++ b/docs/cli-agents/librechat.mdx
@@ -6,6 +6,10 @@ icon: "message"
 
 [LibreChat](https://github.com/danny-avila/LibreChat) is a modern, open-source chat client that supports multiple AI providers. By adding Bifrost as a custom provider, you get access to any model configured in Bifrost through a familiar chat interface, plus governance features like virtual keys and built-in observability.
 
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with LibreChat, try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+</Note>
+
 ## Setup
 
 ### 1. Install LibreChat

--- a/docs/cli-agents/open-webui.mdx
+++ b/docs/cli-agents/open-webui.mdx
@@ -6,6 +6,10 @@ icon: "globe"
 
 [Open WebUI](https://github.com/open-webui/open-webui) is a modern, open-source chat interface that supports OpenAI-compatible APIs. By adding Bifrost as a connection, you get access to any model configured in Bifrost through a familiar ChatGPT-like interface, plus governance features like virtual keys and built-in observability.
 
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with Open WebUI, try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+</Note>
+
 ## Setup
 
 ### 1. Install Open WebUI

--- a/docs/cli-agents/opencode.mdx
+++ b/docs/cli-agents/opencode.mdx
@@ -8,6 +8,10 @@ icon: "codepen"
 
 ![Opencode with Bifrost](../media/opencode-with-bifrost.png)
 
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with OpenCode, try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+</Note>
+
 ## Setup
 
 ### 1. Configure OpenCode to work with Bifrost

--- a/docs/cli-agents/overview.mdx
+++ b/docs/cli-agents/overview.mdx
@@ -14,6 +14,10 @@ Bifrost provides **100% compatible endpoints** for OpenAI, Anthropic, and Gemini
 - **Load Balancing**: Automatically distribute requests across multiple providers and regions
 - **Advanced Features**: Governance, caching, failover, and more - all transparent to your agent
 
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with your CLI agent, try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+</Note>
+
 ## CLI Agents
 
 <CardGroup cols={3}>
@@ -25,6 +29,9 @@ Bifrost provides **100% compatible endpoints** for OpenAI, Anthropic, and Gemini
   </Card>
   <Card title="Claude Code" icon="terminal" href="/cli-agents/claude-code">
     AI-powered coding directly in your terminal
+  </Card>
+  <Card title="Claude for Office" icon="file-word" href="/cli-agents/claude-for-office">
+    Claude in Word, Excel, PowerPoint, and Outlook
   </Card>
   <Card title="Codex CLI" icon="code" href="/cli-agents/codex-cli">
     OpenAI's powerful code generation CLI

--- a/docs/cli-agents/qwen-code.mdx
+++ b/docs/cli-agents/qwen-code.mdx
@@ -6,6 +6,10 @@ icon: "q"
 
 [Qwen Code](https://github.com/QwenLM/qwen-code) is Alibaba's powerful coding assistant with advanced reasoning capabilities. By connecting it to Bifrost, you get access to any provider/model in your Bifrost configuration, plus governance features like virtual keys and built-in observability.
 
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with Qwen Code, try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+</Note>
+
 ## Setup
 
 ### 1. Install Qwen Code

--- a/docs/cli-agents/roo-code.mdx
+++ b/docs/cli-agents/roo-code.mdx
@@ -6,6 +6,10 @@ icon: "code"
 
 [Roo Code](https://roo-code.net/) is an AI-powered VS Code extension that supports OpenAI-compatible APIs. By connecting it to Bifrost, you get access to any provider/model in your Bifrost configuration, plus governance features like virtual keys and built-in observability.
 
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with Roo Code, try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+</Note>
+
 ## Setup
 
 ### 1. Install Roo Code

--- a/docs/cli-agents/zed-editor.mdx
+++ b/docs/cli-agents/zed-editor.mdx
@@ -8,6 +8,10 @@ icon: "z"
 
 ![Zed editor integration](../media/zed-editor-integration.png)
 
+<Note>
+If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with Zed, try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+</Note>
+
 ## Setup
 
 ### 1. Configure Bifrost Provider

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -256,6 +256,7 @@
               "cli-agents/cursor",
               "cli-agents/librechat",
               "cli-agents/claude-code",
+              "cli-agents/claude-for-office",
               "cli-agents/codex-cli",
               "cli-agents/gemini-cli",
               "cli-agents/qwen-code",

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -77,7 +77,9 @@ func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 			origin := string(ctx.Request.Header.Peek("Origin"))
 			allowed := IsOriginAllowed(origin, config.ClientConfig.AllowedOrigins)
 			allowedHeaders := []string{"Content-Type", "Authorization", "X-Requested-With", "X-Stainless-Timeout", "X-Api-Key"}
-			if len(config.ClientConfig.AllowedHeaders) > 0 {
+			if slices.Contains(config.ClientConfig.AllowedHeaders, "*") {
+				allowedHeaders = []string{"*"}
+			} else if len(config.ClientConfig.AllowedHeaders) > 0 {
 				// append allowed headers from config to the default headers
 				for _, header := range config.ClientConfig.AllowedHeaders {
 					if !slices.Contains(allowedHeaders, header) {

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -71,7 +71,7 @@ func TestCorsMiddleware_LocalhostOrigins(t *testing.T) {
 			if string(ctx.Response.Header.Peek("Access-Control-Allow-Methods")) != "GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD" {
 				t.Errorf("Access-Control-Allow-Methods header not set correctly")
 			}
-			if string(ctx.Response.Header.Peek("Access-Control-Allow-Headers")) != "Content-Type, Authorization, X-Requested-With, X-Stainless-Timeout" {
+			if string(ctx.Response.Header.Peek("Access-Control-Allow-Headers")) != "Content-Type, Authorization, X-Requested-With, X-Stainless-Timeout, X-Api-Key" {
 				t.Errorf("Access-Control-Allow-Headers header not set correctly")
 			}
 			if string(ctx.Response.Header.Peek("Access-Control-Allow-Credentials")) != "true" {
@@ -864,10 +864,44 @@ func TestCorsMiddleware_DefaultHeaders(t *testing.T) {
 	handler(ctx)
 
 	// Check default headers are set
-	expectedHeaders := "Content-Type, Authorization, X-Requested-With, X-Stainless-Timeout"
+	expectedHeaders := "Content-Type, Authorization, X-Requested-With, X-Stainless-Timeout, X-Api-Key"
 	actualHeaders := string(ctx.Response.Header.Peek("Access-Control-Allow-Headers"))
 	if actualHeaders != expectedHeaders {
 		t.Errorf("Expected Access-Control-Allow-Headers to be %s, got %s", expectedHeaders, actualHeaders)
+	}
+
+	if !nextCalled {
+		t.Error("Next handler was not called")
+	}
+}
+
+// TestCorsMiddleware_WildcardHeaders tests that wildcard allowed headers sets Access-Control-Allow-Headers to *
+func TestCorsMiddleware_WildcardHeaders(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	config := &lib.Config{
+		ClientConfig: configstore.ClientConfig{
+			AllowedOrigins: []string{"https://example.com"},
+			AllowedHeaders: []string{"*"},
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Origin", "https://example.com")
+
+	nextCalled := false
+	next := func(ctx *fasthttp.RequestCtx) {
+		nextCalled = true
+	}
+
+	middleware := CorsMiddleware(config)
+	handler := middleware(next)
+	handler(ctx)
+
+	// Check that wildcard is set
+	actualHeaders := string(ctx.Response.Header.Peek("Access-Control-Allow-Headers"))
+	if actualHeaders != "*" {
+		t.Errorf("Expected Access-Control-Allow-Headers to be *, got %s", actualHeaders)
 	}
 
 	if !nextCalled {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -621,6 +621,9 @@ func applyClientConfigDefaults(cc *configstore.ClientConfig) {
 	if cc.AllowedOrigins == nil {
 		cc.AllowedOrigins = DefaultClientConfig.AllowedOrigins
 	}
+	if cc.AllowedHeaders == nil {
+		cc.AllowedHeaders = DefaultClientConfig.AllowedHeaders
+	}
 	if cc.EnableLogging == nil {
 		cc.EnableLogging = new(true)
 	}


### PR DESCRIPTION
## Summary

Adds documentation and support for Claude for Office (Microsoft 365 add-in) integration with Bifrost, enabling governance features like virtual keys, budget controls, and observability for office-based AI usage.

## Changes

- Added comprehensive documentation for Claude for Office integration including setup instructions, configuration steps, and usage guidelines
- Updated CORS middleware to properly handle wildcard (`*`) allowed headers by setting `Access-Control-Allow-Headers` to `*` when wildcard is present in configuration
- Changed default allowed headers configuration from empty array to `["*"]` to support broader client compatibility
- Added Claude for Office card to the CLI agents overview page
- Updated documentation navigation to include the new Claude for Office guide

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Docs

## How to test

Test the CORS middleware changes:

```sh
go test ./transports/bifrost-http/handlers/
```

Test Claude for Office integration:
1. Install Claude for Office add-in from Microsoft AppSource
2. Configure with Bifrost endpoint and virtual key
3. Verify requests route through Bifrost with proper CORS headers
4. Check observability logs for tracked usage

Verify documentation builds:

```sh
# Docs
cd docs
npm run build
```

## Screenshots/Recordings

N/A - Documentation and backend changes only

## Breaking changes

- [ ] Yes
- [x] No

The default configuration change to wildcard headers maintains backward compatibility while enabling broader client support.

## Related issues

N/A

## Security considerations

- Virtual keys provide secure access control for organizational deployments
- CORS wildcard headers increase permissiveness but are necessary for Office add-in compatibility
- All requests are logged for audit purposes

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable