### PR TITLE
feat: add link to create a provider if none present

### DIFF
--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -28,7 +28,6 @@ import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import Toggle from "@/components/ui/toggle";
-import Link from "next/link";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/components/ui/utils";
 import { ModelPlaceholders } from "@/lib/constants/config";
@@ -48,6 +47,7 @@ import { CreateVirtualKeyRequest, Customer, Team, UpdateVirtualKeyRequest, Virtu
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Building, Info, RotateCcw, Trash2, Users, X } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { components, MultiValueProps, OptionProps } from "react-select";
@@ -152,6 +152,7 @@ type VirtualKeyType = {
 
 export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, onCancel }: VirtualKeySheetProps) {
 	const [isOpen, setIsOpen] = useState(true);
+	const router = useRouter();
 	const isEditing = !!virtualKey;
 
 	const hasCreateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Create);
@@ -576,6 +577,11 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 									<Select
 										value={selectedProvider}
 										onValueChange={(provider) => {
+											if (provider === "__manage_providers__") {
+												router.push("/workspace/providers");
+												setSelectedProvider("");
+												return;
+											}
 											handleAddProvider(provider);
 											setSelectedProvider(""); // Reset to placeholder state
 										}}
@@ -592,17 +598,16 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 
 												if (unconfiguredProviders.length === 0) {
 													return (
-														<Link
-															href="/workspace/providers"
-															className="text-muted-foreground hover:text-foreground block px-2 py-1.5 text-sm transition-colors"
-															aria-label="Open provider configuration"
+														<SelectItem
+															value="__manage_providers__"
+															className="text-muted-foreground hover:text-foreground"
 															data-testid="vk-provider-config-link"
 														>
 															<span>
 																No providers left to configure. <span className="text-primary font-medium underline">Click to add</span>
 															</span>
-														</Link>
-														);
+														</SelectItem>
+													);
 												}
 
 												// Separate base providers and custom providers

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -28,6 +28,7 @@ import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import Toggle from "@/components/ui/toggle";
+import Link from "next/link";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/components/ui/utils";
 import { ModelPlaceholders } from "@/lib/constants/config";
@@ -590,7 +591,18 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 												);
 
 												if (unconfiguredProviders.length === 0) {
-													return <div className="text-muted-foreground px-2 py-1.5 text-sm">No providers left to configure</div>;
+													return (
+														<Link
+															href="/workspace/providers"
+															className="text-muted-foreground hover:text-foreground block px-2 py-1.5 text-sm transition-colors"
+															aria-label="Open provider configuration"
+															data-testid="vk-provider-config-link"
+														>
+															<span>
+																No providers left to configure. <span className="text-primary font-medium underline">Click to add</span>
+															</span>
+														</Link>
+														);
 												}
 
 												// Separate base providers and custom providers


### PR DESCRIPTION
## Summary

Add a link to the Model Provider page in Virtual keys setup, when there is no model provider present.

## Changes

- Added a Link to `workspace/providers` when no model provider is present in the system.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Verify if you can see the text "Click to add" next to "No providers left to configure" and also it goes to the Model Providers page

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```



## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.  
Before:  
![image.png](https://app.graphite.com/user-attachments/assets/879b9bd1-4877-4e0b-9376-a68f540c2537.png)



After:  
![image.png](https://app.graphite.com/user-attachments/assets/40afefa0-94d5-404f-9adf-4d3615dea260.png)



## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

N/A

## Security considerations

No security implications - this change only adds a link to the UI.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable