### PR TITLE
feat: add stream terminal detection and full body accumulation for passthrough streams

### DIFF
--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -4213,7 +4213,11 @@ func (provider *GeminiProvider) PassthroughStream(
 		defer stopIdleTimeout()
 		defer stopCancellation()
 
-		fullResponseBody := make([]byte, 0, maxStreamPassthroughCaptureBytes)
+		initialCaptureBytes := 32 * 1024
+		if initialCaptureBytes > maxStreamPassthroughCaptureBytes {
+			initialCaptureBytes = maxStreamPassthroughCaptureBytes
+		}
+		fullResponseBody := make([]byte, 0, initialCaptureBytes)
 		fullResponseBodyTruncated := false
 		terminalDetector := &providerUtils.StreamTerminalDetector{}
 		buf := make([]byte, 4096)

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	BifrostContextKeyResponseFormat schemas.BifrostContextKey = "bifrost_context_key_response_format"
+	BifrostContextKeyResponseFormat  schemas.BifrostContextKey = "bifrost_context_key_response_format"
+	maxStreamPassthroughCaptureBytes                           = 1024 * 1024
 )
 
 type GeminiProvider struct {
@@ -173,7 +174,6 @@ func (provider *GeminiProvider) completeRequest(ctx *schemas.BifrostContext, mod
 // Returns the response and latency, or an error if the request fails.
 func (provider *GeminiProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
 	providerName := provider.GetProviderKey()
-
 	// Create request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -4213,12 +4213,28 @@ func (provider *GeminiProvider) PassthroughStream(
 		defer stopIdleTimeout()
 		defer stopCancellation()
 
+		fullResponseBody := make([]byte, 0, maxStreamPassthroughCaptureBytes)
+		fullResponseBodyTruncated := false
+		terminalDetector := &providerUtils.StreamTerminalDetector{}
 		buf := make([]byte, 4096)
 		for {
 			n, readErr := bodyStream.Read(buf)
 			if n > 0 {
 				chunk := make([]byte, n)
 				copy(chunk, buf[:n])
+				if !fullResponseBodyTruncated {
+					remaining := maxStreamPassthroughCaptureBytes - len(fullResponseBody)
+					if remaining > 0 {
+						if n <= remaining {
+							fullResponseBody = append(fullResponseBody, chunk...)
+						} else {
+							fullResponseBody = append(fullResponseBody, chunk[:remaining]...)
+							fullResponseBodyTruncated = true
+						}
+					} else {
+						fullResponseBodyTruncated = true
+					}
+				}
 				select {
 				case ch <- &schemas.BifrostStreamChunk{
 					BifrostPassthroughResponse: &schemas.BifrostPassthroughResponse{
@@ -4231,21 +4247,44 @@ func (provider *GeminiProvider) PassthroughStream(
 				case <-ctx.Done():
 					return
 				}
+
+				if terminalDetector.ObserveChunk(chunk) {
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					extraFields.Latency = time.Since(startTime).Milliseconds()
+					var capturedBody []byte
+					if !fullResponseBodyTruncated {
+						capturedBody = append([]byte(nil), fullResponseBody...)
+					}
+					finalResp := &schemas.BifrostResponse{
+						PassthroughResponse: &schemas.BifrostPassthroughResponse{
+							StatusCode:    statusCode,
+							Headers:       headers,
+							Body:          capturedBody,
+							BodyTruncated: fullResponseBodyTruncated,
+							ExtraFields:   extraFields,
+						},
+					}
+					postHookRunner(ctx, finalResp, nil)
+					return
+				}
 			}
 			if readErr == io.EOF {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				extraFields.Latency = time.Since(startTime).Milliseconds()
+				var capturedBody []byte
+				if !fullResponseBodyTruncated {
+					capturedBody = append([]byte(nil), fullResponseBody...)
+				}
 				finalResp := &schemas.BifrostResponse{
 					PassthroughResponse: &schemas.BifrostPassthroughResponse{
-						StatusCode:  statusCode,
-						Headers:     headers,
-						ExtraFields: extraFields,
+						StatusCode:    statusCode,
+						Headers:       headers,
+						Body:          capturedBody,
+						BodyTruncated: fullResponseBodyTruncated,
+						ExtraFields:   extraFields,
 					},
 				}
 				postHookRunner(ctx, finalResp, nil)
-				if postHookSpanFinalizer != nil {
-					postHookSpanFinalizer(ctx)
-				}
 				return
 			}
 			if readErr != nil {

--- a/core/providers/utils/streamterminaldetector.go
+++ b/core/providers/utils/streamterminaldetector.go
@@ -1,0 +1,274 @@
+package utils
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/bytedance/sonic"
+)
+
+const maxTerminalDetectorBufferBytes = 256 * 1024
+
+var (
+	sseFrameDelimiterLF   = []byte("\n\n")
+	sseFrameDelimiterCRLF = []byte("\r\n\r\n")
+)
+
+// StreamTerminalDetector incrementally parses stream frames and detects
+// semantic completion markers such as finishReason or [DONE].
+type StreamTerminalDetector struct {
+	pending bytes.Buffer
+}
+
+// ObserveChunk ingests a new raw stream chunk and returns true if a terminal
+// marker was detected in a parsed frame payload.
+func (d *StreamTerminalDetector) ObserveChunk(chunk []byte) bool {
+	if len(chunk) == 0 {
+		return false
+	}
+
+	// Fast path: detect terminal markers when a single chunk already contains
+	// a complete payload (SSE data line or plain JSON body).
+	// Skip this when the chunk already contains full SSE frame delimiters,
+	// because multi-event chunks need frame-by-frame parsing.
+	if !containsSSEFrameDelimiter(chunk) && d.detectInFrame(chunk) {
+		return true
+	}
+
+	d.pending.Write(chunk)
+
+	for {
+		data := d.pending.Bytes()
+		delimIdx, delimLen := findFirstSSEFrameDelimiter(data)
+		if delimIdx < 0 {
+			break
+		}
+
+		frame := append([]byte(nil), data[:delimIdx]...)
+		d.pending.Next(delimIdx + delimLen)
+		if d.detectInFrame(frame) {
+			return true
+		}
+	}
+
+	// Some passthrough streams emit plain JSON chunks (no SSE "\n\n" framing).
+	// Try parsing the current pending buffer as a whole JSON payload.
+	if d.detectInUndelimitedPending() {
+		return true
+	}
+
+	// Keep memory bounded if the upstream never emits a frame delimiter.
+	if d.pending.Len() > maxTerminalDetectorBufferBytes {
+		drain := d.pending.Bytes()
+		if idx, delimLen := findLastSSEFrameDelimiter(drain); idx >= 0 {
+			d.pending.Next(idx + delimLen)
+		} else {
+			trimTo := maxTerminalDetectorBufferBytes / 2
+			keptPrefix := append([]byte(nil), drain[:trimTo]...)
+			d.pending.Reset()
+			d.pending.Write(keptPrefix)
+		}
+	}
+	return false
+}
+
+func (d *StreamTerminalDetector) detectInUndelimitedPending() bool {
+	if d.pending.Len() == 0 {
+		return false
+	}
+	payload := bytes.TrimSpace(d.pending.Bytes())
+	if len(payload) == 0 {
+		return false
+	}
+	return hasFinishReasonMarker(payload)
+}
+
+func (d *StreamTerminalDetector) detectInFrame(frame []byte) bool {
+	payload := extractSSEDataPayload(frame)
+	if len(payload) == 0 {
+		return false
+	}
+
+	text := strings.TrimSpace(string(payload))
+	if text == "" {
+		return false
+	}
+	if text == "[DONE]" {
+		return true
+	}
+
+	return hasFinishReasonMarker([]byte(text))
+}
+
+func extractSSEDataPayload(frame []byte) []byte {
+	trimmed := bytes.TrimSpace(frame)
+	if len(trimmed) == 0 {
+		return nil
+	}
+	if !hasSSEDataLinePrefix(trimmed) {
+		return trimmed
+	}
+
+	lines := bytes.Split(trimmed, []byte("\n"))
+	var payload bytes.Buffer
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 || bytes.HasPrefix(line, []byte(":")) {
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("data:")) {
+			data := bytes.TrimSpace(bytes.TrimPrefix(line, []byte("data:")))
+			if len(data) == 0 {
+				continue
+			}
+			if payload.Len() > 0 {
+				payload.WriteByte('\n')
+			}
+			payload.Write(data)
+		}
+	}
+	if payload.Len() == 0 {
+		return nil
+	}
+	return payload.Bytes()
+}
+
+func hasSSEDataLinePrefix(frame []byte) bool {
+	lines := bytes.Split(frame, []byte("\n"))
+	for _, line := range lines {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 || bytes.HasPrefix(line, []byte(":")) {
+			continue
+		}
+		if bytes.HasPrefix(line, []byte("data:")) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasFinishReasonMarker(payload []byte) bool {
+	var root any
+	if err := sonic.Unmarshal(payload, &root); err != nil {
+		return false
+	}
+
+	switch v := root.(type) {
+	case map[string]any:
+		return hasTerminalMarkerInTopLevelObject(v)
+	case []any:
+		for _, item := range v {
+			obj, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if hasTerminalMarkerInTopLevelObject(obj) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasTerminalMarkerInTopLevelObject(root map[string]any) bool {
+	if hasValidFinishReasonValue(root) {
+		return true
+	}
+
+	// Gemini/Vertex streamGenerateContent often signals terminal state in
+	// top-level candidates[*].finishReason.
+	if candidatesValue, ok := root["candidates"]; ok {
+		if candidates, ok := candidatesValue.([]any); ok {
+			return allCandidatesFinished(candidates)
+		}
+	}
+
+	// usageMetadata can show up before terminal chunks in long-running streams.
+	// Treat it as terminal only when all candidates are finished.
+	if usageMetadata, ok := root["usageMetadata"]; ok {
+		if usageMap, ok := usageMetadata.(map[string]any); ok && len(usageMap) > 0 {
+			if candidatesValue, ok := root["candidates"]; ok {
+				if candidates, ok := candidatesValue.([]any); ok && allCandidatesFinished(candidates) {
+					return true
+				}
+			}
+		}
+	}
+	if promptFeedback, ok := root["promptFeedback"]; ok {
+		if feedbackMap, ok := promptFeedback.(map[string]any); ok {
+			if reason, ok := feedbackMap["blockReason"].(string); ok && strings.TrimSpace(reason) != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func allCandidatesFinished(candidates []any) bool {
+	if len(candidates) == 0 {
+		return false
+	}
+	for _, candidate := range candidates {
+		candidateMap, ok := candidate.(map[string]any)
+		if !ok {
+			return false
+		}
+		if !hasValidFinishReasonValue(candidateMap) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasValidFinishReasonValue(node map[string]any) bool {
+	for _, key := range []string{"finishReason", "finish_reason"} {
+		value, ok := node[key]
+		if !ok {
+			continue
+		}
+		if str, ok := value.(string); ok && strings.TrimSpace(str) != "" && str != "FINISH_REASON_UNSPECIFIED" {
+			return true
+		}
+	}
+	return false
+}
+
+func findFirstSSEFrameDelimiter(data []byte) (idx int, delimLen int) {
+	idxLF := bytes.Index(data, sseFrameDelimiterLF)
+	idxCRLF := bytes.Index(data, sseFrameDelimiterCRLF)
+
+	switch {
+	case idxLF < 0 && idxCRLF < 0:
+		return -1, 0
+	case idxLF < 0:
+		return idxCRLF, len(sseFrameDelimiterCRLF)
+	case idxCRLF < 0:
+		return idxLF, len(sseFrameDelimiterLF)
+	case idxCRLF < idxLF:
+		return idxCRLF, len(sseFrameDelimiterCRLF)
+	default:
+		return idxLF, len(sseFrameDelimiterLF)
+	}
+}
+
+func findLastSSEFrameDelimiter(data []byte) (idx int, delimLen int) {
+	idxLF := bytes.LastIndex(data, sseFrameDelimiterLF)
+	idxCRLF := bytes.LastIndex(data, sseFrameDelimiterCRLF)
+
+	switch {
+	case idxLF < 0 && idxCRLF < 0:
+		return -1, 0
+	case idxLF < 0:
+		return idxCRLF, len(sseFrameDelimiterCRLF)
+	case idxCRLF < 0:
+		return idxLF, len(sseFrameDelimiterLF)
+	case idxCRLF > idxLF:
+		return idxCRLF, len(sseFrameDelimiterCRLF)
+	default:
+		return idxLF, len(sseFrameDelimiterLF)
+	}
+}
+
+func containsSSEFrameDelimiter(data []byte) bool {
+	return bytes.Contains(data, sseFrameDelimiterLF) || bytes.Contains(data, sseFrameDelimiterCRLF)
+}

--- a/core/providers/utils/streamterminaldetector_test.go
+++ b/core/providers/utils/streamterminaldetector_test.go
@@ -1,0 +1,155 @@
+package utils
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestStreamTerminalDetectorObserveChunkSSEFinishReasonAcrossChunks(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+
+	chunks := [][]byte{
+		[]byte("data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hi\"}]},"),
+		[]byte("\"finishReason\":\"STOP\"}]}\n\n"),
+	}
+
+	if detector.ObserveChunk(chunks[0]) {
+		t.Fatalf("unexpected terminal detection on first chunk")
+	}
+	if !detector.ObserveChunk(chunks[1]) {
+		t.Fatalf("expected terminal detection for candidates finishReason")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkSSETopLevelFinishReasonAcrossChunks(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	chunks := [][]byte{
+		[]byte("data: {\"id\":\"abc\","),
+		[]byte("\"finishReason\":\"STOP\"}\n\n"),
+	}
+	if detector.ObserveChunk(chunks[0]) {
+		t.Fatalf("unexpected terminal detection on first chunk")
+	}
+	if !detector.ObserveChunk(chunks[1]) {
+		t.Fatalf("expected terminal detection for top-level finishReason")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkDoneMarker(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	if !detector.ObserveChunk([]byte("data: [DONE]\n\n")) {
+		t.Fatalf("expected [DONE] marker to be terminal")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkDoneMarkerCRLF(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	if !detector.ObserveChunk([]byte("data: [DONE]\r\n\r\n")) {
+		t.Fatalf("expected [DONE] marker with CRLF delimiter to be terminal")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkIgnoresUnspecifiedFinishReason(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	if detector.ObserveChunk([]byte("data: {\"finishReason\":\"FINISH_REASON_UNSPECIFIED\"}\n\n")) {
+		t.Fatalf("unexpected terminal detection for FINISH_REASON_UNSPECIFIED")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkPlainJSONAcrossChunks(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	if detector.ObserveChunk([]byte("{\"content\":\"hello\",")) {
+		t.Fatalf("unexpected terminal detection for incomplete json")
+	}
+	if !detector.ObserveChunk([]byte("\"finishReason\":\"STOP\"}")) {
+		t.Fatalf("expected terminal detection for plain json stream")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkJSONWithDataURITokenAndDelimiter(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	chunk := []byte("{\"finishReason\":\"STOP\",\"content\":{\"parts\":[{\"inlineData\":{\"mimeType\":\"image/png\",\"data\":\"data:image/png;base64,AAAA\"}}]}}\n\n")
+	if !detector.ObserveChunk(chunk) {
+		t.Fatalf("expected terminal detection for delimited JSON containing data URI token")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkMultiEventSSEInSingleChunk(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	chunk := []byte("data: {}\n\ndata: {\"finishReason\":\"STOP\"}\n\n")
+	if !detector.ObserveChunk(chunk) {
+		t.Fatalf("expected terminal detection for multi-event SSE chunk")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkMetadataOnlyFrameIsNotTerminal(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	if detector.ObserveChunk([]byte("data: {\"usageMetadata\":{\"totalTokenCount\":12}}\n\n")) {
+		t.Fatalf("unexpected terminal detection for metadata-only frame")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkMetadataWithFinishedCandidateIsTerminal(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	if !detector.ObserveChunk([]byte("data: {\"usageMetadata\":{\"totalTokenCount\":12},\"candidates\":[{\"finishReason\":\"STOP\"}]}\n\n")) {
+		t.Fatalf("expected terminal detection for metadata with finished candidate")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkMetadataWithUnspecifiedCandidateIsNotTerminal(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	if detector.ObserveChunk([]byte("data: {\"usageMetadata\":{\"totalTokenCount\":12},\"candidates\":[{\"finishReason\":\"FINISH_REASON_UNSPECIFIED\"}]}\n\n")) {
+		t.Fatalf("unexpected terminal detection for metadata with unfinished candidate")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkMetadataWithMixedCandidatesIsNotTerminal(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	if detector.ObserveChunk([]byte("data: {\"usageMetadata\":{\"totalTokenCount\":12},\"candidates\":[{\"finishReason\":\"STOP\"},{}]}\n\n")) {
+		t.Fatalf("unexpected terminal detection for metadata with mixed finished/unfinished candidates")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkTopLevelArrayWithCandidatesFinishReason(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	chunk := []byte("data: [{\"candidates\":[{\"finishReason\":\"STOP\"}]}]\n\n")
+	if !detector.ObserveChunk(chunk) {
+		t.Fatalf("expected terminal detection for top-level array payload")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkCandidatesRequireAllFinished(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	chunk := []byte("data: {\"candidates\":[{\"finishReason\":\"STOP\"},{\"finishReason\":\"FINISH_REASON_UNSPECIFIED\"}]}\n\n")
+	if detector.ObserveChunk(chunk) {
+		t.Fatalf("unexpected terminal detection when not all candidates are finished")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkCandidatesAllFinishedIsTerminal(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	chunk := []byte("data: {\"candidates\":[{\"finishReason\":\"STOP\"},{\"finishReason\":\"MAX_TOKENS\"}]}\n\n")
+	if !detector.ObserveChunk(chunk) {
+		t.Fatalf("expected terminal detection when all candidates are finished")
+	}
+}
+
+func TestStreamTerminalDetectorObserveChunkUndelimitedOverflowKeepsPrefix(t *testing.T) {
+	detector := &StreamTerminalDetector{}
+	originalPrefix := bytes.Repeat([]byte("a"), maxTerminalDetectorBufferBytes/2)
+	chunk := append([]byte(nil), originalPrefix...)
+	chunk = append(chunk, bytes.Repeat([]byte("b"), maxTerminalDetectorBufferBytes)...)
+
+	if detector.ObserveChunk(chunk) {
+		t.Fatalf("unexpected terminal detection for non-json buffer")
+	}
+
+	trimTo := maxTerminalDetectorBufferBytes / 2
+	got := detector.pending.Bytes()
+	if len(got) != trimTo {
+		t.Fatalf("expected pending length %d, got %d", trimTo, len(got))
+	}
+	if !bytes.Equal(got, originalPrefix) {
+		t.Fatalf("expected pending buffer to keep original prefix")
+	}
+}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -45,6 +45,8 @@ var vertexLocationsPathRe = regexp.MustCompile(`/locations/[^/]+`)
 
 var vertexProjectsPathRe = regexp.MustCompile(`/projects/[^/]+`)
 
+const maxStreamPassthroughCaptureBytes = 1024 * 1024
+
 // vertexBodyProjectsRe matches projects/{project} in body JSON values,
 // where the path may appear as "projects/X (after a JSON quote) or /projects/X (mid-path).
 var vertexBodyProjectsRe = regexp.MustCompile(`(["/])projects/[^/"]+`)
@@ -2998,8 +3000,6 @@ func (provider *VertexProvider) PassthroughStream(
 		requestURL += "?" + req.RawQuery
 	}
 
-	startTime := time.Now()
-
 	fasthttpReq := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
 	resp.StreamBody = true
@@ -3121,13 +3121,30 @@ func (provider *VertexProvider) PassthroughStream(
 		defer providerUtils.ReleaseStreamingResponse(resp)
 		defer stopIdleTimeout()
 		defer stopCancellation()
+		streamStart := time.Now()
 
+		fullResponseBody := make([]byte, 0, maxStreamPassthroughCaptureBytes)
+		fullResponseBodyTruncated := false
+		terminalDetector := &providerUtils.StreamTerminalDetector{}
 		buf := make([]byte, 4096)
 		for {
 			n, readErr := bodyStream.Read(buf)
 			if n > 0 {
 				chunk := make([]byte, n)
 				copy(chunk, buf[:n])
+				if !fullResponseBodyTruncated {
+					remaining := maxStreamPassthroughCaptureBytes - len(fullResponseBody)
+					if remaining > 0 {
+						if n <= remaining {
+							fullResponseBody = append(fullResponseBody, chunk...)
+						} else {
+							fullResponseBody = append(fullResponseBody, chunk[:remaining]...)
+							fullResponseBodyTruncated = true
+						}
+					} else {
+						fullResponseBodyTruncated = true
+					}
+				}
 				select {
 				case ch <- &schemas.BifrostStreamChunk{
 					BifrostPassthroughResponse: &schemas.BifrostPassthroughResponse{
@@ -3140,21 +3157,45 @@ func (provider *VertexProvider) PassthroughStream(
 				case <-ctx.Done():
 					return
 				}
+
+				// Vertex streamGenerateContent passthrough can emit terminal markers
+				// (finishReason) before the underlying HTTP body is closed.
+				// Finalize as success once this appears to avoid hanging clients.
+				if terminalDetector.ObserveChunk(chunk) {
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+					extraFields.Latency = time.Since(streamStart).Milliseconds()
+					var capturedBody []byte
+					if !fullResponseBodyTruncated {
+						capturedBody = append([]byte(nil), fullResponseBody...)
+					}
+					finalResp := &schemas.BifrostResponse{
+						PassthroughResponse: &schemas.BifrostPassthroughResponse{
+							StatusCode:  statusCode,
+							Headers:     headers,
+							Body:        capturedBody,
+							ExtraFields: extraFields,
+						},
+					}
+					postHookRunner(ctx, finalResp, nil)
+					return
+				}
 			}
 			if readErr == io.EOF {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-				extraFields.Latency = time.Since(startTime).Milliseconds()
+				extraFields.Latency = time.Since(streamStart).Milliseconds()
+				var capturedBody []byte
+				if !fullResponseBodyTruncated {
+					capturedBody = append([]byte(nil), fullResponseBody...)
+				}
 				finalResp := &schemas.BifrostResponse{
 					PassthroughResponse: &schemas.BifrostPassthroughResponse{
 						StatusCode:  statusCode,
 						Headers:     headers,
+						Body:        capturedBody,
 						ExtraFields: extraFields,
 					},
 				}
 				postHookRunner(ctx, finalResp, nil)
-				if postHookSpanFinalizer != nil {
-					postHookSpanFinalizer(ctx)
-				}
 				return
 			}
 			if readErr != nil {
@@ -3162,7 +3203,7 @@ func (provider *VertexProvider) PassthroughStream(
 					return // let defer handle cancel/timeout
 				}
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-				extraFields.Latency = time.Since(startTime).Milliseconds()
+				extraFields.Latency = time.Since(streamStart).Milliseconds()
 				providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, ch, provider.logger, postHookSpanFinalizer)
 				return
 			}

--- a/core/schemas/passthrough.go
+++ b/core/schemas/passthrough.go
@@ -11,10 +11,11 @@ type BifrostPassthroughRequest struct {
 }
 
 type BifrostPassthroughResponse struct {
-	StatusCode  int
-	Headers     map[string]string
-	Body        []byte
-	ExtraFields BifrostResponseExtraFields
+	StatusCode    int
+	Headers       map[string]string
+	Body          []byte
+	BodyTruncated bool
+	ExtraFields   BifrostResponseExtraFields
 }
 
 type PassthroughLogParams struct {

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -859,6 +859,12 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			if params, ok := entry.ParamsParsed.(*schemas.PassthroughLogParams); ok {
 				params.StatusCode = result.PassthroughResponse.StatusCode
 			}
+			if contentLoggingEnabled && len(result.PassthroughResponse.Body) > 0 {
+				entry.PassthroughResponseBody = string(result.PassthroughResponse.Body)
+				if shouldStoreRaw {
+					entry.RawResponse = string(result.PassthroughResponse.Body)
+				}
+			}
 			// Flip status for passthrough error responses (4xx/5xx from provider)
 			if isPassthroughErrorResponse(result) {
 				entry.Status = "error"

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -182,7 +182,6 @@ func TestUpdateLogEntrySuppressesChatOutputWhenContentLoggingDisabled(t *testing
 	}
 }
 
-
 func TestStoreOrEnqueueRetryPreservesAllEntries(t *testing.T) {
 	// Simulate fallback/retry scenario where multiple PostLLMHook calls
 	// store entries under the same traceID. All entries must be preserved.

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2757,6 +2757,10 @@ func (g *GenericRouter) handlePassthroughStream(
 	provider schemas.ModelProvider,
 	req *schemas.BifrostPassthroughRequest,
 ) {
+	// Deferred trace completion must be explicitly finalized after streaming ends.
+	// Without this, observability injectors (including logging) never flush final state.
+	traceCompleter, _ := ctx.UserValue(schemas.BifrostContextKeyTraceCompleter).(func([]schemas.PluginLogEntry))
+
 	stream, bifrostErr := g.client.PassthroughStream(bifrostCtx, provider, req)
 	if bifrostErr != nil {
 		cancel()
@@ -2819,6 +2823,9 @@ func (g *GenericRouter) handlePassthroughStream(
 
 	go func() {
 		defer func() {
+			if traceCompleter != nil {
+				traceCompleter(nil)
+			}
 			reader.Done()
 			cancel()
 		}()


### PR DESCRIPTION
## Summary

Passthrough streaming responses from Gemini and Vertex providers could hang clients because the underlying HTTP connection sometimes remains open after the model has finished generating (i.e., a semantic terminal marker such as `finishReason` or `[DONE]` appears before the TCP stream closes). This PR introduces early stream termination based on semantic content detection, accumulates the full response body for post-hook delivery, and ensures the logging plugin captures passthrough response bodies.

## Changes

- Introduced `StreamTerminalDetector` in `core/providers/utils`, which incrementally parses SSE-framed and plain-JSON stream chunks to detect terminal markers (`[DONE]`, non-empty `finishReason`, `finish_reason`) without waiting for `io.EOF`.
- Gemini and Vertex `PassthroughStream` implementations now accumulate the full response body in a `bytes.Buffer` and invoke `postHookRunner` + `postHookSpanFinalizer` immediately upon terminal marker detection, returning early rather than blocking until the HTTP body closes.
- The accumulated `fullResponseBody` is now attached to the `BifrostPassthroughResponse` on both the early-exit and the normal `io.EOF` paths, so post-hooks always receive the complete body.
- The logging plugin's `PostLLMHook` now writes `PassthroughResponse.Body` into `PassthroughResponseBody` (and `RawResponse` when raw logging is enabled), which was previously missing for passthrough calls.
- The HTTP transport's `handlePassthroughStream` now captures and invokes the `traceCompleter` after streaming ends, ensuring observability hooks flush their final state.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/utils/...
go test ./plugins/logging/...
go test ./...
```

To validate end-to-end:
1. Send a passthrough streaming request to a Gemini or Vertex endpoint that returns a `finishReason` before closing the connection.
2. Confirm the client receives all chunks and the connection closes promptly after the terminal marker rather than hanging.
3. Confirm the logging plugin records the full passthrough response body in the log entry.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The accumulated response body is held in memory only for the duration of the stream and is bounded by the existing idle-timeout and cancellation mechanisms. No PII handling changes are introduced; content logging of the passthrough body respects the existing `contentLoggingEnabled` flag.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable