### PR TITLE
fixed missing param

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Snyk test (all projects)
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: snyk test --all-projects --detection-depth=4 --exclude=examples,tests/scripts --sarif-file-output=snyk.sarif || true
+        run: snyk test --all-projects --detection-depth=4 --exclude=examples,tests --sarif-file-output=snyk.sarif || true
 
       - name: Upload SARIF
         if: always() && hashFiles('snyk.sarif') != ''


### PR DESCRIPTION
## Summary

Updates the Snyk security scanning workflow to exclude the entire `tests` directory instead of only `tests/scripts`, broadening the scope of excluded test files from vulnerability scanning.

## Changes

- Modified the `--exclude` parameter in the Snyk test command from `examples,tests/scripts` to `examples,tests`
- This change ensures all test-related files are excluded from security vulnerability scanning, not just scripts within the tests directory

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify the Snyk workflow runs successfully with the updated exclusion pattern:

```sh
# Trigger the Snyk workflow manually or through a push/PR
# Check that the workflow completes without scanning test files
# Verify SARIF output excludes vulnerabilities from the tests directory
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

## Related issues

N/A

## Security considerations

This change reduces the scope of security scanning by excluding more test files, which is generally acceptable as test dependencies typically don't affect production security posture.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable