### PR TITLE
fix: restore prompt stream EOF before trace flush

### DIFF
--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2291,8 +2291,8 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 
 	// Producer goroutine: processes the stream channel, formats events, sends to reader
 	go func() {
-		// Separate defers ensure each cleanup runs even if an earlier one panics (LIFO order)
-		defer reader.Done()
+		// Keep cleanups separate so one panic does not skip the others (LIFO order).
+		// Signal EOF to the client first, then complete trace flushing, then release pooled request state.
 		defer schemas.ReleaseHTTPRequest(httpReq)
 		defer func() {
 			// Complete the trace after streaming finishes
@@ -2301,6 +2301,7 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 				traceCompleter()
 			}
 		}()
+		defer reader.Done()
 
 		// Create encoder for AWS Event Stream if needed
 		var eventStreamEncoder *eventstream.Encoder


### PR DESCRIPTION
## Summary

This PR adjusts the streaming cleanup order in `transports/bifrost-http/integrations/router.go` so the SSE reader signals EOF to the client before trace flushing runs, while still keeping cleanup steps separated for panic isolation.

This patch was produced from an **agent-driven investigation** of a reported regression in `v1.5.0-prerelease2` where OpenAI Responses-compatible streams emitted `response.completed` but did not terminate promptly downstream.

If this direction is not appropriate for current `main`, please feel free to close the PR.

## What changed

- keep cleanup steps as separate defers
- run `reader.Done()` first during goroutine teardown
- run `traceCompleter()` after EOF signaling
- release pooled `HTTPRequest` state last

## Why

Issue #2606 documents the regression analysis and reproduction matrix:

- direct fake upstream: exits normally
- official `v1.5.0-prerelease1`: exits normally
- official `v1.5.0-prerelease2`: hangs until timeout after terminal stream event

The analysis traced the regression back to the cleanup ordering introduced in `#2513` for the tagged prerelease2 behavior.

Current `main` has already diverged somewhat from the exact prerelease2 tracing path, but this patch keeps cleanup units separate and narrowly focuses on restoring prompt downstream EOF.

## Validation

Agent-run validation completed during analysis:

- built a clean `transports/v1.5.0-prerelease2` snapshot with the equivalent EOF-first cleanup patch via `transports/Dockerfile.local`
- reproduced the same fake `/openai/responses` scenario
- observed patched prerelease2 exit normally (`~0.18s`, `returncode 0`) instead of timing out (`20.00s`) after `response.completed`

## Notes

This is intentionally a minimal transport-layer change. If maintainers prefer a different approach for current `main`, this PR can be closed in favor of that direction.

Closes #2606
