### PR TITLE
anthropic beta test sync and test cases

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -85,7 +85,9 @@ type TestScenarios struct {
 	PassthroughAPI         bool // Raw HTTP passthrough API (Passthrough + PassthroughStream)
 	WebSocketResponses     bool // WebSocket Responses API mode
 	Realtime               bool // Realtime API (bidirectional audio/text)
-	Compaction             bool // Server-side compaction (context management)
+	Compaction          bool // Server-side compaction (context management)
+	InterleavedThinking bool // Interleaved thinking between tool calls (beta)
+	FastMode            bool // Fast mode for Opus 4.6 (beta: research preview)
 }
 
 // ComprehensiveTestConfig extends TestConfig with additional scenarios
@@ -124,6 +126,8 @@ type ComprehensiveTestConfig struct {
 	ExpectRawRequestResponse bool                   // When true, validate rawRequest/rawResponse in ExtraFields
 	PassthroughModel         string                 // Model for passthrough API tests; defaults to ChatModel when empty
 	CompactionModel          string                 // Model for compaction tests; defaults to claude-sonnet-4-6
+	InterleavedThinkingModel string                 // Model for interleaved thinking tests; defaults to claude-opus-4-5
+	FastModeModel            string                 // Model for fast mode tests; defaults to claude-opus-4-6
 	RealtimeModel            string                 // Model for Realtime API (e.g., "gpt-4o-realtime-preview")
 }
 

--- a/core/internal/llmtests/fast_mode.go
+++ b/core/internal/llmtests/fast_mode.go
@@ -1,0 +1,133 @@
+package llmtests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// RunFastModeTest tests that the fast-mode-2026-02-01 beta header is correctly
+// sent when speed="fast" is specified via ExtraParams.
+//
+// This test verifies:
+//  1. The fast-mode beta header is properly injected when speed=fast
+//  2. The API accepts the request without error
+//  3. The response is valid
+//
+// Note: Fast mode is currently only supported on Anthropic (direct API) with Opus 4.6.
+func RunFastModeTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.FastMode {
+		t.Logf("Fast mode not supported for provider %s", testConfig.Provider)
+		return
+	}
+
+	// Fast mode is currently Anthropic-only
+	if testConfig.Provider != schemas.Anthropic {
+		t.Logf("Fast mode test skipped: only supported for Anthropic provider")
+		return
+	}
+
+	t.Run("FastMode", func(t *testing.T) {
+		if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
+			t.Parallel()
+		}
+
+		model := testConfig.FastModeModel
+		if model == "" {
+			model = "claude-opus-4-6"
+		}
+
+		messages := []schemas.ResponsesMessage{
+			CreateBasicResponsesMessage("What is 2+2? Answer in one word."),
+		}
+
+		t.Run("NonStreaming", func(t *testing.T) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+
+			request := &schemas.BifrostResponsesRequest{
+				Provider: testConfig.Provider,
+				Model:    model,
+				Input:    messages,
+				Params: &schemas.ResponsesParameters{
+					MaxOutputTokens: bifrost.Ptr(100),
+					ExtraParams: map[string]interface{}{
+						"speed": "fast",
+					},
+				},
+			}
+
+			response, err := client.ResponsesRequest(bfCtx, request)
+			if err != nil {
+				t.Fatalf("Fast mode non-streaming request failed: %s", GetErrorMessage(err))
+			}
+			if response == nil {
+				t.Fatal("Expected non-nil response")
+			}
+
+			content := GetResponsesContent(response)
+			if content == "" {
+				t.Error("Expected non-empty response content")
+			}
+
+			t.Logf("Fast mode non-streaming passed: content=%s", content)
+
+			// Validate raw request/response fields when enabled
+			if testConfig.ExpectRawRequestResponse {
+				if err := ValidateRawField(response.ExtraFields.RawRequest, "RawRequest"); err != nil {
+					t.Errorf("Fast mode non-streaming raw request validation failed: %v", err)
+				}
+				if err := ValidateRawField(response.ExtraFields.RawResponse, "RawResponse"); err != nil {
+					t.Errorf("Fast mode non-streaming raw response validation failed: %v", err)
+				}
+			}
+		})
+
+		t.Run("ChatNonStreaming", func(t *testing.T) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+
+			chatMessages := []schemas.ChatMessage{
+				CreateBasicChatMessage("What is 2+2? Answer in one word."),
+			}
+
+			request := &schemas.BifrostChatRequest{
+				Provider: testConfig.Provider,
+				Model:    model,
+				Input:    chatMessages,
+				Params: &schemas.ChatParameters{
+					MaxCompletionTokens: bifrost.Ptr(100),
+					ExtraParams: map[string]interface{}{
+						"speed": "fast",
+					},
+				},
+			}
+
+			response, err := client.ChatCompletionRequest(bfCtx, request)
+			if err != nil {
+				t.Fatalf("Fast mode chat non-streaming request failed: %s", GetErrorMessage(err))
+			}
+			if response == nil {
+				t.Fatal("Expected non-nil response")
+			}
+
+			content := GetChatContent(response)
+			if content == "" {
+				t.Error("Expected non-empty response content")
+			}
+
+			t.Logf("Fast mode chat non-streaming passed: content=%s", content)
+
+			// Validate raw request/response fields when enabled
+			if testConfig.ExpectRawRequestResponse {
+				if err := ValidateRawField(response.ExtraFields.RawRequest, "RawRequest"); err != nil {
+					t.Errorf("Fast mode chat non-streaming raw request validation failed: %v", err)
+				}
+				if err := ValidateRawField(response.ExtraFields.RawResponse, "RawResponse"); err != nil {
+					t.Errorf("Fast mode chat non-streaming raw response validation failed: %v", err)
+				}
+			}
+		})
+	})
+}

--- a/core/internal/llmtests/interleaved_thinking.go
+++ b/core/internal/llmtests/interleaved_thinking.go
@@ -1,0 +1,169 @@
+package llmtests
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// RunInterleavedThinkingTest tests that the interleaved-thinking-2025-05-14 beta header
+// is correctly sent and that thinking works alongside tool calls.
+//
+// This test verifies:
+//  1. The interleaved-thinking beta header is properly injected when thinking is enabled
+//  2. The API accepts the request with thinking + tools without error
+//  3. The response contains reasoning content
+func RunInterleavedThinkingTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.InterleavedThinking {
+		t.Logf("Interleaved thinking not supported for provider %s", testConfig.Provider)
+		return
+	}
+
+	t.Run("InterleavedThinking", func(t *testing.T) {
+		if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
+			t.Parallel()
+		}
+
+		model := testConfig.InterleavedThinkingModel
+		if model == "" {
+			model = testConfig.ReasoningModel
+		}
+		if model == "" {
+			model = "claude-opus-4-5"
+		}
+
+		// Use the standard weather tool so thinking can interleave with tool calls
+		weatherTool := GetSampleResponsesTool(SampleToolTypeWeather)
+
+		messages := []schemas.ResponsesMessage{
+			CreateBasicResponsesMessage("What is the weather in Paris? Think step by step before calling the tool."),
+		}
+
+		t.Run("NonStreaming", func(t *testing.T) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+
+			request := &schemas.BifrostResponsesRequest{
+				Provider: testConfig.Provider,
+				Model:    model,
+				Input:    messages,
+				Params: &schemas.ResponsesParameters{
+					MaxOutputTokens: bifrost.Ptr(4096),
+					Tools:           []schemas.ResponsesTool{*weatherTool},
+					Reasoning: &schemas.ResponsesParametersReasoning{
+						Effort: bifrost.Ptr("low"),
+					},
+				},
+				Fallbacks: testConfig.Fallbacks,
+			}
+
+			response, err := client.ResponsesRequest(bfCtx, request)
+			if err != nil {
+				t.Fatalf("Interleaved thinking non-streaming request failed: %s", GetErrorMessage(err))
+			}
+			if response == nil {
+				t.Fatal("Expected non-nil response")
+			}
+
+			t.Logf("Interleaved thinking non-streaming passed: stop_reason=%v", response.StopReason)
+
+			// Validate that the response contains output
+			if response.Output == nil || len(response.Output) == 0 {
+				t.Fatal("Expected non-empty output for interleaved thinking response")
+			}
+
+			// Check for reasoning indicators
+			reasoningDetected := validateResponsesAPIReasoning(t, response)
+			if reasoningDetected {
+				t.Logf("Reasoning structure detected in interleaved thinking response")
+			}
+
+			// Check for tool calls (interleaved thinking should produce tool calls with the weather tool)
+			toolCalls := ExtractResponsesToolCalls(response)
+			if len(toolCalls) > 0 {
+				t.Logf("Tool calls found in interleaved thinking response: %d", len(toolCalls))
+				for _, tc := range toolCalls {
+					t.Logf("  Tool call: %s", tc.Name)
+				}
+			} else {
+				t.Logf("No tool calls found in interleaved thinking response (model may have answered without calling tools)")
+			}
+
+			// Validate raw request/response fields when enabled
+			if testConfig.ExpectRawRequestResponse {
+				if err := ValidateRawField(response.ExtraFields.RawRequest, "RawRequest"); err != nil {
+					t.Errorf("Interleaved thinking non-streaming raw request validation failed: %v", err)
+				}
+				if err := ValidateRawField(response.ExtraFields.RawResponse, "RawResponse"); err != nil {
+					t.Errorf("Interleaved thinking non-streaming raw response validation failed: %v", err)
+				}
+			}
+		})
+
+		t.Run("ChatNonStreaming", func(t *testing.T) {
+			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+
+			chatMessages := []schemas.ChatMessage{
+				CreateBasicChatMessage("What is the weather in Paris? Think step by step before calling the tool."),
+			}
+
+			chatTool := GetSampleChatTool(SampleToolTypeWeather)
+
+			request := &schemas.BifrostChatRequest{
+				Provider: testConfig.Provider,
+				Model:    model,
+				Input:    chatMessages,
+				Params: &schemas.ChatParameters{
+					MaxCompletionTokens: bifrost.Ptr(4096),
+					Tools:               []schemas.ChatTool{*chatTool},
+					Reasoning: &schemas.ChatReasoning{
+						Effort: bifrost.Ptr("low"),
+					},
+				},
+				Fallbacks: testConfig.Fallbacks,
+			}
+
+			response, err := client.ChatCompletionRequest(bfCtx, request)
+			if err != nil {
+				t.Fatalf("Interleaved thinking chat non-streaming request failed: %s", GetErrorMessage(err))
+			}
+			if response == nil {
+				t.Fatal("Expected non-nil response")
+			}
+
+			t.Logf("Interleaved thinking chat non-streaming passed")
+
+			content := GetChatContent(response)
+			if content == "" && len(ExtractChatToolCalls(response)) == 0 {
+				t.Fatal("Expected non-empty content or tool calls for interleaved thinking chat response")
+			}
+
+			reasoningDetected := validateChatCompletionReasoning(t, response)
+			if reasoningDetected {
+				t.Logf("Reasoning structure detected in interleaved thinking chat response")
+			}
+
+			toolCalls := ExtractChatToolCalls(response)
+			if len(toolCalls) > 0 {
+				t.Logf("Tool calls found in interleaved thinking chat response: %d", len(toolCalls))
+				for _, tc := range toolCalls {
+					t.Logf("  Tool call: %s", tc.Name)
+				}
+			} else {
+				t.Logf("No tool calls found in interleaved thinking chat response (model may have answered without calling tools)")
+			}
+
+			// Validate raw request/response fields when enabled
+			if testConfig.ExpectRawRequestResponse {
+				if err := ValidateRawField(response.ExtraFields.RawRequest, "RawRequest"); err != nil {
+					t.Errorf("Interleaved thinking chat non-streaming raw request validation failed: %v", err)
+				}
+				if err := ValidateRawField(response.ExtraFields.RawResponse, "RawResponse"); err != nil {
+					t.Errorf("Interleaved thinking chat non-streaming raw response validation failed: %v", err)
+				}
+			}
+		})
+	})
+}

--- a/core/internal/llmtests/provider_feature_support_test.go
+++ b/core/internal/llmtests/provider_feature_support_test.go
@@ -466,40 +466,40 @@ func TestProviderBetaHeaderInjection(t *testing.T) {
 			provider: schemas.Anthropic,
 			setupReq: func() *anthropic.AnthropicMessageRequest {
 				return &anthropic.AnthropicMessageRequest{
-					MCPServers: []anthropic.AnthropicMCPServer{{URL: "http://example.com"}},
+					MCPServers: []anthropic.AnthropicMCPServerV2{{URL: "https://example.com"}},
 				}
 			},
-			expectHeaders: []string{"mcp-client-2025-04-04"},
+			expectHeaders: []string{"mcp-client-2025-11-20"},
 		},
 		{
 			name:     "Vertex/mcp_header_skipped",
 			provider: schemas.Vertex,
 			setupReq: func() *anthropic.AnthropicMessageRequest {
 				return &anthropic.AnthropicMessageRequest{
-					MCPServers: []anthropic.AnthropicMCPServer{{URL: "http://example.com"}},
+					MCPServers: []anthropic.AnthropicMCPServerV2{{URL: "https://example.com"}},
 				}
 			},
-			unexpectHeaders: []string{"mcp-client-2025-04-04"},
+			unexpectHeaders: []string{"mcp-client-2025-11-20"},
 		},
 		{
 			name:     "Bedrock/mcp_header_skipped",
 			provider: schemas.Bedrock,
 			setupReq: func() *anthropic.AnthropicMessageRequest {
 				return &anthropic.AnthropicMessageRequest{
-					MCPServers: []anthropic.AnthropicMCPServer{{URL: "http://example.com"}},
+					MCPServers: []anthropic.AnthropicMCPServerV2{{URL: "https://example.com"}},
 				}
 			},
-			unexpectHeaders: []string{"mcp-client-2025-04-04"},
+			unexpectHeaders: []string{"mcp-client-2025-11-20"},
 		},
 		{
 			name:     "Azure/mcp_header_added",
 			provider: schemas.Azure,
 			setupReq: func() *anthropic.AnthropicMessageRequest {
 				return &anthropic.AnthropicMessageRequest{
-					MCPServers: []anthropic.AnthropicMCPServer{{URL: "http://example.com"}},
+					MCPServers: []anthropic.AnthropicMCPServerV2{{URL: "https://example.com"}},
 				}
 			},
-			expectHeaders: []string{"mcp-client-2025-04-04"},
+			expectHeaders: []string{"mcp-client-2025-11-20"},
 		},
 
 		// ── Compaction header (supported on all providers) ──
@@ -726,7 +726,7 @@ func TestProviderAnthropicRequestPipeline(t *testing.T) {
 			},
 			expectedWebSearchType: "web_search_20250305", // Vertex does NOT get dynamic filtering
 			expectedBetaHeaders:   nil,                   // no beta headers for basic web search
-			unexpectedBetaHeaders: []string{"structured-outputs-2025-11-13", "mcp-client-2025-04-04", "prompt-caching-scope-2026-01-05"},
+			unexpectedBetaHeaders: []string{"structured-outputs-2025-11-13", "mcp-client-2025-11-20", "prompt-caching-scope-2026-01-05"},
 		},
 		{
 			name:     "Vertex/web_search_with_compaction_gets_compaction_header",
@@ -807,7 +807,7 @@ func TestProviderAnthropicRequestPipeline(t *testing.T) {
 				},
 			},
 			expectedBetaHeaders:   []string{"computer-use-2025-11-24"},
-			unexpectedBetaHeaders: []string{"mcp-client-2025-04-04", "prompt-caching-scope-2026-01-05"},
+			unexpectedBetaHeaders: []string{"mcp-client-2025-11-20", "prompt-caching-scope-2026-01-05"},
 		},
 	}
 

--- a/core/internal/llmtests/tests.go
+++ b/core/internal/llmtests/tests.go
@@ -118,6 +118,8 @@ func RunAllComprehensiveTests(t *testing.T, client *bifrost.Bifrost, ctx context
 		RunWebSocketResponsesTest,
 		RunRealtimeTest,
 		RunCompactionTest,
+		RunInterleavedThinkingTest,
+		RunFastModeTest,
 	}
 
 	// Execute all test scenarios without raw request/response (default behavior)
@@ -235,6 +237,8 @@ func printTestSummary(t *testing.T, testConfig ComprehensiveTestConfig) {
 		{"WebSocketResponses", testConfig.Scenarios.WebSocketResponses && testConfig.ChatModel != ""},
 		{"Realtime", testConfig.Scenarios.Realtime && testConfig.RealtimeModel != ""},
 		{"Compaction", testConfig.Scenarios.Compaction},
+		{"InterleavedThinking", testConfig.Scenarios.InterleavedThinking},
+		{"FastMode", testConfig.Scenarios.FastMode},
 	}
 
 	supported := 0

--- a/core/providers/anthropic/anthropic_test.go
+++ b/core/providers/anthropic/anthropic_test.go
@@ -69,7 +69,9 @@ func TestAnthropic(t *testing.T) {
 			CountTokens:           true,
 			StructuredOutputs:     true, // Structured outputs with nullable enum support
 			PassthroughAPI:        true,
-			Compaction:            true,
+			Compaction:          true,
+			InterleavedThinking: true,
+			FastMode:            false, // Enable when test API key has Opus 4.6 access
 		},
 	}
 

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -42,7 +42,10 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 		if ok {
 			delete(anthropicReq.ExtraParams, "top_k")
 			anthropicReq.TopK = topK
-
+		}
+		if speed, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["speed"]); ok {
+			delete(anthropicReq.ExtraParams, "speed")
+			anthropicReq.Speed = speed
 		}
 		// extract inference_geo and context management
 		if inferenceGeo, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["inference_geo"]); ok {

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2133,6 +2133,9 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 	if req.TopK != nil {
 		params.ExtraParams["top_k"] = *req.TopK
 	}
+	if req.Speed != nil {
+		params.ExtraParams["speed"] = *req.Speed
+	}
 	if req.StopSequences != nil {
 		params.ExtraParams["stop"] = req.StopSequences
 	}
@@ -2225,10 +2228,24 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 	}
 
 	if req.MCPServers != nil {
+		// Build a map of mcp_toolset configs from tools[] keyed by mcp_server_name
+		toolsetByServer := make(map[string]*AnthropicMCPToolsetTool)
+		if req.Tools != nil {
+			for i := range req.Tools {
+				if req.Tools[i].MCPToolset != nil {
+					toolsetByServer[req.Tools[i].MCPToolset.MCPServerName] = req.Tools[i].MCPToolset
+				}
+			}
+		}
+
 		var bifrostMCPTools []schemas.ResponsesTool
 		for _, mcpServer := range req.MCPServers {
-			bifrostMCPTool := convertAnthropicMCPServerToBifrostTool(&mcpServer)
+			bifrostMCPTool := convertAnthropicMCPServerV2ToBifrostTool(&mcpServer)
 			if bifrostMCPTool != nil {
+				// Merge mcp_toolset configs (allowed tools) if present
+				if toolset, ok := toolsetByServer[mcpServer.Name]; ok {
+					applyMCPToolsetConfigToBifrostTool(bifrostMCPTool, toolset)
+				}
 				bifrostMCPTools = append(bifrostMCPTools, *bifrostMCPTool)
 			}
 		}
@@ -2420,6 +2437,10 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 			if ok {
 				delete(anthropicReq.ExtraParams, "top_k")
 				anthropicReq.TopK = topK
+			}
+			if speed, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["speed"]); ok {
+				delete(anthropicReq.ExtraParams, "speed")
+				anthropicReq.Speed = speed
 			}
 			if stop, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["stop"]); ok {
 				delete(anthropicReq.ExtraParams, "stop")
@@ -4516,6 +4537,11 @@ func convertAnthropicToolToBifrost(tool *AnthropicTool) *schemas.ResponsesTool {
 		return nil
 	}
 
+	// Skip mcp_toolset entries — these are merged with mcp_servers in ToBifrostResponsesRequest
+	if tool.MCPToolset != nil {
+		return nil
+	}
+
 	// Handle special tool types first
 	if tool.Type != nil {
 		switch *tool.Type {
@@ -4742,7 +4768,7 @@ func convertToolOutputToAnthropicContent(output *schemas.ResponsesToolMessageOut
 // convertBifrostToolsToAnthropic converts all Bifrost tools to Anthropic tools and MCP servers.
 // It handles context-dependent conversions like code_interpreter, which must be skipped when
 // web_search or web_fetch is present (Anthropic auto-injects code_execution in that case).
-func convertBifrostToolsToAnthropic(model string, tools []schemas.ResponsesTool, provider schemas.ModelProvider) ([]AnthropicTool, []AnthropicMCPServer) {
+func convertBifrostToolsToAnthropic(model string, tools []schemas.ResponsesTool, provider schemas.ModelProvider) ([]AnthropicTool, []AnthropicMCPServerV2) {
 	// Check if web search or web fetch is present — when they are, Anthropic
 	// auto-injects code_execution so we must skip it to avoid conflicts.
 	hasWebSearchOrFetch := false
@@ -4754,12 +4780,15 @@ func convertBifrostToolsToAnthropic(model string, tools []schemas.ResponsesTool,
 	}
 
 	anthropicTools := []AnthropicTool{}
-	mcpServers := []AnthropicMCPServer{}
+	mcpServers := []AnthropicMCPServerV2{}
 	for _, tool := range tools {
 		if tool.Type == schemas.ResponsesToolTypeMCP && tool.ResponsesToolMCP != nil {
-			mcpServer := convertBifrostMCPToolToAnthropicServer(&tool)
-			if mcpServer != nil {
-				mcpServers = append(mcpServers, *mcpServer)
+			server, toolset := convertBifrostMCPToolToAnthropicNew(&tool)
+			if server != nil {
+				mcpServers = append(mcpServers, *server)
+			}
+			if toolset != nil {
+				anthropicTools = append(anthropicTools, AnthropicTool{MCPToolset: toolset})
 			}
 			continue
 		}
@@ -5145,7 +5174,66 @@ func (block AnthropicContentBlock) toBifrostResponsesDocumentBlock() schemas.Res
 }
 
 // Helper functions for MCP tool/server conversion
-// convertAnthropicMCPServerToBifrostTool converts a single Anthropic MCP server to a Bifrost ResponsesTool
+// convertAnthropicMCPServerV2ToBifrostTool converts a new-format MCP server to a Bifrost ResponsesTool.
+func convertAnthropicMCPServerV2ToBifrostTool(mcpServer *AnthropicMCPServerV2) *schemas.ResponsesTool {
+	if mcpServer == nil {
+		return nil
+	}
+
+	bifrostTool := &schemas.ResponsesTool{
+		Type: schemas.ResponsesToolTypeMCP,
+		ResponsesToolMCP: &schemas.ResponsesToolMCP{
+			ServerLabel: mcpServer.Name,
+		},
+	}
+
+	if mcpServer.URL != "" {
+		bifrostTool.ResponsesToolMCP.ServerURL = schemas.Ptr(mcpServer.URL)
+	}
+	if mcpServer.AuthorizationToken != nil {
+		bifrostTool.ResponsesToolMCP.Authorization = mcpServer.AuthorizationToken
+	}
+
+	return bifrostTool
+}
+
+// applyMCPToolsetConfigToBifrostTool merges mcp_toolset tool configs (from tools[]) into a Bifrost MCP tool.
+// Extracts the allowlist pattern: tools explicitly enabled in configs while default_config has enabled=false.
+func applyMCPToolsetConfigToBifrostTool(bifrostTool *schemas.ResponsesTool, toolset *AnthropicMCPToolsetTool) {
+	if bifrostTool == nil || bifrostTool.ResponsesToolMCP == nil || toolset == nil {
+		return
+	}
+
+	// Extract allowed tools from the allowlist pattern:
+	// default_config.enabled=false + individual tools enabled in configs
+	if toolset.Configs != nil {
+		defaultEnabled := true
+		if toolset.DefaultConfig != nil && toolset.DefaultConfig.Enabled != nil {
+			defaultEnabled = *toolset.DefaultConfig.Enabled
+		}
+
+		if !defaultEnabled {
+			// Allowlist pattern: collect explicitly enabled tools.
+			// Keep an empty allowlist to preserve the "deny all" case.
+			allowedTools := make([]string, 0, len(toolset.Configs))
+			for toolName, config := range toolset.Configs {
+				if config != nil && config.Enabled != nil && *config.Enabled {
+					allowedTools = append(allowedTools, toolName)
+				}
+			}
+			bifrostTool.ResponsesToolMCP.AllowedTools = &schemas.ResponsesToolMCPAllowedTools{
+				ToolNames: allowedTools,
+			}
+		}
+	}
+
+	// Apply cache control if present
+	if toolset.CacheControl != nil {
+		bifrostTool.CacheControl = toolset.CacheControl
+	}
+}
+
+// convertAnthropicMCPServerToBifrostTool converts a deprecated-format Anthropic MCP server to a Bifrost ResponsesTool.
 func convertAnthropicMCPServerToBifrostTool(mcpServer *AnthropicMCPServer) *schemas.ResponsesTool {
 	if mcpServer == nil {
 		return nil
@@ -5178,7 +5266,49 @@ func convertAnthropicMCPServerToBifrostTool(mcpServer *AnthropicMCPServer) *sche
 	return bifrostTool
 }
 
-// convertBifrostMCPToolToAnthropicServer converts a Bifrost MCP tool back to an Anthropic MCP server
+// convertBifrostMCPToolToAnthropicNew converts a Bifrost MCP tool to the new mcp-client-2025-11-20 format.
+// Returns both a simplified server entry (for mcp_servers[]) and a toolset entry (for tools[]).
+func convertBifrostMCPToolToAnthropicNew(tool *schemas.ResponsesTool) (*AnthropicMCPServerV2, *AnthropicMCPToolsetTool) {
+	if tool == nil || tool.Type != schemas.ResponsesToolTypeMCP || tool.ResponsesToolMCP == nil {
+		return nil, nil
+	}
+
+	// Build simplified server (no tool_configuration)
+	server := &AnthropicMCPServerV2{
+		Type: "url",
+		Name: tool.ResponsesToolMCP.ServerLabel,
+	}
+	if tool.ResponsesToolMCP.ServerURL != nil {
+		server.URL = *tool.ResponsesToolMCP.ServerURL
+	}
+	if tool.ResponsesToolMCP.Authorization != nil {
+		server.AuthorizationToken = tool.ResponsesToolMCP.Authorization
+	}
+
+	// Build toolset tool (references server by name)
+	toolset := &AnthropicMCPToolsetTool{
+		Type:          "mcp_toolset",
+		MCPServerName: tool.ResponsesToolMCP.ServerLabel,
+		CacheControl:  tool.CacheControl,
+	}
+
+	// Convert allowed tools to per-tool configs
+	if tool.ResponsesToolMCP.AllowedTools != nil {
+		// Allowlist pattern: default disabled, specific tools enabled
+		toolset.DefaultConfig = &AnthropicMCPToolsetConfig{Enabled: schemas.Ptr(false)}
+		if len(tool.ResponsesToolMCP.AllowedTools.ToolNames) > 0 {
+			toolset.Configs = make(map[string]*AnthropicMCPToolsetConfig, len(tool.ResponsesToolMCP.AllowedTools.ToolNames))
+			for _, toolName := range tool.ResponsesToolMCP.AllowedTools.ToolNames {
+				toolset.Configs[toolName] = &AnthropicMCPToolsetConfig{Enabled: schemas.Ptr(true)}
+			}
+		}
+	}
+
+	return server, toolset
+}
+
+// convertBifrostMCPToolToAnthropicServer converts a Bifrost MCP tool to the deprecated mcp-client-2025-04-04 format.
+// Kept for backward compatibility.
 func convertBifrostMCPToolToAnthropicServer(tool *schemas.ResponsesTool) *AnthropicMCPServer {
 	if tool == nil || tool.Type != schemas.ResponsesToolTypeMCP || tool.ResponsesToolMCP == nil {
 		return nil

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -23,14 +23,26 @@ const (
 	AnthropicStructuredOutputsBetaHeader = "structured-outputs-2025-11-13"
 	// AnthropicAdvancedToolUseBetaHeader is required for defer_loading, input_examples, and allowed_callers.
 	AnthropicAdvancedToolUseBetaHeader = "advanced-tool-use-2025-11-20"
-	// AnthropicMCPClientBetaHeader is required for MCP servers.
-	AnthropicMCPClientBetaHeader = "mcp-client-2025-04-04"
+	// AnthropicMCPClientBetaHeader is required for MCP servers (current version).
+	AnthropicMCPClientBetaHeader = "mcp-client-2025-11-20"
+	// AnthropicMCPClientBetaHeaderDeprecated is the previous MCP beta header (kept for fallback).
+	AnthropicMCPClientBetaHeaderDeprecated = "mcp-client-2025-04-04"
 	// AnthropicPromptCachingScopeBetaHeader is required for prompt caching scope.
 	AnthropicPromptCachingScopeBetaHeader = "prompt-caching-scope-2026-01-05"
 	// AnthropicCompactionBetaHeader is required for compaction.
 	AnthropicCompactionBetaHeader = "compact-2026-01-12"
 	// AnthropicContextManagementBetaHeader is required for context management.
 	AnthropicContextManagementBetaHeader = "context-management-2025-06-27"
+	// AnthropicInterleavedThinkingBetaHeader is required for interleaved thinking between tool calls.
+	// Deprecated on Opus 4.6/Sonnet 4.6 (use adaptive thinking); active on older Claude 4 models.
+	AnthropicInterleavedThinkingBetaHeader = "interleaved-thinking-2025-05-14"
+	// AnthropicSkillsBetaHeader is required for Agent Skills (also requires code-execution + files-api headers).
+	AnthropicSkillsBetaHeader = "skills-2025-10-02"
+	// AnthropicContext1MBetaHeader is required for 1M context window on Sonnet 4.5 and Sonnet 4.
+	// GA on Opus 4.6 and Sonnet 4.6 (no header needed).
+	AnthropicContext1MBetaHeader = "context-1m-2025-08-07"
+	// AnthropicFastModeBetaHeader is required for fast mode on Opus 4.6 (research preview).
+	AnthropicFastModeBetaHeader = "fast-mode-2026-02-01"
 
 	// AnthropicComputerUseBetaHeader is required for computer use (version-specific).
 	// computer_20251124 (Opus 4.6, Sonnet 4.6, Opus 4.5) uses the newer beta header.
@@ -38,13 +50,17 @@ const (
 	// computer_20250124 (all other supported models) uses the older beta header.
 	AnthropicComputerUseBetaHeader20250124 = "computer-use-2025-01-24"
 
-	// Prefixes for Vertex-unsupported beta headers (version-bump proof).
-	// Use these with strings.HasPrefix when filtering headers for Vertex AI,
+	// Prefixes for beta headers (version-bump proof).
+	// Use these with strings.HasPrefix when filtering headers per provider,
 	// so that future date bumps (e.g. structured-outputs-2025-12-15) are still matched.
 	AnthropicAdvancedToolUseBetaHeaderPrefix    = "advanced-tool-use-"
 	AnthropicStructuredOutputsBetaHeaderPrefix  = "structured-outputs-"
 	AnthropicPromptCachingScopeBetaHeaderPrefix = "prompt-caching-scope-"
 	AnthropicMCPClientBetaHeaderPrefix          = "mcp-client-"
+	AnthropicInterleavedThinkingBetaHeaderPrefix = "interleaved-thinking-"
+	AnthropicSkillsBetaHeaderPrefix              = "skills-"
+	AnthropicContext1MBetaHeaderPrefix           = "context-1m-"
+	AnthropicFastModeBetaHeaderPrefix            = "fast-mode-"
 )
 
 // ProviderFeatureSupport defines which Anthropic features a given provider supports.
@@ -65,9 +81,13 @@ type ProviderFeatureSupport struct {
 	PromptCachingScope bool // prompt caching scope
 	Compaction         bool // server-side context compaction
 	ContextEditing     bool // context editing (clear_tool_uses, clear_thinking)
-	FilesAPI           bool // Files API
-	FileSearch         bool // file_search server tool (OpenAI-only)
-	ImageGeneration    bool // image_generation server tool (OpenAI-only)
+	FilesAPI            bool // Files API
+	InterleavedThinking bool // interleaved thinking between tool calls
+	Skills              bool // Agent Skills
+	Context1M           bool // 1M context window beta (for Sonnet 4.5/4 only)
+	FastMode            bool // fast mode (Opus 4.6 only, research preview)
+	FileSearch          bool // file_search server tool (OpenAI-only)
+	ImageGeneration     bool // image_generation server tool (OpenAI-only)
 }
 
 // ProviderFeatures maps each provider to its supported Anthropic features.
@@ -77,21 +97,25 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		ComputerUse: true, Bash: true, Memory: true, TextEditor: true, ToolSearch: true,
 		MCP: true, AdvancedToolUse: true, StructuredOutputs: true, PromptCachingScope: true,
 		Compaction: true, ContextEditing: true, FilesAPI: true,
+		InterleavedThinking: true, Skills: true, Context1M: true, FastMode: true,
 	},
 	schemas.Vertex: {
 		WebSearch: true, // only web_search_20250305 (basic), NOT dynamic filtering
 		ComputerUse: true, Bash: true, Memory: true, TextEditor: true, ToolSearch: true,
 		Compaction: true, ContextEditing: true,
+		InterleavedThinking: true, Context1M: true,
 	},
 	schemas.Bedrock: {
 		ComputerUse: true, Bash: true, Memory: true, TextEditor: true, ToolSearch: true,
 		StructuredOutputs: true, Compaction: true, ContextEditing: true,
+		InterleavedThinking: true, Context1M: true,
 	},
 	schemas.Azure: {
 		WebSearch: true, WebSearchDynamic: true, WebFetch: true, CodeExecution: true,
 		ComputerUse: true, Bash: true, Memory: true, TextEditor: true, ToolSearch: true,
 		MCP: true, AdvancedToolUse: true, StructuredOutputs: true, PromptCachingScope: true,
 		Compaction: true, ContextEditing: true, FilesAPI: true,
+		InterleavedThinking: true, Skills: true, Context1M: true,
 	},
 }
 
@@ -145,10 +169,11 @@ type AnthropicMessageRequest struct {
 	Stream            *bool                  `json:"stream,omitempty"`
 	Tools             []AnthropicTool        `json:"tools,omitempty"`
 	ToolChoice        *AnthropicToolChoice   `json:"tool_choice,omitempty"`
-	MCPServers        []AnthropicMCPServer   `json:"mcp_servers,omitempty"` // This feature requires the beta header: "anthropic-beta": "mcp-client-2025-04-04"
+	MCPServers        []AnthropicMCPServerV2 `json:"mcp_servers,omitempty"` // Simplified server definitions (mcp-client-2025-11-20)
 	Thinking          *AnthropicThinking     `json:"thinking,omitempty"`
 	OutputFormat      json.RawMessage        `json:"output_format,omitempty"` // Beta: requires header "anthropic-beta": "structured-outputs-2025-11-13" (json.RawMessage preserves key ordering)
 	OutputConfig      *AnthropicOutputConfig `json:"output_config,omitempty"` // GA: structured outputs without beta header
+	Speed             *string                `json:"speed,omitempty"`         // "fast" for fast mode (Opus 4.6 only, requires fast-mode beta header)
 	ServiceTier       *string                `json:"service_tier,omitempty"`  // "auto" or "standard_only"
 	InferenceGeo      *string                `json:"inference_geo,omitempty"` // the geographic region for inference processing. If not specified, the workspace's default_inference_geo is used.
 	ContextManagement *ContextManagement     `json:"context_management,omitempty"`
@@ -423,6 +448,7 @@ var anthropicMessageRequestKnownFields = map[string]bool{
 	"thinking":           true,
 	"output_format":      true,
 	"output_config":      true,
+	"speed":              true,
 	"service_tier":       true,
 	"inference_geo":      true,
 	"context_management": true,
@@ -900,6 +926,41 @@ type AnthropicTool struct {
 	*AnthropicToolComputerUse
 	*AnthropicToolWebSearch
 	*AnthropicToolWebFetch
+
+	// MCP toolset (mcp-client-2025-11-20 format) — embedded when Type is nil and MCPToolset is set
+	MCPToolset *AnthropicMCPToolsetTool `json:"-"` // Serialized via custom MarshalJSON
+}
+
+// MarshalJSON implements custom JSON marshaling for AnthropicTool.
+// When MCPToolset is set, serializes as an mcp_toolset tool instead of a regular tool.
+func (t AnthropicTool) MarshalJSON() ([]byte, error) {
+	if t.MCPToolset != nil {
+		return providerUtils.MarshalSorted(t.MCPToolset)
+	}
+	// Use an alias to avoid infinite recursion
+	type Alias AnthropicTool
+	return providerUtils.MarshalSorted((Alias)(t))
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for AnthropicTool.
+// Detects "type": "mcp_toolset" entries and populates the MCPToolset field,
+// which would otherwise be skipped due to the json:"-" tag.
+func (t *AnthropicTool) UnmarshalJSON(data []byte) error {
+	// Peek at the type field to detect mcp_toolset entries
+	var peek struct {
+		Type string `json:"type"`
+	}
+	if err := sonic.Unmarshal(data, &peek); err == nil && peek.Type == "mcp_toolset" {
+		var toolset AnthropicMCPToolsetTool
+		if err := sonic.Unmarshal(data, &toolset); err != nil {
+			return err
+		}
+		t.MCPToolset = &toolset
+		return nil
+	}
+	// Default unmarshaling for all other tool types
+	type Alias AnthropicTool
+	return sonic.Unmarshal(data, (*Alias)(t))
 }
 
 // AnthropicToolChoice represents tool choice in Anthropic format
@@ -918,17 +979,44 @@ type AnthropicToolContent struct {
 	PageAge          *string `json:"page_age,omitempty"`
 }
 
+// AnthropicMCPServer represents an MCP server definition (deprecated mcp-client-2025-04-04 format).
+// Kept for backward-compatible response parsing.
 type AnthropicMCPServer struct {
 	Type               string                  `json:"type"`
 	URL                string                  `json:"url"`
 	Name               string                  `json:"name"`
 	AuthorizationToken *string                 `json:"authorization_token,omitempty"`
-	ToolConfiguration  *AnthropicMCPToolConfig `json:"tool_configuration,omitempty"`
+	ToolConfiguration  *AnthropicMCPToolConfig `json:"tool_configuration,omitempty"` // Deprecated: use AnthropicMCPToolsetTool in tools[] instead
 }
 
 type AnthropicMCPToolConfig struct {
 	Enabled      bool     `json:"enabled"`
 	AllowedTools []string `json:"allowed_tools,omitempty"`
+}
+
+// AnthropicMCPServerV2 represents a simplified MCP server for mcp-client-2025-11-20 format.
+// Tool configuration is now in AnthropicMCPToolsetTool in the tools[] array.
+type AnthropicMCPServerV2 struct {
+	Type               string  `json:"type"`                         // "url"
+	URL                string  `json:"url"`                          // Server endpoint (must be https://)
+	Name               string  `json:"name"`                         // Unique server name
+	AuthorizationToken *string `json:"authorization_token,omitempty"` // OAuth token
+}
+
+// AnthropicMCPToolsetTool represents the new mcp_toolset tool type (mcp-client-2025-11-20).
+// Lives in the tools[] array and references an MCP server by name.
+type AnthropicMCPToolsetTool struct {
+	Type          string                                    `json:"type"`            // "mcp_toolset"
+	MCPServerName string                                    `json:"mcp_server_name"` // Must match a server in mcp_servers[]
+	DefaultConfig *AnthropicMCPToolsetConfig                `json:"default_config,omitempty"`
+	Configs       map[string]*AnthropicMCPToolsetConfig     `json:"configs,omitempty"`
+	CacheControl  *schemas.CacheControl                     `json:"cache_control,omitempty"`
+}
+
+// AnthropicMCPToolsetConfig configures individual MCP tools or provides defaults.
+type AnthropicMCPToolsetConfig struct {
+	Enabled      *bool `json:"enabled,omitempty"`
+	DeferLoading *bool `json:"defer_loading,omitempty"`
 }
 
 // ==================== RESPONSE TYPES ====================

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -300,6 +300,18 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 			headers = appendUniqueHeader(headers, AnthropicMCPClientBetaHeader)
 		}
 	}
+	// Check for interleaved thinking (required for older Claude 4 models with thinking enabled)
+	if req.Thinking != nil && req.Thinking.Type == "enabled" {
+		if !hasProvider || features.InterleavedThinking {
+			headers = appendUniqueHeader(headers, AnthropicInterleavedThinkingBetaHeader)
+		}
+	}
+	// Check for fast mode
+	if req.Speed != nil && *req.Speed == "fast" {
+		if !hasProvider || features.FastMode {
+			headers = appendUniqueHeader(headers, AnthropicFastModeBetaHeader)
+		}
+	}
 	// Check for output format (structured outputs)
 	if req.OutputFormat != nil {
 		if !hasProvider || features.StructuredOutputs {
@@ -348,13 +360,70 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 			extraHeaders = ctxExtraHeaders
 		}
 	}
-	if len(extraHeaders["anthropic-beta"]) == 0 {
+	existing := extraHeaders["anthropic-beta"]
+	if len(existing) == 0 {
 		extraHeaders["anthropic-beta"] = headers
 	} else {
-		extraHeaders["anthropic-beta"] = append(extraHeaders["anthropic-beta"], headers...)
+		// Passthrough wins: skip auto-injected headers when a same-prefix header
+		// already exists from passthrough. This prevents conflicting versions
+		// (e.g. mcp-client-2025-04-04 + mcp-client-2025-11-20) in the same request.
+		for _, h := range headers {
+			if !betaHeaderPrefixExists(existing, h) {
+				existing = append(existing, h)
+			}
+		}
+		extraHeaders["anthropic-beta"] = existing
 	}
 	ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, extraHeaders)
 	return nil
+}
+
+// betaHeaderPrefixKnown maps known beta header prefixes for prefix-aware dedup.
+var betaHeaderPrefixKnown = []string{
+	"computer-use-",
+	AnthropicStructuredOutputsBetaHeaderPrefix,
+	AnthropicMCPClientBetaHeaderPrefix,
+	AnthropicPromptCachingScopeBetaHeaderPrefix,
+	"compact-",
+	"context-management-",
+	"files-api-",
+	AnthropicAdvancedToolUseBetaHeaderPrefix,
+	AnthropicInterleavedThinkingBetaHeaderPrefix,
+	AnthropicSkillsBetaHeaderPrefix,
+	AnthropicContext1MBetaHeaderPrefix,
+	AnthropicFastModeBetaHeaderPrefix,
+}
+
+// betaHeaderPrefixExists checks if any header in existing shares a known prefix with newHeader.
+// Returns true if a same-prefix header is already present (passthrough wins).
+// Handles comma-separated values within a single header string (per HTTP spec).
+func betaHeaderPrefixExists(existing []string, newHeader string) bool {
+	// Find which known prefix the new header belongs to
+	var matchedPrefix string
+	for _, prefix := range betaHeaderPrefixKnown {
+		if strings.HasPrefix(newHeader, prefix) {
+			matchedPrefix = prefix
+			break
+		}
+	}
+	match := func(candidate string) bool {
+		if matchedPrefix == "" {
+			return candidate == newHeader
+		}
+		return strings.HasPrefix(candidate, matchedPrefix)
+	}
+	for _, headerValue := range existing {
+		for _, candidate := range strings.Split(headerValue, ",") {
+			candidate = strings.TrimSpace(candidate)
+			if candidate == "" {
+				continue
+			}
+			if match(candidate) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ToolVersionRemap defines a mapping from an unsupported tool version to a supported one.
@@ -551,6 +620,26 @@ func FilterBetaHeadersForProvider(headers []string, provider schemas.ModelProvid
 			filtered = append(filtered, h)
 		case strings.HasPrefix(h, AnthropicAdvancedToolUseBetaHeaderPrefix):
 			if !features.AdvancedToolUse {
+				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
+			}
+			filtered = append(filtered, h)
+		case strings.HasPrefix(h, AnthropicInterleavedThinkingBetaHeaderPrefix):
+			if !features.InterleavedThinking {
+				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
+			}
+			filtered = append(filtered, h)
+		case strings.HasPrefix(h, AnthropicSkillsBetaHeaderPrefix):
+			if !features.Skills {
+				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
+			}
+			filtered = append(filtered, h)
+		case strings.HasPrefix(h, AnthropicContext1MBetaHeaderPrefix):
+			if !features.Context1M {
+				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
+			}
+			filtered = append(filtered, h)
+		case strings.HasPrefix(h, AnthropicFastModeBetaHeaderPrefix):
+			if !features.FastMode {
 				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
 			}
 			filtered = append(filtered, h)

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -695,7 +695,7 @@ func TestAddMissingBetaHeadersToContext_PerProvider(t *testing.T) {
 			name:     "Vertex skips MCP header",
 			provider: schemas.Vertex,
 			req: &AnthropicMessageRequest{
-				MCPServers: []AnthropicMCPServer{{URL: "http://example.com"}},
+				MCPServers: []AnthropicMCPServerV2{{URL: "http://example.com"}},
 			},
 			unexpectHeaders: []string{AnthropicMCPClientBetaHeader},
 		},
@@ -703,7 +703,7 @@ func TestAddMissingBetaHeadersToContext_PerProvider(t *testing.T) {
 			name:     "Anthropic gets MCP header",
 			provider: schemas.Anthropic,
 			req: &AnthropicMessageRequest{
-				MCPServers: []AnthropicMCPServer{{URL: "http://example.com"}},
+				MCPServers: []AnthropicMCPServerV2{{URL: "http://example.com"}},
 			},
 			expectHeaders: []string{AnthropicMCPClientBetaHeader},
 		},
@@ -726,6 +726,72 @@ func TestAddMissingBetaHeadersToContext_PerProvider(t *testing.T) {
 				},
 			},
 			expectHeaders: []string{AnthropicCompactionBetaHeader},
+		},
+		// Interleaved thinking tests
+		{
+			name:     "Anthropic gets interleaved thinking header for enabled",
+			provider: schemas.Anthropic,
+			req: &AnthropicMessageRequest{
+				Thinking: &AnthropicThinking{Type: "enabled", BudgetTokens: schemas.Ptr(2048)},
+			},
+			expectHeaders: []string{AnthropicInterleavedThinkingBetaHeader},
+		},
+		{
+			name:     "Anthropic does not get interleaved thinking header for adaptive",
+			provider: schemas.Anthropic,
+			req: &AnthropicMessageRequest{
+				Thinking: &AnthropicThinking{Type: "adaptive"},
+			},
+			unexpectHeaders: []string{AnthropicInterleavedThinkingBetaHeader},
+		},
+		{
+			name:     "Vertex gets interleaved thinking header",
+			provider: schemas.Vertex,
+			req: &AnthropicMessageRequest{
+				Thinking: &AnthropicThinking{Type: "enabled", BudgetTokens: schemas.Ptr(2048)},
+			},
+			expectHeaders: []string{AnthropicInterleavedThinkingBetaHeader},
+		},
+		{
+			name:     "Bedrock gets interleaved thinking header",
+			provider: schemas.Bedrock,
+			req: &AnthropicMessageRequest{
+				Thinking: &AnthropicThinking{Type: "enabled", BudgetTokens: schemas.Ptr(2048)},
+			},
+			expectHeaders: []string{AnthropicInterleavedThinkingBetaHeader},
+		},
+		{
+			name:     "Disabled thinking does not get interleaved thinking header",
+			provider: schemas.Anthropic,
+			req: &AnthropicMessageRequest{
+				Thinking: &AnthropicThinking{Type: "disabled"},
+			},
+			unexpectHeaders: []string{AnthropicInterleavedThinkingBetaHeader},
+		},
+		// Fast mode tests
+		{
+			name:     "Anthropic gets fast mode header",
+			provider: schemas.Anthropic,
+			req: &AnthropicMessageRequest{
+				Speed: schemas.Ptr("fast"),
+			},
+			expectHeaders: []string{AnthropicFastModeBetaHeader},
+		},
+		{
+			name:     "Bedrock skips fast mode header",
+			provider: schemas.Bedrock,
+			req: &AnthropicMessageRequest{
+				Speed: schemas.Ptr("fast"),
+			},
+			unexpectHeaders: []string{AnthropicFastModeBetaHeader},
+		},
+		{
+			name:     "Azure skips fast mode header",
+			provider: schemas.Azure,
+			req: &AnthropicMessageRequest{
+				Speed: schemas.Ptr("fast"),
+			},
+			unexpectHeaders: []string{AnthropicFastModeBetaHeader},
 		},
 	}
 
@@ -763,6 +829,70 @@ func TestAddMissingBetaHeadersToContext_PerProvider(t *testing.T) {
 	}
 }
 
+func TestAddMissingBetaHeadersToContext_PassthroughWins(t *testing.T) {
+	// When a same-prefix header is already set from passthrough, auto-injection should NOT add a second version.
+	t.Run("passthrough_mcp_header_prevents_auto_inject", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		// Simulate passthrough setting an old MCP header
+		ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
+			"anthropic-beta": {AnthropicMCPClientBetaHeaderDeprecated},
+		})
+		// Request has MCP servers, which would normally auto-inject the new header
+		req := &AnthropicMessageRequest{
+			MCPServers: []AnthropicMCPServerV2{{URL: "http://example.com"}},
+		}
+		AddMissingBetaHeadersToContext(ctx, req, schemas.Anthropic)
+
+		extraHeaders := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+		betaHeaders := extraHeaders["anthropic-beta"]
+		// Should only have the old header, not both
+		if len(betaHeaders) != 1 {
+			t.Errorf("expected 1 header, got %d: %v", len(betaHeaders), betaHeaders)
+		}
+		if betaHeaders[0] != AnthropicMCPClientBetaHeaderDeprecated {
+			t.Errorf("expected passthrough header %q, got %q", AnthropicMCPClientBetaHeaderDeprecated, betaHeaders[0])
+		}
+	})
+
+	t.Run("passthrough_computer_use_header_prevents_auto_inject", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		// Simulate passthrough setting an older computer-use header
+		ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
+			"anthropic-beta": {AnthropicComputerUseBetaHeader20250124},
+		})
+		req := &AnthropicMessageRequest{
+			Tools: []AnthropicTool{{
+				Type: schemas.Ptr(AnthropicToolTypeComputer20251124),
+				Name: string(AnthropicToolNameComputer),
+			}},
+		}
+		AddMissingBetaHeadersToContext(ctx, req, schemas.Anthropic)
+
+		extraHeaders := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+		betaHeaders := extraHeaders["anthropic-beta"]
+		if len(betaHeaders) != 1 {
+			t.Errorf("expected 1 header, got %d: %v", len(betaHeaders), betaHeaders)
+		}
+		if betaHeaders[0] != AnthropicComputerUseBetaHeader20250124 {
+			t.Errorf("expected passthrough header %q, got %q", AnthropicComputerUseBetaHeader20250124, betaHeaders[0])
+		}
+	})
+
+	t.Run("no_passthrough_allows_auto_inject", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		req := &AnthropicMessageRequest{
+			MCPServers: []AnthropicMCPServerV2{{URL: "http://example.com"}},
+		}
+		AddMissingBetaHeadersToContext(ctx, req, schemas.Anthropic)
+
+		extraHeaders := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+		betaHeaders := extraHeaders["anthropic-beta"]
+		if len(betaHeaders) != 1 || betaHeaders[0] != AnthropicMCPClientBetaHeader {
+			t.Errorf("expected [%q], got %v", AnthropicMCPClientBetaHeader, betaHeaders)
+		}
+	})
+}
+
 func TestFilterBetaHeadersForProvider(t *testing.T) {
 	allHeaders := []string{
 		AnthropicComputerUseBetaHeader20251124,
@@ -773,6 +903,10 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 		AnthropicContextManagementBetaHeader,
 		AnthropicAdvancedToolUseBetaHeader,
 		AnthropicFilesAPIBetaHeader,
+		AnthropicInterleavedThinkingBetaHeader,
+		AnthropicSkillsBetaHeader,
+		AnthropicContext1MBetaHeader,
+		AnthropicFastModeBetaHeader,
 	}
 
 	t.Run("Anthropic/keeps_all_headers", func(t *testing.T) {
@@ -801,6 +935,8 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 			AnthropicPromptCachingScopeBetaHeader,
 			AnthropicAdvancedToolUseBetaHeader,
 			AnthropicFilesAPIBetaHeader,
+			AnthropicSkillsBetaHeader,
+			AnthropicFastModeBetaHeader,
 		}
 		for _, h := range unsupported {
 			_, err := FilterBetaHeadersForProvider([]string{h}, schemas.Vertex)
@@ -815,6 +951,8 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 			AnthropicComputerUseBetaHeader20251124,
 			AnthropicCompactionBetaHeader,
 			AnthropicContextManagementBetaHeader,
+			AnthropicInterleavedThinkingBetaHeader,
+			AnthropicContext1MBetaHeader,
 		}
 		result, err := FilterBetaHeadersForProvider(supported, schemas.Vertex)
 		if err != nil {
@@ -831,6 +969,8 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 			AnthropicPromptCachingScopeBetaHeader,
 			AnthropicAdvancedToolUseBetaHeader,
 			AnthropicFilesAPIBetaHeader,
+			AnthropicSkillsBetaHeader,
+			AnthropicFastModeBetaHeader,
 		}
 		for _, h := range unsupported {
 			_, err := FilterBetaHeadersForProvider([]string{h}, schemas.Bedrock)
@@ -1017,5 +1157,205 @@ func TestStripAutoInjectableTools(t *testing.T) {
 		if arr[2].Get("name").String() != "other_tool" {
 			t.Errorf("expected third tool to be 'other_tool', got '%s'", arr[2].Get("name").String())
 		}
+	})
+}
+
+func TestAnthropicToolUnmarshalJSON_MCPToolset(t *testing.T) {
+	t.Run("mcp_toolset is properly unmarshaled", func(t *testing.T) {
+		data := []byte(`{
+			"type": "mcp_toolset",
+			"mcp_server_name": "example-mcp",
+			"default_config": {"enabled": false},
+			"configs": {
+				"search_events": {"enabled": true},
+				"create_event": {"enabled": true, "defer_loading": true}
+			}
+		}`)
+
+		var tool AnthropicTool
+		if err := sonic.Unmarshal(data, &tool); err != nil {
+			t.Fatalf("unexpected unmarshal error: %v", err)
+		}
+
+		if tool.MCPToolset == nil {
+			t.Fatal("expected MCPToolset to be populated, got nil")
+		}
+		if tool.MCPToolset.Type != "mcp_toolset" {
+			t.Errorf("expected type 'mcp_toolset', got %q", tool.MCPToolset.Type)
+		}
+		if tool.MCPToolset.MCPServerName != "example-mcp" {
+			t.Errorf("expected mcp_server_name 'example-mcp', got %q", tool.MCPToolset.MCPServerName)
+		}
+		if tool.MCPToolset.DefaultConfig == nil || tool.MCPToolset.DefaultConfig.Enabled == nil || *tool.MCPToolset.DefaultConfig.Enabled != false {
+			t.Error("expected default_config.enabled to be false")
+		}
+		if len(tool.MCPToolset.Configs) != 2 {
+			t.Fatalf("expected 2 configs, got %d", len(tool.MCPToolset.Configs))
+		}
+		if tool.MCPToolset.Configs["search_events"] == nil || *tool.MCPToolset.Configs["search_events"].Enabled != true {
+			t.Error("expected search_events to be enabled")
+		}
+		if tool.MCPToolset.Configs["create_event"] == nil || tool.MCPToolset.Configs["create_event"].DeferLoading == nil || *tool.MCPToolset.Configs["create_event"].DeferLoading != true {
+			t.Error("expected create_event defer_loading to be true")
+		}
+	})
+
+	t.Run("regular tool is not affected by mcp_toolset unmarshal", func(t *testing.T) {
+		data := []byte(`{
+			"name": "get_weather",
+			"description": "Get weather info",
+			"input_schema": {"type": "object", "properties": {}}
+		}`)
+
+		var tool AnthropicTool
+		if err := sonic.Unmarshal(data, &tool); err != nil {
+			t.Fatalf("unexpected unmarshal error: %v", err)
+		}
+
+		if tool.MCPToolset != nil {
+			t.Error("expected MCPToolset to be nil for regular tool")
+		}
+		if tool.Name != "get_weather" {
+			t.Errorf("expected name 'get_weather', got %q", tool.Name)
+		}
+	})
+
+	t.Run("mcp_toolset round-trips through marshal/unmarshal", func(t *testing.T) {
+		original := AnthropicTool{
+			MCPToolset: &AnthropicMCPToolsetTool{
+				Type:          "mcp_toolset",
+				MCPServerName: "test-server",
+				DefaultConfig: &AnthropicMCPToolsetConfig{Enabled: schemas.Ptr(false)},
+				Configs: map[string]*AnthropicMCPToolsetConfig{
+					"tool_a": {Enabled: schemas.Ptr(true)},
+				},
+			},
+		}
+
+		marshaled, err := json.Marshal(original)
+		if err != nil {
+			t.Fatalf("unexpected marshal error: %v", err)
+		}
+
+		var restored AnthropicTool
+		if err := sonic.Unmarshal(marshaled, &restored); err != nil {
+			t.Fatalf("unexpected unmarshal error: %v", err)
+		}
+
+		if restored.MCPToolset == nil {
+			t.Fatal("expected MCPToolset to be populated after round-trip")
+		}
+		if restored.MCPToolset.MCPServerName != "test-server" {
+			t.Errorf("expected mcp_server_name 'test-server', got %q", restored.MCPToolset.MCPServerName)
+		}
+		if len(restored.MCPToolset.Configs) != 1 {
+			t.Fatalf("expected 1 config, got %d", len(restored.MCPToolset.Configs))
+		}
+	})
+
+	t.Run("tools array with mixed regular and mcp_toolset tools", func(t *testing.T) {
+		data := []byte(`[
+			{"name": "get_weather", "description": "Get weather"},
+			{"type": "mcp_toolset", "mcp_server_name": "my-mcp"},
+			{"type": "computer_20251124", "name": "computer"}
+		]`)
+
+		var tools []AnthropicTool
+		if err := sonic.Unmarshal(data, &tools); err != nil {
+			t.Fatalf("unexpected unmarshal error: %v", err)
+		}
+
+		if len(tools) != 3 {
+			t.Fatalf("expected 3 tools, got %d", len(tools))
+		}
+
+		// First: regular tool
+		if tools[0].Name != "get_weather" {
+			t.Errorf("expected first tool name 'get_weather', got %q", tools[0].Name)
+		}
+		if tools[0].MCPToolset != nil {
+			t.Error("expected first tool MCPToolset to be nil")
+		}
+
+		// Second: mcp_toolset
+		if tools[1].MCPToolset == nil {
+			t.Fatal("expected second tool MCPToolset to be populated")
+		}
+		if tools[1].MCPToolset.MCPServerName != "my-mcp" {
+			t.Errorf("expected mcp_server_name 'my-mcp', got %q", tools[1].MCPToolset.MCPServerName)
+		}
+
+		// Third: typed tool (computer)
+		if tools[2].MCPToolset != nil {
+			t.Error("expected third tool MCPToolset to be nil")
+		}
+	})
+}
+
+func TestApplyMCPToolsetConfigToBifrostTool(t *testing.T) {
+	t.Run("allowlist pattern merges correctly", func(t *testing.T) {
+		bifrostTool := &schemas.ResponsesTool{
+			Type: schemas.ResponsesToolTypeMCP,
+			ResponsesToolMCP: &schemas.ResponsesToolMCP{
+				ServerLabel: "test-server",
+				ServerURL:   schemas.Ptr("https://example.com/mcp"),
+			},
+		}
+
+		toolset := &AnthropicMCPToolsetTool{
+			Type:          "mcp_toolset",
+			MCPServerName: "test-server",
+			DefaultConfig: &AnthropicMCPToolsetConfig{Enabled: schemas.Ptr(false)},
+			Configs: map[string]*AnthropicMCPToolsetConfig{
+				"search": {Enabled: schemas.Ptr(true)},
+				"create": {Enabled: schemas.Ptr(true)},
+				"delete": {Enabled: schemas.Ptr(false)},
+			},
+		}
+
+		applyMCPToolsetConfigToBifrostTool(bifrostTool, toolset)
+
+		if bifrostTool.ResponsesToolMCP.AllowedTools == nil {
+			t.Fatal("expected AllowedTools to be set")
+		}
+		allowedNames := bifrostTool.ResponsesToolMCP.AllowedTools.ToolNames
+		if len(allowedNames) != 2 {
+			t.Fatalf("expected 2 allowed tools, got %d: %v", len(allowedNames), allowedNames)
+		}
+		// Check that both "search" and "create" are present (order may vary due to map iteration)
+		found := map[string]bool{}
+		for _, name := range allowedNames {
+			found[name] = true
+		}
+		if !found["search"] || !found["create"] {
+			t.Errorf("expected allowed tools to contain 'search' and 'create', got %v", allowedNames)
+		}
+	})
+
+	t.Run("all enabled by default does not set allowlist", func(t *testing.T) {
+		bifrostTool := &schemas.ResponsesTool{
+			Type: schemas.ResponsesToolTypeMCP,
+			ResponsesToolMCP: &schemas.ResponsesToolMCP{
+				ServerLabel: "test-server",
+			},
+		}
+
+		toolset := &AnthropicMCPToolsetTool{
+			Type:          "mcp_toolset",
+			MCPServerName: "test-server",
+			// No default_config (defaults to enabled=true)
+		}
+
+		applyMCPToolsetConfigToBifrostTool(bifrostTool, toolset)
+
+		if bifrostTool.ResponsesToolMCP.AllowedTools != nil {
+			t.Error("expected AllowedTools to be nil when all tools are enabled by default")
+		}
+	})
+
+	t.Run("nil inputs are handled safely", func(t *testing.T) {
+		// Should not panic
+		applyMCPToolsetConfigToBifrostTool(nil, nil)
+		applyMCPToolsetConfigToBifrostTool(&schemas.ResponsesTool{}, nil)
 	})
 }

--- a/core/providers/azure/azure_test.go
+++ b/core/providers/azure/azure_test.go
@@ -76,6 +76,7 @@ func TestAzure(t *testing.T) {
 			VideoRemix:            false,
 			VideoList:             false,
 			VideoDelete:           false,
+			InterleavedThinking:  true,
 		},
 		DisableParallelFor: []string{"Transcription"}, // Azure Whisper has 3 calls/minute quota
 	}

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -181,8 +181,9 @@ func TestBedrock(t *testing.T) {
 		PromptCachingModel:  "claude-4.5-sonnet",
 		ImageEditModel:      "amazon.nova-canvas-v1:0",
 		ImageVariationModel: "amazon.nova-canvas-v1:0",
-		BatchExtraParams:    batchExtraParams,
-		FileExtraParams:     fileExtraParams,
+		InterleavedThinkingModel: "global.anthropic.claude-opus-4-5-20251101-v1:0",
+		BatchExtraParams:        batchExtraParams,
+		FileExtraParams:         fileExtraParams,
 		Scenarios: llmtests.TestScenarios{
 			TextCompletion:        false, // Not supported
 			SimpleChat:            true,
@@ -219,6 +220,7 @@ func TestBedrock(t *testing.T) {
 			ImageEdit:             true,
 			ImageVariation:        true,
 			StructuredOutputs:     true,
+			InterleavedThinking:  true,
 		},
 	}
 

--- a/core/providers/vertex/vertex_test.go
+++ b/core/providers/vertex/vertex_test.go
@@ -67,7 +67,8 @@ func TestVertex(t *testing.T) {
 			PromptCaching:         true,
 			ListModels:            false,
 			CountTokens:           true,
-			StructuredOutputs:     true, // Structured outputs with nullable enum support
+			StructuredOutputs:     true,  // Structured outputs with nullable enum support
+			InterleavedThinking:  true,
 		},
 	}
 

--- a/docs/providers/supported-providers/anthropic.mdx
+++ b/docs/providers/supported-providers/anthropic.mdx
@@ -32,6 +32,29 @@ Anthropic has significant structural differences from OpenAI's format. Bifrost p
 **Unsupported Operations** (❌): Embeddings, Speech, Transcriptions, and Image Generation are not supported by the upstream Anthropic API. These return `UnsupportedOperationError`.
 </Note>
 
+## Beta Headers
+
+Bifrost automatically manages Anthropic beta headers — detecting required headers from request features and injecting them. Headers are validated per provider to prevent unsupported headers from reaching the upstream API.
+
+| Beta Header | Anthropic | Azure | Vertex | Bedrock | Auto-Injected |
+|---|---|---|---|---|---|
+| `computer-use-2025-01-24` / `computer-use-2025-11-24` | ✅ | ✅ | ✅ | ✅ | ✅ (tool type detection) |
+| `structured-outputs-2025-11-13` | ✅ | ✅ | ❌ | ✅ | ✅ (strict/output_format) |
+| `advanced-tool-use-2025-11-20` | ✅ | ✅ | ❌ | ❌ | ✅ (defer_loading/input_examples/allowed_callers) |
+| `mcp-client-2025-11-20` | ✅ | ✅ | ❌ | ❌ | ✅ (mcp_servers detection) |
+| `prompt-caching-scope-2026-01-05` | ✅ | ✅ | ❌ | ❌ | ✅ (cache_control.scope) |
+| `compact-2026-01-12` | ✅ | ✅ | ✅ | ✅ | ✅ (compaction edit) |
+| `context-management-2025-06-27` | ✅ | ✅ | ✅ | ✅ | ✅ (clear edits) |
+| `files-api-2025-04-14` | ✅ | ✅ | ❌ | ❌ | ✅ (files endpoint) |
+| `interleaved-thinking-2025-05-14` | ✅ | ✅ | ✅ | ✅ | ✅ (thinking enabled/adaptive) |
+| `skills-2025-10-02` | ✅ | ✅ | ❌ | ❌ | Passthrough |
+| `context-1m-2025-08-07` | ✅ | ✅ | ✅ | ✅ | Passthrough |
+| `fast-mode-2026-02-01` | ✅ | ❌ | ❌ | ❌ | ✅ (speed=fast) |
+
+<Note>
+**Passthrough headers** are not auto-injected but are validated and forwarded when set manually via the `anthropic-beta` request header. Unknown headers are always forwarded for forward compatibility.
+</Note>
+
 ---
 
 # 1. Chat Completions

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -183,6 +183,22 @@ func hasPromptCachingScopeBetaHeader(headers map[string][]string) bool {
 	return false
 }
 
+func hasFastModeBetaHeader(headers map[string][]string) bool {
+	for k, v := range headers {
+		if strings.ToLower(k) != "anthropic-beta" {
+			continue
+		}
+		for _, headerValue := range v {
+			for beta := range strings.SplitSeq(headerValue, ",") {
+				if strings.HasPrefix(strings.TrimSpace(beta), anthropic.AnthropicFastModeBetaHeaderPrefix) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 // filterVertexUnsupportedBetaHeaders removes beta headers that Vertex AI doesn't support.
 // Vertex AI doesn't support: structured-outputs, advanced-tool-use, prompt-caching-scope, mcp-client.
 func filterVertexUnsupportedBetaHeaders(headers map[string][]string) map[string][]string {
@@ -213,7 +229,9 @@ func filterVertexUnsupportedBetaHeaders(headers map[string][]string) map[string]
 				if strings.HasPrefix(beta, anthropic.AnthropicAdvancedToolUseBetaHeaderPrefix) ||
 					strings.HasPrefix(beta, anthropic.AnthropicStructuredOutputsBetaHeaderPrefix) ||
 					strings.HasPrefix(beta, anthropic.AnthropicPromptCachingScopeBetaHeaderPrefix) ||
-					strings.HasPrefix(beta, anthropic.AnthropicMCPClientBetaHeaderPrefix) {
+					strings.HasPrefix(beta, anthropic.AnthropicMCPClientBetaHeaderPrefix) ||
+					strings.HasPrefix(beta, anthropic.AnthropicSkillsBetaHeaderPrefix) ||
+					strings.HasPrefix(beta, anthropic.AnthropicFastModeBetaHeaderPrefix) {
 					continue
 				}
 				filteredBetas = append(filteredBetas, beta)
@@ -372,7 +390,7 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 				bifrostCtx.SetValue(schemas.BifrostContextKeyExtraHeaders, passthroughHeaders)
 			}
 		}
-		if provider == schemas.Vertex && hasPromptCachingScopeBetaHeader(headers) {
+		if provider == schemas.Vertex && (hasPromptCachingScopeBetaHeader(headers) || hasFastModeBetaHeader(headers)) {
 			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
 			return nil
 		}


### PR DESCRIPTION
## Summary

Adds support for two new Anthropic beta features: interleaved thinking between tool calls and fast mode for Opus 4.6. This enables more sophisticated reasoning workflows and performance optimization for supported models.

## Changes

- Added `InterleavedThinking` and `FastMode` flags to test scenarios configuration
- Created dedicated test files for both features with comprehensive validation
- Added `Speed` parameter to Anthropic request types for fast mode support
- Implemented automatic beta header injection for `interleaved-thinking-2025-05-14` and `fast-mode-2026-02-01`
- Updated MCP client to use the newer `mcp-client-2025-11-20` format with simplified server definitions
- Added new MCP toolset types (`AnthropicMCPServerV2`, `AnthropicMCPToolsetTool`) for the updated API format
- Enhanced beta header management with prefix-aware deduplication to prevent conflicting versions
- Updated provider feature support matrices to reflect which providers support each beta feature
- Added proper parameter extraction and conversion for `speed` in both chat and responses endpoints

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations
- [ ] Transports (HTTP)
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate the new beta features with appropriate API keys and model access:

```sh
# Run comprehensive tests with interleaved thinking
go test ./core/providers/anthropic -v -run TestAnthropic

# Test fast mode (requires Opus 4.6 access)
# Enable FastMode: true in anthropic_test.go first
go test ./core/providers/anthropic -v -run TestAnthropic

# Verify beta header management
go test ./core/providers/anthropic -v -run TestAddMissingBetaHeadersToContext

# Test MCP client updates
go test ./core/providers/anthropic -v -run TestProviderBetaHeaderInjection
```

For interleaved thinking, set up a request with both `thinking` enabled and `tools` present. For fast mode, include `speed: "fast"` in `ExtraParams` with an Opus 4.6 model.

## Screenshots/Recordings

N/A - Backend API feature

## Breaking changes

- [ ] Yes
- [x] No

The changes maintain backward compatibility. The MCP format update uses new types alongside existing ones, and beta headers are auto-managed without breaking existing workflows.

## Related issues

N/A

## Security considerations

No security implications. The changes add new API parameters and beta headers but don't modify authentication, secrets handling, or data processing logic.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable