### PR TITLE
chore: update chart version on helm and add pgres, access provider config example

### DIFF
--- a/docs/deployment-guides/config-json.mdx
+++ b/docs/deployment-guides/config-json.mdx
@@ -197,6 +197,105 @@ A production-ready file with PostgreSQL storage, multi-provider setup, governanc
 
 ---
 
+## Enterprise Example: Postgres + etcd + Access Profiles
+
+Use this pattern when you want enterprise access-profile configuration to be seeded directly from `config.json`, while running clustered nodes with etcd discovery.
+
+```json
+{
+  "$schema": "https://www.getbifrost.ai/schema",
+  "cluster_config": {
+    "enabled": true,
+    "discovery": {
+      "enabled": true,
+      "type": "etcd",
+      "service_name": "bifrost-cluster",
+      "etcd_endpoints": ["http://localhost:2379"]
+    }
+  },
+  "config_store": {
+    "enabled": true,
+    "type": "postgres",
+    "config": {
+      "host": "localhost",
+      "port": "5432",
+      "user": "postgres",
+      "password": "env.PG_PASSWORD",
+      "db_name": "bifrost-config",
+      "ssl_mode": "disable"
+    }
+  },
+  "logs_store": {
+    "enabled": true,
+    "type": "postgres",
+    "config": {
+      "host": "localhost",
+      "port": "5432",
+      "user": "postgres",
+      "password": "env.PG_PASSWORD",
+      "db_name": "bifrost-config",
+      "ssl_mode": "disable"
+    }
+  },
+  "mcp": {
+    "client_configs": [
+      {
+        "client_id": "echo_http",
+        "name": "echo_http",
+        "connection_type": "http",
+        "connection_string": "https://mcpplaygroundonline.com/mcp-echo-server",
+        "auth_type": "none",
+        "tools_to_execute": ["echo"]
+      }
+    ]
+  },
+  "access_profiles": [
+    {
+      "name": "platform-default",
+      "description": "Default profile for enterprise access-profile testing",
+      "is_active": true,
+      "tags": ["platform", "test"],
+      "provider_configs": [
+        {
+          "provider_name": "OpenAi",
+          "all_models_allowed": false,
+          "allowed_models": ["gpt-4o-mini"]
+        }
+      ]
+    },
+    {
+      "name": "platform-readonly-mcp",
+      "description": "Profile for validating MCP include/exclude behavior",
+      "is_active": true,
+      "tags": ["mcp", "test"],
+      "mcp_servers": [
+        {
+          "mcp_server_id": "echo_http"
+        }
+      ],
+      "mcp_tool_overrides": [
+        {
+          "mcp_client_id": "echo_http",
+          "tool_name": "echo",
+          "action": "include"
+        },
+        {
+          "mcp_client_id": "github",
+          "tool_name": "create_pull_request",
+          "action": "exclude"
+        }
+      ]
+    }
+  ]
+}
+```
+
+<Note>
+`access_profiles` is an enterprise capability. For OSS-only deployments, use `governance.virtual_keys` and related governance resources instead.
+</Note>
+
+---
+
 ## Example Configs
 
 Ready-to-use reference configurations from the [examples/configs](https://github.com/maximhq/bifrost/tree/main/examples/configs) directory on GitHub:

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.2
-appVersion: "1.5.0-prerelease4"
+version: 2.1.3
+appVersion: "1.5.0-prerelease5"
 keywords:
   - ai
   - gateway

--- a/helm-charts/bifrost/templates/stateful.yaml
+++ b/helm-charts/bifrost/templates/stateful.yaml
@@ -88,7 +88,7 @@ spec:
               value: {{ .Values.bifrost.logLevel | quote }}
             - name: LOG_STYLE
               value: {{ .Values.bifrost.logStyle | quote }}
-            {{- if .Values.bifrost.encryptionKeySecret }}
+            {{- if .Values.bifrost.encryptionKeySecret.name }}
             - name: BIFROST_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary

Adds a new enterprise example configuration to the `config.json` deployment guide, demonstrating how to seed access profiles directly from `config.json` while running clustered nodes with etcd discovery and Postgres storage. Also bumps the Helm chart to `2.1.3` / `appVersion 1.5.0-prerelease5`.

## Changes

- Added a new **Enterprise Example: Postgres + etcd + Access Profiles** section to `docs/deployment-guides/config-json.mdx`, including a full annotated JSON snippet covering:
  - etcd-based cluster discovery
  - Postgres config and logs stores
  - MCP client configuration with an HTTP echo server
  - Two access profiles (`platform-default` and `platform-readonly-mcp`) demonstrating model allowlists and MCP tool include/exclude overrides
- Added a `<Note>` clarifying that `access_profiles` is an enterprise capability and that OSS deployments should use `governance.virtual_keys` instead
- Bumped Helm chart version from `2.1.2` → `2.1.3` and `appVersion` from `1.5.0-prerelease4` → `1.5.0-prerelease5`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation to confirm the new enterprise example section appears correctly between the production-ready example and the **Example Configs** section. Verify the JSON snippet is valid and the `<Note>` callout renders as expected.

Confirm the Helm chart version reflects `2.1.3` / `1.5.0-prerelease5`:

```sh
helm show chart ./helm-charts/bifrost | grep -E "version|appVersion"
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The example config references `env.PG_PASSWORD` for database credentials, demonstrating the recommended pattern of reading secrets from environment variables rather than hardcoding them. No new secrets or auth surfaces are introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable