### PR TITLE
listByModels exception fixes

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -655,7 +655,7 @@ func (provider *BedrockProvider) listModelsByKey(ctx *schemas.BifrostContext, ke
 	providerName := provider.GetProviderKey()
 	config := key.BedrockKeyConfig
 	region := DefaultBedrockRegion
-	if config.Region != nil && config.Region.GetValue() != "" {
+	if config != nil && config.Region != nil && config.Region.GetValue() != "" {
 		region = config.Region.GetValue()
 	}
 
@@ -697,10 +697,14 @@ func (provider *BedrockProvider) listModelsByKey(ctx *schemas.BifrostContext, ke
 	// If Value is set, use API Key authentication - else use IAM role authentication
 	if key.Value.GetValue() != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key.Value.GetValue()))
-	} else {
-		// Sign the request using either explicit credentials or IAM role authentication
-
+	} else if config != nil {
+		// Sign the request using explicit credentials or IAM role authentication
 		if err := signAWSRequest(ctx, req, config.AccessKey, config.SecretKey, config.SessionToken, config.RoleARN, config.ExternalID, config.RoleSessionName, region, bedrockSigningService); err != nil {
+			return nil, err
+		}
+	} else {
+		// No config and no API key — inherited auth via default credential chain
+		if err := signAWSRequest(ctx, req, schemas.EnvVar{}, schemas.EnvVar{}, nil, nil, nil, nil, region, bedrockSigningService); err != nil {
 			return nil, err
 		}
 	}

--- a/core/providers/ollama/ollama.go
+++ b/core/providers/ollama/ollama.go
@@ -66,6 +66,9 @@ func (provider *OllamaProvider) GetProviderKey() schemas.ModelProvider {
 
 // listModelsByKey performs a list models request for a single Ollama key.
 func (provider *OllamaProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	if key.OllamaKeyConfig == nil || key.OllamaKeyConfig.URL.GetValue() == "" {
+		return nil, providerUtils.NewConfigurationError("ollama key config URL is required")
+	}
 	return openai.ListModelsByKey(
 		ctx,
 		provider.client,

--- a/core/providers/sgl/sgl.go
+++ b/core/providers/sgl/sgl.go
@@ -67,6 +67,9 @@ func (provider *SGLProvider) GetProviderKey() schemas.ModelProvider {
 // listModelsByKey performs a list models request for a single SGL key,
 // resolving the per-key URL so each backend is queried individually.
 func (provider *SGLProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
+	if key.SGLKeyConfig == nil || key.SGLKeyConfig.URL.GetValue() == "" {
+		return nil, providerUtils.NewConfigurationError("sgl key config URL is required")
+	}
 	return openai.ListModelsByKey(
 		ctx,
 		provider.client,

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2402,6 +2402,19 @@ func HandleMultipleListModelsRequests(
 		wg.Add(1)
 		go func(k schemas.Key) {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					results <- schemas.ListModelsByKeyResult{
+						Err: &schemas.BifrostError{
+							IsBifrostError: true,
+							Error: &schemas.ErrorField{
+								Message: fmt.Sprintf("panic in listModelsByKey for key %s: %v", k.ID, r),
+							},
+						},
+						KeyID: k.ID,
+					}
+				}
+			}()
 			resp, bifrostErr := listModelsByKey(ctx, k, request)
 			results <- schemas.ListModelsByKeyResult{Response: resp, Err: bifrostErr, KeyID: k.ID}
 		}(key)

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -114,7 +114,10 @@ const cloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
 // It uses the JWT config if auth credentials are provided.
 // It returns an error if the token source creation fails.
 func getAuthTokenSource(key schemas.Key) (oauth2.TokenSource, error) {
-	authCredentials := key.VertexKeyConfig.AuthCredentials
+	var authCredentials schemas.EnvVar
+	if key.VertexKeyConfig != nil {
+		authCredentials = key.VertexKeyConfig.AuthCredentials
+	}
 	var tokenSource oauth2.TokenSource
 	if authCredentials.GetValue() == "" {
 		creds, err := google.FindDefaultCredentials(context.Background(), cloudPlatformScope)
@@ -173,7 +176,10 @@ func (provider *VertexProvider) GetProviderKey() schemas.ModelProvider {
 // 1. If deployments or allowedModels are configured, return those (no API call needed)
 // 2. Otherwise, fetch from the publishers.models.list API endpoint (Model Garden)
 func (provider *VertexProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	region := key.VertexKeyConfig.Region.GetValue()
+	var region string
+	if key.VertexKeyConfig != nil {
+		region = key.VertexKeyConfig.Region.GetValue()
+	}
 	if region == "" {
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
@@ -255,7 +261,9 @@ func (provider *VertexProvider) listModelsByKey(ctx *schemas.BifrostContext, key
 			// Handle error response
 			if resp.StatusCode() != fasthttp.StatusOK {
 				if resp.StatusCode() == fasthttp.StatusUnauthorized || resp.StatusCode() == fasthttp.StatusForbidden {
-					removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+					if key.VertexKeyConfig != nil {
+						removeVertexClient(key.VertexKeyConfig.AuthCredentials.GetValue())
+					}
 				}
 
 				// Non-Google publishers may not be available in all regions;


### PR DESCRIPTION
## Summary

Adds null safety checks and panic recovery for provider configurations to prevent runtime crashes when key configurations are missing or incomplete.

## Changes

- Added null safety checks for `BedrockKeyConfig`, `OllamaKeyConfig`, `SGLKeyConfig`, and `VertexKeyConfig` before accessing their properties
- Enhanced Bedrock provider to handle three authentication scenarios: API key, explicit credentials, and default credential chain
- Added configuration validation for Ollama and SGL providers to require URL configuration
- Implemented panic recovery mechanism in `HandleMultipleListModelsRequests` to gracefully handle unexpected errors during concurrent model listing operations
- Added proper error handling for Vertex provider client cleanup when authentication fails

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test with various provider configurations to ensure proper error handling:

```sh
# Core/Transports
go version
go test ./...

# Test with missing configurations
# - Bedrock keys without config
# - Ollama keys without URL
# - SGL keys without URL  
# - Vertex keys without region/credentials
```

Verify that providers handle missing configurations gracefully without panicking.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Improves security by preventing potential information disclosure through panic stack traces when configurations are malformed.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable