### PR TITLE
feat: add users API handler and SSO config validation

### DIFF
--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1120,12 +1120,30 @@ func GeneratePluginHash(p tables.TablePlugin) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
+// GoogleSSOConfig holds configuration for Google SSO authentication.
+type GoogleSSOConfig struct {
+	ClientID     *schemas.EnvVar `json:"client_id"`
+	ClientSecret *schemas.EnvVar `json:"client_secret"`
+}
+
+// SAMLConfig holds configuration for SAML authentication.
+type SAMLConfig struct {
+	MetadataURL    string `json:"metadata_url,omitempty"`
+	IdPSSOURL      string `json:"idp_sso_url,omitempty"`
+	IdPCertificate string `json:"idp_certificate,omitempty"`
+	EntityID       string `json:"entity_id,omitempty"`
+}
+
 // AuthConfig represents configured auth config for Bifrost dashboard
 type AuthConfig struct {
 	AdminUserName          *schemas.EnvVar `json:"admin_username"`
 	AdminPassword          *schemas.EnvVar `json:"admin_password"`
 	IsEnabled              bool            `json:"is_enabled"`
 	DisableAuthOnInference bool            `json:"disable_auth_on_inference"`
+	EnabledMethods         []string        `json:"enabled_methods,omitempty"`
+	GoogleSSOConfig        *GoogleSSOConfig `json:"google_sso_config,omitempty"`
+	SAMLConfig             *SAMLConfig      `json:"saml_config,omitempty"`
+	AllowedDomains         []string        `json:"allowed_domains,omitempty"`
 }
 
 // ConfigMap maps provider names to their configurations.

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3601,3 +3601,87 @@ func (s *RDBConfigStore) GetOauthConfigByTokenID(ctx context.Context, tokenID st
 	}
 	return &config, nil
 }
+
+// GetUserByID retrieves a user by ID.
+func (s *RDBConfigStore) GetUserByID(ctx context.Context, id string) (*tables.TableUser, error) {
+	var user tables.TableUser
+	result := s.db.WithContext(ctx).Where("id = ?", id).First(&user)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("failed to get user by id: %w", result.Error)
+	}
+	return &user, nil
+}
+
+// GetUserByEmail retrieves a user by email.
+func (s *RDBConfigStore) GetUserByEmail(ctx context.Context, email string) (*tables.TableUser, error) {
+	var user tables.TableUser
+	result := s.db.WithContext(ctx).Where("email = ?", email).First(&user)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("failed to get user by email: %w", result.Error)
+	}
+	return &user, nil
+}
+
+// GetUsersPaginated retrieves users with pagination and optional search.
+func (s *RDBConfigStore) GetUsersPaginated(ctx context.Context, params UsersQueryParams) ([]tables.TableUser, int64, error) {
+	baseQuery := s.db.WithContext(ctx).Model(&tables.TableUser{})
+
+	if params.Search != "" {
+		search := "%" + strings.ToLower(params.Search) + "%"
+		baseQuery = baseQuery.Where("LOWER(email) LIKE ? OR LOWER(name) LIKE ?", search, search)
+	}
+
+	var totalCount int64
+	if err := baseQuery.Count(&totalCount).Error; err != nil {
+		return nil, 0, err
+	}
+
+	limit := params.Limit
+	offset := params.Offset
+	if limit <= 0 {
+		limit = 25
+	} else if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var users []tables.TableUser
+	if err := baseQuery.
+		Order("created_at ASC, id ASC").
+		Limit(limit).
+		Offset(offset).
+		Find(&users).Error; err != nil {
+		return nil, 0, err
+	}
+	return users, totalCount, nil
+}
+
+// CreateUser creates a new user.
+func (s *RDBConfigStore) CreateUser(ctx context.Context, user *tables.TableUser) error {
+	return s.db.WithContext(ctx).Create(user).Error
+}
+
+// UpdateUser updates an existing user.
+func (s *RDBConfigStore) UpdateUser(ctx context.Context, user *tables.TableUser) error {
+	return s.db.WithContext(ctx).Save(user).Error
+}
+
+// DeleteUser deletes a user by ID.
+func (s *RDBConfigStore) DeleteUser(ctx context.Context, id string) error {
+	result := s.db.WithContext(ctx).Where("id = ?", id).Delete(&tables.TableUser{})
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete user: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -62,6 +62,13 @@ type CustomersQueryParams struct {
 	Search string
 }
 
+// UsersQueryParams holds pagination, filtering, and search parameters for user queries.
+type UsersQueryParams struct {
+	Limit  int
+	Offset int
+	Search string
+}
+
 // ConfigStore is the interface for the config store.
 type ConfigStore interface {
 	// Health check
@@ -215,6 +222,14 @@ type ConfigStore interface {
 	CreateSession(ctx context.Context, session *tables.SessionsTable) error
 	DeleteSession(ctx context.Context, token string) error
 	FlushSessions(ctx context.Context) error
+
+	// User CRUD
+	GetUserByID(ctx context.Context, id string) (*tables.TableUser, error)
+	GetUserByEmail(ctx context.Context, email string) (*tables.TableUser, error)
+	GetUsersPaginated(ctx context.Context, params UsersQueryParams) ([]tables.TableUser, int64, error)
+	CreateUser(ctx context.Context, user *tables.TableUser) error
+	UpdateUser(ctx context.Context, user *tables.TableUser) error
+	DeleteUser(ctx context.Context, id string) error
 
 	// Model pricing CRUD
 	GetModelPrices(ctx context.Context) ([]tables.TableModelPricing, error)

--- a/framework/configstore/tables/user.go
+++ b/framework/configstore/tables/user.go
@@ -1,0 +1,19 @@
+package tables
+
+import "time"
+
+// TableUser represents a user in the database for SSO and user management.
+type TableUser struct {
+	ID        string    `gorm:"primaryKey;type:varchar(36)" json:"id"`
+	Email     string    `gorm:"type:varchar(255);uniqueIndex;not null" json:"email"`
+	Name      string    `gorm:"type:varchar(255)" json:"name"`
+	Role      string    `gorm:"type:varchar(50);not null;default:'viewer'" json:"role"` // "admin" or "viewer"
+	Provider  string    `gorm:"type:varchar(50)" json:"provider"`                      // "password", "google_sso", "saml"
+	AvatarURL string    `gorm:"type:text" json:"avatar_url,omitempty"`
+	LastLogin *time.Time `gorm:"index" json:"last_login,omitempty"`
+	CreatedAt time.Time `gorm:"index;not null" json:"created_at"`
+	UpdatedAt time.Time `gorm:"index;not null" json:"updated_at"`
+}
+
+// TableName sets the table name for the user model.
+func (TableUser) TableName() string { return "users" }

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -526,6 +526,12 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			}
 		}
 
+		// Validate SSO config fields
+		if err := validateSSOConfig(payload.AuthConfig); err != nil {
+			SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+			return
+		}
+
 		if payload.AuthConfig.IsEnabled {
 			// Initialize nil pointers to empty EnvVar to prevent nil-pointer dereference
 			if payload.AuthConfig.AdminUserName == nil {
@@ -861,6 +867,49 @@ func validateHeaderFilterConfig(config *configstoreTables.GlobalHeaderFilterConf
 
 	if len(foundSecurityHeaders) > 0 {
 		return fmt.Errorf("the following headers are not allowed to be configured: %s. These headers are security headers and are always blocked", strings.Join(foundSecurityHeaders, ", "))
+	}
+
+	return nil
+}
+
+// validateSSOConfig validates SSO-related fields in the auth config.
+func validateSSOConfig(authConfig *configstore.AuthConfig) error {
+	if authConfig == nil {
+		return nil
+	}
+	// Validate enabled methods
+	for _, method := range authConfig.EnabledMethods {
+		switch method {
+		case "password", "google_sso", "saml":
+			// valid
+		default:
+			return fmt.Errorf("invalid auth method: %s", method)
+		}
+	}
+
+	// Validate Google SSO config if enabled
+	if slices.Contains(authConfig.EnabledMethods, "google_sso") {
+		if authConfig.GoogleSSOConfig == nil ||
+			authConfig.GoogleSSOConfig.ClientID == nil ||
+			authConfig.GoogleSSOConfig.ClientID.GetValue() == "" {
+			return fmt.Errorf("Google SSO requires client_id")
+		}
+		if authConfig.GoogleSSOConfig.ClientSecret == nil ||
+			authConfig.GoogleSSOConfig.ClientSecret.GetValue() == "" {
+			return fmt.Errorf("Google SSO requires client_secret")
+		}
+	}
+
+	// Validate SAML config if enabled
+	if slices.Contains(authConfig.EnabledMethods, "saml") {
+		if authConfig.SAMLConfig == nil {
+			return fmt.Errorf("SAML requires configuration")
+		}
+		hasMetadata := authConfig.SAMLConfig.MetadataURL != ""
+		hasManual := authConfig.SAMLConfig.IdPSSOURL != "" && authConfig.SAMLConfig.IdPCertificate != ""
+		if !hasMetadata && !hasManual {
+			return fmt.Errorf("SAML requires either metadata_url or manual IdP configuration (idp_sso_url + idp_certificate)")
+		}
 	}
 
 	return nil

--- a/transports/bifrost-http/handlers/users.go
+++ b/transports/bifrost-http/handlers/users.go
@@ -1,0 +1,206 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/fasthttp/router"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// UsersHandler manages HTTP requests for user management operations.
+type UsersHandler struct {
+	configStore configstore.ConfigStore
+}
+
+// NewUsersHandler creates a new users handler instance.
+func NewUsersHandler(configStore configstore.ConfigStore) *UsersHandler {
+	return &UsersHandler{
+		configStore: configStore,
+	}
+}
+
+// RegisterRoutes registers the user management routes.
+func (h *UsersHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	r.GET("/api/users", lib.ChainMiddlewares(h.listUsers, middlewares...))
+	r.GET("/api/users/me", lib.ChainMiddlewares(h.getCurrentUser, middlewares...))
+	r.GET("/api/users/{id}", lib.ChainMiddlewares(h.getUser, middlewares...))
+	r.PUT("/api/users/{id}/role", lib.ChainMiddlewares(h.updateUserRole, middlewares...))
+	r.DELETE("/api/users/{id}", lib.ChainMiddlewares(h.deleteUser, middlewares...))
+}
+
+// listUsers handles GET /api/users - List users with pagination and optional search.
+func (h *UsersHandler) listUsers(ctx *fasthttp.RequestCtx) {
+	if h.configStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "config store not available")
+		return
+	}
+
+	limit := 25
+	offset := 0
+	if l := string(ctx.QueryArgs().Peek("limit")); l != "" {
+		if i, err := strconv.Atoi(l); err == nil {
+			limit = i
+		}
+	}
+	if o := string(ctx.QueryArgs().Peek("offset")); o != "" {
+		if i, err := strconv.Atoi(o); err == nil {
+			offset = i
+		}
+	}
+	limit, offset = ClampPaginationParams(limit, offset)
+	search := string(ctx.QueryArgs().Peek("search"))
+
+	users, total, err := h.configStore.GetUsersPaginated(ctx, configstore.UsersQueryParams{
+		Limit:  limit,
+		Offset: offset,
+		Search: search,
+	})
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to list users: %v", err))
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"users":  users,
+		"total":  total,
+		"limit":  limit,
+		"offset": offset,
+	})
+}
+
+// getCurrentUser handles GET /api/users/me - Get the currently authenticated user.
+func (h *UsersHandler) getCurrentUser(ctx *fasthttp.RequestCtx) {
+	if h.configStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "config store not available")
+		return
+	}
+
+	userID, _ := ctx.UserValue(schemas.BifrostContextKeyUserID).(string)
+	if userID == "" {
+		// No user ID in context: return a default admin representation
+		SendJSON(ctx, map[string]any{
+			"id":    "admin",
+			"email": "admin",
+			"name":  "Admin",
+			"role":  "admin",
+		})
+		return
+	}
+
+	user, err := h.configStore.GetUserByID(ctx, userID)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "user not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get user: %v", err))
+		return
+	}
+
+	SendJSON(ctx, user)
+}
+
+// getUser handles GET /api/users/{id} - Get a specific user by ID.
+func (h *UsersHandler) getUser(ctx *fasthttp.RequestCtx) {
+	if h.configStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "config store not available")
+		return
+	}
+
+	id, ok := ctx.UserValue("id").(string)
+	if !ok || id == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "user ID is required")
+		return
+	}
+
+	user, err := h.configStore.GetUserByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "user not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get user: %v", err))
+		return
+	}
+
+	SendJSON(ctx, user)
+}
+
+// updateUserRole handles PUT /api/users/{id}/role - Update a user's role.
+func (h *UsersHandler) updateUserRole(ctx *fasthttp.RequestCtx) {
+	if h.configStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "config store not available")
+		return
+	}
+
+	id, ok := ctx.UserValue("id").(string)
+	if !ok || id == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "user ID is required")
+		return
+	}
+
+	payload := struct {
+		Role string `json:"role"`
+	}{}
+	if err := json.Unmarshal(ctx.PostBody(), &payload); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("invalid request format: %v", err))
+		return
+	}
+
+	if payload.Role != "admin" && payload.Role != "viewer" {
+		SendError(ctx, fasthttp.StatusBadRequest, "role must be 'admin' or 'viewer'")
+		return
+	}
+
+	user, err := h.configStore.GetUserByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "user not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get user: %v", err))
+		return
+	}
+
+	user.Role = payload.Role
+	if err := h.configStore.UpdateUser(ctx, user); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to update user role: %v", err))
+		return
+	}
+
+	SendJSON(ctx, user)
+}
+
+// deleteUser handles DELETE /api/users/{id} - Delete a user.
+func (h *UsersHandler) deleteUser(ctx *fasthttp.RequestCtx) {
+	if h.configStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "config store not available")
+		return
+	}
+
+	id, ok := ctx.UserValue("id").(string)
+	if !ok || id == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "user ID is required")
+		return
+	}
+
+	if err := h.configStore.DeleteUser(ctx, id); err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "user not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to delete user: %v", err))
+		return
+	}
+
+	SendJSON(ctx, map[string]any{
+		"status":  "success",
+		"message": "user deleted successfully",
+	})
+}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1025,6 +1025,7 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	pluginsHandler := handlers.NewPluginsHandler(callbacks, s.Config.ConfigStore)
 	sessionHandler := handlers.NewSessionHandler(s.Config.ConfigStore, s.WSTicketStore)
 	promptsHandler := handlers.NewPromptsHandler(s.Config.ConfigStore)
+	usersHandler := handlers.NewUsersHandler(s.Config.ConfigStore)
 	// Going ahead with API handlers
 	healthHandler.RegisterRoutes(s.Router, middlewares...)
 	providerHandler.RegisterRoutes(s.Router, middlewares...)
@@ -1039,6 +1040,9 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	}
 	if promptsHandler != nil {
 		promptsHandler.RegisterRoutes(s.Router, middlewares...)
+	}
+	if usersHandler != nil {
+		usersHandler.RegisterRoutes(s.Router, middlewares...)
 	}
 	if cacheHandler != nil {
 		cacheHandler.RegisterRoutes(s.Router, middlewares...)


### PR DESCRIPTION
## Summary
- Add REST endpoints for user management (`/api/users`, `/api/users/me`, `/api/users/{id}`, `/api/users/{id}/role`) with list, get, update role, and delete operations
- Add SSO configuration validation in the config handler: validates `enabled_methods`, requires Google SSO `client_id`/`client_secret` when `google_sso` is enabled, and requires SAML `metadata_url` or manual IdP config when `saml` is enabled
- Add `TableUser` model, `UsersQueryParams`, and user CRUD methods to the `ConfigStore` interface and RDB implementation
- Extend `AuthConfig` with `EnabledMethods`, `GoogleSSOConfig`, `SAMLConfig`, and `AllowedDomains` fields

## Test plan
- [ ] Verify `framework/configstore` builds cleanly (`go build ./configstore/...`)
- [ ] Verify SSO validation rejects invalid auth methods, missing Google SSO credentials, and missing SAML config
- [ ] Verify users API endpoints return proper error responses when config store is unavailable
- [ ] Verify user role update validates role is "admin" or "viewer"
- [ ] Integration test: full user CRUD lifecycle with a running server and database