### PR TITLE
fix: added the .next entry back to .gitignore for backward compatibility.

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -14,6 +14,7 @@
 /coverage
 
 # build output
+/.next/
 /out/
 
 # production


### PR DESCRIPTION
## Summary

Add `.next/` directory to gitignore to prevent Next.js build artifacts from being tracked in version control.

## Changes

- Added `/.next/` to the UI gitignore file under the build output section
- Ensures Next.js build cache and generated files are excluded from git tracking

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Verify that `.next/` directory is properly ignored after building the UI:

```sh
# UI
cd ui
pnpm i || npm i
pnpm build || npm run build
git status # Should not show .next/ directory as untracked
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects which files are tracked by git.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable