### PR TITLE
removed docker build steps

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -637,224 +637,6 @@ jobs:
             tests/e2e/playwright-report/
           retention-days: 30
 
-  # # Docker image test - amd64
-  # test-docker-image-amd64:
-  #   needs: [check-skip, detect-changes]
-  #   if: needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true'
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #   steps:
-  #     - name: Harden Runner
-  #       uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-  #       with:
-  #         egress-policy: block
-  #         allowed-endpoints: >
-  #           api.anthropic.com:443
-  #           api.cerebras.ai:443
-  #           api.cohere.ai:443
-  #           api.elevenlabs.io:443
-  #           api.github.com:443
-  #           api.groq.com:443
-  #           api.mistral.ai:443
-  #           api.openai.com:443
-  #           api.parasail.io:443
-  #           api.replicate.com:443
-  #           auth.docker.io:443
-  #           bedrock.us-east-1.amazonaws.com:443
-  #           dl-cdn.alpinelinux.org:443
-  #           fonts.googleapis.com:443
-  #           fonts.gstatic.com:443
-  #           generativelanguage.googleapis.com:443
-  #           getbifrost.ai:443
-  #           ghcr.io:443
-  #           github.com:443
-  #           huggingface.co:443
-  #           maxim-o1.openai.azure.com:443
-  #           nodejs.org:443
-  #           openrouter.ai:443
-  #           pkg-containers.githubusercontent.com:443
-  #           production.cloudflare.docker.com:443
-  #           proxy.golang.org:443
-  #           registry-1.docker.io:443
-  #           registry.npmjs.org:443
-  #           release-assets.githubusercontent.com:443
-  #           storage.googleapis.com:443
-  #           sum.golang.org:443
-  #           telemetry.qdrant.io:443
-  #           www.getbifrost.ai:443
-
-  #     - name: Checkout repository
-  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-  #       with:
-  #         fetch-depth: 0
-  #         fetch-tags: true
-
-  #     - name: Set up Go
-  #       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-  #       with:
-  #         go-version: "1.26.1"
-
-  #     - name: Set up Node.js
-  #       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-  #       with:
-  #         node-version: "25"
-
-  #     - name: Install Newman
-  #       run: npm install -g newman newman-reporter-html
-
-  #     - name: Setup Docker Buildx
-  #       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-  #     - name: Test Docker image (amd64)
-  #       env:
-  #         CI: "1"
-  #         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-  #         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-  #         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-  #         VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
-  #         VERTEX_CREDENTIALS: ${{ secrets.VERTEX_CREDENTIALS }}
-  #         GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
-  #         MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
-  #         COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
-  #         GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-  #         PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
-  #         CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
-  #         OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-  #         PARASAIL_API_KEY: ${{ secrets.PARASAIL_API_KEY }}
-  #         ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
-  #         FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
-  #         HUGGING_FACE_API_KEY: ${{ secrets.HUGGING_FACE_API_KEY }}
-  #         XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-  #         REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
-  #         AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
-  #         AZURE_ENDPOINT: ${{ secrets.AZURE_ENDPOINT }}
-  #         AZURE_API_VERSION: ${{ secrets.AZURE_API_VERSION }}
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_REGION: ${{ secrets.AWS_REGION }}
-  #         AWS_ARN: ${{ secrets.AWS_ARN }}
-  #       run: |
-  #         chmod +x ./.github/workflows/scripts/test-docker-image.sh
-  #         ./.github/workflows/scripts/test-docker-image.sh linux/amd64
-
-  #     - name: Upload Newman reports
-  #       if: ${{ !cancelled() }}
-  #       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-  #       with:
-  #         name: newman-reports-amd64
-  #         path: tests/e2e/api/newman-reports/
-  #         retention-days: 30
-
-  # # Docker image test - arm64
-  # test-docker-image-arm64:
-  #   needs: [check-skip, detect-changes]
-  #   if: needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true'
-  #   runs-on: ubuntu-24.04-arm
-  #   permissions:
-  #     contents: read
-  #   steps:
-  #     - name: Harden Runner
-  #       uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
-  #       with:
-  #         egress-policy: block
-  #         allowed-endpoints: >
-  #           api.anthropic.com:443
-  #           api.cerebras.ai:443
-  #           api.cohere.ai:443
-  #           api.elevenlabs.io:443
-  #           api.github.com:443
-  #           api.groq.com:443
-  #           api.mistral.ai:443
-  #           api.openai.com:443
-  #           api.parasail.io:443
-  #           api.replicate.com:443
-  #           auth.docker.io:443
-  #           bedrock.us-east-1.amazonaws.com:443
-  #           dl-cdn.alpinelinux.org:443
-  #           fonts.googleapis.com:443
-  #           fonts.gstatic.com:443
-  #           generativelanguage.googleapis.com:443
-  #           getbifrost.ai:443
-  #           ghcr.io:443
-  #           github.com:443
-  #           huggingface.co:443
-  #           maxim-o1.openai.azure.com:443
-  #           nodejs.org:443
-  #           openrouter.ai:443
-  #           pkg-containers.githubusercontent.com:443
-  #           production.cloudflare.docker.com:443
-  #           proxy.golang.org:443
-  #           registry-1.docker.io:443
-  #           registry.npmjs.org:443
-  #           release-assets.githubusercontent.com:443
-  #           storage.googleapis.com:443
-  #           sum.golang.org:443
-  #           telemetry.qdrant.io:443
-  #           www.getbifrost.ai:443
-
-  #     - name: Checkout repository
-  #       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-  #       with:
-  #         fetch-depth: 0
-  #         fetch-tags: true
-
-  #     - name: Set up Go
-  #       uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
-  #       with:
-  #         go-version: "1.26.1"
-
-  #     - name: Set up Node.js
-  #       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-  #       with:
-  #         node-version: "25"
-
-  #     - name: Install Newman
-  #       run: npm install -g newman newman-reporter-html
-
-  #     - name: Setup Docker Buildx
-  #       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-  #     - name: Test Docker image (arm64)
-  #       env:
-  #         CI: "1"
-  #         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-  #         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-  #         GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-  #         VERTEX_PROJECT_ID: ${{ secrets.VERTEX_PROJECT_ID }}
-  #         VERTEX_CREDENTIALS: ${{ secrets.VERTEX_CREDENTIALS }}
-  #         GOOGLE_LOCATION: ${{ secrets.GOOGLE_LOCATION }}
-  #         MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
-  #         COHERE_API_KEY: ${{ secrets.COHERE_API_KEY }}
-  #         GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-  #         PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
-  #         CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
-  #         OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-  #         PARASAIL_API_KEY: ${{ secrets.PARASAIL_API_KEY }}
-  #         ELEVENLABS_API_KEY: ${{ secrets.ELEVENLABS_API_KEY }}
-  #         FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
-  #         HUGGING_FACE_API_KEY: ${{ secrets.HUGGING_FACE_API_KEY }}
-  #         XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-  #         REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
-  #         AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
-  #         AZURE_ENDPOINT: ${{ secrets.AZURE_ENDPOINT }}
-  #         AZURE_API_VERSION: ${{ secrets.AZURE_API_VERSION }}
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         AWS_REGION: ${{ secrets.AWS_REGION }}
-  #         AWS_ARN: ${{ secrets.AWS_ARN }}
-  #       run: |
-  #         chmod +x ./.github/workflows/scripts/test-docker-image.sh
-  #         ./.github/workflows/scripts/test-docker-image.sh linux/arm64
-
-  #     - name: Upload Newman reports
-  #       if: ${{ !cancelled() }}
-  #       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-  #       with:
-  #         name: newman-reports-arm64
-  #         path: tests/e2e/api/newman-reports/
-  #         retention-days: 30
-
   core-release:
     needs:
       [
@@ -866,10 +648,8 @@ jobs:
         test-plugins,
         test-bifrost-http,
         test-migrations,
-        test-docker-image-amd64,
-        test-docker-image-arm64,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.core-needs-release == 'true' && (needs.test-core.result == 'success' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.core-needs-release == 'true' && (needs.test-core.result == 'success' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -961,11 +741,9 @@ jobs:
         test-plugins,
         test-bifrost-http,
         test-migrations,
-        test-docker-image-amd64,
-        test-docker-image-arm64,
         core-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.framework-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && needs.test-framework.result == 'success' && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.framework-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && needs.test-framework.result == 'success' && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1067,12 +845,10 @@ jobs:
         test-plugins,
         test-bifrost-http,
         test-migrations,
-        test-docker-image-amd64,
-        test-docker-image-arm64,
         core-release,
         framework-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.plugins-need-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && needs.test-plugins.result == 'success' && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.plugins-need-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && needs.test-plugins.result == 'success' && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped')  && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1192,13 +968,11 @@ jobs:
         test-plugins,
         test-bifrost-http,
         test-migrations,
-        test-docker-image-amd64,
-        test-docker-image-arm64,
         core-release,
         framework-release,
         plugins-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && needs.test-bifrost-http.result == 'success' && needs.test-migrations.result == 'success' && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.bifrost-http-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && needs.test-bifrost-http.result == 'success' && needs.test-migrations.result == 'success'  && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1450,14 +1224,12 @@ jobs:
         test-plugins,
         test-bifrost-http,
         test-migrations,
-        test-docker-image-amd64,
-        test-docker-image-arm64,
         core-release,
         framework-release,
         plugins-release,
         bifrost-http-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1537,14 +1309,12 @@ jobs:
         test-plugins,
         test-bifrost-http,
         test-migrations,
-        test-docker-image-amd64,
-        test-docker-image-arm64,
         core-release,
         framework-release,
         plugins-release,
         bifrost-http-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
@@ -1657,14 +1427,12 @@ jobs:
         test-plugins,
         test-bifrost-http,
         test-migrations,
-        test-docker-image-amd64,
-        test-docker-image-arm64,
         core-release,
         framework-release,
         plugins-release,
         bifrost-http-release,
       ]
-    if: "always() && needs.check-skip.outputs.should-skip != 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1698,8 +1466,6 @@ jobs:
         test-plugins,
         test-bifrost-http,
         test-migrations,
-        test-docker-image-amd64,
-        test-docker-image-arm64,
         core-release,
         framework-release,
         plugins-release,


### PR DESCRIPTION
## Summary

The `test-docker-image-amd64` and `test-docker-image-arm64` CI jobs have been removed from the release pipeline. These jobs were already commented out and non-functional, and all references to them as dependencies and gate conditions in downstream release jobs have been cleaned up.

## Changes

- Deleted the commented-out `test-docker-image-amd64` and `test-docker-image-arm64` job definitions from the release pipeline.
- Removed `test-docker-image-amd64` and `test-docker-image-arm64` from the `needs` arrays of `core-release`, `framework-release`, `plugins-release`, `bifrost-http-release`, the Docker build/push jobs, the manifest job, and the final notification job.
- Removed the corresponding result checks for those two jobs from all `if` conditions in the affected release jobs.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Trigger the release pipeline and confirm that all release jobs proceed without waiting on or referencing the removed Docker image test jobs.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable