### PR TITLE
fixed helm-release action

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -38,9 +38,9 @@ jobs:
           version: v4.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: "1.26"
+          go-version: "1.26.2"
 
       - name: Run chart-testing (lint)
         run: |


### PR DESCRIPTION
## Summary

Updates the Helm release workflow to use a more recent version of the Go setup action and patches the Go version to address potential compatibility issues.

## Changes

- Updated `actions/setup-go` from v5 to v6.3.0 with pinned commit hash for security
- Bumped Go version from "1.26" to "1.26.2" to include latest patch fixes

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Verify the GitHub Actions workflow runs successfully with the updated Go setup:

```sh
# Trigger the helm-release workflow and verify it completes
# Check that Go 1.26.2 is properly installed in the CI environment
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The action is now pinned to a specific commit hash to prevent supply chain attacks through action updates.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable