### PR TITLE
removes prerelease tag from helm chart

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.0-prerelease2
+version: 2.1.1
 appVersion: "1.4.11"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,14 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.0-prerelease2
+**Latest Version:** 2.1.1
 
 ## Changelog
+
+### v2.1.1
+
+- Made `bifrost.governance.virtualKeys[].value` optional — template no longer fails when the field is omitted, allowing the backend to auto-generate the virtual key value
+- When `value` is absent, the rendered `config.json` omits the field entirely (consistent with other optional VK fields)
 
 ### v2.1.0-prerelease2 (prerelease)
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -354,7 +354,8 @@ false
 {{- if .Values.bifrost.governance.virtualKeys }}
 {{- $vks := list }}
 {{- range .Values.bifrost.governance.virtualKeys }}
-{{- $vk := dict "id" .id "name" .name "value" .value }}
+{{- $vk := dict "id" .id "name" .name }}
+{{- if .value }}{{- $_ := set $vk "value" .value }}{{- end }}
 {{- if .description }}{{- $_ := set $vk "description" .description }}{{- end }}
 {{- if hasKey . "is_active" }}{{- $_ := set $vk "is_active" .is_active }}{{- end }}
 {{- if .team_id }}{{- $_ := set $vk "team_id" .team_id }}{{- end }}
@@ -1266,9 +1267,6 @@ Call this template at the beginning of deployment/stateful templates
 {{- end }}
 {{- if not $vk.name }}
 {{- fail (printf "ERROR: bifrost.governance.virtualKeys[%d].name is required for virtual key '%s'." $idx $vk.id) }}
-{{- end }}
-{{- if not $vk.value }}
-{{- fail (printf "ERROR: bifrost.governance.virtualKeys[%d].value is required for virtual key '%s'." $idx $vk.id) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -468,7 +468,7 @@ bifrost:
       # - id: "vk-1"
       #   name: "Virtual Key 1"
       #   description: "Virtual key description"
-      #   value: "vk-..."
+      #   value: "vk-..."           # Optional - auto-generated if omitted
       #   is_active: true
       #   team_id: "team-1"        # Mutually exclusive with customer_id
       #   customer_id: ""          # Mutually exclusive with team_id

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,27 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.4.11
+    created: "2026-04-15T18:00:00.000000+00:00"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+    digest: ""
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getmaxim.ai/bifrost/bifrost-logo-only.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    maintainers:
+    - email: akshay@getmaxim.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.1.tgz
+    version: 2.1.1
+  - apiVersion: v2
+    appVersion: 1.4.11
     created: "2026-04-15T12:00:00.000000+00:00"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
     digest: ""
@@ -649,4 +670,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-04-13T12:00:00.000000+00:00"
+generated: "2026-04-15T18:00:00.000000+00:00"


### PR DESCRIPTION
## Summary

Release Bifrost Helm chart version 2.1.1 with improved virtual key configuration flexibility. The `value` field for virtual keys is now optional, allowing the backend to auto-generate virtual key values when not explicitly provided.

## Changes

- Made `bifrost.governance.virtualKeys[].value` field optional in Helm templates
- Updated template logic to conditionally include the `value` field only when present
- Removed validation that previously required the `value` field to be set
- Updated documentation and examples to reflect the optional nature of the field
- Bumped chart version from 2.1.0-prerelease2 to 2.1.1

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Deploy the Helm chart with virtual keys configured both with and without the `value` field:

```sh
# Test with explicit value
helm install bifrost ./helm-charts/bifrost --set bifrost.governance.virtualKeys[0].id=vk-1 --set bifrost.governance.virtualKeys[0].name="Test Key" --set bifrost.governance.virtualKeys[0].value="vk-explicit-123"

# Test with auto-generated value (omit value field)
helm install bifrost ./helm-charts/bifrost --set bifrost.governance.virtualKeys[0].id=vk-2 --set bifrost.governance.virtualKeys[0].name="Auto Key"

# Verify the rendered config.json includes/omits the value field appropriately
helm template bifrost ./helm-charts/bifrost --values test-values.yaml
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

This change is backward compatible - existing configurations with explicit `value` fields will continue to work unchanged.

## Related issues

N/A

## Security considerations

Auto-generated virtual key values should be cryptographically secure and generated by the backend service. The Helm chart no longer enforces explicit key values, delegating this responsibility to the application.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable