### PR TITLE
test fixes --skip-pipeline

### DIFF
--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -85,7 +85,7 @@ func TestToAnthropicChatRequest_CachingDeterminism(t *testing.T) {
 			Model:    "claude-sonnet-4-20250514",
 			Input: []schemas.ChatMessage{{
 				Role:    schemas.ChatMessageRoleUser,
-				Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("test")},
+				Content: &schemas.ChatMessageContent{ContentStr: new("test")},
 			}},
 			Params: &schemas.ChatParameters{
 				Tools: []schemas.ChatTool{{

--- a/transports/bifrost-http/lib/validator_test.go
+++ b/transports/bifrost-http/lib/validator_test.go
@@ -680,17 +680,15 @@ func TestValidateConfigSchema_MCPClientConfig_Valid_Stdio(t *testing.T) {
 	}
 }
 
-func TestValidateConfigSchema_MCPClientConfig_Valid_Websocket(t *testing.T) {
-	// Valid MCP client config with websocket connection type
+func TestValidateConfigSchema_MCPClientConfig_Valid_Sse(t *testing.T) {
+	// Valid MCP client config with sse connection type
 	validConfig := `{
 		"mcp": {
 			"client_configs": [
 				{
 					"name": "my-mcp-client",
-					"connection_type": "websocket",
-					"websocket_config": {
-						"url": "ws://localhost:8080"
-					}
+					"connection_type": "sse",
+					"connection_string": "http://localhost:8080"
 				}
 			]
 		}
@@ -698,7 +696,7 @@ func TestValidateConfigSchema_MCPClientConfig_Valid_Websocket(t *testing.T) {
 
 	err := ValidateConfigSchema([]byte(validConfig), loadLocalSchema(t))
 	if err != nil {
-		t.Errorf("expected valid MCP client config (websocket) to pass validation, got error: %v", err)
+		t.Errorf("expected valid MCP client config (sse) to pass validation, got error: %v", err)
 	}
 }
 
@@ -710,9 +708,7 @@ func TestValidateConfigSchema_MCPClientConfig_Valid_Http(t *testing.T) {
 				{
 					"name": "my-mcp-client",
 					"connection_type": "http",
-					"http_config": {
-						"url": "http://localhost:8080"
-					}
+					"connection_string": "http://localhost:8080"
 				}
 			]
 		}
@@ -1202,7 +1198,7 @@ func TestValidateConfigSchema_OtelPlugin_Valid(t *testing.T) {
 				"name": "otel",
 				"config": {
 					"collector_url": "http://localhost:4318",
-					"trace_type": "otel",
+					"trace_type": "genai_extension",
 					"protocol": "http"
 				}
 			}
@@ -1223,7 +1219,7 @@ func TestValidateConfigSchema_OtelPlugin_MissingCollectorUrl(t *testing.T) {
 				"enabled": true,
 				"name": "otel",
 				"config": {
-					"trace_type": "otel",
+					"trace_type": "genai_extension",
 					"protocol": "http"
 				}
 			}
@@ -1266,7 +1262,7 @@ func TestValidateConfigSchema_OtelPlugin_MissingProtocol(t *testing.T) {
 				"name": "otel",
 				"config": {
 					"collector_url": "http://localhost:4318",
-					"trace_type": "otel"
+					"trace_type": "genai_extension"
 				}
 			}
 		]


### PR DESCRIPTION
## Summary

Updates test configurations to align with current API specifications and replaces deprecated utility function usage.

## Changes

- Replaced `schemas.Ptr("test")` with `new("test")` in Anthropic chat test for string pointer creation
- Updated MCP client configuration tests to use `sse` connection type instead of `websocket` with simplified `connection_string` field
- Modified HTTP MCP client config to use `connection_string` instead of nested `http_config` object
- Changed OpenTelemetry plugin tests to use `genai_extension` trace type instead of `otel`

## Type of change

- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

Validate that all tests pass with the updated configurations:

```sh
# Core/Transports
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications - these are test configuration updates only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable