### PR TITLE
fix: delete fallbacks from anthropic req

### DIFF
--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -235,6 +235,13 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 			}
 		}
 	}
+
+	// delete fallbacks field
+	jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "fallbacks")
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+	}
+
 	return jsonBody, nil
 }
 

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -1474,6 +1474,39 @@ func TestAnthropicToolUnmarshalJSON_MCPToolset(t *testing.T) {
 	})
 }
 
+func TestGetRequestBodyForResponses_RawBodyStripsFallbacks(t *testing.T) {
+	rawBody := []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"messages":[{"role":"user","content":"hello"}],"fallbacks":["claude-haiku-4-5"],"temperature":0.7}`)
+
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+	request := &schemas.BifrostResponsesRequest{
+		Provider:       schemas.Anthropic,
+		Model:          "claude-sonnet-4-5",
+		RawRequestBody: rawBody,
+	}
+
+	result, bifrostErr := getRequestBodyForResponses(ctx, request, schemas.Anthropic, false, nil)
+	if bifrostErr != nil {
+		t.Fatalf("unexpected error: %v", bifrostErr)
+	}
+
+	if providerUtils.GetJSONField(result, "fallbacks").Exists() {
+		t.Error("expected 'fallbacks' to be absent from raw-body output")
+	}
+
+	// Other fields must survive the round-trip
+	if !providerUtils.GetJSONField(result, "model").Exists() {
+		t.Error("expected 'model' to be present")
+	}
+	if !providerUtils.GetJSONField(result, "max_tokens").Exists() {
+		t.Error("expected 'max_tokens' to be present")
+	}
+	if !providerUtils.GetJSONField(result, "temperature").Exists() {
+		t.Error("expected 'temperature' to be present")
+	}
+}
+
 func TestApplyMCPToolsetConfigToBifrostTool(t *testing.T) {
 	t.Run("allowlist pattern merges correctly", func(t *testing.T) {
 		bifrostTool := &schemas.ResponsesTool{


### PR DESCRIPTION
## Summary

Remove the `fallbacks` field from Anthropic provider request bodies to ensure compatibility with the Anthropic API specification.

## Changes

- Added logic to delete the `fallbacks` field from JSON request bodies in the Anthropic provider's `getRequestBodyForResponses` function
- Implemented proper error handling for the field deletion operation with appropriate Bifrost error wrapping

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Test Anthropic provider requests to ensure the `fallbacks` field is properly removed and requests succeed:

```sh
# Core/Transports
go version
go test ./...

# Test specific Anthropic provider functionality
go test ./core/providers/anthropic/...
```

Verify that requests to the Anthropic API no longer include the `fallbacks` field and complete successfully.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - this change only removes an unsupported field from API requests.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable