### PR TITLE
feat: Add api to reload config.json to avoid container reloads

### DIFF
--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -44,6 +44,7 @@ var securityHeaders = []string{
 type ConfigManager interface {
 	UpdateAuthConfig(ctx context.Context, authConfig *configstore.AuthConfig) error
 	ReloadClientConfigFromConfigStore(ctx context.Context) error
+	ReloadConfigFromFile(ctx context.Context) error
 	ReloadPricingManager(ctx context.Context) error
 	ForceReloadPricing(ctx context.Context) error
 	UpdateDropExcessRequests(ctx context.Context, value bool)
@@ -75,10 +76,34 @@ func NewConfigHandler(configManager ConfigManager, store *lib.Config) *ConfigHan
 func (h *ConfigHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
 	r.GET("/api/config", lib.ChainMiddlewares(h.getConfig, middlewares...))
 	r.PUT("/api/config", lib.ChainMiddlewares(h.updateConfig, middlewares...))
+	r.POST("/api/config/reload", lib.ChainMiddlewares(h.reloadConfig, middlewares...))
 	r.GET("/api/version", lib.ChainMiddlewares(h.getVersion, middlewares...))
 	r.GET("/api/proxy-config", lib.ChainMiddlewares(h.getProxyConfig, middlewares...))
 	r.PUT("/api/proxy-config", lib.ChainMiddlewares(h.updateProxyConfig, middlewares...))
 	r.POST("/api/pricing/force-sync", lib.ChainMiddlewares(h.forceSyncPricing, middlewares...))
+}
+
+// reloadConfig reloads config.json from disk and hot-applies supported settings to the running instance.
+func (h *ConfigHandler) reloadConfig(ctx *fasthttp.RequestCtx) {
+	if err := h.configManager.ReloadConfigFromFile(ctx); err != nil {
+		errorMessage := err.Error()
+		statusCode := fasthttp.StatusInternalServerError
+
+		// Reload validation and file-mode eligibility failures are request errors,
+		// so they should be surfaced as 400 instead of 500.
+		if strings.Contains(errorMessage, "only available in file-based config mode") || strings.Contains(errorMessage, "failed to parse config.json") {
+			statusCode = fasthttp.StatusBadRequest
+		}
+
+		SendError(ctx, statusCode, errorMessage)
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusOK)
+	SendJSON(ctx, map[string]any{
+		"status":  "success",
+		"message": "config reloaded successfully",
+	})
 }
 
 // getVersion handles GET /api/version - Get the current version

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -160,6 +160,10 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("failed to unmarshal config data: %w", err)
 	}
 
+	if temp.Client != nil && temp.ClientConfigAlias != nil && !reflect.DeepEqual(temp.Client, temp.ClientConfigAlias) {
+		return fmt.Errorf("config contains conflicting client blocks: both 'client' and 'client_config' are set with different values")
+	}
+
 	// Set simple fields
 	// Backward compatibility: accept both `client` (schema key) and
 	// `client_config` (legacy/common user key) as the client config source.

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -141,7 +141,8 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 	// First, unmarshal into a temporary struct to get all fields except the complex configs
 	type TempConfigData struct {
 		FrameworkConfig   json.RawMessage                       `json:"framework,omitempty"`
-		Client            *configstore.ClientConfig             `json:"client"`
+		Client            *configstore.ClientConfig             `json:"client,omitempty"`
+		ClientConfigAlias *configstore.ClientConfig             `json:"client_config,omitempty"`
 		EncryptionKey     *schemas.EnvVar                       `json:"encryption_key"`
 		AuthConfig        *configstore.AuthConfig               `json:"auth_config,omitempty"`
 		Providers         map[string]configstore.ProviderConfig `json:"providers"`
@@ -160,7 +161,13 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 	}
 
 	// Set simple fields
-	cd.Client = temp.Client
+	// Backward compatibility: accept both `client` (schema key) and
+	// `client_config` (legacy/common user key) as the client config source.
+	if temp.Client != nil {
+		cd.Client = temp.Client
+	} else {
+		cd.Client = temp.ClientConfigAlias
+	}
 	cd.EncryptionKey = temp.EncryptionKey
 	cd.AuthConfig = temp.AuthConfig
 	cd.Providers = temp.Providers

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -4,6 +4,7 @@ package server
 import (
 	"context"
 	"embed"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -694,6 +695,21 @@ func (s *BifrostHTTPServer) ReloadConfigFromFile(ctx context.Context) error {
 		return fmt.Errorf("failed to read config.json at %s: %w", configFilePath, err)
 	}
 
+	configFileBytes, err := os.ReadFile(configFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read config.json at %s: %w", configFilePath, err)
+	}
+
+	var fileConfigData lib.ConfigData
+	if err := json.Unmarshal(configFileBytes, &fileConfigData); err != nil {
+		return fmt.Errorf("failed to parse config.json: %w", err)
+	}
+
+	fileProviderSet := make(map[schemas.ModelProvider]struct{}, len(fileConfigData.Providers))
+	for provider := range fileConfigData.Providers {
+		fileProviderSet[schemas.ModelProvider(strings.ToLower(provider))] = struct{}{}
+	}
+
 	// Reuse the canonical startup loader so parsing/merging/defaulting stays consistent.
 	newConfig, err := lib.LoadConfig(ctx, configDir)
 	if err != nil {
@@ -709,35 +725,171 @@ func (s *BifrostHTTPServer) ReloadConfigFromFile(ctx context.Context) error {
 	skipDBCtx := context.WithValue(ctx, schemas.BifrostContextKeySkipDBUpdate, true)
 
 	currentProviderSet := make(map[schemas.ModelProvider]struct{}, len(currentProviders))
+	currentProviderConfigByName := make(map[schemas.ModelProvider]configstore.ProviderConfig, len(currentProviders))
 	for _, provider := range currentProviders {
 		currentProviderSet[provider] = struct{}{}
+		providerConfig, getErr := s.Config.GetProviderConfigRaw(provider)
+		if getErr != nil {
+			return fmt.Errorf("failed to snapshot provider %s config before reload: %w", provider, getErr)
+		}
+		currentProviderConfigByName[provider] = *providerConfig
+	}
+
+	oldClientConfig := s.Config.ClientConfig
+	oldGovernanceConfig := s.Config.GovernanceConfig
+	oldFrameworkConfig := s.Config.FrameworkConfig
+	oldProxyConfig := s.Config.ProxyConfig
+	oldPluginConfigs := s.Config.PluginConfigs
+	oldWebSocketConfig := s.Config.WebSocketConfig
+	oldMaxRequestBodySize := 0
+	if s.Server != nil {
+		oldMaxRequestBodySize = s.Server.MaxRequestBodySize
+	}
+
+	getAuthConfig := func(governanceConfig *configstore.GovernanceConfig) *configstore.AuthConfig {
+		if governanceConfig == nil {
+			return nil
+		}
+		return governanceConfig.AuthConfig
+	}
+
+	reloadClientWithCurrentConfig := func() error {
+		if s.Config.ClientConfig == nil {
+			return fmt.Errorf("client config not found")
+		}
+		account := lib.NewBaseAccount(s.Config)
+		var mcpConfig *schemas.MCPConfig
+		if s.Config.MCPConfig != nil {
+			mcpConfig = s.Config.MCPConfig
+		}
+		return s.Client.ReloadConfig(schemas.BifrostConfig{
+			Account:            account,
+			InitialPoolSize:    s.Config.ClientConfig.InitialPoolSize,
+			DropExcessRequests: s.Config.ClientConfig.DropExcessRequests,
+			LLMPlugins:         s.Config.GetLoadedLLMPlugins(),
+			MCPPlugins:         s.Config.GetLoadedMCPPlugins(),
+			MCPConfig:          mcpConfig,
+			Logger:             logger,
+		})
+	}
+
+	applyRuntimeConfig := func() {
+		if s.Config.ClientConfig != nil {
+			s.Config.SetHeaderMatcher(lib.NewHeaderMatcher(s.Config.ClientConfig.HeaderFilterConfig))
+		}
+		if s.AuthMiddleware != nil {
+			if s.Config.ClientConfig != nil {
+				s.AuthMiddleware.UpdateWhitelistedRoutes(s.Config.ClientConfig.WhitelistedRoutes)
+			}
+			s.AuthMiddleware.UpdateAuthConfig(getAuthConfig(s.Config.GovernanceConfig))
+		}
+		if s.Server != nil && s.Config.ClientConfig != nil {
+			s.Server.MaxRequestBodySize = s.Config.ClientConfig.MaxRequestBodySizeMB * 1024 * 1024
+		}
+	}
+
+	addedProviders := make([]schemas.ModelProvider, 0)
+	updatedProviders := make([]schemas.ModelProvider, 0)
+	removedProviders := make([]schemas.ModelProvider, 0)
+
+	rollback := func(reloadErr error) error {
+		for i := len(removedProviders) - 1; i >= 0; i-- {
+			provider := removedProviders[i]
+			providerConfig, ok := currentProviderConfigByName[provider]
+			if !ok {
+				continue
+			}
+			if err := s.Config.AddProvider(skipDBCtx, provider, providerConfig); err != nil {
+				logger.Warn("rollback failed to restore removed provider %s: %v", provider, err)
+				continue
+			}
+			if err := s.Client.UpdateProvider(provider); err != nil {
+				logger.Warn("rollback failed to activate restored provider %s: %v", provider, err)
+			}
+		}
+
+		for i := len(updatedProviders) - 1; i >= 0; i-- {
+			provider := updatedProviders[i]
+			providerConfig, ok := currentProviderConfigByName[provider]
+			if !ok {
+				continue
+			}
+			if err := s.Config.UpdateProviderConfig(skipDBCtx, provider, providerConfig); err != nil {
+				logger.Warn("rollback failed to restore provider %s config: %v", provider, err)
+				continue
+			}
+			if err := s.Client.UpdateProvider(provider); err != nil {
+				logger.Warn("rollback failed to reactivate provider %s: %v", provider, err)
+			}
+		}
+
+		for i := len(addedProviders) - 1; i >= 0; i-- {
+			provider := addedProviders[i]
+			if err := s.RemoveProvider(skipDBCtx, provider); err != nil {
+				logger.Warn("rollback failed to remove added provider %s: %v", provider, err)
+			}
+		}
+
+		s.Config.Mu.Lock()
+		s.Config.ClientConfig = oldClientConfig
+		s.Config.GovernanceConfig = oldGovernanceConfig
+		s.Config.FrameworkConfig = oldFrameworkConfig
+		s.Config.ProxyConfig = oldProxyConfig
+		s.Config.PluginConfigs = oldPluginConfigs
+		s.Config.WebSocketConfig = oldWebSocketConfig
+		s.Config.Mu.Unlock()
+
+		applyRuntimeConfig()
+		if s.Server != nil {
+			s.Server.MaxRequestBodySize = oldMaxRequestBodySize
+		}
+		if s.AuthMiddleware != nil {
+			s.AuthMiddleware.UpdateAuthConfig(getAuthConfig(oldGovernanceConfig))
+		}
+
+		if err := reloadClientWithCurrentConfig(); err != nil {
+			logger.Warn("rollback failed to reload client config: %v", err)
+		}
+
+		if oldFrameworkConfig != nil && oldFrameworkConfig.Pricing != nil {
+			if err := s.ReloadPricingManager(ctx); err != nil {
+				logger.Warn("rollback failed to reload pricing manager: %v", err)
+			}
+		}
+
+		return reloadErr
 	}
 
 	for provider, providerConfig := range newConfig.Providers {
 		if _, exists := currentProviderSet[provider]; exists {
 			if err := s.Config.UpdateProviderConfig(skipDBCtx, provider, providerConfig); err != nil {
-				return fmt.Errorf("failed to update provider %s: %w", provider, err)
+				return rollback(fmt.Errorf("failed to update provider %s: %w", provider, err))
 			}
+			updatedProviders = append(updatedProviders, provider)
 			continue
 		}
 
 		if err := s.Config.AddProvider(skipDBCtx, provider, providerConfig); err != nil {
-			return fmt.Errorf("failed to add provider %s: %w", provider, err)
+			return rollback(fmt.Errorf("failed to add provider %s: %w", provider, err))
 		}
 
 		if err := s.Client.UpdateProvider(provider); err != nil {
-			return fmt.Errorf("failed to activate provider %s: %w", provider, err)
+			return rollback(fmt.Errorf("failed to activate provider %s: %w", provider, err))
 		}
+
+		addedProviders = append(addedProviders, provider)
 	}
 
 	for _, provider := range currentProviders {
-		if _, exists := newConfig.Providers[provider]; exists {
+		if _, exists := fileProviderSet[provider]; exists {
 			continue
 		}
 
 		if err := s.RemoveProvider(skipDBCtx, provider); err != nil {
-			return fmt.Errorf("failed to remove provider %s: %w", provider, err)
+			return rollback(fmt.Errorf("failed to remove provider %s: %w", provider, err))
 		}
+
+		removedProviders = append(removedProviders, provider)
 	}
 
 	// Swap live in-memory config pointers under lock to avoid partial visibility.
@@ -751,34 +903,16 @@ func (s *BifrostHTTPServer) ReloadConfigFromFile(ctx context.Context) error {
 	s.Config.Mu.Unlock()
 
 	// Rebuild derived runtime artifacts that depend on ClientConfig.
-	s.Config.SetHeaderMatcher(lib.NewHeaderMatcher(s.Config.ClientConfig.HeaderFilterConfig))
-
-	if s.AuthMiddleware != nil {
-		s.AuthMiddleware.UpdateWhitelistedRoutes(s.Config.ClientConfig.WhitelistedRoutes)
-	}
-
-	account := lib.NewBaseAccount(s.Config)
-	var mcpConfig *schemas.MCPConfig
-	if s.Config.MCPConfig != nil {
-		mcpConfig = s.Config.MCPConfig
-	}
+	applyRuntimeConfig()
 
 	// Reload core runtime config so request-path behavior reflects new client settings.
-	if err := s.Client.ReloadConfig(schemas.BifrostConfig{
-		Account:            account,
-		InitialPoolSize:    s.Config.ClientConfig.InitialPoolSize,
-		DropExcessRequests: s.Config.ClientConfig.DropExcessRequests,
-		LLMPlugins:         s.Config.GetLoadedLLMPlugins(),
-		MCPPlugins:         s.Config.GetLoadedMCPPlugins(),
-		MCPConfig:          mcpConfig,
-		Logger:             logger,
-	}); err != nil {
-		return fmt.Errorf("failed to reload client config: %w", err)
+	if err := reloadClientWithCurrentConfig(); err != nil {
+		return rollback(fmt.Errorf("failed to reload client config: %w", err))
 	}
 
 	if s.Config.FrameworkConfig != nil && s.Config.FrameworkConfig.Pricing != nil {
 		if err := s.ReloadPricingManager(ctx); err != nil {
-			return fmt.Errorf("failed to reload pricing manager: %w", err)
+			return rollback(fmt.Errorf("failed to reload pricing manager: %w", err))
 		}
 	}
 

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"slices"
 	"strings"
 	"syscall"
@@ -59,6 +60,7 @@ type ServerCallbacks interface {
 	// Auth related callbacks
 	UpdateAuthConfig(ctx context.Context, authConfig *configstore.AuthConfig) error
 	ReloadClientConfigFromConfigStore(ctx context.Context) error
+	ReloadConfigFromFile(ctx context.Context) error
 	// Pricing related callbacks
 	ReloadPricingManager(ctx context.Context) error
 	ForceReloadPricing(ctx context.Context) error
@@ -672,6 +674,114 @@ func (s *BifrostHTTPServer) ReloadClientConfigFromConfigStore(ctx context.Contex
 			Logger:             logger,
 		})
 	}
+	return nil
+}
+
+// ReloadConfigFromFile reloads config.json from disk and hot-applies it to the running server.
+func (s *BifrostHTTPServer) ReloadConfigFromFile(ctx context.Context) error {
+	if s.Config == nil || s.Client == nil {
+		return fmt.Errorf("bifrost server is not initialized")
+	}
+
+	configDir := GetDefaultConfigDir(s.AppDir)
+	configFilePath := filepath.Join(configDir, "config.json")
+
+	// Mirror startup behavior: a readable config.json is required for file-based reload.
+	if _, err := os.Stat(configFilePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("config reload is only available in file-based config mode; config.json was not found at %s", configFilePath)
+		}
+		return fmt.Errorf("failed to read config.json at %s: %w", configFilePath, err)
+	}
+
+	// Reuse the canonical startup loader so parsing/merging/defaulting stays consistent.
+	newConfig, err := lib.LoadConfig(ctx, configDir)
+	if err != nil {
+		return fmt.Errorf("failed to parse config.json: %w", err)
+	}
+	defer newConfig.Close(ctx)
+
+	currentProviders, err := s.Config.GetAllProviders()
+	if err != nil {
+		return fmt.Errorf("failed to read current providers: %w", err)
+	}
+
+	skipDBCtx := context.WithValue(ctx, schemas.BifrostContextKeySkipDBUpdate, true)
+
+	currentProviderSet := make(map[schemas.ModelProvider]struct{}, len(currentProviders))
+	for _, provider := range currentProviders {
+		currentProviderSet[provider] = struct{}{}
+	}
+
+	for provider, providerConfig := range newConfig.Providers {
+		if _, exists := currentProviderSet[provider]; exists {
+			if err := s.Config.UpdateProviderConfig(skipDBCtx, provider, providerConfig); err != nil {
+				return fmt.Errorf("failed to update provider %s: %w", provider, err)
+			}
+			continue
+		}
+
+		if err := s.Config.AddProvider(skipDBCtx, provider, providerConfig); err != nil {
+			return fmt.Errorf("failed to add provider %s: %w", provider, err)
+		}
+
+		if err := s.Client.UpdateProvider(provider); err != nil {
+			return fmt.Errorf("failed to activate provider %s: %w", provider, err)
+		}
+	}
+
+	for _, provider := range currentProviders {
+		if _, exists := newConfig.Providers[provider]; exists {
+			continue
+		}
+
+		if err := s.RemoveProvider(skipDBCtx, provider); err != nil {
+			return fmt.Errorf("failed to remove provider %s: %w", provider, err)
+		}
+	}
+
+	// Swap live in-memory config pointers under lock to avoid partial visibility.
+	s.Config.Mu.Lock()
+	s.Config.ClientConfig = newConfig.ClientConfig
+	s.Config.GovernanceConfig = newConfig.GovernanceConfig
+	s.Config.FrameworkConfig = newConfig.FrameworkConfig
+	s.Config.ProxyConfig = newConfig.ProxyConfig
+	s.Config.PluginConfigs = newConfig.PluginConfigs
+	s.Config.WebSocketConfig = newConfig.WebSocketConfig
+	s.Config.Mu.Unlock()
+
+	// Rebuild derived runtime artifacts that depend on ClientConfig.
+	s.Config.SetHeaderMatcher(lib.NewHeaderMatcher(s.Config.ClientConfig.HeaderFilterConfig))
+
+	if s.AuthMiddleware != nil {
+		s.AuthMiddleware.UpdateWhitelistedRoutes(s.Config.ClientConfig.WhitelistedRoutes)
+	}
+
+	account := lib.NewBaseAccount(s.Config)
+	var mcpConfig *schemas.MCPConfig
+	if s.Config.MCPConfig != nil {
+		mcpConfig = s.Config.MCPConfig
+	}
+
+	// Reload core runtime config so request-path behavior reflects new client settings.
+	if err := s.Client.ReloadConfig(schemas.BifrostConfig{
+		Account:            account,
+		InitialPoolSize:    s.Config.ClientConfig.InitialPoolSize,
+		DropExcessRequests: s.Config.ClientConfig.DropExcessRequests,
+		LLMPlugins:         s.Config.GetLoadedLLMPlugins(),
+		MCPPlugins:         s.Config.GetLoadedMCPPlugins(),
+		MCPConfig:          mcpConfig,
+		Logger:             logger,
+	}); err != nil {
+		return fmt.Errorf("failed to reload client config: %w", err)
+	}
+
+	if s.Config.FrameworkConfig != nil && s.Config.FrameworkConfig.Pricing != nil {
+		if err := s.ReloadPricingManager(ctx); err != nil {
+			return fmt.Errorf("failed to reload pricing manager: %w", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

This PR fixes runtime config reload behavior for `POST /api/config/reload` so changes in `config.json` are actually reflected in live memory and in `GET /api/config`. It also aligns reload behavior with Bifrost’s existing load/merge architecture and removes false assumptions about DB mode detection.

## Changes

- Reload now reuses the same config loading flow as startup (lib.LoadConfig)
- Runtime configuration is properly applied to the active server and client
- Ensured thread-safe updates to in-memory config
- Preserved existing provider reconciliation logic (add/update/remove)
- Fixed incorrect handling of file vs DB config mode
- Removed false success responses, reload only succeeds after full apply
- Improved logging and observability for reload operations
- Added support for both:
1. **client**
2. **client_config** (prevents silent config issues)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test
Run the following tests to validate reload behavior and runtime updates:
### Unit tests:

```sh
cd transports
go test ./bifrost-http/lib ./bifrost-http/server ./bifrost-http/handlers
```

## Screenshots/Recordings

<img width="968" height="299" alt="Screenshot From 2026-04-08 23-46-05" src="https://github.com/user-attachments/assets/4bd931f3-acdf-41ba-98d1-5dcd1260bdfe" />


## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes: #1480

## Security considerations

None

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable