### PR TITLE
feat(api): add /api/models/details for model capability metadata

### DIFF
--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -567,6 +567,8 @@ paths:
     $ref: './paths/management/providers.yaml#/keys'
   /api/models:
     $ref: './paths/management/providers.yaml#/models'
+  /api/models/details:
+    $ref: './paths/management/providers.yaml#/models-details'
   /api/models/parameters:
     $ref: './paths/management/providers.yaml#/models-parameters'
   /api/models/base:

--- a/docs/openapi/paths/management/providers.yaml
+++ b/docs/openapi/paths/management/providers.yaml
@@ -182,14 +182,24 @@ models:
       - name: keys
         in: query
         description: Comma-separated list of key IDs to filter models accessible by those keys
+        style: form
+        explode: false
         schema:
-          type: string
+          type: array
+          items:
+            type: string
       - name: limit
         in: query
         description: Maximum number of results to return (default 5)
         schema:
           type: integer
           default: 5
+      - name: unfiltered
+        in: query
+        description: If true, return all models including those filtered out by provider-level restrictions
+        schema:
+          type: boolean
+          default: false
     responses:
       '200':
         description: Successful response
@@ -197,6 +207,56 @@ models:
           application/json:
             schema:
               $ref: '../../schemas/management/providers.yaml#/ListModelsResponse'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+models-details:
+  get:
+    operationId: listModelDetailsManagement
+    summary: List model details
+    description: |
+      Lists available models with capability metadata, when available from the model catalog, with optional filtering by query, provider, or keys.
+    tags:
+      - Providers
+    parameters:
+      - name: query
+        in: query
+        description: Filter models by name (case-insensitive partial match)
+        schema:
+          type: string
+      - name: provider
+        in: query
+        description: Filter by specific provider name
+        schema:
+          type: string
+      - name: keys
+        in: query
+        description: Comma-separated list of key IDs to filter models accessible by those keys
+        style: form
+        explode: false
+        schema:
+          type: array
+          items:
+            type: string
+      - name: limit
+        in: query
+        description: Maximum number of results to return (default 20)
+        schema:
+          type: integer
+          default: 20
+      - name: unfiltered
+        in: query
+        description: If true, return all models including those filtered out by provider-level restrictions
+        schema:
+          type: boolean
+          default: false
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/providers.yaml#/ListModelDetailsResponse'
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 

--- a/docs/openapi/schemas/management/providers.yaml
+++ b/docs/openapi/schemas/management/providers.yaml
@@ -350,6 +350,45 @@ ModelResponse:
       items:
         type: string
 
+Architecture:
+  type: object
+  properties:
+    modality:
+      type: string
+    tokenizer:
+      type: string
+    instruct_type:
+      type: string
+    input_modalities:
+      type: array
+      items:
+        type: string
+    output_modalities:
+      type: array
+      items:
+        type: string
+
+ModelDetailsResponse:
+  type: object
+  description: Model details with capability metadata
+  properties:
+    name:
+      type: string
+    provider:
+      type: string
+    context_length:
+      type: integer
+    max_input_tokens:
+      type: integer
+    max_output_tokens:
+      type: integer
+    architecture:
+      $ref: '#/Architecture'
+    accessible_by_keys:
+      type: array
+      items:
+        type: string
+
 ListModelsResponse:
   type: object
   description: List models response
@@ -358,5 +397,16 @@ ListModelsResponse:
       type: array
       items:
         $ref: '#/ModelResponse'
+    total:
+      type: integer
+
+ListModelDetailsResponse:
+  type: object
+  description: List model details response
+  properties:
+    models:
+      type: array
+      items:
+        $ref: '#/ModelDetailsResponse'
     total:
       type: integer

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -326,6 +326,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddBudgetCalendarAlignedColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddModelCapabilityColumns(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -4870,6 +4873,53 @@ func migrationAddBudgetCalendarAlignedColumn(ctx context.Context, db *gorm.DB) e
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_budget_calendar_aligned_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddModelCapabilityColumns adds model capability metadata columns to governance_model_pricing.
+func migrationAddModelCapabilityColumns(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_model_capability_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			columns := []string{
+				"context_length",
+				"max_input_tokens",
+				"max_output_tokens",
+				"architecture",
+			}
+			for _, column := range columns {
+				if !mg.HasColumn(&tables.TableModelPricing{}, column) {
+					if err := mg.AddColumn(&tables.TableModelPricing{}, column); err != nil {
+						return fmt.Errorf("failed to add %s column: %w", column, err)
+					}
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			columns := []string{
+				"context_length",
+				"max_input_tokens",
+				"max_output_tokens",
+				"architecture",
+			}
+			for _, column := range columns {
+				if mg.HasColumn(&tables.TableModelPricing{}, column) {
+					if err := mg.DropColumn(&tables.TableModelPricing{}, column); err != nil {
+						return fmt.Errorf("failed to drop %s column: %w", column, err)
+					}
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_model_capability_columns migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/tables/modelpricing.go
+++ b/framework/configstore/tables/modelpricing.go
@@ -1,12 +1,18 @@
 package tables
 
+import "github.com/maximhq/bifrost/core/schemas"
+
 // TableModelPricing represents pricing information for AI models
 type TableModelPricing struct {
-	ID        uint   `gorm:"primaryKey;autoIncrement" json:"id"`
-	Model     string `gorm:"type:varchar(255);not null;uniqueIndex:idx_model_provider_mode" json:"model"`
-	BaseModel string `gorm:"type:varchar(255);default:null" json:"base_model,omitempty"`
-	Provider  string `gorm:"type:varchar(50);not null;uniqueIndex:idx_model_provider_mode" json:"provider"`
-	Mode      string `gorm:"type:varchar(50);not null;uniqueIndex:idx_model_provider_mode" json:"mode"`
+	ID              uint                  `gorm:"primaryKey;autoIncrement" json:"id"`
+	Model           string                `gorm:"type:varchar(255);not null;uniqueIndex:idx_model_provider_mode" json:"model"`
+	BaseModel       string                `gorm:"type:varchar(255);default:null" json:"base_model,omitempty"`
+	Provider        string                `gorm:"type:varchar(50);not null;uniqueIndex:idx_model_provider_mode" json:"provider"`
+	Mode            string                `gorm:"type:varchar(50);not null;uniqueIndex:idx_model_provider_mode" json:"mode"`
+	ContextLength   *int                  `gorm:"default:null" json:"context_length,omitempty"`
+	MaxInputTokens  *int                  `gorm:"default:null" json:"max_input_tokens,omitempty"`
+	MaxOutputTokens *int                  `gorm:"default:null" json:"max_output_tokens,omitempty"`
+	Architecture    *schemas.Architecture `gorm:"type:text;serializer:json;default:null" json:"architecture,omitempty"`
 
 	// Costs - Text
 	InputCostPerToken          float64  `gorm:"not null" json:"input_cost_per_token"`

--- a/framework/modelcatalog/capabilities_test.go
+++ b/framework/modelcatalog/capabilities_test.go
@@ -80,6 +80,109 @@ func TestGetModelCapabilityEntryForModel_FallsBackToAnyModeDeterministically(t *
 	}
 }
 
+func TestGetModelCapabilityEntryForModel_ResolvesAliasFamilyViaBaseModel(t *testing.T) {
+	contextLengthChat := 128000
+
+	mc := &ModelCatalog{
+		pricingData: map[string]configstoreTables.TableModelPricing{
+			makeKey("gpt-4o-2024-08-06", "openai", "responses"): {
+				Model:           "gpt-4o-2024-08-06",
+				BaseModel:       "gpt-4o",
+				Provider:        "openai",
+				Mode:            "responses",
+				ContextLength:   capabilityIntPtr(64000),
+				MaxOutputTokens: capabilityIntPtr(8000),
+			},
+			makeKey("gpt-4o-2024-08-06", "openai", "chat"): {
+				Model:           "gpt-4o-2024-08-06",
+				BaseModel:       "gpt-4o",
+				Provider:        "openai",
+				Mode:            "chat",
+				ContextLength:   &contextLengthChat,
+				MaxOutputTokens: capabilityIntPtr(16000),
+			},
+		},
+		baseModelIndex: map[string]string{
+			"gpt-4o-2024-08-06": "gpt-4o",
+		},
+	}
+
+	entry := mc.GetModelCapabilityEntryForModel("gpt-4o", schemas.OpenAI)
+	if entry == nil {
+		t.Fatal("expected capability entry for base-model alias")
+	}
+	if entry.Mode != "chat" {
+		t.Fatalf("expected chat mode to win for alias family, got %q", entry.Mode)
+	}
+	if entry.ContextLength == nil || *entry.ContextLength != contextLengthChat {
+		t.Fatalf("expected alias family context_length=%d, got %#v", contextLengthChat, entry.ContextLength)
+	}
+}
+
+func TestGetModelCapabilityEntryForModel_ResolvesProviderPrefixedAlias(t *testing.T) {
+	mc := &ModelCatalog{
+		pricingData: map[string]configstoreTables.TableModelPricing{
+			makeKey("gpt-4o-2024-08-06", "openai", "chat"): {
+				Model:           "gpt-4o-2024-08-06",
+				BaseModel:       "gpt-4o",
+				Provider:        "openai",
+				Mode:            "chat",
+				ContextLength:   capabilityIntPtr(128000),
+				MaxOutputTokens: capabilityIntPtr(16000),
+			},
+		},
+		baseModelIndex: map[string]string{
+			"gpt-4o-2024-08-06": "gpt-4o",
+		},
+	}
+
+	entry := mc.GetModelCapabilityEntryForModel("openai/gpt-4o", schemas.OpenAI)
+	if entry == nil {
+		t.Fatal("expected capability entry for provider-prefixed alias")
+	}
+	if entry.Mode != "chat" {
+		t.Fatalf("expected chat mode for provider-prefixed alias, got %q", entry.Mode)
+	}
+}
+
+func TestGetModelCapabilityEntryForModel_PrefersLiteralMatchOverAliasFamily(t *testing.T) {
+	literalContextLength := 32000
+	aliasContextLength := 128000
+
+	mc := &ModelCatalog{
+		pricingData: map[string]configstoreTables.TableModelPricing{
+			makeKey("gpt-4o", "openai", "chat"): {
+				Model:           "gpt-4o",
+				BaseModel:       "gpt-4o",
+				Provider:        "openai",
+				Mode:            "chat",
+				ContextLength:   &literalContextLength,
+				MaxOutputTokens: capabilityIntPtr(4000),
+			},
+			makeKey("gpt-4o-2024-08-06", "openai", "chat"): {
+				Model:           "gpt-4o-2024-08-06",
+				BaseModel:       "gpt-4o",
+				Provider:        "openai",
+				Mode:            "chat",
+				ContextLength:   &aliasContextLength,
+				MaxOutputTokens: capabilityIntPtr(16000),
+			},
+		},
+		baseModelIndex: map[string]string{
+			"gpt-4o":            "gpt-4o",
+			"gpt-4o-2024-08-06": "gpt-4o",
+		},
+	}
+
+	entry := mc.GetModelCapabilityEntryForModel("gpt-4o", schemas.OpenAI)
+	if entry == nil {
+		t.Fatal("expected literal capability entry")
+	}
+	if entry.ContextLength == nil || *entry.ContextLength != literalContextLength {
+		t.Fatalf("expected literal match to win with context_length=%d, got %#v", literalContextLength, entry.ContextLength)
+	}
+}
+
 func TestCapabilityFieldsRoundTripThroughPricingConversions(t *testing.T) {
 	modality := "text"
 	entry := PricingEntry{

--- a/framework/modelcatalog/capabilities_test.go
+++ b/framework/modelcatalog/capabilities_test.go
@@ -1,0 +1,116 @@
+package modelcatalog
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+func TestGetModelCapabilityEntryForModel_PrefersChatThenResponsesThenCompletion(t *testing.T) {
+	contextLengthChat := 128000
+	maxInputTokensChat := 64000
+	maxOutputTokensChat := 16000
+	modality := "text"
+
+	mc := &ModelCatalog{
+		pricingData: map[string]configstoreTables.TableModelPricing{
+			makeKey("gpt-4o", "openai", "responses"): {
+				Model:           "gpt-4o",
+				Provider:        "openai",
+				Mode:            "responses",
+				ContextLength:   capabilityIntPtr(200000),
+				MaxInputTokens:  capabilityIntPtr(100000),
+				MaxOutputTokens: capabilityIntPtr(32000),
+			},
+			makeKey("gpt-4o", "openai", "chat"): {
+				Model:           "gpt-4o",
+				Provider:        "openai",
+				Mode:            "chat",
+				ContextLength:   &contextLengthChat,
+				MaxInputTokens:  &maxInputTokensChat,
+				MaxOutputTokens: &maxOutputTokensChat,
+				Architecture: &schemas.Architecture{
+					Modality: &modality,
+				},
+			},
+		},
+	}
+
+	entry := mc.GetModelCapabilityEntryForModel("gpt-4o", schemas.OpenAI)
+	if entry == nil {
+		t.Fatal("expected capability entry")
+	}
+	if entry.Mode != "chat" {
+		t.Fatalf("expected chat mode to win, got %q", entry.Mode)
+	}
+	if entry.ContextLength == nil || *entry.ContextLength != contextLengthChat {
+		t.Fatalf("expected context_length=%d, got %#v", contextLengthChat, entry.ContextLength)
+	}
+	if entry.MaxInputTokens == nil || *entry.MaxInputTokens != maxInputTokensChat {
+		t.Fatalf("expected max_input_tokens=%d, got %#v", maxInputTokensChat, entry.MaxInputTokens)
+	}
+	if entry.MaxOutputTokens == nil || *entry.MaxOutputTokens != maxOutputTokensChat {
+		t.Fatalf("expected max_output_tokens=%d, got %#v", maxOutputTokensChat, entry.MaxOutputTokens)
+	}
+	if entry.Architecture == nil || entry.Architecture.Modality == nil || *entry.Architecture.Modality != modality {
+		t.Fatalf("expected architecture modality=%q, got %#v", modality, entry.Architecture)
+	}
+}
+
+func TestGetModelCapabilityEntryForModel_FallsBackToAnyModeDeterministically(t *testing.T) {
+	mc := &ModelCatalog{
+		pricingData: map[string]configstoreTables.TableModelPricing{
+			makeKey("imagen", "vertex", "image_generation"): {
+				Model:           "imagen",
+				Provider:        "vertex",
+				Mode:            "image_generation",
+				ContextLength:   capabilityIntPtr(4096),
+				MaxOutputTokens: capabilityIntPtr(1),
+			},
+		},
+	}
+
+	entry := mc.GetModelCapabilityEntryForModel("imagen", schemas.Vertex)
+	if entry == nil {
+		t.Fatal("expected capability entry")
+	}
+	if entry.Mode != "image_generation" {
+		t.Fatalf("expected image_generation fallback, got %q", entry.Mode)
+	}
+}
+
+func TestCapabilityFieldsRoundTripThroughPricingConversions(t *testing.T) {
+	modality := "text"
+	entry := PricingEntry{
+		BaseModel:          "gpt-4o",
+		Provider:           "openai",
+		Mode:               "chat",
+		InputCostPerToken:  1,
+		OutputCostPerToken: 2,
+		ContextLength:      capabilityIntPtr(128000),
+		MaxInputTokens:     capabilityIntPtr(64000),
+		MaxOutputTokens:    capabilityIntPtr(16000),
+		Architecture: &schemas.Architecture{
+			Modality: &modality,
+		},
+	}
+
+	table := convertPricingDataToTableModelPricing("gpt-4o", entry)
+	roundTrip := convertTableModelPricingToPricingData(&table)
+
+	if roundTrip.ContextLength == nil || *roundTrip.ContextLength != 128000 {
+		t.Fatalf("expected context_length to round-trip, got %#v", roundTrip.ContextLength)
+	}
+	if roundTrip.MaxInputTokens == nil || *roundTrip.MaxInputTokens != 64000 {
+		t.Fatalf("expected max_input_tokens to round-trip, got %#v", roundTrip.MaxInputTokens)
+	}
+	if roundTrip.MaxOutputTokens == nil || *roundTrip.MaxOutputTokens != 16000 {
+		t.Fatalf("expected max_output_tokens to round-trip, got %#v", roundTrip.MaxOutputTokens)
+	}
+	if roundTrip.Architecture == nil || roundTrip.Architecture.Modality == nil || *roundTrip.Architecture.Modality != modality {
+		t.Fatalf("expected architecture to round-trip, got %#v", roundTrip.Architecture)
+	}
+}
+
+func capabilityIntPtr(v int) *int { return &v }

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -65,6 +65,11 @@ type PricingEntry struct {
 	Provider  string `json:"provider"`
 	Mode      string `json:"mode"`
 
+	ContextLength   *int                  `json:"context_length,omitempty"`
+	MaxInputTokens  *int                  `json:"max_input_tokens,omitempty"`
+	MaxOutputTokens *int                  `json:"max_output_tokens,omitempty"`
+	Architecture    *schemas.Architecture `json:"architecture,omitempty"`
+
 	// Costs - Text
 	InputCostPerToken          float64  `json:"input_cost_per_token"`
 	OutputCostPerToken         float64  `json:"output_cost_per_token"`
@@ -121,9 +126,6 @@ type PricingEntry struct {
 	OutputCostPerAudioToken     *float64 `json:"output_cost_per_audio_token,omitempty"`
 	OutputCostPerVideoPerSecond *float64 `json:"output_cost_per_video_per_second,omitempty"`
 	OutputCostPerSecond         *float64 `json:"output_cost_per_second,omitempty"`
-
-	// Model parameters
-	MaxOutputTokens *int `json:"max_output_tokens,omitempty"`
 
 	// Costs - Other
 	//
@@ -391,6 +393,43 @@ func (mc *ModelCatalog) GetPricingEntryForModel(model string, provider schemas.M
 		}
 	}
 	return nil
+}
+
+// GetModelCapabilityEntryForModel returns capability metadata for a model/provider pair.
+// It prefers chat, then responses, then text-completion entries; if none exist,
+// it falls back to the lexicographically first available mode for deterministic behavior.
+func (mc *ModelCatalog) GetModelCapabilityEntryForModel(model string, provider schemas.ModelProvider) *PricingEntry {
+	mc.mu.RLock()
+	defer mc.mu.RUnlock()
+
+	preferredModes := []schemas.RequestType{
+		schemas.ChatCompletionRequest,
+		schemas.ResponsesRequest,
+		schemas.TextCompletionRequest,
+	}
+
+	for _, mode := range preferredModes {
+		key := makeKey(model, string(provider), normalizeRequestType(mode))
+		pricing, ok := mc.pricingData[key]
+		if ok {
+			return convertTableModelPricingToPricingData(&pricing)
+		}
+	}
+
+	prefix := model + "|" + string(provider) + "|"
+	matchingKeys := make([]string, 0)
+	for key := range mc.pricingData {
+		if strings.HasPrefix(key, prefix) {
+			matchingKeys = append(matchingKeys, key)
+		}
+	}
+	if len(matchingKeys) == 0 {
+		return nil
+	}
+
+	slices.Sort(matchingKeys)
+	pricing := mc.pricingData[matchingKeys[0]]
+	return convertTableModelPricingToPricingData(&pricing)
 }
 
 // GetModelsForProvider returns all available models for a given provider (thread-safe)

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -402,6 +402,25 @@ func (mc *ModelCatalog) GetModelCapabilityEntryForModel(model string, provider s
 	mc.mu.RLock()
 	defer mc.mu.RUnlock()
 
+	if entry := mc.getCapabilityEntryForExactModelUnsafe(model, provider); entry != nil {
+		return entry
+	}
+
+	baseModel := mc.getBaseModelNameUnsafe(model)
+	if baseModel != model {
+		if entry := mc.getCapabilityEntryForExactModelUnsafe(baseModel, provider); entry != nil {
+			return entry
+		}
+	}
+
+	if entry := mc.getCapabilityEntryForModelFamilyUnsafe(baseModel, provider); entry != nil {
+		return entry
+	}
+
+	return nil
+}
+
+func (mc *ModelCatalog) getCapabilityEntryForExactModelUnsafe(model string, provider schemas.ModelProvider) *PricingEntry {
 	preferredModes := []schemas.RequestType{
 		schemas.ChatCompletionRequest,
 		schemas.ResponsesRequest,
@@ -423,8 +442,53 @@ func (mc *ModelCatalog) GetModelCapabilityEntryForModel(model string, provider s
 			matchingKeys = append(matchingKeys, key)
 		}
 	}
+	return mc.selectCapabilityEntryFromKeysUnsafe(matchingKeys)
+}
+
+func (mc *ModelCatalog) getCapabilityEntryForModelFamilyUnsafe(baseModel string, provider schemas.ModelProvider) *PricingEntry {
+	if baseModel == "" {
+		return nil
+	}
+
+	matchingKeys := make([]string, 0)
+	for key, pricing := range mc.pricingData {
+		if normalizeProvider(pricing.Provider) != string(provider) {
+			continue
+		}
+		if mc.getBaseModelNameUnsafe(pricing.Model) != baseModel {
+			continue
+		}
+		matchingKeys = append(matchingKeys, key)
+	}
+	return mc.selectCapabilityEntryFromKeysUnsafe(matchingKeys)
+}
+
+func (mc *ModelCatalog) selectCapabilityEntryFromKeysUnsafe(matchingKeys []string) *PricingEntry {
 	if len(matchingKeys) == 0 {
 		return nil
+	}
+
+	preferredModes := []string{
+		normalizeRequestType(schemas.ChatCompletionRequest),
+		normalizeRequestType(schemas.ResponsesRequest),
+		normalizeRequestType(schemas.TextCompletionRequest),
+	}
+
+	for _, mode := range preferredModes {
+		modeMatches := make([]string, 0)
+		for _, key := range matchingKeys {
+			parts := strings.SplitN(key, "|", 3)
+			if len(parts) != 3 || parts[2] != mode {
+				continue
+			}
+			modeMatches = append(modeMatches, key)
+		}
+		if len(modeMatches) == 0 {
+			continue
+		}
+		slices.Sort(modeMatches)
+		pricing := mc.pricingData[modeMatches[0]]
+		return convertTableModelPricingToPricingData(&pricing)
 	}
 
 	slices.Sort(matchingKeys)

--- a/framework/modelcatalog/main_test.go
+++ b/framework/modelcatalog/main_test.go
@@ -145,3 +145,14 @@ func TestIsSameModel_EmptyStrings(t *testing.T) {
 	assert.False(t, mc.IsSameModel("gpt-4o", ""))
 	assert.False(t, mc.IsSameModel("", "gpt-4o"))
 }
+
+func TestIsModelAllowedForProvider_PrefixedAllowedModelInCatalog(t *testing.T) {
+	mc := newTestCatalog(
+		map[schemas.ModelProvider][]string{
+			schemas.OpenRouter: {"openai/gpt-4o"},
+		},
+		nil,
+	)
+
+	assert.True(t, mc.IsModelAllowedForProvider(schemas.OpenRouter, "gpt-4o", []string{"openai/gpt-4o"}))
+}

--- a/framework/modelcatalog/utils.go
+++ b/framework/modelcatalog/utils.go
@@ -95,10 +95,14 @@ func convertPricingDataToTableModelPricing(modelKey string, entry PricingEntry) 
 	modelName := extractModelName(modelKey)
 
 	return configstoreTables.TableModelPricing{
-		Model:     modelName,
-		BaseModel: entry.BaseModel,
-		Provider:  provider,
-		Mode:      entry.Mode,
+		Model:           modelName,
+		BaseModel:       entry.BaseModel,
+		Provider:        provider,
+		Mode:            entry.Mode,
+		ContextLength:   entry.ContextLength,
+		MaxInputTokens:  entry.MaxInputTokens,
+		MaxOutputTokens: entry.MaxOutputTokens,
+		Architecture:    entry.Architecture,
 
 		// Costs - Text
 		InputCostPerToken:                 entry.InputCostPerToken,
@@ -167,9 +171,13 @@ func convertPricingDataToTableModelPricing(modelKey string, entry PricingEntry) 
 // convertTableModelPricingToPricingData converts the TableModelPricing struct to a PricingEntry struct
 func convertTableModelPricingToPricingData(pricing *configstoreTables.TableModelPricing) *PricingEntry {
 	return &PricingEntry{
-		BaseModel: pricing.BaseModel,
-		Provider:  pricing.Provider,
-		Mode:      pricing.Mode,
+		BaseModel:       pricing.BaseModel,
+		Provider:        pricing.Provider,
+		Mode:            pricing.Mode,
+		ContextLength:   pricing.ContextLength,
+		MaxInputTokens:  pricing.MaxInputTokens,
+		MaxOutputTokens: pricing.MaxOutputTokens,
+		Architecture:    pricing.Architecture,
 
 		// Costs - Text
 		InputCostPerToken:                 pricing.InputCostPerToken,

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
@@ -841,14 +842,39 @@ func (h *ProviderHandler) getModelParameters(ctx *fasthttp.RequestCtx) {
 }
 
 // keyAllowsModelForList reports whether a provider key permits model for catalog listing.
-func keyAllowsModelForList(key schemas.Key, model string) bool {
-	if len(key.BlacklistedModels) > 0 && slices.Contains(key.BlacklistedModels, model) {
+func keyAllowsModelForList(provider schemas.ModelProvider, model string, key schemas.Key, modelCatalog *modelcatalog.ModelCatalog) bool {
+	if len(key.BlacklistedModels) > 0 && keyModelListAllowsModel(provider, model, key.BlacklistedModels, modelCatalog) {
 		return false
 	}
 	if len(key.Models) > 0 {
-		return slices.Contains(key.Models, model)
+		return keyModelListAllowsModel(provider, model, key.Models, modelCatalog)
 	}
 	return true
+}
+
+func keyModelListAllowsModel(provider schemas.ModelProvider, model string, allowedModels []string, modelCatalog *modelcatalog.ModelCatalog) bool {
+	if len(allowedModels) == 0 {
+		return false
+	}
+
+	if modelCatalog == nil {
+		return slices.Contains(allowedModels, model)
+	}
+
+	if modelCatalog.IsModelAllowedForProvider(provider, model, allowedModels) {
+		return true
+	}
+
+	for _, allowedModel := range allowedModels {
+		if strings.Contains(allowedModel, "/") {
+			continue
+		}
+		if modelCatalog.IsSameModel(allowedModel, model) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func splitAndTrimCSV(value string) []string {
@@ -940,7 +966,7 @@ func (h *ProviderHandler) getLegacyFilteredModelsForProvider(provider schemas.Mo
 		return models, nil
 	}
 
-	return filterModelsByKeysWithAccessMap(config, models, validKeyIDs)
+	return filterModelsByKeysWithAccessMap(config, provider, h.inMemoryStore.ModelCatalog, models, validKeyIDs)
 }
 
 func (h *ProviderHandler) getStrictFilteredModelsForProvider(provider schemas.ModelProvider, keyIDs []string, unfiltered bool) ([]string, map[string][]string) {
@@ -970,12 +996,12 @@ func (h *ProviderHandler) getStrictFilteredModelsForProvider(provider schemas.Mo
 		return []string{}, map[string][]string{}
 	}
 
-	return filterModelsByKeysWithAccessMap(config, models, validKeyIDs)
+	return filterModelsByKeysWithAccessMap(config, provider, h.inMemoryStore.ModelCatalog, models, validKeyIDs)
 }
 
 // filterModelsByKeysWithAccessMap filters models based on key-level model restrictions
 // and returns the exact key IDs that grant access to each returned model.
-func filterModelsByKeysWithAccessMap(config *configstore.ProviderConfig, models []string, keyIDs []string) ([]string, map[string][]string) {
+func filterModelsByKeysWithAccessMap(config *configstore.ProviderConfig, provider schemas.ModelProvider, modelCatalog *modelcatalog.ModelCatalog, models []string, keyIDs []string) ([]string, map[string][]string) {
 	if config == nil {
 		return []string{}, map[string][]string{}
 	}
@@ -1010,7 +1036,7 @@ func filterModelsByKeysWithAccessMap(config *configstore.ProviderConfig, models 
 	for _, model := range models {
 		grantedBy := make([]string, 0, len(matchedKeys))
 		for _, matched := range matchedKeys {
-			if keyAllowsModelForList(matched.key, model) {
+			if keyAllowsModelForList(provider, model, matched.key, modelCatalog) {
 				grantedBy = append(grantedBy, matched.id)
 			}
 		}

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -939,6 +939,35 @@ func getValidKeyIDsForProvider(config *configstore.ProviderConfig, keyIDs []stri
 	return valid
 }
 
+func getStrictKeyIDsForProvider(config *configstore.ProviderConfig, keyIDs []string) []string {
+	if config == nil || len(keyIDs) == 0 {
+		return nil
+	}
+
+	existing := make(map[string]bool, len(config.Keys))
+	for _, key := range config.Keys {
+		if key.Enabled != nil && !*key.Enabled {
+			continue
+		}
+		existing[key.ID] = true
+	}
+
+	valid := make([]string, 0, len(keyIDs))
+	seen := make(map[string]bool, len(keyIDs))
+	for _, keyID := range keyIDs {
+		trimmed := strings.TrimSpace(keyID)
+		if trimmed == "" || seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		if !existing[trimmed] {
+			return []string{}
+		}
+		valid = append(valid, trimmed)
+	}
+	return valid
+}
+
 func (h *ProviderHandler) getLegacyFilteredModelsForProvider(provider schemas.ModelProvider, keyIDs []string, unfiltered bool) ([]string, map[string][]string) {
 	var models []string
 	if unfiltered {
@@ -991,7 +1020,7 @@ func (h *ProviderHandler) getStrictFilteredModelsForProvider(provider schemas.Mo
 		return []string{}, map[string][]string{}
 	}
 
-	validKeyIDs := getValidKeyIDsForProvider(config, keyIDs)
+	validKeyIDs := getStrictKeyIDsForProvider(config, keyIDs)
 	if len(validKeyIDs) == 0 {
 		return []string{}, map[string][]string{}
 	}

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -99,6 +99,7 @@ func (h *ProviderHandler) RegisterRoutes(r *router.Router, middlewares ...schema
 	r.DELETE("/api/providers/{provider}", lib.ChainMiddlewares(h.deleteProvider, middlewares...))
 	r.GET("/api/keys", lib.ChainMiddlewares(h.listKeys, middlewares...))
 	r.GET("/api/models", lib.ChainMiddlewares(h.listModels, middlewares...))
+	r.GET("/api/models/details", lib.ChainMiddlewares(h.listModelDetails, middlewares...))
 	r.GET("/api/models/parameters", lib.ChainMiddlewares(h.getModelParameters, middlewares...))
 	r.GET("/api/models/base", lib.ChainMiddlewares(h.listBaseModels, middlewares...))
 }
@@ -624,14 +625,31 @@ type ListModelsResponse struct {
 	Total  int             `json:"total"`
 }
 
+// ModelDetailsResponse represents a model with capability metadata.
+type ModelDetailsResponse struct {
+	Name             string                `json:"name"`
+	Provider         string                `json:"provider"`
+	ContextLength    *int                  `json:"context_length,omitempty"`
+	MaxInputTokens   *int                  `json:"max_input_tokens,omitempty"`
+	MaxOutputTokens  *int                  `json:"max_output_tokens,omitempty"`
+	Architecture     *schemas.Architecture `json:"architecture,omitempty"`
+	AccessibleByKeys []string              `json:"accessible_by_keys,omitempty"`
+}
+
+// ListModelDetailsResponse represents the response for listing detailed models.
+type ListModelDetailsResponse struct {
+	Models []ModelDetailsResponse `json:"models"`
+	Total  int                    `json:"total"`
+}
+
 // listModels handles GET /api/models - List models with filtering
 // Query parameters:
 //   - query: Filter models by name (case-insensitive partial match)
 //   - provider: Filter by specific provider name
 //   - keys: Comma-separated list of key IDs to filter models accessible by those keys
+//   - unfiltered: If true, bypass provider-level model pool restrictions only
 //   - limit: Maximum number of results to return (default: 5)
 func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
-	// Parse query parameters
 	queryParam := string(ctx.QueryArgs().Peek("query"))
 	providerParam := string(ctx.QueryArgs().Peek("provider"))
 	keysParam := string(ctx.QueryArgs().Peek("keys"))
@@ -640,7 +658,6 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 
 	unfiltered := unfilteredParam == "true"
 
-	// Parse limit with default
 	limit := 5
 	if limitParam != "" {
 		if n, err := ctx.QueryArgs().GetUint("limit"); err == nil {
@@ -648,85 +665,46 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
-	var allModels []ModelResponse
+	keyIDs := splitAndTrimCSV(keysParam)
+	allModels := make([]ModelResponse, 0)
 
-	// If provider is specified, get models for that provider only
 	if providerParam != "" {
 		provider := schemas.ModelProvider(providerParam)
-		var models []string
-		if unfiltered {
-			models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
-		} else {
-			models = h.modelsManager.GetModelsForProvider(provider)
-			// Filter by keys if specified
-			if keysParam != "" {
-				keyIDs := strings.Split(keysParam, ",")
-				models = h.filterModelsByKeys(provider, models, keyIDs)
-			}
-		}
+		models, accessByModel := h.getFilteredModelsForProvider(provider, keyIDs, unfiltered)
+		models = filterModelNames(models, queryParam)
 		for _, model := range models {
-			allModels = append(allModels, ModelResponse{
+			entry := ModelResponse{
 				Name:     model,
 				Provider: string(provider),
-			})
+			}
+			if keys := accessByModel[model]; len(keys) > 0 {
+				entry.AccessibleByKeys = keys
+			}
+			allModels = append(allModels, entry)
 		}
 	} else {
-		// Get all providers
 		providers, err := h.inMemoryStore.GetAllProviders()
 		if err != nil {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get providers: %v", err))
 			return
 		}
 
-		// Collect models from all providers
 		for _, provider := range providers {
-			var models []string
-			if unfiltered {
-				models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
-			} else {
-				models = h.modelsManager.GetModelsForProvider(provider)
-				// Filter by keys if specified
-				if keysParam != "" {
-					keyIDs := strings.Split(keysParam, ",")
-					models = h.filterModelsByKeys(provider, models, keyIDs)
-				}
-
-			}
+			models, accessByModel := h.getFilteredModelsForProvider(provider, keyIDs, unfiltered)
+			models = filterModelNames(models, queryParam)
 			for _, model := range models {
-				allModels = append(allModels, ModelResponse{
+				entry := ModelResponse{
 					Name:     model,
 					Provider: string(provider),
-				})
+				}
+				if keys := accessByModel[model]; len(keys) > 0 {
+					entry.AccessibleByKeys = keys
+				}
+				allModels = append(allModels, entry)
 			}
 		}
 	}
 
-	// Apply query filter if provided (fuzzy search)
-	// We are currently doing it in memory to later make use of in memory model pools
-	if queryParam != "" {
-		filtered := []ModelResponse{}
-		queryLower := strings.ToLower(queryParam)
-		// Remove common separators for more flexible matching
-		queryNormalized := strings.ReplaceAll(strings.ReplaceAll(queryLower, "-", ""), "_", "")
-
-		for _, model := range allModels {
-			modelLower := strings.ToLower(model.Name)
-			modelNormalized := strings.ReplaceAll(strings.ReplaceAll(modelLower, "-", ""), "_", "")
-
-			// Match if:
-			// 1. Direct substring match
-			// 2. Normalized substring match (ignoring - and _)
-			// 3. All query characters appear in order (fuzzy match)
-			if strings.Contains(modelLower, queryLower) ||
-				strings.Contains(modelNormalized, queryNormalized) ||
-				fuzzyMatch(modelLower, queryLower) {
-				filtered = append(filtered, model)
-			}
-		}
-		allModels = filtered
-	}
-
-	// Apply limit
 	total := len(allModels)
 	if limit > 0 && limit < len(allModels) {
 		allModels = allModels[:limit]
@@ -738,6 +716,98 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 	}
 
 	SendJSON(ctx, response)
+}
+
+// listModelDetails handles GET /api/models/details - List models with capability metadata.
+// Query parameters:
+//   - query: Filter models by name (case-insensitive partial match)
+//   - provider: Filter by specific provider name
+//   - keys: Comma-separated list of key IDs to filter models accessible by those keys
+//   - unfiltered: If true, bypass provider-level model pool restrictions only
+//   - limit: Maximum number of results to return (default: 20)
+func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
+	queryParam := string(ctx.QueryArgs().Peek("query"))
+	providerParam := string(ctx.QueryArgs().Peek("provider"))
+	keysParam := string(ctx.QueryArgs().Peek("keys"))
+	limitParam := string(ctx.QueryArgs().Peek("limit"))
+	unfilteredParam := string(ctx.QueryArgs().Peek("unfiltered"))
+
+	unfiltered := unfilteredParam == "true"
+
+	limit := 20
+	if limitParam != "" {
+		if n, err := ctx.QueryArgs().GetUint("limit"); err == nil {
+			limit = n
+		}
+	}
+
+	modelCatalog := h.inMemoryStore.ModelCatalog
+	if modelCatalog == nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "model catalog not available")
+		return
+	}
+
+	keyIDs := splitAndTrimCSV(keysParam)
+	allModels := make([]ModelDetailsResponse, 0)
+
+	if providerParam != "" {
+		provider := schemas.ModelProvider(providerParam)
+		models, accessByModel := h.getFilteredModelsForProvider(provider, keyIDs, unfiltered)
+		models = filterModelNames(models, queryParam)
+		for _, model := range models {
+			details := ModelDetailsResponse{
+				Name:     model,
+				Provider: string(provider),
+			}
+			if keys := accessByModel[model]; len(keys) > 0 {
+				details.AccessibleByKeys = keys
+			}
+			if capabilities := modelCatalog.GetModelCapabilityEntryForModel(model, provider); capabilities != nil {
+				details.ContextLength = capabilities.ContextLength
+				details.MaxInputTokens = capabilities.MaxInputTokens
+				details.MaxOutputTokens = capabilities.MaxOutputTokens
+				details.Architecture = capabilities.Architecture
+			}
+			allModels = append(allModels, details)
+		}
+	} else {
+		providers, err := h.inMemoryStore.GetAllProviders()
+		if err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get providers: %v", err))
+			return
+		}
+
+		for _, provider := range providers {
+			models, accessByModel := h.getFilteredModelsForProvider(provider, keyIDs, unfiltered)
+			models = filterModelNames(models, queryParam)
+			for _, model := range models {
+				details := ModelDetailsResponse{
+					Name:     model,
+					Provider: string(provider),
+				}
+				if keys := accessByModel[model]; len(keys) > 0 {
+					details.AccessibleByKeys = keys
+				}
+				if capabilities := modelCatalog.GetModelCapabilityEntryForModel(model, provider); capabilities != nil {
+					details.ContextLength = capabilities.ContextLength
+					details.MaxInputTokens = capabilities.MaxInputTokens
+					details.MaxOutputTokens = capabilities.MaxOutputTokens
+					details.Architecture = capabilities.Architecture
+				}
+				allModels = append(allModels, details)
+			}
+		}
+	}
+
+	total := len(allModels)
+	if limit > 0 && limit < len(allModels) {
+		allModels = allModels[:limit]
+	}
+
+	SendJSON(ctx, ListModelDetailsResponse{
+		Models: allModels,
+		Total:  total,
+	})
 }
 
 // getModelParameters handles GET /api/models/parameters - Get model parameters for a specific model
@@ -781,39 +851,146 @@ func keyAllowsModelForList(key schemas.Key, model string) bool {
 	return true
 }
 
-// filterModelsByKeys filters models based on key-level model restrictions
-func (h *ProviderHandler) filterModelsByKeys(provider schemas.ModelProvider, models []string, keyIDs []string) []string {
-	// Get provider config to access keys
-	config, err := h.inMemoryStore.GetProviderConfigRaw(provider)
-	if err != nil {
-		logger.Warn("Failed to get config for provider %s: %v", provider, err)
-		return models
+func splitAndTrimCSV(value string) []string {
+	if value == "" {
+		return nil
 	}
-	keysByID := make(map[string]schemas.Key, len(config.Keys))
-	for i := range config.Keys {
-		k := config.Keys[i]
-		keysByID[k.ID] = k
-	}
-	matchedKeys := make([]schemas.Key, 0, len(keyIDs))
-	for _, keyID := range keyIDs {
-		if key, ok := keysByID[keyID]; ok {
-			matchedKeys = append(matchedKeys, key)
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
 		}
 	}
-	// Unknown key IDs (or empty keyIDs): do not filter
-	if len(matchedKeys) == 0 {
+	return result
+}
+
+func filterModelNames(models []string, query string) []string {
+	if query == "" {
 		return models
 	}
+
 	filtered := make([]string, 0, len(models))
+	queryLower := strings.ToLower(query)
+	queryNormalized := strings.ReplaceAll(strings.ReplaceAll(queryLower, "-", ""), "_", "")
 	for _, model := range models {
-		for _, key := range matchedKeys {
-			if keyAllowsModelForList(key, model) {
-				filtered = append(filtered, model)
-				break
-			}
+		modelLower := strings.ToLower(model)
+		modelNormalized := strings.ReplaceAll(strings.ReplaceAll(modelLower, "-", ""), "_", "")
+		if strings.Contains(modelLower, queryLower) ||
+			strings.Contains(modelNormalized, queryNormalized) ||
+			fuzzyMatch(modelLower, queryLower) {
+			filtered = append(filtered, model)
 		}
 	}
 	return filtered
+}
+
+func getValidKeyIDsForProvider(config *configstore.ProviderConfig, keyIDs []string) []string {
+	if config == nil || len(keyIDs) == 0 {
+		return nil
+	}
+
+	existing := make(map[string]bool, len(config.Keys))
+	for _, key := range config.Keys {
+		if key.Enabled != nil && !*key.Enabled {
+			continue
+		}
+		existing[key.ID] = true
+	}
+
+	valid := make([]string, 0, len(keyIDs))
+	seen := make(map[string]bool, len(keyIDs))
+	for _, keyID := range keyIDs {
+		if keyID == "" || seen[keyID] {
+			continue
+		}
+		seen[keyID] = true
+		if existing[keyID] {
+			valid = append(valid, keyID)
+		}
+	}
+	return valid
+}
+
+func (h *ProviderHandler) getFilteredModelsForProvider(provider schemas.ModelProvider, keyIDs []string, unfiltered bool) ([]string, map[string][]string) {
+	var models []string
+	if unfiltered {
+		models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
+	} else {
+		models = h.modelsManager.GetModelsForProvider(provider)
+	}
+
+	if len(keyIDs) == 0 {
+		return models, nil
+	}
+
+	config, err := h.inMemoryStore.GetProviderConfigRaw(provider)
+	if err != nil {
+		logger.Warn("Failed to get config for provider %s: %v", provider, err)
+		return []string{}, map[string][]string{}
+	}
+	if config == nil {
+		logger.Warn("Failed to get config for provider %s: nil provider config", provider)
+		return []string{}, map[string][]string{}
+	}
+
+	validKeyIDs := getValidKeyIDsForProvider(config, keyIDs)
+	if len(validKeyIDs) == 0 {
+		return []string{}, map[string][]string{}
+	}
+
+	return filterModelsByKeysWithAccessMap(config, models, validKeyIDs)
+}
+
+// filterModelsByKeysWithAccessMap filters models based on key-level model restrictions
+// and returns the exact key IDs that grant access to each returned model.
+func filterModelsByKeysWithAccessMap(config *configstore.ProviderConfig, models []string, keyIDs []string) ([]string, map[string][]string) {
+	if config == nil {
+		return []string{}, map[string][]string{}
+	}
+
+	keysByID := make(map[string]schemas.Key, len(config.Keys))
+	for _, key := range config.Keys {
+		if key.Enabled != nil && !*key.Enabled {
+			continue
+		}
+		keysByID[key.ID] = key
+	}
+
+	type matchedKey struct {
+		id  string
+		key schemas.Key
+	}
+
+	matchedKeys := make([]matchedKey, 0, len(keyIDs))
+	for _, keyID := range keyIDs {
+		key, ok := keysByID[keyID]
+		if !ok {
+			continue
+		}
+		matchedKeys = append(matchedKeys, matchedKey{id: keyID, key: key})
+	}
+	if len(matchedKeys) == 0 {
+		return []string{}, map[string][]string{}
+	}
+
+	filtered := make([]string, 0, len(models))
+	accessByModel := make(map[string][]string, len(models))
+	for _, model := range models {
+		grantedBy := make([]string, 0, len(matchedKeys))
+		for _, matched := range matchedKeys {
+			if keyAllowsModelForList(matched.key, model) {
+				grantedBy = append(grantedBy, matched.id)
+			}
+		}
+		if len(grantedBy) == 0 {
+			continue
+		}
+		filtered = append(filtered, model)
+		accessByModel[model] = grantedBy
+	}
+	return filtered, accessByModel
 }
 
 // ListBaseModelsResponse represents the response for listing base models

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -670,7 +670,7 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 
 	if providerParam != "" {
 		provider := schemas.ModelProvider(providerParam)
-		models, accessByModel := h.getFilteredModelsForProvider(provider, keyIDs, unfiltered)
+		models, accessByModel := h.getLegacyFilteredModelsForProvider(provider, keyIDs, unfiltered)
 		models = filterModelNames(models, queryParam)
 		for _, model := range models {
 			entry := ModelResponse{
@@ -690,7 +690,7 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 		}
 
 		for _, provider := range providers {
-			models, accessByModel := h.getFilteredModelsForProvider(provider, keyIDs, unfiltered)
+			models, accessByModel := h.getLegacyFilteredModelsForProvider(provider, keyIDs, unfiltered)
 			models = filterModelNames(models, queryParam)
 			for _, model := range models {
 				entry := ModelResponse{
@@ -752,7 +752,7 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 
 	if providerParam != "" {
 		provider := schemas.ModelProvider(providerParam)
-		models, accessByModel := h.getFilteredModelsForProvider(provider, keyIDs, unfiltered)
+		models, accessByModel := h.getStrictFilteredModelsForProvider(provider, keyIDs, unfiltered)
 		models = filterModelNames(models, queryParam)
 		for _, model := range models {
 			details := ModelDetailsResponse{
@@ -778,7 +778,7 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 		}
 
 		for _, provider := range providers {
-			models, accessByModel := h.getFilteredModelsForProvider(provider, keyIDs, unfiltered)
+			models, accessByModel := h.getStrictFilteredModelsForProvider(provider, keyIDs, unfiltered)
 			models = filterModelNames(models, queryParam)
 			for _, model := range models {
 				details := ModelDetailsResponse{
@@ -913,7 +913,37 @@ func getValidKeyIDsForProvider(config *configstore.ProviderConfig, keyIDs []stri
 	return valid
 }
 
-func (h *ProviderHandler) getFilteredModelsForProvider(provider schemas.ModelProvider, keyIDs []string, unfiltered bool) ([]string, map[string][]string) {
+func (h *ProviderHandler) getLegacyFilteredModelsForProvider(provider schemas.ModelProvider, keyIDs []string, unfiltered bool) ([]string, map[string][]string) {
+	var models []string
+	if unfiltered {
+		models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
+		return models, nil
+	}
+	models = h.modelsManager.GetModelsForProvider(provider)
+
+	if len(keyIDs) == 0 {
+		return models, nil
+	}
+
+	config, err := h.inMemoryStore.GetProviderConfigRaw(provider)
+	if err != nil {
+		logger.Warn("Failed to get config for provider %s: %v", provider, err)
+		return models, nil
+	}
+	if config == nil {
+		logger.Warn("Failed to get config for provider %s: nil provider config", provider)
+		return models, nil
+	}
+
+	validKeyIDs := getValidKeyIDsForProvider(config, keyIDs)
+	if len(validKeyIDs) == 0 {
+		return models, nil
+	}
+
+	return filterModelsByKeysWithAccessMap(config, models, validKeyIDs)
+}
+
+func (h *ProviderHandler) getStrictFilteredModelsForProvider(provider schemas.ModelProvider, keyIDs []string, unfiltered bool) ([]string, map[string][]string) {
 	var models []string
 	if unfiltered {
 		models = h.modelsManager.GetUnfilteredModelsForProvider(provider)

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -40,21 +40,21 @@ func (m *mockModelsManager) GetUnfilteredModelsForProvider(provider schemas.Mode
 	return result
 }
 
-func providerHandlerForTest(keys []schemas.Key, filtered, unfiltered []string) *ProviderHandler {
+func providerHandlerForTest(provider schemas.ModelProvider, keys []schemas.Key, filtered, unfiltered []string) *ProviderHandler {
 	return &ProviderHandler{
 		inMemoryStore: &lib.Config{
 			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
-				schemas.OpenAI: {
+				provider: {
 					Keys: keys,
 				},
 			},
 		},
 		modelsManager: &mockModelsManager{
 			filtered: map[schemas.ModelProvider][]string{
-				schemas.OpenAI: filtered,
+				provider: filtered,
 			},
 			unfiltered: map[schemas.ModelProvider][]string{
-				schemas.OpenAI: unfiltered,
+				provider: unfiltered,
 			},
 		},
 	}
@@ -66,6 +66,7 @@ func TestListModels_UnknownKeysDoNotFilter(t *testing.T) {
 	SetLogger(&mockLogger{})
 
 	h := providerHandlerForTest(
+		schemas.OpenAI,
 		[]schemas.Key{{ID: "key-a"}},
 		[]string{"gpt-4o", "gpt-4o-mini"},
 		[]string{"gpt-4o", "gpt-4o-mini"},
@@ -103,6 +104,7 @@ func TestListModels_ReturnsExactAccessibleByKeysAndSkipsDisabledKeys(t *testing.
 	SetLogger(&mockLogger{})
 
 	h := providerHandlerForTest(
+		schemas.OpenAI,
 		[]schemas.Key{
 			{ID: "key-a", Models: []string{"gpt-4o"}},
 			{ID: "key-b", Models: []string{"gpt-4o", "gpt-4o-mini"}},
@@ -148,6 +150,7 @@ func TestListModels_UnfilteredIgnoresKeys(t *testing.T) {
 	SetLogger(&mockLogger{})
 
 	h := providerHandlerForTest(
+		schemas.OpenAI,
 		[]schemas.Key{
 			{ID: "key-b", Models: []string{"gpt-4o-mini"}},
 		},
@@ -185,6 +188,7 @@ func TestListModels_UnfilteredWithoutKeysReturnsAllUnfilteredModels(t *testing.T
 	SetLogger(&mockLogger{})
 
 	h := providerHandlerForTest(
+		schemas.OpenAI,
 		[]schemas.Key{
 			{ID: "key-b", Models: []string{"gpt-4o-mini"}},
 		},
@@ -222,6 +226,7 @@ func TestListModelDetails_ErrorsWhenModelCatalogUnavailable(t *testing.T) {
 	SetLogger(&mockLogger{})
 
 	h := providerHandlerForTest(
+		schemas.OpenAI,
 		[]schemas.Key{{ID: "key-a"}},
 		[]string{"gpt-4o"},
 		[]string{"gpt-4o"},
@@ -242,6 +247,7 @@ func TestListModelDetails_FailsClosedForUnknownKeys(t *testing.T) {
 	SetLogger(&mockLogger{})
 
 	h := providerHandlerForTest(
+		schemas.OpenAI,
 		[]schemas.Key{{ID: "key-a"}},
 		[]string{"gpt-4o", "gpt-4o-mini"},
 		[]string{"gpt-4o", "gpt-4o-mini"},
@@ -272,6 +278,7 @@ func TestListModelDetails_UnfilteredStillHonorsKeys(t *testing.T) {
 	SetLogger(&mockLogger{})
 
 	h := providerHandlerForTest(
+		schemas.OpenAI,
 		[]schemas.Key{
 			{ID: "key-b", Models: []string{"gpt-4o-mini"}},
 		},
@@ -300,5 +307,40 @@ func TestListModelDetails_UnfilteredStillHonorsKeys(t *testing.T) {
 	}
 	if len(resp.Models[0].AccessibleByKeys) != 1 || resp.Models[0].AccessibleByKeys[0] != "key-b" {
 		t.Fatalf("expected exact accessible_by_keys for gpt-4o-mini, got %#v", resp.Models[0].AccessibleByKeys)
+	}
+}
+
+func TestListModels_UsesCatalogAwareAliasMatchingForKeyAllowlist(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		schemas.OpenAI,
+		[]schemas.Key{
+			{ID: "key-a", Models: []string{"gpt-4o-2024-08-06"}},
+		},
+		[]string{"gpt-4o"},
+		[]string{"gpt-4o"},
+	)
+	h.inMemoryStore.ModelCatalog = modelcatalog.NewTestCatalog(map[string]string{
+		"gpt-4o-2024-08-06": "gpt-4o",
+	})
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models?provider=openai&keys=key-a")
+
+	h.listModels(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var resp ListModelsResponse
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Total != 1 || len(resp.Models) != 1 || resp.Models[0].Name != "gpt-4o" {
+		t.Fatalf("expected gpt-4o to be matched through alias allowlist, got %#v", resp.Models)
 	}
 }

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -274,6 +274,71 @@ func TestListModelDetails_FailsClosedForUnknownKeys(t *testing.T) {
 	}
 }
 
+func TestListModelDetails_FailsClosedForMixedValidAndUnknownKeys(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		schemas.OpenAI,
+		[]schemas.Key{{ID: "key-a"}},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+	)
+	h.inMemoryStore.ModelCatalog = &modelcatalog.ModelCatalog{}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models/details?provider=openai&keys=key-a,missing")
+
+	h.listModelDetails(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var resp ListModelDetailsResponse
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Total != 0 || len(resp.Models) != 0 {
+		t.Fatalf("expected no models, got %#v", resp.Models)
+	}
+}
+
+func TestListModelDetails_FailsClosedForDisabledKeys(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		schemas.OpenAI,
+		[]schemas.Key{
+			{ID: "key-a"},
+			{ID: "key-disabled", Enabled: boolPtr(false)},
+		},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+	)
+	h.inMemoryStore.ModelCatalog = &modelcatalog.ModelCatalog{}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models/details?provider=openai&keys=key-a,key-disabled")
+
+	h.listModelDetails(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var resp ListModelDetailsResponse
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Total != 0 || len(resp.Models) != 0 {
+		t.Fatalf("expected no models, got %#v", resp.Models)
+	}
+}
+
 func TestListModelDetails_UnfilteredStillHonorsKeys(t *testing.T) {
 	SetLogger(&mockLogger{})
 

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -1,0 +1,227 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+type mockModelsManager struct {
+	filtered   map[schemas.ModelProvider][]string
+	unfiltered map[schemas.ModelProvider][]string
+}
+
+func (m *mockModelsManager) ReloadProvider(_ context.Context, _ schemas.ModelProvider) (*configstoreTables.TableProvider, error) {
+	return nil, nil
+}
+
+func (m *mockModelsManager) RemoveProvider(_ context.Context, _ schemas.ModelProvider) error {
+	return nil
+}
+
+func (m *mockModelsManager) GetModelsForProvider(provider schemas.ModelProvider) []string {
+	models := m.filtered[provider]
+	result := make([]string, len(models))
+	copy(result, models)
+	return result
+}
+
+func (m *mockModelsManager) GetUnfilteredModelsForProvider(provider schemas.ModelProvider) []string {
+	models := m.unfiltered[provider]
+	result := make([]string, len(models))
+	copy(result, models)
+	return result
+}
+
+func providerHandlerForTest(keys []schemas.Key, filtered, unfiltered []string) *ProviderHandler {
+	return &ProviderHandler{
+		inMemoryStore: &lib.Config{
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				schemas.OpenAI: {
+					Keys: keys,
+				},
+			},
+		},
+		modelsManager: &mockModelsManager{
+			filtered: map[schemas.ModelProvider][]string{
+				schemas.OpenAI: filtered,
+			},
+			unfiltered: map[schemas.ModelProvider][]string{
+				schemas.OpenAI: unfiltered,
+			},
+		},
+	}
+}
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestListModels_FailsClosedForUnknownKeys(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		[]schemas.Key{{ID: "key-a"}},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+	)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models?provider=openai&keys=missing")
+
+	h.listModels(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var resp ListModelsResponse
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Total != 0 {
+		t.Fatalf("expected total=0, got %d", resp.Total)
+	}
+	if len(resp.Models) != 0 {
+		t.Fatalf("expected no models, got %#v", resp.Models)
+	}
+}
+
+func TestListModels_ReturnsExactAccessibleByKeysAndSkipsDisabledKeys(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		[]schemas.Key{
+			{ID: "key-a", Models: []string{"gpt-4o"}},
+			{ID: "key-b", Models: []string{"gpt-4o", "gpt-4o-mini"}},
+			{ID: "key-disabled", Enabled: boolPtr(false)},
+		},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+	)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models?provider=openai&keys=key-a,key-b,key-disabled")
+
+	h.listModels(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var resp ListModelsResponse
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Total != 2 {
+		t.Fatalf("expected total=2, got %d", resp.Total)
+	}
+
+	got := map[string][]string{}
+	for _, model := range resp.Models {
+		got[model.Name] = model.AccessibleByKeys
+	}
+
+	if len(got["gpt-4o"]) != 2 || got["gpt-4o"][0] != "key-a" || got["gpt-4o"][1] != "key-b" {
+		t.Fatalf("expected gpt-4o to be accessible by [key-a key-b], got %#v", got["gpt-4o"])
+	}
+	if len(got["gpt-4o-mini"]) != 1 || got["gpt-4o-mini"][0] != "key-b" {
+		t.Fatalf("expected gpt-4o-mini to be accessible by [key-b], got %#v", got["gpt-4o-mini"])
+	}
+}
+
+func TestListModels_UnfilteredStillHonorsKeys(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		[]schemas.Key{
+			{ID: "key-b", Models: []string{"gpt-4o-mini"}},
+		},
+		[]string{"gpt-4o"},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+	)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models?provider=openai&keys=key-b&unfiltered=true")
+
+	h.listModels(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var resp ListModelsResponse
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Total != 1 || len(resp.Models) != 1 || resp.Models[0].Name != "gpt-4o-mini" {
+		t.Fatalf("expected only gpt-4o-mini, got %#v", resp.Models)
+	}
+}
+
+func TestListModels_UnfilteredWithoutKeysReturnsAllUnfilteredModels(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		[]schemas.Key{
+			{ID: "key-b", Models: []string{"gpt-4o-mini"}},
+		},
+		[]string{"gpt-4o"},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+	)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models?provider=openai&unfiltered=true")
+
+	h.listModels(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var resp ListModelsResponse
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Total != 2 || len(resp.Models) != 2 {
+		t.Fatalf("expected both unfiltered models, got %#v", resp.Models)
+	}
+
+	for _, model := range resp.Models {
+		if len(model.AccessibleByKeys) != 0 {
+			t.Fatalf("expected no accessible_by_keys when no key filter is requested, got %#v", resp.Models)
+		}
+	}
+}
+
+func TestListModelDetails_ErrorsWhenModelCatalogUnavailable(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		[]schemas.Key{{ID: "key-a"}},
+		[]string{"gpt-4o"},
+		[]string{"gpt-4o"},
+	)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models/details?provider=openai")
+
+	h.listModelDetails(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+}

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/modelcatalog"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
@@ -61,7 +62,7 @@ func providerHandlerForTest(keys []schemas.Key, filtered, unfiltered []string) *
 
 func boolPtr(v bool) *bool { return &v }
 
-func TestListModels_FailsClosedForUnknownKeys(t *testing.T) {
+func TestListModels_UnknownKeysDoNotFilter(t *testing.T) {
 	SetLogger(&mockLogger{})
 
 	h := providerHandlerForTest(
@@ -85,11 +86,16 @@ func TestListModels_FailsClosedForUnknownKeys(t *testing.T) {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
 
-	if resp.Total != 0 {
-		t.Fatalf("expected total=0, got %d", resp.Total)
+	if resp.Total != 2 {
+		t.Fatalf("expected total=2, got %d", resp.Total)
 	}
-	if len(resp.Models) != 0 {
-		t.Fatalf("expected no models, got %#v", resp.Models)
+	if len(resp.Models) != 2 {
+		t.Fatalf("expected all models to be returned, got %#v", resp.Models)
+	}
+	for _, model := range resp.Models {
+		if len(model.AccessibleByKeys) != 0 {
+			t.Fatalf("expected no accessible_by_keys annotations, got %#v", resp.Models)
+		}
 	}
 }
 
@@ -138,7 +144,7 @@ func TestListModels_ReturnsExactAccessibleByKeysAndSkipsDisabledKeys(t *testing.
 	}
 }
 
-func TestListModels_UnfilteredStillHonorsKeys(t *testing.T) {
+func TestListModels_UnfilteredIgnoresKeys(t *testing.T) {
 	SetLogger(&mockLogger{})
 
 	h := providerHandlerForTest(
@@ -164,8 +170,14 @@ func TestListModels_UnfilteredStillHonorsKeys(t *testing.T) {
 		t.Fatalf("failed to unmarshal response: %v", err)
 	}
 
-	if resp.Total != 1 || len(resp.Models) != 1 || resp.Models[0].Name != "gpt-4o-mini" {
-		t.Fatalf("expected only gpt-4o-mini, got %#v", resp.Models)
+	if resp.Total != 2 || len(resp.Models) != 2 {
+		t.Fatalf("expected both unfiltered models, got %#v", resp.Models)
+	}
+
+	for _, model := range resp.Models {
+		if len(model.AccessibleByKeys) != 0 {
+			t.Fatalf("expected no accessible_by_keys when unfiltered bypasses key filtering, got %#v", resp.Models)
+		}
 	}
 }
 
@@ -223,5 +235,70 @@ func TestListModelDetails_ErrorsWhenModelCatalogUnavailable(t *testing.T) {
 
 	if ctx.Response.StatusCode() != fasthttp.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+}
+
+func TestListModelDetails_FailsClosedForUnknownKeys(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		[]schemas.Key{{ID: "key-a"}},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+	)
+	h.inMemoryStore.ModelCatalog = &modelcatalog.ModelCatalog{}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models/details?provider=openai&keys=missing")
+
+	h.listModelDetails(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var resp ListModelDetailsResponse
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Total != 0 || len(resp.Models) != 0 {
+		t.Fatalf("expected no models, got %#v", resp.Models)
+	}
+}
+
+func TestListModelDetails_UnfilteredStillHonorsKeys(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		[]schemas.Key{
+			{ID: "key-b", Models: []string{"gpt-4o-mini"}},
+		},
+		[]string{"gpt-4o"},
+		[]string{"gpt-4o", "gpt-4o-mini"},
+	)
+	h.inMemoryStore.ModelCatalog = &modelcatalog.ModelCatalog{}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models/details?provider=openai&keys=key-b&unfiltered=true")
+
+	h.listModelDetails(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var resp ListModelDetailsResponse
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Total != 1 || len(resp.Models) != 1 || resp.Models[0].Name != "gpt-4o-mini" {
+		t.Fatalf("expected only gpt-4o-mini, got %#v", resp.Models)
+	}
+	if len(resp.Models[0].AccessibleByKeys) != 1 || resp.Models[0].AccessibleByKeys[0] != "key-b" {
+		t.Fatalf("expected exact accessible_by_keys for gpt-4o-mini, got %#v", resp.Models[0].AccessibleByKeys)
 	}
 }


### PR DESCRIPTION
## Summary

Adds `GET /api/models/details` to expose model capability metadata from the model catalog, including token limits and architecture data when available.

This also tightens `/api/models` filtering so key-based access is handled consistently across both endpoints, with exact `accessible_by_keys` annotations and fail-closed behavior for invalid keys.

Supersedes #1983.

---

## Changes

- Added `GET /api/models/details` for model capability metadata
- Added capability fields to model pricing persistence:
    - `context_length`
    - `max_input_tokens`
    - `max_output_tokens`
    - `architecture`
- Added a migration for the new `governance_model_pricing` columns
- Added `GetModelCapabilityEntryForModel` in the model catalog with preferred mode precedence
- Refactored model filtering so `/api/models` and `/api/models/details` share key filtering behavior
- Added exact `accessible_by_keys` per returned model
- Added `unfiltered` support to `/api/models/details` and documented it for `/api/models`
- Updated OpenAPI docs for the new endpoint and response schema
- Added targeted handler and modelcatalog tests

---

## Type of Change

- [x] Feature
- [x] Bug fix
- [x] Refactor
- [x] Documentation

---

## Affected Areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Docs

---

## Behavioral Notes

- `unfiltered=true` bypasses provider-level model pool restrictions only
- `keys` filtering still applies when `unfiltered=true`
- Invalid or unknown key IDs fail closed with `200` and empty results
- Disabled keys do not grant access
- Capability fields are returned when available from the model catalog

---

## How to Test

```bash
BASE="http://localhost:8080"

# Existing endpoint
curl "$BASE/api/models?provider=openai"
curl "$BASE/api/models?provider=openai&query=gpt"
curl "$BASE/api/models?provider=openai&keys=<real-openai-key-id>"
curl "$BASE/api/models?provider=openai&keys=missing"
curl "$BASE/api/models?provider=openai&unfiltered=true"
curl "$BASE/api/models?provider=openai&unfiltered=true&keys=<real-openai-key-id>"

# New endpoint
curl "$BASE/api/models/details?provider=openai&limit=5"
curl "$BASE/api/models/details?provider=openai&query=gpt"
curl "$BASE/api/models/details?provider=openai&keys=<real-openai-key-id>"
curl "$BASE/api/models/details?provider=openai&keys=missing"
curl "$BASE/api/models/details?provider=openai&unfiltered=true"
curl "$BASE/api/models/details?provider=openai&unfiltered=true&keys=<real-openai-key-id>"

# Targeted tests
cd framework && go test ./modelcatalog/...
cd transports && go test ./bifrost-http/handlers/...
```

---

## Breaking Changes

- [x] No

The endpoints remain additive. The only intentional semantic tightening is that `keys` are still honored when `unfiltered=true`.

---

## Related Issues

- Closes #1954
- Supersedes #1983

---

## Security Considerations

The new endpoint follows existing management API auth and provider configuration rules. Key filtering remains fail-closed and `unfiltered` does not bypass key-level access restrictions.

---

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I manually verified endpoint behavior