### PR TITLE
fix(mcp): per_user_oauth clients now send Authorization header to backend

### DIFF
--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -68,9 +68,10 @@ const (
 type MCPAuthType string
 
 const (
-	MCPAuthTypeNone    MCPAuthType = "none"    // No authentication
-	MCPAuthTypeHeaders MCPAuthType = "headers" // Header-based authentication (API keys, etc.)
-	MCPAuthTypeOauth   MCPAuthType = "oauth"   // OAuth 2.0 authentication
+	MCPAuthTypeNone         MCPAuthType = "none"            // No authentication
+	MCPAuthTypeHeaders      MCPAuthType = "headers"         // Header-based authentication (API keys, etc.)
+	MCPAuthTypeOauth        MCPAuthType = "oauth"           // OAuth 2.0 authentication
+	MCPAuthTypePerUserOauth MCPAuthType = "per_user_oauth" // Per-user OAuth 2.1 authentication
 )
 
 // MCPClientConfig defines tool filtering for an MCP client.
@@ -81,7 +82,7 @@ type MCPClientConfig struct {
 	ConnectionType   MCPConnectionType `json:"connection_type"`             // How to connect (HTTP, STDIO, SSE, or InProcess)
 	ConnectionString *EnvVar           `json:"connection_string,omitempty"` // HTTP or SSE URL (required for HTTP or SSE connections)
 	StdioConfig      *MCPStdioConfig   `json:"stdio_config,omitempty"`      // STDIO configuration (required for STDIO connections)
-	AuthType         MCPAuthType       `json:"auth_type"`                   // Authentication type (none, headers, or oauth)
+	AuthType         MCPAuthType       `json:"auth_type"`                   // Authentication type (none, headers, oauth, or per_user_oauth)
 	OauthConfigID    *string           `json:"oauth_config_id,omitempty"`   // OAuth config ID (references oauth_configs table)
 	State            string            `json:"state,omitempty"`             // Connection state (connected, disconnected, error)
 	Headers          map[string]EnvVar `json:"headers,omitempty"`           // Headers to send with the request (for headers auth type)
@@ -123,7 +124,7 @@ func (c *MCPClientConfig) HttpHeaders(ctx context.Context, oauth2Provider OAuth2
 	headers := make(map[string]string)
 
 	switch c.AuthType {
-	case MCPAuthTypeOauth:
+	case MCPAuthTypeOauth, MCPAuthTypePerUserOauth:
 		if c.OauthConfigID == nil {
 			return nil, ErrOAuth2ConfigNotFound
 		}

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -28,7 +28,7 @@ type TableMCPClient struct {
 	ToolSyncInterval       int             `gorm:"default:0" json:"tool_sync_interval"`             // Per-client tool sync interval in minutes (0 = use global, -1 = disabled)
 
 	// OAuth authentication fields
-	AuthType      string            `gorm:"type:varchar(20);default:'headers'" json:"auth_type"`                         // "none", "headers", "oauth"
+	AuthType      string            `gorm:"type:varchar(20);default:'headers'" json:"auth_type"`                         // "none", "headers", "oauth", "per_user_oauth"
 	OauthConfigID *string           `gorm:"type:varchar(255);index;constraint:OnDelete:CASCADE" json:"oauth_config_id"`  // Foreign key to oauth_configs.ID with CASCADE delete
 	OauthConfig   *TableOauthConfig `gorm:"foreignKey:OauthConfigID;references:ID;constraint:OnDelete:CASCADE" json:"-"` // Gorm relationship
 

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -316,7 +316,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Check if OAuth flow is needed
-	if req.AuthType == "oauth" {
+	if req.AuthType == "oauth" || req.AuthType == "per_user_oauth" {
 		if req.OauthConfig == nil {
 			SendError(ctx, fasthttp.StatusBadRequest, "OAuth configuration is required when auth_type is 'oauth'")
 			return


### PR DESCRIPTION
per_user_oauth was listed in the JSON schema as a valid auth_type but was missing from the Go MCPAuthType enum and the HttpHeaders() switch. It fell through to the default case, which only used static headers and never fetched the OAuth token via oauth2Provider.GetAccessToken().

Added MCPAuthTypePerUserOauth = "per_user_oauth" and merged its handling into the existing MCPAuthTypeOauth case so both auth types fetch and attach the Bearer token the same way.

Fixes #2806