### PR TITLE
feat: add frontend SSO types and API hooks

### DIFF
--- a/ui/lib/store/apis/index.ts
+++ b/ui/lib/store/apis/index.ts
@@ -12,3 +12,4 @@ export * from "./pluginsApi";
 export * from "./providersApi";
 export * from "./promptsApi";
 export * from "./sessionApi";
+export * from "./usersApi";

--- a/ui/lib/store/apis/sessionApi.ts
+++ b/ui/lib/store/apis/sessionApi.ts
@@ -1,3 +1,4 @@
+import type { AuthMethodsResponse } from "@/lib/types/sso";
 import { baseApi, clearAuthStorage } from "./baseApi";
 
 export interface LoginRequest {
@@ -23,6 +24,13 @@ export const sessionApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
 		// Check if auth is enabled
 		isAuthEnabled: builder.query<IsAuthEnabledResponse, void>({
+			query: () => ({
+				url: "/session/is-auth-enabled",
+				method: "GET",
+			}),
+		}),
+		// Get available auth methods (SSO, password, etc.)
+		authMethods: builder.query<AuthMethodsResponse, void>({
 			query: () => ({
 				url: "/session/is-auth-enabled",
 				method: "GET",
@@ -58,4 +66,4 @@ export const sessionApi = baseApi.injectEndpoints({
 	}),
 });
 
-export const { useIsAuthEnabledQuery, useLoginMutation, useLogoutMutation } = sessionApi;
+export const { useIsAuthEnabledQuery, useAuthMethodsQuery, useLoginMutation, useLogoutMutation } = sessionApi;

--- a/ui/lib/store/apis/usersApi.ts
+++ b/ui/lib/store/apis/usersApi.ts
@@ -1,0 +1,36 @@
+import { baseApi } from "./baseApi";
+import type { User } from "@/lib/types/sso";
+
+interface UsersQueryParams {
+	limit?: number;
+	offset?: number;
+	search?: string;
+}
+
+interface PaginatedUsersResponse {
+	users: User[];
+	total: number;
+}
+
+export const usersApi = baseApi.injectEndpoints({
+	endpoints: (builder) => ({
+		getUsers: builder.query<PaginatedUsersResponse, UsersQueryParams>({
+			query: (params) => ({ url: "/users", params }),
+			providesTags: ["Users"],
+		}),
+		getCurrentUser: builder.query<User, void>({
+			query: () => ({ url: "/users/me" }),
+			providesTags: ["Users"],
+		}),
+		updateUserRole: builder.mutation<User, { id: string; role: string }>({
+			query: ({ id, ...body }) => ({ url: `/users/${id}/role`, method: "PUT", body }),
+			invalidatesTags: ["Users"],
+		}),
+		deleteUser: builder.mutation<void, string>({
+			query: (id) => ({ url: `/users/${id}`, method: "DELETE" }),
+			invalidatesTags: ["Users"],
+		}),
+	}),
+});
+
+export const { useGetUsersQuery, useGetCurrentUserQuery, useUpdateUserRoleMutation, useDeleteUserMutation } = usersApi;

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -2,6 +2,7 @@
 
 import { KnownProvidersNames } from "@/lib/constants/logs";
 import { EnvVar } from "./schemas";
+import type { GoogleSSOConfig, SAMLConfig } from "./sso";
 
 // Known provider names - all supported standard providers
 export type KnownProvider = (typeof KnownProvidersNames)[number];
@@ -400,6 +401,10 @@ export interface AuthConfig {
 	admin_password: EnvVar;
 	is_enabled: boolean;
 	disable_auth_on_inference?: boolean;
+	enabled_methods?: string[];
+	google_sso_config?: GoogleSSOConfig;
+	saml_config?: SAMLConfig;
+	default_role?: string;
 }
 
 // Global proxy type (for global proxy configuration, not per-provider)

--- a/ui/lib/types/sso.ts
+++ b/ui/lib/types/sso.ts
@@ -1,0 +1,40 @@
+import type { EnvVar } from "./schemas";
+
+export interface GoogleSSOConfig {
+	client_id: EnvVar;
+	client_secret: EnvVar;
+	allowed_domains?: string[];
+}
+
+export interface SAMLConfig {
+	entity_id: string;
+	metadata_url?: string;
+	idp_sso_url?: string;
+	idp_certificate?: string;
+	idp_entity_id?: string;
+	sign_requests: boolean;
+	force_authn: boolean;
+	name_id_format?: string;
+}
+
+export interface User {
+	id: string;
+	email: string;
+	name: string;
+	role: string; // "admin" | "viewer"
+	auth_provider: string; // "password" | "google_sso" | "saml"
+	external_id: string;
+	avatar_url: string;
+	is_active: boolean;
+	last_login_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface AuthMethodsResponse {
+	is_auth_enabled: boolean;
+	has_valid_token: boolean;
+	enabled_methods: string[];
+	google_sso?: { login_url: string };
+	saml?: { login_url: string };
+}


### PR DESCRIPTION
## Summary
- Add new `ui/lib/types/sso.ts` with TypeScript types for Google SSO config, SAML config, User, and AuthMethodsResponse
- Extend `AuthConfig` in `ui/lib/types/config.ts` with SSO fields (`enabled_methods`, `google_sso_config`, `saml_config`, `default_role`)
- Add `authMethods` RTK Query endpoint to `sessionApi.ts` for querying available auth methods
- Add new `ui/lib/store/apis/usersApi.ts` with Users CRUD endpoints (getUsers, getCurrentUser, updateUserRole, deleteUser)
- Export new usersApi from `ui/lib/store/apis/index.ts`

## Test plan
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Verify SSO types align with backend API response shapes once backend is implemented
- [ ] Verify RTK Query hooks work correctly when integrated with UI components