### PR TITLE
fix: preserve existing query params in OAuth upstream authorize URL

### DIFF
--- a/transports/bifrost-http/handlers/oauth2_per_user.go
+++ b/transports/bifrost-http/handlers/oauth2_per_user.go
@@ -557,8 +557,19 @@ func (h *PerUserOAuthHandler) handleUpstreamAuthorize(ctx *fasthttp.RequestCtx) 
 		params.Set("scope", strings.Join(scopes, " "))
 	}
 
-	upstreamAuthorizeURL := templateConfig.AuthorizeURL + "?" + params.Encode()
-	ctx.Redirect(upstreamAuthorizeURL, fasthttp.StatusFound)
+	baseURL, err := url.Parse(templateConfig.AuthorizeURL)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, "Invalid upstream authorize URL")
+		return
+	}
+	existing := baseURL.Query()
+	for k, vals := range params {
+		for _, v := range vals {
+			existing.Set(k, v)
+		}
+	}
+	baseURL.RawQuery = existing.Encode()
+	ctx.Redirect(baseURL.String(), fasthttp.StatusFound)
 }
 
 // Ensure unused imports are referenced.

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- fix: malformed OAuth authorization URL when base URL already contains query parameters


### PR DESCRIPTION
## Summary

Fixes a bug where the OAuth upstream authorization URL would become malformed if the configured `AuthorizeURL` already contained query parameters. Previously, the redirect URL was constructed by naively appending a `?` and new parameters, which would result in a broken URL if a `?` already existed in the base URL.

## Changes

- Replaced string concatenation for building the upstream authorize URL with proper URL parsing using `url.Parse`, merging any existing query parameters from the base URL with the newly constructed ones before redirecting.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Configure a per-user OAuth handler where the `AuthorizeURL` includes existing query parameters (e.g., `https://provider.example.com/authorize?prompt=consent`). Initiate the OAuth flow and verify the redirect URL is well-formed, preserving both the existing query parameters and the newly appended ones.

```sh
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No new security implications. The fix ensures the authorization redirect URL is correctly constructed, which prevents potential issues with malformed redirect URLs that could cause OAuth flows to fail or behave unexpectedly.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable