### PR TITLE
fix(ui): restore ESLint config loading

### DIFF
--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -1,5 +1,4 @@
 import { fixupConfigRules } from "@eslint/compat";
-import eslintPluginImport from "eslint-plugin-import";
 import { FlatCompat } from "@eslint/eslintrc";
 import js from "@eslint/js";
 import typescriptEslintEslintPlugin from "@typescript-eslint/eslint-plugin";
@@ -24,7 +23,6 @@ const eslintConfig = [
 			prettier: eslintPluginPrettier,
 			"@typescript-eslint": typescriptEslintEslintPlugin,
 			"unused-imports": eslintPluginUnusedImports,
-			import: eslintPluginImport,
 		},
 	},
 	{


### PR DESCRIPTION
## Summary

Remove the duplicate ESLint plugin registration so the frontend lint command can load the config and report real violations again.

## Changes

- Stop re-registering the `import` plugin in the flat ESLint config
- Let the Next.js ESLint presets provide the plugin definitions they already include
- Restore `next lint` from a config crash to normal lint execution

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# UI
cd ui
pnpm exec next lint
pnpm exec next build
```

Expected outcomes:
- `pnpm exec next lint` loads successfully and reports actual lint violations instead of failing with `Cannot redefine plugin \"import\"`
- `pnpm exec next build` still fails on the existing missing PDF dependencies in `lib/utils/pdf.ts`

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

Not needed for this tooling fix.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

None.

## Security considerations

No security impact.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable