### PR TITLE
feat: add `key_ids` support to helm provider configs and update docs

### DIFF
--- a/docs/deployment-guides/helm/governance.mdx
+++ b/docs/deployment-guides/helm/governance.mdx
@@ -182,7 +182,6 @@ bifrost:
           - provider: "openai"
             weight: 1
             allowed_models: ["gpt-4o", "gpt-4o-mini"]
-            # No keys[] → all configured OpenAI keys allowed
 
       # 3. Multi-provider with weighted routing
       - id: "vk-multi"
@@ -212,8 +211,7 @@ bifrost:
           - provider: "openai"
             weight: 1
             allowed_models: ["*"]
-            keys:
-              - name: "openai-primary"  # pin to specific configured key
+            key_ids: ["openai-primary"]  # pin to specific configured key by name
 
       # 5. Restricted testing key
       - id: "vk-testing"
@@ -238,9 +236,10 @@ bifrost:
           - provider: "openai"
             weight: 1
             allowed_models: ["*"]
-            keys:
-              - name: "openai-batch"    # only the batch-flagged key
+            key_ids: ["openai-batch"]    # only the batch-flagged key
 ```
+
+`provider_configs[].key_ids` and `provider_configs[].keys` are both supported in Helm values. Prefer `key_ids` for parity with `config.json` (`key_ids` should contain provider key names).
 
 **Use a virtual key in API calls:**
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3093,6 +3093,13 @@
           "type": "string",
           "description": "Associated rate limit ID"
         },
+        "key_ids": {
+          "type": "array",
+          "description": "Key identifiers allowed for this provider config. Use [\"*\"] to allow all keys; empty array denies all (deny-by-default). In Helm values, use provider key names.",
+          "items": {
+            "type": "string"
+          }
+        },
         "keys": {
           "type": "array",
           "description": "Provider keys for this config (empty means all keys allowed for this provider)",


### PR DESCRIPTION
## Summary

Adds `key_ids` as the preferred field for pinning provider keys in Helm virtual key configurations, aligning Helm values with the `config.json` schema. Previously, only the `keys[].name` syntax was supported; `key_ids` is now the recommended approach for consistency.

## Changes

- Replaced `keys[].name` with `key_ids` in Helm governance documentation examples for pinning specific provider keys
- Added `key_ids` to `values.schema.json` as a supported field on provider configs, with a description clarifying its behavior (`["*"]` allows all keys, empty array denies all)
- Added a note in the docs clarifying that both `key_ids` and `keys` are supported in Helm values, with `key_ids` preferred for parity with `config.json`
- Removed a now-redundant inline comment about omitting `keys[]` allowing all configured keys

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Validate the Helm chart renders correctly with `key_ids` in virtual key provider configs:

```sh
helm template bifrost ./helm-charts/bifrost -f your-values.yaml
```

Confirm that a virtual key config using `key_ids: ["openai-primary"]` renders the same effective configuration as the previous `keys: [{name: "openai-primary"}]` syntax.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This change only affects how provider key references are expressed in Helm values; no secrets or auth flows are modified.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable