### PR TITLE
fix: prevent edit mode activation when clicking interactive elements in message views

### DIFF
--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -177,17 +177,17 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete, onNaviga
 						</SheetTitle>
 					</div>
 					<div className="flex items-center">
-						<Button variant="ghost" className="size-8" disabled={!hasPrev} onClick={() => onNavigate?.("prev")} aria-label="Previous log" data-testid="logdetails-prev-button">
+						<Button variant="ghost" className="size-8" disabled={!hasPrev} onClick={() => onNavigate?.("prev")} aria-label="Previous log" data-testid="logdetails-prev-button" type="button">
 							<ChevronUp className="size-4" />
 						</Button>
-						<Button variant="ghost" className="size-8" disabled={!hasNext} onClick={() => onNavigate?.("next")} aria-label="Next log" data-testid="logdetails-next-button">
+						<Button variant="ghost" className="size-8" disabled={!hasNext} onClick={() => onNavigate?.("next")} aria-label="Next log" data-testid="logdetails-next-button" type="button">
 							<ChevronDown className="size-4" />
 						</Button>
 					</div>
 					<AlertDialog>
 						<DropdownMenu>
 							<DropdownMenuTrigger asChild>
-								<Button variant="ghost" className="size-8">
+								<Button variant="ghost" className="size-8" type="button">
 									<MoreVertical className="h-3 w-3" />
 								</Button>
 							</DropdownMenuTrigger>

--- a/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
@@ -83,17 +83,17 @@ export function MCPLogDetailSheet({ log, open, onOpenChange, handleDelete, onNav
 						</SheetTitle>
 					</div>
 					<div className="flex items-center">
-						<Button variant="ghost" className="size-8" disabled={!hasPrev} onClick={() => onNavigate?.("prev")} aria-label="Previous log" data-testid="mcp-log-nav-prev">
+						<Button variant="ghost" className="size-8" disabled={!hasPrev} onClick={() => onNavigate?.("prev")} aria-label="Previous log" data-testid="mcp-log-nav-prev" type="button">
 							<ChevronUp className="size-4" />
 						</Button>
-						<Button variant="ghost" className="size-8" disabled={!hasNext} onClick={() => onNavigate?.("next")} aria-label="Next log" data-testid="mcp-log-nav-next">
+						<Button variant="ghost" className="size-8" disabled={!hasNext} onClick={() => onNavigate?.("next")} aria-label="Next log" data-testid="mcp-log-nav-next" type="button">
 							<ChevronDown className="size-4" />
 						</Button>
 					</div>
 					<AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
 						<DropdownMenu>
 							<DropdownMenuTrigger asChild>
-								<Button variant="ghost" className="size-8">
+								<Button variant="ghost" className="size-8" type="button">
 									<MoreVertical className="h-3 w-3" />
 								</Button>
 							</DropdownMenuTrigger>

--- a/ui/app/workspace/plugins/sheets/pluginSequenceSheet.tsx
+++ b/ui/app/workspace/plugins/sheets/pluginSequenceSheet.tsx
@@ -177,7 +177,7 @@ export default function PluginSequenceSheet({ open, onClose, plugins }: PluginSe
 						<Button type="button" variant="outline" onClick={onClose} disabled={isLoading} data-testid="plugin-sequence-cancel-button">
 							Cancel
 						</Button>
-						<Button onClick={handleSave} disabled={isLoading} isLoading={isLoading} data-testid="plugin-sequence-save-button">
+						<Button onClick={handleSave} disabled={isLoading} isLoading={isLoading} data-testid="plugin-sequence-save-button" type="button">
 							Save Sequence
 						</Button>
 					</div>

--- a/ui/app/workspace/routing-rules/components/celBuilder/celRuleBuilder.tsx
+++ b/ui/app/workspace/routing-rules/components/celBuilder/celRuleBuilder.tsx
@@ -122,7 +122,7 @@ export function CELRuleBuilder({
 			<div className="space-y-2">
 				<div className="flex items-center justify-between">
 					<Label>CEL Expression Preview</Label>
-					<Button variant="outline" size="sm" onClick={handleCopy} disabled={!celExpression} className="gap-2">
+					<Button variant="outline" size="sm" onClick={handleCopy} disabled={!celExpression} className="gap-2" type="button">
 						{copied ? (
 							<>
 								<Check className="h-4 w-4" />

--- a/ui/components/prompts/components/messagesView/assistantMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/assistantMessageView.tsx
@@ -156,8 +156,10 @@ export function AssistantMessageView({
 				) : (
 					<div
 						className={!disabled && !isStreaming ? "cursor-text" : undefined}
-						onClick={() => {
-							if (!disabled && !isStreaming) setEditMode(true);
+						onClick={(e) => {
+							if (disabled || isStreaming || editMode) return;
+							if ((e.target as HTMLElement).closest("button, a, [role='button']")) return;
+							setEditMode(true);
 						}}
 					>
 						<Markdown content={content} isStreaming={isStreaming} className="text-muted-foreground" />

--- a/ui/components/prompts/components/messagesView/systemMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/systemMessageView.tsx
@@ -119,7 +119,7 @@ export function SystemMessageView({
 				</div>
 			</div>
 
-			<div onClick={() => { if (!disabled && !editMode) setEditMode(true); }} className={!disabled && !editMode ? "cursor-text" : ""}>
+			<div onClick={(e) => { if (!disabled && !editMode && !(e.target as HTMLElement).closest("button, a, [role='button']")) setEditMode(true); }} className={!disabled && !editMode ? "cursor-text" : ""}>
 				{editMode ? (
 					<RichTextarea
 						autoFocus
@@ -168,8 +168,10 @@ export function SystemMessageView({
 				) : (
 					<div
 						className={!disabled ? "cursor-text" : undefined}
-						onClick={() => {
-							if (!disabled) setEditMode(true);
+						onClick={(e) => {
+							if (disabled || editMode) return;
+							if ((e.target as HTMLElement).closest("button, a, [role='button']")) return;
+							setEditMode(true);
 						}}
 					>
 						<Markdown content={content} className="text-muted-foreground" />

--- a/ui/components/prompts/components/messagesView/userMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/userMessageView.tsx
@@ -286,8 +286,10 @@ export function UserMessageView({
 				) : (
 					<div
 						className={!disabled ? "cursor-text" : undefined}
-						onClick={() => {
-							if (!disabled) setEditMode(true);
+						onClick={(e) => {
+							if (disabled || editMode) return;
+							if ((e.target as HTMLElement).closest("button, a, [role='button']")) return;
+							setEditMode(true);
 						}}
 					>
 						<Markdown content={content} className="text-muted-foreground" />


### PR DESCRIPTION
## Summary

Prevents edit mode from being triggered when clicking on interactive elements (buttons, links, or elements with button role) within message views. This fixes the issue where clicking on buttons or links inside messages would unintentionally activate edit mode.

## Changes

- Added event target checking in onClick handlers for assistant, system, and user message views
- Modified click handlers to check if the clicked element is within a button, link, or element with button role using `closest()` method
- Restructured conditional logic for better readability and early returns

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to a message view with interactive elements (buttons, links)
2. Click on buttons or links within the message content
3. Verify that edit mode is not triggered when clicking interactive elements
4. Click on non-interactive areas of the message to confirm edit mode still works
5. Test across all message types (assistant, system, user)

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a UI interaction improvement.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable