### PR TITLE
fix: vertex endpoint correction

### DIFF
--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -1377,9 +1377,14 @@ func (provider *VertexProvider) Embedding(ctx *schemas.BifrostContext, key schem
 		return nil, bifrostErr
 	}
 
+	// For custom/fine-tuned models, validate projectNumber is set
+	projectNumber := key.VertexKeyConfig.ProjectNumber.GetValue()
+	if schemas.IsAllDigitsASCII(request.Model) && projectNumber == "" {
+		return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
+	}
+
 	// Build the native Vertex embedding API endpoint
-	url := fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:predict",
-		region, projectID, region, request.Model)
+	url := getCompleteURLForGeminiEndpoint(request.Model, region, projectID, projectNumber, ":predict")
 
 	// Create HTTP request for streaming
 	req := fasthttp.AcquireRequest()


### PR DESCRIPTION
## Summary

Adds validation for project number configuration when using fine-tuned models in the Vertex AI embedding provider and refactors URL construction to use a centralized helper function.  
  
fixes #2496

## Changes

- Added validation to ensure `projectNumber` is configured when using custom/fine-tuned models (identified by all-digit model names)
- Replaced inline URL construction with `getCompleteURLForGeminiEndpoint` helper function for consistency
- Returns a configuration error when project number is missing for fine-tuned models

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test with fine-tuned models to ensure proper validation:

```sh
# Test with missing project number for fine-tuned model
# Should return configuration error

# Test with valid project number for fine-tuned model
# Should proceed normally

# Test with standard models (non-numeric names)
# Should work without project number requirement

go test ./core/providers/vertex/...
```

Ensure the `projectNumber` configuration is set in your Vertex AI key config when using fine-tuned models.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change improves configuration validation to prevent runtime errors when using fine-tuned models without proper project number configuration.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable