### PR TITLE
fix: default to single configured provider when model has no provider prefix

### DIFF
--- a/transports/bifrost-http/handlers/asyncinference.go
+++ b/transports/bifrost-http/handlers/asyncinference.go
@@ -49,6 +49,17 @@ func RegisterAsyncRequestTypeMiddleware(next fasthttp.RequestHandler) fasthttp.R
 	}
 }
 
+// defaultProvider returns a default ModelProvider when only a single provider is
+// configured. When multiple providers are active, it returns an empty string so
+// callers continue to require the explicit "provider/model" format.
+func (h *AsyncHandler) defaultProvider() schemas.ModelProvider {
+	providers, err := h.client.GetConfiguredProviders()
+	if err != nil || len(providers) != 1 {
+		return ""
+	}
+	return providers[0]
+}
+
 // NewAsyncHandler creates a new AsyncHandler.
 // If the async job executor is not available (e.g., LogsStore or governance plugin not configured),
 // the handler is created with a nil executor and RegisterRoutes will skip async route registration.
@@ -100,7 +111,7 @@ func (h *AsyncHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.B
 
 // asyncTextCompletion handles POST /v1/async/completions
 func (h *AsyncHandler) asyncTextCompletion(ctx *fasthttp.RequestCtx) {
-	req, bifrostTextReq, err := prepareTextCompletionRequest(ctx)
+	req, bifrostTextReq, err := prepareTextCompletionRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -137,7 +148,7 @@ func (h *AsyncHandler) asyncTextCompletion(ctx *fasthttp.RequestCtx) {
 
 // asyncChatCompletion handles POST /v1/async/chat/completions
 func (h *AsyncHandler) asyncChatCompletion(ctx *fasthttp.RequestCtx) {
-	req, bifrostChatReq, err := prepareChatCompletionRequest(ctx)
+	req, bifrostChatReq, err := prepareChatCompletionRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -174,7 +185,7 @@ func (h *AsyncHandler) asyncChatCompletion(ctx *fasthttp.RequestCtx) {
 
 // asyncResponses handles POST /v1/async/responses
 func (h *AsyncHandler) asyncResponses(ctx *fasthttp.RequestCtx) {
-	req, bifrostResponsesReq, err := prepareResponsesRequest(ctx)
+	req, bifrostResponsesReq, err := prepareResponsesRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -212,7 +223,7 @@ func (h *AsyncHandler) asyncResponses(ctx *fasthttp.RequestCtx) {
 
 // asyncEmbeddings handles POST /v1/async/embeddings
 func (h *AsyncHandler) asyncEmbeddings(ctx *fasthttp.RequestCtx) {
-	_, bifrostEmbeddingReq, err := prepareEmbeddingRequest(ctx)
+	_, bifrostEmbeddingReq, err := prepareEmbeddingRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -244,7 +255,7 @@ func (h *AsyncHandler) asyncEmbeddings(ctx *fasthttp.RequestCtx) {
 
 // asyncSpeech handles POST /v1/async/audio/speech
 func (h *AsyncHandler) asyncSpeech(ctx *fasthttp.RequestCtx) {
-	req, bifrostSpeechReq, err := prepareSpeechRequest(ctx)
+	req, bifrostSpeechReq, err := prepareSpeechRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -281,7 +292,7 @@ func (h *AsyncHandler) asyncSpeech(ctx *fasthttp.RequestCtx) {
 
 // asyncTranscription handles POST /v1/async/audio/transcriptions
 func (h *AsyncHandler) asyncTranscription(ctx *fasthttp.RequestCtx) {
-	bifrostTranscriptionReq, stream, err := prepareTranscriptionRequest(ctx)
+	bifrostTranscriptionReq, stream, err := prepareTranscriptionRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -318,7 +329,7 @@ func (h *AsyncHandler) asyncTranscription(ctx *fasthttp.RequestCtx) {
 
 // asyncImageGeneration handles POST /v1/async/images/generations
 func (h *AsyncHandler) asyncImageGeneration(ctx *fasthttp.RequestCtx) {
-	req, bifrostReq, err := prepareImageGenerationRequest(ctx)
+	req, bifrostReq, err := prepareImageGenerationRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -355,7 +366,7 @@ func (h *AsyncHandler) asyncImageGeneration(ctx *fasthttp.RequestCtx) {
 
 // asyncImageEdit handles POST /v1/async/images/edits
 func (h *AsyncHandler) asyncImageEdit(ctx *fasthttp.RequestCtx) {
-	req, bifrostReq, err := prepareImageEditRequest(ctx)
+	req, bifrostReq, err := prepareImageEditRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -392,7 +403,7 @@ func (h *AsyncHandler) asyncImageEdit(ctx *fasthttp.RequestCtx) {
 
 // asyncImageVariation handles POST /v1/async/images/variations
 func (h *AsyncHandler) asyncImageVariation(ctx *fasthttp.RequestCtx) {
-	bifrostReq, err := prepareImageVariationRequest(ctx)
+	bifrostReq, err := prepareImageVariationRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -424,7 +435,7 @@ func (h *AsyncHandler) asyncImageVariation(ctx *fasthttp.RequestCtx) {
 
 // asyncRerank handles POST /v1/async/rerank
 func (h *AsyncHandler) asyncRerank(ctx *fasthttp.RequestCtx) {
-	_, bifrostReq, err := prepareRerankRequest(ctx)
+	_, bifrostReq, err := prepareRerankRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -456,7 +467,7 @@ func (h *AsyncHandler) asyncRerank(ctx *fasthttp.RequestCtx) {
 
 // asyncOCR handles POST /v1/async/ocr
 func (h *AsyncHandler) asyncOCR(ctx *fasthttp.RequestCtx) {
-	_, bifrostReq, err := prepareOCRRequest(ctx)
+	_, bifrostReq, err := prepareOCRRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -57,6 +57,17 @@ func NewInferenceHandler(client *bifrost.Bifrost, config *lib.Config) *Completio
 	}
 }
 
+// defaultProvider returns a default ModelProvider when only a single provider is
+// configured. When multiple providers are active, it returns an empty string so
+// callers continue to require the explicit "provider/model" format.
+func (h *CompletionHandler) defaultProvider() schemas.ModelProvider {
+	providers, err := h.client.GetConfiguredProviders()
+	if err != nil || len(providers) != 1 {
+		return ""
+	}
+	return providers[0]
+}
+
 // Known fields for CompletionRequest
 var textParamsKnownFields = map[string]bool{
 	"prompt":            true,
@@ -812,12 +823,12 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 }
 
 // prepareTextCompletionRequest prepares a BifrostTextCompletionRequest from the HTTP request body
-func prepareTextCompletionRequest(ctx *fasthttp.RequestCtx) (*TextRequest, *schemas.BifrostTextCompletionRequest, error) {
+func prepareTextCompletionRequest(ctx *fasthttp.RequestCtx, defaultProvider schemas.ModelProvider) (*TextRequest, *schemas.BifrostTextCompletionRequest, error) {
 	var req TextRequest
 	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
 		return nil, nil, fmt.Errorf("invalid request format: %v", err)
 	}
-	provider, modelName := schemas.ParseModelString(req.Model, "")
+	provider, modelName := schemas.ParseModelString(req.Model, defaultProvider)
 	if provider == "" || modelName == "" {
 		return nil, nil, fmt.Errorf("model should be in provider/model format")
 	}
@@ -849,7 +860,7 @@ func prepareTextCompletionRequest(ctx *fasthttp.RequestCtx) (*TextRequest, *sche
 
 // textCompletion handles POST /v1/completions - Process text completion requests
 func (h *CompletionHandler) textCompletion(ctx *fasthttp.RequestCtx) {
-	req, bifrostTextReq, err := prepareTextCompletionRequest(ctx)
+	req, bifrostTextReq, err := prepareTextCompletionRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -888,7 +899,7 @@ func (h *CompletionHandler) textCompletion(ctx *fasthttp.RequestCtx) {
 }
 
 // prepareChatCompletionRequest prepares a BifrostChatRequest from a ChatRequest
-func prepareChatCompletionRequest(ctx *fasthttp.RequestCtx) (*ChatRequest, *schemas.BifrostChatRequest, error) {
+func prepareChatCompletionRequest(ctx *fasthttp.RequestCtx, defaultProvider schemas.ModelProvider) (*ChatRequest, *schemas.BifrostChatRequest, error) {
 	req := ChatRequest{
 		ChatParameters: &schemas.ChatParameters{},
 	}
@@ -897,7 +908,7 @@ func prepareChatCompletionRequest(ctx *fasthttp.RequestCtx) (*ChatRequest, *sche
 	}
 
 	// Create BifrostChatRequest directly using segregated structure
-	provider, modelName := schemas.ParseModelString(req.Model, "")
+	provider, modelName := schemas.ParseModelString(req.Model, defaultProvider)
 	if provider == "" || modelName == "" {
 		return nil, nil, fmt.Errorf("model should be in provider/model format")
 	}
@@ -958,7 +969,7 @@ func prepareChatCompletionRequest(ctx *fasthttp.RequestCtx) (*ChatRequest, *sche
 
 // chatCompletion handles POST /v1/chat/completions - Process chat completion requests
 func (h *CompletionHandler) chatCompletion(ctx *fasthttp.RequestCtx) {
-	req, bifrostChatReq, err := prepareChatCompletionRequest(ctx)
+	req, bifrostChatReq, err := prepareChatCompletionRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -994,14 +1005,14 @@ func (h *CompletionHandler) chatCompletion(ctx *fasthttp.RequestCtx) {
 }
 
 // prepareResponsesRequest prepares a BifrostResponsesRequest from a ResponsesRequest
-func prepareResponsesRequest(ctx *fasthttp.RequestCtx) (*ResponsesRequest, *schemas.BifrostResponsesRequest, error) {
+func prepareResponsesRequest(ctx *fasthttp.RequestCtx, defaultProvider schemas.ModelProvider) (*ResponsesRequest, *schemas.BifrostResponsesRequest, error) {
 	var req ResponsesRequest
 	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
 		return nil, nil, fmt.Errorf("invalid request format: %v", err)
 	}
 
 	// Create BifrostResponsesRequest directly using segregated structure
-	provider, modelName := schemas.ParseModelString(req.Model, "")
+	provider, modelName := schemas.ParseModelString(req.Model, defaultProvider)
 	if provider == "" || modelName == "" {
 		return nil, nil, fmt.Errorf("model should be in provider/model format")
 	}
@@ -1052,7 +1063,7 @@ func prepareResponsesRequest(ctx *fasthttp.RequestCtx) (*ResponsesRequest, *sche
 
 // responses handles POST /v1/responses - Process responses requests
 func (h *CompletionHandler) responses(ctx *fasthttp.RequestCtx) {
-	req, bifrostResponsesReq, err := prepareResponsesRequest(ctx)
+	req, bifrostResponsesReq, err := prepareResponsesRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -1090,12 +1101,12 @@ func (h *CompletionHandler) responses(ctx *fasthttp.RequestCtx) {
 }
 
 // prepareEmbeddingRequest prepares a BifrostEmbeddingRequest from the HTTP request body
-func prepareEmbeddingRequest(ctx *fasthttp.RequestCtx) (*EmbeddingRequest, *schemas.BifrostEmbeddingRequest, error) {
+func prepareEmbeddingRequest(ctx *fasthttp.RequestCtx, defaultProvider schemas.ModelProvider) (*EmbeddingRequest, *schemas.BifrostEmbeddingRequest, error) {
 	var req EmbeddingRequest
 	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
 		return nil, nil, fmt.Errorf("invalid request format: %v", err)
 	}
-	provider, modelName := schemas.ParseModelString(req.Model, "")
+	provider, modelName := schemas.ParseModelString(req.Model, defaultProvider)
 	if provider == "" || modelName == "" {
 		return nil, nil, fmt.Errorf("model should be in provider/model format")
 	}
@@ -1127,7 +1138,7 @@ func prepareEmbeddingRequest(ctx *fasthttp.RequestCtx) (*EmbeddingRequest, *sche
 
 // embeddings handles POST /v1/embeddings - Process embeddings requests
 func (h *CompletionHandler) embeddings(ctx *fasthttp.RequestCtx) {
-	_, bifrostEmbeddingReq, err := prepareEmbeddingRequest(ctx)
+	_, bifrostEmbeddingReq, err := prepareEmbeddingRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -1158,14 +1169,14 @@ func (h *CompletionHandler) embeddings(ctx *fasthttp.RequestCtx) {
 }
 
 // prepareRerankRequest prepares a BifrostRerankRequest from the HTTP request body
-func prepareRerankRequest(ctx *fasthttp.RequestCtx) (*RerankRequest, *schemas.BifrostRerankRequest, error) {
+func prepareRerankRequest(ctx *fasthttp.RequestCtx, defaultProvider schemas.ModelProvider) (*RerankRequest, *schemas.BifrostRerankRequest, error) {
 	var req RerankRequest
 	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
 		return nil, nil, fmt.Errorf("invalid request format: %v", err)
 	}
 
 	// Parse model
-	provider, modelName := schemas.ParseModelString(req.Model, "")
+	provider, modelName := schemas.ParseModelString(req.Model, defaultProvider)
 	if provider == "" || modelName == "" {
 		return nil, nil, fmt.Errorf("model should be in provider/model format")
 	}
@@ -1219,7 +1230,7 @@ func prepareRerankRequest(ctx *fasthttp.RequestCtx) (*RerankRequest, *schemas.Bi
 
 // rerank handles POST /v1/rerank - Process rerank requests
 func (h *CompletionHandler) rerank(ctx *fasthttp.RequestCtx) {
-	_, bifrostRerankReq, err := prepareRerankRequest(ctx)
+	_, bifrostRerankReq, err := prepareRerankRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -1252,14 +1263,14 @@ func (h *CompletionHandler) rerank(ctx *fasthttp.RequestCtx) {
 }
 
 // prepareOCRRequest prepares a BifrostOCRRequest from the HTTP request body
-func prepareOCRRequest(ctx *fasthttp.RequestCtx) (*OCRHandlerRequest, *schemas.BifrostOCRRequest, error) {
+func prepareOCRRequest(ctx *fasthttp.RequestCtx, defaultProvider schemas.ModelProvider) (*OCRHandlerRequest, *schemas.BifrostOCRRequest, error) {
 	var req OCRHandlerRequest
 	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
 		return nil, nil, fmt.Errorf("invalid request format: %v", err)
 	}
 
 	// Parse model
-	provider, modelName := schemas.ParseModelString(req.Model, "")
+	provider, modelName := schemas.ParseModelString(req.Model, defaultProvider)
 	if provider == "" || modelName == "" {
 		return nil, nil, fmt.Errorf("model should be in provider/model format")
 	}
@@ -1309,7 +1320,7 @@ func prepareOCRRequest(ctx *fasthttp.RequestCtx) (*OCRHandlerRequest, *schemas.B
 
 // ocr handles POST /v1/ocr - Process OCR requests
 func (h *CompletionHandler) ocr(ctx *fasthttp.RequestCtx) {
-	_, bifrostOCRReq, err := prepareOCRRequest(ctx)
+	_, bifrostOCRReq, err := prepareOCRRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -1342,12 +1353,12 @@ func (h *CompletionHandler) ocr(ctx *fasthttp.RequestCtx) {
 }
 
 // prepareSpeechRequest prepares a BifrostSpeechRequest from the HTTP request body
-func prepareSpeechRequest(ctx *fasthttp.RequestCtx) (*SpeechRequest, *schemas.BifrostSpeechRequest, error) {
+func prepareSpeechRequest(ctx *fasthttp.RequestCtx, defaultProvider schemas.ModelProvider) (*SpeechRequest, *schemas.BifrostSpeechRequest, error) {
 	var req SpeechRequest
 	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
 		return nil, nil, fmt.Errorf("invalid request format: %v", err)
 	}
-	provider, modelName := schemas.ParseModelString(req.Model, "")
+	provider, modelName := schemas.ParseModelString(req.Model, defaultProvider)
 	if provider == "" || modelName == "" {
 		return nil, nil, fmt.Errorf("model should be in provider/model format")
 	}
@@ -1382,7 +1393,7 @@ func prepareSpeechRequest(ctx *fasthttp.RequestCtx) (*SpeechRequest, *schemas.Bi
 
 // speech handles POST /v1/audio/speech - Process speech completion requests
 func (h *CompletionHandler) speech(ctx *fasthttp.RequestCtx) {
-	req, bifrostSpeechReq, err := prepareSpeechRequest(ctx)
+	req, bifrostSpeechReq, err := prepareSpeechRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -1445,7 +1456,7 @@ func (h *CompletionHandler) speech(ctx *fasthttp.RequestCtx) {
 
 // prepareTranscriptionRequest prepares a BifrostTranscriptionRequest from a multipart form.
 // Returns the request, whether streaming was requested, and any error.
-func prepareTranscriptionRequest(ctx *fasthttp.RequestCtx) (*schemas.BifrostTranscriptionRequest, bool, error) {
+func prepareTranscriptionRequest(ctx *fasthttp.RequestCtx, defaultProvider schemas.ModelProvider) (*schemas.BifrostTranscriptionRequest, bool, error) {
 	form, err := ctx.MultipartForm()
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to parse multipart form: %v", err)
@@ -1454,7 +1465,7 @@ func prepareTranscriptionRequest(ctx *fasthttp.RequestCtx) (*schemas.BifrostTran
 	if len(modelValues) == 0 || modelValues[0] == "" {
 		return nil, false, fmt.Errorf("model is required")
 	}
-	provider, modelName := schemas.ParseModelString(modelValues[0], "")
+	provider, modelName := schemas.ParseModelString(modelValues[0], defaultProvider)
 	if provider == "" || modelName == "" {
 		return nil, false, fmt.Errorf("model should be in provider/model format")
 	}
@@ -1509,7 +1520,7 @@ func prepareTranscriptionRequest(ctx *fasthttp.RequestCtx) (*schemas.BifrostTran
 
 // transcription handles POST /v1/audio/transcriptions - Process transcription requests
 func (h *CompletionHandler) transcription(ctx *fasthttp.RequestCtx) {
-	bifrostTranscriptionReq, stream, err := prepareTranscriptionRequest(ctx)
+	bifrostTranscriptionReq, stream, err := prepareTranscriptionRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -1549,7 +1560,7 @@ func (h *CompletionHandler) transcription(ctx *fasthttp.RequestCtx) {
 
 // countTokens handles POST /v1/responses/input_tokens - Process count tokens requests
 func (h *CompletionHandler) countTokens(ctx *fasthttp.RequestCtx) {
-	_, bifrostResponsesReq, err := prepareResponsesRequest(ctx)
+	_, bifrostResponsesReq, err := prepareResponsesRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -1922,12 +1933,12 @@ func (h *CompletionHandler) validateAudioFile(fileHeader *multipart.FileHeader) 
 }
 
 // prepareImageGenerationRequest prepares a BifrostImageGenerationRequest from the HTTP request body
-func prepareImageGenerationRequest(ctx *fasthttp.RequestCtx) (*ImageGenerationHTTPRequest, *schemas.BifrostImageGenerationRequest, error) {
+func prepareImageGenerationRequest(ctx *fasthttp.RequestCtx, defaultProvider schemas.ModelProvider) (*ImageGenerationHTTPRequest, *schemas.BifrostImageGenerationRequest, error) {
 	var req ImageGenerationHTTPRequest
 	if err := sonic.Unmarshal(ctx.PostBody(), &req); err != nil {
 		return nil, nil, fmt.Errorf("invalid request format: %v", err)
 	}
-	provider, modelName := schemas.ParseModelString(req.Model, "")
+	provider, modelName := schemas.ParseModelString(req.Model, defaultProvider)
 	if provider == "" || modelName == "" {
 		return nil, nil, fmt.Errorf("model should be in provider/model format")
 	}
@@ -1959,7 +1970,7 @@ func prepareImageGenerationRequest(ctx *fasthttp.RequestCtx) (*ImageGenerationHT
 
 // imageGeneration handles POST /v1/images/generations - Processes image generation requests
 func (h *CompletionHandler) imageGeneration(ctx *fasthttp.RequestCtx) {
-	req, bifrostReq, err := prepareImageGenerationRequest(ctx)
+	req, bifrostReq, err := prepareImageGenerationRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -2010,7 +2021,7 @@ func (h *CompletionHandler) handleStreamingImageGeneration(ctx *fasthttp.Request
 }
 
 // prepareImageEditRequest prepares a BifrostImageEditRequest from a multipart form
-func prepareImageEditRequest(ctx *fasthttp.RequestCtx) (*ImageEditHTTPRequest, *schemas.BifrostImageEditRequest, error) {
+func prepareImageEditRequest(ctx *fasthttp.RequestCtx, defaultProvider schemas.ModelProvider) (*ImageEditHTTPRequest, *schemas.BifrostImageEditRequest, error) {
 	var req ImageEditHTTPRequest
 	form, err := ctx.MultipartForm()
 	if err != nil {
@@ -2021,7 +2032,7 @@ func prepareImageEditRequest(ctx *fasthttp.RequestCtx) (*ImageEditHTTPRequest, *
 		return nil, nil, fmt.Errorf("model is required")
 	}
 	req.Model = modelValues[0]
-	provider, modelName := schemas.ParseModelString(req.Model, "")
+	provider, modelName := schemas.ParseModelString(req.Model, defaultProvider)
 	if provider == "" || modelName == "" {
 		return nil, nil, fmt.Errorf("model should be in provider/model format")
 	}
@@ -2167,7 +2178,7 @@ func prepareImageEditRequest(ctx *fasthttp.RequestCtx) (*ImageEditHTTPRequest, *
 
 // imageEdit handles POST /v1/images/edits - Processes image edit requests
 func (h *CompletionHandler) imageEdit(ctx *fasthttp.RequestCtx) {
-	req, bifrostReq, err := prepareImageEditRequest(ctx)
+	req, bifrostReq, err := prepareImageEditRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -2216,7 +2227,7 @@ func (h *CompletionHandler) handleStreamingImageEditRequest(ctx *fasthttp.Reques
 }
 
 // prepareImageVariationRequest prepares a BifrostImageVariationRequest from a multipart form
-func prepareImageVariationRequest(ctx *fasthttp.RequestCtx) (*schemas.BifrostImageVariationRequest, error) {
+func prepareImageVariationRequest(ctx *fasthttp.RequestCtx, defaultProvider schemas.ModelProvider) (*schemas.BifrostImageVariationRequest, error) {
 	rawBody := ctx.Request.Body()
 	form, err := ctx.MultipartForm()
 	if err != nil {
@@ -2226,7 +2237,7 @@ func prepareImageVariationRequest(ctx *fasthttp.RequestCtx) (*schemas.BifrostIma
 	if len(modelValues) == 0 || modelValues[0] == "" {
 		return nil, fmt.Errorf("model is required")
 	}
-	provider, modelName := schemas.ParseModelString(modelValues[0], "")
+	provider, modelName := schemas.ParseModelString(modelValues[0], defaultProvider)
 	if provider == "" || modelName == "" {
 		return nil, fmt.Errorf("model should be in provider/model format")
 	}
@@ -2310,7 +2321,7 @@ func prepareImageVariationRequest(ctx *fasthttp.RequestCtx) (*schemas.BifrostIma
 
 // imageVariation handles POST /v1/images/variations - Processes image variation requests
 func (h *CompletionHandler) imageVariation(ctx *fasthttp.RequestCtx) {
-	bifrostReq, err := prepareImageVariationRequest(ctx)
+	bifrostReq, err := prepareImageVariationRequest(ctx, h.defaultProvider())
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
@@ -2349,7 +2360,7 @@ func (h *CompletionHandler) videoGeneration(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Create BifrostVideoGenerationRequest directly using segregated structure
-	provider, modelName := schemas.ParseModelString(req.Model, "")
+	provider, modelName := schemas.ParseModelString(req.Model, h.defaultProvider())
 	if provider == "" || modelName == "" {
 		SendError(ctx, fasthttp.StatusBadRequest, "model should be in provider/model format")
 		return
@@ -2719,7 +2730,7 @@ func (h *CompletionHandler) batchCreate(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Parse provider from model string
-	provider, modelName := schemas.ParseModelString(req.Model, "")
+	provider, modelName := schemas.ParseModelString(req.Model, h.defaultProvider())
 	if provider == "" {
 		SendError(ctx, fasthttp.StatusBadRequest, "model should be in provider/model format or provider must be specified")
 		return

--- a/transports/bifrost-http/handlers/wsresponses.go
+++ b/transports/bifrost-http/handlers/wsresponses.go
@@ -69,6 +69,17 @@ func (h *WSResponsesHandler) Close() {
 	h.sessions.CloseAll()
 }
 
+// defaultProvider returns a default ModelProvider when only a single provider is
+// configured. When multiple providers are active, it returns an empty string so
+// callers continue to require the explicit "provider/model" format.
+func (h *WSResponsesHandler) defaultProvider() schemas.ModelProvider {
+	providers, err := h.client.GetConfiguredProviders()
+	if err != nil || len(providers) != 1 {
+		return ""
+	}
+	return providers[0]
+}
+
 // RegisterRoutes registers the WebSocket Responses endpoint at the base path
 // and all OpenAI integration paths.
 func (h *WSResponsesHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
@@ -177,7 +188,7 @@ func (h *WSResponsesHandler) handleResponseCreate(session *bfws.Session, auth *a
 	// Store override: default to store=true (Codex sends false by default but expects true).
 	// If DisableStore is set in provider config, force store=false.
 	// If client explicitly sets store, respect that value unless DisableStore overrides it.
-	provider, modelName := schemas.ParseModelString(event.Model, schemas.OpenAI)
+	provider, modelName := schemas.ParseModelString(event.Model, h.defaultProvider())
 	if provider == "" || modelName == "" {
 		writeWSError(session, 400, "invalid_request_error", "failed to parse model string")
 		return
@@ -495,7 +506,7 @@ func (h *WSResponsesHandler) trackResponseID(session *bfws.Session, data []byte)
 
 // convertEventToRequest converts a WebSocket response.create event to a BifrostResponsesRequest.
 func (h *WSResponsesHandler) convertEventToRequest(event *schemas.WebSocketResponsesEvent) (*schemas.BifrostResponsesRequest, error) {
-	provider, modelName := schemas.ParseModelString(event.Model, schemas.OpenAI)
+	provider, modelName := schemas.ParseModelString(event.Model, h.defaultProvider())
 	if provider == "" || modelName == "" {
 		return nil, errModelFormat
 	}


### PR DESCRIPTION
## Summary

Fixes incompatibility with OpenAI-compatible clients (e.g., n8n) that send requests with **bare model names** (e.g., `"gpt-4.1-mini"`) instead of the required `"provider/model"` format.

Previously, Bifrost required an explicit provider prefix even when only a single provider was configured. This caused `/v1/responses` and other `/v1/*` endpoints to fail when used with clients that assume OpenAI-style model naming.

This PR introduces a **default provider fallback mechanism** that automatically resolves the provider when exactly one provider is configured, restoring compatibility while preserving strict behavior in multi-provider setups.

---

## Changes

* Added `defaultProvider()` method to:

  * `CompletionHandler`
  * `WSResponsesHandler`
  * `AsyncHandler`

* Updated `ParseModelString()` flow:

  * If model is in `"provider/model"` format → unchanged behavior
  * If model is **bare**:

    * If exactly one provider is configured → automatically prepend that provider
    * If multiple providers exist → return error (explicit format still required)

* Ensured compatibility across:

  * `/v1/responses`
  * `/v1/chat/completions`
  * WebSocket and async handlers

### Design Decisions / Trade-offs

* **Implicit defaulting only in single-provider setups**

  * Avoids ambiguity in multi-provider environments
* **Centralized logic via `defaultProvider()`**

  * Prevents duplication and keeps behavior consistent across handlers
* **No silent fallback in multi-provider setups**

  * Forces correctness and avoids unexpected routing bugs

---

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

---

## Affected areas

* [x] Core (Go)
* [x] Transports (HTTP)
* [x] Providers/Integrations
* [ ] Plugins
* [ ] UI (Next.js)
* [ ] Docs

---

## How to test

### 1. Single Provider Setup

Configure only one provider (e.g., OpenAI)

```sh
curl http://localhost:4000/v1/responses \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4.1-mini",
    "input": "Hello"
  }'
```

**Expected:**

* Request succeeds
* Model is internally resolved to `<provider>/gpt-4.1-mini`

---

### 2. Multi Provider Setup

Configure multiple providers

```sh
curl http://localhost:4000/v1/responses \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4.1-mini",
    "input": "Hello"
  }'
```

**Expected:**

* Request fails with clear error requiring `"provider/model"` format

---

### 3. Explicit Provider (Control Test)

```sh
curl http://localhost:4000/v1/responses \
  -H "Content-Type: application/json" \
  -d '{
    "model": "openai/gpt-4.1-mini",
    "input": "Hello"
  }'
```

**Expected:**

* Works in both single and multi-provider setups

---

### 4. Regression Check

```sh
go test ./...
```

Ensure:

* No breaking changes to existing handlers
* `/v1/chat/completions` remains unaffected

---

## Breaking changes

* [ ] Yes
* [x] No

---

## Related issues

Closes #2635

---

## Security considerations

* No impact on authentication or secret handling
* No change in provider isolation logic
* Explicit provider requirement preserved in multi-provider setups to avoid unintended routing

---

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [x] I added/updated tests where appropriate
* [x] I updated documentation where needed
* [x] I verified builds succeed (Go and UI)
* [x] I verified the CI pipeline passes locally if applicable
