### PR TITLE
fix: case insensitive lookup in merge beta headers

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: case-insensitive `anthropic-beta` merge in `MergeBetaHeaders`

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -607,12 +607,19 @@ func MergeBetaHeaders(providerExtraHeaders map[string]string, ctx context.Contex
 			}
 		}
 	}
-	if v := providerExtraHeaders[AnthropicBetaHeader]; v != "" {
-		add(v)
+	for k, v := range providerExtraHeaders {
+		if strings.EqualFold(k, AnthropicBetaHeader) && v != "" {
+			add(v)
+		}
 	}
 	if ctxHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
-		for _, v := range ctxHeaders[AnthropicBetaHeader] {
-			add(v)
+		for k, vals := range ctxHeaders {
+			if !strings.EqualFold(k, AnthropicBetaHeader) {
+				continue
+			}
+			for _, v := range vals {
+				add(v)
+			}
 		}
 	}
 	return all

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -1,9 +1,12 @@
 package anthropic
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
+	"slices"
 	"testing"
 	"time"
 
@@ -890,6 +893,46 @@ func TestAddMissingBetaHeadersToContext_PassthroughWins(t *testing.T) {
 		betaHeaders := extraHeaders[AnthropicBetaHeader]
 		if len(betaHeaders) != 1 || betaHeaders[0] != AnthropicMCPClientBetaHeader {
 			t.Errorf("expected [%q], got %v", AnthropicMCPClientBetaHeader, betaHeaders)
+		}
+	})
+}
+
+func TestMergeBetaHeaders(t *testing.T) {
+	t.Run("context_extra_headers_case_insensitive_key", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
+			"Anthropic-Beta": {"structured-outputs-2025-11-13"},
+		})
+		got := MergeBetaHeaders(nil, ctx)
+		want := []string{"structured-outputs-2025-11-13"}
+		if !slices.Equal(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("provider_extra_headers_case_insensitive_key", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+		got := MergeBetaHeaders(map[string]string{
+			"Anthropic-Beta": "mcp-client-2025-04-04",
+		}, ctx)
+		want := []string{"mcp-client-2025-04-04"}
+		if !slices.Equal(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("merges_provider_then_context_deduping_tokens", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
+			"ANTHROPIC-BETA": {"foo,bar", "bar,baz"},
+		})
+		got := MergeBetaHeaders(map[string]string{
+			"anthropic-beta": "foo",
+		}, ctx)
+		sort.Strings(got)
+		wantSorted := []string{"bar", "baz", "foo"}
+		if !slices.Equal(got, wantSorted) {
+			t.Fatalf("got %v, want %v", got, wantSorted)
 		}
 	})
 }

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- fix: case-insensitive `anthropic-beta` merge in `MergeBetaHeaders`


### PR DESCRIPTION
## Summary

Fixed case-insensitive header matching for `anthropic-beta` headers in the `MergeBetaHeaders` function. Previously, the function only matched headers with exact case, causing headers like `Anthropic-Beta` or `ANTHROPIC-BETA` to be ignored.

## Changes

- Modified `MergeBetaHeaders` to use `strings.EqualFold` for case-insensitive comparison when processing both provider extra headers and context headers
- Replaced direct map key access with iteration over all headers to check for case-insensitive matches
- Added comprehensive test coverage for case-insensitive header matching and merging behavior

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the existing and new test cases to verify case-insensitive header matching works correctly:

```sh
# Core/Transports
go version
go test ./core/providers/anthropic/...
```

Test with headers using different cases like `Anthropic-Beta`, `ANTHROPIC-BETA`, or `anthropic-beta` to ensure they are all properly merged.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects header case sensitivity handling and doesn't introduce new security vectors.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable