### PR TITLE
fix: bedrock tool choice conversion to auto

### DIFF
--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2202,7 +2202,11 @@ func convertResponsesToolChoice(toolChoice schemas.ResponsesToolChoice) *Bedrock
 			}
 			// If Name is nil or empty, return nil as we can't construct a valid tool choice
 			return nil
-		case schemas.ResponsesToolChoiceTypeAuto, schemas.ResponsesToolChoiceTypeAny, schemas.ResponsesToolChoiceTypeRequired:
+		case schemas.ResponsesToolChoiceTypeAuto:
+			return &BedrockToolChoice{
+				Auto: &BedrockToolChoiceAuto{},
+			}
+		case schemas.ResponsesToolChoiceTypeAny, schemas.ResponsesToolChoiceTypeRequired:
 			return &BedrockToolChoice{
 				Any: &BedrockToolChoiceAny{},
 			}


### PR DESCRIPTION
## Summary

Fixed tool choice handling in the Bedrock provider by separating the `Auto` tool choice type from `Any` and `Required` types, ensuring each maps to the correct Bedrock-specific structure.

## Changes

- Split the combined case statement for `ResponsesToolChoiceTypeAuto`, `ResponsesToolChoiceTypeAny`, and `ResponsesToolChoiceTypeRequired`
- `ResponsesToolChoiceTypeAuto` now returns `BedrockToolChoiceAuto` instead of `BedrockToolChoiceAny`
- `ResponsesToolChoiceTypeAny` and `ResponsesToolChoiceTypeRequired` continue to return `BedrockToolChoiceAny`

This ensures proper mapping between the generic tool choice types and Bedrock's specific tool choice structures.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test tool choice functionality with the Bedrock provider to ensure `Auto` tool choice behaves correctly and differently from `Any`/`Required` choices.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is an internal mapping fix with no security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable