### PR TITLE
fix(helm): use correct templating for mcpClientConfig

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.0.17
+version: 2.0.18
 appVersion: "1.4.11"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,17 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.0.17
+**Latest Version:** 2.0.18
 
 ## Changelog
+
+### v2.0.18
+
+- Fixed MCP client config template to correctly map camelCase keys in Helm values:
+  - `toolsToExecute` → `tools_to_execute`
+  - `toolsToAutoExecute` → `tools_to_auto_execute`
+  - `authType` → `auth_type`
+  - `oauthConfigId` → `oauth_config_id`
 
 ### v2.0.16
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -697,17 +697,17 @@ false
 {{- if $client.headers }}
 {{- $_ := set $cc "headers" $client.headers }}
 {{- end }}
-{{- if $client.tools_to_execute }}
-{{- $_ := set $cc "tools_to_execute" $client.tools_to_execute }}
+{{- if $client.toolsToExecute }}
+{{- $_ := set $cc "tools_to_execute" $client.toolsToExecute }}
 {{- end }}
-{{- if $client.tools_to_auto_execute }}
-{{- $_ := set $cc "tools_to_auto_execute" $client.tools_to_auto_execute }}
+{{- if $client.toolsToAutoExecute }}
+{{- $_ := set $cc "tools_to_auto_execute" $client.toolsToAutoExecute }}
 {{- end }}
-{{- if $client.auth_type }}
-{{- $_ := set $cc "auth_type" $client.auth_type }}
+{{- if $client.authType }}
+{{- $_ := set $cc "auth_type" $client.authType }}
 {{- end }}
-{{- if $client.oauth_config_id }}
-{{- $_ := set $cc "oauth_config_id" $client.oauth_config_id }}
+{{- if $client.oauthConfigId }}
+{{- $_ := set $cc "oauth_config_id" $client.oauthConfigId }}
 {{- end }}
 {{- if hasKey $client "isPingAvailable" }}
 {{- $_ := set $cc "is_ping_available" $client.isPingAvailable }}

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,27 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.4.11
+    created: "2026-04-13T12:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.0.18.tgz
+    version: 2.0.18
+  - apiVersion: v2
+    appVersion: 1.4.11
     created: "2026-04-08T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
     digest: ""


### PR DESCRIPTION
## Summary

Fix MCP client values not being rendered into `config.json` in the Helm ConfigMap due to key-name mismatch.

## Changes

- Updated MCP client templating to read camelCase Helm values and emit snake_case config keys:
  - `toolsToExecute` → `tools_to_execute`
  - `toolsToAutoExecute` → `tools_to_auto_execute`
  - `authType` → `auth_type`
  - `oauthConfigId` → `oauth_config_id`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Render Helm chart with MCP client values
cat >/tmp/mcp-values.yaml <<'EOF'
bifrost:
  mcp:
    enabled: true
    clientConfigs:
      - name: mcp-http
        connectionType: http
        httpConfig:
          url: https://example-http
        authType: oauth
        oauthConfigId: oauth-1
        toolsToExecute: ["a", "b"]
        toolsToAutoExecute: ["a"]
EOF

helm template test ./helm-charts/bifrost -f  | grep -E 'tools_to_execute|tools_to_auto_execute|auth_type|oauth_config_id'