### PR TITLE
fix index to contain enteprise release notes

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -623,6 +623,9 @@
             "item": "Enterprise",
             "icon": "building",
             "pages": [
+              "changelogs/ent-v1.3.16",
+              "changelogs/ent-v1.3.15",
+              "changelogs/ent-v1.3.14",
               "changelogs/ent-v1.3.13",
               "changelogs/ent-v1.3.12",
               "changelogs/ent-v1.3.11",


### PR DESCRIPTION
## Summary

Adds documentation entries for Enterprise changelog versions 1.3.16, 1.3.15, and 1.3.14 to the documentation navigation structure.

## Changes

- Added three new changelog page references to the Enterprise section of the documentation navigation
- Entries are ordered chronologically with newest versions first (v1.3.16, v1.3.15, v1.3.14)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify that the documentation site builds correctly and the new changelog entries appear in the Enterprise section navigation.

```sh
# Docs
cd docs
# Build and serve documentation to verify navigation structure
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a documentation navigation change only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable