### PR TITLE
feat: store VK at OAuth client registration to skip identity selection in consent flow

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -414,6 +414,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationNormalizeOtelTraceType(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddPerUserOAuthClientVirtualKeyID(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -6556,6 +6559,37 @@ func migrationNormalizeOtelTraceType(ctx context.Context, db *gorm.DB) error {
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running normalize_otel_trace_type migration: %s", err.Error())
 
+	}
+	return nil
+}
+
+// migrationAddPerUserOAuthClientVirtualKeyID adds virtual_key_id to oauth_per_user_clients
+// so the VK supplied by the client at registration time can be stored and pre-populated
+// into the consent flow, skipping the manual identity-selection step.
+func migrationAddPerUserOAuthClientVirtualKeyID(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_per_user_oauth_client_virtual_key_id",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TablePerUserOAuthClient{}, "virtual_key_id") {
+				if err := mg.AddColumn(&tables.TablePerUserOAuthClient{}, "VirtualKeyID"); err != nil {
+					return fmt.Errorf("failed to add virtual_key_id column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasColumn(&tables.TablePerUserOAuthClient{}, "virtual_key_id") {
+				_ = mg.DropColumn(&tables.TablePerUserOAuthClient{}, "VirtualKeyID")
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_per_user_oauth_client_virtual_key_id migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -251,13 +251,14 @@ func (t *TableOauthUserToken) AfterFind(tx *gorm.DB) error {
 // MCP clients (like Claude Code) register themselves with Bifrost's OAuth
 // authorization server to obtain a client_id for the authorization code flow.
 type TablePerUserOAuthClient struct {
-	ID           string    `gorm:"type:varchar(255);primaryKey" json:"id"`
-	ClientID     string    `gorm:"type:varchar(255);uniqueIndex;not null" json:"client_id"`
-	ClientName   string    `gorm:"type:varchar(255)" json:"client_name"`
-	RedirectURIs string    `gorm:"type:text;not null" json:"redirect_uris"` // JSON array of allowed redirect URIs
-	GrantTypes   string    `gorm:"type:text" json:"grant_types"`            // JSON array of grant types
-	CreatedAt    time.Time `gorm:"index;not null" json:"created_at"`
-	UpdatedAt    time.Time `gorm:"index;not null" json:"updated_at"`
+	ID             string    `gorm:"type:varchar(255);primaryKey" json:"id"`
+	ClientID       string    `gorm:"type:varchar(255);uniqueIndex;not null" json:"client_id"`
+	ClientName     string    `gorm:"type:varchar(255)" json:"client_name"`
+	RedirectURIs   string    `gorm:"type:text;not null" json:"redirect_uris"` // JSON array of allowed redirect URIs
+	GrantTypes     string    `gorm:"type:text" json:"grant_types"`            // JSON array of grant types
+	VirtualKeyID   *string   `gorm:"type:varchar(255);index" json:"virtual_key_id"` // Pre-populated from Authorization header at registration
+	CreatedAt      time.Time `gorm:"index;not null" json:"created_at"`
+	UpdatedAt      time.Time `gorm:"index;not null" json:"updated_at"`
 }
 
 // TableName returns the table name for per-user OAuth clients.

--- a/transports/bifrost-http/handlers/oauth2_per_user.go
+++ b/transports/bifrost-http/handlers/oauth2_per_user.go
@@ -100,6 +100,15 @@ func (h *PerUserOAuthHandler) handleDynamicClientRegistration(ctx *fasthttp.Requ
 		GrantTypes:   string(grantTypesJSON),
 	}
 
+	// If the client sends a VK in the Authorization header, store it so the consent
+	// flow can skip the manual identity-selection step.
+	if authHeader := strings.TrimSpace(string(ctx.Request.Header.Peek("Authorization"))); authHeader != "" {
+		if vk, err := h.store.ConfigStore.GetVirtualKeyByValue(ctx, authHeader); err == nil && vk != nil && vk.IsActive {
+			vkID := vk.ID
+			client.VirtualKeyID = &vkID
+		}
+	}
+
 	if err := h.store.ConfigStore.CreatePerUserOAuthClient(ctx, client); err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to register client: %v", err))
 		return
@@ -189,12 +198,15 @@ func (h *PerUserOAuthHandler) handleAuthorize(ctx *fasthttp.RequestCtx) {
 	browserSecretHash := fmt.Sprintf("%x", sha256.Sum256([]byte(browserSecret)))
 
 	// Create a PendingFlow to carry OAuth params through the consent screen.
+	// Pre-populate VirtualKeyID from the registered client if it was set at registration time
+	// (i.e. the client sent its VK in the Authorization header during /register).
 	flow := &tables.TablePerUserOAuthPendingFlow{
 		ID:                uuid.New().String(),
 		ClientID:          clientID,
 		RedirectURI:       redirectURI,
 		CodeChallenge:     codeChallenge,
 		State:             state,
+		VirtualKeyID:      client.VirtualKeyID,
 		BrowserSecretHash: browserSecretHash,
 		ExpiresAt:         time.Now().Add(15 * time.Minute),
 	}
@@ -202,7 +214,7 @@ func (h *PerUserOAuthHandler) handleAuthorize(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create pending flow: %v", err))
 		return
 	}
-	logger.Debug("[oauth/authorize] PendingFlow created: flow_id=%s client_id=%s", flow.ID, clientID)
+	logger.Debug("[oauth/authorize] PendingFlow created: flow_id=%s client_id=%s vk_prepopulated=%v", flow.ID, clientID, client.VirtualKeyID != nil)
 
 	// Set HttpOnly cookie binding this flow to the current browser.
 	var cookie fasthttp.Cookie
@@ -216,8 +228,14 @@ func (h *PerUserOAuthHandler) handleAuthorize(ctx *fasthttp.RequestCtx) {
 	cookie.SetMaxAge(15 * 60) // 15 minutes, matching flow TTL
 	ctx.Response.Header.SetCookie(&cookie)
 
-	// Redirect to consent screen with flow_id (relative path — stays on current origin).
-	consentURL := fmt.Sprintf("/oauth/consent?flow_id=%s", url.QueryEscape(flow.ID))
+	// If VK was pre-populated from registration, skip the identity page and go straight
+	// to the MCP connections screen.
+	var consentURL string
+	if client.VirtualKeyID != nil {
+		consentURL = fmt.Sprintf("/oauth/consent/mcps?flow_id=%s", url.QueryEscape(flow.ID))
+	} else {
+		consentURL = fmt.Sprintf("/oauth/consent?flow_id=%s", url.QueryEscape(flow.ID))
+	}
 	ctx.Redirect(consentURL, fasthttp.StatusFound)
 }
 

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- feat: auto vk detection in per user mcp oauth registration


### PR DESCRIPTION
## Summary

When an MCP client (e.g. Claude Code) registers via the OAuth dynamic client registration endpoint and includes a Virtual Key in the `Authorization` header, that VK is now automatically detected, stored on the client record, and used to skip the manual identity-selection step during the consent flow — redirecting the user directly to the MCP connections screen instead.

## Changes

- Added `VirtualKeyID` (nullable `*string`) field to `TablePerUserOAuthClient` to persist the VK supplied at registration time.
- Added a database migration (`add_per_user_oauth_client_virtual_key_id`) to add the `virtual_key_id` column to the `oauth_per_user_clients` table.
- During dynamic client registration (`/register`), if a valid, active VK is found in the `Authorization` header, its ID is stored on the client record.
- During the authorization flow (`/authorize`), if the client has a pre-populated `VirtualKeyID`, it is carried into the `TablePerUserOAuthPendingFlow` and the user is redirected to `/oauth/consent/mcps` instead of `/oauth/consent`, bypassing the identity-selection step.
- Updated the authorize debug log to indicate whether a VK was pre-populated.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Register an MCP OAuth client via `POST /oauth/register`, including a valid Virtual Key in the `Authorization` header.
2. Confirm the returned client record has `virtual_key_id` populated in the database.
3. Initiate the authorization flow for that client and verify the redirect goes to `/oauth/consent/mcps?flow_id=...` rather than `/oauth/consent?flow_id=...`.
4. Register a client without an `Authorization` header and confirm the redirect still goes to `/oauth/consent?flow_id=...`.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The `Authorization` header value is validated against the store (`GetVirtualKeyByValue`) and only stored if the key exists and is active — preventing arbitrary or invalid values from being persisted. The `VirtualKeyID` is an internal reference and is not exposed beyond the consent flow.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable