### PR TITLE
feat: add SSO login buttons to login page

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
@@ -11,6 +11,15 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
+const GoogleIcon = () => (
+	<svg viewBox="0 0 24 24" className="mr-2 h-4 w-4">
+		<path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+		<path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+		<path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+		<path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+	</svg>
+);
+
 const externalLinks = [
 	{
 		title: "Discord Server",
@@ -45,8 +54,15 @@ export default function LoginView() {
 	const hasValidToken = isAuthEnabledData?.has_valid_token || false;
 	const [login, { isLoading: isLoggingIn }] = useLoginMutation();
 
+	const showPasswordForm = !isAuthEnabledData?.enabled_methods || isAuthEnabledData.enabled_methods.includes("password");
+	const hasSSO = !!(isAuthEnabledData?.google_sso || isAuthEnabledData?.saml);
+
 	useEffect(() => {
 		setMounted(true);
+		const params = new URLSearchParams(window.location.search);
+		if (params.get("error")) {
+			setErrorMessage(params.get("message") || "SSO login failed. Please try again.");
+		}
 	}, []);
 
 	// Check auth status on component mount
@@ -117,59 +133,96 @@ export default function LoginView() {
 						<p className="text-muted-foreground text-sm">Sign in to your account to continue</p>
 					</div>
 
-					<form onSubmit={handleSubmit} className="space-y-5">
-						{errorMessage && <div className="bg-destructive/10 text-destructive rounded-sm p-3 text-sm">{errorMessage}</div>}
+					{errorMessage && <div className="bg-destructive/10 text-destructive rounded-sm p-3 text-sm">{errorMessage}</div>}
 
-						<div className="space-y-2">
-							<Label htmlFor="username" className="text-sm font-medium">
-								Username
-							</Label>
-							<Input
-								id="username"
-								type="text"
-								placeholder="Enter your username"
-								value={username}
-								onChange={(e) => setUsername(e.target.value)}
-								required
-								className="text-sm"
-								autoComplete="username"
-							/>
-						</div>
-
-						<div className="space-y-2">
-							<Label htmlFor="password" className="text-sm font-medium">
-								Password
-							</Label>
-							<div className="relative">
-								<Input
-									id="password"
-									type={showPassword ? "text" : "password"}
-									placeholder="Enter your password"
-									value={password}
-									onChange={(e) => setPassword(e.target.value)}
-									required
-									className="text-sm pr-10"
-									autoComplete="current-password"
-								/>
-								<button
-									type="button"
-									onClick={() => setShowPassword(!showPassword)}
-									className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
-									aria-label={showPassword ? "Hide password" : "Show password"}
+					{hasSSO && (
+						<div className="space-y-3">
+							{isAuthEnabledData?.google_sso && (
+								<Button
+									variant="outline"
+									className="h-9 w-full text-sm"
+									onClick={() => window.location.href = isAuthEnabledData.google_sso!.login_url}
 								>
-									{showPassword ? (
-										<EyeOff className="h-4 w-4" />
-									) : (
-										<Eye className="h-4 w-4" />
-									)}
-								</button>
+									<GoogleIcon />
+									Sign in with Google
+								</Button>
+							)}
+							{isAuthEnabledData?.saml && (
+								<Button
+									variant="outline"
+									className="h-9 w-full text-sm"
+									onClick={() => window.location.href = isAuthEnabledData.saml!.login_url}
+								>
+									Sign in with SSO
+								</Button>
+							)}
+						</div>
+					)}
+
+					{hasSSO && showPasswordForm && (
+						<div className="relative my-4">
+							<div className="absolute inset-0 flex items-center">
+								<span className="w-full border-t" />
+							</div>
+							<div className="relative flex justify-center text-xs uppercase">
+								<span className="bg-card px-2 text-muted-foreground">or</span>
 							</div>
 						</div>
+					)}
 
-						<Button type="submit" className="h-9 w-full text-sm" isLoading={isLoading} disabled={isLoading}>
-							{isLoading || isLoggingIn ? "Signing in..." : "Sign in"}
-						</Button>
-					</form>
+					{showPasswordForm && (
+						<form onSubmit={handleSubmit} className="space-y-5">
+							<div className="space-y-2">
+								<Label htmlFor="username" className="text-sm font-medium">
+									Username
+								</Label>
+								<Input
+									id="username"
+									type="text"
+									placeholder="Enter your username"
+									value={username}
+									onChange={(e) => setUsername(e.target.value)}
+									required
+									className="text-sm"
+									autoComplete="username"
+								/>
+							</div>
+
+							<div className="space-y-2">
+								<Label htmlFor="password" className="text-sm font-medium">
+									Password
+								</Label>
+								<div className="relative">
+									<Input
+										id="password"
+										type={showPassword ? "text" : "password"}
+										placeholder="Enter your password"
+										value={password}
+										onChange={(e) => setPassword(e.target.value)}
+										required
+										className="text-sm pr-10"
+										autoComplete="current-password"
+									/>
+									<button
+										type="button"
+										onClick={() => setShowPassword(!showPassword)}
+										className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+										aria-label={showPassword ? "Hide password" : "Show password"}
+									>
+										{showPassword ? (
+											<EyeOff className="h-4 w-4" />
+										) : (
+											<Eye className="h-4 w-4" />
+										)}
+									</button>
+								</div>
+							</div>
+
+							<Button type="submit" className="h-9 w-full text-sm" isLoading={isLoading} disabled={isLoading}>
+								{isLoading || isLoggingIn ? "Signing in..." : "Sign in"}
+							</Button>
+						</form>
+					)}
 
 					{/* Social Links */}
 					<div className="flex items-center justify-center gap-4 pt-4">

--- a/ui/lib/store/apis/sessionApi.ts
+++ b/ui/lib/store/apis/sessionApi.ts
@@ -12,6 +12,9 @@ export interface LoginResponse {
 export interface IsAuthEnabledResponse {
 	is_auth_enabled: boolean;
 	has_valid_token: boolean;
+	enabled_methods?: string[];
+	google_sso?: { login_url: string };
+	saml?: { login_url: string };
 }
 
 export interface LogoutResponse {


### PR DESCRIPTION
## Summary
- Add Google OAuth and SAML SSO login buttons to the enterprise login page, conditionally rendered based on `enabled_methods`, `google_sso`, and `saml` fields from the `/session/is-auth-enabled` endpoint response
- Password form is conditionally shown only when `enabled_methods` includes "password" (or when the field is absent, for backward compatibility)
- An "or" divider separates SSO buttons from the password form when both are available
- SSO callback errors (redirected via `?error=...&message=...` query params) are surfaced in the existing error banner

## Test plan
- [ ] Verify login page renders normally (password form only) when backend returns no SSO fields
- [ ] Verify Google SSO button appears when `google_sso.login_url` is present in the auth response
- [ ] Verify SAML SSO button appears when `saml.login_url` is present in the auth response
- [ ] Verify "or" divider appears when both SSO and password are enabled
- [ ] Verify password form is hidden when `enabled_methods` does not include "password"
- [ ] Verify SSO error message displays when redirected with `?error=sso_failed&message=...`
- [ ] Run `cd ui && npx tsc --noEmit` — passes with zero errors