### PR TITLE
refactor: move complexity analyzer config methods onto `RDBConfigStore` and add to `ConfigStore` interface

### DIFF
--- a/framework/configstore/complexityconfig.go
+++ b/framework/configstore/complexityconfig.go
@@ -1,7 +1,6 @@
 package configstore
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -106,35 +105,6 @@ func DecodeComplexityAnalyzerConfig(data []byte) (*ComplexityAnalyzerConfig, err
 		return nil, fmt.Errorf("invalid complexity analyzer config: %w", err)
 	}
 	return &normalized, nil
-}
-
-// GetComplexityAnalyzerConfig retrieves the typed complexity analyzer config
-// from governance_config. Returns nil with no error when the key is absent.
-func GetComplexityAnalyzerConfig(ctx context.Context, store ConfigStore) (*ComplexityAnalyzerConfig, error) {
-	raw, err := GetComplexityAnalyzerConfigRaw(ctx, store)
-	if err != nil {
-		return nil, err
-	}
-	return DecodeComplexityAnalyzerConfig(raw)
-}
-
-// UpdateComplexityAnalyzerConfig normalizes, validates, and persists the typed
-// complexity analyzer config into governance_config.
-func UpdateComplexityAnalyzerConfig(ctx context.Context, store ConfigStore, cfg *ComplexityAnalyzerConfig) error {
-	if cfg == nil {
-		return fmt.Errorf("complexity analyzer config is nil")
-	}
-
-	normalized := cfg.Normalized()
-	if err := normalized.Validate(); err != nil {
-		return err
-	}
-
-	raw, err := json.Marshal(normalized)
-	if err != nil {
-		return fmt.Errorf("failed to marshal complexity analyzer config: %w", err)
-	}
-	return UpdateComplexityAnalyzerConfigRaw(ctx, store, raw)
 }
 
 func normalizeComplexityKeywordList(values []string) []string {

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3623,7 +3623,7 @@ func (s *RDBConfigStore) GetGovernanceConfig(ctx context.Context) (*GovernanceCo
 			}
 		}
 	}
-	complexityAnalyzerConfig, err := GetComplexityAnalyzerConfig(ctx, s)
+	complexityAnalyzerConfig, err := s.GetComplexityAnalyzerConfig(ctx)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Warn("failed to load complexity analyzer config from governance_config: %v", err)
@@ -3645,15 +3645,10 @@ func (s *RDBConfigStore) GetGovernanceConfig(ctx context.Context) (*GovernanceCo
 	}, nil
 }
 
-// GetComplexityAnalyzerConfigRaw retrieves the raw JSON bytes for the complexity
-// analyzer config from governance_config. Returns nil with no error when the key
-// is absent or empty. Callers are responsible for decoding and validating.
-func GetComplexityAnalyzerConfigRaw(ctx context.Context, store ConfigStore) (json.RawMessage, error) {
-	if store == nil {
-		return nil, fmt.Errorf("config store is nil")
-	}
-
-	configEntry, err := store.GetConfig(ctx, tables.ConfigComplexityAnalyzerConfigKey)
+// GetComplexityAnalyzerConfig retrieves the typed complexity analyzer config
+// from governance_config. Returns nil with no error when the key is absent.
+func (s *RDBConfigStore) GetComplexityAnalyzerConfig(ctx context.Context) (*ComplexityAnalyzerConfig, error) {
+	configEntry, err := s.GetConfig(ctx, tables.ConfigComplexityAnalyzerConfigKey)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return nil, nil
@@ -3664,21 +3659,27 @@ func GetComplexityAnalyzerConfigRaw(ctx context.Context, store ConfigStore) (jso
 		return nil, nil
 	}
 
-	return json.RawMessage(configEntry.Value), nil
+	return DecodeComplexityAnalyzerConfig([]byte(configEntry.Value))
 }
 
-// UpdateComplexityAnalyzerConfigRaw upserts raw JSON bytes for the complexity
-// analyzer config into the governance config store. Callers are responsible for
-// normalizing and validating before calling this.
-func UpdateComplexityAnalyzerConfigRaw(ctx context.Context, store ConfigStore, raw json.RawMessage) error {
-	if store == nil {
-		return fmt.Errorf("config store is nil")
-	}
-	if len(raw) == 0 {
-		return fmt.Errorf("complexity analyzer config data is empty")
+// UpdateComplexityAnalyzerConfig normalizes, validates, and persists the typed
+// complexity analyzer config into governance_config.
+func (s *RDBConfigStore) UpdateComplexityAnalyzerConfig(ctx context.Context, config *ComplexityAnalyzerConfig) error {
+	if config == nil {
+		return fmt.Errorf("complexity analyzer config is nil")
 	}
 
-	return store.UpdateConfig(ctx, &tables.TableGovernanceConfig{
+	normalized := config.Normalized()
+	if err := normalized.Validate(); err != nil {
+		return err
+	}
+
+	raw, err := json.Marshal(normalized)
+	if err != nil {
+		return fmt.Errorf("failed to marshal complexity analyzer config: %w", err)
+	}
+
+	return s.UpdateConfig(ctx, &tables.TableGovernanceConfig{
 		Key:   tables.ConfigComplexityAnalyzerConfigKey,
 		Value: string(raw),
 	})

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -70,28 +70,49 @@ func TestComplexityAnalyzerConfigRoundTrip(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()
 
-	raw := json.RawMessage(`{"tier_boundaries":{"simple_medium":0.18,"medium_complex":0.35,"complex_reasoning":0.60},"keywords":{"code_keywords":["function","router","endpoint"],"reasoning_keywords":["step by step"],"technical_keywords":["architecture"],"simple_keywords":["hello"]}}`)
+	cfg := &ComplexityAnalyzerConfig{
+		TierBoundaries: ComplexityTierBoundaries{
+			SimpleMedium:     0.18,
+			MediumComplex:    0.35,
+			ComplexReasoning: 0.60,
+		},
+		Keywords: ComplexityEditableKeywordConfig{
+			CodeKeywords:      []string{"function", "router", "endpoint"},
+			ReasoningKeywords: []string{"step by step"},
+			TechnicalKeywords: []string{"architecture"},
+			SimpleKeywords:    []string{"hello"},
+		},
+	}
 
-	err := UpdateComplexityAnalyzerConfigRaw(ctx, store, raw)
+	err := store.UpdateComplexityAnalyzerConfig(ctx, cfg)
 	require.NoError(t, err)
 
-	loaded, err := GetComplexityAnalyzerConfigRaw(ctx, store)
+	loaded, err := store.GetComplexityAnalyzerConfig(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
-
-	var parsed map[string]interface{}
-	require.NoError(t, json.Unmarshal(loaded, &parsed))
-	tb := parsed["tier_boundaries"].(map[string]interface{})
-	assert.Equal(t, 0.18, tb["simple_medium"])
+	assert.Equal(t, 0.18, loaded.TierBoundaries.SimpleMedium)
+	assert.Equal(t, []string{"function", "router", "endpoint"}, loaded.Keywords.CodeKeywords)
 }
 
 func TestGetGovernanceConfig_IncludesComplexityAnalyzerConfig(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()
 
-	raw := json.RawMessage(`{"tier_boundaries":{"simple_medium":0.15,"medium_complex":0.35,"complex_reasoning":0.72},"keywords":{"code_keywords":["function"],"reasoning_keywords":["step by step"],"technical_keywords":["kubernetes","latency"],"simple_keywords":["hello"]}}`)
+	cfg := &ComplexityAnalyzerConfig{
+		TierBoundaries: ComplexityTierBoundaries{
+			SimpleMedium:     0.15,
+			MediumComplex:    0.35,
+			ComplexReasoning: 0.72,
+		},
+		Keywords: ComplexityEditableKeywordConfig{
+			CodeKeywords:      []string{"function"},
+			ReasoningKeywords: []string{"step by step"},
+			TechnicalKeywords: []string{"kubernetes", "latency"},
+			SimpleKeywords:    []string{"hello"},
+		},
+	}
 
-	err := UpdateComplexityAnalyzerConfigRaw(ctx, store, raw)
+	err := store.UpdateComplexityAnalyzerConfig(ctx, cfg)
 	require.NoError(t, err)
 
 	governanceConfig, err := store.GetGovernanceConfig(ctx)

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -134,6 +134,8 @@ type ConfigStore interface {
 	// Config CRUD
 	GetConfig(ctx context.Context, key string) (*tables.TableGovernanceConfig, error)
 	UpdateConfig(ctx context.Context, config *tables.TableGovernanceConfig, tx ...*gorm.DB) error
+	GetComplexityAnalyzerConfig(ctx context.Context) (*ComplexityAnalyzerConfig, error)
+	UpdateComplexityAnalyzerConfig(ctx context.Context, config *ComplexityAnalyzerConfig) error
 
 	// Plugins CRUD
 	GetPlugins(ctx context.Context) ([]*tables.TablePlugin, error)

--- a/framework/go.mod
+++ b/framework/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	cloud.google.com/go/storage v1.61.3
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.3
+	github.com/google/cel-go v0.26.1
 	github.com/google/uuid v1.6.0
 	github.com/maximhq/bifrost/core v1.5.4
 	github.com/pinecone-io/go-pinecone/v5 v5.3.0
@@ -35,6 +36,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
@@ -75,6 +77,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
+	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tidwall/sjson v1.2.5 // indirect
@@ -89,6 +92,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.starlark.net v0.0.0-20260102030733-3fee463870c9 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20260316180232-0b37fe3546d5 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/framework/go.sum
+++ b/framework/go.sum
@@ -43,6 +43,7 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
+github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
@@ -187,6 +188,7 @@ github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9v
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/google/cel-go v0.26.1 h1:iPbVVEdkhTX++hpe3lzSk7D3G3QSYqLGoHOcEio+UXQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
@@ -274,6 +276,7 @@ github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qq
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
+github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -343,6 +346,7 @@ golang.org/x/arch v0.23.0 h1:lKF64A2jF6Zd8L0knGltUnegD62JMFBiCPBmQpToHhg=
 golang.org/x/arch v0.23.0/go.mod h1:dNHoOeKiyja7GTvF9NJS1l3Z2yntpQNzgrjh1cU103A=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
+golang.org/x/exp v0.0.0-20251113190631-e25ba8c21ef6 h1:zfMcR1Cs4KNuomFFgGefv5N0czO2XZpUbxGUy8i8ug0=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=

--- a/plugins/governance/complexity/analyzer.go
+++ b/plugins/governance/complexity/analyzer.go
@@ -137,15 +137,15 @@ func (a *ComplexityAnalyzer) Analyze(input ComplexityInput) *ComplexityResult {
 	tier := a.classifyTier(finalScore)
 	overrideReason := ""
 	if strongCount >= 2 {
-		if tier != "REASONING" {
-			overrideReason = "strong_reasoning_count"
+		if tier != TierReasoning {
+			overrideReason = TierOverrideReasonStrongReasoningCount
 		}
-		tier = "REASONING"
+		tier = TierReasoning
 	} else if strongCount >= 1 && (userCodeScore > 0.5 || userTechnicalScore > 0.5) {
-		if tier != "REASONING" {
-			overrideReason = "strong_reasoning_with_signal"
+		if tier != TierReasoning {
+			overrideReason = TierOverrideReasonStrongReasoningWithSignal
 		}
-		tier = "REASONING"
+		tier = TierReasoning
 	}
 
 	return &ComplexityResult{
@@ -239,12 +239,12 @@ func isReferentialFollowup(signals textSignalCounts, lastMsgScore, convScore flo
 func (a *ComplexityAnalyzer) classifyTier(score float64) string {
 	switch {
 	case score < a.tierBoundaries.SimpleMedium:
-		return "SIMPLE"
+		return TierSimple
 	case score < a.tierBoundaries.MediumComplex:
-		return "MEDIUM"
+		return TierMedium
 	case score < a.tierBoundaries.ComplexReasoning:
-		return "COMPLEX"
+		return TierComplex
 	default:
-		return "REASONING"
+		return TierReasoning
 	}
 }

--- a/plugins/governance/complexity/config.go
+++ b/plugins/governance/complexity/config.go
@@ -26,7 +26,7 @@ type ComplexityContributions struct {
 type ComplexityResult struct {
 	// Weighted total score (0.0–1.0)
 	Score float64
-	// Computed tier: "SIMPLE", "MEDIUM", "COMPLEX", or "REASONING"
+	// Computed tier. See the Tier* constants in this package.
 	Tier string
 
 	// Individual dimension scores used in the weighted sum (0.0–1.0 each)
@@ -60,12 +60,21 @@ type ComplexityResult struct {
 
 	// TierOverrideReason is set when the tier was promoted past what the
 	// numeric score alone would classify. Empty when tier came from boundaries.
-	// Values: "strong_reasoning_count" (≥2 strong reasoning keywords) or
-	// "strong_reasoning_with_signal" (≥1 strong reasoning keyword plus
-	// code/technical signal). Used by the routing log so readers can see why
-	// a low-score prompt still ended up in REASONING.
+	// Values correspond to the TierOverrideReason* constants in this package.
+	// Used by the routing log so readers can see why a low-score prompt still
+	// ended up in REASONING.
 	TierOverrideReason string
 }
+
+const (
+	TierSimple    = "SIMPLE"
+	TierMedium    = "MEDIUM"
+	TierComplex   = "COMPLEX"
+	TierReasoning = "REASONING"
+
+	TierOverrideReasonStrongReasoningCount      = "strong_reasoning_count"
+	TierOverrideReasonStrongReasoningWithSignal = "strong_reasoning_with_signal"
+)
 
 // TierBoundaries defines the score thresholds for tier classification.
 type TierBoundaries = configstore.ComplexityTierBoundaries

--- a/plugins/governance/complexity/format.go
+++ b/plugins/governance/complexity/format.go
@@ -6,35 +6,14 @@ import (
 	"strings"
 )
 
-// FormatLog renders a human-readable, multi-line summary of the complexity
-// analysis for the routing engine log. The primary line carries
-// tier/score/word-count/non-zero match counts; conditional annotation lines
-// are appended only when they actually apply (tier override, output floor,
-// referential followup, conversation blending). The full scoring internals
-// (dimensions, contributions, dampener) are emitted separately by FormatDebug
+// FormatLog renders the concise routing-engine log summary for complexity
+// analysis. Detailed scoring internals are emitted separately by FormatDebug
 // for engineer-level debug logs.
 func FormatLog(result *ComplexityResult) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Complexity: tier=%s score=%.2f words=%d matches=[%s]",
 		result.Tier, result.Score, result.WordCount,
 		formatMatchCounts(result))
-
-	if result.TierOverrideReason != "" {
-		fmt.Fprintf(&b, "\n  └─ tier override: %s (%d reasoning keyword match%s → promoted to REASONING)",
-			result.TierOverrideReason, result.ReasoningMatchCount,
-			pluralS(result.ReasoningMatchCount))
-	}
-	if result.OutputFloorApplied {
-		fmt.Fprintf(&b, "\n  └─ output-floor applied: strong output signals set minimum score %.2f",
-			result.OutputFloorMinScore)
-	}
-	if result.ReferentialFollowup {
-		fmt.Fprintf(&b, "\n  └─ referential-followup: short ask interpreted as continuation of prior turn")
-	}
-	if result.ConversationBlend > result.LastMessageScore+0.02 {
-		fmt.Fprintf(&b, "\n  └─ conversation-blended: last-message %.2f → %.2f (prior turns pulled score up)",
-			result.LastMessageScore, result.ConversationBlend)
-	}
 	return b.String()
 }
 
@@ -145,11 +124,4 @@ func formatMatchCounts(result *ComplexityResult) string {
 		return "none"
 	}
 	return strings.Join(parts, " ")
-}
-
-func pluralS(n int) string {
-	if n == 1 {
-		return ""
-	}
-	return "es"
 }

--- a/plugins/governance/complexity_extract.go
+++ b/plugins/governance/complexity_extract.go
@@ -17,20 +17,16 @@ import (
 // must be text-only for this POC. Mixed or non-text user content is skipped so we do not
 // accidentally reroute embeddings, images, speech, or multimodal chat/responses traffic.
 //
-// Streaming request types intentionally fall through to the default case here. Complexity
-// routing only applies to the initial request payload we inspect in the transport pre-hook;
-// the streaming response path continues separately via HTTPTransportStreamChunkHook, which
-// operates on output chunks rather than rebuilding ComplexityInput from streamed content.
-// If we ever want complexity coverage for ChatCompletionStreamRequest,
-// TextCompletionStreamRequest, or ResponsesStreamRequest, add explicit handling for those
-// request types here instead of relying on the default fallthrough.
+// Streaming request types use the same initial request payload shapes as their non-streaming
+// counterparts, so complexity analysis can run before the provider call regardless of whether
+// the downstream response is streamed back over SSE.
 func buildComplexityInput(ctx *schemas.BifrostContext, body map[string]any) (complexity.ComplexityInput, bool) {
 	switch requestTypeFromContext(ctx) {
-	case schemas.ChatCompletionRequest:
+	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
 		return extractFromChatCompletion(body)
-	case schemas.TextCompletionRequest:
+	case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
 		return extractFromTextCompletion(body)
-	case schemas.ResponsesRequest:
+	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest:
 		// OpenAI-style responses traffic uses "input", while Anthropic-native messages are routed
 		// through the same request type by the integration layer. GenAI native requests use
 		// "contents", and Bedrock Converse uses "messages" with Bedrock-style content blocks.

--- a/plugins/governance/complexity_extract_test.go
+++ b/plugins/governance/complexity_extract_test.go
@@ -267,6 +267,78 @@ func TestBuildComplexityInput_ResponsesIgnoresAssistantOutputHistory(t *testing.
 	assert.Equal(t, "Review carefully", input.SystemText)
 }
 
+func TestBuildComplexityInput_SupportsStreamingRequestTypes(t *testing.T) {
+	tests := []struct {
+		name         string
+		requestType  schemas.RequestType
+		body         map[string]any
+		wantLastUser string
+		wantSystem   string
+	}{
+		{
+			name:        "chat_completion_stream",
+			requestType: schemas.ChatCompletionStreamRequest,
+			body: map[string]any{
+				"stream": true,
+				"messages": []interface{}{
+					map[string]interface{}{
+						"role":    "system",
+						"content": "Be concise",
+					},
+					map[string]interface{}{
+						"role":    "user",
+						"content": "Explain vector clocks",
+					},
+				},
+			},
+			wantLastUser: "Explain vector clocks",
+			wantSystem:   "Be concise",
+		},
+		{
+			name:        "text_completion_stream",
+			requestType: schemas.TextCompletionStreamRequest,
+			body: map[string]any{
+				"stream": true,
+				"prompt": "Write a short summary of this changelog",
+			},
+			wantLastUser: "Write a short summary of this changelog",
+		},
+		{
+			name:        "responses_stream",
+			requestType: schemas.ResponsesStreamRequest,
+			body: map[string]any{
+				"stream":       true,
+				"instructions": "Answer carefully",
+				"input": []interface{}{
+					map[string]interface{}{
+						"role": "user",
+						"content": []interface{}{
+							map[string]interface{}{
+								"type": "input_text",
+								"text": "Compare Go channels and mutexes",
+							},
+						},
+					},
+				},
+			},
+			wantLastUser: "Compare Go channels and mutexes",
+			wantSystem:   "Answer carefully",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeyHTTPRequestType, tt.requestType)
+
+			input, ok := buildComplexityInput(ctx, tt.body)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantLastUser, input.LastUserText)
+			assert.Equal(t, tt.wantSystem, input.SystemText)
+		})
+	}
+}
+
 func TestBuildComplexityInput_SkipsUnsupportedRequestTypesEvenWhenTextIsPresent(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/plugins/governance/http_transport_prehook_test.go
+++ b/plugins/governance/http_transport_prehook_test.go
@@ -442,12 +442,11 @@ func TestResolveAnalyzerConfigFromStoreOrArg_PrefersConfiguredArgOverStoredConfi
 		},
 	}, logger)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
 
 	storedCfg := complexity.DefaultAnalyzerConfig()
 	storedCfg.TierBoundaries.SimpleMedium = 0.22
-	storedRaw, err := json.Marshal(storedCfg)
-	require.NoError(t, err)
-	require.NoError(t, configstore.UpdateComplexityAnalyzerConfigRaw(ctx, store, storedRaw))
+	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, &storedCfg))
 
 	argCfg := complexity.DefaultAnalyzerConfig()
 	argCfg.TierBoundaries.SimpleMedium = 0.11
@@ -471,12 +470,11 @@ func TestResolveAnalyzerConfigFromStoreOrArg_InvalidConfiguredArgFallsBackToStor
 		},
 	}, logger)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
 
 	storedCfg := complexity.DefaultAnalyzerConfig()
 	storedCfg.TierBoundaries.SimpleMedium = 0.22
-	storedRaw, err := json.Marshal(storedCfg)
-	require.NoError(t, err)
-	require.NoError(t, configstore.UpdateComplexityAnalyzerConfigRaw(ctx, store, storedRaw))
+	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, &storedCfg))
 
 	// Invalid config: SimpleMedium > MediumComplex violates ordering constraint
 	argCfg := complexity.DefaultAnalyzerConfig()
@@ -501,12 +499,11 @@ func TestResolveAnalyzerConfigFromStoreOrArg_FallsBackToStoredConfigWhenArgMissi
 		},
 	}, logger)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close(ctx) })
 
 	storedCfg := complexity.DefaultAnalyzerConfig()
 	storedCfg.TierBoundaries.SimpleMedium = 0.22
-	storedRaw, err := json.Marshal(storedCfg)
-	require.NoError(t, err)
-	require.NoError(t, configstore.UpdateComplexityAnalyzerConfigRaw(ctx, store, storedRaw))
+	require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, &storedCfg))
 
 	resolved := resolveAnalyzerConfigFromStoreOrArg(ctx, logger, store, &configstore.GovernanceConfig{})
 	require.NotNil(t, resolved)
@@ -678,7 +675,11 @@ func TestHTTPTransportPreHook_InvalidComplexityConfigFallsBackToDefaults(t *test
 	}
 	require.NoError(t, json.Unmarshal(req.Body, &payload))
 	require.Equal(t, "openai/gpt-4o-mini", payload.Model)
-	require.NotEmpty(t, logger.warnings)
+	require.Contains(
+		t,
+		strings.Join(logger.warnings, "\n"),
+		"invalid complexity analyzer config from provided governance config",
+	)
 }
 
 func TestHTTPTransportPreHook_ComplexitySkippedWhenNoRulesReferenceIt(t *testing.T) {

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -375,7 +375,7 @@ func resolveAnalyzerConfigFromStoreOrArg(
 		}
 	}
 	if configStore != nil {
-		cfg, err := configstore.GetComplexityAnalyzerConfig(ctx, configStore)
+		cfg, err := configStore.GetComplexityAnalyzerConfig(ctx)
 		if err != nil {
 			if logger != nil {
 				logger.Warn("failed to load complexity analyzer config from store, falling back to configured/default values: %v", err)
@@ -944,7 +944,14 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 		computeComplexity = func() *complexity.ComplexityResult {
 			if input, ok := buildComplexityInput(ctx, body); ok {
 				result := analyzer.Analyze(input)
-				p.logger.Debug("[Governance] Complexity analysis details: %s", complexity.FormatDebug(result))
+				if p.logger != nil {
+					p.logger.Debug(
+						"[Governance] Complexity analysis details: tier=%s score=%.2f words=%d",
+						result.Tier,
+						result.Score,
+						result.WordCount,
+					)
+				}
 				ctx.AppendRoutingEngineLog(schemas.RoutingEngineRoutingRule, complexity.FormatLog(result))
 				return result
 			}

--- a/plugins/governance/test_utils.go
+++ b/plugins/governance/test_utils.go
@@ -243,7 +243,6 @@ func assertRateLimitInfo(t *testing.T, result *EvaluationResult) {
 	assert.NotNil(t, result.RateLimitInfo, "RateLimitInfo should be present in result")
 }
 
-
 func buildModelConfig(id, modelName string, provider *string, budget *configstoreTables.TableBudget, rateLimit *configstoreTables.TableRateLimit) *configstoreTables.TableModelConfig {
 	mc := &configstoreTables.TableModelConfig{
 		ID:        id,

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -341,7 +341,7 @@ func (h *GovernanceHandler) getComplexityAnalyzerConfig(ctx *fasthttp.RequestCtx
 		return
 	}
 
-	cfg, err := configstore.GetComplexityAnalyzerConfig(ctx, h.configStore)
+	cfg, err := h.configStore.GetComplexityAnalyzerConfig(ctx)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get complexity analyzer config: %v", err))
 		return
@@ -378,19 +378,24 @@ func (h *GovernanceHandler) updateComplexityAnalyzerConfig(ctx *fasthttp.Request
 		return
 	}
 
-	previousRaw, err := configstore.GetComplexityAnalyzerConfigRaw(ctx, h.configStore)
+	previousConfigEntry, err := getComplexityAnalyzerConfigEntry(ctx, h.configStore)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to read existing complexity analyzer config: %v", err))
 		return
 	}
 
-	if err := configstore.UpdateComplexityAnalyzerConfig(ctx, h.configStore, normalized); err != nil {
+	if err := h.configStore.UpdateComplexityAnalyzerConfig(ctx, normalized); err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to update complexity analyzer config: %v", err))
+		return
+	}
+	writtenConfigEntry, err := getComplexityAnalyzerConfigEntry(ctx, h.configStore)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to read updated complexity analyzer config: %v", err))
 		return
 	}
 
 	if err := h.governanceManager.ReloadComplexityAnalyzerConfig(ctx, normalized); err != nil {
-		if rollbackErr := rollbackComplexityAnalyzerConfig(ctx, h.configStore, previousRaw); rollbackErr != nil {
+		if rollbackErr := rollbackComplexityAnalyzerConfig(ctx, h.configStore, writtenConfigEntry, previousConfigEntry); rollbackErr != nil {
 			logger.Error("failed to rollback complexity analyzer config after reload failure: %v", rollbackErr)
 		}
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to reload complexity analyzer config: %v", err))
@@ -410,19 +415,24 @@ func (h *GovernanceHandler) resetComplexityAnalyzerConfig(ctx *fasthttp.RequestC
 
 	defaults := complexity.DefaultAnalyzerConfig()
 
-	previousRaw, err := configstore.GetComplexityAnalyzerConfigRaw(ctx, h.configStore)
+	previousConfigEntry, err := getComplexityAnalyzerConfigEntry(ctx, h.configStore)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to read existing complexity analyzer config: %v", err))
 		return
 	}
 
-	if err := configstore.UpdateComplexityAnalyzerConfig(ctx, h.configStore, &defaults); err != nil {
+	if err := h.configStore.UpdateComplexityAnalyzerConfig(ctx, &defaults); err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to persist default complexity analyzer config: %v", err))
+		return
+	}
+	writtenConfigEntry, err := getComplexityAnalyzerConfigEntry(ctx, h.configStore)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to read reset complexity analyzer config: %v", err))
 		return
 	}
 
 	if err := h.governanceManager.ReloadComplexityAnalyzerConfig(ctx, &defaults); err != nil {
-		if rollbackErr := rollbackComplexityAnalyzerConfig(ctx, h.configStore, previousRaw); rollbackErr != nil {
+		if rollbackErr := rollbackComplexityAnalyzerConfig(ctx, h.configStore, writtenConfigEntry, previousConfigEntry); rollbackErr != nil {
 			logger.Error("failed to rollback complexity analyzer config after reset reload failure: %v", rollbackErr)
 		}
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to reload complexity analyzer config: %v", err))
@@ -432,14 +442,52 @@ func (h *GovernanceHandler) resetComplexityAnalyzerConfig(ctx *fasthttp.RequestC
 	SendJSON(ctx, &defaults)
 }
 
-func rollbackComplexityAnalyzerConfig(ctx context.Context, store configstore.ConfigStore, previousRaw json.RawMessage) error {
-	if len(previousRaw) == 0 {
+func getComplexityAnalyzerConfigEntry(ctx context.Context, store configstore.ConfigStore) (*configstoreTables.TableGovernanceConfig, error) {
+	configEntry, err := store.GetConfig(ctx, configstoreTables.ConfigComplexityAnalyzerConfigKey)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return configEntry, nil
+}
+
+func rollbackComplexityAnalyzerConfig(
+	ctx context.Context,
+	store configstore.ConfigStore,
+	writtenConfigEntry *configstoreTables.TableGovernanceConfig,
+	previousConfigEntry *configstoreTables.TableGovernanceConfig,
+) error {
+	currentConfigEntry, err := getComplexityAnalyzerConfigEntry(ctx, store)
+	if err != nil {
+		return fmt.Errorf("failed to read current complexity analyzer config for rollback: %w", err)
+	}
+	if !sameComplexityAnalyzerConfigValue(currentConfigEntry, writtenConfigEntry) {
+		return nil
+	}
+	if previousConfigEntry == nil || previousConfigEntry.Value == "" {
 		return store.UpdateConfig(ctx, &configstoreTables.TableGovernanceConfig{
 			Key:   configstoreTables.ConfigComplexityAnalyzerConfigKey,
 			Value: "",
 		})
 	}
-	return configstore.UpdateComplexityAnalyzerConfigRaw(ctx, store, previousRaw)
+	return store.UpdateConfig(ctx, &configstoreTables.TableGovernanceConfig{
+		Key:   configstoreTables.ConfigComplexityAnalyzerConfigKey,
+		Value: previousConfigEntry.Value,
+	})
+}
+
+func sameComplexityAnalyzerConfigValue(a, b *configstoreTables.TableGovernanceConfig) bool {
+	aValue := ""
+	if a != nil {
+		aValue = a.Value
+	}
+	bValue := ""
+	if b != nil {
+		bValue = b.Value
+	}
+	return aValue == bValue
 }
 
 // Virtual Key CRUD Operations

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -48,10 +48,14 @@ type mockGovernanceManagerForBoundaries struct {
 	GovernanceManager
 	reloadAnalyzerCalls int
 	reloadErr           error
+	onReload            func(*complexity.AnalyzerConfig)
 }
 
 func (m *mockGovernanceManagerForBoundaries) ReloadComplexityAnalyzerConfig(ctx context.Context, config *complexity.AnalyzerConfig) error {
 	m.reloadAnalyzerCalls++
+	if m.onReload != nil {
+		m.onReload(config)
+	}
 	return m.reloadErr
 }
 
@@ -76,6 +80,29 @@ func (m *mockConfigStoreForBoundaries) GetConfig(_ context.Context, key string) 
 		return nil, err
 	}
 	return &configstoreTables.TableGovernanceConfig{Key: key, Value: string(raw)}, nil
+}
+
+func (m *mockConfigStoreForBoundaries) GetComplexityAnalyzerConfig(_ context.Context) (*configstore.ComplexityAnalyzerConfig, error) {
+	if m.analyzerConfig == nil {
+		return nil, nil
+	}
+	normalized, err := complexity.ValidateAndNormalize(m.analyzerConfig)
+	if err != nil {
+		return nil, err
+	}
+	return normalized, nil
+}
+
+func (m *mockConfigStoreForBoundaries) UpdateComplexityAnalyzerConfig(_ context.Context, cfg *configstore.ComplexityAnalyzerConfig) error {
+	if cfg == nil {
+		return errors.New("complexity analyzer config is nil")
+	}
+	normalized, err := complexity.ValidateAndNormalize(cfg)
+	if err != nil {
+		return err
+	}
+	m.analyzerConfig = normalized
+	return nil
 }
 
 func (m *mockConfigStoreForBoundaries) UpdateConfig(_ context.Context, cfg *configstoreTables.TableGovernanceConfig, _ ...*gorm.DB) error {
@@ -425,6 +452,78 @@ func TestUpdateComplexityAnalyzerConfig_RollsBackStoreWhenReloadFails(t *testing
 	require.Equal(t, previous.Keywords.ReasoningKeywords, store.analyzerConfig.Keywords.ReasoningKeywords)
 	require.Equal(t, previous.Keywords.TechnicalKeywords, store.analyzerConfig.Keywords.TechnicalKeywords)
 	require.Equal(t, previous.Keywords.SimpleKeywords, store.analyzerConfig.Keywords.SimpleKeywords)
+}
+
+func TestUpdateComplexityAnalyzerConfig_DoesNotRollbackOverNewerStoredConfig(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	previous := complexity.AnalyzerConfig{
+		TierBoundaries: complexity.TierBoundaries{
+			SimpleMedium:     0.15,
+			MediumComplex:    0.35,
+			ComplexReasoning: 0.65,
+		},
+		Keywords: complexity.EditableKeywordConfig{
+			CodeKeywords:      []string{"function", "api"},
+			ReasoningKeywords: []string{"analyze"},
+			TechnicalKeywords: []string{"latency"},
+			SimpleKeywords:    []string{"what is"},
+		},
+	}
+	newer := complexity.AnalyzerConfig{
+		TierBoundaries: complexity.TierBoundaries{
+			SimpleMedium:     0.33,
+			MediumComplex:    0.55,
+			ComplexReasoning: 0.88,
+		},
+		Keywords: complexity.EditableKeywordConfig{
+			CodeKeywords:      []string{"router"},
+			ReasoningKeywords: []string{"reason"},
+			TechnicalKeywords: []string{"kubernetes"},
+			SimpleKeywords:    []string{"define"},
+		},
+	}
+	newerNormalized, err := complexity.ValidateAndNormalize(&newer)
+	require.NoError(t, err)
+
+	store := &mockConfigStoreForBoundaries{analyzerConfig: &previous}
+	manager := &mockGovernanceManagerForBoundaries{
+		reloadErr: errors.New("boom"),
+		onReload: func(_ *complexity.AnalyzerConfig) {
+			store.analyzerConfig = newerNormalized
+		},
+	}
+	h := &GovernanceHandler{
+		configStore:       store,
+		governanceManager: manager,
+	}
+
+	payload := `{
+		"tier_boundaries":{"simple_medium":0.22,"medium_complex":0.44,"complex_reasoning":0.77},
+		"keywords":{
+			"code_keywords":["function","endpoint","router"],
+			"reasoning_keywords":["step by step"],
+			"technical_keywords":["kubernetes","latency"],
+			"simple_keywords":["what is"]
+		}
+	}`
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("PUT")
+	ctx.Request.SetRequestURI("/api/governance/complexity")
+	ctx.Request.SetBodyString(payload)
+
+	h.updateComplexityAnalyzerConfig(ctx)
+
+	require.Equal(t, fasthttp.StatusInternalServerError, ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	require.Contains(t, string(ctx.Response.Body()), "failed to reload complexity analyzer config")
+	require.Equal(t, 1, manager.reloadAnalyzerCalls)
+	require.NotNil(t, store.analyzerConfig)
+	require.Equal(t, newerNormalized.TierBoundaries, store.analyzerConfig.TierBoundaries)
+	require.Equal(t, newerNormalized.Keywords.CodeKeywords, store.analyzerConfig.Keywords.CodeKeywords)
+	require.Equal(t, newerNormalized.Keywords.ReasoningKeywords, store.analyzerConfig.Keywords.ReasoningKeywords)
+	require.Equal(t, newerNormalized.Keywords.TechnicalKeywords, store.analyzerConfig.Keywords.TechnicalKeywords)
+	require.Equal(t, newerNormalized.Keywords.SimpleKeywords, store.analyzerConfig.Keywords.SimpleKeywords)
 }
 
 // Ensure mockLogger satisfies schemas.Logger (already defined in middlewares_test.go

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1469,7 +1469,7 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 			config.GovernanceConfig.ComplexityAnalyzerConfig = normalized
 			if current == nil || !reflect.DeepEqual(current, normalized) {
 				if config.ConfigStore != nil {
-					if err := configstore.UpdateComplexityAnalyzerConfig(ctx, config.ConfigStore, normalized); err != nil {
+					if err := config.ConfigStore.UpdateComplexityAnalyzerConfig(ctx, normalized); err != nil {
 						logger.Warn("failed to sync complexity analyzer config from config file: %v", err)
 					}
 				}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -380,14 +380,6 @@ import (
 	"gorm.io/gorm"
 )
 
-func mustMarshalComplexityAnalyzerConfig(t *testing.T, cfg complexity.AnalyzerConfig) json.RawMessage {
-	t.Helper()
-
-	raw, err := json.Marshal(cfg)
-	require.NoError(t, err)
-	return raw
-}
-
 // MockConfigStore implements the ConfigStore interface for testing
 type MockConfigStore struct {
 	clientConfig     *configstore.ClientConfig
@@ -633,6 +625,32 @@ func (m *MockConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) 
 // Governance config
 func (m *MockConfigStore) GetGovernanceConfig(ctx context.Context) (*configstore.GovernanceConfig, error) {
 	return m.governanceConfig, nil
+}
+
+func (m *MockConfigStore) GetComplexityAnalyzerConfig(ctx context.Context) (*configstore.ComplexityAnalyzerConfig, error) {
+	if m.governanceConfig == nil || m.governanceConfig.ComplexityAnalyzerConfig == nil {
+		return nil, nil
+	}
+	normalized := m.governanceConfig.ComplexityAnalyzerConfig.Normalized()
+	if err := normalized.Validate(); err != nil {
+		return nil, err
+	}
+	return &normalized, nil
+}
+
+func (m *MockConfigStore) UpdateComplexityAnalyzerConfig(ctx context.Context, config *configstore.ComplexityAnalyzerConfig) error {
+	if config == nil {
+		return errors.New("complexity analyzer config is nil")
+	}
+	normalized := config.Normalized()
+	if err := normalized.Validate(); err != nil {
+		return err
+	}
+	if m.governanceConfig == nil {
+		m.governanceConfig = &configstore.GovernanceConfig{}
+	}
+	m.governanceConfig.ComplexityAnalyzerConfig = &normalized
+	return nil
 }
 
 func (m *MockConfigStore) CreateBudget(ctx context.Context, budget *tables.TableBudget, tx ...*gorm.DB) error {
@@ -12565,9 +12583,7 @@ func TestSQLite_ComplexityAnalyzerConfig_FileSeeded(t *testing.T) {
 	require.Equal(t, 0.18, loadedConfig.TierBoundaries.SimpleMedium)
 	require.Equal(t, []string{"kubernetes", "latency"}, loadedConfig.Keywords.TechnicalKeywords)
 
-	storedRaw, err := configstore.GetComplexityAnalyzerConfigRaw(ctx, config.ConfigStore)
-	require.NoError(t, err)
-	stored, err := complexity.DecodeAndValidate(storedRaw)
+	stored, err := config.ConfigStore.GetComplexityAnalyzerConfig(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, stored)
 	require.Equal(t, 0.73, stored.TierBoundaries.ComplexReasoning)
@@ -12590,16 +12606,14 @@ func TestSQLite_ComplexityAnalyzerConfig_UpdatePersists(t *testing.T) {
 	cfg.TierBoundaries.SimpleMedium = 0.20
 	cfg.TierBoundaries.MediumComplex = 0.40
 	cfg.TierBoundaries.ComplexReasoning = 0.70
-	require.NoError(t, configstore.UpdateComplexityAnalyzerConfigRaw(ctx, config1.ConfigStore, mustMarshalComplexityAnalyzerConfig(t, cfg)))
+	require.NoError(t, config1.ConfigStore.UpdateComplexityAnalyzerConfig(ctx, &cfg))
 	config1.Close(ctx)
 
 	config2, err := LoadConfig(ctx, tempDir)
 	require.NoError(t, err)
 	defer config2.Close(ctx)
 
-	storedRaw, err := configstore.GetComplexityAnalyzerConfigRaw(ctx, config2.ConfigStore)
-	require.NoError(t, err)
-	stored, err := complexity.DecodeAndValidate(storedRaw)
+	stored, err := config2.ConfigStore.GetComplexityAnalyzerConfig(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, stored)
 	require.Equal(t, 0.20, stored.TierBoundaries.SimpleMedium)
@@ -12627,9 +12641,7 @@ func TestSQLite_ComplexityAnalyzerConfig_FileWinsOnRestartWhenPresent(t *testing
 	config1, err := LoadConfig(ctx, tempDir)
 	require.NoError(t, err)
 
-	storedRaw, err := configstore.GetComplexityAnalyzerConfigRaw(ctx, config1.ConfigStore)
-	require.NoError(t, err)
-	stored, err := complexity.DecodeAndValidate(storedRaw)
+	stored, err := config1.ConfigStore.GetComplexityAnalyzerConfig(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, stored, "DB should be seeded from file")
 	require.Equal(t, 0.15, stored.TierBoundaries.SimpleMedium)
@@ -12639,7 +12651,7 @@ func TestSQLite_ComplexityAnalyzerConfig_FileWinsOnRestartWhenPresent(t *testing
 	edited.TierBoundaries.SimpleMedium = 0.20
 	edited.TierBoundaries.MediumComplex = 0.45
 	edited.TierBoundaries.ComplexReasoning = 0.75
-	require.NoError(t, configstore.UpdateComplexityAnalyzerConfigRaw(ctx, config1.ConfigStore, mustMarshalComplexityAnalyzerConfig(t, edited)))
+	require.NoError(t, config1.ConfigStore.UpdateComplexityAnalyzerConfig(ctx, &edited))
 	config1.Close(ctx)
 
 	// Step 3: Restart with same file still present — file should win
@@ -12654,9 +12666,7 @@ func TestSQLite_ComplexityAnalyzerConfig_FileWinsOnRestartWhenPresent(t *testing
 	require.Equal(t, 0.35, reloadedConfig.TierBoundaries.MediumComplex)
 	require.Equal(t, 0.60, reloadedConfig.TierBoundaries.ComplexReasoning)
 
-	reloadedRaw, err := configstore.GetComplexityAnalyzerConfigRaw(ctx, config2.ConfigStore)
-	require.NoError(t, err)
-	reloaded, err := complexity.DecodeAndValidate(reloadedRaw)
+	reloaded, err := config2.ConfigStore.GetComplexityAnalyzerConfig(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 0.15, reloaded.TierBoundaries.SimpleMedium, "DB should be resynced from file when file config is present")
 }


### PR DESCRIPTION
## Summary

Moves `GetComplexityAnalyzerConfig` and `UpdateComplexityAnalyzerConfig` from package-level functions operating on a `ConfigStore` interface to methods directly on `RDBConfigStore`, and adds them to the `ConfigStore` interface. This eliminates the intermediate raw-bytes layer (`GetComplexityAnalyzerConfigRaw` / `UpdateComplexityAnalyzerConfigRaw`) so callers work with typed `*ComplexityAnalyzerConfig` values throughout. Additionally, complexity routing is extended to cover streaming request types, the rollback logic is hardened against concurrent writes, and tier string literals are replaced with named constants.

## Changes

- `GetComplexityAnalyzerConfig` and `UpdateComplexityAnalyzerConfig` are now methods on `RDBConfigStore` and declared on the `ConfigStore` interface; the raw-bytes variants and the old package-level helpers are removed.
- `GetComplexityAnalyzerConfigRaw` / `UpdateComplexityAnalyzerConfigRaw` are removed; all callers now use the typed methods directly.
- `TierSimple`, `TierMedium`, `TierComplex`, `TierReasoning`, `TierOverrideReasonStrongReasoningCount`, and `TierOverrideReasonStrongReasoningWithSignal` constants are introduced in the `complexity` package to replace inline string literals.
- Streaming request types (`ChatCompletionStreamRequest`, `TextCompletionStreamRequest`, `ResponsesStreamRequest`) are now handled in `buildComplexityInput`, enabling complexity analysis before the provider call regardless of whether the response is streamed.
- The rollback path in `updateComplexityAnalyzerConfig` and `resetComplexityAnalyzerConfig` now reads back the written entry and compares it against the current store value before rolling back, preventing a rollback from clobbering a concurrently written config.
- `FormatLog` no longer appends annotation lines for tier override, output floor, referential followup, or conversation blending; the debug logger call in `applyRoutingRules` is guarded with a nil check and simplified.
- Tests are updated to use typed structs instead of raw JSON, and mock stores implement the new interface methods.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
go test ./plugins/governance/...
go test ./transports/bifrost-http/...
```

Verify that:
- Complexity analyzer config round-trips correctly through `UpdateComplexityAnalyzerConfig` → `GetComplexityAnalyzerConfig`.
- Streaming chat, text completion, and responses requests are routed through complexity analysis.
- A reload failure does not roll back the store when a concurrent write has already replaced the written value.

## Breaking changes

- [x] Yes
- [ ] No

`GetComplexityAnalyzerConfigRaw`, `UpdateComplexityAnalyzerConfigRaw`, the package-level `GetComplexityAnalyzerConfig`, and the package-level `UpdateComplexityAnalyzerConfig` functions are removed. Any code outside this repository calling those functions must migrate to `store.GetComplexityAnalyzerConfig(ctx)` and `store.UpdateComplexityAnalyzerConfig(ctx, cfg)`. Implementations of the `ConfigStore` interface must add the two new methods.

## Related issues

## Security considerations

No new auth, secrets, or PII surface area introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable