### PR TITLE
helm fix

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - v1.5.0
     paths:
       - "helm-charts/bifrost/**"
       - ".github/workflows/helm-release.yml"


### PR DESCRIPTION
## Summary

Remove the `v1.5.0` branch from the Helm release workflow trigger to prevent automatic releases from that branch.

## Changes

- Removed `v1.5.0` from the list of branches that trigger the Helm release workflow
- The workflow now only triggers on pushes to the `main` branch when Helm chart files are modified

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Verify that the Helm release workflow only triggers on pushes to the main branch:

1. Push changes to the `main` branch that modify files in `helm-charts/bifrost/` - workflow should trigger
2. Push changes to the `v1.5.0` branch that modify Helm chart files - workflow should not trigger

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None - this change only affects CI workflow triggers.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable