### PR TITLE
fix: whitelist /metrics in auth middleware and skip request logging f…

### DIFF
--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -21,7 +21,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-var loggingSkipPaths = []string{"/health", "/_next", "/api/dev"}
+var loggingSkipPaths = []string{"/health", "/metrics", "/_next", "/api/dev"}
 
 // SecurityHeadersMiddleware sets security-related HTTP headers on every response.
 // This should wrap the outermost handler so all responses (API, UI, errors) include these headers.
@@ -554,6 +554,7 @@ func (m *AuthMiddleware) APIMiddleware() schemas.BifrostHTTPMiddleware {
 		"/api/session/login",
 		"/api/oauth/callback",
 		"/health",
+		"/metrics",
 	}
 	whitelistedPrefixes := []string{
 		"/api/oauth/callback",


### PR DESCRIPTION
## Summary

The `/metrics` Prometheus endpoint was unintentionally placed behind API auth, returning 401 for unauthenticated Prometheus scrapers. This PR whitelists `/metrics` in the auth middleware (same pattern as `/health`) and skips request logging for it to avoid log noise from frequent scrapes.

## Changes

- Added `/metrics` to `whitelistedRoutes` in `APIMiddleware()` so it bypasses auth, matching how `/health` is already handled
- Added `/metrics` to `loggingSkipPaths` to suppress request logs from frequent Prometheus scrapes (same as `/health`)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# 1. Start Bifrost with auth enabled
make dev

# 2. Confirm auth blocks other API routes
curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/api/config
# Expected: 401

# 3. Confirm /metrics is accessible without auth
curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/metrics
# Expected: 200

# 4. Confirm /health still works
curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health
# Expected: 200

Screenshots/Recordings:
NA

Breaking changes
 Yes
 No
Related issues
Closes #2346

Security considerations
/metrics exposes Prometheus telemetry data (request counts, latencies, error rates). This is standard practice — Prometheus endpoints are typically unauthenticated and access is controlled at the network level (firewall, internal VPC). This was the original behavior before the regression.

Checklist
 I read docs/contributing/README.md and followed the guidelines
 I added/updated tests where appropriate
 I updated documentation where needed
 I verified builds succeed (Go and UI)
 I verified the CI pipeline passes locally if applicable

