### PR TITLE
[do not merge] feat: ollama integration

### DIFF
--- a/core/providers/ollama/chat.go
+++ b/core/providers/ollama/chat.go
@@ -1,0 +1,195 @@
+package ollama
+
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func (req *OllamaChatRequest) ToBifrostChatRequest() *schemas.BifrostChatRequest {
+	if req == nil {
+		return nil
+	}
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Ollama,
+		Model:    req.Model,
+		Input:    make([]schemas.ChatMessage, 0, len(req.Messages)),
+		Params: &schemas.ChatParameters{
+			LogProbs:    req.Logprobs,
+			TopLogProbs: req.TopLogprobs,
+			ExtraParams: make(map[string]any),
+		},
+		Fallbacks: schemas.ParseFallbacks(req.Fallbacks),
+	}
+
+	if req.Options != nil {
+		bifrostReq.Params.FrequencyPenalty = req.Options.FrequencyPenalty
+		bifrostReq.Params.PresencePenalty = req.Options.PresencePenalty
+		bifrostReq.Params.Temperature = req.Options.Temperature
+		bifrostReq.Params.Seed = req.Options.Seed
+		if len(req.Options.Stop) > 0 {
+			bifrostReq.Params.Stop = []string(req.Options.Stop)
+		}
+		bifrostReq.Params.TopP = req.Options.TopP
+		bifrostReq.Params.TopK = req.Options.TopK
+	}
+
+	if req.KeepAlive != nil {
+		bifrostReq.Params.ExtraParams["keep_alive"] = req.KeepAlive
+	}
+
+	if req.Think != nil {
+		switch v := req.Think.(type) {
+		case bool:
+			bifrostReq.Params.Reasoning = &schemas.ChatReasoning{Enabled: &v}
+		case string:
+			bifrostReq.Params.Reasoning = &schemas.ChatReasoning{Effort: &v}
+		}
+	}
+
+	for _, msg := range req.Messages {
+		var bifrostMsg schemas.ChatMessage
+		bifrostMsg.Role = schemas.ChatMessageRole(msg.Role)
+
+		if len(msg.ToolCalls) == 0 && len(msg.Images) == 0 {
+			if msg.Content != "" {
+				bifrostMsg.Content = &schemas.ChatMessageContent{ContentStr: &msg.Content}
+			}
+			bifrostReq.Input = append(bifrostReq.Input, bifrostMsg)
+			continue
+		}
+
+		var bifrostContentBlocks []schemas.ChatContentBlock
+		var bifrostToolCalls []schemas.ChatAssistantMessageToolCall
+
+		if msg.Content != "" {
+			bifrostContentBlocks = append(bifrostContentBlocks, schemas.ChatContentBlock{
+				Type: schemas.ChatContentBlockTypeText,
+				Text: &msg.Content,
+			})
+		}
+
+		if len(msg.Images) > 0 {
+			for _, base64Image := range msg.Images {
+				var bifrostContentBlock schemas.ChatContentBlock
+				bifrostContentBlock.Type = schemas.ChatContentBlockTypeImage
+				bifrostContentBlock.ImageURLStruct = &schemas.ChatInputImage{URL: base64Image}
+				bifrostContentBlocks = append(bifrostContentBlocks, bifrostContentBlock)
+			}
+			bifrostMsg.Content = &schemas.ChatMessageContent{ContentBlocks: bifrostContentBlocks}
+		}
+
+		if len(msg.ToolCalls) > 0 {
+			for _, toolCall := range msg.ToolCalls {
+				var bifrostToolCall schemas.ChatAssistantMessageToolCall
+				if toolCall.Function != nil {
+					bifrostToolCall = schemas.ChatAssistantMessageToolCall{
+						Type: schemas.Ptr("function"),
+						Function: schemas.ChatAssistantMessageToolCallFunction{
+							Name: &toolCall.Function.Name,
+						},
+					}
+				}
+				bifrostToolCalls = append(bifrostToolCalls, bifrostToolCall)
+			}
+			bifrostMsg.ChatAssistantMessage = &schemas.ChatAssistantMessage{ToolCalls: bifrostToolCalls}
+		}
+		bifrostReq.Input = append(bifrostReq.Input, bifrostMsg)
+	}
+
+	if len(req.Tools) > 0 {
+		var tools []schemas.ChatTool
+		for _, tool := range req.Tools {
+			var bifrostTool schemas.ChatTool
+			bifrostTool.Type = schemas.ChatToolType(tool.Type)
+			bifrostTool.Function = &schemas.ChatToolFunction{
+				Name:        tool.Function.Name,
+				Description: &tool.Function.Description,
+				Parameters:  tool.Function.Parameters,
+			}
+			tools = append(tools, bifrostTool)
+		}
+		bifrostReq.Params.Tools = tools
+	}
+
+	return bifrostReq
+}
+
+func ToOllamaChatResponse(resp *schemas.BifrostChatResponse) *OllamaChatResponse {
+	msg := OllamaChatMessage{Role: OllamaMessageRoleAssistant}
+	doneReason := ""
+	promptEval, evalCount := 0, 0
+
+	if len(resp.Choices) > 0 {
+		c := resp.Choices[0]
+		if c.ChatNonStreamResponseChoice != nil && c.ChatNonStreamResponseChoice.Message != nil {
+			m := c.ChatNonStreamResponseChoice.Message
+			if m.Content != nil && m.Content.ContentStr != nil {
+				msg.Content = *m.Content.ContentStr
+			}
+			if m.ChatAssistantMessage != nil {
+				msg.Thinking = m.ChatAssistantMessage.Reasoning
+				msg.ToolCalls = bifrostToolCallsToOllamaToolCalls(m.ChatAssistantMessage.ToolCalls)
+			}
+		}
+		if c.FinishReason != nil {
+			doneReason = *c.FinishReason
+		}
+	}
+	if resp.Usage != nil {
+		promptEval = resp.Usage.PromptTokens
+		evalCount = resp.Usage.CompletionTokens
+	}
+	return &OllamaChatResponse{
+		Model:   resp.Model,
+		Message: &msg,
+		OllamaCommonResponseFields: &OllamaCommonResponseFields{
+			Done:            true,
+			DoneReason:      doneReason,
+			PromptEvalCount: promptEval,
+			EvalCount:       evalCount,
+		},
+	}
+}
+
+// ToOllamaChatStreamChunk converts a streaming BifrostChatResponse to an NDJSON line.
+func ToOllamaChatStreamChunk(resp *schemas.BifrostChatResponse) (string, any, error) {
+	msg := OllamaChatMessage{Role: OllamaMessageRoleAssistant}
+	doneReason := ""
+	done := false
+
+	if len(resp.Choices) > 0 {
+		c := resp.Choices[0]
+		if c.ChatStreamResponseChoice != nil && c.ChatStreamResponseChoice.Delta != nil {
+			d := c.ChatStreamResponseChoice.Delta
+			if d.Content != nil {
+				msg.Content = *d.Content
+			}
+			if d.Reasoning != nil {
+				msg.Thinking = d.Reasoning
+			}
+			if len(d.ToolCalls) > 0 {
+				msg.ToolCalls = bifrostToolCallsToOllamaToolCalls(d.ToolCalls)
+			}
+		}
+		if c.FinishReason != nil {
+			done = true
+			doneReason = *c.FinishReason
+		}
+	}
+
+	chunk := &OllamaChatResponse{
+		Model:   resp.Model,
+		Message: &msg,
+		OllamaCommonResponseFields: &OllamaCommonResponseFields{
+			Done:       done,
+			DoneReason: doneReason,
+		},
+	}
+	if done && resp.Usage != nil {
+		chunk.PromptEvalCount = resp.Usage.PromptTokens
+		chunk.EvalCount = resp.Usage.CompletionTokens
+	}
+
+	json, err := NdjsonLine(chunk)
+	return "", json, err
+}

--- a/core/providers/ollama/embed.go
+++ b/core/providers/ollama/embed.go
@@ -1,0 +1,59 @@
+package ollama
+
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// ToBifrostEmbeddingRequest converts an OllamaEmbedRequest to a BifrostEmbeddingRequest.
+func (req *OllamaEmbedRequest) ToBifrostEmbeddingRequest() (*schemas.BifrostEmbeddingRequest, error) {
+	if req == nil {
+		return nil, nil
+	}
+
+	provider, model := schemas.ParseModelString(req.Model, schemas.Ollama)
+
+	var input schemas.EmbeddingInput
+	if len(req.Input) == 1 {
+		s := req.Input[0]
+		input.Text = &s
+	} else if len(req.Input) > 1 {
+		input.Texts = []string(req.Input)
+	}
+
+	var params *schemas.EmbeddingParameters
+	if req.Dimensions != nil || req.Truncate != nil || req.KeepAlive != "" {
+		params = &schemas.EmbeddingParameters{}
+		extra := make(map[string]any)
+		if req.Dimensions != nil {
+			extra["dimensions"] = *req.Dimensions
+		}
+		if req.Truncate != nil {
+			extra["truncate"] = *req.Truncate
+		}
+		if req.KeepAlive != "" {
+			extra["keep_alive"] = req.KeepAlive
+		}
+		if len(extra) > 0 {
+			params.ExtraParams = extra
+		}
+	}
+
+	return &schemas.BifrostEmbeddingRequest{
+		Provider: provider,
+		Model:    model,
+		Input:    &input,
+		Params:   params,
+	}, nil
+}
+
+// ToOllamaEmbedResponse converts a BifrostEmbeddingResponse to an OllamaEmbedResponse.
+func ToOllamaEmbedResponse(resp *schemas.BifrostEmbeddingResponse) *OllamaEmbedResponse {
+	embeddings := make([][]float64, 0, len(resp.Data))
+	for _, d := range resp.Data {
+		embeddings = append(embeddings, d.Embedding.EmbeddingArray)
+	}
+	return &OllamaEmbedResponse{
+		Model:      resp.Model,
+		Embeddings: embeddings,
+	}
+}

--- a/core/providers/ollama/generate.go
+++ b/core/providers/ollama/generate.go
@@ -1,0 +1,126 @@
+package ollama
+
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// ToBifrostTextCompletionRequest converts an OllamaGenerateRequest to a BifrostTextCompletionRequest.
+func (req *OllamaGenerateRequest) ToBifrostTextCompletionRequest() *schemas.BifrostTextCompletionRequest {
+	if req == nil {
+		return nil
+	}
+
+	provider, model := schemas.ParseModelString(req.Model, schemas.Ollama)
+
+	prompt := req.Prompt
+	if req.System != "" {
+		prompt = req.System + "\n\n" + prompt
+	}
+
+	bifrostReq := &schemas.BifrostTextCompletionRequest{
+		Provider: provider,
+		Model:    model,
+		Input:    &schemas.TextCompletionInput{PromptStr: &prompt},
+	}
+
+	params := &schemas.TextCompletionParameters{}
+	extra := make(map[string]any)
+
+	if req.Options != nil {
+		o := req.Options
+		params.Temperature = o.Temperature
+		params.TopP = o.TopP
+		params.Seed = o.Seed
+		params.MaxTokens = o.NumPredict
+		params.FrequencyPenalty = o.FrequencyPenalty
+		params.PresencePenalty = o.PresencePenalty
+		if len(o.Stop) > 0 {
+			params.Stop = []string(o.Stop)
+		}
+	}
+	if req.Suffix != "" {
+		params.Suffix = &req.Suffix
+	}
+	if req.TopLogprobs != nil {
+		params.LogProbs = req.TopLogprobs
+	}
+	if len(extra) > 0 {
+		params.ExtraParams = extra
+	}
+
+	bifrostReq.Params = params
+	return bifrostReq
+}
+
+// ToOllamaGenerateResponse converts a BifrostTextCompletionResponse to an OllamaGenerateResponse.
+func ToOllamaGenerateResponse(resp *schemas.BifrostTextCompletionResponse) *OllamaGenerateResponse {
+	text := ""
+	thinking := ""
+	doneReason := ""
+	promptEval, evalCount := 0, 0
+
+	if len(resp.Choices) > 0 {
+		c := resp.Choices[0]
+		text = extractGenerateText(c)
+		thinking = extractGenerateThinking(c)
+		if c.FinishReason != nil {
+			doneReason = *c.FinishReason
+		}
+	}
+	if resp.Usage != nil {
+		promptEval = resp.Usage.PromptTokens
+		evalCount = resp.Usage.CompletionTokens
+	}
+	return &OllamaGenerateResponse{
+		Model:           resp.Model,
+		Response:        text,
+		Thinking:        thinking,
+		Done:            true,
+		DoneReason:      doneReason,
+		PromptEvalCount: promptEval,
+		EvalCount:       evalCount,
+	}
+}
+
+// ToOllamaGenerateStreamChunk converts a streaming BifrostTextCompletionResponse to an NDJSON line.
+func ToOllamaGenerateStreamChunk(resp *schemas.BifrostTextCompletionResponse) (string, any, error) {
+	text := ""
+	thinking := ""
+	doneReason := ""
+	done := false
+
+	if len(resp.Choices) > 0 {
+		c := resp.Choices[0]
+		if c.ChatStreamResponseChoice != nil && c.ChatStreamResponseChoice.Delta != nil {
+			d := c.ChatStreamResponseChoice.Delta
+			if d.Content != nil {
+				text = *d.Content
+			}
+			if d.Reasoning != nil {
+				thinking = *d.Reasoning
+			}
+		} else {
+			text = extractGenerateText(c)
+			thinking = extractGenerateThinking(c)
+		}
+		if c.FinishReason != nil {
+			done = true
+			doneReason = *c.FinishReason
+		}
+	}
+
+	chunk := &OllamaGenerateResponse{
+		Model:      resp.Model,
+		Response:   text,
+		Thinking:   thinking,
+		Done:       done,
+		DoneReason: doneReason,
+	}
+	if done && resp.Usage != nil {
+		chunk.PromptEvalCount = resp.Usage.PromptTokens
+		chunk.EvalCount = resp.Usage.CompletionTokens
+	}
+
+	json, err := NdjsonLine(chunk)
+	return "", json, err
+}

--- a/core/providers/ollama/ollama.go
+++ b/core/providers/ollama/ollama.go
@@ -13,16 +13,6 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// OllamaProvider implements the Provider interface for Ollama's API.
-type OllamaProvider struct {
-	logger              schemas.Logger        // Logger for provider operations
-	client              *fasthttp.Client      // HTTP client for unary API requests (ReadTimeout bounds overall response)
-	streamingClient     *fasthttp.Client      // HTTP client for streaming API requests (no ReadTimeout; idle governed by NewIdleTimeoutReader)
-	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
-	sendBackRawRequest  bool                  // Whether to include raw request in BifrostResponse
-	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
-}
-
 // NewOllamaProvider creates a new Ollama provider instance.
 // It initializes the HTTP client with the provided configuration and sets up response pools.
 // The client is configured with timeouts, concurrency limits, and optional proxy settings.

--- a/core/providers/ollama/types.go
+++ b/core/providers/ollama/types.go
@@ -1,0 +1,217 @@
+package ollama
+
+import (
+	"errors"
+	"time"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// OllamaProvider implements the Provider interface for Ollama's API.
+type OllamaProvider struct {
+	logger              schemas.Logger        // Logger for provider operations
+	client              *fasthttp.Client      // HTTP client for unary API requests (ReadTimeout bounds overall response)
+	streamingClient     *fasthttp.Client      // HTTP client for streaming API requests (no ReadTimeout; idle governed by NewIdleTimeoutReader)
+	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
+	sendBackRawRequest  bool                  // Whether to include raw request in BifrostResponse
+	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
+}
+
+// OllamaChatRequest is the request type for Ollama's native /api/chat endpoint.
+type OllamaChatRequest struct {
+	Model       string              `json:"model"`
+	Messages    []OllamaChatMessage `json:"messages"`
+	Tools       []OllamaTool        `json:"tools,omitempty"`
+	Format      any                 `json:"format,omitempty"`     // "json" or JSON schema object
+	Think       any                 `json:"think,omitempty"`      // bool or "high"/"medium"/"low"
+	KeepAlive   any                 `json:"keep_alive,omitempty"` // string (e.g. "5m") or number (seconds)
+	Stream      *bool               `json:"stream,omitempty"`     // ollama defaults to true
+	Options     *OllamaOptions      `json:"options,omitempty"`
+	Logprobs    *bool               `json:"logprobs,omitempty"`
+	TopLogprobs *int                `json:"top_logprobs,omitempty"`
+
+	// Bifrost specific field
+	Fallbacks []string `json:"fallbacks,omitempty"`
+}
+
+// IsStreamingRequested implements the StreamingRequest interface
+func (r *OllamaChatRequest) IsStreamingRequested() bool {
+	return r.Stream == nil || *r.Stream
+}
+
+// OllamaChatResponse is the response type for Ollama's native /api/chat endpoint.
+type OllamaChatResponse struct {
+	Model     string             `json:"model"`
+	CreatedAt time.Time          `json:"created_at"`
+	Message   *OllamaChatMessage `json:"message"`
+
+	*OllamaCommonResponseFields
+}
+
+type OllamaCommonResponseFields struct {
+	Done               bool   `json:"done"`
+	DoneReason         string `json:"done_reason"`
+	TotalDuration      int    `json:"total_duration"`
+	LoadDuration       int    `json:"load_duration"`
+	PromptEvalCount    int    `json:"prompt_eval_count"`
+	PromptEvalDuration int    `json:"prompt_eval_duration"`
+	EvalCount          int    `json:"eval_count"`
+	EvalDuration       int    `json:"eval_duration"`
+	LogProbs           []struct {
+		OllamaLogProb
+		TopLogprobs []OllamaLogProb `json:"top_logprobs,omitempty"`
+	} `json:"logprobs,omitempty"`
+}
+
+type OllamaLogProb struct {
+	Token   string  `json:"token"`
+	Logprob float64 `json:"logprob"`
+	Bytes   []byte  `json:"bytes,omitempty"`
+}
+
+type OllamaMessageRole string
+
+const (
+	OllamaMessageRoleSystem    OllamaMessageRole = "system"
+	OllamaMessageRoleUser      OllamaMessageRole = "user"
+	OllamaMessageRoleAssistant OllamaMessageRole = "assistant"
+	OllamaMessageRoleTool      OllamaMessageRole = "tool"
+)
+
+type OllamaChatMessage struct {
+	Role      OllamaMessageRole `json:"role"`
+	Content   string            `json:"content"`
+	Images    []string          `json:"images,omitempty"`
+	ToolCalls []OllamaToolCall  `json:"tool_calls,omitempty"`
+	Thinking  *string           `json:"thinking,omitempty"`
+}
+
+type OllamaToolType string
+
+const (
+	OllamaToolTypeFunction OllamaToolType = "function"
+)
+
+// OllamaTool is the tool definition for ollama
+type OllamaTool struct {
+	Type     OllamaToolType      `json:"type"`
+	Function *OllamaToolFunction `json:"function"`
+}
+
+// OllamaToolCall is the tool call for ollama
+type OllamaToolCall struct {
+	Function *OllamaToolFunction `json:"function"`
+}
+
+type OllamaToolFunction struct {
+	Name        string                          `json:"name"`
+	Parameters  *schemas.ToolFunctionParameters `json:"arguments"`
+	Description string                          `json:"description,omitempty"`
+}
+
+// OllamaEmbedInput is a []string that unmarshals from either a JSON string or array of strings.
+type OllamaEmbedInput []string
+
+func (e *OllamaEmbedInput) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := sonic.Unmarshal(data, &s); err == nil {
+		*e = OllamaEmbedInput{s}
+		return nil
+	}
+	var ss []string
+	if err := sonic.Unmarshal(data, &ss); err == nil {
+		*e = OllamaEmbedInput(ss)
+		return nil
+	}
+	return errors.New("input must be a string or array of strings")
+}
+
+// OllamaEmbedRequest is the request type for Ollama's /api/embed endpoint.
+type OllamaEmbedRequest struct {
+	Model      string           `json:"model"`
+	Input      OllamaEmbedInput `json:"input"`
+	Truncate   *bool            `json:"truncate,omitempty"`
+	Dimensions *int             `json:"dimensions,omitempty"`
+	KeepAlive  string           `json:"keep_alive,omitempty"`
+	Options    *OllamaOptions   `json:"options,omitempty"`
+}
+
+// OllamaEmbedResponse is the response for /api/embed.
+type OllamaEmbedResponse struct {
+	Model           string      `json:"model"`
+	Embeddings      [][]float64 `json:"embeddings"`
+	TotalDuration   int64       `json:"total_duration,omitempty"`
+	LoadDuration    int64       `json:"load_duration,omitempty"`
+	PromptEvalCount int         `json:"prompt_eval_count,omitempty"`
+}
+
+// OllamaGenerateRequest is the request type for Ollama's /api/generate endpoint.
+type OllamaGenerateRequest struct {
+	Model       string         `json:"model"`
+	Prompt      string         `json:"prompt,omitempty"`
+	Suffix      string         `json:"suffix,omitempty"`
+	Images      []string       `json:"images,omitempty"`
+	System      string         `json:"system,omitempty"`
+	Format      any            `json:"format,omitempty"` // "json" or JSON schema object
+	Think       any            `json:"think,omitempty"`  // bool or "high"/"medium"/"low"
+	Raw         *bool          `json:"raw,omitempty"`
+	KeepAlive   any            `json:"keep_alive,omitempty"` // string (e.g. "5m") or number (seconds)
+	Stream      *bool          `json:"stream,omitempty"`     // ollama defaults to true
+	Options     *OllamaOptions `json:"options,omitempty"`
+	Logprobs    *bool          `json:"logprobs,omitempty"`
+	TopLogprobs *int           `json:"top_logprobs,omitempty"`
+}
+
+// IsStreamingRequested implements the StreamingRequest interface.
+func (r *OllamaGenerateRequest) IsStreamingRequested() bool {
+	return r.Stream == nil || *r.Stream
+}
+
+// OllamaGenerateResponse is the response for /api/generate (streaming and non-streaming).
+type OllamaGenerateResponse struct {
+	Model              string `json:"model"`
+	CreatedAt          string `json:"created_at"`
+	Response           string `json:"response"`
+	Thinking           string `json:"thinking,omitempty"`
+	Done               bool   `json:"done"`
+	DoneReason         string `json:"done_reason,omitempty"`
+	TotalDuration      int64  `json:"total_duration,omitempty"`
+	LoadDuration       int64  `json:"load_duration,omitempty"`
+	PromptEvalCount    int    `json:"prompt_eval_count,omitempty"`
+	PromptEvalDuration int64  `json:"prompt_eval_duration,omitempty"`
+	EvalCount          int    `json:"eval_count,omitempty"`
+	EvalDuration       int64  `json:"eval_duration,omitempty"`
+}
+
+// OllamaOptions holds Ollama model generation options.
+type OllamaOptions struct {
+	Temperature      *float64      `json:"temperature,omitempty"`
+	TopP             *float64      `json:"top_p,omitempty"`
+	TopK             *int          `json:"top_k,omitempty"`
+	MinP             *float64      `json:"min_p,omitempty"`
+	Seed             *int          `json:"seed,omitempty"`
+	NumPredict       *int          `json:"num_predict,omitempty"`
+	NumCtx           *int          `json:"num_ctx,omitempty"`
+	Stop             OllamaStopSeq `json:"stop,omitempty"`
+	FrequencyPenalty *float64      `json:"frequency_penalty,omitempty"`
+	PresencePenalty  *float64      `json:"presence_penalty,omitempty"`
+}
+
+// OllamaStopSeq unmarshals from either a JSON string or an array of strings.
+type OllamaStopSeq []string
+
+func (s *OllamaStopSeq) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := sonic.Unmarshal(data, &str); err == nil {
+		*s = OllamaStopSeq{str}
+		return nil
+	}
+	var arr []string
+	if err := sonic.Unmarshal(data, &arr); err == nil {
+		*s = OllamaStopSeq(arr)
+		return nil
+	}
+	return errors.New("stop must be a string or array of strings")
+}

--- a/core/providers/ollama/utils.go
+++ b/core/providers/ollama/utils.go
@@ -1,0 +1,56 @@
+package ollama
+
+import (
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// ndjsonLine marshals v and appends a newline (the NDJSON streaming wire format).
+func NdjsonLine(v any) (string, error) {
+	b, err := sonic.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(b) + "\n", nil
+}
+
+// bifrostToolCallsToOllamaToolCalls converts Bifrost tool calls to ollama tool calls.
+func bifrostToolCallsToOllamaToolCalls(calls []schemas.ChatAssistantMessageToolCall) []OllamaToolCall {
+	if len(calls) == 0 {
+		return nil
+	}
+	result := make([]OllamaToolCall, 0, len(calls))
+	for _, tc := range calls {
+		fc := OllamaToolFunction{}
+		if tc.Function.Name != nil {
+			fc.Name = *tc.Function.Name
+		}
+		result = append(result, OllamaToolCall{Function: &fc})
+	}
+	return result
+}
+
+// extractGenerateText pulls the generated text from any response choice variant.
+func extractGenerateText(c schemas.BifrostResponseChoice) string {
+	if c.TextCompletionResponseChoice != nil && c.TextCompletionResponseChoice.Text != nil {
+		return *c.TextCompletionResponseChoice.Text
+	}
+	if c.ChatNonStreamResponseChoice != nil && c.ChatNonStreamResponseChoice.Message != nil {
+		m := c.ChatNonStreamResponseChoice.Message
+		if m.Content != nil && m.Content.ContentStr != nil {
+			return *m.Content.ContentStr
+		}
+	}
+	return ""
+}
+
+// extractGenerateThinking pulls the reasoning/thinking text from a non-stream choice.
+func extractGenerateThinking(c schemas.BifrostResponseChoice) string {
+	if c.ChatNonStreamResponseChoice != nil && c.ChatNonStreamResponseChoice.Message != nil {
+		m := c.ChatNonStreamResponseChoice.Message
+		if m.ChatAssistantMessage != nil && m.ChatAssistantMessage.Reasoning != nil {
+			return *m.ChatAssistantMessage.Reasoning
+		}
+	}
+	return ""
+}

--- a/transports/bifrost-http/handlers/integrations.go
+++ b/transports/bifrost-http/handlers/integrations.go
@@ -32,6 +32,7 @@ func NewIntegrationHandler(client *bifrost.Bifrost, handlerStore lib.HandlerStor
 		integrations.NewLangChainRouter(client, handlerStore, logger),
 		integrations.NewPydanticAIRouter(client, handlerStore, logger),
 		integrations.NewBedrockRouter(client, handlerStore, logger),
+		integrations.NewOllamaRouter(client, handlerStore, logger),
 		// passthrough routers
 		integrations.NewGenAIPassthroughRouter(client, handlerStore, logger),
 		integrations.NewOpenAIPassthroughRouter(client, handlerStore, logger),

--- a/transports/bifrost-http/integrations/ollama.go
+++ b/transports/bifrost-http/integrations/ollama.go
@@ -1,0 +1,147 @@
+package integrations
+
+import (
+	"context"
+	"errors"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	ollama "github.com/maximhq/bifrost/core/providers/ollama"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// OllamaRouter handles Ollama-compatible API endpoints.
+type OllamaRouter struct {
+	*GenericRouter
+}
+
+// OllamaErrorResponse is the error response for Ollama.
+type OllamaErrorResponse struct {
+	Error string `json:"error"`
+}
+
+func toOllamaErrorResponse(err *schemas.BifrostError) *OllamaErrorResponse {
+	if err.Error != nil {
+		return &OllamaErrorResponse{Error: err.Error.Message}
+	}
+	return &OllamaErrorResponse{Error: "an unknown error occurred"}
+}
+
+// CreateOllamaRouteConfigs returns route configurations for Ollama-compatible endpoints.
+func CreateOllamaRouteConfigs(pathPrefix string) []RouteConfig {
+	var routes []RouteConfig
+
+	// POST /api/generate → text completion
+	routes = append(routes, RouteConfig{
+		Type:   RouteConfigTypeOllama,
+		Path:   pathPrefix + "/api/generate",
+		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.TextCompletionRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) any {
+			return &ollama.OllamaGenerateRequest{}
+		},
+		RequestConverter: func(ctx *schemas.BifrostContext, req any) (*schemas.BifrostRequest, error) {
+			r, ok := req.(*ollama.OllamaGenerateRequest)
+			if !ok {
+				return nil, errors.New("invalid request type for ollama generate")
+			}
+			return &schemas.BifrostRequest{
+				TextCompletionRequest: r.ToBifrostTextCompletionRequest(),
+			}, nil
+		},
+		TextResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostTextCompletionResponse) (any, error) {
+			return ollama.ToOllamaGenerateResponse(resp), nil
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) any {
+			return toOllamaErrorResponse(err)
+		},
+		StreamConfig: &StreamConfig{
+			TextStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostTextCompletionResponse) (string, any, error) {
+				return ollama.ToOllamaGenerateStreamChunk(resp)
+			},
+			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) any {
+				line, _ := ollama.NdjsonLine(toOllamaErrorResponse(err))
+				return line
+			},
+		},
+	})
+
+	// POST /api/chat → chat completion
+	routes = append(routes, RouteConfig{
+		Type:   RouteConfigTypeOllama,
+		Path:   pathPrefix + "/api/chat",
+		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.ChatCompletionRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) any {
+			return &ollama.OllamaChatRequest{}
+		},
+		RequestConverter: func(ctx *schemas.BifrostContext, req any) (*schemas.BifrostRequest, error) {
+			r, ok := req.(*ollama.OllamaChatRequest)
+			if !ok {
+				return nil, errors.New("invalid request type for ollama chat")
+			}
+			return &schemas.BifrostRequest{
+				ChatRequest: r.ToBifrostChatRequest(),
+			}, nil
+		},
+		ChatResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostChatResponse) (any, error) {
+			return ollama.ToOllamaChatResponse(resp), nil
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) any {
+			return toOllamaErrorResponse(err)
+		},
+		StreamConfig: &StreamConfig{
+			ChatStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostChatResponse) (string, any, error) {
+				return ollama.ToOllamaChatStreamChunk(resp)
+			},
+			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) any {
+				line, _ := ollama.NdjsonLine(toOllamaErrorResponse(err))
+				return line
+			},
+		},
+	})
+
+	// POST /api/embed → embeddings
+	routes = append(routes, RouteConfig{
+		Type:   RouteConfigTypeOllama,
+		Path:   pathPrefix + "/api/embed",
+		Method: "POST",
+		GetHTTPRequestType: func(ctx *fasthttp.RequestCtx) schemas.RequestType {
+			return schemas.EmbeddingRequest
+		},
+		GetRequestTypeInstance: func(ctx context.Context) any {
+			return &ollama.OllamaEmbedRequest{}
+		},
+		RequestConverter: func(ctx *schemas.BifrostContext, req any) (*schemas.BifrostRequest, error) {
+			r, ok := req.(*ollama.OllamaEmbedRequest)
+			if !ok {
+				return nil, errors.New("invalid request type for ollama embed")
+			}
+			bifrostReq, err := r.ToBifrostEmbeddingRequest()
+			if err != nil {
+				return nil, err
+			}
+			return &schemas.BifrostRequest{EmbeddingRequest: bifrostReq}, nil
+		},
+		EmbeddingResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostEmbeddingResponse) (any, error) {
+			return ollama.ToOllamaEmbedResponse(resp), nil
+		},
+		ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) any {
+			return toOllamaErrorResponse(err)
+		},
+	})
+
+	return routes
+}
+
+// NewOllamaRouter creates a new OllamaRouter.
+func NewOllamaRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *OllamaRouter {
+	return &OllamaRouter{
+		GenericRouter: NewGenericRouter(client, handlerStore, CreateOllamaRouteConfigs("/ollama"), nil, logger),
+	}
+}

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -395,6 +395,7 @@ const (
 	RouteConfigTypeGenAI     RouteConfigType = "genai"
 	RouteConfigTypeBedrock   RouteConfigType = "bedrock"
 	RouteConfigTypeCohere    RouteConfigType = "cohere"
+	RouteConfigTypeOllama    RouteConfigType = "ollama"
 )
 
 // RouteConfig defines the configuration for a single route in an integration.
@@ -2250,6 +2251,8 @@ func (g *GenericRouter) handleStreamingRequest(ctx *fasthttp.RequestCtx, config 
 	if config.Type == RouteConfigTypeBedrock {
 		ctx.SetContentType("application/vnd.amazon.eventstream")
 		ctx.Response.Header.Set("x-amzn-bedrock-content-type", "application/json")
+	} else if config.Type == RouteConfigTypeOllama {
+		ctx.SetContentType("application/x-ndjson")
 	} else {
 		ctx.SetContentType("text/event-stream")
 	}
@@ -2529,11 +2532,14 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 					continue
 				}
 
-				// Build and send SSE event
+				// Build and send SSE/NDJSON event
 				var buf []byte
 				var sent bool
 				if sseString, ok := convertedResponse.(string); ok {
-					if strings.HasPrefix(sseString, "data: ") || strings.HasPrefix(sseString, "event: ") {
+					if config.Type == RouteConfigTypeOllama {
+						// NDJSON format: send raw JSON line directly (no SSE wrapper)
+						sent = reader.Send([]byte(sseString))
+					} else if strings.HasPrefix(sseString, "data: ") || strings.HasPrefix(sseString, "event: ") {
 						// Pre-formatted SSE string (e.g. Anthropic custom event types)
 						if eventType != "" {
 							// Prepend event type line to pre-formatted data
@@ -2570,7 +2576,7 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 		//   - OpenAI "responses" API and Anthropic messages API: they signal completion by simply closing the stream, not sending [DONE].
 		//   - Bedrock: uses AWS Event Stream format rather than SSE with [DONE].
 		// Bifrost handles any additional cleanup internally on normal stream completion.
-		if shouldSendDoneMarker && config.Type != RouteConfigTypeGenAI && config.Type != RouteConfigTypeBedrock {
+		if shouldSendDoneMarker && config.Type != RouteConfigTypeGenAI && config.Type != RouteConfigTypeBedrock && config.Type != RouteConfigTypeOllama {
 			if !reader.SendDone() {
 				g.logger.Warn("Failed to write SSE done marker: client disconnected")
 				cancel()

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -28,6 +28,7 @@ var availableIntegrations = []string{
 	"bedrock",
 	"pydantic",
 	"cohere",
+	"ollama",
 }
 
 // newBifrostErrorWithCode is like newBifrostError but sets an explicit HTTP status code.


### PR DESCRIPTION
## Summary

Adds an Ollama-compatible HTTP integration to the Bifrost transport layer, enabling clients that use the Ollama API to route requests through Bifrost without modification.

## Changes

- Added `OllamaRouter` with route handlers for `/ollama/api/generate` (text completion), `/ollama/api/chat` (chat completion), and `/ollama/api/embed` (embeddings)
- Implemented full request/response conversion between Ollama wire format and Bifrost internal schemas, including:
    - `OllamaOptions` mapped to `ChatParameters` and `TextCompletionParameters`
    - Ollama's `think` field mapped to Bifrost's `ChatReasoning` (supports both bool and effort string values)
    - Ollama's `format` field mapped to `ResponseFormat` (`"json"` → `json_object`, or pass-through for JSON schema objects)
    - Tool definitions and tool calls converted bidirectionally, with Bifrost's stringified arguments unparsed back to JSON objects for Ollama responses
    - Image content in messages converted to base64 data URL content blocks
    - `OllamaStop` custom unmarshaler handles both string and array forms
- Streaming uses NDJSON (`application/x-ndjson`) rather than SSE; raw JSON lines are written directly without SSE wrapping or a `[DONE]` terminator
- Registered `RouteConfigTypeOllama` in the router and wired the new router into the integration handler chain
- Added `"ollama"` to the available integrations list

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/...

# Start the Bifrost HTTP transport and send an Ollama-style chat request
curl -X POST http://localhost:8080/ollama/api/chat \
  -H "Content-Type: application/json" \
  -d '{"model": "ollama/llama3", "messages": [{"role": "user", "content": "Hello"}], "stream": false}'

# Test streaming
curl -X POST http://localhost:8080/ollama/api/chat \
  -H "Content-Type: application/json" \
  -d '{"model": "ollama/llama3", "messages": [{"role": "user", "content": "Hello"}], "stream": true}'

# Test embeddings
curl -X POST http://localhost:8080/ollama/api/embed \
  -H "Content-Type: application/json" \
  -d '{"model": "ollama/nomic-embed-text", "input": "Hello world"}'
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth mechanisms introduced. Requests follow the same handler and middleware chain as existing integrations.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable