### PR TITLE
fix(governance): populate customer virtual_keys in governance APIs

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1518,11 +1518,10 @@ func preloadCustomerRelations(db *gorm.DB, prefix string) *gorm.DB {
 		Preload(relation("VirtualKeys"))
 }
 
-func preloadVirtualKeyRelations(db *gorm.DB) *gorm.DB {
+func preloadVirtualKeyBaseRelations(db *gorm.DB) *gorm.DB {
 	db = db.Preload("Team").Preload("Team.Customer")
 
 	db = db.Preload("Customer")
-	db = preloadCustomerRelations(db, "Customer.")
 
 	return db.
 		Preload("Budget").
@@ -1537,12 +1536,16 @@ func preloadVirtualKeyRelations(db *gorm.DB) *gorm.DB {
 		Preload("MCPConfigs.MCPClient")
 }
 
+func preloadVirtualKeyDetailRelations(db *gorm.DB) *gorm.DB {
+	return preloadCustomerRelations(preloadVirtualKeyBaseRelations(db), "Customer.")
+}
+
 // GetVirtualKeys retrieves all virtual keys from the database.
 func (s *RDBConfigStore) GetVirtualKeys(ctx context.Context) ([]tables.TableVirtualKey, error) {
 	var virtualKeys []tables.TableVirtualKey
 
 	// Preload all relationships for complete information
-	if err := preloadVirtualKeyRelations(s.db.WithContext(ctx)).
+	if err := preloadVirtualKeyBaseRelations(s.db.WithContext(ctx)).
 		Order("created_at ASC").
 		Find(&virtualKeys).Error; err != nil {
 		return nil, err
@@ -1591,7 +1594,7 @@ func (s *RDBConfigStore) GetVirtualKeysPaginated(ctx context.Context, params Vir
 
 	// Fetch with preloads and pagination
 	var virtualKeys []tables.TableVirtualKey
-	if err := preloadVirtualKeyRelations(baseQuery).
+	if err := preloadVirtualKeyBaseRelations(baseQuery).
 		Order("created_at ASC, id ASC").
 		Offset(offset).
 		Limit(limit).
@@ -1604,7 +1607,7 @@ func (s *RDBConfigStore) GetVirtualKeysPaginated(ctx context.Context, params Vir
 // GetVirtualKey retrieves a virtual key from the database.
 func (s *RDBConfigStore) GetVirtualKey(ctx context.Context, id string) (*tables.TableVirtualKey, error) {
 	var virtualKey tables.TableVirtualKey
-	if err := preloadVirtualKeyRelations(s.db.WithContext(ctx)).
+	if err := preloadVirtualKeyDetailRelations(s.db.WithContext(ctx)).
 		First(&virtualKey, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
@@ -1618,7 +1621,7 @@ func (s *RDBConfigStore) GetVirtualKey(ctx context.Context, id string) (*tables.
 func (s *RDBConfigStore) GetVirtualKeyByValue(ctx context.Context, value string) (*tables.TableVirtualKey, error) {
 	valueHash := encrypt.HashSHA256(value)
 	var virtualKey tables.TableVirtualKey
-	query := preloadVirtualKeyRelations(s.db.WithContext(ctx))
+	query := preloadVirtualKeyBaseRelations(s.db.WithContext(ctx))
 
 	// Use hash-based lookup if hash column is populated, fall back to plaintext for backward compat
 	if err := query.Where("value_hash = ?", valueHash).First(&virtualKey).Error; err != nil {

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1503,15 +1503,28 @@ func (s *RDBConfigStore) GetRedactedVirtualKeys(ctx context.Context, ids []strin
 	return virtualKeys, nil
 }
 
-// GetVirtualKeys retrieves all virtual keys from the database.
-func (s *RDBConfigStore) GetVirtualKeys(ctx context.Context) ([]tables.TableVirtualKey, error) {
-	var virtualKeys []tables.TableVirtualKey
+func preloadCustomerRelations(db *gorm.DB, prefix string) *gorm.DB {
+	relation := func(name string) string {
+		if prefix == "" {
+			return name
+		}
+		return prefix + name
+	}
 
-	// Preload all relationships for complete information
-	if err := s.db.WithContext(ctx).
-		Preload("Team").
-		Preload("Team.Customer").
-		Preload("Customer").
+	return db.
+		Preload(relation("Teams")).
+		Preload(relation("Budget")).
+		Preload(relation("RateLimit")).
+		Preload(relation("VirtualKeys"))
+}
+
+func preloadVirtualKeyRelations(db *gorm.DB) *gorm.DB {
+	db = db.Preload("Team").Preload("Team.Customer")
+
+	db = db.Preload("Customer")
+	db = preloadCustomerRelations(db, "Customer.")
+
+	return db.
 		Preload("Budget").
 		Preload("RateLimit").
 		Preload("ProviderConfigs").
@@ -1521,7 +1534,15 @@ func (s *RDBConfigStore) GetVirtualKeys(ctx context.Context) ([]tables.TableVirt
 			return db.Select("id, name, key_id, models_json, provider")
 		}).
 		Preload("MCPConfigs").
-		Preload("MCPConfigs.MCPClient").
+		Preload("MCPConfigs.MCPClient")
+}
+
+// GetVirtualKeys retrieves all virtual keys from the database.
+func (s *RDBConfigStore) GetVirtualKeys(ctx context.Context) ([]tables.TableVirtualKey, error) {
+	var virtualKeys []tables.TableVirtualKey
+
+	// Preload all relationships for complete information
+	if err := preloadVirtualKeyRelations(s.db.WithContext(ctx)).
 		Order("created_at ASC").
 		Find(&virtualKeys).Error; err != nil {
 		return nil, err
@@ -1570,20 +1591,7 @@ func (s *RDBConfigStore) GetVirtualKeysPaginated(ctx context.Context, params Vir
 
 	// Fetch with preloads and pagination
 	var virtualKeys []tables.TableVirtualKey
-	if err := baseQuery.
-		Preload("Team").
-		Preload("Team.Customer").
-		Preload("Customer").
-		Preload("Budget").
-		Preload("RateLimit").
-		Preload("ProviderConfigs").
-		Preload("ProviderConfigs.Budget").
-		Preload("ProviderConfigs.RateLimit").
-		Preload("ProviderConfigs.Keys", func(db *gorm.DB) *gorm.DB {
-			return db.Select("id, name, key_id, models_json, provider")
-		}).
-		Preload("MCPConfigs").
-		Preload("MCPConfigs.MCPClient").
+	if err := preloadVirtualKeyRelations(baseQuery).
 		Order("created_at ASC, id ASC").
 		Offset(offset).
 		Limit(limit).
@@ -1596,20 +1604,7 @@ func (s *RDBConfigStore) GetVirtualKeysPaginated(ctx context.Context, params Vir
 // GetVirtualKey retrieves a virtual key from the database.
 func (s *RDBConfigStore) GetVirtualKey(ctx context.Context, id string) (*tables.TableVirtualKey, error) {
 	var virtualKey tables.TableVirtualKey
-	if err := s.db.WithContext(ctx).
-		Preload("Team").
-		Preload("Team.Customer").
-		Preload("Customer").
-		Preload("Budget").
-		Preload("RateLimit").
-		Preload("ProviderConfigs").
-		Preload("ProviderConfigs.Budget").
-		Preload("ProviderConfigs.RateLimit").
-		Preload("ProviderConfigs.Keys", func(db *gorm.DB) *gorm.DB {
-			return db.Select("id, name, key_id, models_json, provider")
-		}).
-		Preload("MCPConfigs").
-		Preload("MCPConfigs.MCPClient").
+	if err := preloadVirtualKeyRelations(s.db.WithContext(ctx)).
 		First(&virtualKey, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
@@ -1623,20 +1618,7 @@ func (s *RDBConfigStore) GetVirtualKey(ctx context.Context, id string) (*tables.
 func (s *RDBConfigStore) GetVirtualKeyByValue(ctx context.Context, value string) (*tables.TableVirtualKey, error) {
 	valueHash := encrypt.HashSHA256(value)
 	var virtualKey tables.TableVirtualKey
-	query := s.db.WithContext(ctx).
-		Preload("Team").
-		Preload("Team.Customer").
-		Preload("Customer").
-		Preload("Budget").
-		Preload("RateLimit").
-		Preload("ProviderConfigs").
-		Preload("ProviderConfigs.Budget").
-		Preload("ProviderConfigs.RateLimit").
-		Preload("ProviderConfigs.Keys", func(db *gorm.DB) *gorm.DB {
-			return db.Select("id, name, key_id, models_json, provider")
-		}).
-		Preload("MCPConfigs").
-		Preload("MCPConfigs.MCPClient")
+	query := preloadVirtualKeyRelations(s.db.WithContext(ctx))
 
 	// Use hash-based lookup if hash column is populated, fall back to plaintext for backward compat
 	if err := query.Where("value_hash = ?", valueHash).First(&virtualKey).Error; err != nil {
@@ -2240,7 +2222,9 @@ func (s *RDBConfigStore) DeleteTeam(ctx context.Context, id string) error {
 // GetCustomers retrieves all customers from the database.
 func (s *RDBConfigStore) GetCustomers(ctx context.Context) ([]tables.TableCustomer, error) {
 	var customers []tables.TableCustomer
-	if err := s.db.WithContext(ctx).Preload("Teams").Preload("Budget").Preload("RateLimit").Order("created_at ASC").Find(&customers).Error; err != nil {
+	if err := preloadCustomerRelations(s.db.WithContext(ctx), "").
+		Order("created_at ASC").
+		Find(&customers).Error; err != nil {
 		return nil, err
 	}
 	return customers, nil
@@ -2268,8 +2252,7 @@ func (s *RDBConfigStore) GetCustomersPaginated(ctx context.Context, params Custo
 		offset = 0
 	}
 	var customers []tables.TableCustomer
-	if err := baseQuery.
-		Preload("Teams").Preload("Budget").Preload("RateLimit").
+	if err := preloadCustomerRelations(baseQuery, "").
 		Order("created_at ASC, id ASC").
 		Offset(offset).Limit(limit).
 		Find(&customers).Error; err != nil {
@@ -2281,7 +2264,8 @@ func (s *RDBConfigStore) GetCustomersPaginated(ctx context.Context, params Custo
 // GetCustomer retrieves a specific customer from the database.
 func (s *RDBConfigStore) GetCustomer(ctx context.Context, id string) (*tables.TableCustomer, error) {
 	var customer tables.TableCustomer
-	if err := s.db.WithContext(ctx).Preload("Teams").Preload("Budget").Preload("RateLimit").First(&customer, "id = ?", id).Error; err != nil {
+	if err := preloadCustomerRelations(s.db.WithContext(ctx), "").
+		First(&customer, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -191,33 +191,27 @@ func NewLocalGovernanceStore(ctx context.Context, logger schemas.Logger, configS
 }
 
 func (gs *LocalGovernanceStore) GetGovernanceData() *GovernanceData {
-	virtualKeys := make(map[string]*configstoreTables.TableVirtualKey)
-	gs.virtualKeys.Range(func(key, value interface{}) bool {
-		vk, ok := value.(*configstoreTables.TableVirtualKey)
-		if !ok || vk == nil {
-			return true // continue
+	refreshVKAssociations := func(vk *configstoreTables.TableVirtualKey) {
+		if vk == nil {
+			return
 		}
-		// Cross-reference live budget/rate limit from standalone maps
-		// (usage updates clone into budgets/rateLimits maps, so embedded pointers go stale)
-		clone := *vk
-		if clone.BudgetID != nil {
-			if liveBudget, exists := gs.budgets.Load(*clone.BudgetID); exists && liveBudget != nil {
+		if vk.BudgetID != nil {
+			if liveBudget, exists := gs.budgets.Load(*vk.BudgetID); exists && liveBudget != nil {
 				if b, ok := liveBudget.(*configstoreTables.TableBudget); ok {
-					clone.Budget = b
+					vk.Budget = b
 				}
 			}
 		}
-		if clone.RateLimitID != nil {
-			if liveRL, exists := gs.rateLimits.Load(*clone.RateLimitID); exists && liveRL != nil {
+		if vk.RateLimitID != nil {
+			if liveRL, exists := gs.rateLimits.Load(*vk.RateLimitID); exists && liveRL != nil {
 				if rl, ok := liveRL.(*configstoreTables.TableRateLimit); ok {
-					clone.RateLimit = rl
+					vk.RateLimit = rl
 				}
 			}
 		}
-		// Also fix embedded ProviderConfigs
-		if len(clone.ProviderConfigs) > 0 {
-			configs := make([]configstoreTables.TableVirtualKeyProviderConfig, len(clone.ProviderConfigs))
-			copy(configs, clone.ProviderConfigs)
+		if len(vk.ProviderConfigs) > 0 {
+			configs := make([]configstoreTables.TableVirtualKeyProviderConfig, len(vk.ProviderConfigs))
+			copy(configs, vk.ProviderConfigs)
 			for i := range configs {
 				if configs[i].BudgetID != nil {
 					if liveBudget, exists := gs.budgets.Load(*configs[i].BudgetID); exists && liveBudget != nil {
@@ -234,8 +228,38 @@ func (gs *LocalGovernanceStore) GetGovernanceData() *GovernanceData {
 					}
 				}
 			}
-			clone.ProviderConfigs = configs
+			vk.ProviderConfigs = configs
 		}
+	}
+
+	refreshTeamAssociations := func(team *configstoreTables.TableTeam) {
+		if team == nil {
+			return
+		}
+		if team.BudgetID != nil {
+			if liveBudget, exists := gs.budgets.Load(*team.BudgetID); exists && liveBudget != nil {
+				if b, ok := liveBudget.(*configstoreTables.TableBudget); ok {
+					team.Budget = b
+				}
+			}
+		}
+		if team.RateLimitID != nil {
+			if liveRL, exists := gs.rateLimits.Load(*team.RateLimitID); exists && liveRL != nil {
+				if rl, ok := liveRL.(*configstoreTables.TableRateLimit); ok {
+					team.RateLimit = rl
+				}
+			}
+		}
+	}
+
+	virtualKeys := make(map[string]*configstoreTables.TableVirtualKey)
+	gs.virtualKeys.Range(func(key, value interface{}) bool {
+		vk, ok := value.(*configstoreTables.TableVirtualKey)
+		if !ok || vk == nil {
+			return true // continue
+		}
+		clone := *vk
+		refreshVKAssociations(&clone)
 		virtualKeys[key.(string)] = &clone
 		return true // continue iteration
 	})
@@ -245,22 +269,8 @@ func (gs *LocalGovernanceStore) GetGovernanceData() *GovernanceData {
 		if !ok || team == nil {
 			return true // continue
 		}
-		// Cross-reference live budget/rate limit from standalone maps
 		clone := *team
-		if clone.BudgetID != nil {
-			if liveBudget, exists := gs.budgets.Load(*clone.BudgetID); exists && liveBudget != nil {
-				if b, ok := liveBudget.(*configstoreTables.TableBudget); ok {
-					clone.Budget = b
-				}
-			}
-		}
-		if clone.RateLimitID != nil {
-			if liveRL, exists := gs.rateLimits.Load(*clone.RateLimitID); exists && liveRL != nil {
-				if rl, ok := liveRL.(*configstoreTables.TableRateLimit); ok {
-					clone.RateLimit = rl
-				}
-			}
-		}
+		refreshTeamAssociations(&clone)
 		teams[key.(string)] = &clone
 		return true // continue iteration
 	})
@@ -270,8 +280,9 @@ func (gs *LocalGovernanceStore) GetGovernanceData() *GovernanceData {
 		if !ok || customer == nil {
 			return true // continue
 		}
-		// Cross-reference live budget/rate limit from standalone maps
 		clone := *customer
+		clone.Teams = make([]configstoreTables.TableTeam, 0)
+		clone.VirtualKeys = make([]configstoreTables.TableVirtualKey, 0)
 		if clone.BudgetID != nil {
 			if liveBudget, exists := gs.budgets.Load(*clone.BudgetID); exists && liveBudget != nil {
 				if b, ok := liveBudget.(*configstoreTables.TableBudget); ok {
@@ -289,6 +300,55 @@ func (gs *LocalGovernanceStore) GetGovernanceData() *GovernanceData {
 		customers[key.(string)] = &clone
 		return true // continue iteration
 	})
+
+	for _, team := range teams {
+		if team == nil {
+			continue
+		}
+		if team.CustomerID != nil {
+			if customer, exists := customers[*team.CustomerID]; exists && customer != nil {
+				team.Customer = customer
+
+				nestedTeam := *team
+				nestedTeam.Customer = nil
+				customer.Teams = append(customer.Teams, nestedTeam)
+			}
+		}
+	}
+
+	for _, vk := range virtualKeys {
+		if vk == nil {
+			continue
+		}
+		if vk.TeamID != nil {
+			if team, exists := teams[*vk.TeamID]; exists && team != nil {
+				vk.Team = team
+			}
+		}
+		if vk.CustomerID != nil {
+			if customer, exists := customers[*vk.CustomerID]; exists && customer != nil {
+				vk.Customer = customer
+
+				nestedVK := *vk
+				nestedVK.Customer = nil
+				refreshVKAssociations(&nestedVK)
+				customer.VirtualKeys = append(customer.VirtualKeys, nestedVK)
+			}
+		}
+	}
+
+	for _, customer := range customers {
+		if customer == nil {
+			continue
+		}
+		sort.Slice(customer.Teams, func(i, j int) bool {
+			return customer.Teams[i].CreatedAt.Before(customer.Teams[j].CreatedAt)
+		})
+		sort.Slice(customer.VirtualKeys, func(i, j int) bool {
+			return customer.VirtualKeys[i].CreatedAt.Before(customer.VirtualKeys[j].CreatedAt)
+		})
+	}
+
 	budgets := make(map[string]*configstoreTables.TableBudget)
 	gs.budgets.Range(func(key, value interface{}) bool {
 		budget, ok := value.(*configstoreTables.TableBudget)

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -331,7 +331,6 @@ func (gs *LocalGovernanceStore) GetGovernanceData() *GovernanceData {
 
 				nestedVK := *vk
 				nestedVK.Customer = nil
-				refreshVKAssociations(&nestedVK)
 				customer.VirtualKeys = append(customer.VirtualKeys, nestedVK)
 			}
 		}
@@ -342,9 +341,15 @@ func (gs *LocalGovernanceStore) GetGovernanceData() *GovernanceData {
 			continue
 		}
 		sort.Slice(customer.Teams, func(i, j int) bool {
+			if customer.Teams[i].CreatedAt.Equal(customer.Teams[j].CreatedAt) {
+				return customer.Teams[i].ID < customer.Teams[j].ID
+			}
 			return customer.Teams[i].CreatedAt.Before(customer.Teams[j].CreatedAt)
 		})
 		sort.Slice(customer.VirtualKeys, func(i, j int) bool {
+			if customer.VirtualKeys[i].CreatedAt.Equal(customer.VirtualKeys[j].CreatedAt) {
+				return customer.VirtualKeys[i].ID < customer.VirtualKeys[j].ID
+			}
 			return customer.VirtualKeys[i].CreatedAt.Before(customer.VirtualKeys[j].CreatedAt)
 		})
 	}

--- a/tests/governance/customer_virtual_keys_response_test.go
+++ b/tests/governance/customer_virtual_keys_response_test.go
@@ -1,0 +1,564 @@
+package governance
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestCustomerResponsesIncludeAssignedVirtualKeys(t *testing.T) {
+	t.Parallel()
+	testData := NewGlobalTestData()
+	defer testData.Cleanup(t)
+
+	customerName := "test-customer-vk-response-" + generateRandomID()
+	createCustomerResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/customers",
+		Body: CreateCustomerRequest{
+			Name: customerName,
+		},
+	})
+
+	if createCustomerResp.StatusCode != 200 {
+		t.Fatalf("Failed to create customer: status %d", createCustomerResp.StatusCode)
+	}
+
+	customerID := ExtractIDFromResponse(t, createCustomerResp)
+	testData.AddCustomer(customerID)
+
+	customerData := createCustomerResp.Body["customer"].(map[string]interface{})
+	assertJSONArrayField(t, customerData, "teams", 0)
+	assertJSONArrayField(t, customerData, "virtual_keys", 0)
+
+	vkName := "test-vk-customer-response-" + generateRandomID()
+	createVKResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/virtual-keys",
+		Body: CreateVirtualKeyRequest{
+			Name:       vkName,
+			CustomerID: &customerID,
+		},
+	})
+
+	if createVKResp.StatusCode != 200 {
+		t.Fatalf("Failed to create VK: status %d", createVKResp.StatusCode)
+	}
+
+	vkID := ExtractIDFromResponse(t, createVKResp)
+	testData.AddVirtualKey(vkID)
+
+	customerDetailReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/customers/" + customerID,
+	}
+	customerListReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/customers",
+	}
+	customerMemoryDetailReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/customers/" + customerID + "?from_memory=true",
+	}
+	customerMemoryListReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/customers?from_memory=true",
+	}
+
+	if _, ok := WaitForAPICondition(t, customerDetailReq, func(resp *APIResponse) bool {
+		return customerHasVirtualKey(resp, customerID, vkID)
+	}, 5*time.Second, "db customer detail shows assigned virtual key"); !ok {
+		t.Fatalf("Customer detail never showed assigned virtual key")
+	}
+
+	if _, ok := WaitForAPICondition(t, customerListReq, func(resp *APIResponse) bool {
+		return customerHasVirtualKey(resp, customerID, vkID)
+	}, 5*time.Second, "db customer list shows assigned virtual key"); !ok {
+		t.Fatalf("Customer list never showed assigned virtual key")
+	}
+
+	if _, ok := WaitForAPICondition(t, customerMemoryDetailReq, func(resp *APIResponse) bool {
+		return customerHasVirtualKey(resp, customerID, vkID)
+	}, 5*time.Second, "in-memory customer detail shows assigned virtual key"); !ok {
+		t.Fatalf("In-memory customer detail never showed assigned virtual key")
+	}
+
+	if _, ok := WaitForAPICondition(t, customerMemoryListReq, func(resp *APIResponse) bool {
+		return customerHasVirtualKey(resp, customerID, vkID)
+	}, 5*time.Second, "in-memory customer list shows assigned virtual key"); !ok {
+		t.Fatalf("In-memory customer list never showed assigned virtual key")
+	}
+}
+
+func TestVirtualKeyResponsesEmbedConsistentCustomerRelations(t *testing.T) {
+	t.Parallel()
+	testData := NewGlobalTestData()
+	defer testData.Cleanup(t)
+
+	customerName := "test-vk-embedded-customer-" + generateRandomID()
+	createCustomerResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/customers",
+		Body: CreateCustomerRequest{
+			Name: customerName,
+		},
+	})
+
+	if createCustomerResp.StatusCode != 200 {
+		t.Fatalf("Failed to create customer: status %d", createCustomerResp.StatusCode)
+	}
+
+	customerID := ExtractIDFromResponse(t, createCustomerResp)
+	testData.AddCustomer(customerID)
+
+	vkName := "test-vk-embedded-customer-" + generateRandomID()
+	createVKResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/virtual-keys",
+		Body: CreateVirtualKeyRequest{
+			Name:       vkName,
+			CustomerID: &customerID,
+		},
+	})
+
+	if createVKResp.StatusCode != 200 {
+		t.Fatalf("Failed to create VK: status %d", createVKResp.StatusCode)
+	}
+
+	vkID := ExtractIDFromResponse(t, createVKResp)
+	testData.AddVirtualKey(vkID)
+
+	getVKReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/virtual-keys/" + vkID,
+	}
+	getVKMemoryReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/virtual-keys/" + vkID + "?from_memory=true",
+	}
+
+	if _, ok := WaitForAPICondition(t, getVKReq, func(resp *APIResponse) bool {
+		return embeddedCustomerHasExpectedRelations(resp, customerID, vkID) && responseJSONIsMarshalable(resp)
+	}, 5*time.Second, "db virtual key embeds normalized customer"); !ok {
+		t.Fatalf("Virtual key detail never returned embedded customer with normalized relations")
+	}
+
+	if _, ok := WaitForAPICondition(t, getVKMemoryReq, func(resp *APIResponse) bool {
+		return embeddedCustomerHasExpectedRelations(resp, customerID, vkID) && responseJSONIsMarshalable(resp)
+	}, 5*time.Second, "in-memory virtual key embeds normalized customer"); !ok {
+		t.Fatalf("In-memory virtual key detail never returned embedded customer with normalized relations")
+	}
+}
+
+func TestCustomerResponsesIncludeMultipleAssignedVirtualKeys(t *testing.T) {
+	t.Parallel()
+	testData := NewGlobalTestData()
+	defer testData.Cleanup(t)
+
+	customerName := "test-customer-multi-vk-" + generateRandomID()
+	createCustomerResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/customers",
+		Body: CreateCustomerRequest{
+			Name: customerName,
+		},
+	})
+
+	if createCustomerResp.StatusCode != 200 {
+		t.Fatalf("Failed to create customer: status %d", createCustomerResp.StatusCode)
+	}
+
+	customerID := ExtractIDFromResponse(t, createCustomerResp)
+	testData.AddCustomer(customerID)
+
+	vk1ID := createCustomerVirtualKeyForTest(t, testData, customerID, "test-customer-multi-vk-1-")
+	vk2ID := createCustomerVirtualKeyForTest(t, testData, customerID, "test-customer-multi-vk-2-")
+
+	customerDetailReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/customers/" + customerID,
+	}
+	customerListReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/customers",
+	}
+	customerMemoryDetailReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/customers/" + customerID + "?from_memory=true",
+	}
+	customerMemoryListReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/customers?from_memory=true",
+	}
+
+	expectedVKs := []string{vk1ID, vk2ID}
+
+	if _, ok := WaitForAPICondition(t, customerDetailReq, func(resp *APIResponse) bool {
+		return customerHasExactVirtualKeys(resp, customerID, expectedVKs)
+	}, 5*time.Second, "db customer detail shows both assigned virtual keys"); !ok {
+		t.Fatalf("Customer detail never showed both assigned virtual keys")
+	}
+
+	if _, ok := WaitForAPICondition(t, customerListReq, func(resp *APIResponse) bool {
+		return customerHasExactVirtualKeys(resp, customerID, expectedVKs)
+	}, 5*time.Second, "db customer list shows both assigned virtual keys"); !ok {
+		t.Fatalf("Customer list never showed both assigned virtual keys")
+	}
+
+	if _, ok := WaitForAPICondition(t, customerMemoryDetailReq, func(resp *APIResponse) bool {
+		return customerHasExactVirtualKeys(resp, customerID, expectedVKs)
+	}, 5*time.Second, "in-memory customer detail shows both assigned virtual keys"); !ok {
+		t.Fatalf("In-memory customer detail never showed both assigned virtual keys")
+	}
+
+	if _, ok := WaitForAPICondition(t, customerMemoryListReq, func(resp *APIResponse) bool {
+		return customerHasExactVirtualKeys(resp, customerID, expectedVKs)
+	}, 5*time.Second, "in-memory customer list shows both assigned virtual keys"); !ok {
+		t.Fatalf("In-memory customer list never showed both assigned virtual keys")
+	}
+}
+
+func TestCustomerResponsesExcludeTeamScopedVirtualKeys(t *testing.T) {
+	t.Parallel()
+	testData := NewGlobalTestData()
+	defer testData.Cleanup(t)
+
+	customerName := "test-customer-team-vk-" + generateRandomID()
+	createCustomerResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/customers",
+		Body: CreateCustomerRequest{
+			Name: customerName,
+		},
+	})
+
+	if createCustomerResp.StatusCode != 200 {
+		t.Fatalf("Failed to create customer: status %d", createCustomerResp.StatusCode)
+	}
+
+	customerID := ExtractIDFromResponse(t, createCustomerResp)
+	testData.AddCustomer(customerID)
+
+	teamName := "test-team-team-vk-" + generateRandomID()
+	createTeamResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/teams",
+		Body: CreateTeamRequest{
+			Name:       teamName,
+			CustomerID: &customerID,
+		},
+	})
+
+	if createTeamResp.StatusCode != 200 {
+		t.Fatalf("Failed to create team: status %d", createTeamResp.StatusCode)
+	}
+
+	teamID := ExtractIDFromResponse(t, createTeamResp)
+	testData.AddTeam(teamID)
+
+	vkName := "test-team-scoped-vk-" + generateRandomID()
+	createVKResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/virtual-keys",
+		Body: CreateVirtualKeyRequest{
+			Name:   vkName,
+			TeamID: &teamID,
+		},
+	})
+
+	if createVKResp.StatusCode != 200 {
+		t.Fatalf("Failed to create team-scoped VK: status %d", createVKResp.StatusCode)
+	}
+
+	vkID := ExtractIDFromResponse(t, createVKResp)
+	testData.AddVirtualKey(vkID)
+
+	customerDetailReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/customers/" + customerID,
+	}
+	customerListReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/customers",
+	}
+	customerMemoryDetailReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/customers/" + customerID + "?from_memory=true",
+	}
+	customerMemoryListReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/customers?from_memory=true",
+	}
+	getVKReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/virtual-keys/" + vkID,
+	}
+	getVKMemoryReq := APIRequest{
+		Method: "GET",
+		Path:   "/api/governance/virtual-keys/" + vkID + "?from_memory=true",
+	}
+
+	if _, ok := WaitForAPICondition(t, customerDetailReq, func(resp *APIResponse) bool {
+		return customerExcludesVirtualKey(resp, customerID, vkID, 0)
+	}, 5*time.Second, "db customer detail excludes team-scoped virtual key"); !ok {
+		t.Fatalf("Customer detail incorrectly included team-scoped virtual key")
+	}
+
+	if _, ok := WaitForAPICondition(t, customerListReq, func(resp *APIResponse) bool {
+		return customerExcludesVirtualKey(resp, customerID, vkID, 0)
+	}, 5*time.Second, "db customer list excludes team-scoped virtual key"); !ok {
+		t.Fatalf("Customer list incorrectly included team-scoped virtual key")
+	}
+
+	if _, ok := WaitForAPICondition(t, customerMemoryDetailReq, func(resp *APIResponse) bool {
+		return customerExcludesVirtualKey(resp, customerID, vkID, 0)
+	}, 5*time.Second, "in-memory customer detail excludes team-scoped virtual key"); !ok {
+		t.Fatalf("In-memory customer detail incorrectly included team-scoped virtual key")
+	}
+
+	if _, ok := WaitForAPICondition(t, customerMemoryListReq, func(resp *APIResponse) bool {
+		return customerExcludesVirtualKey(resp, customerID, vkID, 0)
+	}, 5*time.Second, "in-memory customer list excludes team-scoped virtual key"); !ok {
+		t.Fatalf("In-memory customer list incorrectly included team-scoped virtual key")
+	}
+
+	if _, ok := WaitForAPICondition(t, getVKReq, func(resp *APIResponse) bool {
+		return virtualKeyHasExpectedTeam(resp, vkID, teamID) && responseJSONIsMarshalable(resp)
+	}, 5*time.Second, "db virtual key retains team relationship"); !ok {
+		t.Fatalf("DB virtual key detail never returned expected team relationship")
+	}
+
+	if _, ok := WaitForAPICondition(t, getVKMemoryReq, func(resp *APIResponse) bool {
+		return virtualKeyHasExpectedTeam(resp, vkID, teamID) && responseJSONIsMarshalable(resp)
+	}, 5*time.Second, "in-memory virtual key retains team relationship"); !ok {
+		t.Fatalf("In-memory virtual key detail never returned expected team relationship")
+	}
+}
+
+func createCustomerVirtualKeyForTest(t *testing.T, testData *GlobalTestData, customerID, namePrefix string) string {
+	t.Helper()
+
+	vkName := namePrefix + generateRandomID()
+	createVKResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/virtual-keys",
+		Body: CreateVirtualKeyRequest{
+			Name:       vkName,
+			CustomerID: &customerID,
+		},
+	})
+
+	if createVKResp.StatusCode != 200 {
+		t.Fatalf("Failed to create VK: status %d", createVKResp.StatusCode)
+	}
+
+	vkID := ExtractIDFromResponse(t, createVKResp)
+	testData.AddVirtualKey(vkID)
+	return vkID
+}
+
+func extractCustomerFromResponse(body map[string]interface{}, customerID string) map[string]interface{} {
+	if customer, ok := body["customer"].(map[string]interface{}); ok {
+		id, _ := customer["id"].(string)
+		if id == customerID {
+			return customer
+		}
+	}
+
+	if customers, ok := body["customers"].([]interface{}); ok {
+		for _, item := range customers {
+			customer, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			id, _ := customer["id"].(string)
+			if id == customerID {
+				return customer
+			}
+		}
+	}
+
+	if customers, ok := body["customers"].(map[string]interface{}); ok {
+		if customer, ok := customers[customerID].(map[string]interface{}); ok {
+			return customer
+		}
+	}
+
+	return nil
+}
+
+func customerHasVirtualKey(resp *APIResponse, customerID, vkID string) bool {
+	if resp.StatusCode != 200 {
+		return false
+	}
+
+	customer := extractCustomerFromResponse(resp.Body, customerID)
+	if customer == nil {
+		return false
+	}
+
+	if !arrayFieldContainsID(customer, "virtual_keys", vkID) {
+		return false
+	}
+
+	return fieldIsJSONArray(customer, "teams")
+}
+
+func customerHasExactVirtualKeys(resp *APIResponse, customerID string, expectedVKIDs []string) bool {
+	if resp.StatusCode != 200 {
+		return false
+	}
+
+	customer := extractCustomerFromResponse(resp.Body, customerID)
+	if customer == nil || !fieldIsJSONArray(customer, "teams") {
+		return false
+	}
+
+	values, ok := customer["virtual_keys"].([]interface{})
+	if !ok || len(values) != len(expectedVKIDs) {
+		return false
+	}
+
+	for _, expectedID := range expectedVKIDs {
+		if !arrayFieldContainsID(customer, "virtual_keys", expectedID) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func customerExcludesVirtualKey(resp *APIResponse, customerID, vkID string, expectedLen int) bool {
+	if resp.StatusCode != 200 {
+		return false
+	}
+
+	customer := extractCustomerFromResponse(resp.Body, customerID)
+	if customer == nil || !fieldIsJSONArray(customer, "teams") {
+		return false
+	}
+
+	values, ok := customer["virtual_keys"].([]interface{})
+	if !ok || len(values) != expectedLen {
+		return false
+	}
+
+	return !arrayFieldContainsID(customer, "virtual_keys", vkID)
+}
+
+func embeddedCustomerHasExpectedRelations(resp *APIResponse, customerID, vkID string) bool {
+	if resp.StatusCode != 200 {
+		return false
+	}
+
+	virtualKey, ok := resp.Body["virtual_key"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	customer, ok := virtualKey["customer"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	id, _ := customer["id"].(string)
+	if id != customerID {
+		return false
+	}
+
+	if !fieldIsJSONArray(customer, "teams") {
+		return false
+	}
+
+	if !arrayFieldContainsID(customer, "virtual_keys", vkID) {
+		return false
+	}
+
+	values, ok := customer["virtual_keys"].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, item := range values {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		if nestedCustomer, exists := entry["customer"]; exists && nestedCustomer != nil {
+			return false
+		}
+	}
+
+	return true
+}
+
+func virtualKeyHasExpectedTeam(resp *APIResponse, vkID, teamID string) bool {
+	if resp.StatusCode != 200 {
+		return false
+	}
+
+	virtualKey, ok := resp.Body["virtual_key"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	id, _ := virtualKey["id"].(string)
+	if id != vkID {
+		return false
+	}
+
+	team, ok := virtualKey["team"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	actualTeamID, _ := team["id"].(string)
+	if actualTeamID != teamID {
+		return false
+	}
+
+	customer, exists := virtualKey["customer"]
+	return !exists || customer == nil
+}
+
+func arrayFieldContainsID(parent map[string]interface{}, field, id string) bool {
+	values, ok := parent[field].([]interface{})
+	if !ok {
+		return false
+	}
+	for _, item := range values {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		entryID, _ := entry["id"].(string)
+		if entryID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func fieldIsJSONArray(parent map[string]interface{}, field string) bool {
+	_, ok := parent[field].([]interface{})
+	return ok
+}
+
+func assertJSONArrayField(t *testing.T, parent map[string]interface{}, field string, expectedLen int) {
+	t.Helper()
+
+	values, ok := parent[field].([]interface{})
+	if !ok {
+		t.Fatalf("Expected %q to be an array, got %T", field, parent[field])
+	}
+	if len(values) != expectedLen {
+		t.Fatalf("Expected %q length %d, got %d", field, expectedLen, len(values))
+	}
+}
+
+func responseJSONIsMarshalable(resp *APIResponse) bool {
+	if !json.Valid(resp.RawBody) {
+		return false
+	}
+	_, err := json.Marshal(resp.Body)
+	return err == nil
+}

--- a/tests/governance/customer_virtual_keys_response_test.go
+++ b/tests/governance/customer_virtual_keys_response_test.go
@@ -27,7 +27,10 @@ func TestCustomerResponsesIncludeAssignedVirtualKeys(t *testing.T) {
 	customerID := ExtractIDFromResponse(t, createCustomerResp)
 	testData.AddCustomer(customerID)
 
-	customerData := createCustomerResp.Body["customer"].(map[string]interface{})
+	customerData, ok := createCustomerResp.Body["customer"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected 'customer' in response body, got: %v", createCustomerResp.Body)
+	}
 	assertJSONArrayField(t, customerData, "teams", 0)
 	assertJSONArrayField(t, customerData, "virtual_keys", 0)
 


### PR DESCRIPTION
## Summary

Fixes #2306 by correctly populating `customer.virtual_keys` in governance customer
responses and keeping customer/virtual-key relationships consistent across DB-backed
and in-memory governance reads.

---

## Changes

- Extracted repeated GORM preload chains into reusable helpers:
`preloadVirtualKeyRelations()` and `preloadCustomerRelations()`
- Fixed DB-backed customer reads to preload `VirtualKeys`, so
`/api/governance/customers` and `/api/governance/customers/{id}` no longer return
`virtual_keys: null` when keys are assigned
- Fixed in-memory governance store assembly to rebuild customer `Teams` and
`VirtualKeys` relationships consistently
- Added relationship refresh logic so embedded VK/team objects use live
budget/rate-limit references from the governance store
- Implemented proper sorting of nested collections by creation date
- Preserved non-recursive nested response shape by clearing embedded back-references
when rebuilding in-memory customer collections
- Added focused governance regression coverage for customer/VK response consistency,
including multi-VK and team-scoped VK cases

---

## Type of Change

- [x] Bug fix
- [x] Refactor

## Affected Areas

- Framework (Go)
- Plugins
- Tests

---

## How to Test

**Focused governance regressions for this fix**

```bash
cd tests/governance
GOWORK=off go test -parallel 1 -run \
  'TestCustomerResponsesIncludeAssignedVirtualKeys|TestVirtualKeyResponsesEmbedConsistentCustomerRelations|TestCustomerResponsesIncludeMultipleAssignedVirtualKeys|TestCustomerResponsesExcludeTeamScopedVirtualKeys'
```

**Lower-level validation**

```bash
cd ../framework
go test ./configstore

cd ../plugins/governance
go test ./...
```

**Manual API proof for #2306**

1. Create a customer
2. Create a virtual key with `customer_id` set to that customer
3. Verify:
    - `GET /api/governance/customers/{id}` returns the VK under `customer.virtual_keys`
    - `GET /api/governance/customers` returns the customer with that VK under `virtual_keys`
    - `GET /api/governance/virtual-keys/{id}` shows the same `customer_id` and embedded customer

---

## The New Tests Verify

- Customer responses include assigned virtual keys
- Virtual key responses embed consistent customer relations
- Multiple customer-scoped virtual keys are returned correctly
- Team-scoped virtual keys are excluded from `customer.virtual_keys`
- Serialized JSON responses remain non-recursive and marshalable

---

## Breaking Changes

No

---

## Related Issues

Fixes #2306

---

## Security Considerations

No security implications. This is a governance data consistency and query refactor change.

---

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified the relevant local Go test coverage for the issue path
- [ ] I verified the CI pipeline passes locally if applicable