### PR TITLE
[fix]: logging propagate LLM log metadata to MCP tool logs

### DIFF
--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -6,6 +6,7 @@ package logging
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -24,6 +25,10 @@ import (
 
 const (
 	PluginName = "logging"
+	// logMetadataSnapshotKey is the context key for a shallow copy of log metadata from PreLLMHook (x-bf-lh-*, configured headers).
+	// Defined here so the logging plugin does not require a newer core module than go.mod's require line.
+	// Value must stay stable if ever moved to core/schemas.
+	logMetadataSnapshotKey schemas.BifrostContextKey = "bifrost-log-metadata-snapshot"
 )
 
 // LogOperation represents the type of logging operation
@@ -227,7 +232,7 @@ type LoggerPlugin struct {
 	pendingLogs           sync.Map              // Maps requestID -> *PendingLogData (PreLLMHook input data awaiting PostLLMHook)
 	writeQueue            chan *writeQueueEntry // Buffered channel for batch write queue
 	closed                atomic.Bool           // Set during cleanup to prevent sends on closed writeQueue
-	deferredUsageSem      chan struct{}          // Limits concurrent deferred usage DB updates
+	deferredUsageSem      chan struct{}         // Limits concurrent deferred usage DB updates
 }
 
 // Init creates new logger plugin with given log store
@@ -383,6 +388,18 @@ func (p *LoggerPlugin) captureLoggingHeaders(ctx *schemas.BifrostContext) map[st
 	return metadata
 }
 
+// resolveLogMetadataForMCP returns metadata for MCP tool logs: prefer live request headers,
+// else fall back to the snapshot from the latest PreLLMHook on this context (agent mode).
+func (p *LoggerPlugin) resolveLogMetadataForMCP(ctx *schemas.BifrostContext) map[string]interface{} {
+	if meta := p.captureLoggingHeaders(ctx); meta != nil {
+		return maps.Clone(meta)
+	}
+	if snap, ok := ctx.Value(logMetadataSnapshotKey).(map[string]interface{}); ok && len(snap) > 0 {
+		return maps.Clone(snap)
+	}
+	return nil
+}
+
 // PreLLMHook is called before a request is processed - FULLY ASYNC, NO DATABASE I/O
 // Parameters:
 //   - ctx: The Bifrost context
@@ -514,6 +531,11 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 			initialData.Metadata = make(map[string]interface{})
 		}
 		initialData.Metadata["isAsyncRequest"] = true
+	}
+
+	// Snapshot for MCP tool logs: headers map may not be present on ctx during nested MCP execution.
+	if initialData.Metadata != nil {
+		ctx.SetValue(logMetadataSnapshotKey, maps.Clone(initialData.Metadata))
 	}
 
 	// Queue the log creation message (non-blocking) - Using sync.Pool
@@ -895,6 +917,9 @@ func (p *LoggerPlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 	virtualKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyID)
 	virtualKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName)
 
+	// Resolve before the async goroutine so we do not race on shared context / header maps.
+	mcpMetadata := p.resolveLogMetadataForMCP(ctx)
+
 	go func() {
 		entry := &logstore.MCPToolLog{
 			ID:          requestID,
@@ -921,8 +946,7 @@ func (p *LoggerPlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 			entry.ArgumentsParsed = arguments
 		}
 
-		// Capture configured logging headers and x-bf-lh-* headers into metadata
-		entry.MetadataParsed = p.captureLoggingHeaders(ctx)
+		entry.MetadataParsed = mcpMetadata
 
 		if err := p.store.CreateMCPToolLog(p.ctx, entry); err != nil {
 			p.logger.Warn("Failed to insert initial MCP tool log entry for request %s: %v", requestID, err)

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -392,7 +392,7 @@ func (p *LoggerPlugin) captureLoggingHeaders(ctx *schemas.BifrostContext) map[st
 // else fall back to the snapshot from the latest PreLLMHook on this context (agent mode).
 func (p *LoggerPlugin) resolveLogMetadataForMCP(ctx *schemas.BifrostContext) map[string]interface{} {
 	if meta := p.captureLoggingHeaders(ctx); meta != nil {
-		return maps.Clone(meta)
+		return meta
 	}
 	if snap, ok := ctx.Value(logMetadataSnapshotKey).(map[string]interface{}); ok && len(snap) > 0 {
 		return maps.Clone(snap)
@@ -525,17 +525,17 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 	// Capture configured logging headers and x-bf-lh-* headers into metadata first
 	initialData.Metadata = p.captureLoggingHeaders(ctx)
 
-	// System entries are set after so they take precedence over dynamic header values
+	// Snapshot header-derived metadata for MCP logs before system-only fields are added.
+	if initialData.Metadata != nil {
+		ctx.SetValue(logMetadataSnapshotKey, maps.Clone(initialData.Metadata))
+	}
+
+	// System entries are set after so they take precedence over dynamic header values.
 	if isAsync, ok := ctx.Value(schemas.BifrostIsAsyncRequest).(bool); ok && isAsync {
 		if initialData.Metadata == nil {
 			initialData.Metadata = make(map[string]interface{})
 		}
 		initialData.Metadata["isAsyncRequest"] = true
-	}
-
-	// Snapshot for MCP tool logs: headers map may not be present on ctx during nested MCP execution.
-	if initialData.Metadata != nil {
-		ctx.SetValue(logMetadataSnapshotKey, maps.Clone(initialData.Metadata))
 	}
 
 	// Queue the log creation message (non-blocking) - Using sync.Pool


### PR DESCRIPTION
## Summary

This PR fixes missing `mcp_tool_logs.metadata` when parent logs.metadata correctly includes `x-bf-lh-*` and configured logging headers. MCP hooks reused captureLoggingHeaders, which only reads `BifrostContextKeyRequestHeaders`; that map is often absent on the context used during agent / nested MCP execution, and metadata was read inside a deferred goroutine, which was fragile. 
The logging plugin now snapshots metadata in PreLLMHook and PreMCPHook resolves metadata synchronously (headers first, else snapshot) before the async DB insert. We here used Clone on map to do so.

## Changes

- MCP log metadata alignment: After building `initialData.Metadata` in PreLLMHook, store a clone on context under `logMetadataSnapshotKey` so nested MCP execution can reuse the same metadata without relying on the full HTTP header map.
- resolveLogMetadataForMCP: Prefer `captureLoggingHeaders(ctx)`; if nil, fall back to the snapshot; return `maps.Clone` so callers do not share mutable maps.
- PreMCPHook: Call `resolveLogMetadataForMCP(ctx) `before go func() and set `entry.MetadataParsed = mcpMetadata` inside the goroutine to avoid racing on context / header reads.
- Plugin-local context key: `logMetadataSnapshotKey` is defined in plugins/logging (string "bifrost-log-metadata-snapshot") so the module keeps building against the current core version in go.mod without a new core export.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate MCP tool logs inherit the same logging metadata as the parent LLM log:

```
cd plugins/logging
go build ./...
```
Or just manually use postgres as log store and test it with MCP like :

1. Postgres (or your log backend), logging enabled.
2. Send a gateway request with e.g. `x-bf-lh-correlation-id`: <uuid> (or configured logging_headers).
3. Trigger agent mode with an auto-executed MCP tool.
4. Check Logs on dashboards


If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Relates to logging-headers / MCP tool log metadata behavior (e.g. PR #1719 column & wiring; this fixes propagation when RequestHeaders is missing on the MCP context).

Closes - #2515 


## Security considerations

Nothing

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


