### PR TITLE
fix: remove redundant static header assignment in tool execution

### DIFF
--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -710,12 +709,6 @@ func (m *ToolsManager) executeToolInternal(ctx *schemas.BifrostContext, toolCall
 		}
 
 		callRequest.Header = utils.BuildPerUserOAuthHeaders(callRequest.Header, accessToken)
-	} else if client.ExecutionConfig.Headers != nil {
-		headers := make(http.Header)
-		for key, value := range client.ExecutionConfig.Headers {
-			headers.Add(key, value.GetValue())
-		}
-		callRequest.Header = headers
 	}
 
 	// Create timeout context for tool execution


### PR DESCRIPTION
## Summary

Removes the fallback logic that manually applied static headers from `ExecutionConfig.Headers` when OAuth was not in use during tool execution. This eliminates a redundant or incorrect header-injection path in the tool execution flow.

## Changes

- Removed the `else if` branch in `executeToolInternal` that constructed and assigned `http.Header` from `client.ExecutionConfig.Headers` when no OAuth access token was present. This path was either duplicating header application that happens elsewhere or applying headers that should not be set at this stage.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./...
```

Verify that tool execution still correctly applies headers through the intended code path and that removing this branch does not cause headers to be dropped in valid scenarios.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

This change removes a code path that could have inadvertently forwarded sensitive static headers to tool endpoints outside of the OAuth flow. Removing it reduces the surface area for unintended credential or header leakage.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable