### PR TITLE
fixes validate schema from config.go

### DIFF
--- a/.github/workflows/scripts/validate-schema-sync.sh
+++ b/.github/workflows/scripts/validate-schema-sync.sh
@@ -20,6 +20,12 @@ if ! command -v go >/dev/null 2>&1; then
   exit 2
 fi
 
+# Ensure go.work exists. Matches the convention used by every other
+# Go-touching CI wrapper (test-bifrost-http.sh, test-all-plugins.sh, etc.)
+# — setup-go-workspace.sh is idempotent: returns early when go.work is
+# already present, so local developers aren't re-initialised.
+source "$SCRIPT_DIR/setup-go-workspace.sh"
+
 echo "🔍 Validating Go ↔ config.schema.json sync (recursive, AST-based)"
 echo "=================================================================="
 


### PR DESCRIPTION
## Summary

Adds Go workspace initialization to the schema validation script to ensure consistency with other CI workflows and prevent build failures when `go.work` is missing.

## Changes

- Added call to `setup-go-workspace.sh` in `validate-schema-sync.sh` to ensure Go workspace is properly initialized
- Follows the same pattern used by other Go-related CI scripts (`test-bifrost-http.sh`, `test-all-plugins.sh`)
- The setup script is idempotent, so it won't reinitialize existing workspaces for local developers

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the schema validation script to ensure it properly initializes the Go workspace:

```sh
.github/workflows/scripts/validate-schema-sync.sh
```

Verify that `go.work` is created if it doesn't exist, and that the script runs successfully without workspace-related errors.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects CI workspace setup.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable