### PR TITLE
docs: move migration guides from tab to group

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -100,6 +100,13 @@
             ]
           },
           {
+            "group": "Migration Guides",
+            "icon": "arrow-up-right-dots",
+            "pages": [
+              "migration-guides/v1.5.0"
+            ]
+          },
+          {
             "group": "SDK Integrations",
             "icon": "plug",
             "pages": [
@@ -467,13 +474,6 @@
           "benchmarking/t3.medium",
           "benchmarking/t3.xl",
           "benchmarking/run-your-own-benchmarks"
-        ]
-      },
-      {
-        "tab": "Migration Guides",
-        "icon": "arrow-up-right-dots",
-        "pages": [
-          "migration-guides/v1.5.0"
         ]
       },
       {


### PR DESCRIPTION
## Summary

Reorganized the documentation navigation structure by moving the Migration Guides section from a top-level tab to a group within the main navigation sidebar.

## Changes

- Moved Migration Guides from a standalone tab to a navigation group positioned between "API Reference" and "SDK Integrations"
- Retained the same icon (`arrow-up-right-dots`) and page structure for the Migration Guides section
- Simplified the overall documentation navigation by reducing the number of top-level tabs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the documentation site renders correctly with the new navigation structure:

1. Build and serve the documentation locally
2. Confirm Migration Guides appears as a group in the main sidebar
3. Verify the v1.5.0 migration guide is accessible under the new location
4. Check that the overall navigation flow feels intuitive

## Screenshots/Recordings

N/A - Navigation structure change only

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - documentation structure change only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable