### PR TITLE
fix version detection for minor patches

### DIFF
--- a/.github/workflows/scripts/detect-all-changes.sh
+++ b/.github/workflows/scripts/detect-all-changes.sh
@@ -88,17 +88,26 @@ else
   FRAMEWORK_MAJOR_MINOR=$(echo "$FRAMEWORK_BASE_VERSION" | cut -d. -f1,2)
   echo "   🔍 Checking track: ${FRAMEWORK_MAJOR_MINOR}.x"
   
-  ALL_TAGS=$(git tag -l "framework/v${FRAMEWORK_MAJOR_MINOR}.*" | sort -V)
-  STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-' || true)
-  PRERELEASE_TAGS=$(echo "$ALL_TAGS" | grep '\-' || true)
   LATEST_FRAMEWORK_TAG=""
-  if [ -n "$STABLE_TAGS" ]; then
-    LATEST_FRAMEWORK_TAG=$(echo "$STABLE_TAGS" | tail -1)
-    echo "latest framework tag (stable preferred): $LATEST_FRAMEWORK_TAG"
+  if [[ "$FRAMEWORK_VERSION" == *"-"* ]]; then
+    # current_version has prerelease, so include all versions but prefer stable
+    ALL_TAGS=$(git tag -l "framework/v${FRAMEWORK_MAJOR_MINOR}.*" | sort -V)
+    STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-' || true)
+    PRERELEASE_TAGS=$(echo "$ALL_TAGS" | grep '\-' || true)
+    if [ -n "$STABLE_TAGS" ]; then
+      # Get the highest stable version
+      LATEST_FRAMEWORK_TAG=$(echo "$STABLE_TAGS" | tail -1)
+      echo "latest framework tag (stable preferred): $LATEST_FRAMEWORK_TAG"
+    else
+      # No stable versions, get highest prerelease
+      LATEST_FRAMEWORK_TAG=$(echo "$PRERELEASE_TAGS" | tail -1)
+      echo "latest framework tag (prerelease only): $LATEST_FRAMEWORK_TAG"
+    fi
   else
-    LATEST_FRAMEWORK_TAG=$(echo "$PRERELEASE_TAGS" | tail -1)
-    echo "latest framework tag (prerelease only): $LATEST_FRAMEWORK_TAG"  
-  fi      
+    # VERSION has no prerelease, so only consider stable releases in same track
+    LATEST_FRAMEWORK_TAG=$(git tag -l "framework/v${FRAMEWORK_MAJOR_MINOR}.*" | grep -v '\-' | sort -V | tail -1 || true)
+    echo "latest framework tag (stable only): $LATEST_FRAMEWORK_TAG"
+  fi
   if [ -z "$LATEST_FRAMEWORK_TAG" ]; then
     echo "   ✅ First framework release in track ${FRAMEWORK_MAJOR_MINOR}.x: $FRAMEWORK_VERSION"
     FRAMEWORK_NEEDS_RELEASE="true"
@@ -153,20 +162,20 @@ for plugin_dir in plugins/*/; do
   echo "      🔍 Checking track: ${plugin_major_minor}.x"
 
   if [[ "$current_version" == *"-"* ]]; then
-      # current_version has prerelease, so include all versions but prefer stable
-      ALL_TAGS=$(git tag -l "plugins/${plugin_name}/v${plugin_major_minor}.*" | sort -V)
-      STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-' || true)
-      PRERELEASE_TAGS=$(echo "$ALL_TAGS" | grep '\-' || true)
-      
-      if [ -n "$STABLE_TAGS" ]; then
-        # Get the highest stable version
-        LATEST_PLUGIN_TAG=$(echo "$STABLE_TAGS" | tail -1)
-        echo "latest plugin tag (stable preferred): $LATEST_PLUGIN_TAG"
-      else
-        # No stable versions, get highest prerelease
-        LATEST_PLUGIN_TAG=$(echo "$PRERELEASE_TAGS" | tail -1)
-        echo "latest plugin tag (prerelease only): $LATEST_PLUGIN_TAG"
-      fi
+    # current_version has prerelease, so include all versions but prefer stable
+    ALL_TAGS=$(git tag -l "plugins/${plugin_name}/v${plugin_major_minor}.*" | sort -V)
+    STABLE_TAGS=$(echo "$ALL_TAGS" | grep -v '\-' || true)
+    PRERELEASE_TAGS=$(echo "$ALL_TAGS" | grep '\-' || true)
+
+    if [ -n "$STABLE_TAGS" ]; then
+      # Get the highest stable version
+      LATEST_PLUGIN_TAG=$(echo "$STABLE_TAGS" | tail -1)
+      echo "latest plugin tag (stable preferred): $LATEST_PLUGIN_TAG"
+    else
+      # No stable versions, get highest prerelease
+      LATEST_PLUGIN_TAG=$(echo "$PRERELEASE_TAGS" | tail -1)
+      echo "latest plugin tag (prerelease only): $LATEST_PLUGIN_TAG"
+    fi
   else
     # VERSION has no prerelease, so only consider stable releases in same track
     LATEST_PLUGIN_TAG=$(git tag -l "plugins/${plugin_name}/v${plugin_major_minor}.*" | grep -v '\-' | sort -V | tail -1 || true)


### PR DESCRIPTION
## Summary

Fixes version comparison logic in the change detection script to properly handle stable vs prerelease versions for both framework and plugin releases.

## Changes

- Modified framework version comparison to only consider stable releases when the current version is stable, and prefer stable releases when the current version is a prerelease
- Applied consistent indentation to the plugin version comparison logic that already had the correct behavior
- Ensures that stable releases are not compared against prerelease versions, preventing incorrect change detection

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs
- [x] CI/CD

## How to test

Test the change detection script with different version scenarios:

```sh
# Test with stable framework version
FRAMEWORK_VERSION="1.2.3" .github/workflows/scripts/detect-all-changes.sh

# Test with prerelease framework version  
FRAMEWORK_VERSION="1.2.3-beta.1" .github/workflows/scripts/detect-all-changes.sh

# Verify that stable versions only compare against other stable versions
# and prerelease versions prefer stable but fall back to prerelease
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is an internal CI script change that improves version comparison accuracy.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable