### PR TITLE
fix(streaming): preserve and forward OpenRouter annotations 

### DIFF
--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1114,6 +1114,35 @@ func HandleOpenAIChatCompletionStreaming(
 		var created int
 		forwardedTerminalFinishReason := false
 
+		// Collect provider-specific top-level fields across streaming chunks.
+		// Perplexity (direct and via OpenRouter) returns citations, search_results,
+		// and videos in the final chunk which often has an empty delta and would
+		// otherwise be skipped by the content-gated forwarding condition below.
+		// This fix is scoped to the known fields above; other provider-specific
+		// top-level metadata should be added here when encountered.
+		var collectedCitations []string
+		var collectedSearchResults []schemas.SearchResult
+		var collectedVideos []schemas.VideoResult
+		// seenCitations deduplicates URL strings (first-seen wins — no richer form exists).
+		seenCitations := make(map[string]struct{})
+		// seenSearchResultURLs / seenVideoURLs map URL → slice index so that a later
+		// chunk carrying updated metadata for the same URL overwrites the earlier entry
+		// (keep-last). URL is used as a best-effort dedup key; entries with an empty
+		// URL are appended unconditionally to avoid collapsing distinct results.
+		// Note: assumes metadata sets are bounded in size (typical for web-search APIs).
+		seenSearchResultURLs := make(map[string]int)
+		seenVideoURLs := make(map[string]int)
+		// Collect delta.annotations from individual chunks so the full aggregated set can
+		// be attached to the final synthetic chunk for downstream clients that prefer not
+		// to implement streaming logic. Each annotation chunk still flows through to the
+		// client individually via the streaming gate below.
+		// Composite key "url:startIndex:endIndex" (or "title:startIndex:endIndex" for
+		// no-URL annotations) keeps per-position citations distinct while deduplicating
+		// exact repeats with keep-last semantics so a later, richer copy always wins.
+		// TODO: Generalize metadata accumulation for all provider-specific top-level fields.
+		var collectedAnnotations []schemas.ChatAssistantMessageAnnotation
+		seenAnnotationKeys := make(map[string]int) // value = index in collectedAnnotations
+
 		for {
 			// If context was cancelled/timed out, let defer handle it
 			if ctx.Err() != nil {
@@ -1262,6 +1291,44 @@ func HandleOpenAIChatCompletionStreaming(
 					response.Usage = nil
 				}
 
+				// Collect citations/search_results/videos before the choices length check
+				// so they are not lost when they arrive in empty-choices or empty-delta chunks.
+				for _, c := range response.Citations {
+					if _, exists := seenCitations[c]; !exists {
+						seenCitations[c] = struct{}{}
+						collectedCitations = append(collectedCitations, c)
+					}
+				}
+				// SearchResults and Videos use keep-last semantics: if the same URL appears
+				// again in a later chunk (e.g. with a more complete title or snippet), the
+				// newer entry replaces the earlier one at the same position in the slice so
+				// that insertion order is preserved. Entries with an empty URL are always
+				// appended (no dedup) to avoid silently collapsing distinct results.
+				for _, sr := range response.SearchResults {
+					if sr.URL == "" {
+						collectedSearchResults = append(collectedSearchResults, sr)
+						continue
+					}
+					if idx, exists := seenSearchResultURLs[sr.URL]; exists {
+						collectedSearchResults[idx] = sr
+					} else {
+						seenSearchResultURLs[sr.URL] = len(collectedSearchResults)
+						collectedSearchResults = append(collectedSearchResults, sr)
+					}
+				}
+				for _, v := range response.Videos {
+					if v.URL == "" {
+						collectedVideos = append(collectedVideos, v)
+						continue
+					}
+					if idx, exists := seenVideoURLs[v.URL]; exists {
+						collectedVideos[idx] = v
+					} else {
+						seenVideoURLs[v.URL] = len(collectedVideos)
+						collectedVideos = append(collectedVideos, v)
+					}
+				}
+
 				if response.Model != "" {
 					modelName = response.Model
 				}
@@ -1285,14 +1352,29 @@ func HandleOpenAIChatCompletionStreaming(
 					created = response.Created
 				}
 
-				// Handle regular content chunks, including reasoning
+				// Collect annotations from this chunk for the final synthetic chunk aggregation.
+				if choice.ChatStreamResponseChoice != nil && choice.ChatStreamResponseChoice.Delta != nil {
+					for _, ann := range choice.ChatStreamResponseChoice.Delta.Annotations {
+						key := annotationCompositeKey(ann)
+						if idx, exists := seenAnnotationKeys[key]; exists {
+							// Keep-last: a later chunk may carry richer metadata (title, sources, type).
+							collectedAnnotations[idx] = ann
+						} else {
+							seenAnnotationKeys[key] = len(collectedAnnotations)
+							collectedAnnotations = append(collectedAnnotations, ann)
+						}
+					}
+				}
+
+				// Handle regular content chunks, including reasoning and annotations
 				if choice.ChatStreamResponseChoice != nil &&
 					choice.ChatStreamResponseChoice.Delta != nil &&
 					((choice.ChatStreamResponseChoice.Delta.Content != nil && *choice.ChatStreamResponseChoice.Delta.Content != "") ||
 						choice.ChatStreamResponseChoice.Delta.Reasoning != nil ||
 						len(choice.ChatStreamResponseChoice.Delta.ReasoningDetails) > 0 ||
 						choice.ChatStreamResponseChoice.Delta.Audio != nil ||
-						len(choice.ChatStreamResponseChoice.Delta.ToolCalls) > 0) {
+						len(choice.ChatStreamResponseChoice.Delta.ToolCalls) > 0 ||
+						len(choice.ChatStreamResponseChoice.Delta.Annotations) > 0) {
 					if choice.FinishReason != nil && *choice.FinishReason != "" {
 						forwardedTerminalFinishReason = true
 					}
@@ -1322,6 +1404,16 @@ func HandleOpenAIChatCompletionStreaming(
 				finalFinishReason = nil
 			}
 			response := providerUtils.CreateBifrostChatCompletionChunkResponse(messageID, usage, finalFinishReason, chunkIndex, modelName, created)
+			// Attach any provider-specific top-level fields collected during the stream
+			// (e.g. Perplexity citations that arrived in empty-delta chunks).
+			response.Citations = collectedCitations
+			response.SearchResults = collectedSearchResults
+			response.Videos = collectedVideos
+			// Attach aggregated annotations to the final synthetic chunk so downstream
+			// clients can retrieve the complete set without streaming logic.
+			if len(collectedAnnotations) > 0 {
+				response.Choices[0].ChatStreamResponseChoice.Delta.Annotations = collectedAnnotations
+			}
 			if postResponseConverter != nil {
 				response = postResponseConverter(response)
 			}

--- a/core/providers/openai/streaming_citations_test.go
+++ b/core/providers/openai/streaming_citations_test.go
@@ -1,0 +1,634 @@
+package openai_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bytedance/sonic"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	openaiprovider "github.com/maximhq/bifrost/core/providers/openai"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// noopPostHook is a minimal PostHookRunner that passes through responses unchanged.
+func noopPostHook(_ *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return result, err
+}
+
+// newTestOpenAIProvider creates an OpenAI provider pointing at the given base URL.
+func newTestOpenAIProvider(t *testing.T, baseURL string) *openaiprovider.OpenAIProvider {
+	t.Helper()
+	return openaiprovider.NewOpenAIProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{
+			BaseURL:                        baseURL,
+			DefaultRequestTimeoutInSeconds: 10,
+		},
+	}, bifrost.NewNoOpLogger())
+}
+
+// drainStreamCitations collects all chat-response chunks from the stream channel
+// and returns the Citations, SearchResults and Videos from the final synthetic
+// (terminal) chunk — i.e. the last non-nil BifrostChatResponse.
+func drainStreamCitations(t *testing.T, stream chan *schemas.BifrostStreamChunk) ([]string, []schemas.SearchResult, []schemas.VideoResult) {
+	t.Helper()
+
+	var lastChatResp *schemas.BifrostChatResponse
+	for chunk := range stream {
+		if chunk == nil {
+			continue
+		}
+		if chunk.BifrostError != nil {
+			t.Fatalf("stream returned error: %v", chunk.BifrostError)
+		}
+		if chunk.BifrostChatResponse != nil {
+			lastChatResp = chunk.BifrostChatResponse
+		}
+	}
+	if lastChatResp == nil {
+		t.Fatal("stream produced no BifrostChatResponse chunks")
+	}
+	return lastChatResp.Citations, lastChatResp.SearchResults, lastChatResp.Videos
+}
+
+// TestHandleOpenAIChatCompletionStreaming_CitationsCollectedFromEmptyChoicesChunk
+// verifies that citations arriving in an empty-choices final chunk (the Perplexity
+// pattern) are accumulated and attached to the terminal synthetic chunk, not dropped.
+func TestHandleOpenAIChatCompletionStreaming_CitationsCollectedFromEmptyChoicesChunk(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Chunk 1: content delta
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"The answer.\"},\"finish_reason\":null}]}\n\n")
+		// Chunk 2: finish_reason chunk
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+		// Chunk 3: empty choices + citations (Perplexity pattern)
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[],\"citations\":[\"https://example.com/a\",\"https://example.com/b\"],\"search_results\":[{\"url\":\"https://example.com/a\",\"title\":\"Source A\"},{\"url\":\"https://example.com/b\",\"title\":\"Source B\"}]}\n\n")
+		// Terminator
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(t, server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewEnvVar("test-key")}
+
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHook, nil, key, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "sonar",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletionStream returned error: %v", bifrostErr)
+	}
+
+	citations, searchResults, _ := drainStreamCitations(t, stream)
+
+	if len(citations) != 2 {
+		t.Errorf("expected 2 citations, got %d: %v", len(citations), citations)
+	}
+	if len(searchResults) != 2 {
+		t.Errorf("expected 2 search_results, got %d: %v", len(searchResults), searchResults)
+	}
+	if len(citations) > 0 && citations[0] != "https://example.com/a" {
+		t.Errorf("expected first citation %q, got %q", "https://example.com/a", citations[0])
+	}
+}
+
+// TestHandleOpenAIChatCompletionStreaming_CitationsDeduplicated verifies that a
+// citation URL appearing in multiple chunks is only kept once in the terminal chunk.
+func TestHandleOpenAIChatCompletionStreaming_CitationsDeduplicated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// First chunk with citations
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[],\"citations\":[\"https://example.com/a\",\"https://example.com/b\"]}\n\n")
+		// Second chunk that repeats the same citations plus one new one
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[],\"citations\":[\"https://example.com/b\",\"https://example.com/c\"]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(t, server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewEnvVar("test-key")}
+
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHook, nil, key, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "sonar",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletionStream returned error: %v", bifrostErr)
+	}
+
+	citations, _, _ := drainStreamCitations(t, stream)
+
+	// Expect exactly 3 unique citations in first-seen order: a, b, c
+	if len(citations) != 3 {
+		t.Errorf("expected 3 deduplicated citations, got %d: %v", len(citations), citations)
+	}
+	expected := []string{"https://example.com/a", "https://example.com/b", "https://example.com/c"}
+	for i, want := range expected {
+		if i >= len(citations) {
+			break
+		}
+		if citations[i] != want {
+			t.Errorf("citations[%d]: expected %q, got %q", i, want, citations[i])
+		}
+	}
+}
+
+// TestHandleOpenAIChatCompletionStreaming_SearchResultsDeduplicated verifies that
+// SearchResult entries sharing the same URL are deduplicated across chunks.
+func TestHandleOpenAIChatCompletionStreaming_SearchResultsDeduplicated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[],\"search_results\":[{\"url\":\"https://example.com/x\",\"title\":\"X\"}]}\n\n")
+		// Same URL repeated
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[],\"search_results\":[{\"url\":\"https://example.com/x\",\"title\":\"X-duplicate\"},{\"url\":\"https://example.com/y\",\"title\":\"Y\"}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(t, server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewEnvVar("test-key")}
+
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHook, nil, key, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "sonar",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletionStream returned error: %v", bifrostErr)
+	}
+
+	_, searchResults, _ := drainStreamCitations(t, stream)
+
+	if len(searchResults) != 2 {
+		t.Errorf("expected 2 deduplicated search_results, got %d: %v", len(searchResults), searchResults)
+	}
+	if len(searchResults) > 0 && searchResults[0].URL != "https://example.com/x" {
+		t.Errorf("expected first search result URL %q, got %q", "https://example.com/x", searchResults[0].URL)
+	}
+}
+
+// TestHandleOpenAIChatCompletionStreaming_CitationsInContentAndEmptyChunk validates the
+// realistic mixed scenario: a provider emits partial citations alongside content
+// and then repeats/extends them in a trailing empty-choices chunk. The final
+// result must contain exactly the deduplicated union, in first-seen order.
+func TestHandleOpenAIChatCompletionStreaming_CitationsInContentAndEmptyChunk(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Content chunk that already carries one citation
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"The answer.\"},\"finish_reason\":null}],\"citations\":[\"https://example.com/a\"]}\n\n")
+		// Finish-reason chunk (no citations)
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+		// Empty-choices chunk with the same citation repeated plus a new one
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[],\"citations\":[\"https://example.com/a\",\"https://example.com/b\"]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(t, server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewEnvVar("test-key")}
+
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHook, nil, key, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "sonar",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletionStream returned error: %v", bifrostErr)
+	}
+
+	citations, _, _ := drainStreamCitations(t, stream)
+
+	// Expect exactly 2 citations: "a" (first-seen) and "b" (new), with "a" not duplicated.
+	if len(citations) != 2 {
+		t.Errorf("expected 2 deduplicated citations, got %d: %v", len(citations), citations)
+	}
+	expected := []string{"https://example.com/a", "https://example.com/b"}
+	for i, want := range expected {
+		if i >= len(citations) {
+			break
+		}
+		if citations[i] != want {
+			t.Errorf("citations[%d]: expected %q, got %q", i, want, citations[i])
+		}
+	}
+}
+
+// TestHandleOpenAIChatCompletionStreaming_SearchResultKeepLast verifies that when a
+// provider sends two chunks carrying the same search-result URL, the later entry
+// (with potentially richer metadata) overwrites the first in the final output,
+// preserving insertion order of the URL slot.
+func TestHandleOpenAIChatCompletionStreaming_SearchResultKeepLast(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// First chunk: partial metadata
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[],\"search_results\":[{\"url\":\"https://example.com/x\",\"title\":\"Old title\"}]}\n\n")
+		// Second chunk: same URL with a richer title (simulates provider updating metadata)
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[],\"search_results\":[{\"url\":\"https://example.com/x\",\"title\":\"Better title\"},{\"url\":\"https://example.com/y\",\"title\":\"Y\"}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(t, server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewEnvVar("test-key")}
+
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHook, nil, key, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "sonar",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletionStream returned error: %v", bifrostErr)
+	}
+
+	_, searchResults, _ := drainStreamCitations(t, stream)
+
+	// Expect 2 entries preserving insertion order (x first, y second).
+	if len(searchResults) != 2 {
+		t.Errorf("expected 2 search_results, got %d: %v", len(searchResults), searchResults)
+	}
+	// The entry for URL "x" must carry the latest title.
+	if len(searchResults) > 0 {
+		if searchResults[0].URL != "https://example.com/x" {
+			t.Errorf("expected first URL %q, got %q", "https://example.com/x", searchResults[0].URL)
+		}
+		if searchResults[0].Title != "Better title" {
+			t.Errorf("expected keep-last title %q, got %q", "Better title", searchResults[0].Title)
+		}
+	}
+}
+
+// TestHandleOpenAIChatCompletionStreaming_EmptyURLSearchResultsNotCollapsed verifies
+// that search results with an empty URL are never collapsed into one slot. Each is
+// appended as a distinct entry regardless of how many empty-URL results appear.
+func TestHandleOpenAIChatCompletionStreaming_EmptyURLSearchResultsNotCollapsed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Two search results with no URL — must not be deduplicated against each other.
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-abc\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"sonar\",\"choices\":[],\"search_results\":[{\"url\":\"\",\"title\":\"No-URL result A\"},{\"url\":\"\",\"title\":\"No-URL result B\"}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(t, server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewEnvVar("test-key")}
+
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHook, nil, key, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "sonar",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletionStream returned error: %v", bifrostErr)
+	}
+
+	_, searchResults, _ := drainStreamCitations(t, stream)
+
+	// Both results must survive — empty URL must not collapse them into one.
+	if len(searchResults) != 2 {
+		t.Errorf("expected 2 search_results (empty-URL entries kept distinct), got %d: %v", len(searchResults), searchResults)
+	}
+	if len(searchResults) >= 1 && searchResults[0].Title != "No-URL result A" {
+		t.Errorf("expected title %q, got %q", "No-URL result A", searchResults[0].Title)
+	}
+	if len(searchResults) >= 2 && searchResults[1].Title != "No-URL result B" {
+		t.Errorf("expected title %q, got %q", "No-URL result B", searchResults[1].Title)
+	}
+}
+
+// drainStreamAnnotations drains the stream and returns:
+//   - chunksWithAnnotations: count of received chunks (intermediate + final synthetic)
+//     whose delta.annotations slice is non-empty. Use this to verify annotation-only
+//     chunks are not dropped by the forwarding gate.
+//   - finalChunkAnnotations: annotations on the last BifrostChatResponse chunk (the
+//     terminal synthetic chunk produced by Bifrost).
+func drainStreamAnnotations(t *testing.T, stream chan *schemas.BifrostStreamChunk) (chunksWithAnnotations int, finalChunkAnnotations []schemas.ChatAssistantMessageAnnotation) {
+	t.Helper()
+	var lastChatResp *schemas.BifrostChatResponse
+	for chunk := range stream {
+		if chunk == nil {
+			continue
+		}
+		if chunk.BifrostError != nil {
+			t.Fatalf("stream returned error: %v", chunk.BifrostError)
+		}
+		if chunk.BifrostChatResponse != nil {
+			if len(chunk.BifrostChatResponse.Choices) > 0 {
+				choice := chunk.BifrostChatResponse.Choices[0]
+				if choice.ChatStreamResponseChoice != nil &&
+					choice.ChatStreamResponseChoice.Delta != nil &&
+					len(choice.ChatStreamResponseChoice.Delta.Annotations) > 0 {
+					chunksWithAnnotations++
+				}
+			}
+			lastChatResp = chunk.BifrostChatResponse
+		}
+	}
+	if lastChatResp == nil {
+		t.Fatal("stream produced no BifrostChatResponse chunks")
+	}
+	if len(lastChatResp.Choices) > 0 {
+		choice := lastChatResp.Choices[0]
+		if choice.ChatStreamResponseChoice != nil && choice.ChatStreamResponseChoice.Delta != nil {
+			finalChunkAnnotations = choice.ChatStreamResponseChoice.Delta.Annotations
+		}
+	}
+	return
+}
+
+// TestHandleOpenAIChatCompletionStreaming_AnnotationOnlyChunkForwarded verifies that
+// a chunk carrying only delta.annotations (no content, reasoning, or tool calls) is
+// not dropped by the forwarding gate and reaches the stream consumer.
+func TestHandleOpenAIChatCompletionStreaming_AnnotationOnlyChunkForwarded(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Chunk 1: role header
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-ann\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n")
+		// Chunk 2: annotation-only — no content, purely delta.annotations
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-ann\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://example.com/src\",\"title\":\"Source\",\"start_index\":0,\"end_index\":3}}]},\"finish_reason\":null}]}\n\n")
+		// Chunk 3: finish
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-ann\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(t, server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewEnvVar("test-key")}
+
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHook, nil, key, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletionStream returned error: %v", bifrostErr)
+	}
+
+	chunksWithAnnotations, finalAnnotations := drainStreamAnnotations(t, stream)
+
+	// At least 2 annotation-bearing chunks: the intermediate annotation-only chunk AND
+	// the final synthetic chunk (both should carry the annotation).
+	if chunksWithAnnotations < 2 {
+		t.Errorf("expected >= 2 chunks with annotations (intermediate + synthetic), got %d — annotation-only chunk may have been dropped by forwarding gate", chunksWithAnnotations)
+	}
+	if len(finalAnnotations) != 1 {
+		t.Errorf("expected 1 annotation on final synthetic chunk, got %d", len(finalAnnotations))
+	}
+	if len(finalAnnotations) > 0 && finalAnnotations[0].URLCitation.Title != "Source" {
+		t.Errorf("expected annotation title %q, got %q", "Source", finalAnnotations[0].URLCitation.Title)
+	}
+}
+
+// TestHandleOpenAIChatCompletionStreaming_AnnotationsAggregatedOnFinalChunk verifies
+// that annotations from multiple streaming chunks are collected and attached to the
+// terminal synthetic chunk's delta.Annotations so non-streaming consumers get the
+// full set in one place.
+func TestHandleOpenAIChatCompletionStreaming_AnnotationsAggregatedOnFinalChunk(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Chunk 1: content with first annotation
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-agg\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"See \",\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://example.com/a\",\"title\":\"A\",\"start_index\":0,\"end_index\":3}}]},\"finish_reason\":null}]}\n\n")
+		// Chunk 2: second annotation (different URL and position)
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-agg\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://example.com/b\",\"title\":\"B\",\"start_index\":4,\"end_index\":7}}]},\"finish_reason\":null}]}\n\n")
+		// Chunk 3: finish
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-agg\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(t, server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewEnvVar("test-key")}
+
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHook, nil, key, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletionStream returned error: %v", bifrostErr)
+	}
+
+	_, finalAnnotations := drainStreamAnnotations(t, stream)
+
+	// Both annotations must be present on the synthetic final chunk.
+	if len(finalAnnotations) != 2 {
+		t.Errorf("expected 2 aggregated annotations on final chunk, got %d: %v", len(finalAnnotations), finalAnnotations)
+	}
+	if len(finalAnnotations) >= 1 && finalAnnotations[0].URLCitation.Title != "A" {
+		t.Errorf("expected first annotation title %q, got %q", "A", finalAnnotations[0].URLCitation.Title)
+	}
+	if len(finalAnnotations) >= 2 && finalAnnotations[1].URLCitation.Title != "B" {
+		t.Errorf("expected second annotation title %q, got %q", "B", finalAnnotations[1].URLCitation.Title)
+	}
+}
+
+// TestHandleOpenAIChatCompletionStreaming_AnnotationsDeduplicatedByCompositeKey verifies
+// composite-key deduplication semantics:
+//   - Same URL + same position across chunks → deduplicated to one entry (keep-last).
+//   - Same URL + different positions → kept as two distinct entries.
+func TestHandleOpenAIChatCompletionStreaming_AnnotationsDeduplicatedByCompositeKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Chunk 1: annotation at position 0-5 with old title
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-dedup\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://example.com/src\",\"title\":\"Old title\",\"start_index\":0,\"end_index\":5}}]},\"finish_reason\":null}]}\n\n")
+		// Chunk 2: same URL + same position → should replace chunk 1 (keep-last)
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-dedup\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://example.com/src\",\"title\":\"New title\",\"start_index\":0,\"end_index\":5}}]},\"finish_reason\":null}]}\n\n")
+		// Chunk 3: same URL but different position → must NOT be deduplicated
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-dedup\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://example.com/src\",\"title\":\"Different position\",\"start_index\":10,\"end_index\":15}}]},\"finish_reason\":null}]}\n\n")
+		// Chunk 4: finish
+		fmt.Fprint(w, "data: {\"id\":\"chatcmpl-dedup\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(t, server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewEnvVar("test-key")}
+
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHook, nil, key, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletionStream returned error: %v", bifrostErr)
+	}
+
+	_, finalAnnotations := drainStreamAnnotations(t, stream)
+
+	// Expect 2 entries: position 0-5 (keep-last title) and position 10-15.
+	if len(finalAnnotations) != 2 {
+		t.Errorf("expected 2 annotations (same-position dedup, different-position kept), got %d: %v", len(finalAnnotations), finalAnnotations)
+	}
+	// Position 0-5 should carry the keep-last title, not the old one.
+	if len(finalAnnotations) >= 1 {
+		if finalAnnotations[0].URLCitation.StartIndex != 0 || finalAnnotations[0].URLCitation.EndIndex != 5 {
+			t.Errorf("expected first annotation at 0-5, got %d-%d", finalAnnotations[0].URLCitation.StartIndex, finalAnnotations[0].URLCitation.EndIndex)
+		}
+		if finalAnnotations[0].URLCitation.Title != "New title" {
+			t.Errorf("expected keep-last title %q, got %q", "New title", finalAnnotations[0].URLCitation.Title)
+		}
+	}
+	// Position 10-15 must be a distinct entry.
+	if len(finalAnnotations) >= 2 {
+		if finalAnnotations[1].URLCitation.StartIndex != 10 || finalAnnotations[1].URLCitation.EndIndex != 15 {
+			t.Errorf("expected second annotation at 10-15, got %d-%d", finalAnnotations[1].URLCitation.StartIndex, finalAnnotations[1].URLCitation.EndIndex)
+		}
+	}
+}
+
+// TestHandleOpenAIChatCompletionStreaming_AnnotationsInSerializedJSON verifies that
+// annotations appear in the actual serialized JSON output of each BifrostStreamChunk,
+// not just in the Go struct fields. This catches serialization issues (e.g., sonic
+// JIT mishandling embedded struct pointers, build caching, or field tag problems)
+// that struct-level assertions would miss.
+//
+// The test simulates the exact pattern seen with OpenRouter + Perplexity Sonar:
+// an initial chunk carries delta.annotations alongside content:"" and role:"assistant".
+func TestHandleOpenAIChatCompletionStreaming_AnnotationsInSerializedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// Chunk 1: content + role + annotations (OpenRouter + Perplexity pattern)
+		fmt.Fprint(w, "data: {\"id\":\"gen-test-json\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"perplexity/sonar\",\"provider\":\"Perplexity\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"\",\"role\":\"assistant\",\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://example.com/a\",\"title\":\"Source A\",\"start_index\":0,\"end_index\":5}},{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://example.com/b\",\"title\":\"Source B\",\"start_index\":10,\"end_index\":15}}]},\"finish_reason\":null}]}\n\n")
+		// Chunk 2: regular content
+		fmt.Fprint(w, "data: {\"id\":\"gen-test-json\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"perplexity/sonar\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Saturn has rings\"},\"finish_reason\":null}]}\n\n")
+		// Chunk 3: annotation-only (no content)
+		fmt.Fprint(w, "data: {\"id\":\"gen-test-json\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"perplexity/sonar\",\"choices\":[{\"index\":0,\"delta\":{\"annotations\":[{\"type\":\"url_citation\",\"url_citation\":{\"url\":\"https://example.com/c\",\"title\":\"Source C\",\"start_index\":20,\"end_index\":25}}]},\"finish_reason\":null}]}\n\n")
+		// Chunk 4: finish
+		fmt.Fprint(w, "data: {\"id\":\"gen-test-json\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"perplexity/sonar\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer server.Close()
+
+	provider := newTestOpenAIProvider(t, server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewEnvVar("test-key")}
+
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, noopPostHook, nil, key, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "perplexity/sonar",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletionStream returned error: %v", bifrostErr)
+	}
+
+	// Track chunks where the serialized JSON contains "annotations" in delta
+	var jsonAnnotationChunks int
+	var allChunks int
+	var finalChunkJSON string
+
+	for chunk := range stream {
+		if chunk == nil {
+			continue
+		}
+		if chunk.BifrostError != nil {
+			t.Fatalf("stream returned error: %v", chunk.BifrostError)
+		}
+		allChunks++
+
+		// Serialize exactly as the HTTP handler does: sonic.Marshal → BifrostStreamChunk.MarshalJSON
+		chunkJSON, err := sonic.Marshal(chunk)
+		if err != nil {
+			t.Fatalf("failed to marshal chunk %d: %v", allChunks, err)
+		}
+		chunkStr := string(chunkJSON)
+		finalChunkJSON = chunkStr
+
+		// Verify annotations in serialized JSON (not just struct fields)
+		if strings.Contains(chunkStr, `"annotations"`) {
+			jsonAnnotationChunks++
+
+			// Parse the serialized JSON back and verify structure
+			var parsed map[string]interface{}
+			if err := sonic.UnmarshalString(chunkStr, &parsed); err != nil {
+				t.Fatalf("failed to re-parse chunk JSON: %v", err)
+			}
+			choices, ok := parsed["choices"].([]interface{})
+			if !ok || len(choices) == 0 {
+				t.Fatal("serialized JSON has no choices array")
+			}
+			choice, ok := choices[0].(map[string]interface{})
+			if !ok {
+				t.Fatal("choices[0] is not an object")
+			}
+			delta, ok := choice["delta"].(map[string]interface{})
+			if !ok {
+				t.Fatal("choices[0].delta is not an object")
+			}
+			annotations, ok := delta["annotations"].([]interface{})
+			if !ok || len(annotations) == 0 {
+				t.Fatalf("choices[0].delta.annotations missing or empty in serialized JSON: delta=%v", delta)
+			}
+			// Verify annotation structure
+			ann, ok := annotations[0].(map[string]interface{})
+			if !ok {
+				t.Fatal("annotation[0] is not an object")
+			}
+			if ann["type"] != "url_citation" {
+				t.Errorf("expected annotation type %q, got %v", "url_citation", ann["type"])
+			}
+			urlCitation, ok := ann["url_citation"].(map[string]interface{})
+			if !ok {
+				t.Fatal("annotation[0].url_citation is not an object")
+			}
+			if urlCitation["url"] == nil || urlCitation["url"] == "" {
+				t.Error("annotation[0].url_citation.url is missing or empty in serialized JSON")
+			}
+		}
+	}
+
+	// At least 3 chunks should have annotations:
+	// chunk 1 (content + annotations), chunk 3 (annotation-only), final synthetic chunk
+	if jsonAnnotationChunks < 3 {
+		t.Errorf("expected >= 3 chunks with annotations in serialized JSON, got %d out of %d total", jsonAnnotationChunks, allChunks)
+	}
+
+	// Verify the final (synthetic) chunk has all 3 aggregated annotations
+	if !strings.Contains(finalChunkJSON, `"annotations"`) {
+		t.Fatal("final synthetic chunk JSON does not contain annotations")
+	}
+	var finalParsed map[string]interface{}
+	if err := sonic.UnmarshalString(finalChunkJSON, &finalParsed); err != nil {
+		t.Fatalf("failed to parse final chunk JSON: %v", err)
+	}
+	finalChoices := finalParsed["choices"].([]interface{})
+	finalDelta := finalChoices[0].(map[string]interface{})["delta"].(map[string]interface{})
+	finalAnnotations := finalDelta["annotations"].([]interface{})
+	if len(finalAnnotations) != 3 {
+		t.Errorf("expected 3 aggregated annotations on final chunk, got %d", len(finalAnnotations))
+	}
+}

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -106,3 +106,8 @@ func SanitizeUserField(user *string) *string {
 	}
 	return user
 }
+
+// annotationCompositeKey delegates to schemas.AnnotationCompositeKey.
+func annotationCompositeKey(ann schemas.ChatAssistantMessageAnnotation) string {
+	return schemas.AnnotationCompositeKey(ann)
+}

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1330,6 +1330,23 @@ type ChatAssistantMessageAnnotationCitation struct {
 	Type       *string      `json:"type,omitempty"`
 }
 
+// AnnotationCompositeKey returns a per-position deduplication key for ann.
+// The key prefers URL when available (the most stable identifier across
+// partial→final streaming updates), falling back to Title, then Type.
+// Format: "type:base:startIndex:endIndex". This keeps citations of the same
+// source at different text offsets as distinct entries while deduplicating
+// exact repeats with keep-last semantics.
+func AnnotationCompositeKey(ann ChatAssistantMessageAnnotation) string {
+	if ann.URLCitation.URL != nil && *ann.URLCitation.URL != "" {
+		return fmt.Sprintf("%s:%s:%d:%d", ann.Type, *ann.URLCitation.URL, ann.URLCitation.StartIndex, ann.URLCitation.EndIndex)
+	}
+	base := ann.URLCitation.Title
+	if base == "" {
+		base = ann.Type
+	}
+	return fmt.Sprintf("%s:%s:%d:%d", ann.Type, base, ann.URLCitation.StartIndex, ann.URLCitation.EndIndex)
+}
+
 // ChatAssistantMessageToolCall represents a tool call in a message
 type ChatAssistantMessageToolCall struct {
 	Index    uint16                               `json:"index"`
@@ -1421,13 +1438,14 @@ type ChatStreamResponseChoice struct {
 
 // ChatStreamResponseChoiceDelta represents a delta in the stream response
 type ChatStreamResponseChoiceDelta struct {
-	Role             *string                        `json:"role,omitempty"`      // Only in the first chunk
-	Content          *string                        `json:"content,omitempty"`   // May be empty string or null
-	Refusal          *string                        `json:"refusal,omitempty"`   // Refusal content if any
-	Audio            *ChatAudioMessageAudio         `json:"audio,omitempty"`     // Audio data if any
-	Reasoning        *string                        `json:"reasoning,omitempty"` // May be empty string or null
-	ReasoningDetails []ChatReasoningDetails         `json:"reasoning_details,omitempty"`
-	ToolCalls        []ChatAssistantMessageToolCall `json:"tool_calls,omitempty"` // If tool calls used (supports incremental updates)
+	Role             *string                          `json:"role,omitempty"`             // Only in the first chunk
+	Content          *string                          `json:"content,omitempty"`          // May be empty string or null
+	Refusal          *string                          `json:"refusal,omitempty"`          // Refusal content if any
+	Audio            *ChatAudioMessageAudio           `json:"audio,omitempty"`            // Audio data if any
+	Reasoning        *string                          `json:"reasoning,omitempty"`        // May be empty string or null
+	ReasoningDetails []ChatReasoningDetails           `json:"reasoning_details,omitempty"`
+	Annotations      []ChatAssistantMessageAnnotation `json:"annotations,omitempty"`      // OpenAI-style url_citation annotations (e.g. OpenRouter→Perplexity)
+	ToolCalls        []ChatAssistantMessageToolCall   `json:"tool_calls,omitempty"`       // If tool calls used (supports incremental updates)
 }
 
 // UnmarshalJSON implements custom unmarshalling for ChatStreamResponseChoiceDelta.

--- a/framework/streaming/chat.go
+++ b/framework/streaming/chat.go
@@ -107,7 +107,38 @@ func deepCopyChatStreamDelta(original *schemas.ChatStreamResponseChoiceDelta) *s
 		}
 	}
 
+	// Deep copy Annotations slice
+	if original.Annotations != nil {
+		copy.Annotations = make([]schemas.ChatAssistantMessageAnnotation, len(original.Annotations))
+		for i, ann := range original.Annotations {
+			copyAnn := schemas.ChatAssistantMessageAnnotation{
+				Type: ann.Type,
+				URLCitation: schemas.ChatAssistantMessageAnnotationCitation{
+					StartIndex: ann.URLCitation.StartIndex,
+					EndIndex:   ann.URLCitation.EndIndex,
+					Title:      ann.URLCitation.Title,
+				},
+			}
+			if ann.URLCitation.URL != nil {
+				urlCopy := *ann.URLCitation.URL
+				copyAnn.URLCitation.URL = &urlCopy
+			}
+			if ann.URLCitation.Type != nil {
+				typCopy := *ann.URLCitation.Type
+				copyAnn.URLCitation.Type = &typCopy
+			}
+			// Sources is *interface{}; share the pointer — content is not mutated downstream
+			copyAnn.URLCitation.Sources = ann.URLCitation.Sources
+			copy.Annotations[i] = copyAnn
+		}
+	}
+
 	return copy
+}
+
+// annotationCompositeKey delegates to schemas.AnnotationCompositeKey.
+func annotationCompositeKey(ann schemas.ChatAssistantMessageAnnotation) string {
+	return schemas.AnnotationCompositeKey(ann)
 }
 
 // buildCompleteMessageFromChunks builds a complete message from accumulated chunks.
@@ -146,6 +177,12 @@ func (a *Accumulator) buildCompleteMessageFromChatStreamChunks(chunks []*ChatStr
 		args strings.Builder
 	}
 	var tcAccums map[uint16]*tcAccum
+
+	// Annotations collected across chunks; deduplicated by composite key (url:start:end
+	// or title:start:end for no-URL) with keep-last semantics so the final synthetic
+	// chunk's richer copies replace stale earlier versions at the same position.
+	var collectedAnnotations []schemas.ChatAssistantMessageAnnotation
+	seenAnnotationKeys := make(map[string]int) // value = index in collectedAnnotations
 
 	for _, chunk := range chunks {
 		if chunk == nil || chunk.Delta == nil {
@@ -252,6 +289,18 @@ func (a *Accumulator) buildCompleteMessageFromChatStreamChunks(chunks []*ChatStr
 				acc.args.WriteString(args)
 			}
 		}
+		// Accumulate annotations using composite key (url:startIndex:endIndex or
+		// title:startIndex:endIndex for no-URL). Keep-last so the final synthetic
+		// chunk's fully-resolved copy of each citation wins over an earlier, partial one.
+		for _, ann := range chunk.Delta.Annotations {
+			key := annotationCompositeKey(ann)
+			if idx, exists := seenAnnotationKeys[key]; exists {
+				collectedAnnotations[idx] = ann
+			} else {
+				seenAnnotationKeys[key] = len(collectedAnnotations)
+				collectedAnnotations = append(collectedAnnotations, ann)
+			}
+		}
 	}
 
 	// Finalize content
@@ -344,6 +393,14 @@ func (a *Accumulator) buildCompleteMessageFromChatStreamChunks(chunks []*ChatStr
 			})
 		}
 		completeMessage.ChatAssistantMessage.ToolCalls = toolCalls
+	}
+
+	// Finalize annotations
+	if len(collectedAnnotations) > 0 {
+		if completeMessage.ChatAssistantMessage == nil {
+			completeMessage.ChatAssistantMessage = &schemas.ChatAssistantMessage{}
+		}
+		completeMessage.ChatAssistantMessage.Annotations = collectedAnnotations
 	}
 
 	return completeMessage

--- a/ui/app/workspace/logs/views/logChatMessageView.tsx
+++ b/ui/app/workspace/logs/views/logChatMessageView.tsx
@@ -194,16 +194,29 @@ export default function LogChatMessageView({ message, audioFormat }: LogChatMess
 			{/* Handle annotations */}
 			{message.annotations && message.annotations.length > 0 && (
 				<CollapsibleBox title="Annotations" onCopy={() => JSON.stringify(message.annotations, null, 2)} collapsedHeight={100}>
-					<CodeEditor
-						className="z-0 w-full"
-						shouldAdjustInitialHeight={true}
-						maxHeight={400}
-						wrap={true}
-						code={JSON.stringify(message.annotations, null, 2)}
-						lang="json"
-						readonly={true}
-						options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
-					/>
+					<div className="flex flex-wrap gap-2 px-4 py-3">
+						{message.annotations.map((ann, idx) => {
+							const uc = ann?.url_citation;
+							if (!uc?.url) {
+								// eslint-disable-next-line no-console
+								console.debug("[annotations] skipping malformed annotation at index", idx, ann);
+								return null;
+							}
+							const base = uc.url || uc.title || "";
+							return (
+								<a
+									key={`${base}:${uc.start_index ?? 0}:${uc.end_index ?? 0}`}
+									href={uc.url}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/50 px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+									title={uc.url}
+								>
+									<span className="max-w-[240px] truncate">{uc.title || uc.url}</span>
+								</a>
+							);
+						})}
+					</div>
 				</CollapsibleBox>
 			)}
 

--- a/ui/app/workspace/logs/views/logResponsesMessageView.tsx
+++ b/ui/app/workspace/logs/views/logResponsesMessageView.tsx
@@ -144,16 +144,29 @@ function ContentBlockView({ block }: { block: ResponsesMessageContentBlock; inde
 		const jsonContent = JSON.stringify(block.annotations, null, 2);
 		return (
 			<CollapsibleBox title="Annotations" onCopy={() => jsonContent} collapsedHeight={100}>
-				<CodeEditor
-					className="z-0 w-full"
-					shouldAdjustInitialHeight={true}
-					maxHeight={150}
-					wrap={true}
-					code={jsonContent}
-					lang="json"
-					readonly={true}
-					options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
-				/>
+				<div className="flex flex-wrap gap-2 px-4 py-3">
+					{block.annotations.map((ann: { type?: string; url_citation?: { url?: string; title?: string; start_index?: number; end_index?: number } }, idx: number) => {
+						const uc = ann?.url_citation;
+						if (!uc?.url) {
+							// eslint-disable-next-line no-console
+							console.debug("[annotations] skipping malformed annotation at index", idx, ann);
+							return null;
+						}
+						const base = uc.url || uc.title || "";
+						return (
+							<a
+								key={`${base}:${uc.start_index ?? 0}:${uc.end_index ?? 0}`}
+								href={uc.url}
+								target="_blank"
+								rel="noopener noreferrer"
+								className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/50 px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+								title={uc.url}
+							>
+								<span className="max-w-[240px] truncate">{uc.title || uc.url}</span>
+							</a>
+						);
+					})}
+				</div>
 			</CollapsibleBox>
 		);
 	}

--- a/ui/components/prompts/components/messagesView/assistantMessageView.tsx
+++ b/ui/components/prompts/components/messagesView/assistantMessageView.tsx
@@ -1,7 +1,7 @@
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { Message, SerializedMessage } from "@/lib/message";
-import { InfoIcon, PencilIcon, XIcon } from "lucide-react";
+import { Message, SerializedMessage, type Annotation } from "@/lib/message";
+import { InfoIcon, LinkIcon, PencilIcon, XIcon } from "lucide-react";
 import { Markdown } from "@/components/ui/markdown";
 import { useEffect, useMemo, useRef, useState } from "react";
 import MessageRoleSwitcher from "./messageRoleSwitcher";
@@ -38,6 +38,7 @@ export function AssistantMessageView({
 	const content = message.content;
 	const isEmpty = !content;
 	const usage = message.usage;
+	const annotations = message.annotations;
 	const jsonBufferRef = useRef<string | null>(null);
 	const contentIsJson = useMemo(() => !isEmpty && !isStreaming && isJson(content), [content, isEmpty, isStreaming]);
 	const formattedJson = useMemo(() => {
@@ -187,6 +188,34 @@ export function AssistantMessageView({
 					</div>
 				)}
 			</div>
+
+			{annotations && annotations.length > 0 && (
+				<div className="mt-2 border-t border-border pt-2">
+					<div className="flex flex-wrap gap-2">
+						{annotations.map((ann, i) => {
+						if (!ann?.url_citation?.url) {
+							// eslint-disable-next-line no-console
+							console.debug("[annotations] skipping malformed annotation at index", i, ann);
+							return null;
+						}
+						const base = ann.url_citation.url || ann.url_citation.title || "";
+						return (
+							<a
+								key={`${base}:${ann.url_citation.start_index ?? 0}:${ann.url_citation.end_index ?? 0}`}
+									href={ann.url_citation.url}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="inline-flex items-center gap-1 rounded-md border border-border bg-muted/50 px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+									title={ann.url_citation.url}
+								>
+									<LinkIcon className="size-3 shrink-0" />
+									<span className="max-w-[200px] truncate">{ann.url_citation.title || ann.url_citation.url}</span>
+								</a>
+							);
+						})}
+					</div>
+				</div>
+			)}
 		</div>
 	);
 }

--- a/ui/components/prompts/context.tsx
+++ b/ui/components/prompts/context.tsx
@@ -436,22 +436,25 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 						if (!isActive()) return;
 						setMessages([...allMessages, placeholder]);
 					},
-					onStreamChunk: (content) => {
+					onStreamChunk: (content, annotations) => {
 						if (!isActive()) return;
 						setMessages((prev) => {
 							const updated = [...prev];
 							const last = updated[updated.length - 1];
 							const clone = last.clone();
 							clone.content = content;
+							if (annotations) clone.annotations = annotations;
 							updated[updated.length - 1] = clone;
 							return updated;
 						});
 					},
-					onComplete: (content, usage) => {
+					onComplete: (content, usage, annotations) => {
 						if (!isActive()) return;
 						setMessages((prev) => {
 							const updated = [...prev];
-							updated[updated.length - 1] = Message.response(content, 0, usage);
+							const msg = Message.response(content, 0, usage);
+							if (annotations) msg.annotations = annotations;
+							updated[updated.length - 1] = msg;
 							return updated;
 						});
 					},
@@ -515,22 +518,25 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 						if (!isActive()) return;
 						setMessages([...allMessages, placeholder]);
 					},
-					onStreamChunk: (content) => {
+					onStreamChunk: (content, annotations) => {
 						if (!isActive()) return;
 						setMessages((prev) => {
 							const updated = [...prev];
 							const last = updated[updated.length - 1];
 							const clone = last.clone();
 							clone.content = content;
+							if (annotations) clone.annotations = annotations;
 							updated[updated.length - 1] = clone;
 							return updated;
 						});
 					},
-					onComplete: (content, usage) => {
+					onComplete: (content, usage, annotations) => {
 						if (!isActive()) return;
 						setMessages((prev) => {
 							const updated = [...prev];
-							updated[updated.length - 1] = Message.response(content, 0, usage);
+							const msg = Message.response(content, 0, usage);
+							if (annotations) msg.annotations = annotations;
+							updated[updated.length - 1] = msg;
 							return updated;
 						});
 					},

--- a/ui/components/prompts/utils/executor.ts
+++ b/ui/components/prompts/utils/executor.ts
@@ -1,4 +1,4 @@
-import { Message, type CompletionUsage, type ToolCall, type VariableMap, replaceVariablesInMessages } from "@/lib/message";
+import { Message, type Annotation, type CompletionUsage, type ToolCall, type VariableMap, replaceVariablesInMessages } from "@/lib/message";
 import { getErrorMessage } from "@/lib/store";
 import type { ModelParams } from "@/lib/types/prompts";
 
@@ -20,8 +20,8 @@ function getBaseUrl() {
 
 export interface ExecutionCallbacks {
 	onStreamingStart: (allMessages: Message[], placeholder: Message) => void;
-	onStreamChunk: (content: string) => void;
-	onComplete: (content: string, usage?: CompletionUsage) => void;
+	onStreamChunk: (content: string, annotations?: Annotation[]) => void;
+	onComplete: (content: string, usage?: CompletionUsage, annotations?: Annotation[]) => void;
 	onToolCallComplete: (content: string, toolCalls: ToolCall[], usage?: CompletionUsage) => void;
 	onEmptyResponse: () => void;
 	onError: (error: string) => void;
@@ -87,11 +87,12 @@ export async function executePrompt(
 			const data = await response.json();
 			const content = data.choices?.[0]?.message?.content ?? "";
 			const toolCalls = data.choices?.[0]?.message?.tool_calls as ToolCall[] | undefined;
+			const annotations = data.choices?.[0]?.message?.annotations as Annotation[] | undefined;
 			const usage = data.usage as CompletionUsage | undefined;
 			if (toolCalls && toolCalls.length > 0) {
 				callbacks.onToolCallComplete(content, toolCalls, usage);
 			} else if (content) {
-				callbacks.onComplete(content, usage);
+				callbacks.onComplete(content, usage, annotations);
 			} else {
 				callbacks.onEmptyResponse();
 			}
@@ -103,6 +104,12 @@ export async function executePrompt(
 			let assistantContent = "";
 			let streamUsage: CompletionUsage | undefined;
 			const toolCallsMap = new Map<number, ToolCall>();
+			let collectedAnnotations: Annotation[] = [];
+			// Accumulate annotations from delta chunks as they arrive.
+			// The backend deduplicates via schemas.AnnotationCompositeKey; this UI-side
+			// guard using the same (url, start_index, end_index) key provides a safety net
+			// in case a provider resends the same annotation across multiple chunks.
+			const annotationSeen = new Set<string>();
 			let buffer = "";
 
 			while (true) {
@@ -131,7 +138,24 @@ export async function executePrompt(
 						const content = delta?.content;
 						if (content) {
 							assistantContent += content;
-							callbacks.onStreamChunk(assistantContent);
+						}
+
+						const deltaAnnotations = delta?.annotations as Annotation[] | undefined;
+						if (deltaAnnotations?.length) {
+							const newAnnotations = deltaAnnotations.filter((a, i) => {
+								const base = a.url_citation?.url || a.url_citation?.title || "";
+								const k = `${base}:${a.url_citation?.start_index ?? 0}:${a.url_citation?.end_index ?? 0}`;
+								if (annotationSeen.has(k)) return false;
+								annotationSeen.add(k);
+								return true;
+							});
+							if (newAnnotations.length) {
+								collectedAnnotations = [...collectedAnnotations, ...newAnnotations];
+							}
+						}
+
+						if (content || deltaAnnotations?.length) {
+							callbacks.onStreamChunk(assistantContent, collectedAnnotations.length > 0 ? collectedAnnotations : undefined);
 						}
 
 						const deltaToolCalls = delta?.tool_calls as Array<{
@@ -170,7 +194,7 @@ export async function executePrompt(
 			if (toolCalls.length > 0) {
 				callbacks.onToolCallComplete(assistantContent, toolCalls, streamUsage);
 			} else if (assistantContent) {
-				callbacks.onComplete(assistantContent, streamUsage);
+				callbacks.onComplete(assistantContent, streamUsage, collectedAnnotations.length > 0 ? collectedAnnotations : undefined);
 			} else {
 				callbacks.onEmptyResponse();
 			}

--- a/ui/lib/message/index.ts
+++ b/ui/lib/message/index.ts
@@ -2,6 +2,8 @@ export { Message } from "./message";
 export {
 	MessageRole,
 	MessageType,
+	type Annotation,
+	type AnnotationCitation,
 	type APIMessage,
 	type CompletionRequest,
 	type CompletionResult,

--- a/ui/lib/message/message.ts
+++ b/ui/lib/message/message.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 import {
+	Annotation,
 	APIMessage,
 	CompletionRequest,
 	CompletionResult,
@@ -265,6 +266,27 @@ export class Message {
 			return calls && calls.length > 0 ? calls : undefined;
 		}
 		return undefined;
+	}
+
+	// Annotations
+
+	public get annotations(): Annotation[] | undefined {
+		if (this.originalType === MessageType.CompletionResult) {
+			const anns = (this._payload as CompletionResult)?.choices?.[0]?.message?.annotations;
+			return anns && anns.length > 0 ? anns : undefined;
+		}
+		return undefined;
+	}
+
+	public set annotations(annotations: Annotation[] | undefined) {
+		if (this.originalType === MessageType.CompletionResult) {
+			const result = this._payload as CompletionResult;
+			const choices = result?.choices?.map((c) => ({ ...c })) ?? [];
+			if (choices[0]) {
+				choices[0].message = { ...choices[0].message, annotations };
+			}
+			this._payload = { ...result, choices } as CompletionResult;
+		}
 	}
 
 	public get toolCallId(): string | undefined {

--- a/ui/lib/message/types.ts
+++ b/ui/lib/message/types.ts
@@ -24,6 +24,18 @@ export type ToolCall = {
 	function: ToolCallFunction;
 };
 
+export type AnnotationCitation = {
+  start_index?: number
+  end_index?: number
+  title?: string
+  url?: string
+}
+
+export type Annotation = {
+  type: string
+  url_citation?: AnnotationCitation
+}
+
 export type MessageContent = {
 	type: "text" | "image_url" | "input_audio" | "file";
 	text?: string;
@@ -62,6 +74,7 @@ export type CompletionResultChoice = {
 		role: MessageRole;
 		content: string;
 		tool_calls?: ToolCall[];
+		annotations?: Annotation[];
 	};
 	finish_reason?: string;
 };


### PR DESCRIPTION
## Summary

Fixes missing citations when using Perplexity Sonar via OpenRouter in streaming mode.

The root cause was that OpenRouter returns source references as `choices[].delta.annotations` (OpenAI-style `url_citation`), but these were not being parsed, forwarded, or accumulated within Bifrost. As a result, all citation data was silently dropped during streaming.

This PR ensures that annotations are correctly preserved and propagated end-to-end, restoring expected citation behavior for OpenRouter + Perplexity.

---

## Changes

* **Schema update**

  * Added `Annotations` field to `ChatStreamResponseChoiceDelta` to correctly unmarshal `delta.annotations` from OpenRouter responses.

* **Streaming pipeline fix**

  * Updated forwarding logic to allow chunks containing only annotations (previously skipped due to empty content).
  * Ensures annotation-only chunks are not dropped during streaming.

* **Accumulation & deduplication**

  * Implemented accumulation of annotations across streaming chunks.
  * Deduplicated annotations using URL as a best-effort key.
  * Handled edge cases where URL may be missing (fallback append behavior).

* **Deep copy support**

  * Extended `deepCopyChatStreamDelta` to include annotations.
  * Ensures annotations persist correctly through internal transformations.

* **Final message aggregation**

  * Aggregated annotations into the final assistant message for non-streaming consumers.

* **Tests added**

  * Streaming test for annotation-only chunks
  * Mixed scenario test (content + annotation chunks)
  * Deduplication validation

### Design decisions / trade-offs

* Used URL as a best-effort deduplication key (consistent with provider behavior), with fallback for empty URLs.
* Kept implementation scoped to known metadata fields to avoid introducing large architectural changes in a bugfix PR.
* Preserved streaming semantics (annotations flow through chunks) while also ensuring final aggregation for downstream consumers.

---

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

---

## Affected areas

* [x] Core (Go)
* [ ] Transports (HTTP)
* [x] Providers/Integrations
* [ ] Plugins
* [ ] UI (Next.js)
* [ ] Docs

---

## How to test

### 1. Run Bifrost locally

```sh
PORT=8081 LOG_LEVEL=debug make run LOCAL=1
```

---

### 2. Streaming validation (OpenRouter + Perplexity)

```sh
curl -N http://localhost:8081/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "openrouter/perplexity/sonar",
    "messages": [
      {"role": "user", "content": "Explain Saturn rings with sources"}
    ],
    "stream": true
  }'
```

#### Expected outcome:

* Multiple streaming chunks contain:

  ```json
  "annotations": [...]
  ```
* No annotation-only chunks are dropped
* URLs are deduplicated
* Order is preserved

---

### 3. Compare with OpenRouter direct

```sh
curl -N https://openrouter.ai/api/v1/chat/completions \
  -H "Authorization: Bearer $OPENROUTER_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "perplexity/sonar",
    "messages": [
      {"role": "user", "content": "Explain Saturn rings with sources"}
    ],
    "stream": true
  }'
```

#### Expected:

* Annotation structure matches (`delta.annotations`)
* Bifrost output should closely mirror provider output (minor differences due to search variability are acceptable)

---

### 4. Run tests

```sh
go test ./providers/openai/ -run TestHandleOpenAIChatCompletionStreaming -v
go test ./...
```

---

## Screenshots/Recordings

<img width="1067" height="803" alt="Screenshot 2026-04-12 143419" src="https://github.com/user-attachments/assets/4b0991ec-d0fa-424d-82f2-b60aeaa03d4e" />


---

## Breaking changes

* [ ] Yes
* [x] No

---

## Related issues

Closes #2543

---

## Security considerations

* No changes to authentication, secrets, or data handling.
* Only affects response transformation and streaming behavior.
* No new external inputs or attack surfaces introduced.

---

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [x] I added/updated tests where appropriate
* [ ] I updated documentation where needed
* [x] I verified builds succeed (Go and UI)
* [x] I verified the CI pipeline passes locally if applicable
