### PR TITLE
feat(openrouter): support model-variant suffixes

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -7059,7 +7059,17 @@ func (bifrost *Bifrost) selectKeyFromProviderForModelWithPool(ctx *schemas.Bifro
 			// NOTE: Model filtering uses the original requested model (which may be an alias).
 			// key.Models and key.BlacklistedModels must therefore be expressed in alias keys.
 			// The provider-specific identifier is resolved later in the handler closure via key.Aliases.Resolve(model).
-			modelSupported := hasValue && key.Models.IsAllowed(model) && !key.BlacklistedModels.IsBlocked(model)
+			// OpenRouter variant suffixes (:nitro, :floor, :online, :thinking, :exacto,
+			// :extended, :free) are routing hints, not distinct models. Fall back to the
+			// base model when evaluating allow/deny lists so users don't have to enumerate
+			// every variant in their key.Models configuration.
+			aclBase := model
+			if baseProviderType == schemas.OpenRouter {
+				aclBase = schemas.BaseOpenRouterModel(model)
+			}
+			allowedForKey := key.Models.IsAllowed(model) || (aclBase != model && key.Models.IsAllowed(aclBase))
+			blockedForKey := key.BlacklistedModels.IsBlocked(model) || (aclBase != model && key.BlacklistedModels.IsBlocked(aclBase))
+			modelSupported := hasValue && allowedForKey && !blockedForKey
 			if baseProviderType == schemas.VLLM && key.VLLMKeyConfig != nil {
 				if key.VLLMKeyConfig.ModelName != "" {
 					modelSupported = modelSupported && (key.VLLMKeyConfig.ModelName == model)

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -182,13 +182,19 @@ func (ka KeyAliases) Resolve(model string) string {
 	}
 	// OpenRouter variant fallback: try to resolve the base model (:nitro/:free/etc stripped),
 	// then re-append the variant suffix so the target is routed identically to the base.
+	// If the resolved alias target already carries a variant suffix, strip it first to
+	// avoid producing a double-variant string like "foo:nitro:nitro".
 	if base, variant := SplitOpenRouterVariant(model); variant != "" {
+		appendVariant := func(target string) string {
+			targetBase, _ := SplitOpenRouterVariant(target)
+			return targetBase + ":" + variant
+		}
 		if alias, ok := ka[base]; ok {
-			return alias + ":" + variant
+			return appendVariant(alias)
 		}
 		for k, v := range ka {
 			if strings.EqualFold(k, base) {
-				return v + ":" + variant
+				return appendVariant(v)
 			}
 		}
 	}

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -180,6 +180,18 @@ func (ka KeyAliases) Resolve(model string) string {
 			return v
 		}
 	}
+	// OpenRouter variant fallback: try to resolve the base model (:nitro/:free/etc stripped),
+	// then re-append the variant suffix so the target is routed identically to the base.
+	if base, variant := SplitOpenRouterVariant(model); variant != "" {
+		if alias, ok := ka[base]; ok {
+			return alias + ":" + variant
+		}
+		for k, v := range ka {
+			if strings.EqualFold(k, base) {
+				return v + ":" + variant
+			}
+		}
+	}
 	return model
 }
 

--- a/core/schemas/openrouter_variant_test.go
+++ b/core/schemas/openrouter_variant_test.go
@@ -1,0 +1,79 @@
+package schemas
+
+import "testing"
+
+func TestSplitOpenRouterVariant(t *testing.T) {
+	tests := []struct {
+		name        string
+		model       string
+		wantBase    string
+		wantVariant string
+	}{
+		{"nitro", "openai/gpt-5.2:nitro", "openai/gpt-5.2", "nitro"},
+		{"floor", "openai/gpt-5.2:floor", "openai/gpt-5.2", "floor"},
+		{"online", "anthropic/claude-3.7:online", "anthropic/claude-3.7", "online"},
+		{"thinking", "deepseek/deepseek-r1:thinking", "deepseek/deepseek-r1", "thinking"},
+		{"exacto", "openai/gpt-5.2:exacto", "openai/gpt-5.2", "exacto"},
+		{"extended", "anthropic/claude-sonnet-4.5:extended", "anthropic/claude-sonnet-4.5", "extended"},
+		{"free", "meta-llama/llama-3.2-3b-instruct:free", "meta-llama/llama-3.2-3b-instruct", "free"},
+		{"case insensitive", "openai/gpt-5.2:NITRO", "openai/gpt-5.2", "nitro"},
+		{"no variant", "openai/gpt-5.2", "openai/gpt-5.2", ""},
+		{"unknown suffix preserved", "openai/gpt-5.2:foobar", "openai/gpt-5.2:foobar", ""},
+		{"colon only", "openai/gpt-5.2:", "openai/gpt-5.2:", ""},
+		{"empty", "", "", ""},
+		{"bedrock-like id untouched", "anthropic.claude-sonnet-4-v1:0", "anthropic.claude-sonnet-4-v1:0", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBase, gotVariant := SplitOpenRouterVariant(tc.model)
+			if gotBase != tc.wantBase || gotVariant != tc.wantVariant {
+				t.Fatalf("SplitOpenRouterVariant(%q) = (%q, %q), want (%q, %q)",
+					tc.model, gotBase, gotVariant, tc.wantBase, tc.wantVariant)
+			}
+		})
+	}
+}
+
+func TestBaseOpenRouterModel(t *testing.T) {
+	if got := BaseOpenRouterModel("openai/gpt-5.2:nitro"); got != "openai/gpt-5.2" {
+		t.Fatalf("expected base openai/gpt-5.2, got %q", got)
+	}
+	if got := BaseOpenRouterModel("openai/gpt-5.2"); got != "openai/gpt-5.2" {
+		t.Fatalf("expected passthrough, got %q", got)
+	}
+}
+
+func TestWhiteListAllowsBaseViaOpenRouterVariant(t *testing.T) {
+	wl := WhiteList{"openai/gpt-5.2", "anthropic/claude-3.7-sonnet"}
+
+	// Exact match still works.
+	if !wl.IsAllowed("openai/gpt-5.2") {
+		t.Fatal("base model should be allowed")
+	}
+
+	// Variant must resolve via SplitOpenRouterVariant at the dispatch site,
+	// not inside WhiteList itself (which remains provider-agnostic).
+	if wl.IsAllowed("openai/gpt-5.2:nitro") {
+		t.Fatal("WhiteList.IsAllowed should NOT match variant directly; variant-awareness is the caller's responsibility")
+	}
+
+	// But the helper lets the caller fall back to base.
+	base := BaseOpenRouterModel("openai/gpt-5.2:nitro")
+	if !wl.IsAllowed(base) {
+		t.Fatalf("variant-stripped base %q should be allowed", base)
+	}
+}
+
+func TestKeyAliasesResolveOpenRouterVariant(t *testing.T) {
+	aliases := KeyAliases{"openai/gpt-5.2": "openai/gpt-5.2-provider-id"}
+
+	if got := aliases.Resolve("openai/gpt-5.2"); got != "openai/gpt-5.2-provider-id" {
+		t.Fatalf("direct alias resolution failed: got %q", got)
+	}
+	if got := aliases.Resolve("openai/gpt-5.2:nitro"); got != "openai/gpt-5.2-provider-id:nitro" {
+		t.Fatalf("variant alias resolution failed: got %q", got)
+	}
+	if got := aliases.Resolve("unknown/model:nitro"); got != "unknown/model:nitro" {
+		t.Fatalf("unknown model should return input: got %q", got)
+	}
+}

--- a/core/schemas/openrouter_variant_test.go
+++ b/core/schemas/openrouter_variant_test.go
@@ -65,15 +65,53 @@ func TestWhiteListAllowsBaseViaOpenRouterVariant(t *testing.T) {
 }
 
 func TestKeyAliasesResolveOpenRouterVariant(t *testing.T) {
-	aliases := KeyAliases{"openai/gpt-5.2": "openai/gpt-5.2-provider-id"}
+	base := KeyAliases{"openai/gpt-5.2": "openai/gpt-5.2-provider-id"}
 
-	if got := aliases.Resolve("openai/gpt-5.2"); got != "openai/gpt-5.2-provider-id" {
-		t.Fatalf("direct alias resolution failed: got %q", got)
+	tests := []struct {
+		name    string
+		aliases KeyAliases
+		input   string
+		want    string
+	}{
+		{"direct base match", base, "openai/gpt-5.2", "openai/gpt-5.2-provider-id"},
+		{"variant via base fallback", base, "openai/gpt-5.2:nitro", "openai/gpt-5.2-provider-id:nitro"},
+		{"variant case insensitive", base, "openai/gpt-5.2:NITRO", "openai/gpt-5.2-provider-id:nitro"},
+		{"case-insensitive base match", base, "OpenAI/GPT-5.2:free", "openai/gpt-5.2-provider-id:free"},
+		{"unknown variant suffix passes through", base, "openai/gpt-5.2:foobar", "openai/gpt-5.2:foobar"},
+		{"empty trailing colon passes through", base, "openai/gpt-5.2:", "openai/gpt-5.2:"},
+		{"unknown model returns input", base, "unknown/model:nitro", "unknown/model:nitro"},
+		{"nil aliases returns input", nil, "openai/gpt-5.2:nitro", "openai/gpt-5.2:nitro"},
 	}
-	if got := aliases.Resolve("openai/gpt-5.2:nitro"); got != "openai/gpt-5.2-provider-id:nitro" {
-		t.Fatalf("variant alias resolution failed: got %q", got)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.aliases.Resolve(tc.input); got != tc.want {
+				t.Fatalf("Resolve(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
 	}
-	if got := aliases.Resolve("unknown/model:nitro"); got != "unknown/model:nitro" {
-		t.Fatalf("unknown model should return input: got %q", got)
+}
+
+// TestKeyAliasesResolveExactVariantWins pins down that an alias configured for
+// the exact variant slug takes precedence over the base-model fallback.
+func TestKeyAliasesResolveExactVariantWins(t *testing.T) {
+	aliases := KeyAliases{
+		"openai/gpt-5.2":       "base-target",
+		"openai/gpt-5.2:nitro": "custom-target",
+	}
+	if got := aliases.Resolve("openai/gpt-5.2:nitro"); got != "custom-target" {
+		t.Fatalf("exact variant alias should win, got %q", got)
+	}
+	if got := aliases.Resolve("openai/gpt-5.2:free"); got != "base-target:free" {
+		t.Fatalf("variant without exact alias must fall back to base, got %q", got)
+	}
+}
+
+// TestKeyAliasesResolveAvoidsDoubleVariant pins down that if the alias target
+// already carries a variant suffix, Resolve strips it before re-appending the
+// request variant, so we never produce "foo:nitro:nitro".
+func TestKeyAliasesResolveAvoidsDoubleVariant(t *testing.T) {
+	aliases := KeyAliases{"openai/gpt-5.2": "provider-id:free"}
+	if got := aliases.Resolve("openai/gpt-5.2:nitro"); got != "provider-id:nitro" {
+		t.Fatalf("double-variant should be stripped, got %q", got)
 	}
 }

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -77,6 +77,50 @@ func IsKnownProvider(provider string) bool {
 	return knownProviders[provider]
 }
 
+// openRouterVariants is the set of known OpenRouter model-slug suffixes.
+// See https://openrouter.ai/docs/guides/routing/model-variants/*
+// Variants are routing hints server-side (e.g. :nitro sorts providers by
+// throughput); base-model ACL / pricing / capability lookups should treat
+// them as transparent.
+var openRouterVariants = map[string]struct{}{
+	"nitro":    {}, // sort providers by throughput
+	"floor":    {}, // sort providers by price (cheapest first)
+	"online":   {}, // enable real-time web search (deprecated; superseded by server tool)
+	"thinking": {}, // extended reasoning
+	"exacto":   {}, // quality-first provider sort for tool use
+	"extended": {}, // extended context window
+	"free":     {}, // free tier of the model
+}
+
+// SplitOpenRouterVariant splits an OpenRouter model slug into its base model
+// and variant suffix, if the suffix is a known OpenRouter variant.
+//
+// Examples:
+//
+//	"openai/gpt-5.2:nitro"           -> ("openai/gpt-5.2", "nitro")
+//	"anthropic/claude-3.7:thinking"  -> ("anthropic/claude-3.7", "thinking")
+//	"meta-llama/llama-3.2-3b:free"   -> ("meta-llama/llama-3.2-3b", "free")
+//	"openai/gpt-5.2"                 -> ("openai/gpt-5.2", "")
+//	"openai/gpt-5.2:foo"             -> ("openai/gpt-5.2:foo", "")  (not a known variant)
+func SplitOpenRouterVariant(model string) (base, variant string) {
+	idx := strings.LastIndex(model, ":")
+	if idx <= 0 || idx == len(model)-1 {
+		return model, ""
+	}
+	suffix := strings.ToLower(model[idx+1:])
+	if _, ok := openRouterVariants[suffix]; !ok {
+		return model, ""
+	}
+	return model[:idx], suffix
+}
+
+// BaseOpenRouterModel returns the model id with any recognized OpenRouter
+// variant suffix stripped. Returns the id unchanged if no variant is present.
+func BaseOpenRouterModel(model string) string {
+	base, _ := SplitOpenRouterVariant(model)
+	return base
+}
+
 // ParseModelString extracts provider and model from a model string.
 // For model strings like "anthropic/claude", it returns ("anthropic", "claude").
 // For model strings like "claude", it returns ("", "claude").

--- a/framework/modelcatalog/models.go
+++ b/framework/modelcatalog/models.go
@@ -269,7 +269,21 @@ func (mc *ModelCatalog) getBaseModelNameUnsafe(model string) string {
 		return base
 	}
 
-	// Step 2: Strip provider prefix and try again
+	// Step 2: Strip OpenRouter variant suffix (:nitro, :free, :thinking, ...) and retry.
+	// Variants are server-side routing hints — pricing/capability lookups should hit the base entry.
+	if variantStripped := schemas.BaseOpenRouterModel(model); variantStripped != model {
+		if base, ok := mc.baseModelIndex[variantStripped]; ok {
+			return base
+		}
+		// Also try after stripping provider prefix from the variant-stripped form.
+		if _, inner := schemas.ParseModelString(variantStripped, ""); inner != variantStripped {
+			if base, ok := mc.baseModelIndex[inner]; ok {
+				return base
+			}
+		}
+	}
+
+	// Step 3: Strip provider prefix and try again
 	_, baseName := schemas.ParseModelString(model, "")
 	if baseName != model {
 		if base, ok := mc.baseModelIndex[baseName]; ok {
@@ -277,9 +291,9 @@ func (mc *ModelCatalog) getBaseModelNameUnsafe(model string) string {
 		}
 	}
 
-	// Step 3: Fallback to algorithmic date/version stripping
+	// Step 4: Fallback to algorithmic date/version stripping
 	// (for models not in the catalog, e.g., user-configured custom models)
-	return schemas.BaseModelName(baseName)
+	return schemas.BaseModelName(schemas.BaseOpenRouterModel(baseName))
 }
 
 // IsSameModel checks if two model strings refer to the same underlying model.


### PR DESCRIPTION
## Summary

OpenRouter supports model-variant suffixes (`:nitro`, `:floor`, `:online`, `:thinking`, `:exacto`, `:extended`, `:free`) as server-side routing hints. Bifrost was dropping requests with these suffixes at the key-selection layer because `WhiteList`/`BlackList` use exact-match and users typically store only the base model (e.g. `openai/gpt-5.2`) in `key.Models`. Request for `openai/gpt-5.2:nitro` then failed with `no keys found that support model: openai/gpt-5.2:nitro` even though the user intended the base model to be allowed.

This change makes variants transparent for allow-list / blacklist / alias / pricing / capability lookups when the provider is OpenRouter, while keeping exact matches authoritative (backward compatible).

Refs: https://openrouter.ai/docs/guides/routing/model-variants

## Changes

- **`core/schemas/utils.go`** — `SplitOpenRouterVariant(model) (base, variant)` + `BaseOpenRouterModel(model)` helpers. Variant lower-cased on return for consistent downstream identifiers. Unknown suffixes and non-OpenRouter patterns (e.g. Bedrock `model-v1:0`) pass through untouched.
- **`core/bifrost.go`** — in `selectKeyFromProviderForModelWithPool`, when `baseProviderType == schemas.OpenRouter`, fall back to the variant-stripped base when evaluating `key.Models.IsAllowed` / `key.BlacklistedModels.IsBlocked`. Exact match wins first; fallback is additive.
- **`core/schemas/account.go`** — `KeyAliases.Resolve` falls back to base-model alias lookup and re-appends the variant suffix to the resolved target. Provider-agnostic but no-op for non-variant strings, so safe across all providers.
- **`framework/modelcatalog/models.go`** — `getBaseModelNameUnsafe` strips variant suffix before catalog index lookup so pricing and capability entries resolve for variant requests. Applied under the existing `RLock`.
- **`core/schemas/openrouter_variant_test.go`** (new) — unit tests covering known variants, case insensitivity, Bedrock-style ids (`v1:0`), `WhiteList` interaction, and `KeyAliases.Resolve`.

### Design notes / trade-offs

- `WhiteList` / `BlackList` themselves stay provider-agnostic; variant-awareness lives at the dispatch site behind the `schemas.OpenRouter` guard. Keeps the core types clean and avoids cross-provider leakage.
- No model-catalog expansion for variants in the list-models endpoint: OpenRouter doesn't expose which variants apply per model, and blindly adding 7 rows per model would surface invalid combinations (e.g. `:thinking` on non-reasoning models). Passthrough behavior is intentional — if a variant doesn't apply, OpenRouter returns an error.
- `:online` variant is deprecated by OpenRouter (superseded by the `openrouter:web_search` server tool). Included in the variant set so existing configs keep working.
- The separate pre-existing issue where users store `key.Models` with provider prefix (`openrouter/openai/gpt-5.2`) is untouched; it is orthogonal to variants.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)

## How to test

```sh
go version  # go1.24+

# From repo root, set up workspace (so framework pulls local core)
make setup-workspace

# Run unit tests
cd core && go test ./schemas/... -count=1 -race
cd ../framework && go test ./modelcatalog/... -count=1 -race

# Integration: with an OpenRouter provider configured and a key whose
# Models allow-list contains "openai/gpt-5.2" (no variant), send a chat
# completion with model "openai/gpt-5.2:nitro". Request should now be
# routed to OpenRouter; server handles the :nitro sort. Repeat for each
# of :floor, :online, :thinking, :exacto, :extended, :free.
```

Expected result: 291 pass in core/schemas, 166 pass in framework/modelcatalog. No new lint/vet findings attributable to this change.

## Breaking changes

- [ ] Yes
- [x] No

Exact matches still win first; the variant fallback is purely additive. Users who explicitly allow-listed `openai/gpt-5.2:nitro` still match exactly; users who allow-listed only `openai/gpt-5.2` now additionally allow all of its variants.

## Related issues

None linked — surfaced while investigating OpenRouter variant support.

## Security considerations

No new auth, secrets, or PII paths. The change only widens an internal exact-match comparison in the ACL layer by an additional deterministic lookup (stripped base). Blacklist behavior is likewise widened: blocking a base now also blocks all of its variants, which is the stricter direction and matches user intent.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go)
- [x] I verified tests pass locally (`go test ./schemas/... ./modelcatalog/...`)