### PR TITLE
updated mocker in semanticcache plugin

### DIFF
--- a/plugins/semanticcache/go.mod
+++ b/plugins/semanticcache/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/maximhq/bifrost/core v1.5.1
 	github.com/maximhq/bifrost/framework v1.3.1
-	github.com/maximhq/bifrost/plugins/mocker v1.4.17
+	github.com/maximhq/bifrost/plugins/mocker v1.5.0
 )
 
 require (

--- a/plugins/semanticcache/go.sum
+++ b/plugins/semanticcache/go.sum
@@ -199,8 +199,8 @@ github.com/maximhq/bifrost/core v1.5.1 h1:iJoVnI4q0CpNylBqXLVaZUc0qgJhd8j8Xa2vtN
 github.com/maximhq/bifrost/core v1.5.1/go.mod h1:O6VEP2MHkQgo1iLYoxGQ7a+3VBBlHoETCH+pOR6Q5X8=
 github.com/maximhq/bifrost/framework v1.3.1 h1:HpKD0JigkxsR6+jI3DDxAm9AKsO241E3sj2BpxG82Xs=
 github.com/maximhq/bifrost/framework v1.3.1/go.mod h1:M+MDjP4cRZMinI2qk0DHtTp9ayFWaoQ2Ye+ikmyhGYQ=
-github.com/maximhq/bifrost/plugins/mocker v1.4.17 h1:CEItx77k22fS/N5K8/dCQpse88yfbgzVebQWJXOH4NY=
-github.com/maximhq/bifrost/plugins/mocker v1.4.17/go.mod h1:RrA/XyRkggxYiK10k6D6r9VjfmRyiGBIW92ZvhWAtUw=
+github.com/maximhq/bifrost/plugins/mocker v1.5.0 h1:mZ2oZNOnISG6wdhAwkxwplSl0QBPPLFk+IJYEdsi8XU=
+github.com/maximhq/bifrost/plugins/mocker v1.5.0/go.mod h1:ewREvrpRbIyMwnm50MkPdMbr2a4rRwxlAiiCk6YxgYA=
 github.com/oapi-codegen/runtime v1.1.1 h1:EXLHh0DXIJnWhdRPN2w4MXAzFyE4CskzhNLUmtpMYro=
 github.com/oapi-codegen/runtime v1.1.1/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=


### PR DESCRIPTION
## Summary

Updates the mocker plugin dependency in the semanticcache plugin from version 1.4.17 to 1.5.0.

## Changes

- Upgraded `github.com/maximhq/bifrost/plugins/mocker` dependency from v1.4.17 to v1.5.0
- Updated corresponding go.sum checksums to reflect the new version

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate that the semanticcache plugin builds and tests pass with the updated dependency.

```sh
cd plugins/semanticcache
go mod tidy
go test ./...
go build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

Standard dependency update - no additional security implications beyond those in the updated mocker plugin version.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable