### PR TITLE
removes claude desktop docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -268,7 +268,6 @@
               "cli-agents/librechat",
               "cli-agents/claude-code",
               "cli-agents/claude-for-office",
-              "cli-agents/claude-desktop",
               "cli-agents/codex-cli",
               "cli-agents/gemini-cli",
               "cli-agents/qwen-code",


### PR DESCRIPTION
## Summary

Removed the `claude-desktop` CLI agent from the documentation navigation structure.

## Changes

- Removed `cli-agents/claude-desktop` entry from the docs.json navigation array
- This removes the Claude Desktop CLI agent from the documentation site's navigation menu

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify that the documentation site builds correctly and the Claude Desktop CLI agent no longer appears in the navigation:

```sh
# Build and serve documentation
cd docs
npm install
npm run build
npm run serve
```

Navigate to the CLI agents section and confirm `claude-desktop` is no longer listed in the sidebar navigation.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this is a documentation navigation change only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable