### PR TITLE
refactor: replace FilterPopover with LogsSidebar in dashboard layout

### DIFF
--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -1,5 +1,6 @@
-import { FilterPopover } from "@/components/filters/filterPopover";
+import { LogsSidebar } from "@/app/workspace/logs/views/logsSidebar";
 import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
+import { ScrollArea } from "@/components/ui/scrollArea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
 	useGetMCPAvailableFilterDataQuery,
@@ -55,15 +56,6 @@ const DEFAULT_START_TIME = (() => {
 	return Math.floor(date.getTime() / 1000);
 })();
 
-// Predefined time periods
-const TIME_PERIODS = [
-	{ label: "Last hour", value: "1h" },
-	{ label: "Last 6 hours", value: "6h" },
-	{ label: "Last 24 hours", value: "24h" },
-	{ label: "Last 7 days", value: "7d" },
-	{ label: "Last 30 days", value: "30d" },
-];
-
 const parseCsvParam = (value: string): string[] => (value ? value.split(",").filter(Boolean) : []);
 const sanitizeSeriesLabels = (values?: string[]): string[] => {
 	if (!values) return [];
@@ -71,24 +63,6 @@ const sanitizeSeriesLabels = (values?: string[]): string[] => {
 
 	return [...new Set(trimmedValues)];
 };
-
-function getTimeRangeFromPeriod(period: string): { start: number; end: number } {
-	const now = Math.floor(Date.now() / 1000);
-	switch (period) {
-		case "1h":
-			return { start: now - 3600, end: now };
-		case "6h":
-			return { start: now - 6 * 3600, end: now };
-		case "24h":
-			return { start: now - 24 * 3600, end: now };
-		case "7d":
-			return { start: now - 7 * 24 * 3600, end: now };
-		case "30d":
-			return { start: now - 30 * 24 * 3600, end: now };
-		default:
-			return { start: now - 24 * 3600, end: now };
-	}
-}
 
 export default function DashboardPage() {
 	// Data states - Overview
@@ -242,15 +216,6 @@ export default function DashboardPage() {
 			...(selectedMcpServerLabels.length > 0 && { server_labels: selectedMcpServerLabels }),
 		}),
 		[urlState.start_time, urlState.end_time, selectedMcpToolNames, selectedMcpServerLabels],
-	);
-
-	// Date range for picker
-	const dateRange = useMemo(
-		() => ({
-			from: dateUtils.fromUnixTimestamp(urlState.start_time),
-			to: dateUtils.fromUnixTimestamp(urlState.end_time),
-		}),
-		[urlState.start_time, urlState.end_time],
 	);
 
 	// Model lists for each chart's legend (must match what the chart component actually renders)
@@ -496,33 +461,6 @@ export default function DashboardPage() {
 		return () => window.clearTimeout(timeoutId);
 	}, [urlState.tab, ensureOverviewDataLoaded, ensureProviderDataLoaded, ensureMcpDataLoaded, ensureRankingsDataLoaded]);
 
-	// Handle time period change
-	const handlePeriodChange = useCallback(
-		(period: string | undefined) => {
-			if (!period) return;
-			const { start, end } = getTimeRangeFromPeriod(period);
-			setUrlState({
-				start_time: start,
-				end_time: end,
-				period,
-			});
-		},
-		[setUrlState],
-	);
-
-	// Handle custom date range change
-	const handleDateRangeChange = useCallback(
-		(range: { from?: Date; to?: Date }) => {
-			if (!range.from || !range.to) return;
-			setUrlState({
-				start_time: dateUtils.toUnixTimestamp(range.from),
-				end_time: dateUtils.toUnixTimestamp(range.to),
-				period: "", // Clear period when custom range is selected
-			});
-		},
-		[setUrlState],
-	);
-
 	// Tab change handler
 	const handleTabChange = useCallback(
 		(tab: string) => {
@@ -538,29 +476,27 @@ export default function DashboardPage() {
 	const handleModelChartToggle = useCallback((type: ChartType) => setUrlState({ model_chart: type }), [setUrlState]);
 	const handleLatencyChartToggle = useCallback((type: ChartType) => setUrlState({ latency_chart: type }), [setUrlState]);
 
-	// Filter change handler for FilterPopover
-	const handleFilterChange = useCallback(
-		(key: keyof LogFilters, values: string[] | boolean | string) => {
-			const urlKeyMap: Partial<Record<keyof LogFilters, string>> = {
-				providers: "providers",
-				models: "models",
-				selected_key_ids: "selected_key_ids",
-				virtual_key_ids: "virtual_key_ids",
-				objects: "objects",
-				status: "status",
-				routing_rule_ids: "routing_rule_ids",
-				routing_engine_used: "routing_engine_used",
-				missing_cost_only: "missing_cost_only",
-			};
-			const urlKey = urlKeyMap[key];
-			if (!urlKey) return;
-			if (typeof values === "boolean") {
-				setUrlState({ [urlKey]: String(values) });
-			} else if (typeof values === "string") {
-				setUrlState({ [urlKey]: values });
-			} else {
-				setUrlState({ [urlKey]: values.join(",") });
-			}
+	// Adapter: converts a full LogFilters object to dashboard's CSV-based URL state
+	const setFilters = useCallback(
+		(newFilters: LogFilters) => {
+			setUrlState({
+				start_time: newFilters.start_time ? dateUtils.toUnixTimestamp(new Date(newFilters.start_time)) : undefined,
+				end_time: newFilters.end_time ? dateUtils.toUnixTimestamp(new Date(newFilters.end_time)) : undefined,
+				period: "", // Clear period when filters change (custom range)
+				providers: (newFilters.providers || []).join(","),
+				models: (newFilters.models || []).join(","),
+				selected_key_ids: (newFilters.selected_key_ids || []).join(","),
+				virtual_key_ids: (newFilters.virtual_key_ids || []).join(","),
+				objects: (newFilters.objects || []).join(","),
+				status: (newFilters.status || []).join(","),
+				routing_rule_ids: (newFilters.routing_rule_ids || []).join(","),
+				routing_engine_used: (newFilters.routing_engine_used || []).join(","),
+				missing_cost_only: String(newFilters.missing_cost_only ?? false),
+				metadata_filters:
+					newFilters.metadata_filters && Object.keys(newFilters.metadata_filters).length > 0
+						? JSON.stringify(newFilters.metadata_filters)
+						: "",
+			});
 		},
 		[setUrlState],
 	);
@@ -704,196 +640,192 @@ export default function DashboardPage() {
 	}, []);
 
 	return (
-		<div id="dashboard-root" className="mx-auto flex h-full min-h-[calc(100vh-100px)] w-full flex-col gap-4">
-			{/* Header with time filter */}
-			<div className="flex items-center justify-between">
-				<div className="flex items-center gap-2">
-					<h1 className="text-lg font-semibold">Dashboard</h1>
+		<div id="dashboard-root" className="no-padding-parent no-border-parent bg-background flex h-[calc(100vh_-_16px)] w-full gap-3">
+			{/* Sidebar Filters */}
+			<LogsSidebar filters={filters} onFiltersChange={setFilters} />
+
+			{/* Main Content */}
+			<ScrollArea className="bg-card flex min-w-0 flex-1 flex-col gap-4 rounded-l-md">
+				{/* Header */}
+				<div className="flex items-center justify-between p-4">
+					<div className="flex items-center gap-2">
+						<h1 className="text-lg font-semibold">Dashboard</h1>
+					</div>
+					<div className="flex items-center gap-2">
+						<ExportPopover
+							getData={getDashboardData}
+							onPreloadData={handlePreloadData}
+							onPdfExport={handlePdfExport}
+							onPdfExportDone={handlePdfExportDone}
+						/>
+						{urlState.tab === "mcp" && mcpFilterData && (
+							<div className="flex items-center gap-1">
+								{mcpFilterData.tool_names?.length > 0 && (
+									<ModelFilterSelect
+										models={mcpFilterData.tool_names}
+										selectedModel={selectedMcpToolNames.length === 1 ? selectedMcpToolNames[0] : "all"}
+										onModelChange={(value) => {
+											if (value === "all") {
+												setUrlState({ mcp_tool_names: "" });
+											} else {
+												setUrlState({ mcp_tool_names: value });
+											}
+										}}
+										placeholder="All Tools"
+										data-testid="dashboard-mcp-tool-filter"
+									/>
+								)}
+								{mcpFilterData.server_labels?.length > 0 && (
+									<ModelFilterSelect
+										models={mcpFilterData.server_labels}
+										selectedModel={selectedMcpServerLabels.length === 1 ? selectedMcpServerLabels[0] : "all"}
+										onModelChange={(value) => {
+											if (value === "all") {
+												setUrlState({ mcp_server_labels: "" });
+											} else {
+												setUrlState({ mcp_server_labels: value });
+											}
+										}}
+										placeholder="All Servers"
+										data-testid="dashboard-mcp-server-filter"
+									/>
+								)}
+							</div>
+						)}
+					</div>
 				</div>
-				<div className="flex items-center gap-2">
-					<ExportPopover
-						getData={getDashboardData}
-						onPreloadData={handlePreloadData}
-						onPdfExport={handlePdfExport}
-						onPdfExportDone={handlePdfExportDone}
-					/>
-					{(urlState.tab === "overview" || urlState.tab === "provider-usage" || urlState.tab === "rankings") && (
-						<FilterPopover filters={filters} onFilterChange={handleFilterChange} showParentRequestIdFilter={false} />
-					)}
-					{urlState.tab === "mcp" && mcpFilterData && (
-						<div className="flex items-center gap-1">
-							{mcpFilterData.tool_names?.length > 0 && (
-								<ModelFilterSelect
-									models={mcpFilterData.tool_names}
-									selectedModel={selectedMcpToolNames.length === 1 ? selectedMcpToolNames[0] : "all"}
-									onModelChange={(value) => {
-										if (value === "all") {
-											setUrlState({ mcp_tool_names: "" });
-										} else {
-											setUrlState({ mcp_tool_names: value });
-										}
-									}}
-									placeholder="All Tools"
-									data-testid="dashboard-mcp-tool-filter"
+
+				<div className="p-4">
+					{/* Tabs */}
+					<Tabs value={urlState.tab} onValueChange={handleTabChange}>
+						<TabsList className="mb-2">
+							<TabsTrigger value="overview" data-testid="dashboard-tab-overview">
+								Overview
+							</TabsTrigger>
+							<TabsTrigger value="provider-usage" data-testid="dashboard-tab-provider-usage">
+								Provider Usage
+							</TabsTrigger>
+							<TabsTrigger value="rankings" data-testid="dashboard-tab-rankings">
+								Model Rankings
+							</TabsTrigger>
+							<TabsTrigger value="mcp" data-testid="dashboard-tab-mcp">
+								MCP usage
+							</TabsTrigger>
+							<TabsTrigger value="user-rankings" data-testid="dashboard-tab-user-rankings">
+								User Rankings
+							</TabsTrigger>
+						</TabsList>
+
+						{/* Overview Tab */}
+						<TabsContent value="overview" {...(pdfMode && { forceMount: true })}>
+							<div id="dashboard-section-overview">
+								<OverviewTab
+									histogramData={histogramData}
+									tokenData={tokenData}
+									costData={costData}
+									modelData={modelData}
+									latencyData={latencyData}
+									loadingHistogram={loadingHistogram}
+									loadingTokens={loadingTokens}
+									loadingCost={loadingCost}
+									loadingModels={loadingModels}
+									loadingLatency={loadingLatency}
+									startTime={urlState.start_time}
+									endTime={urlState.end_time}
+									volumeChartType={toChartType(urlState.volume_chart)}
+									tokenChartType={toChartType(urlState.token_chart)}
+									costChartType={toChartType(urlState.cost_chart)}
+									modelChartType={toChartType(urlState.model_chart)}
+									latencyChartType={toChartType(urlState.latency_chart)}
+									costModel={urlState.cost_model}
+									usageModel={urlState.usage_model}
+									costModels={costModels}
+									usageModels={usageModels}
+									availableModels={availableModels}
+									onVolumeChartToggle={handleVolumeChartToggle}
+									onTokenChartToggle={handleTokenChartToggle}
+									onCostChartToggle={handleCostChartToggle}
+									onModelChartToggle={handleModelChartToggle}
+									onLatencyChartToggle={handleLatencyChartToggle}
+									onCostModelChange={handleCostModelChange}
+									onUsageModelChange={handleUsageModelChange}
 								/>
-							)}
-							{mcpFilterData.server_labels?.length > 0 && (
-								<ModelFilterSelect
-									models={mcpFilterData.server_labels}
-									selectedModel={selectedMcpServerLabels.length === 1 ? selectedMcpServerLabels[0] : "all"}
-									onModelChange={(value) => {
-										if (value === "all") {
-											setUrlState({ mcp_server_labels: "" });
-										} else {
-											setUrlState({ mcp_server_labels: value });
-										}
-									}}
-									placeholder="All Servers"
-									data-testid="dashboard-mcp-server-filter"
+							</div>
+						</TabsContent>
+
+						{/* Provider Usage Tab */}
+						<TabsContent value="provider-usage" {...(pdfMode && { forceMount: true })}>
+							<div id="dashboard-section-provider-usage">
+								<ProviderUsageTab
+									providerCostData={providerCostData}
+									providerTokenData={providerTokenData}
+									providerLatencyData={providerLatencyData}
+									loadingProviderCost={loadingProviderCost}
+									loadingProviderTokens={loadingProviderTokens}
+									loadingProviderLatency={loadingProviderLatency}
+									startTime={urlState.start_time}
+									endTime={urlState.end_time}
+									providerCostChartType={toChartType(urlState.provider_cost_chart)}
+									providerTokenChartType={toChartType(urlState.provider_token_chart)}
+									providerLatencyChartType={toChartType(urlState.provider_latency_chart)}
+									providerCostProvider={urlState.provider_cost_provider}
+									providerTokenProvider={urlState.provider_token_provider}
+									providerLatencyProvider={urlState.provider_latency_provider}
+									availableProviders={availableProviders}
+									providerCostProviders={providerCostProviders}
+									providerTokenProviders={providerTokenProviders}
+									providerLatencyProviders={providerLatencyProviders}
+									onProviderCostChartToggle={handleProviderCostChartToggle}
+									onProviderTokenChartToggle={handleProviderTokenChartToggle}
+									onProviderLatencyChartToggle={handleProviderLatencyChartToggle}
+									onProviderCostProviderChange={handleProviderCostProviderChange}
+									onProviderTokenProviderChange={handleProviderTokenProviderChange}
+									onProviderLatencyProviderChange={handleProviderLatencyProviderChange}
 								/>
-							)}
-						</div>
-					)}
-					<DateTimePickerWithRange
-						dateTime={dateRange}
-						onDateTimeUpdate={handleDateRangeChange}
-						preDefinedPeriods={TIME_PERIODS}
-						predefinedPeriod={urlState.period || undefined}
-						onPredefinedPeriodChange={handlePeriodChange}
-						triggerTestId="dashboard-filter-daterange"
-						popupAlignment="end"
-					/>
+							</div>
+						</TabsContent>
+
+						{/* Model Rankings Tab */}
+						<TabsContent value="rankings" {...(pdfMode && { forceMount: true })}>
+							<div id="dashboard-section-rankings">
+								<ModelRankingsTab
+									rankingsData={rankingsData}
+									loading={loadingRankings}
+									modelData={modelData}
+									loadingModels={loadingModels}
+									startTime={urlState.start_time}
+									endTime={urlState.end_time}
+								/>
+							</div>
+						</TabsContent>
+
+						{/* MCP Tab */}
+						<TabsContent value="mcp" {...(pdfMode && { forceMount: true })}>
+							<div id="dashboard-section-mcp">
+								<MCPTab
+									mcpHistogramData={mcpHistogramData}
+									mcpCostData={mcpCostData}
+									mcpTopToolsData={mcpTopToolsData}
+									loadingMcpHistogram={loadingMcpHistogram}
+									loadingMcpCost={loadingMcpCost}
+									loadingMcpTopTools={loadingMcpTopTools}
+									startTime={urlState.start_time}
+									endTime={urlState.end_time}
+									mcpVolumeChartType={toChartType(urlState.mcp_volume_chart)}
+									mcpCostChartType={toChartType(urlState.mcp_cost_chart)}
+									onMcpVolumeChartToggle={handleMcpVolumeChartToggle}
+									onMcpCostChartToggle={handleMcpCostChartToggle}
+								/>
+							</div>
+						</TabsContent>
+
+						{/* User Rankings Tab (Enterprise) */}
+						<TabsContent value="user-rankings">
+							<UserRankingsTab />
+						</TabsContent>
+					</Tabs>
 				</div>
-			</div>
-
-			{/* Tabs */}
-			<Tabs value={urlState.tab} onValueChange={handleTabChange}>
-				<TabsList className="mb-2">
-					<TabsTrigger value="overview" data-testid="dashboard-tab-overview">
-						Overview
-					</TabsTrigger>
-					<TabsTrigger value="provider-usage" data-testid="dashboard-tab-provider-usage">
-						Provider Usage
-					</TabsTrigger>
-					<TabsTrigger value="rankings" data-testid="dashboard-tab-rankings">
-						Model Rankings
-					</TabsTrigger>
-					<TabsTrigger value="mcp" data-testid="dashboard-tab-mcp">
-						MCP usage
-					</TabsTrigger>
-					<TabsTrigger value="user-rankings" data-testid="dashboard-tab-user-rankings">
-						User Rankings
-					</TabsTrigger>
-				</TabsList>
-
-				{/* Overview Tab */}
-				<TabsContent value="overview" {...(pdfMode && { forceMount: true })}>
-					<div id="dashboard-section-overview">
-						<OverviewTab
-							histogramData={histogramData}
-							tokenData={tokenData}
-							costData={costData}
-							modelData={modelData}
-							latencyData={latencyData}
-							loadingHistogram={loadingHistogram}
-							loadingTokens={loadingTokens}
-							loadingCost={loadingCost}
-							loadingModels={loadingModels}
-							loadingLatency={loadingLatency}
-							startTime={urlState.start_time}
-							endTime={urlState.end_time}
-							volumeChartType={toChartType(urlState.volume_chart)}
-							tokenChartType={toChartType(urlState.token_chart)}
-							costChartType={toChartType(urlState.cost_chart)}
-							modelChartType={toChartType(urlState.model_chart)}
-							latencyChartType={toChartType(urlState.latency_chart)}
-							costModel={urlState.cost_model}
-							usageModel={urlState.usage_model}
-							costModels={costModels}
-							usageModels={usageModels}
-							availableModels={availableModels}
-							onVolumeChartToggle={handleVolumeChartToggle}
-							onTokenChartToggle={handleTokenChartToggle}
-							onCostChartToggle={handleCostChartToggle}
-							onModelChartToggle={handleModelChartToggle}
-							onLatencyChartToggle={handleLatencyChartToggle}
-							onCostModelChange={handleCostModelChange}
-							onUsageModelChange={handleUsageModelChange}
-						/>
-					</div>
-				</TabsContent>
-
-				{/* Provider Usage Tab */}
-				<TabsContent value="provider-usage" {...(pdfMode && { forceMount: true })}>
-					<div id="dashboard-section-provider-usage">
-						<ProviderUsageTab
-							providerCostData={providerCostData}
-							providerTokenData={providerTokenData}
-							providerLatencyData={providerLatencyData}
-							loadingProviderCost={loadingProviderCost}
-							loadingProviderTokens={loadingProviderTokens}
-							loadingProviderLatency={loadingProviderLatency}
-							startTime={urlState.start_time}
-							endTime={urlState.end_time}
-							providerCostChartType={toChartType(urlState.provider_cost_chart)}
-							providerTokenChartType={toChartType(urlState.provider_token_chart)}
-							providerLatencyChartType={toChartType(urlState.provider_latency_chart)}
-							providerCostProvider={urlState.provider_cost_provider}
-							providerTokenProvider={urlState.provider_token_provider}
-							providerLatencyProvider={urlState.provider_latency_provider}
-							availableProviders={availableProviders}
-							providerCostProviders={providerCostProviders}
-							providerTokenProviders={providerTokenProviders}
-							providerLatencyProviders={providerLatencyProviders}
-							onProviderCostChartToggle={handleProviderCostChartToggle}
-							onProviderTokenChartToggle={handleProviderTokenChartToggle}
-							onProviderLatencyChartToggle={handleProviderLatencyChartToggle}
-							onProviderCostProviderChange={handleProviderCostProviderChange}
-							onProviderTokenProviderChange={handleProviderTokenProviderChange}
-							onProviderLatencyProviderChange={handleProviderLatencyProviderChange}
-						/>
-					</div>
-				</TabsContent>
-
-				{/* Model Rankings Tab */}
-				<TabsContent value="rankings" {...(pdfMode && { forceMount: true })}>
-					<div id="dashboard-section-rankings">
-						<ModelRankingsTab
-							rankingsData={rankingsData}
-							loading={loadingRankings}
-							modelData={modelData}
-							loadingModels={loadingModels}
-							startTime={urlState.start_time}
-							endTime={urlState.end_time}
-						/>
-					</div>
-				</TabsContent>
-
-				{/* MCP Tab */}
-				<TabsContent value="mcp" {...(pdfMode && { forceMount: true })}>
-					<div id="dashboard-section-mcp">
-						<MCPTab
-							mcpHistogramData={mcpHistogramData}
-							mcpCostData={mcpCostData}
-							mcpTopToolsData={mcpTopToolsData}
-							loadingMcpHistogram={loadingMcpHistogram}
-							loadingMcpCost={loadingMcpCost}
-							loadingMcpTopTools={loadingMcpTopTools}
-							startTime={urlState.start_time}
-							endTime={urlState.end_time}
-							mcpVolumeChartType={toChartType(urlState.mcp_volume_chart)}
-							mcpCostChartType={toChartType(urlState.mcp_cost_chart)}
-							onMcpVolumeChartToggle={handleMcpVolumeChartToggle}
-							onMcpCostChartToggle={handleMcpCostChartToggle}
-						/>
-					</div>
-				</TabsContent>
-
-				{/* User Rankings Tab (Enterprise) */}
-				<TabsContent value="user-rankings">
-					<UserRankingsTab />
-				</TabsContent>
-			</Tabs>
+			</ScrollArea>
 		</div>
 	);
 }

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -2,6 +2,7 @@ import { LogDetailSheet } from "@/app/workspace/logs/sheets/logDetailsSheet";
 import { SessionDetailsSheet } from "@/app/workspace/logs/sheets/sessionDetailsSheet";
 import { createColumns } from "@/app/workspace/logs/views/columns";
 import { EmptyState } from "@/app/workspace/logs/views/emptyState";
+import { LogsSidebar } from "@/app/workspace/logs/views/logsSidebar";
 import { LogsDataTable } from "@/app/workspace/logs/views/logsTable";
 import { LogsVolumeChart } from "@/app/workspace/logs/views/logsVolumeChart";
 import FullPageLoader from "@/components/fullPageLoader";
@@ -224,12 +225,12 @@ export default function LogsPage() {
 			missing_cost_only: urlState.missing_cost_only,
 			metadata_filters: urlState.metadata_filters
 				? (() => {
-					try {
-						return JSON.parse(urlState.metadata_filters);
-					} catch {
-						return undefined;
-					}
-				})()
+						try {
+							return JSON.parse(urlState.metadata_filters);
+						} catch {
+							return undefined;
+						}
+					})()
 				: undefined,
 		}),
 		// Only re-derive filters when filter-related URL params change (not pagination)
@@ -294,7 +295,7 @@ export default function LogsPage() {
 				content_search: newFilters.content_search || "",
 				start_time: newFilters.start_time ? dateUtils.toUnixTimestamp(new Date(newFilters.start_time)) : undefined,
 				end_time: newFilters.end_time ? dateUtils.toUnixTimestamp(new Date(newFilters.end_time)) : undefined,
-				missing_cost_only: newFilters.missing_cost_only ?? filters.missing_cost_only ?? false,
+				missing_cost_only: newFilters.missing_cost_only ?? false,
 				metadata_filters: newFilters.metadata_filters ? JSON.stringify(newFilters.metadata_filters) : "",
 				offset: 0,
 			});
@@ -825,7 +826,8 @@ export default function LogsPage() {
 				title: "Success Rate",
 				value: fetchingStats ? <Skeleton className="h-8 w-16" /> : stats ? `${stats.success_rate.toFixed(2)}%` : "-",
 				icon: <CheckCircle className="size-4" />,
-				description: "Success rate as perceived by the system. Each fallback counts as a separate attempt. Retries on the same request are counted as one attempt.",
+				description:
+					"Success rate as perceived by the system. Each fallback counts as a separate attempt. Retries on the same request are counted as one attempt.",
 			},
 			{
 				title: "User Success Rate",
@@ -910,14 +912,18 @@ export default function LogsPage() {
 	);
 
 	return (
-		<div className="dark:bg-card h-[calc(100dvh-3.3rem)] max-h-[calc(100dvh-1.5rem)] bg-white">
+		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(100vh_-_16px)]">
 			{initialLoading ? (
 				<FullPageLoader />
 			) : showEmptyState ? (
 				<EmptyState isSocketConnected={isSocketConnected} error={error} />
 			) : (
-				<div className="mx-auto flex h-full w-full flex-col">
-					<div className="flex h-full flex-col gap-2 overflow-hidden">
+				<div className="bg-background flex h-full w-full grow gap-3">
+					{/* Sidebar Filters */}
+					<LogsSidebar filters={filters} onFiltersChange={setFilters} />
+
+					{/* Main Content */}
+					<div className="bg-card flex min-w-0 flex-1 flex-col gap-2 overflow-hidden rounded-l-md p-4 pb-2">
 						<div className="grid shrink-0 grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
 							{statCards.map((card) => (
 								<Card key={card.title} className="py-4 shadow-none">
@@ -990,6 +996,7 @@ export default function LogsPage() {
 								isSocketConnected={isSocketConnected}
 								fetchLogs={fetchLogs}
 								fetchStats={fetchStats}
+								sidebarFilters
 							/>
 						</div>
 					</div>

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -33,8 +33,8 @@ import {
 } from "@/lib/constants/logs";
 import { LogEntry } from "@/lib/types/logs";
 import { Link } from "@tanstack/react-router";
-import { Clipboard, Loader2, MoreVertical, Trash2 } from "lucide-react";
 import { addMilliseconds, format } from "date-fns";
+import { Clipboard, Loader2, MoreVertical, Trash2 } from "lucide-react";
 import type { ReactNode } from "react";
 import { toast } from "sonner";
 import BlockHeader from "../views/blockHeader";

--- a/ui/app/workspace/logs/views/emptyState.tsx
+++ b/ui/app/workspace/logs/views/emptyState.tsx
@@ -3,8 +3,8 @@ import { Button } from "@/components/ui/button";
 import { CodeEditor } from "@/components/ui/codeEditor";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { getExampleBaseUrl } from "@/lib/utils/port";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { getExampleBaseUrl } from "@/lib/utils/port";
 import { AlertTriangle, Copy } from "lucide-react";
 import { useMemo, useState } from "react";
 
@@ -251,7 +251,7 @@ const result = await chain.invoke({ input: "What is LangChain?" });`,
 				</Alert>
 			)}
 
-			<div className="w-full space-y-6">
+			<div className="w-full space-y-6 p-4">
 				<div className="flex flex-row items-center gap-2">
 					<div>
 						<h3 className="text-lg font-semibold">Integrate under 60 seconds</h3>

--- a/ui/app/workspace/logs/views/filters.tsx
+++ b/ui/app/workspace/logs/views/filters.tsx
@@ -53,9 +53,19 @@ interface LogFiltersProps {
 	onLiveToggle: (enabled: boolean) => void;
 	fetchLogs: () => Promise<void>;
 	fetchStats: () => Promise<void>;
+	/** When true, hide FilterPopover and DateTimePicker (they live in the sidebar instead) */
+	hidePopoverFilters?: boolean;
 }
 
-export function LogFilters({ filters, onFiltersChange, liveEnabled, onLiveToggle, fetchLogs, fetchStats }: LogFiltersProps) {
+export function LogFilters({
+	filters,
+	onFiltersChange,
+	liveEnabled,
+	onLiveToggle,
+	fetchLogs,
+	fetchStats,
+	hidePopoverFilters,
+}: LogFiltersProps) {
 	const [openMoreActionsPopover, setOpenMoreActionsPopover] = useState(false);
 	const [localSearch, setLocalSearch] = useState(filters.content_search || "");
 	const searchTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -147,7 +157,7 @@ export function LogFilters({ filters, onFiltersChange, liveEnabled, onLiveToggle
 	);
 
 	return (
-		<div className="flex items-center justify-between space-x-2">
+		<div className="flex grow items-center justify-between space-x-2">
 			<Button variant={"outline"} size="sm" className="h-7.5" onClick={() => onLiveToggle(!liveEnabled)}>
 				{liveEnabled ? (
 					<>
@@ -172,43 +182,47 @@ export function LogFilters({ filters, onFiltersChange, liveEnabled, onLiveToggle
 				/>
 			</div>
 
-			<DateTimePickerWithRange
-				triggerTestId="filter-date-range"
-				dateTime={{
-					from: startTime,
-					to: endTime,
-				}}
-				onDateTimeUpdate={(p) => {
-					setStartTime(p.from);
-					setEndTime(p.to);
-					onFiltersChange({
-						...filters,
-						start_time: p.from?.toISOString(),
-						end_time: p.to?.toISOString(),
-					});
-				}}
-				preDefinedPeriods={LOG_TIME_PERIODS}
-				onPredefinedPeriodChange={(periodValue) => {
-					if (!periodValue) return;
-					const { from, to } = getRangeForPeriod(periodValue);
-					setStartTime(from);
-					setEndTime(to);
-					onFiltersChange({
-						...filters,
-						start_time: from.toISOString(),
-						end_time: to.toISOString(),
-					});
-				}}
-			/>
-			<FilterPopover
-				filters={filters}
-				onFilterChange={handleFilterChange}
-				onMetadataFilterChange={handleMetadataFilterChange}
-				showMissingCost
-			/>
+			{!hidePopoverFilters && (
+				<>
+					<DateTimePickerWithRange
+						triggerTestId="filter-date-range"
+						dateTime={{
+							from: startTime,
+							to: endTime,
+						}}
+						onDateTimeUpdate={(p) => {
+							setStartTime(p.from);
+							setEndTime(p.to);
+							onFiltersChange({
+								...filters,
+								start_time: p.from?.toISOString(),
+								end_time: p.to?.toISOString(),
+							});
+						}}
+						preDefinedPeriods={LOG_TIME_PERIODS}
+						onPredefinedPeriodChange={(periodValue) => {
+							if (!periodValue) return;
+							const { from, to } = getRangeForPeriod(periodValue);
+							setStartTime(from);
+							setEndTime(to);
+							onFiltersChange({
+								...filters,
+								start_time: from.toISOString(),
+								end_time: to.toISOString(),
+							});
+						}}
+					/>
+					<FilterPopover
+						filters={filters}
+						onFilterChange={handleFilterChange}
+						onMetadataFilterChange={handleMetadataFilterChange}
+						showMissingCost
+					/>
+				</>
+			)}
 			<Popover open={openMoreActionsPopover} onOpenChange={setOpenMoreActionsPopover}>
 				<PopoverTrigger asChild>
-					<Button variant="outline" size="sm" className="h-7.5">
+					<Button variant="outline" size="sm" className="h-7.5 w-7.5">
 						<MoreVertical className="h-4 w-4" />
 					</Button>
 				</PopoverTrigger>

--- a/ui/app/workspace/logs/views/logsSidebar.tsx
+++ b/ui/app/workspace/logs/views/logsSidebar.tsx
@@ -1,0 +1,735 @@
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scrollArea";
+import { Skeleton } from "@/components/ui/skeleton";
+import { RequestTypeLabels, RequestTypes, RoutingEngineUsedLabels, Statuses } from "@/lib/constants/logs";
+import { useGetAvailableFilterDataQuery, useGetProvidersQuery } from "@/lib/store";
+import type { LogFilters } from "@/lib/types/logs";
+import { cn } from "@/lib/utils";
+import { ChevronDown, RotateCcw } from "lucide-react";
+import { Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// LogsSidebar – orchestrator
+// ---------------------------------------------------------------------------
+
+interface LogsSidebarProps {
+	filters: LogFilters;
+	onFiltersChange: (filters: LogFilters) => void;
+}
+
+export function LogsSidebar({ filters, onFiltersChange }: LogsSidebarProps) {
+	const activeFilterCount = useMemo(() => {
+		const excludedKeys = ["start_time", "end_time", "content_search", "metadata_filters"];
+		let count = Object.entries(filters).reduce((c, [key, value]) => {
+			if (excludedKeys.includes(key)) return c;
+			if (Array.isArray(value)) return c + value.length;
+			return c + (value ? 1 : 0);
+		}, 0);
+		if (filters.metadata_filters) {
+			count += Object.keys(filters.metadata_filters).length;
+		}
+		return count;
+	}, [filters]);
+
+	const handleReset = useCallback(() => {
+		onFiltersChange({
+			start_time: filters.start_time,
+			end_time: filters.end_time,
+		});
+	}, [filters.start_time, filters.end_time, onFiltersChange]);
+
+	return (
+		<div className="bg-card flex h-full w-64 shrink-0 flex-col rounded-r-md">
+			{/* Header */}
+			<div className="flex h-11 items-center justify-between border-b pr-3 pl-5">
+				<span className="text-sm font-semibold">Filters</span>
+				{activeFilterCount > 0 && (
+					<Button
+						variant="outline"
+						size="sm"
+						className="text-muted-foreground h-7 px-2 text-xs"
+						onClick={handleReset}
+						data-testid="filters-reset-button"
+					>
+						<RotateCcw className="size-3" />
+						Reset
+					</Button>
+				)}
+			</div>
+
+			{/* Scrollable filter sections */}
+			<ScrollArea className="flex flex-1 overflow-y-auto p-2 pb-0" viewportClassName="no-table">
+				<div className="flex grow flex-col gap-1">
+					{/* First 2 open by default */}
+					<StatusFilter filters={filters} onFiltersChange={onFiltersChange} defaultOpen />
+					<ModelsFilter filters={filters} onFiltersChange={onFiltersChange} defaultOpen />
+					{/* Rest closed unless they have active filters */}
+					<SelectedKeysFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<VirtualKeysFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<ProvidersFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<TypeFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<AliasesFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<RoutingEnginesFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<RoutingRulesFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<SessionFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<CostFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<MetadataFilters filters={filters} onFiltersChange={onFiltersChange} />
+				</div>
+			</ScrollArea>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers & primitives
+// ---------------------------------------------------------------------------
+
+function groupByName(items: { name: string; id: string }[]) {
+	const map = new Map<string, string[]>();
+	for (const item of items) {
+		const ids = map.get(item.name) || [];
+		ids.push(item.id);
+		map.set(item.name, ids);
+	}
+	return map;
+}
+
+function dedup(items: { name: string }[]) {
+	return [...new Map(items.map((i) => [i.name, i])).values()].map((i) => i.name);
+}
+
+/** Shared props every individual filter component receives. */
+interface FilterComponentProps {
+	filters: LogFilters;
+	onFiltersChange: (filters: LogFilters) => void;
+	defaultOpen?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// FilterSection – collapsible wrapper
+// ---------------------------------------------------------------------------
+
+function FilterSectionSkeleton({ rows = 3 }: { rows?: number }) {
+	return (
+		<>
+			{Array.from({ length: rows }).map((_, i) => (
+				<div key={i} className="flex items-center gap-2.5 px-3 py-2">
+					<Skeleton className="size-4 shrink-0 rounded-[4px]" />
+					<Skeleton className="h-3.5 w-full rounded" />
+				</div>
+			))}
+		</>
+	);
+}
+
+function FilterSection({
+	title,
+	children,
+	defaultOpen = false,
+	loading = false,
+	onOpenChange,
+	testId,
+}: {
+	title: string;
+	children: React.ReactNode;
+	defaultOpen?: boolean;
+	loading?: boolean;
+	onOpenChange?: (open: boolean) => void;
+	testId?: string;
+}) {
+	const [open, setOpen] = useState(defaultOpen);
+
+	// Force open when defaultOpen flips to true (e.g. a filter in this section becomes active)
+	useEffect(() => {
+		if (defaultOpen) setOpen(true);
+	}, [defaultOpen]);
+
+	const handleOpenChange = (next: boolean) => {
+		setOpen(next);
+		onOpenChange?.(next);
+	};
+
+	return (
+		<Collapsible open={open} onOpenChange={handleOpenChange} className="last:pb-2">
+			<CollapsibleTrigger
+				className="flex h-8 w-full cursor-pointer items-center gap-1.5 px-2 py-2 text-sm font-medium hover:opacity-80"
+				data-testid={testId}
+			>
+				<ChevronDown className={cn("size-3.5 transition-transform", open ? "rotate-0" : "-rotate-90")} />
+				<span>{title}</span>
+			</CollapsibleTrigger>
+			<CollapsibleContent className="pt-1">
+				<div className="divide-border divide-y overflow-hidden rounded-sm border">{loading ? <FilterSectionSkeleton /> : children}</div>
+			</CollapsibleContent>
+		</Collapsible>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// CheckboxFilterItem – single checkbox row
+// ---------------------------------------------------------------------------
+
+function CheckboxFilterItem({
+	label,
+	checked,
+	onCheckedChange,
+	labelClassName,
+	testId,
+}: {
+	label: string;
+	checked: boolean;
+	onCheckedChange: (checked: boolean) => void;
+	labelClassName?: string;
+	testId?: string;
+}) {
+	return (
+		<label className="hover:bg-muted/50 flex cursor-pointer items-center gap-2.5 px-3 py-2 text-sm" data-testid={testId}>
+			<Checkbox checked={checked} onCheckedChange={onCheckedChange} />
+			<span className={cn("truncate", labelClassName)}>{label}</span>
+		</label>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// SearchableCheckboxList – list of checkbox rows with a search input.
+// Caller passes `inputRef` to control focus (see `useAutoFocusOnOpen`).
+// ---------------------------------------------------------------------------
+
+function useAutoFocusOnOpen(isOpen: boolean) {
+	const ref = useRef<HTMLInputElement>(null);
+	useEffect(() => {
+		if (isOpen) ref.current?.focus({ preventScroll: true });
+	}, [isOpen]);
+	return ref;
+}
+
+function SearchableCheckboxList({
+	items,
+	isSelected,
+	onToggle,
+	placeholder = "Search...",
+	inputRef,
+	testIdPrefix,
+}: {
+	items: { key: string; label: string }[];
+	isSelected: (key: string) => boolean;
+	onToggle: (key: string) => void;
+	placeholder?: string;
+	inputRef?: Ref<HTMLInputElement>;
+	testIdPrefix?: string;
+}) {
+	const [query, setQuery] = useState("");
+	const normalized = query.trim().toLowerCase();
+	const filtered = normalized ? items.filter((item) => item.label.toLowerCase().includes(normalized)) : items;
+
+	return (
+		<>
+			<div className="border-b">
+				<Input
+					ref={inputRef}
+					value={query}
+					onChange={(e) => setQuery(e.target.value)}
+					placeholder={placeholder}
+					className="h-8 border-0 text-xs"
+					data-testid={testIdPrefix ? `${testIdPrefix}-search` : undefined}
+				/>
+			</div>
+			{filtered.map((item) => (
+				<CheckboxFilterItem
+					key={item.key}
+					label={item.label}
+					checked={isSelected(item.key)}
+					onCheckedChange={() => onToggle(item.key)}
+					testId={testIdPrefix ? `${testIdPrefix}-checkbox-${item.key}` : undefined}
+				/>
+			))}
+			{filtered.length === 0 && <div className="text-muted-foreground flex h-9 items-center px-3 text-xs">No results</div>}
+		</>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// StatusFilter
+// ---------------------------------------------------------------------------
+
+function StatusFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = (filters.status || []).length > 0;
+	return (
+		<FilterSection title="Status" defaultOpen={defaultOpen || hasActive} testId="status-filter-toggle">
+			{Statuses.map((status) => (
+				<CheckboxFilterItem
+					key={status}
+					labelClassName="capitalize"
+					label={status}
+					checked={(filters.status || []).includes(status)}
+					onCheckedChange={() => {
+						const current = filters.status || [];
+						const next = current.includes(status) ? current.filter((s) => s !== status) : [...current, status];
+						onFiltersChange({ ...filters, status: next });
+					}}
+					testId={`status-filter-checkbox-${status}`}
+				/>
+			))}
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// ProvidersFilter – fetches providers internally
+// ---------------------------------------------------------------------------
+
+function ProvidersFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = (filters.providers || []).length > 0;
+	const [opened, setOpened] = useState(defaultOpen || hasActive);
+	const searchInputRef = useAutoFocusOnOpen(opened);
+	const { data: providersData, isUninitialized, isLoading } = useGetProvidersQuery(undefined, { skip: !opened && !hasActive });
+	const availableProviders = providersData || [];
+
+	// Hide only if data was fetched (not loading) and came back empty
+	if (!isUninitialized && !isLoading && availableProviders.length === 0 && !hasActive) return null;
+
+	return (
+		<FilterSection
+			title="Providers"
+			defaultOpen={defaultOpen || hasActive}
+			loading={isLoading}
+			onOpenChange={setOpened}
+			testId="providers-filter-toggle"
+		>
+			<SearchableCheckboxList
+				inputRef={searchInputRef}
+				placeholder="Search providers"
+				items={availableProviders.map((p) => ({ key: p.name, label: p.name }))}
+				isSelected={(name) => (filters.providers || []).includes(name)}
+				onToggle={(name) => {
+					const current = filters.providers || [];
+					const next = current.includes(name) ? current.filter((p) => p !== name) : [...current, name];
+					onFiltersChange({ ...filters, providers: next });
+				}}
+				testIdPrefix="providers-filter"
+			/>
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// TypeFilter
+// ---------------------------------------------------------------------------
+
+function TypeFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = (filters.objects || []).length > 0;
+	return (
+		<FilterSection title="Type" defaultOpen={defaultOpen || hasActive} testId="type-filter-toggle">
+			{RequestTypes.map((type) => {
+				const label = RequestTypeLabels[type as keyof typeof RequestTypeLabels] ?? type;
+				return (
+					<CheckboxFilterItem
+						key={type}
+						label={label}
+						checked={(filters.objects || []).includes(type)}
+						onCheckedChange={() => {
+							const current = filters.objects || [];
+							const next = current.includes(type) ? current.filter((t) => t !== type) : [...current, type];
+							onFiltersChange({ ...filters, objects: next });
+						}}
+						testId={`type-filter-checkbox-${type}`}
+					/>
+				);
+			})}
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// ModelsFilter – fetches available models internally
+// ---------------------------------------------------------------------------
+
+function ModelsFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = (filters.models || []).length > 0;
+	const [opened, setOpened] = useState(defaultOpen || hasActive);
+	const searchInputRef = useAutoFocusOnOpen(opened);
+	const { data: filterData, isUninitialized, isLoading } = useGetAvailableFilterDataQuery(undefined, { skip: !opened && !hasActive });
+	const availableModels = filterData?.models || [];
+
+	if (!isUninitialized && !isLoading && availableModels.length === 0 && !hasActive) return null;
+
+	return (
+		<FilterSection
+			title="Models"
+			defaultOpen={defaultOpen || hasActive}
+			loading={isLoading}
+			onOpenChange={setOpened}
+			testId="models-filter-toggle"
+		>
+			<SearchableCheckboxList
+				inputRef={searchInputRef}
+				placeholder="Search models"
+				items={availableModels.map((m) => ({ key: m, label: m }))}
+				isSelected={(model) => (filters.models || []).includes(model)}
+				onToggle={(model) => {
+					const current = filters.models || [];
+					const next = current.includes(model) ? current.filter((m) => m !== model) : [...current, model];
+					onFiltersChange({ ...filters, models: next });
+				}}
+				testIdPrefix="models-filter"
+			/>
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// AliasesFilter – fetches available aliases internally
+// ---------------------------------------------------------------------------
+
+function AliasesFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = (filters.aliases || []).length > 0;
+	const [opened, setOpened] = useState(defaultOpen || hasActive);
+	const searchInputRef = useAutoFocusOnOpen(opened);
+	const { data: filterData, isUninitialized, isLoading } = useGetAvailableFilterDataQuery(undefined, { skip: !opened && !hasActive });
+	const availableAliases = filterData?.aliases || [];
+
+	if (!isUninitialized && !isLoading && availableAliases.length === 0 && !hasActive) return null;
+
+	return (
+		<FilterSection
+			title="Aliases"
+			defaultOpen={defaultOpen || hasActive}
+			loading={isLoading}
+			onOpenChange={setOpened}
+			testId="aliases-filter-toggle"
+		>
+			<SearchableCheckboxList
+				inputRef={searchInputRef}
+				placeholder="Search aliases"
+				items={availableAliases.map((a) => ({ key: a, label: a }))}
+				isSelected={(alias) => (filters.aliases || []).includes(alias)}
+				onToggle={(alias) => {
+					const current = filters.aliases || [];
+					const next = current.includes(alias) ? current.filter((a) => a !== alias) : [...current, alias];
+					onFiltersChange({ ...filters, aliases: next });
+				}}
+				testIdPrefix="aliases-filter"
+			/>
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// SelectedKeysFilter – fetches keys, resolves name→IDs for deduplication
+// ---------------------------------------------------------------------------
+
+function SelectedKeysFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = (filters.selected_key_ids || []).length > 0;
+	const [opened, setOpened] = useState(defaultOpen || hasActive);
+	const searchInputRef = useAutoFocusOnOpen(opened);
+	const { data: filterData, isUninitialized, isLoading } = useGetAvailableFilterDataQuery(undefined, { skip: !opened && !hasActive });
+	const availableSelectedKeys = filterData?.selected_keys || [];
+	const nameToIds = useMemo(() => groupByName(availableSelectedKeys), [availableSelectedKeys]);
+
+	if (!isUninitialized && !isLoading && availableSelectedKeys.length === 0 && !hasActive) return null;
+
+	const toggle = (name: string) => {
+		const resolvedIds = nameToIds.get(name) || [name];
+		const current = filters.selected_key_ids || [];
+		const allSelected = resolvedIds.every((id) => current.includes(id));
+		const next = allSelected
+			? current.filter((v) => !resolvedIds.includes(v))
+			: [...current, ...resolvedIds.filter((id) => !current.includes(id))];
+		onFiltersChange({ ...filters, selected_key_ids: next });
+	};
+
+	const isSelected = (name: string) => {
+		const resolvedIds = nameToIds.get(name) || [name];
+		const current = filters.selected_key_ids || [];
+		return resolvedIds.every((id) => current.includes(id));
+	};
+
+	return (
+		<FilterSection
+			title="Selected Keys"
+			defaultOpen={defaultOpen || hasActive}
+			loading={isLoading}
+			onOpenChange={setOpened}
+			testId="selected-keys-filter-toggle"
+		>
+			<SearchableCheckboxList
+				inputRef={searchInputRef}
+				placeholder="Search keys"
+				items={dedup(availableSelectedKeys).map((name) => ({ key: name, label: name }))}
+				isSelected={isSelected}
+				onToggle={toggle}
+				testIdPrefix="selected-keys-filter"
+			/>
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// VirtualKeysFilter
+// ---------------------------------------------------------------------------
+
+function VirtualKeysFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = (filters.virtual_key_ids || []).length > 0;
+	const [opened, setOpened] = useState(defaultOpen || hasActive);
+	const searchInputRef = useAutoFocusOnOpen(opened);
+	const { data: filterData, isUninitialized, isLoading } = useGetAvailableFilterDataQuery(undefined, { skip: !opened && !hasActive });
+	const availableVirtualKeys = filterData?.virtual_keys || [];
+	const nameToIds = useMemo(() => groupByName(availableVirtualKeys), [availableVirtualKeys]);
+
+	if (!isUninitialized && !isLoading && availableVirtualKeys.length === 0 && !hasActive) return null;
+
+	const toggle = (name: string) => {
+		const resolvedIds = nameToIds.get(name) || [name];
+		const current = filters.virtual_key_ids || [];
+		const allSelected = resolvedIds.every((id) => current.includes(id));
+		const next = allSelected
+			? current.filter((v) => !resolvedIds.includes(v))
+			: [...current, ...resolvedIds.filter((id) => !current.includes(id))];
+		onFiltersChange({ ...filters, virtual_key_ids: next });
+	};
+
+	const isSelected = (name: string) => {
+		const resolvedIds = nameToIds.get(name) || [name];
+		const current = filters.virtual_key_ids || [];
+		return resolvedIds.every((id) => current.includes(id));
+	};
+
+	return (
+		<FilterSection
+			title="Virtual Keys"
+			defaultOpen={defaultOpen || hasActive}
+			loading={isLoading}
+			onOpenChange={setOpened}
+			testId="virtual-keys-filter-toggle"
+		>
+			<SearchableCheckboxList
+				inputRef={searchInputRef}
+				placeholder="Search virtual keys"
+				items={dedup(availableVirtualKeys).map((name) => ({ key: name, label: name }))}
+				isSelected={isSelected}
+				onToggle={toggle}
+				testIdPrefix="virtual-keys-filter"
+			/>
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// RoutingEnginesFilter
+// ---------------------------------------------------------------------------
+
+function RoutingEnginesFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = (filters.routing_engine_used || []).length > 0;
+	const [opened, setOpened] = useState(defaultOpen || hasActive);
+	const searchInputRef = useAutoFocusOnOpen(opened);
+	const { data: filterData, isUninitialized, isLoading } = useGetAvailableFilterDataQuery(undefined, { skip: !opened && !hasActive });
+	const availableRoutingEngines = filterData?.routing_engines || [];
+
+	if (!isUninitialized && !isLoading && availableRoutingEngines.length === 0 && !hasActive) return null;
+
+	return (
+		<FilterSection
+			title="Routing Engines"
+			defaultOpen={defaultOpen || hasActive}
+			loading={isLoading}
+			onOpenChange={setOpened}
+			testId="routing-engines-filter-toggle"
+		>
+			<SearchableCheckboxList
+				inputRef={searchInputRef}
+				placeholder="Search engines"
+				items={availableRoutingEngines.map((engine) => ({
+					key: engine,
+					label: RoutingEngineUsedLabels[engine as keyof typeof RoutingEngineUsedLabels] ?? engine,
+				}))}
+				isSelected={(engine) => (filters.routing_engine_used || []).includes(engine)}
+				onToggle={(engine) => {
+					const current = filters.routing_engine_used || [];
+					const next = current.includes(engine) ? current.filter((e) => e !== engine) : [...current, engine];
+					onFiltersChange({ ...filters, routing_engine_used: next });
+				}}
+				testIdPrefix="routing-engines-filter"
+			/>
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// RoutingRulesFilter
+// ---------------------------------------------------------------------------
+
+function RoutingRulesFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = (filters.routing_rule_ids || []).length > 0;
+	const [opened, setOpened] = useState(defaultOpen || hasActive);
+	const searchInputRef = useAutoFocusOnOpen(opened);
+	const { data: filterData, isUninitialized, isLoading } = useGetAvailableFilterDataQuery(undefined, { skip: !opened && !hasActive });
+	const availableRoutingRules = filterData?.routing_rules || [];
+	const nameToIds = useMemo(() => groupByName(availableRoutingRules), [availableRoutingRules]);
+
+	if (!isUninitialized && !isLoading && availableRoutingRules.length === 0 && !hasActive) return null;
+
+	const toggle = (name: string) => {
+		const resolvedIds = nameToIds.get(name) || [name];
+		const current = filters.routing_rule_ids || [];
+		const allSelected = resolvedIds.every((id) => current.includes(id));
+		const next = allSelected
+			? current.filter((v) => !resolvedIds.includes(v))
+			: [...current, ...resolvedIds.filter((id) => !current.includes(id))];
+		onFiltersChange({ ...filters, routing_rule_ids: next });
+	};
+
+	const isSelected = (name: string) => {
+		const resolvedIds = nameToIds.get(name) || [name];
+		const current = filters.routing_rule_ids || [];
+		return resolvedIds.every((id) => current.includes(id));
+	};
+
+	return (
+		<FilterSection
+			title="Routing Rules"
+			defaultOpen={defaultOpen || hasActive}
+			loading={isLoading}
+			onOpenChange={setOpened}
+			testId="routing-rules-filter-toggle"
+		>
+			<SearchableCheckboxList
+				inputRef={searchInputRef}
+				placeholder="Search rules"
+				items={dedup(availableRoutingRules).map((name) => ({ key: name, label: name }))}
+				isSelected={isSelected}
+				onToggle={toggle}
+				testIdPrefix="routing-rules-filter"
+			/>
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// SessionFilter
+// ---------------------------------------------------------------------------
+
+function SessionFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = !!filters.parent_request_id;
+	return (
+		<FilterSection title="Session" defaultOpen={defaultOpen || hasActive} testId="session-filter-toggle">
+			<div className="px-3 py-2.5">
+				<Input
+					value={filters.parent_request_id || ""}
+					onChange={(e) => onFiltersChange({ ...filters, parent_request_id: e.target.value })}
+					placeholder="Parent request ID"
+					className="h-8 text-sm"
+					data-testid="session-filter-input"
+				/>
+			</div>
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// CostFilter
+// ---------------------------------------------------------------------------
+
+function CostFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = !!filters.missing_cost_only;
+	return (
+		<FilterSection title="Cost" defaultOpen={defaultOpen || hasActive} testId="cost-filter-toggle">
+			<CheckboxFilterItem
+				label="Show missing cost only"
+				checked={!!filters.missing_cost_only}
+				onCheckedChange={(checked) => onFiltersChange({ ...filters, missing_cost_only: !!checked })}
+				testId="cost-filter-missing-only-checkbox"
+			/>
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// MetadataFilters – fetches metadata keys internally
+// ---------------------------------------------------------------------------
+
+function MetadataFilters({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = !!filters.metadata_filters && Object.keys(filters.metadata_filters).length > 0;
+	const [opened, setOpened] = useState(defaultOpen || hasActive);
+	const { data: filterData, isUninitialized, isLoading } = useGetAvailableFilterDataQuery(undefined, { skip: !opened && !hasActive });
+	const availableMetadataKeys = filterData?.metadata_keys || {};
+	const [customInputs, setCustomInputs] = useState<Record<string, string>>({});
+
+	const handleChange = useCallback(
+		(metadataKey: string, value: string | undefined) => {
+			const current = { ...(filters.metadata_filters || {}) };
+			if (value === undefined) {
+				delete current[metadataKey];
+			} else {
+				current[metadataKey] = value;
+			}
+			onFiltersChange({
+				...filters,
+				metadata_filters: Object.keys(current).length > 0 ? current : undefined,
+			});
+		},
+		[filters, onFiltersChange],
+	);
+
+	const entries = Object.entries(availableMetadataKeys);
+	const isEmpty = !isUninitialized && !isLoading && entries.length === 0 && !hasActive;
+
+	return (
+		<FilterSection
+			title="Metadata"
+			defaultOpen={defaultOpen || hasActive}
+			loading={isLoading}
+			onOpenChange={setOpened}
+			testId="metadata-filter-toggle"
+		>
+			{isEmpty ? (
+				<div className="text-muted-foreground px-3 py-2 text-xs">No metadata keys</div>
+			) : (
+				entries.map(([metadataKey, values]) => (
+					<div key={metadataKey} data-testid={`metadata-${metadataKey}-filter-group`}>
+						<div className="text-muted-foreground px-3 pt-2 pb-1 text-xs font-medium">{metadataKey}</div>
+						{values.map((value: string) => (
+							<CheckboxFilterItem
+								key={value}
+								label={value}
+								checked={filters.metadata_filters?.[metadataKey] === value}
+								onCheckedChange={() => {
+									const currentValue = filters.metadata_filters?.[metadataKey];
+									handleChange(metadataKey, currentValue === value ? undefined : value);
+								}}
+								testId={`metadata-${metadataKey}-filter-checkbox-${value}`}
+							/>
+						))}
+						<div className="px-3 py-2.5">
+							<Input
+								className="placeholder:text-muted-foreground h-7 w-full rounded border bg-transparent px-2 text-sm"
+								placeholder="Custom value..."
+								value={
+									customInputs[metadataKey] ??
+									(filters.metadata_filters?.[metadataKey] && !values.includes(filters.metadata_filters[metadataKey])
+										? filters.metadata_filters[metadataKey]
+										: "")
+								}
+								onChange={(e) => {
+									const newVal = e.target.value;
+									setCustomInputs((prev) => ({ ...prev, [metadataKey]: newVal }));
+									if (newVal === "" && filters.metadata_filters?.[metadataKey]) {
+										handleChange(metadataKey, undefined);
+									}
+								}}
+								onKeyDown={(e) => {
+									if (e.key === "Enter" && customInputs[metadataKey]?.trim()) {
+										handleChange(metadataKey, customInputs[metadataKey].trim());
+									}
+								}}
+								data-testid={`metadata-${metadataKey}-filter-custom-input`}
+							/>
+						</div>
+					</div>
+				))
+			)}
+		</FilterSection>
+	);
+}

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -44,6 +44,8 @@ interface DataTableProps {
 	onLiveToggle: (enabled: boolean) => void;
 	fetchLogs: () => Promise<void>;
 	fetchStats: () => Promise<void>;
+	/** When true, filters are rendered in a sidebar — hide them from the table header */
+	sidebarFilters?: boolean;
 }
 
 export function LogsDataTable({
@@ -61,6 +63,7 @@ export function LogsDataTable({
 	onLiveToggle,
 	fetchLogs,
 	fetchStats,
+	sidebarFilters = false,
 }: DataTableProps) {
 	const [sorting, setSorting] = useState<SortingState>([{ id: pagination.sort_by, desc: pagination.order === "desc" }]);
 	const tableContainerRef = useRef<HTMLDivElement>(null);
@@ -165,16 +168,30 @@ export function LogsDataTable({
 	return (
 		<div className="flex h-full flex-col gap-2">
 			<div className="flex shrink-0 items-center gap-2">
-				<div className="flex-1">
-					<LogFiltersComponent
-						filters={filters}
-						onFiltersChange={onFiltersChange}
-						liveEnabled={liveEnabled}
-						onLiveToggle={onLiveToggle}
-						fetchLogs={fetchLogs}
-						fetchStats={fetchStats}
-					/>
-				</div>
+				{sidebarFilters ? (
+					<div className="flex flex-1 items-center gap-2">
+						<LogFiltersComponent
+							filters={filters}
+							onFiltersChange={onFiltersChange}
+							liveEnabled={liveEnabled}
+							onLiveToggle={onLiveToggle}
+							fetchLogs={fetchLogs}
+							fetchStats={fetchStats}
+							hidePopoverFilters
+						/>
+					</div>
+				) : (
+					<div className="flex-1">
+						<LogFiltersComponent
+							filters={filters}
+							onFiltersChange={onFiltersChange}
+							liveEnabled={liveEnabled}
+							onLiveToggle={onLiveToggle}
+							fetchLogs={fetchLogs}
+							fetchStats={fetchStats}
+						/>
+					</div>
+				)}
 				<ColumnConfigDropdown entries={entries} labels={columnLabels} onToggleVisibility={toggleVisibility} onReset={reset} />
 			</div>
 

--- a/ui/app/workspace/logs/views/logsVolumeChart.tsx
+++ b/ui/app/workspace/logs/views/logsVolumeChart.tsx
@@ -318,7 +318,7 @@ export function LogsVolumeChart({
 						</div>
 					</div>
 				</div>
-				<div className="" style={{ height: "131px", marginTop: 4 }}>
+				<div className="" style={{ height: "128px", marginTop: 8 }}>
 					<Skeleton className="h-full w-full" />
 				</div>
 			</Card>

--- a/ui/components/table/columnConfigDropdown.tsx
+++ b/ui/components/table/columnConfigDropdown.tsx
@@ -1,8 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import type { ColumnConfigEntry } from "./hooks/useColumnConfig";
 import { Columns3, RotateCcw } from "lucide-react";
+import type { ColumnConfigEntry } from "./hooks/useColumnConfig";
 
 interface ColumnConfigDropdownProps {
 	entries: ColumnConfigEntry[];
@@ -22,7 +22,7 @@ export function ColumnConfigDropdown({ entries, labels = {}, onToggleVisibility,
 	return (
 		<Popover>
 			<PopoverTrigger asChild>
-				<Button variant="outline" size="sm" className="h-7.5" data-testid="column-config-trigger" aria-label="Column configuration">
+				<Button variant="outline" size="sm" className="h-7.5 w-7.5" data-testid="column-config-trigger" aria-label="Column configuration">
 					<Columns3 className="h-4 w-4" />
 				</Button>
 			</PopoverTrigger>


### PR DESCRIPTION
## Summary

Refactored the dashboard page to use a sidebar-based filtering interface instead of inline filter components, improving the user experience and layout consistency.

## Changes

- Replaced `FilterPopover` with `LogsSidebar` component for a persistent filtering interface
- Removed predefined time periods and custom date range picker from the header
- Restructured the layout to use a sidebar + main content area with `ScrollArea`
- Simplified filter handling by replacing individual filter change handlers with a unified `setFilters` function that accepts a complete `LogFilters` object
- Removed unused time period utilities and date range management code
- Updated the layout to use full viewport height with proper spacing and rounded corners

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the dashboard page and verify:
1. The sidebar appears on the left with filtering options
2. All dashboard tabs (Overview, Provider Usage, Model Rankings, MCP usage, User Rankings) function correctly
3. Filters in the sidebar properly update the dashboard data
4. The layout is responsive and scrollable
5. MCP-specific filters still appear in the header when on the MCP tab

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

No security implications - this is a UI layout refactor that doesn't change data handling or authentication.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable