### PR TITLE
[DO NOT MERGE] feat: add explicit TeamID and CustomerID support to routing context

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -883,9 +883,21 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 		}
 	}
 
+	var teamID, customerID *string
+	teamIDStr, ok := ctx.Value(schemas.BifrostContextKeyGovernanceTeamID).(string)
+	if ok {
+		teamID = &teamIDStr
+	}
+	customerIDStr, ok := ctx.Value(schemas.BifrostContextKeyGovernanceCustomerID).(string)
+	if ok {
+		customerID = &customerIDStr
+	}
+
 	// Build routing context
 	routingCtx := &RoutingContext{
 		VirtualKey:               virtualKey,
+		TeamID:                   teamID,
+		CustomerID:               customerID,
 		Provider:                 provider,
 		Model:                    model,
 		RequestType:              requestType,

--- a/plugins/governance/routing.go
+++ b/plugins/governance/routing.go
@@ -34,6 +34,8 @@ type RoutingDecision struct {
 // Reuses existing configstore table types for VirtualKey, Team, Customer
 type RoutingContext struct {
 	VirtualKey               *configstoreTables.TableVirtualKey // nil if no VK
+	TeamID                   *string                            // nil if no team (set explicitly or automatically derived from VirtualKey)
+	CustomerID               *string                            // nil if no customer (set explicitly or automatically derived from VirtualKey)
 	Provider                 schemas.ModelProvider              // Current provider
 	Model                    string                             // Current model
 	RequestType              string                             // Normalized request type (e.g., "chat_completion", "embedding") from HTTP context
@@ -124,7 +126,7 @@ func (re *RoutingEngine) EvaluateRoutingRules(ctx *schemas.BifrostContext, routi
 			return nil, fmt.Errorf("failed to extract routing variables: %w", err)
 		}
 
-		scopeChain := buildScopeChain(routingCtx.VirtualKey)
+		scopeChain := buildScopeChain(routingCtx)
 		re.logger.Debug("[RoutingEngine] Scope chain (step=%d): %v", chainStep, scopeChainToStrings(scopeChain))
 		if chainStep == 0 {
 			ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, fmt.Sprintf("Scope chain: %v", scopeChainToStrings(scopeChain)))
@@ -305,36 +307,53 @@ func selectWeightedTarget(targets []configstoreTables.TableRoutingTarget) (confi
 // buildScopeChain builds the scope evaluation chain based on organizational hierarchy
 // Returns scope levels in precedence order (highest to lowest)
 // VirtualKey > Team > Customer > Global
-func buildScopeChain(virtualKey *configstoreTables.TableVirtualKey) []ScopeLevel {
+func buildScopeChain(ctx *RoutingContext) []ScopeLevel {
 	var chain []ScopeLevel
 
 	// VirtualKey level (highest precedence)
-	if virtualKey != nil {
-		chain = append(chain, ScopeLevel{
-			ScopeName: "virtual_key",
-			ScopeID:   virtualKey.ID,
-		})
-
-		// Team level
-		if virtualKey.Team != nil {
+	if ctx != nil {
+		virtualKey := ctx.VirtualKey
+		if virtualKey != nil {
 			chain = append(chain, ScopeLevel{
-				ScopeName: "team",
-				ScopeID:   virtualKey.Team.ID,
+				ScopeName: "virtual_key",
+				ScopeID:   virtualKey.ID,
 			})
-
-			// Customer level (from Team)
-			if virtualKey.Team.Customer != nil {
+		}
+		// Use explicitly set TeamID | CustomerID if provided, otherwise derive from VirtualKey
+		if ctx.TeamID != nil || ctx.CustomerID != nil {
+			if ctx.TeamID != nil {
 				chain = append(chain, ScopeLevel{
-					ScopeName: "customer",
-					ScopeID:   virtualKey.Team.Customer.ID,
+					ScopeName: "team",
+					ScopeID:   *ctx.TeamID,
 				})
 			}
-		} else if virtualKey.Customer != nil {
-			// Customer level (VK attached directly to customer, no Team)
-			chain = append(chain, ScopeLevel{
-				ScopeName: "customer",
-				ScopeID:   virtualKey.Customer.ID,
-			})
+			if ctx.CustomerID != nil {
+				chain = append(chain, ScopeLevel{
+					ScopeName: "customer",
+					ScopeID:   *ctx.CustomerID,
+				})
+			}
+		} else if virtualKey != nil {
+			// Team level (automatically derived from VirtualKey)
+			if virtualKey.Team != nil {
+				chain = append(chain, ScopeLevel{
+					ScopeName: "team",
+					ScopeID:   virtualKey.Team.ID,
+				})
+				// Customer level (from Team)
+				if virtualKey.Team.Customer != nil {
+					chain = append(chain, ScopeLevel{
+						ScopeName: "customer",
+						ScopeID:   virtualKey.Team.Customer.ID,
+					})
+				}
+			} else if virtualKey.Customer != nil {
+				// Customer level (VK attached directly to customer, no Team)
+				chain = append(chain, ScopeLevel{
+					ScopeName: "customer",
+					ScopeID:   virtualKey.Customer.ID,
+				})
+			}
 		}
 	}
 

--- a/plugins/governance/routing_test.go
+++ b/plugins/governance/routing_test.go
@@ -32,7 +32,7 @@ func TestBuildScopeChain_VirtualKeyOnly(t *testing.T) {
 		Name: "test-vk",
 	}
 
-	chain := buildScopeChain(vk)
+	chain := buildScopeChain(&RoutingContext{VirtualKey: vk})
 
 	require.Equal(t, 2, len(chain))
 	assert.Equal(t, "virtual_key", chain[0].ScopeName)
@@ -54,7 +54,7 @@ func TestBuildScopeChain_WithTeam(t *testing.T) {
 		Team: team,
 	}
 
-	chain := buildScopeChain(vk)
+	chain := buildScopeChain(&RoutingContext{VirtualKey: vk})
 
 	require.Equal(t, 3, len(chain))
 	assert.Equal(t, "virtual_key", chain[0].ScopeName)
@@ -83,7 +83,7 @@ func TestBuildScopeChain_FullHierarchy(t *testing.T) {
 		Team: team,
 	}
 
-	chain := buildScopeChain(vk)
+	chain := buildScopeChain(&RoutingContext{VirtualKey: vk})
 
 	require.Equal(t, 4, len(chain))
 	assert.Equal(t, "virtual_key", chain[0].ScopeName)


### PR DESCRIPTION
## Summary

Enhanced the governance plugin's routing engine to support explicit team and customer ID context for routing decisions. This allows routing rules to be evaluated based on explicitly provided team/customer context rather than only deriving it from virtual key relationships.

## Changes

- Added `TeamID` and `CustomerID` fields to `RoutingContext` struct to support explicit context
- Modified `applyRoutingRules` to extract team and customer IDs from Bifrost context and populate the routing context
- Updated `buildScopeChain` function to prioritize explicitly set team/customer IDs over virtual key-derived relationships
- Enhanced scope chain building logic to handle cases where team/customer context is provided independently of virtual key hierarchy
- Updated all test cases to use the new `RoutingContext` parameter structure

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate that routing rules work with explicit team/customer context:

```sh
# Run governance plugin tests
go test ./plugins/governance/...

# Test routing with explicit context
go test -run TestBuildScopeChain ./plugins/governance/

# Verify full plugin functionality
go test ./...
```

Test scenarios should include:
- Routing with virtual key hierarchy (existing behavior)
- Routing with explicit team ID context
- Routing with explicit customer ID context
- Mixed scenarios with both virtual key and explicit context

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

The changes are backward compatible - existing virtual key-based routing continues to work unchanged.

## Related issues

N/A

## Security considerations

The changes maintain existing access control patterns by using the same context keys and scope evaluation logic. No new security implications introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable