### PR TITLE
anthropic beta headers

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -198,6 +198,12 @@ func (provider *AnthropicProvider) completeRequest(ctx *schemas.BifrostContext, 
 	}
 	req.Header.Set("anthropic-version", provider.apiVersion)
 
+	if betaHeaders := FilterBetaHeadersForProvider(MergeBetaHeaders(provider.networkConfig.ExtraHeaders, ctx), schemas.Anthropic, provider.networkConfig.BetaHeaderOverrides); len(betaHeaders) > 0 {
+		req.Header.Set(AnthropicBetaHeader, strings.Join(betaHeaders, ","))
+	} else {
+		req.Header.Del(AnthropicBetaHeader)
+	}
+
 	usedLargePayloadBody := setAnthropicRequestBody(ctx, req, jsonData)
 
 	requestClient := provider.client
@@ -550,6 +556,7 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 		jsonData,
 		headers,
 		provider.networkConfig.ExtraHeaders,
+		provider.networkConfig.BetaHeaderOverrides,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
@@ -573,6 +580,7 @@ func HandleAnthropicChatCompletionStreaming(
 	jsonBody []byte,
 	headers map[string]string,
 	extraHeaders map[string]string,
+	betaHeaderOverrides map[string]bool,
 	sendBackRawRequest bool,
 	sendBackRawResponse bool,
 	providerName schemas.ModelProvider,
@@ -589,7 +597,14 @@ func HandleAnthropicChatCompletionStreaming(
 	req.Header.SetMethod(http.MethodPost)
 	req.SetRequestURI(url)
 	req.Header.SetContentType("application/json")
-	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, nil)
+
+	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, []string{AnthropicBetaHeader})
+
+	if betaHeaders := FilterBetaHeadersForProvider(MergeBetaHeaders(extraHeaders, ctx), providerName, betaHeaderOverrides); len(betaHeaders) > 0 {
+		req.Header.Set(AnthropicBetaHeader, strings.Join(betaHeaders, ","))
+	} else {
+		req.Header.Del(AnthropicBetaHeader)
+	}
 
 	for key, value := range headers {
 		req.Header.Set(key, value)
@@ -1025,6 +1040,7 @@ func (provider *AnthropicProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 		jsonBody,
 		headers,
 		provider.networkConfig.ExtraHeaders,
+		provider.networkConfig.BetaHeaderOverrides,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
@@ -1048,6 +1064,7 @@ func HandleAnthropicResponsesStream(
 	jsonBody []byte,
 	headers map[string]string,
 	extraHeaders map[string]string,
+	betaHeaderOverrides map[string]bool,
 	sendBackRawRequest bool,
 	sendBackRawResponse bool,
 	providerName schemas.ModelProvider,
@@ -1064,9 +1081,16 @@ func HandleAnthropicResponsesStream(
 	req.Header.SetMethod(http.MethodPost)
 	req.SetRequestURI(url)
 	req.Header.SetContentType("application/json")
-	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, nil)
 
-	// Set headers, merging anthropic-beta with any user-supplied values
+	providerUtils.SetExtraHeaders(ctx, req, extraHeaders, []string{AnthropicBetaHeader})
+
+	if betaHeaders := FilterBetaHeadersForProvider(MergeBetaHeaders(extraHeaders, ctx), providerName, betaHeaderOverrides); len(betaHeaders) > 0 {
+		req.Header.Set(AnthropicBetaHeader, strings.Join(betaHeaders, ","))
+	} else {
+		req.Header.Del(AnthropicBetaHeader)
+	}
+
+	// Set auth/static headers, applied after extra headers so they always win
 	for key, value := range headers {
 		req.Header.Set(key, value)
 	}

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -16,6 +16,9 @@ const (
 	AnthropicDefaultMaxTokens = 4096
 	MinimumReasoningMaxTokens = 1024
 
+	// AnthropicBetaHeader is the HTTP header name used to enable Anthropic beta features.
+	AnthropicBetaHeader = "anthropic-beta"
+
 	// Beta headers for various Anthropic features
 	// AnthropicFilesAPIBetaHeader is the required beta header for the Files API.
 	AnthropicFilesAPIBetaHeader = "files-api-2025-04-14"
@@ -43,6 +46,8 @@ const (
 	AnthropicContext1MBetaHeader = "context-1m-2025-08-07"
 	// AnthropicFastModeBetaHeader is required for fast mode on Opus 4.6 (research preview).
 	AnthropicFastModeBetaHeader = "fast-mode-2026-02-01"
+	// AnthropicRedactThinkingBetaHeader is required for redacting thinking blocks in responses.
+	AnthropicRedactThinkingBetaHeader = "redact-thinking-2026-02-12"
 
 	// AnthropicComputerUseBetaHeader is required for computer use (version-specific).
 	// computer_20251124 (Opus 4.6, Sonnet 4.6, Opus 4.5) uses the newer beta header.
@@ -61,6 +66,7 @@ const (
 	AnthropicSkillsBetaHeaderPrefix              = "skills-"
 	AnthropicContext1MBetaHeaderPrefix           = "context-1m-"
 	AnthropicFastModeBetaHeaderPrefix            = "fast-mode-"
+	AnthropicRedactThinkingBetaHeaderPrefix       = "redact-thinking-"
 )
 
 // ProviderFeatureSupport defines which Anthropic features a given provider supports.
@@ -86,6 +92,7 @@ type ProviderFeatureSupport struct {
 	Skills              bool // Agent Skills
 	Context1M           bool // 1M context window beta (for Sonnet 4.5/4 only)
 	FastMode            bool // fast mode (Opus 4.6 only, research preview)
+	RedactThinking      bool // redact thinking blocks in responses
 	FileSearch          bool // file_search server tool (OpenAI-only)
 	ImageGeneration     bool // image_generation server tool (OpenAI-only)
 }
@@ -98,6 +105,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		MCP: true, AdvancedToolUse: true, StructuredOutputs: true, PromptCachingScope: true,
 		Compaction: true, ContextEditing: true, FilesAPI: true,
 		InterleavedThinking: true, Skills: true, Context1M: true, FastMode: true,
+		RedactThinking: true,
 	},
 	schemas.Vertex: {
 		WebSearch: true, // only web_search_20250305 (basic), NOT dynamic filtering
@@ -116,6 +124,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		MCP: true, AdvancedToolUse: true, StructuredOutputs: true, PromptCachingScope: true,
 		Compaction: true, ContextEditing: true, FilesAPI: true,
 		InterleavedThinking: true, Skills: true, Context1M: true,
+		RedactThinking: true,
 	},
 }
 

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -64,7 +65,7 @@ func ValidateToolsForProvider(tools []schemas.ResponsesTool, provider schemas.Mo
 			if !features.ImageGeneration {
 				return fmt.Errorf("tool type '%s' is not supported by provider '%s'", tool.Type, provider)
 			}
-		// ResponsesToolTypeFunction, ResponsesToolTypeCustom, etc. are always allowed
+			// ResponsesToolTypeFunction, ResponsesToolTypeCustom, etc. are always allowed
 		}
 	}
 	return nil
@@ -364,9 +365,9 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 			extraHeaders = ctxExtraHeaders
 		}
 	}
-	existing := extraHeaders["anthropic-beta"]
+	existing := extraHeaders[AnthropicBetaHeader]
 	if len(existing) == 0 {
-		extraHeaders["anthropic-beta"] = headers
+		extraHeaders[AnthropicBetaHeader] = headers
 	} else {
 		// Passthrough wins: skip auto-injected headers when a same-prefix header
 		// already exists from passthrough. This prevents conflicting versions
@@ -376,7 +377,7 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 				existing = append(existing, h)
 			}
 		}
-		extraHeaders["anthropic-beta"] = existing
+		extraHeaders[AnthropicBetaHeader] = existing
 	}
 	ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, extraHeaders)
 	return nil
@@ -396,6 +397,7 @@ var betaHeaderPrefixKnown = []string{
 	AnthropicSkillsBetaHeaderPrefix,
 	AnthropicContext1MBetaHeaderPrefix,
 	AnthropicFastModeBetaHeaderPrefix,
+	AnthropicRedactThinkingBetaHeaderPrefix,
 }
 
 // betaHeaderPrefixExists checks if any header in existing shares a known prefix with newHeader.
@@ -574,85 +576,129 @@ func RemapRawToolVersionsForProvider(jsonBody []byte, provider schemas.ModelProv
 	return jsonBody, nil
 }
 
+// betaHeaderPrefixToFeature maps each known beta header prefix to a function that checks
+// whether the feature is supported by the provider's default feature set.
+var betaHeaderPrefixToFeature = map[string]func(ProviderFeatureSupport) bool{
+	"computer-use-": func(f ProviderFeatureSupport) bool { return f.ComputerUse },
+	AnthropicStructuredOutputsBetaHeaderPrefix:  func(f ProviderFeatureSupport) bool { return f.StructuredOutputs },
+	AnthropicMCPClientBetaHeaderPrefix:          func(f ProviderFeatureSupport) bool { return f.MCP },
+	AnthropicPromptCachingScopeBetaHeaderPrefix: func(f ProviderFeatureSupport) bool { return f.PromptCachingScope },
+	"compact-":                                   func(f ProviderFeatureSupport) bool { return f.Compaction },
+	"context-management-":                        func(f ProviderFeatureSupport) bool { return f.ContextEditing },
+	"files-api-":                                 func(f ProviderFeatureSupport) bool { return f.FilesAPI },
+	AnthropicAdvancedToolUseBetaHeaderPrefix:     func(f ProviderFeatureSupport) bool { return f.AdvancedToolUse },
+	AnthropicInterleavedThinkingBetaHeaderPrefix: func(f ProviderFeatureSupport) bool { return f.InterleavedThinking },
+	AnthropicSkillsBetaHeaderPrefix:              func(f ProviderFeatureSupport) bool { return f.Skills },
+	AnthropicContext1MBetaHeaderPrefix:           func(f ProviderFeatureSupport) bool { return f.Context1M },
+	AnthropicFastModeBetaHeaderPrefix:            func(f ProviderFeatureSupport) bool { return f.FastMode },
+	AnthropicRedactThinkingBetaHeaderPrefix:      func(f ProviderFeatureSupport) bool { return f.RedactThinking },
+}
+
+// MergeBetaHeaders collects anthropic-beta values from provider ExtraHeaders and
+// per-request context headers, deduplicating them.
+func MergeBetaHeaders(providerExtraHeaders map[string]string, ctx context.Context) []string {
+	seen := make(map[string]bool)
+	var all []string
+	add := func(v string) {
+		for _, part := range strings.Split(v, ",") {
+			if t := strings.TrimSpace(part); t != "" && !seen[t] {
+				seen[t] = true
+				all = append(all, t)
+			}
+		}
+	}
+	if v := providerExtraHeaders[AnthropicBetaHeader]; v != "" {
+		add(v)
+	}
+	if ctxHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
+		for _, v := range ctxHeaders[AnthropicBetaHeader] {
+			add(v)
+		}
+	}
+	return all
+}
+
 // FilterBetaHeadersForProvider validates that all beta headers are supported by the given provider.
 // Returns an error if a known beta header is not supported by the provider.
-// Unknown headers (not matched by any known prefix) are forwarded as-is for forward compatibility.
-func FilterBetaHeadersForProvider(headers []string, provider schemas.ModelProvider) ([]string, error) {
+// Unknown headers are forwarded only to Anthropic; for other providers they are silently dropped.
+// If overrides is non-nil, its entries (keyed by prefix) take precedence over the hardcoded defaults.
+func FilterBetaHeadersForProvider(headers []string, provider schemas.ModelProvider, overrides ...map[string]bool) []string {
 	features, hasProvider := ProviderFeatures[provider]
 	if !hasProvider {
 		// Unknown provider — allow all headers (safe default for custom providers)
-		return headers, nil
+		return headers
+	}
+
+	var overrideMap map[string]bool
+	if len(overrides) > 0 {
+		overrideMap = overrides[0]
 	}
 
 	filtered := make([]string, 0, len(headers))
 	for _, h := range headers {
-		switch {
-		case strings.HasPrefix(h, "computer-use-"):
-			if !features.ComputerUse {
-				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
+		tokens := strings.Split(h, ",")
+		for _, token := range tokens {
+			token = strings.TrimSpace(token)
+
+			if token == "" {
+				continue
 			}
-			filtered = append(filtered, h)
-		case strings.HasPrefix(h, AnthropicStructuredOutputsBetaHeaderPrefix):
-			if !features.StructuredOutputs {
-				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
+
+			// Find which known prefix this token matches
+			var matchedPrefix string
+			for _, prefix := range betaHeaderPrefixKnown {
+				if strings.HasPrefix(token, prefix) {
+					matchedPrefix = prefix
+					break
+				}
 			}
-			filtered = append(filtered, h)
-		case strings.HasPrefix(h, AnthropicMCPClientBetaHeaderPrefix):
-			if !features.MCP {
-				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
+
+			if matchedPrefix == "" {
+				// Check if any custom override prefix matches this unknown header
+				if overrideMap != nil {
+					matched := false
+					for prefix, allowed := range overrideMap {
+						if strings.HasPrefix(token, prefix) {
+							if allowed {
+								filtered = append(filtered, token)
+							}
+							// If not allowed, silently drop — custom overrides are user preferences,
+							// not hard incompatibilities that should break the request.
+							matched = true
+							break
+						}
+					}
+					if matched {
+						continue
+					}
+				}
+				// No override match — forward only to Anthropic API for forward compatibility.
+				// Non-Anthropic providers reject unrecognized headers, so drop unknown ones.
+				if provider == schemas.Anthropic {
+					filtered = append(filtered, token)
+				}
+				continue
 			}
-			filtered = append(filtered, h)
-		case strings.HasPrefix(h, AnthropicPromptCachingScopeBetaHeaderPrefix):
-			if !features.PromptCachingScope {
-				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
+
+			// Check override first, then fall back to hardcoded feature support
+			supported := false
+			if overrideMap != nil {
+				if override, hasOverride := overrideMap[matchedPrefix]; hasOverride {
+					supported = override
+				} else if featureCheck, ok := betaHeaderPrefixToFeature[matchedPrefix]; ok {
+					supported = featureCheck(features)
+				}
+			} else if featureCheck, ok := betaHeaderPrefixToFeature[matchedPrefix]; ok {
+				supported = featureCheck(features)
 			}
-			filtered = append(filtered, h)
-		case strings.HasPrefix(h, "compact-"):
-			if !features.Compaction {
-				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
+
+			if !supported {
+				continue
 			}
-			filtered = append(filtered, h)
-		case strings.HasPrefix(h, "context-management-"):
-			if !features.ContextEditing {
-				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
-			}
-			filtered = append(filtered, h)
-		case strings.HasPrefix(h, "files-api-"):
-			if !features.FilesAPI {
-				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
-			}
-			filtered = append(filtered, h)
-		case strings.HasPrefix(h, AnthropicAdvancedToolUseBetaHeaderPrefix):
-			if !features.AdvancedToolUse {
-				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
-			}
-			filtered = append(filtered, h)
-		case strings.HasPrefix(h, AnthropicInterleavedThinkingBetaHeaderPrefix):
-			if !features.InterleavedThinking {
-				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
-			}
-			filtered = append(filtered, h)
-		case strings.HasPrefix(h, AnthropicSkillsBetaHeaderPrefix):
-			if !features.Skills {
-				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
-			}
-			filtered = append(filtered, h)
-		case strings.HasPrefix(h, AnthropicContext1MBetaHeaderPrefix):
-			if !features.Context1M {
-				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
-			}
-			filtered = append(filtered, h)
-		case strings.HasPrefix(h, AnthropicFastModeBetaHeaderPrefix):
-			if !features.FastMode {
-				return nil, fmt.Errorf("beta header '%s' is not supported by provider '%s'", h, provider)
-			}
-			filtered = append(filtered, h)
-		default:
-			// Unknown headers are forwarded for forward compatibility
-			filtered = append(filtered, h)
+			filtered = append(filtered, token)
 		}
 	}
-	return filtered, nil
+	return filtered
 }
 
 // appendUniqueHeader adds a header to the slice if not already present
@@ -667,9 +713,9 @@ func appendUniqueHeader(slice []string, item string) []string {
 
 // appendBetaHeader appends a beta header to the request, preserving any existing beta headers
 func appendBetaHeader(req *fasthttp.Request, betaHeader string) {
-	existing := string(req.Header.Peek("anthropic-beta"))
+	existing := string(req.Header.Peek(AnthropicBetaHeader))
 	if existing == "" {
-		req.Header.Set("anthropic-beta", betaHeader)
+		req.Header.Set(AnthropicBetaHeader, betaHeader)
 		return
 	}
 	// Check if header already present
@@ -678,7 +724,7 @@ func appendBetaHeader(req *fasthttp.Request, betaHeader string) {
 			return
 		}
 	}
-	req.Header.Set("anthropic-beta", existing+","+betaHeader)
+	req.Header.Set(AnthropicBetaHeader, existing+","+betaHeader)
 }
 
 // convertChatResponseFormatToTool converts a response_format config to an Anthropic tool for structured output
@@ -2048,4 +2094,3 @@ func IsClaudeCodeRequest(ctx *schemas.BifrostContext) bool {
 	}
 	return false
 }
-

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -802,7 +803,7 @@ func TestAddMissingBetaHeadersToContext_PerProvider(t *testing.T) {
 
 			var headers []string
 			if extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
-				headers = extraHeaders["anthropic-beta"]
+				headers = extraHeaders[AnthropicBetaHeader]
 			}
 
 			for _, expected := range tt.expectHeaders {
@@ -844,7 +845,7 @@ func TestAddMissingBetaHeadersToContext_PassthroughWins(t *testing.T) {
 		AddMissingBetaHeadersToContext(ctx, req, schemas.Anthropic)
 
 		extraHeaders := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
-		betaHeaders := extraHeaders["anthropic-beta"]
+		betaHeaders := extraHeaders[AnthropicBetaHeader]
 		// Should only have the old header, not both
 		if len(betaHeaders) != 1 {
 			t.Errorf("expected 1 header, got %d: %v", len(betaHeaders), betaHeaders)
@@ -869,7 +870,7 @@ func TestAddMissingBetaHeadersToContext_PassthroughWins(t *testing.T) {
 		AddMissingBetaHeadersToContext(ctx, req, schemas.Anthropic)
 
 		extraHeaders := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
-		betaHeaders := extraHeaders["anthropic-beta"]
+		betaHeaders := extraHeaders[AnthropicBetaHeader]
 		if len(betaHeaders) != 1 {
 			t.Errorf("expected 1 header, got %d: %v", len(betaHeaders), betaHeaders)
 		}
@@ -886,7 +887,7 @@ func TestAddMissingBetaHeadersToContext_PassthroughWins(t *testing.T) {
 		AddMissingBetaHeadersToContext(ctx, req, schemas.Anthropic)
 
 		extraHeaders := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
-		betaHeaders := extraHeaders["anthropic-beta"]
+		betaHeaders := extraHeaders[AnthropicBetaHeader]
 		if len(betaHeaders) != 1 || betaHeaders[0] != AnthropicMCPClientBetaHeader {
 			t.Errorf("expected [%q], got %v", AnthropicMCPClientBetaHeader, betaHeaders)
 		}
@@ -907,28 +908,28 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 		AnthropicSkillsBetaHeader,
 		AnthropicContext1MBetaHeader,
 		AnthropicFastModeBetaHeader,
+		AnthropicRedactThinkingBetaHeader,
+	}
+
+	containsHeader := func(result []string, h string) bool {
+		for _, r := range result {
+			if r == h {
+				return true
+			}
+		}
+		return false
 	}
 
 	t.Run("Anthropic/keeps_all_headers", func(t *testing.T) {
-		result, err := FilterBetaHeadersForProvider(allHeaders, schemas.Anthropic)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		result := FilterBetaHeadersForProvider(allHeaders, schemas.Anthropic)
 		for _, h := range allHeaders {
-			found := false
-			for _, r := range result {
-				if r == h {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if !containsHeader(result, h) {
 				t.Errorf("expected header %q to be kept for Anthropic, got %v", h, result)
 			}
 		}
 	})
 
-	t.Run("Vertex/errors_on_unsupported_headers", func(t *testing.T) {
+	t.Run("Vertex/drops_unsupported_headers", func(t *testing.T) {
 		unsupported := []string{
 			AnthropicStructuredOutputsBetaHeader,
 			AnthropicMCPClientBetaHeader,
@@ -937,16 +938,17 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 			AnthropicFilesAPIBetaHeader,
 			AnthropicSkillsBetaHeader,
 			AnthropicFastModeBetaHeader,
+			AnthropicRedactThinkingBetaHeader,
 		}
 		for _, h := range unsupported {
-			_, err := FilterBetaHeadersForProvider([]string{h}, schemas.Vertex)
-			if err == nil {
-				t.Errorf("expected error for header %q on Vertex, got nil", h)
+			result := FilterBetaHeadersForProvider([]string{h}, schemas.Vertex)
+			if len(result) != 0 {
+				t.Errorf("expected header %q to be dropped for Vertex, got %v", h, result)
 			}
 		}
 	})
 
-	t.Run("Vertex/allows_supported_headers", func(t *testing.T) {
+	t.Run("Vertex/keeps_supported_headers", func(t *testing.T) {
 		supported := []string{
 			AnthropicComputerUseBetaHeader20251124,
 			AnthropicCompactionBetaHeader,
@@ -954,16 +956,13 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 			AnthropicInterleavedThinkingBetaHeader,
 			AnthropicContext1MBetaHeader,
 		}
-		result, err := FilterBetaHeadersForProvider(supported, schemas.Vertex)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
+		result := FilterBetaHeadersForProvider(supported, schemas.Vertex)
 		if len(result) != len(supported) {
 			t.Errorf("expected %d headers, got %d: %v", len(supported), len(result), result)
 		}
 	})
 
-	t.Run("Bedrock/errors_on_unsupported_headers", func(t *testing.T) {
+	t.Run("Bedrock/drops_unsupported_headers", func(t *testing.T) {
 		unsupported := []string{
 			AnthropicMCPClientBetaHeader,
 			AnthropicPromptCachingScopeBetaHeader,
@@ -971,35 +970,175 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 			AnthropicFilesAPIBetaHeader,
 			AnthropicSkillsBetaHeader,
 			AnthropicFastModeBetaHeader,
+			AnthropicRedactThinkingBetaHeader,
 		}
 		for _, h := range unsupported {
-			_, err := FilterBetaHeadersForProvider([]string{h}, schemas.Bedrock)
-			if err == nil {
-				t.Errorf("expected error for header %q on Bedrock, got nil", h)
+			result := FilterBetaHeadersForProvider([]string{h}, schemas.Bedrock)
+			if len(result) != 0 {
+				t.Errorf("expected header %q to be dropped for Bedrock, got %v", h, result)
 			}
 		}
 	})
 
-	t.Run("unknown_headers_forwarded", func(t *testing.T) {
-		headers := []string{"some-future-beta-2025"}
-		result, err := FilterBetaHeadersForProvider(headers, schemas.Vertex)
-		if err != nil {
-			t.Fatalf("unexpected error for unknown headers: %v", err)
+	t.Run("Azure/drops_unsupported_headers", func(t *testing.T) {
+		unsupported := []string{
+			AnthropicFastModeBetaHeader,
 		}
+		for _, h := range unsupported {
+			result := FilterBetaHeadersForProvider([]string{h}, schemas.Azure)
+			if len(result) != 0 {
+				t.Errorf("expected header %q to be dropped for Azure, got %v", h, result)
+			}
+		}
+	})
+
+	t.Run("Azure/keeps_supported_headers", func(t *testing.T) {
+		supported := []string{
+			AnthropicComputerUseBetaHeader20251124,
+			AnthropicStructuredOutputsBetaHeader,
+			AnthropicMCPClientBetaHeader,
+			AnthropicPromptCachingScopeBetaHeader,
+			AnthropicCompactionBetaHeader,
+			AnthropicContextManagementBetaHeader,
+			AnthropicAdvancedToolUseBetaHeader,
+			AnthropicFilesAPIBetaHeader,
+			AnthropicInterleavedThinkingBetaHeader,
+			AnthropicSkillsBetaHeader,
+			AnthropicContext1MBetaHeader,
+			AnthropicRedactThinkingBetaHeader,
+		}
+		result := FilterBetaHeadersForProvider(supported, schemas.Azure)
+		if len(result) != len(supported) {
+			t.Errorf("expected %d headers, got %d: %v", len(supported), len(result), result)
+		}
+	})
+
+	t.Run("Bedrock/keeps_supported_headers", func(t *testing.T) {
+		supported := []string{
+			AnthropicComputerUseBetaHeader20251124,
+			AnthropicStructuredOutputsBetaHeader,
+			AnthropicCompactionBetaHeader,
+			AnthropicContextManagementBetaHeader,
+			AnthropicInterleavedThinkingBetaHeader,
+			AnthropicContext1MBetaHeader,
+		}
+		result := FilterBetaHeadersForProvider(supported, schemas.Bedrock)
+		if len(result) != len(supported) {
+			t.Errorf("expected %d headers, got %d: %v", len(supported), len(result), result)
+		}
+	})
+
+	t.Run("unknown_headers_dropped_for_non_anthropic", func(t *testing.T) {
+		result := FilterBetaHeadersForProvider([]string{"some-future-beta-2025"}, schemas.Vertex)
+		if len(result) != 0 {
+			t.Errorf("expected unknown header to be dropped for Vertex, got %v", result)
+		}
+	})
+
+	t.Run("unknown_headers_forwarded_for_anthropic", func(t *testing.T) {
+		headers := []string{"some-future-beta-2025"}
+		result := FilterBetaHeadersForProvider(headers, schemas.Anthropic)
 		if len(result) != len(headers) {
-			t.Errorf("expected all unknown headers to be forwarded, got %v", result)
+			t.Errorf("expected unknown header to be forwarded for Anthropic, got %v", result)
 		}
 	})
 
 	t.Run("unknown_provider_allows_all", func(t *testing.T) {
-		result, err := FilterBetaHeadersForProvider(allHeaders, schemas.ModelProvider("custom-provider"))
-		if err != nil {
-			t.Fatalf("unexpected error for unknown provider: %v", err)
-		}
+		result := FilterBetaHeadersForProvider(allHeaders, schemas.ModelProvider("custom-provider"))
 		if len(result) != len(allHeaders) {
 			t.Errorf("expected all headers for unknown provider, got %v", result)
 		}
 	})
+
+	t.Run("override_enables_unsupported_header", func(t *testing.T) {
+		// redact-thinking is not supported on Vertex by default
+		overrides := map[string]bool{AnthropicRedactThinkingBetaHeaderPrefix: true}
+		result := FilterBetaHeadersForProvider([]string{AnthropicRedactThinkingBetaHeader}, schemas.Vertex, overrides)
+		if len(result) != 1 || result[0] != AnthropicRedactThinkingBetaHeader {
+			t.Errorf("expected override to allow header, got %v", result)
+		}
+	})
+
+	t.Run("override_disables_supported_header", func(t *testing.T) {
+		// compaction is supported on Vertex by default; override to false should drop it silently
+		overrides := map[string]bool{"compact-": false}
+		result := FilterBetaHeadersForProvider([]string{AnthropicCompactionBetaHeader}, schemas.Vertex, overrides)
+		if len(result) != 0 {
+			t.Errorf("expected override false to drop supported header, got %v", result)
+		}
+	})
+
+	t.Run("override_nil_uses_defaults", func(t *testing.T) {
+		// Passing nil overrides should behave identically to no overrides
+		result := FilterBetaHeadersForProvider([]string{AnthropicCompactionBetaHeader}, schemas.Vertex, nil)
+		if len(result) != 1 {
+			t.Errorf("expected default behavior with nil overrides, got %v", result)
+		}
+	})
+
+	// Custom override tests for all providers
+	customOverrideProviders := []struct {
+		provider                schemas.ModelProvider
+		expectForwardNoOverride bool // unknown headers forwarded without override?
+	}{
+		{schemas.Anthropic, true},
+		{schemas.Vertex, false},
+		{schemas.Bedrock, false},
+		{schemas.Azure, false},
+	}
+
+	for _, tc := range customOverrideProviders {
+		tc := tc
+		t.Run(fmt.Sprintf("%s/custom_override_enables_unknown_header", tc.provider), func(t *testing.T) {
+			overrides := map[string]bool{"new-feature-": true}
+			result := FilterBetaHeadersForProvider([]string{"new-feature-2026-01-01"}, tc.provider, overrides)
+			if len(result) != 1 || result[0] != "new-feature-2026-01-01" {
+				t.Errorf("expected custom override to allow header on %s, got %v", tc.provider, result)
+			}
+		})
+
+		t.Run(fmt.Sprintf("%s/custom_override_disables_unknown_header", tc.provider), func(t *testing.T) {
+			overrides := map[string]bool{"new-feature-": false}
+			result := FilterBetaHeadersForProvider([]string{"new-feature-2026-01-01"}, tc.provider, overrides)
+			if len(result) != 0 {
+				t.Errorf("expected custom override false to drop header on %s, got %v", tc.provider, result)
+			}
+		})
+
+		t.Run(fmt.Sprintf("%s/custom_override_no_match_still_handled_correctly", tc.provider), func(t *testing.T) {
+			overrides := map[string]bool{"new-feature-": true}
+			result := FilterBetaHeadersForProvider([]string{"other-thing-2026"}, tc.provider, overrides)
+			if tc.expectForwardNoOverride {
+				if len(result) != 1 {
+					t.Errorf("expected unknown header forwarded to %s, got %v", tc.provider, result)
+				}
+			} else {
+				if len(result) != 0 {
+					t.Errorf("expected unknown header dropped for %s, got %v", tc.provider, result)
+				}
+			}
+		})
+
+		t.Run(fmt.Sprintf("%s/custom_override_with_multiple_prefixes", tc.provider), func(t *testing.T) {
+			overrides := map[string]bool{
+				"alpha-": true,
+				"beta-":  false,
+				"gamma-": true,
+			}
+			result := FilterBetaHeadersForProvider([]string{"alpha-2026-01"}, tc.provider, overrides)
+			if len(result) != 1 {
+				t.Errorf("expected alpha- allowed on %s, got %v", tc.provider, result)
+			}
+			result = FilterBetaHeadersForProvider([]string{"beta-2026-01"}, tc.provider, overrides)
+			if len(result) != 0 {
+				t.Errorf("expected beta- dropped on %s, got %v", tc.provider, result)
+			}
+			result = FilterBetaHeadersForProvider([]string{"gamma-2026-01"}, tc.provider, overrides)
+			if len(result) != 1 {
+				t.Errorf("expected gamma- allowed on %s, got %v", tc.provider, result)
+			}
+		})
+	}
 }
 
 func TestStripAutoInjectableTools(t *testing.T) {

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -220,13 +221,18 @@ func (provider *AzureProvider) completeRequest(
 		}
 	}()
 
-	// Set any extra headers from network config
-	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-	req.Header.SetMethod(http.MethodPost)
-	req.Header.SetContentType("application/json")
-
 	var url string
 	isAnthropicModel := schemas.IsAnthropicModel(deployment)
+
+	// Set any extra headers from network config.
+	// For Anthropic models, exclude anthropic-beta — it is merged and filtered explicitly below.
+	if isAnthropicModel {
+		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, []string{anthropic.AnthropicBetaHeader})
+	} else {
+		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	}
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
 
 	// Get authentication headers
 	authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, isAnthropicModel)
@@ -247,6 +253,13 @@ func (provider *AzureProvider) completeRequest(
 	if isAnthropicModel {
 		req.Header.Set("anthropic-version", AzureAnthropicAPIVersionDefault)
 		url = fmt.Sprintf("%s/%s", endpoint, path)
+
+		// Merge ExtraHeaders + context anthropic-beta, filter for Azure, then set as HTTP header
+		if betaHeaders := anthropic.FilterBetaHeadersForProvider(anthropic.MergeBetaHeaders(provider.networkConfig.ExtraHeaders, ctx), schemas.Azure, provider.networkConfig.BetaHeaderOverrides); len(betaHeaders) > 0 {
+			req.Header.Set(anthropic.AnthropicBetaHeader, strings.Join(betaHeaders, ","))
+		} else {
+			req.Header.Del(anthropic.AnthropicBetaHeader)
+		}
 	} else {
 		apiVersion := key.AzureKeyConfig.APIVersion
 		if apiVersion == nil {
@@ -701,6 +714,7 @@ func (provider *AzureProvider) ChatCompletionStream(ctx *schemas.BifrostContext,
 			jsonData,
 			authHeader,
 			provider.networkConfig.ExtraHeaders,
+			provider.networkConfig.BetaHeaderOverrides,
 			providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 			provider.GetProviderKey(),
@@ -895,6 +909,7 @@ func (provider *AzureProvider) ResponsesStream(ctx *schemas.BifrostContext, post
 			jsonData,
 			authHeader,
 			provider.networkConfig.ExtraHeaders,
+			provider.networkConfig.BetaHeaderOverrides,
 			providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 			provider.GetProviderKey(),

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -178,6 +178,12 @@ func (provider *BedrockProvider) completeRequest(ctx *schemas.BifrostContext, js
 	// Set any extra headers from network config
 	providerUtils.SetExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
+	if filtered := anthropic.FilterBetaHeadersForProvider(anthropic.MergeBetaHeaders(provider.networkConfig.ExtraHeaders, ctx), schemas.Bedrock, provider.networkConfig.BetaHeaderOverrides); len(filtered) > 0 {
+		req.Header.Set(anthropic.AnthropicBetaHeader, strings.Join(filtered, ","))
+	} else {
+		req.Header.Del(anthropic.AnthropicBetaHeader)
+	}
+
 	// If Value is set, use API Key authentication - else use IAM role authentication
 	if key.Value.GetValue() != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key.Value.GetValue()))
@@ -404,6 +410,12 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx *schemas.BifrostContex
 
 	// Set any extra headers from network config
 	providerUtils.SetExtraHeadersHTTP(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	if filtered := anthropic.FilterBetaHeadersForProvider(anthropic.MergeBetaHeaders(provider.networkConfig.ExtraHeaders, ctx), schemas.Bedrock, provider.networkConfig.BetaHeaderOverrides); len(filtered) > 0 {
+		req.Header.Set(anthropic.AnthropicBetaHeader, strings.Join(filtered, ","))
+	} else {
+		req.Header.Del(anthropic.AnthropicBetaHeader)
+	}
 
 	// If Value is set, use API Key authentication - else use IAM role authentication
 	req.Header.Set("Accept", "application/vnd.amazon.eventstream")
@@ -1030,7 +1042,7 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to parse bedrock response", err, providerName), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
-	// Convert using the new response converter	
+	// Convert using the new response converter
 	bifrostResponse, err := bedrockResponse.ToBifrostChatResponse(ctx, request.Model)
 	if err != nil {
 		return nil, providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError("failed to convert bedrock response", err, providerName), jsonData, responseBody, provider.sendBackRawRequest, provider.sendBackRawResponse)

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -519,6 +519,9 @@ func SetExtraHeaders(ctx context.Context, req *fasthttp.Request, extraHeaders ma
 	// Give priority to extra headers in the context
 	if extraHeaders, ok := (ctx).Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
 		for k, values := range filterHeaders(extraHeaders) {
+			if skipHeaders != nil && slices.Contains(skipHeaders, strings.ToLower(k)) {
+				continue
+			}
 			for i, v := range values {
 				if i == 0 {
 					req.Header.Set(k, v)
@@ -1083,6 +1086,9 @@ func SetExtraHeadersHTTP(ctx context.Context, req *http.Request, extraHeaders ma
 	// Give priority to extra headers in the context
 	if extraHeaders, ok := (ctx).Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
 		for k, values := range filterHeaders(extraHeaders) {
+			if skipHeaders != nil && slices.Contains(skipHeaders, strings.ToLower(k)) {
+				continue
+			}
 			for i, v := range values {
 				if i == 0 {
 					req.Header.Set(k, v)

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, deployment string, providerName schemas.ModelProvider, isStreaming bool, isCountTokens bool) ([]byte, *schemas.BifrostError) {
+func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, deployment string, providerName schemas.ModelProvider, isStreaming bool, isCountTokens bool, betaHeaderOverrides map[string]bool, providerExtraHeaders map[string]string) ([]byte, *schemas.BifrostError) {
 	// Large payload mode: body streams directly from the LP reader — skip all body building
 	// (matches CheckContextAndGetRequestBody guard).
 	if providerUtils.IsLargePayloadPassthroughEnabled(ctx) {
@@ -120,20 +120,6 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 			}
 		}
 
-		// Inject beta headers into body as anthropic_beta (Vertex uses body field, not HTTP header)
-		if extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
-			betaHeaders, betaErr := anthropic.FilterBetaHeadersForProvider(extraHeaders["anthropic-beta"], schemas.Vertex)
-			if betaErr != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, betaErr, providerName)
-			}
-			if len(betaHeaders) > 0 {
-				jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_beta", betaHeaders)
-				if err != nil {
-					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
-				}
-			}
-		}
-
 		if isCountTokens {
 			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "max_tokens")
 			if err != nil {
@@ -152,6 +138,13 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 		}
 
 		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "region")
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+		}
+	}
+
+	if betaHeaders := anthropic.FilterBetaHeadersForProvider(anthropic.MergeBetaHeaders(providerExtraHeaders, ctx), schemas.Vertex, betaHeaderOverrides); len(betaHeaders) > 0 {
+		jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_beta", betaHeaders)
 		if err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 		}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -415,16 +415,10 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 					}
 				}
 				// Inject beta headers into body as anthropic_beta (Vertex uses body field, not HTTP header)
-				if extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
-					betaHeaders, betaErr := anthropic.FilterBetaHeadersForProvider(extraHeaders["anthropic-beta"], schemas.Vertex)
-					if betaErr != nil {
-						return nil, fmt.Errorf("unsupported beta header: %w", betaErr)
-					}
-					if len(betaHeaders) > 0 {
-						rawBody, err = providerUtils.SetJSONField(rawBody, "anthropic_beta", betaHeaders)
-						if err != nil {
-							return nil, fmt.Errorf("failed to set anthropic_beta: %w", err)
-						}
+				if betaHeaders := anthropic.FilterBetaHeadersForProvider(anthropic.MergeBetaHeaders(provider.networkConfig.ExtraHeaders, ctx), schemas.Vertex, provider.networkConfig.BetaHeaderOverrides); len(betaHeaders) > 0 {
+					rawBody, err = providerUtils.SetJSONField(rawBody, "anthropic_beta", betaHeaders)
+					if err != nil {
+						return nil, fmt.Errorf("failed to set anthropic_beta: %w", err)
 					}
 				}
 				// Remove model field (it's in URL for Vertex)
@@ -555,7 +549,9 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
-	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	// Skip anthropic-beta from context headers — Anthropic models on Vertex use the
+	// anthropic_beta body field instead, and other model families don't use it.
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, []string{anthropic.AnthropicBetaHeader})
 
 	// If auth query is set, add it to the URL
 	// Otherwise, get the oauth2 token and set the Authorization header
@@ -786,16 +782,10 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 					}
 				}
 				// Inject beta headers into body as anthropic_beta (Vertex uses body field, not HTTP header)
-				if extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
-					betaHeaders, betaErr := anthropic.FilterBetaHeadersForProvider(extraHeaders["anthropic-beta"], schemas.Vertex)
-					if betaErr != nil {
-						return nil, fmt.Errorf("unsupported beta header: %w", betaErr)
-					}
-					if len(betaHeaders) > 0 {
-						rawBody, err = providerUtils.SetJSONField(rawBody, "anthropic_beta", betaHeaders)
-						if err != nil {
-							return nil, fmt.Errorf("failed to set anthropic_beta: %w", err)
-						}
+				if betaHeaders := anthropic.FilterBetaHeadersForProvider(anthropic.MergeBetaHeaders(provider.networkConfig.ExtraHeaders, ctx), schemas.Vertex, provider.networkConfig.BetaHeaderOverrides); len(betaHeaders) > 0 {
+					rawBody, err = providerUtils.SetJSONField(rawBody, "anthropic_beta", betaHeaders)
+					if err != nil {
+						return nil, fmt.Errorf("failed to set anthropic_beta: %w", err)
 					}
 				}
 
@@ -857,6 +847,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			jsonData,
 			headers,
 			provider.networkConfig.ExtraHeaders,
+			provider.networkConfig.BetaHeaderOverrides,
 			providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 			providerName,
@@ -1030,7 +1021,7 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 	}
 
 	if schemas.IsAnthropicModel(deployment) {
-		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, deployment, providerName, false, false)
+		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, deployment, providerName, false, false, provider.networkConfig.BetaHeaderOverrides, provider.networkConfig.ExtraHeaders)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
@@ -1066,7 +1057,7 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 
 		req.Header.SetMethod(http.MethodPost)
 		req.Header.SetContentType("application/json")
-		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, []string{anthropic.AnthropicBetaHeader})
 
 		// Getting oauth2 token
 		tokenSource, err := getAuthTokenSource(key)
@@ -1355,7 +1346,7 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 			return nil, providerUtils.NewConfigurationError("project ID is not set", providerName)
 		}
 
-		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, deployment, providerName, true, false)
+		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, deployment, providerName, true, false, provider.networkConfig.BetaHeaderOverrides, provider.networkConfig.ExtraHeaders)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
@@ -1401,6 +1392,7 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 			jsonBody,
 			headers,
 			provider.networkConfig.ExtraHeaders,
+			provider.networkConfig.BetaHeaderOverrides,
 			providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 			provider.GetProviderKey(),
@@ -2889,7 +2881,7 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 	)
 
 	if schemas.IsAnthropicModel(deployment) {
-		jsonBody, bifrostErr = getRequestBodyForAnthropicResponses(ctx, request, deployment, providerName, false, true)
+		jsonBody, bifrostErr = getRequestBodyForAnthropicResponses(ctx, request, deployment, providerName, false, true, provider.networkConfig.BetaHeaderOverrides, provider.networkConfig.ExtraHeaders)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
@@ -2964,7 +2956,7 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
-	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, []string{anthropic.AnthropicBetaHeader})
 
 	if authQuery != "" {
 		completeURL = fmt.Sprintf("%s?%s", completeURL, authQuery)

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -63,6 +63,7 @@ type NetworkConfig struct {
 	StreamIdleTimeoutInSeconds     int               `json:"stream_idle_timeout_in_seconds,omitempty"` // Idle timeout per stream chunk (0 = use default 60s)
 	MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`              // Max TCP connections per provider host (default: 5000)
 	EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`                   // Force HTTP/2 on provider connections (relevant for net/http-based providers like Bedrock)
+	BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`           // Override default beta header support per provider (keys are prefixes like "redact-thinking-")
 }
 
 // UnmarshalJSON customizes JSON unmarshaling for NetworkConfig.
@@ -82,6 +83,7 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 		StreamIdleTimeoutInSeconds     int               `json:"stream_idle_timeout_in_seconds,omitempty"`
 		MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`
 		EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`
+		BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`
 	}
 
 	var alias NetworkConfigAlias
@@ -99,6 +101,7 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 	nc.StreamIdleTimeoutInSeconds = alias.StreamIdleTimeoutInSeconds
 	nc.MaxConnsPerHost = alias.MaxConnsPerHost
 	nc.EnforceHTTP2 = alias.EnforceHTTP2
+	nc.BetaHeaderOverrides = alias.BetaHeaderOverrides
 
 	// Convert milliseconds to time.Duration (nanoseconds)
 	// Only convert if value is greater than 0
@@ -129,6 +132,7 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 		StreamIdleTimeoutInSeconds     int               `json:"stream_idle_timeout_in_seconds,omitempty"`
 		MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`
 		EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`
+		BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`
 	}
 
 	alias := NetworkConfigAlias{
@@ -144,6 +148,7 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 		StreamIdleTimeoutInSeconds: nc.StreamIdleTimeoutInSeconds,
 		MaxConnsPerHost:            nc.MaxConnsPerHost,
 		EnforceHTTP2:               nc.EnforceHTTP2,
+		BetaHeaderOverrides:        nc.BetaHeaderOverrides,
 	}
 
 	return json.Marshal(alias)
@@ -532,6 +537,13 @@ func (config *ProviderConfig) CheckAndSetDefaults() {
 		headersCopy := make(map[string]string, len(config.NetworkConfig.ExtraHeaders))
 		maps.Copy(headersCopy, config.NetworkConfig.ExtraHeaders)
 		config.NetworkConfig.ExtraHeaders = headersCopy
+	}
+
+	// Create a defensive copy of BetaHeaderOverrides to prevent data races
+	if config.NetworkConfig.BetaHeaderOverrides != nil {
+		overridesCopy := make(map[string]bool, len(config.NetworkConfig.BetaHeaderOverrides))
+		maps.Copy(overridesCopy, config.NetworkConfig.BetaHeaderOverrides)
+		config.NetworkConfig.BetaHeaderOverrides = overridesCopy
 	}
 }
 

--- a/docs/providers/supported-providers/anthropic.mdx
+++ b/docs/providers/supported-providers/anthropic.mdx
@@ -50,9 +50,12 @@ Bifrost automatically manages Anthropic beta headers — detecting required head
 | `skills-2025-10-02` | ✅ | ✅ | ❌ | ❌ | Passthrough |
 | `context-1m-2025-08-07` | ✅ | ✅ | ✅ | ✅ | Passthrough |
 | `fast-mode-2026-02-01` | ✅ | ❌ | ❌ | ❌ | ✅ (speed=fast) |
+| `redact-thinking-2026-02-12` | ✅ | ✅ | ❌ | ❌ | Passthrough |
 
 <Note>
-**Passthrough headers** are not auto-injected but are validated and forwarded when set manually via the `anthropic-beta` request header. Unknown headers are always forwarded for forward compatibility.
+**Passthrough headers** are not auto-injected but are validated and forwarded when set manually via the `anthropic-beta` request header. Unknown headers are forwarded to Anthropic only; for other providers (Vertex, Bedrock, Azure), unknown headers are silently dropped by default to prevent upstream errors.
+
+**Beta header overrides**: You can override the default support per provider via the Beta Headers tab in provider configuration, or by setting `beta_header_overrides` in the provider's `network_config`. See [Beta Header Overrides](/quickstart/gateway/provider-configuration#beta-header-overrides) for details.
 </Note>
 
 ---

--- a/docs/providers/supported-providers/azure.mdx
+++ b/docs/providers/supported-providers/azure.mdx
@@ -37,6 +37,16 @@ Azure is a cloud provider offering access to OpenAI and Anthropic models through
 **Azure-specific**: Batch operations and Text Completions are not supported by Azure OpenAI Service. Responses API uses preview API version and is available for both OpenAI and Anthropic models.
 </Note>
 
+## Beta Headers
+
+For Anthropic models on Azure, Bifrost validates `anthropic-beta` headers. Azure supports most Anthropic beta features.
+
+**Supported**: `computer-use-*`, `structured-outputs-*`, `advanced-tool-use-*`, `mcp-client-*`, `prompt-caching-scope-*`, `compact-*`, `context-management-*`, `files-api-*`, `interleaved-thinking-*`, `skills-*`, `context-1m-*`, `redact-thinking-*`
+
+**Not supported**: `fast-mode-*`
+
+You can override these defaults per provider via the **Beta Headers** tab in provider configuration or via [`beta_header_overrides`](/quickstart/gateway/provider-configuration#beta-header-overrides). See the full support matrix in the [Anthropic provider docs](/providers/supported-providers/anthropic#beta-headers).
+
 ---
 
 # 1. Chat Completions

--- a/docs/providers/supported-providers/bedrock.mdx
+++ b/docs/providers/supported-providers/bedrock.mdx
@@ -51,6 +51,16 @@ AWS Bedrock supports multiple model families (Claude, Nova, Mistral, Llama, Cohe
 **Limitations**: Images must be in base64 or data URI format (remote URLs not supported). Text completion streaming is not supported.
 </Note>
 
+## Beta Headers
+
+For Claude models on Bedrock, Bifrost validates `anthropic-beta` headers to ensure only supported features are forwarded.
+
+**Supported**: `computer-use-*`, `structured-outputs-*`, `compact-*`, `context-management-*`, `interleaved-thinking-*`, `context-1m-*`
+
+**Not supported**: `advanced-tool-use-*`, `mcp-client-*`, `prompt-caching-scope-*`, `files-api-*`, `skills-*`, `fast-mode-*`, `redact-thinking-*`
+
+You can override these defaults per provider via the **Beta Headers** tab in provider configuration or via [`beta_header_overrides`](/quickstart/gateway/provider-configuration#beta-header-overrides). See the full support matrix in the [Anthropic provider docs](/providers/supported-providers/anthropic#beta-headers).
+
 ---
 
 # 1. Chat Completions

--- a/docs/providers/supported-providers/vertex.mdx
+++ b/docs/providers/supported-providers/vertex.mdx
@@ -39,6 +39,16 @@ Vertex AI is Google's unified ML platform providing access to Google's Gemini mo
 **Vertex-specific**: Endpoints vary by model type. Responses API available for both Gemini and Anthropic models.
 </Note>
 
+## Beta Headers
+
+For Anthropic models on Vertex AI, Bifrost validates `anthropic-beta` headers to ensure only supported features are forwarded. Unsupported headers are rejected with a clear error.
+
+**Supported**: `computer-use-*`, `compact-*`, `context-management-*`, `interleaved-thinking-*`, `context-1m-*`
+
+**Not supported**: `structured-outputs-*`, `advanced-tool-use-*`, `mcp-client-*`, `prompt-caching-scope-*`, `files-api-*`, `skills-*`, `fast-mode-*`, `redact-thinking-*`
+
+You can override these defaults per provider via the **Beta Headers** tab in provider configuration or via [`beta_header_overrides`](/quickstart/gateway/provider-configuration#beta-header-overrides). See the full support matrix in the [Anthropic provider docs](/providers/supported-providers/anthropic#beta-headers).
+
 ---
 
 # 1. Chat Completions

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -694,6 +694,61 @@ denylist := map[string]bool{
 
 This denylist is applied to both static and dynamic headers to prevent security vulnerabilities.
 
+#### Beta Header Overrides
+
+For Anthropic-family providers (Anthropic, Vertex, Bedrock, Azure), Bifrost maintains a default support matrix for `anthropic-beta` headers. You can override these defaults per provider when upstream support changes before Bifrost updates its defaults.
+
+<Tabs group="beta-header-overrides">
+
+<Tab title="Using Web UI">
+
+1. Navigate to **"Model Providers"** → **"Configurations"** → select your provider → **"Beta Headers"** tab
+2. Each known beta header shows its default support status
+3. Use the override dropdown to set **Enabled**, **Disabled**, or **Default** (use built-in defaults)
+4. Save configuration
+
+</Tab>
+
+<Tab title="Using API">
+
+```bash
+curl --location --request PUT 'http://localhost:8080/api/providers/vertex' \
+--header 'Content-Type: application/json' \
+--data '{
+    "network_config": {
+        "beta_header_overrides": {
+            "redact-thinking-": true,
+            "fast-mode-": false
+        }
+    }
+}'
+```
+
+</Tab>
+
+<Tab title="Using config.json">
+
+```json
+{
+    "providers": {
+        "vertex": {
+            "network_config": {
+                "beta_header_overrides": {
+                    "redact-thinking-": true,
+                    "fast-mode-": false
+                }
+            }
+        }
+    }
+}
+```
+
+</Tab>
+
+</Tabs>
+
+Override keys are beta header **prefixes** (e.g. `"redact-thinking-"`), not full header values. This ensures overrides apply regardless of date-versioned header bumps. See the full support matrix in the [Anthropic provider docs](/providers/supported-providers/anthropic#beta-headers).
+
 ### Setting Up a Proxy
 
 Route requests through proxies for compliance, security, or geographic requirements. This example shows both HTTP proxy for OpenAI and authenticated SOCKS5 proxy for Anthropic, useful for corporate environments or regional access.

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -239,6 +239,8 @@ bifrost:
     #     retry_backoff_max_ms: 5000                    # Max retry backoff in ms
     #     stream_idle_timeout_in_seconds: 60            # Max wait for next stream chunk (default: 60)
     #     max_conns_per_host: 5000                      # Max TCP connections per host (default: 5000)
+    #     beta_header_overrides:                         # Override Anthropic beta header support (optional)
+    #       redact-thinking-: true                       # Enable/disable specific beta headers by prefix
     #   # Concurrency configuration (optional)
     #   concurrency_and_buffer_size:
     #     concurrency: 100                              # Number of concurrent requests

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -172,7 +172,7 @@ var passthroughSafeHeaders = map[string]bool{
 
 func hasPromptCachingScopeBetaHeader(headers map[string][]string) bool {
 	for k, v := range headers {
-		if strings.ToLower(k) == "anthropic-beta" {
+		if strings.ToLower(k) == anthropic.AnthropicBetaHeader {
 			for _, headerValue := range v {
 				if strings.Contains(headerValue, anthropic.AnthropicPromptCachingScopeBetaHeader) {
 					return true
@@ -185,7 +185,7 @@ func hasPromptCachingScopeBetaHeader(headers map[string][]string) bool {
 
 func hasFastModeBetaHeader(headers map[string][]string) bool {
 	for k, v := range headers {
-		if strings.ToLower(k) != "anthropic-beta" {
+		if strings.ToLower(k) != anthropic.AnthropicBetaHeader {
 			continue
 		}
 		for _, headerValue := range v {
@@ -206,7 +206,7 @@ func filterVertexUnsupportedBetaHeaders(headers map[string][]string) map[string]
 	var betaHeaders []string
 	var found bool
 	for k, v := range headers {
-		if strings.ToLower(k) == "anthropic-beta" {
+		if strings.ToLower(k) == anthropic.AnthropicBetaHeader {
 			betaHeaderKey = k
 			betaHeaders = v
 			found = true
@@ -231,7 +231,8 @@ func filterVertexUnsupportedBetaHeaders(headers map[string][]string) map[string]
 					strings.HasPrefix(beta, anthropic.AnthropicPromptCachingScopeBetaHeaderPrefix) ||
 					strings.HasPrefix(beta, anthropic.AnthropicMCPClientBetaHeaderPrefix) ||
 					strings.HasPrefix(beta, anthropic.AnthropicSkillsBetaHeaderPrefix) ||
-					strings.HasPrefix(beta, anthropic.AnthropicFastModeBetaHeaderPrefix) {
+					strings.HasPrefix(beta, anthropic.AnthropicFastModeBetaHeaderPrefix) ||
+					strings.HasPrefix(beta, anthropic.AnthropicRedactThinkingBetaHeaderPrefix) {
 					continue
 				}
 				filteredBetas = append(filteredBetas, beta)
@@ -253,12 +254,8 @@ func extractPassthroughHeaders(allHeaders map[string][]string, provider schemas.
 	filtered := make(map[string][]string)
 	for k, v := range allHeaders {
 		if passthroughSafeHeaders[strings.ToLower(k)] {
-			filtered[k] = v
+			filtered[strings.ToLower(k)] = v
 		}
-	}
-
-	if provider == schemas.Vertex {
-		filtered = filterVertexUnsupportedBetaHeaders(filtered)
 	}
 
 	return filtered

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2056,6 +2056,13 @@
           "minimum": 1,
           "maximum": 10000,
           "description": "Maximum number of TCP connections per provider host. For HTTP/2 (e.g. Bedrock), each connection supports ~100 concurrent streams. Default: 5000."
+        },
+        "beta_header_overrides": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Override default Anthropic beta header support per provider. Keys are header prefixes (e.g. 'redact-thinking-'), values are true (supported) or false (unsupported). Headers not listed use the built-in defaults."
         }
       },
       "additionalProperties": false

--- a/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
@@ -4,7 +4,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ModelProvider } from "@/lib/types/config";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useEffect, useMemo, useState } from "react";
-import { ApiStructureFormFragment, GovernanceFormFragment, OpenAIConfigFormFragment, ProxyFormFragment } from "../fragments";
+import { ApiStructureFormFragment, BetaHeadersFormFragment, GovernanceFormFragment, OpenAIConfigFormFragment, ProxyFormFragment } from "../fragments";
 import { DebuggingFormFragment } from "../fragments/debuggingFormFragment";
 import { NetworkFormFragment } from "../fragments/networkFormFragment";
 import { PerformanceFormFragment } from "../fragments/performanceFormFragment";
@@ -15,7 +15,9 @@ interface Props {
 	provider: ModelProvider;
 }
 
-const availableTabs = (hasCustomProviderConfig: boolean, hasGovernanceAccess: boolean, isOpenAI: boolean) => {
+const ANTHROPIC_FAMILY_PROVIDERS = ["anthropic", "vertex", "bedrock", "azure"];
+
+const availableTabs = (hasCustomProviderConfig: boolean, hasGovernanceAccess: boolean, isOpenAI: boolean, isAnthropicFamily: boolean) => {
 	const tabs = [];
 	if (hasCustomProviderConfig) {
 		tabs.push({
@@ -41,6 +43,12 @@ const availableTabs = (hasCustomProviderConfig: boolean, hasGovernanceAccess: bo
 			label: "Governance",
 		});
 	}
+	if (isAnthropicFamily) {
+		tabs.push({
+			id: "beta-headers",
+			label: "Beta Headers",
+		});
+	}
 	tabs.push({
 		id: "debugging",
 		label: "Debugging",
@@ -59,10 +67,11 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 	const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
 	const hasCustomProviderConfig = !!provider.custom_provider_config;
 	const isOpenAI = provider.name === "openai";
+	const isAnthropicFamily = ANTHROPIC_FAMILY_PROVIDERS.includes(provider.name.toLowerCase());
 
 	const tabs = useMemo(() => {
-		return availableTabs(hasCustomProviderConfig, hasGovernanceAccess, isOpenAI);
-	}, [hasCustomProviderConfig, hasGovernanceAccess, isOpenAI]);
+		return availableTabs(hasCustomProviderConfig, hasGovernanceAccess, isOpenAI, isAnthropicFamily);
+	}, [hasCustomProviderConfig, hasGovernanceAccess, isOpenAI, isAnthropicFamily]);
 
 	useEffect(() => {
 		setSelectedTab((previousTab) => {
@@ -125,6 +134,9 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 						</TabsContent>
 						<TabsContent value="governance">
 							<GovernanceFormFragment provider={provider} />
+						</TabsContent>
+						<TabsContent value="beta-headers">
+							<BetaHeadersFormFragment provider={provider} />
 						</TabsContent>
 						<TabsContent value="debugging">
 							<DebuggingFormFragment provider={provider} />

--- a/ui/app/workspace/providers/fragments/betaHeadersFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/betaHeadersFormFragment.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Form } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
+import { useUpdateProviderMutation } from "@/lib/store/apis/providersApi";
+import { ModelProvider, NetworkConfig } from "@/lib/types/config";
+import { betaHeadersFormSchema, type BetaHeadersFormSchema } from "@/lib/types/schemas";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Plus, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useForm, type Resolver } from "react-hook-form";
+import { toast } from "sonner";
+
+// Known beta headers with their prefixes, descriptions, and default support per provider.
+// This mirrors the Go ProviderFeatures map in core/providers/anthropic/types.go.
+const KNOWN_BETA_HEADERS = [
+	{ prefix: "computer-use-", label: "Computer Use", description: "Computer use client tool", defaults: { anthropic: true, vertex: true, bedrock: true, azure: true } },
+	{ prefix: "structured-outputs-", label: "Structured Outputs", description: "Strict tool validation and output_format", defaults: { anthropic: true, vertex: false, bedrock: true, azure: true } },
+	{ prefix: "advanced-tool-use-", label: "Advanced Tool Use", description: "defer_loading, input_examples, allowed_callers", defaults: { anthropic: true, vertex: false, bedrock: false, azure: true } },
+	{ prefix: "mcp-client-", label: "MCP Client", description: "MCP connector support", defaults: { anthropic: true, vertex: false, bedrock: false, azure: true } },
+	{ prefix: "prompt-caching-scope-", label: "Prompt Caching Scope", description: "Prompt caching scope control", defaults: { anthropic: true, vertex: false, bedrock: false, azure: true } },
+	{ prefix: "compact-", label: "Compaction", description: "Server-side context compaction", defaults: { anthropic: true, vertex: true, bedrock: true, azure: true } },
+	{ prefix: "context-management-", label: "Context Management", description: "Context editing (clear_tool_uses, clear_thinking)", defaults: { anthropic: true, vertex: true, bedrock: true, azure: true } },
+	{ prefix: "files-api-", label: "Files API", description: "Files API support", defaults: { anthropic: true, vertex: false, bedrock: false, azure: true } },
+	{ prefix: "interleaved-thinking-", label: "Interleaved Thinking", description: "Interleaved thinking between tool calls", defaults: { anthropic: true, vertex: true, bedrock: true, azure: true } },
+	{ prefix: "skills-", label: "Skills", description: "Agent Skills", defaults: { anthropic: true, vertex: false, bedrock: false, azure: true } },
+	{ prefix: "context-1m-", label: "Context 1M", description: "1M context window (beta for Sonnet 4.5/4)", defaults: { anthropic: true, vertex: true, bedrock: true, azure: true } },
+	{ prefix: "fast-mode-", label: "Fast Mode", description: "Fast mode (Opus 4.6 research preview)", defaults: { anthropic: true, vertex: false, bedrock: false, azure: false } },
+	{ prefix: "redact-thinking-", label: "Redact Thinking", description: "Redact thinking blocks in responses", defaults: { anthropic: true, vertex: false, bedrock: false, azure: true } },
+] as const;
+
+const KNOWN_PREFIXES = new Set<string>(KNOWN_BETA_HEADERS.map((h) => h.prefix));
+
+type ProviderKey = "anthropic" | "vertex" | "bedrock" | "azure";
+
+const ANTHROPIC_FAMILY_PROVIDERS: ProviderKey[] = ["anthropic", "vertex", "bedrock", "azure"];
+
+function getProviderKey(providerName: string): ProviderKey | null {
+	const name = providerName.toLowerCase();
+	if (ANTHROPIC_FAMILY_PROVIDERS.includes(name as ProviderKey)) {
+		return name as ProviderKey;
+	}
+	return null;
+}
+
+interface BetaHeadersFormFragmentProps {
+	provider: ModelProvider;
+}
+
+export function BetaHeadersFormFragment({ provider }: BetaHeadersFormFragmentProps) {
+	const dispatch = useAppDispatch();
+	const hasUpdateProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
+	const [updateProvider, { isLoading: isUpdatingProvider }] = useUpdateProviderMutation();
+	const providerKey = getProviderKey(provider.name);
+	const [newPrefix, setNewPrefix] = useState("");
+	const [newPrefixError, setNewPrefixError] = useState<string | null>(null);
+
+	const form = useForm<BetaHeadersFormSchema, any, BetaHeadersFormSchema>({
+		resolver: zodResolver(betaHeadersFormSchema) as Resolver<BetaHeadersFormSchema, any, BetaHeadersFormSchema>,
+		mode: "onChange",
+		reValidateMode: "onChange",
+		defaultValues: {
+			beta_header_overrides: provider.network_config?.beta_header_overrides ?? {},
+		},
+	});
+
+	useEffect(() => {
+		form.reset({
+			beta_header_overrides: provider.network_config?.beta_header_overrides ?? {},
+		});
+	}, [form, provider.name, provider.network_config?.beta_header_overrides]);
+
+	const overrides = form.watch("beta_header_overrides") ?? {};
+
+	// Manual dirty tracking — RHF's deep equality on records is unreliable with setValue
+	const savedOverrides = provider.network_config?.beta_header_overrides ?? {};
+	const isManuallyDirty = useMemo(() => {
+		const currentKeys = Object.keys(overrides);
+		const savedKeys = Object.keys(savedOverrides);
+		if (currentKeys.length !== savedKeys.length) return true;
+		return currentKeys.some((key) => overrides[key] !== savedOverrides[key]);
+	}, [overrides, savedOverrides]);
+
+	useEffect(() => {
+		dispatch(setProviderFormDirtyState(isManuallyDirty));
+	}, [isManuallyDirty, dispatch]);
+
+	// Custom prefixes are overrides that don't match any known prefix
+	const customPrefixes = useMemo(() => {
+		return Object.keys(overrides).filter((prefix) => !KNOWN_PREFIXES.has(prefix));
+	}, [overrides]);
+
+	const headerRows = useMemo(() => {
+		if (!providerKey) return [];
+		return KNOWN_BETA_HEADERS.map((header) => {
+			const defaultSupported = header.defaults[providerKey];
+			const override = overrides[header.prefix];
+			return { ...header, defaultSupported, override };
+		});
+	}, [providerKey, overrides]);
+
+	const onSubmit = (data: BetaHeadersFormSchema) => {
+		const cleanedOverrides: Record<string, boolean> = {};
+		if (data.beta_header_overrides) {
+			for (const [prefix, value] of Object.entries(data.beta_header_overrides)) {
+				cleanedOverrides[prefix] = value;
+			}
+		}
+
+		const updatedProvider: ModelProvider = {
+			...provider,
+			network_config: {
+				...(provider.network_config ?? {} as NetworkConfig),
+				beta_header_overrides: Object.keys(cleanedOverrides).length > 0 ? cleanedOverrides : undefined,
+			},
+		};
+		updateProvider(updatedProvider)
+			.unwrap()
+			.then(() => {
+				toast.success("Beta header configuration updated successfully");
+				form.reset(data);
+			})
+			.catch((err) => {
+				toast.error("Failed to update beta header configuration", {
+					description: getErrorMessage(err),
+				});
+			});
+	};
+
+	const setOverride = useCallback(
+		(prefix: string, value: "default" | "enabled" | "disabled") => {
+			const current = form.getValues("beta_header_overrides") ?? {};
+			const updated = { ...current };
+			if (value === "default") {
+				delete updated[prefix];
+			} else {
+				updated[prefix] = value === "enabled";
+			}
+			form.setValue("beta_header_overrides", updated, { shouldDirty: true });
+		},
+		[form],
+	);
+
+	const removeCustomPrefix = useCallback(
+		(prefix: string) => {
+			const current = form.getValues("beta_header_overrides") ?? {};
+			const updated = { ...current };
+			delete updated[prefix];
+			form.setValue("beta_header_overrides", updated, { shouldDirty: true });
+		},
+		[form],
+	);
+
+	const addCustomPrefix = useCallback(() => {
+		let prefix = newPrefix.trim().toLowerCase();
+		if (!prefix) return;
+
+		// Ensure prefix ends with "-"
+		if (!prefix.endsWith("-")) {
+			prefix = prefix + "-";
+		}
+
+		// Validate
+		if (KNOWN_PREFIXES.has(prefix)) {
+			setNewPrefixError("This is a known header — use the override dropdown above instead");
+			return;
+		}
+		if (overrides[prefix] !== undefined) {
+			setNewPrefixError("This prefix already exists");
+			return;
+		}
+		if (!/^[a-z0-9-]+$/.test(prefix)) {
+			setNewPrefixError("Prefix must contain only lowercase letters, numbers, and hyphens");
+			return;
+		}
+
+		const current = form.getValues("beta_header_overrides") ?? {};
+		form.setValue("beta_header_overrides", { ...current, [prefix]: true }, { shouldDirty: true });
+		setNewPrefix("");
+		setNewPrefixError(null);
+	}, [newPrefix, overrides, form]);
+
+	const getSelectValue = (prefix: string): string => {
+		const override = overrides[prefix];
+		if (override === undefined) return "default";
+		return override ? "enabled" : "disabled";
+	};
+
+	if (!providerKey) return null;
+
+	return (
+		<Form {...form}>
+			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6" data-testid="provider-config-beta-headers-content">
+				<div className="space-y-2">
+					<p className="text-muted-foreground text-xs">
+						Configure which Anthropic beta headers are allowed for this provider. Override the defaults when a provider adds or removes support for a beta feature.
+					</p>
+					<div className="rounded-md border">
+						<table className="w-full text-sm">
+							<thead>
+								<tr className="border-b">
+									<th className="px-3 py-2 text-left font-medium">Beta Header</th>
+									<th className="px-3 py-2 text-left font-medium">Default</th>
+									<th className="w-[180px] px-3 py-2 text-left font-medium">Override</th>
+								</tr>
+							</thead>
+							<tbody>
+								{headerRows.map((row) => (
+									<tr key={row.prefix} className="border-b last:border-b-0">
+										<td className="px-3 py-2">
+											<div className="flex flex-col gap-0.5">
+												<span className="font-mono text-xs">{row.prefix}*</span>
+												<span className="text-muted-foreground text-xs">{row.description}</span>
+											</div>
+										</td>
+										<td className="px-3 py-2">
+											<Badge variant={row.defaultSupported ? "default" : "secondary"} className="text-xs">
+												{row.defaultSupported ? "Supported" : "Unsupported"}
+											</Badge>
+										</td>
+										<td className="w-[180px] px-3 py-2">
+											<Select
+												value={getSelectValue(row.prefix)}
+												onValueChange={(val) => setOverride(row.prefix, val as "default" | "enabled" | "disabled")}
+												disabled={!hasUpdateProviderAccess}
+											>
+												<SelectTrigger className="h-8 text-xs" data-testid={`provider-beta-override-select-${row.prefix.replace(/-/g, "")}`}>
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="default">Default</SelectItem>
+													<SelectItem value="enabled">Supported</SelectItem>
+													<SelectItem value="disabled">Unsupported</SelectItem>
+												</SelectContent>
+											</Select>
+										</td>
+									</tr>
+								))}
+								{customPrefixes.map((prefix) => (
+									<tr key={prefix} className="border-b last:border-b-0">
+										<td className="px-3 py-2">
+											<div className="flex flex-col gap-0.5">
+												<span className="font-mono text-xs">{prefix}*</span>
+												<span className="text-muted-foreground text-xs">Custom header</span>
+											</div>
+										</td>
+										<td className="px-3 py-2">
+											<Badge variant="outline" className="text-xs">
+												Custom
+											</Badge>
+										</td>
+										<td className="w-[180px] px-3 py-2">
+											<div className="flex items-center gap-1">
+												<Select
+													value={overrides[prefix] ? "enabled" : "disabled"}
+													onValueChange={(val) => setOverride(prefix, val as "enabled" | "disabled")}
+													disabled={!hasUpdateProviderAccess}
+												>
+													<SelectTrigger className="h-8 text-xs" data-testid={`provider-beta-custom-override-select-${prefix.replace(/-/g, "")}`}>
+														<SelectValue />
+													</SelectTrigger>
+													<SelectContent>
+														<SelectItem value="enabled">Supported</SelectItem>
+														<SelectItem value="disabled">Unsupported</SelectItem>
+													</SelectContent>
+												</Select>
+												<Button
+													type="button"
+													variant="ghost"
+													size="icon"
+													className="h-8 w-8 shrink-0"
+													disabled={!hasUpdateProviderAccess}
+													onClick={() => removeCustomPrefix(prefix)}
+													data-testid={`provider-beta-remove-prefix-btn-${prefix.replace(/-/g, "")}`}
+													aria-label={`Remove custom prefix ${prefix}`}
+												>
+													<Trash2 className="h-3.5 w-3.5" />
+												</Button>
+											</div>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+
+					<div className="flex items-start gap-2 pt-2">
+						<div className="flex-1">
+							<Input
+								placeholder="Add custom beta header prefix (e.g. new-feature-)"
+								value={newPrefix}
+								onChange={(e) => {
+									setNewPrefix(e.target.value);
+									setNewPrefixError(null);
+								}}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") {
+										e.preventDefault();
+										addCustomPrefix();
+									}
+								}}
+								disabled={!hasUpdateProviderAccess}
+								className="h-8 text-xs"
+								data-testid="provider-beta-custom-prefix-input"
+								aria-label="Custom beta header prefix"
+								aria-describedby={newPrefixError ? "custom-prefix-error" : undefined}
+							/>
+							{newPrefixError && <p className="text-destructive mt-1 text-xs" id="custom-prefix-error">{newPrefixError}</p>}
+						</div>
+						<Button 
+							type="button" 
+							variant="outline" 
+							size="sm" 
+							className="h-8" 
+							disabled={!hasUpdateProviderAccess || !newPrefix.trim()} 
+							onClick={addCustomPrefix}
+							data-testid="provider-beta-add-prefix-btn"
+						>
+							<Plus className="mr-1 h-3.5 w-3.5" />
+							Add
+						</Button>
+					</div>
+				</div>
+
+				<div className="flex justify-end space-x-2 pb-6">
+					<Button
+						type="submit"
+						disabled={!isManuallyDirty || !hasUpdateProviderAccess || isUpdatingProvider}
+						isLoading={isUpdatingProvider}
+						data-testid="provider-beta-save-btn"
+					>
+						Save Beta Header Configuration
+					</Button>
+				</div>
+			</form>
+		</Form>
+	);
+}

--- a/ui/app/workspace/providers/fragments/index.ts
+++ b/ui/app/workspace/providers/fragments/index.ts
@@ -1,4 +1,5 @@
 export { AllowedRequestsFields } from "./allowedRequestsFields";
+export { BetaHeadersFormFragment } from "./betaHeadersFormFragment";
 export { ApiKeyFormFragment } from "./apiKeysFormFragment";
 export { ApiStructureFormFragment } from "./apiStructureFormFragment";
 export { DebuggingFormFragment } from "./debuggingFormFragment";

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -161,6 +161,7 @@ export interface NetworkConfig {
 	stream_idle_timeout_in_seconds?: number;
 	max_conns_per_host?: number;
 	enforce_http2?: boolean;
+	beta_header_overrides?: Record<string, boolean>;
 }
 
 // ConcurrencyAndBufferSize matching Go's schemas.ConcurrencyAndBufferSize

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -691,6 +691,13 @@ export const debuggingFormSchema = z.object({
 
 export type DebuggingFormSchema = z.infer<typeof debuggingFormSchema>;
 
+// Beta Headers tab
+export const betaHeadersFormSchema = z.object({
+	beta_header_overrides: z.record(z.string(), z.boolean()).optional(),
+});
+
+export type BetaHeadersFormSchema = z.infer<typeof betaHeadersFormSchema>;
+
 // OpenAI Config tab
 export const openaiConfigFormSchema = z.object({
 	disable_store: z.boolean(),


### PR DESCRIPTION
## Summary

Adds support for the `redact-thinking-2026-02-12` beta header across Anthropic-family providers, enabling redaction of thinking blocks in model responses. This PR also introduces a beta header override system that allows administrators to customize which beta headers are supported per provider via configuration.

## Changes

- Added `AnthropicRedactThinkingBetaHeader` constant and related prefix for the new beta header
- Updated provider feature support matrices to include `RedactThinking` capability
- Refactored beta header filtering logic to use a map-based approach for better maintainability
- Implemented beta header override system allowing per-provider customization via `beta_header_overrides` configuration
- Added comprehensive UI for managing beta header overrides in the provider configuration interface
- Updated documentation to reflect new beta header support and override capabilities
- Enhanced filtering logic to drop unknown headers for non-Anthropic providers while forwarding them to Anthropic for forward compatibility

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

Test the new beta header support and override functionality:

```sh
# Core/Transports
go version
go test ./...

# Test beta header filtering
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "anthropic-beta: redact-thinking-2026-02-12" \
  -d '{"model": "claude-3-5-sonnet-20241022", "messages": [{"role": "user", "content": "Hello"}]}'

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

To test beta header overrides, configure a provider with custom `beta_header_overrides` in the network configuration:

```json
{
  "providers": {
    "vertex": {
      "network_config": {
        "beta_header_overrides": {
          "redact-thinking-": true
        }
      }
    }
  }
}
```

## Screenshots/Recordings

The UI now includes a "Beta Headers" tab for Anthropic-family providers showing default support status and override controls for each known beta header, plus the ability to add custom header prefixes.

## Breaking changes

- [ ] Yes
- [x] No

This is a backward-compatible addition. Existing configurations continue to work unchanged.

## Related issues

Enables support for thinking block redaction functionality in Anthropic models across all supported providers.

## Security considerations

Beta header overrides are controlled by RBAC permissions and only affect which headers are forwarded to upstream providers. No security implications as this doesn't change authentication or data handling.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable