### PR TITLE
fix(ui): label icon-only action buttons

### DIFF
--- a/ui/app/workspace/logs/views/emptyState.tsx
+++ b/ui/app/workspace/logs/views/emptyState.tsx
@@ -62,7 +62,7 @@ function CodeBlock({ code, language, onLanguageChange, showLanguageSelect = fals
 						</SelectContent>
 					</Select>
 				)}
-				<Button variant="ghost" size="icon" onClick={() => copyToClipboard(code)}>
+				<Button variant="ghost" size="icon" onClick={() => copyToClipboard(code)} aria-label="Copy to clipboard">
 					<Copy className="size-4" />
 				</Button>
 			</div>

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -269,7 +269,7 @@ export default function MCPClientsTable({ mcpClients, totalCount, refetch, searc
 
 										<AlertDialog>
 											<AlertDialogTrigger asChild>
-												<Button variant="ghost" size="icon" className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30" disabled={!hasDeleteMCPClientAccess}>
+												<Button variant="ghost" size="icon" className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30" disabled={!hasDeleteMCPClientAccess} aria-label={`Delete MCP server ${c.config.name}`}>
 													<Trash2 className="h-4 w-4" />
 												</Button>
 											</AlertDialogTrigger>

--- a/ui/components/ui/headersTable.tsx
+++ b/ui/components/ui/headersTable.tsx
@@ -262,7 +262,7 @@ export function HeadersTable<T extends HeaderValue>({
 									</TableCell>
 									<TableCell className="p-2">
 										{!disabled && (
-											<Button type="button" variant="ghost" size="icon" onClick={() => handleDelete(key, index)} className="h-8 w-8">
+											<Button type="button" variant="ghost" size="icon" onClick={() => handleDelete(key, index)} className="h-8 w-8" aria-label="Delete header">
 												<Trash className="h-4 w-4" />
 											</Button>
 										)}

--- a/ui/components/ui/headersTable.tsx
+++ b/ui/components/ui/headersTable.tsx
@@ -262,7 +262,7 @@ export function HeadersTable<T extends HeaderValue>({
 									</TableCell>
 									<TableCell className="p-2">
 										{!disabled && (
-											<Button type="button" variant="ghost" size="icon" onClick={() => handleDelete(key, index)} className="h-8 w-8" aria-label="Delete header">
+											<Button type="button" variant="ghost" size="icon" onClick={() => handleDelete(key, index)} className="h-8 w-8" aria-label={`Delete header ${key}`}>
 												<Trash className="h-4 w-4" />
 											</Button>
 										)}


### PR DESCRIPTION
## Summary

Add accessible names to validated icon-only action buttons so screen readers can identify the copy and delete controls.

## Changes

- Add `aria-label` to the log empty-state copy button
- Add `aria-label` to the headers table delete button
- Add `aria-label` to the MCP client delete button, including the server name for context

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# UI
cd ui
pnpm exec next build
```

Expected outcomes:
- The edited icon-only buttons now expose accessible names in the DOM
- Screen readers can identify the copy and delete controls without relying on icon glyphs alone
- Existing unrelated frontend issues still remain on main: missing PDF dependencies break `pnpm exec next build`

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

Not needed for these accessibility-only label updates.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

None.

## Security considerations

No security impact.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable