### PR TITLE
fix: [DO NOT MERGE]delete fallbacks from anthropic req

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4465,10 +4465,10 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 		bifrost.releaseChannelMessage(msg)
 		// Checking if need to drop raw messages
 		// This we use for requests like containers, container files, skills etc.
-		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop && resp != nil {
-			extraField := resp.GetExtraFields()
-			extraField.RawRequest = nil
-			extraField.RawResponse = nil
+		if resp != nil {
+			dropReq, _ := ctx.Value(schemas.BifrostContextKeyRawRequestForLogging).(bool)
+			dropResp, _ := ctx.Value(schemas.BifrostContextKeyRawResponseForLogging).(bool)
+			resp.GetExtraFields().StripRaw(dropReq, dropResp)
 		}
 		return resp, nil
 	case bifrostErrVal := <-msg.Err:
@@ -4476,16 +4476,13 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 		resp, bifrostErrPtr = pipeline.RunPostLLMHooks(msg.Context, nil, bifrostErrPtr, pluginCount)
 		bifrost.releaseChannelMessage(msg)
 		// Drop raw request/response on error path too
-		if drop, ok := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool); ok && drop {
-			if bifrostErrPtr != nil {
-				bifrostErrPtr.ExtraFields.RawRequest = nil
-				bifrostErrPtr.ExtraFields.RawResponse = nil
-			}
-			if resp != nil {
-				extraField := resp.GetExtraFields()
-				extraField.RawRequest = nil
-				extraField.RawResponse = nil
-			}
+		dropReq, _ := ctx.Value(schemas.BifrostContextKeyRawRequestForLogging).(bool)
+		dropResp, _ := ctx.Value(schemas.BifrostContextKeyRawResponseForLogging).(bool)
+		if bifrostErrPtr != nil {
+			bifrostErrPtr.ExtraFields.StripRaw(dropReq, dropResp)
+		}
+		if resp != nil {
+			resp.GetExtraFields().StripRaw(dropReq, dropResp)
 		}
 		if bifrostErrPtr != nil {
 			return nil, bifrostErrPtr
@@ -4953,24 +4950,16 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, !IsStandardProvider(baseProvider))
 
 		// Determine whether this provider attempt should capture raw payloads.
-		// logging-only mode (store_raw_request_response=true, send_back_raw_*=false):
-		//   sets BifrostContextKeySendBackRaw* = true so providers capture via the unified
-		//   ShouldSendBackRaw* path, and sets BifrostContextKeyRawRequestResponseForLogging
-		//   so the payload is stripped before the response reaches the client.
-		// full send-back mode (send_back_raw_request/response=true):
-		//   BifrostContextKeySendBackRaw* are set as before; stripping flag stays false.
-		// Always set both flags explicitly so stale values from a previous provider
-		// attempt (e.g. first attempt was logging-only, fallback is full send-back)
-		// cannot leak into the new attempt on a reused context.
 		existingSendBackReq, _ := req.Context.Value(schemas.BifrostContextKeySendBackRawRequest).(bool)
 		existingSendBackResp, _ := req.Context.Value(schemas.BifrostContextKeySendBackRawResponse).(bool)
-		loggingOnly := config.StoreRawRequestResponse &&
-			!config.SendBackRawRequest && !existingSendBackReq &&
-			!config.SendBackRawResponse && !existingSendBackResp
-		req.Context.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, loggingOnly)
-		if loggingOnly {
-			// Enable capture via the standard flags so ShouldSendBackRaw* needs only one check.
+		loggingOnlyReq := config.StoreRawRequestResponse && !config.SendBackRawRequest && !existingSendBackReq
+		loggingOnlyResp := config.StoreRawRequestResponse && !config.SendBackRawResponse && !existingSendBackResp
+		req.Context.SetValue(schemas.BifrostContextKeyRawRequestForLogging, loggingOnlyReq)
+		req.Context.SetValue(schemas.BifrostContextKeyRawResponseForLogging, loggingOnlyResp)
+		if loggingOnlyReq || config.SendBackRawRequest || existingSendBackReq {
 			req.Context.SetValue(schemas.BifrostContextKeySendBackRawRequest, true)
+		}
+		if loggingOnlyResp || config.SendBackRawResponse || existingSendBackResp {
 			req.Context.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
 		}
 

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -235,6 +235,11 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 			}
 		}
 	}
+	// not part of Anthropic's API
+	jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "fallbacks")
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+	}
 	return jsonBody, nil
 }
 

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1737,12 +1737,13 @@ func SendInProgressEventResponsesChunk(ctx *schemas.BifrostContext, postHookRunn
 
 // BuildClientStreamChunk constructs a BifrostStreamChunk from post-hook results.
 // It never mutates the shared processedResponse or processedError objects — when in
-// logging-only mode (BifrostContextKeyRawRequestResponseForLogging) it shallow-copies
+// logging-only mode (BifrostContextKeyRawRequestForLogging and BifrostContextKeyRawResponseForLogging) it shallow-copies
 // each inner response struct and the BifrostError, nils only the raw fields on those
 // copies, and returns them as the outgoing chunk. This is safe for concurrent PostLLMHook
 // goroutines that still hold references to the originals.
 func BuildClientStreamChunk(ctx context.Context, processedResponse *schemas.BifrostResponse, processedError *schemas.BifrostError) *schemas.BifrostStreamChunk {
-	dropRaw, _ := ctx.Value(schemas.BifrostContextKeyRawRequestResponseForLogging).(bool)
+	dropReq, _ := ctx.Value(schemas.BifrostContextKeyRawRequestForLogging).(bool)
+	dropResp, _ := ctx.Value(schemas.BifrostContextKeyRawResponseForLogging).(bool)
 	streamResponse := &schemas.BifrostStreamChunk{}
 	if processedResponse != nil {
 		streamResponse.BifrostTextCompletionResponse = processedResponse.TextCompletionResponse
@@ -1753,51 +1754,44 @@ func BuildClientStreamChunk(ctx context.Context, processedResponse *schemas.Bifr
 		streamResponse.BifrostImageGenerationStreamResponse = processedResponse.ImageGenerationStreamResponse
 		// Strip raw fields from client-facing copies without mutating the shared objects
 		// that PostLLMHook goroutines may still be reading.
-		if dropRaw {
+		if dropReq || dropResp {
 			if streamResponse.BifrostTextCompletionResponse != nil {
 				cp := *streamResponse.BifrostTextCompletionResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
+				cp.ExtraFields.StripRaw(dropReq, dropResp)
 				streamResponse.BifrostTextCompletionResponse = &cp
 			}
 			if streamResponse.BifrostChatResponse != nil {
 				cp := *streamResponse.BifrostChatResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
+				cp.ExtraFields.StripRaw(dropReq, dropResp)
 				streamResponse.BifrostChatResponse = &cp
 			}
 			if streamResponse.BifrostResponsesStreamResponse != nil {
 				cp := *streamResponse.BifrostResponsesStreamResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
+				cp.ExtraFields.StripRaw(dropReq, dropResp)
 				streamResponse.BifrostResponsesStreamResponse = &cp
 			}
 			if streamResponse.BifrostSpeechStreamResponse != nil {
 				cp := *streamResponse.BifrostSpeechStreamResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
+				cp.ExtraFields.StripRaw(dropReq, dropResp)
 				streamResponse.BifrostSpeechStreamResponse = &cp
 			}
 			if streamResponse.BifrostTranscriptionStreamResponse != nil {
 				cp := *streamResponse.BifrostTranscriptionStreamResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
+				cp.ExtraFields.StripRaw(dropReq, dropResp)
 				streamResponse.BifrostTranscriptionStreamResponse = &cp
 			}
 			if streamResponse.BifrostImageGenerationStreamResponse != nil {
 				cp := *streamResponse.BifrostImageGenerationStreamResponse
-				cp.ExtraFields.RawRequest = nil
-				cp.ExtraFields.RawResponse = nil
+				cp.ExtraFields.StripRaw(dropReq, dropResp)
 				streamResponse.BifrostImageGenerationStreamResponse = &cp
 			}
 		}
 	}
 	if processedError != nil {
-		if dropRaw {
+		if dropReq || dropResp {
 			// Strip raw fields from a client-facing copy without mutating the shared error object.
 			errCopy := *processedError
-			errCopy.ExtraFields.RawRequest = nil
-			errCopy.ExtraFields.RawResponse = nil
+			errCopy.ExtraFields.StripRaw(dropReq, dropResp)
 			streamResponse.BifrostError = &errCopy
 		} else {
 			streamResponse.BifrostError = processedError

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -1105,9 +1105,10 @@ func TestBuildClientStreamChunk_ImageGenerationStripping(t *testing.T) {
 
 	response := &schemas.BifrostResponse{ImageGenerationStreamResponse: imgResp}
 
-	t.Run("logging-only: raw fields stripped from image gen chunk, original preserved", func(t *testing.T) {
+	t.Run("both logging-only: both raw fields stripped, original preserved", func(t *testing.T) {
 		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-		ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+		ctx.SetValue(schemas.BifrostContextKeyRawRequestForLogging, true)
+		ctx.SetValue(schemas.BifrostContextKeyRawResponseForLogging, true)
 
 		chunk := BuildClientStreamChunk(ctx, response, nil)
 		if chunk.BifrostImageGenerationStreamResponse == nil {
@@ -1131,6 +1132,38 @@ func TestBuildClientStreamChunk_ImageGenerationStripping(t *testing.T) {
 		}
 	})
 
+	t.Run("req logging-only only: only RawRequest stripped", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyRawRequestForLogging, true)
+
+		chunk := BuildClientStreamChunk(ctx, response, nil)
+		if chunk.BifrostImageGenerationStreamResponse == nil {
+			t.Fatal("expected BifrostImageGenerationStreamResponse in chunk")
+		}
+		if chunk.BifrostImageGenerationStreamResponse.ExtraFields.RawRequest != nil {
+			t.Error("expected RawRequest stripped from chunk, but it was present")
+		}
+		if chunk.BifrostImageGenerationStreamResponse.ExtraFields.RawResponse == nil {
+			t.Error("expected RawResponse present in chunk (send-back), but it was nil")
+		}
+	})
+
+	t.Run("resp logging-only only: only RawResponse stripped", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyRawResponseForLogging, true)
+
+		chunk := BuildClientStreamChunk(ctx, response, nil)
+		if chunk.BifrostImageGenerationStreamResponse == nil {
+			t.Fatal("expected BifrostImageGenerationStreamResponse in chunk")
+		}
+		if chunk.BifrostImageGenerationStreamResponse.ExtraFields.RawRequest == nil {
+			t.Error("expected RawRequest present in chunk (send-back), but it was nil")
+		}
+		if chunk.BifrostImageGenerationStreamResponse.ExtraFields.RawResponse != nil {
+			t.Error("expected RawResponse stripped from chunk, but it was present")
+		}
+	})
+
 	t.Run("no logging flag: raw fields preserved in image gen chunk", func(t *testing.T) {
 		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
@@ -1148,9 +1181,8 @@ func TestBuildClientStreamChunk_ImageGenerationStripping(t *testing.T) {
 }
 
 // TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChunk verifies
-// that when BifrostContextKeyRawRequestResponseForLogging is set, ProcessAndSendResponse
-// strips RawRequest and RawResponse from the outgoing stream chunk, while leaving other
-// ExtraFields intact. It also verifies that the original BifrostResponse is not mutated
+// that ProcessAndSendResponse strips RawRequest and/or RawResponse independently based on
+// per-field context flags. It also verifies that the original BifrostResponse is not mutated
 // (shared object safety for PostLLMHook goroutines).
 func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChunk(t *testing.T) {
 	rawReq := json.RawMessage(`{"model":"gpt-4","messages":[]}`)
@@ -1158,26 +1190,49 @@ func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChu
 
 	tests := []struct {
 		name           string
-		loggingOnly    bool
-		expectStripped bool
+		dropReq        bool
+		dropResp       bool
+		expectReqNil   bool
+		expectRespNil  bool
 	}{
 		{
-			name:           "logging-only flag set: raw data stripped from chunk",
-			loggingOnly:    true,
-			expectStripped: true,
+			name:          "both logging-only: both fields stripped",
+			dropReq:       true,
+			dropResp:      true,
+			expectReqNil:  true,
+			expectRespNil: true,
 		},
 		{
-			name:           "logging-only flag not set: raw data preserved in chunk",
-			loggingOnly:    false,
-			expectStripped: false,
+			name:          "req logging-only only: only RawRequest stripped",
+			dropReq:       true,
+			dropResp:      false,
+			expectReqNil:  true,
+			expectRespNil: false,
+		},
+		{
+			name:          "resp logging-only only: only RawResponse stripped",
+			dropReq:       false,
+			dropResp:      true,
+			expectReqNil:  false,
+			expectRespNil: true,
+		},
+		{
+			name:          "no logging flags: both fields preserved",
+			dropReq:       false,
+			dropResp:      false,
+			expectReqNil:  false,
+			expectRespNil: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-			if tt.loggingOnly {
-				ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+			if tt.dropReq {
+				ctx.SetValue(schemas.BifrostContextKeyRawRequestForLogging, true)
+			}
+			if tt.dropResp {
+				ctx.SetValue(schemas.BifrostContextKeyRawResponseForLogging, true)
 			}
 
 			response := &schemas.BifrostResponse{
@@ -1206,30 +1261,29 @@ func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChu
 			hasRawReq := chunk.BifrostChatResponse.ExtraFields.RawRequest != nil
 			hasRawResp := chunk.BifrostChatResponse.ExtraFields.RawResponse != nil
 
-			if tt.expectStripped {
-				if hasRawReq {
-					t.Error("expected RawRequest to be nil (stripped) in chunk, but it was present")
-				}
-				if hasRawResp {
-					t.Error("expected RawResponse to be nil (stripped) in chunk, but it was present")
-				}
-				// Critical: the original shared object must NOT have been mutated.
+			if tt.expectReqNil && hasRawReq {
+				t.Error("expected RawRequest to be nil (stripped) in chunk, but it was present")
+			}
+			if !tt.expectReqNil && !hasRawReq {
+				t.Error("expected RawRequest to be present in chunk, but it was nil")
+			}
+			if tt.expectRespNil && hasRawResp {
+				t.Error("expected RawResponse to be nil (stripped) in chunk, but it was present")
+			}
+			if !tt.expectRespNil && !hasRawResp {
+				t.Error("expected RawResponse to be present in chunk, but it was nil")
+			}
+
+			// When any field is stripped, the chunk must be a copy — original must not be mutated.
+			if tt.dropReq || tt.dropResp {
 				if response.ChatResponse.ExtraFields.RawRequest == nil {
-					t.Error("original BifrostResponse.ChatResponse.ExtraFields.RawRequest was mutated (nil); shared object must be preserved")
+					t.Error("original BifrostResponse.ChatResponse.ExtraFields.RawRequest was mutated; shared object must be preserved")
 				}
 				if response.ChatResponse.ExtraFields.RawResponse == nil {
-					t.Error("original BifrostResponse.ChatResponse.ExtraFields.RawResponse was mutated (nil); shared object must be preserved")
+					t.Error("original BifrostResponse.ChatResponse.ExtraFields.RawResponse was mutated; shared object must be preserved")
 				}
-				// The chunk must be a copy, not the same pointer as the original.
 				if chunk.BifrostChatResponse == response.ChatResponse {
 					t.Error("chunk.BifrostChatResponse is the same pointer as the original; it must be a copy to avoid data races")
-				}
-			} else {
-				if !hasRawReq {
-					t.Error("expected RawRequest to be present in chunk, but it was nil")
-				}
-				if !hasRawResp {
-					t.Error("expected RawResponse to be present in chunk, but it was nil")
 				}
 			}
 		})
@@ -1237,35 +1291,58 @@ func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromResponseChu
 }
 
 // TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromErrorChunk verifies
-// that when BifrostContextKeyRawRequestResponseForLogging is set, raw data is stripped
-// from BifrostError payloads embedded in stream chunks, without mutating the shared
+// that per-field logging flags strip RawRequest and/or RawResponse independently from
+// BifrostError payloads embedded in stream chunks, without mutating the shared
 // BifrostError object (shared object safety for PostLLMHook goroutines).
 func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromErrorChunk(t *testing.T) {
 	rawReq := json.RawMessage(`{"model":"gpt-4"}`)
 	rawResp := json.RawMessage(`{"error":"rate limit exceeded"}`)
 
 	tests := []struct {
-		name           string
-		loggingOnly    bool
-		expectStripped bool
+		name          string
+		dropReq       bool
+		dropResp      bool
+		expectReqNil  bool
+		expectRespNil bool
 	}{
 		{
-			name:           "logging-only flag set: raw data stripped from error chunk",
-			loggingOnly:    true,
-			expectStripped: true,
+			name:          "both logging-only: both fields stripped from error chunk",
+			dropReq:       true,
+			dropResp:      true,
+			expectReqNil:  true,
+			expectRespNil: true,
 		},
 		{
-			name:           "logging-only flag not set: raw data preserved in error chunk",
-			loggingOnly:    false,
-			expectStripped: false,
+			name:          "req logging-only only: only RawRequest stripped from error chunk",
+			dropReq:       true,
+			dropResp:      false,
+			expectReqNil:  true,
+			expectRespNil: false,
+		},
+		{
+			name:          "resp logging-only only: only RawResponse stripped from error chunk",
+			dropReq:       false,
+			dropResp:      true,
+			expectReqNil:  false,
+			expectRespNil: true,
+		},
+		{
+			name:          "no logging flags: both fields preserved in error chunk",
+			dropReq:       false,
+			dropResp:      false,
+			expectReqNil:  false,
+			expectRespNil: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-			if tt.loggingOnly {
-				ctx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+			if tt.dropReq {
+				ctx.SetValue(schemas.BifrostContextKeyRawRequestForLogging, true)
+			}
+			if tt.dropResp {
+				ctx.SetValue(schemas.BifrostContextKeyRawResponseForLogging, true)
 			}
 
 			// Use a postHookRunner that converts the response to a BifrostError with raw data
@@ -1296,30 +1373,29 @@ func TestProcessAndSendResponse_StoreRawLoggingOnly_StripsRawDataFromErrorChunk(
 			hasRawReq := chunk.BifrostError.ExtraFields.RawRequest != nil
 			hasRawResp := chunk.BifrostError.ExtraFields.RawResponse != nil
 
-			if tt.expectStripped {
-				if hasRawReq {
-					t.Error("expected RawRequest to be nil (stripped) in error chunk, but it was present")
-				}
-				if hasRawResp {
-					t.Error("expected RawResponse to be nil (stripped) in error chunk, but it was present")
-				}
-				// Critical: the original shared BifrostError must NOT have been mutated.
+			if tt.expectReqNil && hasRawReq {
+				t.Error("expected RawRequest to be nil (stripped) in error chunk, but it was present")
+			}
+			if !tt.expectReqNil && !hasRawReq {
+				t.Error("expected RawRequest to be present in error chunk, but it was nil")
+			}
+			if tt.expectRespNil && hasRawResp {
+				t.Error("expected RawResponse to be nil (stripped) in error chunk, but it was present")
+			}
+			if !tt.expectRespNil && !hasRawResp {
+				t.Error("expected RawResponse to be present in error chunk, but it was nil")
+			}
+
+			// When any field is stripped, the chunk must be a copy — original must not be mutated.
+			if tt.dropReq || tt.dropResp {
 				if bifrostErr.ExtraFields.RawRequest == nil {
-					t.Error("original BifrostError.ExtraFields.RawRequest was mutated (nil); shared object must be preserved")
+					t.Error("original BifrostError.ExtraFields.RawRequest was mutated; shared object must be preserved")
 				}
 				if bifrostErr.ExtraFields.RawResponse == nil {
-					t.Error("original BifrostError.ExtraFields.RawResponse was mutated (nil); shared object must be preserved")
+					t.Error("original BifrostError.ExtraFields.RawResponse was mutated; shared object must be preserved")
 				}
-				// The chunk must hold a copy, not the same pointer as the original.
 				if chunk.BifrostError == bifrostErr {
 					t.Error("chunk.BifrostError is the same pointer as the original; it must be a copy to avoid data races")
-				}
-			} else {
-				if !hasRawReq {
-					t.Error("expected RawRequest to be present in error chunk, but it was nil")
-				}
-				if !hasRawResp {
-					t.Error("expected RawResponse to be present in error chunk, but it was nil")
 				}
 			}
 		})

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -205,12 +205,13 @@ const (
 	BifrostContextKeyTraceCompleter                      BifrostContextKey = "bifrost-trace-completer"                          // func() (callback to complete trace after streaming - set by tracing middleware)
 	BifrostContextKeyPostHookSpanFinalizer               BifrostContextKey = "bifrost-posthook-span-finalizer"                  // func(context.Context) (callback to finalize post-hook spans after streaming - set by bifrost)
 	BifrostContextKeyAccumulatorID                       BifrostContextKey = "bifrost-accumulator-id"                           // string (ID for streaming accumulator lookup - set by tracer for accumulator operations)
-	BifrostContextKeyHasEmittedMessageDelta              BifrostContextKey = "bifrost-has-emitted-message-delta"                 // bool (tracks whether message_delta was already emitted during streaming - avoids duplicates)
+	BifrostContextKeyHasEmittedMessageDelta              BifrostContextKey = "bifrost-has-emitted-message-delta"                // bool (tracks whether message_delta was already emitted during streaming - avoids duplicates)
 	BifrostContextKeySkipDBUpdate                        BifrostContextKey = "bifrost-skip-db-update"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyGovernancePluginName                BifrostContextKey = "governance-plugin-name"                           // string (name of the governance plugin that processed the request - set by bifrost)
 	BifrostContextKeyIsEnterprise                        BifrostContextKey = "is-enterprise"                                    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyAvailableProviders                  BifrostContextKey = "available-providers"                              // []ModelProvider (set by bifrost - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyRawRequestResponseForLogging        BifrostContextKey = "bifrost-raw-request-response-for-logging"         // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyRawRequestForLogging                BifrostContextKey = "bifrost-raw-request-for-logging"                  // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - strip raw request before sending to client
+	BifrostContextKeyRawResponseForLogging               BifrostContextKey = "bifrost-raw-response-for-logging"                 // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - strip raw response before sending to client
 	BifrostContextKeyRetryDBFetch                        BifrostContextKey = "bifrost-retry-db-fetch"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY))
@@ -810,6 +811,16 @@ type BifrostResponseExtraFields struct {
 	ProviderResponseHeaders map[string]string  `json:"provider_response_headers,omitempty"` // HTTP response headers from the provider (filtered to exclude transport-level headers)
 }
 
+// StripRaw nils RawRequest and/or RawResponse based on the provided flags.
+func (e *BifrostResponseExtraFields) StripRaw(dropReq, dropResp bool) {
+	if dropReq {
+		e.RawRequest = nil
+	}
+	if dropResp {
+		e.RawResponse = nil
+	}
+}
+
 type BifrostMCPResponseExtraFields struct {
 	ClientName string `json:"client_name"`
 	ToolName   string `json:"tool_name"`
@@ -975,4 +986,14 @@ type BifrostErrorExtraFields struct {
 	RawResponse    interface{}   `json:"raw_response,omitempty"`
 	LiteLLMCompat  bool          `json:"litellm_compat,omitempty"`
 	KeyStatuses    []KeyStatus   `json:"key_statuses,omitempty"`
+}
+
+// StripRaw nils RawRequest and/or RawResponse based on the provided flags.
+func (e *BifrostErrorExtraFields) StripRaw(dropReq, dropResp bool) {
+	if dropReq {
+		e.RawRequest = nil
+	}
+	if dropResp {
+		e.RawResponse = nil
+	}
 }

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -520,7 +520,8 @@ type ContainerCreateRequest struct {
 func enableRawRequestResponseForContainer(bifrostCtx *schemas.BifrostContext) {
 	bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawRequest, true)
 	bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
-	bifrostCtx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+	bifrostCtx.SetValue(schemas.BifrostContextKeyRawRequestForLogging, true)
+	bifrostCtx.SetValue(schemas.BifrostContextKeyRawResponseForLogging, true)
 }
 
 // parseFallbacks extracts fallbacks from string array and converts to Fallback structs

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -3258,7 +3258,8 @@ func parseOpenAIVideoGenerationMultipartRequest(ctx *fasthttp.RequestCtx, req in
 func enableRawRequestResponseForContainer(bifrostCtx *schemas.BifrostContext) {
 	bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawRequest, true)
 	bifrostCtx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
-	bifrostCtx.SetValue(schemas.BifrostContextKeyRawRequestResponseForLogging, true)
+	bifrostCtx.SetValue(schemas.BifrostContextKeyRawRequestForLogging, true)
+	bifrostCtx.SetValue(schemas.BifrostContextKeyRawResponseForLogging, true)
 }
 
 // parseContainerFileCreateMultipartRequest is a RequestParser that handles multipart/form-data for container file create requests


### PR DESCRIPTION
## Summary

Fixes raw payload capture logic in Bifrost to handle request and response flags independently, and removes the "fallbacks" field from Anthropic API requests.

## Changes

- Refactored raw payload capture logic to evaluate request and response flags separately instead of requiring both conditions to be met
- Added removal of "fallbacks" field from Anthropic request bodies as it's not part of their official API
- Simplified the conditional logic for setting `BifrostContextKeySendBackRawRequest` and `BifrostContextKeySendBackRawResponse` flags

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test raw payload capture with different flag combinations and verify Anthropic requests don't include the fallbacks field:

```sh
# Core/Transports
go version
go test ./...

# Test with various raw payload configurations
# - store_raw_request_response=true, send_back_raw_request=false, send_back_raw_response=true
# - store_raw_request_response=true, send_back_raw_request=true, send_back_raw_response=false
# - Verify Anthropic requests exclude "fallbacks" field
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change improves the accuracy of raw payload handling without exposing additional data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable