### PR TITLE
feat: add image size and aspect ratio support for Gemini image generation and editing

### DIFF
--- a/core/providers/gemini/images.go
+++ b/core/providers/gemini/images.go
@@ -94,6 +94,17 @@ func (request *GeminiGenerationRequest) ToBifrostImageGenerationRequest(ctx *sch
 		}
 	}
 
+	// Extract imageConfig from GenerationConfig if present
+	if request.GenerationConfig.ImageConfig != nil {
+		size := convertImagenFormatToSize(
+			&request.GenerationConfig.ImageConfig.ImageSize,
+			&request.GenerationConfig.ImageConfig.AspectRatio,
+		)
+		if size != "" {
+			bifrostReq.Params.Size = &size
+		}
+	}
+
 	return bifrostReq
 }
 
@@ -285,6 +296,17 @@ func (request *GeminiGenerationRequest) ToBifrostImageEditRequest(ctx *schemas.B
 		}
 		if len(images) > 0 {
 			bifrostReq.Input.Images = images
+		}
+	}
+
+	// Extract imageConfig from GenerationConfig if present
+	if request.GenerationConfig.ImageConfig != nil {
+		size := convertImagenFormatToSize(
+			&request.GenerationConfig.ImageConfig.ImageSize,
+			&request.GenerationConfig.ImageConfig.AspectRatio,
+		)
+		if size != "" {
+			bifrostReq.Params.Size = &size
 		}
 	}
 
@@ -744,6 +766,17 @@ func ToGeminiImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 	// Convert parameters to generation config
 	if bifrostReq.Params != nil {
 		geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
+
+		// Handle size conversion
+		if bifrostReq.Params.Size != nil && strings.ToLower(*bifrostReq.Params.Size) != "auto" {
+			imageSize, aspectRatio := convertSizeToImagenFormat(*bifrostReq.Params.Size)
+			if imageSize != "" && aspectRatio != "" {
+				geminiReq.GenerationConfig.ImageConfig = &GeminiImageConfig{
+					ImageSize:   imageSize,
+					AspectRatio: aspectRatio,
+				}
+			}
+		}
 
 		// Handle extra parameters
 		if bifrostReq.Params.ExtraParams != nil {


### PR DESCRIPTION
## Summary

Adds bidirectional support for image size and aspect ratio configuration in Gemini provider's image generation and editing requests by extracting ImageConfig from GenerationConfig and converting between Bifrost and Gemini formats.

## Changes

- Added extraction of `ImageConfig` from `GenerationConfig` in `ToBifrostImageGenerationRequest` and `ToBifrostImageEditRequest` methods
- Added size parameter conversion from Bifrost format to Gemini's ImageConfig format in `ToGeminiImageEditRequest`
- Implemented proper handling of image size and aspect ratio parameters when converting between request formats
- Added validation to skip conversion when size is set to "auto"

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test image generation and editing requests with size and aspect ratio parameters:

```sh
# Core/Transports
go version
go test ./...

# Test with Gemini provider image requests containing ImageConfig
# Verify size parameters are properly converted between formats
# Test both generation and editing endpoints
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #2283

## Security considerations

No security implications - this change only affects parameter conversion between internal request formats.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable