### PR TITLE
feat: auto-fill incoming model for empty fallbacks in routing rules

### DIFF
--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,0 +1,1 @@
+- feat: automatically add incoming model to empty fallbacks in routing rules

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -939,9 +939,23 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 		// Append routing-rule to routing engines used
 		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyRoutingEnginesUsed, schemas.RoutingEngineRoutingRule)
 
-		// Add fallbacks if present
+		// Add fallbacks if present; fill in the incoming model for fallbacks that omit it
 		if len(decision.Fallbacks) > 0 {
-			body["fallbacks"] = decision.Fallbacks
+			resolvedFallbacks := make([]string, 0, len(decision.Fallbacks))
+			for _, fb := range decision.Fallbacks {
+				fbProvider, fbModel := schemas.ParseModelString(fb, "")
+				trimmedFbProvider := strings.TrimSpace(string(fbProvider))
+				trimmedFbModel := strings.TrimSpace(fbModel)
+				if trimmedFbProvider == "" {
+					continue
+				}
+				if trimmedFbModel == "" && model != "" {
+					resolvedFallbacks = append(resolvedFallbacks, trimmedFbProvider+"/"+model)
+				} else {
+					resolvedFallbacks = append(resolvedFallbacks, trimmedFbProvider+"/"+trimmedFbModel)
+				}
+			}
+			body["fallbacks"] = resolvedFallbacks
 		}
 
 		// Pin specific API key by ID if the routing rule specifies one

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -3180,6 +3180,10 @@ func (h *GovernanceHandler) createRoutingRule(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 400, err.Error())
 		return
 	}
+	if err := validateRoutingFallbacks(req.Fallbacks); err != nil {
+		SendError(ctx, 400, err.Error())
+		return
+	}
 
 	// Set defaults and normalize scope/scope_id
 	scope := req.Scope
@@ -3321,6 +3325,10 @@ func (h *GovernanceHandler) updateRoutingRule(ctx *fasthttp.RequestCtx) {
 		rule.ParsedQuery = req.Query
 	}
 	if req.Fallbacks != nil {
+		if err := validateRoutingFallbacks(req.Fallbacks); err != nil {
+			SendError(ctx, 400, err.Error())
+			return
+		}
 		rule.ParsedFallbacks = req.Fallbacks
 	}
 	if req.Scope != nil && *req.Scope != "" {
@@ -3811,6 +3819,21 @@ func validateRoutingTargets(targets []RoutingTarget) error {
 	}
 	if math.Abs(total-1.0) > 0.001 {
 		return fmt.Errorf("target weights must sum to 1, got %.4f", total)
+	}
+	return nil
+}
+
+// validateRoutingFallbacks ensures each fallback parses to a non-empty known provider via
+// schemas.ParseModelString (e.g. "openai/gpt-4o", or "azure/" to use the incoming model).
+func validateRoutingFallbacks(fallbacks []string) error {
+	for i, fb := range fallbacks {
+		if strings.TrimSpace(fb) == "" {
+			return fmt.Errorf("fallbacks[%d] must not be empty", i)
+		}
+		provider, _ := schemas.ParseModelString(fb, "")
+		if provider == "" {
+			return fmt.Errorf("fallbacks[%d] %q is invalid: must use a known provider prefix (e.g. \"openai/gpt-4o\" or \"azure/\" for the incoming model)", i, fb)
+		}
 	}
 	return nil
 }

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -188,17 +188,17 @@ func TestBudgetRemovalRequestDetection(t *testing.T) {
 		},
 		{
 			name: "max limit present is not removal",
-			req:  &UpdateBudgetRequest{MaxLimit: bifrostFloat(10)},
+			req:  &UpdateBudgetRequest{MaxLimit: schemas.Ptr(10.0)},
 			want: false,
 		},
 		{
 			name: "reset duration only is not removal",
-			req:  &UpdateBudgetRequest{ResetDuration: bifrostString("1h")},
+			req:  &UpdateBudgetRequest{ResetDuration: schemas.Ptr("1h")},
 			want: false,
 		},
 		{
 			name: "calendar aligned only is treated as removal",
-			req:  &UpdateBudgetRequest{CalendarAligned: bifrostBool(true)},
+			req:  &UpdateBudgetRequest{CalendarAligned: schemas.Ptr(true)},
 			want: true,
 		},
 	}
@@ -230,19 +230,19 @@ func TestRateLimitRemovalRequestDetection(t *testing.T) {
 		},
 		{
 			name: "token limit present is not removal",
-			req:  &UpdateRateLimitRequest{TokenMaxLimit: bifrostInt64(100)},
+			req:  &UpdateRateLimitRequest{TokenMaxLimit: schemas.Ptr(int64(100))},
 			want: false,
 		},
 		{
 			name: "request limit present is not removal",
-			req:  &UpdateRateLimitRequest{RequestMaxLimit: bifrostInt64(10)},
+			req:  &UpdateRateLimitRequest{RequestMaxLimit: schemas.Ptr(int64(10))},
 			want: false,
 		},
 		{
 			name: "durations only is not removal",
 			req: &UpdateRateLimitRequest{
-				TokenResetDuration:   bifrostString("1h"),
-				RequestResetDuration: bifrostString("1h"),
+				TokenResetDuration:   schemas.Ptr("1h"),
+				RequestResetDuration: schemas.Ptr("1h"),
 			},
 			want: false,
 		},
@@ -320,18 +320,31 @@ func TestCollectProviderConfigDeleteIDs(t *testing.T) {
 	}
 }
 
-func bifrostFloat(v float64) *float64 {
-	return &v
-}
+func TestValidateRoutingFallbacks(t *testing.T) {
 
-func bifrostInt64(v int64) *int64 {
-	return &v
-}
-
-func bifrostString(v string) *string {
-	return &v
-}
-
-func bifrostBool(v bool) *bool {
-	return &v
+	tests := []struct {
+		name    string
+		fbs     []string
+		wantErr bool
+	}{
+		{name: "nil", fbs: nil, wantErr: false},
+		{name: "empty", fbs: []string{}, wantErr: false},
+		{name: "provider model", fbs: []string{"openai/gpt-4o"}, wantErr: false},
+		{name: "provider slash incoming model", fbs: []string{"azure/"}, wantErr: false},
+		{name: "bare known provider name rejected", fbs: []string{"openrouter"}, wantErr: true},
+		{name: "bare model rejected", fbs: []string{"gpt-4o"}, wantErr: true},
+		{name: "empty element", fbs: []string{"openai/gpt-4o", ""}, wantErr: true},
+		{name: "huggingface namespace not a provider prefix", fbs: []string{"meta-llama/Llama-3.1-8B"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRoutingFallbacks(tt.fbs)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
 }

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,2 @@
 - feat: add support for cache creation cost above 1 hour
+- feat: add support for dynamically selecting incoming model for fallbacks in routing rules

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -233,9 +233,9 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 		const submitPromise =
 			isEditing && editingRule
 				? updateRoutingRule({
-						id: editingRule.id,
-						data: payload,
-					}).unwrap()
+					id: editingRule.id,
+					data: payload,
+				}).unwrap()
 				: createRoutingRule(payload).unwrap();
 
 		submitPromise
@@ -413,10 +413,10 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 							{((scope === "team" && teamsData.teams.length === 0) ||
 								(scope === "customer" && customersData.customers.length === 0) ||
 								(scope === "virtual_key" && vksData.virtual_keys.length === 0)) && (
-								<p className="text-muted-foreground text-sm">
-									No {scope === "team" ? "teams" : scope === "customer" ? "customers" : "virtual keys"} available
-								</p>
-							)}
+									<p className="text-muted-foreground text-sm">
+										No {scope === "team" ? "teams" : scope === "customer" ? "customers" : "virtual keys"} available
+									</p>
+								)}
 							{errors.scope_id && <p className="text-destructive text-sm">{errors.scope_id.message}</p>}
 						</div>
 					)}
@@ -497,7 +497,11 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 					{/* Fallbacks */}
 					<div className="space-y-3">
 						<div className="flex items-center justify-between">
-							<Label>Fallbacks</Label>
+							<div>
+								<Label>Fallbacks</Label>								<p className="text-muted-foreground text-xs mt-0.5">
+									Provider is required, but model is optional. Leave model empty to use the incoming request value.
+								</p>
+							</div>
 							<Button
 								type="button"
 								variant="outline"
@@ -564,7 +568,7 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 													provider={fbProvider || undefined}
 													value={fbModel}
 													onChange={handleModelChange}
-													placeholder="Select model..."
+													placeholder="Incoming (optional)"
 													isSingleSelect
 													disabled={!fbProvider}
 													className="!h-9 !min-h-9 w-full"


### PR DESCRIPTION
## Summary

When a routing rule specifies fallbacks using only a provider (e.g., `openai/`), the model portion was left empty, requiring users to always specify a full `provider/model` string. This PR allows fallback entries in routing rules to omit the model, in which case the incoming request's model is automatically substituted at runtime.

## Changes

- When processing routing rule fallbacks, if a fallback entry specifies a provider but no model, the model from the incoming request is injected automatically, producing a fully-qualified `provider/model` fallback string.
- The fallback model selector in the UI now shows `"Incoming (optional)"` as its placeholder, communicating that leaving the model blank will use the incoming request's model.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Configure a routing rule with a fallback entry that specifies only a provider (e.g., `anthropic` with no model selected). Send a request targeting a specific model. Verify that the fallback resolves to `anthropic/<incoming-model>` rather than failing or using an empty model string.

```sh
go test ./plugins/governance/...
```

In the UI, open a routing rule sheet, add a fallback, select a provider, and leave the model field blank. Confirm the placeholder reads `"Incoming (optional)"`.

## Screenshots/Recordings

**Before:** Model selector placeholder read `"Select model..."`, giving no indication that omitting a model was valid or meaningful.

**After:** Model selector placeholder reads `"Incoming (optional)"`, clearly indicating the incoming request's model will be used if left blank.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. The substituted model value comes directly from the validated incoming request context.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable