### PR TITLE
temp hack for tests

### DIFF
--- a/.github/workflows/scripts/setup-go-workspace.sh
+++ b/.github/workflows/scripts/setup-go-workspace.sh
@@ -18,6 +18,9 @@ if [ -f "go.work" ]; then
   return 0 2>/dev/null || exit 0
 fi
 go work init
+# Bump workspace go directive so GOTOOLCHAIN=auto switches to >= 1.26.2
+# (required by published core@v1.4.19 which is referenced from transports/go.mod).
+go work edit -go=1.26.2 -toolchain=go1.26.2
 go work use ./core
 go work use ./framework
 go work use ./plugins/governance


### PR DESCRIPTION
## Summary

The Go workspace setup script was not specifying a `go` directive or toolchain version, which caused `GOTOOLCHAIN=auto` to select a Go version lower than what `core@v1.4.19` requires. This adds an explicit `go 1.26.2` and `toolchain go1.26.2` directive to the workspace so the correct toolchain is used automatically.

## Changes

- Added `go work edit -go=1.26.2 -toolchain=go1.26.2` to `setup-go-workspace.sh` so that `GOTOOLCHAIN=auto` selects Go >= 1.26.2, satisfying the minimum version required by the published `core@v1.4.19` module referenced in `transports/go.mod`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Verify the workspace is initialized with the correct Go version
bash .github/workflows/scripts/setup-go-workspace.sh
grep -E "^go |^toolchain" go.work
# Expected output:
# go 1.26.2
# toolchain go1.26.2

go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable