### PR TITLE
fix: deterministic MCP tool and property ordering for prompt caching

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+[fix]: deterministic MCP tool and property ordering for prompt caching [@ivanetchart](https://github.com/ivanetchart)

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -218,7 +219,23 @@ func (m *ToolsManager) GetAvailableTools(ctx context.Context) []schemas.ChatTool
 		}
 	}
 
+	// Sort tools by function name for deterministic ordering.
+	// MCP servers back tools with Go maps whose iteration order is randomized,
+	// so without sorting the tool list changes across requests, breaking
+	// prefix-based prompt caching (e.g. Anthropic, OpenAI).
+	sort.Slice(availableTools, func(i, j int) bool {
+		return chatToolName(availableTools[i]) < chatToolName(availableTools[j])
+	})
+
 	return availableTools
+}
+
+// chatToolName returns the function name of a ChatTool, or "" if unavailable.
+func chatToolName(t schemas.ChatTool) string {
+	if t.Function != nil {
+		return t.Function.Name
+	}
+	return ""
 }
 
 // buildIntegrationDuplicateCheckMap builds a map of tool names to check for duplicates

--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -468,23 +468,20 @@ func shouldSkipToolForRequest(ctx context.Context, clientName, toolName string) 
 	return false // Tool is allowed (default when no filtering specified)
 }
 
-// convertMCPToolToBifrostSchema converts an MCP tool definition to Bifrost format.
+// convertMCPToolToBifrostSchema converts an MCP tool definition to the Bifrost ChatTool format.
+//
+// Properties are stored in an OrderedMap with keys sorted lexicographically.
+// This guarantees stable JSON serialization, which is required for reliable
+// prompt caching in downstream providers.
 func convertMCPToolToBifrostSchema(mcpTool *mcp.Tool, logger schemas.Logger) schemas.ChatTool {
 	var properties *schemas.OrderedMap
 	if len(mcpTool.InputSchema.Properties) > 0 {
-		// Fix array schemas on the source map before copying to OrderedMap
 		FixArraySchemas(mcpTool.InputSchema.Properties, logger)
-
-		orderedProps := schemas.NewOrderedMapWithCapacity(len(mcpTool.InputSchema.Properties))
-		for k, v := range mcpTool.InputSchema.Properties {
-			orderedProps.Set(k, v)
-		}
-
-		properties = orderedProps
+		properties = schemas.OrderedMapFromMap(mcpTool.InputSchema.Properties)
 	} else {
-		// For tools with no parameters, initialize an empty properties map
+		// For tools with no parameters, initialize an empty properties map.
 		// This is required by some providers (e.g., OpenAI) which expect
-		// object schemas to always have a properties field, even if empty
+		// object schemas to always have a properties field, even if empty.
 		properties = schemas.NewOrderedMap()
 	}
 	return schemas.ChatTool{

--- a/core/schemas/orderedmap.go
+++ b/core/schemas/orderedmap.go
@@ -54,9 +54,10 @@ func NewOrderedMapFromPairs(pairs ...Pair) *OrderedMap {
 }
 
 // OrderedMapFromMap creates an OrderedMap from a plain map.
-// Key order is NOT guaranteed since Go maps have undefined iteration order.
-// Use this only when insertion order doesn't matter (e.g., for hashing).
-func OrderedMapFromMap(m map[string]interface{}) *OrderedMap {
+// Since Go maps have undefined iteration order, keys are sorted
+// lexicographically by default for deterministic output. Pass a custom
+// sortFn to override the sorting behavior (e.g. case-insensitive, reverse).
+func OrderedMapFromMap(m map[string]interface{}, sortFn ...func([]string)) *OrderedMap {
 	if m == nil {
 		return nil
 	}
@@ -67,6 +68,11 @@ func OrderedMapFromMap(m map[string]interface{}) *OrderedMap {
 	for k, v := range m {
 		om.keys = append(om.keys, k)
 		om.values[k] = v
+	}
+	if len(sortFn) > 0 && sortFn[0] != nil {
+		sortFn[0](om.keys)
+	} else {
+		sort.Strings(om.keys)
 	}
 	return om
 }

--- a/core/schemas/orderedmap_test.go
+++ b/core/schemas/orderedmap_test.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"encoding/json"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -283,6 +284,27 @@ func TestOrderedMapFromMap(t *testing.T) {
 func TestOrderedMapFromMap_Nil(t *testing.T) {
 	om := OrderedMapFromMap(nil)
 	assert.Nil(t, om)
+}
+
+func TestOrderedMapFromMap_DefaultSortsKeys(t *testing.T) {
+	m := map[string]interface{}{"z": 3, "a": 1, "m": 2}
+	om := OrderedMapFromMap(m)
+
+	data, err := json.Marshal(om)
+	require.NoError(t, err)
+	assert.Equal(t, `{"a":1,"m":2,"z":3}`, string(data))
+}
+
+func TestOrderedMapFromMap_CustomSortFn(t *testing.T) {
+	m := map[string]interface{}{"z": 3, "a": 1, "m": 2}
+	reverse := func(keys []string) {
+		sort.Sort(sort.Reverse(sort.StringSlice(keys)))
+	}
+	om := OrderedMapFromMap(m, reverse)
+
+	data, err := json.Marshal(om)
+	require.NoError(t, err)
+	assert.Equal(t, `{"z":3,"m":2,"a":1}`, string(data))
 }
 
 func TestOrderedMap_NestedOrderedMapMarshal(t *testing.T) {


### PR DESCRIPTION
## Summary

MCP tools backed by Go maps have non-deterministic iteration order, causing the tool list and property keys to shuffle across requests. This breaks prefix-based prompt caching (Anthropic, OpenAI) since tool definitions form the first level of the cache prefix.

## Changes

- Sort `GetAvailableTools()` result by function name (`core/mcp/toolmanager.go`)
- Sort MCP tool property keys via `OrderedMapFromMap` default sorting (`core/mcp/utils.go`)
- Make `OrderedMapFromMap` sort keys lexicographically by default, with an optional `sortFn` override for custom ordering (`core/schemas/orderedmap.go`)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
cd core
go test ./schemas/... ./mcp/... -count=1 -v
```

Key tests:
- `TestOrderedMapFromMap_DefaultSortsKeys` — verifies default lexicographic sorting
- `TestOrderedMapFromMap_CustomSortFn` — verifies custom sort override
- Existing `TestOrderedMap*` tests verify no regressions in insertion-order preservation

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

`OrderedMapFromMap` now sorts keys by default. Existing callers that relied on non-deterministic (random) ordering will now get sorted output, which is strictly more deterministic. The variadic `sortFn` parameter is backward-compatible — no call sites need changes.

## Related issues

Closes #2347

Related upstream context:
- #1742 — `MergeExtraParams` produces non-deterministic JSON key ordering
- #2082 — deterministic tool schema serialization for prompt caching
- #522 — sort tools alphabetically while generating hash (still open)

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable