### PR TITLE
fix(cli): add actionable Codex hint when model list is empty

### DIFF
--- a/cli/internal/ui/tui/chooser.go
+++ b/cli/internal/ui/tui/chooser.go
@@ -572,7 +572,7 @@ func (m chooserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.models = msg.models
 			if len(m.models) == 0 {
-				m.loadErr = "no models found \u2014 type a model name manually"
+				m.loadErr = m.emptyModelsMessage()
 				m.notify(m.loadErr, false)
 			}
 		}
@@ -949,6 +949,15 @@ func (m chooserModel) currentHarness() HarnessOption {
 		return m.cfg.Harnesses[len(m.cfg.Harnesses)-1]
 	}
 	return m.cfg.Harnesses[m.harnessIdx]
+}
+
+func (m chooserModel) emptyModelsMessage() string {
+	harness := strings.ToLower(strings.TrimSpace(m.currentHarness().ID))
+	if harness == "codex" {
+		return "no models found — Codex may still be using native auth/config; run /logout, point ~/.codex/config.toml to Bifrost, and relaunch Codex in the same shell"
+	}
+
+	return "no models found — type a model name manually"
 }
 
 // currentModel returns the currently selected model name from the visible

--- a/cli/internal/ui/tui/chooser_test.go
+++ b/cli/internal/ui/tui/chooser_test.go
@@ -70,3 +70,21 @@ func TestChooserUpdateShortcutRequestsUpdate(t *testing.T) {
 		t.Fatal("expected y to request update when update is available")
 	}
 }
+
+func TestEmptyModelsMessageForCodexShowsConfigHint(t *testing.T) {
+	m := newChooserModel(ChooserConfig{
+		Harnesses: []HarnessOption{{ID: "codex", Label: "Codex CLI", Installed: true}},
+	})
+	m.phase = phaseModel
+	m.harnessIdx = 0
+
+	next, _ := m.Update(modelsMsg{models: nil, err: nil})
+	got := next.(chooserModel)
+
+	if !strings.Contains(got.loadErr, "Codex") {
+		t.Fatalf("expected codex-specific hint, got %q", got.loadErr)
+	}
+	if !strings.Contains(got.loadErr, "config.toml") {
+		t.Fatalf("expected config.toml hint, got %q", got.loadErr)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Codex-specific empty-state message when model discovery returns no models
- keep the existing generic empty-state message for other harnesses
- add a regression test covering the Codex empty-model path

## Why
In Codex setup, users can reach model selection with an empty list and no clear next step. This adds an explicit hint to logout/reconfigure Codex so setup is recoverable.

## Testing
- cd cli
- go test ./internal/ui/tui -run 'Test(EmptyModelsMessageForCodexShowsConfigHint|ChooserUpdateShortcutRequestsUpdate)$'

Closes #2514

Greetings, saschabuehrle