### PR TITLE
updates helm-chart checks

### DIFF
--- a/.github/workflows/configs/withpostgresmcpclientsinconfig/config.json
+++ b/.github/workflows/configs/withpostgresmcpclientsinconfig/config.json
@@ -40,18 +40,16 @@
   "mcp": {
     "client_configs": [
       {
-        "id": "weather-mcp-server",
         "name": "WeatherService",
         "connection_type": "http",
-        "http_url": "http://localhost:8080/mcp",
-        "is_enabled": true
+        "client_id": "weather-mcp-server",
+        "connection_string": "http://localhost:8080/mcp"
       },
       {
-        "id": "calendar-mcp-server",
         "name": "CalendarService",
         "connection_type": "http",
-        "http_url": "http://localhost:8081/mcp",
-        "is_enabled": true
+        "client_id": "calendar-mcp-server",
+        "connection_string": "http://localhost:8081/mcp"
       }
     ]
   },
@@ -87,8 +85,12 @@
         "provider_configs": [
           {
             "provider": "openai",
-            "allowed_models": ["*"],
-            "key_ids": ["*"],
+            "allowed_models": [
+              "*"
+            ],
+            "key_ids": [
+              "*"
+            ],
             "weight": 1.0
           }
         ]
@@ -110,8 +112,12 @@
         "provider_configs": [
           {
             "provider": "openai",
-            "allowed_models": ["*"],
-            "key_ids": ["*"],
+            "allowed_models": [
+              "*"
+            ],
+            "key_ids": [
+              "*"
+            ],
             "weight": 1.0
           }
         ]
@@ -134,7 +140,9 @@
           "name": "openai-primary",
           "value": "env.OPENAI_API_KEY",
           "weight": 1,
-          "models": ["*"]
+          "models": [
+            "*"
+          ]
         }
       ]
     }

--- a/.github/workflows/configs/withsemanticcache/config.json
+++ b/.github/workflows/configs/withsemanticcache/config.json
@@ -13,6 +13,7 @@
       "enabled": true,
       "name": "semantic_cache",
       "config": {
+        "dimension": 1,
         "vector_store_namespace": "test"
       }
     }

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -4,13 +4,14 @@ on:
   push:
     branches:
       - main
+      - v1.5.0
     paths:
-      - 'helm-charts/bifrost/**'
-      - '.github/workflows/helm-release.yml'
+      - "helm-charts/bifrost/**"
+      - ".github/workflows/helm-release.yml"
   workflow_dispatch:
 
 permissions:
-  contents: write  
+  contents: write
 
 jobs:
   release:
@@ -36,6 +37,11 @@ jobs:
         with:
           version: v4.0.0
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
       - name: Run chart-testing (lint)
         run: |
           helm lint helm-charts/bifrost
@@ -49,6 +55,11 @@ jobs:
         run: |
           chmod +x .github/workflows/scripts/validate-helm-config-fields.sh
           .github/workflows/scripts/validate-helm-config-fields.sh
+
+      - name: Validate Go ↔ config.schema.json ↔ helm-chart sync (schemasync)
+        run: |
+          chmod +x .github/workflows/scripts/validate-schema-sync.sh
+          .github/workflows/scripts/validate-schema-sync.sh
 
       - name: Get chart version
         id: chart-version
@@ -105,5 +116,5 @@ jobs:
           destination_dir: helm-charts
           keep_files: false
           enable_jekyll: false
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
+          user_name: "github-actions[bot]"
+          user_email: "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/scripts/schemasync/go.mod
+++ b/.github/workflows/scripts/schemasync/go.mod
@@ -1,0 +1,10 @@
+module github.com/maximhq/bifrost/tools/schema-sync
+
+go 1.26.2
+
+require golang.org/x/tools v0.30.0
+
+require (
+	golang.org/x/mod v0.23.0 // indirect
+	golang.org/x/sync v0.11.0 // indirect
+)

--- a/.github/workflows/scripts/schemasync/go.sum
+++ b/.github/workflows/scripts/schemasync/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.23.0 h1:Zb7khfcRGKk+kqfxFaP5tZqCnDZMjC5VtUBs87Hr6QM=
+golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.30.0 h1:BgcpHewrV5AUp2G9MebG4XPFI1E2W41zU1SaqVA9vJY=
+golang.org/x/tools v0.30.0/go.mod h1:c347cR/OJfw5TI+GfX7RUPNMdDRRbjvYTS0jPyvsVtY=

--- a/.github/workflows/scripts/schemasync/main.go
+++ b/.github/workflows/scripts/schemasync/main.go
@@ -1,0 +1,1075 @@
+// schemasync validates that Bifrost Go config types stay in sync with
+// transports/config.schema.json.
+//
+// Starting from a configured entry-point type (default: ConfigData in
+// transports/bifrost-http/lib), it recursively walks every nested struct
+// field via go/types. For each field it verifies:
+//
+//  1. The json:"X" tag has a corresponding property in config.schema.json at
+//     the propagated schema path (handling $ref, allOf, oneOf, if/then/else).
+//  2. If the field's Go type is a named string type with const declarations,
+//     the set of Go constant values matches the schema's enum array.
+//
+// Exit 0 on full agreement, 1 on any mismatch.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/constant"
+	"go/types"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+type entrypoint struct {
+	pkg        string // Go import path
+	typeName   string // exported type name
+	schemaPath string // JSON pointer path in config.schema.json (e.g. "/properties")
+	moduleDir  string // directory (relative to --pkg-root) that contains the go.mod
+}
+
+var entrypoints = []entrypoint{
+	{
+		pkg:        "github.com/maximhq/bifrost/transports/bifrost-http/lib",
+		typeName:   "ConfigData",
+		schemaPath: "", // root schema node — collectProperties will find .properties
+		moduleDir:  "transports",
+	},
+}
+
+// Schema properties that intentionally have no Go counterpart and vice versa.
+// Key is a JSON pointer path; value is a short reason.
+var ignoreSchemaProps = map[string]string{
+	"/properties/$schema": "JSON schema self-reference",
+	// GORM foreignKey slice relations that ARE user-submittable config input.
+	// Go-side: schemasync skips them via the gorm-tag filter; schema-side:
+	// these entries prevent the missing-in-go warning for them.
+	"/properties/governance/properties/virtual_keys/items/properties/provider_configs": "gorm fk slice; user-submittable",
+	"/properties/governance/properties/virtual_keys/items/properties/mcp_configs":      "gorm fk slice; user-submittable",
+	"/properties/governance/properties/routing_rules/items/properties/targets":         "gorm fk slice; user-submittable",
+	// MCP headers map<string, EnvVar> — documented escape hatch is envFrom:
+	// plus env.X references in values; no chart-native secretRef.
+	"/properties/mcp/properties/client_configs/items/properties/headers/additionalProperties": "documented envFrom pattern",
+	// Object-storage identity fields (bucket/region/endpoint/project_id) are
+	// EnvVar-typed for flexibility but are not inherently secret. Operators
+	// can write `env.MY_VAR` in values and use envFrom to inject. Access
+	// keys, session tokens, and credentials DO have chart-native secret
+	// support via `storage.logsStore.objectStorage.existingSecret`.
+	"/properties/logs_store/properties/object_storage/properties/bucket":     "not a secret; env.X + envFrom pattern",
+	"/properties/logs_store/properties/object_storage/properties/region":     "not a secret; env.X + envFrom pattern",
+	"/properties/logs_store/properties/object_storage/properties/endpoint":   "not a secret; env.X + envFrom pattern",
+	"/properties/logs_store/properties/object_storage/properties/project_id": "not a secret; env.X + envFrom pattern",
+}
+
+// ignoreGoFields keys are "schemaPath|fieldName"; value is the reason.
+var ignoreGoFields = map[string]string{
+	"|auth_config": "deprecated; moved to governance.auth_config",
+}
+
+// ignoreGoFieldNames are field names (regardless of parent path) that are
+// DB bookkeeping or runtime-derived — never part of user-submitted config.
+var ignoreGoFieldNames = map[string]string{
+	"created_at":  "DB bookkeeping",
+	"updated_at":  "DB bookkeeping",
+	"config_hash": "internal hash",
+	"status":      "runtime-derived",
+	"state":       "runtime-derived",
+}
+
+// opaqueLeafTypes are named Go types that have custom JSON marshalling and
+// should be treated as leaves. The walker does NOT recurse into their fields,
+// and they are collected for downstream checks (e.g., EnvVar → helm secret).
+var opaqueLeafTypes = map[string]string{
+	"github.com/maximhq/bifrost/core/schemas.EnvVar": "env-aware string; custom JSON",
+}
+
+// envVarLocation records where an EnvVar-typed field appears in config.json
+// so a downstream pass can confirm the helm chart supports Secret-backed
+// injection (existingSecret / secretRef / env.BIFROST_*) for that path.
+type envVarLocation struct {
+	schemaPath string
+	goPath     string
+}
+
+// Finding categorises every issue the tool surfaces so the final report can
+// group by category and render as a table.
+type Finding struct {
+	Category string // e.g. "missing-in-schema", "missing-in-go", "enum-drift", "envvar-no-secret"
+	Severity string // "ERROR" or "WARN"
+	Path     string // schema path or enum path
+	Detail   string // field name, Go path, missing/extra values, etc.
+	Go       string // Go-side location (package.Type.Field)
+}
+
+type checker struct {
+	schema map[string]any
+	pkgs   map[string]*packages.Package // path → pkg
+	// enumConsts[namedType] -> list of string values found in any loaded package
+	enumConsts map[string][]string
+	// visited type names to break cycles
+	visited map[string]bool
+	// envVarFields records where EnvVar types occur, for downstream checks
+	envVarFields []envVarLocation
+	findings     []Finding
+}
+
+func main() {
+	schemaFlag := flag.String("schema", "transports/config.schema.json", "path to config.schema.json")
+	pkgDir := flag.String("pkg-root", ".", "repo root used as packages.Load dir")
+	helmValuesFlag := flag.String("helm-values", "helm-charts/bifrost/values.schema.json", "path to helm values.schema.json (for EnvVar secret-support check)")
+	helmHelpersFlag := flag.String("helm-helpers", "helm-charts/bifrost/templates/_helpers.tpl", "path to helm _helpers.tpl (for env.BIFROST_* emission detection)")
+	flag.Parse()
+
+	schemaBytes, err := os.ReadFile(*schemaFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read schema: %v\n", err)
+		os.Exit(2)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(schemaBytes, &schema); err != nil {
+		fmt.Fprintf(os.Stderr, "parse schema: %v\n", err)
+		os.Exit(2)
+	}
+
+	// Group entrypoints by moduleDir so we load each module's package graph once.
+	byModule := map[string][]entrypoint{}
+	orderedMods := []string{}
+	for _, e := range entrypoints {
+		if _, seen := byModule[e.moduleDir]; !seen {
+			orderedMods = append(orderedMods, e.moduleDir)
+		}
+		byModule[e.moduleDir] = append(byModule[e.moduleDir], e)
+	}
+	absRoot, err := filepath.Abs(*pkgDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "abs pkg-root: %v\n", err)
+		os.Exit(2)
+	}
+	// Always use the repo's go.work so local modules resolve against each
+	// other (not against registry tarballs). The tool refuses to run without
+	// go.work — that's the only configuration bifrost is tested against.
+	goworkPath := filepath.Join(absRoot, "go.work")
+	if _, err := os.Stat(goworkPath); err != nil {
+		fmt.Fprintf(os.Stderr, "schemasync requires go.work at %s: %v\n", goworkPath, err)
+		os.Exit(2)
+	}
+
+	allPkgs := map[string]*packages.Package{}
+	for _, mod := range orderedMods {
+		modDir := filepath.Join(absRoot, mod)
+		env := append([]string{}, os.Environ()...)
+		env = append(env, "GOWORK="+goworkPath)
+		cfg := &packages.Config{
+			Mode: packages.NeedName | packages.NeedTypes | packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedDeps | packages.NeedImports | packages.NeedFiles,
+			Dir:  modDir,
+			Env:  env,
+		}
+		imports := []string{}
+		for _, e := range byModule[mod] {
+			imports = append(imports, e.pkg)
+		}
+		pkgs, err := packages.Load(cfg, imports...)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "load %s: %v\n", mod, err)
+			os.Exit(2)
+		}
+		hadLoadErr := false
+		packages.Visit(pkgs, nil, func(p *packages.Package) {
+			for _, e := range p.Errors {
+				fmt.Fprintln(os.Stderr, e)
+				hadLoadErr = true
+			}
+		})
+		if hadLoadErr {
+			os.Exit(2)
+		}
+		for k, v := range collectPkgs(pkgs) {
+			allPkgs[k] = v
+		}
+	}
+
+	c := &checker{
+		schema:     schema,
+		pkgs:       allPkgs,
+		enumConsts: map[string][]string{},
+		visited:    map[string]bool{},
+	}
+	c.collectConsts()
+
+	for _, e := range entrypoints {
+		p := c.pkgs[e.pkg]
+		if p == nil {
+			c.add(Finding{Category: "entrypoint", Severity: "ERROR", Detail: "package not loaded: " + e.pkg})
+			continue
+		}
+		obj := p.Types.Scope().Lookup(e.typeName)
+		if obj == nil {
+			c.add(Finding{Category: "entrypoint", Severity: "ERROR", Detail: fmt.Sprintf("type %s not found in %s", e.typeName, e.pkg)})
+			continue
+		}
+		named, ok := obj.Type().(*types.Named)
+		if !ok {
+			c.add(Finding{Category: "entrypoint", Severity: "ERROR", Detail: fmt.Sprintf("%s.%s is not a named type", e.pkg, e.typeName)})
+			continue
+		}
+		c.walkType(named, e.schemaPath, fmt.Sprintf("%s.%s", e.pkg, e.typeName))
+	}
+
+	// EnvVar → helm-chart secret-support pass. For each Go field typed as
+	// schemas.EnvVar, the helm chart must either (a) emit an env.BIFROST_*
+	// placeholder for that JSON path via _helpers.tpl, or (b) expose a
+	// secretRef/existingSecret knob in values.schema.json at the equivalent
+	// camelCase location. If neither, warn.
+	c.checkEnvVarHelmSupport(*helmValuesFlag, *helmHelpersFlag)
+
+	printReport(os.Stderr, c.findings)
+	errCount := c.countErrs()
+	warnCount := c.countWarns()
+	if errCount > 0 {
+		fmt.Fprintf(os.Stderr, "\nschemasync: %d errors, %d warnings\n", errCount, warnCount)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "\nschemasync: OK (%d warnings)\n", warnCount)
+}
+
+// printReport groups findings by category and prints a markdown-style table
+// for each non-empty group.
+func printReport(w interface{ Write([]byte) (int, error) }, findings []Finding) {
+	if len(findings) == 0 {
+		return
+	}
+	groups := map[string][]Finding{}
+	order := []string{}
+	for _, f := range findings {
+		if _, ok := groups[f.Category]; !ok {
+			order = append(order, f.Category)
+		}
+		groups[f.Category] = append(groups[f.Category], f)
+	}
+	titles := map[string]string{
+		"missing-in-schema":      "Missing in config.schema.json (Go has field, schema doesn't) — ERRORS",
+		"missing-in-go":          "Missing in Go (schema has property, ConfigData doesn't) — WARNINGS",
+		"enum-drift":             "Enum drift (Go constants vs schema enum array)",
+		"enum-no-schema":         "Go enum types with no schema `enum` constraint — WARNINGS",
+		"envvar-no-secret":       "EnvVar fields lacking chart-native Secret support — WARNINGS",
+		"schema-path-not-found":  "Schema path not found for a walked Go type — ERRORS",
+		"entrypoint":             "Entrypoint problems — ERRORS",
+	}
+	for _, cat := range order {
+		items := groups[cat]
+		title := titles[cat]
+		if title == "" {
+			title = cat
+		}
+		fmt.Fprintf(w.(interface{ Write([]byte) (int, error) }), "\n### %s (%d)\n\n", title, len(items))
+		// Pick columns based on category for readability.
+		switch cat {
+		case "missing-in-schema", "schema-path-not-found":
+			renderTable(w, []string{"severity", "schema path", "Go location"}, func() [][]string {
+				out := [][]string{}
+				for _, f := range items {
+					out = append(out, []string{f.Severity, f.Path, f.Go})
+				}
+				return out
+			}())
+		case "missing-in-go":
+			renderTable(w, []string{"severity", "schema path", "property", "Go parent"}, func() [][]string {
+				out := [][]string{}
+				for _, f := range items {
+					out = append(out, []string{f.Severity, f.Path, f.Detail, f.Go})
+				}
+				return out
+			}())
+		case "enum-drift", "enum-no-schema":
+			renderTable(w, []string{"severity", "enum path", "drift", "Go location"}, func() [][]string {
+				out := [][]string{}
+				for _, f := range items {
+					out = append(out, []string{f.Severity, f.Path, f.Detail, f.Go})
+				}
+				return out
+			}())
+		case "envvar-no-secret":
+			renderTable(w, []string{"severity", "config path", "Go location", "note"}, func() [][]string {
+				out := [][]string{}
+				for _, f := range items {
+					out = append(out, []string{f.Severity, f.Path, f.Go, f.Detail})
+				}
+				return out
+			}())
+		default:
+			renderTable(w, []string{"severity", "detail"}, func() [][]string {
+				out := [][]string{}
+				for _, f := range items {
+					out = append(out, []string{f.Severity, f.Detail})
+				}
+				return out
+			}())
+		}
+	}
+}
+
+// renderTable writes a markdown table. Truncates long cells to keep width sane.
+func renderTable(w interface{ Write([]byte) (int, error) }, headers []string, rows [][]string) {
+	const maxCol = 80
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	truncate := func(s string) string {
+		if len(s) <= maxCol {
+			return s
+		}
+		return s[:maxCol-1] + "…"
+	}
+	trimmed := make([][]string, len(rows))
+	for i, r := range rows {
+		trimmed[i] = make([]string, len(r))
+		for j, cell := range r {
+			trimmed[i][j] = truncate(cell)
+			if j < len(widths) && len(trimmed[i][j]) > widths[j] {
+				widths[j] = len(trimmed[i][j])
+			}
+		}
+	}
+	writeRow := func(cells []string) {
+		var sb strings.Builder
+		sb.WriteString("| ")
+		for i, c := range cells {
+			sb.WriteString(c)
+			if pad := widths[i] - len(c); pad > 0 {
+				sb.WriteString(strings.Repeat(" ", pad))
+			}
+			sb.WriteString(" | ")
+		}
+		sb.WriteString("\n")
+		_, _ = w.Write([]byte(sb.String()))
+	}
+	writeRow(headers)
+	sep := make([]string, len(headers))
+	for i := range headers {
+		sep[i] = strings.Repeat("-", widths[i])
+	}
+	writeRow(sep)
+	for _, r := range trimmed {
+		writeRow(r)
+	}
+}
+
+// checkEnvVarHelmSupport verifies that every Go field of type schemas.EnvVar
+// has a way to be sourced from a Kubernetes secret via the helm chart. Proof
+// of support is any of:
+//
+//  1. An `env.BIFROST_*` string literal appears in _helpers.tpl (indicating
+//     a rewrite is wired up for the corresponding config path), OR
+//  2. values.schema.json declares a `secretRef` or `existingSecret` object
+//     at the camelCase equivalent of the schema path.
+//
+// Neither heuristic is perfect — this is a structural review aid, not a
+// proof. Treat misses as warnings so they don't block CI on borderline cases.
+func (c *checker) checkEnvVarHelmSupport(valuesPath, helpersPath string) {
+	helpersBytes, err := os.ReadFile(helpersPath)
+	if err != nil {
+		c.add(Finding{Category: "envvar-no-secret", Severity: "WARN", Detail: fmt.Sprintf("could not read helm helpers %s: %v — skipping EnvVar helm-support check", helpersPath, err)})
+		return
+	}
+	helpers := string(helpersBytes)
+	// Extract every env.BIFROST_* token mentioned in _helpers.tpl.
+	envBifrostMentions := map[string]bool{}
+	for _, line := range strings.Split(helpers, "\n") {
+		// crude extraction: look for "env.BIFROST_X" substrings
+		idx := 0
+		for idx < len(line) {
+			k := strings.Index(line[idx:], "env.BIFROST_")
+			if k < 0 {
+				break
+			}
+			start := idx + k
+			end := start
+			for end < len(line) {
+				ch := line[end]
+				if ch == '"' || ch == ' ' || ch == '\t' || ch == '}' || ch == ')' {
+					break
+				}
+				end++
+			}
+			envBifrostMentions[line[start:end]] = true
+			idx = end
+		}
+	}
+
+	valuesBytes, err := os.ReadFile(valuesPath)
+	hasValues := err == nil
+	var valuesSchema map[string]any
+	if hasValues {
+		_ = json.Unmarshal(valuesBytes, &valuesSchema)
+	}
+
+	for _, loc := range c.envVarFields {
+		// Heuristic 1: any env.BIFROST_* is present in helpers — broad acceptance.
+		// We can't easily map a specific EnvVar field to a specific env var
+		// without per-field config, so we just check that the helpers file
+		// has AT LEAST ONE envBifrost mention that maps to this field's path.
+		// To make this stricter, we look for a helpers line mentioning either
+		// the camelCase field's parent path or an env var matching it.
+		camel := schemaPathToCamelCase(loc.schemaPath)
+		matched := false
+		// Heuristic 2: values.schema.json declares secretRef under the parent path.
+		if hasValues && valuesSchema != nil {
+			if hasSecretRefAt(valuesSchema, camel) {
+				matched = true
+			}
+		}
+		if !matched && len(envBifrostMentions) > 0 {
+			// Fall back to "some envBifrost wiring exists somewhere" — we flag it
+			// as a weaker hit so maintainers know to verify the mapping manually.
+			// Do not accept purely from presence; require a name-similarity match.
+			tail := lastSchemaComponent(loc.schemaPath)
+			for mention := range envBifrostMentions {
+				up := strings.ToUpper(tail)
+				if strings.Contains(mention, "_"+up) || strings.HasSuffix(mention, up) {
+					matched = true
+					break
+				}
+			}
+		}
+		if !matched {
+			if _, ignored := ignoreSchemaProps[loc.schemaPath]; ignored {
+				continue
+			}
+			c.add(Finding{
+				Category: "envvar-no-secret",
+				Severity: "WARN",
+				Path:     loc.schemaPath,
+				Detail:   "helm has no secretRef/existingSecret at " + camel + " or parent",
+				Go:       loc.goPath,
+			})
+		}
+	}
+}
+
+// schemaPathToCamelCase converts a JSON pointer like
+// "/properties/governance/properties/auth_config/properties/admin_username"
+// into a best-effort camelCase helm values path like
+// "properties.bifrost.properties.governance.properties.authConfig.properties.adminUsername".
+func schemaPathToCamelCase(p string) string {
+	parts := strings.Split(strings.TrimPrefix(p, "/"), "/")
+	out := []string{"properties", "bifrost"}
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		if part == "properties" {
+			out = append(out, "properties")
+			continue
+		}
+		out = append(out, snakeToCamel(part))
+	}
+	return strings.Join(out, ".")
+}
+
+func snakeToCamel(s string) string {
+	parts := strings.Split(s, "_")
+	for i := 1; i < len(parts); i++ {
+		if parts[i] != "" {
+			parts[i] = strings.ToUpper(parts[i][:1]) + parts[i][1:]
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+func lastSchemaComponent(p string) string {
+	parts := strings.Split(p, "/")
+	for i := len(parts) - 1; i >= 0; i-- {
+		if parts[i] != "" && parts[i] != "properties" {
+			return parts[i]
+		}
+	}
+	return ""
+}
+
+// hasSecretRefAt returns true if EITHER (a) the target subtree declares a
+// secretRef/existingSecret/*Secret knob inside its own "properties", OR
+// (b) a SIBLING of the target (at the same properties-map level) is named
+// "<target>Secret" / "secretRef" / "existingSecret" / has "Secret" suffix.
+// Sibling match is how the helm chart's encryptionKey + encryptionKeySecret
+// pattern works: the Secret-source knob is a sibling of the field itself.
+func hasSecretRefAt(schema map[string]any, dotted string) bool {
+	parts := strings.Split(dotted, ".")
+	var cur any = schema
+	var propsAtTarget map[string]any // map in which the last non-"properties" part lives
+	var targetName string
+	for _, p := range parts {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return false
+		}
+		// Resolve $ref at this node before descending.
+		if ref, ok := m["$ref"].(string); ok && strings.HasPrefix(ref, "#/") {
+			resolved := jsonPointerGet(schema, strings.TrimPrefix(ref, "#/"))
+			if rm, ok := resolved.(map[string]any); ok {
+				m = rm
+			}
+		}
+		if p != "properties" {
+			propsAtTarget = m
+			targetName = p
+		}
+		next, present := m[p]
+		if !present {
+			break
+		}
+		cur = next
+	}
+	// (a) target itself declares a Secret knob in its own properties.
+	if m, ok := cur.(map[string]any); ok && secretRefPresent(m) {
+		return true
+	}
+	// (b) a sibling of target matches <target>Secret or a generic Secret knob.
+	if propsAtTarget != nil && targetName != "" {
+		for k := range propsAtTarget {
+			if k == targetName {
+				continue
+			}
+			if k == "secretRef" || k == "existingSecret" {
+				return true
+			}
+			if strings.HasSuffix(k, "Secret") || strings.HasSuffix(k, "SecretRef") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// jsonPointerGet resolves a /-delimited JSON Pointer into a schema root.
+// Used by hasSecretRefAt to follow $ref entries in helm values.schema.json.
+func jsonPointerGet(root any, pointer string) any {
+	if pointer == "" {
+		return root
+	}
+	parts := strings.Split(pointer, "/")
+	cur := root
+	for _, p := range parts {
+		p = strings.ReplaceAll(p, "~1", "/")
+		p = strings.ReplaceAll(p, "~0", "~")
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		cur = m[p]
+		if cur == nil {
+			return nil
+		}
+	}
+	return cur
+}
+
+func secretRefPresent(m map[string]any) bool {
+	if m == nil {
+		return false
+	}
+	props, ok := m["properties"].(map[string]any)
+	if !ok {
+		return false
+	}
+	for k := range props {
+		if k == "secretRef" || k == "existingSecret" || k == "encryptionKeySecret" {
+			return true
+		}
+		if strings.HasSuffix(k, "Secret") || strings.HasSuffix(k, "SecretRef") {
+			return true
+		}
+	}
+	return false
+}
+
+func collectPkgs(roots []*packages.Package) map[string]*packages.Package {
+	out := map[string]*packages.Package{}
+	packages.Visit(roots, nil, func(p *packages.Package) {
+		out[p.PkgPath] = p
+	})
+	return out
+}
+
+func (c *checker) add(f Finding) { c.findings = append(c.findings, f) }
+
+// countErrs returns the number of ERROR-severity findings.
+func (c *checker) countErrs() int {
+	n := 0
+	for _, f := range c.findings {
+		if f.Severity == "ERROR" {
+			n++
+		}
+	}
+	return n
+}
+
+// countWarns returns the number of WARN-severity findings.
+func (c *checker) countWarns() int {
+	n := 0
+	for _, f := range c.findings {
+		if f.Severity == "WARN" {
+			n++
+		}
+	}
+	return n
+}
+
+// collectConsts scans all loaded packages for `const X NamedStringType = "v"`
+// and indexes them by namedType key "pkgpath.TypeName".
+func (c *checker) collectConsts() {
+	for _, p := range c.pkgs {
+		if p.Types == nil {
+			continue
+		}
+		scope := p.Types.Scope()
+		for _, name := range scope.Names() {
+			obj := scope.Lookup(name)
+			cnst, ok := obj.(*types.Const)
+			if !ok {
+				continue
+			}
+			named, ok := cnst.Type().(*types.Named)
+			if !ok {
+				continue
+			}
+			// Only named string types
+			basic, ok := named.Underlying().(*types.Basic)
+			if !ok || basic.Kind() != types.String {
+				continue
+			}
+			key := named.Obj().Pkg().Path() + "." + named.Obj().Name()
+			v := cnst.Val()
+			if v.Kind() != constant.String {
+				continue
+			}
+			c.enumConsts[key] = append(c.enumConsts[key], constant.StringVal(v))
+		}
+	}
+	for k := range c.enumConsts {
+		sort.Strings(c.enumConsts[k])
+	}
+}
+
+// walkType recursively walks a struct type, verifying each json-tagged field
+// has a schema counterpart at the propagated schemaPath.
+func (c *checker) walkType(t types.Type, schemaPath, goPath string) {
+	t = deref(t)
+	named, _ := t.(*types.Named)
+	if named != nil {
+		key := named.Obj().Pkg().Path() + "." + named.Obj().Name()
+		// Treat opaque types (like schemas.EnvVar) as leaves.
+		if _, isOpaque := opaqueLeafTypes[key]; isOpaque {
+			if key == "github.com/maximhq/bifrost/core/schemas.EnvVar" {
+				c.envVarFields = append(c.envVarFields, envVarLocation{schemaPath, goPath})
+			}
+			return
+		}
+		if c.visited[key+"@"+schemaPath] {
+			return
+		}
+		c.visited[key+"@"+schemaPath] = true
+	}
+	structType, ok := t.Underlying().(*types.Struct)
+	if !ok {
+		return
+	}
+
+	schemaNode := c.resolveSchema(schemaPath)
+	if schemaNode == nil {
+		c.add(Finding{Category: "schema-path-not-found", Severity: "ERROR", Path: schemaPath, Go: goPath})
+		return
+	}
+
+	// Collect every property key reachable from this schema node across
+	// properties/allOf/oneOf/anyOf/if-then-else branches.
+	schemaProps := c.collectProperties(schemaNode, schemaPath)
+
+	goFieldTags := map[string]*types.Var{}
+	for i := 0; i < structType.NumFields(); i++ {
+		f := structType.Field(i)
+		if !f.Exported() {
+			continue
+		}
+		tag := reflectTag(structType.Tag(i), "json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if name == "" {
+			continue
+		}
+		// Skip GORM relational fields (populated from joins; never user-submitted).
+		// GORM relational fields (`foreignKey`, `many2many`) are populated
+		// from DB joins, not user-submitted config. Skip them from the walk so
+		// schemasync only compares user-input config against config.schema.json.
+		// Schema properties for these relations may still exist (validated at
+		// the missing-in-go layer); add the schema path to ignoreSchemaProps
+		// for deliberate exceptions (see below for `provider_configs`, etc.).
+		gormTag := reflectTag(structType.Tag(i), "gorm")
+		if strings.Contains(gormTag, "foreignKey") || strings.Contains(gormTag, "many2many") {
+			continue
+		}
+		goFieldTags[name] = f
+	}
+
+	// Go-field → schema check
+	for name, f := range goFieldTags {
+		childPath := schemaPath + "/properties/" + name
+		if _, ignored := ignoreGoFields[schemaPath+"|"+name]; ignored {
+			continue
+		}
+		if _, ignored := ignoreGoFieldNames[name]; ignored {
+			continue
+		}
+		childSchema := schemaProps[name]
+		if childSchema == nil {
+			c.add(Finding{
+				Category: "missing-in-schema",
+				Severity: "ERROR",
+				Path:     schemaPath + "/properties/" + name,
+				Detail:   name,
+				Go:       goPath + "." + f.Name(),
+			})
+			continue
+		}
+		// Recurse into field type
+		c.walkField(f.Type(), childSchema, childPath, goPath+"."+f.Name())
+	}
+
+	// Schema-key → Go field check (warnings; schema may legitimately be broader)
+	for name := range schemaProps {
+		if _, ignored := ignoreSchemaProps[schemaPath+"/properties/"+name]; ignored {
+			continue
+		}
+		if _, ignored := ignoreGoFields[schemaPath+"|"+name]; ignored {
+			continue
+		}
+		if _, ok := goFieldTags[name]; !ok {
+			c.add(Finding{
+				Category: "missing-in-go",
+				Severity: "WARN",
+				Path:     schemaPath + "/properties/" + name,
+				Detail:   name,
+				Go:       goPath,
+			})
+		}
+	}
+}
+
+// walkField dispatches based on the field's Go type.
+func (c *checker) walkField(t types.Type, schemaNode map[string]any, schemaPath, goPath string) {
+	t = deref(t)
+
+	// Named type → opaque-leaf check + enum check (if string const type)
+	if named, ok := t.(*types.Named); ok {
+		key := named.Obj().Pkg().Path() + "." + named.Obj().Name()
+		if _, isOpaque := opaqueLeafTypes[key]; isOpaque {
+			if key == "github.com/maximhq/bifrost/core/schemas.EnvVar" {
+				c.envVarFields = append(c.envVarFields, envVarLocation{schemaPath, goPath})
+			}
+			return // do not recurse into opaque types
+		}
+		if goVals, hasConsts := c.enumConsts[key]; hasConsts && len(goVals) > 0 {
+			c.checkEnum(goVals, schemaNode, schemaPath, goPath, key)
+		}
+	}
+
+	switch u := t.Underlying().(type) {
+	case *types.Struct:
+		// Recurse into named struct (anonymous structs are inlined below)
+		if _, ok := t.(*types.Named); ok {
+			c.walkType(t, schemaPath, goPath)
+		} else {
+			// Anonymous inline struct — rare but handle by walking tags
+			c.walkAnonymous(u, schemaPath, goPath)
+		}
+	case *types.Slice:
+		elem := u.Elem()
+		if _, isStruct := deref(elem).Underlying().(*types.Struct); isStruct {
+			itemsNode := c.resolveRef(schemaNode)
+			if _, ok := itemsNode["items"].(map[string]any); ok {
+				c.walkType(elem, schemaPath+"/items", goPath+"[]")
+			}
+		}
+	case *types.Array:
+		elem := u.Elem()
+		if _, isStruct := deref(elem).Underlying().(*types.Struct); isStruct {
+			itemsNode := c.resolveRef(schemaNode)
+			if _, ok := itemsNode["items"].(map[string]any); ok {
+				c.walkType(elem, schemaPath+"/items", goPath+"[]")
+			}
+		}
+	case *types.Map:
+		elem := u.Elem()
+		if _, isStruct := deref(elem).Underlying().(*types.Struct); isStruct {
+			node := c.resolveRef(schemaNode)
+			if _, ok := node["additionalProperties"].(map[string]any); ok {
+				c.walkType(elem, schemaPath+"/additionalProperties", goPath+"[]")
+			}
+			// If no additionalProperties/patternProperties, silently skip — schemas
+			// often describe provider-keyed maps via oneOf branches.
+		}
+	case *types.Basic, *types.Interface:
+		// Leaf — nothing to recurse into.
+	}
+}
+
+// walkAnonymous handles anonymous (inline) struct fields — rare; we treat
+// them as a struct walk at the same schemaPath.
+func (c *checker) walkAnonymous(st *types.Struct, schemaPath, goPath string) {
+	// Not common in this codebase; fall back to flat tag-check.
+	schemaNode := c.resolveSchema(schemaPath)
+	if schemaNode == nil {
+		return
+	}
+	props := c.collectProperties(schemaNode, schemaPath)
+	for i := 0; i < st.NumFields(); i++ {
+		f := st.Field(i)
+		if !f.Exported() {
+			continue
+		}
+		tag := reflectTag(st.Tag(i), "json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if _, ok := props[name]; !ok {
+			c.add(Finding{
+				Category: "missing-in-schema",
+				Severity: "ERROR",
+				Path:     schemaPath + "/properties/" + name,
+				Detail:   name,
+				Go:       goPath + "." + f.Name(),
+			})
+		}
+	}
+}
+
+// checkEnum diffs Go string-const values against schema enum array.
+func (c *checker) checkEnum(goVals []string, schemaNode map[string]any, schemaPath, goPath, typeKey string) {
+	node := c.resolveRef(schemaNode)
+	rawEnum, ok := node["enum"]
+	if !ok {
+		c.add(Finding{
+			Category: "enum-no-schema",
+			Severity: "WARN",
+			Path:     schemaPath,
+			Detail:   fmt.Sprintf("%v (Go consts)", goVals),
+			Go:       typeKey,
+		})
+		return
+	}
+	enumArr, ok := rawEnum.([]any)
+	if !ok {
+		c.add(Finding{Category: "enum-drift", Severity: "ERROR", Path: schemaPath, Detail: "schema enum is not an array"})
+		return
+	}
+	schemaSet := map[string]bool{}
+	for _, v := range enumArr {
+		if s, ok := v.(string); ok {
+			schemaSet[s] = true
+		}
+	}
+	goSet := map[string]bool{}
+	for _, v := range goVals {
+		goSet[v] = true
+	}
+	var missingInSchema, extraInSchema []string
+	for v := range goSet {
+		if !schemaSet[v] {
+			missingInSchema = append(missingInSchema, v)
+		}
+	}
+	for v := range schemaSet {
+		if !goSet[v] {
+			extraInSchema = append(extraInSchema, v)
+		}
+	}
+	sort.Strings(missingInSchema)
+	sort.Strings(extraInSchema)
+	if len(missingInSchema) > 0 {
+		c.add(Finding{
+			Category: "enum-drift",
+			Severity: "ERROR",
+			Path:     schemaPath,
+			Detail:   fmt.Sprintf("schema missing Go consts %v", missingInSchema),
+			Go:       goPath + " (" + typeKey + ")",
+		})
+	}
+	if len(extraInSchema) > 0 {
+		c.add(Finding{
+			Category: "enum-drift",
+			Severity: "WARN",
+			Path:     schemaPath,
+			Detail:   fmt.Sprintf("schema has %v with no Go const", extraInSchema),
+			Go:       typeKey,
+		})
+	}
+}
+
+// collectProperties walks the schema subtree rooted at `node`, unioning
+// property keys from the direct `properties`, and recursively from `allOf`,
+// `oneOf`, `anyOf`, `then`, `else`. Handles $ref.
+// Returns map of propertyName → subschema.
+func (c *checker) collectProperties(node map[string]any, atPath string) map[string]map[string]any {
+	out := map[string]map[string]any{}
+	c.mergeProperties(out, node, atPath, map[string]bool{})
+	return out
+}
+
+func (c *checker) mergeProperties(out map[string]map[string]any, node map[string]any, atPath string, seen map[string]bool) {
+	if node == nil {
+		return
+	}
+	node = c.resolveRef(node)
+	if ref, ok := node["$ref"].(string); ok && seen[ref] {
+		return
+	}
+	if ref, ok := node["$ref"].(string); ok {
+		seen[ref] = true
+	}
+	if props, ok := node["properties"].(map[string]any); ok {
+		for k, v := range props {
+			if m, ok := v.(map[string]any); ok {
+				if _, already := out[k]; !already {
+					out[k] = m
+				}
+			}
+		}
+	}
+	for _, key := range []string{"allOf", "oneOf", "anyOf"} {
+		if arr, ok := node[key].([]any); ok {
+			for _, item := range arr {
+				if m, ok := item.(map[string]any); ok {
+					c.mergeProperties(out, m, atPath+"/"+key, seen)
+				}
+			}
+		}
+	}
+	for _, key := range []string{"then", "else"} {
+		if m, ok := node[key].(map[string]any); ok {
+			c.mergeProperties(out, m, atPath+"/"+key, seen)
+		}
+	}
+}
+
+// resolveSchema walks a JSON-pointer path into c.schema, resolving $ref at
+// each intermediate node.
+func (c *checker) resolveSchema(path string) map[string]any {
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	var cur any = c.schema
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil
+		}
+		m = c.resolveRef(m)
+		cur = m[unescapeJSONPointer(p)]
+		if cur == nil {
+			return nil
+		}
+	}
+	if m, ok := cur.(map[string]any); ok {
+		return c.resolveRef(m)
+	}
+	return nil
+}
+
+// resolveRef follows a $ref pointer (recursively) to the final target node.
+// $ref values are expected as "#/$defs/xxx" style JSON pointers.
+func (c *checker) resolveRef(node map[string]any) map[string]any {
+	for i := 0; i < 16; i++ {
+		ref, ok := node["$ref"].(string)
+		if !ok {
+			return node
+		}
+		if !strings.HasPrefix(ref, "#/") {
+			return node // external refs unsupported
+		}
+		parts := strings.Split(strings.TrimPrefix(ref, "#/"), "/")
+		var cur any = c.schema
+		ok2 := true
+		for _, p := range parts {
+			m, isMap := cur.(map[string]any)
+			if !isMap {
+				ok2 = false
+				break
+			}
+			cur = m[unescapeJSONPointer(p)]
+			if cur == nil {
+				ok2 = false
+				break
+			}
+		}
+		if !ok2 {
+			return node
+		}
+		next, ok := cur.(map[string]any)
+		if !ok {
+			return node
+		}
+		node = next
+	}
+	return node
+}
+
+func unescapeJSONPointer(s string) string {
+	s = strings.ReplaceAll(s, "~1", "/")
+	s = strings.ReplaceAll(s, "~0", "~")
+	return s
+}
+
+// deref strips pointer wrappers to get the underlying type.
+func deref(t types.Type) types.Type {
+	for {
+		p, ok := t.(*types.Pointer)
+		if !ok {
+			return t
+		}
+		t = p.Elem()
+	}
+}
+
+// reflectTag parses a single struct-tag key; mirrors reflect.StructTag.Get.
+func reflectTag(tag, key string) string {
+	for tag != "" {
+		for tag != "" && tag[0] == ' ' {
+			tag = tag[1:]
+		}
+		i := 0
+		for i < len(tag) && tag[i] > ' ' && tag[i] != ':' && tag[i] != '"' && tag[i] != 0x7f {
+			i++
+		}
+		if i == 0 || i+1 >= len(tag) || tag[i] != ':' || tag[i+1] != '"' {
+			break
+		}
+		name := tag[:i]
+		tag = tag[i+1:]
+		i = 1
+		for i < len(tag) && tag[i] != '"' {
+			if tag[i] == '\\' {
+				i++
+			}
+			i++
+		}
+		if i >= len(tag) {
+			break
+		}
+		val := tag[1:i]
+		tag = tag[i+1:]
+		if name == key {
+			return val
+		}
+	}
+	return ""
+}

--- a/.github/workflows/scripts/validate-helm-schema.sh
+++ b/.github/workflows/scripts/validate-helm-schema.sh
@@ -196,8 +196,8 @@ else
   echo "✅ VLLM key config required fields match: [$HELM_VLLM_REQUIRED]"
 fi
 
-# Check concurrency_config required fields
-CONFIG_CONCURRENCY_REQUIRED=$(jq -r '."$defs".concurrency_config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
+# Check concurrency_and_buffer_size required fields (renamed from concurrency_config)
+CONFIG_CONCURRENCY_REQUIRED=$(jq -r '."$defs".concurrency_and_buffer_size.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
 HELM_CONCURRENCY_REQUIRED=$(jq -r '."$defs".concurrencyConfig.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
 
 if [ "$CONFIG_CONCURRENCY_REQUIRED" != "$HELM_CONCURRENCY_REQUIRED" ]; then
@@ -433,31 +433,10 @@ else
   echo "✅ MCP stdio config required fields match: [$CONFIG_MCP_STDIO_REQUIRED]"
 fi
 
-# Check MCP websocket_config required fields
-CONFIG_MCP_WS_REQUIRED=$(jq -r '."$defs".mcp_client_config.properties.websocket_config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
-HELM_MCP_WS_REQUIRED=$(jq -r '."$defs".mcpClientConfig.properties.websocketConfig.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
-
-if [ "$CONFIG_MCP_WS_REQUIRED" != "$HELM_MCP_WS_REQUIRED" ]; then
-  echo "❌ MCP websocket config required fields mismatch:"
-  echo "   Config: [$CONFIG_MCP_WS_REQUIRED]"
-  echo "   Helm:   [$HELM_MCP_WS_REQUIRED]"
-  ERRORS=$((ERRORS + 1))
-else
-  echo "✅ MCP websocket config required fields match: [$CONFIG_MCP_WS_REQUIRED]"
-fi
-
-# Check MCP http_config required fields
-CONFIG_MCP_HTTP_REQUIRED=$(jq -r '."$defs".mcp_client_config.properties.http_config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
-HELM_MCP_HTTP_REQUIRED=$(jq -r '."$defs".mcpClientConfig.properties.httpConfig.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
-
-if [ "$CONFIG_MCP_HTTP_REQUIRED" != "$HELM_MCP_HTTP_REQUIRED" ]; then
-  echo "❌ MCP http config required fields mismatch:"
-  echo "   Config: [$CONFIG_MCP_HTTP_REQUIRED]"
-  echo "   Helm:   [$HELM_MCP_HTTP_REQUIRED]"
-  ERRORS=$((ERRORS + 1))
-else
-  echo "✅ MCP http config required fields match: [$CONFIG_MCP_HTTP_REQUIRED]"
-fi
+# MCP websocket_config and http_config were removed from config.schema.json
+# because the corresponding Go fields don't exist (MCP rendering uses
+# connection_type + connection_string directly, not sub-object configs).
+# Helm still declares them for user convenience — not a schema sync concern.
 
 echo ""
 echo "🔍 Checking required fields in SAML/SCIM config..."

--- a/.github/workflows/scripts/validate-schema-sync.sh
+++ b/.github/workflows/scripts/validate-schema-sync.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate that Go config types in transports/bifrost-http/lib/config.go
+# stay in sync (fields + enum values) with transports/config.schema.json.
+# Walks the type graph recursively via go/types rather than regex-parsing source.
+
+if command -v readlink >/dev/null 2>&1 && readlink -f "$0" >/dev/null 2>&1; then
+  SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
+fi
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+TOOL_DIR="$SCRIPT_DIR/schemasync"
+
+cd "$REPO_ROOT"
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "❌ go toolchain required for schema-sync validation"
+  exit 2
+fi
+
+echo "🔍 Validating Go ↔ config.schema.json sync (recursive, AST-based)"
+echo "=================================================================="
+
+# The schemasync tool is its own module (separate go.mod). Build it with
+# GOWORK=off so the tool's deps (golang.org/x/tools) resolve against its
+# own go.mod, not the repo's go.work. At runtime the tool itself sets
+# GOWORK=<repo-root>/go.work when loading bifrost packages.
+(cd "$TOOL_DIR" && GOWORK=off go build -o /tmp/schemasync .)
+/tmp/schemasync \
+  --schema "$REPO_ROOT/transports/config.schema.json" \
+  --pkg-root "$REPO_ROOT" \
+  --helm-values "$REPO_ROOT/helm-charts/bifrost/values.schema.json" \
+  --helm-helpers "$REPO_ROOT/helm-charts/bifrost/templates/_helpers.tpl"

--- a/examples/configs/withconfigstore/config.json
+++ b/examples/configs/withconfigstore/config.json
@@ -22,7 +22,9 @@
         "provider_configs": [
           {
             "provider": "azure",
-            "key_ids": ["*"],
+            "key_ids": [
+              "*"
+            ],
             "allowed_models": [
               "gpt-4.1-2025-04-14",
               "gpt-4.1-mini-2025-04-14",
@@ -48,7 +50,8 @@
             ],
             "weight": 0.5
           }
-        ]
+        ],
+        "name": "vk-gpt"
       }
     ]
   }

--- a/examples/configs/withpostgresmcpclientsinconfig/config.json
+++ b/examples/configs/withpostgresmcpclientsinconfig/config.json
@@ -40,18 +40,16 @@
   "mcp": {
     "client_configs": [
       {
-        "id": "weather-mcp-server",
         "name": "WeatherService",
         "connection_type": "http",
-        "http_url": "http://localhost:8080/mcp",
-        "is_enabled": true
+        "client_id": "weather-mcp-server",
+        "connection_string": "http://localhost:8080/mcp"
       },
       {
-        "id": "calendar-mcp-server",
         "name": "CalendarService",
         "connection_type": "http",
-        "http_url": "http://localhost:8081/mcp",
-        "is_enabled": true
+        "client_id": "calendar-mcp-server",
+        "connection_string": "http://localhost:8081/mcp"
       }
     ]
   },
@@ -88,8 +86,12 @@
           {
             "provider": "openai",
             "weight": 1.0,
-            "allowed_models": ["*"],
-            "key_ids": ["*"]
+            "allowed_models": [
+              "*"
+            ],
+            "key_ids": [
+              "*"
+            ]
           }
         ]
       },
@@ -111,8 +113,12 @@
           {
             "provider": "openai",
             "weight": 1.0,
-            "allowed_models": ["*"],
-            "key_ids": ["*"]
+            "allowed_models": [
+              "*"
+            ],
+            "key_ids": [
+              "*"
+            ]
           }
         ]
       }
@@ -134,7 +140,9 @@
           "name": "openai-primary",
           "value": "env.OPENAI_API_KEY",
           "weight": 1,
-          "models": ["*"]
+          "models": [
+            "*"
+          ]
         }
       ]
     }

--- a/examples/configs/withprompushgateway/config.json
+++ b/examples/configs/withprompushgateway/config.json
@@ -1,220 +1,245 @@
 {
-    "$schema": "https://www.getbifrost.ai/schema",
-    "providers": {
-        "openai": {
-            "keys": [
-                {
-                    "name": "OpenAI API Key",
-                    "value": "env.OPENAI_API_KEY",
-                    "weight": 1,
-                    "use_for_batch_api": true,
-                    "models": ["*"]
-                }
-            ],
-            "network_config": {
-                "default_request_timeout_in_seconds": 300
-            }
-        },
-        "anthropic": {
-            "keys": [
-                {
-                    "name": "Anthropic API Key",
-                    "value": "env.ANTHROPIC_API_KEY",
-                    "weight": 1,
-                    "use_for_batch_api": true,
-                    "models": ["*"]
-                }
-            ],
-            "network_config": {
-                "default_request_timeout_in_seconds": 300
-            }
-        },
-        "gemini": {
-            "keys": [
-                {
-                    "value": "env.GEMINI_API_KEY",
-                    "weight": 1,
-                    "use_for_batch_api": true,
-                    "models": ["*"]
-                }
-            ],
-            "network_config": {
-                "default_request_timeout_in_seconds": 300
-            }
-        },
-        "vertex": {
-            "keys": [
-                {
-                    "name": "Vertex API Key",
-                    "vertex_key_config": {
-                        "project_id": "env.VERTEX_PROJECT_ID",
-                        "region": "env.GOOGLE_LOCATION",
-                        "auth_credentials": "env.VERTEX_CREDENTIALS"
-                    },
-                    "weight": 1,
-                    "models": ["*"]
-                }
-            ],
-            "network_config": {
-                "default_request_timeout_in_seconds": 300
-            }
-        },
-        "mistral": {
-            "keys": [
-                {
-                    "name": "Mistral API Key",
-                    "value": "env.MISTRAL_API_KEY",
-                    "weight": 1,
-                    "models": ["*"]
-                }
-            ],
-            "network_config": {
-                "default_request_timeout_in_seconds": 300
-            }
-        },
-        "cohere": {
-            "keys": [
-                {
-                    "name": "Cohere API Key",
-                    "value": "env.COHERE_API_KEY",
-                    "weight": 1,
-                    "models": ["*"]
-                }
-            ],
-            "network_config": {
-                "default_request_timeout_in_seconds": 300
-            }
-        },
-        "groq": {
-            "keys": [
-                {
-                    "name": "Groq API Key",
-                    "value": "env.GROQ_API_KEY",
-                    "weight": 1,
-                    "models": ["*"]
-                }
-            ],
-            "network_config": {
-                "default_request_timeout_in_seconds": 300
-            }
-        },
-        "perplexity": {
-            "keys": [
-                {
-                    "name": "Perplexity API Key",
-                    "value": "env.PERPLEXITY_API_KEY",
-                    "weight": 1,
-                    "models": ["*"]
-                }
-            ],
-            "network_config": {
-                "default_request_timeout_in_seconds": 300
-            }
-        },
-        "cerebras": {
-            "keys": [
-                {
-                    "name": "Cerebras API Key",
-                    "value": "env.CEREBRAS_API_KEY",
-                    "weight": 1,
-                    "models": ["*"]
-                }
-            ],
-            "network_config": {
-                "default_request_timeout_in_seconds": 300
-            }
-        },
-        "openrouter": {
-            "keys": [
-                {
-                    "name": "OpenRouter API Key",
-                    "value": "env.OPENROUTER_API_KEY",
-                    "weight": 1,
-                    "models": ["*"]
-                }
-            ],
-            "network_config": {
-                "default_request_timeout_in_seconds": 300
-            }
-        },
-        "azure": {
-            "keys": [
-                {
-                    "name": "Azure API Key",
-                    "value": "env.AZURE_API_KEY",
-                    "azure_key_config": {
-                        "endpoint": "env.AZURE_ENDPOINT",
-                        "api_version": "env.AZURE_API_VERSION"
-                    },
-                    "weight": 1,
-                    "models": ["*"]
-                }
-            ],
-            "network_config": {
-                "default_request_timeout_in_seconds": 300
-            }
-        },
-        "bedrock": {
-            "keys": [
-                {
-                    "name": "Bedrock API Key",
-                    "bedrock_key_config": {
-                        "access_key": "env.AWS_ACCESS_KEY_ID",
-                        "secret_key": "env.AWS_SECRET_ACCESS_KEY",
-                        "region": "env.AWS_REGION",
-                        "arn": "env.AWS_ARN"
-                    },
-                    "weight": 1,
-                    "use_for_batch_api": true,
-                    "models": ["*"]
-                }
-            ],
-            "network_config": {
-                "default_request_timeout_in_seconds": 300
-            }
-        }
-    },
-    "client": {
-        "drop_excess_requests": false,
-        "initial_pool_size": 300,
-        "allowed_origins": [
+  "$schema": "https://www.getbifrost.ai/schema",
+  "providers": {
+    "openai": {
+      "keys": [
+        {
+          "name": "OpenAI API Key",
+          "value": "env.OPENAI_API_KEY",
+          "weight": 1,
+          "use_for_batch_api": true,
+          "models": [
             "*"
-        ],
-        "enable_logging": true,
-        "enforce_auth_on_inference": false,
-        "allow_direct_keys": false,
-        "max_request_body_size_mb": 100
-    },
-    "config_store": {
-      "enabled": true,
-      "type": "sqlite",
-      "config":{
-        "path": "../../examples/configs/withprompushgateway/config.db"
+          ]
+        }
+      ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
       }
     },
-    "logs_store": {
-        "enabled": true,
-        "type": "sqlite",
-        "config": {
-            "path": "../../examples/configs/withprompushgateway/logs.db"
-        }
-    },
-    "plugins": [
+    "anthropic": {
+      "keys": [
         {
-            "name": "telemetry",
-            "enabled": true,
-            "config": {
-                "push_gateway": {
-                    "enabled": true,
-                    "push_gateway_url": "http://localhost:9091",
-                    "job_name": "bifrost",
-                    "push_interval": 15,
-                    "basic_auth": {
-                        "username": "admin",
-                        "password": "admin"
-                    }
-                }
-            }
+          "name": "Anthropic API Key",
+          "value": "env.ANTHROPIC_API_KEY",
+          "weight": 1,
+          "use_for_batch_api": true,
+          "models": [
+            "*"
+          ]
         }
-    ]
+      ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      }
+    },
+    "gemini": {
+      "keys": [
+        {
+          "value": "env.GEMINI_API_KEY",
+          "weight": 1,
+          "use_for_batch_api": true,
+          "models": [
+            "*"
+          ],
+          "name": "gemini-key-1"
+        }
+      ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      }
+    },
+    "vertex": {
+      "keys": [
+        {
+          "name": "Vertex API Key",
+          "vertex_key_config": {
+            "project_id": "env.VERTEX_PROJECT_ID",
+            "region": "env.GOOGLE_LOCATION",
+            "auth_credentials": "env.VERTEX_CREDENTIALS"
+          },
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      }
+    },
+    "mistral": {
+      "keys": [
+        {
+          "name": "Mistral API Key",
+          "value": "env.MISTRAL_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      }
+    },
+    "cohere": {
+      "keys": [
+        {
+          "name": "Cohere API Key",
+          "value": "env.COHERE_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      }
+    },
+    "groq": {
+      "keys": [
+        {
+          "name": "Groq API Key",
+          "value": "env.GROQ_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      }
+    },
+    "perplexity": {
+      "keys": [
+        {
+          "name": "Perplexity API Key",
+          "value": "env.PERPLEXITY_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      }
+    },
+    "cerebras": {
+      "keys": [
+        {
+          "name": "Cerebras API Key",
+          "value": "env.CEREBRAS_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      }
+    },
+    "openrouter": {
+      "keys": [
+        {
+          "name": "OpenRouter API Key",
+          "value": "env.OPENROUTER_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      }
+    },
+    "azure": {
+      "keys": [
+        {
+          "name": "Azure API Key",
+          "value": "env.AZURE_API_KEY",
+          "azure_key_config": {
+            "endpoint": "env.AZURE_ENDPOINT",
+            "api_version": "env.AZURE_API_VERSION"
+          },
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      }
+    },
+    "bedrock": {
+      "keys": [
+        {
+          "name": "Bedrock API Key",
+          "bedrock_key_config": {
+            "access_key": "env.AWS_ACCESS_KEY_ID",
+            "secret_key": "env.AWS_SECRET_ACCESS_KEY",
+            "region": "env.AWS_REGION",
+            "arn": "env.AWS_ARN"
+          },
+          "weight": 1,
+          "use_for_batch_api": true,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      }
+    }
+  },
+  "client": {
+    "drop_excess_requests": false,
+    "initial_pool_size": 300,
+    "allowed_origins": [
+      "*"
+    ],
+    "enable_logging": true,
+    "enforce_auth_on_inference": false,
+    "allow_direct_keys": false,
+    "max_request_body_size_mb": 100
+  },
+  "config_store": {
+    "enabled": true,
+    "type": "sqlite",
+    "config": {
+      "path": "../../examples/configs/withprompushgateway/config.db"
+    }
+  },
+  "logs_store": {
+    "enabled": true,
+    "type": "sqlite",
+    "config": {
+      "path": "../../examples/configs/withprompushgateway/logs.db"
+    }
+  },
+  "plugins": [
+    {
+      "name": "telemetry",
+      "enabled": true,
+      "config": {
+        "push_gateway": {
+          "enabled": true,
+          "push_gateway_url": "http://localhost:9091",
+          "job_name": "bifrost",
+          "push_interval": 15,
+          "basic_auth": {
+            "username": "admin",
+            "password": "admin"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/examples/configs/withroutingrules/config.json
+++ b/examples/configs/withroutingrules/config.json
@@ -15,11 +15,11 @@
         "description": "Route all GPT-4 model requests to Azure provider",
         "enabled": true,
         "cel_expression": "model.startsWith('gpt-4')",
-        "provider": "azure",
-        "model": "",
+        "targets": [
+          { "provider": "azure", "weight": 1.0 }
+        ],
         "fallbacks": ["openai"],
         "scope": "global",
-        "scope_id": null,
         "priority": 0
       },
       {
@@ -28,11 +28,12 @@
         "description": "Route to fallback providers when budget usage exceeds 80%",
         "enabled": true,
         "cel_expression": "budget_used >= 80.0",
-        "provider": "",
-        "model": "",
+        "targets": [
+          { "provider": "anthropic", "weight": 0.5 },
+          { "provider": "openai", "weight": 0.5 }
+        ],
         "fallbacks": ["anthropic", "openai"],
         "scope": "global",
-        "scope_id": null,
         "priority": 10
       },
       {
@@ -41,11 +42,11 @@
         "description": "Route embedding requests to cost-effective provider",
         "enabled": true,
         "cel_expression": "request_type == 'embedding'",
-        "provider": "openai",
-        "model": "text-embedding-3-small",
+        "targets": [
+          { "provider": "openai", "model": "text-embedding-3-small", "weight": 1.0 }
+        ],
         "fallbacks": [],
         "scope": "global",
-        "scope_id": null,
         "priority": 5
       },
       {
@@ -54,8 +55,9 @@
         "description": "Premium virtual keys always use Azure",
         "enabled": true,
         "cel_expression": "virtual_key_name == 'premium-tier'",
-        "provider": "azure",
-        "model": "",
+        "targets": [
+          { "provider": "azure", "weight": 1.0 }
+        ],
         "fallbacks": ["openai", "anthropic"],
         "scope": "virtual_key",
         "scope_id": "premium-tier",

--- a/examples/configs/withsemanticcache/config.json
+++ b/examples/configs/withsemanticcache/config.json
@@ -13,6 +13,7 @@
       "enabled": true,
       "name": "semantic_cache",
       "config": {
+        "dimension": 1,
         "ttl": 300,
         "threshold": 0.8
       }

--- a/examples/configs/withvirtualkeys/config.json
+++ b/examples/configs/withvirtualkeys/config.json
@@ -1,321 +1,314 @@
 {
-    "$schema": "https://www.getbifrost.ai/schema",
-    "client": {
-        "allow_direct_keys": false,
-        "allowed_origins": [
-            "*"
-        ],
-        "disable_content_logging": false,
-        "drop_excess_requests": false,
-        "enable_logging": true,
-        "enforce_auth_on_inference": true,
-        "initial_pool_size": 300,
-        "log_retention_days": 365,
-        "max_request_body_size_mb": 100
-    },
-    "config_store": {
-        "config": {
-            "path": "../../examples/configs/withvirtualkeys/config.db"
-        },
-        "enabled": true,
-        "type": "sqlite"
-    },
-    "framework": {
-        "pricing": {
-            "pricing_sync_interval": 86400
-        }
-    },
-    "governance": {
-        "auth_config": {
-            "admin_password": "env.BIFROST_ADMIN_PASSWORD",
-            "admin_username": "env.BIFROST_ADMIN_USERNAME",
-            "disable_auth_on_inference": true,
-            "is_enabled": false
-        },
-        "virtual_keys": [
-            {
-                "id": "sk-bf-vk-prod-assistant-us-01",
-                "is_active": true,
-                "name": "prod-assistant-us-key-01-configurations",
-                "provider_configs": [
-                    {
-                        "key_ids": [
-                            "key-azure-us-1-prod"
-                        ],
-                        "allowed_models": ["*"],
-                        "provider": "azure",
-                        "weight": 0.5
-                    },
-                    {
-                        "key_ids": [
-                            "key-vertex-us-east1-prod",
-                            "key-vertex-global-prod"
-                        ],
-                        "allowed_models": ["*"],
-                        "provider": "vertex",
-                        "weight": 0.5
-                    },
-                    {
-                        "key_ids": [
-                            "key-openai-us-1-prod"
-                        ],
-                        "allowed_models": ["*"],
-                        "provider": "openai",
-                        "weight": 0.5
-                    }
-                ],
-                "value": "env.BIFROST_VK_PROD_ASSISTANT_US_01"
-            },
-            {
-                "id": "sk-bf-vk-prod-assistant-eu-01",
-                "is_active": true,
-                "name": "prod-assistant-eu-key-01-configurations",
-                "provider_configs": [
-                    {
-                        "key_ids": [
-                            "key-azure-eu-1-prod"
-                        ],
-                        "allowed_models": ["*"],
-                        "provider": "azure",
-                        "weight": 0.5
-                    },
-                    {
-                        "key_ids": [
-                            "key-vertex-eu-west1-prod",
-                            "key-vertex-global-prod"
-                        ],
-                        "allowed_models": ["*"],
-                        "provider": "vertex",
-                        "weight": 0.5
-                    },
-                    {
-                        "key_ids": [
-                            "key-bedrock-eu-central-1-prod"
-                        ],
-                        "allowed_models": ["*"],
-                        "provider": "bedrock",
-                        "weight": 0.5
-                    }
-                ],
-                "value": "sk-bf-vk-prod-assistant-eu-01"
-            }
-        ]
-    },
-    "logs_store": {
-        "config": {
-            "path": "../../examples/configs/withvirtualkeys/logs.db"
-        },
-        "enabled": true,
-        "type": "sqlite"
-    },
-    "plugins": [
-        {
-            "config": {
-                "is_vk_mandatory": true
-            },
-            "enabled": true,
-            "name": "governance"
-        }
+  "$schema": "https://www.getbifrost.ai/schema",
+  "client": {
+    "allow_direct_keys": false,
+    "allowed_origins": [
+      "*"
     ],
-    "providers": {
-        "azure": {
-            "keys": [
-                {
-                    "id": "key-azure-us-1-prod",
-                    "azure_key_config": {
-                        "api_version": "2025-03-01-preview",
-                        "deployments": {
-                            "gpt-4.1": "gpt-4.1",
-                            "gpt-4.1-mini": "gpt-4.1-mini",
-                            "gpt-4o": "gpt-4o",
-                            "gpt-4o-mini": "gpt-4o-mini",
-                            "gpt-5": "gpt-5",
-                            "gpt-5-mini": "gpt-5-mini",
-                            "gpt-5.1": "gpt-5.1"
-                        },
-                        "endpoint": "https://orca-prod-us-east-1.openai.azure.com/"
-                    },
-                    "models": [
-                        "gpt-4.1",
-                        "gpt-4.1-mini",
-                        "gpt-4o",
-                        "gpt-4o-mini",
-                        "gpt-5",
-                        "gpt-5-mini",
-                        "gpt-5.1"
-                    ],
-                    "name": "azure-us-key-1-prod",
-                    "value": "env.AZURE_OPENAI_API_KEY_US_EAST_1",
-                    "weight": 1
-                },
-                {
-                    "id": "key-azure-us-2-prod",
-                    "azure_key_config": {
-                        "api_version": "2025-03-01-preview",
-                        "deployments": {
-                            "gpt-4.1": "gpt-4.1",
-                            "gpt-4.1-mini": "gpt-4.1-mini",
-                            "gpt-4o": "gpt-4o",
-                            "gpt-4o-mini": "gpt-4o-mini",
-                            "gpt-5": "gpt-5",
-                            "gpt-5-mini": "gpt-5-mini",
-                            "gpt-5.1": "gpt-5.1"
-                        },
-                        "endpoint": "https://orca-prod-us-east-2.openai.azure.com/"
-                    },
-                    "models": [
-                        "gpt-4.1",
-                        "gpt-4.1-mini",
-                        "gpt-4o",
-                        "gpt-4o-mini",
-                        "gpt-5",
-                        "gpt-5-mini",
-                        "gpt-5.1"
-                    ],
-                    "name": "azure-us-key-2-prod",
-                    "value": "env.AZURE_OPENAI_API_KEY_US_EAST_2",
-                    "weight": 1
-                },
-                {
-                    "id": "key-azure-eu-1-prod",
-                    "azure_key_config": {
-                        "api_version": "2025-03-01-preview",
-                        "deployments": {
-                            "gpt-4.1": "gpt-4.1",
-                            "gpt-4.1-mini": "gpt-4.1-mini",
-                            "gpt-4o": "gpt-4o",
-                            "gpt-4o-mini": "gpt-4o-mini",
-                            "gpt-5": "gpt-5",
-                            "gpt-5-mini": "gpt-5-mini",
-                            "gpt-5.1": "gpt-5.1"
-                        },
-                        "endpoint": "https://orca-prod-eu-central-1.openai.azure.com/"
-                    },
-                    "models": [
-                        "gpt-4.1",
-                        "gpt-4.1-mini",
-                        "gpt-4o",
-                        "gpt-4o-mini",
-                        "gpt-5",
-                        "gpt-5-mini",
-                        "gpt-5.1"
-                    ],
-                    "name": "azure-eu-key-1-prod",
-                    "value": "env.AZURE_OPENAI_API_KEY_EU_CENTRAL_1",
-                    "weight": 1
-                }
-            ]
-        },
-        "bedrock": {
-            "keys": [
-                {
-                    "id": "key-bedrock-us-east-1-prod",
-                    "bedrock_key_config": {
-                        "access_key": "env.AWS_ACCESS_KEY_ID_US_EAST_1",
-                        "region": "us-east-1",
-                        "secret_key": "env.AWS_SECRET_ACCESS_KEY_US_EAST_1"
-                    },
-                    "models": ["*"],
-                    "name": "bedrock-us-east-1-prod",
-                    "weight": 1
-                },
-                {
-                    "id": "key-bedrock-us-west-2-prod",
-                    "bedrock_key_config": {
-                        "access_key": "env.AWS_ACCESS_KEY_ID_US_WEST_2",
-                        "region": "us-west-2",
-                        "secret_key": "env.AWS_SECRET_ACCESS_KEY_US_WEST_2"
-                    },
-                    "models": ["*"],
-                    "name": "bedrock-us-west-2-prod",
-                    "weight": 1
-                },
-                {
-                    "id": "key-bedrock-eu-central-1-prod",
-                    "bedrock_key_config": {
-                        "access_key": "env.AWS_ACCESS_KEY_ID_EU_CENTRAL_1",
-                        "region": "eu-central-1",
-                        "secret_key": "env.AWS_SECRET_ACCESS_KEY_EU_CENTRAL_1"
-                    },
-                    "models": ["*"],
-                    "name": "bedrock-eu-central-1-prod",
-                    "weight": 1
-                }
-            ]
-        },
-        "vertex": {
-            "keys": [
-                {
-                    "id": "key-vertex-us-east1-prod",
-                    "models": [
-                        "google/gemini-2.5-pro",
-                        "google/gemini-2.5-flash-lite",
-                        "google/gemini-2.5-flash"
-                    ],
-                    "name": "vertex-us-east1-prod",
-                    "vertex_key_config": {
-                        "auth_credentials": "env.VERTEX_CREDENTIALS_US_EAST1",
-                        "project_id": "agentic-ai-project-1",
-                        "region": "us-east1"
-                    },
-                    "weight": 1
-                },
-                {
-                    "id": "key-vertex-eu-west1-prod",
-                    "models": [
-                        "google/gemini-2.5-pro",
-                        "google/gemini-2.5-flash-lite",
-                        "google/gemini-2.5-flash"
-                    ],
-                    "name": "vertex-europe-west1-prod",
-                    "vertex_key_config": {
-                        "auth_credentials": "env.VERTEX_CREDENTIALS_EUROPE_WEST1",
-                        "project_id": "agentic-ai-project-1",
-                        "region": "europe-west1"
-                    },
-                    "weight": 1
-                },
-                {
-                    "id": "key-vertex-us-west1-prod",
-                    "models": [
-                        "google/gemini-2.5-pro",
-                        "google/gemini-2.5-flash-lite",
-                        "google/gemini-2.5-flash"
-                    ],
-                    "name": "vertex-us-west1-prod",
-                    "vertex_key_config": {
-                        "auth_credentials": "env.VERTEX_CREDENTIALS_US_WEST1",
-                        "project_id": "agentic-ai-project-1",
-                        "region": "us-west1"
-                    },
-                    "weight": 1
-                },
-                {
-                    "id": "key-vertex-global-prod",
-                    "models": [
-                        "google/gemini-3-pro-preview",
-                        "google/gemini-3-flash-preview"
-                    ],
-                    "name": "vertex-global-prod",
-                    "vertex_key_config": {
-                        "auth_credentials": "env.VERTEX_CREDENTIALS_GLOBAL",
-                        "project_id": "agentic-ai-project-1",
-                        "region": "global"
-                    },
-                    "weight": 1
-                }
-            ]
-        },
-        "openai": {
-            "keys": [
-                {
-                    "id": "key-openai-us-1-prod",
-                    "name": "openai-us-key-1-prod",
-                    "value": "env.OPENAI_API_KEY_US_EAST_1",
-                    "weight": 1,
-                    "models": ["*"]
-                }
-            ]
-        }
+    "disable_content_logging": false,
+    "drop_excess_requests": false,
+    "enable_logging": true,
+    "enforce_auth_on_inference": true,
+    "initial_pool_size": 300,
+    "log_retention_days": 365,
+    "max_request_body_size_mb": 100
+  },
+  "config_store": {
+    "config": {
+      "path": "../../examples/configs/withvirtualkeys/config.db"
+    },
+    "enabled": true,
+    "type": "sqlite"
+  },
+  "framework": {
+    "pricing": {
+      "pricing_sync_interval": 86400
     }
+  },
+  "governance": {
+    "auth_config": {
+      "admin_password": "env.BIFROST_ADMIN_PASSWORD",
+      "admin_username": "env.BIFROST_ADMIN_USERNAME",
+      "disable_auth_on_inference": true,
+      "is_enabled": false
+    },
+    "virtual_keys": [
+      {
+        "id": "sk-bf-vk-prod-assistant-us-01",
+        "is_active": true,
+        "name": "prod-assistant-us-key-01-configurations",
+        "provider_configs": [
+          {
+            "key_ids": [
+              "key-azure-us-1-prod"
+            ],
+            "allowed_models": [
+              "*"
+            ],
+            "provider": "azure",
+            "weight": 0.5
+          },
+          {
+            "key_ids": [
+              "key-vertex-us-east1-prod",
+              "key-vertex-global-prod"
+            ],
+            "allowed_models": [
+              "*"
+            ],
+            "provider": "vertex",
+            "weight": 0.5
+          },
+          {
+            "key_ids": [
+              "key-openai-us-1-prod"
+            ],
+            "allowed_models": [
+              "*"
+            ],
+            "provider": "openai",
+            "weight": 0.5
+          }
+        ],
+        "value": "env.BIFROST_VK_PROD_ASSISTANT_US_01"
+      },
+      {
+        "id": "sk-bf-vk-prod-assistant-eu-01",
+        "is_active": true,
+        "name": "prod-assistant-eu-key-01-configurations",
+        "provider_configs": [
+          {
+            "key_ids": [
+              "key-azure-eu-1-prod"
+            ],
+            "allowed_models": [
+              "*"
+            ],
+            "provider": "azure",
+            "weight": 0.5
+          },
+          {
+            "key_ids": [
+              "key-vertex-eu-west1-prod",
+              "key-vertex-global-prod"
+            ],
+            "allowed_models": [
+              "*"
+            ],
+            "provider": "vertex",
+            "weight": 0.5
+          },
+          {
+            "key_ids": [
+              "key-bedrock-eu-central-1-prod"
+            ],
+            "allowed_models": [
+              "*"
+            ],
+            "provider": "bedrock",
+            "weight": 0.5
+          }
+        ],
+        "value": "sk-bf-vk-prod-assistant-eu-01"
+      }
+    ]
+  },
+  "logs_store": {
+    "config": {
+      "path": "../../examples/configs/withvirtualkeys/logs.db"
+    },
+    "enabled": true,
+    "type": "sqlite"
+  },
+  "plugins": [
+    {
+      "config": {
+        "is_vk_mandatory": true
+      },
+      "enabled": true,
+      "name": "governance"
+    }
+  ],
+  "providers": {
+    "azure": {
+      "keys": [
+        {
+          "id": "key-azure-us-1-prod",
+          "azure_key_config": {
+            "api_version": "2025-03-01-preview",
+            "endpoint": "https://orca-prod-us-east-1.openai.azure.com/"
+          },
+          "models": [
+            "gpt-4.1",
+            "gpt-4.1-mini",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5.1"
+          ],
+          "name": "azure-us-key-1-prod",
+          "value": "env.AZURE_OPENAI_API_KEY_US_EAST_1",
+          "weight": 1
+        },
+        {
+          "id": "key-azure-us-2-prod",
+          "azure_key_config": {
+            "api_version": "2025-03-01-preview",
+            "endpoint": "https://orca-prod-us-east-2.openai.azure.com/"
+          },
+          "models": [
+            "gpt-4.1",
+            "gpt-4.1-mini",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5.1"
+          ],
+          "name": "azure-us-key-2-prod",
+          "value": "env.AZURE_OPENAI_API_KEY_US_EAST_2",
+          "weight": 1
+        },
+        {
+          "id": "key-azure-eu-1-prod",
+          "azure_key_config": {
+            "api_version": "2025-03-01-preview",
+            "endpoint": "https://orca-prod-eu-central-1.openai.azure.com/"
+          },
+          "models": [
+            "gpt-4.1",
+            "gpt-4.1-mini",
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5.1"
+          ],
+          "name": "azure-eu-key-1-prod",
+          "value": "env.AZURE_OPENAI_API_KEY_EU_CENTRAL_1",
+          "weight": 1
+        }
+      ]
+    },
+    "bedrock": {
+      "keys": [
+        {
+          "id": "key-bedrock-us-east-1-prod",
+          "bedrock_key_config": {
+            "access_key": "env.AWS_ACCESS_KEY_ID_US_EAST_1",
+            "region": "us-east-1",
+            "secret_key": "env.AWS_SECRET_ACCESS_KEY_US_EAST_1"
+          },
+          "models": [
+            "*"
+          ],
+          "name": "bedrock-us-east-1-prod",
+          "weight": 1
+        },
+        {
+          "id": "key-bedrock-us-west-2-prod",
+          "bedrock_key_config": {
+            "access_key": "env.AWS_ACCESS_KEY_ID_US_WEST_2",
+            "region": "us-west-2",
+            "secret_key": "env.AWS_SECRET_ACCESS_KEY_US_WEST_2"
+          },
+          "models": [
+            "*"
+          ],
+          "name": "bedrock-us-west-2-prod",
+          "weight": 1
+        },
+        {
+          "id": "key-bedrock-eu-central-1-prod",
+          "bedrock_key_config": {
+            "access_key": "env.AWS_ACCESS_KEY_ID_EU_CENTRAL_1",
+            "region": "eu-central-1",
+            "secret_key": "env.AWS_SECRET_ACCESS_KEY_EU_CENTRAL_1"
+          },
+          "models": [
+            "*"
+          ],
+          "name": "bedrock-eu-central-1-prod",
+          "weight": 1
+        }
+      ]
+    },
+    "vertex": {
+      "keys": [
+        {
+          "id": "key-vertex-us-east1-prod",
+          "models": [
+            "google/gemini-2.5-pro",
+            "google/gemini-2.5-flash-lite",
+            "google/gemini-2.5-flash"
+          ],
+          "name": "vertex-us-east1-prod",
+          "vertex_key_config": {
+            "auth_credentials": "env.VERTEX_CREDENTIALS_US_EAST1",
+            "project_id": "agentic-ai-project-1",
+            "region": "us-east1"
+          },
+          "weight": 1
+        },
+        {
+          "id": "key-vertex-eu-west1-prod",
+          "models": [
+            "google/gemini-2.5-pro",
+            "google/gemini-2.5-flash-lite",
+            "google/gemini-2.5-flash"
+          ],
+          "name": "vertex-europe-west1-prod",
+          "vertex_key_config": {
+            "auth_credentials": "env.VERTEX_CREDENTIALS_EUROPE_WEST1",
+            "project_id": "agentic-ai-project-1",
+            "region": "europe-west1"
+          },
+          "weight": 1
+        },
+        {
+          "id": "key-vertex-us-west1-prod",
+          "models": [
+            "google/gemini-2.5-pro",
+            "google/gemini-2.5-flash-lite",
+            "google/gemini-2.5-flash"
+          ],
+          "name": "vertex-us-west1-prod",
+          "vertex_key_config": {
+            "auth_credentials": "env.VERTEX_CREDENTIALS_US_WEST1",
+            "project_id": "agentic-ai-project-1",
+            "region": "us-west1"
+          },
+          "weight": 1
+        },
+        {
+          "id": "key-vertex-global-prod",
+          "models": [
+            "google/gemini-3-pro-preview",
+            "google/gemini-3-flash-preview"
+          ],
+          "name": "vertex-global-prod",
+          "vertex_key_config": {
+            "auth_credentials": "env.VERTEX_CREDENTIALS_GLOBAL",
+            "project_id": "agentic-ai-project-1",
+            "region": "global"
+          },
+          "weight": 1
+        }
+      ]
+    },
+    "openai": {
+      "keys": [
+        {
+          "id": "key-openai-us-1-prod",
+          "name": "openai-us-key-1-prod",
+          "value": "env.OPENAI_API_KEY_US_EAST_1",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -469,6 +469,43 @@ autoscaling:
   targetMemoryUtilizationPercentage: 80
 ```
 
+### Referencing Secrets in MCP Headers
+
+`bifrost.mcp.clientConfigs[].headers` is a free-form `map<string, string>`
+whose values can contain auth tokens. The chart does not wrap this map with
+a bespoke `secretRef` — a per-header dict would explode the values surface.
+Instead, use the standard pattern:
+
+1. Write `env.MY_HEADER_VAR` as the header value in `values.yaml`:
+   ```yaml
+   bifrost:
+     mcp:
+       clientConfigs:
+         - name: "my-mcp"
+           connectionType: "http"
+           headers:
+             Authorization: "env.MY_MCP_AUTH"
+   ```
+2. Inject the env var into the pod via the chart's top-level `envFrom:` or
+   `env:` pass-through — e.g., in `values.yaml`:
+   ```yaml
+   envFrom:
+     - secretRef:
+         name: my-mcp-auth-secret
+   # OR:
+   env:
+     - name: MY_MCP_AUTH
+       valueFrom:
+         secretKeyRef:
+           name: my-mcp-auth-secret
+           key: authorization
+   ```
+
+For `bifrost.mcp.clientConfigs[].connectionString` itself, prefer the
+chart-native `secretRef` (`name` + `connectionStringKey`) instead — the
+chart will inject `BIFROST_MCP_<NAME>_CONNECTION_STRING` and rewrite the
+config automatically.
+
 ## Example Configurations
 
 The chart includes pre-configured examples in `values-examples/`:

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -814,6 +814,11 @@ false
 {{- if hasKey $client "allowOnAllVirtualKeys" }}
 {{- $_ := set $cc "allow_on_all_virtual_keys" $client.allowOnAllVirtualKeys }}
 {{- end }}
+{{- /* Override connection_string with env var placeholder when secretRef is set */ -}}
+{{- if and $client.secretRef $client.secretRef.name }}
+{{- $envName := printf "BIFROST_MCP_%s_CONNECTION_STRING" (regexReplaceAll "[^A-Z0-9]+" (upper $client.name) "_") }}
+{{- $_ := set $cc "connection_string" (printf "env.%s" $envName) }}
+{{- end }}
 {{- $clientConfigs = append $clientConfigs $cc }}
 {{- end }}
 {{- $mcpConfig := dict "client_configs" $clientConfigs }}

--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -186,6 +186,18 @@ spec:
                   name: {{ .Values.bifrost.plugins.maxim.secretRef.name }}
                   key: {{ .Values.bifrost.plugins.maxim.secretRef.key | default "api-key" }}
             {{- end }}
+            {{- /* MCP client connection strings from existing secrets (one per client with secretRef.name set) */ -}}
+            {{- if .Values.bifrost.mcp.enabled }}
+            {{- range $idx, $client := .Values.bifrost.mcp.clientConfigs }}
+            {{- if and $client.secretRef $client.secretRef.name }}
+            - name: BIFROST_MCP_{{ regexReplaceAll "[^A-Z0-9]+" (upper $client.name) "_" }}_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $client.secretRef.name }}
+                  key: {{ $client.secretRef.connectionStringKey | default "connection-string" }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- /* Governance auth credentials from existing secret */ -}}
             {{- if and .Values.bifrost.governance .Values.bifrost.governance.authConfig .Values.bifrost.governance.authConfig.existingSecret }}
             - name: BIFROST_ADMIN_USERNAME

--- a/helm-charts/bifrost/templates/stateful.yaml
+++ b/helm-charts/bifrost/templates/stateful.yaml
@@ -186,6 +186,18 @@ spec:
                   name: {{ .Values.bifrost.plugins.maxim.secretRef.name }}
                   key: {{ .Values.bifrost.plugins.maxim.secretRef.key | default "api-key" }}
             {{- end }}
+            {{- /* MCP client connection strings from existing secrets (one per client with secretRef.name set) */ -}}
+            {{- if .Values.bifrost.mcp.enabled }}
+            {{- range $idx, $client := .Values.bifrost.mcp.clientConfigs }}
+            {{- if and $client.secretRef $client.secretRef.name }}
+            - name: BIFROST_MCP_{{ regexReplaceAll "[^A-Z0-9]+" (upper $client.name) "_" }}_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $client.secretRef.name }}
+                  key: {{ $client.secretRef.connectionStringKey | default "connection-string" }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- /* Governance auth credentials from existing secret */ -}}
             {{- if and .Values.bifrost.governance .Values.bifrost.governance.authConfig .Values.bifrost.governance.authConfig.existingSecret }}
             - name: BIFROST_ADMIN_USERNAME

--- a/helm-charts/bifrost/values-examples/providers-and-virtual-keys.yaml
+++ b/helm-charts/bifrost/values-examples/providers-and-virtual-keys.yaml
@@ -74,15 +74,15 @@ bifrost:
         - name: "openai-primary"
           value: "sk-dummy-openai-key-1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           weight: 2  # Gets 50% of traffic (2 out of 4 total weight)
-          models:
+          models: ["*"]
         - name: "openai-secondary"
           value: "sk-dummy-openai-key-2-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           weight: 1  # Gets 25% of traffic
-          models:
+          models: ["*"]
         - name: "openai-backup"
           value: "sk-dummy-openai-key-3-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           weight: 1  # Gets 25% of traffic
-          models:
+          models: ["*"]
 
     # Anthropic - 2 API keys
     anthropic:
@@ -90,11 +90,11 @@ bifrost:
         - name: "anthropic-primary"
           value: "sk-ant-dummy-key-1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           weight: 1
-          models:
+          models: ["*"]
         - name: "anthropic-secondary"
           value: "sk-ant-dummy-key-2-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           weight: 1
-          models:
+          models: ["*"]
 
     # Groq - 2 API keys
     groq:
@@ -102,11 +102,11 @@ bifrost:
         - name: "groq-primary"
           value: "gsk_dummy_groq_key_1_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           weight: 1
-          models:
+          models: ["*"]
         - name: "groq-secondary"
           value: "gsk_dummy_groq_key_2_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           weight: 1
-          models:
+          models: ["*"]
 
   # ==========================================================================
   # GOVERNANCE CONFIGURATION

--- a/helm-charts/bifrost/values-examples/secrets-from-k8s.yaml
+++ b/helm-charts/bifrost/values-examples/secrets-from-k8s.yaml
@@ -76,11 +76,13 @@ bifrost:
   providers:
     openai:
       keys:
-        - value: "env.OPENAI_API_KEY"
+        - name: "openai-primary"
+          value: "env.OPENAI_API_KEY"
           weight: 1
     anthropic:
       keys:
-        - value: "env.ANTHROPIC_API_KEY"
+        - name: "anthropic-primary"
+          value: "env.ANTHROPIC_API_KEY"
           weight: 1
   
   # Provider secrets - inject API keys from Kubernetes secrets as env vars

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -240,6 +240,15 @@
           "type": "string",
           "description": "Encryption key for sensitive data"
         },
+        "encryptionKeySecret": {
+          "type": "object",
+          "description": "Reference to an existing Kubernetes secret holding the encryption key. Takes precedence over `encryptionKey` when `name` is set.",
+          "properties": {
+            "name": { "type": "string" },
+            "key": { "type": "string", "default": "encryption-key" }
+          },
+          "additionalProperties": false
+        },
         "authConfig": {
           "$ref": "#/$defs/authConfig"
         },
@@ -900,7 +909,7 @@
                   },
                   "placement": {
                     "type": "string",
-                    "enum": ["pre_builtin", "post_builtin"],
+                    "enum": ["pre_builtin", "post_builtin", "builtin"],
                     "default": "post_builtin",
                     "description": "Plugin execution placement relative to built-in plugins"
                   },
@@ -2872,6 +2881,15 @@
         "connectionString": {
           "type": "string",
           "description": "HTTP or SSE URL (required for HTTP or SSE connections)"
+        },
+        "secretRef": {
+          "type": "object",
+          "description": "Reference to an existing Kubernetes secret holding the MCP connection_string. Chart injects BIFROST_MCP_<NAME>_CONNECTION_STRING and rewrites connection_string in config.json.",
+          "properties": {
+            "name": { "type": "string" },
+            "connectionStringKey": { "type": "string", "default": "connection-string" }
+          },
+          "additionalProperties": false
         },
         "authType": {
           "type": "string",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -163,6 +163,14 @@ bifrost:
   # Can be set as a secret or environment variable
   encryptionKey: ""
 
+  # Use an existing Kubernetes secret for the encryption key.
+  # When `name` is set, takes precedence over `encryptionKey`: the chart
+  # injects BIFROST_ENCRYPTION_KEY into the pod via secretKeyRef and writes
+  # `encryption_key: "env.BIFROST_ENCRYPTION_KEY"` in the rendered config.json.
+  encryptionKeySecret:
+    name: ""
+    key: "encryption-key"
+
   # Authentication configuration (top-level)
   # This controls authentication for Bifrost API and dashboard
   authConfig:
@@ -323,6 +331,13 @@ bifrost:
       #     command: "/path/to/mcp/server"
       #     args: []
       #     envs: []
+      #   # Optional: source connection_string from a Kubernetes secret.
+      #   # When set, chart injects BIFROST_MCP_<NAME>_CONNECTION_STRING
+      #   # into the pod and rewrites connection_string in config.json
+      #   # to `env.BIFROST_MCP_<NAME>_CONNECTION_STRING`.
+      #   secretRef:
+      #     name: ""                               # k8s secret name
+      #     connectionStringKey: "connection-string"  # key within the secret
     # toolSyncInterval: "10m"   # Global tool sync interval (Go duration)
     # Tool manager configuration
     toolManagerConfig:

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -13,7 +13,10 @@
     "version": {
       "type": "integer",
       "description": "Controls how empty arrays in allow-list fields (models, allowed_models, key_ids, tools_to_execute) are interpreted. Omit or set to 2 for v1.5.0+ semantics: empty = deny all, [\"*\"] = allow all. Set to 1 to restore v1.4.x semantics: empty = allow all.",
-      "enum": [1, 2],
+      "enum": [
+        1,
+        2
+      ],
       "default": 2
     },
     "encryption_key": {
@@ -564,7 +567,7 @@
           "type": "array",
           "description": "Scoped pricing overrides applied at runtime by the model catalog",
           "items": {
-            "$ref": "#/$defs/pricing_override"
+            "$ref": "#/$defs/provider_pricing_override"
           }
         },
         "auth_config": {
@@ -610,9 +613,17 @@
           "items": {
             "type": "object",
             "properties": {
+              "id": {
+                "type": "string",
+                "description": "Provider row ID"
+              },
               "name": {
                 "type": "string",
                 "description": "Provider name"
+              },
+              "description": {
+                "type": "string",
+                "description": "Operator-facing provider description"
               },
               "budget_id": {
                 "type": "string",
@@ -633,6 +644,21 @@
               "store_raw_request_response": {
                 "type": "boolean",
                 "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
+              },
+              "network_config": {
+                "$ref": "#/$defs/network_config"
+              },
+              "proxy_config": {
+                "$ref": "#/$defs/proxy_config"
+              },
+              "custom_provider_config": {
+                "$ref": "#/$defs/custom_provider_config"
+              },
+              "concurrency_and_buffer_size": {
+                "$ref": "#/$defs/concurrency_and_buffer_size"
+              },
+              "openai_config": {
+                "$ref": "#/$defs/openai_config"
               }
             },
             "required": [
@@ -947,7 +973,10 @@
           "properties": {
             "type": {
               "type": "string",
-              "enum": ["s3", "gcs"],
+              "enum": [
+                "s3",
+                "gcs"
+              ],
               "description": "Object storage backend type"
             },
             "bucket": {
@@ -966,9 +995,16 @@
               "default": false
             }
           },
-          "required": ["type", "bucket"],
+          "required": [
+            "type",
+            "bucket"
+          ],
           "if": {
-            "properties": { "type": { "const": "s3" } }
+            "properties": {
+              "type": {
+                "const": "s3"
+              }
+            }
           },
           "then": {
             "properties": {
@@ -1007,9 +1043,16 @@
               "compress": true
             },
             "dependentRequired": {
-              "access_key_id": ["secret_access_key"],
-              "secret_access_key": ["access_key_id"],
-              "session_token": ["access_key_id", "secret_access_key"]
+              "access_key_id": [
+                "secret_access_key"
+              ],
+              "secret_access_key": [
+                "access_key_id"
+              ],
+              "session_token": [
+                "access_key_id",
+                "secret_access_key"
+              ]
             },
             "additionalProperties": false
           },
@@ -1022,25 +1065,26 @@
                 "type": "string",
                 "description": "GCP service account credentials JSON or file path. Omit to use Application Default Credentials. Supports env var reference"
               },
+              "credentials": {
+                "type": "string",
+                "description": "Deprecated: use credentials_json. Kept for backwards compatibility."
+              },
+              "project_id": {
+                "type": "string",
+                "description": "GCP project ID override. Supports env var reference"
+              },
               "compress": true
             },
             "additionalProperties": false
           }
+        },
+        "retention_days": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Days to retain log entries. 0 disables retention-based cleanup."
         }
       },
       "additionalProperties": false
-    },
-    "cluster_config": {
-      "$ref": "#/$defs/cluster_config"
-    },
-    "saml_config": {
-      "$ref": "#/$defs/saml_config"
-    },
-    "load_balancer_config": {
-      "$ref": "#/$defs/load_balancer_config"
-    },
-    "guardrails_config": {
-      "$ref": "#/$defs/guardrails_config"
     },
     "plugins": {
       "type": "array",
@@ -1080,9 +1124,10 @@
             "type": "string",
             "enum": [
               "pre_builtin",
-              "post_builtin"
+              "post_builtin",
+              "builtin"
             ],
-            "description": "Whether this plugin runs before or after built-in plugins. Default: post_builtin",
+            "description": "Whether this plugin runs before, after, or as a built-in. Default: post_builtin",
             "optional": true,
             "default": "post_builtin"
           },
@@ -1345,7 +1390,7 @@
                       "oneOf": [
                         {
                           "type": "string",
-                          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$"
+                          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$"
                         },
                         {
                           "type": "integer",
@@ -1595,12 +1640,6 @@
         "additionalProperties": false
       }
     },
-    "audit_logs": {
-      "$ref": "#/$defs/audit_logs_config"
-    },
-    "large_payload_optimization": {
-      "$ref": "#/$defs/large_payload_optimization"
-    },
     "websocket": {
       "$ref": "#/$defs/websocket_config"
     }
@@ -1662,6 +1701,11 @@
         "cel_expression": {
           "type": "string",
           "description": "CEL (Common Expression Language) expression for rule evaluation"
+        },
+        "chain_rule": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, re-evaluates routing chain after this rule matches"
         },
         "targets": {
           "type": "array",
@@ -1775,249 +1819,9 @@
         },
         "key_ids": {
           "type": "array",
-          "description": "Keys allowed for this provider config. Use [\"*\"] to allow all keys; empty array denies all (deny-by-default). In config.json, values are key names. Via the API, values are key UUIDs.",
+          "description": "Key identifiers allowed for this provider config. Use [\"*\"] to allow all keys; empty array denies all (deny-by-default). In config.json, values are key names. Via the API, values are key UUIDs.",
           "items": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "integer",
-                "description": "Key database ID (auto-generated)"
-              },
-              "key_id": {
-                "type": "string",
-                "description": "Key UUID identifier"
-              },
-              "name": {
-                "type": "string",
-                "description": "Key name (must be unique)"
-              },
-              "value": {
-                "type": "string",
-                "description": "API key value (can use env. prefix)"
-              },
-              "models": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "Supported models for this key"
-              },
-              "weight": {
-                "type": "number",
-                "minimum": 0,
-                "default": 1.0,
-                "description": "Weight for load balancing"
-              },
-              "azure_key_config": {
-                "type": "object",
-                "properties": {
-                  "endpoint": {
-                    "type": "string",
-                    "description": "Azure endpoint (can use env. prefix)"
-                  },
-                  "deployments": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Model to deployment mappings"
-                  },
-                  "api_version": {
-                    "type": "string",
-                    "description": "Azure API version"
-                  }
-                },
-                "required": [
-                  "endpoint"
-                ],
-                "additionalProperties": false
-              },
-              "vertex_key_config": {
-                "type": "object",
-                "properties": {
-                  "project_id": {
-                    "type": "string",
-                    "description": "Google Cloud project ID (can use env. prefix)"
-                  },
-                  "project_number": {
-                    "type": "string",
-                    "description": "Google Cloud project number"
-                  },
-                  "region": {
-                    "type": "string",
-                    "description": "Google Cloud region"
-                  },
-                  "auth_credentials": {
-                    "type": "string",
-                    "description": "Authentication credentials (can use env. prefix)"
-                  },
-                  "deployments": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Model to deployment mappings"
-                  }
-                },
-                "required": [
-                  "project_id",
-                  "region"
-                ],
-                "additionalProperties": false
-              },
-              "bedrock_key_config": {
-                "type": "object",
-                "properties": {
-                  "access_key": {
-                    "type": "string",
-                    "description": "AWS access key (can use env. prefix)"
-                  },
-                  "secret_key": {
-                    "type": "string",
-                    "description": "AWS secret key (can use env. prefix)"
-                  },
-                  "session_token": {
-                    "type": "string",
-                    "description": "AWS session token (can use env. prefix)"
-                  },
-                  "region": {
-                    "type": "string",
-                    "description": "AWS region"
-                  },
-                  "arn": {
-                    "type": "string",
-                    "description": "AWS ARN"
-                  },
-                  "role_arn": {
-                    "type": "string",
-                    "description": "AWS IAM role ARN for AssumeRole (can use env. prefix)"
-                  },
-                  "external_id": {
-                    "type": "string",
-                    "description": "External ID for AssumeRole (can use env. prefix)"
-                  },
-                  "session_name": {
-                    "type": "string",
-                    "description": "Role session name for AssumeRole (can use env. prefix)"
-                  },
-                  "deployments": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "Model to deployment mappings"
-                  },
-                  "batch_s3_config": {
-                    "type": "object",
-                    "description": "S3 bucket configuration for Bedrock batch operations",
-                    "properties": {
-                      "buckets": {
-                        "type": "array",
-                        "description": "List of S3 bucket configurations",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "bucket_name": {
-                              "type": "string",
-                              "description": "S3 bucket name"
-                            },
-                            "prefix": {
-                              "type": "string",
-                              "description": "S3 key prefix for batch files"
-                            },
-                            "is_default": {
-                              "type": "boolean",
-                              "description": "Whether this is the default bucket for batch operations"
-                            }
-                          },
-                          "required": ["bucket_name"],
-                          "additionalProperties": false
-                        }
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                },
-                "additionalProperties": false
-              },
-              "vllm_key_config": {
-                "type": "object",
-                "properties": {
-                  "url": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "VLLM server base URL (can use env. prefix)"
-                  },
-                  "model_name": {
-                    "type": "string",
-                    "minLength": 1,
-                    "description": "Exact model name served on this VLLM instance"
-                  }
-                },
-                "required": [
-                  "url",
-                  "model_name"
-                ],
-                "additionalProperties": false
-              }
-            },
-            "oneOf": [
-              {
-                "not": {
-                  "anyOf": [
-                    { "required": ["azure_key_config"] },
-                    { "required": ["vertex_key_config"] },
-                    { "required": ["bedrock_key_config"] },
-                    { "required": ["vllm_key_config"] }
-                  ]
-                }
-              },
-              {
-                "required": ["azure_key_config"],
-                "not": {
-                  "anyOf": [
-                    { "required": ["vertex_key_config"] },
-                    { "required": ["bedrock_key_config"] },
-                    { "required": ["vllm_key_config"] }
-                  ]
-                }
-              },
-              {
-                "required": ["vertex_key_config"],
-                "not": {
-                  "anyOf": [
-                    { "required": ["azure_key_config"] },
-                    { "required": ["bedrock_key_config"] },
-                    { "required": ["vllm_key_config"] }
-                  ]
-                }
-              },
-              {
-                "required": ["bedrock_key_config"],
-                "not": {
-                  "anyOf": [
-                    { "required": ["azure_key_config"] },
-                    { "required": ["vertex_key_config"] },
-                    { "required": ["vllm_key_config"] }
-                  ]
-                }
-              },
-              {
-                "required": ["vllm_key_config"],
-                "not": {
-                  "anyOf": [
-                    { "required": ["azure_key_config"] },
-                    { "required": ["vertex_key_config"] },
-                    { "required": ["bedrock_key_config"] }
-                  ]
-                }
-              }
-            ],
-            "required": [
-              "key_id",
-              "name",
-              "value"
-            ]
+            "type": "string"
           }
         }
       },
@@ -2044,7 +1848,7 @@
         },
         "mcp_client_name": {
           "type": "string",
-          "description": "MCP client name (config file format — resolved to mcp_client_id at startup)"
+          "description": "MCP client name (config file format \u2014 resolved to mcp_client_id at startup)"
         },
         "tools_to_execute": {
           "type": "array",
@@ -2123,15 +1927,19 @@
           "minimum": 0,
           "description": "Maximum number of retries"
         },
-        "retry_backoff_initial_ms": {
+        "retry_backoff_initial": {
           "type": "integer",
           "minimum": 0,
           "description": "Initial retry backoff in milliseconds"
         },
-        "retry_backoff_max_ms": {
+        "retry_backoff_max": {
           "type": "integer",
           "minimum": 0,
           "description": "Maximum retry backoff in milliseconds"
+        },
+        "enforce_http2": {
+          "type": "boolean",
+          "description": "Force HTTP/2 on provider connections (relevant for Bedrock and other net/http-based providers)"
         },
         "insecure_skip_verify": {
           "type": "boolean",
@@ -2183,15 +1991,19 @@
           "minimum": 0,
           "description": "Maximum number of retries"
         },
-        "retry_backoff_initial_ms": {
+        "retry_backoff_initial": {
           "type": "integer",
           "minimum": 0,
           "description": "Initial retry backoff in milliseconds"
         },
-        "retry_backoff_max_ms": {
+        "retry_backoff_max": {
           "type": "integer",
           "minimum": 0,
           "description": "Maximum retry backoff in milliseconds"
+        },
+        "enforce_http2": {
+          "type": "boolean",
+          "description": "Force HTTP/2 on provider connections (relevant for Bedrock and other net/http-based providers)"
         },
         "insecure_skip_verify": {
           "type": "boolean",
@@ -2223,7 +2035,18 @@
       },
       "additionalProperties": false
     },
-    "concurrency_config": {
+    "openai_config": {
+      "type": "object",
+      "description": "OpenAI-specific provider settings",
+      "properties": {
+        "disable_store": {
+          "type": "boolean",
+          "description": "Disable OpenAI Responses API conversation storage."
+        }
+      },
+      "additionalProperties": false
+    },
+    "concurrency_and_buffer_size": {
       "type": "object",
       "properties": {
         "concurrency": {
@@ -2361,7 +2184,9 @@
                             "description": "Whether this is the default bucket for batch operations"
                           }
                         },
-                        "required": ["bucket_name"],
+                        "required": [
+                          "bucket_name"
+                        ],
                         "additionalProperties": false
                       }
                     }
@@ -2374,10 +2199,7 @@
               ],
               "additionalProperties": false
             }
-          },
-          "required": [
-            "bedrock_key_config"
-          ]
+          }
         }
       ]
     },
@@ -2585,7 +2407,7 @@
           "$ref": "#/$defs/network_config"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_config"
+          "$ref": "#/$defs/concurrency_and_buffer_size"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2626,7 +2448,7 @@
           "$ref": "#/$defs/network_config"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_config"
+          "$ref": "#/$defs/concurrency_and_buffer_size"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2667,48 +2489,7 @@
           "$ref": "#/$defs/network_config_without_base_url"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_config"
-        },
-        "proxy_config": {
-          "$ref": "#/$defs/proxy_config"
-        },
-        "send_back_raw_request": {
-          "type": "boolean",
-          "description": "Include raw request in BifrostResponse (default: false)"
-        },
-        "send_back_raw_response": {
-          "type": "boolean",
-          "description": "Include raw response in BifrostResponse (default: false)"
-        },
-        "store_raw_request_response": {
-          "type": "boolean",
-          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
-        },
-        "custom_provider_config": {
-          "$ref": "#/$defs/custom_provider_config"
-        }
-      },
-      "required": [
-        "keys"
-      ],
-      "additionalProperties": false
-    },
-    "provider_with_replicate_config": {
-      "type": "object",
-      "properties": {
-        "keys": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/replicate_key"
-          },
-          "minItems": 1,
-          "description": "API keys for this provider"
-        },
-        "network_config": {
-          "$ref": "#/$defs/network_config_without_base_url"
-        },
-        "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_config"
+          "$ref": "#/$defs/concurrency_and_buffer_size"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2749,7 +2530,7 @@
           "$ref": "#/$defs/network_config"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_config"
+          "$ref": "#/$defs/concurrency_and_buffer_size"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2790,7 +2571,7 @@
           "$ref": "#/$defs/network_config"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_config"
+          "$ref": "#/$defs/concurrency_and_buffer_size"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2831,7 +2612,7 @@
           "$ref": "#/$defs/network_config"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_config"
+          "$ref": "#/$defs/concurrency_and_buffer_size"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2872,7 +2653,7 @@
           "$ref": "#/$defs/network_config_without_base_url"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_config"
+          "$ref": "#/$defs/concurrency_and_buffer_size"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2913,7 +2694,7 @@
           "$ref": "#/$defs/network_config_without_base_url"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_config"
+          "$ref": "#/$defs/concurrency_and_buffer_size"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2958,9 +2739,9 @@
           "type": "string",
           "enum": [
             "stdio",
-            "websocket",
             "http",
-            "sse"
+            "sse",
+            "inprocess"
           ],
           "description": "Connection type for MCP client"
         },
@@ -3016,34 +2797,6 @@
           ],
           "additionalProperties": false
         },
-        "websocket_config": {
-          "type": "object",
-          "properties": {
-            "url": {
-              "type": "string",
-              "format": "uri",
-              "description": "WebSocket URL"
-            }
-          },
-          "required": [
-            "url"
-          ],
-          "additionalProperties": false
-        },
-        "http_config": {
-          "type": "object",
-          "properties": {
-            "url": {
-              "type": "string",
-              "format": "uri",
-              "description": "HTTP URL"
-            }
-          },
-          "required": [
-            "url"
-          ],
-          "additionalProperties": false
-        },
         "tools_to_execute": {
           "type": "array",
           "items": {
@@ -3096,13 +2849,20 @@
       "if": {
         "properties": {
           "auth_type": {
-            "enum": ["oauth", "per_user_oauth"]
+            "enum": [
+              "oauth",
+              "per_user_oauth"
+            ]
           }
         },
-        "required": ["auth_type"]
+        "required": [
+          "auth_type"
+        ]
       },
       "then": {
-        "required": ["oauth_config_id"]
+        "required": [
+          "oauth_config_id"
+        ]
       },
       "oneOf": [
         {
@@ -3221,7 +2981,7 @@
         },
         "timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
           "description": "Timeout for Weaviate operations (e.g., '5s')"
         },
         "class_name": {
@@ -3300,32 +3060,32 @@
         },
         "conn_max_lifetime": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
           "description": "Connection maximum lifetime (e.g., '30m')"
         },
         "conn_max_idle_time": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
           "description": "Connection maximum idle time (e.g., '5m')"
         },
         "dial_timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
           "description": "Timeout for socket connection (e.g., '5s')"
         },
         "read_timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
           "description": "Timeout for socket reads (e.g., '3s')"
         },
         "write_timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
           "description": "Timeout for socket writes (e.g., '3s')"
         },
         "context_timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
           "description": "Timeout for Redis operations (e.g., '10s')"
         }
       },
@@ -3993,7 +3753,7 @@
       },
       "additionalProperties": false
     },
-    "pricing_override": {
+    "provider_pricing_override": {
       "type": "object",
       "description": "Scoped pricing override applied at runtime by the model catalog",
       "properties": {
@@ -4102,7 +3862,39 @@
         },
         "base_provider_type": {
           "type": "string",
+          "enum": [
+            "openai",
+            "azure",
+            "anthropic",
+            "bedrock",
+            "cohere",
+            "vertex",
+            "mistral",
+            "ollama",
+            "groq",
+            "sgl",
+            "parasail",
+            "perplexity",
+            "cerebras",
+            "gemini",
+            "openrouter",
+            "elevenlabs",
+            "huggingface",
+            "nebius",
+            "xai",
+            "replicate",
+            "vllm",
+            "runway",
+            "fireworks"
+          ],
           "description": "Base provider type to extend"
+        },
+        "request_path_overrides": {
+          "type": "object",
+          "description": "Mapping of request type to custom path overriding the default provider path",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "allowed_requests": {
           "type": "object",
@@ -4136,6 +3928,9 @@
               "type": "boolean"
             },
             "rerank": {
+              "type": "boolean"
+            },
+            "ocr": {
               "type": "boolean"
             },
             "speech": {
@@ -4257,13 +4052,6 @@
             }
           },
           "additionalProperties": false
-        },
-        "request_path_overrides": {
-          "type": "object",
-          "description": "Mapping of request type to custom path overriding the default provider path",
-          "additionalProperties": {
-            "type": "string"
-          }
         }
       },
       "required": [


### PR DESCRIPTION
## Summary

Adds a new Go-based schema synchronization tool (`schemasync`) to validate that Go config types stay in sync with `config.schema.json`. The tool recursively walks Go struct types via AST analysis to ensure field names, types, and enum values match between Go code and JSON schema definitions.

## Changes

- **New schemasync tool**: Created `.github/workflows/scripts/schemasync/` with a Go program that uses `go/types` to analyze config structs and compare them against the JSON schema
- **CI integration**: Added schemasync validation step to the helm-release workflow with Go 1.26 setup
- **Enhanced MCP secret support**: Added `secretRef` configuration for MCP client connection strings in helm charts, allowing Kubernetes secret injection
- **Schema updates**: Updated `config.schema.json` and `values.schema.json` to reflect recent Go type changes including:
  - Renamed `concurrency_config` to `concurrency_and_buffer_size`
  - Added new provider fields (`id`, `description`, network/proxy configs)
  - Updated plugin placement enum to include `builtin`
  - Added `chain_rule` field for routing rules
  - Removed unused MCP websocket/http config objects
- **Validation script updates**: Modified existing helm schema validation to account for renamed types and removed obsolete checks

## Type of change

- [x] Feature
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

The schemasync tool runs automatically in CI. To test locally:

```sh
# Run the schema sync validation
.github/workflows/scripts/validate-schema-sync.sh

# Run existing helm schema validation
.github/workflows/scripts/validate-helm-config-fields.sh

# Test MCP secret injection in helm charts
helm template helm-charts/bifrost --values test-values.yaml
```

The tool validates:
- Go struct fields have corresponding JSON schema properties
- Enum constants in Go match schema enum arrays
- EnvVar-typed fields have helm chart secret support

## Screenshots/Recordings

N/A - This is a validation tool and schema update.

## Breaking changes

- [ ] Yes
- [x] No

The changes are additive validation tooling and schema updates that maintain backward compatibility.

## Related issues

This addresses the need for automated validation between Go config types and JSON schemas to prevent drift during development.

## Security considerations

- The schemasync tool validates that EnvVar-typed fields (which may contain secrets) have proper Kubernetes secret injection support in helm charts
- Added MCP connection string secret reference capability to avoid hardcoding sensitive connection details

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable