### PR TITLE
streaming blocker fix

### DIFF
--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -1569,6 +1569,18 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 	go func() {
 		defer func() {
 			schemas.ReleaseHTTPRequest(httpReq)
+			// Retrieve and run transport post-hook completer before closing the stream
+			// so errors can still be communicated to the client as SSE events.
+			// Must retrieve here (not before goroutine) because TransportInterceptorMiddleware
+			// sets BifrostContextKeyTransportPostHookCompleter after next(ctx) returns.
+			if postHookCompleter, ok := ctx.UserValue(schemas.BifrostContextKeyTransportPostHookCompleter).(func() error); ok && postHookCompleter != nil {
+				if err := postHookCompleter(); err != nil {
+					errorJSON, marshalErr := sonic.Marshal(map[string]string{"error": err.Error()})
+					if marshalErr == nil {
+						reader.SendError(errorJSON)
+					}
+				}
+			}
 			reader.Done()
 			// Complete the trace after streaming finishes
 			// This ensures all spans (including llm.call) are properly ended before the trace is sent to OTEL

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -354,15 +354,17 @@ func TransportInterceptorMiddleware(config *lib.Config) schemas.BifrostHTTPMiddl
 			next(ctx)
 
 			// For streaming responses, store a callback to run post-hooks after the stream ends.
-			// The streaming handler calls this before traceCompleter.
+			// The streaming handler calls this BEFORE reader.Done() so that errors can
+			// still be sent as SSE events. applyResponse=false because the response is
+			// already on the wire and mutating ctx.Response would corrupt the chunked stream.
 			if deferred, ok := ctx.UserValue(schemas.BifrostContextKeyDeferTraceCompletion).(bool); ok && deferred {
-				ctx.SetUserValue(schemas.BifrostContextKeyTransportPostHookCompleter, func() {
-					runTransportPostHooks(ctx, plugins, bifrostCtx)
+				ctx.SetUserValue(schemas.BifrostContextKeyTransportPostHookCompleter, func() error {
+					return runTransportPostHooks(ctx, plugins, bifrostCtx, false)
 				})
 				return
 			}
 
-			runTransportPostHooks(ctx, plugins, bifrostCtx)
+			_ = runTransportPostHooks(ctx, plugins, bifrostCtx, true)
 		}
 	}
 }
@@ -377,7 +379,8 @@ func TransportInterceptorMiddleware(config *lib.Config) schemas.BifrostHTTPMiddl
 // BifrostContext lifecycle. These logs are merged into the trace by the
 // TracingMiddleware at trace completion, alongside core-level plugin logs
 // which travel through BifrostContext → Trace → AttachPluginLogs.
-func runTransportPostHooks(ctx *fasthttp.RequestCtx, plugins []schemas.HTTPTransportPlugin, bifrostCtx *schemas.BifrostContext) {
+func runTransportPostHooks(ctx *fasthttp.RequestCtx, plugins []schemas.HTTPTransportPlugin, bifrostCtx *schemas.BifrostContext, applyResponse bool) error {
+	shouldApplyShortCircuit := applyResponse
 	httpResp := schemas.AcquireHTTPResponse()
 	defer schemas.ReleaseHTTPResponse(httpResp)
 	fasthttpResponseToHTTPResponse(ctx, httpResp)
@@ -404,8 +407,10 @@ func runTransportPostHooks(ctx *fasthttp.RequestCtx, plugins []schemas.HTTPTrans
 					ctx.SetUserValue(schemas.BifrostContextKeyTransportPluginLogs, postHookLogs)
 				}
 			}
-			applyHTTPResponseToCtx(ctx, httpResp)
-			return
+			if shouldApplyShortCircuit {
+				applyHTTPResponseToCtx(ctx, httpResp)
+			}
+			return fmt.Errorf("HTTPTransportPostHook plugin %s: %w", pluginName, err)
 		}
 	}
 	// Drain post-hook plugin logs and merge with pre-hook logs
@@ -416,7 +421,10 @@ func runTransportPostHooks(ctx *fasthttp.RequestCtx, plugins []schemas.HTTPTrans
 			ctx.SetUserValue(schemas.BifrostContextKeyTransportPluginLogs, postHookLogs)
 		}
 	}
-	applyHTTPResponseToCtx(ctx, httpResp)
+	if shouldApplyShortCircuit {
+		applyHTTPResponseToCtx(ctx, httpResp)
+	}
+	return nil
 }
 
 // getBifrostContextFromFastHTTP gets or creates a BifrostContext from fasthttp context.
@@ -519,6 +527,12 @@ func fasthttpResponseToHTTPResponse(ctx *fasthttp.RequestCtx, resp *schemas.HTTP
 	resp.StatusCode = ctx.Response.StatusCode()
 	for key, value := range ctx.Response.Header.All() {
 		resp.Headers[string(key)] = string(value)
+	}
+	// Skip response body copy for streaming (SSE) responses — the body is an active
+	// io.Reader consumed by fasthttp's writeBodyChunked. Calling Body() would race
+	// with the chunked writer (Body() drains and closes the bodyStream).
+	if deferred, ok := ctx.UserValue(schemas.BifrostContextKeyDeferTraceCompletion).(bool); ok && deferred {
+		return
 	}
 	// Skip response body copy when large payload/response mode is active — the response is
 	// streamed directly to the client and materializing it here would spike memory.
@@ -924,10 +938,6 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 
 			// Store a trace completion callback for streaming handlers to use
 			ctx.SetUserValue(schemas.BifrostContextKeyTraceCompleter, func() {
-				// Run deferred HTTPTransportPostHook for streaming responses
-				if postHookCompleter, ok := ctx.UserValue(schemas.BifrostContextKeyTransportPostHookCompleter).(func()); ok {
-					postHookCompleter()
-				}
 				// Attach transport plugin logs before completing the trace (streaming path)
 				if transportLogs, ok := ctx.UserValue(schemas.BifrostContextKeyTransportPluginLogs).([]schemas.PluginLogEntry); ok && len(transportLogs) > 0 {
 					tracer.AttachPluginLogs(traceID, transportLogs)


### PR DESCRIPTION
## Summary

Fixes error handling for transport post-hooks in streaming responses by ensuring errors can be communicated to clients as SSE events before the stream closes.

## Changes

- Modified `runTransportPostHooks` to return errors instead of immediately applying response changes for streaming contexts
- Added error handling in the streaming response producer goroutine to send post-hook errors as SSE events
- Introduced `applyResponse` parameter to control whether response modifications should be applied to the context
- Prevented response body copying for streaming responses to avoid race conditions with the chunked writer
- Removed duplicate post-hook execution from the tracing middleware since it's now handled in the streaming handler

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test streaming responses with transport plugins that may error during post-hooks:

```sh
# Core/Transports
go version
go test ./...

# Test streaming endpoints with plugins that have post-hook errors
# Verify errors are sent as SSE events before stream closure
# Verify non-streaming responses still handle post-hook errors correctly
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change improves error visibility without exposing additional information.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable