### PR TITLE
[feat] Add PDB to Helm Chart

### DIFF
--- a/helm-charts/bifrost/templates/NOTES.txt
+++ b/helm-charts/bifrost/templates/NOTES.txt
@@ -53,6 +53,9 @@ Configuration:
 {{- else }}
 - Replicas: {{ .Values.replicaCount }}
 {{- end }}
+{{- if .Values.podDisruptionBudget.enabled }}
+- PodDisruptionBudget: Enabled ({{ if .Values.podDisruptionBudget.minAvailable }}minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}{{ end }}{{ if .Values.podDisruptionBudget.maxUnavailable }}maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}{{ end }})
+{{- end }}
 
 Metrics: http://{{ include "bifrost.fullname" . }}:{{ .Values.service.port }}/metrics
 

--- a/helm-charts/bifrost/templates/NOTES.txt
+++ b/helm-charts/bifrost/templates/NOTES.txt
@@ -54,7 +54,7 @@ Configuration:
 - Replicas: {{ .Values.replicaCount }}
 {{- end }}
 {{- if .Values.podDisruptionBudget.enabled }}
-- PodDisruptionBudget: Enabled ({{ if .Values.podDisruptionBudget.minAvailable }}minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}{{ end }}{{ if .Values.podDisruptionBudget.maxUnavailable }}maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}{{ end }})
+- PodDisruptionBudget: Enabled ({{ if hasKey .Values.podDisruptionBudget "maxUnavailable" }}maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}{{ else if hasKey .Values.podDisruptionBudget "minAvailable" }}minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}{{ else }}minAvailable: 1{{ end }})
 {{- end }}
 
 Metrics: http://{{ include "bifrost.fullname" . }}:{{ .Values.service.port }}/metrics

--- a/helm-charts/bifrost/templates/pdb.yaml
+++ b/helm-charts/bifrost/templates/pdb.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-{{- $useStatefulSet := and (eq .Values.storage.mode "sqlite") .Values.storage.persistence.enabled (not .Values.storage.persistence.existingClaim) }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -8,11 +7,12 @@ metadata:
   labels:
     {{- include "bifrost.labels" . | nindent 4 }}
 spec:
-  {{- if .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
-  {{- end }}
-  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else if hasKey .Values.podDisruptionBudget "minAvailable" }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  minAvailable: 1
   {{- end }}
   {{- if .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
   unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}

--- a/helm-charts/bifrost/templates/pdb.yaml
+++ b/helm-charts/bifrost/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- $useStatefulSet := and (eq .Values.storage.mode "sqlite") .Values.storage.persistence.enabled (not .Values.storage.persistence.existingClaim) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "bifrost.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "bifrost.serverSelectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm-charts/bifrost/values-examples/production-ha.yaml
+++ b/helm-charts/bifrost/values-examples/production-ha.yaml
@@ -5,6 +5,11 @@
 # Multiple replicas for HA
 replicaCount: 3
 
+# Pod disruption budget for HA during node drains and cluster upgrades
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+
 # Auto-scaling configuration
 autoscaling:
   enabled: true

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -163,6 +163,35 @@
     "readinessProbe": {
       "type": "object"
     },
+    "podDisruptionBudget": {
+      "type": "object",
+      "description": "PodDisruptionBudget configuration for high availability",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable PodDisruptionBudget"
+        },
+        "minAvailable": {
+          "description": "Minimum number/percentage of pods that must remain available",
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]+%$" }
+          ]
+        },
+        "maxUnavailable": {
+          "description": "Maximum number/percentage of pods that can be unavailable",
+          "oneOf": [
+            { "type": "integer", "minimum": 0 },
+            { "type": "string", "pattern": "^[0-9]+%$" }
+          ]
+        },
+        "unhealthyPodEvictionPolicy": {
+          "type": "string",
+          "enum": ["IfHealthy", "AlwaysAllow"],
+          "description": "Policy for evicting unhealthy pods (Kubernetes 1.27+)"
+        }
+      }
+    },
     "autoscaling": {
       "type": "object",
       "properties": {

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -187,9 +187,12 @@
         },
         "unhealthyPodEvictionPolicy": {
           "type": "string",
-          "enum": ["IfHealthy", "AlwaysAllow"],
+          "enum": ["IfHealthyBudget", "AlwaysAllow"],
           "description": "Policy for evicting unhealthy pods (Kubernetes 1.27+)"
         }
+      },
+      "not": {
+        "required": ["minAvailable", "maxUnavailable"]
       }
     },
     "autoscaling": {

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -191,8 +191,34 @@
           "description": "Policy for evicting unhealthy pods (Kubernetes 1.27+)"
         }
       },
-      "not": {
-        "required": ["minAvailable", "maxUnavailable"]
+      "if": {
+        "properties": { "enabled": { "const": true } },
+        "required": ["enabled"]
+      },
+      "then": {
+        "oneOf": [
+          {
+            "required": ["minAvailable"],
+            "not": { "required": ["maxUnavailable"] }
+          },
+          {
+            "required": ["maxUnavailable"],
+            "not": { "required": ["minAvailable"] }
+          },
+          {
+            "not": {
+              "anyOf": [
+                { "required": ["minAvailable"] },
+                { "required": ["maxUnavailable"] }
+              ]
+            }
+          }
+        ]
+      },
+      "else": {
+        "not": {
+          "required": ["minAvailable", "maxUnavailable"]
+        }
       }
     },
     "autoscaling": {

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -108,17 +108,15 @@ podDisruptionBudget:
   # Ensures a minimum number of pods remain available during voluntary disruptions
   # (e.g., node drains, cluster upgrades, spot instance evictions)
   enabled: false
-  # Minimum number of pods that must remain available during disruption
-  # Can be an integer (e.g., 1) or a percentage string (e.g., "50%")
-  # Only one of minAvailable or maxUnavailable can be set
-  minAvailable: 1
-  # Maximum number of pods that can be unavailable during disruption
-  # Can be an integer (e.g., 1) or a percentage string (e.g., "25%")
+  # Set exactly one of minAvailable or maxUnavailable (not both).
+  # Can be an integer (e.g., 1) or a percentage string (e.g., "50%").
+  # If neither is set, defaults to minAvailable: 1.
+  # minAvailable: 1
   # maxUnavailable: 1
   # Unhealthy pod eviction policy (requires Kubernetes 1.27+)
-  # Options: IfHealthy (default), AlwaysAllow
+  # Options: IfHealthyBudget (default), AlwaysAllow
   # AlwaysAllow allows eviction of unhealthy pods even if it violates the budget
-  # unhealthyPodEvictionPolicy: IfHealthy
+  # unhealthyPodEvictionPolicy: IfHealthyBudget
 
 autoscaling:
   enabled: false

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -103,6 +103,23 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 3
 
+podDisruptionBudget:
+  # Enable PodDisruptionBudget for high availability
+  # Ensures a minimum number of pods remain available during voluntary disruptions
+  # (e.g., node drains, cluster upgrades, spot instance evictions)
+  enabled: false
+  # Minimum number of pods that must remain available during disruption
+  # Can be an integer (e.g., 1) or a percentage string (e.g., "50%")
+  # Only one of minAvailable or maxUnavailable can be set
+  minAvailable: 1
+  # Maximum number of pods that can be unavailable during disruption
+  # Can be an integer (e.g., 1) or a percentage string (e.g., "25%")
+  # maxUnavailable: 1
+  # Unhealthy pod eviction policy (requires Kubernetes 1.27+)
+  # Options: IfHealthy (default), AlwaysAllow
+  # AlwaysAllow allows eviction of unhealthy pods even if it violates the budget
+  # unhealthyPodEvictionPolicy: IfHealthy
+
 autoscaling:
   enabled: false
   minReplicas: 1


### PR DESCRIPTION
## Summary
Allow users to set a PDB via the helm chart, this allows people to ensure their bifrost deployment stays HA and is more durable to changes made to kubernetes clusters.

## Changes

Added to the helm chart.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


