### PR TITLE
adds technical explnation of unsupported multinode setup for oss

### DIFF
--- a/docs/deployment-guides/how-to/multinode.mdx
+++ b/docs/deployment-guides/how-to/multinode.mdx
@@ -8,6 +8,19 @@ icon: "layer-group"
 
 Running multiple Bifrost nodes provides high availability, load distribution, and fault tolerance for your AI gateway. This guide covers the recommended approach for deploying multiple Bifrost nodes in OSS deployments.
 
+<Warning>
+  Running multiple OSS Bifrost nodes with a Postgres backend is not supported.
+  
+  Here is the short technical explanation:
+  
+  - Bifrost is designed to keep all critical information in memory, including provider configs, API keys, budgets, usage, and traffic distribution.
+  - Once a node is initialized, it does not read this information back from the database.
+  - In the Enterprise version, we use a slightly modified version of RAFT to synchronize this state in real time across nodes, while the database acts only as a dumb store.
+  - Based on our current view, OSS is sufficient for startups and medium-scale teams, and can easily handle around 3,000–5,000 RPS on a single instance.
+  - If you need high availability and enterprise capabilities such as real-time synchronization, the Enterprise plan is the right fit. 
+  - And yes, that is part of how we draw the OSS vs Enterprise line 💰.
+</Warning>
+
 ### OSS vs Enterprise
 
 | Aspect | OSS Approach | Enterprise Approach |


### PR DESCRIPTION
## Summary

Added a warning to the multinode deployment documentation clarifying that running multiple OSS Bifrost nodes with a Postgres backend is not supported, explaining the technical limitations and recommending the Enterprise plan for high availability scenarios.

## Changes

- Added a warning callout explaining why multiple OSS nodes with Postgres backend is unsupported
- Provided technical context about Bifrost's in-memory architecture and lack of real-time synchronization in OSS
- Clarified that OSS is designed for single-instance deployments handling 3,000-5,000 RPS
- Directed users requiring high availability to the Enterprise plan which includes RAFT-based synchronization

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the documentation renders correctly and the warning is prominently displayed:

```sh
# Navigate to docs directory and build/preview
cd docs
# Follow your documentation build process to verify rendering
```

## Screenshots/Recordings

N/A - Documentation change only

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - documentation clarification only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable