### PR TITLE
docs: update langchain sdk docs for google

### DIFF
--- a/docs/integrations/langchain-sdk.mdx
+++ b/docs/integrations/langchain-sdk.mdx
@@ -122,7 +122,7 @@ const anthropicLlm = new ChatAnthropic({
 // Google models via Langchain
 const googleLlm = new ChatGoogleGenerativeAI({
   model: "gemini-2.5-flash",
-  baseURL
+  baseUrl: baseURL
 });
 
 // All work the same way
@@ -326,7 +326,7 @@ import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 
 const llm = new ChatGoogleGenerativeAI({
   model: "gemini-2.5-flash",
-  baseURL: "http://localhost:8080/langchain",
+  baseUrl: "http://localhost:8080/langchain",
   additionalHeaders: {
     "x-bf-vk": "your-virtual-key",  // Virtual key for governance
   }

--- a/docs/integrations/langchain-sdk.mdx
+++ b/docs/integrations/langchain-sdk.mdx
@@ -87,8 +87,8 @@ anthropic_llm = ChatAnthropic(
 
 # Google models via Langchain
 google_llm = ChatGoogleGenerativeAI(
-    model="gemini-1.5-flash",
-    google_api_base=base_url
+    model="gemini-2.5-flash",
+    base_url=base_url
 )
 
 # All work the same way
@@ -121,7 +121,7 @@ const anthropicLlm = new ChatAnthropic({
 
 // Google models via Langchain
 const googleLlm = new ChatGoogleGenerativeAI({
-  model: "gemini-1.5-flash",
+  model: "gemini-2.5-flash",
   baseURL
 });
 
@@ -193,7 +193,7 @@ from langchain_core.messages import HumanMessage
 
 llm = ChatGoogleGenerativeAI(
     model="gemini-2.5-flash",
-    google_api_base="http://localhost:8080/langchain",
+    base_url="http://localhost:8080/langchain",
     additional_headers={
         "x-bf-vk": "your-virtual-key",  # Virtual key for governance
     }


### PR DESCRIPTION
## Summary

Updates the LangChain SDK documentation to use the correct model version and parameter names for Google Generative AI integration.

## Changes

- Updated Google model from `gemini-1.5-flash` to `gemini-2.5-flash` in Python and JavaScript examples
- Changed parameter name from `google_api_base` to `base_url` in Python examples to match the correct LangChain API

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the documentation examples work correctly with the updated model and parameter names:

```sh
# Test Python example
pip install langchain-google-genai
python -c "from langchain_google_genai import ChatGoogleGenerativeAI; llm = ChatGoogleGenerativeAI(model='gemini-2.5-flash', base_url='http://localhost:8080/langchain')"

# Test JavaScript example  
npm install @langchain/google-genai
node -e "const { ChatGoogleGenerativeAI } = require('@langchain/google-genai'); const llm = new ChatGoogleGenerativeAI({ model: 'gemini-2.5-flash', baseURL: 'http://localhost:8080/langchain' });"
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - documentation-only changes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable