### PR TITLE
feat: support Bedrock fine-grained tool streaming passthrough

### DIFF
--- a/.github/workflows/ghcr-image.yml
+++ b/.github/workflows/ghcr-image.yml
@@ -7,6 +7,11 @@ on:
         description: "Optional image tag override, e.g. v1.5.0-prerelease3-bedrock-extra-parameters"
         required: false
         type: string
+      platforms:
+        description: "Docker platforms to build, comma-separated"
+        required: false
+        default: linux/amd64
+        type: string
       push_image:
         description: "Push image to GHCR"
         required: true
@@ -41,9 +46,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -104,11 +106,11 @@ jobs:
           file: ./transports/Dockerfile.local
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
-          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'workflow_dispatch' || inputs.push_image }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: ${{ github.event_name == 'workflow_dispatch' && inputs.platforms || 'linux/amd64' }}
 
       - name: Print published tags
         shell: bash

--- a/.github/workflows/ghcr-image.yml
+++ b/.github/workflows/ghcr-image.yml
@@ -40,13 +40,13 @@ jobs:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@e9b1fce52c5f5a2a565de72c27548c725fb6f93b # v3.6.0
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@v3
 
       - name: Compute image metadata
         id: meta
@@ -91,14 +91,14 @@ jobs:
 
       - name: Log in to GHCR
         if: github.event_name != 'workflow_dispatch' || inputs.push_image
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and optionally push image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./transports/Dockerfile.local

--- a/.github/workflows/ghcr-image.yml
+++ b/.github/workflows/ghcr-image.yml
@@ -1,0 +1,118 @@
+name: Publish GHCR Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Optional image tag override, e.g. v1.5.0-prerelease3-bedrock-extra-parameters"
+        required: false
+        type: string
+      push_image:
+        description: "Push image to GHCR"
+        required: true
+        default: true
+        type: boolean
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+    paths:
+      - ".github/workflows/ghcr-image.yml"
+      - "core/**"
+      - "framework/**"
+      - "plugins/**"
+      - "transports/**"
+      - "ui/**"
+
+concurrency:
+  group: ghcr-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    if: github.repository_owner != 'maximhq' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e9b1fce52c5f5a2a565de72c27548c725fb6f93b # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Compute image metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          IMAGE="ghcr.io/${OWNER_LC}/bifrost"
+          SHORT_SHA="${GITHUB_SHA::7}"
+
+          sanitize_ref() {
+            echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's#[^a-z0-9._-]#-#g'
+          }
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${{ inputs.image_tag }}" ]]; then
+            PRIMARY_TAG="${{ inputs.image_tag }}"
+          elif [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            PRIMARY_TAG="${GITHUB_REF_NAME}"
+          else
+            PRIMARY_TAG="$(sanitize_ref "${GITHUB_REF_NAME}")-${SHORT_SHA}"
+          fi
+
+          VERSION="${PRIMARY_TAG#v}"
+          TAGS="${IMAGE}:${PRIMARY_TAG}"
+
+          if [[ "${GITHUB_REF_NAME}" == "${DEFAULT_BRANCH}" ]]; then
+            TAGS="${TAGS}"$'\n'"${IMAGE}:latest"
+          fi
+
+          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
+            TAGS="${TAGS}"$'\n'"${IMAGE}:sha-${SHORT_SHA}"
+          fi
+
+          {
+            echo "image=${IMAGE}"
+            echo "version=${VERSION}"
+            echo "tags<<EOF"
+            echo "${TAGS}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        if: github.event_name != 'workflow_dispatch' || inputs.push_image
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and optionally push image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: ./transports/Dockerfile.local
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'workflow_dispatch' || inputs.push_image }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Print published tags
+        shell: bash
+        run: |
+          echo "Image: ${{ steps.meta.outputs.image }}"
+          echo "Tags:"
+          echo "${{ steps.meta.outputs.tags }}"

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2121,6 +2121,9 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 	params := &schemas.ResponsesParameters{
 		ExtraParams: make(map[string]interface{}),
 	}
+	for k, v := range req.ExtraParams {
+		params.ExtraParams[k] = v
+	}
 
 	if req.MaxTokens > 0 {
 		params.MaxOutputTokens = &req.MaxTokens
@@ -4720,10 +4723,11 @@ func convertAnthropicToolToBifrost(tool *AnthropicTool) *schemas.ResponsesTool {
 		Description: tool.Description,
 	}
 
-	if tool.InputSchema != nil || tool.Strict != nil {
+	if tool.InputSchema != nil || tool.Strict != nil || tool.EagerInputStreaming != nil {
 		bifrostTool.ResponsesToolFunction = &schemas.ResponsesToolFunction{
-			Parameters: tool.InputSchema,
-			Strict:     tool.Strict,
+			Parameters:          tool.InputSchema,
+			Strict:              tool.Strict,
+			EagerInputStreaming: tool.EagerInputStreaming,
 		}
 	}
 
@@ -5008,6 +5012,7 @@ func convertBifrostToolToAnthropic(model string, tool *schemas.ResponsesTool, pr
 	// Convert parameters and strict from ToolFunction
 	if tool.ResponsesToolFunction != nil {
 		anthropicTool.Strict = tool.ResponsesToolFunction.Strict
+		anthropicTool.EagerInputStreaming = tool.ResponsesToolFunction.EagerInputStreaming
 	}
 	if tool.ResponsesToolFunction != nil && tool.ResponsesToolFunction.Parameters != nil {
 		anthropicTool.InputSchema = tool.ResponsesToolFunction.Parameters

--- a/core/providers/anthropic/text.go
+++ b/core/providers/anthropic/text.go
@@ -71,11 +71,19 @@ func (req *AnthropicTextRequest) ToBifrostTextCompletionRequest(ctx *schemas.Bif
 		Fallbacks: schemas.ParseFallbacks(req.Fallbacks),
 	}
 
+	if len(req.ExtraParams) > 0 {
+		bifrostReq.Params.ExtraParams = make(map[string]interface{}, len(req.ExtraParams)+1)
+		for k, v := range req.ExtraParams {
+			bifrostReq.Params.ExtraParams[k] = v
+		}
+	}
+
 	// Add extra params if present
 	if req.TopK != nil {
-		bifrostReq.Params.ExtraParams = map[string]interface{}{
-			"top_k": *req.TopK,
+		if bifrostReq.Params.ExtraParams == nil {
+			bifrostReq.Params.ExtraParams = make(map[string]interface{}, 1)
 		}
+		bifrostReq.Params.ExtraParams["top_k"] = *req.TopK
 	}
 
 	return bifrostReq

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -39,6 +39,8 @@ const (
 	// AnthropicInterleavedThinkingBetaHeader is required for interleaved thinking between tool calls.
 	// Deprecated on Opus 4.6/Sonnet 4.6 (use adaptive thinking); active on older Claude 4 models.
 	AnthropicInterleavedThinkingBetaHeader = "interleaved-thinking-2025-05-14"
+	// AnthropicFineGrainedToolStreamingBetaHeader is required for fine-grained tool argument streaming.
+	AnthropicFineGrainedToolStreamingBetaHeader = "fine-grained-tool-streaming-2025-05-14"
 	// AnthropicSkillsBetaHeader is required for Agent Skills (also requires code-execution + files-api headers).
 	AnthropicSkillsBetaHeader = "skills-2025-10-02"
 	// AnthropicContext1MBetaHeader is required for 1M context window on Sonnet 4.5 and Sonnet 4.
@@ -60,45 +62,47 @@ const (
 	// Prefixes for beta headers (version-bump proof).
 	// Use these with strings.HasPrefix when filtering headers per provider,
 	// so that future date bumps (e.g. structured-outputs-2025-12-15) are still matched.
-	AnthropicAdvancedToolUseBetaHeaderPrefix     = "advanced-tool-use-"
-	AnthropicStructuredOutputsBetaHeaderPrefix   = "structured-outputs-"
-	AnthropicPromptCachingScopeBetaHeaderPrefix  = "prompt-caching-scope-"
-	AnthropicMCPClientBetaHeaderPrefix           = "mcp-client-"
-	AnthropicInterleavedThinkingBetaHeaderPrefix = "interleaved-thinking-"
-	AnthropicSkillsBetaHeaderPrefix              = "skills-"
-	AnthropicContext1MBetaHeaderPrefix           = "context-1m-"
-	AnthropicFastModeBetaHeaderPrefix            = "fast-mode-"
-	AnthropicRedactThinkingBetaHeaderPrefix      = "redact-thinking-"
-	AnthropicTaskBudgetsBetaHeaderPrefix         = "task-budgets-"
+	AnthropicAdvancedToolUseBetaHeaderPrefix          = "advanced-tool-use-"
+	AnthropicFineGrainedToolStreamingBetaHeaderPrefix = "fine-grained-tool-streaming-"
+	AnthropicStructuredOutputsBetaHeaderPrefix        = "structured-outputs-"
+	AnthropicPromptCachingScopeBetaHeaderPrefix       = "prompt-caching-scope-"
+	AnthropicMCPClientBetaHeaderPrefix                = "mcp-client-"
+	AnthropicInterleavedThinkingBetaHeaderPrefix      = "interleaved-thinking-"
+	AnthropicSkillsBetaHeaderPrefix                   = "skills-"
+	AnthropicContext1MBetaHeaderPrefix                = "context-1m-"
+	AnthropicFastModeBetaHeaderPrefix                 = "fast-mode-"
+	AnthropicRedactThinkingBetaHeaderPrefix           = "redact-thinking-"
+	AnthropicTaskBudgetsBetaHeaderPrefix              = "task-budgets-"
 )
 
 // ProviderFeatureSupport defines which Anthropic features a given provider supports.
 // Source: https://docs.anthropic.com/en/build-with-claude/overview (March 2026)
 type ProviderFeatureSupport struct {
-	WebSearch           bool // web_search server tool
-	WebSearchDynamic    bool // web_search_20260209 (dynamic filtering, requires code_execution)
-	WebFetch            bool // web_fetch server tool
-	CodeExecution       bool // code_execution server tool
-	ComputerUse         bool // computer_use client tool
-	Bash                bool // bash client tool
-	Memory              bool // memory client tool
-	TextEditor          bool // text_editor client tool
-	ToolSearch          bool // tool_search server tool
-	MCP                 bool // MCP connector
-	AdvancedToolUse     bool // advanced-tool-use (defer_loading, input_examples, allowed_callers)
-	StructuredOutputs   bool // strict tool validation and output_format
-	PromptCachingScope  bool // prompt caching scope
-	Compaction          bool // server-side context compaction
-	ContextEditing      bool // context editing (clear_tool_uses, clear_thinking)
-	FilesAPI            bool // Files API
-	InterleavedThinking bool // interleaved thinking between tool calls
-	Skills              bool // Agent Skills
-	Context1M           bool // 1M context window beta (for Sonnet 4.5/4 only)
-	FastMode            bool // fast mode (Opus 4.6 only, research preview)
-	RedactThinking      bool // redact thinking blocks in responses
-	TaskBudgets         bool // task_budget in output_config (Opus 4.7+)
-	FileSearch          bool // file_search server tool (OpenAI-only)
-	ImageGeneration     bool // image_generation server tool (OpenAI-only)
+	WebSearch                bool // web_search server tool
+	WebSearchDynamic         bool // web_search_20260209 (dynamic filtering, requires code_execution)
+	WebFetch                 bool // web_fetch server tool
+	CodeExecution            bool // code_execution server tool
+	ComputerUse              bool // computer_use client tool
+	Bash                     bool // bash client tool
+	Memory                   bool // memory client tool
+	TextEditor               bool // text_editor client tool
+	ToolSearch               bool // tool_search server tool
+	MCP                      bool // MCP connector
+	AdvancedToolUse          bool // advanced-tool-use (defer_loading, input_examples, allowed_callers)
+	FineGrainedToolStreaming bool // fine-grained-tool-streaming (eager_input_streaming)
+	StructuredOutputs        bool // strict tool validation and output_format
+	PromptCachingScope       bool // prompt caching scope
+	Compaction               bool // server-side context compaction
+	ContextEditing           bool // context editing (clear_tool_uses, clear_thinking)
+	FilesAPI                 bool // Files API
+	InterleavedThinking      bool // interleaved thinking between tool calls
+	Skills                   bool // Agent Skills
+	Context1M                bool // 1M context window beta (for Sonnet 4.5/4 only)
+	FastMode                 bool // fast mode (Opus 4.6 only, research preview)
+	RedactThinking           bool // redact thinking blocks in responses
+	TaskBudgets              bool // task_budget in output_config (Opus 4.7+)
+	FileSearch               bool // file_search server tool (OpenAI-only)
+	ImageGeneration          bool // image_generation server tool (OpenAI-only)
 }
 
 // ProviderFeatures maps each provider to its supported Anthropic features.
@@ -106,7 +110,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 	schemas.Anthropic: {
 		WebSearch: true, WebSearchDynamic: true, WebFetch: true, CodeExecution: true,
 		ComputerUse: true, Bash: true, Memory: true, TextEditor: true, ToolSearch: true,
-		MCP: true, AdvancedToolUse: true, StructuredOutputs: true, PromptCachingScope: true,
+		MCP: true, AdvancedToolUse: true, FineGrainedToolStreaming: true, StructuredOutputs: true, PromptCachingScope: true,
 		Compaction: true, ContextEditing: true, FilesAPI: true,
 		InterleavedThinking: true, Skills: true, Context1M: true, FastMode: true,
 		RedactThinking: true, TaskBudgets: true,
@@ -119,7 +123,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 	},
 	schemas.Bedrock: {
 		ComputerUse: true, Bash: true, Memory: true, TextEditor: true, ToolSearch: true,
-		StructuredOutputs: true, Compaction: true, ContextEditing: true,
+		FineGrainedToolStreaming: true, StructuredOutputs: true, Compaction: true, ContextEditing: true,
 		InterleavedThinking: true, Context1M: true,
 	},
 	schemas.Azure: {
@@ -153,6 +157,11 @@ type AnthropicTextRequest struct {
 // GetExtraParams implements the RequestBodyWithExtraParams interface
 func (req *AnthropicTextRequest) GetExtraParams() map[string]interface{} {
 	return req.ExtraParams
+}
+
+// SetExtraParams implements the ExtraParamsSetter interface.
+func (req *AnthropicTextRequest) SetExtraParams(params map[string]interface{}) {
+	req.ExtraParams = params
 }
 
 // IsStreamingRequested implements the StreamingRequest interface
@@ -220,6 +229,11 @@ func (req *AnthropicMessageRequest) SetStripCacheControlScope(strip bool) {
 // GetExtraParams implements the RequestBodyWithExtraParams interface
 func (req *AnthropicMessageRequest) GetExtraParams() map[string]interface{} {
 	return req.ExtraParams
+}
+
+// SetExtraParams implements the ExtraParamsSetter interface.
+func (req *AnthropicMessageRequest) SetExtraParams(params map[string]interface{}) {
+	req.ExtraParams = params
 }
 
 type AnthropicMetaData struct {
@@ -938,15 +952,16 @@ type AnthropicToolInputExample struct {
 
 // AnthropicTool represents a tool in Anthropic format
 type AnthropicTool struct {
-	Name           string                          `json:"name"`
-	Type           *AnthropicToolType              `json:"type,omitempty"`
-	Description    *string                         `json:"description,omitempty"`
-	InputSchema    *schemas.ToolFunctionParameters `json:"input_schema,omitempty"`
-	CacheControl   *schemas.CacheControl           `json:"cache_control,omitempty"`
-	DeferLoading   *bool                           `json:"defer_loading,omitempty"`   // Beta: defer loading of tool definition
-	Strict         *bool                           `json:"strict,omitempty"`          // Whether to enforce strict parameter validation
-	AllowedCallers []string                        `json:"allowed_callers,omitempty"` // Beta: which callers can use this tool
-	InputExamples  []AnthropicToolInputExample     `json:"input_examples,omitempty"`  // Beta: example inputs for the tool
+	Name                string                          `json:"name"`
+	Type                *AnthropicToolType              `json:"type,omitempty"`
+	Description         *string                         `json:"description,omitempty"`
+	InputSchema         *schemas.ToolFunctionParameters `json:"input_schema,omitempty"`
+	EagerInputStreaming *bool                           `json:"eager_input_streaming,omitempty"` // Beta: stream tool input JSON in smaller deltas
+	CacheControl        *schemas.CacheControl           `json:"cache_control,omitempty"`
+	DeferLoading        *bool                           `json:"defer_loading,omitempty"`   // Beta: defer loading of tool definition
+	Strict              *bool                           `json:"strict,omitempty"`          // Whether to enforce strict parameter validation
+	AllowedCallers      []string                        `json:"allowed_callers,omitempty"` // Beta: which callers can use this tool
+	InputExamples       []AnthropicToolInputExample     `json:"input_examples,omitempty"`  // Beta: example inputs for the tool
 
 	*AnthropicToolComputerUse
 	*AnthropicToolWebSearch

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -291,6 +291,11 @@ func AddMissingBetaHeadersToContext(ctx *schemas.BifrostContext, req *AnthropicM
 			if len(tool.AllowedCallers) > 0 {
 				headers = appendUniqueHeader(headers, AnthropicAdvancedToolUseBetaHeader)
 			}
+			if tool.EagerInputStreaming != nil && *tool.EagerInputStreaming {
+				if !hasProvider || features.FineGrainedToolStreaming {
+					headers = appendUniqueHeader(headers, AnthropicFineGrainedToolStreamingBetaHeader)
+				}
+			}
 			// Check for cache control with scope
 			if !hasCachingScope && tool.CacheControl != nil && tool.CacheControl.Scope != nil {
 				if !hasProvider || features.PromptCachingScope {
@@ -415,6 +420,7 @@ var betaHeaderPrefixKnown = []string{
 	"context-management-",
 	"files-api-",
 	AnthropicAdvancedToolUseBetaHeaderPrefix,
+	AnthropicFineGrainedToolStreamingBetaHeaderPrefix,
 	AnthropicInterleavedThinkingBetaHeaderPrefix,
 	AnthropicSkillsBetaHeaderPrefix,
 	AnthropicContext1MBetaHeaderPrefix,
@@ -606,10 +612,13 @@ var betaHeaderPrefixToFeature = map[string]func(ProviderFeatureSupport) bool{
 	AnthropicStructuredOutputsBetaHeaderPrefix:  func(f ProviderFeatureSupport) bool { return f.StructuredOutputs },
 	AnthropicMCPClientBetaHeaderPrefix:          func(f ProviderFeatureSupport) bool { return f.MCP },
 	AnthropicPromptCachingScopeBetaHeaderPrefix: func(f ProviderFeatureSupport) bool { return f.PromptCachingScope },
-	"compact-":                                   func(f ProviderFeatureSupport) bool { return f.Compaction },
-	"context-management-":                        func(f ProviderFeatureSupport) bool { return f.ContextEditing },
-	"files-api-":                                 func(f ProviderFeatureSupport) bool { return f.FilesAPI },
-	AnthropicAdvancedToolUseBetaHeaderPrefix:     func(f ProviderFeatureSupport) bool { return f.AdvancedToolUse },
+	"compact-":                               func(f ProviderFeatureSupport) bool { return f.Compaction },
+	"context-management-":                    func(f ProviderFeatureSupport) bool { return f.ContextEditing },
+	"files-api-":                             func(f ProviderFeatureSupport) bool { return f.FilesAPI },
+	AnthropicAdvancedToolUseBetaHeaderPrefix: func(f ProviderFeatureSupport) bool { return f.AdvancedToolUse },
+	AnthropicFineGrainedToolStreamingBetaHeaderPrefix: func(f ProviderFeatureSupport) bool {
+		return f.FineGrainedToolStreaming
+	},
 	AnthropicInterleavedThinkingBetaHeaderPrefix: func(f ProviderFeatureSupport) bool { return f.InterleavedThinking },
 	AnthropicSkillsBetaHeaderPrefix:              func(f ProviderFeatureSupport) bool { return f.Skills },
 	AnthropicContext1MBetaHeaderPrefix:           func(f ProviderFeatureSupport) bool { return f.Context1M },

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -1059,6 +1059,7 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 	t.Run("Bedrock/keeps_supported_headers", func(t *testing.T) {
 		supported := []string{
 			AnthropicComputerUseBetaHeader20251124,
+			AnthropicFineGrainedToolStreamingBetaHeader,
 			AnthropicStructuredOutputsBetaHeader,
 			AnthropicCompactionBetaHeader,
 			AnthropicContextManagementBetaHeader,
@@ -1068,6 +1069,32 @@ func TestFilterBetaHeadersForProvider(t *testing.T) {
 		result := FilterBetaHeadersForProvider(supported, schemas.Bedrock)
 		if len(result) != len(supported) {
 			t.Errorf("expected %d headers, got %d: %v", len(supported), len(result), result)
+		}
+	})
+
+	t.Run("Bedrock/auto_adds_fine_grained_tool_streaming_header", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		req := &AnthropicMessageRequest{
+			Tools: []AnthropicTool{
+				{
+					Name:                "write_file",
+					EagerInputStreaming: schemas.Ptr(true),
+				},
+			},
+		}
+
+		if err := AddMissingBetaHeadersToContext(ctx, req, schemas.Bedrock); err != nil {
+			t.Fatalf("AddMissingBetaHeadersToContext() error = %v", err)
+		}
+
+		extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+		if !ok {
+			t.Fatal("expected extra headers to be set on context")
+		}
+
+		betaHeaders := extraHeaders[AnthropicBetaHeader]
+		if len(betaHeaders) != 1 || betaHeaders[0] != AnthropicFineGrainedToolStreamingBetaHeader {
+			t.Fatalf("expected %q to be added, got %v", AnthropicFineGrainedToolStreamingBetaHeader, betaHeaders)
 		}
 	})
 

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -41,6 +41,15 @@ type BedrockProvider struct {
 	sendBackRawResponse  bool                          // Whether to include raw response in BifrostResponse
 }
 
+func (provider *BedrockProvider) streamingHTTPClient() *http.Client {
+	return &http.Client{
+		Transport:     provider.client.Transport,
+		CheckRedirect: provider.client.CheckRedirect,
+		Jar:           provider.client.Jar,
+		Timeout:       0,
+	}
+}
+
 // assumeRoleCredsCache caches *aws.CredentialsCache instances keyed by the
 // unique combination of role parameters so that STS AssumeRole is not called
 // on every request.
@@ -463,7 +472,7 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx *schemas.BifrostContex
 	}
 
 	// Make the request
-	resp, respErr := provider.client.Do(req)
+	resp, respErr := provider.streamingHTTPClient().Do(req)
 	if respErr != nil {
 		if errors.Is(respErr, context.Canceled) {
 			return nil, deployment, &schemas.BifrostError{

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -181,53 +181,53 @@ func TestBedrock(t *testing.T) {
 			{Provider: schemas.Bedrock, Model: "claude-4-sonnet"},
 			{Provider: schemas.Bedrock, Model: "claude-4.5-sonnet"},
 		},
-		EmbeddingModel:      "cohere.embed-v4:0",
-		RerankModel:         rerankModelARN,
-		ReasoningModel:      "claude-4.5-sonnet",
-		PromptCachingModel:  "claude-4.5-sonnet",
-		ImageEditModel:      "amazon.nova-canvas-v1:0",
-		ImageVariationModel: "amazon.nova-canvas-v1:0",
+		EmbeddingModel:           "cohere.embed-v4:0",
+		RerankModel:              rerankModelARN,
+		ReasoningModel:           "claude-4.5-sonnet",
+		PromptCachingModel:       "claude-4.5-sonnet",
+		ImageEditModel:           "amazon.nova-canvas-v1:0",
+		ImageVariationModel:      "amazon.nova-canvas-v1:0",
 		InterleavedThinkingModel: "global.anthropic.claude-opus-4-5-20251101-v1:0",
-		BatchExtraParams:        batchExtraParams,
-		FileExtraParams:         fileExtraParams,
+		BatchExtraParams:         batchExtraParams,
+		FileExtraParams:          fileExtraParams,
 		Scenarios: llmtests.TestScenarios{
-			TextCompletion:        false, // Not supported
-			SimpleChat:            true,
-			CompletionStream:      true,
-			MultiTurnConversation: true,
-			ToolCalls:             true,
-			ToolCallsStreaming:    true,
+			TextCompletion:             false, // Not supported
+			SimpleChat:                 true,
+			CompletionStream:           true,
+			MultiTurnConversation:      true,
+			ToolCalls:                  true,
+			ToolCallsStreaming:         true,
 			MultipleToolCalls:          true,
 			MultipleToolCallsStreaming: true,
-			End2EndToolCalling:    true,
-			AutomaticFunctionCall: true,
-			ImageURL:              false, // Bedrock doesn't support image URL
-			ImageBase64:           true,
-			MultipleImages:        false, // Since one of the image is URL
-			FileBase64:            true,
-			FileURL:               false, // S3 urls supported for nova models
-			CompleteEnd2End:       true,
-			Embedding:             true,
-			Rerank:                rerankModelARN != "",
-			ListModels:            true,
-			Reasoning:             true,
-			PromptCaching:         true,
-			BatchCreate:           true,
-			BatchList:             true,
-			BatchRetrieve:         true,
-			BatchCancel:           true,
-			BatchResults:          true,
-			FileUpload:            true,
-			FileList:              true,
-			FileRetrieve:          true,
-			FileDelete:            true,
-			FileContent:           true,
-			FileBatchInput:        true,
-			CountTokens:           true,
-			ImageEdit:             true,
-			ImageVariation:        true,
-			StructuredOutputs:     true,
-			InterleavedThinking:  true,
+			End2EndToolCalling:         true,
+			AutomaticFunctionCall:      true,
+			ImageURL:                   false, // Bedrock doesn't support image URL
+			ImageBase64:                true,
+			MultipleImages:             false, // Since one of the image is URL
+			FileBase64:                 true,
+			FileURL:                    false, // S3 urls supported for nova models
+			CompleteEnd2End:            true,
+			Embedding:                  true,
+			Rerank:                     rerankModelARN != "",
+			ListModels:                 true,
+			Reasoning:                  true,
+			PromptCaching:              true,
+			BatchCreate:                true,
+			BatchList:                  true,
+			BatchRetrieve:              true,
+			BatchCancel:                true,
+			BatchResults:               true,
+			FileUpload:                 true,
+			FileList:                   true,
+			FileRetrieve:               true,
+			FileDelete:                 true,
+			FileContent:                true,
+			FileBatchInput:             true,
+			CountTokens:                true,
+			ImageEdit:                  true,
+			ImageVariation:             true,
+			StructuredOutputs:          true,
+			InterleavedThinking:        true,
 		},
 	}
 
@@ -4316,4 +4316,35 @@ func TestToolResultImageContentResponsesAPI(t *testing.T) {
 		require.NotNil(t, toolResult)
 		assert.Empty(t, toolResult.Content, "remote URL image should be dropped (Bedrock only supports base64)")
 	})
+}
+
+func TestToBedrockResponsesRequest_PreservesEagerInputStreaming(t *testing.T) {
+	t.Parallel()
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	req := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Bedrock,
+		Model:    "global.anthropic.claude-sonnet-4-6-v1:0",
+		Params: &schemas.ResponsesParameters{
+			Tools: []schemas.ResponsesTool{
+				{
+					Type:        schemas.ResponsesToolTypeFunction,
+					Name:        schemas.Ptr("write_file"),
+					Description: schemas.Ptr("Write content to a file"),
+					ResponsesToolFunction: &schemas.ResponsesToolFunction{
+						EagerInputStreaming: schemas.Ptr(true),
+					},
+				},
+			},
+		},
+	}
+
+	result, err := bedrock.ToBedrockResponsesRequest(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.ToolConfig)
+	require.Len(t, result.ToolConfig.Tools, 1)
+	require.NotNil(t, result.ToolConfig.Tools[0].ToolSpec)
+	require.NotNil(t, result.ToolConfig.Tools[0].ToolSpec.EagerInputStreaming)
+	assert.True(t, *result.ToolConfig.Tools[0].ToolSpec.EagerInputStreaming)
 }

--- a/core/providers/bedrock/invoke.go
+++ b/core/providers/bedrock/invoke.go
@@ -394,6 +394,9 @@ func (r *BedrockInvokeRequest) convertAnthropicTools() *BedrockToolConfig {
 			inputSchemaBytes, _ := providerUtils.MarshalSorted(inputSchema)
 			spec.InputSchema = BedrockToolInputSchema{JSON: json.RawMessage(inputSchemaBytes)}
 		}
+		if eagerInputStreaming, ok := toolMap["eager_input_streaming"].(bool); ok {
+			spec.EagerInputStreaming = &eagerInputStreaming
+		}
 
 		bedrockTools = append(bedrockTools, BedrockTool{ToolSpec: spec})
 	}
@@ -780,7 +783,7 @@ func toAnthropicInvokeStreamBytes(resp *schemas.BifrostResponsesStreamResponse) 
 				"type":  "content_block_delta",
 				"index": idx,
 				"delta": map[string]interface{}{
-					"type":          "input_json_delta",
+					"type":         "input_json_delta",
 					"partial_json": *resp.Delta,
 				},
 			}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1433,6 +1433,7 @@ func (request *BedrockConverseRequest) ToBifrostResponsesRequest(ctx *schemas.Bi
 						}
 					}
 				}
+				bifrostTool.ResponsesToolFunction.EagerInputStreaming = tool.ToolSpec.EagerInputStreaming
 
 				bifrostReq.Params.Tools = append(bifrostReq.Params.Tools, bifrostTool)
 			} else if tool.CachePoint != nil && !schemas.IsNovaModel(bifrostReq.Model) {
@@ -1933,8 +1934,9 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 				}
 				bedrockTool := BedrockTool{
 					ToolSpec: &BedrockToolSpec{
-						Name:        name,
-						Description: &description,
+						Name:                name,
+						Description:         &description,
+						EagerInputStreaming: tool.ResponsesToolFunction.EagerInputStreaming,
 						InputSchema: BedrockToolInputSchema{
 							JSON: json.RawMessage(schemaObjectBytes),
 						},

--- a/core/providers/bedrock/streaming_client_test.go
+++ b/core/providers/bedrock/streaming_client_test.go
@@ -1,0 +1,27 @@
+package bedrock
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestStreamingHTTPClient_DisablesTotalTimeout(t *testing.T) {
+	t.Parallel()
+
+	baseTransport := http.DefaultTransport
+	provider := &BedrockProvider{
+		client: &http.Client{
+			Transport: baseTransport,
+			Timeout:   120 * time.Second,
+		},
+	}
+
+	streamClient := provider.streamingHTTPClient()
+	if streamClient.Timeout != 0 {
+		t.Fatalf("streaming client timeout = %v, want 0", streamClient.Timeout)
+	}
+	if streamClient.Transport != baseTransport {
+		t.Fatal("streaming client should reuse the provider transport")
+	}
+}

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -308,9 +308,10 @@ type BedrockTool struct {
 
 // BedrockToolSpec represents the specification of a tool
 type BedrockToolSpec struct {
-	Name        string                 `json:"name"`                  // Required: Tool name
-	Description *string                `json:"description,omitempty"` // Optional: Tool description
-	InputSchema BedrockToolInputSchema `json:"inputSchema"`           // Required: JSON schema for tool input
+	Name                string                 `json:"name"`                            // Required: Tool name
+	Description         *string                `json:"description,omitempty"`           // Optional: Tool description
+	InputSchema         BedrockToolInputSchema `json:"inputSchema"`                     // Required: JSON schema for tool input
+	EagerInputStreaming *bool                  `json:"eager_input_streaming,omitempty"` // Anthropic-compatible Bedrock extension for fine-grained tool streaming
 }
 
 // BedrockToolInputSchema represents the input schema for a tool (union type)

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1935,7 +1935,7 @@ func SetupStreamCancellation(ctx context.Context, bodyStream io.Reader, logger s
 // before bifrost considers the connection stalled and closes it. This protects
 // against providers that stop sending data but keep the TCP connection open
 // (e.g., Azure TPM throttling).
-const DefaultStreamIdleTimeout = 60 * time.Second
+const DefaultStreamIdleTimeout = 600 * time.Second
 
 // SetStreamIdleTimeoutIfEmpty sets the stream idle timeout on the context from
 // the provider's network config, but only if no valid timeout is already present.

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -8,18 +8,18 @@ import (
 )
 
 const (
-	DefaultMaxRetries              = 0
-	DefaultRetryBackoffInitial     = 500 * time.Millisecond
-	DefaultRetryBackoffMax         = 5 * time.Second
+	DefaultMaxRetries                 = 0
+	DefaultRetryBackoffInitial        = 500 * time.Millisecond
+	DefaultRetryBackoffMax            = 5 * time.Second
 	DefaultRequestTimeoutInSeconds    = 30
-	DefaultMaxConnDurationInSeconds  = 300 // 5 minutes — forces connection recycling to prevent stale connections from NAT/LB silent drops
-	DefaultBufferSize                = 5000
-	DefaultConcurrency             = 1000
-	DefaultStreamBufferSize              = 256
-	DefaultStreamIdleTimeoutInSeconds    = 60 // Idle timeout per stream chunk — if no data for this many seconds, bifrost closes the connection
-	DefaultMaxConnsPerHost               = 5000
-	MaxConnsPerHostUpperBound            = 10000
-	DefaultMaxIdleConnsPerHost           = 40
+	DefaultMaxConnDurationInSeconds   = 300 // 5 minutes — forces connection recycling to prevent stale connections from NAT/LB silent drops
+	DefaultBufferSize                 = 5000
+	DefaultConcurrency                = 1000
+	DefaultStreamBufferSize           = 256
+	DefaultStreamIdleTimeoutInSeconds = 600 // Idle timeout per stream chunk — if no data for this many seconds, bifrost closes the connection
+	DefaultMaxConnsPerHost            = 5000
+	MaxConnsPerHostUpperBound         = 10000
+	DefaultMaxIdleConnsPerHost        = 40
 )
 
 // Pre-defined errors for provider operations
@@ -52,18 +52,18 @@ const (
 //   - When marshaling to JSON: a time.Duration is converted to milliseconds
 type NetworkConfig struct {
 	// BaseURL is supported for OpenAI, Anthropic, Cohere, Mistral, and Ollama providers (required for Ollama)
-	BaseURL                        string            `json:"base_url,omitempty"`                 // Base URL for the provider (optional)
-	ExtraHeaders                   map[string]string `json:"extra_headers,omitempty"`            // Additional headers to include in requests (optional)
-	DefaultRequestTimeoutInSeconds int               `json:"default_request_timeout_in_seconds"` // Default timeout for requests
-	MaxRetries                     int               `json:"max_retries"`                        // Maximum number of retries
-	RetryBackoffInitial            time.Duration     `json:"retry_backoff_initial"`              // Initial backoff duration (stored as nanoseconds, JSON as milliseconds)
-	RetryBackoffMax                time.Duration     `json:"retry_backoff_max"`                  // Maximum backoff duration (stored as nanoseconds, JSON as milliseconds)
-	InsecureSkipVerify             bool              `json:"insecure_skip_verify,omitempty"`     // Disables TLS certificate verification for provider connections
-	CACertPEM                      string            `json:"ca_cert_pem,omitempty"`              // PEM-encoded CA certificate to trust for provider endpoint connections
-	StreamIdleTimeoutInSeconds     int               `json:"stream_idle_timeout_in_seconds,omitempty"` // Idle timeout per stream chunk (0 = use default 60s)
-	MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`              // Max TCP connections per provider host (default: 5000)
-	EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`                   // Force HTTP/2 on provider connections (relevant for net/http-based providers like Bedrock)
-	BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`           // Override default beta header support per provider (keys are prefixes like "redact-thinking-")
+	BaseURL                        string            `json:"base_url,omitempty"`                       // Base URL for the provider (optional)
+	ExtraHeaders                   map[string]string `json:"extra_headers,omitempty"`                  // Additional headers to include in requests (optional)
+	DefaultRequestTimeoutInSeconds int               `json:"default_request_timeout_in_seconds"`       // Default timeout for requests
+	MaxRetries                     int               `json:"max_retries"`                              // Maximum number of retries
+	RetryBackoffInitial            time.Duration     `json:"retry_backoff_initial"`                    // Initial backoff duration (stored as nanoseconds, JSON as milliseconds)
+	RetryBackoffMax                time.Duration     `json:"retry_backoff_max"`                        // Maximum backoff duration (stored as nanoseconds, JSON as milliseconds)
+	InsecureSkipVerify             bool              `json:"insecure_skip_verify,omitempty"`           // Disables TLS certificate verification for provider connections
+	CACertPEM                      string            `json:"ca_cert_pem,omitempty"`                    // PEM-encoded CA certificate to trust for provider endpoint connections
+	StreamIdleTimeoutInSeconds     int               `json:"stream_idle_timeout_in_seconds,omitempty"` // Idle timeout per stream chunk (0 = use default 600s)
+	MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`             // Max TCP connections per provider host (default: 5000)
+	EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`                  // Force HTTP/2 on provider connections (relevant for net/http-based providers like Bedrock)
+	BetaHeaderOverrides            map[string]bool   `json:"beta_header_overrides,omitempty"`          // Override default beta header support per provider (keys are prefixes like "redact-thinking-")
 }
 
 // UnmarshalJSON customizes JSON unmarshaling for NetworkConfig.
@@ -485,14 +485,14 @@ type ProviderConfig struct {
 	NetworkConfig            NetworkConfig            `json:"network_config"`              // Network configuration
 	ConcurrencyAndBufferSize ConcurrencyAndBufferSize `json:"concurrency_and_buffer_size"` // Concurrency settings
 	// Logger instance, can be provided by the user or bifrost default logger is used if not provided
-	Logger               Logger                    `json:"-"`
-	ProxyConfig          *ProxyConfig              `json:"proxy_config,omitempty"` // Proxy configuration
-	SendBackRawRequest        bool                      `json:"send_back_raw_request"`         // Send raw request back in the bifrost response (default: false)
-	SendBackRawResponse       bool                      `json:"send_back_raw_response"`        // Send raw response back in the bifrost response (default: false)
-	StoreRawRequestResponse   bool                      `json:"store_raw_request_response"`    // Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)
-	CustomProviderConfig *CustomProviderConfig     `json:"custom_provider_config,omitempty"`
-	OpenAIConfig         *OpenAIConfig             `json:"openai_config,omitempty"`
-	PricingOverrides     []ProviderPricingOverride `json:"pricing_overrides,omitempty"`
+	Logger                  Logger                    `json:"-"`
+	ProxyConfig             *ProxyConfig              `json:"proxy_config,omitempty"`     // Proxy configuration
+	SendBackRawRequest      bool                      `json:"send_back_raw_request"`      // Send raw request back in the bifrost response (default: false)
+	SendBackRawResponse     bool                      `json:"send_back_raw_response"`     // Send raw response back in the bifrost response (default: false)
+	StoreRawRequestResponse bool                      `json:"store_raw_request_response"` // Capture raw request/response for internal logging only; strip from API responses returned to clients (default: false)
+	CustomProviderConfig    *CustomProviderConfig     `json:"custom_provider_config,omitempty"`
+	OpenAIConfig            *OpenAIConfig             `json:"openai_config,omitempty"`
+	PricingOverrides        []ProviderPricingOverride `json:"pricing_overrides,omitempty"`
 }
 
 // OpenAIConfig holds OpenAI-specific provider configuration.

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1652,8 +1652,9 @@ func (t *ResponsesTool) UnmarshalJSON(data []byte) error {
 
 // ResponsesToolFunction represents a tool function
 type ResponsesToolFunction struct {
-	Parameters *ToolFunctionParameters `json:"parameters,omitempty"` // A JSON schema object describing the parameters
-	Strict     *bool                   `json:"strict"`               // Whether to enforce strict parameter validation
+	Parameters          *ToolFunctionParameters `json:"parameters,omitempty"`            // A JSON schema object describing the parameters
+	Strict              *bool                   `json:"strict"`                          // Whether to enforce strict parameter validation
+	EagerInputStreaming *bool                   `json:"eager_input_streaming,omitempty"` // Provider-specific fine-grained tool argument streaming
 }
 
 // ResponsesToolFileSearch represents a tool file search

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -199,6 +199,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddHeaderFilterConfigJSONColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddAzureDeploymentsJSONColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddAzureClientIDAndClientSecretAndTenantIDColumns(ctx, db); err != nil {
 		return err
 	}
@@ -2549,6 +2552,37 @@ func migrationAddAzureClientIDAndClientSecretAndTenantIDColumns(ctx context.Cont
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running azure_client_id_and_client_secret_and_tenant_id migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddAzureDeploymentsJSONColumn adds the azure_deployments_json column to the key table.
+func migrationAddAzureDeploymentsJSONColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_azure_deployments_json_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&tables.TableKey{}, "azure_deployments_json") {
+				if err := migrator.AddColumn(&tables.TableKey{}, "azure_deployments_json"); err != nil {
+					return fmt.Errorf("failed to add azure_deployments_json column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if migrator.HasColumn(&tables.TableKey{}, "azure_deployments_json") {
+				if err := migrator.DropColumn(&tables.TableKey{}, "azure_deployments_json"); err != nil {
+					return fmt.Errorf("failed to drop azure_deployments_json column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running azure_deployments_json migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -884,3 +884,192 @@ func TestMigrationAddStoreRawRequestResponseColumn_Idempotent(t *testing.T) {
 		})
 	}
 }
+
+func setupKeyTestDBWithoutAzureDeploymentsColumn(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err, "Failed to create SQLite test database")
+
+	err = db.Exec(`
+		CREATE TABLE config_providers (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name VARCHAR(50) NOT NULL UNIQUE,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			encryption_status VARCHAR(20) DEFAULT 'plain_text'
+		)
+	`).Error
+	require.NoError(t, err, "Failed to create config_providers table")
+
+	err = db.Exec(`
+		CREATE TABLE config_keys (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name VARCHAR(255) NOT NULL,
+			provider_id INTEGER NOT NULL,
+			provider VARCHAR(50),
+			key_id VARCHAR(255) NOT NULL,
+			value TEXT NOT NULL,
+			created_at DATETIME NOT NULL,
+			updated_at DATETIME NOT NULL,
+			config_hash VARCHAR(255),
+			encryption_status VARCHAR(20) DEFAULT 'plain_text'
+		)
+	`).Error
+	require.NoError(t, err, "Failed to create config_keys table")
+
+	err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS gomigrate (
+			id VARCHAR(255) PRIMARY KEY
+		)
+	`).Error
+	require.NoError(t, err, "Failed to create gomigrate table")
+
+	return db
+}
+
+func trySetupPostgresKeyTestDBWithoutAzureDeploymentsColumn(t *testing.T, testSuffix string) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(postgres.Open(postgresDSN), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		return nil
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil
+	}
+	if err := sqlDB.Ping(); err != nil {
+		return nil
+	}
+
+	providersTable := fmt.Sprintf("config_providers_%s", strings.ReplaceAll(testSuffix, "-", "_"))
+	keysTable := fmt.Sprintf("config_keys_%s", strings.ReplaceAll(testSuffix, "-", "_"))
+	gomigrateTable := fmt.Sprintf("gomigrate_%s", strings.ReplaceAll(testSuffix, "-", "_"))
+
+	db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", gomigrateTable))
+	db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", keysTable))
+	db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", providersTable))
+
+	err = db.Exec(fmt.Sprintf(`
+		CREATE TABLE %s (
+			id SERIAL PRIMARY KEY,
+			name VARCHAR(50) NOT NULL UNIQUE,
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL,
+			encryption_status VARCHAR(20) DEFAULT 'plain_text'
+		)
+	`, providersTable)).Error
+	if err != nil {
+		return nil
+	}
+
+	err = db.Exec(fmt.Sprintf(`
+		CREATE TABLE %s (
+			id SERIAL PRIMARY KEY,
+			name VARCHAR(255) NOT NULL,
+			provider_id INTEGER NOT NULL,
+			provider VARCHAR(50),
+			key_id VARCHAR(255) NOT NULL,
+			value TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL,
+			updated_at TIMESTAMP NOT NULL,
+			config_hash VARCHAR(255),
+			encryption_status VARCHAR(20) DEFAULT 'plain_text'
+		)
+	`, keysTable)).Error
+	if err != nil {
+		return nil
+	}
+
+	err = db.Exec(fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id VARCHAR(255) PRIMARY KEY
+		)
+	`, gomigrateTable)).Error
+	if err != nil {
+		return nil
+	}
+
+	// Map Gormigrate to the temporary table name for this test database.
+	db.Exec(fmt.Sprintf("ALTER TABLE %s RENAME TO gomigrate", gomigrateTable))
+	db.Exec(fmt.Sprintf("ALTER TABLE %s RENAME TO config_providers", providersTable))
+	db.Exec(fmt.Sprintf("ALTER TABLE %s RENAME TO config_keys", keysTable))
+
+	t.Cleanup(func() {
+		db.Exec("DROP TABLE IF EXISTS gomigrate")
+		db.Exec("DROP TABLE IF EXISTS config_keys")
+		db.Exec("DROP TABLE IF EXISTS config_providers")
+	})
+
+	return db
+}
+
+func forEachKeyMigrationDB(t *testing.T, testSuffix string) []namedDB {
+	t.Helper()
+
+	dbs := []namedDB{{"sqlite", setupKeyTestDBWithoutAzureDeploymentsColumn(t)}}
+	if pgDB := trySetupPostgresKeyTestDBWithoutAzureDeploymentsColumn(t, testSuffix); pgDB != nil {
+		dbs = append(dbs, namedDB{"postgres", pgDB})
+	}
+	return dbs
+}
+
+func TestMigrationAddAzureDeploymentsJSONColumn(t *testing.T) {
+	for _, ndb := range forEachKeyMigrationDB(t, "azure_deployments_json") {
+		ndb := ndb
+		t.Run(ndb.name, func(t *testing.T) {
+			db := ndb.db
+			ctx := context.Background()
+
+			now := time.Now()
+
+			err := db.Exec(`
+				INSERT INTO config_providers (
+					name, created_at, updated_at, encryption_status
+				) VALUES (?, ?, ?, ?)
+			`, "azure_provider", now, now, "plain_text").Error
+			require.NoError(t, err, "Failed to insert provider")
+
+			var providerID uint
+			err = db.Table("config_providers").
+				Select("id").
+				Where("name = ?", "azure_provider").
+				Scan(&providerID).Error
+			require.NoError(t, err, "Failed to fetch provider id")
+			require.NotZero(t, providerID, "provider id should be populated")
+
+			err = db.Exec(`
+				INSERT INTO config_keys (
+					name, provider_id, provider, key_id, value, created_at, updated_at, encryption_status
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			`, "azure_key", providerID, "azure", "azure-key-id", "test-value", now, now, "plain_text").Error
+			require.NoError(t, err, "Failed to insert key row with old schema")
+
+			hasColumn := db.Migrator().HasColumn(&tables.TableKey{}, "azure_deployments_json")
+			assert.False(t, hasColumn, "azure_deployments_json column should not exist before migration")
+
+			err = migrationAddAzureDeploymentsJSONColumn(ctx, db)
+			require.NoError(t, err, "Migration should succeed")
+
+			hasColumn = db.Migrator().HasColumn(&tables.TableKey{}, "azure_deployments_json")
+			assert.True(t, hasColumn, "azure_deployments_json column should exist after migration")
+
+			var deploymentsJSON *string
+			err = db.Table("config_keys").
+				Select("azure_deployments_json").
+				Where("name = ?", "azure_key").
+				Scan(&deploymentsJSON).Error
+			require.NoError(t, err, "Failed to query azure_deployments_json")
+			assert.Nil(t, deploymentsJSON, "existing rows should default to NULL after migration")
+
+			err = migrationAddAzureDeploymentsJSONColumn(ctx, db)
+			require.NoError(t, err, "Migration should be idempotent")
+		})
+	}
+}

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/openai"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
@@ -82,6 +83,69 @@ func TestRequestWithSettableExtraParams_AllOpenAIRequestTypes(t *testing.T) {
 			assert.Equal(t, extra, getter.GetExtraParams())
 		})
 	}
+}
+
+func TestRequestWithSettableExtraParams_AnthropicRequests(t *testing.T) {
+	t.Run("AnthropicMessageRequest propagates extra params to Bifrost responses request", func(t *testing.T) {
+		req := &anthropic.AnthropicMessageRequest{
+			Model:     "bedrock/global.anthropic.claude-sonnet-4-6",
+			MaxTokens: 128,
+			Messages: []anthropic.AnthropicMessage{
+				{
+					Role: anthropic.AnthropicMessageRoleUser,
+					Content: anthropic.AnthropicContent{
+						ContentStr: schemas.Ptr("hello"),
+					},
+				},
+			},
+		}
+		extra := map[string]interface{}{
+			"anthropic_beta": []interface{}{"fine-grained-tool-streaming-2025-05-14"},
+			"custom_flag":    true,
+		}
+
+		rws, ok := interface{}(req).(RequestWithSettableExtraParams)
+		require.True(t, ok, "AnthropicMessageRequest should implement RequestWithSettableExtraParams")
+
+		rws.SetExtraParams(extra)
+
+		require.Equal(t, extra, req.GetExtraParams())
+
+		ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+		bifrostReq := req.ToBifrostResponsesRequest(ctx)
+
+		require.NotNil(t, bifrostReq)
+		require.NotNil(t, bifrostReq.Params)
+		assert.Equal(t, extra["anthropic_beta"], bifrostReq.Params.ExtraParams["anthropic_beta"])
+		assert.Equal(t, extra["custom_flag"], bifrostReq.Params.ExtraParams["custom_flag"])
+		assert.Equal(t, schemas.Bedrock, bifrostReq.Provider)
+	})
+
+	t.Run("AnthropicTextRequest propagates extra params to Bifrost text request", func(t *testing.T) {
+		req := &anthropic.AnthropicTextRequest{
+			Model:             "bedrock/anthropic.claude-v2",
+			Prompt:            "hello",
+			MaxTokensToSample: 32,
+		}
+		extra := map[string]interface{}{
+			"anthropic_beta": []interface{}{"fine-grained-tool-streaming-2025-05-14"},
+			"custom_flag":    true,
+		}
+
+		rws, ok := interface{}(req).(RequestWithSettableExtraParams)
+		require.True(t, ok, "AnthropicTextRequest should implement RequestWithSettableExtraParams")
+
+		rws.SetExtraParams(extra)
+
+		ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+		bifrostReq := req.ToBifrostTextCompletionRequest(ctx)
+
+		require.NotNil(t, bifrostReq)
+		require.NotNil(t, bifrostReq.Params)
+		assert.Equal(t, extra["anthropic_beta"], bifrostReq.Params.ExtraParams["anthropic_beta"])
+		assert.Equal(t, extra["custom_flag"], bifrostReq.Params.ExtraParams["custom_flag"])
+		assert.Equal(t, schemas.Bedrock, bifrostReq.Provider)
+	})
 }
 
 func TestExtraParamsRequiresPassthroughHeader(t *testing.T) {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1831,7 +1831,7 @@
           "type": "integer",
           "minimum": 5,
           "maximum": 3600,
-          "description": "Idle timeout per stream chunk in seconds. If no data is received for this many seconds, the stream is closed. Default: 60."
+          "description": "Idle timeout per stream chunk in seconds. If no data is received for this many seconds, the stream is closed. Default: 600."
         },
         "max_conns_per_host": {
           "type": "integer",
@@ -1895,7 +1895,7 @@
           "type": "integer",
           "minimum": 5,
           "maximum": 3600,
-          "description": "Idle timeout per stream chunk in seconds. If no data is received for this many seconds, the stream is closed. Default: 60."
+          "description": "Idle timeout per stream chunk in seconds. If no data is received for this many seconds, the stream is closed. Default: 600."
         },
         "max_conns_per_host": {
           "type": "integer",

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -85,7 +85,7 @@ export const DefaultNetworkConfig = {
 	retry_backoff_max: 10000,
 	insecure_skip_verify: false,
 	ca_cert_pem: "",
-	stream_idle_timeout_in_seconds: 60,
+	stream_idle_timeout_in_seconds: 600,
 	max_conns_per_host: 5000,
 	enforce_http2: false,
 } satisfies NetworkConfig;


### PR DESCRIPTION
## Summary
- preserve Anthropic-compatible `extra_params` through the Anthropic -> Bifrost -> Bedrock request path
- pass `eager_input_streaming` through tool conversion and allow the Bedrock fine-grained tool streaming beta header
- raise the default stream idle timeout to 600 seconds and avoid Bedrock streaming requests being cut off by the total HTTP client timeout
- add a generic GHCR workflow for forks that publishes `ghcr.io/<repo_owner>/bifrost` from `transports/Dockerfile.local`

## Testing
- `cd core && go test ./providers/anthropic ./schemas -run 'TestFilterBetaHeadersForProvider|TestAddMissingBetaHeadersToContext|TestSonic_.*|TestNetworkConfig_StreamIdleTimeoutRoundTrip'`
- `cd core && go test ./providers/bedrock -run 'TestToBedrockResponsesRequest_PreservesEagerInputStreaming|TestStreamingHTTPClient_DisablesTotalTimeout|TestToolResultImageContentResponsesAPI'`
- `cd core && go test ./providers/utils -run 'TestIdleTimeoutReader|TestMaxConnWaitTimeoutAlignedWithReadTimeout'`
- `cd transports && GOWORK=/tmp/bifrost-go-work/go test ./bifrost-http/integrations -run 'TestRequestWithSettableExtraParams_AnthropicRequests|TestRequestWithSettableExtraParams_OpenAIChatRequest|TestRequestWithSettableExtraParams_AllOpenAIRequestTypes|TestExtraParamsRequiresPassthroughHeader'`
