### PR TITLE
feat: add user-facing success rate metric for fallback chains

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -290,12 +290,19 @@ func (s *RDBLogStore) getStatsFromMatView(ctx context.Context, filters SearchFil
 	if result.TotalCount > 0 {
 		successRate = float64(result.SuccessCount) / float64(result.TotalCount) * 100
 	}
+
+	// User-facing success rate requires per-request fallback chain data which is not
+	// available in the materialized view. Scanning the raw logs table on large datasets
+	// (>100 GB) can take minutes, so the matview path uses the per-attempt success rate
+	// as a fast approximation. Accurate chain-level computation runs in the raw-table path.
+
 	return &SearchStats{
-		TotalRequests:  result.TotalCount,
-		SuccessRate:    successRate,
-		AverageLatency: result.AvgLatency,
-		TotalTokens:    result.TotalTokens,
-		TotalCost:      result.TotalCost,
+		TotalRequests:         result.TotalCount,
+		SuccessRate:           successRate,
+		UserFacingSuccessRate: successRate,
+		AverageLatency:        result.AvgLatency,
+		TotalTokens:           result.TotalTokens,
+		TotalCost:             result.TotalCost,
 	}, nil
 }
 

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -726,6 +726,43 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 				stats.TotalCost = result.TotalCost.Float64
 			}
 		}
+
+		// User-facing success rate: count each fallback chain as one user request.
+		// A chain is identified by the original request (fallback_index=0); any successful
+		// attempt (original or fallback) makes the whole chain a success.
+		// When scoped to a specific parent request, root rows are excluded by definition
+		// (they have parent_request_id = NULL), so fall back to the per-attempt success rate.
+		if filters.ParentRequestID != "" {
+			stats.UserFacingSuccessRate = stats.SuccessRate
+		} else {
+			var userFacingResult struct {
+				TotalUserRequests      sql.NullInt64 `gorm:"column:total_user_requests"`
+				SuccessfulUserRequests sql.NullInt64 `gorm:"column:successful_user_requests"`
+			}
+			userFacingQuery := s.db.WithContext(ctx).Model(&Log{})
+			userFacingQuery = s.applyFilters(userFacingQuery, filters)
+			// Scope to root rows only so denominator and numerator are drawn from the same population.
+			// A chain is successful if the root itself succeeded or any of its fallbacks succeeded.
+			userFacingQuery = userFacingQuery.Where("fallback_index = ?", 0).Where("status IN ?", []string{"success", "error"})
+			if err := userFacingQuery.Select(`
+				COUNT(DISTINCT id) as total_user_requests,
+				COUNT(DISTINCT CASE
+					WHEN status = 'success' THEN id
+					WHEN EXISTS (
+						SELECT 1
+						FROM logs fallback
+						WHERE fallback.parent_request_id = logs.id
+							AND fallback.status = 'success'
+					) THEN id
+					ELSE NULL
+				END) as successful_user_requests
+			`).Scan(&userFacingResult).Error; err != nil {
+				return nil, err
+			}
+			if userFacingResult.TotalUserRequests.Int64 > 0 {
+				stats.UserFacingSuccessRate = float64(userFacingResult.SuccessfulUserRequests.Int64) / float64(userFacingResult.TotalUserRequests.Int64) * 100
+			}
+		}
 	}
 
 	return stats, nil

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -93,11 +93,12 @@ type SessionSummaryResult struct {
 }
 
 type SearchStats struct {
-	TotalRequests  int64   `json:"total_requests"`
-	SuccessRate    float64 `json:"success_rate"`    // Percentage of successful requests
-	AverageLatency float64 `json:"average_latency"` // Average latency in milliseconds
-	TotalTokens    int64   `json:"total_tokens"`    // Total tokens used
-	TotalCost      float64 `json:"total_cost"`      // Total cost in dollars
+	TotalRequests         int64   `json:"total_requests"`
+	SuccessRate           float64 `json:"success_rate"`             // Percentage of individual attempts that succeeded
+	UserFacingSuccessRate float64 `json:"user_facing_success_rate"` // Percentage of user requests that ultimately succeeded (fallback chains counted as one request)
+	AverageLatency        float64 `json:"average_latency"`          // Average latency in milliseconds
+	TotalTokens           int64   `json:"total_tokens"`             // Total tokens used
+	TotalCost             float64 `json:"total_cost"`               // Total cost in dollars
 }
 
 // Log represents a complete log entry for a request/response cycle

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -8,6 +8,7 @@ import FullPageLoader from "@/components/fullPageLoader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useWebSocket } from "@/hooks/useWebSocket";
 import {
 	getErrorMessage,
@@ -29,7 +30,7 @@ import type {
 } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { AlertCircle, BarChart, CheckCircle, Clock, DollarSign, Hash } from "lucide-react";
+import { AlertCircle, BarChart, CheckCircle, Clock, DollarSign, Hash, Info } from "lucide-react";
 import { parseAsArrayOf, parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -223,12 +224,12 @@ export default function LogsPage() {
 			missing_cost_only: urlState.missing_cost_only,
 			metadata_filters: urlState.metadata_filters
 				? (() => {
-						try {
-							return JSON.parse(urlState.metadata_filters);
-						} catch {
-							return undefined;
-						}
-					})()
+					try {
+						return JSON.parse(urlState.metadata_filters);
+					} catch {
+						return undefined;
+					}
+				})()
 				: undefined,
 		}),
 		// Only re-derive filters when filter-related URL params change (not pagination)
@@ -478,6 +479,11 @@ export default function LogsPage() {
 						const successCount = (prevStats.success_rate / 100) * prevStats.total_requests;
 						const newSuccessCount = log.status === "success" ? successCount + 1 : successCount;
 						newStats.success_rate = (newSuccessCount / newStats.total_requests) * 100;
+
+						// Update user-facing success rate (same approximation as success_rate)
+						const userSuccessCount = ((prevStats.user_facing_success_rate ?? 0) / 100) * prevStats.total_requests;
+						const newUserSuccessCount = log.status === "success" ? userSuccessCount + 1 : userSuccessCount;
+						newStats.user_facing_success_rate = (newUserSuccessCount / newStats.total_requests) * 100;
 
 						// Update average latency
 						if (log.latency) {
@@ -819,6 +825,13 @@ export default function LogsPage() {
 				title: "Success Rate",
 				value: fetchingStats ? <Skeleton className="h-8 w-16" /> : stats ? `${stats.success_rate.toFixed(2)}%` : "-",
 				icon: <CheckCircle className="size-4" />,
+				description: "Success rate as perceived by the system. Each fallback counts as a separate attempt. Retries on the same request are counted as one attempt.",
+			},
+			{
+				title: "User Success Rate",
+				value: fetchingStats ? <Skeleton className="h-8 w-16" /> : stats ? `${(stats.user_facing_success_rate ?? 0).toFixed(2)}%` : "-",
+				icon: <CheckCircle className="size-4" />,
+				description: "Success rate as perceived by the end user. It includes fallback chains as one request.",
 			},
 			{
 				title: "Avg Latency",
@@ -905,12 +918,29 @@ export default function LogsPage() {
 			) : (
 				<div className="mx-auto flex h-full w-full flex-col">
 					<div className="flex h-full flex-col gap-2 overflow-hidden">
-						<div className="grid shrink-0 grid-cols-1 gap-4 md:grid-cols-5">
+						<div className="grid shrink-0 grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
 							{statCards.map((card) => (
 								<Card key={card.title} className="py-4 shadow-none">
 									<CardContent className="flex items-center justify-between px-4">
 										<div className="w-full min-w-0">
-											<div className="text-muted-foreground text-xs">{card.title}</div>
+											<div className="text-muted-foreground flex items-center gap-1 text-xs">
+												{card.title}
+												{"description" in card && card.description && (
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<button
+																type="button"
+																aria-label={`${card.title} info`}
+																data-testid={`logs-metric-info-${card.title.toLowerCase().replace(/\s+/g, "-")}`}
+																className="inline-flex items-center"
+															>
+																<Info className="size-3 cursor-help" />
+															</button>
+														</TooltipTrigger>
+														<TooltipContent className="max-w-72 text-left text-xs text-wrap">{card.description}</TooltipContent>
+													</Tooltip>
+												)}
+											</div>
 											<div className="truncate font-mono text-xl font-medium sm:text-2xl">{card.value}</div>
 										</div>
 									</CardContent>

--- a/ui/app/workspace/model-catalog/views/modelCatalogView.tsx
+++ b/ui/app/workspace/model-catalog/views/modelCatalogView.tsx
@@ -50,7 +50,7 @@ export default function ModelCatalogView() {
 				triggerStats({ filters: { providers: [p.name], start_time: dayAgo, end_time: now } })
 					.unwrap()
 					.then((stats) => [p.name, stats] as const)
-					.catch(() => [p.name, { total_requests: 0, success_rate: 0, average_latency: 0, total_tokens: 0, total_cost: 0 }] as const),
+					.catch(() => [p.name, { total_requests: 0, success_rate: 0, user_facing_success_rate: 0, average_latency: 0, total_tokens: 0, total_cost: 0 }] as const),
 			),
 		).then((results) => {
 			if (!cancelled) setStatsMap(new Map(results));

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -553,6 +553,7 @@ export interface Pagination {
 export interface LogStats {
   total_requests: number;
   success_rate: number;
+  user_facing_success_rate: number;
   average_latency: number;
   total_tokens: number;
   total_cost: number;


### PR DESCRIPTION
## Summary

Adds a new "User Success Rate" metric that provides a more user-centric view of API success by treating fallback chains as single requests. This complements the existing success rate which counts individual attempts separately.

## Changes

- Added `UserFacingSuccessRate` field to `SearchStats` struct and API responses
- Implemented user-facing success rate calculation in both materialized view and direct database query paths
- Updated logs UI to display both success rate metrics with tooltips explaining the difference
- Modified grid layout to accommodate the additional metric card
- Updated TypeScript types to include the new field

The user-facing success rate counts each fallback chain as one user request, where a chain is successful if any attempt (original or fallback) returns a response. This provides better insight into actual user experience compared to the raw attempt-based success rate.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Verify the new metric appears correctly in the logs dashboard and shows different values from the standard success rate when fallback requests are present.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Test with API requests that trigger fallbacks to see the difference between the two success rate metrics.

## Screenshots/Recordings

The logs page now displays 6 metric cards instead of 5, with the new "User Success Rate" card including a tooltip explanation.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications - this is a read-only analytics feature that uses existing data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable