### PR TITLE
feat: extend auth middleware for SSO route whitelisting and user context

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -222,6 +222,8 @@ const (
 	BifrostContextKeySkipListModelsGovernanceFiltering   BifrostContextKey = "bifrost-skip-list-models-governance-filtering"    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeySCIMClaims                          BifrostContextKey = "scim_claims"
 	BifrostContextKeyUserID                              BifrostContextKey = "user_id"
+	BifrostContextKeyUserRole                            BifrostContextKey = "bifrost-user-role"          // string (user role from SSO - set by auth middleware)
+	BifrostContextKeyAuthProvider                        BifrostContextKey = "bifrost-auth-provider"      // string (auth provider e.g. "google", "saml", "password" - set by auth middleware)
 	BifrostContextKeyTargetUserID                        BifrostContextKey = "target_user_id"
 	BifrostContextKeyIsAzureUserAgent                    BifrostContextKey = "bifrost-is-azure-user-agent" // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an Azure user agent (only used in gateway)
 	BifrostContextKeyVideoOutputRequested                BifrostContextKey = "bifrost-video-output-requested"

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3299,6 +3299,16 @@ func (s *RDBConfigStore) FlushSessions(ctx context.Context) error {
 	return s.db.WithContext(ctx).Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&tables.SessionsTable{}).Error
 }
 
+// GetUserByID retrieves a user by their ID.
+func (s *RDBConfigStore) GetUserByID(ctx context.Context, id string) (*tables.TableUser, error) {
+	var user tables.TableUser
+	result := s.db.WithContext(ctx).Where("id = ?", id).First(&user)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &user, nil
+}
+
 // ExecuteTransaction executes a transaction.
 func (s *RDBConfigStore) ExecuteTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
 	return s.db.WithContext(ctx).Transaction(fn)

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -216,6 +216,9 @@ type ConfigStore interface {
 	DeleteSession(ctx context.Context, token string) error
 	FlushSessions(ctx context.Context) error
 
+	// User CRUD
+	GetUserByID(ctx context.Context, id string) (*tables.TableUser, error)
+
 	// Model pricing CRUD
 	GetModelPrices(ctx context.Context) ([]tables.TableModelPricing, error)
 	UpsertModelPrices(ctx context.Context, pricing *tables.TableModelPricing, tx ...*gorm.DB) error

--- a/framework/configstore/tables/sessions.go
+++ b/framework/configstore/tables/sessions.go
@@ -12,6 +12,7 @@ import (
 type SessionsTable struct {
 	ID               int       `gorm:"primaryKey;autoIncrement" json:"id"`
 	Token            string    `gorm:"type:text;not null;uniqueIndex" json:"token"`
+	UserID           string    `gorm:"type:varchar(255);index" json:"user_id,omitempty"`
 	ExpiresAt        time.Time `gorm:"index;not null" json:"expires_at,omitempty"`
 	CreatedAt        time.Time `gorm:"index;not null" json:"created_at"`
 	UpdatedAt        time.Time `gorm:"index;not null" json:"updated_at"`

--- a/framework/configstore/tables/users.go
+++ b/framework/configstore/tables/users.go
@@ -1,0 +1,17 @@
+package tables
+
+import "time"
+
+// TableUser represents a user account in the database.
+type TableUser struct {
+	ID           string    `gorm:"primaryKey;type:varchar(255)" json:"id"`
+	Email        string    `gorm:"type:varchar(255);uniqueIndex" json:"email"`
+	Name         string    `gorm:"type:varchar(255)" json:"name"`
+	Role         string    `gorm:"type:varchar(50);default:'viewer'" json:"role"`
+	AuthProvider string    `gorm:"type:varchar(50)" json:"auth_provider"` // e.g. "google", "saml", "password"
+	CreatedAt    time.Time `gorm:"index;not null" json:"created_at"`
+	UpdatedAt    time.Time `gorm:"index;not null" json:"updated_at"`
+}
+
+// TableName sets the table name for TableUser.
+func (TableUser) TableName() string { return "users" }

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -15,6 +15,7 @@ import (
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/encrypt"
 	"github.com/maximhq/bifrost/framework/tracing"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
@@ -487,15 +488,30 @@ func fasthttpResponseToHTTPResponse(ctx *fasthttp.RequestCtx, resp *schemas.HTTP
 }
 
 // validateSession checks if a session token is valid
-func validateSession(_ *fasthttp.RequestCtx, store configstore.ConfigStore, token string) bool {
+func validateSession(_ *fasthttp.RequestCtx, store configstore.ConfigStore, token string) (*tables.SessionsTable, bool) {
 	session, err := store.GetSession(context.Background(), token)
 	if err != nil || session == nil {
-		return false
+		return nil, false
 	}
 	if session.ExpiresAt.Before(time.Now()) {
-		return false
+		return nil, false
 	}
-	return true
+	return session, true
+}
+
+// setUserContext loads the user from the store (if the session has a UserID) and
+// attaches user info to the request context.
+func setUserContext(ctx *fasthttp.RequestCtx, store configstore.ConfigStore, session *tables.SessionsTable) {
+	if session == nil || session.UserID == "" {
+		return
+	}
+	user, err := store.GetUserByID(context.Background(), session.UserID)
+	if err != nil || user == nil {
+		return
+	}
+	ctx.SetUserValue(schemas.BifrostContextKeyUserID, user.ID)
+	ctx.SetUserValue(schemas.BifrostContextKeyUserRole, user.Role)
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthProvider, user.AuthProvider)
 }
 
 // isInferenceWSEndpoint returns true for WebSocket endpoints that should use
@@ -571,9 +587,15 @@ func (m *AuthMiddleware) APIMiddleware() schemas.BifrostHTTPMiddleware {
 		"/api/session/login",
 		"/api/oauth/callback",
 		"/health",
+		"/api/auth/sso/google/login",
+		"/api/auth/sso/google/callback",
+		"/api/auth/sso/saml/login",
+		"/api/auth/sso/saml/acs",
+		"/api/auth/sso/saml/metadata",
 	}
 	whitelistedPrefixes := []string{
 		"/api/oauth/callback",
+		"/api/auth/sso/",
 	}
 	return m.middleware(func(authConfig *configstore.AuthConfig, url string) bool {
 		if slices.Contains(systemWhitelistedRoutes, url) ||
@@ -630,10 +652,13 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 						ticket := string(ctx.Request.URI().QueryArgs().Peek("ticket"))
 						if ticket != "" && m.wsTicketStore != nil {
 							sessionToken := m.wsTicketStore.Consume(ticket)
-							if sessionToken != "" && validateSession(ctx, m.store, sessionToken) {
-								ctx.SetUserValue(schemas.BifrostContextKeySessionToken, sessionToken)
-								next(ctx)
-								return
+							if sessionToken != "" {
+								if session, ok := validateSession(ctx, m.store, sessionToken); ok {
+									ctx.SetUserValue(schemas.BifrostContextKeySessionToken, sessionToken)
+									setUserContext(ctx, m.store, session)
+									next(ctx)
+									return
+								}
 							}
 							SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
 							return
@@ -641,8 +666,9 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 						// Fallback: legacy ?token= param (for backward compatibility)
 						token := string(ctx.Request.URI().QueryArgs().Peek("token"))
 						if token != "" {
-							if validateSession(ctx, m.store, token) {
+							if session, ok := validateSession(ctx, m.store, token); ok {
 								ctx.SetUserValue(schemas.BifrostContextKeySessionToken, token)
+								setUserContext(ctx, m.store, session)
 								next(ctx)
 								return
 							}
@@ -651,10 +677,13 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 						}
 						// Fallback: cookie-based WS auth
 						cookieToken := string(ctx.Request.Header.Cookie("token"))
-						if cookieToken != "" && validateSession(ctx, m.store, cookieToken) {
-							ctx.SetUserValue(schemas.BifrostContextKeySessionToken, cookieToken)
-							next(ctx)
-							return
+						if cookieToken != "" {
+							if session, ok := validateSession(ctx, m.store, cookieToken); ok {
+								ctx.SetUserValue(schemas.BifrostContextKeySessionToken, cookieToken)
+								setUserContext(ctx, m.store, session)
+								next(ctx)
+								return
+							}
 						}
 						SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
 						return
@@ -663,10 +692,13 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 				// Cookie-based auth fallback: if no Authorization header, check for the HTTPOnly session cookie.
 				// This supports the dashboard which relies on cookies instead of localStorage tokens.
 				cookieToken := string(ctx.Request.Header.Cookie("token"))
-				if cookieToken != "" && validateSession(ctx, m.store, cookieToken) {
-					ctx.SetUserValue(schemas.BifrostContextKeySessionToken, cookieToken)
-					next(ctx)
-					return
+				if cookieToken != "" {
+					if session, ok := validateSession(ctx, m.store, cookieToken); ok {
+						ctx.SetUserValue(schemas.BifrostContextKeySessionToken, cookieToken)
+						setUserContext(ctx, m.store, session)
+						next(ctx)
+						return
+					}
 				}
 				SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
 				return
@@ -716,7 +748,8 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 			// Checking bearer auth for dashboard calls
 			if scheme == "Bearer" {
 				// Verify the session
-				if !validateSession(ctx, m.store, token) {
+				session, valid := validateSession(ctx, m.store, token)
+				if !valid {
 					// Here we will check if its the base64 of username:password
 					// This is for backward compatibility with the old auth system
 					decodedBytes, err := base64.StdEncoding.DecodeString(token)
@@ -753,6 +786,7 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 				}
 				// setting up session in the request
 				ctx.SetUserValue(schemas.BifrostContextKeySessionToken, token)
+				setUserContext(ctx, m.store, session)
 				// Continue with the next handler
 				next(ctx)
 				return


### PR DESCRIPTION
## Summary
- Add SSO routes (Google OAuth + SAML) to the auth middleware whitelist so login/callback endpoints bypass authentication
- Add `BifrostContextKeyUserRole` and `BifrostContextKeyAuthProvider` context key constants for SSO user info propagation
- Modify `validateSession` to return the session object, enabling user context extraction after successful validation
- Add `setUserContext` helper that loads user from DB via `GetUserByID` and attaches UserID, Role, and AuthProvider to the request context
- Add `UserID` field to `SessionsTable` for SSO session tracking
- Add `TableUser` struct and `GetUserByID` to ConfigStore interface and RDB implementation

## Test plan
- [x] `go build ./...` passes for core module
- [x] `go vet ./configstore/...` passes for framework module
- [x] All existing auth flows (password login, Basic auth, Bearer token, WS ticket, cookie) are preserved
- [ ] Integration test with SSO login creating a session with UserID and verifying context propagation