### PR TITLE
fix: preserve explicit empty tool parameter schemas for openai paths

### DIFF
--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -107,6 +108,43 @@ func TestToOpenAIChatRequest_PreservesPropertyOrder(t *testing.T) {
 	keys := normalizedParams.Properties.Keys()
 	if len(keys) != 3 || keys[0] != "reasoning" || keys[1] != "answer" || keys[2] != "confidence" {
 		t.Errorf("expected property order [reasoning, answer, confidence], got %v", keys)
+	}
+}
+
+func TestToOpenAIChatRequest_PreservesExplicitEmptyToolParameters(t *testing.T) {
+	var tool schemas.ChatTool
+	err := json.Unmarshal([]byte(`{"type":"function","function":{"name":"empty_schema","parameters":{},"strict":false}}`), &tool)
+	if err != nil {
+		t.Fatalf("failed to unmarshal tool: %v", err)
+	}
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser}},
+		Params: &schemas.ChatParameters{
+			Tools: []schemas.ChatTool{tool},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+	result := ToOpenAIChatRequest(ctx, bifrostReq)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	params := result.ChatParameters.Tools[0].Function.Parameters
+	if params == nil {
+		t.Fatal("expected tool parameters to be preserved")
+	}
+
+	marshaled, err := schemas.Marshal(params)
+	if err != nil {
+		t.Fatalf("failed to marshal parameters: %v", err)
+	}
+	if string(marshaled) != `{}` {
+		t.Fatalf("expected parameters to remain {}, got %s", marshaled)
 	}
 }
 

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -1500,6 +1500,48 @@ func TestToOpenAIResponsesRequest_ToolNormalization(t *testing.T) {
 	}
 }
 
+func TestToOpenAIResponsesRequest_PreservesExplicitEmptyToolParameters(t *testing.T) {
+	var tool schemas.ResponsesTool
+	err := json.Unmarshal([]byte(`{"type":"function","name":"empty_schema","parameters":{},"strict":false}`), &tool)
+	if err != nil {
+		t.Fatalf("failed to unmarshal tool: %v", err)
+	}
+
+	bifrostReq := &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
+		Input: []schemas.ResponsesMessage{
+			{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: schemas.Ptr("hello"),
+				},
+			},
+		},
+		Params: &schemas.ResponsesParameters{
+			Tools: []schemas.ResponsesTool{tool},
+		},
+	}
+
+	result := ToOpenAIResponsesRequest(bifrostReq)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	params := result.Tools[0].ResponsesToolFunction.Parameters
+	if params == nil {
+		t.Fatal("expected tool parameters to be preserved")
+	}
+
+	marshaled, err := schemas.Marshal(params)
+	if err != nil {
+		t.Fatalf("failed to marshal parameters: %v", err)
+	}
+	if string(marshaled) != `{}` {
+		t.Fatalf("expected parameters to remain {}, got %s", marshaled)
+	}
+}
+
 // =============================================================================
 // Helper Functions
 // =============================================================================

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -361,13 +361,17 @@ type ToolFunctionParameters struct {
 	// keyOrder preserves the JSON key order from the original input so that
 	// MarshalJSON can emit keys in the same order the client sent them.
 	keyOrder JSONKeyOrder `json:"-"`
+	// explicitEmptyObject tracks a client-supplied raw {} schema.
+	explicitEmptyObject bool `json:"-"`
 }
 
-// MarshalJSON serializes ToolFunctionParameters to JSON, preserving the original key
-// order from the input JSON. If no original order was captured (programmatic construction),
-// it falls back to the default struct field declaration order.
-// Properties is always emitted as an object, never null.
+// MarshalJSON serializes ToolFunctionParameters while preserving the original
+// top-level key order when available. A client-supplied raw `{}` stays `{}`;
+// otherwise object schemas always emit `properties` as an object, never null.
 func (t ToolFunctionParameters) MarshalJSON() ([]byte, error) {
+	if t.explicitEmptyObject && !t.hasDefinedSchemaFields() {
+		return []byte("{}"), nil
+	}
 	if t.Properties == nil {
 		// Initialize with an empty map (not nil values) so it marshals to {} instead of null
 		// Required by OpenAI and JSON Schema spec
@@ -383,13 +387,15 @@ func (t ToolFunctionParameters) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements custom JSON unmarshalling for ToolFunctionParameters.
 // It handles both JSON object format (standard) and JSON string format (used by some providers like xAI).
-// It captures the original key order for order-preserving re-serialization.
+// It captures the original key order for order-preserving re-serialization and
+// records whether the client provided an explicit empty object schema.
 func (t *ToolFunctionParameters) UnmarshalJSON(data []byte) error {
 	// Try to unmarshal as a JSON string first (xAI sends parameters as a string)
 	var jsonStr string
 	if err := Unmarshal(data, &jsonStr); err == nil {
 		data = []byte(jsonStr)
 	}
+	trimmed := bytes.TrimSpace(data)
 
 	type Alias ToolFunctionParameters
 	var temp Alias
@@ -405,6 +411,7 @@ func (t *ToolFunctionParameters) UnmarshalJSON(data []byte) error {
 		t.AdditionalProperties = nil
 	}
 
+	t.explicitEmptyObject = bytes.Equal(trimmed, []byte("{}"))
 	t.keyOrder.Capture(data)
 	return nil
 }
@@ -477,6 +484,34 @@ func (t *ToolFunctionParameters) Normalized() *ToolFunctionParameters {
 		out.Default = sortedCopySlice(v)
 	}
 	return &out
+}
+
+// hasDefinedSchemaFields reports whether the schema contains any real JSON Schema
+// fields, allowing MarshalJSON to distinguish an explicit raw `{}` from a
+// populated object schema such as `{"type":"object","properties":{}}`.
+func (t *ToolFunctionParameters) hasDefinedSchemaFields() bool {
+	if t == nil {
+		return false
+	}
+	if t.Type != "" || t.Description != nil || len(t.Required) > 0 || t.AdditionalProperties != nil || len(t.Enum) > 0 {
+		return true
+	}
+	if t.Properties != nil || t.Defs != nil || t.Definitions != nil || t.Ref != nil {
+		return true
+	}
+	if t.Items != nil || t.MinItems != nil || t.MaxItems != nil {
+		return true
+	}
+	if len(t.AnyOf) > 0 || len(t.OneOf) > 0 || len(t.AllOf) > 0 {
+		return true
+	}
+	if t.Format != nil || t.Pattern != nil || t.MinLength != nil || t.MaxLength != nil {
+		return true
+	}
+	if t.Minimum != nil || t.Maximum != nil {
+		return true
+	}
+	return t.Title != nil || t.Default != nil || t.Nullable != nil
 }
 
 type AdditionalPropertiesStruct struct {

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -409,8 +409,16 @@ func (t *ToolFunctionParameters) UnmarshalJSON(data []byte) error {
 		t.AdditionalProperties = nil
 	}
 
-	var rawObject map[string]interface{}
-	t.explicitEmptyObject = Unmarshal(data, &rawObject) == nil && len(rawObject) == 0
+	trimmed := bytes.TrimSpace(data)
+	t.explicitEmptyObject = len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}'
+	if t.explicitEmptyObject {
+		for _, b := range trimmed[1 : len(trimmed)-1] {
+			if b != ' ' && b != '\t' && b != '\n' && b != '\r' {
+				t.explicitEmptyObject = false
+				break
+			}
+		}
+	}
 	t.keyOrder.Capture(data)
 	return nil
 }

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -410,14 +410,11 @@ func (t *ToolFunctionParameters) UnmarshalJSON(data []byte) error {
 	}
 
 	trimmed := bytes.TrimSpace(data)
-	t.explicitEmptyObject = len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}'
-	if t.explicitEmptyObject {
-		for _, b := range trimmed[1 : len(trimmed)-1] {
-			if b != ' ' && b != '\t' && b != '\n' && b != '\r' {
-				t.explicitEmptyObject = false
-				break
-			}
-		}
+	if len(trimmed) >= 2 && trimmed[0] == '{' && trimmed[len(trimmed)-1] == '}' {
+		inner := bytes.TrimSpace(trimmed[1 : len(trimmed)-1])
+		t.explicitEmptyObject = len(inner) == 0
+	} else {
+		t.explicitEmptyObject = false
 	}
 	t.keyOrder.Capture(data)
 	return nil

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -395,8 +395,6 @@ func (t *ToolFunctionParameters) UnmarshalJSON(data []byte) error {
 	if err := Unmarshal(data, &jsonStr); err == nil {
 		data = []byte(jsonStr)
 	}
-	trimmed := bytes.TrimSpace(data)
-
 	type Alias ToolFunctionParameters
 	var temp Alias
 	if err := Unmarshal(data, &temp); err != nil {
@@ -411,7 +409,8 @@ func (t *ToolFunctionParameters) UnmarshalJSON(data []byte) error {
 		t.AdditionalProperties = nil
 	}
 
-	t.explicitEmptyObject = bytes.Equal(trimmed, []byte("{}"))
+	var rawObject map[string]interface{}
+	t.explicitEmptyObject = Unmarshal(data, &rawObject) == nil && len(rawObject) == 0
 	t.keyOrder.Capture(data)
 	return nil
 }

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -795,6 +795,20 @@ func TestToolFunctionParameters_ExplicitEmptyObjectPreserved(t *testing.T) {
 	assert.Equal(t, `{}`, string(normalized))
 }
 
+func TestToolFunctionParameters_ExplicitEmptyObjectWhitespacePreserved(t *testing.T) {
+	var params ToolFunctionParameters
+	err := Unmarshal([]byte(` { } `), &params)
+	require.NoError(t, err)
+
+	marshaled, err := Marshal(params)
+	require.NoError(t, err)
+	assert.Equal(t, `{}`, string(marshaled))
+
+	normalized, err := Marshal(params.Normalized())
+	require.NoError(t, err)
+	assert.Equal(t, `{}`, string(normalized))
+}
+
 func TestToolFunctionParameters_ExplicitObjectSchemaPreserved(t *testing.T) {
 	var params ToolFunctionParameters
 	err := Unmarshal([]byte(`{"type":"object","properties":{}}`), &params)

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -781,6 +781,34 @@ func TestResponsesTool_MarshalJSON_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestToolFunctionParameters_ExplicitEmptyObjectPreserved(t *testing.T) {
+	var params ToolFunctionParameters
+	err := Unmarshal([]byte(`{}`), &params)
+	require.NoError(t, err)
+
+	marshaled, err := Marshal(params)
+	require.NoError(t, err)
+	assert.Equal(t, `{}`, string(marshaled))
+
+	normalized, err := Marshal(params.Normalized())
+	require.NoError(t, err)
+	assert.Equal(t, `{}`, string(normalized))
+}
+
+func TestToolFunctionParameters_ExplicitObjectSchemaPreserved(t *testing.T) {
+	var params ToolFunctionParameters
+	err := Unmarshal([]byte(`{"type":"object","properties":{}}`), &params)
+	require.NoError(t, err)
+
+	marshaled, err := Marshal(params)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"object","properties":{}}`, string(marshaled))
+
+	normalized, err := Marshal(params.Normalized())
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"object","properties":{}}`, string(normalized))
+}
+
 // TestResponsesToolFileSearchFilter_MarshalJSON_Deterministic verifies deterministic
 // serialization for file search filters.
 func TestResponsesToolFileSearchFilter_MarshalJSON_Deterministic(t *testing.T) {

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -837,6 +837,7 @@ func DeepCopyChatTool(original ChatTool) ChatTool {
 			copyParams := &ToolFunctionParameters{
 				Type:     original.Function.Parameters.Type,
 				keyOrder: original.Function.Parameters.keyOrder,
+				explicitEmptyObject: original.Function.Parameters.explicitEmptyObject,
 			}
 
 			if original.Function.Parameters.Description != nil {


### PR DESCRIPTION
## Summary

Preserves explicit empty object schemas (`{}`) in tool function parameters while maintaining proper JSON Schema normalization for populated schemas.

Fixes a bug where `"parameters": {}` was being incorrectly rewritten into an invalid OpenAI function schema shape (`{"type":"","properties":{}}`). Now preserves `{}` as-is while keeping populated schemas like `{"type":"object","properties":{}}` unchanged.

## Changes

- Added `explicitEmptyObject` field to `ToolFunctionParameters` to track when a client provides a raw `{}` schema
- Modified `MarshalJSON` to preserve empty objects as `{}` instead of expanding them to `{"type":"","properties":{}}`
- Added `hasDefinedSchemaFields()` method to distinguish between explicit empty objects and populated schemas
- Updated `DeepCopyChatTool` to preserve the `explicitEmptyObject` flag during copying
- Added comprehensive tests for both chat and responses API paths to verify empty parameter preservation

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that tool function parameters handle both empty and populated schemas correctly:

```bash
# Core/Transports
go test ./core/providers/openai/... -run TestToOpenAIChatRequest_PreservesExplicitEmptyToolParameters
go test ./core/providers/openai/... -run TestToOpenAIResponsesRequest_PreservesExplicitEmptyToolParameters
go test ./core/schemas/... -run TestToolFunctionParameters_ExplicitEmptyObjectPreserved

```

Test cases verify:

- Raw `{}` schemas remain as `{}`
- Populated schemas like `{"type":"object","properties":{}}` preserve their structure
- Normalization works correctly for both cases

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #2398

## Security considerations

No security implications — this change only affects JSON serialization behavior for tool schemas.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable