### PR TITLE
Fix plugin pipeline use-after-release race in short-circuit streaming path

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4616,6 +4616,7 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 			return newBifrostMessageChan(resp), nil
 		}
 		bifrost.releasePluginPipeline(pipeline)
+		return nil, nil
 	}
 	if preReq == nil {
 		bifrost.releasePluginPipeline(pipeline)

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4615,8 +4615,8 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 			}
 			return newBifrostMessageChan(resp), nil
 		}
-		bifrost.releasePluginPipeline(pipeline)
-		return nil, nil
+		// Empty short-circuit (all payload fields nil) is treated as no short-circuit;
+		// fall through to normal request processing with preReq.
 	}
 	if preReq == nil {
 		bifrost.releasePluginPipeline(pipeline)
@@ -4632,7 +4632,8 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 	msg := bifrost.getChannelMessage(*preReq)
 	msg.Context = ctx
 
-	// From here on, all paths are non-streaming and can safely defer pipeline release.
+	// From here on, the pipeline is not used to process individual stream chunks,
+	// so it is safe to defer its release.
 	defer bifrost.releasePluginPipeline(pipeline)
 
 	// Check if provider is closing before attempting to send (lock-free atomic check)

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4541,13 +4541,13 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 	}
 
 	pipeline := bifrost.getPluginPipeline()
-	defer bifrost.releasePluginPipeline(pipeline)
 
 	preReq, shortCircuit, preCount := pipeline.RunLLMPreHooks(ctx, req)
 	if shortCircuit != nil {
 		// Handle short-circuit with response (success case)
 		if shortCircuit.Response != nil {
 			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, shortCircuit.Response, nil, preCount)
+			bifrost.releasePluginPipeline(pipeline)
 			if bifrostErr != nil {
 				return nil, bifrostErr
 			}
@@ -4557,13 +4557,12 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		if shortCircuit.Stream != nil {
 			outputStream := make(chan *schemas.BifrostStreamChunk)
 
-			// Create a post hook runner cause pipeline object is put back in the pool on defer
-			pipelinePostHookRunner := func(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
-				return pipeline.RunPostLLMHooks(ctx, result, err, preCount)
-			}
-
+			// The goroutine takes ownership of the pipeline and releases it
+			// after the stream is fully drained. We must NOT defer release
+			// in the parent because it returns before the goroutine finishes.
 			go func() {
 				defer close(outputStream)
+				defer bifrost.releasePluginPipeline(pipeline)
 
 				for streamMsg := range shortCircuit.Stream {
 					if streamMsg == nil {
@@ -4591,7 +4590,7 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 					}
 
 					// Run post hooks on the stream message
-					processedResponse, processedError := pipelinePostHookRunner(ctx, bifrostResponse, streamMsg.BifrostError)
+					processedResponse, processedError := pipeline.RunPostLLMHooks(ctx, bifrostResponse, streamMsg.BifrostError, preCount)
 
 					// Build the client-facing chunk via the shared helper, which strips raw
 					// request/response fields when in logging-only mode without mutating the
@@ -4610,13 +4609,16 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		// Handle short-circuit with error
 		if shortCircuit.Error != nil {
 			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, nil, shortCircuit.Error, preCount)
+			bifrost.releasePluginPipeline(pipeline)
 			if bifrostErr != nil {
 				return nil, bifrostErr
 			}
 			return newBifrostMessageChan(resp), nil
 		}
+		bifrost.releasePluginPipeline(pipeline)
 	}
 	if preReq == nil {
+		bifrost.releasePluginPipeline(pipeline)
 		bifrostErr := newBifrostErrorFromMsg("bifrost request after plugin hooks cannot be nil")
 		bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
 			RequestType:    req.RequestType,
@@ -4628,6 +4630,9 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 
 	msg := bifrost.getChannelMessage(*preReq)
 	msg.Context = ctx
+
+	// From here on, all paths are non-streaming and can safely defer pipeline release.
+	defer bifrost.releasePluginPipeline(pipeline)
 
 	// Check if provider is closing before attempting to send (lock-free atomic check)
 	// This prevents "send on closed channel" panics during provider removal/update


### PR DESCRIPTION
The defer releasePluginPipeline(pipeline) at the top of tryStreamRequest would fire when the function returned, but a goroutine spawned for short-circuit streaming continued using that pipeline, introducing a use-after-release race.   

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


