### PR TITLE
removed reason form telemetry events

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4801,6 +4801,22 @@ func executeRequestWithRetries[T any](
 		// Attempt the request
 		result, bifrostError = requestHandler()
 
+		// For streaming requests that returned success, check if the first chunk
+		// is actually an error (e.g., rate limits sent as SSE events in HTTP 200).
+		// This enables retries and fallbacks for providers that embed errors in
+		// the SSE stream instead of returning proper HTTP error status codes.
+		if bifrostError == nil {
+			if streamChan, ok := any(result).(chan *schemas.BifrostStreamChunk); ok {
+				checkedStream, drainDone, firstChunkErr := providerUtils.CheckFirstStreamChunkForError(streamChan)
+				if firstChunkErr != nil {
+					<-drainDone
+					bifrostError = firstChunkErr
+				} else {
+					result = any(checkedStream).(T)
+				}
+			}
+		}
+
 		// Check if result is a streaming channel - if so, defer span completion
 		if _, isStreamChan := any(result).(chan *schemas.BifrostStreamChunk); isStreamChan {
 			// For streaming requests, store the span handle in TraceStore keyed by trace ID
@@ -4850,7 +4866,8 @@ func executeRequestWithRetries[T any](
 		if (bifrostError.StatusCode != nil && retryableStatusCodes[*bifrostError.StatusCode]) ||
 			(bifrostError.Error != nil &&
 				(IsRateLimitErrorMessage(bifrostError.Error.Message) ||
-					(bifrostError.Error.Type != nil && IsRateLimitErrorMessage(*bifrostError.Error.Type)))) {
+					(bifrostError.Error.Type != nil && IsRateLimitErrorMessage(*bifrostError.Error.Type)) ||
+					(bifrostError.Error.Code != nil && IsRateLimitErrorMessage(*bifrostError.Error.Code)))) {
 			shouldRetry = true
 			logger.Debug("detected rate limit error in message, will retry: %s", bifrostError.Error.Message)
 		}

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -399,6 +399,8 @@ func TestIsRateLimitError_AllPatterns(t *testing.T) {
 		"api rate limit",
 		"usage limit",
 		"concurrent requests limit",
+		"burst_rate",
+		"rate increased",
 	}
 
 	for _, pattern := range patterns {
@@ -479,6 +481,20 @@ func TestIsRateLimitError_EdgeCases(t *testing.T) {
 		message := "RATE LIMIT exceeded 🚫"
 		if !IsRateLimitErrorMessage(message) {
 			t.Error("Message with unicode should still detect rate limit pattern")
+		}
+	})
+
+	t.Run("DashScopeErrorCode", func(t *testing.T) {
+		// DashScope returns "limit_burst_rate" as the error code
+		if !IsRateLimitErrorMessage("limit_burst_rate") {
+			t.Error("DashScope error code 'limit_burst_rate' should be detected as rate limit error")
+		}
+	})
+
+	t.Run("DashScopeErrorMessage", func(t *testing.T) {
+		// DashScope returns this as the error message
+		if !IsRateLimitErrorMessage("Request rate increased too quickly, please slow down and try again") {
+			t.Error("DashScope error message should be detected as rate limit error")
 		}
 	})
 }

--- a/core/providers/utils/stream.go
+++ b/core/providers/utils/stream.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// CheckFirstStreamChunkForError reads the first chunk from a streaming channel to detect
+// errors returned inside HTTP 200 SSE streams (e.g., providers that send rate limit
+// errors as SSE events instead of HTTP 429).
+//
+// If the first chunk is an error, it drains the source channel (so the provider
+// goroutine can exit cleanly) and returns the error for synchronous handling,
+// enabling retries and fallbacks.
+//
+// If the first chunk is valid data, it returns a wrapped channel that re-emits
+// the first chunk followed by all remaining chunks from the source.
+//
+// If the source channel is closed immediately (empty stream), it returns a
+// closed channel with nil error.
+func CheckFirstStreamChunkForError(
+	stream chan *schemas.BifrostStreamChunk,
+) (chan *schemas.BifrostStreamChunk, <-chan struct{}, *schemas.BifrostError) {
+	firstChunk, ok := <-stream
+	if !ok {
+		// Channel closed immediately (empty stream)
+		ch := make(chan *schemas.BifrostStreamChunk)
+		close(ch)
+		done := make(chan struct{})
+		close(done)
+		return ch, done, nil
+	}
+
+	// Check if first chunk is an error
+	if firstChunk.BifrostError != nil && firstChunk.BifrostError.Error != nil &&
+		(firstChunk.BifrostError.Error.Message != "" || firstChunk.BifrostError.Error.Code != nil || firstChunk.BifrostError.Error.Type != nil) {
+		// Drain source channel to let the provider goroutine exit cleanly
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for range stream {
+			}
+		}()
+		return nil, done, firstChunk.BifrostError
+	}
+
+	// First chunk is valid data — wrap channel to re-inject it
+	done := make(chan struct{})
+	wrapped := make(chan *schemas.BifrostStreamChunk, max(cap(stream), 1))
+	wrapped <- firstChunk
+	go func() {
+		defer close(done)
+		defer close(wrapped)
+		for chunk := range stream {
+			wrapped <- chunk
+		}
+	}()
+	return wrapped, done, nil
+}

--- a/core/providers/utils/stream_test.go
+++ b/core/providers/utils/stream_test.go
@@ -1,0 +1,196 @@
+package utils
+
+import (
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestCheckFirstStreamChunk_ErrorInFirstChunk(t *testing.T) {
+	stream := make(chan *schemas.BifrostStreamChunk, 2)
+	stream <- &schemas.BifrostStreamChunk{
+		BifrostError: &schemas.BifrostError{
+			Error: &schemas.ErrorField{
+				Code:    schemas.Ptr("limit_burst_rate"),
+				Message: "Request rate increased too quickly",
+			},
+		},
+	}
+	close(stream)
+
+	_, drainDone, err := CheckFirstStreamChunkForError(stream)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	<-drainDone
+	if err.Error.Message != "Request rate increased too quickly" {
+		t.Errorf("unexpected error message: %s", err.Error.Message)
+	}
+	if err.Error.Code == nil || *err.Error.Code != "limit_burst_rate" {
+		t.Errorf("unexpected error code: %v", err.Error.Code)
+	}
+}
+
+func TestCheckFirstStreamChunk_ValidFirstChunk(t *testing.T) {
+	stream := make(chan *schemas.BifrostStreamChunk, 3)
+	chunk1 := &schemas.BifrostStreamChunk{
+		BifrostChatResponse: &schemas.BifrostChatResponse{
+			ID: "chatcmpl-123",
+		},
+	}
+	chunk2 := &schemas.BifrostStreamChunk{
+		BifrostChatResponse: &schemas.BifrostChatResponse{
+			ID: "chatcmpl-123",
+		},
+	}
+	stream <- chunk1
+	stream <- chunk2
+	close(stream)
+
+	wrapped, _, err := CheckFirstStreamChunkForError(stream)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// First chunk should be re-injected
+	got1 := <-wrapped
+	if got1.BifrostChatResponse == nil || got1.BifrostChatResponse.ID != "chatcmpl-123" {
+		t.Error("first chunk not re-injected correctly")
+	}
+
+	// Second chunk should follow
+	got2 := <-wrapped
+	if got2.BifrostChatResponse == nil || got2.BifrostChatResponse.ID != "chatcmpl-123" {
+		t.Error("second chunk not forwarded correctly")
+	}
+
+	// Channel should be closed
+	_, ok := <-wrapped
+	if ok {
+		t.Error("expected wrapped channel to be closed")
+	}
+}
+
+func TestCheckFirstStreamChunk_EmptyStream(t *testing.T) {
+	stream := make(chan *schemas.BifrostStreamChunk)
+	close(stream)
+
+	wrapped, _, err := CheckFirstStreamChunkForError(stream)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Wrapped channel should be closed
+	_, ok := <-wrapped
+	if ok {
+		t.Error("expected wrapped channel to be closed")
+	}
+}
+
+func TestCheckFirstStreamChunk_ErrorInSecondChunk(t *testing.T) {
+	stream := make(chan *schemas.BifrostStreamChunk, 3)
+	stream <- &schemas.BifrostStreamChunk{
+		BifrostChatResponse: &schemas.BifrostChatResponse{
+			ID: "chatcmpl-123",
+		},
+	}
+	stream <- &schemas.BifrostStreamChunk{
+		BifrostError: &schemas.BifrostError{
+			Error: &schemas.ErrorField{
+				Message: "some error in second chunk",
+			},
+		},
+	}
+	close(stream)
+
+	// Should NOT return error — only first chunk matters for retry
+	wrapped, _, err := CheckFirstStreamChunkForError(stream)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Read all chunks
+	got1 := <-wrapped
+	if got1.BifrostChatResponse == nil {
+		t.Error("first chunk should be valid data")
+	}
+	got2 := <-wrapped
+	if got2.BifrostError == nil {
+		t.Error("second chunk should be the error")
+	}
+
+	_, ok := <-wrapped
+	if ok {
+		t.Error("expected wrapped channel to be closed")
+	}
+}
+
+func TestCheckFirstStreamChunk_ErrorDrainsSource(t *testing.T) {
+	stream := make(chan *schemas.BifrostStreamChunk, 5)
+	stream <- &schemas.BifrostStreamChunk{
+		BifrostError: &schemas.BifrostError{
+			Error: &schemas.ErrorField{
+				Message: "rate limit error",
+			},
+		},
+	}
+	// Add more chunks that should be drained
+	stream <- &schemas.BifrostStreamChunk{
+		BifrostChatResponse: &schemas.BifrostChatResponse{ID: "1"},
+	}
+	stream <- &schemas.BifrostStreamChunk{
+		BifrostChatResponse: &schemas.BifrostChatResponse{ID: "2"},
+	}
+	close(stream)
+
+	_, drainDone, err := CheckFirstStreamChunkForError(stream)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	<-drainDone
+	if err.Error.Message != "rate limit error" {
+		t.Errorf("unexpected error message: %s", err.Error.Message)
+	}
+}
+
+func TestCheckFirstStreamChunk_ErrorWithEmptyMessage(t *testing.T) {
+	// Error with empty message and no code/type should NOT be treated as an error
+	stream := make(chan *schemas.BifrostStreamChunk, 2)
+	stream <- &schemas.BifrostStreamChunk{
+		BifrostError: &schemas.BifrostError{
+			Error: &schemas.ErrorField{
+				Message: "",
+			},
+		},
+	}
+	close(stream)
+
+	wrapped, _, err := CheckFirstStreamChunkForError(stream)
+	if err != nil {
+		t.Fatalf("unexpected error for empty message: %v", err)
+	}
+	// Should be treated as valid chunk
+	<-wrapped
+}
+
+func TestCheckFirstStreamChunk_CodeOnlyError(t *testing.T) {
+	// Error with code but no message should be treated as an error
+	stream := make(chan *schemas.BifrostStreamChunk, 2)
+	stream <- &schemas.BifrostStreamChunk{
+		BifrostError: &schemas.BifrostError{
+			Error: &schemas.ErrorField{
+				Code: schemas.Ptr("limit_burst_rate"),
+			},
+		},
+	}
+	close(stream)
+
+	_, drainDone, err := CheckFirstStreamChunkForError(stream)
+	if err == nil {
+		t.Fatal("expected error for code-only error, got nil")
+	}
+	<-drainDone
+	if err.Error.Code == nil || *err.Error.Code != "limit_burst_rate" {
+		t.Errorf("unexpected error code: %v", err.Error.Code)
+	}
+}

--- a/core/utils.go
+++ b/core/utils.go
@@ -48,6 +48,8 @@ var rateLimitPatterns = []string{
 	"api rate limit",
 	"usage limit",
 	"concurrent requests limit",
+	"burst_rate",
+	"rate increased",
 }
 
 // dynamicallyConfigurableProviders is the list of providers that can be dynamically configured.

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -806,7 +806,7 @@ These are the same **Prometheus-style metrics** from the telemetry plugin, pushe
 |--------|------|-------------|
 | `bifrost_upstream_requests_total` | Counter | Total requests to upstream providers |
 | `bifrost_success_requests_total` | Counter | Successful upstream requests |
-| `bifrost_error_requests_total` | Counter | Error requests with reason labels |
+| `bifrost_error_requests_total` | Counter | Error requests with status code labels |
 | `bifrost_input_tokens_total` | Counter | Total input tokens |
 | `bifrost_output_tokens_total` | Counter | Total output tokens |
 | `bifrost_cache_hits_total` | Counter | Cache hits |

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -49,7 +49,7 @@ These metrics track requests forwarded to AI providers:
 |--------|------|-------------|---------|
 | `bifrost_upstream_requests_total` | Counter | Total requests forwarded to upstream providers | Base Labels, custom labels |
 | `bifrost_success_requests_total` | Counter | Total successful requests to upstream providers | Base Labels, custom labels |
-| `bifrost_error_requests_total` | Counter | Total failed requests to upstream providers | Base Labels, `reason`, custom labels |
+| `bifrost_error_requests_total` | Counter | Total failed requests to upstream providers | Base Labels, `status_code`, custom labels |
 | `bifrost_upstream_latency_seconds` | Histogram | Latency of upstream provider requests | Base Labels, `is_success`, custom labels |
 | `bifrost_input_tokens_total` | Counter | Total input tokens sent to upstream providers | Base Labels, custom labels |
 | `bifrost_output_tokens_total` | Counter | Total output tokens received from upstream providers | Base Labels, custom labels |

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -237,7 +237,7 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 			Name: "bifrost_error_requests_total",
 			Help: "Total number of error requests forwarded to upstream providers by Bifrost.",
 		},
-		append(append(defaultBifrostLabels, "reason"), filteredCustomLabels...),
+		append(append(defaultBifrostLabels, "status_code"), filteredCustomLabels...),
 	)
 
 	bifrostInputTokensTotal := factory.NewCounterVec(
@@ -467,10 +467,14 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 
 		// Record error and success counts
 		if bifrostErr != nil {
-			// Add reason to label values (create new slice to avoid modifying original)
+			// Add status_code to label values (create new slice to avoid modifying original)
+			statusCode := "unknown"
+			if bifrostErr.StatusCode != nil {
+				statusCode = strconv.Itoa(*bifrostErr.StatusCode)
+			}
 			errorPromLabelValues := make([]string, 0, len(promLabelValues)+1)
 			errorPromLabelValues = append(errorPromLabelValues, promLabelValues[:len(p.defaultBifrostLabels)]...) // all default labels
-			errorPromLabelValues = append(errorPromLabelValues, bifrostErr.Error.Message)                         // reason
+			errorPromLabelValues = append(errorPromLabelValues, statusCode)                                       // status_code
 			errorPromLabelValues = append(errorPromLabelValues, promLabelValues[len(p.defaultBifrostLabels):]...) // then custom labels
 
 			p.ErrorRequestsTotal.WithLabelValues(errorPromLabelValues...).Inc()

--- a/tests/integrations/python/pyproject.toml
+++ b/tests/integrations/python/pyproject.toml
@@ -121,3 +121,6 @@ exclude_lines = [
     "if TYPE_CHECKING:",
 ]
 
+
+[tool.uv]
+exclude-newer = "7 days"


### PR DESCRIPTION
## Summary

Updates the telemetry plugin to track HTTP status codes instead of error messages for better error categorization and monitoring in Prometheus metrics.

## Changes

- Changed the `bifrost_error_requests_total` metric label from "reason" to "status_code"
- Modified error tracking logic to extract and use HTTP status codes from `BifrostError` objects
- Added fallback to "unknown" status code when no status code is available
- Updated comments to reflect the new status_code labeling approach

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that error metrics are properly labeled with status codes by triggering various error conditions and checking the Prometheus metrics endpoint.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Test by making requests that result in different HTTP error codes (400, 401, 500, etc.) and verify the `bifrost_error_requests_total` metric shows the correct status_code labels.

## Screenshots/Recordings

## Breaking changes

- [x] Yes
- [ ] No

This changes the Prometheus metric label from "reason" to "status_code", which will break existing dashboards or alerting rules that depend on the "reason" label for the `bifrost_error_requests_total` metric.

## Related issues

## Security considerations

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable