### PR TITLE
feat: adds support for multiple deployments in ollama and sgl

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4966,7 +4966,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 
 		key := schemas.Key{}
 		var keys []schemas.Key
-		if providerRequiresKey(baseProvider, config.CustomProviderConfig) {
+		if providerRequiresKey(config.CustomProviderConfig) {
 			// ListModels needs all enabled/supported keys so providers can aggregate
 			// and report per-key statuses (KeyStatuses).
 			if req.RequestType == schemas.ListModelsRequest {

--- a/core/providers/ollama/ollama.go
+++ b/core/providers/ollama/ollama.go
@@ -3,7 +3,6 @@
 package ollama
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -50,11 +49,7 @@ func NewOllamaProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
 
-	// BaseURL is required for Ollama
-	if config.NetworkConfig.BaseURL == "" {
-		return nil, fmt.Errorf("base_url is required for ollama provider")
-	}
-
+	// BaseURL is optional when keys have ollama_key_config with per-key URLs
 	return &OllamaProvider{
 		logger:              logger,
 		client:              client,
@@ -69,17 +64,42 @@ func (provider *OllamaProvider) GetProviderKey() schemas.ModelProvider {
 	return schemas.Ollama
 }
 
-// ListModels performs a list models request to Ollama's API.
-func (provider *OllamaProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	if provider.networkConfig.BaseURL == "" {
-		return nil, providerUtils.NewConfigurationError("base_url is not set", provider.GetProviderKey())
+// getBaseURL resolves the base URL for a request from the per-key ollama_key_config.
+// Each Ollama key must have its own URL configured — there is no provider-level fallback.
+func (provider *OllamaProvider) getBaseURL(key schemas.Key) string {
+	if key.OllamaKeyConfig != nil && key.OllamaKeyConfig.URL.GetValue() != "" {
+		return strings.TrimRight(key.OllamaKeyConfig.URL.GetValue(), "/")
 	}
-	return openai.HandleOpenAIListModelsRequest(
+	return ""
+}
+
+// baseURLOrError returns the resolved base URL or a BifrostError when none is configured.
+func (provider *OllamaProvider) baseURLOrError(key schemas.Key) (string, *schemas.BifrostError) {
+	u := provider.getBaseURL(key)
+	if u == "" {
+		return "", providerUtils.NewBifrostOperationError(
+			"no base URL configured: set ollama_key_config.url on the key",
+			nil,
+			provider.GetProviderKey(),
+		)
+	}
+	return u, nil
+}
+
+// listModelsByKey performs a list models request for a single Ollama key,
+// resolving the per-key URL so each backend is queried individually.
+func (provider *OllamaProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+	url := baseURL + providerUtils.GetPathFromContext(ctx, "/v1/models")
+	return openai.ListModelsByKey(
 		ctx,
 		provider.client,
-		request,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/models"),
-		keys,
+		url,
+		key,
+		request.Unfiltered,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -87,12 +107,28 @@ func (provider *OllamaProvider) ListModels(ctx *schemas.BifrostContext, keys []s
 	)
 }
 
+// ListModels performs a list models request to Ollama's API.
+// Requests are made concurrently per key so that each backend is queried
+// with its own URL (from ollama_key_config).
+func (provider *OllamaProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	return providerUtils.HandleMultipleListModelsRequests(
+		ctx,
+		keys,
+		request,
+		provider.listModelsByKey,
+	)
+}
+
 // TextCompletion performs a text completion request to the Ollama API.
 func (provider *OllamaProvider) TextCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
 	return openai.HandleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
+		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -109,10 +145,14 @@ func (provider *OllamaProvider) TextCompletion(ctx *schemas.BifrostContext, key 
 // It formats the request, sends it to Ollama, and processes the response.
 // Returns a channel of BifrostStreamChunk objects or an error if the request fails.
 func (provider *OllamaProvider) TextCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
 	return openai.HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -129,10 +169,14 @@ func (provider *OllamaProvider) TextCompletionStream(ctx *schemas.BifrostContext
 
 // ChatCompletion performs a chat completion request to the Ollama API.
 func (provider *OllamaProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -150,11 +194,15 @@ func (provider *OllamaProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 // Uses Ollama's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
 func (provider *OllamaProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
 	// Use shared OpenAI-compatible streaming logic
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -199,10 +247,14 @@ func (provider *OllamaProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 
 // Embedding performs an embedding request to the Ollama API.
 func (provider *OllamaProvider) Embedding(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
 	return openai.HandleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
+		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/sgl/sgl.go
+++ b/core/providers/sgl/sgl.go
@@ -3,7 +3,6 @@
 package sgl
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -50,11 +49,7 @@ func NewSGLProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*SGL
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
 
-	// BaseURL is required for SGLang
-	if config.NetworkConfig.BaseURL == "" {
-		return nil, fmt.Errorf("base_url is required for sgl provider")
-	}
-
+	// BaseURL is optional when keys have sgl_key_config with per-key URLs
 	return &SGLProvider{
 		logger:              logger,
 		client:              client,
@@ -69,27 +64,71 @@ func (provider *SGLProvider) GetProviderKey() schemas.ModelProvider {
 	return schemas.SGL
 }
 
-// ListModels performs a list models request to SGL's API.
-func (provider *SGLProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	return openai.HandleOpenAIListModelsRequest(
+// getBaseURL resolves the base URL for a request from the per-key sgl_key_config.
+// Each SGL key must have its own URL configured — there is no provider-level fallback.
+func (provider *SGLProvider) getBaseURL(key schemas.Key) string {
+	if key.SGLKeyConfig != nil && key.SGLKeyConfig.URL.GetValue() != "" {
+		return strings.TrimRight(key.SGLKeyConfig.URL.GetValue(), "/")
+	}
+	return ""
+}
+
+// baseURLOrError returns the resolved base URL or a BifrostError when none is configured.
+func (provider *SGLProvider) baseURLOrError(key schemas.Key) (string, *schemas.BifrostError) {
+	u := provider.getBaseURL(key)
+	if u == "" {
+		return "", providerUtils.NewBifrostOperationError(
+			"no base URL configured: set sgl_key_config.url on the key",
+			nil,
+			provider.GetProviderKey(),
+		)
+	}
+	return u, nil
+}
+
+// listModelsByKey performs a list models request for a single SGL key,
+// resolving the per-key URL so each backend is queried individually.
+func (provider *SGLProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+	url := baseURL + providerUtils.GetPathFromContext(ctx, "/v1/models")
+	return openai.ListModelsByKey(
 		ctx,
 		provider.client,
-		request,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/models"),
-		keys,
+		url,
+		key,
+		request.Unfiltered,
 		provider.networkConfig.ExtraHeaders,
-		schemas.SGL,
+		provider.GetProviderKey(),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 	)
 }
 
-// TextCompletion is not supported by the SGL provider.
+// ListModels performs a list models request to SGL's API.
+// Requests are made concurrently per key so that each backend is queried
+// with its own URL (from sgl_key_config).
+func (provider *SGLProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	return providerUtils.HandleMultipleListModelsRequests(
+		ctx,
+		keys,
+		request,
+		provider.listModelsByKey,
+	)
+}
+
+// TextCompletion performs a text completion request to the SGL API.
 func (provider *SGLProvider) TextCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (*schemas.BifrostTextCompletionResponse, *schemas.BifrostError) {
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
 	return openai.HandleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
+		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -106,10 +145,14 @@ func (provider *SGLProvider) TextCompletion(ctx *schemas.BifrostContext, key sch
 // It formats the request, sends it to SGL, and processes the response.
 // Returns a channel of BifrostStreamChunk objects or an error if the request fails.
 func (provider *SGLProvider) TextCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
 	return openai.HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -126,10 +169,14 @@ func (provider *SGLProvider) TextCompletionStream(ctx *schemas.BifrostContext, p
 
 // ChatCompletion performs a chat completion request to the SGL API.
 func (provider *SGLProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -147,11 +194,15 @@ func (provider *SGLProvider) ChatCompletion(ctx *schemas.BifrostContext, key sch
 // Uses SGL's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostResponse objects representing the stream or an error if the request fails.
 func (provider *SGLProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
 	// Use shared OpenAI-compatible streaming logic
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -194,12 +245,16 @@ func (provider *SGLProvider) ResponsesStream(ctx *schemas.BifrostContext, postHo
 	)
 }
 
-// Embedding is not supported by the SGL provider.
+// Embedding performs an embedding request to the SGL API.
 func (provider *SGLProvider) Embedding(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
 	return openai.HandleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
+		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -120,23 +120,24 @@ func (bl BlackList) Validate() error {
 // Key represents an API key and its associated configuration for a provider.
 // It contains the key value, supported models, and a weight for load balancing.
 type Key struct {
-	ID                   string                `json:"id"`                               // The unique identifier for the key (used by bifrost to identify the key)
-	Name                 string                `json:"name"`                             // The name of the key (used by users to identify the key, not used by bifrost)
-	Value                EnvVar                `json:"value"`                            // The actual API key value
-	Models               WhiteList             `json:"models"`                           // List of models this key can access
-	BlacklistedModels    BlackList             `json:"blacklisted_models"`               // List of models this key cannot access
-	Weight               float64               `json:"weight"`                           // Weight for load balancing between multiple keys
-	AzureKeyConfig       *AzureKeyConfig       `json:"azure_key_config,omitempty"`       // Azure-specific key configuration
-	VertexKeyConfig      *VertexKeyConfig      `json:"vertex_key_config,omitempty"`      // Vertex-specific key configuration
-	BedrockKeyConfig     *BedrockKeyConfig     `json:"bedrock_key_config,omitempty"`     // AWS Bedrock-specific key configuration
-	HuggingFaceKeyConfig *HuggingFaceKeyConfig `json:"huggingface_key_config,omitempty"` // Hugging Face-specific key configuration
-	ReplicateKeyConfig   *ReplicateKeyConfig   `json:"replicate_key_config,omitempty"`   // Replicate-specific key configuration
-	VLLMKeyConfig        *VLLMKeyConfig        `json:"vllm_key_config,omitempty"`        // vLLM-specific key configuration
-	Enabled              *bool                 `json:"enabled,omitempty"`                // Whether the key is active (default:true)
-	UseForBatchAPI       *bool                 `json:"use_for_batch_api,omitempty"`      // Whether this key can be used for batch API operations (default:false for new keys, migrated keys default to true)
-	ConfigHash           string                `json:"config_hash,omitempty"`            // Hash of config.json version, used for change detection
-	Status               KeyStatusType         `json:"status,omitempty"`                 // Status of key
-	Description          string                `json:"description,omitempty"`            // Description of key
+	ID                 string              `json:"id"`                             // The unique identifier for the key (used by bifrost to identify the key)
+	Name               string              `json:"name"`                           // The name of the key (used by users to identify the key, not used by bifrost)
+	Value              EnvVar              `json:"value"`                          // The actual API key value
+	Models             WhiteList           `json:"models"`                         // List of models this key can access
+	BlacklistedModels  BlackList           `json:"blacklisted_models"`             // List of models this key cannot access
+	Weight             float64             `json:"weight"`                         // Weight for load balancing between multiple keys
+	AzureKeyConfig     *AzureKeyConfig     `json:"azure_key_config,omitempty"`     // Azure-specific key configuration
+	VertexKeyConfig    *VertexKeyConfig    `json:"vertex_key_config,omitempty"`    // Vertex-specific key configuration
+	BedrockKeyConfig   *BedrockKeyConfig   `json:"bedrock_key_config,omitempty"`   // AWS Bedrock-specific key configuration
+	ReplicateKeyConfig *ReplicateKeyConfig `json:"replicate_key_config,omitempty"` // Replicate-specific key configuration
+	VLLMKeyConfig      *VLLMKeyConfig      `json:"vllm_key_config,omitempty"`      // vLLM-specific key configuration
+	OllamaKeyConfig    *OllamaKeyConfig    `json:"ollama_key_config,omitempty"`    // Ollama-specific key configuration
+	SGLKeyConfig       *SGLKeyConfig       `json:"sgl_key_config,omitempty"`       // SGLang-specific key configuration
+	Enabled            *bool               `json:"enabled,omitempty"`              // Whether the key is active (default:true)
+	UseForBatchAPI     *bool               `json:"use_for_batch_api,omitempty"`    // Whether this key can be used for batch API operations (default:false for new keys, migrated keys default to true)
+	ConfigHash         string              `json:"config_hash,omitempty"`          // Hash of config.json version, used for change detection
+	Status             KeyStatusType       `json:"status,omitempty"`               // Status of key
+	Description        string              `json:"description,omitempty"`          // Description of key
 }
 
 type AzureAuthType string
@@ -204,10 +205,6 @@ type BedrockKeyConfig struct {
 // NOTE: To use Bedrock IAM role authentication, set both AccessKey and SecretKey to empty strings.
 // To use Bedrock API Key authentication, set Value in Key struct instead.
 
-type HuggingFaceKeyConfig struct {
-	Deployments map[string]string `json:"deployments,omitempty"` // Mapping of model identifiers to deployment names
-}
-
 type ReplicateKeyConfig struct {
 	Deployments map[string]string `json:"deployments,omitempty"` // Mapping of model identifiers to deployment names
 }
@@ -218,6 +215,20 @@ type ReplicateKeyConfig struct {
 type VLLMKeyConfig struct {
 	URL       EnvVar `json:"url"`        // VLLM server base URL (required, supports env. prefix)
 	ModelName string `json:"model_name"` // Exact model name served on this VLLM instance (used for key selection)
+}
+
+// OllamaKeyConfig represents the Ollama-specific key configuration.
+// It allows each key to target a different Ollama server URL,
+// enabling per-key routing and round-robin load balancing across multiple Ollama instances.
+type OllamaKeyConfig struct {
+	URL EnvVar `json:"url"` // Ollama server base URL (required, supports env. prefix)
+}
+
+// SGLKeyConfig represents the SGLang-specific key configuration.
+// It allows each key to target a different SGLang server URL,
+// enabling per-key routing and round-robin load balancing across multiple SGLang instances.
+type SGLKeyConfig struct {
+	URL EnvVar `json:"url"` // SGLang server base URL (required, supports env. prefix)
 }
 
 // Account defines the interface for managing provider accounts and their configurations.

--- a/core/schemas/envvar.go
+++ b/core/schemas/envvar.go
@@ -117,6 +117,9 @@ func (e *EnvVar) Equals(other *EnvVar) bool {
 
 // Redacted returns a new SecretKey with the value redacted.
 func (e *EnvVar) Redacted() *EnvVar {
+	if e == nil {
+		return nil
+	}
 	if e.Val == "" {
 		return &EnvVar{
 			Val:     "",
@@ -297,4 +300,15 @@ func (e *EnvVar) CoerceBool(defaultValue bool) bool {
 		return defaultValue
 	}
 	return val
+}
+
+// IsDefined returns true if the EnvVar has a source (static value or env key)
+func (e *EnvVar) IsDefined() bool {
+	if e == nil {
+		return false
+	}
+	if e.IsFromEnv() {
+		return e.EnvVar != ""
+	}
+	return e.Val != ""
 }

--- a/core/utils.go
+++ b/core/utils.go
@@ -87,19 +87,19 @@ func Ptr[T any](v T) *T {
 }
 
 // providerRequiresKey returns true if the given provider requires an API key for authentication.
-// Some providers like Ollama, SGL, and vLLM are keyless and don't require API keys.
-func providerRequiresKey(providerKey schemas.ModelProvider, customConfig *schemas.CustomProviderConfig) bool {
+func providerRequiresKey(customConfig *schemas.CustomProviderConfig) bool {
 	// Keyless custom providers are not allowed for Bedrock.
 	if customConfig != nil && customConfig.IsKeyLess && customConfig.BaseProviderType != schemas.Bedrock {
 		return false
 	}
-	return !IsKeylessProvider(providerKey)
+	return true
 }
 
-// canProviderKeyValueBeEmpty returns true if the given provider allows the API key to be empty.
-// Some providers like Vertex and Bedrock have their credentials in additional key configs..
+// CanProviderKeyValueBeEmpty returns true if the given provider allows the API key to be empty.
+// Some providers like Vertex and Bedrock have their credentials in additional key configs.
+// Ollama and SGL are keyless (API Key is optional) but use per-key server URLs.
 func CanProviderKeyValueBeEmpty(providerKey schemas.ModelProvider) bool {
-	return providerKey == schemas.Vertex || providerKey == schemas.Bedrock || providerKey == schemas.VLLM || providerKey == schemas.Azure
+	return providerKey == schemas.Vertex || providerKey == schemas.Bedrock || providerKey == schemas.VLLM || providerKey == schemas.Azure || providerKey == schemas.Ollama || providerKey == schemas.SGL
 }
 
 func isKeySkippingAllowed(providerKey schemas.ModelProvider) bool {
@@ -261,11 +261,6 @@ var standardProvidersSet = func() map[schemas.ModelProvider]struct{} {
 func IsStandardProvider(providerKey schemas.ModelProvider) bool {
 	_, ok := standardProvidersSet[providerKey]
 	return ok
-}
-
-// IsKeylessProvider reports whether providerKey is a keyless provider.
-func IsKeylessProvider(providerKey schemas.ModelProvider) bool {
-	return providerKey == schemas.Ollama || providerKey == schemas.SGL
 }
 
 // IsStreamRequestType returns true if the given request type is a stream request.

--- a/docs/openapi/schemas/management/providers.yaml
+++ b/docs/openapi/schemas/management/providers.yaml
@@ -139,14 +139,34 @@ BedrockKeyConfig:
               is_default:
                 type: boolean
 
-HuggingFaceKeyConfig:
+VllmKeyConfig:
   type: object
-  description: Hugging Face-specific key configuration
+  description: VLLM-specific key configuration
   properties:
-    deployments:
-      type: object
-      additionalProperties:
-        type: string
+    url:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+    model_name:
+      type: string
+  required:
+    - url
+
+OllamaKeyConfig:
+  type: object
+  description: Ollama-specific key configuration
+  properties:
+    url:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+  required:
+    - url
+
+SglKeyConfig:
+  type: object
+  description: SGLang-specific key configuration
+  properties:
+    url:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+  required:
+    - url
 
 ReplicateKeyConfig:
   type: object
@@ -200,12 +220,14 @@ Key:
       $ref: '#/VertexKeyConfig'
     bedrock_key_config:
       $ref: '#/BedrockKeyConfig'
-    huggingface_key_config:
-      $ref: '#/HuggingFaceKeyConfig'
     replicate_key_config:
       $ref: '#/ReplicateKeyConfig'
     vllm_key_config:
-      $ref: '#/VLLMKeyConfig'
+      $ref: '#/VllmKeyConfig'
+    ollama_key_config:
+      $ref: '#/OllamaKeyConfig'
+    sgl_key_config:
+      $ref: '#/SglKeyConfig'
     enabled:
       type: boolean
       description: Whether the key is active (defaults to true)

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -408,6 +408,18 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			vllmConfig.URL = *key.VLLMKeyConfig.URL.Redacted()
 			redactedConfig.Keys[i].VLLMKeyConfig = vllmConfig
 		}
+
+		if key.OllamaKeyConfig != nil {
+			ollamaConfig := &schemas.OllamaKeyConfig{}
+			ollamaConfig.URL = *key.OllamaKeyConfig.URL.Redacted()
+			redactedConfig.Keys[i].OllamaKeyConfig = ollamaConfig
+		}
+
+		if key.SGLKeyConfig != nil {
+			sglConfig := &schemas.SGLKeyConfig{}
+			sglConfig.URL = *key.SGLKeyConfig.URL.Redacted()
+			redactedConfig.Keys[i].SGLKeyConfig = sglConfig
+		}
 	}
 	return &redactedConfig
 }
@@ -561,6 +573,22 @@ func GenerateKeyHash(key schemas.Key) (string, error) {
 	// Hash VLLMKeyConfig
 	if key.VLLMKeyConfig != nil {
 		data, err := sonic.Marshal(key.VLLMKeyConfig)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
+	// Hash OllamaKeyConfig
+	if key.OllamaKeyConfig != nil {
+		data, err := sonic.Marshal(key.OllamaKeyConfig)
+		if err != nil {
+			return "", err
+		}
+		hash.Write(data)
+	}
+	// Hash SGLKeyConfig
+	if key.SGLKeyConfig != nil {
+		data, err := sonic.Marshal(key.SGLKeyConfig)
 		if err != nil {
 			return "", err
 		}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -281,7 +281,6 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 		return err
 	}
 	if err := migrationAddOutputCostPerVideoPerSecond(ctx, db); err != nil {
-
 		return err
 	}
 	if err := migrationDropEnableGovernanceColumn(ctx, db); err != nil {
@@ -348,6 +347,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 		return err
 	}
 	if err := migrationAddModelCapabilityColumns(ctx, db); err != nil {
+		return err
+	}
+	if err := migrationAddOllamaSGLConfigColumns(ctx, db); err != nil {
 		return err
 	}
 	return nil
@@ -5089,6 +5091,8 @@ func migrationBackfillAllowedModelsWildcard(ctx context.Context, db *gorm.DB) er
 					BedrockKeyConfig:   key.BedrockKeyConfig,
 					ReplicateKeyConfig: key.ReplicateKeyConfig,
 					VLLMKeyConfig:      key.VLLMKeyConfig,
+					OllamaKeyConfig:    key.OllamaKeyConfig,
+					SGLKeyConfig:       key.SGLKeyConfig,
 					Enabled:            key.Enabled,
 					UseForBatchAPI:     key.UseForBatchAPI,
 				}
@@ -5388,6 +5392,101 @@ func migrationAddModelCapabilityColumns(ctx context.Context, db *gorm.DB) error 
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_model_capability_columns migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddOllamaSGLConfigColumns adds ollama_url and sgl_url columns to the key table
+func migrationAddOllamaSGLConfigColumns(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_ollama_sgl_config_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&tables.TableKey{}, "ollama_url") {
+				if err := migrator.AddColumn(&tables.TableKey{}, "ollama_url"); err != nil {
+					return err
+				}
+			}
+			if !migrator.HasColumn(&tables.TableKey{}, "sgl_url") {
+				if err := migrator.AddColumn(&tables.TableKey{}, "sgl_url"); err != nil {
+					return err
+				}
+			}
+
+			// Backfill: for each ollama/sgl provider with a base_url, create a key
+			// with that URL and clear base_url from network_config.
+			var providers []tables.TableProvider
+			if err := tx.Where("name IN ?", []string{"ollama", "sgl"}).Find(&providers).Error; err != nil {
+				return fmt.Errorf("failed to fetch ollama/sgl providers for URL backfill: %w", err)
+			}
+			for _, p := range providers {
+				if p.NetworkConfigJSON == "" {
+					continue
+				}
+				var nc schemas.NetworkConfig
+				if err := json.Unmarshal([]byte(p.NetworkConfigJSON), &nc); err != nil {
+					log.Printf("[Migration] Failed to parse network_config for provider %s (id=%d), skipping: %v", p.Name, p.ID, err)
+					continue
+				}
+				if nc.BaseURL == "" {
+					continue
+				}
+
+				// Create a new key with the provider's base_url
+				urlEnvVar := schemas.EnvVar{Val: nc.BaseURL}
+				enabled := true
+				weight := 1.0
+				newKey := tables.TableKey{
+					Provider:   p.Name,
+					ProviderID: p.ID,
+					KeyID:      uuid.NewString(),
+					Weight:     &weight,
+					Enabled:    &enabled,
+					Models:     schemas.WhiteList{"*"},
+				}
+				if strings.ToLower(p.Name) == "ollama" {
+					newKey.Name = "Default Ollama Key"
+					newKey.OllamaKeyConfig = &schemas.OllamaKeyConfig{URL: urlEnvVar}
+				}
+				if strings.ToLower(p.Name) == "sgl" {
+					newKey.Name = "Default SGL Key"
+					newKey.SGLKeyConfig = &schemas.SGLKeyConfig{URL: urlEnvVar}
+				}
+
+				schemaKey := schemaKeyFromTableKey(newKey)
+				hash, err := GenerateKeyHash(schemaKey)
+				if err != nil {
+					return fmt.Errorf("failed to generate hash for new key on provider %s: %w", p.Name, err)
+				}
+				newKey.ConfigHash = hash
+				if err := tx.Create(&newKey).Error; err != nil {
+					return fmt.Errorf("failed to create key for provider %s: %w", p.Name, err)
+				}
+
+				log.Printf("[Migration] Created key '%s' for provider '%s' from network_config.base_url", newKey.Name, p.Name)
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasColumn(&tables.TableKey{}, "ollama_url") {
+				if err := migrator.DropColumn(&tables.TableKey{}, "ollama_url"); err != nil {
+					return err
+				}
+			}
+			if migrator.HasColumn(&tables.TableKey{}, "sgl_url") {
+				if err := migrator.DropColumn(&tables.TableKey{}, "sgl_url"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running ollama sgl key config columns migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -50,6 +50,8 @@ func schemaKeyFromTableKey(dbKey tables.TableKey) schemas.Key {
 		BedrockKeyConfig:   dbKey.BedrockKeyConfig,
 		ReplicateKeyConfig: dbKey.ReplicateKeyConfig,
 		VLLMKeyConfig:      dbKey.VLLMKeyConfig,
+		OllamaKeyConfig:    dbKey.OllamaKeyConfig,
+		SGLKeyConfig:       dbKey.SGLKeyConfig,
 		ConfigHash:         dbKey.ConfigHash,
 		Status:             schemas.KeyStatusType(dbKey.Status),
 		Description:        dbKey.Description,
@@ -73,6 +75,8 @@ func tableKeyFromSchemaKey(provider tables.TableProvider, key schemas.Key) (tabl
 		BedrockKeyConfig:   key.BedrockKeyConfig,
 		ReplicateKeyConfig: key.ReplicateKeyConfig,
 		VLLMKeyConfig:      key.VLLMKeyConfig,
+		OllamaKeyConfig:    key.OllamaKeyConfig,
+		SGLKeyConfig:       key.SGLKeyConfig,
 		ConfigHash:         key.ConfigHash,
 		Status:             string(key.Status),
 		Description:        key.Description,
@@ -375,6 +379,8 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 				BedrockKeyConfig:   key.BedrockKeyConfig,
 				ReplicateKeyConfig: key.ReplicateKeyConfig,
 				VLLMKeyConfig:      key.VLLMKeyConfig,
+				OllamaKeyConfig:    key.OllamaKeyConfig,
+				SGLKeyConfig:       key.SGLKeyConfig,
 				ConfigHash:         keyHash,
 				Status:             string(key.Status),
 				Description:        key.Description,
@@ -546,6 +552,8 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 			BedrockKeyConfig:   key.BedrockKeyConfig,
 			ReplicateKeyConfig: key.ReplicateKeyConfig,
 			VLLMKeyConfig:      key.VLLMKeyConfig,
+			OllamaKeyConfig:    key.OllamaKeyConfig,
+			SGLKeyConfig:       key.SGLKeyConfig,
 			ConfigHash:         keyHash,
 			Status:             string(key.Status),
 			Description:        key.Description,
@@ -669,6 +677,8 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 			BedrockKeyConfig:   key.BedrockKeyConfig,
 			ReplicateKeyConfig: key.ReplicateKeyConfig,
 			VLLMKeyConfig:      key.VLLMKeyConfig,
+			OllamaKeyConfig:    key.OllamaKeyConfig,
+			SGLKeyConfig:       key.SGLKeyConfig,
 			ConfigHash:         key.ConfigHash,
 			Status:             string(key.Status),
 			Description:        key.Description,
@@ -1390,7 +1400,7 @@ func (s *RDBConfigStore) UpdateVectorStoreConfig(ctx context.Context, config *ve
 		if err != nil {
 			return err
 		}
-		var record = &tables.TableVectorStoreConfig{
+		record := &tables.TableVectorStoreConfig{
 			Type:    string(config.Type),
 			Enabled: config.Enabled,
 			Config:  jsonConfig,
@@ -1429,7 +1439,7 @@ func (s *RDBConfigStore) UpdateLogsStoreConfig(ctx context.Context, config *logs
 		if err != nil {
 			return err
 		}
-		var record = &tables.TableLogStoreConfig{
+		record := &tables.TableLogStoreConfig{
 			Enabled: config.Enabled,
 			Type:    string(config.Type),
 			Config:  jsonConfig,
@@ -3416,7 +3426,6 @@ func (s *RDBConfigStore) GetAuthConfig(ctx context.Context) (*AuthConfig, error)
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
 		}
-
 	}
 	if err := s.db.WithContext(ctx).First(&tables.TableGovernanceConfig{}, "key = ?", tables.ConfigIsAuthEnabledKey).Select("value").Scan(&isEnabled).Error; err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {

--- a/framework/configstore/tables/key.go
+++ b/framework/configstore/tables/key.go
@@ -64,6 +64,12 @@ type TableKey struct {
 	VLLMUrl       *schemas.EnvVar `gorm:"type:text" json:"vllm_url,omitempty"`
 	VLLMModelName *string         `gorm:"type:varchar(255)" json:"vllm_model_name,omitempty"`
 
+	// Ollama config fields (embedded)
+	OllamaUrl *schemas.EnvVar `gorm:"type:text" json:"ollama_url,omitempty"`
+
+	// SGL config fields (embedded)
+	SGLUrl *schemas.EnvVar `gorm:"type:text" json:"sgl_url,omitempty"`
+
 	// Batch API configuration
 	UseForBatchAPI *bool `gorm:"default:false" json:"use_for_batch_api,omitempty"` // Whether this key can be used for batch API operations
 
@@ -80,6 +86,8 @@ type TableKey struct {
 	BedrockKeyConfig   *schemas.BedrockKeyConfig   `gorm:"-" json:"bedrock_key_config,omitempty"`
 	ReplicateKeyConfig *schemas.ReplicateKeyConfig `gorm:"-" json:"replicate_key_config,omitempty"`
 	VLLMKeyConfig      *schemas.VLLMKeyConfig      `gorm:"-" json:"vllm_key_config,omitempty"`
+	OllamaKeyConfig    *schemas.OllamaKeyConfig    `gorm:"-" json:"ollama_key_config,omitempty"`
+	SGLKeyConfig       *schemas.SGLKeyConfig       `gorm:"-" json:"sgl_key_config,omitempty"`
 }
 
 // TableName sets the table name for each model
@@ -307,17 +315,13 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		k.BedrockBatchS3ConfigJSON = nil
 	}
 
-	if k.ReplicateKeyConfig != nil {
-		if k.ReplicateKeyConfig.Deployments != nil {
-			data, err := sonic.Marshal(k.ReplicateKeyConfig.Deployments)
-			if err != nil {
-				return err
-			}
-			s := string(data)
-			k.ReplicateDeploymentsJSON = &s
-		} else {
-			k.ReplicateDeploymentsJSON = nil
+	if k.ReplicateKeyConfig != nil && k.ReplicateKeyConfig.Deployments != nil {
+		data, err := sonic.Marshal(k.ReplicateKeyConfig.Deployments)
+		if err != nil {
+			return err
 		}
+		s := string(data)
+		k.ReplicateDeploymentsJSON = &s
 	} else {
 		k.ReplicateDeploymentsJSON = nil
 	}
@@ -338,6 +342,20 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 	} else {
 		k.VLLMUrl = nil
 		k.VLLMModelName = nil
+	}
+
+	if k.OllamaKeyConfig != nil && k.OllamaKeyConfig.URL.GetValue() != "" {
+		u := k.OllamaKeyConfig.URL
+		k.OllamaUrl = &u
+	} else {
+		k.OllamaUrl = nil
+	}
+
+	if k.SGLKeyConfig != nil && k.SGLKeyConfig.URL.GetValue() != "" {
+		u := k.SGLKeyConfig.URL
+		k.SGLUrl = &u
+	} else {
+		k.SGLUrl = nil
 	}
 
 	// Encrypt sensitive fields after serialization
@@ -408,6 +426,14 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		// VLLM
 		if err := encryptEnvVarPtr(&k.VLLMUrl); err != nil {
 			return fmt.Errorf("failed to encrypt vllm url: %w", err)
+		}
+		// Ollama
+		if err := encryptEnvVarPtr(&k.OllamaUrl); err != nil {
+			return fmt.Errorf("failed to encrypt ollama url: %w", err)
+		}
+		// SGL
+		if err := encryptEnvVarPtr(&k.SGLUrl); err != nil {
+			return fmt.Errorf("failed to encrypt sgl url: %w", err)
 		}
 		k.EncryptionStatus = EncryptionStatusEncrypted
 	}
@@ -486,6 +512,14 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		// VLLM
 		if err := decryptEnvVarPtr(&k.VLLMUrl); err != nil {
 			return fmt.Errorf("failed to decrypt vllm url: %w", err)
+		}
+		// Ollama
+		if err := decryptEnvVarPtr(&k.OllamaUrl); err != nil {
+			return fmt.Errorf("failed to decrypt ollama url: %w", err)
+		}
+		// SGL
+		if err := decryptEnvVarPtr(&k.SGLUrl); err != nil {
+			return fmt.Errorf("failed to decrypt sgl url: %w", err)
 		}
 	}
 
@@ -631,6 +665,22 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		k.VLLMKeyConfig = vllmConfig
 	} else {
 		k.VLLMKeyConfig = nil
+	}
+	// Reconstruct Ollama config if fields are present
+	if k.OllamaUrl != nil {
+		k.OllamaKeyConfig = &schemas.OllamaKeyConfig{
+			URL: *k.OllamaUrl,
+		}
+	} else {
+		k.OllamaKeyConfig = nil
+	}
+	// Reconstruct SGL config if fields are present
+	if k.SGLUrl != nil {
+		k.SGLKeyConfig = &schemas.SGLKeyConfig{
+			URL: *k.SGLUrl,
+		}
+	} else {
+		k.SGLKeyConfig = nil
 	}
 	return nil
 }

--- a/transports/bifrost-http/handlers/provider_keys.go
+++ b/transports/bifrost-http/handlers/provider_keys.go
@@ -88,13 +88,23 @@ func (h *ProviderHandler) createProviderKey(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if bifrost.IsKeylessProvider(provider) || (providerConfig.CustomProviderConfig != nil && providerConfig.CustomProviderConfig.IsKeyLess) {
+	if providerConfig.CustomProviderConfig != nil && providerConfig.CustomProviderConfig.IsKeyLess {
 		SendError(ctx, fasthttp.StatusBadRequest, "Cannot add keys to a keyless provider")
 		return
 	}
 
-	if key.Value.GetValue() == "" {
+	baseProvider := provider
+	if providerConfig.CustomProviderConfig != nil && providerConfig.CustomProviderConfig.BaseProviderType != "" {
+		baseProvider = providerConfig.CustomProviderConfig.BaseProviderType
+	}
+
+	if !bifrost.CanProviderKeyValueBeEmpty(baseProvider) && key.Value.GetValue() == "" {
 		SendError(ctx, fasthttp.StatusBadRequest, "Key value must not be empty")
+		return
+	}
+
+	if err := validateProviderKeyURL(provider, key); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -166,7 +176,7 @@ func (h *ProviderHandler) updateProviderKey(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if bifrost.IsKeylessProvider(provider) || (providerConfig.CustomProviderConfig != nil && providerConfig.CustomProviderConfig.IsKeyLess) {
+	if providerConfig.CustomProviderConfig != nil && providerConfig.CustomProviderConfig.IsKeyLess {
 		SendError(ctx, fasthttp.StatusBadRequest, "Cannot update keys on a keyless provider")
 		return
 	}
@@ -194,8 +204,23 @@ func (h *ProviderHandler) updateProviderKey(ctx *fasthttp.RequestCtx) {
 	updateKey.ID = keyID
 	mergedKey := h.mergeUpdatedKey(*oldRawKey, *oldRedactedKey, updateKey)
 
+	baseProvider := provider
+	if providerConfig.CustomProviderConfig != nil && providerConfig.CustomProviderConfig.BaseProviderType != "" {
+		baseProvider = providerConfig.CustomProviderConfig.BaseProviderType
+	}
+
+	if !bifrost.CanProviderKeyValueBeEmpty(baseProvider) && mergedKey.Value.GetValue() == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "Key value must not be empty")
+		return
+	}
+
 	if err := mergedKey.BlacklistedModels.Validate(); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid blacklisted_models: %v", err))
+		return
+	}
+
+	if err := validateProviderKeyURL(provider, mergedKey); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -245,7 +270,7 @@ func (h *ProviderHandler) deleteProviderKey(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	if bifrost.IsKeylessProvider(provider) || (providerConfig.CustomProviderConfig != nil && providerConfig.CustomProviderConfig.IsKeyLess) {
+	if providerConfig.CustomProviderConfig != nil && providerConfig.CustomProviderConfig.IsKeyLess {
 		SendError(ctx, fasthttp.StatusBadRequest, "Cannot delete keys on a keyless provider")
 		return
 	}
@@ -400,6 +425,20 @@ func (h *ProviderHandler) mergeUpdatedKey(oldRawKey, oldRedactedKey, updateKey s
 		}
 	}
 
+	if updateKey.OllamaKeyConfig != nil && oldRedactedKey.OllamaKeyConfig != nil && oldRawKey.OllamaKeyConfig != nil {
+		if updateKey.OllamaKeyConfig.URL.IsRedacted() &&
+			updateKey.OllamaKeyConfig.URL.Equals(&oldRedactedKey.OllamaKeyConfig.URL) {
+			mergedKey.OllamaKeyConfig.URL = oldRawKey.OllamaKeyConfig.URL
+		}
+	}
+
+	if updateKey.SGLKeyConfig != nil && oldRedactedKey.SGLKeyConfig != nil && oldRawKey.SGLKeyConfig != nil {
+		if updateKey.SGLKeyConfig.URL.IsRedacted() &&
+			updateKey.SGLKeyConfig.URL.Equals(&oldRedactedKey.SGLKeyConfig.URL) {
+			mergedKey.SGLKeyConfig.URL = oldRawKey.SGLKeyConfig.URL
+		}
+	}
+
 	mergedKey.ConfigHash = oldRawKey.ConfigHash
 	mergedKey.Status = oldRawKey.Status
 
@@ -423,4 +462,19 @@ func getKeyIDFromCtx(ctx *fasthttp.RequestCtx) (string, error) {
 	}
 
 	return decoded, nil
+}
+
+// validateProviderKeyURL checks that Ollama/SGL keys have a server URL configured.
+func validateProviderKeyURL(provider schemas.ModelProvider, key schemas.Key) error {
+	switch provider {
+	case schemas.Ollama:
+		if key.OllamaKeyConfig == nil || !key.OllamaKeyConfig.URL.IsDefined() {
+			return fmt.Errorf("ollama_key_config.url is required for Ollama keys")
+		}
+	case schemas.SGL:
+		if key.SGLKeyConfig == nil || !key.SGLKeyConfig.URL.IsDefined() {
+			return fmt.Errorf("sgl_key_config.url is required for SGL keys")
+		}
+	}
+	return nil
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -795,6 +795,8 @@ func mergeProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []schema
 					BedrockKeyConfig:   dbKey.BedrockKeyConfig,
 					ReplicateKeyConfig: dbKey.ReplicateKeyConfig,
 					VLLMKeyConfig:      dbKey.VLLMKeyConfig,
+					OllamaKeyConfig:    dbKey.OllamaKeyConfig,
+					SGLKeyConfig:       dbKey.SGLKeyConfig,
 					Enabled:            dbKey.Enabled,
 					UseForBatchAPI:     dbKey.UseForBatchAPI,
 				})
@@ -873,6 +875,8 @@ func reconcileProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []sc
 					BedrockKeyConfig:   dbKey.BedrockKeyConfig,
 					ReplicateKeyConfig: dbKey.ReplicateKeyConfig,
 					VLLMKeyConfig:      dbKey.VLLMKeyConfig,
+					OllamaKeyConfig:    dbKey.OllamaKeyConfig,
+					SGLKeyConfig:       dbKey.SGLKeyConfig,
 					Enabled:            dbKey.Enabled,
 					UseForBatchAPI:     dbKey.UseForBatchAPI,
 				})
@@ -3350,16 +3354,63 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 			if blacklisted == nil {
 				blacklisted = []string{}
 			}
-			keys = append(keys, configstoreTables.TableKey{
+			configStoreKey := configstoreTables.TableKey{
 				KeyID:             key.ID,
 				Name:              key.Name,
-				Value:             *schemas.NewEnvVar(""),
+				Value:             *key.Value.Redacted(),
 				Models:            models,
 				BlacklistedModels: blacklisted,
 				Weight:            bifrost.Ptr(key.Weight),
 				Provider:          string(providerKey),
 				ConfigHash:        key.ConfigHash,
-			})
+			}
+			if key.AzureKeyConfig != nil {
+				cfg := *key.AzureKeyConfig // safe copy
+				cfg.Endpoint = *cfg.Endpoint.Redacted()
+				cfg.ClientID = cfg.ClientID.Redacted()
+				cfg.ClientSecret = cfg.ClientSecret.Redacted()
+				cfg.TenantID = cfg.TenantID.Redacted()
+				configStoreKey.AzureKeyConfig = &cfg
+			}
+			if key.BedrockKeyConfig != nil {
+				cfg := *key.BedrockKeyConfig // safe copy
+				cfg.ARN = key.BedrockKeyConfig.ARN.Redacted()
+				cfg.AccessKey = *cfg.AccessKey.Redacted()
+				cfg.ExternalID = cfg.ExternalID.Redacted()
+				cfg.Region = cfg.Region.Redacted()
+				cfg.RoleARN = cfg.RoleARN.Redacted()
+				cfg.RoleSessionName = cfg.RoleSessionName.Redacted()
+				cfg.SecretKey = *cfg.SecretKey.Redacted()
+				cfg.SessionToken = cfg.SessionToken.Redacted()
+				configStoreKey.BedrockKeyConfig = &cfg
+			}
+			if key.VertexKeyConfig != nil {
+				cfg := *key.VertexKeyConfig // safe copy
+				cfg.ProjectID = *cfg.ProjectID.Redacted()
+				cfg.ProjectNumber = *cfg.ProjectNumber.Redacted()
+				cfg.Region = *cfg.Region.Redacted()
+				cfg.AuthCredentials = *cfg.AuthCredentials.Redacted()
+				configStoreKey.VertexKeyConfig = &cfg
+			}
+			if key.ReplicateKeyConfig != nil {
+				configStoreKey.ReplicateKeyConfig = key.ReplicateKeyConfig
+			}
+			if key.VLLMKeyConfig != nil {
+				cfg := *key.VLLMKeyConfig // safe copy
+				cfg.URL = *cfg.URL.Redacted()
+				configStoreKey.VLLMKeyConfig = &cfg
+			}
+			if key.OllamaKeyConfig != nil {
+				cfg := *key.OllamaKeyConfig // safe copy
+				cfg.URL = *cfg.URL.Redacted()
+				configStoreKey.OllamaKeyConfig = &cfg
+			}
+			if key.SGLKeyConfig != nil {
+				cfg := *key.SGLKeyConfig // safe copy
+				cfg.URL = *cfg.URL.Redacted()
+				configStoreKey.SGLKeyConfig = &cfg
+			}
+			keys = append(keys, configStoreKey)
 		}
 	}
 

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -507,7 +507,7 @@ func (s *BifrostHTTPServer) ReloadProvider(ctx context.Context, provider schemas
 
 	// Read current key count from in-memory store (providerInfo.Keys is not preloaded from DB)
 	inMemoryKeys, _ := s.Config.GetProviderKeysRaw(provider)
-	isKeylessProvider := bifrost.IsKeylessProvider(provider) || (providerInfo.CustomProviderConfig != nil && providerInfo.CustomProviderConfig.IsKeyLess)
+	isKeylessProvider := providerInfo.CustomProviderConfig != nil && providerInfo.CustomProviderConfig.IsKeyLess
 	hasNoKeys := len(inMemoryKeys) == 0 && !isKeylessProvider
 
 	// Getting allowed models from all provider keys (needed before model listing)

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -217,7 +217,7 @@
           "$ref": "#/$defs/provider"
         },
         "ollama": {
-          "$ref": "#/$defs/provider"
+          "$ref": "#/$defs/provider_with_ollama_config"
         },
         "groq": {
           "$ref": "#/$defs/provider"
@@ -229,7 +229,7 @@
           "$ref": "#/$defs/provider"
         },
         "sgl": {
-          "$ref": "#/$defs/provider"
+          "$ref": "#/$defs/provider_with_sgl_config"
         },
         "parasail": {
           "$ref": "#/$defs/provider"
@@ -1728,6 +1728,66 @@
       },
       "additionalProperties": false
     },
+    "network_config_without_base_url": {
+      "type": "object",
+      "properties": {
+        "extra_headers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Additional headers to send with requests"
+        },
+        "default_request_timeout_in_seconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Default request timeout in seconds"
+        },
+        "max_retries": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum number of retries"
+        },
+        "retry_backoff_initial_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Initial retry backoff in milliseconds"
+        },
+        "retry_backoff_max_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum retry backoff in milliseconds"
+        },
+        "insecure_skip_verify": {
+          "type": "boolean",
+          "description": "Disable TLS certificate verification for provider connections. This bypasses server certificate validation and should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for self-signed or private CA deployments."
+        },
+        "ca_cert_pem": {
+          "type": "string",
+          "description": "PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA)"
+        },
+        "stream_idle_timeout_in_seconds": {
+          "type": "integer",
+          "minimum": 5,
+          "maximum": 3600,
+          "description": "Idle timeout per stream chunk in seconds. If no data is received for this many seconds, the stream is closed. Default: 60."
+        },
+        "max_conns_per_host": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10000,
+          "description": "Maximum number of TCP connections per provider host. For HTTP/2 (e.g. Bedrock), each connection supports ~100 concurrent streams. Default: 5000."
+        },
+        "beta_header_overrides": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Override default Anthropic beta header support per provider. Keys are header prefixes (e.g. 'redact-thinking-'), values are true (supported) or false (unsupported). Headers not listed use the built-in defaults."
+        }
+      },
+      "additionalProperties": false
+    },
     "concurrency_config": {
       "type": "object",
       "properties": {
@@ -1864,6 +1924,64 @@
           },
           "required": [
             "vllm_key_config"
+          ]
+        }
+      ]
+    },
+    "ollama_key": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_key"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ollama_key_config": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Ollama server base URL (can use env. prefix)"
+                }
+              },
+              "required": [
+                "url"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "ollama_key_config"
+          ]
+        }
+      ]
+    },
+    "sgl_key": {
+      "allOf": [
+        {
+          "$ref": "#/$defs/base_key"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "sgl_key_config": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "SGLang server base URL (can use env. prefix)"
+                }
+              },
+              "required": [
+                "url"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "sgl_key_config"
           ]
         }
       ]
@@ -2050,7 +2168,7 @@
           "description": "API keys for this provider"
         },
         "network_config": {
-          "$ref": "#/$defs/network_config"
+          "$ref": "#/$defs/network_config_without_base_url"
         },
         "concurrency_and_buffer_size": {
           "$ref": "#/$defs/concurrency_config"
@@ -2133,6 +2251,88 @@
         },
         "network_config": {
           "$ref": "#/$defs/network_config"
+        },
+        "concurrency_and_buffer_size": {
+          "$ref": "#/$defs/concurrency_config"
+        },
+        "proxy_config": {
+          "$ref": "#/$defs/proxy_config"
+        },
+        "send_back_raw_request": {
+          "type": "boolean",
+          "description": "Include raw request in BifrostResponse (default: false)"
+        },
+        "send_back_raw_response": {
+          "type": "boolean",
+          "description": "Include raw response in BifrostResponse (default: false)"
+        },
+        "store_raw_request_response": {
+          "type": "boolean",
+          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+        },
+        "custom_provider_config": {
+          "$ref": "#/$defs/custom_provider_config"
+        }
+      },
+      "required": [
+        "keys"
+      ],
+      "additionalProperties": false
+    },
+    "provider_with_ollama_config": {
+      "type": "object",
+      "properties": {
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ollama_key"
+          },
+          "minItems": 1,
+          "description": "API keys for this provider"
+        },
+        "network_config": {
+          "$ref": "#/$defs/network_config_without_base_url"
+        },
+        "concurrency_and_buffer_size": {
+          "$ref": "#/$defs/concurrency_config"
+        },
+        "proxy_config": {
+          "$ref": "#/$defs/proxy_config"
+        },
+        "send_back_raw_request": {
+          "type": "boolean",
+          "description": "Include raw request in BifrostResponse (default: false)"
+        },
+        "send_back_raw_response": {
+          "type": "boolean",
+          "description": "Include raw response in BifrostResponse (default: false)"
+        },
+        "store_raw_request_response": {
+          "type": "boolean",
+          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+        },
+        "custom_provider_config": {
+          "$ref": "#/$defs/custom_provider_config"
+        }
+      },
+      "required": [
+        "keys"
+      ],
+      "additionalProperties": false
+    },
+    "provider_with_sgl_config": {
+      "type": "object",
+      "properties": {
+        "keys": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/sgl_key"
+          },
+          "minItems": 1,
+          "description": "API keys for this provider"
+        },
+        "network_config": {
+          "$ref": "#/$defs/network_config_without_base_url"
         },
         "concurrency_and_buffer_size": {
           "$ref": "#/$defs/concurrency_config"

--- a/ui/app/workspace/providers/dialogs/addNewKeySheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewKeySheet.tsx
@@ -16,7 +16,8 @@ export default function AddNewKeySheet({ show, onCancel, provider, keyId, provid
 	const isEditing = keyId !== null;
 	const resolvedProviderName = (providerName ?? provider.name).toLowerCase();
 	const isVLLM = resolvedProviderName === "vllm";
-	const entityLabel = isVLLM ? "model" : "key";
+	const isOllamaOrSGL = resolvedProviderName === "ollama" || resolvedProviderName === "sgl";
+	const entityLabel = isVLLM ? "model" : isOllamaOrSGL ? "server" : "key";
 	const EntityLabel = entityLabel.charAt(0).toUpperCase() + entityLabel.slice(1);
 	const dialogTitle = isEditing ? `Edit ${entityLabel}` : `Add new ${entityLabel}`;
 	const successMessage = isEditing ? `${EntityLabel} updated successfully` : `${EntityLabel} added successfully`;

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -55,6 +55,9 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 	const isAzure = providerName === "azure";
 	const isReplicate = providerName === "replicate";
 	const isVLLM = providerName === "vllm";
+	const isOllama = providerName === "ollama";
+	const isSGL = providerName === "sgl";
+	const isKeylessProvider = isOllama || isSGL;
 	const supportsBatchAPI = BATCH_SUPPORTED_PROVIDERS.includes(providerName);
 
 	// Auth type state for Azure: 'api_key', 'entra_id', or 'default_credential'
@@ -171,7 +174,7 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 				/>
 			</div>
 			{/* Hide API Key field for Azure when using Entra ID/Default Credential, and for Bedrock when not using API Key auth */}
-			{!isAzure && !isBedrock && (
+			{!isAzure && !isBedrock && !isKeylessProvider && (
 				<FormField
 					control={control}
 					name={`key.value`}
@@ -203,7 +206,9 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 												</span>
 											</TooltipTrigger>
 											<TooltipContent>
-												<p>Select specific models this key applies to, or choose "Allow All Models" to allow all. Leave empty to deny all.</p>
+												<p>
+													Select specific models this key applies to, or choose "Allow All Models" to allow all. Leave empty to deny all.
+												</p>
 											</TooltipContent>
 										</Tooltip>
 									</TooltipProvider>
@@ -255,8 +260,8 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 											</TooltipTrigger>
 											<TooltipContent className="max-w-sm">
 												<p>
-													Models this key must never serve. The denylist always wins — if a model appears in both Allowed Models and here, it is blocked.
-													Select "All Models" to block every model on this key.
+													Models this key must never serve. The denylist always wins — if a model appears in both Allowed Models and here,
+													it is blocked. Select "All Models" to block every model on this key.
 												</p>
 											</TooltipContent>
 										</Tooltip>
@@ -686,6 +691,31 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 								<FormDescription>Exact model name served on this vLLM instance</FormDescription>
 								<FormControl>
 									<Input data-testid="key-input-vllm-model-name" placeholder="meta-llama/Llama-3-70b-hf" {...field} />
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+				</div>
+			)}
+			{isKeylessProvider && (
+				<div className="space-y-4">
+					<FormField
+						control={control}
+						name={`key.${isOllama ? "ollama_key_config" : "sgl_key_config"}.url`}
+						render={({ field }) => (
+							<FormItem>
+								<FormLabel>Server URL (Required)</FormLabel>
+								<FormDescription>
+									Base URL of the {isOllama ? "Ollama" : "SGLang"} server (e.g.{" "}
+									{isOllama ? "http://localhost:11434" : "http://localhost:30000"} or {isOllama ? "env.OLLAMA_URL" : "env.SGL_URL"})
+								</FormDescription>
+								<FormControl>
+									<EnvVarInput
+										data-testid={`key-input-${isOllama ? "ollama" : "sgl"}-url`}
+										placeholder={isOllama ? "http://localhost:11434" : "http://localhost:30000"}
+										{...field}
+									/>
 								</FormControl>
 								<FormMessage />
 							</FormItem>

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -77,8 +77,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				ca_cert_pem: provider.network_config?.ca_cert_pem ?? DefaultNetworkConfig.ca_cert_pem,
 				stream_idle_timeout_in_seconds:
 					provider.network_config?.stream_idle_timeout_in_seconds ?? DefaultNetworkConfig.stream_idle_timeout_in_seconds,
-				max_conns_per_host:
-					provider.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
+				max_conns_per_host: provider.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
 				enforce_http2: provider.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
 			},
 		},
@@ -89,7 +88,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 	}, [form.formState.isDirty, dispatch]);
 
 	const onSubmit = (data: NetworkOnlyFormSchema) => {
-		const requiresBaseUrl = isCustomProvider || provider.name === "ollama" || provider.name === "sgl";
+		const requiresBaseUrl = isCustomProvider;
 		if (requiresBaseUrl && (data.network_config?.base_url ?? "").trim() === "") {
 			if ((provider.network_config?.base_url ?? "").trim() !== "") {
 				toast.error("You can't remove network configuration for this provider.");
@@ -112,8 +111,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				ca_cert_pem: data.network_config?.ca_cert_pem?.trim() || undefined,
 				stream_idle_timeout_in_seconds:
 					data.network_config?.stream_idle_timeout_in_seconds ?? DefaultNetworkConfig.stream_idle_timeout_in_seconds,
-				max_conns_per_host:
-					data.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
+				max_conns_per_host: data.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
 				enforce_http2: data.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
 			},
 		});
@@ -145,14 +143,13 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				ca_cert_pem: provider.network_config?.ca_cert_pem ?? DefaultNetworkConfig.ca_cert_pem,
 				stream_idle_timeout_in_seconds:
 					provider.network_config?.stream_idle_timeout_in_seconds ?? DefaultNetworkConfig.stream_idle_timeout_in_seconds,
-				max_conns_per_host:
-					provider.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
+				max_conns_per_host: provider.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
 			},
 		});
 	}, [form, provider.name, provider.network_config]);
 
-	const baseURLRequired = provider.name === "ollama" || provider.name === "sgl" || isCustomProvider;
-	const hideBaseURL = provider.name === "vllm";
+	const baseURLRequired = isCustomProvider;
+	const hideBaseURL = provider.name === "vllm" || provider.name === "ollama" || provider.name === "sgl";
 
 	return (
 		<Form {...form}>
@@ -191,17 +188,17 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 											<Input
 												placeholder="30"
 												{...field}
-												value={field.value === undefined || Number.isNaN(field.value) ? '' : field.value}
+												value={field.value === undefined || Number.isNaN(field.value) ? "" : field.value}
 												disabled={!hasUpdateProviderAccess}
 												onChange={(e) => {
-													const value = e.target.value
-													if (value === '') {
-														field.onChange(undefined)
-														return
+													const value = e.target.value;
+													if (value === "") {
+														field.onChange(undefined);
+														return;
 													}
-													const parsed = Number(value)
+													const parsed = Number(value);
 													if (!Number.isNaN(parsed)) {
-														field.onChange(parsed)
+														field.onChange(parsed);
 													}
 													form.trigger("network_config");
 												}}
@@ -223,25 +220,25 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 												placeholder="60"
 												data-testid="network-config-stream-idle-timeout-input"
 												{...field}
-												value={field.value === undefined || Number.isNaN(field.value) ? '' : field.value}
+												value={field.value === undefined || Number.isNaN(field.value) ? "" : field.value}
 												disabled={!hasUpdateProviderAccess}
 												onChange={(e) => {
-													const value = e.target.value
-													if (value === '') {
-														field.onChange(undefined)
-														return
+													const value = e.target.value;
+													if (value === "") {
+														field.onChange(undefined);
+														return;
 													}
-													const parsed = Number(value)
+													const parsed = Number(value);
 													if (!Number.isNaN(parsed)) {
-														field.onChange(parsed)
+														field.onChange(parsed);
 													}
 													form.trigger("network_config");
 												}}
 											/>
 										</FormControl>
 										<FormDescription>
-											{field.value ? secondsToHumanReadable(field.value) : ""}
-											{" "}Max time to wait for next chunk before closing a stalled stream
+											{field.value ? secondsToHumanReadable(field.value) : ""} Max time to wait for next chunk before closing a stalled
+											stream
 										</FormDescription>
 										<FormMessage />
 									</FormItem>
@@ -257,17 +254,17 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 											<Input
 												placeholder="0"
 												{...field}
-												value={field.value === undefined || Number.isNaN(field.value) ? '' : field.value}
+												value={field.value === undefined || Number.isNaN(field.value) ? "" : field.value}
 												disabled={!hasUpdateProviderAccess}
 												onChange={(e) => {
-													const value = e.target.value
-													if (value === '') {
-														field.onChange(undefined)
-														return
+													const value = e.target.value;
+													if (value === "") {
+														field.onChange(undefined);
+														return;
 													}
-													const parsed = Number(value)
+													const parsed = Number(value);
 													if (!Number.isNaN(parsed)) {
-														field.onChange(parsed)
+														field.onChange(parsed);
 													}
 													form.trigger("network_config");
 												}}
@@ -289,17 +286,17 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 											<Input
 												placeholder="e.g 500"
 												{...field}
-												value={field.value === undefined || Number.isNaN(field.value) ? '' : field.value}
+												value={field.value === undefined || Number.isNaN(field.value) ? "" : field.value}
 												disabled={!hasUpdateProviderAccess}
 												onChange={(e) => {
-													const value = e.target.value
-													if (value === '') {
-														field.onChange(undefined)
-														return
+													const value = e.target.value;
+													if (value === "") {
+														field.onChange(undefined);
+														return;
 													}
-													const parsed = Number(value)
+													const parsed = Number(value);
 													if (!Number.isNaN(parsed)) {
-														field.onChange(parsed)
+														field.onChange(parsed);
 													}
 													form.trigger("network_config");
 												}}
@@ -319,17 +316,17 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 											<Input
 												placeholder="e.g 10000"
 												{...field}
-												value={field.value === undefined || Number.isNaN(field.value) ? '' : field.value}
+												value={field.value === undefined || Number.isNaN(field.value) ? "" : field.value}
 												disabled={!hasUpdateProviderAccess}
 												onChange={(e) => {
-													const value = e.target.value
-													if (value === '') {
-														field.onChange(undefined)
-														return
+													const value = e.target.value;
+													if (value === "") {
+														field.onChange(undefined);
+														return;
 													}
-													const parsed = Number(value)
+													const parsed = Number(value);
 													if (!Number.isNaN(parsed)) {
-														field.onChange(parsed)
+														field.onChange(parsed);
 													}
 													form.trigger("network_config");
 												}}
@@ -352,24 +349,25 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 												data-testid="network-config-max-conns-per-host-input"
 												placeholder="5000"
 												{...field}
-												value={field.value === undefined || Number.isNaN(field.value) ? '' : field.value}
+												value={field.value === undefined || Number.isNaN(field.value) ? "" : field.value}
 												disabled={!hasUpdateProviderAccess}
 												onChange={(e) => {
-													const value = e.target.value
-													if (value === '') {
-														field.onChange(undefined)
-														return
+													const value = e.target.value;
+													if (value === "") {
+														field.onChange(undefined);
+														return;
 													}
-													const parsed = Number(value)
+													const parsed = Number(value);
 													if (!Number.isNaN(parsed)) {
-														field.onChange(parsed)
+														field.onChange(parsed);
 													}
 													form.trigger("network_config");
 												}}
 											/>
 										</FormControl>
 										<FormDescription>
-											Max TCP connections per provider host. For HTTP/2 providers (e.g. Bedrock), each connection supports ~100 concurrent streams.
+											Max TCP connections per provider host. For HTTP/2 providers (e.g. Bedrock), each connection supports ~100 concurrent
+											streams.
 										</FormDescription>
 										<FormMessage />
 									</FormItem>
@@ -384,7 +382,8 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 									<div className="space-y-0.5">
 										<FormLabel>Enforce HTTP/2</FormLabel>
 										<FormDescription>
-											Force HTTP/2 on provider connections. Relevant for net/http-based providers (e.g. Bedrock) where each HTTP/2 connection supports ~100 concurrent streams.
+											Force HTTP/2 on provider connections. Relevant for net/http-based providers (e.g. Bedrock) where each HTTP/2
+											connection supports ~100 concurrent streams.
 										</FormDescription>
 									</div>
 									<FormControl>
@@ -427,7 +426,9 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 										<div className="space-y-0.5">
 											<FormLabel>Skip TLS verification</FormLabel>
 											<FormDescription>
-												Disable TLS certificate verification for provider connections. This bypasses server certificate validation and should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for self-signed or private CA deployments.
+												Disable TLS certificate verification for provider connections. This bypasses server certificate validation and
+												should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for
+												self-signed or private CA deployments.
 											</FormDescription>
 										</div>
 										<FormControl>

--- a/ui/app/workspace/providers/views/modelProviderConfig.tsx
+++ b/ui/app/workspace/providers/views/modelProviderConfig.tsx
@@ -6,7 +6,6 @@ import { useMemo, useState } from "react";
 import ProviderConfigSheet from "../dialogs/providerConfigSheet";
 import ModelProviderKeysTableView from "./modelProviderKeysTableView";
 import ProviderGovernanceTable from "./providerGovernanceTable";
-import { keysRequired } from "./utils";
 
 interface Props {
 	provider: ModelProvider;
@@ -22,13 +21,19 @@ export default function ModelProviderConfig({ provider, onRequestDelete }: Props
 		if (provider.custom_provider_config) {
 			return !(provider.custom_provider_config?.is_key_less ?? false);
 		}
-		return keysRequired(provider.name);
+		return true;
 	}, [provider.name, provider.custom_provider_config?.is_key_less]);
 
 	const editConfigButton = (
 		<div className="flex items-center gap-2">
 			{onRequestDelete && hasDeleteProviderAccess && (
-				<Button variant="outline" onClick={onRequestDelete} className="text-destructive hover:bg-destructive/10 hover:text-destructive" aria-label="Delete provider" data-testid="provider-delete-btn">
+				<Button
+					variant="outline"
+					onClick={onRequestDelete}
+					className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+					aria-label="Delete provider"
+					data-testid="provider-delete-btn"
+				>
 					<Trash className="h-4 w-4" />
 				</Button>
 			)}

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -31,13 +31,14 @@ interface Props {
 	provider: ModelProvider;
 	headerActions?: ReactNode;
 	isKeyless?: boolean;
-	providerName?: string;
 }
 
-export default function ModelProviderKeysTableView({ provider, className, headerActions, isKeyless, providerName }: Props) {
-	const isVLLM = (providerName ?? "").toLowerCase() === "vllm";
-	const entityLabel = isVLLM ? "model" : "key";
-	const entityLabelPlural = isVLLM ? "models" : "keys";
+export default function ModelProviderKeysTableView({ provider, className, headerActions, isKeyless }: Props) {
+	const providerName = provider.name?.toLowerCase() ?? "";
+	const isVLLM = providerName === "vllm";
+	const isOllamaOrSGL = providerName === "ollama" || providerName === "sgl";
+	const entityLabel = isVLLM ? "model" : isOllamaOrSGL ? "server" : "key";
+	const entityLabelPlural = isVLLM ? "models" : isOllamaOrSGL ? "servers" : "keys";
 	const EntityLabel = entityLabel.charAt(0).toUpperCase() + entityLabel.slice(1);
 	const hasUpdateProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
 	const hasDeleteProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Delete);
@@ -132,7 +133,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 					<Table className="w-full" data-testid="keys-table">
 						<TableHeader className="w-full">
 							<TableRow>
-								<TableHead>{isVLLM ? "Model" : "API Key"}</TableHead>
+								<TableHead>{isVLLM ? "Model" : isOllamaOrSGL ? "Server" : "API Key"}</TableHead>
 								<TableHead>Weight</TableHead>
 								<TableHead>Enabled</TableHead>
 								<TableHead className="text-right"></TableHead>

--- a/ui/app/workspace/providers/views/utils.ts
+++ b/ui/app/workspace/providers/views/utils.ts
@@ -1,8 +1,6 @@
 import { DefaultNetworkConfig, DefaultPerformanceConfig } from "@/lib/constants/config";
 import { ModelProvider, UpdateProviderRequest } from "@/lib/types/config";
 
-export const keysRequired = (selectedProvider: string) => selectedProvider.toLowerCase() === "custom" || !["ollama", "sgl"].includes(selectedProvider.toLowerCase());
-
 export const buildProviderUpdatePayload = (provider: ModelProvider, updates: Partial<UpdateProviderRequest>) => {
 	const { name } = provider;
 

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -226,7 +226,7 @@ export const ProviderFormSchema = z
 		}
 
 		// Base URL validation for specific providers
-		const baseURLRequired = data.selectedProvider === "ollama" || data.selectedProvider === "sgl" || isCustomProvider;
+		const baseURLRequired = isCustomProvider;
 		if (baseURLRequired) {
 			if (!data.networkConfig?.base_url) {
 				ctx.addIssue({

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -112,6 +112,26 @@ export const DefaultVLLMKeyConfig: VLLMKeyConfig = {
 	model_name: "",
 } as const satisfies Required<VLLMKeyConfig>;
 
+// OllamaKeyConfig matching Go's schemas.OllamaKeyConfig
+export interface OllamaKeyConfig {
+	url: EnvVar;
+}
+
+// Default OllamaKeyConfig
+export const DefaultOllamaKeyConfig: OllamaKeyConfig = {
+	url: { value: "", env_var: "", from_env: false },
+} as const satisfies Required<OllamaKeyConfig>;
+
+// SGLKeyConfig matching Go's schemas.SGLKeyConfig
+export interface SGLKeyConfig {
+	url: EnvVar;
+}
+
+// Default SGLKeyConfig
+export const DefaultSGLKeyConfig: SGLKeyConfig = {
+	url: { value: "", env_var: "", from_env: false },
+} as const satisfies Required<SGLKeyConfig>;
+
 // Key structure matching Go's schemas.Key
 export interface ModelProviderKey {
 	id: string;
@@ -127,6 +147,8 @@ export interface ModelProviderKey {
 	bedrock_key_config?: BedrockKeyConfig;
 	replicate_key_config?: ReplicateKeyConfig;
 	vllm_key_config?: VLLMKeyConfig;
+	ollama_key_config?: OllamaKeyConfig;
+	sgl_key_config?: SGLKeyConfig;
 	config_hash?: string; // Present when config is synced from config.json
 	status?: "unknown" | "success" | "list_models_failed";
 	description?: string;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -164,6 +164,20 @@ export const vllmKeyConfigSchema = z.object({
 	model_name: z.string().trim().min(1, "Model name is required"),
 });
 
+// Ollama key config schema
+export const ollamaKeyConfigSchema = z.object({
+	url: envVarSchema.refine((v) => !!v.value?.trim() || !!v.env_var?.trim(), {
+		message: "Server URL is required",
+	}),
+});
+
+// SGL key config schema
+export const sglKeyConfigSchema = z.object({
+	url: envVarSchema.refine((v) => !!v.value?.trim() || !!v.env_var?.trim(), {
+		message: "Server URL is required",
+	}),
+});
+
 // Model provider key schema
 export const modelProviderKeySchema = z
 	.object({
@@ -197,13 +211,22 @@ export const modelProviderKeySchema = z
 		bedrock_key_config: bedrockKeyConfigSchema.optional(),
 		replicate_key_config: replicateKeyConfigSchema.optional(),
 		vllm_key_config: vllmKeyConfigSchema.optional(),
+		ollama_key_config: ollamaKeyConfigSchema.optional(),
+		sgl_key_config: sglKeyConfigSchema.optional(),
 		use_for_batch_api: z.boolean().optional(),
 		enabled: z.boolean().optional(),
 	})
 	.refine(
 		(data) => {
-			// If bedrock_key_config, azure_key_config, vertex_key_config, or vllm_key_config is present, value is not required
-			if (data.bedrock_key_config || data.azure_key_config || data.vertex_key_config || data.vllm_key_config) {
+			// If a provider-specific key config is present, value is not required
+			if (
+				data.bedrock_key_config ||
+				data.azure_key_config ||
+				data.vertex_key_config ||
+				data.vllm_key_config ||
+				data.ollama_key_config ||
+				data.sgl_key_config
+			) {
 				return true;
 			}
 			// Otherwise, value is required


### PR DESCRIPTION
## Summary

Refactors Ollama and SGL providers to support per-key server URLs instead of requiring a single provider-level base URL. This enables load balancing across multiple Ollama/SGL instances by configuring different server URLs for each key.

## Changes

- **Provider Architecture**: Modified Ollama and SGL providers to resolve base URLs from per-key configurations (`ollama_key_config.url` and `sgl_key_config.url`) rather than provider-level `base_url`
- **Key Configuration**: Added `OllamaKeyConfig` and `SGLKeyConfig` schemas with required URL fields, including database migrations and UI support
- **Request Handling**: Updated all API endpoints (chat, completions, embeddings, list models) to use per-key URLs with proper error handling when URLs are missing
- **List Models**: Refactored to query each backend concurrently using `HandleMultipleListModelsRequests` pattern
- **Key Management**: Updated key validation logic to allow empty API key values for Ollama/SGL while requiring URL configuration
- **UI Updates**: Enhanced forms to show "server" terminology for Ollama/SGL instead of "key", added URL input fields with proper validation

## Type of change

- [x] Feature
- [x] Refactor

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] UI (Next.js)

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Test with multiple Ollama/SGL instances:
1. Configure multiple keys with different `ollama_key_config.url` values
2. Verify list models queries each instance separately
3. Test chat/completion requests route to correct servers
4. Confirm load balancing works across configured instances

## Breaking changes

- [x] Yes

**Migration Required**: Existing Ollama/SGL configurations using provider-level `base_url` must migrate to per-key URL configuration. Each key now requires an `ollama_key_config.url` or `sgl_key_config.url` field. The provider-level `base_url` is no longer used.

## Security considerations

Per-key URL configuration allows more granular control over which servers each key can access, improving security isolation between different Ollama/SGL deployments.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable