### PR TITLE
fix Client settings UI to accept * as accepted headers

### DIFF
--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -794,9 +794,11 @@ func headerFilterConfigEqual(a, b *configstoreTables.GlobalHeaderFilterConfig) b
 	return slices.Equal(a.Allowlist, b.Allowlist) && slices.Equal(a.Denylist, b.Denylist)
 }
 
-// validateHeaderFilterConfig validates that no security headers are in the allowlist or denylist
+// validateHeaderFilterConfig validates that no exact security header names are in the allowlist or denylist
 // and that wildcard patterns use valid syntax (only trailing * is supported).
-// Returns an error if any security headers are found or patterns are invalid.
+// Wildcard patterns that would match security headers are allowed because security headers
+// are unconditionally stripped at runtime regardless of configuration.
+// Returns an error if any exact security headers are found or patterns are invalid.
 func validateHeaderFilterConfig(config *configstoreTables.GlobalHeaderFilterConfig) error {
 	if config == nil {
 		return nil
@@ -830,15 +832,12 @@ func validateHeaderFilterConfig(config *configstoreTables.GlobalHeaderFilterConf
 
 	var foundSecurityHeaders []string
 
-	// Check allowlist for security headers (including wildcard patterns)
+	// Check allowlist for exact security header names.
+	// Wildcard patterns are allowed — security headers are always stripped at runtime
+	// unconditionally in ctx.go, regardless of allowlist/denylist configuration.
 	for _, header := range config.Allowlist {
 		headerLower := strings.ToLower(strings.TrimSpace(header))
 		if strings.Contains(headerLower, "*") {
-			for _, secHeader := range securityHeaders {
-				if lib.HeaderMatchesPattern(headerLower, secHeader) && !slices.Contains(foundSecurityHeaders, secHeader) {
-					foundSecurityHeaders = append(foundSecurityHeaders, secHeader)
-				}
-			}
 			continue
 		}
 		if slices.Contains(securityHeaders, headerLower) {
@@ -846,15 +845,10 @@ func validateHeaderFilterConfig(config *configstoreTables.GlobalHeaderFilterConf
 		}
 	}
 
-	// Check denylist for security headers (including wildcard patterns)
+	// Check denylist for exact security header names.
 	for _, header := range config.Denylist {
 		headerLower := strings.ToLower(strings.TrimSpace(header))
 		if strings.Contains(headerLower, "*") {
-			for _, secHeader := range securityHeaders {
-				if lib.HeaderMatchesPattern(headerLower, secHeader) && !slices.Contains(foundSecurityHeaders, secHeader) {
-					foundSecurityHeaders = append(foundSecurityHeaders, secHeader)
-				}
-			}
 			continue
 		}
 		if slices.Contains(securityHeaders, headerLower) && !slices.Contains(foundSecurityHeaders, headerLower) {

--- a/transports/bifrost-http/handlers/config_headerfilter_test.go
+++ b/transports/bifrost-http/handlers/config_headerfilter_test.go
@@ -85,28 +85,22 @@ func TestValidateHeaderFilterConfig(t *testing.T) {
 			errSubstr: "not allowed to be configured",
 		},
 		{
-			name: "wildcard matching security header rejected",
+			name: "wildcard matching security header allowed (runtime strips security headers)",
 			config: &configstoreTables.GlobalHeaderFilterConfig{
 				Allowlist: []string{"authorization*"},
 			},
-			wantErr:   true,
-			errSubstr: "not allowed to be configured",
 		},
 		{
-			name: "wildcard prefix matching security headers rejected",
+			name: "wildcard prefix matching security headers allowed (runtime strips security headers)",
 			config: &configstoreTables.GlobalHeaderFilterConfig{
 				Allowlist: []string{"x-api-*"},
 			},
-			wantErr:   true,
-			errSubstr: "not allowed to be configured",
 		},
 		{
-			name: "bare wildcard in allowlist rejected (matches all security headers)",
+			name: "bare wildcard in allowlist allowed (runtime strips security headers)",
 			config: &configstoreTables.GlobalHeaderFilterConfig{
 				Allowlist: []string{"*"},
 			},
-			wantErr:   true,
-			errSubstr: "not allowed to be configured",
 		},
 		// Invalid wildcard syntax
 		{

--- a/ui/app/workspace/config/views/clientSettingsView.tsx
+++ b/ui/app/workspace/config/views/clientSettingsView.tsx
@@ -191,7 +191,7 @@ export default function ClientSettingsView() {
 				await updateCoreConfig({ ...bifrostConfig!, client_config: cleanedConfig }).unwrap();
 				coreConfigSaved = true;
 			} catch (error) {
-				toast.error(`Failed to save core config: ${getErrorMessage(error)}`);
+				toast.error(`Failed to save client config: ${getErrorMessage(error)}`);
 			}
 		}
 


### PR DESCRIPTION
## Summary

Relaxes header filter validation to allow wildcard patterns that match security headers while maintaining strict validation for exact security header names. This change recognizes that security headers are unconditionally stripped at runtime regardless of configuration.

## Changes

- Modified `validateHeaderFilterConfig` to only reject exact security header names in allowlist/denylist
- Removed validation logic that prevented wildcard patterns from matching security headers
- Updated function comments to clarify that wildcard patterns are allowed because security headers are always stripped at runtime
- Fixed error message in UI to correctly reference "client config" instead of "core config"

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Validate that wildcard patterns in header filter configuration are now accepted:

```sh
# Core/Transports
go version
go test ./transports/bifrost-http/handlers/...

# Test specific scenarios:
# - Wildcard patterns like "authorization*" should be accepted
# - Exact security header names like "authorization" should still be rejected
# - Invalid wildcard syntax should still be rejected

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A - Backend validation changes only

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change maintains security by ensuring security headers are always stripped at runtime in `ctx.go`, regardless of allowlist/denylist configuration. The validation change only affects configuration acceptance, not runtime behavior.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable