### PR TITLE
chore: bump bifrost helm chart version to 2.1.2

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.1
+version: 2.1.2
 appVersion: "1.5.0"
 keywords:
   - ai


### PR DESCRIPTION
## Summary

Bumps the Bifrost Helm chart version from `2.1.1` to `2.1.2` to reflect recent changes and ensure proper versioning for chart releases.

## Changes

- Incremented Helm chart version to `2.1.2`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
helm lint helm-charts/bifrost
helm package helm-charts/bifrost
```

Verify the packaged chart reflects version `2.1.2`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable