### PR TITLE
fix: preserve cached provider metadata on cross-provider cache hits

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -805,6 +805,9 @@ type BifrostCacheDebug struct {
 	CacheID *string `json:"cache_id,omitempty"`
 	HitType *string `json:"hit_type,omitempty"`
 
+	RequestedProvider *string `json:"requested_provider,omitempty"`
+	RequestedModel    *string `json:"requested_model,omitempty"`
+
 	// Semantic cache only (provider, model, and input tokens will be present for semantic cache, even if cache is not hit)
 	ProviderUsed *string `json:"provider_used,omitempty"`
 	ModelUsed    *string `json:"model_used,omitempty"`

--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -102,6 +102,8 @@ if err != nil {
 
 ## Semantic Cache Configuration
 
+> **UI Note**: The current Web UI flow configures provider-backed semantic caching. If you want direct-only mode (`dimension: 1` with no `provider`), configure it through `config.json`.
+
 <Tabs group="cache-config">
 
 <Tab title="Go SDK">
@@ -201,8 +203,6 @@ bifrostConfig := schemas.BifrostConfig{
 ```
 
 > **Note**: In `config.json` setups, provider keys are taken from the provider config on initialization, so you do not need to duplicate `keys` inside the plugin config. Any updates to the provider keys will not be reflected until next restart.
-
-> **UI Note**: The current Web UI flow configures provider-backed semantic caching. If you want direct-only mode (`dimension: 1` with no `provider`), configure it through `config.json`.
 
 **TTL Format Options:**
 - Duration strings: `"30s"`, `"5m"`, `"1h"`, `"24h"`

--- a/docs/openapi/schemas/inference/common.yaml
+++ b/docs/openapi/schemas/inference/common.yaml
@@ -121,6 +121,10 @@ BifrostCacheDebug:
       type: string
     hit_type:
       type: string
+    requested_provider:
+      type: string
+    requested_model:
+      type: string
     provider_used:
       type: string
     model_used:

--- a/plugins/semanticcache/plugin_cache_type_test.go
+++ b/plugins/semanticcache/plugin_cache_type_test.go
@@ -329,6 +329,229 @@ func (s *directFastPathStore) DeleteAll(ctx context.Context, namespace string, q
 
 func (s *directFastPathStore) Close(ctx context.Context, namespace string) error { return nil }
 
+func newCrossProviderChatRequest(provider schemas.ModelProvider, model string, requestType schemas.RequestType, prompt string) *schemas.BifrostRequest {
+	return &schemas.BifrostRequest{
+		RequestType: requestType,
+		ChatRequest: &schemas.BifrostChatRequest{
+			Provider: provider,
+			Model:    model,
+			Input: []schemas.ChatMessage{
+				{
+					Role: schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{
+						ContentStr: bifrost.Ptr(prompt),
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestDirectCacheHitPreservesCachedProviderMetadataAcrossProviders(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	store := newDirectFastPathStore()
+	config := getDefaultTestConfig()
+	config.CacheByProvider = bifrost.Ptr(false)
+	config.CacheByModel = bifrost.Ptr(false)
+	config.ConversationHistoryThreshold = DefaultConversationHistoryThreshold
+	plugin := &Plugin{
+		store:  store,
+		config: config,
+		logger: logger,
+	}
+
+	const cacheKey = "cross-provider-direct-single"
+	const prompt = "Explain green threading in Go in one short sentence."
+
+	seedCtx := CreateContextWithCacheKeyAndType(cacheKey, CacheTypeDirect)
+	seedReq := newCrossProviderChatRequest(schemas.OpenAI, "gpt-5.2", schemas.ChatCompletionRequest, prompt)
+
+	_, shortCircuit, err := plugin.PreLLMHook(seedCtx, seedReq)
+	if err != nil {
+		t.Fatalf("seed PreLLMHook failed: %v", err)
+	}
+	if shortCircuit != nil {
+		t.Fatal("expected seed request to miss cache")
+	}
+
+	seedResponse := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ID: "cross-provider-direct-single",
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+						Message: &schemas.ChatMessage{
+							Role: schemas.ChatMessageRoleAssistant,
+							Content: &schemas.ChatMessageContent{
+								ContentStr: bifrost.Ptr("Go schedules lightweight goroutines in user space onto a smaller pool of OS threads."),
+							},
+						},
+					},
+				},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				Provider:       schemas.OpenAI,
+				ModelRequested: "gpt-5.2",
+				RequestType:    schemas.ChatCompletionRequest,
+			},
+		},
+	}
+
+	if _, _, err = plugin.PostLLMHook(seedCtx, seedResponse, nil); err != nil {
+		t.Fatalf("seed PostLLMHook failed: %v", err)
+	}
+	plugin.WaitForPendingOperations()
+
+	hitCtx := CreateContextWithCacheKeyAndType(cacheKey, CacheTypeDirect)
+	hitReq := newCrossProviderChatRequest(schemas.Anthropic, "claude-sonnet-4-6", schemas.ChatCompletionRequest, prompt)
+
+	_, shortCircuit, err = plugin.PreLLMHook(hitCtx, hitReq)
+	if err != nil {
+		t.Fatalf("hit PreLLMHook failed: %v", err)
+	}
+	if shortCircuit == nil || shortCircuit.Response == nil || shortCircuit.Response.ChatResponse == nil {
+		t.Fatal("expected cross-provider direct cache hit to return a response")
+	}
+
+	extraFields := shortCircuit.Response.ChatResponse.ExtraFields
+	if extraFields.Provider != schemas.OpenAI {
+		t.Fatalf("expected cached provider %q, got %q", schemas.OpenAI, extraFields.Provider)
+	}
+	if extraFields.ModelRequested != "gpt-5.2" {
+		t.Fatalf("expected cached model_requested %q, got %q", "gpt-5.2", extraFields.ModelRequested)
+	}
+	if extraFields.CacheDebug == nil {
+		t.Fatal("expected cache_debug on cache hit")
+	}
+	if !extraFields.CacheDebug.CacheHit {
+		t.Fatal("expected cache hit to be marked in cache_debug")
+	}
+	if extraFields.CacheDebug.HitType == nil || *extraFields.CacheDebug.HitType != string(CacheTypeDirect) {
+		t.Fatalf("expected hit_type %q, got %v", CacheTypeDirect, extraFields.CacheDebug.HitType)
+	}
+	if extraFields.CacheDebug.RequestedProvider == nil || *extraFields.CacheDebug.RequestedProvider != string(schemas.Anthropic) {
+		t.Fatalf("expected requested_provider %q, got %v", schemas.Anthropic, extraFields.CacheDebug.RequestedProvider)
+	}
+	if extraFields.CacheDebug.RequestedModel == nil || *extraFields.CacheDebug.RequestedModel != "claude-sonnet-4-6" {
+		t.Fatalf("expected requested_model %q, got %v", "claude-sonnet-4-6", extraFields.CacheDebug.RequestedModel)
+	}
+}
+
+func TestStreamingDirectCacheHitPreservesCachedProviderMetadataAcrossProviders(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	store := newDirectFastPathStore()
+	config := getDefaultTestConfig()
+	config.CacheByProvider = bifrost.Ptr(false)
+	config.CacheByModel = bifrost.Ptr(false)
+	config.ConversationHistoryThreshold = DefaultConversationHistoryThreshold
+	plugin := &Plugin{
+		store:  store,
+		config: config,
+		logger: logger,
+	}
+
+	const cacheKey = "cross-provider-direct-stream"
+	const prompt = "Explain green threading in Go in one short sentence."
+
+	seedCtx := CreateContextWithCacheKeyAndType(cacheKey, CacheTypeDirect)
+	seedReq := newCrossProviderChatRequest(schemas.OpenAI, "gpt-5.2", schemas.ChatCompletionStreamRequest, prompt)
+
+	_, shortCircuit, err := plugin.PreLLMHook(seedCtx, seedReq)
+	if err != nil {
+		t.Fatalf("seed PreLLMHook failed: %v", err)
+	}
+	if shortCircuit != nil {
+		t.Fatal("expected seed request to miss cache")
+	}
+
+	chunks := []struct {
+		content      string
+		chunkIndex   int
+		finishReason *string
+		streamEnd    bool
+	}{
+		{content: "Go schedules lightweight goroutines", chunkIndex: 0, finishReason: nil, streamEnd: false},
+		{content: " onto a smaller pool of OS threads.", chunkIndex: 1, finishReason: bifrost.Ptr("stop"), streamEnd: true},
+	}
+
+	for _, chunk := range chunks {
+		seedCtx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, chunk.streamEnd)
+		chunkResponse := &schemas.BifrostResponse{
+			ChatResponse: &schemas.BifrostChatResponse{
+				ID: "cross-provider-direct-stream",
+				Choices: []schemas.BifrostResponseChoice{
+					{
+						Index:        chunk.chunkIndex,
+						FinishReason: chunk.finishReason,
+						ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+							Delta: &schemas.ChatStreamResponseChoiceDelta{
+								Content: bifrost.Ptr(chunk.content),
+							},
+						},
+					},
+				},
+				ExtraFields: schemas.BifrostResponseExtraFields{
+					Provider:       schemas.OpenAI,
+					ModelRequested: "gpt-5.2",
+					RequestType:    schemas.ChatCompletionStreamRequest,
+					ChunkIndex:     chunk.chunkIndex,
+				},
+			},
+		}
+
+		if _, _, err = plugin.PostLLMHook(seedCtx, chunkResponse, nil); err != nil {
+			t.Fatalf("seed PostLLMHook failed for chunk %d: %v", chunk.chunkIndex, err)
+		}
+		plugin.WaitForPendingOperations()
+	}
+
+	hitCtx := CreateContextWithCacheKeyAndType(cacheKey, CacheTypeDirect)
+	hitReq := newCrossProviderChatRequest(schemas.Anthropic, "claude-sonnet-4-6", schemas.ChatCompletionStreamRequest, prompt)
+
+	_, shortCircuit, err = plugin.PreLLMHook(hitCtx, hitReq)
+	if err != nil {
+		t.Fatalf("hit PreLLMHook failed: %v", err)
+	}
+	if shortCircuit == nil || shortCircuit.Stream == nil {
+		t.Fatal("expected cross-provider streaming direct cache hit to return a stream")
+	}
+
+	chunkCount := 0
+	for chunk := range shortCircuit.Stream {
+		if chunk.BifrostChatResponse == nil {
+			t.Fatal("expected cached chat stream chunk")
+		}
+
+		extraFields := chunk.BifrostChatResponse.ExtraFields
+		if extraFields.Provider != schemas.OpenAI {
+			t.Fatalf("expected cached provider %q on chunk %d, got %q", schemas.OpenAI, chunkCount, extraFields.Provider)
+		}
+		if extraFields.ModelRequested != "gpt-5.2" {
+			t.Fatalf("expected cached model_requested %q on chunk %d, got %q", "gpt-5.2", chunkCount, extraFields.ModelRequested)
+		}
+		if chunkCount == len(chunks)-1 {
+			if extraFields.CacheDebug == nil || !extraFields.CacheDebug.CacheHit {
+				t.Fatal("expected final cached stream chunk to include cache_debug cache_hit=true")
+			}
+			if extraFields.CacheDebug.HitType == nil || *extraFields.CacheDebug.HitType != string(CacheTypeDirect) {
+				t.Fatalf("expected final stream hit_type %q, got %v", CacheTypeDirect, extraFields.CacheDebug.HitType)
+			}
+			if extraFields.CacheDebug.RequestedProvider == nil || *extraFields.CacheDebug.RequestedProvider != string(schemas.Anthropic) {
+				t.Fatalf("expected final stream requested_provider %q, got %v", schemas.Anthropic, extraFields.CacheDebug.RequestedProvider)
+			}
+			if extraFields.CacheDebug.RequestedModel == nil || *extraFields.CacheDebug.RequestedModel != "claude-sonnet-4-6" {
+				t.Fatalf("expected final stream requested_model %q, got %v", "claude-sonnet-4-6", extraFields.CacheDebug.RequestedModel)
+			}
+		}
+
+		chunkCount++
+	}
+
+	if chunkCount != len(chunks) {
+		t.Fatalf("expected %d cached stream chunks, got %d", len(chunks), chunkCount)
+	}
+}
+
 func TestCacheTypeDirectUsesChunkLookup(t *testing.T) {
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	store := newDirectFastPathStore()

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -387,11 +387,10 @@ func (plugin *Plugin) buildStreamingResponseFromResult(ctx *schemas.BifrostConte
 				continue
 			}
 
-			extraFields := cachedResponse.GetExtraFields()
-
 			// Add cache debug to only the last chunk and set stream end indicator
 			if i == len(streamArray)-1 {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				extraFields := cachedResponse.GetExtraFields()
 				cacheDebug := schemas.BifrostCacheDebug{
 					CacheHit:          true,
 					HitType:           bifrost.Ptr(string(cacheType)),

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -303,7 +303,7 @@ func (plugin *Plugin) buildResponseFromResult(ctx *schemas.BifrostContext, req *
 
 // buildSingleResponseFromResult constructs a single response from cached data
 func (plugin *Plugin) buildSingleResponseFromResult(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, result vectorstore.SearchResult, responseData interface{}, cacheType CacheType, threshold float64, similarity float64, inputTokens int) (*schemas.LLMPluginShortCircuit, error) {
-	provider, _, _ := req.GetRequestFields()
+	requestedProvider, requestedModel, _ := req.GetRequestFields()
 
 	responseStr, ok := responseData.(string)
 	if !ok {
@@ -324,6 +324,8 @@ func (plugin *Plugin) buildSingleResponseFromResult(ctx *schemas.BifrostContext,
 	extraFields.CacheDebug.CacheHit = true
 	extraFields.CacheDebug.HitType = bifrost.Ptr(string(cacheType))
 	extraFields.CacheDebug.CacheID = bifrost.Ptr(result.ID)
+	extraFields.CacheDebug.RequestedProvider = bifrost.Ptr(string(requestedProvider))
+	extraFields.CacheDebug.RequestedModel = bifrost.Ptr(requestedModel)
 	if cacheType == CacheTypeSemantic {
 		extraFields.CacheDebug.ProviderUsed = bifrost.Ptr(string(plugin.config.Provider))
 		extraFields.CacheDebug.ModelUsed = bifrost.Ptr(plugin.config.EmbeddingModel)
@@ -338,8 +340,6 @@ func (plugin *Plugin) buildSingleResponseFromResult(ctx *schemas.BifrostContext,
 		extraFields.CacheDebug.InputTokens = nil
 	}
 
-	extraFields.Provider = provider
-
 	ctx.SetValue(isCacheHitKey, true)
 	ctx.SetValue(cacheHitTypeKey, cacheType)
 
@@ -350,7 +350,7 @@ func (plugin *Plugin) buildSingleResponseFromResult(ctx *schemas.BifrostContext,
 
 // buildStreamingResponseFromResult constructs a streaming response from cached data
 func (plugin *Plugin) buildStreamingResponseFromResult(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, result vectorstore.SearchResult, streamData interface{}, cacheType CacheType, threshold float64, similarity float64, inputTokens int) (*schemas.LLMPluginShortCircuit, error) {
-	provider, _, _ := req.GetRequestFields()
+	requestedProvider, requestedModel, _ := req.GetRequestFields()
 
 	// Parse stream_chunks
 	streamArray, err := plugin.parseStreamChunks(streamData)
@@ -393,9 +393,11 @@ func (plugin *Plugin) buildStreamingResponseFromResult(ctx *schemas.BifrostConte
 			if i == len(streamArray)-1 {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				cacheDebug := schemas.BifrostCacheDebug{
-					CacheHit: true,
-					HitType:  bifrost.Ptr(string(cacheType)),
-					CacheID:  bifrost.Ptr(result.ID),
+					CacheHit:          true,
+					HitType:           bifrost.Ptr(string(cacheType)),
+					CacheID:           bifrost.Ptr(result.ID),
+					RequestedProvider: bifrost.Ptr(string(requestedProvider)),
+					RequestedModel:    bifrost.Ptr(requestedModel),
 				}
 				if cacheType == CacheTypeSemantic {
 					cacheDebug.ProviderUsed = bifrost.Ptr(string(plugin.config.Provider))
@@ -412,9 +414,6 @@ func (plugin *Plugin) buildStreamingResponseFromResult(ctx *schemas.BifrostConte
 				}
 				extraFields.CacheDebug = &cacheDebug
 			}
-
-			// extraField is a pointer so it'll automatically reflect on the parent struct
-			extraFields.Provider = provider
 
 			// Send chunk to stream
 			streamChan <- &schemas.BifrostStreamChunk{

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -382,6 +382,8 @@ export interface CacheDebug {
 	cache_hit: boolean;
 	cache_id?: string;
 	hit_type?: string;
+	requested_provider?: string;
+	requested_model?: string;
 	provider_used?: string;
 	model_used?: string;
 	input_tokens?: number;


### PR DESCRIPTION
## Summary

Fixes cross-provider cache hit metadata so cached responses keep their original provider/model ownership, and adds `requested_provider` and `requested_model` to cache debug information. On a cache hit, `extra_fields.provider` and `extra_fields.model_requested` now describe the cached response that was actually served, while `cache_debug.requested_provider` and `cache_debug.requested_model` show what the client originally asked for.

## Changes

- Preserved cached `extra_fields.provider` and `extra_fields.model_requested` on cross-provider cache hits instead of overwriting them with the incoming request provider
- Added `RequestedProvider` and `RequestedModel` fields to `BifrostCacheDebug`
- Updated cache hit response building for both single-response and streaming paths to populate `requested_provider` and `requested_model` from the incoming request
- Added deterministic regression tests for cross-provider direct cache hits in both single-response and streaming flows
- Updated UI log types to include `requested_provider` and `requested_model`
- Updated inference OpenAPI schema and bundled OpenAPI spec for the new cache debug fields
- Moved the semantic cache UI note above the config tabs to improve documentation flow

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Breaking change

## Affected areas

- [x] Core (Go)
- [x] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

**Test cache debug information:**

```bash
# Seed request (openai)
curl -s http://localhost:8080/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -H 'x-bf-cache-key: direct-provider-check1' \
  -H 'x-bf-mcp-include-clients: __none__' \
  -H 'x-bf-mcp-include-tools: __none__' \
  -d '{
    "model": "openai/gpt-5.2",
    "messages": [
      {"role":"user","content":"Explain green threading in Go in one short sentence."}
    ]
  }' | jq '.extra_fields | {provider, model_requested, cache_debug}'

# Cross-provider cache hit request (anthropic)
curl -s http://localhost:8080/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -H 'x-bf-cache-key: direct-provider-check1' \
  -H 'x-bf-mcp-include-clients: __none__' \
  -H 'x-bf-mcp-include-tools: __none__' \
  -d '{
    "model": "anthropic/claude-sonnet-4-6",
    "messages": [
      {"role":"user","content":"Explain green threading in Go in one short sentence."}
    ]
  }' | jq '.extra_fields | {provider, model_requested, cache_debug}'
```

Check the second response includes:

- `cache_debug.cache_hit: true`
- `cache_debug.hit_type: "direct"`
- `provider: "openai"`
- `model_requested: "gpt-5.2"`
- `cache_debug.requested_provider: "anthropic"`
- `cache_debug.requested_model: "claude-sonnet-4-6"`

**Run regression tests:**

```bash
go test ./plugins/semanticcache \
  -run 'TestDirectCacheHitPreservesCachedProviderMetadataAcrossProviders|TestStreamingDirectCacheHitPreservesCachedProviderMetadataAcrossProviders' \
  -count=1
```

## Breaking changes

- [ ] Yes
- [x] No

This is additive and corrective:

- `requested_provider` and `requested_model` are new optional fields in `cache_debug`
- cache-hit `provider` now correctly reflects the cached response owner instead of the incoming request provider

## Related issues

Fixes incorrect provider metadata on cross-provider cache hits and improves cache observability for requested-vs-served metadata.

## Security considerations

No security implications - only corrects cache-hit metadata and adds debugging fields to existing cache responses.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable