### PR TITLE
virtual key fixes

### DIFF
--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -11694,7 +11694,7 @@ func TestGenerateTeamHash(t *testing.T) {
 		ID:            "team-1",
 		Name:          "Test Team",
 		CustomerID:    &customerID,
-		BudgetID:      &budgetID,
+		Budgets:       []tables.TableBudget{{ID: budgetID}},
 		ParsedProfile: map[string]interface{}{"key": "value"},
 		ParsedConfig:  map[string]interface{}{"setting": true},
 		ParsedClaims:  map[string]interface{}{"role": "admin"},
@@ -11742,7 +11742,7 @@ func TestGenerateTeamHash(t *testing.T) {
 	// Different BudgetID should produce different hash
 	newBudgetID := "budget-2"
 	team5 := team1
-	team5.BudgetID = &newBudgetID
+	team5.Budgets = []tables.TableBudget{{ID: newBudgetID}}
 	hash5, _ := configstore.GenerateTeamHash(team5)
 	if hash1 == hash5 {
 		t.Error("Different BudgetID should produce different hash")
@@ -13090,7 +13090,7 @@ func TestGenerateTeamHash_RuntimeVsMigrationParity(t *testing.T) {
 	initTestLogger()
 
 	db := setupTestDB(t)
-	if err := db.AutoMigrate(&tables.TableTeam{}); err != nil {
+	if err := db.AutoMigrate(&tables.TableBudget{}, &tables.TableTeam{}); err != nil {
 		t.Fatalf("Failed to migrate: %v", err)
 	}
 
@@ -13188,7 +13188,7 @@ func TestGenerateTeamHash_RuntimeVsMigrationParity(t *testing.T) {
 			ID:            uuid.New().String(),
 			Name:          "Test Team All",
 			CustomerID:    &customerID,
-			BudgetID:      &budgetID,
+			Budgets:       []tables.TableBudget{{ID: budgetID}},
 			ParsedProfile: map[string]interface{}{"key": "value"},
 			ParsedConfig:  map[string]interface{}{"setting": true},
 			ParsedClaims:  map[string]interface{}{"role": "user"},
@@ -13198,7 +13198,7 @@ func TestGenerateTeamHash_RuntimeVsMigrationParity(t *testing.T) {
 		db.Create(&teamToSave)
 
 		var teamFromDB tables.TableTeam
-		db.Where("id = ?", teamToSave.ID).First(&teamFromDB)
+		db.Preload("Budgets").Where("id = ?", teamToSave.ID).First(&teamFromDB)
 
 		hashAfterLoad, _ := configstore.GenerateTeamHash(teamFromDB)
 

--- a/ui/app/workspace/virtual-keys/hooks/useVirtualKeyUsage.ts
+++ b/ui/app/workspace/virtual-keys/hooks/useVirtualKeyUsage.ts
@@ -41,7 +41,7 @@ export function useVirtualKeyUsage(vk: VirtualKey | null | undefined): {
 	const isManagedByProfile = managingProfile !== undefined;
 
 	const displayBudgets: Budget[] | undefined = managingProfile
-		? (managingProfile.budget_lines ?? []).map((line) => ({
+		? (managingProfile.budgets ?? []).map((line) => ({
 				id: line.id,
 				max_limit: line.max_limit,
 				reset_duration: line.reset_duration,
@@ -50,7 +50,7 @@ export function useVirtualKeyUsage(vk: VirtualKey | null | undefined): {
 			}))
 		: vk?.budgets;
 
-	const apRL = managingProfile?.rate_limits;
+	const apRL = managingProfile?.rate_limit;
 	const hasApRateLimit = !!(apRL && (apRL.token_max_limit != null || apRL.request_max_limit != null));
 	// When profile-managed, never fall back to raw VK rate limits (that would contradict the
 	// locked edit/delete UX). If the profile has no rate limit, displayRateLimit is undefined.

--- a/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
@@ -342,7 +342,7 @@ export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKe
 					<div className="space-y-4">
 						<h3 className="font-semibold">
 							Budget Information
-							{isManagedByProfile && managingProfile?.budget_lines?.length ? (
+							{isManagedByProfile && managingProfile?.budgets?.length ? (
 								<span className="text-muted-foreground ml-2 text-xs font-normal">(from {managingProfile.name})</span>
 							) : null}
 						</h3>

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -1,4 +1,6 @@
+import { useVirtualKeyUsage } from "@/app/workspace/virtual-keys/hooks/useVirtualKeyUsage";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -11,13 +13,12 @@ import {
 } from "@/components/ui/alertDialog";
 import { AsyncMultiSelect } from "@/components/ui/asyncMultiselect";
 import { Button } from "@/components/ui/button";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import { ConfigSyncAlert } from "@/components/ui/configSyncAlert";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
-import MultiBudgetLines from "@/components/ui/multiBudgetLines";
+import MultiBudgetLines from "@/components/ui/MultiBudgetLines";
 import { MultiSelect } from "@/components/ui/multiSelect";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -44,7 +45,6 @@ import {
 import { KnownProvider } from "@/lib/types/config";
 import { CreateVirtualKeyRequest, Customer, Team, UpdateVirtualKeyRequest, VirtualKey } from "@/lib/types/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { useVirtualKeyUsage } from "@/app/workspace/virtual-keys/hooks/useVirtualKeyUsage";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
 import { Building, Info, Lock, RotateCcw, Trash2, Users, X } from "lucide-react";
@@ -58,6 +58,9 @@ interface VirtualKeySheetProps {
 	virtualKey?: VirtualKey | null;
 	teams: Team[];
 	customers: Customer[];
+	// When set and not editing, the new VK is created owned by this team and the sheet locks
+	// all fields except name/description (same treatment as access-profile-managed keys).
+	defaultTeamId?: string;
 	onSave: () => void;
 	onCancel: () => void;
 }
@@ -150,7 +153,7 @@ type VirtualKeyType = {
 	provider: string;
 };
 
-export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, onCancel }: VirtualKeySheetProps) {
+export default function VirtualKeySheet({ virtualKey, teams, customers, defaultTeamId, onSave, onCancel }: VirtualKeySheetProps) {
 	const [isOpen, setIsOpen] = useState(true);
 	const navigate = useNavigate();
 	const isEditing = !!virtualKey;
@@ -163,6 +166,12 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 	// of assignees — directly-attached users don't imply an access-profile relation.
 	const { assignedUsers, isManagedByProfile: isManagedByProfileHook } = useVirtualKeyUsage(virtualKey);
 	const isManagedByProfile = isEditing && isManagedByProfileHook;
+	// Team attachment: when a VK already belongs to a team (edit) or will be created for one
+	// (create from team detail sheet via defaultTeamId), the team assignment is fixed — users
+	// can still edit providers/budgets/rate limits/MCP, but not reparent the VK.
+	const attachedTeamId = isEditing ? (virtualKey?.team_id || "") : (defaultTeamId || "");
+	const attachedTeam = attachedTeamId ? teams.find((t) => t.id === attachedTeamId) : undefined;
+	const isTeamLocked = !!attachedTeamId;
 
 	const handleClose = () => {
 		setIsOpen(false);
@@ -215,8 +224,14 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 					mcp_client_name: config.mcp_client?.name || "",
 					tools_to_execute: config.tools_to_execute || [],
 				})) || [],
-			entityType: virtualKey?.team_id ? "team" : virtualKey?.customer_id ? "customer" : "none",
-			teamId: virtualKey?.team_id || "",
+			entityType: virtualKey?.team_id
+				? "team"
+				: virtualKey?.customer_id
+					? "customer"
+					: !isEditing && defaultTeamId
+						? "team"
+						: "none",
+			teamId: virtualKey?.team_id || (!isEditing ? defaultTeamId || "" : ""),
 			customerId: virtualKey?.customer_id || "",
 			isActive: virtualKey?.is_active ?? true,
 			budgets:
@@ -536,6 +551,25 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 									<AlertDescription>
 										This virtual key is managed by an access profile. Only the name and description can be modified — providers, budgets, rate limits, and
 										MCP access are controlled by the profile.
+									</AlertDescription>
+								</Alert>
+							)}
+
+							{isTeamLocked && !isManagedByProfile && (
+								<Alert variant="info">
+									<Users className="h-4 w-4" />
+									<AlertDescription>
+										<p>This virtual key is attached to team{" "}
+										<a
+											data-testid="vk-team-link"
+											href={`/workspace/governance/teams?team=${encodeURIComponent(attachedTeamId)}`}
+											target="_blank"
+											rel="noopener noreferrer"
+											className="font-medium underline underline-offset-2 hover:no-underline"
+										>
+											{attachedTeam?.name ?? virtualKey?.team?.name ?? attachedTeamId}
+										</a>
+										. The team assignment can't be changed here — all other fields remain editable.</p>
 									</AlertDescription>
 								</Alert>
 							)}
@@ -1363,6 +1397,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 																}
 															}}
 															defaultValue={field.value}
+															disabled={isTeamLocked}
 														>
 															<FormControl className="w-full">
 																<SelectTrigger data-testid="vk-entity-type-select">
@@ -1386,7 +1421,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, onSave, 
 													render={({ field }) => (
 														<FormItem>
 															<FormLabel className="font-normal">Select Team</FormLabel>
-															<Select onValueChange={field.onChange} defaultValue={field.value}>
+															<Select onValueChange={field.onChange} defaultValue={field.value} disabled={isTeamLocked}>
 																<FormControl className="w-full">
 																	<SelectTrigger data-testid="vk-team-select">
 																		<SelectValue placeholder="Select a team" />

--- a/ui/components/ui/multiBudgetLines.tsx
+++ b/ui/components/ui/multiBudgetLines.tsx
@@ -6,120 +6,146 @@ import { Plus, RotateCcw, Trash2 } from "lucide-react";
 import { useMemo } from "react";
 
 export interface BudgetLineEntry {
-	max_limit?: number;
-	reset_duration: string;
+  max_limit?: number;
+  reset_duration: string;
 }
 
 interface MultiBudgetLinesProps {
-	id: string;
-	"data-testid"?: string;
-	label?: string;
-	lines: BudgetLineEntry[];
-	onChange: (lines: BudgetLineEntry[]) => void;
-	options?: { label: string; value: string }[];
-	onReset?: () => void;
-	showReset?: boolean;
+  id?: string;
+  "data-testid"?: string;
+  label?: string;
+  lines: BudgetLineEntry[];
+  onChange: (lines: BudgetLineEntry[]) => void;
+  options?: { label: string; value: string }[];
+  onReset?: () => void;
+  showReset?: boolean;
 }
 
 export default function MultiBudgetLines({
-	id,
-	"data-testid": testId,
-	label = "Budget Configuration",
-	lines,
-	onChange,
-	options = resetDurationOptions,
-	onReset,
-	showReset,
+  id,
+  "data-testid": testId,
+  label = "Budget Configuration",
+  lines,
+  onChange,
+  options = resetDurationOptions,
+  onReset,
+  showReset,
 }: MultiBudgetLinesProps) {
-	// Track which reset durations are already used (for duplicate detection)
-	const usedDurations = useMemo(() => {
-		const counts = new Map<string, number>();
-		for (const line of lines) {
-			counts.set(line.reset_duration, (counts.get(line.reset_duration) || 0) + 1);
-		}
-		return counts;
-	}, [lines]);
+  // Track which reset durations are already used (for duplicate detection)
+  const usedDurations = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const line of lines) {
+      counts.set(
+        line.reset_duration,
+        (counts.get(line.reset_duration) || 0) + 1,
+      );
+    }
+    return counts;
+  }, [lines]);
 
-	function addLine() {
-		// Pick the first unused duration, falling back to the first option value
-		const usedSet = new Set(lines.map((l) => l.reset_duration));
-		const available = options.find((o) => !usedSet.has(o.value));
-		onChange([...lines, { max_limit: undefined, reset_duration: available?.value ?? options[0]?.value ?? "" }]);
-	}
+  function addLine() {
+    // Pick the first unused duration, falling back to the first option value
+    const usedSet = new Set(lines.map((l) => l.reset_duration));
+    const available = options.find((o) => !usedSet.has(o.value));
+    onChange([
+      ...lines,
+      {
+        max_limit: undefined,
+        reset_duration: available?.value ?? options[0]?.value ?? "",
+      },
+    ]);
+  }
 
-	function removeLine(index: number) {
-		onChange(lines.filter((_, i) => i !== index));
-	}
+  function removeLine(index: number) {
+    onChange(lines.filter((_, i) => i !== index));
+  }
 
-	function updateMaxLimit(index: number, value: number | undefined) {
-		const updated = [...lines];
-		updated[index] = { ...updated[index], max_limit: value };
-		onChange(updated);
-	}
+  function updateMaxLimit(index: number, value: number | undefined) {
+    const updated = [...lines];
+    updated[index] = { ...updated[index], max_limit: value };
+    onChange(updated);
+  }
 
-	function updateResetDuration(index: number, value: string) {
-		const updated = [...lines];
-		updated[index] = { ...updated[index], reset_duration: value };
-		onChange(updated);
-	}
+  function updateResetDuration(index: number, value: string) {
+    const updated = [...lines];
+    updated[index] = { ...updated[index], reset_duration: value };
+    onChange(updated);
+  }
 
-	return (
-		<div className="space-y-3" data-testid={testId}>
-			<div className="flex items-center justify-between">
-				<Label className="text-sm font-medium">{label}</Label>
-				<div className="flex items-center gap-2">
-					{onReset && (showReset ?? true) && (
-						<Button data-testid={`${id}-reset-btn`} type="button" variant="ghost" size="sm" onClick={onReset}>
-							<RotateCcw className="mr-1 h-3 w-3" />
-							Reset
-						</Button>
-					)}
-					<Button data-testid={`${id}-add-btn`} variant="outline" size="sm" type="button" onClick={addLine}>
-						<Plus className="mr-1 h-3 w-3" />
-						Add Budget
-					</Button>
-				</div>
-			</div>
+  return (
+    <div className="space-y-3" data-testid={testId}>
+      <div className="flex items-center justify-between">
+        <Label className="text-sm font-medium">{label}</Label>
+        <div className="flex items-center gap-2">
+          {onReset && (showReset ?? true) && (
+            <Button
+              data-testid={`${id}-reset-btn`}
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onReset}
+            >
+              <RotateCcw className="mr-1 h-3 w-3" />
+              Reset
+            </Button>
+          )}
+          <Button
+            data-testid={`${id}-add-btn`}
+            variant="outline"
+            size="sm"
+            type="button"
+            onClick={addLine}
+          >
+            <Plus className="mr-1 h-3 w-3" />
+            Add Budget
+          </Button>
+        </div>
+      </div>
 
-			{lines.length === 0 && (
-				<div className="text-muted-foreground rounded-md border border-dashed p-3 text-center text-sm">No budget limits configured.</div>
-			)}
+      {lines.length === 0 && (
+        <div className="text-muted-foreground rounded-md border border-dashed p-3 text-center text-sm">
+          No budget limits configured.
+        </div>
+      )}
 
-			{lines.map((line, index) => {
-				const isDuplicate = (usedDurations.get(line.reset_duration) || 0) > 1;
-				return (
-					<div key={index} className="space-y-1">
-						<div className="flex items-end gap-2">
-							<div className="flex-1">
-								<NumberAndSelect
-									id={`${id}-${index}`}
-									labelClassName="font-normal"
-									label="Maximum Spend (USD)"
-									value={line.max_limit}
-									selectValue={line.reset_duration}
-									onChangeNumber={(value) => updateMaxLimit(index, value)}
-									onChangeSelect={(value) => updateResetDuration(index, value)}
-									options={options}
-								/>
-							</div>
-							<Button
-								data-testid={`${id}-remove-${index}`}
-								aria-label={`Remove budget ${index + 1}`}
-								variant="ghost"
-								size="icon"
-								type="button"
-								className="text-destructive mb-0.5 h-8 w-8 shrink-0"
-								onClick={() => removeLine(index)}
-							>
-								<Trash2 className="h-4 w-4" />
-							</Button>
-						</div>
-						{isDuplicate && (
-							<p className="text-destructive pl-0.5 text-xs">Duplicate reset period — each budget line must use a different interval.</p>
-						)}
-					</div>
-				);
-			})}
-		</div>
-	);
+      {lines.map((line, index) => {
+        const isDuplicate = (usedDurations.get(line.reset_duration) || 0) > 1;
+        return (
+          <div key={index} className="space-y-1">
+            <div className="flex items-end gap-2">
+              <div className="flex-1">
+                <NumberAndSelect
+                  id={`${id}-${index}`}
+                  labelClassName="font-normal"
+                  label="Maximum Spend (USD)"
+                  value={line.max_limit}
+                  selectValue={line.reset_duration}
+                  onChangeNumber={(value) => updateMaxLimit(index, value)}
+                  onChangeSelect={(value) => updateResetDuration(index, value)}
+                  options={options}
+                />
+              </div>
+              <Button
+                data-testid={`${id}-remove-${index}`}
+                aria-label={`Remove budget ${index + 1}`}
+                variant="ghost"
+                size="icon"
+                type="button"
+                className="text-destructive mb-0.5 h-8 w-8 shrink-0"
+                onClick={() => removeLine(index)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+            {isDuplicate && (
+              <p className="text-destructive pl-0.5 text-xs">
+                Duplicate reset period — each budget line must use a different
+                interval.
+              </p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

Renames budget-related fields across the backend and frontend to align on a consistent `budgets` naming convention, replacing the older `budget_lines` and `BudgetID` field references.

## Changes

- Replaced `BudgetID *string` with `Budgets []tables.TableBudget` in team hash generation tests, ensuring the hash logic correctly reflects the new budget structure
- Replaced `managingProfile.budget_lines` with `managingProfile.budgets` in `useVirtualKeyUsage` and `virtualKeyDetailsSheet` to match the updated API shape
- Replaced `managingProfile.rate_limits` with `managingProfile.rate_limit` (singular) in `useVirtualKeyUsage` to match the correct field name
- Made `id` optional in `MultiBudgetLines` component props and reformatted the file to use consistent 2-space indentation

## Type of change

- [x] Refactor

## Affected areas

- [x] Transports (HTTP)
- [x] UI (React)

## How to test

```sh
# Core/Transports
go test ./transports/bifrost-http/lib/...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Verify that virtual key detail sheets correctly display budget information sourced from a managing profile, and that rate limit display behaves correctly when a profile has or does not have a rate limit configured.

## Breaking changes

- [x] Yes

The `BudgetID` field on team objects has been replaced by a `Budgets` slice. Any code still referencing `BudgetID` directly will need to be updated to use `Budgets[0].ID` or iterate the slice as appropriate.

## Related issues

## Security considerations

No security implications. These are display and data-model field renames only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable