### PR TITLE
feat: add async support and loading state to Switch component

### DIFF
--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -220,7 +220,7 @@ export const createColumns = (onDelete: (log: LogEntry) => void, hasDeleteAccess
 		cell: ({ row }) => {
 			const log = row.original;
 			return (
-				<Button variant="outline" size="icon" onClick={() => onDelete(log)} disabled={!hasDeleteAccess}>
+				<Button variant="outline" size="icon" aria-label="Delete log" className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30" onClick={() => onDelete(log)} disabled={!hasDeleteAccess}>
 					<Trash2 />
 				</Button>
 			);

--- a/ui/app/workspace/mcp-logs/views/columns.tsx
+++ b/ui/app/workspace/mcp-logs/views/columns.tsx
@@ -101,7 +101,7 @@ export const createMCPColumns = (
 		cell: ({ row }) => {
 			const log = row.original;
 			return (
-				<Button variant="outline" size="icon" onClick={() => void handleDelete(log)} disabled={!hasDeleteAccess} aria-label="Delete log">
+				<Button variant="outline" size="icon" className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30" onClick={() => void handleDelete(log)} disabled={!hasDeleteAccess} aria-label="Delete log">
 					<Trash2 />
 				</Button>
 			);

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -269,7 +269,7 @@ export default function MCPClientsTable({ mcpClients, totalCount, refetch, searc
 
 										<AlertDialog>
 											<AlertDialogTrigger asChild>
-												<Button variant="ghost" size="icon" disabled={!hasDeleteMCPClientAccess}>
+												<Button variant="ghost" size="icon" className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30" disabled={!hasDeleteMCPClientAccess}>
 													<Trash2 className="h-4 w-4" />
 												</Button>
 											</AlertDialogTrigger>
@@ -283,7 +283,7 @@ export default function MCPClientsTable({ mcpClients, totalCount, refetch, searc
 												</AlertDialogHeader>
 												<AlertDialogFooter>
 													<AlertDialogCancel>Cancel</AlertDialogCancel>
-													<AlertDialogAction onClick={() => handleDelete(c)}>Delete</AlertDialogAction>
+													<AlertDialogAction onClick={() => handleDelete(c)} className="bg-destructive hover:bg-destructive/90">Delete</AlertDialogAction>
 												</AlertDialogFooter>
 											</AlertDialogContent>
 										</AlertDialog>

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -215,6 +215,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 															Edit
 														</DropdownMenuItem>
 														<DropdownMenuItem
+															variant="destructive"
 															onClick={() => {
 																setShowDeleteKeyDialog({ show: true, keyIndex: index });
 															}}

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -181,8 +181,8 @@ export default function ModelProviderKeysTableView({ provider, className, header
 												checked={isKeyEnabled}
 												size="md"
 												disabled={!hasUpdateProviderAccess}
-												onCheckedChange={(checked) => {
-													updateProvider({
+												onAsyncCheckedChange={async (checked) => {
+													await updateProvider({
 														...provider,
 														keys: provider.keys.map((k, i) => (i === index ? { ...k, enabled: checked } : k)),
 													})

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -177,6 +177,7 @@ export function RoutingRulesTable({ rules, totalCount, isLoading, onEdit, canDel
 											<Button
 												variant="ghost"
 												size="sm"
+												className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30"
 												onClick={() => setDeleteRuleId(rule.id)}
 												aria-label="Delete routing rule"
 											>

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -79,7 +79,7 @@ export default function VirtualKeysTable({
   const selectedVirtualKey = useMemo(
     () => (selectedVirtualKeyId ? virtualKeys.find((vk) => vk.id === selectedVirtualKeyId) ?? null : null),
     [selectedVirtualKeyId, virtualKeys],
-  )
+  )	
 
   const hasCreateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Create)
   const hasUpdateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Update)
@@ -332,6 +332,7 @@ export default function VirtualKeysTable({
 															<Button
 																variant="ghost"
 																size="sm"
+																className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30"
 																onClick={(e) => e.stopPropagation()}
 																disabled={!hasDeleteAccess}
 																data-testid={`vk-delete-btn-${vk.name}`}
@@ -349,7 +350,7 @@ export default function VirtualKeysTable({
 															</AlertDialogHeader>
 															<AlertDialogFooter>
 																<AlertDialogCancel>Cancel</AlertDialogCancel>
-																<AlertDialogAction onClick={() => handleDelete(vk.id)} disabled={isDeleting}>
+																<AlertDialogAction onClick={() => handleDelete(vk.id)} disabled={isDeleting} className="bg-destructive hover:bg-destructive/90">
 																	{isDeleting ? "Deleting..." : "Delete"}
 																</AlertDialogAction>
 															</AlertDialogFooter>

--- a/ui/components/prompts/fragments/sidebar.tsx
+++ b/ui/components/prompts/fragments/sidebar.tsx
@@ -445,7 +445,7 @@ function DroppableFolder({
 							)}
 							{canDelete && (
 								<DropdownMenuItem
-									className="text-destructive"
+									variant="destructive"
 									data-testid="folder-action-delete"
 									onClick={(e) => {
 										e.stopPropagation();
@@ -559,14 +559,15 @@ function DraggablePromptItem({ prompt, isSelected, onSelect, onEdit, onDelete, c
 						)}
 						{canDelete && (
 							<DropdownMenuItem
-								className="text-destructive hover:text-destructive cursor-pointer"
+								variant="destructive"
+								className="cursor-pointer"
 								data-testid="prompt-action-delete"
 								onClick={(e) => {
 									e.stopPropagation();
 									onDelete();
 								}}
 							>
-								<Trash2 className="text-destructive h-4 w-4" />
+								<Trash2 className="h-4 w-4" />
 								Delete
 							</DropdownMenuItem>
 						)}

--- a/ui/components/ui/switch.tsx
+++ b/ui/components/ui/switch.tsx
@@ -1,35 +1,74 @@
 "use client";
 
 import * as SwitchPrimitives from "@radix-ui/react-switch";
+import { Loader2 } from "lucide-react";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
 interface SwitchProps extends React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> {
 	size?: "default" | "md";
+	onAsyncCheckedChange?: (checked: boolean) => Promise<void>;
 }
 
 const Switch = React.forwardRef<React.ElementRef<typeof SwitchPrimitives.Root>, SwitchProps>(
-	({ className, size = "md", ...props }, ref) => (
-		<SwitchPrimitives.Root
-			className={cn(
-				"peer focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input inline-flex shrink-0 cursor-pointer items-center rounded-sm border-2 border-transparent transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
-				size === "default" && "h-6 w-11",
-				size === "md" && "h-5 w-9",
-				className,
-			)}
-			{...props}
-			ref={ref}
-		>
-			<SwitchPrimitives.Thumb
+	({ className, size = "md", onAsyncCheckedChange, onCheckedChange, disabled, ...props }, ref) => {
+		const [loading, setLoading] = React.useState(false);
+
+		const handleCheckedChange = React.useCallback(
+			(checked: boolean) => {
+				if (onAsyncCheckedChange) {
+					setLoading(true);
+					// Wrap in Promise.resolve().then() to catch synchronous throws from the handler,
+					// ensuring .finally() always runs and resets loading state.
+					Promise.resolve()
+						.then(() => onAsyncCheckedChange(checked))
+						.catch(() => {})
+						.finally(() => {
+							setLoading(false);
+						});
+				} else {
+					onCheckedChange?.(checked);
+				}
+			},
+			[onAsyncCheckedChange, onCheckedChange],
+		);
+
+		return (
+			<SwitchPrimitives.Root
 				className={cn(
-					"pointer-events-none block rounded-sm bg-white shadow-lg ring-0 transition-transform dark:bg-zinc-900",
-					size === "default" && "h-5 w-5 data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
-					size === "md" && "h-4 w-4 data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+					"peer focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input inline-flex shrink-0 cursor-pointer items-center rounded-sm border-2 border-transparent transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50",
+					size === "default" && "h-6 w-11",
+					size === "md" && "h-5 w-9",
+					className,
 				)}
-			/>
-		</SwitchPrimitives.Root>
-	),
+				disabled={disabled || loading}
+				onCheckedChange={handleCheckedChange}
+				{...props}
+				ref={ref}
+			>
+				<SwitchPrimitives.Thumb
+					className={cn(
+						"pointer-events-none relative block rounded-sm bg-white shadow-lg ring-0 transition-transform dark:bg-zinc-900",
+						size === "default" &&
+							"h-5 w-5 data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+						size === "md" &&
+							"h-4 w-4 data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+					)}
+				>
+					{loading && (
+						<Loader2
+							className={cn(
+								"absolute inset-0 m-auto animate-spin text-muted-foreground",
+								size === "default" && "h-3 w-3",
+								size === "md" && "h-2.5 w-2.5",
+							)}
+						/>
+					)}
+				</SwitchPrimitives.Thumb>
+			</SwitchPrimitives.Root>
+		);
+	},
 );
 Switch.displayName = SwitchPrimitives.Root.displayName;
 


### PR DESCRIPTION
## Summary

Added async support to the Switch component with loading state indication and updated the model provider keys table to use async operations when toggling key states.

## Changes

- Enhanced Switch component with `onAsyncCheckedChange` prop that accepts async functions and displays a loading spinner during execution
- Added loading state management that disables the switch and shows a Loader2 icon while async operations are in progress
- Updated model provider keys table to use the new async handler for enabling/disabling provider keys
- Maintained backward compatibility by preserving the original `onCheckedChange` prop for synchronous operations

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Navigate to the workspace providers section and toggle provider keys to verify the loading state appears during async operations.

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

[Screen Recording 2026-04-01 at 6.56.52 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/e546c16b-ce33-46ac-b8cc-d7afbd74b57e.mov" />](https://app.graphite.com/user-attachments/video/e546c16b-ce33-46ac-b8cc-d7afbd74b57e.mov)



## Breaking changes

- [ ] Yes
- [x] No

## Related issues



## Security considerations

No security implications - this is a UI enhancement for better user experience during async operations.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable