### PR TITLE
fix: provider level multiline budget duplication issue and unfiltered true param for ModelMultiselect

### DIFF
--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -871,7 +871,9 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		if req.ProviderConfigs != nil {
 			// Get existing provider configs for comparison
 			var existingConfigs []configstoreTables.TableVirtualKeyProviderConfig
-			if err := tx.Where("virtual_key_id = ?", vk.ID).Find(&existingConfigs).Error; err != nil {
+			if err := tx.Where("virtual_key_id = ?", vk.ID).
+				Preload("Budgets").
+				Find(&existingConfigs).Error; err != nil {
 				return err
 			}
 			// Create maps for easier lookup

--- a/ui/components/prompts/fragments/settingsPanel.tsx
+++ b/ui/components/prompts/fragments/settingsPanel.tsx
@@ -151,10 +151,11 @@ export function SettingsPanel() {
 						<ModelMultiselect
 							provider={provider}
 							keys={filterKeys && filterKeys.length > 0 ? filterKeys : undefined}
-						vks={filterVks}
+							vks={filterVks}
 							value={model}
 							onChange={(v) => onModelChange(v)}
 							isSingleSelect
+							unfiltered
 							placeholder={!provider ? "Select a provider first" : "Select model"}
 							disabled={!provider}
 						/>


### PR DESCRIPTION
## Summary

Fixes virtual key provider config updates to stop duplication of budgets on
provider level by ensuring budget data is properly loaded and enables unfiltered
model display.

## Changes

- Added `Preload("Budgets")` to the database query when fetching existing
  provider configs during virtual key updates to ensure budget relationships are
  loaded to prevent duplication of budgets on provider level
- Added `unfiltered` prop to `ModelMultiselect` component in the settings panel
  to show all available models
- Fixed indentation for the `vks` prop in the ModelMultiselect component

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Test the virtual key update functionality to ensure budget data is properly
preserved:

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Verify that updating virtual key provider configurations maintains budget
associations and that the model selector shows all available models without
filtering.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this change only affects data loading relationships
and UI filtering behavior.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

