### PR TITLE
fix(gemini): accept numeric values for Schema int64 fields (minLength, maxLength, etc.)

### DIFF
--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -958,6 +958,63 @@ type Schema struct {
 	Type Type `json:"type,omitempty"`
 }
 
+// toInt64Ptr converts an any value (from JSON) to *int64, accepting both
+// JSON numbers (float64 from standard unmarshal) and JSON strings ("1" from
+// Google's protobuf int64 serialization). Returns nil for nil or unparseable values.
+func toInt64Ptr(v any) *int64 {
+	if v == nil {
+		return nil
+	}
+	switch val := v.(type) {
+	case float64:
+		i := int64(val)
+		return &i
+	case string:
+		i, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return nil
+		}
+		return &i
+	default:
+		return nil
+	}
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for Schema.
+// The `,string` tag on int64 fields (minLength, maxLength, etc.) only accepts
+// JSON strings like `"1"`, but standard JSON Schema sends numbers like `1`.
+// This method accepts both forms, fixing compatibility with non-protobuf clients.
+func (s *Schema) UnmarshalJSON(data []byte) error {
+	// Alias prevents infinite recursion by stripping Schema's UnmarshalJSON.
+	type Alias Schema
+	aux := &struct {
+		*Alias
+		// Override `,string`-tagged fields with `any` to accept both numbers and strings.
+		MaxItems      any `json:"maxItems,omitempty"`
+		MaxLength     any `json:"maxLength,omitempty"`
+		MaxProperties any `json:"maxProperties,omitempty"`
+		MinItems      any `json:"minItems,omitempty"`
+		MinLength     any `json:"minLength,omitempty"`
+		MinProperties any `json:"minProperties,omitempty"`
+	}{
+		Alias: (*Alias)(s),
+	}
+
+	if err := sonic.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	// Convert flex fields (number or string) to *int64.
+	s.MaxItems = toInt64Ptr(aux.MaxItems)
+	s.MaxLength = toInt64Ptr(aux.MaxLength)
+	s.MaxProperties = toInt64Ptr(aux.MaxProperties)
+	s.MinItems = toInt64Ptr(aux.MinItems)
+	s.MinLength = toInt64Ptr(aux.MinLength)
+	s.MinProperties = toInt64Ptr(aux.MinProperties)
+
+	return nil
+}
+
 // Type represents the type of the data.
 type Type string
 


### PR DESCRIPTION
## Problem

When clients send standard JSON Schema with numeric values like `"minLength": 1` through the GenAI integration, Bifrost returns a **500 "Invalid JSON"** error.

This is because the `Schema` struct in `core/providers/gemini/types.go` uses `json:",string"` tags on 6 `*int64` fields:

```go
MinLength     *int64 `json:"minLength,omitempty,string"`
MaxLength     *int64 `json:"maxLength,omitempty,string"`
MinItems      *int64 `json:"minItems,omitempty,string"`
MaxItems      *int64 `json:"maxItems,omitempty,string"`
MinProperties *int64 `json:"minProperties,omitempty,string"`
MaxProperties *int64 `json:"maxProperties,omitempty,string"`
```

The `,string` tag tells `sonic.Unmarshal` to **only accept JSON strings** (e.g., `"1"`), which is the Google Protobuf convention for int64 serialization. However, standard JSON Schema and all major SDKs (AI SDK, OpenAI SDK, etc.) send these as **JSON numbers** (e.g., `1`), causing the parse to fail.

### Reproduction

```json
{
  "tools": [{
    "functionDeclarations": [{
      "name": "example",
      "parameters": {
        "type": "object",
        "properties": {
          "subject": {
            "type": "string",
            "minLength": 1  // ← numeric value causes 500 error
          }
        }
      }
    }]
  }]
}
```

Error: `Mismatch type string with value number`

## Solution

Add a custom `UnmarshalJSON` method to `Schema` that accepts **both** JSON numbers and JSON strings for these 6 fields, while preserving the existing `,string` tag behavior for `MarshalJSON` (outbound requests to Gemini API still use protobuf-style string serialization).

The fix uses an embedded alias struct pattern to override only the affected fields with `any` type during unmarshaling, then converts them to `*int64` via a helper function.

## Impact

- **Affected fields**: `minLength`, `maxLength`, `minItems`, `maxItems`, `minProperties`, `maxProperties`
- **Affected integration**: GenAI (`/genai/v1beta/...`)
- **Not affected**: OpenAI integration (uses `map[string]any` for tool schemas)
- **Backward compatible**: Still accepts string values from Google's own protobuf serialization