### PR TITLE
fix(oauth2): don't mark OAuth config expired on transient network failures

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,2 @@
+fix: don't mark oauth config expired on transient refresh failures
+fix: only treat invalid_grant and unauthorized_client as permanent OAuth errors

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -651,7 +651,7 @@ type PermanentOAuthError struct {
 }
 
 func (e *PermanentOAuthError) Error() string {
-	return fmt.Sprintf("permanent OAuth error (status %d): %s", e.StatusCode, e.Body)
+	return fmt.Sprintf("permanent oauth error (status %d): %s", e.StatusCode, e.Body)
 }
 
 // sleepIfNotLastAttempt waits with exponential backoff between retry attempts.

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -21,6 +21,11 @@ import (
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 )
 
+const (
+	maxTokenRetries = 3
+	networkTimeout  = 30 * time.Second
+)
+
 // OAuth2Provider implements the schemas.OAuth2Provider interface
 // It provides OAuth 2.0 authentication functionality with database persistence
 type OAuth2Provider struct {
@@ -647,10 +652,6 @@ func (e *PermanentOAuthError) Error() string {
 	return fmt.Sprintf("permanent OAuth error (status %d): %s", e.StatusCode, e.Body)
 }
 
-// maxTokenRetries is the number of total attempts for token endpoint requests.
-// Transient errors (network failures, 5xx) are retried; 4xx errors are not.
-const maxTokenRetries = 3
-
 // sleepIfNotLastAttempt waits with exponential backoff between retry attempts.
 // No-ops on the final attempt to avoid sleeping before returning an error.
 // Respects context cancellation so worker shutdown is not delayed.
@@ -667,7 +668,7 @@ func sleepIfNotLastAttempt(ctx context.Context, attempt int, baseDelay time.Dura
 // Transport errors and 5xx responses are retried up to maxTokenRetries times with
 // exponential backoff. HTTP 4xx responses are returned immediately as PermanentOAuthError.
 func (p *OAuth2Provider) callTokenEndpoint(ctx context.Context, tokenURL string, data url.Values) (*schemas.OAuth2TokenExchangeResponse, error) {
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{Timeout: networkTimeout}
 	var lastErr error
 
 	for attempt := range maxTokenRetries {

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -623,7 +623,9 @@ func (p *OAuth2Provider) markExpiredIfPermanent(ctx context.Context, oauthConfig
 	var permErr *PermanentOAuthError
 	if errors.As(err, &permErr) {
 		oauthConfig.Status = "expired"
-		if updateErr := p.configStore.UpdateOauthConfig(ctx, oauthConfig); updateErr != nil {
+		updateCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if updateErr := p.configStore.UpdateOauthConfig(updateCtx, oauthConfig); updateErr != nil {
 			logger.Error("Failed to update oauth config status: %s, error: %s", oauthConfig.ID, updateErr.Error())
 		}
 	}

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -700,11 +700,22 @@ func (p *OAuth2Provider) callTokenEndpoint(ctx context.Context, tokenURL string,
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			// Per RFC 6749 §5.2, only 400 (invalid_grant, unauthorized_client) and 401
-			// signal permanent auth failures that require user re-authorization. All other
-			// status codes — 403, 404, 429, 5xx — are treated as transient and retried.
-			if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized {
+			if resp.StatusCode == http.StatusUnauthorized {
 				return nil, &PermanentOAuthError{StatusCode: resp.StatusCode, Body: string(body)}
+			}
+			// Per RFC 6749 §5.2, only invalid_grant and unauthorized_client within a 400
+			// require user re-authorization. Other 400s (invalid_request, unsupported_grant_type,
+			// etc.) are configuration or request errors — fail fast without expiring the config.
+			if resp.StatusCode == http.StatusBadRequest {
+				var oauthErr struct {
+					Error string `json:"error"`
+				}
+				if json.Unmarshal(body, &oauthErr) == nil {
+					if oauthErr.Error == "invalid_grant" || oauthErr.Error == "unauthorized_client" {
+						return nil, &PermanentOAuthError{StatusCode: resp.StatusCode, Body: string(body)}
+					}
+				}
+				return nil, fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))
 			}
 			// Transient error (rate limit, server error, etc.) — retry
 			lastErr = fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -26,7 +26,7 @@ import (
 type OAuth2Provider struct {
 	configStore    configstore.ConfigStore
 	mu             sync.RWMutex
-	retryBaseDelay time.Duration // base delay for token endpoint retry backoff; defaults to 1s
+	retryBaseDelay time.Duration // base delay for token endpoint retry backoff; doubles each attempt (1×, 2×, 4×)
 }
 
 // NewOAuth2Provider creates a new OAuth provider instance
@@ -36,7 +36,8 @@ func NewOAuth2Provider(configStore configstore.ConfigStore, logger schemas.Logge
 	}
 	SetLogger(logger)
 	return &OAuth2Provider{
-		configStore: configStore,
+		configStore:    configStore,
+		retryBaseDelay: time.Second,
 	}
 }
 
@@ -74,12 +75,7 @@ func (p *OAuth2Provider) GetAccessToken(ctx context.Context, oauthConfigID strin
 	if time.Now().After(token.ExpiresAt) {
 		// Attempt automatic refresh
 		if err := p.RefreshAccessToken(ctx, oauthConfigID); err != nil {
-			// Permanent rejection — mark the config expired so the user knows to re-authorize
-			var permErr *PermanentOAuthError
-			if errors.As(err, &permErr) {
-				oauthConfig.Status = "expired"
-				p.configStore.UpdateOauthConfig(ctx, oauthConfig)
-			}
+			p.markExpiredIfPermanent(ctx, oauthConfig, err)
 			return "", fmt.Errorf("token expired and refresh failed: %w", err)
 		}
 		// Reload token after refresh
@@ -613,6 +609,19 @@ func (p *OAuth2Provider) exchangeCodeForTokensWithPKCE(tokenURL, code, clientID,
 	return p.callTokenEndpoint(tokenURL, data)
 }
 
+// markExpiredIfPermanent marks oauth_config.status as "expired" when a refresh failure
+// is a permanent auth rejection (PermanentOAuthError). Transient failures are ignored —
+// the TokenRefreshWorker will retry on the next tick.
+func (p *OAuth2Provider) markExpiredIfPermanent(ctx context.Context, oauthConfig *tables.TableOauthConfig, err error) {
+	var permErr *PermanentOAuthError
+	if errors.As(err, &permErr) {
+		oauthConfig.Status = "expired"
+		if updateErr := p.configStore.UpdateOauthConfig(ctx, oauthConfig); updateErr != nil {
+			logger.Error("Failed to update oauth config status: %s, error: %s", oauthConfig.ID, updateErr.Error())
+		}
+	}
+}
+
 // exchangeRefreshToken exchanges refresh token for new access token
 func (p *OAuth2Provider) exchangeRefreshToken(tokenURL, clientID, clientSecret, refreshToken string) (*schemas.OAuth2TokenExchangeResponse, error) {
 	data := url.Values{}
@@ -640,15 +649,19 @@ func (e *PermanentOAuthError) Error() string {
 // Transient errors (network failures, 5xx) are retried; 4xx errors are not.
 const maxTokenRetries = 3
 
+// sleepIfNotLastAttempt waits with exponential backoff between retry attempts.
+// No-ops on the final attempt to avoid sleeping before returning an error.
+func sleepIfNotLastAttempt(attempt int, baseDelay time.Duration) {
+	if attempt < maxTokenRetries-1 {
+		time.Sleep(time.Duration(1<<attempt) * baseDelay)
+	}
+}
+
 // callTokenEndpoint makes a POST request to the OAuth token endpoint with retry logic.
 // Transport errors and 5xx responses are retried up to maxTokenRetries times with
 // exponential backoff. HTTP 4xx responses are returned immediately as PermanentOAuthError.
 func (p *OAuth2Provider) callTokenEndpoint(tokenURL string, data url.Values) (*schemas.OAuth2TokenExchangeResponse, error) {
-	baseDelay := p.retryBaseDelay
-	if baseDelay == 0 {
-		baseDelay = time.Second
-	}
-
+	client := &http.Client{Timeout: 30 * time.Second}
 	var lastErr error
 
 	for attempt := range maxTokenRetries {
@@ -659,14 +672,11 @@ func (p *OAuth2Provider) callTokenEndpoint(tokenURL string, data url.Values) (*s
 		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		req.Header.Set("Accept", "application/json")
 
-		client := &http.Client{Timeout: 30 * time.Second}
 		resp, err := client.Do(req)
 		if err != nil {
 			// Transport error (DNS failure, timeout, connection refused) — retry
 			lastErr = fmt.Errorf("token request failed: %w", err)
-			if attempt < maxTokenRetries-1 {
-				time.Sleep(time.Duration(1<<attempt) * baseDelay)
-			}
+			sleepIfNotLastAttempt(attempt, p.retryBaseDelay)
 			continue
 		}
 
@@ -674,22 +684,20 @@ func (p *OAuth2Provider) callTokenEndpoint(tokenURL string, data url.Values) (*s
 		resp.Body.Close()
 		if err != nil {
 			lastErr = fmt.Errorf("failed to read response: %w", err)
-			if attempt < maxTokenRetries-1 {
-				time.Sleep(time.Duration(1<<attempt) * baseDelay)
-			}
+			sleepIfNotLastAttempt(attempt, p.retryBaseDelay)
 			continue
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			if resp.StatusCode >= 400 && resp.StatusCode < 500 {
-				// 4xx = permanent rejection from auth server (invalid_grant, unauthorized_client, etc.)
+			// Per RFC 6749 §5.2, only 400 (invalid_grant, unauthorized_client) and 401
+			// signal permanent auth failures that require user re-authorization. All other
+			// status codes — 403, 404, 429, 5xx — are treated as transient and retried.
+			if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnauthorized {
 				return nil, &PermanentOAuthError{StatusCode: resp.StatusCode, Body: string(body)}
 			}
-			// 5xx = transient server error — retry
+			// Transient error (rate limit, server error, etc.) — retry
 			lastErr = fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))
-			if attempt < maxTokenRetries-1 {
-				time.Sleep(time.Duration(1<<attempt) * baseDelay)
-			}
+			sleepIfNotLastAttempt(attempt, p.retryBaseDelay)
 			continue
 		}
 

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -653,9 +653,13 @@ const maxTokenRetries = 3
 
 // sleepIfNotLastAttempt waits with exponential backoff between retry attempts.
 // No-ops on the final attempt to avoid sleeping before returning an error.
-func sleepIfNotLastAttempt(attempt int, baseDelay time.Duration) {
+// Respects context cancellation so worker shutdown is not delayed.
+func sleepIfNotLastAttempt(ctx context.Context, attempt int, baseDelay time.Duration) {
 	if attempt < maxTokenRetries-1 {
-		time.Sleep(time.Duration(1<<attempt) * baseDelay)
+		select {
+		case <-time.After(time.Duration(1<<attempt) * baseDelay):
+		case <-ctx.Done():
+		}
 	}
 }
 
@@ -676,9 +680,13 @@ func (p *OAuth2Provider) callTokenEndpoint(ctx context.Context, tokenURL string,
 
 		resp, err := client.Do(req)
 		if err != nil {
+			// Propagate context cancellation immediately — no point retrying.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			// Transport error (DNS failure, timeout, connection refused) — retry
 			lastErr = fmt.Errorf("token request failed: %w", err)
-			sleepIfNotLastAttempt(attempt, p.retryBaseDelay)
+			sleepIfNotLastAttempt(ctx, attempt, p.retryBaseDelay)
 			continue
 		}
 
@@ -686,7 +694,7 @@ func (p *OAuth2Provider) callTokenEndpoint(ctx context.Context, tokenURL string,
 		resp.Body.Close()
 		if err != nil {
 			lastErr = fmt.Errorf("failed to read response: %w", err)
-			sleepIfNotLastAttempt(attempt, p.retryBaseDelay)
+			sleepIfNotLastAttempt(ctx, attempt, p.retryBaseDelay)
 			continue
 		}
 
@@ -699,7 +707,7 @@ func (p *OAuth2Provider) callTokenEndpoint(ctx context.Context, tokenURL string,
 			}
 			// Transient error (rate limit, server error, etc.) — retry
 			lastErr = fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))
-			sleepIfNotLastAttempt(attempt, p.retryBaseDelay)
+			sleepIfNotLastAttempt(ctx, attempt, p.retryBaseDelay)
 			continue
 		}
 

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,8 +24,9 @@ import (
 // OAuth2Provider implements the schemas.OAuth2Provider interface
 // It provides OAuth 2.0 authentication functionality with database persistence
 type OAuth2Provider struct {
-	configStore configstore.ConfigStore
-	mu          sync.RWMutex
+	configStore    configstore.ConfigStore
+	mu             sync.RWMutex
+	retryBaseDelay time.Duration // base delay for token endpoint retry backoff; defaults to 1s
 }
 
 // NewOAuth2Provider creates a new OAuth provider instance
@@ -72,6 +74,12 @@ func (p *OAuth2Provider) GetAccessToken(ctx context.Context, oauthConfigID strin
 	if time.Now().After(token.ExpiresAt) {
 		// Attempt automatic refresh
 		if err := p.RefreshAccessToken(ctx, oauthConfigID); err != nil {
+			// Permanent rejection — mark the config expired so the user knows to re-authorize
+			var permErr *PermanentOAuthError
+			if errors.As(err, &permErr) {
+				oauthConfig.Status = "expired"
+				p.configStore.UpdateOauthConfig(ctx, oauthConfig)
+			}
 			return "", fmt.Errorf("token expired and refresh failed: %w", err)
 		}
 		// Reload token after refresh
@@ -616,60 +624,100 @@ func (p *OAuth2Provider) exchangeRefreshToken(tokenURL, clientID, clientSecret, 
 	return p.callTokenEndpoint(tokenURL, data)
 }
 
-// callTokenEndpoint makes a POST request to the OAuth token endpoint
+// PermanentOAuthError indicates the OAuth provider rejected the request in a way
+// that requires user re-authorization (e.g. revoked refresh token, invalid_grant).
+// Distinct from transient network failures which should be retried.
+type PermanentOAuthError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *PermanentOAuthError) Error() string {
+	return fmt.Sprintf("permanent OAuth error (status %d): %s", e.StatusCode, e.Body)
+}
+
+// maxTokenRetries is the number of total attempts for token endpoint requests.
+// Transient errors (network failures, 5xx) are retried; 4xx errors are not.
+const maxTokenRetries = 3
+
+// callTokenEndpoint makes a POST request to the OAuth token endpoint with retry logic.
+// Transport errors and 5xx responses are retried up to maxTokenRetries times with
+// exponential backoff. HTTP 4xx responses are returned immediately as PermanentOAuthError.
 func (p *OAuth2Provider) callTokenEndpoint(tokenURL string, data url.Values) (*schemas.OAuth2TokenExchangeResponse, error) {
-	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(data.Encode()))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+	baseDelay := p.retryBaseDelay
+	if baseDelay == 0 {
+		baseDelay = time.Second
 	}
 
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Accept", "application/json")
+	var lastErr error
 
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("token request failed: %w", err)
-	}
-	defer resp.Body.Close()
+	for attempt := range maxTokenRetries {
+		req, err := http.NewRequest("POST", tokenURL, strings.NewReader(data.Encode()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("Accept", "application/json")
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-
-	var tokenResponse schemas.OAuth2TokenExchangeResponse
-
-	// Try to parse as JSON first
-	if err := json.Unmarshal(body, &tokenResponse); err != nil {
-		// If JSON parsing fails, try to parse as URL-encoded form data
-		// (GitHub's OAuth endpoint may return application/x-www-form-urlencoded)
-		formValues, parseErr := url.ParseQuery(string(body))
-		if parseErr != nil {
-			return nil, fmt.Errorf("failed to parse token response as JSON or form data: JSON error: %w, form error: %v", err, parseErr)
+		client := &http.Client{Timeout: 30 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			// Transport error (DNS failure, timeout, connection refused) — retry
+			lastErr = fmt.Errorf("token request failed: %w", err)
+			if attempt < maxTokenRetries-1 {
+				time.Sleep(time.Duration(1<<attempt) * baseDelay)
+			}
+			continue
 		}
 
-		tokenResponse.AccessToken = formValues.Get("access_token")
-		tokenResponse.RefreshToken = formValues.Get("refresh_token")
-		tokenResponse.TokenType = formValues.Get("token_type")
-		tokenResponse.Scope = formValues.Get("scope")
-
-		// Parse expires_in if present
-		if expiresIn := formValues.Get("expires_in"); expiresIn != "" {
-			fmt.Sscanf(expiresIn, "%d", &tokenResponse.ExpiresIn)
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			lastErr = fmt.Errorf("failed to read response: %w", err)
+			if attempt < maxTokenRetries-1 {
+				time.Sleep(time.Duration(1<<attempt) * baseDelay)
+			}
+			continue
 		}
+
+		if resp.StatusCode != http.StatusOK {
+			if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+				// 4xx = permanent rejection from auth server (invalid_grant, unauthorized_client, etc.)
+				return nil, &PermanentOAuthError{StatusCode: resp.StatusCode, Body: string(body)}
+			}
+			// 5xx = transient server error — retry
+			lastErr = fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, string(body))
+			if attempt < maxTokenRetries-1 {
+				time.Sleep(time.Duration(1<<attempt) * baseDelay)
+			}
+			continue
+		}
+
+		// Try to parse as JSON first
+		var tokenResponse schemas.OAuth2TokenExchangeResponse
+		if err := json.Unmarshal(body, &tokenResponse); err != nil {
+			// Fall back to URL-encoded form data (GitHub's OAuth endpoint returns this format)
+			formValues, parseErr := url.ParseQuery(string(body))
+			if parseErr != nil {
+				return nil, fmt.Errorf("failed to parse token response as JSON or form data: JSON error: %w, form error: %v", err, parseErr)
+			}
+			tokenResponse.AccessToken = formValues.Get("access_token")
+			tokenResponse.RefreshToken = formValues.Get("refresh_token")
+			tokenResponse.TokenType = formValues.Get("token_type")
+			tokenResponse.Scope = formValues.Get("scope")
+			if expiresIn := formValues.Get("expires_in"); expiresIn != "" {
+				fmt.Sscanf(expiresIn, "%d", &tokenResponse.ExpiresIn)
+			}
+		}
+
+		if tokenResponse.AccessToken == "" {
+			return nil, fmt.Errorf("token response missing access_token, body: %s", string(body))
+		}
+
+		return &tokenResponse, nil
 	}
 
-	// Validate that we got an access token
-	if tokenResponse.AccessToken == "" {
-		return nil, fmt.Errorf("token response missing access_token, body: %s", string(body))
-	}
-
-	return &tokenResponse, nil
+	return nil, fmt.Errorf("token request failed after %d attempts: %w", maxTokenRetries, lastErr)
 }
 
 // generateSecureRandomString generates a cryptographically secure random string

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -116,6 +116,7 @@ func (p *OAuth2Provider) RefreshAccessToken(ctx context.Context, oauthConfigID s
 
 	// Call OAuth provider's token endpoint with refresh_token
 	newTokenResponse, err := p.exchangeRefreshToken(
+		ctx,
 		oauthConfig.TokenURL,
 		oauthConfig.ClientID,
 		oauthConfig.ClientSecret,
@@ -511,6 +512,7 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 
 	// Exchange code for tokens with PKCE verifier
 	tokenResponse, err := p.exchangeCodeForTokensWithPKCE(
+		ctx,
 		oauthConfig.TokenURL,
 		code,
 		oauthConfig.ClientID,
@@ -579,7 +581,7 @@ func (p *OAuth2Provider) buildAuthorizeURLWithPKCE(authorizeURL, clientID, redir
 }
 
 // exchangeCodeForTokens exchanges authorization code for access/refresh tokens
-func (p *OAuth2Provider) exchangeCodeForTokens(tokenURL, code, clientID, clientSecret, redirectURI string) (*schemas.OAuth2TokenExchangeResponse, error) {
+func (p *OAuth2Provider) exchangeCodeForTokens(ctx context.Context, tokenURL, code, clientID, clientSecret, redirectURI string) (*schemas.OAuth2TokenExchangeResponse, error) {
 	data := url.Values{}
 	data.Set("grant_type", "authorization_code")
 	data.Set("code", code)
@@ -589,11 +591,11 @@ func (p *OAuth2Provider) exchangeCodeForTokens(tokenURL, code, clientID, clientS
 		data.Set("client_secret", clientSecret)
 	}
 
-	return p.callTokenEndpoint(tokenURL, data)
+	return p.callTokenEndpoint(ctx, tokenURL, data)
 }
 
 // exchangeCodeForTokensWithPKCE exchanges authorization code for access/refresh tokens with PKCE verifier
-func (p *OAuth2Provider) exchangeCodeForTokensWithPKCE(tokenURL, code, clientID, clientSecret, redirectURI, codeVerifier string) (*schemas.OAuth2TokenExchangeResponse, error) {
+func (p *OAuth2Provider) exchangeCodeForTokensWithPKCE(ctx context.Context, tokenURL, code, clientID, clientSecret, redirectURI, codeVerifier string) (*schemas.OAuth2TokenExchangeResponse, error) {
 	data := url.Values{}
 	data.Set("grant_type", "authorization_code")
 	data.Set("code", code)
@@ -606,7 +608,7 @@ func (p *OAuth2Provider) exchangeCodeForTokensWithPKCE(tokenURL, code, clientID,
 		data.Set("client_secret", clientSecret)
 	}
 
-	return p.callTokenEndpoint(tokenURL, data)
+	return p.callTokenEndpoint(ctx, tokenURL, data)
 }
 
 // markExpiredIfPermanent marks oauth_config.status as "expired" when a refresh failure
@@ -623,14 +625,14 @@ func (p *OAuth2Provider) markExpiredIfPermanent(ctx context.Context, oauthConfig
 }
 
 // exchangeRefreshToken exchanges refresh token for new access token
-func (p *OAuth2Provider) exchangeRefreshToken(tokenURL, clientID, clientSecret, refreshToken string) (*schemas.OAuth2TokenExchangeResponse, error) {
+func (p *OAuth2Provider) exchangeRefreshToken(ctx context.Context, tokenURL, clientID, clientSecret, refreshToken string) (*schemas.OAuth2TokenExchangeResponse, error) {
 	data := url.Values{}
 	data.Set("grant_type", "refresh_token")
 	data.Set("refresh_token", refreshToken)
 	data.Set("client_id", clientID)
 	data.Set("client_secret", clientSecret)
 
-	return p.callTokenEndpoint(tokenURL, data)
+	return p.callTokenEndpoint(ctx, tokenURL, data)
 }
 
 // PermanentOAuthError indicates the OAuth provider rejected the request in a way
@@ -660,12 +662,12 @@ func sleepIfNotLastAttempt(attempt int, baseDelay time.Duration) {
 // callTokenEndpoint makes a POST request to the OAuth token endpoint with retry logic.
 // Transport errors and 5xx responses are retried up to maxTokenRetries times with
 // exponential backoff. HTTP 4xx responses are returned immediately as PermanentOAuthError.
-func (p *OAuth2Provider) callTokenEndpoint(tokenURL string, data url.Values) (*schemas.OAuth2TokenExchangeResponse, error) {
+func (p *OAuth2Provider) callTokenEndpoint(ctx context.Context, tokenURL string, data url.Values) (*schemas.OAuth2TokenExchangeResponse, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
 	var lastErr error
 
 	for attempt := range maxTokenRetries {
-		req, err := http.NewRequest("POST", tokenURL, strings.NewReader(data.Encode()))
+		req, err := http.NewRequestWithContext(ctx, "POST", tokenURL, strings.NewReader(data.Encode()))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create request: %w", err)
 		}

--- a/framework/oauth2/sync.go
+++ b/framework/oauth2/sync.go
@@ -2,7 +2,6 @@ package oauth2
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -116,15 +115,7 @@ func (w *TokenRefreshWorker) refreshExpiredTokens(ctx context.Context) {
 			// Only mark as expired for permanent auth rejections (e.g. invalid_grant, 401).
 			// Transient failures (DNS, timeout, offline) are skipped — the worker will
 			// retry on the next tick and the connection heals automatically when online.
-			var permErr *PermanentOAuthError
-			if errors.As(err, &permErr) {
-				oauthConfig.Status = "expired"
-				if updateErr := w.provider.configStore.UpdateOauthConfig(ctx, oauthConfig); updateErr != nil {
-					if w.logger != nil {
-						w.logger.Error("Failed to update oauth config status: %s, error: %s", oauthConfig.ID, updateErr.Error())
-					}
-				}
-			}
+			w.provider.markExpiredIfPermanent(ctx, oauthConfig, err)
 		} else {
 			if w.logger != nil {
 				w.logger.Debug("Successfully refreshed token: %s", oauthConfig.ID)

--- a/framework/oauth2/sync.go
+++ b/framework/oauth2/sync.go
@@ -2,6 +2,7 @@ package oauth2
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -112,11 +113,16 @@ func (w *TokenRefreshWorker) refreshExpiredTokens(ctx context.Context) {
 				w.logger.Error("Failed to refresh token", "oauth_config_id", oauthConfig.ID, "error", err)
 			}
 
-			// Mark the oauth_config as expired so user knows to re-authorize
-			oauthConfig.Status = "expired"
-			if updateErr := w.provider.configStore.UpdateOauthConfig(ctx, oauthConfig); updateErr != nil {
-				if w.logger != nil {
-					w.logger.Error("Failed to update oauth config status: %s, error: %s", oauthConfig.ID, updateErr.Error())
+			// Only mark as expired for permanent auth rejections (e.g. invalid_grant, 401).
+			// Transient failures (DNS, timeout, offline) are skipped — the worker will
+			// retry on the next tick and the connection heals automatically when online.
+			var permErr *PermanentOAuthError
+			if errors.As(err, &permErr) {
+				oauthConfig.Status = "expired"
+				if updateErr := w.provider.configStore.UpdateOauthConfig(ctx, oauthConfig); updateErr != nil {
+					if w.logger != nil {
+						w.logger.Error("Failed to update oauth config status: %s, error: %s", oauthConfig.ID, updateErr.Error())
+					}
 				}
 			}
 		} else {

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -270,3 +270,47 @@ func TestTokenRefreshWorker_429RateLimit_DoesNotMarkExpired(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "authorized", cfg.Status, "429 rate limit must not mark config as expired")
 }
+
+func TestTokenRefreshWorker_400InvalidRequest_DoesNotMarkExpired(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_request",
+			"error_description": "Missing required parameter",
+		})
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+
+	worker := newTestWorker(store)
+	worker.refreshExpiredTokens(context.Background())
+
+	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	require.NoError(t, err)
+	assert.Equal(t, "authorized", cfg.Status, "400 invalid_request must not mark config as expired")
+}
+
+func TestTokenRefreshWorker_400UnauthorizedClient_MarksExpired(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":             "unauthorized_client",
+			"error_description": "Client is not authorized for this grant type",
+		})
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+
+	worker := newTestWorker(store)
+	worker.refreshExpiredTokens(context.Background())
+
+	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	require.NoError(t, err)
+	assert.Equal(t, "expired", cfg.Status, "400 unauthorized_client must mark config as expired")
+}

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -207,3 +207,66 @@ func TestTokenRefreshWorker_SuccessfulRefresh_UpdatesToken(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "new-access-token", token.AccessToken)
 }
+
+func TestTokenRefreshWorker_ConnectionRefused_DoesNotMarkExpired(t *testing.T) {
+	// This is the exact failure mode that triggered this fix: the machine goes
+	// offline, DNS fails, and the token endpoint is unreachable. The transport
+	// error (client.Do fails) must not mark the config expired.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	tokenURL := server.URL + "/token"
+	server.Close() // close immediately so all connection attempts are refused
+
+	store := newTestConfigStore()
+	oauthConfigID := seedFixtures(t, store, tokenURL)
+
+	worker := newTestWorker(store)
+	worker.refreshExpiredTokens(context.Background())
+
+	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	require.NoError(t, err)
+	assert.Equal(t, "authorized", cfg.Status, "connection refused must not mark config as expired")
+}
+
+func TestTokenRefreshWorker_400InvalidGrant_MarksExpired(t *testing.T) {
+	// 400 invalid_grant is the canonical RFC 6749 signal that a refresh token
+	// has been revoked. Must mark the config expired.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_grant",
+			"error_description": "The refresh token has been revoked",
+		})
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+
+	worker := newTestWorker(store)
+	worker.refreshExpiredTokens(context.Background())
+
+	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	require.NoError(t, err)
+	assert.Equal(t, "expired", cfg.Status, "400 invalid_grant must mark config as expired")
+}
+
+func TestTokenRefreshWorker_429RateLimit_DoesNotMarkExpired(t *testing.T) {
+	// 429 Too Many Requests is a transient rate limit — not a permanent auth
+	// rejection. Must not mark the config expired.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+
+	worker := newTestWorker(store)
+	worker.refreshExpiredTokens(context.Background())
+
+	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	require.NoError(t, err)
+	assert.Equal(t, "authorized", cfg.Status, "429 rate limit must not mark config as expired")
+}

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -42,8 +42,7 @@ func (s *testConfigStore) GetOauthConfigByID(_ context.Context, id string) (*tab
 	if cfg == nil {
 		return nil, nil
 	}
-	copy := *cfg
-	return &copy, nil
+	return bifrost.Ptr(*cfg), nil
 }
 
 func (s *testConfigStore) GetOauthConfigByTokenID(_ context.Context, tokenID string) (*tables.TableOauthConfig, error) {
@@ -51,8 +50,7 @@ func (s *testConfigStore) GetOauthConfigByTokenID(_ context.Context, tokenID str
 	defer s.mu.Unlock()
 	for _, cfg := range s.oauthConfigs {
 		if cfg.TokenID != nil && *cfg.TokenID == tokenID {
-			copy := *cfg
-			return &copy, nil
+			return bifrost.Ptr(*cfg), nil
 		}
 	}
 	return nil, nil
@@ -61,8 +59,7 @@ func (s *testConfigStore) GetOauthConfigByTokenID(_ context.Context, tokenID str
 func (s *testConfigStore) UpdateOauthConfig(_ context.Context, cfg *tables.TableOauthConfig) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	copy := *cfg
-	s.oauthConfigs[cfg.ID] = &copy
+	s.oauthConfigs[cfg.ID] = bifrost.Ptr(*cfg)
 	return nil
 }
 
@@ -73,15 +70,13 @@ func (s *testConfigStore) GetOauthTokenByID(_ context.Context, id string) (*tabl
 	if token == nil {
 		return nil, nil
 	}
-	copy := *token
-	return &copy, nil
+	return bifrost.Ptr(*token), nil
 }
 
 func (s *testConfigStore) UpdateOauthToken(_ context.Context, token *tables.TableOauthToken) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	copy := *token
-	s.oauthTokens[token.ID] = &copy
+	s.oauthTokens[token.ID] = bifrost.Ptr(*token)
 	return nil
 }
 
@@ -91,8 +86,7 @@ func (s *testConfigStore) GetExpiringOauthTokens(_ context.Context, before time.
 	var expiring []*tables.TableOauthToken
 	for _, token := range s.oauthTokens {
 		if token.ExpiresAt.Before(before) {
-			copy := *token
-			expiring = append(expiring, &copy)
+			expiring = append(expiring, bifrost.Ptr(*token))
 		}
 	}
 	return expiring, nil
@@ -121,7 +115,7 @@ func seedFixtures(t *testing.T, store *testConfigStore, tokenURL string) (oauthC
 		RedirectURI: "http://localhost/callback",
 		Scopes:      `["read"]`,
 		Status:      "authorized",
-		TokenID:     &tokenID,
+		TokenID:     bifrost.Ptr(tokenID),
 		ExpiresAt:   time.Now().Add(24 * time.Hour),
 	}
 

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -1,0 +1,209 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+// testConfigStore is a minimal in-memory implementation of configstore.ConfigStore
+// for use in oauth2 tests. Embeds the interface so unneeded methods panic if called.
+type testConfigStore struct {
+	configstore.ConfigStore
+
+	mu           sync.Mutex
+	oauthConfigs map[string]*tables.TableOauthConfig
+	oauthTokens  map[string]*tables.TableOauthToken
+}
+
+func newTestConfigStore() *testConfigStore {
+	return &testConfigStore{
+		oauthConfigs: make(map[string]*tables.TableOauthConfig),
+		oauthTokens:  make(map[string]*tables.TableOauthToken),
+	}
+}
+
+func (s *testConfigStore) GetOauthConfigByID(_ context.Context, id string) (*tables.TableOauthConfig, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cfg := s.oauthConfigs[id]
+	if cfg == nil {
+		return nil, nil
+	}
+	copy := *cfg
+	return &copy, nil
+}
+
+func (s *testConfigStore) GetOauthConfigByTokenID(_ context.Context, tokenID string) (*tables.TableOauthConfig, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, cfg := range s.oauthConfigs {
+		if cfg.TokenID != nil && *cfg.TokenID == tokenID {
+			copy := *cfg
+			return &copy, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *testConfigStore) UpdateOauthConfig(_ context.Context, cfg *tables.TableOauthConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	copy := *cfg
+	s.oauthConfigs[cfg.ID] = &copy
+	return nil
+}
+
+func (s *testConfigStore) GetOauthTokenByID(_ context.Context, id string) (*tables.TableOauthToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	token := s.oauthTokens[id]
+	if token == nil {
+		return nil, nil
+	}
+	copy := *token
+	return &copy, nil
+}
+
+func (s *testConfigStore) UpdateOauthToken(_ context.Context, token *tables.TableOauthToken) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	copy := *token
+	s.oauthTokens[token.ID] = &copy
+	return nil
+}
+
+func (s *testConfigStore) GetExpiringOauthTokens(_ context.Context, before time.Time) ([]*tables.TableOauthToken, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var expiring []*tables.TableOauthToken
+	for _, token := range s.oauthTokens {
+		if token.ExpiresAt.Before(before) {
+			copy := *token
+			expiring = append(expiring, &copy)
+		}
+	}
+	return expiring, nil
+}
+
+// seedFixtures inserts an authorized oauth_config + token pair into the store.
+// The token expires 1 minute from now so GetExpiringOauthTokens will find it.
+func seedFixtures(t *testing.T, store *testConfigStore, tokenURL string) (oauthConfigID string) {
+	t.Helper()
+
+	tokenID := "test-token-id"
+	store.oauthTokens[tokenID] = &tables.TableOauthToken{
+		ID:           tokenID,
+		AccessToken:  "old-access-token",
+		RefreshToken: "refresh-token",
+		TokenType:    "bearer",
+		ExpiresAt:    time.Now().Add(1 * time.Minute),
+		Scopes:       "[]",
+	}
+
+	oauthConfigID = "test-oauth-config-id"
+	store.oauthConfigs[oauthConfigID] = &tables.TableOauthConfig{
+		ID:          oauthConfigID,
+		ClientID:    "test-client-id",
+		TokenURL:    tokenURL,
+		RedirectURI: "http://localhost/callback",
+		Scopes:      `["read"]`,
+		Status:      "authorized",
+		TokenID:     &tokenID,
+		ExpiresAt:   time.Now().Add(24 * time.Hour),
+	}
+
+	return oauthConfigID
+}
+
+func newTestWorker(store *testConfigStore) *TokenRefreshWorker {
+	noopLogger := bifrost.NewDefaultLogger(schemas.LogLevelError)
+	provider := NewOAuth2Provider(store, noopLogger)
+	provider.retryBaseDelay = 1 * time.Millisecond // speed up retry backoff in tests
+	return NewTokenRefreshWorker(provider, noopLogger)
+}
+
+func TestTokenRefreshWorker_TransientError_DoesNotMarkExpired(t *testing.T) {
+	// A 503 response from the token server is a transient failure.
+	// The oauth_config must stay "authorized" so the connection can
+	// heal automatically when the server recovers.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+
+	worker := newTestWorker(store)
+	worker.refreshExpiredTokens(context.Background())
+
+	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	require.NoError(t, err)
+	assert.Equal(t, "authorized", cfg.Status, "transient server error must not mark config as expired")
+}
+
+func TestTokenRefreshWorker_PermanentError_MarksExpired(t *testing.T) {
+	// A 401 invalid_grant response is a permanent rejection from the auth server.
+	// The oauth_config must be marked "expired" to prompt the user to re-authorize.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_grant",
+			"error_description": "Refresh token expired or revoked",
+		})
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+
+	worker := newTestWorker(store)
+	worker.refreshExpiredTokens(context.Background())
+
+	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	require.NoError(t, err)
+	assert.Equal(t, "expired", cfg.Status, "permanent auth rejection must mark config as expired")
+}
+
+func TestTokenRefreshWorker_SuccessfulRefresh_UpdatesToken(t *testing.T) {
+	// A successful refresh must update the stored access token and
+	// leave the oauth_config status as "authorized".
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "new-access-token",
+			"refresh_token": "new-refresh-token",
+			"token_type":    "bearer",
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+
+	store := newTestConfigStore()
+	oauthConfigID := seedFixtures(t, store, server.URL+"/token")
+
+	worker := newTestWorker(store)
+	worker.refreshExpiredTokens(context.Background())
+
+	cfg, err := store.GetOauthConfigByID(context.Background(), oauthConfigID)
+	require.NoError(t, err)
+	assert.Equal(t, "authorized", cfg.Status)
+
+	token, err := store.GetOauthTokenByID(context.Background(), *cfg.TokenID)
+	require.NoError(t, err)
+	assert.Equal(t, "new-access-token", token.AccessToken)
+}


### PR DESCRIPTION

## Summary

OAuth-authenticated MCP connections are permanently locked out whenever the machine is briefly offline during a token refresh — even though the refresh token is still valid. This PR fixes that by distinguishing between permanent auth rejections and transient network failures.

**Before:** any refresh failure (DNS failure, timeout, rate limit, 5xx) → `oauth_config.status = "expired"` → user must manually re-authorize via browser.

**After:** only RFC 6749 permanent errors (400 `invalid_grant`, 401) mark the config expired. Everything else retries automatically and the connection heals when connectivity is restored.

---

## Changes

The root cause is that `callTokenEndpoint` had no error classification — a DNS failure and an `invalid_grant` rejection were both plain `error` values. `TokenRefreshWorker` had no way to distinguish them and conservatively marked everything as expired.

This PR adds a `PermanentOAuthError` type for HTTP 400/401 responses from auth servers (per RFC 6749 §5.2). `callTokenEndpoint` now retries up to 3 times with exponential backoff for transport errors and 5xx, and returns `PermanentOAuthError` immediately for genuine auth rejections. `TokenRefreshWorker` and `GetAccessToken` only call `markExpiredIfPermanent` on `PermanentOAuthError` — transient failures skip the tick and the connection heals on the next cycle.

Context is now propagated into the token endpoint HTTP requests so caller deadlines and cancellations are respected.

---

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

---

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

---

## How to test

```sh
cd framework
go test ./oauth2/... -v
```

Expected: 6 tests pass, including `TestTokenRefreshWorker_ConnectionRefused_DoesNotMarkExpired` which reproduces the exact failure mode.

To reproduce the original bug manually:
1. Configure an OAuth MCP client (e.g. Notion)
2. Disconnect from the network while the token is near expiry
3. Without this fix: reconnecting shows `oauth not authorized yet, status: expired`
4. With this fix: connection heals automatically once network is restored

---

## Breaking changes

- [x] No

`PermanentOAuthError` implements `error` — all existing callers checking `err != nil` are unaffected. Internal function signatures (`callTokenEndpoint`, `exchangeRefreshToken`, etc.) are package-private.

---

## Related issues

Closes #2557

---

## Security considerations

No secrets or auth tokens are added or logged. The change affects retry behaviour only — permanent failures still mark the config expired and require re-authorization.

---

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable