### PR TITLE
fix: populate model and created fields in final streaming chunk response

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2149,6 +2149,7 @@ func CreateBifrostTextCompletionChunkResponse(
 ) *schemas.BifrostTextCompletionResponse {
 	response := &schemas.BifrostTextCompletionResponse{
 		ID:     id,
+		Model:  model,
 		Object: "text_completion",
 		Usage:  usage,
 		Choices: []schemas.BifrostResponseChoice{

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2178,9 +2178,11 @@ func CreateBifrostChatCompletionChunkResponse(
 	model string,
 ) *schemas.BifrostChatResponse {
 	response := &schemas.BifrostChatResponse{
-		ID:     id,
-		Object: "chat.completion.chunk",
-		Usage:  usage,
+		ID:      id,
+		Model:   model,
+		Created: int(time.Now().Unix()),
+		Object:  "chat.completion.chunk",
+		Usage:   usage,
 		Choices: []schemas.BifrostResponseChoice{
 			{
 				FinishReason: finishReason,


### PR DESCRIPTION
## Summary

This PR fixes a bug where the final streaming chunk response was missing the `model` and `created` fields in `CreateBifrostChatCompletionChunkResponse()`.

## Problem

In `core/providers/utils/utils.go`, the function `CreateBifrostChatCompletionChunkResponse()` constructs a `BifrostChatResponse` struct but did not populate the `Model` or `Created` fields. This causes downstream consumers that rely on these standard OpenAI-compatible fields to fail or receive incomplete data.

The function already accepts a `model string` parameter — it was simply not being used to populate the `Model` field on the response.

## Fix

- Added `Model: model` to populate the model field from the existing function parameter
- Added `Created: int(time.Now().Unix())` to populate the creation timestamp (`time` package is already imported)

## Related Issue

Closes #2613

---

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>