### PR TITLE
fix: allow zero-weight routing targets and prevent GORM default override

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3801,6 +3801,102 @@ func (bifrost *Bifrost) SelectKeyForProvider(ctx *schemas.BifrostContext, provid
 	return bifrost.selectKeyFromProviderForModel(ctx, schemas.WebSocketResponsesRequest, providerKey, model, baseProvider)
 }
 
+func setProviderContextMetadata(ctx *schemas.BifrostContext, config *schemas.ProviderConfig) {
+	isCustomProvider := config != nil && config.CustomProviderConfig != nil
+	ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, isCustomProvider)
+	if isCustomProvider {
+		ctx.SetValue(schemas.BifrostContextKeyCustomProviderMetadata, &schemas.CustomProviderContextMetadata{
+			ProviderKey:          schemas.ModelProvider(config.CustomProviderConfig.CustomProviderKey),
+			BaseProviderType:     config.CustomProviderConfig.BaseProviderType,
+			SupportsResponsesAPI: config.CustomProviderConfig.SupportsResponsesAPI,
+		})
+		ctx.SetValue(schemas.BifrostContextKeyCustomProviderConfig, nil)
+		return
+	}
+	ctx.SetValue(schemas.BifrostContextKeyCustomProviderMetadata, nil)
+	ctx.SetValue(schemas.BifrostContextKeyCustomProviderConfig, nil)
+}
+
+func (bifrost *Bifrost) setProviderContextMetadataForKey(ctx *schemas.BifrostContext, providerKey schemas.ModelProvider) error {
+	config, err := bifrost.account.GetConfigForProvider(providerKey)
+	if err != nil {
+		return fmt.Errorf("failed to get config for provider %s: %w", providerKey, err)
+	}
+	if config == nil {
+		return fmt.Errorf("config is nil for provider %s", providerKey)
+	}
+	setProviderContextMetadata(ctx, config)
+	return nil
+}
+
+func logResponsesToChatCompletionRetry(logger schemas.Logger, providerKey schemas.ModelProvider, model string, bifrostErr *schemas.BifrostError, warnings []string, isStreaming bool) {
+	if logger == nil {
+		return
+	}
+
+	if isStreaming {
+		logger.Warn("custom provider %s does not appear to support the OpenAI responses API cleanly for streaming; retrying via chat completions fallback: %s", providerKey, schemas.ResponsesToChatCompletionFallbackErrorMessage(bifrostErr))
+	} else {
+		logger.Warn("custom provider %s does not appear to support the OpenAI responses API cleanly; retrying via chat completions fallback: %s", providerKey, schemas.ResponsesToChatCompletionFallbackErrorMessage(bifrostErr))
+	}
+
+	if len(warnings) > 0 {
+		logger.Warn("responses->chat completion fallback for provider %s model %s is compatibility-only: %s", providerKey, model, strings.Join(warnings, "; "))
+	}
+}
+
+func runPostLLMHooksWithResponsesCompatMetadata(ctx *schemas.BifrostContext, pipeline *PluginPipeline, result *schemas.BifrostResponse, bifrostErr *schemas.BifrostError, runFrom int) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	resp, processedErr := pipeline.RunPostLLMHooks(ctx, result, bifrostErr, runFrom)
+	schemas.ApplyResponsesToChatCompletionFallbackMetadata(ctx, resp, processedErr)
+	return resp, processedErr
+}
+
+func (bifrost *Bifrost) retryResponsesToChatCompletionRequest(provider schemas.Provider, config *schemas.ProviderConfig, req *ChannelMessage, key schemas.Key, keys []schemas.Key, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, bool) {
+	state, ok := schemas.GetResponsesToChatCompletionCompatState(req.Context)
+	if !ok || state == nil || state.FallbackRequest == nil || bifrostErr == nil || !state.ShouldRetry(bifrostErr) {
+		return nil, bifrostErr, false
+	}
+
+	logResponsesToChatCompletionRetry(bifrost.logger, provider.GetProviderKey(), state.OriginalModel, bifrostErr, state.Warnings, false)
+	if _, activated := schemas.ActivateResponsesToChatCompletionCompatState(req.Context, schemas.ResponsesToChatCompletionFallbackReasonRuntimeUnsupported); !activated {
+		return nil, bifrostErr, false
+	}
+
+	fallbackMsg := &ChannelMessage{
+		BifrostRequest: *state.FallbackRequest,
+		Context:        req.Context,
+	}
+
+	result, retryErr := executeRequestWithRetries(req.Context, config, func() (*schemas.BifrostResponse, *schemas.BifrostError) {
+		return bifrost.handleProviderRequest(provider, config, fallbackMsg, key, keys)
+	}, state.FallbackRequest.RequestType, provider.GetProviderKey(), state.OriginalModel, state.FallbackRequest, bifrost.logger)
+
+	return result, retryErr, true
+}
+
+func (bifrost *Bifrost) retryResponsesToChatCompletionStream(provider schemas.Provider, config *schemas.ProviderConfig, req *ChannelMessage, key schemas.Key, postHookRunner schemas.PostHookRunner, bifrostErr *schemas.BifrostError) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError, bool) {
+	state, ok := schemas.GetResponsesToChatCompletionCompatState(req.Context)
+	if !ok || state == nil || state.FallbackRequest == nil || bifrostErr == nil || !state.ShouldRetry(bifrostErr) {
+		return nil, bifrostErr, false
+	}
+
+	logResponsesToChatCompletionRetry(bifrost.logger, provider.GetProviderKey(), state.OriginalModel, bifrostErr, state.Warnings, true)
+	if _, activated := schemas.ActivateResponsesToChatCompletionCompatState(req.Context, schemas.ResponsesToChatCompletionFallbackReasonRuntimeUnsupported); !activated {
+		return nil, bifrostErr, false
+	}
+
+	fallbackMsg := &ChannelMessage{
+		BifrostRequest: *state.FallbackRequest,
+		Context:        req.Context,
+	}
+
+	stream, retryErr := executeRequestWithRetries(req.Context, config, func() (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+		return bifrost.handleProviderStreamRequest(provider, fallbackMsg, key, postHookRunner)
+	}, state.FallbackRequest.RequestType, provider.GetProviderKey(), state.OriginalModel, state.FallbackRequest, bifrost.logger)
+
+	return stream, retryErr, true
+}
+
 // WSStreamHooks holds the post-hook runner and cleanup function returned by RunStreamPreHooks.
 // Call PostHookRunner for each streaming chunk, setting StreamEndIndicator on the final chunk.
 // Call Cleanup when done to release the pipeline back to the pool.
@@ -3819,6 +3915,19 @@ func (bifrost *Bifrost) RunStreamPreHooks(ctx *schemas.BifrostContext, req *sche
 	if ctx == nil {
 		ctx = bifrost.ctx
 	}
+
+	provider, model, _ := req.GetRequestFields()
+	if err := bifrost.setProviderContextMetadataForKey(ctx, provider); err != nil {
+		bifrostErr := newBifrostError(err)
+		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+			RequestType:    req.RequestType,
+			Provider:       provider,
+			ModelRequested: model,
+		}
+		return nil, bifrostErr
+	}
+	schemas.ClearResponsesToChatCompletionFallback(ctx)
+	schemas.ClearResponsesToChatCompletionCompatState(ctx)
 
 	if _, ok := ctx.Value(schemas.BifrostContextKeyRequestID).(string); !ok {
 		ctx.SetValue(schemas.BifrostContextKeyRequestID, uuid.New().String())
@@ -3855,7 +3964,7 @@ func (bifrost *Bifrost) RunStreamPreHooks(ctx *schemas.BifrostContext, req *sche
 	}
 	if shortCircuit != nil {
 		if shortCircuit.Error != nil {
-			_, bifrostErr := pipeline.RunPostLLMHooks(ctx, nil, shortCircuit.Error, preCount)
+			_, bifrostErr := runPostLLMHooksWithResponsesCompatMetadata(ctx, pipeline, nil, shortCircuit.Error, preCount)
 			cleanup()
 			if bifrostErr != nil {
 				return nil, bifrostErr
@@ -3863,7 +3972,7 @@ func (bifrost *Bifrost) RunStreamPreHooks(ctx *schemas.BifrostContext, req *sche
 			return nil, shortCircuit.Error
 		}
 		if shortCircuit.Response != nil {
-			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, shortCircuit.Response, nil, preCount)
+			resp, bifrostErr := runPostLLMHooksWithResponsesCompatMetadata(ctx, pipeline, shortCircuit.Response, nil, preCount)
 			cleanup()
 			if bifrostErr != nil {
 				return nil, bifrostErr
@@ -3876,7 +3985,7 @@ func (bifrost *Bifrost) RunStreamPreHooks(ctx *schemas.BifrostContext, req *sche
 	}
 
 	postHookRunner := func(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
-		return pipeline.RunPostLLMHooks(ctx, result, err, preCount)
+		return runPostLLMHooksWithResponsesCompatMetadata(ctx, pipeline, result, err, preCount)
 	}
 
 	return &WSStreamHooks{
@@ -4331,6 +4440,18 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 		return nil, bifrostErr
 	}
 
+	if err := bifrost.setProviderContextMetadataForKey(ctx, provider); err != nil {
+		bifrostErr := newBifrostError(err)
+		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+			RequestType:    req.RequestType,
+			Provider:       provider,
+			ModelRequested: model,
+		}
+		return nil, bifrostErr
+	}
+	schemas.ClearResponsesToChatCompletionFallback(ctx)
+	schemas.ClearResponsesToChatCompletionCompatState(ctx)
+
 	// Add MCP tools to request if MCP is configured and requested
 	if bifrost.MCPManager != nil {
 		req = bifrost.MCPManager.AddToolsToRequest(ctx, req)
@@ -4354,7 +4475,7 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	if shortCircuit != nil {
 		// Handle short-circuit with response (success case)
 		if shortCircuit.Response != nil {
-			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, shortCircuit.Response, nil, preCount)
+			resp, bifrostErr := runPostLLMHooksWithResponsesCompatMetadata(ctx, pipeline, shortCircuit.Response, nil, preCount)
 			if bifrostErr != nil {
 				return nil, bifrostErr
 			}
@@ -4362,7 +4483,7 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 		}
 		// Handle short-circuit with error
 		if shortCircuit.Error != nil {
-			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, nil, shortCircuit.Error, preCount)
+			resp, bifrostErr := runPostLLMHooksWithResponsesCompatMetadata(ctx, pipeline, nil, shortCircuit.Error, preCount)
 			if bifrostErr != nil {
 				return nil, bifrostErr
 			}
@@ -4457,7 +4578,7 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	pluginCount := len(*bifrost.llmPlugins.Load())
 	select {
 	case result = <-msg.Response:
-		resp, bifrostErr := pipeline.RunPostLLMHooks(msg.Context, result, nil, pluginCount)
+		resp, bifrostErr := runPostLLMHooksWithResponsesCompatMetadata(msg.Context, pipeline, result, nil, pluginCount)
 		if bifrostErr != nil {
 			bifrost.releaseChannelMessage(msg)
 			return nil, bifrostErr
@@ -4473,7 +4594,7 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 		return resp, nil
 	case bifrostErrVal := <-msg.Err:
 		bifrostErrPtr := &bifrostErrVal
-		resp, bifrostErrPtr = pipeline.RunPostLLMHooks(msg.Context, nil, bifrostErrPtr, pluginCount)
+		resp, bifrostErrPtr = runPostLLMHooksWithResponsesCompatMetadata(msg.Context, pipeline, nil, bifrostErrPtr, pluginCount)
 		bifrost.releaseChannelMessage(msg)
 		// Drop raw request/response on error path too
 		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop {
@@ -4513,6 +4634,18 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		return nil, bifrostErr
 	}
 
+	if err := bifrost.setProviderContextMetadataForKey(ctx, provider); err != nil {
+		bifrostErr := newBifrostError(err)
+		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
+			RequestType:    req.RequestType,
+			Provider:       provider,
+			ModelRequested: model,
+		}
+		return nil, bifrostErr
+	}
+	schemas.ClearResponsesToChatCompletionFallback(ctx)
+	schemas.ClearResponsesToChatCompletionCompatState(ctx)
+
 	// Add MCP tools to request if MCP is configured and requested
 	if req.RequestType != schemas.SpeechStreamRequest && req.RequestType != schemas.TranscriptionStreamRequest && bifrost.MCPManager != nil {
 		req = bifrost.MCPManager.AddToolsToRequest(ctx, req)
@@ -4547,7 +4680,7 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 	if shortCircuit != nil {
 		// Handle short-circuit with response (success case)
 		if shortCircuit.Response != nil {
-			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, shortCircuit.Response, nil, preCount)
+			resp, bifrostErr := runPostLLMHooksWithResponsesCompatMetadata(ctx, pipeline, shortCircuit.Response, nil, preCount)
 			if bifrostErr != nil {
 				return nil, bifrostErr
 			}
@@ -4559,7 +4692,7 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 
 			// Create a post hook runner cause pipeline object is put back in the pool on defer
 			pipelinePostHookRunner := func(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
-				return pipeline.RunPostLLMHooks(ctx, result, err, preCount)
+				return runPostLLMHooksWithResponsesCompatMetadata(ctx, pipeline, result, err, preCount)
 			}
 
 			go func() {
@@ -4593,13 +4726,10 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 					// Run post hooks on the stream message
 					processedResponse, processedError := pipelinePostHookRunner(ctx, bifrostResponse, streamMsg.BifrostError)
 
-					// Build the client-facing chunk via the shared helper, which strips raw
-					// request/response fields when in logging-only mode without mutating the
-					// shared processedResponse or processedError objects.
 					streamResponse := providerUtils.BuildClientStreamChunk(ctx, processedResponse, processedError)
-
-					// Send the processed message to the output stream
-					outputStream <- streamResponse
+					if streamResponse != nil {
+						outputStream <- streamResponse
+					}
 
 					//TODO: Release the processed response immediately after use
 				}
@@ -4609,7 +4739,7 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		}
 		// Handle short-circuit with error
 		if shortCircuit.Error != nil {
-			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, nil, shortCircuit.Error, preCount)
+			resp, bifrostErr := runPostLLMHooksWithResponsesCompatMetadata(ctx, pipeline, nil, shortCircuit.Error, preCount)
 			if bifrostErr != nil {
 				return nil, bifrostErr
 			}
@@ -4712,7 +4842,7 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		// Marking final chunk
 		ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 		// On error we will complete post-hooks
-		recoveredResp, recoveredErr := pipeline.RunPostLLMHooks(ctx, nil, &bifrostErrVal, len(*bifrost.llmPlugins.Load()))
+		recoveredResp, recoveredErr := runPostLLMHooksWithResponsesCompatMetadata(ctx, pipeline, nil, &bifrostErrVal, len(*bifrost.llmPlugins.Load()))
 		bifrost.releaseChannelMessage(msg)
 		if recoveredErr != nil {
 			return nil, recoveredErr
@@ -4950,7 +5080,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		if cfg := config.CustomProviderConfig; cfg != nil && cfg.BaseProviderType != "" {
 			baseProvider = cfg.BaseProviderType
 		}
-		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, !IsStandardProvider(baseProvider))
+		setProviderContextMetadata(req.Context, config)
 
 		// Determine whether this provider attempt should capture raw payloads.
 		// logging-only mode (store_raw_request_response=true, send_back_raw_*=false):
@@ -5069,7 +5199,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		if IsStreamRequestType(req.RequestType) {
 			pipeline = bifrost.getPluginPipeline()
 			postHookRunner = func(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
-				resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, result, err, len(*bifrost.llmPlugins.Load()))
+				resp, bifrostErr := runPostLLMHooksWithResponsesCompatMetadata(ctx, pipeline, result, err, len(*bifrost.llmPlugins.Load()))
 				if bifrostErr != nil {
 					return nil, bifrostErr
 				}
@@ -5094,6 +5224,18 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 			result, bifrostError = executeRequestWithRetries(req.Context, config, func() (*schemas.BifrostResponse, *schemas.BifrostError) {
 				return bifrost.handleProviderRequest(provider, config, req, key, keys)
 			}, req.RequestType, provider.GetProviderKey(), model, &req.BifrostRequest, bifrost.logger)
+		}
+
+		if IsStreamRequestType(req.RequestType) {
+			if retriedStream, retryErr, retried := bifrost.retryResponsesToChatCompletionStream(provider, config, req, key, postHookRunner, bifrostError); retried {
+				stream = retriedStream
+				bifrostError = retryErr
+			}
+		} else {
+			if retriedResult, retryErr, retried := bifrost.retryResponsesToChatCompletionRequest(provider, config, req, key, keys, bifrostError); retried {
+				result = retriedResult
+				bifrostError = retryErr
+			}
 		}
 
 		// Release pipeline immediately for non-streaming requests only

--- a/core/custom_provider_context_test.go
+++ b/core/custom_provider_context_test.go
@@ -1,0 +1,62 @@
+package bifrost
+
+import (
+	"context"
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestSetProviderContextMetadata_MarksCustomProvider(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	config := &schemas.ProviderConfig{
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			CustomProviderKey:    "lmstudio",
+			BaseProviderType:     schemas.OpenAI,
+			SupportsResponsesAPI: schemas.Ptr(false),
+		},
+	}
+
+	setProviderContextMetadata(ctx, config)
+
+	isCustomProvider, ok := ctx.Value(schemas.BifrostContextKeyIsCustomProvider).(bool)
+	if !ok || !isCustomProvider {
+		t.Fatalf("expected custom provider flag to be true, got %v", ctx.Value(schemas.BifrostContextKeyIsCustomProvider))
+	}
+	metadata, ok := schemas.GetCustomProviderContextMetadata(ctx)
+	if !ok || metadata == nil {
+		t.Fatal("expected custom provider metadata to be stored in context")
+	}
+	if metadata.ProviderKey != "lmstudio" {
+		t.Fatalf("expected custom provider key lmstudio, got %s", metadata.ProviderKey)
+	}
+	if metadata.BaseProviderType != schemas.OpenAI {
+		t.Fatalf("expected base provider type openai, got %s", metadata.BaseProviderType)
+	}
+	if metadata.SupportsResponsesAPI == nil || *metadata.SupportsResponsesAPI {
+		t.Fatalf("expected supports_responses_api=false metadata, got %+v", metadata.SupportsResponsesAPI)
+	}
+	if customProviderConfig := ctx.Value(schemas.BifrostContextKeyCustomProviderConfig); customProviderConfig != nil {
+		t.Fatalf("expected full custom provider config to stay off context, got %+v", customProviderConfig)
+	}
+}
+
+func TestSetProviderContextMetadata_ClearsCustomProviderValues(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyIsCustomProvider, true)
+	ctx.SetValue(schemas.BifrostContextKeyCustomProviderMetadata, &schemas.CustomProviderContextMetadata{ProviderKey: "lmstudio"})
+	ctx.SetValue(schemas.BifrostContextKeyCustomProviderConfig, &schemas.CustomProviderConfig{CustomProviderKey: "lmstudio"})
+
+	setProviderContextMetadata(ctx, &schemas.ProviderConfig{})
+
+	isCustomProvider, ok := ctx.Value(schemas.BifrostContextKeyIsCustomProvider).(bool)
+	if !ok || isCustomProvider {
+		t.Fatalf("expected custom provider flag to be false, got %v", ctx.Value(schemas.BifrostContextKeyIsCustomProvider))
+	}
+	if metadata := ctx.Value(schemas.BifrostContextKeyCustomProviderMetadata); metadata != nil {
+		t.Fatalf("expected custom provider metadata to be cleared, got %+v", metadata)
+	}
+	if customProviderConfig := ctx.Value(schemas.BifrostContextKeyCustomProviderConfig); customProviderConfig != nil {
+		t.Fatalf("expected custom provider config to be cleared, got %+v", customProviderConfig)
+	}
+}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -90,116 +90,17 @@ func (provider *OpenAIProvider) buildRequestURL(ctx *schemas.BifrostContext, def
 	return provider.networkConfig.BaseURL + path
 }
 
-func (provider *OpenAIProvider) shouldForceResponsesToChatFallback() bool {
-	return provider.customProviderConfig != nil && provider.customProviderConfig.SupportsResponsesAPI != nil && !*provider.customProviderConfig.SupportsResponsesAPI
-}
-
-func (provider *OpenAIProvider) canAutoFallbackResponsesToChat() bool {
-	return provider.customProviderConfig != nil && provider.customProviderConfig.SupportsResponsesAPI == nil
-}
-
-func shouldRetryResponsesAsChat(err *schemas.BifrostError) bool {
-	if err == nil {
+func shouldBypassAllowedRequestsCheck(ctx *schemas.BifrostContext) bool {
+	if ctx == nil {
 		return false
 	}
 
-	if err.StatusCode != nil {
-		switch *err.StatusCode {
-		case http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusGone, http.StatusNotImplemented:
-			return true
-		}
-	}
-
-	if err.Error == nil {
+	state, ok := schemas.GetResponsesToChatCompletionCompatState(ctx)
+	if !ok || state == nil || !state.Active {
 		return false
 	}
 
-	message := strings.ToLower(strings.TrimSpace(err.Error.Message))
-	for _, unsupportedMarker := range []string{
-		strings.ToLower(schemas.ErrProviderResponseHTML),
-		strings.ToLower(schemas.ErrProviderResponseUnmarshal),
-		strings.ToLower(schemas.ErrProviderResponseEmpty),
-	} {
-		if strings.Contains(message, unsupportedMarker) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func responsesFallbackErrorMessage(err *schemas.BifrostError) string {
-	if err == nil || err.Error == nil {
-		return "unknown responses API error"
-	}
-
-	return err.Error.Message
-}
-
-func (provider *OpenAIProvider) responsesToChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
-	chatRequest := request.ToChatRequest()
-	if provider.disableStore {
-		if chatRequest.Params == nil {
-			chatRequest.Params = &schemas.ChatParameters{}
-		}
-		chatRequest.Params.Store = schemas.Ptr(false)
-	}
-
-	chatResponse, err := HandleOpenAIChatCompletionRequest(
-		ctx,
-		provider.client,
-		provider.buildRequestURL(ctx, "/v1/chat/completions", schemas.ChatCompletionRequest),
-		chatRequest,
-		key,
-		provider.networkConfig.ExtraHeaders,
-		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
-		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
-		provider.GetProviderKey(),
-		nil,
-		nil,
-		provider.logger,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return chatResponse.ToBifrostResponsesResponse(), nil
-}
-
-func (provider *OpenAIProvider) responsesStreamToChatCompletion(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback, true)
-
-	var authHeader map[string]string
-	if key.Value.GetValue() != "" {
-		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
-	}
-
-	chatRequest := request.ToChatRequest()
-	if provider.disableStore {
-		if chatRequest.Params == nil {
-			chatRequest.Params = &schemas.ChatParameters{}
-		}
-		chatRequest.Params.Store = schemas.Ptr(false)
-	}
-
-	return HandleOpenAIChatCompletionStreaming(
-		ctx,
-		provider.client,
-		provider.buildRequestURL(ctx, "/v1/chat/completions", schemas.ChatCompletionStreamRequest),
-		chatRequest,
-		authHeader,
-		provider.networkConfig.ExtraHeaders,
-		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
-		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
-		provider.GetProviderKey(),
-		postHookRunner,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		provider.logger,
-	)
+	return state.OriginalRequestType == schemas.ResponsesRequest || state.OriginalRequestType == schemas.ResponsesStreamRequest
 }
 
 func (provider *OpenAIProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
@@ -856,8 +757,10 @@ func HandleOpenAITextCompletionStreaming(
 // Returns a BifrostResponse containing the completion results or an error if the request fails.
 func (provider *OpenAIProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 	// Check if chat completion is allowed for this provider
-	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ChatCompletionRequest); err != nil {
-		return nil, err
+	if !shouldBypassAllowedRequestsCheck(ctx) {
+		if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ChatCompletionRequest); err != nil {
+			return nil, err
+		}
 	}
 
 	if provider.disableStore {
@@ -1025,8 +928,10 @@ func HandleOpenAIChatCompletionRequest(
 // Returns a channel for streaming responses and any error that occurred.
 func (provider *OpenAIProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	// Check if chat completion stream is allowed for this provider
-	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ChatCompletionStreamRequest); err != nil {
-		return nil, err
+	if !shouldBypassAllowedRequestsCheck(ctx) {
+		if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ChatCompletionStreamRequest); err != nil {
+			return nil, err
+		}
 	}
 	var authHeader map[string]string
 	if key.Value.GetValue() != "" {
@@ -1351,6 +1256,7 @@ func HandleOpenAIChatCompletionStreaming(
 					response.ExtraFields.Provider = providerName
 					response.ExtraFields.ModelRequested = request.Model
 					response.ExtraFields.ChunkIndex = response.SequenceNumber
+					response.ExtraFields.LiteLLMCompat = true
 
 					if sendBackRawResponse {
 						response.ExtraFields.RawResponse = jsonData
@@ -1491,11 +1397,6 @@ func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schem
 		return nil, err
 	}
 
-	if provider.shouldForceResponsesToChatFallback() {
-		provider.logger.Debug("custom provider %s is configured with supports_responses_api=false; using chat completions fallback for responses requests", provider.GetProviderKey())
-		return provider.responsesToChatCompletion(ctx, key, request)
-	}
-
 	if provider.disableStore {
 		if request.Params == nil {
 			request.Params = &schemas.ResponsesParameters{}
@@ -1517,10 +1418,6 @@ func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schem
 		nil,
 		provider.logger,
 	)
-	if err != nil && provider.canAutoFallbackResponsesToChat() && shouldRetryResponsesAsChat(err) {
-		provider.logger.Warn("custom provider %s does not appear to support the OpenAI responses API cleanly; retrying via chat completions fallback: %s", provider.GetProviderKey(), responsesFallbackErrorMessage(err))
-		return provider.responsesToChatCompletion(ctx, key, request)
-	}
 
 	return response, err
 }
@@ -1669,11 +1566,6 @@ func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 		return nil, err
 	}
 
-	if provider.shouldForceResponsesToChatFallback() {
-		provider.logger.Debug("custom provider %s is configured with supports_responses_api=false; using chat completions fallback for streaming responses requests", provider.GetProviderKey())
-		return provider.responsesStreamToChatCompletion(ctx, postHookRunner, key, request)
-	}
-
 	var authHeader map[string]string
 	if key.Value.GetValue() != "" {
 		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
@@ -1703,10 +1595,6 @@ func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 		nil,
 		provider.logger,
 	)
-	if err != nil && provider.canAutoFallbackResponsesToChat() && shouldRetryResponsesAsChat(err) {
-		provider.logger.Warn("custom provider %s does not appear to support the OpenAI responses API cleanly for streaming; retrying via chat completions fallback: %s", provider.GetProviderKey(), responsesFallbackErrorMessage(err))
-		return provider.responsesStreamToChatCompletion(ctx, postHookRunner, key, request)
-	}
 
 	return streamChan, err
 }

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -90,6 +90,118 @@ func (provider *OpenAIProvider) buildRequestURL(ctx *schemas.BifrostContext, def
 	return provider.networkConfig.BaseURL + path
 }
 
+func (provider *OpenAIProvider) shouldForceResponsesToChatFallback() bool {
+	return provider.customProviderConfig != nil && provider.customProviderConfig.SupportsResponsesAPI != nil && !*provider.customProviderConfig.SupportsResponsesAPI
+}
+
+func (provider *OpenAIProvider) canAutoFallbackResponsesToChat() bool {
+	return provider.customProviderConfig != nil && provider.customProviderConfig.SupportsResponsesAPI == nil
+}
+
+func shouldRetryResponsesAsChat(err *schemas.BifrostError) bool {
+	if err == nil {
+		return false
+	}
+
+	if err.StatusCode != nil {
+		switch *err.StatusCode {
+		case http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusGone, http.StatusNotImplemented:
+			return true
+		}
+	}
+
+	if err.Error == nil {
+		return false
+	}
+
+	message := strings.ToLower(strings.TrimSpace(err.Error.Message))
+	for _, unsupportedMarker := range []string{
+		strings.ToLower(schemas.ErrProviderResponseHTML),
+		strings.ToLower(schemas.ErrProviderResponseUnmarshal),
+		strings.ToLower(schemas.ErrProviderResponseEmpty),
+	} {
+		if strings.Contains(message, unsupportedMarker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func responsesFallbackErrorMessage(err *schemas.BifrostError) string {
+	if err == nil || err.Error == nil {
+		return "unknown responses API error"
+	}
+
+	return err.Error.Message
+}
+
+func (provider *OpenAIProvider) responsesToChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+	chatRequest := request.ToChatRequest()
+	if provider.disableStore {
+		if chatRequest.Params == nil {
+			chatRequest.Params = &schemas.ChatParameters{}
+		}
+		chatRequest.Params.Store = schemas.Ptr(false)
+	}
+
+	chatResponse, err := HandleOpenAIChatCompletionRequest(
+		ctx,
+		provider.client,
+		provider.buildRequestURL(ctx, "/v1/chat/completions", schemas.ChatCompletionRequest),
+		chatRequest,
+		key,
+		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
+		nil,
+		nil,
+		provider.logger,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return chatResponse.ToBifrostResponsesResponse(), nil
+}
+
+func (provider *OpenAIProvider) responsesStreamToChatCompletion(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	ctx.SetValue(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback, true)
+
+	var authHeader map[string]string
+	if key.Value.GetValue() != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
+	}
+
+	chatRequest := request.ToChatRequest()
+	if provider.disableStore {
+		if chatRequest.Params == nil {
+			chatRequest.Params = &schemas.ChatParameters{}
+		}
+		chatRequest.Params.Store = schemas.Ptr(false)
+	}
+
+	return HandleOpenAIChatCompletionStreaming(
+		ctx,
+		provider.client,
+		provider.buildRequestURL(ctx, "/v1/chat/completions", schemas.ChatCompletionStreamRequest),
+		chatRequest,
+		authHeader,
+		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
+		postHookRunner,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		provider.logger,
+	)
+}
+
 func (provider *OpenAIProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ListModelsRequest); err != nil {
 		return nil, err
@@ -1379,6 +1491,11 @@ func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schem
 		return nil, err
 	}
 
+	if provider.shouldForceResponsesToChatFallback() {
+		provider.logger.Debug("custom provider %s is configured with supports_responses_api=false; using chat completions fallback for responses requests", provider.GetProviderKey())
+		return provider.responsesToChatCompletion(ctx, key, request)
+	}
+
 	if provider.disableStore {
 		if request.Params == nil {
 			request.Params = &schemas.ResponsesParameters{}
@@ -1386,7 +1503,7 @@ func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schem
 		request.Params.Store = schemas.Ptr(false)
 	}
 
-	return HandleOpenAIResponsesRequest(
+	response, err := HandleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
 		provider.buildRequestURL(ctx, "/v1/responses", schemas.ResponsesRequest),
@@ -1400,6 +1517,12 @@ func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schem
 		nil,
 		provider.logger,
 	)
+	if err != nil && provider.canAutoFallbackResponsesToChat() && shouldRetryResponsesAsChat(err) {
+		provider.logger.Warn("custom provider %s does not appear to support the OpenAI responses API cleanly; retrying via chat completions fallback: %s", provider.GetProviderKey(), responsesFallbackErrorMessage(err))
+		return provider.responsesToChatCompletion(ctx, key, request)
+	}
+
+	return response, err
 }
 
 // HandleOpenAIResponsesRequest handles a responses request to OpenAI's API.
@@ -1545,6 +1668,12 @@ func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
 		return nil, err
 	}
+
+	if provider.shouldForceResponsesToChatFallback() {
+		provider.logger.Debug("custom provider %s is configured with supports_responses_api=false; using chat completions fallback for streaming responses requests", provider.GetProviderKey())
+		return provider.responsesStreamToChatCompletion(ctx, postHookRunner, key, request)
+	}
+
 	var authHeader map[string]string
 	if key.Value.GetValue() != "" {
 		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
@@ -1557,7 +1686,7 @@ func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 	}
 
 	// Use shared streaming logic
-	return HandleOpenAIResponsesStreaming(
+	streamChan, err := HandleOpenAIResponsesStreaming(
 		ctx,
 		provider.client,
 		provider.buildRequestURL(ctx, "/v1/responses", schemas.ResponsesStreamRequest),
@@ -1574,6 +1703,12 @@ func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 		nil,
 		provider.logger,
 	)
+	if err != nil && provider.canAutoFallbackResponsesToChat() && shouldRetryResponsesAsChat(err) {
+		provider.logger.Warn("custom provider %s does not appear to support the OpenAI responses API cleanly for streaming; retrying via chat completions fallback: %s", provider.GetProviderKey(), responsesFallbackErrorMessage(err))
+		return provider.responsesStreamToChatCompletion(ctx, postHookRunner, key, request)
+	}
+
+	return streamChan, err
 }
 
 // HandleOpenAIResponsesStreaming handles streaming for OpenAI-compatible APIs.

--- a/core/providers/openai/responses_fallback_test.go
+++ b/core/providers/openai/responses_fallback_test.go
@@ -1,0 +1,513 @@
+package openai
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+type testOpenAILogger struct{}
+
+func (testOpenAILogger) Debug(string, ...any)                   {}
+func (testOpenAILogger) Info(string, ...any)                    {}
+func (testOpenAILogger) Warn(string, ...any)                    {}
+func (testOpenAILogger) Error(string, ...any)                   {}
+func (testOpenAILogger) Fatal(string, ...any)                   {}
+func (testOpenAILogger) SetLevel(schemas.LogLevel)              {}
+func (testOpenAILogger) SetOutputType(schemas.LoggerOutputType) {}
+func (testOpenAILogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func testOpenAIResponsesCtx() *schemas.BifrostContext {
+	return schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+}
+
+func testOpenAIResponsesRequest() *schemas.BifrostResponsesRequest {
+	content := "hello"
+	return &schemas.BifrostResponsesRequest{
+		Model: "test-model",
+		Input: []schemas.ResponsesMessage{{
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{
+				ContentStr: &content,
+			},
+		}},
+		Params: &schemas.ResponsesParameters{
+			MaxOutputTokens: schemas.Ptr(7),
+		},
+	}
+}
+
+func noopOpenAIPostHookRunner(_ *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return result, err
+}
+
+func newTestOpenAIProvider(baseURL string, customConfig *schemas.CustomProviderConfig) *OpenAIProvider {
+	return NewOpenAIProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{
+			BaseURL:                        baseURL,
+			DefaultRequestTimeoutInSeconds: 5,
+		},
+		CustomProviderConfig: customConfig,
+	}, testOpenAILogger{})
+}
+
+func testChatCompletionBody(text string) []byte {
+	finishReason := string(schemas.BifrostFinishReasonStop)
+	response := &schemas.BifrostChatResponse{
+		ID:      "chatcmpl-test",
+		Object:  "chat.completion",
+		Created: 1,
+		Model:   "test-model",
+		Choices: []schemas.BifrostResponseChoice{{
+			Index:        0,
+			FinishReason: &finishReason,
+			ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+				Message: &schemas.ChatMessage{
+					Role: schemas.ChatMessageRoleAssistant,
+					Content: &schemas.ChatMessageContent{
+						ContentStr: &text,
+					},
+				},
+			},
+		}},
+		Usage: &schemas.BifrostLLMUsage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+	}
+	body, _ := sonic.Marshal(response)
+	return body
+}
+
+func testResponsesBody(text string) []byte {
+	messageType := schemas.ResponsesMessageTypeMessage
+	role := schemas.ResponsesInputMessageRoleAssistant
+	status := "completed"
+	textType := schemas.ResponsesOutputMessageContentTypeText
+	response := &schemas.BifrostResponsesResponse{
+		ID:        schemas.Ptr("resp-test"),
+		Object:    "response",
+		CreatedAt: 1,
+		Model:     "test-model",
+		Status:    &status,
+		Output: []schemas.ResponsesMessage{{
+			Type: &messageType,
+			Role: &role,
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+					Type: textType,
+					Text: &text,
+				}},
+			},
+		}},
+	}
+	body, _ := sonic.Marshal(response)
+	return body
+}
+
+func TestResponses_CustomProviderFallsBackToChatCompletion(t *testing.T) {
+	t.Parallel()
+
+	var chatHits atomic.Int32
+	var responsesHits atomic.Int32
+	var requestBody atomic.Value
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+
+		switch r.URL.Path {
+		case "/v1/chat/completions":
+			chatHits.Add(1)
+			requestBody.Store(string(bodyBytes))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(testChatCompletionBody("fallback response"))
+		case "/v1/responses":
+			responsesHits.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"unexpected responses endpoint"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(server.URL, &schemas.CustomProviderConfig{
+		CustomProviderKey:    "lmstudio",
+		BaseProviderType:     schemas.OpenAI,
+		IsKeyLess:            true,
+		SupportsResponsesAPI: schemas.Ptr(false),
+	})
+
+	response, bifrostErr := provider.Responses(testOpenAIResponsesCtx(), schemas.Key{}, testOpenAIResponsesRequest())
+	if bifrostErr != nil {
+		t.Fatalf("Responses returned error: %v", bifrostErr.Error)
+	}
+	if response == nil {
+		t.Fatal("Responses returned nil response")
+	}
+	if chatHits.Load() != 1 {
+		t.Fatalf("expected one chat completion request, got %d", chatHits.Load())
+	}
+	if responsesHits.Load() != 0 {
+		t.Fatalf("expected zero responses endpoint requests, got %d", responsesHits.Load())
+	}
+
+	body, _ := requestBody.Load().(string)
+	if !strings.Contains(body, `"messages"`) {
+		t.Fatalf("expected chat completion payload to contain messages, got %s", body)
+	}
+	if strings.Contains(body, `"input"`) {
+		t.Fatalf("expected chat completion payload to omit responses input, got %s", body)
+	}
+	if !strings.Contains(body, `"max_completion_tokens":`) {
+		t.Fatalf("expected chat completion payload to contain max_completion_tokens, got %s", body)
+	}
+	if strings.Contains(body, `"max_output_tokens"`) {
+		t.Fatalf("expected chat completion payload to omit max_output_tokens, got %s", body)
+	}
+
+	if response.ExtraFields.Provider != schemas.ModelProvider("lmstudio") {
+		t.Fatalf("expected provider to remain lmstudio, got %s", response.ExtraFields.Provider)
+	}
+	if response.ExtraFields.RequestType != schemas.ResponsesRequest {
+		t.Fatalf("expected request type %s, got %s", schemas.ResponsesRequest, response.ExtraFields.RequestType)
+	}
+	if response.Model != "test-model" {
+		t.Fatalf("expected model test-model, got %s", response.Model)
+	}
+	if len(response.Output) == 0 || response.Output[0].Content == nil || len(response.Output[0].Content.ContentBlocks) == 0 {
+		t.Fatalf("expected converted responses output, got %+v", response.Output)
+	}
+	if got := response.Output[0].Content.ContentBlocks[0].Text; got == nil || *got != "fallback response" {
+		t.Fatalf("expected converted output text fallback response, got %+v", got)
+	}
+}
+
+func TestResponses_CustomProviderAutoFallsBackAfterUnsupportedResponsesError(t *testing.T) {
+	t.Parallel()
+
+	var chatHits atomic.Int32
+	var responsesHits atomic.Int32
+	var chatRequestBody atomic.Value
+	var responsesRequestBody atomic.Value
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+
+		switch r.URL.Path {
+		case "/v1/responses":
+			responsesHits.Add(1)
+			responsesRequestBody.Store(string(bodyBytes))
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"responses endpoint unsupported"}}`))
+		case "/v1/chat/completions":
+			chatHits.Add(1)
+			chatRequestBody.Store(string(bodyBytes))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(testChatCompletionBody("auto fallback response"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(server.URL, &schemas.CustomProviderConfig{
+		CustomProviderKey: "lmstudio",
+		BaseProviderType:  schemas.OpenAI,
+		IsKeyLess:         true,
+	})
+
+	response, bifrostErr := provider.Responses(testOpenAIResponsesCtx(), schemas.Key{}, testOpenAIResponsesRequest())
+	if bifrostErr != nil {
+		t.Fatalf("Responses returned error: %v", bifrostErr.Error)
+	}
+	if response == nil {
+		t.Fatal("Responses returned nil response")
+	}
+	if responsesHits.Load() != 1 {
+		t.Fatalf("expected one native responses attempt before fallback, got %d", responsesHits.Load())
+	}
+	if chatHits.Load() != 1 {
+		t.Fatalf("expected one chat completion fallback request, got %d", chatHits.Load())
+	}
+
+	responsesBody, _ := responsesRequestBody.Load().(string)
+	if !strings.Contains(responsesBody, `"input"`) {
+		t.Fatalf("expected initial responses payload to contain input, got %s", responsesBody)
+	}
+
+	chatBody, _ := chatRequestBody.Load().(string)
+	if !strings.Contains(chatBody, `"messages"`) {
+		t.Fatalf("expected fallback chat payload to contain messages, got %s", chatBody)
+	}
+	if strings.Contains(chatBody, `"input"`) {
+		t.Fatalf("expected fallback chat payload to omit responses input, got %s", chatBody)
+	}
+
+	if got := response.Output[0].Content.ContentBlocks[0].Text; got == nil || *got != "auto fallback response" {
+		t.Fatalf("expected converted output text auto fallback response, got %+v", got)
+	}
+}
+
+func TestResponses_CustomProviderUsesNativeResponsesWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	var chatHits atomic.Int32
+	var responsesHits atomic.Int32
+	var requestBody atomic.Value
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+
+		switch r.URL.Path {
+		case "/v1/responses":
+			responsesHits.Add(1)
+			requestBody.Store(string(bodyBytes))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(testResponsesBody("native custom response"))
+		case "/v1/chat/completions":
+			chatHits.Add(1)
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"unexpected chat endpoint"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(server.URL, &schemas.CustomProviderConfig{
+		CustomProviderKey:    "lmstudio",
+		BaseProviderType:     schemas.OpenAI,
+		IsKeyLess:            true,
+		SupportsResponsesAPI: schemas.Ptr(true),
+	})
+
+	response, bifrostErr := provider.Responses(testOpenAIResponsesCtx(), schemas.Key{}, testOpenAIResponsesRequest())
+	if bifrostErr != nil {
+		t.Fatalf("Responses returned error: %v", bifrostErr.Error)
+	}
+	if response == nil {
+		t.Fatal("Responses returned nil response")
+	}
+	if responsesHits.Load() != 1 {
+		t.Fatalf("expected one responses request, got %d", responsesHits.Load())
+	}
+	if chatHits.Load() != 0 {
+		t.Fatalf("expected zero chat completion requests, got %d", chatHits.Load())
+	}
+
+	body, _ := requestBody.Load().(string)
+	if !strings.Contains(body, `"input"`) {
+		t.Fatalf("expected native responses payload to contain input, got %s", body)
+	}
+	if strings.Contains(body, `"messages"`) {
+		t.Fatalf("expected native responses payload to omit messages, got %s", body)
+	}
+	if !strings.Contains(body, `"max_output_tokens":`) {
+		t.Fatalf("expected native responses payload to contain max_output_tokens, got %s", body)
+	}
+
+	if response.ExtraFields.Provider != schemas.ModelProvider("lmstudio") {
+		t.Fatalf("expected provider to remain lmstudio, got %s", response.ExtraFields.Provider)
+	}
+	if len(response.Output) == 0 || response.Output[0].Content == nil || len(response.Output[0].Content.ContentBlocks) == 0 {
+		t.Fatalf("expected native responses output, got %+v", response.Output)
+	}
+	if got := response.Output[0].Content.ContentBlocks[0].Text; got == nil || *got != "native custom response" {
+		t.Fatalf("expected native output text native custom response, got %+v", got)
+	}
+}
+
+func TestResponsesStream_CustomProviderAutoFallsBackToChatCompletionStream(t *testing.T) {
+	t.Parallel()
+
+	var chatHits atomic.Int32
+	var responsesHits atomic.Int32
+	var requestBody atomic.Value
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+
+		switch r.URL.Path {
+		case "/v1/chat/completions":
+			chatHits.Add(1)
+			requestBody.Store(string(bodyBytes))
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				t.Fatal("response writer does not implement http.Flusher")
+			}
+
+			chunks := []string{
+				`{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant"}}]}`,
+				`{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"content":"fallback stream"}}]}`,
+				`{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+			}
+
+			for _, chunk := range chunks {
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", chunk)
+				flusher.Flush()
+			}
+			_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+			flusher.Flush()
+		case "/v1/responses":
+			responsesHits.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"unexpected responses endpoint"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(server.URL, &schemas.CustomProviderConfig{
+		CustomProviderKey: "lmstudio",
+		BaseProviderType:  schemas.OpenAI,
+		IsKeyLess:         true,
+	})
+
+	ctx := testOpenAIResponsesCtx()
+	streamChan, bifrostErr := provider.ResponsesStream(ctx, noopOpenAIPostHookRunner, schemas.Key{}, testOpenAIResponsesRequest())
+	if bifrostErr != nil {
+		t.Fatalf("ResponsesStream returned error: %v", bifrostErr.Error)
+	}
+
+	responses := collectResponsesStream(t, streamChan)
+	if chatHits.Load() != 1 {
+		t.Fatalf("expected one chat completion stream request, got %d", chatHits.Load())
+	}
+	if responsesHits.Load() != 1 {
+		t.Fatalf("expected one native responses stream attempt before fallback, got %d", responsesHits.Load())
+	}
+
+	body, _ := requestBody.Load().(string)
+	if !strings.Contains(body, `"messages"`) {
+		t.Fatalf("expected streaming chat payload to contain messages, got %s", body)
+	}
+	if strings.Contains(body, `"input"`) {
+		t.Fatalf("expected streaming chat payload to omit responses input, got %s", body)
+	}
+
+	seenTypes := map[schemas.ResponsesStreamResponseType]bool{}
+	for _, response := range responses {
+		seenTypes[response.Type] = true
+	}
+
+	if !seenTypes[schemas.ResponsesStreamResponseTypeCreated] {
+		t.Fatalf("expected response.created event, got %#v", seenTypes)
+	}
+	if !seenTypes[schemas.ResponsesStreamResponseTypeOutputTextDelta] {
+		t.Fatalf("expected response.output_text.delta event, got %#v", seenTypes)
+	}
+	if !seenTypes[schemas.ResponsesStreamResponseTypeCompleted] {
+		t.Fatalf("expected response.completed event, got %#v", seenTypes)
+	}
+	if ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback) != true {
+		t.Fatalf("expected fallback context marker to be set, got %v", ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback))
+	}
+}
+
+func TestResponses_NativeOpenAIStillUsesResponsesEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var chatHits atomic.Int32
+	var responsesHits atomic.Int32
+	var requestBody atomic.Value
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+
+		switch r.URL.Path {
+		case "/v1/responses":
+			responsesHits.Add(1)
+			requestBody.Store(string(bodyBytes))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(testResponsesBody("native response"))
+		case "/v1/chat/completions":
+			chatHits.Add(1)
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"unexpected chat endpoint"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(server.URL, nil)
+
+	response, bifrostErr := provider.Responses(testOpenAIResponsesCtx(), schemas.Key{}, testOpenAIResponsesRequest())
+	if bifrostErr != nil {
+		t.Fatalf("Responses returned error: %v", bifrostErr.Error)
+	}
+	if response == nil {
+		t.Fatal("Responses returned nil response")
+	}
+	if responsesHits.Load() != 1 {
+		t.Fatalf("expected one responses request, got %d", responsesHits.Load())
+	}
+	if chatHits.Load() != 0 {
+		t.Fatalf("expected zero chat completion requests, got %d", chatHits.Load())
+	}
+
+	body, _ := requestBody.Load().(string)
+	if !strings.Contains(body, `"input"`) {
+		t.Fatalf("expected native responses payload to contain input, got %s", body)
+	}
+	if strings.Contains(body, `"messages"`) {
+		t.Fatalf("expected native responses payload to omit messages, got %s", body)
+	}
+	if got := response.Output[0].Content.ContentBlocks[0].Text; got == nil || *got != "native response" {
+		t.Fatalf("expected native output text native response, got %+v", got)
+	}
+}
+
+func collectResponsesStream(t *testing.T, stream chan *schemas.BifrostStreamChunk) []*schemas.BifrostResponsesStreamResponse {
+	t.Helper()
+
+	responses := make([]*schemas.BifrostResponsesStreamResponse, 0)
+	timeout := time.After(3 * time.Second)
+
+	for {
+		select {
+		case chunk, ok := <-stream:
+			if !ok {
+				return responses
+			}
+			if chunk == nil {
+				continue
+			}
+			if chunk.BifrostError != nil {
+				t.Fatalf("unexpected stream error: %+v", chunk.BifrostError)
+			}
+			if chunk.BifrostResponsesStreamResponse != nil {
+				responses = append(responses, chunk.BifrostResponsesStreamResponse)
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for stream to complete")
+		}
+	}
+}

--- a/core/providers/openai/responses_fallback_test.go
+++ b/core/providers/openai/responses_fallback_test.go
@@ -2,14 +2,12 @@ package openai
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/bytedance/sonic"
 
@@ -114,23 +112,16 @@ func testResponsesBody(text string) []byte {
 	return body
 }
 
-func TestResponses_CustomProviderFallsBackToChatCompletion(t *testing.T) {
+func TestResponses_CustomProviderConfiguredUnsupported_DoesNotFallbackInsideProvider(t *testing.T) {
 	t.Parallel()
 
 	var chatHits atomic.Int32
 	var responsesHits atomic.Int32
-	var requestBody atomic.Value
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bodyBytes, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("failed to read request body: %v", err)
-		}
-
 		switch r.URL.Path {
 		case "/v1/chat/completions":
 			chatHits.Add(1)
-			requestBody.Store(string(bodyBytes))
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write(testChatCompletionBody("fallback response"))
 		case "/v1/responses":
@@ -150,74 +141,39 @@ func TestResponses_CustomProviderFallsBackToChatCompletion(t *testing.T) {
 		SupportsResponsesAPI: schemas.Ptr(false),
 	})
 
-	response, bifrostErr := provider.Responses(testOpenAIResponsesCtx(), schemas.Key{}, testOpenAIResponsesRequest())
-	if bifrostErr != nil {
-		t.Fatalf("Responses returned error: %v", bifrostErr.Error)
+	ctx := testOpenAIResponsesCtx()
+	response, bifrostErr := provider.Responses(ctx, schemas.Key{}, testOpenAIResponsesRequest())
+	if bifrostErr == nil {
+		t.Fatal("expected provider-level responses call to fail without compat fallback")
 	}
-	if response == nil {
-		t.Fatal("Responses returned nil response")
+	if response != nil {
+		t.Fatalf("expected nil response on provider-level failure, got %+v", response)
 	}
-	if chatHits.Load() != 1 {
-		t.Fatalf("expected one chat completion request, got %d", chatHits.Load())
+	if chatHits.Load() != 0 {
+		t.Fatalf("expected zero chat completion requests, got %d", chatHits.Load())
 	}
-	if responsesHits.Load() != 0 {
-		t.Fatalf("expected zero responses endpoint requests, got %d", responsesHits.Load())
+	if responsesHits.Load() != 1 {
+		t.Fatalf("expected one responses endpoint request, got %d", responsesHits.Load())
 	}
-
-	body, _ := requestBody.Load().(string)
-	if !strings.Contains(body, `"messages"`) {
-		t.Fatalf("expected chat completion payload to contain messages, got %s", body)
-	}
-	if strings.Contains(body, `"input"`) {
-		t.Fatalf("expected chat completion payload to omit responses input, got %s", body)
-	}
-	if !strings.Contains(body, `"max_completion_tokens":`) {
-		t.Fatalf("expected chat completion payload to contain max_completion_tokens, got %s", body)
-	}
-	if strings.Contains(body, `"max_output_tokens"`) {
-		t.Fatalf("expected chat completion payload to omit max_output_tokens, got %s", body)
-	}
-
-	if response.ExtraFields.Provider != schemas.ModelProvider("lmstudio") {
-		t.Fatalf("expected provider to remain lmstudio, got %s", response.ExtraFields.Provider)
-	}
-	if response.ExtraFields.RequestType != schemas.ResponsesRequest {
-		t.Fatalf("expected request type %s, got %s", schemas.ResponsesRequest, response.ExtraFields.RequestType)
-	}
-	if response.Model != "test-model" {
-		t.Fatalf("expected model test-model, got %s", response.Model)
-	}
-	if len(response.Output) == 0 || response.Output[0].Content == nil || len(response.Output[0].Content.ContentBlocks) == 0 {
-		t.Fatalf("expected converted responses output, got %+v", response.Output)
-	}
-	if got := response.Output[0].Content.ContentBlocks[0].Text; got == nil || *got != "fallback response" {
-		t.Fatalf("expected converted output text fallback response, got %+v", got)
+	if ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback) != nil {
+		t.Fatalf("expected no fallback marker on provider-only path, got %v", ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback))
 	}
 }
 
-func TestResponses_CustomProviderAutoFallsBackAfterUnsupportedResponsesError(t *testing.T) {
+func TestResponses_CustomProviderRuntimeUnsupported_DoesNotFallbackInsideProvider(t *testing.T) {
 	t.Parallel()
 
 	var chatHits atomic.Int32
 	var responsesHits atomic.Int32
-	var chatRequestBody atomic.Value
-	var responsesRequestBody atomic.Value
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bodyBytes, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("failed to read request body: %v", err)
-		}
-
 		switch r.URL.Path {
 		case "/v1/responses":
 			responsesHits.Add(1)
-			responsesRequestBody.Store(string(bodyBytes))
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte(`{"error":{"message":"responses endpoint unsupported"}}`))
 		case "/v1/chat/completions":
 			chatHits.Add(1)
-			chatRequestBody.Store(string(bodyBytes))
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write(testChatCompletionBody("auto fallback response"))
 		default:
@@ -232,35 +188,22 @@ func TestResponses_CustomProviderAutoFallsBackAfterUnsupportedResponsesError(t *
 		IsKeyLess:         true,
 	})
 
-	response, bifrostErr := provider.Responses(testOpenAIResponsesCtx(), schemas.Key{}, testOpenAIResponsesRequest())
-	if bifrostErr != nil {
-		t.Fatalf("Responses returned error: %v", bifrostErr.Error)
+	ctx := testOpenAIResponsesCtx()
+	response, bifrostErr := provider.Responses(ctx, schemas.Key{}, testOpenAIResponsesRequest())
+	if bifrostErr == nil {
+		t.Fatal("expected provider-level responses call to fail without runtime compat retry")
 	}
-	if response == nil {
-		t.Fatal("Responses returned nil response")
+	if response != nil {
+		t.Fatalf("expected nil response on provider-level failure, got %+v", response)
 	}
 	if responsesHits.Load() != 1 {
-		t.Fatalf("expected one native responses attempt before fallback, got %d", responsesHits.Load())
+		t.Fatalf("expected one native responses attempt, got %d", responsesHits.Load())
 	}
-	if chatHits.Load() != 1 {
-		t.Fatalf("expected one chat completion fallback request, got %d", chatHits.Load())
+	if chatHits.Load() != 0 {
+		t.Fatalf("expected zero chat completion fallback requests, got %d", chatHits.Load())
 	}
-
-	responsesBody, _ := responsesRequestBody.Load().(string)
-	if !strings.Contains(responsesBody, `"input"`) {
-		t.Fatalf("expected initial responses payload to contain input, got %s", responsesBody)
-	}
-
-	chatBody, _ := chatRequestBody.Load().(string)
-	if !strings.Contains(chatBody, `"messages"`) {
-		t.Fatalf("expected fallback chat payload to contain messages, got %s", chatBody)
-	}
-	if strings.Contains(chatBody, `"input"`) {
-		t.Fatalf("expected fallback chat payload to omit responses input, got %s", chatBody)
-	}
-
-	if got := response.Output[0].Content.ContentBlocks[0].Text; got == nil || *got != "auto fallback response" {
-		t.Fatalf("expected converted output text auto fallback response, got %+v", got)
+	if ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback) != nil {
+		t.Fatalf("expected no fallback marker on provider-only path, got %v", ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback))
 	}
 }
 
@@ -336,45 +279,22 @@ func TestResponses_CustomProviderUsesNativeResponsesWhenEnabled(t *testing.T) {
 	}
 }
 
-func TestResponsesStream_CustomProviderAutoFallsBackToChatCompletionStream(t *testing.T) {
+func TestResponsesStream_CustomProviderRuntimeUnsupported_DoesNotFallbackInsideProvider(t *testing.T) {
 	t.Parallel()
 
 	var chatHits atomic.Int32
 	var responsesHits atomic.Int32
-	var requestBody atomic.Value
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bodyBytes, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("failed to read request body: %v", err)
-		}
-
 		switch r.URL.Path {
 		case "/v1/chat/completions":
 			chatHits.Add(1)
-			requestBody.Store(string(bodyBytes))
 			w.Header().Set("Content-Type", "text/event-stream")
-			flusher, ok := w.(http.Flusher)
-			if !ok {
-				t.Fatal("response writer does not implement http.Flusher")
-			}
-
-			chunks := []string{
-				`{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant"}}]}`,
-				`{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"content":"fallback stream"}}]}`,
-				`{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
-			}
-
-			for _, chunk := range chunks {
-				_, _ = fmt.Fprintf(w, "data: %s\n\n", chunk)
-				flusher.Flush()
-			}
-			_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
-			flusher.Flush()
+			_, _ = w.Write([]byte("unused"))
 		case "/v1/responses":
 			responsesHits.Add(1)
 			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte(`{"error":{"message":"unexpected responses endpoint"}}`))
+			_, _ = w.Write([]byte(`{"error":{"message":"responses endpoint unsupported"}}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -389,42 +309,20 @@ func TestResponsesStream_CustomProviderAutoFallsBackToChatCompletionStream(t *te
 
 	ctx := testOpenAIResponsesCtx()
 	streamChan, bifrostErr := provider.ResponsesStream(ctx, noopOpenAIPostHookRunner, schemas.Key{}, testOpenAIResponsesRequest())
-	if bifrostErr != nil {
-		t.Fatalf("ResponsesStream returned error: %v", bifrostErr.Error)
+	if bifrostErr == nil {
+		t.Fatal("expected provider-level responses stream call to fail without runtime compat retry")
 	}
-
-	responses := collectResponsesStream(t, streamChan)
-	if chatHits.Load() != 1 {
-		t.Fatalf("expected one chat completion stream request, got %d", chatHits.Load())
+	if streamChan != nil {
+		t.Fatal("expected nil stream when provider-level stream setup fails")
+	}
+	if chatHits.Load() != 0 {
+		t.Fatalf("expected zero chat completion stream requests, got %d", chatHits.Load())
 	}
 	if responsesHits.Load() != 1 {
-		t.Fatalf("expected one native responses stream attempt before fallback, got %d", responsesHits.Load())
+		t.Fatalf("expected one native responses stream attempt, got %d", responsesHits.Load())
 	}
-
-	body, _ := requestBody.Load().(string)
-	if !strings.Contains(body, `"messages"`) {
-		t.Fatalf("expected streaming chat payload to contain messages, got %s", body)
-	}
-	if strings.Contains(body, `"input"`) {
-		t.Fatalf("expected streaming chat payload to omit responses input, got %s", body)
-	}
-
-	seenTypes := map[schemas.ResponsesStreamResponseType]bool{}
-	for _, response := range responses {
-		seenTypes[response.Type] = true
-	}
-
-	if !seenTypes[schemas.ResponsesStreamResponseTypeCreated] {
-		t.Fatalf("expected response.created event, got %#v", seenTypes)
-	}
-	if !seenTypes[schemas.ResponsesStreamResponseTypeOutputTextDelta] {
-		t.Fatalf("expected response.output_text.delta event, got %#v", seenTypes)
-	}
-	if !seenTypes[schemas.ResponsesStreamResponseTypeCompleted] {
-		t.Fatalf("expected response.completed event, got %#v", seenTypes)
-	}
-	if ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback) != true {
-		t.Fatalf("expected fallback context marker to be set, got %v", ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback))
+	if ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback) != nil {
+		t.Fatalf("expected no fallback marker on provider-only path, got %v", ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback))
 	}
 }
 
@@ -482,32 +380,5 @@ func TestResponses_NativeOpenAIStillUsesResponsesEndpoint(t *testing.T) {
 	}
 	if got := response.Output[0].Content.ContentBlocks[0].Text; got == nil || *got != "native response" {
 		t.Fatalf("expected native output text native response, got %+v", got)
-	}
-}
-
-func collectResponsesStream(t *testing.T, stream chan *schemas.BifrostStreamChunk) []*schemas.BifrostResponsesStreamResponse {
-	t.Helper()
-
-	responses := make([]*schemas.BifrostResponsesStreamResponse, 0)
-	timeout := time.After(3 * time.Second)
-
-	for {
-		select {
-		case chunk, ok := <-stream:
-			if !ok {
-				return responses
-			}
-			if chunk == nil {
-				continue
-			}
-			if chunk.BifrostError != nil {
-				t.Fatalf("unexpected stream error: %+v", chunk.BifrostError)
-			}
-			if chunk.BifrostResponsesStreamResponse != nil {
-				responses = append(responses, chunk.BifrostResponsesStreamResponse)
-			}
-		case <-timeout:
-			t.Fatal("timed out waiting for stream to complete")
-		}
 	}
 }

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1838,11 +1838,12 @@ func ProcessAndSendResponse(
 	}
 
 	streamResponse := BuildClientStreamChunk(ctx, processedResponse, processedError)
-
-	select {
-	case responseChan <- streamResponse:
-	case <-ctx.Done():
-		return
+	if streamResponse != nil {
+		select {
+		case responseChan <- streamResponse:
+		case <-ctx.Done():
+			return
+		}
 	}
 
 	// Check if this is the final chunk and complete deferred span with post-processed data

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -2,6 +2,7 @@
 package schemas
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -161,94 +162,98 @@ type BifrostContextKey string
 
 // BifrostContextKeyRequestType is a context key for the request type.
 const (
-	BifrostContextKeySessionToken                        BifrostContextKey = "bifrost-session-token"                // string (session token for authentication - set by auth middleware)
-	BifrostContextKeyVirtualKey                          BifrostContextKey = "x-bf-vk"                              // string
-	BifrostContextKeyAPIKeyName                          BifrostContextKey = "x-bf-api-key"                         // string (explicit key name selection)
-	BifrostContextKeyAPIKeyID                            BifrostContextKey = "x-bf-api-key-id"                      // string (explicit key ID selection, takes priority over name)
-	BifrostContextKeyRequestID                           BifrostContextKey = "request-id"                           // string
-	BifrostContextKeyFallbackRequestID                   BifrostContextKey = "fallback-request-id"                  // string
-	BifrostContextKeyDirectKey                           BifrostContextKey = "bifrost-direct-key"                   // Key struct
-	BifrostContextKeySelectedKeyID                       BifrostContextKey = "bifrost-selected-key-id"              // string (to store the selected key ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
-	BifrostContextKeySelectedKeyName                     BifrostContextKey = "bifrost-selected-key-name"            // string (to store the selected key name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyGovernanceVirtualKeyID              BifrostContextKey = "bifrost-governance-virtual-key-id"    // string (to store the virtual key ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyGovernanceVirtualKeyName            BifrostContextKey = "bifrost-governance-virtual-key-name"  // string (to store the virtual key name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyGovernanceTeamID                    BifrostContextKey = "bifrost-governance-team-id"           // string (to store the team ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyGovernanceTeamName                  BifrostContextKey = "bifrost-governance-team-name"         // string (to store the team name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyGovernanceCustomerID                BifrostContextKey = "bifrost-governance-customer-id"       // string (to store the customer ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyGovernanceCustomerName              BifrostContextKey = "bifrost-governance-customer-name"     // string (to store the customer name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyGovernanceUserID                    BifrostContextKey = "bifrost-governance-user-id"           // string (to store the user ID (set by enterprise governance plugin - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyGovernanceRoutingRuleID             BifrostContextKey = "bifrost-governance-routing-rule-id"   // string (to store the routing rule ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyGovernanceRoutingRuleName           BifrostContextKey = "bifrost-governance-routing-rule-name" // string (to store the routing rule name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyGovernanceIncludeOnlyKeys           BifrostContextKey = "bf-governance-include-only-keys"      // []string (to store the include-only key IDs for provider config routing (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyNumberOfRetries                     BifrostContextKey = "bifrost-number-of-retries"            // int (to store the number of retries (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyFallbackIndex                       BifrostContextKey = "bifrost-fallback-index"               // int (to store the fallback index (set by bifrost - DO NOT SET THIS MANUALLY)) 0 for primary, 1 for first fallback, etc.
-	BifrostContextKeyStreamEndIndicator                  BifrostContextKey = "bifrost-stream-end-indicator"         // bool (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyStreamIdleTimeout                   BifrostContextKey = "bifrost-stream-idle-timeout"          // time.Duration (per-chunk idle timeout for streaming)
-	BifrostContextKeySkipKeySelection                    BifrostContextKey = "bifrost-skip-key-selection"           // bool (will pass an empty key to the provider)
-	BifrostContextKeyExtraHeaders                        BifrostContextKey = "bifrost-extra-headers"                // map[string][]string
-	BifrostContextKeyURLPath                             BifrostContextKey = "bifrost-extra-url-path"               // string
-	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"
-	BifrostContextKeySendBackRawRequest                  BifrostContextKey = "bifrost-send-back-raw-request"                    // bool
-	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool
-	BifrostContextKeyIntegrationType                     BifrostContextKey = "bifrost-integration-type"                         // integration used in gateway (e.g. openai, anthropic, bedrock, etc.)
-	BifrostContextKeyIsResponsesToChatCompletionFallback BifrostContextKey = "bifrost-is-responses-to-chat-completion-fallback" // bool (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostMCPAgentOriginalRequestID                     BifrostContextKey = "bifrost-mcp-agent-original-request-id"            // string (to store the original request ID for MCP agent mode)
-	BifrostContextKeyParentMCPRequestID                  BifrostContextKey = "bf-parent-mcp-request-id"                         // string (parent request ID for nested tool calls from executeCode)
-	BifrostContextKeyStructuredOutputToolName            BifrostContextKey = "bifrost-structured-output-tool-name"              // string (to store the name of the structured output tool (set by bifrost))
-	BifrostContextKeyUserAgent                           BifrostContextKey = "bifrost-user-agent"                               // string (set by bifrost)
-	BifrostContextKeyTraceID                             BifrostContextKey = "bifrost-trace-id"                                 // string (trace ID for distributed tracing - set by tracing middleware)
-	BifrostContextKeySpanID                              BifrostContextKey = "bifrost-span-id"                                  // string (current span ID for child span creation - set by tracer)
-	BifrostContextKeyParentSpanID                        BifrostContextKey = "bifrost-parent-span-id"                           // string (parent span ID from W3C traceparent header - set by tracing middleware)
-	BifrostContextKeyStreamStartTime                     BifrostContextKey = "bifrost-stream-start-time"                        // time.Time (start time for streaming TTFT calculation - set by bifrost)
-	BifrostContextKeyTracer                              BifrostContextKey = "bifrost-tracer"                                   // Tracer (tracer instance for completing deferred spans - set by bifrost)
-	BifrostContextKeyDeferTraceCompletion                BifrostContextKey = "bifrost-defer-trace-completion"                   // bool (signals trace completion should be deferred for streaming - set by streaming handlers)
-	BifrostContextKeyTraceCompleter                      BifrostContextKey = "bifrost-trace-completer"                          // func() (callback to complete trace after streaming - set by tracing middleware)
-	BifrostContextKeyPostHookSpanFinalizer               BifrostContextKey = "bifrost-posthook-span-finalizer"                  // func(context.Context) (callback to finalize post-hook spans after streaming - set by bifrost)
-	BifrostContextKeyAccumulatorID                       BifrostContextKey = "bifrost-accumulator-id"                           // string (ID for streaming accumulator lookup - set by tracer for accumulator operations)
-	BifrostContextKeyHasEmittedMessageDelta              BifrostContextKey = "bifrost-has-emitted-message-delta"                 // bool (tracks whether message_delta was already emitted during streaming - avoids duplicates)
-	BifrostContextKeySkipDBUpdate                        BifrostContextKey = "bifrost-skip-db-update"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyGovernancePluginName                BifrostContextKey = "governance-plugin-name"                           // string (name of the governance plugin that processed the request - set by bifrost)
-	BifrostContextKeyIsEnterprise                        BifrostContextKey = "is-enterprise"                                    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyAvailableProviders                  BifrostContextKey = "available-providers"                              // []ModelProvider (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyRawRequestResponseForLogging        BifrostContextKey = "bifrost-raw-request-response-for-logging"         // bool (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyRetryDBFetch                        BifrostContextKey = "bifrost-retry-db-fetch"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyPassthroughExtraParams              BifrostContextKey = "bifrost-passthrough-extra-params"                 // bool
-	BifrostContextKeyRoutingEnginesUsed                  BifrostContextKey = "bifrost-routing-engines-used"                     // []string (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engines used ("routing-rule", "governance", "loadbalancing", etc.)
-	BifrostContextKeyRoutingEngineLogs                   BifrostContextKey = "bifrost-routing-engine-logs"                      // []RoutingEngineLogEntry (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engine log entries
-	BifrostContextKeySkipPluginPipeline                  BifrostContextKey = "bifrost-skip-plugin-pipeline"                     // bool - skip plugin pipeline for the request
-	BifrostIsAsyncRequest                                BifrostContextKey = "bifrost-is-async-request"                         // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an async request (only used in gateway)
-	BifrostContextKeyRequestHeaders                      BifrostContextKey = "bifrost-request-headers"                          // map[string]string (all request headers with lowercased keys)
-	BifrostContextKeySkipListModelsGovernanceFiltering   BifrostContextKey = "bifrost-skip-list-models-governance-filtering"    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeySCIMClaims                          BifrostContextKey = "scim_claims"
-	BifrostContextKeyUserID                              BifrostContextKey = "user_id"
-	BifrostContextKeyTargetUserID                        BifrostContextKey = "target_user_id"
-	BifrostContextKeyIsAzureUserAgent                    BifrostContextKey = "bifrost-is-azure-user-agent" // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an Azure user agent (only used in gateway)
-	BifrostContextKeyVideoOutputRequested                BifrostContextKey = "bifrost-video-output-requested"
-	BifrostContextKeyValidateKeys                        BifrostContextKey = "bifrost-validate-keys"                      // bool (triggers additional key validation during provider add/update)
-	BifrostContextKeyProviderResponseHeaders             BifrostContextKey = "bifrost-provider-response-headers"          // map[string]string (set by provider handlers for response header forwarding)
-	BifrostContextKeyLargePayloadMode                    BifrostContextKey = "bifrost-large-payload-mode"                 // bool (set by bifrost - DO NOT SET THIS MANUALLY)) indicates large payload streaming mode is active
-	BifrostContextKeyLargePayloadReader                  BifrostContextKey = "bifrost-large-payload-reader"               // io.Reader (set by bifrost - DO NOT SET THIS MANUALLY)) upstream reader for large payloads
-	BifrostContextKeyLargePayloadContentLength           BifrostContextKey = "bifrost-large-payload-content-length"       // int (set by bifrost - DO NOT SET THIS MANUALLY)) content length for large payloads
-	BifrostContextKeyLargePayloadContentType             BifrostContextKey = "bifrost-large-payload-content-type"         // string (set by enterprise - DO NOT SET THIS MANUALLY)) original content type for large payload passthrough
-	BifrostContextKeyLargePayloadMetadata                BifrostContextKey = "bifrost-large-payload-metadata"             // *LargePayloadMetadata (set by bifrost - DO NOT SET THIS MANUALLY)) routing metadata for large payloads
-	BifrostContextKeyLargePayloadRequestThreshold        BifrostContextKey = "bifrost-large-payload-request-threshold"    // int64 (set by enterprise - DO NOT SET THIS MANUALLY)) request threshold used by transport heuristics
-	BifrostContextKeyLargeResponseMode                   BifrostContextKey = "bifrost-large-response-mode"                // bool (set by bifrost - DO NOT SET THIS MANUALLY)) indicates large response streaming mode is active
-	BifrostContextKeyLargePayloadRequestPreview          BifrostContextKey = "bifrost-large-payload-request-preview"      // string (set by bifrost - DO NOT SET THIS MANUALLY)) truncated request body preview for logging
-	BifrostContextKeyLargePayloadResponsePreview         BifrostContextKey = "bifrost-large-payload-response-preview"     // string (set by bifrost - DO NOT SET THIS MANUALLY)) truncated response body preview for logging
-	BifrostContextKeyLargeResponseReader                 BifrostContextKey = "bifrost-large-response-reader"              // io.ReadCloser (set by bifrost - DO NOT SET THIS MANUALLY)) upstream reader for large responses
-	BifrostContextKeyLargeResponseContentLength          BifrostContextKey = "bifrost-large-response-content-length"      // int (set by bifrost - DO NOT SET THIS MANUALLY)) content length for large responses
-	BifrostContextKeyLargeResponseContentType            BifrostContextKey = "bifrost-large-response-content-type"        // string (set by bifrost - DO NOT SET THIS MANUALLY)) upstream content type for large responses
-	BifrostContextKeyLargeResponseContentDisposition     BifrostContextKey = "bifrost-large-response-content-disposition" // string (set by bifrost - DO NOT SET THIS MANUALLY)) downstream content disposition for large responses
-	BifrostContextKeyLargeResponseThreshold              BifrostContextKey = "bifrost-large-response-threshold"           // int64 (set by enterprise - DO NOT SET THIS MANUALLY)) threshold for response streaming
-	BifrostContextKeyLargePayloadPrefetchSize            BifrostContextKey = "bifrost-large-payload-prefetch-size"        // int (set by enterprise - DO NOT SET THIS MANUALLY)) prefetch buffer size for metadata extraction from large responses
-	BifrostContextKeyDeferredUsage                       BifrostContextKey = "bifrost-deferred-usage"                     // chan *BifrostLLMUsage (set by provider Phase B — delivers usage after response streaming completes)
-	BifrostContextKeyDeferredLargePayloadMetadata        BifrostContextKey = "bifrost-deferred-large-payload-metadata"    // <-chan *LargePayloadMetadata (set by enterprise Phase B request — delivers metadata after body streaming)
-	BifrostContextKeySSEReaderFactory                    BifrostContextKey = "bifrost-sse-reader-factory"                 // *providerUtils.SSEReaderFactory (set by enterprise — replaces default bufio.Scanner SSE readers with streaming readers)
-	BifrostContextKeySessionID                           BifrostContextKey = "bifrost-session-id"                         // string session ID for the request (session stickiness)
-	BifrostContextKeySessionTTL                          BifrostContextKey = "bifrost-session-ttl"                        // time.Duration session TTL for the request (session stickiness)
-	BifrostContextKeyMCPLogID                            BifrostContextKey = "bifrost-mcp-log-id"                         // string (unique UUID for each MCP tool log entry - set per goroutine by agent executor - DO NOT SET THIS MANUALLY)
+	BifrostContextKeySessionToken                            BifrostContextKey = "bifrost-session-token"                // string (session token for authentication - set by auth middleware)
+	BifrostContextKeyVirtualKey                              BifrostContextKey = "x-bf-vk"                              // string
+	BifrostContextKeyAPIKeyName                              BifrostContextKey = "x-bf-api-key"                         // string (explicit key name selection)
+	BifrostContextKeyAPIKeyID                                BifrostContextKey = "x-bf-api-key-id"                      // string (explicit key ID selection, takes priority over name)
+	BifrostContextKeyRequestID                               BifrostContextKey = "request-id"                           // string
+	BifrostContextKeyFallbackRequestID                       BifrostContextKey = "fallback-request-id"                  // string
+	BifrostContextKeyDirectKey                               BifrostContextKey = "bifrost-direct-key"                   // Key struct
+	BifrostContextKeySelectedKeyID                           BifrostContextKey = "bifrost-selected-key-id"              // string (to store the selected key ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeySelectedKeyName                         BifrostContextKey = "bifrost-selected-key-name"            // string (to store the selected key name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernanceVirtualKeyID                  BifrostContextKey = "bifrost-governance-virtual-key-id"    // string (to store the virtual key ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernanceVirtualKeyName                BifrostContextKey = "bifrost-governance-virtual-key-name"  // string (to store the virtual key name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernanceTeamID                        BifrostContextKey = "bifrost-governance-team-id"           // string (to store the team ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernanceTeamName                      BifrostContextKey = "bifrost-governance-team-name"         // string (to store the team name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernanceCustomerID                    BifrostContextKey = "bifrost-governance-customer-id"       // string (to store the customer ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernanceCustomerName                  BifrostContextKey = "bifrost-governance-customer-name"     // string (to store the customer name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernanceUserID                        BifrostContextKey = "bifrost-governance-user-id"           // string (to store the user ID (set by enterprise governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernanceRoutingRuleID                 BifrostContextKey = "bifrost-governance-routing-rule-id"   // string (to store the routing rule ID (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernanceRoutingRuleName               BifrostContextKey = "bifrost-governance-routing-rule-name" // string (to store the routing rule name (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernanceIncludeOnlyKeys               BifrostContextKey = "bf-governance-include-only-keys"      // []string (to store the include-only key IDs for provider config routing (set by bifrost governance plugin - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyNumberOfRetries                         BifrostContextKey = "bifrost-number-of-retries"            // int (to store the number of retries (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyFallbackIndex                           BifrostContextKey = "bifrost-fallback-index"               // int (to store the fallback index (set by bifrost - DO NOT SET THIS MANUALLY)) 0 for primary, 1 for first fallback, etc.
+	BifrostContextKeyStreamEndIndicator                      BifrostContextKey = "bifrost-stream-end-indicator"         // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyStreamIdleTimeout                       BifrostContextKey = "bifrost-stream-idle-timeout"          // time.Duration (per-chunk idle timeout for streaming)
+	BifrostContextKeySkipKeySelection                        BifrostContextKey = "bifrost-skip-key-selection"           // bool (will pass an empty key to the provider)
+	BifrostContextKeyExtraHeaders                            BifrostContextKey = "bifrost-extra-headers"                // map[string][]string
+	BifrostContextKeyURLPath                                 BifrostContextKey = "bifrost-extra-url-path"               // string
+	BifrostContextKeyUseRawRequestBody                       BifrostContextKey = "bifrost-use-raw-request-body"
+	BifrostContextKeySendBackRawRequest                      BifrostContextKey = "bifrost-send-back-raw-request"                        // bool
+	BifrostContextKeySendBackRawResponse                     BifrostContextKey = "bifrost-send-back-raw-response"                       // bool
+	BifrostContextKeyIntegrationType                         BifrostContextKey = "bifrost-integration-type"                             // integration used in gateway (e.g. openai, anthropic, bedrock, etc.)
+	BifrostContextKeyIsResponsesToChatCompletionFallback     BifrostContextKey = "bifrost-is-responses-to-chat-completion-fallback"     // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyResponsesToChatCompletionFallbackReason BifrostContextKey = "bifrost-responses-to-chat-completion-fallback-reason" // ResponsesToChatCompletionFallbackReason (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostMCPAgentOriginalRequestID                         BifrostContextKey = "bifrost-mcp-agent-original-request-id"                // string (to store the original request ID for MCP agent mode)
+	BifrostContextKeyParentMCPRequestID                      BifrostContextKey = "bf-parent-mcp-request-id"                             // string (parent request ID for nested tool calls from executeCode)
+	BifrostContextKeyStructuredOutputToolName                BifrostContextKey = "bifrost-structured-output-tool-name"                  // string (to store the name of the structured output tool (set by bifrost))
+	BifrostContextKeyUserAgent                               BifrostContextKey = "bifrost-user-agent"                                   // string (set by bifrost)
+	BifrostContextKeyTraceID                                 BifrostContextKey = "bifrost-trace-id"                                     // string (trace ID for distributed tracing - set by tracing middleware)
+	BifrostContextKeySpanID                                  BifrostContextKey = "bifrost-span-id"                                      // string (current span ID for child span creation - set by tracer)
+	BifrostContextKeyParentSpanID                            BifrostContextKey = "bifrost-parent-span-id"                               // string (parent span ID from W3C traceparent header - set by tracing middleware)
+	BifrostContextKeyStreamStartTime                         BifrostContextKey = "bifrost-stream-start-time"                            // time.Time (start time for streaming TTFT calculation - set by bifrost)
+	BifrostContextKeyTracer                                  BifrostContextKey = "bifrost-tracer"                                       // Tracer (tracer instance for completing deferred spans - set by bifrost)
+	BifrostContextKeyDeferTraceCompletion                    BifrostContextKey = "bifrost-defer-trace-completion"                       // bool (signals trace completion should be deferred for streaming - set by streaming handlers)
+	BifrostContextKeyTraceCompleter                          BifrostContextKey = "bifrost-trace-completer"                              // func() (callback to complete trace after streaming - set by tracing middleware)
+	BifrostContextKeyPostHookSpanFinalizer                   BifrostContextKey = "bifrost-posthook-span-finalizer"                      // func(context.Context) (callback to finalize post-hook spans after streaming - set by bifrost)
+	BifrostContextKeyAccumulatorID                           BifrostContextKey = "bifrost-accumulator-id"                               // string (ID for streaming accumulator lookup - set by tracer for accumulator operations)
+	BifrostContextKeyHasEmittedMessageDelta                  BifrostContextKey = "bifrost-has-emitted-message-delta"                    // bool (tracks whether message_delta was already emitted during streaming - avoids duplicates)
+	BifrostContextKeySkipDBUpdate                            BifrostContextKey = "bifrost-skip-db-update"                               // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyGovernancePluginName                    BifrostContextKey = "governance-plugin-name"                               // string (name of the governance plugin that processed the request - set by bifrost)
+	BifrostContextKeyIsEnterprise                            BifrostContextKey = "is-enterprise"                                        // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyAvailableProviders                      BifrostContextKey = "available-providers"                                  // []ModelProvider (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyRawRequestResponseForLogging            BifrostContextKey = "bifrost-raw-request-response-for-logging"             // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyRetryDBFetch                            BifrostContextKey = "bifrost-retry-db-fetch"                               // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyIsCustomProvider                        BifrostContextKey = "bifrost-is-custom-provider"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyCustomProviderMetadata                  BifrostContextKey = "bifrost-custom-provider-metadata"                     // *CustomProviderContextMetadata (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyCustomProviderConfig                    BifrostContextKey = "bifrost-custom-provider-config"                       // *CustomProviderConfig (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyResponsesToChatCompletionCompatState    BifrostContextKey = "bifrost-responses-to-chat-completion-compat-state"    // *ResponsesToChatCompletionCompatState (set by bifrost/plugins - DO NOT SET THIS MANUALLY)
+	BifrostContextKeyHTTPRequestType                         BifrostContextKey = "bifrost-http-request-type"                            // RequestType (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyPassthroughExtraParams                  BifrostContextKey = "bifrost-passthrough-extra-params"                     // bool
+	BifrostContextKeyRoutingEnginesUsed                      BifrostContextKey = "bifrost-routing-engines-used"                         // []string (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engines used ("routing-rule", "governance", "loadbalancing", etc.)
+	BifrostContextKeyRoutingEngineLogs                       BifrostContextKey = "bifrost-routing-engine-logs"                          // []RoutingEngineLogEntry (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engine log entries
+	BifrostContextKeySkipPluginPipeline                      BifrostContextKey = "bifrost-skip-plugin-pipeline"                         // bool - skip plugin pipeline for the request
+	BifrostIsAsyncRequest                                    BifrostContextKey = "bifrost-is-async-request"                             // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an async request (only used in gateway)
+	BifrostContextKeyRequestHeaders                          BifrostContextKey = "bifrost-request-headers"                              // map[string]string (all request headers with lowercased keys)
+	BifrostContextKeySkipListModelsGovernanceFiltering       BifrostContextKey = "bifrost-skip-list-models-governance-filtering"        // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeySCIMClaims                              BifrostContextKey = "scim_claims"
+	BifrostContextKeyUserID                                  BifrostContextKey = "user_id"
+	BifrostContextKeyTargetUserID                            BifrostContextKey = "target_user_id"
+	BifrostContextKeyIsAzureUserAgent                        BifrostContextKey = "bifrost-is-azure-user-agent" // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an Azure user agent (only used in gateway)
+	BifrostContextKeyVideoOutputRequested                    BifrostContextKey = "bifrost-video-output-requested"
+	BifrostContextKeyValidateKeys                            BifrostContextKey = "bifrost-validate-keys"                      // bool (triggers additional key validation during provider add/update)
+	BifrostContextKeyProviderResponseHeaders                 BifrostContextKey = "bifrost-provider-response-headers"          // map[string]string (set by provider handlers for response header forwarding)
+	BifrostContextKeyLargePayloadMode                        BifrostContextKey = "bifrost-large-payload-mode"                 // bool (set by bifrost - DO NOT SET THIS MANUALLY)) indicates large payload streaming mode is active
+	BifrostContextKeyLargePayloadReader                      BifrostContextKey = "bifrost-large-payload-reader"               // io.Reader (set by bifrost - DO NOT SET THIS MANUALLY)) upstream reader for large payloads
+	BifrostContextKeyLargePayloadContentLength               BifrostContextKey = "bifrost-large-payload-content-length"       // int (set by bifrost - DO NOT SET THIS MANUALLY)) content length for large payloads
+	BifrostContextKeyLargePayloadContentType                 BifrostContextKey = "bifrost-large-payload-content-type"         // string (set by enterprise - DO NOT SET THIS MANUALLY)) original content type for large payload passthrough
+	BifrostContextKeyLargePayloadMetadata                    BifrostContextKey = "bifrost-large-payload-metadata"             // *LargePayloadMetadata (set by bifrost - DO NOT SET THIS MANUALLY)) routing metadata for large payloads
+	BifrostContextKeyLargePayloadRequestThreshold            BifrostContextKey = "bifrost-large-payload-request-threshold"    // int64 (set by enterprise - DO NOT SET THIS MANUALLY)) request threshold used by transport heuristics
+	BifrostContextKeyLargeResponseMode                       BifrostContextKey = "bifrost-large-response-mode"                // bool (set by bifrost - DO NOT SET THIS MANUALLY)) indicates large response streaming mode is active
+	BifrostContextKeyLargePayloadRequestPreview              BifrostContextKey = "bifrost-large-payload-request-preview"      // string (set by bifrost - DO NOT SET THIS MANUALLY)) truncated request body preview for logging
+	BifrostContextKeyLargePayloadResponsePreview             BifrostContextKey = "bifrost-large-payload-response-preview"     // string (set by bifrost - DO NOT SET THIS MANUALLY)) truncated response body preview for logging
+	BifrostContextKeyLargeResponseReader                     BifrostContextKey = "bifrost-large-response-reader"              // io.ReadCloser (set by bifrost - DO NOT SET THIS MANUALLY)) upstream reader for large responses
+	BifrostContextKeyLargeResponseContentLength              BifrostContextKey = "bifrost-large-response-content-length"      // int (set by bifrost - DO NOT SET THIS MANUALLY)) content length for large responses
+	BifrostContextKeyLargeResponseContentType                BifrostContextKey = "bifrost-large-response-content-type"        // string (set by bifrost - DO NOT SET THIS MANUALLY)) upstream content type for large responses
+	BifrostContextKeyLargeResponseContentDisposition         BifrostContextKey = "bifrost-large-response-content-disposition" // string (set by bifrost - DO NOT SET THIS MANUALLY)) downstream content disposition for large responses
+	BifrostContextKeyLargeResponseThreshold                  BifrostContextKey = "bifrost-large-response-threshold"           // int64 (set by enterprise - DO NOT SET THIS MANUALLY)) threshold for response streaming
+	BifrostContextKeyLargePayloadPrefetchSize                BifrostContextKey = "bifrost-large-payload-prefetch-size"        // int (set by enterprise - DO NOT SET THIS MANUALLY)) prefetch buffer size for metadata extraction from large responses
+	BifrostContextKeyDeferredUsage                           BifrostContextKey = "bifrost-deferred-usage"                     // chan *BifrostLLMUsage (set by provider Phase B — delivers usage after response streaming completes)
+	BifrostContextKeyDeferredLargePayloadMetadata            BifrostContextKey = "bifrost-deferred-large-payload-metadata"    // <-chan *LargePayloadMetadata (set by enterprise Phase B request — delivers metadata after body streaming)
+	BifrostContextKeySSEReaderFactory                        BifrostContextKey = "bifrost-sse-reader-factory"                 // *providerUtils.SSEReaderFactory (set by enterprise — replaces default bufio.Scanner SSE readers with streaming readers)
+	BifrostContextKeySessionID                               BifrostContextKey = "bifrost-session-id"                         // string session ID for the request (session stickiness)
+	BifrostContextKeySessionTTL                              BifrostContextKey = "bifrost-session-ttl"                        // time.Duration session TTL for the request (session stickiness)
+	BifrostContextKeyMCPLogID                                BifrostContextKey = "bifrost-mcp-log-id"                         // string (unique UUID for each MCP tool log entry - set per goroutine by agent executor - DO NOT SET THIS MANUALLY)
 )
 
 const (
@@ -697,6 +702,157 @@ type BifrostResponse struct {
 	PassthroughResponse           *BifrostPassthroughResponse
 }
 
+type ResponsesToChatCompletionFallbackReason string
+
+const (
+	ResponsesToChatCompletionFallbackReasonConfiguredUnsupported ResponsesToChatCompletionFallbackReason = "configured_unsupported"
+	ResponsesToChatCompletionFallbackReasonRuntimeUnsupported    ResponsesToChatCompletionFallbackReason = "runtime_unsupported"
+)
+
+type CustomProviderContextMetadata struct {
+	ProviderKey          ModelProvider
+	BaseProviderType     ModelProvider
+	SupportsResponsesAPI *bool
+}
+
+type ResponsesToChatCompletionRetryPolicy struct {
+	UnsupportedStatusCodes     []int
+	UnsupportedErrorSubstrings []string
+}
+
+type ResponsesToChatCompletionCompatState struct {
+	OriginalRequestType RequestType
+	OriginalModel       string
+	IsStreaming         bool
+	RetryEligible       bool
+	RetryPolicy         *ResponsesToChatCompletionRetryPolicy
+	Active              bool
+	FallbackReason      ResponsesToChatCompletionFallbackReason
+	FallbackRequest     *BifrostRequest
+	Warnings            []string
+}
+
+func GetCustomProviderContextMetadata(ctx context.Context) (*CustomProviderContextMetadata, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+
+	metadata, ok := ctx.Value(BifrostContextKeyCustomProviderMetadata).(*CustomProviderContextMetadata)
+	if !ok || metadata == nil {
+		return nil, false
+	}
+
+	return metadata, true
+}
+
+func SetResponsesToChatCompletionCompatState(ctx *BifrostContext, state *ResponsesToChatCompletionCompatState) {
+	if ctx == nil {
+		return
+	}
+
+	if state == nil {
+		ctx.ClearValue(BifrostContextKeyResponsesToChatCompletionCompatState)
+		return
+	}
+
+	ctx.SetValue(BifrostContextKeyResponsesToChatCompletionCompatState, state)
+}
+
+func ClearResponsesToChatCompletionCompatState(ctx *BifrostContext) {
+	if ctx == nil {
+		return
+	}
+
+	ctx.ClearValue(BifrostContextKeyResponsesToChatCompletionCompatState)
+}
+
+func GetResponsesToChatCompletionCompatState(ctx context.Context) (*ResponsesToChatCompletionCompatState, bool) {
+	if ctx == nil {
+		return nil, false
+	}
+
+	state, ok := ctx.Value(BifrostContextKeyResponsesToChatCompletionCompatState).(*ResponsesToChatCompletionCompatState)
+	if !ok || state == nil {
+		return nil, false
+	}
+
+	return state, true
+}
+
+func ActivateResponsesToChatCompletionCompatState(ctx *BifrostContext, reason ResponsesToChatCompletionFallbackReason) (*ResponsesToChatCompletionCompatState, bool) {
+	state, ok := GetResponsesToChatCompletionCompatState(ctx)
+	if !ok || state == nil {
+		return nil, false
+	}
+
+	state.Active = true
+	state.RetryEligible = false
+	state.FallbackReason = reason
+	SetResponsesToChatCompletionFallback(ctx, reason)
+
+	return state, true
+}
+
+func SetResponsesToChatCompletionFallback(ctx *BifrostContext, reason ResponsesToChatCompletionFallbackReason) {
+	if ctx == nil {
+		return
+	}
+
+	ctx.SetValue(BifrostContextKeyIsResponsesToChatCompletionFallback, true)
+	if reason == "" {
+		ctx.ClearValue(BifrostContextKeyResponsesToChatCompletionFallbackReason)
+		return
+	}
+	ctx.SetValue(BifrostContextKeyResponsesToChatCompletionFallbackReason, reason)
+}
+
+func ClearResponsesToChatCompletionFallback(ctx *BifrostContext) {
+	if ctx == nil {
+		return
+	}
+
+	ctx.ClearValue(BifrostContextKeyIsResponsesToChatCompletionFallback)
+	ctx.ClearValue(BifrostContextKeyResponsesToChatCompletionFallbackReason)
+}
+
+func GetResponsesToChatCompletionFallback(ctx context.Context) (ResponsesToChatCompletionFallbackReason, bool) {
+	if ctx == nil {
+		return "", false
+	}
+
+	isFallback, ok := ctx.Value(BifrostContextKeyIsResponsesToChatCompletionFallback).(bool)
+	if !ok || !isFallback {
+		return "", false
+	}
+
+	switch reason := ctx.Value(BifrostContextKeyResponsesToChatCompletionFallbackReason).(type) {
+	case ResponsesToChatCompletionFallbackReason:
+		return reason, true
+	case string:
+		return ResponsesToChatCompletionFallbackReason(reason), true
+	default:
+		return "", true
+	}
+}
+
+func ApplyResponsesToChatCompletionFallbackMetadata(ctx context.Context, response *BifrostResponse, bifrostErr *BifrostError) {
+	reason, ok := GetResponsesToChatCompletionFallback(ctx)
+	if !ok {
+		return
+	}
+
+	if response != nil {
+		extraFields := response.GetExtraFields()
+		extraFields.ResponsesToChatCompletionFallback = true
+		extraFields.ResponsesToChatCompletionFallbackReason = string(reason)
+	}
+
+	if bifrostErr != nil {
+		bifrostErr.ExtraFields.ResponsesToChatCompletionFallback = true
+		bifrostErr.ExtraFields.ResponsesToChatCompletionFallbackReason = string(reason)
+	}
+}
+
 func (r *BifrostResponse) GetExtraFields() *BifrostResponseExtraFields {
 	switch {
 	case r.ListModelsResponse != nil:
@@ -796,18 +952,20 @@ type BifrostMCPResponse struct {
 
 // BifrostResponseExtraFields contains additional fields in a response.
 type BifrostResponseExtraFields struct {
-	RequestType             RequestType        `json:"request_type"`
-	Provider                ModelProvider      `json:"provider,omitempty"`
-	ModelRequested          string             `json:"model_requested,omitempty"`
-	ModelDeployment         string             `json:"model_deployment,omitempty"` // only present for providers which use model deployments (e.g. Azure, Bedrock)
-	Latency                 int64              `json:"latency"`                    // in milliseconds (for streaming responses this will be each chunk latency, and the last chunk latency will be the total latency)
-	ChunkIndex              int                `json:"chunk_index"`                // used for streaming responses to identify the chunk index, will be 0 for non-streaming responses
-	RawRequest              interface{}        `json:"raw_request,omitempty"`
-	RawResponse             interface{}        `json:"raw_response,omitempty"`
-	CacheDebug              *BifrostCacheDebug `json:"cache_debug,omitempty"`
-	ParseErrors             []BatchError       `json:"parse_errors,omitempty"` // errors encountered while parsing JSONL batch results
-	LiteLLMCompat           bool               `json:"litellm_compat,omitempty"`
-	ProviderResponseHeaders map[string]string  `json:"provider_response_headers,omitempty"` // HTTP response headers from the provider (filtered to exclude transport-level headers)
+	RequestType                             RequestType        `json:"request_type"`
+	Provider                                ModelProvider      `json:"provider,omitempty"`
+	ModelRequested                          string             `json:"model_requested,omitempty"`
+	ModelDeployment                         string             `json:"model_deployment,omitempty"` // only present for providers which use model deployments (e.g. Azure, Bedrock)
+	Latency                                 int64              `json:"latency"`                    // in milliseconds (for streaming responses this will be each chunk latency, and the last chunk latency will be the total latency)
+	ChunkIndex                              int                `json:"chunk_index"`                // used for streaming responses to identify the chunk index, will be 0 for non-streaming responses
+	RawRequest                              interface{}        `json:"raw_request,omitempty"`
+	RawResponse                             interface{}        `json:"raw_response,omitempty"`
+	CacheDebug                              *BifrostCacheDebug `json:"cache_debug,omitempty"`
+	ParseErrors                             []BatchError       `json:"parse_errors,omitempty"` // errors encountered while parsing JSONL batch results
+	LiteLLMCompat                           bool               `json:"litellm_compat,omitempty"`
+	ResponsesToChatCompletionFallback       bool               `json:"responses_to_chat_completion_fallback,omitempty"`
+	ResponsesToChatCompletionFallbackReason string             `json:"responses_to_chat_completion_fallback_reason,omitempty"`
+	ProviderResponseHeaders                 map[string]string  `json:"provider_response_headers,omitempty"` // HTTP response headers from the provider (filtered to exclude transport-level headers)
 }
 
 type BifrostMCPResponseExtraFields struct {
@@ -968,11 +1126,13 @@ func (e *ErrorField) UnmarshalJSON(data []byte) error {
 
 // BifrostErrorExtraFields contains additional fields in an error response.
 type BifrostErrorExtraFields struct {
-	Provider       ModelProvider `json:"provider,omitempty"`
-	ModelRequested string        `json:"model_requested,omitempty"`
-	RequestType    RequestType   `json:"request_type,omitempty"`
-	RawRequest     interface{}   `json:"raw_request,omitempty"`
-	RawResponse    interface{}   `json:"raw_response,omitempty"`
-	LiteLLMCompat  bool          `json:"litellm_compat,omitempty"`
-	KeyStatuses    []KeyStatus   `json:"key_statuses,omitempty"`
+	Provider                                ModelProvider `json:"provider,omitempty"`
+	ModelRequested                          string        `json:"model_requested,omitempty"`
+	RequestType                             RequestType   `json:"request_type,omitempty"`
+	RawRequest                              interface{}   `json:"raw_request,omitempty"`
+	RawResponse                             interface{}   `json:"raw_response,omitempty"`
+	LiteLLMCompat                           bool          `json:"litellm_compat,omitempty"`
+	ResponsesToChatCompletionFallback       bool          `json:"responses_to_chat_completion_fallback,omitempty"`
+	ResponsesToChatCompletionFallbackReason string        `json:"responses_to_chat_completion_fallback_reason,omitempty"`
+	KeyStatuses                             []KeyStatus   `json:"key_statuses,omitempty"`
 }

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 	"sync"
@@ -1025,11 +1026,18 @@ func (brr *BifrostResponsesRequest) ToChatRequest() *BifrostChatRequest {
 			Temperature:       brr.Params.Temperature,
 			TopLogProbs:       brr.Params.TopLogProbs,
 			TopP:              brr.Params.TopP,
+			User:              brr.Params.User,
 			ExtraParams:       brr.Params.ExtraParams,
 
 			// Map specific fields
 			MaxCompletionTokens: brr.Params.MaxOutputTokens, // max_output_tokens -> max_completion_tokens
 			Metadata:            brr.Params.Metadata,
+		}
+
+		if brr.Params.Text != nil && brr.Params.Text.Format != nil && brr.Params.Text.Format.Type != "" && brr.Params.Text.Format.Type != "text" {
+			if responseFormat, err := ConvertViaJSON[interface{}](brr.Params.Text.Format); err == nil {
+				bcr.Params.ResponseFormat = &responseFormat
+			}
 		}
 
 		// Convert StreamOptions
@@ -1066,6 +1074,124 @@ func (brr *BifrostResponsesRequest) ToChatRequest() *BifrostChatRequest {
 	bcr.RawRequestBody = brr.RawRequestBody
 
 	return bcr
+}
+
+// ToChatFallbackRequest is the compatibility seam for Responses -> Chat fallback.
+// Keep fallback-specific request shaping behind this method so schema evolution has a
+// single place to update. This bridge is best-effort rather than fully lossless.
+func (brr *BifrostResponsesRequest) ToChatFallbackRequest() *BifrostChatRequest {
+	return brr.ToChatRequest()
+}
+
+// ChatFallbackWarnings returns known caveats for Responses -> Chat fallback.
+// It intentionally reports only request features that are dropped or normalized today.
+func (brr *BifrostResponsesRequest) ChatFallbackWarnings() []string {
+	if brr == nil {
+		return nil
+	}
+
+	warnings := make([]string, 0, 5)
+
+	for _, input := range brr.Input {
+		if input.Type != nil && *input.Type == ResponsesMessageTypeReasoning {
+			warnings = append(warnings, "reasoning input items are dropped during Responses to Chat fallback")
+			break
+		}
+	}
+
+	for _, input := range brr.Input {
+		if input.Role != nil && *input.Role == ResponsesInputMessageRoleDeveloper {
+			warnings = append(warnings, "developer role is normalized to system during Responses to Chat fallback")
+			break
+		}
+	}
+
+	if brr.Params == nil {
+		return warnings
+	}
+
+	for _, tool := range brr.Params.Tools {
+		if tool.Type != ResponsesToolTypeFunction {
+			warnings = append(warnings, "non-function tools are dropped during Responses to Chat fallback")
+			break
+		}
+	}
+
+	if brr.Params.ToolChoice != nil && brr.Params.ToolChoice.ResponsesToolChoiceStruct != nil {
+		switch brr.Params.ToolChoice.ResponsesToolChoiceStruct.Type {
+		case ResponsesToolChoiceTypeAllowedTools, ResponsesToolChoiceTypeCustom:
+			warnings = append(warnings, fmt.Sprintf("tool_choice type %q is not preserved during Responses to Chat fallback", brr.Params.ToolChoice.ResponsesToolChoiceStruct.Type))
+		}
+	}
+
+	if brr.Params.Truncation != nil {
+		warnings = append(warnings, "responses truncation is not forwarded during Responses to Chat fallback")
+	}
+
+	return warnings
+}
+
+func DefaultResponsesToChatCompletionRetryPolicy() *ResponsesToChatCompletionRetryPolicy {
+	return &ResponsesToChatCompletionRetryPolicy{
+		UnsupportedStatusCodes: []int{
+			http.StatusNotFound,
+			http.StatusMethodNotAllowed,
+			http.StatusGone,
+			http.StatusNotImplemented,
+		},
+		UnsupportedErrorSubstrings: []string{
+			strings.ToLower(ErrProviderResponseHTML),
+			strings.ToLower(ErrProviderResponseUnmarshal),
+			strings.ToLower(ErrProviderResponseEmpty),
+		},
+	}
+}
+
+func (policy *ResponsesToChatCompletionRetryPolicy) ShouldRetry(err *BifrostError) bool {
+	if policy == nil || err == nil {
+		return false
+	}
+
+	if err.StatusCode != nil {
+		for _, statusCode := range policy.UnsupportedStatusCodes {
+			if *err.StatusCode == statusCode {
+				return true
+			}
+		}
+	}
+
+	if err.Error == nil {
+		return false
+	}
+
+	message := strings.ToLower(strings.TrimSpace(err.Error.Message))
+	for _, unsupportedMarker := range policy.UnsupportedErrorSubstrings {
+		if strings.Contains(message, unsupportedMarker) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (state *ResponsesToChatCompletionCompatState) ShouldRetry(err *BifrostError) bool {
+	if state == nil || !state.RetryEligible || state.RetryPolicy == nil {
+		return false
+	}
+
+	return state.RetryPolicy.ShouldRetry(err)
+}
+
+func ResponsesToChatCompletionFallbackErrorMessage(err *BifrostError) string {
+	if err == nil {
+		return "unknown responses API error"
+	}
+
+	if err.Error == nil {
+		return "unknown responses API error"
+	}
+
+	return err.Error.Message
 }
 
 func sanitizeResponsesToolsForChatFallback(tools []ResponsesTool) []ChatTool {

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -1,6 +1,10 @@
 package schemas
 
-import "testing"
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
 
 func TestToChatMessages_PreservesDeveloperRole(t *testing.T) {
 	messages := []ResponsesMessage{
@@ -251,6 +255,109 @@ func TestToChatRequest_PreservesStringToolChoiceAutoAndNone(t *testing.T) {
 				t.Fatalf("expected tool choice %q, got %q", choice, *chatReq.Params.ToolChoice.ChatToolChoiceStr)
 			}
 		})
+	}
+}
+
+func TestToChatFallbackRequest_PreservesUserAndStructuredOutputFormat(t *testing.T) {
+	user := "user-123"
+	verbosity := "high"
+	formatType := "json_schema"
+	schemaType := "object"
+	req := &BifrostResponsesRequest{
+		Params: &ResponsesParameters{
+			User: &user,
+			Text: &ResponsesTextConfig{
+				Verbosity: &verbosity,
+				Format: &ResponsesTextConfigFormat{
+					Type: formatType,
+					JSONSchema: &ResponsesTextConfigFormatJSONSchema{
+						Type: &schemaType,
+					},
+				},
+			},
+		},
+	}
+
+	chatReq := req.ToChatFallbackRequest()
+	if chatReq == nil || chatReq.Params == nil {
+		t.Fatal("expected non-nil chat fallback request params")
+	}
+	if chatReq.Params.User == nil || *chatReq.Params.User != user {
+		t.Fatalf("expected user %q to be preserved, got %+v", user, chatReq.Params.User)
+	}
+	if chatReq.Params.ResponseFormat == nil {
+		t.Fatal("expected structured output format to be forwarded")
+	}
+	if chatReq.Params.Verbosity == nil || *chatReq.Params.Verbosity != verbosity {
+		t.Fatalf("expected verbosity %q to be preserved, got %+v", verbosity, chatReq.Params.Verbosity)
+	}
+	responseFormat, ok := (*chatReq.Params.ResponseFormat).(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected response_format to be a map, got %T", *chatReq.Params.ResponseFormat)
+	}
+	if got, _ := responseFormat["type"].(string); got != formatType {
+		t.Fatalf("expected response_format type %q, got %q", formatType, got)
+	}
+}
+
+func TestChatFallbackWarnings_ReportsDroppedCompatibilityFeatures(t *testing.T) {
+	truncation := "auto"
+	developer := ResponsesInputMessageRoleDeveloper
+	choiceType := ResponsesToolChoiceTypeAllowedTools
+	req := &BifrostResponsesRequest{
+		Input: []ResponsesMessage{{Role: &developer}},
+		Params: &ResponsesParameters{
+			Truncation: &truncation,
+			Tools:      []ResponsesTool{{Type: ResponsesToolTypeWebSearch, Name: Ptr("search")}},
+			ToolChoice: &ResponsesToolChoice{
+				ResponsesToolChoiceStruct: &ResponsesToolChoiceStruct{Type: choiceType},
+			},
+		},
+	}
+
+	warnings := req.ChatFallbackWarnings()
+	if len(warnings) < 3 {
+		t.Fatalf("expected multiple compatibility warnings, got %#v", warnings)
+	}
+
+	joined := strings.Join(warnings, "\n")
+	if !containsWarning(joined, "developer role") {
+		t.Fatalf("expected developer-role warning, got %#v", warnings)
+	}
+	if !containsWarning(joined, "non-function tools") {
+		t.Fatalf("expected tool warning, got %#v", warnings)
+	}
+	if !containsWarning(joined, "tool_choice type") {
+		t.Fatalf("expected tool_choice warning, got %#v", warnings)
+	}
+	if !containsWarning(joined, "truncation") {
+		t.Fatalf("expected truncation warning, got %#v", warnings)
+	}
+}
+
+func containsWarning(joined string, fragment string) bool {
+	return strings.Contains(joined, fragment)
+}
+
+func TestDefaultResponsesToChatCompletionRetryPolicy_UsesUnsupportedEndpointSignals(t *testing.T) {
+	policy := DefaultResponsesToChatCompletionRetryPolicy()
+	if policy == nil {
+		t.Fatal("expected default retry policy")
+	}
+
+	notFound := http.StatusNotFound
+	if !policy.ShouldRetry(&BifrostError{StatusCode: &notFound}) {
+		t.Fatal("expected 404 to trigger runtime fallback retry")
+	}
+
+	unsupportedResponseErr := &BifrostError{Error: &ErrorField{Message: ErrProviderResponseHTML}}
+	if !policy.ShouldRetry(unsupportedResponseErr) {
+		t.Fatal("expected provider HTML response marker to trigger runtime fallback retry")
+	}
+
+	unauthorized := http.StatusUnauthorized
+	if policy.ShouldRetry(&BifrostError{StatusCode: &unauthorized}) {
+		t.Fatal("expected 401 to remain a hard failure")
 	}
 }
 

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -8,18 +8,18 @@ import (
 )
 
 const (
-	DefaultMaxRetries              = 0
-	DefaultRetryBackoffInitial     = 500 * time.Millisecond
-	DefaultRetryBackoffMax         = 5 * time.Second
+	DefaultMaxRetries                 = 0
+	DefaultRetryBackoffInitial        = 500 * time.Millisecond
+	DefaultRetryBackoffMax            = 5 * time.Second
 	DefaultRequestTimeoutInSeconds    = 30
-	DefaultMaxConnDurationInSeconds  = 300 // 5 minutes — forces connection recycling to prevent stale connections from NAT/LB silent drops
-	DefaultBufferSize                = 5000
-	DefaultConcurrency             = 1000
-	DefaultStreamBufferSize              = 256
-	DefaultStreamIdleTimeoutInSeconds    = 60 // Idle timeout per stream chunk — if no data for this many seconds, bifrost closes the connection
-	DefaultMaxConnsPerHost               = 5000
-	MaxConnsPerHostUpperBound            = 10000
-	DefaultMaxIdleConnsPerHost           = 40
+	DefaultMaxConnDurationInSeconds   = 300 // 5 minutes — forces connection recycling to prevent stale connections from NAT/LB silent drops
+	DefaultBufferSize                 = 5000
+	DefaultConcurrency                = 1000
+	DefaultStreamBufferSize           = 256
+	DefaultStreamIdleTimeoutInSeconds = 60 // Idle timeout per stream chunk — if no data for this many seconds, bifrost closes the connection
+	DefaultMaxConnsPerHost            = 5000
+	MaxConnsPerHostUpperBound         = 10000
+	DefaultMaxIdleConnsPerHost        = 40
 )
 
 // Pre-defined errors for provider operations
@@ -52,18 +52,18 @@ const (
 //   - When marshaling to JSON: a time.Duration is converted to milliseconds
 type NetworkConfig struct {
 	// BaseURL is supported for OpenAI, Anthropic, Cohere, Mistral, and Ollama providers (required for Ollama)
-	BaseURL                        string            `json:"base_url,omitempty"`                 // Base URL for the provider (optional)
-	ExtraHeaders                   map[string]string `json:"extra_headers,omitempty"`            // Additional headers to include in requests (optional)
-	DefaultRequestTimeoutInSeconds int               `json:"default_request_timeout_in_seconds"` // Default timeout for requests
-	MaxRetries                     int               `json:"max_retries"`                        // Maximum number of retries
-	RetryBackoffInitial            time.Duration     `json:"retry_backoff_initial"`              // Initial backoff duration (stored as nanoseconds, JSON as milliseconds)
-	RetryBackoffMax                time.Duration     `json:"retry_backoff_max"`                  // Maximum backoff duration (stored as nanoseconds, JSON as milliseconds)
-	InsecureSkipVerify             bool              `json:"insecure_skip_verify,omitempty"`     // Disables TLS certificate verification for provider connections
-	CACertPEM                      string            `json:"ca_cert_pem,omitempty"`              // PEM-encoded CA certificate to trust for provider endpoint connections
+	BaseURL                        string            `json:"base_url,omitempty"`                       // Base URL for the provider (optional)
+	ExtraHeaders                   map[string]string `json:"extra_headers,omitempty"`                  // Additional headers to include in requests (optional)
+	DefaultRequestTimeoutInSeconds int               `json:"default_request_timeout_in_seconds"`       // Default timeout for requests
+	MaxRetries                     int               `json:"max_retries"`                              // Maximum number of retries
+	RetryBackoffInitial            time.Duration     `json:"retry_backoff_initial"`                    // Initial backoff duration (stored as nanoseconds, JSON as milliseconds)
+	RetryBackoffMax                time.Duration     `json:"retry_backoff_max"`                        // Maximum backoff duration (stored as nanoseconds, JSON as milliseconds)
+	InsecureSkipVerify             bool              `json:"insecure_skip_verify,omitempty"`           // Disables TLS certificate verification for provider connections
+	CACertPEM                      string            `json:"ca_cert_pem,omitempty"`                    // PEM-encoded CA certificate to trust for provider endpoint connections
 	StreamIdleTimeoutInSeconds     int               `json:"stream_idle_timeout_in_seconds,omitempty"` // Idle timeout per stream chunk (0 = use default 60s)
-	MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`              // Max TCP connections per provider host (default: 5000)
-	EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`                   // Force HTTP/2 on provider connections (relevant for net/http-based providers like Bedrock)
-	BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`           // Override default beta header support per provider (keys are prefixes like "redact-thinking-")
+	MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`             // Max TCP connections per provider host (default: 5000)
+	EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`                  // Force HTTP/2 on provider connections (relevant for net/http-based providers like Bedrock)
+	BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`          // Override default beta header support per provider (keys are prefixes like "redact-thinking-")
 }
 
 // UnmarshalJSON customizes JSON unmarshaling for NetworkConfig.
@@ -405,6 +405,7 @@ type CustomProviderConfig struct {
 	CustomProviderKey    string                 `json:"-"`                                // Custom provider key, internally set by Bifrost
 	IsKeyLess            bool                   `json:"is_key_less"`                      // Whether the custom provider requires a key (not allowed for Bedrock)
 	BaseProviderType     ModelProvider          `json:"base_provider_type"`               // Base provider type
+	SupportsResponsesAPI *bool                  `json:"supports_responses_api,omitempty"` // Whether the upstream provider supports the native OpenAI Responses API (true = force native, false = force chat fallback, nil = try native first and auto-fallback on obvious unsupported-endpoint failures)
 	AllowedRequests      *AllowedRequests       `json:"allowed_requests,omitempty"`       // Allowed requests for the custom provider
 	RequestPathOverrides map[RequestType]string `json:"request_path_overrides,omitempty"` // Mapping of request type to its custom path which will override the default path of the provider (not allowed for Bedrock)
 }
@@ -485,14 +486,14 @@ type ProviderConfig struct {
 	NetworkConfig            NetworkConfig            `json:"network_config"`              // Network configuration
 	ConcurrencyAndBufferSize ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"` // Concurrency settings
 	// Logger instance, can be provided by the user or bifrost default logger is used if not provided
-	Logger               Logger                    `json:"-"`
-	ProxyConfig          *ProxyConfig              `json:"proxy_config,omitempty"` // Proxy configuration
-	SendBackRawRequest        bool                      `json:"send_back_raw_request"`         // Send raw request back in the bifrost response (default: false)
-	SendBackRawResponse       bool                      `json:"send_back_raw_response"`        // Send raw response back in the bifrost response (default: false)
-	StoreRawRequestResponse   bool                      `json:"store_raw_request_response"`    // Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)
-	CustomProviderConfig *CustomProviderConfig     `json:"custom_provider_config,omitempty"`
-	OpenAIConfig         *OpenAIConfig             `json:"openai_config,omitempty"`
-	PricingOverrides     []ProviderPricingOverride `json:"pricing_overrides,omitempty"`
+	Logger                  Logger                    `json:"-"`
+	ProxyConfig             *ProxyConfig              `json:"proxy_config,omitempty"`     // Proxy configuration
+	SendBackRawRequest      bool                      `json:"send_back_raw_request"`      // Send raw request back in the bifrost response (default: false)
+	SendBackRawResponse     bool                      `json:"send_back_raw_response"`     // Send raw response back in the bifrost response (default: false)
+	StoreRawRequestResponse bool                      `json:"store_raw_request_response"` // Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)
+	CustomProviderConfig    *CustomProviderConfig     `json:"custom_provider_config,omitempty"`
+	OpenAIConfig            *OpenAIConfig             `json:"openai_config,omitempty"`
+	PricingOverrides        []ProviderPricingOverride `json:"pricing_overrides,omitempty"`
 }
 
 // OpenAIConfig holds OpenAI-specific provider configuration.

--- a/framework/configstore/tables/routing_rules.go
+++ b/framework/configstore/tables/routing_rules.go
@@ -89,7 +89,7 @@ type TableRoutingTarget struct {
 	Provider *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"provider,omitempty"` // nil = use incoming provider
 	Model    *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"model,omitempty"`    // nil = use incoming model
 	KeyID    *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"key_id,omitempty"`   // nil = no key pin
-	Weight   float64 `gorm:"not null;default:1" json:"weight"`                                                  // must sum to 1 across all targets in a rule
+	Weight   float64 `gorm:"not null" json:"weight"`                                                      // must sum to 1 across all targets in a rule
 }
 
 // TableName for TableRoutingTarget

--- a/plugins/litellmcompat/main.go
+++ b/plugins/litellmcompat/main.go
@@ -83,9 +83,12 @@ func (p *LiteLLMCompatPlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostC
 // it converts them to chat completion requests.
 func (p *LiteLLMCompatPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
 	tc := &TransformContext{}
+	schemas.ClearResponsesToChatCompletionFallback(ctx)
+	schemas.ClearResponsesToChatCompletionCompatState(ctx)
 
 	// Apply request transforms in sequence
 	req = transformTextToChatRequest(ctx, req, tc, p.modelCatalog, p.logger)
+	req = transformResponsesToChatRequest(ctx, req, p.logger)
 
 	// Store the transform context for use in PostHook
 	ctx.SetValue(TransformContextKey, tc)
@@ -99,24 +102,30 @@ func (p *LiteLLMCompatPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schem
 func (p *LiteLLMCompatPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
 	// Retrieve the transform context
 	transformCtxValue := ctx.Value(TransformContextKey)
-	if transformCtxValue == nil {
-		return result, bifrostErr, nil
-	}
-	tc, ok := transformCtxValue.(*TransformContext)
-	if !ok || tc == nil {
-		return result, bifrostErr, nil
+	var tc *TransformContext
+	if transformCtxValue != nil {
+		transformCtx, ok := transformCtxValue.(*TransformContext)
+		if ok {
+			tc = transformCtx
+		}
 	}
 
 	// Apply response transforms in sequence
 	// Note: tool-call content runs before text-to-chat because text-to-chat may convert
 	// the response type, and tool-call content needs to operate on chat responses
 	if result != nil {
-		result = transformTextToChatResponse(ctx, result, tc, p.logger)
+		if tc != nil {
+			result = transformTextToChatResponse(ctx, result, tc, p.logger)
+		}
+		result = transformResponsesToChatResponse(ctx, result, p.logger)
 	}
 
 	// Transform error metadata if there's an error
 	if bifrostErr != nil {
-		bifrostErr = transformTextToChatError(ctx, bifrostErr, tc)
+		if tc != nil {
+			bifrostErr = transformTextToChatError(ctx, bifrostErr, tc)
+		}
+		bifrostErr = transformResponsesToChatError(ctx, bifrostErr)
 	}
 
 	return result, bifrostErr, nil

--- a/plugins/litellmcompat/responsestochat.go
+++ b/plugins/litellmcompat/responsestochat.go
@@ -1,0 +1,114 @@
+package litellmcompat
+
+import (
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// transformResponsesToChatRequest applies the Responses -> Chat compatibility bridge.
+// This path is intentionally best-effort rather than fully lossless; keep request shaping
+// behind schemas.ToChatFallbackRequest so schema evolution has one compatibility seam.
+func transformResponsesToChatRequest(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, logger schemas.Logger) *schemas.BifrostRequest {
+	if req.RequestType != schemas.ResponsesRequest && req.RequestType != schemas.ResponsesStreamRequest {
+		return req
+	}
+
+	if req.ResponsesRequest == nil {
+		return req
+	}
+
+	metadata, ok := schemas.GetCustomProviderContextMetadata(ctx)
+	if !ok || metadata == nil || metadata.BaseProviderType != schemas.OpenAI {
+		return req
+	}
+
+	if metadata.SupportsResponsesAPI != nil && *metadata.SupportsResponsesAPI {
+		return req
+	}
+
+	chatRequest := req.ResponsesRequest.ToChatFallbackRequest()
+	if chatRequest == nil {
+		return req
+	}
+
+	fallbackRequestType := schemas.ChatCompletionRequest
+	if req.RequestType == schemas.ResponsesStreamRequest {
+		fallbackRequestType = schemas.ChatCompletionStreamRequest
+	}
+
+	state := &schemas.ResponsesToChatCompletionCompatState{
+		OriginalRequestType: req.RequestType,
+		OriginalModel:       req.ResponsesRequest.Model,
+		IsStreaming:         req.RequestType == schemas.ResponsesStreamRequest,
+		FallbackRequest: &schemas.BifrostRequest{
+			RequestType: fallbackRequestType,
+			ChatRequest: chatRequest,
+		},
+		Warnings: req.ResponsesRequest.ChatFallbackWarnings(),
+	}
+	schemas.SetResponsesToChatCompletionCompatState(ctx, state)
+
+	if metadata.SupportsResponsesAPI == nil {
+		state.RetryEligible = true
+		state.RetryPolicy = schemas.DefaultResponsesToChatCompletionRetryPolicy()
+		return req
+	}
+
+	if _, activated := schemas.ActivateResponsesToChatCompletionCompatState(ctx, schemas.ResponsesToChatCompletionFallbackReasonConfiguredUnsupported); !activated {
+		return req
+	}
+	logResponsesToChatFallback(logger, state.OriginalModel, state.FallbackReason, state.Warnings)
+
+	return state.FallbackRequest
+}
+
+func transformResponsesToChatResponse(ctx *schemas.BifrostContext, resp *schemas.BifrostResponse, logger schemas.Logger) *schemas.BifrostResponse {
+	state, ok := schemas.GetResponsesToChatCompletionCompatState(ctx)
+	if !ok || state == nil || !state.Active || resp == nil || state.IsStreaming || resp.ChatResponse == nil {
+		return resp
+	}
+
+	responsesResponse := resp.ChatResponse.ToBifrostResponsesResponse()
+	if responsesResponse == nil {
+		return resp
+	}
+
+	responsesResponse.ExtraFields.RequestType = state.OriginalRequestType
+	responsesResponse.ExtraFields.ModelRequested = state.OriginalModel
+	responsesResponse.ExtraFields.LiteLLMCompat = true
+
+	if logger != nil {
+		logger.Debug("litellmcompat: converted chat response back to responses for model %s (reason=%s)", state.OriginalModel, state.FallbackReason)
+	}
+
+	return &schemas.BifrostResponse{
+		ResponsesResponse: responsesResponse,
+	}
+}
+
+func transformResponsesToChatError(ctx *schemas.BifrostContext, err *schemas.BifrostError) *schemas.BifrostError {
+	state, ok := schemas.GetResponsesToChatCompletionCompatState(ctx)
+	if !ok || state == nil || err == nil || !state.Active {
+		return err
+	}
+
+	err.ExtraFields.RequestType = state.OriginalRequestType
+	err.ExtraFields.ModelRequested = state.OriginalModel
+	err.ExtraFields.LiteLLMCompat = true
+
+	return err
+}
+
+func logResponsesToChatFallback(logger schemas.Logger, model string, reason schemas.ResponsesToChatCompletionFallbackReason, warnings []string) {
+	if logger == nil {
+		return
+	}
+
+	logger.Info("litellmcompat: applied responses->chat completion fallback for model %s (reason=%s)", model, reason)
+	if len(warnings) == 0 {
+		return
+	}
+
+	logger.Warn("litellmcompat: responses->chat completion fallback for model %s is compatibility-only: %s", model, strings.Join(warnings, "; "))
+}

--- a/plugins/litellmcompat/responsestochat_test.go
+++ b/plugins/litellmcompat/responsestochat_test.go
@@ -1,0 +1,199 @@
+package litellmcompat
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func testResponsesCompatRequest(requestType schemas.RequestType) *schemas.BifrostRequest {
+	content := "hello"
+	return &schemas.BifrostRequest{
+		RequestType: requestType,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Provider: schemas.ModelProvider("lmstudio"),
+			Model:    "test-model",
+			Input: []schemas.ResponsesMessage{{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: &content,
+				},
+			}},
+			Params: &schemas.ResponsesParameters{
+				MaxOutputTokens: schemas.Ptr(7),
+			},
+		},
+	}
+}
+
+func testResponsesCompatContext() *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyCustomProviderMetadata, &schemas.CustomProviderContextMetadata{
+		ProviderKey:          "lmstudio",
+		BaseProviderType:     schemas.OpenAI,
+		SupportsResponsesAPI: schemas.Ptr(false),
+	})
+	return ctx
+}
+
+func TestPreLLMHook_TransformsForcedResponsesRequestToChatCompletion(t *testing.T) {
+	plugin := &LiteLLMCompatPlugin{config: Config{Enabled: true}}
+	ctx := testResponsesCompatContext()
+
+	transformedReq, shortCircuit, err := plugin.PreLLMHook(ctx, testResponsesCompatRequest(schemas.ResponsesRequest))
+	if err != nil {
+		t.Fatalf("PreLLMHook returned error: %v", err)
+	}
+	if shortCircuit != nil {
+		t.Fatal("expected no short circuit")
+	}
+	if transformedReq == nil || transformedReq.ChatRequest == nil {
+		t.Fatal("expected chat request after transform")
+	}
+	if transformedReq.RequestType != schemas.ChatCompletionRequest {
+		t.Fatalf("expected request type %s, got %s", schemas.ChatCompletionRequest, transformedReq.RequestType)
+	}
+	if transformedReq.ChatRequest.Model != "test-model" {
+		t.Fatalf("expected model test-model, got %s", transformedReq.ChatRequest.Model)
+	}
+	if len(transformedReq.ChatRequest.Input) == 0 {
+		t.Fatal("expected transformed chat input")
+	}
+	if ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback) != true {
+		t.Fatalf("expected fallback context marker to be set, got %v", ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback))
+	}
+	if reason, _ := ctx.Value(schemas.BifrostContextKeyResponsesToChatCompletionFallbackReason).(schemas.ResponsesToChatCompletionFallbackReason); reason != schemas.ResponsesToChatCompletionFallbackReasonConfiguredUnsupported {
+		t.Fatalf("expected fallback reason %q, got %q", schemas.ResponsesToChatCompletionFallbackReasonConfiguredUnsupported, reason)
+	}
+	state, ok := schemas.GetResponsesToChatCompletionCompatState(ctx)
+	if !ok || state == nil {
+		t.Fatal("expected responses compat state to be stored on context")
+	}
+	if !state.Active || state.RetryEligible {
+		t.Fatalf("expected active forced fallback state, got %+v", state)
+	}
+
+	chatText := "fallback response"
+	finishReason := string(schemas.BifrostFinishReasonStop)
+	result, bifrostErr, err := plugin.PostLLMHook(ctx, &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ID:      "chatcmpl-test",
+			Created: 1,
+			Model:   "test-model",
+			Choices: []schemas.BifrostResponseChoice{{
+				Index:        0,
+				FinishReason: &finishReason,
+				ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+					Message: &schemas.ChatMessage{
+						Role: schemas.ChatMessageRoleAssistant,
+						Content: &schemas.ChatMessageContent{
+							ContentStr: &chatText,
+						},
+					},
+				},
+			}},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				Provider:       schemas.ModelProvider("lmstudio"),
+				RequestType:    schemas.ChatCompletionRequest,
+				ModelRequested: "test-model",
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("PostLLMHook returned error: %v", err)
+	}
+	if bifrostErr != nil {
+		t.Fatalf("expected nil error, got %+v", bifrostErr)
+	}
+	if result == nil || result.ResponsesResponse == nil {
+		t.Fatal("expected responses response after transform")
+	}
+	if result.ResponsesResponse.ExtraFields.RequestType != schemas.ResponsesRequest {
+		t.Fatalf("expected request type %s, got %s", schemas.ResponsesRequest, result.ResponsesResponse.ExtraFields.RequestType)
+	}
+	if !result.ResponsesResponse.ExtraFields.LiteLLMCompat {
+		t.Fatal("expected litellm compat marker to be set")
+	}
+	if len(result.ResponsesResponse.Output) == 0 || result.ResponsesResponse.Output[0].Content == nil || len(result.ResponsesResponse.Output[0].Content.ContentBlocks) == 0 {
+		t.Fatal("expected transformed responses output")
+	}
+	if got := result.ResponsesResponse.Output[0].Content.ContentBlocks[0].Text; got == nil || *got != "fallback response" {
+		t.Fatalf("expected fallback response text, got %+v", got)
+	}
+}
+
+func TestPreLLMHook_PreparesRuntimeResponsesFallback(t *testing.T) {
+	plugin := &LiteLLMCompatPlugin{config: Config{Enabled: true}}
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyCustomProviderMetadata, &schemas.CustomProviderContextMetadata{
+		ProviderKey:      "lmstudio",
+		BaseProviderType: schemas.OpenAI,
+	})
+
+	originalReq := testResponsesCompatRequest(schemas.ResponsesRequest)
+	transformedReq, shortCircuit, err := plugin.PreLLMHook(ctx, originalReq)
+	if err != nil {
+		t.Fatalf("PreLLMHook returned error: %v", err)
+	}
+	if shortCircuit != nil {
+		t.Fatal("expected no short circuit")
+	}
+	if transformedReq != originalReq {
+		t.Fatal("expected native responses request to be kept for runtime probing")
+	}
+	if ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback) != nil {
+		t.Fatalf("expected fallback context marker to stay unset before runtime retry, got %v", ctx.Value(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback))
+	}
+	state, ok := schemas.GetResponsesToChatCompletionCompatState(ctx)
+	if !ok || state == nil {
+		t.Fatal("expected compat state to be stored for runtime retry")
+	}
+	if state.Active || !state.RetryEligible {
+		t.Fatalf("expected runtime retry state to be eligible but inactive, got %+v", state)
+	}
+	if state.RetryPolicy == nil {
+		t.Fatal("expected runtime retry policy to be prepared by compat plugin")
+	}
+	if state.FallbackRequest == nil || state.FallbackRequest.ChatRequest == nil {
+		t.Fatal("expected fallback chat request to be prepared")
+	}
+	if state.FallbackRequest.RequestType != schemas.ChatCompletionRequest {
+		t.Fatalf("expected fallback request type %s, got %s", schemas.ChatCompletionRequest, state.FallbackRequest.RequestType)
+	}
+	if state.OriginalRequestType != schemas.ResponsesRequest {
+		t.Fatalf("expected original request type %s, got %s", schemas.ResponsesRequest, state.OriginalRequestType)
+	}
+	statusCode := http.StatusNotFound
+	if !state.ShouldRetry(&schemas.BifrostError{StatusCode: &statusCode}) {
+		t.Fatal("expected compat state retry policy to treat 404 as runtime fallback trigger")
+	}
+}
+
+func TestPreLLMHook_TransformsForcedResponsesStreamRequestToChatCompletionStream(t *testing.T) {
+	plugin := &LiteLLMCompatPlugin{config: Config{Enabled: true}}
+	ctx := testResponsesCompatContext()
+
+	transformedReq, shortCircuit, err := plugin.PreLLMHook(ctx, testResponsesCompatRequest(schemas.ResponsesStreamRequest))
+	if err != nil {
+		t.Fatalf("PreLLMHook returned error: %v", err)
+	}
+	if shortCircuit != nil {
+		t.Fatal("expected no short circuit")
+	}
+	if transformedReq == nil || transformedReq.ChatRequest == nil {
+		t.Fatal("expected chat stream request after transform")
+	}
+	if transformedReq.RequestType != schemas.ChatCompletionStreamRequest {
+		t.Fatalf("expected request type %s, got %s", schemas.ChatCompletionStreamRequest, transformedReq.RequestType)
+	}
+
+	state, ok := schemas.GetResponsesToChatCompletionCompatState(ctx)
+	if !ok || state == nil {
+		t.Fatal("expected compat state to be stored for forced streaming fallback")
+	}
+	if !state.Active || !state.IsStreaming || state.FallbackRequest == nil {
+		t.Fatalf("expected active streaming fallback state, got %+v", state)
+	}
+}

--- a/plugins/litellmcompat/runtime_fallback_integration_test.go
+++ b/plugins/litellmcompat/runtime_fallback_integration_test.go
@@ -1,0 +1,394 @@
+package litellmcompat
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+type integrationAccount struct {
+	mu      sync.RWMutex
+	configs map[schemas.ModelProvider]*schemas.ProviderConfig
+}
+
+func newIntegrationAccount(baseURL string, supportsResponsesAPI *bool, allowedRequests *schemas.AllowedRequests) *integrationAccount {
+	providerKey := schemas.ModelProvider("lmstudio")
+	return &integrationAccount{
+		configs: map[schemas.ModelProvider]*schemas.ProviderConfig{
+			providerKey: &schemas.ProviderConfig{
+				NetworkConfig: schemas.NetworkConfig{
+					BaseURL:                        baseURL,
+					DefaultRequestTimeoutInSeconds: 5,
+				},
+				ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
+					Concurrency: 1,
+					BufferSize:  8,
+				},
+				CustomProviderConfig: &schemas.CustomProviderConfig{
+					CustomProviderKey:    string(providerKey),
+					BaseProviderType:     schemas.OpenAI,
+					SupportsResponsesAPI: supportsResponsesAPI,
+					AllowedRequests:      allowedRequests,
+					IsKeyLess:            true,
+				},
+			},
+		},
+	}
+}
+
+func (a *integrationAccount) GetConfiguredProviders() ([]schemas.ModelProvider, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	providers := make([]schemas.ModelProvider, 0, len(a.configs))
+	for providerKey := range a.configs {
+		providers = append(providers, providerKey)
+	}
+
+	return providers, nil
+}
+
+func (a *integrationAccount) GetKeysForProvider(context.Context, schemas.ModelProvider) ([]schemas.Key, error) {
+	return nil, nil
+}
+
+func (a *integrationAccount) GetConfigForProvider(providerKey schemas.ModelProvider) (*schemas.ProviderConfig, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	config, ok := a.configs[providerKey]
+	if !ok {
+		return nil, fmt.Errorf("provider %s not configured", providerKey)
+	}
+
+	configCopy := *config
+	if config.CustomProviderConfig != nil {
+		customProviderConfigCopy := *config.CustomProviderConfig
+		configCopy.CustomProviderConfig = &customProviderConfigCopy
+	}
+
+	return &configCopy, nil
+}
+
+func newIntegrationBifrost(t *testing.T, serverURL string, supportsResponsesAPI *bool, allowedRequests *schemas.AllowedRequests) *bifrost.Bifrost {
+	t.Helper()
+
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelError)
+	plugin, err := InitWithModelCatalog(Config{Enabled: true}, logger, nil)
+	if err != nil {
+		t.Fatalf("InitWithModelCatalog returned error: %v", err)
+	}
+
+	instance, err := bifrost.Init(context.Background(), schemas.BifrostConfig{
+		Account:         newIntegrationAccount(serverURL, supportsResponsesAPI, allowedRequests),
+		Logger:          logger,
+		LLMPlugins:      []schemas.LLMPlugin{plugin},
+		InitialPoolSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("bifrost.Init returned error: %v", err)
+	}
+
+	return instance
+}
+
+func integrationResponsesRequest() *schemas.BifrostResponsesRequest {
+	content := "hello"
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.ModelProvider("lmstudio"),
+		Model:    "test-model",
+		Input: []schemas.ResponsesMessage{{
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{
+				ContentStr: &content,
+			},
+		}},
+		Params: &schemas.ResponsesParameters{
+			MaxOutputTokens: schemas.Ptr(7),
+		},
+	}
+}
+
+func integrationChatCompletionBody(text string) []byte {
+	finishReason := string(schemas.BifrostFinishReasonStop)
+	response := &schemas.BifrostChatResponse{
+		ID:      "chatcmpl-test",
+		Object:  "chat.completion",
+		Created: 1,
+		Model:   "test-model",
+		Choices: []schemas.BifrostResponseChoice{{
+			Index:        0,
+			FinishReason: &finishReason,
+			ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+				Message: &schemas.ChatMessage{
+					Role: schemas.ChatMessageRoleAssistant,
+					Content: &schemas.ChatMessageContent{
+						ContentStr: &text,
+					},
+				},
+			},
+		}},
+		Usage: &schemas.BifrostLLMUsage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+	}
+	body, _ := sonic.Marshal(response)
+	return body
+}
+
+func collectRuntimeFallbackStream(t *testing.T, stream chan *schemas.BifrostStreamChunk) []*schemas.BifrostResponsesStreamResponse {
+	t.Helper()
+
+	responses := make([]*schemas.BifrostResponsesStreamResponse, 0)
+	timeout := time.After(3 * time.Second)
+
+	for {
+		select {
+		case chunk, ok := <-stream:
+			if !ok {
+				return responses
+			}
+			if chunk == nil {
+				continue
+			}
+			if chunk.BifrostError != nil {
+				t.Fatalf("unexpected stream error: %+v", chunk.BifrostError)
+			}
+			if chunk.BifrostResponsesStreamResponse != nil {
+				responses = append(responses, chunk.BifrostResponsesStreamResponse)
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for stream to complete")
+		}
+	}
+}
+
+func TestResponsesRequest_RuntimeFallbackRunsThroughBifrostCompat(t *testing.T) {
+	t.Parallel()
+
+	var chatHits atomic.Int32
+	var responsesHits atomic.Int32
+	var chatRequestBody atomic.Value
+	var responsesRequestBody atomic.Value
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+
+		switch r.URL.Path {
+		case "/v1/responses":
+			responsesHits.Add(1)
+			responsesRequestBody.Store(string(bodyBytes))
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"responses endpoint unsupported"}}`))
+		case "/v1/chat/completions":
+			chatHits.Add(1)
+			chatRequestBody.Store(string(bodyBytes))
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(integrationChatCompletionBody("runtime fallback response"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	instance := newIntegrationBifrost(t, server.URL, nil, &schemas.AllowedRequests{Responses: true})
+	defer instance.Shutdown()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	response, bifrostErr := instance.ResponsesRequest(ctx, integrationResponsesRequest())
+	if bifrostErr != nil {
+		t.Fatalf("ResponsesRequest returned error: %v", bifrostErr.Error)
+	}
+	if response == nil {
+		t.Fatal("ResponsesRequest returned nil response")
+	}
+	if responsesHits.Load() != 1 {
+		t.Fatalf("expected one native responses attempt, got %d", responsesHits.Load())
+	}
+	if chatHits.Load() != 1 {
+		t.Fatalf("expected one fallback chat attempt, got %d", chatHits.Load())
+	}
+
+	responsesBody, _ := responsesRequestBody.Load().(string)
+	if !strings.Contains(responsesBody, `"input"`) {
+		t.Fatalf("expected initial responses payload to contain input, got %s", responsesBody)
+	}
+	chatBody, _ := chatRequestBody.Load().(string)
+	if !strings.Contains(chatBody, `"messages"`) {
+		t.Fatalf("expected fallback chat payload to contain messages, got %s", chatBody)
+	}
+	if strings.Contains(chatBody, `"input"`) {
+		t.Fatalf("expected fallback chat payload to omit responses input, got %s", chatBody)
+	}
+
+	if !response.ExtraFields.LiteLLMCompat {
+		t.Fatal("expected litellm compat marker on fallback response")
+	}
+	if !response.ExtraFields.ResponsesToChatCompletionFallback {
+		t.Fatal("expected explicit responses-to-chat fallback marker on response")
+	}
+	if response.ExtraFields.ResponsesToChatCompletionFallbackReason != string(schemas.ResponsesToChatCompletionFallbackReasonRuntimeUnsupported) {
+		t.Fatalf("expected fallback reason %q, got %q", schemas.ResponsesToChatCompletionFallbackReasonRuntimeUnsupported, response.ExtraFields.ResponsesToChatCompletionFallbackReason)
+	}
+	if got := response.Output[0].Content.ContentBlocks[0].Text; got == nil || *got != "runtime fallback response" {
+		t.Fatalf("expected converted output text runtime fallback response, got %+v", got)
+	}
+	if reason, ok := schemas.GetResponsesToChatCompletionFallback(ctx); !ok || reason != schemas.ResponsesToChatCompletionFallbackReasonRuntimeUnsupported {
+		t.Fatalf("expected runtime fallback context reason, got %q (ok=%v)", reason, ok)
+	}
+}
+
+func TestResponsesRequest_ConfiguredFallbackBypassesChatAllowedRequestsGate(t *testing.T) {
+	t.Parallel()
+
+	var chatHits atomic.Int32
+	var responsesHits atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+
+		switch r.URL.Path {
+		case "/v1/responses":
+			responsesHits.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+		case "/v1/chat/completions":
+			chatHits.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(integrationChatCompletionBody("configured fallback response"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	instance := newIntegrationBifrost(t, server.URL, schemas.Ptr(false), &schemas.AllowedRequests{Responses: true})
+	defer instance.Shutdown()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	response, bifrostErr := instance.ResponsesRequest(ctx, integrationResponsesRequest())
+	if bifrostErr != nil {
+		t.Fatalf("ResponsesRequest returned error: %v", bifrostErr.Error)
+	}
+	if response == nil {
+		t.Fatal("ResponsesRequest returned nil response")
+	}
+	if responsesHits.Load() != 0 {
+		t.Fatalf("expected zero native responses attempts during configured fallback, got %d", responsesHits.Load())
+	}
+	if chatHits.Load() != 1 {
+		t.Fatalf("expected one fallback chat attempt, got %d", chatHits.Load())
+	}
+	if got := response.Output[0].Content.ContentBlocks[0].Text; got == nil || *got != "configured fallback response" {
+		t.Fatalf("expected converted output text configured fallback response, got %+v", got)
+	}
+	if reason, ok := schemas.GetResponsesToChatCompletionFallback(ctx); !ok || reason != schemas.ResponsesToChatCompletionFallbackReasonConfiguredUnsupported {
+		t.Fatalf("expected configured fallback context reason, got %q (ok=%v)", reason, ok)
+	}
+}
+
+func TestResponsesStreamRequest_RuntimeFallbackRunsThroughBifrostCompat(t *testing.T) {
+	t.Parallel()
+
+	var chatHits atomic.Int32
+	var responsesHits atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("failed to read request body: %v", err)
+		}
+
+		switch r.URL.Path {
+		case "/v1/responses":
+			responsesHits.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"responses endpoint unsupported"}}`))
+		case "/v1/chat/completions":
+			chatHits.Add(1)
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				t.Fatal("response writer does not implement http.Flusher")
+			}
+
+			chunks := []string{
+				`{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"role":"assistant"}}]}`,
+				`{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"content":"runtime fallback stream"}}]}`,
+				`{"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+			}
+
+			for _, chunk := range chunks {
+				_, _ = fmt.Fprintf(w, "data: %s\n\n", chunk)
+				flusher.Flush()
+			}
+			_, _ = fmt.Fprint(w, "data: [DONE]\n\n")
+			flusher.Flush()
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	instance := newIntegrationBifrost(t, server.URL, nil, &schemas.AllowedRequests{ResponsesStream: true})
+	defer instance.Shutdown()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	streamChan, bifrostErr := instance.ResponsesStreamRequest(ctx, integrationResponsesRequest())
+	if bifrostErr != nil {
+		t.Fatalf("ResponsesStreamRequest returned error: %v", bifrostErr.Error)
+	}
+
+	responses := collectRuntimeFallbackStream(t, streamChan)
+	if responsesHits.Load() != 1 {
+		t.Fatalf("expected one native responses stream attempt, got %d", responsesHits.Load())
+	}
+	if chatHits.Load() != 1 {
+		t.Fatalf("expected one fallback chat stream attempt, got %d", chatHits.Load())
+	}
+
+	seenTypes := map[schemas.ResponsesStreamResponseType]bool{}
+	for _, response := range responses {
+		seenTypes[response.Type] = true
+		if response.ExtraFields.RequestType != schemas.ResponsesStreamRequest {
+			t.Fatalf("expected request type %s, got %s", schemas.ResponsesStreamRequest, response.ExtraFields.RequestType)
+		}
+		if !response.ExtraFields.LiteLLMCompat {
+			t.Fatal("expected litellm compat marker on streamed fallback response")
+		}
+		if !response.ExtraFields.ResponsesToChatCompletionFallback {
+			t.Fatal("expected explicit responses-to-chat fallback marker on streamed response")
+		}
+		if response.ExtraFields.ResponsesToChatCompletionFallbackReason != string(schemas.ResponsesToChatCompletionFallbackReasonRuntimeUnsupported) {
+			t.Fatalf("expected fallback reason %q, got %q", schemas.ResponsesToChatCompletionFallbackReasonRuntimeUnsupported, response.ExtraFields.ResponsesToChatCompletionFallbackReason)
+		}
+	}
+
+	if !seenTypes[schemas.ResponsesStreamResponseTypeCreated] {
+		t.Fatalf("expected response.created event, got %#v", seenTypes)
+	}
+	if !seenTypes[schemas.ResponsesStreamResponseTypeOutputTextDelta] {
+		t.Fatalf("expected response.output_text.delta event, got %#v", seenTypes)
+	}
+	if !seenTypes[schemas.ResponsesStreamResponseTypeCompleted] {
+		t.Fatalf("expected response.completed event, got %#v", seenTypes)
+	}
+	if reason, ok := schemas.GetResponsesToChatCompletionFallback(ctx); !ok || reason != schemas.ResponsesToChatCompletionFallbackReasonRuntimeUnsupported {
+		t.Fatalf("expected runtime fallback context reason, got %q (ok=%v)", reason, ok)
+	}
+}

--- a/tests/e2e/features/routing-rules/routing-rules.spec.ts
+++ b/tests/e2e/features/routing-rules/routing-rules.spec.ts
@@ -163,6 +163,29 @@ test.describe('Routing Rules', () => {
 
       await routingRulesPage.cancelRule()
     })
+
+    test('should allow zero-weight routing target without rejecting input', async ({ routingRulesPage }) => {
+      await routingRulesPage.createBtn.click()
+      await expect(routingRulesPage.sheet).toBeVisible({ timeout: 5000 })
+
+      await routingRulesPage.nameInput.fill(`Zero Weight Rule ${Date.now()}`)
+
+      // Set the default target weight to 0
+      const weightInput = routingRulesPage.sheet.getByTestId('routing-target-0-weight-input')
+      await weightInput.clear()
+      await weightInput.fill('0')
+
+      await routingRulesPage.saveBtn.click()
+
+      // Weight = 0 must not trigger the old "must be greater than 0" rejection.
+      // The only toast shown should be the sum constraint (0 ≠ 1).
+      const toast = routingRulesPage.page.locator('[data-sonner-toast]').first()
+      await expect(toast).toBeVisible({ timeout: 5000 })
+      const toastText = await toast.textContent()
+      expect(toastText).not.toContain('greater than 0')
+
+      await routingRulesPage.cancelRule()
+    })
   })
 
   test.describe('Table Display', () => {

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -131,7 +131,7 @@ type RoutingTarget struct {
 	Provider *string `json:"provider,omitempty"` // nil = use incoming provider
 	Model    *string `json:"model,omitempty"`    // nil = use incoming model
 	KeyID    *string `json:"key_id,omitempty"`   // nil = no key pin
-	Weight   float64 `json:"weight"`             // must be > 0; all weights must sum to 1
+	Weight   float64 `json:"weight"`             // must be >= 0; all weights must sum to 1
 }
 
 // CreateRoutingRuleRequest represents the request body for creating a routing rule
@@ -3314,7 +3314,7 @@ func validateRoutingScope(scope string) error {
 	return nil
 }
 
-// validateRoutingTargets checks that all weights are positive, that no two
+// validateRoutingTargets checks that all weights are non-negative, that no two
 // targets share the same (provider, model, key_id) identity, and that all
 // weights sum to 1.
 func validateRoutingTargets(targets []RoutingTarget) error {
@@ -3322,7 +3322,7 @@ func validateRoutingTargets(targets []RoutingTarget) error {
 	total := 0.0
 	for _, t := range targets {
 		if t.Weight < 0 {
-			return fmt.Errorf("each target weight must be positive")
+			return fmt.Errorf("each target weight must be non-negative")
 		}
 		if t.KeyID != nil && *t.KeyID != "" && (t.Provider == nil || *t.Provider == "") {
 			return fmt.Errorf("key_id requires provider to be set")

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -106,7 +106,7 @@ func loadBuiltinPlugin(ctx context.Context, name string, pluginConfig any, bifro
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal litellmcompat plugin config: %w", err)
 		}
-		return litellmcompat.Init(*litellmConfig, logger)
+		return litellmcompat.InitWithModelCatalog(*litellmConfig, logger, bifrostConfig.ModelCatalog)
 
 	default:
 		return nil, fmt.Errorf("unknown built-in plugin: %s", name)
@@ -201,7 +201,10 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 	}
 	s.Config.SetPluginOrderInfo(semanticcache.PluginName, builtinPlacement, schemas.Ptr(5))
 
-	// 6. Litellmcompat (if configured in PluginConfigs)
+	// 6. Litellmcompat (if configured in PluginConfigs).
+	// Keep this late in the built-in chain so governance/caching hooks can inspect the
+	// original request shape before compat rewrites. Downstream plugins can still inspect
+	// the fallback context markers when a Responses request is bridged to Chat.
 	litellmcompatConfig := s.getPluginConfig(litellmcompat.PluginName)
 	if litellmcompatConfig != nil && litellmcompatConfig.Enabled {
 		s.registerPluginWithStatus(ctx, litellmcompat.PluginName, nil, litellmcompatConfig.Config, false)
@@ -221,7 +224,6 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 
 	return nil
 }
-
 
 // loadCustomPlugins loads plugins from PluginConfigs
 func (s *BifrostHTTPServer) loadCustomPlugins(ctx context.Context) error {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1993,6 +1993,10 @@
           "type": "string",
           "description": "Base provider type to extend"
         },
+        "supports_responses_api": {
+          "type": "boolean",
+          "description": "Controls native OpenAI Responses API usage for custom OpenAI-compatible providers. true forces /v1/responses, false forces an internal Chat Completions fallback, and omitting it keeps native behavior first with an automatic downgrade on obvious unsupported-endpoint failures."
+        },
         "allowed_requests": {
           "type": "object",
           "description": "Allowed request types for the custom provider",

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -200,8 +200,8 @@ export function RoutingRuleSheet({
 			return;
 		}
 		for (const t of targets) {
-			if (t.weight <= 0) {
-				toast.error("Each target weight must be greater than 0");
+			if (t.weight < 0) {
+				toast.error("Each target weight must be at least 0");
 				return;
 			}
 		}
@@ -644,7 +644,7 @@ function TargetRow({ target, index, availableProviders, providersData, showRemov
 						<Input
 							id={`routing-target-${index}-weight-input`}
 							type="number"
-							min={0.001}
+							min={0}
 							max={1}
 							step={0.001}
 							value={target.weight}


### PR DESCRIPTION
## Summary

Fixes an inconsistency where routing targets with `weight = 0` were rejected in the UI and silently coerced to `1` in the persistence layer due to ORM defaults.

This PR ensures that:

* `weight = 0` is accepted across UI, API, and backend validation
* Zero-weight targets are correctly persisted without being overridden
* Validation messages and comments reflect the intended behavior (`>= 0`)

---

## Changes

* UI (Next.js)

  * Updated weight input constraint from `min=0.001` to `min=0`
  * Adjusted validation logic from `<= 0` to `< 0`
  * Updated error messaging to allow zero-weight targets

* Backend (Go)

  * Aligned validation messaging from “positive” to “non-negative”
  * Updated struct and function comments to reflect `weight >= 0`

* Persistence Layer

  * Removed `default:1` from GORM model for `weight`
  * Fixes silent coercion where `weight = 0` was being stored as `1`
  * Ensures explicit zero values are preserved during insert and update

* Tests

  * Added E2E coverage to ensure zero-weight inputs are not rejected by legacy validation

---

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

---

## Affected areas

* [x] Core (Go)
* [x] Transports (HTTP)
* [ ] Providers/Integrations
* [ ] Plugins
* [x] UI (Next.js)
* [ ] Docs

---

## How to test

### Backend Validation

```sh
curl http://localhost:8099/health
```

Expected:

```json
{"status":"ok"}
```

---

### TC1 Negative weight should fail

```sh
curl -X POST http://localhost:8099/api/governance/routing-rules \
-H 'Content-Type: application/json' \
-d '{"name":"tc1","targets":[{"weight":-0.5}],"scope":"global","priority":10}'
```

Expected:

* HTTP 400
* "each target weight must be non-negative"

---

### TC2 Zero weight allowed but invalid sum

```sh
curl -X POST http://localhost:8099/api/governance/routing-rules \
-H 'Content-Type: application/json' \
-d '{"name":"tc2","targets":[{"weight":0}],"scope":"global","priority":11}'
```

Expected:

* HTTP 400
* "target weights must sum to 1"
* No "greater than 0" error

---

### TC3 Valid case with zero weight

```sh
curl -X POST http://localhost:8099/api/governance/routing-rules \
-H 'Content-Type: application/json' \
-d '{"name":"tc3","targets":[{"provider":"openai","model":"gpt-4o","weight":1},{"provider":"anthropic","model":"claude-3-5-sonnet-20241022","weight":0}],"scope":"global","priority":500}'
```

Expected:

* HTTP 200
* Rule created successfully

---

### TC4 Verify persistence via API

```sh
curl http://localhost:8099/api/governance/routing-rules/<RULE_ID> | python3 -m json.tool
```

Expected:

```json
"weight": 0
```

---

### TC5 Verify persistence via DB

```sh
sqlite3 /tmp/bifrost-test/config.db \
"SELECT provider, model, weight FROM routing_targets;"
```

Expected:

```text
... | 0.0
```

---

## Screenshots/Recordings

* Backend validation for negative weight rejection
* Zero weight accepted and only sum validation triggered
* Successful rule creation with `weight = 0`
* Database verification showing `0.0`


<img width="1451" height="841" alt="Screenshot 2026-04-11 132306" src="https://github.com/user-attachments/assets/73d12078-74b1-41f6-88d8-9ca7acfcca48" />


---

## Breaking changes

* [ ] Yes
* [x] No

---

## Related issues

Closes #2633

---

## Security considerations

No direct security impact.
Changes are limited to validation consistency and persistence correctness.

---

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [x] I added or updated tests where appropriate
* [x] I updated documentation where needed
* [x] I verified builds succeed for Go and UI
* [x] I verified the CI pipeline passes locally if applicable
