### PR TITLE
test case fix for bifrost-http

### DIFF
--- a/transports/bifrost-http/lib/validator_test.go
+++ b/transports/bifrost-http/lib/validator_test.go
@@ -605,7 +605,7 @@ func TestValidateConfigSchema_VirtualKeyProviderConfig_MissingProvider(t *testin
 // =============================================================================
 
 func TestValidateConfigSchema_VirtualKeyMCPConfig_Valid(t *testing.T) {
-	// Valid virtual key MCP config with required field: mcp_client_id
+	// Valid virtual key MCP config identifying the MCP client by mcp_client_id (DB form)
 	validConfig := `{
 		"governance": {
 			"virtual_keys": [
@@ -629,9 +629,11 @@ func TestValidateConfigSchema_VirtualKeyMCPConfig_Valid(t *testing.T) {
 	}
 }
 
-func TestValidateConfigSchema_VirtualKeyMCPConfig_MissingMCPClientId(t *testing.T) {
-	// Missing required field: mcp_client_id
-	invalidConfig := `{
+func TestValidateConfigSchema_VirtualKeyMCPConfig_ValidWithClientName(t *testing.T) {
+	// Valid virtual key MCP config identifying the MCP client by mcp_client_name
+	// (config-file form — resolved to mcp_client_id at startup). Either identifier
+	// alone is sufficient; neither is required at the JSON Schema level.
+	validConfig := `{
 		"governance": {
 			"virtual_keys": [
 				{
@@ -640,6 +642,7 @@ func TestValidateConfigSchema_VirtualKeyMCPConfig_MissingMCPClientId(t *testing.
 					"value": "vk_test_123456",
 					"mcp_configs": [
 						{
+							"mcp_client_name": "my-mcp-client",
 							"tools_to_execute": ["tool1"]
 						}
 					]
@@ -648,9 +651,9 @@ func TestValidateConfigSchema_VirtualKeyMCPConfig_MissingMCPClientId(t *testing.
 		}
 	}`
 
-	err := ValidateConfigSchema([]byte(invalidConfig), loadLocalSchema(t))
-	if err == nil {
-		t.Error("expected config missing 'mcp_client_id' in virtual key MCP config to fail validation")
+	err := ValidateConfigSchema([]byte(validConfig), loadLocalSchema(t))
+	if err != nil {
+		t.Errorf("expected virtual key MCP config with mcp_client_name to pass validation, got error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Updates virtual key MCP configuration validation to support both `mcp_client_id` and `mcp_client_name` as valid client identifiers, removing the strict requirement for `mcp_client_id`.

## Changes

- Modified test case to validate MCP config with `mcp_client_name` instead of requiring `mcp_client_id`
- Added new test `TestValidateConfigSchema_VirtualKeyMCPConfig_ValidWithClientName` to verify `mcp_client_name` is accepted
- Renamed and updated `TestValidateConfigSchema_VirtualKeyMCPConfig_MissingMCPClientId` to demonstrate valid configuration using client name
- Updated test comments to clarify that `mcp_client_name` represents the config-file form that gets resolved to `mcp_client_id` at startup

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate the configuration schema changes by running the validator tests:

```sh
go version
cd transports/bifrost-http/lib
go test -v -run TestValidateConfigSchema_VirtualKeyMCPConfig
```

Expected outcomes:
- `TestValidateConfigSchema_VirtualKeyMCPConfig_Valid` should pass with `mcp_client_id`
- `TestValidateConfigSchema_VirtualKeyMCPConfig_ValidWithClientName` should pass with `mcp_client_name`

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this change only affects configuration validation to accept alternative client identification methods.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable