### PR TITLE
docs: delete example for patronus_ai

### DIFF
--- a/docs/enterprise/guardrails.mdx
+++ b/docs/enterprise/guardrails.mdx
@@ -508,16 +508,6 @@ curl -X DELETE http://localhost:8080/api/enterprise/guardrails/providers/1
               "professional_tone": "Ensure responses maintain a professional tone"
             }
           }
-        },
-        {
-          "id": 4,
-          "provider_name": "patronus_ai",
-          "policy_name": "Hallucination Detection",
-          "enabled": true,
-          "config": {
-            "api_key": "${PATRONUS_API_KEY}",
-            "api_endpoint": "https://api.patronus.ai/v1"
-          }
         }
       ]
     }


### PR DESCRIPTION
## Summary

Removed the Patronus AI guardrail provider example from the enterprise guardrails documentation.

## Changes

- Removed the Patronus AI provider configuration example with ID 4 from the JSON response example
- The example included "Hallucination Detection" policy with API key and endpoint configuration

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the documentation renders correctly and the JSON example is valid:

```sh
# Validate the documentation builds without errors
# Check that the remaining JSON structure is properly formatted
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

This change removes an example that referenced API keys, which is appropriate for documentation cleanup.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable