### PR TITLE
feat: claude opus 4.7 compatibility

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -3,3 +3,4 @@
 - fix: Bedrock provider - emit message_stop event for Anthropic invoke stream [@tefimov](https://github.com/tefimov)
 - fix: gemini preserves thinkingLevel parameters during round-trip and finish reason mapping
 - fix: WebSearch tool argument handling for all clients by removing the Claude Code user agent restriction
+- feat: claude-opus-4-7 compatibility

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -30,18 +30,24 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 			anthropicReq.MaxTokens = *bifrostReq.Params.MaxCompletionTokens
 		}
 
-		// Anthropic doesn't allow both temperature and top_p to be specified
-		// If both are present, prefer temperature (more commonly used)
-		if bifrostReq.Params.Temperature != nil {
-			anthropicReq.Temperature = bifrostReq.Params.Temperature
-		} else if bifrostReq.Params.TopP != nil {
-			anthropicReq.TopP = bifrostReq.Params.TopP
+		// Opus 4.7+ rejects temperature, top_p, and top_k with a 400 error.
+		if !IsOpus47(bifrostReq.Model) {
+			// Anthropic doesn't allow both temperature and top_p to be specified.
+			// If both are present, prefer temperature (more commonly used).
+			if bifrostReq.Params.Temperature != nil {
+				anthropicReq.Temperature = bifrostReq.Params.Temperature
+			} else if bifrostReq.Params.TopP != nil {
+				anthropicReq.TopP = bifrostReq.Params.TopP
+			}
 		}
 		anthropicReq.StopSequences = bifrostReq.Params.Stop
 		topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"])
 		if ok {
 			delete(anthropicReq.ExtraParams, "top_k")
-			anthropicReq.TopK = topK
+			// Opus 4.7+ rejects top_k with a 400 error.
+			if !IsOpus47(bifrostReq.Model) {
+				anthropicReq.TopK = topK
+			}
 		}
 		if speed, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["speed"]); ok {
 			delete(anthropicReq.ExtraParams, "speed")
@@ -189,23 +195,28 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 		// Convert reasoning
 		if bifrostReq.Params.Reasoning != nil {
 			if bifrostReq.Params.Reasoning.MaxTokens != nil {
-				budgetTokens := *bifrostReq.Params.Reasoning.MaxTokens
-				if *bifrostReq.Params.Reasoning.MaxTokens == -1 {
-					// anthropic does not support dynamic reasoning budget like gemini
-					// setting it to default max tokens
-					budgetTokens = MinimumReasoningMaxTokens
-				}
-				if budgetTokens < MinimumReasoningMaxTokens {
-					return nil, fmt.Errorf("reasoning.max_tokens must be >= %d for anthropic", MinimumReasoningMaxTokens)
-				}
-				anthropicReq.Thinking = &AnthropicThinking{
-					Type:         "enabled",
-					BudgetTokens: schemas.Ptr(budgetTokens),
+				if IsOpus47(bifrostReq.Model) {
+					// Opus 4.7+: budget_tokens removed; adaptive thinking is the only thinking-on mode.
+					anthropicReq.Thinking = &AnthropicThinking{Type: "adaptive"}
+				} else {
+					budgetTokens := *bifrostReq.Params.Reasoning.MaxTokens
+					if *bifrostReq.Params.Reasoning.MaxTokens == -1 {
+						// anthropic does not support dynamic reasoning budget like gemini
+						// setting it to default max tokens
+						budgetTokens = MinimumReasoningMaxTokens
+					}
+					if budgetTokens < MinimumReasoningMaxTokens {
+						return nil, fmt.Errorf("reasoning.max_tokens must be >= %d for anthropic", MinimumReasoningMaxTokens)
+					}
+					anthropicReq.Thinking = &AnthropicThinking{
+						Type:         "enabled",
+						BudgetTokens: schemas.Ptr(budgetTokens),
+					}
 				}
 			} else if bifrostReq.Params.Reasoning.Effort != nil && *bifrostReq.Params.Reasoning.Effort != "none" {
 				effort := MapBifrostEffortToAnthropic(*bifrostReq.Params.Reasoning.Effort)
-				if SupportsAdaptiveThinking(bifrostReq.Model) {
-					// Opus 4.6+: adaptive thinking + native effort
+				if SupportsAdaptiveThinking(bifrostReq.Model) || IsOpus47(bifrostReq.Model) {
+					// Opus 4.6+ and Opus 4.7+: adaptive thinking + native effort
 					anthropicReq.Thinking = &AnthropicThinking{Type: "adaptive"}
 					setEffortOnOutputConfig(anthropicReq, effort)
 				} else if SupportsNativeEffort(bifrostReq.Model) {

--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -511,3 +511,163 @@ func TestToAnthropicChatRequest_NormalFlowUnchanged(t *testing.T) {
 		t.Errorf("block 1: expected text %q, got %v", responseText, blocks[1].Text)
 	}
 }
+
+func TestToAnthropicChatRequest_Opus47_StripsTemperatureTopPTopK(t *testing.T) {
+	temp := 0.7
+	topP := 0.9
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-opus-4-7-20260401",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}},
+		},
+		Params: &schemas.ChatParameters{
+			Temperature: &temp,
+			TopP:        &topP,
+			ExtraParams: map[string]interface{}{"top_k": 40},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+	result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Temperature != nil {
+		t.Errorf("expected Temperature to be nil for Opus 4.7, got %v", result.Temperature)
+	}
+	if result.TopP != nil {
+		t.Errorf("expected TopP to be nil for Opus 4.7, got %v", result.TopP)
+	}
+	if result.TopK != nil {
+		t.Errorf("expected TopK to be nil for Opus 4.7, got %v", result.TopK)
+	}
+}
+
+func TestToAnthropicChatRequest_NonOpus47_PreservesTemperature(t *testing.T) {
+	temp := 0.7
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-opus-4-6-20250514",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}},
+		},
+		Params: &schemas.ChatParameters{
+			Temperature: &temp,
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+	result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Temperature == nil || *result.Temperature != temp {
+		t.Errorf("expected Temperature %v, got %v", temp, result.Temperature)
+	}
+}
+
+func TestToAnthropicChatRequest_Opus47_ReasoningMaxTokens_AdaptiveOnly(t *testing.T) {
+	maxTok := 2048
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-opus-4-7-20260401",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("think")}},
+		},
+		Params: &schemas.ChatParameters{
+			MaxCompletionTokens: schemas.Ptr(8192),
+			Reasoning:           &schemas.ChatReasoning{MaxTokens: &maxTok},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+	result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Thinking == nil {
+		t.Fatal("expected Thinking to be set")
+	}
+	if result.Thinking.Type != "adaptive" {
+		t.Errorf("expected thinking type 'adaptive' for Opus 4.7, got %q", result.Thinking.Type)
+	}
+	if result.Thinking.BudgetTokens != nil {
+		t.Errorf("expected BudgetTokens to be nil for Opus 4.7, got %v", result.Thinking.BudgetTokens)
+	}
+}
+
+func TestToAnthropicChatRequest_NonOpus47_ReasoningMaxTokens_EnabledWithBudget(t *testing.T) {
+	maxTok := 2048
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-opus-4-6-20250514",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("think")}},
+		},
+		Params: &schemas.ChatParameters{
+			MaxCompletionTokens: schemas.Ptr(8192),
+			Reasoning:           &schemas.ChatReasoning{MaxTokens: &maxTok},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+	result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Thinking == nil {
+		t.Fatal("expected Thinking to be set")
+	}
+	if result.Thinking.Type != "enabled" {
+		t.Errorf("expected thinking type 'enabled' for Opus 4.6, got %q", result.Thinking.Type)
+	}
+	if result.Thinking.BudgetTokens == nil || *result.Thinking.BudgetTokens != maxTok {
+		t.Errorf("expected BudgetTokens %d, got %v", maxTok, result.Thinking.BudgetTokens)
+	}
+}
+
+func TestToAnthropicChatRequest_Opus47_ReasoningEffort_AdaptiveWithEffort(t *testing.T) {
+	effort := "high"
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-opus-4-7-20260401",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("think")}},
+		},
+		Params: &schemas.ChatParameters{
+			MaxCompletionTokens: schemas.Ptr(8192),
+			Reasoning:           &schemas.ChatReasoning{Effort: &effort},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+	result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Thinking == nil {
+		t.Fatal("expected Thinking to be set")
+	}
+	if result.Thinking.Type != "adaptive" {
+		t.Errorf("expected thinking type 'adaptive' for Opus 4.7 effort-based, got %q", result.Thinking.Type)
+	}
+	if result.OutputConfig == nil || result.OutputConfig.Effort == nil {
+		t.Error("expected OutputConfig.Effort to be set for Opus 4.7 effort-based reasoning")
+	}
+}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2158,6 +2158,9 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 		// GA structured outputs - OutputConfig.Format has same structure as OutputFormat
 		params.Text = convertAnthropicOutputFormatToResponsesTextConfig(req.OutputConfig.Format)
 	}
+	if req.OutputConfig != nil && req.OutputConfig.TaskBudget != nil {
+		params.ExtraParams["task_budget"] = req.OutputConfig.TaskBudget
+	}
 	if req.Thinking != nil {
 		if req.Thinking.Type == "enabled" || req.Thinking.Type == "adaptive" {
 			var summary *string
@@ -2170,10 +2173,14 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 					summary = schemas.Ptr("detailed")
 				}
 			}
+			// If the request was sent with display:"omitted"
+			if req.Thinking.Display != nil && *req.Thinking.Display == "omitted" {
+				summary = schemas.Ptr("none")
+			}
 			if req.OutputConfig != nil && req.OutputConfig.Effort != nil {
 				// Native effort present — map to Bifrost enum (e.g., "max" → "high")
 				params.Reasoning = &schemas.ResponsesParametersReasoning{
-					Effort:    schemas.Ptr(MapAnthropicEffortToBifrost(*req.OutputConfig.Effort)),
+					Effort:    schemas.Ptr(*req.OutputConfig.Effort),
 					MaxTokens: req.Thinking.BudgetTokens,
 					Summary:   summary,
 				}
@@ -2299,12 +2306,15 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 		if bifrostReq.Params.MaxOutputTokens != nil {
 			anthropicReq.MaxTokens = *bifrostReq.Params.MaxOutputTokens
 		}
-		// Anthropic doesn't allow both temperature and top_p to be specified
-		// If both are present, prefer temperature (more commonly used)
-		if bifrostReq.Params.Temperature != nil {
-			anthropicReq.Temperature = bifrostReq.Params.Temperature
-		} else if bifrostReq.Params.TopP != nil {
-			anthropicReq.TopP = bifrostReq.Params.TopP
+		// Opus 4.7+ rejects temperature, top_p, and top_k with a 400 error.
+		if !IsOpus47(bifrostReq.Model) {
+			// Anthropic doesn't allow both temperature and top_p to be specified.
+			// If both are present, prefer temperature (more commonly used).
+			if bifrostReq.Params.Temperature != nil {
+				anthropicReq.Temperature = bifrostReq.Params.Temperature
+			} else if bifrostReq.Params.TopP != nil {
+				anthropicReq.TopP = bifrostReq.Params.TopP
+			}
 		}
 		if bifrostReq.Params.User != nil {
 			anthropicReq.Metadata = &AnthropicMetaData{
@@ -2364,26 +2374,31 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 		}
 		if bifrostReq.Params.Reasoning != nil {
 			if bifrostReq.Params.Reasoning.MaxTokens != nil {
-				budgetTokens := *bifrostReq.Params.Reasoning.MaxTokens
-				if *bifrostReq.Params.Reasoning.MaxTokens == -1 {
-					// anthropic does not support dynamic reasoning budget like gemini
-					// setting it to default max tokens
-					budgetTokens = MinimumReasoningMaxTokens
-				}
-				if budgetTokens < MinimumReasoningMaxTokens {
-					return nil, fmt.Errorf("reasoning.max_tokens must be >= %d for anthropic", MinimumReasoningMaxTokens)
-				}
-				anthropicReq.Thinking = &AnthropicThinking{
-					Type:         "enabled",
-					BudgetTokens: schemas.Ptr(budgetTokens),
+				if IsOpus47(bifrostReq.Model) {
+					// Opus 4.7+: budget_tokens removed; adaptive thinking is the only thinking-on mode.
+					anthropicReq.Thinking = &AnthropicThinking{Type: "adaptive"}
+				} else {
+					budgetTokens := *bifrostReq.Params.Reasoning.MaxTokens
+					if *bifrostReq.Params.Reasoning.MaxTokens == -1 {
+						// anthropic does not support dynamic reasoning budget like gemini
+						// setting it to default max tokens
+						budgetTokens = MinimumReasoningMaxTokens
+					}
+					if budgetTokens < MinimumReasoningMaxTokens {
+						return nil, fmt.Errorf("reasoning.max_tokens must be >= %d for anthropic", MinimumReasoningMaxTokens)
+					}
+					anthropicReq.Thinking = &AnthropicThinking{
+						Type:         "enabled",
+						BudgetTokens: schemas.Ptr(budgetTokens),
+					}
 				}
 			} else {
 				if bifrostReq.Params.Reasoning.Effort != nil {
 					if *bifrostReq.Params.Reasoning.Effort != "none" {
 						effort := MapBifrostEffortToAnthropic(*bifrostReq.Params.Reasoning.Effort)
 
-						if SupportsAdaptiveThinking(bifrostReq.Model) {
-							// Opus 4.6+: adaptive thinking + native effort
+						if SupportsAdaptiveThinking(bifrostReq.Model) || IsOpus47(bifrostReq.Model) {
+							// Opus 4.6+ and Opus 4.7+: adaptive thinking + native effort
 							anthropicReq.Thinking = &AnthropicThinking{Type: "adaptive"}
 							setEffortOnOutputConfig(anthropicReq, effort)
 						} else if SupportsNativeEffort(bifrostReq.Model) {
@@ -2413,6 +2428,15 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 							Type: "disabled",
 						}
 					}
+				}
+			}
+			if anthropicReq.Thinking != nil && anthropicReq.Thinking.Type != "disabled" {
+				if bifrostReq.Params.Reasoning != nil &&
+					bifrostReq.Params.Reasoning.Summary != nil && *bifrostReq.Params.Reasoning.Summary == "none" {
+					anthropicReq.Thinking.Display = schemas.Ptr("omitted")
+				} else {
+					// Default to "summarized" to preserve visible thinking output
+					anthropicReq.Thinking.Display = schemas.Ptr("summarized")
 				}
 			}
 		}
@@ -2449,7 +2473,9 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 			topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"])
 			if ok {
 				delete(anthropicReq.ExtraParams, "top_k")
-				anthropicReq.TopK = topK
+				if !IsOpus47(bifrostReq.Model) {
+					anthropicReq.TopK = topK
+				}
 			}
 			if speed, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["speed"]); ok {
 				delete(anthropicReq.ExtraParams, "speed")
@@ -2474,6 +2500,31 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 						anthropicReq.ContextManagement = &cm
 					}
 				}
+			}
+			if tbVal, exists := bifrostReq.Params.ExtraParams["task_budget"]; exists {
+				// Always consume provider-specific key from passthrough extras.
+				delete(anthropicReq.ExtraParams, "task_budget")
+				var taskBudget *AnthropicTaskBudget
+				switch v := tbVal.(type) {
+				case *AnthropicTaskBudget:
+					taskBudget = v
+				case AnthropicTaskBudget:
+					taskBudget = &v
+				default:
+					if data, err := providerUtils.MarshalSorted(v); err == nil {
+						var tb AnthropicTaskBudget
+						if sonic.Unmarshal(data, &tb) == nil {
+							taskBudget = &tb
+						}
+					}
+				}
+				if taskBudget == nil {
+					return nil, fmt.Errorf("invalid task_budget format for anthropic")
+				}
+				if anthropicReq.OutputConfig == nil {
+					anthropicReq.OutputConfig = &AnthropicOutputConfig{}
+				}
+				anthropicReq.OutputConfig.TaskBudget = taskBudget
 			}
 		}
 

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -48,6 +48,8 @@ const (
 	AnthropicFastModeBetaHeader = "fast-mode-2026-02-01"
 	// AnthropicRedactThinkingBetaHeader is required for redacting thinking blocks in responses.
 	AnthropicRedactThinkingBetaHeader = "redact-thinking-2026-02-12"
+	// AnthropicTaskBudgetsBetaHeader is required for output_config.task_budget (Opus 4.7+).
+	AnthropicTaskBudgetsBetaHeader = "task-budgets-2026-03-13"
 
 	// AnthropicComputerUseBetaHeader is required for computer use (version-specific).
 	// computer_20251124 (Opus 4.6, Sonnet 4.6, Opus 4.5) uses the newer beta header.
@@ -67,6 +69,7 @@ const (
 	AnthropicContext1MBetaHeaderPrefix           = "context-1m-"
 	AnthropicFastModeBetaHeaderPrefix            = "fast-mode-"
 	AnthropicRedactThinkingBetaHeaderPrefix      = "redact-thinking-"
+	AnthropicTaskBudgetsBetaHeaderPrefix         = "task-budgets-"
 )
 
 // ProviderFeatureSupport defines which Anthropic features a given provider supports.
@@ -93,6 +96,7 @@ type ProviderFeatureSupport struct {
 	Context1M           bool // 1M context window beta (for Sonnet 4.5/4 only)
 	FastMode            bool // fast mode (Opus 4.6 only, research preview)
 	RedactThinking      bool // redact thinking blocks in responses
+	TaskBudgets         bool // task_budget in output_config (Opus 4.7+)
 	FileSearch          bool // file_search server tool (OpenAI-only)
 	ImageGeneration     bool // image_generation server tool (OpenAI-only)
 }
@@ -105,7 +109,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		MCP: true, AdvancedToolUse: true, StructuredOutputs: true, PromptCachingScope: true,
 		Compaction: true, ContextEditing: true, FilesAPI: true,
 		InterleavedThinking: true, Skills: true, Context1M: true, FastMode: true,
-		RedactThinking: true,
+		RedactThinking: true, TaskBudgets: true,
 	},
 	schemas.Vertex: {
 		WebSearch:   true, // only web_search_20250305 (basic), NOT dynamic filtering
@@ -124,7 +128,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		MCP: true, AdvancedToolUse: true, StructuredOutputs: true, PromptCachingScope: true,
 		Compaction: true, ContextEditing: true, FilesAPI: true,
 		InterleavedThinking: true, Skills: true, Context1M: true,
-		RedactThinking: true,
+		RedactThinking: true, TaskBudgets: true,
 	},
 }
 
@@ -156,11 +160,22 @@ func (req *AnthropicTextRequest) IsStreamingRequested() bool {
 	return req.Stream != nil && *req.Stream
 }
 
-// AnthropicOutputConfig represents the GA structured outputs config (output_config.format)
-// and the effort parameter (output_config.effort) for controlling token spending.
+// AnthropicTaskBudget represents an advisory token budget for a full agentic loop (output_config.task_budget).
+// The model sees a running countdown and uses it to prioritize work and finish gracefully.
+// Requires beta header "task-budgets-2026-03-13". Minimum total: 20 000 tokens.
+// This is advisory, not a hard cap — use max_tokens as the per-request hard ceiling.
+type AnthropicTaskBudget struct {
+	Type      string `json:"type"`                // always "tokens"
+	Total     int    `json:"total"`               // total advisory token budget across the agentic loop
+	Remaining *int   `json:"remaining,omitempty"` // optional; tracks remaining tokens for client-side compaction
+}
+
+// AnthropicOutputConfig represents the GA structured outputs config (output_config.format),
+// the effort parameter (output_config.effort), and the task budget (output_config.task_budget).
 type AnthropicOutputConfig struct {
-	Format json.RawMessage `json:"format,omitempty"`
-	Effort *string         `json:"effort,omitempty"` // "low", "medium", "high", "max" (Opus 4.5+)
+	Format     json.RawMessage      `json:"format,omitempty"`      // JSON schema for structured outputs
+	Effort     *string              `json:"effort,omitempty"`      // "low" | "medium" | "high" | "xhigh" | "max"
+	TaskBudget *AnthropicTaskBudget `json:"task_budget,omitempty"` // advisory token budget; requires task-budgets-2026-03-13 beta header
 }
 
 // AnthropicMessageRequest represents an Anthropic messages API request
@@ -212,8 +227,9 @@ type AnthropicMetaData struct {
 }
 
 type AnthropicThinking struct {
-	Type         string `json:"type"` // "enabled" or "disabled"
-	BudgetTokens *int   `json:"budget_tokens,omitempty"`
+	Type         string  `json:"type"`                    // "enabled", "disabled", or "adaptive"
+	BudgetTokens *int    `json:"budget_tokens,omitempty"` // Only for type "enabled" (not supported on Opus 4.7+)
+	Display      *string `json:"display,omitempty"`       // "summarized" | "omitted" — controls whether thinking content appears in the response (Opus 4.7+)
 }
 
 type ContextManagementEditType string

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -90,6 +90,17 @@ var (
 	}
 )
 
+// IsOpus47 returns true if the model is Claude Opus 4.7 or a later generation where:
+//   - Extended thinking (budget_tokens) is removed — only adaptive thinking is supported.
+//   - temperature, top_p, and top_k are not supported (setting them returns a 400).
+func IsOpus47(model string) bool {
+	model = strings.ToLower(model)
+	if !strings.Contains(model, "opus") {
+		return false
+	}
+	return strings.Contains(model, "4-7") || strings.Contains(model, "4.7")
+}
+
 // SupportsNativeEffort returns true if the model supports Anthropic's native output_config.effort parameter.
 // Currently supported on Claude Opus 4.5 and Opus 4.6.
 func SupportsNativeEffort(model string) bool {
@@ -102,11 +113,18 @@ func SupportsNativeEffort(model string) bool {
 }
 
 // SupportsAdaptiveThinking returns true if the model supports thinking.type: "adaptive".
-// Currently only supported on Claude Opus 4.6.
+// Currently supported on Claude Opus 4.6, Claude Sonnet 4.6, and Claude Opus 4.7+.
+// On Opus 4.7+ adaptive is the only thinking-on mode; on Opus 4.6 and Sonnet 4.6 it
+// coexists with the deprecated budget_tokens-based extended thinking.
 func SupportsAdaptiveThinking(model string) bool {
+	if IsOpus47(model) {
+		return true
+	}
 	model = strings.ToLower(model)
-	return strings.Contains(model, "opus") &&
-		(strings.Contains(model, "4-6") || strings.Contains(model, "4.6"))
+	if !strings.Contains(model, "4-6") && !strings.Contains(model, "4.6") {
+		return false
+	}
+	return strings.Contains(model, "opus") || strings.Contains(model, "sonnet")
 }
 
 // MapBifrostEffortToAnthropic maps a Bifrost effort level to an Anthropic effort level.
@@ -114,15 +132,6 @@ func SupportsAdaptiveThinking(model string) bool {
 func MapBifrostEffortToAnthropic(effort string) string {
 	if effort == "minimal" {
 		return "low"
-	}
-	return effort
-}
-
-// MapAnthropicEffortToBifrost maps an Anthropic effort level to a Bifrost effort level.
-// Anthropic supports "max" (Opus 4.6+) which is not in Bifrost's enum; it maps to "high".
-func MapAnthropicEffortToBifrost(effort string) string {
-	if effort == "max" {
-		return "high"
 	}
 	return effort
 }
@@ -324,6 +333,12 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 			headers = appendUniqueHeader(headers, AnthropicFastModeBetaHeader)
 		}
 	}
+	// Check for task budget
+	if req.OutputConfig != nil && req.OutputConfig.TaskBudget != nil {
+		if !hasProvider || features.TaskBudgets {
+			headers = appendUniqueHeader(headers, AnthropicTaskBudgetsBetaHeader)
+		}
+	}
 	// Check for output format (structured outputs)
 	if req.OutputFormat != nil {
 		if !hasProvider || features.StructuredOutputs {
@@ -405,6 +420,7 @@ var betaHeaderPrefixKnown = []string{
 	AnthropicContext1MBetaHeaderPrefix,
 	AnthropicFastModeBetaHeaderPrefix,
 	AnthropicRedactThinkingBetaHeaderPrefix,
+	AnthropicTaskBudgetsBetaHeaderPrefix,
 }
 
 // betaHeaderPrefixExists checks if any header in existing shares a known prefix with newHeader.
@@ -599,6 +615,7 @@ var betaHeaderPrefixToFeature = map[string]func(ProviderFeatureSupport) bool{
 	AnthropicContext1MBetaHeaderPrefix:           func(f ProviderFeatureSupport) bool { return f.Context1M },
 	AnthropicFastModeBetaHeaderPrefix:            func(f ProviderFeatureSupport) bool { return f.FastMode },
 	AnthropicRedactThinkingBetaHeaderPrefix:      func(f ProviderFeatureSupport) bool { return f.RedactThinking },
+	AnthropicTaskBudgetsBetaHeaderPrefix:         func(f ProviderFeatureSupport) bool { return f.TaskBudgets },
 }
 
 // MergeBetaHeaders collects anthropic-beta values from provider ExtraHeaders and

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -1574,3 +1574,109 @@ func TestApplyMCPToolsetConfigToBifrostTool(t *testing.T) {
 		applyMCPToolsetConfigToBifrostTool(&schemas.ResponsesTool{}, nil)
 	})
 }
+
+func TestSupportsAdaptiveThinking(t *testing.T) {
+	tests := []struct {
+		model    string
+		expected bool
+	}{
+		{"claude-opus-4-7-20260401", true},
+		{"claude-opus-4.7-20260401", true},
+		{"claude-opus-4-6-20250514", true},
+		{"claude-opus-4.6-20250514", true},
+		{"claude-sonnet-4-6-20250514", true},
+		{"claude-sonnet-4.6-20250514", true},
+		{"claude-opus-4-5-20241022", false},
+		{"claude-sonnet-4-5-20241022", false},
+		{"claude-haiku-4-6-20250514", false}, // haiku does not support adaptive
+		{"claude-haiku-4-7-20260401", false}, // haiku, not opus
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			got := SupportsAdaptiveThinking(tt.model)
+			if got != tt.expected {
+				t.Errorf("SupportsAdaptiveThinking(%q) = %v, want %v", tt.model, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAddMissingBetaHeadersToContext_TaskBudgets(t *testing.T) {
+	tests := []struct {
+		name            string
+		provider        schemas.ModelProvider
+		req             *AnthropicMessageRequest
+		expectHeaders   []string
+		unexpectHeaders []string
+	}{
+		{
+			name:     "Anthropic gets task-budgets header when task_budget set",
+			provider: schemas.Anthropic,
+			req: &AnthropicMessageRequest{
+				OutputConfig: &AnthropicOutputConfig{
+					TaskBudget: &AnthropicTaskBudget{Type: "tokens", Total: 50000},
+				},
+			},
+			expectHeaders: []string{AnthropicTaskBudgetsBetaHeader},
+		},
+		{
+			name:     "Vertex does not get task-budgets header when task_budget set",
+			provider: schemas.Vertex,
+			req: &AnthropicMessageRequest{
+				OutputConfig: &AnthropicOutputConfig{
+					TaskBudget: &AnthropicTaskBudget{Type: "tokens", Total: 50000},
+				},
+			},
+			unexpectHeaders: []string{AnthropicTaskBudgetsBetaHeader},
+		},
+		{
+			name:     "no task-budgets header when task_budget is nil",
+			provider: schemas.Anthropic,
+			req: &AnthropicMessageRequest{
+				OutputConfig: &AnthropicOutputConfig{},
+			},
+			unexpectHeaders: []string{AnthropicTaskBudgetsBetaHeader},
+		},
+		{
+			name:            "no task-budgets header when output_config is nil",
+			provider:        schemas.Anthropic,
+			req:             &AnthropicMessageRequest{},
+			unexpectHeaders: []string{AnthropicTaskBudgetsBetaHeader},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(nil, time.Time{})
+			AddMissingBetaHeadersToContext(ctx, tt.req, tt.provider)
+
+			var headers []string
+			if extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
+				headers = extraHeaders[AnthropicBetaHeader]
+			}
+
+			for _, expected := range tt.expectHeaders {
+				found := false
+				for _, h := range headers {
+					if h == expected {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected header %q not found in %v", expected, headers)
+				}
+			}
+
+			for _, unexpected := range tt.unexpectHeaders {
+				for _, h := range headers {
+					if h == unexpected {
+						t.Errorf("unexpected header %q found in %v", unexpected, headers)
+					}
+				}
+			}
+		})
+	}
+}

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -85,7 +85,7 @@ func effortToThinkingLevel(effort string, model string) string {
 			return "high" // Pro models don't support medium, use high
 		}
 		return "medium"
-	case "high":
+	case "high", "xhigh", "max":
 		return "high"
 	default:
 		if isPro {

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -104,12 +104,17 @@ func (req *OpenAIChatRequest) filterOpenAISpecificParameters() {
 	// Handle reasoning parameter: OpenAI uses effort-based reasoning
 	// Priority: effort (native) > max_tokens (estimated)
 	if req.ChatParameters.Reasoning != nil {
+		reasoningCopy := *req.ChatParameters.Reasoning
+		req.ChatParameters.Reasoning = &reasoningCopy
 		if req.ChatParameters.Reasoning.Effort != nil {
 			// Native field is provided, use it (and clear max_tokens)
 			effort := *req.ChatParameters.Reasoning.Effort
-			// Convert "minimal" to "low" for non-OpenAI providers
-			if effort == "minimal" {
+			// Convert "minimal" to "low"; cap "xhigh"/"max" to "high" — OpenAI tops out at high.
+			switch effort {
+			case "minimal":
 				req.ChatParameters.Reasoning.Effort = schemas.Ptr("low")
+			case "xhigh", "max":
+				req.ChatParameters.Reasoning.Effort = schemas.Ptr("high")
 			}
 			// Clear max_tokens since OpenAI doesn't use it
 			req.ChatParameters.Reasoning.MaxTokens = nil

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -201,9 +201,12 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 			if req.ResponsesParameters.Reasoning.Effort != nil {
 				// Native field is provided, use it (and clear max_tokens)
 				effort := *req.ResponsesParameters.Reasoning.Effort
-				// Convert "minimal" to "low" for non-OpenAI providers
-				if effort == "minimal" {
+				// Convert "minimal" to "low"; cap "xhigh"/"max" to "high" — OpenAI tops out at high.
+				switch effort {
+				case "minimal":
 					req.ResponsesParameters.Reasoning.Effort = schemas.Ptr("low")
+				case "xhigh", "max":
+					req.ResponsesParameters.Reasoning.Effort = schemas.Ptr("high")
 				}
 				// Clear max_tokens since OpenAI doesn't use it
 				req.ResponsesParameters.Reasoning.MaxTokens = nil
@@ -218,6 +221,11 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 				req.ResponsesParameters.Reasoning.Effort = schemas.Ptr(effort)
 				// Clear max_tokens since OpenAI doesn't use it
 				req.ResponsesParameters.Reasoning.MaxTokens = nil
+			}
+
+			// summary:"none" is Anthropic-specific (maps to display:"omitted"); strip it for OpenAI.
+			if req.ResponsesParameters.Reasoning.Summary != nil && *req.ResponsesParameters.Reasoning.Summary == "none" {
+				req.ResponsesParameters.Reasoning.Summary = nil
 			}
 
 			// Handle xAI-specific parameter filtering

--- a/core/providers/perplexity/chat.go
+++ b/core/providers/perplexity/chat.go
@@ -38,10 +38,14 @@ func ToPerplexityChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) *
 
 		// Handle reasoning effort mapping
 		if bifrostReq.Params.Reasoning != nil && bifrostReq.Params.Reasoning.Effort != nil {
-			if *bifrostReq.Params.Reasoning.Effort == "minimal" {
+			effort := *bifrostReq.Params.Reasoning.Effort
+			switch effort {
+			case "minimal":
 				perplexityReq.ReasoningEffort = schemas.Ptr("low")
-			} else {
-				perplexityReq.ReasoningEffort = bifrostReq.Params.Reasoning.Effort
+			case "xhigh", "max":
+				perplexityReq.ReasoningEffort = schemas.Ptr("high")
+			default:
+				perplexityReq.ReasoningEffort = &effort
 			}
 		}
 

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2557,9 +2557,8 @@ func GetReasoningEffortFromBudgetTokens(
 	}
 }
 
-// GetBudgetTokensFromReasoningEffort converts OpenAI reasoning effort
-// into a reasoning token budget.
-// effort ∈ {"none", "minimal", "low", "medium", "high"}
+// GetBudgetTokensFromReasoningEffort converts reasoning effort into a reasoning token budget.
+// effort ∈ {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
 func GetBudgetTokensFromReasoningEffort(
 	effort string,
 	minBudgetTokens int,
@@ -2589,6 +2588,10 @@ func GetBudgetTokensFromReasoningEffort(
 		ratio = 0.425
 	case "high":
 		ratio = 0.80
+	case "xhigh":
+		ratio = 0.92
+	case "max":
+		ratio = 1.0
 	default:
 		// Unknown effort → safe default
 		ratio = 0.425

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -2,3 +2,4 @@
 - fix: Bedrock integration - update to use InvokeModelRawChunks for multi-event support [@tefimov](https://github.com/tefimov)
 - fix: gemini preserves thinkingLevel parameters during round-trip and finish reason mapping
 - fix: WebSearch tool argument handling for all clients by removing the Claude Code user agent restriction
+- feat: claude-opus-4-7 compatibility


### PR DESCRIPTION
## Summary

Adds support for Claude Opus 4.7 model with specific parameter handling and reasoning configuration changes. Opus 4.7 rejects temperature, top_p, and top_k parameters and only supports adaptive thinking mode without budget tokens.

## Changes

- Added `IsOpus47()` function to detect Claude Opus 4.7 models
- Modified parameter handling to skip temperature, top_p, and top_k for Opus 4.7 models
- Updated reasoning configuration to use adaptive thinking only for Opus 4.7 (no budget_tokens)
- Added support for `display` parameter in thinking configuration to control output visibility
- Extended adaptive thinking support to include Sonnet 4.6 models
- Added task budget support with new beta header `task-budgets-2026-03-13`
- Updated effort mapping to handle Opus 4.7's "xhigh" effort level
- Added comprehensive test coverage for Opus 4.7 specific behaviors
- Fixed OpenAI responses to filter out Anthropic-specific summary:"none" parameter

## Type of change

- [x] Feature
- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

Validate the changes with the following tests:

```sh
# Core/Transports
go version
go test ./core/providers/anthropic/...

# Specific test cases for Opus 4.7
go test -run TestToAnthropicChatRequest_Opus47 ./core/providers/anthropic/
go test -run TestSupportsAdaptiveThinking ./core/providers/anthropic/
go test -run TestAddMissingBetaHeadersToContext_TaskBudgets ./core/providers/anthropic/
```

Test with Claude Opus 4.7 model requests to ensure:
- Temperature, top_p, top_k parameters are stripped
- Reasoning uses adaptive thinking without budget_tokens
- Task budget beta headers are properly added

## Breaking changes

- [ ] Yes
- [x] No

The changes maintain backward compatibility while adding new model support.

## Security considerations

No security implications. Changes only affect parameter handling and model-specific configurations for Anthropic's Claude models.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable