### PR TITLE
feat: add access_profiles schema support to config.json and Helm chart

### DIFF
--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -17,11 +17,12 @@ This page is a concise reference for every top-level key in `config.json`. Click
 | Key | Type | Description | Guide |
 |-----|------|-------------|-------|
 | `$schema` | string | Schema URL for IDE validation. Set to `"https://www.getbifrost.ai/schema"` | — |
-| `encryption_key` | string | AES-256 key (derived via Argon2id). Accepts `env.VAR` prefix. Also read from `BIFROST_ENCRYPTION_KEY` env var | [Client](/deployment-guides/config-json/client#encryption-key) |
+| `encryption_key` | string | Optional AES-256 key (derived via Argon2id). Accepts `env.VAR` prefix and is also read from `BIFROST_ENCRYPTION_KEY`. If omitted, data is stored in plaintext. | [Client](/deployment-guides/config-json/client#encryption-key) |
 | `client` | object | Worker pool, logging, CORS, auth enforcement, header filtering, MCP, compat shims | [Client](/deployment-guides/config-json/client) |
 | `providers` | object | LLM provider API keys, network settings, concurrency | [Providers](/deployment-guides/config-json/providers) |
 | `governance` | object | Admin auth, virtual keys, budgets, rate limits, routing rules, customers, teams | [Governance](/deployment-guides/config-json/governance) |
 | `guardrails_config` | object | Content moderation providers and CEL-based rules *(enterprise only)* | [Guardrails](/deployment-guides/config-json/guardrails) |
+| `access_profiles` | array | Access profile templates for enterprise RBAC/governance controls *(enterprise only)* | [Enterprise Governance](/enterprise/advanced-governance) |
 | `config_store` | object | Configuration database backend — SQLite, PostgreSQL, or disabled (file-only mode) | [Storage](/deployment-guides/config-json/storage#config_store) |
 | `logs_store` | object | Request/response log database — SQLite, PostgreSQL + optional S3/GCS offload | [Storage](/deployment-guides/config-json/storage#logs_store) |
 | `vector_store` | object | Vector database for semantic cache — Weaviate, Redis, Qdrant, Pinecone, Valkey | [Storage](/deployment-guides/config-json/storage#vector_store) |
@@ -115,6 +116,38 @@ Full documentation: [Governance](/deployment-guides/config-json/governance).
 Enterprise-only. Two sub-keys: `guardrail_providers` (array) and `guardrail_rules` (array).
 
 Full documentation: [Guardrails](/deployment-guides/config-json/guardrails).
+
+---
+
+## `access_profiles`
+
+Enterprise-only. Defines access profile templates that can later be attached to roles/users.
+
+```json
+{
+  "access_profiles": [
+    {
+      "name": "platform-default",
+      "description": "Default platform profile",
+      "is_active": true,
+      "tags": ["platform", "default"],
+      "provider_configs": [
+        {
+          "provider_name": "openai",
+          "all_models_allowed": false,
+          "allowed_models": ["gpt-4o", "gpt-4o-mini"]
+        }
+      ],
+      "mcp_servers": [
+        { "mcp_server_id": "github" }
+      ],
+      "mcp_tool_overrides": [
+        { "mcp_client_id": "github", "tool_name": "create_pull_request", "action": "include" }
+      ]
+    }
+  ]
+}
+```
 
 ---
 

--- a/docs/deployment-guides/helm/client.mdx
+++ b/docs/deployment-guides/helm/client.mdx
@@ -172,7 +172,7 @@ helm upgrade bifrost bifrost/bifrost \
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `bifrost.encryptionKey` | 32-byte encryption key (plain text — use secret in production) | `""` |
+| `bifrost.encryptionKey` | Optional encryption key (plain text — use `encryptionKeySecret` in production). If omitted, data is stored in plaintext. | `""` |
 | `bifrost.encryptionKeySecret.name` | Kubernetes Secret name containing the key | `""` |
 | `bifrost.encryptionKeySecret.key` | Key within the secret | `"encryption-key"` |
 

--- a/docs/deployment-guides/helm/governance.mdx
+++ b/docs/deployment-guides/helm/governance.mdx
@@ -419,3 +419,28 @@ kubectl create secret generic bifrost-admin-credentials \
 
 helm install bifrost bifrost/bifrost -f governance-full-values.yaml
 ```
+
+---
+
+## Access Profiles (Enterprise)
+
+You can seed enterprise `access_profiles` directly from Helm values. The chart renders `bifrost.accessProfiles` into top-level `access_profiles` in `config.json`.
+
+```yaml
+bifrost:
+  accessProfiles:
+    - name: "platform-default"
+      description: "Default profile for platform users"
+      is_active: true
+      tags: ["platform", "default"]
+      provider_configs:
+        - provider_name: "openai"
+          all_models_allowed: false
+          allowed_models: ["gpt-4o", "gpt-4o-mini"]
+      mcp_servers:
+        - mcp_server_id: "github"
+      mcp_tool_overrides:
+        - mcp_client_id: "github"
+          tool_name: "create_pull_request"
+          action: "include"
+```

--- a/docs/deployment-guides/helm/governance.mdx
+++ b/docs/deployment-guides/helm/governance.mdx
@@ -182,7 +182,6 @@ bifrost:
           - provider: "openai"
             weight: 1
             allowed_models: ["gpt-4o", "gpt-4o-mini"]
-            # No keys[] → all configured OpenAI keys allowed
 
       # 3. Multi-provider with weighted routing
       - id: "vk-multi"
@@ -212,8 +211,7 @@ bifrost:
           - provider: "openai"
             weight: 1
             allowed_models: ["*"]
-            keys:
-              - name: "openai-primary"  # pin to specific configured key
+            key_ids: ["openai-primary"]  # pin to specific configured key by name
 
       # 5. Restricted testing key
       - id: "vk-testing"
@@ -238,9 +236,10 @@ bifrost:
           - provider: "openai"
             weight: 1
             allowed_models: ["*"]
-            keys:
-              - name: "openai-batch"    # only the batch-flagged key
+            key_ids: ["openai-batch"]    # only the batch-flagged key
 ```
+
+`provider_configs[].key_ids` and `provider_configs[].keys` are both supported in Helm values. Prefer `key_ids` for parity with `config.json` (`key_ids` should contain provider key names).
 
 **Use a virtual key in API calls:**
 

--- a/docs/deployment-guides/helm/troubleshooting.mdx
+++ b/docs/deployment-guides/helm/troubleshooting.mdx
@@ -92,7 +92,7 @@ kubectl get secret bifrost-encryption -o jsonpath='{.data.key}' | base64 -d
 kubectl logs -l app.kubernetes.io/name=bifrost --previous --tail=50
 
 # Common causes shown in logs:
-# "encryption key is required" → bifrost.encryptionKey or encryptionKeySecret not set
+# "encryption key is not initialized" → no key provided; optional, but data will be stored in plaintext
 # "failed to connect to database" → see Database section below
 # "image.tag is required" → set image.tag in values
 ```

--- a/docs/deployment-guides/helm/values.mdx
+++ b/docs/deployment-guides/helm/values.mdx
@@ -300,7 +300,7 @@ A quick-reference table of the most commonly used top-level parameters:
 | `postgresql.enabled` | Deploy embedded PostgreSQL | `false` |
 | `vectorStore.enabled` | Enable vector store | `false` |
 | `vectorStore.type` | Vector store type (`weaviate`, `redis`, `qdrant`) | `none` |
-| `bifrost.encryptionKey` | Encryption key (use `encryptionKeySecret` in production) | `""` |
+| `bifrost.encryptionKey` | Optional encryption key (use `encryptionKeySecret` in production). If omitted, data is stored in plaintext. | `""` |
 | `ingress.enabled` | Enable ingress | `false` |
 | `autoscaling.enabled` | Enable HPA | `false` |
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -541,6 +541,10 @@ false
 {{- $_ := set $config "guardrails_config" $guardrails }}
 {{- end }}
 {{- end }}
+{{- /* Access Profiles (Enterprise) */ -}}
+{{- if .Values.bifrost.accessProfiles }}
+{{- $_ := set $config "access_profiles" .Values.bifrost.accessProfiles }}
+{{- end }}
 {{- /* Config Store */ -}}
 {{- if .Values.storage.configStore.enabled }}
 {{- $configStoreType := .Values.storage.configStore.type | default .Values.storage.mode }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -238,7 +238,7 @@
         },
         "encryptionKey": {
           "type": "string",
-          "description": "Encryption key for sensitive data"
+          "description": "Encryption key for sensitive data. If not set, encryption is disabled and data is stored in plaintext."
         },
         "encryptionKeySecret": {
           "type": "object",
@@ -1662,6 +1662,127 @@
             }
           }
         },
+        "accessProfiles": {
+          "type": "array",
+          "description": "Enterprise access profile templates rendered as top-level access_profiles in config.json",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "description": { "type": "string" },
+              "is_active": { "type": "boolean" },
+              "tags": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "budgets": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "max_limit": { "type": "number" },
+                    "reset_duration": { "type": "string" }
+                  },
+                  "required": ["id", "max_limit", "reset_duration"],
+                  "additionalProperties": false
+                }
+              },
+              "rate_limit": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "string" },
+                  "token_max_limit": { "type": "integer" },
+                  "token_reset_duration": { "type": "string" },
+                  "request_max_limit": { "type": "integer" },
+                  "request_reset_duration": { "type": "string" }
+                },
+                "required": ["id"],
+                "additionalProperties": false
+              },
+              "provider_configs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "provider_name": { "type": "string" },
+                    "all_models_allowed": { "type": "boolean" },
+                    "allowed_models": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    "budgets": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "max_limit": { "type": "number" },
+                          "reset_duration": { "type": "string" }
+                        },
+                        "required": ["id", "max_limit", "reset_duration"],
+                        "additionalProperties": false
+                      }
+                    },
+                    "rate_limit": {
+                      "type": "object",
+                      "properties": {
+                        "id": { "type": "string" },
+                        "token_max_limit": { "type": "integer" },
+                        "token_reset_duration": { "type": "string" },
+                        "request_max_limit": { "type": "integer" },
+                        "request_reset_duration": { "type": "string" }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": ["provider_name"],
+                  "additionalProperties": false
+                }
+              },
+              "mcp_tool_groups": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "tool_group_id": { "type": "integer" }
+                  },
+                  "required": ["tool_group_id"],
+                  "additionalProperties": false
+                }
+              },
+              "mcp_servers": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "mcp_server_id": { "type": "string" }
+                  },
+                  "required": ["mcp_server_id"],
+                  "additionalProperties": false
+                }
+              },
+              "mcp_tool_overrides": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "mcp_client_id": { "type": "string" },
+                    "tool_name": { "type": "string" },
+                    "action": {
+                      "type": "string",
+                      "enum": ["include", "exclude"]
+                    }
+                  },
+                  "required": ["mcp_client_id", "tool_name", "action"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
         "auditLogs": {
           "type": "object",
           "properties": {
@@ -2700,7 +2821,7 @@
           "additionalProperties": false
         }
       },
-      "required": [
+      "required":[
         "name",
         "weight"
       ],

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3093,6 +3093,13 @@
           "type": "string",
           "description": "Associated rate limit ID"
         },
+        "key_ids": {
+          "type": "array",
+          "description": "Key identifiers allowed for this provider config. Use [\"*\"] to allow all keys; empty array denies all (deny-by-default). In Helm values, use provider key names.",
+          "items": {
+            "type": "string"
+          }
+        },
         "keys": {
           "type": "array",
           "description": "Provider keys for this config (empty means all keys allowed for this provider)",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -608,6 +608,34 @@ bifrost:
       #   enabled: true
       #   config: {}
 
+  # Access profiles (enterprise): seed RBAC access profile templates from Helm.
+  # This is rendered directly as top-level `access_profiles` in config.json.
+  accessProfiles: []
+    # - name: "platform-default"
+    #   description: "Default platform profile"
+    #   is_active: true
+    #   tags: ["platform", "default"]
+    #   budgets:
+    #     - id: "ap-budget-1"
+    #       max_limit: 100
+    #       reset_duration: "1M"
+    #   rate_limit:
+    #     id: "ap-rate-limit-1"
+    #     token_max_limit: 200000
+    #     token_reset_duration: "1h"
+    #   provider_configs:
+    #     - provider_name: "openai"
+    #       all_models_allowed: false
+    #       allowed_models: ["gpt-4o", "gpt-4o-mini"]
+    #   mcp_tool_groups:
+    #     - tool_group_id: 1
+    #   mcp_servers:
+    #     - mcp_server_id: "github"
+    #   mcp_tool_overrides:
+    #     - mcp_client_id: "github"
+    #       tool_name: "create_pull_request"
+    #       action: "include"
+
   # Audit logs configuration for CADF-compliant activity logging
   auditLogs:
     disabled: false

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1544,6 +1544,9 @@
     },
     "scim_config": {
       "$ref": "#/$defs/scim_config"
+    },
+    "access_profiles": {
+      "$ref": "#/$defs/access_profiles"
     }
   },
   "additionalProperties": false,
@@ -3368,6 +3371,215 @@
           }
         }
       },
+      "additionalProperties": false
+    },
+    "access_profiles": {
+      "type": "array",
+      "description": "Enterprise access profile templates for RBAC-driven governance controls",
+      "items": {
+        "$ref": "#/$defs/access_profile"
+      }
+    },
+    "budget_line": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Budget ID"
+        },
+        "max_limit": {
+          "type": "number",
+          "description": "Maximum spend limit in USD"
+        },
+        "reset_duration": {
+          "type": "string",
+          "description": "Reset window, e.g. \"1M\", \"1h\""
+        }
+      },
+      "required": [
+        "id",
+        "max_limit",
+        "reset_duration"
+      ],
+      "additionalProperties": false
+    },
+    "rate_limit_line": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Rate limit ID"
+        },
+        "token_max_limit": {
+          "type": "integer",
+          "description": "Maximum number of tokens allowed in the reset window"
+        },
+        "token_reset_duration": {
+          "type": "string",
+          "description": "Token reset window, e.g. \"1M\", \"1h\""
+        },
+        "request_max_limit": {
+          "type": "integer",
+          "description": "Maximum number of requests allowed in the reset window"
+        },
+        "request_reset_duration": {
+          "type": "string",
+          "description": "Request reset window, e.g. \"1M\", \"1h\""
+        }
+      },
+      "required": ["id"],
+      "additionalProperties": false
+    },
+    "access_profile": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique access profile name"
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional profile description"
+        },
+        "is_active": {
+          "type": "boolean",
+          "description": "Whether this access profile is active",
+          "default": true
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional list of tags for filtering and grouping profiles"
+        },
+        "budgets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/budget_line"
+          },
+          "description": "Profile-level budgets"
+        },
+        "rate_limit": {
+          "$ref": "#/$defs/rate_limit_line"
+        },
+        "provider_configs": {
+          "type": "array",
+          "description": "Per-provider restrictions and limits for this profile",
+          "items": {
+            "$ref": "#/$defs/access_profile_provider_config"
+          }
+        },
+        "mcp_tool_groups": {
+          "type": "array",
+          "description": "MCP tool group associations",
+          "items": {
+            "$ref": "#/$defs/access_profile_mcp_tool_group"
+          }
+        },
+        "mcp_servers": {
+          "type": "array",
+          "description": "MCP server associations",
+          "items": {
+            "$ref": "#/$defs/access_profile_mcp_server"
+          }
+        },
+        "mcp_tool_overrides": {
+          "type": "array",
+          "description": "Per-tool include/exclude MCP overrides",
+          "items": {
+            "$ref": "#/$defs/access_profile_mcp_tool_override"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "access_profile_provider_config": {
+      "type": "object",
+      "properties": {
+        "provider_name": {
+          "type": "string",
+          "description": "Provider name"
+        },
+        "all_models_allowed": {
+          "type": "boolean",
+          "description": "Whether all models under this provider are allowed",
+          "default": false
+        },
+        "allowed_models": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allowed model names (ignored when all_models_allowed is true)"
+        },
+        "budgets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/budget_line"
+          }
+        },
+        "rate_limit": {
+          "$ref": "#/$defs/rate_limit_line"
+        }
+      },
+      "required": [
+        "provider_name"
+      ],
+      "additionalProperties": false
+    },
+    "access_profile_mcp_tool_group": {
+      "type": "object",
+      "properties": {
+        "tool_group_id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "MCP tool group ID"
+        }
+      },
+      "required": [
+        "tool_group_id"
+      ],
+      "additionalProperties": false
+    },
+    "access_profile_mcp_server": {
+      "type": "object",
+      "properties": {
+        "mcp_server_id": {
+          "type": "string",
+          "description": "MCP server identifier"
+        }
+      },
+      "required": [
+        "mcp_server_id"
+      ],
+      "additionalProperties": false
+    },
+    "access_profile_mcp_tool_override": {
+      "type": "object",
+      "properties": {
+        "mcp_client_id": {
+          "type": "string",
+          "description": "MCP client identifier"
+        },
+        "tool_name": {
+          "type": "string",
+          "description": "Tool name"
+        },
+        "action": {
+          "type": "string",
+          "enum": ["include", "exclude"],
+          "description": "Override action"
+        }
+      },
+      "required": [
+        "mcp_client_id",
+        "tool_name",
+        "action"
+      ],
       "additionalProperties": false
     },
     "audit_logs_config": {


### PR DESCRIPTION
## Summary

Adds support for seeding enterprise `access_profiles` via `config.json` and Helm values. This allows operators to define RBAC access profile templates — including provider restrictions, model allowlists, budgets, rate limits, and MCP server/tool controls — declaratively at deploy time rather than only through the API.

## Changes

- Added `access_profiles` as a top-level key in `config.schema.json`, with full schema definitions for `access_profile`, `access_profile_provider_config`, `access_profile_mcp_tool_group`, `access_profile_mcp_server`, and `access_profile_mcp_tool_override`
- Added `bifrost.accessProfiles` to the Helm chart's `values.yaml`, `values.schema.json`, and `_helpers.tpl` so the array is rendered directly into `config.json` as `access_profiles`
- Documented `access_profiles` in the `config.json` schema reference page with a usage example
- Documented Helm-based access profile seeding in the Helm governance guide

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Add an `access_profiles` entry to `config.json` and verify it is accepted without validation errors:

```json
{
  "access_profiles": [
    {
      "name": "platform-default",
      "is_active": true,
      "provider_configs": [
        {
          "provider_name": "openai",
          "all_models_allowed": false,
          "allowed_models": ["gpt-4o", "gpt-4o-mini"]
        }
      ],
      "mcp_servers": [{ "mcp_server_id": "github" }],
      "mcp_tool_overrides": [
        { "mcp_client_id": "github", "tool_name": "create_pull_request", "action": "include" }
      ]
    }
  ]
}
```

For Helm, set `bifrost.accessProfiles` in your values and confirm the rendered `config.json` contains the expected `access_profiles` array:

```sh
helm template bifrost ./helm-charts/bifrost -f your-values.yaml | grep -A 20 access_profiles
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Access profiles are an enterprise RBAC feature. Profiles defined here control which providers, models, and MCP tools are accessible to attached roles/users. Ensure that `config.json` and Helm values containing access profile definitions are treated with the same sensitivity as other governance configuration (e.g., stored in secrets or restricted ConfigMaps).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable