### PR TITLE
docs: add version requirement note for per-user OAuth

### DIFF
--- a/docs/mcp/per-user-oauth.mdx
+++ b/docs/mcp/per-user-oauth.mdx
@@ -7,6 +7,8 @@ icon: "users"
 
 ## Overview
 
+<Info>Per-user OAuth is available in **Bifrost v1.5.0-prerelease2 and above**.</Info>
+
 **Per-user OAuth** lets each end-user connect to upstream MCP services (Notion, GitHub, etc.) using their own credentials. Instead of a single shared admin token, every user gets their own access — scoped to their account, their data.
 
 This is different from [server-level OAuth](./oauth), where an admin authenticates once and every request uses the same shared token:


### PR DESCRIPTION
## Summary

Added version requirement information to the per-user OAuth documentation to clarify when this feature became available.

## Changes

- Added an info callout specifying that per-user OAuth requires Bifrost v1.5.0-prerelease2 or higher
- Positioned the version requirement prominently in the Overview section for immediate visibility

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the documentation renders correctly with the new info callout:

```sh
# Navigate to the docs directory and build/preview
cd docs
# Follow your standard documentation preview process
```

## Screenshots/Recordings

N/A - Documentation text addition only

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - documentation-only change.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable