### PR TITLE
fix: replace find-then-upsert with atomic ON CONFLICT to prevent deadlocks

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6253,17 +6253,21 @@ func (bifrost *Bifrost) getAllSupportedKeys(ctx *schemas.BifrostContext, provide
 
 	// Filter keys for ListModels - only check if key has a value
 	var supportedKeys []schemas.Key
-	for _, k := range keys {
+	for _, key := range keys {
 		// Skip disabled keys (default enabled when nil)
-		if k.Enabled != nil && !*k.Enabled {
+		if key.Enabled != nil && !*key.Enabled {
 			continue
 		}
-		if strings.TrimSpace(k.Value.GetValue()) != "" || CanProviderKeyValueBeEmpty(baseProviderType) {
-			supportedKeys = append(supportedKeys, k)
+		if err := validateKey(baseProviderType, &key); err != nil {
+			bifrost.logger.Warn("error validating key %s (%s) for provider %s: %s, skipping key", key.Name, key.ID, providerKey, err.Error())
+			continue
+		}
+		if strings.TrimSpace(key.Value.GetValue()) != "" || CanProviderKeyValueBeEmpty(baseProviderType) {
+			supportedKeys = append(supportedKeys, key)
 		}
 	}
 
-	bifrost.logger.Debug("[Bifrost] Provider %s: %d enabled keys found", providerKey, len(supportedKeys))
+	bifrost.logger.Debug("[Bifrost] Provider %s: %d valid keys found", providerKey, len(supportedKeys))
 
 	if len(supportedKeys) == 0 {
 		return nil, fmt.Errorf("no valid keys found for provider: %v", providerKey)
@@ -6303,6 +6307,11 @@ func (bifrost *Bifrost) getKeysForBatchAndFileOps(ctx *schemas.BifrostContext, p
 
 		// For batch operations, only include keys with UseForBatchAPI enabled
 		if isBatchOp && (k.UseForBatchAPI == nil || !*k.UseForBatchAPI) {
+			continue
+		}
+
+		if err := validateKey(baseProviderType, &k); err != nil {
+			bifrost.logger.Warn("error validating key %s (%s) for provider %s: %s, skipping key", k.Name, k.ID, providerKey, err.Error())
 			continue
 		}
 
@@ -6397,9 +6406,8 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *schemas.BifrostContex
 			if key.Enabled != nil && !*key.Enabled {
 				continue
 			}
-			isKeyValid := validateKey(providerKey, &key)
-			if !isKeyValid {
-				bifrost.logger.Warn("key %s is not valid for provider: %s", key.ID, providerKey)
+			if err := validateKey(baseProviderType, &key); err != nil {
+				bifrost.logger.Warn("error validating key %s (%s) for provider %s: %s, skipping key", key.Name, key.ID, providerKey, err.Error())
 				continue
 			}
 			if strings.TrimSpace(key.Value.GetValue()) != "" || CanProviderKeyValueBeEmpty(baseProviderType) {
@@ -6413,9 +6421,8 @@ func (bifrost *Bifrost) selectKeyFromProviderForModel(ctx *schemas.BifrostContex
 			if key.Enabled != nil && !*key.Enabled {
 				continue
 			}
-			isKeyValid := validateKey(providerKey, &key)
-			if !isKeyValid {
-				bifrost.logger.Warn("key %s is not valid for provider: %s", key.ID, providerKey)
+			if err := validateKey(baseProviderType, &key); err != nil {
+				bifrost.logger.Warn("error validating key %s (%s) for provider %s: %s, skipping key", key.Name, key.ID, providerKey, err.Error())
 				continue
 			}
 			hasValue := strings.TrimSpace(key.Value.GetValue()) != "" || CanProviderKeyValueBeEmpty(baseProviderType)

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -309,15 +309,6 @@ func (provider *AzureProvider) completeRequest(
 // listModelsByKey performs a list models request for a single key.
 // Returns the response and latency, or an error if the request fails.
 func (provider *AzureProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	// Validate Azure key configuration
-	if key.AzureKeyConfig == nil {
-		return nil, providerUtils.NewConfigurationError("azure key config not set")
-	}
-
-	if key.AzureKeyConfig.Endpoint.GetValue() == "" {
-		return nil, providerUtils.NewConfigurationError("endpoint not set")
-	}
-
 	// Get API version
 	apiVersion := key.AzureKeyConfig.APIVersion
 	if apiVersion == nil {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2402,6 +2402,21 @@ func HandleMultipleListModelsRequests(
 		wg.Add(1)
 		go func(k schemas.Key) {
 			defer wg.Done()
+			// Should never panic, but if it does, we need to handle it gracefully
+			defer func() {
+				if r := recover(); r != nil {
+					getLogger().Error("panic in listModelsByKey for key %s (%s): %v", k.Name, k.ID, r)
+					results <- schemas.ListModelsByKeyResult{
+						Err: &schemas.BifrostError{
+							IsBifrostError: true,
+							Error: &schemas.ErrorField{
+								Message: "internal error while listing models for key",
+							},
+						},
+						KeyID: k.ID,
+					}
+				}
+			}()
 			resp, bifrostErr := listModelsByKey(ctx, k, request)
 			results <- schemas.ListModelsByKeyResult{Response: resp, Err: bifrostErr, KeyID: k.ID}
 		}(key)

--- a/core/utils.go
+++ b/core/utils.go
@@ -133,15 +133,15 @@ func validateRequest(req *schemas.BifrostRequest) *schemas.BifrostError {
 }
 
 // validateKey validates the given key.
-func validateKey(providerKey schemas.ModelProvider, key *schemas.Key) bool {
-	// Valid the key for the provider
+func validateKey(providerKey schemas.ModelProvider, key *schemas.Key) error {
+	// Validate the key for the provider
 	switch providerKey {
 	case schemas.Azure:
 		if key.AzureKeyConfig == nil {
-			return false
+			return fmt.Errorf("azure_key_config is required")
 		}
 		if key.AzureKeyConfig.Endpoint.GetValue() == "" {
-			return false
+			return fmt.Errorf("azure_key_config.endpoint is required")
 		}
 	case schemas.Bedrock:
 		// Key is valid if either:
@@ -149,32 +149,41 @@ func validateKey(providerKey schemas.ModelProvider, key *schemas.Key) bool {
 		// 2. Value is provided and is not empty
 		if key.BedrockKeyConfig == nil {
 			if key.Value.GetValue() == "" {
-				return false
+				return fmt.Errorf("either value in key or bedrock_key_config is required")
 			}
 			key.BedrockKeyConfig = &schemas.BedrockKeyConfig{}
 		}
 	case schemas.Vertex:
 		if key.VertexKeyConfig == nil {
-			return false
+			return fmt.Errorf("vertex_key_config is required")
 		}
 	case schemas.Replicate:
 		if key.ReplicateKeyConfig == nil {
-			return false
+			return fmt.Errorf("replicate_key_config is required")
 		}
 	case schemas.VLLM:
-		if key.VLLMKeyConfig == nil || key.VLLMKeyConfig.URL.GetValue() == "" {
-			return false
+		if key.VLLMKeyConfig == nil {
+			return fmt.Errorf("vllm_key_config is required")
+		}
+		if key.VLLMKeyConfig.URL.GetValue() == "" {
+			return fmt.Errorf("vllm_key_config.url is required")
 		}
 	case schemas.Ollama:
-		if key.OllamaKeyConfig == nil || key.OllamaKeyConfig.URL.GetValue() == "" {
-			return false
+		if key.OllamaKeyConfig == nil {
+			return fmt.Errorf("ollama_key_config is required")
+		}
+		if key.OllamaKeyConfig.URL.GetValue() == "" {
+			return fmt.Errorf("ollama_key_config.url is required")
 		}
 	case schemas.SGL:
-		if key.SGLKeyConfig == nil || key.SGLKeyConfig.URL.GetValue() == "" {
-			return false
+		if key.SGLKeyConfig == nil {
+			return fmt.Errorf("sgl_key_config is required")
+		}
+		if key.SGLKeyConfig.URL.GetValue() == "" {
+			return fmt.Errorf("sgl_key_config.url is required")
 		}
 	}
-	return true
+	return nil
 }
 
 // IsRateLimitErrorMessage checks if an error message indicates a rate limit issue

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -377,6 +377,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddWhitelistedRoutesJSONColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddModelPricingUniqueIndex(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -6138,6 +6141,59 @@ func migrationAddWhitelistedRoutesJSONColumn(ctx context.Context, db *gorm.DB) e
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_whitelisted_routes_json_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddModelPricingUniqueIndex ensures the composite unique index (model, provider, mode)
+// exists on governance_model_pricing so that atomic ON CONFLICT upserts work correctly.
+func migrationAddModelPricingUniqueIndex(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_model_pricing_unique_index",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// Remove duplicate rows before creating the unique index.
+			// The old find-then-insert path could have produced duplicates on
+			// multinode deployments, and CREATE UNIQUE INDEX will fail on a table
+			// that still contains them. Keep the row with the lowest ID for each
+			// (model, provider, mode) combination.
+			result := tx.Exec(`
+				DELETE FROM governance_model_pricing
+				WHERE id NOT IN (
+					SELECT MIN(id)
+					FROM governance_model_pricing
+					GROUP BY model, provider, mode
+				)
+			`)
+			if result.Error != nil {
+				return fmt.Errorf("failed to deduplicate model pricing rows: %w", result.Error)
+			}
+			if result.RowsAffected > 0 {
+				log.Printf("[migration] removed %d duplicate row(s) from governance_model_pricing before creating unique index", result.RowsAffected)
+			}
+
+			if !mg.HasIndex(&tables.TableModelPricing{}, "idx_model_provider_mode") {
+				if err := mg.CreateIndex(&tables.TableModelPricing{}, "idx_model_provider_mode"); err != nil {
+					return fmt.Errorf("failed to create unique index idx_model_provider_mode: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasIndex(&tables.TableModelPricing{}, "idx_model_provider_mode") {
+				if err := mg.DropIndex(&tables.TableModelPricing{}, "idx_model_provider_mode"); err != nil {
+					return fmt.Errorf("failed to drop unique index idx_model_provider_mode: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_model_pricing_unique_index migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1509,8 +1509,8 @@ func (s *RDBConfigStore) GetModelPrices(ctx context.Context) ([]tables.TableMode
 }
 
 // UpsertModelPrices creates or updates a model pricing record in the database.
-// Uses a find-then-create-or-update pattern so it works regardless of dialect
-// (SQLite vs PostgreSQL) and constraint naming.
+// Uses a single atomic ON CONFLICT statement to avoid deadlocks in multinode deployments
+// where multiple nodes may attempt concurrent upserts for the same model on startup.
 func (s *RDBConfigStore) UpsertModelPrices(ctx context.Context, pricing *tables.TableModelPricing, tx ...*gorm.DB) error {
 	var txDB *gorm.DB
 	if len(tx) > 0 {
@@ -1520,22 +1520,10 @@ func (s *RDBConfigStore) UpsertModelPrices(ctx context.Context, pricing *tables.
 	}
 	db := txDB.WithContext(ctx)
 
-	var existing tables.TableModelPricing
-	err := db.Where("model = ? AND provider = ? AND mode = ?", pricing.Model, pricing.Provider, pricing.Mode).First(&existing).Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			// No existing row: create
-			if err := db.Create(pricing).Error; err != nil {
-				return s.parseGormError(err)
-			}
-			return nil
-		}
-		return s.parseGormError(err)
-	}
-
-	// Existing row: update by setting ID and saving (full replace)
-	pricing.ID = existing.ID
-	if err := db.Save(pricing).Error; err != nil {
+	if err := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "model"}, {Name: "provider"}, {Name: "mode"}},
+		UpdateAll: true,
+	}).Create(pricing).Error; err != nil {
 		return s.parseGormError(err)
 	}
 	return nil
@@ -1700,6 +1688,8 @@ func (s *RDBConfigStore) GetModelParametersByModel(ctx context.Context, model st
 }
 
 // UpsertModelParameters inserts or updates model parameters for a specific model.
+// Uses a single atomic ON CONFLICT statement to avoid deadlocks in multinode deployments
+// where multiple nodes may attempt concurrent upserts for the same model on startup.
 func (s *RDBConfigStore) UpsertModelParameters(ctx context.Context, params *tables.TableModelParameters, tx ...*gorm.DB) error {
 	var txDB *gorm.DB
 	if len(tx) > 0 {
@@ -1709,20 +1699,10 @@ func (s *RDBConfigStore) UpsertModelParameters(ctx context.Context, params *tabl
 	}
 	db := txDB.WithContext(ctx)
 
-	var existing tables.TableModelParameters
-	err := db.Where("model = ?", params.Model).First(&existing).Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			if err := db.Create(params).Error; err != nil {
-				return s.parseGormError(err)
-			}
-			return nil
-		}
-		return s.parseGormError(err)
-	}
-
-	params.ID = existing.ID
-	if err := db.Save(params).Error; err != nil {
+	if err := db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "model"}},
+		UpdateAll: true,
+	}).Create(params).Error; err != nil {
 		return s.parseGormError(err)
 	}
 	return nil

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -79,6 +79,21 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 		distributedLockManager: configstore.NewDistributedLockManager(configStore, logger, configstore.WithDefaultTTL(30*time.Second)),
 	}
 
+	// Initialize syncCtx early so background startup goroutines can use it and
+	// Cleanup() can cancel them. startSyncWorker is still called at the end after
+	// cold-start paths have completed.
+	mc.syncCtx, mc.syncCancel = context.WithCancel(ctx)
+
+	// If Init returns an error the caller never owns mc and will never call
+	// Cleanup(), so cancel syncCtx to stop any background goroutines that were
+	// already spawned before the failure.
+	initSucceeded := false
+	defer func() {
+		if !initSucceeded {
+			mc.syncCancel()
+		}
+	}()
+
 	logger.Info("initializing model catalog...")
 	if configStore != nil {
 		// Per-model lazy load when the in-memory cache misses (eviction, new models, or if
@@ -99,14 +114,6 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 			}
 			return &providerUtils.ModelParams{MaxOutputTokens: p.MaxOutputTokens}
 		})
-		lock, err := mc.distributedLockManager.NewLock("model_catalog_pricing_sync")
-		if err != nil {
-			return nil, fmt.Errorf("failed to create model catalog pricing sync lock: %w", err)
-		}
-		if err := lock.LockWithRetry(ctx, 10); err != nil {
-			return nil, fmt.Errorf("failed to acquire model catalog pricing sync lock: %w", err)
-		}
-		defer lock.Unlock(ctx)
 		var wg sync.WaitGroup
 		var pricingErr, paramsErr error
 		wg.Add(2)
@@ -121,15 +128,21 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 			mc.mu.RUnlock()
 			if hasPricingData {
 				mc.logger.Info("existing pricing data found in database, syncing from URL in background")
+				mc.wg.Add(1)
 				go func() {
-					if err := mc.syncPricing(context.Background()); err != nil {
+					defer mc.wg.Done()
+					if err := mc.withDistributedLock(mc.syncCtx, "model_catalog_pricing_startup_sync", 10, func() error {
+						return mc.syncPricing(mc.syncCtx)
+					}); err != nil {
 						mc.logger.Warn("background startup pricing sync failed: %v", err)
 					} else {
 						mc.logger.Info("background startup pricing sync completed successfully")
 					}
 				}()
 			} else {
-				if err := mc.syncPricing(ctx); err != nil {
+				if err := mc.withDistributedLock(ctx, "model_catalog_pricing_startup_sync", 10, func() error {
+					return mc.syncPricing(ctx)
+				}); err != nil {
 					pricingErr = fmt.Errorf("failed to sync pricing data: %w", err)
 				}
 			}
@@ -143,15 +156,21 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 			}
 			if n > 0 {
 				mc.logger.Info("existing model parameters found in database (%d records), syncing from URL in background", n)
+				mc.wg.Add(1)
 				go func() {
-					if err := mc.syncModelParameters(context.Background()); err != nil {
+					defer mc.wg.Done()
+					if err := mc.withDistributedLock(mc.syncCtx, "model_catalog_params_startup_sync", 10, func() error {
+						return mc.syncModelParameters(mc.syncCtx)
+					}); err != nil {
 						mc.logger.Warn("background startup model parameters sync failed: %v", err)
 					} else {
 						mc.logger.Info("background startup model parameters sync completed successfully")
 					}
 				}()
 			} else {
-				if err := mc.syncModelParameters(ctx); err != nil {
+				if err := mc.withDistributedLock(ctx, "model_catalog_params_startup_sync", 10, func() error {
+					return mc.syncModelParameters(ctx)
+				}); err != nil {
 					paramsErr = fmt.Errorf("failed to sync model parameters data: %w", err)
 				}
 			}
@@ -185,8 +204,8 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 	}
 
 	// Start background sync worker
-	mc.syncCtx, mc.syncCancel = context.WithCancel(ctx)
 	mc.startSyncWorker(mc.syncCtx)
+	initSucceeded = true
 	return mc, nil
 }
 
@@ -230,6 +249,7 @@ func (mc *ModelCatalog) UpdateSyncConfig(ctx context.Context, config *Config) er
 	if config.PricingURL != nil {
 		mc.pricingURL = *config.PricingURL
 	}
+
 	mc.syncInterval = DefaultSyncInterval
 	if config.PricingSyncInterval != nil {
 		mc.syncInterval = *config.PricingSyncInterval

--- a/framework/modelcatalog/sync.go
+++ b/framework/modelcatalog/sync.go
@@ -21,10 +21,8 @@ const (
 
 // syncPricing syncs pricing data from URL to database and updates cache
 func (mc *ModelCatalog) syncPricing(ctx context.Context) error {
-	mc.logger.Debug("starting pricing data synchronization for governance")
 	if mc.shouldSyncGate != nil {
 		if !mc.shouldSyncGate(ctx) {
-			mc.logger.Debug("pricing sync cancelled by custom gate")
 			return nil
 		}
 	}
@@ -39,7 +37,7 @@ func (mc *ModelCatalog) syncPricing(ctx context.Context) error {
 			return fmt.Errorf("failed to get pricing records: %w", pricingErr)
 		}
 		if len(pricingRecords) > 0 {
-			mc.logger.Error("failed to load pricing data from URL, but existing data found in database: %v", err)
+			mc.logger.Warn("failed to fetch pricing from URL, falling back to existing database records: %v", err)
 			return nil
 		} else {
 			return fmt.Errorf("failed to load pricing data from URL and no existing data in database: %w", err)
@@ -83,7 +81,7 @@ func (mc *ModelCatalog) syncPricing(ctx context.Context) error {
 	// Populate model params cache from pricing datasheet max_output_tokens
 	mc.populateModelParamsFromPricing(pricingData)
 
-	mc.logger.Info("successfully synced %d pricing records", len(pricingData))
+	mc.logger.Debug("successfully synced %d pricing records", len(pricingData))
 	return nil
 }
 
@@ -188,7 +186,7 @@ func (mc *ModelCatalog) loadPricingFromDatabase(ctx context.Context) error {
 		mc.pricingData[key] = pricing
 	}
 
-	mc.logger.Debug("loaded %d pricing records into cache", len(pricingRecords))
+	mc.logger.Debug("loaded %d pricing records from database into memory", len(mc.pricingData))
 	return nil
 }
 
@@ -227,6 +225,35 @@ func (mc *ModelCatalog) startSyncWorker(ctx context.Context) {
 	go mc.syncWorker(ctx)
 }
 
+// withDistributedLock acquires a named distributed lock and executes fn under it.
+// Pass retries=0 to block until acquired (Lock); pass retries>0 to use LockWithRetry.
+func (mc *ModelCatalog) withDistributedLock(ctx context.Context, key string, retries int, fn func() error) error {
+	lock, err := mc.distributedLockManager.NewLock(key)
+	if err != nil {
+		return fmt.Errorf("failed to create lock %q: %w", key, err)
+	}
+	if retries > 0 {
+		if err := lock.LockWithRetry(ctx, retries); err != nil {
+			return fmt.Errorf("failed to acquire lock %q: %w", key, err)
+		}
+	} else {
+		if err := lock.Lock(ctx); err != nil {
+			return fmt.Errorf("failed to acquire lock %q: %w", key, err)
+		}
+	}
+	// Use a fresh context for unlock so that a cancelled or timed-out work context
+	// does not prevent the lock row from being deleted. If we reused ctx and it was
+	// already cancelled when the defer fires, ReleaseLock's DB call would fail
+	// silently and the lock would stay in the database until TTL expiry (30s),
+	// blocking every other node from acquiring it during that window.
+	defer func() {
+		if err := lock.Unlock(context.Background()); err != nil {
+			mc.logger.Warn("failed to release distributed lock %q: %v", key, err)
+		}
+	}()
+	return fn()
+}
+
 // syncTick performs a single sync tick with proper lock management
 // if the last sync was more than the sync interval ago, sync pricing and model parameters in parallel
 func (mc *ModelCatalog) syncTick(ctx context.Context) {
@@ -236,44 +263,44 @@ func (mc *ModelCatalog) syncTick(ctx context.Context) {
 	mc.syncMu.RUnlock()
 
 	if time.Since(lastSync) >= interval {
-		lock, err := mc.distributedLockManager.NewLock("model_catalog_pricing_sync")
-		if err != nil {
-			mc.logger.Error("failed to create model catalog pricing sync lock: %v", err)
-			return
-		}
-		if err := lock.Lock(ctx); err != nil {
-			mc.logger.Error("failed to acquire model catalog pricing sync lock: %v", err)
-			return
-		}
-		defer lock.Unlock(ctx)
-		// Sync pricing and model parameters in parallel
-		var wg sync.WaitGroup
-		var pricingErr, paramsErr error
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
-			if err := mc.syncPricing(ctx); err != nil {
-				mc.logger.Error("background pricing sync failed: %v", err)
-				pricingErr = err
-			}
-		}()
-		go func() {
-			defer wg.Done()
-			if err := mc.syncModelParameters(ctx); err != nil {
-				mc.logger.Error("background model parameters sync failed: %v", err)
-				paramsErr = err
-			}
-		}()
-		wg.Wait()
+		mc.logger.Debug("starting model catalog background sync")
+		if err := mc.withDistributedLock(ctx, "model_catalog_pricing_sync", 10, func() error {
+			// Sync pricing and model parameters in parallel
+			var wg sync.WaitGroup
+			var pricingErr, paramsErr error
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				if err := mc.syncPricing(ctx); err != nil {
+					mc.logger.Error("background pricing sync failed: %v", err)
+					pricingErr = err
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				if err := mc.syncModelParameters(ctx); err != nil {
+					mc.logger.Error("background model parameters sync failed: %v", err)
+					paramsErr = err
+				}
+			}()
+			wg.Wait()
 
-		if pricingErr == nil && paramsErr == nil {
-			if mc.afterSyncHook != nil {
-				mc.afterSyncHook(ctx)
+			if pricingErr == nil && paramsErr == nil {
+				if mc.afterSyncHook != nil {
+					mc.afterSyncHook(ctx)
+				}
+				mc.syncMu.Lock()
+				mc.lastSyncedAt = time.Now()
+				mc.syncMu.Unlock()
 			}
-			mc.syncMu.Lock()
-			mc.lastSyncedAt = time.Now()
-			mc.syncMu.Unlock()
+			if pricingErr != nil {
+				return pricingErr
+			}
+			return paramsErr
+		}); err != nil {
+			mc.logger.Error("failed to run model catalog sync: %v", err)
 		}
+		mc.logger.Debug("model catalog background sync completed")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes deadlock issues in multinode deployments by replacing find-then-update patterns with atomic ON CONFLICT upsert operations and refining distributed lock usage for model catalog synchronization.

## Changes

- **Replaced find-then-update with atomic upserts**: Modified `UpsertModelPrices` and `UpsertModelParameters` to use GORM's `ON CONFLICT` clause instead of separate SELECT and INSERT/UPDATE operations
- **Refined distributed locking strategy**: Moved from coarse-grained locking around entire sync operations to more targeted locking with separate locks for pricing and parameter syncs during startup
- **Improved background sync handling**: Enhanced the sync worker to use proper distributed locking and better error handling
- **Reduced log verbosity**: Changed some INFO level logs to DEBUG to reduce noise during normal operations

The atomic upsert approach eliminates race conditions where multiple nodes could simultaneously attempt to insert the same model pricing or parameter records, preventing deadlocks that occurred with the previous find-then-create-or-update pattern.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test multinode deployment scenarios where multiple instances start simultaneously:

```sh
# Test basic functionality
go test ./framework/configstore/...
go test ./framework/modelcatalog/...

# Test concurrent upsert operations
# Deploy multiple instances and verify no deadlocks occur during startup
# Check logs for successful model catalog synchronization without lock contention errors
```

Verify that model pricing and parameter data is correctly synchronized across all nodes without database deadlocks.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Addresses deadlock issues in multinode deployments during model catalog initialization.

## Security considerations

No security implications - this change only affects internal database operations and distributed locking mechanisms.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable