### PR TITLE
[fix]: OpenAI provider - flatten array-form tool_result output for Responses API

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: OpenAI provider - flatten array-form tool_result output for Responses API (thanks [@martingiguere](https://github.com/martingiguere)!)
 - fix: Gemini provider - handle content block tool outputs in Responses API path (thanks [@tom-diacono](https://github.com/tom-diacono)!)
 - fix: case-insensitive `anthropic-beta` merge in `MergeBetaHeaders`
 - fix: Bedrock provider - emit message_stop event for Anthropic invoke stream (thanks [@tefimov](https://github.com/tefimov)!)

--- a/core/providers/openai/responses_marshal_test.go
+++ b/core/providers/openai/responses_marshal_test.go
@@ -523,3 +523,174 @@ func TestOpenAIResponsesRequest_MarshalJSON_RoundTrip(t *testing.T) {
 		}
 	})
 }
+
+// Regression test for multi-turn Anthropic tool_result with array-form content.
+// The OpenAI Responses API defines function_call_output.output as a string (see
+// https://platform.openai.com/docs/api-reference/responses/create). When an
+// Anthropic client sends a tool_result whose content is an array of text blocks,
+// Bifrost's Anthropic→Responses translator populates
+// ResponsesToolMessageOutputStruct.ResponsesFunctionToolCallOutputBlocks.
+// Historically, that array was marshaled verbatim onto the wire, which some
+// strict OpenAI-compat upstreams (e.g. Ollama Cloud) reject with an error like
+//
+//	json: cannot unmarshal array into Go struct field ResponsesFunctionCallOutput.output of type string
+//
+// The outgoing OpenAI Responses request must emit `output` as a string for
+// text-only tool outputs.
+func TestOpenAIResponsesRequestInput_MarshalJSON_FunctionCallOutputFlattensTextBlocksToString(t *testing.T) {
+	outputText := "line1"
+	callID := "toolu_abc123"
+	functionName := "read_file"
+
+	input := &OpenAIResponsesRequestInput{
+		OpenAIResponsesRequestInputArray: []schemas.ResponsesMessage{
+			{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{
+					ContentStr: schemas.Ptr("Read /tmp/test.txt and tell me what it contains."),
+				},
+			},
+			{
+				Type:   schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+				Status: schemas.Ptr("completed"),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    schemas.Ptr(callID),
+					Name:      schemas.Ptr(functionName),
+					Arguments: schemas.Ptr(`{"path":"/tmp/test.txt"}`),
+				},
+			},
+			{
+				Type:   schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+				Status: schemas.Ptr("completed"),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID: schemas.Ptr(callID),
+					Output: &schemas.ResponsesToolMessageOutputStruct{
+						ResponsesFunctionToolCallOutputBlocks: []schemas.ResponsesMessageContentBlock{
+							{
+								Type: schemas.ResponsesInputMessageContentBlockTypeText,
+								Text: schemas.Ptr(outputText),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	jsonBytes, err := input.MarshalJSON()
+	if err != nil {
+		t.Fatalf("Failed to marshal OpenAIResponsesRequestInput: %v", err)
+	}
+
+	var messages []map[string]interface{}
+	if err := sonic.Unmarshal(jsonBytes, &messages); err != nil {
+		t.Fatalf("Failed to unmarshal marshaled input as array: %v\nraw=%s", err, string(jsonBytes))
+	}
+
+	var fcoMsg map[string]interface{}
+	for _, m := range messages {
+		if t, ok := m["type"].(string); ok && t == string(schemas.ResponsesMessageTypeFunctionCallOutput) {
+			fcoMsg = m
+			break
+		}
+	}
+	if fcoMsg == nil {
+		t.Fatalf("did not find function_call_output message in marshaled JSON: %s", string(jsonBytes))
+	}
+
+	outputVal, ok := fcoMsg["output"]
+	if !ok {
+		t.Fatalf("function_call_output message has no `output` field: %s", string(jsonBytes))
+	}
+
+	outputStr, isString := outputVal.(string)
+	if !isString {
+		t.Fatalf("function_call_output.output must be a string (OpenAI Responses API spec); got %T: %v\nraw=%s", outputVal, outputVal, string(jsonBytes))
+	}
+	if outputStr != outputText {
+		t.Fatalf("function_call_output.output mismatch: want %q, got %q", outputText, outputStr)
+	}
+}
+
+// Flattening must concatenate multiple text blocks with newline separators so
+// every character from the upstream tool response reaches the model.
+func TestOpenAIResponsesRequestInput_MarshalJSON_FunctionCallOutputConcatenatesMultipleTextBlocks(t *testing.T) {
+	callID := "toolu_multi"
+	input := &OpenAIResponsesRequestInput{
+		OpenAIResponsesRequestInputArray: []schemas.ResponsesMessage{
+			{
+				Type:   schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+				Status: schemas.Ptr("completed"),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID: schemas.Ptr(callID),
+					Output: &schemas.ResponsesToolMessageOutputStruct{
+						ResponsesFunctionToolCallOutputBlocks: []schemas.ResponsesMessageContentBlock{
+							{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("line1")},
+							{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("line2")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	jsonBytes, err := input.MarshalJSON()
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+	var messages []map[string]interface{}
+	if err := sonic.Unmarshal(jsonBytes, &messages); err != nil {
+		t.Fatalf("Failed to unmarshal: %v\nraw=%s", err, string(jsonBytes))
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(messages))
+	}
+	got, ok := messages[0]["output"].(string)
+	if !ok {
+		t.Fatalf("output must be string, got %T", messages[0]["output"])
+	}
+	if want := "line1\nline2"; got != want {
+		t.Fatalf("flattened output mismatch: want %q, got %q", want, got)
+	}
+}
+
+// When the tool result contains a non-text block (e.g. an image), flattening is
+// unsafe — preserve the array form and let the upstream handle it. This keeps
+// the fix scoped to the common text-only case without dropping rich content.
+func TestOpenAIResponsesRequestInput_MarshalJSON_FunctionCallOutputPreservesNonTextBlocks(t *testing.T) {
+	callID := "toolu_with_image"
+	imageURL := "https://example.com/screenshot.png"
+	input := &OpenAIResponsesRequestInput{
+		OpenAIResponsesRequestInputArray: []schemas.ResponsesMessage{
+			{
+				Type:   schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+				Status: schemas.Ptr("completed"),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID: schemas.Ptr(callID),
+					Output: &schemas.ResponsesToolMessageOutputStruct{
+						ResponsesFunctionToolCallOutputBlocks: []schemas.ResponsesMessageContentBlock{
+							{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("here is the screenshot:")},
+							{
+								Type: schemas.ResponsesInputMessageContentBlockTypeImage,
+								ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{
+									ImageURL: &imageURL,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	jsonBytes, err := input.MarshalJSON()
+	if err != nil {
+		t.Fatalf("Failed to marshal: %v", err)
+	}
+	var messages []map[string]interface{}
+	if err := sonic.Unmarshal(jsonBytes, &messages); err != nil {
+		t.Fatalf("Failed to unmarshal: %v\nraw=%s", err, string(jsonBytes))
+	}
+	if _, isString := messages[0]["output"].(string); isString {
+		t.Fatalf("non-text blocks must not be flattened to string; raw=%s", string(jsonBytes))
+	}
+}

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -4,10 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/bytedance/sonic"
-	"github.com/maximhq/bifrost/core/schemas"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
 )
 
 const MinMaxCompletionTokens = 16
@@ -427,8 +428,23 @@ func (r *OpenAIResponsesRequestInput) MarshalJSON() ([]byte, error) {
 					}
 				}
 
-				// Strip CacheControl and FileType from tool message output blocks if needed
-				if msg.ResponsesToolMessage.Output != nil && msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks != nil {
+				// Collapse text-only tool output blocks into a single string.
+				// OpenAI's Responses API defines function_call_output.output as
+				// a string; Anthropic's multi-turn tool_result content arrives
+				// as an array of content blocks and has to be flattened here.
+				// Strict upstream implementations (e.g. Ollama Cloud) return a
+				// 400 otherwise.
+				if msg.ResponsesToolMessage.Output != nil &&
+					msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks != nil &&
+					isFunctionCallOutputBlocksFlattenable(msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks) {
+					flattened := flattenFunctionCallOutputBlocks(msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks)
+					outputCopy := *msg.ResponsesToolMessage.Output
+					outputCopy.ResponsesToolCallOutputStr = &flattened
+					outputCopy.ResponsesFunctionToolCallOutputBlocks = nil
+					toolMsgCopy.Output = &outputCopy
+					toolMsgModified = true
+				} else if msg.ResponsesToolMessage.Output != nil && msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks != nil {
+					// Strip CacheControl and FileType from tool message output blocks if needed
 					hasToolModification := false
 					for _, block := range msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks {
 						if block.CacheControl != nil || block.Citations != nil || (block.ResponsesInputMessageContentBlockFile != nil && block.ResponsesInputMessageContentBlockFile.FileType != nil) {
@@ -527,6 +543,12 @@ func hasFieldsToStripInResponsesMessage(msg schemas.ResponsesMessage) bool {
 		}
 		// Check output blocks
 		if msg.ResponsesToolMessage.Output != nil && msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks != nil {
+			// Text-only block arrays must be flattened to a string — OpenAI's
+			// Responses API defines function_call_output.output as a string
+			// and strict upstreams reject the array form.
+			if isFunctionCallOutputBlocksFlattenable(msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks) {
+				return true
+			}
 			for _, block := range msg.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks {
 				if block.CacheControl != nil {
 					return true
@@ -538,6 +560,41 @@ func hasFieldsToStripInResponsesMessage(msg schemas.ResponsesMessage) bool {
 		}
 	}
 	return false
+}
+
+// isFunctionCallOutputBlocksFlattenable reports whether a function_call_output
+// content block slice contains only text blocks and can therefore be collapsed
+// into a single string for the OpenAI Responses API wire format.
+func isFunctionCallOutputBlocksFlattenable(blocks []schemas.ResponsesMessageContentBlock) bool {
+	if len(blocks) == 0 {
+		return false
+	}
+	for _, block := range blocks {
+		if block.Type != schemas.ResponsesInputMessageContentBlockTypeText &&
+			block.Type != schemas.ResponsesOutputMessageContentTypeText {
+			return false
+		}
+		if block.Text == nil {
+			return false
+		}
+	}
+	return true
+}
+
+// flattenFunctionCallOutputBlocks concatenates the text of every block in the
+// slice. Callers must first verify flattenability via
+// isFunctionCallOutputBlocksFlattenable.
+func flattenFunctionCallOutputBlocks(blocks []schemas.ResponsesMessageContentBlock) string {
+	var b strings.Builder
+	for i, block := range blocks {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		if block.Text != nil {
+			b.WriteString(*block.Text)
+		}
+	}
+	return b.String()
 }
 
 // filterSupportedAnnotations filters out unsupported (non-OpenAI native) citation types


### PR DESCRIPTION
## Summary

Multi-turn Anthropic `tool_result` blocks with array-form `content` cause HTTP 400 on the OpenAI provider path. The OpenAI Responses API defines `function_call_output.output` as a string, but the marshaler emitted it as a JSON array. Strict upstreams (Ollama Cloud, `openai-go` typed models) reject it.

This is the same class of bug fixed for the Gemini provider in #2692.

Closes #2779

## Changes

- In `OpenAIResponsesRequestInput.MarshalJSON`, collapse text-only `ResponsesFunctionToolCallOutputBlocks` into a newline-joined string before serialization
- Non-text blocks (images, files, audio) are left as-is — they cannot be losslessly flattened
- Two new helpers: `isFunctionCallOutputBlocksFlattenable()` and `flattenFunctionCallOutputBlocks()`
- `hasFieldsToStripInResponsesMessage` updated to trigger the copy path when flattening is needed

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```bash
# Run the three new regression tests
cd core && go test ./providers/openai/... -run "FunctionCallOutput" -v -count=1

# Run full OpenAI provider suite to check for regressions
cd core && go test ./providers/openai/... -count=1
```

Manual reproduction with curl (requires Bifrost running with any OpenAI-compatible provider):

```bash
curl -sS -X POST http://localhost:8080/anthropic/v1/messages \
  -H "Content-Type: application/json" \
  -H "x-api-key: sk-local-dev" \
  -H "anthropic-version: 2023-06-01" \
  -d '{
    "model": "openai/any-model",
    "max_tokens": 500,
    "tools": [{"name": "read_file", "description": "Read a file", "input_schema": {"type": "object", "properties": {"path": {"type": "string"}}, "required": ["path"]}}],
    "messages": [
      {"role": "user", "content": "Read /tmp/test.txt"},
      {"role": "assistant", "content": [
        {"type": "tool_use", "id": "toolu_abc123", "name": "read_file", "input": {"path": "/tmp/test.txt"}}
      ]},
      {"role": "user", "content": [
        {"type": "tool_result", "tool_use_id": "toolu_abc123", "content": [
          {"type": "text", "text": "line1"}
        ]}
      ]}
    ]
  }'
```

Pre-fix: HTTP 400. Post-fix: HTTP 200.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #2779
Related: #2692 (same bug class, Gemini provider)

## Security considerations

None. Only affects outbound serialization of tool output content in the OpenAI provider marshaler.

## Checklist

- [x] I read the contributing guidelines and followed them
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable