### PR TITLE
fix(helm): auto-default k8s discovery label selector to exclude non-gateway pods

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -441,11 +441,24 @@ false
 {{- if .Values.bifrost.cluster.discovery.allowedAddressSpace }}
 {{- $_ := set $discovery "allowed_address_space" .Values.bifrost.cluster.discovery.allowedAddressSpace }}
 {{- end }}
+{{- if eq .Values.bifrost.cluster.discovery.type "kubernetes" }}
+{{- if .Values.bifrost.cluster.discovery.k8sNamespace }}
+{{- $_ := set $discovery "k8s_namespace" .Values.bifrost.cluster.discovery.k8sNamespace }}
+{{- else }}
+{{- $_ := set $discovery "k8s_namespace" .Release.Namespace }}
+{{- end }}
+{{- if .Values.bifrost.cluster.discovery.k8sLabelSelector }}
+{{- $_ := set $discovery "k8s_label_selector" .Values.bifrost.cluster.discovery.k8sLabelSelector }}
+{{- else }}
+{{- $_ := set $discovery "k8s_label_selector" (printf "app.kubernetes.io/name=%s,app.kubernetes.io/instance=%s,app.kubernetes.io/component=server" (include "bifrost.name" .) .Release.Name) }}
+{{- end }}
+{{- else }}
 {{- if .Values.bifrost.cluster.discovery.k8sNamespace }}
 {{- $_ := set $discovery "k8s_namespace" .Values.bifrost.cluster.discovery.k8sNamespace }}
 {{- end }}
 {{- if .Values.bifrost.cluster.discovery.k8sLabelSelector }}
 {{- $_ := set $discovery "k8s_label_selector" .Values.bifrost.cluster.discovery.k8sLabelSelector }}
+{{- end }}
 {{- end }}
 {{- if .Values.bifrost.cluster.discovery.dnsNames }}
 {{- $_ := set $discovery "dns_names" .Values.bifrost.cluster.discovery.dnsNames }}

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -522,7 +522,10 @@ bifrost:
       type: ""
       allowedAddressSpace: []
       # Kubernetes discovery
+      # Defaults to the release namespace if empty
       k8sNamespace: ""
+      # Defaults to "app.kubernetes.io/name=bifrost,app.kubernetes.io/instance=<release>,app.kubernetes.io/component=server"
+      # which ensures only bifrost gateway pods are discovered (not PostgreSQL, Redis, etc.)
       k8sLabelSelector: ""
       # DNS discovery
       dnsNames: []


### PR DESCRIPTION
## Summary

auto-default k8s discovery label selector to exclude non-gateway pods

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


