### PR TITLE
feat: per-request overrides for raw request/response capture

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4611,12 +4611,19 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 			return nil, bifrostErr
 		}
 		bifrost.releaseChannelMessage(msg)
-		// Checking if need to drop raw messages
-		// This we use for requests like containers, container files, skills etc.
-		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop && resp != nil {
-			extraField := resp.GetExtraFields()
-			extraField.RawRequest = nil
-			extraField.RawResponse = nil
+		// Strip raw fields that were captured for logging but should not reach the client.
+		if resp != nil {
+			dropReq, _ := ctx.Value(schemas.BifrostContextKeyDropRawRequestFromClient).(bool)
+			dropResp, _ := ctx.Value(schemas.BifrostContextKeyDropRawResponseFromClient).(bool)
+			if dropReq || dropResp {
+				extraField := resp.GetExtraFields()
+				if dropReq {
+					extraField.RawRequest = nil
+				}
+				if dropResp {
+					extraField.RawResponse = nil
+				}
+			}
 		}
 		return resp, nil
 	case bifrostErrVal := <-msg.Err:
@@ -4624,16 +4631,26 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 		resp, bifrostErrPtr = pipeline.RunPostLLMHooks(msg.Context, nil, bifrostErrPtr, pluginCount)
 		drainAndAttachPluginLogs(msg.Context)
 		bifrost.releaseChannelMessage(msg)
-		// Drop raw request/response on error path too
-		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop {
+		// Strip raw fields on error path too.
+		dropReq, _ := ctx.Value(schemas.BifrostContextKeyDropRawRequestFromClient).(bool)
+		dropResp, _ := ctx.Value(schemas.BifrostContextKeyDropRawResponseFromClient).(bool)
+		if dropReq || dropResp {
 			if bifrostErrPtr != nil {
-				bifrostErrPtr.ExtraFields.RawRequest = nil
-				bifrostErrPtr.ExtraFields.RawResponse = nil
+				if dropReq {
+					bifrostErrPtr.ExtraFields.RawRequest = nil
+				}
+				if dropResp {
+					bifrostErrPtr.ExtraFields.RawResponse = nil
+				}
 			}
 			if resp != nil {
 				extraField := resp.GetExtraFields()
-				extraField.RawRequest = nil
-				extraField.RawResponse = nil
+				if dropReq {
+					extraField.RawRequest = nil
+				}
+				if dropResp {
+					extraField.RawResponse = nil
+				}
 			}
 		}
 		if bifrostErrPtr != nil {
@@ -5102,26 +5119,56 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, !IsStandardProvider(baseProvider))
 
 		// Determine whether this provider attempt should capture raw payloads.
-		// logging-only mode (store_raw_request_response=true, send_back_raw_*=false):
-		//   sets BifrostContextKeySendBackRaw* = true so providers capture via the unified
-		//   ShouldSendBackRaw* path, and sets BifrostContextKeyRawRequestResponseForLogging
-		//   so the payload is stripped before the response reaches the client.
-		// full send-back mode (send_back_raw_request/response=true):
-		//   BifrostContextKeySendBackRaw* are set as before; stripping flag stays false.
-		// Always set both flags explicitly so stale values from a previous provider
-		// attempt (e.g. first attempt was logging-only, fallback is full send-back)
-		// cannot leak into the new attempt on a reused context.
-		existingSendBackReq, _ := req.Context.Value(schemas.BifrostContextKeySendBackRawRequest).(bool)
-		existingSendBackResp, _ := req.Context.Value(schemas.BifrostContextKeySendBackRawResponse).(bool)
-		loggingOnly := config.StoreRawRequestResponse &&
-			!config.SendBackRawRequest && !existingSendBackReq &&
-			!config.SendBackRawResponse && !existingSendBackResp
-		req.Context.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, loggingOnly)
-		if loggingOnly {
-			// Enable capture via the standard flags so ShouldSendBackRaw* needs only one check.
-			req.Context.SetValue(schemas.BifrostContextKeySendBackRawRequest, true)
-			req.Context.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
+		//
+		// Effective values are computed by merging provider config with any per-request
+		// context overrides (BifrostContextKeySendBackRawRequest/Response and
+		// BifrostContextKeyStoreRawRequestResponse). A context value set to either true
+		// or false fully overrides the provider config for that flag.
+		//
+		// Each flag is independent:
+		//   send_back_raw_request  — include raw request bytes in the client response.
+		//   send_back_raw_response — include raw response bytes in the client response.
+		//   store_raw_request_response — persist raw bytes in log records (logging plugin only).
+		//
+		// Capture is enabled per-side whenever send-back OR store is requested for that side.
+		// Strip flags tell the response path to remove that side's bytes before the payload
+		// reaches the caller (used when store=true but send-back=false for that side).
+		//
+		// All internal signals are always written explicitly on every attempt so stale values
+		// from a previous provider attempt (e.g. different fallback provider config) cannot
+		// leak into the new attempt on a reused context. The user override keys
+		// (BifrostContextKeySendBackRaw*, BifrostContextKeyStoreRawRequestResponse) are
+		// never overwritten — they are read-only from bifrost.go's perspective.
+
+		// Step 1: compute effective value for each flag (provider config ← per-request override).
+		effectiveSendBackReq := config.SendBackRawRequest
+		if override, ok := req.Context.Value(schemas.BifrostContextKeySendBackRawRequest).(bool); ok {
+			effectiveSendBackReq = override
 		}
+		effectiveSendBackResp := config.SendBackRawResponse
+		if override, ok := req.Context.Value(schemas.BifrostContextKeySendBackRawResponse).(bool); ok {
+			effectiveSendBackResp = override
+		}
+		effectiveStore := config.StoreRawRequestResponse
+		if override, ok := req.Context.Value(schemas.BifrostContextKeyStoreRawRequestResponse).(bool); ok {
+			effectiveStore = override
+		}
+
+		// Step 2: derive per-side capture and strip flags.
+		// Capture if we need to send the data back OR store it — independent per side.
+		captureReq := effectiveSendBackReq || effectiveStore
+		captureResp := effectiveSendBackResp || effectiveStore
+		// Strip from client response if we captured for storage but not for send-back.
+		dropReq := effectiveStore && !effectiveSendBackReq
+		dropResp := effectiveStore && !effectiveSendBackResp
+
+		// Step 3: write all internal signals explicitly (never touch the user override keys).
+		req.Context.SetValue(schemas.BifrostContextKeyCaptureRawRequest, captureReq)
+		req.Context.SetValue(schemas.BifrostContextKeyCaptureRawResponse, captureResp)
+		req.Context.SetValue(schemas.BifrostContextKeyDropRawRequestFromClient, dropReq)
+		req.Context.SetValue(schemas.BifrostContextKeyDropRawResponseFromClient, dropResp)
+		// Tells the logging plugin whether to persist raw bytes in log records.
+		req.Context.SetValue(schemas.BifrostContextKeyShouldStoreRawInLogs, effectiveStore)
 
 		key := schemas.Key{}
 		var keys []schemas.Key

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1643,28 +1643,24 @@ func NewProviderAPIError(message string, err error, statusCode int, errorType *s
 	}
 }
 
-// ShouldSendBackRawRequest checks if the raw request should be captured.
-// Context overrides are intentionally restricted to asymmetric behavior: a context value can only
-// promote false→true and will not override a true config to false, avoiding accidental suppression.
-// Both full send-back mode and logging-only mode (store_raw_request_response) set
-// BifrostContextKeySendBackRawRequest=true in the request context so a single flag is checked here.
-// In logging-only mode the payload is stripped before the response reaches the client.
+// ShouldSendBackRawRequest checks if raw request bytes should be captured.
+// bifrost.go always writes BifrostContextKeyCaptureRawRequest before provider dispatch,
+// combining provider config, per-request overrides, and store_raw_request_response.
+// The default parameter is a fallback for callers outside the normal bifrost dispatch path.
 func ShouldSendBackRawRequest(ctx context.Context, defaultSendBackRawRequest bool) bool {
-	if sendBackRawRequest, ok := ctx.Value(schemas.BifrostContextKeySendBackRawRequest).(bool); ok && sendBackRawRequest {
-		return sendBackRawRequest
+	if capture, ok := ctx.Value(schemas.BifrostContextKeyCaptureRawRequest).(bool); ok {
+		return capture
 	}
 	return defaultSendBackRawRequest
 }
 
-// ShouldSendBackRawResponse checks if the raw response should be captured.
-// Context overrides are intentionally restricted to asymmetric behavior: a context value can only
-// promote false→true and will not override a true config to false, avoiding accidental suppression.
-// Both full send-back mode and logging-only mode (store_raw_request_response) set
-// BifrostContextKeySendBackRawResponse=true in the request context so a single flag is checked here.
-// In logging-only mode the payload is stripped before the response reaches the client.
+// ShouldSendBackRawResponse checks if raw response bytes should be captured.
+// bifrost.go always writes BifrostContextKeyCaptureRawResponse before provider dispatch,
+// combining provider config, per-request overrides, and store_raw_request_response.
+// The default parameter is a fallback for callers outside the normal bifrost dispatch path.
 func ShouldSendBackRawResponse(ctx context.Context, defaultSendBackRawResponse bool) bool {
-	if sendBackRawResponse, ok := ctx.Value(schemas.BifrostContextKeySendBackRawResponse).(bool); ok && sendBackRawResponse {
-		return sendBackRawResponse
+	if capture, ok := ctx.Value(schemas.BifrostContextKeyCaptureRawResponse).(bool); ok {
+		return capture
 	}
 	return defaultSendBackRawResponse
 }
@@ -1706,13 +1702,14 @@ func SendInProgressEventResponsesChunk(ctx *schemas.BifrostContext, postHookRunn
 }
 
 // BuildClientStreamChunk constructs a BifrostStreamChunk from post-hook results.
-// It never mutates the shared processedResponse or processedError objects — when in
-// logging-only mode (BifrostContextKeyRawRequestResponseForLogging) it shallow-copies
-// each inner response struct and the BifrostError, nils only the raw fields on those
-// copies, and returns them as the outgoing chunk. This is safe for concurrent PostLLMHook
-// goroutines that still hold references to the originals.
+// It never mutates the shared processedResponse or processedError objects — when raw fields
+// need to be stripped (captured for storage but not for send-back), it shallow-copies each
+// inner response struct and nils only the appropriate per-side field on those copies.
+// This is safe for concurrent PostLLMHook goroutines that still hold references to the originals.
 func BuildClientStreamChunk(ctx context.Context, processedResponse *schemas.BifrostResponse, processedError *schemas.BifrostError) *schemas.BifrostStreamChunk {
-	dropRaw, _ := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool)
+	dropReq, _ := ctx.Value(schemas.BifrostContextKeyDropRawRequestFromClient).(bool)
+	dropResp, _ := ctx.Value(schemas.BifrostContextKeyDropRawResponseFromClient).(bool)
+	drop := dropReq || dropResp
 	streamResponse := &schemas.BifrostStreamChunk{}
 	if processedResponse != nil {
 		streamResponse.BifrostTextCompletionResponse = processedResponse.TextCompletionResponse
@@ -1723,51 +1720,79 @@ func BuildClientStreamChunk(ctx context.Context, processedResponse *schemas.Bifr
 		streamResponse.BifrostImageGenerationStreamResponse = processedResponse.ImageGenerationStreamResponse
 		// Strip raw fields from client-facing copies without mutating the shared objects
 		// that PostLLMHook goroutines may still be reading.
-		if dropRaw {
+		if drop {
 			if streamResponse.BifrostTextCompletionResponse != nil {
 				cp := *streamResponse.BifrostTextCompletionResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
+				if dropReq {
+					cp.ExtraFields.RawRequest = nil
+				}
+				if dropResp {
+					cp.ExtraFields.RawResponse = nil
+				}
 				streamResponse.BifrostTextCompletionResponse = &cp
 			}
 			if streamResponse.BifrostChatResponse != nil {
 				cp := *streamResponse.BifrostChatResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
+				if dropReq {
+					cp.ExtraFields.RawRequest = nil
+				}
+				if dropResp {
+					cp.ExtraFields.RawResponse = nil
+				}
 				streamResponse.BifrostChatResponse = &cp
 			}
 			if streamResponse.BifrostResponsesStreamResponse != nil {
 				cp := *streamResponse.BifrostResponsesStreamResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
+				if dropReq {
+					cp.ExtraFields.RawRequest = nil
+				}
+				if dropResp {
+					cp.ExtraFields.RawResponse = nil
+				}
 				streamResponse.BifrostResponsesStreamResponse = &cp
 			}
 			if streamResponse.BifrostSpeechStreamResponse != nil {
 				cp := *streamResponse.BifrostSpeechStreamResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
+				if dropReq {
+					cp.ExtraFields.RawRequest = nil
+				}
+				if dropResp {
+					cp.ExtraFields.RawResponse = nil
+				}
 				streamResponse.BifrostSpeechStreamResponse = &cp
 			}
 			if streamResponse.BifrostTranscriptionStreamResponse != nil {
 				cp := *streamResponse.BifrostTranscriptionStreamResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
+				if dropReq {
+					cp.ExtraFields.RawRequest = nil
+				}
+				if dropResp {
+					cp.ExtraFields.RawResponse = nil
+				}
 				streamResponse.BifrostTranscriptionStreamResponse = &cp
 			}
 			if streamResponse.BifrostImageGenerationStreamResponse != nil {
 				cp := *streamResponse.BifrostImageGenerationStreamResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
+				if dropReq {
+					cp.ExtraFields.RawRequest = nil
+				}
+				if dropResp {
+					cp.ExtraFields.RawResponse = nil
+				}
 				streamResponse.BifrostImageGenerationStreamResponse = &cp
 			}
 		}
 	}
 	if processedError != nil {
-		if dropRaw {
+		if drop {
 			// Strip raw fields from a client-facing copy without mutating the shared error object.
 			errCopy := *processedError
-			errCopy.ExtraFields.RawRequest = nil
-			errCopy.ExtraFields.RawResponse = nil
+			if dropReq {
+				errCopy.ExtraFields.RawRequest = nil
+			}
+			if dropResp {
+				errCopy.ExtraFields.RawResponse = nil
+			}
 			streamResponse.BifrostError = &errCopy
 		} else {
 			streamResponse.BifrostError = processedError

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -1107,7 +1107,8 @@ func TestBuildClientStreamChunk_ImageGenerationStripping(t *testing.T) {
 
 	t.Run("logging-only: raw fields stripped from image gen chunk, original preserved", func(t *testing.T) {
 		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-		ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+		ctx.SetValue(schemas.BifrostContextKeyDropRawRequestFromClient, true)
+		ctx.SetValue(schemas.BifrostContextKeyDropRawResponseFromClient, true)
 
 		chunk := BuildClientStreamChunk(ctx, response, nil)
 		if chunk.BifrostImageGenerationStreamResponse == nil {
@@ -1148,9 +1149,9 @@ func TestBuildClientStreamChunk_ImageGenerationStripping(t *testing.T) {
 }
 
 // TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChunk verifies
-// that when BifrostContextKeyRawRequestResponseForLogging is set, ProcessAndSendResponse
-// strips RawRequest and RawResponse from the outgoing stream chunk, while leaving other
-// ExtraFields intact. It also verifies that the original BifrostResponse is not mutated
+// that when drop-raw context flags are set, ProcessAndSendResponse strips RawRequest and
+// RawResponse from the outgoing stream chunk, while leaving other ExtraFields intact.
+// It also verifies that the original BifrostResponse is not mutated
 // (shared object safety for PostLLMHook goroutines).
 func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChunk(t *testing.T) {
 	rawReq := json.RawMessage(`{"model":"gpt-4","messages":[]}`)
@@ -1177,7 +1178,8 @@ func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChu
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 			if tt.loggingOnly {
-				ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+				ctx.SetValue(schemas.BifrostContextKeyDropRawRequestFromClient, true)
+				ctx.SetValue(schemas.BifrostContextKeyDropRawResponseFromClient, true)
 			}
 
 			response := &schemas.BifrostResponse{
@@ -1237,9 +1239,9 @@ func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChu
 }
 
 // TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromErrorChunk verifies
-// that when BifrostContextKeyRawRequestResponseForLogging is set, raw data is stripped
-// from BifrostError payloads embedded in stream chunks, without mutating the shared
-// BifrostError object (shared object safety for PostLLMHook goroutines).
+// that when drop-raw context flags are set, raw data is stripped from BifrostError
+// payloads embedded in stream chunks, without mutating the shared BifrostError object
+// (shared object safety for PostLLMHook goroutines).
 func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromErrorChunk(t *testing.T) {
 	rawReq := json.RawMessage(`{"model":"gpt-4"}`)
 	rawResp := json.RawMessage(`{"error":"rate limit exceeded"}`)
@@ -1265,7 +1267,8 @@ func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromErrorChunk(
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 			if tt.loggingOnly {
-				ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+				ctx.SetValue(schemas.BifrostContextKeyDropRawRequestFromClient, true)
+				ctx.SetValue(schemas.BifrostContextKeyDropRawResponseFromClient, true)
 			}
 
 			// Use a postHookRunner that converts the response to a BifrostError with raw data

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -198,8 +198,8 @@ const (
 	BifrostContextKeyURLPath                             BifrostContextKey = "bifrost-extra-url-path"                // string
 	BifrostContextKeyUseRawRequestBody                   BifrostContextKey = "bifrost-use-raw-request-body"
 	BifrostContextKeyChangeRequestType                   BifrostContextKey = "bifrost-change-request-type"                      // RequestType (set by plugins to trigger request type conversion in core, e.g. text->chat or chat->responses)
-	BifrostContextKeySendBackRawRequest                  BifrostContextKey = "bifrost-send-back-raw-request"                    // bool
-	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool
+	BifrostContextKeySendBackRawRequest                  BifrostContextKey = "bifrost-send-back-raw-request"                    // bool (per-request override — read by bifrost.go, never overwritten)
+	BifrostContextKeySendBackRawResponse                 BifrostContextKey = "bifrost-send-back-raw-response"                   // bool (per-request override — read by bifrost.go, never overwritten)
 	BifrostContextKeyIntegrationType                     BifrostContextKey = "bifrost-integration-type"                         // integration used in gateway (e.g. openai, anthropic, bedrock, etc.)
 	BifrostContextKeyIsResponsesToChatCompletionFallback BifrostContextKey = "bifrost-is-responses-to-chat-completion-fallback" // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostMCPAgentOriginalRequestID                     BifrostContextKey = "bifrost-mcp-agent-original-request-id"            // string (to store the original request ID for MCP agent mode)
@@ -224,7 +224,12 @@ const (
 	BifrostContextKeyGovernancePluginName                BifrostContextKey = "governance-plugin-name"                           // string (name of the governance plugin that processed the request - set by bifrost)
 	BifrostContextKeyIsEnterprise                        BifrostContextKey = "is-enterprise"                                    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyAvailableProviders                  BifrostContextKey = "available-providers"                              // []ModelProvider (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyRawRequestResponseForLogging        BifrostContextKey = "bifrost-raw-request-response-for-logging"         // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyStoreRawRequestResponse             BifrostContextKey = "bifrost-store-raw-request-response"               // bool (per-request override — read by bifrost.go, never overwritten)
+	BifrostContextKeyCaptureRawRequest                   BifrostContextKey = "bifrost-capture-raw-request"                      // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when providers should capture raw request bytes
+	BifrostContextKeyCaptureRawResponse                  BifrostContextKey = "bifrost-capture-raw-response"                     // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when providers should capture raw response bytes
+	BifrostContextKeyDropRawRequestFromClient            BifrostContextKey = "bifrost-drop-raw-request-from-client"             // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when raw request should be stripped from the client-facing response
+	BifrostContextKeyDropRawResponseFromClient           BifrostContextKey = "bifrost-drop-raw-response-from-client"            // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when raw response should be stripped from the client-facing response
+	BifrostContextKeyShouldStoreRawInLogs                BifrostContextKey = "bifrost-should-store-raw-in-logs"                 // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when raw request/response should be persisted in log records
 	BifrostContextKeyRetryDBFetch                        BifrostContextKey = "bifrost-retry-db-fetch"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY))

--- a/docs/providers/request-options.mdx
+++ b/docs/providers/request-options.mdx
@@ -16,7 +16,9 @@ Bifrost provides request options that control behavior, enable features, and pas
 | `BifrostContextKeySessionID` | `x-bf-session-id` | `string` | Session ID for key stickiness (requires KV store) |
 | `BifrostContextKeySessionTTL` | `x-bf-session-ttl` | `time.Duration` | Session-to-key cache TTL (duration string or seconds) |
 | `BifrostContextKeyRequestID` | `x-request-id` | `string` | Custom request ID for tracking |
-| `BifrostContextKeySendBackRawResponse` | `x-bf-send-back-raw-response` | `bool` | Include raw provider response |
+| `BifrostContextKeySendBackRawRequest` | `x-bf-send-back-raw-request` | `bool` | Include raw provider request in the response |
+| `BifrostContextKeySendBackRawResponse` | `x-bf-send-back-raw-response` | `bool` | Include raw provider response in the response |
+| `BifrostContextKeyStoreRawRequestResponse` | `x-bf-store-raw-request-response` | `bool` | Persist raw request/response in log records |
 | `BifrostContextKeyPassthroughExtraParams` | `x-bf-passthrough-extra-params` | `bool` | Enable passthrough for extra parameters |
 | `BifrostContextKeyExtraHeaders` | `x-bf-eh-*` | `map[string][]string` | Custom headers forwarded to provider |
 | `BifrostContextKeyDirectKey` | `-` | `schemas.Key` | Direct key credentials (Go SDK only) |
@@ -269,14 +271,69 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
 </Tab>
 </Tabs>
 
+### Send Back Raw Request
+
+**Context Key:** `BifrostContextKeySendBackRawRequest`  
+**Header:** `x-bf-send-back-raw-request`  
+**Type:** `bool` (header values: `"true"` or `"false"`)  
+**Required:** No
+
+Include the exact JSON body sent to the provider alongside Bifrost's standardized response. Accepts `"true"` or `"false"` — either value fully overrides the provider-level `send_back_raw_request` config for this request.
+
+<Tabs>
+<Tab title="Gateway (cURL)">
+```bash
+curl --location 'http://localhost:8080/v1/chat/completions' \
+--header 'x-bf-send-back-raw-request: true' \
+--header 'Content-Type: application/json' \
+--data '{
+    "model": "openai/gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Hello!"}]
+}'
+```
+</Tab>
+<Tab title="Go SDK">
+```go
+ctx := context.Background()
+ctx = context.WithValue(ctx, schemas.BifrostContextKeySendBackRawRequest, true)
+
+response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
+    Provider: schemas.OpenAI,
+    Model:    "gpt-4o-mini",
+    Input:    messages,
+})
+
+// Access raw request
+if response.ChatResponse != nil {
+    rawReq := response.ChatResponse.ExtraFields.RawRequest
+}
+```
+</Tab>
+</Tabs>
+
+The raw request appears in `extra_fields.raw_request`:
+
+```json
+{
+    "choices": [...],
+    "usage": {...},
+    "extra_fields": {
+        "provider": "openai",
+        "raw_request": {
+            // Exact JSON sent to the provider
+        }
+    }
+}
+```
+
 ### Send Back Raw Response
 
 **Context Key:** `BifrostContextKeySendBackRawResponse`  
 **Header:** `x-bf-send-back-raw-response`  
-**Type:** `bool` (header value: `"true"`)  
+**Type:** `bool` (header values: `"true"` or `"false"`)  
 **Required:** No
 
-Include the original provider response alongside Bifrost's standardized response format.
+Include the original provider response alongside Bifrost's standardized response format. Accepts `"true"` or `"false"` — either value fully overrides the provider-level `send_back_raw_response` config for this request.
 
 <Tabs>
 <Tab title="Gateway (cURL)">
@@ -323,6 +380,51 @@ The raw response appears in `extra_fields.raw_response`:
     }
 }
 ```
+
+### Store Raw Request/Response
+
+**Context Key:** `BifrostContextKeyStoreRawRequestResponse`  
+**Header:** `x-bf-store-raw-request-response`  
+**Type:** `bool` (header values: `"true"` or `"false"`)  
+**Required:** No
+
+Persist the raw provider request and response in the log record. Accepts `"true"` or `"false"` — either value fully overrides the provider-level `store_raw_request_response` config for this request.
+
+This is orthogonal to the send-back flags: enabling this does not affect whether raw data appears in the API response, and enabling send-back does not automatically store raw data in logs. Use this when you want observability into provider payloads without necessarily exposing them to the caller, or combine it with `x-bf-send-back-raw-*` to do both.
+
+<Tabs>
+<Tab title="Gateway (cURL)">
+```bash
+curl --location 'http://localhost:8080/v1/chat/completions' \
+--header 'x-bf-store-raw-request-response: true' \
+--header 'Content-Type: application/json' \
+--data '{
+    "model": "openai/gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Hello!"}]
+}'
+```
+</Tab>
+<Tab title="Go SDK">
+```go
+ctx := context.Background()
+ctx = context.WithValue(ctx, schemas.BifrostContextKeyStoreRawRequestResponse, true)
+
+response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
+    Provider: schemas.OpenAI,
+    Model:    "gpt-4o-mini",
+    Input:    messages,
+})
+// Raw data is persisted in the log record.
+// ExtraFields.RawRequest/RawResponse are nil unless send-back flags are also enabled.
+```
+</Tab>
+</Tabs>
+
+<Note>
+`x-bf-store-raw-request-response` only has effect when the logging plugin is active — raw data is written to the log record by the logging plugin. Without it, enabling this flag captures the data but nothing persists it.
+
+`x-bf-store-raw-request-response` and `x-bf-send-back-raw-*` are orthogonal — you can enable any combination. Enabling store does not send data back to the caller; enabling send-back does not persist data in logs. Enable both to do both.
+</Note>
 
 ### Passthrough Extra Parameters
 

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -860,6 +860,10 @@ curl --location 'http://localhost:8080/api/providers' \
 
 Include the original provider response alongside Bifrost's standardized response format. Useful for debugging and accessing provider-specific metadata.
 
+<Note>
+You can override this per request using the `x-bf-send-back-raw-response` header (`"true"` or `"false"`), regardless of the provider-level config. See [Request Options](../../providers/request-options#send-back-raw-response) for details.
+</Note>
+
 <Tabs group="raw-response">
 
 <Tab title="Using Web UI">
@@ -936,6 +940,10 @@ When enabled, the raw provider response appears in `extra_fields.raw_response`:
 
 Include the original request sent to the provider alongside Bifrost's response. Useful for debugging request transformations and verifying what was actually sent to the provider.
 
+<Note>
+You can override this per request using the `x-bf-send-back-raw-request` header (`"true"` or `"false"`), regardless of the provider-level config. See [Request Options](../../providers/request-options#send-back-raw-request) for details.
+</Note>
+
 <Tabs group="raw-request">
 
 <Tab title="Using Web UI">
@@ -1011,6 +1019,71 @@ When enabled, the raw provider request appears in `extra_fields.raw_request`:
 <Tip>
 You can enable both `send_back_raw_request` and `send_back_raw_response` together to see the complete request-response cycle for debugging purposes.
 </Tip>
+
+### Store Raw Request/Response
+
+Persist the raw provider request and response in the log record. This is orthogonal to `send_back_raw_request` and `send_back_raw_response` — enabling this does not affect whether raw data appears in the API response, and enabling send-back does not automatically store raw data in logs. Enable both to do both.
+
+<Tabs group="store-raw">
+
+<Tab title="Using Web UI">
+
+1. Navigate to **"Model Providers"** → **"Configurations"** → **{Provider}** → **"Provider level configuration"** → **"Performance tuning"**
+2. Toggle **"Store Raw Request/Response"** to enabled
+3. Save configuration
+
+</Tab>
+
+<Tab title="Using API">
+
+```bash
+curl --location 'http://localhost:8080/api/providers' \
+--header 'Content-Type: application/json' \
+--data '{
+    "provider": "openai",
+    "keys": [
+        {
+            "name": "openai-key-1",
+            "value": "env.OPENAI_API_KEY",
+            "models": ["*"],
+            "weight": 1.0
+        }
+    ],
+    "store_raw_request_response": true
+}'
+```
+
+</Tab>
+
+<Tab title="Using config.json">
+
+```json
+{
+    "providers": {
+        "openai": {
+            "keys": [
+                {
+                    "name": "openai-key-1",
+                    "value": "env.OPENAI_API_KEY",
+                    "models": ["*"],
+                    "weight": 1.0
+                }
+            ],
+            "store_raw_request_response": true
+        }
+    }
+}
+```
+
+</Tab>
+
+</Tabs>
+
+<Note>
+`store_raw_request_response` only has effect when the logging plugin is active — raw data is written to the log record by the logging plugin. Without it, enabling this flag captures the data but nothing persists it.
+
+You can override this per request using the `x-bf-store-raw-request-response` header (`"true"` or `"false"`), regardless of the provider-level config. See [Request Options](../../providers/request-options#store-raw-requestresponse) for details.
+</Note>
 
 ### Passthrough Extra Parameters
 

--- a/docs/quickstart/go-sdk/provider-configuration.mdx
+++ b/docs/quickstart/go-sdk/provider-configuration.mdx
@@ -328,13 +328,32 @@ func (a *MyAccount) GetConfigForProvider(provider schemas.ModelProvider) (*schem
 
 Include the original provider response alongside Bifrost's standardized response format. Useful for debugging and accessing provider-specific metadata.
 
+**Provider-level default** (applies to all requests for this provider):
+
 ```go
-func (a *MyAccount) GetConfigForProvider(ctx *context.Context, provider schemas.ModelProvider) (*schemas.ProviderConfig, error) {
+func (a *MyAccount) GetConfigForProvider(provider schemas.ModelProvider) (*schemas.ProviderConfig, error) {
     return &schemas.ProviderConfig{
         NetworkConfig: schemas.DefaultNetworkConfig,
         ConcurrencyAndBufferSize: schemas.DefaultConcurrencyAndBufferSize,
-        SendBackRawResponse: true, // Include raw provider response
+        SendBackRawResponse: true,
     }, nil
+}
+```
+
+**Per-request override** (overrides the provider default for a single request):
+
+```go
+ctx := context.Background()
+ctx = context.WithValue(ctx, schemas.BifrostContextKeySendBackRawResponse, true) // or false to suppress
+
+response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
+    Provider: schemas.OpenAI,
+    Model:    "gpt-4o-mini",
+    Input:    messages,
+})
+
+if response.ChatResponse != nil {
+    rawResp := response.ChatResponse.ExtraFields.RawResponse // original provider JSON
 }
 ```
 
@@ -368,13 +387,32 @@ type BifrostResponseExtraFields struct {
 
 Include the original request sent to the provider alongside Bifrost's response. Useful for debugging request transformations and verifying what was actually sent to the provider.
 
+**Provider-level default** (applies to all requests for this provider):
+
 ```go
-func (a *MyAccount) GetConfigForProvider(ctx *context.Context, provider schemas.ModelProvider) (*schemas.ProviderConfig, error) {
+func (a *MyAccount) GetConfigForProvider(provider schemas.ModelProvider) (*schemas.ProviderConfig, error) {
     return &schemas.ProviderConfig{
         NetworkConfig: schemas.DefaultNetworkConfig,
         ConcurrencyAndBufferSize: schemas.DefaultConcurrencyAndBufferSize,
-        SendBackRawRequest: true, // Include raw provider request
+        SendBackRawRequest: true,
     }, nil
+}
+```
+
+**Per-request override** (overrides the provider default for a single request):
+
+```go
+ctx := context.Background()
+ctx = context.WithValue(ctx, schemas.BifrostContextKeySendBackRawRequest, true) // or false to suppress
+
+response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
+    Provider: schemas.OpenAI,
+    Model:    "gpt-4o-mini",
+    Input:    messages,
+})
+
+if response.ChatResponse != nil {
+    rawReq := response.ChatResponse.ExtraFields.RawRequest // exact JSON sent to the provider
 }
 ```
 
@@ -388,9 +426,42 @@ type BifrostResponseExtraFields struct {
 }
 ```
 
-<Tip>
-You can enable both `SendBackRawRequest` and `SendBackRawResponse` together to see the complete request-response cycle for debugging purposes.
-</Tip>
+### Store Raw Request/Response
+
+Persist the raw provider request and response in the log record without necessarily returning them in the API response. This is orthogonal to the send-back flags — enabling this does not affect what the caller receives, and enabling send-back does not automatically store data in logs. Enable both to do both.
+
+**Provider-level default** (applies to all requests for this provider):
+
+```go
+func (a *MyAccount) GetConfigForProvider(provider schemas.ModelProvider) (*schemas.ProviderConfig, error) {
+    return &schemas.ProviderConfig{
+        NetworkConfig: schemas.DefaultNetworkConfig,
+        ConcurrencyAndBufferSize: schemas.DefaultConcurrencyAndBufferSize,
+        StoreRawRequestResponse: true,
+    }, nil
+}
+```
+
+**Per-request override** (overrides the provider default for a single request):
+
+```go
+ctx := context.Background()
+ctx = context.WithValue(ctx, schemas.BifrostContextKeyStoreRawRequestResponse, true) // or false to disable
+
+response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
+    Provider: schemas.OpenAI,
+    Model:    "gpt-4o-mini",
+    Input:    messages,
+})
+// Raw data is persisted in the log record.
+// ExtraFields.RawRequest/RawResponse are nil unless send-back flags are also enabled.
+```
+
+<Note>
+`StoreRawRequestResponse` only has effect when the logging plugin is active — raw data is written to the log record by the logging plugin. Without it, enabling this flag captures the data but nothing persists it.
+
+`StoreRawRequestResponse`, `SendBackRawRequest`, and `SendBackRawResponse` are orthogonal controls — enabling any one does not imply the others. Enable any combination depending on whether you need raw data in logs, in the response, or both.
+</Note>
 
 ## Provider-Specific Authentication
 

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -79,24 +79,29 @@ func applyLargePayloadPreviews(ctx *schemas.BifrostContext, updateData *UpdateLo
 	}
 }
 
-func applyLargePayloadPreviewsToEntry(ctx *schemas.BifrostContext, entry *logstore.Log) {
+func applyLargePayloadPreviewsToEntry(ctx *schemas.BifrostContext, entry *logstore.Log, contentLoggingEnabled bool) {
 	if ctx == nil || entry == nil {
 		return
 	}
 
 	updateData := &UpdateLogData{}
 	applyLargePayloadPreviews(ctx, updateData)
+	shouldStoreRaw, _ := ctx.Value(schemas.BifrostContextKeyShouldStoreRawInLogs).(bool)
 
 	if updateData.IsLargePayloadRequest {
 		entry.IsLargePayloadRequest = true
-		if preview, ok := updateData.RawRequest.(string); ok {
-			entry.RawRequest = preview
+		if shouldStoreRaw && contentLoggingEnabled {
+			if preview, ok := updateData.RawRequest.(string); ok {
+				entry.RawRequest = preview
+			}
 		}
 	}
 	if updateData.IsLargePayloadResponse {
 		entry.IsLargePayloadResponse = true
-		if preview, ok := updateData.RawResponse.(string); ok {
-			entry.RawResponse = preview
+		if shouldStoreRaw && contentLoggingEnabled {
+			if preview, ok := updateData.RawResponse.(string); ok {
+				entry.RawResponse = preview
+			}
 		}
 	}
 }
@@ -689,6 +694,8 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	numberOfRetries := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyNumberOfRetries)
 
 	requestType, _, originalModelRequested, resolvedModelUsed := bifrost.GetResponseFields(result, bifrostErr)
+	shouldStoreRaw, _ := ctx.Value(schemas.BifrostContextKeyShouldStoreRawInLogs).(bool)
+	contentLoggingEnabled := p.disableContentLogging == nil || !*p.disableContentLogging
 
 	isFinalChunk := bifrost.IsFinalChunk(ctx)
 
@@ -738,7 +745,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 				entry.ErrorDetails = string(data)
 			}
 			entry.ErrorDetailsParsed = bifrostErr
-			applyLargePayloadPreviewsToEntry(ctx, entry)
+			applyLargePayloadPreviewsToEntry(ctx, entry, contentLoggingEnabled)
 			p.storeOrEnqueueEntry(ctx, entry, p.makePostWriteCallback(nil))
 		} else {
 			p.logger.Warn("no pending log data found for request %s, skipping log write", requestID)
@@ -781,7 +788,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			entry.ErrorDetails = string(data)
 		}
 		entry.ErrorDetailsParsed = bifrostErr
-		if p.disableContentLogging == nil || !*p.disableContentLogging {
+		if shouldStoreRaw && contentLoggingEnabled {
 			if bifrostErr.ExtraFields.RawRequest != nil {
 				rawReqBytes, err := sonic.Marshal(bifrostErr.ExtraFields.RawRequest)
 				if err == nil {
@@ -796,7 +803,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 				}
 			}
 		}
-		applyLargePayloadPreviewsToEntry(ctx, entry)
+		applyLargePayloadPreviewsToEntry(ctx, entry, contentLoggingEnabled)
 		p.storeOrEnqueueEntry(ctx, entry, p.makePostWriteCallback(nil))
 		p.scheduleDeferredUsageUpdate(ctx, requestID, entry.TokenUsageParsed != nil)
 		return result, bifrostErr, nil
@@ -828,7 +835,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		} else if isFinalChunk {
 			// Apply streaming output fields to the entry
 			entry.Stream = true
-			p.applyStreamingOutputToEntry(entry, streamResponse)
+			p.applyStreamingOutputToEntry(entry, streamResponse, shouldStoreRaw)
 		}
 		// Backfill passthrough status_code from response (streaming path)
 		if result != nil && result.PassthroughResponse != nil {
@@ -840,7 +847,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 				entry.Status = "error"
 			}
 		}
-		applyLargePayloadPreviewsToEntry(ctx, entry)
+		applyLargePayloadPreviewsToEntry(ctx, entry, contentLoggingEnabled)
 
 		if requestType != schemas.PassthroughStreamRequest && tracer != nil && traceID != "" {
 			tracer.CleanupStreamAccumulator(traceID)
@@ -865,24 +872,23 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		// Realtime turns that fail mid-stream still need their input transcript
 		// surfaced — backfill from bifrostErr.ExtraFields.RawRequest if present.
 		if requestType == schemas.RealtimeRequest {
-			contentLoggingEnabled := p.disableContentLogging == nil || !*p.disableContentLogging
-			applyRealtimeRawRequestBackfill(entry, bifrostErr.ExtraFields.RawRequest, contentLoggingEnabled)
+			applyRealtimeRawRequestBackfill(entry, bifrostErr.ExtraFields.RawRequest, contentLoggingEnabled, shouldStoreRaw)
 		}
 	} else if result != nil {
 		entry.Status = "success"
 		extraFields := result.GetExtraFields()
 		applyModelAlias(entry, extraFields.OriginalModelRequested, extraFields.ResolvedModelUsed)
 		if requestType == schemas.RealtimeRequest {
-			p.applyRealtimeOutputToEntry(entry, result)
+			p.applyRealtimeOutputToEntry(entry, result, shouldStoreRaw)
 		} else {
-			p.applyNonStreamingOutputToEntry(entry, result)
+			p.applyNonStreamingOutputToEntry(entry, result, shouldStoreRaw)
 		}
 		// Flip status for passthrough error responses (4xx/5xx from provider)
 		if isPassthroughErrorResponse(result) {
 			entry.Status = "error"
 		}
 	}
-	applyLargePayloadPreviewsToEntry(ctx, entry)
+	applyLargePayloadPreviewsToEntry(ctx, entry, contentLoggingEnabled)
 
 	// Calculate cost
 	var cacheDebug *schemas.BifrostCacheDebug

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -131,49 +131,6 @@ func applySerializedLogUpdates(
 	}
 }
 
-// applySerializedStreamingLogUpdates copies serialized streaming fields from a
-// temporary log entry into the GORM update map, respecting content-logging
-// gates.
-func applySerializedStreamingLogUpdates(
-	updates map[string]interface{},
-	entry *logstore.Log,
-	streamResponse *streaming.ProcessedStreamResponse,
-	cacheDebug *schemas.BifrostCacheDebug,
-	contentLoggingEnabled bool,
-) {
-	if streamResponse.Data.TokenUsage != nil {
-		updates["token_usage"] = entry.TokenUsage
-		updates["prompt_tokens"] = streamResponse.Data.TokenUsage.PromptTokens
-		updates["completion_tokens"] = streamResponse.Data.TokenUsage.CompletionTokens
-		updates["total_tokens"] = streamResponse.Data.TokenUsage.TotalTokens
-		updates["cached_read_tokens"] = entry.CachedReadTokens
-	}
-
-	if !contentLoggingEnabled {
-		return
-	}
-
-	if streamResponse.Data.TranscriptionOutput != nil {
-		updates["transcription_output"] = entry.TranscriptionOutput
-	}
-	if streamResponse.Data.AudioOutput != nil {
-		updates["speech_output"] = entry.SpeechOutput
-	}
-	if streamResponse.Data.ImageGenerationOutput != nil {
-		updates["image_generation_output"] = entry.ImageGenerationOutput
-	}
-	if cacheDebug != nil {
-		updates["cache_debug"] = entry.CacheDebug
-	}
-	if streamResponse.Data.OutputMessage != nil {
-		updates["output_message"] = entry.OutputMessage
-		updates["content_summary"] = entry.ContentSummary
-	}
-	if streamResponse.Data.OutputMessages != nil {
-		updates["responses_output"] = entry.ResponsesOutput
-	}
-}
-
 // updateLogEntry updates an existing log entry using GORM
 func (p *LoggerPlugin) updateLogEntry(
 	ctx context.Context,
@@ -348,174 +305,6 @@ func (p *LoggerPlugin) updateLogEntry(
 	return p.store.Update(ctx, requestID, updates)
 }
 
-// updateStreamingLogEntry handles streaming updates using GORM
-func (p *LoggerPlugin) updateStreamingLogEntry(
-	ctx context.Context,
-	requestID string,
-	selectedKeyID string,
-	selectedKeyName string,
-	virtualKeyID string,
-	virtualKeyName string,
-	routingRuleID string,
-	routingRuleName string,
-	numberOfRetries int,
-	cacheDebug *schemas.BifrostCacheDebug,
-	routingEngineLogs string,
-	streamResponse *streaming.ProcessedStreamResponse,
-	isFinalChunk bool,
-	isLargePayloadRequest bool,
-	isLargePayloadResponse bool,
-) error {
-	p.logger.Debug("[logging] updating streaming log entry %s", requestID)
-	updates := make(map[string]interface{})
-	updates["selected_key_id"] = selectedKeyID
-	updates["selected_key_name"] = selectedKeyName
-	if virtualKeyID != "" {
-		updates["virtual_key_id"] = virtualKeyID
-	}
-	if virtualKeyName != "" {
-		updates["virtual_key_name"] = virtualKeyName
-	}
-	if routingRuleID != "" {
-		updates["routing_rule_id"] = routingRuleID
-	}
-	if routingRuleName != "" {
-		updates["routing_rule_name"] = routingRuleName
-	}
-	if numberOfRetries != 0 {
-		updates["number_of_retries"] = numberOfRetries
-	}
-	if routingEngineLogs != "" {
-		updates["routing_engine_logs"] = routingEngineLogs
-	}
-	// Handle error case first
-	if streamResponse.Data.ErrorDetails != nil {
-		tempEntry := &logstore.Log{}
-		tempEntry.ErrorDetailsParsed = streamResponse.Data.ErrorDetails
-		if err := tempEntry.SerializeFields(); err != nil {
-			return fmt.Errorf("failed to serialize error details: %w", err)
-		}
-		errorUpdates := map[string]interface{}{
-			"status":        "error",
-			"latency":       float64(streamResponse.Data.Latency),
-			"error_details": tempEntry.ErrorDetails,
-		}
-		if isLargePayloadRequest {
-			errorUpdates["is_large_payload_request"] = true
-		}
-		if isLargePayloadResponse {
-			errorUpdates["is_large_payload_response"] = true
-		}
-		return p.store.Update(ctx, requestID, errorUpdates)
-	}
-
-	// Always mark as streaming and update timestamp
-	updates["stream"] = true
-
-	tempEntry := &logstore.Log{}
-	updates["latency"] = float64(streamResponse.Data.Latency)
-
-	// Update model and alias from resolved/requested model pair.
-	tempEntry2 := &logstore.Log{}
-	applyModelAlias(tempEntry2, streamResponse.RequestedModel, streamResponse.ResolvedModel)
-	if tempEntry2.Model != "" {
-		updates["model"] = tempEntry2.Model
-	}
-	updates["alias"] = tempEntry2.Alias
-
-	needsSerialization := false
-
-	// Update token usage if provided
-	if streamResponse.Data.TokenUsage != nil {
-		tempEntry.TokenUsageParsed = streamResponse.Data.TokenUsage
-		needsSerialization = true
-	}
-
-	// Handle cost from pricing plugin
-	if streamResponse.Data.Cost != nil {
-		updates["cost"] = *streamResponse.Data.Cost
-	}
-	// Handle finish reason - if present, mark as complete
-	if isFinalChunk {
-		updates["status"] = "success"
-	}
-
-	contentLoggingEnabled := p.disableContentLogging == nil || !*p.disableContentLogging
-	if contentLoggingEnabled {
-		// Handle transcription output from stream updates
-		if streamResponse.Data.TranscriptionOutput != nil {
-			tempEntry.TranscriptionOutputParsed = streamResponse.Data.TranscriptionOutput
-			needsSerialization = true
-		}
-		// Handle speech output from stream updates
-		if streamResponse.Data.AudioOutput != nil {
-			tempEntry.SpeechOutputParsed = streamResponse.Data.AudioOutput
-			needsSerialization = true
-		}
-		// Handle image generation output from stream updates
-		if streamResponse.Data.ImageGenerationOutput != nil {
-			tempEntry.ImageGenerationOutputParsed = streamResponse.Data.ImageGenerationOutput
-			needsSerialization = true
-		}
-		// Handle cache debug
-		if cacheDebug != nil {
-			tempEntry.CacheDebugParsed = cacheDebug
-			needsSerialization = true
-		}
-		// Create content summary
-		if streamResponse.Data.OutputMessage != nil {
-			tempEntry.OutputMessageParsed = streamResponse.Data.OutputMessage
-			needsSerialization = true
-		}
-		// Handle responses output from stream updates
-		if streamResponse.Data.OutputMessages != nil {
-			tempEntry.ResponsesOutputParsed = streamResponse.Data.OutputMessages
-			needsSerialization = true
-		}
-		// Handle raw request from stream updates
-		if streamResponse.RawRequest != nil && *streamResponse.RawRequest != nil {
-			if isLargePayloadRequest {
-				// Large payload preview is already a string — skip sonic.Marshal to avoid
-				// double-encoding a pre-truncated preview string.
-				if str, ok := (*streamResponse.RawRequest).(string); ok {
-					updates["raw_request"] = str
-				}
-			} else {
-				rawRequestBytes, err := sonic.Marshal(*streamResponse.RawRequest)
-				if err != nil {
-					p.logger.Error("failed to marshal raw request: %v", err)
-				} else {
-					updates["raw_request"] = string(rawRequestBytes)
-				}
-			}
-		}
-		// Handle raw response from stream updates
-		if streamResponse.Data.RawResponse != nil {
-			updates["raw_response"] = *streamResponse.Data.RawResponse
-		}
-	}
-
-	if needsSerialization {
-		if err := tempEntry.SerializeFields(); err != nil {
-			p.logger.Error("failed to serialize streaming log update fields: %v", err)
-		} else {
-			applySerializedStreamingLogUpdates(updates, tempEntry, streamResponse, cacheDebug, contentLoggingEnabled)
-		}
-	}
-	// Persist large payload flags for dashboard tagging
-	if isLargePayloadRequest {
-		updates["is_large_payload_request"] = true
-	}
-	if isLargePayloadResponse {
-		updates["is_large_payload_response"] = true
-	}
-	// Only perform update if there's something to update
-	if len(updates) > 0 {
-		return p.store.Update(ctx, requestID, updates)
-	}
-	return nil
-}
-
 // makePostWriteCallback creates a callback function for use after the batch writer commits.
 // It receives the already-inserted entry directly (no DB re-read needed).
 func (p *LoggerPlugin) makePostWriteCallback(enrichFn func(*logstore.Log)) func(entry *logstore.Log) {
@@ -537,7 +326,8 @@ func (p *LoggerPlugin) makePostWriteCallback(enrichFn func(*logstore.Log)) func(
 }
 
 // applyStreamingOutputToEntry applies accumulated streaming data to a log entry.
-func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamResponse *streaming.ProcessedStreamResponse) {
+// shouldStoreRaw gates whether raw request/response bytes are written to the entry.
+func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamResponse *streaming.ProcessedStreamResponse, shouldStoreRaw bool) {
 	if streamResponse.Data == nil {
 		return
 	}
@@ -599,16 +389,18 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 		if streamResponse.Data.OutputMessages != nil {
 			entry.ResponsesOutputParsed = streamResponse.Data.OutputMessages
 		}
-		// Raw request
-		if streamResponse.RawRequest != nil && *streamResponse.RawRequest != nil {
-			rawRequestBytes, err := sonic.Marshal(*streamResponse.RawRequest)
-			if err == nil {
-				entry.RawRequest = string(rawRequestBytes)
+		if shouldStoreRaw {
+			// Raw request
+			if streamResponse.RawRequest != nil && *streamResponse.RawRequest != nil {
+				rawRequestBytes, err := sonic.Marshal(*streamResponse.RawRequest)
+				if err == nil {
+					entry.RawRequest = string(rawRequestBytes)
+				}
 			}
-		}
-		// Raw response
-		if streamResponse.Data.RawResponse != nil {
-			entry.RawResponse = *streamResponse.Data.RawResponse
+			// Raw response
+			if streamResponse.Data.RawResponse != nil {
+				entry.RawResponse = *streamResponse.Data.RawResponse
+			}
 		}
 	}
 }
@@ -622,7 +414,8 @@ func isPassthroughErrorResponse(result *schemas.BifrostResponse) bool {
 }
 
 // applyNonStreamingOutputToEntry applies non-streaming response data to a log entry.
-func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, result *schemas.BifrostResponse) {
+// shouldStoreRaw gates whether raw request/response bytes are written to the entry.
+func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, result *schemas.BifrostResponse, shouldStoreRaw bool) {
 	if result == nil {
 		return
 	}
@@ -670,16 +463,18 @@ func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, resul
 	// Extract raw request/response and output content
 	extraFields := result.GetExtraFields()
 	if p.disableContentLogging == nil || !*p.disableContentLogging {
-		if extraFields.RawRequest != nil {
-			rawRequestBytes, err := sonic.Marshal(extraFields.RawRequest)
-			if err == nil {
-				entry.RawRequest = string(rawRequestBytes)
+		if shouldStoreRaw {
+			if extraFields.RawRequest != nil {
+				rawRequestBytes, err := sonic.Marshal(extraFields.RawRequest)
+				if err == nil {
+					entry.RawRequest = string(rawRequestBytes)
+				}
 			}
-		}
-		if extraFields.RawResponse != nil {
-			rawRespBytes, err := sonic.Marshal(extraFields.RawResponse)
-			if err == nil {
-				entry.RawResponse = string(rawRespBytes)
+			if extraFields.RawResponse != nil {
+				rawRespBytes, err := sonic.Marshal(extraFields.RawResponse)
+				if err == nil {
+					entry.RawResponse = string(rawRespBytes)
+				}
 			}
 		}
 		if result.ListModelsResponse != nil && result.ListModelsResponse.Data != nil {
@@ -739,7 +534,7 @@ func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, resul
 	}
 }
 
-func (p *LoggerPlugin) applyRealtimeOutputToEntry(entry *logstore.Log, result *schemas.BifrostResponse) {
+func (p *LoggerPlugin) applyRealtimeOutputToEntry(entry *logstore.Log, result *schemas.BifrostResponse, shouldStoreRaw bool) {
 	if result == nil || result.ResponsesResponse == nil {
 		return
 	}
@@ -761,8 +556,8 @@ func (p *LoggerPlugin) applyRealtimeOutputToEntry(entry *logstore.Log, result *s
 	}
 
 	extraFields := result.GetExtraFields()
-	applyRealtimeRawRequestBackfill(entry, extraFields.RawRequest, contentLoggingEnabled)
-	if contentLoggingEnabled && extraFields.RawResponse != nil {
+	applyRealtimeRawRequestBackfill(entry, extraFields.RawRequest, contentLoggingEnabled, shouldStoreRaw)
+	if shouldStoreRaw && contentLoggingEnabled && extraFields.RawResponse != nil {
 		switch raw := extraFields.RawResponse.(type) {
 		case string:
 			entry.RawResponse = strings.TrimSpace(raw)
@@ -779,22 +574,28 @@ func (p *LoggerPlugin) applyRealtimeOutputToEntry(entry *logstore.Log, result *s
 // InputHistoryParsed from any embedded realtime user/transcript events.
 // Used by both success and error paths so realtime turns that fail mid-stream
 // still surface their input transcript in logs.
-func applyRealtimeRawRequestBackfill(entry *logstore.Log, rawRequest any, contentLoggingEnabled bool) {
+// shouldStoreRaw gates whether entry.RawRequest is populated; InputHistoryParsed
+// (parsed content) is always extracted when contentLoggingEnabled regardless.
+func applyRealtimeRawRequestBackfill(entry *logstore.Log, rawRequest any, contentLoggingEnabled bool, shouldStoreRaw bool) {
 	if !contentLoggingEnabled || rawRequest == nil {
 		return
 	}
+	var rawStr string
 	switch raw := rawRequest.(type) {
 	case string:
-		entry.RawRequest = strings.TrimSpace(raw)
+		rawStr = strings.TrimSpace(raw)
 	default:
 		if rawRequestBytes, err := sonic.Marshal(rawRequest); err == nil {
-			entry.RawRequest = string(rawRequestBytes)
+			rawStr = string(rawRequestBytes)
 		}
 	}
-	if strings.TrimSpace(entry.RawRequest) == "" {
+	if rawStr == "" {
 		return
 	}
-	if inputHistory := extractRealtimeInputHistoryFromRawRequest(entry.RawRequest); len(inputHistory) > 0 {
+	if shouldStoreRaw {
+		entry.RawRequest = rawStr
+	}
+	if inputHistory := extractRealtimeInputHistoryFromRawRequest(rawStr); len(inputHistory) > 0 {
 		entry.InputHistoryParsed = mergeRealtimeInputHistory(entry.InputHistoryParsed, inputHistory)
 	}
 }

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/logstore"
-	"github.com/maximhq/bifrost/framework/streaming"
 )
 
 type testLogger struct{}
@@ -183,66 +182,6 @@ func TestUpdateLogEntrySuppressesChatOutputWhenContentLoggingDisabled(t *testing
 	}
 }
 
-func TestUpdateStreamingLogEntryPreservesResponsesInputContentSummary(t *testing.T) {
-	store := newTestStore(t)
-	plugin := &LoggerPlugin{
-		store:  store,
-		logger: testLogger{},
-	}
-
-	requestID := "req-stream"
-	now := time.Now().UTC()
-	inputText := "stream request-side text"
-	initial := &InitialLogData{
-		Object:   "responses_stream",
-		Provider: "openai",
-		Model:    "gpt-4o-mini",
-		ResponsesInputHistory: []schemas.ResponsesMessage{{
-			Content: &schemas.ResponsesMessageContent{
-				ContentStr: &inputText,
-			},
-		}},
-	}
-
-	if err := plugin.insertInitialLogEntry(context.Background(), requestID, "", now, 0, nil, initial); err != nil {
-		t.Fatalf("insertInitialLogEntry() error = %v", err)
-	}
-
-	responsesText := "streamed response text"
-	streamResponse := &streaming.ProcessedStreamResponse{
-		Data: &streaming.AccumulatedData{
-			Latency: 25,
-			TokenUsage: &schemas.BifrostLLMUsage{
-				PromptTokens:     10,
-				CompletionTokens: 5,
-				TotalTokens:      15,
-			},
-			OutputMessages: []schemas.ResponsesMessage{{
-				Content: &schemas.ResponsesMessageContent{
-					ContentStr: &responsesText,
-				},
-			}},
-		},
-	}
-
-	if err := plugin.updateStreamingLogEntry(context.Background(), requestID, "", "", "", "", "", "", 0, nil, "", streamResponse, true, false, false); err != nil {
-		t.Fatalf("updateStreamingLogEntry() error = %v", err)
-	}
-
-	logEntry, err := store.FindByID(context.Background(), requestID)
-	if err != nil {
-		t.Fatalf("FindByID() error = %v", err)
-	}
-	if logEntry.TokenUsageParsed == nil || logEntry.TokenUsageParsed.TotalTokens != 15 {
-		t.Fatalf("expected token usage to be updated, got %+v", logEntry.TokenUsageParsed)
-	}
-	if !strings.Contains(logEntry.ContentSummary, inputText) {
-		t.Fatalf("expected content summary to preserve responses input, got %q", logEntry.ContentSummary)
-	}
-	if strings.Contains(logEntry.ContentSummary, responsesText) {
-		t.Fatalf("expected content summary to avoid overwriting with streamed responses output-only data, got %q", logEntry.ContentSummary)
-	}
-}
 
 func TestStoreOrEnqueueRetryPreservesAllEntries(t *testing.T) {
 	// Simulate fallback/retry scenario where multiple PostLLMHook calls
@@ -336,7 +275,7 @@ func TestApplyRealtimeOutputToEntryBackfillsUserTranscriptFromRawRequest(t *test
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result)
+	plugin.applyRealtimeOutputToEntry(entry, result, true)
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error = %v", err)
 	}
@@ -385,7 +324,7 @@ func TestApplyRealtimeOutputToEntryBackfillsMissingTranscriptPlaceholder(t *test
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result)
+	plugin.applyRealtimeOutputToEntry(entry, result, true)
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error = %v", err)
 	}
@@ -425,7 +364,7 @@ func TestApplyRealtimeOutputToEntryBackfillsDoneMissingTranscriptPlaceholder(t *
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result)
+	plugin.applyRealtimeOutputToEntry(entry, result, true)
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error = %v", err)
 	}
@@ -465,7 +404,7 @@ func TestApplyRealtimeOutputToEntryBackfillsRetrievedUserAndToolHistory(t *testi
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result)
+	plugin.applyRealtimeOutputToEntry(entry, result, true)
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error = %v", err)
 	}
@@ -506,7 +445,7 @@ func TestApplyRealtimeOutputToEntryBackfillsCreatedUserAndToolHistory(t *testing
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result)
+	plugin.applyRealtimeOutputToEntry(entry, result, true)
 
 	if len(entry.InputHistoryParsed) != 2 {
 		t.Fatalf("len(InputHistoryParsed) = %d, want 2", len(entry.InputHistoryParsed))
@@ -557,7 +496,7 @@ func TestApplyRealtimeOutputToEntryBackfillsAddedUserAndToolHistory(t *testing.T
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result)
+	plugin.applyRealtimeOutputToEntry(entry, result, true)
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error = %v", err)
 	}
@@ -620,7 +559,7 @@ func TestApplyRealtimeOutputToEntryMergesRawTranscriptIntoStructuredRealtimeHist
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result)
+	plugin.applyRealtimeOutputToEntry(entry, result, true)
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error = %v", err)
 	}
@@ -645,5 +584,45 @@ func TestApplyRealtimeOutputToEntryMergesRawTranscriptIntoStructuredRealtimeHist
 	}
 	if strings.Count(entry.ContentSummary, "Hello.") != 1 {
 		t.Fatalf("ContentSummary = %q, want one merged transcript", entry.ContentSummary)
+	}
+}
+
+func TestApplyRealtimeOutputToEntryDoesNotPersistRawWhenShouldStoreRawFalse(t *testing.T) {
+	plugin := &LoggerPlugin{}
+	entry := &logstore.Log{}
+
+	assistantText := "Hello!"
+	messageType := schemas.ResponsesMessageTypeMessage
+	assistantRole := schemas.ResponsesInputMessageRoleAssistant
+	result := &schemas.BifrostResponse{
+		ResponsesResponse: &schemas.BifrostResponsesResponse{
+			Output: []schemas.ResponsesMessage{{
+				Type: &messageType,
+				Role: &assistantRole,
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: &assistantText,
+				},
+			}},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.RealtimeRequest,
+				RawRequest:  `{"type":"conversation.item.input_audio_transcription.completed","transcript":"Hello."}`,
+				RawResponse: `{"type":"response.done"}`,
+			},
+		},
+	}
+
+	plugin.applyRealtimeOutputToEntry(entry, result, false)
+
+	if entry.RawRequest != "" {
+		t.Fatalf("expected RawRequest to remain empty when shouldStoreRaw=false, got %q", entry.RawRequest)
+	}
+	if entry.RawResponse != "" {
+		t.Fatalf("expected RawResponse to remain empty when shouldStoreRaw=false, got %q", entry.RawResponse)
+	}
+	if len(entry.InputHistoryParsed) == 0 {
+		t.Fatal("expected InputHistoryParsed to still be backfilled when shouldStoreRaw=false")
+	}
+	if entry.InputHistoryParsed[0].Role != schemas.ChatMessageRoleUser {
+		t.Fatalf("InputHistoryParsed[0].Role = %q, want user", entry.InputHistoryParsed[0].Role)
 	}
 }

--- a/transports/bifrost-http/handlers/devpprof.go
+++ b/transports/bifrost-http/handlers/devpprof.go
@@ -537,7 +537,6 @@ func categorizeGoroutine(g *GoroutineGroup) {
 		"Inject",                // Observability plugin inject
 		"insertInitialLogEntry", // Logging
 		"updateLogEntry",        // Logging
-		"updateStreamingLogEntry",
 		"retryOnNotFound",
 		"BroadcastLogUpdate",
 	}

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -518,13 +518,13 @@ type ContainerCreateRequest struct {
 
 // Helper functions
 
-// enableRawRequestResponseForContainer sets context flags to always capture raw request/response
-// for container operations. Container operations don't have model-specific content, so raw
-// data is useful for debugging and should be enabled by default.
+// enableRawRequestResponseForContainer sets per-request overrides to always capture and
+// send back raw request/response for container operations. Container operations don't have
+// model-specific content, so raw data is useful for debugging and should be enabled by default.
 func enableRawRequestResponseForContainer(bifrostCtx *schemas.BifrostContext) {
 	bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawRequest, true)
 	bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
-	bifrostCtx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+	bifrostCtx.SetValue(schemas.BifrostContextKeyStoreRawRequestResponse, true)
 }
 
 // parseFallbacks extracts fallbacks from string array and converts to Fallback structs

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -3280,13 +3280,13 @@ func parseOpenAIVideoGenerationMultipartRequest(ctx *fasthttp.RequestCtx, req in
 	return nil
 }
 
-// enableRawRequestResponseForContainer sets context flags to always capture raw request/response
-// for container operations. Container operations don't have model-specific content, so raw
-// data is useful for debugging and should be enabled by default.
+// enableRawRequestResponseForContainer sets per-request overrides to always capture and
+// send back raw request/response for container operations. Container operations don't have
+// model-specific content, so raw data is useful for debugging and should be enabled by default.
 func enableRawRequestResponseForContainer(bifrostCtx *schemas.BifrostContext) {
 	bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawRequest, true)
 	bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
-	bifrostCtx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+	bifrostCtx.SetValue(schemas.BifrostContextKeyStoreRawRequestResponse, true)
 }
 
 // parseContainerFileCreateMultipartRequest is a RequestParser that handles multipart/form-data for container file create requests

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -107,6 +107,11 @@ func ParseSessionIDFromBaggage(header string) string {
 // 8. Session Stickiness Headers:
 //   - x-bf-session-id: Session identifier for key binding (reuse same key across requests)
 //   - x-bf-session-ttl: Per-request TTL override (duration string e.g. "30m" or seconds integer)
+//
+// 9. Raw Capture Headers (per-request override of provider config; accepts "true" or "false"):
+//   - x-bf-send-back-raw-request: include raw provider request in the BifrostResponse returned to the caller
+//   - x-bf-send-back-raw-response: include raw provider response in the BifrostResponse returned to the caller
+//   - x-bf-store-raw-request-response: capture raw request/response for logging only (stripped from client response)
 
 // Parameters:
 //   - ctx: The FastHTTP request context containing the original headers
@@ -423,10 +428,23 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 			mcpExtraHeaders[keyStr] = append(mcpExtraHeaders[keyStr], string(value))
 			return true
 		}
-		// Send back raw response header
+		// Raw capture headers — all three support "true"/"false" to fully override the
+		// provider-level config for this request.
+		if keyStr == "x-bf-send-back-raw-request" {
+			if b, err := strconv.ParseBool(string(value)); err == nil {
+				bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawRequest, b)
+			}
+			return true
+		}
 		if keyStr == "x-bf-send-back-raw-response" {
-			if valueStr := string(value); valueStr == "true" {
-				bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
+			if b, err := strconv.ParseBool(string(value)); err == nil {
+				bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawResponse, b)
+			}
+			return true
+		}
+		if keyStr == "x-bf-store-raw-request-response" {
+			if b, err := strconv.ParseBool(string(value)); err == nil {
+				bifrostCtx.SetValue(schemas.BifrostContextKeyStoreRawRequestResponse, b)
 			}
 			return true
 		}

--- a/ui/app/workspace/providers/fragments/debuggingFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/debuggingFormFragment.tsx
@@ -3,12 +3,14 @@
 import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
 import { useUpdateProviderMutation } from "@/lib/store/apis/providersApi";
 import { ModelProvider } from "@/lib/types/config";
 import { debuggingFormSchema, type DebuggingFormSchema } from "@/lib/types/schemas";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { useEffect } from "react";
 import { useForm, type Resolver } from "react-hook-form";
 import { toast } from "sonner";
@@ -32,7 +34,9 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 			store_raw_request_response: provider.store_raw_request_response ?? false,
 		},
 	});
-	const storeRawEnabled = form.watch("store_raw_request_response");
+	const sendBackRawRequest = form.watch("send_back_raw_request");
+	const sendBackRawResponse = form.watch("send_back_raw_response");
+	const storeRawRequestResponse = form.watch("store_raw_request_response");
 
 	useEffect(() => {
 		dispatch(setProviderFormDirtyState(form.formState.isDirty));
@@ -69,9 +73,93 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 	return (
 		<Form {...form}>
 			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6" data-testid="provider-config-debugging-content">
-				<div className="space-y-0">
+				<div className="space-y-4">
 
-					{/* Parent: Store Raw Request/Response */}
+					{/* Send Back Raw Request */}
+					<FormField
+						control={form.control}
+						name="send_back_raw_request"
+						render={({ field }) => (
+							<FormItem>
+								<div className="flex items-center justify-between space-x-2">
+									<div className="space-y-0.5">
+										<div className="flex items-center gap-1.5">
+											<FormLabel>Send Back Raw Request</FormLabel>
+											<TooltipProvider>
+												<Tooltip>
+													<TooltipTrigger asChild data-testid="provider-debugging-send-back-raw-request-tooltip-trigger">
+														<Info className="text-muted-foreground h-3 w-3 cursor-pointer" />
+													</TooltipTrigger>
+													<TooltipContent>
+														Override per-request with header: <code>x-bf-send-back-raw-request: {String(!sendBackRawRequest)}</code>
+													</TooltipContent>
+												</Tooltip>
+											</TooltipProvider>
+										</div>
+										<p className="text-muted-foreground text-xs">
+											Include the raw provider request alongside the parsed request in the API response.
+										</p>
+									</div>
+									<FormControl>
+										<Switch
+											size="md"
+											checked={field.value}
+											disabled={!hasUpdateProviderAccess}
+											onCheckedChange={(checked) => {
+												field.onChange(checked);
+												form.trigger("send_back_raw_request");
+											}}
+										/>
+									</FormControl>
+								</div>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+
+					{/* Send Back Raw Response */}
+					<FormField
+						control={form.control}
+						name="send_back_raw_response"
+						render={({ field }) => (
+							<FormItem>
+								<div className="flex items-center justify-between space-x-2">
+									<div className="space-y-0.5">
+										<div className="flex items-center gap-1.5">
+											<FormLabel>Send Back Raw Response</FormLabel>
+											<TooltipProvider>
+												<Tooltip>
+													<TooltipTrigger asChild data-testid="provider-debugging-send-back-raw-response-tooltip-trigger">
+														<Info className="text-muted-foreground h-3 w-3 cursor-pointer" />
+													</TooltipTrigger>
+													<TooltipContent>
+														Override per-request with header: <code>x-bf-send-back-raw-response: {String(!sendBackRawResponse)}</code>
+													</TooltipContent>
+												</Tooltip>
+											</TooltipProvider>
+										</div>
+										<p className="text-muted-foreground text-xs">
+											Include the raw provider response alongside the parsed response in the API response.
+										</p>
+									</div>
+									<FormControl>
+										<Switch
+											size="md"
+											checked={field.value}
+											disabled={!hasUpdateProviderAccess}
+											onCheckedChange={(checked) => {
+												field.onChange(checked);
+												form.trigger("send_back_raw_response");
+											}}
+										/>
+									</FormControl>
+								</div>
+								<FormMessage />
+							</FormItem>
+						)}
+					/>
+
+					{/* Store Raw Request/Response */}
 					<FormField
 						control={form.control}
 						name="store_raw_request_response"
@@ -79,9 +167,21 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 							<FormItem>
 								<div className="flex items-center justify-between space-x-2">
 									<div className="space-y-0.5">
-										<FormLabel>Enable Raw Request/Response</FormLabel>
+										<div className="flex items-center gap-1.5">
+											<FormLabel>Store Raw Request/Response</FormLabel>
+											<TooltipProvider>
+												<Tooltip>
+													<TooltipTrigger asChild data-testid="provider-debugging-store-raw-request-response-tooltip-trigger">
+														<Info className="text-muted-foreground h-3 w-3 cursor-pointer" />
+													</TooltipTrigger>
+													<TooltipContent>
+														Override per-request with header: <code>x-bf-store-raw-request-response: {String(!storeRawRequestResponse)}</code>
+													</TooltipContent>
+												</Tooltip>
+											</TooltipProvider>
+										</div>
 										<p className="text-muted-foreground text-xs">
-											Capture the raw provider request and response for internal logging. Raw payloads are not returned to clients unless send_back_raw_request and send_back_raw_response are also enabled.
+											Persist raw request and response payloads in log records.
 										</p>
 									</div>
 									<FormControl>
@@ -92,10 +192,6 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 											disabled={!hasUpdateProviderAccess}
 											onCheckedChange={(checked) => {
 												field.onChange(checked);
-												if (!checked) {
-													form.setValue("send_back_raw_request", false, { shouldDirty: true });
-													form.setValue("send_back_raw_response", false, { shouldDirty: true });
-												}
 												form.trigger("store_raw_request_response");
 											}}
 										/>
@@ -106,80 +202,6 @@ export function DebuggingFormFragment({ provider }: DebuggingFormFragmentProps) 
 						)}
 					/>
 
-					{/* Children with tree connectors */}
-					<div className="relative mt-3 space-y-3 pl-6">
-
-						{/* Child 1: Send Back Raw Request — trunk continues past this to next sibling */}
-						<div className="relative">
-							{/* Vertical trunk — extends past bottom by the gap (space-y-3 = 0.75rem) to connect with child 2 */}
-							<div className="absolute -left-6 top-0 -bottom-3 w-px bg-border" />
-							{/* Horizontal branch at label center (~9px from top) */}
-							<div className="absolute -left-6 top-[0.5625rem] w-5 h-px bg-border" />
-							<FormField
-								control={form.control}
-								name="send_back_raw_request"
-								render={({ field }) => (
-									<FormItem>
-										<div className="flex items-center justify-between space-x-2">
-											<div className="space-y-0.5">
-												<FormLabel>Send Back Raw Request</FormLabel>
-												<p className="text-muted-foreground text-xs">
-												Include the raw provider request alongside the parsed request for debugging and advanced use cases
-												</p>
-											</div>
-											<FormControl>
-												<Switch
-													size="md"
-													checked={field.value}
-													disabled={!hasUpdateProviderAccess || !storeRawEnabled}
-													onCheckedChange={(checked) => {
-														field.onChange(checked);
-														form.trigger("send_back_raw_request");
-													}}
-												/>
-											</FormControl>
-										</div>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-						</div>
-
-						{/* Child 2: Send Back Raw Response — last child, trunk stops at label */}
-						<div className="relative">
-							{/* L-connector: vertical from top down to label center, then turns right */}
-							<div className="absolute -left-6 top-0 w-5 h-[0.5625rem] border-l border-b border-border rounded-bl" />
-							<FormField
-								control={form.control}
-								name="send_back_raw_response"
-								render={({ field }) => (
-									<FormItem>
-										<div className="flex items-center justify-between space-x-2">
-											<div className="space-y-0.5">
-												<FormLabel>Send Back Raw Response</FormLabel>
-												<p className="text-muted-foreground text-xs">
-												Include the raw provider response alongside the parsed response for debugging and advanced use cases
-												</p>
-											</div>
-											<FormControl>
-												<Switch
-													size="md"
-													checked={field.value}
-													disabled={!hasUpdateProviderAccess || !storeRawEnabled}
-													onCheckedChange={(checked) => {
-														field.onChange(checked);
-														form.trigger("send_back_raw_response");
-													}}
-												/>
-											</FormControl>
-										</div>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-						</div>
-
-					</div>
 				</div>
 
 				<div className="flex justify-end space-x-2 pb-6">


### PR DESCRIPTION
## Summary

Refactors raw request/response capture logic to support per-request overrides and clarifies the distinction between sending raw data back to clients versus storing it in logs. Previously, the three capture modes (send-back request, send-back response, store for logging) were tightly coupled and only supported asymmetric overrides. This change makes them orthogonal controls with full per-request override support.

## Changes

- **Decoupled capture modes**: `send_back_raw_request`, `send_back_raw_response`, and `store_raw_request_response` are now independent controls that can be enabled in any combination
- **Full per-request overrides**: All three modes now accept `"true"` or `"false"` headers that completely override provider-level config, replacing the previous asymmetric behavior
- **Clearer logging control**: Added `BifrostContextKeyShouldStoreRawInLogs` flag to explicitly control when the logging plugin persists raw data, preventing automatic storage when only send-back modes are enabled
- **Enhanced documentation**: Updated provider configuration docs and request options to clarify the orthogonal nature of these controls
- **Improved UI**: Redesigned the debugging form to show all three options as independent toggles with per-request override hints

Key design decisions:
- Maintained backward compatibility for existing provider configs
- Always write context flags explicitly to prevent stale values from previous provider attempts
- Separated capture logic (should providers collect raw bytes) from persistence logic (should logging plugin store them)

## Type of change

- [x] Feature
- [x] Refactor
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins
- [x] UI (Next.js)
- [x] Docs

## How to test

Test provider-level configuration:
```sh
# Test provider config with different combinations
curl -X POST http://localhost:8080/api/providers \
  -H "Content-Type: application/json" \
  -d '{
    "provider": "openai",
    "keys": [{"name": "test", "value": "env.OPENAI_API_KEY", "models": ["*"]}],
    "send_back_raw_request": true,
    "send_back_raw_response": false,
    "store_raw_request_response": true
  }'
```

Test per-request overrides:
```sh
# Override all three flags for a single request
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "x-bf-send-back-raw-request: false" \
  -H "x-bf-send-back-raw-response: true" \
  -H "x-bf-store-raw-request-response: false" \
  -H "Content-Type: application/json" \
  -d '{"model": "openai/gpt-4o-mini", "messages": [{"role": "user", "content": "test"}]}'
```

Verify logging behavior:
```sh
# Check that raw data appears in logs only when store flag is true
# and in API response only when send-back flags are true
```

Core tests:
```sh
go test ./core/... -v
go test ./plugins/logging/... -v
go test ./transports/bifrost-http/... -v
```

UI tests:
```sh
cd ui
pnpm test
pnpm build
```

## Screenshots/Recordings

The UI debugging form now shows three independent toggles instead of a hierarchical tree structure, with tooltip hints showing the per-request override headers.

## Breaking changes

- [ ] Yes
- [x] No

This change maintains full backward compatibility. Existing provider configurations continue to work as before, and the new per-request override behavior is additive.

## Related issues

Addresses user requests for more granular control over raw data capture and clearer separation between client-facing and logging-only modes.

## Security considerations

Raw request/response data may contain sensitive information (API keys, user content). The new orthogonal controls provide better security by allowing operators to:
- Store raw data for debugging without exposing it to clients
- Send raw data to specific clients without automatically logging it
- Disable both modes entirely when not needed

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable