### PR TITLE
remove pending marshal to map to fix caching issues at provider level

### DIFF
--- a/core/mcp/agentadaptors.go
+++ b/core/mcp/agentadaptors.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"fmt"
 
-	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -262,7 +261,7 @@ func createChatResponseWithExecutedToolsAndNonAutoExecutableCalls(
 		}
 
 		// Convert to JSON string for display
-		jsonBytes, err := sonic.Marshal(toolResultsMap)
+		jsonBytes, err := schemas.MarshalSorted(toolResultsMap)
 		if err != nil {
 			// Fallback to simple string representation
 			contentText = fmt.Sprintf("The Output from allowed tools calls is - %v\n\nNow I shall call these tools next...", toolResultsMap)
@@ -498,7 +497,7 @@ func createResponsesResponseWithExecutedToolsAndNonAutoExecutableCalls(
 		}
 
 		// Convert to JSON string for display
-		jsonBytes, err := sonic.Marshal(toolResultsMap)
+		jsonBytes, err := schemas.MarshalSorted(toolResultsMap)
 		if err != nil {
 			// Fallback to simple string representation
 			contentText = fmt.Sprintf("The Output from allowed tools calls is - %v\n\nNow I shall call these tools next...", toolResultsMap)

--- a/core/mcp/codemode/starlark/executecode.go
+++ b/core/mcp/codemode/starlark/executecode.go
@@ -176,7 +176,7 @@ func (s *StarlarkCodeMode) handleExecuteToolCode(ctx context.Context, toolCall s
 				responseText = "Execution completed successfully."
 			}
 			if hasResult {
-				resultJSON, err := sonic.MarshalIndent(result.Result, "", "  ")
+				resultJSON, err := schemas.MarshalSortedIndent(result.Result, "", "  ")
 				if err == nil {
 					responseText += fmt.Sprintf("\nReturn value: %s", string(resultJSON))
 					s.logger.Debug("%s Added return value to response (JSON length: %d chars)", codemcp.CodeModeLogPrefix, len(resultJSON))
@@ -429,7 +429,7 @@ func (s *StarlarkCodeMode) callMCPTool(ctx context.Context, clientName, toolName
 	}
 
 	// Marshal arguments to JSON for the tool call
-	argsJSON, err := sonic.Marshal(args)
+	argsJSON, err := schemas.MarshalSorted(args)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal tool arguments: %v", err)
 	}

--- a/core/mcp/codemode/starlark/utils.go
+++ b/core/mcp/codemode/starlark/utils.go
@@ -104,9 +104,9 @@ func goToStarlark(v interface{}) starlark.Value {
 		return dict
 	default:
 		// Try to marshal to JSON and parse as a generic structure
-		if jsonBytes, err := sonic.Marshal(val); err == nil {
+		if jsonBytes, err := schemas.MarshalSorted(val); err == nil {
 			var generic interface{}
-			if sonic.Unmarshal(jsonBytes, &generic) == nil {
+			if schemas.Unmarshal(jsonBytes, &generic) == nil {
 				return goToStarlark(generic)
 			}
 		}
@@ -179,7 +179,7 @@ func formatResultForLog(result interface{}) string {
 	var resultStr string
 	if result == nil {
 		resultStr = "null"
-	} else if resultBytes, err := sonic.Marshal(result); err == nil {
+	} else if resultBytes, err := schemas.MarshalSorted(result); err == nil {
 		resultStr = string(resultBytes)
 	} else {
 		resultStr = fmt.Sprintf("%v", result)
@@ -265,7 +265,7 @@ func extractTextFromMCPResponse(toolResponse *mcp.CallToolResult, toolName strin
 			result.WriteString(fmt.Sprintf("[Embedded Resource Response: %s]\n", content.Type))
 		default:
 			// Fallback: try to extract from map structure
-			if jsonBytes, err := json.Marshal(contentBlock); err == nil {
+			if jsonBytes, err := schemas.MarshalSorted(contentBlock); err == nil {
 				var contentMap map[string]interface{}
 				if json.Unmarshal(jsonBytes, &contentMap) == nil {
 					if text, ok := contentMap["text"].(string); ok {

--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -521,7 +521,7 @@ func extractTextFromMCPResponse(toolResponse *mcp.CallToolResult, toolName strin
 			result.WriteString(fmt.Sprintf("[Embedded Resource Response: %s]\n", content.Type))
 		default:
 			// Fallback: try to extract from map structure
-			if jsonBytes, err := json.Marshal(contentBlock); err == nil {
+			if jsonBytes, err := schemas.MarshalSorted(contentBlock); err == nil {
 				var contentMap map[string]interface{}
 				if json.Unmarshal(jsonBytes, &contentMap) == nil {
 					if text, ok := contentMap["text"].(string); ok {

--- a/core/network/multipart.go
+++ b/core/network/multipart.go
@@ -8,7 +8,6 @@ import (
 	"mime/multipart"
 	"strings"
 
-	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -131,7 +130,7 @@ func WriteMultipartField(writer *multipart.Writer, name string, val any) error {
 	case string:
 		return writer.WriteField(name, v)
 	case []string:
-		encoded, err := sonic.Marshal(v)
+		encoded, err := schemas.MarshalSorted(v)
 		if err != nil {
 			return err
 		}
@@ -158,7 +157,7 @@ func SerializePayloadToRequest(req *schemas.HTTPRequest, payload map[string]any,
 		req.Headers["Content-Type"] = newCT
 		return nil
 	}
-	body, err := sonic.Marshal(payload)
+	body, err := schemas.MarshalSorted(payload)
 	if err != nil {
 		return err
 	}

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -1396,7 +1396,7 @@ func (provider *AnthropicProvider) BatchCreate(ctx *schemas.BifrostContext, key 
 		}
 	}
 
-	jsonData, err := sonic.Marshal(anthropicReq)
+	jsonData, err := providerUtils.MarshalSorted(anthropicReq)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 	}

--- a/core/providers/anthropic/errors.go
+++ b/core/providers/anthropic/errors.go
@@ -3,7 +3,6 @@ package anthropic
 import (
 	"fmt"
 
-	"github.com/bytedance/sonic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
@@ -46,7 +45,7 @@ func ToAnthropicResponsesStreamError(bifrostErr *schemas.BifrostError) string {
 	anthropicErr := ToAnthropicChatCompletionError(bifrostErr)
 
 	// Marshal to JSON
-	jsonData, err := sonic.Marshal(anthropicErr)
+	jsonData, err := providerUtils.MarshalSorted(anthropicErr)
 	if err != nil {
 		return ""
 	}

--- a/core/providers/anthropic/payload_ordering_test.go
+++ b/core/providers/anthropic/payload_ordering_test.go
@@ -1,0 +1,52 @@
+package anthropic
+
+import (
+	"testing"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayloadOrdering_AnthropicMessageRequest(t *testing.T) {
+	req := &AnthropicMessageRequest{
+		Model:     "claude-sonnet-4-20250514",
+		MaxTokens: 1024,
+		Messages: []AnthropicMessage{
+			{
+				Role:    "user",
+				Content: AnthropicContent{ContentStr: schemas.Ptr("hello")},
+			},
+		},
+		Temperature: schemas.Ptr(0.7),
+		Stream:      schemas.Ptr(true),
+		Tools: []AnthropicTool{
+			{
+				Name:        "get_weather",
+				Description: schemas.Ptr("Get weather"),
+				InputSchema: &schemas.ToolFunctionParameters{
+					Type: "object",
+					Properties: schemas.NewOrderedMapFromPairs(
+						schemas.KV("location", map[string]interface{}{"type": "string"}),
+					),
+					Required: []string{"location"},
+				},
+			},
+		},
+	}
+
+	result, err := providerUtils.MarshalSorted(req)
+	require.NoError(t, err)
+
+	golden := `{"model":"claude-sonnet-4-20250514","max_tokens":1024,"messages":[{"role":"user","content":"hello"}],"temperature":0.7,"stream":true,"tools":[{"name":"get_weather","description":"Get weather","input_schema":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}]}`
+
+	assert.Equal(t, golden, string(result), "payload field ordering changed — if intentional, update the golden string")
+
+	// Determinism: 100 iterations must produce identical bytes
+	for i := 0; i < 100; i++ {
+		iter, err := providerUtils.MarshalSorted(req)
+		require.NoError(t, err)
+		assert.Equal(t, string(result), string(iter), "non-deterministic marshal output on iteration %d", i)
+	}
+}

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -2599,7 +2599,7 @@ func (provider *AzureProvider) BatchCreate(ctx *schemas.BifrostContext, key sche
 		openAIReq.CompletionWindow = "24h"
 	}
 
-	jsonData, err := sonic.Marshal(openAIReq)
+	jsonData, err := providerUtils.MarshalSorted(openAIReq)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 	}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -2878,7 +2878,7 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 		}
 	}
 
-	jsonData, err := sonic.Marshal(bedrockReq)
+	jsonData, err := providerUtils.MarshalSorted(bedrockReq)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 	}
@@ -3609,7 +3609,7 @@ func (provider *BedrockProvider) CountTokens(ctx *schemas.BifrostContext, key sc
 	countTokensReq := &BedrockCountTokensRequest{}
 	countTokensReq.Input.Converse = converseReq
 
-	jsonData, err := sonic.Marshal(countTokensReq)
+	jsonData, err := providerUtils.MarshalSorted(countTokensReq)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 	}

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -119,7 +119,15 @@ func assertBedrockRequestEqual(t *testing.T, expected, actual *bedrock.BedrockCo
 		actualTool, exists := actualToolMap[name]
 		assert.True(t, exists, "Tool %s not found in actual tools", name)
 		if exists {
-			assert.Equal(t, expectedTool, actualTool, "Tool %s differs", name)
+			// Compare tool specs field-by-field, using JSON-semantic comparison
+			// for InputSchema to handle key ordering differences from sorted marshaling
+			if expectedTool.ToolSpec != nil && actualTool.ToolSpec != nil {
+				assert.Equal(t, expectedTool.ToolSpec.Name, actualTool.ToolSpec.Name, "Tool %s name differs", name)
+				assert.Equal(t, expectedTool.ToolSpec.Description, actualTool.ToolSpec.Description, "Tool %s description differs", name)
+				jsonEqual(t, expectedTool.ToolSpec.InputSchema.JSON, actualTool.ToolSpec.InputSchema.JSON, "Tool %s input schema differs", name)
+			} else {
+				assert.Equal(t, expectedTool, actualTool, "Tool %s differs", name)
+			}
 		}
 	}
 }

--- a/core/providers/bedrock/payload_ordering_test.go
+++ b/core/providers/bedrock/payload_ordering_test.go
@@ -1,0 +1,55 @@
+package bedrock
+
+import (
+	"encoding/json"
+	"testing"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayloadOrdering_BedrockConverseRequest(t *testing.T) {
+	req := &BedrockConverseRequest{
+		Messages: []BedrockMessage{
+			{
+				Role: "user",
+				Content: []BedrockContentBlock{
+					{Text: schemas.Ptr("hello")},
+				},
+			},
+		},
+		InferenceConfig: &BedrockInferenceConfig{
+			Temperature: schemas.Ptr(0.7),
+			MaxTokens:   schemas.Ptr(1024),
+		},
+		ToolConfig: &BedrockToolConfig{
+			Tools: []BedrockTool{
+				{
+					ToolSpec: &BedrockToolSpec{
+						Name:        "get_weather",
+						Description: schemas.Ptr("Get weather"),
+						InputSchema: BedrockToolInputSchema{
+							JSON: json.RawMessage(`{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}`),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := providerUtils.MarshalSorted(req)
+	require.NoError(t, err)
+
+	golden := `{"messages":[{"role":"user","content":[{"text":"hello"}]}],"inferenceConfig":{"maxTokens":1024,"temperature":0.7},"toolConfig":{"tools":[{"toolSpec":{"name":"get_weather","description":"Get weather","inputSchema":{"json":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}}}]}}`
+
+	assert.Equal(t, golden, string(result), "payload field ordering changed — if intentional, update the golden string")
+
+	// Determinism: 100 iterations must produce identical bytes
+	for i := 0; i < 100; i++ {
+		iter, err := providerUtils.MarshalSorted(req)
+		require.NoError(t, err)
+		assert.Equal(t, string(result), string(iter), "non-deterministic marshal output on iteration %d", i)
+	}
+}

--- a/core/providers/bedrock/s3.go
+++ b/core/providers/bedrock/s3.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/bytedance/sonic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -120,7 +119,7 @@ func ConvertBedrockRequestsToJSONL(requests []schemas.BatchRequestItem, modelID 
 		}
 
 		// Marshal the request as a JSON line
-		line, err := sonic.Marshal(bedrockReq)
+		line, err := providerUtils.MarshalSorted(bedrockReq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal batch request item %s: %w", req.CustomID, err)
 		}

--- a/core/providers/cohere/utils.go
+++ b/core/providers/cohere/utils.go
@@ -282,7 +282,7 @@ func convertCohereResponseFormatToBifrost(cohereFormat *CohereResponseFormat) *i
 	data := []byte(`{}`)
 	if cohereFormat.JSONSchema != nil {
 		data, _ = sjson.SetBytes(data, "type", "json_schema")
-		schemaBytes, _ := schemas.Marshal(cohereFormat.JSONSchema)
+		schemaBytes, _ := schemas.MarshalSorted(cohereFormat.JSONSchema)
 		data, _ = sjson.SetRawBytes(data, "json_schema", schemaBytes)
 	} else {
 		data, _ = sjson.SetBytes(data, "type", string(cohereFormat.Type))

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -677,7 +677,7 @@ func writeTranscriptionMultipart(writer *multipart.Writer, reqBody *ElevenlabsTr
 	}
 
 	if len(reqBody.AdditionalFormats) > 0 {
-		payload, err := sonic.Marshal(reqBody.AdditionalFormats)
+		payload, err := providerUtils.MarshalSorted(reqBody.AdditionalFormats)
 		if err != nil {
 			return providerUtils.NewBifrostOperationError("failed to marshal additional_formats", err, providerName)
 		}
@@ -731,7 +731,7 @@ func writeTranscriptionMultipart(writer *multipart.Writer, reqBody *ElevenlabsTr
 				}
 			}
 		default:
-			payload, err := sonic.Marshal(v)
+			payload, err := providerUtils.MarshalSorted(v)
 			if err != nil {
 				return providerUtils.NewBifrostOperationError("failed to marshal webhook_metadata", err, providerName)
 			}

--- a/core/providers/elevenlabs/realtime.go
+++ b/core/providers/elevenlabs/realtime.go
@@ -207,10 +207,10 @@ func (provider *ElevenlabsProvider) ToProviderRealtimeEvent(bifrostEvent *schema
 			"type":             elUserAudioChunk,
 			"user_audio_chunk": bifrostEvent.Delta.Audio,
 		}
-		return json.Marshal(out)
+		return schemas.MarshalSorted(out)
 
 	case schemas.RealtimeEventType("pong"):
-		return json.Marshal(map[string]interface{}{
+		return schemas.MarshalSorted(map[string]interface{}{
 			"type": "pong",
 		})
 
@@ -218,6 +218,6 @@ func (provider *ElevenlabsProvider) ToProviderRealtimeEvent(bifrostEvent *schema
 		out := map[string]interface{}{
 			"type": string(bifrostEvent.Type),
 		}
-		return json.Marshal(out)
+		return schemas.MarshalSorted(out)
 	}
 }

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -2701,7 +2701,7 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 			// The body is in OpenAI format (with "messages"), so we need to convert
 			// messages to Gemini's "contents" format using the standard conversion.
 			if rawMessages, ok := body["messages"]; ok {
-				messagesBytes, err := sonic.Marshal(rawMessages)
+				messagesBytes, err := providerUtils.MarshalSorted(rawMessages)
 				if err != nil {
 					return nil, providerUtils.NewBifrostOperationError("failed to marshal messages", err, providerName)
 				}
@@ -2716,7 +2716,7 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 				geminiReq.SystemInstruction = systemInstruction
 			} else {
 				// If no "messages" key, try direct unmarshal (already in Gemini format)
-				requestBytes, err := sonic.Marshal(body)
+				requestBytes, err := providerUtils.MarshalSorted(body)
 				if err != nil {
 					return nil, providerUtils.NewBifrostOperationError("failed to marshal gemini request", err, providerName)
 				}
@@ -2744,7 +2744,7 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 		}
 	}
 
-	jsonData, err := sonic.Marshal(batchReq)
+	jsonData, err := providerUtils.MarshalSorted(batchReq)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 	}
@@ -3693,12 +3693,7 @@ func (provider *GeminiProvider) FileUpload(ctx *schemas.BifrostContext, key sche
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to create metadata field", err, providerName)
 	}
-	metadata := map[string]interface{}{
-		"file": map[string]string{
-			"displayName": request.Filename,
-		},
-	}
-	metadataJSON, err := sonic.Marshal(metadata)
+	metadataJSON, err := providerUtils.SetJSONField([]byte(`{}`), "file.displayName", request.Filename)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to marshal metadata", err, providerName)
 	}
@@ -4251,17 +4246,10 @@ func (provider *GeminiProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 			return nil, bifrostErr
 		}
 
-		var payload map[string]any
-		if err := sonic.Unmarshal(jsonData, &payload); err == nil {
-			delete(payload, "toolConfig")
-			delete(payload, "generationConfig")
-			delete(payload, "systemInstruction")
-			newData, err := sonic.Marshal(payload)
-			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, provider.GetProviderKey())
-			}
-			jsonData = newData
-		}
+		// Use sjson to delete fields directly from JSON bytes, preserving key ordering
+		jsonData, _ = providerUtils.DeleteJSONField(jsonData, "toolConfig")
+		jsonData, _ = providerUtils.DeleteJSONField(jsonData, "generationConfig")
+		jsonData, _ = providerUtils.DeleteJSONField(jsonData, "systemInstruction")
 	}
 
 	providerName := provider.GetProviderKey()

--- a/core/providers/gemini/payload_ordering_test.go
+++ b/core/providers/gemini/payload_ordering_test.go
@@ -1,0 +1,56 @@
+package gemini
+
+import (
+	"testing"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayloadOrdering_GeminiGenerationRequest(t *testing.T) {
+	req := &GeminiGenerationRequest{
+		Model: "gemini-2.0-flash",
+		Contents: []Content{
+			{
+				Parts: []*Part{{Text: "hello"}},
+				Role:  "user",
+			},
+		},
+		GenerationConfig: GenerationConfig{
+			Temperature: schemas.Ptr(float64(0.7)),
+		},
+		Tools: []Tool{
+			{
+				FunctionDeclarations: []*FunctionDeclaration{
+					{
+						Name:        "get_weather",
+						Description: "Get weather",
+						Parameters: &Schema{
+							Type: "OBJECT",
+							Properties: map[string]*Schema{
+								"location": {Type: "STRING"},
+							},
+							Required: []string{"location"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := providerUtils.MarshalSorted(req)
+	require.NoError(t, err)
+
+	golden := `{"model":"gemini-2.0-flash","contents":[{"parts":[{"text":"hello"}],"role":"user"}],"generationConfig":{"temperature":0.7},"tools":[{"functionDeclarations":[{"description":"Get weather","name":"get_weather","parameters":{"properties":{"location":{"type":"STRING"}},"required":["location"],"type":"OBJECT"}}]}]}`
+
+	assert.Equal(t, golden, string(result), "payload field ordering changed — if intentional, update the golden string")
+
+	// Determinism: 100 iterations must produce identical bytes
+	for i := 0; i < 100; i++ {
+		iter, err := providerUtils.MarshalSorted(req)
+		require.NoError(t, err)
+		assert.Equal(t, string(result), string(iter), "non-deterministic marshal output on iteration %d", i)
+	}
+}

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -1223,7 +1223,7 @@ func (p Part) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	return sonic.Marshal(aux)
+	return providerUtils.MarshalSorted(aux)
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling for Part.

--- a/core/providers/huggingface/chat.go
+++ b/core/providers/huggingface/chat.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bytedance/sonic"
 
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -76,18 +77,29 @@ func ToHuggingFaceChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) 
 			hfReq.TopP = params.TopP
 		}
 
-		// Handle response format
+		// Handle response format (direct type assertion to avoid marshal→unmarshal round-trip)
 		if params.ResponseFormat != nil {
-			// Convert the response format to HuggingFace format
-			responseFormatJSON, err := sonic.Marshal(params.ResponseFormat)
-			if err != nil {
-				return nil, fmt.Errorf("failed to convert ResponseFormat (marshal): %w", err)
+			var hfRF *HuggingFaceResponseFormat
+			if rfMap, ok := (*params.ResponseFormat).(map[string]interface{}); ok {
+				hfRF = &HuggingFaceResponseFormat{}
+				if t, ok := rfMap["type"].(string); ok {
+					hfRF.Type = t
+				}
+				if jsVal, ok := rfMap["json_schema"]; ok {
+					jsBytes, err := providerUtils.MarshalSorted(jsVal)
+					if err != nil {
+						return nil, fmt.Errorf("failed to marshal json_schema: %w", err)
+					}
+					var hfSchema HuggingFaceJSONSchema
+					if err := sonic.Unmarshal(jsBytes, &hfSchema); err != nil {
+						return nil, fmt.Errorf("failed to unmarshal json_schema: %w", err)
+					}
+					hfRF.JSONSchema = &hfSchema
+				}
+			} else if converted, err := schemas.ConvertViaJSON[HuggingFaceResponseFormat](*params.ResponseFormat); err == nil {
+				hfRF = &converted
 			}
-			var hfResponseFormat HuggingFaceResponseFormat
-			if err := sonic.Unmarshal(responseFormatJSON, &hfResponseFormat); err != nil {
-				return nil, fmt.Errorf("failed to convert ResponseFormat (unmarshal): %w", err)
-			}
-			hfReq.ResponseFormat = &hfResponseFormat
+			hfReq.ResponseFormat = hfRF
 		}
 
 		// Handle stream options

--- a/core/providers/huggingface/chat_test.go
+++ b/core/providers/huggingface/chat_test.go
@@ -1,0 +1,132 @@
+package huggingface
+
+import (
+	"encoding/json"
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToHuggingFaceChatCompletionRequest_ResponseFormat(t *testing.T) {
+	makeReq := func(rf *interface{}) *schemas.BifrostChatRequest {
+		return &schemas.BifrostChatRequest{
+			Model: "test-model",
+			Input: []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hello")}}},
+			Params: &schemas.ChatParameters{
+				ResponseFormat: rf,
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		responseFormat *interface{}
+		wantErr        bool
+		validate       func(t *testing.T, result *HuggingFaceChatRequest)
+	}{
+		{
+			name:           "nil_response_format",
+			responseFormat: nil,
+			validate: func(t *testing.T, result *HuggingFaceChatRequest) {
+				assert.Nil(t, result.ResponseFormat)
+			},
+		},
+		{
+			name: "map_type_only",
+			responseFormat: func() *interface{} {
+				var rf interface{} = map[string]interface{}{"type": "json_object"}
+				return &rf
+			}(),
+			validate: func(t *testing.T, result *HuggingFaceChatRequest) {
+				require.NotNil(t, result.ResponseFormat)
+				assert.Equal(t, "json_object", result.ResponseFormat.Type)
+				assert.Nil(t, result.ResponseFormat.JSONSchema)
+			},
+		},
+		{
+			name: "map_with_json_schema",
+			responseFormat: func() *interface{} {
+				var rf interface{} = map[string]interface{}{
+					"type": "json_schema",
+					"json_schema": map[string]interface{}{
+						"name":        "my_schema",
+						"description": "A test schema",
+						"strict":      true,
+						"schema": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"answer": map[string]interface{}{"type": "string"},
+							},
+						},
+					},
+				}
+				return &rf
+			}(),
+			validate: func(t *testing.T, result *HuggingFaceChatRequest) {
+				require.NotNil(t, result.ResponseFormat)
+				assert.Equal(t, "json_schema", result.ResponseFormat.Type)
+				require.NotNil(t, result.ResponseFormat.JSONSchema)
+				assert.Equal(t, "my_schema", result.ResponseFormat.JSONSchema.Name)
+				assert.Equal(t, "A test schema", result.ResponseFormat.JSONSchema.Description)
+				require.NotNil(t, result.ResponseFormat.JSONSchema.Strict)
+				assert.True(t, *result.ResponseFormat.JSONSchema.Strict)
+				require.NotNil(t, result.ResponseFormat.JSONSchema.Schema)
+				// Verify schema content round-tripped correctly
+				var schemaMap map[string]interface{}
+				err := json.Unmarshal(result.ResponseFormat.JSONSchema.Schema, &schemaMap)
+				require.NoError(t, err)
+				assert.Equal(t, "object", schemaMap["type"])
+				props, ok := schemaMap["properties"].(map[string]interface{})
+				require.True(t, ok)
+				assert.Contains(t, props, "answer")
+			},
+		},
+		{
+			name: "struct_fallback_via_convert",
+			responseFormat: func() *interface{} {
+				var rf interface{} = HuggingFaceResponseFormat{
+					Type: "json_schema",
+					JSONSchema: &HuggingFaceJSONSchema{
+						Name:   "fallback_schema",
+						Strict: schemas.Ptr(true),
+					},
+				}
+				return &rf
+			}(),
+			validate: func(t *testing.T, result *HuggingFaceChatRequest) {
+				require.NotNil(t, result.ResponseFormat, "ResponseFormat should not be nil — ConvertViaJSON fallback must handle struct values")
+				assert.Equal(t, "json_schema", result.ResponseFormat.Type)
+				require.NotNil(t, result.ResponseFormat.JSONSchema)
+				assert.Equal(t, "fallback_schema", result.ResponseFormat.JSONSchema.Name)
+				require.NotNil(t, result.ResponseFormat.JSONSchema.Strict)
+				assert.True(t, *result.ResponseFormat.JSONSchema.Strict)
+			},
+		},
+		{
+			name: "inconvertible_value_graceful_nil",
+			responseFormat: func() *interface{} {
+				var rf interface{} = 42
+				return &rf
+			}(),
+			validate: func(t *testing.T, result *HuggingFaceChatRequest) {
+				assert.Nil(t, result.ResponseFormat, "inconvertible value should gracefully result in nil ResponseFormat")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := makeReq(tt.responseFormat)
+			result, err := ToHuggingFaceChatCompletionRequest(req)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			tt.validate(t, result)
+		})
+	}
+}

--- a/core/providers/huggingface/payload_ordering_test.go
+++ b/core/providers/huggingface/payload_ordering_test.go
@@ -1,0 +1,51 @@
+package huggingface
+
+import (
+	"testing"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayloadOrdering_HuggingFaceChatRequest(t *testing.T) {
+	req := &HuggingFaceChatRequest{
+		Model: "meta-llama/Llama-3-70B-Instruct",
+		Messages: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hello")}},
+		},
+		Temperature: schemas.Ptr(0.7),
+		Stream:      schemas.Ptr(true),
+		Tools: []schemas.ChatTool{
+			{
+				Type: "function",
+				Function: &schemas.ChatToolFunction{
+					Name:        "get_weather",
+					Description: schemas.Ptr("Get weather"),
+					Parameters: &schemas.ToolFunctionParameters{
+						Type: "object",
+						Properties: schemas.NewOrderedMapFromPairs(
+							schemas.KV("location", map[string]interface{}{"type": "string"}),
+						),
+						Required: []string{"location"},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := providerUtils.MarshalSorted(req)
+	require.NoError(t, err)
+
+	golden := `{"messages":[{"role":"user","content":"hello"}],"model":"meta-llama/Llama-3-70B-Instruct","stream":true,"temperature":0.7,"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}}]}`
+
+	assert.Equal(t, golden, string(result), "payload field ordering changed — if intentional, update the golden string")
+
+	// Determinism: 100 iterations must produce identical bytes
+	for i := 0; i < 100; i++ {
+		iter, err := providerUtils.MarshalSorted(req)
+		require.NoError(t, err)
+		assert.Equal(t, string(result), string(iter), "non-deterministic marshal output on iteration %d", i)
+	}
+}

--- a/core/providers/huggingface/types.go
+++ b/core/providers/huggingface/types.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/bytedance/sonic"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -120,10 +121,10 @@ const (
 // containing the `function` key and `type` field.
 func (t HuggingFaceToolChoice) MarshalJSON() ([]byte, error) {
 	if t.EnumValue != nil {
-		return sonic.Marshal(*t.EnumValue)
+		return providerUtils.MarshalSorted(*t.EnumValue)
 	}
 	if t.Function != nil {
-		return sonic.Marshal(struct {
+		return providerUtils.MarshalSorted(struct {
 			Type     string                          `json:"type"`
 			Function *schemas.ChatToolChoiceFunction `json:"function"`
 		}{
@@ -226,10 +227,10 @@ func (i *InputsCustomType) UnmarshalJSON(data []byte) error {
 
 func (i InputsCustomType) MarshalJSON() ([]byte, error) {
 	if len(i.Texts) > 0 {
-		return sonic.Marshal(i.Texts)
+		return providerUtils.MarshalSorted(i.Texts)
 	}
 	if i.Text != nil {
-		return sonic.Marshal(*i.Text)
+		return providerUtils.MarshalSorted(*i.Text)
 	}
 	return []byte("null"), nil
 }
@@ -326,10 +327,10 @@ type HuggingFaceTranscriptionEarlyStopping struct {
 // MarshalJSON implements custom JSON marshaling for HuggingFaceTranscriptionEarlyStopping
 func (e HuggingFaceTranscriptionEarlyStopping) MarshalJSON() ([]byte, error) {
 	if e.BoolValue != nil {
-		return sonic.Marshal(*e.BoolValue)
+		return providerUtils.MarshalSorted(*e.BoolValue)
 	}
 	if e.StringValue != nil {
-		return sonic.Marshal(*e.StringValue)
+		return providerUtils.MarshalSorted(*e.StringValue)
 	}
 	return []byte("null"), nil
 }

--- a/core/providers/openai/files.go
+++ b/core/providers/openai/files.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"time"
 
-	"github.com/bytedance/sonic"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -117,7 +117,7 @@ func (r *OpenAIFileResponse) ToBifrostFileRetrieveResponse(providerName schemas.
 func ConvertRequestsToJSONL(requests []schemas.BatchRequestItem) ([]byte, error) {
 	var buf bytes.Buffer
 	for _, req := range requests {
-		line, err := sonic.Marshal(req)
+		line, err := providerUtils.MarshalSorted(req)
 		if err != nil {
 			return nil, err
 		}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -5487,7 +5487,7 @@ func (provider *OpenAIProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 		openAIReq.CompletionWindow = "24h"
 	}
 
-	jsonData, err := sonic.Marshal(openAIReq)
+	jsonData, err := providerUtils.MarshalSorted(openAIReq)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 	}
@@ -5973,7 +5973,7 @@ func (provider *OpenAIProvider) ContainerCreate(ctx *schemas.BifrostContext, key
 		}
 	}
 
-	jsonBody, err := sonic.Marshal(reqBody)
+	jsonBody, err := providerUtils.MarshalSorted(reqBody)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 	}

--- a/core/providers/openai/payload_ordering_test.go
+++ b/core/providers/openai/payload_ordering_test.go
@@ -1,0 +1,59 @@
+package openai
+
+import (
+	"testing"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayloadOrdering_OpenAIChatRequest(t *testing.T) {
+	req := &OpenAIChatRequest{
+		Model: "gpt-4o",
+		Messages: []OpenAIMessage{
+			{
+				Role:    schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hello")},
+			},
+		},
+		ChatParameters: schemas.ChatParameters{
+			Temperature: schemas.Ptr(0.7),
+			Tools: []schemas.ChatTool{
+				{
+					Type: "function",
+					Function: &schemas.ChatToolFunction{
+						Name:        "get_weather",
+						Description: schemas.Ptr("Get weather"),
+						Parameters: &schemas.ToolFunctionParameters{
+							Type: "object",
+							Properties: schemas.NewOrderedMapFromPairs(
+								schemas.KV("location", map[string]interface{}{"type": "string"}),
+							),
+							Required: []string{"location"},
+						},
+					},
+				},
+			},
+			Reasoning: &schemas.ChatReasoning{
+				Effort: schemas.Ptr("high"),
+			},
+		},
+		Stream: schemas.Ptr(true),
+	}
+
+	result, err := providerUtils.MarshalSorted(req)
+	require.NoError(t, err)
+
+	golden := `{"model":"gpt-4o","temperature":0.7,"stream":true,"messages":[{"role":"user","content":"hello"}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather","parameters":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}}],"reasoning_effort":"high"}`
+
+	assert.Equal(t, golden, string(result), "payload field ordering changed — if intentional, update the golden string")
+
+	// Determinism: 100 iterations must produce identical bytes
+	for i := 0; i < 100; i++ {
+		iter, err := providerUtils.MarshalSorted(req)
+		require.NoError(t, err)
+		assert.Equal(t, string(result), string(iter), "non-deterministic marshal output on iteration %d", i)
+	}
+}

--- a/core/providers/openai/realtime.go
+++ b/core/providers/openai/realtime.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -272,7 +273,7 @@ func (provider *OpenAIProvider) ToProviderRealtimeEvent(bifrostEvent *schemas.Bi
 		}
 	}
 
-	return json.Marshal(out)
+	return providerUtils.MarshalSorted(out)
 }
 
 func isRealtimeDeltaEvent(eventType string) bool {

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 )
 
 const MinMaxCompletionTokens = 16
@@ -234,7 +235,7 @@ func (req *OpenAIChatRequest) MarshalJSON() ([]byte, error) {
 		aux.ReasoningEffort = req.Reasoning.Effort
 	}
 
-	return sonic.Marshal(aux)
+	return providerUtils.MarshalSorted(aux)
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for OpenAIChatRequest.
@@ -301,7 +302,7 @@ func (r *OpenAIResponsesRequestInput) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements custom JSON marshalling for OpenAIResponsesRequestInput
 func (r *OpenAIResponsesRequestInput) MarshalJSON() ([]byte, error) {
 	if r.OpenAIResponsesRequestInputStr != nil {
-		return sonic.Marshal(*r.OpenAIResponsesRequestInputStr)
+		return providerUtils.MarshalSorted(*r.OpenAIResponsesRequestInputStr)
 	}
 	if r.OpenAIResponsesRequestInputArray != nil {
 		// First pass: check if we need to modify anything
@@ -315,7 +316,7 @@ func (r *OpenAIResponsesRequestInput) MarshalJSON() ([]byte, error) {
 
 		// If no CacheControl found anywhere, marshal as-is
 		if !needsCopy {
-			return sonic.Marshal(r.OpenAIResponsesRequestInputArray)
+			return providerUtils.MarshalSorted(r.OpenAIResponsesRequestInputArray)
 		}
 
 		// Only copy messages that have CacheControl
@@ -458,9 +459,9 @@ func (r *OpenAIResponsesRequestInput) MarshalJSON() ([]byte, error) {
 				}
 			}
 		}
-		return sonic.Marshal(messagesCopy)
+		return providerUtils.MarshalSorted(messagesCopy)
 	}
-	return sonic.Marshal(nil)
+	return providerUtils.MarshalSorted(nil)
 }
 
 // Helper function to check if a chat message has any CacheControl fields or FileType in file blocks
@@ -653,7 +654,7 @@ func (resp *OpenAIResponsesRequest) MarshalJSON() ([]byte, error) {
 		}
 	}
 
-	return sonic.Marshal(aux)
+	return providerUtils.MarshalSorted(aux)
 }
 
 // IsStreamingRequested implements the StreamingRequest interface

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -678,7 +678,7 @@ func (provider *ReplicateProvider) TextCompletionStream(ctx *schemas.BifrostCont
 					// Set raw response if enabled (per-chunk event as JSON string)
 					if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 						rawEvent := ReplicateSSEEvent{Event: eventType, Data: eventData}
-						if eventJSON, err := sonic.Marshal(rawEvent); err == nil {
+						if eventJSON, err := providerUtils.MarshalSorted(rawEvent); err == nil {
 							response.ExtraFields.RawResponse = string(eventJSON)
 						}
 					}
@@ -1060,7 +1060,7 @@ func (provider *ReplicateProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 					// Set raw response if enabled (per-chunk event as JSON string)
 					if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
 						rawEvent := ReplicateSSEEvent{Event: eventType, Data: eventData}
-						if eventJSON, err := sonic.Marshal(rawEvent); err == nil {
+						if eventJSON, err := providerUtils.MarshalSorted(rawEvent); err == nil {
 							response.ExtraFields.RawResponse = string(eventJSON)
 						}
 					}
@@ -1281,15 +1281,11 @@ func (provider *ReplicateProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 		return nil, bifrostErr
 	}
 
-	// Enable streaming
-	var replicateReq ReplicatePredictionRequest
-	if err := sonic.Unmarshal(jsonData, &replicateReq); err == nil {
-		replicateReq.Stream = schemas.Ptr(true)
-		var streamErr error
-		jsonData, streamErr = sonic.Marshal(replicateReq)
-		if streamErr != nil {
-			return nil, providerUtils.NewBifrostOperationError("failed to marshal request", streamErr, provider.GetProviderKey())
-		}
+	// Enable streaming (using sjson to set field directly, preserving key order)
+	if updatedData, err := providerUtils.SetJSONField(jsonData, "stream", true); err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to set stream field", err, provider.GetProviderKey())
+	} else {
+		jsonData = updatedData
 	}
 
 	// Build prediction URL
@@ -3040,7 +3036,7 @@ func (provider *ReplicateProvider) FileUpload(ctx *schemas.BifrostContext, key s
 	if request.ExtraParams != nil {
 		if metadata, ok := request.ExtraParams["metadata"].(map[string]interface{}); ok {
 			if len(metadata) > 0 {
-				metadataJSON, err := sonic.Marshal(metadata)
+				metadataJSON, err := providerUtils.MarshalSorted(metadata)
 				if err != nil {
 					return nil, providerUtils.NewBifrostOperationError("failed to marshal metadata", err, providerName)
 				}

--- a/core/providers/runway/types.go
+++ b/core/providers/runway/types.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/bytedance/sonic"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 )
 
 type Reference struct {
@@ -36,13 +37,13 @@ func (pi PromptImage) MarshalJSON() ([]byte, error) {
 	}
 
 	if pi.PromptImageStr != nil {
-		return sonic.Marshal(*pi.PromptImageStr)
+		return providerUtils.MarshalSorted(*pi.PromptImageStr)
 	}
 	if pi.PromptImageObject != nil {
-		return sonic.Marshal(pi.PromptImageObject)
+		return providerUtils.MarshalSorted(pi.PromptImageObject)
 	}
 	// If both are nil, return null
-	return sonic.Marshal(nil)
+	return []byte("null"), nil
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for PromptImage.

--- a/core/providers/runway/videos.go
+++ b/core/providers/runway/videos.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bytedance/sonic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
@@ -84,12 +83,9 @@ func ToRunwayVideoGenerationRequest(bifrostReq *schemas.BifrostVideoGenerationRe
 				if refs, ok := refsVal.([]Reference); ok && refs != nil {
 					request.References = refs
 					delete(request.ExtraParams, "references")
-				} else if data, err := sonic.Marshal(refsVal); err == nil {
-					var refs []Reference
-					if sonic.Unmarshal(data, &refs) == nil {
-						request.References = refs
-						delete(request.ExtraParams, "references")
-					}
+				} else if refs, err := schemas.ConvertViaJSON[[]Reference](refsVal); err == nil {
+					request.References = refs
+					delete(request.ExtraParams, "references")
 				}
 			}
 
@@ -98,12 +94,9 @@ func ToRunwayVideoGenerationRequest(bifrostReq *schemas.BifrostVideoGenerationRe
 				if refImages, ok := refImagesVal.([]ReferenceImage); ok && refImages != nil {
 					delete(request.ExtraParams, "reference_images")
 					request.ReferenceImages = refImages
-				} else if data, err := sonic.Marshal(refImagesVal); err == nil {
-					var refImages []ReferenceImage
-					if sonic.Unmarshal(data, &refImages) == nil {
-						delete(request.ExtraParams, "reference_images")
-						request.ReferenceImages = refImages
-					}
+				} else if refImages, err := schemas.ConvertViaJSON[[]ReferenceImage](refImagesVal); err == nil {
+					delete(request.ExtraParams, "reference_images")
+					request.ReferenceImages = refImages
 				}
 			}
 
@@ -113,12 +106,9 @@ func ToRunwayVideoGenerationRequest(bifrostReq *schemas.BifrostVideoGenerationRe
 					if cm, ok := cmVal.(*ContentModeration); ok && cm != nil {
 						delete(request.ExtraParams, "content_moderation")
 						request.ContentModeration = cm
-					} else if data, err := sonic.Marshal(cmVal); err == nil {
-						var cm ContentModeration
-						if sonic.Unmarshal(data, &cm) == nil {
-							delete(request.ExtraParams, "content_moderation")
-							request.ContentModeration = &cm
-						}
+					} else if cm, err := schemas.ConvertViaJSON[ContentModeration](cmVal); err == nil {
+						delete(request.ExtraParams, "content_moderation")
+						request.ContentModeration = &cm
 					}
 				}
 			}

--- a/core/providers/runway/videos_test.go
+++ b/core/providers/runway/videos_test.go
@@ -1,0 +1,116 @@
+package runway
+
+import (
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeVideoReq(model string, extraParams map[string]interface{}) *schemas.BifrostVideoGenerationRequest {
+	return &schemas.BifrostVideoGenerationRequest{
+		Model: model,
+		Input: &schemas.VideoGenerationInput{
+			Prompt: "test prompt",
+		},
+		Params: &schemas.VideoGenerationParameters{
+			ExtraParams: extraParams,
+		},
+	}
+}
+
+func TestToRunwayVideoGenerationRequest_References(t *testing.T) {
+	t.Run("direct_typed_references", func(t *testing.T) {
+		refs := []Reference{{Type: "image", URI: "https://example.com/img.jpg"}}
+		req := makeVideoReq("gen3", map[string]interface{}{
+			"references": refs,
+		})
+
+		result, err := ToRunwayVideoGenerationRequest(req)
+		require.NoError(t, err)
+		require.Len(t, result.References, 1)
+		assert.Equal(t, "image", result.References[0].Type)
+		assert.Equal(t, "https://example.com/img.jpg", result.References[0].URI)
+		assert.NotContains(t, result.ExtraParams, "references")
+	})
+
+	t.Run("map_fallback_references", func(t *testing.T) {
+		// Simulates what happens when references arrive via JSON deserialization
+		req := makeVideoReq("gen3", map[string]interface{}{
+			"references": []interface{}{
+				map[string]interface{}{"type": "image", "uri": "https://example.com/img.jpg"},
+			},
+		})
+
+		result, err := ToRunwayVideoGenerationRequest(req)
+		require.NoError(t, err)
+		require.Len(t, result.References, 1, "ConvertViaJSON fallback should convert map-based references")
+		assert.Equal(t, "image", result.References[0].Type)
+		assert.Equal(t, "https://example.com/img.jpg", result.References[0].URI)
+		assert.NotContains(t, result.ExtraParams, "references")
+	})
+}
+
+func TestToRunwayVideoGenerationRequest_ReferenceImages(t *testing.T) {
+	t.Run("direct_typed_reference_images", func(t *testing.T) {
+		refImages := []ReferenceImage{{URI: "https://example.com/ref.jpg", Tag: "style"}}
+		req := makeVideoReq("gen3", map[string]interface{}{
+			"reference_images": refImages,
+		})
+
+		result, err := ToRunwayVideoGenerationRequest(req)
+		require.NoError(t, err)
+		require.Len(t, result.ReferenceImages, 1)
+		assert.Equal(t, "https://example.com/ref.jpg", result.ReferenceImages[0].URI)
+		assert.Equal(t, "style", result.ReferenceImages[0].Tag)
+		assert.NotContains(t, result.ExtraParams, "reference_images")
+	})
+
+	t.Run("map_fallback_reference_images", func(t *testing.T) {
+		req := makeVideoReq("gen3", map[string]interface{}{
+			"reference_images": []interface{}{
+				map[string]interface{}{"uri": "https://example.com/ref.jpg", "tag": "style"},
+			},
+		})
+
+		result, err := ToRunwayVideoGenerationRequest(req)
+		require.NoError(t, err)
+		require.Len(t, result.ReferenceImages, 1, "ConvertViaJSON fallback should convert map-based reference images")
+		assert.Equal(t, "https://example.com/ref.jpg", result.ReferenceImages[0].URI)
+		assert.Equal(t, "style", result.ReferenceImages[0].Tag)
+		assert.NotContains(t, result.ExtraParams, "reference_images")
+	})
+}
+
+func TestToRunwayVideoGenerationRequest_ContentModeration(t *testing.T) {
+	// ContentModeration handling only applies to veo models
+	t.Run("pointer_content_moderation", func(t *testing.T) {
+		cm := &ContentModeration{PublicFigureThreshold: schemas.Ptr("high")}
+		req := makeVideoReq("veo-model", map[string]interface{}{
+			"content_moderation": cm,
+		})
+
+		result, err := ToRunwayVideoGenerationRequest(req)
+		require.NoError(t, err)
+		require.NotNil(t, result.ContentModeration)
+		require.NotNil(t, result.ContentModeration.PublicFigureThreshold)
+		assert.Equal(t, "high", *result.ContentModeration.PublicFigureThreshold)
+		assert.NotContains(t, result.ExtraParams, "content_moderation")
+	})
+
+	t.Run("map_fallback_content_moderation", func(t *testing.T) {
+		req := makeVideoReq("veo-model", map[string]interface{}{
+			"content_moderation": map[string]interface{}{
+				"public_figure_threshold": "high",
+			},
+		})
+
+		result, err := ToRunwayVideoGenerationRequest(req)
+		require.NoError(t, err)
+		require.NotNil(t, result.ContentModeration, "ConvertViaJSON fallback should convert map-based content moderation")
+		require.NotNil(t, result.ContentModeration.PublicFigureThreshold)
+		assert.Equal(t, "high", *result.ContentModeration.PublicFigureThreshold)
+		assert.NotContains(t, result.ExtraParams, "content_moderation")
+	})
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -964,7 +964,7 @@ func MergeExtraParamsIntoJSON(jsonBody []byte, extraParams map[string]interface{
 	sort.Strings(extraKeys)
 	for _, k := range extraKeys {
 		v := extraParams[k]
-		newValBytes, err := sonic.Marshal(v)
+		newValBytes, err := MarshalSorted(v)
 		if err != nil {
 			continue
 		}
@@ -982,7 +982,7 @@ func MergeExtraParamsIntoJSON(jsonBody []byte, extraParams map[string]interface{
 				if existingDec.Decode(&existingMap) == nil {
 					if newDec.Decode(&newMap) == nil {
 						MergeExtraParams(existingMap, newMap)
-						if merged, err := sortedAPI.Marshal(existingMap); err == nil {
+						if merged, err := MarshalSorted(existingMap); err == nil {
 							pairs[idx].val = merged
 							continue
 						}
@@ -1039,7 +1039,7 @@ func CheckContextAndGetRequestBody(ctx context.Context, request RequestBodyGette
 			return nil, NewBifrostOperationError("request body is not provided", nil, providerType)
 		}
 
-		jsonBody, err := sonic.MarshalIndent(convertedBody, "", "  ")
+		jsonBody, err := MarshalSortedIndent(convertedBody, "", "  ")
 		if err != nil {
 			return nil, NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerType)
 		}

--- a/core/providers/utils/utils_json_test.go
+++ b/core/providers/utils/utils_json_test.go
@@ -1,0 +1,122 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetJSONField(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		path     string
+		value    interface{}
+		expected string
+	}{
+		{
+			name:     "set_string_on_empty_object",
+			data:     []byte(`{}`),
+			path:     "name",
+			value:    "test",
+			expected: `{"name":"test"}`,
+		},
+		{
+			name:     "set_nested_path",
+			data:     []byte(`{}`),
+			path:     "file.displayName",
+			value:    "photo.jpg",
+			expected: `{"file":{"displayName":"photo.jpg"}}`,
+		},
+		{
+			name:     "set_boolean",
+			data:     []byte(`{"model":"x"}`),
+			path:     "stream",
+			value:    true,
+			expected: `{"model":"x","stream":true}`,
+		},
+		{
+			name:     "set_string_array",
+			data:     []byte(`{}`),
+			path:     "betas",
+			value:    []string{"a", "b"},
+			expected: `{"betas":["a","b"]}`,
+		},
+		{
+			name:  "preserves_existing_fields",
+			data:  []byte(`{"a":1,"b":2}`),
+			path:  "c",
+			value: 3,
+			expected: `{"a":1,"b":2,"c":3}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := SetJSONField(tt.data, tt.path, tt.value)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(result), "exact byte-level ordering must match")
+		})
+	}
+}
+
+func TestDeleteJSONField(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		path     string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "delete_existing_field",
+			data:     []byte(`{"a":1,"b":2}`),
+			path:     "a",
+			expected: `{"b":2}`,
+		},
+		{
+			name:     "delete_nonexistent_field",
+			data:     []byte(`{"a":1}`),
+			path:     "b",
+			expected: `{"a":1}`,
+		},
+		{
+			name:     "sequential_deletes",
+			data:     []byte(`{"a":1,"b":2,"c":3}`),
+			path:     "", // handled in validate
+			expected: `{}`,
+		},
+		{
+			name:     "preserves_remaining_order",
+			data:     []byte(`{"x":1,"y":2,"z":3}`),
+			path:     "y",
+			expected: `{"x":1,"z":3}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "sequential_deletes" {
+				data := []byte(`{"a":1,"b":2,"c":3}`)
+				var err error
+				data, err = DeleteJSONField(data, "a")
+				require.NoError(t, err)
+				data, err = DeleteJSONField(data, "b")
+				require.NoError(t, err)
+				data, err = DeleteJSONField(data, "c")
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, string(data), "exact byte-level ordering must match")
+				return
+			}
+
+			result, err := DeleteJSONField(tt.data, tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(result), "exact byte-level ordering must match")
+		})
+	}
+}

--- a/core/providers/vertex/types.go
+++ b/core/providers/vertex/types.go
@@ -3,7 +3,7 @@ package vertex
 import (
 	"time"
 
-	"github.com/bytedance/sonic"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 )
 
 // Vertex AI Embedding API types
@@ -85,7 +85,7 @@ func (r *VertexRequestBody) GetExtraParams() map[string]interface{} {
 // MarshalJSON implements custom JSON marshalling for VertexRequestBody.
 // It marshals the RequestBody field directly without wrapping.
 func (r *VertexRequestBody) MarshalJSON() ([]byte, error) {
-	return sonic.Marshal(r.RequestBody)
+	return providerUtils.MarshalSorted(r.RequestBody)
 }
 
 // VertexRawRequestBody holds pre-serialized JSON bytes to preserve key ordering

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -2575,11 +2575,8 @@ func (provider *VertexProvider) VideoRetrieve(ctx *schemas.BifrostContext, key s
 		authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
 	}
 
-	// Create request body with operation name
-	requestBody := map[string]string{
-		"operationName": taskID,
-	}
-	jsonBody, err := sonic.Marshal(requestBody)
+	// Create request body with operation name (using sjson to avoid map marshaling)
+	jsonBody, err := providerUtils.SetJSONField([]byte(`{}`), "operationName", taskID)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to marshal request", err, providerName)
 	}
@@ -2912,17 +2909,10 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 		// Skip field-stripping when large payload mode is active — jsonBody is nil
 		// and the raw body will stream directly from the ingress reader.
 		if jsonBody != nil {
-			var payload map[string]any
-			if err := sonic.Unmarshal(jsonBody, &payload); err == nil {
-				delete(payload, "toolConfig")
-				delete(payload, "generationConfig")
-				delete(payload, "systemInstruction")
-				newBody, err := sonic.Marshal(payload)
-				if err != nil {
-					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
-				}
-				jsonBody = newBody
-			}
+			// Use sjson to delete fields directly from JSON bytes, preserving key ordering
+			jsonBody, _ = providerUtils.DeleteJSONField(jsonBody, "toolConfig")
+			jsonBody, _ = providerUtils.DeleteJSONField(jsonBody, "generationConfig")
+			jsonBody, _ = providerUtils.DeleteJSONField(jsonBody, "systemInstruction")
 		}
 	}
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -837,21 +837,21 @@ type BifrostStreamChunk struct {
 // This ensures that only the non-nil embedded struct is marshaled,
 func (bs BifrostStreamChunk) MarshalJSON() ([]byte, error) {
 	if bs.BifrostTextCompletionResponse != nil {
-		return Marshal(bs.BifrostTextCompletionResponse)
+		return MarshalSorted(bs.BifrostTextCompletionResponse)
 	} else if bs.BifrostChatResponse != nil {
-		return Marshal(bs.BifrostChatResponse)
+		return MarshalSorted(bs.BifrostChatResponse)
 	} else if bs.BifrostResponsesStreamResponse != nil {
-		return Marshal(bs.BifrostResponsesStreamResponse)
+		return MarshalSorted(bs.BifrostResponsesStreamResponse)
 	} else if bs.BifrostSpeechStreamResponse != nil {
-		return Marshal(bs.BifrostSpeechStreamResponse)
+		return MarshalSorted(bs.BifrostSpeechStreamResponse)
 	} else if bs.BifrostTranscriptionStreamResponse != nil {
-		return Marshal(bs.BifrostTranscriptionStreamResponse)
+		return MarshalSorted(bs.BifrostTranscriptionStreamResponse)
 	} else if bs.BifrostImageGenerationStreamResponse != nil {
-		return Marshal(bs.BifrostImageGenerationStreamResponse)
+		return MarshalSorted(bs.BifrostImageGenerationStreamResponse)
 	} else if bs.BifrostPassthroughResponse != nil {
-		return Marshal(bs.BifrostPassthroughResponse)
+		return MarshalSorted(bs.BifrostPassthroughResponse)
 	} else if bs.BifrostError != nil {
-		return Marshal(bs.BifrostError)
+		return MarshalSorted(bs.BifrostError)
 	}
 	// Return empty object if both are nil (shouldn't happen in practice)
 	return []byte("{}"), nil

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -374,7 +374,7 @@ func (t ToolFunctionParameters) MarshalJSON() ([]byte, error) {
 		t.Properties = &OrderedMap{values: make(map[string]interface{})}
 	}
 	type Alias ToolFunctionParameters
-	data, err := Marshal(Alias(t))
+	data, err := MarshalSorted(Alias(t))
 	if err != nil {
 		return nil, err
 	}
@@ -495,12 +495,12 @@ func (a AdditionalPropertiesStruct) MarshalJSON() ([]byte, error) {
 
 	// If bool is set, marshal as boolean
 	if a.AdditionalPropertiesBool != nil {
-		return Marshal(*a.AdditionalPropertiesBool)
+		return MarshalSorted(*a.AdditionalPropertiesBool)
 	}
 
 	// If map is set, marshal as object
 	if a.AdditionalPropertiesMap != nil {
-		return Marshal(a.AdditionalPropertiesMap)
+		return MarshalSorted(a.AdditionalPropertiesMap)
 	}
 
 	// If both are nil, return null
@@ -586,7 +586,7 @@ func (s ChatToolChoiceStruct) MarshalJSON() ([]byte, error) {
 	buf.WriteByte('{')
 
 	// Always emit "type" first
-	typeBytes, err := Marshal(string(s.Type))
+	typeBytes, err := MarshalSorted(string(s.Type))
 	if err != nil {
 		return nil, err
 	}
@@ -596,7 +596,7 @@ func (s ChatToolChoiceStruct) MarshalJSON() ([]byte, error) {
 	switch s.Type {
 	case ChatToolChoiceTypeFunction:
 		if s.Function != nil {
-			funcBytes, err := Marshal(s.Function)
+			funcBytes, err := MarshalSorted(s.Function)
 			if err != nil {
 				return nil, err
 			}
@@ -605,7 +605,7 @@ func (s ChatToolChoiceStruct) MarshalJSON() ([]byte, error) {
 		}
 	case ChatToolChoiceTypeCustom:
 		if s.Custom != nil {
-			customBytes, err := Marshal(s.Custom)
+			customBytes, err := MarshalSorted(s.Custom)
 			if err != nil {
 				return nil, err
 			}
@@ -614,7 +614,7 @@ func (s ChatToolChoiceStruct) MarshalJSON() ([]byte, error) {
 		}
 	case ChatToolChoiceTypeAllowedTools:
 		if s.AllowedTools != nil {
-			allowedBytes, err := Marshal(s.AllowedTools)
+			allowedBytes, err := MarshalSorted(s.AllowedTools)
 			if err != nil {
 				return nil, err
 			}
@@ -668,13 +668,13 @@ func (ctc ChatToolChoice) MarshalJSON() ([]byte, error) {
 	}
 
 	if ctc.ChatToolChoiceStr != nil {
-		return Marshal(ctc.ChatToolChoiceStr)
+		return MarshalSorted(ctc.ChatToolChoiceStr)
 	}
 	if ctc.ChatToolChoiceStruct != nil {
-		return Marshal(ctc.ChatToolChoiceStruct)
+		return MarshalSorted(ctc.ChatToolChoiceStruct)
 	}
 	// If both are nil, return null
-	return Marshal(nil)
+	return MarshalSorted(nil)
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for ChatMessageContent.
@@ -804,13 +804,13 @@ func (mc ChatMessageContent) MarshalJSON() ([]byte, error) {
 	}
 
 	if mc.ContentStr != nil {
-		return Marshal(*mc.ContentStr)
+		return MarshalSorted(*mc.ContentStr)
 	}
 	if mc.ContentBlocks != nil {
-		return Marshal(mc.ContentBlocks)
+		return MarshalSorted(mc.ContentBlocks)
 	}
 	// If both are nil, return null
-	return Marshal(nil)
+	return MarshalSorted(nil)
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for ChatMessageContent.
@@ -1202,7 +1202,7 @@ func (d ChatPromptTokensDetails) MarshalJSON() ([]byte, error) {
 		CachedWriteTokens int `json:"cached_write_tokens,omitempty"`
 		CachedTokens      int `json:"cached_tokens"`
 	}
-	return Marshal(raw{
+	return MarshalSorted(raw{
 		TextTokens:        d.TextTokens,
 		AudioTokens:       d.AudioTokens,
 		ImageTokens:       d.ImageTokens,

--- a/core/schemas/embedding.go
+++ b/core/schemas/embedding.go
@@ -56,16 +56,16 @@ func (e *EmbeddingInput) MarshalJSON() ([]byte, error) {
 	}
 
 	if e.Text != nil {
-		return Marshal(*e.Text)
+		return MarshalSorted(*e.Text)
 	}
 	if e.Texts != nil {
-		return Marshal(e.Texts)
+		return MarshalSorted(e.Texts)
 	}
 	if e.Embedding != nil {
-		return Marshal(e.Embedding)
+		return MarshalSorted(e.Embedding)
 	}
 	if e.Embeddings != nil {
-		return Marshal(e.Embeddings)
+		return MarshalSorted(e.Embeddings)
 	}
 
 	return nil, fmt.Errorf("invalid embedding input")
@@ -127,13 +127,13 @@ type EmbeddingStruct struct {
 
 func (be EmbeddingStruct) MarshalJSON() ([]byte, error) {
 	if be.EmbeddingStr != nil {
-		return Marshal(be.EmbeddingStr)
+		return MarshalSorted(be.EmbeddingStr)
 	}
 	if be.EmbeddingArray != nil {
-		return Marshal(be.EmbeddingArray)
+		return MarshalSorted(be.EmbeddingArray)
 	}
 	if be.Embedding2DArray != nil {
-		return Marshal(be.Embedding2DArray)
+		return MarshalSorted(be.Embedding2DArray)
 	}
 	return nil, fmt.Errorf("no embedding found")
 }

--- a/core/schemas/json_native.go
+++ b/core/schemas/json_native.go
@@ -38,6 +38,26 @@ func MarshalSorted(v interface{}) ([]byte, error) {
 	return sonic.ConfigStd.Marshal(v)
 }
 
+// MarshalSortedIndent encodes v to indented JSON with map keys sorted alphabetically.
+func MarshalSortedIndent(v interface{}, prefix, indent string) ([]byte, error) {
+	return sonic.ConfigStd.MarshalIndent(v, prefix, indent)
+}
+
+// ConvertViaJSON converts src to type T via JSON round-trip using sorted marshaling.
+// Use as fallback when direct type assertion fails (e.g., map[string]interface{} from JSON).
+func ConvertViaJSON[T any](src interface{}) (T, error) {
+	var zero T
+	data, err := MarshalSorted(src)
+	if err != nil {
+		return zero, err
+	}
+	var result T
+	if err := Unmarshal(data, &result); err != nil {
+		return zero, err
+	}
+	return result, nil
+}
+
 // MarshalDeeplySorted encodes v to JSON with all map keys sorted alphabetically,
 // including nested maps inside OrderedMap and other custom types with MarshalJSON.
 // This ensures fully deterministic output for hashing/caching purposes.
@@ -88,8 +108,8 @@ func normalizeForSortedMarshal(v interface{}) interface{} {
 		}
 		return result
 	default:
-		// For structs and other types, marshal to JSON then unmarshal to map
-		// This handles types with custom MarshalJSON that may contain unsorted maps
+		// Intentional round-trip: converts structs with custom MarshalJSON into plain
+		// maps so sonic.ConfigStd can sort all keys. Cannot use sjson since input is a Go struct.
 		rv := reflect.ValueOf(v)
 		if rv.Kind() == reflect.Ptr {
 			if rv.IsNil() {

--- a/core/schemas/json_native_test.go
+++ b/core/schemas/json_native_test.go
@@ -1,0 +1,92 @@
+package schemas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test helper types for ConvertViaJSON tests
+type convertTestTarget struct {
+	Type string `json:"type"`
+	Name string `json:"name,omitempty"`
+}
+
+type convertTestSource struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+}
+
+type convertTestDest struct {
+	Name  string `json:"name"`
+	Value int    `json:"value"`
+}
+
+func TestConvertViaJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		validate func(t *testing.T)
+	}{
+		{
+			name:  "map_to_struct",
+			input: map[string]interface{}{"type": "json_object", "name": "test_format"},
+			validate: func(t *testing.T) {
+				result, err := ConvertViaJSON[convertTestTarget](map[string]interface{}{"type": "json_object", "name": "test_format"})
+				require.NoError(t, err)
+				assert.Equal(t, "json_object", result.Type)
+				assert.Equal(t, "test_format", result.Name)
+			},
+		},
+		{
+			name: "struct_to_struct",
+			validate: func(t *testing.T) {
+				src := convertTestSource{Name: "hello", Value: 42}
+				result, err := ConvertViaJSON[convertTestDest](src)
+				require.NoError(t, err)
+				assert.Equal(t, "hello", result.Name)
+				assert.Equal(t, 42, result.Value)
+			},
+		},
+		{
+			name: "slice_conversion",
+			validate: func(t *testing.T) {
+				src := []interface{}{
+					map[string]interface{}{"type": "image", "name": "a"},
+					map[string]interface{}{"type": "video", "name": "b"},
+				}
+				result, err := ConvertViaJSON[[]convertTestTarget](src)
+				require.NoError(t, err)
+				require.Len(t, result, 2)
+				assert.Equal(t, "image", result[0].Type)
+				assert.Equal(t, "a", result[0].Name)
+				assert.Equal(t, "video", result[1].Type)
+				assert.Equal(t, "b", result[1].Name)
+			},
+		},
+		{
+			name: "invalid_input_returns_error",
+			validate: func(t *testing.T) {
+				result, err := ConvertViaJSON[convertTestTarget](42)
+				require.Error(t, err)
+				assert.Equal(t, convertTestTarget{}, result)
+			},
+		},
+		{
+			name: "nil_input",
+			validate: func(t *testing.T) {
+				result, err := ConvertViaJSON[convertTestTarget](nil)
+				// nil marshals to "null" which unmarshals to zero struct — no error
+				require.NoError(t, err)
+				assert.Equal(t, convertTestTarget{}, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.validate(t)
+		})
+	}
+}

--- a/core/schemas/jsonkeyorder.go
+++ b/core/schemas/jsonkeyorder.go
@@ -180,7 +180,7 @@ func ReorderJSONKeys(data []byte, order []string) ([]byte, error) {
 			buf.WriteByte(',')
 		}
 		first = false
-		keyBytes, _ := Marshal(key)
+		keyBytes, _ := MarshalSorted(key)
 		buf.Write(keyBytes)
 		buf.WriteByte(':')
 		buf.Write(val)
@@ -196,7 +196,7 @@ func ReorderJSONKeys(data []byte, order []string) ([]byte, error) {
 			buf.WriteByte(',')
 		}
 		first = false
-		keyBytes, _ := Marshal(kv.key)
+		keyBytes, _ := MarshalSorted(kv.key)
 		buf.Write(keyBytes)
 		buf.WriteByte(':')
 		buf.Write(kv.val)

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bytedance/sonic"
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -109,11 +108,11 @@ type MCPClientConfig struct {
 // NewMCPClientConfigFromMap creates a new MCP client config from a map[string]any.
 func NewMCPClientConfigFromMap(configMap map[string]any) *MCPClientConfig {
 	var config MCPClientConfig
-	data, err := sonic.Marshal(configMap)
+	data, err := MarshalSorted(configMap)
 	if err != nil {
 		return nil
 	}
-	if err := sonic.Unmarshal(data, &config); err != nil {
+	if err := Unmarshal(data, &config); err != nil {
 		return nil
 	}
 	return &config

--- a/core/schemas/models.go
+++ b/core/schemas/models.go
@@ -37,7 +37,7 @@ func (k KeyStatus) MarshalJSON() ([]byte, error) {
 		errCopy.ExtraFields.KeyStatuses = nil
 		alias.Error = &errCopy
 	}
-	return Marshal(alias)
+	return MarshalSorted(alias)
 }
 
 type BifrostListModelsRequest struct {
@@ -214,7 +214,7 @@ func encodePaginationCursor(offset int, lastID string) (string, error) {
 		LastID: lastID,
 	}
 
-	jsonData, err := Marshal(cursor)
+	jsonData, err := MarshalSorted(cursor)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal pagination cursor: %w", err)
 	}

--- a/core/schemas/orderedmap.go
+++ b/core/schemas/orderedmap.go
@@ -187,7 +187,7 @@ func (om OrderedMap) MarshalJSON() ([]byte, error) {
 		}
 
 		// key
-		keyBytes, err := Marshal(k)
+		keyBytes, err := MarshalSorted(k)
 		if err != nil {
 			return nil, err
 		}
@@ -195,7 +195,7 @@ func (om OrderedMap) MarshalJSON() ([]byte, error) {
 		buf.WriteByte(':')
 
 		// value — nested *OrderedMap values will use their own MarshalJSON
-		valBytes, err := Marshal(om.values[k])
+		valBytes, err := MarshalSorted(om.values[k])
 		if err != nil {
 			return nil, err
 		}
@@ -225,14 +225,14 @@ func (om *OrderedMap) MarshalSorted() ([]byte, error) {
 			buf.WriteByte(',')
 		}
 
-		keyBytes, err := Marshal(k)
+		keyBytes, err := MarshalSorted(k)
 		if err != nil {
 			return nil, err
 		}
 		buf.Write(keyBytes)
 		buf.WriteByte(':')
 
-		valBytes, err := Marshal(om.values[k])
+		valBytes, err := MarshalSorted(om.values[k])
 		if err != nil {
 			return nil, err
 		}

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -330,13 +330,13 @@ func (rc ResponsesResponseConversation) MarshalJSON() ([]byte, error) {
 	}
 
 	if rc.ResponsesResponseConversationStr != nil {
-		return Marshal(*rc.ResponsesResponseConversationStr)
+		return MarshalSorted(*rc.ResponsesResponseConversationStr)
 	}
 	if rc.ResponsesResponseConversationStruct != nil {
-		return Marshal(rc.ResponsesResponseConversationStruct)
+		return MarshalSorted(rc.ResponsesResponseConversationStruct)
 	}
 	// If both are nil, return null
-	return Marshal(nil)
+	return MarshalSorted(nil)
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for ResponsesMessageContent.
@@ -374,13 +374,13 @@ func (rc ResponsesResponseInstructions) MarshalJSON() ([]byte, error) {
 	}
 
 	if rc.ResponsesResponseInstructionsStr != nil {
-		return Marshal(*rc.ResponsesResponseInstructionsStr)
+		return MarshalSorted(*rc.ResponsesResponseInstructionsStr)
 	}
 	if rc.ResponsesResponseInstructionsArray != nil {
-		return Marshal(rc.ResponsesResponseInstructionsArray)
+		return MarshalSorted(rc.ResponsesResponseInstructionsArray)
 	}
 	// If both are nil, return null
-	return Marshal(nil)
+	return MarshalSorted(nil)
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for ResponsesMessageContent.
@@ -486,7 +486,7 @@ func (d ResponsesResponseInputTokens) MarshalJSON() ([]byte, error) {
 		CachedWriteTokens int `json:"cached_write_tokens"`
 		CachedTokens      int `json:"cached_tokens"`
 	}
-	return Marshal(raw{
+	return MarshalSorted(raw{
 		TextTokens:        d.TextTokens,
 		AudioTokens:       d.AudioTokens,
 		ImageTokens:       d.ImageTokens,
@@ -582,13 +582,13 @@ func (rc ResponsesMessageContent) MarshalJSON() ([]byte, error) {
 	}
 
 	if rc.ContentStr != nil {
-		return Marshal(*rc.ContentStr)
+		return MarshalSorted(*rc.ContentStr)
 	}
 	if rc.ContentBlocks != nil {
-		return Marshal(rc.ContentBlocks)
+		return MarshalSorted(rc.ContentBlocks)
 	}
 	// If both are nil, return null
-	return Marshal(nil)
+	return MarshalSorted(nil)
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for ResponsesMessageContent.
@@ -753,19 +753,19 @@ type ResponsesToolMessageActionStruct struct {
 
 func (action ResponsesToolMessageActionStruct) MarshalJSON() ([]byte, error) {
 	if action.ResponsesComputerToolCallAction != nil {
-		return Marshal(action.ResponsesComputerToolCallAction)
+		return MarshalSorted(action.ResponsesComputerToolCallAction)
 	}
 	if action.ResponsesWebSearchToolCallAction != nil {
-		return Marshal(action.ResponsesWebSearchToolCallAction)
+		return MarshalSorted(action.ResponsesWebSearchToolCallAction)
 	}
 	if action.ResponsesWebFetchToolCallAction != nil {
-		return Marshal(action.ResponsesWebFetchToolCallAction)
+		return MarshalSorted(action.ResponsesWebFetchToolCallAction)
 	}
 	if action.ResponsesLocalShellToolCallAction != nil {
-		return Marshal(action.ResponsesLocalShellToolCallAction)
+		return MarshalSorted(action.ResponsesLocalShellToolCallAction)
 	}
 	if action.ResponsesMCPApprovalRequestAction != nil {
-		return Marshal(action.ResponsesMCPApprovalRequestAction)
+		return MarshalSorted(action.ResponsesMCPApprovalRequestAction)
 	}
 	return nil, fmt.Errorf("responses tool message action struct is empty")
 }
@@ -840,13 +840,13 @@ type ResponsesToolMessageOutputStruct struct {
 
 func (output ResponsesToolMessageOutputStruct) MarshalJSON() ([]byte, error) {
 	if output.ResponsesToolCallOutputStr != nil {
-		return Marshal(*output.ResponsesToolCallOutputStr)
+		return MarshalSorted(*output.ResponsesToolCallOutputStr)
 	}
 	if output.ResponsesFunctionToolCallOutputBlocks != nil {
-		return Marshal(output.ResponsesFunctionToolCallOutputBlocks)
+		return MarshalSorted(output.ResponsesFunctionToolCallOutputBlocks)
 	}
 	if output.ResponsesComputerToolCallOutput != nil {
-		return Marshal(output.ResponsesComputerToolCallOutput)
+		return MarshalSorted(output.ResponsesComputerToolCallOutput)
 	}
 	return nil, fmt.Errorf("responses tool message output struct is neither a string nor an array of responses message content blocks nor a computer tool call output data nor an image generation call output")
 }
@@ -994,13 +994,13 @@ func (rf ResponsesFunctionToolCallOutput) MarshalJSON() ([]byte, error) {
 	}
 
 	if rf.ResponsesFunctionToolCallOutputStr != nil {
-		return Marshal(*rf.ResponsesFunctionToolCallOutputStr)
+		return MarshalSorted(*rf.ResponsesFunctionToolCallOutputStr)
 	}
 	if rf.ResponsesFunctionToolCallOutputBlocks != nil {
-		return Marshal(rf.ResponsesFunctionToolCallOutputBlocks)
+		return MarshalSorted(rf.ResponsesFunctionToolCallOutputBlocks)
 	}
 	// If both are nil, return null
-	return Marshal(nil)
+	return MarshalSorted(nil)
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for ResponsesFunctionToolCallOutput.
@@ -1103,10 +1103,10 @@ func (o ResponsesCodeInterpreterOutput) MarshalJSON() ([]byte, error) {
 
 	// Marshal whichever one is present
 	if o.ResponsesCodeInterpreterOutputLogs != nil {
-		return Marshal(o.ResponsesCodeInterpreterOutputLogs)
+		return MarshalSorted(o.ResponsesCodeInterpreterOutputLogs)
 	}
 	if o.ResponsesCodeInterpreterOutputImage != nil {
-		return Marshal(o.ResponsesCodeInterpreterOutputImage)
+		return MarshalSorted(o.ResponsesCodeInterpreterOutputImage)
 	}
 
 	// Return null if neither is set
@@ -1291,13 +1291,13 @@ func (tc ResponsesToolChoice) MarshalJSON() ([]byte, error) {
 	}
 
 	if tc.ResponsesToolChoiceStr != nil {
-		return Marshal(tc.ResponsesToolChoiceStr)
+		return MarshalSorted(tc.ResponsesToolChoiceStr)
 	}
 	if tc.ResponsesToolChoiceStruct != nil {
-		return Marshal(tc.ResponsesToolChoiceStruct)
+		return MarshalSorted(tc.ResponsesToolChoiceStruct)
 	}
 	// If both are nil, return null
-	return Marshal(nil)
+	return MarshalSorted(nil)
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for ChatMessageContent.
@@ -1439,7 +1439,7 @@ func (t ResponsesTool) MarshalJSON() ([]byte, error) {
 		}
 	}
 	if t.CacheControl != nil {
-		ccBytes, ccErr := Marshal(t.CacheControl)
+		ccBytes, ccErr := MarshalSorted(t.CacheControl)
 		if ccErr != nil {
 			return nil, ccErr
 		}
@@ -1453,47 +1453,47 @@ func (t ResponsesTool) MarshalJSON() ([]byte, error) {
 	switch t.Type {
 	case ResponsesToolTypeFunction:
 		if t.ResponsesToolFunction != nil {
-			typeBytes, err = Marshal(t.ResponsesToolFunction)
+			typeBytes, err = MarshalSorted(t.ResponsesToolFunction)
 		}
 	case ResponsesToolTypeFileSearch:
 		if t.ResponsesToolFileSearch != nil {
-			typeBytes, err = Marshal(t.ResponsesToolFileSearch)
+			typeBytes, err = MarshalSorted(t.ResponsesToolFileSearch)
 		}
 	case ResponsesToolTypeComputerUsePreview:
 		if t.ResponsesToolComputerUsePreview != nil {
-			typeBytes, err = Marshal(t.ResponsesToolComputerUsePreview)
+			typeBytes, err = MarshalSorted(t.ResponsesToolComputerUsePreview)
 		}
 	case ResponsesToolTypeWebSearch:
 		if t.ResponsesToolWebSearch != nil {
-			typeBytes, err = Marshal(t.ResponsesToolWebSearch)
+			typeBytes, err = MarshalSorted(t.ResponsesToolWebSearch)
 		}
 	case ResponsesToolTypeWebFetch:
 		if t.ResponsesToolWebFetch != nil {
-			typeBytes, err = Marshal(t.ResponsesToolWebFetch)
+			typeBytes, err = MarshalSorted(t.ResponsesToolWebFetch)
 		}
 	case ResponsesToolTypeMCP:
 		if t.ResponsesToolMCP != nil {
-			typeBytes, err = Marshal(t.ResponsesToolMCP)
+			typeBytes, err = MarshalSorted(t.ResponsesToolMCP)
 		}
 	case ResponsesToolTypeCodeInterpreter:
 		if t.ResponsesToolCodeInterpreter != nil {
-			typeBytes, err = Marshal(t.ResponsesToolCodeInterpreter)
+			typeBytes, err = MarshalSorted(t.ResponsesToolCodeInterpreter)
 		}
 	case ResponsesToolTypeImageGeneration:
 		if t.ResponsesToolImageGeneration != nil {
-			typeBytes, err = Marshal(t.ResponsesToolImageGeneration)
+			typeBytes, err = MarshalSorted(t.ResponsesToolImageGeneration)
 		}
 	case ResponsesToolTypeLocalShell:
 		if t.ResponsesToolLocalShell != nil {
-			typeBytes, err = Marshal(t.ResponsesToolLocalShell)
+			typeBytes, err = MarshalSorted(t.ResponsesToolLocalShell)
 		}
 	case ResponsesToolTypeCustom:
 		if t.ResponsesToolCustom != nil {
-			typeBytes, err = Marshal(t.ResponsesToolCustom)
+			typeBytes, err = MarshalSorted(t.ResponsesToolCustom)
 		}
 	case ResponsesToolTypeWebSearchPreview:
 		if t.ResponsesToolWebSearchPreview != nil {
-			typeBytes, err = Marshal(t.ResponsesToolWebSearchPreview)
+			typeBytes, err = MarshalSorted(t.ResponsesToolWebSearchPreview)
 		}
 	}
 	if err != nil {
@@ -1540,7 +1540,7 @@ func (t *ResponsesTool) UnmarshalJSON(data []byte) error {
 		t.Description = &description
 	}
 	if cacheControl, ok := raw["cache_control"]; ok {
-		bytes, err := Marshal(cacheControl)
+		bytes, err := MarshalSorted(cacheControl)
 		if err != nil {
 			return err
 		}
@@ -1690,7 +1690,7 @@ func (f *ResponsesToolFileSearchFilter) MarshalJSON() ([]byte, error) {
 		if f.ResponsesToolFileSearchCompoundFilter == nil {
 			return nil, fmt.Errorf("compound filter is nil but type is %s", f.Type)
 		}
-		filtersBytes, fErr := Marshal(f.ResponsesToolFileSearchCompoundFilter.Filters)
+		filtersBytes, fErr := MarshalSorted(f.ResponsesToolFileSearchCompoundFilter.Filters)
 		if fErr != nil {
 			return nil, fErr
 		}
@@ -1873,7 +1873,7 @@ func (i *Interval) MarshalJSON() ([]byte, error) {
 		aux.EndTime = (*time.Time)(&i.EndTime)
 	}
 
-	return Marshal(aux)
+	return MarshalSorted(aux)
 }
 
 // ResponsesToolWebSearchUserLocation - The approximate location of the user
@@ -1926,14 +1926,14 @@ func (as ResponsesToolMCPAllowedToolsApprovalSetting) MarshalJSON() ([]byte, err
 	}
 
 	if as.Setting != nil {
-		return Marshal(*as.Setting)
+		return MarshalSorted(*as.Setting)
 	}
 	if as.Always != nil || as.Never != nil {
 		// Build JSON bytes with deterministic key order using sjson
 		data := []byte(`{}`)
 		var err error
 		if as.Always != nil {
-			alwaysBytes, aErr := Marshal(as.Always)
+			alwaysBytes, aErr := MarshalSorted(as.Always)
 			if aErr != nil {
 				return nil, aErr
 			}
@@ -1942,7 +1942,7 @@ func (as ResponsesToolMCPAllowedToolsApprovalSetting) MarshalJSON() ([]byte, err
 			}
 		}
 		if as.Never != nil {
-			neverBytes, nErr := Marshal(as.Never)
+			neverBytes, nErr := MarshalSorted(as.Never)
 			if nErr != nil {
 				return nil, nErr
 			}
@@ -1953,7 +1953,7 @@ func (as ResponsesToolMCPAllowedToolsApprovalSetting) MarshalJSON() ([]byte, err
 		return data, nil
 	}
 	// If all are nil, return null
-	return Marshal(nil)
+	return MarshalSorted(nil)
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for ResponsesToolMCPAllowedToolsApprovalSetting

--- a/core/schemas/speech.go
+++ b/core/schemas/speech.go
@@ -90,13 +90,13 @@ func (vi *SpeechVoiceInput) MarshalJSON() ([]byte, error) {
 	}
 
 	if vi.Voice != nil {
-		return Marshal(*vi.Voice)
+		return MarshalSorted(*vi.Voice)
 	}
 	if len(vi.MultiVoiceConfig) > 0 {
-		return Marshal(vi.MultiVoiceConfig)
+		return MarshalSorted(vi.MultiVoiceConfig)
 	}
 	// If both are nil, return null
-	return Marshal(nil)
+	return MarshalSorted(nil)
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for SpeechVoiceInput.

--- a/core/schemas/textcompletions.go
+++ b/core/schemas/textcompletions.go
@@ -94,9 +94,9 @@ func (t *TextCompletionInput) MarshalJSON() ([]byte, error) {
 		return nil, fmt.Errorf("text completion input must set exactly one of: prompt_str or prompt_array")
 	}
 	if t.PromptStr != nil {
-		return Marshal(*t.PromptStr)
+		return MarshalSorted(*t.PromptStr)
 	}
-	return Marshal(t.PromptArray)
+	return MarshalSorted(t.PromptArray)
 }
 
 func (t *TextCompletionInput) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
## Summary

Replace `sonic.Marshal` with `providerUtils.MarshalSorted` across all provider implementations to ensure consistent JSON key ordering for deterministic output and improved testing reliability.

## Issues

Closes #2333 #2347

## Changes

- Replaced `sonic.Marshal` calls with `providerUtils.MarshalSorted` in Anthropic, Azure, Bedrock, Gemini, OpenAI, and Vertex providers
- Updated batch creation, token counting, and file conversion functions to use sorted marshaling
- Modified custom `MarshalJSON` implementations in OpenAI and Gemini types to use sorted marshaling
- Replaced direct JSON field manipulation with `providerUtils.DeleteJSONField` and `providerUtils.SetJSONField` in Gemini and Vertex providers to preserve key ordering
- Updated Bedrock tests to handle key ordering differences in tool input schemas with JSON-semantic comparison
- Removed unused `sonic` import from Bedrock S3 utilities

## Type of change

- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

Verify that all provider functionality continues to work with deterministic JSON output:

```sh
# Core/Transports
go version
go test ./...

# Specifically test provider functionality
go test ./core/providers/...
```

Test batch operations, token counting, and file operations across all providers to ensure consistent behavior.

## Breaking changes

- [ ] No

The change maintains API compatibility while ensuring deterministic JSON serialization.

## Security considerations

No security implications - this is purely a serialization consistency improvement.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable