### PR TITLE
fixes azure form to show api key in the right section

### DIFF
--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -58,40 +58,40 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 	const supportsBatchAPI = BATCH_SUPPORTED_PROVIDERS.includes(providerName);
 
 	// Auth type state for Azure: 'api_key', 'entra_id', or 'default_credential'
-	const [azureAuthType, setAzureAuthType] = useState<'api_key' | 'entra_id' | 'default_credential'>('api_key')
+	const [azureAuthType, setAzureAuthType] = useState<"api_key" | "entra_id" | "default_credential">("api_key");
 
 	// Auth type state for Bedrock: 'iam_role', 'explicit', or 'api_key'
-	const [bedrockAuthType, setBedrockAuthType] = useState<'iam_role' | 'explicit' | 'api_key'>('iam_role')
+	const [bedrockAuthType, setBedrockAuthType] = useState<"iam_role" | "explicit" | "api_key">("iam_role");
 
 	// Detect auth type from existing form values when editing
 	useEffect(() => {
-		if (form.formState.isDirty) return
+		if (form.formState.isDirty) return;
 		if (isAzure) {
-			const clientId = form.getValues('key.azure_key_config.client_id')?.value
-			const clientSecret = form.getValues('key.azure_key_config.client_secret')?.value
-			const tenantId = form.getValues('key.azure_key_config.tenant_id')?.value
-			const apiKey = form.getValues('key.value')?.value
+			const clientId = form.getValues("key.azure_key_config.client_id")?.value;
+			const clientSecret = form.getValues("key.azure_key_config.client_secret")?.value;
+			const tenantId = form.getValues("key.azure_key_config.tenant_id")?.value;
+			const apiKey = form.getValues("key.value")?.value;
 			if (clientId || clientSecret || tenantId) {
-				setAzureAuthType('entra_id')
+				setAzureAuthType("entra_id");
 			} else if (!apiKey) {
-				setAzureAuthType('default_credential')
+				setAzureAuthType("default_credential");
 			}
 		}
-	}, [isAzure, form])
+	}, [isAzure, form]);
 
 	useEffect(() => {
-		if (form.formState.isDirty) return
+		if (form.formState.isDirty) return;
 		if (isBedrock) {
-			const accessKey = form.getValues('key.bedrock_key_config.access_key')?.value
-			const secretKey = form.getValues('key.bedrock_key_config.secret_key')?.value
-			const apiKey = form.getValues('key.value')?.value
+			const accessKey = form.getValues("key.bedrock_key_config.access_key")?.value;
+			const secretKey = form.getValues("key.bedrock_key_config.secret_key")?.value;
+			const apiKey = form.getValues("key.value")?.value;
 			if (accessKey || secretKey) {
-				setBedrockAuthType('explicit')
+				setBedrockAuthType("explicit");
 			} else if (apiKey) {
-				setBedrockAuthType('api_key')
+				setBedrockAuthType("api_key");
 			}
 		}
-	}, [isBedrock, form])
+	}, [isBedrock, form]);
 
 	return (
 		<div data-tab="api-keys" className="space-y-4 overflow-hidden">
@@ -171,81 +171,81 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 				/>
 			</div>
 			{/* Hide API Key field for Azure when using Entra ID/Default Credential, and for Bedrock when not using API Key auth */}
-			{!(isAzure && (azureAuthType === "entra_id" || azureAuthType === "default_credential")) && !(isBedrock) && (
-					<FormField
-						control={control}
-						name={`key.value`}
-						render={({ field }) => (
-							<FormItem>
-								<FormLabel>API Key {isVertex ? "(Supported only for gemini and fine-tuned models)" : isVLLM ? "(Optional)" : ""}</FormLabel>
-								<FormControl>
-									<EnvVarInput placeholder="API Key or env.MY_KEY" type="text" {...field} />
-								</FormControl>
-								<FormMessage />
-							</FormItem>
-						)}
-					/>
-				)}
-			{!isVLLM && (
-				<>
+			{!isAzure && !isBedrock && (
 				<FormField
 					control={control}
-					name={`key.models`}
+					name={`key.value`}
 					render={({ field }) => (
 						<FormItem>
-							<div className="flex items-center gap-2">
-								<FormLabel>Allowed Models</FormLabel>
-								<TooltipProvider>
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<span>
-												<Info className="text-muted-foreground h-3 w-3" />
-											</span>
-										</TooltipTrigger>
-										<TooltipContent>
-											<p>Comma-separated list of models this key applies to. Leave blank for all models.</p>
-										</TooltipContent>
-									</Tooltip>
-								</TooltipProvider>
-							</div>
+							<FormLabel>API Key {isVertex ? "(Supported only for gemini and fine-tuned models)" : isVLLM ? "(Optional)" : ""}</FormLabel>
 							<FormControl>
-								<ModelMultiselect provider={providerName} value={field.value || []} onChange={field.onChange} unfiltered={true} />
+								<EnvVarInput placeholder="API Key or env.MY_KEY" type="text" {...field} />
 							</FormControl>
 							<FormMessage />
 						</FormItem>
 					)}
 				/>
-				<FormField
-				control={control}
-				name={`key.blacklisted_models`}
-				render={({ field }) => (
-					<FormItem data-testid="apikey-blacklisted-models-field">
-						<div className="flex items-center gap-2">
-							<FormLabel>Blacklisted models</FormLabel>
-							<TooltipProvider>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<span>
-											<Info className="text-muted-foreground h-3 w-3" />
-										</span>
-									</TooltipTrigger>
-									<TooltipContent className="max-w-sm">
-										<p>
-											Comma-separated list of models this key must never use. If a model appears in both Allowed Models and here, the blacklist wins. Leave
-											empty if none.
-										</p>
-									</TooltipContent>
-								</Tooltip>
-							</TooltipProvider>
-						</div>
-						<FormControl>
-							<ModelMultiselect provider={providerName} value={field.value || []} onChange={field.onChange} unfiltered={true} />
-						</FormControl>
-						<FormMessage />
-					</FormItem>
-				)}
-			/>
-			</>
+			)}
+			{!isVLLM && (
+				<>
+					<FormField
+						control={control}
+						name={`key.models`}
+						render={({ field }) => (
+							<FormItem>
+								<div className="flex items-center gap-2">
+									<FormLabel>Allowed Models</FormLabel>
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<span>
+													<Info className="text-muted-foreground h-3 w-3" />
+												</span>
+											</TooltipTrigger>
+											<TooltipContent>
+												<p>Comma-separated list of models this key applies to. Leave blank for all models.</p>
+											</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								</div>
+								<FormControl>
+									<ModelMultiselect provider={providerName} value={field.value || []} onChange={field.onChange} unfiltered={true} />
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+					<FormField
+						control={control}
+						name={`key.blacklisted_models`}
+						render={({ field }) => (
+							<FormItem data-testid="apikey-blacklisted-models-field">
+								<div className="flex items-center gap-2">
+									<FormLabel>Blacklisted models</FormLabel>
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<span>
+													<Info className="text-muted-foreground h-3 w-3" />
+												</span>
+											</TooltipTrigger>
+											<TooltipContent className="max-w-sm">
+												<p>
+													Comma-separated list of models this key must never use. If a model appears in both Allowed Models and here, the
+													blacklist wins. Leave empty if none.
+												</p>
+											</TooltipContent>
+										</Tooltip>
+									</TooltipProvider>
+								</div>
+								<FormControl>
+									<ModelMultiselect provider={providerName} value={field.value || []} onChange={field.onChange} unfiltered={true} />
+								</FormControl>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+				</>
 			)}
 			{supportsBatchAPI && !isBedrock && !isAzure && <BatchAPIFormField control={control} form={form} />}
 			{isAzure && (
@@ -283,6 +283,23 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 							</TabsList>
 						</Tabs>
 					</div>
+					{azureAuthType === "api_key" && (
+						<FormField
+							control={control}
+							name={`key.value`}
+							render={({ field }) => (
+								<FormItem>
+									<FormLabel>
+										API Key {isVertex ? "(Supported only for gemini and fine-tuned models)" : isVLLM ? "(Optional)" : ""}
+									</FormLabel>
+									<FormControl>
+										<EnvVarInput placeholder="API Key or env.MY_KEY" type="text" {...field} />
+									</FormControl>
+									<FormMessage />
+								</FormItem>
+							)}
+						/>
+					)}
 					{azureAuthType === "default_credential" && (
 						<p className="text-muted-foreground text-sm">
 							Uses DefaultAzureCredential — automatically detects managed identity on Azure VMs and containers, workload identity in AKS,
@@ -382,7 +399,12 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 											</TooltipProvider>
 										</div>
 										<FormControl>
-											<TagInput data-testid="apikey-azure-scopes-input" placeholder="Add scope (Enter or comma)" value={field.value ?? []} onValueChange={field.onChange} />
+											<TagInput
+												data-testid="apikey-azure-scopes-input"
+												placeholder="Add scope (Enter or comma)"
+												value={field.value ?? []}
+												onValueChange={field.onChange}
+											/>
 										</FormControl>
 										<FormMessage />
 									</FormItem>
@@ -653,9 +675,15 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 							}}
 						>
 							<TabsList className="grid w-full grid-cols-3">
-								<TabsTrigger data-testid="apikey-bedrock-iam-role-tab" value="iam_role">IAM Role (Inherited)</TabsTrigger>
-								<TabsTrigger data-testid="apikey-bedrock-explicit-credentials-tab" value="explicit">Explicit Credentials</TabsTrigger>
-								<TabsTrigger data-testid="apikey-bedrock-api-key-tab" value="api_key">API Key</TabsTrigger>
+								<TabsTrigger data-testid="apikey-bedrock-iam-role-tab" value="iam_role">
+									IAM Role (Inherited)
+								</TabsTrigger>
+								<TabsTrigger data-testid="apikey-bedrock-explicit-credentials-tab" value="explicit">
+									Explicit Credentials
+								</TabsTrigger>
+								<TabsTrigger data-testid="apikey-bedrock-api-key-tab" value="api_key">
+									API Key
+								</TabsTrigger>
 							</TabsList>
 						</Tabs>
 						{bedrockAuthType === "iam_role" && (
@@ -718,7 +746,12 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 								<FormItem>
 									<FormLabel>API Key</FormLabel>
 									<FormControl>
-										<EnvVarInput data-testid="apikey-bedrock-api-key-input" placeholder="API Key or env.BEDROCK_API_KEY" type="text" {...field} />
+										<EnvVarInput
+											data-testid="apikey-bedrock-api-key-input"
+											placeholder="API Key or env.BEDROCK_API_KEY"
+											type="text"
+											{...field}
+										/>
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -769,7 +802,11 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 										<FormLabel>External ID (Optional)</FormLabel>
 										<FormDescription>Required by the role's trust policy when using cross-account access</FormDescription>
 										<FormControl>
-											<EnvVarInput data-testid="apikey-bedrock-external-id-input" placeholder="external-id or env.AWS_EXTERNAL_ID" {...field} />
+											<EnvVarInput
+												data-testid="apikey-bedrock-external-id-input"
+												placeholder="external-id or env.AWS_EXTERNAL_ID"
+												{...field}
+											/>
 										</FormControl>
 										<FormMessage />
 									</FormItem>


### PR DESCRIPTION
## Summary

Fixes the API key form display logic for Azure and Bedrock providers by ensuring the API key field is properly shown when using API key authentication and hidden when using alternative authentication methods.

## Changes

- Fixed conditional rendering logic for the API key field to properly handle Azure and Bedrock providers
- Added dedicated API key field for Azure when "api_key" authentication type is selected
- Standardized quote usage from single quotes to double quotes throughout the component
- Added missing semicolons for consistent code formatting
- Improved code formatting for better readability in TabsTrigger and EnvVarInput components

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

1. Navigate to the workspace providers configuration
2. Configure an Azure provider and verify:
   - API key field appears when "API Key" authentication is selected
   - API key field is hidden when "Entra ID" or "Default Credential" is selected
3. Configure a Bedrock provider and verify the API key field displays correctly for each authentication method
4. Verify other providers still show the API key field as expected

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A - Logic fix for form field visibility

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this change only affects UI form field visibility logic.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable