### PR TITLE
fix: enforce virtual key provider filtering in list models routes

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -453,6 +453,8 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 		}
 	}
 
+	providerKeys = resolveListModelsProviders(ctx, providerKeys)
+
 	startTime := time.Now()
 
 	// Result structure for collecting provider responses
@@ -595,6 +597,38 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 	response = response.ApplyPagination(req.PageSize, req.PageToken)
 
 	return response, nil
+}
+
+func resolveListModelsProviders(ctx *schemas.BifrostContext, providerKeys []schemas.ModelProvider) []schemas.ModelProvider {
+	if ctx == nil {
+		return providerKeys
+	}
+
+	raw := ctx.Value(schemas.BifrostContextKeyAvailableProviders)
+	availableProviders, ok := raw.([]schemas.ModelProvider)
+	if !ok || len(availableProviders) == 0 {
+		return providerKeys
+	}
+
+	allowed := make(map[schemas.ModelProvider]struct{}, len(availableProviders))
+	for _, provider := range availableProviders {
+		if strings.TrimSpace(string(provider)) == "" {
+			continue
+		}
+		allowed[provider] = struct{}{}
+	}
+	if len(allowed) == 0 {
+		return providerKeys
+	}
+
+	filtered := make([]schemas.ModelProvider, 0, len(providerKeys))
+	for _, provider := range providerKeys {
+		if _, ok := allowed[provider]; ok {
+			filtered = append(filtered, provider)
+		}
+	}
+
+	return filtered
 }
 
 // TextCompletionRequest sends a text completion request to the specified provider.

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -229,6 +229,46 @@ func TestExecuteRequestWithRetries_NonRetryableErrors(t *testing.T) {
 	}
 }
 
+func TestResolveListModelsProviders(t *testing.T) {
+	t.Run("filters to allowed providers while preserving configured order", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{
+			schemas.ModelProvider("packyapi"),
+			schemas.ModelProvider("azure"),
+		})
+
+		got := resolveListModelsProviders(ctx, []schemas.ModelProvider{
+			schemas.ModelProvider("openai"),
+			schemas.ModelProvider("azure"),
+			schemas.ModelProvider("packyapi"),
+			schemas.ModelProvider("anthropic"),
+		})
+
+		if len(got) != 2 {
+			t.Fatalf("expected 2 providers after filtering, got %d (%v)", len(got), got)
+		}
+		if got[0] != schemas.ModelProvider("azure") || got[1] != schemas.ModelProvider("packyapi") {
+			t.Fatalf("expected filtering to preserve configured provider order, got %v", got)
+		}
+	})
+
+	t.Run("noops when available providers are unset", func(t *testing.T) {
+		providers := []schemas.ModelProvider{
+			schemas.ModelProvider("openai"),
+			schemas.ModelProvider("azure"),
+		}
+		got := resolveListModelsProviders(nil, providers)
+		if len(got) != len(providers) {
+			t.Fatalf("expected providers to be unchanged, got %v", got)
+		}
+		for i := range providers {
+			if got[i] != providers[i] {
+				t.Fatalf("expected providers to be unchanged, got %v", got)
+			}
+		}
+	})
+}
+
 // Test executeRequestWithRetries - retryable conditions
 func TestExecuteRequestWithRetries_RetryableConditions(t *testing.T) {
 	config := createTestConfig(1, 100*time.Millisecond, 1*time.Second)

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -759,6 +759,9 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 
 	// If provider is empty, list all models from all providers
 	if provider == "" {
+		if err := lib.ApplyVirtualKeyProviderFilter(bifrostCtx, h.config.ConfigStore); err != nil {
+			logger.Warn("failed to apply virtual key provider filter for list models: %v", err)
+		}
 		resp, bifrostErr = h.client.ListAllModels(bifrostCtx, bifrostListModelsReq)
 	} else {
 		resp, bifrostErr = h.client.ListModelsRequest(bifrostCtx, bifrostListModelsReq)

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -620,9 +620,12 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 		// Set integration type to context
 		bifrostCtx.SetValue(schemas.BifrostContextKeyIntegrationType, string(config.Type))
 
-		// Set available providers to context
-		availableProviders := g.handlerStore.GetAvailableProviders()
-		bifrostCtx.SetValue(schemas.BifrostContextKeyAvailableProviders, availableProviders)
+		// Preserve default provider scoping for inference routes, but let list-models
+		// requests inject a virtual-key-specific provider filter later.
+		if config.ListModelsResponseConverter == nil {
+			availableProviders := g.handlerStore.GetAvailableProviders()
+			bifrostCtx.SetValue(schemas.BifrostContextKeyAvailableProviders, availableProviders)
+		}
 
 		// Async retrieve: check x-bf-async-id header early (before body parsing)
 		if asyncID := string(ctx.Request.Header.Peek(schemas.AsyncHeaderGetID)); asyncID != "" {
@@ -866,6 +869,11 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 		if bifrostReq.ListModelsRequest.Provider != "" {
 			listModelsResponse, bifrostErr = g.client.ListModelsRequest(bifrostCtx, bifrostReq.ListModelsRequest)
 		} else {
+			if cfg, ok := g.handlerStore.(*lib.Config); ok {
+				if err := lib.ApplyVirtualKeyProviderFilter(bifrostCtx, cfg.ConfigStore); err != nil {
+					g.logger.Warn("failed to apply virtual key provider filter for list models: %v", err)
+				}
+			}
 			listModelsResponse, bifrostErr = g.client.ListAllModels(bifrostCtx, bifrostReq.ListModelsRequest)
 		}
 

--- a/transports/bifrost-http/lib/list_models.go
+++ b/transports/bifrost-http/lib/list_models.go
@@ -1,0 +1,54 @@
+package lib
+
+import (
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+)
+
+// ApplyVirtualKeyProviderFilter resolves the current virtual key and injects the
+// allowed provider list into the request context for list-models fan-out.
+func ApplyVirtualKeyProviderFilter(ctx *schemas.BifrostContext, store configstore.ConfigStore) error {
+	if ctx == nil || store == nil {
+		return nil
+	}
+
+	if existing, ok := ctx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider); ok && len(existing) > 0 {
+		return nil
+	}
+
+	virtualKey, _ := ctx.Value(schemas.BifrostContextKeyVirtualKey).(string)
+	virtualKey = strings.TrimSpace(virtualKey)
+	if virtualKey == "" {
+		return nil
+	}
+
+	vk, err := store.GetVirtualKeyByValue(ctx, virtualKey)
+	if err != nil || vk == nil || !vk.IsActive {
+		return err
+	}
+	if len(vk.ProviderConfigs) == 0 {
+		return nil
+	}
+
+	availableProviders := make([]schemas.ModelProvider, 0, len(vk.ProviderConfigs))
+	seen := make(map[schemas.ModelProvider]struct{}, len(vk.ProviderConfigs))
+	for _, pc := range vk.ProviderConfigs {
+		provider := schemas.ModelProvider(strings.TrimSpace(pc.Provider))
+		if provider == "" {
+			continue
+		}
+		if _, ok := seen[provider]; ok {
+			continue
+		}
+		seen[provider] = struct{}{}
+		availableProviders = append(availableProviders, provider)
+	}
+
+	if len(availableProviders) > 0 {
+		ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, availableProviders)
+	}
+
+	return nil
+}

--- a/transports/bifrost-http/lib/list_models_test.go
+++ b/transports/bifrost-http/lib/list_models_test.go
@@ -1,0 +1,119 @@
+package lib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+type virtualKeyByValueStore struct {
+	*MockConfigStore
+	virtualKey *tables.TableVirtualKey
+	gotValue   string
+}
+
+func (m *virtualKeyByValueStore) GetVirtualKeyByValue(ctx context.Context, value string) (*tables.TableVirtualKey, error) {
+	m.gotValue = value
+	return m.virtualKey, nil
+}
+
+func TestApplyVirtualKeyProviderFilter_SetsAvailableProviders(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+
+	store := &virtualKeyByValueStore{
+		MockConfigStore: NewMockConfigStore(),
+		virtualKey: &tables.TableVirtualKey{
+			IsActive: true,
+			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
+				{Provider: "azure"},
+				{Provider: "azure"},
+				{Provider: "packyapi"},
+				{Provider: ""},
+			},
+		},
+	}
+
+	if err := ApplyVirtualKeyProviderFilter(ctx, store); err != nil {
+		t.Fatalf("ApplyVirtualKeyProviderFilter returned error: %v", err)
+	}
+
+	if store.gotValue != "sk-bf-test" {
+		t.Fatalf("expected store lookup to receive sk-bf-test, got %q", store.gotValue)
+	}
+
+	got, ok := ctx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+	if !ok {
+		t.Fatal("expected available providers to be set on context")
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 unique providers, got %d (%v)", len(got), got)
+	}
+	if got[0] != schemas.ModelProvider("azure") || got[1] != schemas.ModelProvider("packyapi") {
+		t.Fatalf("unexpected providers order/content: %v", got)
+	}
+}
+
+func TestApplyVirtualKeyProviderFilter_NoVirtualKeyNoop(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	store := &virtualKeyByValueStore{MockConfigStore: NewMockConfigStore()}
+
+	if err := ApplyVirtualKeyProviderFilter(ctx, store); err != nil {
+		t.Fatalf("ApplyVirtualKeyProviderFilter returned error: %v", err)
+	}
+	if got := ctx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
+		t.Fatalf("expected no available providers on context, got %v", got)
+	}
+}
+
+func TestApplyVirtualKeyProviderFilter_DoesNotOverwriteExistingProviders(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, []schemas.ModelProvider{"governance"})
+
+	store := &virtualKeyByValueStore{
+		MockConfigStore: NewMockConfigStore(),
+		virtualKey: &tables.TableVirtualKey{
+			IsActive: true,
+			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
+				{Provider: "azure"},
+			},
+		},
+	}
+
+	if err := ApplyVirtualKeyProviderFilter(ctx, store); err != nil {
+		t.Fatalf("ApplyVirtualKeyProviderFilter returned error: %v", err)
+	}
+
+	got, ok := ctx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+	if !ok || len(got) != 1 || got[0] != "governance" {
+		t.Fatalf("expected existing providers to be preserved, got %v", got)
+	}
+	if store.gotValue != "" {
+		t.Fatalf("expected store lookup to be skipped when providers already exist, got %q", store.gotValue)
+	}
+}
+
+func TestApplyVirtualKeyProviderFilter_InactiveVirtualKeyNoop(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-inactive")
+
+	store := &virtualKeyByValueStore{
+		MockConfigStore: NewMockConfigStore(),
+		virtualKey: &tables.TableVirtualKey{
+			IsActive: false,
+			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
+				{Provider: "azure"},
+			},
+		},
+	}
+
+	if err := ApplyVirtualKeyProviderFilter(ctx, store); err != nil {
+		t.Fatalf("ApplyVirtualKeyProviderFilter returned error: %v", err)
+	}
+	if got := ctx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
+		t.Fatalf("expected inactive virtual key to leave providers unset, got %v", got)
+	}
+}

--- a/transports/bifrost-http/lib/list_models_test.go
+++ b/transports/bifrost-http/lib/list_models_test.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -12,11 +13,12 @@ type virtualKeyByValueStore struct {
 	*MockConfigStore
 	virtualKey *tables.TableVirtualKey
 	gotValue   string
+	err        error
 }
 
 func (m *virtualKeyByValueStore) GetVirtualKeyByValue(ctx context.Context, value string) (*tables.TableVirtualKey, error) {
 	m.gotValue = value
-	return m.virtualKey, nil
+	return m.virtualKey, m.err
 }
 
 func TestApplyVirtualKeyProviderFilter_SetsAvailableProviders(t *testing.T) {
@@ -115,5 +117,60 @@ func TestApplyVirtualKeyProviderFilter_InactiveVirtualKeyNoop(t *testing.T) {
 	}
 	if got := ctx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
 		t.Fatalf("expected inactive virtual key to leave providers unset, got %v", got)
+	}
+}
+
+func TestApplyVirtualKeyProviderFilter_NilVirtualKeyNoop(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-missing")
+
+	store := &virtualKeyByValueStore{
+		MockConfigStore: NewMockConfigStore(),
+		virtualKey:      nil,
+	}
+
+	if err := ApplyVirtualKeyProviderFilter(ctx, store); err != nil {
+		t.Fatalf("ApplyVirtualKeyProviderFilter returned error: %v", err)
+	}
+	if got := ctx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
+		t.Fatalf("expected missing virtual key to leave providers unset, got %v", got)
+	}
+}
+
+func TestApplyVirtualKeyProviderFilter_EmptyProviderConfigsNoop(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-empty")
+
+	store := &virtualKeyByValueStore{
+		MockConfigStore: NewMockConfigStore(),
+		virtualKey: &tables.TableVirtualKey{
+			IsActive:        true,
+			ProviderConfigs: nil,
+		},
+	}
+
+	if err := ApplyVirtualKeyProviderFilter(ctx, store); err != nil {
+		t.Fatalf("ApplyVirtualKeyProviderFilter returned error: %v", err)
+	}
+	if got := ctx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
+		t.Fatalf("expected empty provider configs to leave providers unset, got %v", got)
+	}
+}
+
+func TestApplyVirtualKeyProviderFilter_StoreError(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-error")
+
+	wantErr := errors.New("store unavailable")
+	store := &virtualKeyByValueStore{
+		MockConfigStore: NewMockConfigStore(),
+		err:             wantErr,
+	}
+
+	if err := ApplyVirtualKeyProviderFilter(ctx, store); !errors.Is(err, wantErr) {
+		t.Fatalf("expected store error %v, got %v", wantErr, err)
+	}
+	if got := ctx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
+		t.Fatalf("expected store error to leave providers unset, got %v", got)
 	}
 }


### PR DESCRIPTION
## Summary

This PR fixes `list models` behavior for virtual keys.

Before this change, `GET /v1/models` and integration-backed model listing routes could still fan out across all configured providers even when the request was authenticated with a virtual key restricted to a smaller
provider set. That caused unnecessary provider probes and could surface noisy forbidden logs.

## Changes

- Added a shared helper to resolve the current virtual key and derive its allowed provider list
- Applied that provider filter before `ListAllModels` is called in the classic `/v1/models` handler
- Applied the same filtering in the generic integration router for routes such as `/openai/v1/models`
- Reused the shared `BifrostContext` from `fasthttp` user values so transport middleware and handlers operate on the same request-scoped context
- Avoided overwriting an already narrowed `available providers` context value inside the generic router
- Added tests for the new provider-filter helper and shared-context behavior

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Go tests
go test ./transports/...

# Optional full verification
go test ./...

Manual verification:

# 1. Start bifrost with a virtual key that is restricted to a subset of providers

# 2. Call the classic route
curl -H "Authorization: Bearer <virtual-key>" \
  http://localhost:8080/v1/models

# 3. Call an integration-backed list-models route
curl -H "Authorization: Bearer <virtual-key>" \
  http://localhost:8080/openai/v1/models

Expected outcome:

- Only models from providers allowed by the virtual key are returned
- The request should not fan out to disallowed providers
- Forbidden provider-probe logs should no longer appear for these routes

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This change tightens virtual-key scoping during model listing so requests only evaluate providers explicitly allowed for that virtual key.

## Checklist

- [x] I read docs/contributing/README.md and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
