### PR TITLE
compilatin fix

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/user-groups/teamsView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/user-groups/teamsView.tsx
@@ -1,10 +1,10 @@
+import TeamsTable from "@/app/workspace/governance/views/teamsTable";
 import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import TeamsTable from "@/app/workspace/governance/views/teamsTable";
 
 const POLLING_INTERVAL = 5000;
 const PAGE_SIZE = 25;
@@ -58,7 +58,10 @@ export function TeamsView() {
 	const teamsTotal = teamsData?.total_count ?? 0;
 
 	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
-	}, [teamsTotal, offset, teamsData]);
+	useEffect(() => {
+		if (!teamsData || offset < teamsTotal) return;
+		setOffset(teamsTotal === 0 ? 0 : Math.floor((teamsTotal - 1) / PAGE_SIZE) * PAGE_SIZE);
+	}, [teamsTotal, offset]);
 
 	const isLoading = vkLoading || customersLoading || teamsLoading;
 


### PR DESCRIPTION
## Summary

Fixes a pagination offset snap-back bug in the Teams view where the `useEffect` responsible for resetting the page offset when the total count shrinks (e.g. after deleting the last item on the last page) was malformed or missing its effect body.

## Changes

- Added the missing `useEffect` body that resets `offset` to the last valid page when `teamsTotal` shrinks past the current offset
- Removed `teamsData` from the `useEffect` dependency array since the guard condition only needs `teamsTotal` and `offset` to determine whether a reset is necessary
- Reordered the `TeamsTable` import to follow alphabetical convention

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Teams governance view with multiple pages of teams.
2. Delete all teams on the last page.
3. Verify the view automatically snaps back to the new last valid page rather than showing an empty page or erroring.
4. Delete all teams entirely and verify the offset resets to `0`.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable