### PR TITLE
fixes tag detection for cahgnes

### DIFF
--- a/.github/workflows/scripts/detect-all-changes.sh
+++ b/.github/workflows/scripts/detect-all-changes.sh
@@ -47,8 +47,8 @@ else
   else
     if [[ "$CORE_VERSION" == *"-"* ]]; then
       # current_version has prerelease, so include all versions but prefer stable
-      ALL_TAGS=$(git tag -l "core/v${CORE_MAJOR_MINOR}.*" | sort -V)      
-      STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-')      
+      ALL_TAGS=$(git tag -l "core/v${CORE_MAJOR_MINOR}.*" | sort -V)
+      STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-' || true)
       PRERELEASE_TAGS=$(echo "$ALL_TAGS" | grep '\-' || true)
       if [ -n "$STABLE_TAGS" ]; then
         # Get the highest stable version
@@ -61,7 +61,7 @@ else
       fi
     else
       # VERSION has no prerelease, so only consider stable releases in same track
-      LATEST_CORE_TAG=$(git tag -l "core/v${CORE_MAJOR_MINOR}.*" | grep -v '\-' | sort -V | tail -1)
+      LATEST_CORE_TAG=$(git tag -l "core/v${CORE_MAJOR_MINOR}.*" | grep -v '\-' | sort -V | tail -1 || true)
       echo "latest core tag (stable only): $LATEST_CORE_TAG"
     fi
     PREVIOUS_CORE_VERSION=${LATEST_CORE_TAG#core/v}
@@ -89,7 +89,7 @@ else
   echo "   🔍 Checking track: ${FRAMEWORK_MAJOR_MINOR}.x"
   
   ALL_TAGS=$(git tag -l "framework/v${FRAMEWORK_MAJOR_MINOR}.*" | sort -V)
-  STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-')
+  STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-' || true)
   PRERELEASE_TAGS=$(echo "$ALL_TAGS" | grep '\-' || true)
   LATEST_FRAMEWORK_TAG=""
   if [ -n "$STABLE_TAGS" ]; then

--- a/docs/plugins/writing-go-plugin.mdx
+++ b/docs/plugins/writing-go-plugin.mdx
@@ -63,7 +63,120 @@ require github.com/maximhq/bifrost/core v1.2.38
 Create `main.go` with the required plugin functions. Here's the complete hello-world example:
 
 <Tabs>
-  <Tab title="v1.4.x+">
+  <Tab title="v1.5.x+">
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Init is called when the plugin is loaded
+// config contains the plugin configuration from config.json
+func Init(config any) error {
+	fmt.Println("Init called")
+	// Initialize your plugin here (database connections, API clients, etc.)
+	return nil
+}
+
+// GetName returns the plugin's unique identifier
+func GetName() string {
+	return "Hello World Plugin"
+}
+
+// HTTPTransportPreHook intercepts requests BEFORE they enter Bifrost core
+// Modify req in-place. Return (*HTTPResponse, nil) to short-circuit.
+// Only called when using HTTP transport (bifrost-http)
+func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	// Use ctx.Log for structured, scoped logging (recommended)
+	ctx.Log(schemas.LogLevelInfo, "HTTPTransportPreHook called")
+
+	// Read headers using case-insensitive helper (recommended)
+	contentType := req.CaseInsensitiveHeaderLookup("Content-Type")
+	fmt.Printf("Content-Type: %s\n", contentType)
+
+	// Modify request in-place
+	req.Headers["x-custom-header"] = "custom-value"
+
+	// Store values in context for use in other hooks
+	ctx.SetValue(schemas.BifrostContextKey("my-plugin-key"), "pre-hook-value")
+
+	// Return nil to continue, or return &schemas.HTTPResponse{} to short-circuit
+	return nil, nil
+}
+
+// HTTPTransportPostHook intercepts responses AFTER they exit Bifrost core
+// Modify resp in-place. Called in reverse order of pre-hooks.
+// Only called for NON-STREAMING responses when using HTTP transport (bifrost-http)
+func HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	ctx.Log(schemas.LogLevelInfo, "HTTPTransportPostHook called")
+
+	// Modify response headers
+	resp.Headers["x-processed-by"] = "my-plugin"
+
+	// Read context values set in pre-hook
+	if val := ctx.Value(schemas.BifrostContextKey("my-plugin-key")); val != nil {
+		fmt.Printf("Context value: %v\n", val)
+	}
+
+	// Return nil to continue, or return error to short-circuit
+	return nil
+}
+
+// HTTPTransportStreamChunkHook intercepts streaming chunks BEFORE they're sent to the client
+// Modify chunk or return nil to skip. Called in reverse order of pre-hooks.
+// Only called for STREAMING responses when using HTTP transport (bifrost-http)
+func HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, chunk *schemas.BifrostStreamChunk) (*schemas.BifrostStreamChunk, error) {
+	ctx.Log(schemas.LogLevelInfo, "HTTPTransportStreamChunkHook called")
+
+	// chunk is a typed struct containing one of:
+	// - BifrostTextCompletionResponse (text completion streaming)
+	// - BifrostChatResponse (chat completion streaming)
+	// - BifrostResponsesStreamResponse (responses API streaming)
+	// - BifrostSpeechStreamResponse (speech synthesis streaming)
+	// - BifrostTranscriptionStreamResponse (transcription streaming)
+	// - BifrostImageGenerationStreamResponse (image generation streaming)
+	// - BifrostError (error during streaming)
+
+	// Return chunk unchanged to pass through
+	return chunk, nil
+
+	// Or return nil to skip/filter this chunk:
+	// return nil, nil
+
+	// Or return modified chunk:
+	// modifiedChunk := &schemas.BifrostStreamChunk{BifrostChatResponse: ...}
+	// return modifiedChunk, nil
+}
+
+
+// PreLLMHook is called before the request is sent to the provider
+// This is where you can modify requests or short-circuit the flow
+func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
+	ctx.Log(schemas.LogLevelInfo, "PreLLMHook called")
+	// Modify the request or return a short-circuit to skip provider call
+	return req, nil, nil
+}
+
+// PostLLMHook is called after receiving a response from the provider
+// This is where you can modify responses or handle errors
+func PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	ctx.Log(schemas.LogLevelInfo, "PostLLMHook called")
+	// Modify the response or error before returning to caller
+	return resp, bifrostErr, nil
+}
+
+// Cleanup is called when Bifrost shuts down
+func Cleanup() error {
+	fmt.Println("Cleanup called")
+	// Clean up resources (close connections, flush buffers, etc.)
+	return nil
+}
+```
+  </Tab>
+  <Tab title="v1.4.x">
 ```go
 package main
 
@@ -260,8 +373,34 @@ func Init(config any) error {
 
 Returns a unique identifier for your plugin. This name appears in logs and status reports.
 
+#### `ctx.Log(level, msg)` <sup>v1.5.x+</sup>
+
+Emits a structured log entry scoped to the current plugin. Use this instead of `fmt.Println` for production logging — entries are collected per-request and can be retrieved programmatically.
+
+```go
+ctx.Log(schemas.LogLevelInfo, "processing request")
+ctx.Log(schemas.LogLevelWarn, "cache miss, falling back to provider")
+ctx.Log(schemas.LogLevelError, "failed to parse response body")
+```
+
+**Available log levels:**
+
+| Constant | Value |
+|---|---|
+| `schemas.LogLevelDebug` | `"debug"` |
+| `schemas.LogLevelInfo` | `"info"` |
+| `schemas.LogLevelWarn` | `"warn"` |
+| `schemas.LogLevelError` | `"error"` |
+
+Key points:
+- **Thread-safe** — safe to call from concurrent goroutines
+- **Scoped** — each entry is automatically tagged with your plugin's name
+- **Timestamped** — entries include Unix millisecond timestamps
+- **No-op when unscoped** — safe to call in any context; silently ignored outside plugin hooks
+- Logs are retrievable via `ctx.GetPluginLogs()` (read copy) or `ctx.DrainPluginLogs()` (transfer ownership)
+
 <Tabs>
-  <Tab title="v1.4.x+">
+  <Tab title="v1.5.x+">
 #### `HTTPTransportPreHook(ctx, req)`
 
 **HTTP transport only.** Intercepts requests BEFORE they enter Bifrost core. Use this to:
@@ -330,6 +469,61 @@ req.Headers["X-Custom-Header"] = "value"
 
 The helper methods (`CaseInsensitiveHeaderLookup` and `CaseInsensitiveQueryLookup`) ensure your plugin works correctly regardless of how the client sends header/query parameter names.
 </Note>
+
+<Warning>
+These functions are **only called** when using `bifrost-http`. They are **not invoked** when using Bifrost as a Go SDK.
+</Warning>
+  </Tab>
+  <Tab title="v1.4.x">
+#### `HTTPTransportPreHook(ctx, req)`
+
+**HTTP transport only.** Intercepts requests BEFORE they enter Bifrost core. Use this to:
+- Modify request headers, body, or query params in-place
+- Short-circuit with a custom response
+- Store values in `BifrostContext` for use in other hooks
+- Works with both native .so and WASM plugins
+
+Key points:
+- Receives serializable `*HTTPRequest` (not raw fasthttp)
+- Modify `req.Headers`, `req.Body`, `req.Query` directly
+- Return `(nil, nil)` to continue to next plugin/handler
+- Return `(*HTTPResponse, nil)` to short-circuit with response
+- Return `(nil, error)` to short-circuit with error
+
+#### `HTTPTransportPostHook(ctx, req, resp)`
+
+**HTTP transport only.** Intercepts responses AFTER they exit Bifrost core. Use this to:
+- Modify response headers or body in-place
+- Log or monitor response data
+- Access context values set in pre-hook
+- Called in **reverse order** of pre-hooks
+
+Key points:
+- Receives both `*HTTPRequest` and `*HTTPResponse`
+- Modify `resp.Headers`, `resp.Body`, `resp.StatusCode` directly
+- Return `nil` to continue to next plugin/handler
+- Return `error` to short-circuit with error and skip remaining post-hooks
+- **NOT called for streaming responses** - use `HTTPTransportStreamChunkHook` instead
+
+#### `HTTPTransportStreamChunkHook(ctx, req, chunk)`
+
+**HTTP transport only.** Intercepts streaming response chunks BEFORE they're written to the client. Use this to:
+- Modify streaming chunks in real-time
+- Filter/skip specific chunks
+- Log or monitor streaming data
+- Called in **reverse order** of pre-hooks
+
+Key points:
+- Receives a `*schemas.BifrostStreamChunk` typed struct (not raw bytes)
+- The struct contains one non-nil field based on the response type (chat, text completion, responses, speech, transcription, image generation, or error)
+- Return `(chunk, nil)` to pass through unchanged
+- Return `(nil, nil)` to skip/filter the chunk entirely
+- Return `(modifiedChunk, nil)` to return a modified chunk
+- Return `(nil, error)` to send error to client and stop streaming
+
+<Warning>
+`HTTPTransportPostHook` is **NOT called** for streaming responses. Use `HTTPTransportStreamChunkHook` to intercept streaming data.
+</Warning>
 
 <Warning>
 These functions are **only called** when using `bifrost-http`. They are **not invoked** when using Bifrost as a Go SDK.
@@ -536,7 +730,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 Check the logs for plugin hook calls:
 
 <Tabs>
-  <Tab title="v1.4.x+ (non-streaming)">
+  <Tab title="v1.5.x+ (non-streaming)">
 ```
 HTTPTransportPreHook called
 PreLLMHook called
@@ -544,7 +738,23 @@ PostLLMHook called
 HTTPTransportPostHook called
 ```
   </Tab>
-  <Tab title="v1.4.x+ (streaming)">
+  <Tab title="v1.5.x+ (streaming)">
+```
+HTTPTransportPreHook called
+PreLLMHook called
+PostLLMHook called
+HTTPTransportStreamChunkHook called (per chunk)
+```
+  </Tab>
+  <Tab title="v1.4.x (non-streaming)">
+```
+HTTPTransportPreHook called
+PreLLMHook called
+PostLLMHook called
+HTTPTransportPostHook called
+```
+  </Tab>
+  <Tab title="v1.4.x (streaming)">
 ```
 HTTPTransportPreHook called
 PreLLMHook called
@@ -571,6 +781,7 @@ For plugins that need to maintain state across requests:
 package main
 
 import (
+	"fmt"
 	"sync"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -586,6 +797,7 @@ func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*sche
 	count := requestCount
 	mu.Unlock()
 	
+	ctx.Log(schemas.LogLevelInfo, fmt.Sprintf("request count: %d", count))
 	// Use count for rate limiting, metrics, etc.
 	return req, nil, nil
 }
@@ -600,10 +812,12 @@ func PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bif
 	if bifrostErr != nil {
 		// Allow fallbacks for rate limit errors
 		if bifrostErr.Error.Type != nil && *bifrostErr.Error.Type == "rate_limit" {
+			ctx.Log(schemas.LogLevelWarn, "rate limit hit, allowing fallbacks")
 			allowFallbacks := true
 			bifrostErr.AllowFallbacks = &allowFallbacks
 		} else {
 			// Don't try fallbacks for auth errors
+			ctx.Log(schemas.LogLevelError, "auth error, blocking fallbacks")
 			allowFallbacks := false
 			bifrostErr.AllowFallbacks = &allowFallbacks
 		}
@@ -623,11 +837,13 @@ func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*sche
 	
 	// Check cache
 	if cached, ok := cache.Load(key); ok {
+		ctx.Log(schemas.LogLevelDebug, "cache hit")
 		return req, &schemas.LLMPluginShortCircuit{
 			Response: cached.(*schemas.BifrostResponse),
 		}, nil
 	}
 	
+	ctx.Log(schemas.LogLevelDebug, "cache miss")
 	return req, nil, nil
 }
 
@@ -636,6 +852,7 @@ func PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bif
 		// Store in cache
 		key := generateCacheKeyFromResponse(resp)
 		cache.Store(key, resp)
+		ctx.Log(schemas.LogLevelDebug, "response cached")
 	}
 	return resp, bifrostErr, nil
 }

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,4 +1,5 @@
 - feat: VK provider config key_ids now supports ["*"] wildcard to allow all keys; empty key_ids denies all; handler resolves wildcard to AllowAllKeys flag without DB key lookups
+- feat: now plugins can start injecting logs at trace level. Just use `ctx.Log(schemas.LogLevelInfo, "Test log")`
 - feat: add option to disable automatic MCP tool injection per request
 - feat: virtual key MCP configs now act as an execution-time allow-list — tools not permitted by the VK are blocked at inference and MCP tool execution
 - refactor: standardize empty array conventions in bifrost. Empty array means no tools/keys are allowed, ["*"] means all tools/keys are allowed.


### PR DESCRIPTION
## Summary

Fixes shell script errors in the change detection workflow by adding proper error handling to grep commands that may return no matches.

## Changes

- Added `|| true` to grep commands in `detect-all-changes.sh` to prevent script failures when no matching tags are found
- Applied fix to both core and framework tag filtering logic where grep searches for stable tags (those without hyphens)
- Removed trailing whitespace from affected lines

The issue occurred because grep returns a non-zero exit code when no matches are found, causing the script to fail in bash strict mode. Adding `|| true` ensures the script continues execution even when no stable tags exist.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs
- [x] CI/CD

## How to test

Test the change detection script with repositories that have different tag scenarios:

```sh
# Test with repository having only prerelease tags
.github/workflows/scripts/detect-all-changes.sh

# Test with repository having mixed stable and prerelease tags
.github/workflows/scripts/detect-all-changes.sh

# Test with repository having no tags matching the pattern
.github/workflows/scripts/detect-all-changes.sh
```

Expected outcome: Script should complete successfully in all scenarios without grep-related errors.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a build script improvement with no security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable