### PR TITLE
fix(ui): validate OAuth popup messages

### DIFF
--- a/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
@@ -154,7 +154,11 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	// Listen for postMessage from OAuth callback popup
 	useEffect(() => {
 		const handleMessage = (event: MessageEvent) => {
-			// Verify message is from OAuth callback
+			// Only accept messages from the popup we opened and our own callback origin.
+			if (event.source !== popupRef.current || event.origin !== window.location.origin) {
+				return
+			}
+
 			if (event.data?.type === "oauth_success") {
 				// Trigger immediate status check; stopPolling is called inside
 				// checkOAuthStatus only after a confirmed terminal state, so


### PR DESCRIPTION
## Summary

Validate OAuth popup `postMessage` events against the popup window reference and the current origin before triggering the completion flow.

## Changes

- Restrict the OAuth message listener to the popup instance opened by the dialog
- Require the message origin to match the current app origin before handling `oauth_success`
- Keep the existing polling/completion flow unchanged once a trusted message is received

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# UI
cd ui
pnpm exec vitest run lib/message/variables.test.ts
pnpm exec tsc --noEmit
```

Expected outcomes:
- The OAuth listener only reacts to messages from the popup window opened by the UI
- Same-origin OAuth callbacks continue to complete successfully
- Current unrelated frontend issues still remain on main: the prompt variable test failure and missing PDF type dependencies in `pnpm exec tsc --noEmit`

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

Not needed for this logic-only UI fix.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

None.

## Security considerations

This hardens the OAuth popup flow by ensuring `postMessage` events come from the expected popup and origin before the UI treats them as trusted.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable