### PR TITLE
lastdump usage lock

### DIFF
--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1939,6 +1939,15 @@ func (gs *LocalGovernanceStore) DumpBudgets(ctx context.Context, baselines map[s
 			}
 			return fmt.Errorf("failed to dump budgets to database: %w", err)
 		}
+
+		// After successful dump, update LastDBUsagesBudgets so this node's broadcast
+		// delta reflects "nothing uncommitted". This prevents double-counting if
+		// this node transitions from leader to non-leader.
+		gs.LastDBUsagesBudgetsMu.Lock()
+		for _, inMemoryBudget := range budgets {
+			gs.LastDBUsagesBudgets[inMemoryBudget.ID] = inMemoryBudget.CurrentUsage
+		}
+		gs.LastDBUsagesBudgetsMu.Unlock()
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Fixes a double-counting issue in governance budget tracking that occurs when a node transitions from leader to non-leader role by updating the LastDBUsagesBudgets after successfully dumping budgets to the database.

## Changes

- Added logic to update `LastDBUsagesBudgets` with current usage values after successful budget dump to database
- This ensures the node's broadcast delta reflects "nothing uncommitted" state, preventing double-counting during leader transitions
- Added proper mutex locking around the LastDBUsagesBudgets update operation

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the governance plugin's budget tracking behavior during leader transitions:

```sh
# Core/Transports
go version
go test ./...
```

Verify that budget usage is not double-counted when nodes transition between leader and non-leader states in a multi-node governance setup.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is an internal state management fix for budget tracking consistency.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable