### PR TITLE
fix: make encryptionKey optional for helm deployments

### DIFF
--- a/helm-charts/bifrost/templates/stateful.yaml
+++ b/helm-charts/bifrost/templates/stateful.yaml
@@ -88,7 +88,7 @@ spec:
               value: {{ .Values.bifrost.logLevel | quote }}
             - name: LOG_STYLE
               value: {{ .Values.bifrost.logStyle | quote }}
-            {{- if .Values.bifrost.encryptionKeySecret }}
+            {{- if .Values.bifrost.encryptionKeySecret.name }}
             - name: BIFROST_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

Fixes a bug where the `BIFROST_ENCRYPTION_KEY` environment variable was required and not optional for Bifrost StatefulSet when using a Kubernetes secret reference.

## Changes

- Updated the Helm template condition from `{{- if .Values.bifrost.encryptionKeySecret }}` to `{{- if .Values.bifrost.encryptionKeySecret.name }}` to ensure the secret key reference is only rendered when a secret name is explicitly provided.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy the Bifrost Helm chart with `encryptionKeySecret` set to an empty object or with only partial values and verify that the `BIFROST_ENCRYPTION_KEY` env var is not rendered. Then deploy with a valid `encryptionKeySecret.name` and confirm the env var is correctly injected from the referenced secret.

```sh
helm template bifrost ./helm-charts/bifrost --set bifrost.encryptionKeySecret.name=my-secret
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change ensures encryption key secrets are only referenced when a valid secret name is provided, preventing misconfigured or empty secret references from being rendered into the pod spec.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable