### PR TITLE
fixed validation checks

### DIFF
--- a/.github/workflows/scripts/validate-helm-templates.sh
+++ b/.github/workflows/scripts/validate-helm-templates.sh
@@ -270,7 +270,7 @@ test_template "client: new properties (Gap 1+2)" \
 test_template "otel: headers + tls_ca_cert + insecure (Gap 3)" \
   --set bifrost.plugins.otel.enabled=true \
   --set bifrost.plugins.otel.config.collector_url=otel:4317 \
-  --set bifrost.plugins.otel.config.trace_type=otel \
+  --set bifrost.plugins.otel.config.trace_type=genai_extension \
   --set bifrost.plugins.otel.config.protocol=grpc \
   --set 'bifrost.plugins.otel.config.headers.Authorization=Bearer token' \
   --set bifrost.plugins.otel.config.tls_ca_cert=/certs/ca.pem \
@@ -317,7 +317,7 @@ test_template "combined: all new Gap 1-8 fields" \
   --set bifrost.client.hideDeletedVirtualKeysInFilters=true \
   --set bifrost.plugins.otel.enabled=true \
   --set bifrost.plugins.otel.config.collector_url=otel:4317 \
-  --set bifrost.plugins.otel.config.trace_type=otel \
+  --set bifrost.plugins.otel.config.trace_type=genai_extension \
   --set bifrost.plugins.otel.config.protocol=grpc \
   --set bifrost.plugins.otel.config.insecure=true \
   --set bifrost.plugins.governance.enabled=true \


### PR DESCRIPTION
## Summary

Updates the OpenTelemetry trace type configuration in Helm template validation tests from `otel` to `genai_extension` to align with the new trace type naming convention.

## Changes

- Changed `bifrost.plugins.otel.config.trace_type` value from `otel` to `genai_extension` in two test scenarios
- Updated both the standalone OTEL test and the combined configuration test to use the new trace type

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Run the Helm template validation script to ensure the tests pass with the updated trace type configuration:

```sh
./.github/workflows/scripts/validate-helm-templates.sh
```

Verify that the OTEL plugin configuration accepts the `genai_extension` trace type and that Helm charts render correctly with this setting.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a configuration value update in test scripts.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable