### PR TITLE
refactor: standardize delete button styling with red theme across workspace tables

### DIFF
--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -220,7 +220,7 @@ export const createColumns = (onDelete: (log: LogEntry) => void, hasDeleteAccess
 		cell: ({ row }) => {
 			const log = row.original;
 			return (
-				<Button variant="outline" size="icon" onClick={() => onDelete(log)} disabled={!hasDeleteAccess}>
+				<Button variant="outline" size="icon" aria-label="Delete log" className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30" onClick={() => onDelete(log)} disabled={!hasDeleteAccess}>
 					<Trash2 />
 				</Button>
 			);

--- a/ui/app/workspace/mcp-logs/views/columns.tsx
+++ b/ui/app/workspace/mcp-logs/views/columns.tsx
@@ -101,7 +101,7 @@ export const createMCPColumns = (
 		cell: ({ row }) => {
 			const log = row.original;
 			return (
-				<Button variant="outline" size="icon" onClick={() => void handleDelete(log)} disabled={!hasDeleteAccess} aria-label="Delete log">
+				<Button variant="outline" size="icon" className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30" onClick={() => void handleDelete(log)} disabled={!hasDeleteAccess} aria-label="Delete log">
 					<Trash2 />
 				</Button>
 			);

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -269,7 +269,7 @@ export default function MCPClientsTable({ mcpClients, totalCount, refetch, searc
 
 										<AlertDialog>
 											<AlertDialogTrigger asChild>
-												<Button variant="ghost" size="icon" disabled={!hasDeleteMCPClientAccess}>
+												<Button variant="ghost" size="icon" className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30" disabled={!hasDeleteMCPClientAccess}>
 													<Trash2 className="h-4 w-4" />
 												</Button>
 											</AlertDialogTrigger>
@@ -283,7 +283,7 @@ export default function MCPClientsTable({ mcpClients, totalCount, refetch, searc
 												</AlertDialogHeader>
 												<AlertDialogFooter>
 													<AlertDialogCancel>Cancel</AlertDialogCancel>
-													<AlertDialogAction onClick={() => handleDelete(c)}>Delete</AlertDialogAction>
+													<AlertDialogAction onClick={() => handleDelete(c)} className="bg-destructive hover:bg-destructive/90">Delete</AlertDialogAction>
 												</AlertDialogFooter>
 											</AlertDialogContent>
 										</AlertDialog>

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -215,6 +215,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 															Edit
 														</DropdownMenuItem>
 														<DropdownMenuItem
+															variant="destructive"
 															onClick={() => {
 																setShowDeleteKeyDialog({ show: true, keyIndex: index });
 															}}

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -177,6 +177,7 @@ export function RoutingRulesTable({ rules, totalCount, isLoading, onEdit, canDel
 											<Button
 												variant="ghost"
 												size="sm"
+												className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30"
 												onClick={() => setDeleteRuleId(rule.id)}
 												aria-label="Delete routing rule"
 											>

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -79,7 +79,7 @@ export default function VirtualKeysTable({
   const selectedVirtualKey = useMemo(
     () => (selectedVirtualKeyId ? virtualKeys.find((vk) => vk.id === selectedVirtualKeyId) ?? null : null),
     [selectedVirtualKeyId, virtualKeys],
-  )
+  )	
 
   const hasCreateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Create)
   const hasUpdateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Update)
@@ -332,6 +332,7 @@ export default function VirtualKeysTable({
 															<Button
 																variant="ghost"
 																size="sm"
+																className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30"
 																onClick={(e) => e.stopPropagation()}
 																disabled={!hasDeleteAccess}
 																data-testid={`vk-delete-btn-${vk.name}`}
@@ -349,7 +350,7 @@ export default function VirtualKeysTable({
 															</AlertDialogHeader>
 															<AlertDialogFooter>
 																<AlertDialogCancel>Cancel</AlertDialogCancel>
-																<AlertDialogAction onClick={() => handleDelete(vk.id)} disabled={isDeleting}>
+																<AlertDialogAction onClick={() => handleDelete(vk.id)} disabled={isDeleting} className="bg-destructive hover:bg-destructive/90">
 																	{isDeleting ? "Deleting..." : "Delete"}
 																</AlertDialogAction>
 															</AlertDialogFooter>

--- a/ui/components/prompts/fragments/sidebar.tsx
+++ b/ui/components/prompts/fragments/sidebar.tsx
@@ -445,7 +445,7 @@ function DroppableFolder({
 							)}
 							{canDelete && (
 								<DropdownMenuItem
-									className="text-destructive"
+									variant="destructive"
 									data-testid="folder-action-delete"
 									onClick={(e) => {
 										e.stopPropagation();
@@ -559,14 +559,15 @@ function DraggablePromptItem({ prompt, isSelected, onSelect, onEdit, onDelete, c
 						)}
 						{canDelete && (
 							<DropdownMenuItem
-								className="text-destructive hover:text-destructive cursor-pointer"
+								variant="destructive"
+								className="cursor-pointer"
 								data-testid="prompt-action-delete"
 								onClick={(e) => {
 									e.stopPropagation();
 									onDelete();
 								}}
 							>
-								<Trash2 className="text-destructive h-4 w-4" />
+								<Trash2 className="h-4 w-4" />
 								Delete
 							</DropdownMenuItem>
 						)}


### PR DESCRIPTION
## Summary

Standardizes the visual styling of delete buttons and destructive actions across the UI to provide consistent user experience and better visual hierarchy for dangerous operations.

## Changes

- Applied consistent destructive styling (`text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30`) to delete buttons in logs, MCP logs, MCP clients, routing rules, and virtual keys tables
- Updated AlertDialog delete actions to use destructive background styling (`bg-destructive hover:bg-destructive/90`)
- Replaced manual destructive CSS classes with `variant="destructive"` prop on DropdownMenuItem components for delete actions in prompts sidebar and model provider keys
- Added missing `aria-label="Delete log"` to logs table delete button for accessibility

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Navigate to each affected area and verify delete buttons have consistent red styling:

1. Go to workspace logs and verify delete buttons are styled with red text and hover effects
2. Check MCP logs table for consistent delete button styling
3. Visit MCP registry and confirm delete buttons and confirmation dialogs use destructive styling
4. Test routing rules table delete buttons
5. Check virtual keys table delete buttons and confirmation dialogs
6. Verify prompts sidebar dropdown delete options use proper destructive variant
7. Test model provider keys dropdown delete options

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Inconsistent delete button styling across different tables and components
After: Unified red destructive styling for all delete actions

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is purely a visual styling update.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable