### PR TITLE
adds server bootstrap timer

### DIFF
--- a/transports/bifrost-http/main.go
+++ b/transports/bifrost-http/main.go
@@ -58,6 +58,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	_ "go.uber.org/automaxprocs" // Automatically set GOMAXPROCS based on container cgroup limits
 
@@ -145,11 +146,13 @@ func main() {
 	handlers.SetLogger(logger)
 
 	ctx := context.Background()
+	t := time.Now()
 	err := server.Bootstrap(ctx)
 	if err != nil {
 		logger.Error("failed to bootstrap server: %v", err)
 		os.Exit(1)
 	}
+	logger.Info("Time spent in Bifrost server bootstrap %d ms", time.Since(t).Milliseconds())
 	err = server.Start()
 	if err != nil {
 		logger.Error("failed to start server: %v", err)


### PR DESCRIPTION
## Summary

Adds bootstrap timing instrumentation to the Bifrost HTTP transport to measure and log the time spent during server initialization.

## Changes

- Added timing measurement around the `server.Bootstrap()` call
- Logs the bootstrap duration in milliseconds to help with performance monitoring and debugging startup times

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Start the Bifrost HTTP transport and verify the bootstrap timing log message appears:

```sh
go run transports/bifrost-http/main.go
```

Expected outcome: Log output should include a message like "Time spent in Bifrost server bootstrap X ms" where X is the measured duration.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only adds performance logging without exposing sensitive information.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable