### PR TITLE
feat: track and report dropped parameters during provider conversion

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -609,7 +609,7 @@ func (bifrost *Bifrost) TextCompletionRequest(ctx *schemas.BifrostContext, req *
 	if err != nil {
 		return nil, err
 	}
-	//TODO: Release the response
+	// TODO: Release the response
 	return response.TextCompletionResponse, nil
 }
 
@@ -922,7 +922,7 @@ func (bifrost *Bifrost) EmbeddingRequest(ctx *schemas.BifrostContext, req *schem
 	if err != nil {
 		return nil, err
 	}
-	//TODO: Release the response
+	// TODO: Release the response
 	return response.EmbeddingResponse, nil
 }
 
@@ -1026,7 +1026,7 @@ func (bifrost *Bifrost) SpeechRequest(ctx *schemas.BifrostContext, req *schemas.
 	if err != nil {
 		return nil, err
 	}
-	//TODO: Release the response
+	// TODO: Release the response
 	return response.SpeechResponse, nil
 }
 
@@ -1099,7 +1099,7 @@ func (bifrost *Bifrost) TranscriptionRequest(ctx *schemas.BifrostContext, req *s
 	if err != nil {
 		return nil, err
 	}
-	//TODO: Release the response
+	// TODO: Release the response
 	return response.TranscriptionResponse, nil
 }
 
@@ -1139,7 +1139,8 @@ func (bifrost *Bifrost) TranscriptionStreamRequest(ctx *schemas.BifrostContext, 
 
 // ImageGenerationRequest sends an image generation request to the specified provider.
 func (bifrost *Bifrost) ImageGenerationRequest(ctx *schemas.BifrostContext,
-	req *schemas.BifrostImageGenerationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
+	req *schemas.BifrostImageGenerationRequest,
+) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
 	if req == nil {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
@@ -1192,7 +1193,8 @@ func (bifrost *Bifrost) ImageGenerationRequest(ctx *schemas.BifrostContext,
 
 // ImageGenerationStreamRequest sends an image generation stream request to the specified provider.
 func (bifrost *Bifrost) ImageGenerationStreamRequest(ctx *schemas.BifrostContext,
-	req *schemas.BifrostImageGenerationRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	req *schemas.BifrostImageGenerationRequest,
+) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	if req == nil {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
@@ -1405,7 +1407,8 @@ func (bifrost *Bifrost) ImageVariationRequest(ctx *schemas.BifrostContext, req *
 
 // VideoGenerationRequest sends a video generation request to the specified provider.
 func (bifrost *Bifrost) VideoGenerationRequest(ctx *schemas.BifrostContext,
-	req *schemas.BifrostVideoGenerationRequest) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
+	req *schemas.BifrostVideoGenerationRequest,
+) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
 	if req == nil {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
@@ -4082,6 +4085,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 				KeyStatuses:    primaryErr.ExtraFields.KeyStatuses,
 			}
 		}
+		AttachDroppedParams(ctx, primaryResult, primaryErr)
 		return primaryResult, primaryErr
 	}
 
@@ -4113,6 +4117,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 		if fallbackErr == nil {
 			bifrost.logger.Debug(fmt.Sprintf("successfully used fallback provider %s with model %s", fallback.Provider, fallback.Model))
 			tracer.EndSpan(handle, schemas.SpanStatusOk, "")
+			AttachDroppedParams(ctx, result, nil)
 			return result, nil
 		}
 
@@ -4132,6 +4137,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 				RawResponse:    fallbackErr.ExtraFields.RawResponse,
 				KeyStatuses:    fallbackErr.ExtraFields.KeyStatuses,
 			}
+			AttachDroppedParams(ctx, nil, fallbackErr)
 			return nil, fallbackErr
 		}
 	}
@@ -4148,6 +4154,7 @@ func (bifrost *Bifrost) handleRequest(ctx *schemas.BifrostContext, req *schemas.
 	}
 
 	// All providers failed, return the original error
+	AttachDroppedParams(ctx, nil, primaryErr)
 	return nil, primaryErr
 }
 
@@ -4197,6 +4204,7 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 				KeyStatuses:    primaryErr.ExtraFields.KeyStatuses,
 			}
 		}
+		AttachDroppedParams(ctx, nil, primaryErr)
 		return primaryResult, primaryErr
 	}
 
@@ -4245,6 +4253,7 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 				RawResponse:    fallbackErr.ExtraFields.RawResponse,
 				KeyStatuses:    fallbackErr.ExtraFields.KeyStatuses,
 			}
+			AttachDroppedParams(ctx, nil, fallbackErr)
 			return nil, fallbackErr
 		}
 	}
@@ -4261,6 +4270,7 @@ func (bifrost *Bifrost) handleStreamRequest(ctx *schemas.BifrostContext, req *sc
 	}
 
 	// All providers failed, return the original error
+	AttachDroppedParams(ctx, nil, primaryErr)
 	return nil, primaryErr
 }
 
@@ -4594,7 +4604,7 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 					// Send the processed message to the output stream
 					outputStream <- streamResponse
 
-					//TODO: Release the processed response immediately after use
+					// TODO: Release the processed response immediately after use
 				}
 			}()
 

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -33,6 +33,9 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 		// Anthropic doesn't allow both temperature and top_p to be specified
 		// If both are present, prefer temperature (more commonly used)
 		if bifrostReq.Params.Temperature != nil {
+			if bifrostReq.Params.TopP != nil {
+				schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "top_p")
+			}
 			anthropicReq.Temperature = bifrostReq.Params.Temperature
 		} else if bifrostReq.Params.TopP != nil {
 			anthropicReq.TopP = bifrostReq.Params.TopP

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2201,7 +2201,6 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 				params.Include = []string{"web_search_call.action.sources"}
 			}
 		}
-
 	}
 
 	bifrostReq.Params = params
@@ -2289,6 +2288,9 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 		// Anthropic doesn't allow both temperature and top_p to be specified
 		// If both are present, prefer temperature (more commonly used)
 		if bifrostReq.Params.Temperature != nil {
+			if bifrostReq.Params.TopP != nil {
+				schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "top_p")
+			}
 			anthropicReq.Temperature = bifrostReq.Params.Temperature
 		} else if bifrostReq.Params.TopP != nil {
 			anthropicReq.TopP = bifrostReq.Params.TopP
@@ -4098,7 +4100,6 @@ func convertBifrostMessageToAnthropicMessage(msg *schemas.ResponsesMessage, pend
 			}
 		}
 	}
-
 
 	return &anthropicMsg
 }

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -768,7 +768,7 @@ func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schema
 			ctx,
 			request,
 			func() (providerUtils.RequestBodyWithExtraParams, error) {
-				reqBody := openai.ToOpenAIResponsesRequest(request)
+				reqBody := openai.ToOpenAIResponsesRequest(ctx, request)
 				if reqBody != nil {
 					reqBody.Model = deployment
 				}

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -2010,7 +2010,6 @@ func (provider *GeminiProvider) TranscriptionStream(ctx *schemas.BifrostContext,
 		}
 		ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 		providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, nil, response, nil), responseChan)
-
 	}()
 
 	return responseChan, nil

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -58,24 +58,27 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 	case schemas.OpenAI, schemas.Azure:
 		return openaiReq
 	case schemas.XAI:
-		openaiReq.filterOpenAISpecificParameters()
-		openaiReq.applyXAICompatibility(bifrostReq.Model)
+		openaiReq.filterOpenAISpecificParameters(ctx)
+		openaiReq.applyXAICompatibility(ctx, bifrostReq.Model)
 		return openaiReq
 	case schemas.Gemini:
-		openaiReq.filterOpenAISpecificParameters()
+		openaiReq.filterOpenAISpecificParameters(ctx)
 		// Removing extra parameters that are not supported by Gemini
+		if openaiReq.ServiceTier != nil {
+			schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "service_tier")
+		}
 		openaiReq.ServiceTier = nil
 		return openaiReq
 	case schemas.Mistral:
-		openaiReq.filterOpenAISpecificParameters()
-		openaiReq.applyMistralCompatibility()
+		openaiReq.filterOpenAISpecificParameters(ctx)
+		openaiReq.applyMistralCompatibility(ctx)
 		return openaiReq
 	case schemas.Vertex:
-		openaiReq.filterOpenAISpecificParameters()
+		openaiReq.filterOpenAISpecificParameters(ctx)
 
 		// Apply Mistral-specific transformations for Vertex Mistral models
 		if schemas.IsMistralModel(bifrostReq.Model) {
-			openaiReq.applyMistralCompatibility()
+			openaiReq.applyMistralCompatibility(ctx)
 		}
 		return openaiReq
 	default:
@@ -83,13 +86,13 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		if isCustomProvider, ok := ctx.Value(schemas.BifrostContextKeyIsCustomProvider).(bool); ok && isCustomProvider {
 			return openaiReq
 		}
-		openaiReq.filterOpenAISpecificParameters()
+		openaiReq.filterOpenAISpecificParameters(ctx)
 		return openaiReq
 	}
 }
 
 // Filter OpenAI Specific Parameters
-func (req *OpenAIChatRequest) filterOpenAISpecificParameters() {
+func (req *OpenAIChatRequest) filterOpenAISpecificParameters(ctx *schemas.BifrostContext) {
 	// Handle reasoning parameter: OpenAI uses effort-based reasoning
 	// Priority: effort (native) > max_tokens (estimated)
 	if req.ChatParameters.Reasoning != nil {
@@ -101,6 +104,9 @@ func (req *OpenAIChatRequest) filterOpenAISpecificParameters() {
 				req.ChatParameters.Reasoning.Effort = schemas.Ptr("low")
 			}
 			// Clear max_tokens since OpenAI doesn't use it
+			if req.ChatParameters.Reasoning.MaxTokens != nil {
+				schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "reasoning.max_tokens")
+			}
 			req.ChatParameters.Reasoning.MaxTokens = nil
 		} else if req.ChatParameters.Reasoning.MaxTokens != nil {
 			// Estimate effort from max_tokens
@@ -112,36 +118,44 @@ func (req *OpenAIChatRequest) filterOpenAISpecificParameters() {
 			effort := utils.GetReasoningEffortFromBudgetTokens(maxTokens, MinReasoningMaxTokens, maxCompletionTokens)
 			req.ChatParameters.Reasoning.Effort = schemas.Ptr(effort)
 			// Clear max_tokens since OpenAI doesn't use it
+			schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "reasoning.max_tokens")
 			req.ChatParameters.Reasoning.MaxTokens = nil
 		}
 	}
 
 	if req.ChatParameters.Prediction != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "prediction")
 		req.ChatParameters.Prediction = nil
 	}
 	if req.ChatParameters.PromptCacheKey != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "prompt_cache_key")
 		req.ChatParameters.PromptCacheKey = nil
 	}
 	if req.ChatParameters.PromptCacheRetention != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "prompt_cache_retention")
 		req.ChatParameters.PromptCacheRetention = nil
 	}
 	if req.ChatParameters.Verbosity != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "verbosity")
 		req.ChatParameters.Verbosity = nil
 	}
 	if req.ChatParameters.Store != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "store")
 		req.ChatParameters.Store = nil
 	}
 	if req.ChatParameters.WebSearchOptions != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "web_search_options")
 		req.ChatParameters.WebSearchOptions = nil
 	}
 }
 
 // applyMistralCompatibility applies Mistral-specific transformations to the request
-func (req *OpenAIChatRequest) applyMistralCompatibility() {
+func (req *OpenAIChatRequest) applyMistralCompatibility(ctx *schemas.BifrostContext) {
 	// Mistral uses max_tokens instead of max_completion_tokens
 	if req.MaxCompletionTokens != nil {
 		req.MaxTokens = req.MaxCompletionTokens
 		req.MaxCompletionTokens = nil
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "max_completion_tokens")
 	}
 
 	// Mistral does not support ToolChoiceStruct, only simple tool choice strings are supported
@@ -152,24 +166,36 @@ func (req *OpenAIChatRequest) applyMistralCompatibility() {
 }
 
 // applyXAICompatibility applies xAI-specific transformations to the request
-func (req *OpenAIChatRequest) applyXAICompatibility(model string) {
+func (req *OpenAIChatRequest) applyXAICompatibility(ctx *schemas.BifrostContext, model string) {
 	// Only apply filters if this is a grok reasoning model
 	if !schemas.IsGrokReasoningModel(model) {
 		return
 	}
 
+	if req.ChatParameters.PresencePenalty != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "presence_penalty")
+	}
 	req.ChatParameters.PresencePenalty = nil
 
 	// Only non-mini grok-3 models support frequency_penalty and stop
 	// grok-3-mini only supports reasoning_effort in reasoning mode
 	if !strings.Contains(model, "grok-3") || strings.Contains(model, "grok-3-mini") {
+		if req.ChatParameters.FrequencyPenalty != nil {
+			schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "frequency_penalty")
+		}
 		req.ChatParameters.FrequencyPenalty = nil
+		if req.ChatParameters.Stop != nil {
+			schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "stop")
+		}
 		req.ChatParameters.Stop = nil
 	}
 
 	// Only grok-3-mini supports reasoning_effort
 	if req.ChatParameters.Reasoning != nil &&
 		!strings.Contains(model, "grok-3-mini") {
+		if req.ChatParameters.Reasoning.Effort != nil {
+			schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "reasoning.effort")
+		}
 		// Clear reasoning_effort for non-grok-3-mini models
 		req.ChatParameters.Reasoning.Effort = nil
 	}

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -173,6 +174,7 @@ func TestToOpenAIChatRequest_CachingDeterminism(t *testing.T) {
 }
 
 func TestApplyXAICompatibility(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 	tests := []struct {
 		name     string
 		model    string
@@ -474,7 +476,7 @@ func TestApplyXAICompatibility(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Apply the compatibility function
-			tt.request.applyXAICompatibility(tt.model)
+			tt.request.applyXAICompatibility(ctx, tt.model)
 
 			// Validate the results
 			tt.validate(t, tt.request)

--- a/core/providers/openai/images.go
+++ b/core/providers/openai/images.go
@@ -11,7 +11,7 @@ import (
 )
 
 // ToOpenAIImageGenerationRequest converts a Bifrost Image Request to OpenAI format
-func ToOpenAIImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRequest) *OpenAIImageGenerationRequest {
+func ToOpenAIImageGenerationRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.BifrostImageGenerationRequest) *OpenAIImageGenerationRequest {
 	if bifrostReq == nil || bifrostReq.Input == nil || bifrostReq.Input.Prompt == "" {
 		return nil
 	}
@@ -27,9 +27,9 @@ func ToOpenAIImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 
 	switch bifrostReq.Provider {
 	case schemas.XAI:
-		filterXAISpecificParameters(req)
+		filterXAISpecificParameters(ctx, req)
 	case schemas.OpenAI, schemas.Azure:
-		filterOpenAISpecificParameters(req)
+		filterOpenAISpecificParameters(ctx, req)
 	}
 	if bifrostReq.Params != nil {
 		req.ExtraParams = bifrostReq.Params.ExtraParams
@@ -37,16 +37,37 @@ func ToOpenAIImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 	return req
 }
 
-func filterXAISpecificParameters(req *OpenAIImageGenerationRequest) {
+func filterXAISpecificParameters(ctx *schemas.BifrostContext, req *OpenAIImageGenerationRequest) {
+	if req.ImageGenerationParameters.Quality != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "quality")
+	}
 	req.ImageGenerationParameters.Quality = nil
+	if req.ImageGenerationParameters.Style != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "style")
+	}
 	req.ImageGenerationParameters.Style = nil
+	if req.ImageGenerationParameters.Size != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "size")
+	}
 	req.ImageGenerationParameters.Size = nil
+	if req.ImageGenerationParameters.OutputCompression != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "output_compression")
+	}
 	req.ImageGenerationParameters.OutputCompression = nil
 }
 
-func filterOpenAISpecificParameters(req *OpenAIImageGenerationRequest) {
+func filterOpenAISpecificParameters(ctx *schemas.BifrostContext, req *OpenAIImageGenerationRequest) {
+	if req.ImageGenerationParameters.Seed != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "seed")
+	}
 	req.ImageGenerationParameters.Seed = nil
+	if req.NumInferenceSteps != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "num_inference_steps")
+	}
 	req.NumInferenceSteps = nil
+	if req.NegativePrompt != nil {
+		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "negative_prompt")
+	}
 	req.NegativePrompt = nil
 }
 

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1465,7 +1465,7 @@ func HandleOpenAIResponsesRequest(
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return ToOpenAIResponsesRequest(request), nil
+			return ToOpenAIResponsesRequest(ctx, request), nil
 		},
 		providerName)
 	if bifrostErr != nil {
@@ -1611,7 +1611,7 @@ func HandleOpenAIResponsesStreaming(
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			reqBody := ToOpenAIResponsesRequest(request)
+			reqBody := ToOpenAIResponsesRequest(ctx, request)
 			if reqBody != nil {
 				reqBody.Stream = schemas.Ptr(true)
 				if postRequestConverter != nil {
@@ -2958,7 +2958,7 @@ func HandleOpenAIImageGenerationRequest(
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return ToOpenAIImageGenerationRequest(request), nil
+			return ToOpenAIImageGenerationRequest(ctx, request), nil
 		},
 		providerName)
 	if bifrostErr != nil {
@@ -3098,7 +3098,7 @@ func HandleOpenAIImageGenerationStreaming(
 			if customRequestConverter != nil {
 				return customRequestConverter(request)
 			}
-			reqBody := ToOpenAIImageGenerationRequest(request)
+			reqBody := ToOpenAIImageGenerationRequest(ctx, request)
 			if reqBody != nil {
 				reqBody.Stream = schemas.Ptr(true)
 				if postRequestConverter != nil {
@@ -4102,7 +4102,7 @@ func HandleOpenAICountTokensRequest(
 		ctx,
 		request,
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
-			return ToOpenAIResponsesRequest(request), nil
+			return ToOpenAIResponsesRequest(ctx, request), nil
 		},
 		providerName,
 	)

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -44,7 +44,7 @@ func (resp *OpenAIResponsesRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 }
 
 // ToOpenAIResponsesRequest converts a Bifrost responses request to OpenAI format
-func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *OpenAIResponsesRequest {
+func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.BifrostResponsesRequest) *OpenAIResponsesRequest {
 	if bifrostReq == nil || bifrostReq.Input == nil {
 		return nil
 	}
@@ -206,6 +206,9 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 					req.ResponsesParameters.Reasoning.Effort = schemas.Ptr("low")
 				}
 				// Clear max_tokens since OpenAI doesn't use it
+				if req.ResponsesParameters.Reasoning.MaxTokens != nil {
+					schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "reasoning.max_tokens")
+				}
 				req.ResponsesParameters.Reasoning.MaxTokens = nil
 			} else if req.ResponsesParameters.Reasoning.MaxTokens != nil {
 				// Estimate effort from max_tokens
@@ -217,6 +220,7 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 				effort := utils.GetReasoningEffortFromBudgetTokens(maxTokens, MinReasoningMaxTokens, maxOutputTokens)
 				req.ResponsesParameters.Reasoning.Effort = schemas.Ptr(effort)
 				// Clear max_tokens since OpenAI doesn't use it
+				schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "reasoning.max_tokens")
 				req.ResponsesParameters.Reasoning.MaxTokens = nil
 			}
 
@@ -226,6 +230,7 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 				schemas.IsGrokReasoningModel(bifrostReq.Model) &&
 				!strings.Contains(bifrostReq.Model, "grok-3-mini") {
 				// Clear reasoning_effort for non-grok-3-mini xAI reasoning models
+				schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "reasoning.effort")
 				req.ResponsesParameters.Reasoning.Effort = nil
 			}
 
@@ -234,6 +239,7 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 			// Regular models like gpt-4o, gpt-4, gpt-3.5-turbo don't support it
 			if bifrostReq.Provider == schemas.OpenAI && !isOpenAIReasoningModel(bifrostReq.Model) {
 				// Clear reasoning for non-reasoning OpenAI models to avoid API errors
+				schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "reasoning")
 				req.ResponsesParameters.Reasoning = nil
 			}
 		}
@@ -258,6 +264,7 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 				stripTopP = false
 			}
 			if stripTopP {
+				schemas.AppendToContextList(ctx, schemas.BifrostContextKeyDroppedParams, "top_p")
 				req.ResponsesParameters.TopP = nil
 			}
 		}
@@ -365,4 +372,3 @@ func (resp *OpenAIResponsesRequest) filterUnsupportedTools() {
 	}
 	resp.Tools = filteredTools
 }
-

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -9,6 +10,7 @@ import (
 )
 
 func TestToOpenAIResponsesRequest_ReasoningOnlyMessageSkip(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 	tests := []struct {
 		name                     string
 		model                    string
@@ -184,7 +186,7 @@ func TestToOpenAIResponsesRequest_ReasoningOnlyMessageSkip(t *testing.T) {
 				Input: []schemas.ResponsesMessage{tt.message},
 			}
 
-			result := ToOpenAIResponsesRequest(bifrostReq)
+			result := ToOpenAIResponsesRequest(ctx, bifrostReq)
 
 			if result == nil {
 				t.Fatal("ToOpenAIResponsesRequest returned nil")
@@ -227,6 +229,7 @@ func TestToOpenAIResponsesRequest_ReasoningOnlyMessageSkip(t *testing.T) {
 }
 
 func TestToOpenAIResponsesRequest_GPTOSS_SummaryToContentBlocks(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 	tests := []struct {
 		name              string
 		model             string
@@ -316,7 +319,7 @@ func TestToOpenAIResponsesRequest_GPTOSS_SummaryToContentBlocks(t *testing.T) {
 				Input: []schemas.ResponsesMessage{tt.message},
 			}
 
-			result := ToOpenAIResponsesRequest(bifrostReq)
+			result := ToOpenAIResponsesRequest(ctx, bifrostReq)
 
 			if result == nil {
 				t.Fatal("ToOpenAIResponsesRequest returned nil")
@@ -1413,6 +1416,7 @@ func TestResponsesTool_EdgeCases(t *testing.T) {
 }
 
 func TestToOpenAIResponsesRequest_ToolNormalization(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 	// Create function tool with unsorted properties
 	unsortedParams := &schemas.ToolFunctionParameters{
 		Type: "object",
@@ -1444,14 +1448,14 @@ func TestToOpenAIResponsesRequest_ToolNormalization(t *testing.T) {
 					},
 				},
 				{
-					Type: schemas.ResponsesToolTypeWebSearch,
+					Type:                   schemas.ResponsesToolTypeWebSearch,
 					ResponsesToolWebSearch: &schemas.ResponsesToolWebSearch{},
 				},
 			},
 		},
 	}
 
-	result := ToOpenAIResponsesRequest(bifrostReq)
+	result := ToOpenAIResponsesRequest(ctx, bifrostReq)
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -222,7 +222,7 @@ const (
 	BifrostContextKeyRoutingEnginesUsed                  BifrostContextKey = "bifrost-routing-engines-used"                     // []string (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engines used ("routing-rule", "governance", "loadbalancing", etc.)
 	BifrostContextKeyRoutingEngineLogs                   BifrostContextKey = "bifrost-routing-engine-logs"                      // []RoutingEngineLogEntry (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engine log entries
 	BifrostContextKeyTransportPluginLogs                 BifrostContextKey = "bifrost-transport-plugin-logs"                    // []PluginLogEntry (transport-layer plugin logs accumulated during HTTP transport hooks)
-	BifrostContextKeyTransportPostHookCompleter          BifrostContextKey = "bifrost-transport-posthook-completer"              // func() (callback to run HTTPTransportPostHook after streaming - set by transport interceptor middleware)
+	BifrostContextKeyTransportPostHookCompleter          BifrostContextKey = "bifrost-transport-posthook-completer"             // func() (callback to run HTTPTransportPostHook after streaming - set by transport interceptor middleware)
 	BifrostContextKeySkipPluginPipeline                  BifrostContextKey = "bifrost-skip-plugin-pipeline"                     // bool - skip plugin pipeline for the request
 	BifrostIsAsyncRequest                                BifrostContextKey = "bifrost-is-async-request"                         // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an async request (only used in gateway)
 	BifrostContextKeyRequestHeaders                      BifrostContextKey = "bifrost-request-headers"                          // map[string]string (all request headers with lowercased keys)
@@ -256,6 +256,7 @@ const (
 	BifrostContextKeySessionID                           BifrostContextKey = "bifrost-session-id"                         // string session ID for the request (session stickiness)
 	BifrostContextKeySessionTTL                          BifrostContextKey = "bifrost-session-ttl"                        // time.Duration session TTL for the request (session stickiness)
 	BifrostContextKeyMCPExtraHeaders                     BifrostContextKey = "bifrost-mcp-extra-headers"                  // map[string][]string (these headers are forwarded only to the MCP while tool execution if they are in the allowlist of the MCP client)
+	BifrostContextKeyDroppedParams                       BifrostContextKey = "bifrost-dropped-params"                     // []string (params dropped during provider conversion)
 )
 
 const (
@@ -822,6 +823,7 @@ type BifrostResponseExtraFields struct {
 	ParseErrors             []BatchError       `json:"parse_errors,omitempty"` // errors encountered while parsing JSONL batch results
 	LiteLLMCompat           bool               `json:"litellm_compat,omitempty"`
 	ProviderResponseHeaders map[string]string  `json:"provider_response_headers,omitempty"` // HTTP response headers from the provider (filtered to exclude transport-level headers)
+	DroppedParams           []string           `json:"dropped_params,omitempty"`            // params dropped during provider conversion
 }
 
 type BifrostMCPResponseExtraFields struct {
@@ -986,4 +988,5 @@ type BifrostErrorExtraFields struct {
 	RawResponse    interface{}   `json:"raw_response,omitempty"`
 	LiteLLMCompat  bool          `json:"litellm_compat,omitempty"`
 	KeyStatuses    []KeyStatus   `json:"key_statuses,omitempty"`
+	DroppedParams  []string      `json:"dropped_params,omitempty"`
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -525,3 +525,23 @@ func isPromptOptionalImageEditType(t *string) bool {
 		normalized,
 	)
 }
+
+// AttachDroppedParams attaches dropped params from the context to the response and/or error extra fields.
+func AttachDroppedParams(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, err *schemas.BifrostError) {
+	if ctx == nil {
+		return
+	}
+	droppedParams, ok := ctx.Value(schemas.BifrostContextKeyDroppedParams).([]string)
+	if !ok || len(droppedParams) == 0 {
+		return
+	}
+	if resp != nil {
+		extraFields := resp.GetExtraFields()
+		if extraFields != nil {
+			extraFields.DroppedParams = droppedParams
+		}
+	}
+	if err != nil {
+		err.ExtraFields.DroppedParams = droppedParams
+	}
+}


### PR DESCRIPTION
## Summary

This change introduces a dropped parameters tracking system that records when provider-specific parameters are filtered out during request conversion, providing better visibility into parameter compatibility across different AI providers.

## Changes

- **Added dropped parameter tracking infrastructure**: New context key `BifrostContextKeyDroppedParams` and utility functions to track parameters that are removed during provider conversion
- **Enhanced provider conversion logic**: Updated OpenAI, Anthropic, Gemini, and Azure providers to record dropped parameters when filtering incompatible parameters
- **Extended response/error fields**: Added `DroppedParams` field to both `BifrostResponseExtraFields` and `BifrostErrorExtraFields` to surface this information to clients
- **Improved parameter filtering**: Made parameter filtering context-aware across chat, image generation, and responses endpoints
- **Code formatting cleanup**: Standardized TODO comment formatting and fixed function parameter alignment

The system tracks parameters like `top_p` when dropped in favor of `temperature` for Anthropic, reasoning parameters for different model types, and provider-specific incompatible parameters.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the dropped parameters tracking by making requests with parameters that are incompatible with specific providers:

```sh
# Test Anthropic parameter dropping (top_p when temperature is present)
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "claude-3-sonnet-20240229",
    "messages": [{"role": "user", "content": "Hello"}],
    "temperature": 0.7,
    "top_p": 0.9
  }'

# Test XAI parameter dropping for reasoning models
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "grok-3-mini",
    "messages": [{"role": "user", "content": "Hello"}],
    "presence_penalty": 0.5,
    "frequency_penalty": 0.3
  }'

# Core tests
go test ./core/providers/openai/...
go test ./core/providers/anthropic/...
go test ./core/...
```

Check the response `extra_fields.dropped_params` array to verify dropped parameters are correctly tracked.

## Breaking changes

- [ ] Yes
- [x] No

This is a non-breaking addition that only adds new optional fields to response structures.

## Security considerations

No security implications - this change only adds informational metadata about parameter compatibility.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable