### PR TITLE
docs: changelog updates

### DIFF
--- a/.github/workflows/scripts/detect-all-changes.sh
+++ b/.github/workflows/scripts/detect-all-changes.sh
@@ -47,8 +47,8 @@ else
   else
     if [[ "$CORE_VERSION" == *"-"* ]]; then
       # current_version has prerelease, so include all versions but prefer stable
-      ALL_TAGS=$(git tag -l "core/v${CORE_MAJOR_MINOR}.*" | sort -V)      
-      STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-')      
+      ALL_TAGS=$(git tag -l "core/v${CORE_MAJOR_MINOR}.*" | sort -V)
+      STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-' || true)
       PRERELEASE_TAGS=$(echo "$ALL_TAGS" | grep '\-' || true)
       if [ -n "$STABLE_TAGS" ]; then
         # Get the highest stable version
@@ -61,7 +61,7 @@ else
       fi
     else
       # VERSION has no prerelease, so only consider stable releases in same track
-      LATEST_CORE_TAG=$(git tag -l "core/v${CORE_MAJOR_MINOR}.*" | grep -v '\-' | sort -V | tail -1)
+      LATEST_CORE_TAG=$(git tag -l "core/v${CORE_MAJOR_MINOR}.*" | grep -v '\-' | sort -V | tail -1 || true)
       echo "latest core tag (stable only): $LATEST_CORE_TAG"
     fi
     PREVIOUS_CORE_VERSION=${LATEST_CORE_TAG#core/v}
@@ -89,7 +89,7 @@ else
   echo "   🔍 Checking track: ${FRAMEWORK_MAJOR_MINOR}.x"
   
   ALL_TAGS=$(git tag -l "framework/v${FRAMEWORK_MAJOR_MINOR}.*" | sort -V)
-  STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-')
+  STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-' || true)
   PRERELEASE_TAGS=$(echo "$ALL_TAGS" | grep '\-' || true)
   LATEST_FRAMEWORK_TAG=""
   if [ -n "$STABLE_TAGS" ]; then

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -3,4 +3,5 @@
 - refactor: standardize empty array conventions in bifrost. Empty array means deny all, ["*"] means allow all for models/tools/keys.
 - feat: add support for request-level extra headers in MCP tool execution using BifrostContextKeyMCPExtraHeaders key in context.
 - fix: send back accumulated usage in MCP agent mode.
-- fix: case-insensitive `anthropic-beta` merge in `MergeBetaHeaders`
+- feat: add StabilityAI provider support to Bedrock.
+- fix: handle text, vtt, srt response formats in OpenAI transcription response.

--- a/docs/features/keys-management.mdx
+++ b/docs/features/keys-management.mdx
@@ -29,25 +29,28 @@ This ensures optimal key usage while respecting your configuration constraints.
 <Tab title="Gateway">
 
 ```bash
-# Configure multiple keys with weights via API
+# 1. Create or ensure the provider exists
 curl -X POST http://localhost:8080/api/providers \
   -H "Content-Type: application/json" \
+  -d '{ "provider": "openai" }'
+
+# 2. Add keys individually via the dedicated keys API
+curl -X POST http://localhost:8080/api/providers/openai/keys \
+  -H "Content-Type: application/json" \
   -d '{
-    "provider": "openai",
-    "keys": [
-      {
-        "name": "openai-key-1",
-        "value": "env.OPENAI_API_KEY_1",
-        "models": ["gpt-4o", "gpt-4o-mini"],
-        "weight": 0.7
-      },
-      {
-        "name": "openai-key-2",
-        "value": "env.OPENAI_API_KEY_2", 
-        "models": ["*"],
-        "weight": 0.3
-      }
-    ]
+    "name": "openai-key-1",
+    "value": "env.OPENAI_API_KEY_1",
+    "models": ["gpt-4o", "gpt-4o-mini"],
+    "weight": 0.7
+  }'
+
+curl -X POST http://localhost:8080/api/providers/openai/keys \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "openai-key-2",
+    "value": "env.OPENAI_API_KEY_2",
+    "models": ["*"],
+    "weight": 0.3
   }'
 
 # Regular request (uses weighted key selection)
@@ -174,29 +177,33 @@ Keys can be restricted to specific models for access control and cost management
 - **Denylist**: Block specific models on a key
 
 **Example Model Restrictions:**
+
+Each key is created individually via `POST /api/providers/{provider}/keys`:
+
 ```json
+// Premium-only key
 {
-  "keys": [
-    {
-      "name": "openai-pre-key-1",
-      "value": "premium-key",
-      "models": ["gpt-4o", "o1-preview"],  // Only premium models
-      "weight": 1.0
-    },
-    {
-      "name": "openai-std-key-1",
-      "value": "standard-key", 
-      "models": ["gpt-4o-mini", "gpt-3.5-turbo"], // Only standard models
-      "weight": 1.0
-    },
-    {
-      "name": "openai-shared-key",
-      "value": "env.OPENAI_API_KEY",
-      "models": ["gpt-4o", "gpt-4o-mini"],
-      "blacklisted_models": ["gpt-5"],
-      "weight": 1.0
-    }
-  ]
+  "name": "openai-pre-key-1",
+  "value": "premium-key",
+  "models": ["gpt-4o", "o1-preview"],
+  "weight": 1.0
+}
+
+// Standard-only key
+{
+  "name": "openai-std-key-1",
+  "value": "standard-key",
+  "models": ["gpt-4o-mini", "gpt-3.5-turbo"],
+  "weight": 1.0
+}
+
+// Shared key with denylist
+{
+  "name": "openai-shared-key",
+  "value": "env.OPENAI_API_KEY",
+  "models": ["gpt-4o", "gpt-4o-mini"],
+  "blacklisted_models": ["gpt-5"],
+  "weight": 1.0
 }
 ```
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -563,6 +563,10 @@ paths:
     $ref: './paths/management/providers.yaml#/providers'
   /api/providers/{provider}:
     $ref: './paths/management/providers.yaml#/providers-by-name'
+  /api/providers/{provider}/keys:
+    $ref: './paths/management/providers.yaml#/provider-keys'
+  /api/providers/{provider}/keys/{key_id}:
+    $ref: './paths/management/providers.yaml#/provider-key-by-id'
   /api/keys:
     $ref: './paths/management/providers.yaml#/keys'
   /api/models:
@@ -978,6 +982,8 @@ components:
       $ref: './schemas/management/providers.yaml#/UpdateProviderRequest'
     Key:
       $ref: './schemas/management/providers.yaml#/Key'
+    ListProviderKeysResponse:
+      $ref: './schemas/management/providers.yaml#/ListProviderKeysResponse'
     NetworkConfig:
       $ref: './schemas/management/providers.yaml#/NetworkConfig'
     ConcurrencyAndBufferSize:

--- a/docs/openapi/paths/management/providers.yaml
+++ b/docs/openapi/paths/management/providers.yaml
@@ -141,6 +141,205 @@ providers-by-name:
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 
+provider-keys:
+  get:
+    operationId: listProviderKeys
+    summary: List keys for a provider
+    description: Returns all keys configured for a specific provider.
+    tags:
+      - Providers
+    parameters:
+      - name: provider
+        in: path
+        required: true
+        description: Provider name
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/providers.yaml#/ListProviderKeysResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Provider not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+  post:
+    operationId: createProviderKey
+    summary: Create a key for a provider
+    description: |
+      Creates a new API key for the specified provider. The key `id` is auto-generated
+      if omitted. `enabled` defaults to `true` if omitted. `value` is required and must
+      not be empty. Keys cannot be created on keyless providers.
+    tags:
+      - Providers
+    parameters:
+      - name: provider
+        in: path
+        required: true
+        description: Provider name
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/management/providers.yaml#/Key'
+    responses:
+      '200':
+        description: Key created successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/providers.yaml#/Key'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Provider not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '409':
+        description: Key ID already exists
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+provider-key-by-id:
+  get:
+    operationId: getProviderKey
+    summary: Get a specific key for a provider
+    description: Returns a single key for the specified provider.
+    tags:
+      - Providers
+    parameters:
+      - name: provider
+        in: path
+        required: true
+        description: Provider name
+        schema:
+          type: string
+      - name: key_id
+        in: path
+        required: true
+        description: Key ID
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/providers.yaml#/Key'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Provider or key not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+  put:
+    operationId: updateProviderKey
+    summary: Update a key for a provider
+    description: |
+      Updates an existing key. Send the full key object. Redacted values sent back
+      unchanged are automatically preserved (the server merges them with the stored
+      raw values).
+    tags:
+      - Providers
+    parameters:
+      - name: provider
+        in: path
+        required: true
+        description: Provider name
+        schema:
+          type: string
+      - name: key_id
+        in: path
+        required: true
+        description: Key ID
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/management/providers.yaml#/Key'
+    responses:
+      '200':
+        description: Key updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/providers.yaml#/Key'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Provider or key not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+  delete:
+    operationId: deleteProviderKey
+    summary: Delete a key from a provider
+    description: Deletes a key from the specified provider. Returns the deleted key.
+    tags:
+      - Providers
+    parameters:
+      - name: provider
+        in: path
+        required: true
+        description: Provider name
+        schema:
+          type: string
+      - name: key_id
+        in: path
+        required: true
+        description: Key ID
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Key deleted successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/providers.yaml#/Key'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        description: Provider or key not found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
 keys:
   get:
     operationId: listKeys

--- a/docs/openapi/schemas/management/providers.yaml
+++ b/docs/openapi/schemas/management/providers.yaml
@@ -148,6 +148,26 @@ HuggingFaceKeyConfig:
       additionalProperties:
         type: string
 
+ReplicateKeyConfig:
+  type: object
+  description: Replicate-specific key configuration
+  properties:
+    deployments:
+      type: object
+      additionalProperties:
+        type: string
+
+VLLMKeyConfig:
+  type: object
+  description: vLLM-specific key configuration for per-key routing to different vLLM instances
+  properties:
+    url:
+      $ref: '../../schemas/management/common.yaml#/EnvVar'
+      description: vLLM server base URL (required)
+    model_name:
+      type: string
+      description: Exact model name served on this vLLM instance
+
 Key:
   type: object
   description: API key configuration
@@ -165,7 +185,12 @@ Key:
       type: array
       items:
         type: string
-      description: List of models this key can access
+      description: List of models this key can access (whitelist)
+    blacklisted_models:
+      type: array
+      items:
+        type: string
+      description: List of models this key cannot access (blacklist)
     weight:
       type: number
       description: Weight for load balancing
@@ -177,10 +202,25 @@ Key:
       $ref: '#/BedrockKeyConfig'
     huggingface_key_config:
       $ref: '#/HuggingFaceKeyConfig'
+    replicate_key_config:
+      $ref: '#/ReplicateKeyConfig'
+    vllm_key_config:
+      $ref: '#/VLLMKeyConfig'
     enabled:
       type: boolean
+      description: Whether the key is active (defaults to true)
     use_for_batch_api:
       type: boolean
+      description: Whether this key can be used for batch API operations
+    config_hash:
+      type: string
+      description: Hash of config.json version, used for change detection
+    status:
+      type: string
+      description: Status of key (e.g., success, list_models_failed)
+    description:
+      type: string
+      description: Error or status description for the key
 
 AllowedRequests:
   type: object
@@ -258,10 +298,6 @@ ProviderResponse:
   properties:
     name:
       $ref: '../../schemas/inference/common.yaml#/ModelProvider'
-    keys:
-      type: array
-      items:
-        $ref: '#/Key'
     network_config:
       $ref: '#/NetworkConfig'
     concurrency_and_buffer_size:
@@ -272,10 +308,18 @@ ProviderResponse:
       type: boolean
     send_back_raw_response:
       type: boolean
+    store_raw_request_response:
+      type: boolean
     custom_provider_config:
       $ref: '#/CustomProviderConfig'
-    status:
+    provider_status:
       $ref: '#/ProviderStatus'
+    status:
+      type: string
+      description: Operational status (e.g., list_models_failed)
+    description:
+      type: string
+      description: Error/status description
     config_hash:
       type: string
       description: Hash of config.json version, used for change detection
@@ -293,16 +337,12 @@ ListProvidersResponse:
 
 AddProviderRequest:
   type: object
-  description: Add provider request
+  description: Add provider request. Keys are managed separately via /api/providers/{provider}/keys.
   required:
     - provider
   properties:
     provider:
       $ref: '../../schemas/inference/common.yaml#/ModelProvider'
-    keys:
-      type: array
-      items:
-        $ref: '#/Key'
     network_config:
       $ref: '#/NetworkConfig'
     concurrency_and_buffer_size:
@@ -312,18 +352,16 @@ AddProviderRequest:
     send_back_raw_request:
       type: boolean
     send_back_raw_response:
+      type: boolean
+    store_raw_request_response:
       type: boolean
     custom_provider_config:
       $ref: '#/CustomProviderConfig'
 
 UpdateProviderRequest:
   type: object
-  description: Update provider request
+  description: Update provider request. Keys are managed separately via /api/providers/{provider}/keys.
   properties:
-    keys:
-      type: array
-      items:
-        $ref: '#/Key'
     network_config:
       $ref: '#/NetworkConfig'
     concurrency_and_buffer_size:
@@ -334,8 +372,21 @@ UpdateProviderRequest:
       type: boolean
     send_back_raw_response:
       type: boolean
+    store_raw_request_response:
+      type: boolean
     custom_provider_config:
       $ref: '#/CustomProviderConfig'
+
+ListProviderKeysResponse:
+  type: object
+  description: Response for listing keys for a provider
+  properties:
+    keys:
+      type: array
+      items:
+        $ref: '#/Key'
+    total:
+      type: integer
 
 ModelResponse:
   type: object

--- a/docs/plugins/writing-go-plugin.mdx
+++ b/docs/plugins/writing-go-plugin.mdx
@@ -63,7 +63,120 @@ require github.com/maximhq/bifrost/core v1.2.38
 Create `main.go` with the required plugin functions. Here's the complete hello-world example:
 
 <Tabs>
-  <Tab title="v1.4.x+">
+  <Tab title="v1.5.x+">
+```go
+package main
+
+import (
+	"fmt"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Init is called when the plugin is loaded
+// config contains the plugin configuration from config.json
+func Init(config any) error {
+	fmt.Println("Init called")
+	// Initialize your plugin here (database connections, API clients, etc.)
+	return nil
+}
+
+// GetName returns the plugin's unique identifier
+func GetName() string {
+	return "Hello World Plugin"
+}
+
+// HTTPTransportPreHook intercepts requests BEFORE they enter Bifrost core
+// Modify req in-place. Return (*HTTPResponse, nil) to short-circuit.
+// Only called when using HTTP transport (bifrost-http)
+func HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
+	// Use ctx.Log for structured, scoped logging (recommended)
+	ctx.Log(schemas.LogLevelInfo, "HTTPTransportPreHook called")
+
+	// Read headers using case-insensitive helper (recommended)
+	contentType := req.CaseInsensitiveHeaderLookup("Content-Type")
+	fmt.Printf("Content-Type: %s\n", contentType)
+
+	// Modify request in-place
+	req.Headers["x-custom-header"] = "custom-value"
+
+	// Store values in context for use in other hooks
+	ctx.SetValue(schemas.BifrostContextKey("my-plugin-key"), "pre-hook-value")
+
+	// Return nil to continue, or return &schemas.HTTPResponse{} to short-circuit
+	return nil, nil
+}
+
+// HTTPTransportPostHook intercepts responses AFTER they exit Bifrost core
+// Modify resp in-place. Called in reverse order of pre-hooks.
+// Only called for NON-STREAMING responses when using HTTP transport (bifrost-http)
+func HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
+	ctx.Log(schemas.LogLevelInfo, "HTTPTransportPostHook called")
+
+	// Modify response headers
+	resp.Headers["x-processed-by"] = "my-plugin"
+
+	// Read context values set in pre-hook
+	if val := ctx.Value(schemas.BifrostContextKey("my-plugin-key")); val != nil {
+		fmt.Printf("Context value: %v\n", val)
+	}
+
+	// Return nil to continue, or return error to short-circuit
+	return nil
+}
+
+// HTTPTransportStreamChunkHook intercepts streaming chunks BEFORE they're sent to the client
+// Modify chunk or return nil to skip. Called in reverse order of pre-hooks.
+// Only called for STREAMING responses when using HTTP transport (bifrost-http)
+func HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, chunk *schemas.BifrostStreamChunk) (*schemas.BifrostStreamChunk, error) {
+	ctx.Log(schemas.LogLevelInfo, "HTTPTransportStreamChunkHook called")
+
+	// chunk is a typed struct containing one of:
+	// - BifrostTextCompletionResponse (text completion streaming)
+	// - BifrostChatResponse (chat completion streaming)
+	// - BifrostResponsesStreamResponse (responses API streaming)
+	// - BifrostSpeechStreamResponse (speech synthesis streaming)
+	// - BifrostTranscriptionStreamResponse (transcription streaming)
+	// - BifrostImageGenerationStreamResponse (image generation streaming)
+	// - BifrostError (error during streaming)
+
+	// Return chunk unchanged to pass through
+	return chunk, nil
+
+	// Or return nil to skip/filter this chunk:
+	// return nil, nil
+
+	// Or return modified chunk:
+	// modifiedChunk := &schemas.BifrostStreamChunk{BifrostChatResponse: ...}
+	// return modifiedChunk, nil
+}
+
+
+// PreLLMHook is called before the request is sent to the provider
+// This is where you can modify requests or short-circuit the flow
+func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
+	ctx.Log(schemas.LogLevelInfo, "PreLLMHook called")
+	// Modify the request or return a short-circuit to skip provider call
+	return req, nil, nil
+}
+
+// PostLLMHook is called after receiving a response from the provider
+// This is where you can modify responses or handle errors
+func PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	ctx.Log(schemas.LogLevelInfo, "PostLLMHook called")
+	// Modify the response or error before returning to caller
+	return resp, bifrostErr, nil
+}
+
+// Cleanup is called when Bifrost shuts down
+func Cleanup() error {
+	fmt.Println("Cleanup called")
+	// Clean up resources (close connections, flush buffers, etc.)
+	return nil
+}
+```
+  </Tab>
+  <Tab title="v1.4.x">
 ```go
 package main
 
@@ -260,8 +373,34 @@ func Init(config any) error {
 
 Returns a unique identifier for your plugin. This name appears in logs and status reports.
 
+#### `ctx.Log(level, msg)` <sup>v1.5.x+</sup>
+
+Emits a structured log entry scoped to the current plugin. Use this instead of `fmt.Println` for production logging — entries are collected per-request and can be retrieved programmatically.
+
+```go
+ctx.Log(schemas.LogLevelInfo, "processing request")
+ctx.Log(schemas.LogLevelWarn, "cache miss, falling back to provider")
+ctx.Log(schemas.LogLevelError, "failed to parse response body")
+```
+
+**Available log levels:**
+
+| Constant | Value |
+|---|---|
+| `schemas.LogLevelDebug` | `"debug"` |
+| `schemas.LogLevelInfo` | `"info"` |
+| `schemas.LogLevelWarn` | `"warn"` |
+| `schemas.LogLevelError` | `"error"` |
+
+Key points:
+- **Thread-safe** — safe to call from concurrent goroutines
+- **Scoped** — each entry is automatically tagged with your plugin's name
+- **Timestamped** — entries include Unix millisecond timestamps
+- **No-op when unscoped** — safe to call in any context; silently ignored outside plugin hooks
+- Logs are retrievable via `ctx.GetPluginLogs()` (read copy) or `ctx.DrainPluginLogs()` (transfer ownership)
+
 <Tabs>
-  <Tab title="v1.4.x+">
+  <Tab title="v1.5.x+">
 #### `HTTPTransportPreHook(ctx, req)`
 
 **HTTP transport only.** Intercepts requests BEFORE they enter Bifrost core. Use this to:
@@ -330,6 +469,61 @@ req.Headers["X-Custom-Header"] = "value"
 
 The helper methods (`CaseInsensitiveHeaderLookup` and `CaseInsensitiveQueryLookup`) ensure your plugin works correctly regardless of how the client sends header/query parameter names.
 </Note>
+
+<Warning>
+These functions are **only called** when using `bifrost-http`. They are **not invoked** when using Bifrost as a Go SDK.
+</Warning>
+  </Tab>
+  <Tab title="v1.4.x">
+#### `HTTPTransportPreHook(ctx, req)`
+
+**HTTP transport only.** Intercepts requests BEFORE they enter Bifrost core. Use this to:
+- Modify request headers, body, or query params in-place
+- Short-circuit with a custom response
+- Store values in `BifrostContext` for use in other hooks
+- Works with both native .so and WASM plugins
+
+Key points:
+- Receives serializable `*HTTPRequest` (not raw fasthttp)
+- Modify `req.Headers`, `req.Body`, `req.Query` directly
+- Return `(nil, nil)` to continue to next plugin/handler
+- Return `(*HTTPResponse, nil)` to short-circuit with response
+- Return `(nil, error)` to short-circuit with error
+
+#### `HTTPTransportPostHook(ctx, req, resp)`
+
+**HTTP transport only.** Intercepts responses AFTER they exit Bifrost core. Use this to:
+- Modify response headers or body in-place
+- Log or monitor response data
+- Access context values set in pre-hook
+- Called in **reverse order** of pre-hooks
+
+Key points:
+- Receives both `*HTTPRequest` and `*HTTPResponse`
+- Modify `resp.Headers`, `resp.Body`, `resp.StatusCode` directly
+- Return `nil` to continue to next plugin/handler
+- Return `error` to short-circuit with error and skip remaining post-hooks
+- **NOT called for streaming responses** - use `HTTPTransportStreamChunkHook` instead
+
+#### `HTTPTransportStreamChunkHook(ctx, req, chunk)`
+
+**HTTP transport only.** Intercepts streaming response chunks BEFORE they're written to the client. Use this to:
+- Modify streaming chunks in real-time
+- Filter/skip specific chunks
+- Log or monitor streaming data
+- Called in **reverse order** of pre-hooks
+
+Key points:
+- Receives a `*schemas.BifrostStreamChunk` typed struct (not raw bytes)
+- The struct contains one non-nil field based on the response type (chat, text completion, responses, speech, transcription, image generation, or error)
+- Return `(chunk, nil)` to pass through unchanged
+- Return `(nil, nil)` to skip/filter the chunk entirely
+- Return `(modifiedChunk, nil)` to return a modified chunk
+- Return `(nil, error)` to send error to client and stop streaming
+
+<Warning>
+`HTTPTransportPostHook` is **NOT called** for streaming responses. Use `HTTPTransportStreamChunkHook` to intercept streaming data.
+</Warning>
 
 <Warning>
 These functions are **only called** when using `bifrost-http`. They are **not invoked** when using Bifrost as a Go SDK.
@@ -536,7 +730,7 @@ curl -X POST http://localhost:8080/v1/chat/completions \
 Check the logs for plugin hook calls:
 
 <Tabs>
-  <Tab title="v1.4.x+ (non-streaming)">
+  <Tab title="v1.5.x+ (non-streaming)">
 ```
 HTTPTransportPreHook called
 PreLLMHook called
@@ -544,7 +738,23 @@ PostLLMHook called
 HTTPTransportPostHook called
 ```
   </Tab>
-  <Tab title="v1.4.x+ (streaming)">
+  <Tab title="v1.5.x+ (streaming)">
+```
+HTTPTransportPreHook called
+PreLLMHook called
+PostLLMHook called
+HTTPTransportStreamChunkHook called (per chunk)
+```
+  </Tab>
+  <Tab title="v1.4.x (non-streaming)">
+```
+HTTPTransportPreHook called
+PreLLMHook called
+PostLLMHook called
+HTTPTransportPostHook called
+```
+  </Tab>
+  <Tab title="v1.4.x (streaming)">
 ```
 HTTPTransportPreHook called
 PreLLMHook called
@@ -571,6 +781,7 @@ For plugins that need to maintain state across requests:
 package main
 
 import (
+	"fmt"
 	"sync"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -586,6 +797,7 @@ func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*sche
 	count := requestCount
 	mu.Unlock()
 	
+	ctx.Log(schemas.LogLevelInfo, fmt.Sprintf("request count: %d", count))
 	// Use count for rate limiting, metrics, etc.
 	return req, nil, nil
 }
@@ -600,10 +812,12 @@ func PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bif
 	if bifrostErr != nil {
 		// Allow fallbacks for rate limit errors
 		if bifrostErr.Error.Type != nil && *bifrostErr.Error.Type == "rate_limit" {
+			ctx.Log(schemas.LogLevelWarn, "rate limit hit, allowing fallbacks")
 			allowFallbacks := true
 			bifrostErr.AllowFallbacks = &allowFallbacks
 		} else {
 			// Don't try fallbacks for auth errors
+			ctx.Log(schemas.LogLevelError, "auth error, blocking fallbacks")
 			allowFallbacks := false
 			bifrostErr.AllowFallbacks = &allowFallbacks
 		}
@@ -623,11 +837,13 @@ func PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*sche
 	
 	// Check cache
 	if cached, ok := cache.Load(key); ok {
+		ctx.Log(schemas.LogLevelDebug, "cache hit")
 		return req, &schemas.LLMPluginShortCircuit{
 			Response: cached.(*schemas.BifrostResponse),
 		}, nil
 	}
 	
+	ctx.Log(schemas.LogLevelDebug, "cache miss")
 	return req, nil, nil
 }
 
@@ -636,6 +852,7 @@ func PostLLMHook(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, bif
 		// Store in cache
 		key := generateCacheKeyFromResponse(resp)
 		cache.Store(key, resp)
+		ctx.Log(schemas.LogLevelDebug, "response cached")
 	}
 	return resp, bifrostErr, nil
 }

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,4 +1,6 @@
+- feat: dedicated provider keys API — keys are now managed via `/api/providers/{provider}/keys` endpoints instead of being embedded in provider create/update payloads
 - feat: VK provider config key_ids now supports ["*"] wildcard to allow all keys; empty key_ids denies all; handler resolves wildcard to AllowAllKeys flag without DB key lookups
+- feat: now plugins can start injecting logs at trace level. Just use `ctx.Log(schemas.LogLevelInfo, "Test log")`
 - feat: add option to disable automatic MCP tool injection per request
 - feat: virtual key MCP configs now act as an execution-time allow-list — tools not permitted by the VK are blocked at inference and MCP tool execution
 - refactor: standardize empty array conventions in bifrost. Empty array means no tools/keys are allowed, ["*"] means all tools/keys are allowed.
@@ -54,7 +56,7 @@ The following automatic migrations run on upgrade:
 </Note>
 
 <Warning>
-**This migration is not revertible.** Although all migrations are correctly handled automatically, it is recommended to **make a backup copy of your config store database** before upgrading to v1.5.0-prerelease1. If anything goes wrong, a backup is the only way to restore your previous state. It is also to note that any database which has been successfully migrated to v1.5.0-prereleaseX can not be used to run v1.4.x.
+**This migration is not revertible.** Although all migrations are correctly handled automatically, it is recommended to **make a backup copy of your config store database** before upgrading to v1.5.0-prerelease1. If anything goes wrong, a backup is the only way to restore your previous state. It is also worth noting that any database which has been successfully migrated to v1.5.0-prereleaseX can not be used to run v1.4.x.
 </Warning>
 
 **The automatic migration only protects your existing data.** If you also define your configuration through `config.json` or manage virtual keys via the API, you must update those manually using this guide.
@@ -749,6 +751,110 @@ Support for image editing via the dedicated `/v1/images/edits` endpoint on Repli
 
 ---
 
+## Breaking Change 9: Provider Keys API Separated from Provider API
+
+**Who is affected:** Anyone who reads keys from provider API responses, or sends keys in provider create/update requests via the REST API.
+
+### What changed
+
+Provider key management has been separated into dedicated endpoints. The `keys` field has been **removed** from all provider API requests and responses.
+
+- `GET /api/providers` and `GET /api/providers/{provider}` no longer return a `keys` field.
+- `POST /api/providers` no longer accepts a `keys` field. Create the provider first, then add keys separately.
+- `PUT /api/providers/{provider}` no longer accepts a `keys` field. Existing keys are preserved as-is during provider updates.
+- The existing `GET /api/keys` endpoint (flat key list across all providers) is **unchanged**.
+
+### New endpoints
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/api/providers/{provider}/keys` | List all keys for a provider |
+| `GET` | `/api/providers/{provider}/keys/{key_id}` | Get a single key |
+| `POST` | `/api/providers/{provider}/keys` | Create a new key |
+| `PUT` | `/api/providers/{provider}/keys/{key_id}` | Update a key |
+| `DELETE` | `/api/providers/{provider}/keys/{key_id}` | Delete a key |
+
+**List keys** returns `{ "keys": [...], "total": N }`. All other endpoints return a single key object. Delete returns the deleted key for confirmation. Key values are always redacted in responses.
+
+**Create key notes:**
+- `id` is auto-generated if omitted
+- `enabled` defaults to `true` if omitted
+- `value` is required and must not be empty
+- Provider-specific config fields (`azure_key_config`, `vertex_key_config`, `bedrock_key_config`, `vllm_key_config`) are supported as before
+- Keyless providers (e.g., Ollama) reject key creation with `400`
+
+**Update key notes:**
+Send the full key object. Redacted values sent back unchanged are automatically preserved (same merge behavior as before).
+
+### How to update
+
+**Creating a provider with keys:**
+
+**Before (v1.4.x):**
+```bash
+curl -X POST localhost:8080/api/providers -d '{
+  "provider": "openai",
+  "keys": [{"name": "main", "value": "sk-..."}],
+  "network_config": { ... }
+}'
+```
+
+**After (v1.5.0):** Create the provider first, then add keys separately:
+```bash
+curl -X POST localhost:8080/api/providers -d '{
+  "provider": "openai",
+  "network_config": { ... }
+}'
+
+curl -X POST localhost:8080/api/providers/openai/keys -d '{
+  "name": "main", "value": "sk-..."
+}'
+```
+
+**Reading keys:**
+
+**Before (v1.4.x):**
+```bash
+curl localhost:8080/api/providers/openai | jq '.keys'
+```
+
+**After (v1.5.0):**
+```bash
+curl localhost:8080/api/providers/openai/keys | jq '.keys'
+```
+
+**Updating / deleting keys:**
+
+**Before (v1.4.x):** Bulk replace via provider update:
+```bash
+curl -X PUT localhost:8080/api/providers/openai -d '{
+  "keys": [{"id": "key-1", "name": "updated", "value": "sk-new"}],
+  "network_config": { ... }
+}'
+```
+
+**After (v1.5.0):** Individual key operations:
+```bash
+# Update one key
+curl -X PUT localhost:8080/api/providers/openai/keys/key-1 \
+  -d '{ "name": "updated", "value": "sk-new" }'
+
+# Delete a key
+curl -X DELETE localhost:8080/api/providers/openai/keys/key-2
+
+# Add a new key
+curl -X POST localhost:8080/api/providers/openai/keys \
+  -d '{ "name": "new-key", "value": "sk-..." }'
+```
+
+### Other behavioral changes
+
+- **Model discovery** is automatically triggered after key create, update, and delete operations.
+- **Provider updates** (`PUT /api/providers/{provider}`) now invalidate key status caches, so key statuses refresh after provider config changes.
+- **Existing keys are safe** — no data migration is needed. All existing keys remain intact and accessible via the new endpoints.
+
+---
+
 ## Quick Migration Checklist
 
 Use this checklist when upgrading to v1.5.0:
@@ -783,6 +889,10 @@ If you parse the Virtual Key API response in your code, update the `weight` fiel
 <Step title="Fix any invalid WhiteList values">
 Check that none of your lists mix `"*"` with other values (e.g., `["*", "gpt-4o"]`), and that none have duplicate entries. These will now be rejected with HTTP 400.
 </Step>
+
+<Step title="Migrate key management to dedicated endpoints">
+Stop sending `keys` in provider create/update payloads and stop reading `keys` from provider responses. Use the new `/api/providers/{provider}/keys` endpoints for all key CRUD operations.
+</Step>
 </Steps>
 
 ---
@@ -812,6 +922,12 @@ The most common cause is a whitelist validation failure — either `["*", "gpt-4
 A provider config with `key_ids` omitted or set to `[]` now **blocks all keys** (`allow_all_keys: false`, no specific keys configured). This is different from `allowed_models` — there is no automatic migration for `key_ids`.
 
 **Fix:** Add `"key_ids": ["*"]` to any provider config that previously had `allowed_keys: []` or no `allowed_keys` field.
+
+### Provider create/update returns errors about `keys` field
+
+The `keys` field has been removed from provider API payloads. Use the dedicated `/api/providers/{provider}/keys` endpoints to manage keys separately.
+
+**Fix:** Remove `keys` from your provider create/update requests. Create keys via `POST /api/providers/{provider}/keys` after creating the provider.
 
 ### Existing keys work fine but newly created keys are blocked
 

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -6,10 +6,11 @@
 - fix: add support for `x-bf-mcp-include-clients` and `x-bf-mcp-include-tools` request headers to filter MCP tools/list response when using bifrost as an MCP gateway.
 - refactor: parallelize model listing for providers to speed up startup time.
 - fix: send back accumulated usage in MCP agent mode.
-- feat: MCP edit UI now supports assigning virtual keys with per-tool access control directly from the MCP server edit sheet.
+- feat: MCP configuration now supports assigning virtual keys with per-tool access control.
 - feat: adds option to allow MCP clients to run on all virtual keys without explicit assignment.
 - feat: add support for pricing overrides.
-- fix: case-insensitive `anthropic-beta` merge in `MergeBetaHeaders`
+- feat: add StabilityAI provider support to Bedrock.
+- fix: handle text, vtt, srt response formats in OpenAI transcription response.
 
 <Warning>
 **v1.5.0 contains multiple breaking changes** to how Bifrost interprets empty arrays and wildcard values across Virtual Keys, provider keys, and MCP configurations. Existing deployments are protected by automatic database migrations — but any **new** configuration created after upgrading must follow the new semantics described below.
@@ -53,7 +54,7 @@ The following automatic migrations run on upgrade:
 </Note>
 
 <Warning>
-**This migration is not revertible.** Although all migrations are correctly handled automatically, it is recommended to **make a backup copy of your config store database** before upgrading to v1.5.0-prerelease1. If anything goes wrong, a backup is the only way to restore your previous state.
+**This migration is not revertible.** Although all migrations are correctly handled automatically, it is recommended to **make a backup copy of your config store database** before upgrading to v1.5.0-prerelease1. If anything goes wrong, a backup is the only way to restore your previous state. It is also to note that any database which has been successfully migrated to v1.5.0-prereleaseX can not be used to run v1.4.x.
 </Warning>
 
 **The automatic migration only protects your existing data.** If you also define your configuration through `config.json` or manage virtual keys via the API, you must update those manually using this guide.


### PR DESCRIPTION
## Summary

This PR adds StabilityAI provider support to Bedrock and fixes OpenAI transcription response handling for multiple text formats. Additionally, it includes minor documentation updates for MCP configuration clarity and database migration warnings.

## Changes

- Added StabilityAI provider integration to Bedrock for expanded model access
- Fixed OpenAI transcription response handling to properly support text, vtt, and srt response formats
- Updated MCP configuration documentation to clarify virtual key assignment functionality
- Enhanced database migration warning to specify version compatibility constraints

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Validate StabilityAI provider functionality through Bedrock:
```sh
# Test Bedrock StabilityAI integration
curl -X POST /v1/chat/completions \
  -H "Authorization: Bearer your-key" \
  -d '{"model": "stability.stable-diffusion-xl", "messages": [...]}'
```

Test OpenAI transcription with different response formats:
```sh
# Test transcription with text format
curl -X POST /v1/audio/transcriptions \
  -H "Authorization: Bearer your-key" \
  -F "file=@audio.mp3" \
  -F "model=whisper-1" \
  -F "response_format=text"

# Test with vtt format
curl -X POST /v1/audio/transcriptions \
  -H "Authorization: Bearer your-key" \
  -F "file=@audio.mp3" \
  -F "model=whisper-1" \
  -F "response_format=vtt"
```

Run standard test suite:
```sh
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

StabilityAI provider integration follows existing Bedrock security patterns with proper credential handling and request validation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable