### PR TITLE
refactor: replace lazy query with polling query and fix overflow in log details sheet

### DIFF
--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
-import { useLazyGetLogByIdQuery } from "@/lib/store/apis/logsApi";
+import { useGetLogByIdQuery } from "@/lib/store/apis/logsApi";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -85,13 +85,15 @@ const isContainerOperation = (object: string) => {
 export function LogDetailSheet({ log, open, onOpenChange, handleDelete, onNavigate, hasPrev = false, hasNext = false }: LogDetailSheetProps) {
 	const { copy: copyRequestId } = useCopyToClipboard({ successMessage: "Request ID copied" });
 	const { copy: copyBody } = useCopyToClipboard({ successMessage: "Request body copied to clipboard", errorMessage: "Failed to copy request body" });
-	const [fetchLog, { data: fullLog, isFetching }] = useLazyGetLogByIdQuery();
-
+	const [pollingInterval, setPollingInterval] = useState(0);
+	const { data: fullLog, isLoading, isError } = useGetLogByIdQuery(log?.id ?? "", {
+		skip: !open || !log?.id,
+		pollingInterval,
+	});
+	const shouldPoll = isError || fullLog?.status === "processing";
 	useEffect(() => {
-		if (open && log?.id) {
-			fetchLog(log.id);
-		}
-	}, [open, log?.id, fetchLog]);
+		setPollingInterval(shouldPoll ? 2000 : 0);
+	}, [shouldPoll]);
 
 	// Keyboard navigation: arrow up/down to navigate between logs
 	useHotkeys("up", () => onNavigate?.("prev"), { enabled: open && hasPrev, preventDefault: true });
@@ -99,8 +101,8 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete, onNaviga
 
 	if (!log) return null;
 
-	// Show a loader until the full log data is fetched from the dedicated single-log endpoint.
-	const isFullDataReady = fullLog?.id === log.id && !isFetching;
+	// Show a loader only on the initial fetch, not during background polling refetches.
+	const isFullDataReady = fullLog?.id === log.id && !isLoading;
 	const displayLog = isFullDataReady ? fullLog : log;
 
 	const isContainer = isContainerOperation(displayLog.object);
@@ -142,9 +144,9 @@ export function LogDetailSheet({ log, open, onOpenChange, handleDelete, onNaviga
 					</div>
 				) : (
 				<>
-				<SheetHeader className="flex flex-row items-center px-0">
-					<div className="flex w-full items-center justify-between">
-						<SheetTitle className="flex w-fit items-center gap-2 font-medium">
+				<SheetHeader className="flex flex-row items-center px-0 overflow-x-hidden">
+					<div className="flex w-full items-center justify-between overflow-x-hidden">
+						<SheetTitle className="flex w-fit items-center gap-2 font-medium overflow-x-hidden">
 							{displayLog.id && (
 								<p className="text-md max-w-full truncate">
 									Request ID:{" "}

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -394,4 +394,5 @@ export const {
 	useDeleteLogsMutation,
 	useRecalculateLogCostsMutation,
 	useLazyGetLogByIdQuery,
+	useGetLogByIdQuery,
 } = logsApi;


### PR DESCRIPTION
## Summary

Improves log detail sheet reliability by switching from lazy loading to automatic polling for failed log fetches and fixes UI overflow issues in the sheet header.

## Changes

- Replaced `useLazyGetLogByIdQuery` with `useGetLogByIdQuery` for automatic data fetching when the sheet opens
- Added polling mechanism that retries every 2 seconds when log fetch fails, stopping when successful
- Fixed horizontal overflow issues in the sheet header by adding `overflow-x-hidden` classes
- Exported `useGetLogByIdQuery` hook from the logs API

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Open the logs page and click on a log entry to view details
2. Verify the log details load automatically without manual triggering
3. Test with network issues or slow responses to confirm polling retry behavior
4. Check that long request IDs don't cause horizontal overflow in the sheet header

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects UI data fetching patterns and styling.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable