### PR TITLE
feat: adds codex compatibility

### DIFF
--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -866,6 +866,7 @@ func (output ResponsesToolMessageOutputStruct) MarshalJSON() ([]byte, error) {
 	}
 	return nil, fmt.Errorf("responses tool message output struct is neither a string nor an array of responses message content blocks nor a computer tool call output data nor an image generation call output")
 }
+
 func (output *ResponsesToolMessageOutputStruct) UnmarshalJSON(data []byte) error {
 	var str string
 	if err := Unmarshal(data, &str); err == nil {
@@ -997,7 +998,7 @@ type ResponsesWebFetchToolCallAction struct {
 
 // ResponsesFunctionToolCallOutput represents a function tool call output
 type ResponsesFunctionToolCallOutput struct {
-	ResponsesFunctionToolCallOutputStr    *string //A JSON string of the output of the function tool call.
+	ResponsesFunctionToolCallOutputStr    *string // A JSON string of the output of the function tool call.
 	ResponsesFunctionToolCallOutputBlocks []ResponsesMessageContentBlock
 }
 
@@ -1364,6 +1365,7 @@ const (
 	ResponsesToolTypeWebSearchPreview   ResponsesToolType = "web_search_preview"
 	ResponsesToolTypeMemory             ResponsesToolType = "memory"
 	ResponsesToolTypeToolSearch         ResponsesToolType = "tool_search"
+	ResponsesToolTypeNamespace          ResponsesToolType = "namespace"
 )
 
 // normalizeResponsesToolType maps versioned/provider-specific tool type strings
@@ -1425,6 +1427,7 @@ type ResponsesTool struct {
 	*ResponsesToolLocalShell
 	*ResponsesToolCustom
 	*ResponsesToolWebSearchPreview
+	*ResponsesToolNamespace
 }
 
 // mergeJSONFields merges all top-level fields from src into dst using sjson,
@@ -1550,6 +1553,10 @@ func (t ResponsesTool) MarshalJSON() ([]byte, error) {
 	case ResponsesToolTypeWebSearchPreview:
 		if t.ResponsesToolWebSearchPreview != nil {
 			typeBytes, err = MarshalSorted(t.ResponsesToolWebSearchPreview)
+		}
+	case ResponsesToolTypeNamespace:
+		if t.ResponsesToolNamespace != nil {
+			typeBytes, err = MarshalSorted(t.ResponsesToolNamespace)
 		}
 	}
 	if err != nil {
@@ -1711,6 +1718,13 @@ func (t *ResponsesTool) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		t.ResponsesToolWebSearchPreview = &webSearchPreviewTool
+
+	case ResponsesToolTypeNamespace:
+		var namespaceTool ResponsesToolNamespace
+		if err := Unmarshal(data, &namespaceTool); err != nil {
+			return err
+		}
+		t.ResponsesToolNamespace = &namespaceTool
 	}
 
 	return nil
@@ -2122,6 +2136,11 @@ type ResponsesToolWebFetch struct {
 	MaxUses          *int                           `json:"max_uses,omitempty"`
 	Filters          *ResponsesToolWebSearchFilters `json:"filters,omitempty"`
 	MaxContentTokens *int                           `json:"max_content_tokens,omitempty"`
+}
+
+// ResponsesToolNamespace represents a namespace tool that groups related function tools.
+type ResponsesToolNamespace struct {
+	Tools []ResponsesTool `json:"tools,omitempty"`
 }
 
 // ======================================================= Streaming Structs =======================================================

--- a/plugins/compat/changelog.md
+++ b/plugins/compat/changelog.md
@@ -1,0 +1,2 @@
+- feat: drops tools web_search and web_search_preview if model does not support it  
+- feat: flattens tool type namespace if provider does not support it

--- a/plugins/compat/conversion.go
+++ b/plugins/compat/conversion.go
@@ -1,16 +1,52 @@
 package compat
 
-import "github.com/maximhq/bifrost/core/schemas"
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+)
 
 // applyParameterConversion rewrites request fields in place for provider compatibility.
 func applyParameterConversion(req *schemas.BifrostRequest) {
 	if req == nil {
 		return
 	}
-
 	if req.ChatRequest != nil {
 		normalizeDeveloperRoleForChatRequest(req.ChatRequest)
 	}
+	if req.ResponsesRequest != nil {
+		flattenNamespaceTools(req.ResponsesRequest)
+	}
+}
+
+// flattenNamespaceTools expands namespace scoped tools into a flat list of tools.
+func flattenNamespaceTools(req *schemas.BifrostResponsesRequest) {
+	if req == nil || req.Params == nil {
+		return
+	}
+	// ignore openai models or azure hosted openai models
+	if req.Provider == schemas.OpenAI || (req.Provider == schemas.Azure && !schemas.IsAnthropicModel(req.Model)) {
+		return
+	}
+	hasNamespace := false
+	finalSize := len(req.Params.Tools)
+	for _, tool := range req.Params.Tools {
+		if tool.Type != schemas.ResponsesToolTypeNamespace || tool.ResponsesToolNamespace == nil || tool.ResponsesToolNamespace.Tools == nil {
+			continue
+		}
+		finalSize += len(tool.ResponsesToolNamespace.Tools)
+		hasNamespace = true
+	}
+	if !hasNamespace {
+		return
+	}
+	flattened := make([]schemas.ResponsesTool, 0, finalSize)
+	for _, tool := range req.Params.Tools {
+		if tool.Type != schemas.ResponsesToolTypeNamespace {
+			flattened = append(flattened, tool)
+		} else if tool.ResponsesToolNamespace != nil && tool.ResponsesToolNamespace.Tools != nil {
+			flattened = append(flattened, tool.ResponsesToolNamespace.Tools...)
+		}
+	}
+	req.Params.Tools = flattened
 }
 
 func normalizeDeveloperRoleForChatRequest(req *schemas.BifrostChatRequest) {

--- a/plugins/compat/dropparams.go
+++ b/plugins/compat/dropparams.go
@@ -1,6 +1,10 @@
 package compat
 
-import "github.com/maximhq/bifrost/core/schemas"
+import (
+	"fmt"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
 
 // dropUnsupportedParams removes unsupported model parameters from a request in place.
 func dropUnsupportedParams(req *schemas.BifrostRequest, supportedParams []string) []string {
@@ -167,6 +171,10 @@ func dropUnsupportedParams(req *schemas.BifrostRequest, supportedParams []string
 			params.Tools = nil
 			dropped = append(dropped, "tools")
 		}
+		if !isSupported["web_search"] {
+			droppedKeys := dropWebsearchToolCalls(req)
+			dropped = append(dropped, droppedKeys...)
+		}
 	}
 
 	if req.TextCompletionRequest != nil && req.TextCompletionRequest.Params != nil {
@@ -213,6 +221,21 @@ func dropUnsupportedParams(req *schemas.BifrostRequest, supportedParams []string
 			dropped = append(dropped, "top_p")
 		}
 	}
+	return dropped
+}
 
+// dropWebsearchToolCalls drops web search tool calls from the request
+func dropWebsearchToolCalls(req *schemas.BifrostRequest) []string {
+	dropped := []string{}
+	tools := req.ResponsesRequest.Params.Tools
+	kept := tools[:0]
+	for i, tool := range tools {
+		if tool.Type == schemas.ResponsesToolTypeWebSearch || tool.Type == schemas.ResponsesToolTypeWebSearchPreview {
+			dropped = append(dropped, fmt.Sprintf("tools[%d].%s", i, tool.Type))
+		} else {
+			kept = append(kept, tool)
+		}
+	}
+	req.ResponsesRequest.Params.Tools = kept
 	return dropped
 }


### PR DESCRIPTION
## Summary

Adds support for a new `namespace` tool type in the Responses API, which allows grouping related function tools under a single namespace container. For providers that do not natively support namespace-scoped tools (non-OpenAI, non-Azure-OpenAI), the namespace tools are automatically flattened into a flat tool list during request conversion. Additionally, web search tool calls are now dropped from requests when the target model does not support the `web_search` parameter.

## Changes

- Added `ResponsesToolTypeNamespace` constant and `ResponsesToolNamespace` struct to represent a namespace tool containing a nested list of tools.
- Wired `ResponsesToolNamespace` into `ResponsesTool` marshal/unmarshal logic so namespace tools round-trip correctly through JSON.
- Added `flattenNamespaceTools` in the compat plugin to expand namespace tools into a flat list for providers that do not support the namespace type natively (skipped for OpenAI and Azure-hosted OpenAI models).
- Added `dropWebsearchToolCalls` in the compat plugin to remove web search tools from requests when the model does not declare `web_search` as a supported parameter.
- Fixed a missing newline after `MarshalJSON` and a comment spacing nit in `responses.go`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

- Send a Responses API request with a `namespace`\-typed tool containing nested function tools to a non-OpenAI provider and verify the tools are flattened before the upstream call.
- Send a request with a web search tool to a model that does not list `web_search` as a supported param and verify the tool is stripped from the outgoing request.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Namespace flattening and web search tool dropping are purely structural transformations on outbound requests.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable