### PR TITLE
fix: convert developer role to system for bedrock and gemini (vertex)

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
 - feat: add model alias support
 - refactor: standardize extra fields handling for all providers
+- fix: converts developer role to system role for bedrock, gemini and vertex providers.

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -362,8 +362,8 @@ func convertMessages(bifrostMessages []schemas.ChatMessage) ([]BedrockMessage, [
 	for i := 0; i < len(bifrostMessages); i++ {
 		msg := bifrostMessages[i]
 		switch msg.Role {
-		case schemas.ChatMessageRoleSystem:
-			// Convert system message
+		case schemas.ChatMessageRoleSystem, schemas.ChatMessageRoleDeveloper:
+			// Convert system or developer message (Bedrock does not support developer role, treat as system)
 			systemMsgs, err := convertSystemMessages(msg)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to convert system message: %w", err)

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -497,23 +497,21 @@ func convertFileDataToBytes(fileData string) ([]byte, string) {
 	return dataBytes, mimeType
 }
 
-var (
-	// Maps Gemini finish reasons to Bifrost format
-	geminiFinishReasonToBifrost = map[FinishReason]string{
-		FinishReasonStop:                  "stop",
-		FinishReasonMaxTokens:             "length",
-		FinishReasonSafety:                "content_filter",
-		FinishReasonRecitation:            "content_filter",
-		FinishReasonLanguage:              "content_filter",
-		FinishReasonOther:                 "stop",
-		FinishReasonBlocklist:             "content_filter",
-		FinishReasonProhibitedContent:     "content_filter",
-		FinishReasonSPII:                  "content_filter",
-		FinishReasonMalformedFunctionCall: "stop",
-		FinishReasonImageSafety:           "content_filter",
-		FinishReasonUnexpectedToolCall:    "tool_calls",
-	}
-)
+// Maps Gemini finish reasons to Bifrost format
+var geminiFinishReasonToBifrost = map[FinishReason]string{
+	FinishReasonStop:                  "stop",
+	FinishReasonMaxTokens:             "length",
+	FinishReasonSafety:                "content_filter",
+	FinishReasonRecitation:            "content_filter",
+	FinishReasonLanguage:              "content_filter",
+	FinishReasonOther:                 "stop",
+	FinishReasonBlocklist:             "content_filter",
+	FinishReasonProhibitedContent:     "content_filter",
+	FinishReasonSPII:                  "content_filter",
+	FinishReasonMalformedFunctionCall: "stop",
+	FinishReasonImageSafety:           "content_filter",
+	FinishReasonUnexpectedToolCall:    "tool_calls",
+}
 
 // ConvertGeminiFinishReasonToBifrost converts Gemini finish reasons to Bifrost format
 func ConvertGeminiFinishReasonToBifrost(providerReason FinishReason) string {
@@ -1485,8 +1483,8 @@ func convertBifrostMessagesToGemini(messages []schemas.ChatMessage) ([]Content, 
 	callIDToFunctionName := make(map[string]string)
 
 	for i, message := range messages {
-		// Handle system messages separately - Gemini requires them in SystemInstruction field
-		if message.Role == schemas.ChatMessageRoleSystem {
+		// Handle system or developer messages separately - Gemini requires them in SystemInstruction field
+		if message.Role == schemas.ChatMessageRoleSystem || message.Role == schemas.ChatMessageRoleDeveloper {
 			if systemInstruction == nil {
 				systemInstruction = &Content{}
 			}


### PR DESCRIPTION
## Summary

Added support for the developer message role in Bedrock and Gemini providers by treating developer messages the same as system messages.

## Changes

- **Bedrock provider**: Extended the system message handling case to also process `schemas.ChatMessageRoleDeveloper` messages, treating them as system messages since Bedrock doesn't natively support the developer role
- **Gemini provider**: Updated message conversion logic to handle developer messages alongside system messages in the SystemInstruction field, as Gemini requires both types to be processed similarly
- **Code style**: Simplified the `geminiFinishReasonToBifrost` variable declaration by removing unnecessary `var()` block syntax  


## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Send a request to gemini / bedrock with role: developer.
curl --location 'http://localhost:8080/v1/chat/completions' \
--header 'Content-Type: application/json' \
--data '{
    "model": "bedrock/anthropic.claude-3-haiku-20240307-v1:0",
    "messages": [
        {
            "role": "developer",
            "content": "You are a helpful agent"
        },
        {
            "role": "user",
            "content": "Hello"
        }
    ]
}
'
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Closes #2492

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable