### PR TITLE
user level oauth for mcp gateway

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5,6 +5,7 @@ package bifrost
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"slices"
@@ -3589,6 +3590,43 @@ func (bifrost *Bifrost) ReconnectMCPClient(id string) error {
 	return bifrost.MCPManager.ReconnectClient(id)
 }
 
+// VerifyPerUserOAuthConnection delegates to the MCP manager to verify an MCP
+// server using a temporary access token and discover available tools. The
+// connection is closed after verification. If the MCP manager is not yet
+// initialized, it is lazily created (same as AddMCPClient).
+func (bifrost *Bifrost) VerifyPerUserOAuthConnection(ctx context.Context, config *schemas.MCPClientConfig, accessToken string) (map[string]schemas.ChatTool, map[string]string, error) {
+	// Ensure MCP manager is initialized (lazy init, same pattern as AddMCPClient)
+	if bifrost.MCPManager == nil {
+		bifrost.mcpInitOnce.Do(func() {
+			mcpConfig := schemas.MCPConfig{
+				ClientConfigs: []*schemas.MCPClientConfig{},
+			}
+			mcpConfig.PluginPipelineProvider = func() interface{} {
+				return bifrost.getPluginPipeline()
+			}
+			mcpConfig.ReleasePluginPipeline = func(pipeline interface{}) {
+				if pp, ok := pipeline.(*PluginPipeline); ok {
+					bifrost.releasePluginPipeline(pp)
+				}
+			}
+			codeMode := starlark.NewStarlarkCodeMode(nil, bifrost.logger)
+			bifrost.MCPManager = mcp.NewMCPManager(bifrost.ctx, mcpConfig, bifrost.oauth2Provider, bifrost.logger, codeMode)
+		})
+	}
+	if bifrost.MCPManager == nil {
+		return nil, nil, fmt.Errorf("MCP manager is not initialized")
+	}
+	return bifrost.MCPManager.VerifyPerUserOAuthConnection(ctx, config, accessToken)
+}
+
+// SetClientTools delegates to the MCP manager to update the tool map for an
+// existing MCP client.
+func (bifrost *Bifrost) SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+	if bifrost.MCPManager != nil {
+		bifrost.MCPManager.SetClientTools(clientID, tools, toolNameMapping)
+	}
+}
+
 // UpdateToolManagerConfig updates the tool manager config for the MCP manager.
 // This allows for hot-reloading of the tool manager config at runtime.
 // Pass the current value of disableAutoToolInject whenever only other fields
@@ -5494,6 +5532,11 @@ func (bifrost *Bifrost) handleMCPToolExecution(ctx *schemas.BifrostContext, mcpR
 				RequestType: requestType,
 			},
 		}
+		// Preserve MCPUserOAuthRequiredError for downstream detection in agent mode
+		var oauthErr *schemas.MCPUserOAuthRequiredError
+		if errors.As(err, &oauthErr) {
+			bifrostErr.ExtraFields.MCPAuthRequired = oauthErr
+		}
 	} else if result == nil {
 		bifrostErr = &schemas.BifrostError{
 			IsBifrostError: false,
@@ -5547,6 +5590,9 @@ func (bifrost *Bifrost) executeMCPToolWithHooks(ctx *schemas.BifrostContext, req
 
 	resp, bifrostErr := bifrost.handleMCPToolExecution(ctx, request, requestType)
 	if bifrostErr != nil {
+		if bifrostErr.ExtraFields.MCPAuthRequired != nil {
+			return nil, bifrostErr.ExtraFields.MCPAuthRequired
+		}
 		return nil, fmt.Errorf("%s", GetErrorMessage(bifrostErr))
 	}
 	return resp, nil

--- a/core/mcp/agent.go
+++ b/core/mcp/agent.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -284,6 +285,8 @@ func (a *AgentModeExecutor) executeAgent(
 			wg := sync.WaitGroup{}
 			wg.Add(len(autoExecutableTools))
 			channelToolResults := make(chan *schemas.ChatMessage, len(autoExecutableTools))
+			var authRequiredErr *schemas.MCPUserOAuthRequiredError
+			var authRequiredOnce sync.Once
 			for _, toolCall := range autoExecutableTools {
 				go func(toolCall schemas.ChatAssistantMessageToolCall) {
 					defer wg.Done()
@@ -295,6 +298,15 @@ func (a *AgentModeExecutor) executeAgent(
 
 					mcpResponse, toolErr := executeToolFunc(ctx, mcpRequest)
 					if toolErr != nil {
+						// Check if this is a per-user OAuth auth-required error
+						var oauthErr *schemas.MCPUserOAuthRequiredError
+						if errors.As(toolErr, &oauthErr) {
+							authRequiredOnce.Do(func() {
+								authRequiredErr = oauthErr
+							})
+							channelToolResults <- createToolResultMessage(toolCall, "", toolErr)
+							return
+						}
 						a.logger.Warn("Tool execution failed: %v", toolErr)
 						channelToolResults <- createToolResultMessage(toolCall, "", toolErr)
 					} else if mcpResponse != nil && mcpResponse.ChatMessage != nil {
@@ -310,6 +322,23 @@ func (a *AgentModeExecutor) executeAgent(
 			}
 			wg.Wait()
 			close(channelToolResults)
+
+			// If any tool required per-user OAuth, stop the agent loop and return the error
+			if authRequiredErr != nil {
+				statusCode := 401
+				errType := "mcp_auth_required"
+				return nil, &schemas.BifrostError{
+					IsBifrostError: true,
+					StatusCode:     &statusCode,
+					Error: &schemas.ErrorField{
+						Message: authRequiredErr.Message,
+						Type:    &errType,
+					},
+					ExtraFields: schemas.BifrostErrorExtraFields{
+						MCPAuthRequired: authRequiredErr,
+					},
+				}
+			}
 
 			// Collect tool results
 			executedToolResults = make([]*schemas.ChatMessage, 0, len(autoExecutableTools))

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -118,6 +118,33 @@ func (m *MCPManager) AddClient(config *schemas.MCPClientConfig) error {
 	// This is to avoid deadlocks when the connection attempt is made
 	m.mu.Unlock()
 
+	// Per-user OAuth: skip persistent connection. Auth is per-request at runtime.
+	// The admin verifies the configuration via a sample login before this is called,
+	// and tools are populated separately via SetClientTools().
+	if configCopy.AuthType == schemas.MCPAuthTypePerUserOauth {
+		m.mu.Lock()
+		if client, exists := m.clientMap[config.ID]; exists {
+			if config.ConnectionString != nil {
+				url := config.ConnectionString.GetValue()
+				client.ConnectionInfo.ConnectionURL = &url
+			}
+			// Restore discovered tools from config (persisted in DB across restarts)
+			if len(config.DiscoveredTools) > 0 {
+				for toolName, tool := range config.DiscoveredTools {
+					client.ToolMap[toolName] = tool
+				}
+				client.ToolNameMapping = config.DiscoveredToolNameMapping
+				client.State = schemas.MCPConnectionStateConnected
+				m.logger.Info("%s Per-user OAuth MCP client '%s' restored with %d tools", MCPLogPrefix, config.Name, len(config.DiscoveredTools))
+			} else {
+				client.State = schemas.MCPConnectionStatePendingTools
+				m.logger.Info("%s Per-user OAuth MCP client '%s' registered (connection deferred to runtime)", MCPLogPrefix, config.Name)
+			}
+		}
+		m.mu.Unlock()
+		return nil
+	}
+
 	// Connect using the copied config
 	if err := m.connectToMCPClient(configCopy); err != nil {
 		// Clean up the failed entry — this is a user-initiated action (UI/API),
@@ -129,6 +156,92 @@ func (m *MCPManager) AddClient(config *schemas.MCPClientConfig) error {
 	}
 
 	return nil
+}
+
+// VerifyPerUserOAuthConnection creates a temporary MCP connection using the
+// provided access token to verify the server is reachable and discover available
+// tools. The connection is closed after verification. This is used during
+// per-user OAuth client setup when the admin does a test login to validate the
+// OAuth configuration before saving the MCP client.
+//
+// Parameters:
+//   - config: MCP client configuration (connection URL, name, etc.)
+//   - accessToken: temporary OAuth access token from the admin's test login
+//
+// Returns:
+//   - map[string]schemas.ChatTool: discovered tools keyed by prefixed name
+//   - map[string]string: tool name mapping (sanitized → original MCP name)
+//   - error: any error during verification
+func (m *MCPManager) VerifyPerUserOAuthConnection(ctx context.Context, config *schemas.MCPClientConfig, accessToken string) (map[string]schemas.ChatTool, map[string]string, error) {
+	if config.ConnectionString == nil || config.ConnectionString.GetValue() == "" {
+		return nil, nil, fmt.Errorf("connection URL is required for per-user OAuth verification")
+	}
+
+	// Create HTTP transport with the admin's temporary Bearer token
+	headers := map[string]string{
+		"Authorization": "Bearer " + accessToken,
+	}
+	httpTransport, err := transport.NewStreamableHTTP(config.ConnectionString.GetValue(), transport.WithHTTPHeaders(headers))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create HTTP transport for verification: %w", err)
+	}
+
+	// Create temporary MCP client
+	tempClient := client.NewClient(httpTransport)
+	ctx, cancel := context.WithTimeout(ctx, MCPClientConnectionEstablishTimeout)
+	defer cancel()
+
+	// Start transport
+	if err := tempClient.Start(ctx); err != nil {
+		return nil, nil, fmt.Errorf("failed to start MCP connection for verification: %w", err)
+	}
+	defer tempClient.Close()
+
+	// Initialize MCP handshake
+	initRequest := mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			Capabilities:    mcp.ClientCapabilities{},
+			ClientInfo: mcp.Implementation{
+				Name:    fmt.Sprintf("Bifrost-%s-verify", config.Name),
+				Version: "1.0.0",
+			},
+		},
+	}
+	if _, err := tempClient.Initialize(ctx, initRequest); err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize MCP connection for verification: %w", err)
+	}
+
+	// Discover tools
+	tools, toolNameMapping, err := retrieveExternalTools(ctx, tempClient, config.Name, m.logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to discover tools during verification: %w", err)
+	}
+
+	m.logger.Info("%s Per-user OAuth verification succeeded for '%s': discovered %d tools", MCPLogPrefix, config.Name, len(tools))
+	return tools, toolNameMapping, nil
+}
+
+// SetClientTools updates the tool map and name mapping for an existing client.
+// This is used to populate tools discovered during per-user OAuth verification,
+// where tool discovery happens separately from client creation.
+//
+// Parameters:
+//   - clientID: ID of the client to update
+//   - tools: discovered tools keyed by prefixed name
+//   - toolNameMapping: mapping from sanitized tool names to original MCP names
+func (m *MCPManager) SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if client, exists := m.clientMap[clientID]; exists {
+		for toolName, tool := range tools {
+			client.ToolMap[toolName] = tool
+		}
+		client.ToolNameMapping = toolNameMapping
+		client.State = schemas.MCPConnectionStateConnected
+		m.logger.Debug("%s Set %d tools on client '%s'", MCPLogPrefix, len(tools), client.Name)
+	}
 }
 
 // RemoveClient removes an MCP client from the manager.

--- a/core/mcp/interface.go
+++ b/core/mcp/interface.go
@@ -3,6 +3,8 @@
 package mcp
 
 import (
+	"context"
+
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -59,6 +61,14 @@ type MCPManagerInterface interface {
 
 	// ReconnectClient reconnects an MCP client by ID
 	ReconnectClient(id string) error
+
+	// VerifyPerUserOAuthConnection creates a temporary MCP connection using a
+	// test access token to verify connectivity and discover tools. The connection
+	// is closed after verification.
+	VerifyPerUserOAuthConnection(ctx context.Context, config *schemas.MCPClientConfig, accessToken string) (map[string]schemas.ChatTool, map[string]string, error)
+
+	// SetClientTools updates the tool map and name mapping for an existing client.
+	SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string)
 
 	// Tool Registration
 	// RegisterTool registers a local tool with the MCP server

--- a/core/mcp/mcp.go
+++ b/core/mcp/mcp.go
@@ -103,7 +103,7 @@ func NewMCPManager(ctx context.Context, config schemas.MCPConfig, oauth2Provider
 		}
 	}
 
-	manager.toolsManager = NewToolsManager(config.ToolManagerConfig, manager, config.FetchNewRequestIDFunc, pluginPipelineProvider, releasePluginPipeline, logger)
+	manager.toolsManager = NewToolsManager(config.ToolManagerConfig, manager, config.FetchNewRequestIDFunc, pluginPipelineProvider, releasePluginPipeline, oauth2Provider, logger)
 
 	// Set up CodeMode if provided - inject dependencies after manager is created
 	if codeMode != nil {

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -6,10 +6,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync/atomic"
 	"time"
 
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/maximhq/bifrost/core/mcp/utils"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -37,6 +40,9 @@ type ToolsManager struct {
 	clientManager         ClientManager
 	logger                schemas.Logger
 	agentModeExecutor     *AgentModeExecutor
+
+	// OAuth2Provider for per-user OAuth token management
+	oauth2Provider schemas.OAuth2Provider
 
 	// CodeMode implementation for code execution (Starlark by default)
 	codeMode CodeMode
@@ -74,6 +80,7 @@ func NewToolsManager(
 	fetchNewRequestIDFunc func(ctx *schemas.BifrostContext) string,
 	pluginPipelineProvider func() PluginPipeline,
 	releasePluginPipeline func(pipeline PluginPipeline),
+	oauth2Provider schemas.OAuth2Provider,
 	logger schemas.Logger,
 ) *ToolsManager {
 	return NewToolsManagerWithCodeMode(
@@ -83,6 +90,7 @@ func NewToolsManager(
 		pluginPipelineProvider,
 		releasePluginPipeline,
 		nil, // Use default code mode (will be set later via SetCodeMode)
+		oauth2Provider,
 		logger,
 	)
 }
@@ -107,6 +115,7 @@ func NewToolsManagerWithCodeMode(
 	pluginPipelineProvider func() PluginPipeline,
 	releasePluginPipeline func(pipeline PluginPipeline),
 	codeMode CodeMode,
+	oauth2Provider schemas.OAuth2Provider,
 	logger schemas.Logger,
 ) *ToolsManager {
 	if config == nil {
@@ -143,6 +152,7 @@ func NewToolsManagerWithCodeMode(
 		codeMode:               codeMode,
 		logger:                 logger,
 		agentModeExecutor:      agentModeExecutor,
+		oauth2Provider:         oauth2Provider,
 	}
 
 	// Initialize atomic values
@@ -568,6 +578,84 @@ func (m *ToolsManager) executeToolInternal(ctx *schemas.BifrostContext, toolCall
 		Header: utils.GetHeadersForToolExecution(ctx, client),
 	}
 
+	// Handle per-user OAuth: inject user-specific Authorization header
+	if client.ExecutionConfig.AuthType == schemas.MCPAuthTypePerUserOauth {
+		if m.oauth2Provider == nil {
+			return nil, "", "", fmt.Errorf("per-user OAuth requires an OAuth2Provider but none is configured")
+		}
+		virtualKeyID, _ := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID).(string)
+		userID, _ := ctx.Value(schemas.BifrostContextKeyGovernanceUserID).(string)
+		sessionToken, _ := ctx.Value(schemas.BifrostContextKeyMCPUserSession).(string)
+
+		// Optional X-Bf-User-Id header overrides user identity; if absent, falls back to virtual key
+		if mcpUserID, _ := ctx.Value(schemas.BifrostContextKeyMCPUserID).(string); mcpUserID != "" {
+			userID = mcpUserID
+		}
+
+		// Try identity-based token lookup first (works even without session token)
+		accessToken, err := m.oauth2Provider.GetUserAccessTokenByIdentity(ctx, virtualKeyID, userID, sessionToken, client.ExecutionConfig.ID)
+		if err != nil && sessionToken != "" {
+			// Had session but token lookup failed — return error
+			return nil, "", "", fmt.Errorf("failed to get user access token for MCP server %s: %w", client.ExecutionConfig.Name, err)
+		}
+		if err != nil {
+			// No session and no token by identity — user hasn't authenticated yet.
+			// Initiate OAuth flow to get a proper authorize URL with session tracking.
+			if client.ExecutionConfig.OauthConfigID == nil || *client.ExecutionConfig.OauthConfigID == "" {
+				return nil, "", "", fmt.Errorf("per-user OAuth requires an OAuth config but MCP client %s has none", client.ExecutionConfig.Name)
+			}
+			redirectURI := buildRedirectURIFromContext(ctx)
+			if redirectURI == "" {
+				return nil, "", "", fmt.Errorf("per-user OAuth requires a redirect URI but none is available in context")
+			}
+			flowInitiation, sessionID, flowErr := m.oauth2Provider.InitiateUserOAuthFlow(ctx, *client.ExecutionConfig.OauthConfigID, client.ExecutionConfig.ID, redirectURI)
+			if flowErr != nil {
+				return nil, "", "", fmt.Errorf("failed to initiate per-user OAuth flow for %s: %w", client.ExecutionConfig.Name, flowErr)
+			}
+			return nil, "", "", &schemas.MCPUserOAuthRequiredError{
+				MCPClientID:   client.ExecutionConfig.ID,
+				MCPClientName: client.ExecutionConfig.Name,
+				AuthorizeURL:  flowInitiation.AuthorizeURL,
+				SessionID:     sessionID,
+				Message:       fmt.Sprintf("Authentication required for %s. Please visit the authorize URL to connect your account.", client.ExecutionConfig.Name),
+			}
+		}
+
+		if client.Conn == nil {
+			// No persistent connection — create temporary connection with user's token
+			toolExecutionTimeout := m.toolExecutionTimeout.Load().(time.Duration)
+			toolCtx, cancel := context.WithTimeout(ctx, toolExecutionTimeout)
+			defer cancel()
+
+			toolResponse, callErr := executeToolWithUserToken(toolCtx, client.ExecutionConfig, originalMCPToolName, arguments, accessToken, m.logger)
+			if callErr != nil {
+				if toolCtx.Err() == context.DeadlineExceeded {
+					return nil, "", "", fmt.Errorf("MCP tool call timed out after %v: %s", toolExecutionTimeout, toolName)
+				}
+				m.logger.Error("%s Tool execution failed for %s via client %s: %v", MCPLogPrefix, toolName, client.ExecutionConfig.Name, callErr)
+				return nil, "", "", fmt.Errorf("MCP tool call failed: %v", callErr)
+			}
+			responseText := extractTextFromMCPResponse(toolResponse, toolName)
+			return createToolResponseMessage(*toolCall, responseText), client.ExecutionConfig.Name, sanitizedToolName, nil
+		}
+
+		// Persistent connection exists — use per-call headers
+		headers := make(http.Header)
+		if client.ExecutionConfig.Headers != nil {
+			for key, value := range client.ExecutionConfig.Headers {
+				headers.Add(key, value.GetValue())
+			}
+		}
+		headers.Set("Authorization", "Bearer "+accessToken)
+		callRequest.Header = headers
+	} else if client.ExecutionConfig.Headers != nil {
+		headers := make(http.Header)
+		for key, value := range client.ExecutionConfig.Headers {
+			headers.Add(key, value.GetValue())
+		}
+		callRequest.Header = headers
+	}
+
 	// Create timeout context for tool execution
 	toolExecutionTimeout := m.toolExecutionTimeout.Load().(time.Duration)
 	toolCtx, cancel := context.WithTimeout(ctx, toolExecutionTimeout)
@@ -688,6 +776,86 @@ func (m *ToolsManager) UpdateConfig(config *schemas.MCPToolManagerConfig) {
 	m.disableAutoToolInject.Store(config.DisableAutoToolInject)
 
 	m.logger.Info("%s tool manager configuration updated with tool execution timeout: %v, max agent depth: %d, and code mode binding level: %s", MCPLogPrefix, config.ToolExecutionTimeout, config.MaxAgentDepth, config.CodeModeBindingLevel)
+}
+
+// executeToolWithUserToken creates a temporary MCP connection using the user's
+// OAuth access token, calls the specified tool, and closes the connection.
+// This is used for per_user_oauth clients which have no persistent connection —
+// each tool call gets its own short-lived connection authenticated with the
+// requesting user's token.
+//
+// Parameters:
+//   - ctx: context with timeout for the entire operation
+//   - config: MCP client configuration (connection URL, name)
+//   - toolName: original MCP tool name to call
+//   - arguments: tool call arguments
+//   - accessToken: user's OAuth access token
+//   - logger: logger instance
+//
+// Returns:
+//   - *mcp.CallToolResult: tool execution result
+//   - error: any error during connection or execution
+func executeToolWithUserToken(ctx context.Context, config *schemas.MCPClientConfig, toolName string, arguments map[string]interface{}, accessToken string, logger schemas.Logger) (*mcp.CallToolResult, error) {
+	if config.ConnectionString == nil || config.ConnectionString.GetValue() == "" {
+		return nil, fmt.Errorf("connection URL is required for per-user OAuth tool execution")
+	}
+
+	// Create HTTP transport with the user's Bearer token, preserving configured headers
+	headers := make(map[string]string)
+	if config.Headers != nil {
+		for key, value := range config.Headers {
+			headers[key] = value.GetValue()
+		}
+	}
+	headers["Authorization"] = "Bearer " + accessToken
+	httpTransport, err := transport.NewStreamableHTTP(config.ConnectionString.GetValue(), transport.WithHTTPHeaders(headers))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP transport: %w", err)
+	}
+
+	// Create temporary MCP client
+	tempClient := client.NewClient(httpTransport)
+	if err := tempClient.Start(ctx); err != nil {
+		return nil, fmt.Errorf("failed to start temporary MCP connection: %w", err)
+	}
+	defer tempClient.Close()
+
+	// Initialize MCP handshake
+	initRequest := mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			Capabilities:    mcp.ClientCapabilities{},
+			ClientInfo: mcp.Implementation{
+				Name:    fmt.Sprintf("Bifrost-%s-user", config.Name),
+				Version: "1.0.0",
+			},
+		},
+	}
+	if _, err := tempClient.Initialize(ctx, initRequest); err != nil {
+		return nil, fmt.Errorf("failed to initialize temporary MCP connection: %w", err)
+	}
+
+	// Call the tool
+	callRequest := mcp.CallToolRequest{
+		Request: mcp.Request{
+			Method: string(mcp.MethodToolsCall),
+		},
+		Params: mcp.CallToolParams{
+			Name:      toolName,
+			Arguments: arguments,
+		},
+	}
+	return tempClient.CallTool(ctx, callRequest)
+}
+
+// buildRedirectURIFromContext extracts the OAuth redirect URI from context.
+// The URI is set by the HTTP middleware from the request's host.
+func buildRedirectURIFromContext(ctx *schemas.BifrostContext) string {
+	if uri, ok := ctx.Value(schemas.BifrostContextKeyOAuthRedirectURI).(string); ok && uri != "" {
+		return uri
+	}
+	// Fallback — should not happen if middleware is configured correctly
+	return ""
 }
 
 // GetCodeModeBindingLevel returns the current code mode binding level.

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -209,6 +209,9 @@ const (
 	BifrostContextKeyTraceCompleter                      BifrostContextKey = "bifrost-trace-completer"                          // func() (callback to complete trace after streaming - set by tracing middleware)
 	BifrostContextKeyPostHookSpanFinalizer               BifrostContextKey = "bifrost-posthook-span-finalizer"                  // func(context.Context) (callback to finalize post-hook spans after streaming - set by bifrost)
 	BifrostContextKeyAccumulatorID                       BifrostContextKey = "bifrost-accumulator-id"                           // string (ID for streaming accumulator lookup - set by tracer for accumulator operations)
+	BifrostContextKeyMCPUserSession                      BifrostContextKey = "bifrost-mcp-user-session"                         // string (per-user OAuth session token from X-Bifrost-MCP-Session header)
+	BifrostContextKeyMCPUserID                           BifrostContextKey = "bifrost-mcp-user-id"                              // string (per-user OAuth user identifier from X-Bf-User-Id header)
+	BifrostContextKeyOAuthRedirectURI                    BifrostContextKey = "bifrost-oauth-redirect-uri"                       // string (OAuth callback URL, e.g. https://host/api/oauth/callback - set by HTTP middleware)
 	BifrostContextKeyHasEmittedMessageDelta              BifrostContextKey = "bifrost-has-emitted-message-delta"                // bool (tracks whether message_delta was already emitted during streaming - avoids duplicates)
 	BifrostContextKeySkipDBUpdate                        BifrostContextKey = "bifrost-skip-db-update"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyGovernancePluginName                BifrostContextKey = "governance-plugin-name"                           // string (name of the governance plugin that processed the request - set by bifrost)
@@ -1203,12 +1206,13 @@ func (e *ErrorField) UnmarshalJSON(data []byte) error {
 
 // BifrostErrorExtraFields contains additional fields in an error response.
 type BifrostErrorExtraFields struct {
-	Provider               ModelProvider `json:"provider,omitempty"`
-	OriginalModelRequested string        `json:"original_model_requested,omitempty"`
-	ResolvedModelUsed      string        `json:"resolved_model_used,omitempty"`
-	RequestType            RequestType   `json:"request_type,omitempty"`
-	RawRequest             interface{}   `json:"raw_request,omitempty"`
-	RawResponse            interface{}   `json:"raw_response,omitempty"`
-	LiteLLMCompat          bool          `json:"litellm_compat,omitempty"`
-	KeyStatuses            []KeyStatus   `json:"key_statuses,omitempty"`
+	Provider               ModelProvider              `json:"provider,omitempty"`
+	OriginalModelRequested string                     `json:"original_model_requested,omitempty"`
+	ResolvedModelUsed      string                     `json:"resolved_model_used,omitempty"`
+	RequestType            RequestType                `json:"request_type,omitempty"`
+	RawRequest             interface{}                `json:"raw_request,omitempty"`
+	RawResponse            interface{}                `json:"raw_response,omitempty"`
+	LiteLLMCompat          bool                       `json:"litellm_compat,omitempty"`
+	KeyStatuses            []KeyStatus                `json:"key_statuses,omitempty"`
+	MCPAuthRequired        *MCPUserOAuthRequiredError `json:"mcp_auth_required,omitempty"` // Set when a per-user OAuth MCP tool requires authentication
 }

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -20,7 +20,22 @@ var (
 	ErrOAuth2TokenExpired         = errors.New("oauth2 token expired")
 	ErrOAuth2TokenInvalid         = errors.New("oauth2 token invalid")
 	ErrOAuth2RefreshFailed        = errors.New("oauth2 token refresh failed")
+	ErrOAuth2NotPerUserSession    = errors.New("state does not match a per-user oauth session")
 )
+
+// MCPUserOAuthRequiredError is returned when a per-user OAuth MCP server requires
+// the user to authenticate before tool execution can proceed.
+type MCPUserOAuthRequiredError struct {
+	MCPClientID   string `json:"mcp_client_id"`
+	MCPClientName string `json:"mcp_client_name"`
+	AuthorizeURL  string `json:"authorize_url"`
+	SessionID     string `json:"session_id"`
+	Message       string `json:"message"`
+}
+
+func (e *MCPUserOAuthRequiredError) Error() string {
+	return e.Message
+}
 
 // MCPConfig represents the configuration for MCP integration in Bifrost.
 // It enables tool auto-discovery and execution from local and external MCP servers.
@@ -69,9 +84,10 @@ const (
 type MCPAuthType string
 
 const (
-	MCPAuthTypeNone    MCPAuthType = "none"    // No authentication
-	MCPAuthTypeHeaders MCPAuthType = "headers" // Header-based authentication (API keys, etc.)
-	MCPAuthTypeOauth   MCPAuthType = "oauth"   // OAuth 2.0 authentication
+	MCPAuthTypeNone         MCPAuthType = "none"           // No authentication
+	MCPAuthTypeHeaders      MCPAuthType = "headers"        // Header-based authentication (API keys, etc.)
+	MCPAuthTypeOauth        MCPAuthType = "oauth"          // OAuth 2.0 authentication (server-level, admin authenticates once)
+	MCPAuthTypePerUserOauth MCPAuthType = "per_user_oauth" // Per-user OAuth 2.0 authentication (each user authenticates individually)
 )
 
 // MCPClientConfig defines tool filtering for an MCP client.
@@ -106,6 +122,10 @@ type MCPClientConfig struct {
 	ToolPricing           map[string]float64 `json:"tool_pricing,omitempty"`              // Tool pricing for each tool (cost per execution)
 	ConfigHash            string             `json:"-"`                                   // Config hash for reconciliation (not serialized)
 	AllowOnAllVirtualKeys bool               `json:"allow_on_all_virtual_keys"` // Whether to allow the MCP client to run on all virtual keys
+
+	// Discovered tools for per-user OAuth clients (persisted so they survive restart)
+	DiscoveredTools          map[string]ChatTool `json:"-"` // Discovered tool schemas keyed by prefixed name
+	DiscoveredToolNameMapping map[string]string   `json:"-"` // Mapping from sanitized tool names to original MCP names
 }
 
 // NewMCPClientConfigFromMap creates a new MCP client config from a map[string]any.
@@ -150,6 +170,9 @@ func (c *MCPClientConfig) HttpHeaders(ctx context.Context, oauth2Provider OAuth2
 		for key, value := range c.Headers {
 			headers[key] = value.GetValue()
 		}
+	case MCPAuthTypePerUserOauth:
+		// Per-user OAuth: headers are injected per-call in executeToolInternal, not at connection level
+		return headers, nil
 	case MCPAuthTypeNone:
 		// No headers to add
 	default:
@@ -182,9 +205,10 @@ type MCPStdioConfig struct {
 type MCPConnectionState string
 
 const (
-	MCPConnectionStateConnected    MCPConnectionState = "connected"    // Client is connected and ready to use
-	MCPConnectionStateDisconnected MCPConnectionState = "disconnected" // Client is not connected
-	MCPConnectionStateError        MCPConnectionState = "error"        // Client is in an error state, and cannot be used
+	MCPConnectionStateConnected    MCPConnectionState = "connected"     // Client is connected and ready to use
+	MCPConnectionStateDisconnected MCPConnectionState = "disconnected"  // Client is not connected
+	MCPConnectionStateError        MCPConnectionState = "error"         // Client is in an error state, and cannot be used
+	MCPConnectionStatePendingTools MCPConnectionState = "pending_tools" // Connected but tools not yet populated
 )
 
 // MCPClientState represents a connected MCP client with its configuration and tools.

--- a/core/schemas/oauth.go
+++ b/core/schemas/oauth.go
@@ -7,7 +7,7 @@ import (
 
 // OauthProvider interface defines OAuth operations
 type OAuth2Provider interface {
-	// GetAccessToken retrieves the access token for a given oauth_config_id
+	// GetAccessToken retrieves the access token for a given oauth_config_id (server-level OAuth)
 	GetAccessToken(ctx context.Context, oauthConfigID string) (string, error)
 
 	// RefreshAccessToken refreshes the access token for a given oauth_config_id
@@ -18,6 +18,31 @@ type OAuth2Provider interface {
 
 	// RevokeToken revokes the OAuth token
 	RevokeToken(ctx context.Context, oauthConfigID string) error
+
+	// Per-user OAuth methods
+
+	// GetUserAccessToken retrieves the access token for a per-user OAuth session.
+	// If the token is expired, it automatically attempts a refresh.
+	GetUserAccessToken(ctx context.Context, sessionToken string) (string, error)
+
+	// GetUserAccessTokenByIdentity retrieves the upstream access token for a user
+	// identified by virtualKeyID, userID, or sessionToken (fallback), for a specific
+	// MCP client. Tokens looked up by identity persist across sessions.
+	GetUserAccessTokenByIdentity(ctx context.Context, virtualKeyID, userID, sessionToken, mcpClientID string) (string, error)
+
+	// InitiateUserOAuthFlow creates a per-user OAuth session and returns the authorization URL.
+	// Returns (flow initiation details, session ID for polling, error).
+	InitiateUserOAuthFlow(ctx context.Context, oauthConfigID string, mcpClientID string, redirectURI string) (*OAuth2FlowInitiation, string, error)
+
+	// CompleteUserOAuthFlow handles the OAuth callback for a per-user flow.
+	// Returns the session token that the user should send on subsequent requests.
+	CompleteUserOAuthFlow(ctx context.Context, state string, code string) (string, error)
+
+	// RefreshUserAccessToken refreshes a per-user OAuth access token.
+	RefreshUserAccessToken(ctx context.Context, sessionToken string) error
+
+	// RevokeUserToken revokes a per-user OAuth token and marks the session as revoked.
+	RevokeUserToken(ctx context.Context, sessionToken string) error
 }
 
 // OauthConfig represents OAuth client configuration

--- a/docs/openapi/schemas/management/mcp.yaml
+++ b/docs/openapi/schemas/management/mcp.yaml
@@ -2,12 +2,13 @@
 
 MCPAuthType:
   type: string
-  enum: [none, headers, oauth]
+  enum: [none, headers, oauth, per_user_oauth]
   description: |
     Authentication type for MCP connections:
     - none: No authentication
     - headers: Header-based authentication (API keys, custom headers, etc.)
-    - oauth: OAuth 2.0 authentication
+    - oauth: OAuth 2.0 authentication (server-level, admin authenticates once)
+    - per_user_oauth: Per-user OAuth 2.0 authentication (each user authenticates individually)
 
 MCPConnectionType:
   type: string

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -367,6 +367,12 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddMultiBudgetTables(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddPerUserOAuthTables(ctx, db); err != nil {
+		return err
+	}
+	if err := migrationAddMCPClientDiscoveredToolsColumns(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -5885,7 +5891,6 @@ func migrationAddMultiBudgetTables(ctx context.Context, db *gorm.DB) error {
 			// Drop legacy budget_id columns from VK and ProviderConfig (raw SQL to avoid GORM FK lookup issues)
 			_ = tx.Exec("ALTER TABLE governance_virtual_keys DROP COLUMN IF EXISTS budget_id")
 			_ = tx.Exec("ALTER TABLE governance_virtual_key_provider_configs DROP COLUMN IF EXISTS budget_id")
-
 			return nil
 		},
 		Rollback: func(tx *gorm.DB) error {
@@ -5899,6 +5904,7 @@ func migrationAddMultiBudgetTables(ctx context.Context, db *gorm.DB) error {
 			if mg.HasColumn(&tables.TableBudget{}, "provider_config_id") {
 				if err := mg.DropColumn(&tables.TableBudget{}, "provider_config_id"); err != nil {
 					return err
+
 				}
 			}
 			return nil
@@ -5906,6 +5912,96 @@ func migrationAddMultiBudgetTables(ctx context.Context, db *gorm.DB) error {
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_multi_budget_tables migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddPerUserOAuthTables adds the oauth_user_sessions and oauth_user_tokens tables
+func migrationAddPerUserOAuthTables(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_per_user_oauth_tables",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := tx.AutoMigrate(&tables.TablePerUserOAuthClient{}); err != nil {
+				return fmt.Errorf("failed to create oauth_per_user_clients table: %w", err)
+			}
+			if err := tx.AutoMigrate(&tables.TablePerUserOAuthSession{}); err != nil {
+				return fmt.Errorf("failed to create oauth_per_user_sessions table: %w", err)
+			}
+			if err := tx.AutoMigrate(&tables.TablePerUserOAuthCode{}); err != nil {
+				return fmt.Errorf("failed to create oauth_per_user_codes table: %w", err)
+			}
+			if err := tx.AutoMigrate(&tables.TableOauthUserToken{}); err != nil {
+				return fmt.Errorf("failed to add identity columns to oauth_user_tokens: %w", err)
+			}
+			if err := tx.AutoMigrate(&tables.TableOauthUserSession{}); err != nil {
+				return fmt.Errorf("failed to create oauth_user_sessions table: %w", err)
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			for _, table := range []any{
+				&tables.TablePerUserOAuthCode{},
+				&tables.TablePerUserOAuthSession{},
+				&tables.TablePerUserOAuthClient{},
+				&tables.TableOauthUserToken{},
+				&tables.TableOauthUserSession{},
+			} {
+				if mg.HasTable(table) {
+					if err := mg.DropTable(table); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_per_user_oauth_tables migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddMCPClientDiscoveredToolsColumns adds discovered_tools_json and tool_name_mapping_json columns to the mcp_client table
+func migrationAddMCPClientDiscoveredToolsColumns(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_mcp_client_discovered_tools_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&tables.TableMCPClient{}, "discovered_tools_json") {
+				if err := migrator.AddColumn(&tables.TableMCPClient{}, "discovered_tools_json"); err != nil {
+					return err
+				}
+			}
+			if !migrator.HasColumn(&tables.TableMCPClient{}, "tool_name_mapping_json") {
+				if err := migrator.AddColumn(&tables.TableMCPClient{}, "tool_name_mapping_json"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasColumn(&tables.TableMCPClient{}, "discovered_tools_json") {
+				if err := migrator.DropColumn(&tables.TableMCPClient{}, "discovered_tools_json"); err != nil {
+					return err
+				}
+			}
+			if migrator.HasColumn(&tables.TableMCPClient{}, "tool_name_mapping_json") {
+				if err := migrator.DropColumn(&tables.TableMCPClient{}, "tool_name_mapping_json"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_mcp_client_discovered_tools_columns migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1086,22 +1086,24 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 			clientConfigs := make([]*schemas.MCPClientConfig, len(dbMCPClients))
 			for i, dbClient := range dbMCPClients {
 				clientConfigs[i] = &schemas.MCPClientConfig{
-					ID:                    dbClient.ClientID,
-					Name:                  dbClient.Name,
-					IsCodeModeClient:      dbClient.IsCodeModeClient,
-					ConnectionType:        schemas.MCPConnectionType(dbClient.ConnectionType),
-					ConnectionString:      dbClient.ConnectionString,
-					StdioConfig:           dbClient.StdioConfig,
-					AuthType:              schemas.MCPAuthType(dbClient.AuthType),
-					OauthConfigID:         dbClient.OauthConfigID,
-					ToolsToExecute:        dbClient.ToolsToExecute,
-					ToolsToAutoExecute:    dbClient.ToolsToAutoExecute,
-					Headers:               dbClient.Headers,
-					AllowedExtraHeaders:   dbClient.AllowedExtraHeaders,
-					IsPingAvailable:       dbClient.IsPingAvailable,
-					ToolSyncInterval:      time.Duration(dbClient.ToolSyncInterval) * time.Minute,
-					ToolPricing:           dbClient.ToolPricing,
-					AllowOnAllVirtualKeys: dbClient.AllowOnAllVirtualKeys,
+					ID:                        dbClient.ClientID,
+					Name:                      dbClient.Name,
+					IsCodeModeClient:          dbClient.IsCodeModeClient,
+					ConnectionType:            schemas.MCPConnectionType(dbClient.ConnectionType),
+					ConnectionString:          dbClient.ConnectionString,
+					StdioConfig:               dbClient.StdioConfig,
+					AuthType:                  schemas.MCPAuthType(dbClient.AuthType),
+					OauthConfigID:             dbClient.OauthConfigID,
+					ToolsToExecute:            dbClient.ToolsToExecute,
+					ToolsToAutoExecute:        dbClient.ToolsToAutoExecute,
+					Headers:                   dbClient.Headers,
+					AllowedExtraHeaders:       dbClient.AllowedExtraHeaders,
+					IsPingAvailable:           dbClient.IsPingAvailable,
+					ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Minute,
+					ToolPricing:               dbClient.ToolPricing,
+					AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
+					DiscoveredTools:           dbClient.DiscoveredTools,
+					DiscoveredToolNameMapping: dbClient.DiscoveredToolNameMapping,
 				}
 			}
 			return &schemas.MCPConfig{
@@ -1123,22 +1125,24 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 	clientConfigs := make([]*schemas.MCPClientConfig, len(dbMCPClients))
 	for i, dbClient := range dbMCPClients {
 		clientConfigs[i] = &schemas.MCPClientConfig{
-			ID:                    dbClient.ClientID,
-			Name:                  dbClient.Name,
-			IsCodeModeClient:      dbClient.IsCodeModeClient,
-			ConnectionType:        schemas.MCPConnectionType(dbClient.ConnectionType),
-			ConnectionString:      dbClient.ConnectionString,
-			StdioConfig:           dbClient.StdioConfig,
-			AuthType:              schemas.MCPAuthType(dbClient.AuthType),
-			OauthConfigID:         dbClient.OauthConfigID,
-			ToolsToExecute:        dbClient.ToolsToExecute,
-			ToolsToAutoExecute:    dbClient.ToolsToAutoExecute,
-			Headers:               dbClient.Headers,
-			AllowedExtraHeaders:   dbClient.AllowedExtraHeaders,
-			IsPingAvailable:       dbClient.IsPingAvailable,
-			ToolSyncInterval:      time.Duration(dbClient.ToolSyncInterval) * time.Minute,
-			AllowOnAllVirtualKeys: dbClient.AllowOnAllVirtualKeys,
-			ToolPricing:           dbClient.ToolPricing,
+			ID:                        dbClient.ClientID,
+			Name:                      dbClient.Name,
+			IsCodeModeClient:          dbClient.IsCodeModeClient,
+			ConnectionType:            schemas.MCPConnectionType(dbClient.ConnectionType),
+			ConnectionString:          dbClient.ConnectionString,
+			StdioConfig:               dbClient.StdioConfig,
+			AuthType:                  schemas.MCPAuthType(dbClient.AuthType),
+			OauthConfigID:             dbClient.OauthConfigID,
+			ToolsToExecute:            dbClient.ToolsToExecute,
+			ToolsToAutoExecute:        dbClient.ToolsToAutoExecute,
+			Headers:                   dbClient.Headers,
+			AllowedExtraHeaders:       dbClient.AllowedExtraHeaders,
+			IsPingAvailable:           dbClient.IsPingAvailable,
+			ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Minute,
+			AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
+			ToolPricing:               dbClient.ToolPricing,
+			DiscoveredTools:           dbClient.DiscoveredTools,
+			DiscoveredToolNameMapping: dbClient.DiscoveredToolNameMapping,
 		}
 	}
 	return &schemas.MCPConfig{
@@ -1350,6 +1354,26 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		}
 		return nil
 	})
+}
+
+// UpdateMCPClientDiscoveredTools persists discovered tools for a per-user OAuth MCP client.
+func (s *RDBConfigStore) UpdateMCPClientDiscoveredTools(ctx context.Context, clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) error {
+	toolsJSON, err := json.Marshal(tools)
+	if err != nil {
+		return fmt.Errorf("failed to marshal discovered tools: %w", err)
+	}
+	mappingJSON, err := json.Marshal(toolNameMapping)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tool name mapping: %w", err)
+	}
+	return s.db.WithContext(ctx).
+		Model(&tables.TableMCPClient{}).
+		Where("client_id = ?", clientID).
+		Updates(map[string]interface{}{
+			"discovered_tools_json":  string(toolsJSON),
+			"tool_name_mapping_json": string(mappingJSON),
+			"updated_at":            time.Now(),
+		}).Error
 }
 
 // DeleteMCPClientConfig deletes an MCP client configuration from the database.
@@ -3909,4 +3933,302 @@ func (s *RDBConfigStore) GetOauthConfigByTokenID(ctx context.Context, tokenID st
 		return nil, fmt.Errorf("failed to get oauth config by token id: %w", result.Error)
 	}
 	return &config, nil
+}
+
+// ---------- Per-User OAuth Session CRUD ----------
+
+// GetOauthUserSessionByID retrieves a per-user OAuth session by its ID
+func (s *RDBConfigStore) GetOauthUserSessionByID(ctx context.Context, id string) (*tables.TableOauthUserSession, error) {
+	var session tables.TableOauthUserSession
+	result := s.db.WithContext(ctx).Where("id = ?", id).First(&session)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get oauth user session: %w", result.Error)
+	}
+	return &session, nil
+}
+
+// GetOauthUserSessionByState retrieves a per-user OAuth session by its state token
+func (s *RDBConfigStore) GetOauthUserSessionByState(ctx context.Context, state string) (*tables.TableOauthUserSession, error) {
+	var session tables.TableOauthUserSession
+	result := s.db.WithContext(ctx).Where("state = ?", state).First(&session)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get oauth user session by state: %w", result.Error)
+	}
+	return &session, nil
+}
+
+// ClaimOauthUserSessionByState atomically claims a pending per-user OAuth session by its state token.
+// Returns nil if the session doesn't exist or has already been claimed by another request.
+func (s *RDBConfigStore) ClaimOauthUserSessionByState(ctx context.Context, state string) (*tables.TableOauthUserSession, error) {
+	var session tables.TableOauthUserSession
+	result := s.db.WithContext(ctx).Where("state = ? AND status = ?", state, "pending").First(&session)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to claim oauth user session by state: %w", result.Error)
+	}
+	// Atomically transition from "pending" to "claiming" to prevent concurrent claims
+	updateResult := s.db.WithContext(ctx).Model(&tables.TableOauthUserSession{}).
+		Where("id = ? AND status = ?", session.ID, "pending").
+		Update("status", "claiming")
+	if updateResult.Error != nil {
+		return nil, fmt.Errorf("failed to claim oauth user session: %w", updateResult.Error)
+	}
+	if updateResult.RowsAffected == 0 {
+		return nil, nil // Another request already claimed this session
+	}
+	session.Status = "claiming"
+	return &session, nil
+}
+
+// GetOauthUserSessionBySessionToken retrieves a per-user OAuth session by its Bifrost session token (hashed lookup)
+func (s *RDBConfigStore) GetOauthUserSessionBySessionToken(ctx context.Context, sessionToken string) (*tables.TableOauthUserSession, error) {
+	var session tables.TableOauthUserSession
+	tokenHash := encrypt.HashSHA256(sessionToken)
+	result := s.db.WithContext(ctx).Where("session_token_hash = ?", tokenHash).First(&session)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get oauth user session by session token: %w", result.Error)
+	}
+	return &session, nil
+}
+
+// CreateOauthUserSession creates a new per-user OAuth session
+func (s *RDBConfigStore) CreateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error {
+	result := s.db.WithContext(ctx).Create(session)
+	if result.Error != nil {
+		return fmt.Errorf("failed to create oauth user session: %w", result.Error)
+	}
+	return nil
+}
+
+// UpdateOauthUserSession updates an existing per-user OAuth session
+func (s *RDBConfigStore) UpdateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error {
+	result := s.db.WithContext(ctx).Save(session)
+	if result.Error != nil {
+		return fmt.Errorf("failed to update oauth user session: %w", result.Error)
+	}
+	return nil
+}
+
+// ---------- Per-User OAuth Token CRUD ----------
+
+// GetOauthUserTokenBySessionToken retrieves a per-user OAuth token by its Bifrost session token
+// GetOauthUserTokenByIdentity looks up an upstream OAuth token by user identity and MCP client.
+// Priority: userID > virtualKeyID > sessionToken (fallback for anonymous users).
+func (s *RDBConfigStore) GetOauthUserTokenByIdentity(ctx context.Context, virtualKeyID, userID, sessionToken, mcpClientID string) (*tables.TableOauthUserToken, error) {
+	var token tables.TableOauthUserToken
+	var result *gorm.DB
+
+	if userID != "" {
+		result = s.db.WithContext(ctx).Where("user_id = ? AND mcp_client_id = ?", userID, mcpClientID).First(&token)
+	} else if virtualKeyID != "" {
+		result = s.db.WithContext(ctx).Where("virtual_key_id = ? AND mcp_client_id = ?", virtualKeyID, mcpClientID).First(&token)
+	} else if sessionToken != "" {
+		result = s.db.WithContext(ctx).Where("session_token = ? AND mcp_client_id = ?", sessionToken, mcpClientID).First(&token)
+	} else {
+		return nil, nil
+	}
+
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get oauth user token by identity: %w", result.Error)
+	}
+	return &token, nil
+}
+
+func (s *RDBConfigStore) GetOauthUserTokenBySessionToken(ctx context.Context, sessionToken string) (*tables.TableOauthUserToken, error) {
+	var token tables.TableOauthUserToken
+	tokenHash := encrypt.HashSHA256(sessionToken)
+	result := s.db.WithContext(ctx).Where("session_token_hash = ?", tokenHash).First(&token)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get oauth user token by session token: %w", result.Error)
+	}
+	return &token, nil
+}
+
+// CreateOauthUserToken creates a new per-user OAuth token
+func (s *RDBConfigStore) CreateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error {
+	result := s.db.WithContext(ctx).Create(token)
+	if result.Error != nil {
+		return fmt.Errorf("failed to create oauth user token: %w", result.Error)
+	}
+	return nil
+}
+
+// UpdateOauthUserToken updates an existing per-user OAuth token
+func (s *RDBConfigStore) UpdateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error {
+	result := s.db.WithContext(ctx).Save(token)
+	if result.Error != nil {
+		return fmt.Errorf("failed to update oauth user token: %w", result.Error)
+	}
+	return nil
+}
+
+// DeleteOauthUserToken deletes a per-user OAuth token by its ID
+func (s *RDBConfigStore) DeleteOauthUserToken(ctx context.Context, id string) error {
+	result := s.db.WithContext(ctx).Where("id = ?", id).Delete(&tables.TableOauthUserToken{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete oauth user token: %w", result.Error)
+	}
+	return nil
+}
+
+// DeleteOauthUserTokensByMCPClient deletes all per-user OAuth tokens for a specific MCP client
+func (s *RDBConfigStore) DeleteOauthUserTokensByMCPClient(ctx context.Context, mcpClientID string) error {
+	result := s.db.WithContext(ctx).Where("mcp_client_id = ?", mcpClientID).Delete(&tables.TableOauthUserToken{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete oauth user tokens for mcp client: %w", result.Error)
+	}
+	return nil
+}
+
+// ---------- Per-User OAuth Authorization Server CRUD ----------
+
+// GetPerUserOAuthClientByClientID retrieves a dynamically registered OAuth client by its client_id.
+func (s *RDBConfigStore) GetPerUserOAuthClientByClientID(ctx context.Context, clientID string) (*tables.TablePerUserOAuthClient, error) {
+	var client tables.TablePerUserOAuthClient
+	result := s.db.WithContext(ctx).Where("client_id = ?", clientID).First(&client)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get per-user oauth client: %w", result.Error)
+	}
+	return &client, nil
+}
+
+// CreatePerUserOAuthClient creates a new dynamically registered OAuth client.
+func (s *RDBConfigStore) CreatePerUserOAuthClient(ctx context.Context, client *tables.TablePerUserOAuthClient) error {
+	result := s.db.WithContext(ctx).Create(client)
+	if result.Error != nil {
+		return fmt.Errorf("failed to create per-user oauth client: %w", result.Error)
+	}
+	return nil
+}
+
+// GetPerUserOAuthSessionByAccessToken retrieves a Bifrost-issued session by its access token.
+func (s *RDBConfigStore) GetPerUserOAuthSessionByAccessToken(ctx context.Context, accessToken string) (*tables.TablePerUserOAuthSession, error) {
+	var session tables.TablePerUserOAuthSession
+	tokenHash := encrypt.HashSHA256(accessToken)
+	result := s.db.WithContext(ctx).Where("access_token_hash = ?", tokenHash).First(&session)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get per-user oauth session: %w", result.Error)
+	}
+	return &session, nil
+}
+
+// GetPerUserOAuthSessionByID retrieves a Bifrost-issued session by its ID.
+func (s *RDBConfigStore) GetPerUserOAuthSessionByID(ctx context.Context, id string) (*tables.TablePerUserOAuthSession, error) {
+	var session tables.TablePerUserOAuthSession
+	result := s.db.WithContext(ctx).Where("id = ?", id).First(&session)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get per-user oauth session by id: %w", result.Error)
+	}
+	return &session, nil
+}
+
+// CreatePerUserOAuthSession creates a new Bifrost-issued OAuth session.
+func (s *RDBConfigStore) CreatePerUserOAuthSession(ctx context.Context, session *tables.TablePerUserOAuthSession) error {
+	result := s.db.WithContext(ctx).Create(session)
+	if result.Error != nil {
+		return fmt.Errorf("failed to create per-user oauth session: %w", result.Error)
+	}
+	return nil
+}
+
+// UpdatePerUserOAuthSession updates a Bifrost-issued OAuth session (e.g., to attach user identity).
+func (s *RDBConfigStore) UpdatePerUserOAuthSession(ctx context.Context, session *tables.TablePerUserOAuthSession) error {
+	result := s.db.WithContext(ctx).Save(session)
+	if result.Error != nil {
+		return fmt.Errorf("failed to update per-user oauth session: %w", result.Error)
+	}
+	return nil
+}
+
+// DeletePerUserOAuthSession deletes a Bifrost-issued OAuth session by ID.
+func (s *RDBConfigStore) DeletePerUserOAuthSession(ctx context.Context, id string) error {
+	result := s.db.WithContext(ctx).Where("id = ?", id).Delete(&tables.TablePerUserOAuthSession{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete per-user oauth session: %w", result.Error)
+	}
+	return nil
+}
+
+// GetPerUserOAuthCodeByCode retrieves an authorization code record.
+func (s *RDBConfigStore) GetPerUserOAuthCodeByCode(ctx context.Context, code string) (*tables.TablePerUserOAuthCode, error) {
+	var codeRecord tables.TablePerUserOAuthCode
+	codeHash := encrypt.HashSHA256(code)
+	result := s.db.WithContext(ctx).Where("code_hash = ?", codeHash).First(&codeRecord)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get per-user oauth code: %w", result.Error)
+	}
+	return &codeRecord, nil
+}
+
+// CreatePerUserOAuthCode creates a new authorization code record.
+func (s *RDBConfigStore) CreatePerUserOAuthCode(ctx context.Context, code *tables.TablePerUserOAuthCode) error {
+	result := s.db.WithContext(ctx).Create(code)
+	if result.Error != nil {
+		return fmt.Errorf("failed to create per-user oauth code: %w", result.Error)
+	}
+	return nil
+}
+
+// ClaimPerUserOAuthCode atomically marks an authorization code as used.
+// Returns the code record if successfully claimed, nil if already used or not found.
+func (s *RDBConfigStore) ClaimPerUserOAuthCode(ctx context.Context, code string) (*tables.TablePerUserOAuthCode, error) {
+	codeHash := encrypt.HashSHA256(code)
+	var codeRecord tables.TablePerUserOAuthCode
+	result := s.db.WithContext(ctx).Where("code_hash = ? AND used = ?", codeHash, false).First(&codeRecord)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to find per-user oauth code: %w", result.Error)
+	}
+	// Atomically mark as used
+	updateResult := s.db.WithContext(ctx).Model(&tables.TablePerUserOAuthCode{}).
+		Where("id = ? AND used = ?", codeRecord.ID, false).
+		Update("used", true)
+	if updateResult.Error != nil {
+		return nil, fmt.Errorf("failed to claim per-user oauth code: %w", updateResult.Error)
+	}
+	if updateResult.RowsAffected == 0 {
+		return nil, nil // Another request already claimed it
+	}
+	codeRecord.Used = true
+	return &codeRecord, nil
+}
+
+// UpdatePerUserOAuthCode updates an authorization code record (e.g., marking as used).
+func (s *RDBConfigStore) UpdatePerUserOAuthCode(ctx context.Context, code *tables.TablePerUserOAuthCode) error {
+	result := s.db.WithContext(ctx).Save(code)
+	if result.Error != nil {
+		return fmt.Errorf("failed to update per-user oauth code: %w", result.Error)
+	}
+	return nil
 }

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -117,6 +117,7 @@ type ConfigStore interface {
 	GetMCPClientsPaginated(ctx context.Context, params MCPClientsQueryParams) ([]tables.TableMCPClient, int64, error)
 	CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig) error
 	UpdateMCPClientConfig(ctx context.Context, id string, clientConfig *tables.TableMCPClient) error
+	UpdateMCPClientDiscoveredTools(ctx context.Context, clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) error
 	DeleteMCPClientConfig(ctx context.Context, id string) error
 
 	// Vector store config CRUD
@@ -300,6 +301,35 @@ type ConfigStore interface {
 	CreateOauthToken(ctx context.Context, token *tables.TableOauthToken) error
 	UpdateOauthToken(ctx context.Context, token *tables.TableOauthToken) error
 	DeleteOauthToken(ctx context.Context, id string) error
+
+	// Per-user OAuth session CRUD
+	GetOauthUserSessionByID(ctx context.Context, id string) (*tables.TableOauthUserSession, error)
+	GetOauthUserSessionByState(ctx context.Context, state string) (*tables.TableOauthUserSession, error)
+	ClaimOauthUserSessionByState(ctx context.Context, state string) (*tables.TableOauthUserSession, error)
+	GetOauthUserSessionBySessionToken(ctx context.Context, sessionToken string) (*tables.TableOauthUserSession, error)
+	CreateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error
+	UpdateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error
+
+	// Per-user OAuth token CRUD
+	GetOauthUserTokenByIdentity(ctx context.Context, virtualKeyID, userID, sessionToken, mcpClientID string) (*tables.TableOauthUserToken, error)
+	GetOauthUserTokenBySessionToken(ctx context.Context, sessionToken string) (*tables.TableOauthUserToken, error)
+	CreateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error
+	UpdateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error
+	DeleteOauthUserToken(ctx context.Context, id string) error
+	DeleteOauthUserTokensByMCPClient(ctx context.Context, mcpClientID string) error
+
+	// Per-user OAuth Authorization Server CRUD (Bifrost as OAuth server)
+	GetPerUserOAuthClientByClientID(ctx context.Context, clientID string) (*tables.TablePerUserOAuthClient, error)
+	CreatePerUserOAuthClient(ctx context.Context, client *tables.TablePerUserOAuthClient) error
+	GetPerUserOAuthSessionByAccessToken(ctx context.Context, accessToken string) (*tables.TablePerUserOAuthSession, error)
+	GetPerUserOAuthSessionByID(ctx context.Context, id string) (*tables.TablePerUserOAuthSession, error)
+	CreatePerUserOAuthSession(ctx context.Context, session *tables.TablePerUserOAuthSession) error
+	UpdatePerUserOAuthSession(ctx context.Context, session *tables.TablePerUserOAuthSession) error
+	DeletePerUserOAuthSession(ctx context.Context, id string) error
+	GetPerUserOAuthCodeByCode(ctx context.Context, code string) (*tables.TablePerUserOAuthCode, error)
+	ClaimPerUserOAuthCode(ctx context.Context, code string) (*tables.TablePerUserOAuthCode, error)
+	CreatePerUserOAuthCode(ctx context.Context, code *tables.TablePerUserOAuthCode) error
+	UpdatePerUserOAuthCode(ctx context.Context, code *tables.TablePerUserOAuthCode) error
 
 	// Not found retry wrapper
 	RetryOnNotFound(ctx context.Context, fn func(ctx context.Context) (any, error), maxRetries int, retryDelay time.Duration) (any, error)

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -28,6 +28,10 @@ type TableMCPClient struct {
 	ToolPricingJSON         string          `gorm:"type:text" json:"-"`                              // JSON serialized map[string]float64
 	ToolSyncInterval        int             `gorm:"default:0" json:"tool_sync_interval"`             // Per-client tool sync interval in minutes (0 = use global, -1 = disabled)
 
+	// Per-user OAuth: discovered tools persisted so they survive restart
+	DiscoveredToolsJSON       string `gorm:"type:text" json:"-"`                              // JSON serialized map[string]schemas.ChatTool
+	ToolNameMappingJSON       string `gorm:"type:text" json:"-"`                              // JSON serialized map[string]string
+
 	// OAuth authentication fields
 	AuthType      string            `gorm:"type:varchar(20);default:'headers'" json:"auth_type"`                         // "none", "headers", "oauth"
 	OauthConfigID *string           `gorm:"type:varchar(255);index;constraint:OnDelete:CASCADE" json:"oauth_config_id"`  // Foreign key to oauth_configs.ID with CASCADE delete
@@ -45,12 +49,14 @@ type TableMCPClient struct {
 	UpdatedAt time.Time `gorm:"index;not null" json:"updated_at"`
 
 	// Virtual fields for runtime use (not stored in DB)
-	StdioConfig         *schemas.MCPStdioConfig   `gorm:"-" json:"stdio_config,omitempty"`
-	ToolsToExecute      schemas.WhiteList         `gorm:"-" json:"tools_to_execute"`
-	ToolsToAutoExecute  schemas.WhiteList         `gorm:"-" json:"tools_to_auto_execute"`
-	Headers             map[string]schemas.EnvVar `gorm:"-" json:"headers"`
-	AllowedExtraHeaders schemas.WhiteList         `gorm:"-" json:"allowed_extra_headers"`
-	ToolPricing         map[string]float64        `gorm:"-" json:"tool_pricing"`
+	StdioConfig               *schemas.MCPStdioConfig    `gorm:"-" json:"stdio_config,omitempty"`
+	ToolsToExecute            schemas.WhiteList          `gorm:"-" json:"tools_to_execute"`
+	ToolsToAutoExecute        schemas.WhiteList          `gorm:"-" json:"tools_to_auto_execute"`
+	Headers                   map[string]schemas.EnvVar  `gorm:"-" json:"headers"`
+	AllowedExtraHeaders       schemas.WhiteList          `gorm:"-" json:"allowed_extra_headers"`
+	ToolPricing               map[string]float64         `gorm:"-" json:"tool_pricing"`
+	DiscoveredTools           map[string]schemas.ChatTool `gorm:"-" json:"-"`
+	DiscoveredToolNameMapping map[string]string           `gorm:"-" json:"-"`
 }
 
 // TableName sets the table name for each model
@@ -138,6 +144,22 @@ func (c *TableMCPClient) BeforeSave(tx *gorm.DB) error {
 		c.ToolPricingJSON = "{}"
 	}
 
+	if c.DiscoveredTools != nil {
+		data, err := json.Marshal(c.DiscoveredTools)
+		if err != nil {
+			return err
+		}
+		c.DiscoveredToolsJSON = string(data)
+	}
+
+	if c.DiscoveredToolNameMapping != nil {
+		data, err := json.Marshal(c.DiscoveredToolNameMapping)
+		if err != nil {
+			return err
+		}
+		c.ToolNameMappingJSON = string(data)
+	}
+
 	// Encrypt sensitive fields after serialization.
 	// Always set EncryptionStatus when encryption is enabled so the startup
 	// batch pass does not re-process this row indefinitely.
@@ -213,6 +235,16 @@ func (c *TableMCPClient) AfterFind(tx *gorm.DB) error {
 	}
 	if c.ToolPricingJSON != "" {
 		if err := json.Unmarshal([]byte(c.ToolPricingJSON), &c.ToolPricing); err != nil {
+			return err
+		}
+	}
+	if c.DiscoveredToolsJSON != "" {
+		if err := sonic.Unmarshal([]byte(c.DiscoveredToolsJSON), &c.DiscoveredTools); err != nil {
+			return err
+		}
+	}
+	if c.ToolNameMappingJSON != "" {
+		if err := sonic.Unmarshal([]byte(c.ToolNameMappingJSON), &c.DiscoveredToolNameMapping); err != nil {
 			return err
 		}
 	}

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -132,3 +132,224 @@ func (t *TableOauthToken) AfterFind(tx *gorm.DB) error {
 	}
 	return nil
 }
+
+// ---------- Per-User OAuth Tables ----------
+
+// TableOauthUserSession tracks pending per-user OAuth flows.
+// Each record maps an OAuth state token to a specific MCP client, allowing
+// the callback to associate the resulting tokens with the correct user session.
+type TableOauthUserSession struct {
+	ID               string    `gorm:"type:varchar(255);primaryKey" json:"id"`                      // Session UUID
+	MCPClientID      string    `gorm:"type:varchar(255);not null;index" json:"mcp_client_id"`       // Which MCP server this auth is for
+	OauthConfigID    string    `gorm:"type:varchar(255);not null;index" json:"oauth_config_id"`     // Template OAuth config (holds client_id, token_url, etc.)
+	State            string    `gorm:"type:varchar(255);uniqueIndex;not null" json:"-"`             // CSRF state token sent to OAuth provider
+	RedirectURI      string    `gorm:"type:text" json:"-"`                                          // Per-request redirect URI used in authorize step
+	CodeVerifier     string    `gorm:"type:text" json:"-"`                                          // PKCE code verifier (kept secret)
+	SessionToken     string    `gorm:"type:varchar(255)" json:"-"`                                  // Bifrost session ID (links to oauth_per_user_sessions)
+	SessionTokenHash string    `gorm:"type:varchar(64);uniqueIndex" json:"-"`                       // SHA-256 hash of SessionToken for secure lookups
+	GatewaySessionID string    `gorm:"type:varchar(255);index" json:"-"`                            // Bifrost MCP gateway session ID (separate from SessionToken)
+	VirtualKeyID     string    `gorm:"type:varchar(255);index" json:"virtual_key_id"`               // VK identity (propagated to oauth_user_tokens)
+	UserID           string    `gorm:"type:varchar(255);index" json:"user_id"`                      // Enterprise user identity (propagated to oauth_user_tokens)
+	Status           string    `gorm:"type:varchar(50);not null;index" json:"status"`               // "pending", "authorized", "failed", "expired"
+	EncryptionStatus string    `gorm:"type:varchar(20);default:'plain_text'" json:"-"`
+	ExpiresAt        time.Time `gorm:"index;not null" json:"expires_at"`                            // Flow expiration (15 min)
+	CreatedAt        time.Time `gorm:"index;not null" json:"created_at"`
+	UpdatedAt        time.Time `gorm:"index;not null" json:"updated_at"`
+}
+
+func (TableOauthUserSession) TableName() string {
+	return "oauth_user_sessions"
+}
+
+func (s *TableOauthUserSession) BeforeSave(tx *gorm.DB) error {
+	if s.Status == "" {
+		s.Status = "pending"
+	}
+	if s.SessionToken != "" {
+		s.SessionTokenHash = encrypt.HashSHA256(s.SessionToken)
+	}
+	if encrypt.IsEnabled() {
+		if s.CodeVerifier != "" {
+			if err := encryptString(&s.CodeVerifier); err != nil {
+				return fmt.Errorf("failed to encrypt oauth user session code verifier: %w", err)
+			}
+		}
+		s.EncryptionStatus = EncryptionStatusEncrypted
+	}
+	return nil
+}
+
+func (s *TableOauthUserSession) AfterFind(tx *gorm.DB) error {
+	if s.EncryptionStatus == EncryptionStatusEncrypted && s.CodeVerifier != "" {
+		if err := decryptString(&s.CodeVerifier); err != nil {
+			return fmt.Errorf("failed to decrypt oauth user session code verifier: %w", err)
+		}
+	}
+	return nil
+}
+
+// TableOauthUserToken stores per-user OAuth credentials.
+// Each record holds the access/refresh tokens for a specific user session + MCP client pair.
+// Lookup is by SessionToken (from the X-Bifrost-MCP-Session header).
+type TableOauthUserToken struct {
+	ID               string     `gorm:"type:varchar(255);primaryKey" json:"id"`                     // Token UUID
+	SessionToken     string     `gorm:"type:varchar(255)" json:"-"`                                 // Maps to Bifrost session (fallback for anonymous users)
+	SessionTokenHash string     `gorm:"type:varchar(64);index" json:"-"`                           // SHA-256 hash of SessionToken for secure lookups
+	VirtualKeyID     string     `gorm:"type:varchar(255);index:idx_vk_mcp" json:"virtual_key_id"`  // VK identity (persistent across sessions)
+	UserID           string     `gorm:"type:varchar(255);index:idx_user_mcp" json:"user_id"`       // Enterprise user identity (persistent across sessions)
+	MCPClientID      string     `gorm:"type:varchar(255);not null;index:idx_vk_mcp;index:idx_user_mcp" json:"mcp_client_id"` // Which MCP server
+	OauthConfigID    string     `gorm:"type:varchar(255);not null;index" json:"oauth_config_id"`    // Template OAuth config
+	AccessToken      string     `gorm:"type:text;not null" json:"-"`                                // Encrypted user's OAuth access token
+	RefreshToken     string     `gorm:"type:text" json:"-"`                                         // Encrypted user's OAuth refresh token
+	TokenType        string     `gorm:"type:varchar(50);not null" json:"token_type"`                // "Bearer"
+	ExpiresAt        time.Time  `gorm:"index;not null" json:"expires_at"`                           // Token expiry
+	Scopes           string     `gorm:"type:text" json:"scopes"`                                    // JSON array of granted scopes
+	LastRefreshedAt  *time.Time `gorm:"index" json:"last_refreshed_at,omitempty"`                   // Last refresh time
+	EncryptionStatus string     `gorm:"type:varchar(20);default:'plain_text'" json:"-"`
+	CreatedAt        time.Time  `gorm:"index;not null" json:"created_at"`
+	UpdatedAt        time.Time  `gorm:"index;not null" json:"updated_at"`
+}
+
+func (TableOauthUserToken) TableName() string {
+	return "oauth_user_tokens"
+}
+
+func (t *TableOauthUserToken) BeforeSave(tx *gorm.DB) error {
+	if t.TokenType == "" {
+		t.TokenType = "Bearer"
+	}
+	if t.SessionToken != "" {
+		t.SessionTokenHash = encrypt.HashSHA256(t.SessionToken)
+	}
+	if encrypt.IsEnabled() {
+		if err := encryptString(&t.AccessToken); err != nil {
+			return fmt.Errorf("failed to encrypt oauth user access token: %w", err)
+		}
+		if err := encryptString(&t.RefreshToken); err != nil {
+			return fmt.Errorf("failed to encrypt oauth user refresh token: %w", err)
+		}
+		t.EncryptionStatus = EncryptionStatusEncrypted
+	}
+	return nil
+}
+
+func (t *TableOauthUserToken) AfterFind(tx *gorm.DB) error {
+	if t.EncryptionStatus == EncryptionStatusEncrypted {
+		if err := decryptString(&t.AccessToken); err != nil {
+			return fmt.Errorf("failed to decrypt oauth user access token: %w", err)
+		}
+		if err := decryptString(&t.RefreshToken); err != nil {
+			return fmt.Errorf("failed to decrypt oauth user refresh token: %w", err)
+		}
+	}
+	return nil
+}
+
+// ---------- Per-User OAuth Authorization Server Tables ----------
+
+// TablePerUserOAuthClient stores dynamically registered OAuth clients (RFC 7591).
+// MCP clients (like Claude Code) register themselves with Bifrost's OAuth
+// authorization server to obtain a client_id for the authorization code flow.
+type TablePerUserOAuthClient struct {
+	ID           string    `gorm:"type:varchar(255);primaryKey" json:"id"`
+	ClientID     string    `gorm:"type:varchar(255);uniqueIndex;not null" json:"client_id"`
+	ClientName   string    `gorm:"type:varchar(255)" json:"client_name"`
+	RedirectURIs string    `gorm:"type:text;not null" json:"redirect_uris"` // JSON array of allowed redirect URIs
+	GrantTypes   string    `gorm:"type:text" json:"grant_types"`            // JSON array of grant types
+	CreatedAt    time.Time `gorm:"index;not null" json:"created_at"`
+	UpdatedAt    time.Time `gorm:"index;not null" json:"updated_at"`
+}
+
+// TableName returns the table name for per-user OAuth clients.
+func (TablePerUserOAuthClient) TableName() string {
+	return "oauth_per_user_clients"
+}
+
+// TablePerUserOAuthSession stores Bifrost-issued access tokens for authenticated
+// MCP connections. When a user authenticates via Bifrost's OAuth flow, a session
+// is created. The access token is included in all subsequent MCP requests.
+// Upstream provider tokens are linked via the oauth_user_tokens table.
+type TablePerUserOAuthSession struct {
+	ID               string    `gorm:"type:varchar(255);primaryKey" json:"id"`
+	AccessToken      string    `gorm:"type:text;not null" json:"-"`                          // Bifrost-issued access token (encrypted)
+	AccessTokenHash  string    `gorm:"type:varchar(64);uniqueIndex" json:"-"`               // SHA-256 hash for secure lookups
+	RefreshToken     string    `gorm:"type:text" json:"-"`                                  // Bifrost-issued refresh token (encrypted, optional)
+	RefreshTokenHash string    `gorm:"type:varchar(64);index" json:"-"`                     // SHA-256 hash for secure lookups (not unique — refresh tokens are optional)
+	ClientID         string    `gorm:"type:varchar(255);not null;index" json:"client_id"`  // Which OAuth client registered this session
+	VirtualKeyID     string    `gorm:"type:varchar(255);index" json:"virtual_key_id"`      // Linked VK identity (set when VK is present during auth)
+	UserID           string    `gorm:"type:varchar(255);index" json:"user_id"`             // Linked enterprise user identity (set when user ID is present)
+	ExpiresAt        time.Time `gorm:"index;not null" json:"expires_at"`
+	EncryptionStatus string    `gorm:"type:varchar(20);default:'plain_text'" json:"-"`
+	CreatedAt        time.Time `gorm:"index;not null" json:"created_at"`
+	UpdatedAt        time.Time `gorm:"index;not null" json:"updated_at"`
+}
+
+// TableName returns the table name for per-user OAuth sessions.
+func (TablePerUserOAuthSession) TableName() string {
+	return "oauth_per_user_sessions"
+}
+
+// BeforeSave encrypts sensitive fields.
+func (s *TablePerUserOAuthSession) BeforeSave(tx *gorm.DB) error {
+	if s.AccessToken != "" {
+		s.AccessTokenHash = encrypt.HashSHA256(s.AccessToken)
+	}
+	if s.RefreshToken != "" {
+		s.RefreshTokenHash = encrypt.HashSHA256(s.RefreshToken)
+	}
+	if encrypt.IsEnabled() {
+		if err := encryptString(&s.AccessToken); err != nil {
+			return fmt.Errorf("failed to encrypt per-user oauth access token: %w", err)
+		}
+		if s.RefreshToken != "" {
+			if err := encryptString(&s.RefreshToken); err != nil {
+				return fmt.Errorf("failed to encrypt per-user oauth refresh token: %w", err)
+			}
+		}
+		s.EncryptionStatus = EncryptionStatusEncrypted
+	}
+	return nil
+}
+
+// AfterFind decrypts sensitive fields.
+func (s *TablePerUserOAuthSession) AfterFind(tx *gorm.DB) error {
+	if s.EncryptionStatus == EncryptionStatusEncrypted {
+		if err := decryptString(&s.AccessToken); err != nil {
+			return fmt.Errorf("failed to decrypt per-user oauth access token: %w", err)
+		}
+		if s.RefreshToken != "" {
+			if err := decryptString(&s.RefreshToken); err != nil {
+				return fmt.Errorf("failed to decrypt per-user oauth refresh token: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// TablePerUserOAuthCode stores authorization codes during the OAuth flow.
+// Codes are short-lived (5 minutes) and single-use.
+type TablePerUserOAuthCode struct {
+	ID            string    `gorm:"type:varchar(255);primaryKey" json:"id"`
+	Code          string    `gorm:"type:text;not null" json:"-"`                     // Authorization code
+	CodeHash      string    `gorm:"type:varchar(64);uniqueIndex" json:"-"`           // SHA-256 hash for secure lookups
+	ClientID      string    `gorm:"type:varchar(255);not null;index" json:"client_id"`
+	RedirectURI   string    `gorm:"type:text;not null" json:"redirect_uri"`
+	CodeChallenge string    `gorm:"type:varchar(255);not null" json:"-"`  // PKCE S256 challenge
+	Scopes        string    `gorm:"type:text" json:"scopes"`             // JSON array of requested scopes
+	ExpiresAt     time.Time `gorm:"index;not null" json:"expires_at"`    // 5 min TTL
+	Used          bool      `gorm:"default:false;not null" json:"used"`  // Single-use flag
+	CreatedAt     time.Time `gorm:"index;not null" json:"created_at"`
+}
+
+// BeforeSave hashes the code for secure lookups.
+func (c *TablePerUserOAuthCode) BeforeSave(tx *gorm.DB) error {
+	if c.Code != "" {
+		c.CodeHash = encrypt.HashSHA256(c.Code)
+	}
+	return nil
+}
+
+// TableName returns the table name for per-user OAuth authorization codes.
+func (TablePerUserOAuthCode) TableName() string {
+	return "oauth_per_user_codes"
+}

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -680,3 +680,339 @@ func generateSecureRandomString(length int) (string, error) {
 	}
 	return base64.URLEncoding.EncodeToString(bytes)[:length], nil
 }
+
+// generateSessionToken generates a cryptographically secure opaque session token (hex-encoded)
+func generateSessionToken() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("failed to generate session token: %w", err)
+	}
+	return fmt.Sprintf("%x", bytes), nil
+}
+
+// ---------- Per-User OAuth Methods ----------
+
+// InitiateUserOAuthFlow creates a per-user OAuth session and returns the authorization URL.
+// It reuses the template OAuth config (which holds client_id, token_url, etc.) to build the flow.
+func (p *OAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigID string, mcpClientID string, redirectURI string) (*schemas.OAuth2FlowInitiation, string, error) {
+	// Load the template OAuth config
+	templateConfig, err := p.configStore.GetOauthConfigByID(ctx, oauthConfigID)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to load template oauth config: %w", err)
+	}
+	if templateConfig == nil {
+		return nil, "", schemas.ErrOAuth2ConfigNotFound
+	}
+
+	// Generate state token for CSRF protection
+	state, err := generateSecureRandomString(32)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate state token: %w", err)
+	}
+
+	// Generate PKCE challenge
+	codeVerifier, codeChallenge, err := GeneratePKCEChallenge()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate PKCE challenge: %w", err)
+	}
+
+	// Parse scopes from template config
+	var scopes []string
+	if templateConfig.Scopes != "" {
+		json.Unmarshal([]byte(templateConfig.Scopes), &scopes)
+	}
+
+	// Generate session token upfront to avoid empty unique-index collisions on pending sessions
+	sessionToken, err := generateSessionToken()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate session token: %w", err)
+	}
+
+	// Create per-user OAuth session
+	sessionID := uuid.New().String()
+	expiresAt := time.Now().Add(15 * time.Minute)
+
+	// Propagate identity from context so the callback can link the token to the user
+	virtualKeyID, _ := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID).(string)
+	userID, _ := ctx.Value(schemas.BifrostContextKeyGovernanceUserID).(string)
+	// For OSS: prefer X-Bf-User-Id header as user identity
+	if mcpUserID, _ := ctx.Value(schemas.BifrostContextKeyMCPUserID).(string); mcpUserID != "" {
+		userID = mcpUserID
+	}
+
+	session := &tables.TableOauthUserSession{
+		ID:            sessionID,
+		MCPClientID:   mcpClientID,
+		OauthConfigID: oauthConfigID,
+		State:         state,
+		RedirectURI:   redirectURI,
+		CodeVerifier:  codeVerifier,
+		SessionToken:  sessionToken,
+		VirtualKeyID:  virtualKeyID,
+		UserID:        userID,
+		Status:        "pending",
+		ExpiresAt:     expiresAt,
+	}
+
+	if err := p.configStore.CreateOauthUserSession(ctx, session); err != nil {
+		return nil, "", fmt.Errorf("failed to create per-user oauth session: %w", err)
+	}
+
+	// Build authorize URL with PKCE
+	authURL := p.buildAuthorizeURLWithPKCE(
+		templateConfig.AuthorizeURL,
+		templateConfig.ClientID,
+		redirectURI,
+		state,
+		codeChallenge,
+		scopes,
+	)
+
+	logger.Debug("Per-user OAuth flow initiated: session_id=%s, mcp_client_id=%s", sessionID, mcpClientID)
+
+	return &schemas.OAuth2FlowInitiation{
+		OauthConfigID: oauthConfigID,
+		AuthorizeURL:  authURL,
+		State:         state,
+		ExpiresAt:     expiresAt,
+	}, sessionID, nil
+}
+
+// CompleteUserOAuthFlow handles the OAuth callback for a per-user flow.
+// It looks up the session by state, exchanges code for tokens, and returns a session token.
+func (p *OAuth2Provider) CompleteUserOAuthFlow(ctx context.Context, state string, code string) (string, error) {
+	// Atomically claim session by state to prevent concurrent callback races
+	session, err := p.configStore.ClaimOauthUserSessionByState(ctx, state)
+	if err != nil {
+		return "", fmt.Errorf("failed to claim per-user oauth session: %w", err)
+	}
+	if session == nil {
+		// State not found or already claimed — not a per-user session
+		return "", schemas.ErrOAuth2NotPerUserSession
+	}
+
+	// Check expiry
+	if time.Now().After(session.ExpiresAt) {
+		session.Status = "expired"
+		p.configStore.UpdateOauthUserSession(ctx, session)
+		return "", fmt.Errorf("per-user oauth flow expired")
+	}
+
+	// Load template OAuth config for token_url, client_id, etc.
+	templateConfig, err := p.configStore.GetOauthConfigByID(ctx, session.OauthConfigID)
+	if err != nil || templateConfig == nil {
+		session.Status = "failed"
+		p.configStore.UpdateOauthUserSession(ctx, session)
+		return "", fmt.Errorf("failed to load template oauth config: %w", err)
+	}
+
+	// Exchange code for tokens with PKCE verifier
+	// Use the redirect URI stored in the session (same one used in authorize step)
+	// to satisfy OAuth spec requirement that redirect_uri must match
+	redirectURI := session.RedirectURI
+	if redirectURI == "" {
+		redirectURI = templateConfig.RedirectURI
+	}
+	tokenResponse, err := p.exchangeCodeForTokensWithPKCE(
+		templateConfig.TokenURL,
+		code,
+		templateConfig.ClientID,
+		templateConfig.ClientSecret,
+		redirectURI,
+		session.CodeVerifier,
+	)
+	if err != nil {
+		session.Status = "failed"
+		p.configStore.UpdateOauthUserSession(ctx, session)
+		return "", fmt.Errorf("per-user token exchange failed: %w", err)
+	}
+
+	// Use existing session token if set (e.g., Bifrost session ID from MCP spec OAuth flow),
+	// otherwise generate a new one (for standalone per-user OAuth via X-Bifrost-MCP-Session header).
+	sessionToken := session.SessionToken
+	if sessionToken == "" {
+		sessionToken, err = generateSessionToken()
+		if err != nil {
+			session.Status = "failed"
+			p.configStore.UpdateOauthUserSession(ctx, session)
+			return "", err
+		}
+	}
+
+	// Parse scopes
+	var scopes []string
+	if tokenResponse.Scope != "" {
+		scopes = strings.Split(tokenResponse.Scope, " ")
+	}
+	scopesJSON, _ := json.Marshal(scopes)
+
+	// Create per-user OAuth token record, propagating identity from session
+	tokenRecord := &tables.TableOauthUserToken{
+		ID:            uuid.New().String(),
+		SessionToken:  sessionToken,
+		VirtualKeyID:  session.VirtualKeyID,
+		UserID:        session.UserID,
+		MCPClientID:   session.MCPClientID,
+		OauthConfigID: session.OauthConfigID,
+		AccessToken:   strings.TrimSpace(tokenResponse.AccessToken),
+		RefreshToken:  strings.TrimSpace(tokenResponse.RefreshToken),
+		TokenType:     tokenResponse.TokenType,
+		ExpiresAt:     time.Now().Add(time.Duration(tokenResponse.ExpiresIn) * time.Second),
+		Scopes:        string(scopesJSON),
+	}
+
+	if err := p.configStore.CreateOauthUserToken(ctx, tokenRecord); err != nil {
+		return "", fmt.Errorf("failed to create per-user oauth token: %w", err)
+	}
+
+	// Update session with session token and mark as authorized
+	session.SessionToken = sessionToken
+	session.Status = "authorized"
+	if err := p.configStore.UpdateOauthUserSession(ctx, session); err != nil {
+		return "", fmt.Errorf("failed to update per-user oauth session: %w", err)
+	}
+
+	logger.Debug("Per-user OAuth flow completed: session_id=%s, mcp_client_id=%s", session.ID, session.MCPClientID)
+
+	return sessionToken, nil
+}
+
+// GetUserAccessToken retrieves the access token for a per-user OAuth session.
+// If the token is expired, it automatically attempts a refresh.
+func (p *OAuth2Provider) GetUserAccessToken(ctx context.Context, sessionToken string) (string, error) {
+	token, err := p.configStore.GetOauthUserTokenBySessionToken(ctx, sessionToken)
+	if err != nil {
+		return "", fmt.Errorf("failed to load per-user oauth token: %w", err)
+	}
+	if token == nil {
+		return "", fmt.Errorf("per-user oauth token not found for session")
+	}
+
+	// Check if token is expired
+	if time.Now().After(token.ExpiresAt) {
+		if err := p.RefreshUserAccessToken(ctx, sessionToken); err != nil {
+			return "", fmt.Errorf("per-user token expired and refresh failed: %w", err)
+		}
+		// Reload token after refresh
+		token, err = p.configStore.GetOauthUserTokenBySessionToken(ctx, sessionToken)
+		if err != nil || token == nil {
+			return "", fmt.Errorf("failed to reload per-user token after refresh")
+		}
+	}
+
+	accessToken := strings.TrimSpace(token.AccessToken)
+	if accessToken == "" {
+		return "", fmt.Errorf("per-user access token is empty after sanitization")
+	}
+	return accessToken, nil
+}
+
+// GetUserAccessTokenByIdentity retrieves the upstream access token for a user
+// identified by virtualKeyID, userID, or sessionToken (fallback), for a specific
+// MCP client. Identity-based lookups persist tokens across sessions so users don't
+// need to re-authenticate with upstream providers on reconnect.
+func (p *OAuth2Provider) GetUserAccessTokenByIdentity(ctx context.Context, virtualKeyID, userID, sessionToken, mcpClientID string) (string, error) {
+	token, err := p.configStore.GetOauthUserTokenByIdentity(ctx, virtualKeyID, userID, sessionToken, mcpClientID)
+	if err != nil {
+		return "", fmt.Errorf("failed to load per-user oauth token by identity: %w", err)
+	}
+	if token == nil {
+		return "", fmt.Errorf("per-user oauth token not found for this user and MCP server")
+	}
+
+	// Check if token is expired — attempt refresh
+	if time.Now().After(token.ExpiresAt) {
+		if token.SessionToken != "" {
+			if err := p.RefreshUserAccessToken(ctx, token.SessionToken); err != nil {
+				return "", fmt.Errorf("per-user token expired and refresh failed: %w", err)
+			}
+			// Reload after refresh
+			token, err = p.configStore.GetOauthUserTokenByIdentity(ctx, virtualKeyID, userID, sessionToken, mcpClientID)
+			if err != nil || token == nil {
+				return "", fmt.Errorf("failed to reload per-user token after refresh")
+			}
+		} else {
+			return "", fmt.Errorf("per-user token expired and no session token available for refresh")
+		}
+	}
+
+	accessToken := strings.TrimSpace(token.AccessToken)
+	if accessToken == "" {
+		return "", fmt.Errorf("per-user access token is empty after sanitization")
+	}
+	return accessToken, nil
+}
+
+// RefreshUserAccessToken refreshes a per-user OAuth access token.
+func (p *OAuth2Provider) RefreshUserAccessToken(ctx context.Context, sessionToken string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	token, err := p.configStore.GetOauthUserTokenBySessionToken(ctx, sessionToken)
+	if err != nil || token == nil {
+		return fmt.Errorf("per-user oauth token not found: %w", err)
+	}
+
+	if token.RefreshToken == "" {
+		return fmt.Errorf("no refresh token available for per-user oauth session")
+	}
+
+	// Load template OAuth config for token_url, client_id, etc.
+	templateConfig, err := p.configStore.GetOauthConfigByID(ctx, token.OauthConfigID)
+	if err != nil || templateConfig == nil {
+		return fmt.Errorf("failed to load template oauth config for refresh: %w", err)
+	}
+
+	// Exchange refresh token
+	newTokenResponse, err := p.exchangeRefreshToken(
+		templateConfig.TokenURL,
+		templateConfig.ClientID,
+		templateConfig.ClientSecret,
+		token.RefreshToken,
+	)
+	if err != nil {
+		return fmt.Errorf("per-user token refresh failed: %w", err)
+	}
+
+	// Update token
+	now := time.Now()
+	token.AccessToken = strings.TrimSpace(newTokenResponse.AccessToken)
+	if newTokenResponse.RefreshToken != "" {
+		token.RefreshToken = strings.TrimSpace(newTokenResponse.RefreshToken)
+	}
+	token.ExpiresAt = now.Add(time.Duration(newTokenResponse.ExpiresIn) * time.Second)
+	token.LastRefreshedAt = &now
+
+	if err := p.configStore.UpdateOauthUserToken(ctx, token); err != nil {
+		return fmt.Errorf("failed to update per-user token after refresh: %w", err)
+	}
+
+	logger.Debug("Per-user OAuth token refreshed: session_token=...%s", sessionToken[len(sessionToken)-4:])
+	return nil
+}
+
+// RevokeUserToken revokes a per-user OAuth token and marks the session as revoked.
+func (p *OAuth2Provider) RevokeUserToken(ctx context.Context, sessionToken string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	token, err := p.configStore.GetOauthUserTokenBySessionToken(ctx, sessionToken)
+	if err != nil || token == nil {
+		return fmt.Errorf("per-user oauth token not found: %w", err)
+	}
+
+	// Delete the token
+	if err := p.configStore.DeleteOauthUserToken(ctx, token.ID); err != nil {
+		return fmt.Errorf("failed to delete per-user oauth token: %w", err)
+	}
+
+	// Update session status
+	session, err := p.configStore.GetOauthUserSessionBySessionToken(ctx, sessionToken)
+	if err == nil && session != nil {
+		session.Status = "revoked"
+		p.configStore.UpdateOauthUserSession(ctx, session)
+	}
+
+	logger.Debug("Per-user OAuth token revoked: session_token=...%s", sessionToken[len(sessionToken)-4:])
+	return nil
+}

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -27,6 +27,11 @@ type MCPManager interface {
 	RemoveMCPClient(ctx context.Context, id string) error
 	UpdateMCPClient(ctx context.Context, id string, updatedConfig *schemas.MCPClientConfig) error
 	ReconnectMCPClient(ctx context.Context, id string) error
+	// VerifyPerUserOAuthConnection verifies an MCP server using a temporary access
+	// token and discovers available tools. The connection is closed after verification.
+	VerifyPerUserOAuthConnection(ctx context.Context, config *schemas.MCPClientConfig, accessToken string) (map[string]schemas.ChatTool, map[string]string, error)
+	// SetClientTools updates the tool map for an existing client.
+	SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string)
 }
 
 // MCPHandler manages HTTP requests for MCP tool operations
@@ -378,7 +383,94 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// Check if OAuth flow is needed
+	// Handle per-user OAuth: admin does a test OAuth login to verify the configuration.
+	// Uses the same pending_oauth pattern as server-level OAuth, but on completion we
+	// verify the connection, discover tools, save the client, and discard the admin's token.
+	if req.AuthType == "per_user_oauth" {
+		if req.OauthConfig == nil {
+			SendError(ctx, fasthttp.StatusBadRequest, "OAuth configuration is required when auth_type is 'per_user_oauth'")
+			return
+		}
+
+		if req.OauthConfig.ClientID == "" && req.ConnectionString.GetValue() == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "Either client_id must be provided, or server URL must be set for OAuth discovery and dynamic client registration")
+			return
+		}
+
+		scheme := "http"
+		if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
+			scheme = "https"
+		}
+		host := string(ctx.Host())
+		redirectURI := fmt.Sprintf("%s://%s/api/oauth/callback", scheme, host)
+
+		flowInitiation, err := h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
+			ClientID:        req.OauthConfig.ClientID,
+			ClientSecret:    req.OauthConfig.ClientSecret,
+			AuthorizeURL:    req.OauthConfig.AuthorizeURL,
+			TokenURL:        req.OauthConfig.TokenURL,
+			RegistrationURL: req.OauthConfig.RegistrationURL,
+			RedirectURI:     redirectURI,
+			Scopes:          req.OauthConfig.Scopes,
+			ServerURL:       req.ConnectionString.GetValue(),
+		})
+		if err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initiate OAuth flow: %v", err))
+			return
+		}
+
+		toolSyncInterval := mcp.DefaultToolSyncInterval
+		if req.ToolSyncInterval != 0 {
+			toolSyncInterval = time.Duration(req.ToolSyncInterval) * time.Minute
+		} else {
+			config, err := h.store.ConfigStore.GetClientConfig(ctx)
+			if err == nil && config != nil {
+				toolSyncInterval = time.Duration(config.MCPToolSyncInterval) * time.Minute
+			}
+		}
+
+		isPingAvailable := true
+		if req.IsPingAvailable != nil {
+			isPingAvailable = *req.IsPingAvailable
+		}
+
+		pendingConfig := schemas.MCPClientConfig{
+			ID:                 req.ClientID,
+			Name:               req.Name,
+			IsCodeModeClient:   req.IsCodeModeClient,
+			IsPingAvailable:    &isPingAvailable,
+			ToolSyncInterval:   toolSyncInterval,
+			ConnectionType:     schemas.MCPConnectionType(req.ConnectionType),
+			ConnectionString:   req.ConnectionString,
+			StdioConfig:        req.StdioConfig,
+			AuthType:           schemas.MCPAuthTypePerUserOauth,
+			OauthConfigID:      &flowInitiation.OauthConfigID,
+			ToolsToExecute:     req.ToolsToExecute,
+			ToolsToAutoExecute: req.ToolsToAutoExecute,
+			ToolPricing:           req.ToolPricing,
+			Headers:               req.Headers,
+			AllowedExtraHeaders:   req.AllowedExtraHeaders,
+			AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
+		}
+
+		if err := h.oauthHandler.StorePendingMCPClient(flowInitiation.OauthConfigID, pendingConfig); err != nil {
+			logger.Error(fmt.Sprintf("[Add MCP Client] Failed to store pending MCP client: %v", err))
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to store pending MCP client: %v", err))
+			return
+		}
+
+		SendJSON(ctx, map[string]any{
+			"status":          "pending_oauth",
+			"message":         "Test OAuth configuration: please authorize to verify the setup. This login is only used to verify connectivity and discover available tools — it will not be saved.",
+			"oauth_config_id": flowInitiation.OauthConfigID,
+			"authorize_url":   flowInitiation.AuthorizeURL,
+			"expires_at":      flowInitiation.ExpiresAt,
+			"mcp_client_id":   req.ClientID,
+		})
+		return
+	}
+
+	// Check if server-level OAuth flow is needed
 	if req.AuthType == "oauth" {
 		if req.OauthConfig == nil {
 			SendError(ctx, fasthttp.StatusBadRequest, "OAuth configuration is required when auth_type is 'oauth'")
@@ -933,7 +1025,68 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// Creating MCP client config in config store
+	// Handle per-user OAuth completion: verify connection with admin's temp token,
+	// discover tools, create client (without persistent connection), discard token.
+	if mcpClientConfig.AuthType == schemas.MCPAuthTypePerUserOauth {
+		// Get admin's temporary access token for verification
+		accessToken, err := h.oauthHandler.GetAccessToken(ctx, oauthConfigID)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get admin access token for verification: %v", err))
+			return
+		}
+		// Always clean up admin's temp token and pending config, even on failure
+		defer h.oauthHandler.RevokeToken(ctx, oauthConfigID)
+		defer h.oauthHandler.RemovePendingMCPClient(oauthConfigID)
+
+		// Verify connection and discover tools using admin's temp token
+		tools, toolNameMapping, err := h.mcpManager.VerifyPerUserOAuthConnection(ctx, mcpClientConfig, accessToken)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("OAuth configuration test failed: %v", err))
+			return
+		}
+
+		// Persist MCP client config in config store
+		if h.store.ConfigStore != nil {
+			if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, mcpClientConfig); err != nil {
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
+				return
+			}
+		}
+
+		// Add MCP client to manager (skips connection for per_user_oauth)
+		if err := h.mcpManager.AddMCPClient(ctx, mcpClientConfig); err != nil {
+			// Clean up DB entry on failure
+			if h.store.ConfigStore != nil {
+				if delErr := h.store.ConfigStore.DeleteMCPClientConfig(ctx, mcpClientConfig.ID); delErr != nil {
+					logger.Error(fmt.Sprintf("Failed to delete MCP client config from database: %v. please restart bifrost to keep core and database in sync", delErr))
+					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to delete MCP client config from database: %v. please restart bifrost to keep core and database in sync", delErr))
+					return
+				}
+			}
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to register MCP client: %v", err))
+			return
+		}
+
+		// Set discovered tools on the client
+		h.mcpManager.SetClientTools(mcpClientConfig.ID, tools, toolNameMapping)
+
+		// Persist discovered tools to DB so they survive restart
+		if h.store.ConfigStore != nil {
+			if err := h.store.ConfigStore.UpdateMCPClientDiscoveredTools(ctx, mcpClientConfig.ID, tools, toolNameMapping); err != nil {
+				logger.Warn(fmt.Sprintf("[OAuth Complete] Failed to persist discovered tools for %s: %v", mcpClientConfig.ID, err))
+			}
+		}
+
+		logger.Debug(fmt.Sprintf("[OAuth Complete] Per-user OAuth MCP client verified and created: %s (%d tools)", mcpClientConfig.ID, len(tools)))
+		SendJSON(ctx, map[string]any{
+			"status":      "success",
+			"message":     fmt.Sprintf("OAuth configuration verified successfully. %d tools discovered. Each user will authenticate individually when using this MCP server.", len(tools)),
+			"tools_count": len(tools),
+		})
+		return
+	}
+
+	// Standard server-level OAuth completion
 	if h.store.ConfigStore != nil {
 		if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, mcpClientConfig); err != nil {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/fasthttp/router"
@@ -30,11 +31,12 @@ type MCPToolManager interface {
 // MCPServerHandler manages HTTP requests for MCP server operations
 // It implements the MCP protocol over HTTP streaming (SSE) for MCP clients
 type MCPServerHandler struct {
-	toolManager     MCPToolManager
-	globalMCPServer *server.MCPServer
-	vkMCPServers    map[string]*server.MCPServer // Map of vk value -> mcp server
-	config          *lib.Config
-	mu              sync.RWMutex
+	toolManager          MCPToolManager
+	globalMCPServer      *server.MCPServer
+	vkMCPServers         map[string]*server.MCPServer // Map of vk value -> mcp server
+	config               *lib.Config
+	hasPerUserOAuthServers bool // Whether any per_user_oauth MCP servers are configured
+	mu                   sync.RWMutex
 }
 
 // NewMCPServerHandler creates a new MCP server handler instance
@@ -399,6 +401,15 @@ func (h *MCPServerHandler) makeIncludeClientsFilter() server.ToolFilterFunc {
 
 // Utility methods
 
+// SetHasPerUserOAuthServers updates whether any per_user_oauth MCP servers are
+// configured. When true, the /mcp endpoint returns 401 with WWW-Authenticate
+// for unauthenticated requests to trigger the MCP spec OAuth flow.
+func (h *MCPServerHandler) SetHasPerUserOAuthServers(value bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.hasPerUserOAuthServers = value
+}
+
 func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*server.MCPServer, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
@@ -408,6 +419,43 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*se
 	h.config.Mu.RUnlock()
 
 	vk := getVKFromRequest(ctx)
+
+	// Check for Bifrost per-user OAuth Bearer token (not a VK)
+	perUserSession := h.getPerUserOAuthSession(ctx)
+
+	// If per_user_oauth servers are configured and no valid auth, return 401 with discovery
+	if h.hasPerUserOAuthServers && vk == "" && perUserSession == nil {
+		if !enforceVK {
+			// Even without enforced VK, per_user_oauth servers require auth
+			scheme := "http"
+			if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
+				scheme = "https"
+			}
+			host := string(ctx.Host())
+			resourceMetadataURL := fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource", scheme, host)
+			ctx.Response.Header.Set("WWW-Authenticate",
+				fmt.Sprintf(`Bearer resource_metadata="%s"`, resourceMetadataURL))
+			return nil, fmt.Errorf("OAuth authentication required for MCP access")
+		}
+	}
+
+	// If a per-user OAuth session is present, inject it into context and use global server.
+	// Also attach user identity to the session if not already set (first request after auth).
+	if perUserSession != nil {
+		// Propagate the access token so ConvertToBifrostContext picks it up
+		// and downstream tool execution can find the per-user OAuth session.
+		if perUserSession.AccessToken != "" {
+			ctx.Request.Header.Set("X-Bifrost-MCP-Session", perUserSession.AccessToken)
+		}
+		ctx.SetUserValue(string(schemas.BifrostContextKeyMCPUserSession), perUserSession.AccessToken)
+
+		// Identity (VirtualKeyID, UserID) is resolved by governance middleware downstream.
+		// Do not store the raw VK secret here — governance resolves the actual VK ID.
+
+		if vk == "" {
+			return h.globalMCPServer, nil
+		}
+	}
 
 	// Return global MCP server if not enforcing virtual key header and no virtual key is provided
 	if !enforceVK && vk == "" {
@@ -426,6 +474,35 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*se
 	}
 
 	return vkServer, nil
+}
+
+// getPerUserOAuthSession extracts and validates a Bifrost-issued per-user OAuth
+// token from the Authorization header. Returns the session if valid, nil otherwise.
+func (h *MCPServerHandler) getPerUserOAuthSession(ctx *fasthttp.RequestCtx) *tables.TablePerUserOAuthSession {
+	authHeader := strings.TrimSpace(string(ctx.Request.Header.Peek("Authorization")))
+	if authHeader == "" || !strings.HasPrefix(strings.ToLower(authHeader), "bearer ") {
+		return nil
+	}
+	token := strings.TrimSpace(authHeader[7:])
+	if token == "" || strings.HasPrefix(strings.ToLower(token), governance.VirtualKeyPrefix) {
+		return nil // It's a virtual key, not a per-user OAuth token
+	}
+
+	if h.config.ConfigStore == nil {
+		return nil
+	}
+
+	session, err := h.config.ConfigStore.GetPerUserOAuthSessionByAccessToken(ctx, token)
+	if err != nil || session == nil {
+		return nil
+	}
+
+	// Check expiry
+	if session.ExpiresAt.Before(time.Now()) {
+		return nil
+	}
+
+	return session
 }
 
 func getVKFromRequest(ctx *fasthttp.RequestCtx) string {

--- a/transports/bifrost-http/handlers/oauth2.go
+++ b/transports/bifrost-http/handlers/oauth2.go
@@ -5,6 +5,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html"
 
@@ -59,7 +60,45 @@ func (h *OAuthHandler) handleOAuthCallback(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// Complete OAuth flow
+	// Try per-user OAuth runtime flow first (state from oauth_user_sessions table).
+	// This handles the case where an end-user authenticates during inference.
+	sessionToken, perUserErr := h.oauthProvider.CompleteUserOAuthFlow(context.Background(), state, code)
+	if perUserErr != nil && !errors.Is(perUserErr, schemas.ErrOAuth2NotPerUserSession) {
+		// Real per-user error (not "state not found") — don't fall through to admin flow
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Per-user OAuth flow failed: %v", perUserErr))
+		return
+	}
+	if perUserErr == nil && sessionToken != "" {
+		// Per-user runtime OAuth flow completed — show session token
+		ctx.SetStatusCode(fasthttp.StatusOK)
+		ctx.SetContentType("text/html")
+		ctx.SetBodyString(`
+			<!DOCTYPE html>
+			<html>
+			<head>
+				<title>Authorization Successful</title>
+				<script>
+					if (window.opener) {
+						window.opener.postMessage({ type: 'oauth_success' }, window.location.origin);
+						window.close();
+					}
+				</script>
+			</head>
+			<body>
+				<div style="display: flex; align-items: center; justify-content: center; height: 100vh; font-family: system-ui;">
+					<div style="text-align: center;">
+						<h1>Authorization Successful</h1>
+						<p style="color: #666; font-size: 13px;">You can close this tab.</p>
+					</div>
+				</div>
+			</body>
+			</html>
+		`)
+		return
+	}
+
+	// Fall through to standard OAuth flow (handles both admin test logins for
+	// per_user_oauth setup and regular server-level OAuth).
 	if err := h.oauthProvider.CompleteOAuthFlow(context.Background(), state, code); err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("OAuth flow completion failed: %v", err))
 		return
@@ -86,7 +125,7 @@ func (h *OAuthHandler) handleOAuthCallback(ctx *fasthttp.RequestCtx) {
 		<body>
 			<div style="display: flex; align-items: center; justify-content: center; height: 100vh; font-family: system-ui;">
 				<div style="text-align: center;">
-					<h1>✓ Authorization Successful</h1>
+					<h1>Authorization Successful</h1>
 					<p id="message">This window will close automatically...</p>
 				</div>
 			</div>
@@ -245,7 +284,25 @@ func (h *OAuthHandler) GetPendingMCPClientByState(state string) (*schemas.MCPCli
 	return h.oauthProvider.GetPendingMCPClientByState(state)
 }
 
-// RemovePendingMCPClient removes a pending MCP client after OAuth completion
+// RemovePendingMCPClient removes a pending MCP client after OAuth completion.
 func (h *OAuthHandler) RemovePendingMCPClient(oauthConfigID string) error {
 	return h.oauthProvider.RemovePendingMCPClient(oauthConfigID)
+}
+
+// GetAccessToken retrieves the access token for a given oauth_config_id.
+// Used during per-user OAuth setup to get the admin's temporary token for verification.
+func (h *OAuthHandler) GetAccessToken(ctx context.Context, oauthConfigID string) (string, error) {
+	return h.oauthProvider.GetAccessToken(ctx, oauthConfigID)
+}
+
+// jsEscapeString returns a JSON-encoded string (with quotes) safe for embedding in JavaScript.
+func jsEscapeString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// RevokeToken revokes the OAuth token for a given oauth_config_id.
+// Used during per-user OAuth setup to discard the admin's temporary token after verification.
+func (h *OAuthHandler) RevokeToken(ctx context.Context, oauthConfigID string) error {
+	return h.oauthProvider.RevokeToken(ctx, oauthConfigID)
 }

--- a/transports/bifrost-http/handlers/oauth2_metadata.go
+++ b/transports/bifrost-http/handlers/oauth2_metadata.go
@@ -1,0 +1,85 @@
+// Package handlers provides HTTP request handlers for the Bifrost HTTP transport.
+// This file implements OAuth 2.0 metadata discovery endpoints per RFC 9728
+// (Protected Resource Metadata) and RFC 8414 (Authorization Server Metadata).
+// These endpoints enable MCP-spec-compliant clients (like Claude Code) to
+// automatically discover Bifrost's OAuth configuration and authenticate.
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/fasthttp/router"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// OAuthMetadataHandler serves OAuth 2.0 discovery metadata endpoints.
+// It provides the Protected Resource Metadata (RFC 9728) and Authorization
+// Server Metadata (RFC 8414) that MCP clients use to discover how to
+// authenticate with Bifrost's MCP server endpoint.
+type OAuthMetadataHandler struct {
+	store *lib.Config
+}
+
+// NewOAuthMetadataHandler creates a new OAuth metadata handler instance.
+func NewOAuthMetadataHandler(store *lib.Config) *OAuthMetadataHandler {
+	return &OAuthMetadataHandler{store: store}
+}
+
+// RegisterRoutes registers the well-known metadata discovery routes.
+// These routes do NOT go through auth middleware since they must be
+// accessible to unauthenticated clients during OAuth discovery.
+func (h *OAuthMetadataHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	// RFC 9728: Protected Resource Metadata
+	r.GET("/.well-known/oauth-protected-resource", lib.ChainMiddlewares(h.handleProtectedResourceMetadata, middlewares...))
+	// RFC 8414: Authorization Server Metadata
+	r.GET("/.well-known/oauth-authorization-server", lib.ChainMiddlewares(h.handleAuthorizationServerMetadata, middlewares...))
+}
+
+// handleProtectedResourceMetadata serves the Protected Resource Metadata
+// document per RFC 9728. MCP clients fetch this after receiving a 401 response
+// to discover which authorization server(s) protect the MCP resource.
+//
+// GET /.well-known/oauth-protected-resource
+func (h *OAuthMetadataHandler) handleProtectedResourceMetadata(ctx *fasthttp.RequestCtx) {
+	scheme := "http"
+	if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
+		scheme = "https"
+	}
+	host := string(ctx.Host())
+	baseURL := fmt.Sprintf("%s://%s", scheme, host)
+
+	SendJSON(ctx, map[string]interface{}{
+		"resource":                 baseURL + "/mcp",
+		"authorization_servers":    []string{baseURL},
+		"scopes_supported":        []string{"mcp:read", "mcp:write"},
+		"bearer_methods_supported": []string{"header"},
+	})
+}
+
+// handleAuthorizationServerMetadata serves the Authorization Server Metadata
+// document per RFC 8414. MCP clients use this to discover Bifrost's OAuth
+// endpoints (authorize, token, register) and supported capabilities.
+//
+// GET /.well-known/oauth-authorization-server
+func (h *OAuthMetadataHandler) handleAuthorizationServerMetadata(ctx *fasthttp.RequestCtx) {
+	scheme := "http"
+	if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
+		scheme = "https"
+	}
+	host := string(ctx.Host())
+	baseURL := fmt.Sprintf("%s://%s", scheme, host)
+
+	SendJSON(ctx, map[string]interface{}{
+		"issuer":                                baseURL,
+		"authorization_endpoint":                baseURL + "/api/oauth/per-user/authorize",
+		"token_endpoint":                        baseURL + "/api/oauth/per-user/token",
+		"registration_endpoint":                 baseURL + "/api/oauth/per-user/register",
+		"response_types_supported":              []string{"code"},
+		"grant_types_supported":                 []string{"authorization_code"},
+		"code_challenge_methods_supported":       []string{"S256"},
+		"token_endpoint_auth_methods_supported": []string{"none"},
+		"scopes_supported":                      []string{"mcp:read", "mcp:write"},
+	})
+}

--- a/transports/bifrost-http/handlers/oauth2_per_user.go
+++ b/transports/bifrost-http/handlers/oauth2_per_user.go
@@ -1,0 +1,457 @@
+// Package handlers provides HTTP request handlers for the Bifrost HTTP transport.
+// This file implements Bifrost's OAuth 2.1 Authorization Server for per-user MCP
+// authentication. It provides Dynamic Client Registration (RFC 7591), Authorization
+// Code flow with PKCE, and token issuance. MCP clients (Claude Code, IDEs) use
+// these endpoints to authenticate users before accessing Bifrost's /mcp endpoint.
+package handlers
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/fasthttp/router"
+	"github.com/google/uuid"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// PerUserOAuthHandler implements Bifrost's OAuth 2.1 Authorization Server.
+// It handles dynamic client registration, authorization code issuance with PKCE,
+// and token exchange for MCP per-user authentication.
+type PerUserOAuthHandler struct {
+	store *lib.Config
+}
+
+// NewPerUserOAuthHandler creates a new per-user OAuth handler instance.
+func NewPerUserOAuthHandler(store *lib.Config) *PerUserOAuthHandler {
+	return &PerUserOAuthHandler{store: store}
+}
+
+// RegisterRoutes registers the per-user OAuth authorization server routes.
+// These routes do NOT go through auth middleware since they are part of the
+// OAuth flow that unauthenticated clients use to obtain tokens.
+func (h *PerUserOAuthHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	r.POST("/api/oauth/per-user/register", lib.ChainMiddlewares(h.handleDynamicClientRegistration, middlewares...))
+	r.GET("/api/oauth/per-user/authorize", lib.ChainMiddlewares(h.handleAuthorize, middlewares...))
+	r.POST("/api/oauth/per-user/token", lib.ChainMiddlewares(h.handleToken, middlewares...))
+	r.GET("/api/oauth/per-user/upstream/authorize", lib.ChainMiddlewares(h.handleUpstreamAuthorize, middlewares...))
+}
+
+// handleDynamicClientRegistration handles OAuth 2.0 Dynamic Client Registration
+// per RFC 7591. MCP clients register themselves to obtain a client_id.
+//
+// POST /api/oauth/per-user/register
+func (h *PerUserOAuthHandler) handleDynamicClientRegistration(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "OAuth registration unavailable: config store is disabled")
+		return
+	}
+
+	var req struct {
+		ClientName              string   `json:"client_name"`
+		RedirectURIs            []string `json:"redirect_uris"`
+		GrantTypes              []string `json:"grant_types"`
+		ResponseTypes           []string `json:"response_types"`
+		TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+		Scope                   string   `json:"scope"`
+	}
+
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid registration request: %v", err))
+		return
+	}
+
+	if len(req.RedirectURIs) == 0 {
+		SendError(ctx, fasthttp.StatusBadRequest, "redirect_uris is required")
+		return
+	}
+
+	// Generate client_id
+	clientID := uuid.New().String()
+
+	// Serialize arrays
+	redirectURIsJSON, _ := json.Marshal(req.RedirectURIs)
+	grantTypes := req.GrantTypes
+	if len(grantTypes) == 0 {
+		grantTypes = []string{"authorization_code"}
+	}
+	grantTypesJSON, _ := json.Marshal(grantTypes)
+
+	client := &tables.TablePerUserOAuthClient{
+		ID:           uuid.New().String(),
+		ClientID:     clientID,
+		ClientName:   req.ClientName,
+		RedirectURIs: string(redirectURIsJSON),
+		GrantTypes:   string(grantTypesJSON),
+	}
+
+	if err := h.store.ConfigStore.CreatePerUserOAuthClient(ctx, client); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to register client: %v", err))
+		return
+	}
+
+	// Return RFC 7591 response
+	ctx.SetStatusCode(fasthttp.StatusCreated)
+	SendJSON(ctx, map[string]interface{}{
+		"client_id":                  clientID,
+		"client_name":               req.ClientName,
+		"redirect_uris":             req.RedirectURIs,
+		"grant_types":               grantTypes,
+		"response_types":            req.ResponseTypes,
+		"token_endpoint_auth_method": "none",
+	})
+}
+
+// handleAuthorize handles the OAuth 2.1 authorization endpoint.
+// It validates the request, shows a consent page, and issues an authorization code.
+//
+// GET /api/oauth/per-user/authorize?response_type=code&client_id=xxx&redirect_uri=xxx&state=xxx&code_challenge=xxx&code_challenge_method=S256
+func (h *PerUserOAuthHandler) handleAuthorize(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "OAuth authorization unavailable: config store is disabled")
+		return
+	}
+
+	// Extract parameters
+	responseType := string(ctx.QueryArgs().Peek("response_type"))
+	clientID := string(ctx.QueryArgs().Peek("client_id"))
+	redirectURI := string(ctx.QueryArgs().Peek("redirect_uri"))
+	state := string(ctx.QueryArgs().Peek("state"))
+	codeChallenge := string(ctx.QueryArgs().Peek("code_challenge"))
+	codeChallengeMethod := string(ctx.QueryArgs().Peek("code_challenge_method"))
+	scope := string(ctx.QueryArgs().Peek("scope"))
+
+	// Validate required parameters
+	if responseType != "code" {
+		SendError(ctx, fasthttp.StatusBadRequest, "response_type must be 'code'")
+		return
+	}
+	if clientID == "" || redirectURI == "" || state == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "client_id, redirect_uri, and state are required")
+		return
+	}
+	if codeChallenge == "" || codeChallengeMethod != "S256" {
+		SendError(ctx, fasthttp.StatusBadRequest, "PKCE is required: code_challenge and code_challenge_method=S256")
+		return
+	}
+
+	// Validate client exists and redirect_uri is allowed
+	client, err := h.store.ConfigStore.GetPerUserOAuthClientByClientID(ctx, clientID)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to validate client: %v", err))
+		return
+	}
+	if client == nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "Unknown client_id")
+		return
+	}
+
+	// Verify redirect_uri is registered
+	var allowedURIs []string
+	json.Unmarshal([]byte(client.RedirectURIs), &allowedURIs)
+	uriAllowed := false
+	for _, allowed := range allowedURIs {
+		if allowed == redirectURI {
+			uriAllowed = true
+			break
+		}
+	}
+	if !uriAllowed {
+		SendError(ctx, fasthttp.StatusBadRequest, "redirect_uri not registered for this client")
+		return
+	}
+
+	// Generate authorization code
+	code, err := generateOpaqueToken(32)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to generate authorization code")
+		return
+	}
+
+	// Store authorization code
+	codeRecord := &tables.TablePerUserOAuthCode{
+		ID:            uuid.New().String(),
+		Code:          code,
+		ClientID:      clientID,
+		RedirectURI:   redirectURI,
+		CodeChallenge: codeChallenge,
+		Scopes:        scope,
+		ExpiresAt:     time.Now().Add(5 * time.Minute),
+	}
+	if err := h.store.ConfigStore.CreatePerUserOAuthCode(ctx, codeRecord); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to store authorization code: %v", err))
+		return
+	}
+
+	// Auto-approve and redirect back with code (no consent page for MCP clients)
+	// Build redirect URL with code and state
+	redirectURL, err := url.Parse(redirectURI)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "Invalid redirect_uri")
+		return
+	}
+	q := redirectURL.Query()
+	q.Set("code", code)
+	q.Set("state", state)
+	redirectURL.RawQuery = q.Encode()
+
+	ctx.Redirect(redirectURL.String(), fasthttp.StatusFound)
+}
+
+// handleToken handles the OAuth 2.1 token endpoint.
+// It validates the authorization code + PKCE verifier and issues access/refresh tokens.
+//
+// POST /api/oauth/per-user/token
+func (h *PerUserOAuthHandler) handleToken(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "OAuth token endpoint unavailable: config store is disabled")
+		return
+	}
+
+	// Parse form-encoded body
+	grantType := string(ctx.FormValue("grant_type"))
+	code := string(ctx.FormValue("code"))
+	redirectURI := string(ctx.FormValue("redirect_uri"))
+	clientID := string(ctx.FormValue("client_id"))
+	codeVerifier := string(ctx.FormValue("code_verifier"))
+
+	if grantType != "authorization_code" {
+		sendOAuthError(ctx, fasthttp.StatusBadRequest, "unsupported_grant_type", "Only authorization_code grant is supported")
+		return
+	}
+
+	if code == "" || clientID == "" || codeVerifier == "" {
+		sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_request", "code, client_id, and code_verifier are required")
+		return
+	}
+
+	// Atomically claim authorization code (prevents concurrent redemption)
+	codeRecord, err := h.store.ConfigStore.ClaimPerUserOAuthCode(ctx, code)
+	if err != nil {
+		sendOAuthError(ctx, fasthttp.StatusInternalServerError, "server_error", "Failed to validate code")
+		return
+	}
+	if codeRecord == nil {
+		sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_grant", "Invalid or already used authorization code")
+		return
+	}
+
+	// Validate code is not expired
+	if time.Now().After(codeRecord.ExpiresAt) {
+		sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_grant", "Authorization code expired")
+		return
+	}
+
+	// Validate client_id matches
+	if codeRecord.ClientID != clientID {
+		sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_grant", "client_id mismatch")
+		return
+	}
+
+	// Validate redirect_uri matches
+	if redirectURI != "" && codeRecord.RedirectURI != redirectURI {
+		sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_grant", "redirect_uri mismatch")
+		return
+	}
+
+	// Validate PKCE: SHA256(code_verifier) must match code_challenge
+	verifierHash := sha256.Sum256([]byte(codeVerifier))
+	computedChallenge := base64.RawURLEncoding.EncodeToString(verifierHash[:])
+	if computedChallenge != codeRecord.CodeChallenge {
+		sendOAuthError(ctx, fasthttp.StatusBadRequest, "invalid_grant", "PKCE verification failed")
+		return
+	}
+
+	// Generate access token and refresh token
+	accessToken, err := generateOpaqueToken(32)
+	if err != nil {
+		sendOAuthError(ctx, fasthttp.StatusInternalServerError, "server_error", "Failed to generate access token")
+		return
+	}
+	refreshToken, err := generateOpaqueToken(32)
+	if err != nil {
+		sendOAuthError(ctx, fasthttp.StatusInternalServerError, "server_error", "Failed to generate refresh token")
+		return
+	}
+
+	// Store session
+	expiresAt := time.Now().Add(24 * time.Hour) // 24-hour access token
+	session := &tables.TablePerUserOAuthSession{
+		ID:           uuid.New().String(),
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		ClientID:     clientID,
+		ExpiresAt:    expiresAt,
+	}
+	if err := h.store.ConfigStore.CreatePerUserOAuthSession(ctx, session); err != nil {
+		sendOAuthError(ctx, fasthttp.StatusInternalServerError, "server_error", "Failed to create session")
+		return
+	}
+
+	// Return OAuth token response
+	ctx.SetContentType("application/json")
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	SendJSON(ctx, map[string]interface{}{
+		"access_token": accessToken,
+		"token_type":   "Bearer",
+		"expires_in":   int(time.Until(expiresAt).Seconds()),
+		"scope":        codeRecord.Scopes,
+	})
+}
+
+// sendOAuthError sends an OAuth 2.0 error response per RFC 6749 Section 5.2.
+func sendOAuthError(ctx *fasthttp.RequestCtx, statusCode int, errorCode, description string) {
+	ctx.SetContentType("application/json")
+	ctx.SetStatusCode(statusCode)
+	resp, _ := json.Marshal(map[string]string{
+		"error":             errorCode,
+		"error_description": description,
+	})
+	ctx.SetBody(resp)
+}
+
+// generateOpaqueToken generates a cryptographically secure random token.
+func generateOpaqueToken(length int) (string, error) {
+	bytes := make([]byte, length)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(bytes), nil
+}
+
+// handleUpstreamAuthorize handles the upstream OAuth proxy for per-user OAuth.
+// When a user needs to authenticate with an upstream MCP server (e.g., Notion),
+// this endpoint redirects them to the upstream provider's OAuth authorize URL.
+// After the user authenticates, the callback stores their upstream token linked
+// to their Bifrost session.
+//
+// GET /api/oauth/per-user/upstream/authorize?mcp_client_id=xxx&session=xxx
+func (h *PerUserOAuthHandler) handleUpstreamAuthorize(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "OAuth upstream authorization unavailable: config store is disabled")
+		return
+	}
+
+	mcpClientID := string(ctx.QueryArgs().Peek("mcp_client_id"))
+	sessionID := string(ctx.QueryArgs().Peek("session"))
+
+	if mcpClientID == "" || sessionID == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "mcp_client_id and session are required")
+		return
+	}
+
+	// Validate the Bifrost session exists
+	session, err := h.store.ConfigStore.GetPerUserOAuthSessionByID(ctx, sessionID)
+	if err != nil || session == nil {
+		SendError(ctx, fasthttp.StatusUnauthorized, "Invalid or expired session")
+		return
+	}
+
+	// Look up the MCP client config to get the template OAuth config
+	mcpClient, err := h.store.ConfigStore.GetMCPClientByID(ctx, mcpClientID)
+	if err != nil || mcpClient == nil {
+		SendError(ctx, fasthttp.StatusNotFound, "MCP client not found")
+		return
+	}
+
+	if mcpClient.AuthType != string(schemas.MCPAuthTypePerUserOauth) {
+		SendError(ctx, fasthttp.StatusBadRequest, "MCP client does not use per-user OAuth")
+		return
+	}
+
+	if mcpClient.OauthConfigID == nil || *mcpClient.OauthConfigID == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "MCP client has no OAuth configuration")
+		return
+	}
+
+	// Load template OAuth config (has upstream authorize_url, client_id, etc.)
+	templateConfig, err := h.store.ConfigStore.GetOauthConfigByID(ctx, *mcpClient.OauthConfigID)
+	if err != nil || templateConfig == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to load OAuth template config")
+		return
+	}
+
+	// Generate PKCE challenge for upstream
+	codeVerifier, err := generateOpaqueToken(32)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to generate PKCE verifier")
+		return
+	}
+	verifierHash := sha256.Sum256([]byte(codeVerifier))
+	codeChallenge := base64.RawURLEncoding.EncodeToString(verifierHash[:])
+
+	// Generate state for upstream
+	state, err := generateOpaqueToken(32)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to generate state token")
+		return
+	}
+
+	// Build redirect URI (Bifrost's callback endpoint)
+	scheme := "http"
+	if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
+		scheme = "https"
+	}
+	host := string(ctx.Host())
+	redirectURI := fmt.Sprintf("%s://%s/api/oauth/callback", scheme, host)
+
+	// Look up Bifrost session to propagate identity to upstream OAuth flow
+	var virtualKeyID, userID string
+	if bifrostSession, err := h.store.ConfigStore.GetPerUserOAuthSessionByID(ctx, sessionID); err == nil && bifrostSession != nil {
+		virtualKeyID = bifrostSession.VirtualKeyID
+		userID = bifrostSession.UserID
+	}
+
+	// Store upstream OAuth session (links state → session + mcp_client + identity)
+	upstreamSession := &tables.TableOauthUserSession{
+		ID:            uuid.New().String(),
+		MCPClientID:   mcpClientID,
+		OauthConfigID: *mcpClient.OauthConfigID,
+		State:         state,
+		CodeVerifier:  codeVerifier,
+		GatewaySessionID: sessionID, // Link to Bifrost MCP gateway session
+		VirtualKeyID:  virtualKeyID,
+		UserID:        userID,
+		Status:        "pending",
+		ExpiresAt:     time.Now().Add(15 * time.Minute),
+	}
+	if err := h.store.ConfigStore.CreateOauthUserSession(ctx, upstreamSession); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create upstream OAuth session: %v", err))
+		return
+	}
+
+	// Parse scopes from template config
+	var scopes []string
+	if templateConfig.Scopes != "" {
+		json.Unmarshal([]byte(templateConfig.Scopes), &scopes)
+	}
+
+	// Build upstream authorize URL with PKCE
+	params := url.Values{}
+	params.Set("response_type", "code")
+	params.Set("client_id", templateConfig.ClientID)
+	params.Set("redirect_uri", redirectURI)
+	params.Set("state", state)
+	params.Set("code_challenge", codeChallenge)
+	params.Set("code_challenge_method", "S256")
+	if len(scopes) > 0 {
+		params.Set("scope", strings.Join(scopes, " "))
+	}
+
+	upstreamAuthorizeURL := templateConfig.AuthorizeURL + "?" + params.Encode()
+	ctx.Redirect(upstreamAuthorizeURL, fasthttp.StatusFound)
+}
+
+// Ensure unused imports are referenced.
+var _ = html.EscapeString
+var _ configstore.ConfigStore

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -585,6 +585,10 @@ func (m *MockConfigStore) GetMCPClientsPaginated(ctx context.Context, params con
 	return nil, 0, nil
 }
 
+func (m *MockConfigStore) UpdateMCPClientDiscoveredTools(ctx context.Context, clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) error {
+	return nil
+}
+
 func (m *MockConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) error {
 	return nil
 }
@@ -1114,6 +1118,81 @@ func (m *MockConfigStore) UpdateOauthToken(ctx context.Context, token *tables.Ta
 }
 
 func (m *MockConfigStore) DeleteOauthToken(ctx context.Context, id string) error {
+	return nil
+}
+
+// Per-user OAuth session CRUD
+func (m *MockConfigStore) GetOauthUserSessionByID(ctx context.Context, id string) (*tables.TableOauthUserSession, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) GetOauthUserSessionByState(ctx context.Context, state string) (*tables.TableOauthUserSession, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) ClaimOauthUserSessionByState(ctx context.Context, state string) (*tables.TableOauthUserSession, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) GetOauthUserSessionBySessionToken(ctx context.Context, sessionToken string) (*tables.TableOauthUserSession, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) CreateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error {
+	return nil
+}
+func (m *MockConfigStore) UpdateOauthUserSession(ctx context.Context, session *tables.TableOauthUserSession) error {
+	return nil
+}
+
+// Per-user OAuth token CRUD
+func (m *MockConfigStore) GetOauthUserTokenByIdentity(ctx context.Context, virtualKeyID, userID, sessionToken, mcpClientID string) (*tables.TableOauthUserToken, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) GetOauthUserTokenBySessionToken(ctx context.Context, sessionToken string) (*tables.TableOauthUserToken, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) CreateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error {
+	return nil
+}
+func (m *MockConfigStore) UpdateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error {
+	return nil
+}
+func (m *MockConfigStore) DeleteOauthUserToken(ctx context.Context, id string) error {
+	return nil
+}
+func (m *MockConfigStore) DeleteOauthUserTokensByMCPClient(ctx context.Context, mcpClientID string) error {
+	return nil
+}
+
+// Per-user OAuth Authorization Server CRUD
+func (m *MockConfigStore) GetPerUserOAuthClientByClientID(ctx context.Context, clientID string) (*tables.TablePerUserOAuthClient, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) CreatePerUserOAuthClient(ctx context.Context, client *tables.TablePerUserOAuthClient) error {
+	return nil
+}
+func (m *MockConfigStore) GetPerUserOAuthSessionByAccessToken(ctx context.Context, accessToken string) (*tables.TablePerUserOAuthSession, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) GetPerUserOAuthSessionByID(ctx context.Context, id string) (*tables.TablePerUserOAuthSession, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) CreatePerUserOAuthSession(ctx context.Context, session *tables.TablePerUserOAuthSession) error {
+	return nil
+}
+func (m *MockConfigStore) UpdatePerUserOAuthSession(ctx context.Context, session *tables.TablePerUserOAuthSession) error {
+	return nil
+}
+func (m *MockConfigStore) DeletePerUserOAuthSession(ctx context.Context, id string) error {
+	return nil
+}
+func (m *MockConfigStore) GetPerUserOAuthCodeByCode(ctx context.Context, code string) (*tables.TablePerUserOAuthCode, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) ClaimPerUserOAuthCode(ctx context.Context, code string) (*tables.TablePerUserOAuthCode, error) {
+	return nil, nil
+}
+func (m *MockConfigStore) CreatePerUserOAuthCode(ctx context.Context, code *tables.TablePerUserOAuthCode) error {
+	return nil
+}
+func (m *MockConfigStore) UpdatePerUserOAuthCode(ctx context.Context, code *tables.TablePerUserOAuthCode) error {
 	return nil
 }
 

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -8,6 +8,7 @@ package lib
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -431,6 +432,26 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 		return true
 	})
 	bifrostCtx.SetValue(schemas.BifrostContextKeyRequestHeaders, allHeaders)
+
+	// Extract per-user MCP OAuth session token from X-Bifrost-MCP-Session header
+	if mcpSession := string(ctx.Request.Header.Peek("X-Bifrost-MCP-Session")); mcpSession != "" {
+		bifrostCtx.SetValue(schemas.BifrostContextKeyMCPUserSession, mcpSession)
+	}
+
+	// Extract per-user MCP OAuth user identifier from X-Bf-User-Id header
+	if mcpUserID := string(ctx.Request.Header.Peek("X-Bf-User-Id")); mcpUserID != "" {
+		bifrostCtx.SetValue(schemas.BifrostContextKeyMCPUserID, mcpUserID)
+	}
+
+	// Build and set OAuth redirect URI for per-user OAuth flows
+	scheme := "http"
+	if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
+		scheme = "https"
+	}
+	host := string(ctx.Host())
+	if host != "" {
+		bifrostCtx.SetValue(schemas.BifrostContextKeyOAuthRedirectURI, fmt.Sprintf("%s://%s/api/oauth/callback", scheme, host))
+	}
 
 	if allowDirectKeys {
 		// Extract API key from Authorization header (Bearer format), x-api-key, or x-goog-api-key header

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -92,6 +92,10 @@ type ServerCallbacks interface {
 	RemoveMCPClient(ctx context.Context, id string) error
 	UpdateMCPClient(ctx context.Context, id string, updatedConfig *schemas.MCPClientConfig) error
 	UpdateMCPToolManagerConfig(ctx context.Context, maxAgentDepth int, toolExecutionTimeoutInSeconds int, codeModeBindingLevel string, disableAutoToolInject bool) error
+	// VerifyPerUserOAuthConnection verifies an MCP server using a temporary token and discovers tools.
+	VerifyPerUserOAuthConnection(ctx context.Context, config *schemas.MCPClientConfig, accessToken string) (map[string]schemas.ChatTool, map[string]string, error)
+	// SetClientTools updates the tool map for an existing client.
+	SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string)
 	ReconnectMCPClient(ctx context.Context, id string) error
 	// Logging related callbacks
 	NewLogEntryAdded(ctx context.Context, logEntry *logstore.Log) error
@@ -234,6 +238,17 @@ func (s *BifrostHTTPServer) RemoveMCPClient(ctx context.Context, id string) erro
 		logger.Warn("failed to sync MCP servers after removing client: %v", err)
 	}
 	return nil
+}
+
+// VerifyPerUserOAuthConnection delegates to the Bifrost client to verify an MCP
+// server using a temporary access token and discover available tools.
+func (s *BifrostHTTPServer) VerifyPerUserOAuthConnection(ctx context.Context, config *schemas.MCPClientConfig, accessToken string) (map[string]schemas.ChatTool, map[string]string, error) {
+	return s.Client.VerifyPerUserOAuthConnection(ctx, config, accessToken)
+}
+
+// SetClientTools delegates to the Bifrost client to update tool map for an existing MCP client.
+func (s *BifrostHTTPServer) SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string) {
+	s.Client.SetClientTools(clientID, tools, toolNameMapping)
 }
 
 // ExecuteChatMCPTool executes an MCP tool call and returns the result as a chat message.
@@ -1065,6 +1080,11 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	mcpHandler.RegisterRoutes(s.Router, middlewares...)
 	configHandler.RegisterRoutes(s.Router, middlewares...)
 	oauthHandler.RegisterRoutes(s.Router, middlewares...)
+	// OAuth metadata + per-user OAuth endpoints (no auth middleware — must be publicly accessible)
+	oauthMetadataHandler := handlers.NewOAuthMetadataHandler(s.Config)
+	oauthMetadataHandler.RegisterRoutes(s.Router)
+	perUserOAuthHandler := handlers.NewPerUserOAuthHandler(s.Config)
+	perUserOAuthHandler.RegisterRoutes(s.Router)
 	if pluginsHandler != nil {
 		pluginsHandler.RegisterRoutes(s.Router, middlewares...)
 	}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2546,13 +2546,14 @@
           "enum": [
             "none",
             "headers",
-            "oauth"
+            "oauth",
+            "per_user_oauth"
           ],
           "description": "Authentication type for MCP connection"
         },
         "oauth_config_id": {
           "type": "string",
-          "description": "OAuth config ID reference (for oauth auth type)"
+          "description": "OAuth config ID reference (required when auth_type is 'oauth' or 'per_user_oauth')"
         },
         "headers": {
           "type": "object",
@@ -2665,6 +2666,17 @@
         "connection_type"
       ],
       "additionalProperties": false,
+      "if": {
+        "properties": {
+          "auth_type": {
+            "enum": ["oauth", "per_user_oauth"]
+          }
+        },
+        "required": ["auth_type"]
+      },
+      "then": {
+        "required": ["oauth_config_id"]
+      },
       "oneOf": [
         {
           "properties": {

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -62,6 +62,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 		authorizeUrl: string;
 		oauthConfigId: string;
 		mcpClientId: string;
+		isPerUserOauth?: boolean;
 	} | null>(null);
 	const { toast } = useToast();
 
@@ -176,7 +177,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			: []),
 
 		// OAuth validation
-		...(form.auth_type === "oauth"
+		...((form.auth_type === "oauth" || form.auth_type === "per_user_oauth")
 			? [
 				// Client ID is optional if provider supports dynamic registration (RFC 7591)
 				// URLs are optional (will be discovered), but if provided must be valid
@@ -230,7 +231,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					}
 					: undefined,
 			oauth_config:
-				form.auth_type === "oauth"
+				(form.auth_type === "oauth" || form.auth_type === "per_user_oauth")
 					? {
 						client_id: form.oauth_config?.client_id || "", // Can be empty for dynamic registration
 						client_secret: form.oauth_config?.client_secret || undefined,
@@ -256,6 +257,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					authorizeUrl: response.authorize_url,
 					oauthConfigId: response.oauth_config_id,
 					mcpClientId: response.mcp_client_id,
+					isPerUserOauth: form.auth_type === "per_user_oauth",
 				});
 			} else {
 				setIsLoading(false);
@@ -401,6 +403,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 										<SelectItem value="none" data-testid="auth-type-none">None</SelectItem>
 										<SelectItem value="headers" data-testid="auth-type-headers">Headers</SelectItem>
 										<SelectItem value="oauth" data-testid="auth-type-oauth">OAuth 2.0</SelectItem>
+										<SelectItem value="per_user_oauth" data-testid="auth-type-per-user-oauth">Per-User OAuth 2.0</SelectItem>
 									</SelectContent>
 								</Select>
 							</div>
@@ -418,7 +421,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 								</div>
 							)}
 
-							{form.auth_type === "oauth" && (
+							{(form.auth_type === "oauth" || form.auth_type === "per_user_oauth") && (
 								<>
 									<div className="space-y-2">
 										<div className="flex items-center gap-2">
@@ -606,6 +609,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					authorizeUrl={oauthFlow.authorizeUrl}
 					oauthConfigId={oauthFlow.oauthConfigId}
 					mcpClientId={oauthFlow.mcpClientId}
+					isPerUserOauth={oauthFlow.isPerUserOauth}
 				/>
 			)}
 		</Sheet>

--- a/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
@@ -15,6 +15,7 @@ interface OAuth2AuthorizerProps {
 	authorizeUrl: string
 	oauthConfigId: string
 	mcpClientId: string
+	isPerUserOauth?: boolean
 }
 
 export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
@@ -25,8 +26,9 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	authorizeUrl,
 	oauthConfigId,
 	mcpClientId,
+	isPerUserOauth,
 }) => {
-	const [status, setStatus] = useState<"pending" | "polling" | "success" | "failed">("pending")
+	const [status, setStatus] = useState<"confirm" | "pending" | "polling" | "success" | "failed">(isPerUserOauth ? "confirm" : "pending")
 	const [errorMessage, setErrorMessage] = useState<string | null>(null)
 	const popupRef = useRef<Window | null>(null)
 	const pollIntervalRef = useRef<NodeJS.Timeout | null>(null)
@@ -169,12 +171,18 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 		}
 	}, [checkOAuthStatus])
 
-	// Open popup when dialog opens
+	// Open popup when dialog opens (skip if waiting for user confirmation)
 	useEffect(() => {
 		if (open && status === "pending") {
 			openPopup()
 		}
 	}, [open, status, openPopup])
+
+	// Handle user confirming per-user OAuth test
+	const handleConfirmPerUserOAuth = () => {
+		setStatus("pending")
+		openPopup()
+	}
 
 	// Cleanup on unmount
 	useEffect(() => {
@@ -187,9 +195,13 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	}, [stopPolling])
 
 	const handleRetry = () => {
-		setStatus("pending")
 		setErrorMessage(null)
-		openPopup()
+		if (isPerUserOauth) {
+			setStatus("confirm")
+		} else {
+			setStatus("pending")
+			openPopup()
+		}
 	}
 
 	const handleCancel = () => {
@@ -204,8 +216,9 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 		<Dialog open={open}>
 			<DialogContent className="sm:max-w-md" onPointerDownOutside={(e) => e.preventDefault()} onEscapeKeyDown={(e) => e.preventDefault()}>
 				<DialogHeader>
-					<DialogTitle>OAuth Authorization</DialogTitle>
+					<DialogTitle>{status === "confirm" ? "Test OAuth Configuration" : "OAuth Authorization"}</DialogTitle>
 					<DialogDescription>
+						{status === "confirm" && "A one-time login is needed to verify your OAuth setup."}
 						{status === "pending" && "Opening authorization window..."}
 						{status === "polling" && "Waiting for authorization..."}
 						{status === "success" && "Authorization successful!"}
@@ -214,6 +227,30 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 				</DialogHeader>
 
 				<div className="flex flex-col items-center justify-center space-y-4">
+					{status === "confirm" && (
+						<>
+							<div className="text-muted-foreground space-y-3 text-sm">
+								<p>
+									To set up this MCP server, we need to verify that your OAuth configuration is correct and discover the available tools.
+								</p>
+								<p>
+									You will be asked to log in to the OAuth provider. This is a <strong>one-time test</strong> to confirm the setup works. Your credentials will <strong>not</strong> be stored or used for any other purpose.
+								</p>
+								<p>
+									Once verified, each user will authenticate individually when they use this MCP server.
+								</p>
+							</div>
+							<div className="flex w-full justify-end space-x-2">
+								<Button onClick={handleCancel} variant="outline" data-testid="per-user-oauth-cancel">
+									Cancel
+								</Button>
+								<Button onClick={handleConfirmPerUserOAuth} data-testid="per-user-oauth-confirm">
+									Continue with Test Login
+								</Button>
+							</div>
+						</>
+					)}
+
 					{status === "polling" && (
 						<>
 							<Loader2 className="text-secondary-foreground h-4 w-4 animate-spin" />

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -532,10 +532,10 @@ export default function AppSidebar() {
 						hasAccess: hasMCPGatewayAccess,
 					},
 					{
-						title: "Tool groups",
+						title: "Virtual MCP Servers",
 						url: "/workspace/mcp-tool-groups",
 						icon: ToolCase,
-						description: "MCP tool groups",
+						description: "Virtual MCP servers",
 						hasAccess: hasMCPGatewayAccess,
 					},
 					{

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -5,7 +5,7 @@ export type MCPConnectionType = "http" | "stdio" | "sse";
 
 export type MCPConnectionState = "connected" | "disconnected" | "error";
 
-export type MCPAuthType = "none" | "headers" | "oauth";
+export type MCPAuthType = "none" | "headers" | "oauth" | "per_user_oauth";
 
 export type { EnvVar };
 


### PR DESCRIPTION
## Summary

Adds per-user OAuth authentication for MCP servers, allowing each user to authenticate individually with their own credentials rather than using shared server-level authentication.

## Changes

- Added new `per_user_oauth` authentication type for MCP clients
- Implemented per-user OAuth flow with temporary connections for tool execution
- Added database tables for tracking user OAuth sessions and tokens
- Enhanced MCP agent mode to handle OAuth authentication errors gracefully
- Added verification system for admins to test OAuth configurations before deployment
- Extended OAuth2Provider interface with per-user methods
- Added session token support via `X-Bifrost-MCP-Session` header
- Updated UI to support per-user OAuth configuration with confirmation dialog

Key design decisions:
- Per-user OAuth clients have no persistent connections - each tool call creates a temporary authenticated connection
- Admin verification uses a one-time test login to discover tools and validate configuration
- Session tokens are cryptographically secure and map to encrypted user credentials
- OAuth errors in agent mode return structured error responses to trigger user authentication

## Type of change

- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] UI (Next.js)

## How to test

1. Set up an MCP server that supports OAuth (e.g., GitHub, Google Drive)
2. Create a new MCP client with `per_user_oauth` auth type
3. Complete the admin verification flow to test OAuth configuration
4. Make a chat request that uses MCP tools - should receive OAuth error with authorization URL
5. Complete user OAuth flow and retry with session token header

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

New configuration:
- `auth_type: "per_user_oauth"` for MCP client configs
- `X-Bifrost-MCP-Session` header for authenticated requests

## Screenshots/Recordings

UI now includes per-user OAuth option in MCP client form with confirmation dialog explaining the test login process.

## Breaking changes

- [ ] Yes
- [x] No

Additive changes only - existing OAuth and authentication methods remain unchanged.

## Related issues

Enables individual user authentication for MCP servers requiring personal credentials.

## Security considerations

- User OAuth tokens are encrypted at rest using existing encryption framework
- Session tokens are cryptographically secure (32-byte random hex)
- Admin test tokens are immediately revoked after verification
- PKCE is used for OAuth flows to prevent authorization code interception
- Per-user tokens are scoped to specific MCP clients

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable