### PR TITLE
docs: add VS Code extension setup for Claude Code with Bifrost

### DIFF
--- a/docs/cli-agents/claude-code.mdx
+++ b/docs/cli-agents/claude-code.mdx
@@ -31,6 +31,42 @@ Claude Code supports multiple authentication methods. Choose the one that matche
 claude
 ```
 
+## Setup with the VS Code extension
+
+If you prefer using Claude Code inside VS Code, install the [Claude Code extension](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) and point it to Bifrost using the same environment variables you use for the CLI.
+
+### 1. Install the extension
+
+1. Open **Extensions** in VS Code (`Cmd+Shift+X` on macOS)
+2. Search for **Claude Code**
+3. Install **Claude Code** by Anthropic
+
+### 2. Configure Bifrost endpoint
+
+Add Bifrost variables in your editor settings:
+
+```json
+{
+  "claudeCode.environmentVariables": [
+    {
+      "name": "ANTHROPIC_BASE_URL",
+      "value": "http://localhost:8080/anthropic"
+    },
+    {
+      "name": "ANTHROPIC_DEFAULT_SONNET_MODEL",
+      "value": "vertex/claude-sonnet-4-6"
+    },
+    {
+      "name": "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+      "value": "vertex/claude-haiku-4-5"
+    }
+  ]
+}
+```
+
+If virtual keys are enabled, also add `ANTHROPIC_API_KEY` in the same list (use your Bifrost virtual key value). If not, set it to `dummy`.
+
+
 ## Amazon Bedrock via Bifrost
 
 ### Setup


### PR DESCRIPTION
## Summary

Adds documentation for setting up Claude Code with the VS Code extension, pointing it to Bifrost as the backend endpoint.

## Changes

- Added a new "Setup with the VS Code extension" section to the Claude Code docs, covering how to install the extension and configure the `claudeCode.environmentVariables` settings to route requests through Bifrost, including `ANTHROPIC_BASE_URL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, and `ANTHROPIC_DEFAULT_HAIKU_MODEL`, with a note on handling `ANTHROPIC_API_KEY` for virtual key setups.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Navigate to the Claude Code docs page.
2. Verify the new "Setup with the VS Code extension" section appears between the CLI authentication section and the "Amazon Bedrock via Bifrost" section.
3. Confirm the JSON config snippet renders correctly and the extension marketplace link resolves.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `ANTHROPIC_API_KEY` guidance instructs users to use their Bifrost virtual key value or set it to `dummy` when virtual keys are not enabled. No secrets are hardcoded in the documentation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable