### PR TITLE
fix: use incremental delta writes for governance usage dumps

### DIFF
--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1746,67 +1746,103 @@ func (gs *LocalGovernanceStore) DumpRateLimits(ctx context.Context, tokenBaselin
 		return true // continue
 	})
 
-	// Prepare rate limit usage updates with baselines
-	type rateLimitUpdate struct {
+	// Snapshot current in-memory values for delta computation
+	type rateLimitSnapshot struct {
 		ID                  string
 		TokenCurrentUsage   int64
 		RequestCurrentUsage int64
 	}
-	var rateLimitUpdates []rateLimitUpdate
+	var snapshots []rateLimitSnapshot
 	for rateLimitID := range rateLimitIDs {
 		if rateLimitValue, exists := gs.rateLimits.Load(rateLimitID); exists && rateLimitValue != nil {
 			if rateLimit, ok := rateLimitValue.(*configstoreTables.TableRateLimit); ok && rateLimit != nil {
-				update := rateLimitUpdate{
+				snapshots = append(snapshots, rateLimitSnapshot{
 					ID:                  rateLimit.ID,
 					TokenCurrentUsage:   rateLimit.TokenCurrentUsage,
 					RequestCurrentUsage: rateLimit.RequestCurrentUsage,
-				}
-				if tokenBaseline, exists := tokenBaselines[rateLimit.ID]; exists {
-					update.TokenCurrentUsage += tokenBaseline
-				}
-				if requestBaseline, exists := requestBaselines[rateLimit.ID]; exists {
-					update.RequestCurrentUsage += requestBaseline
-				}
-				rateLimitUpdates = append(rateLimitUpdates, update)
+				})
 			}
 		}
 	}
 
-	// Save all updated rate limits to database using direct UPDATE to avoid overwriting config fields
-	if len(rateLimitUpdates) > 0 && gs.configStore != nil {
-		if err := gs.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-			for _, update := range rateLimitUpdates {
-				// Direct UPDATE only updates usage fields
-				// This prevents overwriting max_limit or reset_duration that may have been changed by other nodes/requests
-				result := tx.WithContext(ctx).
-					Session(&gorm.Session{SkipHooks: true}).
-					Model(&configstoreTables.TableRateLimit{}).
-					Where("id = ?", update.ID).
-					Updates(map[string]interface{}{
-						"token_current_usage":   update.TokenCurrentUsage,
-						"request_current_usage": update.RequestCurrentUsage,
-					})
-
-				if result.Error != nil {
-					return fmt.Errorf("failed to dump rate limit %s: %w", update.ID, result.Error)
-				}
-			}
-			return nil
-		}); err != nil {
-			// Check if error is a deadlock (SQLSTATE 40P01 for PostgreSQL, 1213 for MySQL)
-			errStr := err.Error()
-			isDeadlock := strings.Contains(errStr, "deadlock") ||
-				strings.Contains(errStr, "40P01") ||
-				strings.Contains(errStr, "1213")
-
-			if isDeadlock {
-				// Deadlock means another node is updating the same rows - this is fine!
-				// Our usage data will be synced via gossip and written in the next dump cycle
-				gs.logger.Debug("Rate limit dump encountered deadlock (another node is updating) - will retry next cycle")
-				return nil // Not a real error in multi-node setup
-			}
-			return fmt.Errorf("failed to dump rate limits to database: %w", err)
+	if len(snapshots) > 0 && gs.configStore != nil {
+		// Compute deltas: how much usage this replica accumulated since last dump
+		gs.LastDBUsagesRateLimitsTokensMu.RLock()
+		gs.LastDBUsagesRateLimitsRequestsMu.RLock()
+		type rateLimitDelta struct {
+			ID           string
+			TokenDelta   int64
+			RequestDelta int64
 		}
+		var deltas []rateLimitDelta
+		for _, snap := range snapshots {
+			lastTokens := gs.LastDBUsagesTokensRateLimits[snap.ID]     // 0 if not found
+			lastRequests := gs.LastDBUsagesRequestsRateLimits[snap.ID] // 0 if not found
+			tokenDelta := snap.TokenCurrentUsage - lastTokens
+			requestDelta := snap.RequestCurrentUsage - lastRequests
+			if tokenBaseline, exists := tokenBaselines[snap.ID]; exists {
+				tokenDelta += tokenBaseline
+			}
+			if requestBaseline, exists := requestBaselines[snap.ID]; exists {
+				requestDelta += requestBaseline
+			}
+			// Only write if there is a meaningful change
+			if tokenDelta != 0 || requestDelta != 0 {
+				deltas = append(deltas, rateLimitDelta{
+					ID:           snap.ID,
+					TokenDelta:   tokenDelta,
+					RequestDelta: requestDelta,
+				})
+			}
+		}
+		gs.LastDBUsagesRateLimitsRequestsMu.RUnlock()
+		gs.LastDBUsagesRateLimitsTokensMu.RUnlock()
+
+		if len(deltas) > 0 {
+			if err := gs.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+				for _, d := range deltas {
+					// Atomic increment: SET field = field + delta
+					// This is safe for multi-replica: each replica only adds its own delta
+					result := tx.WithContext(ctx).
+						Session(&gorm.Session{SkipHooks: true}).
+						Model(&configstoreTables.TableRateLimit{}).
+						Where("id = ?", d.ID).
+						Updates(map[string]interface{}{
+							"token_current_usage":   gorm.Expr("token_current_usage + ?", d.TokenDelta),
+							"request_current_usage": gorm.Expr("request_current_usage + ?", d.RequestDelta),
+						})
+
+					if result.Error != nil {
+						return fmt.Errorf("failed to dump rate limit %s: %w", d.ID, result.Error)
+					}
+				}
+				return nil
+			}); err != nil {
+				// Check if error is a deadlock (SQLSTATE 40P01 for PostgreSQL, 1213 for MySQL)
+				errStr := err.Error()
+				isDeadlock := strings.Contains(errStr, "deadlock") ||
+					strings.Contains(errStr, "40P01") ||
+					strings.Contains(errStr, "1213")
+
+				if isDeadlock {
+					// Deadlock means another node is updating the same rows concurrently.
+					// Do NOT update LastDBUsages so the delta will be retried in the next cycle.
+					gs.logger.Debug("Rate limit dump encountered deadlock (another node is updating) - will retry next cycle")
+					return nil
+				}
+				return fmt.Errorf("failed to dump rate limits to database: %w", err)
+			}
+		}
+
+		// Update last-written tracking so next dump computes the correct delta
+		gs.LastDBUsagesRateLimitsTokensMu.Lock()
+		gs.LastDBUsagesRateLimitsRequestsMu.Lock()
+		for _, snap := range snapshots {
+			gs.LastDBUsagesTokensRateLimits[snap.ID] = snap.TokenCurrentUsage
+			gs.LastDBUsagesRequestsRateLimits[snap.ID] = snap.RequestCurrentUsage
+		}
+		gs.LastDBUsagesRateLimitsRequestsMu.Unlock()
+		gs.LastDBUsagesRateLimitsTokensMu.Unlock()
 	}
 	return nil
 }
@@ -1822,58 +1858,85 @@ func (gs *LocalGovernanceStore) DumpBudgets(ctx context.Context, baselines map[s
 		baselines = map[string]float64{}
 	}
 
-	budgets := make(map[string]*configstoreTables.TableBudget)
+	// Snapshot current in-memory values for delta computation
+	type budgetSnapshot struct {
+		ID           string
+		CurrentUsage float64
+	}
+	var snapshots []budgetSnapshot
 
 	gs.budgets.Range(func(key, value interface{}) bool {
-		// Type-safe conversion
 		keyStr, keyOk := key.(string)
 		budget, budgetOk := value.(*configstoreTables.TableBudget)
-
 		if keyOk && budgetOk && budget != nil {
-			budgets[keyStr] = budget // Store budget by ID
+			snapshots = append(snapshots, budgetSnapshot{
+				ID:           keyStr,
+				CurrentUsage: budget.CurrentUsage,
+			})
 		}
-		return true // continue iteration
+		return true
 	})
 
-	if len(budgets) > 0 && gs.configStore != nil {
-		if err := gs.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-			// Update each budget atomically using direct UPDATE to avoid deadlocks
-			// (SELECT + Save pattern causes deadlocks when multiple instances run concurrently)
-			for _, inMemoryBudget := range budgets {
-				// Calculate the new usage value
-				newUsage := inMemoryBudget.CurrentUsage
-				if baseline, exists := baselines[inMemoryBudget.ID]; exists {
-					newUsage += baseline
-				}
-
-				// Direct UPDATE avoids read-then-write lock escalation that causes deadlocks
-				// Use Session with SkipHooks to avoid triggering BeforeSave hook validation
-				result := tx.WithContext(ctx).
-					Session(&gorm.Session{SkipHooks: true}).
-					Model(&configstoreTables.TableBudget{}).
-					Where("id = ?", inMemoryBudget.ID).
-					Update("current_usage", newUsage)
-
-				if result.Error != nil {
-					return fmt.Errorf("failed to update budget %s: %w", inMemoryBudget.ID, result.Error)
-				}
-			}
-			return nil
-		}); err != nil {
-			// Check if error is a deadlock (SQLSTATE 40P01 for PostgreSQL, 1213 for MySQL)
-			errStr := err.Error()
-			isDeadlock := strings.Contains(errStr, "deadlock") ||
-				strings.Contains(errStr, "40P01") ||
-				strings.Contains(errStr, "1213")
-
-			if isDeadlock {
-				// Deadlock means another node is updating the same rows - this is fine!
-				// Our usage data will be synced via gossip and written in the next dump cycle
-				gs.logger.Debug("Budget dump encountered deadlock (another node is updating) - will retry next cycle")
-				return nil // Not a real error in multi-node setup
-			}
-			return fmt.Errorf("failed to dump budgets to database: %w", err)
+	if len(snapshots) > 0 && gs.configStore != nil {
+		// Compute deltas: how much usage this replica accumulated since last dump
+		gs.LastDBUsagesBudgetsMu.RLock()
+		type budgetDelta struct {
+			ID    string
+			Delta float64
 		}
+		var deltas []budgetDelta
+		for _, snap := range snapshots {
+			lastWritten := gs.LastDBUsagesBudgets[snap.ID] // 0 if not found (first dump after startup)
+			delta := snap.CurrentUsage - lastWritten
+			if baseline, exists := baselines[snap.ID]; exists {
+				delta += baseline
+			}
+			// Only write if there is a meaningful change to avoid unnecessary DB writes
+			if delta > 0.0001 || delta < -0.0001 {
+				deltas = append(deltas, budgetDelta{ID: snap.ID, Delta: delta})
+			}
+		}
+		gs.LastDBUsagesBudgetsMu.RUnlock()
+
+		if len(deltas) > 0 {
+			if err := gs.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+				for _, d := range deltas {
+					// Atomic increment: SET current_usage = current_usage + delta
+					// This is safe for multi-replica: each replica only adds its own delta
+					result := tx.WithContext(ctx).
+						Session(&gorm.Session{SkipHooks: true}).
+						Model(&configstoreTables.TableBudget{}).
+						Where("id = ?", d.ID).
+						Update("current_usage", gorm.Expr("current_usage + ?", d.Delta))
+
+					if result.Error != nil {
+						return fmt.Errorf("failed to update budget %s: %w", d.ID, result.Error)
+					}
+				}
+				return nil
+			}); err != nil {
+				// Check if error is a deadlock (SQLSTATE 40P01 for PostgreSQL, 1213 for MySQL)
+				errStr := err.Error()
+				isDeadlock := strings.Contains(errStr, "deadlock") ||
+					strings.Contains(errStr, "40P01") ||
+					strings.Contains(errStr, "1213")
+
+				if isDeadlock {
+					// Deadlock means another node is updating the same rows concurrently.
+					// Do NOT update LastDBUsages so the delta will be retried in the next cycle.
+					gs.logger.Debug("Budget dump encountered deadlock (another node is updating) - will retry next cycle")
+					return nil
+				}
+				return fmt.Errorf("failed to dump budgets to database: %w", err)
+			}
+		}
+
+		// Update last-written tracking so next dump computes the correct delta
+		gs.LastDBUsagesBudgetsMu.Lock()
+		for _, snap := range snapshots {
+			gs.LastDBUsagesBudgets[snap.ID] = snap.CurrentUsage
+		}
+		gs.LastDBUsagesBudgetsMu.Unlock()
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
Use incremental delta writes for governance usage dumps to prevent multi-replica data loss

DumpBudgets and DumpRateLimits were using absolute SET writes (SET current_usage = X), causing each replica to overwrite the others' accumulated usage every 10s flush cycle. Changed to delta-based atomic increments (SET current_usage = current_usage + delta) using the existing but unused LastDBUsages tracking maps, so each replica only contributes its own incremental usage to the database.

The bug is a last-writer-wins problem in plugins/governance/store.go. The two dump functions — DumpBudgets (line 1851) and DumpRateLimits (line 1776) — were using absolute SET writes:
-- Before (broken): each replica overwrites with its local view
```
UPDATE budgets SET current_usage = 5.0 WHERE id = 'budget-123';
UPDATE rate_limits SET token_current_usage = 42, request_current_usage = 10 WHERE id = 'rl-456';
```
Every 10 seconds, each Kubernetes replica dumps its in-memory accumulation to the database. Since each replica only sees its own traffic, it writes a partial value that overwrites the contributions of all other replicas. The database value oscillates depending on which replica flushes last.
What Was Broken

Step | Replica A | Replica B | DB (truth)
-- | -- | -- | --
t=0 | mem=0 | mem=0 | 0
t=5s | handles $5 → mem=5 | handles $3 → mem=3 | 0
t=10s | dumps → SET 5 |   | 5
t=10s |   | dumps → SET 3 | 3 (lost $5!)
t=15s | handles $2 → mem=7 | handles $1 → mem=4 | 3
t=20s | dumps → SET 7 |   | 7
t=20s |   | dumps → SET 4 | 4 (lost $7!)

The value alternates between replicas' views. The true total ($11) is never reached.

## Changes

TLDR: `plugins/governance/store.go` — `DumpBudgets()` and `DumpRateLimits()` rewritten to use delta-based atomic increments via `gorm.Expr()`, leveraging the pre-existing `LastDBUsages` tracking maps.

Changed both DumpBudgets and DumpRateLimits from absolute SET to incremental delta-based writes:
-- After (fixed): each replica only adds its own delta
```
UPDATE budgets SET current_usage = current_usage + 2.0 WHERE id = 'budget-123';
UPDATE rate_limits SET token_current_usage = token_current_usage + 5, 
                       request_current_usage = request_current_usage + 1 WHERE id = 'rl-456';
```
The mechanism uses the already-existing (but unused) LastDBUsages* maps:
1. Snapshot the current in-memory values
2. Compute delta = current_in_memory - last_written_value (what this replica accumulated since its last dump)
3. Atomic SQL increment using gorm.Expr("current_usage + ?", delta) — each replica only adds its own contribution
4. Update LastDBUsages* after successful write, so the next cycle computes a fresh delta
5. On deadlock, skip the LastDBUsages* update so the delta is retried in the next cycle (no data loss)
The reset paths (ResetExpiredBudgetsInMemory, ResetExpiredRateLimitsInMemory) already correctly zero both the in-memory counter and the LastDBUsages* tracker, so resets produce the correct delta (0 - 0 = 0, then new usage accumulates normally).

Step | Replica A (delta) | Replica B (delta) | DB (truth)
-- | -- | -- | --
t=0 | mem=0, last=0 | mem=0, last=0 | 0
t=5s | handles $5 → mem=5 | handles $3 → mem=3 | 0
t=10s | delta=5−0=5, ADD 5 | delta=3−0=3, ADD 3 | 8 (correct!)
t=15s | handles $2 → mem=7 | handles $1 → mem=4 | 8
t=20s | delta=7−5=2, ADD 2 | delta=4−3=1, ADD 1 | 11 (correct!)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run 2 replicas of bifrost
Create 1 VK with a budget limit assigned
Generate inference calls on both instances (individually or via loadbalancer)

Get the current usage of the budget associated to that virtual key by inspecting the database (PG in that case)
```
select current_usage from governance_budgets where id = 'budget_id';
```

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


