### PR TITLE
fix(semantic-cache): harden direct-only config handling and align UI types

### DIFF
--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -166,6 +166,7 @@ bifrostConfig := schemas.BifrostConfig{
 **Required Fields:**
 - **Provider**: The provider to use for caching.
 - **Embedding Model**: The embedding model to use for caching.
+- **Dimension**: The embedding dimension for the configured embedding model.
 
 **Note**: Changes will need a restart of the Bifrost server to take effect, because the plugin is loaded on startup only.
 
@@ -182,6 +183,7 @@ bifrostConfig := schemas.BifrostConfig{
       "config": {        
         "provider": "openai",
         "embedding_model": "text-embedding-3-small",
+        "dimension": 1536,
         
         "cleanup_on_shutdown": true,
         "ttl": "5m",
@@ -198,7 +200,9 @@ bifrostConfig := schemas.BifrostConfig{
 }
 ```
 
-> **Note**: All the available keys will be taken from the provider config on initialization, so make sure to add the keys to the provider you have specified in the config. Any updates to the keys will not be reflected until next restart.
+> **Note**: In `config.json` setups, provider keys are taken from the provider config on initialization, so you do not need to duplicate `keys` inside the plugin config. Any updates to the provider keys will not be reflected until next restart.
+
+> **UI Note**: The current Web UI flow configures provider-backed semantic caching. If you want direct-only mode (`dimension: 1` with no `provider`), configure it through `config.json`.
 
 **TTL Format Options:**
 - Duration strings: `"30s"`, `"5m"`, `"1h"`, `"24h"`
@@ -224,7 +228,9 @@ Exact-match direct entries are stored and retrieved using a deterministic cache 
 
 ### Setup
 
-To enable direct-only mode globally, omit the `provider` and `keys` fields from the plugin config. The plugin will automatically fall back to direct search only.
+To enable direct-only mode globally, set `dimension: 1` and omit the `provider` and `keys` fields from the plugin config. The plugin will automatically fall back to direct search only.
+
+> **Important**: If you specify `dimension: 1` and also provide a `provider`, Bifrost treats the config as provider-backed semantic mode, not direct-only mode. To use direct-only mode, omit the `provider` field entirely.
 
 <Warning>
 A vector store is still required as the storage backend, even in direct hash mode. See [Recommended Vector Store](#recommended-vector-store) below for the best choice.
@@ -398,7 +404,7 @@ Override default TTL and similarity threshold per request:
 
 <Tab title="Go SDK">
 
-You can set TTL and threshold in the request context, in the keys you configured in the plugin config:
+You can set TTL and threshold in the request context using the semantic cache context keys:
 
 ```go
 // Go SDK: Custom TTL and threshold

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -321,8 +321,10 @@ func Init(ctx context.Context, config *Config, logger schemas.Logger, store vect
 		waitGroup: sync.WaitGroup{},
 	}
 
-	if config.Provider == "" || len(config.Keys) == 0 {
-		logger.Warn(PluginLoggerPrefix + " Provider and keys are required for semantic cache, falling back to direct search only")
+	if config.Provider == "" && config.Dimension == 1 {
+		logger.Info(PluginLoggerPrefix + " Starting in direct-only mode (dimension=1, no embedding provider)")
+	} else if config.Provider == "" || len(config.Keys) == 0 {
+		logger.Warn(PluginLoggerPrefix + " Incomplete semantic mode config: missing provider or keys, falling back to direct search only")
 	} else {
 		// Validate that the provider supports embeddings
 		if bifrost.IsStandardProvider(config.Provider) && !ProvidersWithEmbeddingSupport[config.Provider] {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3447,6 +3447,7 @@ func (c *Config) AddProviderKeysToSemanticCacheConfig(config *schemas.PluginConf
 	providerVal, exists := configMap["provider"]
 	if !exists {
 		if hasDimension && dimension == 1 {
+			delete(configMap, "embedding_model")
 			return nil
 		}
 		return fmt.Errorf("semantic_cache plugin requires 'provider' for semantic mode (dimension > 1). For direct-only mode, set dimension: 1 and omit provider")
@@ -3462,6 +3463,7 @@ func (c *Config) AddProviderKeysToSemanticCacheConfig(config *schemas.PluginConf
 	if provider == "" {
 		if hasDimension && dimension == 1 {
 			delete(configMap, "provider")
+			delete(configMap, "embedding_model")
 			return nil
 		}
 		return fmt.Errorf("semantic_cache plugin requires a non-empty 'provider' for semantic mode (dimension > 1). For direct-only mode, set dimension: 1 and omit provider")

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3447,6 +3447,7 @@ func (c *Config) AddProviderKeysToSemanticCacheConfig(config *schemas.PluginConf
 	providerVal, exists := configMap["provider"]
 	if !exists {
 		if hasDimension && dimension == 1 {
+			delete(configMap, "keys")
 			delete(configMap, "embedding_model")
 			return nil
 		}
@@ -3463,6 +3464,7 @@ func (c *Config) AddProviderKeysToSemanticCacheConfig(config *schemas.PluginConf
 	if provider == "" {
 		if hasDimension && dimension == 1 {
 			delete(configMap, "provider")
+			delete(configMap, "keys")
 			delete(configMap, "embedding_model")
 			return nil
 		}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3457,6 +3457,7 @@ func (c *Config) AddProviderKeysToSemanticCacheConfig(config *schemas.PluginConf
 		return fmt.Errorf("semantic_cache plugin 'provider' field must be a string, got %T", providerVal)
 	}
 	provider = strings.TrimSpace(provider)
+	configMap["provider"] = provider
 
 	if provider == "" {
 		if hasDimension && dimension == 1 {
@@ -3465,6 +3466,26 @@ func (c *Config) AddProviderKeysToSemanticCacheConfig(config *schemas.PluginConf
 		}
 		return fmt.Errorf("semantic_cache plugin requires a non-empty 'provider' for semantic mode (dimension > 1). For direct-only mode, set dimension: 1 and omit provider")
 	}
+	if !hasDimension {
+		return fmt.Errorf("semantic_cache plugin requires 'dimension' for provider-backed semantic mode. For direct-only mode, set dimension: 1 and omit provider")
+	}
+	if dimension <= 1 {
+		return fmt.Errorf("semantic_cache plugin requires 'dimension' > 1 when 'provider' is set. Use dimension: 1 only for direct-only mode without a provider")
+	}
+
+	embeddingModelVal, exists := configMap["embedding_model"]
+	if !exists {
+		return fmt.Errorf("semantic_cache plugin requires 'embedding_model' when 'provider' is set")
+	}
+	embeddingModel, ok := embeddingModelVal.(string)
+	if !ok {
+		return fmt.Errorf("semantic_cache plugin 'embedding_model' field must be a string, got %T", embeddingModelVal)
+	}
+	embeddingModel = strings.TrimSpace(embeddingModel)
+	if embeddingModel == "" {
+		return fmt.Errorf("semantic_cache plugin requires a non-empty 'embedding_model' when 'provider' is set")
+	}
+	configMap["embedding_model"] = embeddingModel
 
 	keys, err := c.GetProviderConfigRaw(schemas.ModelProvider(provider))
 	if err != nil {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -3437,19 +3438,32 @@ func (c *Config) AddProviderKeysToSemanticCacheConfig(config *schemas.PluginConf
 		return fmt.Errorf("semantic_cache plugin config must be a map, got %T", config.Config)
 	}
 
+	dimension, hasDimension, err := semanticCacheConfigDimension(configMap)
+	if err != nil {
+		return err
+	}
+
 	// Check if provider key exists and is a string
 	providerVal, exists := configMap["provider"]
 	if !exists {
-		return fmt.Errorf("semantic_cache plugin missing required 'provider' field")
+		if hasDimension && dimension == 1 {
+			return nil
+		}
+		return fmt.Errorf("semantic_cache plugin requires 'provider' for semantic mode (dimension > 1). For direct-only mode, set dimension: 1 and omit provider")
 	}
 
 	provider, ok := providerVal.(string)
 	if !ok {
 		return fmt.Errorf("semantic_cache plugin 'provider' field must be a string, got %T", providerVal)
 	}
+	provider = strings.TrimSpace(provider)
 
 	if provider == "" {
-		return fmt.Errorf("semantic_cache plugin 'provider' field cannot be empty")
+		if hasDimension && dimension == 1 {
+			delete(configMap, "provider")
+			return nil
+		}
+		return fmt.Errorf("semantic_cache plugin requires a non-empty 'provider' for semantic mode (dimension > 1). For direct-only mode, set dimension: 1 and omit provider")
 	}
 
 	keys, err := c.GetProviderConfigRaw(schemas.ModelProvider(provider))
@@ -3460,6 +3474,50 @@ func (c *Config) AddProviderKeysToSemanticCacheConfig(config *schemas.PluginConf
 	configMap["keys"] = keys.Keys
 
 	return nil
+}
+
+func semanticCacheConfigDimension(configMap map[string]interface{}) (int, bool, error) {
+	dimensionVal, exists := configMap["dimension"]
+	if !exists {
+		return 0, false, nil
+	}
+
+	switch v := dimensionVal.(type) {
+	case int:
+		if v < 1 {
+			return 0, false, fmt.Errorf("semantic_cache plugin 'dimension' must be >= 1, got %d", v)
+		}
+		return v, true, nil
+	case int32:
+		if v < 1 {
+			return 0, false, fmt.Errorf("semantic_cache plugin 'dimension' must be >= 1, got %d", v)
+		}
+		return int(v), true, nil
+	case int64:
+		if v < 1 {
+			return 0, false, fmt.Errorf("semantic_cache plugin 'dimension' must be >= 1, got %d", v)
+		}
+		return int(v), true, nil
+	case float64:
+		if v != math.Trunc(v) {
+			return 0, false, fmt.Errorf("semantic_cache plugin 'dimension' field must be an integer, got %v", v)
+		}
+		if v < 1 {
+			return 0, false, fmt.Errorf("semantic_cache plugin 'dimension' must be >= 1, got %v", v)
+		}
+		return int(v), true, nil
+	case json.Number:
+		parsed, err := v.Int64()
+		if err != nil {
+			return 0, false, fmt.Errorf("semantic_cache plugin 'dimension' field must be an integer, got %q", v)
+		}
+		if parsed < 1 {
+			return 0, false, fmt.Errorf("semantic_cache plugin 'dimension' must be >= 1, got %d", parsed)
+		}
+		return int(parsed), true, nil
+	default:
+		return 0, false, fmt.Errorf("semantic_cache plugin 'dimension' field must be numeric, got %T", dimensionVal)
+	}
 }
 
 func (c *Config) RemoveProviderKeysFromSemanticCacheConfig(config *configstoreTables.TablePlugin) error {

--- a/transports/bifrost-http/lib/semantic_cache_config_test.go
+++ b/transports/bifrost-http/lib/semantic_cache_config_test.go
@@ -1,0 +1,104 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/plugins/semanticcache"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddProviderKeysToSemanticCacheConfig_DirectOnlyMode(t *testing.T) {
+	config := &Config{}
+	pluginConfig := &schemas.PluginConfig{
+		Name: semanticcache.PluginName,
+		Config: map[string]interface{}{
+			"dimension": 1,
+			"ttl":       "5m",
+		},
+	}
+
+	err := config.AddProviderKeysToSemanticCacheConfig(pluginConfig)
+	require.NoError(t, err)
+
+	configMap, ok := pluginConfig.Config.(map[string]interface{})
+	require.True(t, ok)
+	_, hasKeys := configMap["keys"]
+	require.False(t, hasKeys, "direct-only mode should not inject provider keys")
+}
+
+func TestAddProviderKeysToSemanticCacheConfig_InjectsProviderKeys(t *testing.T) {
+	config := &Config{
+		Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+			schemas.OpenAI: {
+				Keys: []schemas.Key{
+					{
+						Name:   "openai-key",
+						Value:  *schemas.NewEnvVar("sk-test"),
+						Weight: 1,
+					},
+				},
+			},
+		},
+	}
+	pluginConfig := &schemas.PluginConfig{
+		Name: semanticcache.PluginName,
+		Config: map[string]interface{}{
+			"provider":  "openai",
+			"dimension": 1536,
+		},
+	}
+
+	err := config.AddProviderKeysToSemanticCacheConfig(pluginConfig)
+	require.NoError(t, err)
+
+	configMap, ok := pluginConfig.Config.(map[string]interface{})
+	require.True(t, ok)
+	keys, ok := configMap["keys"].([]schemas.Key)
+	require.True(t, ok, "provider-backed mode should inject provider keys")
+	require.Len(t, keys, 1)
+	require.Equal(t, "openai-key", keys[0].Name)
+}
+
+func TestAddProviderKeysToSemanticCacheConfig_SemanticModeMissingProvider(t *testing.T) {
+	config := &Config{}
+	pluginConfig := &schemas.PluginConfig{
+		Name: semanticcache.PluginName,
+		Config: map[string]interface{}{
+			"dimension": 1536,
+		},
+	}
+
+	err := config.AddProviderKeysToSemanticCacheConfig(pluginConfig)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires 'provider' for semantic mode")
+}
+
+func TestAddProviderKeysToSemanticCacheConfig_InvalidDimensionZero(t *testing.T) {
+	config := &Config{}
+	pluginConfig := &schemas.PluginConfig{
+		Name: semanticcache.PluginName,
+		Config: map[string]interface{}{
+			"dimension": 0,
+		},
+	}
+
+	err := config.AddProviderKeysToSemanticCacheConfig(pluginConfig)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "'dimension' must be >= 1")
+}
+
+func TestAddProviderKeysToSemanticCacheConfig_InvalidDimensionNegative(t *testing.T) {
+	config := &Config{}
+	pluginConfig := &schemas.PluginConfig{
+		Name: semanticcache.PluginName,
+		Config: map[string]interface{}{
+			"dimension": -1,
+		},
+	}
+
+	err := config.AddProviderKeysToSemanticCacheConfig(pluginConfig)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "'dimension' must be >= 1")
+}

--- a/transports/bifrost-http/lib/semantic_cache_config_test.go
+++ b/transports/bifrost-http/lib/semantic_cache_config_test.go
@@ -28,12 +28,13 @@ func TestAddProviderKeysToSemanticCacheConfig_DirectOnlyMode(t *testing.T) {
 	require.False(t, hasKeys, "direct-only mode should not inject provider keys")
 }
 
-func TestAddProviderKeysToSemanticCacheConfig_DirectOnlyModeRemovesStaleEmbeddingModel(t *testing.T) {
+func TestAddProviderKeysToSemanticCacheConfig_DirectOnlyModeRemovesStaleProviderBackedFields(t *testing.T) {
 	config := &Config{}
 	pluginConfig := &schemas.PluginConfig{
 		Name: semanticcache.PluginName,
 		Config: map[string]interface{}{
 			"dimension":       1,
+			"keys":            []schemas.Key{{Name: "stale-key"}},
 			"embedding_model": "text-embedding-3-small",
 		},
 	}
@@ -43,6 +44,8 @@ func TestAddProviderKeysToSemanticCacheConfig_DirectOnlyModeRemovesStaleEmbeddin
 
 	configMap, ok := pluginConfig.Config.(map[string]interface{})
 	require.True(t, ok)
+	_, hasKeys := configMap["keys"]
+	require.False(t, hasKeys, "direct-only mode should remove stale provider keys")
 	_, hasEmbeddingModel := configMap["embedding_model"]
 	require.False(t, hasEmbeddingModel, "direct-only mode should remove stale embedding_model")
 }

--- a/transports/bifrost-http/lib/semantic_cache_config_test.go
+++ b/transports/bifrost-http/lib/semantic_cache_config_test.go
@@ -45,8 +45,9 @@ func TestAddProviderKeysToSemanticCacheConfig_InjectsProviderKeys(t *testing.T) 
 	pluginConfig := &schemas.PluginConfig{
 		Name: semanticcache.PluginName,
 		Config: map[string]interface{}{
-			"provider":  "openai",
-			"dimension": 1536,
+			"provider":        "openai",
+			"embedding_model": "text-embedding-3-small",
+			"dimension":       1536,
 		},
 	}
 
@@ -59,6 +60,7 @@ func TestAddProviderKeysToSemanticCacheConfig_InjectsProviderKeys(t *testing.T) 
 	require.True(t, ok, "provider-backed mode should inject provider keys")
 	require.Len(t, keys, 1)
 	require.Equal(t, "openai-key", keys[0].Name)
+	require.Equal(t, "openai", configMap["provider"])
 }
 
 func TestAddProviderKeysToSemanticCacheConfig_SemanticModeMissingProvider(t *testing.T) {
@@ -73,6 +75,52 @@ func TestAddProviderKeysToSemanticCacheConfig_SemanticModeMissingProvider(t *tes
 	err := config.AddProviderKeysToSemanticCacheConfig(pluginConfig)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "requires 'provider' for semantic mode")
+}
+
+func TestAddProviderKeysToSemanticCacheConfig_ProviderBackedModeMissingDimension(t *testing.T) {
+	config := &Config{}
+	pluginConfig := &schemas.PluginConfig{
+		Name: semanticcache.PluginName,
+		Config: map[string]interface{}{
+			"provider":        "openai",
+			"embedding_model": "text-embedding-3-small",
+		},
+	}
+
+	err := config.AddProviderKeysToSemanticCacheConfig(pluginConfig)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires 'dimension' for provider-backed semantic mode")
+}
+
+func TestAddProviderKeysToSemanticCacheConfig_ProviderBackedModeDimensionOne(t *testing.T) {
+	config := &Config{}
+	pluginConfig := &schemas.PluginConfig{
+		Name: semanticcache.PluginName,
+		Config: map[string]interface{}{
+			"provider":        "openai",
+			"embedding_model": "text-embedding-3-small",
+			"dimension":       1,
+		},
+	}
+
+	err := config.AddProviderKeysToSemanticCacheConfig(pluginConfig)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires 'dimension' > 1")
+}
+
+func TestAddProviderKeysToSemanticCacheConfig_ProviderBackedModeMissingEmbeddingModel(t *testing.T) {
+	config := &Config{}
+	pluginConfig := &schemas.PluginConfig{
+		Name: semanticcache.PluginName,
+		Config: map[string]interface{}{
+			"provider":  "openai",
+			"dimension": 1536,
+		},
+	}
+
+	err := config.AddProviderKeysToSemanticCacheConfig(pluginConfig)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires 'embedding_model'")
 }
 
 func TestAddProviderKeysToSemanticCacheConfig_InvalidDimensionZero(t *testing.T) {

--- a/transports/bifrost-http/lib/semantic_cache_config_test.go
+++ b/transports/bifrost-http/lib/semantic_cache_config_test.go
@@ -28,6 +28,25 @@ func TestAddProviderKeysToSemanticCacheConfig_DirectOnlyMode(t *testing.T) {
 	require.False(t, hasKeys, "direct-only mode should not inject provider keys")
 }
 
+func TestAddProviderKeysToSemanticCacheConfig_DirectOnlyModeRemovesStaleEmbeddingModel(t *testing.T) {
+	config := &Config{}
+	pluginConfig := &schemas.PluginConfig{
+		Name: semanticcache.PluginName,
+		Config: map[string]interface{}{
+			"dimension":       1,
+			"embedding_model": "text-embedding-3-small",
+		},
+	}
+
+	err := config.AddProviderKeysToSemanticCacheConfig(pluginConfig)
+	require.NoError(t, err)
+
+	configMap, ok := pluginConfig.Config.(map[string]interface{})
+	require.True(t, ok)
+	_, hasEmbeddingModel := configMap["embedding_model"]
+	require.False(t, hasEmbeddingModel, "direct-only mode should remove stale embedding_model")
+}
+
 func TestAddProviderKeysToSemanticCacheConfig_InjectsProviderKeys(t *testing.T) {
 	config := &Config{
 		Providers: map[schemas.ModelProvider]configstore.ProviderConfig{

--- a/transports/bifrost-http/lib/validator_test.go
+++ b/transports/bifrost-http/lib/validator_test.go
@@ -1025,7 +1025,7 @@ func TestValidateConfigSchema_Plugin_MissingName(t *testing.T) {
 // =============================================================================
 
 func TestValidateConfigSchema_SemanticCachePlugin_Valid(t *testing.T) {
-	// Valid semantic cache plugin with all required fields: provider, keys, dimension
+	// Valid semantic cache plugin with provider and dimension. Keys are injected at runtime.
 	validConfig := `{
 		"plugins": [
 			{
@@ -1033,7 +1033,6 @@ func TestValidateConfigSchema_SemanticCachePlugin_Valid(t *testing.T) {
 				"name": "semantic_cache",
 				"config": {
 					"provider": "openai",
-					"keys": ["sk-test-key"],
 					"dimension": 1536
 				}
 			}
@@ -1047,14 +1046,13 @@ func TestValidateConfigSchema_SemanticCachePlugin_Valid(t *testing.T) {
 }
 
 func TestValidateConfigSchema_SemanticCachePlugin_MissingProvider(t *testing.T) {
-	// Missing required field: provider
+	// Missing required field: provider for semantic mode (dimension > 1)
 	invalidConfig := `{
 		"plugins": [
 			{
 				"enabled": true,
 				"name": "semantic_cache",
 				"config": {
-					"keys": ["sk-test-key"],
 					"dimension": 1536
 				}
 			}
@@ -1067,9 +1065,9 @@ func TestValidateConfigSchema_SemanticCachePlugin_MissingProvider(t *testing.T) 
 	}
 }
 
-func TestValidateConfigSchema_SemanticCachePlugin_MissingKeys(t *testing.T) {
-	// Missing required field: keys
-	invalidConfig := `{
+func TestValidateConfigSchema_SemanticCachePlugin_ProviderWithoutKeys(t *testing.T) {
+	// Keys are not required at schema level for provider-backed config.
+	validConfig := `{
 		"plugins": [
 			{
 				"enabled": true,
@@ -1082,9 +1080,28 @@ func TestValidateConfigSchema_SemanticCachePlugin_MissingKeys(t *testing.T) {
 		]
 	}`
 
-	err := ValidateConfigSchema([]byte(invalidConfig), loadLocalSchema(t))
-	if err == nil {
-		t.Error("expected config missing 'keys' in semantic cache plugin to fail validation")
+	err := ValidateConfigSchema([]byte(validConfig), loadLocalSchema(t))
+	if err != nil {
+		t.Errorf("expected provider-backed semantic cache config without plugin keys to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_SemanticCachePlugin_DirectModeValid(t *testing.T) {
+	validConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "semantic_cache",
+				"config": {
+					"dimension": 1
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(validConfig), loadLocalSchema(t))
+	if err != nil {
+		t.Errorf("expected direct-only semantic cache config to pass validation, got error: %v", err)
 	}
 }
 
@@ -1096,8 +1113,7 @@ func TestValidateConfigSchema_SemanticCachePlugin_MissingDimension(t *testing.T)
 				"enabled": true,
 				"name": "semantic_cache",
 				"config": {
-					"provider": "openai",
-					"keys": ["sk-test-key"]
+					"provider": "openai"
 				}
 			}
 		]

--- a/transports/bifrost-http/lib/validator_test.go
+++ b/transports/bifrost-http/lib/validator_test.go
@@ -1025,7 +1025,7 @@ func TestValidateConfigSchema_Plugin_MissingName(t *testing.T) {
 // =============================================================================
 
 func TestValidateConfigSchema_SemanticCachePlugin_Valid(t *testing.T) {
-	// Valid semantic cache plugin with provider and dimension. Keys are injected at runtime.
+	// Valid semantic cache plugin with provider, embedding model, and dimension. Keys are injected at runtime.
 	validConfig := `{
 		"plugins": [
 			{
@@ -1033,6 +1033,7 @@ func TestValidateConfigSchema_SemanticCachePlugin_Valid(t *testing.T) {
 				"name": "semantic_cache",
 				"config": {
 					"provider": "openai",
+					"embedding_model": "text-embedding-3-small",
 					"dimension": 1536
 				}
 			}
@@ -1074,6 +1075,7 @@ func TestValidateConfigSchema_SemanticCachePlugin_ProviderWithoutKeys(t *testing
 				"name": "semantic_cache",
 				"config": {
 					"provider": "openai",
+					"embedding_model": "text-embedding-3-small",
 					"dimension": 1536
 				}
 			}
@@ -1083,6 +1085,26 @@ func TestValidateConfigSchema_SemanticCachePlugin_ProviderWithoutKeys(t *testing
 	err := ValidateConfigSchema([]byte(validConfig), loadLocalSchema(t))
 	if err != nil {
 		t.Errorf("expected provider-backed semantic cache config without plugin keys to pass validation, got error: %v", err)
+	}
+}
+
+func TestValidateConfigSchema_SemanticCachePlugin_ProviderWithoutEmbeddingModel(t *testing.T) {
+	invalidConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "semantic_cache",
+				"config": {
+					"provider": "openai",
+					"dimension": 1536
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig), loadLocalSchema(t))
+	if err == nil {
+		t.Error("expected provider-backed semantic cache config without embedding_model to fail validation")
 	}
 }
 
@@ -1105,6 +1127,27 @@ func TestValidateConfigSchema_SemanticCachePlugin_DirectModeValid(t *testing.T) 
 	}
 }
 
+func TestValidateConfigSchema_SemanticCachePlugin_DimensionOneWithProviderInvalid(t *testing.T) {
+	invalidConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "semantic_cache",
+				"config": {
+					"provider": "openai",
+					"embedding_model": "text-embedding-3-small",
+					"dimension": 1
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig), loadLocalSchema(t))
+	if err == nil {
+		t.Error("expected dimension: 1 with provider in semantic cache plugin to fail validation")
+	}
+}
+
 func TestValidateConfigSchema_SemanticCachePlugin_MissingDimension(t *testing.T) {
 	// Missing required field: dimension
 	invalidConfig := `{
@@ -1113,7 +1156,8 @@ func TestValidateConfigSchema_SemanticCachePlugin_MissingDimension(t *testing.T)
 				"enabled": true,
 				"name": "semantic_cache",
 				"config": {
-					"provider": "openai"
+					"provider": "openai",
+					"embedding_model": "text-embedding-3-small"
 				}
 			}
 		]

--- a/transports/bifrost-http/lib/validator_test.go
+++ b/transports/bifrost-http/lib/validator_test.go
@@ -1127,6 +1127,26 @@ func TestValidateConfigSchema_SemanticCachePlugin_DirectModeValid(t *testing.T) 
 	}
 }
 
+func TestValidateConfigSchema_SemanticCachePlugin_DirectModeWithEmbeddingModelInvalid(t *testing.T) {
+	invalidConfig := `{
+		"plugins": [
+			{
+				"enabled": true,
+				"name": "semantic_cache",
+				"config": {
+					"dimension": 1,
+					"embedding_model": "text-embedding-3-small"
+				}
+			}
+		]
+	}`
+
+	err := ValidateConfigSchema([]byte(invalidConfig), loadLocalSchema(t))
+	if err == nil {
+		t.Error("expected direct-only semantic cache config with embedding_model to fail validation")
+	}
+}
+
 func TestValidateConfigSchema_SemanticCachePlugin_DimensionOneWithProviderInvalid(t *testing.T) {
 	invalidConfig := `{
 		"plugins": [

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1131,7 +1131,7 @@
                   "properties": {
                     "provider": {
                       "type": "string",
-                      "description": "Provider to use for generating embeddings",
+                      "description": "Provider to use for generating embeddings. Required for semantic search; omit it for direct hash mode with dimension: 1.",
                       "enum": [
                         "openai",
                         "anthropic",
@@ -1155,7 +1155,7 @@
                     },
                     "keys": {
                       "type": "array",
-                      "description": "API keys for the embedding provider (required for semantic caching, not needed for direct caching with dimension: 1)",
+                      "description": "API keys for the embedding provider. These are injected at runtime for config-driven setups and are not needed for direct caching with dimension: 1.",
                       "items": {
                         "type": "string"
                       }
@@ -1219,9 +1219,27 @@
                     }
                   },
                   "required": [
-                    "provider",
-                    "keys",
                     "dimension"
+                  ],
+                  "allOf": [
+                    {
+                      "if": {
+                        "properties": {
+                          "dimension": {
+                            "const": 1
+                          }
+                        },
+                        "required": [
+                          "dimension"
+                        ]
+                      },
+                      "then": {},
+                      "else": {
+                        "required": [
+                          "provider"
+                        ]
+                      }
+                    }
                   ],
                   "additionalProperties": false
                 }

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1163,7 +1163,7 @@
                     },
                     "embedding_model": {
                       "type": "string",
-                      "description": "Model to use for generating embeddings (optional)"
+                      "description": "Model to use for generating embeddings in provider-backed semantic caching. Required when provider is set and not allowed in direct-only mode."
                     },
                     "cleanup_on_shutdown": {
                       "type": "boolean",
@@ -1248,6 +1248,11 @@
                         }
                       },
                       "else": {
+                        "not": {
+                          "required": [
+                            "embedding_model"
+                          ]
+                        },
                         "properties": {
                           "dimension": {
                             "const": 1

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1131,6 +1131,7 @@
                   "properties": {
                     "provider": {
                       "type": "string",
+                      "minLength": 1,
                       "description": "Provider to use for generating embeddings. Required for semantic search; omit it for direct hash mode with dimension: 1.",
                       "enum": [
                         "openai",
@@ -1225,19 +1226,33 @@
                     {
                       "if": {
                         "properties": {
-                          "dimension": {
-                            "const": 1
+                          "provider": {
+                            "type": "string",
+                            "minLength": 1
                           }
                         },
                         "required": [
-                          "dimension"
-                        ]
-                      },
-                      "then": {},
-                      "else": {
-                        "required": [
                           "provider"
                         ]
+                      },
+                      "then": {
+                        "required": [
+                          "provider",
+                          "embedding_model"
+                        ],
+                        "properties": {
+                          "dimension": {
+                            "type": "integer",
+                            "minimum": 2
+                          }
+                        }
+                      },
+                      "else": {
+                        "properties": {
+                          "dimension": {
+                            "const": 1
+                          }
+                        }
                       }
                     }
                   ],

--- a/ui/app/workspace/config/views/pluginsForm.tsx
+++ b/ui/app/workspace/config/views/pluginsForm.tsx
@@ -55,7 +55,8 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 	const semanticCachePlugin = useMemo(() => plugins?.find((plugin) => plugin.name === SEMANTIC_CACHE_PLUGIN), [plugins]);
 
 	const isSemanticCacheEnabled = Boolean(semanticCachePlugin?.enabled);
-	const isDirectOnlyConfig = cacheConfig.dimension === 1 && !cacheConfig.provider;
+	const loadedDirectOnlyConfig = serverCacheConfig.dimension === 1 && !serverCacheConfig.provider;
+	const hasInvalidProviderBackedDimension = cacheConfig.dimension === 1 && Boolean(cacheConfig.provider?.trim());
 
 	// Initialize cache config from plugin data
 	useEffect(() => {
@@ -108,6 +109,11 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 
 	// Save all changes
 	const handleSave = async () => {
+		if (hasInvalidProviderBackedDimension) {
+			toast.error("Provider-backed semantic cache requires the embedding model's real dimension. Use a value greater than 1, or remove the provider to keep direct-only mode.")
+			return
+		}
+
 		try {
 			if (semanticCachePlugin) {
 				// Update existing plugin
@@ -176,7 +182,7 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 							}}
 						/>
 						{(isSemanticCacheEnabled || originalCacheEnabled) && (
-							<Button onClick={handleSave} disabled={!hasChanges || isUpdating || isCreating} size="sm">
+							<Button onClick={handleSave} disabled={!hasChanges || isUpdating || isCreating || hasInvalidProviderBackedDimension} size="sm">
 								{isUpdating || isCreating ? "Saving..." : "Save"}
 							</Button>
 						)}
@@ -193,10 +199,16 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 					) : (
 						<div className="mt-4 space-y-4">
 							<Separator />
-							{isDirectOnlyConfig && (
+							{loadedDirectOnlyConfig && (
 								<div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
-									This plugin is currently configured in direct-only mode via <code>config.json</code>. The Web UI currently edits
-									provider-backed semantic cache settings; keep using <code>config.json</code> if you want to stay in direct-only mode.
+									This plugin was loaded in direct-only mode via <code>config.json</code>. The Web UI currently edits provider-backed
+									semantic cache settings; keep using <code>config.json</code> if you want to stay in direct-only mode.
+								</div>
+							)}
+							{hasInvalidProviderBackedDimension && (
+								<div className="rounded-md border border-red-200 bg-red-50 p-3 text-xs text-red-900">
+									You selected a provider while keeping <code>dimension: 1</code>. That is only valid for direct-only mode. Set the
+									embedding model&apos;s real dimension before saving, or remove the provider to stay in direct-only mode.
 								</div>
 							)}
 							{/* Provider and Model Settings */}

--- a/ui/app/workspace/config/views/pluginsForm.tsx
+++ b/ui/app/workspace/config/views/pluginsForm.tsx
@@ -9,14 +9,15 @@ import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { getProviderLabel } from "@/lib/constants/logs";
 import { getErrorMessage, useCreatePluginMutation, useGetPluginsQuery, useGetProvidersQuery, useUpdatePluginMutation } from "@/lib/store";
-import { CacheConfig, ModelProviderName } from "@/lib/types/config";
+import { CacheConfig, EditorCacheConfig, ModelProviderName } from "@/lib/types/config";
 import { SEMANTIC_CACHE_PLUGIN } from "@/lib/types/plugins";
+import { cacheConfigSchema } from "@/lib/types/schemas";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Loader2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
-const defaultCacheConfig: CacheConfig = {
+const defaultCacheConfig: EditorCacheConfig = {
 	ttl_seconds: 300,
 	threshold: 0.8,
 	conversation_history_threshold: 3,
@@ -25,15 +26,60 @@ const defaultCacheConfig: CacheConfig = {
 	cache_by_provider: true,
 };
 
+const toEditorCacheConfig = (config?: Partial<CacheConfig>): EditorCacheConfig => ({
+	...defaultCacheConfig,
+	...config,
+});
+
+const normalizeCacheConfigForSave = (config: EditorCacheConfig) => {
+	const normalized: Record<string, unknown> = {
+		ttl_seconds: config.ttl_seconds,
+		threshold: config.threshold,
+		cache_by_model: config.cache_by_model,
+		cache_by_provider: config.cache_by_provider,
+	};
+
+	if (config.conversation_history_threshold !== undefined) {
+		normalized.conversation_history_threshold = config.conversation_history_threshold;
+	}
+	if (config.exclude_system_prompt !== undefined) {
+		normalized.exclude_system_prompt = config.exclude_system_prompt;
+	}
+	if (config.created_at !== undefined) {
+		normalized.created_at = config.created_at;
+	}
+	if (config.updated_at !== undefined) {
+		normalized.updated_at = config.updated_at;
+	}
+	if (config.keys !== undefined) {
+		normalized.keys = config.keys;
+	}
+
+	const provider = config.provider?.trim();
+	const embeddingModel = config.embedding_model?.trim();
+
+	if (provider) {
+		normalized.provider = provider;
+	}
+	if (embeddingModel) {
+		normalized.embedding_model = embeddingModel;
+	}
+	if (config.dimension !== undefined) {
+		normalized.dimension = config.dimension;
+	}
+
+	return normalized;
+};
+
 interface PluginsFormProps {
 	isVectorStoreEnabled: boolean;
 }
 
 export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) {
 	const hasSettingsUpdateAccess = useRbac(RbacResource.Settings, RbacOperation.Update);
-	const [cacheConfig, setCacheConfig] = useState<CacheConfig>(defaultCacheConfig);
+	const [cacheConfig, setCacheConfig] = useState<EditorCacheConfig>(defaultCacheConfig);
 	const [originalCacheEnabled, setOriginalCacheEnabled] = useState<boolean>(false);
-	const [serverCacheConfig, setServerCacheConfig] = useState<CacheConfig>(defaultCacheConfig);
+	const [serverCacheConfig, setServerCacheConfig] = useState<EditorCacheConfig>(defaultCacheConfig);
 	const [serverCacheEnabled, setServerCacheEnabled] = useState<boolean>(false);
 
 	const { data: providersData, error: providersError, isLoading: providersLoading } = useGetProvidersQuery();
@@ -61,7 +107,7 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 	// Initialize cache config from plugin data
 	useEffect(() => {
 		if (semanticCachePlugin?.config) {
-			const config = { ...defaultCacheConfig, ...semanticCachePlugin.config };
+			const config = toEditorCacheConfig(semanticCachePlugin.config as Partial<CacheConfig>);
 			setCacheConfig(config);
 			setServerCacheConfig(config);
 			setOriginalCacheEnabled(semanticCachePlugin.enabled);
@@ -103,7 +149,7 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 	};
 
 	// Update cache config locally
-	const updateCacheConfigLocal = (updates: Partial<CacheConfig>) => {
+	const updateCacheConfigLocal = (updates: Partial<EditorCacheConfig>) => {
 		setCacheConfig((prev) => ({ ...prev, ...updates }));
 	};
 
@@ -114,25 +160,36 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 			return
 		}
 
+		const parseResult = cacheConfigSchema.safeParse(normalizeCacheConfigForSave(cacheConfig));
+		if (!parseResult.success) {
+			const firstIssue = parseResult.error.issues[0]?.message ?? "Semantic cache configuration is invalid."
+			toast.error(firstIssue)
+			return
+		}
+
+		const savedConfig = parseResult.data as CacheConfig;
+
 		try {
 			if (semanticCachePlugin) {
 				// Update existing plugin
 				await updatePlugin({
 					name: SEMANTIC_CACHE_PLUGIN,
-					data: { enabled: originalCacheEnabled, config: cacheConfig },
+					data: { enabled: originalCacheEnabled, config: savedConfig },
 				}).unwrap();
 			} else {
 				// Create new plugin
 				await createPlugin({
 					name: SEMANTIC_CACHE_PLUGIN,
 					enabled: originalCacheEnabled,
-					config: cacheConfig,
+					config: savedConfig,
 					path: "",
 				}).unwrap();
 			}
 			toast.success("Plugin configuration updated successfully");
 			// Update server state to match current state
-			setServerCacheConfig(cacheConfig);
+			const normalizedConfig = toEditorCacheConfig(savedConfig);
+			setCacheConfig(normalizedConfig);
+			setServerCacheConfig(normalizedConfig);
 			setServerCacheEnabled(originalCacheEnabled);
 		} catch (error) {
 			const errorMessage = getErrorMessage(error);

--- a/ui/app/workspace/config/views/pluginsForm.tsx
+++ b/ui/app/workspace/config/views/pluginsForm.tsx
@@ -17,10 +17,6 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 const defaultCacheConfig: CacheConfig = {
-	provider: "openai" as ModelProviderName,
-	keys: [],
-	embedding_model: "text-embedding-3-small",
-	dimension: 0,
 	ttl_seconds: 300,
 	threshold: 0.8,
 	conversation_history_threshold: 3,
@@ -59,6 +55,7 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 	const semanticCachePlugin = useMemo(() => plugins?.find((plugin) => plugin.name === SEMANTIC_CACHE_PLUGIN), [plugins]);
 
 	const isSemanticCacheEnabled = Boolean(semanticCachePlugin?.enabled);
+	const isDirectOnlyConfig = cacheConfig.dimension === 1 && !cacheConfig.provider;
 
 	// Initialize cache config from plugin data
 	useEffect(() => {
@@ -77,6 +74,8 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 			setCacheConfig((prev) => ({
 				...prev,
 				provider: providers[0].name as ModelProviderName,
+				embedding_model: prev.embedding_model ?? "text-embedding-3-small",
+				dimension: prev.dimension ?? 1536,
 			}));
 		}
 	}, [providers, semanticCachePlugin?.config]);
@@ -194,6 +193,12 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 					) : (
 						<div className="mt-4 space-y-4">
 							<Separator />
+							{isDirectOnlyConfig && (
+								<div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+									This plugin is currently configured in direct-only mode via <code>config.json</code>. The Web UI currently edits
+									provider-backed semantic cache settings; keep using <code>config.json</code> if you want to stay in direct-only mode.
+								</div>
+							)}
 							{/* Provider and Model Settings */}
 							<div className="space-y-4">
 								<h3 className="text-sm font-medium">Provider and Model Settings</h3>
@@ -221,7 +226,7 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 										<Input
 											id="embedding_model"
 											placeholder="text-embedding-3-small"
-											value={cacheConfig.embedding_model}
+											value={cacheConfig.embedding_model ?? ""}
 											onChange={(e) => updateCacheConfigLocal({ embedding_model: e.target.value })}
 										/>
 									</div>
@@ -279,7 +284,7 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 										<Input
 											id="dimension"
 											type="number"
-											min="0"
+											min="1"
 											value={cacheConfig.dimension === undefined || Number.isNaN(cacheConfig.dimension) ? '' : cacheConfig.dimension}
 											onChange={(e) => {
 												const value = e.target.value

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -518,11 +518,7 @@ export const DefaultCoreConfig: CoreConfig = {
 };
 
 // Semantic cache configuration types
-export interface CacheConfig {
-	provider?: ModelProviderName;
-	keys?: ModelProviderKey[];
-	embedding_model?: string;
-	dimension?: number;
+interface BaseCacheConfig {
 	ttl_seconds: number;
 	threshold: number;
 	conversation_history_threshold?: number;
@@ -531,6 +527,29 @@ export interface CacheConfig {
 	cache_by_provider: boolean;
 	created_at?: string;
 	updated_at?: string;
+}
+
+export interface DirectCacheConfig extends BaseCacheConfig {
+	dimension: 1;
+	provider?: undefined;
+	keys?: ModelProviderKey[];
+	embedding_model?: undefined;
+}
+
+export interface ProviderBackedCacheConfig extends BaseCacheConfig {
+	provider: ModelProviderName;
+	keys?: ModelProviderKey[];
+	embedding_model: string;
+	dimension: number;
+}
+
+export type CacheConfig = DirectCacheConfig | ProviderBackedCacheConfig;
+
+export interface EditorCacheConfig extends BaseCacheConfig {
+	provider?: ModelProviderName;
+	keys?: ModelProviderKey[];
+	embedding_model?: string;
+	dimension?: number;
 }
 
 // Maxim configuration types

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -519,10 +519,10 @@ export const DefaultCoreConfig: CoreConfig = {
 
 // Semantic cache configuration types
 export interface CacheConfig {
-	provider: ModelProviderName;
-	keys: ModelProviderKey[];
-	embedding_model: string;
-	dimension: number;
+	provider?: ModelProviderName;
+	keys?: ModelProviderKey[];
+	embedding_model?: string;
+	dimension?: number;
 	ttl_seconds: number;
 	threshold: number;
 	conversation_history_threshold?: number;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -597,20 +597,30 @@ export const updateProviderRequestSchema = z.object({
 });
 
 // Cache config schema
-export const cacheConfigSchema = z.object({
-	provider: modelProviderNameSchema.optional(),
-	keys: z.array(modelProviderKeySchema).optional(),
-	embedding_model: z.string().min(1, "Embedding model is required").optional(),
-	dimension: z.number().min(1, "Dimension must be at least 1"),
-	ttl_seconds: z.number().min(1).default(3600),
+const baseCacheConfigSchema = z.object({
+	ttl_seconds: z.number().int().min(1).default(3600),
 	threshold: z.number().min(0).max(1).default(0.8),
-	conversation_history_threshold: z.number().min(0).max(1).optional(),
+	conversation_history_threshold: z.number().int().min(0).optional(),
 	exclude_system_prompt: z.boolean().optional(),
 	cache_by_model: z.boolean().default(false),
 	cache_by_provider: z.boolean().default(false),
 	created_at: z.string().optional(),
 	updated_at: z.string().optional(),
 });
+
+const directCacheConfigSchema = baseCacheConfigSchema.extend({
+	dimension: z.literal(1),
+	keys: z.array(modelProviderKeySchema).optional(),
+}).strict();
+
+const providerBackedCacheConfigSchema = baseCacheConfigSchema.extend({
+	provider: modelProviderNameSchema,
+	keys: z.array(modelProviderKeySchema).optional(),
+	embedding_model: z.string().min(1, "Embedding model is required"),
+	dimension: z.number().int().min(2, "Dimension must be greater than 1 for provider-backed semantic cache"),
+}).strict();
+
+export const cacheConfigSchema = z.union([directCacheConfigSchema, providerBackedCacheConfigSchema]);
 
 // Core config schema
 export const coreConfigSchema = z.object({

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -598,9 +598,10 @@ export const updateProviderRequestSchema = z.object({
 
 // Cache config schema
 export const cacheConfigSchema = z.object({
-	provider: modelProviderNameSchema,
-	keys: z.array(modelProviderKeySchema).min(1, "At least one key is required"),
-	embedding_model: z.string().min(1, "Embedding model is required"),
+	provider: modelProviderNameSchema.optional(),
+	keys: z.array(modelProviderKeySchema).optional(),
+	embedding_model: z.string().min(1, "Embedding model is required").optional(),
+	dimension: z.number().min(1, "Dimension must be at least 1"),
 	ttl_seconds: z.number().min(1).default(3600),
 	threshold: z.number().min(0).max(1).default(0.8),
 	conversation_history_threshold: z.number().min(0).max(1).optional(),


### PR DESCRIPTION
## Summary

Fixes a contract mismatch in semantic cache direct-only mode. The docs and runtime plugin already supported the documented `dimension: 1` / no-provider setup, but the schema, transport config loading, and UI contract had not been updated to match. As a result, a valid direct-only config was either rejected, warned on, or represented inconsistently across setup paths.

This PR makes that setup work cleanly through schema validation, config loading, plugin initialization, docs, and the Web UI contract. It aligns the product around two supported modes:

- **Provider-backed semantic mode** — `provider` + `embedding_model` + `dimension > 1`
- **Direct-only mode** — `dimension: 1` with no provider

## Changes

- Updated semantic cache schema validation to keep `dimension` required and only require `provider` for semantic mode
- Removed the user-facing requirement to provide plugin `keys` in config-driven setup
- Hardened transport config loading to treat `dimension: 1` with no provider as valid direct-only mode
- Added loader validation for invalid dimensions (`< 1`) and improved error messages for semantic-mode misconfiguration
- Changed semantic cache plugin logging so intentional direct-only mode logs as `info` instead of `warning`
- Updated docs and examples to include `dimension`, explain direct-only setup, and clarify that `dimension: 1` plus provider is still provider-backed mode
- Aligned UI types/schema with the backend contract and added a warning when loading a direct-only config in the current provider-backed UI flow
- Added targeted tests for schema validation, direct-only mode, provider-backed key injection, and invalid dimensions

## Type of Change

- Bug fix
- Documentation
- UI contract cleanup

## Affected Areas

- Core config handling (Go)
- Transports (HTTP)
- Plugins
- UI (Next.js)
- Docs

## How to Test

**Run targeted Go tests:**

```bash
cd transports
go test ./bifrost-http/lib -run 'TestValidateConfigSchema_SemanticCachePlugin_|TestAddProviderKeysToSemanticCacheConfig_' -v
```

**Run UI typecheck:**

```bash
cd ui
bun x tsc --noEmit
```

**End-to-end docs-style direct-only verification with Redis:**

- Start Redis/Valkey
- Run Bifrost with a `config.json` using `dimension: 1`, no plugin provider, and Redis vector store
- Send the same request twice with `x-bf-cache-key`
- Confirm second response returns `extra_fields.cache_debug.hit_type = "direct"`

## Breaking Changes

Yes

This PR enforces the existing semantic cache contract more consistently across setup paths. In practice:

- Semantic cache configs should include `dimension`
- Provider-backed mode should use the embedding model's dimension, e.g. `1536` for `text-embedding-3-small`
- Direct-only mode should use `dimension: 1` and omit `provider`

## Security Considerations

No security impact. This change affects configuration validation, startup behavior, UI contract alignment, and documentation only.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified targeted Go tests pass
- [x] I verified UI typecheck passes
- [x] I validated the direct-only docs flow end to end with Redis