### PR TITLE
feat: Add Embeddings in OpenRouter provider

### DIFF
--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -380,9 +380,21 @@ func (provider *OpenRouterProvider) ResponsesStream(ctx *schemas.BifrostContext,
 	)
 }
 
-// Embedding is not supported by the OpenRouter provider.
+// Embedding performs an embedding request to the OpenRouter API.
 func (provider *OpenRouterProvider) Embedding(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.EmbeddingRequest, provider.GetProviderKey())
+	return openai.HandleOpenAIEmbeddingRequest(
+		ctx,
+		provider.client,
+		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
+		request,
+		key,
+		provider.networkConfig.ExtraHeaders,
+		provider.GetProviderKey(),
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		nil,
+		provider.logger,
+	)
 }
 
 // Speech is not supported by the OpenRouter provider.

--- a/core/providers/openrouter/openrouter_test.go
+++ b/core/providers/openrouter/openrouter_test.go
@@ -28,7 +28,7 @@ func TestOpenRouter(t *testing.T) {
 		ChatModel:      "openai/gpt-4.1",
 		VisionModel:    "openai/gpt-4o",
 		TextModel:      "google/gemini-2.5-flash",
-		EmbeddingModel: "",
+		EmbeddingModel: "qwen/qwen3-embedding-4b",
 		ReasoningModel: "openai/gpt-oss-120b",
 		Scenarios: llmtests.TestScenarios{
 			TextCompletion:        true,
@@ -50,6 +50,7 @@ func TestOpenRouter(t *testing.T) {
 			Reasoning:             true,
 			ListModels:            true,
 			StructuredOutputs:     true, // Structured outputs with nullable enum support
+			Embedding:             true,
 		},
 	}
 

--- a/docs/providers/supported-providers/openrouter.mdx
+++ b/docs/providers/supported-providers/openrouter.mdx
@@ -21,7 +21,7 @@ OpenRouter is an **OpenAI-compatible provider routing service** that accesses mo
 | Responses API | ✅ | ✅ | `/v1/responses` |
 | Text Completions | ✅ | ✅ | `/v1/completions` |
 | List Models | ✅ | - | `/v1/models` |
-| Embeddings | ❌ | ❌ | - |
+| Embeddings | ✅ | - | `/v1/embeddings` |
 | Image Generation | ❌ | ❌ | - |
 | Speech (TTS) | ❌ | ❌ | - |
 | Transcriptions (STT) | ❌ | ❌ | - |
@@ -29,7 +29,7 @@ OpenRouter is an **OpenAI-compatible provider routing service** that accesses mo
 | Batch | ❌ | ❌ | - |
 
 <Note>
-**Unsupported Operations** (❌): Embeddings, Image Generation, Speech, Transcriptions, Files, and Batch are not supported by the upstream OpenRouter API. These return a `BifrostError` with an error code of `"unsupported_operation"`.
+**Unsupported Operations** (❌): Image Generation, Speech, Transcriptions, Files, and Batch are not supported by the upstream OpenRouter API. These return a `BifrostError` with an error code of `"unsupported_operation"`.
 
 **Note**: OpenRouter's Responses API is currently in **beta**.
 </Note>
@@ -131,11 +131,30 @@ Lists 100+ models available through OpenRouter, including:
 
 ---
 
+# 5. Embeddings
+
+OpenRouter supports embeddings through their OpenAI-compatible API. This allows you to generate vector embeddings for text using models from various providers.
+
+| Parameter | Mapping |
+|-----------|---------|
+| `input` | Direct pass-through (string or array of strings) |
+| `model` | Model ID (e.g., `cohere/embed-multilingual-v3.0`, `amazon/amazon-embeddings-v2`) |
+| `dimensions` | Number of dimensions for the output embedding |
+| `encoding_format` | Output format (`float` or `base64`) |
+
+**Supported Models:** OpenRouter supports various embedding models including:
+- Cohere (embed-multilingual-v3.0, embed-english-v3.0, etc.)
+- Amazon (amazon-embeddings-v2)
+- And other providers
+
+The embedding request/response follows the standard OpenAI format.
+
+---
+
 ## Unsupported Features
 
 | Feature | Reason |
 |---------|--------|
-| Embedding | Not offered by OpenRouter API |
 | Image Generation | Not offered by OpenRouter API |
 | Speech/TTS | Not offered by OpenRouter API |
 | Transcription/STT | Not offered by OpenRouter API |


### PR DESCRIPTION
##  Summary

  Added Embeddings support to the OpenRouter provider. Previously, embedding requests returned an "unsupported_operation" error. Now the
   provider can handle embedding requests via OpenRouter's OpenAI-compatible /v1/embeddings endpoint.

##  Changes

  - core/providers/openrouter/openrouter.go: Implemented the Embedding method to handle embedding requests using
  openai.HandleOpenAIEmbeddingRequest, calling the /v1/embeddings endpoint.
  - core/providers/openrouter/openrouter_test.go: Added an embedding model (qwen/qwen3-embedding-4b) and enabled embedding tests.
  - docs/providers/supported-providers/openrouter.mdx: Updated the provider support table and added documentation for the new embeddings
   feature.

##  Type of change

  - [ ] Bug fix
  - [X] Feature
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Chore/CI

  Affected areas

  - [X] Core (Go)
  - [ ] Transports (HTTP)
  - [ ] Providers/Integrations
  - [ ] Plugins
  - [ ] UI (Next.js)
  - [X] Docs

  How to test

  1. go test ./core/providers/openrouter/...
  2. Test embedding requests with the OpenRouter provider to verify the /v1/embeddings endpoint works correctly.

  Breaking changes

  - Yes
  - [X] No

  Related issues

  #2538 

  Security considerations

  None AFAIK