### PR TITLE
migration fix

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -14,6 +14,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/encrypt"
 	"github.com/maximhq/bifrost/framework/migrator"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -3596,6 +3597,65 @@ func migrationDropDeploymentColumnsAndAddAliases(ctx context.Context, db *gorm.D
 				if m.HasColumn(&tables.TableKey{}, col) {
 					if err := tx.Exec("ALTER TABLE config_keys DROP COLUMN " + col).Error; err != nil {
 						return err
+					}
+				}
+			}
+
+			// Fail fast if there are encrypted rows that need fixup but encryption isn't initialized.
+			// The migration drops legacy deployment columns below, so skipping this fixup
+			// would silently lose the ability to recover those values.
+			// This case will ideally never happen
+			var encryptedAliasCount int64
+			if err := tx.Table("config_keys").
+				Where(
+					"encryption_status = ? AND aliases_json IS NOT NULL AND aliases_json != '' AND aliases_json != '{}'",
+					tables.EncryptionStatusEncrypted,
+				).
+				Count(&encryptedAliasCount).Error; err != nil {
+				return fmt.Errorf("failed to count encrypted aliases for fixup: %w", err)
+			}
+			if encryptedAliasCount > 0 && !encrypt.IsEnabled() {
+				return fmt.Errorf("encryption must be enabled before migrating encrypted aliases")
+			}
+
+			// Encrypt aliases_json for rows where encryption_status is already 'encrypted'.
+			// The raw SQL copy above preserved the original column's encryption state:
+			// - bedrock_deployments_json was encrypted -> aliases_json is already encrypted
+			// - azure/vertex/replicate were never encrypted -> aliases_json is plaintext
+			// AfterFind will try to decrypt aliases_json for encrypted rows, so we must
+			// encrypt any plaintext values first.
+			if encrypt.IsEnabled() {
+				type aliasRow struct {
+					ID          uint
+					AliasesJSON *string
+				}
+				var plainRows []aliasRow
+				if err := tx.Raw(
+					"SELECT id, aliases_json FROM config_keys WHERE encryption_status = ? AND aliases_json IS NOT NULL AND aliases_json != '' AND aliases_json != '{}'",
+					tables.EncryptionStatusEncrypted,
+				).Scan(&plainRows).Error; err != nil {
+					return fmt.Errorf("failed to fetch aliases for encryption fixup: %w", err)
+				}
+				for _, row := range plainRows {
+					if row.AliasesJSON == nil || *row.AliasesJSON == "" {
+						continue
+					}
+					// If Decrypt succeeds, the value is already encrypted — skip it (bedrock case).
+					// If Decrypt fails, the value is plaintext — encrypt it.
+					if _, err := encrypt.Decrypt(*row.AliasesJSON); err != nil {
+						if !json.Valid([]byte(*row.AliasesJSON)) {
+							return fmt.Errorf("failed to decrypt aliases for key %d: %w", row.ID, err)
+						}
+						encrypted, encErr := encrypt.Encrypt(*row.AliasesJSON)
+						if encErr != nil {
+							return fmt.Errorf("failed to encrypt aliases for key %d: %w", row.ID, encErr)
+						}
+						if err := tx.Exec(
+							"UPDATE config_keys SET aliases_json = ? WHERE id = ?",
+							encrypted, row.ID,
+						).Error; err != nil {
+							return fmt.Errorf("failed to update encrypted aliases for key %d: %w", row.ID, err)
+						}
 					}
 				}
 			}

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/encrypt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/postgres"
@@ -883,4 +884,209 @@ func TestMigrationAddStoreRawRequestResponseColumn_Idempotent(t *testing.T) {
 			assert.Equal(t, firstHash, secondHash, "Hash should remain unchanged after idempotent migration run")
 		})
 	}
+}
+
+// setupKeyDBWithLegacyDeploymentColumns creates an in-memory SQLite database
+// with the config_keys table including legacy deployment columns and NO aliases_json.
+// This simulates the pre-aliases, post-encryption database state.
+func setupKeyDBWithLegacyDeploymentColumns(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+
+	// Create migrations table (required by the migrator)
+	err = db.Exec(`CREATE TABLE IF NOT EXISTS migrations (id VARCHAR(255) PRIMARY KEY)`).Error
+	require.NoError(t, err)
+
+	// Create config_keys table with legacy deployment columns and encryption_status
+	// but WITHOUT aliases_json — simulating a DB from before the aliases migration
+	err = db.Exec(`
+		CREATE TABLE config_keys (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name VARCHAR(255) NOT NULL UNIQUE,
+			provider_id INTEGER NOT NULL,
+			provider VARCHAR(50),
+			key_id VARCHAR(255) NOT NULL UNIQUE,
+			value TEXT NOT NULL,
+			models_json TEXT,
+			blacklisted_models_json TEXT,
+			weight REAL,
+			enabled BOOLEAN DEFAULT true,
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL,
+			config_hash VARCHAR(255),
+			azure_endpoint TEXT,
+			azure_api_version TEXT,
+			azure_client_id TEXT,
+			azure_client_secret TEXT,
+			azure_tenant_id TEXT,
+			azure_scopes TEXT,
+			azure_deployments_json TEXT,
+			vertex_project_id TEXT,
+			vertex_project_number TEXT,
+			vertex_region TEXT,
+			vertex_auth_credentials TEXT,
+			vertex_deployments_json TEXT,
+			bedrock_access_key TEXT,
+			bedrock_secret_key TEXT,
+			bedrock_session_token TEXT,
+			bedrock_region TEXT,
+			bedrock_arn TEXT,
+			bedrock_role_arn TEXT,
+			bedrock_external_id TEXT,
+			bedrock_role_session_name TEXT,
+			bedrock_batch_s3_config TEXT,
+			bedrock_deployments_json TEXT,
+			replicate_deployments_json TEXT,
+			replicate_use_deployments_endpoint BOOLEAN,
+			vllm_url TEXT,
+			vllm_model_name TEXT,
+			use_for_batch_api BOOLEAN DEFAULT false,
+			status VARCHAR(50) DEFAULT 'unknown',
+			description TEXT,
+			encryption_status VARCHAR(20) DEFAULT 'plain_text',
+			ollama_url TEXT,
+			sgl_url TEXT
+		)
+	`).Error
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		db.Exec("DELETE FROM migrations")
+		db.Exec("DROP TABLE IF EXISTS config_keys")
+	})
+
+	return db
+}
+
+// TestMigrationDropDeploymentColumnsAndAddAliases_EncryptedRows tests that the
+// aliases migration correctly handles rows where encryption_status is 'encrypted'
+// but deployment columns contain plaintext JSON (because those columns were never
+// in the encryption list). This was the root cause of the base64 decode crash.
+func TestMigrationDropDeploymentColumnsAndAddAliases_EncryptedRows(t *testing.T) {
+	if !encrypt.IsEnabled() {
+		t.Skip("encryption not enabled, skipping encrypted rows test")
+	}
+
+	db := setupKeyDBWithLegacyDeploymentColumns(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Format("2006-01-02 15:04:05")
+
+	// Encrypt the key values (simulating what EncryptPlaintextRows would have done)
+	encVal1, err := encrypt.Encrypt("sk-azure-key-1")
+	require.NoError(t, err)
+	encVal2, err := encrypt.Encrypt("sk-vertex-key-1")
+	require.NoError(t, err)
+	encVal3, err := encrypt.Encrypt("sk-replicate-key-1")
+	require.NoError(t, err)
+
+	// Insert encrypted rows with PLAINTEXT deployment JSON.
+	// azure_deployments_json, vertex_deployments_json, and replicate_deployments_json
+	// were never in the encryption list, so they remain plaintext even though the row
+	// is marked as encrypted.
+	err = db.Exec(`
+		INSERT INTO config_keys (
+			name, provider_id, provider, key_id, value, models_json,
+			azure_deployments_json, encryption_status, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, 'encrypted', ?, ?)`,
+		"azure-key-1", 1, "azure", "ak-1", encVal1, `["*"]`,
+		`{"gpt-4":"dep-gpt4","gpt-3.5":"dep-gpt35"}`, now, now,
+	).Error
+	require.NoError(t, err)
+
+	err = db.Exec(`
+		INSERT INTO config_keys (
+			name, provider_id, provider, key_id, value, models_json,
+			vertex_deployments_json, encryption_status, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, 'encrypted', ?, ?)`,
+		"vertex-key-1", 2, "vertex", "vk-1", encVal2, `["*"]`,
+		`{"gemini-pro":"dep-gemini"}`, now, now,
+	).Error
+	require.NoError(t, err)
+
+	err = db.Exec(`
+		INSERT INTO config_keys (
+			name, provider_id, provider, key_id, value, models_json,
+			replicate_deployments_json, encryption_status, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, 'encrypted', ?, ?)`,
+		"replicate-key-1", 3, "replicate", "rk-1", encVal3, `["*"]`,
+		`{"llama":"dep-llama"}`, now, now,
+	).Error
+	require.NoError(t, err)
+
+	// Run the aliases migration — this should NOT crash with base64 decode error.
+	err = migrationDropDeploymentColumnsAndAddAliases(ctx, db)
+	require.NoError(t, err, "migration should not crash on encrypted rows with plaintext deployment data")
+
+	// Verify aliases_json was populated and is readable via GORM hooks
+	var keys []tables.TableKey
+	err = db.Order("name").Find(&keys).Error
+	require.NoError(t, err)
+	require.Len(t, keys, 3)
+
+	// Azure key should have its deployment data migrated to aliases
+	assert.Equal(t, "azure-key-1", keys[0].Name)
+	assert.NotNil(t, keys[0].Aliases)
+
+	// Vertex key
+	assert.Equal(t, "vertex-key-1", keys[2].Name)
+	assert.NotNil(t, keys[2].Aliases)
+
+	// Replicate key — sorted alphabetically, it's between azure and vertex
+	assert.Equal(t, "replicate-key-1", keys[1].Name)
+	assert.NotNil(t, keys[1].Aliases)
+}
+
+// TestMigrationDropDeploymentColumnsAndAddAliases_BedrockEncrypted tests the branch
+// where bedrock_deployments_json is already encrypted before migration. The migration
+// should detect it's already encrypted (Decrypt succeeds) and NOT double-encrypt it.
+func TestMigrationDropDeploymentColumnsAndAddAliases_BedrockEncrypted(t *testing.T) {
+	if !encrypt.IsEnabled() {
+		t.Skip("encryption not enabled, skipping bedrock encrypted test")
+	}
+
+	db := setupKeyDBWithLegacyDeploymentColumns(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Format("2006-01-02 15:04:05")
+
+	// Encrypt the key value
+	encVal, err := encrypt.Encrypt("sk-bedrock-key-1")
+	require.NoError(t, err)
+
+	// Encrypt the deployments JSON (simulating bedrock which WAS in the encryption list)
+	bedrockDeployments := `{"claude":"dep-claude","claude-instant":"dep-instant"}`
+	encDeployments, err := encrypt.Encrypt(bedrockDeployments)
+	require.NoError(t, err)
+
+	// Insert a bedrock row where bedrock_deployments_json is already encrypted
+	err = db.Exec(`
+		INSERT INTO config_keys (
+			name, provider_id, provider, key_id, value, models_json,
+			bedrock_deployments_json, encryption_status, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, 'encrypted', ?, ?)`,
+		"bedrock-key-1", 4, "bedrock", "bk-1", encVal, `["*"]`,
+		encDeployments, now, now,
+	).Error
+	require.NoError(t, err)
+
+	// Run the aliases migration — should detect already-encrypted data and skip re-encryption
+	err = migrationDropDeploymentColumnsAndAddAliases(ctx, db)
+	require.NoError(t, err, "migration should handle already-encrypted bedrock deployments")
+
+	// Verify aliases_json was populated and is readable via GORM hooks (AfterFind decrypts)
+	var keys []tables.TableKey
+	err = db.Find(&keys).Error
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+
+	assert.Equal(t, "bedrock-key-1", keys[0].Name)
+	assert.NotNil(t, keys[0].Aliases)
+
+	// Verify the aliases contain the original deployment data (not double-encrypted)
+	aliases := keys[0].Aliases
+	assert.Contains(t, aliases, "claude")
+	assert.Equal(t, "dep-claude", aliases["claude"])
+	assert.Equal(t, "dep-instant", aliases["claude-instant"])
 }


### PR DESCRIPTION
## Summary

Fixes a base64 decode crash in the database migration that drops deployment columns and adds aliases. The issue occurred when encrypted rows contained plaintext deployment JSON data, causing the migration to fail when attempting to decrypt already-plaintext values.

## Changes

- Added encryption fixup logic in `migrationDropDeploymentColumnsAndAddAliases` to properly handle mixed encryption states
- The migration now checks if `aliases_json` values are already encrypted before attempting to encrypt them
- Added comprehensive test coverage for the encryption edge case with `TestMigrationDropDeploymentColumnsAndAddAliases_EncryptedRows`
- Test includes setup helper `setupKeyDBWithLegacyDeploymentColumns` to simulate pre-migration database state

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the migration tests to verify the fix:

```sh
go test ./framework/configstore -run TestMigrationDropDeploymentColumnsAndAddAliases_EncryptedRows -v
```

Test the broader migration functionality:

```sh
go test ./framework/configstore -run TestMigration -v
```

Ensure encryption is enabled when running tests that depend on it.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes migration crashes when processing encrypted rows with plaintext deployment data during the aliases migration.

## Security considerations

This change improves the security posture by ensuring consistent encryption of sensitive deployment data during migrations. The fix prevents potential data corruption or exposure that could occur from failed migrations.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable