### PR TITLE
bedrock: align BedrockGuardrailTrace with the AWS Converse API schema

### DIFF
--- a/core/providers/bedrock/guardrail_trace_test.go
+++ b/core/providers/bedrock/guardrail_trace_test.go
@@ -73,7 +73,7 @@ func TestBedrockGuardrailTrace_DecodesAWSConverseShape(t *testing.T) {
 }
 
 // TestBedrockGuardrailTrace_DecodesEmptyTrace covers the non-blocked path
-// described in #2772 — a request with `trace = "enabled"` that does not
+// described in #2772, a request with `trace = "enabled"` that does not
 // trip any policy used to fail to decode because the previous schema
 // required slice fields. The empty payload here is what the runtime emits
 // in that scenario.

--- a/core/providers/bedrock/guardrail_trace_test.go
+++ b/core/providers/bedrock/guardrail_trace_test.go
@@ -1,0 +1,87 @@
+package bedrock_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/providers/bedrock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBedrockGuardrailTrace_DecodesAWSConverseShape verifies that the
+// BedrockGuardrailTrace struct deserialises a payload that matches the
+// AWS Bedrock Runtime GuardrailTraceAssessment schema:
+//
+//	https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_GuardrailTraceAssessment.html
+//
+// In particular it pins:
+//   - inputAssessment is a map keyed by guardrail ID (singular, not a slice);
+//   - outputAssessments is a map whose values are arrays of assessments;
+//   - actionReason and modelOutput are surfaced (#2772).
+//
+// The payload below mirrors the shape AWS returns when a Converse request
+// runs with a guardrail attached and `trace = "enabled"`. Before this
+// schema fix, sonic.Unmarshal failed on this exact response shape because
+// inputAssessment was modelled as a []BedrockGuardrailAssessment slice.
+func TestBedrockGuardrailTrace_DecodesAWSConverseShape(t *testing.T) {
+	payload := []byte(`{
+        "action": "GUARDRAIL_INTERVENED",
+        "actionReason": "Guardrail blocked the request",
+        "modelOutput": ["redacted"],
+        "inputAssessment": {
+            "abc123": {
+                "topicPolicy": {
+                    "topics": [
+                        {"name": "Investment Advice", "type": "DENY", "action": "BLOCKED"}
+                    ]
+                }
+            }
+        },
+        "outputAssessments": {
+            "abc123": [
+                {
+                    "contentPolicy": {
+                        "filters": [
+                            {"type": "VIOLENCE", "confidence": "HIGH", "action": "BLOCKED"}
+                        ]
+                    }
+                }
+            ]
+        }
+    }`)
+
+	var trace bedrock.BedrockGuardrailTrace
+	require.NoError(t, json.Unmarshal(payload, &trace), "payload matching AWS schema must deserialise")
+
+	require.NotNil(t, trace.Action)
+	assert.Equal(t, "GUARDRAIL_INTERVENED", *trace.Action)
+
+	require.NotNil(t, trace.ActionReason)
+	assert.Equal(t, "Guardrail blocked the request", *trace.ActionReason)
+
+	assert.Equal(t, []string{"redacted"}, trace.ModelOutput)
+
+	require.Contains(t, trace.InputAssessment, "abc123",
+		"inputAssessment must be keyed by guardrail ID (singular map, not a slice)")
+	assert.NotNil(t, trace.InputAssessment["abc123"].TopicPolicy)
+
+	require.Contains(t, trace.OutputAssessments, "abc123",
+		"outputAssessments must be keyed by guardrail ID with array values")
+	require.Len(t, trace.OutputAssessments["abc123"], 1)
+	assert.NotNil(t, trace.OutputAssessments["abc123"][0].ContentPolicy)
+}
+
+// TestBedrockGuardrailTrace_DecodesEmptyTrace covers the non-blocked path
+// described in #2772 — a request with `trace = "enabled"` that does not
+// trip any policy used to fail to decode because the previous schema
+// required slice fields. The empty payload here is what the runtime emits
+// in that scenario.
+func TestBedrockGuardrailTrace_DecodesEmptyTrace(t *testing.T) {
+	var trace bedrock.BedrockGuardrailTrace
+	require.NoError(t, json.Unmarshal([]byte(`{}`), &trace))
+	assert.Nil(t, trace.Action)
+	assert.Nil(t, trace.ActionReason)
+	assert.Empty(t, trace.InputAssessment)
+	assert.Empty(t, trace.OutputAssessments)
+}

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -411,12 +411,16 @@ type BedrockConverseTrace struct {
 	Guardrail *BedrockGuardrailTrace `json:"guardrail,omitempty"` // Guardrail trace details
 }
 
-// BedrockGuardrailTrace represents detailed guardrail trace information
+// BedrockGuardrailTrace represents detailed guardrail trace information.
+// Field shapes match the AWS Bedrock Runtime GuardrailTraceAssessment type:
+//   https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_GuardrailTraceAssessment.html
+// InputAssessment is a map keyed by guardrail ID (singular, per the AWS API),
+// and OutputAssessments is a map whose values are arrays of assessments.
 type BedrockGuardrailTrace struct {
-	Action            *string                      `json:"action,omitempty"`            // Action taken by guardrail
-	InputAssessments  []BedrockGuardrailAssessment `json:"inputAssessments,omitempty"`  // Input assessments
-	OutputAssessments []BedrockGuardrailAssessment `json:"outputAssessments,omitempty"` // Output assessments
-	Trace             *BedrockGuardrailTraceDetail `json:"trace,omitempty"`             // Detailed trace information
+	Action            *string                                 `json:"action,omitempty"`          // Action taken by guardrail
+	InputAssessment   map[string]BedrockGuardrailAssessment   `json:"inputAssessment,omitempty"` // Input assessments, keyed by guardrail ID
+	OutputAssessments map[string][]BedrockGuardrailAssessment `json:"outputAssessments,omitempty"` // Output assessments, keyed by guardrail ID
+	Trace             *BedrockGuardrailTraceDetail            `json:"trace,omitempty"`           // Detailed trace information
 }
 
 // BedrockGuardrailAssessment represents a guardrail assessment

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -417,10 +417,12 @@ type BedrockConverseTrace struct {
 // InputAssessment is a map keyed by guardrail ID (singular, per the AWS API),
 // and OutputAssessments is a map whose values are arrays of assessments.
 type BedrockGuardrailTrace struct {
-	Action            *string                                 `json:"action,omitempty"`          // Action taken by guardrail
-	InputAssessment   map[string]BedrockGuardrailAssessment   `json:"inputAssessment,omitempty"` // Input assessments, keyed by guardrail ID
+	Action            *string                                 `json:"action,omitempty"`            // Action taken by guardrail
+	ActionReason      *string                                 `json:"actionReason,omitempty"`      // Reason for the guardrail action
+	InputAssessment   map[string]BedrockGuardrailAssessment   `json:"inputAssessment,omitempty"`   // Input assessments, keyed by guardrail ID
+	ModelOutput       []string                                `json:"modelOutput,omitempty"`       // Model output assessed by the guardrail
 	OutputAssessments map[string][]BedrockGuardrailAssessment `json:"outputAssessments,omitempty"` // Output assessments, keyed by guardrail ID
-	Trace             *BedrockGuardrailTraceDetail            `json:"trace,omitempty"`           // Detailed trace information
+	Trace             *BedrockGuardrailTraceDetail            `json:"trace,omitempty"`             // Detailed trace information
 }
 
 // BedrockGuardrailAssessment represents a guardrail assessment


### PR DESCRIPTION
## Summary

Aligns `BedrockGuardrailTrace` in `core/providers/bedrock/types.go` with the actual AWS Bedrock Runtime `GuardrailTraceAssessment` schema, so that `sonic.Unmarshal` stops failing on non-blocked requests when `trace` is enabled on the guardrail.

Fixes #2772.

## Root cause

`GuardrailTraceAssessment` from the AWS Runtime API:

| Field | Official shape |
| --- | --- |
| `inputAssessment` | `map<string, GuardrailAssessment>`, **singular**, keyed by guardrail ID |
| `outputAssessments` | `map<string, GuardrailAssessment[]>`, **plural**, keyed by guardrail ID, values are arrays |

Bifrost's struct declared both as flat `[]BedrockGuardrailAssessment`, and the input field used the plural JSON tag `inputAssessments`:

- `InputAssessment` was silently dropped because the JSON key didn't match.
- `outputAssessments` hit a type mismatch (object → slice), causing `sonic.Unmarshal` to fail with `Mismatch type []bedrock.BedrockGuardrailAssessment with value object` and the Bedrock response body to fail parsing.

This only surfaces when the guardrail **passes**, on a blocked-at-input response, Bedrock doesn't include `outputAssessments`, so the unmarshal happens to succeed.

## Change

- Rename `InputAssessments` → `InputAssessment` and retype as `map[string]BedrockGuardrailAssessment` with JSON tag `inputAssessment`.
- Retype `OutputAssessments` as `map[string][]BedrockGuardrailAssessment`. Tag (`outputAssessments`) unchanged.

## Call-site impact

Verified via `gh api` code search that `InputAssessments` and `OutputAssessments` are not referenced anywhere else in the repository, the fields only appear in `types.go`. No call-site updates are required.

## Testing

- `go build ./...` passes.
- Replaying a recorded Bedrock Converse response with `guardrailConfig.trace=enabled` and a passed guardrail: `sonic.Unmarshal` succeeds on the fixed struct, `InputAssessment[<guardrail-id>]` and `OutputAssessments[<guardrail-id>][0]` populate correctly.