### PR TITLE
fix: increases buffer size for custom plugin installs from URLs

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+fix: increases buffer size for custom plugin installs from URLs

--- a/framework/plugins/utils.go
+++ b/framework/plugins/utils.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"time"
 
@@ -12,26 +13,60 @@ var (
 	ErrPluginNotFound = fmt.Errorf("plugin not found")
 )
 
+// pluginDownloadClient is a fasthttp client with a larger read buffer to handle
+// responses with large headers.
+var pluginDownloadClient = &fasthttp.Client{
+	ReadBufferSize: 64 * 1024, // 64KB, matches the bifrost HTTP server setting
+}
+
 // DownloadPlugin downloads a plugin from a URL and returns the local file path
-func DownloadPlugin(url string, extension string) (string, error) {
+func DownloadPlugin(pluginURL string, extension string) (string, error) {
 	req := fasthttp.AcquireRequest()
 	defer fasthttp.ReleaseRequest(req)
 	response := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseResponse(response)
 
-	req.SetRequestURI(url)
 	req.Header.SetMethod(fasthttp.MethodGet)
 	req.Header.Set("Accept", "application/octet-stream")
 	req.Header.Set("Accept-Encoding", "gzip")
 	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
 
-	err := fasthttp.DoTimeout(req, response, 120*time.Second)
-	if err != nil {
-		return "", err
-	}
+	const maxRedirects = 5
+	currentURL := pluginURL
+	for i := 0; i <= maxRedirects; i++ {
+		req.SetRequestURI(currentURL)
+		if i > 0 {
+			response.Reset()
+		}
 
-	if response.StatusCode() != fasthttp.StatusOK {
-		return "", fmt.Errorf("failed to download plugin: %d", response.StatusCode())
+		if err := pluginDownloadClient.DoTimeout(req, response, 120*time.Second); err != nil {
+			return "", err
+		}
+
+		statusCode := response.StatusCode()
+		if statusCode == fasthttp.StatusOK {
+			break
+		}
+		if statusCode >= 300 && statusCode < 400 {
+			if i == maxRedirects {
+				return "", fmt.Errorf("too many redirects downloading plugin")
+			}
+			location := string(response.Header.Peek("Location"))
+			if location == "" {
+				return "", fmt.Errorf("redirect response missing Location header: HTTP %d", statusCode)
+			}
+			loc, err := url.Parse(location)
+			if err != nil {
+				return "", fmt.Errorf("invalid Location header %q: %w", location, err)
+			}
+			base, err := url.Parse(currentURL)
+			if err != nil {
+				return "", fmt.Errorf("invalid request URL %q: %w", currentURL, err)
+			}
+			currentURL = base.ResolveReference(loc).String()
+			continue
+		}
+		return "", fmt.Errorf("failed to download plugin: HTTP %d", statusCode)
 	}
 
 	// Decompress the response body if it was gzip/deflate compressed

--- a/framework/plugins/utils_test.go
+++ b/framework/plugins/utils_test.go
@@ -1,0 +1,90 @@
+package plugins
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const fakePluginBytes = "fake-plugin-binary-content"
+
+func TestDownloadPlugin_DirectDownload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(fakePluginBytes))
+	}))
+	defer server.Close()
+
+	path, err := DownloadPlugin(server.URL, ".so")
+	require.NoError(t, err)
+	defer os.Remove(path)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, fakePluginBytes, string(data))
+}
+
+func TestDownloadPlugin_FollowsRedirect(t *testing.T) {
+	// Final destination
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(fakePluginBytes))
+	}))
+	defer target.Close()
+
+	// Redirect server (simulates GitHub → S3)
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	path, err := DownloadPlugin(redirector.URL, ".so")
+	require.NoError(t, err)
+	defer os.Remove(path)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, fakePluginBytes, string(data))
+}
+
+func TestDownloadPlugin_TooManyRedirects(t *testing.T) {
+	// Server that always redirects to itself
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, server.URL, http.StatusFound)
+	}))
+	defer server.Close()
+
+	_, err := DownloadPlugin(server.URL, ".so")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many redirects")
+}
+
+func TestDownloadPlugin_NonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, err := DownloadPlugin(server.URL, ".so")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestDownloadPlugin_FileExtensionPreserved(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(fakePluginBytes))
+	}))
+	defer server.Close()
+
+	path, err := DownloadPlugin(server.URL, ".so")
+	require.NoError(t, err)
+	defer os.Remove(path)
+
+	assert.Contains(t, path, ".so")
+}


### PR DESCRIPTION
## Summary

Enhances the plugin download functionality to handle HTTP redirects and improves compatibility with servers that send large headers by increasing the read buffer size.

fixes: [#2397](https://github.com/maximhq/bifrost/issues/2397)

## Changes

- Added a dedicated `fasthttp.Client` with a 64KB read buffer to match the bifrost HTTP server configuration and handle responses with large headers
- Implemented HTTP redirect following with a maximum of 5 redirects to support plugin downloads from services like GitHub that redirect to CDNs
- Added proper error handling for redirect loops and missing Location headers
- Refactored the download logic into a loop that processes redirects sequentially
- Added comprehensive test coverage for direct downloads, redirect following, redirect limits, and error conditions

## Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate the plugin download functionality with various scenarios:

```sh
# Run the new tests
go test ./framework/plugins -v

# Test with a plugin URL that redirects (e.g., GitHub releases)
# The function should now handle redirects automatically

# Test with direct download URLs
# Should continue to work as before
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The redirect following is limited to 5 redirects maximum to prevent infinite redirect loops. The implementation validates that Location headers are present in redirect responses to avoid potential issues with malformed responses.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable