### PR TITLE
core schema changes --skip-pipeline

### DIFF
--- a/core/internal/llmtests/server_tools_via_openai.go
+++ b/core/internal/llmtests/server_tools_via_openai.go
@@ -1,0 +1,152 @@
+package llmtests
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// RunServerToolsViaOpenAIEndpointTest reproduces the user-reported bug where
+// sending an Anthropic-server-tool-shaped entry in tools[] via the OpenAI-
+// compatible chat-completions endpoint was silently dropped (Claude responded
+// with a prose "I can't check real-time data" fallback). The fix was a
+// combination of:
+//   - ChatTool schema gaining Name + all server-tool variant fields.
+//   - ToAnthropicChatRequest learning to convert non-function tools (server
+//     tools) into AnthropicTool with the correct variant embed.
+//
+// This test sends the exact curl-reported shape via BifrostChatRequest +
+// ChatCompletionRequest and asserts the request succeeds end-to-end against
+// the provider. It covers three server tools that have single-turn triggers
+// (web_search, web_fetch, code_execution) across all supporting providers per
+// Table 20. Other variants (bash, memory, text_editor, tool_search,
+// mcp_toolset, computer_use) require multi-turn tool loops or infra setup
+// and are covered by the schema / unit-level round-trip tests instead.
+func RunServerToolsViaOpenAIEndpointTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context, testConfig ComprehensiveTestConfig) {
+	if !testConfig.Scenarios.ServerToolsViaOpenAIEndpoint {
+		t.Logf("ServerToolsViaOpenAIEndpoint not supported for provider %s", testConfig.Provider)
+		return
+	}
+
+	cases := []struct {
+		name     string
+		toolType schemas.ChatToolType
+		toolName string
+		prompt   string
+		// extra lets the case set server-tool metadata (max_uses etc.).
+		extra func(*schemas.ChatTool)
+		// supported reports whether this tool is supported on the given
+		// provider per Table 20 (cited provider feature matrix).
+		supported func(schemas.ModelProvider) bool
+	}{
+		{
+			name:     "web_search",
+			toolType: "web_search_20260209",
+			toolName: "web_search",
+			prompt:   "What is the weather in San Francisco today? Use the web_search tool.",
+			extra: func(t *schemas.ChatTool) {
+				five := 5
+				t.MaxUses = &five
+				t.AllowedCallers = []string{"direct"}
+			},
+			// web_search: Anthropic + Vertex + Azure per Table 20 (not Bedrock).
+			supported: func(p schemas.ModelProvider) bool {
+				return p == schemas.Anthropic || p == schemas.Vertex || p == schemas.Azure
+			},
+		},
+		{
+			name:     "web_fetch",
+			toolType: "web_fetch_20260309",
+			toolName: "web_fetch",
+			prompt:   "Fetch https://example.com and summarise the title.",
+			extra: func(t *schemas.ChatTool) {
+				three := 3
+				t.MaxUses = &three
+			},
+			// web_fetch: Anthropic + Azure only per Table 20.
+			supported: func(p schemas.ModelProvider) bool {
+				return p == schemas.Anthropic || p == schemas.Azure
+			},
+		},
+		{
+			name:     "code_execution",
+			toolType: "code_execution_20250825",
+			toolName: "code_execution",
+			prompt:   "Compute 2^64 minus 1 using the code_execution tool and return the result.",
+			// code_execution: Anthropic + Azure only per Table 20.
+			supported: func(p schemas.ModelProvider) bool {
+				return p == schemas.Anthropic || p == schemas.Azure
+			},
+		},
+	}
+
+	t.Run("ServerToolsViaOpenAIEndpoint", func(t *testing.T) {
+		if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
+			t.Parallel()
+		}
+
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				if !tc.supported(testConfig.Provider) {
+					t.Skipf("%s not supported on %s per Table 20", tc.name, testConfig.Provider)
+				}
+				if os.Getenv("SKIP_PARALLEL_TESTS") != "true" {
+					t.Parallel()
+				}
+
+				tool := schemas.ChatTool{
+					Type: tc.toolType,
+					Name: tc.toolName,
+				}
+				if tc.extra != nil {
+					tc.extra(&tool)
+				}
+
+				req := &schemas.BifrostChatRequest{
+					Provider: testConfig.Provider,
+					Model:    testConfig.ChatModel,
+					Input: []schemas.ChatMessage{
+						CreateBasicChatMessage(tc.prompt),
+					},
+					Params: &schemas.ChatParameters{
+						MaxCompletionTokens: bifrost.Ptr(500),
+						Tools:               []schemas.ChatTool{tool},
+					},
+					Fallbacks: testConfig.Fallbacks,
+				}
+
+				bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+				resp, err := client.ChatCompletionRequest(bfCtx, req)
+				if err != nil {
+					t.Fatalf("%s tool request failed: %s", tc.name, GetErrorMessage(err))
+				}
+				if resp == nil {
+					t.Fatal("expected non-nil response")
+				}
+
+				// Regression signals:
+				//   1. Upstream accepted the request (no error).
+				//   2. Response is not the prose fallback Claude emits when
+				//      the server-tool was silently stripped pre-fix
+				//      ("I can't/cannot/don't have access to real-time ...").
+				// The schema + conversion unit tests prove the outbound
+				// request carries the tool; this live test proves the
+				// provider accepts the shape AND actually uses the tool
+				// rather than answering from parametric memory.
+				content := GetChatContent(resp)
+				lc := strings.ToLower(content)
+				if strings.Contains(lc, "can't access real-time") ||
+					strings.Contains(lc, "cannot access real-time") ||
+					strings.Contains(lc, "don't have access to real-time") {
+					t.Fatalf("%s regression: tool appears to be ignored, content=%q", tc.name, content)
+				}
+				t.Logf("%s tool live call succeeded: chars=%d", tc.name, len(content))
+			})
+		}
+	})
+}

--- a/core/internal/llmtests/tests.go
+++ b/core/internal/llmtests/tests.go
@@ -121,6 +121,7 @@ func RunAllComprehensiveTests(t *testing.T, client *bifrost.Bifrost, ctx context
 		RunInterleavedThinkingTest,
 		RunFastModeTest,
 		RunEagerInputStreamingTest,
+		RunServerToolsViaOpenAIEndpointTest,
 	}
 
 	// Execute all test scenarios without raw request/response (default behavior)
@@ -241,6 +242,7 @@ func printTestSummary(t *testing.T, testConfig ComprehensiveTestConfig) {
 		{"InterleavedThinking", testConfig.Scenarios.InterleavedThinking},
 		{"FastMode", testConfig.Scenarios.FastMode},
 		{"EagerInputStreaming", testConfig.Scenarios.EagerInputStreaming},
+		{"ServerToolsViaOpenAIEndpoint", testConfig.Scenarios.ServerToolsViaOpenAIEndpoint},
 	}
 
 	supported := 0

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -450,6 +450,28 @@ func (provider *AnthropicProvider) ChatCompletion(ctx *schemas.BifrostContext, k
 		return nil, bifrostErr
 	}
 
+	// On the raw-body passthrough path, the typed-struct StripUnsupportedAnthropicFields
+	// was not invoked. Apply the JSON-level sanitizer for behavioural parity so
+	// unsupported request-level and tool-level fields don't leak to providers that
+	// would reject them.
+	if useRawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && useRawBody {
+		// Feature gating keyed to schemas.Anthropic (not provider.GetProviderKey())
+		// so custom Anthropic aliases get the same feature lookup as the typed
+		// path above (line 445), keeping raw and typed behavior in lockstep.
+		sanitized, rawErr := stripUnsupportedFieldsFromRawBody(jsonData, schemas.Anthropic, request.Model)
+		if rawErr != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, rawErr, provider.GetProviderKey())
+		}
+		jsonData = sanitized
+		// Auto-inject matching anthropic-beta headers for fields the sanitizer
+		// preserved. Probe-unmarshal reuses the typed path's header walker so
+		// the two paths stay in lockstep.
+		var probe AnthropicMessageRequest
+		if err := schemas.Unmarshal(jsonData, &probe); err == nil {
+			AddMissingBetaHeadersToContext(ctx, &probe, schemas.Anthropic)
+		}
+	}
+
 	// Use struct directly for JSON marshaling
 	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(ctx, jsonData, provider.buildRequestURL(ctx, "/v1/messages", schemas.ChatCompletionRequest), key.Value.GetValue(), &providerUtils.RequestMetadata{
 		Provider:    provider.GetProviderKey(),
@@ -532,6 +554,25 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 		provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
+	}
+
+	// On the raw-body passthrough path, the typed-struct StripUnsupportedAnthropicFields
+	// was not invoked. Apply the JSON-level sanitizer for behavioural parity.
+	if useRawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && useRawBody {
+		// Feature gating keyed to schemas.Anthropic (not provider.GetProviderKey())
+		// to keep raw and typed paths in lockstep on custom aliases — mirrors
+		// the typed path's hardcoded schemas.Anthropic at line 548.
+		sanitized, rawErr := stripUnsupportedFieldsFromRawBody(jsonData, schemas.Anthropic, request.Model)
+		if rawErr != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, rawErr, provider.GetProviderKey())
+		}
+		jsonData = sanitized
+		// Auto-inject matching anthropic-beta headers for fields the sanitizer
+		// preserved. Probe-unmarshal reuses the typed path's header walker.
+		var probe AnthropicMessageRequest
+		if err := schemas.Unmarshal(jsonData, &probe); err == nil {
+			AddMissingBetaHeadersToContext(ctx, &probe, schemas.Anthropic)
+		}
 	}
 
 	// Prepare Anthropic headers

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -3,12 +3,238 @@ package anthropic
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bytedance/sonic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
+
+// convertFunctionToolToAnthropic turns an OpenAI-style function tool
+// (schemas.ChatTool with non-nil Function) into an AnthropicTool.
+// Factored out from ToAnthropicChatRequest's tool loop so the loop can branch
+// cleanly between function and server-tool shapes.
+func convertFunctionToolToAnthropic(tool schemas.ChatTool) AnthropicTool {
+	anthropicTool := AnthropicTool{
+		Name: tool.Function.Name,
+	}
+	if tool.Function.Description != nil {
+		anthropicTool.Description = tool.Function.Description
+	}
+
+	// Convert function parameters to input_schema
+	if tool.Function.Parameters != nil && (tool.Function.Parameters.Type != "" || tool.Function.Parameters.Properties != nil) {
+		anthropicTool.InputSchema = &schemas.ToolFunctionParameters{
+			Type:                 tool.Function.Parameters.Type,
+			Description:          tool.Function.Parameters.Description,
+			Properties:           tool.Function.Parameters.Properties,
+			Required:             tool.Function.Parameters.Required,
+			Enum:                 tool.Function.Parameters.Enum,
+			AdditionalProperties: tool.Function.Parameters.AdditionalProperties,
+			Defs:                 tool.Function.Parameters.Defs,
+			Definitions:          tool.Function.Parameters.Definitions,
+			Ref:                  tool.Function.Parameters.Ref,
+			Items:                tool.Function.Parameters.Items,
+			MinItems:             tool.Function.Parameters.MinItems,
+			MaxItems:             tool.Function.Parameters.MaxItems,
+			AnyOf:                tool.Function.Parameters.AnyOf,
+			OneOf:                tool.Function.Parameters.OneOf,
+			AllOf:                tool.Function.Parameters.AllOf,
+			Format:               tool.Function.Parameters.Format,
+			Pattern:              tool.Function.Parameters.Pattern,
+			MinLength:            tool.Function.Parameters.MinLength,
+			MaxLength:            tool.Function.Parameters.MaxLength,
+			Minimum:              tool.Function.Parameters.Minimum,
+			Maximum:              tool.Function.Parameters.Maximum,
+			Title:                tool.Function.Parameters.Title,
+			Default:              tool.Function.Parameters.Default,
+			Nullable:             tool.Function.Parameters.Nullable,
+		}
+	}
+
+	if anthropicTool.InputSchema != nil {
+		anthropicTool.InputSchema = anthropicTool.InputSchema.Normalized()
+	}
+
+	if tool.CacheControl != nil {
+		anthropicTool.CacheControl = tool.CacheControl
+	}
+	if tool.DeferLoading != nil {
+		anthropicTool.DeferLoading = tool.DeferLoading
+	}
+	if len(tool.AllowedCallers) > 0 {
+		anthropicTool.AllowedCallers = tool.AllowedCallers
+	}
+	if len(tool.InputExamples) > 0 {
+		anthropicTool.InputExamples = make([]AnthropicToolInputExample, len(tool.InputExamples))
+		for i, ex := range tool.InputExamples {
+			anthropicTool.InputExamples[i] = AnthropicToolInputExample{
+				Input:       ex.Input,
+				Description: ex.Description,
+			}
+		}
+	}
+	if tool.EagerInputStreaming != nil {
+		anthropicTool.EagerInputStreaming = tool.EagerInputStreaming
+	}
+	// ChatToolFunction.Strict is the canonical neutral slot for Anthropic's strict.
+	if tool.Function.Strict != nil {
+		anthropicTool.Strict = tool.Function.Strict
+	}
+	return anthropicTool
+}
+
+// convertServerToolToAnthropic reconstructs an AnthropicTool from the
+// server-tool shape of a schemas.ChatTool (Function=nil, Name+Type+variant
+// fields populated). Returns (tool, true) when Type looks like a known
+// server-tool; (zero, false) when it doesn't, so the caller can drop it
+// cleanly rather than forward a malformed tool.
+//
+// Supported type prefixes:
+//   - web_search_*    → AnthropicToolWebSearch
+//   - web_fetch_*     → AnthropicToolWebFetch
+//   - computer_*      → AnthropicToolComputerUse
+//   - text_editor_*   → AnthropicToolTextEditor
+//   - mcp_toolset     → AnthropicMCPToolsetTool (via MCPToolset pointer)
+//
+// bash_*, memory_*, code_execution_*, and tool_search_* carry no variant
+// config — their Type + Name alone are enough, handled in the default branch.
+func convertServerToolToAnthropic(tool schemas.ChatTool) (AnthropicTool, bool) {
+	typeStr := string(tool.Type)
+	if typeStr == "" {
+		return AnthropicTool{}, false
+	}
+
+	// mcp_toolset is serialized via a dedicated embedded type (AnthropicMCPToolsetTool)
+	// and carries its identity in MCPServerName, not Name — handle before the
+	// generic Name guard below.
+	if typeStr == "mcp_toolset" {
+		if tool.MCPServerName == "" {
+			return AnthropicTool{}, false
+		}
+		toolset := &AnthropicMCPToolsetTool{
+			Type:          "mcp_toolset",
+			MCPServerName: tool.MCPServerName,
+			DefaultConfig: convertMCPToolsetConfig(tool.DefaultConfig),
+			Configs:       convertMCPToolsetConfigMap(tool.Configs),
+			CacheControl:  tool.CacheControl,
+		}
+		return AnthropicTool{MCPToolset: toolset}, true
+	}
+
+	// Remaining server tools (web_search, web_fetch, computer, text_editor, etc.)
+	// identify themselves via Name.
+	if tool.Name == "" {
+		return AnthropicTool{}, false
+	}
+
+	atype := AnthropicToolType(typeStr)
+	anthropicTool := AnthropicTool{
+		Name:                tool.Name,
+		Type:                &atype,
+		CacheControl:        tool.CacheControl,
+		DeferLoading:        tool.DeferLoading,
+		AllowedCallers:      tool.AllowedCallers,
+		EagerInputStreaming: tool.EagerInputStreaming,
+	}
+	if len(tool.InputExamples) > 0 {
+		anthropicTool.InputExamples = make([]AnthropicToolInputExample, len(tool.InputExamples))
+		for i, ex := range tool.InputExamples {
+			anthropicTool.InputExamples[i] = AnthropicToolInputExample{
+				Input:       ex.Input,
+				Description: ex.Description,
+			}
+		}
+	}
+
+	switch {
+	case strings.HasPrefix(typeStr, "web_search_"):
+		anthropicTool.AnthropicToolWebSearch = &AnthropicToolWebSearch{
+			MaxUses:        tool.MaxUses,
+			AllowedDomains: tool.AllowedDomains,
+			BlockedDomains: tool.BlockedDomains,
+			UserLocation:   convertUserLocation(tool.UserLocation),
+		}
+	case strings.HasPrefix(typeStr, "web_fetch_"):
+		anthropicTool.AnthropicToolWebFetch = &AnthropicToolWebFetch{
+			MaxUses:          tool.MaxUses,
+			AllowedDomains:   tool.AllowedDomains,
+			BlockedDomains:   tool.BlockedDomains,
+			MaxContentTokens: tool.MaxContentTokens,
+			Citations:        convertCitationsConfig(tool.Citations),
+			UseCache:         tool.UseCache,
+		}
+	case strings.HasPrefix(typeStr, "computer_"):
+		anthropicTool.AnthropicToolComputerUse = &AnthropicToolComputerUse{
+			DisplayWidthPx:  tool.DisplayWidthPx,
+			DisplayHeightPx: tool.DisplayHeightPx,
+			DisplayNumber:   tool.DisplayNumber,
+			EnableZoom:      tool.EnableZoom,
+		}
+	case strings.HasPrefix(typeStr, "text_editor_"):
+		anthropicTool.AnthropicToolTextEditor = &AnthropicToolTextEditor{
+			MaxCharacters: tool.MaxCharacters,
+		}
+	case strings.HasPrefix(typeStr, "bash_"),
+		strings.HasPrefix(typeStr, "memory_"),
+		strings.HasPrefix(typeStr, "code_execution_"),
+		strings.HasPrefix(typeStr, "tool_search_tool_"):
+		// No variant-specific config — Type + Name alone.
+	default:
+		// Unknown type — pass through Type + Name and let Anthropic reject
+		// if it's truly invalid. This keeps forward-compat for new tool
+		// versions that aren't yet known to Bifrost.
+	}
+	return anthropicTool, true
+}
+
+// convertUserLocation mirrors schemas.ChatToolUserLocation onto
+// AnthropicToolWebSearchUserLocation.
+func convertUserLocation(loc *schemas.ChatToolUserLocation) *AnthropicToolWebSearchUserLocation {
+	if loc == nil {
+		return nil
+	}
+	return &AnthropicToolWebSearchUserLocation{
+		Type:     loc.Type,
+		City:     loc.City,
+		Region:   loc.Region,
+		Country:  loc.Country,
+		Timezone: loc.Timezone,
+	}
+}
+
+// convertCitationsConfig mirrors the request-side citations config
+// ({"enabled": true/false}) onto AnthropicCitations' request form.
+func convertCitationsConfig(c *schemas.ChatToolCitationsConfig) *AnthropicCitations {
+	if c == nil {
+		return nil
+	}
+	return &AnthropicCitations{Config: &schemas.Citations{Enabled: c.Enabled}}
+}
+
+// convertMCPToolsetConfig mirrors a single mcp_toolset config.
+func convertMCPToolsetConfig(c *schemas.ChatMCPToolsetConfig) *AnthropicMCPToolsetConfig {
+	if c == nil {
+		return nil
+	}
+	return &AnthropicMCPToolsetConfig{
+		Enabled:      c.Enabled,
+		DeferLoading: c.DeferLoading,
+	}
+}
+
+// convertMCPToolsetConfigMap mirrors the per-tool mcp_toolset configs map.
+func convertMCPToolsetConfigMap(m map[string]*schemas.ChatMCPToolsetConfig) map[string]*AnthropicMCPToolsetConfig {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]*AnthropicMCPToolsetConfig, len(m))
+	for k, v := range m {
+		out[k] = convertMCPToolsetConfig(v)
+	}
+	return out
+}
 
 // ToAnthropicChatRequest converts a Bifrost request to Anthropic format
 // This is the reverse of ConvertChatRequestToBifrost for provider-side usage
@@ -41,24 +267,48 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 			}
 		}
 		anthropicReq.StopSequences = bifrostReq.Params.Stop
-		topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"])
-		if ok {
+
+		// TopK — prefer the promoted neutral field; fall back to ExtraParams.
+		// Opus 4.7+ rejects top_k with a 400 error.
+		if bifrostReq.Params.TopK != nil {
+			if !IsOpus47(bifrostReq.Model) {
+				anthropicReq.TopK = bifrostReq.Params.TopK
+			}
+		} else if topK, ok := schemas.SafeExtractIntPointer(bifrostReq.Params.ExtraParams["top_k"]); ok {
 			delete(anthropicReq.ExtraParams, "top_k")
-			// Opus 4.7+ rejects top_k with a 400 error.
 			if !IsOpus47(bifrostReq.Model) {
 				anthropicReq.TopK = topK
 			}
 		}
-		if speed, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["speed"]); ok {
+
+		// Speed — prefer neutral field, then ExtraParams.
+		if bifrostReq.Params.Speed != nil {
+			anthropicReq.Speed = bifrostReq.Params.Speed
+		} else if speed, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["speed"]); ok {
 			delete(anthropicReq.ExtraParams, "speed")
 			anthropicReq.Speed = speed
 		}
-		// extract inference_geo and context management
-		if inferenceGeo, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["inference_geo"]); ok {
+
+		// InferenceGeo — prefer neutral field, then ExtraParams.
+		if bifrostReq.Params.InferenceGeo != nil {
+			anthropicReq.InferenceGeo = bifrostReq.Params.InferenceGeo
+		} else if inferenceGeo, ok := schemas.SafeExtractStringPointer(bifrostReq.Params.ExtraParams["inference_geo"]); ok {
 			delete(anthropicReq.ExtraParams, "inference_geo")
 			anthropicReq.InferenceGeo = inferenceGeo
 		}
-		if cmVal := bifrostReq.Params.ExtraParams["context_management"]; cmVal != nil {
+
+		// ContextManagement — the neutral type is json.RawMessage; decode to
+		// the Anthropic-shape ContextManagement. Fall back to ExtraParams
+		// (legacy map-valued or typed-pointer paths) if the raw is empty.
+		// Surface decode errors on the typed path so callers get immediate
+		// feedback on malformed config instead of a silent drop.
+		if len(bifrostReq.Params.ContextManagement) > 0 {
+			var cm ContextManagement
+			if err := sonic.Unmarshal(bifrostReq.Params.ContextManagement, &cm); err != nil {
+				return nil, fmt.Errorf("context_management: failed to parse: %w", err)
+			}
+			anthropicReq.ContextManagement = &cm
+		} else if cmVal := bifrostReq.Params.ExtraParams["context_management"]; cmVal != nil {
 			if cm, ok := cmVal.(*ContextManagement); ok && cm != nil {
 				delete(anthropicReq.ExtraParams, "context_management")
 				anthropicReq.ContextManagement = cm
@@ -69,6 +319,65 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 					anthropicReq.ContextManagement = &cm
 				}
 			}
+		}
+
+		// Container — map the neutral ChatContainer union onto the Anthropic
+		// AnthropicContainer union. Both follow the string-or-object pattern.
+		if bifrostReq.Params.Container != nil {
+			c := &AnthropicContainer{}
+			if bifrostReq.Params.Container.ContainerStr != nil {
+				c.ContainerStr = bifrostReq.Params.Container.ContainerStr
+			} else if bifrostReq.Params.Container.ContainerObject != nil {
+				obj := &AnthropicContainerObject{
+					ID: bifrostReq.Params.Container.ContainerObject.ID,
+				}
+				if len(bifrostReq.Params.Container.ContainerObject.Skills) > 0 {
+					obj.Skills = make([]AnthropicContainerSkill, len(bifrostReq.Params.Container.ContainerObject.Skills))
+					for i, sk := range bifrostReq.Params.Container.ContainerObject.Skills {
+						obj.Skills[i] = AnthropicContainerSkill{
+							SkillID: sk.SkillID,
+							Type:    sk.Type,
+							Version: sk.Version,
+						}
+					}
+				}
+				c.ContainerObject = obj
+			}
+			anthropicReq.Container = c
+		}
+
+		// Top-level CacheControl on the request.
+		if bifrostReq.Params.CacheControl != nil {
+			anthropicReq.CacheControl = bifrostReq.Params.CacheControl
+		}
+
+		// TaskBudget — maps onto output_config.task_budget. If an OutputConfig
+		// already exists (e.g. from structured outputs), attach the budget to
+		// it; otherwise create one.
+		if bifrostReq.Params.TaskBudget != nil {
+			tb := &AnthropicTaskBudget{
+				Type:      bifrostReq.Params.TaskBudget.Type,
+				Total:     bifrostReq.Params.TaskBudget.Total,
+				Remaining: bifrostReq.Params.TaskBudget.Remaining,
+			}
+			if anthropicReq.OutputConfig == nil {
+				anthropicReq.OutputConfig = &AnthropicOutputConfig{}
+			}
+			anthropicReq.OutputConfig.TaskBudget = tb
+		}
+
+		// MCPServers — mirror the neutral ChatMCPServer[] to AnthropicMCPServerV2[].
+		if len(bifrostReq.Params.MCPServers) > 0 {
+			servers := make([]AnthropicMCPServerV2, len(bifrostReq.Params.MCPServers))
+			for i, s := range bifrostReq.Params.MCPServers {
+				servers[i] = AnthropicMCPServerV2{
+					Type:               s.Type,
+					URL:                s.URL,
+					Name:               s.Name,
+					AuthorizationToken: s.AuthorizationToken,
+				}
+			}
+			anthropicReq.MCPServers = servers
 		}
 		if bifrostReq.Params.ResponseFormat != nil {
 			// Vertex doesn't support native structured outputs, so convert to tool
@@ -93,72 +402,24 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 			}
 		}
 
-		// Convert tools
+		// Convert tools. Three neutral ChatTool shapes are supported:
+		//   (1) Function tool (tool.Function != nil) — existing path.
+		//   (2) Anthropic server tool (tool.Function == nil, Type is a
+		//       server-tool version string, Name populated at top level) —
+		//       new path handled by convertServerToolToAnthropic.
+		//   (3) Custom tool (tool.Custom != nil) — not currently forwarded
+		//       to Anthropic; skipped.
 		if bifrostReq.Params.Tools != nil {
 			tools := make([]AnthropicTool, 0, len(bifrostReq.Params.Tools))
 			for _, tool := range bifrostReq.Params.Tools {
-				if tool.Function == nil {
+				if tool.Function != nil {
+					tools = append(tools, convertFunctionToolToAnthropic(tool))
 					continue
 				}
-				anthropicTool := AnthropicTool{
-					Name: tool.Function.Name,
+				// Non-function tool: attempt server-tool reconstruction.
+				if converted, ok := convertServerToolToAnthropic(tool); ok {
+					tools = append(tools, converted)
 				}
-				if tool.Function.Description != nil {
-					anthropicTool.Description = tool.Function.Description
-				}
-
-				// Convert function parameters to input_schema
-				if tool.Function.Parameters != nil && (tool.Function.Parameters.Type != "" || tool.Function.Parameters.Properties != nil) {
-					anthropicTool.InputSchema = &schemas.ToolFunctionParameters{
-						Type:                 tool.Function.Parameters.Type,
-						Description:          tool.Function.Parameters.Description,
-						Properties:           tool.Function.Parameters.Properties,
-						Required:             tool.Function.Parameters.Required,
-						Enum:                 tool.Function.Parameters.Enum,
-						AdditionalProperties: tool.Function.Parameters.AdditionalProperties,
-						// JSON Schema definition fields
-						Defs:        tool.Function.Parameters.Defs,
-						Definitions: tool.Function.Parameters.Definitions,
-						Ref:         tool.Function.Parameters.Ref,
-						// Array schema fields
-						Items:    tool.Function.Parameters.Items,
-						MinItems: tool.Function.Parameters.MinItems,
-						MaxItems: tool.Function.Parameters.MaxItems,
-						// Composition fields
-						AnyOf: tool.Function.Parameters.AnyOf,
-						OneOf: tool.Function.Parameters.OneOf,
-						AllOf: tool.Function.Parameters.AllOf,
-						// String validation fields
-						Format:    tool.Function.Parameters.Format,
-						Pattern:   tool.Function.Parameters.Pattern,
-						MinLength: tool.Function.Parameters.MinLength,
-						MaxLength: tool.Function.Parameters.MaxLength,
-						// Number validation fields
-						Minimum: tool.Function.Parameters.Minimum,
-						Maximum: tool.Function.Parameters.Maximum,
-						// Misc fields
-						Title:    tool.Function.Parameters.Title,
-						Default:  tool.Function.Parameters.Default,
-						Nullable: tool.Function.Parameters.Nullable,
-					}
-				}
-
-				if anthropicTool.InputSchema != nil {
-					anthropicTool.InputSchema = anthropicTool.InputSchema.Normalized()
-				}
-
-				if tool.CacheControl != nil {
-					anthropicTool.CacheControl = tool.CacheControl
-				}
-
-				// Fine-grained tool streaming — promoted neutral flag on ChatTool.
-				// Anthropic auto-injects beta header fine-grained-tool-streaming-2025-05-14
-				// via AddMissingBetaHeadersToContext when this is set.
-				if tool.EagerInputStreaming != nil {
-					anthropicTool.EagerInputStreaming = tool.EagerInputStreaming
-				}
-
-				tools = append(tools, anthropicTool)
 			}
 			if anthropicReq.Tools == nil {
 				anthropicReq.Tools = tools
@@ -252,6 +513,18 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 				anthropicReq.Thinking = &AnthropicThinking{
 					Type: "disabled",
 				}
+			}
+
+			// thinking.display — map the neutral ChatReasoning.Display onto
+			// AnthropicThinking.Display. Valid for "enabled" and "adaptive"
+			// modes only; Anthropic rejects display on "disabled" ("there is
+			// nothing to display", per the extended-thinking doc). We attach
+			// on non-disabled modes and let the upstream provider enforce
+			// model-level support.
+			if bifrostReq.Params.Reasoning.Display != nil &&
+				anthropicReq.Thinking != nil &&
+				anthropicReq.Thinking.Type != "disabled" {
+				anthropicReq.Thinking.Display = bifrostReq.Params.Reasoning.Display
 			}
 		}
 
@@ -424,6 +697,11 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 
 	anthropicReq.Messages = anthropicMessages
 	anthropicReq.System = systemContent
+
+	// Strip request- and tool-level fields the target Anthropic-family
+	// provider does not support. Fail-closed tool validation stays in
+	// ValidateToolsForProvider; this is strip-silently for additive fields.
+	stripUnsupportedAnthropicFields(anthropicReq, bifrostReq.Provider, bifrostReq.Model)
 
 	return anthropicReq, nil
 }

--- a/core/providers/anthropic/chat_server_tools_test.go
+++ b/core/providers/anthropic/chat_server_tools_test.go
@@ -1,0 +1,366 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// TestChatTool_ServerToolRoundTrip verifies that every Anthropic server-tool
+// variant survives Marshal/Unmarshal through the neutral ChatTool schema.
+// This locks in the fix for the user-reported bug where a raw JSON tool like
+// {"type":"web_search_20260209","name":"web_search","max_uses":5} was being
+// dropped at the neutral-schema layer because ChatTool had no slots for the
+// server-tool metadata.
+func TestChatTool_ServerToolRoundTrip(t *testing.T) {
+	five := 5
+	ptrTrue := true
+	w, h := 1280, 800
+	maxChars := 16000
+	maxContent := 32000
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "web_search_20260209",
+			raw:  `{"type":"web_search_20260209","name":"web_search","max_uses":5,"allowed_callers":["direct"]}`,
+		},
+		{
+			name: "web_search_with_domains",
+			raw:  `{"type":"web_search_20250305","name":"web_search","allowed_domains":["example.com","docs.example.com"]}`,
+		},
+		{
+			name: "web_search_with_user_location",
+			raw:  `{"type":"web_search_20250305","name":"web_search","user_location":{"type":"approximate","city":"San Francisco","country":"US","timezone":"America/Los_Angeles"}}`,
+		},
+		{
+			name: "web_fetch_20260309",
+			raw:  `{"type":"web_fetch_20260309","name":"web_fetch","max_uses":5,"max_content_tokens":32000,"citations":{"enabled":true},"use_cache":true}`,
+		},
+		{
+			name: "computer_20251124",
+			raw:  `{"type":"computer_20251124","name":"computer","display_width_px":1280,"display_height_px":800,"display_number":1,"enable_zoom":true}`,
+		},
+		{
+			name: "text_editor_20250728",
+			raw:  `{"type":"text_editor_20250728","name":"str_replace_based_edit_tool","max_characters":16000}`,
+		},
+		{
+			name: "bash_20250124",
+			raw:  `{"type":"bash_20250124","name":"bash"}`,
+		},
+		{
+			name: "memory_20250818",
+			raw:  `{"type":"memory_20250818","name":"memory"}`,
+		},
+		{
+			name: "code_execution_20250825",
+			raw:  `{"type":"code_execution_20250825","name":"code_execution"}`,
+		},
+		{
+			name: "tool_search_tool_bm25",
+			raw:  `{"type":"tool_search_tool_bm25","name":"tool_search_tool_bm25"}`,
+		},
+		{
+			name: "mcp_toolset",
+			raw:  `{"type":"mcp_toolset","name":"my_mcp","mcp_server_name":"notion","configs":{"search":{"enabled":true}}}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Variant-specific field assertions. Invoked twice — once after
+			// initial decode, once after round-trip — so that a regression in
+			// MarshalSorted that silently drops any variant-specific field
+			// fails this test instead of sneaking through.
+			assertVariantFields := func(label string, tl schemas.ChatTool) {
+				t.Helper()
+				switch tc.name {
+				case "web_search_20260209":
+					if tl.MaxUses == nil || *tl.MaxUses != five {
+						t.Errorf("%s: MaxUses not preserved, got %v", label, tl.MaxUses)
+					}
+					if len(tl.AllowedCallers) != 1 || tl.AllowedCallers[0] != "direct" {
+						t.Errorf("%s: AllowedCallers not preserved, got %v", label, tl.AllowedCallers)
+					}
+				case "web_fetch_20260309":
+					if tl.MaxContentTokens == nil || *tl.MaxContentTokens != maxContent {
+						t.Errorf("%s: MaxContentTokens not preserved, got %v", label, tl.MaxContentTokens)
+					}
+					if tl.Citations == nil || tl.Citations.Enabled == nil || !*tl.Citations.Enabled {
+						t.Errorf("%s: Citations not preserved, got %v", label, tl.Citations)
+					}
+					if tl.UseCache == nil || !*tl.UseCache {
+						t.Errorf("%s: UseCache not preserved", label)
+					}
+					_ = ptrTrue
+				case "computer_20251124":
+					if tl.DisplayWidthPx == nil || *tl.DisplayWidthPx != w {
+						t.Errorf("%s: DisplayWidthPx not preserved, got %v", label, tl.DisplayWidthPx)
+					}
+					if tl.DisplayHeightPx == nil || *tl.DisplayHeightPx != h {
+						t.Errorf("%s: DisplayHeightPx not preserved, got %v", label, tl.DisplayHeightPx)
+					}
+				case "text_editor_20250728":
+					if tl.MaxCharacters == nil || *tl.MaxCharacters != maxChars {
+						t.Errorf("%s: MaxCharacters not preserved, got %v", label, tl.MaxCharacters)
+					}
+				case "mcp_toolset":
+					if tl.MCPServerName != "notion" {
+						t.Errorf("%s: MCPServerName not preserved, got %q", label, tl.MCPServerName)
+					}
+					if len(tl.Configs) != 1 {
+						t.Errorf("%s: Configs not preserved, got %v", label, tl.Configs)
+					}
+				}
+			}
+
+			var tool schemas.ChatTool
+			if err := sonic.Unmarshal([]byte(tc.raw), &tool); err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+			if string(tool.Type) == "" {
+				t.Errorf("Type should be preserved, got empty")
+			}
+			if tool.Name == "" {
+				t.Errorf("Name should be preserved, got empty")
+			}
+			assertVariantFields("first decode", tool)
+
+			// Re-marshal and re-decode — all preserved fields should survive round trip.
+			out, err := schemas.MarshalSorted(tool)
+			if err != nil {
+				t.Fatalf("marshal failed: %v", err)
+			}
+			var tool2 schemas.ChatTool
+			if err := sonic.Unmarshal(out, &tool2); err != nil {
+				t.Fatalf("second unmarshal failed: %v\njson: %s", err, string(out))
+			}
+			if tool.Name != tool2.Name || tool.Type != tool2.Type {
+				t.Errorf("round-trip mismatch\n  in: %s\n  out: %s", tc.raw, string(out))
+			}
+			assertVariantFields("round trip", tool2)
+		})
+	}
+}
+
+// TestToAnthropicChatRequest_ServerTools verifies every ChatTool server-tool
+// shape converts correctly through ToAnthropicChatRequest.
+func TestToAnthropicChatRequest_ServerTools(t *testing.T) {
+	mk := func(rawTool string) *schemas.BifrostChatRequest {
+		var tool schemas.ChatTool
+		if err := sonic.Unmarshal([]byte(rawTool), &tool); err != nil {
+			t.Fatalf("test setup: %v", err)
+		}
+		return &schemas.BifrostChatRequest{
+			Provider: schemas.Anthropic,
+			Model:    "claude-sonnet-4-6",
+			Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}}},
+			Params:   &schemas.ChatParameters{Tools: []schemas.ChatTool{tool}},
+		}
+	}
+
+	type check struct {
+		expectName       string
+		expectType       AnthropicToolType
+		expectWebSearch  bool
+		expectWebFetch   bool
+		expectComputer   bool
+		expectTextEditor bool
+		expectMCPToolset bool
+	}
+
+	cases := []struct {
+		name string
+		raw  string
+		want check
+	}{
+		{
+			name: "web_search",
+			raw:  `{"type":"web_search_20260209","name":"web_search","max_uses":5}`,
+			want: check{expectName: "web_search", expectType: "web_search_20260209", expectWebSearch: true},
+		},
+		{
+			name: "web_fetch",
+			raw:  `{"type":"web_fetch_20260309","name":"web_fetch","max_uses":3,"use_cache":true}`,
+			want: check{expectName: "web_fetch", expectType: "web_fetch_20260309", expectWebFetch: true},
+		},
+		{
+			name: "computer_20251124",
+			raw:  `{"type":"computer_20251124","name":"computer","display_width_px":1280,"display_height_px":800}`,
+			want: check{expectName: "computer", expectType: "computer_20251124", expectComputer: true},
+		},
+		{
+			name: "text_editor_20250728",
+			raw:  `{"type":"text_editor_20250728","name":"str_replace_based_edit_tool","max_characters":16000}`,
+			want: check{expectName: "str_replace_based_edit_tool", expectType: "text_editor_20250728", expectTextEditor: true},
+		},
+		{
+			name: "bash_20250124",
+			raw:  `{"type":"bash_20250124","name":"bash"}`,
+			want: check{expectName: "bash", expectType: "bash_20250124"},
+		},
+		{
+			name: "mcp_toolset",
+			raw:  `{"type":"mcp_toolset","name":"notion","mcp_server_name":"notion"}`,
+			want: check{expectMCPToolset: true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := mk(tc.raw)
+			out, err := ToAnthropicChatRequest(nil, req)
+			if err != nil {
+				t.Fatalf("conversion failed: %v", err)
+			}
+			if len(out.Tools) != 1 {
+				t.Fatalf("expected 1 tool, got %d (raw: %s)", len(out.Tools), tc.raw)
+			}
+			at := out.Tools[0]
+			if tc.want.expectMCPToolset {
+				if at.MCPToolset == nil {
+					t.Errorf("expected MCPToolset to be set")
+				}
+				return
+			}
+			if at.Name != tc.want.expectName {
+				t.Errorf("Name: got %q want %q", at.Name, tc.want.expectName)
+			}
+			if at.Type == nil || *at.Type != tc.want.expectType {
+				t.Errorf("Type: got %v want %q", at.Type, tc.want.expectType)
+			}
+			if tc.want.expectWebSearch && at.AnthropicToolWebSearch == nil {
+				t.Errorf("expected AnthropicToolWebSearch populated")
+			}
+			if tc.want.expectWebFetch && at.AnthropicToolWebFetch == nil {
+				t.Errorf("expected AnthropicToolWebFetch populated")
+			}
+			if tc.want.expectComputer && at.AnthropicToolComputerUse == nil {
+				t.Errorf("expected AnthropicToolComputerUse populated")
+			}
+			if tc.want.expectTextEditor && at.AnthropicToolTextEditor == nil {
+				t.Errorf("expected AnthropicToolTextEditor populated")
+			}
+		})
+	}
+}
+
+// TestToBifrostResponsesRequest_MCPToolsetPreservesAnthropicFlags verifies
+// that when an Anthropic request carries an mcp_toolset tool with the four
+// Anthropic-native flags (DeferLoading, AllowedCallers, InputExamples,
+// EagerInputStreaming), those flags survive the inbound conversion into the
+// neutral ResponsesTool on the mcp_servers merge path. Before the fix, the
+// merge path only applied MCP configs (allowlist/cache-control) and dropped
+// the flags because convertAnthropicToolToBifrost skips mcp_toolset entries.
+func TestToBifrostResponsesRequest_MCPToolsetPreservesAnthropicFlags(t *testing.T) {
+	toolsetType := "mcp_toolset"
+	_ = toolsetType // shape documentation only; AnthropicTool.Type is pointer-to-enum and left nil for mcp_toolset
+
+	req := &AnthropicMessageRequest{
+		Model: "claude-sonnet-4-6",
+		Tools: []AnthropicTool{
+			{
+				Name:                "notion",
+				DeferLoading:        schemas.Ptr(true),
+				AllowedCallers:      []string{"direct", "agent"},
+				EagerInputStreaming: schemas.Ptr(false),
+				InputExamples: []AnthropicToolInputExample{
+					{Input: json.RawMessage(`{"q":"hello"}`), Description: schemas.Ptr("basic")},
+				},
+				MCPToolset: &AnthropicMCPToolsetTool{
+					Type:          "mcp_toolset",
+					MCPServerName: "notion",
+					DefaultConfig: &AnthropicMCPToolsetConfig{Enabled: schemas.Ptr(true)},
+				},
+			},
+		},
+		MCPServers: []AnthropicMCPServerV2{
+			{Type: "url", URL: "https://mcp.example.com", Name: "notion"},
+		},
+	}
+
+	got := req.ToBifrostResponsesRequest(nil)
+	if got == nil || got.Params == nil {
+		t.Fatalf("ToBifrostResponsesRequest returned nil params")
+	}
+
+	// The mcp_toolset tool should have been dropped by convertAnthropicToolToBifrost
+	// and re-created on the mcp_servers merge path — end result: exactly one tool,
+	// of type mcp, carrying the Anthropic flags we set.
+	if len(got.Params.Tools) != 1 {
+		t.Fatalf("expected 1 mcp tool after merge, got %d", len(got.Params.Tools))
+	}
+	mcp := got.Params.Tools[0]
+	if mcp.Type != schemas.ResponsesToolTypeMCP {
+		t.Errorf("expected MCP tool, got type=%q", mcp.Type)
+	}
+	if mcp.DeferLoading == nil || !*mcp.DeferLoading {
+		t.Errorf("DeferLoading dropped on mcp_toolset merge path")
+	}
+	if len(mcp.AllowedCallers) != 2 || mcp.AllowedCallers[0] != "direct" {
+		t.Errorf("AllowedCallers dropped on mcp_toolset merge path, got %v", mcp.AllowedCallers)
+	}
+	if len(mcp.InputExamples) != 1 {
+		t.Errorf("InputExamples dropped on mcp_toolset merge path, got len=%d", len(mcp.InputExamples))
+	}
+	if mcp.EagerInputStreaming == nil || *mcp.EagerInputStreaming {
+		t.Errorf("EagerInputStreaming dropped on mcp_toolset merge path, got %v", mcp.EagerInputStreaming)
+	}
+}
+
+// TestToAnthropicChatRequest_ServerTools_ReproUserBug is the exact shape
+// from the reported curl — web_search_20260209 with max_uses + allowed_callers.
+// Verifies the request reaches ToAnthropicChatRequest output with a populated
+// tools array (previously it was silently dropped).
+func TestToAnthropicChatRequest_ServerTools_ReproUserBug(t *testing.T) {
+	raw := []byte(`{
+      "model":"claude-sonnet-4-6",
+      "messages":[{"role":"user","content":"What is the weather in SF?"}],
+      "tools":[{"name":"web_search","type":"web_search_20260209","max_uses":5,"allowed_callers":["direct"]}]
+    }`)
+	// Unmarshal through the neutral schema the way the OpenAI endpoint does.
+	var inner struct {
+		Model    string             `json:"model"`
+		Messages []json.RawMessage  `json:"messages"`
+		Tools    []schemas.ChatTool `json:"tools"`
+	}
+	if err := sonic.Unmarshal(raw, &inner); err != nil {
+		t.Fatalf("outer unmarshal: %v", err)
+	}
+	if len(inner.Tools) != 1 {
+		t.Fatalf("setup: expected 1 tool in raw JSON, got %d", len(inner.Tools))
+	}
+	if inner.Tools[0].Name == "" {
+		t.Errorf("Name lost at neutral-schema decode (was the bug). Got: %+v", inner.Tools[0])
+	}
+	if inner.Tools[0].MaxUses == nil {
+		t.Errorf("MaxUses lost at neutral-schema decode (was the bug)")
+	}
+
+	req := &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    inner.Model,
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}}},
+		Params:   &schemas.ChatParameters{Tools: inner.Tools},
+	}
+	out, err := ToAnthropicChatRequest(nil, req)
+	if err != nil {
+		t.Fatalf("conversion failed: %v", err)
+	}
+	if len(out.Tools) != 1 {
+		t.Fatalf("repro bug: expected 1 tool after conversion, got %d (tools array was empty — this was the bug)", len(out.Tools))
+	}
+	if out.Tools[0].Name != "web_search" {
+		t.Errorf("tool Name: got %q, want %q", out.Tools[0].Name, "web_search")
+	}
+	if out.Tools[0].AnthropicToolWebSearch == nil ||
+		out.Tools[0].AnthropicToolWebSearch.MaxUses == nil ||
+		*out.Tools[0].AnthropicToolWebSearch.MaxUses != 5 {
+		t.Errorf("tool max_uses lost: %+v", out.Tools[0])
+	}
+}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2239,6 +2239,7 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 		for _, tool := range req.Tools {
 			bifrostTool := convertAnthropicToolToBifrost(&tool)
 			if bifrostTool != nil {
+				applyAnthropicToolFlagsToResponsesTool(&tool, bifrostTool)
 				bifrostTools = append(bifrostTools, *bifrostTool)
 			}
 		}
@@ -2248,12 +2249,17 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 	}
 
 	if req.MCPServers != nil {
-		// Build a map of mcp_toolset configs from tools[] keyed by mcp_server_name
-		toolsetByServer := make(map[string]*AnthropicMCPToolsetTool)
+		// Build a map of mcp_toolset entries from tools[] keyed by mcp_server_name.
+		// Stores the full *AnthropicTool (not just *AnthropicMCPToolsetTool) so
+		// top-level Anthropic tool flags (DeferLoading, AllowedCallers,
+		// InputExamples, EagerInputStreaming) survive the mcp_servers merge path —
+		// without this, mcp_toolset tools bypass applyAnthropicToolFlagsToResponsesTool
+		// because convertAnthropicToolToBifrost skips them.
+		toolsetByServer := make(map[string]*AnthropicTool)
 		if req.Tools != nil {
 			for i := range req.Tools {
 				if req.Tools[i].MCPToolset != nil {
-					toolsetByServer[req.Tools[i].MCPToolset.MCPServerName] = req.Tools[i].MCPToolset
+					toolsetByServer[req.Tools[i].MCPToolset.MCPServerName] = &req.Tools[i]
 				}
 			}
 		}
@@ -2262,9 +2268,10 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 		for _, mcpServer := range req.MCPServers {
 			bifrostMCPTool := convertAnthropicMCPServerV2ToBifrostTool(&mcpServer)
 			if bifrostMCPTool != nil {
-				// Merge mcp_toolset configs (allowed tools) if present
-				if toolset, ok := toolsetByServer[mcpServer.Name]; ok {
-					applyMCPToolsetConfigToBifrostTool(bifrostMCPTool, toolset)
+				// Merge mcp_toolset configs (allowed tools) + Anthropic tool flags if present
+				if toolWithFlags, ok := toolsetByServer[mcpServer.Name]; ok {
+					applyMCPToolsetConfigToBifrostTool(bifrostMCPTool, toolWithFlags.MCPToolset)
+					applyAnthropicToolFlagsToResponsesTool(toolWithFlags, bifrostMCPTool)
 				}
 				bifrostMCPTools = append(bifrostMCPTools, *bifrostMCPTool)
 			}
@@ -4851,16 +4858,78 @@ func convertBifrostToolsToAnthropic(model string, tools []schemas.ResponsesTool,
 				mcpServers = append(mcpServers, *server)
 			}
 			if toolset != nil {
-				anthropicTools = append(anthropicTools, AnthropicTool{MCPToolset: toolset})
+				mcpTool := AnthropicTool{MCPToolset: toolset}
+				applyResponsesToolAnthropicFlags(&mcpTool, &tool)
+				anthropicTools = append(anthropicTools, mcpTool)
 			}
 			continue
 		}
 		anthropicTool := convertBifrostToolToAnthropic(model, &tool, provider, hasWebSearchOrFetch)
 		if anthropicTool != nil {
+			applyResponsesToolAnthropicFlags(anthropicTool, &tool)
 			anthropicTools = append(anthropicTools, *anthropicTool)
 		}
 	}
 	return anthropicTools, mcpServers
+}
+
+// applyAnthropicToolFlagsToResponsesTool propagates the Anthropic-native tool
+// flags (DeferLoading, AllowedCallers, InputExamples, EagerInputStreaming) in
+// the inbound direction: from the incoming AnthropicTool onto the neutral
+// ResponsesTool when the native Anthropic /v1/messages endpoint is the entry
+// point. Called once per converted tool so every return path inside
+// convertAnthropicToolToBifrost benefits.
+func applyAnthropicToolFlagsToResponsesTool(at *AnthropicTool, rt *schemas.ResponsesTool) {
+	if at == nil || rt == nil {
+		return
+	}
+	if at.DeferLoading != nil {
+		rt.DeferLoading = at.DeferLoading
+	}
+	if len(at.AllowedCallers) > 0 {
+		rt.AllowedCallers = at.AllowedCallers
+	}
+	if len(at.InputExamples) > 0 {
+		rt.InputExamples = make([]schemas.ChatToolInputExample, len(at.InputExamples))
+		for i, ex := range at.InputExamples {
+			rt.InputExamples[i] = schemas.ChatToolInputExample{
+				Input:       ex.Input,
+				Description: ex.Description,
+			}
+		}
+	}
+	if at.EagerInputStreaming != nil {
+		rt.EagerInputStreaming = at.EagerInputStreaming
+	}
+}
+
+// applyResponsesToolAnthropicFlags propagates the Anthropic-native tool flags
+// (DeferLoading, AllowedCallers, InputExamples, EagerInputStreaming) from the
+// neutral ResponsesTool onto the provider-native AnthropicTool. Called once
+// per converted tool so every branch in convertBifrostToolToAnthropic
+// benefits without duplicating the logic on each return path.
+func applyResponsesToolAnthropicFlags(at *AnthropicTool, rt *schemas.ResponsesTool) {
+	if at == nil || rt == nil {
+		return
+	}
+	if rt.DeferLoading != nil {
+		at.DeferLoading = rt.DeferLoading
+	}
+	if len(rt.AllowedCallers) > 0 {
+		at.AllowedCallers = rt.AllowedCallers
+	}
+	if len(rt.InputExamples) > 0 {
+		at.InputExamples = make([]AnthropicToolInputExample, len(rt.InputExamples))
+		for i, ex := range rt.InputExamples {
+			at.InputExamples[i] = AnthropicToolInputExample{
+				Input:       ex.Input,
+				Description: ex.Description,
+			}
+		}
+	}
+	if rt.EagerInputStreaming != nil {
+		at.EagerInputStreaming = rt.EagerInputStreaming
+	}
 }
 
 // Helper function to convert Tool back to AnthropicTool

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -1099,7 +1099,7 @@ func (ac *AnthropicCitations) MarshalJSON() ([]byte, error) {
 		ac.TextCitations = nil
 	}
 	if ac.Config != nil && ac.TextCitations != nil {
-		return nil, fmt.Errorf("AnthropicCitations: both Config and TextCitations are set; only one should be non-nil")
+		return nil, fmt.Errorf("both Config and TextCitations are set; only one should be non-nil")
 	}
 
 	if ac.Config != nil {

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -90,6 +90,437 @@ var (
 	}
 )
 
+// stripUnsupportedAnthropicFields removes request-level and tool-level fields
+// that the target Anthropic-family provider does not support, according to the
+// ProviderFeatures map (types.go). Tool-type validation (fail-closed) is handled
+// separately by ValidateToolsForProvider; this helper handles request-level
+// fields (strip silently, since they're additive enhancements).
+//
+// Mutates req in place. Safe to call multiple times.
+func stripUnsupportedAnthropicFields(req *AnthropicMessageRequest, provider schemas.ModelProvider, model string) {
+	if req == nil {
+		return
+	}
+	features, ok := ProviderFeatures[provider]
+	if !ok {
+		// Unknown provider — safe default: don't strip anything.
+		return
+	}
+
+	// Request-level fields gated by ProviderFeatures flags.
+	if req.Container != nil {
+		// Skills form (object with skills[]) is beta-gated; bare string id is universal.
+		// Intent signal: non-empty skills = caller explicitly wants skills; empty
+		// skills:[] = likely caller oversight we can silently correct.
+		hasSkills := req.Container.ContainerObject != nil && len(req.Container.ContainerObject.Skills) > 0
+		// Strip an explicit empty or non-empty skills array on Skills=false
+		// providers. omitempty already handles this at serialize time for empty
+		// arrays, but we clear it explicitly so hasSkills-based decisions below
+		// and raw-path parity both stay correct.
+		if !features.Skills && req.Container.ContainerObject != nil && req.Container.ContainerObject.Skills != nil {
+			req.Container.ContainerObject.Skills = nil
+		}
+		switch {
+		case hasSkills && !features.Skills:
+			// Caller wanted non-empty skills but provider doesn't support them.
+			req.Container = nil
+		case !hasSkills && !features.ContainerBasic:
+			req.Container = nil
+		}
+	}
+	if len(req.MCPServers) > 0 && !features.MCP {
+		req.MCPServers = nil
+	}
+	// Speed is both provider-gated (FastMode flag) and model-gated
+	// (Opus 4.6 only per SupportsFastMode). Strip if either gate fails —
+	// Anthropic's API rejects speed:"fast" on non-Opus-4.6 models with a 400.
+	if req.Speed != nil && (!features.FastMode || !SupportsFastMode(model)) {
+		req.Speed = nil
+	}
+	if req.OutputConfig != nil && req.OutputConfig.TaskBudget != nil && !features.TaskBudgets {
+		req.OutputConfig.TaskBudget = nil
+		// Clean up an empty OutputConfig so it doesn't serialize as {}
+		if req.OutputConfig.Format == nil && req.OutputConfig.Effort == nil {
+			req.OutputConfig = nil
+		}
+	}
+	if req.InferenceGeo != nil && !features.InferenceGeo {
+		req.InferenceGeo = nil
+	}
+	// cache_control.scope — strip on providers without PromptCachingScope
+	// support at every slot scope can live: top-level request, tools, system
+	// blocks, and message content blocks. Vertex additionally uses the
+	// marshal-time SetStripCacheControlScope mechanism (vertex/utils.go:104,
+	// types.go MarshalJSON); after this strip runs, that marshal-time pass
+	// becomes a safe no-op for Vertex (nothing left to strip).
+	if !features.PromptCachingScope {
+		// Top-level.
+		if req.CacheControl != nil && req.CacheControl.Scope != nil {
+			req.CacheControl.Scope = nil
+			// If scope was the only meaningful field, drop the whole CacheControl
+			// so we don't serialize an empty object.
+			if req.CacheControl.TTL == nil && req.CacheControl.Type == "" {
+				req.CacheControl = nil
+			}
+		}
+		// Per-tool cache_control.scope.
+		for i := range req.Tools {
+			if req.Tools[i].CacheControl != nil && req.Tools[i].CacheControl.Scope != nil {
+				req.Tools[i].CacheControl.Scope = nil
+				// Drop the parent if scope was the only meaningful field.
+				if req.Tools[i].CacheControl.TTL == nil && req.Tools[i].CacheControl.Type == "" {
+					req.Tools[i].CacheControl = nil
+				}
+			}
+		}
+		// System block scopes.
+		if req.System != nil {
+			for i := range req.System.ContentBlocks {
+				if req.System.ContentBlocks[i].CacheControl != nil && req.System.ContentBlocks[i].CacheControl.Scope != nil {
+					req.System.ContentBlocks[i].CacheControl.Scope = nil
+					if req.System.ContentBlocks[i].CacheControl.TTL == nil && req.System.ContentBlocks[i].CacheControl.Type == "" {
+						req.System.ContentBlocks[i].CacheControl = nil
+					}
+				}
+			}
+		}
+		// Message block scopes.
+		for mi := range req.Messages {
+			for ci := range req.Messages[mi].Content.ContentBlocks {
+				cc := req.Messages[mi].Content.ContentBlocks[ci].CacheControl
+				if cc != nil && cc.Scope != nil {
+					cc.Scope = nil
+					if cc.TTL == nil && cc.Type == "" {
+						req.Messages[mi].Content.ContentBlocks[ci].CacheControl = nil
+					}
+				}
+			}
+		}
+	}
+	if req.ContextManagement != nil {
+		// Gate edits by their type — compaction vs context-editing flags.
+		kept := make([]ContextManagementEdit, 0, len(req.ContextManagement.Edits))
+		for _, edit := range req.ContextManagement.Edits {
+			switch edit.Type {
+			case ContextManagementEditTypeCompact:
+				if features.Compaction {
+					kept = append(kept, edit)
+				}
+			case ContextManagementEditTypeClearToolUses, ContextManagementEditTypeClearThinking:
+				if features.ContextEditing {
+					kept = append(kept, edit)
+				}
+			default:
+				// Unknown edit type — keep and let upstream reject.
+				kept = append(kept, edit)
+			}
+		}
+		if len(kept) == 0 {
+			req.ContextManagement = nil
+		} else {
+			req.ContextManagement.Edits = kept
+		}
+	}
+
+	// Tool-level flags — strip per-tool without dropping the tool itself.
+	for i := range req.Tools {
+		tool := &req.Tools[i]
+		if tool.DeferLoading != nil && !features.AdvancedToolUse {
+			tool.DeferLoading = nil
+		}
+		if len(tool.AllowedCallers) > 0 && !features.AdvancedToolUse {
+			tool.AllowedCallers = nil
+		}
+		// InputExamples has its own feature flag (InputExamples) because
+		// Bedrock supports the tool-examples-2025-10-29 header standalone —
+		// without the full advanced-tool-use-2025-11-20 bundle. On Anthropic
+		// and Azure, the bundle flag (AdvancedToolUse) is also set, so either
+		// gate would work there.
+		if len(tool.InputExamples) > 0 && !features.InputExamples {
+			tool.InputExamples = nil
+		}
+		if tool.EagerInputStreaming != nil && !features.EagerInputStreaming {
+			tool.EagerInputStreaming = nil
+		}
+		if tool.Strict != nil && !features.StructuredOutputs {
+			tool.Strict = nil
+		}
+	}
+}
+
+// stripUnsupportedFieldsFromRawBody is the raw-JSON equivalent of
+// StripUnsupportedAnthropicFields. It mutates the request body bytes using
+// sjson/gjson (preserving key order for prompt caching) so the raw-body
+// passthrough path has behavioural parity with the typed conversion path.
+//
+// Scope: every field the typed helper handles.
+//   - top-level: speed (provider + model gated), container (.skills gated by
+//     features.Skills, bare string by features.ContainerBasic), mcp_servers,
+//     inference_geo, cache_control.scope, output_config.task_budget,
+//     context_management.edits[] (gated per edit type).
+//   - nested: tool.CacheControl.Scope, system block scopes, message block
+//     scopes (all stripped when !features.PromptCachingScope).
+//   - per-tool: defer_loading, allowed_callers (AdvancedToolUse bundle),
+//     input_examples (narrow InputExamples flag), eager_input_streaming
+//     (EagerInputStreaming), strict (StructuredOutputs).
+//
+// Unknown providers: safe default — no stripping (parity with the typed helper).
+// Unknown edit types in context_management: left in place for the provider
+// to reject (parity with the typed helper).
+func stripUnsupportedFieldsFromRawBody(jsonBody []byte, provider schemas.ModelProvider, model string) ([]byte, error) {
+	if len(jsonBody) == 0 {
+		return jsonBody, nil
+	}
+	features, ok := ProviderFeatures[provider]
+	if !ok {
+		return jsonBody, nil
+	}
+
+	// Fall back to body-embedded model when caller didn't pass one.
+	if model == "" {
+		if modelResult := providerUtils.GetJSONField(jsonBody, "model"); modelResult.Exists() {
+			model = modelResult.String()
+		}
+	}
+
+	var err error
+
+	// speed — provider AND model gate
+	if providerUtils.JSONFieldExists(jsonBody, "speed") {
+		if !features.FastMode || !SupportsFastMode(model) {
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "speed")
+			if err != nil {
+				return nil, fmt.Errorf("strip raw speed: %w", err)
+			}
+		}
+	}
+
+	// inference_geo
+	if !features.InferenceGeo && providerUtils.JSONFieldExists(jsonBody, "inference_geo") {
+		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "inference_geo")
+		if err != nil {
+			return nil, fmt.Errorf("strip raw inference_geo: %w", err)
+		}
+	}
+
+	// mcp_servers
+	if !features.MCP && providerUtils.JSONFieldExists(jsonBody, "mcp_servers") {
+		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "mcp_servers")
+		if err != nil {
+			return nil, fmt.Errorf("strip raw mcp_servers: %w", err)
+		}
+	}
+
+	// container — two variants: bare string id (ContainerBasic), or object
+	// {id, skills[]} where skills require Skills flag.
+	// Distinguishes three states: no skills field (bare form), skills:[] (empty
+	// array — caller oversight, silently strip), skills:[…] (non-empty — caller
+	// explicitly wants skills). Mirrors the typed path's hybrid decision.
+	if containerResult := providerUtils.GetJSONField(jsonBody, "container"); containerResult.Exists() {
+		hasSkillsField, hasNonEmptySkills := false, false
+		if containerResult.IsObject() {
+			if skills := containerResult.Get("skills"); skills.Exists() {
+				hasSkillsField = true
+				if skills.IsArray() && len(skills.Array()) > 0 {
+					hasNonEmptySkills = true
+				}
+			}
+		}
+		// Always strip the skills key on Skills=false providers — critical on
+		// the raw path since bytes flow directly to the provider and an
+		// explicit empty array would still be rejected as unknown field.
+		if !features.Skills && hasSkillsField {
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "container.skills")
+			if err != nil {
+				return nil, fmt.Errorf("strip raw container.skills: %w", err)
+			}
+		}
+		drop := false
+		switch {
+		case hasNonEmptySkills:
+			drop = !features.Skills
+		default:
+			drop = !features.ContainerBasic
+		}
+		if drop {
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "container")
+			if err != nil {
+				return nil, fmt.Errorf("strip raw container: %w", err)
+			}
+		}
+	}
+
+	// output_config.task_budget
+	if !features.TaskBudgets && providerUtils.JSONFieldExists(jsonBody, "output_config.task_budget") {
+		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "output_config.task_budget")
+		if err != nil {
+			return nil, fmt.Errorf("strip raw output_config.task_budget: %w", err)
+		}
+		// Drop an empty parent so we don't serialize output_config:{} (matches
+		// typed-path behavior at lines 129-134).
+		if oc := providerUtils.GetJSONField(jsonBody, "output_config"); oc.IsObject() && len(oc.Map()) == 0 {
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "output_config")
+			if err != nil {
+				return nil, fmt.Errorf("strip raw output_config: %w", err)
+			}
+		}
+	}
+
+	// top-level cache_control.scope
+	if !features.PromptCachingScope && providerUtils.JSONFieldExists(jsonBody, "cache_control.scope") {
+		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "cache_control.scope")
+		if err != nil {
+			return nil, fmt.Errorf("strip raw cache_control.scope: %w", err)
+		}
+		// Drop an empty parent so we don't serialize cache_control:{} (matches
+		// typed-path behavior at lines 147-153).
+		if cc := providerUtils.GetJSONField(jsonBody, "cache_control"); cc.IsObject() && len(cc.Map()) == 0 {
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "cache_control")
+			if err != nil {
+				return nil, fmt.Errorf("strip raw cache_control: %w", err)
+			}
+		}
+	}
+
+	// context_management.edits[] — gate per edit.type.
+	if editsResult := providerUtils.GetJSONField(jsonBody, "context_management.edits"); editsResult.Exists() && editsResult.IsArray() {
+		edits := editsResult.Array()
+		// Collect indices to drop (iterate forwards, delete in reverse).
+		dropIndices := []int{}
+		for i, edit := range edits {
+			editType := edit.Get("type").String()
+			keep := true
+			switch editType {
+			case string(ContextManagementEditTypeCompact):
+				keep = features.Compaction
+			case string(ContextManagementEditTypeClearToolUses), string(ContextManagementEditTypeClearThinking):
+				keep = features.ContextEditing
+			}
+			if !keep {
+				dropIndices = append(dropIndices, i)
+			}
+		}
+		if len(dropIndices) == len(edits) && len(edits) > 0 {
+			// All edits unsupported — drop the whole context_management.
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "context_management")
+			if err != nil {
+				return nil, fmt.Errorf("strip raw context_management: %w", err)
+			}
+		} else {
+			for i := len(dropIndices) - 1; i >= 0; i-- {
+				path := fmt.Sprintf("context_management.edits.%d", dropIndices[i])
+				jsonBody, err = providerUtils.DeleteJSONField(jsonBody, path)
+				if err != nil {
+					return nil, fmt.Errorf("strip raw context_management.edits[%d]: %w", dropIndices[i], err)
+				}
+			}
+		}
+	}
+
+	// per-tool flags + nested scope
+	if toolsResult := providerUtils.GetJSONField(jsonBody, "tools"); toolsResult.Exists() && toolsResult.IsArray() {
+		for i := range toolsResult.Array() {
+			base := fmt.Sprintf("tools.%d", i)
+			if !features.AdvancedToolUse {
+				if providerUtils.JSONFieldExists(jsonBody, base+".defer_loading") {
+					jsonBody, err = providerUtils.DeleteJSONField(jsonBody, base+".defer_loading")
+					if err != nil {
+						return nil, fmt.Errorf("strip raw %s.defer_loading: %w", base, err)
+					}
+				}
+				if providerUtils.JSONFieldExists(jsonBody, base+".allowed_callers") {
+					jsonBody, err = providerUtils.DeleteJSONField(jsonBody, base+".allowed_callers")
+					if err != nil {
+						return nil, fmt.Errorf("strip raw %s.allowed_callers: %w", base, err)
+					}
+				}
+			}
+			if !features.InputExamples && providerUtils.JSONFieldExists(jsonBody, base+".input_examples") {
+				jsonBody, err = providerUtils.DeleteJSONField(jsonBody, base+".input_examples")
+				if err != nil {
+					return nil, fmt.Errorf("strip raw %s.input_examples: %w", base, err)
+				}
+			}
+			if !features.EagerInputStreaming && providerUtils.JSONFieldExists(jsonBody, base+".eager_input_streaming") {
+				jsonBody, err = providerUtils.DeleteJSONField(jsonBody, base+".eager_input_streaming")
+				if err != nil {
+					return nil, fmt.Errorf("strip raw %s.eager_input_streaming: %w", base, err)
+				}
+			}
+			if !features.StructuredOutputs && providerUtils.JSONFieldExists(jsonBody, base+".strict") {
+				jsonBody, err = providerUtils.DeleteJSONField(jsonBody, base+".strict")
+				if err != nil {
+					return nil, fmt.Errorf("strip raw %s.strict: %w", base, err)
+				}
+			}
+			if !features.PromptCachingScope && providerUtils.JSONFieldExists(jsonBody, base+".cache_control.scope") {
+				jsonBody, err = providerUtils.DeleteJSONField(jsonBody, base+".cache_control.scope")
+				if err != nil {
+					return nil, fmt.Errorf("strip raw %s.cache_control.scope: %w", base, err)
+				}
+				// Drop the parent if cache_control is now an empty object, so
+				// we don't forward a malformed `cache_control: {}` marker.
+				if ccResult := providerUtils.GetJSONField(jsonBody, base+".cache_control"); ccResult.Exists() && ccResult.IsObject() && len(ccResult.Map()) == 0 {
+					jsonBody, err = providerUtils.DeleteJSONField(jsonBody, base+".cache_control")
+					if err != nil {
+						return nil, fmt.Errorf("strip raw %s.cache_control empty parent: %w", base, err)
+					}
+				}
+			}
+		}
+	}
+
+	// Nested scope on system blocks (system can be a string OR array of blocks).
+	if !features.PromptCachingScope {
+		if systemResult := providerUtils.GetJSONField(jsonBody, "system"); systemResult.Exists() && systemResult.IsArray() {
+			for i := range systemResult.Array() {
+				path := fmt.Sprintf("system.%d.cache_control.scope", i)
+				if providerUtils.JSONFieldExists(jsonBody, path) {
+					jsonBody, err = providerUtils.DeleteJSONField(jsonBody, path)
+					if err != nil {
+						return nil, fmt.Errorf("strip raw system[%d].cache_control.scope: %w", i, err)
+					}
+					parentPath := fmt.Sprintf("system.%d.cache_control", i)
+					if ccResult := providerUtils.GetJSONField(jsonBody, parentPath); ccResult.Exists() && ccResult.IsObject() && len(ccResult.Map()) == 0 {
+						jsonBody, err = providerUtils.DeleteJSONField(jsonBody, parentPath)
+						if err != nil {
+							return nil, fmt.Errorf("strip raw system[%d].cache_control empty parent: %w", i, err)
+						}
+					}
+				}
+			}
+		}
+		// Nested scope on messages[].content[] blocks.
+		if messagesResult := providerUtils.GetJSONField(jsonBody, "messages"); messagesResult.Exists() && messagesResult.IsArray() {
+			messages := messagesResult.Array()
+			for mi := range messages {
+				contentResult := providerUtils.GetJSONField(jsonBody, fmt.Sprintf("messages.%d.content", mi))
+				if !contentResult.Exists() || !contentResult.IsArray() {
+					continue
+				}
+				for ci := range contentResult.Array() {
+					path := fmt.Sprintf("messages.%d.content.%d.cache_control.scope", mi, ci)
+					if providerUtils.JSONFieldExists(jsonBody, path) {
+						jsonBody, err = providerUtils.DeleteJSONField(jsonBody, path)
+						if err != nil {
+							return nil, fmt.Errorf("strip raw messages[%d].content[%d].cache_control.scope: %w", mi, ci, err)
+						}
+						parentPath := fmt.Sprintf("messages.%d.content.%d.cache_control", mi, ci)
+						if ccResult := providerUtils.GetJSONField(jsonBody, parentPath); ccResult.Exists() && ccResult.IsObject() && len(ccResult.Map()) == 0 {
+							jsonBody, err = providerUtils.DeleteJSONField(jsonBody, parentPath)
+							if err != nil {
+								return nil, fmt.Errorf("strip raw messages[%d].content[%d].cache_control empty parent: %w", mi, ci, err)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return jsonBody, nil
+}
+
 // IsOpus47 returns true if the model is Claude Opus 4.7 or a later generation where:
 //   - Extended thinking (budget_tokens) is removed — only adaptive thinking is supported.
 //   - temperature, top_p, and top_k are not supported (setting them returns a 400).
@@ -110,6 +541,20 @@ func SupportsNativeEffort(model string) bool {
 	}
 	return strings.Contains(model, "4-5") || strings.Contains(model, "4.5") ||
 		strings.Contains(model, "4-6") || strings.Contains(model, "4.6")
+}
+
+// SupportsFastMode returns true if the model supports speed:"fast" (research
+// preview). Per Anthropic's fast-mode docs, only Opus 4.6 supports it;
+// requests carrying speed:"fast" to any other model are rejected with 400.
+// Beta header: fast-mode-2026-02-01.
+//
+// Source: https://platform.claude.com/docs/en/build-with-claude/fast-mode
+func SupportsFastMode(model string) bool {
+	model = strings.ToLower(model)
+	if !strings.Contains(model, "opus") {
+		return false
+	}
+	return strings.Contains(model, "4-6") || strings.Contains(model, "4.6")
 }
 
 // SupportsAdaptiveThinking returns true if the model supports thinking.type: "adaptive".
@@ -191,6 +636,26 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 		jsonBody, err = StripAutoInjectableTools(jsonBody)
 		if err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+		}
+		// Sanitize raw-body fields the target provider does not support.
+		// Behavioural parity with StripUnsupportedAnthropicFields on the typed path.
+		// Feature gating keyed to schemas.Anthropic (not providerName) to match
+		// the typed path below which also hardcodes schemas.Anthropic — ensures
+		// custom Anthropic aliases get identical feature lookup in both modes.
+		jsonBody, err = stripUnsupportedFieldsFromRawBody(jsonBody, schemas.Anthropic, "")
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+		}
+		// Auto-inject matching anthropic-beta headers for fields the sanitizer
+		// preserved (speed, task_budget, cache_control.scope, input_examples,
+		// defer_loading, allowed_callers, eager_input_streaming, mcp_servers,
+		// structured outputs, etc). Without this, raw-body callers who supply
+		// gated fields but not headers would 400 upstream. Single source of
+		// truth: probe-unmarshal into the typed struct and reuse the typed
+		// path's header walker.
+		var probe AnthropicMessageRequest
+		if err := schemas.Unmarshal(jsonBody, &probe); err == nil {
+			AddMissingBetaHeadersToContext(ctx, &probe, schemas.Anthropic)
 		}
 		// Remove excluded fields
 		for _, field := range excludeFields {
@@ -281,13 +746,23 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 					headers = appendUniqueHeader(headers, AnthropicStructuredOutputsBetaHeader)
 				}
 			}
-			// Advanced-tool-use features. defer_loading and allowed_callers
-			// are only in the advanced-tool-use-2025-11-20 bundle; emit the
-			// bundle header only when the target provider supports the full
-			// bundle (Anthropic/Azure).
+			// Check for advanced-tool-use features. defer_loading and
+			// allowed_callers are only available as part of the bundle
+			// header; input_examples additionally has a standalone header
+			// (tool-examples-2025-10-29) used on Bedrock where the bundle is
+			// not accepted.
 			if tool.DeferLoading != nil && *tool.DeferLoading {
 				if !hasProvider || features.AdvancedToolUse {
 					headers = appendUniqueHeader(headers, AnthropicAdvancedToolUseBetaHeader)
+				}
+			}
+			if len(tool.InputExamples) > 0 {
+				if !hasProvider || features.AdvancedToolUse {
+					// Bundle header covers input_examples transitively.
+					headers = appendUniqueHeader(headers, AnthropicAdvancedToolUseBetaHeader)
+				} else if features.InputExamples {
+					// Narrow standalone header (e.g. Bedrock).
+					headers = appendUniqueHeader(headers, AnthropicToolExamplesBetaHeader)
 				}
 			}
 			if len(tool.AllowedCallers) > 0 {
@@ -323,6 +798,14 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 			}
 		}
 	}
+	// Check for cache control with scope at the top level of the request
+	// (mirrors the tool/system/message checks below).
+	if !hasCachingScope && req.CacheControl != nil && req.CacheControl.Scope != nil {
+		if !hasProvider || features.PromptCachingScope {
+			headers = appendUniqueHeader(headers, AnthropicPromptCachingScopeBetaHeader)
+			hasCachingScope = true
+		}
+	}
 	// Check for compaction
 	if req.ContextManagement != nil {
 		for _, edit := range req.ContextManagement.Edits {
@@ -350,9 +833,11 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 			headers = appendUniqueHeader(headers, AnthropicInterleavedThinkingBetaHeader)
 		}
 	}
-	// Check for fast mode
+	// Check for fast mode. Only add the beta header when both the provider
+	// supports fast mode AND the model does (Opus 4.6 only per
+	// SupportsFastMode); otherwise sending the header guarantees a 400.
 	if req.Speed != nil && *req.Speed == "fast" {
-		if !hasProvider || features.FastMode {
+		if (!hasProvider || features.FastMode) && SupportsFastMode(req.Model) {
 			headers = appendUniqueHeader(headers, AnthropicFastModeBetaHeader)
 		}
 	}

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -772,19 +772,32 @@ func TestAddMissingBetaHeadersToContext_PerProvider(t *testing.T) {
 			},
 			unexpectHeaders: []string{AnthropicInterleavedThinkingBetaHeader},
 		},
-		// Fast mode tests
+		// Fast mode tests — fast mode is Opus 4.6 only (research preview),
+		// so tests must set Model to exercise the path. Non-Opus-4.6 models
+		// are model-gated out regardless of provider flag.
 		{
 			name:     "Anthropic gets fast mode header",
 			provider: schemas.Anthropic,
 			req: &AnthropicMessageRequest{
+				Model: "claude-opus-4-6",
 				Speed: schemas.Ptr("fast"),
 			},
 			expectHeaders: []string{AnthropicFastModeBetaHeader},
 		},
 		{
+			name:     "Anthropic skips fast mode header on non-Opus-4.6 model",
+			provider: schemas.Anthropic,
+			req: &AnthropicMessageRequest{
+				Model: "claude-sonnet-4-6",
+				Speed: schemas.Ptr("fast"),
+			},
+			unexpectHeaders: []string{AnthropicFastModeBetaHeader},
+		},
+		{
 			name:     "Bedrock skips fast mode header",
 			provider: schemas.Bedrock,
 			req: &AnthropicMessageRequest{
+				Model: "claude-opus-4-6", // fast mode is model-gated; set a supporting model so the test actually exercises provider suppression
 				Speed: schemas.Ptr("fast"),
 			},
 			unexpectHeaders: []string{AnthropicFastModeBetaHeader},
@@ -793,6 +806,7 @@ func TestAddMissingBetaHeadersToContext_PerProvider(t *testing.T) {
 			name:     "Azure skips fast mode header",
 			provider: schemas.Azure,
 			req: &AnthropicMessageRequest{
+				Model: "claude-opus-4-6", // fast mode is model-gated; set a supporting model so the test actually exercises provider suppression
 				Speed: schemas.Ptr("fast"),
 			},
 			unexpectHeaders: []string{AnthropicFastModeBetaHeader},
@@ -1237,6 +1251,239 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
+	t.Run("bedrock_strips_new_request_level_fields", func(t *testing.T) {
+		// Raw body with every new typed field. Targeting Bedrock: speed (no FastMode),
+		// inference_geo (no InferenceGeo), mcp_servers (no MCP), container.skills
+		// (no Skills), top-level cache_control.scope (no PromptCachingScope),
+		// output_config.task_budget (no TaskBudgets). All should be stripped.
+		input := []byte(`{
+			"model":"claude-opus-4-6",
+			"speed":"fast",
+			"inference_geo":"us-east-1",
+			"mcp_servers":[{"type":"url","url":"https://example.com","name":"x"}],
+			"container":{"id":"c-1","skills":[{"skill_id":"s","type":"anthropic"}]},
+			"cache_control":{"type":"ephemeral","ttl":"5m","scope":"user"},
+			"output_config":{"task_budget":{"type":"tokens","total":20000}}
+		}`)
+		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, path := range []string{"speed", "inference_geo", "mcp_servers", "container", "cache_control.scope", "output_config.task_budget"} {
+			if providerUtils.JSONFieldExists(result, path) {
+				t.Errorf("expected %q to be stripped for Bedrock, got: %s", path, string(result))
+			}
+		}
+		// Confirm non-scope cache_control fields are retained.
+		if !providerUtils.JSONFieldExists(result, "cache_control.ttl") {
+			t.Errorf("expected cache_control.ttl to survive, got: %s", string(result))
+		}
+	})
+
+	t.Run("vertex_strips_mcp_strict_and_input_examples_via_feature_check", func(t *testing.T) {
+		// Vertex: no MCP, no InputExamples, no StructuredOutputs.
+		// tool.strict stripped; tool.input_examples stripped; mcp_servers stripped.
+		// tool.cache_control.scope stripped (Vertex has no PromptCachingScope).
+		input := []byte(`{
+			"model":"claude-sonnet-4-6",
+			"mcp_servers":[{"type":"url","url":"u","name":"n"}],
+			"tools":[{"name":"t1","strict":true,"input_examples":[{"input":{"a":1}}],"cache_control":{"type":"ephemeral","scope":"user"}}]
+		}`)
+		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Vertex, "claude-sonnet-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, path := range []string{"mcp_servers", "tools.0.strict", "tools.0.input_examples", "tools.0.cache_control.scope"} {
+			if providerUtils.JSONFieldExists(result, path) {
+				t.Errorf("expected %q to be stripped for Vertex, got: %s", path, string(result))
+			}
+		}
+		if !providerUtils.JSONFieldExists(result, "tools.0.name") {
+			t.Errorf("expected tool name to survive")
+		}
+	})
+
+	t.Run("bedrock_keeps_input_examples_via_standalone_flag", func(t *testing.T) {
+		// Bedrock has InputExamples=true via tool-examples-2025-10-29 but
+		// AdvancedToolUse=false. input_examples should be KEPT; defer_loading
+		// and allowed_callers (bundle-only) should be STRIPPED.
+		input := []byte(`{
+			"model":"claude-opus-4-6",
+			"tools":[{"name":"t1","input_examples":[{"input":{"a":1}}],"defer_loading":true,"allowed_callers":["direct"]}]
+		}`)
+		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !providerUtils.JSONFieldExists(result, "tools.0.input_examples") {
+			t.Errorf("expected tools[0].input_examples to survive on Bedrock, got: %s", string(result))
+		}
+		for _, path := range []string{"tools.0.defer_loading", "tools.0.allowed_callers"} {
+			if providerUtils.JSONFieldExists(result, path) {
+				t.Errorf("expected %q to be stripped for Bedrock (AdvancedToolUse bundle unsupported), got: %s", path, string(result))
+			}
+		}
+	})
+
+	t.Run("speed_stripped_on_non_opus_46_even_on_anthropic", func(t *testing.T) {
+		// Model gate: fast-mode is Opus 4.6 only per docs. Even on Anthropic
+		// direct where FastMode=true, targeting a different model must strip.
+		input := []byte(`{"model":"claude-sonnet-4-6","speed":"fast"}`)
+		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Anthropic, "claude-sonnet-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if providerUtils.JSONFieldExists(result, "speed") {
+			t.Errorf("expected speed stripped for non-Opus-4.6 model on Anthropic, got: %s", string(result))
+		}
+	})
+
+	t.Run("anthropic_direct_is_noop", func(t *testing.T) {
+		// Anthropic supports everything — body should survive untouched.
+		input := []byte(`{"model":"claude-opus-4-6","speed":"fast","mcp_servers":[{"type":"url","url":"u","name":"n"}],"container":{"id":"c"},"tools":[{"name":"t","defer_loading":true,"input_examples":[{"input":{"a":1}}]}]}`)
+		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Anthropic, "claude-opus-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, path := range []string{"speed", "mcp_servers", "container", "tools.0.defer_loading", "tools.0.input_examples"} {
+			if !providerUtils.JSONFieldExists(result, path) {
+				t.Errorf("expected %q preserved on Anthropic direct, got: %s", path, string(result))
+			}
+		}
+	})
+
+	t.Run("nested_scope_stripped_on_messages_and_system", func(t *testing.T) {
+		// Nested scope on system blocks and message blocks must also be stripped
+		// when the provider lacks PromptCachingScope.
+		input := []byte(`{
+			"model":"claude-opus-4-6",
+			"system":[{"type":"text","text":"hi","cache_control":{"type":"ephemeral","scope":"user"}}],
+			"messages":[{"role":"user","content":[{"type":"text","text":"q","cache_control":{"type":"ephemeral","scope":"global"}}]}]
+		}`)
+		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, path := range []string{"system.0.cache_control.scope", "messages.0.content.0.cache_control.scope"} {
+			if providerUtils.JSONFieldExists(result, path) {
+				t.Errorf("expected nested %q stripped, got: %s", path, string(result))
+			}
+		}
+	})
+
+	t.Run("unknown_provider_is_safe_noop", func(t *testing.T) {
+		input := []byte(`{"model":"claude-opus-4-6","speed":"fast"}`)
+		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.ModelProvider("custom"), "claude-opus-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !providerUtils.JSONFieldExists(result, "speed") {
+			t.Errorf("expected speed preserved for unknown provider (safe default), got: %s", string(result))
+		}
+	})
+
+	t.Run("container_empty_skills_stripped_but_container_preserved", func(t *testing.T) {
+		// Skills=false provider (Bedrock), ContainerBasic=true.
+		// skills:[] is a caller oversight — strip the empty key, preserve container.
+		input := []byte(`{"model":"claude-opus-4-6","container":{"id":"c-1","skills":[]}}`)
+		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if providerUtils.JSONFieldExists(result, "container.skills") {
+			t.Errorf("expected empty container.skills stripped on Skills=false provider, got: %s", string(result))
+		}
+		if !providerUtils.JSONFieldExists(result, "container.id") {
+			t.Errorf("expected container.id preserved (bare form still valid), got: %s", string(result))
+		}
+	})
+
+	t.Run("container_nonempty_skills_drops_whole_container", func(t *testing.T) {
+		// Non-empty skills signals caller intent; provider doesn't support — drop container.
+		input := []byte(`{"model":"claude-opus-4-6","container":{"id":"c-1","skills":[{"skill_id":"s","type":"anthropic"}]}}`)
+		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if providerUtils.JSONFieldExists(result, "container") {
+			t.Errorf("expected whole container dropped for non-empty skills on Skills=false, got: %s", string(result))
+		}
+	})
+
+	t.Run("container_empty_skills_on_skills_capable_provider_preserved", func(t *testing.T) {
+		// On Anthropic direct (Skills=true), the empty skills array must be preserved
+		// as-is — our strip logic only fires when !features.Skills.
+		input := []byte(`{"model":"claude-opus-4-6","container":{"id":"c-1","skills":[]}}`)
+		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Anthropic, "claude-opus-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !providerUtils.JSONFieldExists(result, "container.skills") {
+			t.Errorf("expected container.skills preserved on Skills=true provider, got: %s", string(result))
+		}
+	})
+}
+
+// TestStripUnsupportedAnthropicFields_ContainerSkillsGating mirrors the raw-path
+// tests above on the typed path — ensures the typed sanitizer treats explicit
+// empty skills arrays as a stripable (not drop-triggering) signal.
+func TestStripUnsupportedAnthropicFields_ContainerSkillsGating(t *testing.T) {
+	t.Run("empty_skills_on_skills_false_provider_strips_skills_keeps_container", func(t *testing.T) {
+		req := &AnthropicMessageRequest{
+			Model: "claude-opus-4-6",
+			Container: &AnthropicContainer{
+				ContainerObject: &AnthropicContainerObject{
+					ID:     schemas.Ptr("c-1"),
+					Skills: []AnthropicContainerSkill{}, // explicit empty
+				},
+			},
+		}
+		stripUnsupportedAnthropicFields(req, schemas.Bedrock, "claude-opus-4-6")
+		if req.Container == nil {
+			t.Fatalf("expected container preserved (bare form valid with empty skills), got nil")
+		}
+		if req.Container.ContainerObject == nil || req.Container.ContainerObject.Skills != nil {
+			t.Errorf("expected skills cleared on Skills=false, got %v", req.Container.ContainerObject)
+		}
+	})
+
+	t.Run("nonempty_skills_on_skills_false_provider_drops_container", func(t *testing.T) {
+		req := &AnthropicMessageRequest{
+			Model: "claude-opus-4-6",
+			Container: &AnthropicContainer{
+				ContainerObject: &AnthropicContainerObject{
+					ID:     schemas.Ptr("c-1"),
+					Skills: []AnthropicContainerSkill{{SkillID: "s", Type: "anthropic"}},
+				},
+			},
+		}
+		stripUnsupportedAnthropicFields(req, schemas.Bedrock, "claude-opus-4-6")
+		if req.Container != nil {
+			t.Errorf("expected whole container dropped for non-empty skills on Skills=false, got %v", req.Container)
+		}
+	})
+
+	t.Run("empty_skills_on_skills_true_provider_preserved", func(t *testing.T) {
+		req := &AnthropicMessageRequest{
+			Model: "claude-opus-4-6",
+			Container: &AnthropicContainer{
+				ContainerObject: &AnthropicContainerObject{
+					ID:     schemas.Ptr("c-1"),
+					Skills: []AnthropicContainerSkill{},
+				},
+			},
+		}
+		stripUnsupportedAnthropicFields(req, schemas.Anthropic, "claude-opus-4-6")
+		if req.Container == nil || req.Container.ContainerObject == nil {
+			t.Fatalf("expected container preserved on Skills=true provider, got %v", req.Container)
+		}
+		if req.Container.ContainerObject.Skills == nil {
+			t.Errorf("expected empty skills preserved on Skills=true provider (not nilled)")
+		}
+	})
 }
 
 func TestStripAutoInjectableTools(t *testing.T) {

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -229,6 +229,8 @@ func TestBedrock(t *testing.T) {
 			StructuredOutputs:     true,
 			InterleavedThinking:  true,
 			EagerInputStreaming:  true, // fine-grained-tool-streaming-2025-05-14 (per B-header)
+			// ServerToolsViaOpenAIEndpoint: Bedrock does not support web_search / web_fetch /
+			// code_execution server tools per Table 20, so no cases would run. Left off.
 		},
 	}
 

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -1120,7 +1120,7 @@ func convertToolConfig(model string, params *schemas.ChatParameters) *BedrockToo
 			bedrockTool := BedrockTool{
 				ToolSpec: &BedrockToolSpec{
 					Name:        tool.Function.Name,
-					Description: schemas.Ptr(description),
+					Description: new(description),
 					InputSchema: BedrockToolInputSchema{
 						JSON: json.RawMessage(schemaObjectBytes),
 					},

--- a/core/providers/openai/responses_marshal_test.go
+++ b/core/providers/openai/responses_marshal_test.go
@@ -694,3 +694,179 @@ func TestOpenAIResponsesRequestInput_MarshalJSON_FunctionCallOutputPreservesNonT
 		t.Fatalf("non-text blocks must not be flattened to string; raw=%s", string(jsonBytes))
 	}
 }
+
+// TestOpenAIResponsesRequest_MarshalJSON_StripsAnthropicToolFlags ensures the
+// Responses serializer drops the four Anthropic-native tool flags
+// (defer_loading, allowed_callers, input_examples, eager_input_streaming)
+// along with CacheControl before forwarding to OpenAI — mirroring the Chat
+// path's behavior so Anthropic-flavored tools cannot 400 OpenAI via Responses.
+func TestOpenAIResponsesRequest_MarshalJSON_StripsAnthropicToolFlags(t *testing.T) {
+	req := &OpenAIResponsesRequest{
+		Model: "gpt-4o",
+		Input: OpenAIResponsesRequestInput{
+			OpenAIResponsesRequestInputArray: []schemas.ResponsesMessage{
+				{
+					Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{
+						ContentStr: schemas.Ptr("hello"),
+					},
+				},
+			},
+		},
+		ResponsesParameters: schemas.ResponsesParameters{
+			Tools: []schemas.ResponsesTool{
+				{
+					Type:                schemas.ResponsesToolTypeFunction,
+					Name:                schemas.Ptr("lookup"),
+					Description:         schemas.Ptr("lookup something"),
+					CacheControl:        &schemas.CacheControl{Type: "ephemeral"},
+					DeferLoading:        schemas.Ptr(true),
+					AllowedCallers:      []string{"direct", "agent"},
+					EagerInputStreaming: schemas.Ptr(false),
+					InputExamples: []schemas.ChatToolInputExample{
+						{Input: json.RawMessage(`{"q":"hi"}`)},
+					},
+					ResponsesToolFunction: &schemas.ResponsesToolFunction{},
+				},
+			},
+		},
+	}
+
+	jsonBytes, err := req.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	raw := string(jsonBytes)
+
+	// None of the five Anthropic-only tool keys must survive on the wire.
+	for _, key := range []string{`"cache_control"`, `"defer_loading"`, `"allowed_callers"`, `"input_examples"`, `"eager_input_streaming"`} {
+		if strings.Contains(raw, key) {
+			t.Errorf("OpenAI Responses serializer must strip %s; raw=%s", key, raw)
+		}
+	}
+	// Function tool identity should be preserved.
+	if !strings.Contains(raw, `"name":"lookup"`) {
+		t.Errorf("tool identity lost after strip; raw=%s", raw)
+	}
+}
+
+// TestOpenAIResponsesRequest_MarshalJSON_DropsAnthropicOnlyToolTypes verifies
+// that Anthropic-only tool types (web_fetch, memory) are dropped entirely when
+// serializing for OpenAI Responses. Per OpenAI's OpenAPI spec the Responses
+// Tool discriminator union does not include web_fetch or memory, so forwarding
+// them would trigger a 400 schema-validation error. Mirrors the Chat path's
+// isAnthropicServerToolShape drop behavior.
+func TestOpenAIResponsesRequest_MarshalJSON_DropsAnthropicOnlyToolTypes(t *testing.T) {
+	req := &OpenAIResponsesRequest{
+		Model: "gpt-4o",
+		Input: OpenAIResponsesRequestInput{
+			OpenAIResponsesRequestInputArray: []schemas.ResponsesMessage{
+				{
+					Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{
+						ContentStr: schemas.Ptr("hello"),
+					},
+				},
+			},
+		},
+		ResponsesParameters: schemas.ResponsesParameters{
+			Tools: []schemas.ResponsesTool{
+				// Kept: function (OpenAI-native).
+				{
+					Type:                  schemas.ResponsesToolTypeFunction,
+					Name:                  schemas.Ptr("keeper_func"),
+					ResponsesToolFunction: &schemas.ResponsesToolFunction{},
+				},
+				// Dropped: web_fetch (Anthropic-only).
+				{
+					Type:                  schemas.ResponsesToolTypeWebFetch,
+					Name:                  schemas.Ptr("anthropic_webfetch"),
+					ResponsesToolWebFetch: &schemas.ResponsesToolWebFetch{},
+				},
+				// Kept: web_search (both support).
+				{
+					Type:                   schemas.ResponsesToolTypeWebSearch,
+					ResponsesToolWebSearch: &schemas.ResponsesToolWebSearch{},
+				},
+				// Dropped: memory (Anthropic-only).
+				{
+					Type: schemas.ResponsesToolTypeMemory,
+					Name: schemas.Ptr("anthropic_memory"),
+				},
+				// Kept: tool_search (both support per OpenAI OpenAPI spec).
+				{
+					Type: schemas.ResponsesToolTypeToolSearch,
+				},
+			},
+		},
+	}
+
+	jsonBytes, err := req.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	raw := string(jsonBytes)
+
+	// Dropped types must not appear on the wire.
+	for _, dropped := range []string{`"web_fetch"`, `"memory"`, `"anthropic_webfetch"`, `"anthropic_memory"`} {
+		if strings.Contains(raw, dropped) {
+			t.Errorf("Anthropic-only tool must be dropped; found %s in raw=%s", dropped, raw)
+		}
+	}
+	// Kept types must still appear.
+	for _, kept := range []string{`"function"`, `"web_search"`, `"tool_search"`, `"keeper_func"`} {
+		if !strings.Contains(raw, kept) {
+			t.Errorf("supported tool %s should be preserved; raw=%s", kept, raw)
+		}
+	}
+
+	// Confirm the tools array is present and has exactly 3 entries (2 dropped of 5).
+	var decoded struct {
+		Tools []map[string]interface{} `json:"tools"`
+	}
+	if err := json.Unmarshal(jsonBytes, &decoded); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if len(decoded.Tools) != 3 {
+		t.Errorf("expected 3 tools after drop (function, web_search, tool_search), got %d; tools=%+v", len(decoded.Tools), decoded.Tools)
+	}
+}
+
+// TestOpenAIResponsesRequest_MarshalJSON_KeepsAllWhenAllSupported verifies the
+// no-reshape fast path: if every tool is OpenAI-compatible with no
+// Anthropic-only flags, the tools slice passes through unchanged (no copy,
+// no drop).
+func TestOpenAIResponsesRequest_MarshalJSON_KeepsAllWhenAllSupported(t *testing.T) {
+	req := &OpenAIResponsesRequest{
+		Model: "gpt-4o",
+		Input: OpenAIResponsesRequestInput{
+			OpenAIResponsesRequestInputArray: []schemas.ResponsesMessage{
+				{
+					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+				},
+			},
+		},
+		ResponsesParameters: schemas.ResponsesParameters{
+			Tools: []schemas.ResponsesTool{
+				{Type: schemas.ResponsesToolTypeFunction, Name: schemas.Ptr("f"), ResponsesToolFunction: &schemas.ResponsesToolFunction{}},
+				{Type: schemas.ResponsesToolTypeWebSearch, ResponsesToolWebSearch: &schemas.ResponsesToolWebSearch{}},
+				{Type: schemas.ResponsesToolTypeCodeInterpreter, ResponsesToolCodeInterpreter: &schemas.ResponsesToolCodeInterpreter{}},
+			},
+		},
+	}
+
+	jsonBytes, err := req.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var decoded struct {
+		Tools []map[string]interface{} `json:"tools"`
+	}
+	if err := json.Unmarshal(jsonBytes, &decoded); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if len(decoded.Tools) != 3 {
+		t.Errorf("expected 3 tools preserved, got %d", len(decoded.Tools))
+	}
+}

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -185,27 +185,42 @@ func (req *OpenAIChatRequest) MarshalJSON() ([]byte, error) {
 		processedMessages = req.Messages
 	}
 
-	// Process tools if needed
+	// Process tools if needed.
+	// On outbound to OpenAI we need to:
+	//   (a) Strip CacheControl (Anthropic-only, existing behavior).
+	//   (b) Drop Anthropic server tools entirely (Function == nil && Custom == nil);
+	//       OpenAI won't accept web_search_20260209 etc.
+	//   (c) Strip Anthropic-native per-tool flags (DeferLoading, AllowedCallers,
+	//       InputExamples, EagerInputStreaming) when they're set on function tools.
 	var processedTools []schemas.ChatTool
 	if len(req.Tools) > 0 {
-		needsToolCopy := false
+		needsToolChange := false
 		for _, tool := range req.Tools {
-			if tool.CacheControl != nil {
-				needsToolCopy = true
+			if tool.CacheControl != nil || isAnthropicServerToolShape(tool) || hasAnthropicOnlyToolFlags(tool) {
+				needsToolChange = true
 				break
 			}
 		}
 
-		if needsToolCopy {
-			processedTools = make([]schemas.ChatTool, len(req.Tools))
-			for i, tool := range req.Tools {
-				if tool.CacheControl != nil {
-					toolCopy := tool
-					toolCopy.CacheControl = nil
-					processedTools[i] = toolCopy
-				} else {
-					processedTools[i] = tool
+		if needsToolChange {
+			processedTools = make([]schemas.ChatTool, 0, len(req.Tools))
+			for _, tool := range req.Tools {
+				// Drop Anthropic server tools (no function/custom payload).
+				// OpenAI would reject the request if we forwarded them.
+				if isAnthropicServerToolShape(tool) {
+					continue
 				}
+				if tool.CacheControl == nil && !hasAnthropicOnlyToolFlags(tool) {
+					processedTools = append(processedTools, tool)
+					continue
+				}
+				toolCopy := tool
+				toolCopy.CacheControl = nil
+				toolCopy.DeferLoading = nil
+				toolCopy.AllowedCallers = nil
+				toolCopy.InputExamples = nil
+				toolCopy.EagerInputStreaming = nil
+				processedTools = append(processedTools, toolCopy)
 			}
 		} else {
 			processedTools = req.Tools
@@ -489,6 +504,52 @@ func (r *OpenAIResponsesRequestInput) MarshalJSON() ([]byte, error) {
 }
 
 // Helper function to check if a chat message has any CacheControl fields or FileType in file blocks
+// isAnthropicServerToolShape reports whether the tool carries the Anthropic
+// server-tool shape (Function and Custom both nil). On outbound to OpenAI,
+// these must be dropped — OpenAI doesn't accept tool types like
+// web_search_20260209, computer_20251124, mcp_toolset, etc.
+func isAnthropicServerToolShape(t schemas.ChatTool) bool {
+	return t.Function == nil && t.Custom == nil
+}
+
+// hasAnthropicOnlyToolFlags reports whether the tool carries any of the
+// Anthropic-native flags that OpenAI would reject (DeferLoading,
+// AllowedCallers, InputExamples, EagerInputStreaming). Strip these when
+// forwarding to OpenAI.
+func hasAnthropicOnlyToolFlags(t schemas.ChatTool) bool {
+	return t.DeferLoading != nil ||
+		len(t.AllowedCallers) > 0 ||
+		len(t.InputExamples) > 0 ||
+		t.EagerInputStreaming != nil
+}
+
+// hasAnthropicOnlyResponsesToolFlags is the ResponsesTool-typed parallel of
+// hasAnthropicOnlyToolFlags. The four flags were promoted onto ResponsesTool
+// in core/schemas/responses.go for the Anthropic-via-Responses path; the
+// OpenAI Responses serializer must strip them so they don't leak to OpenAI
+// and trigger a 400 on unknown fields.
+func hasAnthropicOnlyResponsesToolFlags(t schemas.ResponsesTool) bool {
+	return t.DeferLoading != nil ||
+		len(t.AllowedCallers) > 0 ||
+		len(t.InputExamples) > 0 ||
+		t.EagerInputStreaming != nil
+}
+
+// isAnthropicOnlyResponsesToolType reports whether the tool type exists only
+// in Anthropic's taxonomy and is not part of OpenAI's Responses API Tool union
+// (per OpenAI's OpenAPI spec component.schemas.Tool, which enumerates function,
+// file_search, computer[_use_preview], web_search[_preview], mcp,
+// code_interpreter, image_generation, local_shell, custom, tool_search, and
+// related shell/namespace/apply_patch variants). Forwarding web_fetch or
+// memory to OpenAI guarantees a 400 on schema discriminator validation, so
+// these get dropped in the Responses→OpenAI serializer — mirroring the Chat
+// path's isAnthropicServerToolShape drop behavior for schema parity across
+// both endpoints.
+func isAnthropicOnlyResponsesToolType(t schemas.ResponsesTool) bool {
+	return t.Type == schemas.ResponsesToolTypeWebFetch ||
+		t.Type == schemas.ResponsesToolTypeMemory
+}
+
 func hasFieldsToStripInChatMessage(msg OpenAIMessage) bool {
 	if msg.Content != nil && msg.Content.ContentBlocks != nil {
 		for _, block := range msg.Content.ContentBlocks {
@@ -661,27 +722,45 @@ func (resp *OpenAIResponsesRequest) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	// Process tools if needed
+	// Process tools if needed.
+	// Mirrors the Chat path (see ChatRequest.MarshalJSON) so the same
+	// Anthropic-flavored tool payload doesn't leak via the Responses serializer:
+	//   (a) Drop Anthropic-only tool TYPES entirely (web_fetch, memory) since
+	//       OpenAI's Responses Tool union doesn't include them — forwarding
+	//       would 400 on the discriminator.
+	//   (b) Strip CacheControl (Anthropic-only schema field).
+	//   (c) Strip the four Anthropic-native per-tool flags (DeferLoading,
+	//       AllowedCallers, InputExamples, EagerInputStreaming).
 	var processedTools []schemas.ResponsesTool
 	if len(resp.Tools) > 0 {
-		needsToolCopy := false
+		needsReshape := false
 		for _, tool := range resp.Tools {
-			if tool.CacheControl != nil {
-				needsToolCopy = true
+			if isAnthropicOnlyResponsesToolType(tool) ||
+				tool.CacheControl != nil ||
+				hasAnthropicOnlyResponsesToolFlags(tool) {
+				needsReshape = true
 				break
 			}
 		}
 
-		if needsToolCopy {
-			processedTools = make([]schemas.ResponsesTool, len(resp.Tools))
-			for i, tool := range resp.Tools {
-				if tool.CacheControl != nil {
-					toolCopy := tool
-					toolCopy.CacheControl = nil
-					processedTools[i] = toolCopy
-				} else {
-					processedTools[i] = tool
+		if needsReshape {
+			processedTools = make([]schemas.ResponsesTool, 0, len(resp.Tools))
+			for _, tool := range resp.Tools {
+				if isAnthropicOnlyResponsesToolType(tool) {
+					// Drop — OpenAI Responses has no web_fetch or memory.
+					continue
 				}
+				if tool.CacheControl == nil && !hasAnthropicOnlyResponsesToolFlags(tool) {
+					processedTools = append(processedTools, tool)
+					continue
+				}
+				toolCopy := tool
+				toolCopy.CacheControl = nil
+				toolCopy.DeferLoading = nil
+				toolCopy.AllowedCallers = nil
+				toolCopy.InputExamples = nil
+				toolCopy.EagerInputStreaming = nil
+				processedTools = append(processedTools, toolCopy)
 			}
 		} else {
 			processedTools = resp.Tools

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -209,6 +210,19 @@ type ChatParameters struct {
 	Verbosity            *string               `json:"verbosity,omitempty"`          // "low" | "medium" | "high"
 	WebSearchOptions     *ChatWebSearchOptions `json:"web_search_options,omitempty"` // Web search options (OpenAI only)
 
+	// Anthropic-native knobs promoted to the neutral layer. These pass through
+	// typed to Anthropic-family providers (honored/stripped per ProviderFeatures
+	// in core/providers/anthropic/types.go). Non-Anthropic providers (OpenAI
+	// etc.) silently ignore them.
+	TopK              *int            `json:"top_k,omitempty"`              // Anthropic top_k sampling
+	Speed             *string         `json:"speed,omitempty"`              // "fast" (Anthropic fast-mode-2026-02-01 beta, Opus 4.6 only)
+	InferenceGeo      *string         `json:"inference_geo,omitempty"`      // Anthropic inference_geo (Claude API only)
+	MCPServers        []ChatMCPServer `json:"mcp_servers,omitempty"`        // Anthropic MCP connector (mcp-client-2025-11-20)
+	Container         *ChatContainer  `json:"container,omitempty"`          // Anthropic container (string id, or object with skills[] — beta skills-2025-10-02)
+	CacheControl      *CacheControl   `json:"cache_control,omitempty"`      // Top-level request cache control (Anthropic family)
+	TaskBudget        *ChatTaskBudget `json:"task_budget,omitempty"`        // Anthropic output_config.task_budget (task-budgets-2026-03-13 beta)
+	ContextManagement json.RawMessage `json:"context_management,omitempty"` // Anthropic context_management — complex union, passed as raw JSON to the provider layer
+
 	// Dynamic parameters that can be provider-specific, they are directly
 	// added to the request as is.
 	ExtraParams map[string]interface{} `json:"-"`
@@ -270,6 +284,7 @@ type ChatReasoning struct {
 	Enabled   *bool   `json:"enabled,omitempty"`    // Explicitly enable or disable reasoning (required by OpenRouter to disable reasoning for some models)
 	Effort    *string `json:"effort,omitempty"`     // "none" |  "minimal" | "low" | "medium" | "high" (any value other than "none" will enable reasoning)
 	MaxTokens *int    `json:"max_tokens,omitempty"` // Maximum number of tokens to generate for the reasoning output (required for anthropic)
+	Display   *string `json:"display,omitempty"`    // Anthropic thinking.display: "summarized" | "omitted" (requires model support for adaptive thinking)
 }
 
 // ChatPrediction represents predicted output content for the model to reference (OpenAI only).
@@ -323,18 +338,170 @@ type MCPToolAnnotations struct {
 }
 
 // ChatTool represents a tool definition.
+//
+// Three shapes coexist under this type:
+//  1. OpenAI function tool:   Type="function", Function non-nil.
+//  2. Custom tool:            Type="custom",   Custom non-nil.
+//  3. Anthropic server tool:  Type=server-tool version string (e.g.
+//     "web_search_20260209", "computer_20251124", "mcp_toolset"), Function/Custom
+//     nil, Name populated at top level, and the variant-specific fields
+//     (MaxUses, DisplayWidthPx, etc.) populated inline.
+//
+// JSON shape for (3) matches Anthropic's native tool format directly
+// (e.g. {"type":"web_search_20260209","name":"web_search","max_uses":5}).
+//
+// Custom MarshalJSON/UnmarshalJSON enforce the union invariant:
+//   - On marshal, fields that don't match Type are cleared on a copy so the
+//     wire format always carries exactly one variant. Mixed caller state
+//     (e.g. Type="web_search_20260209" with Function also set) gets
+//     canonicalized instead of being forwarded ambiguously to providers.
+//   - On unmarshal, tolerantly accept whatever JSON shape comes in, then
+//     normalize the decoded struct so downstream code sees a canonical shape.
 type ChatTool struct {
 	Type         ChatToolType        `json:"type"`
-	Function     *ChatToolFunction   `json:"function,omitempty"`      // Function definition
-	Custom       *ChatToolCustom     `json:"custom,omitempty"`        // Custom tool definition
+	Function     *ChatToolFunction   `json:"function,omitempty"`      // Function definition (shape 1)
+	Custom       *ChatToolCustom     `json:"custom,omitempty"`        // Custom tool definition (shape 2)
 	CacheControl *CacheControl       `json:"cache_control,omitempty"` // Cache control for the tool
 	Annotations  *MCPToolAnnotations `json:"-"`                       // MCP tool annotations (Bifrost-internal, never forwarded to providers)
 
-	// EagerInputStreaming enables fine-grained tool input streaming
-	// (Anthropic fine-grained-tool-streaming-2025-05-14). On Anthropic-family
-	// providers the model emits input_json_delta events before full arguments
-	// are determined. Silently ignored on providers that don't support it.
-	EagerInputStreaming *bool `json:"eager_input_streaming,omitempty"`
+	// Anthropic-native tool flags promoted to the neutral layer. All optional;
+	// ignored by providers that don't support them. Gating per ProviderFeatures
+	// in core/providers/anthropic/types.go.
+	DeferLoading        *bool                  `json:"defer_loading,omitempty"`         // Anthropic advanced-tool-use: defer loading of tool definition
+	AllowedCallers      []string               `json:"allowed_callers,omitempty"`       // Anthropic advanced-tool-use: which callers can invoke this tool ("direct", "code_execution_20250825", "code_execution_20260120")
+	InputExamples       []ChatToolInputExample `json:"input_examples,omitempty"`        // Anthropic tool-examples-2025-10-29: example inputs for the tool
+	EagerInputStreaming *bool                  `json:"eager_input_streaming,omitempty"` // Anthropic fine-grained-tool-streaming-2025-05-14: stream input_json_delta before full args are determined (custom tools only)
+
+	// Anthropic server-tool fields (shape 3). All optional; only populated when
+	// Type is a server-tool version string. Function tools carry their name
+	// inside Function.Name — use omitempty here so Name doesn't double-emit.
+	Name string `json:"name,omitempty"`
+
+	// web_search_* and web_fetch_*:
+	MaxUses        *int                  `json:"max_uses,omitempty"`
+	AllowedDomains []string              `json:"allowed_domains,omitempty"`
+	BlockedDomains []string              `json:"blocked_domains,omitempty"`
+	UserLocation   *ChatToolUserLocation `json:"user_location,omitempty"`
+
+	// web_fetch_* only:
+	MaxContentTokens *int                     `json:"max_content_tokens,omitempty"`
+	Citations        *ChatToolCitationsConfig `json:"citations,omitempty"`
+	UseCache         *bool                    `json:"use_cache,omitempty"` // web_fetch_20260309+ only
+
+	// computer_*:
+	DisplayWidthPx  *int  `json:"display_width_px,omitempty"`
+	DisplayHeightPx *int  `json:"display_height_px,omitempty"`
+	DisplayNumber   *int  `json:"display_number,omitempty"`
+	EnableZoom      *bool `json:"enable_zoom,omitempty"` // computer_20251124 only
+
+	// text_editor_20250728+:
+	MaxCharacters *int `json:"max_characters,omitempty"`
+
+	// mcp_toolset:
+	MCPServerName string                           `json:"mcp_server_name,omitempty"`
+	DefaultConfig *ChatMCPToolsetConfig            `json:"default_config,omitempty"`
+	Configs       map[string]*ChatMCPToolsetConfig `json:"configs,omitempty"`
+}
+
+// normalizeShape clears fields that don't belong to the ChatTool's active
+// variant, encoding the three-way union invariant:
+//
+//  1. Type="function": keep Function; nil Custom, server-tool Name, and
+//     variant metadata (function tools carry their name inside Function.Name).
+//  2. Type="custom":   keep Custom and top-level Name; nil Function and
+//     server-tool variant metadata.
+//  3. Any other Type:  server-tool variant — keep Name and variant fields;
+//     nil Function and Custom.
+//
+// Called by both Marshal (strict wire format) and Unmarshal (canonicalize
+// after tolerant decode of potentially mixed input).
+func (t *ChatTool) normalizeShape() {
+	switch t.Type {
+	case ChatToolTypeFunction:
+		t.Custom = nil
+		t.Name = ""
+		t.clearServerToolVariantFields()
+	case ChatToolTypeCustom:
+		t.Function = nil
+		t.clearServerToolVariantFields()
+	default:
+		t.Function = nil
+		t.Custom = nil
+	}
+}
+
+func (t *ChatTool) clearServerToolVariantFields() {
+	t.MaxUses = nil
+	t.AllowedDomains = nil
+	t.BlockedDomains = nil
+	t.UserLocation = nil
+	t.MaxContentTokens = nil
+	t.Citations = nil
+	t.UseCache = nil
+	t.DisplayWidthPx = nil
+	t.DisplayHeightPx = nil
+	t.DisplayNumber = nil
+	t.EnableZoom = nil
+	t.MaxCharacters = nil
+	t.MCPServerName = ""
+	t.DefaultConfig = nil
+	t.Configs = nil
+}
+
+// MarshalJSON enforces the ChatTool union invariant: exactly one variant's
+// fields are emitted on the wire, matching Type. A mix-state tool
+// (e.g. Type="web_search_20260209" with Function also populated) would
+// otherwise serialize both, and downstream provider converters — which
+// dispatch on the top-level Type/Name shape — could misinterpret or
+// silently forward the stray fields.
+func (t ChatTool) MarshalJSON() ([]byte, error) {
+	normalized := t
+	normalized.normalizeShape()
+	type Alias ChatTool
+	return MarshalSorted((*Alias)(&normalized))
+}
+
+// UnmarshalJSON tolerantly decodes whatever JSON shape arrives, then
+// canonicalizes the struct via normalizeShape so downstream code sees a
+// single-variant result even if the input mixed multiple variants.
+// Resets the receiver before decoding so omitted optional fields from a
+// prior payload don't survive the new decode; mirrors ChatContainer.UnmarshalJSON.
+func (t *ChatTool) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		*t = ChatTool{}
+		return nil
+	}
+
+	type Alias ChatTool
+	var temp Alias
+	if err := Unmarshal(data, &temp); err != nil {
+		return err
+	}
+	*t = ChatTool(temp)
+	t.normalizeShape()
+	return nil
+}
+
+// ChatToolUserLocation is the neutral user_location for web_search tools.
+type ChatToolUserLocation struct {
+	Type     *string `json:"type,omitempty"` // "approximate"
+	City     *string `json:"city,omitempty"`
+	Region   *string `json:"region,omitempty"`
+	Country  *string `json:"country,omitempty"`
+	Timezone *string `json:"timezone,omitempty"`
+}
+
+// ChatToolCitationsConfig is the request-side citations config on web_fetch
+// ({"enabled": true/false}). Distinct from response-side text citations.
+type ChatToolCitationsConfig struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
+// ChatMCPToolsetConfig configures an MCP toolset entry (mcp_toolset tool).
+type ChatMCPToolsetConfig struct {
+	Enabled      *bool `json:"enabled,omitempty"`
+	DeferLoading *bool `json:"defer_loading,omitempty"`
 }
 
 // ChatToolFunction represents a function definition.
@@ -960,6 +1127,103 @@ type CacheControl struct {
 	Type  CacheControlType `json:"type"`
 	TTL   *string          `json:"ttl,omitempty"`   // "1m" | "1h"
 	Scope *string          `json:"scope,omitempty"` // "user" | "global"
+}
+
+// ---------------------------------------------------------------------------
+// Neutral mirror types for Anthropic-native knobs promoted onto ChatParameters
+// ---------------------------------------------------------------------------
+// These live in schemas/ (not provider-specific) so ChatParameters stays
+// import-free of provider packages. The anthropic provider reads them in
+// ToAnthropicChatRequest and maps them to AnthropicMessageRequest fields.
+
+// ChatContainerSkill describes one skill attached to a container.
+// Origin: Anthropic container.skills[] (beta skills-2025-10-02).
+type ChatContainerSkill struct {
+	SkillID string  `json:"skill_id"`
+	Type    string  `json:"type"`              // "anthropic" | "custom"
+	Version *string `json:"version,omitempty"` // Optional version pin
+}
+
+// ChatContainerObject is the object form of ChatContainer.
+// Both fields are optional — ID alone is a bare container reference;
+// adding Skills makes it beta-gated.
+type ChatContainerObject struct {
+	ID     *string              `json:"id,omitempty"`
+	Skills []ChatContainerSkill `json:"skills,omitempty"`
+}
+
+// ChatContainer is the union "container" field on a chat request.
+// Anthropic's API accepts either a plain string (container id) or an object
+// with id + skills[]. Mirrors AnthropicContainer in the provider package.
+type ChatContainer struct {
+	ContainerStr    *string
+	ContainerObject *ChatContainerObject
+}
+
+// MarshalJSON emits the raw string or the object form directly.
+func (c ChatContainer) MarshalJSON() ([]byte, error) {
+	if c.ContainerStr != nil && c.ContainerObject != nil {
+		return nil, fmt.Errorf("both ContainerStr and ContainerObject are set; only one should be non-nil")
+	}
+	if c.ContainerStr != nil {
+		return MarshalSorted(*c.ContainerStr)
+	}
+	if c.ContainerObject != nil {
+		return MarshalSorted(c.ContainerObject)
+	}
+	return MarshalSorted(nil)
+}
+
+// UnmarshalJSON accepts either a plain string or the object form.
+// Uses the build-tag-aware package-level Unmarshal (sonic on native, stdlib
+// json on wasm/tinygo) and clears the inactive union arm on each success so
+// repeated decodes into the same value don't leave both arms populated.
+// JSON null clears both arms. Follows the ChatToolChoice.UnmarshalJSON pattern.
+func (c *ChatContainer) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		c.ContainerStr = nil
+		c.ContainerObject = nil
+		return nil
+	}
+
+	var s string
+	if err := Unmarshal(data, &s); err == nil {
+		c.ContainerStr = &s
+		c.ContainerObject = nil
+		return nil
+	}
+	var obj ChatContainerObject
+	if err := Unmarshal(data, &obj); err == nil {
+		c.ContainerStr = nil
+		c.ContainerObject = &obj
+		return nil
+	}
+	return fmt.Errorf("container field is neither a string nor an object")
+}
+
+// ChatTaskBudget advises the model of a full-loop token budget.
+// Origin: Anthropic output_config.task_budget (beta task-budgets-2026-03-13).
+type ChatTaskBudget struct {
+	Type      string `json:"type"`                // Always "tokens"
+	Total     int    `json:"total"`               // Total advisory budget
+	Remaining *int   `json:"remaining,omitempty"` // Optional client-side counter
+}
+
+// ChatToolInputExample is one example input for a tool, shown to the model.
+// Origin: Anthropic tool.input_examples (beta tool-examples-2025-10-29).
+type ChatToolInputExample struct {
+	Input       json.RawMessage `json:"input"`
+	Description *string         `json:"description,omitempty"`
+}
+
+// ChatMCPServer is an MCP server definition attached to a chat request.
+// Origin: Anthropic mcp_servers[] (mcp-client-2025-11-20 format).
+type ChatMCPServer struct {
+	Type               string  `json:"type"` // "url"
+	URL                string  `json:"url"`
+	Name               string  `json:"name"`
+	AuthorizationToken *string `json:"authorization_token,omitempty"`
 }
 
 // ChatInputImage represents image data in a message.

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1406,6 +1406,14 @@ type ResponsesTool struct {
 	// Not in OpenAI's schemas, but sent by a few providers (Anthropic, Bedrock are some of them)
 	CacheControl *CacheControl `json:"cache_control,omitempty"`
 
+	// Anthropic-native tool flags promoted to the neutral layer. All optional;
+	// ignored by providers that don't support them. Gated per ProviderFeatures
+	// in core/providers/anthropic/types.go.
+	DeferLoading        *bool                  `json:"defer_loading,omitempty"`         // Anthropic advanced-tool-use: defer loading of tool definition
+	AllowedCallers      []string               `json:"allowed_callers,omitempty"`       // Anthropic advanced-tool-use: which callers can invoke this tool
+	InputExamples       []ChatToolInputExample `json:"input_examples,omitempty"`        // Anthropic tool-examples-2025-10-29: example inputs for the tool
+	EagerInputStreaming *bool                  `json:"eager_input_streaming,omitempty"` // Anthropic fine-grained-tool-streaming-2025-05-14
+
 	*ResponsesToolFunction
 	*ResponsesToolFileSearch
 	*ResponsesToolComputerUsePreview
@@ -1460,6 +1468,38 @@ func (t ResponsesTool) MarshalJSON() ([]byte, error) {
 			return nil, ccErr
 		}
 		if data, err = sjson.SetRawBytes(data, "cache_control", ccBytes); err != nil {
+			return nil, err
+		}
+	}
+	// Anthropic-native tool flags promoted to the neutral layer. Must be
+	// emitted here (before the type-specific merge) so the wire format carries
+	// them to providers that gate features on these keys. Without this block
+	// MarshalJSON silently drops the fields despite their json tags.
+	if t.DeferLoading != nil {
+		if data, err = sjson.SetBytes(data, "defer_loading", *t.DeferLoading); err != nil {
+			return nil, err
+		}
+	}
+	if len(t.AllowedCallers) > 0 {
+		callersBytes, callersErr := MarshalSorted(t.AllowedCallers)
+		if callersErr != nil {
+			return nil, callersErr
+		}
+		if data, err = sjson.SetRawBytes(data, "allowed_callers", callersBytes); err != nil {
+			return nil, err
+		}
+	}
+	if len(t.InputExamples) > 0 {
+		examplesBytes, examplesErr := MarshalSorted(t.InputExamples)
+		if examplesErr != nil {
+			return nil, examplesErr
+		}
+		if data, err = sjson.SetRawBytes(data, "input_examples", examplesBytes); err != nil {
+			return nil, err
+		}
+	}
+	if t.EagerInputStreaming != nil {
+		if data, err = sjson.SetBytes(data, "eager_input_streaming", *t.EagerInputStreaming); err != nil {
 			return nil, err
 		}
 	}
@@ -1565,6 +1605,32 @@ func (t *ResponsesTool) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		t.CacheControl = &cc
+	}
+	// Anthropic-native tool flags. Mirror the emit side in MarshalJSON above —
+	// without these reads, a round-trip silently drops the fields.
+	if v, ok := raw["defer_loading"].(bool); ok {
+		t.DeferLoading = Ptr(v)
+	}
+	if v, ok := raw["allowed_callers"]; ok {
+		bytes, err := MarshalSorted(v)
+		if err != nil {
+			return err
+		}
+		if err := Unmarshal(bytes, &t.AllowedCallers); err != nil {
+			return err
+		}
+	}
+	if v, ok := raw["input_examples"]; ok {
+		bytes, err := MarshalSorted(v)
+		if err != nil {
+			return err
+		}
+		if err := Unmarshal(bytes, &t.InputExamples); err != nil {
+			return err
+		}
+	}
+	if v, ok := raw["eager_input_streaming"].(bool); ok {
+		t.EagerInputStreaming = Ptr(v)
 	}
 
 	// Based on type, unmarshal into the appropriate embedded struct

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -781,6 +781,204 @@ func TestResponsesTool_MarshalJSON_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestResponsesTool_RoundTrip_AnthropicFields ensures the Anthropic-native tool
+// flags promoted onto ResponsesTool (defer_loading, allowed_callers,
+// input_examples, eager_input_streaming) survive a full Marshal→Unmarshal→
+// Marshal cycle. Before MarshalJSON/UnmarshalJSON were taught to handle these
+// keys, all four were silently dropped at the JSON boundary.
+func TestResponsesTool_RoundTrip_AnthropicFields(t *testing.T) {
+	original := ResponsesTool{
+		Type:                ResponsesToolTypeFunction,
+		Name:                Ptr("lookup"),
+		Description:         Ptr("lookup something"),
+		DeferLoading:        Ptr(true),
+		AllowedCallers:      []string{"direct", "agent"},
+		EagerInputStreaming: Ptr(false),
+		InputExamples: []ChatToolInputExample{
+			{Input: json.RawMessage(`{"q":"hello"}`), Description: Ptr("basic")},
+			{Input: json.RawMessage(`{"q":"world"}`)},
+		},
+		ResponsesToolFunction: &ResponsesToolFunction{
+			Parameters: &ToolFunctionParameters{},
+		},
+	}
+
+	data, err := Marshal(original)
+	require.NoError(t, err)
+
+	// All four keys must appear in the wire bytes.
+	for _, key := range []string{`"defer_loading"`, `"allowed_callers"`, `"input_examples"`, `"eager_input_streaming"`} {
+		assert.Contains(t, string(data), key,
+			"%s must be emitted by MarshalJSON — otherwise it is silently dropped", key)
+	}
+
+	var decoded ResponsesTool
+	require.NoError(t, Unmarshal(data, &decoded))
+
+	require.NotNil(t, decoded.DeferLoading)
+	assert.True(t, *decoded.DeferLoading)
+	assert.Equal(t, []string{"direct", "agent"}, decoded.AllowedCallers)
+	require.NotNil(t, decoded.EagerInputStreaming)
+	assert.False(t, *decoded.EagerInputStreaming)
+	require.Len(t, decoded.InputExamples, 2)
+	assert.JSONEq(t, `{"q":"hello"}`, string(decoded.InputExamples[0].Input))
+	require.NotNil(t, decoded.InputExamples[0].Description)
+	assert.Equal(t, "basic", *decoded.InputExamples[0].Description)
+	assert.JSONEq(t, `{"q":"world"}`, string(decoded.InputExamples[1].Input))
+
+	// Second-round marshal must be byte-stable.
+	data2, err := Marshal(decoded)
+	require.NoError(t, err)
+	assert.Equal(t, string(data), string(data2), "round-trip must be stable")
+}
+
+// TestChatTool_MarshalJSON_EnforcesUnion verifies that the custom codec
+// canonicalizes mixed-state ChatTools on the wire, regardless of what the
+// caller populated in memory. Exactly one variant's fields survive marshal —
+// matching Type — so downstream provider converters can't misinterpret or
+// forward stray fields from a different shape.
+func TestChatTool_MarshalJSON_EnforcesUnion(t *testing.T) {
+	t.Run("function_type_clears_custom_and_server_tool_fields", func(t *testing.T) {
+		tool := ChatTool{
+			Type:     ChatToolTypeFunction,
+			Function: &ChatToolFunction{Name: "get_weather"},
+			// Mixed state: server-tool + custom fields also populated.
+			Custom:        &ChatToolCustom{},
+			Name:          "leaked_name",
+			MaxUses:       Ptr(5),
+			DisplayWidthPx: Ptr(1280),
+			MCPServerName: "leaked_server",
+		}
+		data, err := Marshal(tool)
+		require.NoError(t, err)
+		raw := string(data)
+
+		assert.Contains(t, raw, `"type":"function"`)
+		assert.Contains(t, raw, `"get_weather"`)
+		for _, leak := range []string{`"custom"`, `"leaked_name"`, `"max_uses"`, `"display_width_px"`, `"mcp_server_name"`} {
+			assert.NotContains(t, raw, leak, "function-type wire must not carry %s", leak)
+		}
+	})
+
+	t.Run("custom_type_clears_function_and_server_tool_fields", func(t *testing.T) {
+		tool := ChatTool{
+			Type:   ChatToolTypeCustom,
+			Custom: &ChatToolCustom{Format: &ChatToolCustomFormat{Type: "text"}},
+			Name:   "my_custom",
+			// Leaks
+			Function: &ChatToolFunction{Name: "should_be_stripped"},
+			MaxUses:  Ptr(5),
+		}
+		data, err := Marshal(tool)
+		require.NoError(t, err)
+		raw := string(data)
+
+		assert.Contains(t, raw, `"type":"custom"`)
+		assert.Contains(t, raw, `"my_custom"`)    // custom tool retains top-level Name
+		assert.Contains(t, raw, `"format"`)       // custom's format field
+		assert.NotContains(t, raw, `"function"`)
+		assert.NotContains(t, raw, `"should_be_stripped"`)
+		assert.NotContains(t, raw, `"max_uses"`)
+	})
+
+	t.Run("server_tool_type_clears_function_and_custom", func(t *testing.T) {
+		tool := ChatTool{
+			Type:    "web_search_20260209",
+			Name:    "web_search",
+			MaxUses: Ptr(5),
+			AllowedCallers: []string{"direct"},
+			// Leaks
+			Function: &ChatToolFunction{Name: "should_be_stripped"},
+			Custom:   &ChatToolCustom{},
+		}
+		data, err := Marshal(tool)
+		require.NoError(t, err)
+		raw := string(data)
+
+		assert.Contains(t, raw, `"type":"web_search_20260209"`)
+		assert.Contains(t, raw, `"web_search"`)
+		assert.Contains(t, raw, `"max_uses":5`)
+		assert.Contains(t, raw, `"allowed_callers":["direct"]`)
+		assert.NotContains(t, raw, `"function"`)
+		assert.NotContains(t, raw, `"custom"`)
+		assert.NotContains(t, raw, `"should_be_stripped"`)
+	})
+}
+
+// TestChatTool_UnmarshalJSON_NormalizesMixedInput verifies that tolerant
+// decode of a mixed-shape payload produces a canonical single-variant struct
+// so downstream provider conversion code doesn't have to defend against
+// the untrusted shape.
+func TestChatTool_UnmarshalJSON_NormalizesMixedInput(t *testing.T) {
+	t.Run("function_type_mixed_with_server_fields_normalizes", func(t *testing.T) {
+		// Caller sends a function tool but also includes server-tool metadata.
+		raw := []byte(`{
+			"type":"function",
+			"function":{"name":"get_weather"},
+			"name":"stray_server_name",
+			"max_uses":5,
+			"display_width_px":1280
+		}`)
+		var tool ChatTool
+		require.NoError(t, Unmarshal(raw, &tool))
+
+		assert.Equal(t, ChatToolTypeFunction, tool.Type)
+		require.NotNil(t, tool.Function)
+		assert.Equal(t, "get_weather", tool.Function.Name)
+		assert.Empty(t, tool.Name, "function-type must nil top-level Name (lives in Function.Name)")
+		assert.Nil(t, tool.MaxUses)
+		assert.Nil(t, tool.DisplayWidthPx)
+	})
+
+	t.Run("server_tool_type_mixed_with_function_normalizes", func(t *testing.T) {
+		// Caller sends a server-tool but also includes function.
+		raw := []byte(`{
+			"type":"web_search_20260209",
+			"name":"web_search",
+			"max_uses":5,
+			"function":{"name":"stray"}
+		}`)
+		var tool ChatTool
+		require.NoError(t, Unmarshal(raw, &tool))
+
+		assert.Equal(t, ChatToolType("web_search_20260209"), tool.Type)
+		assert.Equal(t, "web_search", tool.Name)
+		require.NotNil(t, tool.MaxUses)
+		assert.Equal(t, 5, *tool.MaxUses)
+		assert.Nil(t, tool.Function, "server-tool must nil Function")
+		assert.Nil(t, tool.Custom, "server-tool must nil Custom")
+	})
+}
+
+// TestChatTool_RoundTrip_SurvivesMixedInput verifies that a mixed-input
+// payload, once canonicalized by Unmarshal and re-emitted by Marshal, drops
+// the stray fields and produces a deterministic single-variant wire format.
+func TestChatTool_RoundTrip_SurvivesMixedInput(t *testing.T) {
+	raw := []byte(`{
+		"type":"web_search_20260209",
+		"name":"web_search",
+		"max_uses":5,
+		"function":{"name":"stray"},
+		"custom":{"format":{"type":"text"}}
+	}`)
+	var tool ChatTool
+	require.NoError(t, Unmarshal(raw, &tool))
+
+	out, err := Marshal(tool)
+	require.NoError(t, err)
+	outStr := string(out)
+	assert.NotContains(t, outStr, `"function"`)
+	assert.NotContains(t, outStr, `"custom"`)
+	assert.Contains(t, outStr, `"web_search_20260209"`)
+
+	// Second pass must be byte-stable (critical for prompt caching keys).
+	var tool2 ChatTool
+	require.NoError(t, Unmarshal(out, &tool2))
+	out2, err := Marshal(tool2)
+	require.NoError(t, err)
+	assert.Equal(t, string(out), string(out2), "round-trip must be stable")
+}
+
 func TestToolFunctionParameters_ExplicitEmptyObjectPreserved(t *testing.T) {
 	var params ToolFunctionParameters
 	err := Unmarshal([]byte(`{}`), &params)


### PR DESCRIPTION
## Summary

Promotes Anthropic-native parameters to the neutral ChatParameters layer, enabling direct access to advanced Anthropic features like containers, MCP servers, task budgets, and enhanced tool configurations without requiring ExtraParams.

## Changes

- Added neutral fields to `ChatParameters` for Anthropic-specific features: `TopK`, `Speed`, `InferenceGeo`, `MCPServers`, `Container`, `CacheControl`, `TaskBudget`, and `ContextManagement`
- Enhanced `ChatTool` with Anthropic tool flags: `DeferLoading`, `AllowedCallers`, `InputExamples`, and `EagerInputStreaming`
- Added `Display` field to `ChatReasoning` for Anthropic adaptive thinking control
- Implemented `StripUnsupportedAnthropicFields` function to remove unsupported features based on provider capabilities
- Updated parameter mapping logic to prefer neutral fields over ExtraParams with fallback support
- Added comprehensive JSON marshaling/unmarshaling for union types like `ChatContainer`

The design maintains backward compatibility by falling back to ExtraParams when neutral fields are not set, while providing type-safe access to advanced Anthropic features.

## Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate the new parameter handling and provider feature gating:

```sh
# Core/Transports
go version
go test ./...

# Test Anthropic provider parameter mapping
go test ./core/providers/anthropic/...

# Verify schema validation
go test ./core/schemas/...
```

Test with requests containing the new neutral fields to ensure proper mapping to Anthropic API format and appropriate stripping for unsupported providers.

## Screenshots/Recordings

N/A - Backend API changes only.

## Breaking changes

- [ ] Yes
- [x] No

This change is fully backward compatible. Existing ExtraParams usage continues to work, while new neutral fields provide enhanced type safety.

## Related issues

N/A

## Security considerations

The new MCP server configuration includes authorization tokens. Ensure proper handling of sensitive credentials in the `ChatMCPServer.AuthorizationToken` field.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable