### PR TITLE
docs: add OCR OpenAPI spec, async rerank/OCR endpoints, and update provider support matrix

### DIFF
--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -270,122 +270,6 @@ func (provider *MistralProvider) Speech(ctx *schemas.BifrostContext, key schemas
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
-// Rerank is not supported by the Mistral provider.
-func (provider *MistralProvider) Rerank(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostRerankRequest) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.RerankRequest, provider.GetProviderKey())
-}
-
-// OCR performs an OCR request to the Mistral API.
-// It sends a JSON request to Mistral's OCR endpoint and returns the extracted content.
-func (provider *MistralProvider) OCR(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostOCRRequest) (*schemas.BifrostOCRResponse, *schemas.BifrostError) {
-	// Convert Bifrost request to Mistral format
-	mistralReq := ToMistralOCRRequest(request)
-	if mistralReq == nil {
-		return nil, providerUtils.NewBifrostOperationError("ocr request input is not provided", nil)
-	}
-
-	// Marshal request body
-	requestBody, err := sonic.Marshal(mistralReq)
-	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-	}
-
-	// Merge extra params into JSON payload
-	if len(mistralReq.ExtraParams) > 0 {
-		requestBody, err = providerUtils.MergeExtraParamsIntoJSON(requestBody, mistralReq.ExtraParams)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-		}
-	}
-
-	// Create HTTP request
-	req := fasthttp.AcquireRequest()
-	resp := fasthttp.AcquireResponse()
-	defer fasthttp.ReleaseRequest(req)
-	defer fasthttp.ReleaseResponse(resp)
-
-	// Set extra headers from network config
-	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/ocr"))
-	req.Header.SetMethod(http.MethodPost)
-	req.Header.SetContentType("application/json")
-	if key.Value.GetValue() != "" {
-		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
-	}
-
-	req.SetBody(requestBody)
-
-	// Set raw request if enabled
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		request.RawRequestBody = requestBody
-	}
-
-	// Make request
-	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
-	defer wait()
-	if bifrostErr != nil {
-		return nil, bifrostErr
-	}
-
-	// Handle error response
-	if resp.StatusCode() != fasthttp.StatusOK {
-		return nil, ParseMistralError(resp)
-	}
-
-	responseBody, err := providerUtils.CheckAndDecodeBody(resp)
-	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
-	}
-
-	// Check for empty response
-	trimmed := strings.TrimSpace(string(responseBody))
-	if len(trimmed) == 0 {
-		return nil, &schemas.BifrostError{
-			IsBifrostError: true,
-			Error: &schemas.ErrorField{
-				Message: schemas.ErrProviderResponseEmpty,
-			},
-		}
-	}
-
-	copiedResponseBody := append([]byte(nil), responseBody...)
-
-	// Parse Mistral's OCR response
-	var mistralResponse MistralOCRResponse
-	if err := sonic.Unmarshal(copiedResponseBody, &mistralResponse); err != nil {
-		if providerUtils.IsHTMLResponse(resp, copiedResponseBody) {
-			return nil, &schemas.BifrostError{
-				IsBifrostError: false,
-				Error: &schemas.ErrorField{
-					Message: schemas.ErrProviderResponseHTML,
-					Error:   errors.New(string(copiedResponseBody)),
-				},
-			}
-		}
-		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err)
-	}
-
-	// Convert to Bifrost format
-	response := mistralResponse.ToBifrostOCRResponse()
-	if response == nil {
-		return nil, providerUtils.NewBifrostOperationError("failed to convert ocr response", nil)
-	}
-
-	// Set extra fields
-	response.ExtraFields.Latency = latency.Milliseconds()
-
-	// Set raw response if enabled
-	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-		var rawResponse interface{}
-		if err := sonic.Unmarshal(copiedResponseBody, &rawResponse); err == nil {
-			response.ExtraFields.RawResponse = rawResponse
-		}
-	}
-
-	return response, nil
-}
-
 // SpeechStream is not supported by the Mistral provider.
 func (provider *MistralProvider) SpeechStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
@@ -638,7 +522,7 @@ func (provider *MistralProvider) TranscriptionStream(ctx *schemas.BifrostContext
 			}
 
 			chunkIndex++
-			provider.processTranscriptionStreamEvent(ctx, postHookRunner, currentEvent, currentData, request.Model, providerName, chunkIndex, startTime, &lastChunkTime, responseChan, postHookSpanFinalizer)
+			provider.processTranscriptionStreamEvent(ctx, postHookRunner, currentEvent, currentData, chunkIndex, startTime, &lastChunkTime, responseChan, postHookSpanFinalizer)
 			// Break on terminal stream indicator (covers both done events and error events
 			// that processTranscriptionStreamEvent signals via context).
 			if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); ended {
@@ -656,8 +540,6 @@ func (provider *MistralProvider) processTranscriptionStreamEvent(
 	postHookRunner schemas.PostHookRunner,
 	eventType string,
 	jsonData string,
-	model string,
-	providerName schemas.ModelProvider,
 	chunkIndex int,
 	startTime time.Time,
 	lastChunkTime *time.Time,
@@ -721,6 +603,122 @@ func (provider *MistralProvider) processTranscriptionStreamEvent(
 	}
 
 	providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, nil, response, nil), responseChan, postHookSpanFinalizer)
+}
+
+// Rerank is not supported by the Mistral provider.
+func (provider *MistralProvider) Rerank(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostRerankRequest) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.RerankRequest, provider.GetProviderKey())
+}
+
+// OCR performs an OCR request to the Mistral API.
+// It sends a JSON request to Mistral's OCR endpoint and returns the extracted content.
+func (provider *MistralProvider) OCR(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostOCRRequest) (*schemas.BifrostOCRResponse, *schemas.BifrostError) {
+	// Convert Bifrost request to Mistral format
+	mistralReq := ToMistralOCRRequest(request)
+	if mistralReq == nil {
+		return nil, providerUtils.NewBifrostOperationError("ocr request input is not provided", nil)
+	}
+
+	// Marshal request body
+	requestBody, err := sonic.Marshal(mistralReq)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+	}
+
+	// Merge extra params into JSON payload
+	if len(mistralReq.ExtraParams) > 0 {
+		requestBody, err = providerUtils.MergeExtraParamsIntoJSON(requestBody, mistralReq.ExtraParams)
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+		}
+	}
+
+	// Create HTTP request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	// Set extra headers from network config
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/ocr"))
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+	if key.Value.GetValue() != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+
+	req.SetBody(requestBody)
+
+	// Set raw request if enabled
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		request.RawRequestBody = requestBody
+	}
+
+	// Make request
+	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		return nil, ParseMistralError(resp)
+	}
+
+	responseBody, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
+	}
+
+	// Check for empty response
+	trimmed := strings.TrimSpace(string(responseBody))
+	if len(trimmed) == 0 {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: &schemas.ErrorField{
+				Message: schemas.ErrProviderResponseEmpty,
+			},
+		}
+	}
+
+	copiedResponseBody := append([]byte(nil), responseBody...)
+
+	// Parse Mistral's OCR response
+	var mistralResponse MistralOCRResponse
+	if err := sonic.Unmarshal(copiedResponseBody, &mistralResponse); err != nil {
+		if providerUtils.IsHTMLResponse(resp, copiedResponseBody) {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Message: schemas.ErrProviderResponseHTML,
+					Error:   errors.New(string(copiedResponseBody)),
+				},
+			}
+		}
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err)
+	}
+
+	// Convert to Bifrost format
+	response := mistralResponse.ToBifrostOCRResponse()
+	if response == nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to convert ocr response", nil)
+	}
+
+	// Set extra fields
+	response.ExtraFields.Latency = latency.Milliseconds()
+
+	// Set raw response if enabled
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		var rawResponse interface{}
+		if err := sonic.Unmarshal(copiedResponseBody, &rawResponse); err == nil {
+			response.ExtraFields.RawResponse = rawResponse
+		}
+	}
+
+	return response, nil
 }
 
 // BatchCreate is not supported by Mistral provider.

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -54,6 +54,10 @@
       "description": "OpenAI Responses API compatible endpoints"
     },
     {
+      "name": "OCR",
+      "description": "Optical character recognition for documents and images"
+    },
+    {
       "name": "Rerank",
       "description": "Document reranking by relevance to a query"
     },
@@ -1511,6 +1515,72 @@
                       "$ref": "#/components/schemas/BifrostResponseExtraFields"
                     }
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/ocr": {
+      "post": {
+        "operationId": "performOCR",
+        "summary": "Perform OCR",
+        "description": "Extracts text and content from documents or images using optical character recognition.\nSupports PDF URLs, base64-encoded documents, and image URLs.\n",
+        "tags": [
+          "OCR"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OCRRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OCRResponse"
                 }
               }
             }
@@ -7852,6 +7922,270 @@
         "operationId": "getAsyncImageVariationJob",
         "summary": "Get async image variation job",
         "description": "Retrieves the status and result of an async image variation job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
+        "tags": [
+          "Async Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AsyncJobId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job completed (successfully or with failure)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Job is still pending or processing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found or expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/async/rerank": {
+      "post": {
+        "operationId": "createAsyncRerank",
+        "summary": "Create async rerank",
+        "description": "Submits a rerank request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\n",
+        "tags": [
+          "Async Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AsyncResultTTL"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RerankRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Job accepted for processing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/async/rerank/{job_id}": {
+      "get": {
+        "operationId": "getAsyncRerankJob",
+        "summary": "Get async rerank job",
+        "description": "Retrieves the status and result of an async rerank job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
+        "tags": [
+          "Async Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AsyncJobId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job completed (successfully or with failure)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Job is still pending or processing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found or expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/async/ocr": {
+      "post": {
+        "operationId": "createAsyncOCR",
+        "summary": "Create async OCR job",
+        "description": "Submits an OCR request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\n",
+        "tags": [
+          "Async Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AsyncResultTTL"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OCRRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Job accepted for processing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/async/ocr/{job_id}": {
+      "get": {
+        "operationId": "getAsyncOCRJob",
+        "summary": "Get async OCR job",
+        "description": "Retrieves the status and result of an async OCR job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
         "tags": [
           "Async Jobs"
         ],
@@ -46669,6 +47003,426 @@
           },
           "extra_fields": {
             "$ref": "#/components/schemas/BifrostResponseExtraFields"
+          }
+        }
+      },
+      "OCRRequest": {
+        "type": "object",
+        "required": [
+          "model",
+          "document"
+        ],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "Model in provider/model format",
+            "example": "mistral/mistral-ocr-latest"
+          },
+          "id": {
+            "type": "string",
+            "description": "Optional unique identifier for the request"
+          },
+          "document": {
+            "$ref": "#/components/schemas/OCRDocument"
+          },
+          "fallbacks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Fallback models in provider/model format"
+          },
+          "include_image_base64": {
+            "type": "boolean",
+            "description": "Whether to include base64-encoded images in the response"
+          },
+          "pages": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "description": "Specific page indices to process (0-based)"
+          },
+          "image_limit": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Maximum number of images to extract per page"
+          },
+          "image_min_size": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Minimum image size in pixels to extract"
+          },
+          "table_format": {
+            "type": "string",
+            "description": "Format for extracted tables (e.g., \"markdown\", \"html\")"
+          },
+          "extract_header": {
+            "type": "boolean",
+            "description": "Whether to extract page headers"
+          },
+          "extract_footer": {
+            "type": "boolean",
+            "description": "Whether to extract page footers"
+          },
+          "confidence_scores_granularity": {
+            "type": "string",
+            "enum": [
+              "page",
+              "block",
+              "word",
+              "document"
+            ],
+            "description": "Granularity of confidence scores to include in the response"
+          },
+          "bbox_annotation_format": {
+            "type": "object",
+            "description": "Format for bounding box annotations. Supports text, json_object, and json_schema modes.",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "text",
+                  "json_object",
+                  "json_schema"
+                ],
+                "description": "The format type"
+              },
+              "json_schema": {
+                "type": "object",
+                "description": "JSON schema definition (required when type is json_schema)",
+                "properties": {
+                  "schema": {
+                    "type": "object",
+                    "description": "The JSON schema"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the schema"
+                  },
+                  "strict": {
+                    "type": "boolean",
+                    "description": "Whether to enforce strict validation"
+                  }
+                }
+              }
+            },
+            "oneOf": [
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "text",
+                      "json_object"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "type",
+                  "json_schema"
+                ],
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "json_schema"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "document_annotation_format": {
+            "type": "object",
+            "description": "Format for document-level annotations. Supports text, json_object, and json_schema modes.",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "text",
+                  "json_object",
+                  "json_schema"
+                ],
+                "description": "The format type"
+              },
+              "json_schema": {
+                "type": "object",
+                "description": "JSON schema definition (required when type is json_schema)",
+                "properties": {
+                  "schema": {
+                    "type": "object",
+                    "description": "The JSON schema"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the schema"
+                  },
+                  "strict": {
+                    "type": "boolean",
+                    "description": "Whether to enforce strict validation"
+                  }
+                }
+              }
+            },
+            "oneOf": [
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "text",
+                      "json_object"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "type",
+                  "json_schema"
+                ],
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "json_schema"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "document_annotation_prompt": {
+            "type": "string",
+            "description": "Custom prompt for document annotation"
+          }
+        }
+      },
+      "OCRDocument": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "document_url",
+              "image_url"
+            ],
+            "description": "Type of document input:\n- `document_url`: A PDF URL or base64 data URL\n- `image_url`: An image URL\n"
+          },
+          "document_url": {
+            "type": "string",
+            "description": "URL or base64 data URL of the document (required when type is document_url)"
+          },
+          "image_url": {
+            "type": "string",
+            "description": "URL of the image to process (required when type is image_url)"
+          }
+        },
+        "oneOf": [
+          {
+            "required": [
+              "type",
+              "document_url"
+            ],
+            "properties": {
+              "type": {
+                "enum": [
+                  "document_url"
+                ]
+              }
+            }
+          },
+          {
+            "required": [
+              "type",
+              "image_url"
+            ],
+            "properties": {
+              "type": {
+                "enum": [
+                  "image_url"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "OCRResponse": {
+        "type": "object",
+        "required": [
+          "model",
+          "pages"
+        ],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "Model used to perform OCR"
+          },
+          "pages": {
+            "type": "array",
+            "description": "Processed pages with extracted content",
+            "items": {
+              "$ref": "#/components/schemas/OCRPage"
+            }
+          },
+          "usage_info": {
+            "$ref": "#/components/schemas/OCRUsageInfo"
+          },
+          "document_annotation": {
+            "type": "string",
+            "description": "Document-level annotation if requested"
+          },
+          "extra_fields": {
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
+          }
+        }
+      },
+      "OCRPage": {
+        "type": "object",
+        "required": [
+          "index",
+          "markdown"
+        ],
+        "properties": {
+          "index": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Zero-based page index"
+          },
+          "markdown": {
+            "type": "string",
+            "description": "Extracted text content in Markdown format"
+          },
+          "images": {
+            "type": "array",
+            "description": "Images extracted from this page",
+            "items": {
+              "$ref": "#/components/schemas/OCRPageImage"
+            }
+          },
+          "dimensions": {
+            "$ref": "#/components/schemas/OCRPageDimensions"
+          },
+          "tables": {
+            "type": "array",
+            "description": "Tables extracted from this page (present when table_format is set)",
+            "nullable": true,
+            "items": {
+              "type": "object"
+            }
+          },
+          "header": {
+            "type": "string",
+            "nullable": true,
+            "description": "Header content extracted from this page (present when extract_header is true)"
+          },
+          "footer": {
+            "type": "string",
+            "nullable": true,
+            "description": "Footer content extracted from this page (present when extract_footer is true)"
+          },
+          "confidence_scores": {
+            "type": "object",
+            "nullable": true,
+            "description": "Confidence scores for this page (present when confidence_scores_granularity is set)",
+            "properties": {
+              "average_page_confidence_score": {
+                "type": "number",
+                "description": "Average confidence score for the page"
+              },
+              "minimum_page_confidence_score": {
+                "type": "number",
+                "description": "Minimum confidence score for the page"
+              },
+              "word_confidence_scores": {
+                "type": "array",
+                "description": "Per-word confidence scores",
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      },
+      "OCRPageImage": {
+        "type": "object",
+        "required": [
+          "id",
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the image within the page"
+          },
+          "top_left_x": {
+            "type": "number",
+            "description": "X coordinate of the top-left corner of the image bounding box"
+          },
+          "top_left_y": {
+            "type": "number",
+            "description": "Y coordinate of the top-left corner of the image bounding box"
+          },
+          "bottom_right_x": {
+            "type": "number",
+            "description": "X coordinate of the bottom-right corner of the image bounding box"
+          },
+          "bottom_right_y": {
+            "type": "number",
+            "description": "Y coordinate of the bottom-right corner of the image bounding box"
+          },
+          "image_base64": {
+            "type": "string",
+            "description": "Base64-encoded image data (present when include_image_base64 is true)"
+          }
+        }
+      },
+      "OCRPageDimensions": {
+        "type": "object",
+        "required": [
+          "dpi",
+          "height",
+          "width"
+        ],
+        "properties": {
+          "dpi": {
+            "type": "integer",
+            "description": "Dots per inch of the page"
+          },
+          "height": {
+            "type": "integer",
+            "description": "Page height in pixels"
+          },
+          "width": {
+            "type": "integer",
+            "description": "Page width in pixels"
+          }
+        }
+      },
+      "OCRUsageInfo": {
+        "type": "object",
+        "required": [
+          "pages_processed",
+          "doc_size_bytes"
+        ],
+        "properties": {
+          "pages_processed": {
+            "type": "integer",
+            "description": "Number of pages processed"
+          },
+          "doc_size_bytes": {
+            "type": "integer",
+            "description": "Size of the processed document in bytes"
           }
         }
       },

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -78,6 +78,8 @@ tags:
     description: Text completion generation
   - name: Responses
     description: OpenAI Responses API compatible endpoints
+  - name: OCR
+    description: Optical character recognition for documents and images
   - name: Rerank
     description: Document reranking by relevance to a query
   - name: Embeddings
@@ -147,6 +149,8 @@ paths:
     $ref: './paths/inference/text-completions.yaml#/text-completions'
   /v1/responses:
     $ref: './paths/inference/responses.yaml#/responses'
+  /v1/ocr:
+    $ref: './paths/inference/ocr.yaml#/ocr'
   /v1/rerank:
     $ref: './paths/inference/rerank.yaml#/rerank'
   /v1/embeddings:
@@ -233,6 +237,14 @@ paths:
     $ref: './paths/inference/async.yaml#/async-image-edit-job'
   /v1/async/images/variations/{job_id}:
     $ref: './paths/inference/async.yaml#/async-image-variation-job'
+  /v1/async/rerank:
+    $ref: './paths/inference/async.yaml#/async-rerank'
+  /v1/async/rerank/{job_id}:
+    $ref: './paths/inference/async.yaml#/async-rerank-job'
+  /v1/async/ocr:
+    $ref: './paths/inference/ocr.yaml#/async-ocr'
+  /v1/async/ocr/{job_id}:
+    $ref: './paths/inference/ocr.yaml#/async-ocr-job'
 
   # ==================== OpenAI Integration ====================
   # Chat Completions
@@ -957,6 +969,22 @@ components:
       $ref: './schemas/inference/files.yaml#/FileUploadResponse'
     FileListResponse:
       $ref: './schemas/inference/files.yaml#/FileListResponse'
+
+    # ==================== OCR ====================
+    OCRRequest:
+      $ref: './schemas/inference/ocr.yaml#/OCRRequest'
+    OCRDocument:
+      $ref: './schemas/inference/ocr.yaml#/OCRDocument'
+    OCRResponse:
+      $ref: './schemas/inference/ocr.yaml#/OCRResponse'
+    OCRPage:
+      $ref: './schemas/inference/ocr.yaml#/OCRPage'
+    OCRPageImage:
+      $ref: './schemas/inference/ocr.yaml#/OCRPageImage'
+    OCRPageDimensions:
+      $ref: './schemas/inference/ocr.yaml#/OCRPageDimensions'
+    OCRUsageInfo:
+      $ref: './schemas/inference/ocr.yaml#/OCRUsageInfo'
 
     # ==================== OpenAI Integration ====================
     OpenAIChatRequest:

--- a/docs/openapi/paths/inference/async.yaml
+++ b/docs/openapi/paths/inference/async.yaml
@@ -636,13 +636,82 @@ async-image-variation-job:
             schema:
               $ref: '../../schemas/inference/common.yaml#/BifrostError'
 
-# --- Shared parameters ---
-
     security:
     - BearerAuth: []
     - BasicAuth: []
     - VirtualKeyAuth: []
     - ApiKeyAuth: []
+async-rerank:
+  post:
+    operationId: createAsyncRerank
+    summary: Create async rerank
+    description: |
+      Submits a rerank request for asynchronous execution. Returns a job ID immediately
+      with HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.
+    tags:
+    - Async Jobs
+    parameters:
+    - $ref: '#/components/parameters/AsyncResultTTL'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/inference/rerank.yaml#/RerankRequest'
+    responses:
+      '202':
+        description: Job accepted for processing
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/async.yaml#/AsyncJobResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+async-rerank-job:
+  get:
+    operationId: getAsyncRerankJob
+    summary: Get async rerank job
+    description: |
+      Retrieves the status and result of an async rerank job.
+      Returns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.
+    tags:
+    - Async Jobs
+    parameters:
+    - $ref: '#/components/parameters/AsyncJobId'
+    responses:
+      '200':
+        description: Job completed (successfully or with failure)
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/async.yaml#/AsyncJobResponse'
+      '202':
+        description: Job is still pending or processing
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/async.yaml#/AsyncJobResponse'
+      '404':
+        description: Job not found or expired
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+
+# --- Shared parameters ---
+
 components:
   parameters:
     AsyncJobId:

--- a/docs/openapi/paths/inference/ocr.yaml
+++ b/docs/openapi/paths/inference/ocr.yaml
@@ -1,0 +1,103 @@
+# OCR Endpoints
+
+ocr:
+  post:
+    operationId: performOCR
+    summary: Perform OCR
+    description: |
+      Extracts text and content from documents or images using optical character recognition.
+      Supports PDF URLs, base64-encoded documents, and image URLs.
+    tags:
+    - OCR
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/inference/ocr.yaml#/OCRRequest'
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/ocr.yaml#/OCRResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+
+async-ocr:
+  post:
+    operationId: createAsyncOCR
+    summary: Create async OCR job
+    description: |
+      Submits an OCR request for asynchronous execution. Returns a job ID immediately
+      with HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.
+    tags:
+    - Async Jobs
+    parameters:
+    - $ref: '../../openapi.yaml#/components/parameters/AsyncResultTTL'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/inference/ocr.yaml#/OCRRequest'
+    responses:
+      '202':
+        description: Job accepted for processing
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/async.yaml#/AsyncJobResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+
+async-ocr-job:
+  get:
+    operationId: getAsyncOCRJob
+    summary: Get async OCR job
+    description: |
+      Retrieves the status and result of an async OCR job.
+      Returns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.
+    tags:
+    - Async Jobs
+    parameters:
+    - $ref: '../../openapi.yaml#/components/parameters/AsyncJobId'
+    responses:
+      '200':
+        description: Job completed (successfully or with failure)
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/async.yaml#/AsyncJobResponse'
+      '202':
+        description: Job is still pending or processing
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/async.yaml#/AsyncJobResponse'
+      '404':
+        description: Job not found or expired
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []

--- a/docs/openapi/schemas/inference/ocr.yaml
+++ b/docs/openapi/schemas/inference/ocr.yaml
@@ -1,0 +1,286 @@
+# OCR API schemas
+
+OCRRequest:
+  type: object
+  required:
+    - model
+    - document
+  properties:
+    model:
+      type: string
+      description: Model in provider/model format
+      example: mistral/mistral-ocr-latest
+    id:
+      type: string
+      description: Optional unique identifier for the request
+    document:
+      $ref: "#/OCRDocument"
+    fallbacks:
+      type: array
+      items:
+        type: string
+      description: Fallback models in provider/model format
+    include_image_base64:
+      type: boolean
+      description: Whether to include base64-encoded images in the response
+    pages:
+      type: array
+      items:
+        type: integer
+        minimum: 0
+      description: Specific page indices to process (0-based)
+    image_limit:
+      type: integer
+      minimum: 1
+      description: Maximum number of images to extract per page
+    image_min_size:
+      type: integer
+      minimum: 1
+      description: Minimum image size in pixels to extract
+    table_format:
+      type: string
+      description: Format for extracted tables (e.g., "markdown", "html")
+    extract_header:
+      type: boolean
+      description: Whether to extract page headers
+    extract_footer:
+      type: boolean
+      description: Whether to extract page footers
+    confidence_scores_granularity:
+      type: string
+      enum:
+        - page
+        - block
+        - word
+        - document
+      description: Granularity of confidence scores to include in the response
+    bbox_annotation_format:
+      type: object
+      description: "Format for bounding box annotations. Supports text, json_object, and json_schema modes."
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - text
+            - json_object
+            - json_schema
+          description: The format type
+        json_schema:
+          type: object
+          description: JSON schema definition (required when type is json_schema)
+          properties:
+            schema:
+              type: object
+              description: The JSON schema
+            name:
+              type: string
+              description: Name of the schema
+            strict:
+              type: boolean
+              description: Whether to enforce strict validation
+      oneOf:
+        - properties:
+            type:
+              enum: [text, json_object]
+        - required: [type, json_schema]
+          properties:
+            type:
+              enum: [json_schema]
+    document_annotation_format:
+      type: object
+      description: "Format for document-level annotations. Supports text, json_object, and json_schema modes."
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - text
+            - json_object
+            - json_schema
+          description: The format type
+        json_schema:
+          type: object
+          description: JSON schema definition (required when type is json_schema)
+          properties:
+            schema:
+              type: object
+              description: The JSON schema
+            name:
+              type: string
+              description: Name of the schema
+            strict:
+              type: boolean
+              description: Whether to enforce strict validation
+      oneOf:
+        - properties:
+            type:
+              enum: [text, json_object]
+        - required: [type, json_schema]
+          properties:
+            type:
+              enum: [json_schema]
+    document_annotation_prompt:
+      type: string
+      description: Custom prompt for document annotation
+
+OCRDocument:
+  type: object
+  properties:
+    type:
+      type: string
+      enum:
+        - document_url
+        - image_url
+      description: |
+        Type of document input:
+        - `document_url`: A PDF URL or base64 data URL
+        - `image_url`: An image URL
+    document_url:
+      type: string
+      description: URL or base64 data URL of the document (required when type is document_url)
+    image_url:
+      type: string
+      description: URL of the image to process (required when type is image_url)
+  oneOf:
+    - required: [type, document_url]
+      properties:
+        type:
+          enum: [document_url]
+    - required: [type, image_url]
+      properties:
+        type:
+          enum: [image_url]
+
+OCRResponse:
+  type: object
+  required:
+    - model
+    - pages
+  properties:
+    model:
+      type: string
+      description: Model used to perform OCR
+    pages:
+      type: array
+      description: Processed pages with extracted content
+      items:
+        $ref: "#/OCRPage"
+    usage_info:
+      $ref: "#/OCRUsageInfo"
+    document_annotation:
+      type: string
+      description: Document-level annotation if requested
+    extra_fields:
+      $ref: "./common.yaml#/BifrostResponseExtraFields"
+
+OCRPage:
+  type: object
+  required:
+    - index
+    - markdown
+  properties:
+    index:
+      type: integer
+      minimum: 0
+      description: Zero-based page index
+    markdown:
+      type: string
+      description: Extracted text content in Markdown format
+    images:
+      type: array
+      description: Images extracted from this page
+      items:
+        $ref: "#/OCRPageImage"
+    dimensions:
+      $ref: "#/OCRPageDimensions"
+    tables:
+      type: array
+      description: Tables extracted from this page (present when table_format is set)
+      nullable: true
+      items:
+        type: object
+    header:
+      type: string
+      nullable: true
+      description: Header content extracted from this page (present when extract_header is true)
+    footer:
+      type: string
+      nullable: true
+      description: Footer content extracted from this page (present when extract_footer is true)
+    confidence_scores:
+      type: object
+      nullable: true
+      description: Confidence scores for this page (present when confidence_scores_granularity is set)
+      properties:
+        average_page_confidence_score:
+          type: number
+          description: Average confidence score for the page
+        minimum_page_confidence_score:
+          type: number
+          description: Minimum confidence score for the page
+        word_confidence_scores:
+          type: array
+          description: Per-word confidence scores
+          items:
+            type: number
+
+OCRPageImage:
+  type: object
+  required:
+    - id
+    - top_left_x
+    - top_left_y
+    - bottom_right_x
+    - bottom_right_y
+  properties:
+    id:
+      type: string
+      description: Unique identifier for the image within the page
+    top_left_x:
+      type: number
+      description: X coordinate of the top-left corner of the image bounding box
+    top_left_y:
+      type: number
+      description: Y coordinate of the top-left corner of the image bounding box
+    bottom_right_x:
+      type: number
+      description: X coordinate of the bottom-right corner of the image bounding box
+    bottom_right_y:
+      type: number
+      description: Y coordinate of the bottom-right corner of the image bounding box
+    image_base64:
+      type: string
+      description: Base64-encoded image data (present when include_image_base64 is true)
+
+OCRPageDimensions:
+  type: object
+  required:
+    - dpi
+    - height
+    - width
+  properties:
+    dpi:
+      type: integer
+      description: Dots per inch of the page
+    height:
+      type: integer
+      description: Page height in pixels
+    width:
+      type: integer
+      description: Page width in pixels
+
+OCRUsageInfo:
+  type: object
+  required:
+    - pages_processed
+    - doc_size_bytes
+  properties:
+    pages_processed:
+      type: integer
+      description: Number of pages processed
+    doc_size_bytes:
+      type: integer
+      description: Size of the processed document in bytes

--- a/docs/providers/supported-providers/mistral.mdx
+++ b/docs/providers/supported-providers/mistral.mdx
@@ -1,35 +1,42 @@
 ---
 title: "Mistral"
-description: "Mistral API conversion guide - parameter mapping, message handling, tool support, transcription, and streaming behavior"
+description: "Mistral API conversion guide - parameter mapping, message handling, tool support, transcription, OCR, and streaming behavior"
 icon: "m"
 ---
 
 ## Overview
 
 Mistral is an **OpenAI-compatible provider** with custom compatibility handling for specific features. Bifrost converts requests to Mistral's expected format while supporting their unique API endpoints. Key characteristics:
+
 - **OpenAI-compatible format** - Chat and streaming endpoints
 - **Transcription API** - Native audio transcription support
+- **OCR API** - Native document and image OCR support
 - **Tool calling support** - Function definitions with string-based tool choice
 - **Streaming support** - Server-Sent Events for chat and transcription
 - **Parameter compatibility** - max_completion_tokens → max_tokens conversion
 
 ### Supported Operations
 
-| Operation | Non-Streaming | Streaming | Endpoint |
-|-----------|---------------|-----------|----------|
-| Chat Completions | ✅ | ✅ | `/v1/chat/completions` |
-| Responses API | ✅ | ✅ | `/v1/chat/completions` |
-| Transcriptions (STT) | ✅ | ✅ | `/v1/audio/transcriptions` |
-| Embeddings | ✅ | - | `/v1/embeddings` |
-| List Models | ✅ | - | `/v1/models` |
-| Image Generation | ❌ | ❌ | - |
-| Text Completions | ❌ | ❌ | - |
-| Speech (TTS) | ❌ | ❌ | - |
-| Files | ❌ | ❌ | - |
-| Batch | ❌ | ❌ | - |
+| Operation            | Non-Streaming | Streaming | Endpoint                   |
+| -------------------- | ------------- | --------- | -------------------------- |
+| Chat Completions     | ✅            | ✅        | `/v1/chat/completions`     |
+| Responses API        | ✅            | ✅        | `/v1/chat/completions`     |
+| Transcriptions (STT) | ✅            | ✅        | `/v1/audio/transcriptions` |
+| OCR                  | ✅            | -         | `/v1/ocr`                  |
+| Embeddings           | ✅            | -         | `/v1/embeddings`           |
+| List Models          | ✅            | -         | `/v1/models`               |
+| Image Generation     | ❌            | ❌        | -                          |
+| Text Completions     | ❌            | ❌        | -                          |
+| Speech (TTS)         | ❌            | ❌        | -                          |
+| Files                | ❌            | ❌        | -                          |
+| Batch                | ❌            | ❌        | -                          |
 
 <Note>
-**Unsupported Operations** (❌): Text Completions, Speech (TTS), Files, and Batch are not supported by the upstream Mistral API. Image Generation is not currently supported by Bifrost's Mistral integration (Mistral API supports image generation, but Bifrost has not yet implemented this feature). These return `UnsupportedOperationError`.
+  **Unsupported Operations** (❌): Text Completions, Speech (TTS), Files, and
+  Batch are not supported by the upstream Mistral API. Image Generation is not
+  currently supported by Bifrost's Mistral integration (Mistral API supports
+  image generation, but Bifrost has not yet implemented this feature). These
+  return `UnsupportedOperationError`.
 </Note>
 
 ---
@@ -42,20 +49,21 @@ Mistral supports most OpenAI chat completion parameters with some conversions. F
 
 ### Parameter Mapping & Conversions
 
-| Parameter | OpenAI | Mistral | Notes |
-|-----------|--------|---------|-------|
-| `max_completion_tokens` | ✅ | `max_tokens` | **Conversion required** |
-| `temperature` | ✅ | ✅ | Direct pass-through |
-| `top_p` | ✅ | ✅ | Direct pass-through |
-| `stop` | ✅ | ✅ | Stop sequences |
-| `tools` | ✅ | ✅ | Function definitions |
-| `tool_choice` | String only | String only | **Limitations apply** |
-| `user` | ✅ | ✅ | Max 64 characters |
-| `frequency_penalty`, `presence_penalty` | ✅ | ✅ | Direct pass-through |
+| Parameter                               | OpenAI      | Mistral      | Notes                   |
+| --------------------------------------- | ----------- | ------------ | ----------------------- |
+| `max_completion_tokens`                 | ✅          | `max_tokens` | **Conversion required** |
+| `temperature`                           | ✅          | ✅           | Direct pass-through     |
+| `top_p`                                 | ✅          | ✅           | Direct pass-through     |
+| `stop`                                  | ✅          | ✅           | Stop sequences          |
+| `tools`                                 | ✅          | ✅           | Function definitions    |
+| `tool_choice`                           | String only | String only  | **Limitations apply**   |
+| `user`                                  | ✅          | ✅           | Max 64 characters       |
+| `frequency_penalty`, `presence_penalty` | ✅          | ✅           | Direct pass-through     |
 
 ### Critical Conversions
 
 **max_completion_tokens → max_tokens:**
+
 ```json
 // Bifrost request
 {"max_completion_tokens": 4096}
@@ -66,6 +74,7 @@ Mistral supports most OpenAI chat completion parameters with some conversions. F
 
 **Tool Choice Simplification:**
 Mistral only supports simple string tool choice, not structured constraints:
+
 ```json
 // OpenAI supports specific tool forcing
 {"tool_choice": {"type": "function", "function": {"name": "specific_tool"}}}
@@ -77,6 +86,7 @@ Mistral only supports simple string tool choice, not structured constraints:
 ### Filtered Parameters
 
 Removed for Mistral compatibility:
+
 - `prompt_cache_key` - Not supported
 - `cache_control` - Stripped from content blocks
 - `verbosity` - Anthropic-specific
@@ -86,6 +96,7 @@ Removed for Mistral compatibility:
 ## Message Conversion
 
 Full OpenAI message support:
+
 - All roles: user, assistant, system, tool, developer
 - Content types: text, images, audio, files
 
@@ -93,16 +104,17 @@ Full OpenAI message support:
 
 Tool definitions supported with constraints:
 
-| Aspect | Support | Notes |
-|--------|---------|-------|
-| Function definitions | ✅ | Full parameter schema support |
-| Tool choice "auto" | ✅ | Default mode |
-| Tool choice "any" | ✅ | Requires any tool |
-| Tool choice "none" | ✅ | No tools |
-| Specific tool forcing | ❌ | Not supported - simplified to "any" |
-| Parallel tools | ✅ | Multiple tools in one turn |
+| Aspect                | Support | Notes                               |
+| --------------------- | ------- | ----------------------------------- |
+| Function definitions  | ✅      | Full parameter schema support       |
+| Tool choice "auto"    | ✅      | Default mode                        |
+| Tool choice "any"     | ✅      | Requires any tool                   |
+| Tool choice "none"    | ✅      | No tools                            |
+| Specific tool forcing | ❌      | Not supported - simplified to "any" |
+| Parallel tools        | ✅      | Multiple tools in one turn          |
 
 **Limitation Caveat:**
+
 ```go
 // Bifrost allows specifying a specific tool
 {
@@ -121,6 +133,7 @@ Tool definitions supported with constraints:
 ## Response Conversion
 
 Standard OpenAI-compatible response:
+
 - `choices[].message.content` - Response text
 - `choices[].message.tool_calls` - Function calls
 - `usage` - Token counts (prompt_tokens, completion_tokens)
@@ -148,15 +161,15 @@ Mistral provides native audio transcription with streaming support.
 
 ### Parameter Mapping
 
-| Parameter | Bifrost | Mistral | Notes |
-|-----------|---------|---------|-------|
-| `file` | Binary audio | Multipart form | Converted to multipart |
-| `model` | Model name | model | |
-| `language` | ISO-639-1 | language | Optional language hint |
-| `prompt` | Optional | prompt | Context for recognition |
-| `response_format` | Format type | response_format | json, text, etc. |
-| `temperature` | float | temperature | Sampling temperature |
-| `timestamp_granularities` | Array | Array field | Segment/word timestamps |
+| Parameter                 | Bifrost      | Mistral         | Notes                   |
+| ------------------------- | ------------ | --------------- | ----------------------- |
+| `file`                    | Binary audio | Multipart form  | Converted to multipart  |
+| `model`                   | Model name   | model           |                         |
+| `language`                | ISO-639-1    | language        | Optional language hint  |
+| `prompt`                  | Optional     | prompt          | Context for recognition |
+| `response_format`         | Format type  | response_format | json, text, etc.        |
+| `temperature`             | float        | temperature     | Sampling temperature    |
+| `timestamp_granularities` | Array        | Array field     | Segment/word timestamps |
 
 ### Multipart Form Structure
 
@@ -182,21 +195,25 @@ en
   "text": "transcribed text",
   "language": "en",
   "duration": 3.5,
-  "segments": [{
-    "id": 0,
-    "start": 0.0,
-    "end": 1.5,
-    "text": "transcribed segment",
-    "temperature": 0.0,
-    "avg_logprob": -0.45,
-    "compression_ratio": 1.2,
-    "no_speech_prob": 0.001
-  }],
-  "words": [{
-    "word": "transcribed",
-    "start": 0.0,
-    "end": 0.8
-  }]
+  "segments": [
+    {
+      "id": 0,
+      "start": 0.0,
+      "end": 1.5,
+      "text": "transcribed segment",
+      "temperature": 0.0,
+      "avg_logprob": -0.45,
+      "compression_ratio": 1.2,
+      "no_speech_prob": 0.001
+    }
+  ],
+  "words": [
+    {
+      "word": "transcribed",
+      "start": 0.0,
+      "end": 0.8
+    }
+  ]
 }
 ```
 
@@ -204,12 +221,12 @@ en
 
 Mistral supports SSE streaming for transcription with custom event types:
 
-| Event Type | Content | Notes |
-|-----------|---------|-------|
-| `transcription.language` | Language code | Language detected |
-| `transcription.text.delta` | Text delta | Incremental text |
-| `transcription.segment` | Full segment | Complete segment data |
-| `transcription.done` | Final usage | Completion with tokens |
+| Event Type                 | Content       | Notes                  |
+| -------------------------- | ------------- | ---------------------- |
+| `transcription.language`   | Language code | Language detected      |
+| `transcription.text.delta` | Text delta    | Incremental text       |
+| `transcription.segment`    | Full segment  | Complete segment data  |
+| `transcription.done`       | Final usage   | Completion with tokens |
 
 ---
 
@@ -217,18 +234,49 @@ Mistral supports SSE streaming for transcription with custom event types:
 
 Mistral supports text embeddings:
 
-| Parameter | Notes |
-|-----------|-------|
-| `input` | Text or array of texts |
-| `model` | Embedding model name |
-| `dimensions` | Custom output dimensions (optional) |
-| `encoding_format` | "float" or "base64" |
+| Parameter         | Notes                               |
+| ----------------- | ----------------------------------- |
+| `input`           | Text or array of texts              |
+| `model`           | Embedding model name                |
+| `dimensions`      | Custom output dimensions (optional) |
+| `encoding_format` | "float" or "base64"                 |
 
 Response returns embedding vectors with token usage.
 
 ---
 
-# 5. List Models
+# 5. OCR
+
+Mistral provides native OCR support for extracting text and content from documents and images via the `mistral-ocr-latest` model.
+
+## Request Parameters
+
+| Parameter                    | Notes                                                      |
+| ---------------------------- | ---------------------------------------------------------- |
+| `model`                      | OCR model name (e.g., `mistral/mistral-ocr-latest`)        |
+| `document`                   | Document input — see document types below                  |
+| `include_image_base64`       | Return extracted images as base64                          |
+| `pages`                      | Specific page indices to process (0-based)                 |
+| `image_limit`                | Max images to extract per page                             |
+| `image_min_size`             | Minimum image size in pixels to extract                    |
+| `table_format`               | Format for extracted tables (e.g., `"markdown"`, `"html"`) |
+| `extract_header`             | Extract page headers                                       |
+| `extract_footer`             | Extract page footers                                       |
+| `confidence_scores_granularity` | Confidence detail level: `page`, `block`, `word`, or `document` |
+| `bbox_annotation_format`     | Format for bounding box annotations                        |
+| `document_annotation_format` | Format for document-level annotations                      |
+| `document_annotation_prompt` | Custom prompt for document annotation                      |
+
+### Document Types
+
+| `type`         | Required field | Use case                   |
+| -------------- | -------------- | -------------------------- |
+| `document_url` | `document_url` | PDF URL or base64 data URL |
+| `image_url`    | `image_url`    | Image URL                  |
+
+---
+
+# 6. List Models
 
 Lists available Mistral models with context length and capabilities.
 
@@ -236,30 +284,28 @@ Lists available Mistral models with context length and capabilities.
 
 ## Unsupported Features
 
-| Feature | Reason |
-|---------|--------|
-| Text Completions | Not offered by Mistral API |
+| Feature          | Reason                                                                 |
+| ---------------- | ---------------------------------------------------------------------- |
+| Text Completions | Not offered by Mistral API                                             |
 | Image Generation | Not yet implemented in Bifrost integration (Mistral API supports this) |
-| Speech/TTS | Not offered by Mistral API |
-| File Management | Not offered by Mistral API |
-| Batch Operations | Not offered by Mistral API |
+| Speech/TTS       | Not offered by Mistral API                                             |
+| File Management  | Not offered by Mistral API                                             |
+| Batch Operations | Not offered by Mistral API                                             |
 
 ---
 
 ## Caveats
 
 <Accordion title="Cache Control Stripped">
-**Severity**: Medium
-**Behavior**: Cache control directives removed from messages
-**Impact**: Prompt caching features unavailable
-**Code**: Stripped during JSON marshaling
+  **Severity**: Medium **Behavior**: Cache control directives removed from
+  messages **Impact**: Prompt caching features unavailable **Code**: Stripped
+  during JSON marshaling
 </Accordion>
 
 <Accordion title="Parameter Filtering">
-**Severity**: Low
-**Behavior**: OpenAI-specific parameters filtered
-**Impact**: prompt_cache_key, verbosity, store removed
-**Code**: filterOpenAISpecificParameters
+  **Severity**: Low **Behavior**: OpenAI-specific parameters filtered
+  **Impact**: prompt_cache_key, verbosity, store removed **Code**:
+  filterOpenAISpecificParameters
 </Accordion>
 
 <Accordion title="User Field Size Limit">

--- a/docs/providers/supported-providers/overview.mdx
+++ b/docs/providers/supported-providers/overview.mdx
@@ -7,64 +7,71 @@ icon: "circle-info"
 ## Overview
 
 Bifrost supports a wide range of AI providers, all accessible through a consistent OpenAI-compatible interface. This standardization allows you to switch between providers without modifying your application code, as all responses follow the same structure regardless of the underlying provider.
- 
-Bifrost can also act as a provider-compatible gateway (for example, <u>[Anthropic](../../integrations/anthropic-sdk/overview)</u>, <u>[Google Gemini](../../integrations/genai-sdk/overview)</u>, <u>Cohere</u>, <u>[Bedrock](../../integrations/bedrock-sdk/overview)</u>, and others), exposing provider-specific endpoints so you can use existing provider SDKs or integrations with no code changes, see [What is an integration?](../../integrations/what-is-an-integration) for details.
 
+Bifrost can also act as a provider-compatible gateway (for example, <u>[Anthropic](../../integrations/anthropic-sdk/overview)</u>, <u>[Google Gemini](../../integrations/genai-sdk/overview)</u>, <u>Cohere</u>, <u>[Bedrock](../../integrations/bedrock-sdk/overview)</u>, and others), exposing provider-specific endpoints so you can use existing provider SDKs or integrations with no code changes, see [What is an integration?](../../integrations/what-is-an-integration) for details.
 
 ## Provider Support Matrix
 
 The following table summarizes which operations are supported by each provider via Bifrost’s unified interface.
 
-| Provider | Models | Text | Text (stream) | Chat | Chat (stream) | Responses | Responses (stream) | Images | Images (stream) | Image Edit | Image Edit (stream) | Image Variation | Embeddings | TTS | TTS (stream) | STT | STT (stream) | Files | Batch | Count tokens |
-|----------|--------|------|----------------|------|---------------|-----------|--------------------|--------|-----------------|------------|---------------------|-----------------|------------|-----|-------------|-----|--------------|-------|-------|--------------|
-| Anthropic (`anthropic/<model>`) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Azure (`azure/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| Bedrock (`bedrock/<model>`) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Cerebras (`cerebras/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Cohere (`cohere/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| Elevenlabs (`elevenlabs/<model>`) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Fireworks (`fireworks/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Gemini (`gemini/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Groq (`groq/<model>`) | ✅ | 🟡 | 🟡 | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Hugging Face (`huggingface/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Mistral (`mistral/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| Nebius (`nebius/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Ollama (`ollama/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| OpenAI (`openai/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| OpenRouter (`openrouter/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Parasail (`parasail/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Perplexity (`perplexity/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Replicate (`replicate/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| SGL (`sgl/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Vertex AI (`vertex/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| vLLM (`vllm/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| xAI (`xai/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-
+| Provider                             | Models | Text | Text (stream) | Chat | Chat (stream) | Responses | Responses (stream) | Images | Images (stream) | Image Edit | Image Edit (stream) | Image Variation | Embeddings | TTS | TTS (stream) | STT | STT (stream) | Files | Batch | Count tokens | Rerank | OCR | Video | Video Remix | Containers | Passthrough | Passthrough (stream) |
+| ------------------------------------ | ------ | ---- | ------------- | ---- | ------------- | --------- | ------------------ | ------ | --------------- | ---------- | ------------------- | --------------- | ---------- | --- | ------------ | --- | ------------ | ----- | ----- | ------------ | ------ | --- | ----- | ----------- | ---------- | ----------- | -------------------- |
+| Anthropic (`anthropic/<model>`)      | ✅     | ✅   | ❌            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ✅    | ✅    | ✅           | ❌     | ❌  | ❌    | ❌          | ❌         | ✅          | ✅                   |
+| Azure (`azure/<model>`)              | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ✅     | ✅              | ✅         | ✅                  | ❌              | ✅         | ✅  | ✅           | ✅  | ❌           | ✅    | ✅    | ❌           | ❌     | ❌  | ✅    | ❌          | ❌         | ✅          | ✅                   |
+| Bedrock (`bedrock/<model>`)          | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ✅     | ❌              | ✅         | ❌                  | ✅              | ✅         | ❌  | ❌           | ❌  | ❌           | ✅    | ✅    | ✅           | ✅     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Cerebras (`cerebras/<model>`)        | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Cohere (`cohere/<model>`)            | ✅     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ✅           | ✅     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Elevenlabs (`elevenlabs/<model>`)    | ✅     | ❌   | ❌            | ❌   | ❌            | ❌        | ❌                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ✅  | ✅           | ✅  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Fireworks (`fireworks/<model>`)      | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Gemini (`gemini/<model>`)            | ✅     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ✅     | ❌              | ✅         | ❌                  | ❌              | ✅         | ✅  | ✅           | ✅  | ✅           | ✅    | ✅    | ✅           | ❌     | ❌  | ✅    | ❌          | ❌         | ✅          | ✅                   |
+| Groq (`groq/<model>`)                | ✅     | 🟡   | 🟡            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ✅  | ❌           | ✅  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Hugging Face (`huggingface/<model>`) | ✅     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ✅     | ✅              | ✅         | ✅                  | ❌              | ✅         | ✅  | ❌           | ✅  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Mistral (`mistral/<model>`)          | ✅     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ✅  | ✅           | ❌    | ❌    | ❌           | ❌     | ✅  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Nebius (`nebius/<model>`)            | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ✅     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Ollama (`ollama/<model>`)            | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| OpenAI (`openai/<model>`)            | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ✅     | ✅              | ✅         | ✅                  | ✅              | ✅         | ✅  | ✅           | ✅  | ✅           | ✅    | ✅    | ✅           | ❌     | ❌  | ✅    | ✅          | ✅         | ✅          | ✅                   |
+| OpenRouter (`openrouter/<model>`)    | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Parasail (`parasail/<model>`)        | ✅     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Perplexity (`perplexity/<model>`)    | ❌     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Replicate (`replicate/<model>`)      | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ✅     | ✅              | ✅         | ✅                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ✅    | ❌    | ❌           | ❌     | ❌  | ✅    | ❌          | ❌         | ❌          | ❌                   |
+| Runway (`runway/<model>`)            | ❌     | ❌   | ❌            | ❌   | ❌            | ❌        | ❌                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ✅    | ❌          | ❌         | ❌          | ❌                   |
+| SGL (`sgl/<model>`)                  | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Vertex AI (`vertex/<model>`)         | ✅     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ✅     | ❌              | ✅         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ✅           | ✅     | ❌  | ✅    | ❌          | ❌         | ✅          | ✅                   |
+| vLLM (`vllm/<model>`)                | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ✅  | ✅           | ❌    | ❌    | ❌           | ✅     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| xAI (`xai/<model>`)                  | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ✅     | ❌              | ❌         | ❌                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
 
 - 🟡 Not supported by the downstream provider, but internally implemented by Bifrost as a fallback.
 - ❌ Not supported by the downstream provider, hence not supported by Bifrost.
 - ✅ Fully supported by the downstream provider, or internally implemented by Bifrost.
 
-
 <Note>
-Some operations are not supported by the downstream provider, and their internal implementation in Bifrost is optional. 🟡
-Like Text completions are not supported by Groq, but Bifrost can emulate them internally using the Chat Completions API. This feature is disabled by default, but it can be enabled by setting `compat.convert_text_to_chat` to `true` in the client configuration.
-We do not promote using such fallbacks, since text completions and chat completions are fundamentally different. However, this option is available to help users migrating from LiteLLM (which does support these fallbacks).
+  Some operations are not supported by the downstream provider, and their
+  internal implementation in Bifrost is optional. 🟡 Like Text completions are
+  not supported by Groq, but Bifrost can emulate them internally using the Chat
+  Completions API. This feature is disabled by default, but it can be enabled by
+  setting `compat.convert_text_to_chat` to `true` in the client configuration.
+  We do not promote using such fallbacks, since text completions and chat
+  completions are fundamentally different. However, this option is available to
+  help users migrating from LiteLLM (which does support these fallbacks).
 </Note>
 
-
 Notes:
+
 - "Models" refers to the list models operation (`/v1/models`).
 - "Text" refers to the classic text completion interface (`/v1/completions`).
 - "Responses" refers to the OpenAI-style Responses API (`/v1/responses`). Depending on the provider, Bifrost either uses a native responses endpoint or maps to an equivalent chat API.
-- Reranking (`/v1/rerank`) is currently supported for Cohere, Bedrock, Vertex AI, and vLLM. See each provider page for model-specific requirements.
 - "Images" refers to the Image Generation API (`/v1/images/generations`).
 - "Image Edit" refers to the Image Edit API (`/v1/images/edits`).
 - "Image Variation" refers to the Image Variation API (`/v1/images/variations`).
 - TTS corresponds to `/v1/audio/speech` and STT to `/v1/audio/transcriptions`.
 - "Files" refers to the Files API operations (`/v1/files`) for uploading, listing, retrieving, and deleting files.
 - "Batch" refers to the Batch API operations (`/v1/batches`) for creating, listing, retrieving, canceling, and getting results of batch jobs.
-
+- "Rerank" refers to the Rerank APIs (`/v1/rerank`, `/v1/async/rerank`, `/v1/async/rerank/{job_id}`). See each provider page for model-specific requirements.
+- "OCR" refers to the OCR APIs (`/v1/ocr`, `/v1/async/ocr`, `/v1/async/ocr/{job_id}`) for optical character recognition on documents and images.
+- "Video" refers to Video API operations for generating, retrieving, downloading, deleting, and listing videos.
+- "Video Remix" refers to the video remix operation, which generates a new video by transforming an existing one.
+- "Containers" refers to the Containers API operations for creating, listing, retrieving, and deleting containers and container files.
+- "Passthrough" refers to the Passthrough API, which forwards requests directly to the provider without Bifrost's transformation layer.
 
 ## Response Format
 
@@ -134,7 +141,6 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
 </Tab>
 </Tabs>
 
-
 ## Custom Providers
 
 In addition to the built-in providers, Bifrost supports custom provider configurations. Custom providers allow you to create multiple instances of the same base provider with different configurations, request type restrictions, and access patterns. This is useful for environment-specific configurations, role-based access control, and feature testing.
@@ -159,6 +165,7 @@ Provider information is included in the `extra_fields` section of each response,
 Bifrost can optionally return the raw request that was sent to the provider and the raw response received back. This is useful for debugging, auditing, and understanding how Bifrost transforms requests between different provider formats.
 
 **What's included:**
+
 - **`raw_request`** - The exact request body (JSON/data structure) that was sent to the provider's API endpoint
 - **`raw_response`** - The exact response body received from the provider (before Bifrost's normalization)
 - **Provider transformation details** - Shows exactly how Bifrost converted your input to provider-specific format
@@ -188,15 +195,19 @@ Bifrost can optionally return the raw request that was sent to the provider and 
 ```
 
 **Use cases:**
+
 - **Debugging** - Verify how your request was transformed for the specific provider
 - **Auditing** - Track exactly what was sent to external APIs
 - **Cost analysis** - See actual token counts before Bifrost's normalization
 - **Integration testing** - Validate provider-specific transformations
 
 **Configuration options:**
+
 - **[Go SDK Provider Configuration](../../quickstart/go-sdk/provider-configuration)** - Configure `SendBackRawResponse` and other provider settings
 - **[Gateway Provider Configuration](../../quickstart/gateway/provider-configuration)** - Configure `send_back_raw_response` via API, UI, or config file
 
 <Note>
-Enabling raw request/response may increase response payload size and has minimal performance impact. Use it selectively in debugging/testing environments or when you need audit trails.
+  Enabling raw request/response may increase response payload size and has
+  minimal performance impact. Use it selectively in debugging/testing
+  environments or when you need audit trails.
 </Note>


### PR DESCRIPTION
## Summary

This PR adds OCR (Optical Character Recognition) as a documented, first-class operation in Bifrost's OpenAPI specification and provider support matrix, and fixes a minor signature issue in the Mistral transcription stream handler. The OCR implementation for the Mistral provider already existed but was repositioned in the file for better logical grouping alongside other non-streaming operations.

## Changes

- Relocated the `Rerank` stub and `OCR` implementation in `mistral.go` to appear after the streaming handlers, improving code organization without changing behavior
- Removed unused `model` and `providerName` parameters from `processTranscriptionStreamEvent` and its call site
- Added `/v1/ocr` and `/v1/async/ocr` (with job polling) endpoint definitions to the OpenAPI spec (both JSON and YAML), including full request/response schemas for `OCRRequest`, `OCRResponse`, `OCRPage`, `OCRPageImage`, `OCRPageDimensions`, and `OCRUsageInfo`
- Added `/v1/async/rerank` and `/v1/async/rerank/{job_id}` endpoint definitions to the OpenAPI spec
- Added a dedicated `ocr.yaml` path file and `ocr.yaml` schema file under the modular OpenAPI directory structure
- Updated the Mistral provider documentation to list OCR as a supported operation with full parameter and document-type reference tables
- Expanded the provider support matrix in the overview docs to include Rerank, OCR, Video, Video Remix, Containers, and Passthrough columns, and added several new providers (Runway) to the matrix
- Added an `OCR` tag to the OpenAPI spec for grouping OCR endpoints

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./core/providers/mistral/...
```

To validate the OCR endpoint:
1. Start the Bifrost gateway with a valid Mistral API key configured
2. Send a POST request to `/v1/ocr` with a `mistral/mistral-ocr-latest` model and a `document_url` or `image_url` document input
3. Confirm a valid `OCRResponse` is returned with `pages` containing `index` and `markdown` fields
4. Send a POST to `/v1/async/ocr` and confirm a `202` response with a job ID, then poll `/v1/async/ocr/{job_id}` for the result

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth mechanisms introduced. OCR requests use the same Bearer token authorization as all other Mistral endpoints.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable