### PR TITLE
fix: map unsupported reasoning_effort values for Mistral provider

### DIFF
--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -149,6 +149,15 @@ func (req *OpenAIChatRequest) applyMistralCompatibility() {
 		req.ToolChoice.ChatToolChoiceStr = schemas.Ptr("any")
 		req.ToolChoice.ChatToolChoiceStruct = nil
 	}
+
+	// Mistral only accepts reasoning_effort values "none" or "high".
+	// Map any other values (e.g. "low", "medium") to "high" to avoid 422 errors.
+	if req.ChatParameters.Reasoning != nil && req.ChatParameters.Reasoning.Effort != nil {
+		effort := *req.ChatParameters.Reasoning.Effort
+		if effort != "none" && effort != "high" {
+			req.ChatParameters.Reasoning.Effort = schemas.Ptr("high")
+		}
+	}
 }
 
 // applyXAICompatibility applies xAI-specific transformations to the request

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -151,11 +151,11 @@ func (req *OpenAIChatRequest) applyMistralCompatibility() {
 	}
 
 	// Mistral only accepts reasoning_effort values "none" or "high".
-	// Map any other values (e.g. "low", "medium") to "high" to avoid 422 errors.
+	// Drop unsupported values (e.g. "low", "medium") instead of coercing.
 	if req.ChatParameters.Reasoning != nil && req.ChatParameters.Reasoning.Effort != nil {
 		effort := *req.ChatParameters.Reasoning.Effort
 		if effort != "none" && effort != "high" {
-			req.ChatParameters.Reasoning.Effort = schemas.Ptr("high")
+			req.ChatParameters.Reasoning.Effort = nil
 		}
 	}
 }

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -481,3 +481,80 @@ func TestApplyXAICompatibility(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyMistralCompatibility_ReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name           string
+		effort         *string
+		expectedEffort *string
+	}{
+		{
+			name:           "none is preserved",
+			effort:         schemas.Ptr("none"),
+			expectedEffort: schemas.Ptr("none"),
+		},
+		{
+			name:           "high is preserved",
+			effort:         schemas.Ptr("high"),
+			expectedEffort: schemas.Ptr("high"),
+		},
+		{
+			name:           "medium is mapped to high",
+			effort:         schemas.Ptr("medium"),
+			expectedEffort: schemas.Ptr("high"),
+		},
+		{
+			name:           "low is mapped to high",
+			effort:         schemas.Ptr("low"),
+			expectedEffort: schemas.Ptr("high"),
+		},
+		{
+			name:           "nil effort is preserved",
+			effort:         nil,
+			expectedEffort: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &OpenAIChatRequest{
+				Model:    "mistral-large-latest",
+				Messages: []OpenAIMessage{},
+				ChatParameters: schemas.ChatParameters{
+					Reasoning: &schemas.ChatReasoning{
+						Effort: tt.effort,
+					},
+				},
+			}
+			req.applyMistralCompatibility()
+
+			if tt.expectedEffort == nil {
+				if req.Reasoning.Effort != nil {
+					t.Errorf("Expected Reasoning.Effort to be nil, got %v", *req.Reasoning.Effort)
+				}
+			} else {
+				if req.Reasoning.Effort == nil {
+					t.Fatalf("Expected Reasoning.Effort to be %q, got nil", *tt.expectedEffort)
+				}
+				if *req.Reasoning.Effort != *tt.expectedEffort {
+					t.Errorf("Expected Reasoning.Effort to be %q, got %q", *tt.expectedEffort, *req.Reasoning.Effort)
+				}
+			}
+		})
+	}
+
+	// Test nil reasoning is handled gracefully
+	t.Run("nil reasoning is handled gracefully", func(t *testing.T) {
+		req := &OpenAIChatRequest{
+			Model:    "mistral-large-latest",
+			Messages: []OpenAIMessage{},
+			ChatParameters: schemas.ChatParameters{
+				Reasoning: nil,
+			},
+		}
+		req.applyMistralCompatibility()
+		if req.Reasoning != nil {
+			t.Errorf("Expected Reasoning to remain nil, got %v", req.Reasoning)
+		}
+	})
+}

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -482,6 +482,54 @@ func TestApplyXAICompatibility(t *testing.T) {
 	}
 }
 
+func TestToOpenAIChatRequest_VertexMistralDropsUnsupportedReasoningEffort(t *testing.T) {
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+
+	t.Run("drops unsupported reasoning effort for Vertex Mistral models", func(t *testing.T) {
+		req := &schemas.BifrostChatRequest{
+			Provider: schemas.Vertex,
+			Model:    "mistral-large-latest",
+			Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser}},
+			Params: &schemas.ChatParameters{
+				Reasoning: &schemas.ChatReasoning{
+					Effort: schemas.Ptr("medium"),
+				},
+			},
+		}
+
+		got := ToOpenAIChatRequest(ctx, req)
+		if got == nil {
+			t.Fatal("expected non-nil OpenAI chat request")
+		}
+		if got.Reasoning == nil {
+			t.Fatal("expected Reasoning to remain non-nil")
+		}
+		if got.Reasoning.Effort != nil {
+			t.Fatalf("expected unsupported Reasoning.Effort to be dropped, got %q", *got.Reasoning.Effort)
+		}
+	})
+
+	t.Run("preserves nil reasoning for Vertex Mistral models", func(t *testing.T) {
+		req := &schemas.BifrostChatRequest{
+			Provider: schemas.Vertex,
+			Model:    "mistral-large-latest",
+			Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser}},
+			Params: &schemas.ChatParameters{
+				Reasoning: nil,
+			},
+		}
+
+		got := ToOpenAIChatRequest(ctx, req)
+		if got == nil {
+			t.Fatal("expected non-nil OpenAI chat request")
+		}
+		if got.Reasoning != nil {
+			t.Fatalf("expected Reasoning to remain nil, got %#v", got.Reasoning)
+		}
+	})
+}
+
 func TestApplyMistralCompatibility_ReasoningEffort(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -499,14 +499,14 @@ func TestApplyMistralCompatibility_ReasoningEffort(t *testing.T) {
 			expectedEffort: schemas.Ptr("high"),
 		},
 		{
-			name:           "medium is mapped to high",
+			name:           "medium is dropped (unsupported)",
 			effort:         schemas.Ptr("medium"),
-			expectedEffort: schemas.Ptr("high"),
+			expectedEffort: nil,
 		},
 		{
-			name:           "low is mapped to high",
+			name:           "low is dropped (unsupported)",
 			effort:         schemas.Ptr("low"),
-			expectedEffort: schemas.Ptr("high"),
+			expectedEffort: nil,
 		},
 		{
 			name:           "nil effort is preserved",


### PR DESCRIPTION
## Summary

Fixes #2196

- Mistral only accepts `reasoning_effort` values `"none"` or `"high"`, but Bifrost forwards unsupported values like `"medium"` or `"low"` (e.g. from Claude Code), causing a 422 error from Mistral's API.
- This adds reasoning effort validation in `applyMistralCompatibility()` to drop unsupported values instead of coercing them, avoiding unexpected higher token usage. The values `"none"` and `"high"` are preserved as-is.
- Also applies to Vertex Mistral models since they share the same compatibility path.

## Test plan

- [x] Added unit tests for reasoning_effort values: `"none"` (preserved), `"high"` (preserved), `"medium"` (dropped), `"low"` (dropped), `nil` (preserved)
- [x] Added route-level coverage for Vertex Mistral model handling
- [x] Added test for nil `Reasoning` struct (graceful handling)
