### PR TITLE
update scripts to use skip-ci

### DIFF
--- a/.github/workflows/npx-publish.yml
+++ b/.github/workflows/npx-publish.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           COMMIT_MESSAGE=$(git log -1 --pretty=%B)
           FIRST_LINE=$(echo "$COMMIT_MESSAGE" | head -n 1)
-          if [[ "$FIRST_LINE" == *"--skip-pipeline"* ]]; then
+          if [[ "$FIRST_LINE" == *"--skip-ci"* ]]; then
             echo "should-skip=true" >> $GITHUB_OUTPUT
           else
             echo "should-skip=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/openapi-bundle.yml
+++ b/.github/workflows/openapi-bundle.yml
@@ -61,5 +61,5 @@ jobs:
             echo "No changes to commit"
             exit 0
           fi
-          git commit -m "chore: regenerate openapi.json --skip-pipeline"
+          git commit -m "chore: regenerate openapi.json --skip-ci"
           git push origin "$CURRENT_BRANCH"

--- a/.github/workflows/pr-test-notifier.yml
+++ b/.github/workflows/pr-test-notifier.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           COMMIT_MESSAGE=$(git log -1 --pretty=%B)
           FIRST_LINE=$(echo "$COMMIT_MESSAGE" | head -n 1)
-          if [[ "$FIRST_LINE" == *"--skip-pipeline"* ]]; then
+          if [[ "$FIRST_LINE" == *"--skip-ci"* ]]; then
             echo "should-skip=true" >> $GITHUB_OUTPUT
           else
             echo "should-skip=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           COMMIT_MESSAGE=$(git log -1 --pretty=%B)
           FIRST_LINE=$(echo "$COMMIT_MESSAGE" | head -n 1)
-          if [[ "$FIRST_LINE" == *"--skip-pipeline"* ]]; then
+          if [[ "$FIRST_LINE" == *"--skip-ci"* ]]; then
             echo "should-skip=true" >> $GITHUB_OUTPUT
           else
             echo "should-skip=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/scripts/push-cli-mintlify-changelog.sh
+++ b/.github/workflows/scripts/push-cli-mintlify-changelog.sh
@@ -244,7 +244,7 @@ git add docs/docs.json
 git add "$CLI_CHANGELOG_PATH"
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-git commit -m "Adds CLI changelog for v$VERSION --skip-pipeline"
+git commit -m "Adds CLI changelog for v$VERSION --skip-ci"
 git push origin "$CURRENT_BRANCH"
 
 echo "✅ Pushed CLI changelog for v$VERSION"

--- a/.github/workflows/scripts/push-mintlify-changelog.sh
+++ b/.github/workflows/scripts/push-mintlify-changelog.sh
@@ -282,5 +282,5 @@ for file in "${CLEANED_CHANGELOG_FILES[@]}"; do
 done
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-git commit -m "Adds changelog for $VERSION --skip-pipeline"
+git commit -m "Adds changelog for $VERSION --skip-ci"
 git push origin "$CURRENT_BRANCH"

--- a/.github/workflows/scripts/release-bifrost-http-prep.sh
+++ b/.github/workflows/scripts/release-bifrost-http-prep.sh
@@ -147,7 +147,7 @@ if ! git diff --cached --quiet; then
   git config user.name "github-actions[bot]"
   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
   echo "🔧 Committing and pushing changes..."
-  git commit -m "transports: update dependencies --skip-pipeline"
+  git commit -m "transports: update dependencies --skip-ci"
   git push -u origin HEAD
 else
   echo "ℹ️ No staged changes to commit"

--- a/.github/workflows/scripts/release-framework.sh
+++ b/.github/workflows/scripts/release-framework.sh
@@ -89,7 +89,7 @@ echo "✅ Framework build validation successful"
 if ! git diff --cached --quiet; then
   git config user.name "github-actions[bot]"
   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-  git commit -m "framework: bump core to $CORE_VERSION --skip-pipeline"
+  git commit -m "framework: bump core to $CORE_VERSION --skip-ci"
   # Push the bump so go.mod/go.sum changes are recorded on the branch
   CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
   if [ "$CURRENT_BRANCH" = "HEAD" ]; then

--- a/.github/workflows/scripts/release-single-plugin.sh
+++ b/.github/workflows/scripts/release-single-plugin.sh
@@ -85,7 +85,7 @@ if ! git diff --cached --quiet; then
   git config user.name "github-actions[bot]"
   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
   echo "🔧 Committing and pushing changes..."
-  git commit -m "plugins/${PLUGIN_NAME}: bump core to $CORE_VERSION and framework to $FRAMEWORK_VERSION --skip-pipeline"
+  git commit -m "plugins/${PLUGIN_NAME}: bump core to $CORE_VERSION and framework to $FRAMEWORK_VERSION --skip-ci"
   git push -u origin HEAD
 else
   echo "ℹ️ No staged changes to commit"

--- a/docs/security.mdx
+++ b/docs/security.mdx
@@ -57,7 +57,7 @@ to the GitHub Security tab.
 </Tabs>
 
 <Note>
-  Snyk checks can be skipped by including `--skip-pipeline` in the first line of a commit message. This is
+  Snyk checks can be skipped by including `--skip-ci` in the first line of a commit message. This is
   intended for documentation-only or CI configuration changes.
 </Note>
 


### PR DESCRIPTION
## Summary

Renames the CI skip flag from `--skip-pipeline` to `--skip-ci` across all workflows and automation scripts. This standardizes the flag name to be more intuitive and consistent with common CI conventions.

## Changes

- Replaced all occurrences of `--skip-pipeline` with `--skip-ci` in workflow condition checks and automated commit messages
- Updated the security documentation to reflect the new flag name

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Trigger a commit with `--skip-ci` in the first line of the commit message and verify that the `npx-publish`, `pr-test-notifier`, and `pr-tests` workflows correctly skip execution.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Any existing automation or scripts that rely on `--skip-pipeline` in commit messages will need to be updated to use `--skip-ci` instead.

## Security considerations

No security implications. The Snyk skip behavior remains the same; only the flag name has changed.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable