### PR TITLE
fix race in data reading from fasthttp req for integrations

### DIFF
--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2291,9 +2291,10 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 
 	// Producer goroutine: processes the stream channel, formats events, sends to reader
 	go func() {
+		// Separate defers ensure each cleanup runs even if an earlier one panics (LIFO order)
+		defer reader.Done()
+		defer schemas.ReleaseHTTPRequest(httpReq)
 		defer func() {
-			schemas.ReleaseHTTPRequest(httpReq)
-			reader.Done()
 			// Complete the trace after streaming finishes
 			// This ensures all spans (including llm.call) are properly ended before the trace is sent to OTEL
 			if traceCompleter != nil {


### PR DESCRIPTION
## Summary

Fixed the order of cleanup operations in the streaming handler's defer block to ensure trace completion happens before releasing HTTP requests and marking the reader as done.

## Issues

closes #2511

## Changes

- Moved trace completion (`traceCompleter()`) to execute before `schemas.ReleaseHTTPRequest(httpReq)` and `reader.Done()`
- This ensures all spans (including llm.call) are properly ended before the trace is sent to OTEL

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test streaming endpoints to verify traces are properly completed and sent to OTEL without timing issues.

```sh
# Core/Transports
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is an internal cleanup order fix.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable