### PR TITLE
refactor: updates prompt model parameters UI

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/prompt-deployments/promptDeploymentView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/prompt-deployments/promptDeploymentView.tsx
@@ -1,7 +1,7 @@
 import { Router } from "lucide-react";
 import ContactUsView from "../views/contactUsView";
 
-export default function PromptDeploymentView() {
+export default function PromptDeploymentView(_props?: { omitTitle?: boolean }) {
 	return (
 		<div className="w-full">
 			<ContactUsView

--- a/ui/app/_fallbacks/enterprise/components/prompt-deployments/promptDeploymentsAccordionItem.tsx
+++ b/ui/app/_fallbacks/enterprise/components/prompt-deployments/promptDeploymentsAccordionItem.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { usePromptContext } from "@/components/prompts/context";
+import { AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { cn } from "@/lib/utils";
+import PromptDeploymentView from "./promptDeploymentView";
+
+export type SettingsSidebarSection = "parameters" | "deployments";
+
+export function PromptDeploymentsAccordionItem({
+	activeSection,
+}: {
+	activeSection: SettingsSidebarSection | undefined;
+}) {
+	const { selectedPromptId } = usePromptContext();
+	if (!selectedPromptId) {
+		return null;
+	}
+
+	const deploymentsOpen = activeSection === "deployments";
+
+	return (
+		<AccordionItem
+			value="deployments"
+			className={cn(
+				"border-border/60 flex min-h-0 flex-col border-b-0 border-t pt-1",
+				deploymentsOpen ? "min-h-0 grow overflow-hidden" : "shrink-0 grow-0",
+			)}
+		>
+			<AccordionTrigger data-testid="prompt-deployments-trigger" className="text-muted-foreground w-full min-w-0 shrink-0 py-3 pr-1 text-xs font-medium uppercase hover:no-underline">
+				<span className="min-w-0 flex-1 text-left">Deployments</span>
+			</AccordionTrigger>
+			<AccordionContent
+				containerClassName="data-[state=open]:flex data-[state=open]:min-h-0 data-[state=open]:flex-1 data-[state=open]:flex-col"
+				className="min-h-0 flex-1 overflow-y-auto pb-2 pt-0"
+			>
+				<PromptDeploymentView omitTitle />
+			</AccordionContent>
+		</AccordionItem>
+	);
+}

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -3,36 +3,54 @@
  * Create/Edit form for routing rules
  */
 
-import { useState, useEffect, useCallback } from "react";
-import { useForm } from "react-hook-form";
-import { RuleGroupType } from "react-querybuilder";
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+"use client";
+
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
-import { X, Save, Plus, Trash2 } from "lucide-react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import {
-	RoutingRule,
-	RoutingRuleFormData,
-	RoutingTargetFormData,
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
+} from "@/components/ui/sheet";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
+import { getProviderLabel } from "@/lib/constants/logs";
+import { getErrorMessage } from "@/lib/store";
+import {
+	useGetCustomersQuery,
+	useGetTeamsQuery,
+	useGetVirtualKeysQuery,
+} from "@/lib/store/apis/governanceApi";
+import { useGetAllKeysQuery, useGetProvidersQuery } from "@/lib/store/apis/providersApi";
+import {
+	useCreateRoutingRuleMutation,
+	useGetRoutingRulesQuery,
+	useUpdateRoutingRuleMutation,
+} from "@/lib/store/apis/routingRulesApi";
+import {
 	DEFAULT_ROUTING_RULE_FORM_DATA,
 	DEFAULT_ROUTING_TARGET,
 	ROUTING_RULE_SCOPES,
+	RoutingRule,
+	RoutingRuleFormData,
+	RoutingTargetFormData,
 } from "@/lib/types/routingRules";
-import { useCreateRoutingRuleMutation, useUpdateRoutingRuleMutation, useGetRoutingRulesQuery } from "@/lib/store/apis/routingRulesApi";
-import { useGetVirtualKeysQuery, useGetTeamsQuery, useGetCustomersQuery } from "@/lib/store/apis/governanceApi";
-import { useGetProvidersQuery, useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
+import {
+	validateRateLimitAndBudgetRules,
+	validateRoutingRules
+} from "@/lib/utils/celConverterRouting";
+import { Plus, Save, Trash2, X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { RuleGroupType } from "react-querybuilder";
 import { toast } from "sonner";
-import { Suspense, lazy } from "react";
-import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
-import { getProviderLabel } from "@/lib/constants/logs";
-import { Separator } from "@/components/ui/separator";
-import { getErrorMessage } from "@/lib/store";
-import { validateRoutingRules, validateRateLimitAndBudgetRules } from "@/lib/utils/celConverterRouting";
 
 interface RoutingRuleDialogProps {
 	open: boolean;

--- a/ui/components/prompts/fragments/settingsPanel.tsx
+++ b/ui/components/prompts/fragments/settingsPanel.tsx
@@ -1,8 +1,8 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { ComboboxSelect } from "@/components/ui/combobox";
 import ModelParameters from "@/components/ui/custom/modelParameters";
 import { Label } from "@/components/ui/label";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
-import { ScrollArea } from "@/components/ui/scrollArea";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getProviderLabel } from "@/lib/constants/logs";
@@ -10,8 +10,9 @@ import { useGetVirtualKeysQuery } from "@/lib/store";
 import { useGetAllKeysQuery, useGetProvidersQuery } from "@/lib/store/apis/providersApi";
 import { ModelProviderName } from "@/lib/types/config";
 import { ModelParams } from "@/lib/types/prompts";
-import PromptDeploymentView from "@enterprise/components/prompt-deployments/promptDeploymentView";
-import { useCallback, useMemo } from "react";
+import { cn } from "@/lib/utils";
+import { PromptDeploymentsAccordionItem } from "@enterprise/components/prompt-deployments/promptDeploymentsAccordionItem";
+import { useCallback, useMemo, useState } from "react";
 import { ApiKeySelectorView } from "../components/apiKeySelectorView";
 import { VariablesTableView } from "../components/variablesTableView";
 import { usePromptContext } from "../context";
@@ -26,6 +27,9 @@ export function SettingsPanel() {
 		setModelParams: onModelParamsChange,
 		apiKeyId,
 		setApiKeyId,
+		variables,
+		setVariables,
+		selectedPromptId,
 	} = usePromptContext();
 
 	const onProviderChange = useCallback(
@@ -113,6 +117,11 @@ export function SettingsPanel() {
 		[onModelParamsChange],
 	);
 
+	const hasModel = Boolean(model);
+
+	type SettingsSection = "parameters" | "deployments";
+	const [openSection, setOpenSection] = useState<SettingsSection | undefined>("parameters");
+
 	if (isInitialLoading) {
 		return (
 			<div className="flex h-full flex-col">
@@ -131,66 +140,98 @@ export function SettingsPanel() {
 	}
 
 	return (
-		<div className="flex h-full flex-col">
-			<ScrollArea className="grow overflow-y-auto" viewportClassName="no-table">
-				<div className="space-y-6 p-4">
-					<div className="flex flex-col gap-2" data-testid="settings-provider">
-						<Label className="text-muted-foreground text-xs font-medium uppercase">Provider</Label>
-						<ComboboxSelect
-							options={providerOptions}
-							value={provider}
-							onValueChange={(v) => v && onProviderChange(v)}
-							placeholder="Select provider"
-							hideClear
-						/>
-					</div>
+		<div className="flex h-full min-h-0 flex-col">
+			<div className="flex min-h-0 flex-1 flex-col px-4 pb-4 pt-2">
+				<Accordion
+					type="single"
+					collapsible
+					value={openSection ?? ""}
+					onValueChange={(v) => {
+						if (v === "parameters" || v === "deployments") {
+							setOpenSection(v);
+						} else {
+							setOpenSection(undefined);
+						}
+					}}
+					className="flex min-h-0 flex-1 flex-col"
+				>
+					<AccordionItem
+						value="parameters"
+						className={cn(
+							"flex min-h-0 flex-col border-b-0",
+							openSection === "parameters" ? "flex-1" : "shrink-0 overflow-hidden",
+						)}
+					>
+						<AccordionTrigger data-testid="prompts-configuration-trigger" className="text-muted-foreground shrink-0 py-3 pr-1 text-xs font-medium uppercase hover:no-underline">
+							<span className="min-w-0 flex-1 text-left font-semibold">Configuration</span>
+						</AccordionTrigger>
+						<AccordionContent
+							containerClassName="data-[state=open]:flex data-[state=open]:min-h-0 data-[state=open]:flex-1 data-[state=open]:flex-col"
+							className="min-h-0 flex-1 overflow-y-auto pb-2 pt-0"
+						>
+							<div className="space-y-6">
+								<div className="flex flex-col gap-2" data-testid="settings-provider">
+									<Label className="text-muted-foreground text-xs font-medium uppercase">Provider</Label>
+									<ComboboxSelect
+										options={providerOptions}
+										value={provider}
+										onValueChange={(v) => v && onProviderChange(v)}
+										placeholder="Select provider"
+										hideClear
+									/>
+								</div>
 
-					<div className="flex flex-col gap-2" data-testid="settings-model">
-						<Label className="text-muted-foreground text-xs font-medium uppercase">Model</Label>
-						<ModelMultiselect
-							provider={provider}
-							keys={filterKeys && filterKeys.length > 0 ? filterKeys : undefined}
-							vks={filterVks}
-							value={model}
-							onChange={(v) => onModelChange(v)}
-							isSingleSelect
-							unfiltered
-							placeholder={!provider ? "Select a provider first" : "Select model"}
-							disabled={!provider}
-						/>
-					</div>
+								<div className="flex flex-col gap-2" data-testid="settings-model">
+									<Label className="text-muted-foreground text-xs font-medium uppercase">Model</Label>
+									<ModelMultiselect
+										provider={provider}
+										keys={filterKeys && filterKeys.length > 0 ? filterKeys : undefined}
+										vks={filterVks}
+										value={model}
+										onChange={(v) => onModelChange(v)}
+										isSingleSelect
+										placeholder={!provider ? "Select a provider first" : "Select model"}
+										disabled={!provider}
+										unfiltered={true}
+									/>
+								</div>
 
-					{(providerKeys.length > 0 || providerVirtualKeys.length > 0) && !!provider && (
-						<ApiKeySelectorView
-							providerKeys={providerKeys}
-							virtualKeys={providerVirtualKeys}
-							value={apiKeyId}
-							onValueChange={(v) => onApiKeyIdChange(v ?? "__auto__")}
-							disabled={!provider}
-						/>
-					)}
+								{(providerKeys.length > 0 || providerVirtualKeys.length > 0) && !!provider && (
+									<ApiKeySelectorView
+										providerKeys={providerKeys}
+										virtualKeys={providerVirtualKeys}
+										value={apiKeyId}
+										onValueChange={(v) => onApiKeyIdChange(v ?? "__auto__")}
+										disabled={!provider}
+									/>
+								)}
 
-					{Object.keys(variables).length > 0 && (
-						<>
-							<Separator />
-							<VariablesTableView variables={variables} onChange={setVariables} />
-						</>
-					)}
+								{Object.keys(variables).length > 0 && (
+									<>
+										<Separator />
+										<VariablesTableView variables={variables} onChange={setVariables} />
+									</>
+								)}
 
-					{model && (
-						<>
-							<Separator />
-
-							<div className="flex flex-col gap-4">
-								<Label className="text-muted-foreground text-xs font-medium uppercase">Model Parameters</Label>
-								<ModelParameters model={model} config={modelParams} onChange={handleModelParamsChange} hideFields={["promptTools"]} />
+								{hasModel && (
+									<>
+										<Separator />
+										<div className="flex flex-col gap-4">
+											<ModelParameters
+												model={model}
+												config={modelParams}
+												onChange={handleModelParamsChange}
+												hideFields={["promptTools"]}
+											/>
+										</div>
+									</>
+								)}
 							</div>
-						</>
-					)}
-
-					<PromptDeploymentView />
-				</div>
-			</ScrollArea>
+						</AccordionContent>
+					</AccordionItem>
+					{selectedPromptId && <PromptDeploymentsAccordionItem activeSection={openSection} />}
+				</Accordion>
+			</div>
 		</div>
 	);
 }

--- a/ui/components/ui/accordion.tsx
+++ b/ui/components/ui/accordion.tsx
@@ -14,27 +14,38 @@ function AccordionItem({ className, ...props }: React.ComponentProps<typeof Acco
 
 function AccordionTrigger({ className, children, ...props }: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
 	return (
-		<AccordionPrimitive.Header className="flex">
+		<AccordionPrimitive.Header className="flex w-full min-w-0">
 			<AccordionPrimitive.Trigger
 				data-slot="accordion-trigger"
 				className={cn(
-					"focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-sm py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+					"focus-visible:border-ring focus-visible:ring-ring/50 flex w-full min-w-0 flex-1 items-center justify-between gap-2 rounded-sm py-4 text-left text-sm font-medium transition-colors outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
 					className,
 				)}
 				{...props}
 			>
 				{children}
-				<ChevronDownIcon className="text-muted-foreground pointer-events-none my-auto size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+				<ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 transition-transform duration-200" />
 			</AccordionPrimitive.Trigger>
 		</AccordionPrimitive.Header>
 	);
 }
 
-function AccordionContent({ className, children, ...props }: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+function AccordionContent({
+	className,
+	containerClassName,
+	children,
+	...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content> & {
+	/** Classes merged onto the Radix content wrapper (outer). `className` still targets the inner div. */
+	containerClassName?: string;
+}) {
 	return (
 		<AccordionPrimitive.Content
 			data-slot="accordion-content"
-			className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+			className={cn(
+				"data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm",
+				containerClassName,
+			)}
 			{...props}
 		>
 			<div className={cn("pt-0 pb-4", className)}>{children}</div>


### PR DESCRIPTION
## Summary

Refactored the prompt settings panel to use an accordion layout, separating configuration and deployments into collapsible sections for improved organization and space utilization.

## Changes

- Converted the settings panel from a scrollable layout to an accordion-based interface with "Configuration" and "Deployments" sections
- Added `PromptDeploymentsAccordionItem` component to handle the deployments section within the accordion
- Enhanced the `AccordionContent` component with a `containerClassName` prop for better layout control
- Modified `PromptDeploymentView` to accept an optional `omitTitle` prop for cleaner integration
- Improved accordion trigger styling for better alignment and spacing

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Validate the accordion functionality and layout in the prompt settings panel:

1. Navigate to the prompts interface
2. Select a prompt to view the settings panel
3. Verify the "Configuration" section expands/collapses properly
4. Verify the "Deployments" section appears when a prompt is selected
5. Test that only one section can be open at a time
6. Ensure all existing functionality (provider selection, model parameters, etc.) works within the accordion

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

No security implications - this is a UI layout refactor that doesn't affect authentication, data handling, or API interactions.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable