### PR TITLE
fixes * allowed headers for CORS

### DIFF
--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -76,9 +76,26 @@ func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 		corsFlow:
 			origin := string(ctx.Request.Header.Peek("Origin"))
 			allowed := IsOriginAllowed(origin, config.ClientConfig.AllowedOrigins)
+			// Credentialed responses are sent when the origin is not matched solely by a
+			// wildcard AllowedOrigins — i.e. the origin is localhost or explicitly listed.
+			credentialed := !slices.Contains(config.ClientConfig.AllowedOrigins, "*") ||
+				isLocalhostOrigin(origin) ||
+				slices.Contains(config.ClientConfig.AllowedOrigins, origin)
+
 			allowedHeaders := []string{"Content-Type", "Authorization", "X-Requested-With", "X-Stainless-Timeout", "X-Api-Key"}
 			if slices.Contains(config.ClientConfig.AllowedHeaders, "*") {
-				allowedHeaders = []string{"*"}
+				if credentialed {
+					// Per the Fetch spec, Access-Control-Allow-Headers: * is NOT treated as a
+					// wildcard when Access-Control-Allow-Credentials: true is set — browsers
+					// interpret it as a literal header name. For credentialed preflight requests,
+					// reflect back the requested headers instead.
+					if requestedHeaders := string(ctx.Request.Header.Peek("Access-Control-Request-Headers")); requestedHeaders != "" {
+						allowedHeaders = []string{requestedHeaders}
+					}
+					// For non-preflight requests (no Access-Control-Request-Headers), keep defaults.
+				} else {
+					allowedHeaders = []string{"*"}
+				}
 			} else if len(config.ClientConfig.AllowedHeaders) > 0 {
 				// append allowed headers from config to the default headers
 				for _, header := range config.ClientConfig.AllowedHeaders {
@@ -92,13 +109,7 @@ func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 				ctx.Response.Header.Set("Access-Control-Allow-Origin", origin)
 				ctx.Response.Header.Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD")
 				ctx.Response.Header.Set("Access-Control-Allow-Headers", strings.Join(allowedHeaders, ", "))
-				// Set Allow-Credentials for credentialed requests. Only skip when wildcard
-				// is configured AND the origin was matched by the wildcard (not by localhost rule
-				// or explicit listing). Localhost origins and explicitly listed origins always
-				// get credentials support since we return the specific origin.
-				if !slices.Contains(config.ClientConfig.AllowedOrigins, "*") ||
-					isLocalhostOrigin(origin) ||
-					slices.Contains(config.ClientConfig.AllowedOrigins, origin) {
+				if credentialed {
 					ctx.Response.Header.Set("Access-Control-Allow-Credentials", "true")
 				}
 				ctx.Response.Header.Set("Access-Control-Max-Age", "86400")

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -875,8 +875,83 @@ func TestCorsMiddleware_DefaultHeaders(t *testing.T) {
 	}
 }
 
-// TestCorsMiddleware_WildcardHeaders tests that wildcard allowed headers sets Access-Control-Allow-Headers to *
-func TestCorsMiddleware_WildcardHeaders(t *testing.T) {
+// TestCorsMiddleware_WildcardHeaders_NonCredentialed tests that wildcard allowed headers
+// sets Access-Control-Allow-Headers to * for non-credentialed requests (wildcard origins).
+func TestCorsMiddleware_WildcardHeaders_NonCredentialed(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	config := &lib.Config{
+		ClientConfig: configstore.ClientConfig{
+			AllowedOrigins: []string{"*"},
+			AllowedHeaders: []string{"*"},
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("Origin", "https://example.com")
+
+	nextCalled := false
+	next := func(ctx *fasthttp.RequestCtx) {
+		nextCalled = true
+	}
+
+	middleware := CorsMiddleware(config)
+	handler := middleware(next)
+	handler(ctx)
+
+	// Non-credentialed: wildcard is valid per spec
+	actualHeaders := string(ctx.Response.Header.Peek("Access-Control-Allow-Headers"))
+	if actualHeaders != "*" {
+		t.Errorf("Expected Access-Control-Allow-Headers to be *, got %s", actualHeaders)
+	}
+
+	if !nextCalled {
+		t.Error("Next handler was not called")
+	}
+}
+
+// TestCorsMiddleware_WildcardHeaders_CredentialedPreflight tests that wildcard allowed headers
+// reflects Access-Control-Request-Headers for credentialed preflight requests instead of sending
+// the literal *, which browsers don't treat as a wildcard when credentials are present.
+func TestCorsMiddleware_WildcardHeaders_CredentialedPreflight(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	config := &lib.Config{
+		ClientConfig: configstore.ClientConfig{
+			AllowedOrigins: []string{"https://example.com"},
+			AllowedHeaders: []string{"*"},
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("OPTIONS")
+	ctx.Request.Header.Set("Origin", "https://example.com")
+	ctx.Request.Header.Set("Access-Control-Request-Headers", "Authorization, X-Custom-Header")
+
+	next := func(ctx *fasthttp.RequestCtx) {
+		t.Error("Next handler should not be called for preflight")
+	}
+
+	middleware := CorsMiddleware(config)
+	handler := middleware(next)
+	handler(ctx)
+
+	// Credentialed preflight: should reflect requested headers, not *
+	actualHeaders := string(ctx.Response.Header.Peek("Access-Control-Allow-Headers"))
+	if actualHeaders != "Authorization, X-Custom-Header" {
+		t.Errorf("Expected Access-Control-Allow-Headers to reflect requested headers, got %s", actualHeaders)
+	}
+
+	// Should also have credentials
+	creds := string(ctx.Response.Header.Peek("Access-Control-Allow-Credentials"))
+	if creds != "true" {
+		t.Errorf("Expected Access-Control-Allow-Credentials to be true, got %s", creds)
+	}
+}
+
+// TestCorsMiddleware_WildcardHeaders_CredentialedNonPreflight tests that wildcard allowed headers
+// uses defaults for credentialed non-preflight requests (no Access-Control-Request-Headers).
+func TestCorsMiddleware_WildcardHeaders_CredentialedNonPreflight(t *testing.T) {
 	SetLogger(&mockLogger{})
 
 	config := &lib.Config{
@@ -898,10 +973,16 @@ func TestCorsMiddleware_WildcardHeaders(t *testing.T) {
 	handler := middleware(next)
 	handler(ctx)
 
-	// Check that wildcard is set
+	// Credentialed non-preflight: should use defaults (not *)
 	actualHeaders := string(ctx.Response.Header.Peek("Access-Control-Allow-Headers"))
-	if actualHeaders != "*" {
-		t.Errorf("Expected Access-Control-Allow-Headers to be *, got %s", actualHeaders)
+	defaultHeaders := []string{"Content-Type", "Authorization", "X-Requested-With", "X-Stainless-Timeout", "X-Api-Key"}
+	for _, header := range defaultHeaders {
+		if !containsHeader(actualHeaders, header) {
+			t.Errorf("Expected Access-Control-Allow-Headers to contain %s, got %s", header, actualHeaders)
+		}
+	}
+	if actualHeaders == "*" {
+		t.Error("Expected Access-Control-Allow-Headers to NOT be * for credentialed requests")
 	}
 
 	if !nextCalled {


### PR DESCRIPTION
## Summary

Fix CORS header handling for credentialed requests when wildcard headers are configured. The previous implementation incorrectly sent `Access-Control-Allow-Headers: *` for credentialed requests, which browsers don't treat as a wildcard when `Access-Control-Allow-Credentials: true` is present.

## Changes

- Extract credentialed request logic into a reusable variable to determine when credentials should be allowed
- For credentialed preflight requests with wildcard headers configured, reflect back the `Access-Control-Request-Headers` value instead of sending `*`
- For credentialed non-preflight requests with wildcard headers, use the default header list instead of `*`
- Add comprehensive test coverage for wildcard header behavior in both credentialed and non-credentialed scenarios

The fix ensures compliance with the Fetch specification, which states that `Access-Control-Allow-Headers: *` is treated as a literal header name (not a wildcard) when credentials are enabled.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate CORS behavior with different origin and header configurations:

```sh
# Run the updated tests
go test ./transports/bifrost-http/handlers -v

# Test credentialed preflight requests
curl -X OPTIONS -H "Origin: https://example.com" \
     -H "Access-Control-Request-Headers: Authorization, X-Custom-Header" \
     http://localhost:8080/api/endpoint

# Test non-credentialed requests with wildcard origins
curl -X OPTIONS -H "Origin: https://example.com" \
     -H "Access-Control-Request-Headers: Authorization" \
     http://localhost:8080/api/endpoint
```

Verify that credentialed requests receive proper header reflection instead of `*`, while non-credentialed requests continue to receive `*` when appropriate.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This fix improves CORS compliance and ensures proper header validation for credentialed cross-origin requests, preventing potential security issues with overly permissive header policies.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable