### PR TITLE
fix: accept string durations in MCP config JSON to avoid Helm config conflicts while maintaining backward compatibility.

### DIFF
--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -5,7 +5,9 @@ package schemas
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -75,7 +77,7 @@ const (
 
 // MCPClientConfig defines tool filtering for an MCP client.
 type MCPClientConfig struct {
-	ID               string            `json:"client_id"`                          // Client ID
+	ID               string            `json:"client_id"`                   // Client ID
 	Name             string            `json:"name"`                        // Client name
 	IsCodeModeClient bool              `json:"is_code_mode_client"`         // Whether the client is a code mode client
 	ConnectionType   MCPConnectionType `json:"connection_type"`             // How to connect (HTTP, STDIO, SSE, or InProcess)
@@ -103,6 +105,130 @@ type MCPClientConfig struct {
 	ToolSyncInterval time.Duration      `json:"tool_sync_interval,omitempty"` // Per-client override for tool sync interval (0 = use global, negative = disabled)
 	ToolPricing      map[string]float64 `json:"tool_pricing,omitempty"`       // Tool pricing for each tool (cost per execution)
 	ConfigHash       string             `json:"-"`                            // Config hash for reconciliation (not serialized)
+}
+
+func parseFlexibleDurationJSON(data json.RawMessage) (time.Duration, error) {
+	if len(data) == 0 || string(data) == "null" {
+		return 0, nil
+	}
+
+	var durationString string
+	if err := json.Unmarshal(data, &durationString); err == nil {
+		parsedDuration, parseErr := time.ParseDuration(durationString)
+		if parseErr != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", durationString, parseErr)
+		}
+		return parsedDuration, nil
+	}
+
+	var durationNanos int64
+	if err := json.Unmarshal(data, &durationNanos); err == nil {
+		return time.Duration(durationNanos), nil
+	}
+
+	return 0, errors.New("must be a duration string or integer nanoseconds")
+}
+
+// UnmarshalJSON accepts duration fields as either Go duration strings (for example "10m")
+// or raw integer nanoseconds for backward compatibility.
+func (c *MCPConfig) UnmarshalJSON(data []byte) error {
+	type rawMCPConfig struct {
+		ClientConfigs     []*MCPClientConfig    `json:"client_configs,omitempty"`
+		ToolManagerConfig *MCPToolManagerConfig `json:"tool_manager_config,omitempty"`
+		ToolSyncInterval  json.RawMessage       `json:"tool_sync_interval,omitempty"`
+	}
+
+	var raw rawMCPConfig
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	c.ClientConfigs = raw.ClientConfigs
+	c.ToolManagerConfig = raw.ToolManagerConfig
+
+	parsedDuration, err := parseFlexibleDurationJSON(raw.ToolSyncInterval)
+	if err != nil {
+		return fmt.Errorf("tool_sync_interval: %w", err)
+	}
+	c.ToolSyncInterval = parsedDuration
+
+	return nil
+}
+
+// UnmarshalJSON accepts tool_execution_timeout as either a Go duration string
+// or raw integer nanoseconds for backward compatibility.
+func (c *MCPToolManagerConfig) UnmarshalJSON(data []byte) error {
+	type rawMCPToolManagerConfig struct {
+		ToolExecutionTimeout json.RawMessage      `json:"tool_execution_timeout,omitempty"`
+		MaxAgentDepth        int                  `json:"max_agent_depth"`
+		CodeModeBindingLevel CodeModeBindingLevel `json:"code_mode_binding_level,omitempty"`
+	}
+
+	var raw rawMCPToolManagerConfig
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	c.MaxAgentDepth = raw.MaxAgentDepth
+	c.CodeModeBindingLevel = raw.CodeModeBindingLevel
+
+	parsedDuration, err := parseFlexibleDurationJSON(raw.ToolExecutionTimeout)
+	if err != nil {
+		return fmt.Errorf("tool_execution_timeout: %w", err)
+	}
+	c.ToolExecutionTimeout = parsedDuration
+
+	return nil
+}
+
+// UnmarshalJSON accepts tool_sync_interval as either a Go duration string
+// or raw integer nanoseconds for backward compatibility.
+func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
+	type rawMCPClientConfig struct {
+		ID                 string             `json:"client_id"`
+		Name               string             `json:"name"`
+		IsCodeModeClient   bool               `json:"is_code_mode_client"`
+		ConnectionType     MCPConnectionType  `json:"connection_type"`
+		ConnectionString   *EnvVar            `json:"connection_string,omitempty"`
+		StdioConfig        *MCPStdioConfig    `json:"stdio_config,omitempty"`
+		AuthType           MCPAuthType        `json:"auth_type"`
+		OauthConfigID      *string            `json:"oauth_config_id,omitempty"`
+		State              string             `json:"state,omitempty"`
+		Headers            map[string]EnvVar  `json:"headers,omitempty"`
+		ToolsToExecute     []string           `json:"tools_to_execute,omitempty"`
+		ToolsToAutoExecute []string           `json:"tools_to_auto_execute,omitempty"`
+		IsPingAvailable    bool               `json:"is_ping_available"`
+		ToolSyncInterval   json.RawMessage    `json:"tool_sync_interval,omitempty"`
+		ToolPricing        map[string]float64 `json:"tool_pricing,omitempty"`
+	}
+
+	var raw rawMCPClientConfig
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	c.ID = raw.ID
+	c.Name = raw.Name
+	c.IsCodeModeClient = raw.IsCodeModeClient
+	c.ConnectionType = raw.ConnectionType
+	c.ConnectionString = raw.ConnectionString
+	c.StdioConfig = raw.StdioConfig
+	c.AuthType = raw.AuthType
+	c.OauthConfigID = raw.OauthConfigID
+	c.State = raw.State
+	c.Headers = raw.Headers
+	c.ToolsToExecute = raw.ToolsToExecute
+	c.ToolsToAutoExecute = raw.ToolsToAutoExecute
+	c.IsPingAvailable = raw.IsPingAvailable
+	c.ToolPricing = raw.ToolPricing
+
+	parsedDuration, err := parseFlexibleDurationJSON(raw.ToolSyncInterval)
+	if err != nil {
+		return fmt.Errorf("tool_sync_interval: %w", err)
+	}
+	c.ToolSyncInterval = parsedDuration
+
+	return nil
 }
 
 // NewMCPClientConfigFromMap creates a new MCP client config from a map[string]any.

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -135,20 +135,15 @@ func parseFlexibleDurationJSON(data json.RawMessage) (time.Duration, error) {
 // UnmarshalJSON accepts duration fields as either Go duration strings (for example "10m")
 // or raw integer nanoseconds for backward compatibility.
 func (c *MCPConfig) UnmarshalJSON(data []byte) error {
-	type rawMCPConfig struct {
-		ClientConfigs     []*MCPClientConfig    `json:"client_configs,omitempty"`
-		ToolManagerConfig *MCPToolManagerConfig `json:"tool_manager_config,omitempty"`
-		ToolSyncInterval  json.RawMessage       `json:"tool_sync_interval,omitempty"`
+	type alias MCPConfig
+	var raw struct {
+		*alias
+		ToolSyncInterval json.RawMessage `json:"tool_sync_interval,omitempty"`
 	}
-
-	var raw rawMCPConfig
+	raw.alias = (*alias)(c)
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-
-	c.ClientConfigs = raw.ClientConfigs
-	c.ToolManagerConfig = raw.ToolManagerConfig
-
 	parsedDuration, err := parseFlexibleDurationJSON(raw.ToolSyncInterval)
 	if err != nil {
 		return fmt.Errorf("tool_sync_interval: %w", err)
@@ -161,19 +156,15 @@ func (c *MCPConfig) UnmarshalJSON(data []byte) error {
 // UnmarshalJSON accepts tool_execution_timeout as either a Go duration string
 // or raw integer nanoseconds for backward compatibility.
 func (c *MCPToolManagerConfig) UnmarshalJSON(data []byte) error {
-	type rawMCPToolManagerConfig struct {
-		ToolExecutionTimeout json.RawMessage      `json:"tool_execution_timeout,omitempty"`
-		MaxAgentDepth        int                  `json:"max_agent_depth"`
-		CodeModeBindingLevel CodeModeBindingLevel `json:"code_mode_binding_level,omitempty"`
+	type alias MCPToolManagerConfig
+	var raw struct {
+		*alias
+		ToolExecutionTimeout json.RawMessage `json:"tool_execution_timeout,omitempty"`
 	}
-
-	var raw rawMCPToolManagerConfig
+	raw.alias = (*alias)(c)
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-
-	c.MaxAgentDepth = raw.MaxAgentDepth
-	c.CodeModeBindingLevel = raw.CodeModeBindingLevel
 
 	parsedDuration, err := parseFlexibleDurationJSON(raw.ToolExecutionTimeout)
 	if err != nil {
@@ -187,43 +178,15 @@ func (c *MCPToolManagerConfig) UnmarshalJSON(data []byte) error {
 // UnmarshalJSON accepts tool_sync_interval as either a Go duration string
 // or raw integer nanoseconds for backward compatibility.
 func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
-	type rawMCPClientConfig struct {
-		ID                 string             `json:"client_id"`
-		Name               string             `json:"name"`
-		IsCodeModeClient   bool               `json:"is_code_mode_client"`
-		ConnectionType     MCPConnectionType  `json:"connection_type"`
-		ConnectionString   *EnvVar            `json:"connection_string,omitempty"`
-		StdioConfig        *MCPStdioConfig    `json:"stdio_config,omitempty"`
-		AuthType           MCPAuthType        `json:"auth_type"`
-		OauthConfigID      *string            `json:"oauth_config_id,omitempty"`
-		State              string             `json:"state,omitempty"`
-		Headers            map[string]EnvVar  `json:"headers,omitempty"`
-		ToolsToExecute     []string           `json:"tools_to_execute,omitempty"`
-		ToolsToAutoExecute []string           `json:"tools_to_auto_execute,omitempty"`
-		IsPingAvailable    bool               `json:"is_ping_available"`
-		ToolSyncInterval   json.RawMessage    `json:"tool_sync_interval,omitempty"`
-		ToolPricing        map[string]float64 `json:"tool_pricing,omitempty"`
+	type alias MCPClientConfig
+	var raw struct {
+		*alias
+		ToolSyncInterval json.RawMessage `json:"tool_sync_interval,omitempty"`
 	}
-
-	var raw rawMCPClientConfig
+	raw.alias = (*alias)(c)
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-
-	c.ID = raw.ID
-	c.Name = raw.Name
-	c.IsCodeModeClient = raw.IsCodeModeClient
-	c.ConnectionType = raw.ConnectionType
-	c.ConnectionString = raw.ConnectionString
-	c.StdioConfig = raw.StdioConfig
-	c.AuthType = raw.AuthType
-	c.OauthConfigID = raw.OauthConfigID
-	c.State = raw.State
-	c.Headers = raw.Headers
-	c.ToolsToExecute = raw.ToolsToExecute
-	c.ToolsToAutoExecute = raw.ToolsToAutoExecute
-	c.IsPingAvailable = raw.IsPingAvailable
-	c.ToolPricing = raw.ToolPricing
 
 	parsedDuration, err := parseFlexibleDurationJSON(raw.ToolSyncInterval)
 	if err != nil {

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -115,6 +115,9 @@ func parseFlexibleDurationJSON(data json.RawMessage) (time.Duration, error) {
 	var durationString string
 	if err := json.Unmarshal(data, &durationString); err == nil {
 		parsedDuration, parseErr := time.ParseDuration(durationString)
+		if durationString == "" {
+			return 0, nil
+		}
 		if parseErr != nil {
 			return 0, fmt.Errorf("invalid duration %q: %w", durationString, parseErr)
 		}


### PR DESCRIPTION
## Summary

Fix MCP config duration parsing so string values like `"10m"` and `"45s"` work at runtime.

The Helm values schema and raw config schema already allow string durations for MCP config, but the Go runtime was using plain `time.Duration` fields with default JSON unmarshalling. That caused valid configs such as `tool_sync_interval: "10m"` to fail during config load.

This PR makes MCP duration fields accept both Go duration strings and integer nanoseconds for backward compatibility.


## Changes

- Added flexible duration JSON parsing helper in `core/schemas/mcp.go`
- `MCPConfig.tool_sync_interval` now accepts:
  - `"10m"`
  - `600000000000`
- `MCPClientConfig.tool_sync_interval` now accepts the same formats
- `MCPToolManagerConfig.tool_execution_timeout` now also accepts string durations
- Added regression tests for:
  - global MCP tool sync interval
  - per-client MCP tool sync interval
  - tool execution timeout
  - invalid duration handling

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

# Core
```
cd core
go version
go test ./schemas
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [x] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Closes #2546 

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


