### PR TITLE
fix: cleanup OAuth sessions on virtual key deletion and prevent race condition

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2186,6 +2186,22 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string) error 
 		if err := tx.WithContext(ctx).Delete(&tables.TableVirtualKeyMCPConfig{}, "virtual_key_id = ?", id).Error; err != nil {
 			return err
 		}
+		// Delete per-user OAuth pending flows tied to this VK
+		if err := tx.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TablePerUserOAuthPendingFlow{}).Error; err != nil {
+			return err
+		}
+		// Delete per-user OAuth sessions tied to this VK
+		if err := tx.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TablePerUserOAuthSession{}).Error; err != nil {
+			return err
+		}
+		// Delete upstream OAuth user sessions tied to this VK
+		if err := tx.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableOauthUserSession{}).Error; err != nil {
+			return err
+		}
+		// Delete upstream OAuth user tokens tied to this VK
+		if err := tx.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableOauthUserToken{}).Error; err != nil {
+			return err
+		}
 		// Delete budgets owned by this virtual key
 		if err := tx.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableBudget{}).Error; err != nil {
 			return err

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -277,7 +277,7 @@ type TablePerUserOAuthSession struct {
 	RefreshTokenHash string           `gorm:"type:varchar(64);index" json:"-"`                   // SHA-256 hash for secure lookups (not unique — refresh tokens are optional)
 	ClientID         string           `gorm:"type:varchar(255);not null;index" json:"client_id"` // Which OAuth client registered this session
 	VirtualKeyID     *string          `gorm:"type:varchar(255);index" json:"virtual_key_id"`     // Linked VK identity (set when VK is present during auth)
-	VirtualKey       *TableVirtualKey `gorm:"foreignKey:VirtualKeyID" json:"-"`                  // Linked VK identity (server-only, not serialized)
+	VirtualKey       *TableVirtualKey `gorm:"foreignKey:VirtualKeyID" json:"-"` // Linked VK identity (server-only, not serialized)
 	UserID           *string          `gorm:"type:varchar(255);index" json:"user_id"`            // Linked enterprise user identity (set when user ID is present)
 	ExpiresAt        time.Time        `gorm:"index;not null" json:"expires_at"`
 	EncryptionStatus string           `gorm:"type:varchar(20);default:'plain_text'" json:"-"`

--- a/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
@@ -32,6 +32,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	const [errorMessage, setErrorMessage] = useState<string | null>(null)
 	const popupRef = useRef<Window | null>(null)
 	const pollIntervalRef = useRef<NodeJS.Timeout | null>(null)
+	const isCompletingRef = useRef(false)
 
 	// RTK Query hooks
 	const [getOAuthStatus] = useLazyGetOAuthConfigStatusQuery()
@@ -47,6 +48,10 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 
 	// Handle successful OAuth completion
 	const handleOAuthComplete = useCallback(async () => {
+		// Guard against concurrent calls (race between postMessage and polling)
+		if (isCompletingRef.current) return
+		isCompletingRef.current = true
+
 		// Close popup if still open
 		if (popupRef.current && !popupRef.current.closed) {
 			popupRef.current.close()
@@ -130,6 +135,9 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 
 	// Open popup and start polling
 	const openPopup = useCallback(() => {
+		// Reset completion guard for each fresh OAuth attempt
+		isCompletingRef.current = false
+
 		// Close any existing popup
 		if (popupRef.current && !popupRef.current.closed) {
 			popupRef.current.close()
@@ -196,6 +204,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 
 	const handleRetry = () => {
 		setErrorMessage(null)
+		isCompletingRef.current = false
 		if (isPerUserOauth) {
 			setStatus("confirm")
 		} else {
@@ -206,6 +215,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 
 	const handleCancel = () => {
 		stopPolling()
+		isCompletingRef.current = false
 		if (popupRef.current && !popupRef.current.closed) {
 			popupRef.current.close()
 		}


### PR DESCRIPTION
## Summary

Fixes data integrity issues when deleting virtual keys by ensuring proper cleanup of OAuth-related records and prevents race conditions in the OAuth authorization flow.

## Changes

- Added deletion of `TablePerUserOAuthPendingFlow` and `TablePerUserOAuthSession` records when a virtual key is deleted to prevent orphaned OAuth data
- Implemented race condition protection in OAuth2Authorizer using a ref guard to prevent concurrent completion handling between postMessage and polling mechanisms
- Fixed code formatting in OAuth table definition

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Test virtual key deletion with associated OAuth sessions and verify no orphaned records remain. Test OAuth authorization flow completion to ensure no duplicate completion handling occurs.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Improves data cleanup by ensuring OAuth sessions and pending flows are properly removed when virtual keys are deleted, preventing potential data leakage.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable