### PR TITLE
fix: preserve provider precision in embedding responses

### DIFF
--- a/core/internal/llmtests/embedding.go
+++ b/core/internal/llmtests/embedding.go
@@ -13,7 +13,7 @@ import (
 )
 
 // cosineSimilarity computes the cosine similarity between two vectors
-func cosineSimilarity(a, b []float32) float64 {
+func cosineSimilarity(a, b []float64) float64 {
 	if len(a) != len(b) {
 		panic(fmt.Errorf("cosineSimilarity: vectors must have same length, got %d and %d", len(a), len(b)))
 	}
@@ -23,9 +23,9 @@ func cosineSimilarity(a, b []float32) float64 {
 	var normB float64
 
 	for i := 0; i < len(a); i++ {
-		dotProduct += float64(a[i] * b[i])
-		normA += float64(a[i] * a[i])
-		normB += float64(b[i] * b[i])
+		dotProduct += a[i] * b[i]
+		normA += a[i] * a[i]
+		normB += b[i] * b[i]
 	}
 
 	if normA == 0 || normB == 0 {
@@ -120,7 +120,7 @@ func validateEmbeddingSemantics(t *testing.T, response *schemas.BifrostEmbedding
 	}
 
 	// Extract and validate embeddings
-	embeddings := make([][]float32, len(testTexts))
+	embeddings := make([][]float64, len(testTexts))
 	responseDataLength := len(response.Data)
 	if responseDataLength != len(testTexts) {
 		if responseDataLength > 0 && response.Data[0].Embedding.Embedding2DArray != nil {

--- a/core/internal/llmtests/utils.go
+++ b/core/internal/llmtests/utils.go
@@ -587,8 +587,8 @@ func ExtractToolCalls(response *schemas.BifrostResponse) []ToolCallInfo {
 	return []ToolCallInfo{}
 }
 
-// getEmbeddingVector extracts the float32 vector from a BifrostEmbeddingResponse
-func getEmbeddingVector(embedding schemas.EmbeddingData) ([]float32, error) {
+// getEmbeddingVector extracts the float64 vector from a BifrostEmbeddingResponse.
+func getEmbeddingVector(embedding schemas.EmbeddingData) ([]float64, error) {
 	if embedding.Embedding.EmbeddingArray != nil {
 		return embedding.Embedding.EmbeddingArray, nil
 	}

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -239,8 +239,8 @@ type BedrockDocumentSourceData struct {
 
 // BedrockToolUse represents a tool use request
 type BedrockToolUse struct {
-	ToolUseID string      `json:"toolUseId"` // Required: Unique identifier for this tool use
-	Name      string      `json:"name"`      // Required: Name of the tool to use
+	ToolUseID string          `json:"toolUseId"` // Required: Unique identifier for this tool use
+	Name      string          `json:"name"`      // Required: Name of the tool to use
 	Input     json.RawMessage `json:"input"`     // Required: Input parameters for the tool (json.RawMessage preserves key ordering for prompt caching)
 }
 
@@ -658,7 +658,7 @@ func (req *BedrockTitanEmbeddingRequest) GetExtraParams() map[string]interface{}
 
 // BedrockTitanEmbeddingResponse represents a Bedrock Titan embedding response
 type BedrockTitanEmbeddingResponse struct {
-	Embedding           []float32 `json:"embedding"`           // The embedding vector
+	Embedding           []float64 `json:"embedding"`           // The embedding vector
 	InputTextTokenCount int       `json:"inputTextTokenCount"` // Number of tokens in input
 }
 

--- a/core/providers/cohere/types.go
+++ b/core/providers/cohere/types.go
@@ -293,7 +293,7 @@ type CohereEmbeddingResponse struct {
 
 // CohereEmbeddingData represents the embeddings object with different types
 type CohereEmbeddingData struct {
-	Float   [][]float32 `json:"float,omitempty"`   // Float embeddings
+	Float   [][]float64 `json:"float,omitempty"`   // Float embeddings
 	Int8    [][]int8    `json:"int8,omitempty"`    // Int8 embeddings
 	Uint8   [][]uint8   `json:"uint8,omitempty"`   // Uint8 embeddings
 	Binary  [][]int8    `json:"binary,omitempty"`  // Binary embeddings
@@ -421,8 +421,8 @@ type CohereCitation struct {
 type CohereSource struct {
 	Type       CohereSourceType `json:"type"`                  // Source type ("tool" or "document")
 	ID         *string          `json:"id,omitempty"`          // Source ID (nullable)
-	ToolOutput *json.RawMessage  `json:"tool_output,omitempty"` // Tool output (for tool sources, json.RawMessage preserves key ordering)
-	Document   *json.RawMessage  `json:"document,omitempty"`    // Document data (for document sources, json.RawMessage preserves key ordering)
+	ToolOutput *json.RawMessage `json:"tool_output,omitempty"` // Tool output (for tool sources, json.RawMessage preserves key ordering)
+	Document   *json.RawMessage `json:"document,omitempty"`    // Document data (for document sources, json.RawMessage preserves key ordering)
 }
 
 // ==================== STREAMING TYPES ====================

--- a/core/providers/gemini/embedding.go
+++ b/core/providers/gemini/embedding.go
@@ -85,7 +85,7 @@ func ToGeminiEmbeddingResponse(bifrostResp *schemas.BifrostEmbeddingResponse) *G
 
 	// Convert each embedding from Bifrost format to Gemini format
 	for i, embedding := range bifrostResp.Data {
-		var values []float32
+		var values []float64
 
 		// Extract embedding values from BifrostEmbeddingResponse
 		if embedding.Embedding.EmbeddingArray != nil {

--- a/core/providers/gemini/embedding.go
+++ b/core/providers/gemini/embedding.go
@@ -89,10 +89,10 @@ func ToGeminiEmbeddingResponse(bifrostResp *schemas.BifrostEmbeddingResponse) *G
 
 		// Extract embedding values from BifrostEmbeddingResponse
 		if embedding.Embedding.EmbeddingArray != nil {
-			values = embedding.Embedding.EmbeddingArray
+			values = append([]float64(nil), embedding.Embedding.EmbeddingArray...)
 		} else if len(embedding.Embedding.Embedding2DArray) > 0 {
 			// If it's a 2D array, take the first array
-			values = embedding.Embedding.Embedding2DArray[0]
+			values = append([]float64(nil), embedding.Embedding.Embedding2DArray[0]...)
 		}
 
 		geminiEmbedding := GeminiEmbedding{

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -199,6 +199,24 @@ func TestEmptyCandidatesRegression(t *testing.T) {
 	}
 }
 
+func TestToBifrostEmbeddingResponsePreservesPrecision(t *testing.T) {
+	const want = 0.12345678901234568
+
+	resp := gemini.ToBifrostEmbeddingResponse(&gemini.GeminiEmbeddingResponse{
+		Embeddings: []gemini.GeminiEmbedding{
+			{
+				Values: []float64{want},
+			},
+		},
+	}, "gemini-embedding-001")
+
+	require.NotNil(t, resp)
+
+	got := resp.Data[0].Embedding.EmbeddingArray[0]
+	assert.Equal(t, want, got)
+	assert.NotEqual(t, float64(float32(want)), got)
+}
+
 // TestThoughtSignatureInToolCalls tests that thought signatures are properly embedded in tool call IDs
 // for both streaming and non-streaming responses to enable round-trip compatibility
 func TestThoughtSignatureInToolCalls(t *testing.T) {

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -1432,7 +1432,7 @@ type GeminiEmbeddingResponse struct {
 
 // GeminiEmbedding represents a single embedding in the response
 type GeminiEmbedding struct {
-	Values     []float32                   `json:"values"`
+	Values     []float64                   `json:"values"`
 	Statistics *ContentEmbeddingStatistics `json:"statistics,omitempty"`
 }
 

--- a/core/providers/huggingface/embedding.go
+++ b/core/providers/huggingface/embedding.go
@@ -124,12 +124,8 @@ func UnmarshalHuggingFaceEmbeddingResponse(data []byte, model string) (*schemas.
 	if err := sonic.Unmarshal(data, &arr2D); err == nil {
 		embeddings := make([]schemas.EmbeddingData, len(arr2D))
 		for idx, embedding := range arr2D {
-			conv := make([]float32, len(embedding))
-			for i, v := range embedding {
-				conv[i] = float32(v)
-			}
 			embeddings[idx] = schemas.EmbeddingData{
-				Embedding: schemas.EmbeddingStruct{EmbeddingArray: conv},
+				Embedding: schemas.EmbeddingStruct{EmbeddingArray: append([]float64(nil), embedding...)},
 				Index:     idx,
 				Object:    "embedding",
 			}
@@ -149,13 +145,9 @@ func UnmarshalHuggingFaceEmbeddingResponse(data []byte, model string) (*schemas.
 	// Try 1D array: [num, ...]
 	var arr1D []float64
 	if err := sonic.Unmarshal(data, &arr1D); err == nil {
-		conv := make([]float32, len(arr1D))
-		for i, v := range arr1D {
-			conv[i] = float32(v)
-		}
 		return &schemas.BifrostEmbeddingResponse{
 			Data: []schemas.EmbeddingData{{
-				Embedding: schemas.EmbeddingStruct{EmbeddingArray: conv},
+				Embedding: schemas.EmbeddingStruct{EmbeddingArray: append([]float64(nil), arr1D...)},
 				Index:     0,
 				Object:    "embedding",
 			}},

--- a/core/providers/huggingface/huggingface_test.go
+++ b/core/providers/huggingface/huggingface_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/maximhq/bifrost/core/internal/llmtests"
+	"github.com/maximhq/bifrost/core/providers/huggingface"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -78,4 +79,26 @@ func TestHuggingface(t *testing.T) {
 	t.Run("HuggingFaceTests", func(t *testing.T) {
 		llmtests.RunAllComprehensiveTests(t, client, ctx, testConfig)
 	})
+}
+
+func TestUnmarshalHuggingFaceEmbeddingResponsePreservesPrecision(t *testing.T) {
+	const want = 0.12345678901234568
+
+	resp, err := huggingface.UnmarshalHuggingFaceEmbeddingResponse([]byte(`[[0.12345678901234568]]`), "test-model")
+	if err != nil {
+		t.Fatalf("UnmarshalHuggingFaceEmbeddingResponse failed: %v", err)
+	}
+
+	if resp == nil || len(resp.Data) != 1 {
+		t.Fatalf("expected single embedding response, got %#v", resp)
+	}
+
+	got := resp.Data[0].Embedding.EmbeddingArray[0]
+	if got != want {
+		t.Fatalf("expected %0.18f, got %0.18f", want, got)
+	}
+
+	if got == float64(float32(want)) {
+		t.Fatalf("expected preserved precision, got float32-rounded value %0.18f", got)
+	}
 }

--- a/core/providers/huggingface/huggingface_test.go
+++ b/core/providers/huggingface/huggingface_test.go
@@ -92,6 +92,34 @@ func TestUnmarshalHuggingFaceEmbeddingResponsePreservesPrecision(t *testing.T) {
 	if resp == nil || len(resp.Data) != 1 {
 		t.Fatalf("expected single embedding response, got %#v", resp)
 	}
+	if len(resp.Data[0].Embedding.EmbeddingArray) != 1 {
+		t.Fatalf("expected single embedding value, got %#v", resp.Data[0].Embedding.EmbeddingArray)
+	}
+
+	got := resp.Data[0].Embedding.EmbeddingArray[0]
+	if got != want {
+		t.Fatalf("expected %0.18f, got %0.18f", want, got)
+	}
+
+	if got == float64(float32(want)) {
+		t.Fatalf("expected preserved precision, got float32-rounded value %0.18f", got)
+	}
+}
+
+func TestUnmarshalHuggingFaceEmbeddingResponse1DPreservesPrecision(t *testing.T) {
+	const want = 0.12345678901234568
+
+	resp, err := huggingface.UnmarshalHuggingFaceEmbeddingResponse([]byte(`[0.12345678901234568]`), "test-model")
+	if err != nil {
+		t.Fatalf("UnmarshalHuggingFaceEmbeddingResponse failed: %v", err)
+	}
+
+	if resp == nil || len(resp.Data) != 1 {
+		t.Fatalf("expected single embedding response, got %#v", resp)
+	}
+	if len(resp.Data[0].Embedding.EmbeddingArray) != 1 {
+		t.Fatalf("expected single embedding value, got %#v", resp.Data[0].Embedding.EmbeddingArray)
+	}
 
 	got := resp.Data[0].Embedding.EmbeddingArray[0]
 	if got != want {

--- a/core/providers/vertex/embedding.go
+++ b/core/providers/vertex/embedding.go
@@ -84,17 +84,11 @@ func (response *VertexEmbeddingResponse) ToBifrostEmbeddingResponse() *schemas.B
 			continue
 		}
 
-		// Convert float64 values to float32 for Bifrost format
-		embeddingFloat32 := make([]float32, 0, len(prediction.Embeddings.Values))
-		for _, v := range prediction.Embeddings.Values {
-			embeddingFloat32 = append(embeddingFloat32, float32(v))
-		}
-
 		// Create embedding object
 		embedding := schemas.EmbeddingData{
 			Object: "embedding",
 			Embedding: schemas.EmbeddingStruct{
-				EmbeddingArray: embeddingFloat32,
+				EmbeddingArray: append([]float64(nil), prediction.Embeddings.Values...),
 			},
 			Index: i,
 		}

--- a/core/schemas/embedding.go
+++ b/core/schemas/embedding.go
@@ -116,13 +116,14 @@ type EmbeddingParameters struct {
 type EmbeddingData struct {
 	Index     int             `json:"index"`
 	Object    string          `json:"object"`    // "embedding"
-	Embedding EmbeddingStruct `json:"embedding"` // can be string, []float32 or [][]float32
+	Embedding EmbeddingStruct `json:"embedding"` // can be string, []float64 or [][]float64
 }
 
 type EmbeddingStruct struct {
+	// Embedding responses preserve provider precision in normalized API output.
 	EmbeddingStr     *string
-	EmbeddingArray   []float32
-	Embedding2DArray [][]float32
+	EmbeddingArray   []float64
+	Embedding2DArray [][]float64
 }
 
 func (be EmbeddingStruct) MarshalJSON() ([]byte, error) {
@@ -146,19 +147,19 @@ func (be *EmbeddingStruct) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	// Try to unmarshal as a direct array of float32
-	var arrayContent []float32
+	// Try to unmarshal as a direct array of float64
+	var arrayContent []float64
 	if err := Unmarshal(data, &arrayContent); err == nil {
 		be.EmbeddingArray = arrayContent
 		return nil
 	}
 
-	// Try to unmarshal as a direct 2D array of float32
-	var arrayContent2D [][]float32
+	// Try to unmarshal as a direct 2D array of float64
+	var arrayContent2D [][]float64
 	if err := Unmarshal(data, &arrayContent2D); err == nil {
 		be.Embedding2DArray = arrayContent2D
 		return nil
 	}
 
-	return fmt.Errorf("embedding field is neither a string nor an array of float32 nor a 2D array of float32")
+	return fmt.Errorf("embedding field is neither a string nor an array of float64 nor a 2D array of float64")
 }

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"encoding/json"
+	"math"
 	"strings"
 	"testing"
 
@@ -155,6 +156,31 @@ func TestSonic_OrderedMap_NestedPreservesOrder(t *testing.T) {
 	output, err := Marshal(om)
 	require.NoError(t, err)
 	assert.Equal(t, input, string(output))
+}
+
+func TestSonic_EmbeddingStruct_PreservesFloat64Precision(t *testing.T) {
+	const want = 0.12345678901234568
+
+	var embedding EmbeddingStruct
+	err := embedding.UnmarshalJSON([]byte(`[0.12345678901234568]`))
+	require.NoError(t, err)
+
+	require.Len(t, embedding.EmbeddingArray, 1)
+
+	got := embedding.EmbeddingArray[0]
+	assert.Equal(t, want, got)
+
+	float32Rounded := float64(float32(want))
+	assert.NotEqual(t, float32Rounded, got)
+
+	marshaled, err := embedding.MarshalJSON()
+	require.NoError(t, err)
+
+	var roundTrip []float64
+	err = Unmarshal(marshaled, &roundTrip)
+	require.NoError(t, err)
+	require.Len(t, roundTrip, 1)
+	assert.Equal(t, math.Float64bits(got), math.Float64bits(roundTrip[0]))
 }
 
 // --- ToolFunctionParameters through sonic ---

--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -214,6 +214,8 @@ bifrostConfig := schemas.BifrostConfig{
 
 Direct hash mode provides exact-match caching without requiring an embedding provider. Each request is hashed deterministically based on its normalized input, parameters, and stream flag. Identical requests produce cache hits; different wording is a cache miss.
 
+Exact-match direct entries are stored and retrieved using a deterministic cache ID. This keeps repeated direct cache lookups fast and consistent across retries, streaming responses, and restarts.
+
 **When to use direct hash mode:**
 - You only need exact-match deduplication (no fuzzy/semantic matching)
 - You cannot or do not want to call an external embedding API

--- a/docs/providers/supported-providers/vertex.mdx
+++ b/docs/providers/supported-providers/vertex.mdx
@@ -640,11 +640,11 @@ Model listing is paginated automatically. If more than 100 models exist, `next_p
 **Code**: `utils.go:33, 71`
 </Accordion>
 
-<Accordion title="Embeddings Float64 Conversion">
+<Accordion title="Embeddings Precision Preservation">
 **Severity**: Low
-**Behavior**: Vertex returns float64 embeddings, converted to float32 for Bifrost
-**Impact**: Minor precision loss (expected for embeddings)
-**Code**: `embedding.go:84-87`
+**Behavior**: Vertex returns float64 embeddings, and Bifrost preserves that precision in normalized embedding responses
+**Impact**: No precision loss in the `/v1/embeddings` response path
+**Code**: `embedding.go:84-91`
 </Accordion>
 
 <Accordion title="List Models API Returns Only Custom Models">

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -97,7 +97,7 @@ type Log struct {
 	ResponsesInputHistory  string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.ResponsesMessage
 	OutputMessage          string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ChatMessage
 	ResponsesOutput        string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ResponsesMessage
-	EmbeddingOutput        string    `gorm:"type:text" json:"-"` // JSON serialized [][]float32
+	EmbeddingOutput        string    `gorm:"type:text" json:"-"` // JSON serialized embedding response data
 	RerankOutput           string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.RerankResult
 	Params                 string    `gorm:"type:text" json:"-"` // JSON serialized *schemas.ModelParameters
 	Tools                  string    `gorm:"type:text" json:"-"` // JSON serialized []schemas.Tool

--- a/plugins/semanticcache/plugin_core_test.go
+++ b/plugins/semanticcache/plugin_core_test.go
@@ -207,6 +207,44 @@ func TestSemanticSearch(t *testing.T) {
 	t.Log("✅ Semantic search test completed successfully!")
 }
 
+func TestToFloat32Embedding(t *testing.T) {
+	input := []float64{0.12345678901234568, -0.875, 1.5}
+
+	got := toFloat32Embedding(input)
+
+	if len(got) != len(input) {
+		t.Fatalf("expected %d elements, got %d", len(input), len(got))
+	}
+
+	for i, want := range input {
+		if got[i] != float32(want) {
+			t.Fatalf("expected element %d to be %v, got %v", i, float32(want), got[i])
+		}
+	}
+}
+
+func TestFlattenToFloat32Embedding(t *testing.T) {
+	input := [][]float64{
+		{0.25, 0.5},
+		{-0.75},
+		{},
+		{1.25, 2.5},
+	}
+
+	got := flattenToFloat32Embedding(input)
+	want := []float32{0.25, 0.5, -0.75, 1.25, 2.5}
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d elements, got %d", len(want), len(got))
+	}
+
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected element %d to be %v, got %v", i, want[i], got[i])
+		}
+	}
+}
+
 // TestDirectVsSemanticSearch tests the difference between direct hash matching and semantic search
 func TestDirectVsSemanticSearch(t *testing.T) {
 	setup := NewTestSetup(t)

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -24,6 +24,38 @@ func normalizeText(text string) string {
 	return strings.ToLower(strings.TrimSpace(text))
 }
 
+// Semantic cache keeps vector-store/search payloads as float32 even though
+// normalized embedding API responses now preserve provider precision as float64.
+func toFloat32Embedding(values []float64) []float32 {
+	if len(values) == 0 {
+		return nil
+	}
+
+	embedding := make([]float32, len(values))
+	for i, value := range values {
+		embedding[i] = float32(value)
+	}
+
+	return embedding
+}
+
+func flattenToFloat32Embedding(values [][]float64) []float32 {
+	total := 0
+	for _, arr := range values {
+		total += len(arr)
+	}
+	if total == 0 {
+		return nil
+	}
+
+	embedding := make([]float32, 0, total)
+	for _, arr := range values {
+		embedding = append(embedding, toFloat32Embedding(arr)...)
+	}
+
+	return embedding
+}
+
 // generateEmbedding generates an embedding for the given text using the configured provider.
 func (plugin *Plugin) generateEmbedding(ctx *schemas.BifrostContext, text string) ([]float32, int, error) {
 	// Create embedding request
@@ -61,14 +93,9 @@ func (plugin *Plugin) generateEmbedding(ctx *schemas.BifrostContext, text string
 		}
 		return vals, inputTokens, nil
 	} else if embedding.EmbeddingArray != nil {
-		return embedding.EmbeddingArray, inputTokens, nil
+		return toFloat32Embedding(embedding.EmbeddingArray), inputTokens, nil
 	} else if len(embedding.Embedding2DArray) > 0 {
-		// Flatten 2D array into single embedding
-		var flattened []float32
-		for _, arr := range embedding.Embedding2DArray {
-			flattened = append(flattened, arr...)
-		}
-		return flattened, inputTokens, nil
+		return flattenToFloat32Embedding(embedding.Embedding2DArray), inputTokens, nil
 	}
 
 	return nil, 0, fmt.Errorf("embedding data is not in expected format")


### PR DESCRIPTION
## Summary

Fixes #2303 by preserving provider precision in normalized embedding responses. Previously, Bifrost narrowed embedding values to `float32` before returning `/v1/embeddings`, which could cause response values to differ from the underlying provider output.

---

## Changes

### What was changed and why

- Changed normalized embedding response arrays in core schema from `[]float32` / `[][]float32` to `[]float64` / `[][]float64`
- Updated provider embedding normalization paths to stop narrowing values before building Bifrost responses
- Kept semantic cache / vector-store internals on `float32`, with an explicit conversion at that boundary
- Added regression coverage for schema precision, provider conversion, and semantic-cache compatibility
- Updated stale Vertex docs and logstore comment to match the new behavior

### Notable design decisions and trade-offs

- The precision-preserving change is limited to normalized API responses, where exact provider fidelity matters
- Semantic cache and vector-store internals remain `float32` intentionally for storage/search compatibility and lower overhead
- This fixes the reported bug without widening the entire embedding pipeline end-to-end

---

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

---

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [x] Docs

---

## How to test

### Targeted Go tests

These are targeted tests, not full suite — they cover the schemas, affected providers, and semantic cache plugin.

```bash
cd core
go test ./schemas ./providers/gemini ./providers/huggingface ./internal/llmtests

cd ../plugins/semanticcache
go test ./...
```

**Expected outcome:** All targeted tests pass.

---

### Functional verification against Gemini

**Direct Gemini request:**

```bash
curl -sS "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents?key=$GEMINI_API_KEY" \
  -H 'content-type: application/json' \
  -d '{
    "requests": [
      {
        "model": "models/gemini-embedding-001",
        "content": {
          "parts": [{ "text": "Precision check text 2026-03-27" }]
        },
        "outputDimensionality": 512
      }
    ]
  }' | jq '.embeddings[0].values[:10]'
```

**Bifrost request:**

```bash
curl -sS http://localhost:8080/v1/embeddings \
  -H 'content-type: application/json' \
  -H "x-goog-api-key: $GEMINI_API_KEY" \
  -d '{
    "model": "gemini/gemini-embedding-001",
    "input": "Precision check text 2026-03-27",
    "dimensions": 512
  }' | jq '.data[0].embedding[:10]'
```

**Expected outcome:** The first 10 embedding values match exactly between direct Gemini output and Bifrost output.

---

## New config / environment variables

None.

---

## Screenshots / Recordings

N/A

---

## Breaking changes

**Yes.**

This is a breaking change for Go consumers of Bifrost response types.

Normalized embedding response arrays now use:

| Before | After |
| --- | --- |
| `[]float32` | `[]float64` |
| `[][]float32` | `[][]float64` |

**Impact:** Any Go code directly consuming `EmbeddingArray` / `Embedding2DArray` as `float32` will need to update types or explicitly convert.

**Notably:** This does not change the JSON response shape for HTTP clients — it changes the Go response types used by consumers importing Bifrost schemas directly.

**Migration:**

- Update direct response consumers to `[]float64`
- Convert to `float32` only at boundaries where lower-precision storage/search is intentional

---

## Related issues

Closes #2303

---

## Security considerations

- No auth or permission model changes
- No new secrets or environment variables
- No known PII or sandboxing impact

---

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable