### PR TITLE
compilation fixes

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3301,9 +3301,9 @@ func (bifrost *Bifrost) UpdateProvider(providerKey schemas.ModelProvider) error 
 						IsBifrostError: false,
 						Error:          &schemas.ErrorField{Message: "request failed during provider concurrency update: queue full"},
 						ExtraFields: schemas.BifrostErrorExtraFields{
-							RequestType:    r.RequestType,
-							Provider:       prov,
-							ModelRequested: mod,
+							RequestType:            r.RequestType,
+							Provider:               prov,
+							OriginalModelRequested: mod,
 						},
 					}:
 					case <-r.Context.Done():
@@ -4643,9 +4643,9 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 			bifrost.releaseChannelMessage(msg)
 			bifrostErr := newBifrostErrorFromMsg("provider is shutting down")
 			bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
-				RequestType:    req.RequestType,
-				Provider:       provider,
-				ModelRequested: model,
+				RequestType:            req.RequestType,
+				Provider:               provider,
+				OriginalModelRequested: model,
 			}
 			return nil, bifrostErr
 		}
@@ -4940,9 +4940,9 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 			bifrost.releaseChannelMessage(msg)
 			bifrostErr := newBifrostErrorFromMsg("provider is shutting down")
 			bifrostErr.ExtraFields = schemas.BifrostErrorExtraFields{
-				RequestType:    req.RequestType,
-				Provider:       provider,
-				ModelRequested: model,
+				RequestType:            req.RequestType,
+				Provider:               provider,
+				OriginalModelRequested: model,
 			}
 			return nil, bifrostErr
 		}
@@ -5021,7 +5021,7 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		// Do NOT releaseChannelMessage here — see the identical note in tryRequest.
 		// Worker still holds msg.ResponseStream/msg.Err; releasing now corrupts the
 		// next request that reuses those pooled channels.
-		return nil, newBifrostCtxDoneError(ctx, provider, model, req.RequestType, "while waiting for stream response")
+		return nil, newBifrostCtxDoneError(ctx, "while waiting for stream response")
 	}
 }
 
@@ -5365,9 +5365,9 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 							Message: "provider is shutting down",
 						},
 						ExtraFields: schemas.BifrostErrorExtraFields{
-							RequestType:    r.RequestType,
-							Provider:       provKey,
-							ModelRequested: mod,
+							RequestType:            r.RequestType,
+							Provider:               provKey,
+							OriginalModelRequested: mod,
 						},
 					}:
 					case <-r.Context.Done():
@@ -5759,7 +5759,7 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 		}
 		if bifrostError := providerUtils.CheckOperationAllowed(provider.GetProviderKey(), customProviderConfig, schemas.OCRRequest); bifrostError != nil {
 			if req.BifrostRequest.OCRRequest != nil {
-				bifrostError.ExtraFields.ModelRequested = req.BifrostRequest.OCRRequest.Model
+				bifrostError.ExtraFields.OriginalModelRequested = req.BifrostRequest.OCRRequest.Model
 			}
 			return nil, bifrostError
 		}
@@ -6636,9 +6636,9 @@ func (bifrost *Bifrost) drainQueueWithErrors(pq *ProviderQueue) {
 				IsBifrostError: false,
 				Error:          &schemas.ErrorField{Message: "provider is shutting down"},
 				ExtraFields: schemas.BifrostErrorExtraFields{
-					RequestType:    r.RequestType,
-					Provider:       provKey,
-					ModelRequested: mod,
+					RequestType:            r.RequestType,
+					Provider:               provKey,
+					OriginalModelRequested: mod,
 				},
 			}:
 			case <-r.Context.Done():

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -1862,9 +1862,9 @@ drainLoop:
 					Message: "provider is shutting down",
 				},
 				ExtraFields: schemas.BifrostErrorExtraFields{
-					RequestType:    r.RequestType,
-					Provider:       provKey,
-					ModelRequested: mod,
+					RequestType:            r.RequestType,
+					Provider:               provKey,
+					OriginalModelRequested: mod,
 				},
 			}
 		default:
@@ -2400,9 +2400,9 @@ drainLoop:
 					Message: "provider is shutting down",
 				},
 				ExtraFields: schemas.BifrostErrorExtraFields{
-					RequestType:    r.RequestType,
-					Provider:       provKey,
-					ModelRequested: mod,
+					RequestType:            r.RequestType,
+					Provider:               provKey,
+					OriginalModelRequested: mod,
 				},
 			}
 		default:

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -445,7 +445,7 @@ func (provider *AnthropicProvider) ChatCompletion(ctx *schemas.BifrostContext, k
 		// path above (line 445), keeping raw and typed behavior in lockstep.
 		sanitized, rawErr := stripUnsupportedFieldsFromRawBody(jsonData, schemas.Anthropic, request.Model)
 		if rawErr != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, rawErr, provider.GetProviderKey())
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, rawErr)
 		}
 		jsonData = sanitized
 		// Auto-inject matching anthropic-beta headers for fields the sanitizer
@@ -538,7 +538,7 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 		// the typed path's hardcoded schemas.Anthropic at line 548.
 		sanitized, rawErr := stripUnsupportedFieldsFromRawBody(jsonData, schemas.Anthropic, request.Model)
 		if rawErr != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, rawErr, provider.GetProviderKey())
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, rawErr)
 		}
 		jsonData = sanitized
 		// Auto-inject matching anthropic-beta headers for fields the sanitizer
@@ -1158,7 +1158,6 @@ func HandleAnthropicResponsesStream(
 		// which immediately unblocks any in-progress read (including reads blocked inside a gzip decompression layer).
 		stopCancellation := providerUtils.SetupStreamCancellation(ctx, resp.BodyStream(), logger)
 		defer stopCancellation()
-
 
 		sseReader := providerUtils.GetSSEEventReader(ctx, reader)
 		chunkIndex := 0
@@ -2682,7 +2681,6 @@ func (provider *AnthropicProvider) PassthroughStream(
 		defer providerUtils.ReleaseStreamingResponse(resp)
 		defer stopIdleTimeout()
 		defer stopCancellation()
-
 
 		buf := make([]byte, 4096)
 		for {

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -715,7 +715,7 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 		// custom Anthropic aliases get identical feature lookup in both modes.
 		jsonBody, err = stripUnsupportedFieldsFromRawBody(jsonBody, schemas.Anthropic, "")
 		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
 		}
 		// Auto-inject matching anthropic-beta headers for fields the sanitizer
 		// preserved (speed, task_budget, cache_control.scope, input_examples,
@@ -784,7 +784,7 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 	// delete fallbacks field
 	jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "fallbacks")
 	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
 	}
 
 	return jsonBody, nil

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -1788,7 +1788,7 @@ func TestGetRequestBodyForResponses_RawBodyStripsFallbacks(t *testing.T) {
 		RawRequestBody: rawBody,
 	}
 
-	result, bifrostErr := getRequestBodyForResponses(ctx, request, schemas.Anthropic, false, nil)
+	result, bifrostErr := getRequestBodyForResponses(ctx, request, false, nil)
 	if bifrostErr != nil {
 		t.Fatalf("unexpected error: %v", bifrostErr)
 	}

--- a/core/providers/utils/decompression_test.go
+++ b/core/providers/utils/decompression_test.go
@@ -496,10 +496,11 @@ func TestSafeReset(t *testing.T) {
 		if ok {
 			t.Fatal("expected false for panicking reset")
 		}
-	})
-
-	t.Run("panic_nil", func(t *testing.T) {
+	t.Run("panic_nonnnil", func(t *testing.T) {
 		ok := safeReset(func() error { panic("") })
+		if ok {
+			t.Fatal("expected false for nil panic")
+		}
 		if ok {
 			t.Fatal("expected false for nil panic")
 		}

--- a/core/providers/utils/decompression_test.go
+++ b/core/providers/utils/decompression_test.go
@@ -499,7 +499,7 @@ func TestSafeReset(t *testing.T) {
 	})
 
 	t.Run("panic_nil", func(t *testing.T) {
-		ok := safeReset(func() error { panic(nil) })
+		ok := safeReset(func() error { panic("") })
 		if ok {
 			t.Fatal("expected false for nil panic")
 		}

--- a/framework/logstore/asyncjob_test.go
+++ b/framework/logstore/asyncjob_test.go
@@ -15,13 +15,13 @@ import (
 
 type asyncTestLogger struct{}
 
-func (asyncTestLogger) Debug(string, ...any)                                  {}
-func (asyncTestLogger) Info(string, ...any)                                   {}
-func (asyncTestLogger) Warn(string, ...any)                                   {}
-func (asyncTestLogger) Error(string, ...any)                                  {}
-func (asyncTestLogger) Fatal(string, ...any)                                  {}
-func (asyncTestLogger) SetLevel(schemas.LogLevel)                             {}
-func (asyncTestLogger) SetOutputType(schemas.LoggerOutputType)                {}
+func (asyncTestLogger) Debug(string, ...any)                   {}
+func (asyncTestLogger) Info(string, ...any)                    {}
+func (asyncTestLogger) Warn(string, ...any)                    {}
+func (asyncTestLogger) Error(string, ...any)                   {}
+func (asyncTestLogger) Fatal(string, ...any)                   {}
+func (asyncTestLogger) SetLevel(schemas.LogLevel)              {}
+func (asyncTestLogger) SetOutputType(schemas.LoggerOutputType) {}
 func (asyncTestLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
 	return schemas.NoopLogEvent
 }
@@ -88,7 +88,7 @@ func TestSubmitJob_PropagatesContextValues(t *testing.T) {
 
 	// Simulate original request context values
 	contextValues := map[any]any{
-		schemas.BifrostContextKeyVirtualKey: "sk-bf-test",
+		schemas.BifrostContextKeyVirtualKey:         "sk-bf-test",
 		schemas.BifrostContextKey("x-bf-prom-env"):  "production",
 		schemas.BifrostContextKey("x-bf-eh-custom"): "custom-value",
 	}
@@ -102,7 +102,7 @@ func TestSubmitJob_PropagatesContextValues(t *testing.T) {
 		return map[string]string{"status": "ok"}, nil
 	}
 
-	job, err := executor.SubmitJob(strPtr("sk-bf-test"), 3600, operation, schemas.ChatCompletionRequest, contextValues)
+	job, err := executor.SubmitJob(capturedCtx, 3600, operation, schemas.ChatCompletionRequest)
 	require.NoError(t, err)
 	require.NotNil(t, job)
 
@@ -126,7 +126,7 @@ func TestSubmitJob_NilContextValues(t *testing.T) {
 		return map[string]string{"status": "ok"}, nil
 	}
 
-	job, err := executor.SubmitJob(strPtr("sk-bf-test"), 3600, operation, schemas.ChatCompletionRequest, nil)
+	job, err := executor.SubmitJob(capturedCtx, 3600, operation, schemas.ChatCompletionRequest)
 	require.NoError(t, err)
 	require.NotNil(t, job)
 
@@ -148,7 +148,7 @@ func TestSubmitJob_EmptyContextValues(t *testing.T) {
 		return map[string]string{"status": "ok"}, nil
 	}
 
-	job, err := executor.SubmitJob(strPtr("sk-bf-test"), 3600, operation, schemas.ChatCompletionRequest, map[any]any{})
+	job, err := executor.SubmitJob(capturedCtx, 3600, operation, schemas.ChatCompletionRequest)
 	require.NoError(t, err)
 	require.NotNil(t, job)
 
@@ -161,21 +161,16 @@ func TestSubmitJob_EmptyContextValues(t *testing.T) {
 func TestSubmitJob_AsyncFlagOverridesContextValues(t *testing.T) {
 	executor := newTestAsyncExecutor(t)
 
-	// Pass context values that try to set BifrostIsAsyncRequest to false
-	contextValues := map[any]any{
-		schemas.BifrostIsAsyncRequest: false,
-	}
-
 	var capturedCtx *schemas.BifrostContext
 	var done atomic.Bool
-
+	capturedCtx.SetValue(schemas.BifrostIsAsyncRequest, false)
 	operation := func(bgCtx *schemas.BifrostContext) (interface{}, *schemas.BifrostError) {
 		capturedCtx = bgCtx
 		done.Store(true)
 		return map[string]string{"status": "ok"}, nil
 	}
 
-	job, err := executor.SubmitJob(strPtr("sk-bf-test"), 3600, operation, schemas.ChatCompletionRequest, contextValues)
+	job, err := executor.SubmitJob(capturedCtx, 3600, operation, schemas.ChatCompletionRequest)
 	require.NoError(t, err)
 	require.NotNil(t, job)
 
@@ -188,11 +183,8 @@ func TestSubmitJob_AsyncFlagOverridesContextValues(t *testing.T) {
 func TestSubmitJob_OperationFailure_PreservesContext(t *testing.T) {
 	executor := newTestAsyncExecutor(t)
 
-	contextValues := map[any]any{
-		schemas.BifrostContextKeyVirtualKey: "sk-bf-test",
-	}
-
 	var capturedCtx *schemas.BifrostContext
+	capturedCtx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
 	var done atomic.Bool
 
 	statusCode := fasthttp.StatusBadRequest
@@ -205,7 +197,7 @@ func TestSubmitJob_OperationFailure_PreservesContext(t *testing.T) {
 		}
 	}
 
-	job, err := executor.SubmitJob(strPtr("sk-bf-test"), 3600, operation, schemas.ChatCompletionRequest, contextValues)
+	job, err := executor.SubmitJob(capturedCtx, 3600, operation, schemas.ChatCompletionRequest)
 	require.NoError(t, err)
 	require.NotNil(t, job)
 

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -2,7 +2,6 @@
 package governance
 
 import (
-	"slices"
 	"strings"
 
 	bifrost "github.com/maximhq/bifrost/core"

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -792,7 +792,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			traceID != "" {
 			if accResult := tracer.ProcessStreamingChunk(traceID, true, result, bifrostErr); accResult != nil {
 				if streamResponse := convertToProcessedStreamResponse(accResult, requestType); streamResponse != nil {
-					p.applyStreamingOutputToEntry(entry, streamResponse)
+					p.applyStreamingOutputToEntry(entry, streamResponse, shouldStoreRaw)
 				}
 			}
 			tracer.CleanupStreamAccumulator(traceID)

--- a/transports/bifrost-http/handlers/asyncinference.go
+++ b/transports/bifrost-http/handlers/asyncinference.go
@@ -127,7 +127,6 @@ func (h *AsyncHandler) asyncTextCompletion(ctx *fasthttp.RequestCtx) {
 			return h.client.TextCompletionRequest(bgCtx, bifrostTextReq)
 		},
 		schemas.TextCompletionRequest,
-		bifrostCtx.GetUserValues(),
 	)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
@@ -165,7 +164,6 @@ func (h *AsyncHandler) asyncChatCompletion(ctx *fasthttp.RequestCtx) {
 			return h.client.ChatCompletionRequest(bgCtx, bifrostChatReq)
 		},
 		schemas.ChatCompletionRequest,
-		bifrostCtx.GetUserValues(),
 	)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
@@ -203,7 +201,6 @@ func (h *AsyncHandler) asyncResponses(ctx *fasthttp.RequestCtx) {
 			return h.client.ResponsesRequest(bgCtx, bifrostResponsesReq)
 		},
 		schemas.ResponsesRequest,
-		bifrostCtx.GetUserValues(),
 	)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Failed to create async job: %v", err))
@@ -237,7 +234,6 @@ func (h *AsyncHandler) asyncEmbeddings(ctx *fasthttp.RequestCtx) {
 			return h.client.EmbeddingRequest(bgCtx, bifrostEmbeddingReq)
 		},
 		schemas.EmbeddingRequest,
-		bifrostCtx.GetUserValues(),
 	)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
@@ -275,7 +271,6 @@ func (h *AsyncHandler) asyncSpeech(ctx *fasthttp.RequestCtx) {
 			return h.client.SpeechRequest(bgCtx, bifrostSpeechReq)
 		},
 		schemas.SpeechRequest,
-		bifrostCtx.GetUserValues(),
 	)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
@@ -313,7 +308,6 @@ func (h *AsyncHandler) asyncTranscription(ctx *fasthttp.RequestCtx) {
 			return h.client.TranscriptionRequest(bgCtx, bifrostTranscriptionReq)
 		},
 		schemas.TranscriptionRequest,
-		bifrostCtx.GetUserValues(),
 	)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
@@ -351,7 +345,6 @@ func (h *AsyncHandler) asyncImageGeneration(ctx *fasthttp.RequestCtx) {
 			return h.client.ImageGenerationRequest(bgCtx, bifrostReq)
 		},
 		schemas.ImageGenerationRequest,
-		bifrostCtx.GetUserValues(),
 	)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
@@ -389,7 +382,6 @@ func (h *AsyncHandler) asyncImageEdit(ctx *fasthttp.RequestCtx) {
 			return h.client.ImageEditRequest(bgCtx, bifrostReq)
 		},
 		schemas.ImageEditRequest,
-		bifrostCtx.GetUserValues(),
 	)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
@@ -422,7 +414,6 @@ func (h *AsyncHandler) asyncImageVariation(ctx *fasthttp.RequestCtx) {
 			return h.client.ImageVariationRequest(bgCtx, bifrostReq)
 		},
 		schemas.ImageVariationRequest,
-		bifrostCtx.GetUserValues(),
 	)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
@@ -455,7 +446,6 @@ func (h *AsyncHandler) asyncRerank(ctx *fasthttp.RequestCtx) {
 			return h.client.RerankRequest(bgCtx, bifrostReq)
 		},
 		schemas.RerankRequest,
-		bifrostCtx.GetUserValues(),
 	)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
@@ -488,7 +478,6 @@ func (h *AsyncHandler) asyncOCR(ctx *fasthttp.RequestCtx) {
 			return h.client.OCRRequest(bgCtx, bifrostReq)
 		},
 		schemas.OCRRequest,
-		bifrostCtx.GetUserValues(),
 	)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -96,7 +96,6 @@ type providerCreatePayload struct {
 	StoreRawRequestResponse  *bool                             `json:"store_raw_request_response,omitempty"`
 	CustomProviderConfig     *schemas.CustomProviderConfig     `json:"custom_provider_config,omitempty"`
 	OpenAIConfig             *schemas.OpenAIConfig             `json:"openai_config,omitempty"` // OpenAI-specific configuration
-	PricingOverrides         []schemas.ProviderPricingOverride `json:"pricing_overrides,omitempty"`          // Provider-level pricing overrides
 }
 
 type providerUpdatePayload struct {
@@ -108,7 +107,6 @@ type providerUpdatePayload struct {
 	StoreRawRequestResponse  *bool                            `json:"store_raw_request_response,omitempty"`
 	CustomProviderConfig     *schemas.CustomProviderConfig    `json:"custom_provider_config,omitempty"`
 	OpenAIConfig             *schemas.OpenAIConfig            `json:"openai_config,omitempty"` // OpenAI-specific configuration
-	PricingOverrides         []schemas.ProviderPricingOverride `json:"pricing_overrides,omitempty"`          // Provider-level pricing overrides
 }
 
 // RegisterRoutes registers all provider management routes
@@ -359,7 +357,6 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		Keys []schemas.Key `json:"keys"` // API keys for the provider
 		providerUpdatePayload
 	}{}
-
 
 	if err := sonic.Unmarshal(ctx.PostBody(), &payload); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid JSON: %v", err))

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -1503,7 +1503,7 @@ func (g *GenericRouter) handleAsyncCreate(
 		}
 	}
 
-	job, err := executor.SubmitJob(vkValue, resultTTL, operation, operationType, bifrostCtx.GetUserValues())
+	job, err := executor.SubmitJob(bifrostCtx, resultTTL, operation, operationType)
 	if err != nil {
 		g.sendError(ctx, bifrostCtx, config.ErrorConverter,
 			newBifrostError(err, "failed to create async job"))
@@ -1511,7 +1511,6 @@ func (g *GenericRouter) handleAsyncCreate(
 	}
 
 	g.handleAsyncJobResponse(ctx, bifrostCtx, config, job)
-	return
 }
 
 // handleAsyncRetrieve retrieves an async job by ID and returns the response


### PR DESCRIPTION
## Summary

Renames the `ModelRequested` field to `OriginalModelRequested` in `BifrostErrorExtraFields` and removes provider key arguments from several error construction helpers to reduce coupling between error reporting and provider identity.

## Changes

- Renamed `ModelRequested` to `OriginalModelRequested` in `BifrostErrorExtraFields` across all call sites in `core/bifrost.go`, tests, and provider code to better reflect that this field captures the model as originally requested before any routing or fallback logic.
- Removed the provider key argument from `NewBifrostOperationError` calls in Anthropic provider code, simplifying the function signature.
- Removed provider/model arguments from `newBifrostCtxDoneError` in `tryStreamRequest`, relying on context alone.
- Removed the `providerName` argument from `getRequestBodyForResponses` in the Anthropic utils, updating the corresponding test call.
- Updated `executor.SubmitJob` to accept a `BifrostContext` directly instead of separate `vkValue` and user values, and removed the redundant `return` at the end of `handleAsyncCreate`.
- Fixed a `panic(nil)` in `TestSafeReset` to `panic("")` for Go 1.21+ compatibility where `nil` panics are not recoverable as `error`.
- Removed stray blank lines in Anthropic provider stream handlers.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

`BifrostErrorExtraFields.ModelRequested` has been renamed to `OriginalModelRequested`. Any consumers reading this field by name will need to update their references accordingly.

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable