### PR TITLE
feat: assign virtual keys on teams page directly

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -28815,6 +28815,10 @@
                             "type": "integer",
                             "description": "Number of members in the team"
                           },
+                          "virtual_key_count": {
+                            "type": "integer",
+                            "description": "Number of virtual keys assigned to the team"
+                          },
                           "created_at": {
                             "type": "string",
                             "format": "date-time"
@@ -28976,6 +28980,10 @@
                     "member_count": {
                       "type": "integer",
                       "description": "Number of members in the team"
+                    },
+                    "virtual_key_count": {
+                      "type": "integer",
+                      "description": "Number of virtual keys assigned to the team"
                     },
                     "created_at": {
                       "type": "string",
@@ -41525,6 +41533,12 @@
         "in": "header",
         "name": "x-api-key",
         "description": "API key authentication via the `x-api-key` header.\nVirtual keys (prefixed with `sk-bf-`) can also be passed here.\n"
+      },
+      "GoogleApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-goog-api-key",
+        "description": "Google API key authentication via the `x-goog-api-key` header.\nVirtual keys (prefixed with `sk-bf-`) can also be passed here.\n"
       }
     },
     "parameters": {
@@ -53765,6 +53779,8 @@
           },
           "virtual_keys": {
             "type": "array",
+            "nullable": true,
+            "description": "Virtual keys assigned to this team. This field may be omitted or returned as null in some responses (for example, when a team is embedded inside a virtual-key response) to avoid nested `virtual_keys` recursion.\n",
             "items": {
               "$ref": "#/components/schemas/VirtualKey"
             }

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -376,6 +376,11 @@ Team:
       $ref: '#/Budget'
     virtual_keys:
       type: array
+      nullable: true
+      description: >
+        Virtual keys assigned to this team. This field may be omitted or returned as null in some
+        responses (for example, when a team is embedded inside a virtual-key response) to avoid
+        nested `virtual_keys` recursion.
       items:
         $ref: '#/VirtualKey'
     profile:

--- a/docs/openapi/schemas/management/users.yaml
+++ b/docs/openapi/schemas/management/users.yaml
@@ -155,6 +155,9 @@ TeamObject:
     member_count:
       type: integer
       description: Number of members in the team
+    virtual_key_count:
+      type: integer
+      description: Number of virtual keys assigned to the team
     created_at:
       type: string
       format: date-time

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2519,10 +2519,14 @@ func (s *RDBConfigStore) DeleteVirtualKeyMCPConfig(ctx context.Context, id uint,
 	return txDB.WithContext(ctx).Delete(&tables.TableVirtualKeyMCPConfig{}, "id = ?", id).Error
 }
 
+const teamSelectWithVKCount = "governance_teams.*, (SELECT COUNT(*) FROM governance_virtual_keys WHERE team_id = governance_teams.id) AS virtual_key_count"
+
 // GetTeams retrieves all teams from the database.
 func (s *RDBConfigStore) GetTeams(ctx context.Context, customerID string) ([]tables.TableTeam, error) {
 	// Preload relationships for complete information
-	query := s.db.WithContext(ctx).Preload("Customer").Preload("Budget").Preload("RateLimit")
+	query := s.db.WithContext(ctx).
+		Select(teamSelectWithVKCount).
+		Preload("Customer").Preload("Budget").Preload("RateLimit")
 	// Optional filtering by customer
 	if customerID != "" {
 		query = query.Where("customer_id = ?", customerID)
@@ -2564,6 +2568,7 @@ func (s *RDBConfigStore) GetTeamsPaginated(ctx context.Context, params TeamsQuer
 
 	var teams []tables.TableTeam
 	if err := baseQuery.
+		Select(teamSelectWithVKCount).
 		Preload("Customer").Preload("Budget").Preload("RateLimit").
 		Order("created_at ASC, id ASC").
 		Offset(offset).Limit(limit).
@@ -2577,7 +2582,10 @@ func (s *RDBConfigStore) GetTeamsPaginated(ctx context.Context, params TeamsQuer
 // GetTeam retrieves a specific team from the database.
 func (s *RDBConfigStore) GetTeam(ctx context.Context, id string) (*tables.TableTeam, error) {
 	var team tables.TableTeam
-	if err := s.db.WithContext(ctx).Preload("Customer").Preload("Budget").Preload("RateLimit").First(&team, "id = ?", id).Error; err != nil {
+	if err := s.db.WithContext(ctx).
+		Select(teamSelectWithVKCount).
+		Preload("Customer").Preload("Budget").Preload("RateLimit").
+		First(&team, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -3425,7 +3433,9 @@ func (s *RDBConfigStore) GetGovernanceConfig(ctx context.Context) (*GovernanceCo
 		Find(&virtualKeys).Error; err != nil {
 		return nil, err
 	}
-	if err := s.db.WithContext(ctx).Find(&teams).Error; err != nil {
+	if err := s.db.WithContext(ctx).
+		Select(teamSelectWithVKCount).
+		Find(&teams).Error; err != nil {
 		return nil, err
 	}
 	if err := s.db.WithContext(ctx).Find(&customers).Error; err != nil {

--- a/framework/configstore/tables/team.go
+++ b/framework/configstore/tables/team.go
@@ -20,7 +20,10 @@ type TableTeam struct {
 	Customer    *TableCustomer    `gorm:"foreignKey:CustomerID" json:"customer,omitempty"`
 	Budget      *TableBudget      `gorm:"foreignKey:BudgetID" json:"budget,omitempty"`
 	RateLimit   *TableRateLimit   `gorm:"foreignKey:RateLimitID" json:"rate_limit,omitempty"`
-	VirtualKeys []TableVirtualKey `gorm:"foreignKey:TeamID" json:"virtual_keys"`
+	VirtualKeys []TableVirtualKey `gorm:"foreignKey:TeamID" json:"virtual_keys,omitempty"`
+
+	// Computed (not a DB column) — populated via correlated subquery in query layer, hence no migration
+	VirtualKeyCount int64 `gorm:"->;-:migration" json:"virtual_key_count"`
 
 	Profile       *string                `gorm:"type:text" json:"-"`
 	ParsedProfile map[string]interface{} `gorm:"-" json:"profile"`

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -283,6 +283,9 @@ func (gs *LocalGovernanceStore) GetGovernanceData() *GovernanceData {
 		}
 		clone := *team
 		refreshTeamAssociations(&clone)
+		// Reset to 0 — will be recomputed from live VKs below to stay accurate
+		// after creates/updates/deletes that don't trigger a full ReloadTeam.
+		clone.VirtualKeyCount = 0
 		teams[key.(string)] = &clone
 		return true // continue iteration
 	})
@@ -313,6 +316,27 @@ func (gs *LocalGovernanceStore) GetGovernanceData() *GovernanceData {
 		return true // continue iteration
 	})
 
+	for _, vk := range virtualKeys {
+		if vk == nil {
+			continue
+		}
+		if vk.TeamID != nil {
+			if team, exists := teams[*vk.TeamID]; exists && team != nil {
+				vk.Team = team
+				team.VirtualKeyCount++
+			}
+		}
+		if vk.CustomerID != nil {
+			if customer, exists := customers[*vk.CustomerID]; exists && customer != nil {
+				vk.Customer = customer
+
+				nestedVK := *vk
+				nestedVK.Customer = nil
+				customer.VirtualKeys = append(customer.VirtualKeys, nestedVK)
+			}
+		}
+	}
+
 	for _, team := range teams {
 		if team == nil {
 			continue
@@ -324,26 +348,6 @@ func (gs *LocalGovernanceStore) GetGovernanceData() *GovernanceData {
 				nestedTeam := *team
 				nestedTeam.Customer = nil
 				customer.Teams = append(customer.Teams, nestedTeam)
-			}
-		}
-	}
-
-	for _, vk := range virtualKeys {
-		if vk == nil {
-			continue
-		}
-		if vk.TeamID != nil {
-			if team, exists := teams[*vk.TeamID]; exists && team != nil {
-				vk.Team = team
-			}
-		}
-		if vk.CustomerID != nil {
-			if customer, exists := customers[*vk.CustomerID]; exists && customer != nil {
-				vk.Customer = customer
-
-				nestedVK := *vk
-				nestedVK.Customer = nil
-				customer.VirtualKeys = append(customer.VirtualKeys, nestedVK)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Adds a virtual key count field to team queries to display the number of virtual keys associated with each team without requiring additional database queries or loading the full virtual keys collection.

## Changes

- Added `VirtualKeyCount` field to `TableTeam` struct as a computed field populated via correlated subquery
- Modified `GetTeams`, `GetTeamsPaginated`, and `GetTeam` methods to include virtual key count in SELECT queries
- Updated TypeScript types to allow nullable `team_id` and `customer_id` in `UpdateVirtualKeyRequest`
- Changed `VirtualKeys` field in team table to be omitempty for cleaner JSON responses

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Verify that team queries return the virtual key count and that virtual key updates handle nullable team/customer IDs:

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Test API endpoints that retrieve teams to ensure `virtual_key_count` field is populated correctly.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The correlated subquery only counts records and doesn't expose sensitive virtual key data. No additional security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable