### PR TITLE
fix: dump all rate limits to DB including access profiles

### DIFF
--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1527,97 +1527,35 @@ func (gs *LocalGovernanceStore) DumpRateLimits(ctx context.Context, tokenBaselin
 	if requestBaselines == nil {
 		requestBaselines = map[string]int64{}
 	}
-	// Collect unique rate limit IDs from virtual keys, model configs, and providers
-	rateLimitIDs := make(map[string]bool)
-	gs.virtualKeys.Range(func(key, value interface{}) bool {
-		vk, ok := value.(*configstoreTables.TableVirtualKey)
-		if !ok || vk == nil {
-			return true // continue
-		}
-		if vk.RateLimitID != nil {
-			rateLimitIDs[*vk.RateLimitID] = true
-		}
-		if vk.ProviderConfigs != nil {
-			for _, pc := range vk.ProviderConfigs {
-				if pc.RateLimitID != nil {
-					rateLimitIDs[*pc.RateLimitID] = true
-				}
-			}
-		}
-		return true // continue
-	})
-	// Collect rate limit IDs from model configs
-	gs.modelConfigs.Range(func(key, value interface{}) bool {
-		mc, ok := value.(*configstoreTables.TableModelConfig)
-		if !ok || mc == nil {
-			return true // continue
-		}
-		if mc.RateLimitID != nil {
-			rateLimitIDs[*mc.RateLimitID] = true
-		}
-		return true // continue
-	})
-	// Collect rate limit IDs from providers
-	gs.providers.Range(func(key, value interface{}) bool {
-		provider, ok := value.(*configstoreTables.TableProvider)
-		if !ok || provider == nil {
-			return true // continue
-		}
-		if provider.RateLimitID != nil {
-			rateLimitIDs[*provider.RateLimitID] = true
-		}
-		return true // continue
-	})
-
-	// Collect rate limit IDs from teams
-	gs.teams.Range(func(key, value interface{}) bool {
-		team, ok := value.(*configstoreTables.TableTeam)
-		if !ok || team == nil {
-			return true // continue
-		}
-		if team.RateLimitID != nil {
-			rateLimitIDs[*team.RateLimitID] = true
-		}
-		return true // continue
-	})
-
-	// Collect rate limit IDs from customers
-	gs.customers.Range(func(key, value interface{}) bool {
-		customer, ok := value.(*configstoreTables.TableCustomer)
-		if !ok || customer == nil {
-			return true // continue
-		}
-		if customer.RateLimitID != nil {
-			rateLimitIDs[*customer.RateLimitID] = true
-		}
-		return true // continue
-	})
-
-	// Prepare rate limit usage updates with baselines
+	// Range over ALL rate limits in memory (mirrors DumpBudgets pattern).
+	// This covers rate limits from every source: virtual keys, model configs,
+	// providers, teams, customers, AND access profiles — whose IDs were
+	// previously missing, causing AP rate-limit usage to never reach the DB.
 	type rateLimitUpdate struct {
 		ID                  string
 		TokenCurrentUsage   int64
 		RequestCurrentUsage int64
 	}
 	var rateLimitUpdates []rateLimitUpdate
-	for rateLimitID := range rateLimitIDs {
-		if rateLimitValue, exists := gs.rateLimits.Load(rateLimitID); exists && rateLimitValue != nil {
-			if rateLimit, ok := rateLimitValue.(*configstoreTables.TableRateLimit); ok && rateLimit != nil {
-				update := rateLimitUpdate{
-					ID:                  rateLimit.ID,
-					TokenCurrentUsage:   rateLimit.TokenCurrentUsage,
-					RequestCurrentUsage: rateLimit.RequestCurrentUsage,
-				}
-				if tokenBaseline, exists := tokenBaselines[rateLimit.ID]; exists {
-					update.TokenCurrentUsage += tokenBaseline
-				}
-				if requestBaseline, exists := requestBaselines[rateLimit.ID]; exists {
-					update.RequestCurrentUsage += requestBaseline
-				}
-				rateLimitUpdates = append(rateLimitUpdates, update)
-			}
+	gs.rateLimits.Range(func(key, value interface{}) bool {
+		rateLimit, ok := value.(*configstoreTables.TableRateLimit)
+		if !ok || rateLimit == nil {
+			return true
 		}
-	}
+		update := rateLimitUpdate{
+			ID:                  rateLimit.ID,
+			TokenCurrentUsage:   rateLimit.TokenCurrentUsage,
+			RequestCurrentUsage: rateLimit.RequestCurrentUsage,
+		}
+		if tokenBaseline, exists := tokenBaselines[rateLimit.ID]; exists {
+			update.TokenCurrentUsage += tokenBaseline
+		}
+		if requestBaseline, exists := requestBaselines[rateLimit.ID]; exists {
+			update.RequestCurrentUsage += requestBaseline
+		}
+		rateLimitUpdates = append(rateLimitUpdates, update)
+		return true
+	})
 
 	// Save all updated rate limits to database using direct UPDATE to avoid overwriting config fields
 	if len(rateLimitUpdates) > 0 && gs.configStore != nil {


### PR DESCRIPTION
## Summary

Access profile rate limit usage was never persisted to the database because `DumpRateLimits` selectively collected rate limit IDs from individual entity types (VKs, model configs, providers, teams, customers) but missed access profiles entirely. This caused the UI to always display 0 for AP rate limit counters.

## Changes

- Replaced the selective ID-collection approach (5 separate `Range` calls over entity-specific sync.Maps) with a single `gs.rateLimits.Range(...)` that iterates over all rate limits in memory
- This mirrors the existing `DumpBudgets` pattern which already uses `gs.budgets.Range(...)` and correctly covers all sources
- Baseline addition logic for multi-node cluster-wide totals is preserved identically

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... -count=1
go test ./plugins/governance/... -run "TestBump" -count=1 -v
make build LOCAL=1
```

## Screenshots/Recordings

N/A — backend-only change.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None. Only affects the periodic DB dump of in-memory rate limit usage counters.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
