### PR TITLE
team budget db structure refactor

### DIFF
--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -910,9 +910,21 @@ func GenerateTeamHash(t tables.TableTeam) (string, error) {
 		hash.Write([]byte("customerID:" + *t.CustomerID))
 	}
 
-	// Hash BudgetID
-	if t.BudgetID != nil {
-		hash.Write([]byte("budgetID:" + *t.BudgetID))
+	// Hash sorted budget IDs — team now owns multiple budgets; slice order must not
+	// affect the hash, otherwise config-sync would flip the hash on every reload.
+	if len(t.Budgets) > 0 {
+		ids := make([]string, len(t.Budgets))
+		for i, b := range t.Budgets {
+			ids[i] = b.ID
+		}
+		sort.Strings(ids)
+		hash.Write([]byte("budgetIDs:"))
+		for i, id := range ids {
+			if i > 0 {
+				hash.Write([]byte{','})
+			}
+			hash.Write([]byte(id))
+		}
 	}
 
 	// Hash Profile - use Profile if set, else marshal ParsedProfile

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -417,6 +417,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrateCalendarAlignedToBudgetsAndRateLimitsTable(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddTeamBudgetsToBudgetsTable(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -6077,6 +6080,133 @@ func migrationAddMultiBudgetTables(ctx context.Context, db *gorm.DB) error {
 	}
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_multi_budget_tables migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddTeamBudgetsToBudgetsTable pivots team budgets from a single-FK on
+// governance_teams.budget_id to multi-budget ownership via governance_budgets.team_id,
+// mirroring how VK/ProviderConfig budgets were restructured in migrationAddMultiBudgetTables.
+func migrationAddTeamBudgetsToBudgetsTable(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_team_budgets_to_budgets_table",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// Add team_id FK column on governance_budgets
+			if !mg.HasColumn(&tables.TableBudget{}, "team_id") {
+				if err := mg.AddColumn(&tables.TableBudget{}, "TeamID"); err != nil {
+					return fmt.Errorf("failed to add team_id column to governance_budgets: %w", err)
+				}
+			}
+
+			// Create index on the new FK column (AddColumn doesn't create indexes from struct tags)
+			if !mg.HasIndex(&tables.TableBudget{}, "idx_governance_budgets_team_id") {
+				if err := mg.CreateIndex(&tables.TableBudget{}, "TeamID"); err != nil {
+					return fmt.Errorf("failed to create index on governance_budgets.team_id: %w", err)
+				}
+			}
+
+			// Create FK constraint with CASCADE delete (defined on TableTeam.Budgets)
+			if !mg.HasConstraint(&tables.TableTeam{}, "Budgets") {
+				if err := mg.CreateConstraint(&tables.TableTeam{}, "Budgets"); err != nil {
+					return fmt.Errorf("failed to create FK constraint for Team -> Budgets: %w", err)
+				}
+			}
+
+			// Backfill: set team_id from legacy governance_teams.budget_id (if column still exists)
+			if mg.HasColumn(&tables.TableTeam{}, "budget_id") {
+				// Preflight: raw SQL below bypasses TableBudget.BeforeSave (which now
+				// enforces exactly-one-of {TeamID, VirtualKeyID, ProviderConfigID}).
+				// Fail fast if any team-referenced budget is already owned by a VK or
+				// ProviderConfig, rather than silently producing a multi-owner row
+				// that would later be rejected by the hook on its next update.
+				var conflictCount int64
+				if err := tx.Raw(`
+					SELECT COUNT(*) FROM governance_budgets b
+					WHERE (b.virtual_key_id IS NOT NULL OR b.provider_config_id IS NOT NULL)
+					  AND EXISTS (SELECT 1 FROM governance_teams t WHERE t.budget_id = b.id)
+				`).Scan(&conflictCount).Error; err != nil {
+					return fmt.Errorf("failed to check for multi-owner team budget conflicts: %w", err)
+				}
+				if conflictCount > 0 {
+					return fmt.Errorf(
+						"cannot migrate team budgets: %d budget row(s) referenced by a team are already owned by a virtual key or provider config; resolve manually before re-running",
+						conflictCount,
+					)
+				}
+
+				if err := tx.Exec(`
+					UPDATE governance_budgets SET team_id = (
+						SELECT id FROM governance_teams
+						WHERE governance_teams.budget_id = governance_budgets.id
+					) WHERE team_id IS NULL AND EXISTS (
+						SELECT 1 FROM governance_teams
+						WHERE governance_teams.budget_id = governance_budgets.id
+					)
+				`).Error; err != nil {
+					return fmt.Errorf("failed to backfill team budget team_id: %w", err)
+				}
+
+				// Drop legacy budget_id column from governance_teams (raw SQL to avoid GORM FK lookup issues)
+				_ = tx.Exec("ALTER TABLE governance_teams DROP COLUMN IF EXISTS budget_id")
+			}
+
+			// Refresh config_hash for teams whose budgets just got linked. GenerateTeamHash
+			// now includes sorted budget IDs, so hashes written by the earlier
+			// migrationAddConfigHashColumn (which ran before budgets were associated)
+			// are stale and would cause phantom drift on the next config.json sync.
+			var teamsToRehash []tables.TableTeam
+			if err := tx.Preload("Budgets").Find(&teamsToRehash).Error; err != nil {
+				return fmt.Errorf("failed to fetch teams for hash refresh: %w", err)
+			}
+			for _, team := range teamsToRehash {
+				if len(team.Budgets) == 0 {
+					continue // hash did not change; skip
+				}
+				hash, err := GenerateTeamHash(team)
+				if err != nil {
+					return fmt.Errorf("failed to generate hash for team %s: %w", team.ID, err)
+				}
+				if err := tx.Model(&tables.TableTeam{}).Where("id = ?", team.ID).Update("config_hash", hash).Error; err != nil {
+					return fmt.Errorf("failed to update hash for team %s: %w", team.ID, err)
+				}
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasColumn(&tables.TableBudget{}, "team_id") {
+				if err := mg.DropColumn(&tables.TableBudget{}, "team_id"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	// SQLite workaround — same reasoning as migrationAddMultiBudgetTables.
+	if db.Dialector.Name() == "sqlite" {
+		sqlDB, err := db.DB()
+		if err != nil {
+			return fmt.Errorf("failed to get underlying sql.DB: %w", err)
+		}
+		sqlDB.SetMaxOpenConns(1)
+		defer sqlDB.SetMaxOpenConns(0)
+
+		if err := db.Exec("PRAGMA foreign_keys = OFF").Error; err != nil {
+			return fmt.Errorf("failed to disable SQLite foreign keys: %w", err)
+		}
+		defer func() {
+			if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+				log.Fatalf("[Migration] FATAL: failed to re-enable SQLite foreign keys: %v", err)
+			}
+		}()
+	}
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_team_budgets_to_budgets_table migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1915,6 +1915,7 @@ func preloadCustomerRelations(db *gorm.DB, prefix string) *gorm.DB {
 	}
 	return db.
 		Preload(relation("Teams")).
+		Preload(relation("Teams.Budgets")).
 		Preload(relation("Budget")).
 		Preload(relation("RateLimit")).
 		Preload(relation("VirtualKeys"))
@@ -2589,7 +2590,7 @@ func (s *RDBConfigStore) GetTeams(ctx context.Context, customerID string) ([]tab
 	// Preload relationships for complete information
 	query := s.DB().WithContext(ctx).
 		Select(teamSelectWithVKCount).
-		Preload("Customer").Preload("Budget").Preload("RateLimit")
+		Preload("Customer").Preload("Budgets").Preload("RateLimit")
 	// Optional filtering by customer
 	if customerID != "" {
 		query = query.Where("customer_id = ?", customerID)
@@ -2632,7 +2633,7 @@ func (s *RDBConfigStore) GetTeamsPaginated(ctx context.Context, params TeamsQuer
 	var teams []tables.TableTeam
 	if err := baseQuery.
 		Select(teamSelectWithVKCount).
-		Preload("Customer").Preload("Budget").Preload("RateLimit").
+		Preload("Customer").Preload("Budgets").Preload("RateLimit").
 		Order("created_at ASC, id ASC").
 		Offset(offset).Limit(limit).
 		Find(&teams).Error; err != nil {
@@ -2647,7 +2648,7 @@ func (s *RDBConfigStore) GetTeam(ctx context.Context, id string) (*tables.TableT
 	var team tables.TableTeam
 	if err := s.DB().WithContext(ctx).
 		Select(teamSelectWithVKCount).
-		Preload("Customer").Preload("Budget").Preload("RateLimit").
+		Preload("Customer").Preload("Budgets").Preload("RateLimit").
 		First(&team, "id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
@@ -2686,10 +2687,12 @@ func (s *RDBConfigStore) UpdateTeam(ctx context.Context, team *tables.TableTeam,
 }
 
 // DeleteTeam deletes a team from the database.
+// Owned budgets cascade via the governance_budgets.team_id FK.
+// Rate limit is a sibling row (team holds a FK to it) — deleted explicitly.
 func (s *RDBConfigStore) DeleteTeam(ctx context.Context, id string) error {
 	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var team tables.TableTeam
-		if err := tx.WithContext(ctx).Preload("Budget").Preload("RateLimit").First(&team, "id = ?", id).Error; err != nil {
+		if err := tx.WithContext(ctx).Preload("RateLimit").First(&team, "id = ?", id).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return ErrNotFound
 			}
@@ -2699,21 +2702,13 @@ func (s *RDBConfigStore) DeleteTeam(ctx context.Context, id string) error {
 		if err := tx.WithContext(ctx).Model(&tables.TableVirtualKey{}).Where("team_id = ?", id).Update("team_id", nil).Error; err != nil {
 			return err
 		}
-		// Store the budget and rate limit IDs before deleting the team
-		budgetID := team.BudgetID
 		rateLimitID := team.RateLimitID
-		// Delete the team first
+		// Delete the team — owned budgets cascade via FK on governance_budgets.team_id
 		if err := tx.WithContext(ctx).Delete(&tables.TableTeam{}, "id = ?", id).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return ErrNotFound
 			}
 			return err
-		}
-		// Delete the team's budget if it exists
-		if budgetID != nil {
-			if err := tx.WithContext(ctx).Delete(&tables.TableBudget{}, "id = ?", *budgetID).Error; err != nil {
-				return err
-			}
 		}
 		// Delete the team's rate limit if it exists
 		if rateLimitID != nil {

--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -15,7 +15,8 @@ type TableBudget struct {
 	LastReset     time.Time `gorm:"index" json:"last_reset"`                         // Last time budget was reset
 	CurrentUsage  float64   `gorm:"default:0" json:"current_usage"`                  // Current usage in dollars
 
-	// Owner FKs: a budget belongs to at most one VK or one ProviderConfig
+	// Owner FKs: a budget belongs to at most one Team, one VK, or one ProviderConfig
+	TeamID           *string `gorm:"type:varchar(255);index" json:"team_id,omitempty"`
 	VirtualKeyID     *string `gorm:"type:varchar(255);index" json:"virtual_key_id,omitempty"`
 	ProviderConfigID *uint   `gorm:"index" json:"provider_config_id,omitempty"`
 
@@ -35,8 +36,18 @@ func (TableBudget) TableName() string { return "governance_budgets" }
 // BeforeSave hook for Budget to validate reset duration format and max limit
 func (b *TableBudget) BeforeSave(tx *gorm.DB) error {
 	// A budget belongs to at most one owner type
-	if b.VirtualKeyID != nil && b.ProviderConfigID != nil {
-		return fmt.Errorf("budget cannot belong to both a virtual key and a provider config")
+	owners := 0
+	if b.TeamID != nil {
+		owners++
+	}
+	if b.VirtualKeyID != nil {
+		owners++
+	}
+	if b.ProviderConfigID != nil {
+		owners++
+	}
+	if owners > 1 {
+		return fmt.Errorf("budget cannot have more than one owner (team/virtual key/provider config)")
 	}
 	// Validate that ResetDuration is in correct format (e.g., "30s", "5m", "1h", "1d", "1w", "1M", "1Y")
 	if d, err := ParseDuration(b.ResetDuration); err != nil {

--- a/framework/configstore/tables/team.go
+++ b/framework/configstore/tables/team.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"time"
 
-	bifrost "github.com/maximhq/bifrost/core"
 	"gorm.io/gorm"
 )
 
@@ -13,12 +12,11 @@ type TableTeam struct {
 	ID          string  `gorm:"primaryKey;type:varchar(255)" json:"id"`
 	Name        string  `gorm:"type:varchar(255);not null" json:"name"`
 	CustomerID  *string `gorm:"type:varchar(255);index" json:"customer_id,omitempty"` // A team can belong to a customer
-	BudgetID    *string `gorm:"type:varchar(255);index" json:"budget_id,omitempty"`
 	RateLimitID *string `gorm:"type:varchar(255);index" json:"rate_limit_id,omitempty"`
 
 	// Relationships
 	Customer    *TableCustomer    `gorm:"foreignKey:CustomerID" json:"customer,omitempty"`
-	Budget      *TableBudget      `gorm:"foreignKey:BudgetID" json:"budget,omitempty"`
+	Budgets     []TableBudget     `gorm:"foreignKey:TeamID;constraint:OnDelete:CASCADE" json:"budgets,omitempty"` // Multiple budgets with different reset intervals
 	RateLimit   *TableRateLimit   `gorm:"foreignKey:RateLimitID" json:"rate_limit,omitempty"`
 	VirtualKeys []TableVirtualKey `gorm:"foreignKey:TeamID" json:"virtual_keys,omitempty"`
 
@@ -52,7 +50,7 @@ func (t *TableTeam) BeforeSave(tx *gorm.DB) error {
 		if err != nil {
 			return err
 		}
-		t.Profile = bifrost.Ptr(string(data))
+		t.Profile = new(string(data))
 	} else {
 		t.Profile = nil
 	}
@@ -61,7 +59,7 @@ func (t *TableTeam) BeforeSave(tx *gorm.DB) error {
 		if err != nil {
 			return err
 		}
-		t.Config = bifrost.Ptr(string(data))
+		t.Config = new(string(data))
 	} else {
 		t.Config = nil
 	}
@@ -70,7 +68,7 @@ func (t *TableTeam) BeforeSave(tx *gorm.DB) error {
 		if err != nil {
 			return err
 		}
-		t.Claims = bifrost.Ptr(string(data))
+		t.Claims = new(string(data))
 	} else {
 		t.Claims = nil
 	}

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -310,12 +310,20 @@ func (gs *LocalGovernanceStore) GetGovernanceData(ctx context.Context) *Governan
 		if team == nil {
 			return
 		}
-		if team.BudgetID != nil {
-			if liveBudget, exists := gs.budgets.Load(*team.BudgetID); exists && liveBudget != nil {
-				if b, ok := liveBudget.(*configstoreTables.TableBudget); ok {
-					team.Budget = b
+		// Allocate a fresh slice — shallow-copying `team` (via `clone := *team` at
+		// the caller) reuses the backing array, so in-place writes would mutate
+		// the live gs.teams entry under concurrent reads. Mirrors the VK pattern
+		// above. Budgets missing from gs.budgets are dropped rather than kept stale.
+		if len(team.Budgets) > 0 {
+			liveBudgets := make([]configstoreTables.TableBudget, 0, len(team.Budgets))
+			for _, b := range team.Budgets {
+				if lb, exists := gs.budgets.Load(b.ID); exists && lb != nil {
+					if budget, ok := lb.(*configstoreTables.TableBudget); ok {
+						liveBudgets = append(liveBudgets, *budget)
+					}
 				}
 			}
+			team.Budgets = liveBudgets
 		}
 		if team.RateLimitID != nil {
 			if liveRL, exists := gs.rateLimits.Load(*team.RateLimitID); exists && liveRL != nil {
@@ -811,16 +819,20 @@ func (gs *LocalGovernanceStore) CheckTeamBudget(ctx context.Context, teamID stri
 		return DecisionAllow, nil
 	}
 	team, ok := teamValue.(*configstoreTables.TableTeam)
-	if !ok || team.BudgetID == nil {
+	if !ok || len(team.Budgets) == 0 {
 		return DecisionAllow, nil
 	}
-	teamBudget := gs.LoadBudget(ctx, *team.BudgetID)
-	if teamBudget == nil {
+	list := make([]*configstoreTables.TableBudget, 0, len(team.Budgets))
+	for _, b := range team.Budgets {
+		if hot := gs.LoadBudget(ctx, b.ID); hot != nil {
+			list = append(list, hot)
+		}
+	}
+	if len(list) == 0 {
 		return DecisionAllow, nil
 	}
 	key := fmt.Sprintf("Team:%s", teamID)
-	entityWiseBudgets := EntityWiseBudgets{key: {teamBudget}}
-	return gs.CheckBudget(ctx, entityWiseBudgets, baselines)
+	return gs.CheckBudget(ctx, EntityWiseBudgets{key: list}, baselines)
 }
 
 // CheckTeamRateLimit checks team-level rate limit and returns evaluation result if violated
@@ -2087,8 +2099,11 @@ func (gs *LocalGovernanceStore) collectBudgetsFromHierarchy(_ context.Context, v
 	if vk.TeamID != nil {
 		if teamValue, exists := gs.teams.Load(*vk.TeamID); exists && teamValue != nil {
 			if team, ok := teamValue.(*configstoreTables.TableTeam); ok && team != nil {
-				if team.BudgetID != nil {
-					if budgetValue, exists := gs.budgets.Load(*team.BudgetID); exists && budgetValue != nil {
+				for _, tb := range team.Budgets {
+					if seen[tb.ID] {
+						continue
+					}
+					if budgetValue, exists := gs.budgets.Load(tb.ID); exists && budgetValue != nil {
 						if budget, ok := budgetValue.(*configstoreTables.TableBudget); ok && budget != nil {
 							if categoryBudgets := entityWiseBudgets["Team"]; categoryBudgets == nil {
 								entityWiseBudgets["Team"] = []*configstoreTables.TableBudget{}
@@ -2372,9 +2387,10 @@ func (gs *LocalGovernanceStore) CreateTeamInMemory(ctx context.Context, team *co
 		return // Nothing to create
 	}
 
-	// Create associated budget if exists
-	if team.Budget != nil {
-		gs.budgets.Store(team.Budget.ID, team.Budget)
+	// Create associated budgets if they exist
+	for i := range team.Budgets {
+		b := team.Budgets[i]
+		gs.budgets.Store(b.ID, &b)
 	}
 
 	// Create associated rate limit if exists
@@ -2401,20 +2417,30 @@ func (gs *LocalGovernanceStore) UpdateTeamInMemory(ctx context.Context, team *co
 		// Create clone to avoid modifying the original
 		clone := *team
 
-		// Handle budget updates with consistent logic
-		if clone.Budget != nil {
-			// Preserve existing usage from memory when updating team budget config
-			if existingBudgetValue, exists := gs.budgets.Load(clone.Budget.ID); exists && existingBudgetValue != nil {
-				if existingBudget, ok := existingBudgetValue.(*configstoreTables.TableBudget); ok && existingBudget != nil {
-					// Preserve current usage and last reset time from existing in-memory budget
-					clone.Budget.CurrentUsage = existingBudget.CurrentUsage
-					clone.Budget.LastReset = existingBudget.LastReset
+		// Reconcile multi-budget slice by ID: preserve live usage on matches,
+		// evict budgets that disappeared from the team (owned-FK semantics —
+		// a team's budgets are team-scoped, so dropping the association means
+		// the budget no longer exists for anyone).
+		existingBudgetIDs := map[string]struct{}{}
+		for _, b := range existingTeam.Budgets {
+			existingBudgetIDs[b.ID] = struct{}{}
+		}
+		nextBudgetIDs := map[string]struct{}{}
+		for i := range clone.Budgets {
+			b := &clone.Budgets[i]
+			nextBudgetIDs[b.ID] = struct{}{}
+			if live, exists := gs.budgets.Load(b.ID); exists && live != nil {
+				if lb, ok := live.(*configstoreTables.TableBudget); ok && lb != nil {
+					b.CurrentUsage = lb.CurrentUsage
+					b.LastReset = lb.LastReset
 				}
 			}
-			gs.budgets.Store(clone.Budget.ID, clone.Budget)
-		} else if existingTeam.Budget != nil {
-			// Budget was removed from the team, delete it from memory
-			gs.budgets.Delete(existingTeam.Budget.ID)
+			gs.budgets.Store(b.ID, b)
+		}
+		for id := range existingBudgetIDs {
+			if _, stillThere := nextBudgetIDs[id]; !stillThere {
+				gs.budgets.Delete(id)
+			}
 		}
 
 		// Handle rate limit updates with consistent logic
@@ -2447,12 +2473,12 @@ func (gs *LocalGovernanceStore) DeleteTeamInMemory(ctx context.Context, teamID s
 		return // Nothing to delete
 	}
 
-	// Get team to check for associated budget and rate limit
+	// Get team to check for associated budgets and rate limit
 	if teamValue, exists := gs.teams.Load(teamID); exists && teamValue != nil {
 		if team, ok := teamValue.(*configstoreTables.TableTeam); ok && team != nil {
-			// Delete associated budget if exists
-			if team.BudgetID != nil {
-				gs.budgets.Delete(*team.BudgetID)
+			// Delete all associated budgets
+			for _, b := range team.Budgets {
+				gs.budgets.Delete(b.ID)
 			}
 			// Delete associated rate limit if exists
 			if team.RateLimitID != nil {
@@ -2807,10 +2833,14 @@ func (gs *LocalGovernanceStore) updateBudgetReferences(ctx context.Context, rese
 		if !ok || team == nil {
 			return true // continue
 		}
-		if team.BudgetID != nil && *team.BudgetID == budgetID {
-			clone := *team
-			clone.Budget = resetBudget
-			gs.teams.Store(key, &clone)
+		for i := range team.Budgets {
+			if team.Budgets[i].ID == budgetID {
+				clone := *team
+				clone.Budgets = append([]configstoreTables.TableBudget(nil), team.Budgets...)
+				clone.Budgets[i] = *resetBudget
+				gs.teams.Store(key, &clone)
+				break
+			}
 		}
 		return true // continue
 	})

--- a/plugins/governance/test_utils.go
+++ b/plugins/governance/test_utils.go
@@ -172,8 +172,8 @@ func buildTeam(id, name string, budget *configstoreTables.TableBudget) *configst
 		Name: name,
 	}
 	if budget != nil {
-		team.Budget = budget
-		team.BudgetID = &budget.ID
+		budget.TeamID = &team.ID
+		team.Budgets = []configstoreTables.TableBudget{*budget}
 	}
 	return team
 }

--- a/tests/governance/advancedscenarios_test.go
+++ b/tests/governance/advancedscenarios_test.go
@@ -24,10 +24,10 @@ func TestVKSwitchTeamAfterBudgetExhaustion(t *testing.T) {
 		Path:   "/api/governance/teams",
 		Body: CreateTeamRequest{
 			Name: team1Name,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      team1Budget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -46,10 +46,10 @@ func TestVKSwitchTeamAfterBudgetExhaustion(t *testing.T) {
 		Path:   "/api/governance/teams",
 		Body: CreateTeamRequest{
 			Name: team2Name,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      team2Budget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -372,10 +372,10 @@ func TestHierarchicalChainBudgetSwitch(t *testing.T) {
 		Body: CreateTeamRequest{
 			Name:       team1Name,
 			CustomerID: &customer1ID,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      100.0, // High budget - customer is limiting
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -415,10 +415,10 @@ func TestHierarchicalChainBudgetSwitch(t *testing.T) {
 		Body: CreateTeamRequest{
 			Name:       team2Name,
 			CustomerID: &customer2ID,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      100.0, // High budget
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -674,10 +674,10 @@ func TestTeamBudgetUpdateAfterExhaustion(t *testing.T) {
 		Path:   "/api/governance/teams",
 		Body: CreateTeamRequest{
 			Name: teamName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      initialBudget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -762,10 +762,10 @@ func TestTeamBudgetUpdateAfterExhaustion(t *testing.T) {
 		Method: "PUT",
 		Path:   "/api/governance/teams/" + teamID,
 		Body: UpdateTeamRequest{
-			Budget: &UpdateBudgetRequest{
-				MaxLimit:      &newBudget,
-				ResetDuration: &resetDuration,
-			},
+			Budgets: &[]BudgetRequest{{
+				MaxLimit:      newBudget,
+				ResetDuration: resetDuration,
+			}},
 		},
 	})
 
@@ -1291,10 +1291,10 @@ func TestTeamDeletionDeletesBudget(t *testing.T) {
 		Path:   "/api/governance/teams",
 		Body: CreateTeamRequest{
 			Name: teamName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      100.0,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -1323,7 +1323,12 @@ func TestTeamDeletionDeletesBudget(t *testing.T) {
 	budgetsMap1 := getBudgetsResp1.Body["budgets"].(map[string]interface{})
 
 	teamData1 := teamsMap1[teamID].(map[string]interface{})
-	budgetID := teamData1["budget_id"].(string)
+	// Teams now expose a `budgets` array instead of a single `budget_id`.
+	budgetsList, ok := teamData1["budgets"].([]interface{})
+	if !ok || len(budgetsList) == 0 {
+		t.Fatalf("Team %s has no budgets in memory before deletion", teamID)
+	}
+	budgetID := budgetsList[0].(map[string]interface{})["id"].(string)
 
 	_, budgetExists := budgetsMap1[budgetID]
 	if !budgetExists {

--- a/tests/governance/configupdatesync_test.go
+++ b/tests/governance/configupdatesync_test.go
@@ -582,10 +582,10 @@ func TestTeamBudgetUpdateSyncToMemory(t *testing.T) {
 		Path:   "/api/governance/teams",
 		Body: CreateTeamRequest{
 			Name: teamName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      initialBudget,
 				ResetDuration: resetDuration,
-			},
+			}},
 		},
 	})
 
@@ -627,7 +627,12 @@ func TestTeamBudgetUpdateSyncToMemory(t *testing.T) {
 
 	teamsMap1 := getTeamsResp1.Body["teams"].(map[string]interface{})
 	teamData1 := teamsMap1[teamID].(map[string]interface{})
-	budgetID, _ := teamData1["budget_id"].(string)
+	// Teams now expose a `budgets` array instead of a single `budget_id`.
+	budgetsList, ok := teamData1["budgets"].([]interface{})
+	if !ok || len(budgetsList) == 0 {
+		t.Fatalf("Team %s has no budgets in memory", teamID)
+	}
+	budgetID, _ := budgetsList[0].(map[string]interface{})["id"].(string)
 
 	getBudgetsResp1 := MakeRequest(t, APIRequest{
 		Method: "GET",
@@ -697,10 +702,10 @@ func TestTeamBudgetUpdateSyncToMemory(t *testing.T) {
 		Method: "PUT",
 		Path:   "/api/governance/teams/" + teamID,
 		Body: UpdateTeamRequest{
-			Budget: &UpdateBudgetRequest{
-				MaxLimit:      &newLowerBudget,
-				ResetDuration: &resetDurationPtr,
-			},
+			Budgets: &[]BudgetRequest{{
+				MaxLimit:      newLowerBudget,
+				ResetDuration: resetDurationPtr,
+			}},
 		},
 	})
 

--- a/tests/governance/customerbudget_test.go
+++ b/tests/governance/customerbudget_test.go
@@ -197,10 +197,10 @@ func TestCustomerBudgetExceededWithMultipleTeams(t *testing.T) {
 			Body: CreateTeamRequest{
 				Name:       "test-team-" + generateRandomID(),
 				CustomerID: &customerID,
-				Budget: &BudgetRequest{
+				Budgets: []BudgetRequest{{
 					MaxLimit:      1.0, // High team budget so customer is the limiting factor
 					ResetDuration: "1h",
-				},
+				}},
 			},
 		})
 

--- a/tests/governance/e2e_test.go
+++ b/tests/governance/e2e_test.go
@@ -29,10 +29,10 @@ func TestMultipleVKsSharingTeamBudgetFairness(t *testing.T) {
 		Path:   "/api/governance/teams",
 		Body: CreateTeamRequest{
 			Name: teamName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      teamBudget,
 				ResetDuration: teamResetDuration,
-			},
+			}},
 		},
 	})
 
@@ -221,10 +221,10 @@ func TestFullBudgetHierarchyEnforcement(t *testing.T) {
 		Body: CreateTeamRequest{
 			Name:       teamName,
 			CustomerID: &customerID,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      100.0, // Medium
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -1086,10 +1086,10 @@ func TestTeamDeletionCascade(t *testing.T) {
 		Path:   "/api/governance/teams",
 		Body: CreateTeamRequest{
 			Name: teamName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      100.0,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 

--- a/tests/governance/edgecases_test.go
+++ b/tests/governance/edgecases_test.go
@@ -43,10 +43,10 @@ func TestCrissCrossComplexBudgetHierarchy(t *testing.T) {
 		Body: CreateTeamRequest{
 			Name:       "test-team-criss-cross-" + generateRandomID(),
 			CustomerID: &customerID,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      teamBudget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 

--- a/tests/governance/inmemorysync_test.go
+++ b/tests/governance/inmemorysync_test.go
@@ -143,10 +143,10 @@ func TestInMemorySyncTeamUpdate(t *testing.T) {
 		Path:   "/api/governance/teams",
 		Body: CreateTeamRequest{
 			Name: teamName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      initialBudget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 
@@ -184,9 +184,10 @@ func TestInMemorySyncTeamUpdate(t *testing.T) {
 		Method: "PUT",
 		Path:   "/api/governance/teams/" + teamID,
 		Body: UpdateTeamRequest{
-			Budget: &UpdateBudgetRequest{
-				MaxLimit: &newTeamBudget,
-			},
+			Budgets: &[]BudgetRequest{{
+				MaxLimit:      newTeamBudget,
+				ResetDuration: "1h",
+			}},
 		},
 	})
 
@@ -223,7 +224,13 @@ func TestInMemorySyncTeamUpdate(t *testing.T) {
 	}
 
 	teamDataMap := teamData2.(map[string]interface{})
-	budgetID, _ := teamDataMap["budget_id"].(string)
+	// Teams now expose a `budgets` array instead of a single `budget_id` — read the first.
+	var budgetID string
+	if budgetsList, ok := teamDataMap["budgets"].([]interface{}); ok && len(budgetsList) > 0 {
+		if b, ok := budgetsList[0].(map[string]interface{}); ok {
+			budgetID, _ = b["id"].(string)
+		}
+	}
 
 	if budgetID != "" {
 		budgetData, budgetExists := budgetsMap2[budgetID]
@@ -477,10 +484,10 @@ func TestDataEndpointConsistency(t *testing.T) {
 		Path:   "/api/governance/teams",
 		Body: CreateTeamRequest{
 			Name: teamName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      30.0,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 

--- a/tests/governance/teambudget_test.go
+++ b/tests/governance/teambudget_test.go
@@ -20,10 +20,10 @@ func TestTeamBudgetExceededWithMultipleVKs(t *testing.T) {
 		Path:   "/api/governance/teams",
 		Body: CreateTeamRequest{
 			Name: teamName,
-			Budget: &BudgetRequest{
+			Budgets: []BudgetRequest{{
 				MaxLimit:      teamBudget,
 				ResetDuration: "1h",
-			},
+			}},
 		},
 	})
 

--- a/tests/governance/test_utils.go
+++ b/tests/governance/test_utils.go
@@ -241,9 +241,9 @@ type BudgetRequest struct {
 
 // CreateTeamRequest represents a request to create a team
 type CreateTeamRequest struct {
-	Name       string         `json:"name"`
-	CustomerID *string        `json:"customer_id,omitempty"`
-	Budget     *BudgetRequest `json:"budget,omitempty"`
+	Name       string          `json:"name"`
+	CustomerID *string         `json:"customer_id,omitempty"`
+	Budgets    []BudgetRequest `json:"budgets,omitempty"`
 }
 
 // CreateCustomerRequest represents a request to create a customer
@@ -279,8 +279,12 @@ type UpdateVirtualKeyRequest struct {
 
 // UpdateTeamRequest represents a request to update a team
 type UpdateTeamRequest struct {
-	Name   *string              `json:"name,omitempty"`
-	Budget *UpdateBudgetRequest `json:"budget,omitempty"`
+	Name *string `json:"name,omitempty"`
+	// Pointer-to-slice so tests can distinguish:
+	//   nil                  → field omitted (budgets untouched by server)
+	//   &[]BudgetRequest{}   → explicit empty array (server clears all budgets)
+	//   &[]BudgetRequest{…}  → replace with the provided budgets
+	Budgets *[]BudgetRequest `json:"budgets,omitempty"`
 }
 
 // UpdateCustomerRequest represents a request to update a customer

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -222,7 +222,7 @@ func collectProviderConfigDeleteIDs(
 type CreateTeamRequest struct {
 	Name       string                  `json:"name" validate:"required"`
 	CustomerID *string                 `json:"customer_id,omitempty"` // Team can belong to a customer
-	Budget     *CreateBudgetRequest    `json:"budget,omitempty"`      // Team can have its own budget
+	Budgets    []CreateBudgetRequest   `json:"budgets,omitempty"`     // Multi-budget: each must have a unique reset_duration
 	RateLimit  *CreateRateLimitRequest `json:"rate_limit,omitempty"`  // Team can have its own rate limit
 }
 
@@ -230,7 +230,7 @@ type CreateTeamRequest struct {
 type UpdateTeamRequest struct {
 	Name       *string                 `json:"name,omitempty"`
 	CustomerID *string                 `json:"customer_id,omitempty"`
-	Budget     *UpdateBudgetRequest    `json:"budget,omitempty"`
+	Budgets    []CreateBudgetRequest   `json:"budgets,omitempty"` // Multi-budget: replaces all team budgets
 	RateLimit  *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
 }
 
@@ -1407,18 +1407,6 @@ func (h *GovernanceHandler) createTeam(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 400, "Team name is required")
 		return
 	}
-	// Validate budget if provided
-	if req.Budget != nil {
-		if req.Budget.MaxLimit < 0 {
-			SendError(ctx, 400, fmt.Sprintf("Budget max_limit cannot be negative: %.2f", req.Budget.MaxLimit))
-			return
-		}
-		// Validate reset duration format
-		if _, err := configstoreTables.ParseDuration(req.Budget.ResetDuration); err != nil {
-			SendError(ctx, 400, fmt.Sprintf("Invalid reset duration format: %s", req.Budget.ResetDuration))
-			return
-		}
-	}
 	// Validate rate limit if provided
 	if req.RateLimit != nil {
 		rateLimit := configstoreTables.TableRateLimit{
@@ -1440,22 +1428,6 @@ func (h *GovernanceHandler) createTeam(ctx *fasthttp.RequestCtx) {
 			Name:       req.Name,
 			CustomerID: req.CustomerID,
 		}
-		if req.Budget != nil {
-			budget := configstoreTables.TableBudget{
-				ID:            uuid.NewString(),
-				MaxLimit:      req.Budget.MaxLimit,
-				ResetDuration: req.Budget.ResetDuration,
-				LastReset:     budgetLastReset(false, req.Budget.ResetDuration),
-				CurrentUsage:  0,
-			}
-			if err := validateBudget(&budget); err != nil {
-				return err
-			}
-			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-				return err
-			}
-			team.BudgetID = &budget.ID
-		}
 		if req.RateLimit != nil {
 			rateLimit := configstoreTables.TableRateLimit{
 				ID:                   uuid.NewString(),
@@ -1471,11 +1443,47 @@ func (h *GovernanceHandler) createTeam(ctx *fasthttp.RequestCtx) {
 			}
 			team.RateLimitID = &rateLimit.ID
 		}
+		// Team row must exist before child budgets (FK on governance_budgets.team_id)
 		if err := h.configStore.CreateTeam(ctx, &team, tx); err != nil {
 			return err
 		}
+		// Create owned multi-budgets; enforce unique reset_duration per team
+		seenDurations := make(map[string]bool)
+		for _, b := range req.Budgets {
+			if b.MaxLimit < 0 {
+				return &badRequestError{err: fmt.Errorf("budget max_limit cannot be negative: %.2f", b.MaxLimit)}
+			}
+			if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
+				return &badRequestError{err: fmt.Errorf("invalid reset duration format: %s", b.ResetDuration)}
+			}
+			if seenDurations[b.ResetDuration] {
+				return &badRequestError{err: fmt.Errorf("duplicate reset_duration in budgets: %s", b.ResetDuration)}
+			}
+			seenDurations[b.ResetDuration] = true
+			budget := configstoreTables.TableBudget{
+				ID:              uuid.NewString(),
+				MaxLimit:        b.MaxLimit,
+				ResetDuration:   b.ResetDuration,
+				LastReset:       budgetLastReset(b.CalendarAligned, b.ResetDuration),
+				CurrentUsage:    0,
+				CalendarAligned: b.CalendarAligned,
+				TeamID:          &team.ID,
+			}
+			if err := validateBudget(&budget); err != nil {
+				return err
+			}
+			if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return err
+			}
+			team.Budgets = append(team.Budgets, budget)
+		}
 		return nil
 	}); err != nil {
+		var badReqErr *badRequestError
+		if errors.As(err, &badReqErr) {
+			SendError(ctx, 400, err.Error())
+			return
+		}
 		logger.Error("failed to create team: %v", err)
 		SendError(ctx, 500, "failed to create team")
 		return
@@ -1548,8 +1556,8 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 	}
 	// Updating team in database
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-		// Track IDs to delete after updating the team (to avoid FK constraint)
-		var budgetIDToDelete, rateLimitIDToDelete string
+		// Track rate-limit ID to delete after updating the team (to avoid FK constraint)
+		var rateLimitIDToDelete string
 
 		// Update fields if provided
 		if req.Name != nil {
@@ -1562,63 +1570,81 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 				team.CustomerID = req.CustomerID
 			}
 		}
-		// Handle budget updates
-		if req.Budget != nil {
-			// Check if budget removal is requested (all fields nil)
-			budgetIsEmpty := isBudgetRemovalRequest(req.Budget)
-			if budgetIsEmpty {
-				// Mark budget for deletion after FK is removed
-				if team.BudgetID != nil {
-					budgetIDToDelete = *team.BudgetID
-					team.BudgetID = nil
-					team.Budget = nil
+		// Multi-budget reconciliation: match by reset_duration, preserve usage on update,
+		// create new budgets for new durations, delete unmatched existing budgets.
+		// Mirrors VK multi-budget handling above.
+		if req.Budgets != nil {
+			// Validate incoming budgets
+			seenDurations := make(map[string]bool)
+			for _, b := range req.Budgets {
+				if b.MaxLimit < 0 {
+					return &badRequestError{err: fmt.Errorf("budget max_limit cannot be negative: %.2f", b.MaxLimit)}
 				}
-			} else if team.BudgetID != nil {
-				// Update existing budget — all fields are optional (partial update)
-				budget := configstoreTables.TableBudget{}
-				if err := tx.First(&budget, "id = ?", *team.BudgetID).Error; err != nil {
-					return err
+				if _, err := configstoreTables.ParseDuration(b.ResetDuration); err != nil {
+					return &badRequestError{err: fmt.Errorf("invalid reset duration format: %s", b.ResetDuration)}
 				}
-				if req.Budget.MaxLimit != nil {
-					budget.MaxLimit = *req.Budget.MaxLimit
+				if seenDurations[b.ResetDuration] {
+					return &badRequestError{err: fmt.Errorf("duplicate reset_duration in budgets: %s", b.ResetDuration)}
 				}
-				if req.Budget.ResetDuration != nil {
-					budget.ResetDuration = *req.Budget.ResetDuration
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.UpdateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				team.Budget = &budget
-			} else {
-				// Create new budget
-				if req.Budget.MaxLimit == nil || req.Budget.ResetDuration == nil {
-					return fmt.Errorf("both max_limit and reset_duration are required when creating a new budget")
-				}
-				if *req.Budget.MaxLimit < 0 {
-					return fmt.Errorf("budget max_limit cannot be negative: %.2f", *req.Budget.MaxLimit)
-				}
-				if _, err := configstoreTables.ParseDuration(*req.Budget.ResetDuration); err != nil {
-					return fmt.Errorf("invalid reset duration format: %s", *req.Budget.ResetDuration)
-				}
-				budget := configstoreTables.TableBudget{
-					ID:            uuid.NewString(),
-					MaxLimit:      *req.Budget.MaxLimit,
-					ResetDuration: *req.Budget.ResetDuration,
-					LastReset:     budgetLastReset(false, *req.Budget.ResetDuration),
-					CurrentUsage:  0,
-				}
-				if err := validateBudget(&budget); err != nil {
-					return err
-				}
-				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
-					return err
-				}
-				team.BudgetID = &budget.ID
-				team.Budget = &budget
+				seenDurations[b.ResetDuration] = true
 			}
+
+			existingByDuration := make(map[string]configstoreTables.TableBudget)
+			for _, existing := range team.Budgets {
+				existingByDuration[existing.ResetDuration] = existing
+			}
+
+			var reconciledBudgets []configstoreTables.TableBudget
+			matchedIDs := make(map[string]bool)
+			for _, b := range req.Budgets {
+				if existing, found := existingByDuration[b.ResetDuration]; found {
+					wasCalendarAligned := existing.CalendarAligned
+					existing.MaxLimit = b.MaxLimit
+					existing.CalendarAligned = b.CalendarAligned
+					// Match the UI's calendar-alignment confirmation promise: on the
+					// false → true transition, snap LastReset to the current period
+					// start and zero out CurrentUsage now, instead of lazily waiting
+					// for the next period boundary in ResetExpiredBudgetsInMemory.
+					if b.CalendarAligned && !wasCalendarAligned {
+						existing.LastReset = configstoreTables.GetCalendarPeriodStart(b.ResetDuration, time.Now())
+						existing.CurrentUsage = 0
+					}
+					if err := validateBudget(&existing); err != nil {
+						return err
+					}
+					if err := h.configStore.UpdateBudget(ctx, &existing, tx); err != nil {
+						return err
+					}
+					reconciledBudgets = append(reconciledBudgets, existing)
+					matchedIDs[existing.ID] = true
+				} else {
+					budget := configstoreTables.TableBudget{
+						ID:              uuid.NewString(),
+						MaxLimit:        b.MaxLimit,
+						ResetDuration:   b.ResetDuration,
+						LastReset:       budgetLastReset(b.CalendarAligned, b.ResetDuration),
+						CurrentUsage:    0,
+						CalendarAligned: b.CalendarAligned,
+						TeamID:          &team.ID,
+					}
+					if err := validateBudget(&budget); err != nil {
+						return err
+					}
+					if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+						return err
+					}
+					reconciledBudgets = append(reconciledBudgets, budget)
+				}
+			}
+			// Delete budgets that are no longer present
+			for _, existing := range team.Budgets {
+				if !matchedIDs[existing.ID] {
+					if err := h.configStore.DeleteBudget(ctx, existing.ID, tx); err != nil {
+						return fmt.Errorf("failed to delete removed team budget: %w", err)
+					}
+				}
+			}
+			team.Budgets = reconciledBudgets
 		}
 		// Handle rate limit updates
 		if req.RateLimit != nil {
@@ -1673,12 +1699,9 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 			return err
 		}
 
-		// Now that FK references are removed, delete the orphaned budget/rate limit
-		if budgetIDToDelete != "" {
-			if err := tx.Delete(&configstoreTables.TableBudget{}, "id = ?", budgetIDToDelete).Error; err != nil {
-				return err
-			}
-		}
+		// Now that FK references are removed, delete the orphaned rate limit.
+		// Budgets are reconciled above (deletion of unmatched rows happens inside
+		// the reconciliation loop), so nothing to clean up here.
 		if rateLimitIDToDelete != "" {
 			if err := tx.Delete(&configstoreTables.TableRateLimit{}, "id = ?", rateLimitIDToDelete).Error; err != nil {
 				return err
@@ -1687,6 +1710,12 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 
 		return nil
 	}); err != nil {
+		var badReqErr *badRequestError
+		if errors.As(err, &badReqErr) {
+			SendError(ctx, 400, err.Error())
+			return
+		}
+		logger.Error("failed to update team: %v", err)
 		SendError(ctx, 500, "Failed to update team")
 		return
 	}
@@ -1808,18 +1837,6 @@ func (h *GovernanceHandler) createCustomer(ctx *fasthttp.RequestCtx) {
 	if req.Name == "" {
 		SendError(ctx, 400, "Customer name is required")
 		return
-	}
-	// Validate budget if provided
-	if req.Budget != nil {
-		if req.Budget.MaxLimit < 0 {
-			SendError(ctx, 400, fmt.Sprintf("Budget max_limit cannot be negative: %.2f", req.Budget.MaxLimit))
-			return
-		}
-		// Validate reset duration format
-		if _, err := configstoreTables.ParseDuration(req.Budget.ResetDuration); err != nil {
-			SendError(ctx, 400, fmt.Sprintf("Invalid reset duration format: %s", req.Budget.ResetDuration))
-			return
-		}
 	}
 	// Validate rate limit if provided
 	if req.RateLimit != nil {

--- a/ui/app/workspace/governance/views/teamDialog.tsx
+++ b/ui/app/workspace/governance/views/teamDialog.tsx
@@ -50,6 +50,7 @@ import { formatDistanceToNow } from "date-fns";
 import isEqual from "lodash.isequal";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import { v4 as uuid } from "uuid";
 
 interface TeamDialogProps {
   team?: Team | null;
@@ -58,13 +59,23 @@ interface TeamDialogProps {
   onCancel: () => void;
 }
 
+// One editable budget row; teams own multiple, each keyed by reset_duration
+// on the wire. The client-side `id` is stable across re-renders and equals
+// the persisted budget's id for existing rows, or a fresh UUID for new ones —
+// used as the React key and for matching against `team.budgets` when we need
+// to distinguish "already persisted" from "just added in the form".
+interface TeamBudgetRow {
+  id: string;
+  maxLimit: number | undefined;
+  resetDuration: string;
+  calendarAligned: boolean;
+}
+
 interface TeamFormData {
   name: string;
   customerId: string;
-  // Budget
-  budgetMaxLimit: number | undefined;
-  budgetResetDuration: string;
-  budgetCalendarAligned: boolean;
+  // Multi-budget: each row has a unique reset_duration on submit
+  budgets: TeamBudgetRow[];
   // Rate Limit
   tokenMaxLimit: number | undefined;
   tokenResetDuration: string;
@@ -80,10 +91,13 @@ const createInitialState = (
   return {
     name: team?.name || "",
     customerId: team?.customer_id || "",
-    // Budget
-    budgetMaxLimit: team?.budget?.max_limit ?? undefined,
-    budgetResetDuration: team?.budget?.reset_duration || "1M",
-    budgetCalendarAligned: team?.budget?.calendar_aligned ?? false,
+    budgets:
+      team?.budgets?.map((b) => ({
+        id: b.id,
+        maxLimit: b.max_limit,
+        resetDuration: b.reset_duration,
+        calendarAligned: b.calendar_aligned ?? false,
+      })) ?? [],
     // Rate Limit
     tokenMaxLimit: team?.rate_limit?.token_max_limit ?? undefined,
     tokenResetDuration: team?.rate_limit?.token_reset_duration || "1h",
@@ -111,7 +125,7 @@ export default function TeamDialog({
     const nextInitial = createInitialState(team);
     setInitialState(nextInitial);
     setFormData({ ...nextInitial, isDirty: false });
-    setShowCalendarAlignWarning(false);
+    setPendingCalendarAlignIdx(null);
   }, [team]);
 
   const hasCreateAccess = useRbac(RbacResource.Teams, RbacOperation.Create);
@@ -123,25 +137,63 @@ export default function TeamDialog({
   const [updateTeam, { isLoading: isUpdating }] = useUpdateTeamMutation();
   const loading = isCreating || isUpdating;
 
-  const [showCalendarAlignWarning, setShowCalendarAlignWarning] =
-    useState(false);
+  // Tracks which row (by index) is awaiting calendar-align confirmation.
+  const [pendingCalendarAlignIdx, setPendingCalendarAlignIdx] = useState<
+    number | null
+  >(null);
+  const showCalendarAlignWarning = pendingCalendarAlignIdx !== null;
 
-  const handleCalendarAlignedChange = (checked: boolean) => {
-    if (checked && isEditing && team?.budget && !team.budget.calendar_aligned) {
-      setShowCalendarAlignWarning(true);
+  const updateBudgetRow = (idx: number, patch: Partial<TeamBudgetRow>) => {
+    setFormData((prev) => {
+      const next = prev.budgets.map((row, i) =>
+        i === idx ? { ...row, ...patch } : row,
+      );
+      return { ...prev, budgets: next };
+    });
+  };
+
+  const addBudgetRow = () => {
+    setFormData((prev) => ({
+      ...prev,
+      budgets: [
+        ...prev.budgets,
+        {
+          id: uuid(),
+          maxLimit: undefined,
+          resetDuration: "1M",
+          calendarAligned: false,
+        },
+      ],
+    }));
+  };
+
+  const removeBudgetRow = (idx: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      budgets: prev.budgets.filter((_, i) => i !== idx),
+    }));
+  };
+
+  const handleCalendarAlignedChange = (idx: number, checked: boolean) => {
+    // Match the persisted budget by stable row id — for seeded rows this equals
+    // the server-side budget id; for newly-added rows it's a client-only UUID
+    // that won't match anything in team.budgets (correctly: no warning for new rows).
+    // Avoids the reset_duration-duplicate ambiguity before validation resolves.
+    const rowId = formData.budgets[idx]?.id;
+    const existingBudget = team?.budgets?.find((b) => b.id === rowId);
+    if (checked && isEditing && existingBudget && !existingBudget.calendar_aligned) {
+      setPendingCalendarAlignIdx(idx);
     } else {
-      updateField("budgetCalendarAligned", checked);
+      updateBudgetRow(idx, { calendarAligned: checked });
     }
   };
 
   // Track isDirty state
   useEffect(() => {
-    const currentData = {
+    const currentData: Omit<TeamFormData, "isDirty"> = {
       name: formData.name,
       customerId: formData.customerId,
-      budgetMaxLimit: formData.budgetMaxLimit,
-      budgetResetDuration: formData.budgetResetDuration,
-      budgetCalendarAligned: formData.budgetCalendarAligned,
+      budgets: formData.budgets,
       tokenMaxLimit: formData.tokenMaxLimit,
       tokenResetDuration: formData.tokenResetDuration,
       requestMaxLimit: formData.requestMaxLimit,
@@ -154,9 +206,7 @@ export default function TeamDialog({
   }, [
     formData.name,
     formData.customerId,
-    formData.budgetMaxLimit,
-    formData.budgetResetDuration,
-    formData.budgetCalendarAligned,
+    formData.budgets,
     formData.tokenMaxLimit,
     formData.tokenResetDuration,
     formData.requestMaxLimit,
@@ -164,71 +214,73 @@ export default function TeamDialog({
     initialState,
   ]);
 
-  // Values for validation and submission (already numbers)
-  const budgetMaxLimitNum = formData.budgetMaxLimit;
   const tokenMaxLimitNum = formData.tokenMaxLimit;
   const requestMaxLimitNum = formData.requestMaxLimit;
 
   // Validation
-  const validator = useMemo(
-    () =>
-      new Validator([
-        // Basic validation
-        Validator.required(formData.name.trim(), "Team name is required"),
+  const validator = useMemo(() => {
+    // Per-row budget validation plus cross-row uniqueness on reset_duration.
+    const budgetValidators = formData.budgets.flatMap((row, idx) => {
+      if (row.maxLimit === undefined || row.maxLimit === null) return [];
+      return [
+        Validator.minValue(
+          row.maxLimit,
+          0.01,
+          `Budget #${idx + 1} max limit must be greater than $0.01`,
+        ),
+        Validator.required(
+          row.resetDuration,
+          `Budget #${idx + 1} reset duration is required`,
+        ),
+      ];
+    });
+    const populatedDurations = formData.budgets
+      .filter((r) => r.maxLimit !== undefined && r.maxLimit !== null)
+      .map((r) => r.resetDuration);
+    const uniqueDurations = new Set(populatedDurations).size;
 
-        // Check if anything is dirty
-        Validator.custom(formData.isDirty, "No changes to save"),
+    return new Validator([
+      Validator.required(formData.name.trim(), "Team name is required"),
+      Validator.custom(formData.isDirty, "No changes to save"),
+      ...budgetValidators,
+      Validator.custom(
+        uniqueDurations === populatedDurations.length,
+        "Each budget must have a distinct reset duration",
+      ),
 
-        // Budget validation
-        ...(formData.budgetMaxLimit !== undefined &&
-        formData.budgetMaxLimit !== null
-          ? [
-              Validator.minValue(
-                budgetMaxLimitNum || 0,
-                0.01,
-                "Budget max limit must be greater than $0.01",
-              ),
-              Validator.required(
-                formData.budgetResetDuration,
-                "Budget reset duration is required",
-              ),
-            ]
-          : []),
+      // Rate limit validation - token limits
+      ...(formData.tokenMaxLimit !== undefined &&
+      formData.tokenMaxLimit !== null
+        ? [
+            Validator.minValue(
+              tokenMaxLimitNum || 0,
+              1,
+              "Token max limit must be at least 1",
+            ),
+            Validator.required(
+              formData.tokenResetDuration,
+              "Token reset duration is required",
+            ),
+          ]
+        : []),
 
-        // Rate limit validation - token limits
-        ...(formData.tokenMaxLimit !== undefined &&
-        formData.tokenMaxLimit !== null
-          ? [
-              Validator.minValue(
-                tokenMaxLimitNum || 0,
-                1,
-                "Token max limit must be at least 1",
-              ),
-              Validator.required(
-                formData.tokenResetDuration,
-                "Token reset duration is required",
-              ),
-            ]
-          : []),
-
-        // Rate limit validation - request limits
-        ...(formData.requestMaxLimit !== undefined &&
-        formData.requestMaxLimit !== null
-          ? [
-              Validator.minValue(
-                requestMaxLimitNum || 0,
-                1,
-                "Request max limit must be at least 1",
-              ),
-              Validator.required(
-                formData.requestResetDuration,
-                "Request reset duration is required",
-              ),
-            ]
-          : []),
-      ]),
-    [formData, budgetMaxLimitNum, tokenMaxLimitNum, requestMaxLimitNum],
-  );
+      // Rate limit validation - request limits
+      ...(formData.requestMaxLimit !== undefined &&
+      formData.requestMaxLimit !== null
+        ? [
+            Validator.minValue(
+              requestMaxLimitNum || 0,
+              1,
+              "Request max limit must be at least 1",
+            ),
+            Validator.required(
+              formData.requestResetDuration,
+              "Request reset duration is required",
+            ),
+          ]
+        : []),
+    ]);
+  }, [formData, tokenMaxLimitNum, requestMaxLimitNum]);
 
   const updateField = <K extends keyof TeamFormData>(
     field: K,
@@ -245,27 +297,25 @@ export default function TeamDialog({
       return;
     }
 
+    // Serialize budget rows whose max_limit was filled in — rows left blank
+    // are silently dropped (the backend treats the slice as authoritative).
+    const submittableBudgets = formData.budgets
+      .filter((r) => r.maxLimit !== undefined && r.maxLimit !== null)
+      .map((r) => ({
+        max_limit: r.maxLimit as number,
+        reset_duration: r.resetDuration,
+        calendar_aligned: r.calendarAligned,
+      }));
+
     try {
       if (isEditing && team) {
         // Update existing team
         const updateData: UpdateTeamRequest = {
           name: formData.name,
           customer_id: formData.customerId || undefined,
+          // Always send: backend treats `budgets` as a full replacement.
+          budgets: submittableBudgets,
         };
-
-        // Detect budget changes using had/has pattern
-        const hadBudget = !!team.budget;
-        const hasBudget =
-          budgetMaxLimitNum !== undefined && budgetMaxLimitNum !== null;
-        if (hasBudget) {
-          updateData.budget = {
-            max_limit: budgetMaxLimitNum,
-            reset_duration: formData.budgetResetDuration,
-            calendar_aligned: formData.budgetCalendarAligned,
-          };
-        } else if (hadBudget) {
-          updateData.budget = {} as UpdateTeamRequest["budget"];
-        }
 
         // Detect rate limit changes using had/has pattern
         const hadRateLimit = !!team.rate_limit;
@@ -296,16 +346,9 @@ export default function TeamDialog({
         const createData: CreateTeamRequest = {
           name: formData.name,
           customer_id: formData.customerId || undefined,
+          budgets:
+            submittableBudgets.length > 0 ? submittableBudgets : undefined,
         };
-
-        // Add budget if enabled
-        if (budgetMaxLimitNum !== undefined && budgetMaxLimitNum !== null) {
-          createData.budget = {
-            max_limit: budgetMaxLimitNum,
-            reset_duration: formData.budgetResetDuration,
-            calendar_aligned: formData.budgetCalendarAligned,
-          };
-        }
 
         // Add rate limit if enabled (token or request limits)
         if (
@@ -411,56 +454,98 @@ export default function TeamDialog({
               )}
             </div>
 
-            {/* Budget Configuration */}
-            <NumberAndSelect
-              id="budgetMaxLimit"
-              label="Maximum Spend (USD)"
-              value={formData.budgetMaxLimit}
-              selectValue={formData.budgetResetDuration}
-              onChangeNumber={(value) => updateField("budgetMaxLimit", value)}
-              onChangeSelect={(value) => {
-                updateField("budgetResetDuration", value);
-                if (!supportsCalendarAlignment(value)) {
-                  updateField("budgetCalendarAligned", false);
-                }
-              }}
-              options={resetDurationOptions}
-              dataTestId="budget-max-limit-input"
-            />
-
-            {/* Calendar alignment toggle — only shown when a budget is set and the period supports alignment */}
-            {formData.budgetMaxLimit &&
-              supportsCalendarAlignment(formData.budgetResetDuration) && (
-                <div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
-                  <div className="space-y-0.5">
-                    <Label
-                      htmlFor="team-budget-calendar-aligned-toggle"
-                      className="text-sm font-normal"
-                    >
-                      Align to calendar cycle
-                    </Label>
-                    <p
-                      id="team-budget-calendar-aligned-description"
-                      className="text-muted-foreground text-xs"
-                    >
-                      Reset at the start of each period (e.g. 1st of month)
-                      instead of rolling from creation date
-                    </p>
-                  </div>
-                  <Switch
-                    id="team-budget-calendar-aligned-toggle"
-                    aria-describedby="team-budget-calendar-aligned-description"
-                    checked={formData.budgetCalendarAligned}
-                    onCheckedChange={handleCalendarAlignedChange}
-                    data-testid="team-budget-calendar-aligned-toggle"
-                  />
-                </div>
+            {/* Multi-budget configuration: one row per budget, each keyed by reset_duration */}
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <Label>Budgets</Label>
+                <button
+                  type="button"
+                  onClick={addBudgetRow}
+                  className="text-primary text-xs font-medium hover:underline"
+                  data-testid="team-add-budget-btn"
+                >
+                  + Add budget
+                </button>
+              </div>
+              {formData.budgets.length === 0 && (
+                <p className="text-muted-foreground text-xs">
+                  No budgets. Click "Add budget" to enforce a spend limit.
+                </p>
               )}
+              {formData.budgets.map((row, idx) => (
+                <div
+                  key={row.id}
+                  className="space-y-2 rounded-md border p-3"
+                  data-testid={`team-budget-row-${idx}`}
+                >
+                  <div className="flex items-start gap-2">
+                    <div className="flex-1">
+                      <NumberAndSelect
+                        id={`budgetMaxLimit-${idx}`}
+                        label={`Budget #${idx + 1} — Maximum Spend (USD)`}
+                        value={row.maxLimit}
+                        selectValue={row.resetDuration}
+                        onChangeNumber={(value) =>
+                          updateBudgetRow(idx, { maxLimit: value })
+                        }
+                        onChangeSelect={(value) => {
+                          const patch: Partial<TeamBudgetRow> = {
+                            resetDuration: value,
+                          };
+                          if (!supportsCalendarAlignment(value)) {
+                            patch.calendarAligned = false;
+                          }
+                          updateBudgetRow(idx, patch);
+                        }}
+                        options={resetDurationOptions}
+                        dataTestId={`budget-max-limit-input-${idx}`}
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => removeBudgetRow(idx)}
+                      className="text-muted-foreground hover:text-destructive mt-6 text-xs font-medium"
+                      data-testid={`team-remove-budget-btn-${idx}`}
+                    >
+                      Remove
+                    </button>
+                  </div>
+
+                  {row.maxLimit !== undefined &&
+                    supportsCalendarAlignment(row.resetDuration) && (
+                      <div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
+                        <div className="space-y-0.5">
+                          <Label
+                            htmlFor={`team-budget-calendar-aligned-toggle-${idx}`}
+                            className="text-sm font-normal"
+                          >
+                            Align to calendar cycle
+                          </Label>
+                          <p className="text-muted-foreground text-xs">
+                            Reset at the start of each period (e.g. 1st of
+                            month) instead of rolling from creation date
+                          </p>
+                        </div>
+                        <Switch
+                          id={`team-budget-calendar-aligned-toggle-${idx}`}
+                          checked={row.calendarAligned}
+                          onCheckedChange={(checked) =>
+                            handleCalendarAlignedChange(idx, checked)
+                          }
+                          data-testid={`team-budget-calendar-aligned-toggle-${idx}`}
+                        />
+                      </div>
+                    )}
+                </div>
+              ))}
+            </div>
 
             {/* Warning dialog shown when enabling calendar alignment on an existing budget */}
             <AlertDialog
               open={showCalendarAlignWarning}
-              onOpenChange={setShowCalendarAlignWarning}
+              onOpenChange={(open) => {
+                if (!open) setPendingCalendarAlignIdx(null);
+              }}
             >
               <AlertDialogContent>
                 <AlertDialogHeader>
@@ -470,13 +555,21 @@ export default function TeamDialog({
                     current usage to{" "}
                     <span className="font-semibold">$0.00</span> and snap the
                     reset date to the start of the current{" "}
-                    {formData.budgetResetDuration === "1d"
+                    {pendingCalendarAlignIdx !== null &&
+                    formData.budgets[pendingCalendarAlignIdx]?.resetDuration ===
+                      "1d"
                       ? "day"
-                      : formData.budgetResetDuration === "1w"
+                      : pendingCalendarAlignIdx !== null &&
+                          formData.budgets[pendingCalendarAlignIdx]
+                            ?.resetDuration === "1w"
                         ? "week"
-                        : formData.budgetResetDuration === "1M"
+                        : pendingCalendarAlignIdx !== null &&
+                            formData.budgets[pendingCalendarAlignIdx]
+                              ?.resetDuration === "1M"
                           ? "month"
-                          : formData.budgetResetDuration === "1Y"
+                          : pendingCalendarAlignIdx !== null &&
+                              formData.budgets[pendingCalendarAlignIdx]
+                                ?.resetDuration === "1Y"
                             ? "year"
                             : "period"}
                     . The usage reset to $0.00 cannot be undone, but calendar
@@ -485,14 +578,21 @@ export default function TeamDialog({
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
-                  <AlertDialogCancel data-testid="team-calendar-align-cancel-btn">
+                  <AlertDialogCancel
+                    data-testid="team-calendar-align-cancel-btn"
+                    onClick={() => setPendingCalendarAlignIdx(null)}
+                  >
                     Cancel
                   </AlertDialogCancel>
                   <AlertDialogAction
                     data-testid="team-calendar-align-enable-btn"
                     onClick={() => {
-                      updateField("budgetCalendarAligned", true);
-                      setShowCalendarAlignWarning(false);
+                      if (pendingCalendarAlignIdx !== null) {
+                        updateBudgetRow(pendingCalendarAlignIdx, {
+                          calendarAligned: true,
+                        });
+                      }
+                      setPendingCalendarAlignIdx(null);
                     }}
                   >
                     Enable Calendar Alignment
@@ -528,45 +628,44 @@ export default function TeamDialog({
             />
 
             {/* Current Usage Section (only shown when editing with existing limits) */}
-            {isEditing && (team?.budget || team?.rate_limit) && (
+            {isEditing &&
+              ((team?.budgets && team.budgets.length > 0) ||
+                team?.rate_limit) && (
               <div className="bg-muted/50 space-y-4 rounded-lg border p-4">
                 <p className="text-sm font-medium">Current Usage</p>
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                  {team?.budget && (
-                    <div className="space-y-1">
-                      <p className="text-muted-foreground text-xs">Budget</p>
+                  {team?.budgets?.map((b) => (
+                    <div key={b.id} className="space-y-1">
+                      <p className="text-muted-foreground text-xs">
+                        Budget ({b.reset_duration})
+                      </p>
                       <div className="flex items-center gap-2">
                         <span className="font-mono text-sm">
-                          {formatCurrency(team.budget.current_usage)} /{" "}
-                          {formatCurrency(team.budget.max_limit)}
+                          {formatCurrency(b.current_usage)} /{" "}
+                          {formatCurrency(b.max_limit)}
                         </span>
                         <Badge
                           variant={
-                            team.budget.max_limit > 0 &&
-                            team.budget.current_usage >= team.budget.max_limit
+                            b.max_limit > 0 && b.current_usage >= b.max_limit
                               ? "destructive"
                               : "default"
                           }
                           className="text-xs"
                         >
-                          {team.budget.max_limit > 0
-                            ? Math.round(
-                                (team.budget.current_usage /
-                                  team.budget.max_limit) *
-                                  100,
-                              )
+                          {b.max_limit > 0
+                            ? Math.round((b.current_usage / b.max_limit) * 100)
                             : 0}
                           %
                         </Badge>
                       </div>
                       <p className="text-muted-foreground text-xs">
                         Last Reset:{" "}
-                        {formatDistanceToNow(new Date(team.budget.last_reset), {
+                        {formatDistanceToNow(new Date(b.last_reset), {
                           addSuffix: true,
                         })}
                       </p>
                     </div>
-                  )}
+                  ))}
                   {team?.rate_limit?.token_max_limit && (
                     <div className="space-y-1">
                       <p className="text-muted-foreground text-xs">Tokens</p>

--- a/ui/app/workspace/governance/views/teamsTable.tsx
+++ b/ui/app/workspace/governance/views/teamsTable.tsx
@@ -173,13 +173,11 @@ export default function TeamsTable({
 										const vks = getVirtualKeysForTeam(team.id);
 										const customerName = getCustomerName(team.customer_id);
 
-										// Budget calculations
-										const isBudgetExhausted =
-											team.budget?.max_limit && team.budget.max_limit > 0 && team.budget.current_usage >= team.budget.max_limit;
-										const budgetPercentage =
-											team.budget?.max_limit && team.budget.max_limit > 0
-												? Math.min((team.budget.current_usage / team.budget.max_limit) * 100, 100)
-												: 0;
+										// Budget calculations — any of the team's budgets exhausted
+										const teamBudgets = team.budgets ?? [];
+										const isBudgetExhausted = teamBudgets.some(
+											(b) => b.max_limit > 0 && b.current_usage >= b.max_limit,
+										);
 
 										// Rate limit calculations
 										const isTokenLimitExhausted =
@@ -224,36 +222,47 @@ export default function TeamsTable({
 													</div>
 												</TableCell>
 												<TableCell className="min-w-[180px]">
-													{team.budget ? (
-														<Tooltip>
-															<TooltipTrigger asChild>
-																<div className="space-y-2">
-																	<div className="flex items-center justify-between gap-4">
-																		<span className="font-medium">{formatCurrency(team.budget.max_limit)}</span>
-																		<span className="text-muted-foreground text-xs">{formatResetDuration(team.budget.reset_duration)}</span>
-																	</div>
-																	<Progress
-																		value={budgetPercentage}
-																		className={cn(
-																			"bg-muted/70 dark:bg-muted/30 h-1.5",
-																			isBudgetExhausted
-																				? "[&>div]:bg-red-500/70"
-																				: budgetPercentage > 80
-																					? "[&>div]:bg-amber-500/70"
-																					: "[&>div]:bg-emerald-500/70",
-																		)}
-																	/>
-																</div>
-															</TooltipTrigger>
-															<TooltipContent>
-																<p className="font-medium">
-																	{formatCurrency(team.budget.current_usage)} / {formatCurrency(team.budget.max_limit)}
-																</p>
-																<p className="text-primary-foreground/80 text-xs">
-																	Resets {formatResetDuration(team.budget.reset_duration)}
-																</p>
-															</TooltipContent>
-														</Tooltip>
+													{teamBudgets.length > 0 ? (
+														<div className="space-y-2.5">
+															{teamBudgets.map((b) => {
+																const budgetPercentage =
+																	b.max_limit > 0 ? Math.min((b.current_usage / b.max_limit) * 100, 100) : 0;
+																const isExhausted = b.max_limit > 0 && b.current_usage >= b.max_limit;
+																return (
+																	<Tooltip key={b.id}>
+																		<TooltipTrigger asChild>
+																			<div className="space-y-1.5">
+																				<div className="flex items-center justify-between gap-4">
+																					<span className="font-medium">{formatCurrency(b.max_limit)}</span>
+																					<span className="text-muted-foreground text-xs">
+																						{formatResetDuration(b.reset_duration)}
+																					</span>
+																				</div>
+																				<Progress
+																					value={budgetPercentage}
+																					className={cn(
+																						"bg-muted/70 dark:bg-muted/30 h-1.5",
+																						isExhausted
+																							? "[&>div]:bg-red-500/70"
+																							: budgetPercentage > 80
+																								? "[&>div]:bg-amber-500/70"
+																								: "[&>div]:bg-emerald-500/70",
+																					)}
+																				/>
+																			</div>
+																		</TooltipTrigger>
+																		<TooltipContent>
+																			<p className="font-medium">
+																				{formatCurrency(b.current_usage)} / {formatCurrency(b.max_limit)}
+																			</p>
+																			<p className="text-primary-foreground/80 text-xs">
+																				Resets {formatResetDuration(b.reset_duration)}
+																			</p>
+																		</TooltipContent>
+																	</Tooltip>
+																);
+															})}
+														</div>
 													) : (
 														<span className="text-muted-foreground text-sm">-</span>
 													)}

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -1,70 +1,83 @@
 import {
-	ArrowUpRight,
-	BookUser,
-	Boxes,
-	BoxIcon,
-	BugIcon,
-	Building,
-	Building2,
-	ChartColumnBig,
-	ChevronsLeftRightEllipsis,
-	Construction,
-	DatabaseZap,
-	FlaskConical,
-	FolderGit,
-	Globe,
-	KeyRound,
-	Landmark,
-	LayoutGrid,
-	LogOut,
-	Logs,
-	Network,
-	PanelLeftClose,
-	Plug,
-	Puzzle,
-	ScrollText,
-	Search,
-	SearchCheck,
-	Settings,
-	Settings2Icon,
-	ShieldCheck,
-	ShieldUser,
-	Shuffle,
-	SlidersHorizontal,
-	Telescope,
-	ToolCase,
-	TrendingUp,
-	User,
-	UserRoundCheck,
-	Users,
-	Wallet,
-	WalletCards
+  ArrowUpRight,
+  BookUser,
+  Boxes,
+  BoxIcon,
+  BugIcon,
+  Building,
+  Building2,
+  ChartColumnBig,
+  ChevronsLeftRightEllipsis,
+  Construction,
+  DatabaseZap,
+  FlaskConical,
+  FolderGit,
+  Globe,
+  KeyRound,
+  Landmark,
+  LayoutGrid,
+  LogOut,
+  Logs,
+  Network,
+  PanelLeftClose,
+  Plug,
+  Puzzle,
+  ScrollText,
+  Search,
+  SearchCheck,
+  Settings,
+  Settings2Icon,
+  ShieldCheck,
+  ShieldUser,
+  Shuffle,
+  SlidersHorizontal,
+  Telescope,
+  ToolCase,
+  TrendingUp,
+  User,
+  UserRoundCheck,
+  Users,
+  Wallet,
+  WalletCards,
 } from "lucide-react";
 
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import {
-	Sidebar,
-	SidebarContent,
-	SidebarGroup,
-	SidebarGroupContent,
-	SidebarHeader,
-	SidebarMenu,
-	SidebarMenuButton,
-	SidebarMenuItem,
-	SidebarMenuSub,
-	SidebarMenuSubButton,
-	SidebarMenuSubItem,
-	useSidebar,
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import { useWebSocket } from "@/hooks/useWebSocket";
 import { IS_ENTERPRISE, TRIAL_EXPIRY } from "@/lib/constants/config";
-import { useGetCoreConfigQuery, useGetLatestReleaseQuery, useGetVersionQuery, useLogoutMutation } from "@/lib/store";
+import {
+  useGetCoreConfigQuery,
+  useGetLatestReleaseQuery,
+  useGetVersionQuery,
+  useLogoutMutation,
+} from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import type { UserInfo } from "@enterprise/lib/store/utils/tokenManager";
 import { getUserInfo } from "@enterprise/lib/store/utils/tokenManager";
-import { BooksIcon, DiscordLogoIcon, GithubLogoIcon } from "@phosphor-icons/react";
+import {
+  BooksIcon,
+  DiscordLogoIcon,
+  GithubLogoIcon,
+} from "@phosphor-icons/react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { differenceInDays } from "date-fns";
 import { ChevronRight } from "lucide-react";
@@ -80,1162 +93,1371 @@ const PRODUCTION_SETUP_DISMISSED_COOKIE = "bifrost_production_setup_dismissed";
 
 // Custom MCP Icon Component
 const MCPIcon = ({ className }: { className?: string }) => (
-	<svg
-		className={className}
-		fill="currentColor"
-		fillRule="evenodd"
-		height="1em"
-		style={{ flex: "none", lineHeight: 1 }}
-		viewBox="0 0 24 24"
-		width="1em"
-		xmlns="http://www.w3.org/2000/svg"
-		aria-label="MCP clients icon"
-	>
-		<title>MCP clients icon</title>
-		<path d="M15.688 2.343a2.588 2.588 0 00-3.61 0l-9.626 9.44a.863.863 0 01-1.203 0 .823.823 0 010-1.18l9.626-9.44a4.313 4.313 0 016.016 0 4.116 4.116 0 011.204 3.54 4.3 4.3 0 013.609 1.18l.05.05a4.115 4.115 0 010 5.9l-8.706 8.537a.274.274 0 000 .393l1.788 1.754a.823.823 0 010 1.18.863.863 0 01-1.203 0l-1.788-1.753a1.92 1.92 0 010-2.754l8.706-8.538a2.47 2.47 0 000-3.54l-.05-.049a2.588 2.588 0 00-3.607-.003l-7.172 7.034-.002.002-.098.097a.863.863 0 01-1.204 0 .823.823 0 010-1.18l7.273-7.133a2.47 2.47 0 00-.003-3.537z" />
-		<path d="M14.485 4.703a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a4.115 4.115 0 000 5.9 4.314 4.314 0 006.016 0l7.12-6.982a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a2.588 2.588 0 01-3.61 0 2.47 2.47 0 010-3.54l7.12-6.982z" />
-	</svg>
+  <svg
+    className={className}
+    fill="currentColor"
+    fillRule="evenodd"
+    height="1em"
+    style={{ flex: "none", lineHeight: 1 }}
+    viewBox="0 0 24 24"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-label="MCP clients icon"
+  >
+    <title>MCP clients icon</title>
+    <path d="M15.688 2.343a2.588 2.588 0 00-3.61 0l-9.626 9.44a.863.863 0 01-1.203 0 .823.823 0 010-1.18l9.626-9.44a4.313 4.313 0 016.016 0 4.116 4.116 0 011.204 3.54 4.3 4.3 0 013.609 1.18l.05.05a4.115 4.115 0 010 5.9l-8.706 8.537a.274.274 0 000 .393l1.788 1.754a.823.823 0 010 1.18.863.863 0 01-1.203 0l-1.788-1.753a1.92 1.92 0 010-2.754l8.706-8.538a2.47 2.47 0 000-3.54l-.05-.049a2.588 2.588 0 00-3.607-.003l-7.172 7.034-.002.002-.098.097a.863.863 0 01-1.204 0 .823.823 0 010-1.18l7.273-7.133a2.47 2.47 0 00-.003-3.537z" />
+    <path d="M14.485 4.703a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a4.115 4.115 0 000 5.9 4.314 4.314 0 006.016 0l7.12-6.982a.823.823 0 000-1.18.863.863 0 00-1.204 0l-7.119 6.982a2.588 2.588 0 01-3.61 0 2.47 2.47 0 010-3.54l7.12-6.982z" />
+  </svg>
 );
 
 // Main navigation items
 
 // External links
 const externalLinks = [
-	{
-		title: "Discord Server",
-		url: "https://discord.gg/exN5KAydbU",
-		icon: DiscordLogoIcon,
-	},
-	{
-		title: "GitHub Repository",
-		url: "https://github.com/maximhq/bifrost",
-		icon: GithubLogoIcon,
-	},
-	{
-		title: "Report a bug",
-		url: "https://github.com/maximhq/bifrost/issues/new?title=[Bug Report]&labels=bug&type=bug&projects=maximhq/1",
-		icon: BugIcon,
-		strokeWidth: 1.5,
-	},
-	{
-		title: "Full Documentation",
-		url: "https://docs.getbifrost.ai",
-		icon: BooksIcon,
-		strokeWidth: 1,
-	},
+  {
+    title: "Discord Server",
+    url: "https://discord.gg/exN5KAydbU",
+    icon: DiscordLogoIcon,
+  },
+  {
+    title: "GitHub Repository",
+    url: "https://github.com/maximhq/bifrost",
+    icon: GithubLogoIcon,
+  },
+  {
+    title: "Report a bug",
+    url: "https://github.com/maximhq/bifrost/issues/new?title=[Bug Report]&labels=bug&type=bug&projects=maximhq/1",
+    icon: BugIcon,
+    strokeWidth: 1.5,
+  },
+  {
+    title: "Full Documentation",
+    url: "https://docs.getbifrost.ai",
+    icon: BooksIcon,
+    strokeWidth: 1,
+  },
 ];
 
 // Base promotional card (memoized outside component to prevent recreation)
 const productionSetupHelpCard = {
-	id: "production-setup",
-	title: "Need help with production setup?",
-	description: (
-		<>
-			We offer help with production setup including custom integrations and dedicated support.
-			<br />
-			<br />
-			Book a demo with our team{" "}
-			<a
-				href="https://calendly.com/maximai/bifrost-demo?utm_source=bfd_sdbr"
-				target="_blank"
-				className="text-primary font-medium underline"
-				rel="noopener noreferrer"
-			>
-				here
-			</a>
-			.
-		</>
-	),
-	dismissible: true,
+  id: "production-setup",
+  title: "Need help with production setup?",
+  description: (
+    <>
+      We offer help with production setup including custom integrations and
+      dedicated support.
+      <br />
+      <br />
+      Book a demo with our team{" "}
+      <a
+        href="https://calendly.com/maximai/bifrost-demo?utm_source=bfd_sdbr"
+        target="_blank"
+        className="text-primary font-medium underline"
+        rel="noopener noreferrer"
+      >
+        here
+      </a>
+      .
+    </>
+  ),
+  dismissible: true,
 };
 
 // Sidebar item interface
 interface SidebarItem {
-	title: string;
-	url: string;
-	icon: React.ComponentType<{ className?: string }>;
-	description: string;
-	isAllowed?: boolean;
-	hasAccess: boolean;
-	subItems?: SidebarItem[];
-	tag?: string;
-	isExternal?: boolean;
-	queryParam?: string; // Optional: for tab-based subitems (e.g., "client-settings")
+  title: string;
+  url: string;
+  icon: React.ComponentType<{ className?: string }>;
+  description: string;
+  isAllowed?: boolean;
+  hasAccess: boolean;
+  subItems?: SidebarItem[];
+  tag?: string;
+  isExternal?: boolean;
+  queryParam?: string; // Optional: for tab-based subitems (e.g., "client-settings")
 }
 
 const getSidebarItemHref = (item: Pick<SidebarItem, "url" | "queryParam">) => {
-	return item.queryParam ? `${item.url}?tab=${item.queryParam}` : item.url;
+  return item.queryParam ? `${item.url}?tab=${item.queryParam}` : item.url;
 };
 
 const SidebarItemView = ({
-	item,
-	isActive,
-	isExternal,
-	isWebSocketConnected,
-	isExpanded,
-	onToggle,
-	pathname,
-	isSidebarCollapsed,
-	expandSidebar,
-	highlightedUrl,
+  item,
+  isActive,
+  isExternal,
+  isWebSocketConnected,
+  isExpanded,
+  onToggle,
+  pathname,
+  isSidebarCollapsed,
+  expandSidebar,
+  highlightedUrl,
 }: {
-	item: SidebarItem;
-	isActive: boolean;
-	isExternal?: boolean;
-	isWebSocketConnected: boolean;
-	isExpanded?: boolean;
-	onToggle?: () => void;
-	pathname: string;
-	isSidebarCollapsed: boolean;
-	expandSidebar: () => void;
-	highlightedUrl?: string;
+  item: SidebarItem;
+  isActive: boolean;
+  isExternal?: boolean;
+  isWebSocketConnected: boolean;
+  isExpanded?: boolean;
+  onToggle?: () => void;
+  pathname: string;
+  isSidebarCollapsed: boolean;
+  expandSidebar: () => void;
+  highlightedUrl?: string;
 }) => {
-	const hasSubItems = "subItems" in item && item.subItems && item.subItems.length > 0;
-	const isRouteMatch = (url: string) => {
-		if (url === "/workspace/custom-pricing") return pathname === url;
-		return pathname.startsWith(url);
-	};
-	const isAnySubItemActive =
-		hasSubItems &&
-		item.subItems?.some((subItem) => {
-			return isRouteMatch(subItem.url);
-		});
+  const hasSubItems =
+    "subItems" in item && item.subItems && item.subItems.length > 0;
+  const isRouteMatch = (url: string) => {
+    if (url === "/workspace/custom-pricing") return pathname === url;
+    return pathname.startsWith(url);
+  };
+  const isAnySubItemActive =
+    hasSubItems &&
+    item.subItems?.some((subItem) => {
+      return isRouteMatch(subItem.url);
+    });
 
-	const handleClick = (e: React.MouseEvent) => {
-		if (hasSubItems && item.hasAccess) {
-			e.preventDefault();
-			// If sidebar is collapsed, expand it first then toggle the submenu
-			if (isSidebarCollapsed) {
-				expandSidebar();
-				// Small delay to allow sidebar to expand before toggling submenu
-				setTimeout(() => {
-					if (onToggle) onToggle();
-				}, 100);
-			} else if (onToggle) {
-				onToggle();
-			}
-		}
-	};
+  const handleClick = (e: React.MouseEvent) => {
+    if (hasSubItems && item.hasAccess) {
+      e.preventDefault();
+      // If sidebar is collapsed, expand it first then toggle the submenu
+      if (isSidebarCollapsed) {
+        expandSidebar();
+        // Small delay to allow sidebar to expand before toggling submenu
+        setTimeout(() => {
+          if (onToggle) onToggle();
+        }, 100);
+      } else if (onToggle) {
+        onToggle();
+      }
+    }
+  };
 
-	const isHighlighted = !hasSubItems && highlightedUrl === item.url;
+  const isHighlighted = !hasSubItems && highlightedUrl === item.url;
 
-	const buttonClassName = `relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${
-		isHighlighted
-			? "bg-sidebar-accent text-accent-foreground border-primary/20"
-			: isActive || isAnySubItemActive
-				? "bg-sidebar-accent text-primary border-primary/20"
-				: item.hasAccess
-					? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
-					: "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-	} `;
+  const buttonClassName = `relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${
+    isHighlighted
+      ? "bg-sidebar-accent text-accent-foreground border-primary/20"
+      : isActive || isAnySubItemActive
+        ? "bg-sidebar-accent text-primary border-primary/20"
+        : item.hasAccess
+          ? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
+          : "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
+  } `;
 
-	const innerContent = (
-		<div className="flex w-full items-center justify-between">
-			<div className="flex w-full items-center gap-2">
-				<item.icon className={`h-4 w-4 shrink-0 ${isActive || isAnySubItemActive ? "text-primary" : "text-muted-foreground"}`} />
-				<span className={`text-sm group-data-[collapsible=icon]:hidden ${isActive || isAnySubItemActive ? "font-medium" : "font-normal"}`}>
-					{item.title}
-				</span>
-				{item.tag && (
-					<Badge variant="secondary" className="text-muted-foreground ml-auto text-xs group-data-[collapsible=icon]:hidden">
-						{item.tag}
-					</Badge>
-				)}
-			</div>
-			{hasSubItems && (
-				<ChevronRight
-					className={`h-4 w-4 transition-transform duration-200 group-data-[collapsible=icon]:hidden ${isExpanded ? "rotate-90" : ""}`}
-				/>
-			)}
-			{!hasSubItems && item.url === "/logs" && isWebSocketConnected && (
-				<div className="h-2 w-2 animate-pulse rounded-full bg-green-800 dark:bg-green-200" />
-			)}
-			{isExternal && <ArrowUpRight className="text-muted-foreground h-4 w-4 group-data-[collapsible=icon]:hidden" size={16} />}
-		</div>
-	);
+  const innerContent = (
+    <div className="flex w-full items-center justify-between">
+      <div className="flex w-full items-center gap-2">
+        <item.icon
+          className={`h-4 w-4 shrink-0 ${isActive || isAnySubItemActive ? "text-primary" : "text-muted-foreground"}`}
+        />
+        <span
+          className={`text-sm group-data-[collapsible=icon]:hidden ${isActive || isAnySubItemActive ? "font-medium" : "font-normal"}`}
+        >
+          {item.title}
+        </span>
+        {item.tag && (
+          <Badge
+            variant="secondary"
+            className="text-muted-foreground ml-auto text-xs group-data-[collapsible=icon]:hidden"
+          >
+            {item.tag}
+          </Badge>
+        )}
+      </div>
+      {hasSubItems && (
+        <ChevronRight
+          className={`h-4 w-4 transition-transform duration-200 group-data-[collapsible=icon]:hidden ${isExpanded ? "rotate-90" : ""}`}
+        />
+      )}
+      {!hasSubItems && item.url === "/logs" && isWebSocketConnected && (
+        <div className="h-2 w-2 animate-pulse rounded-full bg-green-800 dark:bg-green-200" />
+      )}
+      {isExternal && (
+        <ArrowUpRight
+          className="text-muted-foreground h-4 w-4 group-data-[collapsible=icon]:hidden"
+          size={16}
+        />
+      )}
+    </div>
+  );
 
-	// Render strategy:
-	//   - Items with sub-items: <button> (toggle, not navigation)
-	//   - Leaf items, no access: <button> (disabled-style, non-clickable)
-	//   - Leaf items, external:  <a target="_blank">
-	//   - Leaf items, internal:  TanStack <Link> with preload-on-hover
-	let menuButton: React.ReactNode;
-	if (hasSubItems) {
-		menuButton = (
-			<SidebarMenuButton tooltip={item.title} className={buttonClassName} onClick={handleClick}>
-				{innerContent}
-			</SidebarMenuButton>
-		);
-	} else if (!item.hasAccess) {
-		menuButton = (
-			<SidebarMenuButton tooltip={item.title} data-nav-url={item.url} className={buttonClassName}>
-				{innerContent}
-			</SidebarMenuButton>
-		);
-	} else if (isExternal) {
-		menuButton = (
-			<SidebarMenuButton asChild tooltip={item.title} className={buttonClassName}>
-				<a href={item.url} target="_blank" rel="noopener noreferrer" data-nav-url={item.url}>
-					{innerContent}
-				</a>
-			</SidebarMenuButton>
-		);
-	} else {
-		menuButton = (
-			<SidebarMenuButton asChild tooltip={item.title} className={buttonClassName}>
-				<Link to={item.url as any} preload="intent" data-nav-url={item.url}>
-					{innerContent}
-				</Link>
-			</SidebarMenuButton>
-		);
-	}
+  // Render strategy:
+  //   - Items with sub-items: <button> (toggle, not navigation)
+  //   - Leaf items, no access: <button> (disabled-style, non-clickable)
+  //   - Leaf items, external:  <a target="_blank">
+  //   - Leaf items, internal:  TanStack <Link> with preload-on-hover
+  let menuButton: React.ReactNode;
+  if (hasSubItems) {
+    menuButton = (
+      <SidebarMenuButton
+        tooltip={item.title}
+        className={buttonClassName}
+        onClick={handleClick}
+      >
+        {innerContent}
+      </SidebarMenuButton>
+    );
+  } else if (!item.hasAccess) {
+    menuButton = (
+      <SidebarMenuButton
+        tooltip={item.title}
+        data-nav-url={item.url}
+        className={buttonClassName}
+      >
+        {innerContent}
+      </SidebarMenuButton>
+    );
+  } else if (isExternal) {
+    menuButton = (
+      <SidebarMenuButton
+        asChild
+        tooltip={item.title}
+        className={buttonClassName}
+      >
+        <a
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-nav-url={item.url}
+        >
+          {innerContent}
+        </a>
+      </SidebarMenuButton>
+    );
+  } else {
+    menuButton = (
+      <SidebarMenuButton
+        asChild
+        tooltip={item.title}
+        className={buttonClassName}
+      >
+        <Link to={item.url as any} preload="intent" data-nav-url={item.url}>
+          {innerContent}
+        </Link>
+      </SidebarMenuButton>
+    );
+  }
 
-	return (
-		<SidebarMenuItem key={item.title}>
-			{menuButton}
-			{hasSubItems && isExpanded && (
-				<SidebarMenuSub className="border-sidebar-border mt-1 ml-4 space-y-0.5 border-l pl-2">
-					{item.subItems?.map((subItem: SidebarItem) => {
-						const subItemHref = getSidebarItemHref(subItem);
-						// For query param based subitems, check if tab matches
-						const isSubItemActive = subItem.queryParam ? pathname === subItem.url : isRouteMatch(subItem.url);
-						const isSubItemHighlighted = highlightedUrl === subItemHref;
-						const SubItemIcon = subItem.icon;
-						const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${
-							isSubItemHighlighted
-								? "bg-sidebar-accent text-accent-foreground"
-								: isSubItemActive
-									? "bg-sidebar-accent text-primary font-medium"
-									: subItem.hasAccess === false
-										? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-										: "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
-						}`;
-						const subInner = (
-							<div className="flex w-full items-center gap-2">
-								{SubItemIcon && <SubItemIcon className={`h-3.5 w-3.5 ${isSubItemActive ? "text-primary" : "text-muted-foreground"}`} />}
-								<span className={`text-sm ${isSubItemActive ? "font-medium" : "font-normal"}`}>{subItem.title}</span>
-								{subItem.tag && (
-									<Badge variant="secondary" className="text-muted-foreground ml-auto text-xs">
-										{subItem.tag}
-									</Badge>
-								)}
-							</div>
-						);
-						return (
-							<SidebarMenuSubItem key={subItem.title}>
-								{subItem.hasAccess === false ? (
-									<SidebarMenuSubButton data-nav-url={subItemHref} className={subItemClassName}>
-										{subInner}
-									</SidebarMenuSubButton>
-								) : (
-									<SidebarMenuSubButton asChild className={subItemClassName}>
-										<Link to={subItemHref as any} preload="intent" data-nav-url={subItemHref}>
-											{subInner}
-										</Link>
-									</SidebarMenuSubButton>
-								)}
-							</SidebarMenuSubItem>
-						);
-					})}
-				</SidebarMenuSub>
-			)}
-		</SidebarMenuItem>
-	);
+  return (
+    <SidebarMenuItem key={item.title}>
+      {menuButton}
+      {hasSubItems && isExpanded && (
+        <SidebarMenuSub className="border-sidebar-border mt-1 ml-4 space-y-0.5 border-l pl-2">
+          {item.subItems?.map((subItem: SidebarItem) => {
+            const subItemHref = getSidebarItemHref(subItem);
+            // For query param based subitems, check if tab matches
+            const isSubItemActive = subItem.queryParam
+              ? pathname === subItem.url
+              : isRouteMatch(subItem.url);
+            const isSubItemHighlighted = highlightedUrl === subItemHref;
+            const SubItemIcon = subItem.icon;
+            const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${
+              isSubItemHighlighted
+                ? "bg-sidebar-accent text-accent-foreground"
+                : isSubItemActive
+                  ? "bg-sidebar-accent text-primary font-medium"
+                  : subItem.hasAccess === false
+                    ? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
+                    : "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
+            }`;
+            const subInner = (
+              <div className="flex w-full items-center gap-2">
+                {SubItemIcon && (
+                  <SubItemIcon
+                    className={`h-3.5 w-3.5 ${isSubItemActive ? "text-primary" : "text-muted-foreground"}`}
+                  />
+                )}
+                <span
+                  className={`text-sm ${isSubItemActive ? "font-medium" : "font-normal"}`}
+                >
+                  {subItem.title}
+                </span>
+                {subItem.tag && (
+                  <Badge
+                    variant="secondary"
+                    className="text-muted-foreground ml-auto text-xs"
+                  >
+                    {subItem.tag}
+                  </Badge>
+                )}
+              </div>
+            );
+            return (
+              <SidebarMenuSubItem key={subItem.title}>
+                {subItem.hasAccess === false ? (
+                  <SidebarMenuSubButton
+                    data-nav-url={subItemHref}
+                    className={subItemClassName}
+                  >
+                    {subInner}
+                  </SidebarMenuSubButton>
+                ) : (
+                  <SidebarMenuSubButton asChild className={subItemClassName}>
+                    <Link
+                      to={subItemHref as any}
+                      preload="intent"
+                      data-nav-url={subItemHref}
+                    >
+                      {subInner}
+                    </Link>
+                  </SidebarMenuSubButton>
+                )}
+              </SidebarMenuSubItem>
+            );
+          })}
+        </SidebarMenuSub>
+      )}
+    </SidebarMenuItem>
+  );
 };
 
 // Helper function to compare semantic versions
 const compareVersions = (v1: string, v2: string): number => {
-	// Remove 'v' prefix if present
-	const cleanV1 = v1.startsWith("v") ? v1.slice(1) : v1;
-	const cleanV2 = v2.startsWith("v") ? v2.slice(1) : v2;
+  // Remove 'v' prefix if present
+  const cleanV1 = v1.startsWith("v") ? v1.slice(1) : v1;
+  const cleanV2 = v2.startsWith("v") ? v2.slice(1) : v2;
 
-	// Split into main version and prerelease
-	const [mainV1, prereleaseV1] = cleanV1.split("-");
-	const [mainV2, prereleaseV2] = cleanV2.split("-");
+  // Split into main version and prerelease
+  const [mainV1, prereleaseV1] = cleanV1.split("-");
+  const [mainV2, prereleaseV2] = cleanV2.split("-");
 
-	// Compare main version numbers (major.minor.patch)
-	const partsV1 = mainV1.split(".").map(Number);
-	const partsV2 = mainV2.split(".").map(Number);
+  // Compare main version numbers (major.minor.patch)
+  const partsV1 = mainV1.split(".").map(Number);
+  const partsV2 = mainV2.split(".").map(Number);
 
-	for (let i = 0; i < Math.max(partsV1.length, partsV2.length); i++) {
-		const num1 = partsV1[i] || 0;
-		const num2 = partsV2[i] || 0;
+  for (let i = 0; i < Math.max(partsV1.length, partsV2.length); i++) {
+    const num1 = partsV1[i] || 0;
+    const num2 = partsV2[i] || 0;
 
-		if (num1 > num2) return 1;
-		if (num1 < num2) return -1;
-	}
+    if (num1 > num2) return 1;
+    if (num1 < num2) return -1;
+  }
 
-	// If main versions are equal, check prerelease
-	// Version without prerelease is higher than version with prerelease
-	if (!prereleaseV1 && prereleaseV2) return 1;
-	if (prereleaseV1 && !prereleaseV2) return -1;
+  // If main versions are equal, check prerelease
+  // Version without prerelease is higher than version with prerelease
+  if (!prereleaseV1 && prereleaseV2) return 1;
+  if (prereleaseV1 && !prereleaseV2) return -1;
 
-	// Both have prereleases, compare them
-	if (prereleaseV1 && prereleaseV2) {
-		// Extract prerelease number (e.g., "prerelease1" -> 1)
-		const prereleaseNum1 = parseInt(prereleaseV1.replace(/\D/g, "")) || 0;
-		const prereleaseNum2 = parseInt(prereleaseV2.replace(/\D/g, "")) || 0;
+  // Both have prereleases, compare them
+  if (prereleaseV1 && prereleaseV2) {
+    // Extract prerelease number (e.g., "prerelease1" -> 1)
+    const prereleaseNum1 = parseInt(prereleaseV1.replace(/\D/g, "")) || 0;
+    const prereleaseNum2 = parseInt(prereleaseV2.replace(/\D/g, "")) || 0;
 
-		if (prereleaseNum1 > prereleaseNum2) return 1;
-		if (prereleaseNum1 < prereleaseNum2) return -1;
-	}
+    if (prereleaseNum1 > prereleaseNum2) return 1;
+    if (prereleaseNum1 < prereleaseNum2) return -1;
+  }
 
-	return 0;
+  return 0;
 };
 
 export default function AppSidebar() {
-	const pathname = useLocation({ select: (l) => l.pathname });
-	const tsNavigate = useNavigate();
-	// Wrapper that accepts arbitrary string URLs (TanStack Router's `to` is
-	// strictly typed, but our sidebar items come from a runtime config).
-	const navigate = useCallback((url: string) => tsNavigate({ to: url as any }), [tsNavigate]);
-	const [mounted, setMounted] = useState(false);
-	const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
-	const [areCardsEmpty, setAreCardsEmpty] = useState(false);
-	const [userPopoverOpen, setUserPopoverOpen] = useState(false);
-	const [searchQuery, setSearchQuery] = useState("");
-	const [focusedIndex, setFocusedIndex] = useState(-1);
-	const searchInputRef = useRef<HTMLInputElement>(null);
-	const [cookies, setCookie] = useCookies([PRODUCTION_SETUP_DISMISSED_COOKIE]);
-	const isProductionSetupDismissed = !!cookies[PRODUCTION_SETUP_DISMISSED_COOKIE];
-	const { data: latestRelease } = useGetLatestReleaseQuery(undefined, {
-		skip: !mounted, // Only fetch after component is mounted
-	});
-	const hasLogsAccess = useRbac(RbacResource.Logs, RbacOperation.View);
-	const hasObservabilityAccess = useRbac(RbacResource.Observability, RbacOperation.View);
-	const hasModelProvidersAccess = useRbac(RbacResource.ModelProvider, RbacOperation.View);
-	const hasMCPGatewayAccess = useRbac(RbacResource.MCPGateway, RbacOperation.View);
-	const hasPluginsAccess = useRbac(RbacResource.Plugins, RbacOperation.View);
-	const hasUsersAccess = useRbac(RbacResource.Users, RbacOperation.View);
-	const hasUserProvisioningAccess = useRbac(RbacResource.UserProvisioning, RbacOperation.View);
-	const hasAuditLogsAccess = useRbac(RbacResource.AuditLogs, RbacOperation.View);
-	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
-	const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
-	const hasBusinessUnitsAccess = useRbac(RbacResource.Governance, RbacOperation.View);
-	const hasRbacAccess = useRbac(RbacResource.RBAC, RbacOperation.View);
-	const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
-	const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
-	const hasRoutingRulesAccess = useRbac(RbacResource.RoutingRules, RbacOperation.View);
-	const hasGuardrailsProvidersAccess = useRbac(RbacResource.GuardrailsProviders, RbacOperation.View);
-	const hasGuardrailsConfigAccess = useRbac(RbacResource.GuardrailsConfig, RbacOperation.View);
-	const hasClusterConfigAccess = useRbac(RbacResource.Cluster, RbacOperation.View);
-	const isAdaptiveRoutingAllowed = useRbac(RbacResource.AdaptiveRouter, RbacOperation.View);
-	const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.View);
-	const hasPromptRepositoryAccess = useRbac(RbacResource.PromptRepository, RbacOperation.View);
-	const hasPromptDeploymentStrategyAccess = useRbac(RbacResource.PromptDeploymentStrategy, RbacOperation.View);
-	const hasAccessProfilesAccess = useRbac(RbacResource.AccessProfiles, RbacOperation.View);
-	const { data: coreConfig } = useGetCoreConfigQuery({});
-	const isDbConnected = coreConfig?.is_db_connected ?? false;
+  const pathname = useLocation({ select: (l) => l.pathname });
+  const tsNavigate = useNavigate();
+  // Wrapper that accepts arbitrary string URLs (TanStack Router's `to` is
+  // strictly typed, but our sidebar items come from a runtime config).
+  const navigate = useCallback(
+    (url: string) => tsNavigate({ to: url as any }),
+    [tsNavigate],
+  );
+  const [mounted, setMounted] = useState(false);
+  const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
+  const [areCardsEmpty, setAreCardsEmpty] = useState(false);
+  const [userPopoverOpen, setUserPopoverOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [focusedIndex, setFocusedIndex] = useState(-1);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const [cookies, setCookie] = useCookies([PRODUCTION_SETUP_DISMISSED_COOKIE]);
+  const isProductionSetupDismissed =
+    !!cookies[PRODUCTION_SETUP_DISMISSED_COOKIE];
+  const { data: latestRelease } = useGetLatestReleaseQuery(undefined, {
+    skip: !mounted, // Only fetch after component is mounted
+  });
+  const hasLogsAccess = useRbac(RbacResource.Logs, RbacOperation.View);
+  const hasObservabilityAccess = useRbac(
+    RbacResource.Observability,
+    RbacOperation.View,
+  );
+  const hasModelProvidersAccess = useRbac(
+    RbacResource.ModelProvider,
+    RbacOperation.View,
+  );
+  const hasMCPGatewayAccess = useRbac(
+    RbacResource.MCPGateway,
+    RbacOperation.View,
+  );
+  const hasPluginsAccess = useRbac(RbacResource.Plugins, RbacOperation.View);
+  const hasUsersAccess = useRbac(RbacResource.Users, RbacOperation.View);
+  const hasUserProvisioningAccess = useRbac(
+    RbacResource.UserProvisioning,
+    RbacOperation.View,
+  );
+  const hasAuditLogsAccess = useRbac(
+    RbacResource.AuditLogs,
+    RbacOperation.View,
+  );
+  const hasCustomersAccess = useRbac(
+    RbacResource.Customers,
+    RbacOperation.View,
+  );
+  const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
+  const hasBusinessUnitsAccess = useRbac(
+    RbacResource.Governance,
+    RbacOperation.View,
+  );
+  const hasRbacAccess = useRbac(RbacResource.RBAC, RbacOperation.View);
+  const hasVirtualKeysAccess = useRbac(
+    RbacResource.VirtualKeys,
+    RbacOperation.View,
+  );
+  const hasGovernanceAccess = useRbac(
+    RbacResource.Governance,
+    RbacOperation.View,
+  );
+  const hasRoutingRulesAccess = useRbac(
+    RbacResource.RoutingRules,
+    RbacOperation.View,
+  );
+  const hasGuardrailsProvidersAccess = useRbac(
+    RbacResource.GuardrailsProviders,
+    RbacOperation.View,
+  );
+  const hasGuardrailsConfigAccess = useRbac(
+    RbacResource.GuardrailsConfig,
+    RbacOperation.View,
+  );
+  const hasClusterConfigAccess = useRbac(
+    RbacResource.Cluster,
+    RbacOperation.View,
+  );
+  const isAdaptiveRoutingAllowed = useRbac(
+    RbacResource.AdaptiveRouter,
+    RbacOperation.View,
+  );
+  const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.View);
+  const hasPromptRepositoryAccess = useRbac(
+    RbacResource.PromptRepository,
+    RbacOperation.View,
+  );
+  const hasPromptDeploymentStrategyAccess = useRbac(
+    RbacResource.PromptDeploymentStrategy,
+    RbacOperation.View,
+  );
+  const hasAccessProfilesAccess = useRbac(
+    RbacResource.AccessProfiles,
+    RbacOperation.View,
+  );
+  const { data: coreConfig } = useGetCoreConfigQuery({});
+  const isDbConnected = coreConfig?.is_db_connected ?? false;
 
-	const items = useMemo(
-		() => [
-			{
-				title: "Observability",
-				url: "/workspace/logs",
-				icon: Telescope,
-				description: "Request logs & monitoring",
-				hasAccess: hasLogsAccess,
-				subItems: [
-					{
-						title: "Dashboard",
-						url: "/workspace/dashboard",
-						icon: ChartColumnBig,
-						description: "Dashboard",
-						hasAccess: hasObservabilityAccess,
-					},
-					{
-						title: "LLM Logs",
-						url: "/workspace/logs",
-						icon: Logs,
-						description: "LLM request logs & monitoring",
-						hasAccess: hasLogsAccess,
-					},
-					{
-						title: "MCP Logs",
-						url: "/workspace/mcp-logs",
-						icon: MCPIcon,
-						description: "MCP tool execution logs",
-						hasAccess: hasLogsAccess,
-					},
-					{
-						title: "Connectors",
-						url: "/workspace/observability",
-						icon: ChevronsLeftRightEllipsis,
-						description: "Log connectors",
-						hasAccess: hasObservabilityAccess,
-					},
-					{
-						title: "Logs Settings",
-						url: "/workspace/config/logging",
-						icon: Settings,
-						description: "Logs configuration",
-						hasAccess: hasSettingsAccess,
-					},
-				],
-			},
-			{
-				title: "Models",
-				url: "/workspace/providers",
-				icon: BoxIcon,
-				description: "Configure models",
-				hasAccess: true,
-				subItems: [
-					{
-						title: "Model Catalog",
-						url: "/workspace/model-catalog",
-						icon: LayoutGrid,
-						description: "Overview of providers, keys, and usage",
-						hasAccess: hasModelProvidersAccess,
-					},
-					{
-						title: "Model Providers",
-						url: "/workspace/providers",
-						icon: Boxes,
-						description: "Configure models",
-						hasAccess: hasModelProvidersAccess,
-					},
-					{
-						title: "Budgets & Limits",
-						url: "/workspace/model-limits",
-						icon: Wallet,
-						description: "Model limits",
-						hasAccess: hasGovernanceAccess,
-					},
-					{
-						title: "Routing Rules",
-						url: "/workspace/routing-rules",
-						icon: Network,
-						description: "Intelligent routing rules",
-						hasAccess: hasRoutingRulesAccess,
-					},
-					{
-						title: "Pricing Overrides",
-						url: "/workspace/custom-pricing/overrides",
-						icon: SlidersHorizontal,
-						description: "Scoped pricing overrides",
-						hasAccess: hasSettingsAccess,
-					},
-					{
-						title: "Model Settings",
-						url: "/workspace/custom-pricing",
-						icon: Settings,
-						description: "Model and routing configuration",
-						hasAccess: hasSettingsAccess,
-					},
-				],
-			},
-			{
-				title: "MCP Gateway",
-				icon: MCPIcon,
-				description: "MCP configuration",
-				url: "/workspace/mcp-gateway",
-				hasAccess: hasMCPGatewayAccess,
-				subItems: [
-					{
-						title: "MCP Catalog",
-						url: "/workspace/mcp-registry",
-						icon: LayoutGrid,
-						description: "MCP tool catalog",
-						hasAccess: hasMCPGatewayAccess,
-					},
-					{
-						title: "Tool Groups",
-						url: "/workspace/mcp-tool-groups",
-						icon: ToolCase,
-						description: "Tool Groups",
-						hasAccess: hasMCPGatewayAccess,
-					},
-					{
-						title: "Auth Config",
-						url: "/workspace/mcp-auth-config",
-						icon: ShieldUser,
-						description: "MCP auth config",
-						hasAccess: hasMCPGatewayAccess,
-					},
-					{
-						title: "MCP Settings",
-						url: "/workspace/mcp-settings",
-						icon: Settings,
-						description: "MCP configuration",
-						hasAccess: hasMCPGatewayAccess,
-					},
-				],
-			},
-			{
-				title: "Plugins",
-				url: "/workspace/plugins",
-				icon: Puzzle,
-				description: "Manage custom plugins",
-				hasAccess: hasPluginsAccess,
-			},
-			{
-				title: "Governance",
-				url: "/workspace/governance",
-				icon: Landmark,
-				description: "Virtual keys, users, teams, customers & roles",
-				hasAccess: hasGovernanceAccess,
-				subItems: [
-					{
-						title: "Virtual Keys",
-						url: "/workspace/governance/virtual-keys",
-						icon: KeyRound,
-						description: "Manage virtual keys & access",
-						hasAccess: hasVirtualKeysAccess,
-					},
-					{
-						title: "Users",
-						url: "/workspace/governance/users",
-						icon: Users,
-						description: "Manage users",
-						hasAccess: hasUsersAccess,
-					},
-					{
-						title: "Teams",
-						url: "/workspace/governance/teams",
-						icon: Building,
-						description: "Manage teams",
-						hasAccess: hasTeamsAccess,
-					},
-					{
-						title: "Business Units",
-						url: "/workspace/governance/business-units",
-						icon: Building2,
-						description: "Manage business units",
-						hasAccess: hasBusinessUnitsAccess,
-					},
-					{
-						title: "Customers",
-						url: "/workspace/governance/customers",
-						icon: WalletCards,
-						description: "Manage customers",
-						hasAccess: hasCustomersAccess,
-					},
-					{
-						title: "User Provisioning",
-						url: "/workspace/scim",
-						icon: BookUser,
-						description: "User management and provisioning",
-						hasAccess: hasUserProvisioningAccess,
-					},
-					{
-						title: "Roles & Permissions",
-						url: "/workspace/governance/rbac",
-						icon: UserRoundCheck,
-						description: "User roles and permissions",
-						hasAccess: hasRbacAccess,
-					},
-					{
-						title: "Access Profiles",
-						url: "/workspace/governance/access-profiles",
-						icon: ShieldCheck,
-						description: "Manage access profiles for roles",
-						hasAccess: hasAccessProfilesAccess,
-					},
-					{
-						title: "Audit Logs",
-						url: "/workspace/audit-logs",
-						icon: ScrollText,
-						description: "Audit logs and compliance",
-						hasAccess: hasAuditLogsAccess,
-					},
-				],
-			},
-			{
-				title: "Guardrails",
-				url: "/workspace/guardrails",
-				icon: Construction,
-				description: "Guardrails configuration",
-				hasAccess: hasGuardrailsConfigAccess || hasGuardrailsProvidersAccess,
-				subItems: [
-					{
-						title: "Rules",
-						url: "/workspace/guardrails/configuration",
-						icon: SearchCheck,
-						description: "Guardrail rules",
-						hasAccess: hasGuardrailsConfigAccess,
-					},
-					{
-						title: "Providers",
-						url: "/workspace/guardrails/providers",
-						icon: Boxes,
-						description: "Guardrail providers configuration",
-						hasAccess: hasGuardrailsProvidersAccess,
-					},
-				],
-			},
-			{
-				title: "Cluster Config",
-				url: "/workspace/cluster",
-				icon: Network,
-				description: "Manage Bifrost cluster",
-				hasAccess: hasClusterConfigAccess,
-			},
-			{
-				title: "Adaptive Routing",
-				url: "/workspace/adaptive-routing",
-				icon: Shuffle,
-				description: "Manage adaptive load balancer",
-				hasAccess: isAdaptiveRoutingAllowed,
-			},
-			...(isDbConnected
-				? [
-						{
-							title: "Prompt Repository",
-							url: "/workspace/prompt-repo",
-							icon: FolderGit,
-							description: "Prompt repository",
-							hasAccess: hasPromptRepositoryAccess,
-							tag: "Beta",
-						},
-					]
-				: []),
-			{
-				title: "Evals",
-				url: "https://www.getmaxim.ai",
-				icon: FlaskConical,
-				isExternal: true,
-				description: "Evaluations",
-				hasAccess: true,
-			},
-			{
-				title: "Settings",
-				url: "/workspace/config",
-				icon: Settings2Icon,
-				description: "Bifrost settings",
-				hasAccess: hasSettingsAccess || hasAuditLogsAccess || hasUserProvisioningAccess,
-				subItems: [
-					{
-						title: "Client Settings",
-						url: "/workspace/config/client-settings",
-						icon: Settings,
-						description: "Client configuration settings",
-						hasAccess: hasSettingsAccess,
-					},
-					{
-						title: "Compatibility",
-						url: "/workspace/config/compatibility",
-						icon: Plug,
-						description: "Compatibility conversion settings",
-						hasAccess: hasSettingsAccess,
-					},
-					{
-						title: "Caching",
-						url: "/workspace/config/caching",
-						icon: DatabaseZap,
-						description: "Caching configuration",
-						hasAccess: hasSettingsAccess,
-					},
-					{
-						title: "Security",
-						url: "/workspace/config/security",
-						icon: ShieldCheck,
-						description: "Security settings",
-						hasAccess: hasSettingsAccess,
-					},
-					...(IS_ENTERPRISE
-						? [
-								{
-									title: "Proxy",
-									url: "/workspace/config/proxy",
-									icon: Globe,
-									description: "Proxy configuration",
-									hasAccess: hasSettingsAccess,
-								},
-							]
-						: []),
-					{
-						title: "API Keys",
-						url: "/workspace/config/api-keys",
-						icon: KeyRound,
-						description: "API keys management",
-						hasAccess: hasSettingsAccess,
-					},
-					{
-						title: "Performance Tuning",
-						url: "/workspace/config/performance-tuning",
-						icon: TrendingUp,
-						description: "Performance tuning settings",
-						hasAccess: hasSettingsAccess,
-					},
-				],
-			},
-		],
-		[
-			hasLogsAccess,
-			hasObservabilityAccess,
-			hasModelProvidersAccess,
-			hasMCPGatewayAccess,
-			hasPluginsAccess,
-			hasUsersAccess,
-			hasUserProvisioningAccess,
-			hasAuditLogsAccess,
-			hasCustomersAccess,
-			hasTeamsAccess,
-			hasBusinessUnitsAccess,
-			hasRbacAccess,
-			hasVirtualKeysAccess,
-			hasGovernanceAccess,
-			hasRoutingRulesAccess,
-			hasGuardrailsProvidersAccess,
-			hasGuardrailsConfigAccess,
-			hasClusterConfigAccess,
-			isAdaptiveRoutingAllowed,
-			hasSettingsAccess,
-			hasPromptRepositoryAccess,
-			hasPromptDeploymentStrategyAccess,
-			hasAccessProfilesAccess,
-			isDbConnected,
-		],
-	);
+  const items = useMemo(
+    () => [
+      {
+        title: "Observability",
+        url: "/workspace/logs",
+        icon: Telescope,
+        description: "Request logs & monitoring",
+        hasAccess: hasLogsAccess,
+        subItems: [
+          {
+            title: "Dashboard",
+            url: "/workspace/dashboard",
+            icon: ChartColumnBig,
+            description: "Dashboard",
+            hasAccess: hasObservabilityAccess,
+          },
+          {
+            title: "LLM Logs",
+            url: "/workspace/logs",
+            icon: Logs,
+            description: "LLM request logs & monitoring",
+            hasAccess: hasLogsAccess,
+          },
+          {
+            title: "MCP Logs",
+            url: "/workspace/mcp-logs",
+            icon: MCPIcon,
+            description: "MCP tool execution logs",
+            hasAccess: hasLogsAccess,
+          },
+          {
+            title: "Connectors",
+            url: "/workspace/observability",
+            icon: ChevronsLeftRightEllipsis,
+            description: "Log connectors",
+            hasAccess: hasObservabilityAccess,
+          },
+          {
+            title: "Logs Settings",
+            url: "/workspace/config/logging",
+            icon: Settings,
+            description: "Logs configuration",
+            hasAccess: hasSettingsAccess,
+          },
+        ],
+      },
+      {
+        title: "Models",
+        url: "/workspace/providers",
+        icon: BoxIcon,
+        description: "Configure models",
+        hasAccess: true,
+        subItems: [
+          {
+            title: "Model Catalog",
+            url: "/workspace/model-catalog",
+            icon: LayoutGrid,
+            description: "Overview of providers, keys, and usage",
+            hasAccess: hasModelProvidersAccess,
+          },
+          {
+            title: "Model Providers",
+            url: "/workspace/providers",
+            icon: Boxes,
+            description: "Configure models",
+            hasAccess: hasModelProvidersAccess,
+          },
+          {
+            title: "Budgets & Limits",
+            url: "/workspace/model-limits",
+            icon: Wallet,
+            description: "Model limits",
+            hasAccess: hasGovernanceAccess,
+          },
+          {
+            title: "Routing Rules",
+            url: "/workspace/routing-rules",
+            icon: Network,
+            description: "Intelligent routing rules",
+            hasAccess: hasRoutingRulesAccess,
+          },
+          {
+            title: "Pricing Overrides",
+            url: "/workspace/custom-pricing/overrides",
+            icon: SlidersHorizontal,
+            description: "Scoped pricing overrides",
+            hasAccess: hasSettingsAccess,
+          },
+          {
+            title: "Model Settings",
+            url: "/workspace/custom-pricing",
+            icon: Settings,
+            description: "Model and routing configuration",
+            hasAccess: hasSettingsAccess,
+          },
+        ],
+      },
+      {
+        title: "MCP Gateway",
+        icon: MCPIcon,
+        description: "MCP configuration",
+        url: "/workspace/mcp-gateway",
+        hasAccess: hasMCPGatewayAccess,
+        subItems: [
+          {
+            title: "MCP Catalog",
+            url: "/workspace/mcp-registry",
+            icon: LayoutGrid,
+            description: "MCP tool catalog",
+            hasAccess: hasMCPGatewayAccess,
+          },
+          {
+            title: "Tool Groups",
+            url: "/workspace/mcp-tool-groups",
+            icon: ToolCase,
+            description: "Tool Groups",
+            hasAccess: hasMCPGatewayAccess,
+          },
+          {
+            title: "Auth Config",
+            url: "/workspace/mcp-auth-config",
+            icon: ShieldUser,
+            description: "MCP auth config",
+            hasAccess: hasMCPGatewayAccess,
+          },
+          {
+            title: "MCP Settings",
+            url: "/workspace/mcp-settings",
+            icon: Settings,
+            description: "MCP configuration",
+            hasAccess: hasMCPGatewayAccess,
+          },
+        ],
+      },
+      {
+        title: "Plugins",
+        url: "/workspace/plugins",
+        icon: Puzzle,
+        description: "Manage custom plugins",
+        hasAccess: hasPluginsAccess,
+      },
+      {
+        title: "Governance",
+        url: "/workspace/governance",
+        icon: Landmark,
+        description: "Virtual keys, users, teams, customers & roles",
+        hasAccess: hasGovernanceAccess,
+        subItems: [
+          {
+            title: "Virtual Keys",
+            url: "/workspace/governance/virtual-keys",
+            icon: KeyRound,
+            description: "Manage virtual keys & access",
+            hasAccess: hasVirtualKeysAccess,
+          },
+          {
+            title: "Users",
+            url: "/workspace/governance/users",
+            icon: Users,
+            description: "Manage users",
+            hasAccess: hasUsersAccess,
+          },
+          {
+            title: "Teams",
+            url: "/workspace/governance/teams",
+            icon: Building,
+            description: "Manage teams",
+            hasAccess: hasTeamsAccess,
+          },
+          {
+            title: "Business Units",
+            url: "/workspace/governance/business-units",
+            icon: Building2,
+            description: "Manage business units",
+            hasAccess: hasBusinessUnitsAccess,
+          },
+          {
+            title: "Customers",
+            url: "/workspace/governance/customers",
+            icon: WalletCards,
+            description: "Manage customers",
+            hasAccess: hasCustomersAccess,
+          },
+          {
+            title: "User Provisioning",
+            url: "/workspace/scim",
+            icon: BookUser,
+            description: "User management and provisioning",
+            hasAccess: hasUserProvisioningAccess,
+          },
+          {
+            title: "Roles & Permissions",
+            url: "/workspace/governance/rbac",
+            icon: UserRoundCheck,
+            description: "User roles and permissions",
+            hasAccess: hasRbacAccess,
+          },
+          {
+            title: "Access Profiles",
+            url: "/workspace/governance/access-profiles",
+            icon: ShieldCheck,
+            description: "Manage access profiles for roles",
+            hasAccess: hasAccessProfilesAccess,
+          },
+          {
+            title: "Audit Logs",
+            url: "/workspace/audit-logs",
+            icon: ScrollText,
+            description: "Audit logs and compliance",
+            hasAccess: hasAuditLogsAccess,
+          },
+        ],
+      },
+      {
+        title: "Guardrails",
+        url: "/workspace/guardrails",
+        icon: Construction,
+        description: "Guardrails configuration",
+        hasAccess: hasGuardrailsConfigAccess || hasGuardrailsProvidersAccess,
+        subItems: [
+          {
+            title: "Rules",
+            url: "/workspace/guardrails/configuration",
+            icon: SearchCheck,
+            description: "Guardrail rules",
+            hasAccess: hasGuardrailsConfigAccess,
+          },
+          {
+            title: "Providers",
+            url: "/workspace/guardrails/providers",
+            icon: Boxes,
+            description: "Guardrail providers configuration",
+            hasAccess: hasGuardrailsProvidersAccess,
+          },
+        ],
+      },
+      {
+        title: "Cluster Config",
+        url: "/workspace/cluster",
+        icon: Network,
+        description: "Manage Bifrost cluster",
+        hasAccess: hasClusterConfigAccess,
+      },
+      {
+        title: "Adaptive Routing",
+        url: "/workspace/adaptive-routing",
+        icon: Shuffle,
+        description: "Manage adaptive load balancer",
+        hasAccess: isAdaptiveRoutingAllowed,
+      },
+      ...(isDbConnected
+        ? [
+            {
+              title: "Prompt Repository",
+              url: "/workspace/prompt-repo",
+              icon: FolderGit,
+              description: "Prompt repository",
+              hasAccess: hasPromptRepositoryAccess,
+            },
+          ]
+        : []),
+      {
+        title: "Evals",
+        url: "https://www.getmaxim.ai",
+        icon: FlaskConical,
+        isExternal: true,
+        description: "Evaluations",
+        hasAccess: true,
+      },
+      {
+        title: "Settings",
+        url: "/workspace/config",
+        icon: Settings2Icon,
+        description: "Bifrost settings",
+        hasAccess:
+          hasSettingsAccess || hasAuditLogsAccess || hasUserProvisioningAccess,
+        subItems: [
+          {
+            title: "Client Settings",
+            url: "/workspace/config/client-settings",
+            icon: Settings,
+            description: "Client configuration settings",
+            hasAccess: hasSettingsAccess,
+          },
+          {
+            title: "Compatibility",
+            url: "/workspace/config/compatibility",
+            icon: Plug,
+            description: "Compatibility conversion settings",
+            hasAccess: hasSettingsAccess,
+          },
+          {
+            title: "Caching",
+            url: "/workspace/config/caching",
+            icon: DatabaseZap,
+            description: "Caching configuration",
+            hasAccess: hasSettingsAccess,
+          },
+          {
+            title: "Security",
+            url: "/workspace/config/security",
+            icon: ShieldCheck,
+            description: "Security settings",
+            hasAccess: hasSettingsAccess,
+          },
+          ...(IS_ENTERPRISE
+            ? [
+                {
+                  title: "Proxy",
+                  url: "/workspace/config/proxy",
+                  icon: Globe,
+                  description: "Proxy configuration",
+                  hasAccess: hasSettingsAccess,
+                },
+              ]
+            : []),
+          {
+            title: "API Keys",
+            url: "/workspace/config/api-keys",
+            icon: KeyRound,
+            description: "API keys management",
+            hasAccess: hasSettingsAccess,
+          },
+          {
+            title: "Performance Tuning",
+            url: "/workspace/config/performance-tuning",
+            icon: TrendingUp,
+            description: "Performance tuning settings",
+            hasAccess: hasSettingsAccess,
+          },
+        ],
+      },
+    ],
+    [
+      hasLogsAccess,
+      hasObservabilityAccess,
+      hasModelProvidersAccess,
+      hasMCPGatewayAccess,
+      hasPluginsAccess,
+      hasUsersAccess,
+      hasUserProvisioningAccess,
+      hasAuditLogsAccess,
+      hasCustomersAccess,
+      hasTeamsAccess,
+      hasBusinessUnitsAccess,
+      hasRbacAccess,
+      hasVirtualKeysAccess,
+      hasGovernanceAccess,
+      hasRoutingRulesAccess,
+      hasGuardrailsProvidersAccess,
+      hasGuardrailsConfigAccess,
+      hasClusterConfigAccess,
+      isAdaptiveRoutingAllowed,
+      hasSettingsAccess,
+      hasPromptRepositoryAccess,
+      hasPromptDeploymentStrategyAccess,
+      hasAccessProfilesAccess,
+      isDbConnected,
+    ],
+  );
 
-	const filteredItems: SidebarItem[] = useMemo(() => {
-		const query = searchQuery.trim().toLowerCase();
-		if (!query) return items;
+  const filteredItems: SidebarItem[] = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return items;
 
-		return items
-			.map((item) => {
-				const parentMatches = item.title.toLowerCase().includes(query);
-				if (parentMatches) return item;
+    return items
+      .map((item) => {
+        const parentMatches = item.title.toLowerCase().includes(query);
+        if (parentMatches) return item;
 
-				if (item.subItems) {
-					const matchingSubItems = item.subItems.filter((sub) => sub.title.toLowerCase().includes(query));
-					if (matchingSubItems.length > 0) {
-						return { ...item, subItems: matchingSubItems };
-					}
-				}
-				return null;
-			})
-			.filter(Boolean) as SidebarItem[];
-	}, [items, searchQuery]);
+        if (item.subItems) {
+          const matchingSubItems = item.subItems.filter((sub) =>
+            sub.title.toLowerCase().includes(query),
+          );
+          if (matchingSubItems.length > 0) {
+            return { ...item, subItems: matchingSubItems };
+          }
+        }
+        return null;
+      })
+      .filter(Boolean) as SidebarItem[];
+  }, [items, searchQuery]);
 
-	const { data: version } = useGetVersionQuery();
-	const { resolvedTheme } = useTheme();
-	const [logout] = useLogoutMutation();
+  const { data: version } = useGetVersionQuery();
+  const { resolvedTheme } = useTheme();
+  const [logout] = useLogoutMutation();
 
-	// Get user info from localStorage (for enterprise SCIM OAuth)
-	const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  // Get user info from localStorage (for enterprise SCIM OAuth)
+  const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
 
-	useEffect(() => {
-		if (IS_ENTERPRISE) {
-			const info = getUserInfo();
-			setUserInfo(info);
-		}
-	}, []);
+  useEffect(() => {
+    if (IS_ENTERPRISE) {
+      const info = getUserInfo();
+      setUserInfo(info);
+    }
+  }, []);
 
-	const showNewReleaseBanner = useMemo(() => {
-		if (IS_ENTERPRISE) return false;
-		if (latestRelease && version) {
-			return compareVersions(latestRelease.name, version) > 0;
-		}
-		return false;
-	}, [latestRelease, version]);
-	const isAuthEnabled = coreConfig?.auth_config?.is_enabled || false;
+  const showNewReleaseBanner = useMemo(() => {
+    if (IS_ENTERPRISE) return false;
+    if (latestRelease && version) {
+      return compareVersions(latestRelease.name, version) > 0;
+    }
+    return false;
+  }, [latestRelease, version]);
+  const isAuthEnabled = coreConfig?.auth_config?.is_enabled || false;
 
-	useEffect(() => {
-		setMounted(true);
-	}, []);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
-	// Auto-expand items when their subitems are active
-	useEffect(() => {
-		const newExpandedItems = new Set<string>();
-		const isRouteMatch = (url: string) => {
-			if (url === "/workspace/custom-pricing") return pathname === url;
-			return pathname.startsWith(url);
-		};
-		items.forEach((item) => {
-			if (item.subItems?.some((subItem) => isRouteMatch(subItem.url))) {
-				newExpandedItems.add(item.title);
-			}
-		});
-		if (newExpandedItems.size > 0) {
-			setExpandedItems((prev) => new Set([...prev, ...newExpandedItems]));
-		}
-	}, [pathname, items]);
+  // Auto-expand items when their subitems are active
+  useEffect(() => {
+    const newExpandedItems = new Set<string>();
+    const isRouteMatch = (url: string) => {
+      if (url === "/workspace/custom-pricing") return pathname === url;
+      return pathname.startsWith(url);
+    };
+    items.forEach((item) => {
+      if (item.subItems?.some((subItem) => isRouteMatch(subItem.url))) {
+        newExpandedItems.add(item.title);
+      }
+    });
+    if (newExpandedItems.size > 0) {
+      setExpandedItems((prev) => new Set([...prev, ...newExpandedItems]));
+    }
+  }, [pathname, items]);
 
-	// Auto-expand parents when search matches their subItems
-	useEffect(() => {
-		const query = searchQuery.trim().toLowerCase();
-		if (!query) return;
-		const toExpand = new Set<string>();
-		items.forEach((item) => {
-			if (!item.subItems?.length) return;
-			const parentMatches = item.title.toLowerCase().includes(query);
-			if (parentMatches) return;
-			const hasMatchingChild = item.subItems.some((sub) => sub.title.toLowerCase().includes(query));
-			if (hasMatchingChild) {
-				toExpand.add(item.title);
-			}
-		});
-		if (toExpand.size > 0) {
-			setExpandedItems((prev) => {
-				const hasAll = [...toExpand].every((t) => prev.has(t));
-				if (hasAll) return prev;
-				return new Set([...prev, ...toExpand]);
-			});
-		}
-	}, [searchQuery, items]);
+  // Auto-expand parents when search matches their subItems
+  useEffect(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return;
+    const toExpand = new Set<string>();
+    items.forEach((item) => {
+      if (!item.subItems?.length) return;
+      const parentMatches = item.title.toLowerCase().includes(query);
+      if (parentMatches) return;
+      const hasMatchingChild = item.subItems.some((sub) =>
+        sub.title.toLowerCase().includes(query),
+      );
+      if (hasMatchingChild) {
+        toExpand.add(item.title);
+      }
+    });
+    if (toExpand.size > 0) {
+      setExpandedItems((prev) => {
+        const hasAll = [...toExpand].every((t) => prev.has(t));
+        if (hasAll) return prev;
+        return new Set([...prev, ...toExpand]);
+      });
+    }
+  }, [searchQuery, items]);
 
-	// Cmd+K to focus search input
-	useEffect(() => {
-		const handleKeyDown = (event: KeyboardEvent) => {
-			if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
-				event.preventDefault();
-				searchInputRef.current?.focus();
-			}
-		};
-		window.addEventListener("keydown", handleKeyDown);
-		return () => window.removeEventListener("keydown", handleKeyDown);
-	}, []);
+  // Cmd+K to focus search input
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        searchInputRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
-	// Flat list of navigable items for keyboard navigation
-	const navigableItems = useMemo(() => {
-		const result: { title: string; url: string; queryParam?: string; isExternal?: boolean }[] = [];
-		for (const item of filteredItems) {
-			if (item.isExternal) {
-				if (item.hasAccess) result.push({ title: item.title, url: item.url, isExternal: true });
-				continue;
-			}
-			const hasSubItems = item.subItems && item.subItems.length > 0;
-			if (hasSubItems) {
-				// When search is active or parent is expanded, include visible subItems
-				if (searchQuery.trim() || expandedItems.has(item.title)) {
-					for (const sub of item.subItems!) {
-						if (sub.hasAccess === false) continue;
-						result.push({ title: sub.title, url: getSidebarItemHref(sub), queryParam: sub.queryParam });
-					}
-				} else {
-					// Parent is collapsed - include parent as a toggle target
-					if (item.hasAccess) result.push({ title: item.title, url: item.url });
-				}
-			} else {
-				if (item.hasAccess) result.push({ title: item.title, url: item.url });
-			}
-		}
-		return result;
-	}, [filteredItems, expandedItems, searchQuery]);
+  // Flat list of navigable items for keyboard navigation
+  const navigableItems = useMemo(() => {
+    const result: {
+      title: string;
+      url: string;
+      queryParam?: string;
+      isExternal?: boolean;
+    }[] = [];
+    for (const item of filteredItems) {
+      if (item.isExternal) {
+        if (item.hasAccess)
+          result.push({ title: item.title, url: item.url, isExternal: true });
+        continue;
+      }
+      const hasSubItems = item.subItems && item.subItems.length > 0;
+      if (hasSubItems) {
+        // When search is active or parent is expanded, include visible subItems
+        if (searchQuery.trim() || expandedItems.has(item.title)) {
+          for (const sub of item.subItems!) {
+            if (sub.hasAccess === false) continue;
+            result.push({
+              title: sub.title,
+              url: getSidebarItemHref(sub),
+              queryParam: sub.queryParam,
+            });
+          }
+        } else {
+          // Parent is collapsed - include parent as a toggle target
+          if (item.hasAccess) result.push({ title: item.title, url: item.url });
+        }
+      } else {
+        if (item.hasAccess) result.push({ title: item.title, url: item.url });
+      }
+    }
+    return result;
+  }, [filteredItems, expandedItems, searchQuery]);
 
-	const handleSearchKeyDown = useCallback(
-		(e: React.KeyboardEvent<HTMLInputElement>) => {
-			if (e.key === "ArrowDown") {
-				e.preventDefault();
-				setFocusedIndex((prev) => Math.min(prev + 1, navigableItems.length - 1));
-			} else if (e.key === "ArrowUp") {
-				e.preventDefault();
-				setFocusedIndex((prev) => Math.max(prev - 1, 0));
-			} else if (e.key === "Enter") {
-				e.preventDefault();
-				const target = navigableItems[focusedIndex];
-				if (target) {
-					const url = target.url;
-					if (target.isExternal || e.metaKey || e.ctrlKey) {
-						window.open(url, "_blank", "noopener,noreferrer");
-					} else {
-						navigate(url);
-					}
-					setSearchQuery("");
-					setFocusedIndex(-1);
-					searchInputRef.current?.blur();
-				}
-			} else if (e.key === "Escape") {
-				setSearchQuery("");
-				setFocusedIndex(-1);
-				searchInputRef.current?.blur();
-			}
-		},
-		[navigableItems, focusedIndex, navigate],
-	);
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setFocusedIndex((prev) =>
+          Math.min(prev + 1, navigableItems.length - 1),
+        );
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setFocusedIndex((prev) => Math.max(prev - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const target = navigableItems[focusedIndex];
+        if (target) {
+          const url = target.url;
+          if (target.isExternal || e.metaKey || e.ctrlKey) {
+            window.open(url, "_blank", "noopener,noreferrer");
+          } else {
+            navigate(url);
+          }
+          setSearchQuery("");
+          setFocusedIndex(-1);
+          searchInputRef.current?.blur();
+        }
+      } else if (e.key === "Escape") {
+        setSearchQuery("");
+        setFocusedIndex(-1);
+        searchInputRef.current?.blur();
+      }
+    },
+    [navigableItems, focusedIndex, navigate],
+  );
 
-	// Auto-scroll focused item into view
-	useEffect(() => {
-		if (focusedIndex < 0) return;
-		const url = navigableItems[focusedIndex]?.url;
-		if (!url) return;
-		const el = document.querySelector(`[data-nav-url="${url}"]`);
-		el?.scrollIntoView({ block: "nearest" });
-	}, [focusedIndex, navigableItems]);
+  // Auto-scroll focused item into view
+  useEffect(() => {
+    if (focusedIndex < 0) return;
+    const url = navigableItems[focusedIndex]?.url;
+    if (!url) return;
+    const el = document.querySelector(`[data-nav-url="${url}"]`);
+    el?.scrollIntoView({ block: "nearest" });
+  }, [focusedIndex, navigableItems]);
 
-	const toggleItem = (title: string) => {
-		setExpandedItems((prev) => {
-			const next = new Set(prev);
-			if (next.has(title)) {
-				next.delete(title);
-			} else {
-				next.add(title);
-			}
-			return next;
-		});
-	};
+  const toggleItem = (title: string) => {
+    setExpandedItems((prev) => {
+      const next = new Set(prev);
+      if (next.has(title)) {
+        next.delete(title);
+      } else {
+        next.add(title);
+      }
+      return next;
+    });
+  };
 
-	const configExceptions = ["/workspace/config/logging"];
+  const configExceptions = ["/workspace/config/logging"];
 
-	const isActiveRoute = (url: string) => {
-		if (url === "/" && pathname === "/") return true;
-		// Avoid double-highlighting with "/workspace/custom-pricing/overrides"
-		if (url === "/workspace/custom-pricing") return pathname === url;
-		if (url !== "/" && pathname.startsWith(url)) {
-			if (url === "/workspace/config" && configExceptions.some((e) => pathname.startsWith(e))) {
-				return false;
-			}
-			return true;
-		}
-		return false;
-	};
+  const isActiveRoute = (url: string) => {
+    if (url === "/" && pathname === "/") return true;
+    // Avoid double-highlighting with "/workspace/custom-pricing/overrides"
+    if (url === "/workspace/custom-pricing") return pathname === url;
+    if (url !== "/" && pathname.startsWith(url)) {
+      if (
+        url === "/workspace/config" &&
+        configExceptions.some((e) => pathname.startsWith(e))
+      ) {
+        return false;
+      }
+      return true;
+    }
+    return false;
+  };
 
-	// Always render the light theme version for SSR to avoid hydration mismatch
-	const logoSrc = mounted && resolvedTheme === "dark" ? "/bifrost-logo-dark.webp" : "/bifrost-logo.webp";
-	const iconSrc = mounted && resolvedTheme === "dark" ? "/bifrost-icon-dark.webp" : "/bifrost-icon.webp";
+  // Always render the light theme version for SSR to avoid hydration mismatch
+  const logoSrc =
+    mounted && resolvedTheme === "dark"
+      ? "/bifrost-logo-dark.webp"
+      : "/bifrost-logo.webp";
+  const iconSrc =
+    mounted && resolvedTheme === "dark"
+      ? "/bifrost-icon-dark.webp"
+      : "/bifrost-icon.webp";
 
-	const { isConnected: isWebSocketConnected } = useWebSocket();
+  const { isConnected: isWebSocketConnected } = useWebSocket();
 
-	// New release image - based on theme
-	const newReleaseImage = mounted && resolvedTheme === "dark" ? "/images/new-release-image-dark.webp" : "/images/new-release-image.webp";
+  // New release image - based on theme
+  const newReleaseImage =
+    mounted && resolvedTheme === "dark"
+      ? "/images/new-release-image-dark.webp"
+      : "/images/new-release-image.webp";
 
-	// Memoize promo cards array to prevent duplicates and unnecessary re-renders
-	const promoCards = useMemo(() => {
-		const cards = [];
-		// Restart required card - non-dismissible, shown first
-		if (coreConfig?.restart_required?.required) {
-			cards.push({
-				id: "restart-required",
-				title: "Restart Required",
-				description: (
-					<div className="text-xs text-amber-700 dark:text-amber-300/80">
-						{coreConfig.restart_required.reason || "Configuration changes require a server restart to take effect."}
-					</div>
-				),
-				dismissible: false,
-				variant: "warning" as const,
-			});
-		}
-		if (showNewReleaseBanner && latestRelease) {
-			cards.push({
-				id: "new-release",
-				title: `${latestRelease.name} is now available.`,
-				description: (
-					<div className="flex h-full flex-col gap-2">
-						<img src={newReleaseImage} alt="Bifrost" className="h-[95px] rounded-md object-cover" />
-						<a
-							href={`https://docs.getbifrost.ai/changelogs/${latestRelease.name}`}
-							target="_blank"
-							rel="noopener noreferrer"
-							className="text-primary mt-auto pb-1 font-medium underline"
-						>
-							View release notes
-						</a>
-					</div>
-				),
-				dismissible: true,
-			});
-		}
-		// Only show after mounted to ensure cookie is properly hydrated and avoid flash
-		if (!IS_ENTERPRISE && mounted && !isProductionSetupDismissed) {
-			cards.push(productionSetupHelpCard);
-		}
-		return cards;
-	}, [coreConfig?.restart_required, showNewReleaseBanner, latestRelease, newReleaseImage, isProductionSetupDismissed, mounted]);
+  // Memoize promo cards array to prevent duplicates and unnecessary re-renders
+  const promoCards = useMemo(() => {
+    const cards = [];
+    // Restart required card - non-dismissible, shown first
+    if (coreConfig?.restart_required?.required) {
+      cards.push({
+        id: "restart-required",
+        title: "Restart Required",
+        description: (
+          <div className="text-xs text-amber-700 dark:text-amber-300/80">
+            {coreConfig.restart_required.reason ||
+              "Configuration changes require a server restart to take effect."}
+          </div>
+        ),
+        dismissible: false,
+        variant: "warning" as const,
+      });
+    }
+    if (showNewReleaseBanner && latestRelease) {
+      cards.push({
+        id: "new-release",
+        title: `${latestRelease.name} is now available.`,
+        description: (
+          <div className="flex h-full flex-col gap-2">
+            <img
+              src={newReleaseImage}
+              alt="Bifrost"
+              className="h-[95px] rounded-md object-cover"
+            />
+            <a
+              href={`https://docs.getbifrost.ai/changelogs/${latestRelease.name}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary mt-auto pb-1 font-medium underline"
+            >
+              View release notes
+            </a>
+          </div>
+        ),
+        dismissible: true,
+      });
+    }
+    // Only show after mounted to ensure cookie is properly hydrated and avoid flash
+    if (!IS_ENTERPRISE && mounted && !isProductionSetupDismissed) {
+      cards.push(productionSetupHelpCard);
+    }
+    return cards;
+  }, [
+    coreConfig?.restart_required,
+    showNewReleaseBanner,
+    latestRelease,
+    newReleaseImage,
+    isProductionSetupDismissed,
+    mounted,
+  ]);
 
-	// Reset areCardsEmpty when promoCards changes
-	useEffect(() => {
-		if (promoCards.length > 0) {
-			setAreCardsEmpty(false);
-		}
-	}, [promoCards]);
+  // Reset areCardsEmpty when promoCards changes
+  useEffect(() => {
+    if (promoCards.length > 0) {
+      setAreCardsEmpty(false);
+    }
+  }, [promoCards]);
 
-	const hasPromoCards = promoCards.length > 0 && !areCardsEmpty;
-	// When cards are present: 13rem (header 3rem + bottom section ~10rem)
-	// When no cards: 8rem (header 3rem + bottom section without cards ~5rem)
-	const sidebarGroupHeight = hasPromoCards ? "h-[calc(100vh-13rem)]" : "h-[calc(100vh-8rem)]";
+  const hasPromoCards = promoCards.length > 0 && !areCardsEmpty;
+  // When cards are present: 13rem (header 3rem + bottom section ~10rem)
+  // When no cards: 8rem (header 3rem + bottom section without cards ~5rem)
+  const sidebarGroupHeight = hasPromoCards
+    ? "h-[calc(100vh-13rem)]"
+    : "h-[calc(100vh-8rem)]";
 
-	const handleCardsEmpty = () => {
-		setAreCardsEmpty(true);
-	};
+  const handleCardsEmpty = () => {
+    setAreCardsEmpty(true);
+  };
 
-	const handlePromoDismiss = useCallback(
-		(cardId: string) => {
-			if (cardId === "production-setup") {
-				const expiryDate = new Date();
-				expiryDate.setDate(expiryDate.getDate() + 7);
-				setCookie(PRODUCTION_SETUP_DISMISSED_COOKIE, "true", {
-					path: "/",
-					expires: expiryDate,
-				});
-			}
-		},
-		[setCookie],
-	);
+  const handlePromoDismiss = useCallback(
+    (cardId: string) => {
+      if (cardId === "production-setup") {
+        const expiryDate = new Date();
+        expiryDate.setDate(expiryDate.getDate() + 7);
+        setCookie(PRODUCTION_SETUP_DISMISSED_COOKIE, "true", {
+          path: "/",
+          expires: expiryDate,
+        });
+      }
+    },
+    [setCookie],
+  );
 
-	const handleLogout = async () => {
-		try {
-			setUserPopoverOpen(false);
-			await logout().unwrap();
-			navigate("/login");
-		} catch {
-			// Even if logout fails on server, redirect to login
-			navigate("/login");
-		}
-	};
+  const handleLogout = async () => {
+    try {
+      setUserPopoverOpen(false);
+      await logout().unwrap();
+      navigate("/login");
+    } catch {
+      // Even if logout fails on server, redirect to login
+      navigate("/login");
+    }
+  };
 
-	const trialDaysRemaining = useMemo(() => {
-		if (IS_ENTERPRISE && TRIAL_EXPIRY) {
-			const daysRemaining = differenceInDays(new Date(TRIAL_EXPIRY), new Date());
-			return daysRemaining > 0 ? daysRemaining : 0;
-		}
-		return null;
-	}, []);
+  const trialDaysRemaining = useMemo(() => {
+    if (IS_ENTERPRISE && TRIAL_EXPIRY) {
+      const daysRemaining = differenceInDays(
+        new Date(TRIAL_EXPIRY),
+        new Date(),
+      );
+      return daysRemaining > 0 ? daysRemaining : 0;
+    }
+    return null;
+  }, []);
 
-	const { state: sidebarState, toggleSidebar } = useSidebar();
+  const { state: sidebarState, toggleSidebar } = useSidebar();
 
-	return (
-		<Sidebar collapsible="icon" className="overflow-y-clip border-none bg-transparent">
-			<SidebarHeader className="mt-1 ml-2 flex justify-between px-0 group-data-[collapsible=icon]:ml-0 group-data-[collapsible=icon]:h-auto">
-				{/* Expanded state: horizontal layout */}
-				<div className="flex h-10 w-full items-center justify-between px-1.5 group-data-[collapsible=icon]:hidden">
-					<Link to="/workspace/logs" className="group flex items-center gap-2 pl-2">
-						<img className="h-[22px] w-auto" src={logoSrc} alt="Bifrost" width={70} height={70} />
-					</Link>
-					<button
-						onClick={toggleSidebar}
-						className="text-muted-foreground hover:text-foreground hover:bg-sidebar-accent flex h-7 w-7 items-center justify-center rounded-md transition-colors"
-						aria-label="Collapse sidebar"
-					>
-						<PanelLeftClose className="h-4 w-4" />
-					</button>
-				</div>
-				{/* Collapsed state: vertical layout */}
-				<div
-					className="hidden w-full cursor-pointer flex-col items-center gap-2 py-2 group-data-[collapsible=icon]:flex"
-					onClick={toggleSidebar}
-				>
-					<img className="h-[22px] w-auto" src={iconSrc} alt="Bifrost" width={22} height={22} />
-				</div>
-			</SidebarHeader>
-			<div className="mx-2 pb-1 group-data-[collapsible=icon]:hidden">
-				<div className="relative">
-					<Search className="text-muted-foreground absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
-					<input
-						ref={searchInputRef}
-						type="text"
-						aria-label="Search sidebar navigation"
-						placeholder="Search..."
-						value={searchQuery}
-						onChange={(e) => {
-							setSearchQuery(e.target.value);
-							setFocusedIndex(-1);
-						}}
-						onKeyDown={handleSearchKeyDown}
-						className="border-input text-foreground placeholder:text-shadow-muted-foreground focus:ring-ring h-8 w-full rounded-sm border bg-transparent pr-14 pl-8 text-sm outline-none focus:bg-transparent"
-					/>
-					<kbd className="text-muted-foreground pointer-events-none absolute top-1/2 right-2 flex -translate-y-1/2 gap-0.5 text-[10px]">
-						<span className="border-border bg-muted rounded-sm px-1 font-mono shadow-sm">⌘</span>
-						<span className="border-border bg-muted rounded-sm px-1 font-mono shadow-sm">K</span>
-					</kbd>
-				</div>
-			</div>
-			<SidebarContent className="overflow-hidden pb-4">
-				<SidebarGroup className={`custom-scrollbar ${sidebarGroupHeight} overflow-scroll`}>
-					<SidebarGroupContent>
-						<SidebarMenu className="space-y-0.5">
-							{filteredItems.map((item) => {
-								const isActive = isActiveRoute(item.url);
+  return (
+    <Sidebar
+      collapsible="icon"
+      className="overflow-y-clip border-none bg-transparent"
+    >
+      <SidebarHeader className="mt-1 ml-2 flex justify-between px-0 group-data-[collapsible=icon]:ml-0 group-data-[collapsible=icon]:h-auto">
+        {/* Expanded state: horizontal layout */}
+        <div className="flex h-10 w-full items-center justify-between px-1.5 group-data-[collapsible=icon]:hidden">
+          <Link
+            to="/workspace/logs"
+            className="group flex items-center gap-2 pl-2"
+          >
+            <img
+              className="h-[22px] w-auto"
+              src={logoSrc}
+              alt="Bifrost"
+              width={70}
+              height={70}
+            />
+          </Link>
+          <button
+            onClick={toggleSidebar}
+            className="text-muted-foreground hover:text-foreground hover:bg-sidebar-accent flex h-7 w-7 items-center justify-center rounded-md transition-colors"
+            aria-label="Collapse sidebar"
+          >
+            <PanelLeftClose className="h-4 w-4" />
+          </button>
+        </div>
+        {/* Collapsed state: vertical layout */}
+        <div
+          className="hidden w-full cursor-pointer flex-col items-center gap-2 py-2 group-data-[collapsible=icon]:flex"
+          onClick={toggleSidebar}
+        >
+          <img
+            className="h-[22px] w-auto"
+            src={iconSrc}
+            alt="Bifrost"
+            width={22}
+            height={22}
+          />
+        </div>
+      </SidebarHeader>
+      <div className="mx-2 pb-1 group-data-[collapsible=icon]:hidden">
+        <div className="relative">
+          <Search className="text-muted-foreground absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2" />
+          <input
+            ref={searchInputRef}
+            type="text"
+            aria-label="Search sidebar navigation"
+            placeholder="Search..."
+            value={searchQuery}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              setFocusedIndex(-1);
+            }}
+            onKeyDown={handleSearchKeyDown}
+            className="border-input text-foreground placeholder:text-shadow-muted-foreground focus:ring-ring h-8 w-full rounded-sm border bg-transparent pr-14 pl-8 text-sm outline-none focus:bg-transparent"
+          />
+          <kbd className="text-muted-foreground pointer-events-none absolute top-1/2 right-2 flex -translate-y-1/2 gap-0.5 text-[10px]">
+            <span className="border-border bg-muted rounded-sm px-1 font-mono shadow-sm">
+              ⌘
+            </span>
+            <span className="border-border bg-muted rounded-sm px-1 font-mono shadow-sm">
+              K
+            </span>
+          </kbd>
+        </div>
+      </div>
+      <SidebarContent className="overflow-hidden pb-4">
+        <SidebarGroup
+          className={`custom-scrollbar ${sidebarGroupHeight} overflow-scroll`}
+        >
+          <SidebarGroupContent>
+            <SidebarMenu className="space-y-0.5">
+              {filteredItems.map((item) => {
+                const isActive = isActiveRoute(item.url);
 
-								const highlightedUrl = focusedIndex >= 0 ? navigableItems[focusedIndex]?.url : undefined;
-								return (
-									<SidebarItemView
-										key={item.title}
-										item={item}
-										isActive={isActive}
-										isExternal={item.isExternal ?? false}
-										isWebSocketConnected={isWebSocketConnected}
-										isExpanded={expandedItems.has(item.title)}
-										onToggle={() => toggleItem(item.title)}
-										pathname={pathname}
-										isSidebarCollapsed={sidebarState === "collapsed"}
-										expandSidebar={() => toggleSidebar()}
-										highlightedUrl={highlightedUrl}
-									/>
-								);
-							})}
-						</SidebarMenu>
-					</SidebarGroupContent>
-				</SidebarGroup>
-				<div className="flex flex-col gap-4 px-3 group-data-[collapsible=icon]:px-1">
-					<div className="mx-1 group-data-[collapsible=icon]:hidden">
-						<PromoCardStack cards={promoCards} onCardsEmpty={handleCardsEmpty} onDismiss={handlePromoDismiss} />
-					</div>
-					<div className="flex flex-row">
-						<div className="mx-auto flex flex-row gap-4 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:gap-2">
-							{externalLinks.map((item, index) => (
-								<a
-									key={index}
-									href={item.url}
-									target="_blank"
-									rel="noopener noreferrer"
-									className="group flex w-full items-center justify-between"
-									title={item.title}
-								>
-									<div className="flex items-center space-x-3">
-										<item.icon
-											className="hover:text-primary text-muted-foreground h-5 w-5"
-											size={22}
-											weight="regular"
-											strokeWidth={item.strokeWidth}
-										/>
-									</div>
-								</a>
-							))}
-							<ThemeToggle />
-							{IS_ENTERPRISE && userInfo && (userInfo.name || userInfo.email) ? (
-								<Popover open={userPopoverOpen} onOpenChange={setUserPopoverOpen}>
-									<PopoverTrigger asChild>
-										<button
-											className="hover:text-primary text-muted-foreground flex cursor-pointer items-center space-x-3 p-0.5"
-											type="button"
-											aria-label="User menu"
-										>
-											<User className="hover:text-primary text-muted-foreground h-4 w-4" size={20} strokeWidth={2} />
-										</button>
-									</PopoverTrigger>
-									<PopoverContent side="top" align="start" className="w-56 p-0">
-										<div className="flex flex-col">
-											<div className="px-4 py-3">
-												<p className="text-sm font-medium">{userInfo.name || userInfo.email || "User"}</p>
-											</div>
-											<Separator />
-											<button
-												onClick={handleLogout}
-												className="hover:bg-accent hover:text-accent-foreground flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm transition-colors"
-												type="button"
-											>
-												<LogOut className="h-4 w-4" strokeWidth={2} />
-												<span>Logout</span>
-											</button>
-										</div>
-									</PopoverContent>
-								</Popover>
-							) : isAuthEnabled && !IS_ENTERPRISE ? (
-								<div>
-									<button
-										className="hover:text-primary text-muted-foreground flex cursor-pointer items-center space-x-3 p-0.5"
-										onClick={handleLogout}
-										type="button"
-										aria-label="Logout"
-									>
-										<LogOut className="hover:text-primary text-muted-foreground h-4 w-4" size={20} strokeWidth={2} />
-									</button>
-								</div>
-							) : null}
-						</div>
-					</div>
-					<div className="mx-auto flex flex-col items-center gap-1 group-data-[collapsible=icon]:hidden">
-						<div className="font-mono text-xs">{version ?? ""}</div>
-						{trialDaysRemaining !== null && (
-							<div className={cn("text-xs", trialDaysRemaining < 3 ? "text-red-500" : "text-muted-foreground")}>
-								{trialDaysRemaining} {trialDaysRemaining === 1 ? "day" : "days"} remaining
-							</div>
-						)}
-					</div>
-				</div>
-			</SidebarContent>
-		</Sidebar>
-	);
+                const highlightedUrl =
+                  focusedIndex >= 0
+                    ? navigableItems[focusedIndex]?.url
+                    : undefined;
+                return (
+                  <SidebarItemView
+                    key={item.title}
+                    item={item}
+                    isActive={isActive}
+                    isExternal={item.isExternal ?? false}
+                    isWebSocketConnected={isWebSocketConnected}
+                    isExpanded={expandedItems.has(item.title)}
+                    onToggle={() => toggleItem(item.title)}
+                    pathname={pathname}
+                    isSidebarCollapsed={sidebarState === "collapsed"}
+                    expandSidebar={() => toggleSidebar()}
+                    highlightedUrl={highlightedUrl}
+                  />
+                );
+              })}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <div className="flex flex-col gap-4 px-3 group-data-[collapsible=icon]:px-1">
+          <div className="mx-1 group-data-[collapsible=icon]:hidden">
+            <PromoCardStack
+              cards={promoCards}
+              onCardsEmpty={handleCardsEmpty}
+              onDismiss={handlePromoDismiss}
+            />
+          </div>
+          <div className="flex flex-row">
+            <div className="mx-auto flex flex-row gap-4 group-data-[collapsible=icon]:flex-col group-data-[collapsible=icon]:gap-2">
+              {externalLinks.map((item, index) => (
+                <a
+                  key={index}
+                  href={item.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group flex w-full items-center justify-between"
+                  title={item.title}
+                >
+                  <div className="flex items-center space-x-3">
+                    <item.icon
+                      className="hover:text-primary text-muted-foreground h-5 w-5"
+                      size={22}
+                      weight="regular"
+                      strokeWidth={item.strokeWidth}
+                    />
+                  </div>
+                </a>
+              ))}
+              <ThemeToggle />
+              {IS_ENTERPRISE &&
+              userInfo &&
+              (userInfo.name || userInfo.email) ? (
+                <Popover
+                  open={userPopoverOpen}
+                  onOpenChange={setUserPopoverOpen}
+                >
+                  <PopoverTrigger asChild>
+                    <button
+                      className="hover:text-primary text-muted-foreground flex cursor-pointer items-center space-x-3 p-0.5"
+                      type="button"
+                      aria-label="User menu"
+                    >
+                      <User
+                        className="hover:text-primary text-muted-foreground h-4 w-4"
+                        size={20}
+                        strokeWidth={2}
+                      />
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent side="top" align="start" className="w-56 p-0">
+                    <div className="flex flex-col">
+                      <div className="px-4 py-3">
+                        <p className="text-sm font-medium">
+                          {userInfo.name || userInfo.email || "User"}
+                        </p>
+                      </div>
+                      <Separator />
+                      <button
+                        onClick={handleLogout}
+                        className="hover:bg-accent hover:text-accent-foreground flex w-full items-center gap-2 px-4 py-2.5 text-left text-sm transition-colors"
+                        type="button"
+                      >
+                        <LogOut className="h-4 w-4" strokeWidth={2} />
+                        <span>Logout</span>
+                      </button>
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              ) : isAuthEnabled && !IS_ENTERPRISE ? (
+                <div>
+                  <button
+                    className="hover:text-primary text-muted-foreground flex cursor-pointer items-center space-x-3 p-0.5"
+                    onClick={handleLogout}
+                    type="button"
+                    aria-label="Logout"
+                  >
+                    <LogOut
+                      className="hover:text-primary text-muted-foreground h-4 w-4"
+                      size={20}
+                      strokeWidth={2}
+                    />
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          </div>
+          <div className="mx-auto flex flex-col items-center gap-1 group-data-[collapsible=icon]:hidden">
+            <div className="font-mono text-xs">{version ?? ""}</div>
+            {trialDaysRemaining !== null && (
+              <div
+                className={cn(
+                  "text-xs",
+                  trialDaysRemaining < 3
+                    ? "text-red-500"
+                    : "text-muted-foreground",
+                )}
+              >
+                {trialDaysRemaining} {trialDaysRemaining === 1 ? "day" : "days"}{" "}
+                remaining
+              </div>
+            )}
+          </div>
+        </div>
+      </SidebarContent>
+    </Sidebar>
+  );
 }

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -29,11 +29,10 @@ export interface Team {
 	id: string;
 	name: string;
 	customer_id?: string;
-	budget_id?: string;
 	rate_limit_id?: string;
 	// Populated relationships
 	customer?: Customer;
-	budget?: Budget;
+	budgets?: Budget[]; // Multi-budget: each with a distinct reset_duration
 	rate_limit?: RateLimit;
 }
 
@@ -185,14 +184,14 @@ export interface UpdateVirtualKeyRequest {
 export interface CreateTeamRequest {
 	name: string;
 	customer_id?: string;
-	budget?: CreateBudgetRequest;
+	budgets?: CreateBudgetRequest[]; // Multi-budget: each must have a unique reset_duration
 	rate_limit?: CreateRateLimitRequest;
 }
 
 export interface UpdateTeamRequest {
 	name?: string;
 	customer_id?: string;
-	budget?: UpdateBudgetRequest;
+	budgets?: CreateBudgetRequest[]; // Replaces all team budgets; empty array clears
 	rate_limit?: UpdateRateLimitRequest;
 }
 


### PR DESCRIPTION
## Summary

Teams previously supported a single budget via a `budget_id` foreign key on `governance_teams`. This PR migrates team budgets to the same multi-budget ownership model already used by virtual keys and provider configs, where budgets are owned via a `team_id` FK on `governance_budgets`. Teams can now have multiple budgets with different reset intervals (e.g., a daily cap and a monthly cap enforced simultaneously).

## Changes

- **Schema**: Removed `budget_id` from `governance_teams`; added `team_id` to `governance_budgets` with a `CASCADE` delete constraint. `TableTeam.Budget *TableBudget` is replaced by `TableTeam.Budgets []TableBudget`.
- **Migration** (`migrationAddTeamBudgetsToBudgetsTable`): Adds the `team_id` column and index, creates the FK constraint, backfills existing team budgets from the legacy `budget_id` column, then drops `budget_id` from `governance_teams`. Includes a SQLite workaround (foreign key pragma + single connection) matching the pattern used in `migrationAddMultiBudgetTables`.
- **Budget ownership validation**: `TableBudget.BeforeSave` now counts all three owner FK fields (`TeamID`, `VirtualKeyID`, `ProviderConfigID`) and rejects any budget with more than one owner.
- **Config hash**: `GenerateTeamHash` now sorts and serializes all budget IDs rather than a single `budget_id`, preventing hash flips from slice ordering on reload.
- **HTTP handlers**: `CreateTeamRequest` and `UpdateTeamRequest` replace the single `budget`/`UpdateBudgetRequest` field with a `budgets []CreateBudgetRequest` slice. Create inserts the team row first (satisfying the FK), then creates child budgets. Update reconciles by `reset_duration`: matching durations update in place (preserving usage), new durations create new budget rows, and removed durations delete the orphaned rows. Duplicate `reset_duration` values within a single request are rejected.
- **In-memory governance store**: All budget load, store, update, and delete paths in `LocalGovernanceStore` are updated to iterate over `team.Budgets` instead of dereferencing a single `team.Budget` pointer. `UpdateTeamInMemory` reconciles the live budget map by ID, evicting budgets that are no longer associated with the team.
- **`DeleteTeam`**: Budget deletion is now handled entirely by the database cascade; the explicit budget delete inside the transaction is removed.
- **UI**: The team dialog replaces the single budget field with a dynamic list of budget rows, each independently configurable with a max limit, reset duration, and calendar alignment toggle. The calendar-align confirmation dialog is now index-aware. The teams table renders a progress bar per budget. `Team` type drops `budget_id`/`budget` in favor of `budgets?: Budget[]`. All API request types are updated accordingly.
- **Tests**: All governance integration tests updated to use the `budgets: []BudgetRequest{{...}}` array shape.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./plugins/governance/... ./tests/governance/...

# UI
cd ui
pnpm i
pnpm build
```

1. Create a team with two budgets (e.g., `1d` and `1M`) via `POST /api/governance/teams` and confirm both rows appear in `governance_budgets` with the correct `team_id`.
2. Update the team replacing one budget duration; confirm the old budget row is deleted and the new one is created, while the unchanged budget retains its `current_usage`.
3. Delete the team; confirm all associated budget rows are removed via cascade without explicit deletes.
4. Upgrade from a previous schema version; confirm the migration backfills `team_id` on existing budget rows and drops `budget_id` from `governance_teams`.
5. In the UI, open the team dialog, add multiple budget rows with distinct reset durations, save, and verify each budget appears in the current usage section and the teams table.

## Breaking changes

- [x] Yes
- [ ] No

The `budget` / `budget_id` fields are removed from the `Team` object in both the API response and the UI type definitions. Callers reading `team.budget` or `team.budget_id` must migrate to `team.budgets[]`. The `budget` field on `CreateTeamRequest` and `UpdateTeamRequest` is replaced by `budgets[]`. The database schema change is handled automatically by the included migration.

## Related issues

## Security considerations

No new authentication or authorization surfaces are introduced. Budget ownership validation in `BeforeSave` prevents a budget from being assigned to multiple owners simultaneously.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable