### PR TITLE
revert to old schema

### DIFF
--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -10,12 +10,6 @@
       "description": "The schema version. This should be set to \"https://www.getbifrost.ai/schema\"",
       "const": "https://www.getbifrost.ai/schema"
     },
-    "version": {
-      "type": "integer",
-      "description": "Controls how empty arrays in allow-list fields (models, allowed_models, key_ids, tools_to_execute) are interpreted. Omit or set to 2 for v1.5.0+ semantics: empty = deny all, [\"*\"] = allow all. Set to 1 to restore v1.4.x semantics: empty = allow all.",
-      "enum": [1, 2],
-      "default": 2
-    },
     "encryption_key": {
       "type": "string",
       "description": "You can set the value as env.<ENV_VAR_NAME> to use an environment variable. We also read encryption key from BIFROST_ENCRYPTION_KEY environment variable. Note: once set, the encryption key cannot be changed unless you clean up the database. Accepts any string; a secure 32-byte AES-256 key will be derived using Argon2id KDF. If not provided, data will be saved in plain text. Recommended: use a passphrase of at least 16 bytes for better security"
@@ -100,29 +94,9 @@
           "minimum": 1,
           "description": "Maximum request body size in MB"
         },
-        "compat": {
-          "type": "object",
-          "description": "Compat plugin configuration for request type conversion, parameter dropping, and parameter value conversion",
-          "properties": {
-            "convert_text_to_chat": {
-              "type": "boolean",
-              "description": "Convert text completion requests to chat for models that only support chat"
-            },
-            "convert_chat_to_responses": {
-              "type": "boolean",
-              "description": "Convert chat completion requests to responses for models that only support responses"
-            },
-            "should_drop_params": {
-              "type": "boolean",
-              "description": "Drop unsupported parameters based on model catalog allowlist"
-            },
-            "should_convert_params": {
-              "type": "boolean",
-              "description": "Converts model parameter values that are not supported by the model.",
-              "default": false
-            }
-          },
-          "additionalProperties": false
+        "enable_litellm_fallbacks": {
+          "type": "boolean",
+          "description": "Enable litellm-specific fallbacks for text completion for Groq"
         },
         "header_filter_config": {
           "type": "object",
@@ -206,17 +180,6 @@
           "minimum": 0,
           "description": "Global tool sync interval in minutes (0 = disabled)",
           "default": 10
-        },
-        "mcp_disable_auto_tool_inject": {
-          "type": "boolean",
-          "description": "When true, MCP tools are not automatically injected into requests. Tools are only included when explicitly specified via request context filters or headers, such as x-bf-mcp-include-tools or x-bf-mcp-include-clients.",
-          "default": false
-        },
-        "routing_chain_max_depth": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Maximum depth for routing rule chain evaluation",
-          "default": 10
         }
       },
       "additionalProperties": false
@@ -256,7 +219,7 @@
           "$ref": "#/$defs/provider"
         },
         "ollama": {
-          "$ref": "#/$defs/provider_with_ollama_config"
+          "$ref": "#/$defs/provider"
         },
         "groq": {
           "$ref": "#/$defs/provider"
@@ -268,7 +231,7 @@
           "$ref": "#/$defs/provider"
         },
         "sgl": {
-          "$ref": "#/$defs/provider_with_sgl_config"
+          "$ref": "#/$defs/provider"
         },
         "parasail": {
           "$ref": "#/$defs/provider"
@@ -277,7 +240,7 @@
           "$ref": "#/$defs/provider"
         },
         "replicate": {
-          "$ref": "#/$defs/provider_with_replicate_config"
+          "$ref": "#/$defs/provider"
         },
         "elevenlabs": {
           "$ref": "#/$defs/provider"
@@ -292,15 +255,6 @@
           "$ref": "#/$defs/provider"
         },
         "fireworks": {
-          "$ref": "#/$defs/provider"
-        },
-        "nebius": {
-          "$ref": "#/$defs/provider"
-        },
-        "xai": {
-          "$ref": "#/$defs/provider"
-        },
-        "runway": {
           "$ref": "#/$defs/provider"
         }
       },
@@ -338,16 +292,17 @@
                 "format": "date-time",
                 "description": "Last time budget was reset"
               },
-              "virtual_key_id": {
-                "type": "string",
-                "description": "ID of the virtual key this budget belongs to (mutually exclusive with provider_config_id)"
-              },
-              "provider_config_id": {
-                "type": "integer",
-                "description": "ID of the provider config this budget belongs to (mutually exclusive with virtual_key_id)"
+              "calendar_aligned": {
+                "type": "boolean",
+                "description": "Snap resets to calendar boundaries (day/week/month/year start)",
+                "default": false
               }
             },
-            "required": ["id", "max_limit", "reset_duration"],
+            "required": [
+              "id",
+              "max_limit",
+              "reset_duration"
+            ],
             "additionalProperties": false
           }
         },
@@ -398,7 +353,9 @@
                 "description": "Last time request counter was reset"
               }
             },
-            "required": ["id"],
+            "required": [
+              "id"
+            ],
             "additionalProperties": false
           }
         },
@@ -425,7 +382,10 @@
                 "description": "Associated rate limit ID"
               }
             },
-            "required": ["id", "name"],
+            "required": [
+              "id",
+              "name"
+            ],
             "additionalProperties": false
           }
         },
@@ -468,7 +428,10 @@
                 "description": "Team claims data"
               }
             },
-            "required": ["id", "name"],
+            "required": [
+              "id",
+              "name"
+            ],
             "additionalProperties": false
           }
         },
@@ -499,11 +462,6 @@
                 "description": "Whether the virtual key is active",
                 "default": true
               },
-              "calendar_aligned": {
-                "type": "boolean",
-                "description": "Snap all budget resets to calendar boundaries (day, week, month, year)",
-                "default": false
-              },
               "team_id": {
                 "type": "string",
                 "description": "Associated team ID (mutually exclusive with customer_id)"
@@ -512,26 +470,33 @@
                 "type": "string",
                 "description": "Associated customer ID (mutually exclusive with team_id)"
               },
+              "budget_id": {
+                "type": "string",
+                "description": "Associated budget ID"
+              },
               "rate_limit_id": {
                 "type": "string",
                 "description": "Associated rate limit ID"
               },
               "provider_configs": {
                 "type": "array",
-                "description": "Provider configurations for this virtual key (empty means no providers allowed, deny-by-default)",
+                "description": "Provider configurations for this virtual key (empty means all providers allowed)",
                 "items": {
                   "$ref": "#/$defs/virtual_key_provider_config"
                 }
               },
               "mcp_configs": {
                 "type": "array",
-                "description": "MCP configurations for this virtual key (empty array means no MCP tools allowed, deny-by-default)",
+                "description": "MCP configurations for this virtual key",
                 "items": {
                   "$ref": "#/$defs/virtual_key_mcp_config"
                 }
               }
             },
-            "required": ["id", "name"],
+            "required": [
+              "id",
+              "name"
+            ],
             "additionalProperties": false
           }
         },
@@ -540,13 +505,6 @@
           "description": "Routing rules for dynamic provider/model selection based on CEL expressions",
           "items": {
             "$ref": "#/$defs/routing_rule"
-          }
-        },
-        "pricing_overrides": {
-          "type": "array",
-          "description": "Scoped pricing overrides applied at runtime by the model catalog",
-          "items": {
-            "$ref": "#/$defs/provider_pricing_override"
           }
         },
         "auth_config": {
@@ -579,7 +537,10 @@
                 "description": "Rate limit ID to associate with this model"
               }
             },
-            "required": ["id", "model_name"],
+            "required": [
+              "id",
+              "model_name"
+            ],
             "additionalProperties": false
           }
         },
@@ -589,17 +550,9 @@
           "items": {
             "type": "object",
             "properties": {
-              "id": {
-                "type": "string",
-                "description": "Provider row ID"
-              },
               "name": {
                 "type": "string",
                 "description": "Provider name"
-              },
-              "description": {
-                "type": "string",
-                "description": "Operator-facing provider description"
               },
               "budget_id": {
                 "type": "string",
@@ -620,21 +573,6 @@
               "store_raw_request_response": {
                 "type": "boolean",
                 "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
-              },
-              "network_config": {
-                "$ref": "#/$defs/network_config"
-              },
-              "proxy_config": {
-                "$ref": "#/$defs/proxy_config"
-              },
-              "custom_provider_config": {
-                "$ref": "#/$defs/custom_provider_config"
-              },
-              "concurrency_and_buffer_size": {
-                "$ref": "#/$defs/concurrency_and_buffer_size"
-              },
-              "openai_config": {
-                "$ref": "#/$defs/openai_config"
               }
             },
             "required": ["name"]
@@ -674,7 +612,12 @@
         },
         "type": {
           "type": "string",
-          "enum": ["weaviate", "redis", "qdrant", "pinecone"],
+          "enum": [
+            "weaviate",
+            "redis",
+            "qdrant",
+            "pinecone"
+          ],
           "description": "Vector store type (use \"redis\" for Redis or Valkey-compatible endpoints)"
         },
         "config": {
@@ -742,7 +685,10 @@
         },
         "type": {
           "type": "string",
-          "enum": ["sqlite", "postgres"],
+          "enum": [
+            "sqlite",
+            "postgres"
+          ],
           "description": "Configuration store type"
         },
         "config": {
@@ -763,7 +709,9 @@
                     "description": "Database file path"
                   }
                 },
-                "required": ["path"],
+                "required": [
+                  "path"
+                ],
                 "additionalProperties": false
               }
             },
@@ -815,7 +763,14 @@
                     "default": 50
                   }
                 },
-                "required": ["host", "port", "user", "password", "db_name", "ssl_mode"],
+                "required": [
+                  "host",
+                  "port",
+                  "user",
+                  "password",
+                  "db_name",
+                  "ssl_mode"
+                ],
                 "additionalProperties": false
               }
             }
@@ -834,7 +789,10 @@
         },
         "type": {
           "type": "string",
-          "enum": ["sqlite", "postgres"],
+          "enum": [
+            "sqlite",
+            "postgres"
+          ],
           "description": "Logs store type"
         },
         "config": {
@@ -855,7 +813,9 @@
                     "description": "Database file path"
                   }
                 },
-                "required": ["path"],
+                "required": [
+                  "path"
+                ],
                 "additionalProperties": false
               }
             },
@@ -906,124 +866,43 @@
                     "default": 50
                   }
                 },
-                "required": ["host", "port", "user", "password", "db_name", "ssl_mode"],
+                "required": [
+                  "host",
+                  "port",
+                  "user",
+                  "password",
+                  "db_name",
+                  "ssl_mode"
+                ],
                 "additionalProperties": false
               }
             }
           ]
-        },
-        "object_storage": {
-          "type": "object",
-          "description": "Optional object storage for offloading log payloads. When configured, large request/response payloads are stored in S3/GCS while the DB keeps only lightweight index data.",
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": ["s3", "gcs"],
-              "description": "Object storage backend type"
-            },
-            "bucket": {
-              "type": "string",
-              "minLength": 1,
-              "description": "Bucket name. Supports env var reference (e.g. env.S3_BUCKET)"
-            },
-            "prefix": {
-              "type": "string",
-              "description": "Key prefix for stored objects (default: bifrost)",
-              "default": "bifrost"
-            },
-            "compress": {
-              "type": "boolean",
-              "description": "Enable gzip compression for stored objects. Default: false",
-              "default": false
-            }
-          },
-          "required": ["type", "bucket"],
-          "if": {
-            "properties": {
-              "type": {
-                "const": "s3"
-              }
-            }
-          },
-          "then": {
-            "properties": {
-              "type": true,
-              "bucket": true,
-              "prefix": true,
-              "region": {
-                "type": "string",
-                "description": "AWS region. Supports env var reference"
-              },
-              "endpoint": {
-                "type": "string",
-                "description": "Custom S3-compatible endpoint for MinIO/R2. Supports env var reference"
-              },
-              "access_key_id": {
-                "type": "string",
-                "description": "AWS access key ID. Omit to use default credential chain (instance role, env vars, etc.). Supports env var reference"
-              },
-              "secret_access_key": {
-                "type": "string",
-                "description": "AWS secret access key. Supports env var reference"
-              },
-              "session_token": {
-                "type": "string",
-                "description": "AWS session token for STS temporary credentials. Supports env var reference"
-              },
-              "role_arn": {
-                "type": "string",
-                "description": "AWS IAM role ARN for STS AssumeRole. Works with static creds or instance role. Supports env var reference"
-              },
-              "force_path_style": {
-                "type": "boolean",
-                "description": "Use path-style URLs for S3 (required for MinIO). Default: false",
-                "default": false
-              },
-              "compress": true
-            },
-            "dependentRequired": {
-              "access_key_id": ["secret_access_key"],
-              "secret_access_key": ["access_key_id"],
-              "session_token": ["access_key_id", "secret_access_key"]
-            },
-            "additionalProperties": false
-          },
-          "else": {
-            "properties": {
-              "type": true,
-              "bucket": true,
-              "prefix": true,
-              "credentials_json": {
-                "type": "string",
-                "description": "GCP service account credentials JSON or file path. Omit to use Application Default Credentials. Supports env var reference"
-              },
-              "credentials": {
-                "type": "string",
-                "description": "Deprecated: use credentials_json. Kept for backwards compatibility."
-              },
-              "project_id": {
-                "type": "string",
-                "description": "GCP project ID override. Supports env var reference"
-              },
-              "compress": true
-            },
-            "additionalProperties": false
-          }
-        },
-        "retention_days": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Days to retain log entries. 0 disables retention-based cleanup."
         }
       },
       "additionalProperties": false
+    },
+    "cluster_config": {
+      "$ref": "#/$defs/cluster_config"
+    },
+    "saml_config": {
+      "$ref": "#/$defs/saml_config"
+    },
+    "load_balancer_config": {
+      "$ref": "#/$defs/load_balancer_config"
+    },
+    "guardrails_config": {
+      "$ref": "#/$defs/guardrails_config"
     },
     "plugins": {
       "type": "array",
       "description": "Plugins configuration",
       "items": {
         "type": "object",
-        "required": ["enabled", "name"],
+        "required": [
+          "enabled",
+          "name"
+        ],
         "properties": {
           "enabled": {
             "type": "boolean",
@@ -1031,7 +910,7 @@
           },
           "name": {
             "type": "string",
-            "description": "Name of the plugin (built-in: telemetry, prompts, logging, governance, maxim, semantic_cache, otel, or custom plugin name)"
+            "description": "Name of the plugin (built-in: telemetry, logging, governance, maxim, semantic_cache, otel, or custom plugin name)"
           },
           "config": {
             "type": "object",
@@ -1051,8 +930,8 @@
           },
           "placement": {
             "type": "string",
-            "enum": ["pre_builtin", "post_builtin", "builtin"],
-            "description": "Whether this plugin runs before, after, or as a built-in. Default: post_builtin",
+            "enum": ["pre_builtin", "post_builtin"],
+            "description": "Whether this plugin runs before or after built-in plugins. Default: post_builtin",
             "optional": true,
             "default": "post_builtin"
           },
@@ -1073,7 +952,9 @@
               }
             },
             "then": {
-              "required": ["config"],
+              "required": [
+                "config"
+              ],
               "properties": {
                 "config": {
                   "type": "object",
@@ -1149,7 +1030,9 @@
               }
             },
             "then": {
-              "required": ["config"],
+              "required": [
+                "config"
+              ],
               "properties": {
                 "config": {
                   "type": "object",
@@ -1181,7 +1064,9 @@
               }
             },
             "then": {
-              "required": ["config"],
+              "required": [
+                "config"
+              ],
               "properties": {
                 "config": {
                   "type": "object",
@@ -1217,7 +1102,9 @@
               }
             },
             "then": {
-              "required": ["config"],
+              "required": [
+                "config"
+              ],
               "properties": {
                 "config": {
                   "type": "object",
@@ -1232,7 +1119,9 @@
                       "description": "Optional default ID for the Maxim logger instance"
                     }
                   },
-                  "required": ["api_key"],
+                  "required": [
+                    "api_key"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -1247,7 +1136,9 @@
               }
             },
             "then": {
-              "required": ["config"],
+              "required": [
+                "config"
+              ],
               "properties": {
                 "config": {
                   "type": "object",
@@ -1298,7 +1189,7 @@
                       "oneOf": [
                         {
                           "type": "string",
-                          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$"
+                          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$"
                         },
                         {
                           "type": "integer",
@@ -1343,7 +1234,9 @@
                       "description": "Exclude system prompt in cache key (default: false)"
                     }
                   },
-                  "required": ["dimension"],
+                  "required": [
+                    "dimension"
+                  ],
                   "allOf": [
                     {
                       "if": {
@@ -1353,10 +1246,15 @@
                             "minLength": 1
                           }
                         },
-                        "required": ["provider"]
+                        "required": [
+                          "provider"
+                        ]
                       },
                       "then": {
-                        "required": ["provider", "embedding_model"],
+                        "required": [
+                          "provider",
+                          "embedding_model"
+                        ],
                         "properties": {
                           "dimension": {
                             "type": "integer",
@@ -1366,7 +1264,9 @@
                       },
                       "else": {
                         "not": {
-                          "required": ["embedding_model"]
+                          "required": [
+                            "embedding_model"
+                          ]
                         },
                         "properties": {
                           "dimension": {
@@ -1390,7 +1290,9 @@
               }
             },
             "then": {
-              "required": ["config"],
+              "required": [
+                "config"
+              ],
               "properties": {
                 "config": {
                   "type": "object",
@@ -1416,12 +1318,17 @@
                     "trace_type": {
                       "type": "string",
                       "description": "Type of trace to use for the OTEL collector",
-                      "enum": ["genai_extension", "vercel", "open_inference"]
+                      "enum": [
+                        "otel"
+                      ]
                     },
                     "protocol": {
                       "type": "string",
                       "description": "Protocol to use for the OTEL collector",
-                      "enum": ["http", "grpc"]
+                      "enum": [
+                        "http",
+                        "grpc"
+                      ]
                     },
                     "metrics_enabled": {
                       "type": "boolean",
@@ -1463,7 +1370,11 @@
                       "description": "Skip TLS verification (ignored if tls_ca_cert is set)"
                     }
                   },
-                  "required": ["collector_url", "trace_type", "protocol"],
+                  "required": [
+                    "collector_url",
+                    "trace_type",
+                    "protocol"
+                  ],
                   "additionalProperties": false
                 }
               }
@@ -1478,7 +1389,9 @@
               }
             },
             "then": {
-              "required": ["config"],
+              "required": [
+                "config"
+              ],
               "properties": {
                 "config": {
                   "type": "object",
@@ -1524,26 +1437,14 @@
         "additionalProperties": false
       }
     },
-    "websocket": {
-      "$ref": "#/$defs/websocket_config"
-    },
-    "guardrails_config": {
-      "$ref": "#/$defs/guardrails_config"
-    },
     "audit_logs": {
       "$ref": "#/$defs/audit_logs_config"
-    },
-    "cluster_config": {
-      "$ref": "#/$defs/cluster_config"
-    },
-    "load_balancer_config": {
-      "$ref": "#/$defs/load_balancer_config"
     },
     "large_payload_optimization": {
       "$ref": "#/$defs/large_payload_optimization"
     },
-    "scim_config": {
-      "$ref": "#/$defs/scim_config"
+    "websocket": {
+      "$ref": "#/$defs/websocket_config"
     }
   },
   "additionalProperties": false,
@@ -1602,11 +1503,6 @@
           "type": "string",
           "description": "CEL (Common Expression Language) expression for rule evaluation"
         },
-        "chain_rule": {
-          "type": "boolean",
-          "default": false,
-          "description": "If true, re-evaluates routing chain after this rule matches"
-        },
         "targets": {
           "type": "array",
           "minItems": 1,
@@ -1631,7 +1527,7 @@
           "default": "global"
         },
         "scope_id": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "Entity ID for non-global scopes (required for non-global scope)"
         },
         "priority": {
@@ -1646,24 +1542,7 @@
         }
       },
       "required": ["id", "name", "targets"],
-      "additionalProperties": false,
-      "if": {
-        "properties": {
-          "scope": {
-            "enum": ["team", "customer", "virtual_key"]
-          }
-        },
-        "required": ["scope"]
-      },
-      "then": {
-        "required": ["scope_id"],
-        "properties": {
-          "scope_id": {
-            "type": "string",
-            "minLength": 1
-          }
-        }
-      }
+      "additionalProperties": false
     },
     "virtual_key_provider_config": {
       "type": "object",
@@ -1682,30 +1561,276 @@
           "description": "Provider name"
         },
         "weight": {
-          "type": ["number", "null"],
-          "description": "Weight for load balancing (null opts out of weighted routing)",
-          "default": null
+          "type": "number",
+          "description": "Weight for load balancing",
+          "default": 1.0
         },
         "allowed_models": {
           "type": "array",
-          "description": "Allowed models for this provider config. Use [\"*\"] to allow all models; empty array denies all (deny-by-default).",
+          "description": "Allowed models for this provider config (empty means all models allowed)",
           "items": {
             "type": "string"
           }
+        },
+        "budget_id": {
+          "type": "string",
+          "description": "Associated budget ID"
         },
         "rate_limit_id": {
           "type": "string",
           "description": "Associated rate limit ID"
         },
-        "key_ids": {
+        "keys": {
           "type": "array",
-          "description": "Key identifiers allowed for this provider config. Use [\"*\"] to allow all keys; empty array denies all (deny-by-default). In config.json, values are key names. Via the API, values are key UUIDs.",
+          "description": "Provider keys for this config (empty means all keys allowed for this provider)",
           "items": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "Key database ID (auto-generated)"
+              },
+              "key_id": {
+                "type": "string",
+                "description": "Key UUID identifier"
+              },
+              "name": {
+                "type": "string",
+                "description": "Key name (must be unique)"
+              },
+              "value": {
+                "type": "string",
+                "description": "API key value (can use env. prefix)"
+              },
+              "models": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Supported models for this key"
+              },
+              "weight": {
+                "type": "number",
+                "minimum": 0,
+                "default": 1.0,
+                "description": "Weight for load balancing"
+              },
+              "azure_key_config": {
+                "type": "object",
+                "properties": {
+                  "endpoint": {
+                    "type": "string",
+                    "description": "Azure endpoint (can use env. prefix)"
+                  },
+                  "deployments": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Model to deployment mappings"
+                  },
+                  "api_version": {
+                    "type": "string",
+                    "description": "Azure API version"
+                  }
+                },
+                "required": [
+                  "endpoint"
+                ],
+                "additionalProperties": false
+              },
+              "vertex_key_config": {
+                "type": "object",
+                "properties": {
+                  "project_id": {
+                    "type": "string",
+                    "description": "Google Cloud project ID (can use env. prefix)"
+                  },
+                  "project_number": {
+                    "type": "string",
+                    "description": "Google Cloud project number"
+                  },
+                  "region": {
+                    "type": "string",
+                    "description": "Google Cloud region"
+                  },
+                  "auth_credentials": {
+                    "type": "string",
+                    "description": "Authentication credentials (can use env. prefix)"
+                  },
+                  "deployments": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Model to deployment mappings"
+                  }
+                },
+                "required": [
+                  "project_id",
+                  "region"
+                ],
+                "additionalProperties": false
+              },
+              "bedrock_key_config": {
+                "type": "object",
+                "properties": {
+                  "access_key": {
+                    "type": "string",
+                    "description": "AWS access key (can use env. prefix)"
+                  },
+                  "secret_key": {
+                    "type": "string",
+                    "description": "AWS secret key (can use env. prefix)"
+                  },
+                  "session_token": {
+                    "type": "string",
+                    "description": "AWS session token (can use env. prefix)"
+                  },
+                  "region": {
+                    "type": "string",
+                    "description": "AWS region"
+                  },
+                  "arn": {
+                    "type": "string",
+                    "description": "AWS ARN"
+                  },
+                  "role_arn": {
+                    "type": "string",
+                    "description": "AWS IAM role ARN for AssumeRole (can use env. prefix)"
+                  },
+                  "external_id": {
+                    "type": "string",
+                    "description": "External ID for AssumeRole (can use env. prefix)"
+                  },
+                  "session_name": {
+                    "type": "string",
+                    "description": "Role session name for AssumeRole (can use env. prefix)"
+                  },
+                  "deployments": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Model to deployment mappings"
+                  },
+                  "batch_s3_config": {
+                    "type": "object",
+                    "description": "S3 bucket configuration for Bedrock batch operations",
+                    "properties": {
+                      "buckets": {
+                        "type": "array",
+                        "description": "List of S3 bucket configurations",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "bucket_name": {
+                              "type": "string",
+                              "description": "S3 bucket name"
+                            },
+                            "prefix": {
+                              "type": "string",
+                              "description": "S3 key prefix for batch files"
+                            },
+                            "is_default": {
+                              "type": "boolean",
+                              "description": "Whether this is the default bucket for batch operations"
+                            }
+                          },
+                          "required": ["bucket_name"],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              },
+              "vllm_key_config": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "VLLM server base URL (can use env. prefix)"
+                  },
+                  "model_name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Exact model name served on this VLLM instance"
+                  }
+                },
+                "required": [
+                  "url",
+                  "model_name"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "oneOf": [
+              {
+                "not": {
+                  "anyOf": [
+                    { "required": ["azure_key_config"] },
+                    { "required": ["vertex_key_config"] },
+                    { "required": ["bedrock_key_config"] },
+                    { "required": ["vllm_key_config"] }
+                  ]
+                }
+              },
+              {
+                "required": ["azure_key_config"],
+                "not": {
+                  "anyOf": [
+                    { "required": ["vertex_key_config"] },
+                    { "required": ["bedrock_key_config"] },
+                    { "required": ["vllm_key_config"] }
+                  ]
+                }
+              },
+              {
+                "required": ["vertex_key_config"],
+                "not": {
+                  "anyOf": [
+                    { "required": ["azure_key_config"] },
+                    { "required": ["bedrock_key_config"] },
+                    { "required": ["vllm_key_config"] }
+                  ]
+                }
+              },
+              {
+                "required": ["bedrock_key_config"],
+                "not": {
+                  "anyOf": [
+                    { "required": ["azure_key_config"] },
+                    { "required": ["vertex_key_config"] },
+                    { "required": ["vllm_key_config"] }
+                  ]
+                }
+              },
+              {
+                "required": ["vllm_key_config"],
+                "not": {
+                  "anyOf": [
+                    { "required": ["azure_key_config"] },
+                    { "required": ["vertex_key_config"] },
+                    { "required": ["bedrock_key_config"] }
+                  ]
+                }
+              }
+            ],
+            "required": [
+              "key_id",
+              "name",
+              "value"
+            ]
           }
         }
       },
-      "required": ["provider"],
+      "required": [
+        "provider"
+      ],
       "additionalProperties": false
     },
     "virtual_key_mcp_config": {
@@ -1722,20 +1847,19 @@
         },
         "mcp_client_id": {
           "type": "integer",
-          "description": "Associated MCP client ID (database format)"
-        },
-        "mcp_client_name": {
-          "type": "string",
-          "description": "MCP client name (config file format \u2014 resolved to mcp_client_id at startup)"
+          "description": "Associated MCP client ID"
         },
         "tools_to_execute": {
           "type": "array",
-          "description": "Include-only list of tools this Virtual Key is permitted to execute from this MCP client. ['*'] means all tools allowed, [] means no tools allowed (deny-by-default).",
+          "description": "Tools to execute for this MCP config",
           "items": {
             "type": "string"
           }
         }
       },
+      "required": [
+        "mcp_client_id"
+      ],
       "additionalProperties": false
     },
     "auth_config": {
@@ -1780,6 +1904,161 @@
       },
       "additionalProperties": false
     },
+    "pricing_override_match_type": {
+      "type": "string",
+      "enum": [
+        "exact",
+        "wildcard",
+        "regex"
+      ]
+    },
+    "pricing_override_request_type": {
+      "type": "string",
+      "enum": [
+        "text_completion",
+        "text_completion_stream",
+        "chat_completion",
+        "chat_completion_stream",
+        "responses",
+        "responses_stream",
+        "embedding",
+        "rerank",
+        "ocr",
+        "speech",
+        "speech_stream",
+        "transcription",
+        "transcription_stream",
+        "image_generation",
+        "image_generation_stream"
+      ]
+    },
+    "provider_pricing_override": {
+      "type": "object",
+      "properties": {
+        "model_pattern": {
+          "type": "string",
+          "minLength": 1
+        },
+        "match_type": {
+          "$ref": "#/$defs/pricing_override_match_type"
+        },
+        "request_types": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/pricing_override_request_type"
+          }
+        },
+        "input_cost_per_token": { "type": "number", "minimum": 0 },
+        "output_cost_per_token": { "type": "number", "minimum": 0 },
+        "input_cost_per_video_per_second": { "type": "number", "minimum": 0 },
+        "input_cost_per_audio_per_second": { "type": "number", "minimum": 0 },
+        "input_cost_per_character": { "type": "number", "minimum": 0 },
+        "output_cost_per_character": { "type": "number", "minimum": 0 },
+        "input_cost_per_token_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "input_cost_per_character_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "input_cost_per_image_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "input_cost_per_video_per_second_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "input_cost_per_audio_per_second_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "output_cost_per_token_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "output_cost_per_character_above_128k_tokens": { "type": "number", "minimum": 0 },
+        "input_cost_per_token_above_200k_tokens": { "type": "number", "minimum": 0 },
+        "output_cost_per_token_above_200k_tokens": { "type": "number", "minimum": 0 },
+        "cache_creation_input_token_cost_above_200k_tokens": { "type": "number", "minimum": 0 },
+        "cache_read_input_token_cost_above_200k_tokens": { "type": "number", "minimum": 0 },
+        "cache_read_input_token_cost": { "type": "number", "minimum": 0 },
+        "cache_creation_input_token_cost": { "type": "number", "minimum": 0 },
+        "input_cost_per_token_batches": { "type": "number", "minimum": 0 },
+        "output_cost_per_token_batches": { "type": "number", "minimum": 0 },
+        "input_cost_per_image_token": { "type": "number", "minimum": 0 },
+        "output_cost_per_image_token": { "type": "number", "minimum": 0 },
+        "input_cost_per_image": { "type": "number", "minimum": 0 },
+        "output_cost_per_image": { "type": "number", "minimum": 0 },
+        "cache_read_input_image_token_cost": { "type": "number", "minimum": 0 }
+      },
+      "required": [
+        "model_pattern",
+        "match_type"
+      ],
+      "additionalProperties": false
+    },
+    "custom_provider_config": {
+      "type": "object",
+      "description": "Custom provider configuration for extending or customizing provider behavior",
+      "properties": {
+        "is_key_less": {
+          "type": "boolean",
+          "description": "Whether the custom provider requires a key"
+        },
+        "base_provider_type": {
+          "type": "string",
+          "description": "Base provider type to extend"
+        },
+        "allowed_requests": {
+          "type": "object",
+          "description": "Allowed request types for the custom provider",
+          "properties": {
+            "list_models": { "type": "boolean" },
+            "text_completion": { "type": "boolean" },
+            "text_completion_stream": { "type": "boolean" },
+            "chat_completion": { "type": "boolean" },
+            "chat_completion_stream": { "type": "boolean" },
+            "responses": { "type": "boolean" },
+            "responses_stream": { "type": "boolean" },
+            "count_tokens": { "type": "boolean" },
+            "embedding": { "type": "boolean" },
+            "rerank": { "type": "boolean" },
+            "ocr": { "type": "boolean" },
+            "speech": { "type": "boolean" },
+            "speech_stream": { "type": "boolean" },
+            "transcription": { "type": "boolean" },
+            "transcription_stream": { "type": "boolean" },
+            "image_generation": { "type": "boolean" },
+            "image_generation_stream": { "type": "boolean" },
+            "image_edit": { "type": "boolean" },
+            "image_edit_stream": { "type": "boolean" },
+            "image_variation": { "type": "boolean" },
+            "video_generation": { "type": "boolean" },
+            "video_retrieve": { "type": "boolean" },
+            "video_download": { "type": "boolean" },
+            "video_delete": { "type": "boolean" },
+            "video_list": { "type": "boolean" },
+            "video_remix": { "type": "boolean" },
+            "batch_create": { "type": "boolean" },
+            "batch_list": { "type": "boolean" },
+            "batch_retrieve": { "type": "boolean" },
+            "batch_cancel": { "type": "boolean" },
+            "batch_delete": { "type": "boolean" },
+            "batch_results": { "type": "boolean" },
+            "file_upload": { "type": "boolean" },
+            "file_list": { "type": "boolean" },
+            "file_retrieve": { "type": "boolean" },
+            "file_delete": { "type": "boolean" },
+            "file_content": { "type": "boolean" },
+            "container_create": { "type": "boolean" },
+            "container_list": { "type": "boolean" },
+            "container_retrieve": { "type": "boolean" },
+            "container_delete": { "type": "boolean" },
+            "container_file_create": { "type": "boolean" },
+            "container_file_list": { "type": "boolean" },
+            "container_file_retrieve": { "type": "boolean" },
+            "container_file_content": { "type": "boolean" },
+            "container_file_delete": { "type": "boolean" },
+            "passthrough": { "type": "boolean" },
+            "passthrough_stream": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        },
+        "request_path_overrides": {
+          "type": "object",
+          "description": "Mapping of request type to custom path overriding the default provider path",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["base_provider_type"],
+      "additionalProperties": false
+    },
     "network_config": {
       "type": "object",
       "properties": {
@@ -1805,19 +2084,15 @@
           "minimum": 0,
           "description": "Maximum number of retries"
         },
-        "retry_backoff_initial": {
+        "retry_backoff_initial_ms": {
           "type": "integer",
           "minimum": 0,
           "description": "Initial retry backoff in milliseconds"
         },
-        "retry_backoff_max": {
+        "retry_backoff_max_ms": {
           "type": "integer",
           "minimum": 0,
           "description": "Maximum retry backoff in milliseconds"
-        },
-        "enforce_http2": {
-          "type": "boolean",
-          "description": "Force HTTP/2 on provider connections (relevant for Bedrock and other net/http-based providers)"
         },
         "insecure_skip_verify": {
           "type": "boolean",
@@ -1849,82 +2124,7 @@
       },
       "additionalProperties": false
     },
-    "network_config_without_base_url": {
-      "type": "object",
-      "properties": {
-        "extra_headers": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Additional headers to send with requests"
-        },
-        "default_request_timeout_in_seconds": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Default request timeout in seconds"
-        },
-        "max_retries": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Maximum number of retries"
-        },
-        "retry_backoff_initial": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Initial retry backoff in milliseconds"
-        },
-        "retry_backoff_max": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "Maximum retry backoff in milliseconds"
-        },
-        "enforce_http2": {
-          "type": "boolean",
-          "description": "Force HTTP/2 on provider connections (relevant for Bedrock and other net/http-based providers)"
-        },
-        "insecure_skip_verify": {
-          "type": "boolean",
-          "description": "Disable TLS certificate verification for provider connections. This bypasses server certificate validation and should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for self-signed or private CA deployments."
-        },
-        "ca_cert_pem": {
-          "type": "string",
-          "description": "PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA)"
-        },
-        "stream_idle_timeout_in_seconds": {
-          "type": "integer",
-          "minimum": 5,
-          "maximum": 3600,
-          "description": "Idle timeout per stream chunk in seconds. If no data is received for this many seconds, the stream is closed. Default: 60."
-        },
-        "max_conns_per_host": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 10000,
-          "description": "Maximum number of TCP connections per provider host. For HTTP/2 (e.g. Bedrock), each connection supports ~100 concurrent streams. Default: 5000."
-        },
-        "beta_header_overrides": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "boolean"
-          },
-          "description": "Override default Anthropic beta header support per provider. Keys are header prefixes (e.g. 'redact-thinking-'), values are true (supported) or false (unsupported). Headers not listed use the built-in defaults."
-        }
-      },
-      "additionalProperties": false
-    },
-    "openai_config": {
-      "type": "object",
-      "description": "OpenAI-specific provider settings",
-      "properties": {
-        "disable_store": {
-          "type": "boolean",
-          "description": "Disable OpenAI Responses API conversation storage."
-        }
-      },
-      "additionalProperties": false
-    },
-    "concurrency_and_buffer_size": {
+    "concurrency_config": {
       "type": "object",
       "properties": {
         "concurrency": {
@@ -1938,7 +2138,10 @@
           "description": "Buffer size for requests"
         }
       },
-      "required": ["concurrency", "buffer_size"],
+      "required": [
+        "concurrency",
+        "buffer_size"
+      ],
       "additionalProperties": false
     },
     "base_key": {
@@ -1957,7 +2160,8 @@
           "items": {
             "type": "string"
           },
-          "description": "Models this key can access. Use [\"*\"] to allow all models; empty array denies all (deny-by-default)."
+          "default": [],
+          "description": "Supported models for this key"
         },
         "weight": {
           "type": "number",
@@ -1968,20 +2172,12 @@
           "type": "boolean",
           "description": "Whether this key can be used for batch API operations (default: false)",
           "default": false
-        },
-        "aliases": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string",
-            "minLength": 1
-          },
-          "propertyNames": {
-            "minLength": 1
-          },
-          "description": "Model alias mappings: maps a model name to a provider-specific identifier (deployment name, inference profile ID, fine-tuned model ID, etc.)"
         }
       },
-      "required": ["name", "weight"]
+      "required": [
+        "name",
+        "weight"
+      ]
     },
     "bedrock_key": {
       "allOf": [
@@ -2064,10 +2260,15 @@
                   "additionalProperties": false
                 }
               },
-              "required": ["region"],
+              "required": [
+                "region"
+              ],
               "additionalProperties": false
             }
-          }
+          },
+          "required": [
+            "bedrock_key_config"
+          ]
         }
       ]
     },
@@ -2093,83 +2294,16 @@
                   "description": "Exact model name served on this VLLM instance"
                 }
               },
-              "required": ["url", "model_name"],
+              "required": [
+                "url",
+                "model_name"
+              ],
               "additionalProperties": false
             }
           },
-          "required": ["vllm_key_config"]
-        }
-      ]
-    },
-    "replicate_key": {
-      "allOf": [
-        {
-          "$ref": "#/$defs/base_key"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "replicate_key_config": {
-              "type": "object",
-              "properties": {
-                "use_deployments_endpoint": {
-                  "type": "boolean",
-                  "description": "Whether to use the deployments endpoint instead of the models endpoint (default: false)"
-                }
-              },
-              "additionalProperties": false
-            }
-          }
-        }
-      ]
-    },
-    "ollama_key": {
-      "allOf": [
-        {
-          "$ref": "#/$defs/base_key"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "ollama_key_config": {
-              "type": "object",
-              "properties": {
-                "url": {
-                  "type": "string",
-                  "minLength": 1,
-                  "description": "Ollama server base URL (can use env. prefix)"
-                }
-              },
-              "required": ["url"],
-              "additionalProperties": false
-            }
-          },
-          "required": ["ollama_key_config"]
-        }
-      ]
-    },
-    "sgl_key": {
-      "allOf": [
-        {
-          "$ref": "#/$defs/base_key"
-        },
-        {
-          "type": "object",
-          "properties": {
-            "sgl_key_config": {
-              "type": "object",
-              "properties": {
-                "url": {
-                  "type": "string",
-                  "minLength": 1,
-                  "description": "SGLang server base URL (can use env. prefix)"
-                }
-              },
-              "required": ["url"],
-              "additionalProperties": false
-            }
-          },
-          "required": ["sgl_key_config"]
+          "required": [
+            "vllm_key_config"
+          ]
         }
       ]
     },
@@ -2188,16 +2322,28 @@
                   "type": "string",
                   "description": "Azure endpoint (can use env. prefix)"
                 },
+                "deployments": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Model to deployment mappings"
+                },
                 "api_version": {
                   "type": "string",
                   "description": "Azure API version"
                 }
               },
-              "required": ["endpoint", "api_version"],
+              "required": [
+                "endpoint",
+                "api_version"
+              ],
               "additionalProperties": false
             }
           },
-          "required": ["azure_key_config"]
+          "required": [
+            "azure_key_config"
+          ]
         }
       ]
     },
@@ -2227,13 +2373,25 @@
                 "auth_credentials": {
                   "type": "string",
                   "description": "Authentication credentials (can use env. prefix)"
+                },
+                "deployments": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Model to deployment mappings"
                 }
               },
-              "required": ["project_id", "region"],
+              "required": [
+                "project_id",
+                "region"
+              ],
               "additionalProperties": false
             }
           },
-          "required": ["vertex_key_config"]
+          "required": [
+            "vertex_key_config"
+          ]
         }
       ]
     },
@@ -2252,7 +2410,7 @@
           "$ref": "#/$defs/network_config"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_and_buffer_size"
+          "$ref": "#/$defs/concurrency_config"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2271,9 +2429,18 @@
         },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
+        },
+        "pricing_overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/provider_pricing_override"
+          },
+          "description": "Provider-level pricing overrides matched by model pattern"
         }
       },
-      "required": ["keys"],
+      "required": [
+        "keys"
+      ],
       "additionalProperties": false
     },
     "provider_with_bedrock_config": {
@@ -2291,7 +2458,7 @@
           "$ref": "#/$defs/network_config"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_and_buffer_size"
+          "$ref": "#/$defs/concurrency_config"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2310,9 +2477,18 @@
         },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
+        },
+        "pricing_overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/provider_pricing_override"
+          },
+          "description": "Provider-level pricing overrides matched by model pattern"
         }
       },
-      "required": ["keys"],
+      "required": [
+        "keys"
+      ],
       "additionalProperties": false
     },
     "provider_with_vllm_config": {
@@ -2327,49 +2503,10 @@
           "description": "API keys for this provider"
         },
         "network_config": {
-          "$ref": "#/$defs/network_config_without_base_url"
-        },
-        "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_and_buffer_size"
-        },
-        "proxy_config": {
-          "$ref": "#/$defs/proxy_config"
-        },
-        "send_back_raw_request": {
-          "type": "boolean",
-          "description": "Include raw request in BifrostResponse (default: false)"
-        },
-        "send_back_raw_response": {
-          "type": "boolean",
-          "description": "Include raw response in BifrostResponse (default: false)"
-        },
-        "store_raw_request_response": {
-          "type": "boolean",
-          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
-        },
-        "custom_provider_config": {
-          "$ref": "#/$defs/custom_provider_config"
-        }
-      },
-      "required": ["keys"],
-      "additionalProperties": false
-    },
-    "provider_with_replicate_config": {
-      "type": "object",
-      "properties": {
-        "keys": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/replicate_key"
-          },
-          "minItems": 1,
-          "description": "API keys for this provider"
-        },
-        "network_config": {
           "$ref": "#/$defs/network_config"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_and_buffer_size"
+          "$ref": "#/$defs/concurrency_config"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2388,9 +2525,18 @@
         },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
+        },
+        "pricing_overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/provider_pricing_override"
+          },
+          "description": "Provider-level pricing overrides matched by model pattern"
         }
       },
-      "required": ["keys"],
+      "required": [
+        "keys"
+      ],
       "additionalProperties": false
     },
     "provider_with_azure_config": {
@@ -2408,7 +2554,7 @@
           "$ref": "#/$defs/network_config"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_and_buffer_size"
+          "$ref": "#/$defs/concurrency_config"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2427,9 +2573,18 @@
         },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
+        },
+        "pricing_overrides": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/provider_pricing_override"
+          },
+          "description": "Provider-level pricing overrides matched by model pattern"
         }
       },
-      "required": ["keys"],
+      "required": [
+        "keys"
+      ],
       "additionalProperties": false
     },
     "provider_with_vertex_config": {
@@ -2447,7 +2602,7 @@
           "$ref": "#/$defs/network_config"
         },
         "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_and_buffer_size"
+          "$ref": "#/$defs/concurrency_config"
         },
         "proxy_config": {
           "$ref": "#/$defs/proxy_config"
@@ -2466,87 +2621,18 @@
         },
         "custom_provider_config": {
           "$ref": "#/$defs/custom_provider_config"
-        }
-      },
-      "required": ["keys"],
-      "additionalProperties": false
-    },
-    "provider_with_ollama_config": {
-      "type": "object",
-      "properties": {
-        "keys": {
+        },
+        "pricing_overrides": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/ollama_key"
+            "$ref": "#/$defs/provider_pricing_override"
           },
-          "minItems": 1,
-          "description": "API keys for this provider"
-        },
-        "network_config": {
-          "$ref": "#/$defs/network_config_without_base_url"
-        },
-        "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_and_buffer_size"
-        },
-        "proxy_config": {
-          "$ref": "#/$defs/proxy_config"
-        },
-        "send_back_raw_request": {
-          "type": "boolean",
-          "description": "Include raw request in BifrostResponse (default: false)"
-        },
-        "send_back_raw_response": {
-          "type": "boolean",
-          "description": "Include raw response in BifrostResponse (default: false)"
-        },
-        "store_raw_request_response": {
-          "type": "boolean",
-          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
-        },
-        "custom_provider_config": {
-          "$ref": "#/$defs/custom_provider_config"
+          "description": "Provider-level pricing overrides matched by model pattern"
         }
       },
-      "required": ["keys"],
-      "additionalProperties": false
-    },
-    "provider_with_sgl_config": {
-      "type": "object",
-      "properties": {
-        "keys": {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/sgl_key"
-          },
-          "minItems": 1,
-          "description": "API keys for this provider"
-        },
-        "network_config": {
-          "$ref": "#/$defs/network_config_without_base_url"
-        },
-        "concurrency_and_buffer_size": {
-          "$ref": "#/$defs/concurrency_and_buffer_size"
-        },
-        "proxy_config": {
-          "$ref": "#/$defs/proxy_config"
-        },
-        "send_back_raw_request": {
-          "type": "boolean",
-          "description": "Include raw request in BifrostResponse (default: false)"
-        },
-        "send_back_raw_response": {
-          "type": "boolean",
-          "description": "Include raw response in BifrostResponse (default: false)"
-        },
-        "store_raw_request_response": {
-          "type": "boolean",
-          "description": "Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)"
-        },
-        "custom_provider_config": {
-          "$ref": "#/$defs/custom_provider_config"
-        }
-      },
-      "required": ["keys"],
+      "required": [
+        "keys"
+      ],
       "additionalProperties": false
     },
     "mcp_client_config": {
@@ -2566,7 +2652,12 @@
         },
         "connection_type": {
           "type": "string",
-          "enum": ["stdio", "http", "sse", "inprocess"],
+          "enum": [
+            "stdio",
+            "websocket",
+            "http",
+            "sse"
+          ],
           "description": "Connection type for MCP client"
         },
         "connection_string": {
@@ -2575,12 +2666,12 @@
         },
         "auth_type": {
           "type": "string",
-          "enum": ["none", "headers", "oauth", "per_user_oauth"],
+          "enum": ["none", "headers", "oauth"],
           "description": "Authentication type for MCP connection"
         },
         "oauth_config_id": {
           "type": "string",
-          "description": "OAuth config ID reference (required when auth_type is 'oauth' or 'per_user_oauth')"
+          "description": "OAuth config ID reference (for oauth auth type)"
         },
         "headers": {
           "type": "object",
@@ -2611,7 +2702,37 @@
               "description": "Environment variables"
             }
           },
-          "required": ["command"],
+          "required": [
+            "command"
+          ],
+          "additionalProperties": false
+        },
+        "websocket_config": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "WebSocket URL"
+            }
+          },
+          "required": [
+            "url"
+          ],
+          "additionalProperties": false
+        },
+        "http_config": {
+          "type": "object",
+          "properties": {
+            "url": {
+              "type": "string",
+              "format": "uri",
+              "description": "HTTP URL"
+            }
+          },
+          "required": [
+            "url"
+          ],
           "additionalProperties": false
         },
         "tools_to_execute": {
@@ -2632,13 +2753,6 @@
           "type": "string",
           "description": "Per-client override for tool sync interval (Go duration, e.g. '10m', '1h', 0 = use global, negative = disabled)"
         },
-        "allowed_extra_headers": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Allowlist of request-level headers that callers may forward to this MCP server at execution time. Use ['*'] to allow all headers."
-        },
         "is_ping_available": {
           "type": "boolean",
           "description": "Whether the MCP server supports ping for health checks (default: true)",
@@ -2651,26 +2765,13 @@
             "type": "number",
             "minimum": 0
           }
-        },
-        "allow_on_all_virtual_keys": {
-          "type": "boolean",
-          "description": "When true, this MCP server is accessible to all virtual keys without requiring explicit per-key assignment. All tools are allowed by default. If a virtual key has an explicit MCP config for this server, that config takes precedence and overrides this behaviour.",
-          "default": false
         }
       },
-      "required": ["name", "connection_type"],
+      "required": [
+        "name",
+        "connection_type"
+      ],
       "additionalProperties": false,
-      "if": {
-        "properties": {
-          "auth_type": {
-            "enum": ["oauth", "per_user_oauth"]
-          }
-        },
-        "required": ["auth_type"]
-      },
-      "then": {
-        "required": ["oauth_config_id"]
-      },
       "oneOf": [
         {
           "properties": {
@@ -2678,7 +2779,9 @@
               "const": "stdio"
             }
           },
-          "required": ["stdio_config"]
+          "required": [
+            "stdio_config"
+          ]
         },
         {
           "properties": {
@@ -2686,7 +2789,9 @@
               "const": "websocket"
             }
           },
-          "required": ["websocket_config"]
+          "required": [
+            "websocket_config"
+          ]
         },
         {
           "properties": {
@@ -2695,12 +2800,8 @@
             }
           },
           "anyOf": [
-            {
-              "required": ["http_config"]
-            },
-            {
-              "required": ["connection_string"]
-            }
+            { "required": ["http_config"] },
+            { "required": ["connection_string"] }
           ]
         },
         {
@@ -2709,7 +2810,9 @@
               "const": "sse"
             }
           },
-          "required": ["connection_string"]
+          "required": [
+            "connection_string"
+          ]
         }
       ]
     },
@@ -2732,11 +2835,6 @@
           "type": "string",
           "enum": ["server", "tool"],
           "description": "How tools are exposed in VFS for code execution"
-        },
-        "disable_auto_tool_inject": {
-          "type": "boolean",
-          "description": "When true, MCP tools are not automatically injected into requests. Tools are only included when explicitly specified via request context filters or headers, such as x-bf-mcp-include-tools or x-bf-mcp-include-clients.",
-          "default": false
         }
       }
     },
@@ -2775,7 +2873,7 @@
         },
         "timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
           "description": "Timeout for Weaviate operations (e.g., '5s')"
         },
         "class_name": {
@@ -2790,7 +2888,10 @@
           "description": "Properties for Weaviate vector store"
         }
       },
-      "required": ["scheme", "host"],
+      "required": [
+        "scheme",
+        "host"
+      ],
       "additionalProperties": false
     },
     "redis_config": {
@@ -2851,36 +2952,38 @@
         },
         "conn_max_lifetime": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
           "description": "Connection maximum lifetime (e.g., '30m')"
         },
         "conn_max_idle_time": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
           "description": "Connection maximum idle time (e.g., '5m')"
         },
         "dial_timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
           "description": "Timeout for socket connection (e.g., '5s')"
         },
         "read_timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
           "description": "Timeout for socket reads (e.g., '3s')"
         },
         "write_timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
           "description": "Timeout for socket writes (e.g., '3s')"
         },
         "context_timeout": {
           "type": "string",
-          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
+          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
           "description": "Timeout for Redis operations (e.g., '10s')"
         }
       },
-      "required": ["addr"],
+      "required": [
+        "addr"
+      ],
       "additionalProperties": false
     },
     "qdrant_config": {
@@ -2906,7 +3009,9 @@
           "default": false
         }
       },
-      "required": ["host"],
+      "required": [
+        "host"
+      ],
       "additionalProperties": false
     },
     "pinecone_config": {
@@ -2922,7 +3027,10 @@
           "description": "Index host URL from Pinecone console - REQUIRED (e.g., your-index.svc.environment.pinecone.io)"
         }
       },
-      "required": ["api_key", "index_host"],
+      "required": [
+        "api_key",
+        "index_host"
+      ],
       "additionalProperties": false
     },
     "proxy_config": {
@@ -2931,7 +3039,12 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["none", "http", "socks5", "environment"],
+          "enum": [
+            "none",
+            "http",
+            "socks5",
+            "environment"
+          ],
           "description": "Type of proxy to use"
         },
         "url": {
@@ -2952,7 +3065,9 @@
           "description": "PEM-encoded CA certificate to trust for TLS connections through the proxy (for SSL-intercepting proxies)"
         }
       },
-      "required": ["type"],
+      "required": [
+        "type"
+      ],
       "additionalProperties": false
     },
     "cluster_config": {
@@ -3005,11 +3120,18 @@
                   "description": "Number of failed probes before marking as failed"
                 }
               },
-              "required": ["timeout_seconds", "success_threshold", "failure_threshold"],
+              "required": [
+                "timeout_seconds",
+                "success_threshold",
+                "failure_threshold"
+              ],
               "additionalProperties": false
             }
           },
-          "required": ["port", "config"],
+          "required": [
+            "port",
+            "config"
+          ],
           "additionalProperties": false
         },
         "discovery": {
@@ -3022,7 +3144,14 @@
             },
             "type": {
               "type": "string",
-              "enum": ["kubernetes", "dns", "udp", "consul", "etcd", "mdns"],
+              "enum": [
+                "kubernetes",
+                "dns",
+                "udp",
+                "consul",
+                "etcd",
+                "mdns"
+              ],
               "description": "Discovery mechanism type"
             },
             "service_name": {
@@ -3036,8 +3165,9 @@
               "description": "Port to bind for cluster communication"
             },
             "dial_timeout": {
-              "type": "string",
-              "description": "Timeout for discovery dial operations as a Go duration string (e.g. '5s', '1m')"
+              "type": "integer",
+              "minimum": 0,
+              "description": "Timeout for discovery dial operations in nanoseconds"
             },
             "allowed_address_space": {
               "type": "array",
@@ -3083,14 +3213,18 @@
               "description": "mDNS service name for local network discovery"
             }
           },
-          "required": ["type"],
+          "required": [
+            "type"
+          ],
           "additionalProperties": false
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     },
-    "scim_config": {
+    "saml_config": {
       "type": "object",
       "description": "SAML/SCIM (System for Cross-domain Identity Management) configuration",
       "properties": {
@@ -3100,7 +3234,10 @@
         },
         "provider": {
           "type": "string",
-          "enum": ["okta", "entra"],
+          "enum": [
+            "okta",
+            "entra"
+          ],
           "description": "SCIM provider type"
         },
         "config": {
@@ -3108,7 +3245,9 @@
           "description": "Provider-specific configuration"
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false,
       "allOf": [
         {
@@ -3160,11 +3299,7 @@
         },
         "clientSecret": {
           "type": "string",
-          "description": "Okta client secret"
-        },
-        "apiToken": {
-          "type": "string",
-          "description": "Okta API token for Admin API access"
+          "description": "Okta client secret (optional, required for token revocation)"
         },
         "audience": {
           "type": "string",
@@ -3186,7 +3321,10 @@
           "default": "roles"
         }
       },
-      "required": ["issuerUrl", "clientId", "clientSecret", "apiToken"],
+      "required": [
+        "issuerUrl",
+        "clientId"
+      ],
       "additionalProperties": false
     },
     "entra_config": {
@@ -3236,7 +3374,10 @@
           "default": "roles"
         }
       },
-      "required": ["tenantId", "clientId"],
+      "required": [
+        "tenantId",
+        "clientId"
+      ],
       "additionalProperties": false
     },
     "load_balancer_config": {
@@ -3270,7 +3411,9 @@
           }
         }
       },
-      "required": ["enabled"],
+      "required": [
+        "enabled"
+      ],
       "additionalProperties": false
     },
     "guardrails_config": {
@@ -3305,7 +3448,11 @@
               },
               "apply_to": {
                 "type": "string",
-                "enum": ["input", "output", "both"],
+                "enum": [
+                  "input",
+                  "output",
+                  "both"
+                ],
                 "description": "When to apply the guardrail (input, output, or both)"
               },
               "sampling_rate": {
@@ -3327,7 +3474,13 @@
                 "description": "IDs of provider configurations to use with this rule"
               }
             },
-            "required": ["id", "name", "enabled", "cel_expression", "apply_to"],
+            "required": [
+              "id",
+              "name",
+              "enabled",
+              "cel_expression",
+              "apply_to"
+            ],
             "additionalProperties": false
           }
         },
@@ -3363,7 +3516,12 @@
                 "description": "Provider-specific configuration"
               }
             },
-            "required": ["id", "provider_name", "policy_name", "enabled"],
+            "required": [
+              "id",
+              "provider_name",
+              "policy_name",
+              "enabled"
+            ],
             "additionalProperties": false
           }
         }
@@ -3481,297 +3639,6 @@
           "additionalProperties": false
         }
       },
-      "additionalProperties": false
-    },
-    "provider_pricing_override": {
-      "type": "object",
-      "description": "Scoped pricing override applied at runtime by the model catalog",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Unique pricing override ID"
-        },
-        "name": {
-          "type": "string",
-          "description": "Human-readable name for this override"
-        },
-        "scope_kind": {
-          "type": "string",
-          "description": "Scope level for this override",
-          "enum": [
-            "global",
-            "provider",
-            "provider_key",
-            "virtual_key",
-            "virtual_key_provider",
-            "virtual_key_provider_key"
-          ]
-        },
-        "virtual_key_id": {
-          "type": "string",
-          "description": "Virtual key ID (required for virtual_key* scopes)"
-        },
-        "provider_id": {
-          "type": "string",
-          "description": "Provider ID (required for provider* scopes)"
-        },
-        "provider_key_id": {
-          "type": "string",
-          "description": "Provider key ID (required for provider_key and virtual_key_provider_key scopes)"
-        },
-        "match_type": {
-          "type": "string",
-          "description": "How the pattern is matched against model names",
-          "enum": ["exact", "wildcard"]
-        },
-        "pattern": {
-          "type": "string",
-          "description": "Model name pattern to match (exact name or wildcard prefix ending with *)"
-        },
-        "request_types": {
-          "type": "array",
-          "description": "Request types this override applies to. At least one value is required.",
-          "minItems": 1,
-          "items": {
-            "type": "string"
-          }
-        },
-        "pricing_patch": {
-          "type": "string",
-          "description": "JSON-encoded pricing fields to override (e.g. '{\"input_cost_per_token\":0.000001}')"
-        },
-        "config_hash": {
-          "type": "string",
-          "description": "Internal hash for change detection (auto-managed)"
-        }
-      },
-      "required": ["id", "name", "scope_kind", "match_type", "pattern", "request_types"],
-      "additionalProperties": false
-    },
-    "pricing_override_match_type": {
-      "type": "string",
-      "enum": ["exact", "wildcard"]
-    },
-    "pricing_override_request_type": {
-      "type": "string",
-      "enum": [
-        "chat_completion",
-        "text_completion",
-        "responses",
-        "embedding",
-        "rerank",
-        "speech",
-        "transcription",
-        "image_generation",
-        "image_variation",
-        "image_edit",
-        "video_generation",
-        "video_remix"
-      ]
-    },
-    "custom_provider_config": {
-      "type": "object",
-      "description": "Custom provider configuration for extending or customizing provider behavior",
-      "properties": {
-        "is_key_less": {
-          "type": "boolean",
-          "description": "Whether the custom provider requires a key"
-        },
-        "base_provider_type": {
-          "type": "string",
-          "enum": [
-            "openai",
-            "azure",
-            "anthropic",
-            "bedrock",
-            "cohere",
-            "vertex",
-            "mistral",
-            "ollama",
-            "groq",
-            "sgl",
-            "parasail",
-            "perplexity",
-            "cerebras",
-            "gemini",
-            "openrouter",
-            "elevenlabs",
-            "huggingface",
-            "nebius",
-            "xai",
-            "replicate",
-            "vllm",
-            "runway",
-            "fireworks"
-          ],
-          "description": "Base provider type to extend"
-        },
-        "request_path_overrides": {
-          "type": "object",
-          "description": "Mapping of request type to custom path overriding the default provider path",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "allowed_requests": {
-          "type": "object",
-          "description": "Allowed request types for the custom provider",
-          "properties": {
-            "list_models": {
-              "type": "boolean"
-            },
-            "text_completion": {
-              "type": "boolean"
-            },
-            "text_completion_stream": {
-              "type": "boolean"
-            },
-            "chat_completion": {
-              "type": "boolean"
-            },
-            "chat_completion_stream": {
-              "type": "boolean"
-            },
-            "responses": {
-              "type": "boolean"
-            },
-            "responses_stream": {
-              "type": "boolean"
-            },
-            "count_tokens": {
-              "type": "boolean"
-            },
-            "embedding": {
-              "type": "boolean"
-            },
-            "rerank": {
-              "type": "boolean"
-            },
-            "ocr": {
-              "type": "boolean"
-            },
-            "speech": {
-              "type": "boolean"
-            },
-            "speech_stream": {
-              "type": "boolean"
-            },
-            "transcription": {
-              "type": "boolean"
-            },
-            "transcription_stream": {
-              "type": "boolean"
-            },
-            "image_generation": {
-              "type": "boolean"
-            },
-            "image_generation_stream": {
-              "type": "boolean"
-            },
-            "image_edit": {
-              "type": "boolean"
-            },
-            "image_edit_stream": {
-              "type": "boolean"
-            },
-            "image_variation": {
-              "type": "boolean"
-            },
-            "video_generation": {
-              "type": "boolean"
-            },
-            "video_retrieve": {
-              "type": "boolean"
-            },
-            "video_download": {
-              "type": "boolean"
-            },
-            "video_delete": {
-              "type": "boolean"
-            },
-            "video_list": {
-              "type": "boolean"
-            },
-            "video_remix": {
-              "type": "boolean"
-            },
-            "batch_create": {
-              "type": "boolean"
-            },
-            "batch_list": {
-              "type": "boolean"
-            },
-            "batch_retrieve": {
-              "type": "boolean"
-            },
-            "batch_cancel": {
-              "type": "boolean"
-            },
-            "batch_delete": {
-              "type": "boolean"
-            },
-            "batch_results": {
-              "type": "boolean"
-            },
-            "file_upload": {
-              "type": "boolean"
-            },
-            "file_list": {
-              "type": "boolean"
-            },
-            "file_retrieve": {
-              "type": "boolean"
-            },
-            "file_delete": {
-              "type": "boolean"
-            },
-            "file_content": {
-              "type": "boolean"
-            },
-            "container_create": {
-              "type": "boolean"
-            },
-            "container_list": {
-              "type": "boolean"
-            },
-            "container_retrieve": {
-              "type": "boolean"
-            },
-            "container_delete": {
-              "type": "boolean"
-            },
-            "container_file_create": {
-              "type": "boolean"
-            },
-            "container_file_list": {
-              "type": "boolean"
-            },
-            "container_file_retrieve": {
-              "type": "boolean"
-            },
-            "container_file_content": {
-              "type": "boolean"
-            },
-            "container_file_delete": {
-              "type": "boolean"
-            },
-            "passthrough": {
-              "type": "boolean"
-            },
-            "passthrough_stream": {
-              "type": "boolean"
-            },
-            "websocket_responses": {
-              "type": "boolean"
-            },
-            "realtime": {
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
-        }
-      },
-      "required": ["base_provider_type"],
       "additionalProperties": false
     }
   }


### PR DESCRIPTION
## Summary

This PR simplifies and consolidates the `config.schema.json` by removing several features, collapsing provider-specific schema variants, and restructuring key configuration definitions to reduce complexity and align with updated runtime semantics.

## Changes

- Removed the top-level `version` field that controlled allow-list semantics for empty arrays
- Removed the `compat` plugin configuration block (including `convert_text_to_chat`, `convert_chat_to_responses`, `should_drop_params`, `should_convert_params`)
- Replaced `compat` with a simpler `enable_litellm_fallbacks` boolean for Groq text completion fallbacks
- Removed `mcp_disable_auto_tool_inject` and `routing_chain_max_depth` from server config
- Collapsed `provider_with_ollama_config`, `provider_with_sgl_config`, and `provider_with_replicate_config` into the generic `provider` definition; removed their corresponding key types (`ollama_key`, `sgl_key`, `replicate_key`) and `network_config_without_base_url`
- Removed providers `nebius`, `xai`, and `runway` from the providers block
- Moved `calendar_aligned` from `virtual_key` to the `budget` object; removed `virtual_key_id` and `provider_config_id` from budget in favor of a standalone `budget_id` reference on virtual keys
- Removed `chain_rule` from routing rules and relaxed the `scope_id` conditional requirement
- Simplified `virtual_key_provider_config` to inline key definitions with full provider-specific key configs (Azure, Vertex, Bedrock, VLLM), replacing the separate `key_ids` and `keys` split
- Removed `mcp_client_name` and `allow_on_all_virtual_keys` from MCP configs; removed `allowed_extra_headers` and `disable_auto_tool_inject` from MCP client config
- Added `websocket` as a supported MCP connection type with a dedicated `websocket_config` block; removed `inprocess` connection type
- Removed `per_user_oauth` as an MCP auth type and dropped the conditional `oauth_config_id` requirement
- Renamed `concurrency_and_buffer_size` to `concurrency_config`; renamed `retry_backoff_initial`/`retry_backoff_max` to `retry_backoff_initial_ms`/`retry_backoff_max_ms`; removed `enforce_http2` and `openai_config` from network config
- Moved `pricing_overrides` from the top-level config into individual provider definitions
- Simplified `provider_pricing_override` schema, removing scoped fields (`scope_kind`, `virtual_key_id`, `provider_id`, `provider_key_id`) and replacing `pattern` with `model_pattern`; added `regex` as a valid `match_type`; expanded supported `request_types`
- Renamed `scim_config` to `saml_config` in the top-level schema
- Removed `apiToken` from Okta config and made `clientSecret` optional; updated required fields to only `issuerUrl` and `clientId`
- Removed `object_storage` and `retention_days` from the logs store config
- Removed `id` and `description` fields from provider config entries in the `provider_configs` array
- Removed `websocket_responses` and `realtime` from `custom_provider_config` allowed requests; removed the enum constraint on `base_provider_type`
- Removed `disable_auto_tool_inject` from `mcp_client_config` VFS settings
- Added `deployments` mapping to `azure_key_config` and `vertex_key_config`
- Updated `otel` plugin `trace_type` to only accept `"otel"` (removed `genai_extension`, `vercel`, `open_inference`)
- Removed `prompts` from the built-in plugin name list
- Removed `builtin` as a valid plugin `placement` value
- Changed `cluster_config` discovery `dial_timeout` from a Go duration string to an integer (nanoseconds)
- Reformatted many inline `required` arrays to multi-line style for readability

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Validate existing configs against the updated schema to confirm they parse correctly. Verify that configs using removed fields (`version`, `compat`, `mcp_disable_auto_tool_inject`, `chain_rule`, etc.) are rejected by the schema validator.

```sh
go test ./...
```

Confirm that provider configs for Ollama, SGL, and Replicate continue to work using the generic `provider` definition. Confirm MCP clients using `websocket` connection type validate correctly with a `websocket_config` block.

## Breaking changes

- [x] Yes
- [ ] No

The following fields have been removed and configs using them will fail schema validation:

- `version` (top-level)
- `compat` block under server config
- `mcp_disable_auto_tool_inject` and `routing_chain_max_depth` under server config
- `chain_rule` on routing rules
- `calendar_aligned` on virtual keys (now on budgets)
- `virtual_key_id` / `provider_config_id` on budgets
- `apiToken` on Okta config (now optional `clientSecret` only)
- `object_storage` and `retention_days` on logs store
- `id`, `description` on provider config entries
- `allow_on_all_virtual_keys`, `allowed_extra_headers`, `disable_auto_tool_inject` on MCP client config
- `inprocess` MCP connection type and `per_user_oauth` auth type
- `enforce_http2` and `openai_config` from network config
- `builtin` plugin placement value; `prompts` built-in plugin name
- `nebius`, `xai`, `runway` provider entries

Migrate by removing or replacing these fields according to the updated schema definitions.

## Related issues

## Security considerations

Removal of `per_user_oauth` as an MCP auth type should be reviewed to ensure no active integrations depend on it. The relaxed `scope_id` requirement on routing rules should be validated to confirm it does not inadvertently broaden access scope.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable