### PR TITLE
test: add v1.5.0-prerelease1 migration coverage and handle dropped columns

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -133,11 +133,15 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Get previous N transport versions (excluding prereleases)
+# Get previous N transport versions (excluding prereleases) plus explicitly tested prereleases
 get_previous_versions() {
   local count="${1:-3}"
   cd "$REPO_ROOT"
-  git tag -l "transports/v*" | grep -v -- "-" | sort -V | tail -n "$count" | sed 's|transports/||'
+  local stable
+  stable=$(git tag -l "transports/v*" | grep -v -- "-" | sort -V | tail -n "$count" | sed 's|transports/||')
+  # Explicitly include prerelease versions that need migration coverage
+  local prereleases="v1.5.0-prerelease1"
+  echo "$stable"$'\n'"$prereleases" | grep -v '^$' | sort -V | uniq
 }
 
 # Wait for bifrost to start
@@ -837,6 +841,16 @@ append_dynamic_columns_postgres() {
     echo "UPDATE config_keys SET vllm_model_name = '' WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
   fi
 
+  # config_keys.ollama_url, sgl_url (added in v1.5.0-prerelease1)
+  if column_exists_postgres "config_keys" "ollama_url"; then
+    echo "UPDATE config_keys SET ollama_url = '' WHERE name = 'migration-test-key-openai';" >> "$output_file"
+    echo "UPDATE config_keys SET ollama_url = '' WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+  fi
+  if column_exists_postgres "config_keys" "sgl_url"; then
+    echo "UPDATE config_keys SET sgl_url = '' WHERE name = 'migration-test-key-openai';" >> "$output_file"
+    echo "UPDATE config_keys SET sgl_url = '' WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+  fi
+
   # config_keys.encryption_status (added in v1.4.8)
   if column_exists_postgres "config_keys" "encryption_status"; then
     echo "UPDATE config_keys SET encryption_status = 'plain_text' WHERE name = 'migration-test-key-openai';" >> "$output_file"
@@ -963,6 +977,17 @@ append_dynamic_columns_postgres() {
     echo "UPDATE logs SET video_download_output = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
     echo "UPDATE logs SET video_download_output = '' WHERE id = 'log-migration-test-002';" >> "$output_file"
     echo "UPDATE logs SET video_download_output = '' WHERE id = 'log-migration-test-003';" >> "$output_file"
+  fi
+  # logs.image_edit_input, image_variation_input (added in v1.5.0-prerelease1)
+  if column_exists_postgres "logs" "image_edit_input"; then
+    echo "UPDATE logs SET image_edit_input = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
+    echo "UPDATE logs SET image_edit_input = '' WHERE id = 'log-migration-test-002';" >> "$output_file"
+    echo "UPDATE logs SET image_edit_input = '' WHERE id = 'log-migration-test-003';" >> "$output_file"
+  fi
+  if column_exists_postgres "logs" "image_variation_input"; then
+    echo "UPDATE logs SET image_variation_input = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
+    echo "UPDATE logs SET image_variation_input = '' WHERE id = 'log-migration-test-002';" >> "$output_file"
+    echo "UPDATE logs SET image_variation_input = '' WHERE id = 'log-migration-test-003';" >> "$output_file"
   fi
   if column_exists_postgres "logs" "video_list_output"; then
     echo "UPDATE logs SET video_list_output = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
@@ -1375,6 +1400,16 @@ append_dynamic_columns_sqlite() {
       echo "UPDATE config_keys SET vllm_model_name = '' WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
     fi
 
+    # config_keys.ollama_url, sgl_url (added in v1.5.0-prerelease1)
+    if column_exists_sqlite "$config_db" "config_keys" "ollama_url"; then
+      echo "UPDATE config_keys SET ollama_url = '' WHERE name = 'migration-test-key-openai';" >> "$output_file"
+      echo "UPDATE config_keys SET ollama_url = '' WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+    fi
+    if column_exists_sqlite "$config_db" "config_keys" "sgl_url"; then
+      echo "UPDATE config_keys SET sgl_url = '' WHERE name = 'migration-test-key-openai';" >> "$output_file"
+      echo "UPDATE config_keys SET sgl_url = '' WHERE name = 'migration-test-key-anthropic';" >> "$output_file"
+    fi
+
     # config_keys.encryption_status (added in v1.4.8)
     if column_exists_sqlite "$config_db" "config_keys" "encryption_status"; then
       echo "UPDATE config_keys SET encryption_status = 'plain_text' WHERE name = 'migration-test-key-openai';" >> "$output_file"
@@ -1493,6 +1528,17 @@ append_dynamic_columns_sqlite() {
   echo "UPDATE logs SET video_download_output = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
   echo "UPDATE logs SET video_download_output = '' WHERE id = 'log-migration-test-002';" >> "$output_file"
   echo "UPDATE logs SET video_download_output = '' WHERE id = 'log-migration-test-003';" >> "$output_file"
+  # logs.image_edit_input, image_variation_input (added in v1.5.0-prerelease1)
+  if column_exists_sqlite "$logs_db" "logs" "image_edit_input"; then
+    echo "UPDATE logs SET image_edit_input = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
+    echo "UPDATE logs SET image_edit_input = '' WHERE id = 'log-migration-test-002';" >> "$output_file"
+    echo "UPDATE logs SET image_edit_input = '' WHERE id = 'log-migration-test-003';" >> "$output_file"
+  fi
+  if column_exists_sqlite "$logs_db" "logs" "image_variation_input"; then
+    echo "UPDATE logs SET image_variation_input = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
+    echo "UPDATE logs SET image_variation_input = '' WHERE id = 'log-migration-test-002';" >> "$output_file"
+    echo "UPDATE logs SET image_variation_input = '' WHERE id = 'log-migration-test-003';" >> "$output_file"
+  fi
   echo "UPDATE logs SET video_list_output = '' WHERE id = 'log-migration-test-001';" >> "$output_file"
   echo "UPDATE logs SET video_list_output = '' WHERE id = 'log-migration-test-002';" >> "$output_file"
   echo "UPDATE logs SET video_list_output = '' WHERE id = 'log-migration-test-003';" >> "$output_file"
@@ -2677,6 +2723,20 @@ compare_postgres_snapshots() {
     # provider, model (dropped from routing_rules only in v1.4.12)
     if [ "$table" = "routing_rules" ]; then
       dropped_columns="$dropped_columns provider model"
+    fi
+    # azure_deployments_json, vertex_deployments_json, bedrock_deployments_json, replicate_deployments_json
+    # (dropped from config_keys - migrated to provider-level deployment config)
+    if [ "$table" = "config_keys" ]; then
+      dropped_columns="$dropped_columns azure_deployments_json vertex_deployments_json bedrock_deployments_json replicate_deployments_json"
+    fi
+    # budget_id (dropped from governance_virtual_keys and governance_virtual_key_provider_configs
+    # in add_multi_budget_tables - ownership moved to governance_budgets.virtual_key_id/provider_config_id)
+    if [ "$table" = "governance_virtual_keys" ] || [ "$table" = "governance_virtual_key_provider_configs" ]; then
+      dropped_columns="$dropped_columns budget_id"
+    fi
+    # calendar_aligned (dropped from governance_budgets in add_multi_budget_tables - moved to governance_virtual_keys.calendar_aligned)
+    if [ "$table" = "governance_budgets" ]; then
+      dropped_columns="$dropped_columns calendar_aligned"
     fi
     
     local before_col_array

--- a/core/providers/utils/models.go
+++ b/core/providers/utils/models.go
@@ -155,13 +155,15 @@ type aliasMatch struct {
 	value string
 }
 
-// resolveModelID returns all alias entries whose VALUE matches modelID using the pipeline's MatchFns.
+// resolveModelID returns all alias entries whose VALUE matches modelID using the pipeline's MatchFns,
+// plus the raw model ID itself as an additional entry so both the alias key and the original model
+// name appear in the list-models output.
 // Results are sorted by alias key (case-insensitive) for deterministic ordering.
 //
-// If one or more aliases match → returns one aliasMatch per matching alias key.
+// If one or more aliases match → returns one aliasMatch per matching alias key, plus the raw ID.
 //
 //	Example: modelID="gpt-4-turbo", aliases={"my-gpt4":"gpt-4-turbo","gpt4-alias":"gpt-4-turbo"}
-//	  → [{key:"gpt4-alias", value:"gpt-4-turbo"}, {key:"my-gpt4", value:"gpt-4-turbo"}]
+//	  → [{key:"gpt-4-turbo", value:""}, {key:"gpt4-alias", value:"gpt-4-turbo"}, {key:"my-gpt4", value:"gpt-4-turbo"}]
 //
 // If no alias matches → returns a single entry with the original model ID and no alias value.
 //
@@ -177,6 +179,8 @@ func (p *ListModelsPipeline) resolveModelID(modelID string) []aliasMatch {
 	if len(candidates) == 0 {
 		return []aliasMatch{{key: modelID, value: ""}}
 	}
+	// Also include the raw model ID so both the alias key and the original name appear in output.
+	candidates = append(candidates, aliasMatch{key: modelID, value: ""})
 	sort.Slice(candidates, func(i, j int) bool {
 		return strings.ToLower(candidates[i].key) < strings.ToLower(candidates[j].key)
 	})
@@ -206,8 +210,9 @@ func (p *ListModelsPipeline) resolveModelID(modelID string) []aliasMatch {
 //	  FilterModel("gpt-3.5")     → []  (not in allowlist)
 //
 //	allowedModels=*, aliases={"my-gpt4":"gpt-4-turbo","gpt4-alias":"gpt-4-turbo"}, blacklist=[]
-//	  FilterModel("gpt-4-turbo") → [{ResolvedID:"gpt4-alias", AliasValue:"gpt-4-turbo"},
-//	                                {ResolvedID:"my-gpt4",    AliasValue:"gpt-4-turbo"}]
+//	  FilterModel("gpt-4-turbo") → [{ResolvedID:"gpt-4-turbo", AliasValue:""},
+//	                                {ResolvedID:"gpt4-alias",  AliasValue:"gpt-4-turbo"},
+//	                                {ResolvedID:"my-gpt4",     AliasValue:"gpt-4-turbo"}]
 //
 //	allowedModels=["gpt-3.5"], aliases={}, blacklist=[]
 //	  FilterModel("gpt-3.5")     → [{ResolvedID:"gpt-3.5", AliasValue:""}]

--- a/plugins/governance/allow_on_all_virtual_keys_test.go
+++ b/plugins/governance/allow_on_all_virtual_keys_test.go
@@ -11,11 +11,12 @@ import (
 
 // mockInMemoryStore is a test double for InMemoryStore.
 type mockInMemoryStore struct {
-	allowAllClients map[string]string // clientID → clientName
+	allowAllClients     map[string]string // clientID → clientName
+	configuredProviders map[schemas.ModelProvider]configstore.ProviderConfig
 }
 
 func (m *mockInMemoryStore) GetConfiguredProviders() map[schemas.ModelProvider]configstore.ProviderConfig {
-	return nil
+	return m.configuredProviders
 }
 
 func (m *mockInMemoryStore) GetMCPClientsAllowingAllVirtualKeys() map[string]string {

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,0 +1,1 @@
+- fix: preseve routing rule targets for genai and bedrock paths for vk level provider load balancing

--- a/plugins/governance/http_transport_prehook_test.go
+++ b/plugins/governance/http_transport_prehook_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -62,4 +63,307 @@ func TestHTTPTransportPreHook_VirtualKeyReplicateRefinesNestedModel(t *testing.T
 	}
 	require.NoError(t, json.Unmarshal(req.Body, &payload))
 	require.Equal(t, "replicate/openai/gpt-5-nano", payload.Model)
+}
+
+// TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget verifies that when a routing rule
+// matches on the /genai path, governance load balancing does not override the routing-rule target
+// with a provider from the VK pool (regression test for issue #2516).
+func TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget(t *testing.T) {
+	logger := NewMockLogger()
+
+	routingRule := configstoreTables.TableRoutingRule{
+		ID:            "rule-genai-1",
+		Name:          "genai-repro-rule",
+		Enabled:       true,
+		CelExpression: `model == "probe-genai-model" && provider == ""`,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{
+				RuleID:   "rule-genai-1",
+				Provider: bifrost.Ptr("repro-openai-a"),
+				Model:    bifrost.Ptr("error-test"),
+				Weight:   1.0,
+			},
+		},
+		Scope:    "global",
+		Priority: 1,
+	}
+
+	// VK with repro-openai-b at weight=1 — this is what governance LB would wrongly select without the fix
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-genai",
+		"sk-bf-genai-test",
+		"genai-repro-vk",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("repro-openai-b", []string{"*"}),
+		},
+	)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*virtualKey},
+		RoutingRules: []configstoreTables.TableRoutingRule{routingRule},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/genai/v1beta/models/probe-genai-model:generateContent"
+	req.PathParams["model"] = "probe-genai-model:generateContent"
+	req.Headers["Authorization"] = "Bearer sk-bf-genai-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	// Routing rule matched and set context model to "repro-openai-a/error-test:generateContent".
+	// Governance LB must NOT override this with "repro-openai-b/probe-genai-model:generateContent".
+	ctxModel, ok := bfCtx.Value("model").(string)
+	require.True(t, ok, "context model should be set")
+	require.Equal(t, "repro-openai-a/error-test:generateContent", ctxModel)
+}
+
+// TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget_WithStore is a production-like variant
+// of TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget that passes a non-nil inMemoryStore
+// containing the routing-rule provider, confirming the fix holds when p.inMemoryStore != nil
+// and the provider IS present in GetConfiguredProviders (the normal production code path).
+func TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget_WithStore(t *testing.T) {
+	logger := NewMockLogger()
+
+	routingRule := configstoreTables.TableRoutingRule{
+		ID:            "rule-genai-ws-1",
+		Name:          "genai-repro-rule-with-store",
+		Enabled:       true,
+		CelExpression: `model == "probe-genai-model" && provider == ""`,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{
+				RuleID:   "rule-genai-ws-1",
+				Provider: bifrost.Ptr("repro-openai-a"),
+				Model:    bifrost.Ptr("error-test"),
+				Weight:   1.0,
+			},
+		},
+		Scope:    "global",
+		Priority: 1,
+	}
+
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-genai-ws",
+		"sk-bf-genai-ws-test",
+		"genai-repro-vk-with-store",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("repro-openai-b", []string{"*"}),
+		},
+	)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*virtualKey},
+		RoutingRules: []configstoreTables.TableRoutingRule{routingRule},
+	}, nil)
+	require.NoError(t, err)
+
+	// Register the fake provider so ParseModelString can split "repro-openai-a/model"
+	// the same way it would for a real provider in production.
+	schemas.RegisterKnownProvider("repro-openai-a")
+	t.Cleanup(func() { schemas.UnregisterKnownProvider("repro-openai-a") })
+
+	// Use a non-nil inMemoryStore that recognises the routing-rule provider,
+	// mirroring production where configured providers are always registered in the store.
+	inMemStore := &mockInMemoryStore{
+		configuredProviders: map[schemas.ModelProvider]configstore.ProviderConfig{
+			"repro-openai-a": {},
+		},
+	}
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, inMemStore)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/genai/v1beta/models/probe-genai-model:generateContent"
+	req.PathParams["model"] = "probe-genai-model:generateContent"
+	req.Headers["Authorization"] = "Bearer sk-bf-genai-ws-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	ctxModel, ok := bfCtx.Value("model").(string)
+	require.True(t, ok, "context model should be set")
+	require.Equal(t, "repro-openai-a/error-test:generateContent", ctxModel)
+}
+
+// TestHTTPTransportPreHook_GenAINoRoutingRuleStillLoadBalances verifies that when no routing rule
+// matches on the /genai path, governance load balancing still selects a provider from the VK pool.
+func TestHTTPTransportPreHook_GenAINoRoutingRuleStillLoadBalances(t *testing.T) {
+	logger := NewMockLogger()
+
+	// VK with repro-openai-b at weight=1 — LB should select this
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-genai-lb",
+		"sk-bf-genai-lb-test",
+		"genai-lb-vk",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("repro-openai-b", []string{"*"}),
+		},
+	)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*virtualKey},
+		// No routing rules — governance LB should run normally
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/genai/v1beta/models/probe-genai-model:generateContent"
+	req.PathParams["model"] = "probe-genai-model:generateContent"
+	req.Headers["Authorization"] = "Bearer sk-bf-genai-lb-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	// No routing rule: governance LB must still run and select repro-openai-b from the VK pool
+	ctxModel, ok := bfCtx.Value("model").(string)
+	require.True(t, ok, "context model should be set by governance LB")
+	require.Equal(t, "repro-openai-b/probe-genai-model:generateContent", ctxModel)
+}
+
+// TestHTTPTransportPreHook_BedrockRoutingRulePreservesTarget verifies that when a routing rule
+// matches on the /bedrock path, governance load balancing does not override the routing-rule target
+// (regression test mirroring the GenAI fix for the Bedrock integration).
+func TestHTTPTransportPreHook_BedrockRoutingRulePreservesTarget(t *testing.T) {
+	logger := NewMockLogger()
+
+	routingRule := configstoreTables.TableRoutingRule{
+		ID:            "rule-bedrock-1",
+		Name:          "bedrock-repro-rule",
+		Enabled:       true,
+		CelExpression: `model == "probe-bedrock-model" && provider == ""`,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{
+				RuleID:   "rule-bedrock-1",
+				Provider: bifrost.Ptr("repro-openai-a"),
+				Model:    bifrost.Ptr("error-test"),
+				Weight:   1.0,
+			},
+		},
+		Scope:    "global",
+		Priority: 1,
+	}
+
+	// VK with repro-openai-b at weight=1 — this is what governance LB would wrongly select without the fix
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-bedrock",
+		"sk-bf-bedrock-test",
+		"bedrock-repro-vk",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("repro-openai-b", []string{"*"}),
+		},
+	)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*virtualKey},
+		RoutingRules: []configstoreTables.TableRoutingRule{routingRule},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/bedrock/model/probe-bedrock-model/converse"
+	req.PathParams["modelId"] = "probe-bedrock-model"
+	req.Headers["Authorization"] = "Bearer sk-bf-bedrock-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	// Routing rule matched and set context modelId to "repro-openai-a/error-test".
+	// Governance LB must NOT override this with "repro-openai-b/probe-bedrock-model".
+	ctxModelID, ok := bfCtx.Value("modelId").(string)
+	require.True(t, ok, "context modelId should be set")
+	require.Equal(t, "repro-openai-a/error-test", ctxModelID)
+}
+
+// TestHTTPTransportPreHook_BedrockNoRoutingRuleStillLoadBalances verifies that when no routing rule
+// matches on the /bedrock path, governance load balancing still selects a provider from the VK pool.
+func TestHTTPTransportPreHook_BedrockNoRoutingRuleStillLoadBalances(t *testing.T) {
+	logger := NewMockLogger()
+
+	// VK with repro-openai-b at weight=1 — LB should select this
+	virtualKey := buildVirtualKeyWithProviders(
+		"vk-bedrock-lb",
+		"sk-bf-bedrock-lb-test",
+		"bedrock-lb-vk",
+		[]configstoreTables.TableVirtualKeyProviderConfig{
+			buildProviderConfig("repro-openai-b", []string{"*"}),
+		},
+	)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*virtualKey},
+		// No routing rules — governance LB should run normally
+	}, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, plugin.Cleanup())
+	}()
+
+	req := schemas.AcquireHTTPRequest()
+	defer schemas.ReleaseHTTPRequest(req)
+	req.Method = "POST"
+	req.Path = "/bedrock/model/probe-bedrock-model/converse"
+	req.PathParams["modelId"] = "probe-bedrock-model"
+	req.Headers["Authorization"] = "Bearer sk-bf-bedrock-lb-test"
+	req.Headers["Content-Type"] = "application/json"
+	req.Body = []byte(`{"messages":[{"role":"user","content":[{"text":"hi"}]}]}`)
+
+	bfCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	resp, err := plugin.HTTPTransportPreHook(bfCtx, req)
+	require.NoError(t, err)
+	require.Nil(t, resp)
+
+	// No routing rule: governance LB must still run and select repro-openai-b from the VK pool
+	ctxModelID, ok := bfCtx.Value("modelId").(string)
+	require.True(t, ok, "context modelId should be set by governance LB")
+	require.Equal(t, "repro-openai-b/probe-bedrock-model", ctxModelID)
 }

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -551,19 +551,29 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 	if !hasModel {
 		// For genai integration, model is present in URL path instead of the request body
 		if isGeminiPath {
-			modelValue = req.CaseInsensitivePathParamLookup("model")
+			// Prefer context value set by a routing rule (format: "provider/model:suffix")
+			if ctxModel, ok := ctx.Value("model").(string); ok && ctxModel != "" {
+				modelValue = ctxModel
+			} else {
+				modelValue = req.CaseInsensitivePathParamLookup("model")
+			}
 		} else if isBedrockPath {
 			// For bedrock integration, model is present in URL path as modelId
-			rawModelID := req.CaseInsensitivePathParamLookup("modelId")
-			if rawModelID == "" {
-				return body, nil
+			// Prefer context value set by a routing rule (format: "provider/model")
+			if ctxModelID, ok := ctx.Value("modelId").(string); ok && ctxModelID != "" {
+				modelValue = ctxModelID
+			} else {
+				rawModelID := req.CaseInsensitivePathParamLookup("modelId")
+				if rawModelID == "" {
+					return body, nil
+				}
+				// URL-decode the modelId (Bedrock model IDs may be URL-encoded, e.g. anthropic%2Fclaude-3-5-sonnet)
+				decoded, err := url.PathUnescape(rawModelID)
+				if err != nil {
+					decoded = rawModelID
+				}
+				modelValue = decoded
 			}
-			// URL-decode the modelId (Bedrock model IDs may be URL-encoded, e.g. anthropic%2Fclaude-3-5-sonnet)
-			decoded, err := url.PathUnescape(rawModelID)
-			if err != nil {
-				decoded = rawModelID
-			}
-			modelValue = decoded
 		} else {
 			return body, nil
 		}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,6 +1,7 @@
 - feat: add support for chaining routing rules
 - feat: add routing tree UI to better visualize routing rules
 - feat: add model alias — keys now support a top-level `aliases` field mapping any model name to a provider-specific identifier (Azure deployment names, Bedrock inference profile ARNs, Vertex endpoints, Replicate model slugs, fine-tuned model IDs, etc.). The original model name is preserved and returned alongside the resolved identifier in every response. Breaking changes: see below.
+- fix: preseve routing rule targets for genai and bedrock paths for vk level provider load balancing
 
 <Warning>
 **This release contains 4 breaking changes** related to model aliasing. See the [v1.5.0 Migration Guide](/migration-guides/v1.5.0#breaking-change-9-provider-deployments-removed-migrate-to-aliases) for full before/after examples and migration instructions.

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -310,7 +310,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 			provider: provider,
 			weight: "" as string | number, // Default empty string = excluded from weighted routing until user sets a weight
 			allowed_models: ["*"],
-			key_ids: [],
+			key_ids: ["*"],
 		};
 
 		form.setValue("providerConfigs", [...providerConfigs, newConfig], { shouldDirty: true });
@@ -392,6 +392,14 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 							? null
 							: parseFloat(config.weight)
 						: config.weight,
+			budgets: config.budgets
+				? config.budgets
+						.filter((b) => normalizeNumericField(b.max_limit) !== undefined)
+						.map((b) => ({
+							max_limit: normalizeNumericField(b.max_limit)!,
+							reset_duration: b.reset_duration || "1M",
+						}))
+				: undefined,
 			rate_limit: (() => {
 				const tokenMaxLimit = normalizeNumericField(config.rate_limit?.token_max_limit);
 				const requestMaxLimit = normalizeNumericField(config.rate_limit?.request_max_limit);

--- a/ui/components/ui/headersTable.tsx
+++ b/ui/components/ui/headersTable.tsx
@@ -117,20 +117,23 @@ export function HeadersTable<T extends HeaderValue>({
 			return next;
 		});
 
-		const newHeaders = { ...value };
-
-		// Remove old key if it exists and is not empty
-		if (oldKey !== "" && oldKey in newHeaders) {
-			delete newHeaders[oldKey];
+		// Rebuild the object preserving key order so the row doesn't jump to the end
+		const newHeaders: Record<string, T> = {};
+		for (const [k, v] of Object.entries(value) as [string, T][]) {
+			if (k === oldKey && oldKey !== "") {
+				// Replace old key with new key at the same position
+				if (newKey !== "") {
+					newHeaders[newKey] = currentValue;
+				}
+			} else if (k !== "") {
+				newHeaders[k] = v;
+			}
 		}
 
-		// Only add new entry if key is not empty
-		if (newKey !== "") {
+		// If this was a new (empty-key) row, append at the end
+		if (oldKey === "" && newKey !== "") {
 			newHeaders[newKey] = currentValue;
 		}
-
-		// Clean up any empty string keys
-		delete newHeaders[""];
 
 		onChange(newHeaders);
 	};

--- a/ui/lib/utils/celConverterRouting.ts
+++ b/ui/lib/utils/celConverterRouting.ts
@@ -3,18 +3,18 @@
  * Converts react-querybuilder rules to CEL expressions
  */
 
-import { RuleGroupType, RuleType } from 'react-querybuilder';
-import { getOperatorCELSyntax } from '@/lib/config/celOperatorsRouting';
+import { RuleGroupType, RuleType } from "react-querybuilder";
+import { getOperatorCELSyntax } from "@/lib/config/celOperatorsRouting";
 
 /**
  * RE2-incompatible constructs (not supported by CEL/RE2).
  * Used for syntactic checks so patterns validated here work in CEL regex functions.
  */
 const RE2_UNSUPPORTED = {
-  lookbehindPositive: '(?<=',
-  lookbehindNegative: '(?<!',
-  lookaheadPositive: '(?=',
-  lookaheadNegative: '(?!',
+	lookbehindPositive: "(?<=",
+	lookbehindNegative: "(?<!",
+	lookaheadPositive: "(?=",
+	lookaheadNegative: "(?!",
 } as const;
 
 /** Matches numeric backreferences (\1, \2, ... \9, \10, etc.) */
@@ -26,266 +26,268 @@ const RE2_BACKREF = /\\[0-9]+/;
  * error message if invalid or RE2-incompatible.
  */
 export function validateRegexPattern(pattern: string): string | null {
-  if (!pattern || typeof pattern !== 'string') {
-    return null; // Empty patterns are valid
-  }
+	if (!pattern || typeof pattern !== "string") {
+		return null; // Empty patterns are valid
+	}
 
-  // Reject RE2-unsupported constructs
-  if (pattern.includes(RE2_UNSUPPORTED.lookbehindPositive)) {
-    return 'RE2 incompatible: positive lookbehind (?<=...) is not supported';
-  }
-  if (pattern.includes(RE2_UNSUPPORTED.lookbehindNegative)) {
-    return 'RE2 incompatible: negative lookbehind (?<!...) is not supported';
-  }
-  if (pattern.includes(RE2_UNSUPPORTED.lookaheadPositive)) {
-    return 'RE2 incompatible: positive lookahead (?=...) is not supported';
-  }
-  if (pattern.includes(RE2_UNSUPPORTED.lookaheadNegative)) {
-    return 'RE2 incompatible: negative lookahead (?!...) is not supported';
-  }
-  if (RE2_BACKREF.test(pattern)) {
-    return 'RE2 incompatible: numeric backreferences (e.g. \\1, \\2) are not supported';
-  }
+	// Reject RE2-unsupported constructs
+	if (pattern.includes(RE2_UNSUPPORTED.lookbehindPositive)) {
+		return "RE2 incompatible: positive lookbehind (?<=...) is not supported";
+	}
+	if (pattern.includes(RE2_UNSUPPORTED.lookbehindNegative)) {
+		return "RE2 incompatible: negative lookbehind (?<!...) is not supported";
+	}
+	if (pattern.includes(RE2_UNSUPPORTED.lookaheadPositive)) {
+		return "RE2 incompatible: positive lookahead (?=...) is not supported";
+	}
+	if (pattern.includes(RE2_UNSUPPORTED.lookaheadNegative)) {
+		return "RE2 incompatible: negative lookahead (?!...) is not supported";
+	}
+	if (RE2_BACKREF.test(pattern)) {
+		return "RE2 incompatible: numeric backreferences (e.g. \\1, \\2) are not supported";
+	}
 
-  // Basic syntax check via JS RegExp (catches invalid escaping, etc.)
-  try {
-    new RegExp(pattern);
-    return null; // Valid regex
-  } catch (error: unknown) {
-    const errorMessage = error instanceof Error ? error.message : 'Invalid regex pattern';
-    return `Invalid regex: ${errorMessage}`;
-  }
+	// Basic syntax check via JS RegExp (catches invalid escaping, etc.)
+	try {
+		new RegExp(pattern);
+		return null; // Valid regex
+	} catch (error: unknown) {
+		const errorMessage = error instanceof Error ? error.message : "Invalid regex pattern";
+		return `Invalid regex: ${errorMessage}`;
+	}
 }
 
 /**
  * Parse keyValue pair from string format "key:value"
  */
 function parseKeyValue(value: string): { key: string; value: string } | null {
-  if (!value || typeof value !== 'string') {
-    return null;
-  }
+	if (!value || typeof value !== "string") {
+		return null;
+	}
 
-  // Try parsing as JSON array first (for comma-separated values)
-  if (value.startsWith('[')) {
-    return null; // This is an array, not a key-value pair
-  }
+	// Try parsing as JSON array first (for comma-separated values)
+	if (value.startsWith("[")) {
+		return null; // This is an array, not a key-value pair
+	}
 
-  // Handle "key" format for existence checks
-  const colonIndex = value.indexOf(':');
-  if (colonIndex > 0) {
-    return {
-      key: value.substring(0, colonIndex).trim(),
-      value: value.substring(colonIndex + 1).trim(),
-    };
-  }
+	// Handle "key" format for existence checks
+	const colonIndex = value.indexOf(":");
+	if (colonIndex > 0) {
+		return {
+			key: value.substring(0, colonIndex).trim(),
+			value: value.substring(colonIndex + 1).trim(),
+		};
+	}
 
-  // If no colon, treat entire string as key (for existence checks)
-  return {
-    key: value.trim(),
-    value: '',
-  };
+	// If no colon, treat entire string as key (for existence checks)
+	return {
+		key: value.trim(),
+		value: "",
+	};
 }
 
 /**
  * Escape special characters in strings
  */
 function escapeString(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n').replace(/\r/g, '\\r');
+	return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
 }
 
 /**
  * Format value based on operator type
  */
 function formatValue(value: any, operator: string): string {
-  // Handle array values for 'in' and 'notIn' operators
-  if (operator === 'in' || operator === 'notIn') {
-    let arrayValue: string[];
+	// Handle array values for 'in' and 'notIn' operators
+	if (operator === "in" || operator === "notIn") {
+		let arrayValue: string[];
 
-    if (typeof value === 'string') {
-      try {
-        // Try parsing as JSON array
-        arrayValue = JSON.parse(value);
-        if (!Array.isArray(arrayValue)) {
-          arrayValue = [String(value)];
-        }
-      } catch {
-        // Split by comma if not JSON
-        arrayValue = value
-          .split(',')
-          .map((v) => v.trim())
-          .filter((v) => v);
-      }
-    } else if (Array.isArray(value)) {
-      arrayValue = value;
-    } else {
-      arrayValue = [String(value)];
-    }
+		if (typeof value === "string") {
+			try {
+				// Try parsing as JSON array
+				arrayValue = JSON.parse(value);
+				if (!Array.isArray(arrayValue)) {
+					arrayValue = [String(value)];
+				}
+			} catch {
+				// Split by comma if not JSON
+				arrayValue = value
+					.split(",")
+					.map((v) => v.trim())
+					.filter((v) => v);
+			}
+		} else if (Array.isArray(value)) {
+			arrayValue = value;
+		} else {
+			arrayValue = [String(value)];
+		}
 
-    const formattedValues = arrayValue.map((v) => `"${escapeString(String(v))}"`);
-    return `[${formattedValues.join(', ')}]`;
-  }
+		const formattedValues = arrayValue.map((v) => `"${escapeString(String(v))}"`);
+		return `[${formattedValues.join(", ")}]`;
+	}
 
-  // Handle numbers
-  if (typeof value === 'number') {
-    return String(value);
-  }
+	// Handle numbers
+	if (typeof value === "number") {
+		return String(value);
+	}
 
-  // Handle booleans
-  if (typeof value === 'boolean') {
-    return value ? 'true' : 'false';
-  }
+	// Handle booleans
+	if (typeof value === "boolean") {
+		return value ? "true" : "false";
+	}
 
-  // Handle string values (regex patterns for matches operator)
-  if (operator === 'matches') {
-    // For regex, wrap in forward slashes (CEL format) or quotes
-    return `"${escapeString(String(value))}"`;
-  }
+	// Handle string values (regex patterns for matches operator)
+	if (operator === "matches") {
+		// For regex, wrap in forward slashes (CEL format) or quotes
+		return `"${escapeString(String(value))}"`;
+	}
 
-  // Default: treat as string
-  return `"${escapeString(String(value))}"`;
+	// Default: treat as string
+	return `"${escapeString(String(value))}"`;
 }
 
 /**
  * Convert a single rule to CEL expression
  */
 function convertRuleToCEL(rule: RuleType): string {
-  const { field, operator, value } = rule;
+	const { field, operator, value } = rule;
 
-  if (!field || !operator) {
-    return '';
-  }
+	if (!field || !operator) {
+		return "";
+	}
 
-  const celOperator = getOperatorCELSyntax(operator);
+	const celOperator = getOperatorCELSyntax(operator);
 
-  // Handle existence checks (null/notNull)
-  const isKeyValueField = field === 'headers' || field === 'params';
-  if (operator === 'null') {
-    if (isKeyValueField) {
-      const keyValuePair = parseKeyValue(String(value));
-      if (keyValuePair && keyValuePair.key) {
-        return `!(${formatValue(keyValuePair.key, 'text')} in ${field})`;
-      }
-    }
-    // has() requires a field selection (e.g. has(obj.field)) and cannot be used with bare
-    // variable names. Plain string variables are always defined; "not set" means empty string.
-    return `${field} == ""`;
-  }
+	// Handle existence checks (null/notNull)
+	// Key-value path (headers/params) checks key presence in the map.
+	// For all other fields (provider, model, etc.) fall through to the simple equality check.
+	const isKeyValueField = field === "headers" || field === "params";
 
-  if (operator === 'notNull') {
-    if (isKeyValueField) {
-      const keyValuePair = parseKeyValue(String(value));
-      if (keyValuePair && keyValuePair.key) {
-        return `${formatValue(keyValuePair.key, 'text')} in ${field}`;
-      }
-    }
-    return `${field} != ""`;
-  }
+	if (operator === "null") {
+		if (isKeyValueField) {
+			const keyValuePair = parseKeyValue(String(value));
+			if (keyValuePair && keyValuePair.key) {
+				return `!(${formatValue(keyValuePair.key, "text")} in ${field})`;
+			}
+		}
+		// has() requires a field selection (e.g. has(obj.field)) and cannot be used with bare
+		// variable names. Plain string variables are always defined; "not set" means empty string.
+		return `${field} == ""`;
+	}
 
-  // Handle string method operators (startsWith, endsWith, contains, matches)
-  const stringMethods = ['startsWith', 'endsWith', 'contains', 'matches'];
-  if (stringMethods.includes(celOperator)) {
-    const formattedValue = formatValue(value, operator);
+	if (operator === "notNull") {
+		if (isKeyValueField) {
+			const keyValuePair = parseKeyValue(String(value));
+			if (keyValuePair && keyValuePair.key) {
+				return `${formatValue(keyValuePair.key, "text")} in ${field}`;
+			}
+		}
+		return `${field} != ""`;
+	}
 
-    // Handle keyValue fields (headers, params)
-    const isKeyValueField = field === 'headers' || field === 'params';
-    if (isKeyValueField) {
-      const keyValuePair = parseKeyValue(String(value));
-      if (keyValuePair && keyValuePair.key && keyValuePair.value) {
-        const fieldPath = `${field}[${formatValue(keyValuePair.key, 'text')}]`;
-        const actualValue = formatValue(keyValuePair.value, operator);
-        return `${fieldPath}.${celOperator}(${actualValue})`;
-      }
-    }
+	// Handle string method operators (startsWith, endsWith, contains, matches)
+	const stringMethods = ["startsWith", "endsWith", "contains", "matches"];
+	if (stringMethods.includes(celOperator)) {
+		const formattedValue = formatValue(value, operator);
 
-    // Regular field handling
-    return `${field}.${celOperator}(${formattedValue})`;
-  }
+		// Handle keyValue fields (headers, params)
+		if (isKeyValueField) {
+			const keyValuePair = parseKeyValue(String(value));
+			if (keyValuePair && keyValuePair.key && keyValuePair.value) {
+				const fieldPath = `${field}[${formatValue(keyValuePair.key, "text")}]`;
+				const actualValue = formatValue(keyValuePair.value, operator);
+				return `${fieldPath}.${celOperator}(${actualValue})`;
+			}
+		}
 
-  // Handle tokens_used, request, and budget_used
-  // Structure: tokens_used > 80.0 or request >= 75.0 or budget_used > 50.0
-  // These are simple numeric comparisons against percent_used values from GetBudgetAndRateLimitStatus
-  // which already returns the max of model+provider, model-only, and provider-only configs
-  const isRateLimitOrBudgetField = field === 'tokens_used' || field === 'request' || field === 'budget_used';
-  if (isRateLimitOrBudgetField) {
-    const thresholdValue = String(value).trim();
-    if (thresholdValue) {
-      // Convert to double to match CEL variable type (tokens_used, request, budget_used are all doubles)
-      const numValue = parseFloat(thresholdValue);
-      let actualValue: string;
-      if (!isNaN(numValue)) {
-        // Format as double with decimal point
-        actualValue = Number.isInteger(numValue) ? `${numValue}.0` : numValue.toString();
-      } else {
-        actualValue = thresholdValue;
-      }
-      return `${field} ${celOperator} ${actualValue}`;
-    }
-  }
+		// Regular field handling
+		return `${field}.${celOperator}(${formattedValue})`;
+	}
 
-  // Handle other keyValue fields (headers, params) for other operators
-  if (isKeyValueField) {
-    const keyValuePair = parseKeyValue(String(value));
-    if (keyValuePair && keyValuePair.key && keyValuePair.value) {
-      const fieldPath = `${field}[${formatValue(keyValuePair.key, 'text')}]`;
-      const actualValue = formatValue(keyValuePair.value, operator);
+	// Handle tokens_used, request, and budget_used
+	// Structure: tokens_used > 80.0 or request >= 75.0 or budget_used > 50.0
+	// These are simple numeric comparisons against percent_used values from GetBudgetAndRateLimitStatus
+	// which already returns the max of model+provider, model-only, and provider-only configs
+	const isRateLimitOrBudgetField = field === "tokens_used" || field === "request" || field === "budget_used";
+	if (isRateLimitOrBudgetField) {
+		const thresholdValue = String(value).trim();
+		if (thresholdValue) {
+			// Convert to double to match CEL variable type (tokens_used, request, budget_used are all doubles)
+			const numValue = parseFloat(thresholdValue);
+			let actualValue: string;
+			if (!isNaN(numValue)) {
+				// Format as double with decimal point
+				actualValue = Number.isInteger(numValue) ? `${numValue}.0` : numValue.toString();
+			} else {
+				actualValue = thresholdValue;
+			}
+			return `${field} ${celOperator} ${actualValue}`;
+		}
+	}
 
-      // For 'notIn' operator, wrap with negation since CEL has no "not in" infix operator
-      if (operator === 'notIn') {
-        return `!(${fieldPath} in ${actualValue})`;
-      }
+	// Handle other keyValue fields (headers, params) for other operators
+	if (isKeyValueField) {
+		const keyValuePair = parseKeyValue(String(value));
+		if (keyValuePair && keyValuePair.key && keyValuePair.value) {
+			const fieldPath = `${field}[${formatValue(keyValuePair.key, "text")}]`;
+			const actualValue = formatValue(keyValuePair.value, operator);
 
-      // For 'in' operator and others, use standard binary syntax
-      return `${fieldPath} ${celOperator} ${actualValue}`;
-    }
-  }
+			// For 'notIn' operator, wrap with negation since CEL has no "not in" infix operator
+			if (operator === "notIn") {
+				return `!(${fieldPath} in ${actualValue})`;
+			}
 
-  // Regular field handling for binary operators
-  const formattedValue = formatValue(value, operator);
+			// For 'in' operator and others, use standard binary syntax
+			return `${fieldPath} ${celOperator} ${actualValue}`;
+		}
+	}
 
-  // For 'notIn' operator, wrap with negation since CEL has no "not in" infix operator
-  if (operator === 'notIn') {
-    return `!(${field} in ${formattedValue})`;
-  }
+	// Regular field handling for binary operators
+	const formattedValue = formatValue(value, operator);
 
-  return `${field} ${celOperator} ${formattedValue}`;
+	// For 'notIn' operator, wrap with negation since CEL has no "not in" infix operator
+	if (operator === "notIn") {
+		return `!(${field} in ${formattedValue})`;
+	}
+
+	return `${field} ${celOperator} ${formattedValue}`;
 }
 
 /**
  * Convert rule group (possibly nested) to CEL expression
  */
 export function convertRuleGroupToCEL(ruleGroup: RuleGroupType | undefined): string {
-  if (!ruleGroup || !ruleGroup.rules || ruleGroup.rules.length === 0) {
-    return '';
-  }
+	if (!ruleGroup || !ruleGroup.rules || ruleGroup.rules.length === 0) {
+		return "";
+	}
 
-  const combinator = ruleGroup.combinator === 'or' ? '||' : '&&';
-  const expressions: string[] = [];
+	const combinator = ruleGroup.combinator === "or" ? "||" : "&&";
+	const expressions: string[] = [];
 
-  for (const rule of ruleGroup.rules) {
-    if ('rules' in rule) {
-      // It's a nested group
-      const nestedExpression = convertRuleGroupToCEL(rule as RuleGroupType);
-      if (nestedExpression) {
-        expressions.push(`(${nestedExpression})`);
-      }
-    } else {
-      // It's a rule
-      const ruleExpression = convertRuleToCEL(rule as RuleType);
-      if (ruleExpression) {
-        expressions.push(ruleExpression);
-      }
-    }
-  }
+	for (const rule of ruleGroup.rules) {
+		if ("rules" in rule) {
+			// It's a nested group
+			const nestedExpression = convertRuleGroupToCEL(rule as RuleGroupType);
+			if (nestedExpression) {
+				expressions.push(`(${nestedExpression})`);
+			}
+		} else {
+			// It's a rule
+			const ruleExpression = convertRuleToCEL(rule as RuleType);
+			if (ruleExpression) {
+				expressions.push(ruleExpression);
+			}
+		}
+	}
 
-  if (expressions.length === 0) {
-    return '';
-  }
+	if (expressions.length === 0) {
+		return "";
+	}
 
-  if (expressions.length === 1) {
-    return expressions[0];
-  }
+	if (expressions.length === 1) {
+		return expressions[0];
+	}
 
-  return expressions.join(` ${combinator} `);
+	return expressions.join(` ${combinator} `);
 }
 
 /**
@@ -293,76 +295,77 @@ export function convertRuleGroupToCEL(ruleGroup: RuleGroupType | undefined): str
  * Returns array of error messages, empty if valid
  */
 export function validateRoutingRules(ruleGroup: RuleGroupType | undefined): string[] {
-  const errors: string[] = [];
+	const errors: string[] = [];
 
-  if (!ruleGroup || !ruleGroup.rules) {
-    return errors;
-  }
+	if (!ruleGroup || !ruleGroup.rules) {
+		return errors;
+	}
 
-  const validateRule = (rule: RuleType | RuleGroupType) => {
-    if ('rules' in rule) {
-      // Nested group - recursively validate
-      for (const nestedRule of rule.rules) {
-        validateRule(nestedRule);
-      }
-    } else {
-      // Regular rule - check if it uses matches operator
-      if (rule.operator === 'matches' && rule.value) {
-        const regexError = validateRegexPattern(String(rule.value));
-        if (regexError) {
-          errors.push(`Field "${rule.field}": ${regexError}`);
-        }
-      }
-    }
-  };
+	const validateRule = (rule: RuleType | RuleGroupType) => {
+		if ("rules" in rule) {
+			// Nested group - recursively validate
+			for (const nestedRule of rule.rules) {
+				validateRule(nestedRule);
+			}
+		} else {
+			// Regular rule - check if it uses matches operator
+			if (rule.operator === "matches" && rule.value) {
+				const regexError = validateRegexPattern(String(rule.value));
+				if (regexError) {
+					errors.push(`Field "${rule.field}": ${regexError}`);
+				}
+			}
+		}
+	};
 
-  for (const rule of ruleGroup.rules) {
-    validateRule(rule);
-  }
+	for (const rule of ruleGroup.rules) {
+		validateRule(rule);
+	}
 
-  return errors;
+	return errors;
 }
-
 
 /**
  * Validate that rules using rate limits or budgets have a model or provider condition
  * Returns array of error messages, empty if valid
  */
 export function validateRateLimitAndBudgetRules(ruleGroup: RuleGroupType | undefined): string[] {
-  const errors: string[] = [];
+	const errors: string[] = [];
 
-  if (!ruleGroup || !ruleGroup.rules) {
-    return errors;
-  }
+	if (!ruleGroup || !ruleGroup.rules) {
+		return errors;
+	}
 
-  // Check if rule uses rate limits or budgets
-  const hasRateLimitOrBudget = (rule: RuleType | RuleGroupType): boolean => {
-    if ('rules' in rule) {
-      // Nested group
-      return rule.rules.some(r => hasRateLimitOrBudget(r));
-    }
-    // Regular rule - check if field is rate limit or budget
-    return (rule as RuleType).field === 'tokens_used' || (rule as RuleType).field === 'request' || (rule as RuleType).field === 'budget_used';
-  };
+	// Check if rule uses rate limits or budgets
+	const hasRateLimitOrBudget = (rule: RuleType | RuleGroupType): boolean => {
+		if ("rules" in rule) {
+			// Nested group
+			return rule.rules.some((r) => hasRateLimitOrBudget(r));
+		}
+		// Regular rule - check if field is rate limit or budget
+		return (
+			(rule as RuleType).field === "tokens_used" || (rule as RuleType).field === "request" || (rule as RuleType).field === "budget_used"
+		);
+	};
 
-  // Check if rule has model or provider condition
-  const hasModelOrProviderCondition = (rule: RuleType | RuleGroupType): boolean => {
-    if ('rules' in rule) {
-      // Nested group - check all nested rules
-      return rule.rules.some(r => hasModelOrProviderCondition(r));
-    }
-    // Regular rule - check if field is model or provider
-    return (rule as RuleType).field === 'model' || (rule as RuleType).field === 'provider';
-  };
+	// Check if rule has model or provider condition
+	const hasModelOrProviderCondition = (rule: RuleType | RuleGroupType): boolean => {
+		if ("rules" in rule) {
+			// Nested group - check all nested rules
+			return rule.rules.some((r) => hasModelOrProviderCondition(r));
+		}
+		// Regular rule - check if field is model or provider
+		return (rule as RuleType).field === "model" || (rule as RuleType).field === "provider";
+	};
 
-  const ruleHasRateLimitOrBudget = ruleGroup.rules.some(r => hasRateLimitOrBudget(r));
+	const ruleHasRateLimitOrBudget = ruleGroup.rules.some((r) => hasRateLimitOrBudget(r));
 
-  if (ruleHasRateLimitOrBudget) {
-    const hasCondition = hasModelOrProviderCondition(ruleGroup);
-    if (!hasCondition) {
-      errors.push('Rules using rate limits or budget must have a "model" or "provider" condition');
-    }
-  }
+	if (ruleHasRateLimitOrBudget) {
+		const hasCondition = hasModelOrProviderCondition(ruleGroup);
+		if (!hasCondition) {
+			errors.push('Rules using rate limits or budget must have a "model" or "provider" condition');
+		}
+	}
 
-  return errors;
+	return errors;
 }


### PR DESCRIPTION
## Summary

Adds migration test coverage for v1.5.0-prerelease1 by including it in the test matrix and handling new database columns introduced in that version.

## Changes

- Extended `get_previous_versions()` to explicitly include v1.5.0-prerelease1 alongside stable versions for migration testing
- Added migration test support for new columns in v1.5.0-prerelease1:
  - `config_keys.ollama_url` and `config_keys.sgl_url` 
  - `logs.image_edit_input` and `logs.image_variation_input`
- Added handling for dropped columns in schema comparison:
  - Deployment JSON columns moved from `config_keys` to provider-level config
  - Budget-related columns restructured across governance tables
- Applied changes to both PostgreSQL and SQLite migration test paths

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Transports (HTTP)

## How to test

Run the migration test suite to verify prerelease version compatibility:

```sh
# Run migration tests
.github/workflows/scripts/run-migration-tests.sh

# Verify prerelease version is included in test matrix
.github/workflows/scripts/run-migration-tests.sh | grep "v1.5.0-prerelease1"
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None - this only affects test infrastructure and does not change runtime behavior.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable