### PR TITLE
helm chart disabled plugin is not skipped from config.json

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.0.15
+version: 2.0.16
 appVersion: "1.4.11"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,14 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.0.15
+**Latest Version:** 2.0.16
 
 ## Changelog
+
+### v2.0.16
+
+- Fixed disabled plugins being completely removed from rendered config.json instead of being kept with `enabled: false`
+- Applies to all built-in plugins (telemetry, logging, governance, maxim, semantic cache, otel, datadog) and custom plugins
 
 ### v2.0.15
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -737,13 +737,8 @@ false
 {{- end }}
 {{- /* Plugins - as array per schema */ -}}
 {{- $plugins := list }}
-{{- if .Values.bifrost.plugins.telemetry.enabled }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "telemetry" "config" .Values.bifrost.plugins.telemetry.config) }}
-{{- end }}
-{{- if .Values.bifrost.plugins.logging.enabled }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "logging" "config" .Values.bifrost.plugins.logging.config) }}
-{{- end }}
-{{- if .Values.bifrost.plugins.governance.enabled }}
+{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.telemetry.enabled "name" "telemetry" "config" .Values.bifrost.plugins.telemetry.config) }}
+{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.logging.enabled "name" "logging" "config" .Values.bifrost.plugins.logging.config) }}
 {{- $governanceConfig := dict }}
 {{- if hasKey .Values.bifrost.plugins.governance.config "is_vk_mandatory" }}
 {{- $_ := set $governanceConfig "is_vk_mandatory" .Values.bifrost.plugins.governance.config.is_vk_mandatory }}
@@ -754,9 +749,7 @@ false
 {{- if hasKey .Values.bifrost.plugins.governance.config "is_enterprise" }}
 {{- $_ := set $governanceConfig "is_enterprise" .Values.bifrost.plugins.governance.config.is_enterprise }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "governance" "config" $governanceConfig) }}
-{{- end }}
-{{- if .Values.bifrost.plugins.maxim.enabled }}
+{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.governance.enabled "name" "governance" "config" $governanceConfig) }}
 {{- $maximConfig := dict }}
 {{- if and .Values.bifrost.plugins.maxim.secretRef .Values.bifrost.plugins.maxim.secretRef.name }}
 {{- $_ := set $maximConfig "api_key" "env.BIFROST_MAXIM_API_KEY" }}
@@ -766,9 +759,7 @@ false
 {{- if .Values.bifrost.plugins.maxim.config.log_repo_id }}
 {{- $_ := set $maximConfig "log_repo_id" .Values.bifrost.plugins.maxim.config.log_repo_id }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "maxim" "config" $maximConfig) }}
-{{- end }}
-{{- if .Values.bifrost.plugins.semanticCache.enabled }}
+{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.maxim.enabled "name" "maxim" "config" $maximConfig) }}
 {{- $scConfig := dict }}
 {{- $inputConfig := .Values.bifrost.plugins.semanticCache.config | default dict }}
 {{- if $inputConfig.dimension }}
@@ -813,9 +804,7 @@ false
 {{- if hasKey $inputConfig "cleanup_on_shutdown" }}
 {{- $_ := set $scConfig "cleanup_on_shutdown" $inputConfig.cleanup_on_shutdown }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "semantic_cache" "config" $scConfig) }}
-{{- end }}
-{{- if .Values.bifrost.plugins.otel.enabled }}
+{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.semanticCache.enabled "name" "semantic_cache" "config" $scConfig) }}
 {{- $otelConfig := dict }}
 {{- $inputConfig := .Values.bifrost.plugins.otel.config | default dict }}
 {{- if $inputConfig.service_name }}
@@ -848,9 +837,7 @@ false
 {{- if hasKey $inputConfig "insecure" }}
 {{- $_ := set $otelConfig "insecure" $inputConfig.insecure }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "otel" "config" $otelConfig) }}
-{{- end }}
-{{- if .Values.bifrost.plugins.datadog.enabled }}
+{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.otel.enabled "name" "otel" "config" $otelConfig) }}
 {{- $datadogConfig := dict }}
 {{- $inputConfig := .Values.bifrost.plugins.datadog.config | default dict }}
 {{- if $inputConfig.service_name }}
@@ -871,20 +858,17 @@ false
 {{- if hasKey $inputConfig "enable_traces" }}
 {{- $_ := set $datadogConfig "enable_traces" $inputConfig.enable_traces }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "datadog" "config" $datadogConfig) }}
-{{- end }}
+{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.datadog.enabled "name" "datadog" "config" $datadogConfig) }}
 {{- /* Custom plugins */ -}}
 {{- if .Values.bifrost.plugins.custom }}
 {{- range .Values.bifrost.plugins.custom }}
-{{- if .enabled }}
-{{- $customPlugin := dict "enabled" true "name" .name }}
+{{- $customPlugin := dict "enabled" .enabled "name" .name }}
 {{- if .path }}{{- $_ := set $customPlugin "path" .path }}{{- end }}
 {{- if .version }}{{- $_ := set $customPlugin "version" .version }}{{- end }}
 {{- if .config }}{{- $_ := set $customPlugin "config" .config }}{{- end }}
 {{- if .placement }}{{- $_ := set $customPlugin "placement" .placement }}{{- end }}
 {{- if .order }}{{- $_ := set $customPlugin "order" (.order | int) }}{{- end }}
 {{- $plugins = append $plugins $customPlugin }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- if $plugins }}

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,27 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.4.11
+    created: "2026-04-08T12:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.16.tgz
+    version: 2.0.16
+  - apiVersion: v2
+    appVersion: 1.4.11
     created: "2026-04-07T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
     digest: ""
@@ -565,4 +586,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-04-07T12:00:00.000000+00:00"
+generated: "2026-04-08T12:00:00.000000+00:00"


### PR DESCRIPTION
## Summary

Fixed disabled plugins being completely removed from rendered config.json instead of being kept with `enabled: false` status. This ensures all plugins (both built-in and custom) are properly represented in the configuration regardless of their enabled state.

## Changes

- Modified Helm template logic to always include all built-in plugins (telemetry, logging, governance, maxim, semantic cache, otel, datadog) in the rendered configuration with their actual enabled/disabled status
- Updated custom plugin handling to include disabled plugins in the configuration rather than filtering them out
- Bumped Helm chart version from 2.0.15 to 2.0.16

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Deploy the Helm chart with some plugins disabled and verify the rendered config.json contains all plugins with correct enabled/disabled status:

```sh
# Install/upgrade the chart with mixed plugin states
helm upgrade --install bifrost ./helm-charts/bifrost \
  --set bifrost.plugins.telemetry.enabled=true \
  --set bifrost.plugins.logging.enabled=false \
  --set bifrost.plugins.governance.enabled=true

# Check the rendered configuration
kubectl get configmap bifrost-config -o jsonpath='{.data.config\.json}' | jq '.plugins'

# Verify disabled plugins appear with "enabled": false rather than being omitted
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a configuration rendering fix that doesn't affect plugin functionality or access controls.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable