### PR TITLE
feat: add filter to exclude access profile managed virtual keys

### DIFF
--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -15,14 +15,15 @@ import (
 
 // VirtualKeyQueryParams holds pagination, filtering, and search parameters for virtual key queries.
 type VirtualKeyQueryParams struct {
-	Limit      int
-	Offset     int
-	Search     string
-	CustomerID string
-	TeamID     string
-	SortBy     string // name, budget_spent, created_at, status (default: created_at)
-	Order      string // asc, desc (default: asc)
-	Export     bool   // When true, skip default pagination limits (caller controls limit)
+	Limit                              int
+	Offset                             int
+	Search                             string
+	CustomerID                         string
+	TeamID                             string
+	SortBy                             string // name, budget_spent, created_at, status (default: created_at)
+	Order                              string // asc, desc (default: asc)
+	Export                             bool   // When true, skip default pagination limits (caller controls limit)
+	ExcludeAccessProfileManagedVirtual bool   // When true, exclude VKs managed through enterprise access profiles
 }
 
 // ModelConfigsQueryParams holds pagination, filtering, and search parameters for model configs queries.

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -365,16 +365,18 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 	sortBy := string(ctx.QueryArgs().Peek("sort_by"))
 	order := string(ctx.QueryArgs().Peek("order"))
 	isExport := string(ctx.QueryArgs().Peek("export")) == "true"
+	excludeAccessProfileManagedVirtual := string(ctx.QueryArgs().Peek("exclude_access_profile_managed_virtual")) == "true"
 
-	if limitStr != "" || offsetStr != "" || search != "" || customerID != "" || teamID != "" || sortBy != "" || isExport {
+	if limitStr != "" || offsetStr != "" || search != "" || customerID != "" || teamID != "" || sortBy != "" || isExport || excludeAccessProfileManagedVirtual {
 		// Paginated/filtered path
 		params := configstore.VirtualKeyQueryParams{
-			Search:     search,
-			CustomerID: customerID,
-			TeamID:     teamID,
-			SortBy:     sortBy,
-			Order:      order,
-			Export:     isExport,
+			Search:                             search,
+			CustomerID:                         customerID,
+			TeamID:                             teamID,
+			SortBy:                             sortBy,
+			Order:                              order,
+			Export:                             isExport,
+			ExcludeAccessProfileManagedVirtual: excludeAccessProfileManagedVirtual,
 		}
 		if limitStr != "" {
 			n, err := strconv.Atoi(limitStr)

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -61,6 +61,9 @@ export const governanceApi = baseApi.injectEndpoints({
 					...(params?.search && { search: params.search }),
 					...(params?.customer_id && { customer_id: params.customer_id }),
 					...(params?.team_id && { team_id: params.team_id }),
+					...(params?.exclude_access_profile_managed_virtual === true && {
+						exclude_access_profile_managed_virtual: "true",
+					}),
 					...(params?.sort_by && { sort_by: params.sort_by }),
 					...(params?.order && { order: params.order }),
 					...(params?.export && { export: "true" }),

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -249,6 +249,7 @@ export interface GetVirtualKeysParams {
 	search?: string;
 	customer_id?: string;
 	team_id?: string;
+	exclude_access_profile_managed_virtual?: boolean;
 	sort_by?: "name" | "budget_spent" | "created_at" | "status";
 	order?: "asc" | "desc";
 	export?: boolean;


### PR DESCRIPTION
## Summary

Adds support for filtering out virtual keys that are managed through enterprise access profiles when querying virtual keys. This allows callers to exclude access-profile-managed virtual keys from results, which is useful in contexts where only directly managed keys should be shown.

## Changes

- Added `ExcludeAccessProfileManagedVirtual` field to `VirtualKeyQueryParams` in the config store
- Added handling for the `exclude_access_profile_managed_virtual` query parameter in the `getVirtualKeys` HTTP handler
- Added `exclude_access_profile_managed_virtual` to the `GetVirtualKeysParams` TypeScript interface
- Wired the new parameter into the `governanceApi` query builder so it is passed through to the backend when `true`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Pass `exclude_access_profile_managed_virtual=true` as a query parameter when calling the virtual keys list endpoint and verify that virtual keys managed through enterprise access profiles are excluded from the response.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth or secret handling introduced. The filter only restricts which virtual keys are returned and does not expose additional data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable