### PR TITLE
fix: mcp tool logs

### DIFF
--- a/core/mcp/agent.go
+++ b/core/mcp/agent.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	
+
 	"github.com/bytedance/sonic"
+	"github.com/google/uuid"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -291,13 +292,18 @@ func (a *AgentModeExecutor) executeAgent(
 			for _, toolCall := range autoExecutableTools {
 				go func(toolCall schemas.ChatAssistantMessageToolCall) {
 					defer wg.Done()
+					// Create a derived context with a unique MCP log ID so that the logging
+					// plugin can create separate log entries for each parallel tool call.
+					toolCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+					toolCtx.SetValue(schemas.BifrostContextKeyMCPLogID, uuid.New().String())
+
 					// Create MCP request for this tool call
 					mcpRequest := &schemas.BifrostMCPRequest{
 						RequestType:                  schemas.MCPRequestTypeChatToolCall,
 						ChatAssistantMessageToolCall: &toolCall,
 					}
 
-					mcpResponse, toolErr := executeToolFunc(ctx, mcpRequest)
+					mcpResponse, toolErr := executeToolFunc(toolCtx, mcpRequest)
 					if toolErr != nil {
 						a.logger.Warn("Tool execution failed: %v", toolErr)
 						channelToolResults <- createToolResultMessage(toolCall, "", toolErr)

--- a/core/mcp/agent_test.go
+++ b/core/mcp/agent_test.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -529,6 +531,155 @@ func TestExecuteAgentForResponsesRequest_WithNonAutoExecutableTools(t *testing.T
 	// Verify that no LLM calls were made (since tools are non-auto-executable)
 	if llmCaller.responsesCallCount != 0 {
 		t.Errorf("Expected 0 LLM calls for non-auto-executable tools, got %d", llmCaller.responsesCallCount)
+	}
+}
+
+// MockAutoClientManager returns a client state that marks all tools as auto-executable.
+type MockAutoClientManager struct{}
+
+func (m *MockAutoClientManager) GetClientForTool(toolName string) *schemas.MCPClientState {
+	return &schemas.MCPClientState{
+		Name: "test-client",
+		ExecutionConfig: &schemas.MCPClientConfig{
+			Name:               "test-client",
+			ToolsToExecute:     []string{"*"},
+			ToolsToAutoExecute: []string{"*"},
+		},
+	}
+}
+
+func (m *MockAutoClientManager) GetClientByName(clientName string) *schemas.MCPClientState {
+	return nil
+}
+
+func (m *MockAutoClientManager) GetToolPerClient(ctx context.Context) map[string][]schemas.ChatTool {
+	return make(map[string][]schemas.ChatTool)
+}
+
+// TestParallelToolCallsHaveUniqueMCPLogIDs verifies that parallel tool calls within a
+// single LLM response each receive a unique BifrostContextKeyMCPLogID in their context.
+//
+// The logging plugin uses this ID as the primary key for MCPToolLog entries, so each
+// parallel tool call must have a distinct value to avoid PK conflicts and input/output
+// mismatches caused by multiple goroutines racing to update the same row.
+func TestParallelToolCallsHaveUniqueMCPLogIDs(t *testing.T) {
+	const requestID = "test-request-id-123"
+	const numTools = 4
+
+	// Collect the MCP log IDs seen by executeToolFunc across all parallel calls.
+	var mu sync.Mutex
+	seenMCPLogIDs := make([]string, 0, numTools)
+
+	// Build a response with 4 parallel is_prime tool calls.
+	toolCalls := make([]schemas.ChatAssistantMessageToolCall, numTools)
+	for i := range toolCalls {
+		id := fmt.Sprintf("call_%d", i)
+		name := "is_prime"
+		toolCalls[i] = schemas.ChatAssistantMessageToolCall{
+			ID: &id,
+			Function: schemas.ChatAssistantMessageToolCallFunction{
+				Name:      &name,
+				Arguments: fmt.Sprintf(`{"n": %d}`, i+2),
+			},
+		}
+	}
+
+	initialResponse := &schemas.BifrostChatResponse{
+		Choices: []schemas.BifrostResponseChoice{
+			{
+				FinishReason: schemas.Ptr("tool_calls"),
+				ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+					Message: &schemas.ChatMessage{
+						Role: schemas.ChatMessageRoleAssistant,
+						ChatAssistantMessage: &schemas.ChatAssistantMessage{
+							ToolCalls: toolCalls,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// makeReq returns a final non-tool response to terminate the agent loop.
+	makeReq := func(ctx *schemas.BifrostContext, req *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+		return &schemas.BifrostChatResponse{
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					FinishReason: schemas.Ptr("stop"),
+					ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+						Message: &schemas.ChatMessage{
+							Role:    schemas.ChatMessageRoleAssistant,
+							Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("2, 3, and 5 are prime; 4 is not.")},
+						},
+					},
+				},
+			},
+		}, nil
+	}
+
+	executeToolFunc := func(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest) (*schemas.BifrostMCPResponse, error) {
+		mcpLogID, ok := ctx.Value(schemas.BifrostContextKeyMCPLogID).(string)
+		if !ok || mcpLogID == "" {
+			return nil, fmt.Errorf("missing mcp log id in tool context")
+		}
+		mu.Lock()
+		seenMCPLogIDs = append(seenMCPLogIDs, mcpLogID)
+		mu.Unlock()
+
+		toolCallID := ""
+		if req.ChatAssistantMessageToolCall != nil && req.ChatAssistantMessageToolCall.ID != nil {
+			toolCallID = *req.ChatAssistantMessageToolCall.ID
+		}
+		return &schemas.BifrostMCPResponse{
+			ChatMessage: &schemas.ChatMessage{
+				Role: schemas.ChatMessageRoleTool,
+				ChatToolMessage: &schemas.ChatToolMessage{
+					ToolCallID: &toolCallID,
+				},
+				Content: &schemas.ChatMessageContent{
+					ContentStr: schemas.Ptr("true"),
+				},
+			},
+		}, nil
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyRequestID, requestID)
+
+	originalReq := &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4",
+		Input: []schemas.ChatMessage{
+			{
+				Role:    schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("check if 2,3,4,5 are prime")},
+			},
+		},
+	}
+
+	agentModeExecutor := &AgentModeExecutor{logger: &MockLogger{}}
+	_, err := agentModeExecutor.ExecuteAgentForChatRequest(
+		ctx, 10, originalReq, initialResponse, makeReq, nil, executeToolFunc, &MockAutoClientManager{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(seenMCPLogIDs) != numTools {
+		t.Fatalf("expected executeToolFunc to be called %d times, got %d", numTools, len(seenMCPLogIDs))
+	}
+
+	// Each parallel tool call must have a unique MCP log ID so the logging plugin
+	// can create separate MCPToolLog entries without primary key conflicts.
+	uniqueIDs := make(map[string]struct{})
+	for _, id := range seenMCPLogIDs {
+		uniqueIDs[id] = struct{}{}
+	}
+	if len(uniqueIDs) != numTools {
+		t.Errorf(
+			"expected %d unique MCP log IDs (one per parallel tool call), got %d",
+			numTools, len(uniqueIDs),
+		)
 	}
 }
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -247,6 +247,7 @@ const (
 	BifrostContextKeySSEReaderFactory                    BifrostContextKey = "bifrost-sse-reader-factory"                 // *providerUtils.SSEReaderFactory (set by enterprise — replaces default bufio.Scanner SSE readers with streaming readers)
 	BifrostContextKeySessionID                           BifrostContextKey = "bifrost-session-id"                         // string session ID for the request (session stickiness)
 	BifrostContextKeySessionTTL                          BifrostContextKey = "bifrost-session-ttl"                        // time.Duration session TTL for the request (session stickiness)
+	BifrostContextKeyMCPLogID                            BifrostContextKey = "bifrost-mcp-log-id"                         // string (unique UUID for each MCP tool log entry - set per goroutine by agent executor - DO NOT SET THIS MANUALLY)
 )
 
 const (

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -203,6 +203,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddLogsAndDashboardPerformanceIndexes(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddRequestIDColumnToMCPToolLogs(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -1481,6 +1484,57 @@ func migrationAddMetadataColumnToMCPToolLogs(ctx context.Context, db *gorm.DB) e
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while adding metadata column to mcp_tool_logs: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddRequestIDColumnToMCPToolLogs adds the request_id column to the mcp_tool_logs table.
+// This stores the original context request ID separately from the primary key (which is now a UUID),
+// enabling correct logging of parallel tool calls that share the same request ID.
+func migrationAddRequestIDColumnToMCPToolLogs(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "mcp_tool_logs_add_request_id_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&MCPToolLog{}, "request_id") {
+				if err := migrator.AddColumn(&MCPToolLog{}, "request_id"); err != nil {
+					return err
+				}
+			}
+			if err := tx.Exec(
+				"UPDATE mcp_tool_logs SET request_id = id WHERE request_id IS NULL OR request_id = ''",
+			).Error; err != nil {
+				return fmt.Errorf("failed to backfill request_id: %w", err)
+			}
+			if !migrator.HasIndex(&MCPToolLog{}, "idx_mcp_logs_request_id") {
+				if err := migrator.CreateIndex(&MCPToolLog{}, "idx_mcp_logs_request_id"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasIndex(&MCPToolLog{}, "idx_mcp_logs_request_id") {
+				if err := migrator.DropIndex(&MCPToolLog{}, "idx_mcp_logs_request_id"); err != nil {
+					return err
+				}
+			}
+			if migrator.HasColumn(&MCPToolLog{}, "request_id") {
+				if err := migrator.DropColumn(&MCPToolLog{}, "request_id"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding request_id column to mcp_tool_logs: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -638,6 +638,7 @@ func (l *Log) DeserializeFields() error {
 // This is separate from the main Log table since MCP tool calls have different fields
 type MCPToolLog struct {
 	ID             string    `gorm:"primaryKey;type:varchar(255)" json:"id"`
+	RequestID      string    `gorm:"type:varchar(255);column:request_id;index:idx_mcp_logs_request_id" json:"request_id,omitempty"` // The original request ID from context
 	LLMRequestID   *string   `gorm:"type:varchar(255);column:llm_request_id;index:idx_mcp_logs_llm_request_id" json:"llm_request_id,omitempty"` // Links to the LLM request that triggered this tool call
 	Timestamp      time.Time `gorm:"index;not null" json:"timestamp"`
 	ToolName       string    `gorm:"type:varchar(255);index:idx_mcp_logs_tool_name;not null" json:"tool_name"`

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -227,7 +227,7 @@ type LoggerPlugin struct {
 	pendingLogs           sync.Map              // Maps requestID -> *PendingLogData (PreLLMHook input data awaiting PostLLMHook)
 	writeQueue            chan *writeQueueEntry // Buffered channel for batch write queue
 	closed                atomic.Bool           // Set during cleanup to prevent sends on closed writeQueue
-	deferredUsageSem      chan struct{}          // Limits concurrent deferred usage DB updates
+	deferredUsageSem      chan struct{}         // Limits concurrent deferred usage DB updates
 }
 
 // Init creates new logger plugin with given log store
@@ -895,9 +895,17 @@ func (p *LoggerPlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 	virtualKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyID)
 	virtualKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName)
 
+	// Use the per-tool-call unique MCP log ID (set by agent executor per goroutine) as the
+	// primary key. Fall back to requestID if not set (e.g. direct single tool call).
+	mcpLogID, ok := ctx.Value(schemas.BifrostContextKeyMCPLogID).(string)
+	if !ok || mcpLogID == "" {
+		mcpLogID = requestID
+	}
+
 	go func() {
 		entry := &logstore.MCPToolLog{
-			ID:          requestID,
+			ID:          mcpLogID,
+			RequestID:   requestID,
 			Timestamp:   createdTimestamp,
 			ToolName:    toolName,
 			ServerLabel: serverLabel,
@@ -967,6 +975,12 @@ func (p *LoggerPlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schemas.Bi
 	if !ok || requestID == "" {
 		p.logger.Error("request-id not found in context or is empty in PostMCPHook")
 		return resp, bifrostErr, nil
+	}
+
+	// Use the per-tool-call unique MCP log ID to find the correct log entry.
+	mcpLogID, ok := ctx.Value(schemas.BifrostContextKeyMCPLogID).(string)
+	if !ok || mcpLogID == "" {
+		mcpLogID = requestID
 	}
 
 	// Extract virtual key ID and name from context (set by governance plugin)
@@ -1055,7 +1069,7 @@ func (p *LoggerPlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schemas.Bi
 		}
 
 		processingErr := retryOnNotFound(p.ctx, func() error {
-			return p.store.UpdateMCPToolLog(p.ctx, requestID, updates)
+			return p.store.UpdateMCPToolLog(p.ctx, mcpLogID, updates)
 		})
 		if processingErr != nil {
 			p.logger.Warn("failed to process MCP tool log update for request %s: %v", requestID, processingErr)
@@ -1066,7 +1080,7 @@ func (p *LoggerPlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schemas.Bi
 			p.mu.Unlock()
 
 			if callback != nil {
-				if updatedEntry, getErr := p.store.FindMCPToolLog(p.ctx, requestID); getErr == nil {
+				if updatedEntry, getErr := p.store.FindMCPToolLog(p.ctx, mcpLogID); getErr == nil {
 					callback(updatedEntry)
 				} else {
 					p.logger.Warn("failed to find updated entry for callback: %v", getErr)


### PR DESCRIPTION
T## Summary

Fixes primary key conflicts in MCP tool logs when parallel tool calls execute simultaneously. Previously, all parallel tool calls within a single LLM response shared the same request ID as their primary key, causing database conflicts and logging mismatches.

## Changes

- Added unique UUID generation for each parallel tool call using `BifrostContextKeyMCPLogID` context key
- Modified agent executor to create derived contexts with unique MCP log IDs for parallel tool execution
- Added `request_id` column to `mcp_tool_logs` table to preserve original request ID for querying
- Updated logging plugin to use unique MCP log ID as primary key while storing original request ID separately
- Added database migration to handle the new column and index
- Included comprehensive test coverage for parallel tool call scenarios

The design preserves backward compatibility by falling back to request ID when the new context key isn't set, ensuring single tool calls continue working as before.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate parallel tool call logging works correctly:

```sh
# Run core tests including new parallel tool call test
go test ./core/mcp/...

# Run logging plugin tests
go test ./plugins/logging/...

# Run full test suite
go test ./...

# Test with actual parallel tool calls by sending a chat request that triggers multiple tool calls
# Verify in the database that each tool call gets a unique ID in mcp_tool_logs table
# but shares the same request_id value
```

The database migration runs automatically on startup, adding the new `request_id` column and index.

## Screenshots/Recordings

N/A - Backend database schema and logging changes only.

## Breaking changes

- [ ] Yes
- [x] No

The changes are backward compatible. Existing single tool calls continue using request ID as before, and the new column is added via migration.

## Related issues

Resolves database primary key conflicts and logging race conditions in parallel MCP tool execution scenarios.

## Security considerations

No security implications. The changes only affect internal logging mechanics and database schema for better data integrity.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable