### PR TITLE
fix: add proper checks for non existent provider configs while checking for IsModelAllowedForProvider

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -677,8 +677,12 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 		isProviderAllowed := false
 		if p.modelCatalog != nil && p.inMemoryStore != nil {
 			provider := schemas.ModelProvider(config.Provider)
-			providerConfig := p.inMemoryStore.GetConfiguredProviders()[provider]
-			isProviderAllowed = p.modelCatalog.IsModelAllowedForProvider(provider, modelStr, &providerConfig, config.AllowedModels)
+			providerConfig, ok := p.inMemoryStore.GetConfiguredProviders()[provider]
+			providerConfigPtr := &providerConfig
+			if !ok {
+				providerConfigPtr = nil
+			}
+			isProviderAllowed = p.modelCatalog.IsModelAllowedForProvider(provider, modelStr, providerConfigPtr, config.AllowedModels)
 		} else {
 			// Fallback when model catalog is not available: simple string matching
 			// ["*"] = allow all models; [] = deny all models

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -274,8 +274,12 @@ func (r *BudgetResolver) isModelAllowed(vk *configstoreTables.TableVirtualKey, p
 			// This handles all cross-provider logic (OpenRouter, Vertex, Groq, Bedrock)
 			// and provider-prefixed allowed_models entries
 			if r.modelCatalog != nil && r.governanceInMemoryStore != nil {
-				providerConfig := r.governanceInMemoryStore.GetConfiguredProviders()[provider]
-				return r.modelCatalog.IsModelAllowedForProvider(provider, model, &providerConfig, pc.AllowedModels)
+				providerConfig, ok := r.governanceInMemoryStore.GetConfiguredProviders()[provider]
+				providerConfigPtr := &providerConfig
+				if !ok {
+					providerConfigPtr = nil
+				}
+				return r.modelCatalog.IsModelAllowedForProvider(provider, model, providerConfigPtr, pc.AllowedModels)
 			}
 			// Fallback when model catalog is not available: simple string matching
 			// ["*"] = allow all models; [] = deny all models

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -114,8 +114,12 @@ func (p *GovernancePlugin) filterModelsForVirtualKey(
 		for _, pc := range vk.ProviderConfigs {
 			if pc.Provider == string(provider) {
 				if p.modelCatalog != nil && p.inMemoryStore != nil {
-					providerConfig := p.inMemoryStore.GetConfiguredProviders()[provider]
-					if p.modelCatalog.IsModelAllowedForProvider(provider, modelName, &providerConfig, pc.AllowedModels) {
+					providerConfig, ok := p.inMemoryStore.GetConfiguredProviders()[provider]
+					providerConfigPtr := &providerConfig
+					if !ok {
+						providerConfigPtr = nil
+					}
+					if p.modelCatalog.IsModelAllowedForProvider(provider, modelName, providerConfigPtr, pc.AllowedModels) {
 						isAllowed = true
 						break
 					}


### PR DESCRIPTION
## Summary

Fixed a potential panic in the governance plugin when accessing provider
configurations that don't exist in the configured providers map. The code now
safely handles missing provider configurations by passing nil instead of a
pointer to an uninitialized struct.

## Changes

- Added proper existence checks when retrieving provider configurations from the
  in-memory store
- Modified three locations in the governance plugin to use the map lookup's
  second return value (ok) to determine if a provider configuration exists
- When a provider configuration is not found, the code now passes nil to
  `IsModelAllowedForProvider` instead of a pointer to an empty struct

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test with a provider that is not configured in the governance plugin's in-memory
store to ensure no panic occurs when checking model permissions.

```sh
# Core/Transports
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This fix prevents potential runtime panics that could affect service
availability when processing model authorization requests.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

