### PR TITLE
refactor: improve key validation error handling and logging

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6253,17 +6253,21 @@ func (bifrost *Bifrost) getAllSupportedKeys(ctx *schemas.BifrostContext, provide
 
 	// Filter keys for ListModels - only check if key has a value
 	var supportedKeys []schemas.Key
-	for _, k := range keys {
+	for _, key := range keys {
 		// Skip disabled keys (default enabled when nil)
-		if k.Enabled != nil && !*k.Enabled {
+		if key.Enabled != nil && !*key.Enabled {
 			continue
 		}
-		if strings.TrimSpace(k.Value.GetValue()) != "" || CanProviderKeyValueBeEmpty(baseProviderType) {
-			supportedKeys = append(supportedKeys, k)
+		if err := validateKey(baseProviderType, &key); err != nil {
+			bifrost.logger.Warn("error validating key %s (%s) for provider %s: %s, skipping key", key.Name, key.ID, providerKey, err.Error())
+			continue
+		}
+		if strings.TrimSpace(key.Value.GetValue()) != "" || CanProviderKeyValueBeEmpty(baseProviderType) {
+			supportedKeys = append(supportedKeys, key)
 		}
 	}
 
-	bifrost.logger.Debug("[Bifrost] Provider %s: %d enabled keys found", providerKey, len(supportedKeys))
+	bifrost.logger.Debug("[Bifrost] Provider %s: %d valid keys found", providerKey, len(supportedKeys))
 
 	if len(supportedKeys) == 0 {
 		return nil, fmt.Errorf("no valid keys found for provider: %v", providerKey)
@@ -6303,6 +6307,11 @@ func (bifrost *Bifrost) getKeysForBatchAndFileOps(ctx *schemas.BifrostContext, p
 
 		// For batch operations, only include keys with UseForBatchAPI enabled
 		if isBatchOp && (k.UseForBatchAPI == nil || !*k.UseForBatchAPI) {
+			continue
+		}
+
+		if err := validateKey(baseProviderType, &k); err != nil {
+			bifrost.logger.Warn("error validating key %s (%s) for provider %s: %s, skipping key", k.Name, k.ID, providerKey, err.Error())
 			continue
 		}
 
@@ -6397,9 +6406,8 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *schemas.BifrostContex
 			if key.Enabled != nil && !*key.Enabled {
 				continue
 			}
-			isKeyValid := validateKey(providerKey, &key)
-			if !isKeyValid {
-				bifrost.logger.Warn("key %s is not valid for provider: %s", key.ID, providerKey)
+			if err := validateKey(baseProviderType, &key); err != nil {
+				bifrost.logger.Warn("error validating key %s (%s) for provider %s: %s, skipping key", key.Name, key.ID, providerKey, err.Error())
 				continue
 			}
 			if strings.TrimSpace(key.Value.GetValue()) != "" || CanProviderKeyValueBeEmpty(baseProviderType) {
@@ -6413,9 +6421,8 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *schemas.BifrostContex
 			if key.Enabled != nil && !*key.Enabled {
 				continue
 			}
-			isKeyValid := validateKey(providerKey, &key)
-			if !isKeyValid {
-				bifrost.logger.Warn("key %s is not valid for provider: %s", key.ID, providerKey)
+			if err := validateKey(baseProviderType, &key); err != nil {
+				bifrost.logger.Warn("error validating key %s (%s) for provider %s: %s, skipping key", key.Name, key.ID, providerKey, err.Error())
 				continue
 			}
 			hasValue := strings.TrimSpace(key.Value.GetValue()) != "" || CanProviderKeyValueBeEmpty(baseProviderType)

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -309,15 +309,6 @@ func (provider *AzureProvider) completeRequest(
 // listModelsByKey performs a list models request for a single key.
 // Returns the response and latency, or an error if the request fails.
 func (provider *AzureProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	// Validate Azure key configuration
-	if key.AzureKeyConfig == nil {
-		return nil, providerUtils.NewConfigurationError("azure key config not set")
-	}
-
-	if key.AzureKeyConfig.Endpoint.GetValue() == "" {
-		return nil, providerUtils.NewConfigurationError("endpoint not set")
-	}
-
 	// Get API version
 	apiVersion := key.AzureKeyConfig.APIVersion
 	if apiVersion == nil {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2402,6 +2402,21 @@ func HandleMultipleListModelsRequests(
 		wg.Add(1)
 		go func(k schemas.Key) {
 			defer wg.Done()
+			// Should never panic, but if it does, we need to handle it gracefully
+			defer func() {
+				if r := recover(); r != nil {
+					getLogger().Error("panic in listModelsByKey for key %s (%s): %v", k.Name, k.ID, r)
+					results <- schemas.ListModelsByKeyResult{
+						Err: &schemas.BifrostError{
+							IsBifrostError: true,
+							Error: &schemas.ErrorField{
+								Message: "internal error while listing models for key",
+							},
+						},
+						KeyID: k.ID,
+					}
+				}
+			}()
 			resp, bifrostErr := listModelsByKey(ctx, k, request)
 			results <- schemas.ListModelsByKeyResult{Response: resp, Err: bifrostErr, KeyID: k.ID}
 		}(key)

--- a/core/utils.go
+++ b/core/utils.go
@@ -133,15 +133,15 @@ func validateRequest(req *schemas.BifrostRequest) *schemas.BifrostError {
 }
 
 // validateKey validates the given key.
-func validateKey(providerKey schemas.ModelProvider, key *schemas.Key) bool {
-	// Valid the key for the provider
+func validateKey(providerKey schemas.ModelProvider, key *schemas.Key) error {
+	// Validate the key for the provider
 	switch providerKey {
 	case schemas.Azure:
 		if key.AzureKeyConfig == nil {
-			return false
+			return fmt.Errorf("azure_key_config is required")
 		}
 		if key.AzureKeyConfig.Endpoint.GetValue() == "" {
-			return false
+			return fmt.Errorf("azure_key_config.endpoint is required")
 		}
 	case schemas.Bedrock:
 		// Key is valid if either:
@@ -149,32 +149,41 @@ func validateKey(providerKey schemas.ModelProvider, key *schemas.Key) bool {
 		// 2. Value is provided and is not empty
 		if key.BedrockKeyConfig == nil {
 			if key.Value.GetValue() == "" {
-				return false
+				return fmt.Errorf("either value in key or bedrock_key_config is required")
 			}
 			key.BedrockKeyConfig = &schemas.BedrockKeyConfig{}
 		}
 	case schemas.Vertex:
 		if key.VertexKeyConfig == nil {
-			return false
+			return fmt.Errorf("vertex_key_config is required")
 		}
 	case schemas.Replicate:
 		if key.ReplicateKeyConfig == nil {
-			return false
+			return fmt.Errorf("replicate_key_config is required")
 		}
 	case schemas.VLLM:
-		if key.VLLMKeyConfig == nil || key.VLLMKeyConfig.URL.GetValue() == "" {
-			return false
+		if key.VLLMKeyConfig == nil {
+			return fmt.Errorf("vllm_key_config is required")
+		}
+		if key.VLLMKeyConfig.URL.GetValue() == "" {
+			return fmt.Errorf("vllm_key_config.url is required")
 		}
 	case schemas.Ollama:
-		if key.OllamaKeyConfig == nil || key.OllamaKeyConfig.URL.GetValue() == "" {
-			return false
+		if key.OllamaKeyConfig == nil {
+			return fmt.Errorf("ollama_key_config is required")
+		}
+		if key.OllamaKeyConfig.URL.GetValue() == "" {
+			return fmt.Errorf("ollama_key_config.url is required")
 		}
 	case schemas.SGL:
-		if key.SGLKeyConfig == nil || key.SGLKeyConfig.URL.GetValue() == "" {
-			return false
+		if key.SGLKeyConfig == nil {
+			return fmt.Errorf("sgl_key_config is required")
+		}
+		if key.SGLKeyConfig.URL.GetValue() == "" {
+			return fmt.Errorf("sgl_key_config.url is required")
 		}
 	}
-	return true
+	return nil
 }
 
 // IsRateLimitErrorMessage checks if an error message indicates a rate limit issue


### PR DESCRIPTION
## Summary

Improved error handling in key validation by changing the `validateKey` function to return detailed error messages instead of a boolean, providing better debugging information when keys fail validation.

## Changes

- Modified `validateKey` function signature to return `error` instead of `bool`
- Added specific error messages for each provider type's validation failures
- Updated all callers of `validateKey` to handle the new error return type
- Enhanced logging to include the actual validation error message
- Renamed loop variable from `k` to `key` for better readability

## Type of change

- [x] Refactor
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that key validation errors are properly logged with descriptive messages:

```sh
# Core/Transports
go version
go test ./...
```

Test with invalid key configurations for different providers (Azure, Bedrock, Vertex, etc.) to ensure error messages are informative.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change improves security observability by providing clearer error messages when key validation fails, making it easier to identify configuration issues.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable