### PR TITLE
fix: preserve routing rule targets for genai and bedrock paths

### DIFF
--- a/plugins/governance/allow_on_all_virtual_keys_test.go
+++ b/plugins/governance/allow_on_all_virtual_keys_test.go
@@ -11,11 +11,12 @@ import (
 
 // mockInMemoryStore is a test double for InMemoryStore.
 type mockInMemoryStore struct {
-	allowAllClients map[string]string // clientID → clientName
+	allowAllClients     map[string]string // clientID → clientName
+	configuredProviders map[schemas.ModelProvider]configstore.ProviderConfig
 }
 
 func (m *mockInMemoryStore) GetConfiguredProviders() map[schemas.ModelProvider]configstore.ProviderConfig {
-	return nil
+	return m.configuredProviders
 }
 
 func (m *mockInMemoryStore) GetMCPClientsAllowingAllVirtualKeys() map[string]string {

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,0 +1,1 @@
+- fix: preseve routing rule targets for genai and bedrock paths for vk level provider load balancing

--- a/plugins/governance/http_transport_prehook_test.go
+++ b/plugins/governance/http_transport_prehook_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -62,4 +63,307 @@ func TestHTTPTransportPreHook_VirtualKeyReplicateRefinesNestedModel(t *testing.T
 	}
 	require.NoError(t, json.Unmarshal(req.Body, &payload))
 	require.Equal(t, "replicate/openai/gpt-5-nano", payload.Model)
+}
+
+// TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget verifies that when a routing rule
+// matches on the /genai path, governance load balancing does not override the routing-rule target
+// with a provider from the VK pool (regression test for issue #2516).
+func TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget(t *testing.T) {
+	logger := NewMockLogger()
+
+	routingRule := configstoreTables.TableRoutingRule{
+		ID:            "rule-genai-1",
+		Name:          "genai-repro-rule",
+		Enabled:       true,
+		CelExpression: `model == "probe-genai-model" && provider == ""`,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{
+				RuleID:   "rule-genai-1",
+				Provider: bifrost.Ptr("repro-openai-a"),
+				Model:    bifrost.Ptr("error-test"),
+				Weight:   1.0,
+			},
+		},
+		Scope:    "global",
+		Priority: 1,
+	}
+
+	// VK with repro-openai-b at weight=1 — this is what governance LB would wrongly select without the fix
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-genai",
+		"sk-bf-genai-test",
+		"genai-repro-vk",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("repro-openai-b", []string{"*"}),
+		},
+	)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*virtualKey},
+		RoutingRules: []configstoreTables.TableRoutingRule{routingRule},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/genai/v1beta/models/probe-genai-model:generateContent"
+	req.PathParams["model"] = "probe-genai-model:generateContent"
+	req.Headers["Authorization"] = "Bearer sk-bf-genai-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	// Routing rule matched and set context model to "repro-openai-a/error-test:generateContent".
+	// Governance LB must NOT override this with "repro-openai-b/probe-genai-model:generateContent".
+	ctxModel, ok := bfCtx.Value("model").(string)
+	require.True(t, ok, "context model should be set")
+	require.Equal(t, "repro-openai-a/error-test:generateContent", ctxModel)
+}
+
+// TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget_WithStore is a production-like variant
+// of TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget that passes a non-nil inMemoryStore
+// containing the routing-rule provider, confirming the fix holds when p.inMemoryStore != nil
+// and the provider IS present in GetConfiguredProviders (the normal production code path).
+func TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget_WithStore(t *testing.T) {
+	logger := NewMockLogger()
+
+	routingRule := configstoreTables.TableRoutingRule{
+		ID:            "rule-genai-ws-1",
+		Name:          "genai-repro-rule-with-store",
+		Enabled:       true,
+		CelExpression: `model == "probe-genai-model" && provider == ""`,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{
+				RuleID:   "rule-genai-ws-1",
+				Provider: bifrost.Ptr("repro-openai-a"),
+				Model:    bifrost.Ptr("error-test"),
+				Weight:   1.0,
+			},
+		},
+		Scope:    "global",
+		Priority: 1,
+	}
+
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-genai-ws",
+		"sk-bf-genai-ws-test",
+		"genai-repro-vk-with-store",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("repro-openai-b", []string{"*"}),
+		},
+	)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*virtualKey},
+		RoutingRules: []configstoreTables.TableRoutingRule{routingRule},
+	}, nil)
+	require.NoError(t, err)
+
+	// Register the fake provider so ParseModelString can split "repro-openai-a/model"
+	// the same way it would for a real provider in production.
+	schemas.RegisterKnownProvider("repro-openai-a")
+	t.Cleanup(func() { schemas.UnregisterKnownProvider("repro-openai-a") })
+
+	// Use a non-nil inMemoryStore that recognises the routing-rule provider,
+	// mirroring production where configured providers are always registered in the store.
+	inMemStore := &mockInMemoryStore{
+		configuredProviders: map[schemas.ModelProvider]configstore.ProviderConfig{
+			"repro-openai-a": {},
+		},
+	}
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, inMemStore)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/genai/v1beta/models/probe-genai-model:generateContent"
+	req.PathParams["model"] = "probe-genai-model:generateContent"
+	req.Headers["Authorization"] = "Bearer sk-bf-genai-ws-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	ctxModel, ok := bfCtx.Value("model").(string)
+	require.True(t, ok, "context model should be set")
+	require.Equal(t, "repro-openai-a/error-test:generateContent", ctxModel)
+}
+
+// TestHTTPTransportPreHook_GenAINoRoutingRuleStillLoadBalances verifies that when no routing rule
+// matches on the /genai path, governance load balancing still selects a provider from the VK pool.
+func TestHTTPTransportPreHook_GenAINoRoutingRuleStillLoadBalances(t *testing.T) {
+	logger := NewMockLogger()
+
+	// VK with repro-openai-b at weight=1 — LB should select this
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-genai-lb",
+		"sk-bf-genai-lb-test",
+		"genai-lb-vk",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("repro-openai-b", []string{"*"}),
+		},
+	)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*virtualKey},
+		// No routing rules — governance LB should run normally
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/genai/v1beta/models/probe-genai-model:generateContent"
+	req.PathParams["model"] = "probe-genai-model:generateContent"
+	req.Headers["Authorization"] = "Bearer sk-bf-genai-lb-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	// No routing rule: governance LB must still run and select repro-openai-b from the VK pool
+	ctxModel, ok := bfCtx.Value("model").(string)
+	require.True(t, ok, "context model should be set by governance LB")
+	require.Equal(t, "repro-openai-b/probe-genai-model:generateContent", ctxModel)
+}
+
+// TestHTTPTransportPreHook_BedrockRoutingRulePreservesTarget verifies that when a routing rule
+// matches on the /bedrock path, governance load balancing does not override the routing-rule target
+// (regression test mirroring the GenAI fix for the Bedrock integration).
+func TestHTTPTransportPreHook_BedrockRoutingRulePreservesTarget(t *testing.T) {
+	logger := NewMockLogger()
+
+	routingRule := configstoreTables.TableRoutingRule{
+		ID:            "rule-bedrock-1",
+		Name:          "bedrock-repro-rule",
+		Enabled:       true,
+		CelExpression: `model == "probe-bedrock-model" && provider == ""`,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{
+				RuleID:   "rule-bedrock-1",
+				Provider: bifrost.Ptr("repro-openai-a"),
+				Model:    bifrost.Ptr("error-test"),
+				Weight:   1.0,
+			},
+		},
+		Scope:    "global",
+		Priority: 1,
+	}
+
+	// VK with repro-openai-b at weight=1 — this is what governance LB would wrongly select without the fix
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-bedrock",
+		"sk-bf-bedrock-test",
+		"bedrock-repro-vk",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("repro-openai-b", []string{"*"}),
+		},
+	)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*virtualKey},
+		RoutingRules: []configstoreTables.TableRoutingRule{routingRule},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/bedrock/model/probe-bedrock-model/converse"
+	req.PathParams["modelId"] = "probe-bedrock-model"
+	req.Headers["Authorization"] = "Bearer sk-bf-bedrock-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	// Routing rule matched and set context modelId to "repro-openai-a/error-test".
+	// Governance LB must NOT override this with "repro-openai-b/probe-bedrock-model".
+	ctxModelID, ok := bfCtx.Value("modelId").(string)
+	require.True(t, ok, "context modelId should be set")
+	require.Equal(t, "repro-openai-a/error-test", ctxModelID)
+}
+
+// TestHTTPTransportPreHook_BedrockNoRoutingRuleStillLoadBalances verifies that when no routing rule
+// matches on the /bedrock path, governance load balancing still selects a provider from the VK pool.
+func TestHTTPTransportPreHook_BedrockNoRoutingRuleStillLoadBalances(t *testing.T) {
+	logger := NewMockLogger()
+
+	// VK with repro-openai-b at weight=1 — LB should select this
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-bedrock-lb",
+		"sk-bf-bedrock-lb-test",
+		"bedrock-lb-vk",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("repro-openai-b", []string{"*"}),
+		},
+	)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*virtualKey},
+		// No routing rules — governance LB should run normally
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/bedrock/model/probe-bedrock-model/converse"
+	req.PathParams["modelId"] = "probe-bedrock-model"
+	req.Headers["Authorization"] = "Bearer sk-bf-bedrock-lb-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	// No routing rule: governance LB must still run and select repro-openai-b from the VK pool
+	ctxModelID, ok := bfCtx.Value("modelId").(string)
+	require.True(t, ok, "context modelId should be set by governance LB")
+	require.Equal(t, "repro-openai-b/probe-bedrock-model", ctxModelID)
 }

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -551,19 +551,29 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 	if !hasModel {
 		// For genai integration, model is present in URL path instead of the request body
 		if isGeminiPath {
-			modelValue = req.CaseInsensitivePathParamLookup("model")
+			// Prefer context value set by a routing rule (format: "provider/model:suffix")
+			if ctxModel, ok := ctx.Value("model").(string); ok && ctxModel != "" {
+				modelValue = ctxModel
+			} else {
+				modelValue = req.CaseInsensitivePathParamLookup("model")
+			}
 		} else if isBedrockPath {
 			// For bedrock integration, model is present in URL path as modelId
-			rawModelID := req.CaseInsensitivePathParamLookup("modelId")
-			if rawModelID == "" {
-				return body, nil
+			// Prefer context value set by a routing rule (format: "provider/model")
+			if ctxModelID, ok := ctx.Value("modelId").(string); ok && ctxModelID != "" {
+				modelValue = ctxModelID
+			} else {
+				rawModelID := req.CaseInsensitivePathParamLookup("modelId")
+				if rawModelID == "" {
+					return body, nil
+				}
+				// URL-decode the modelId (Bedrock model IDs may be URL-encoded, e.g. anthropic%2Fclaude-3-5-sonnet)
+				decoded, err := url.PathUnescape(rawModelID)
+				if err != nil {
+					decoded = rawModelID
+				}
+				modelValue = decoded
 			}
-			// URL-decode the modelId (Bedrock model IDs may be URL-encoded, e.g. anthropic%2Fclaude-3-5-sonnet)
-			decoded, err := url.PathUnescape(rawModelID)
-			if err != nil {
-				decoded = rawModelID
-			}
-			modelValue = decoded
 		} else {
 			return body, nil
 		}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,6 +1,7 @@
 - feat: add support for chaining routing rules
 - feat: add routing tree UI to better visualize routing rules
 - feat: add model alias — keys now support a top-level `aliases` field mapping any model name to a provider-specific identifier (Azure deployment names, Bedrock inference profile ARNs, Vertex endpoints, Replicate model slugs, fine-tuned model IDs, etc.). The original model name is preserved and returned alongside the resolved identifier in every response. Breaking changes: see below.
+- fix: preseve routing rule targets for genai and bedrock paths for vk level provider load balancing
 
 <Warning>
 **This release contains 4 breaking changes** related to model aliasing. See the [v1.5.0 Migration Guide](/migration-guides/v1.5.0#breaking-change-9-provider-deployments-removed-migrate-to-aliases) for full before/after examples and migration instructions.


### PR DESCRIPTION
## Summary

Fixes a regression where routing rule targets were being overridden by virtual key level provider load balancing for GenAI and Bedrock API paths. When a routing rule matched and set a specific provider/model target, the governance load balancer would incorrectly replace it with a provider from the virtual key pool.

## Changes

- Modified `loadBalanceProvider` to check for existing context values set by routing rules before falling back to path parameter extraction for GenAI and Bedrock paths
- For GenAI paths: prioritize `ctx.Value("model")` over `req.CaseInsensitivePathParamLookup("model")`
- For Bedrock paths: prioritize `ctx.Value("modelId")` over `req.CaseInsensitivePathParamLookup("modelId")`
- Added comprehensive test coverage for both scenarios: when routing rules should preserve targets and when load balancing should still occur

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate that routing rules work correctly with GenAI and Bedrock paths:

```sh
# Run governance plugin tests
go test ./plugins/governance/... -v

# Specifically test the new routing rule preservation logic
go test ./plugins/governance/ -run TestHTTPTransportPreHook_GenAI -v
```

Test scenarios:
1. Create a routing rule targeting GenAI/Bedrock paths with a specific provider
2. Verify the routing rule target is preserved and not overridden by VK load balancing
3. Verify that when no routing rule matches, load balancing still functions normally

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes issue #2516

## Security considerations

No security implications - this is a routing logic fix that preserves existing authentication and authorization flows.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable