### PR TITLE
feat: azure passthrough support

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- feat: added azure passthrough support

--- a/core/internal/llmtests/passthrough_api.go
+++ b/core/internal/llmtests/passthrough_api.go
@@ -41,7 +41,7 @@ func basePassthroughChatRequest(model string) *schemas.BifrostChatRequest {
 //
 // Streaming is requested when stream is true.
 // Returns (req, true) for supported providers, (zero, false) to signal skip.
-func buildPassthroughChatReq(provider schemas.ModelProvider, model string, stream bool) (passthroughChatReq, bool) {
+func buildPassthroughChatReq(t *testing.T, provider schemas.ModelProvider, model string, stream bool) (passthroughChatReq, bool) {
 	bfReq := basePassthroughChatRequest(model)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
@@ -53,9 +53,22 @@ func buildPassthroughChatReq(provider schemas.ModelProvider, model string, strea
 		}
 		body, err := sonic.Marshal(nativeReq)
 		if err != nil {
-			return passthroughChatReq{}, false
+			t.Fatalf("openai: failed to marshal passthrough chat request: %v", err)
 		}
 		return passthroughChatReq{path: "/v1/chat/completions", body: body}, true
+
+	case schemas.Azure:
+		nativeReq := openai.ToOpenAIChatRequest(ctx, bfReq)
+		if stream {
+			nativeReq.Stream = bifrost.Ptr(true)
+		}
+		body, err := sonic.Marshal(nativeReq)
+		if err != nil {
+			t.Fatalf("azure: failed to marshal passthrough chat request: %v", err)
+		}
+		// Azure passthrough expects the deployment-based path; api-version is
+		// injected automatically by buildPassthroughURL from the key config.
+		return passthroughChatReq{path: fmt.Sprintf("/openai/deployments/%s/chat/completions", model), body: body}, true
 
 	case schemas.Anthropic:
 		nativeReq, err := anthropic.ToAnthropicChatRequest(ctx, bfReq)
@@ -67,7 +80,7 @@ func buildPassthroughChatReq(provider schemas.ModelProvider, model string, strea
 		}
 		body, err := sonic.Marshal(nativeReq)
 		if err != nil {
-			return passthroughChatReq{}, false
+			t.Fatalf("anthropic: failed to marshal passthrough chat request: %v", err)
 		}
 		return passthroughChatReq{path: "/v1/messages", body: body}, true
 
@@ -78,7 +91,7 @@ func buildPassthroughChatReq(provider schemas.ModelProvider, model string, strea
 		}
 		body, err := sonic.Marshal(nativeReq)
 		if err != nil {
-			return passthroughChatReq{}, false
+			t.Fatalf("gemini: failed to marshal passthrough chat request: %v", err)
 		}
 		endpoint := ":generateContent"
 		query := ""
@@ -137,7 +150,7 @@ func RunPassthroughAPITest(t *testing.T, client *bifrost.Bifrost, ctx context.Co
 				t.Parallel()
 			}
 
-			req, ok := buildPassthroughChatReq(testConfig.Provider, model, false)
+			req, ok := buildPassthroughChatReq(t, testConfig.Provider, model, false)
 			if !ok {
 				t.Skipf("PassthroughAPI/NonStream: no native request format defined for provider %s", testConfig.Provider)
 			}
@@ -186,7 +199,7 @@ func RunPassthroughAPITest(t *testing.T, client *bifrost.Bifrost, ctx context.Co
 				t.Parallel()
 			}
 
-			req, ok := buildPassthroughChatReq(testConfig.Provider, model, true)
+			req, ok := buildPassthroughChatReq(t, testConfig.Provider, model, true)
 			if !ok {
 				t.Skipf("PassthroughAPI/Stream: no native request format defined for provider %s", testConfig.Provider)
 			}

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -3121,11 +3121,279 @@ func (provider *AzureProvider) ContainerFileDelete(_ *schemas.BifrostContext, _ 
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.ContainerFileDeleteRequest, provider.GetProviderKey())
 }
 
-// Passthrough is not supported by the Azure provider.
-func (provider *AzureProvider) Passthrough(_ *schemas.BifrostContext, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughRequest, provider.GetProviderKey())
+// Passthrough forwards a raw request to Azure's API without any transformation.
+func (provider *AzureProvider) Passthrough(
+	ctx *schemas.BifrostContext,
+	key schemas.Key,
+	req *schemas.BifrostPassthroughRequest,
+) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
+	if key.AzureKeyConfig == nil {
+		return nil, providerUtils.NewConfigurationError("azure key config not set", provider.GetProviderKey())
+	}
+
+	if key.AzureKeyConfig.Endpoint.GetValue() == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set", provider.GetProviderKey())
+	}
+
+	url := provider.buildPassthroughURL(key, req.Path, req.RawQuery)
+
+	fasthttpReq := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseResponse(resp)
+	defer fasthttp.ReleaseRequest(fasthttpReq)
+
+	fasthttpReq.Header.SetMethod(req.Method)
+	fasthttpReq.SetRequestURI(url)
+
+	providerUtils.SetExtraHeaders(ctx, fasthttpReq, provider.networkConfig.ExtraHeaders, nil)
+
+	for k, v := range req.SafeHeaders {
+		fasthttpReq.Header.Set(k, v)
+	}
+
+	authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, schemas.IsAnthropicModel(req.Model))
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+	for k, v := range authHeaders {
+		fasthttpReq.Header.Set(k, v)
+	}
+
+	fasthttpReq.SetBody(req.Body)
+
+	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, fasthttpReq, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+
+	body, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err, provider.GetProviderKey())
+	}
+
+	// Remove wire-level encoding headers after decoding; downstream should recalculate them for the buffered body.
+	for k := range headers {
+		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
+			delete(headers, k)
+		}
+	}
+
+	bifrostResponse := &schemas.BifrostPassthroughResponse{
+		StatusCode: resp.StatusCode(),
+		Headers:    headers,
+		Body:       body,
+	}
+
+	bifrostResponse.ExtraFields.Provider = provider.GetProviderKey()
+	bifrostResponse.ExtraFields.ModelRequested = req.Model
+	bifrostResponse.ExtraFields.RequestType = schemas.PassthroughRequest
+	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
+
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &bifrostResponse.ExtraFields)
+	}
+
+	return bifrostResponse, nil
 }
 
-func (provider *AzureProvider) PassthroughStream(_ *schemas.BifrostContext, _ schemas.PostHookRunner, _ schemas.Key, _ *schemas.BifrostPassthroughRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.PassthroughStreamRequest, provider.GetProviderKey())
+// PassthroughStream forwards a raw streaming request to Azure's API without any transformation.
+// Chunks are piped back as raw bytes, preserving the upstream SSE or binary stream format.
+func (provider *AzureProvider) PassthroughStream(
+	ctx *schemas.BifrostContext,
+	postHookRunner schemas.PostHookRunner,
+	key schemas.Key,
+	req *schemas.BifrostPassthroughRequest,
+) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if key.AzureKeyConfig == nil {
+		return nil, providerUtils.NewConfigurationError("azure key config not set", provider.GetProviderKey())
+	}
+
+	if key.AzureKeyConfig.Endpoint.GetValue() == "" {
+		return nil, providerUtils.NewConfigurationError("endpoint not set", provider.GetProviderKey())
+	}
+
+	url := provider.buildPassthroughURL(key, req.Path, req.RawQuery)
+
+	fasthttpReq := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	resp.StreamBody = true
+	defer fasthttp.ReleaseRequest(fasthttpReq)
+
+	fasthttpReq.Header.SetMethod(req.Method)
+	fasthttpReq.SetRequestURI(url)
+
+	providerUtils.SetExtraHeaders(ctx, fasthttpReq, provider.networkConfig.ExtraHeaders, nil)
+
+	for k, v := range req.SafeHeaders {
+		fasthttpReq.Header.Set(k, v)
+	}
+
+	fasthttpReq.Header.Set("Connection", "close")
+
+	authHeaders, bifrostErr := provider.getAzureAuthHeaders(ctx, key, schemas.IsAnthropicModel(req.Model))
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+	for k, v := range authHeaders {
+		fasthttpReq.Header.Set(k, v)
+	}
+
+	fasthttpReq.SetBody(req.Body)
+
+	activeClient := providerUtils.PrepareResponseStreaming(ctx, provider.client, resp)
+	providerUtils.SetStreamIdleTimeoutIfEmpty(ctx, provider.networkConfig.StreamIdleTimeoutInSeconds)
+
+	startTime := time.Now()
+
+	if err := activeClient.Do(fasthttpReq, resp); err != nil {
+		providerUtils.ReleaseStreamingResponse(resp)
+		if errors.Is(err, context.Canceled) {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Type:    schemas.Ptr(schemas.RequestCancelled),
+					Message: schemas.ErrRequestCancelled,
+					Error:   err,
+				},
+			}
+		}
+		if errors.Is(err, fasthttp.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, providerUtils.NewBifrostTimeoutError(schemas.ErrProviderRequestTimedOut, err, provider.GetProviderKey())
+		}
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err, provider.GetProviderKey())
+	}
+
+	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+
+	rawBodyStream := resp.BodyStream()
+	if rawBodyStream == nil {
+		providerUtils.ReleaseStreamingResponse(resp)
+		return nil, providerUtils.NewBifrostOperationError(
+			"provider returned an empty stream body",
+			fmt.Errorf("provider returned an empty stream body"),
+			provider.GetProviderKey(),
+		)
+	}
+
+	bodyStream, stopIdleTimeout := providerUtils.NewIdleTimeoutReader(rawBodyStream, rawBodyStream, providerUtils.GetStreamIdleTimeout(ctx))
+	stopCancellation := providerUtils.SetupStreamCancellation(ctx, rawBodyStream, provider.logger)
+
+	extraFields := schemas.BifrostResponseExtraFields{
+		Provider:       provider.GetProviderKey(),
+		ModelRequested: req.Model,
+		RequestType:    schemas.PassthroughStreamRequest,
+	}
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &extraFields)
+	}
+	statusCode := resp.StatusCode()
+
+	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
+	go func() {
+		defer func() {
+			if ctx.Err() == context.Canceled {
+				providerUtils.HandleStreamCancellation(ctx, postHookRunner, ch, provider.GetProviderKey(), req.Model, schemas.PassthroughStreamRequest, provider.logger)
+			} else if ctx.Err() == context.DeadlineExceeded {
+				providerUtils.HandleStreamTimeout(ctx, postHookRunner, ch, provider.GetProviderKey(), req.Model, schemas.PassthroughStreamRequest, provider.logger)
+			}
+			close(ch)
+		}()
+		defer providerUtils.ReleaseStreamingResponse(resp)
+		defer stopIdleTimeout()
+		defer stopCancellation()
+
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := bodyStream.Read(buf)
+			if n > 0 {
+				chunk := make([]byte, n)
+				copy(chunk, buf[:n])
+				select {
+				case ch <- &schemas.BifrostStreamChunk{
+					BifrostPassthroughResponse: &schemas.BifrostPassthroughResponse{
+						StatusCode:  statusCode,
+						Headers:     headers,
+						Body:        chunk,
+						ExtraFields: extraFields,
+					},
+				}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if readErr == io.EOF {
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				extraFields.Latency = time.Since(startTime).Milliseconds()
+				finalResp := &schemas.BifrostResponse{
+					PassthroughResponse: &schemas.BifrostPassthroughResponse{
+						StatusCode:  statusCode,
+						Headers:     headers,
+						ExtraFields: extraFields,
+					},
+				}
+				postHookRunner(ctx, finalResp, nil)
+				if finalizer, ok := ctx.Value(schemas.BifrostContextKeyPostHookSpanFinalizer).(func(context.Context)); ok && finalizer != nil {
+					finalizer(ctx)
+				}
+				return
+			}
+			if readErr != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				extraFields.Latency = time.Since(startTime).Milliseconds()
+				providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, ch, schemas.PassthroughStreamRequest, provider.GetProviderKey(), req.Model, provider.logger)
+				return
+			}
+		}
+	}()
+	return ch, nil
+}
+
+// buildPassthroughURL constructs the full Azure URL for a passthrough request.
+func (provider *AzureProvider) buildPassthroughURL(key schemas.Key, path, rawQuery string) string {
+	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
+
+	// Normalise the responses path emitted by the Azure SDK.
+	path = strings.Replace(path, "/openai/responses", "/openai/v1/responses", 1)
+
+	path = strings.Replace(path, "/openai/videos", "/openai/v1/videos", 1)
+
+	var apiVersion string
+	switch {
+	case strings.Contains(path, "openai/v1/responses"):
+		apiVersion = AzureAPIVersionPreview
+	case strings.HasPrefix(path, "/anthropic/"),
+		strings.HasPrefix(path, "/openai/v1/videos"):
+		apiVersion = ""
+	default:
+		if key.AzureKeyConfig.APIVersion != nil {
+			apiVersion = key.AzureKeyConfig.APIVersion.GetValue()
+		}
+		if apiVersion == "" {
+			if values, err := url.ParseQuery(rawQuery); err == nil {
+				apiVersion = values.Get("api-version")
+			}
+		}
+	}
+
+	// Strip api-version from the client query to avoid duplicates.
+	queryValues, _ := url.ParseQuery(rawQuery)
+	queryValues.Del("api-version")
+	cleanQuery := queryValues.Encode()
+
+	fullURL := endpoint + path
+	switch {
+	case cleanQuery != "" && apiVersion != "":
+		fullURL += "?" + cleanQuery + "&api-version=" + apiVersion
+	case cleanQuery != "":
+		fullURL += "?" + cleanQuery
+	case apiVersion != "":
+		fullURL += "?api-version=" + apiVersion
+	}
+	return fullURL
 }

--- a/core/providers/azure/azure_test.go
+++ b/core/providers/azure/azure_test.go
@@ -29,7 +29,7 @@ func TestAzure(t *testing.T) {
 		ChatModel:          "gpt-4o-backup",
 		PromptCachingModel: "gpt-4o-backup",
 		VisionModel:        "gpt-4o",
-		ChatAudioModel: "gpt-4o-mini-audio-preview",
+		ChatAudioModel:     "gpt-4o-mini-audio-preview",
 		Fallbacks: []schemas.Fallback{
 			{Provider: schemas.Azure, Model: "gpt-4o-backup"},
 		},
@@ -41,43 +41,45 @@ func TestAzure(t *testing.T) {
 		ImageGenerationModel: "gpt-image-1",
 		ImageEditModel:       "gpt-image-1",
 		VideoGenerationModel: "sora-2",
+		PassthroughModel:     "gpt-4o",
 		Scenarios: llmtests.TestScenarios{
-			TextCompletion:        false, // Not supported
-			SimpleChat:            true,
-			CompletionStream:      true,
-			MultiTurnConversation: true,
-			ToolCalls:             true,
-			ToolCallsStreaming:    true,
+			TextCompletion:             false, // Not supported
+			SimpleChat:                 true,
+			CompletionStream:           true,
+			MultiTurnConversation:      true,
+			ToolCalls:                  true,
+			ToolCallsStreaming:         true,
 			MultipleToolCalls:          true,
 			MultipleToolCallsStreaming: true,
-			End2EndToolCalling:    true,
-			AutomaticFunctionCall: true,
-			ImageURL:              true,
-			ImageBase64:           true,
-			MultipleImages:        true,
-			CompleteEnd2End:       true,
-			Embedding:             true,
-			ListModels:            true,
-			Reasoning:             true,
-			ChatAudio:             true,
-			Transcription:         false, // Disabled for azure because of 3 calls/minute quota	
-			TranscriptionStream:   false, // Not properly supported yet by Azure
-			SpeechSynthesis:       false, // Disabled for azure because of 3 calls/minute quota
-			SpeechSynthesisStream: false, // Disabled for azure because of 3 calls/minute quota
-			StructuredOutputs:     true,  // Structured outputs with nullable enum support
-			PromptCaching:         true,
-			ImageGeneration:       false, // Skipped for Azure
-			ImageGenerationStream: false, // Skipped for Azure
-			ImageEdit:             false, // Model not deployed on Azure endpoint
-			ImageEditStream:       false, // Model not deployed on Azure endpoint
-			ImageVariation:        false, // Not supported by Azure
-			VideoGeneration:       false, // disabled for now because of long running operations
-			VideoDownload:         false,
-			VideoRetrieve:         false,
-			VideoRemix:            false,
-			VideoList:             false,
-			VideoDelete:           false,
-			InterleavedThinking:  true,
+			End2EndToolCalling:         true,
+			AutomaticFunctionCall:      true,
+			ImageURL:                   true,
+			ImageBase64:                true,
+			MultipleImages:             true,
+			CompleteEnd2End:            true,
+			Embedding:                  true,
+			ListModels:                 true,
+			Reasoning:                  true,
+			ChatAudio:                  true,
+			Transcription:              false, // Disabled for azure because of 3 calls/minute quota
+			TranscriptionStream:        false, // Not properly supported yet by Azure
+			SpeechSynthesis:            false, // Disabled for azure because of 3 calls/minute quota
+			SpeechSynthesisStream:      false, // Disabled for azure because of 3 calls/minute quota
+			StructuredOutputs:          true,  // Structured outputs with nullable enum support
+			PromptCaching:              true,
+			ImageGeneration:            false, // Skipped for Azure
+			ImageGenerationStream:      false, // Skipped for Azure
+			ImageEdit:                  false, // Model not deployed on Azure endpoint
+			ImageEditStream:            false, // Model not deployed on Azure endpoint
+			ImageVariation:             false, // Not supported by Azure
+			VideoGeneration:            false, // disabled for now because of long running operations
+			VideoDownload:              false,
+			VideoRetrieve:              false,
+			VideoRemix:                 false,
+			VideoList:                  false,
+			VideoDelete:                false,
+			InterleavedThinking:        true,
+			PassthroughAPI:             true,
 		},
 		DisableParallelFor: []string{"Transcription"}, // Azure Whisper has 3 calls/minute quota
 	}

--- a/docs/integrations/passthrough.mdx
+++ b/docs/integrations/passthrough.mdx
@@ -18,6 +18,8 @@ When you use passthrough endpoints, the request still flows through Bifrost core
   Default provider: `openai`
 - `/anthropic_passthrough`
   Default provider: `anthropic`
+- `/azure_passthrough`
+  Default provider: `azure`
 - `/genai_passthrough`
   Default provider: `gemini` (with automatic Vertex detection for clients configured to use Vertex)
 
@@ -25,7 +27,7 @@ When you use passthrough endpoints, the request still flows through Bifrost core
 
 ## How It Works
 
-1. Send your request to a passthrough endpoint (OpenAI, Anthropic, or GenAI passthrough).
+1. Send your request to a passthrough endpoint (OpenAI, Anthropic, Azure, or GenAI passthrough).
 2. The integration strips the passthrough prefix and forwards the remaining provider-native path/body.
 3. Bifrost handles provider execution through core inference and plugin pipelines.
 4. Response status, headers, and body are returned as passthrough output (for both stream and non-stream requests).
@@ -41,6 +43,13 @@ When you use passthrough endpoints, the request still flows through Bifrost core
 ### Anthropic Passthrough
 
 - Uses `anthropic` as the default provider.
+
+### Azure Passthrough
+
+- Uses `azure` as the default provider.
+- Requires an Azure key with `endpoint` configured. `api-version` is injected automatically:
+  - **Key config `api_version`** takes priority (consistent with how auth is handled).
+  - Falls back to any `api-version` the client supplied in the query string.
 
 ### GenAI Passthrough
 
@@ -131,6 +140,81 @@ curl -X POST "http://localhost:8080/anthropic_passthrough/v1/messages" \
 </Tab>
 </Tabs>
 
+### Azure Passthrough
+
+<Tabs group="azure-passthrough">
+<Tab title="Azure OpenAI SDK">
+
+```python
+from openai import AzureOpenAI
+
+client = AzureOpenAI(
+    azure_endpoint="http://localhost:8080/azure_passthrough",
+    api_key="dummy-key",
+    api_version="2024-10-21",  # overridden by key config api_version if set
+)
+
+response = client.chat.completions.create(
+    model="gpt-4o",  # your Azure deployment name
+    messages=[{"role": "user", "content": "hello from azure passthrough"}]
+)
+
+print(response.choices[0].message.content)
+```
+
+</Tab>
+<Tab title="OpenAI SDK">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8080/azure_passthrough/openai/v1/",
+    api_key="dummy-key",
+)
+
+response = client.responses.create(
+    model="gpt-4.1",  # your Azure deployment name
+    input="hello from azure passthrough",
+)
+
+print(response.output_text)
+```
+
+</Tab>
+<Tab title="Anthropic SDK (Anthropic on Azure)">
+
+```python
+import anthropic
+
+client = anthropic.Anthropic(
+    base_url="http://localhost:8080/azure_passthrough",
+    api_key="dummy-key",
+)
+
+response = client.messages.create(
+    model="claude-sonnet-4-20250514",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "hello from azure passthrough"}]
+)
+
+print(response.content[0].text)
+```
+
+</Tab>
+<Tab title="cURL">
+
+```bash
+curl -X POST "http://localhost:8080/azure_passthrough/openai/deployments/gpt-4o/chat/completions" \
+  -H "content-type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "hello from azure passthrough"}]
+  }'
+```
+
+</Tab>
+</Tabs>
+
 ### GenAI Passthrough (Gemini)
 
 <Tabs group="genai-passthrough">
@@ -211,3 +295,4 @@ curl -X POST "http://localhost:8080/genai_passthrough/v1/projects/my-project/loc
 ## Notes
 
 - Use passthrough when you need a provider endpoint that is not directly supported by Bifrost integration routes yet.
+- For Azure passthrough, auth headers (`api-key`, `x-api-key`, OAuth token) are always sourced from the Bifrost key config and never forwarded from the client request.

--- a/transports/bifrost-http/handlers/integrations.go
+++ b/transports/bifrost-http/handlers/integrations.go
@@ -33,6 +33,7 @@ func NewIntegrationHandler(client *bifrost.Bifrost, handlerStore lib.HandlerStor
 		integrations.NewGenAIPassthroughRouter(client, handlerStore, logger),
 		integrations.NewOpenAIPassthroughRouter(client, handlerStore, logger),
 		integrations.NewAnthropicPassthroughRouter(client, handlerStore, logger),
+		integrations.NewAzurePassthroughRouter(client, handlerStore, logger),
 		integrations.NewCursorRouter(client, handlerStore, logger),
 	}
 

--- a/transports/bifrost-http/integrations/passthrough.go
+++ b/transports/bifrost-http/integrations/passthrough.go
@@ -47,6 +47,16 @@ func NewOpenAIPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.Handle
 	})
 }
 
+// NewAzurePassthroughRouter creates a passthrough router for /azure_passthrough.
+func NewAzurePassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
+	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{
+		Provider: schemas.Azure,
+		StripPrefix: []string{
+			"/azure_passthrough",
+		},
+	})
+}
+
 // NewGenAIPassthroughRouter creates a passthrough router for /genai_passthrough.
 func NewGenAIPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
 	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- feat: added azure passthrough support


### PR DESCRIPTION
## Summary

Implements passthrough functionality for the Azure provider, enabling raw API requests to be forwarded directly to Azure's API without transformation. This adds support for both regular and streaming passthrough requests through a new `/azure_passthrough` endpoint.

## Changes

- Replaced unsupported operation errors with full implementations of `Passthrough` and `PassthroughStream` methods in the Azure provider
- Added `buildPassthroughURL` helper method that handles Azure-specific URL construction, including API version injection and path normalization for OpenAI responses
- Created new Azure passthrough router in the HTTP transport layer with `/azure_passthrough` prefix stripping
- Integrated the Azure passthrough router into the main integration handler

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test the new Azure passthrough functionality by making requests to the `/azure_passthrough` endpoint:

```sh
# Test regular passthrough request
curl -X POST http://localhost:8080/azure_passthrough/openai/deployments/your-model/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer your-key" \
  -d '{"messages": [{"role": "user", "content": "Hello"}]}'

# Test streaming passthrough request
curl -X POST http://localhost:8080/azure_passthrough/openai/deployments/your-model/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer your-key" \
  -d '{"messages": [{"role": "user", "content": "Hello"}], "stream": true}'

# Run tests
go test ./core/providers/azure/...
go test ./transports/bifrost-http/...
```

Ensure Azure endpoint and API key are properly configured in your key configuration.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The passthrough functionality forwards authentication headers and request bodies directly to Azure's API. Ensure proper key management and access controls are in place as this bypasses normal request validation.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable