### PR TITLE
fix(ui): open OAuth popup from user gesture

### DIFF
--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -16,7 +16,7 @@ import { parseArrayFromText } from "@/lib/utils/array";
 import { Validator } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Info } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { OAuth2Authorizer } from "./oauth2Authorizer";
 
 interface ClientFormProps {
@@ -63,6 +63,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 		oauthConfigId: string;
 		mcpClientId: string;
 	} | null>(null);
+	const oauthPopupRef = useRef<Window | null>(null);
 	const { toast } = useToast();
 
 	// RTK Query mutations
@@ -77,8 +78,18 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			setScopesText("");
 			setOauthFlow(null);
 			setIsLoading(false);
+			oauthPopupRef.current = null;
 		}
 	}, [open]);
+
+	const openOAuthPopupShell = () => {
+		const width = 600;
+		const height = 700;
+		const left = window.screen.width / 2 - width / 2;
+		const top = window.screen.height / 2 - height / 2;
+
+		return window.open("", "oauth_popup", `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`);
+	};
 
 	const handleChange = (
 		field: keyof CreateMCPClientRequest,
@@ -216,6 +227,20 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			return;
 		}
 
+		let popupWindow: Window | null = null;
+		if (form.auth_type === "oauth") {
+			popupWindow = openOAuthPopupShell();
+			if (!popupWindow) {
+				toast({
+					title: "Popup blocked",
+					description: "Please allow popups and try again.",
+					variant: "destructive",
+				});
+				return;
+			}
+			oauthPopupRef.current = popupWindow;
+		}
+
 		setIsLoading(true);
 
 		// Prepare the payload
@@ -258,6 +283,10 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					mcpClientId: response.mcp_client_id,
 				});
 			} else {
+				if (popupWindow && !popupWindow.closed) {
+					popupWindow.close();
+				}
+				oauthPopupRef.current = null;
 				setIsLoading(false);
 				toast({
 					title: "Success",
@@ -267,6 +296,10 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 				onClose();
 			}
 		} catch (error) {
+			if (popupWindow && !popupWindow.closed) {
+				popupWindow.close();
+			}
+			oauthPopupRef.current = null;
 			setIsLoading(false);
 			toast({ title: "Error", description: getErrorMessage(error), variant: "destructive" });
 		}
@@ -605,6 +638,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					authorizeUrl={oauthFlow.authorizeUrl}
 					oauthConfigId={oauthFlow.oauthConfigId}
 					mcpClientId={oauthFlow.mcpClientId}
+					initialPopup={oauthPopupRef.current}
 				/>
 			)}
 		</Sheet>

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -79,6 +79,11 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			setOauthFlow(null);
 			setIsLoading(false);
 			oauthPopupRef.current = null;
+		} else {
+			if (oauthPopupRef.current && !oauthPopupRef.current.closed) {
+				oauthPopupRef.current.close();
+			}
+			oauthPopupRef.current = null;
 		}
 	}, [open]);
 

--- a/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
@@ -15,6 +15,7 @@ interface OAuth2AuthorizerProps {
 	authorizeUrl: string
 	oauthConfigId: string
 	mcpClientId: string
+	initialPopup?: Window | null
 }
 
 export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
@@ -25,6 +26,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	authorizeUrl,
 	oauthConfigId,
 	mcpClientId,
+	initialPopup,
 }) => {
 	const [status, setStatus] = useState<"pending" | "polling" | "success" | "failed">("pending")
 	const [errorMessage, setErrorMessage] = useState<string | null>(null)
@@ -126,12 +128,14 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 		}, 2000) // Poll every 2 seconds
 	}, [checkOAuthStatus, handleOAuthFailed])
 
+	useEffect(() => {
+		popupRef.current = initialPopup ?? null
+	}, [initialPopup])
+
 	// Open popup and start polling
 	const openPopup = useCallback(() => {
 		// Close any existing popup
-		if (popupRef.current && !popupRef.current.closed) {
-			popupRef.current.close()
-		}
+		let popupWindow = popupRef.current
 
 		// Open OAuth popup
 		const width = 600
@@ -139,17 +143,32 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 		const left = window.screen.width / 2 - width / 2
 		const top = window.screen.height / 2 - height / 2
 
-		popupRef.current = window.open(
-			authorizeUrl,
-			"oauth_popup",
-			`width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`,
-		)
+		if (!popupWindow || popupWindow.closed) {
+			popupWindow = window.open(
+				authorizeUrl,
+				"oauth_popup",
+				`width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`,
+			)
+		} else {
+			popupWindow.location.href = authorizeUrl
+			popupWindow.focus()
+		}
+
+		if (!popupWindow) {
+			const message = "Popup blocked. Please allow popups and try again."
+			setStatus("failed")
+			setErrorMessage(message)
+			onError(message)
+			return
+		}
+
+		popupRef.current = popupWindow
 
 		setStatus("polling")
 
 		// Start polling OAuth status
 		startPolling()
-	}, [authorizeUrl, startPolling])
+	}, [authorizeUrl, onError, startPolling])
 
 	// Listen for postMessage from OAuth callback popup
 	useEffect(() => {

--- a/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
@@ -30,7 +30,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 }) => {
 	const [status, setStatus] = useState<"pending" | "polling" | "success" | "failed">("pending")
 	const [errorMessage, setErrorMessage] = useState<string | null>(null)
-	const popupRef = useRef<Window | null>(null)
+	const popupRef = useRef<Window | null>(initialPopup ?? null)
 	const pollIntervalRef = useRef<NodeJS.Timeout | null>(null)
 
 	// RTK Query hooks
@@ -127,10 +127,6 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 			await checkOAuthStatus()
 		}, 2000) // Poll every 2 seconds
 	}, [checkOAuthStatus, handleOAuthFailed])
-
-	useEffect(() => {
-		popupRef.current = initialPopup ?? null
-	}, [initialPopup])
 
 	// Open popup and start polling
 	const openPopup = useCallback(() => {


### PR DESCRIPTION
## Summary

Pre-open the OAuth popup during the create-button click so browsers treat it as a user-initiated window, then reuse that popup once the authorize URL is returned.

## Changes

- Open a blank OAuth popup shell directly from the submit handler for OAuth-based MCP clients
- Reuse and navigate that existing popup once the authorize URL is available
- Surface a clear error when the popup is blocked instead of pretending the flow is polling successfully
- Close the placeholder popup when the create request fails or completes without entering OAuth

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# UI
cd ui
pnpm exec next build
pnpm exec vitest run lib/message/variables.test.ts
```

Expected outcomes:
- OAuth popups are opened from the original user click instead of a later effect
- If the browser blocks popups, the user gets an explicit error instead of a stuck polling state
- Existing unrelated frontend issues still remain on main: missing PDF dependencies break `pnpm exec next build`, and the prompt variable test still fails

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

Not needed for this logic-only UI fix.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

None.

## Security considerations

This change improves the reliability of the OAuth popup flow but does not alter token handling or server-side authorization behavior.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable