### PR TITLE
fix: sanitize empty content blocks in Bedrock provider

### DIFF
--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -3271,7 +3271,7 @@ func convertBifrostReasoningToBedrockReasoning(msg *schemas.ResponsesMessage) []
 func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(content schemas.ResponsesMessageContent) ([]BedrockContentBlock, error) {
 	var blocks []BedrockContentBlock
 
-	if content.ContentStr != nil {
+	if content.ContentStr != nil && *content.ContentStr != "" {
 		blocks = append(blocks, BedrockContentBlock{
 			Text: content.ContentStr,
 		})
@@ -3281,7 +3281,9 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(content s
 			bedrockBlock := BedrockContentBlock{}
 			switch block.Type {
 			case schemas.ResponsesInputMessageContentBlockTypeText, schemas.ResponsesOutputMessageContentTypeText:
-				bedrockBlock.Text = block.Text
+				if block.Text != nil && *block.Text != "" {
+					bedrockBlock.Text = block.Text
+				}
 			case schemas.ResponsesInputMessageContentBlockTypeImage:
 				if block.ResponsesInputMessageContentBlockImage != nil && block.ResponsesInputMessageContentBlockImage.ImageURL != nil {
 					imageSource, err := convertImageToBedrockSource(*block.ResponsesInputMessageContentBlockImage.ImageURL)
@@ -3291,7 +3293,7 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(content s
 					bedrockBlock.Image = imageSource
 				}
 			case schemas.ResponsesOutputMessageContentTypeReasoning:
-				if block.Text != nil {
+				if block.Text != nil && *block.Text != "" {
 					bedrockBlock.ReasoningContent = &BedrockReasoningContent{
 						ReasoningText: &BedrockReasoningContentText{
 							Text:      block.Text,
@@ -3301,7 +3303,7 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(content s
 				}
 			case schemas.ResponsesOutputMessageContentTypeCompaction:
 				// Convert compaction to text block for Bedrock (compaction is Anthropic-specific)
-				if block.ResponsesOutputMessageContentCompaction != nil {
+				if block.ResponsesOutputMessageContentCompaction != nil && block.ResponsesOutputMessageContentCompaction.Summary != "" {
 					bedrockBlock.Text = &block.ResponsesOutputMessageContentCompaction.Summary
 				}
 			case schemas.ResponsesInputMessageContentBlockTypeFile:

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -28,7 +28,7 @@ type TableMCPClient struct {
 	ToolSyncInterval       int             `gorm:"default:0" json:"tool_sync_interval"`             // Per-client tool sync interval in minutes (0 = use global, -1 = disabled)
 
 	// OAuth authentication fields
-	AuthType      string            `gorm:"type:varchar(20);default:'headers'" json:"auth_type"`                         // "none", "headers", "oauth"
+	AuthType      string            `gorm:"type:varchar(20);default:'headers'" json:"auth_type"`                         // "none", "headers", "oauth", "per_user_oauth"
 	OauthConfigID *string           `gorm:"type:varchar(255);index;constraint:OnDelete:CASCADE" json:"oauth_config_id"`  // Foreign key to oauth_configs.ID with CASCADE delete
 	OauthConfig   *TableOauthConfig `gorm:"foreignKey:OauthConfigID;references:ID;constraint:OnDelete:CASCADE" json:"-"` // Gorm relationship
 


### PR DESCRIPTION
Empty content blocks cause issues with Bedrock provider. Adds proper sanitization similar to the fix in #1189 for Anthropic. Fixes #2765