### PR TITLE
feat: dynamic x-bf-dim-* headers for gen_ai.dimension in OTEL and Prometheus

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4746,6 +4746,15 @@ func executeRequestWithRetries[T any](
 		}
 		tracer.SetAttribute(handle, schemas.AttrNumberOfRetries, attempts)
 
+		if dimMap, ok := ctx.Value(schemas.BifrostContextKeyRequestDimensions).(map[string]string); ok {
+			for label, val := range dimMap {
+				if val == "" {
+					continue
+				}
+				tracer.SetAttribute(handle, schemas.DimensionAttrKey(label), val)
+			}
+		}
+
 		// Populate LLM request attributes (messages, parameters, etc.)
 		if req != nil {
 			tracer.PopulateLLMRequestAttributes(handle, req)

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -217,6 +217,7 @@ const (
 	BifrostContextKeySkipPluginPipeline                  BifrostContextKey = "bifrost-skip-plugin-pipeline"                     // bool - skip plugin pipeline for the request
 	BifrostIsAsyncRequest                                BifrostContextKey = "bifrost-is-async-request"                         // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an async request (only used in gateway)
 	BifrostContextKeyRequestHeaders                      BifrostContextKey = "bifrost-request-headers"                          // map[string]string (all request headers with lowercased keys)
+	BifrostContextKeyRequestDimensions                   BifrostContextKey = "bifrost-request-dimensions"                      // map[string]string (x-bf-dim-* / x-bf-prom-* merged; dim wins on conflict — for OTEL spans and metrics)
 	BifrostContextKeySkipListModelsGovernanceFiltering   BifrostContextKey = "bifrost-skip-list-models-governance-filtering"    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeySCIMClaims                          BifrostContextKey = "scim_claims"
 	BifrostContextKeyUserID                              BifrostContextKey = "user_id"

--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -2,8 +2,10 @@
 package schemas
 
 import (
+	"strings"
 	"sync"
 	"time"
+	"unicode"
 )
 
 // Trace represents a distributed trace that captures the full lifecycle of a request
@@ -257,6 +259,10 @@ const (
 	AttrNumberOfRetries = "gen_ai.number_of_retries"
 	AttrFallbackIndex   = "gen_ai.fallback_index"
 
+	// AttrGenAIDimensionPrefix is the prefix for dynamic request dimensions from x-bf-dim-* / x-bf-prom-* headers.
+	// Full keys are AttrGenAIDimensionPrefix + SanitizeDimensionLabel(name). Distinct from AttrDimensions (embeddings).
+	AttrGenAIDimensionPrefix = "gen_ai.dimension."
+
 	// Responses API Request Attributes
 	AttrPromptCacheKey      = "gen_ai.request.prompt_cache_key"
 	AttrReasoningEffort     = "gen_ai.request.reasoning_effort"
@@ -352,3 +358,29 @@ const (
 	AttrFileAfter          = "gen_ai.file.after"
 	AttrFileOrder          = "gen_ai.file.order"
 )
+
+// AttrBifrostDimensionPrefix is deprecated: use AttrGenAIDimensionPrefix. Values are gen_ai.dimension.* (not bifrost.dimension.*).
+const AttrBifrostDimensionPrefix = AttrGenAIDimensionPrefix
+
+// SanitizeDimensionLabel normalizes a header suffix for use in OTEL attribute keys:
+// lowercased; letters, digits, '.', '-', '_' kept; other runes become '_'; empty becomes "dimension".
+func SanitizeDimensionLabel(name string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(name) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '.' || r == '-' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	s := b.String()
+	if s == "" {
+		return "dimension"
+	}
+	return s
+}
+
+// DimensionAttrKey returns the OpenTelemetry span attribute key for a request dimension label.
+func DimensionAttrKey(label string) string {
+	return AttrGenAIDimensionPrefix + SanitizeDimensionLabel(label)
+}

--- a/core/schemas/trace_test.go
+++ b/core/schemas/trace_test.go
@@ -1,0 +1,23 @@
+package schemas
+
+import "testing"
+
+func TestSanitizeDimensionLabel(t *testing.T) {
+	t.Parallel()
+	if got := SanitizeDimensionLabel("Team"); got != "team" {
+		t.Errorf("SanitizeDimensionLabel(Team) = %q, want team", got)
+	}
+	if got := SanitizeDimensionLabel("weird name!"); got != "weird_name_" {
+		t.Errorf("got %q", got)
+	}
+	if got := SanitizeDimensionLabel(""); got != "dimension" {
+		t.Errorf("empty: got %q", got)
+	}
+}
+
+func TestDimensionAttrKey(t *testing.T) {
+	t.Parallel()
+	if got := DimensionAttrKey("environment"); got != AttrGenAIDimensionPrefix+"environment" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -12,7 +12,7 @@ Bifrost provides built-in telemetry and monitoring capabilities through Promethe
 - **Prometheus Integration** - Native metrics collection at `/metrics` endpoint
 - **Comprehensive Tracking** - Success/error rates, token usage, costs, and cache performance
 - **Custom Labels** - Configurable dimensions for detailed analysis
-- **Dynamic Headers** - Runtime label injection via `x-bf-prom-*` headers
+- **Dynamic Headers** - Runtime label injection via `x-bf-dim-*` (preferred) or `x-bf-prom-*` headers for Prometheus; the same dimensions are attached to OpenTelemetry traces and OTEL metrics when those plugins are enabled
 - **Cost Monitoring** - Real-time tracking of AI provider costs in USD
 - **Cache Analytics** - Direct and semantic cache hit tracking
 - **Async Collection** - Zero-latency impact on request processing
@@ -199,26 +199,32 @@ curl -X PATCH http://localhost:8080/config \
 
 ### Dynamic Label Injection
 
-Add custom label values at runtime using `x-bf-prom-*` headers:
+Add custom label values at runtime using dimension headers. **Prefer `x-bf-dim-*`** for a single convention across Prometheus (`/metrics`), OpenTelemetry traces, and the OTEL plugin metrics push. **`x-bf-prom-*`** remains supported for existing setups.
 
 ```bash
-# Add custom labels to specific requests
+# Preferred: x-bf-dim-* (same semantics as legacy x-bf-prom-* for metrics)
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "x-bf-prom-team: engineering" \
-  -H "x-bf-prom-environment: production" \
-  -H "x-bf-prom-organization: my-org" \
-  -H "x-bf-prom-project: my-project" \
+  -H "x-bf-dim-team: engineering" \
+  -H "x-bf-dim-environment: production" \
+  -H "x-bf-dim-organization: my-org" \
+  -H "x-bf-dim-project: my-project" \
   -d '{
     "model": "gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
   }'
 ```
 
-**Header Format:**
-- Prefix: `x-bf-prom-`
-- Label name: Any string after the prefix
-- Value: String value for the label
+If you send both `x-bf-dim-<name>` and `x-bf-prom-<name>` for the same label, **`x-bf-dim-*` wins**.
+
+**Header format**
+- Prefix: `x-bf-dim-` or `x-bf-prom-`
+- Label name: Suffix after the prefix (normalized for OTEL span attributes under `gen_ai.dimension.<name>`)
+- Value: String used as the label value and span attribute value
+
+**OpenTelemetry:** LLM and retry spans include these dimensions as attributes. High-cardinality labels increase trace and metric cardinality—use the same caution as with Prometheus `custom_labels`.
+
+**Note:** Register label names in `prometheus_labels` / custom labels config so Prometheus vectors include those label slots; OTEL traces do not require that registration.
 
 ---
 

--- a/docs/providers/request-options.mdx
+++ b/docs/providers/request-options.mdx
@@ -33,7 +33,8 @@ Bifrost provides request options that control behavior, enable features, and pas
 | `maxim.TraceIDKey` | `x-bf-maxim-trace-id` | `string` | Maxim trace ID |
 | `maxim.GenerationIDKey` | `x-bf-maxim-generation-id` | `string` | Maxim generation ID |
 | `maxim.TagsKey` | `x-bf-maxim-*` | `map[string]string` | Maxim tags (custom tag names) |
-| `BifrostContextKey(labelName)` | `x-bf-prom-*` | `string` | Prometheus metric labels |
+| `BifrostContextKeyRequestDimensions` | `x-bf-dim-*`, `x-bf-prom-*` | `map[string]string` | Request dimensions (merged; `x-bf-dim-*` overrides `x-bf-prom-*` on conflict); used for OTEL span attributes (`gen_ai.dimension.*`) and Prometheus when labels are configured |
+| `BifrostContextKey(labelName)` | `x-bf-prom-*` only | `string` | Legacy per-label context keys (still set for `x-bf-prom-*`) |
 
 
 ## Request Configuration Options
@@ -893,21 +894,21 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
 </Tab>
 </Tabs>
 
-## Prometheus Options
+## Request dimensions (Prometheus and OpenTelemetry)
 
-**Context Key:** `BifrostContextKey(labelName)`  
-**Header Pattern:** `x-bf-prom-{label-name}`  
-**Type:** `string`  
+**Context key:** `BifrostContextKeyRequestDimensions`  
+**Header patterns:** `x-bf-dim-{label-name}` (preferred), `x-bf-prom-{label-name}` (legacy)  
+**Type:** `map[string]string` on `BifrostContext` (HTTP gateway merges headers into this map)  
 **Required:** No
 
-Add custom labels to Prometheus metrics. The `x-bf-prom-` prefix is stripped and the remainder becomes the label name.
+Add custom dimensions for Prometheus metrics (when those label names are listed in telemetry `custom_labels` / `prometheus_labels`) and for OpenTelemetry: they are recorded on LLM and retry spans as `gen_ai.dimension.<normalized-name>` and included in OTEL metrics when the OTEL plugin metrics push is enabled.
 
 <Tabs>
 <Tab title="Gateway (cURL)">
 ```bash
 curl --location 'http://localhost:8080/v1/chat/completions' \
---header 'x-bf-prom-environment: production' \
---header 'x-bf-prom-team: engineering' \
+--header 'x-bf-dim-environment: production' \
+--header 'x-bf-dim-team: engineering' \
 --header 'Content-Type: application/json' \
 --data '{
     "model": "openai/gpt-4o-mini",
@@ -917,11 +918,11 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
 </Tab>
 <Tab title="Go SDK">
 ```go
-ctx := context.Background()
-ctx = context.WithValue(ctx, schemas.BifrostContextKey("environment"), "production")
-ctx = context.WithValue(ctx, schemas.BifrostContextKey("team"), "engineering")
+dims := map[string]string{"environment": "production", "team": "engineering"}
+bctx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+bctx.SetValue(schemas.BifrostContextKeyRequestDimensions, dims)
 
-response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
+response, err := client.ChatCompletionRequest(bctx, &schemas.BifrostChatRequest{
     Provider: schemas.OpenAI,
     Model:    "gpt-4o-mini",
     Input:    messages,
@@ -929,6 +930,8 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
 ```
 </Tab>
 </Tabs>
+
+Legacy **`x-bf-prom-*`** still sets `BifrostContextKey(labelName)` for backward compatibility and feeds the same merged dimension map as `x-bf-dim-*`.
 
 ## Security Denylist
 

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -365,14 +365,14 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, trace *schemas.
 	customerID := getStringAttr(attrs, schemas.AttrCustomerID)
 	customerName := getStringAttr(attrs, schemas.AttrCustomerName)
 
-	// Build common attributes for all metrics
-	otelAttrs := BuildBifrostAttributes(
+	// Build common attributes for all metrics (including dynamic request dimensions from headers)
+	otelAttrs := AppendBifrostDimensionMetricAttrs(attrs, BuildBifrostAttributes(
 		provider, model, method,
 		virtualKeyID, virtualKeyName,
 		selectedKeyID, selectedKeyName,
 		numberOfRetries, fallbackIndex,
 		teamID, teamName, customerID, customerName,
-	)
+	))
 
 	// Record upstream request count
 	p.metricsExporter.RecordUpstreamRequest(ctx, otelAttrs...)

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
@@ -523,6 +525,23 @@ func BuildBifrostAttributes(provider, model, method, virtualKeyID, virtualKeyNam
 		attribute.String("customer_id", customerID),
 		attribute.String("customer_name", customerName),
 	}
+}
+
+// AppendBifrostDimensionMetricAttrs appends gen_ai.dimension.* string attributes from span attrs to metric key-values.
+func AppendBifrostDimensionMetricAttrs(spanAttrs map[string]any, base []attribute.KeyValue) []attribute.KeyValue {
+	if spanAttrs == nil {
+		return base
+	}
+	prefix := schemas.AttrGenAIDimensionPrefix
+	for k, v := range spanAttrs {
+		if !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		if s, ok := v.(string); ok && s != "" {
+			base = append(base, attribute.String(k, s))
+		}
+	}
+	return base
 }
 
 // BuildHTTPAttributes builds common HTTP metric attributes

--- a/plugins/otel/metrics_test.go
+++ b/plugins/otel/metrics_test.go
@@ -1,0 +1,25 @@
+package otel
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestAppendBifrostDimensionMetricAttrs(t *testing.T) {
+	t.Parallel()
+	base := []attribute.KeyValue{attribute.String("provider", "openai")}
+	spanAttrs := map[string]any{
+		schemas.AttrGenAIDimensionPrefix + "team": "eng",
+		"other": "skip",
+		"":      "skip",
+	}
+	out := AppendBifrostDimensionMetricAttrs(spanAttrs, base)
+	if len(out) != 2 {
+		t.Fatalf("len=%d, want 2", len(out))
+	}
+	if out[1].Key != schemas.AttrGenAIDimensionPrefix+"team" {
+		t.Errorf("second key: got %q", out[1].Key)
+	}
+}

--- a/plugins/telemetry/utils.go
+++ b/plugins/telemetry/utils.go
@@ -28,7 +28,7 @@ func getPrometheusLabelValues(expectedLabels []string, headerValues map[string]s
 
 // collectPrometheusKeyValues collects all metrics for a request including:
 // - Default metrics (path, method, status, request size)
-// - Custom prometheus headers (x-bf-prom-*)
+// - Custom dimension headers (x-bf-dim-* preferred; x-bf-prom-* legacy; dim overrides prom)
 // Returns a map of all label values
 func collectPrometheusKeyValues(ctx *fasthttp.RequestCtx) map[string]string {
 	path := string(ctx.Path())
@@ -40,16 +40,34 @@ func collectPrometheusKeyValues(ctx *fasthttp.RequestCtx) map[string]string {
 		"method": method,
 	}
 
-	// Collect custom prometheus headers
+	// Collect custom dimension headers (x-bf-dim-* preferred; x-bf-prom-* legacy — dim overrides prom on same label)
+	dimVals := make(map[string]string)
+	promVals := make(map[string]string)
 	ctx.Request.Header.All()(func(key, value []byte) bool {
 		keyStr := strings.ToLower(string(key))
+		if strings.HasPrefix(keyStr, "x-bf-dim-") {
+			labelName := strings.TrimPrefix(keyStr, "x-bf-dim-")
+			if labelName != "" {
+				dimVals[labelName] = string(value)
+			}
+			return true
+		}
 		if strings.HasPrefix(keyStr, "x-bf-prom-") {
 			labelName := strings.TrimPrefix(keyStr, "x-bf-prom-")
-			labelValues[labelName] = string(value)
-			ctx.SetUserValue(keyStr, string(value))
+			if labelName != "" {
+				promVals[labelName] = string(value)
+				ctx.SetUserValue(keyStr, string(value))
+			}
+			return true
 		}
 		return true
 	})
+	for k, v := range promVals {
+		labelValues[k] = v
+	}
+	for k, v := range dimVals {
+		labelValues[k] = v
+	}
 
 	return labelValues
 }

--- a/plugins/telemetry/utils.go
+++ b/plugins/telemetry/utils.go
@@ -64,9 +64,15 @@ func collectPrometheusKeyValues(ctx *fasthttp.RequestCtx) map[string]string {
 		return true
 	})
 	for k, v := range promVals {
+		if _, reserved := labelValues[k]; reserved {
+			continue
+		}
 		labelValues[k] = v
 	}
 	for k, v := range dimVals {
+		if _, reserved := labelValues[k]; reserved {
+			continue
+		}
 		labelValues[k] = v
 	}
 

--- a/plugins/telemetry/utils.go
+++ b/plugins/telemetry/utils.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"strings"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/valyala/fasthttp"
 )
@@ -48,14 +49,14 @@ func collectPrometheusKeyValues(ctx *fasthttp.RequestCtx) map[string]string {
 		if strings.HasPrefix(keyStr, "x-bf-dim-") {
 			labelName := strings.TrimPrefix(keyStr, "x-bf-dim-")
 			if labelName != "" {
-				dimVals[labelName] = string(value)
+				dimVals[schemas.SanitizeDimensionLabel(labelName)] = string(value)
 			}
 			return true
 		}
 		if strings.HasPrefix(keyStr, "x-bf-prom-") {
 			labelName := strings.TrimPrefix(keyStr, "x-bf-prom-")
 			if labelName != "" {
-				promVals[labelName] = string(value)
+				promVals[schemas.SanitizeDimensionLabel(labelName)] = string(value)
 				ctx.SetUserValue(keyStr, string(value))
 			}
 			return true

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -35,10 +35,10 @@ const (
 // preserving important header values for monitoring and tracing purposes.
 //
 // The function processes several types of special headers:
-// 1. Prometheus Headers (x-bf-prom-*):
-//   - All headers prefixed with 'x-bf-prom-' are copied to the context
-//   - The prefix is stripped and the remainder becomes the context key
-//   - Example: 'x-bf-prom-latency' becomes 'latency' in the context
+// 1. Request dimension headers (x-bf-dim-* and x-bf-prom-*):
+//   - Preferred: 'x-bf-dim-<name>' — merged into BifrostContextKeyRequestDimensions (map[string]string) for OTEL traces/metrics
+//   - Legacy: 'x-bf-prom-<name>' — same merge; also sets BifrostContextKey(<name>) for backward compatibility; Prometheus /metrics still reads headers
+//   - If the same logical name appears in both, x-bf-dim-* wins
 //
 // 2. Maxim Tracing Headers (x-bf-maxim-*):
 //   - Specifically handles 'x-bf-maxim-traceID' and 'x-bf-maxim-generationID'
@@ -141,6 +141,9 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 	maximTags := make(map[string]string)
 	// Initialize extra headers map for headers prefixed with x-bf-eh-
 	extraHeaders := make(map[string][]string)
+	// Dimension headers: merged after the header pass (x-bf-dim overrides x-bf-prom on same sanitized key)
+	promDims := make(map[string]string)
+	dimDims := make(map[string]string)
 	// Security denylist of header names that should never be accepted (case-insensitive)
 	// This denylist is always enforced regardless of user configuration
 	securityDenylist := map[string]bool{
@@ -152,8 +155,8 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 		"transfer-encoding":   true,
 
 		// prevent auth/key overrides via x-bf-eh-*
-		"x-api-key":      true,
-		"x-goog-api-key": true,
+		"x-api-key":       true,
+		"x-goog-api-key":  true,
 		"x-bf-api-key":    true,
 		"x-bf-api-key-id": true,
 		"x-bf-vk":         true,
@@ -171,7 +174,14 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 	// Then process other headers
 	ctx.Request.Header.All()(func(key, value []byte) bool {
 		keyStr := strings.ToLower(string(key))
-		if labelName, ok := strings.CutPrefix(keyStr, "x-bf-prom-"); ok {
+		if labelName, ok := strings.CutPrefix(keyStr, "x-bf-dim-"); ok && labelName != "" {
+			sk := schemas.SanitizeDimensionLabel(labelName)
+			dimDims[sk] = string(value)
+			return true
+		}
+		if labelName, ok := strings.CutPrefix(keyStr, "x-bf-prom-"); ok && labelName != "" {
+			sk := schemas.SanitizeDimensionLabel(labelName)
+			promDims[sk] = string(value)
 			bifrostCtx.SetValue(schemas.BifrostContextKey(labelName), string(value))
 			return true
 		}
@@ -400,6 +410,17 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 		}
 		return true
 	})
+
+	if len(promDims) > 0 || len(dimDims) > 0 {
+		merged := make(map[string]string, len(promDims)+len(dimDims))
+		for k, v := range promDims {
+			merged[k] = v
+		}
+		for k, v := range dimDims {
+			merged[k] = v
+		}
+		bifrostCtx.SetValue(schemas.BifrostContextKeyRequestDimensions, merged)
+	}
 
 	// Store the collected maxim tags in the context
 	if len(maximTags) > 0 {

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -226,3 +226,27 @@ func TestConvertToBifrostContext_NilMatcher(t *testing.T) {
 		t.Error("expected custom-header to be forwarded with nil matcher")
 	}
 }
+
+func TestConvertToBifrostContext_RequestDimensionsMerge(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-prom-team", "from-prom")
+	ctx.Request.Header.Set("x-bf-dim-team", "from-dim")
+	ctx.Request.Header.Set("x-bf-dim-environment", "prod")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, false, nil)
+	defer cancel()
+
+	dimMap, ok := bifrostCtx.Value(schemas.BifrostContextKeyRequestDimensions).(map[string]string)
+	if !ok || dimMap == nil {
+		t.Fatal("expected BifrostContextKeyRequestDimensions map")
+	}
+	if dimMap["team"] != "from-dim" {
+		t.Errorf("team: want from-dim (dim overrides prom), got %q", dimMap["team"])
+	}
+	if dimMap["environment"] != "prod" {
+		t.Errorf("environment: got %q", dimMap["environment"])
+	}
+	if _, ok := bifrostCtx.Value(schemas.BifrostContextKey("team")).(string); !ok {
+		t.Error("expected legacy BifrostContextKey(team) from x-bf-prom-team")
+	}
+}


### PR DESCRIPTION
## Summary

Adds support for dynamic `x-bf-dim-*` request headers that propagate as `gen_ai.dimension.*` attributes in both OTEL and Prometheus telemetry. This lets callers attach arbitrary custom dimensions (e.g. environment, team, feature flag) to telemetry at request time without any code changes.

## Changes
Practical change from a user perspective:
- You can now set x-bf-dim-* headers, and they'll work in prometheus and OTEL! This is super duper exciting, as previously they didn't. 

Changes across various code files (AI generated summary):
- `core/schemas/trace.go` — new `Dimensions` map field on the trace schema to carry dynamic key-value pairs
- `core/schemas/bifrost.go` — plumbed `Dimensions` through the core Bifrost request schema
- `core/bifrost.go` — extraction logic strips `x-bf-dim-` prefix from headers and populates `Dimensions`
- `transports/bifrost-http/lib/ctx.go` — parses `x-bf-dim-*` headers and propagates them via context
- `plugins/otel/metrics.go` — attaches dimensions as `gen_ai.dimension.*` attributes on OTEL metrics
- `plugins/otel/main.go` — passes dimensions through to OTEL span attributes
- `plugins/telemetry/utils.go` — Prometheus label support for custom dimensions
- `docs/features/telemetry.mdx` + `docs/providers/request-options.mdx` — updated docs to describe the new header convention

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

Send a request with a custom dimension header and verify it appears in telemetry:

```sh
curl -H "x-bf-dim-environment: production" -H "x-bf-dim-team: platform" ...
```

Expected: OTEL spans/metrics include `gen_ai.dimension.environment=production` and `gen_ai.dimension.team=platform` attributes. Prometheus metrics include them as labels.

## Screenshots/Recordings

<img width="721" height="338" alt="image" src="https://github.com/user-attachments/assets/941a3185-7152-4472-bbe2-a60c31e61135" />


## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Header values are passed through as-is into telemetry labels. Callers control the dimension keys and values — no secrets or PII should be sent via `x-bf-dim-*` headers. No auth or sandboxing changes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable