### PR TITLE
bumped up hello-world dep

### DIFF
--- a/examples/plugins/hello-world-wasm-go/go.mod
+++ b/examples/plugins/hello-world-wasm-go/go.mod
@@ -2,9 +2,8 @@ module github.com/maximhq/bifrost/examples/plugins/hello-world-wasm
 
 go 1.26.1
 
-require github.com/maximhq/bifrost/core v0.0.0-00010101000000-000000000000
+require github.com/maximhq/bifrost/core v1.4.17
 
-replace github.com/maximhq/bifrost/core => ../../../core
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/examples/plugins/hello-world/go.mod
+++ b/examples/plugins/hello-world/go.mod
@@ -2,7 +2,7 @@ module github.com/maximhq/bifrost/examples/plugins/hello-world
 
 go 1.26.1
 
-require github.com/maximhq/bifrost/core v1.4.19
+require github.com/maximhq/bifrost/core v1.4.17
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect


### PR DESCRIPTION
## Summary

Pins the `bifrost/core` dependency in the example plugin modules to a consistent released version (`v1.4.17`), removing a local `replace` directive that was pointing to the local `core` module path.

## Changes

- Replaced the local `replace` directive in `hello-world-wasm-go/go.mod` with a direct reference to `github.com/maximhq/bifrost/core v1.4.17`
- Downgraded `hello-world/go.mod` from `v1.4.19` to `v1.4.17` to align both example plugins on the same released version

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
cd examples/plugins/hello-world-wasm-go
go mod tidy
go build ./...

cd examples/plugins/hello-world
go mod tidy
go build ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This change only affects dependency resolution for example plugin modules.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable