### PR TITLE
fix: allow custom providers without a list models endpoint to pass in any model rather than restrict it on vk

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773144721,
-        "narHash": "sha256-1fa382ppXYOqqFIECQ3A1qogn/QLwNFvpjx/WivuNBc=",
+        "lastModified": 1776062742,
+        "narHash": "sha256-CYncVXVsUzYK+JZldSuK08ibXrAIJh+T22V13Z4ySS0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fb30d84f085815771af9decacb4b41b841798601",
+        "rev": "1c742e001e98f5191a5586751e16311fe1481f61",
         "type": "github"
       },
       "original": {

--- a/framework/modelcatalog/main_test.go
+++ b/framework/modelcatalog/main_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/stretchr/testify/assert"
 )
@@ -17,9 +18,9 @@ func newTestCatalog(modelPool map[schemas.ModelProvider][]string, baseModelIndex
 		baseModelIndex = make(map[string]string)
 	}
 	return &ModelCatalog{
-		modelPool:       modelPool,
-		baseModelIndex:  baseModelIndex,
-		pricingData:     make(map[string]configstoreTables.TableModelPricing),
+		modelPool:      modelPool,
+		baseModelIndex: baseModelIndex,
+		pricingData:    make(map[string]configstoreTables.TableModelPricing),
 	}
 }
 
@@ -153,5 +154,56 @@ func TestIsModelAllowedForProvider_PrefixedAllowedModelInCatalog(t *testing.T) {
 		nil,
 	)
 
-	assert.True(t, mc.IsModelAllowedForProvider(schemas.OpenRouter, "gpt-4o", []string{"openai/gpt-4o"}))
+	providerConfig := configstore.ProviderConfig{}
+
+	assert.True(t, mc.IsModelAllowedForProvider(schemas.OpenRouter, "gpt-4o", &providerConfig, []string{"openai/gpt-4o"}))
+}
+
+func TestIsModelAllowedForProvider_CustomProviderListModelsDisabled(t *testing.T) {
+	mc := newTestCatalog(nil, nil)
+
+	// Custom provider with list-models disabled + ["*"] → should return true
+	providerConfig := configstore.ProviderConfig{
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			AllowedRequests: &schemas.AllowedRequests{
+				ListModels: false,
+			},
+		},
+	}
+	assert.True(t, mc.IsModelAllowedForProvider("custom-provider", "any-model", &providerConfig, []string{"*"}))
+}
+
+func TestIsModelAllowedForProvider_CustomProviderListModelsEnabled(t *testing.T) {
+	mc := newTestCatalog(
+		map[schemas.ModelProvider][]string{
+			"custom-provider": {"model-a"},
+		},
+		nil,
+	)
+
+	// Custom provider with list-models enabled + ["*"] → should go through catalog
+	providerConfig := configstore.ProviderConfig{
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			AllowedRequests: &schemas.AllowedRequests{
+				ListModels: true,
+			},
+		},
+	}
+	// model-a is in catalog → allowed
+	assert.True(t, mc.IsModelAllowedForProvider("custom-provider", "model-a", &providerConfig, []string{"*"}))
+	// model-b is NOT in catalog → denied
+	assert.False(t, mc.IsModelAllowedForProvider("custom-provider", "model-b", &providerConfig, []string{"*"}))
+}
+
+func TestIsModelAllowedForProvider_NilProviderConfig(t *testing.T) {
+	mc := newTestCatalog(
+		map[schemas.ModelProvider][]string{
+			"some-provider": {"model-x"},
+		},
+		nil,
+	)
+
+	// nil providerConfig + ["*"] → should go through catalog (not bypass)
+	assert.True(t, mc.IsModelAllowedForProvider("some-provider", "model-x", nil, []string{"*"}))
+	assert.False(t, mc.IsModelAllowedForProvider("some-provider", "model-y", nil, []string{"*"}))
 }

--- a/framework/modelcatalog/models.go
+++ b/framework/modelcatalog/models.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 )
 
@@ -194,10 +195,20 @@ func (mc *ModelCatalog) GetProvidersForModel(model string) []schemas.ModelProvid
 //	// Explicit allowedModels without prefix
 //	mc.IsModelAllowedForProvider("openai", "gpt-4o", []string{"gpt-4o"})
 //	// Returns: true (direct match)
-func (mc *ModelCatalog) IsModelAllowedForProvider(provider schemas.ModelProvider, model string, allowedModels schemas.WhiteList) bool {
+func (mc *ModelCatalog) IsModelAllowedForProvider(provider schemas.ModelProvider, model string, providerConfig *configstore.ProviderConfig, allowedModels schemas.WhiteList) bool {
+	isCustomProvider := false
+	hasListModelsEndpointDisabled := false
+	if providerConfig != nil {
+		isCustomProvider = providerConfig.CustomProviderConfig != nil
+		hasListModelsEndpointDisabled = !providerConfig.CustomProviderConfig.IsOperationAllowed(schemas.ListModelsRequest)
+	}
+
 	// Case 1: ["*"] = allow all models; use catalog to determine support
 	// Empty allowedModels = deny all (fail-safe deny-by-default)
 	if allowedModels.IsUnrestricted() {
+		if isCustomProvider && hasListModelsEndpointDisabled {
+			return true
+		}
 		supportedProviders := mc.GetProvidersForModel(model)
 		return slices.Contains(supportedProviders, provider)
 	}

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -171,7 +171,7 @@ func Init(
 	}
 	// Initialize components in dependency order with fixed, optimal settings
 	// Resolver (pure decision engine for hierarchical governance, depends only on store)
-	resolver := NewBudgetResolver(governanceStore, modelCatalog, logger)
+	resolver := NewBudgetResolver(governanceStore, modelCatalog, logger, inMemoryStore)
 
 	// 3. Tracker (business logic owner, depends on store and resolver)
 	tracker := NewUsageTracker(ctx, governanceStore, resolver, configStore, logger)
@@ -282,7 +282,7 @@ func InitFromStore(
 		defaultDepth := DefaultRoutingChainMaxDepth
 		routingChainMaxDepth = &defaultDepth
 	}
-	resolver := NewBudgetResolver(governanceStore, modelCatalog, logger)
+	resolver := NewBudgetResolver(governanceStore, modelCatalog, logger, inMemoryStore)
 	tracker := NewUsageTracker(ctx, governanceStore, resolver, configStore, logger)
 	engine, err := NewRoutingEngine(governanceStore, logger, routingChainMaxDepth)
 	if err != nil {
@@ -675,8 +675,10 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 		// This handles all cross-provider logic (OpenRouter, Vertex, Groq, Bedrock)
 		// and provider-prefixed allowed_models entries
 		isProviderAllowed := false
-		if p.modelCatalog != nil {
-			isProviderAllowed = p.modelCatalog.IsModelAllowedForProvider(schemas.ModelProvider(config.Provider), modelStr, config.AllowedModels)
+		if p.modelCatalog != nil && p.inMemoryStore != nil {
+			provider := schemas.ModelProvider(config.Provider)
+			providerConfig := p.inMemoryStore.GetConfiguredProviders()[provider]
+			isProviderAllowed = p.modelCatalog.IsModelAllowedForProvider(provider, modelStr, &providerConfig, config.AllowedModels)
 		} else {
 			// Fallback when model catalog is not available: simple string matching
 			// ["*"] = allow all models; [] = deny all models

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -793,7 +793,7 @@ func TestResolver_EvaluateModelAndProviderRequest_NoConfigs(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	result := resolver.EvaluateModelAndProviderRequest(ctx, schemas.OpenAI, "gpt-4")
@@ -810,7 +810,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderBudgetExceeded(t *test
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	result := resolver.EvaluateModelAndProviderRequest(ctx, schemas.OpenAI, "gpt-4")
@@ -828,7 +828,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderRateLimitExceeded(t *t
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	result := resolver.EvaluateModelAndProviderRequest(ctx, schemas.OpenAI, "gpt-4")
@@ -846,7 +846,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ModelBudgetExceeded(t *testing
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	result := resolver.EvaluateModelAndProviderRequest(ctx, schemas.OpenAI, "gpt-4")
@@ -864,7 +864,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ModelRateLimitExceeded(t *test
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	result := resolver.EvaluateModelAndProviderRequest(ctx, schemas.OpenAI, "gpt-4")
@@ -882,7 +882,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ModelRateLimitExceeded_Request
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	result := resolver.EvaluateModelAndProviderRequest(ctx, schemas.OpenAI, "gpt-4")
@@ -905,7 +905,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderBudgetThenModelBudget(
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	result := resolver.EvaluateModelAndProviderRequest(ctx, schemas.OpenAI, "gpt-4")
@@ -929,7 +929,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderRateLimitThenModelRate
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	result := resolver.EvaluateModelAndProviderRequest(ctx, schemas.OpenAI, "gpt-4")
@@ -953,7 +953,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderRateLimitThenModelRate
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	result := resolver.EvaluateModelAndProviderRequest(ctx, schemas.OpenAI, "gpt-4")
@@ -980,7 +980,7 @@ func TestResolver_EvaluateModelAndProviderRequest_AllChecksPass(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	result := resolver.EvaluateModelAndProviderRequest(ctx, schemas.OpenAI, "gpt-4")
@@ -998,7 +998,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderOnly_NoModel(t *testin
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	// No model provided
@@ -1016,7 +1016,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ModelOnly_NoProvider(t *testin
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	// No provider provided
@@ -1036,7 +1036,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderSpecificBudget_Differe
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	// Request with Azure (different provider) for same model should pass
@@ -1056,7 +1056,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderSpecificRateLimit_Diff
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	// Request with Azure (different provider) for same model should pass
@@ -1076,7 +1076,7 @@ func TestResolver_EvaluateModelAndProviderRequest_ProviderSpecificRateLimit_Diff
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
 	// Request with Azure (different provider) for same model should pass

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -62,17 +62,19 @@ type UsageInfo struct {
 
 // BudgetResolver provides decision logic for the new hierarchical governance system
 type BudgetResolver struct {
-	store        GovernanceStore
-	logger       schemas.Logger
-	modelCatalog *modelcatalog.ModelCatalog
+	store                   GovernanceStore
+	logger                  schemas.Logger
+	modelCatalog            *modelcatalog.ModelCatalog
+	governanceInMemoryStore InMemoryStore
 }
 
 // NewBudgetResolver creates a new budget-based governance resolver
-func NewBudgetResolver(store GovernanceStore, modelCatalog *modelcatalog.ModelCatalog, logger schemas.Logger) *BudgetResolver {
+func NewBudgetResolver(store GovernanceStore, modelCatalog *modelcatalog.ModelCatalog, logger schemas.Logger, governanceInMemoryStore InMemoryStore) *BudgetResolver {
 	return &BudgetResolver{
-		store:        store,
-		logger:       logger,
-		modelCatalog: modelCatalog,
+		store:                   store,
+		logger:                  logger,
+		modelCatalog:            modelCatalog,
+		governanceInMemoryStore: governanceInMemoryStore,
 	}
 }
 
@@ -271,8 +273,9 @@ func (r *BudgetResolver) isModelAllowed(vk *configstoreTables.TableVirtualKey, p
 			// Delegate model allowance check to model catalog
 			// This handles all cross-provider logic (OpenRouter, Vertex, Groq, Bedrock)
 			// and provider-prefixed allowed_models entries
-			if r.modelCatalog != nil {
-				return r.modelCatalog.IsModelAllowedForProvider(provider, model, pc.AllowedModels)
+			if r.modelCatalog != nil && r.governanceInMemoryStore != nil {
+				providerConfig := r.governanceInMemoryStore.GetConfiguredProviders()[provider]
+				return r.modelCatalog.IsModelAllowedForProvider(provider, model, &providerConfig, pc.AllowedModels)
 			}
 			// Fallback when model catalog is not available: simple string matching
 			// ["*"] = allow all models; [] = deny all models

--- a/plugins/governance/resolver_test.go
+++ b/plugins/governance/resolver_test.go
@@ -26,7 +26,7 @@ func TestBudgetResolver_EvaluateRequest_AllowedRequest(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
@@ -41,7 +41,7 @@ func TestBudgetResolver_EvaluateRequest_VirtualKeyNotFound(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-nonexistent", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
@@ -59,7 +59,7 @@ func TestBudgetResolver_EvaluateRequest_VirtualKeyBlocked(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
@@ -82,7 +82,7 @@ func TestBudgetResolver_EvaluateRequest_ProviderBlocked(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	// Try to use OpenAI (not allowed)
@@ -113,7 +113,7 @@ func TestBudgetResolver_EvaluateRequest_ModelBlocked(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	// Try to use gpt-4o-mini (not in allowed list)
@@ -136,7 +136,7 @@ func TestBudgetResolver_EvaluateRequest_RateLimitExceeded_TokenLimit(t *testing.
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
@@ -159,7 +159,7 @@ func TestBudgetResolver_EvaluateRequest_RateLimitExceeded_RequestLimit(t *testin
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
@@ -197,7 +197,7 @@ func TestBudgetResolver_EvaluateRequest_RateLimitExpired(t *testing.T) {
 	err = store.ResetExpiredRateLimits(context.Background(), expiredRateLimits)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
@@ -219,7 +219,7 @@ func TestBudgetResolver_EvaluateRequest_BudgetExceeded(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
@@ -246,7 +246,7 @@ func TestBudgetResolver_EvaluateRequest_BudgetExpired(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
@@ -280,7 +280,7 @@ func TestBudgetResolver_EvaluateRequest_MultiLevelBudgetHierarchy(t *testing.T) 
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	// Test: All under limit should pass
@@ -314,7 +314,7 @@ func TestBudgetResolver_EvaluateRequest_ProviderLevelRateLimit(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
@@ -337,7 +337,7 @@ func TestBudgetResolver_CheckRateLimits_BothExceeded(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
@@ -352,7 +352,7 @@ func TestBudgetResolver_IsProviderAllowed(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 
 	tests := []struct {
 		name            string
@@ -400,7 +400,7 @@ func TestBudgetResolver_IsModelAllowed(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 
 	tests := []struct {
 		name            string
@@ -488,7 +488,7 @@ func TestBudgetResolver_ContextPopulation(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -416,7 +416,7 @@ func TestGovernanceStore_MultiBudget_ResolverBlocksOnBudgetExceeded(t *testing.T
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
@@ -443,7 +443,7 @@ func TestGovernanceStore_MultiBudget_ResolverAllowsUnderLimit(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	ctx := &schemas.BifrostContext{}
 
 	result := resolver.EvaluateVirtualKeyRequest(ctx, "sk-bf-test", schemas.OpenAI, "gpt-4", schemas.ChatCompletionRequest, false)
@@ -471,7 +471,7 @@ func TestGovernanceStore_MultiBudget_UsageDrivesBlockAfterRequests(t *testing.T)
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 
 	// Request 1: $0.80 — both budgets fine
 	vk, _ = store.GetVirtualKey("sk-bf-test")

--- a/plugins/governance/tracker_test.go
+++ b/plugins/governance/tracker_test.go
@@ -25,7 +25,7 @@ func TestUsageTracker_UpdateUsage_FailedRequest(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	tracker := NewUsageTracker(context.Background(), store, resolver, nil, logger)
 	defer tracker.Cleanup()
 
@@ -60,7 +60,7 @@ func TestUsageTracker_UpdateUsage_VirtualKeyNotFound(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	tracker := NewUsageTracker(context.Background(), store, resolver, nil, logger)
 	defer tracker.Cleanup()
 
@@ -94,7 +94,7 @@ func TestUsageTracker_UpdateUsage_StreamingOptimization(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	tracker := NewUsageTracker(context.Background(), store, resolver, nil, logger)
 	defer tracker.Cleanup()
 
@@ -157,7 +157,7 @@ func TestUsageTracker_Cleanup(t *testing.T) {
 	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{}, nil)
 	require.NoError(t, err)
 
-	resolver := NewBudgetResolver(store, nil, logger)
+	resolver := NewBudgetResolver(store, nil, logger, nil)
 	tracker := NewUsageTracker(context.Background(), store, resolver, nil, logger)
 
 	// Should cleanup without error

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -113,9 +113,17 @@ func (p *GovernancePlugin) filterModelsForVirtualKey(
 		isAllowed := false
 		for _, pc := range vk.ProviderConfigs {
 			if pc.Provider == string(provider) {
-				if p.modelCatalog.IsModelAllowedForProvider(provider, modelName, pc.AllowedModels) {
-					isAllowed = true
-					break
+				if p.modelCatalog != nil && p.inMemoryStore != nil {
+					providerConfig := p.inMemoryStore.GetConfiguredProviders()[provider]
+					if p.modelCatalog.IsModelAllowedForProvider(provider, modelName, &providerConfig, pc.AllowedModels) {
+						isAllowed = true
+						break
+					}
+				} else {
+					if pc.AllowedModels.IsAllowed(modelName) {
+						isAllowed = true
+						break
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Enhanced model validation for custom providers by adding provider configuration
context to model allowlist checks. This enables proper handling of custom
providers that have disabled list models endpoints.

## Changes

- Modified `IsModelAllowedForProvider` method to accept a `ProviderConfig`
  parameter for context-aware validation
- Added logic to allow all models for custom providers when list models endpoint
  is disabled
- Updated `BudgetResolver` to include governance in-memory store for accessing
  provider configurations
- Updated all callers of `IsModelAllowedForProvider` to pass provider
  configuration context
- Updated nixpkgs dependency to latest version

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate model catalog functionality and custom provider handling:

```sh
# Core/Transports
go version
go test ./...

# Test specific model catalog functionality
go test ./framework/modelcatalog/...
go test ./plugins/governance/...
```

Test with custom providers that have disabled list models endpoints to ensure
proper model validation behavior.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

The `IsModelAllowedForProvider` method signature has changed to include a
`ProviderConfig` parameter. Any external callers will need to be updated to pass
the provider configuration.

## Related issues

[#2351](https://github.com/maximhq/bifrost/issues/2351)

## Security considerations

This change improves security by providing more granular control over model
access based on provider configuration, ensuring proper validation for custom
providers with restricted capabilities.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

