### PR TITLE
chore: Persist the selected time range across relevant pages

### DIFF
--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -149,12 +149,15 @@ export default function DashboardPage() {
 	// MCP filter data
 	const { data: mcpFilterData } = useGetMCPAvailableFilterDataQuery();
 
+	// Period is local state only — clicking a period sets start/end in URL, but period itself
+	// is not persisted so refresh shows the actual date range rather than a stale period label
+	const [activePeriod, setActivePeriod] = useState<string | undefined>(undefined);
+
 	// URL state management
 	const [urlState, setUrlState] = useQueryStates(
 		{
 			start_time: parseAsInteger.withDefault(DEFAULT_START_TIME),
 			end_time: parseAsInteger.withDefault(DEFAULT_END_TIME),
-			period: parseAsString.withDefault("24h"),
 			tab: parseAsString.withDefault("overview"),
 			virtual_key_ids: parseAsString.withDefault(""),
 			providers: parseAsString.withDefault(""),
@@ -517,10 +520,12 @@ export default function DashboardPage() {
 	// Adapter: converts a full LogFilters object to dashboard's CSV-based URL state
 	const setFilters = useCallback(
 		(newFilters: LogFilters) => {
+			if (newFilters.start_time !== undefined || newFilters.end_time !== undefined) {
+				setActivePeriod(undefined);
+			}
 			setUrlState({
 				start_time: newFilters.start_time ? dateUtils.toUnixTimestamp(new Date(newFilters.start_time)) : undefined,
 				end_time: newFilters.end_time ? dateUtils.toUnixTimestamp(new Date(newFilters.end_time)) : undefined,
-				period: "", // Clear period when filters change (custom range)
 				providers: (newFilters.providers || []).join(","),
 				models: (newFilters.models || []).join(","),
 				selected_key_ids: (newFilters.selected_key_ids || []).join(","),
@@ -552,7 +557,8 @@ export default function DashboardPage() {
 		(period: string | undefined) => {
 			if (!period) return;
 			const { start, end } = getTimeRangeFromPeriod(period);
-			setUrlState({ start_time: start, end_time: end, period });
+			setActivePeriod(period);
+			setUrlState({ start_time: start, end_time: end });
 		},
 		[setUrlState],
 	);
@@ -560,10 +566,10 @@ export default function DashboardPage() {
 	const handleDateRangeChange = useCallback(
 		(range: { from?: Date; to?: Date }) => {
 			if (!range.from || !range.to) return;
+			setActivePeriod(undefined);
 			setUrlState({
 				start_time: dateUtils.toUnixTimestamp(range.from),
 				end_time: dateUtils.toUnixTimestamp(range.to),
-				period: "",
 			});
 		},
 		[setUrlState],
@@ -764,7 +770,7 @@ export default function DashboardPage() {
 							dateTime={dateRange}
 							onDateTimeUpdate={handleDateRangeChange}
 							preDefinedPeriods={TIME_PERIODS}
-							predefinedPeriod={urlState.period || undefined}
+							predefinedPeriod={activePeriod}
 							onPredefinedPeriodChange={handlePeriodChange}
 							triggerTestId="dashboard-filter-daterange"
 							popupAlignment="end"

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -167,6 +167,8 @@ const getSidebarItemHref = (item: Pick<SidebarItem, "url" | "queryParam">) => {
 	return item.queryParam ? `${item.url}?tab=${item.queryParam}` : item.url;
 };
 
+const TIME_FILTER_PAGES = new Set(["/workspace/dashboard", "/workspace/logs", "/workspace/mcp-logs"]);
+
 const SidebarItemView = ({
 	item,
 	isActive,
@@ -175,6 +177,7 @@ const SidebarItemView = ({
 	isExpanded,
 	onToggle,
 	pathname,
+	search,
 	isSidebarCollapsed,
 	expandSidebar,
 	highlightedUrl,
@@ -186,6 +189,7 @@ const SidebarItemView = ({
 	isExpanded?: boolean;
 	onToggle?: () => void;
 	pathname: string;
+	search: string;
 	isSidebarCollapsed: boolean;
 	expandSidebar: () => void;
 	highlightedUrl?: string;
@@ -296,10 +300,22 @@ const SidebarItemView = ({
 			{hasSubItems && isExpanded && (
 				<SidebarMenuSub className="border-sidebar-border mt-1 ml-4 space-y-0.5 border-l pl-2">
 					{item.subItems?.map((subItem: SidebarItem) => {
-						const subItemHref = getSidebarItemHref(subItem);
+						const baseHref = getSidebarItemHref(subItem);
+						const subItemHref = (() => {
+							if (TIME_FILTER_PAGES.has(subItem.url) && TIME_FILTER_PAGES.has(pathname)) {
+								const currentParams = new URLSearchParams(search);
+								const startTime = currentParams.get("start_time");
+								const endTime = currentParams.get("end_time");
+								if (startTime && endTime) {
+									const sep = baseHref.includes("?") ? "&" : "?";
+									return `${baseHref}${sep}start_time=${startTime}&end_time=${endTime}`;
+								}
+							}
+							return baseHref;
+						})();
 						// For query param based subitems, check if tab matches
 						const isSubItemActive = subItem.queryParam ? pathname === subItem.url : isRouteMatch(subItem.url);
-						const isSubItemHighlighted = highlightedUrl === subItemHref;
+						const isSubItemHighlighted = highlightedUrl ? subItemHref.startsWith(highlightedUrl) : false;
 						const SubItemIcon = subItem.icon;
 						const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${
 							isSubItemHighlighted
@@ -385,6 +401,7 @@ const compareVersions = (v1: string, v2: string): number => {
 
 export default function AppSidebar() {
 	const pathname = useLocation({ select: (l) => l.pathname });
+	const search = useLocation({ select: (l) => l.searchStr ?? "" });
 	const tsNavigate = useNavigate();
 	// Wrapper that accepts arbitrary string URLs (TanStack Router's `to` is
 	// strictly typed, but our sidebar items come from a runtime config).
@@ -1157,6 +1174,7 @@ export default function AppSidebar() {
 										isExpanded={expandedItems.has(item.title)}
 										onToggle={() => toggleItem(item.title)}
 										pathname={pathname}
+										search={search}
 										isSidebarCollapsed={sidebarState === "collapsed"}
 										expandSidebar={() => toggleSidebar()}
 										highlightedUrl={highlightedUrl}


### PR DESCRIPTION
## Summary

The active time period label (e.g. "24h") was being persisted in the URL, causing stale period labels to appear after a page refresh even when the underlying date range had changed. Additionally, navigating between time-filter pages (Dashboard, Logs, MCP Logs) via the sidebar did not carry the current date range forward.

## Changes

- Moved `period` out of URL state into local React state (`activePeriod`). Selecting a period still writes `start_time`/`end_time` to the URL, but the period label itself is ephemeral — on refresh, the UI reflects the actual date range rather than a potentially stale period label.
- Cleared `activePeriod` whenever a custom date range or manual filter change sets explicit `start_time`/`end_time` values.
- Removed the `period` key from `useQueryStates` entirely, eliminating it from the URL query string.
- Added `TIME_FILTER_PAGES` set in the sidebar to identify pages that share a time filter context. When navigating between these pages via sidebar sub-items, the current `start_time` and `end_time` query params are forwarded to the destination URL so the selected date range is preserved across navigation.
- Passed the current `search` string down to `SidebarItemView` to enable reading the active query params when constructing sub-item hrefs.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Dashboard and select a predefined period (e.g. "7d").
2. Refresh the page — confirm the period label is not shown as active, but the date range is still applied correctly.
3. Select a custom date range — confirm the period label clears.
4. While on the Dashboard with a custom date range set, click "Logs" in the sidebar — confirm `start_time` and `end_time` are carried over to the Logs page URL.
5. Navigate between Dashboard, Logs, and MCP Logs via the sidebar and confirm the date range persists across all three.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots showing the period label behavior on refresh and the date range forwarding in the sidebar._

## Breaking changes

- [x] No

## Related issues

## Security considerations

None. Changes are limited to client-side URL state and navigation logic with no auth, secrets, or PII implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable