### PR TITLE
llm validation fixes

### DIFF
--- a/core/internal/llmtests/validation_presets.go
+++ b/core/internal/llmtests/validation_presets.go
@@ -416,35 +416,34 @@ func GetExpectationsForScenario(scenarioName string, testConfig ComprehensiveTes
 // Each provider is explicitly configured for: usage stats, timestamps, model, and latency.
 // If a provider is not listed, defaults are kept (all true from BasicChatExpectations).
 func ModifyExpectationsForProvider(expectations ResponseExpectations, provider schemas.ModelProvider) ResponseExpectations {
+	// NOTE: This function must NOT set ShouldHaveTimestamps or ShouldHaveModel to true.
+	// StreamingExpectations explicitly disables those fields, and overriding them here
+	// would cause streaming tests to incorrectly assert on fields that consolidated
+	// streaming responses cannot reliably carry.
+	// ShouldHaveUsageStats and ShouldHaveLatency may still be enabled here because no
+	// scenario preset disables them, and some presets (e.g. ReasoningExpectations) omit
+	// ShouldHaveLatency entirely.
 	switch provider {
 	case schemas.OpenAI:
 		expectations.ShouldHaveUsageStats = true
-		expectations.ShouldHaveTimestamps = true
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Azure:
 		// Azure OpenAI returns the same fields as OpenAI
 		expectations.ShouldHaveUsageStats = true
-		expectations.ShouldHaveTimestamps = true
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Anthropic:
 		expectations.ShouldHaveUsageStats = true
-		expectations.ShouldHaveTimestamps = true
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Bedrock:
 		// Bedrock returns usage stats for most calls via Bifrost normalization, but not all
 		expectations.ShouldHaveTimestamps = false // Bedrock does not return created timestamps
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Cohere:
 		expectations.ShouldHaveUsageStats = true
-		expectations.ShouldHaveTimestamps = true
 		expectations.ShouldHaveModel = false // Cohere does not return model field in all response types
 		expectations.ShouldHaveLatency = true
 
@@ -452,32 +451,25 @@ func ModifyExpectationsForProvider(expectations ResponseExpectations, provider s
 		// Google Vertex AI returns usage and model but may not return timestamps
 		expectations.ShouldHaveUsageStats = true
 		expectations.ShouldHaveTimestamps = false // Vertex does not return created timestamps
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Mistral:
 		expectations.ShouldHaveUsageStats = true
-		expectations.ShouldHaveTimestamps = true
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Ollama:
 		// Local models may not return usage or timestamps
 		expectations.ShouldHaveUsageStats = false
 		expectations.ShouldHaveTimestamps = false
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Groq:
 		expectations.ShouldHaveUsageStats = true
-		expectations.ShouldHaveTimestamps = true
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Gemini:
 		expectations.ShouldHaveUsageStats = true
 		expectations.ShouldHaveTimestamps = false // Gemini does not return created timestamps
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Perplexity:
@@ -488,73 +480,58 @@ func ModifyExpectationsForProvider(expectations ResponseExpectations, provider s
 
 	case schemas.Cerebras:
 		expectations.ShouldHaveUsageStats = true
-		expectations.ShouldHaveTimestamps = true
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.OpenRouter:
 		// OpenRouter proxies to multiple providers; returns OpenAI-compatible fields
 		expectations.ShouldHaveUsageStats = true
-		expectations.ShouldHaveTimestamps = true
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.XAI:
 		expectations.ShouldHaveUsageStats = true
-		expectations.ShouldHaveTimestamps = true
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Nebius:
 		expectations.ShouldHaveUsageStats = true
-		expectations.ShouldHaveTimestamps = true
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.SGL:
 		// SGLang local inference — may not return all fields
 		expectations.ShouldHaveUsageStats = false
 		expectations.ShouldHaveTimestamps = false
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Parasail:
 		expectations.ShouldHaveUsageStats = true
 		expectations.ShouldHaveTimestamps = false // Parasail does not return created timestamps
-		expectations.ShouldHaveModel = false      // Parasail does not return model field in streaming
+		expectations.ShouldHaveModel = false      // Parasail does not return model field
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Elevenlabs:
 		// Elevenlabs is primarily audio — usage/timestamps may not apply to all calls
 		expectations.ShouldHaveUsageStats = false
 		expectations.ShouldHaveTimestamps = false
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.HuggingFace:
 		expectations.ShouldHaveUsageStats = false
 		expectations.ShouldHaveTimestamps = false
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Replicate:
 		expectations.ShouldHaveUsageStats = false
 		expectations.ShouldHaveTimestamps = false
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.VLLM:
 		// vLLM local inference — OpenAI-compatible
 		expectations.ShouldHaveUsageStats = true
-		expectations.ShouldHaveTimestamps = true
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	case schemas.Runway:
 		// Runway is primarily video/image generation
 		expectations.ShouldHaveUsageStats = false
 		expectations.ShouldHaveTimestamps = false
-		expectations.ShouldHaveModel = true
 		expectations.ShouldHaveLatency = true
 
 	default:


### PR DESCRIPTION
## Summary

Refactored the `ModifyExpectationsForProvider` function to only disable expectations for providers that never return certain fields, rather than explicitly setting fields to true. This prevents overriding scenario-level presets like `StreamingExpectations` which may disable certain fields for streaming responses.

## Changes

- Removed redundant `true` assignments for `ShouldHaveTimestamps` and `ShouldHaveModel` across all providers
- Added documentation explaining that this function should only disable expectations, not enable them
- Preserved all `false` assignments for providers that don't support specific fields (timestamps, usage stats, model info)
- Updated comment for Parasail provider to clarify model field behavior

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the LLM validation tests to ensure expectations are properly set for different scenarios and providers:

```sh
go version
go test ./core/internal/llmtests/...
```

Test streaming scenarios specifically to verify that timestamp and model expectations remain disabled when appropriate.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is an internal testing configuration change.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable