### PR TITLE
fix: clear `BifrostContextKeyStreamEndIndicator` in context for fallback requests

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: clear `BifrostContextKeyStreamEndIndicator` value in context for fallback requests

--- a/core/utils.go
+++ b/core/utils.go
@@ -274,6 +274,7 @@ func clearCtxForFallback(ctx *schemas.BifrostContext) {
 	ctx.ClearValue(schemas.BifrostContextKeyGovernanceIncludeOnlyKeys)
 	ctx.ClearValue(schemas.BifrostContextKeyChangeRequestType)
 	ctx.ClearValue(schemas.BifrostContextKeyAttemptTrail)
+	ctx.ClearValue(schemas.BifrostContextKeyStreamEndIndicator)
 }
 
 var supportedBaseProvidersSet = func() map[schemas.ModelProvider]struct{} {


### PR DESCRIPTION
## Summary

Fixes a bug where the `BifrostContextKeyStreamEndIndicator` value was not being cleared from the context when preparing for fallback requests, which could cause incorrect streaming state to carry over into retry/fallback attempts.

## Changes

- Added `ctx.ClearValue(schemas.BifrostContextKeyStreamEndIndicator)` to `clearCtxForFallback` so that stream end state is properly reset before a fallback request is executed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger a streaming request that fails and falls back to another provider/model. Verify that the fallback request does not inherit the stream end indicator from the failed attempt and completes successfully.

```sh
go version
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable