### PR TITLE
feat: add security schemes to OpenAPI spec and update virtual key examples

### DIFF
--- a/docs/features/governance/virtual-keys.mdx
+++ b/docs/features/governance/virtual-keys.mdx
@@ -162,7 +162,7 @@ curl -X DELETE http://localhost:8080/api/governance/virtual-keys/{vk_id}
       {
         "id": "vk-001",
         "name": "Engineering Team API",
-        "value": "vk-engineering-main",
+        "value": "sk-bf-*",
         "description": "Main API key for engineering team",
         "is_active": true,
         "provider_configs": [
@@ -495,7 +495,7 @@ All governance-enabled requests must include the virtual key header:
 ```bash
 curl -X POST http://localhost:8080/v1/chat/completions \
   -H "Content-Type: application/json" \
-  -H "x-bf-vk: vk-engineering-main" \
+  -H "x-bf-vk: sk-bf-*" \
   -d '{
     "model": "gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -25,6 +25,20 @@
       }
     }
   ],
+  "security": [
+    {
+      "BearerAuth": []
+    },
+    {
+      "BasicAuth": []
+    },
+    {
+      "VirtualKeyAuth": []
+    },
+    {
+      "ApiKeyAuth": []
+    }
+  ],
   "tags": [
     {
       "name": "Models",
@@ -37821,6 +37835,30 @@
     }
   },
   "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Bearer token authentication. Use your provider API key or Bifrost authentication token.\nVirtual keys (prefixed with `sk-bf-`) can also be passed here.\n"
+      },
+      "BasicAuth": {
+        "type": "http",
+        "scheme": "basic",
+        "description": "Basic authentication using username and password.\n"
+      },
+      "VirtualKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-bf-vk",
+        "description": "Bifrost Virtual Key for governance, routing, and access control. Only supported on inference endpoints (`/v1/*`), not on management APIs.\nExample: `sk-bf-*` prefixed keys.\n"
+      },
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key",
+        "description": "API key authentication via the `x-api-key` header.\nVirtual keys (prefixed with `sk-bf-`) can also be passed here.\n"
+      }
+    },
     "parameters": {
       "AsyncJobId": {
         "name": "job_id",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -63,6 +63,12 @@ servers:
         default: http://localhost:8080
         description: Base URL of your Bifrost instance (e.g. https://bifrost.mycompany.com)
 
+security:
+  - BearerAuth: []
+  - BasicAuth: []
+  - VirtualKeyAuth: []
+  - ApiKeyAuth: []
+
 tags:
   # Unified Inference API
   - name: Models
@@ -749,6 +755,33 @@ paths:
     $ref: './paths/management/infrastructure.yaml#/metrics'
 
 components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      description: |
+        Bearer token authentication. Use your provider API key or Bifrost authentication token.
+        Virtual keys (prefixed with `sk-bf-`) can also be passed here.
+    BasicAuth:
+      type: http
+      scheme: basic
+      description: |
+        Basic authentication using username and password.
+    VirtualKeyAuth:
+      type: apiKey
+      in: header
+      name: x-bf-vk
+      description: |
+        Bifrost Virtual Key for governance, routing, and access control. Only supported on inference endpoints (`/v1/*`), not on management APIs.
+        Example: `sk-bf-*` prefixed keys.
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: x-api-key
+      description: |
+        API key authentication via the `x-api-key` header.
+        Virtual keys (prefixed with `sk-bf-`) can also be passed here.
+
   parameters:
     AsyncJobId:
       $ref: './paths/inference/async.yaml#/components/parameters/AsyncJobId'

--- a/docs/providers/request-options.mdx
+++ b/docs/providers/request-options.mdx
@@ -54,7 +54,7 @@ Specify the virtual key identifier for governance, routing, and access control.
 <Tab title="Gateway (cURL)">
 ```bash
 curl --location 'http://localhost:8080/v1/chat/completions' \
---header 'x-bf-vk: vk-engineering-main' \
+--header 'x-bf-vk: sk-bf-*' \
 --header 'Content-Type: application/json' \
 --data '{
     "model": "openai/gpt-4o-mini",
@@ -65,7 +65,7 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
 <Tab title="Go SDK">
 ```go
 ctx := context.Background()
-ctx = context.WithValue(ctx, schemas.BifrostContextKeyVirtualKey, "vk-engineering-main")
+ctx = context.WithValue(ctx, schemas.BifrostContextKeyVirtualKey, "sk-bf-*")
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
     Provider: schemas.OpenAI,


### PR DESCRIPTION
## Summary

Updates virtual key examples in documentation and adds comprehensive authentication schemes to the OpenAPI specification. This standardizes the virtual key format to use the `sk-bf-*` prefix pattern and provides clear authentication options for API consumers.

## Changes

- Updated virtual key examples from `vk-engineering-main` to `sk-bf-*` format across documentation
- Added security schemes to OpenAPI specification including BearerAuth, BasicAuth, VirtualKeyAuth, and ApiKeyAuth
- Enhanced API documentation with detailed descriptions for each authentication method
- Clarified that virtual keys are only supported on inference endpoints (`/v1/*`), not management APIs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Validate the documentation changes by reviewing the updated examples:

```sh
# Test virtual key authentication with new format
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "x-bf-vk: sk-bf-*" \
  -d '{"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "Hello!"}]}'

# Verify OpenAPI spec is valid
# Check that the security schemes are properly defined in the generated documentation
```

## Screenshots/Recordings

![image.png](https://app.graphite.com/user-attachments/assets/0c7fde53-b3af-46f8-b55e-c26bf5363b67.png)



## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change improves security documentation by clearly defining authentication methods and specifying that virtual keys should follow the `sk-bf-*` prefix pattern for better identification and governance.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable