### PR TITLE
fix: allow zero-weight routing targets and prevent GORM default override

### DIFF
--- a/framework/configstore/tables/routing_rules.go
+++ b/framework/configstore/tables/routing_rules.go
@@ -93,7 +93,7 @@ type TableRoutingTarget struct {
 	Model           *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"model,omitempty"`    // nil = use incoming model
 	KeyID           *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"key_id,omitempty"`   // persisted key pin
 	ProviderKeyName *string `gorm:"-" json:"provider_key_name,omitempty"`                                               // config-only alias; resolved to key_id during load
-	Weight          float64 `gorm:"not null;default:1" json:"weight"`                                                  // must sum to 1 across all targets in a rule
+	Weight          float64 `gorm:"not null" json:"weight"`                                                             // must sum to 1 across all targets in a rule
 }
 
 // TableName for TableRoutingTarget

--- a/tests/e2e/features/routing-rules/routing-rules.spec.ts
+++ b/tests/e2e/features/routing-rules/routing-rules.spec.ts
@@ -163,6 +163,29 @@ test.describe('Routing Rules', () => {
 
       await routingRulesPage.cancelRule()
     })
+
+    test('should allow zero-weight routing target without rejecting input', async ({ routingRulesPage }) => {
+      await routingRulesPage.createBtn.click()
+      await expect(routingRulesPage.sheet).toBeVisible({ timeout: 5000 })
+
+      await routingRulesPage.nameInput.fill(`Zero Weight Rule ${Date.now()}`)
+
+      // Set the default target weight to 0
+      const weightInput = routingRulesPage.sheet.getByTestId('routing-target-0-weight-input')
+      await weightInput.clear()
+      await weightInput.fill('0')
+
+      await routingRulesPage.saveBtn.click()
+
+      // Weight = 0 must not trigger the old "must be greater than 0" rejection.
+      // The only toast shown should be the sum constraint (0 ≠ 1).
+      const toast = routingRulesPage.page.locator('[data-sonner-toast]').first()
+      await expect(toast).toBeVisible({ timeout: 5000 })
+      const toastText = await toast.textContent()
+      expect(toastText).not.toContain('greater than 0')
+
+      await routingRulesPage.cancelRule()
+    })
   })
 
   test.describe('Table Display', () => {

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -136,7 +136,7 @@ type RoutingTarget struct {
 	Provider *string `json:"provider,omitempty"` // nil = use incoming provider
 	Model    *string `json:"model,omitempty"`    // nil = use incoming model
 	KeyID    *string `json:"key_id,omitempty"`   // nil = no key pin
-	Weight   float64 `json:"weight"`             // must be > 0; all weights must sum to 1
+	Weight   float64 `json:"weight"`             // must be >= 0; all weights must sum to 1
 }
 
 // CreateRoutingRuleRequest represents the request body for creating a routing rule
@@ -3782,7 +3782,7 @@ func validateRoutingScope(scope string) error {
 	return nil
 }
 
-// validateRoutingTargets checks that all weights are positive, that no two
+// validateRoutingTargets checks that all weights are non-negative, that no two
 // targets share the same (provider, model, key_id) identity, and that all
 // weights sum to 1.
 func validateRoutingTargets(targets []RoutingTarget) error {
@@ -3790,7 +3790,7 @@ func validateRoutingTargets(targets []RoutingTarget) error {
 	total := 0.0
 	for _, t := range targets {
 		if t.Weight < 0 {
-			return fmt.Errorf("each target weight must be positive")
+			return fmt.Errorf("each target weight must be non-negative")
 		}
 		if t.KeyID != nil && *t.KeyID != "" && (t.Provider == nil || *t.Provider == "") {
 			return fmt.Errorf("key_id requires provider to be set")

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -178,8 +178,8 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 			return;
 		}
 		for (const t of targets) {
-			if (t.weight <= 0) {
-				toast.error("Each target weight must be greater than 0");
+			if (t.weight < 0) {
+				toast.error("Each target weight must be at least 0");
 				return;
 			}
 		}
@@ -633,7 +633,7 @@ function TargetRow({ target, index, availableProviders, allKeys, showRemove, onU
 						<Input
 							id={`routing-target-${index}-weight-input`}
 							type="number"
-							min={0.001}
+							min={0}
 							max={1}
 							step={0.001}
 							value={target.weight}


### PR DESCRIPTION
## Summary

Fixes an inconsistency where routing targets with `weight = 0` were rejected in the UI and silently coerced to `1` in the persistence layer due to ORM defaults.

This PR ensures that:

* `weight = 0` is accepted across UI, API, and backend validation
* Zero-weight targets are correctly persisted without being overridden
* Validation messages and comments reflect the intended behavior (`>= 0`)

---

## Changes

* UI (Next.js)

  * Updated weight input constraint from `min=0.001` to `min=0`
  * Adjusted validation logic from `<= 0` to `< 0`
  * Updated error messaging to allow zero-weight targets

* Backend (Go)

  * Aligned validation messaging from “positive” to “non-negative”
  * Updated struct and function comments to reflect `weight >= 0`

* Persistence Layer

  * Removed `default:1` from GORM model for `weight`
  * Fixes silent coercion where `weight = 0` was being stored as `1`
  * Ensures explicit zero values are preserved during insert and update

* Tests

  * Added E2E coverage to ensure zero-weight inputs are not rejected by legacy validation

---

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

---

## Affected areas

* [x] Core (Go)
* [x] Transports (HTTP)
* [ ] Providers/Integrations
* [ ] Plugins
* [x] UI (Next.js)
* [ ] Docs

---

## How to test

### Backend Validation

```sh
curl http://localhost:8099/health
```

Expected:

```json
{"status":"ok"}
```

---

### TC1 Negative weight should fail

```sh
curl -X POST http://localhost:8099/api/governance/routing-rules \
-H 'Content-Type: application/json' \
-d '{"name":"tc1","targets":[{"weight":-0.5}],"scope":"global","priority":10}'
```

Expected:

* HTTP 400
* "each target weight must be non-negative"

---

### TC2 Zero weight allowed but invalid sum

```sh
curl -X POST http://localhost:8099/api/governance/routing-rules \
-H 'Content-Type: application/json' \
-d '{"name":"tc2","targets":[{"weight":0}],"scope":"global","priority":11}'
```

Expected:

* HTTP 400
* "target weights must sum to 1"
* No "greater than 0" error

---

### TC3 Valid case with zero weight

```sh
curl -X POST http://localhost:8099/api/governance/routing-rules \
-H 'Content-Type: application/json' \
-d '{"name":"tc3","targets":[{"provider":"openai","model":"gpt-4o","weight":1},{"provider":"anthropic","model":"claude-3-5-sonnet-20241022","weight":0}],"scope":"global","priority":500}'
```

Expected:

* HTTP 200
* Rule created successfully

---

### TC4 Verify persistence via API

```sh
curl http://localhost:8099/api/governance/routing-rules/<RULE_ID> | python3 -m json.tool
```

Expected:

```json
"weight": 0
```

---

### TC5 Verify persistence via DB

```sh
sqlite3 /tmp/bifrost-test/config.db \
"SELECT provider, model, weight FROM routing_targets;"
```

Expected:

```text
... | 0.0
```

---

## Screenshots/Recordings

* Backend validation for negative weight rejection
* Zero weight accepted and only sum validation triggered
* Successful rule creation with `weight = 0`
* Database verification showing `0.0`


<img width="1451" height="841" alt="Screenshot 2026-04-11 132306" src="https://github.com/user-attachments/assets/73d12078-74b1-41f6-88d8-9ca7acfcca48" />


---

## Breaking changes

* [ ] Yes
* [x] No

---

## Related issues

Closes #2633

---

## Security considerations

No direct security impact.
Changes are limited to validation consistency and persistence correctness.

---

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [x] I added or updated tests where appropriate
* [x] I updated documentation where needed
* [x] I verified builds succeed for Go and UI
* [x] I verified the CI pipeline passes locally if applicable
