### PR TITLE
Fix race condition in updateConfig handler by acquiring store mutex around read-modify-write of ClientConfig

### DIFF
--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -237,10 +237,10 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// Get current config with proper locking
-	h.store.Mu.Lock()
-	defer h.store.Mu.Unlock()
+	// Snapshot current config under read lock
+	h.store.Mu.RLock()
 	currentConfig := *h.store.ClientConfig
+	h.store.Mu.RUnlock()
 	updatedConfig := currentConfig
 
 	var restartReasons []string
@@ -408,7 +408,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	updatedConfig.LogRetentionDays = payload.ClientConfig.LogRetentionDays
 
 	// Update the store with the new config
+	h.store.Mu.Lock()
 	h.store.ClientConfig = &updatedConfig
+	h.store.Mu.Unlock()
 
 	if err := h.store.ConfigStore.UpdateClientConfig(ctx, &updatedConfig); err != nil {
 		logger.Warn("failed to save configuration: %v", err)

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -238,7 +238,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Get current config with proper locking
-	currentConfig := h.store.ClientConfig
+	h.store.Mu.Lock()
+	defer h.store.Mu.Unlock()
+	currentConfig := *h.store.ClientConfig
 	updatedConfig := currentConfig
 
 	var restartReasons []string
@@ -406,9 +408,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	updatedConfig.LogRetentionDays = payload.ClientConfig.LogRetentionDays
 
 	// Update the store with the new config
-	h.store.ClientConfig = updatedConfig
+	h.store.ClientConfig = &updatedConfig
 
-	if err := h.store.ConfigStore.UpdateClientConfig(ctx, updatedConfig); err != nil {
+	if err := h.store.ConfigStore.UpdateClientConfig(ctx, &updatedConfig); err != nil {
 		logger.Warn("failed to save configuration: %v", err)
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to save configuration: %v", err))
 		return


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


