### PR TITLE
feat: updated debugging form for better ux

### DIFF
--- a/ui/app/workspace/providers/fragments/debuggingFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/debuggingFormFragment.tsx
@@ -32,6 +32,7 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 			store_raw_request_response: provider.store_raw_request_response ?? false,
 		},
 	});
+	const storeRawEnabled = form.watch("store_raw_request_response");
 
 	useEffect(() => {
 		dispatch(setProviderFormDirtyState(form.formState.isDirty));
@@ -43,7 +44,8 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 			send_back_raw_response: provider.send_back_raw_response ?? false,
 			store_raw_request_response: provider.store_raw_request_response ?? false,
 		});
-	}, [form, provider.name, provider.send_back_raw_request, provider.send_back_raw_response, provider.store_raw_request_response]);
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [provider.name, provider.send_back_raw_request, provider.send_back_raw_response, provider.store_raw_request_response]);
 
 	const onSubmit = (data: DebuggingFormSchema) => {
 		const updatedProvider = buildProviderUpdatePayload(provider, {
@@ -67,63 +69,9 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 	return (
 		<Form {...form}>
 			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6" data-testid="provider-config-debugging-content">
-				<div className="space-y-4">
-					<FormField
-						control={form.control}
-						name="send_back_raw_request"
-						render={({ field }) => (
-							<FormItem>
-								<div className="flex items-center justify-between space-x-2">
-									<div className="space-y-0.5">
-										<FormLabel>Send Back Raw Request</FormLabel>
-										<p className="text-muted-foreground text-xs">
-											Include the raw provider request alongside the parsed request for debugging and advanced use cases
-										</p>
-									</div>
-									<FormControl>
-										<Switch
-											size="md"
-											checked={field.value}
-											disabled={!hasUpdateProviderAccess}
-											onCheckedChange={(checked) => {
-												field.onChange(checked);
-												form.trigger("send_back_raw_request");
-											}}
-										/>
-									</FormControl>
-								</div>
-								<FormMessage />
-							</FormItem>
-						)}
-					/>
-					<FormField
-						control={form.control}
-						name="send_back_raw_response"
-						render={({ field }) => (
-							<FormItem>
-								<div className="flex items-center justify-between space-x-2">
-									<div className="space-y-0.5">
-										<FormLabel>Send Back Raw Response</FormLabel>
-										<p className="text-muted-foreground text-xs">
-											Include the raw provider response alongside the parsed response for debugging and advanced use cases
-										</p>
-									</div>
-									<FormControl>
-										<Switch
-											size="md"
-											checked={field.value}
-											disabled={!hasUpdateProviderAccess}
-											onCheckedChange={(checked) => {
-												field.onChange(checked);
-												form.trigger("send_back_raw_response");
-											}}
-										/>
-									</FormControl>
-								</div>
-								<FormMessage />
-							</FormItem>
-						)}
-					/>
+				<div className="space-y-0">
+
+					{/* Parent: Store Raw Request/Response */}
 					<FormField
 						control={form.control}
 						name="store_raw_request_response"
@@ -131,9 +79,9 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 							<FormItem>
 								<div className="flex items-center justify-between space-x-2">
 									<div className="space-y-0.5">
-										<FormLabel>Store Raw Request/Response</FormLabel>
+										<FormLabel>Enable Raw Request/Response</FormLabel>
 										<p className="text-muted-foreground text-xs">
-											Capture the raw provider request and response for internal logging. Raw payloads are not returned to clients unless send_back_raw_request or send_back_raw_response are also enabled.
+											Capture the raw provider request and response for internal logging. Raw payloads are not returned to clients unless send_back_raw_request and send_back_raw_response are also enabled.
 										</p>
 									</div>
 									<FormControl>
@@ -144,6 +92,10 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 											disabled={!hasUpdateProviderAccess}
 											onCheckedChange={(checked) => {
 												field.onChange(checked);
+												if (!checked) {
+													form.setValue("send_back_raw_request", false, { shouldDirty: true });
+													form.setValue("send_back_raw_response", false, { shouldDirty: true });
+												}
 												form.trigger("store_raw_request_response");
 											}}
 										/>
@@ -153,6 +105,81 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 							</FormItem>
 						)}
 					/>
+
+					{/* Children with tree connectors */}
+					<div className="relative mt-3 space-y-3 pl-6">
+
+						{/* Child 1: Send Back Raw Request — trunk continues past this to next sibling */}
+						<div className="relative">
+							{/* Vertical trunk — extends past bottom by the gap (space-y-3 = 0.75rem) to connect with child 2 */}
+							<div className="absolute -left-6 top-0 -bottom-3 w-px bg-border" />
+							{/* Horizontal branch at label center (~9px from top) */}
+							<div className="absolute -left-6 top-[0.5625rem] w-5 h-px bg-border" />
+							<FormField
+								control={form.control}
+								name="send_back_raw_request"
+								render={({ field }) => (
+									<FormItem>
+										<div className="flex items-center justify-between space-x-2">
+											<div className="space-y-0.5">
+												<FormLabel>Send Back Raw Request</FormLabel>
+												<p className="text-muted-foreground text-xs">
+												Include the raw provider request alongside the parsed request for debugging and advanced use cases
+												</p>
+											</div>
+											<FormControl>
+												<Switch
+													size="md"
+													checked={field.value}
+													disabled={!hasUpdateProviderAccess || !storeRawEnabled}
+													onCheckedChange={(checked) => {
+														field.onChange(checked);
+														form.trigger("send_back_raw_request");
+													}}
+												/>
+											</FormControl>
+										</div>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
+
+						{/* Child 2: Send Back Raw Response — last child, trunk stops at label */}
+						<div className="relative">
+							{/* L-connector: vertical from top down to label center, then turns right */}
+							<div className="absolute -left-6 top-0 w-5 h-[0.5625rem] border-l border-b border-border rounded-bl" />
+							<FormField
+								control={form.control}
+								name="send_back_raw_response"
+								render={({ field }) => (
+									<FormItem>
+										<div className="flex items-center justify-between space-x-2">
+											<div className="space-y-0.5">
+												<FormLabel>Send Back Raw Response</FormLabel>
+												<p className="text-muted-foreground text-xs">
+												Include the raw provider response alongside the parsed response for debugging and advanced use cases
+												</p>
+											</div>
+											<FormControl>
+												<Switch
+													size="md"
+													checked={field.value}
+													disabled={!hasUpdateProviderAccess || !storeRawEnabled}
+													onCheckedChange={(checked) => {
+														field.onChange(checked);
+														form.trigger("send_back_raw_response");
+													}}
+												/>
+											</FormControl>
+										</div>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+						</div>
+
+					</div>
 				</div>
 
 				<div className="flex justify-end space-x-2 pb-6">


### PR DESCRIPTION
## Summary

Restructured the debugging form to establish a hierarchical relationship between raw request/response options, where the "Store Raw Request/Response" setting acts as a parent control that enables/disables the child options for sending back raw data.

## Changes

- Reorganized form fields to show "Enable Raw Request/Response" as the parent control with "Send Back Raw Request" and "Send Back Raw Response" as dependent child options
- Added visual tree connectors using CSS borders to illustrate the parent-child relationship between form fields
- Implemented automatic disabling of child options when the parent "store_raw_request_response" is disabled
- Added logic to automatically uncheck child options when parent is disabled
- Updated form labels and descriptions for better clarity
- Added form field watching to track the parent control state
- Removed form dependency from useEffect to prevent unnecessary re-renders

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Navigate to the provider debugging configuration form and verify:
1. The "Enable Raw Request/Response" toggle controls the availability of child options
2. When the parent toggle is disabled, child options are automatically disabled and unchecked
3. Visual tree connectors properly display the hierarchical relationship
4. Form validation and submission work correctly with the new structure

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

Screenshots showing the new hierarchical form layout with tree connectors would be helpful to demonstrate the visual improvements.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications - this is a UI restructuring that maintains the same underlying functionality and access controls.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable