### PR TITLE
feat: add virtual key support to model filtering and selection

### DIFF
--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -558,13 +558,15 @@ type ListModelsResponse struct {
 // Query parameters:
 //   - query: Filter models by name (case-insensitive partial match)
 //   - provider: Filter by specific provider name
-//   - keys: Comma-separated list of key IDs to filter models accessible by those keys
+//   - keys: Comma-separated list of provider key UUIDs to filter models accessible by those keys
+//   - vks: Comma-separated list of virtual key UUIDs to filter models accessible by those virtual keys
 //   - limit: Maximum number of results to return (default: 5)
 func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 	// Parse query parameters
 	queryParam := string(ctx.QueryArgs().Peek("query"))
 	providerParam := string(ctx.QueryArgs().Peek("provider"))
 	keysParam := string(ctx.QueryArgs().Peek("keys"))
+	vksParam := string(ctx.QueryArgs().Peek("vks"))
 	limitParam := string(ctx.QueryArgs().Peek("limit"))
 	unfilteredParam := string(ctx.QueryArgs().Peek("unfiltered"))
 
@@ -588,10 +590,16 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 			models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
 		} else {
 			models = h.modelsManager.GetModelsForProvider(provider)
-			// Filter by keys if specified
-			if keysParam != "" {
-				keyIDs := strings.Split(keysParam, ",")
-				models = h.filterModelsByKeys(provider, models, keyIDs)
+			// Filter by keys/vks if specified
+			if keysParam != "" || vksParam != "" {
+				var keyIDs, vkValues []string
+				if keysParam != "" {
+					keyIDs = strings.Split(keysParam, ",")
+				}
+				if vksParam != "" {
+					vkValues = strings.Split(vksParam, ",")
+				}
+				models = h.filterModelsByKeys(ctx, provider, models, keyIDs, vkValues)
 			}
 		}
 		for _, model := range models {
@@ -615,10 +623,16 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 				models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
 			} else {
 				models = h.modelsManager.GetModelsForProvider(provider)
-				// Filter by keys if specified
-				if keysParam != "" {
-					keyIDs := strings.Split(keysParam, ",")
-					models = h.filterModelsByKeys(provider, models, keyIDs)
+				// Filter by keys/vks if specified
+				if keysParam != "" || vksParam != "" {
+					var keyIDs, vkValues []string
+					if keysParam != "" {
+						keyIDs = strings.Split(keysParam, ",")
+					}
+					if vksParam != "" {
+						vkValues = strings.Split(vksParam, ",")
+					}
+					models = h.filterModelsByKeys(ctx, provider, models, keyIDs, vkValues)
 				}
 
 			}
@@ -713,51 +727,86 @@ func keyAllowsModelForList(key schemas.Key, model string) bool {
 }
 
 // filterModelsByKeys filters models based on key-level model restrictions.
+// keyIDs contains provider key UUIDs; vkValues contains virtual key UUIDs.
 // A model is included in the result if at least one of the specified keys grants access to it.
-// A key grants access to a model when: the model is not blacklisted by that key AND
-// the key's allowlist is unrestricted (wildcard) or explicitly contains the model.
-// Empty allowlist (no wildcard) = deny-all for that key.
-func (h *ProviderHandler) filterModelsByKeys(provider schemas.ModelProvider, models []string, keyIDs []string) []string {
-	// Get provider config to access keys
+//
+// Provider key access: the model is not blacklisted AND the allowlist is unrestricted or explicitly contains it.
+// Virtual key access: the virtual key has a ProviderConfig for the given provider AND AllowedModels allows the model.
+func (h *ProviderHandler) filterModelsByKeys(ctx context.Context, provider schemas.ModelProvider, models []string, keyIDs []string, vkValues []string) []string {
+	// Get provider config to access provider-level keys
 	config, err := h.inMemoryStore.GetProviderConfigRaw(provider)
 	if err != nil {
 		logger.Warn("Failed to get config for provider %s: %v", provider, err)
 		return models
 	}
 
-	// Index keys by ID for fast lookup
+	// Index provider keys by ID for fast lookup
 	keyMap := make(map[string]schemas.Key, len(config.Keys))
 	for _, key := range config.Keys {
 		keyMap[key.ID] = key
 	}
 
-	// Collect only the keys referenced by keyIDs
-	matchedKeys := make([]schemas.Key, 0, len(keyIDs))
+	// Resolve provider key UUIDs
+	matchedProviderKeys := make([]schemas.Key, 0, len(keyIDs))
 	for _, keyID := range keyIDs {
 		if key, ok := keyMap[keyID]; ok {
-			matchedKeys = append(matchedKeys, key)
+			matchedProviderKeys = append(matchedProviderKeys, key)
 		}
 	}
 
-	// If none of the requested key IDs exist in config, fall back to returning all models
-	if len(matchedKeys) == 0 {
+	// Resolve virtual key IDs (UUIDs) via DB — never accept raw key values in the URL
+	var matchedVKProviderConfigs []tables.TableVirtualKeyProviderConfig
+	if len(vkValues) > 0 && h.dbStore != nil {
+		for _, vkID := range vkValues {
+			vk, err := h.dbStore.GetVirtualKey(ctx, vkID)
+			if err != nil {
+				continue // not found or db error — skip
+			}
+			if !vk.IsActive {
+				continue // ignore deactivated virtual keys
+			}
+			for _, pc := range vk.ProviderConfigs {
+				if schemas.ModelProvider(pc.Provider) == provider {
+					matchedVKProviderConfigs = append(matchedVKProviderConfigs, pc)
+					break
+				}
+			}
+		}
+	}
+
+	// If nothing matched at all, fall back to returning all models
+	if len(matchedProviderKeys) == 0 && len(matchedVKProviderConfigs) == 0 {
 		return models
 	}
 
 	// For each model, include it if at least one matched key grants access
 	filtered := make([]string, 0, len(models))
 	for _, model := range models {
-		for _, key := range matchedKeys {
-			// Blacklist wins over allowlist
+		granted := false
+
+		// Check provider keys: blacklist wins, then allowlist
+		for _, key := range matchedProviderKeys {
 			if key.BlacklistedModels.IsBlocked(model) {
 				continue
 			}
-			// Unrestricted (wildcard) key grants access to all non-blacklisted models;
-			// restricted key grants access only if the model is explicitly listed
 			if key.Models.IsUnrestricted() || key.Models.Contains(model) {
-				filtered = append(filtered, model)
+				granted = true
 				break
 			}
+		}
+
+		// Check virtual key provider configs
+		if !granted {
+			for _, pc := range matchedVKProviderConfigs {
+				if pc.AllowedModels.IsAllowed(model) {
+					granted = true
+					break
+				}
+			}
+		}
+
+		if granted {
+			filtered = append(filtered, model)
 		}
 	}
 	return filtered

--- a/ui/components/prompts/components/apiKeySelectorView.tsx
+++ b/ui/components/prompts/components/apiKeySelectorView.tsx
@@ -31,7 +31,7 @@ export function ApiKeySelectorView({
 
 	const allOptions = useMemo(() => {
 		const apiKeyOpts = providerKeys.map((k) => ({ label: k.name, value: k.key_id, group: "api" as const }));
-		const vkOpts = virtualKeys.map((vk) => ({ label: vk.name, value: vk.value, group: "virtual" as const }));
+		const vkOpts = virtualKeys.map((vk) => ({ label: vk.name, value: vk.id, group: "virtual" as const }));
 		return [{ label: "Auto (default)", value: "__auto__", group: "api" as const }, ...apiKeyOpts, ...vkOpts];
 	}, [providerKeys, virtualKeys]);
 

--- a/ui/components/prompts/fragments/settingsPanel.tsx
+++ b/ui/components/prompts/fragments/settingsPanel.tsx
@@ -5,10 +5,11 @@ import { Separator } from "@/components/ui/separator";
 import ModelParameters from "@/components/ui/custom/modelParameters";
 import { ModelParams } from "@/lib/types/prompts";
 import { getProviderLabel } from "@/lib/constants/logs";
-import { useGetAllKeysQuery, useGetProvidersQuery, useLazyGetModelsQuery } from "@/lib/store/apis/providersApi";
+import { useGetAllKeysQuery, useGetProvidersQuery } from "@/lib/store/apis/providersApi";
 import { useGetVirtualKeysQuery } from "@/lib/store";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { ModelProviderName } from "@/lib/types/config";
+import { ModelMultiselect } from "@/components/ui/modelMultiselect";
 import { Skeleton } from "@/components/ui/skeleton";
 import { usePromptContext } from "../context";
 import { VariablesTableView } from "../components/variablesTableView";
@@ -77,7 +78,6 @@ export function SettingsPanel() {
 	}, [configuredProviders, provider]);
 
 	const providerKeys = useMemo(() => (allKeys ?? []).filter((k) => k.provider === provider), [allKeys, provider]);
-	const providerKeyConfigs = useMemo(() => providerKeys.map((k) => ({ id: k.key_id, models: k.models })), [providerKeys]);
 
 	// Virtual keys filtered by selected provider
 	const providerVirtualKeys = useMemo(() => {
@@ -91,43 +91,21 @@ export function SettingsPanel() {
 		});
 	}, [virtualKeysData, provider]);
 
-	// Fallback: fetch all models for this provider (used when any key has no models restriction)
-	const [fetchModels, { data: modelsData }] = useLazyGetModelsQuery();
-	useEffect(() => {
-		if (provider) {
-			fetchModels({ provider, limit: 100, unfiltered: true });
-		}
-	}, [provider, fetchModels]);
-	const allProviderModels = useMemo(() => (modelsData?.models ?? []).map((m) => m.name), [modelsData]);
+	// Separate keys/vks to pass to model fetch for filtering.
+	const filterKeys = useMemo(() => {
+		const isProviderKey = providerKeys.some((k) => k.key_id === apiKeyId);
+		if (isProviderKey) return [apiKeyId];
+		const isVirtualKey = providerVirtualKeys.some((vk) => vk.id === apiKeyId);
+		if (isVirtualKey) return undefined;
+		// Auto: pass all provider key IDs
+		return providerKeys.map((k) => k.key_id);
+	}, [apiKeyId, providerKeys, providerVirtualKeys]);
 
-	// Build model list based on key selection
-	const availableModels = useMemo(() => {
-		if (apiKeyId !== "__auto__") {
-			// Specific key selected — find it in provider config
-			const key = providerKeyConfigs.find((k) => k.id === apiKeyId);
-			if (key?.models && key.models.length > 0) {
-				return key.models;
-			}
-			// Key has no model restriction → show all
-			return allProviderModels;
-		}
-
-		// Auto mode — blend models from all keys
-		// If any key has empty models (no restriction), show all models
-		const hasUnrestrictedKey = providerKeyConfigs.some((k) => !k.models || k.models.length === 0);
-		if (hasUnrestrictedKey || providerKeyConfigs.length === 0) {
-			return allProviderModels;
-		}
-
-		// All keys have specific models — show unique union
-		const modelSet = new Set<string>();
-		for (const k of providerKeyConfigs) {
-			for (const m of k.models ?? []) {
-				modelSet.add(m);
-			}
-		}
-		return Array.from(modelSet);
-	}, [apiKeyId, providerKeyConfigs, allProviderModels]);
+	const filterVks = useMemo(() => {
+		const isVirtualKey = providerVirtualKeys.some((vk) => vk.id === apiKeyId);
+		if (isVirtualKey) return [apiKeyId];
+		return undefined;
+	}, [apiKeyId, providerVirtualKeys]);
 
 	const handleModelParamsChange = useCallback(
 		(params: Record<string, any>) => {
@@ -170,12 +148,14 @@ export function SettingsPanel() {
 
 					<div className="flex flex-col gap-2" data-testid="settings-model">
 						<Label className="text-muted-foreground text-xs font-medium uppercase">Model</Label>
-						<ComboboxSelect
-							options={availableModels.map((m) => ({ label: m, value: m }))}
+						<ModelMultiselect
+							provider={provider}
+							keys={filterKeys && filterKeys.length > 0 ? filterKeys : undefined}
+						vks={filterVks}
 							value={model}
-							onValueChange={(v) => v && onModelChange(v)}
+							onChange={(v) => onModelChange(v)}
+							isSingleSelect
 							placeholder={!provider ? "Select a provider first" : "Select model"}
-							hideClear
 							disabled={!provider}
 						/>
 					</div>

--- a/ui/components/ui/modelMultiselect.tsx
+++ b/ui/components/ui/modelMultiselect.tsx
@@ -11,6 +11,7 @@ import { Option } from "./multiselectUtils";
 interface ModelMultiselectPropsBase {
 	provider?: string;
 	keys?: string[];
+	vks?: string[];
 	placeholder?: string;
 	disabled?: boolean;
 	className?: string;
@@ -59,6 +60,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 	const {
 		provider,
 		keys,
+		vks,
 		value,
 		unfiltered = false,
 		onChange,
@@ -90,12 +92,13 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 			model === "*" ? ALL_MODELS_OPTION : { label: model, value: model }
 		));
 
-	// Fetch initial models on mount or when provider/keys change
+	// Fetch initial models on mount or when provider/keys/vks change
 	useEffect(() => {
 		if (provider) {
 			getModels({
 				provider,
 				keys: keys && keys.length > 0 ? keys : undefined,
+				vks: vks && vks.length > 0 ? vks : undefined,
 				limit: 5,
 				unfiltered,
 			});
@@ -104,11 +107,12 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 		} else if (shouldLoadOnEmpty) {
 			getModels({
 				keys: keys && keys.length > 0 ? keys : undefined,
+				vks: vks && vks.length > 0 ? vks : undefined,
 				limit: 20,
 				unfiltered,
 			});
 		}
-	}, [provider, keys, getModels, getBaseModels, shouldLoadOnEmpty, shouldUseBaseModels]);
+	}, [provider, keys, vks, getModels, getBaseModels, shouldLoadOnEmpty, shouldUseBaseModels]);
 
 	// Load options function for AsyncMultiSelect
 	const loadOptions = useCallback(
@@ -144,6 +148,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 					query: query || undefined,
 					provider: provider || undefined,
 					keys: keys && keys.length > 0 ? keys : undefined,
+					vks: vks && vks.length > 0 ? vks : undefined,
 					limit: query ? 50 : shouldLoadOnEmpty && !provider ? 20 : 5,
 					unfiltered,
 				})
@@ -161,7 +166,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 					});
 			}
 		},
-		[getModels, getBaseModels, provider, keys, shouldLoadOnEmpty, shouldUseBaseModels, allowAllOption],
+		[getModels, getBaseModels, provider, keys, vks, shouldLoadOnEmpty, shouldUseBaseModels, allowAllOption],
 	);
 
 	// Handle selection change
@@ -182,6 +187,7 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 					query: currentQuery || undefined,
 					provider,
 					keys: keys && keys.length > 0 ? keys : undefined,
+					vks: vks && vks.length > 0 ? vks : undefined,
 					limit: currentQuery ? 20 : 5,
 					unfiltered,
 				});
@@ -194,12 +200,13 @@ export function ModelMultiselect(props: ModelMultiselectProps) {
 				getModels({
 					query: currentQuery || undefined,
 					keys: keys && keys.length > 0 ? keys : undefined,
+					vks: vks && vks.length > 0 ? vks : undefined,
 					limit: currentQuery ? 20 : 5,
 					unfiltered,
 				});
 			}
 		},
-		[onChange, provider, keys, getModels, getBaseModels, isSingleSelect, shouldLoadOnEmpty, shouldUseBaseModels],
+		[onChange, provider, keys, vks, getModels, getBaseModels, isSingleSelect, shouldLoadOnEmpty, shouldUseBaseModels],
 	);
 
 	// Handle input change - track in both state and ref

--- a/ui/lib/store/apis/providersApi.ts
+++ b/ui/lib/store/apis/providersApi.ts
@@ -35,6 +35,7 @@ export interface GetModelsRequest {
 	query?: string;
 	provider?: string;
 	keys?: string[];
+	vks?: string[];
 	limit?: number;
 	unfiltered?: boolean;
 }
@@ -309,11 +310,12 @@ export const providersApi = baseApi.injectEndpoints({
 
 		// Get models with optional filtering
 		getModels: builder.query<ListModelsResponse, GetModelsRequest>({
-			query: ({ query, provider, keys, limit, unfiltered }) => {
+			query: ({ query, provider, keys, vks, limit, unfiltered }) => {
 				const params = new URLSearchParams();
 				if (query) params.append("query", query);
 				if (provider) params.append("provider", provider);
 				if (keys && keys.length > 0) params.append("keys", keys.join(","));
+				if (vks && vks.length > 0) params.append("vks", vks.join(","));
 				if (limit !== undefined) params.append("limit", limit.toString());
 				if (unfiltered !== undefined) params.append("unfiltered", unfiltered.toString());
 				return `/models?${params.toString()}`;

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -13617,6 +13617,24 @@
 				}
 			}
 		},
+		"node_modules/vitest/node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
 		"node_modules/watchpack": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",


### PR DESCRIPTION
## Summary

Enhanced model filtering to support virtual keys in addition to provider keys. The system now accepts both provider key UUIDs and virtual key values when filtering available models through the API.

## Changes

- Extended `filterModelsByKeys` function to handle virtual key values (sk-vk-...) alongside provider key UUIDs
- Added context parameter to enable database lookups for virtual key resolution
- Updated model filtering logic to check virtual key provider configurations and their allowed models
- Replaced frontend ComboboxSelect with ModelMultiselect component for better model selection UX
- Simplified frontend model filtering logic by delegating to backend API instead of client-side computation

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Test model filtering with both provider keys and virtual keys:

```sh
# Core/Transports
go version
go test ./...

# Test API endpoints with key filtering
curl -X GET "http://localhost:8080/api/providers/{provider}/models?keys=provider-key-uuid,sk-vk-virtual-key"

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Verify that model lists are properly filtered based on:
- Provider key model restrictions (allowlist/blacklist)
- Virtual key provider configurations and allowed models
- Auto mode showing union of all accessible models

## Screenshots/Recordings

N/A - Backend API enhancement with minor UI component change

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Virtual key resolution requires database access and proper validation of key ownership. The implementation maintains existing security boundaries by only returning models that the authenticated keys have access to.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable