### PR TITLE
claude code documentation update

### DIFF
--- a/docs/cli-agents/claude-code.mdx
+++ b/docs/cli-agents/claude-code.mdx
@@ -26,7 +26,7 @@ Claude Code supports multiple authentication methods. Choose the one that matche
    export ANTHROPIC_BASE_URL=http://localhost:8080/anthropic
    ```
 
-2. **Run Claude Code*
+2. **Run Claude Code**
 ```bash
 claude
 ```


### PR DESCRIPTION
## Summary

Fixed a missing closing asterisk in the markdown formatting for the "Run Claude Code" section header in the CLI documentation.

## Changes

- Corrected malformed markdown header by adding the missing closing `*` to properly format "**Run Claude Code**"

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the documentation renders correctly with proper bold formatting for the section header.

```sh
# View the documentation to confirm proper markdown rendering
# The "Run Claude Code" header should appear in bold formatting
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a minor documentation formatting fix.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable