### PR TITLE
refactor: hardcode azure, sgl, and nebius provider icon sizes to 14px

### DIFF
--- a/ui/lib/constants/icons.tsx
+++ b/ui/lib/constants/icons.tsx
@@ -62,19 +62,8 @@ export const ProviderIcons = {
 		);
 	},
 
-	azure: ({ size = "md", className = "" }: IconProps) => {
-		const resolvedSize = resolveSize(size);
-		return (
-			<img
-				src="/images/azure.webp"
-				alt="azure"
-				width={resolvedSize}
-				height={resolvedSize}
-				loading="lazy"
-				decoding="async"
-				className={className}
-			/>
-		);
+	azure: ({ className = "" }: IconProps) => {
+		return <img src="/images/azure.webp" alt="azure" width={14} height={14} loading="lazy" decoding="async" className={className} />;
 	},
 	bedrock: ({ size = "md", className = "" }: IconProps) => {
 		const resolvedSize = resolveSize(size);
@@ -377,19 +366,8 @@ export const ProviderIcons = {
 		);
 	},
 
-	sgl: ({ size = "md", className = "" }: IconProps) => {
-		const resolvedSize = resolveSize(size);
-		return (
-			<img
-				src="/images/sgl.webp"
-				alt="sgl"
-				width={resolvedSize}
-				height={resolvedSize}
-				loading="lazy"
-				decoding="async"
-				className={className}
-			/>
-		);
+	sgl: ({ className = "" }: IconProps) => {
+		return <img src="/images/sgl.webp" alt="sgl" width={14} height={14} loading="lazy" decoding="async" className={className} />;
 	},
 	openai: ({ size = "md", className = "", theme }: IconProps) => {
 		const resolvedSize = resolveSize(size);
@@ -584,19 +562,8 @@ export const ProviderIcons = {
 			</svg>
 		);
 	},
-	nebius: ({ size = "md", className = "" }: IconProps) => {
-		const resolvedSize = resolveSize(size);
-		return (
-			<img
-				src="/images/nebius.webp"
-				alt="nebius"
-				width={resolvedSize}
-				height={resolvedSize}
-				loading="lazy"
-				decoding="async"
-				className={className}
-			/>
-		);
+	nebius: ({ className = "" }: IconProps) => {
+		return <img src="/images/nebius.webp" alt="nebius" width={14} height={14} loading="lazy" decoding="async" className={className} />;
 	},
 	xai: ({ size = "md", className = "" }: IconProps) => {
 		const resolvedSize = resolveSize(size);


### PR DESCRIPTION
## Summary

Fixed icon sizing for Azure, SGL, and Nebius provider icons by removing dynamic size resolution and setting fixed 14x14 pixel dimensions.

## Changes

- Removed `size` parameter and `resolveSize()` function calls from `azure`, `sgl`, and `nebius` icon components
- Set fixed width and height of 14 pixels for these three provider icons
- Simplified the component implementations by removing unnecessary size calculation logic

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Verify that the Azure, SGL, and Nebius provider icons display correctly at the fixed 14x14 pixel size in the UI.

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [x] Yes
- [ ] No

The `size` parameter is no longer accepted for the `azure`, `sgl`, and `nebius` icon components. Any code passing a size parameter to these icons will need to be updated.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable