### PR TITLE
send empty model list vs erroring lsit models call

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6059,7 +6059,7 @@ func (bifrost *Bifrost) getAllSupportedKeys(ctx *schemas.BifrostContext, provide
 	}
 
 	if len(keys) == 0 {
-		return nil, fmt.Errorf("no keys found for provider: %v", providerKey)
+		return []schemas.Key{}, nil
 	}
 
 	// Filter keys for ListModels - only check if key has a value
@@ -6077,7 +6077,7 @@ func (bifrost *Bifrost) getAllSupportedKeys(ctx *schemas.BifrostContext, provide
 	bifrost.logger.Debug("[Bifrost] Provider %s: %d enabled keys found", providerKey, len(supportedKeys))
 
 	if len(supportedKeys) == 0 {
-		return nil, fmt.Errorf("no valid keys found for provider: %v", providerKey)
+		return []schemas.Key{}, nil
 	}
 
 	return supportedKeys, nil

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2362,16 +2362,6 @@ func extractSuccessfulListModelsResponses(
 		if lastError != nil {
 			return nil, keyStatuses, lastError
 		}
-		return nil, keyStatuses, &schemas.BifrostError{
-			IsBifrostError: false,
-			Error: &schemas.ErrorField{
-				Message: "all keys failed to list models",
-			},
-			ExtraFields: schemas.BifrostErrorExtraFields{
-				Provider:    providerName,
-				RequestType: schemas.ListModelsRequest,
-			},
-		}
 	}
 
 	return successfulResponses, keyStatuses, nil


### PR DESCRIPTION
## Summary

Changes error handling behavior when no keys are found for a provider during model listing operations. Instead of returning errors, the system now returns empty results and continues processing.

## Changes

- Modified `getAllSupportedKeys` function to return empty `[]schemas.Key{}` slice instead of errors when no keys or valid keys are found for a provider
- Removed error generation in `extractSuccessfulListModelsResponses` when all keys fail to list models, allowing the function to return gracefully with empty results
- This prevents cascading failures and allows the system to handle missing or invalid provider keys more gracefully

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test scenarios where providers have no configured keys or all keys are invalid:

```sh
# Core/Transports
go version
go test ./...

# Test with provider that has no keys configured
# Test with provider that has invalid/expired keys
# Verify that list models operations continue processing other providers
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change improves system resilience by preventing errors from propagating when provider keys are missing or invalid, which could be part of normal operational scenarios.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable