### PR TITLE
fix: persist passthrough stream log entries before finalization

### DIFF
--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -5,6 +5,7 @@ package logging
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -638,6 +639,15 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 		Status:             "processing",
 	}
 	p.pendingLogsEntries.Store(effectiveRequestID, pending)
+
+	// Persist passthrough stream logs immediately so refreshes can still
+	// see an in-flight row even before PostLLMHook finalizes the entry.
+	if req.RequestType == schemas.PassthroughStreamRequest {
+		initialEntry := buildInitialLogEntry(pending)
+		initialEntry.Stream = true
+		p.enqueueLogEntry(initialEntry, nil)
+	}
+
 	// Call callback synchronously for immediate UI feedback (WebSocket "processing" notification).
 	// The entry does not exist in the DB yet - it will be written when PostLLMHook fires.
 	p.mu.Lock()
@@ -868,6 +878,19 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 
 		if requestType != schemas.PassthroughStreamRequest && tracer != nil && traceID != "" {
 			tracer.CleanupStreamAccumulator(traceID)
+		}
+
+		if requestType == schemas.PassthroughStreamRequest {
+			if err := p.updatePassthroughStreamEntry(ctx, entry); err != nil {
+				if errors.Is(err, logstore.ErrNotFound) {
+					p.storeOrEnqueueEntry(ctx, entry, p.makePostWriteCallback(nil))
+				} else {
+					p.logger.Warn("failed to update passthrough stream log entry %s: %v", entry.ID, err)
+					p.storeOrEnqueueEntry(ctx, entry, p.makePostWriteCallback(nil))
+				}
+			}
+			p.scheduleDeferredUsageUpdate(ctx, requestID, entry.TokenUsageParsed != nil)
+			return result, bifrostErr, nil
 		}
 
 		p.storeOrEnqueueEntry(ctx, entry, p.makePostWriteCallback(nil))

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -309,6 +309,123 @@ func (p *LoggerPlugin) updateLogEntry(
 	return p.store.Update(ctx, requestID, updates)
 }
 
+// updatePassthroughStreamEntry updates a persisted passthrough stream log row
+// with completion/error fields so refreshes show the finalized state.
+func (p *LoggerPlugin) updatePassthroughStreamEntry(ctx context.Context, entry *logstore.Log) error {
+	contentLoggingEnabled := p.disableContentLogging == nil || !*p.disableContentLogging
+
+	updates := map[string]interface{}{
+		"status":                    entry.Status,
+		"stream":                    true,
+		"number_of_retries":         entry.NumberOfRetries,
+		"selected_key_id":           entry.SelectedKeyID,
+		"selected_key_name":         entry.SelectedKeyName,
+		"routing_engine_logs":       entry.RoutingEngineLogs,
+		"passthrough_response_body": entry.PassthroughResponseBody,
+		"is_large_payload_request":  entry.IsLargePayloadRequest,
+		"is_large_payload_response": entry.IsLargePayloadResponse,
+	}
+
+	if contentLoggingEnabled {
+		updates["raw_request"] = entry.RawRequest
+		updates["raw_response"] = entry.RawResponse
+	}
+
+	if entry.Latency != nil {
+		updates["latency"] = *entry.Latency
+	}
+	if entry.Cost != nil {
+		updates["cost"] = *entry.Cost
+	}
+	if entry.ParentRequestID != nil {
+		updates["parent_request_id"] = *entry.ParentRequestID
+	}
+	if entry.VirtualKeyID != nil {
+		updates["virtual_key_id"] = *entry.VirtualKeyID
+	}
+	if entry.VirtualKeyName != nil {
+		updates["virtual_key_name"] = *entry.VirtualKeyName
+	}
+	if entry.RoutingRuleID != nil {
+		updates["routing_rule_id"] = *entry.RoutingRuleID
+	}
+	if entry.RoutingRuleName != nil {
+		updates["routing_rule_name"] = *entry.RoutingRuleName
+	}
+	if entry.Alias != nil {
+		updates["alias"] = *entry.Alias
+	}
+	if entry.SelectedPromptID != nil {
+		updates["selected_prompt_id"] = *entry.SelectedPromptID
+	}
+	if entry.SelectedPromptName != nil {
+		updates["selected_prompt_name"] = *entry.SelectedPromptName
+	}
+	if entry.SelectedPromptVersion != nil {
+		updates["selected_prompt_version"] = *entry.SelectedPromptVersion
+	}
+	if entry.TeamID != nil {
+		updates["team_id"] = *entry.TeamID
+	}
+	if entry.TeamName != nil {
+		updates["team_name"] = *entry.TeamName
+	}
+	if entry.CustomerID != nil {
+		updates["customer_id"] = *entry.CustomerID
+	}
+	if entry.CustomerName != nil {
+		updates["customer_name"] = *entry.CustomerName
+	}
+	if entry.UserID != nil {
+		updates["user_id"] = *entry.UserID
+	}
+	if entry.UserName != nil {
+		updates["user_name"] = *entry.UserName
+	}
+	if entry.BusinessUnitID != nil {
+		updates["business_unit_id"] = *entry.BusinessUnitID
+	}
+	if entry.BusinessUnitName != nil {
+		updates["business_unit_name"] = *entry.BusinessUnitName
+	}
+
+	temp := &logstore.Log{
+		ParamsParsed:       entry.ParamsParsed,
+		TokenUsageParsed:   entry.TokenUsageParsed,
+		ErrorDetailsParsed: entry.ErrorDetailsParsed,
+		MetadataParsed:     entry.MetadataParsed,
+		AttemptTrailParsed: entry.AttemptTrailParsed,
+		RoutingEnginesUsed: entry.RoutingEnginesUsed,
+	}
+	if err := temp.SerializeFields(); err != nil {
+		return err
+	}
+	if temp.Params != "" {
+		updates["params"] = temp.Params
+	}
+	if temp.TokenUsage != "" {
+		updates["token_usage"] = temp.TokenUsage
+		updates["prompt_tokens"] = entry.PromptTokens
+		updates["completion_tokens"] = entry.CompletionTokens
+		updates["total_tokens"] = entry.TotalTokens
+		updates["cached_read_tokens"] = entry.CachedReadTokens
+	}
+	if temp.ErrorDetails != "" {
+		updates["error_details"] = temp.ErrorDetails
+	}
+	if temp.Metadata != nil {
+		updates["metadata"] = *temp.Metadata
+	}
+	if temp.AttemptTrail != "" {
+		updates["attempt_trail"] = temp.AttemptTrail
+	}
+	if temp.RoutingEnginesUsedStr != nil {
+		updates["routing_engines_used"] = *temp.RoutingEnginesUsedStr
+	}
+
+	return p.store.Update(ctx, entry.ID, updates)
+}
+
 // makePostWriteCallback creates a callback function for use after the batch writer commits.
 // It receives the already-inserted entry directly (no DB re-read needed).
 func (p *LoggerPlugin) makePostWriteCallback(enrichFn func(*logstore.Log)) func(entry *logstore.Log) {


### PR DESCRIPTION
## Summary

Passthrough stream requests were not persisting an initial log row before `PostLLMHook` finalized the entry, meaning any page refresh during an in-flight stream would show no record at all. This PR ensures a row is written immediately in `PreLLMHook` for passthrough stream requests, and then updated with the finalized state in `PostLLMHook`.

## Changes

- In `PreLLMHook`, when the request type is `PassthroughStreamRequest`, an initial log entry is enqueued immediately with `Stream: true` so the row is visible in the store before the response completes.
- In `PostLLMHook`, passthrough stream requests now follow a dedicated update path via `updatePassthroughStreamEntry`, which patches the existing row with completion fields (status, latency, cost, token usage, error details, response body, routing info, and all optional identity/metadata fields). If the row is not found, it falls back to a full insert.
- `updatePassthroughStreamEntry` serializes parsed fields (params, token usage, error details, metadata, attempt trail, routing engines) before building the update map, mirroring the pattern used by the existing `updateLogEntry` helper.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Configure a passthrough stream request through Bifrost.
2. While the stream is in flight, refresh the logs UI or query the log store directly.
3. Verify the in-flight row is visible with `status: processing` and `stream: true`.
4. After the stream completes, verify the same row is updated with the finalized status, latency, token usage, and response body rather than a duplicate row being inserted.

```sh
go test ./plugins/logging/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth, secrets, or PII handling introduced. The update map follows the same field exposure as the existing log update path.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable