### PR TITLE
feat: add auth methods discovery endpoint and SSO server wiring

### DIFF
--- a/core/schemas/sso.go
+++ b/core/schemas/sso.go
@@ -1,0 +1,15 @@
+package schemas
+
+// GoogleSSOConfig holds configuration for Google OAuth SSO login.
+type GoogleSSOConfig struct {
+	ClientID     *EnvVar `json:"client_id"`
+	ClientSecret *EnvVar `json:"client_secret"`
+	RedirectURI  string  `json:"redirect_uri,omitempty"`
+}
+
+// SAMLConfig holds configuration for SAML-based SSO login.
+type SAMLConfig struct {
+	IDPURL      string `json:"idp_url"`
+	Certificate string `json:"certificate,omitempty"`
+	EntityID    string `json:"entity_id,omitempty"`
+}

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1122,10 +1122,13 @@ func GeneratePluginHash(p tables.TablePlugin) (string, error) {
 
 // AuthConfig represents configured auth config for Bifrost dashboard
 type AuthConfig struct {
-	AdminUserName          *schemas.EnvVar `json:"admin_username"`
-	AdminPassword          *schemas.EnvVar `json:"admin_password"`
-	IsEnabled              bool            `json:"is_enabled"`
-	DisableAuthOnInference bool            `json:"disable_auth_on_inference"`
+	AdminUserName          *schemas.EnvVar          `json:"admin_username"`
+	AdminPassword          *schemas.EnvVar          `json:"admin_password"`
+	IsEnabled              bool                     `json:"is_enabled"`
+	DisableAuthOnInference bool                     `json:"disable_auth_on_inference"`
+	EnabledMethods         []string                 `json:"enabled_methods,omitempty"`
+	GoogleSSOConfig        *schemas.GoogleSSOConfig `json:"google_sso_config,omitempty"`
+	SAMLConfig             *schemas.SAMLConfig      `json:"saml_config,omitempty"`
 }
 
 // ConfigMap maps provider names to their configurations.

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -574,6 +574,7 @@ func (m *AuthMiddleware) APIMiddleware() schemas.BifrostHTTPMiddleware {
 	}
 	whitelistedPrefixes := []string{
 		"/api/oauth/callback",
+		"/api/auth/sso/",
 	}
 	return m.middleware(func(authConfig *configstore.AuthConfig, url string) bool {
 		if slices.Contains(systemWhitelistedRoutes, url) ||

--- a/transports/bifrost-http/handlers/session.go
+++ b/transports/bifrost-http/handlers/session.go
@@ -73,10 +73,30 @@ func (h *SessionHandler) isAuthEnabled(ctx *fasthttp.RequestCtx) {
 			hasValidToken = true
 		}
 	}
-	SendJSON(ctx, map[string]any{
+	response := map[string]any{
 		"is_auth_enabled": authConfig.IsEnabled,
 		"has_valid_token": hasValidToken,
-	})
+	}
+
+	// Include SSO method information so the frontend knows which login flows are available.
+	if len(authConfig.EnabledMethods) > 0 {
+		response["enabled_methods"] = authConfig.EnabledMethods
+	} else if authConfig.IsEnabled {
+		response["enabled_methods"] = []string{"password"}
+	}
+
+	if authConfig.GoogleSSOConfig != nil {
+		response["google_sso"] = map[string]string{
+			"login_url": "/api/auth/sso/google/login",
+		}
+	}
+	if authConfig.SAMLConfig != nil {
+		response["saml"] = map[string]string{
+			"login_url": "/api/auth/sso/saml/login",
+		}
+	}
+
+	SendJSON(ctx, response)
 }
 
 // login handles POST /api/session/login - Login a user

--- a/transports/bifrost-http/handlers/sso_google.go
+++ b/transports/bifrost-http/handlers/sso_google.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"github.com/fasthttp/router"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+)
+
+// GoogleSSOHandler manages HTTP requests for Google OAuth SSO login.
+type GoogleSSOHandler struct {
+	configStore configstore.ConfigStore
+}
+
+// NewGoogleSSOHandler creates a new Google SSO handler instance.
+func NewGoogleSSOHandler(configStore configstore.ConfigStore) *GoogleSSOHandler {
+	return &GoogleSSOHandler{configStore: configStore}
+}
+
+// RegisterRoutes registers the Google SSO routes.
+// Actual route implementations will be provided by the SSO login flow unit.
+func (h *GoogleSSOHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	// Routes will be registered here once the login/callback handlers are implemented.
+}

--- a/transports/bifrost-http/handlers/sso_saml.go
+++ b/transports/bifrost-http/handlers/sso_saml.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"github.com/fasthttp/router"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+)
+
+// SAMLHandler manages HTTP requests for SAML-based SSO login.
+type SAMLHandler struct {
+	configStore configstore.ConfigStore
+}
+
+// NewSAMLHandler creates a new SAML handler instance.
+func NewSAMLHandler(configStore configstore.ConfigStore) *SAMLHandler {
+	return &SAMLHandler{configStore: configStore}
+}
+
+// RegisterRoutes registers the SAML SSO routes.
+// Actual route implementations will be provided by the SSO login flow unit.
+func (h *SAMLHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	// Routes will be registered here once the login/callback handlers are implemented.
+}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1037,6 +1037,11 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	if sessionHandler != nil {
 		sessionHandler.RegisterRoutes(s.Router, middlewares...)
 	}
+	// SSO handlers
+	googleSSOHandler := handlers.NewGoogleSSOHandler(s.Config.ConfigStore)
+	googleSSOHandler.RegisterRoutes(s.Router, middlewares...)
+	samlHandler := handlers.NewSAMLHandler(s.Config.ConfigStore)
+	samlHandler.RegisterRoutes(s.Router, middlewares...)
 	if promptsHandler != nil {
 		promptsHandler.RegisterRoutes(s.Router, middlewares...)
 	}


### PR DESCRIPTION
## Summary
- Extend the existing `GET /api/session/is-auth-enabled` endpoint to return SSO method discovery info (`enabled_methods`, `google_sso`, `saml` fields) so the frontend knows which login flows are available.
- Add `GoogleSSOConfig` and `SAMLConfig` schema types in `core/schemas/sso.go` and corresponding fields on `AuthConfig` in `framework/configstore/clientconfig.go`.
- Add stub handlers (`GoogleSSOHandler`, `SAMLHandler`) and wire them into server route registration in `server.go`.
- Whitelist `/api/auth/sso/` prefixed routes in the auth middleware so SSO login/callback endpoints bypass authentication.

## Test plan
- [x] `go build ./bifrost-http/handlers/... ./bifrost-http/server/... ./bifrost-http/lib/...` passes with go workspace
- [ ] Verify `GET /api/session/is-auth-enabled` returns `enabled_methods: ["password"]` when auth is enabled with no SSO config
- [ ] Verify `google_sso` and `saml` fields appear in response when corresponding config is set
- [ ] Verify SSO routes under `/api/auth/sso/` bypass auth middleware