### PR TITLE
fixes broken routing rule link

### DIFF
--- a/docs/cli-agents/claude-for-office.mdx
+++ b/docs/cli-agents/claude-for-office.mdx
@@ -87,7 +87,7 @@ For example:
 
 ### Option 2: Use Routing Rules
 
-If you prefer to keep the default model names in Claude for Office and control routing server-side, create a [routing rule](/features/governance/routing-rules) in Bifrost. This lets you route requests to any provider — with fallbacks — without changing anything in the add-in.
+If you prefer to keep the default model names in Claude for Office and control routing server-side, create a [routing rule](/providers/routing-rules) in Bifrost. This lets you route requests to any provider — with fallbacks — without changing anything in the add-in.
 
 For example, you can create a rule that matches requests from Claude for Office (based on the `origin` header) and routes them to Azure with a Vertex AI fallback:
 


### PR DESCRIPTION
## Summary

Fixed a broken documentation link in the Claude for Office guide that was pointing to an incorrect routing rules path.

## Changes

- Updated the routing rules link from `/features/governance/routing-rules` to `/providers/routing-rules` in the Claude for Office documentation
- This ensures users can properly access the routing rules documentation when following the guide

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the routing rules link works correctly in the Claude for Office documentation:

1. Navigate to the Claude for Office documentation page
2. Click on the "routing rule" link in the "Option 2: Use Routing Rules" section
3. Confirm it navigates to the correct routing rules documentation page

## Screenshots/Recordings

N/A - Link fix only

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - documentation link fix only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable