### PR TITLE
feat: add dynamic metadata columns to logs table

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -16,6 +16,7 @@ import { useWebSocket } from "@/hooks/useWebSocket";
 import {
 	getErrorMessage,
 	useDeleteLogsMutation,
+	useGetAvailableFilterDataQuery,
 	useLazyGetLogsHistogramQuery,
 	useLazyGetLogsQuery,
 	useLazyGetLogsStatsQuery,
@@ -859,7 +860,18 @@ export default function LogsPage() {
 		[stats],
 	);
 
-	const columns = useMemo(() => createColumns(handleDelete, hasDeleteAccess), [handleDelete, hasDeleteAccess]);
+	const { data: filterData } = useGetAvailableFilterDataQuery();
+
+	// Get metadata keys from filterdata API so columns always show even with no data on current page
+	const metadataKeys = useMemo(() => {
+		if (!filterData?.metadata_keys) return [];
+		return Object.keys(filterData.metadata_keys).sort();
+	}, [filterData?.metadata_keys]);
+
+	const columns = useMemo(
+		() => createColumns(handleDelete, hasDeleteAccess, metadataKeys),
+		[handleDelete, hasDeleteAccess, metadataKeys],
+	);
 
 	const columnIds = useMemo(
 		() => columns.map((col) => ("id" in col && col.id ? col.id : "accessorKey" in col ? String(col.accessorKey) : "")).filter(Boolean),

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -5,8 +5,8 @@ import { ProviderName, RequestTypeColors, RequestTypeLabels, Status, StatusBarCo
 import { ChatMessageContent, LogEntry, ResponsesMessageContentBlock } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
-import { ArrowUpDown, Trash2 } from "lucide-react";
 import { format } from "date-fns";
+import { ArrowUpDown, Trash2 } from "lucide-react";
 
 function getAssistantToolCallSummary(log?: LogEntry): string {
 	const toolCalls = log?.output_message?.tool_calls || [];
@@ -157,7 +157,11 @@ export function LogMessageCell({ log, maxWidth = "max-w-[400px]" }: { log: LogEn
 	);
 }
 
-export const createColumns = (onDelete: (log: LogEntry) => void, hasDeleteAccess = true): ColumnDef<LogEntry>[] => {
+export const createColumns = (
+	onDelete: (log: LogEntry) => void,
+	hasDeleteAccess = true,
+	metadataKeys: string[] = [],
+): ColumnDef<LogEntry>[] => {
 	const baseColumns: ColumnDef<LogEntry>[] = [
 		{
 			accessorKey: "status",
@@ -291,6 +295,16 @@ export const createColumns = (onDelete: (log: LogEntry) => void, hasDeleteAccess
 		},
 	];
 
+	const metadataColumns: ColumnDef<LogEntry>[] = metadataKeys.map((key) => ({
+		id: `metadata_${key}`,
+		header: key.charAt(0).toUpperCase() + key.slice(1),
+		size: 126,
+		cell: ({ row }) => {
+			const value = row.original.metadata?.[key];
+			return <div className="max-w-[150px] truncate font-mono text-xs">{value ?? "-"}</div>;
+		},
+	}));
+
 	const actionsColumn: ColumnDef<LogEntry> = {
 		id: "actions",
 		size: 72,
@@ -311,5 +325,5 @@ export const createColumns = (onDelete: (log: LogEntry) => void, hasDeleteAccess
 		},
 	};
 
-	return [...baseColumns, actionsColumn];
+	return [...baseColumns, ...metadataColumns, actionsColumn];
 };


### PR DESCRIPTION
## Summary

Adds dynamic metadata columns to the logs table that display all available metadata keys from the API, ensuring metadata columns are always visible even when no data is present on the current page.

## Changes

- Added `useGetAvailableFilterDataQuery` hook to fetch available metadata keys from the API
- Modified `createColumns` function to accept a `metadataKeys` parameter and generate dynamic metadata columns
- Updated column labels logic to include dynamically generated metadata column headers
- Metadata columns display with proper formatting and truncation for long values

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Verify that metadata columns appear in the logs table even when the current page has no log entries with metadata:

1. Navigate to the logs page
2. Ensure metadata columns are visible in the table header
3. Verify metadata values display correctly when present, and show "-" when absent
4. Test with different metadata keys to confirm dynamic column generation

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable