### PR TITLE
feat(oauth): add next-step hints to OAuth MCP client creation response

### DIFF
--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -405,7 +405,10 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			return
 		}
 
-		// Return OAuth flow initiation response
+		// Return OAuth flow initiation response with actionable next-step hints
+		// so API/CLI users know how to complete the flow without consulting docs.
+		completeURL := fmt.Sprintf("/api/mcp/client/%s/complete-oauth", flowInitiation.OauthConfigID)
+		statusURL := fmt.Sprintf("/api/oauth/config/%s/status", flowInitiation.OauthConfigID)
 		SendJSON(ctx, map[string]any{
 			"status":          "pending_oauth",
 			"message":         "OAuth authorization required",
@@ -413,6 +416,13 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			"authorize_url":   flowInitiation.AuthorizeURL,
 			"expires_at":      flowInitiation.ExpiresAt,
 			"mcp_client_id":   req.ClientID,
+			"complete_url":    completeURL,
+			"status_url":      statusURL,
+			"next_steps": []string{
+				"1. Open authorize_url in a browser to approve access",
+				"2. Poll status_url to check when status becomes 'authorized'",
+				"3. POST complete_url to activate the MCP client",
+			},
 		})
 		return
 	}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,2 @@
+- feat: add next-step hints to OAuth MCP client creation response
 - feat: added azure passthrough support


### PR DESCRIPTION
## Summary

Closes #2596

When creating an OAuth MCP client via the REST API, the `pending_oauth` response now includes actionable hints so the caller knows what to do next without consulting docs:

- `complete_url` — the endpoint to POST after authorization
- `status_url` — the endpoint to poll for authorization status
- `next_steps` — human-readable instructions

**Before:**
```json
{
  "status": "pending_oauth",
  "message": "OAuth authorization required",
  "oauth_config_id": "abc123",
  "authorize_url": "https://...",
  "expires_at": "...",
  "mcp_client_id": "xyz789"
}
```

**After:**
```json
{
  "status": "pending_oauth",
  "message": "OAuth authorization required",
  "oauth_config_id": "abc123",
  "authorize_url": "https://...",
  "expires_at": "...",
  "mcp_client_id": "xyz789",
  "complete_url": "/api/mcp/client/abc123/complete-oauth",
  "status_url": "/api/oauth/config/abc123/status",
  "next_steps": [
    "1. Open authorize_url in a browser to approve access",
    "2. Poll status_url to check when status becomes 'authorized'",
    "3. POST complete_url to activate the MCP client"
  ]
}
```

## Test plan

- [x] `go vet ./transports/bifrost-http/handlers/...` — clean
- [x] `go test ./transports/...` — all pass
- [x] Verified JSON output format matches expected shape
- [ ] Manual: create OAuth MCP client via curl, confirm new fields in response