### PR TITLE
Add sends_done_marker config for custom providers

### DIFF
--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -390,6 +390,8 @@ func (provider *OpenAIProvider) TextCompletionStream(ctx *schemas.BifrostContext
 	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.TextCompletionStreamRequest); err != nil {
 		return nil, err
 	}
+	// Store custom provider config in context so streaming handler can check SendsDoneMarker
+	ctx.SetValue(schemas.BifrostContextKeyCustomProviderConfig, provider.customProviderConfig)
 	var authHeader map[string]string
 	if key.Value.GetValue() != "" {
 		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
@@ -562,6 +564,15 @@ func HandleOpenAITextCompletionStreaming(
 
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 
+		// Resolve sends_done_marker once before the loop (custom config overrides provider default)
+		var customCfg *schemas.CustomProviderConfig
+		if v := ctx.Value(schemas.BifrostContextKeyCustomProviderConfig); v != nil {
+			if c, ok := v.(*schemas.CustomProviderConfig); ok {
+				customCfg = c
+			}
+		}
+		providerSendsDoneMarker := providerUtils.ProviderSendsDoneMarker(providerName, customCfg)
+
 		chunkIndex := -1
 		usage := &schemas.BifrostLLMUsage{}
 
@@ -700,7 +711,7 @@ func HandleOpenAITextCompletionStreaming(
 			}
 
 			// For providers that don't send [DONE] marker break on finish_reason
-			if !providerUtils.ProviderSendsDoneMarker(providerName) && finishReason != nil {
+			if !providerSendsDoneMarker && finishReason != nil {
 				break
 			}
 		}
@@ -898,6 +909,8 @@ func (provider *OpenAIProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ChatCompletionStreamRequest); err != nil {
 		return nil, err
 	}
+	// Store custom provider config in context so streaming handler can check SendsDoneMarker
+	ctx.SetValue(schemas.BifrostContextKeyCustomProviderConfig, provider.customProviderConfig)
 	var authHeader map[string]string
 	if key.Value.GetValue() != "" {
 		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
@@ -1101,6 +1114,15 @@ func HandleOpenAIChatCompletionStreaming(
 		}
 
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
+
+		// Resolve sends_done_marker once before the loop (custom config overrides provider default)
+		var customCfg *schemas.CustomProviderConfig
+		if v := ctx.Value(schemas.BifrostContextKeyCustomProviderConfig); v != nil {
+			if c, ok := v.(*schemas.CustomProviderConfig); ok {
+				customCfg = c
+			}
+		}
+		providerSendsDoneMarker := providerUtils.ProviderSendsDoneMarker(providerName, customCfg)
 
 		chunkIndex := -1
 		usage := &schemas.BifrostLLMUsage{}
@@ -1310,7 +1332,7 @@ func HandleOpenAIChatCompletionStreaming(
 				}
 
 				// For providers that don't send [DONE] marker break on finish_reason
-				if !providerUtils.ProviderSendsDoneMarker(providerName) && finishReason != nil {
+				if !providerSendsDoneMarker && finishReason != nil {
 					break
 				}
 			}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2259,7 +2259,12 @@ func GetProviderName(defaultProvider schemas.ModelProvider, customConfig *schema
 // ProviderSendsDoneMarker returns true if the provider sends the [DONE] marker in streaming responses.
 // Some OpenAI-compatible providers (like Cerebras) don't send [DONE] and instead end the stream
 // after sending the finish_reason. This function helps determine the correct stream termination logic.
-func ProviderSendsDoneMarker(providerName schemas.ModelProvider) bool {
+// If customConfig is provided and SendsDoneMarker is set, it overrides the provider default.
+func ProviderSendsDoneMarker(providerName schemas.ModelProvider, customConfig *schemas.CustomProviderConfig) bool {
+	// Check custom provider config override first
+	if customConfig != nil && customConfig.SendsDoneMarker != nil {
+		return *customConfig.SendsDoneMarker
+	}
 	switch providerName {
 	case schemas.Cerebras, schemas.Perplexity, schemas.HuggingFace:
 		// Cerebras, Perplexity, and HuggingFace don't send [DONE] marker, ends stream after finish_reason

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -234,6 +234,7 @@ const (
 	BifrostContextKeyShouldStoreRawInLogs                BifrostContextKey = "bifrost-should-store-raw-in-logs"                 // bool (set by bifrost - DO NOT SET THIS MANUALLY) — true when raw request/response should be persisted in log records
 	BifrostContextKeyRetryDBFetch                        BifrostContextKey = "bifrost-retry-db-fetch"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyCustomProviderConfig                BifrostContextKey = "bifrost-custom-provider-config"                    // *CustomProviderConfig (set by provider methods for streaming handlers)
 	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeyPassthroughExtraParams              BifrostContextKey = "bifrost-passthrough-extra-params"                 // bool
 	BifrostContextKeyRoutingEnginesUsed                  BifrostContextKey = "bifrost-routing-engines-used"                     // []string (set by bifrost - DO NOT SET THIS MANUALLY) - list of routing engines used ("routing-rule", "governance", "loadbalancing", etc.)

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -408,6 +408,7 @@ type CustomProviderConfig struct {
 	BaseProviderType     ModelProvider          `json:"base_provider_type"`               // Base provider type
 	AllowedRequests      *AllowedRequests       `json:"allowed_requests,omitempty"`       // Allowed requests for the custom provider
 	RequestPathOverrides map[RequestType]string `json:"request_path_overrides,omitempty"` // Mapping of request type to its custom path which will override the default path of the provider (not allowed for Bedrock)
+	SendsDoneMarker      *bool                  `json:"sends_done_marker,omitempty"`      // Whether the provider sends [DONE] in SSE streams. nil = use provider default. false = break on finish_reason instead of waiting for [DONE].
 }
 
 // IsOperationAllowed checks if a specific operation is allowed for this custom provider

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3981,6 +3981,10 @@
             }
           },
           "additionalProperties": false
+        },
+        "sends_done_marker": {
+          "type": "boolean",
+          "description": "Whether the provider sends the [DONE] SSE marker in streaming responses. Set to false for providers that close the stream after finish_reason without sending [DONE]. When omitted, the provider default is used (true for most providers, false for Cerebras/Perplexity/HuggingFace)."
         }
       },
       "required": ["base_provider_type"],


### PR DESCRIPTION
## Problem

fixes https://github.com/maximhq/bifrost/issues/2910

Some OpenAI-compatible providers (e.g. MiniMax, Synthetic) do not send the `[DONE]` SSE marker in streaming responses. They close the TCP connection after sending the final chunk with `finish_reason: "stop"`.

Bifrost's OpenAI streaming handler waits for `[DONE]` because `ProviderSendsDoneMarker()` returns `true` for all providers except Cerebras, Perplexity, and HuggingFace. This causes ~60s stream hangs after all content has been delivered, until the idle timeout fires.

## Solution

Add an optional `sends_done_marker` field to `CustomProviderConfig`:

```json
"custom_provider_config": {
  "base_provider_type": "openai",
  "sends_done_marker": false,
  "request_path_overrides": { ... }
}
```

When `sends_done_marker` is `false`, the streaming handler breaks on `finish_reason` instead of waiting for `[DONE]`, matching the existing behavior for Cerebras/Perplexity/HuggingFace.

### Implementation Details

- **`sends_done_marker *bool`** in `CustomProviderConfig` - `nil` uses provider default (backward compatible), `false` breaks on finish_reason, `true` waits for `[DONE]`
- **`ProviderSendsDoneMarker()`** accepts optional `*CustomProviderConfig` via variadic param - checks `SendsDoneMarker` override first, then falls back to provider default
- **`BifrostContextKeyCustomProviderConfig`** - the config is passed through `BifrostContext` to avoid changing `HandleOpenAI*Streaming` function signatures (used by 17+ providers)

## Files Changed

| File | Change |
|------|--------|
| `core/schemas/provider.go` | Add `SendsDoneMarker *bool` field to `CustomProviderConfig` |
| `core/schemas/bifrost.go` | Add `BifrostContextKeyCustomProviderConfig` context key |
| `core/providers/utils/utils.go` | Extend `ProviderSendsDoneMarker()` with optional custom config |
| `core/providers/openai/openai.go` | Set context in `TextCompletionStream`/`ChatCompletionStream`, read in streaming handlers |

## Testing

Built and deployed a custom Docker image with this patch. MiniMax streaming via Bifrost now completes in ~1.7s (previously hung for ~60s after content delivery).

Before:
```
time curl ... MiniMax-M2.7 ... stream=true
# Content arrives, then ~60s silence, then stream closes
```

After (with `"sends_done_marker": false`):
```
time curl ... MiniMax-M2.7 ... stream=true
# Content arrives, stream closes immediately with [DONE]
# Total: ~1.7s
```