### PR TITLE
ci: support extraEnv map on helm values

### DIFF
--- a/helm-charts/bifrost/templates/deployment.yaml
+++ b/helm-charts/bifrost/templates/deployment.yaml
@@ -237,6 +237,12 @@ spec:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- range $name := keys . | sortAlpha }}
+            - name: {{ $name }}
+              value: {{ index $.Values.extraEnv $name | quote }}
+            {{- end }}
+            {{- end }}
           {{- with .Values.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/helm-charts/bifrost/templates/stateful.yaml
+++ b/helm-charts/bifrost/templates/stateful.yaml
@@ -237,6 +237,12 @@ spec:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- range $name := keys . | sortAlpha }}
+            - name: {{ $name }}
+              value: {{ index $.Values.extraEnv $name | quote }}
+            {{- end }}
+            {{- end }}
           {{- with .Values.envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}

--- a/helm-charts/bifrost/values-examples/providers-and-virtual-keys.yaml
+++ b/helm-charts/bifrost/values-examples/providers-and-virtual-keys.yaml
@@ -9,7 +9,7 @@
 #   - Cloud-native providers with nested config (azure, vertex, bedrock)
 #
 # Secrets are referenced via env.VAR_NAME (see ENVIRONMENT VARIABLES block
-# below). Provide them via extraEnv, externalSecrets, or a Kubernetes Secret
+# below). Provide them via extraEnv (map), env, envFrom, or a Kubernetes Secret
 # mounted on the pod — see values-examples/secrets-from-k8s.yaml for patterns.
 #
 # Field names follow transports/config.schema.json (the Bifrost runtime config
@@ -20,7 +20,7 @@
 # ENVIRONMENT VARIABLES REFERENCED
 # ==========================================================================
 # This file uses env.VAR_NAME for all secret values. Supply them via extraEnv
-# or an external secret store. Full list:
+# (map), env, envFrom, or an external secret store. Full list:
 #
 #   Provider API keys:
 #     OPENAI_API_KEY_1, OPENAI_API_KEY_2, OPENAI_API_KEY_3

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -894,6 +894,10 @@ env: []
   # - name: CUSTOM_ENV_VAR
   #   value: "value"
 
+# Additional environment variables appended after env
+extraEnv: {}
+  # ANOTHER_ENV_VAR: "value"
+
 # Environment variables from secrets/configmaps
 envFrom: []
   # - secretRef:


### PR DESCRIPTION
## Summary

Adds support for `extraEnv` configuration in the Bifrost Helm chart to provide an alternative way to set environment variables using a key-value map format instead of the existing array format.

## Changes

- Added `extraEnv` field to values.yaml with map-style configuration (key: value pairs)
- Implemented template logic in both deployment.yaml and stateful.yaml to process extraEnv variables
- Updated documentation in the providers-and-virtual-keys.yaml example to reference the new extraEnv option
- The extraEnv variables are appended after the existing env array and sorted alphabetically by key name

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Test the new extraEnv configuration by deploying the Helm chart with both formats:

```sh
# Test with extraEnv map format
helm install bifrost ./helm-charts/bifrost --set extraEnv.TEST_VAR="test_value" --set extraEnv.ANOTHER_VAR="another_value"

# Verify environment variables are set in the pod
kubectl exec -it <pod-name> -- env | grep -E "(TEST_VAR|ANOTHER_VAR)"

# Test that existing env array format still works
helm upgrade bifrost ./helm-charts/bifrost --set env[0].name="ARRAY_VAR" --set env[0].value="array_value"
```

The new `extraEnv` configuration allows setting environment variables like:
```yaml
extraEnv:
  API_KEY: "secret-key"
  DEBUG_MODE: "true"
  TIMEOUT: "30s"
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

This is a purely additive feature that maintains backward compatibility with existing env configurations.

## Related issues

N/A

## Security considerations

The extraEnv values are quoted in the template to prevent injection attacks. Users should still follow best practices for secret management and avoid putting sensitive values directly in values files.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable