### PR TITLE
fix(bedrock): correct SigV4 service name for agent runtime rerank

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -222,7 +222,7 @@ func (provider *BedrockProvider) completeRequest(ctx *schemas.BifrostContext, js
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key.Value.GetValue()))
 	} else {
 		// Sign the request using either explicit credentials or IAM role authentication
-		if err := signAWSRequest(ctx, req, config.AccessKey, config.SecretKey, config.SessionToken, config.RoleARN, config.ExternalID, config.RoleSessionName, region, "bedrock", provider.GetProviderKey()); err != nil {
+		if err := signAWSRequest(ctx, req, config.AccessKey, config.SecretKey, config.SessionToken, config.RoleARN, config.ExternalID, config.RoleSessionName, region, bedrockSigningService, provider.GetProviderKey()); err != nil {
 			return nil, 0, nil, err
 		}
 	}
@@ -349,7 +349,7 @@ func (provider *BedrockProvider) completeAgentRuntimeRequest(ctx *schemas.Bifros
 	if key.Value.GetValue() != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key.Value.GetValue()))
 	} else {
-		if err := signAWSRequest(ctx, req, config.AccessKey, config.SecretKey, config.SessionToken, config.RoleARN, config.ExternalID, config.RoleSessionName, region, "bedrock-agent-runtime", provider.GetProviderKey()); err != nil {
+		if err := signAWSRequest(ctx, req, config.AccessKey, config.SecretKey, config.SessionToken, config.RoleARN, config.ExternalID, config.RoleSessionName, region, bedrockSigningService, provider.GetProviderKey()); err != nil {
 			return nil, 0, nil, err
 		}
 	}
@@ -457,7 +457,7 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx *schemas.BifrostContex
 	} else {
 		req.Header.Set("Accept", "application/vnd.amazon.eventstream")
 		// Sign the request using either explicit credentials or IAM role authentication
-		if err := signAWSRequest(ctx, req, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, "bedrock", providerName); err != nil {
+		if err := signAWSRequest(ctx, req, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, bedrockSigningService, providerName); err != nil {
 			return nil, deployment, err
 		}
 	}
@@ -721,7 +721,7 @@ func (provider *BedrockProvider) listModelsByKey(ctx *schemas.BifrostContext, ke
 	} else {
 		// Sign the request using either explicit credentials or IAM role authentication
 
-		if err := signAWSRequest(ctx, req, config.AccessKey, config.SecretKey, config.SessionToken, config.RoleARN, config.ExternalID, config.RoleSessionName, region, "bedrock", providerName); err != nil {
+		if err := signAWSRequest(ctx, req, config.AccessKey, config.SecretKey, config.SessionToken, config.RoleARN, config.ExternalID, config.RoleSessionName, region, bedrockSigningService, providerName); err != nil {
 			return nil, err
 		}
 	}
@@ -3070,7 +3070,7 @@ func (provider *BedrockProvider) BatchCreate(ctx *schemas.BifrostContext, key sc
 	}
 
 	// Sign request
-	if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, "bedrock", providerName); err != nil {
+	if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, bedrockSigningService, providerName); err != nil {
 		return nil, providerUtils.EnrichError(ctx, err, jsonData, nil, sendBackRawRequest, sendBackRawResponse)
 	}
 
@@ -3209,7 +3209,7 @@ func (provider *BedrockProvider) BatchList(ctx *schemas.BifrostContext, keys []s
 	}
 
 	// Sign request
-	if bifrostErr := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, "bedrock", providerName); bifrostErr != nil {
+	if bifrostErr := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, bedrockSigningService, providerName); bifrostErr != nil {
 		return nil, bifrostErr
 	}
 
@@ -3397,7 +3397,7 @@ func (provider *BedrockProvider) BatchRetrieve(ctx *schemas.BifrostContext, keys
 		}
 
 		// Sign request
-		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, "bedrock", providerName); err != nil {
+		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, bedrockSigningService, providerName); err != nil {
 			lastErr = err
 			continue
 		}
@@ -3541,7 +3541,7 @@ func (provider *BedrockProvider) BatchCancel(ctx *schemas.BifrostContext, keys [
 		}
 
 		// Sign request
-		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, "bedrock", providerName); err != nil {
+		if err := signAWSRequest(ctx, httpReq, key.BedrockKeyConfig.AccessKey, key.BedrockKeyConfig.SecretKey, key.BedrockKeyConfig.SessionToken, key.BedrockKeyConfig.RoleARN, key.BedrockKeyConfig.ExternalID, key.BedrockKeyConfig.RoleSessionName, region, bedrockSigningService, providerName); err != nil {
 			lastErr = err
 			continue
 		}

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -10,6 +10,12 @@ import (
 
 // DefaultBedrockRegion is the default region for Bedrock
 const DefaultBedrockRegion = "us-east-1"
+
+// bedrockSigningService is the SigV4 service name used when signing all Bedrock
+// API requests. AWS requires "bedrock" as the credential scope service for both
+// bedrock-runtime and bedrock-agent-runtime endpoints.
+const bedrockSigningService = "bedrock"
+
 const MinimumReasoningMaxTokens = 1
 const DefaultCompletionMaxTokens = 4096 // Only used for relative reasoning max token calculation - not passed in body by default
 


### PR DESCRIPTION
## Summary

Fixes a SigV4 signing issue in Bedrock rerank requests where the service name was incorrectly set to `bedrock-agent-runtime` instead of `bedrock`.

This caused AWS to reject requests with a `403 Credential should be scoped to correct service: 'bedrock'` error. The fix aligns signing behavior with AWS requirements, enabling successful authentication and execution of rerank requests.

---

## Changes

* Updated SigV4 signing service name from `bedrock-agent-runtime` to `bedrock` in `completeAgentRuntimeRequest`
* Introduced a shared constant (`bedrockSigningService`) to ensure consistency across all Bedrock signing paths
* Replaced hardcoded service names in all Bedrock request signing locations to avoid future divergence

### Design decisions

* Used a single constant for the service name to prevent similar bugs across different request paths
* Kept the change minimal and scoped to signing logic to avoid unintended side effects

---

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

---

## Affected areas

* [x] Core (Go)
* [ ] Transports (HTTP)
* [x] Providers/Integrations
* [ ] Plugins
* [ ] UI (Next.js)
* [ ] Docs

---

## How to test

### 1. Run tests

```sh
go test ./core/providers/bedrock/... -v -count=1
```

### 2. Start server

```sh
go run ./transports/bifrost-http
```

### 3. Send rerank request

```sh
curl -s -w '\nHTTP_STATUS: %{http_code}\n' -X POST http://localhost:8080/v1/rerank \
-H "Content-Type: application/json" \
-d '{
  "model": "bedrock/cohere-rerank",
  "query": "capital of France",
  "documents": [
    {"text": "Paris is the capital of France."},
    {"text": "Berlin is the capital of Germany."},
    {"text": "Madrid is the capital of Spain."}
  ],
  "top_n": 2,
  "return_documents": true
}'
```

### Expected behavior

* **Before fix:**
  `HTTP 403` with error
  `Credential should be scoped to correct service: 'bedrock'`

<img width="1089" height="306" alt="Screenshot 2026-04-06 202125" src="https://github.com/user-attachments/assets/bbcc57f7-5c8d-4098-bcd1-d52951197caa" />


* **After fix:**
  `HTTP 200` with valid reranked response from Bedrock

<img width="1096" height="338" alt="Screenshot 2026-04-06 202006" src="https://github.com/user-attachments/assets/516cca92-5ae6-4a45-b588-181cad80dce3" />


---

## Screenshots/Recordings

Included:

* Before: 403 SigV4 credential scope error
* After: 200 successful rerank response

---

## Breaking changes

* [ ] Yes
* [x] No

---

## Related issues

Closes #2506
Related discussion: #2294

---

## Security considerations

* No changes to authentication flow or credential handling
* Fix ensures correct SigV4 signing, preventing invalid credential scope usage
* No secrets or sensitive data introduced

---

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [x] I added/updated tests where appropriate
* [x] I updated documentation where needed
* [x] I verified builds succeed (Go and UI)
* [x] I verified the CI pipeline passes locally if applicable


