### PR TITLE
feat(redis): add TLS, cluster mode support and fix valkey-search query syntax handling

### DIFF
--- a/docs/integrations/vector-databases/redis.mdx
+++ b/docs/integrations/vector-databases/redis.mdx
@@ -54,6 +54,11 @@ vectorConfig := &vectorstore.Config{
         Password: "",                      // Optional: Redis password
         DB:       0,                       // Optional: Redis database number (default: 0)
 
+        // Optional: TLS and cluster settings
+        UseTLS:             false,             // Enable TLS for encrypted connections
+        InsecureSkipVerify: false,             // Skip TLS cert verification
+        ClusterMode:        false,             // Use Redis Cluster client for cluster endpoints
+
         // Optional: Connection pool settings
         PoolSize:        10,               // Maximum socket connections
         MaxActiveConns:  10,               // Maximum active connections
@@ -89,6 +94,10 @@ if err != nil {
       "username": "",
       "password": "",
       "db": 0,
+      "use_tls": false,
+      "insecure_skip_verify": false,
+      "ca_cert_pem": "",
+      "cluster_mode": false,
       "pool_size": 10,
       "max_active_conns": 10,
       "min_idle_conns": 5,
@@ -113,6 +122,29 @@ if err != nil {
       "username": "your-username",
       "password": "your-password",
       "db": 0,
+      "use_tls": true,
+      "ca_cert_pem": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+      "cluster_mode": false,
+      "context_timeout": "10s"
+    }
+  }
+}
+```
+
+**For managed Redis Cluster endpoints:**
+```json
+{
+  "vector_store": {
+    "enabled": true,
+    "type": "redis",
+    "config": {
+      "addr": "your-cluster-endpoint:6379",
+      "username": "your-username",
+      "password": "your-password",
+      "db": 0,
+      "use_tls": true,
+      "ca_cert_pem": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+      "cluster_mode": true,
       "context_timeout": "10s"
     }
   }
@@ -139,6 +171,8 @@ Redis provides extensive connection pool configuration:
 ```go
 config := vectorstore.RedisConfig{
     Addr:            "localhost:6379",
+    UseTLS:          true,                     // Enable TLS
+    ClusterMode:     true,                     // Enable cluster mode
     PoolSize:        20,                    // Max socket connections
     MaxActiveConns:  20,                    // Max active connections
     MinIdleConns:    5,                     // Min idle connections
@@ -188,6 +222,10 @@ deleteResults, err := store.DeleteAll(ctx, namespace, queries)
 ```
 
 ### Production Considerations
+
+<Info>
+**TLS and Cluster Mode**: Set `use_tls: true` to enable TLS encryption for the Redis connection, and `insecure_skip_verify: true` if using self-signed certificates. Set `cluster_mode: true` when connecting to a Redis Cluster endpoint. When cluster mode is enabled, the `db` field must be `0` (Redis Cluster does not support database selection).
+</Info>
 
 <Info>
 **Search Module Required**: Redis/Valkey integration requires a search module/API that supports `FT.*` commands (index creation and vector search). If `FT.INFO` or `FT.SEARCH` is unavailable, semantic caching will not work.

--- a/examples/configs/withsemanticcachevalkey/config.json
+++ b/examples/configs/withsemanticcachevalkey/config.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://www.getbifrost.ai/schema",
+  "vector_store": {
+    "enabled": true,
+    "type": "redis",
+    "config": {
+      "addr": "env.REDIS_ADDR",
+      "username": "env.REDIS_USERNAME",
+      "password": "env.REDIS_PASSWORD",
+      "db": 0,
+      "use_tls": true,
+      "insecure_skip_verify": false,
+      "ca_cert_pem": "env.REDIS_CA_CERT_PEM",
+      "cluster_mode": true
+    }
+  },
+  "plugins": [
+    {
+      "enabled": true,
+      "name": "semantic_cache",
+      "config": {
+        "dimension": 1,
+        "ttl": 300,
+        "threshold": 0.8,
+        "default_cache_key": "valkey-repro-cache",
+        "vector_store_namespace": "ValkeySemanticCacheRepro"
+      }
+    }
+  ]
+}

--- a/framework/vectorstore/errors.go
+++ b/framework/vectorstore/errors.go
@@ -5,4 +5,5 @@ import "errors"
 var (
 	ErrNotFound     = errors.New("vectorstore: not found")
 	ErrNotSupported = errors.New("vectorstore: operation not supported on this store")
+	ErrQuerySyntax  = errors.New("vectorstore: query syntax error")
 )

--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -2,6 +2,8 @@ package vectorstore
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -31,6 +33,14 @@ type RedisConfig struct {
 	Password *schemas.EnvVar `json:"password,omitempty"` // Password for Redis AUTH (optional)
 	DB       *schemas.EnvVar `json:"db,omitempty"`       // Redis database number (default: 0)
 
+	// TLS settings
+	UseTLS             *schemas.EnvVar `json:"use_tls,omitempty"`              // Enable TLS for connection (default: false)
+	InsecureSkipVerify *schemas.EnvVar `json:"insecure_skip_verify,omitempty"` // Skip TLS cert verification (default: false)
+	CACertPEM          *schemas.EnvVar `json:"ca_cert_pem,omitempty"`          // PEM-encoded CA certificate to trust for Redis/Valkey TLS
+
+	// Cluster mode
+	ClusterMode *schemas.EnvVar `json:"cluster_mode,omitempty"` // Use Redis Cluster client (default: false)
+
 	// Connection pool and timeout settings (passed directly to Redis client)
 	PoolSize        int           `json:"pool_size,omitempty"`          // Maximum number of socket connections (optional)
 	MaxActiveConns  int           `json:"max_active_conns,omitempty"`   // Maximum number of active connections (optional)
@@ -46,7 +56,7 @@ type RedisConfig struct {
 
 // RedisStore represents the Redis vector store.
 type RedisStore struct {
-	client *redis.Client
+	client redis.UniversalClient
 	config RedisConfig
 	logger schemas.Logger
 
@@ -338,7 +348,7 @@ func (s *RedisStore) executeSearch(ctx context.Context, namespace string, redisQ
 			errMsg = strings.ToLower(result.Err().Error())
 			if isQuerySyntaxError(errMsg) {
 				if IsScanFallbackDisabled(ctx) {
-					return nil, fmt.Errorf("failed to search without scan fallback: %w", result.Err())
+					return nil, fmt.Errorf("%w: %w", ErrQuerySyntax, result.Err())
 				}
 				s.logger.Debug(fmt.Sprintf("FT.SEARCH scan fallback triggered for namespace %s: %s", namespace, result.Err()))
 				scanResults, _, scanErr := s.getAllByScan(ctx, namespace, queries, selectFields, nil, int64(searchLimit))
@@ -360,82 +370,15 @@ func (s *RedisStore) executeSearch(ctx context.Context, namespace string, redisQ
 }
 
 func (s *RedisStore) getAllByScan(ctx context.Context, namespace string, queries []Query, selectFields []string, cursor *string, limit int64) ([]SearchResult, *string, error) {
-	pattern := buildKey(namespace, "*")
-	var (
-		scanCursor uint64
-		all        []SearchResult
-	)
-
 	// Parse offset for deterministic in-memory pagination after full scan.
 	offset, err := parseOffsetCursor(cursor)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	for {
-		keys, nextCursor, err := s.client.Scan(ctx, scanCursor, pattern, BatchLimit).Result()
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to scan keys: %w", err)
-		}
-
-		if len(keys) > 0 {
-			pipe := s.client.Pipeline()
-			cmds := make([]*redis.MapStringStringCmd, len(keys))
-			for i, key := range keys {
-				cmds[i] = pipe.HGetAll(ctx, key)
-			}
-
-			if _, err := pipe.Exec(ctx); err != nil {
-				return nil, nil, fmt.Errorf("failed to fetch scanned keys: %w", err)
-			}
-
-			for i, cmd := range cmds {
-				if cmd.Err() != nil {
-					continue
-				}
-				fields := cmd.Val()
-				if len(fields) == 0 {
-					continue
-				}
-
-				key := keys[i]
-				id := strings.TrimPrefix(key, namespace+":")
-				if id == key {
-					continue
-				}
-
-				properties := make(map[string]interface{}, len(fields))
-				for k, v := range fields {
-					properties[k] = v
-				}
-
-				if !matchesQueriesForScan(properties, queries) {
-					continue
-				}
-
-				searchResult := SearchResult{
-					ID:         id,
-					Properties: make(map[string]interface{}),
-				}
-
-				if len(selectFields) == 0 {
-					searchResult.Properties = properties
-				} else {
-					for _, field := range selectFields {
-						if val, ok := properties[field]; ok {
-							searchResult.Properties[field] = val
-						}
-					}
-				}
-
-				all = append(all, searchResult)
-			}
-		}
-
-		scanCursor = nextCursor
-		if scanCursor == 0 {
-			break
-		}
+	all, err := s.scanAllMatchingResults(ctx, namespace, queries, selectFields)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Ensure stable pagination boundaries for offset cursors across calls.
@@ -467,6 +410,143 @@ func (s *RedisStore) getAllByScan(ctx context.Context, namespace string, queries
 	}
 
 	return results, next, nil
+}
+
+func (s *RedisStore) scanAllMatchingResults(ctx context.Context, namespace string, queries []Query, selectFields []string) ([]SearchResult, error) {
+	if clusterClient, ok := s.client.(*redis.ClusterClient); ok {
+		return s.scanAllMatchingResultsCluster(ctx, clusterClient, namespace, queries, selectFields)
+	}
+	return s.scanAllMatchingResultsSingle(ctx, s.client, namespace, queries, selectFields)
+}
+
+func (s *RedisStore) scanAllMatchingResultsSingle(ctx context.Context, client redis.Cmdable, namespace string, queries []Query, selectFields []string) ([]SearchResult, error) {
+	pattern := buildKey(namespace, "*")
+	var (
+		scanCursor uint64
+		all        []SearchResult
+	)
+
+	for {
+		keys, nextCursor, err := client.Scan(ctx, scanCursor, pattern, BatchLimit).Result()
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan keys: %w", err)
+		}
+
+		matches, err := s.fetchMatchingSearchResults(ctx, client, namespace, keys, queries, selectFields)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, matches...)
+
+		scanCursor = nextCursor
+		if scanCursor == 0 {
+			break
+		}
+	}
+
+	return all, nil
+}
+
+func (s *RedisStore) scanAllMatchingResultsCluster(ctx context.Context, client *redis.ClusterClient, namespace string, queries []Query, selectFields []string) ([]SearchResult, error) {
+	var (
+		all       []SearchResult
+		allMu     sync.Mutex
+		seenIDs   = make(map[string]struct{})
+		seenIDsMu sync.Mutex
+	)
+
+	err := client.ForEachMaster(ctx, func(ctx context.Context, nodeClient *redis.Client) error {
+		matches, err := s.scanAllMatchingResultsSingle(ctx, nodeClient, namespace, queries, selectFields)
+		if err != nil {
+			return err
+		}
+
+		unique := make([]SearchResult, 0, len(matches))
+		seenIDsMu.Lock()
+		for _, match := range matches {
+			if _, ok := seenIDs[match.ID]; ok {
+				continue
+			}
+			seenIDs[match.ID] = struct{}{}
+			unique = append(unique, match)
+		}
+		seenIDsMu.Unlock()
+
+		if len(unique) == 0 {
+			return nil
+		}
+
+		allMu.Lock()
+		all = append(all, unique...)
+		allMu.Unlock()
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan cluster nodes: %w", err)
+	}
+
+	return all, nil
+}
+
+func (s *RedisStore) fetchMatchingSearchResults(ctx context.Context, client redis.Cmdable, namespace string, keys []string, queries []Query, selectFields []string) ([]SearchResult, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	pipe := client.Pipeline()
+	cmds := make([]*redis.MapStringStringCmd, len(keys))
+	for i, key := range keys {
+		cmds[i] = pipe.HGetAll(ctx, key)
+	}
+
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, fmt.Errorf("failed to fetch scanned keys: %w", err)
+	}
+
+	results := make([]SearchResult, 0, len(keys))
+	for i, cmd := range cmds {
+		if cmd.Err() != nil {
+			continue
+		}
+		fields := cmd.Val()
+		if len(fields) == 0 {
+			continue
+		}
+
+		key := keys[i]
+		id := strings.TrimPrefix(key, namespace+":")
+		if id == key {
+			continue
+		}
+
+		properties := make(map[string]interface{}, len(fields))
+		for k, v := range fields {
+			properties[k] = v
+		}
+
+		if !matchesQueriesForScan(properties, queries) {
+			continue
+		}
+
+		searchResult := SearchResult{
+			ID:         id,
+			Properties: make(map[string]interface{}),
+		}
+
+		if len(selectFields) == 0 {
+			searchResult.Properties = properties
+		} else {
+			for _, field := range selectFields {
+				if val, ok := properties[field]; ok {
+					searchResult.Properties[field] = val
+				}
+			}
+		}
+
+		results = append(results, searchResult)
+	}
+
+	return results, nil
 }
 
 func matchesQueriesForScan(properties map[string]interface{}, queries []Query) bool {
@@ -1586,23 +1666,67 @@ func newRedisStore(_ context.Context, config RedisConfig, logger schemas.Logger)
 	if config.DB != nil {
 		db = config.DB.CoerceInt(0)
 	}
-	// Preparing the redis connection
-	client := redis.NewClient(&redis.Options{
-		Addr:            config.Addr.GetValue(),
-		Username:        config.Username.GetValue(),
-		Password:        config.Password.GetValue(),
-		DB:              db,
-		Protocol:        3, // Explicitly use RESP3 protocol
-		PoolSize:        config.PoolSize,
-		MaxActiveConns:  config.MaxActiveConns,
-		MinIdleConns:    config.MinIdleConns,
-		MaxIdleConns:    config.MaxIdleConns,
-		ConnMaxLifetime: config.ConnMaxLifetime,
-		ConnMaxIdleTime: config.ConnMaxIdleTime,
-		DialTimeout:     config.DialTimeout,
-		ReadTimeout:     config.ReadTimeout,
-		WriteTimeout:    config.WriteTimeout,
-	})
+
+	// TLS configuration
+	var tlsConfig *tls.Config
+	if config.UseTLS.CoerceBool(false) {
+		tlsConfig = &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: config.InsecureSkipVerify.CoerceBool(false),
+		}
+		if config.CACertPEM != nil && config.CACertPEM.GetValue() != "" {
+			rootCAs, err := systemCertPoolWithCA(config.CACertPEM.GetValue())
+			if err != nil {
+				return nil, fmt.Errorf("failed to configure Redis TLS CA certificate: %w", err)
+			}
+			tlsConfig.RootCAs = rootCAs
+		}
+	}
+
+	clusterMode := config.ClusterMode.CoerceBool(false)
+
+	var client redis.UniversalClient
+	if clusterMode {
+		// Redis Cluster does not support database selection
+		if db != 0 {
+			return nil, fmt.Errorf("redis cluster mode does not support database selection (DB must be 0)")
+		}
+		client = redis.NewClusterClient(&redis.ClusterOptions{
+			Addrs:           []string{config.Addr.GetValue()},
+			Username:        config.Username.GetValue(),
+			Password:        config.Password.GetValue(),
+			Protocol:        3, // Explicitly use RESP3 protocol
+			TLSConfig:       tlsConfig,
+			PoolSize:        config.PoolSize,
+			MaxActiveConns:  config.MaxActiveConns,
+			MinIdleConns:    config.MinIdleConns,
+			MaxIdleConns:    config.MaxIdleConns,
+			ConnMaxLifetime: config.ConnMaxLifetime,
+			ConnMaxIdleTime: config.ConnMaxIdleTime,
+			DialTimeout:     config.DialTimeout,
+			ReadTimeout:     config.ReadTimeout,
+			WriteTimeout:    config.WriteTimeout,
+		})
+	} else {
+		client = redis.NewClient(&redis.Options{
+			Addr:            config.Addr.GetValue(),
+			Username:        config.Username.GetValue(),
+			Password:        config.Password.GetValue(),
+			DB:              db,
+			Protocol:        3, // Explicitly use RESP3 protocol
+			TLSConfig:       tlsConfig,
+			PoolSize:        config.PoolSize,
+			MaxActiveConns:  config.MaxActiveConns,
+			MinIdleConns:    config.MinIdleConns,
+			MaxIdleConns:    config.MaxIdleConns,
+			ConnMaxLifetime: config.ConnMaxLifetime,
+			ConnMaxIdleTime: config.ConnMaxIdleTime,
+			DialTimeout:     config.DialTimeout,
+			ReadTimeout:     config.ReadTimeout,
+			WriteTimeout:    config.WriteTimeout,
+		})
+	}
+
 	// Creating store connection
 	store := &RedisStore{
 		client:              client,
@@ -1611,4 +1735,15 @@ func newRedisStore(_ context.Context, config RedisConfig, logger schemas.Logger)
 		namespaceFieldTypes: make(map[string]map[string]VectorStorePropertyType),
 	}
 	return store, nil
+}
+
+func systemCertPoolWithCA(caCertPEM string) (*x509.CertPool, error) {
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		rootCAs = x509.NewCertPool()
+	}
+	if !rootCAs.AppendCertsFromPEM([]byte(caCertPEM)) {
+		return nil, fmt.Errorf("failed to parse CA certificate PEM")
+	}
+	return rootCAs, nil
 }

--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -3,8 +3,15 @@ package vectorstore
 import (
 	"bufio"
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"math/big"
 	"net"
 	"os"
 	"strconv"
@@ -46,6 +53,9 @@ func NewRedisTestSetup(t *testing.T) *RedisTestSetup {
 	username := schemas.NewEnvVar(os.Getenv("REDIS_USERNAME"))
 	password := schemas.NewEnvVar(os.Getenv("REDIS_PASSWORD"))
 	db := schemas.NewEnvVar(getEnvWithDefault("REDIS_DB", "0"))
+	useTLS := schemas.NewEnvVar(os.Getenv("REDIS_USE_TLS"))
+	insecureSkipVerify := schemas.NewEnvVar(os.Getenv("REDIS_INSECURE_SKIP_VERIFY"))
+	clusterMode := schemas.NewEnvVar(os.Getenv("REDIS_CLUSTER_MODE"))
 
 	timeoutStr := getEnvWithDefault("REDIS_TIMEOUT", "10s")
 	timeout, err := time.ParseDuration(timeoutStr)
@@ -54,11 +64,14 @@ func NewRedisTestSetup(t *testing.T) *RedisTestSetup {
 	}
 
 	config := RedisConfig{
-		Addr:           addr,
-		Username:       username,
-		Password:       password,
-		DB:             db,
-		ContextTimeout: timeout,
+		Addr:               addr,
+		Username:           username,
+		Password:           password,
+		DB:                 db,
+		UseTLS:             useTLS,
+		InsecureSkipVerify: insecureSkipVerify,
+		ClusterMode:        clusterMode,
+		ContextTimeout:     timeout,
 	}
 
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelInfo)
@@ -217,6 +230,32 @@ func TestRedisConfig_Validation(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "cluster mode with db 0",
+			config: RedisConfig{
+				Addr:        schemas.NewEnvVar("localhost:6379"),
+				ClusterMode: schemas.NewEnvVar("true"),
+			},
+			expectError: false,
+		},
+		{
+			name: "cluster mode rejects non-zero db",
+			config: RedisConfig{
+				Addr:        schemas.NewEnvVar("localhost:6379"),
+				DB:          schemas.NewEnvVar("1"),
+				ClusterMode: schemas.NewEnvVar("true"),
+			},
+			expectError: true,
+			errorMsg:    "redis cluster mode does not support database selection",
+		},
+		{
+			name: "tls enabled",
+			config: RedisConfig{
+				Addr:   schemas.NewEnvVar("localhost:6380"),
+				UseTLS: schemas.NewEnvVar("true"),
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -237,6 +276,113 @@ func TestRedisConfig_Validation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func validTestCertPEM(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+}
+
+func TestNewRedisStore_ConfiguresStandaloneTLSClient(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelInfo)
+
+	store, err := newRedisStore(context.Background(), RedisConfig{
+		Addr:               schemas.NewEnvVar("localhost:6379"),
+		DB:                 schemas.NewEnvVar("2"),
+		UseTLS:             schemas.NewEnvVar("true"),
+		InsecureSkipVerify: schemas.NewEnvVar("true"),
+	}, logger)
+	require.NoError(t, err)
+
+	client, ok := store.client.(*redis.Client)
+	require.True(t, ok, "expected standalone redis client")
+	require.Equal(t, 2, client.Options().DB)
+	require.NotNil(t, client.Options().TLSConfig)
+	assert.True(t, client.Options().TLSConfig.InsecureSkipVerify)
+}
+
+func TestNewRedisStore_ConfiguresStandaloneTLSClientWithCACert(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelInfo)
+
+	store, err := newRedisStore(context.Background(), RedisConfig{
+		Addr:      schemas.NewEnvVar("localhost:6379"),
+		DB:        schemas.NewEnvVar("2"),
+		UseTLS:    schemas.NewEnvVar("true"),
+		CACertPEM: schemas.NewEnvVar(validTestCertPEM(t)),
+	}, logger)
+	require.NoError(t, err)
+
+	client, ok := store.client.(*redis.Client)
+	require.True(t, ok, "expected standalone redis client")
+	require.NotNil(t, client.Options().TLSConfig)
+	require.NotNil(t, client.Options().TLSConfig.RootCAs)
+	assert.False(t, client.Options().TLSConfig.InsecureSkipVerify)
+}
+
+func TestNewRedisStore_ConfiguresClusterTLSClient(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelInfo)
+
+	store, err := newRedisStore(context.Background(), RedisConfig{
+		Addr:               schemas.NewEnvVar("localhost:6379"),
+		UseTLS:             schemas.NewEnvVar("true"),
+		InsecureSkipVerify: schemas.NewEnvVar("true"),
+		ClusterMode:        schemas.NewEnvVar("true"),
+	}, logger)
+	require.NoError(t, err)
+
+	client, ok := store.client.(*redis.ClusterClient)
+	require.True(t, ok, "expected redis cluster client")
+	require.Equal(t, []string{"localhost:6379"}, client.Options().Addrs)
+	require.NotNil(t, client.Options().TLSConfig)
+	assert.True(t, client.Options().TLSConfig.InsecureSkipVerify)
+}
+
+func TestNewRedisStore_ConfiguresClusterTLSClientWithCACert(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelInfo)
+
+	store, err := newRedisStore(context.Background(), RedisConfig{
+		Addr:        schemas.NewEnvVar("localhost:6379"),
+		UseTLS:      schemas.NewEnvVar("true"),
+		CACertPEM:   schemas.NewEnvVar(validTestCertPEM(t)),
+		ClusterMode: schemas.NewEnvVar("true"),
+	}, logger)
+	require.NoError(t, err)
+
+	client, ok := store.client.(*redis.ClusterClient)
+	require.True(t, ok, "expected redis cluster client")
+	require.NotNil(t, client.Options().TLSConfig)
+	require.NotNil(t, client.Options().TLSConfig.RootCAs)
+	assert.False(t, client.Options().TLSConfig.InsecureSkipVerify)
+}
+
+func TestNewRedisStore_RejectsInvalidCACertPEM(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelInfo)
+
+	store, err := newRedisStore(context.Background(), RedisConfig{
+		Addr:      schemas.NewEnvVar("localhost:6379"),
+		UseTLS:    schemas.NewEnvVar("true"),
+		CACertPEM: schemas.NewEnvVar("not-valid-pem"),
+	}, logger)
+	require.Error(t, err)
+	assert.Nil(t, store)
+	assert.Contains(t, err.Error(), "failed to configure Redis TLS CA certificate")
 }
 
 type fakeRedisSearchServer struct {
@@ -422,7 +568,7 @@ func TestRedisStore_ExecuteSearch_DisableScanFallbackOnQuerySyntaxError(t *testi
 
 	_, err := store.executeSearch(WithDisableScanFallback(ctx), TestNamespace, "*", nil, nil, 0, 1)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to search without scan fallback")
+	assert.ErrorIs(t, err, ErrQuerySyntax)
 
 	ftSearchCalls, sawScan := server.stats()
 	assert.Equal(t, 2, ftSearchCalls)

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -624,6 +624,18 @@ false
 {{- if .Values.vectorStore.redis.external.contextTimeout }}
 {{- $_ := set $redisConfig "context_timeout" .Values.vectorStore.redis.external.contextTimeout }}
 {{- end }}
+{{- if .Values.vectorStore.redis.external.useTls }}
+{{- $_ := set $redisConfig "use_tls" true }}
+{{- end }}
+{{- if .Values.vectorStore.redis.external.insecureSkipVerify }}
+{{- $_ := set $redisConfig "insecure_skip_verify" true }}
+{{- end }}
+{{- if .Values.vectorStore.redis.external.caCertPem }}
+{{- $_ := set $redisConfig "ca_cert_pem" .Values.vectorStore.redis.external.caCertPem }}
+{{- end }}
+{{- if .Values.vectorStore.redis.external.clusterMode }}
+{{- $_ := set $redisConfig "cluster_mode" true }}
+{{- end }}
 {{- end }}
 {{- $_ := set $vectorStore "config" $redisConfig }}
 {{- else if eq .Values.vectorStore.type "qdrant" }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1955,6 +1955,25 @@
                   "default": 0,
                   "description": "Redis/Valkey database number"
                 },
+                "useTls": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Enable TLS for the Redis/Valkey connection"
+                },
+                "insecureSkipVerify": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Skip TLS certificate verification for Redis/Valkey connections"
+                },
+                "caCertPem": {
+                  "type": "string",
+                  "description": "PEM-encoded CA certificate to trust for Redis/Valkey TLS connections"
+                },
+                "clusterMode": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "Use Redis Cluster mode for cluster configuration endpoints"
+                },
                 "poolSize": {
                   "type": "integer",
                   "description": "Maximum number of socket connections"

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -733,6 +733,10 @@ vectorStore:
       username: ""
       password: ""
       database: 0
+      useTls: false                # Enable TLS for Redis connection
+      insecureSkipVerify: false    # Skip TLS certificate verification
+      caCertPem: ""                # PEM-encoded CA certificate to trust for Redis TLS
+      clusterMode: false           # Use Redis Cluster mode (required for AWS MemoryDB)
       # Connection pool tuning (optional)
       # poolSize: 10             # Maximum number of socket connections
       # maxActiveConns: 0        # Maximum number of active connections

--- a/plugins/semanticcache/plugin_cache_type_test.go
+++ b/plugins/semanticcache/plugin_cache_type_test.go
@@ -266,6 +266,7 @@ type directFastPathStore struct {
 	getAllCalls    int
 	lastGetChunkID string
 	lastGetAllCtx  context.Context
+	getAllErr      error
 }
 
 func newDirectFastPathStore() *directFastPathStore {
@@ -301,6 +302,9 @@ func (s *directFastPathStore) GetChunks(ctx context.Context, namespace string, i
 func (s *directFastPathStore) GetAll(ctx context.Context, namespace string, queries []vectorstore.Query, selectFields []string, cursor *string, limit int64) ([]vectorstore.SearchResult, *string, error) {
 	s.getAllCalls++
 	s.lastGetAllCtx = ctx
+	if s.getAllErr != nil {
+		return nil, nil, s.getAllErr
+	}
 	return nil, nil, vectorstore.ErrNotSupported
 }
 
@@ -819,6 +823,39 @@ func TestPerformDirectSearchDisablesScanFallbackForLegacyLookup(t *testing.T) {
 	}
 	if !vectorstore.IsScanFallbackDisabled(store.lastGetAllCtx) {
 		t.Fatal("expected legacy direct lookup to disable scan fallback")
+	}
+}
+
+func TestPerformLegacyDirectSearchTreatsQuerySyntaxErrorAsMiss(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	store := newDirectFastPathStore()
+	store.getAllErr = vectorstore.ErrQuerySyntax
+	plugin := &Plugin{
+		store:  store,
+		config: getDefaultTestConfig(),
+		logger: logger,
+	}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
+	}
+
+	ctx := CreateContextWithCacheKey("legacy-query-syntax")
+	_, err := plugin.prepareDirectCacheLookup(ctx, req, "legacy-query-syntax")
+	if err != nil {
+		t.Fatalf("prepareDirectCacheLookup failed: %v", err)
+	}
+
+	shortCircuit, err := plugin.performLegacyDirectSearch(ctx, req, "legacy-query-syntax")
+	if err != nil {
+		t.Fatalf("performLegacyDirectSearch failed: %v", err)
+	}
+	if shortCircuit != nil {
+		t.Fatal("expected query syntax incompatibility to be treated as a miss")
+	}
+	if store.getAllCalls != 1 {
+		t.Fatalf("expected one legacy GetAll call, got %d", store.getAllCalls)
 	}
 }
 

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -69,7 +69,7 @@ func (plugin *Plugin) performLegacyDirectSearch(ctx *schemas.BifrostContext, req
 	var cursor *string
 	results, _, err := plugin.store.GetAll(searchCtx, plugin.config.VectorStoreNamespace, filters, selectFields, cursor, 1)
 	if err != nil {
-		if errors.Is(err, vectorstore.ErrNotFound) {
+		if errors.Is(err, vectorstore.ErrNotFound) || errors.Is(err, vectorstore.ErrQuerySyntax) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to search for legacy direct hash match: %w", err)

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2913,6 +2913,25 @@
           "description": "Redis database number (default: 0)",
           "default": 0
         },
+        "use_tls": {
+          "type": "boolean",
+          "description": "Use TLS for the Redis/Valkey connection (optional)",
+          "default": false
+        },
+        "insecure_skip_verify": {
+          "type": "boolean",
+          "description": "Skip TLS certificate verification for Redis/Valkey connections. Use only when a trusted CA cannot be configured.",
+          "default": false
+        },
+        "ca_cert_pem": {
+          "type": "string",
+          "description": "PEM-encoded CA certificate to trust for Redis/Valkey TLS connections"
+        },
+        "cluster_mode": {
+          "type": "boolean",
+          "description": "Use Redis Cluster mode. Required for cluster configuration endpoints; when enabled, db must be 0.",
+          "default": false
+        },
         "pool_size": {
           "type": "integer",
           "description": "Maximum number of socket connections (optional)"


### PR DESCRIPTION
## Summary

Adds TLS and Redis Cluster support to the Redis vector store integration, enabling secure connections and improving compatibility with managed Redis/Valkey services such as AWS MemoryDB. Also improves semantic-cache handling on `valkey-search` 1.0.x backends by treating legacy direct-search query-syntax incompatibilities as cache misses instead of surfacing repeated direct-search warnings.

## Changes

- Added TLS configuration options (`use_tls`, `insecure_skip_verify`, `ca_cert_pem`) for encrypted Redis connections
- Added Redis Cluster mode support (`cluster_mode`) with proper standalone vs cluster client selection
- Enhanced scan fallback to work across cluster nodes with deduplication
- Added `ErrQuerySyntax` for better Redis/Valkey query-syntax error classification
- Updated the semantic cache plugin to treat legacy direct-search query-syntax incompatibilities as cache misses
- Added test coverage for TLS, CA cert, cluster config, and query-syntax handling
- Updated documentation with TLS and cluster configuration examples
- Added Helm chart support for the new Redis configuration options
- Added an example config for managed Valkey/Redis endpoints

## Type of change

- Feature
- Bug fix
- Refactor
- Documentation

## Affected areas

- Framework (Go)
- Plugins
- Docs
- Helm

## How to test

Targeted tests:

```bash
GOWORK=off go test ./framework/vectorstore -run "TestRedisStore|TestNewRedisStore" -count=1 -v
go test ./plugins/semanticcache -count=1 -v
```

Optional standalone TLS smoke test:

```bash
export REDIS_ADDR="localhost:6380"
export REDIS_USE_TLS=true
export REDIS_INSECURE_SKIP_VERIFY=true
GOWORK=off go test ./framework/vectorstore -run "TestRedisStore|TestNewRedisStore" -count=1 -v
```

## Behavioral validation

- Verified that normal direct semantic-cache hits still work.
- Verified that on backends where legacy metadata `FT.SEARCH` is rejected with `Missing =>`, Bifrost now treats that legacy direct-search failure as a cache miss instead of logging repeated `Direct search failed ...` warnings.

## New configuration options

- `use_tls`: Enable TLS encryption (`boolean`)
- `insecure_skip_verify`: Skip TLS certificate verification (`boolean`)
- `ca_cert_pem`: Custom CA certificate in PEM format (`string`)
- `cluster_mode`: Enable Redis Cluster client (`boolean`, requires `db: 0`)

## Breaking changes

None. All new configuration options are optional with backward-compatible defaults.

## Security considerations

- TLS support enables encrypted connections to Redis/Valkey
- `insecure_skip_verify` should only be used in development or trusted environments
- `ca_cert_pem` enables explicit CA trust for managed/private Redis TLS deployments
- Cluster mode enforces `db: 0` as required by Redis Cluster

## Valkey note

- This change does not make the legacy metadata-search fallback start working on `valkey-search` 1.0.x backends.
- It changes Bifrost to degrade cleanly when those backends reject the legacy `FT.SEARCH` query, avoiding repeated direct-search warning logs.

## Checklist

- [x] I read docs/contributing/README.md and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed where applicable
- [x] I verified the relevant test suite(s) locally