### PR TITLE
removed keycloak

### DIFF
--- a/docs/enterprise/user-provisioning.mdx
+++ b/docs/enterprise/user-provisioning.mdx
@@ -37,9 +37,6 @@ Pick your IdP to follow a step-by-step setup guide. All providers share the same
   <Card title="Zitadel" icon="cloud" href="/enterprise/setting-up-zitadel">
     Cloud or self-hosted Zitadel with project-scoped role claims and service-account-based provisioning.
   </Card>
-  <Card title="Keycloak" icon="lock" href="/enterprise/setting-up-keycloak">
-    Self-hosted Keycloak with realm roles, group path claims, and Admin REST API access.
-  </Card>
   <Card title="Google Workspace" icon="google" href="/enterprise/setting-up-google-workspace">
     Google Workspace domains with OAuth login plus optional Directory API sync via a service account.
   </Card>


### PR DESCRIPTION
## Summary

Removes Keycloak as a supported Identity Provider option from the user provisioning documentation.

## Changes

- Removed the Keycloak card from the IdP selection guide in the user provisioning documentation
- The card previously described Keycloak as supporting "Self-hosted Keycloak with realm roles, group path claims, and Admin REST API access"

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

Verify the user provisioning documentation page renders correctly without the Keycloak option:

```sh
# Navigate to the docs directory and build/serve the documentation
# Verify that /enterprise/user-provisioning page no longer shows Keycloak as an option
# Confirm other IdP options (Zitadel, Google Workspace) are still present and functional
```

## Screenshots/Recordings

N/A - Documentation change only

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this is a documentation-only change removing reference to an IdP option.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable