### PR TITLE
fix: add retry mechanism to model catalog pricing sync lock

### DIFF
--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -248,7 +248,7 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 			if err != nil {
 				return nil, fmt.Errorf("failed to create model catalog pricing sync lock: %w", err)
 			}
-			if err := lock.Lock(ctx); err != nil {
+			if err := lock.LockWithRetry(ctx, 10); err != nil {
 				return nil, fmt.Errorf("failed to acquire model catalog pricing sync lock: %w", err)
 			}
 			defer lock.Unlock(ctx)


### PR DESCRIPTION
## Summary

This PR improves the reliability of model catalog pricing synchronization by adding retry logic to the lock acquisition process. Previously, if the lock couldn't be acquired immediately, the operation would fail. Now it will retry up to 10 times before giving up.

## Changes

- Replaced `lock.Lock(ctx)` with `lock.LockWithRetry(ctx, 10)` in the model catalog initialization
- Added retry mechanism to handle transient lock acquisition failures
- Set retry count to 10 attempts to balance reliability with reasonable timeout behavior

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate that model catalog initialization works reliably under concurrent access scenarios:

```sh
# Core/Transports
go version
go test ./...

# Test concurrent model catalog initialization
go test -race ./framework/modelcatalog/...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change improves system reliability but doesn't introduce new security considerations. The lock mechanism continues to protect against concurrent access to pricing sync operations.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable