### PR TITLE
fix: clear trace id in async request for logging

### DIFF
--- a/framework/logstore/asyncjob.go
+++ b/framework/logstore/asyncjob.go
@@ -125,6 +125,11 @@ func (e *AsyncJobExecutor) executeJob(jobID string, resultTTL int, operation Asy
 		ctx.SetValue(k, v)
 	}
 
+	// Clear trace context inherited from the original HTTP request.
+	ctx.ClearValue(schemas.BifrostContextKeyTraceID)
+	ctx.ClearValue(schemas.BifrostContextKeyParentSpanID)
+	ctx.ClearValue(schemas.BifrostContextKeySpanID)
+
 	markFailed := func(msg string) {
 		now := time.Now().UTC()
 		expiresAt := now.Add(time.Duration(resultTTL) * time.Second)


### PR DESCRIPTION
## Summary

Clears trace ID and parent span ID from the context when executing async jobs to ensure each job has an independent trace lifecycle.

## Changes

- Added calls to clear `BifrostContextKeyTraceID` and `BifrostContextKeyParentSpanID` from the context before executing async jobs
- This prevents async jobs from inheriting trace context from their parent operations, giving them clean, independent tracing

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Verify that async jobs no longer inherit trace context from parent operations:

```sh
go version
go test ./framework/logstore/...
```

Test by creating an async job within a traced operation and confirm the job starts with a fresh trace context.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects tracing context isolation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable