### PR TITLE
fix(ui): detect variables in assistant messages

### DIFF
--- a/ui/lib/message/variables.ts
+++ b/ui/lib/message/variables.ts
@@ -21,12 +21,12 @@ export function extractVariablesFromText(text: string): string[] {
 
 /**
  * Extract all unique Jinja2 variable names from an array of Messages.
- * Scans content of every message (system, user, assistant, tool).
+ * Scans authored prompt messages, including assistant examples.
  */
 export function extractVariablesFromMessages(messages: Message[]): string[] {
   const vars = new Set<string>()
   for (const msg of messages) {
-    if(msg.role === MessageRole.ASSISTANT || msg.role === MessageRole.TOOL) continue;
+    if (msg.role === MessageRole.TOOL) continue
     const content = msg.content
     if (!content) continue
     for (const v of extractVariablesFromText(content)) {


### PR DESCRIPTION
## Summary

Detect Jinja-style variables in assistant prompt messages so the prompt editor, variable table, and execution path stay in sync.

## Changes

- Include assistant messages when extracting prompt variables
- Keep tool-result messages excluded for now
- Update the function comment to match the actual supported message types

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# UI
cd ui
pnpm exec vitest run lib/message/variables.test.ts
pnpm exec next build
```

Expected outcomes:
- `pnpm exec vitest run lib/message/variables.test.ts` passes, including the assistant-message coverage
- Assistant messages with `{{ variable }}` placeholders now populate the variables table in the prompt UI
- Existing unrelated frontend issues still remain on main: missing PDF dependencies break `pnpm exec next build`

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

Not needed for this logic-only UI fix.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

None.

## Security considerations

No security impact.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable