### PR TITLE
fix: add sticky headers and footers to sheet panels with layout refactor

### DIFF
--- a/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { CodeEditor } from "@/components/ui/codeEditor";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -27,6 +28,7 @@ import {
 import { cn } from "@/lib/utils";
 import { ChevronDown, Save, X } from "lucide-react";
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { PricingFieldSelector } from "./pricingFieldSelector";
 
@@ -464,17 +466,28 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 	const [createOverride, { isLoading: isCreating }] = useCreatePricingOverrideMutation();
 	const [updateOverride, { isLoading: isPatching }] = useUpdatePricingOverrideMutation();
 
-	const [form, setForm] = useState<FormState>(defaultFormState);
+	const methods = useForm<FormState>({ defaultValues: defaultFormState });
+	const { control, handleSubmit, setValue, watch, reset, getValues, setError, clearErrors } = methods;
+
 	const [jsonPatch, setJSONPatch] = useState("");
 	const [jsonError, setJSONError] = useState<string>();
 	const jsonEditingRef = useRef(false);
 	const prevOpenRef = useRef(false);
 	const [requestTypePopoverOpen, setRequestTypePopoverOpen] = useState(false);
-	const shouldLockScope = useMemo(() => !editingOverride && isCompleteScopeLock(scopeLock), [editingOverride, scopeLock]);
 
 	const isSaving = isCreating || isPatching;
 	const providers = useMemo<ModelProvider[]>(() => (providersError ? [] : (providersData ?? [])), [providersData, providersError]);
 	const virtualKeys = useMemo(() => (virtualKeysError ? [] : (virtualKeysData?.virtual_keys ?? [])), [virtualKeysData, virtualKeysError]);
+
+	const scopeRoot = watch("scopeRoot");
+	const providerID = watch("providerID");
+	const providerKeyID = watch("providerKeyID");
+	const virtualKeyID = watch("virtualKeyID");
+	const matchType = watch("matchType");
+	const requestTypes = watch("requestTypes");
+	const pricingValues = watch("pricingValues");
+
+	const shouldLockScope = useMemo(() => !editingOverride && isCompleteScopeLock(scopeLock), [editingOverride, scopeLock]);
 
 	const providerKeyOptions = useMemo(
 		() =>
@@ -486,8 +499,8 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 		[allKeysData],
 	);
 	const providerScopedKeyOptions = useMemo(
-		() => providerKeyOptions.filter((key) => key.providerName === form.providerID),
-		[providerKeyOptions, form.providerID],
+		() => providerKeyOptions.filter((key) => key.providerName === providerID),
+		[providerKeyOptions, providerID],
 	);
 
 	// Hydrate the form only when the sheet transitions from closed → open.
@@ -508,11 +521,11 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 				const match = providerKeyOptions.find((k) => k.id === state.providerKeyID);
 				if (match) state.providerID = match.providerName;
 			}
-			setForm(state);
+			reset(state);
 			return;
 		}
 		if (shouldLockScope && scopeLock) {
-			const scopedForm: FormState = {
+			reset({
 				...defaultFormState,
 				virtualKeyID: scopeLock.virtualKeyID ?? "",
 				providerID: scopeLock.providerID ?? "",
@@ -523,99 +536,101 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 					scopeLock.scopeKind === "virtual_key_provider_key"
 						? "virtual_key"
 						: "global",
-			};
-			setForm(scopedForm);
+			});
 			return;
 		}
-		setForm(defaultFormState);
-	}, [open, editingOverride, scopeLock, shouldLockScope, providerKeyOptions]);
+		reset(defaultFormState);
+	}, [open, editingOverride, scopeLock, shouldLockScope, providerKeyOptions, reset]);
 
 	// When providerKeyOptions loads after the sheet is already open in edit mode,
 	// backfill the derived providerID without resetting the rest of the form.
 	useEffect(() => {
 		if (!open || !editingOverride) return;
-		setForm((prev) => {
-			if (prev.providerID || !prev.providerKeyID) return prev;
-			const match = providerKeyOptions.find((k) => k.id === prev.providerKeyID);
-			if (!match) return prev;
-			return { ...prev, providerID: match.providerName };
-		});
-	}, [providerKeyOptions, open, editingOverride]);
+		const currentProviderID = getValues("providerID");
+		const currentProviderKeyID = getValues("providerKeyID");
+		if (currentProviderID || !currentProviderKeyID) return;
+		const match = providerKeyOptions.find((k) => k.id === currentProviderKeyID);
+		if (!match) return;
+		setValue("providerID", match.providerName);
+	}, [providerKeyOptions, open, editingOverride, getValues, setValue]);
 
 	const resolvedScopeKind = useMemo(() => {
 		if (shouldLockScope && scopeLock?.scopeKind) return scopeLock.scopeKind;
-		return deriveScopeKind(form);
-	}, [scopeLock, shouldLockScope, form]);
+		return deriveScopeKind({ scopeRoot, providerID, providerKeyID } as FormState);
+	}, [scopeLock, shouldLockScope, scopeRoot, providerID, providerKeyID]);
 
 	const resolvedVirtualKeyID = useMemo(() => {
 		if (shouldLockScope) return scopeLock?.virtualKeyID;
-		return form.scopeRoot === "virtual_key" ? form.virtualKeyID || undefined : undefined;
-	}, [scopeLock, shouldLockScope, form.scopeRoot, form.virtualKeyID]);
+		return scopeRoot === "virtual_key" ? virtualKeyID || undefined : undefined;
+	}, [scopeLock, shouldLockScope, scopeRoot, virtualKeyID]);
 
 	const resolvedProviderID = useMemo(() => {
 		if (shouldLockScope) return scopeLock?.providerID;
-		return form.providerID || undefined;
-	}, [scopeLock, shouldLockScope, form.providerID]);
+		return providerID || undefined;
+	}, [scopeLock, shouldLockScope, providerID]);
 
 	const resolvedProviderKeyID = useMemo(() => {
 		if (shouldLockScope) return scopeLock?.providerKeyID;
-		return form.providerKeyID || undefined;
-	}, [scopeLock, shouldLockScope, form.providerKeyID]);
+		return providerKeyID || undefined;
+	}, [scopeLock, shouldLockScope, providerKeyID]);
 
 	const pricingFieldErrors = useMemo<FieldErrors>(() => {
-		const errors: FieldErrors = {};
+		const errs: FieldErrors = {};
 		for (const key of patchKeys) {
-			const raw = form.pricingValues[key];
+			const raw = pricingValues[key];
 			if (!raw || raw.trim() === "") continue;
 			const parsed = Number(raw);
-			if (!Number.isFinite(parsed)) errors[key] = "Must be a number";
-			else if (parsed < 0) errors[key] = "Must be >= 0";
+			if (!Number.isFinite(parsed)) errs[key] = "Must be a number";
+			else if (parsed < 0) errs[key] = "Must be >= 0";
 		}
-		return errors;
-	}, [form.pricingValues]);
+		return errs;
+	}, [pricingValues]);
 
 	useEffect(() => {
 		if (!jsonEditingRef.current) {
-			const { patch } = buildPatchFromForm(form);
+			const { patch } = buildPatchFromForm(getValues());
 			const json = Object.keys(patch).length > 0 ? JSON.stringify(patch, null, 2) : "";
 			setJSONPatch(json);
 			setJSONError(undefined);
 		}
-	}, [form]);
+	}, [pricingValues, getValues]);
 
-	const handleJSONChange = useCallback((value: string) => {
-		jsonEditingRef.current = true;
-		setJSONPatch(value);
-		const trimmed = value.trim();
-		if (!trimmed) {
-			setJSONError(undefined);
-			setForm((prev) => ({ ...prev, pricingValues: {} }));
-			return;
-		}
-		try {
-			const parsed = JSON.parse(trimmed);
-			if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
-				setJSONError("Patch must be a JSON object");
+	const handleJSONChange = useCallback(
+		(value: string) => {
+			jsonEditingRef.current = true;
+			setJSONPatch(value);
+			const trimmed = value.trim();
+			if (!trimmed) {
+				setJSONError(undefined);
+				setValue("pricingValues", {});
 				return;
 			}
-			const pricingValues: Partial<Record<PricingFieldKey, string>> = {};
-			for (const [key, val] of Object.entries(parsed)) {
-				if (!patchKeys.includes(key as PricingFieldKey)) {
-					setJSONError(`Unknown field: ${key}`);
+			try {
+				const parsed = JSON.parse(trimmed);
+				if (parsed == null || typeof parsed !== "object" || Array.isArray(parsed)) {
+					setJSONError("Patch must be a JSON object");
 					return;
 				}
-				if (typeof val !== "number" || Number.isNaN(val) || val < 0) {
-					setJSONError(`${key} must be a non-negative number`);
-					return;
+				const newPricingValues: Partial<Record<PricingFieldKey, string>> = {};
+				for (const [key, val] of Object.entries(parsed)) {
+					if (!patchKeys.includes(key as PricingFieldKey)) {
+						setJSONError(`Unknown field: ${key}`);
+						return;
+					}
+					if (typeof val !== "number" || Number.isNaN(val) || val < 0) {
+						setJSONError(`${key} must be a non-negative number`);
+						return;
+					}
+					newPricingValues[key as PricingFieldKey] = String(val);
 				}
-				pricingValues[key as PricingFieldKey] = String(val);
+				setJSONError(undefined);
+				setValue("pricingValues", newPricingValues);
+			} catch {
+				setJSONError("Invalid JSON");
 			}
-			setJSONError(undefined);
-			setForm((prev) => ({ ...prev, pricingValues }));
-		} catch {
-			setJSONError("Invalid JSON");
-		}
-	}, []);
+		},
+		[setValue],
+	);
 
 	const handleFieldChange = useCallback(() => {
 		jsonEditingRef.current = false;
@@ -626,70 +641,45 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 		setRequestTypePopoverOpen(false);
 	};
 
-	const toggleRequestType = (requestType: RequestType) => {
-		setForm((prev) => ({
-			...prev,
-			requestTypes: prev.requestTypes.includes(requestType)
-				? prev.requestTypes.filter((item) => item !== requestType)
-				: [...prev.requestTypes, requestType],
-		}));
-	};
-
-	const handleSave = async () => {
-		if (!form.name.trim()) {
-			toast.error("Name is required");
-			return;
-		}
+	const onSubmit = async (data: FormState) => {
+		let hasErrors = false;
 
 		if (
+			!shouldLockScope &&
 			(resolvedScopeKind === "virtual_key" ||
 				resolvedScopeKind === "virtual_key_provider" ||
 				resolvedScopeKind === "virtual_key_provider_key") &&
 			!resolvedVirtualKeyID
 		) {
-			toast.error("Virtual key is required");
-			return;
-		}
-		if ((resolvedScopeKind === "provider" || resolvedScopeKind === "virtual_key_provider") && !resolvedProviderID) {
-			toast.error("Provider is required");
-			return;
-		}
-		if (resolvedScopeKind === "provider_key" && !resolvedProviderKeyID) {
-			toast.error("Provider key is required");
-			return;
-		}
-		if (resolvedScopeKind === "virtual_key_provider_key" && (!resolvedProviderID || !resolvedProviderKeyID)) {
-			toast.error("Provider and provider key are required");
-			return;
+			setError("virtualKeyID", { message: "Virtual key is required" });
+			hasErrors = true;
 		}
 
-		const pError = patternError(form.matchType, form.pattern);
+		const pError = patternError(data.matchType, data.pattern);
 		if (pError) {
-			toast.error(pError);
-			return;
+			setError("pattern", { message: pError });
+			hasErrors = true;
 		}
 
-		if (form.requestTypes.length === 0) {
-			toast.error("At least one request type must be selected");
-			return;
+		if (data.requestTypes.length === 0) {
+			setError("requestTypes", { message: "At least one request type must be selected" });
+			hasErrors = true;
 		}
 
-		if (jsonError) {
-			toast.error("Fix the JSON error before saving");
-			return;
+		if (Object.keys(pricingFieldErrors).length > 0) {
+			setError("pricingValues", { message: "Fix the pricing field errors above" });
+			hasErrors = true;
+		} else {
+			const { patch } = buildPatchFromForm(data);
+			if (Object.keys(patch).length === 0) {
+				setError("pricingValues", { message: "At least one pricing field must be overridden" });
+				hasErrors = true;
+			}
 		}
 
-		const { patch, errors: pricingErrors } = buildPatchFromForm(form);
-		const firstPricingError = Object.values(pricingErrors)[0];
-		if (firstPricingError) {
-			toast.error(firstPricingError);
-			return;
-		}
-		if (Object.keys(patch).length === 0) {
-			toast.error("At least one pricing field must be overridden");
-			return;
-		}
+		if (hasErrors || jsonError) return;
 
+		const { patch } = buildPatchFromForm(data);
 		let scopedVirtualKeyID: string | undefined;
 		let scopedProviderID: string | undefined;
 		let scopedProviderKeyID: string | undefined;
@@ -718,14 +708,14 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 		}
 
 		const requestPayload: CreatePricingOverrideRequest = {
-			name: form.name.trim(),
+			name: data.name.trim(),
 			scope_kind: resolvedScopeKind,
 			virtual_key_id: scopedVirtualKeyID,
 			provider_id: scopedProviderID,
 			provider_key_id: scopedProviderKeyID,
-			match_type: form.matchType,
-			pattern: form.pattern.trim(),
-			request_types: form.requestTypes.length > 0 ? form.requestTypes : [],
+			match_type: data.matchType,
+			pattern: data.pattern.trim(),
+			request_types: data.requestTypes,
 			patch,
 		};
 
@@ -746,311 +736,403 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 
 	return (
 		<Sheet open={open} onOpenChange={(o) => (o ? onOpenChange(true) : handleCloseDrawer())}>
-			<SheetContent side="right" className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white px-4 pb-6 sm:max-w-2xl">
-				<SheetHeader className="flex flex-col items-start px-3 pt-8">
-					<SheetTitle>{editingOverride ? "Edit Pricing Override" : "Create Pricing Override"}</SheetTitle>
+			<SheetContent side="right" className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white p-0 pt-4 sm:max-w-2xl">
+				<SheetHeader className="flex flex-col items-start px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
+					<SheetTitle className="">{editingOverride ? "Edit Pricing Override" : "Create Pricing Override"}</SheetTitle>
 				</SheetHeader>
 
-				<div className="custom-scrollbar flex-1 space-y-6 overflow-y-auto px-3 pb-4">
-					<div className="space-y-4">
-						<div className="space-y-2">
-							<Label htmlFor="pricing-override-name-input">
-								Name <span className="text-red-500">*</span>
-							</Label>
-							<Input
-								id="pricing-override-name-input"
-								data-testid="pricing-override-name-input"
-								placeholder="e.g., GPT-4 Negotiated Rate"
-								value={form.name}
-								onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
-							/>
-						</div>
-
-						{shouldLockScope && scopeLock ? (
-							<div className="space-y-2">
-								<Label htmlFor="pricing-override-scope-lock-input">Scope</Label>
-								<Input
-									id="pricing-override-scope-lock-input"
-									data-testid="pricing-override-scope-lock-input"
-									value={scopeLock.label ?? scopeLock.scopeKind}
-									readOnly
-								/>
-							</div>
-						) : (
-							<>
-								<div className="space-y-2">
-									<Label htmlFor="pricing-override-scope-root-select">Scope root</Label>
-									<Select
-										value={form.scopeRoot}
-										onValueChange={(value: ScopeRoot) => setForm((prev) => ({ ...prev, scopeRoot: value, virtualKeyID: "" }))}
-									>
-										<SelectTrigger
-											id="pricing-override-scope-root-select"
-											data-testid="pricing-override-scope-root-select"
-											className="w-full"
-										>
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="global">Global</SelectItem>
-											<SelectItem value="virtual_key">Virtual key</SelectItem>
-										</SelectContent>
-									</Select>
-								</div>
-
-								{form.scopeRoot === "virtual_key" && (
-									<div className="space-y-2">
-										<Label htmlFor="pricing-override-virtual-key-select">
-											Virtual key <span className="text-red-500">*</span>
-										</Label>
-										<Select
-											value={form.virtualKeyID || "__none__"}
-											onValueChange={(value) =>
-												setForm((prev) => ({ ...prev, virtualKeyID: value === "__none__" ? "" : value, providerID: "", providerKeyID: "" }))
-											}
-										>
-											<SelectTrigger
-												id="pricing-override-virtual-key-select"
-												data-testid="pricing-override-virtual-key-select"
-												className="w-full"
-												disabled={isVirtualKeysLoading || !!virtualKeysError}
-											>
-												<SelectValue placeholder={isVirtualKeysLoading ? "Loading..." : "Select virtual key"} />
-											</SelectTrigger>
-											<SelectContent>
-												<SelectItem value="__none__">Select virtual key</SelectItem>
-												{virtualKeys.map((vk) => (
-													<SelectItem key={vk.id} value={vk.id}>
-														{vk.name}
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-										{virtualKeysError ? (
-											<p className="text-destructive mt-1 text-xs">Failed to load virtual keys: {getErrorMessage(virtualKeysError)}</p>
-										) : null}
-									</div>
-								)}
-
-								<div className="grid grid-cols-2 gap-2">
-									<div className="space-y-2">
-										<Label htmlFor="pricing-override-provider-select">Provider</Label>
-										<Select
-											value={form.providerID || "__none__"}
-											onValueChange={(value) =>
-												setForm((prev) => ({ ...prev, providerID: value === "__none__" ? "" : value, providerKeyID: "" }))
-											}
-										>
-											<SelectTrigger
-												id="pricing-override-provider-select"
-												data-testid="pricing-override-provider-select"
-												className="w-full"
-												disabled={isProvidersLoading || !!providersError}
-											>
-												{isProvidersLoading ? (
-													<span className="text-muted-foreground">Loading...</span>
-												) : form.providerID ? (
-													<div className="flex items-center gap-1.5">
-														<RenderProviderIcon provider={form.providerID as ProviderIconType} size="sm" className="h-4 w-4 shrink-0" />
-														<span>{getProviderLabel(form.providerID)}</span>
-													</div>
-												) : (
-													<span className="text-muted-foreground">All providers</span>
-												)}
-											</SelectTrigger>
-											<SelectContent>
-												<SelectItem value="__none__">All providers</SelectItem>
-												{providers.map((provider) => (
-													<SelectItem key={provider.name} value={provider.name}>
-														<div className="flex items-center gap-1.5">
-															<RenderProviderIcon provider={provider.name as ProviderIconType} size="sm" className="h-4 w-4 shrink-0" />
-															<span>{getProviderLabel(provider.name)}</span>
-														</div>
-													</SelectItem>
-												))}
-											</SelectContent>
-										</Select>
-										{providersError ? (
-											<p className="text-destructive mt-1 text-xs">Failed to load providers: {getErrorMessage(providersError)}</p>
-										) : null}
-									</div>
-
-									{form.providerID ? (
-										<div className="space-y-2">
-											<Label htmlFor="pricing-override-provider-key-select">Provider key</Label>
-											<Select
-												value={form.providerKeyID || "__none__"}
-												onValueChange={(value) => setForm((prev) => ({ ...prev, providerKeyID: value === "__none__" ? "" : value }))}
-											>
-												<SelectTrigger
-													id="pricing-override-provider-key-select"
-													data-testid="pricing-override-provider-key-select"
-													className="w-full"
-												>
-													<SelectValue placeholder="All provider keys" />
-												</SelectTrigger>
-												<SelectContent>
-													<SelectItem value="__none__">All provider keys</SelectItem>
-													{providerScopedKeyOptions.map((option) => (
-														<SelectItem key={option.id} value={option.id}>
-															{option.label}
-														</SelectItem>
-													))}
-												</SelectContent>
-											</Select>
-										</div>
-									) : (
-										<div />
+				<Form {...methods}>
+					<form onSubmit={handleSubmit(onSubmit)} className="flex min-h-0 flex-1 flex-col">
+						<div className="flex-1 space-y-6 overflow-y-auto px-8 pb-4">
+							<div className="space-y-4">
+								<FormField
+									control={control}
+									name="name"
+									rules={{ required: "Name is required" }}
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>
+												Name <span className="text-red-500">*</span>
+											</FormLabel>
+											<FormControl>
+												<Input data-testid="pricing-override-name-input" placeholder="e.g., GPT-4 Negotiated Rate" {...field} />
+											</FormControl>
+											<FormMessage />
+										</FormItem>
 									)}
-								</div>
-							</>
-						)}
-					</div>
-
-					<div className="space-y-2">
-						<div className="grid grid-cols-[1fr_2fr] gap-2">
-							<div className="space-y-2">
-								<Label htmlFor="pricing-override-match-type-select">Match type</Label>
-								<Select
-									value={form.matchType}
-									onValueChange={(value: PricingOverrideMatchType) => setForm((prev) => ({ ...prev, matchType: value }))}
-								>
-									<SelectTrigger
-										id="pricing-override-match-type-select"
-										data-testid="pricing-override-match-type-select"
-										className="w-full"
-									>
-										<SelectValue placeholder="Select match type" />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="exact">Exact</SelectItem>
-										<SelectItem value="wildcard">Wildcard</SelectItem>
-									</SelectContent>
-								</Select>
-							</div>
-							<div className="space-y-2">
-								<Label htmlFor="pricing-override-pattern-input">
-									Pattern <span className="text-red-500">*</span>
-								</Label>
-								<Input
-									id="pricing-override-pattern-input"
-									data-testid="pricing-override-pattern-input"
-									value={form.pattern}
-									onChange={(e) => setForm((prev) => ({ ...prev, pattern: e.target.value }))}
-									placeholder={form.matchType === "exact" ? "e.g., gpt-4o" : "e.g., gpt-4*"}
 								/>
+
+								{shouldLockScope && scopeLock ? (
+									<div className="space-y-2">
+										<Label htmlFor="pricing-override-scope-lock-input">Scope</Label>
+										<Input
+											id="pricing-override-scope-lock-input"
+											data-testid="pricing-override-scope-lock-input"
+											value={scopeLock.label ?? scopeLock.scopeKind}
+											readOnly
+										/>
+									</div>
+								) : (
+									<>
+										<FormField
+											control={control}
+											name="scopeRoot"
+											render={({ field }) => (
+												<FormItem>
+													<FormLabel>Scope root</FormLabel>
+													<Select
+														value={field.value}
+														onValueChange={(value: ScopeRoot) => {
+															field.onChange(value);
+															setValue("virtualKeyID", "");
+															clearErrors("virtualKeyID");
+														}}
+													>
+														<FormControl>
+															<SelectTrigger
+																data-testid="pricing-override-scope-root-select"
+																className="w-full"
+															>
+																<SelectValue />
+															</SelectTrigger>
+														</FormControl>
+														<SelectContent>
+															<SelectItem value="global">Global</SelectItem>
+															<SelectItem value="virtual_key">Virtual key</SelectItem>
+														</SelectContent>
+													</Select>
+												</FormItem>
+											)}
+										/>
+
+										{scopeRoot === "virtual_key" && (
+											<FormField
+												control={control}
+												name="virtualKeyID"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>
+															Virtual key <span className="text-red-500">*</span>
+														</FormLabel>
+														<Select
+															value={field.value || "__none__"}
+															onValueChange={(value) => {
+																field.onChange(value === "__none__" ? "" : value);
+																setValue("providerID", "");
+																setValue("providerKeyID", "");
+																clearErrors("virtualKeyID");
+															}}
+														>
+															<FormControl>
+																<SelectTrigger
+																	data-testid="pricing-override-virtual-key-select"
+																	className="w-full"
+																	disabled={isVirtualKeysLoading || !!virtualKeysError}
+																>
+																	<SelectValue placeholder={isVirtualKeysLoading ? "Loading..." : "Select virtual key"} />
+																</SelectTrigger>
+															</FormControl>
+															<SelectContent>
+																<SelectItem value="__none__">Select virtual key</SelectItem>
+																{virtualKeys.map((vk) => (
+																	<SelectItem key={vk.id} value={vk.id}>
+																		{vk.name}
+																	</SelectItem>
+																))}
+															</SelectContent>
+														</Select>
+														{virtualKeysError ? (
+															<p className="text-destructive mt-1 text-xs">
+																Failed to load virtual keys: {getErrorMessage(virtualKeysError)}
+															</p>
+														) : (
+															<FormMessage />
+														)}
+													</FormItem>
+												)}
+											/>
+										)}
+
+										<div className="grid grid-cols-2 gap-2">
+											<FormField
+												control={control}
+												name="providerID"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Provider</FormLabel>
+														<Select
+															value={field.value || "__none__"}
+															onValueChange={(value) => {
+																field.onChange(value === "__none__" ? "" : value);
+																setValue("providerKeyID", "");
+															}}
+														>
+															<FormControl>
+																<SelectTrigger
+																	data-testid="pricing-override-provider-select"
+																	className="w-full"
+																	disabled={isProvidersLoading || !!providersError}
+																>
+																	{isProvidersLoading ? (
+																		<span className="text-muted-foreground">Loading...</span>
+																	) : field.value ? (
+																		<div className="flex items-center gap-1.5">
+																			<RenderProviderIcon provider={field.value as ProviderIconType} size="sm" className="h-4 w-4 shrink-0" />
+																			<span>{getProviderLabel(field.value)}</span>
+																		</div>
+																	) : (
+																		<span className="text-muted-foreground">All providers</span>
+																	)}
+																</SelectTrigger>
+															</FormControl>
+															<SelectContent>
+																<SelectItem value="__none__">All providers</SelectItem>
+																{providers.map((provider) => (
+																	<SelectItem key={provider.name} value={provider.name}>
+																		<div className="flex items-center gap-1.5">
+																			<RenderProviderIcon provider={provider.name as ProviderIconType} size="sm" className="h-4 w-4 shrink-0" />
+																			<span>{getProviderLabel(provider.name)}</span>
+																		</div>
+																	</SelectItem>
+																))}
+															</SelectContent>
+														</Select>
+														{providersError ? (
+															<p className="text-destructive mt-1 text-xs">Failed to load providers: {getErrorMessage(providersError)}</p>
+														) : null}
+													</FormItem>
+												)}
+											/>
+
+											{providerID ? (
+												<FormField
+													control={control}
+													name="providerKeyID"
+													render={({ field }) => (
+														<FormItem>
+															<FormLabel>Provider key</FormLabel>
+															<Select
+																value={field.value || "__none__"}
+																onValueChange={(value) => field.onChange(value === "__none__" ? "" : value)}
+															>
+																<FormControl>
+																	<SelectTrigger
+																		data-testid="pricing-override-provider-key-select"
+																		className="w-full"
+																	>
+																		<SelectValue placeholder="All provider keys" />
+																	</SelectTrigger>
+																</FormControl>
+																<SelectContent>
+																	<SelectItem value="__none__">All provider keys</SelectItem>
+																	{providerScopedKeyOptions.map((option) => (
+																		<SelectItem key={option.id} value={option.id}>
+																			{option.label}
+																		</SelectItem>
+																	))}
+																</SelectContent>
+															</Select>
+														</FormItem>
+													)}
+												/>
+											) : (
+												<div />
+											)}
+										</div>
+									</>
+								)}
+							</div>
+
+							<div className="space-y-2">
+								<div className="grid grid-cols-[1fr_2fr] gap-2">
+									<FormField
+										control={control}
+										name="matchType"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>Match type</FormLabel>
+												<Select
+													value={field.value}
+													onValueChange={(value: PricingOverrideMatchType) => {
+														field.onChange(value);
+														clearErrors("pattern");
+													}}
+												>
+													<FormControl>
+														<SelectTrigger
+															data-testid="pricing-override-match-type-select"
+															className="w-full"
+														>
+															<SelectValue placeholder="Select match type" />
+														</SelectTrigger>
+													</FormControl>
+													<SelectContent>
+														<SelectItem value="exact">Exact</SelectItem>
+														<SelectItem value="wildcard">Wildcard</SelectItem>
+													</SelectContent>
+												</Select>
+											</FormItem>
+										)}
+									/>
+									<FormField
+										control={control}
+										name="pattern"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>
+													Pattern <span className="text-red-500">*</span>
+												</FormLabel>
+												<FormControl>
+													<Input
+														data-testid="pricing-override-pattern-input"
+														placeholder={matchType === "exact" ? "e.g., gpt-4o" : "e.g., gpt-4*"}
+														{...field}
+														onChange={(e) => {
+															field.onChange(e);
+															clearErrors("pattern");
+														}}
+													/>
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+								</div>
+							</div>
+
+							<FormField
+								control={control}
+								name="requestTypes"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>
+											Request types <span className="text-red-500">*</span>
+										</FormLabel>
+										<Popover open={requestTypePopoverOpen} onOpenChange={setRequestTypePopoverOpen} modal={false}>
+											<PopoverTrigger asChild>
+												<FormControl>
+													<Button
+														data-testid="pricing-override-request-types-btn"
+														type="button"
+														variant="outline"
+														className="h-10 w-full justify-between"
+													>
+														<span className="truncate text-left">
+															{field.value.length > 0 ? (
+																field.value.map((rt) => RequestTypeLabels[rt as keyof typeof RequestTypeLabels] ?? rt).join(", ")
+															) : (
+																<span className="text-muted-foreground">Select request types...</span>
+															)}
+														</span>
+														<ChevronDown className="h-4 w-4 shrink-0" />
+													</Button>
+												</FormControl>
+											</PopoverTrigger>
+											<PopoverContent align="start" className="w-[320px] p-2" onWheel={(e) => e.stopPropagation()}>
+												<div className="max-h-72 space-y-1 overflow-y-auto" onWheel={(e) => e.stopPropagation()}>
+													{REQUEST_TYPE_GROUPS.map((group) => (
+														<div key={group.label}>
+															<div className="text-muted-foreground px-2 py-1 text-xs font-medium">{group.label}</div>
+															{group.types.map((requestType) => {
+																const checked = field.value.includes(requestType as RequestType);
+																return (
+																	<label
+																		key={requestType}
+																		className="hover:bg-muted flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm"
+																	>
+																		<Checkbox
+																			data-testid={`pricing-override-request-type-checkbox-${requestType}`}
+																			checked={checked}
+																			onCheckedChange={() => {
+																				const current = field.value;
+																				const next = current.includes(requestType as RequestType)
+																					? current.filter((item) => item !== requestType)
+																					: [...current, requestType as RequestType];
+																				field.onChange(next);
+																				if (next.length > 0) clearErrors("requestTypes");
+																			}}
+																		/>
+																		<span>{RequestTypeLabels[requestType as keyof typeof RequestTypeLabels] ?? requestType}</span>
+																	</label>
+																);
+															})}
+														</div>
+													))}
+												</div>
+												<div className="mt-2 flex justify-end">
+													<Button
+														data-testid="pricing-override-request-types-clear-btn"
+														type="button"
+														size="sm"
+														variant="ghost"
+														onClick={() => field.onChange([])}
+													>
+														Clear
+													</Button>
+												</div>
+											</PopoverContent>
+										</Popover>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+
+							<FormField
+								control={control}
+								name="pricingValues"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>
+											Pricing fields <span className="text-red-500">*</span>{" "}
+											<span className="text-muted-foreground text-xs font-normal">(USD per unit)</span>
+										</FormLabel>
+										<PricingFieldSelector
+											key={open ? (editingOverride?.id ?? "new") : "closed"}
+											values={field.value}
+											errors={pricingFieldErrors}
+											selectedRequestTypes={requestTypes}
+											onChange={(key, value) => {
+												handleFieldChange();
+												field.onChange({ ...field.value, [key]: value });
+												clearErrors("pricingValues");
+											}}
+											onFieldInteraction={handleFieldChange}
+										/>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+
+							<div className="space-y-2">
+								<Label className="text-muted-foreground text-xs">JSON</Label>
+								<div className={cn("bg-muted/50 overflow-hidden rounded-md border", jsonError && "border-destructive")}>
+									<CodeEditor
+										lang="json"
+										code={jsonPatch}
+										onChange={handleJSONChange}
+										minHeight={40}
+										maxHeight={200}
+										autoResize
+										shouldAdjustInitialHeight
+										options={{ lineNumbers: "off", scrollBeyondLastLine: false }}
+									/>
+								</div>
+								{jsonError && <p className="text-destructive text-xs">{jsonError}</p>}
 							</div>
 						</div>
-					</div>
 
-					<div className="space-y-2">
-						<Label htmlFor="pricing-override-request-types-btn">
-							Request types <span className="text-red-500">*</span>
-						</Label>
-						<Popover open={requestTypePopoverOpen} onOpenChange={setRequestTypePopoverOpen} modal={false}>
-							<PopoverTrigger asChild>
-								<Button
-									id="pricing-override-request-types-btn"
-									data-testid="pricing-override-request-types-btn"
-									type="button"
-									variant="outline"
-									className="h-10 w-full justify-between"
-								>
-									<span className="truncate text-left">
-										{form.requestTypes.length > 0 ? (
-											form.requestTypes.map((rt) => RequestTypeLabels[rt as keyof typeof RequestTypeLabels] ?? rt).join(", ")
-										) : (
-											<span className="text-muted-foreground">Select request types...</span>
-										)}
-									</span>
-									<ChevronDown className="h-4 w-4 shrink-0" />
-								</Button>
-							</PopoverTrigger>
-							<PopoverContent align="start" className="w-[320px] p-2" onWheel={(e) => e.stopPropagation()}>
-								<div className="max-h-72 space-y-1 overflow-y-auto" onWheel={(e) => e.stopPropagation()}>
-									{REQUEST_TYPE_GROUPS.map((group) => (
-										<div key={group.label}>
-											<div className="text-muted-foreground px-2 py-1 text-xs font-medium">{group.label}</div>
-											{group.types.map((requestType) => {
-												const checked = form.requestTypes.includes(requestType);
-												return (
-													<label
-														key={requestType}
-														className="hover:bg-muted flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm"
-													>
-														<Checkbox
-															data-testid={`pricing-override-request-type-checkbox-${requestType}`}
-															checked={checked}
-															onCheckedChange={() => toggleRequestType(requestType)}
-														/>
-														<span>{RequestTypeLabels[requestType as keyof typeof RequestTypeLabels] ?? requestType}</span>
-													</label>
-												);
-											})}
-										</div>
-									))}
-								</div>
-								<div className="mt-2 flex justify-end">
-									<Button
-										data-testid="pricing-override-request-types-clear-btn"
-										type="button"
-										size="sm"
-										variant="ghost"
-										onClick={() => setForm((prev) => ({ ...prev, requestTypes: [] }))}
-									>
-										Clear
-									</Button>
-								</div>
-							</PopoverContent>
-						</Popover>
-					</div>
-
-					<div className="space-y-2">
-						<Label>
-							Pricing fields <span className="text-red-500">*</span>{" "}
-							<span className="text-muted-foreground text-xs font-normal">(USD per unit)</span>
-						</Label>
-						<PricingFieldSelector
-							key={open ? (editingOverride?.id ?? "new") : "closed"}
-							values={form.pricingValues}
-							errors={pricingFieldErrors}
-							selectedRequestTypes={form.requestTypes}
-							onChange={(key, value) => {
-								handleFieldChange();
-								setForm((prev) => ({ ...prev, pricingValues: { ...prev.pricingValues, [key]: value } }));
-							}}
-							onFieldInteraction={handleFieldChange}
-						/>
-					</div>
-
-					<div className="space-y-2">
-						<Label className="text-muted-foreground text-xs">JSON</Label>
-						<div className={cn("bg-muted/50 overflow-hidden rounded-md border", jsonError && "border-destructive")}>
-							<CodeEditor
-								lang="json"
-								code={jsonPatch}
-								onChange={handleJSONChange}
-								minHeight={40}
-								maxHeight={200}
-								autoResize
-								shouldAdjustInitialHeight
-								options={{ lineNumbers: "off", scrollBeyondLastLine: false }}
-							/>
+						<div className="bg-card sticky bottom-0 flex justify-end gap-3 border-t px-7 py-4">
+							<Button data-testid="pricing-override-cancel-btn" type="button" variant="outline" onClick={handleCloseDrawer} disabled={isSaving}>
+								<X className="h-4 w-4" />
+								Cancel
+							</Button>
+							<Button data-testid="pricing-override-save-btn" type="submit" disabled={isSaving}>
+								<Save className="h-4 w-4" />
+								{editingOverride ? "Update Override" : "Save Override"}
+							</Button>
 						</div>
-						{jsonError && <p className="text-destructive text-xs">{jsonError}</p>}
-					</div>
-				</div>
-
-				<div className="flex justify-end gap-3 px-3 pt-4">
-					<Button data-testid="pricing-override-cancel-btn" type="button" variant="outline" onClick={handleCloseDrawer} disabled={isSaving}>
-						<X className="h-4 w-4" />
-						Cancel
-					</Button>
-					<Button data-testid="pricing-override-save-btn" type="button" onClick={handleSave} disabled={isSaving}>
-						<Save className="h-4 w-4" />
-						{editingOverride ? "Update Override" : "Save Override"}
-					</Button>
-				</div>
+					</form>
+				</Form>
 			</SheetContent>
 		</Sheet>
 	);

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { EnvVarInput } from "@/components/ui/envVarInput";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -11,10 +12,10 @@ import { useToast } from "@/hooks/use-toast";
 import { getErrorMessage, useCreateMCPClientMutation } from "@/lib/store";
 import { CreateMCPClientRequest, EnvVar, MCPAuthType, MCPConnectionType, MCPStdioConfig, OAuthConfig } from "@/lib/types/mcp";
 import { parseArrayFromText } from "@/lib/utils/array";
-import { Validator } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Info } from "lucide-react";
 import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
 import { OAuth2Authorizer } from "./oauth2Authorizer";
 
 interface ClientFormProps {
@@ -51,7 +52,9 @@ const emptyForm: CreateMCPClientRequest = {
 
 const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 	const hasCreateMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Create);
-	const [form, setForm] = useState<CreateMCPClientRequest>(emptyForm);
+	const { toast } = useToast();
+	const [createMCPClient] = useCreateMCPClientMutation();
+
 	const [isLoading, setIsLoading] = useState(false);
 	const [argsText, setArgsText] = useState("");
 	const [envsText, setEnvsText] = useState("");
@@ -62,207 +65,128 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 		mcpClientId: string;
 		isPerUserOauth?: boolean;
 	} | null>(null);
-	const { toast } = useToast();
 
-	// RTK Query mutations
-	const [createMCPClient] = useCreateMCPClientMutation();
+	const methods = useForm<CreateMCPClientRequest>({ defaultValues: emptyForm });
+	const { control, handleSubmit, setValue, watch, reset, setError, clearErrors } = methods;
+
+	const connectionType = watch("connection_type");
+	const authType = watch("auth_type");
+	const connectionString = watch("connection_string");
+	const stdioConfig = watch("stdio_config");
+	const oauthConfig = watch("oauth_config");
+	const headers = watch("headers");
+	const isCodeMode = watch("is_code_mode_client");
+	const isPingAvailable = watch("is_ping_available");
+
+	// Inline header validation (shown live as user edits headers)
+	let headersValidationError: string | null = null;
+	if ((connectionType === "http" || connectionType === "sse") && authType === "headers" && headers) {
+		for (const [key, envVar] of Object.entries(headers)) {
+			if (!envVar.value && !envVar.env_var) {
+				headersValidationError = `Header "${key}" must have a value`;
+				break;
+			}
+		}
+	}
 
 	// Reset form state when dialog opens
 	useEffect(() => {
 		if (open) {
-			setForm(emptyForm);
+			reset(emptyForm);
 			setArgsText("");
 			setEnvsText("");
 			setScopesText("");
 			setOauthFlow(null);
 			setIsLoading(false);
 		}
-	}, [open]);
+	}, [open, reset]);
 
-	const handleChange = (
-		field: keyof CreateMCPClientRequest,
-		value: string | string[] | boolean | MCPConnectionType | MCPStdioConfig | undefined,
-	) => {
-		setForm((prev) => {
-			if (field === "connection_type" && value === "stdio") {
-				return {
-					...prev,
-					connection_type: "stdio" as MCPConnectionType,
-					auth_type: "none" as MCPAuthType,
-					headers: undefined,
-					oauth_config: undefined,
-				};
-			}
-			return { ...prev, [field]: value };
-		});
-	};
+	const onSubmit = async (data: CreateMCPClientRequest) => {
+		let hasErrors = false;
 
-	const handleStdioConfigChange = (field: keyof MCPStdioConfig, value: string | string[]) => {
-		setForm((prev) => ({
-			...prev,
-			stdio_config: {
-				command: "",
-				args: [],
-				envs: [],
-				...(prev.stdio_config || {}),
-				[field]: value,
-			},
-		}));
-	};
-
-	const handleHeadersChange = (value: Record<string, EnvVar>) => {
-		setForm((prev) => ({ ...prev, headers: value }));
-	};
-
-	const handleConnectionStringChange = (value: EnvVar) => {
-		setForm((prev) => ({
-			...prev,
-			connection_string: value,
-		}));
-	};
-
-	const handleOAuthConfigChange = (field: keyof OAuthConfig, value: string | string[]) => {
-		setForm((prev) => ({
-			...prev,
-			oauth_config: {
-				...(prev.oauth_config || emptyOAuthConfig),
-				[field]: value,
-			},
-		}));
-	};
-
-	// Validate headers format
-	const validateHeaders = (): string | null => {
-		if ((form.connection_type === "http" || form.connection_type === "sse") && form.auth_type === "headers" && form.headers) {
-			// Ensure all EnvVar values have either a value or env_var
-			for (const [key, envVar] of Object.entries(form.headers)) {
-				if (!envVar.value && !envVar.env_var) {
-					return `Header "${key}" must have a value`;
-				}
+		if (connectionType === "http" || connectionType === "sse") {
+			const connVal = data.connection_string?.value || "";
+			if (!connVal.trim()) {
+				setError("connection_string", { message: "Connection URL is required" });
+				hasErrors = true;
+			} else if (!/^((https?:\/\/.+)|(env\.[A-Z_]+))$/.test(connVal)) {
+				setError("connection_string", {
+					message: "Connection URL must start with http://, https://, or be an environment variable (env.VAR_NAME)",
+				});
+				hasErrors = true;
 			}
 		}
-		return null;
-	};
 
-	const headersValidationError = validateHeaders();
-
-	// Get the connection string value for validation
-	const connectionStringValue = form.connection_string?.value || "";
-
-	const validator = new Validator([
-		// Name validation
-		Validator.required(form.name?.trim(), "Server name is required"),
-		Validator.pattern(form.name || "", /^[a-zA-Z0-9_]+$/, "Server name can only contain letters, numbers, and underscores"),
-		Validator.custom(!(form.name || "").includes("-"), "Server name cannot contain hyphens"),
-		Validator.custom(!(form.name || "").includes(" "), "Server name cannot contain spaces"),
-		Validator.custom((form.name || "").length === 0 || !/^[0-9]/.test(form.name || ""), "Server name cannot start with a number"),
-		Validator.minLength(form.name || "", 3, "Server name must be at least 3 characters"),
-		Validator.maxLength(form.name || "", 50, "Server name cannot exceed 50 characters"),
-
-		// Connection type specific validation
-		...(form.connection_type === "http" || form.connection_type === "sse"
-			? [
-					Validator.required(connectionStringValue?.trim(), "Connection URL is required"),
-					Validator.pattern(
-						connectionStringValue,
-						/^((https?:\/\/.+)|(env\.[A-Z_]+))$/,
-						"Connection URL must start with http://, https://, or be an environment variable (env.VAR_NAME)",
-					),
-					...(headersValidationError ? [Validator.custom(false, headersValidationError)] : []),
-				]
-			: []),
-
-		// STDIO validation
-		...(form.connection_type === "stdio"
-			? [
-					Validator.required(form.stdio_config?.command?.trim(), "Command is required for STDIO connections"),
-					Validator.pattern(form.stdio_config?.command || "", /^[^<>|&;]+$/, "Command cannot contain special shell characters"),
-				]
-			: []),
-
-		// OAuth validation
-		...(form.auth_type === "oauth" || form.auth_type === "per_user_oauth"
-			? [
-					// Client ID is optional if provider supports dynamic registration (RFC 7591)
-					// URLs are optional (will be discovered), but if provided must be valid
-					...(form.oauth_config?.authorize_url
-						? [Validator.pattern(form.oauth_config.authorize_url, /^https?:\/\/.+$/, "Authorize URL must start with http:// or https://")]
-						: []),
-					...(form.oauth_config?.token_url
-						? [Validator.pattern(form.oauth_config.token_url, /^https?:\/\/.+$/, "Token URL must start with http:// or https://")]
-						: []),
-					...(form.oauth_config?.registration_url
-						? [
-								Validator.pattern(
-									form.oauth_config.registration_url,
-									/^https?:\/\/.+$/,
-									"Registration URL must start with http:// or https://",
-								),
-							]
-						: []),
-				]
-			: []),
-	]);
-
-	const handleSubmit = async () => {
-		// Validate before submitting
-		if (!validator.isValid()) {
-			toast({
-				title: "Validation Error",
-				description: validator.getFirstError() || "Please fix validation errors",
-				variant: "destructive",
-			});
-			return;
+		if (connectionType === "stdio") {
+			const cmd = data.stdio_config?.command || "";
+			if (!cmd.trim()) {
+				setError("stdio_config.command", { message: "Command is required for STDIO connections" });
+				hasErrors = true;
+			} else if (/[<>|&;]/.test(cmd)) {
+				setError("stdio_config.command", { message: "Command cannot contain special shell characters" });
+				hasErrors = true;
+			}
 		}
+
+		if (authType === "oauth" || authType === "per_user_oauth") {
+			if (data.oauth_config?.authorize_url && !/^https?:\/\/.+$/.test(data.oauth_config.authorize_url)) {
+				setError("oauth_config.authorize_url", { message: "Authorize URL must start with http:// or https://" });
+				hasErrors = true;
+			}
+			if (data.oauth_config?.token_url && !/^https?:\/\/.+$/.test(data.oauth_config.token_url)) {
+				setError("oauth_config.token_url", { message: "Token URL must start with http:// or https://" });
+				hasErrors = true;
+			}
+			if (data.oauth_config?.registration_url && !/^https?:\/\/.+$/.test(data.oauth_config.registration_url)) {
+				setError("oauth_config.registration_url", { message: "Registration URL must start with http:// or https://" });
+				hasErrors = true;
+			}
+		}
+
+		if (headersValidationError || hasErrors) return;
 
 		setIsLoading(true);
 
-		// Prepare the payload
 		const payload: CreateMCPClientRequest = {
-			...form,
+			...data,
 			stdio_config:
-				form.connection_type === "stdio"
+				connectionType === "stdio"
 					? {
-							command: form.stdio_config?.command || "",
+							command: data.stdio_config?.command || "",
 							args: parseArrayFromText(argsText),
 							envs: parseArrayFromText(envsText),
 						}
 					: undefined,
 			oauth_config:
-				form.auth_type === "oauth" || form.auth_type === "per_user_oauth"
+				authType === "oauth" || authType === "per_user_oauth"
 					? {
-							client_id: form.oauth_config?.client_id || "", // Can be empty for dynamic registration
-							client_secret: form.oauth_config?.client_secret || undefined,
-							authorize_url: form.oauth_config?.authorize_url || undefined,
-							token_url: form.oauth_config?.token_url || undefined,
-							registration_url: form.oauth_config?.registration_url || undefined,
+							client_id: data.oauth_config?.client_id || "",
+							client_secret: data.oauth_config?.client_secret || undefined,
+							authorize_url: data.oauth_config?.authorize_url || undefined,
+							token_url: data.oauth_config?.token_url || undefined,
+							registration_url: data.oauth_config?.registration_url || undefined,
 							scopes: scopesText.trim() ? parseArrayFromText(scopesText) : undefined,
-							server_url: form.connection_string?.value || undefined, // Set server_url from connection_string
+							server_url: data.connection_string?.value || undefined,
 						}
 					: undefined,
-			headers: form.auth_type === "headers" && form.headers && Object.keys(form.headers).length > 0 ? form.headers : undefined,
+			headers: authType === "headers" && data.headers && Object.keys(data.headers).length > 0 ? data.headers : undefined,
 			tools_to_execute: ["*"],
 		};
 
 		try {
 			const response = await createMCPClient(payload).unwrap();
 
-			// Check if OAuth flow was initiated
 			if (response.status === "pending_oauth" && response.authorize_url) {
 				setIsLoading(false);
-				// Open OAuth authorizer popup
 				setOauthFlow({
 					authorizeUrl: response.authorize_url,
 					oauthConfigId: response.oauth_config_id,
 					mcpClientId: response.mcp_client_id,
-					isPerUserOauth: form.auth_type === "per_user_oauth",
+					isPerUserOauth: authType === "per_user_oauth",
 				});
 			} else {
 				setIsLoading(false);
-				toast({
-					title: "Success",
-					description: "Server created",
-				});
+				toast({ title: "Success", description: "Server created" });
 				onSaved();
 				onClose();
 			}
@@ -274,170 +198,121 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 
 	return (
 		<Sheet open={open} onOpenChange={(open) => !open && onClose()}>
-			<SheetContent className="flex w-full flex-col overflow-x-hidden px-4 pb-8">
-				<SheetHeader className="flex flex-col items-start px-4 pt-8">
+			<SheetContent className="flex w-full flex-col overflow-x-hidden px-0">
+				<SheetHeader className="flex flex-col items-start px-7 pt-8">
 					<SheetTitle>New MCP Server</SheetTitle>
 					<SheetDescription>Configure and connect to a new Model Context Protocol server.</SheetDescription>
 				</SheetHeader>
 
-				<div className="space-y-4 px-4">
-					<div className="space-y-2">
-						<Label htmlFor="client-name">Name</Label>
-						<Input
-							id="client-name"
-							data-testid="client-name-input"
-							value={form.name}
-							onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleChange("name", e.target.value)}
-							placeholder="Server name"
-							maxLength={50}
-						/>
-					</div>
+				<Form {...methods}>
+					<form onSubmit={handleSubmit(onSubmit)} className="flex min-h-0 flex-1 flex-col">
+						<div className="flex-1 space-y-4 overflow-y-auto px-8">
+							{/* Name */}
+							<FormField
+								control={control}
+								name="name"
+								rules={{
+									required: "Server name is required",
+									minLength: { value: 3, message: "Server name must be at least 3 characters" },
+									maxLength: { value: 50, message: "Server name cannot exceed 50 characters" },
+									validate: {
+										format: (v) => /^[a-zA-Z0-9_]+$/.test(v) || "Server name can only contain letters, numbers, and underscores",
+										noLeadingDigit: (v) => !/^[0-9]/.test(v) || "Server name cannot start with a number",
+									},
+								}}
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Name</FormLabel>
+										<FormControl>
+											<Input id="client-name" data-testid="client-name-input" placeholder="Server name" maxLength={50} {...field} />
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
 
-					<div className="w-full space-y-2">
-						<Label>Connection Type</Label>
-						<Select value={form.connection_type} onValueChange={(value: MCPConnectionType) => handleChange("connection_type", value)}>
-							<SelectTrigger className="w-full" data-testid="connection-type-select">
-								<SelectValue placeholder="Select connection type" />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value="http" data-testid="connection-type-http">
-									HTTP (Streamable)
-								</SelectItem>
-								<SelectItem value="sse" data-testid="connection-type-sse">
-									Server-Sent Events (SSE)
-								</SelectItem>
-								<SelectItem value="stdio" data-testid="connection-type-stdio">
-									STDIO
-								</SelectItem>
-							</SelectContent>
-						</Select>
-					</div>
-
-					<div className="flex items-center justify-between space-x-2 rounded-lg border p-4">
-						<div className="flex items-center gap-2">
-							<Label htmlFor="code-mode">Code Mode Server</Label>
-							<TooltipProvider>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<a
-											href="https://docs.getbifrost.ai/mcp/code-mode"
-											target="_blank"
-											rel="noopener noreferrer"
-											data-testid="code-mode-link-help"
-											className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded focus-visible:ring-2 focus-visible:outline-none"
-											aria-label="Learn more about Code Mode"
+							{/* Connection Type */}
+							<FormField
+								control={control}
+								name="connection_type"
+								render={({ field }) => (
+									<FormItem className="w-full">
+										<FormLabel>Connection Type</FormLabel>
+										<Select
+											value={field.value}
+											onValueChange={(value: MCPConnectionType) => {
+												field.onChange(value);
+												if (value === "stdio") {
+													setValue("auth_type", "none");
+													setValue("headers", undefined);
+													setValue("oauth_config", undefined);
+												}
+												clearErrors();
+											}}
 										>
-											<Info className="h-4 w-4 cursor-help" />
-										</a>
-									</TooltipTrigger>
-									<TooltipContent>
-										<p>Learn more about Code Mode</p>
-									</TooltipContent>
-								</Tooltip>
-							</TooltipProvider>
-						</div>
-						<Switch
-							id="code-mode"
-							data-testid="code-mode-switch"
-							checked={form.is_code_mode_client || false}
-							onCheckedChange={(checked) => handleChange("is_code_mode_client", checked)}
-						/>
-					</div>
+											<FormControl>
+												<SelectTrigger className="w-full" data-testid="connection-type-select">
+													<SelectValue placeholder="Select connection type" />
+												</SelectTrigger>
+											</FormControl>
+											<SelectContent>
+												<SelectItem value="http" data-testid="connection-type-http">
+													HTTP (Streamable)
+												</SelectItem>
+												<SelectItem value="sse" data-testid="connection-type-sse">
+													Server-Sent Events (SSE)
+												</SelectItem>
+												<SelectItem value="stdio" data-testid="connection-type-stdio">
+													STDIO
+												</SelectItem>
+											</SelectContent>
+										</Select>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
 
-					<div className="flex items-center justify-between space-x-2 rounded-lg border p-4">
-						<div className="flex items-center gap-2">
-							<Label htmlFor="ping-available">Ping Available for Health Check</Label>
-							<TooltipProvider>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Info className="text-muted-foreground h-4 w-4 cursor-help" />
-									</TooltipTrigger>
-									<TooltipContent className="max-w-xs">
-										<p>
-											Enable to use lightweight ping method for health checks. Disable if your MCP server doesn't support ping - will use
-											listTools instead.
-										</p>
-									</TooltipContent>
-								</Tooltip>
-							</TooltipProvider>
-						</div>
-						<Switch
-							id="ping-available"
-							checked={form.is_ping_available === true}
-							onCheckedChange={(checked) => handleChange("is_ping_available", checked)}
-						/>
-					</div>
-
-					{(form.connection_type === "http" || form.connection_type === "sse") && (
-						<>
-							<div className="space-y-2">
-								<div className="flex w-fit items-center gap-1">
-									<Label>Connection URL</Label>
-									<TooltipProvider>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<span>
-													<Info className="text-muted-foreground ml-1 h-3 w-3" />
-												</span>
-											</TooltipTrigger>
-											<TooltipContent className="max-w-fit">
-												<p>
-													Use <code className="rounded bg-neutral-100 px-1 py-0.5 text-neutral-800">env.&lt;VAR&gt;</code> to read the value
-													from an environment variable.
-												</p>
-											</TooltipContent>
-										</Tooltip>
-									</TooltipProvider>
-								</div>
-
-								<EnvVarInput
-									value={form.connection_string}
-									onChange={handleConnectionStringChange}
-									placeholder="http://your-mcp-server:3000 or env.MCP_SERVER_URL"
-									data-testid="connection-url-input"
-								/>
-							</div>
-							<div className="w-full space-y-2">
-								<Label>Authentication Type</Label>
-								<Select value={form.auth_type} onValueChange={(value: MCPAuthType) => handleChange("auth_type", value)}>
-									<SelectTrigger className="w-full" data-testid="auth-type-select">
-										<SelectValue placeholder="Select authentication type" />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="none" data-testid="auth-type-none">
-											None
-										</SelectItem>
-										<SelectItem value="headers" data-testid="auth-type-headers">
-											Headers
-										</SelectItem>
-										<SelectItem value="oauth" data-testid="auth-type-oauth">
-											OAuth 2.0
-										</SelectItem>
-										<SelectItem value="per_user_oauth" data-testid="auth-type-per-user-oauth">
-											Per-User OAuth 2.0
-										</SelectItem>
-									</SelectContent>
-								</Select>
-							</div>
-							{form.auth_type === "headers" && (
-								<div className="space-y-2" data-testid="mcp-headers-table">
-									<HeadersTable
-										value={form.headers || {}}
-										onChange={handleHeadersChange}
-										keyPlaceholder="Header name"
-										valuePlaceholder="Header value"
-										label="Headers"
-										useEnvVarInput
-									/>
-									{headersValidationError && <p className="text-destructive text-xs">{headersValidationError}</p>}
-								</div>
-							)}
-
-							{(form.auth_type === "oauth" || form.auth_type === "per_user_oauth") && (
-								<>
-									<div className="space-y-2">
+							{/* Code Mode Server */}
+							<FormField
+								control={control}
+								name="is_code_mode_client"
+								render={({ field }) => (
+									<div className="flex items-center justify-between space-x-2 rounded-lg border p-4">
 										<div className="flex items-center gap-2">
-											<Label>OAuth Client ID (optional)</Label>
+											<Label htmlFor="code-mode">Code Mode Server</Label>
+											<TooltipProvider>
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<a
+															href="https://docs.getbifrost.ai/mcp/code-mode"
+															target="_blank"
+															rel="noopener noreferrer"
+															data-testid="code-mode-link-help"
+															className="text-muted-foreground hover:text-foreground focus-visible:ring-ring rounded focus-visible:ring-2 focus-visible:outline-none"
+															aria-label="Learn more about Code Mode"
+														>
+															<Info className="h-4 w-4 cursor-help" />
+														</a>
+													</TooltipTrigger>
+													<TooltipContent>
+														<p>Learn more about Code Mode</p>
+													</TooltipContent>
+												</Tooltip>
+											</TooltipProvider>
+										</div>
+										<Switch id="code-mode" data-testid="code-mode-switch" checked={field.value || false} onCheckedChange={field.onChange} />
+									</div>
+								)}
+							/>
+
+							{/* Ping Available */}
+							<FormField
+								control={control}
+								name="is_ping_available"
+								render={({ field }) => (
+									<div className="flex items-center justify-between space-x-2 rounded-lg border p-4">
+										<div className="flex items-center gap-2">
+											<Label htmlFor="ping-available">Ping Available for Health Check</Label>
 											<TooltipProvider>
 												<Tooltip>
 													<TooltipTrigger asChild>
@@ -445,151 +320,345 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 													</TooltipTrigger>
 													<TooltipContent className="max-w-xs">
 														<p>
-															Leave empty to use Dynamic Client Registration (RFC 7591). Bifrost will automatically register with the OAuth
-															provider if supported.
+															Enable to use lightweight ping method for health checks. Disable if your MCP server doesn't support ping -
+															will use listTools instead.
 														</p>
 													</TooltipContent>
 												</Tooltip>
 											</TooltipProvider>
 										</div>
-										<Input
-											value={form.oauth_config?.client_id || ""}
-											onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleOAuthConfigChange("client_id", e.target.value)}
-											placeholder="your-client-id (auto-generated if empty)"
-										/>
-										<p className="text-muted-foreground text-xs">
-											Will be auto-generated via dynamic registration if left empty and provider supports it
-										</p>
+										<Switch id="ping-available" data-testid="mcp-is-ping-available" checked={field.value === true} onCheckedChange={field.onChange} />
 									</div>
-									<div className="space-y-2">
-										<Label>OAuth Client Secret (optional for PKCE)</Label>
-										<Input
-											type="password"
-											value={form.oauth_config?.client_secret || ""}
-											onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleOAuthConfigChange("client_secret", e.target.value)}
-											placeholder="your-client-secret"
+								)}
+							/>
+
+							{(connectionType === "http" || connectionType === "sse") && (
+								<>
+									{/* Connection URL */}
+									<FormField
+										control={control}
+										name="connection_string"
+										render={({ field }) => (
+											<FormItem>
+												<div className="flex w-fit items-center gap-1">
+													<FormLabel>Connection URL</FormLabel>
+													<TooltipProvider>
+														<Tooltip>
+															<TooltipTrigger asChild>
+																<span>
+																	<Info className="text-muted-foreground ml-1 h-3 w-3" />
+																</span>
+															</TooltipTrigger>
+															<TooltipContent className="max-w-fit">
+																<p>
+																	Use <code className="rounded bg-neutral-100 px-1 py-0.5 text-neutral-800">env.&lt;VAR&gt;</code> to read
+																	the value from an environment variable.
+																</p>
+															</TooltipContent>
+														</Tooltip>
+													</TooltipProvider>
+												</div>
+												<EnvVarInput
+													value={field.value}
+													onChange={(value) => {
+														field.onChange(value);
+														clearErrors("connection_string");
+													}}
+													placeholder="http://your-mcp-server:3000 or env.MCP_SERVER_URL"
+													data-testid="connection-url-input"
+												/>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+
+									{/* Auth Type */}
+									<FormField
+										control={control}
+										name="auth_type"
+										render={({ field }) => (
+											<FormItem className="w-full">
+												<FormLabel>Authentication Type</FormLabel>
+												<Select value={field.value} onValueChange={(value: MCPAuthType) => field.onChange(value)}>
+													<FormControl>
+														<SelectTrigger className="w-full" data-testid="auth-type-select">
+															<SelectValue placeholder="Select authentication type" />
+														</SelectTrigger>
+													</FormControl>
+													<SelectContent>
+														<SelectItem value="none" data-testid="auth-type-none">
+															None
+														</SelectItem>
+														<SelectItem value="headers" data-testid="auth-type-headers">
+															Headers
+														</SelectItem>
+														<SelectItem value="oauth" data-testid="auth-type-oauth">
+															OAuth 2.0
+														</SelectItem>
+														<SelectItem value="per_user_oauth" data-testid="auth-type-per-user-oauth">
+															Per-User OAuth 2.0
+														</SelectItem>
+													</SelectContent>
+												</Select>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+
+									{authType === "headers" && (
+										<FormField
+											control={control}
+											name="headers"
+											render={({ field }) => (
+												<FormItem data-testid="mcp-headers-table">
+													<HeadersTable
+														value={field.value || {}}
+														onChange={field.onChange}
+														keyPlaceholder="Header name"
+														valuePlaceholder="Header value"
+														label="Headers"
+														useEnvVarInput
+													/>
+													{headersValidationError && <p className="text-destructive text-xs">{headersValidationError}</p>}
+													<FormMessage />
+												</FormItem>
+											)}
 										/>
-										<p className="text-muted-foreground text-xs">Leave empty for public clients using PKCE</p>
+									)}
+
+									{(authType === "oauth" || authType === "per_user_oauth") && (
+										<>
+											{/* OAuth Client ID */}
+											<FormField
+												control={control}
+												name="oauth_config.client_id"
+												render={({ field }) => (
+													<FormItem>
+														<div className="flex items-center gap-2">
+															<FormLabel>OAuth Client ID (optional)</FormLabel>
+															<TooltipProvider>
+																<Tooltip>
+																	<TooltipTrigger asChild>
+																		<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+																	</TooltipTrigger>
+																	<TooltipContent className="max-w-xs">
+																		<p>
+																			Leave empty to use Dynamic Client Registration (RFC 7591). Bifrost will automatically register with
+																			the OAuth provider if supported.
+																		</p>
+																	</TooltipContent>
+																</Tooltip>
+															</TooltipProvider>
+														</div>
+														<FormControl>
+															<Input {...field} value={field.value ?? ""} placeholder="your-client-id (auto-generated if empty)" data-testid="mcp-oauth-client-id" />
+														</FormControl>
+														<p className="text-muted-foreground text-xs">
+															Will be auto-generated via dynamic registration if left empty and provider supports it
+														</p>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+
+											{/* OAuth Client Secret */}
+											<FormField
+												control={control}
+												name="oauth_config.client_secret"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>OAuth Client Secret (optional for PKCE)</FormLabel>
+														<FormControl>
+															<Input {...field} type="password" value={field.value ?? ""} placeholder="your-client-secret" data-testid="mcp-oauth-client-secret" />
+														</FormControl>
+														<p className="text-muted-foreground text-xs">Leave empty for public clients using PKCE</p>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+
+											{/* OAuth Authorize URL */}
+											<FormField
+												control={control}
+												name="oauth_config.authorize_url"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Authorization URL (optional, auto-discovered)</FormLabel>
+														<FormControl>
+															<Input
+																{...field}
+																value={field.value ?? ""}
+																onChange={(e) => {
+																	field.onChange(e);
+																	clearErrors("oauth_config.authorize_url");
+																}}
+																placeholder="https://provider.com/oauth/authorize"
+																data-testid="mcp-oauth-authorize-url"
+															/>
+														</FormControl>
+														<FormMessage />
+														<p className="text-muted-foreground text-xs">Will be discovered from server if not provided</p>
+													</FormItem>
+												)}
+											/>
+
+											{/* OAuth Token URL */}
+											<FormField
+												control={control}
+												name="oauth_config.token_url"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Token URL (optional, auto-discovered)</FormLabel>
+														<FormControl>
+															<Input
+																{...field}
+																value={field.value ?? ""}
+																onChange={(e) => {
+																	field.onChange(e);
+																	clearErrors("oauth_config.token_url");
+																}}
+																placeholder="https://provider.com/oauth/token"
+															/>
+														</FormControl>
+														<FormMessage />
+														<p className="text-muted-foreground text-xs">Will be discovered from server if not provided</p>
+													</FormItem>
+												)}
+											/>
+
+											{/* OAuth Registration URL */}
+											<FormField
+												control={control}
+												name="oauth_config.registration_url"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Registration URL (optional, auto-discovered)</FormLabel>
+														<FormControl>
+															<Input
+																{...field}
+																value={field.value ?? ""}
+																onChange={(e) => {
+																	field.onChange(e);
+																	clearErrors("oauth_config.registration_url");
+																}}
+																placeholder="https://provider.com/oauth/register"
+															/>
+														</FormControl>
+														<FormMessage />
+														<p className="text-muted-foreground text-xs">
+															For dynamic client registration, will be discovered if not provided
+														</p>
+													</FormItem>
+												)}
+											/>
+
+											{/* Scopes (local state, not RHF field) */}
+											<div className="space-y-2">
+												<Label>Scopes (optional, comma-separated)</Label>
+												<Input value={scopesText} onChange={(e) => setScopesText(e.target.value)} placeholder="read, write, admin" />
+												<p className="text-muted-foreground text-xs">Will be discovered from server if not provided</p>
+											</div>
+										</>
+									)}
+								</>
+							)}
+
+							{connectionType === "stdio" && (
+								<>
+									<div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
+										<div className="flex items-start gap-2">
+											<Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700" />
+											<div className="flex-1">
+												<p className="text-xs font-medium text-amber-900">Docker Notice</p>
+												<p className="mt-0.5 text-xs text-amber-800">
+													If not using the official Bifrost Docker image, STDIO connections may not work if required commands (npx, python,
+													etc.) aren't installed. You can safely ignore this if running locally or using a custom image with the necessary
+													dependencies.
+												</p>
+											</div>
+										</div>
 									</div>
+
+									{/* STDIO Command */}
+									<FormField
+										control={control}
+										name="stdio_config.command"
+										render={({ field }) => (
+											<FormItem>
+												<FormLabel>Command</FormLabel>
+												<FormControl>
+													<Input
+														{...field}
+														value={field.value ?? ""}
+														onChange={(e) => {
+															field.onChange(e);
+															clearErrors("stdio_config.command");
+														}}
+														placeholder="node, python, /path/to/executable"
+														data-testid="stdio-command-input"
+													/>
+												</FormControl>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+
+									{/* Args (local state) */}
 									<div className="space-y-2">
-										<Label>Authorization URL (optional, auto-discovered)</Label>
+										<Label>Arguments (comma-separated)</Label>
 										<Input
-											value={form.oauth_config?.authorize_url || ""}
-											onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleOAuthConfigChange("authorize_url", e.target.value)}
-											placeholder="https://provider.com/oauth/authorize"
+											value={argsText}
+											onChange={(e) => setArgsText(e.target.value)}
+											placeholder="--port, 3000, --config, config.json"
+											data-testid="stdio-args-input"
 										/>
-										<p className="text-muted-foreground text-xs">Will be discovered from server if not provided</p>
 									</div>
+
+									{/* Envs (local state) */}
 									<div className="space-y-2">
-										<Label>Token URL (optional, auto-discovered)</Label>
+										<Label>Environment Variables (comma-separated)</Label>
 										<Input
-											value={form.oauth_config?.token_url || ""}
-											onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleOAuthConfigChange("token_url", e.target.value)}
-											placeholder="https://provider.com/oauth/token"
+											value={envsText}
+											onChange={(e) => setEnvsText(e.target.value)}
+											placeholder="API_KEY, DATABASE_URL"
+											data-testid="stdio-envs-input"
 										/>
-										<p className="text-muted-foreground text-xs">Will be discovered from server if not provided</p>
-									</div>
-									<div className="space-y-2">
-										<Label>Registration URL (optional, auto-discovered)</Label>
-										<Input
-											value={form.oauth_config?.registration_url || ""}
-											onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleOAuthConfigChange("registration_url", e.target.value)}
-											placeholder="https://provider.com/oauth/register"
-										/>
-										<p className="text-muted-foreground text-xs">For dynamic client registration, will be discovered if not provided</p>
-									</div>
-									<div className="space-y-2">
-										<Label>Scopes (optional, comma-separated)</Label>
-										<Input
-											value={scopesText}
-											onChange={(e: React.ChangeEvent<HTMLInputElement>) => setScopesText(e.target.value)}
-											placeholder="read, write, admin"
-										/>
-										<p className="text-muted-foreground text-xs">Will be discovered from server if not provided</p>
 									</div>
 								</>
 							)}
-						</>
-					)}
+						</div>
 
-					{form.connection_type === "stdio" && (
-						<>
-							<div className="rounded-lg border border-amber-200 bg-amber-50 p-3">
-								<div className="flex items-start gap-2">
-									<Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-700" />
-									<div className="flex-1">
-										<p className="text-xs font-medium text-amber-900">Docker Notice</p>
-										<p className="mt-0.5 text-xs text-amber-800">
-											If not using the official Bifrost Docker image, STDIO connections may not work if required commands (npx, python,
-											etc.) aren't installed. You can safely ignore this if running locally or using a custom image with the necessary
-											dependencies.
-										</p>
-									</div>
-								</div>
+						{/* Form Footer */}
+						<div className="dark:bg-card border-border border-t bg-white px-8 py-4">
+							<div className="flex justify-end gap-2">
+								<Button type="button" variant="outline" onClick={onClose} disabled={isLoading} data-testid="cancel-client-btn">
+									Cancel
+								</Button>
+								<TooltipProvider>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span className="inline-block">
+												<Button
+													type="submit"
+													disabled={isLoading || !hasCreateMCPClientAccess}
+													isLoading={isLoading}
+													data-testid="save-client-btn"
+												>
+													Create
+												</Button>
+											</span>
+										</TooltipTrigger>
+										{!hasCreateMCPClientAccess && (
+											<TooltipContent>
+												<p>You don't have permission to perform this action</p>
+											</TooltipContent>
+										)}
+									</Tooltip>
+								</TooltipProvider>
 							</div>
-							<div className="space-y-2">
-								<Label>Command</Label>
-								<Input
-									value={form.stdio_config?.command || ""}
-									onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleStdioConfigChange("command", e.target.value)}
-									placeholder="node, python, /path/to/executable"
-									data-testid="stdio-command-input"
-								/>
-							</div>
-							<div className="space-y-2">
-								<Label>Arguments (comma-separated)</Label>
-								<Input
-									value={argsText}
-									onChange={(e: React.ChangeEvent<HTMLInputElement>) => setArgsText(e.target.value)}
-									placeholder="--port, 3000, --config, config.json"
-									data-testid="stdio-args-input"
-								/>
-							</div>
-							<div className="space-y-2">
-								<Label>Environment Variables (comma-separated)</Label>
-								<Input
-									value={envsText}
-									onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEnvsText(e.target.value)}
-									placeholder="API_KEY, DATABASE_URL"
-									data-testid="stdio-envs-input"
-								/>
-							</div>
-						</>
-					)}
-				</div>
-				{/* Form Footer */}
-				<div className="dark:bg-card border-border bg-white px-4 py-6">
-					<div className="flex justify-end gap-2">
-						<Button type="button" variant="outline" onClick={onClose} disabled={isLoading} data-testid="cancel-client-btn">
-							Cancel
-						</Button>
-						<TooltipProvider>
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<span className="inline-block">
-										<Button
-											onClick={handleSubmit}
-											disabled={!validator.isValid() || isLoading || !hasCreateMCPClientAccess}
-											isLoading={isLoading}
-											data-testid="save-client-btn"
-										>
-											Create
-										</Button>
-									</span>
-								</TooltipTrigger>
-								{(!validator.isValid() || !hasCreateMCPClientAccess) && (
-									<TooltipContent>
-										<p>
-											{!hasCreateMCPClientAccess
-												? "You don't have permission to perform this action"
-												: validator.getFirstError() || "Please fix validation errors"}
-										</p>
-									</TooltipContent>
-								)}
-							</Tooltip>
-						</TooltipProvider>
-					</div>
-				</div>
+						</div>
+					</form>
+				</Form>
 			</SheetContent>
 
 			{/* OAuth Authorizer Popup */}
@@ -601,20 +670,13 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 						onClose();
 					}}
 					onSuccess={() => {
-						toast({
-							title: "Success",
-							description: "MCP server connected with OAuth",
-						});
+						toast({ title: "Success", description: "MCP server connected with OAuth" });
 						onSaved();
 						setOauthFlow(null);
 						onClose();
 					}}
 					onError={(error) => {
-						toast({
-							title: "OAuth Error",
-							description: error,
-							variant: "destructive",
-						});
+						toast({ title: "OAuth Error", description: error, variant: "destructive" });
 						setOauthFlow(null);
 					}}
 					authorizeUrl={oauthFlow.authorizeUrl}

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -305,30 +305,21 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 
 	return (
 		<Sheet open onOpenChange={onClose}>
-			<SheetContent className="flex w-full flex-col overflow-x-hidden p-8 sm:max-w-[60%]">
+			<SheetContent className="flex w-full flex-col overflow-x-hidden pt-4 sm:max-w-[60%]">
+				<SheetHeader className="w-full p-0 px-8 py-4" showCloseButton={false} headerClassName="mb-0 sticky -top-4 bg-card z-10">
+					<div className="flex w-full items-center justify-between">
+						<div className="space-y-2">
+							<SheetTitle className="flex w-fit items-center gap-2 font-medium">
+								{mcpClient.config.name}
+								<Badge className={MCP_STATUS_COLORS[mcpClient.state]}>{mcpClient.state}</Badge>
+							</SheetTitle>
+							<SheetDescription>MCP server configuration and available tools</SheetDescription>
+						</div>
+					</div>
+				</SheetHeader>
 				<Form {...form}>
 					<form onSubmit={form.handleSubmit(onSubmit)} className="flex h-full flex-col">
-						<SheetHeader className="w-full p-0" showCloseButton={false}>
-							<div className="flex w-full items-center justify-between">
-								<div className="space-y-2">
-									<SheetTitle className="flex w-fit items-center gap-2 font-medium">
-										{mcpClient.config.name}
-										<Badge className={MCP_STATUS_COLORS[mcpClient.state]}>{mcpClient.state}</Badge>
-									</SheetTitle>
-									<SheetDescription>MCP server configuration and available tools</SheetDescription>
-								</div>
-								<Button
-									className="ml-auto"
-									type="submit"
-									disabled={isUpdating || (!form.formState.isDirty && !vkConfigsDirty) || !hasUpdateMCPClientAccess}
-									isLoading={isUpdating}
-								>
-									Save Changes
-								</Button>
-							</div>
-						</SheetHeader>
-
-						<div className="gap-6 space-y-6">
+						<div className="gap-6 space-y-6 px-8">
 							{/* Name and Header Section */}
 							<div className="space-y-4">
 								<h3 className="font-semibold">Basic Information</h3>
@@ -988,6 +979,19 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 									</div>
 								)}
 							</div>
+						</div>
+
+						<div className="bg-card sticky bottom-0 z-10 flex justify-end gap-2 border-t px-8 py-4">
+							<Button type="button" variant="outline" onClick={onClose}>
+								Cancel
+							</Button>
+							<Button
+								type="submit"
+								disabled={isUpdating || (!form.formState.isDirty && !vkConfigsDirty) || !hasUpdateMCPClientAccess}
+								isLoading={isUpdating}
+							>
+								Save Changes
+							</Button>
 						</div>
 					</form>
 				</Form>

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -6,7 +6,6 @@ import NumberAndSelect from "@/components/ui/numberAndSelect";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { resetDurationOptions } from "@/lib/constants/governance";
 import { RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
@@ -110,6 +109,10 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 		(form.watch("requestMaxLimit") !== undefined && form.watch("requestMaxLimit") !== null);
 
 	useEffect(() => {
+		if (hasAnyLimit) form.clearErrors("root");
+	}, [hasAnyLimit, form]);
+
+	useEffect(() => {
 		if (modelConfig) {
 			// Never reset form if user is editing - skip reset entirely
 			if (form.formState.isDirty) {
@@ -131,6 +134,11 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 	const onSubmit = async (data: FormData) => {
 		if (!canSubmit) {
 			toast.error("You don't have permission to perform this action");
+			return;
+		}
+
+		if (!hasAnyLimit) {
+			form.setError("root", { message: "At least one budget or rate limit is required" });
 			return;
 		}
 
@@ -221,7 +229,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 	return (
 		<Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
 			<SheetContent
-				className="flex w-full flex-col overflow-x-hidden p-8"
+				className="flex w-full flex-col overflow-x-hidden pt-4"
 				onInteractOutside={(e) => {
 					if (isEditing ? form.formState.isDirty : !!form.watch("modelName") || hasAnyLimit) e.preventDefault();
 				}}
@@ -230,7 +238,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 				}}
 				data-testid="model-limit-sheet"
 			>
-				<SheetHeader className="flex flex-col items-start p-0">
+				<SheetHeader className="flex flex-col items-start p-0 px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
 					<SheetTitle>{isEditing ? "Edit Model Limit" : "Create Model Limit"}</SheetTitle>
 					<SheetDescription>
 						{isEditing ? "Update budget and rate limit configuration." : "Set up budget and rate limits for a model."}
@@ -239,7 +247,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 
 				<Form {...form}>
 					<form onSubmit={form.handleSubmit(onSubmit)} className="flex h-full flex-col gap-6">
-						<div className="space-y-4">
+						<div className="grow space-y-4 px-8">
 							{/* Provider */}
 							<FormField
 								control={form.control}
@@ -378,6 +386,9 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 										</FormItem>
 									)}
 								/>
+								{form.formState.errors.root && (
+									<p className="text-destructive text-sm">{form.formState.errors.root.message}</p>
+								)}
 							</div>
 
 							{/* Current Usage Display (for editing) */}
@@ -420,55 +431,19 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 						</div>
 
 						{/* Footer */}
-						<div className="py-4">
-							<div className="flex justify-end gap-3">
+						<div className="bg-card sticky bottom-0 shrink-0 border-t px-8 py-4">
+							<div className="flex items-center justify-end gap-3">
+								{!canSubmit && <p className="text-destructive text-sm">You don't have permission to perform this action</p>}
 								<Button type="button" variant="outline" onClick={handleClose}>
 									Cancel
 								</Button>
-								<TooltipProvider>
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<span className="inline-block">
-												<Button
-													type="submit"
-													data-testid="model-limit-button-submit"
-													disabled={
-														isLoading ||
-														!form.formState.isDirty ||
-														!form.formState.isValid ||
-														!canSubmit ||
-														!form.watch("modelName") ||
-														!hasAnyLimit
-													}
-												>
-													{isLoading ? "Saving..." : isEditing ? "Save Changes" : "Create Limit"}
-												</Button>
-											</span>
-										</TooltipTrigger>
-										{(isLoading ||
-											!form.formState.isDirty ||
-											!form.formState.isValid ||
-											!canSubmit ||
-											!form.watch("modelName") ||
-											!hasAnyLimit) && (
-											<TooltipContent>
-												<p>
-													{!canSubmit
-														? "You don't have permission"
-														: isLoading
-															? "Saving..."
-															: !form.formState.isDirty
-																? "No changes made"
-																: !form.watch("modelName")
-																	? "Model name is required"
-																	: !hasAnyLimit
-																		? "At least one budget or rate limit is required"
-																		: "Please fix validation errors"}
-												</p>
-											</TooltipContent>
-										)}
-									</Tooltip>
-								</TooltipProvider>
+								<Button
+									type="submit"
+									data-testid="model-limit-button-submit"
+									disabled={isLoading || !form.formState.isDirty || !canSubmit}
+								>
+									{isLoading ? "Saving..." : isEditing ? "Save Changes" : "Create Limit"}
+								</Button>
 							</div>
 						</div>
 					</form>

--- a/ui/app/workspace/plugins/sheets/addNewPluginSheet.tsx
+++ b/ui/app/workspace/plugins/sheets/addNewPluginSheet.tsx
@@ -149,8 +149,8 @@ export default function AddNewPluginSheet({ open, onClose, onCreate, plugin }: A
 
 	return (
 		<Sheet open={open} onOpenChange={handleClose}>
-			<SheetContent className="flex w-full flex-col overflow-x-hidden p-8">
-				<SheetHeader className="flex flex-col items-start p-0">
+			<SheetContent className="flex w-full flex-col overflow-x-hidden pt-4">
+				<SheetHeader className="flex flex-col items-start px-8 py-4" headerClassName="mb-0 sticky top-0 bg-card z-10">
 					<SheetTitle>{isEditMode ? "Update Plugin" : "Install New Plugin"}</SheetTitle>
 					<SheetDescription>
 						{isEditMode
@@ -161,11 +161,11 @@ export default function AddNewPluginSheet({ open, onClose, onCreate, plugin }: A
 
 				<Form {...form}>
 					<form onSubmit={form.handleSubmit(onSubmit)} className="flex h-full flex-col gap-6">
-						<div className="flex-1 space-y-4">
+						<div className="flex-1 space-y-4 px-8">
 							<PluginFormFragment form={form} isEditMode={isEditMode} />
 						</div>
 
-						<div className="flex justify-end gap-2">
+						<div className="flex justify-end gap-2 bg-card sticky bottom-0 border-t px-8 py-4">
 							<Button type="button" variant="outline" onClick={handleClose} disabled={isLoading}>
 								Cancel
 							</Button>

--- a/ui/app/workspace/providers/dialogs/addNewKeySheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewKeySheet.tsx
@@ -29,8 +29,8 @@ export default function AddNewKeySheet({ show, onCancel, provider, keyId, provid
 				if (!open) onCancel();
 			}}
 		>
-			<SheetContent className="custom-scrollbar p-8" data-testid="key-form" onInteractOutside={(e) => e.preventDefault()}>
-				<SheetHeader className="flex flex-col items-start">
+			<SheetContent className="p-0 pt-4" data-testid="key-form" onInteractOutside={(e) => e.preventDefault()}>
+				<SheetHeader className="flex flex-col items-start px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
 					<SheetTitle>
 						<div className="font-lg flex items-center gap-2">
 							<div className={"flex items-center"}>
@@ -40,17 +40,15 @@ export default function AddNewKeySheet({ show, onCancel, provider, keyId, provid
 						</div>
 					</SheetTitle>
 				</SheetHeader>
-				<div>
-					<ProviderKeyForm
-						provider={provider}
-						keyId={keyId}
-						onCancel={onCancel}
-						onSave={() => {
-							toast.success(successMessage);
-							onCancel();
-						}}
-					/>
-				</div>
+				<ProviderKeyForm
+					provider={provider}
+					keyId={keyId}
+					onCancel={onCancel}
+					onSave={() => {
+						toast.success(successMessage);
+						onCancel();
+					}}
+				/>
 			</SheetContent>
 		</Sheet>
 	);

--- a/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
@@ -96,8 +96,8 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 				if (!open) onCancel();
 			}}
 		>
-			<SheetContent className="custom-scrollbar p-8 sm:max-w-[50%]">
-				<SheetHeader className="flex flex-col items-start">
+			<SheetContent className="p-0 pt-4 sm:max-w-[50%]">
+				<SheetHeader className="flex flex-col items-start px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
 					<SheetTitle>
 						<div className="font-lg flex items-center gap-2">
 							<div className="flex items-center">
@@ -107,47 +107,49 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 						</div>
 					</SheetTitle>
 				</SheetHeader>
-				<div className="w-full rounded-sm border">
-					<Tabs defaultValue={tabs[0]?.id} value={selectedTab} onValueChange={setSelectedTab} className="space-y-6">
-						<div className="custom-scrollbar mb-4 w-full overflow-x-auto">
-							<TabsList className="h-10 w-max min-w-full justify-start rounded-tl-sm rounded-tr-sm rounded-br-none rounded-bl-none">
-								{tabs.map((tab) => (
-									<TabsTrigger
-										key={tab.id}
-										value={tab.id}
-										data-testid={`provider-tab-${tab.id}`}
-										className="flex-none px-3 whitespace-nowrap"
-									>
-										{tab.label}
-									</TabsTrigger>
-								))}
-							</TabsList>
-						</div>
-						<TabsContent value="api-structure">
-							<ApiStructureFormFragment provider={provider} />
-						</TabsContent>
-						<TabsContent value="openai-config">
-							<OpenAIConfigFormFragment provider={provider} />
-						</TabsContent>
-						<TabsContent value="network">
-							<NetworkFormFragment provider={provider} />
-						</TabsContent>
-						<TabsContent value="proxy">
-							<ProxyFormFragment provider={provider} />
-						</TabsContent>
-						<TabsContent value="performance">
-							<PerformanceFormFragment provider={provider} />
-						</TabsContent>
-						<TabsContent value="governance">
-							<GovernanceFormFragment provider={provider} />
-						</TabsContent>
-						<TabsContent value="beta-headers">
-							<BetaHeadersFormFragment provider={provider} />
-						</TabsContent>
-						<TabsContent value="debugging">
-							<DebuggingFormFragment provider={provider} />
-						</TabsContent>
-					</Tabs>
+				<div className="px-8 py-4">
+					<div className="w-full rounded-sm border">
+						<Tabs defaultValue={tabs[0]?.id} value={selectedTab} onValueChange={setSelectedTab}>
+							<div className="custom-scrollbar mb-4 w-full overflow-x-auto">
+								<TabsList className="h-10 w-max min-w-full justify-start rounded-tl-sm rounded-tr-sm rounded-br-none rounded-bl-none">
+									{tabs.map((tab) => (
+										<TabsTrigger
+											key={tab.id}
+											value={tab.id}
+											data-testid={`provider-tab-${tab.id}`}
+											className="flex-none px-3 whitespace-nowrap"
+										>
+											{tab.label}
+										</TabsTrigger>
+									))}
+								</TabsList>
+							</div>
+							<TabsContent value="api-structure">
+								<ApiStructureFormFragment provider={provider} />
+							</TabsContent>
+							<TabsContent value="openai-config">
+								<OpenAIConfigFormFragment provider={provider} />
+							</TabsContent>
+							<TabsContent value="network">
+								<NetworkFormFragment provider={provider} />
+							</TabsContent>
+							<TabsContent value="proxy">
+								<ProxyFormFragment provider={provider} />
+							</TabsContent>
+							<TabsContent value="performance">
+								<PerformanceFormFragment provider={provider} />
+							</TabsContent>
+							<TabsContent value="governance">
+								<GovernanceFormFragment provider={provider} />
+							</TabsContent>
+							<TabsContent value="beta-headers">
+								<BetaHeadersFormFragment provider={provider} />
+							</TabsContent>
+							<TabsContent value="debugging">
+								<DebuggingFormFragment provider={provider} />
+							</TabsContent>
+						</Tabs>
+					</div>
 				</div>
 			</SheetContent>
 		</Sheet>

--- a/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
@@ -96,7 +96,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 
 	return (
 		<Form {...form}>
-			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6">
+			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 p-0">
 				<div className="flex flex-col gap-4">
 					<FormField
 						control={form.control}
@@ -159,7 +159,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 				/>
 
 				{/* Form Actions */}
-				<div className="flex justify-end space-x-2">
+				<div className="flex justify-end gap-2 py-2">
 					<Button type="button" variant="outline" onClick={() => form.reset()} disabled={!hasUpdateProviderAccess}>
 						Reset
 					</Button>

--- a/ui/app/workspace/providers/fragments/betaHeadersFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/betaHeadersFormFragment.tsx
@@ -1,12 +1,12 @@
+import { buildProviderUpdatePayload } from "@/app/workspace/providers/views/utils";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Badge } from "@/components/ui/badge";
 import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
 import { useUpdateProviderMutation } from "@/lib/store/apis/providersApi";
 import { ModelProvider, NetworkConfig } from "@/lib/types/config";
-import { buildProviderUpdatePayload } from "@/app/workspace/providers/views/utils";
 import { betaHeadersFormSchema, type BetaHeadersFormSchema } from "@/lib/types/schemas";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -259,8 +259,8 @@ export function BetaHeadersFormFragment({ provider }: BetaHeadersFormFragmentPro
 
 	return (
 		<Form {...form}>
-			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6" data-testid="provider-config-beta-headers-content">
-				<div className="space-y-2">
+			<form onSubmit={form.handleSubmit(onSubmit)} data-testid="provider-config-beta-headers-content">
+				<div className="space-y-2 px-6 pb-6">
 					<p className="text-muted-foreground text-xs">
 						Configure which Anthropic beta headers are allowed for this provider. Override the defaults when a provider adds or removes
 						support for a beta feature.
@@ -402,7 +402,7 @@ export function BetaHeadersFormFragment({ provider }: BetaHeadersFormFragmentPro
 					</div>
 				</div>
 
-				<div className="flex justify-end space-x-2 pb-6">
+				<div className="bg-card sticky bottom-0 flex justify-end gap-2 rounded-b-sm border-t px-6 py-4">
 					<Button
 						type="submit"
 						disabled={!isManuallyDirty || !hasUpdateProviderAccess || isUpdatingProvider}

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -153,9 +153,9 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 
 	return (
 		<Form {...form}>
-			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6">
+			<form onSubmit={form.handleSubmit(onSubmit)}>
 				{/* Network Configuration */}
-				<div className="space-y-4">
+				<div className="space-y-4 px-6 pb-6">
 					<div className="grid grid-cols-1 gap-4">
 						{!hideBaseURL && (
 							<FormField
@@ -476,7 +476,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				</div>
 
 				{/* Form Actions */}
-				<div className="flex justify-end space-x-2">
+				<div className="bg-card sticky bottom-0 flex justify-end space-x-2 rounded-b-sm border-t px-6 py-4">
 					{!hideBaseURL && (
 						<Button
 							type="button"

--- a/ui/app/workspace/providers/views/providerKeyForm.tsx
+++ b/ui/app/workspace/providers/views/providerKeyForm.tsx
@@ -116,10 +116,12 @@ export default function ProviderKeyForm({ provider, keyId, onCancel, onSave }: P
 
 	return (
 		<Form {...form}>
-			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-				<ApiKeyFormFragment control={form.control} providerName={provider.name} form={form} />
-				{isEditing && currentKey?.config_hash && <ConfigSyncAlert className="mt-4" />}
-				<div className="dark:bg-card bg-white pt-6">
+			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 pt-4">
+				<div className="px-8">
+					<ApiKeyFormFragment control={form.control} providerName={provider.name} form={form} />
+					{isEditing && currentKey?.config_hash && <ConfigSyncAlert className="mt-4" />}
+				</div>
+				<div className="bg-card sticky bottom-0 border-t px-8 py-4">
 					<div className="flex justify-end space-x-3">
 						<Button type="button" variant="outline" onClick={onCancel} data-testid="key-cancel-btn">
 							Cancel
@@ -134,7 +136,7 @@ export default function ProviderKeyForm({ provider, keyId, onCancel, onSave }: P
 											isLoading={form.formState.isSubmitting || isCreatingProviderKey || isUpdatingProviderKey}
 											data-testid="key-save-btn"
 										>
-											<Save className="h-4 w-4" />
+											<Save className="h-4 w-4 shrink-0" />
 											Save
 										</Button>
 									</span>

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -260,337 +260,339 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
-			<SheetContent className="flex w-full min-w-1/2 flex-col gap-4 overflow-x-hidden p-8">
-				<SheetHeader className="flex flex-col items-start">
+			<SheetContent className="flex w-full min-w-1/2 flex-col gap-4 overflow-x-hidden p-0 pt-4">
+				<SheetHeader className="flex flex-col items-start px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
 					<SheetTitle>{isEditing ? "Edit Routing Rule" : "Create New Routing Rule"}</SheetTitle>
 					<SheetDescription>
 						{isEditing ? "Update the routing rule configuration" : "Create a new CEL-based routing rule for intelligent request routing"}
 					</SheetDescription>
 				</SheetHeader>
 
-				<form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-					{/* Rule Name */}
-					<div className="space-y-3">
-						<Label htmlFor="name">
-							Rule Name <span className="text-red-500">*</span>
-						</Label>
-						<Input
-							id="name"
-							placeholder="e.g., Route GPT-4 to Azure"
-							{...register("name", { required: "Rule name is required", maxLength: 255 })}
-						/>
-						{errors.name && <p className="text-destructive text-sm">{errors.name.message}</p>}
-					</div>
-
-					{/* Description */}
-					<div className="space-y-3">
-						<Label htmlFor="description">Description</Label>
-						<Textarea id="description" placeholder="Describe what this rule does..." rows={2} {...register("description")} />
-					</div>
-
-					{/* Enabled Switch */}
-					<div className="flex items-center justify-between rounded-lg border p-4">
-						<div className="space-y-0.5">
-							<Label htmlFor="enabled">Enable Rule</Label>
-							<p className="text-muted-foreground text-sm">Rule will be active and applied to matching requests</p>
-						</div>
-						<Switch id="enabled" checked={enabled} onCheckedChange={(checked) => setValue("enabled", checked)} />
-					</div>
-
-					{/* Chain Rule Switch */}
-					<div className="flex items-center justify-between rounded-lg border p-4">
-						<div className="space-y-0.5">
-							<Label htmlFor="chain_rule">Chain Rule</Label>
-							<p className="text-muted-foreground text-sm">
-								After this rule matches, re-evaluate routing rules using the resolved provider/model as the new context. Useful for
-								composing rules — e.g. normalize a model alias first, then route based on the canonical name.
-							</p>
-						</div>
-						<Switch
-							id="chain_rule"
-							checked={chainRule}
-							onCheckedChange={(checked) => setValue("chain_rule", checked)}
-							data-testid="routing-rule-chain-rule-switch"
-						/>
-					</div>
-
-					{/* Scope and Priority - Side by Side */}
-					<div className="grid grid-cols-2 gap-4">
+				<form onSubmit={handleSubmit(onSubmit)}>
+					<div className="flex flex-col gap-6 px-8">
+						{/* Rule Name */}
 						<div className="space-y-3">
-							<Label htmlFor="scope">Scope</Label>
-							<Select
-								value={scope}
-								onValueChange={(value) => {
-									setValue("scope", value as any);
-									// Clear scope_id when scope changes
-									setValue("scope_id", "");
-								}}
-							>
-								<SelectTrigger className="w-full">
-									<SelectValue placeholder="Select scope..." />
-								</SelectTrigger>
-								<SelectContent>
-									{ROUTING_RULE_SCOPES.map((scopeOption) => (
-										<SelectItem key={scopeOption.value} value={scopeOption.value}>
-											{scopeOption.label}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</div>
-
-						<div className="space-y-3">
-							<Label htmlFor="priority">
-								Priority <span className="text-red-500">*</span>
+							<Label htmlFor="name">
+								Rule Name <span className="text-red-500">*</span>
 							</Label>
 							<Input
-								id="priority"
-								type="number"
-								min={0}
-								max={1000}
-								{...register("priority", {
-									required: "Priority is required",
-									min: { value: 0, message: "Priority must be ≥ 0" },
-									max: { value: 1000, message: "Priority must be ≤ 1000" },
-									valueAsNumber: true,
-								})}
+								id="name"
+								placeholder="e.g., Route GPT-4 to Azure"
+								{...register("name", { required: "Rule name is required", maxLength: 255 })}
 							/>
-							<p className="text-muted-foreground text-xs">Lower numbers = higher priority (0 is highest)</p>
-							{errors.priority && <p className="text-destructive text-sm">{errors.priority.message}</p>}
-						</div>
-					</div>
-
-					{scope !== "global" && (
-						<div className="space-y-2">
-							<Label htmlFor="scope_id">
-								{scope === "team" ? "Team" : scope === "customer" ? "Customer" : "Virtual Key"} <span className="text-red-500">*</span>
-							</Label>
-							{scope === "team" && teamsData.teams.length > 0 && (
-								<Select value={scopeId || ""} onValueChange={(value) => setValue("scope_id", value)}>
-									<SelectTrigger className="w-full">
-										<SelectValue placeholder="Select a team..." />
-									</SelectTrigger>
-									<SelectContent>
-										{teamsData.teams.map((team) => (
-											<SelectItem key={team.id} value={team.id}>
-												{team.name}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-							)}
-							{scope === "customer" && customersData.customers.length > 0 && (
-								<Select value={scopeId || ""} onValueChange={(value) => setValue("scope_id", value)}>
-									<SelectTrigger className="w-full">
-										<SelectValue placeholder="Select a customer..." />
-									</SelectTrigger>
-									<SelectContent>
-										{customersData.customers.map((customer) => (
-											<SelectItem key={customer.id} value={customer.id}>
-												{customer.name}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-							)}
-							{scope === "virtual_key" && vksData.virtual_keys.length > 0 && (
-								<Select value={scopeId || ""} onValueChange={(value) => setValue("scope_id", value)}>
-									<SelectTrigger className="w-full">
-										<SelectValue placeholder="Select a virtual key..." />
-									</SelectTrigger>
-									<SelectContent>
-										{vksData.virtual_keys.map((vk) => (
-											<SelectItem key={vk.id} value={vk.id}>
-												{vk.name}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
-							)}
-							{((scope === "team" && teamsData.teams.length === 0) ||
-								(scope === "customer" && customersData.customers.length === 0) ||
-								(scope === "virtual_key" && vksData.virtual_keys.length === 0)) && (
-									<p className="text-muted-foreground text-sm">
-										No {scope === "team" ? "teams" : scope === "customer" ? "customers" : "virtual keys"} available
-									</p>
-								)}
-							{errors.scope_id && <p className="text-destructive text-sm">{errors.scope_id.message}</p>}
-						</div>
-					)}
-
-					<Separator />
-
-					{/* CEL Rule Builder */}
-					<div className="space-y-3">
-						<Label>Rule Builder</Label>
-						<p className="text-muted-foreground text-sm">
-							Build conditions to determine when this rule should apply. Leave empty to apply this rule to all requests.
-						</p>
-						<CELRuleBuilder
-							key={builderKey}
-							initialQuery={query}
-							onChange={handleQueryChange}
-							providers={availableProviders}
-							models={[]}
-							allowCustomModels={true}
-						/>
-					</div>
-
-					{/* Note about Token/Request Limits and Budget Configuration */}
-					<p className="text-muted-foreground text-xs">
-						Note: Ensure token limits, request limits, and budget are configured in{" "}
-						<strong>Model Providers → Configurations → {"{provider}"} → Governance</strong> (provider-level) or{" "}
-						<strong>Model Providers → Budgets & Limits</strong> section (model-level) before using them in routing rules.
-					</p>
-
-					<Separator />
-
-					{/* Routing Targets */}
-					<div className="space-y-3">
-						<div className="flex items-center justify-between">
-							<div>
-								<Label>Routing Targets</Label>
-								<p className="text-muted-foreground mt-0.5 text-xs">
-									Weights must sum to 1. Leave provider or model empty to use the incoming request value.
-								</p>
-							</div>
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onClick={addTarget}
-								className="shrink-0 gap-2"
-								data-testid="routing-rule-target-add"
-							>
-								<Plus className="h-4 w-4" />
-								Add Target
-							</Button>
+							{errors.name && <p className="text-destructive text-sm">{errors.name.message}</p>}
 						</div>
 
+						{/* Description */}
 						<div className="space-y-3">
-							{targets.map((target, index) => (
-								<TargetRow
-									key={index}
-									target={target}
-									index={index}
-									availableProviders={availableProviders}
-									allKeys={allKeysData}
-									showRemove={targets.length > 1}
-									onUpdate={updateTarget}
-									onRemove={removeTarget}
-								/>
-							))}
+							<Label htmlFor="description">Description</Label>
+							<Textarea id="description" placeholder="Describe what this rule does..." rows={2} {...register("description")} />
 						</div>
 
-						{/* Weight sum indicator */}
-						<div
-							className={`flex items-center justify-end gap-2 text-xs font-medium ${Math.abs(totalWeight - 1) > 0.001 ? "text-destructive" : "text-muted-foreground"}`}
-						>
-							Total weight: {totalWeight.toFixed(4)}
-							{Math.abs(totalWeight - 1) > 0.001 && <span className="text-destructive">(must equal 1)</span>}
+						{/* Enabled Switch */}
+						<div className="flex items-center justify-between rounded-lg border p-4">
+							<div className="space-y-0.5">
+								<Label htmlFor="enabled">Enable Rule</Label>
+								<p className="text-muted-foreground text-sm">Rule will be active and applied to matching requests</p>
+							</div>
+							<Switch id="enabled" checked={enabled} onCheckedChange={(checked) => setValue("enabled", checked)} />
 						</div>
-					</div>
 
-					{/* Fallbacks */}
-					<div className="space-y-3">
-						<div className="flex items-center justify-between">
-							<div>
-								<Label>Fallbacks</Label>								<p className="text-muted-foreground text-xs mt-0.5">
-									Provider is required, but model is optional. Leave model empty to use the incoming request value.
+						{/* Chain Rule Switch */}
+						<div className="flex items-center justify-between rounded-lg border p-4">
+							<div className="space-y-0.5">
+								<Label htmlFor="chain_rule">Chain Rule</Label>
+								<p className="text-muted-foreground text-sm">
+									After this rule matches, re-evaluate routing rules using the resolved provider/model as the new context. Useful for
+									composing rules — e.g. normalize a model alias first, then route based on the canonical name.
 								</p>
 							</div>
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onClick={() => setValue("fallbacks", [...(fallbacks || []), ""])}
-								className="gap-2"
+							<Switch
+								id="chain_rule"
+								checked={chainRule}
+								onCheckedChange={(checked) => setValue("chain_rule", checked)}
+								data-testid="routing-rule-chain-rule-switch"
+							/>
+						</div>
+
+						{/* Scope and Priority - Side by Side */}
+						<div className="grid grid-cols-2 gap-4">
+							<div className="space-y-3">
+								<Label htmlFor="scope">Scope</Label>
+								<Select
+									value={scope}
+									onValueChange={(value) => {
+										setValue("scope", value as any);
+										// Clear scope_id when scope changes
+										setValue("scope_id", "");
+									}}
+								>
+									<SelectTrigger className="w-full">
+										<SelectValue placeholder="Select scope..." />
+									</SelectTrigger>
+									<SelectContent>
+										{ROUTING_RULE_SCOPES.map((scopeOption) => (
+											<SelectItem key={scopeOption.value} value={scopeOption.value}>
+												{scopeOption.label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+
+							<div className="space-y-3">
+								<Label htmlFor="priority">
+									Priority <span className="text-red-500">*</span>
+								</Label>
+								<Input
+									id="priority"
+									type="number"
+									min={0}
+									max={1000}
+									{...register("priority", {
+										required: "Priority is required",
+										min: { value: 0, message: "Priority must be ≥ 0" },
+										max: { value: 1000, message: "Priority must be ≤ 1000" },
+										valueAsNumber: true,
+									})}
+								/>
+								<p className="text-muted-foreground text-xs">Lower numbers = higher priority (0 is highest)</p>
+								{errors.priority && <p className="text-destructive text-sm">{errors.priority.message}</p>}
+							</div>
+						</div>
+
+						{scope !== "global" && (
+							<div className="space-y-2">
+								<Label htmlFor="scope_id">
+									{scope === "team" ? "Team" : scope === "customer" ? "Customer" : "Virtual Key"} <span className="text-red-500">*</span>
+								</Label>
+								{scope === "team" && teamsData.teams.length > 0 && (
+									<Select value={scopeId || ""} onValueChange={(value) => setValue("scope_id", value)}>
+										<SelectTrigger className="w-full">
+											<SelectValue placeholder="Select a team..." />
+										</SelectTrigger>
+										<SelectContent>
+											{teamsData.teams.map((team) => (
+												<SelectItem key={team.id} value={team.id}>
+													{team.name}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								)}
+								{scope === "customer" && customersData.customers.length > 0 && (
+									<Select value={scopeId || ""} onValueChange={(value) => setValue("scope_id", value)}>
+										<SelectTrigger className="w-full">
+											<SelectValue placeholder="Select a customer..." />
+										</SelectTrigger>
+										<SelectContent>
+											{customersData.customers.map((customer) => (
+												<SelectItem key={customer.id} value={customer.id}>
+													{customer.name}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								)}
+								{scope === "virtual_key" && vksData.virtual_keys.length > 0 && (
+									<Select value={scopeId || ""} onValueChange={(value) => setValue("scope_id", value)}>
+										<SelectTrigger className="w-full">
+											<SelectValue placeholder="Select a virtual key..." />
+										</SelectTrigger>
+										<SelectContent>
+											{vksData.virtual_keys.map((vk) => (
+												<SelectItem key={vk.id} value={vk.id}>
+													{vk.name}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								)}
+								{((scope === "team" && teamsData.teams.length === 0) ||
+									(scope === "customer" && customersData.customers.length === 0) ||
+									(scope === "virtual_key" && vksData.virtual_keys.length === 0)) && (
+										<p className="text-muted-foreground text-sm">
+											No {scope === "team" ? "teams" : scope === "customer" ? "customers" : "virtual keys"} available
+										</p>
+									)}
+								{errors.scope_id && <p className="text-destructive text-sm">{errors.scope_id.message}</p>}
+							</div>
+						)}
+
+						<Separator />
+
+						{/* CEL Rule Builder */}
+						<div className="space-y-3">
+							<Label>Rule Builder</Label>
+							<p className="text-muted-foreground text-sm">
+								Build conditions to determine when this rule should apply. Leave empty to apply this rule to all requests.
+							</p>
+							<CELRuleBuilder
+								key={builderKey}
+								initialQuery={query}
+								onChange={handleQueryChange}
+								providers={availableProviders}
+								models={[]}
+								allowCustomModels={true}
+							/>
+						</div>
+
+						{/* Note about Token/Request Limits and Budget Configuration */}
+						<p className="text-muted-foreground text-xs">
+							Note: Ensure token limits, request limits, and budget are configured in{" "}
+							<strong>Model Providers → Configurations → {"{provider}"} → Governance</strong> (provider-level) or{" "}
+							<strong>Model Providers → Budgets & Limits</strong> section (model-level) before using them in routing rules.
+						</p>
+
+						<Separator />
+
+						{/* Routing Targets */}
+						<div className="space-y-3">
+							<div className="flex items-center justify-between">
+								<div>
+									<Label>Routing Targets</Label>
+									<p className="text-muted-foreground mt-0.5 text-xs">
+										Weights must sum to 1. Leave provider or model empty to use the incoming request value.
+									</p>
+								</div>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={addTarget}
+									className="shrink-0 gap-2"
+									data-testid="routing-rule-target-add"
+								>
+									<Plus className="h-4 w-4" />
+									Add Target
+								</Button>
+							</div>
+
+							<div className="space-y-3">
+								{targets.map((target, index) => (
+									<TargetRow
+										key={index}
+										target={target}
+										index={index}
+										availableProviders={availableProviders}
+										allKeys={allKeysData}
+										showRemove={targets.length > 1}
+										onUpdate={updateTarget}
+										onRemove={removeTarget}
+									/>
+								))}
+							</div>
+
+							{/* Weight sum indicator */}
+							<div
+								className={`flex items-center justify-end gap-2 text-xs font-medium ${Math.abs(totalWeight - 1) > 0.001 ? "text-destructive" : "text-muted-foreground"}`}
 							>
-								<Plus className="h-4 w-4" />
-								Add Fallback
-							</Button>
+								Total weight: {totalWeight.toFixed(4)}
+								{Math.abs(totalWeight - 1) > 0.001 && <span className="text-destructive">(must equal 1)</span>}
+							</div>
 						</div>
-						<div className="space-y-2">
-							{(fallbacks || []).length === 0 ? (
-								<p className="text-muted-foreground text-sm">No fallbacks configured</p>
-							) : (
-								(fallbacks || []).map((fallback, index) => {
-									// Parse provider/model from fallback string
-									const parts = fallback.split("/");
-									const fbProvider = parts[0] || "";
-									const fbModel = parts[1] || "";
 
-									const handleProviderChange = (newProvider: string) => {
-										const model = fbModel || "";
-										const newFallback = `${newProvider}/${model}`;
-										const newFallbacks = [...fallbacks];
-										newFallbacks[index] = newFallback;
-										setValue("fallbacks", newFallbacks);
-									};
+						{/* Fallbacks */}
+						<div className="space-y-3">
+							<div className="flex items-center justify-between">
+								<div>
+									<Label>Fallbacks</Label>								<p className="text-muted-foreground text-xs mt-0.5">
+										Provider is required, but model is optional. Leave model empty to use the incoming request value.
+									</p>
+								</div>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => setValue("fallbacks", [...(fallbacks || []), ""])}
+									className="gap-2"
+								>
+									<Plus className="h-4 w-4" />
+									Add Fallback
+								</Button>
+							</div>
+							<div className="space-y-2">
+								{(fallbacks || []).length === 0 ? (
+									<p className="text-muted-foreground text-sm">No fallbacks configured</p>
+								) : (
+									(fallbacks || []).map((fallback, index) => {
+										// Parse provider/model from fallback string
+										const parts = fallback.split("/");
+										const fbProvider = parts[0] || "";
+										const fbModel = parts[1] || "";
 
-									const handleModelChange = (newModel: string) => {
-										const prov = fbProvider || "";
-										const newFallback = `${prov}/${newModel}`;
-										const newFallbacks = [...fallbacks];
-										newFallbacks[index] = newFallback;
-										setValue("fallbacks", newFallbacks);
-									};
+										const handleProviderChange = (newProvider: string) => {
+											const model = fbModel || "";
+											const newFallback = `${newProvider}/${model}`;
+											const newFallbacks = [...fallbacks];
+											newFallbacks[index] = newFallback;
+											setValue("fallbacks", newFallbacks);
+										};
 
-									const handleRemove = () => {
-										const newFallbacks = fallbacks.filter((_: string, i: number) => i !== index);
-										setValue("fallbacks", newFallbacks);
-									};
+										const handleModelChange = (newModel: string) => {
+											const prov = fbProvider || "";
+											const newFallback = `${prov}/${newModel}`;
+											const newFallbacks = [...fallbacks];
+											newFallbacks[index] = newFallback;
+											setValue("fallbacks", newFallbacks);
+										};
 
-									return (
-										<div key={index} className="flex items-center gap-2">
-											<div className="flex-1">
-												<Select value={fbProvider} onValueChange={handleProviderChange}>
-													<SelectTrigger className="w-full">
-														<SelectValue placeholder="Select provider..." />
-													</SelectTrigger>
-													<SelectContent>
-														{availableProviders.map((prov) => (
-															<SelectItem key={prov} value={prov}>
-																<div className="flex items-center gap-2">
-																	<RenderProviderIcon provider={prov as ProviderIconType} size="sm" className="h-4 w-4" />
-																	<span>{getProviderLabel(prov)}</span>
-																</div>
-															</SelectItem>
-														))}
-													</SelectContent>
-												</Select>
+										const handleRemove = () => {
+											const newFallbacks = fallbacks.filter((_: string, i: number) => i !== index);
+											setValue("fallbacks", newFallbacks);
+										};
+
+										return (
+											<div key={index} className="flex items-center gap-2">
+												<div className="flex-1">
+													<Select value={fbProvider} onValueChange={handleProviderChange}>
+														<SelectTrigger className="w-full">
+															<SelectValue placeholder="Select provider..." />
+														</SelectTrigger>
+														<SelectContent>
+															{availableProviders.map((prov) => (
+																<SelectItem key={prov} value={prov}>
+																	<div className="flex items-center gap-2">
+																		<RenderProviderIcon provider={prov as ProviderIconType} size="sm" className="h-4 w-4" />
+																		<span>{getProviderLabel(prov)}</span>
+																	</div>
+																</SelectItem>
+															))}
+														</SelectContent>
+													</Select>
+												</div>
+												<div className="flex-1">
+													<ModelMultiselect
+														provider={fbProvider || undefined}
+														value={fbModel}
+														onChange={handleModelChange}
+														placeholder="Incoming (optional)"
+														isSingleSelect
+														disabled={!fbProvider}
+														className="!h-9 !min-h-9 w-full"
+													/>
+												</div>
+												<Button
+													type="button"
+													variant="ghost"
+													size="sm"
+													onClick={handleRemove}
+													className="h-9 px-2"
+													aria-label={`Remove fallback ${index + 1}`}
+												>
+													<Trash2 className="h-4 w-4" />
+												</Button>
 											</div>
-											<div className="flex-1">
-												<ModelMultiselect
-													provider={fbProvider || undefined}
-													value={fbModel}
-													onChange={handleModelChange}
-													placeholder="Incoming (optional)"
-													isSingleSelect
-													disabled={!fbProvider}
-													className="!h-9 !min-h-9 w-full"
-												/>
-											</div>
-											<Button
-												type="button"
-												variant="ghost"
-												size="sm"
-												onClick={handleRemove}
-												className="h-9 px-2"
-												aria-label={`Remove fallback ${index + 1}`}
-											>
-												<Trash2 className="h-4 w-4" />
-											</Button>
-										</div>
-									);
-								})
-							)}
+										);
+									})
+								)}
+							</div>
+							<p className="text-muted-foreground text-xs">Fallbacks will be used in the order they are defined</p>
 						</div>
-						<p className="text-muted-foreground text-xs">Fallbacks will be used in the order they are defined</p>
+
 					</div>
-
 					{/* Action Buttons */}
-					<div className="flex justify-end gap-3">
+					<div className="bg-card sticky bottom-0 flex justify-end gap-3 border-t px-8 py-4">
 						<Button type="button" variant="outline" onClick={handleCancel} disabled={isLoading}>
 							<X className="h-4 w-4" />
 							Cancel

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -16,11 +16,12 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
 import { getErrorMessage } from "@/lib/store";
-import { useDeleteRoutingRuleMutation } from "@/lib/store/apis/routingRulesApi";
+import { useDeleteRoutingRuleMutation, useUpdateRoutingRuleMutation } from "@/lib/store/apis/routingRulesApi";
 import { RoutingRule, RoutingTarget } from "@/lib/types/routingRules";
 import { getPriorityBadgeClass, getScopeLabel, truncateCELExpression } from "@/lib/utils/routingRules";
 import { ChevronLeft, ChevronRight, Edit, Search, Trash2 } from "lucide-react";
@@ -35,6 +36,8 @@ interface RoutingRulesTableProps {
 	onRowClick: (rule: RoutingRule) => void;
 	/** When false, delete button is hidden and deletion is disabled (e.g. for read-only users). */
 	canDelete?: boolean;
+	/** When false, enabled toggle is disabled (e.g. for read-only users). */
+	canUpdate?: boolean;
 	search: string;
 	onSearchChange: (value: string) => void;
 	offset: number;
@@ -49,6 +52,7 @@ export function RoutingRulesTable({
 	onEdit,
 	onRowClick,
 	canDelete = false,
+	canUpdate = false,
 	search,
 	onSearchChange,
 	offset,
@@ -57,6 +61,7 @@ export function RoutingRulesTable({
 }: RoutingRulesTableProps) {
 	const [deleteRuleId, setDeleteRuleId] = useState<string | null>(null);
 	const [deleteRoutingRule, { isLoading: isDeleting }] = useDeleteRoutingRuleMutation();
+	const [updateRoutingRule] = useUpdateRoutingRuleMutation();
 
 	const handleDelete = async () => {
 		if (!canDelete || !deleteRuleId) return;
@@ -81,7 +86,7 @@ export function RoutingRulesTable({
 							<TableHead>Scope</TableHead>
 							<TableHead className="text-right">Priority</TableHead>
 							<TableHead>Expression</TableHead>
-							<TableHead>Status</TableHead>
+							<TableHead>Enabled</TableHead>
 							<TableHead className="text-right">Actions</TableHead>
 						</TableRow>
 					</TableHeader>
@@ -166,8 +171,23 @@ export function RoutingRulesTable({
 											{truncateCELExpression(rule.cel_expression)}
 										</span>
 									</TableCell>
-									<TableCell>
-										<Badge variant={rule.enabled ? "default" : "secondary"}>{rule.enabled ? "Enabled" : "Disabled"}</Badge>
+									<TableCell onClick={(e) => e.stopPropagation()}>
+										<Switch
+											data-testid={`routing-rule-enabled-${rule.id}-switch`}
+											checked={rule.enabled ?? true}
+											size="md"
+											disabled={!canUpdate}
+											onAsyncCheckedChange={async (checked) => {
+												await updateRoutingRule({ id: rule.id, data: { enabled: checked } })
+													.unwrap()
+													.then(() => {
+														toast.success(`Rule ${checked ? "enabled" : "disabled"} successfully`);
+													})
+													.catch((err) => {
+														toast.error("Failed to update rule", { description: getErrorMessage(err) });
+													});
+											}}
+										/>
 									</TableCell>
 									<TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
 										<div className="flex items-center justify-end gap-2">

--- a/ui/app/workspace/routing-rules/views/routingRulesView.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesView.tsx
@@ -38,6 +38,7 @@ export function RoutingRulesView() {
 	// Permissions
 	const canCreate = useRbac(RbacResource.RoutingRules, RbacOperation.Create);
 	const canDelete = useRbac(RbacResource.RoutingRules, RbacOperation.Delete);
+	const canUpdate = useRbac(RbacResource.RoutingRules, RbacOperation.Update);
 
 	// API
 	const { data: rulesData, isLoading } = useGetRoutingRulesQuery(
@@ -125,6 +126,7 @@ export function RoutingRulesView() {
 				onEdit={handleEdit}
 				onRowClick={handleRowClick}
 				canDelete={canDelete}
+				canUpdate={canUpdate}
 				search={search}
 				onSearchChange={setSearch}
 				offset={offset}

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -2,14 +2,14 @@ import { useVirtualKeyUsage } from "@/app/workspace/virtual-keys/hooks/useVirtua
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
 } from "@/components/ui/alertDialog";
 import { AsyncMultiSelect } from "@/components/ui/asyncMultiselect";
 import { Button } from "@/components/ui/button";
@@ -35,12 +35,12 @@ import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import {
-  getErrorMessage,
-  useCreateVirtualKeyMutation,
-  useGetAllKeysQuery,
-  useGetMCPClientsQuery,
-  useGetProvidersQuery,
-  useUpdateVirtualKeyMutation,
+	getErrorMessage,
+	useCreateVirtualKeyMutation,
+	useGetAllKeysQuery,
+	useGetMCPClientsQuery,
+	useGetProvidersQuery,
+	useUpdateVirtualKeyMutation,
 } from "@/lib/store";
 import { KnownProvider } from "@/lib/types/config";
 import { CreateVirtualKeyRequest, Customer, Team, UpdateVirtualKeyRequest, VirtualKey } from "@/lib/types/governance";
@@ -169,7 +169,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 	// Team attachment: when a VK already belongs to a team (edit) or will be created for one
 	// (create from team detail sheet via defaultTeamId), the team assignment is fixed — users
 	// can still edit providers/budgets/rate limits/MCP, but not reparent the VK.
-	const attachedTeamId = isEditing ? (virtualKey?.team_id || "") : (defaultTeamId || "");
+	const attachedTeamId = isEditing ? virtualKey?.team_id || "" : defaultTeamId || "";
 	const attachedTeam = attachedTeamId ? teams.find((t) => t.id === attachedTeamId) : undefined;
 	const isTeamLocked = !!attachedTeamId;
 
@@ -224,13 +224,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 					mcp_client_name: config.mcp_client?.name || "",
 					tools_to_execute: config.tools_to_execute || [],
 				})) || [],
-			entityType: virtualKey?.team_id
-				? "team"
-				: virtualKey?.customer_id
-					? "customer"
-					: !isEditing && defaultTeamId
-						? "team"
-						: "none",
+			entityType: virtualKey?.team_id ? "team" : virtualKey?.customer_id ? "customer" : !isEditing && defaultTeamId ? "team" : "none",
 			teamId: virtualKey?.team_id || (!isEditing ? defaultTeamId || "" : ""),
 			customerId: virtualKey?.customer_id || "",
 			isActive: virtualKey?.is_active ?? true,
@@ -528,12 +522,12 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 	return (
 		<Sheet open={isOpen} onOpenChange={(open) => !open && handleClose()}>
 			<SheetContent
-				className="flex w-full flex-col overflow-x-hidden px-4 pb-8"
+				className="flex w-full flex-col gap-4 overflow-x-hidden p-0 pt-4"
 				data-testid="vk-sheet-content"
 				onInteractOutside={(e) => e.preventDefault()}
 				onEscapeKeyDown={() => handleClose()}
 			>
-				<SheetHeader className="flex flex-col items-start px-3 pt-8">
+				<SheetHeader className="flex flex-col items-start px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
 					<SheetTitle className="flex items-center gap-2">{isEditing ? virtualKey?.name : "Create Virtual Key"}</SheetTitle>
 					<SheetDescription>
 						{isEditing
@@ -543,14 +537,14 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 				</SheetHeader>
 
 				<Form {...form}>
-					<form onSubmit={form.handleSubmit(onSubmit)} className="flex h-full flex-col gap-6 px-4">
-						<div className="space-y-4">
+					<form onSubmit={form.handleSubmit(onSubmit)} className="flex h-full flex-col gap-6">
+						<div className="space-y-4 px-8">
 							{isManagedByProfile && (
 								<Alert variant="info">
 									<Lock className="h-4 w-4" />
 									<AlertDescription>
-										This virtual key is managed by an access profile. Only the name and description can be modified — providers, budgets, rate limits, and
-										MCP access are controlled by the profile.
+										This virtual key is managed by an access profile. Only the name and description can be modified — providers, budgets,
+										rate limits, and MCP access are controlled by the profile.
 									</AlertDescription>
 								</Alert>
 							)}
@@ -559,17 +553,19 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 								<Alert variant="info">
 									<Users className="h-4 w-4" />
 									<AlertDescription>
-										<p>This virtual key is attached to team{" "}
-										<a
-											data-testid="vk-team-link"
-											href={`/workspace/governance/teams?team=${encodeURIComponent(attachedTeamId)}`}
-											target="_blank"
-											rel="noopener noreferrer"
-											className="font-medium underline underline-offset-2 hover:no-underline"
-										>
-											{attachedTeam?.name ?? virtualKey?.team?.name ?? attachedTeamId}
-										</a>
-										. The team assignment can't be changed here — all other fields remain editable.</p>
+										<p>
+											This virtual key is attached to team{" "}
+											<a
+												data-testid="vk-team-link"
+												href={`/workspace/governance/teams?team=${encodeURIComponent(attachedTeamId)}`}
+												target="_blank"
+												rel="noopener noreferrer"
+												className="font-medium underline underline-offset-2 hover:no-underline"
+											>
+												{attachedTeam?.name ?? virtualKey?.team?.name ?? attachedTeamId}
+											</a>
+											. The team assignment can't be changed here — all other fields remain editable.
+										</p>
 									</AlertDescription>
 								</Alert>
 							)}
@@ -614,7 +610,6 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 										</FormItem>
 									)}
 								/>
-
 							</div>
 							<fieldset
 								disabled={isManagedByProfile}
@@ -622,435 +617,21 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 								inert={isManagedByProfile ? true : undefined}
 								className={isManagedByProfile ? "pointer-events-none space-y-4 opacity-50" : "space-y-4"}
 							>
-							<div className="space-y-4">
-								<FormField
-									control={form.control}
-									name="isActive"
-									render={({ field }) => (
-										<FormItem>
-											<Toggle label="Is this key active?" val={field.value} setVal={field.onChange} data-testid="vk-is-active-toggle" />
-										</FormItem>
-									)}
-								/>
-							</div>
-							{/* Provider Configurations */}
-							<div className="space-y-2">
-								<div className="flex items-center gap-2">
-									<Label className="text-sm font-medium">Provider Configurations</Label>
-									<TooltipProvider>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<span>
-													<Info className="text-muted-foreground h-3 w-3" />
-												</span>
-											</TooltipTrigger>
-											<TooltipContent>
-												<p>
-													Configure which providers this virtual key can use and their specific settings. Leave empty to block all
-													providers. Add providers to allow them.
-												</p>
-											</TooltipContent>
-										</Tooltip>
-									</TooltipProvider>
+								<div className="space-y-4">
+									<FormField
+										control={form.control}
+										name="isActive"
+										render={({ field }) => (
+											<FormItem>
+												<Toggle label="Is this key active?" val={field.value} setVal={field.onChange} data-testid="vk-is-active-toggle" />
+											</FormItem>
+										)}
+									/>
 								</div>
-
-								{/* Add Provider Dropdown */}
-								<div className="flex gap-2">
-									<Select
-										value={selectedProvider}
-										onValueChange={(provider) => {
-											if (provider === "__manage_providers__") {
-												navigate({ to: "/workspace/providers" });
-												setSelectedProvider("");
-												return;
-											}
-											handleAddProvider(provider);
-											setSelectedProvider(""); // Reset to placeholder state
-										}}
-									>
-										<SelectTrigger className="flex-1" data-testid="vk-provider-select">
-											<SelectValue placeholder="Select a provider to add" />
-										</SelectTrigger>
-										<SelectContent>
-											{(() => {
-												// Filter out already configured providers
-												const unconfiguredProviders = availableProviders.filter(
-													(provider) => !providerConfigs.some((config) => config.provider === provider.name),
-												);
-
-												if (unconfiguredProviders.length === 0) {
-													return (
-														<SelectItem
-															value="__manage_providers__"
-															className="text-muted-foreground hover:text-foreground"
-															data-testid="vk-provider-config-link"
-														>
-															<span>
-																No providers left to configure. <span className="text-primary font-medium underline">Click to add</span>
-															</span>
-														</SelectItem>
-													);
-												}
-
-												// Separate base providers and custom providers
-												const baseProviders = unconfiguredProviders.filter((provider) => !provider.custom_provider_config);
-												const customProviders = unconfiguredProviders.filter((provider) => provider.custom_provider_config);
-
-												return (
-													<>
-														{/* Base providers first */}
-														{baseProviders
-															.filter((p) => p.name)
-															.map((provider, index) => (
-																<SelectItem key={`base-${index}`} value={provider.name}>
-																	<RenderProviderIcon provider={provider.name as KnownProvider} size="sm" className="h-4 w-4" />
-																	{ProviderLabels[provider.name as ProviderName]}
-																</SelectItem>
-															))}
-
-														{/* Custom providers second */}
-														{customProviders
-															.filter((p) => p.name)
-															.map((provider, index) => (
-																<SelectItem key={`custom-${index}`} value={provider.name}>
-																	<RenderProviderIcon
-																		provider={provider.custom_provider_config?.base_provider_type || (provider.name as KnownProvider)}
-																		size="sm"
-																		className="h-4 w-4"
-																	/>
-																	{provider.name}
-																</SelectItem>
-															))}
-													</>
-												);
-											})()}
-										</SelectContent>
-									</Select>
-								</div>
-
-								{/* Provider Configurations Table */}
-								{providerConfigs.length > 0 && (
-									<div className="rounded-md border px-2">
-										<Accordion type="multiple" className="w-full">
-											{providerConfigs.map((config, index) => {
-												const providerConfig = availableProviders.find((provider) => provider.name === config.provider);
-												return (
-													<AccordionItem key={index} className="w-full" value={`${config.provider}-${index}`}>
-														<AccordionTrigger className="flex h-12 items-center gap-0 px-1">
-															<div className="flex w-full items-center justify-between">
-																<div className="flex w-fit items-center gap-2">
-																	<RenderProviderIcon
-																		provider={
-																			providerConfig?.custom_provider_config?.base_provider_type || (config.provider as ProviderIconType)
-																		}
-																		size="sm"
-																		className="h-4 w-4"
-																	/>
-																	{providerConfig?.custom_provider_config
-																		? providerConfig.name
-																		: ProviderLabels[config.provider as ProviderName]}
-																</div>
-																<Button
-																	type="button"
-																	variant="ghost"
-																	size="icon"
-																	aria-label={`Remove ${config.provider} provider`}
-																	className="hover:bg-accent/50 h-8 w-8 rounded-sm p-2"
-																	data-testid={`vk-delete-provider-${index}`}
-																	onClick={(e) => {
-																		e.stopPropagation();
-																		handleRemoveProvider(index);
-																	}}
-																>
-																	<Trash2 className="h-4 w-4 opacity-75" />
-																</Button>
-															</div>
-														</AccordionTrigger>
-														<AccordionContent className="flex flex-col gap-4 px-1 text-balance">
-															<div className="flex w-full items-start gap-2">
-																<div className="w-1/4">
-																	<NumberAndSelect
-																		id={`vk-weight-${index}`}
-																		label="Weight"
-																		labelClassName="text-sm font-medium"
-																		placeholder="Exclude from routing"
-																		inputClassName="h-[38px] w-full"
-																		dataTestId={`vk-weight-input-${index}`}
-																		value={config.weight}
-																		onChangeNumber={(value) => handleUpdateProviderConfig(index, "weight", value)}
-																	/>
-																</div>
-																<div className="w-3/4 space-y-2">
-																	<Label className="text-sm font-medium">
-																		Allowed Models <span className="text-muted-foreground ml-auto text-xs italic">type to search</span>
-																	</Label>
-																	{(() => {
-																		const hasWildcardModels = (config.allowed_models || []).includes("*");
-																		return (
-																			<ModelMultiselect
-																				data-testid={`vk-models-multiselect-${index}`}
-																				provider={config.provider}
-																				keys={(() => {
-																					const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
-																					const configKeyIds = config.key_ids || [];
-																					return configKeyIds.includes("*")
-																						? providerKeys.map((key) => key.key_id)
-																						: providerKeys.filter((key) => configKeyIds.includes(key.key_id)).map((key) => key.key_id);
-																				})()}
-																				allowAllOption={true}
-																				value={hasWildcardModels ? ["*"] : config.allowed_models || []}
-																				onChange={(models: string[]) => {
-																					const hadStar = (config.allowed_models || []).includes("*");
-																					const hasStar = models.includes("*");
-																					if (!hadStar && hasStar) {
-																						handleUpdateProviderConfig(index, "allowed_models", ["*"]);
-																					} else if (hadStar && hasStar && models.length > 1) {
-																						handleUpdateProviderConfig(
-																							index,
-																							"allowed_models",
-																							models.filter((m) => m !== "*"),
-																						);
-																					} else {
-																						handleUpdateProviderConfig(index, "allowed_models", models);
-																					}
-																				}}
-																				placeholder={
-																					hasWildcardModels
-																						? "All models allowed"
-																						: (config.allowed_models || []).length === 0
-																							? "No models (deny all)"
-																							: config.provider
-																								? ModelPlaceholders[config.provider as keyof typeof ModelPlaceholders] ||
-																									ModelPlaceholders.default
-																								: ModelPlaceholders.default
-																				}
-																				className="min-h-10 max-w-[500px] min-w-[200px]"
-																			/>
-																		);
-																	})()}
-																	<p className="text-muted-foreground text-xs">
-																		Select specific models or choose “Allow All Models” to allow all. Leave empty to deny all.
-																	</p>
-																</div>
-															</div>
-
-															{/* Allowed Keys for this provider */}
-															{(() => {
-																const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
-																const configKeyIds = config.key_ids || [];
-																const hasWildcard = configKeyIds.includes("*");
-																const allKeyOptions = [
-																	{
-																		label: "Allow All Keys",
-																		value: "*",
-																		description: "Allow all current and future keys for this provider",
-																		provider: "",
-																	},
-																	...providerKeys.map((key) => ({
-																		label: key.name,
-																		value: key.key_id,
-																		description:
-																			key.models == null || key.models.includes("*")
-																				? "All models"
-																				: key.models.filter((m) => m !== "*").join(", ") || "No models (deny all)",
-																		provider: key.provider,
-																	})),
-																];
-																const selectedProviderKeys = hasWildcard
-																	? [allKeyOptions[0]]
-																	: providerKeys
-																			.filter((key) => configKeyIds.includes(key.key_id))
-																			.map((key) => ({
-																				label: key.name,
-																				value: key.key_id,
-																				description:
-																					key.models == null || key.models.includes("*")
-																						? "All models"
-																						: key.models.filter((m) => m !== "*").join(", ") || "No models (deny all)",
-																				provider: key.provider,
-																			}));
-
-																return (
-																	<div className="mx-0.5 space-y-2">
-																		<Label className="text-sm font-medium">Allowed Keys</Label>
-																		<p className="text-muted-foreground text-xs">
-																			Select specific keys or allow all. Leave empty to block all keys for this provider.
-																		</p>
-																		<AsyncMultiSelect
-																			hideSelectedOptions
-																			isNonAsync
-																			closeMenuOnSelect={false}
-																			menuPlacement="auto"
-																			defaultOptions={allKeyOptions}
-																			views={{
-																				multiValue: (multiValueProps: MultiValueProps<VirtualKeyType>) => {
-																					return (
-																						<div
-																							{...multiValueProps.innerProps}
-																							className="bg-accent dark:!bg-card flex cursor-pointer items-center gap-1 rounded-sm px-1 py-0.5 text-sm"
-																						>
-																							{multiValueProps.data.label}{" "}
-																							<X
-																								className="hover:text-foreground text-muted-foreground h-4 w-4 cursor-pointer"
-																								onClick={(e) => {
-																									e.stopPropagation();
-																									multiValueProps.removeProps.onClick?.(e as any);
-																								}}
-																							/>
-																						</div>
-																					);
-																				},
-																				option: (optionProps: OptionProps<VirtualKeyType>) => {
-																					const { Option } = components;
-																					return (
-																						<Option
-																							{...optionProps}
-																							className={cn(
-																								"flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-2 text-sm",
-																								optionProps.isFocused && "bg-accent dark:!bg-card",
-																								"hover:bg-accent",
-																								optionProps.isSelected && "bg-accent dark:!bg-card",
-																							)}
-																						>
-																							<span className="text-content-primary grow truncate text-sm">{optionProps.data.label}</span>
-																							{optionProps.data.description && (
-																								<span className="text-content-tertiary max-w-[70%] text-sm">
-																									{optionProps.data.description}
-																								</span>
-																							)}
-																						</Option>
-																					);
-																				},
-																			}}
-																			value={selectedProviderKeys}
-																			onChange={(keys) => {
-																				const hadStar = hasWildcard;
-																				const hasStar = keys.some((k) => k.value === "*");
-																				if (!hadStar && hasStar) {
-																					// Just selected "Allow All Keys" — set to ["*"] only
-																					handleUpdateProviderConfig(index, "key_ids", ["*"]);
-																				} else if (hadStar && hasStar && keys.length > 1) {
-																					// Had "*", still has "*", but user also selected a specific key — drop "*"
-																					handleUpdateProviderConfig(
-																						index,
-																						"key_ids",
-																						keys.filter((k) => k.value !== "*").map((k) => k.value as string),
-																					);
-																				} else {
-																					handleUpdateProviderConfig(
-																						index,
-																						"key_ids",
-																						keys.map((k) => k.value as string),
-																					);
-																				}
-																			}}
-																			placeholder={
-																				hasWildcard ? "All keys allowed" : configKeyIds.length === 0 ? "No keys selected" : "Select keys..."
-																			}
-																			className="hover:bg-accent w-full"
-																			menuClassName="z-[60] max-h-[300px] overflow-y-auto w-full cursor-pointer custom-scrollbar"
-																		/>
-																	</div>
-																);
-															})()}
-
-															<DottedSeparator />
-
-															{/* Provider Budget Configuration */}
-															<MultiBudgetLines
-																id={`providerBudget-${index}`}
-																data-testid={`vk-provider-budget-${index}`}
-																label="Provider Budget"
-																lines={
-																	config.budgets && config.budgets.length > 0
-																		? config.budgets.map((b) => ({
-																				max_limit: b.max_limit,
-																				reset_duration: b.reset_duration || "1M",
-																			}))
-																		: []
-																}
-																onChange={(lines) => {
-																	const updatedConfigs = [...providerConfigs];
-																	updatedConfigs[index] = {
-																		...updatedConfigs[index],
-																		budgets: lines.map((l) => ({
-																			max_limit: l.max_limit,
-																			reset_duration: l.reset_duration,
-																		})),
-																	};
-																	form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
-																}}
-															/>
-
-															<DottedSeparator />
-
-															{/* Provider Rate Limit Configuration */}
-															<div className="space-y-4">
-																<Label className="text-sm font-medium">Provider Rate Limits</Label>
-
-																<NumberAndSelect
-																	id={`providerTokenLimit-${index}`}
-																	labelClassName="font-normal"
-																	label="Maximum Tokens"
-																	value={config.rate_limit?.token_max_limit}
-																	selectValue={config.rate_limit?.token_reset_duration || "1h"}
-																	onChangeNumber={(value) => {
-																		const currentRateLimit = config.rate_limit || {};
-																		handleUpdateProviderConfig(index, "rate_limit", {
-																			...currentRateLimit,
-																			token_max_limit: value,
-																		});
-																	}}
-																	onChangeSelect={(value) => {
-																		const currentRateLimit = config.rate_limit || {};
-																		handleUpdateProviderConfig(index, "rate_limit", {
-																			...currentRateLimit,
-																			token_reset_duration: value,
-																		});
-																	}}
-																	options={resetDurationOptions}
-																/>
-
-																<NumberAndSelect
-																	id={`providerRequestLimit-${index}`}
-																	labelClassName="font-normal"
-																	label="Maximum Requests"
-																	value={config.rate_limit?.request_max_limit}
-																	selectValue={config.rate_limit?.request_reset_duration || "1h"}
-																	onChangeNumber={(value) => {
-																		const currentRateLimit = config.rate_limit || {};
-																		handleUpdateProviderConfig(index, "rate_limit", {
-																			...currentRateLimit,
-																			request_max_limit: value,
-																		});
-																	}}
-																	onChangeSelect={(value) => {
-																		const currentRateLimit = config.rate_limit || {};
-																		handleUpdateProviderConfig(index, "rate_limit", {
-																			...currentRateLimit,
-																			request_reset_duration: value,
-																		});
-																	}}
-																	options={resetDurationOptions}
-																/>
-															</div>
-														</AccordionContent>
-													</AccordionItem>
-												);
-											})}
-										</Accordion>
-									</div>
-								)}
-								{/* Display validation errors for provider configurations */}
-								{form.formState.errors.providerConfigs && (
-									<div className="text-destructive text-sm">{form.formState.errors.providerConfigs.message}</div>
-								)}
-							</div>
-							{/* MCP Client Configurations */}
-							{((mcpClientsData && mcpClientsData.length > 0) || (mcpConfigs && mcpConfigs.length > 0)) && (
-								<div className="mt-6 space-y-2">
+								{/* Provider Configurations */}
+								<div className="space-y-2">
 									<div className="flex items-center gap-2">
-										<Label className="text-sm font-medium">MCP Client Configurations</Label>
+										<Label className="text-sm font-medium">Provider Configurations</Label>
 										<TooltipProvider>
 											<Tooltip>
 												<TooltipTrigger asChild>
@@ -1060,439 +641,861 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 												</TooltipTrigger>
 												<TooltipContent>
 													<p>
-														Configure which MCP clients this virtual key can use and their allowed tools. Leaving this section empty blocks
-														all MCP tools. After adding an MCP client, you must select specific tools or choose{" "}
-														<span className="font-medium">Allow All Tools</span> to grant tool access.
+														Configure which providers this virtual key can use and their specific settings. Leave empty to block all
+														providers. Add providers to allow them.
 													</p>
 												</TooltipContent>
 											</Tooltip>
 										</TooltipProvider>
 									</div>
 
-									{/* MCP servers available on all virtual keys by default, excluding explicitly overridden ones */}
-									{(() => {
-										const defaultMCPClients = mcpClientsData.filter(
-											(client) =>
-												client.config.allow_on_all_virtual_keys &&
-												!mcpConfigs.some((config) => config.mcp_client_name === client.config.name),
-										);
-										return defaultMCPClients.length > 0 ? (
-											<div className="text-muted-foreground rounded-md border p-3 text-xs">
-												<div className="flex items-start gap-1.5">
-													<Info className="mt-0.5 h-3 w-3 shrink-0" />
-													<span>
-														The following MCP servers are available to this key by default with all tools enabled on that client:{" "}
-														<span className="text-foreground font-medium">{defaultMCPClients.map((c) => c.config.name).join(", ")}</span>.
-														Adding an explicit config for any of them below will override the all-tools default for this key.
-													</span>
-												</div>
-											</div>
-										) : null;
-									})()}
+									{/* Add Provider Dropdown */}
+									<div className="flex gap-2">
+										<Select
+											value={selectedProvider}
+											onValueChange={(provider) => {
+												if (provider === "__manage_providers__") {
+													navigate({ to: "/workspace/providers" });
+													setSelectedProvider("");
+													return;
+												}
+												handleAddProvider(provider);
+												setSelectedProvider(""); // Reset to placeholder state
+											}}
+										>
+											<SelectTrigger className="flex-1" data-testid="vk-provider-select">
+												<SelectValue placeholder="Select a provider to add" />
+											</SelectTrigger>
+											<SelectContent>
+												{(() => {
+													// Filter out already configured providers
+													const unconfiguredProviders = availableProviders.filter(
+														(provider) => !providerConfigs.some((config) => config.provider === provider.name),
+													);
 
-									{/* Add MCP Client Dropdown */}
-									{mcpClientsData && mcpClientsData.length > 0 && (
-										<div className="flex gap-2">
-											<Select
-												value={selectedMCPClient}
-												onValueChange={(mcpClientId) => {
-													handleAddMCPClient(mcpClientId);
-													setSelectedMCPClient(""); // Reset to placeholder state
-												}}
-											>
-												<SelectTrigger className="flex-1">
-													<SelectValue placeholder="Select an MCP client to add" />
-												</SelectTrigger>
-												<SelectContent>
-													{mcpClientsData.filter((client) => !mcpConfigs.some((config) => config.mcp_client_name === client.config.name))
-														.length > 0 ? (
-														mcpClientsData
-															.filter(
-																(client) =>
-																	client.config.name && !mcpConfigs.some((config) => config.mcp_client_name === client.config.name),
-															)
-															.map((client, index) => {
-																const client_tools = client.tools || [];
-																const totalTools = client.config.tools_to_execute?.includes("*")
-																	? client_tools.length
-																	: client_tools.filter((tool) => client.config.tools_to_execute?.includes(tool.name)).length;
-																return (
-																	<SelectItem key={index} value={client.config.name}>
-																		<div className="flex items-center gap-2">
-																			{client.config.name}
-																			<span className="text-muted-foreground text-xs">
-																				({totalTools} {totalTools === 1 ? "enabled tool" : "enabled tools"})
-																			</span>
-																		</div>
-																	</SelectItem>
-																);
-															})
-													) : (
-														<div className="text-muted-foreground px-2 py-1.5 text-sm">All MCP clients configured</div>
-													)}
-												</SelectContent>
-											</Select>
-										</div>
-									)}
-
-									{/* MCP Configurations Table */}
-									{mcpConfigs.length > 0 && (
-										<div className="rounded-md border">
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>MCP Client</TableHead>
-														<TableHead>Allowed Tools</TableHead>
-														<TableHead className="w-[50px]"></TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													{mcpConfigs.map((config, index) => {
-														const mcpClient = mcpClientsData?.find((client) => client.config.name === config.mcp_client_name);
-
-														// Handle new wildcard semantics for client-level filtering
-														const clientToolsToExecute = mcpClient?.config?.tools_to_execute;
-														let availableTools: any[] = [];
-
-														if (!clientToolsToExecute || clientToolsToExecute.length === 0) {
-															// nil/undefined or empty array - no tools available from client config
-															availableTools = [];
-														} else if (clientToolsToExecute.includes("*")) {
-															// Wildcard - all tools available
-															availableTools = mcpClient?.tools || [];
-														} else {
-															// Specific tools listed
-															availableTools = (mcpClient?.tools || []).filter((tool) => clientToolsToExecute.includes(tool.name)) || [];
-														}
-
-														const enabledToolsByConfig =
-															(mcpClient?.tools || []).filter((tool) => config.tools_to_execute?.includes(tool.name)) || [];
-														const selectedTools = config.tools_to_execute || [];
-
+													if (unconfiguredProviders.length === 0) {
 														return (
-															<TableRow key={`${config.mcp_client_name}-${index}`}>
-																<TableCell className="w-[150px]">{config.mcp_client_name}</TableCell>
-																<TableCell>
-																	<MultiSelect
-																		options={[
-																			{
-																				label: "Allow All Tools",
-																				value: "*",
-																				description: "Allow all current and future tools",
-																			},
-																			...[...availableTools, ...enabledToolsByConfig]
-																				.filter((tool, index, arr) => arr.findIndex((t) => t.name === tool.name) === index)
-																				.map((tool) => ({
-																					label: tool.name,
-																					value: tool.name,
-																					description: tool.description,
-																				})),
-																		]}
-																		defaultValue={selectedTools}
-																		onValueChange={(tools: string[]) => {
-																			const hadStar = selectedTools.includes("*");
-																			const hasStar = tools.includes("*");
-																			if (!hadStar && hasStar) {
-																				// Just selected "Allow All Tools" — set to ["*"] only
-																				handleUpdateMCPConfig(index, "tools_to_execute", ["*"]);
-																			} else if (hadStar && hasStar && tools.length > 1) {
-																				// Had "*", still has "*", but user also selected a specific tool — drop "*"
-																				handleUpdateMCPConfig(
-																					index,
-																					"tools_to_execute",
-																					tools.filter((t) => t !== "*"),
-																				);
-																			} else {
-																				handleUpdateMCPConfig(index, "tools_to_execute", tools);
+															<SelectItem
+																value="__manage_providers__"
+																className="text-muted-foreground hover:text-foreground"
+																data-testid="vk-provider-config-link"
+															>
+																<span>
+																	No providers left to configure. <span className="text-primary font-medium underline">Click to add</span>
+																</span>
+															</SelectItem>
+														);
+													}
+
+													// Separate base providers and custom providers
+													const baseProviders = unconfiguredProviders.filter((provider) => !provider.custom_provider_config);
+													const customProviders = unconfiguredProviders.filter((provider) => provider.custom_provider_config);
+
+													return (
+														<>
+															{/* Base providers first */}
+															{baseProviders
+																.filter((p) => p.name)
+																.map((provider, index) => (
+																	<SelectItem key={`base-${index}`} value={provider.name}>
+																		<RenderProviderIcon provider={provider.name as KnownProvider} size="sm" className="h-4 w-4" />
+																		{ProviderLabels[provider.name as ProviderName]}
+																	</SelectItem>
+																))}
+
+															{/* Custom providers second */}
+															{customProviders
+																.filter((p) => p.name)
+																.map((provider, index) => (
+																	<SelectItem key={`custom-${index}`} value={provider.name}>
+																		<RenderProviderIcon
+																			provider={provider.custom_provider_config?.base_provider_type || (provider.name as KnownProvider)}
+																			size="sm"
+																			className="h-4 w-4"
+																		/>
+																		{provider.name}
+																	</SelectItem>
+																))}
+														</>
+													);
+												})()}
+											</SelectContent>
+										</Select>
+									</div>
+
+									{/* Provider Configurations Table */}
+									{providerConfigs.length > 0 && (
+										<div className="rounded-md border px-2">
+											<Accordion type="multiple" className="w-full">
+												{providerConfigs.map((config, index) => {
+													const providerConfig = availableProviders.find((provider) => provider.name === config.provider);
+													return (
+														<AccordionItem key={index} className="w-full" value={`${config.provider}-${index}`}>
+															<AccordionTrigger className="flex h-12 items-center gap-0 px-1">
+																<div className="flex w-full items-center justify-between">
+																	<div className="flex w-fit items-center gap-2">
+																		<RenderProviderIcon
+																			provider={
+																				providerConfig?.custom_provider_config?.base_provider_type || (config.provider as ProviderIconType)
 																			}
-																		}}
-																		placeholder={
-																			selectedTools.length === 0
-																				? "No tools selected"
-																				: selectedTools.includes("*")
-																					? "All tools allowed"
-																					: "Select tools..."
-																		}
-																		variant="inverted"
-																		className="hover:bg-accent w-full bg-white dark:bg-zinc-800"
-																		commandClassName="w-full max-w-96"
-																		modalPopover={true}
-																		animation={0}
-																	/>
-																</TableCell>
-																<TableCell>
+																			size="sm"
+																			className="h-4 w-4"
+																		/>
+																		{providerConfig?.custom_provider_config
+																			? providerConfig.name
+																			: ProviderLabels[config.provider as ProviderName]}
+																	</div>
 																	<Button
 																		type="button"
 																		variant="ghost"
-																		size="sm"
-																		onClick={() => handleRemoveMCPClient(index)}
-																		data-testid={`vk-delete-mcp-${index}`}
+																		size="icon"
+																		aria-label={`Remove ${config.provider} provider`}
+																		className="hover:bg-accent/50 h-8 w-8 rounded-sm p-2"
+																		data-testid={`vk-delete-provider-${index}`}
+																		onClick={(e) => {
+																			e.stopPropagation();
+																			handleRemoveProvider(index);
+																		}}
 																	>
-																		<Trash2 className="h-4 w-4" />
+																		<Trash2 className="h-4 w-4 opacity-75" />
 																	</Button>
-																</TableCell>
-															</TableRow>
-														);
-													})}
-												</TableBody>
-											</Table>
+																</div>
+															</AccordionTrigger>
+															<AccordionContent className="flex flex-col gap-4 px-1 text-balance">
+																<div className="flex w-full items-start gap-2">
+																	<div className="w-1/4">
+																		<NumberAndSelect
+																			id={`vk-weight-${index}`}
+																			label="Weight"
+																			labelClassName="text-sm font-medium"
+																			placeholder="Exclude from routing"
+																			inputClassName="h-[38px] w-full"
+																			dataTestId={`vk-weight-input-${index}`}
+																			value={config.weight}
+																			onChangeNumber={(value) => handleUpdateProviderConfig(index, "weight", value)}
+																		/>
+																	</div>
+																	<div className="w-3/4 space-y-2">
+																		<Label className="text-sm font-medium">
+																			Allowed Models <span className="text-muted-foreground ml-auto text-xs italic">type to search</span>
+																		</Label>
+																		{(() => {
+																			const hasWildcardModels = (config.allowed_models || []).includes("*");
+																			return (
+																				<ModelMultiselect
+																					data-testid={`vk-models-multiselect-${index}`}
+																					provider={config.provider}
+																					keys={(() => {
+																						const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
+																						const configKeyIds = config.key_ids || [];
+																						return configKeyIds.includes("*")
+																							? providerKeys.map((key) => key.key_id)
+																							: providerKeys.filter((key) => configKeyIds.includes(key.key_id)).map((key) => key.key_id);
+																					})()}
+																					allowAllOption={true}
+																					value={hasWildcardModels ? ["*"] : config.allowed_models || []}
+																					onChange={(models: string[]) => {
+																						const hadStar = (config.allowed_models || []).includes("*");
+																						const hasStar = models.includes("*");
+																						if (!hadStar && hasStar) {
+																							handleUpdateProviderConfig(index, "allowed_models", ["*"]);
+																						} else if (hadStar && hasStar && models.length > 1) {
+																							handleUpdateProviderConfig(
+																								index,
+																								"allowed_models",
+																								models.filter((m) => m !== "*"),
+																							);
+																						} else {
+																							handleUpdateProviderConfig(index, "allowed_models", models);
+																						}
+																					}}
+																					placeholder={
+																						hasWildcardModels
+																							? "All models allowed"
+																							: (config.allowed_models || []).length === 0
+																								? "No models (deny all)"
+																								: config.provider
+																									? ModelPlaceholders[config.provider as keyof typeof ModelPlaceholders] ||
+																										ModelPlaceholders.default
+																									: ModelPlaceholders.default
+																					}
+																					className="min-h-10 max-w-[500px] min-w-[200px]"
+																				/>
+																			);
+																		})()}
+																		<p className="text-muted-foreground text-xs">
+																			Select specific models or choose “Allow All Models” to allow all. Leave empty to deny all.
+																		</p>
+																	</div>
+																</div>
+
+																{/* Allowed Keys for this provider */}
+																{(() => {
+																	const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
+																	const configKeyIds = config.key_ids || [];
+																	const hasWildcard = configKeyIds.includes("*");
+																	const allKeyOptions = [
+																		{
+																			label: "Allow All Keys",
+																			value: "*",
+																			description: "Allow all current and future keys for this provider",
+																			provider: "",
+																		},
+																		...providerKeys.map((key) => ({
+																			label: key.name,
+																			value: key.key_id,
+																			description:
+																				key.models == null || key.models.includes("*")
+																					? "All models"
+																					: key.models.filter((m) => m !== "*").join(", ") || "No models (deny all)",
+																			provider: key.provider,
+																		})),
+																	];
+																	const selectedProviderKeys = hasWildcard
+																		? [allKeyOptions[0]]
+																		: providerKeys
+																				.filter((key) => configKeyIds.includes(key.key_id))
+																				.map((key) => ({
+																					label: key.name,
+																					value: key.key_id,
+																					description:
+																						key.models == null || key.models.includes("*")
+																							? "All models"
+																							: key.models.filter((m) => m !== "*").join(", ") || "No models (deny all)",
+																					provider: key.provider,
+																				}));
+
+																	return (
+																		<div className="mx-0.5 space-y-2">
+																			<Label className="text-sm font-medium">Allowed Keys</Label>
+																			<p className="text-muted-foreground text-xs">
+																				Select specific keys or allow all. Leave empty to block all keys for this provider.
+																			</p>
+																			<AsyncMultiSelect
+																				hideSelectedOptions
+																				isNonAsync
+																				closeMenuOnSelect={false}
+																				menuPlacement="auto"
+																				defaultOptions={allKeyOptions}
+																				views={{
+																					multiValue: (multiValueProps: MultiValueProps<VirtualKeyType>) => {
+																						return (
+																							<div
+																								{...multiValueProps.innerProps}
+																								className="bg-accent dark:!bg-card flex cursor-pointer items-center gap-1 rounded-sm px-1 py-0.5 text-sm"
+																							>
+																								{multiValueProps.data.label}{" "}
+																								<X
+																									className="hover:text-foreground text-muted-foreground h-4 w-4 cursor-pointer"
+																									onClick={(e) => {
+																										e.stopPropagation();
+																										multiValueProps.removeProps.onClick?.(e as any);
+																									}}
+																								/>
+																							</div>
+																						);
+																					},
+																					option: (optionProps: OptionProps<VirtualKeyType>) => {
+																						const { Option } = components;
+																						return (
+																							<Option
+																								{...optionProps}
+																								className={cn(
+																									"flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-2 text-sm",
+																									optionProps.isFocused && "bg-accent dark:!bg-card",
+																									"hover:bg-accent",
+																									optionProps.isSelected && "bg-accent dark:!bg-card",
+																								)}
+																							>
+																								<span className="text-content-primary grow truncate text-sm">{optionProps.data.label}</span>
+																								{optionProps.data.description && (
+																									<span className="text-content-tertiary max-w-[70%] text-sm">
+																										{optionProps.data.description}
+																									</span>
+																								)}
+																							</Option>
+																						);
+																					},
+																				}}
+																				value={selectedProviderKeys}
+																				onChange={(keys) => {
+																					const hadStar = hasWildcard;
+																					const hasStar = keys.some((k) => k.value === "*");
+																					if (!hadStar && hasStar) {
+																						// Just selected "Allow All Keys" — set to ["*"] only
+																						handleUpdateProviderConfig(index, "key_ids", ["*"]);
+																					} else if (hadStar && hasStar && keys.length > 1) {
+																						// Had "*", still has "*", but user also selected a specific key — drop "*"
+																						handleUpdateProviderConfig(
+																							index,
+																							"key_ids",
+																							keys.filter((k) => k.value !== "*").map((k) => k.value as string),
+																						);
+																					} else {
+																						handleUpdateProviderConfig(
+																							index,
+																							"key_ids",
+																							keys.map((k) => k.value as string),
+																						);
+																					}
+																				}}
+																				placeholder={
+																					hasWildcard
+																						? "All keys allowed"
+																						: configKeyIds.length === 0
+																							? "No keys selected"
+																							: "Select keys..."
+																				}
+																				className="hover:bg-accent w-full"
+																				menuClassName="z-[60] max-h-[300px] overflow-y-auto w-full cursor-pointer custom-scrollbar"
+																			/>
+																		</div>
+																	);
+																})()}
+
+																<DottedSeparator />
+
+																{/* Provider Budget Configuration */}
+																<MultiBudgetLines
+																	id={`providerBudget-${index}`}
+																	data-testid={`vk-provider-budget-${index}`}
+																	label="Provider Budget"
+																	lines={
+																		config.budgets && config.budgets.length > 0
+																			? config.budgets.map((b) => ({
+																					max_limit: b.max_limit,
+																					reset_duration: b.reset_duration || "1M",
+																				}))
+																			: []
+																	}
+																	onChange={(lines) => {
+																		const updatedConfigs = [...providerConfigs];
+																		updatedConfigs[index] = {
+																			...updatedConfigs[index],
+																			budgets: lines.map((l) => ({
+																				max_limit: l.max_limit,
+																				reset_duration: l.reset_duration,
+																			})),
+																		};
+																		form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
+																	}}
+																/>
+
+																<DottedSeparator />
+
+																{/* Provider Rate Limit Configuration */}
+																<div className="space-y-4">
+																	<Label className="text-sm font-medium">Provider Rate Limits</Label>
+
+																	<NumberAndSelect
+																		id={`providerTokenLimit-${index}`}
+																		labelClassName="font-normal"
+																		label="Maximum Tokens"
+																		value={config.rate_limit?.token_max_limit}
+																		selectValue={config.rate_limit?.token_reset_duration || "1h"}
+																		onChangeNumber={(value) => {
+																			const currentRateLimit = config.rate_limit || {};
+																			handleUpdateProviderConfig(index, "rate_limit", {
+																				...currentRateLimit,
+																				token_max_limit: value,
+																			});
+																		}}
+																		onChangeSelect={(value) => {
+																			const currentRateLimit = config.rate_limit || {};
+																			handleUpdateProviderConfig(index, "rate_limit", {
+																				...currentRateLimit,
+																				token_reset_duration: value,
+																			});
+																		}}
+																		options={resetDurationOptions}
+																	/>
+
+																	<NumberAndSelect
+																		id={`providerRequestLimit-${index}`}
+																		labelClassName="font-normal"
+																		label="Maximum Requests"
+																		value={config.rate_limit?.request_max_limit}
+																		selectValue={config.rate_limit?.request_reset_duration || "1h"}
+																		onChangeNumber={(value) => {
+																			const currentRateLimit = config.rate_limit || {};
+																			handleUpdateProviderConfig(index, "rate_limit", {
+																				...currentRateLimit,
+																				request_max_limit: value,
+																			});
+																		}}
+																		onChangeSelect={(value) => {
+																			const currentRateLimit = config.rate_limit || {};
+																			handleUpdateProviderConfig(index, "rate_limit", {
+																				...currentRateLimit,
+																				request_reset_duration: value,
+																			});
+																		}}
+																		options={resetDurationOptions}
+																	/>
+																</div>
+															</AccordionContent>
+														</AccordionItem>
+													);
+												})}
+											</Accordion>
 										</div>
 									)}
+									{/* Display validation errors for provider configurations */}
+									{form.formState.errors.providerConfigs && (
+										<div className="text-destructive text-sm">{form.formState.errors.providerConfigs.message}</div>
+									)}
 								</div>
-							)}
-							<DottedSeparator className="mt-6 mb-5" />
-							{/* Budget Configuration */}
-							<div className="space-y-4">
-								<MultiBudgetLines
-									id="vkBudget"
-									data-testid="vk-budget-lines"
-									label="Budget Configuration"
-									lines={form.watch("budgets") ?? []}
-									onChange={(lines) => {
-										form.setValue("budgets", lines, { shouldDirty: true });
-									}}
-									onReset={clearVirtualKeyBudget}
-									showReset={isEditing && !!(virtualKey?.budgets?.length || (watchedBudgets && watchedBudgets.length > 0))}
-								/>
-
-								{/* Calendar alignment toggle — shown when any budget supports alignment */}
-								{hasAnyAlignableBudget && (
-									<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
-										<div className="space-y-0.5">
-											<Label htmlFor="vk-budget-calendar-aligned-toggle" className="text-sm font-normal">
-												Align to calendar cycle
-											</Label>
-											<p id="vk-budget-calendar-aligned-description" className="text-muted-foreground text-xs">
-												Reset at the start of each period (e.g. 1st of month) instead of rolling from creation date
-											</p>
+								{/* MCP Client Configurations */}
+								{((mcpClientsData && mcpClientsData.length > 0) || (mcpConfigs && mcpConfigs.length > 0)) && (
+									<div className="mt-6 space-y-2">
+										<div className="flex items-center gap-2">
+											<Label className="text-sm font-medium">MCP Client Configurations</Label>
+											<TooltipProvider>
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<span>
+															<Info className="text-muted-foreground h-3 w-3" />
+														</span>
+													</TooltipTrigger>
+													<TooltipContent>
+														<p>
+															Configure which MCP clients this virtual key can use and their allowed tools. Leaving this section empty
+															blocks all MCP tools. After adding an MCP client, you must select specific tools or choose{" "}
+															<span className="font-medium">Allow All Tools</span> to grant tool access.
+														</p>
+													</TooltipContent>
+												</Tooltip>
+											</TooltipProvider>
 										</div>
-										<Switch
-											id="vk-budget-calendar-aligned-toggle"
-											aria-describedby="vk-budget-calendar-aligned-description"
-											checked={watchedBudgetCalendarAligned}
-											onCheckedChange={handleCalendarAlignedChange}
-											data-testid="vk-budget-calendar-aligned-toggle"
-										/>
+
+										{/* MCP servers available on all virtual keys by default, excluding explicitly overridden ones */}
+										{(() => {
+											const defaultMCPClients = mcpClientsData.filter(
+												(client) =>
+													client.config.allow_on_all_virtual_keys &&
+													!mcpConfigs.some((config) => config.mcp_client_name === client.config.name),
+											);
+											return defaultMCPClients.length > 0 ? (
+												<div className="text-muted-foreground rounded-md border p-3 text-xs">
+													<div className="flex items-start gap-1.5">
+														<Info className="mt-0.5 h-3 w-3 shrink-0" />
+														<span>
+															The following MCP servers are available to this key by default with all tools enabled on that client:{" "}
+															<span className="text-foreground font-medium">{defaultMCPClients.map((c) => c.config.name).join(", ")}</span>.
+															Adding an explicit config for any of them below will override the all-tools default for this key.
+														</span>
+													</div>
+												</div>
+											) : null;
+										})()}
+
+										{/* Add MCP Client Dropdown */}
+										{mcpClientsData && mcpClientsData.length > 0 && (
+											<div className="flex gap-2">
+												<Select
+													value={selectedMCPClient}
+													onValueChange={(mcpClientId) => {
+														handleAddMCPClient(mcpClientId);
+														setSelectedMCPClient(""); // Reset to placeholder state
+													}}
+												>
+													<SelectTrigger className="flex-1">
+														<SelectValue placeholder="Select an MCP client to add" />
+													</SelectTrigger>
+													<SelectContent>
+														{mcpClientsData.filter((client) => !mcpConfigs.some((config) => config.mcp_client_name === client.config.name))
+															.length > 0 ? (
+															mcpClientsData
+																.filter(
+																	(client) =>
+																		client.config.name && !mcpConfigs.some((config) => config.mcp_client_name === client.config.name),
+																)
+																.map((client, index) => {
+																	const client_tools = client.tools || [];
+																	const totalTools = client.config.tools_to_execute?.includes("*")
+																		? client_tools.length
+																		: client_tools.filter((tool) => client.config.tools_to_execute?.includes(tool.name)).length;
+																	return (
+																		<SelectItem key={index} value={client.config.name}>
+																			<div className="flex items-center gap-2">
+																				{client.config.name}
+																				<span className="text-muted-foreground text-xs">
+																					({totalTools} {totalTools === 1 ? "enabled tool" : "enabled tools"})
+																				</span>
+																			</div>
+																		</SelectItem>
+																	);
+																})
+														) : (
+															<div className="text-muted-foreground px-2 py-1.5 text-sm">All MCP clients configured</div>
+														)}
+													</SelectContent>
+												</Select>
+											</div>
+										)}
+
+										{/* MCP Configurations Table */}
+										{mcpConfigs.length > 0 && (
+											<div className="rounded-md border">
+												<Table>
+													<TableHeader>
+														<TableRow>
+															<TableHead>MCP Client</TableHead>
+															<TableHead>Allowed Tools</TableHead>
+															<TableHead className="w-[50px]"></TableHead>
+														</TableRow>
+													</TableHeader>
+													<TableBody>
+														{mcpConfigs.map((config, index) => {
+															const mcpClient = mcpClientsData?.find((client) => client.config.name === config.mcp_client_name);
+
+															// Handle new wildcard semantics for client-level filtering
+															const clientToolsToExecute = mcpClient?.config?.tools_to_execute;
+															let availableTools: any[] = [];
+
+															if (!clientToolsToExecute || clientToolsToExecute.length === 0) {
+																// nil/undefined or empty array - no tools available from client config
+																availableTools = [];
+															} else if (clientToolsToExecute.includes("*")) {
+																// Wildcard - all tools available
+																availableTools = mcpClient?.tools || [];
+															} else {
+																// Specific tools listed
+																availableTools = (mcpClient?.tools || []).filter((tool) => clientToolsToExecute.includes(tool.name)) || [];
+															}
+
+															const enabledToolsByConfig =
+																(mcpClient?.tools || []).filter((tool) => config.tools_to_execute?.includes(tool.name)) || [];
+															const selectedTools = config.tools_to_execute || [];
+
+															return (
+																<TableRow key={`${config.mcp_client_name}-${index}`}>
+																	<TableCell className="w-[150px]">{config.mcp_client_name}</TableCell>
+																	<TableCell>
+																		<MultiSelect
+																			options={[
+																				{
+																					label: "Allow All Tools",
+																					value: "*",
+																					description: "Allow all current and future tools",
+																				},
+																				...[...availableTools, ...enabledToolsByConfig]
+																					.filter((tool, index, arr) => arr.findIndex((t) => t.name === tool.name) === index)
+																					.map((tool) => ({
+																						label: tool.name,
+																						value: tool.name,
+																						description: tool.description,
+																					})),
+																			]}
+																			defaultValue={selectedTools}
+																			onValueChange={(tools: string[]) => {
+																				const hadStar = selectedTools.includes("*");
+																				const hasStar = tools.includes("*");
+																				if (!hadStar && hasStar) {
+																					// Just selected "Allow All Tools" — set to ["*"] only
+																					handleUpdateMCPConfig(index, "tools_to_execute", ["*"]);
+																				} else if (hadStar && hasStar && tools.length > 1) {
+																					// Had "*", still has "*", but user also selected a specific tool — drop "*"
+																					handleUpdateMCPConfig(
+																						index,
+																						"tools_to_execute",
+																						tools.filter((t) => t !== "*"),
+																					);
+																				} else {
+																					handleUpdateMCPConfig(index, "tools_to_execute", tools);
+																				}
+																			}}
+																			placeholder={
+																				selectedTools.length === 0
+																					? "No tools selected"
+																					: selectedTools.includes("*")
+																						? "All tools allowed"
+																						: "Select tools..."
+																			}
+																			variant="inverted"
+																			className="hover:bg-accent w-full bg-white dark:bg-zinc-800"
+																			commandClassName="w-full max-w-96"
+																			modalPopover={true}
+																			animation={0}
+																		/>
+																	</TableCell>
+																	<TableCell>
+																		<Button
+																			type="button"
+																			variant="ghost"
+																			size="sm"
+																			onClick={() => handleRemoveMCPClient(index)}
+																			data-testid={`vk-delete-mcp-${index}`}
+																		>
+																			<Trash2 className="h-4 w-4" />
+																		</Button>
+																	</TableCell>
+																</TableRow>
+															);
+														})}
+													</TableBody>
+												</Table>
+											</div>
+										)}
 									</div>
 								)}
+								<DottedSeparator className="mt-6 mb-5" />
+								{/* Budget Configuration */}
+								<div className="space-y-4">
+									<MultiBudgetLines
+										id="vkBudget"
+										data-testid="vk-budget-lines"
+										label="Budget Configuration"
+										lines={form.watch("budgets") ?? []}
+										onChange={(lines) => {
+											form.setValue("budgets", lines, { shouldDirty: true });
+										}}
+										onReset={clearVirtualKeyBudget}
+										showReset={isEditing && !!(virtualKey?.budgets?.length || (watchedBudgets && watchedBudgets.length > 0))}
+									/>
 
-								{/* Warning dialog shown when enabling calendar alignment on an existing budget */}
-								<AlertDialog open={showCalendarAlignWarning} onOpenChange={setShowCalendarAlignWarning}>
-									<AlertDialogContent>
-										<AlertDialogHeader>
-											<AlertDialogTitle>Reset budget usage?</AlertDialogTitle>
-											<AlertDialogDescription>
-												Enabling calendar alignment will reset all budget usage for this virtual key to{" "}
-												<span className="font-semibold">$0.00</span> and snap each budget&apos;s reset date to the start of its current
-												period (e.g. start of day, week, month, or year). The usage reset to $0.00 cannot be undone, but calendar alignment
-												can be turned off later. This will take effect when you save.
-											</AlertDialogDescription>
-										</AlertDialogHeader>
-										<AlertDialogFooter>
-											<AlertDialogCancel data-testid="vk-calendar-align-cancel-btn">Cancel</AlertDialogCancel>
-											<AlertDialogAction
-												data-testid="vk-calendar-align-enable-btn"
-												onClick={() => {
-													form.setValue("budgetCalendarAligned", true, { shouldDirty: true });
-													setShowCalendarAlignWarning(false);
-												}}
-											>
-												Enable Calendar Alignment
-											</AlertDialogAction>
-										</AlertDialogFooter>
-									</AlertDialogContent>
-								</AlertDialog>
-							</div>
-							{/* Rate Limiting Configuration */}
-							<div className="space-y-4">
-								<div className="flex items-center justify-between gap-2">
-									<Label className="text-sm font-medium">Rate Limiting Configuration</Label>
-									{isEditing && (virtualKey?.rate_limit || watchedTokenMaxLimit || watchedRequestMaxLimit) && (
-										<Button
-											type="button"
-											variant="ghost"
-											size="sm"
-											onClick={clearVirtualKeyRateLimits}
-											data-testid="vk-rate-limit-reset-button"
-										>
-											<RotateCcw className="h-4 w-4" />
-											Reset
-										</Button>
-									)}
-								</div>
-
-								<FormField
-									control={form.control}
-									name="tokenMaxLimit"
-									render={({ field }) => (
-										<FormItem>
-											<NumberAndSelect
-												id="tokenMaxLimit"
-												labelClassName="font-normal"
-												label="Maximum Tokens"
-												value={field.value}
-												selectValue={form.watch("tokenResetDuration") || "1h"}
-												onChangeNumber={(value) => {
-													field.onChange(value);
-												}}
-												onChangeSelect={(value) => form.setValue("tokenResetDuration", value, { shouldDirty: true })}
-												options={resetDurationOptions}
+									{/* Calendar alignment toggle — shown when any budget supports alignment */}
+									{hasAnyAlignableBudget && (
+										<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
+											<div className="space-y-0.5">
+												<Label htmlFor="vk-budget-calendar-aligned-toggle" className="text-sm font-normal">
+													Align to calendar cycle
+												</Label>
+												<p id="vk-budget-calendar-aligned-description" className="text-muted-foreground text-xs">
+													Reset at the start of each period (e.g. 1st of month) instead of rolling from creation date
+												</p>
+											</div>
+											<Switch
+												id="vk-budget-calendar-aligned-toggle"
+												aria-describedby="vk-budget-calendar-aligned-description"
+												checked={watchedBudgetCalendarAligned}
+												onCheckedChange={handleCalendarAlignedChange}
+												data-testid="vk-budget-calendar-aligned-toggle"
 											/>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-
-								<FormField
-									control={form.control}
-									name="requestMaxLimit"
-									render={({ field }) => (
-										<FormItem>
-											<NumberAndSelect
-												id="requestMaxLimit"
-												labelClassName="font-normal"
-												label="Maximum Requests"
-												value={field.value}
-												selectValue={form.watch("requestResetDuration") || "1h"}
-												onChangeNumber={(value) => {
-													field.onChange(value);
-												}}
-												onChangeSelect={(value) => form.setValue("requestResetDuration", value, { shouldDirty: true })}
-												options={resetDurationOptions}
-											/>
-											<FormMessage />
-										</FormItem>
-									)}
-								/>
-							</div>
-							{(teams?.length > 0 || customers?.length > 0) && (
-								<>
-									<DottedSeparator className="my-6" />
-
-									{/* Entity Assignment */}
-									<div className="space-y-4">
-										<Label className="text-sm font-medium">Entity Assignment</Label>
-
-										<div className="grid grid-cols-1 items-center gap-2 md:grid-cols-2">
-											<FormField
-												control={form.control}
-												name="entityType"
-												render={({ field }) => (
-													<FormItem>
-														<FormLabel className="font-normal">Assignment Type</FormLabel>
-														<Select
-															onValueChange={async (value) => {
-																field.onChange(value);
-																// Auto-select first entry when switching to team or customer
-																if (value === "team" && teams && teams.length > 0) {
-																	form.setValue("teamId", teams[0].id, { shouldDirty: true, shouldValidate: true });
-																	form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
-																	// Trigger validation after state updates
-																	await form.trigger(["teamId", "customerId", "entityType"]);
-																} else if (value === "customer" && customers && customers.length > 0) {
-																	form.setValue("customerId", customers[0].id, { shouldDirty: true, shouldValidate: true });
-																	form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
-																	// Trigger validation after state updates
-																	await form.trigger(["teamId", "customerId", "entityType"]);
-																} else if (value === "none") {
-																	form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
-																	form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
-																	// Trigger validation after state updates
-																	await form.trigger(["teamId", "customerId", "entityType"]);
-																}
-															}}
-															defaultValue={field.value}
-															disabled={isTeamLocked}
-														>
-															<FormControl className="w-full">
-																<SelectTrigger data-testid="vk-entity-type-select">
-																	<SelectValue />
-																</SelectTrigger>
-															</FormControl>
-															<SelectContent>
-																<SelectItem value="none">No Assignment</SelectItem>
-																{teams?.length > 0 && <SelectItem value="team">Assign to Team</SelectItem>}
-																{customers?.length > 0 && <SelectItem value="customer">Assign to Customer</SelectItem>}
-															</SelectContent>
-														</Select>
-														<FormMessage />
-													</FormItem>
-												)}
-											/>
-											{form.watch("entityType") === "team" && teams?.length > 0 && (
-												<FormField
-													control={form.control}
-													name="teamId"
-													render={({ field }) => (
-														<FormItem>
-															<FormLabel className="font-normal">Select Team</FormLabel>
-															<Select onValueChange={field.onChange} defaultValue={field.value} disabled={isTeamLocked}>
-																<FormControl className="w-full">
-																	<SelectTrigger data-testid="vk-team-select">
-																		<SelectValue placeholder="Select a team" />
-																	</SelectTrigger>
-																</FormControl>
-																<SelectContent>
-																	{teams.map((team) => (
-																		<SelectItem key={team.id} value={team.id}>
-																			<div className="flex items-center gap-2">
-																				<Users className="h-4 w-4" />
-																				{team.name}
-																				{team.customer && (
-																					<span className="text-muted-foreground flex items-center gap-1">
-																						<Building className="h-2 w-2" />
-																						{team.customer.name}
-																					</span>
-																				)}
-																			</div>
-																		</SelectItem>
-																	))}
-																</SelectContent>
-															</Select>
-															<FormMessage />
-														</FormItem>
-													)}
-												/>
-											)}
-
-											{form.watch("entityType") === "customer" && customers?.length > 0 && (
-												<FormField
-													control={form.control}
-													name="customerId"
-													render={({ field }) => (
-														<FormItem>
-															<FormLabel className="font-normal">Select Customer</FormLabel>
-															<Select onValueChange={field.onChange} defaultValue={field.value}>
-																<FormControl className="w-full">
-																	<SelectTrigger data-testid="vk-customer-select">
-																		<SelectValue placeholder="Select a customer" />
-																	</SelectTrigger>
-																</FormControl>
-																<SelectContent>
-																	{customers.map((customer) => (
-																		<SelectItem key={customer.id} value={customer.id}>
-																			<div className="flex items-center gap-2">
-																				<Building className="h-4 w-4" />
-																				{customer.name}
-																			</div>
-																		</SelectItem>
-																	))}
-																</SelectContent>
-															</Select>
-															<FormMessage />
-														</FormItem>
-													)}
-												/>
-											)}
 										</div>
+									)}
+
+									{/* Warning dialog shown when enabling calendar alignment on an existing budget */}
+									<AlertDialog open={showCalendarAlignWarning} onOpenChange={setShowCalendarAlignWarning}>
+										<AlertDialogContent>
+											<AlertDialogHeader>
+												<AlertDialogTitle>Reset budget usage?</AlertDialogTitle>
+												<AlertDialogDescription>
+													Enabling calendar alignment will reset all budget usage for this virtual key to{" "}
+													<span className="font-semibold">$0.00</span> and snap each budget&apos;s reset date to the start of its current
+													period (e.g. start of day, week, month, or year). The usage reset to $0.00 cannot be undone, but calendar
+													alignment can be turned off later. This will take effect when you save.
+												</AlertDialogDescription>
+											</AlertDialogHeader>
+											<AlertDialogFooter>
+												<AlertDialogCancel data-testid="vk-calendar-align-cancel-btn">Cancel</AlertDialogCancel>
+												<AlertDialogAction
+													data-testid="vk-calendar-align-enable-btn"
+													onClick={() => {
+														form.setValue("budgetCalendarAligned", true, { shouldDirty: true });
+														setShowCalendarAlignWarning(false);
+													}}
+												>
+													Enable Calendar Alignment
+												</AlertDialogAction>
+											</AlertDialogFooter>
+										</AlertDialogContent>
+									</AlertDialog>
+								</div>
+								{/* Rate Limiting Configuration */}
+								<div className="space-y-4">
+									<div className="flex items-center justify-between gap-2">
+										<Label className="text-sm font-medium">Rate Limiting Configuration</Label>
+										{isEditing && (virtualKey?.rate_limit || watchedTokenMaxLimit || watchedRequestMaxLimit) && (
+											<Button
+												type="button"
+												variant="ghost"
+												size="sm"
+												onClick={clearVirtualKeyRateLimits}
+												data-testid="vk-rate-limit-reset-button"
+											>
+												<RotateCcw className="h-4 w-4" />
+												Reset
+											</Button>
+										)}
 									</div>
-								</>
-							)}
-						</fieldset>
+
+									<FormField
+										control={form.control}
+										name="tokenMaxLimit"
+										render={({ field }) => (
+											<FormItem>
+												<NumberAndSelect
+													id="tokenMaxLimit"
+													labelClassName="font-normal"
+													label="Maximum Tokens"
+													value={field.value}
+													selectValue={form.watch("tokenResetDuration") || "1h"}
+													onChangeNumber={(value) => {
+														field.onChange(value);
+													}}
+													onChangeSelect={(value) => form.setValue("tokenResetDuration", value, { shouldDirty: true })}
+													options={resetDurationOptions}
+												/>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+
+									<FormField
+										control={form.control}
+										name="requestMaxLimit"
+										render={({ field }) => (
+											<FormItem>
+												<NumberAndSelect
+													id="requestMaxLimit"
+													labelClassName="font-normal"
+													label="Maximum Requests"
+													value={field.value}
+													selectValue={form.watch("requestResetDuration") || "1h"}
+													onChangeNumber={(value) => {
+														field.onChange(value);
+													}}
+													onChangeSelect={(value) => form.setValue("requestResetDuration", value, { shouldDirty: true })}
+													options={resetDurationOptions}
+												/>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
+								</div>
+								{(teams?.length > 0 || customers?.length > 0) && (
+									<>
+										<DottedSeparator className="my-6" />
+
+										{/* Entity Assignment */}
+										<div className="space-y-4">
+											<Label className="text-sm font-medium">Entity Assignment</Label>
+
+											<div className="grid grid-cols-1 items-center gap-2 md:grid-cols-2">
+												<FormField
+													control={form.control}
+													name="entityType"
+													render={({ field }) => (
+														<FormItem>
+															<FormLabel className="font-normal">Assignment Type</FormLabel>
+															<Select
+																onValueChange={async (value) => {
+																	field.onChange(value);
+																	// Auto-select first entry when switching to team or customer
+																	if (value === "team" && teams && teams.length > 0) {
+																		form.setValue("teamId", teams[0].id, { shouldDirty: true, shouldValidate: true });
+																		form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
+																		// Trigger validation after state updates
+																		await form.trigger(["teamId", "customerId", "entityType"]);
+																	} else if (value === "customer" && customers && customers.length > 0) {
+																		form.setValue("customerId", customers[0].id, { shouldDirty: true, shouldValidate: true });
+																		form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
+																		// Trigger validation after state updates
+																		await form.trigger(["teamId", "customerId", "entityType"]);
+																	} else if (value === "none") {
+																		form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
+																		form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
+																		// Trigger validation after state updates
+																		await form.trigger(["teamId", "customerId", "entityType"]);
+																	}
+																}}
+																defaultValue={field.value}
+																disabled={isTeamLocked}
+															>
+																<FormControl className="w-full">
+																	<SelectTrigger data-testid="vk-entity-type-select">
+																		<SelectValue />
+																	</SelectTrigger>
+																</FormControl>
+																<SelectContent>
+																	<SelectItem value="none">No Assignment</SelectItem>
+																	{teams?.length > 0 && <SelectItem value="team">Assign to Team</SelectItem>}
+																	{customers?.length > 0 && <SelectItem value="customer">Assign to Customer</SelectItem>}
+																</SelectContent>
+															</Select>
+															<FormMessage />
+														</FormItem>
+													)}
+												/>
+												{form.watch("entityType") === "team" && teams?.length > 0 && (
+													<FormField
+														control={form.control}
+														name="teamId"
+														render={({ field }) => (
+															<FormItem>
+																<FormLabel className="font-normal">Select Team</FormLabel>
+																<Select onValueChange={field.onChange} defaultValue={field.value} disabled={isTeamLocked}>
+																	<FormControl className="w-full">
+																		<SelectTrigger data-testid="vk-team-select">
+																			<SelectValue placeholder="Select a team" />
+																		</SelectTrigger>
+																	</FormControl>
+																	<SelectContent>
+																		{teams.map((team) => (
+																			<SelectItem key={team.id} value={team.id}>
+																				<div className="flex items-center gap-2">
+																					<Users className="h-4 w-4" />
+																					{team.name}
+																					{team.customer && (
+																						<span className="text-muted-foreground flex items-center gap-1">
+																							<Building className="h-2 w-2" />
+																							{team.customer.name}
+																						</span>
+																					)}
+																				</div>
+																			</SelectItem>
+																		))}
+																	</SelectContent>
+																</Select>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+												)}
+
+												{form.watch("entityType") === "customer" && customers?.length > 0 && (
+													<FormField
+														control={form.control}
+														name="customerId"
+														render={({ field }) => (
+															<FormItem>
+																<FormLabel className="font-normal">Select Customer</FormLabel>
+																<Select onValueChange={field.onChange} defaultValue={field.value}>
+																	<FormControl className="w-full">
+																		<SelectTrigger data-testid="vk-customer-select">
+																			<SelectValue placeholder="Select a customer" />
+																		</SelectTrigger>
+																	</FormControl>
+																	<SelectContent>
+																		{customers.map((customer) => (
+																			<SelectItem key={customer.id} value={customer.id}>
+																				<div className="flex items-center gap-2">
+																					<Building className="h-4 w-4" />
+																					{customer.name}
+																				</div>
+																			</SelectItem>
+																		))}
+																	</SelectContent>
+																</Select>
+																<FormMessage />
+															</FormItem>
+														)}
+													/>
+												)}
+											</div>
+										</div>
+									</>
+								)}
+							</fieldset>
 						</div>
-						{isEditing && virtualKey?.config_hash && <ConfigSyncAlert className="mt-2" />}
+						{isEditing && virtualKey?.config_hash && (
+							<div className="px-8">
+								<ConfigSyncAlert className="mt-2" />
+							</div>
+						)}
 						{/* Form Footer */}
-						<div className="dark:bg-card border-border bg-white py-6">
+						<div className="border-border bg-card sticky bottom-0 z-10 border-t px-8 py-4">
 							<div className="flex justify-end gap-2">
 								<Button type="button" variant="outline" onClick={handleClose} data-testid="vk-cancel-btn">
 									Cancel
@@ -1501,11 +1504,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 									<Tooltip>
 										<TooltipTrigger asChild>
 											<span className="inline-block">
-												<Button
-													type="submit"
-													disabled={isLoading || !form.formState.isDirty || !form.formState.isValid || !canSubmit}
-													data-testid="vk-save-btn"
-												>
+												<Button type="submit" disabled={isLoading || !form.formState.isDirty || !canSubmit} data-testid="vk-save-btn">
 													{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
 												</Button>
 											</span>
@@ -1517,11 +1516,9 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 														? "You don't have permission to perform this action"
 														: isLoading
 															? "Saving..."
-															: !form.formState.isDirty && !form.formState.isValid
-																? "No changes made and validation errors present"
-																: !form.formState.isDirty
-																	? "No changes made"
-																	: "Please fix validation errors"}
+															: !form.formState.isDirty
+																? "No changes made"
+																: ""}
 												</p>
 											</TooltipContent>
 										)}

--- a/ui/components/prompts/sheets/promptSheet.tsx
+++ b/ui/components/prompts/sheets/promptSheet.tsx
@@ -71,45 +71,47 @@ export function PromptSheet({ open, onOpenChange, prompt, folderId, onSaved }: P
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent
-				className="p-8"
+				className="p-0"
 				onOpenAutoFocus={(e) => {
 					e.preventDefault();
 					document.getElementById("name")?.focus();
 				}}
 			>
-				<form onSubmit={handleSubmit(onSubmit)}>
-					<SheetHeader className="flex flex-col items-start">
+				<form onSubmit={handleSubmit(onSubmit)} className="flex flex-col grow">
+					<SheetHeader className="flex flex-col items-start px-8 pt-8">
 						<SheetTitle>{isEditing ? "Rename Prompt" : "Create Prompt"}</SheetTitle>
 						<SheetDescription>
 							{isEditing ? "Update the prompt name." : folderId ? "Create a new prompt in this folder." : "Create a new prompt."}
 						</SheetDescription>
 					</SheetHeader>
 
-					<div className="mt-6 space-y-4">
-						<div className="space-y-2">
-							<Label htmlFor="name">Name</Label>
-							<Input
-								id="name"
-								data-testid="prompt-name-input"
-								placeholder="Customer Support Assistant"
-								{...register("name", {
-									required: "Prompt name is required",
-									validate: (v) => v.trim().length > 0 || "Prompt name cannot be blank",
-								})}
-								autoFocus
-							/>
-							{errors.name && <p className="text-destructive text-xs">{errors.name.message}</p>}
+					<div className="flex flex-col gap-6 grow">
+						<div className="space-y-4 grow px-8" >
+							<div className="space-y-2">
+								<Label htmlFor="name">Name</Label>
+								<Input
+									id="name"
+									data-testid="prompt-name-input"
+									placeholder="Customer Support Assistant"
+									{...register("name", {
+										required: "Prompt name is required",
+										validate: (v) => v.trim().length > 0 || "Prompt name cannot be blank",
+									})}
+									autoFocus
+								/>
+								{errors.name && <p className="text-destructive text-xs">{errors.name.message}</p>}
+							</div>
 						</div>
-					</div>
 
-					<SheetFooter className="mt-6 flex flex-row items-center justify-end gap-2 p-0">
-						<Button type="button" variant="outline" data-testid="prompt-cancel" onClick={() => onOpenChange(false)}>
-							Cancel
-						</Button>
-						<Button type="submit" data-testid="prompt-submit" disabled={isLoading}>
-							{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
-						</Button>
-					</SheetFooter>
+						<SheetFooter className="flex flex-row items-center justify-end gap-2 py-4 px-8 border-t">
+							<Button type="button" variant="outline" data-testid="prompt-cancel" onClick={() => onOpenChange(false)}>
+								Cancel
+							</Button>
+							<Button type="submit" data-testid="prompt-submit" disabled={isLoading}>
+								{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
+							</Button>
+						</SheetFooter>
+					</div>
 				</form>
 			</SheetContent>
 		</Sheet>

--- a/ui/components/ui/sheet.tsx
+++ b/ui/components/ui/sheet.tsx
@@ -127,13 +127,18 @@ function SheetContent({
 function SheetHeader({
 	className,
 	children,
+	headerClassName,
 	showCloseButton = true,
 	...props
-}: React.ComponentProps<"div"> & { showCloseButton?: boolean }) {
+}: React.ComponentProps<"div"> & { showCloseButton?: boolean; headerClassName?: string }) {
 	const sheetContext = useSheetContext();
 
 	return (
-		<div data-slot="sheet-header" className={cn("flex items-center", sheetContext?.expandable ? "p-0" : "mb-6")} {...props}>
+		<div
+			data-slot="sheet-header"
+			className={cn("flex items-center", sheetContext?.expandable ? "p-0" : "mb-6", headerClassName)}
+			{...props}
+		>
 			{sheetContext?.expandable && sheetContext?.side === "right" && (
 				<button
 					type="button"


### PR DESCRIPTION
## Summary

Refactored sheet and form layouts across guardrail configs, API keys, and access profiles to use sticky headers and footers with proper scrollable content areas

## Changes

- All sheets with forms do not have a sticky header at the top, and form actions like Submit and Cancel are fixed at the bottom so they are always clickable without scrolling.
- Moved some of the form validation to React Hook Form instead of using manual validation.

##   
Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

NA

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable