### PR TITLE
refactor: add response backfill methods

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5178,12 +5178,14 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 		if bifrostError != nil {
 			return nil, bifrostError
 		}
+		chatCompletionResponse.BackfillParams(req.BifrostRequest.ChatRequest)
 		response.ChatResponse = chatCompletionResponse
 	case schemas.ResponsesRequest:
 		responsesResponse, bifrostError := provider.Responses(req.Context, key, req.BifrostRequest.ResponsesRequest)
 		if bifrostError != nil {
 			return nil, bifrostError
 		}
+		responsesResponse.BackfillParams(req.BifrostRequest.ResponsesRequest)
 		response.ResponsesResponse = responsesResponse
 	case schemas.CountTokensRequest:
 		countTokensResponse, bifrostError := provider.CountTokens(req.Context, key, req.BifrostRequest.CountTokensRequest)
@@ -5204,18 +5206,6 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 		}
 		response.RerankResponse = rerankResponse
 	case schemas.OCRRequest:
-		var customProviderConfig *schemas.CustomProviderConfig
-		if config != nil {
-			customProviderConfig = config.CustomProviderConfig
-		}
-		if bifrostError := providerUtils.CheckOperationAllowed(provider.GetProviderKey(), customProviderConfig, schemas.OCRRequest); bifrostError != nil {
-			bifrostError.ExtraFields.Provider = provider.GetProviderKey()
-			bifrostError.ExtraFields.RequestType = schemas.OCRRequest
-			if req.BifrostRequest.OCRRequest != nil {
-				bifrostError.ExtraFields.ModelRequested = req.BifrostRequest.OCRRequest.Model
-			}
-			return nil, bifrostError
-		}
 		ocrResponse, bifrostError := provider.OCR(req.Context, key, req.BifrostRequest.OCRRequest)
 		if bifrostError != nil {
 			return nil, bifrostError

--- a/core/internal/llmtests/response_validation.go
+++ b/core/internal/llmtests/response_validation.go
@@ -446,6 +446,12 @@ func ValidateCountTokensResponse(t *testing.T, response *schemas.BifrostCountTok
 
 // validateChatBasicStructure checks the basic structure of the chat response
 func validateChatBasicStructure(t *testing.T, response *schemas.BifrostChatResponse, expectations ResponseExpectations, result *ValidationResult) {
+	// Check that Object field is not empty (should be "chat.completion" or "chat.completion.chunk")
+	if response.Object == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Object field is empty in chat completion response")
+	}
+
 	// Check choice count
 	if expectations.ExpectedChoiceCount > 0 {
 		actualCount := 0
@@ -831,6 +837,12 @@ func collectTextCompletionResponseMetrics(response *schemas.BifrostTextCompletio
 
 // validateResponsesBasicStructure checks the basic structure of the Responses API response
 func validateResponsesBasicStructure(response *schemas.BifrostResponsesResponse, expectations ResponseExpectations, result *ValidationResult) {
+	// Check that Object field is not empty (should be "response")
+	if response.Object == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "Object field is empty in responses response")
+	}
+
 	// Check choice count
 	if expectations.ExpectedChoiceCount > 0 {
 		actualCount := 0

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -70,27 +70,7 @@ func NewMistralProvider(config *schemas.ProviderConfig, logger schemas.Logger) *
 
 // GetProviderKey returns the provider identifier for Mistral.
 func (provider *MistralProvider) GetProviderKey() schemas.ModelProvider {
-	return provider.reportedProviderKey()
-}
-
-func (provider *MistralProvider) baseProviderKey() schemas.ModelProvider {
 	return schemas.Mistral
-}
-
-func (provider *MistralProvider) reportedProviderKey() schemas.ModelProvider {
-	return providerUtils.GetProviderName(provider.baseProviderKey(), provider.customProviderConfig)
-}
-
-// Shared OpenAI-compatible converters key Mistral compatibility off the base provider,
-// while Bifrost still needs the custom alias for provider identity and reporting.
-func (provider *MistralProvider) normalizeChatRequestProvider(request *schemas.BifrostChatRequest) *schemas.BifrostChatRequest {
-	if request == nil {
-		return nil
-	}
-
-	normalizedRequest := *request
-	normalizedRequest.Provider = provider.baseProviderKey()
-	return &normalizedRequest
 }
 
 // listModelsByKey performs a list models request for a single key.
@@ -180,8 +160,6 @@ func (provider *MistralProvider) TextCompletionStream(ctx *schemas.BifrostContex
 
 // ChatCompletion performs a chat completion request to the Mistral API.
 func (provider *MistralProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-	request = provider.normalizeChatRequestProvider(request)
-
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
@@ -203,8 +181,6 @@ func (provider *MistralProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 // Uses Mistral's OpenAI-compatible streaming format.
 // Returns a channel containing BifrostStreamChunk objects representing the stream or an error if the request fails.
 func (provider *MistralProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	request = provider.normalizeChatRequestProvider(request)
-
 	var authHeader map[string]string
 	if key.Value.GetValue() != "" {
 		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -3,6 +3,7 @@ package schemas
 import (
 	"bytes"
 	"fmt"
+	"time"
 )
 
 // BifrostChatRequest is the request struct for chat completion requests
@@ -29,21 +30,37 @@ func (cr *BifrostChatRequest) GetExtraParams() map[string]interface{} {
 
 // BifrostChatResponse represents the complete result from a chat completion request.
 type BifrostChatResponse struct {
-	ID                      string                     `json:"id"`
-	Choices                 []BifrostResponseChoice    `json:"choices"`
-	Created                 int                        `json:"created"` // The Unix timestamp (in seconds).
-	Model                   string                     `json:"model"`
-	Object                  string                     `json:"object"` // "chat.completion" or "chat.completion.chunk"
-	ServiceTier             *string                    `json:"service_tier,omitempty"`
-	SystemFingerprint       string                     `json:"system_fingerprint"`
-	Usage                   *BifrostLLMUsage           `json:"usage"`
-	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
-	ExtraParams             map[string]interface{}     `json:"-"`
+	ID                string                     `json:"id"`
+	Choices           []BifrostResponseChoice    `json:"choices"`
+	Created           int                        `json:"created"` // The Unix timestamp (in seconds).
+	Model             string                     `json:"model"`
+	Object            string                     `json:"object"` // "chat.completion" or "chat.completion.chunk"
+	ServiceTier       *string                    `json:"service_tier,omitempty"`
+	SystemFingerprint string                     `json:"system_fingerprint"`
+	Usage             *BifrostLLMUsage           `json:"usage"`
+	ExtraFields       BifrostResponseExtraFields `json:"extra_fields"`
+	ExtraParams       map[string]interface{}     `json:"-"`
 
 	// Perplexity-specific fields
 	SearchResults []SearchResult `json:"search_results,omitempty"`
 	Videos        []VideoResult  `json:"videos,omitempty"`
 	Citations     []string       `json:"citations,omitempty"`
+}
+
+// BackfillParams populates response fields from the request that are needed
+func (cr *BifrostChatResponse) BackfillParams(request *BifrostChatRequest) {
+	if cr == nil || request == nil {
+		return
+	}
+	if cr.Model == "" {
+		cr.Model = request.Model
+	}
+	if cr.Object == "" {
+		cr.Object = "chat.completion"
+	}
+	if cr.Created == 0 {
+		cr.Created = int(time.Now().Unix())
+	}
 }
 
 // ToTextCompletionResponse converts a BifrostChatResponse to a BifrostTextCompletionResponse
@@ -63,7 +80,7 @@ func (cr *BifrostChatResponse) ToTextCompletionResponse() *BifrostTextCompletion
 				RequestType:             TextCompletionRequest,
 				ChunkIndex:              cr.ExtraFields.ChunkIndex,
 				Provider:                cr.ExtraFields.Provider,
-				ModelRequested:           cr.ExtraFields.ModelRequested,
+				ModelRequested:          cr.ExtraFields.ModelRequested,
 				Latency:                 cr.ExtraFields.Latency,
 				RawResponse:             cr.ExtraFields.RawResponse,
 				CacheDebug:              cr.ExtraFields.CacheDebug,
@@ -96,7 +113,7 @@ func (cr *BifrostChatResponse) ToTextCompletionResponse() *BifrostTextCompletion
 				RequestType:             TextCompletionRequest,
 				ChunkIndex:              cr.ExtraFields.ChunkIndex,
 				Provider:                cr.ExtraFields.Provider,
-				ModelRequested:           cr.ExtraFields.ModelRequested,
+				ModelRequested:          cr.ExtraFields.ModelRequested,
 				Latency:                 cr.ExtraFields.Latency,
 				RawResponse:             cr.ExtraFields.RawResponse,
 				CacheDebug:              cr.ExtraFields.CacheDebug,
@@ -132,7 +149,7 @@ func (cr *BifrostChatResponse) ToTextCompletionResponse() *BifrostTextCompletion
 				RequestType:             TextCompletionRequest,
 				ChunkIndex:              cr.ExtraFields.ChunkIndex,
 				Provider:                cr.ExtraFields.Provider,
-				ModelRequested:           cr.ExtraFields.ModelRequested,
+				ModelRequested:          cr.ExtraFields.ModelRequested,
 				Latency:                 cr.ExtraFields.Latency,
 				RawResponse:             cr.ExtraFields.RawResponse,
 				CacheDebug:              cr.ExtraFields.CacheDebug,

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -92,6 +92,22 @@ type BifrostResponsesResponse struct {
 	Citations     []string       `json:"citations,omitempty"`
 }
 
+// BackfillParams populates response fields from the request that are needed
+func (resp *BifrostResponsesResponse) BackfillParams(request *BifrostResponsesRequest) {
+	if resp == nil || request == nil {
+		return
+	}
+	if resp.Model == "" {
+		resp.Model = request.Model
+	}
+	if resp.Object == "" {
+		resp.Object = "response"
+	}
+	if resp.CreatedAt == 0 {
+		resp.CreatedAt = int(time.Now().Unix())
+	}
+}
+
 func (resp *BifrostResponsesResponse) WithDefaults() *BifrostResponsesResponse {
 	if resp == nil {
 		return nil
@@ -2080,9 +2096,9 @@ const (
 	ResponsesStreamResponseTypeWebSearchCallResultsAdded      ResponsesStreamResponseType = "response.web_search_call.results.added"
 	ResponsesStreamResponseTypeWebSearchCallResultsCompleted  ResponsesStreamResponseType = "response.web_search_call.results.completed"
 
-	ResponsesStreamResponseTypeWebFetchCallInProgress  ResponsesStreamResponseType = "response.web_fetch_call.in_progress"
-	ResponsesStreamResponseTypeWebFetchCallFetching    ResponsesStreamResponseType = "response.web_fetch_call.fetching"
-	ResponsesStreamResponseTypeWebFetchCallCompleted   ResponsesStreamResponseType = "response.web_fetch_call.completed"
+	ResponsesStreamResponseTypeWebFetchCallInProgress ResponsesStreamResponseType = "response.web_fetch_call.in_progress"
+	ResponsesStreamResponseTypeWebFetchCallFetching   ResponsesStreamResponseType = "response.web_fetch_call.fetching"
+	ResponsesStreamResponseTypeWebFetchCallCompleted  ResponsesStreamResponseType = "response.web_fetch_call.completed"
 
 	ResponsesStreamResponseTypeReasoningSummaryPartAdded ResponsesStreamResponseType = "response.reasoning_summary_part.added"
 	ResponsesStreamResponseTypeReasoningSummaryPartDone  ResponsesStreamResponseType = "response.reasoning_summary_part.done"


### PR DESCRIPTION
## Summary

This PR adds response parameter backfilling functionality and simplifies the Mistral provider implementation by removing custom provider normalization logic and redundant OCR operation validation.

## Changes

- Added `BackfillParams` methods to `BifrostChatResponse` and `BifrostResponsesResponse` that populate missing response fields (model, object type, created timestamp) from the original request
- Integrated backfill calls into the main request handling flow for chat completion and responses requests
- Removed custom provider key normalization logic from Mistral provider, including `reportedProviderKey()`, `baseProviderKey()`, and `normalizeChatRequestProvider()` methods
- Eliminated duplicate OCR operation validation code that was redundant with existing validation elsewhere
- Fixed minor formatting inconsistencies in response type constants

## Type of change

- [x] Refactor
- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

Verify that chat completion and responses requests return properly populated response fields:

```sh
# Core/Transports
go version
go test ./...

# Test chat completion requests to ensure model, object, and created fields are populated
# Test responses requests to ensure model field is backfilled
# Verify Mistral provider still functions correctly without custom normalization
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this change only affects response field population and removes unnecessary validation code.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable