### PR TITLE
minor integration test fixes

### DIFF
--- a/tests/integrations/python/config.json
+++ b/tests/integrations/python/config.json
@@ -238,6 +238,42 @@
             "network_config": {
                 "default_request_timeout_in_seconds": 300
             }
+        },
+        "replicate": {
+            "keys": [
+                {
+                    "name": "Replicate API Key",
+                    "value": "env.REPLICATE_API_KEY",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "default_request_timeout_in_seconds": 300
+            }
+        },
+        "runway": {
+            "keys": [
+                {
+                    "name": "Runway API Key",
+                    "value": "env.RUNWAY_API_KEY",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "default_request_timeout_in_seconds": 300
+            }
+        },
+        "nebius": {
+            "keys": [
+                {
+                    "name": "Nebius API Key",
+                    "value": "env.NEBIUS_API_KEY",
+                    "weight": 1
+                }
+            ],
+            "network_config": {
+                "default_request_timeout_in_seconds": 300
+            }
         }
     },
     "config_store": {
@@ -257,6 +293,7 @@
     "governance": {
         "virtual_keys": [
             {
+                "name": "Test Key",
                 "id": "vk-test",
                 "value": "sk-bf-test-key",
                 "is_active": true

--- a/tests/integrations/python/tests/test_bedrock.py
+++ b/tests/integrations/python/tests/test_bedrock.py
@@ -382,7 +382,7 @@ class TestBedrockIntegration:
         )
         tool_config = convert_to_bedrock_tools([WEATHER_TOOL])
         # Add toolChoice to force the model to use a tool
-        tool_config["toolChoice"] = {"any": {}}
+        tool_config["toolChoice"] = {"auto": {}}
         model_id = format_provider_model(provider, model)
 
         # 1. Initial Request - should trigger tool call
@@ -815,7 +815,7 @@ class TestBedrockIntegration:
         messages = convert_to_bedrock_messages(MULTIPLE_TOOL_CALL_MESSAGES)
         tool_config = convert_to_bedrock_tools([WEATHER_TOOL, CALCULATOR_TOOL])
         # Add toolChoice to force the model to use a tool
-        tool_config["toolChoice"] = {"any": {}}
+        tool_config["toolChoice"] = {"auto": {}}
         model_id = format_provider_model(provider, model)
 
         response = bedrock_client.converse(
@@ -899,7 +899,7 @@ class TestBedrockIntegration:
         )
         tool_config = convert_to_bedrock_tools([WEATHER_TOOL])
         # Add toolChoice to force the model to use a tool
-        tool_config["toolChoice"] = {"any": {}}
+        tool_config["toolChoice"] = {"auto": {}}
         model_id = format_provider_model(provider, model)
 
         # Step 1: Initial request - should trigger tool call


### PR DESCRIPTION
## Summary

Updates Bedrock tool calling configuration to use automatic tool selection and adds a name field to the test virtual key configuration.

## Changes

- Changed `toolChoice` from `{"any": {}}` to `{"auto": {}}` in three Bedrock test methods to allow the model to automatically decide when to use tools rather than forcing tool usage
- Added a `"name": "Test Key"` field to the virtual key configuration in the test config to provide better identification

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the Bedrock integration tests to verify tool calling behavior works correctly with the new auto configuration:

```sh
# Run Bedrock integration tests
cd tests/integrations/python
python -m pytest tests/test_bedrock.py::test_02_converse_with_tool_calling -v
python -m pytest tests/test_bedrock.py::test_08_multiple_tool_calls -v
python -m pytest tests/test_bedrock.py::test_10_end2end_tool_calling -v
```

Verify that the virtual key configuration loads properly with the new name field.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The virtual key configuration change adds a descriptive name field but does not affect the actual key security or access patterns.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable