### PR TITLE
config test fixes

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -3382,7 +3382,7 @@ EOF
       --app-dir "$TEMP_DIR" --port "$BIFROST_PORT" > "$server_log" 2>&1 &
     BIFROST_PID=$!
 
-    if ! wait_for_bifrost "$server_log" 120; then
+    if ! wait_for_bifrost "$server_log" 300; then
       log_error "Failed to start bifrost $version"
       cat "$server_log" 2>/dev/null || true
       stop_bifrost
@@ -3423,7 +3423,7 @@ EOF
     "$current_binary" --app-dir "$TEMP_DIR" --port "$BIFROST_PORT" > "$current_log" 2>&1 &
     BIFROST_PID=$!
 
-    if ! wait_for_bifrost "$current_log" 120; then
+    if ! wait_for_bifrost "$current_log" 300; then
       log_error "Current version failed to start after migrating from $version"
       cat "$current_log"
       stop_bifrost
@@ -3581,7 +3581,7 @@ EOF
       --app-dir "$TEMP_DIR" --port "$BIFROST_PORT" > "$server_log" 2>&1 &
     BIFROST_PID=$!
 
-    if ! wait_for_bifrost "$server_log" 120; then
+    if ! wait_for_bifrost "$server_log" 300; then
       log_error "Failed to start bifrost $version"
       cat "$server_log" 2>/dev/null || true
       stop_bifrost
@@ -3621,7 +3621,7 @@ EOF
     "$current_binary" --app-dir "$TEMP_DIR" --port "$BIFROST_PORT" > "$current_log" 2>&1 &
     BIFROST_PID=$!
 
-    if ! wait_for_bifrost "$current_log" 120; then
+    if ! wait_for_bifrost "$current_log" 300; then
       log_error "Current version failed to start after migrating from $version"
       cat "$current_log"
       stop_bifrost

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -15480,6 +15480,9 @@ var excludedSchemaFields = map[string]map[string]bool{
 		"keys":    true, // Complex nested type, validated separately
 		"key_ids": true, // Config-file format; handled via custom UnmarshalJSON into allow_all_keys/keys
 	},
+	"governance.virtual_keys.mcp_configs": {
+		"mcp_client_name": true, // Config-file format; captured via custom UnmarshalJSON and resolved to mcp_client_id at startup
+	},
 	"mcp.client_configs": {
 		"websocket_config": true, // Schema documents all connection types
 		"http_config":      true, // Schema documents all connection types


### PR DESCRIPTION
## Summary

Increases the timeout for Bifrost server startup in migration tests from 120 seconds to 300 seconds and excludes the `mcp_client_name` field from schema validation tests.

## Changes

- Extended Bifrost startup timeout from 2 minutes to 5 minutes in migration test scripts to allow more time for server initialization during testing
- Added exclusion for `governance.virtual_keys.mcp_configs.mcp_client_name` field in config tests since it's a config-file format that gets resolved to `mcp_client_id` at startup via custom UnmarshalJSON

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the migration tests to verify the increased timeout prevents false failures:

```sh
# Run migration tests
.github/workflows/scripts/run-migration-tests.sh

# Run config tests to verify schema validation works correctly
cd transports/bifrost-http/lib
go test -run TestConfig
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects test timeouts and schema validation exclusions.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable