### PR TITLE
[fix]: bedrock streaming - retry retryable AWS exceptions (serviceUnavailableException, throttlingException, etc.)

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
 - feat: add Fireworks AI as a first-class provider [@ivanetchart](https://github.com/ivanetchart)
+[fix]: bedrock streaming - retry retryable AWS exceptions (503/429/500) by classifying them as IsBifrostError:false [@KTS-o7](https://github.com/KTS-o7)
 - fix: bedrock streaming - retry stale/closed connections by classifying transport errors as IsBifrostError:false [@KTS-o7](https://github.com/KTS-o7)
 - fix: case-insensitive `anthropic-beta` merge in `MergeBetaHeaders`

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -174,6 +174,17 @@ func isStreamTransportError(err error) bool {
 	return errors.As(err, &opErr) || errors.As(err, &dnsErr)
 }
 
+// retryableBedrockExceptions maps AWS Bedrock EventStream exception types to
+// their HTTP status code equivalents. These exceptions are transient and should
+// be retried — the retry gate in executeRequestWithRetries checks StatusCode
+// against retryableStatusCodes (429, 500, 502, 503, 504).
+var retryableBedrockExceptions = map[string]int{
+	"throttlingException":         429,
+	"serviceUnavailableException": 503,
+	"modelNotReadyException":      503,
+	"internalServerException":     500,
+}
+
 // completeRequest sends a request to Bedrock's API and handles the response.
 // It constructs the API URL, sets up AWS authentication, and processes the response.
 // Returns the response body, request latency, or an error if the request fails.
@@ -1015,8 +1026,27 @@ func (provider *BedrockProvider) TextCompletionStream(ctx *schemas.BifrostContex
 						if err := sonic.Unmarshal(message.Payload, &bedrockErr); err == nil && bedrockErr.Message != "" {
 							errMsg = bedrockErr.Message
 						}
-						err := fmt.Errorf("%s stream %s: %s", providerName, excType, errMsg)
-						providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, schemas.TextCompletionStreamRequest, providerName, request.Model, provider.logger)
+						// Retryable AWS exceptions must not set IsBifrostError:true — that would
+						// bypass the retry gate in executeRequestWithRetries. Instead emit
+						// IsBifrostError:false with the equivalent HTTP status code so the existing
+						// retryableStatusCodes gate handles the retry.
+						if statusCode, ok := retryableBedrockExceptions[excType]; ok {
+							providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &schemas.BifrostError{
+								IsBifrostError: false,
+								StatusCode:     &statusCode,
+								Error: &schemas.ErrorField{
+									Message: fmt.Sprintf("%s stream %s: %s", providerName, excType, errMsg),
+								},
+								ExtraFields: schemas.BifrostErrorExtraFields{
+									RequestType:    schemas.TextCompletionStreamRequest,
+									Provider:       providerName,
+									ModelRequested: request.Model,
+								},
+							}, responseChan, provider.logger)
+						} else {
+							err := fmt.Errorf("%s stream %s: %s", providerName, excType, errMsg)
+							providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, schemas.TextCompletionStreamRequest, providerName, request.Model, provider.logger)
+						}
 						return
 					}
 				}
@@ -1268,7 +1298,26 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 						}
 						errMsg := string(message.Payload)
 						err := fmt.Errorf("%s stream %s: %s", providerName, excType, errMsg)
-						providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, schemas.ChatCompletionStreamRequest, providerName, request.Model, provider.logger)
+						// Retryable AWS exceptions must not set IsBifrostError:true — that would
+						// bypass the retry gate in executeRequestWithRetries. Instead emit
+						// IsBifrostError:false with the equivalent HTTP status code so the existing
+						// retryableStatusCodes gate handles the retry.
+						if statusCode, ok := retryableBedrockExceptions[excType]; ok {
+							providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &schemas.BifrostError{
+								IsBifrostError: false,
+								StatusCode:     &statusCode,
+								Error: &schemas.ErrorField{
+									Message: err.Error(),
+								},
+								ExtraFields: schemas.BifrostErrorExtraFields{
+									RequestType:    schemas.ChatCompletionStreamRequest,
+									Provider:       providerName,
+									ModelRequested: request.Model,
+								},
+							}, responseChan, provider.logger)
+						} else {
+							providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, schemas.ChatCompletionStreamRequest, providerName, request.Model, provider.logger)
+						}
 						return
 					}
 				}
@@ -1664,7 +1713,26 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 						}
 						errMsg := string(message.Payload)
 						err := fmt.Errorf("%s stream %s: %s", providerName, excType, errMsg)
-						providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, schemas.ResponsesStreamRequest, providerName, request.Model, provider.logger)
+						// Retryable AWS exceptions must not set IsBifrostError:true — that would
+						// bypass the retry gate in executeRequestWithRetries. Instead emit
+						// IsBifrostError:false with the equivalent HTTP status code so the existing
+						// retryableStatusCodes gate handles the retry.
+						if statusCode, ok := retryableBedrockExceptions[excType]; ok {
+							providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &schemas.BifrostError{
+								IsBifrostError: false,
+								StatusCode:     &statusCode,
+								Error: &schemas.ErrorField{
+									Message: err.Error(),
+								},
+								ExtraFields: schemas.BifrostErrorExtraFields{
+									RequestType:    schemas.ResponsesStreamRequest,
+									Provider:       providerName,
+									ModelRequested: request.Model,
+								},
+							}, responseChan, provider.logger)
+						} else {
+							providerUtils.ProcessAndSendError(ctx, postHookRunner, err, responseChan, schemas.ResponsesStreamRequest, providerName, request.Model, provider.logger)
+						}
 						return
 					}
 				}

--- a/core/providers/bedrock/transport_test.go
+++ b/core/providers/bedrock/transport_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"io"
 	"math/big"
@@ -278,13 +279,14 @@ func TestChatCompletionStream_NetOpError_ChunkIsRetryable(t *testing.T) {
 func writeEventStreamException(t *testing.T, w io.Writer, excType, msg string) {
 	t.Helper()
 	enc := eventstream.NewEncoder()
-	payload := []byte(`{"message":"` + msg + `"}`)
+	payload, err := json.Marshal(map[string]string{"message": msg})
+	require.NoError(t, err, "failed to marshal exception payload")
 	headers := eventstream.Headers{
 		{Name: ":message-type", Value: eventstream.StringValue("exception")},
 		{Name: ":exception-type", Value: eventstream.StringValue(excType)},
 		{Name: ":content-type", Value: eventstream.StringValue("application/json")},
 	}
-	err := enc.Encode(w, eventstream.Message{Headers: headers, Payload: payload})
+	err = enc.Encode(w, eventstream.Message{Headers: headers, Payload: payload})
 	require.NoError(t, err, "failed to encode EventStream exception frame")
 }
 
@@ -396,6 +398,134 @@ func TestChatCompletionStream_NonRetryableException_IsTerminal(t *testing.T) {
 	require.NotNil(t, errChunk, "expected error chunk for validationException")
 	assert.True(t, errChunk.BifrostError.IsBifrostError,
 		"non-retryable validationException must remain IsBifrostError:true")
+}
+
+// testTextCompletionRequest returns a minimal BifrostTextCompletionRequest for streaming tests.
+func testTextCompletionRequest() *schemas.BifrostTextCompletionRequest {
+	prompt := "hello"
+	return &schemas.BifrostTextCompletionRequest{
+		Model: "anthropic.claude-sonnet-4-5",
+		Input: &schemas.TextCompletionInput{PromptStr: &prompt},
+	}
+}
+
+// testResponsesRequest returns a minimal BifrostResponsesRequest for streaming tests.
+func testResponsesRequest() *schemas.BifrostResponsesRequest {
+	msgType := schemas.ResponsesMessageType("message")
+	roleUser := schemas.ResponsesMessageRoleType("user")
+	content := "hello"
+	return &schemas.BifrostResponsesRequest{
+		Model: "anthropic.claude-sonnet-4-5",
+		Input: []schemas.ResponsesMessage{
+			{
+				Type:    &msgType,
+				Role:    &roleUser,
+				Content: &schemas.ResponsesMessageContent{ContentStr: &content},
+			},
+		},
+	}
+}
+
+// assertRetryableExceptionChunk is the shared assertion helper for all three
+// streaming-method retryable-exception tests.
+func assertRetryableExceptionChunk(t *testing.T, streamChan chan *schemas.BifrostStreamChunk, bifrostErr *schemas.BifrostError, excType string, expectedStatus int) {
+	t.Helper()
+	if bifrostErr != nil {
+		assert.False(t, bifrostErr.IsBifrostError, "pre-stream error must be IsBifrostError:false")
+		return
+	}
+	require.NotNil(t, streamChan)
+
+	var errChunk *schemas.BifrostStreamChunk
+	for chunk := range streamChan {
+		if chunk != nil && chunk.BifrostError != nil {
+			errChunk = chunk
+			break
+		}
+	}
+	for range streamChan {
+	}
+
+	require.NotNil(t, errChunk, "expected error chunk for %s", excType)
+	assert.False(t, errChunk.BifrostError.IsBifrostError,
+		"%s must be IsBifrostError:false so retry gate can retry it", excType)
+	require.NotNil(t, errChunk.BifrostError.StatusCode,
+		"%s must carry a StatusCode for the retryableStatusCodes gate", excType)
+	assert.Equal(t, expectedStatus, *errChunk.BifrostError.StatusCode,
+		"%s must map to HTTP %d", excType, expectedStatus)
+}
+
+// TestTextCompletionStream_RetryableException_ChunkIsRetryable mirrors the
+// ChatCompletionStream test for the TextCompletionStream path, which has
+// slightly different payload-parsing logic (extra BedrockError JSON unmarshal).
+func TestTextCompletionStream_RetryableException_ChunkIsRetryable(t *testing.T) {
+	tests := []struct {
+		excType        string
+		expectedStatus int
+	}{
+		{"serviceUnavailableException", 503},
+		{"throttlingException", 429},
+		{"modelNotReadyException", 503},
+		{"internalServerException", 500},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.excType, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
+				w.WriteHeader(http.StatusOK)
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+				writeEventStreamException(t, w, tc.excType, "service is unavailable, please retry")
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+			}))
+			defer ts.Close()
+
+			provider := newTestProviderWithServer(t, ts)
+			streamChan, bifrostErr := provider.TextCompletionStream(testBedrockCtx(), noopPostHookRunner, testBedrockKey(), testTextCompletionRequest())
+			assertRetryableExceptionChunk(t, streamChan, bifrostErr, tc.excType, tc.expectedStatus)
+		})
+	}
+}
+
+// TestResponsesStream_RetryableException_ChunkIsRetryable mirrors the
+// ChatCompletionStream test for the ResponsesStream path.
+func TestResponsesStream_RetryableException_ChunkIsRetryable(t *testing.T) {
+	tests := []struct {
+		excType        string
+		expectedStatus int
+	}{
+		{"serviceUnavailableException", 503},
+		{"throttlingException", 429},
+		{"modelNotReadyException", 503},
+		{"internalServerException", 500},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.excType, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
+				w.WriteHeader(http.StatusOK)
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+				writeEventStreamException(t, w, tc.excType, "service is unavailable, please retry")
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+			}))
+			defer ts.Close()
+
+			provider := newTestProviderWithServer(t, ts)
+			streamChan, bifrostErr := provider.ResponsesStream(testBedrockCtx(), noopPostHookRunner, testBedrockKey(), testResponsesRequest())
+			assertRetryableExceptionChunk(t, streamChan, bifrostErr, tc.excType, tc.expectedStatus)
+		})
+	}
 }
 
 func generateTestCACert(t *testing.T) string {

--- a/core/providers/bedrock/transport_test.go
+++ b/core/providers/bedrock/transport_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"io"
 	"math/big"
 	"net"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -267,6 +269,133 @@ func TestChatCompletionStream_NetOpError_ChunkIsRetryable(t *testing.T) {
 	require.NotNil(t, errChunk.BifrostError.Error)
 	assert.Equal(t, schemas.ErrProviderNetworkError, errChunk.BifrostError.Error.Message,
 		"net.OpError during EventStream decoding must use ErrProviderNetworkError message")
+}
+
+// writeEventStreamException encodes a well-formed AWS EventStream exception
+// frame with the given exception type and message into w.
+// The frame format is: prelude (total_len + headers_len + CRC) + headers + payload + message_CRC.
+// We use the AWS SDK's eventstream.Encoder so the binary framing is correct.
+func writeEventStreamException(t *testing.T, w io.Writer, excType, msg string) {
+	t.Helper()
+	enc := eventstream.NewEncoder()
+	payload := []byte(`{"message":"` + msg + `"}`)
+	headers := eventstream.Headers{
+		{Name: ":message-type", Value: eventstream.StringValue("exception")},
+		{Name: ":exception-type", Value: eventstream.StringValue(excType)},
+		{Name: ":content-type", Value: eventstream.StringValue("application/json")},
+	}
+	err := enc.Encode(w, eventstream.Message{Headers: headers, Payload: payload})
+	require.NoError(t, err, "failed to encode EventStream exception frame")
+}
+
+// TestChatCompletionStream_RetryableException_ChunkIsRetryable verifies that
+// when AWS Bedrock sends a retryable exception (serviceUnavailableException,
+// throttlingException, etc.) through the EventStream, the resulting error chunk
+// has IsBifrostError:false and the correct HTTP StatusCode so that the retry
+// gate in executeRequestWithRetries can retry the request.
+func TestChatCompletionStream_RetryableException_ChunkIsRetryable(t *testing.T) {
+	tests := []struct {
+		excType        string
+		expectedStatus int
+	}{
+		{"serviceUnavailableException", 503},
+		{"throttlingException", 429},
+		{"modelNotReadyException", 503},
+		{"internalServerException", 500},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.excType, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
+				w.WriteHeader(http.StatusOK)
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+				writeEventStreamException(t, w, tc.excType, "service is unavailable, please retry")
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
+			}))
+			defer ts.Close()
+
+			provider := newTestProviderWithServer(t, ts)
+			ctx := testBedrockCtx()
+			key := testBedrockKey()
+
+			streamChan, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHookRunner, key, testChatRequest())
+			if bifrostErr != nil {
+				assert.False(t, bifrostErr.IsBifrostError,
+					"pre-stream error must be IsBifrostError:false")
+				return
+			}
+
+			require.NotNil(t, streamChan)
+
+			var errChunk *schemas.BifrostStreamChunk
+			for chunk := range streamChan {
+				if chunk != nil && chunk.BifrostError != nil {
+					errChunk = chunk
+					break
+				}
+			}
+			for range streamChan {
+			}
+
+			require.NotNil(t, errChunk, "expected error chunk for %s", tc.excType)
+			assert.False(t, errChunk.BifrostError.IsBifrostError,
+				"%s must be IsBifrostError:false so retry gate can retry it", tc.excType)
+			require.NotNil(t, errChunk.BifrostError.StatusCode,
+				"%s must carry a StatusCode for the retryableStatusCodes gate", tc.excType)
+			assert.Equal(t, tc.expectedStatus, *errChunk.BifrostError.StatusCode,
+				"%s must map to HTTP %d", tc.excType, tc.expectedStatus)
+		})
+	}
+}
+
+// TestChatCompletionStream_NonRetryableException_IsTerminal verifies that
+// non-retryable exception types (e.g. validationException, accessDeniedException)
+// continue to use ProcessAndSendError (IsBifrostError:true) and are NOT retried.
+func TestChatCompletionStream_NonRetryableException_IsTerminal(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.amazon.eventstream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		writeEventStreamException(t, w, "validationException", "input validation failed")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer ts.Close()
+
+	provider := newTestProviderWithServer(t, ts)
+	ctx := testBedrockCtx()
+	key := testBedrockKey()
+
+	streamChan, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHookRunner, key, testChatRequest())
+	if bifrostErr != nil {
+		// If error surfaces synchronously it's already a terminal error — fine.
+		return
+	}
+
+	require.NotNil(t, streamChan)
+
+	var errChunk *schemas.BifrostStreamChunk
+	for chunk := range streamChan {
+		if chunk != nil && chunk.BifrostError != nil {
+			errChunk = chunk
+			break
+		}
+	}
+	for range streamChan {
+	}
+
+	require.NotNil(t, errChunk, "expected error chunk for validationException")
+	assert.True(t, errChunk.BifrostError.IsBifrostError,
+		"non-retryable validationException must remain IsBifrostError:true")
 }
 
 func generateTestCACert(t *testing.T) string {

--- a/core/providers/bedrock/transport_test.go
+++ b/core/providers/bedrock/transport_test.go
@@ -327,11 +327,7 @@ func TestChatCompletionStream_RetryableException_ChunkIsRetryable(t *testing.T) 
 			key := testBedrockKey()
 
 			streamChan, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHookRunner, key, testChatRequest())
-			if bifrostErr != nil {
-				assert.False(t, bifrostErr.IsBifrostError,
-					"pre-stream error must be IsBifrostError:false")
-				return
-			}
+			require.Nil(t, bifrostErr, "expected EventStream exception to surface as a stream chunk")
 
 			require.NotNil(t, streamChan)
 
@@ -378,10 +374,7 @@ func TestChatCompletionStream_NonRetryableException_IsTerminal(t *testing.T) {
 	key := testBedrockKey()
 
 	streamChan, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHookRunner, key, testChatRequest())
-	if bifrostErr != nil {
-		// If error surfaces synchronously it's already a terminal error — fine.
-		return
-	}
+	require.Nil(t, bifrostErr, "expected EventStream exception to surface as a stream chunk")
 
 	require.NotNil(t, streamChan)
 
@@ -430,10 +423,7 @@ func testResponsesRequest() *schemas.BifrostResponsesRequest {
 // streaming-method retryable-exception tests.
 func assertRetryableExceptionChunk(t *testing.T, streamChan chan *schemas.BifrostStreamChunk, bifrostErr *schemas.BifrostError, excType string, expectedStatus int) {
 	t.Helper()
-	if bifrostErr != nil {
-		assert.False(t, bifrostErr.IsBifrostError, "pre-stream error must be IsBifrostError:false")
-		return
-	}
+	require.Nil(t, bifrostErr, "expected EventStream exception to surface as a stream chunk, not a pre-stream error")
 	require.NotNil(t, streamChan)
 
 	var errChunk *schemas.BifrostStreamChunk


### PR DESCRIPTION
## Summary

Fixes retryable AWS Bedrock EventStream exceptions (`serviceUnavailableException`, `throttlingException`, `modelNotReadyException`, `internalServerException`) being treated as terminal errors despite `max_retries` configuration.

Same root cause as #2424 / #2427 — these exceptions were routed through `ProcessAndSendError()` which unconditionally sets `IsBifrostError:true`, causing the retry gate in `executeRequestWithRetries` to break immediately.

## Changes

- **`core/providers/bedrock/bedrock.go`**
  - Add `retryableBedrockExceptions` map: exception type → equivalent HTTP status code (`throttlingException→429`, `serviceUnavailableException/modelNotReadyException→503`, `internalServerException→500`)
  - `ChatCompletionStream`, `TextCompletionStream`, `ResponsesStream`: check `excType` against the map at the EventStream exception handler; if retryable, emit `BifrostError{IsBifrostError:false, StatusCode:<http_code>}` so the existing `retryableStatusCodes` gate in `bifrost.go` handles retry; non-retryable exceptions (`validationException`, `accessDeniedException`, etc.) continue through `ProcessAndSendError` unchanged

- **`core/providers/bedrock/transport_test.go`**
  - `TestChatCompletionStream_RetryableException_ChunkIsRetryable` — table test over all 4 retryable exception types using real EventStream binary frames (encoded via `aws-sdk-go-v2/aws/protocol/eventstream`); asserts `IsBifrostError:false` and correct `StatusCode`
  - `TestChatCompletionStream_NonRetryableException_IsTerminal` — verifies `validationException` remains `IsBifrostError:true` (terminal, no retry)

- **`core/changelog.md`**: entry added

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
cd core
go test ./providers/bedrock/... -run "TestChatCompletionStream_RetryableException|TestChatCompletionStream_NonRetryable" -v
```

## Breaking changes

- [x] No

## Related issues

Closes #2480

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)