### PR TITLE
fix: config schema for bedrock key config closes #2484

### DIFF
--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2376,12 +2376,54 @@
               "type": "string",
               "description": "AWS ARN"
             },
+            "role_arn": {
+              "type": "string",
+              "description": "AWS IAM role ARN for AssumeRole (can use env. prefix)"
+            },
+            "external_id": {
+              "type": "string",
+              "description": "External ID for AssumeRole (can use env. prefix)"
+            },
+            "session_name": {
+              "type": "string",
+              "description": "Role session name for AssumeRole (can use env. prefix)"
+            },
             "deployments": {
               "type": "object",
               "additionalProperties": {
                 "type": "string"
               },
               "description": "Model to deployment mappings"
+            },
+            "batch_s3_config": {
+              "type": "object",
+              "description": "S3 bucket configuration for Bedrock batch operations",
+              "properties": {
+                "buckets": {
+                  "type": "array",
+                  "description": "List of S3 bucket configurations",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "bucket_name": {
+                        "type": "string",
+                        "description": "S3 bucket name"
+                      },
+                      "prefix": {
+                        "type": "string",
+                        "description": "S3 key prefix for batch files"
+                      },
+                      "is_default": {
+                        "type": "boolean",
+                        "description": "Whether this is the default bucket for batch operations"
+                      }
+                    },
+                    "required": ["bucket_name"],
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
             }
           },
           "required": [
@@ -2887,12 +2929,44 @@
                     "type": "string",
                     "description": "AWS ARN"
                   },
+                  "role_arn": {
+                    "type": "string",
+                    "description": "AWS IAM role ARN for AssumeRole (can use env. prefix)"
+                  },
+                  "external_id": {
+                    "type": "string",
+                    "description": "External ID for AssumeRole (can use env. prefix)"
+                  },
+                  "session_name": {
+                    "type": "string",
+                    "description": "Role session name for AssumeRole (can use env. prefix)"
+                  },
                   "deployments": {
                     "type": "object",
                     "additionalProperties": {
                       "type": "string"
                     },
                     "description": "Model to deployment mappings"
+                  },
+                  "batch_s3_config": {
+                    "type": "object",
+                    "description": "S3 bucket configuration for Bedrock batch operations",
+                    "properties": {
+                      "buckets": {
+                        "type": "array",
+                        "description": "List of S3 bucket configurations",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "bucket_name": { "type": "string", "description": "S3 bucket name" },
+                            "prefix": { "type": "string", "description": "S3 key prefix for batch files" },
+                            "is_default": { "type": "boolean", "description": "Whether this is the default bucket for batch operations" }
+                          },
+                          "required": ["bucket_name"],
+                          "additionalProperties": false
+                        }
+                      }
+                    }
                   }
                 },
                 "additionalProperties": false

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1685,12 +1685,54 @@
                     "type": "string",
                     "description": "AWS ARN"
                   },
+                  "role_arn": {
+                    "type": "string",
+                    "description": "AWS IAM role ARN for AssumeRole (can use env. prefix)"
+                  },
+                  "external_id": {
+                    "type": "string",
+                    "description": "External ID for AssumeRole (can use env. prefix)"
+                  },
+                  "session_name": {
+                    "type": "string",
+                    "description": "Role session name for AssumeRole (can use env. prefix)"
+                  },
                   "deployments": {
                     "type": "object",
                     "additionalProperties": {
                       "type": "string"
                     },
                     "description": "Model to deployment mappings"
+                  },
+                  "batch_s3_config": {
+                    "type": "object",
+                    "description": "S3 bucket configuration for Bedrock batch operations",
+                    "properties": {
+                      "buckets": {
+                        "type": "array",
+                        "description": "List of S3 bucket configurations",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "bucket_name": {
+                              "type": "string",
+                              "description": "S3 bucket name"
+                            },
+                            "prefix": {
+                              "type": "string",
+                              "description": "S3 key prefix for batch files"
+                            },
+                            "is_default": {
+                              "type": "boolean",
+                              "description": "Whether this is the default bucket for batch operations"
+                            }
+                          },
+                          "required": ["bucket_name"],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
                   }
                 },
                 "additionalProperties": false
@@ -2148,6 +2190,26 @@
                   "type": "string",
                   "description": "AWS session token (can use env. prefix)"
                 },
+                "region": {
+                  "type": "string",
+                  "description": "AWS region"
+                },
+                "arn": {
+                  "type": "string",
+                  "description": "AWS ARN"
+                },
+                "role_arn": {
+                  "type": "string",
+                  "description": "AWS IAM role ARN for AssumeRole (can use env. prefix)"
+                },
+                "external_id": {
+                  "type": "string",
+                  "description": "External ID for AssumeRole (can use env. prefix)"
+                },
+                "session_name": {
+                  "type": "string",
+                  "description": "Role session name for AssumeRole (can use env. prefix)"
+                },
                 "deployments": {
                   "type": "object",
                   "additionalProperties": {
@@ -2155,13 +2217,35 @@
                   },
                   "description": "Model to deployment mappings"
                 },
-                "arn": {
-                  "type": "string",
-                  "description": "AWS ARN"
-                },
-                "region": {
-                  "type": "string",
-                  "description": "AWS region"
+                "batch_s3_config": {
+                  "type": "object",
+                  "description": "S3 bucket configuration for Bedrock batch operations",
+                  "properties": {
+                    "buckets": {
+                      "type": "array",
+                      "description": "List of S3 bucket configurations",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "bucket_name": {
+                            "type": "string",
+                            "description": "S3 bucket name"
+                          },
+                          "prefix": {
+                            "type": "string",
+                            "description": "S3 key prefix for batch files"
+                          },
+                          "is_default": {
+                            "type": "boolean",
+                            "description": "Whether this is the default bucket for batch operations"
+                          }
+                        },
+                        "required": ["bucket_name"],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "required": [

--- a/transports/schema_test/config_schema_test.go
+++ b/transports/schema_test/config_schema_test.go
@@ -564,3 +564,103 @@ func TestSchemaAllowedOriginsWildcard(t *testing.T) {
 		}
 	})
 }
+
+func TestSchemaBedrockKeyConfigSTSFields(t *testing.T) {
+	schema := loadSchema(t)
+
+	stsFields := []string{"role_arn", "external_id", "session_name"}
+	for _, field := range stsFields {
+		t.Run("$defs/bedrock_key has "+field, func(t *testing.T) {
+			_, found := navigateJSON(schema, "$defs", "bedrock_key", "allOf", 1, "properties", "bedrock_key_config", "properties", field)
+			if !found {
+				t.Errorf("$defs/bedrock_key bedrock_key_config is missing '%s' — BedrockKeyConfig Go struct defines this field for STS AssumeRole", field)
+			}
+		})
+	}
+
+	t.Run("$defs/bedrock_key has batch_s3_config", func(t *testing.T) {
+		_, found := navigateJSON(schema, "$defs", "bedrock_key", "allOf", 1, "properties", "bedrock_key_config", "properties", "batch_s3_config")
+		if !found {
+			t.Error("$defs/bedrock_key bedrock_key_config is missing 'batch_s3_config' — BedrockKeyConfig Go struct defines this field for batch operations")
+		}
+	})
+
+	t.Run("bedrock config with STS fields validates successfully", func(t *testing.T) {
+		compiled := compileSchema(t)
+		config := `{
+			"providers": {
+				"bedrock": {
+					"keys": [
+						{
+							"name": "cross-account",
+							"weight": 1,
+							"models": ["us.anthropic.claude-sonnet-4-20250514-v1:0"],
+							"bedrock_key_config": {
+								"region": "us-west-2",
+								"role_arn": "arn:aws:iam::123456789012:role/BedrockAccessRole",
+								"session_name": "bifrost-cross-account",
+								"external_id": "my-external-id"
+							}
+						}
+					]
+				}
+			}
+		}`
+		if err := validateConfig(t, compiled, config); err != nil {
+			t.Errorf("bedrock config with STS AssumeRole fields should be valid, got: %v", err)
+		}
+	})
+
+	t.Run("bedrock config with batch_s3_config validates successfully", func(t *testing.T) {
+		compiled := compileSchema(t)
+		config := `{
+			"providers": {
+				"bedrock": {
+					"keys": [
+						{
+							"name": "batch-key",
+							"weight": 1,
+							"models": ["us.anthropic.claude-sonnet-4-20250514-v1:0"],
+							"bedrock_key_config": {
+								"region": "us-east-1",
+								"batch_s3_config": {
+									"buckets": [
+										{"bucket_name": "my-batch-bucket", "prefix": "bifrost/", "is_default": true},
+										{"bucket_name": "my-secondary-bucket"}
+									]
+								}
+							}
+						}
+					]
+				}
+			}
+		}`
+		if err := validateConfig(t, compiled, config); err != nil {
+			t.Errorf("bedrock config with batch_s3_config should be valid, got: %v", err)
+		}
+	})
+
+	t.Run("bedrock config with unknown fields is rejected", func(t *testing.T) {
+		compiled := compileSchema(t)
+		config := `{
+			"providers": {
+				"bedrock": {
+					"keys": [
+						{
+							"name": "bad-key",
+							"weight": 1,
+							"models": ["us.anthropic.claude-sonnet-4-20250514-v1:0"],
+							"bedrock_key_config": {
+								"region": "us-east-1",
+								"unknown_field": "should-fail"
+							}
+						}
+					]
+				}
+			}
+		}`
+		if err := validateConfig(t, compiled, config); err == nil {
+			t.Error("bedrock config with unknown fields should fail schema validation (additionalProperties: false)")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds support for AWS STS AssumeRole authentication and S3 batch operations configuration to the Bedrock provider schema. This enables cross-account access and batch processing capabilities for Bedrock integrations.

## Changes

- Added STS AssumeRole fields (`role_arn`, `external_id`, `session_name`) to Bedrock key configuration schema
- Added `batch_s3_config` with S3 bucket configuration for Bedrock batch operations
- Updated both Helm chart values schema and transport configuration schema
- Added comprehensive test coverage for new schema fields including validation of STS fields, batch S3 configuration, and rejection of unknown fields

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate the schema changes and test configuration validation:

```sh
# Core/Transports
go version
go test ./...

# Test specific schema validation
go test ./transports/schema_test -v -run TestSchemaBedrockKeyConfigSTSFields
```

Example configuration with new fields:
```json
{
  "providers": {
    "bedrock": {
      "keys": [{
        "name": "cross-account",
        "bedrock_key_config": {
          "region": "us-west-2",
          "role_arn": "arn:aws:iam::123456789012:role/BedrockAccessRole",
          "session_name": "bifrost-cross-account",
          "external_id": "my-external-id",
          "batch_s3_config": {
            "buckets": [
              {"bucket_name": "my-batch-bucket", "prefix": "bifrost/", "is_default": true}
            ]
          }
        }
      }]
    }
  }
}
```

## Screenshots/Recordings

N/A - Schema configuration changes only.

## Breaking changes

- [ ] Yes
- [x] No

These are additive schema changes that maintain backward compatibility.

## Related issues

N/A

## Security considerations

- STS AssumeRole fields support environment variable prefixes for secure credential management
- External ID field provides additional security layer for cross-account access
- S3 bucket configuration enables secure batch operation file storage

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable