### PR TITLE
fix: include rbac loading state in teams page loader

### DIFF
--- a/ui/app/workspace/governance/teams/page.tsx
+++ b/ui/app/workspace/governance/teams/page.tsx
@@ -1,7 +1,7 @@
 import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store";
-import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { RbacOperation, RbacResource, useRbac, useRbacContext } from "@enterprise/lib";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import TeamsTable from "@/app/workspace/governance/views/teamsTable";
@@ -10,6 +10,7 @@ const POLLING_INTERVAL = 5000;
 const PAGE_SIZE = 25;
 
 export default function GovernanceTeamsPage() {
+	const { isLoading: rbacLoading } = useRbacContext();
 	const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
 	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
 	const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
@@ -63,7 +64,7 @@ export default function GovernanceTeamsPage() {
 		setOffset(teamsTotal === 0 ? 0 : Math.floor((teamsTotal - 1) / PAGE_SIZE) * PAGE_SIZE);
 	}, [teamsTotal, offset]);
 
-	const isLoading = vkLoading || customersLoading || teamsLoading;
+	const isLoading = rbacLoading || vkLoading || customersLoading || teamsLoading;
 
 	useEffect(() => {
 		if (!vkError && !customersError && !teamsError) {


### PR DESCRIPTION
## Summary

The Governance Teams page was showing content before RBAC permissions had finished loading, which could cause access control checks to resolve incorrectly or flash unauthorized UI states. This fix ensures the loading state accounts for RBAC context initialization.

## Changes

- Imported `useRbacContext` on the Governance Teams page to expose the RBAC loading state
- Included `rbacLoading` in the composite `isLoading` flag so the full-page loader remains visible until RBAC permissions are fully resolved

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Governance → Teams page
2. Observe that the full-page loader is displayed until RBAC permissions have fully loaded
3. Confirm that team data and access-controlled UI elements render correctly after loading completes

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Verify the loading spinner persists until RBAC context is ready, then the teams table renders as expected.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Ensures RBAC permission checks are not evaluated before the RBAC context has finished initializing, preventing potential premature rendering of access-controlled content.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable