### PR TITLE
Fix: removed unused dependencies

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,6 @@
 			"dependencies": {
 				"@bprogress/core": "1.3.4",
 				"@dagrejs/dagre": "3.0.0",
-				"@dnd-kit/helpers": "0.3.2",
 				"@dnd-kit/react": "0.3.2",
 				"@hookform/resolvers": "5.2.1",
 				"@monaco-editor/react": "4.7.0",
@@ -53,7 +52,6 @@
 				"monaco-editor": "0.52.2",
 				"next-themes": "0.4.6",
 				"nuqs": "2.8.8",
-				"radix-ui": "1.4.3",
 				"react": "19.2.3",
 				"react-cookie": "8.0.1",
 				"react-day-picker": "9.11.1",
@@ -68,8 +66,7 @@
 				"streamdown": "2.3.0",
 				"tailwind-merge": "3.3.1",
 				"uuid": "12.0.0",
-				"zod": "4.2.1",
-				"zustand": "5.0.8"
+				"zod": "4.2.1"
 			},
 			"devDependencies": {
 				"@eslint/compat": "1.3.2",
@@ -433,14 +430,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@dnd-kit/state": "^0.3.2",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@dnd-kit/helpers": {
-			"version": "0.3.2",
-			"license": "MIT",
-			"dependencies": {
-				"@dnd-kit/abstract": "^0.3.2",
 				"tslib": "^2.6.2"
 			}
 		},
@@ -952,27 +941,6 @@
 			"version": "1.1.3",
 			"license": "MIT"
 		},
-		"node_modules/@radix-ui/react-accessible-icon": {
-			"version": "1.1.7",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/react-visually-hidden": "1.2.3"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@radix-ui/react-accordion": {
 			"version": "1.2.12",
 			"license": "MIT",
@@ -1201,32 +1169,6 @@
 				}
 			}
 		},
-		"node_modules/@radix-ui/react-context-menu": {
-			"version": "2.2.16",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-menu": "2.1.16",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-callback-ref": "1.1.1",
-				"@radix-ui/react-use-controllable-state": "1.2.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@radix-ui/react-dialog": {
 			"version": "1.1.15",
 			"license": "MIT",
@@ -1362,32 +1304,6 @@
 				}
 			}
 		},
-		"node_modules/@radix-ui/react-form": {
-			"version": "0.1.8",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-id": "1.1.1",
-				"@radix-ui/react-label": "2.1.7",
-				"@radix-ui/react-primitive": "2.1.3"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@radix-ui/react-hover-card": {
 			"version": "1.1.15",
 			"license": "MIT",
@@ -1476,130 +1392,6 @@
 				"@radix-ui/react-use-callback-ref": "1.1.1",
 				"aria-hidden": "^1.2.4",
 				"react-remove-scroll": "^2.6.3"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-menubar": {
-			"version": "1.1.16",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-collection": "1.1.7",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-direction": "1.1.1",
-				"@radix-ui/react-id": "1.1.1",
-				"@radix-ui/react-menu": "2.1.16",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-roving-focus": "1.1.11",
-				"@radix-ui/react-use-controllable-state": "1.2.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-navigation-menu": {
-			"version": "1.2.14",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-collection": "1.1.7",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-direction": "1.1.1",
-				"@radix-ui/react-dismissable-layer": "1.1.11",
-				"@radix-ui/react-id": "1.1.1",
-				"@radix-ui/react-presence": "1.1.5",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-callback-ref": "1.1.1",
-				"@radix-ui/react-use-controllable-state": "1.2.2",
-				"@radix-ui/react-use-layout-effect": "1.1.1",
-				"@radix-ui/react-use-previous": "1.1.1",
-				"@radix-ui/react-visually-hidden": "1.2.3"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-one-time-password-field": {
-			"version": "0.1.8",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/number": "1.1.1",
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-collection": "1.1.7",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-direction": "1.1.1",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-roving-focus": "1.1.11",
-				"@radix-ui/react-use-controllable-state": "1.2.2",
-				"@radix-ui/react-use-effect-event": "0.0.2",
-				"@radix-ui/react-use-is-hydrated": "0.1.0",
-				"@radix-ui/react-use-layout-effect": "1.1.1"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-password-toggle-field": {
-			"version": "0.1.3",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-id": "1.1.1",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-controllable-state": "1.2.2",
-				"@radix-ui/react-use-effect-event": "0.0.2",
-				"@radix-ui/react-use-is-hydrated": "0.1.0"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -1752,36 +1544,6 @@
 			"dependencies": {
 				"@radix-ui/react-context": "1.1.2",
 				"@radix-ui/react-primitive": "2.1.3"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-radio-group": {
-			"version": "1.3.8",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-direction": "1.1.1",
-				"@radix-ui/react-presence": "1.1.5",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-roving-focus": "1.1.11",
-				"@radix-ui/react-use-controllable-state": "1.2.2",
-				"@radix-ui/react-use-previous": "1.1.1",
-				"@radix-ui/react-use-size": "1.1.1"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -2004,115 +1766,6 @@
 				"@radix-ui/react-primitive": "2.1.3",
 				"@radix-ui/react-roving-focus": "1.1.11",
 				"@radix-ui/react-use-controllable-state": "1.2.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-toast": {
-			"version": "1.2.15",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-collection": "1.1.7",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-dismissable-layer": "1.1.11",
-				"@radix-ui/react-portal": "1.1.9",
-				"@radix-ui/react-presence": "1.1.5",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-callback-ref": "1.1.1",
-				"@radix-ui/react-use-controllable-state": "1.2.2",
-				"@radix-ui/react-use-layout-effect": "1.1.1",
-				"@radix-ui/react-visually-hidden": "1.2.3"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-toggle": {
-			"version": "1.1.10",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-use-controllable-state": "1.2.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-toggle-group": {
-			"version": "1.1.11",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-direction": "1.1.1",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-roving-focus": "1.1.11",
-				"@radix-ui/react-toggle": "1.1.10",
-				"@radix-ui/react-use-controllable-state": "1.2.2"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@radix-ui/react-toolbar": {
-			"version": "1.1.11",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-direction": "1.1.1",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-roving-focus": "1.1.11",
-				"@radix-ui/react-separator": "1.1.7",
-				"@radix-ui/react-toggle-group": "1.1.11"
 			},
 			"peerDependencies": {
 				"@types/react": "*",
@@ -8128,81 +7781,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/radix-ui": {
-			"version": "1.4.3",
-			"license": "MIT",
-			"dependencies": {
-				"@radix-ui/primitive": "1.1.3",
-				"@radix-ui/react-accessible-icon": "1.1.7",
-				"@radix-ui/react-accordion": "1.2.12",
-				"@radix-ui/react-alert-dialog": "1.1.15",
-				"@radix-ui/react-arrow": "1.1.7",
-				"@radix-ui/react-aspect-ratio": "1.1.7",
-				"@radix-ui/react-avatar": "1.1.10",
-				"@radix-ui/react-checkbox": "1.3.3",
-				"@radix-ui/react-collapsible": "1.1.12",
-				"@radix-ui/react-collection": "1.1.7",
-				"@radix-ui/react-compose-refs": "1.1.2",
-				"@radix-ui/react-context": "1.1.2",
-				"@radix-ui/react-context-menu": "2.2.16",
-				"@radix-ui/react-dialog": "1.1.15",
-				"@radix-ui/react-direction": "1.1.1",
-				"@radix-ui/react-dismissable-layer": "1.1.11",
-				"@radix-ui/react-dropdown-menu": "2.1.16",
-				"@radix-ui/react-focus-guards": "1.1.3",
-				"@radix-ui/react-focus-scope": "1.1.7",
-				"@radix-ui/react-form": "0.1.8",
-				"@radix-ui/react-hover-card": "1.1.15",
-				"@radix-ui/react-label": "2.1.7",
-				"@radix-ui/react-menu": "2.1.16",
-				"@radix-ui/react-menubar": "1.1.16",
-				"@radix-ui/react-navigation-menu": "1.2.14",
-				"@radix-ui/react-one-time-password-field": "0.1.8",
-				"@radix-ui/react-password-toggle-field": "0.1.3",
-				"@radix-ui/react-popover": "1.1.15",
-				"@radix-ui/react-popper": "1.2.8",
-				"@radix-ui/react-portal": "1.1.9",
-				"@radix-ui/react-presence": "1.1.5",
-				"@radix-ui/react-primitive": "2.1.3",
-				"@radix-ui/react-progress": "1.1.7",
-				"@radix-ui/react-radio-group": "1.3.8",
-				"@radix-ui/react-roving-focus": "1.1.11",
-				"@radix-ui/react-scroll-area": "1.2.10",
-				"@radix-ui/react-select": "2.2.6",
-				"@radix-ui/react-separator": "1.1.7",
-				"@radix-ui/react-slider": "1.3.6",
-				"@radix-ui/react-slot": "1.2.3",
-				"@radix-ui/react-switch": "1.2.6",
-				"@radix-ui/react-tabs": "1.1.13",
-				"@radix-ui/react-toast": "1.2.15",
-				"@radix-ui/react-toggle": "1.1.10",
-				"@radix-ui/react-toggle-group": "1.1.11",
-				"@radix-ui/react-toolbar": "1.1.11",
-				"@radix-ui/react-tooltip": "1.2.8",
-				"@radix-ui/react-use-callback-ref": "1.1.1",
-				"@radix-ui/react-use-controllable-state": "1.2.2",
-				"@radix-ui/react-use-effect-event": "0.0.2",
-				"@radix-ui/react-use-escape-keydown": "1.1.1",
-				"@radix-ui/react-use-is-hydrated": "0.1.0",
-				"@radix-ui/react-use-layout-effect": "1.1.1",
-				"@radix-ui/react-use-size": "1.1.1",
-				"@radix-ui/react-visually-hidden": "1.2.3"
-			},
-			"peerDependencies": {
-				"@types/react": "*",
-				"@types/react-dom": "*",
-				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"@types/react-dom": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/react": {
 			"version": "19.2.3",
 			"license": "MIT",
@@ -10590,33 +10168,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zustand": {
-			"version": "5.0.8",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12.20.0"
-			},
-			"peerDependencies": {
-				"@types/react": ">=18.0.0",
-				"immer": ">=9.0.6",
-				"react": ">=18.0.0",
-				"use-sync-external-store": ">=1.2.0"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				},
-				"immer": {
-					"optional": true
-				},
-				"react": {
-					"optional": true
-				},
-				"use-sync-external-store": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/zwitch": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,7 +15,6 @@
 	"dependencies": {
 		"@bprogress/core": "1.3.4",
 		"@dagrejs/dagre": "3.0.0",
-		"@dnd-kit/helpers": "0.3.2",
 		"@dnd-kit/react": "0.3.2",
 		"@hookform/resolvers": "5.2.1",
 		"@monaco-editor/react": "4.7.0",
@@ -58,7 +57,6 @@
 		"monaco-editor": "0.52.2",
 		"next-themes": "0.4.6",
 		"nuqs": "2.8.8",
-		"radix-ui": "1.4.3",
 		"react": "19.2.3",
 		"react-cookie": "8.0.1",
 		"react-day-picker": "9.11.1",
@@ -71,10 +69,11 @@
 		"recharts": "3.1.2",
 		"sonner": "2.0.7",
 		"streamdown": "2.3.0",
+		"react-textarea-autosize": "8.5.9",
 		"tailwind-merge": "3.3.1",
+		"tw-animate-css": "1.3.7",
 		"uuid": "12.0.0",
-		"zod": "4.2.1",
-		"zustand": "5.0.8"
+		"zod": "4.2.1"
 	},
 	"devDependencies": {
 		"@eslint/compat": "1.3.2",
@@ -98,9 +97,7 @@
 		"eslint-plugin-unused-imports": "4.2.0",
 		"prettier": "3.6.2",
 		"prettier-plugin-tailwindcss": "0.6.14",
-		"react-textarea-autosize": "8.5.9",
 		"tailwindcss": "4.1.12",
-		"tw-animate-css": "1.3.7",
 		"typescript": "5.9.2",
 		"vite": "8.0.7",
 		"vite-plugin-checker": "0.12.0",


### PR DESCRIPTION
## Summary

Remove unused dependencies from the UI package to reduce bundle size and eliminate unnecessary code. This cleanup removes several packages that are no longer being used in the codebase.  
  
@coderabbitai ignore

## Changes

- Removed `@dnd-kit/helpers` package which was unused
- Removed `radix-ui` meta-package and its associated unused components including:
    - `@radix-ui/react-accessible-icon`
    - `@radix-ui/react-context-menu`
    - `@radix-ui/react-form`
    - `@radix-ui/react-menubar`
    - `@radix-ui/react-navigation-menu`
    - `@radix-ui/react-one-time-password-field`
    - `@radix-ui/react-password-toggle-field`
    - `@radix-ui/react-radio-group`
    - `@radix-ui/react-toast`
    - `@radix-ui/react-toggle`
    - `@radix-ui/react-toggle-group`
    - `@radix-ui/react-toolbar`
- Removed `zustand` state management library
- Moved `react-textarea-autosize` and `tw-animate-css` from devDependencies to dependencies as they appear to be used in production code

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify that the application builds and runs correctly without the removed dependencies:

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
pnpm dev || npm run dev
```

Ensure all existing functionality works as expected and no import errors occur.

## Screenshots/Recordings

N/A - No visual changes expected

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Removing unused dependencies reduces the attack surface by eliminating potential vulnerabilities in unused code.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable