### PR TITLE
fix: disable SQLite foreign key checks during migration

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -5910,6 +5910,15 @@ func migrationAddMultiBudgetTables(ctx context.Context, db *gorm.DB) error {
 			return nil
 		},
 	}})
+	// SQLite workaround: GORM's CreateConstraint rebuilds the table via DROP+RENAME
+	// inside a transaction. The DROP fails when other tables have FKs pointing at the
+	// target table and foreign_keys is ON. PRAGMA foreign_keys cannot be changed inside
+	// a transaction, so we disable it before the migrator opens its transaction.
+	// This only affects SQLite — Postgres supports ALTER TABLE ADD CONSTRAINT natively.
+	if db.Dialector.Name() == "sqlite" {
+		db.Exec("PRAGMA foreign_keys = OFF")
+		defer db.Exec("PRAGMA foreign_keys = ON")
+	}
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_multi_budget_tables migration: %s", err.Error())
 	}


### PR DESCRIPTION
## Summary

Fixes SQLite foreign key constraint errors during the multi-budget tables
migration by temporarily disabling foreign key checks for SQLite databases only.

## Changes

- Added SQLite-specific workaround in `migrationAddMultiBudgetTables` to disable
  foreign keys before migration and re-enable them after
- The fix addresses GORM's table rebuilding process (DROP+RENAME) which fails
  when foreign key constraints are enabled and other tables reference the target
  table
- Only affects SQLite databases as Postgres supports
  `ALTER TABLE ADD CONSTRAINT` natively

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the migration on a SQLite database with existing foreign key relationships
to verify the constraint creation succeeds.

```sh
# Core/Transports
go version
go test ./...
```

Test specifically with SQLite databases that have foreign key constraints
pointing to tables being modified in the migration.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The change temporarily disables foreign key enforcement during migration (only
in case of SQLite), but this is restored immediately after completion and only
affects the migration process itself.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

