### PR TITLE
remvoves enabled change for first party plugins

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.0.16
+version: 2.0.17
 appVersion: "1.4.11"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,14 +4,13 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.0.16
+**Latest Version:** 2.0.17
 
 ## Changelog
 
 ### v2.0.16
 
-- Fixed disabled plugins being completely removed from rendered config.json instead of being kept with `enabled: false`
-- Applies to all built-in plugins (telemetry, logging, governance, maxim, semantic cache, otel, datadog) and custom plugins
+- Fixed disabled custom plugins being completely removed from rendered config.json instead of being kept with `enabled: false`
 
 ### v2.0.15
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -737,8 +737,13 @@ false
 {{- end }}
 {{- /* Plugins - as array per schema */ -}}
 {{- $plugins := list }}
-{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.telemetry.enabled "name" "telemetry" "config" .Values.bifrost.plugins.telemetry.config) }}
-{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.logging.enabled "name" "logging" "config" .Values.bifrost.plugins.logging.config) }}
+{{- if .Values.bifrost.plugins.telemetry.enabled }}
+{{- $plugins = append $plugins (dict "enabled" true "name" "telemetry" "config" .Values.bifrost.plugins.telemetry.config) }}
+{{- end }}
+{{- if .Values.bifrost.plugins.logging.enabled }}
+{{- $plugins = append $plugins (dict "enabled" true "name" "logging" "config" .Values.bifrost.plugins.logging.config) }}
+{{- end }}
+{{- if .Values.bifrost.plugins.governance.enabled }}
 {{- $governanceConfig := dict }}
 {{- if hasKey .Values.bifrost.plugins.governance.config "is_vk_mandatory" }}
 {{- $_ := set $governanceConfig "is_vk_mandatory" .Values.bifrost.plugins.governance.config.is_vk_mandatory }}
@@ -749,7 +754,9 @@ false
 {{- if hasKey .Values.bifrost.plugins.governance.config "is_enterprise" }}
 {{- $_ := set $governanceConfig "is_enterprise" .Values.bifrost.plugins.governance.config.is_enterprise }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.governance.enabled "name" "governance" "config" $governanceConfig) }}
+{{- $plugins = append $plugins (dict "enabled" true "name" "governance" "config" $governanceConfig) }}
+{{- end }}
+{{- if .Values.bifrost.plugins.maxim.enabled }}
 {{- $maximConfig := dict }}
 {{- if and .Values.bifrost.plugins.maxim.secretRef .Values.bifrost.plugins.maxim.secretRef.name }}
 {{- $_ := set $maximConfig "api_key" "env.BIFROST_MAXIM_API_KEY" }}
@@ -759,7 +766,9 @@ false
 {{- if .Values.bifrost.plugins.maxim.config.log_repo_id }}
 {{- $_ := set $maximConfig "log_repo_id" .Values.bifrost.plugins.maxim.config.log_repo_id }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.maxim.enabled "name" "maxim" "config" $maximConfig) }}
+{{- $plugins = append $plugins (dict "enabled" true "name" "maxim" "config" $maximConfig) }}
+{{- end }}
+{{- if .Values.bifrost.plugins.semanticCache.enabled }}
 {{- $scConfig := dict }}
 {{- $inputConfig := .Values.bifrost.plugins.semanticCache.config | default dict }}
 {{- if $inputConfig.dimension }}
@@ -804,7 +813,9 @@ false
 {{- if hasKey $inputConfig "cleanup_on_shutdown" }}
 {{- $_ := set $scConfig "cleanup_on_shutdown" $inputConfig.cleanup_on_shutdown }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.semanticCache.enabled "name" "semantic_cache" "config" $scConfig) }}
+{{- $plugins = append $plugins (dict "enabled" true "name" "semantic_cache" "config" $scConfig) }}
+{{- end }}
+{{- if .Values.bifrost.plugins.otel.enabled }}
 {{- $otelConfig := dict }}
 {{- $inputConfig := .Values.bifrost.plugins.otel.config | default dict }}
 {{- if $inputConfig.service_name }}
@@ -837,7 +848,9 @@ false
 {{- if hasKey $inputConfig "insecure" }}
 {{- $_ := set $otelConfig "insecure" $inputConfig.insecure }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.otel.enabled "name" "otel" "config" $otelConfig) }}
+{{- $plugins = append $plugins (dict "enabled" true "name" "otel" "config" $otelConfig) }}
+{{- end }}
+{{- if .Values.bifrost.plugins.datadog.enabled }}
 {{- $datadogConfig := dict }}
 {{- $inputConfig := .Values.bifrost.plugins.datadog.config | default dict }}
 {{- if $inputConfig.service_name }}
@@ -858,7 +871,8 @@ false
 {{- if hasKey $inputConfig "enable_traces" }}
 {{- $_ := set $datadogConfig "enable_traces" $inputConfig.enable_traces }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" .Values.bifrost.plugins.datadog.enabled "name" "datadog" "config" $datadogConfig) }}
+{{- $plugins = append $plugins (dict "enabled" true "name" "datadog" "config" $datadogConfig) }}
+{{- end }}
 {{- /* Custom plugins */ -}}
 {{- if .Values.bifrost.plugins.custom }}
 {{- range .Values.bifrost.plugins.custom }}

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -20,6 +20,27 @@ entries:
     - https://github.com/maximhq/bifrost
     type: application
     urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.17.tgz
+    version: 2.0.17
+  - apiVersion: v2
+    appVersion: 1.4.11
+    created: "2026-04-08T12:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.16.tgz
     version: 2.0.16
   - apiVersion: v2


### PR DESCRIPTION
## Summary

Fixes built-in plugin rendering in Helm chart configuration to only include enabled plugins instead of including all plugins with `enabled: false` status.

## Changes

- Modified plugin template logic to conditionally include built-in plugins (telemetry, logging, governance, maxim, semantic cache, otel, datadog) only when enabled
- Changed from always including plugins with dynamic `enabled` field to conditional inclusion with hardcoded `enabled: true`
- Updated chart version from 2.0.16 to 2.0.17
- Corrected changelog entry to specify the fix applies only to custom plugins, not built-in plugins

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Deploy the Helm chart with various plugin configurations and verify the rendered config.json only contains enabled plugins:

```sh
# Test with selective plugins enabled
helm template bifrost ./helm-charts/bifrost \
  --set bifrost.plugins.telemetry.enabled=true \
  --set bifrost.plugins.logging.enabled=false \
  --set bifrost.plugins.governance.enabled=true

# Verify only telemetry and governance plugins appear in the config
kubectl get configmap bifrost-config -o yaml | grep -A 20 "plugins:"
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a configuration rendering fix that doesn't affect security posture.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable