### PR TITLE
feat: add SSO configuration types and extend AuthConfig

### DIFF
--- a/core/schemas/sso.go
+++ b/core/schemas/sso.go
@@ -1,0 +1,20 @@
+package schemas
+
+// GoogleSSOConfig holds configuration for Google OAuth SSO login.
+type GoogleSSOConfig struct {
+	ClientID       *EnvVar  `json:"client_id"`
+	ClientSecret   *EnvVar  `json:"client_secret"`
+	AllowedDomains []string `json:"allowed_domains,omitempty"`
+}
+
+// SAMLConfig holds configuration for SAML SSO login.
+type SAMLConfig struct {
+	EntityID       string `json:"entity_id"`
+	MetadataURL    string `json:"metadata_url,omitempty"`
+	IdPSSOURL      string `json:"idp_sso_url,omitempty"`
+	IdPCertificate string `json:"idp_certificate,omitempty"`
+	IdPEntityID    string `json:"idp_entity_id,omitempty"`
+	SignRequests   bool   `json:"sign_requests"`
+	ForceAuthn     bool   `json:"force_authn"`
+	NameIDFormat   string `json:"name_id_format,omitempty"`
+}

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1122,10 +1122,14 @@ func GeneratePluginHash(p tables.TablePlugin) (string, error) {
 
 // AuthConfig represents configured auth config for Bifrost dashboard
 type AuthConfig struct {
-	AdminUserName          *schemas.EnvVar `json:"admin_username"`
-	AdminPassword          *schemas.EnvVar `json:"admin_password"`
-	IsEnabled              bool            `json:"is_enabled"`
-	DisableAuthOnInference bool            `json:"disable_auth_on_inference"`
+	AdminUserName          *schemas.EnvVar          `json:"admin_username"`
+	AdminPassword          *schemas.EnvVar          `json:"admin_password"`
+	IsEnabled              bool                     `json:"is_enabled"`
+	DisableAuthOnInference bool                     `json:"disable_auth_on_inference"`
+	EnabledMethods         []string                 `json:"enabled_methods,omitempty"`
+	GoogleSSOConfig        *schemas.GoogleSSOConfig `json:"google_sso_config,omitempty"`
+	SAMLConfig             *schemas.SAMLConfig      `json:"saml_config,omitempty"`
+	DefaultRole            string                   `json:"default_role,omitempty"`
 }
 
 // ConfigMap maps provider names to their configurations.

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3120,12 +3120,69 @@ func (s *RDBConfigStore) GetAuthConfig(ctx context.Context) (*AuthConfig, error)
 	if username == nil || password == nil {
 		return nil, nil
 	}
-	return &AuthConfig{
+
+	authConfig := &AuthConfig{
 		AdminUserName:          schemas.NewEnvVar(*username),
 		AdminPassword:          schemas.NewEnvVar(*password),
 		IsEnabled:              isEnabled,
 		DisableAuthOnInference: disableAuthOnInference,
-	}, nil
+	}
+
+	// Read enabled auth methods
+	var enabledMethodsJSON *string
+	if err := s.db.WithContext(ctx).First(&tables.TableGovernanceConfig{}, "key = ?", tables.ConfigEnabledAuthMethodsKey).Select("value").Scan(&enabledMethodsJSON).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, err
+		}
+	}
+	if enabledMethodsJSON != nil && *enabledMethodsJSON != "" {
+		if err := json.Unmarshal([]byte(*enabledMethodsJSON), &authConfig.EnabledMethods); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal enabled_auth_methods: %w", err)
+		}
+	}
+
+	// Read Google SSO config
+	var googleSSOJSON *string
+	if err := s.db.WithContext(ctx).First(&tables.TableGovernanceConfig{}, "key = ?", tables.ConfigGoogleSSOConfigKey).Select("value").Scan(&googleSSOJSON).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, err
+		}
+	}
+	if googleSSOJSON != nil && *googleSSOJSON != "" {
+		var googleSSO schemas.GoogleSSOConfig
+		if err := json.Unmarshal([]byte(*googleSSOJSON), &googleSSO); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal google_sso_config: %w", err)
+		}
+		authConfig.GoogleSSOConfig = &googleSSO
+	}
+
+	// Read SAML config
+	var samlJSON *string
+	if err := s.db.WithContext(ctx).First(&tables.TableGovernanceConfig{}, "key = ?", tables.ConfigSAMLConfigKey).Select("value").Scan(&samlJSON).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, err
+		}
+	}
+	if samlJSON != nil && *samlJSON != "" {
+		var samlConfig schemas.SAMLConfig
+		if err := json.Unmarshal([]byte(*samlJSON), &samlConfig); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal saml_config: %w", err)
+		}
+		authConfig.SAMLConfig = &samlConfig
+	}
+
+	// Read default role
+	var defaultRole *string
+	if err := s.db.WithContext(ctx).First(&tables.TableGovernanceConfig{}, "key = ?", tables.ConfigDefaultRoleKey).Select("value").Scan(&defaultRole).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, err
+		}
+	}
+	if defaultRole != nil {
+		authConfig.DefaultRole = *defaultRole
+	}
+
+	return authConfig, nil
 }
 
 // UpdateAuthConfig updates the auth configuration in the database.
@@ -3155,6 +3212,59 @@ func (s *RDBConfigStore) UpdateAuthConfig(ctx context.Context, config *AuthConfi
 		}).Error; err != nil {
 			return err
 		}
+
+		// Save enabled auth methods
+		if config.EnabledMethods != nil {
+			enabledMethodsJSON, err := json.Marshal(config.EnabledMethods)
+			if err != nil {
+				return fmt.Errorf("failed to marshal enabled_auth_methods: %w", err)
+			}
+			if err := tx.Save(&tables.TableGovernanceConfig{
+				Key:   tables.ConfigEnabledAuthMethodsKey,
+				Value: string(enabledMethodsJSON),
+			}).Error; err != nil {
+				return err
+			}
+		}
+
+		// Save Google SSO config
+		if config.GoogleSSOConfig != nil {
+			googleSSOJSON, err := json.Marshal(config.GoogleSSOConfig)
+			if err != nil {
+				return fmt.Errorf("failed to marshal google_sso_config: %w", err)
+			}
+			if err := tx.Save(&tables.TableGovernanceConfig{
+				Key:   tables.ConfigGoogleSSOConfigKey,
+				Value: string(googleSSOJSON),
+			}).Error; err != nil {
+				return err
+			}
+		}
+
+		// Save SAML config
+		if config.SAMLConfig != nil {
+			samlConfigJSON, err := json.Marshal(config.SAMLConfig)
+			if err != nil {
+				return fmt.Errorf("failed to marshal saml_config: %w", err)
+			}
+			if err := tx.Save(&tables.TableGovernanceConfig{
+				Key:   tables.ConfigSAMLConfigKey,
+				Value: string(samlConfigJSON),
+			}).Error; err != nil {
+				return err
+			}
+		}
+
+		// Save default role
+		if config.DefaultRole != "" {
+			if err := tx.Save(&tables.TableGovernanceConfig{
+				Key:   tables.ConfigDefaultRoleKey,
+				Value: config.DefaultRole,
+			}).Error; err != nil {
+				return err
+			}
+		}
+
 		return nil
 	})
 }

--- a/framework/configstore/tables/config.go
+++ b/framework/configstore/tables/config.go
@@ -10,6 +10,10 @@ const (
 	ConfigProxyKey                  = "proxy_config"
 	ConfigRestartRequiredKey        = "restart_required"
 	ConfigHeaderFilterKey           = "header_filter_config"
+	ConfigEnabledAuthMethodsKey     = "enabled_auth_methods"
+	ConfigGoogleSSOConfigKey        = "google_sso_config"
+	ConfigSAMLConfigKey             = "saml_config"
+	ConfigDefaultRoleKey            = "default_role"
 )
 
 // RestartRequiredConfig represents the restart required configuration

--- a/framework/go.mod
+++ b/framework/go.mod
@@ -132,3 +132,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/postgres v1.6.0
 )
+
+replace github.com/maximhq/bifrost/core => ../core

--- a/framework/go.sum
+++ b/framework/go.sum
@@ -193,8 +193,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.32 h1:JD12Ag3oLy1zQA+BNn74xRgaBbdhbNIDYvQUEuuErjs=
 github.com/mattn/go-sqlite3 v1.14.32/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
-github.com/maximhq/bifrost/core v1.4.16 h1:N/fDKXAD1yJLASj28M22j5I9P/Pz9VVV/oHDRWtO3SA=
-github.com/maximhq/bifrost/core v1.4.16/go.mod h1:A+AHUm/jf2lWFz5RNSxcJD/ozPlFJIVK9riMM1nyjt8=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=


### PR DESCRIPTION
## Summary
- Add `GoogleSSOConfig` and `SAMLConfig` type definitions in `core/schemas/sso.go` for Google OAuth and SAML SSO login support
- Extend `AuthConfig` struct with new SSO-related fields: `EnabledMethods`, `GoogleSSOConfig`, `SAMLConfig`, `DefaultRole`
- Update `GetAuthConfig` and `UpdateAuthConfig` in `framework/configstore/rdb.go` to persist and retrieve the new SSO configuration values as JSON key-value pairs in the `governance_config` table
- Add new config key constants (`enabled_auth_methods`, `google_sso_config`, `saml_config`, `default_role`) in `framework/configstore/tables/config.go`

## Test plan
- [x] `cd core && go build ./...` compiles successfully
- [x] `cd framework && go build ./...` compiles successfully
- [ ] Integration test with other SSO units (Google OAuth handler, SAML handler) once they land

> **Note:** The `framework/go.mod` includes a temporary `replace` directive (`github.com/maximhq/bifrost/core => ../core`) to reference the local core module with the new SSO types. This should be removed once `core` is published with a new version that includes these types.