### PR TITLE
refactor: replace WebSocket live updates with RTK Query polling on logs pages

### DIFF
--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -34,7 +34,9 @@ import type {
 	TokenHistogramResponse,
 } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
+import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
 import UserRankingsTab from "@enterprise/components/user-rankings/userRankingsTab";
+import { useLocation } from "@tanstack/react-router";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type ChartType } from "./components/charts/chartTypeToggle";
@@ -47,41 +49,6 @@ import { ProviderUsageTab } from "./components/providerUsageTab";
 
 // Type-safe parser for chart type URL state
 const toChartType = (value: string): ChartType => (value === "line" ? "line" : "bar");
-
-// Predefined time periods
-const TIME_PERIODS = [
-	{ label: "Last hour", value: "1h" },
-	{ label: "Last 6 hours", value: "6h" },
-	{ label: "Last 24 hours", value: "24h" },
-	{ label: "Last 7 days", value: "7d" },
-	{ label: "Last 30 days", value: "30d" },
-];
-
-function getTimeRangeFromPeriod(period: string): { start: number; end: number } {
-	const now = Math.floor(Date.now() / 1000);
-	switch (period) {
-		case "1h":
-			return { start: now - 3600, end: now };
-		case "6h":
-			return { start: now - 6 * 3600, end: now };
-		case "24h":
-			return { start: now - 24 * 3600, end: now };
-		case "7d":
-			return { start: now - 7 * 24 * 3600, end: now };
-		case "30d":
-			return { start: now - 30 * 24 * 3600, end: now };
-		default:
-			return { start: now - 24 * 3600, end: now };
-	}
-}
-
-// Calculate default timestamps once at module level
-const DEFAULT_END_TIME = Math.floor(Date.now() / 1000);
-const DEFAULT_START_TIME = (() => {
-	const date = new Date();
-	date.setHours(date.getHours() - 24);
-	return Math.floor(date.getTime() / 1000);
-})();
 
 const parseCsvParam = (value: string): string[] => (value ? value.split(",").filter(Boolean) : []);
 const sanitizeSeriesLabels = (values?: string[]): string[] => {
@@ -149,15 +116,18 @@ export default function DashboardPage() {
 	// MCP filter data
 	const { data: mcpFilterData } = useGetMCPAvailableFilterDataQuery();
 
-	// Period is local state only — clicking a period sets start/end in URL, but period itself
-	// is not persisted so refresh shows the actual date range rather than a stale period label
-	const [activePeriod, setActivePeriod] = useState<string | undefined>(undefined);
+	// Memoize default time range to prevent recalculation on every render
+	// This is crucial to avoid triggering refetches when the sheet opens/closes
+	const defaultTimeRange = useMemo(() => dateUtils.getDefaultTimeRange(), []);
 
+	const { search } = useLocation();
+	const hasExplicitTimeRange = (search as Record<string, unknown>)?.start_time && (search as Record<string, unknown>)?.end_time;
 	// URL state management
 	const [urlState, setUrlState] = useQueryStates(
 		{
-			start_time: parseAsInteger.withDefault(DEFAULT_START_TIME),
-			end_time: parseAsInteger.withDefault(DEFAULT_END_TIME),
+			period: parseAsString.withDefault(hasExplicitTimeRange ? "" : "1h").withOptions({ clearOnDefault: false }),
+			start_time: parseAsInteger.withDefault(defaultTimeRange.startTime),
+			end_time: parseAsInteger.withDefault(defaultTimeRange.endTime),
 			tab: parseAsString.withDefault("overview"),
 			virtual_key_ids: parseAsString.withDefault(""),
 			providers: parseAsString.withDefault(""),
@@ -224,13 +194,22 @@ export default function DashboardPage() {
 			...(selectedProviders.length > 0 && { providers: selectedProviders }),
 			...(selectedModels.length > 0 && { models: selectedModels }),
 			...(selectedKeyIds.length > 0 && { selected_key_ids: selectedKeyIds }),
-			...(selectedVirtualKeyIds.length > 0 && { virtual_key_ids: selectedVirtualKeyIds }),
+			...(selectedVirtualKeyIds.length > 0 && {
+				virtual_key_ids: selectedVirtualKeyIds,
+			}),
 			...(selectedTypes.length > 0 && { objects: selectedTypes }),
 			...(selectedStatuses.length > 0 && { status: selectedStatuses }),
-			...(selectedRoutingRuleIds.length > 0 && { routing_rule_ids: selectedRoutingRuleIds }),
-			...(selectedRoutingEngines.length > 0 && { routing_engine_used: selectedRoutingEngines }),
+			...(selectedRoutingRuleIds.length > 0 && {
+				routing_rule_ids: selectedRoutingRuleIds,
+			}),
+			...(selectedRoutingEngines.length > 0 && {
+				routing_engine_used: selectedRoutingEngines,
+			}),
 			...(missingCostOnly && { missing_cost_only: true }),
-			...(metadataFilters && Object.keys(metadataFilters).length > 0 && { metadata_filters: metadataFilters }),
+			...(metadataFilters &&
+				Object.keys(metadataFilters).length > 0 && {
+					metadata_filters: metadataFilters,
+				}),
 		}),
 		[
 			urlState.start_time,
@@ -253,8 +232,12 @@ export default function DashboardPage() {
 		() => ({
 			start_time: dateUtils.toISOString(urlState.start_time),
 			end_time: dateUtils.toISOString(urlState.end_time),
-			...(selectedMcpToolNames.length > 0 && { tool_names: selectedMcpToolNames }),
-			...(selectedMcpServerLabels.length > 0 && { server_labels: selectedMcpServerLabels }),
+			...(selectedMcpToolNames.length > 0 && {
+				tool_names: selectedMcpToolNames,
+			}),
+			...(selectedMcpServerLabels.length > 0 && {
+				server_labels: selectedMcpServerLabels,
+			}),
 		}),
 		[urlState.start_time, urlState.end_time, selectedMcpToolNames, selectedMcpServerLabels],
 	);
@@ -520,12 +503,13 @@ export default function DashboardPage() {
 	// Adapter: converts a full LogFilters object to dashboard's CSV-based URL state
 	const setFilters = useCallback(
 		(newFilters: LogFilters) => {
-			if (newFilters.start_time !== undefined || newFilters.end_time !== undefined) {
-				setActivePeriod(undefined);
-			}
+			const newStartTime = newFilters.start_time ? dateUtils.toUnixTimestamp(new Date(newFilters.start_time)) : undefined;
+			const newEndTime = newFilters.end_time ? dateUtils.toUnixTimestamp(new Date(newFilters.end_time)) : undefined;
+			const timeChanged = newStartTime !== urlState.start_time || newEndTime !== urlState.end_time;
 			setUrlState({
-				start_time: newFilters.start_time ? dateUtils.toUnixTimestamp(new Date(newFilters.start_time)) : undefined,
-				end_time: newFilters.end_time ? dateUtils.toUnixTimestamp(new Date(newFilters.end_time)) : undefined,
+				...(timeChanged && { period: "" }),
+				start_time: newStartTime,
+				end_time: newEndTime,
 				providers: (newFilters.providers || []).join(","),
 				models: (newFilters.models || []).join(","),
 				selected_key_ids: (newFilters.selected_key_ids || []).join(","),
@@ -541,7 +525,7 @@ export default function DashboardPage() {
 						: "",
 			});
 		},
-		[setUrlState],
+		[setUrlState, urlState.start_time, urlState.end_time],
 	);
 
 	// Date range for picker
@@ -556,9 +540,12 @@ export default function DashboardPage() {
 	const handlePeriodChange = useCallback(
 		(period: string | undefined) => {
 			if (!period) return;
-			const { start, end } = getTimeRangeFromPeriod(period);
-			setActivePeriod(period);
-			setUrlState({ start_time: start, end_time: end });
+			const { from, to } = getRangeForPeriod(period);
+			setUrlState({
+				period,
+				start_time: Math.floor(from.getTime() / 1000),
+				end_time: Math.floor(to.getTime() / 1000),
+			});
 		},
 		[setUrlState],
 	);
@@ -566,8 +553,8 @@ export default function DashboardPage() {
 	const handleDateRangeChange = useCallback(
 		(range: { from?: Date; to?: Date }) => {
 			if (!range.from || !range.to) return;
-			setActivePeriod(undefined);
 			setUrlState({
+				period: "",
 				start_time: dateUtils.toUnixTimestamp(range.from),
 				end_time: dateUtils.toUnixTimestamp(range.to),
 			});
@@ -770,7 +757,7 @@ export default function DashboardPage() {
 							dateTime={dateRange}
 							onDateTimeUpdate={handleDateRangeChange}
 							preDefinedPeriods={TIME_PERIODS}
-							predefinedPeriod={activePeriod}
+							predefinedPeriod={urlState.period || undefined}
 							onPredefinedPeriodChange={handlePeriodChange}
 							triggerTestId="dashboard-filter-daterange"
 							popupAlignment="end"

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -10,1122 +10,804 @@ import FullPageLoader from "@/components/fullPageLoader";
 import { useColumnConfig } from "@/components/table";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { useWebSocket } from "@/hooks/useWebSocket";
 import {
-  getErrorMessage,
-  useDeleteLogsMutation,
-  useGetAvailableFilterDataQuery,
-  useLazyGetLogsHistogramQuery,
-  useLazyGetLogsQuery,
-  useLazyGetLogsStatsQuery,
+	getErrorMessage,
+	useDeleteLogsMutation,
+	useGetAvailableFilterDataQuery,
+	useGetLogsHistogramQuery,
+	useGetLogsQuery,
+	useGetLogsStatsQuery,
 } from "@/lib/store";
-import { useLazyGetLogByIdQuery } from "@/lib/store/apis/logsApi";
-import type {
-  ChatMessage,
-  ChatMessageContent,
-  ContentBlock,
-  LogEntry,
-  LogFilters,
-  LogsHistogramResponse,
-  LogStats,
-  Pagination,
-} from "@/lib/types/logs";
+import { useLazyGetLogByIdQuery, useLazyGetLogsQuery } from "@/lib/store/apis/logsApi";
+import type { LogEntry, LogFilters, Pagination } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
 import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
+import { getRangeForPeriod } from "@/lib/utils/timeRange";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import NumberFlow from "@number-flow/react";
+import { useLocation } from "@tanstack/react-router";
 import { AlertCircle, BarChart, CheckCircle, Clock, DollarSign, Hash, Info } from "lucide-react";
 import { parseAsArrayOf, parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export default function LogsPage() {
-  const [logs, setLogs] = useState<LogEntry[]>([]);
-  const [totalItems, setTotalItems] = useState(0); // changes with filters
-  const [stats, setStats] = useState<LogStats | null>(null);
-  const [histogram, setHistogram] = useState<LogsHistogramResponse | null>(null);
-  const [initialLoading, setInitialLoading] = useState(true); // on initial load
-  const [fetchingLogs, setFetchingLogs] = useState(false); // on pagination/filters change
-  const [fetchingStats, setFetchingStats] = useState(false); // on stats fetch
-  const [fetchingHistogram, setFetchingHistogram] = useState(false); // on histogram fetch
-  const [error, setError] = useState<string | null>(null);
-  const [showEmptyState, setShowEmptyState] = useState(false);
-
-  const hasDeleteAccess = useRbac(RbacResource.Logs, RbacOperation.Delete);
-
-  // RTK Query lazy hooks for manual triggering
-  const [triggerGetLogs] = useLazyGetLogsQuery();
-  const [triggerGetStats] = useLazyGetLogsStatsQuery();
-  const [triggerGetHistogram] = useLazyGetLogsHistogramQuery();
-  const [deleteLogs] = useDeleteLogsMutation();
-
-  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
-  const [sessionHighlightedLogId, setSessionHighlightedLogId] = useState<string | null>(null);
-  // Stable handler so SessionDetailsSheet's loadSessionPage useCallback doesn't
-  // recreate on every parent re-render. Without this, every live WebSocket log
-  // tick would re-render LogsPage, hand the sheet a fresh inline arrow, recreate
-  // loadSessionPage, and trip the reset effect — wiping sessionLogs and
-  // refetching from offset 0 while the sheet is open.
-  const handleSessionSheetOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      setSelectedSessionId(null);
-      setSessionHighlightedLogId(null);
-    }
-  }, []);
-  const [isChartOpen, setIsChartOpen] = useState(true);
-  const [triggerGetLogById] = useLazyGetLogByIdQuery();
-  const [fetchedLog, setFetchedLog] = useState<LogEntry | null>(null);
-
-  // Debouncing for streaming updates (client-side)
-  const streamingUpdateTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
-
-  // Track if user has manually modified the time range
-  const userModifiedTimeRange = useRef<boolean>(false);
-
-  // Capture initial defaults on mount to detect shared URLs with custom time ranges
-  const initialDefaults = useRef(dateUtils.getDefaultTimeRange());
-
-  // Memoize default time range to prevent recalculation on every render
-  // This is crucial to avoid triggering refetches when the sheet opens/closes
-  const defaultTimeRange = useMemo(() => dateUtils.getDefaultTimeRange(), []);
-
-  // Get fresh default time range for refresh logic
-  const getDefaultTimeRange = () => dateUtils.getDefaultTimeRange();
-
-  // URL state management with nuqs - all filters and pagination in URL
-  const [urlState, setUrlState] = useQueryStates(
-    {
-      parent_request_id: parseAsString.withDefault(""),
-      providers: parseAsArrayOf(parseAsString).withDefault([]),
-      models: parseAsArrayOf(parseAsString).withDefault([]),
-      aliases: parseAsArrayOf(parseAsString).withDefault([]),
-      status: parseAsArrayOf(parseAsString).withDefault([]),
-      objects: parseAsArrayOf(parseAsString).withDefault([]),
-      selected_key_ids: parseAsArrayOf(parseAsString).withDefault([]),
-      virtual_key_ids: parseAsArrayOf(parseAsString).withDefault([]),
-      routing_rule_ids: parseAsArrayOf(parseAsString).withDefault([]),
-      routing_engine_used: parseAsArrayOf(parseAsString).withDefault([]),
-      user_ids: parseAsArrayOf(parseAsString).withDefault([]),
-      team_ids: parseAsArrayOf(parseAsString).withDefault([]),
-      customer_ids: parseAsArrayOf(parseAsString).withDefault([]),
-      business_unit_ids: parseAsArrayOf(parseAsString).withDefault([]),
-      content_search: parseAsString.withDefault(""),
-      start_time: parseAsInteger.withDefault(defaultTimeRange.startTime),
-      end_time: parseAsInteger.withDefault(defaultTimeRange.endTime),
-      limit: parseAsInteger.withDefault(25), // Default fallback, actual value calculated based on table height
-      offset: parseAsInteger.withDefault(0),
-      sort_by: parseAsString.withDefault("timestamp"),
-      order: parseAsString.withDefault("desc"),
-      live_enabled: parseAsBoolean.withDefault(true),
-      missing_cost_only: parseAsBoolean.withDefault(false),
-      metadata_filters: parseAsString.withDefault(""),
-      selected_log: parseAsString.withDefault(""),
-    },
-    {
-      history: "push",
-      shallow: false,
-    },
-  );
-
-  // Derive selectedLog: find in current logs array, or fetch by ID from API
-  const selectedLogId = urlState.selected_log || null;
-  const selectedLogFromData = useMemo(
-    () => (selectedLogId ? (logs.find((l) => l.id === selectedLogId) ?? null) : null),
-    [selectedLogId, logs],
-  );
-
-  const activeLogFetchId = useRef<string | null>(null);
-  useEffect(() => {
-    if (!selectedLogId || selectedLogFromData) {
-      setFetchedLog(null);
-      activeLogFetchId.current = null;
-      return;
-    }
-    // Track which log ID this fetch is for to prevent stale responses
-    const fetchId = selectedLogId;
-    activeLogFetchId.current = fetchId;
-    triggerGetLogById(selectedLogId).then((result) => {
-      if (activeLogFetchId.current === fetchId) {
-        if (result.data) {
-          setFetchedLog(result.data);
-        } else if (result.error) {
-          setError(getErrorMessage(result.error));
-        }
-      }
-    });
-  }, [selectedLogId, selectedLogFromData, triggerGetLogById]);
-
-  const selectedLog = selectedLogFromData ?? fetchedLog;
-
-  // Refresh time range defaults on page focus/visibility
-  useEffect(() => {
-    const refreshDefaultsIfStale = () => {
-      // Skip refresh if user has manually modified the time range
-      if (userModifiedTimeRange.current) {
-        return;
-      }
-
-      // Check if current time range matches the initial defaults (within tolerance)
-      const startTimeDiff = Math.abs(urlState.start_time - initialDefaults.current.startTime);
-      const endTimeDiff = Math.abs(urlState.end_time - initialDefaults.current.endTime);
-      const tolerance = 5; // 5 seconds tolerance for slight timing differences
-
-      // Only refresh if current values match the initial defaults
-      // This preserves shared URLs with custom time ranges
-      if (startTimeDiff <= tolerance && endTimeDiff <= tolerance) {
-        const defaults = getDefaultTimeRange();
-        const currentEndDiff = Math.abs(urlState.end_time - defaults.endTime);
-        // If end time is more than 5 minutes old, refresh both
-        if (currentEndDiff > 300) {
-          setUrlState({
-            start_time: defaults.startTime,
-            end_time: defaults.endTime,
-          });
-          // Update baseline so subsequent focus events compare against refreshed defaults
-          initialDefaults.current.startTime = defaults.startTime;
-          initialDefaults.current.endTime = defaults.endTime;
-        }
-      }
-    };
-
-    const handleVisibilityChange = () => {
-      if (!document.hidden) {
-        refreshDefaultsIfStale();
-      }
-    };
-
-    const handleFocus = () => {
-      refreshDefaultsIfStale();
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    window.addEventListener("focus", handleFocus);
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-      window.removeEventListener("focus", handleFocus);
-    };
-  }, [urlState.start_time, urlState.end_time, setUrlState]);
-
-  // Convert URL state to filters and pagination for API calls
-  const filters: LogFilters = useMemo(
-    () => ({
-      parent_request_id: urlState.parent_request_id,
-      providers: urlState.providers,
-      models: urlState.models,
-      aliases: urlState.aliases,
-      status: urlState.status,
-      objects: urlState.objects,
-      selected_key_ids: urlState.selected_key_ids,
-      virtual_key_ids: urlState.virtual_key_ids,
-      routing_rule_ids: urlState.routing_rule_ids,
-      routing_engine_used: urlState.routing_engine_used,
-      user_ids: urlState.user_ids,
-      team_ids: urlState.team_ids,
-      customer_ids: urlState.customer_ids,
-      business_unit_ids: urlState.business_unit_ids,
-      content_search: urlState.content_search,
-      start_time: dateUtils.toISOString(urlState.start_time),
-      end_time: dateUtils.toISOString(urlState.end_time),
-      missing_cost_only: urlState.missing_cost_only,
-      metadata_filters: urlState.metadata_filters
-        ? (() => {
-          try {
-            return JSON.parse(urlState.metadata_filters);
-          } catch {
-            return undefined;
-          }
-        })()
-        : undefined,
-    }),
-    // Only re-derive filters when filter-related URL params change (not pagination)
-    [
-      urlState.providers,
-      urlState.models,
-      urlState.aliases,
-      urlState.status,
-      urlState.objects,
-      urlState.selected_key_ids,
-      urlState.virtual_key_ids,
-      urlState.routing_rule_ids,
-      urlState.routing_engine_used,
-      urlState.user_ids,
-      urlState.team_ids,
-      urlState.customer_ids,
-      urlState.business_unit_ids,
-      urlState.content_search,
-      urlState.parent_request_id,
-      urlState.start_time,
-      urlState.end_time,
-      urlState.missing_cost_only,
-      urlState.metadata_filters,
-    ],
-  );
-
-  const pagination: Pagination = useMemo(
-    () => ({
-      limit: urlState.limit,
-      offset: urlState.offset,
-      sort_by: urlState.sort_by as "timestamp" | "latency" | "tokens" | "cost",
-      order: urlState.order as "asc" | "desc",
-    }),
-    [urlState.limit, urlState.offset, urlState.sort_by, urlState.order],
-  );
-
-  const liveEnabled = urlState.live_enabled;
-
-  // Helper to update filters in URL
-  const setFilters = useCallback(
-    (newFilters: LogFilters) => {
-      // Mark time range as user-modified only if start_time or end_time actually changed
-      if (newFilters.start_time !== filters.start_time || newFilters.end_time !== filters.end_time) {
-        userModifiedTimeRange.current = true;
-      }
-
-      setUrlState({
-        parent_request_id: newFilters.parent_request_id || "",
-        providers: newFilters.providers || [],
-        models: newFilters.models || [],
-        aliases: newFilters.aliases || [],
-        status: newFilters.status || [],
-        objects: newFilters.objects || [],
-        selected_key_ids: newFilters.selected_key_ids || [],
-        virtual_key_ids: newFilters.virtual_key_ids || [],
-        routing_rule_ids: newFilters.routing_rule_ids || [],
-        routing_engine_used: newFilters.routing_engine_used || [],
-        user_ids: newFilters.user_ids || [],
-        team_ids: newFilters.team_ids || [],
-        customer_ids: newFilters.customer_ids || [],
-        business_unit_ids: newFilters.business_unit_ids || [],
-        content_search: newFilters.content_search || "",
-        start_time: newFilters.start_time ? dateUtils.toUnixTimestamp(new Date(newFilters.start_time)) : undefined,
-        end_time: newFilters.end_time ? dateUtils.toUnixTimestamp(new Date(newFilters.end_time)) : undefined,
-        missing_cost_only: newFilters.missing_cost_only ?? false,
-        metadata_filters: newFilters.metadata_filters ? JSON.stringify(newFilters.metadata_filters) : "",
-        offset: 0,
-      });
-    },
-    [setUrlState, filters],
-  );
-
-  // Helper to update pagination in URL
-  const setPagination = useCallback(
-    (newPagination: Pagination) => {
-      setUrlState({
-        limit: newPagination.limit,
-        offset: newPagination.offset,
-        sort_by: newPagination.sort_by,
-        order: newPagination.order,
-      });
-    },
-    [setUrlState],
-  );
-
-  // Handler for time range changes from the volume chart
-  const handleTimeRangeChange = useCallback(
-    (startTime: number, endTime: number) => {
-      setUrlState({
-        start_time: startTime,
-        end_time: endTime,
-        offset: 0,
-      });
-    },
-    [setUrlState],
-  );
-
-  // Handler for resetting zoom to default 24h view
-  const handleResetZoom = useCallback(() => {
-    const now = Math.floor(Date.now() / 1000);
-    const twentyFourHoursAgo = now - 24 * 60 * 60;
-    setUrlState({
-      start_time: twentyFourHoursAgo,
-      end_time: now,
-      offset: 0,
-    });
-  }, [setUrlState]);
-
-  // Check if user has zoomed (time range is different from default 24h)
-  const isZoomed = useMemo(() => {
-    const currentRange = urlState.end_time - urlState.start_time;
-    const defaultRange = 24 * 60 * 60; // 24 hours in seconds
-    // Consider zoomed if range is less than 90% of default (to account for minor differences)
-    return currentRange < defaultRange * 0.9;
-  }, [urlState.start_time, urlState.end_time]);
-
-  const latest = useRef({
-    logs,
-    filters,
-    pagination,
-    showEmptyState,
-    liveEnabled,
-  });
-  useEffect(() => {
-    latest.current = { logs, filters, pagination, showEmptyState, liveEnabled };
-  }, [logs, filters, pagination, showEmptyState, liveEnabled]);
-
-  const handleFilterByParentRequestId = useCallback(
-    (parentRequestId: string) => {
-      setSelectedSessionId(null);
-      setSessionHighlightedLogId(null);
-      setUrlState({ selected_log: "" }, { history: "replace" });
-      setFilters({
-        ...filters,
-        parent_request_id: parentRequestId,
-      });
-    },
-    [filters, setFilters],
-  );
-
-  const handleDelete = useCallback(
-    async (log: LogEntry) => {
-      try {
-        await deleteLogs({ ids: [log.id] }).unwrap();
-        setLogs((prevLogs) => prevLogs.filter((l) => l.id !== log.id));
-        setTotalItems((prev) => prev - 1);
-        // Clear selected log if it was the deleted one
-        if (urlState.selected_log === log.id) {
-          setUrlState({ selected_log: "" });
-        }
-      } catch (error) {
-        setError(getErrorMessage(error));
-      }
-    },
-    [deleteLogs, urlState.selected_log, setUrlState],
-  );
-
-  const handleLogMessage = useCallback((log: LogEntry, operation: "create" | "update") => {
-    const { logs, filters, pagination, showEmptyState, liveEnabled } = latest.current;
-    // If we were in empty state, exit it since we now have logs
-    if (showEmptyState) {
-      setShowEmptyState(false);
-    }
-
-    if (operation === "create") {
-      // Handle new log creation
-      // Only prepend the new log if we're on the first page and sorted by timestamp desc
-      if (pagination.offset === 0 && pagination.sort_by === "timestamp" && pagination.order === "desc") {
-        // Check if the log matches current filters
-        if (!matchesFilters(log, filters, !liveEnabled)) {
-          return;
-        }
-
-        setLogs((prevLogs: LogEntry[]) => {
-          // Check if log already exists (prevent duplicates)
-          if (prevLogs.some((existingLog) => existingLog.id === log.id)) {
-            return prevLogs;
-          }
-
-          // Remove the last log if we're at the page limit
-          const updatedLogs = [log, ...prevLogs];
-          if (updatedLogs.length > pagination.limit) {
-            updatedLogs.pop();
-          }
-          return updatedLogs;
-        });
-
-        // Update fetchedLog if it matches (for real-time detail sheet updates when log is not on current page)
-        setFetchedLog((prev) => {
-          if (prev && prev.id === log.id) {
-            return log;
-          }
-          return prev;
-        });
-
-        setTotalItems((prev: number) => prev + 1);
-      }
-    } else if (operation === "update") {
-      // Handle log updates with debouncing for streaming
-
-      // Check if the log exists in our current list
-      const logExists = logs.some((existingLog) => existingLog.id === log.id);
-
-      if (!logExists) {
-        // Fallback: if log doesn't exist, treat as create (e.g., user was on different page when created)
-        if (pagination.offset === 0 && pagination.sort_by === "timestamp" && pagination.order === "desc") {
-          // Check if the log matches current filters
-          if (matchesFilters(log, filters, !liveEnabled)) {
-            setLogs((prevLogs: LogEntry[]) => {
-              // Double-check it doesn't exist (race condition protection)
-              if (prevLogs.some((existingLog) => existingLog.id === log.id)) {
-                return prevLogs.map((existingLog) => (existingLog.id === log.id ? log : existingLog));
-              }
-
-              // Add as new log
-              const updatedLogs = [log, ...prevLogs];
-              if (updatedLogs.length > pagination.limit) {
-                updatedLogs.pop();
-              }
-              return updatedLogs;
-            });
-          }
-        }
-      } else {
-        // Normal update flow for existing logs
-        if (log.stream) {
-          // For streaming logs, debounce updates to avoid UI thrashing
-          const existingTimeout = streamingUpdateTimeouts.current.get(log.id);
-          if (existingTimeout) {
-            clearTimeout(existingTimeout);
-          }
-
-          const timeout = setTimeout(() => {
-            updateExistingLog(log);
-            streamingUpdateTimeouts.current.delete(log.id);
-          }, 100); // 100ms debounce for streaming updates
-
-          streamingUpdateTimeouts.current.set(log.id, timeout);
-        } else {
-          // For non-streaming updates, update immediately
-          updateExistingLog(log);
-        }
-
-        // Update stats for completed requests
-        if (log.status == "success" || log.status == "error") {
-          setStats((prevStats) => {
-            if (!prevStats) return prevStats;
-
-            const newStats = { ...prevStats };
-            newStats.total_requests += 1;
-
-            const successCount = (prevStats.success_rate / 100) * prevStats.total_requests;
-
-            const newSuccessCount = log.status === "success" ? successCount + 1 : successCount;
-            newStats.success_rate = (newSuccessCount / newStats.total_requests) * 100;
-
-            // Update user-facing success rate using only root requests as denominator,
-            // matching the server-side metric which counts fallback_index = 0 rows only.
-            if (log.fallback_index === 0) {
-              const userFacingTotal = prevStats.user_facing_total_requests + 1;
-              const userSuccessCount =
-                (prevStats.user_facing_success_rate / 100) *
-                prevStats.user_facing_total_requests;
-              const newUserSuccessCount =
-                log.status === "success"
-                  ? userSuccessCount + 1
-                  : userSuccessCount;
-              newStats.user_facing_total_requests = userFacingTotal;
-              newStats.user_facing_success_rate =
-                (newUserSuccessCount / userFacingTotal) * 100;
-            }
-
-            // Update average latency
-            if (log.latency) {
-              const totalLatency = prevStats.average_latency * prevStats.total_requests;
-              newStats.average_latency = (totalLatency + log.latency) / newStats.total_requests;
-            }
-
-            // Update total tokens
-            if (log.token_usage) {
-              newStats.total_tokens += log.token_usage.total_tokens;
-            }
-
-            // Update total cost
-            if (log.cost) {
-              newStats.total_cost += log.cost;
-            }
-
-            return newStats;
-          });
-
-          // Update histogram for completed requests
-          setHistogram((prevHistogram) => {
-            if (!prevHistogram || typeof prevHistogram.bucket_size_seconds !== "number" || prevHistogram.bucket_size_seconds <= 0) {
-              return prevHistogram;
-            }
-
-            const logTime = new Date(log.timestamp).getTime();
-            const bucketSizeMs = prevHistogram.bucket_size_seconds * 1000;
-            const bucketTime = Math.floor(logTime / bucketSizeMs) * bucketSizeMs;
-
-            const updatedBuckets = [...prevHistogram.buckets];
-            const bucketIndex = updatedBuckets.findIndex((b) => {
-              const bTime = new Date(b.timestamp).getTime();
-              return Math.floor(bTime / bucketSizeMs) * bucketSizeMs === bucketTime;
-            });
-
-            if (bucketIndex >= 0) {
-              // Update existing bucket
-              updatedBuckets[bucketIndex] = {
-                ...updatedBuckets[bucketIndex],
-                count: updatedBuckets[bucketIndex].count + 1,
-                success: updatedBuckets[bucketIndex].success + (log.status === "success" ? 1 : 0),
-                error: updatedBuckets[bucketIndex].error + (log.status === "error" ? 1 : 0),
-              };
-            } else {
-              // Create new bucket for this timestamp
-              const newBucket = {
-                timestamp: new Date(bucketTime).toISOString(),
-                count: 1,
-                success: log.status === "success" ? 1 : 0,
-                error: log.status === "error" ? 1 : 0,
-              };
-              // Insert in sorted order
-              const insertIndex = updatedBuckets.findIndex((b) => new Date(b.timestamp).getTime() > bucketTime);
-              if (insertIndex === -1) {
-                updatedBuckets.push(newBucket);
-              } else {
-                updatedBuckets.splice(insertIndex, 0, newBucket);
-              }
-            }
-
-            return { ...prevHistogram, buckets: updatedBuckets };
-          });
-        }
-      }
-    }
-  }, []);
-
-  const updateExistingLog = useCallback((updatedLog: LogEntry) => {
-    setLogs((prevLogs: LogEntry[]) => {
-      return prevLogs.map((existingLog) => (existingLog.id === updatedLog.id ? updatedLog : existingLog));
-    });
-
-    // Update fetchedLog if it matches the updated log (for real-time detail sheet updates when log is not on current page)
-    setFetchedLog((prev) => {
-      if (prev && prev.id === updatedLog.id) {
-        return updatedLog;
-      }
-      return prev;
-    });
-  }, []);
-
-  const { isConnected: isSocketConnected, subscribe } = useWebSocket();
-
-  // Subscribe to log messages - only when live updates are enabled
-  useEffect(() => {
-    if (!liveEnabled) {
-      return;
-    }
-
-    const unsubscribe = subscribe("log", (data) => {
-      const { payload, operation } = data;
-      handleLogMessage(payload, operation);
-    });
-
-    return unsubscribe;
-  }, [handleLogMessage, subscribe, liveEnabled]);
-
-  // Cleanup timeouts on unmount
-  useEffect(() => {
-    return () => {
-      streamingUpdateTimeouts.current.forEach((timeout) => clearTimeout(timeout));
-      streamingUpdateTimeouts.current.clear();
-    };
-  }, []);
-
-  const fetchLogs = useCallback(async () => {
-    setFetchingLogs(true);
-    setError(null);
-
-    try {
-      const result = await triggerGetLogs({ filters, pagination });
-
-      if (result.error) {
-        const errorMessage = getErrorMessage(result.error);
-        setError(errorMessage);
-        setLogs([]);
-        setTotalItems(0);
-      } else if (result.data) {
-        setLogs(result.data.logs || []);
-        setTotalItems(result.data.stats.total_requests);
-      }
-
-      // Only set showEmptyState on initial load and only based on total logs
-      if (initialLoading) {
-        // Check if there are any logs globally, not just in the current filter
-        setShowEmptyState(result.data ? !result.data.has_logs : true);
-      }
-    } catch {
-      setError("Cannot fetch logs. Please check if logs are enabled in your Bifrost config.");
-      setLogs([]);
-      setTotalItems(0);
-      setShowEmptyState(true);
-    } finally {
-      setFetchingLogs(false);
-    }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters, pagination]);
-
-  const fetchStats = useCallback(async () => {
-    setFetchingStats(true);
-    try {
-      const result = await triggerGetStats({ filters });
-
-      if (result.error) {
-        // Don't show error for stats failure, just log it
-        console.error("Failed to fetch stats:", result.error);
-      } else if (result.data) {
-        setStats(result.data);
-      }
-    } catch (error) {
-      console.error("Failed to fetch stats:", error);
-    } finally {
-      setFetchingStats(false);
-    }
-  }, [filters, triggerGetStats]);
-
-  const fetchHistogram = useCallback(async () => {
-    setFetchingHistogram(true);
-
-    try {
-      const result = await triggerGetHistogram({ filters });
-
-      if (result.error) {
-        // Don't show error for histogram failure, just log it
-        console.error("Failed to fetch histogram:", result.error);
-      } else if (result.data) {
-        setHistogram(result.data);
-      }
-    } catch (error) {
-      console.error("Failed to fetch histogram:", error);
-    } finally {
-      setFetchingHistogram(false);
-    }
-  }, [filters, triggerGetHistogram]);
-
-  // Helper to toggle live updates
-  const handleLiveToggle = useCallback(
-    (enabled: boolean) => {
-      setUrlState({ live_enabled: enabled });
-      // When re-enabling, refetch logs to get latest data
-      if (enabled) {
-        fetchLogs();
-      }
-    },
-    [setUrlState, fetchLogs],
-  );
-
-  // Fetch logs when filters or pagination change
-  useEffect(() => {
-    if (!initialLoading) {
-      fetchLogs();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters, pagination, initialLoading]);
-
-  // Fetch stats and histogram when filters change (but not pagination)
-  useEffect(() => {
-    if (!initialLoading) {
-      fetchStats();
-      fetchHistogram();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters, initialLoading]);
-
-  // Initial load
-  useEffect(() => {
-    const initialLoad = async () => {
-      // Load logs and stats in parallel, don't wait for stats to show the page
-      await fetchLogs();
-      fetchStats(); // Don't await - let it load in background
-      fetchHistogram(); // Don't await - let it load in background
-      setInitialLoading(false);
-    };
-    initialLoad();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const getMessageText = (content: ChatMessageContent): string => {
-    if (typeof content === "string") {
-      return content;
-    }
-    if (Array.isArray(content)) {
-      return content.reduce((acc: string, block: ContentBlock) => {
-        if (block.type === "text" && block.text) {
-          return acc + block.text;
-        }
-        return acc;
-      }, "");
-    }
-    return "";
-  };
-
-  // Helper function to check if a log matches the current filters
-  const matchesFilters = (log: LogEntry, filters: LogFilters, applyTimeFilters = true): boolean => {
-    if (filters.user_ids?.length) {
-      if (!log.user_id || !filters.user_ids.includes(log.user_id)) return false;
-    }
-    if (filters.team_ids?.length) {
-      if (!log.team_id || !filters.team_ids.includes(log.team_id)) return false;
-    }
-    if (filters.customer_ids?.length) {
-      if (!log.customer_id || !filters.customer_ids.includes(log.customer_id)) return false;
-    }
-    if (filters.business_unit_ids?.length) {
-      if (!log.business_unit_id || !filters.business_unit_ids.includes(log.business_unit_id)) return false;
-    }
-    if (filters.missing_cost_only && typeof log.cost === "number" && log.cost > 0) {
-      return false;
-    }
-    if (filters.parent_request_id && log.parent_request_id !== filters.parent_request_id) {
-      return false;
-    }
-    if (filters.providers?.length && !filters.providers.includes(log.provider)) {
-      return false;
-    }
-    if (filters.aliases?.length && !filters.aliases.includes(log.alias ?? "")) {
-      return false;
-    }
-    if (filters.models?.length && !filters.models.includes(log.model)) {
-      return false;
-    }
-    if (filters.status?.length && !filters.status.includes(log.status)) {
-      return false;
-    }
-    if (filters.objects?.length && !filters.objects.includes(log.object)) {
-      return false;
-    }
-    if (filters.selected_key_ids?.length &&
-      (!log.selected_key_id ||
-        !filters.selected_key_ids.includes(log.selected_key_id))) {
-      return false;
-    }
-    if (filters.virtual_key_ids?.length) {
-      if (!log.virtual_key_id || !filters.virtual_key_ids.includes(log.virtual_key_id)) {
-        return false;
-      }
-    }
-    if (filters.routing_rule_ids?.length) {
-      if (!log.routing_rule_id || !filters.routing_rule_ids.includes(log.routing_rule_id)) {
-        return false;
-      }
-    }
-    if (filters.routing_engine_used?.length) {
-      if (!log.routing_engines_used || !log.routing_engines_used.some((engine) => filters.routing_engine_used!.includes(engine))) {
-        return false;
-      }
-    }
-    if (filters.start_time && new Date(log.timestamp) < new Date(filters.start_time)) {
-      return false;
-    }
-    if (applyTimeFilters && filters.end_time && new Date(log.timestamp) > new Date(filters.end_time)) {
-      return false;
-    }
-    if (filters.min_latency && (!log.latency || log.latency < filters.min_latency)) {
-      return false;
-    }
-    if (filters.max_latency && (!log.latency || log.latency > filters.max_latency)) {
-      return false;
-    }
-    if (filters.min_tokens && (!log.token_usage || log.token_usage.total_tokens < filters.min_tokens)) {
-      return false;
-    }
-    if (filters.max_tokens && (!log.token_usage || log.token_usage.total_tokens > filters.max_tokens)) {
-      return false;
-    }
-    if (filters.metadata_filters) {
-      for (const [key, value] of Object.entries(filters.metadata_filters)) {
-        const metadataValue = log.metadata?.[key];
-        if (metadataValue === undefined || String(metadataValue) !== value) {
-          return false;
-        }
-      }
-    }
-    if (filters.content_search) {
-      const search = filters.content_search.toLowerCase();
-      const content = [
-        ...(log.input_history || []).map((msg: ChatMessage) => getMessageText(msg.content)),
-        log.output_message ? getMessageText(log.output_message.content) : "",
-      ]
-        .join(" ")
-        .toLowerCase();
-
-      if (!content.includes(search)) {
-        return false;
-      }
-    }
-    return true;
-  };
-
-  const statCards = useMemo(
-    () => [
-      {
-        title: "Total Requests",
-        value: <NumberFlow value={stats?.total_requests ?? 0} format={COMPACT_NUMBER_FORMAT} />,
-        icon: <BarChart className="size-4" />,
-      },
-      {
-        title: "Success Rate",
-        value: <NumberFlow value={stats?.success_rate ?? 0} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="%" />,
-        icon: <CheckCircle className="size-4" />,
-        description:
-          "Success rate as perceived by the system. Each fallback counts as a separate attempt. Retries on the same request are counted as one attempt.",
-      },
-      {
-        title: "User Success Rate",
-        value: <NumberFlow value={stats?.user_facing_success_rate ?? 0} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="%" />,
-        icon: <CheckCircle className="size-4" />,
-        description: "Success rate as perceived by the end user. It includes fallback chains as one request.",
-      },
-      {
-        title: "Avg Latency",
-        value: (
-          <NumberFlow value={stats?.average_latency ?? 0} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="ms" />
-        ),
-        icon: <Clock className="size-4" />,
-      },
-      {
-        title: "Total Tokens",
-        value: <NumberFlow value={stats?.total_tokens ?? 0} format={COMPACT_NUMBER_FORMAT} />,
-        icon: <Hash className="size-4" />,
-      },
-      {
-        title: "Total Cost",
-        value: (
-          <NumberFlow
-            value={stats?.total_cost ?? 0}
-            format={{
-              ...COMPACT_NUMBER_FORMAT,
-              style: "currency",
-              currency: "USD",
-            }}
-          />
-        ),
-        icon: <DollarSign className="size-4" />,
-      },
-    ],
-    [stats],
-  );
-
-  const { data: filterData } = useGetAvailableFilterDataQuery();
-
-  // Get metadata keys from filterdata API so columns always show even with no data on current page
-  const metadataKeys = useMemo(() => {
-    if (!filterData?.metadata_keys) return [];
-    return Object.keys(filterData.metadata_keys).sort();
-  }, [filterData?.metadata_keys]);
-
-  const columns = useMemo(() => createColumns(handleDelete, hasDeleteAccess, metadataKeys), [handleDelete, hasDeleteAccess, metadataKeys]);
-
-  const columnIds = useMemo(
-    () => columns.map((col) => ("id" in col && col.id ? col.id : "accessorKey" in col ? String(col.accessorKey) : "")).filter(Boolean),
-    [columns],
-  );
-
-  const COLUMN_LABELS: Record<string, string> = useMemo(
-    () => ({
-      timestamp: "Time",
-      request_type: "Type",
-      input: "Message",
-      provider: "Provider",
-      model: "Model",
-      latency: "Latency",
-      tokens: "Tokens",
-      cost: "Cost",
-    }),
-    [],
-  );
-
-  const {
-    entries: columnEntries,
-    columnOrder,
-    columnVisibility,
-    columnPinning,
-    toggleVisibility: toggleColumnVisibility,
-    togglePin: toggleColumnPin,
-    reorder: reorderColumns,
-    reset: resetColumns,
-  } = useColumnConfig({ columnIds, paramName: "cols" });
-
-  // Navigation for log detail sheet
-  const selectedLogIndex = useMemo(() => (selectedLogId ? logs.findIndex((l) => l.id === selectedLogId) : -1), [selectedLogId, logs]);
-
-  const handleLogNavigate = useCallback(
-    (direction: "prev" | "next") => {
-      const currentLogId = selectedLogId || "";
-      if (direction === "prev") {
-        if (selectedLogIndex > 0) {
-          // Navigate to previous log on current page
-          setUrlState({ selected_log: logs[selectedLogIndex - 1].id });
-        } else if (pagination.offset > 0) {
-          // Go to previous page and select the last item
-          const newOffset = Math.max(0, pagination.offset - pagination.limit);
-          setUrlState({ offset: newOffset, selected_log: "" });
-          // Fetch previous page, then select last log
-          triggerGetLogs({
-            filters,
-            pagination: { ...pagination, offset: newOffset },
-          }).then((result) => {
-            if (result.data?.logs?.length) {
-              const lastLog = result.data.logs[result.data.logs.length - 1];
-              setUrlState({ selected_log: lastLog.id });
-            } else if (result.error) {
-              setUrlState({
-                offset: pagination.offset,
-                selected_log: currentLogId,
-              });
-              setError(getErrorMessage(result.error));
-            }
-          });
-        }
-      } else {
-        if (selectedLogIndex >= 0 && selectedLogIndex < logs.length - 1) {
-          // Navigate to next log on current page
-          setUrlState({ selected_log: logs[selectedLogIndex + 1].id });
-        } else if (pagination.offset + pagination.limit < totalItems) {
-          // Go to next page and select the first item
-          const newOffset = pagination.offset + pagination.limit;
-          setUrlState({ offset: newOffset, selected_log: "" });
-          // Fetch next page, then select first log
-          triggerGetLogs({
-            filters,
-            pagination: { ...pagination, offset: newOffset },
-          }).then((result) => {
-            if (result.data?.logs?.length) {
-              const firstLog = result.data.logs[0];
-              setUrlState({ selected_log: firstLog.id });
-            } else if (result.error) {
-              setUrlState({
-                offset: pagination.offset,
-                selected_log: currentLogId,
-              });
-              setError(getErrorMessage(result.error));
-            }
-          });
-        }
-      }
-    },
-    [selectedLogId, selectedLogIndex, logs, pagination, totalItems, filters, setUrlState, triggerGetLogs],
-  );
-
-  return (
-    <div className="dark:bg-card no-padding-parent no-border-parent h-[calc(100vh_-_16px)]">
-      {initialLoading ? (
-        <FullPageLoader />
-      ) : showEmptyState ? (
-        <EmptyState isSocketConnected={isSocketConnected} error={error} />
-      ) : (
-        <div className="bg-background flex h-full w-full grow gap-3">
-          {/* Sidebar Filters */}
-          <LogsFilterSidebar filters={filters} onFiltersChange={setFilters} />
-
-          {/* Main Content */}
-          <div className="bg-card flex min-w-0 flex-1 flex-col gap-2 overflow-hidden rounded-l-md p-4 pb-2">
-            <div className="shrink-0">
-              <LogsHeaderView
-                filters={filters}
-                onFiltersChange={setFilters}
-                liveEnabled={liveEnabled}
-                onLiveToggle={handleLiveToggle}
-                fetchLogs={fetchLogs}
-                fetchStats={fetchStats}
-                columnEntries={columnEntries}
-                columnLabels={COLUMN_LABELS}
-                onToggleColumnVisibility={toggleColumnVisibility}
-                onResetColumns={resetColumns}
-              />
-            </div>
-            <div className="grid shrink-0 grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
-              {statCards.map((card) => (
-                <Card key={card.title} className="py-4 shadow-none">
-                  <CardContent
-                    className={`flex items-center justify-between px-4 transition-opacity duration-200 ${fetchingStats ? "opacity-50" : "opacity-100"}`}
-                  >
-                    <div className="w-full min-w-0">
-                      <div className="text-muted-foreground flex items-center gap-1 text-xs">
-                        <span className="truncate">{card.title}</span>
-                        {"description" in card && card.description && (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                type="button"
-                                aria-label={`${card.title} info`}
-                                data-testid={`logs-metric-info-${card.title.toLowerCase().replace(/\s+/g, "-")}`}
-                                className="inline-flex items-center"
-                              >
-                                <Info className="size-3 cursor-help" />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent className="max-w-72 text-left text-xs text-wrap">{card.description}</TooltipContent>
-                          </Tooltip>
-                        )}
-                      </div>
-                      <div className="truncate font-mono text-xl font-medium sm:text-2xl">{card.value}</div>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-
-            <div className="shrink-0">
-              <LogsVolumeChart
-                data={histogram}
-                loading={fetchingHistogram}
-                onTimeRangeChange={handleTimeRangeChange}
-                onResetZoom={handleResetZoom}
-                isZoomed={isZoomed}
-                startTime={urlState.start_time}
-                endTime={urlState.end_time}
-                isOpen={isChartOpen}
-                onOpenChange={setIsChartOpen}
-              />
-            </div>
-
-            {error && (
-              <Alert variant="destructive" className="shrink-0">
-                <AlertCircle className="h-4 w-4" />
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
-            )}
-
-            <div className="min-h-0 flex-1">
-              <LogsDataTable
-                columns={columns}
-                data={logs}
-                totalItems={totalItems}
-                loading={fetchingLogs}
-                pagination={pagination}
-                onPaginationChange={setPagination}
-                onRowClick={(row, columnId) => {
-                  if (columnId === "actions") return;
-                  setUrlState({ selected_log: row.id }, { history: "replace" });
-                  setSelectedSessionId(null);
-                  setSessionHighlightedLogId(null);
-                }}
-                liveEnabled={liveEnabled}
-                isSocketConnected={isSocketConnected}
-                columnEntries={columnEntries}
-                columnOrder={columnOrder}
-                columnVisibility={columnVisibility}
-                columnPinning={columnPinning}
-                onToggleColumnVisibility={toggleColumnVisibility}
-                onTogglePin={toggleColumnPin}
-                onReorderColumns={reorderColumns}
-              />
-            </div>
-          </div>
-
-          {/* Log Detail Sheet */}
-          <LogDetailSheet
-            log={selectedLog}
-            open={selectedLog !== null}
-            onOpenChange={(open) => !open && setUrlState({ selected_log: "" })}
-            handleDelete={handleDelete}
-            onNavigate={handleLogNavigate}
-            hasPrev={selectedLogIndex > 0 || (selectedLogIndex !== -1 && pagination.offset > 0)}
-            hasNext={selectedLogIndex !== -1 && (selectedLogIndex < logs.length - 1 || pagination.offset + pagination.limit < totalItems)}
-            onFilterByParentRequestId={handleFilterByParentRequestId}
-            onViewSession={(sessionId, logId) => {
-              setUrlState({ selected_log: "" }, { history: "replace" });
-              setSessionHighlightedLogId(logId);
-              setSelectedSessionId(sessionId);
-            }}
-          />
-          <SessionDetailsSheet
-            sessionId={selectedSessionId}
-            highlightedLogId={sessionHighlightedLogId}
-            open={selectedSessionId !== null}
-            onOpenChange={handleSessionSheetOpenChange}
-            liveEnabled={liveEnabled}
-            onLogClick={(log) => {
-              setSelectedSessionId(null);
-              setUrlState({ selected_log: log.id }, { history: "replace" });
-            }}
-            onFilterByParentRequestId={handleFilterByParentRequestId}
-          />
-        </div>
-      )}
-    </div>
-  );
+	const [error, setError] = useState<string | null>(null);
+	const [showEmptyState, setShowEmptyState] = useState(false);
+	const hasCheckedEmptyState = useRef(false);
+
+	const hasDeleteAccess = useRbac(RbacResource.Logs, RbacOperation.Delete);
+
+	const [deleteLogs] = useDeleteLogsMutation();
+	// Lazy query kept only for handleLogNavigate (fetches adjacent pages on demand)
+	const [triggerGetLogs] = useLazyGetLogsQuery();
+
+	const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+	const [sessionHighlightedLogId, setSessionHighlightedLogId] = useState<string | null>(null);
+	// Stable handler so SessionDetailsSheet's loadSessionPage useCallback doesn't
+	// recreate on every parent re-render. Without this, every live WebSocket log
+	// tick would re-render LogsPage, hand the sheet a fresh inline arrow, recreate
+	// loadSessionPage, and trip the reset effect — wiping sessionLogs and
+	// refetching from offset 0 while the sheet is open.
+	const handleSessionSheetOpenChange = useCallback((open: boolean) => {
+		if (!open) {
+			setSelectedSessionId(null);
+			setSessionHighlightedLogId(null);
+		}
+	}, []);
+	const [isChartOpen, setIsChartOpen] = useState(true);
+	const [triggerGetLogById] = useLazyGetLogByIdQuery();
+	const [fetchedLog, setFetchedLog] = useState<LogEntry | null>(null);
+
+	// Track if user has manually modified the time range
+	const userModifiedTimeRange = useRef<boolean>(false);
+
+	// Capture initial defaults on mount to detect shared URLs with custom time ranges
+	const initialDefaults = useRef(dateUtils.getDefaultTimeRange());
+
+	// Memoize default time range to prevent recalculation on every render
+	// This is crucial to avoid triggering refetches when the sheet opens/closes
+	const defaultTimeRange = useMemo(() => dateUtils.getDefaultTimeRange(), []);
+
+	// Get fresh default time range for refresh logic
+	const getDefaultTimeRange = () => dateUtils.getDefaultTimeRange();
+
+	const { search } = useLocation();
+	const hasExplicitTimeRange = (search as Record<string, unknown>)?.start_time && (search as Record<string, unknown>)?.end_time;
+
+	// URL state management with nuqs - all filters and pagination in URL
+	const [urlState, setUrlState] = useQueryStates(
+		{
+			parent_request_id: parseAsString.withDefault(""),
+			providers: parseAsArrayOf(parseAsString).withDefault([]),
+			models: parseAsArrayOf(parseAsString).withDefault([]),
+			aliases: parseAsArrayOf(parseAsString).withDefault([]),
+			status: parseAsArrayOf(parseAsString).withDefault([]),
+			objects: parseAsArrayOf(parseAsString).withDefault([]),
+			selected_key_ids: parseAsArrayOf(parseAsString).withDefault([]),
+			virtual_key_ids: parseAsArrayOf(parseAsString).withDefault([]),
+			routing_rule_ids: parseAsArrayOf(parseAsString).withDefault([]),
+			routing_engine_used: parseAsArrayOf(parseAsString).withDefault([]),
+			user_ids: parseAsArrayOf(parseAsString).withDefault([]),
+			team_ids: parseAsArrayOf(parseAsString).withDefault([]),
+			customer_ids: parseAsArrayOf(parseAsString).withDefault([]),
+			business_unit_ids: parseAsArrayOf(parseAsString).withDefault([]),
+			content_search: parseAsString.withDefault(""),
+			start_time: parseAsInteger.withDefault(defaultTimeRange.startTime),
+			end_time: parseAsInteger.withDefault(defaultTimeRange.endTime),
+			limit: parseAsInteger.withDefault(25), // Default fallback, actual value calculated based on table height
+			offset: parseAsInteger.withDefault(0),
+			sort_by: parseAsString.withDefault("timestamp"),
+			order: parseAsString.withDefault("desc"),
+			polling: parseAsBoolean.withDefault(true).withOptions({ clearOnDefault: false }),
+			period: parseAsString.withDefault(hasExplicitTimeRange ? "" : "1h").withOptions({ clearOnDefault: false }),
+			missing_cost_only: parseAsBoolean.withDefault(false),
+			metadata_filters: parseAsString.withDefault(""),
+			selected_log: parseAsString.withDefault(""),
+		},
+		{
+			history: "push",
+			shallow: false,
+		},
+	);
+
+	// Derive selectedLog: find in current logs array, or fetch by ID from API
+	const selectedLogId = urlState.selected_log || null;
+	const activeLogFetchId = useRef<string | null>(null);
+	const polling = urlState.polling;
+
+	// Refresh time range on page focus/visibility
+	useEffect(() => {
+		const refreshDefaultsIfStale = () => {
+			if (urlState.period) {
+				const { from, to } = getRangeForPeriod(urlState.period);
+				setUrlState(
+					{
+						start_time: Math.floor(from.getTime() / 1000),
+						end_time: Math.floor(to.getTime() / 1000),
+						period: urlState.period ?? "",
+					},
+					{ history: "replace" },
+				);
+				return;
+			}
+
+			// Absolute custom range: skip refresh if user explicitly set it
+			if (userModifiedTimeRange.current) return;
+
+			// Only slide back to default 1h if the timestamps still match the initial defaults
+			const startTimeDiff = Math.abs(urlState.start_time - initialDefaults.current.startTime);
+			const endTimeDiff = Math.abs(urlState.end_time - initialDefaults.current.endTime);
+			const tolerance = 5;
+			if (startTimeDiff <= tolerance && endTimeDiff <= tolerance) {
+				const defaults = getDefaultTimeRange();
+				const currentEndDiff = Math.abs(urlState.end_time - defaults.endTime);
+				if (currentEndDiff > 300) {
+					setUrlState(
+						{
+							start_time: defaults.startTime,
+							end_time: defaults.endTime,
+							period: urlState.period ?? "",
+						},
+						{ history: "replace" },
+					);
+					initialDefaults.current.startTime = defaults.startTime;
+					initialDefaults.current.endTime = defaults.endTime;
+				}
+			}
+		};
+
+		const handleVisibilityChange = () => {
+			if (!document.hidden) refreshDefaultsIfStale();
+		};
+		const handleFocus = () => refreshDefaultsIfStale();
+
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+		window.addEventListener("focus", handleFocus);
+		return () => {
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+			window.removeEventListener("focus", handleFocus);
+		};
+	}, [urlState.period, urlState.start_time, urlState.end_time, setUrlState]);
+
+	// Refresh the time window every 5s while live polling is on and a relative period is active.
+	// Updating start_time/end_time changes RTK args → triggers a refetch without needing pollingInterval.
+	useEffect(() => {
+		if (!polling || !urlState.period) return;
+
+		const id = setInterval(() => {
+			if (document.hidden) return;
+			const { from, to } = getRangeForPeriod(urlState.period);
+			setUrlState(
+				{
+					start_time: Math.floor(from.getTime() / 1000),
+					end_time: Math.floor(to.getTime() / 1000),
+					period: urlState.period ?? "",
+				},
+				{ history: "replace" },
+			);
+		}, 5000);
+
+		return () => clearInterval(id);
+	}, [polling, urlState.period, setUrlState]);
+
+	// Convert URL state to filters and pagination for API calls
+	const filters: LogFilters = useMemo(
+		() => ({
+			parent_request_id: urlState.parent_request_id,
+			providers: urlState.providers,
+			models: urlState.models,
+			aliases: urlState.aliases,
+			status: urlState.status,
+			objects: urlState.objects,
+			selected_key_ids: urlState.selected_key_ids,
+			virtual_key_ids: urlState.virtual_key_ids,
+			routing_rule_ids: urlState.routing_rule_ids,
+			routing_engine_used: urlState.routing_engine_used,
+			user_ids: urlState.user_ids,
+			team_ids: urlState.team_ids,
+			customer_ids: urlState.customer_ids,
+			business_unit_ids: urlState.business_unit_ids,
+			content_search: urlState.content_search,
+			start_time: dateUtils.toISOString(urlState.start_time),
+			end_time: dateUtils.toISOString(urlState.end_time),
+			missing_cost_only: urlState.missing_cost_only,
+			metadata_filters: urlState.metadata_filters
+				? (() => {
+						try {
+							return JSON.parse(urlState.metadata_filters);
+						} catch {
+							return undefined;
+						}
+					})()
+				: undefined,
+		}),
+		// Only re-derive filters when filter-related URL params change (not pagination)
+		[
+			urlState.providers,
+			urlState.models,
+			urlState.aliases,
+			urlState.status,
+			urlState.objects,
+			urlState.selected_key_ids,
+			urlState.virtual_key_ids,
+			urlState.routing_rule_ids,
+			urlState.routing_engine_used,
+			urlState.user_ids,
+			urlState.team_ids,
+			urlState.customer_ids,
+			urlState.business_unit_ids,
+			urlState.content_search,
+			urlState.parent_request_id,
+			urlState.start_time,
+			urlState.end_time,
+			urlState.missing_cost_only,
+			urlState.metadata_filters,
+		],
+	);
+
+	const pagination: Pagination = useMemo(
+		() => ({
+			limit: urlState.limit,
+			offset: urlState.offset,
+			sort_by: urlState.sort_by as "timestamp" | "latency" | "tokens" | "cost",
+			order: urlState.order as "asc" | "desc",
+		}),
+		[urlState.limit, urlState.offset, urlState.sort_by, urlState.order],
+	);
+
+	const period = urlState.period;
+
+	// Helper to update filters in URL
+	const setFilters = useCallback(
+		(newFilters: LogFilters) => {
+			// Mark time range as user-modified only if start_time or end_time actually changed
+			const timeChanged = newFilters.start_time !== filters.start_time || newFilters.end_time !== filters.end_time;
+			if (timeChanged) {
+				userModifiedTimeRange.current = true;
+			}
+
+			setUrlState({
+				// Clear the period whenever an absolute range is applied via setFilters
+				...(timeChanged && { period: "" }),
+				parent_request_id: newFilters.parent_request_id || "",
+				providers: newFilters.providers || [],
+				models: newFilters.models || [],
+				aliases: newFilters.aliases || [],
+				status: newFilters.status || [],
+				objects: newFilters.objects || [],
+				selected_key_ids: newFilters.selected_key_ids || [],
+				virtual_key_ids: newFilters.virtual_key_ids || [],
+				routing_rule_ids: newFilters.routing_rule_ids || [],
+				routing_engine_used: newFilters.routing_engine_used || [],
+				user_ids: newFilters.user_ids || [],
+				team_ids: newFilters.team_ids || [],
+				customer_ids: newFilters.customer_ids || [],
+				business_unit_ids: newFilters.business_unit_ids || [],
+				content_search: newFilters.content_search || "",
+				start_time: newFilters.start_time ? dateUtils.toUnixTimestamp(new Date(newFilters.start_time)) : undefined,
+				end_time: newFilters.end_time ? dateUtils.toUnixTimestamp(new Date(newFilters.end_time)) : undefined,
+				missing_cost_only: newFilters.missing_cost_only ?? false,
+				metadata_filters: newFilters.metadata_filters ? JSON.stringify(newFilters.metadata_filters) : "",
+				offset: 0,
+			});
+		},
+		[setUrlState, filters],
+	);
+
+	// Helper to update pagination in URL
+	const setPagination = useCallback(
+		(newPagination: Pagination) => {
+			setUrlState({
+				limit: newPagination.limit,
+				offset: newPagination.offset,
+				sort_by: newPagination.sort_by,
+				order: newPagination.order,
+			});
+		},
+		[setUrlState],
+	);
+
+	// Handler for time range changes from the volume chart
+	const handleTimeRangeChange = useCallback(
+		(startTime: number, endTime: number) => {
+			userModifiedTimeRange.current = true;
+			setUrlState({
+				period: "",
+				start_time: startTime,
+				end_time: endTime,
+				offset: 0,
+			});
+		},
+		[setUrlState],
+	);
+
+	// Handler for resetting zoom to default 1h view
+	const handleResetZoom = useCallback(() => {
+		const now = Math.floor(Date.now() / 1000);
+		const oneHour = now - 1 * 60 * 60;
+		setUrlState({
+			start_time: oneHour,
+			end_time: now,
+			offset: 0,
+		});
+	}, [setUrlState]);
+
+	// Check if user has zoomed (time range is different from default 1h)
+	const isZoomed = useMemo(() => {
+		const currentRange = urlState.end_time - urlState.start_time;
+		const defaultRange = 24 * 60 * 60; // 24 hours in seconds
+		// Consider zoomed if range is less than 90% of default (to account for minor differences)
+		return currentRange < defaultRange * 0.9;
+	}, [urlState.start_time, urlState.end_time]);
+
+	// Non-lazy RTK Query hooks — RTK handles caching, deduplication, and loading states.
+	// pollingInterval is only set for the no-period case; period polling is handled by
+	// a setInterval that updates URL timestamps, which changes args and triggers RTK to refetch.
+	const {
+		data: logsData,
+		isLoading: logsIsLoading,
+		isFetching: logsIsFetching,
+		error: logsError,
+		refetch: refetchLogs,
+	} = useGetLogsQuery(
+		{ filters, pagination },
+		{
+			// Poll every 5s on the empty state page so we transition as soon as the first log arrives.
+			// When a relative period is active, the setInterval above updates URL timestamps → RTK
+			// detects arg changes and refetches automatically; no separate pollingInterval needed.
+			pollingInterval: showEmptyState ? 5000 : polling && !period ? 5000 : 0,
+			refetchOnMountOrArgChange: true,
+			skipPollingIfUnfocused: true,
+		},
+	);
+
+	const {
+		data: stats,
+		isFetching: statsIsFetching,
+		refetch: refetchStats,
+	} = useGetLogsStatsQuery(
+		{ filters },
+		{
+			pollingInterval: polling && !period ? 5000 : 0,
+			refetchOnMountOrArgChange: true,
+			skipPollingIfUnfocused: true,
+		},
+	);
+
+	const {
+		data: histogram,
+		isLoading: histogramIsLoading,
+		refetch: refetchHistogram,
+	} = useGetLogsHistogramQuery(
+		{ filters },
+		{
+			pollingInterval: polling && !period ? 5000 : 0,
+			refetchOnMountOrArgChange: true,
+			skipPollingIfUnfocused: true,
+		},
+	);
+
+	// Set showEmptyState on first response; clear it as soon as logs appear.
+	useEffect(() => {
+		if (!logsData) return;
+		if (!hasCheckedEmptyState.current) {
+			setShowEmptyState(!logsData.has_logs);
+			hasCheckedEmptyState.current = true;
+		} else if (showEmptyState && logsData.has_logs) {
+			setShowEmptyState(false);
+		}
+	}, [logsData, showEmptyState]);
+
+	// On mount: if period is set and stored timestamps are stale, freshen them so the
+	// initial query uses the correct window (RTK will refetch when args change).
+	useEffect(() => {
+		if (urlState.period) {
+			const { from, to } = getRangeForPeriod(urlState.period);
+			const freshEnd = Math.floor(to.getTime() / 1000);
+			if (Math.abs(urlState.end_time - freshEnd) > 60) {
+				setUrlState(
+					{
+						start_time: Math.floor(from.getTime() / 1000),
+						end_time: freshEnd,
+						period: urlState.period ?? "",
+					},
+					{ history: "replace" },
+				);
+			}
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	const handleFilterByParentRequestId = useCallback(
+		(parentRequestId: string) => {
+			setSelectedSessionId(null);
+			setSessionHighlightedLogId(null);
+			setUrlState({ selected_log: "" }, { history: "replace" });
+			setFilters({
+				...filters,
+				parent_request_id: parentRequestId,
+			});
+		},
+		[filters, setFilters],
+	);
+
+	const handleDelete = useCallback(
+		async (log: LogEntry) => {
+			try {
+				await deleteLogs({ ids: [log.id] }).unwrap();
+				if (urlState.selected_log === log.id) {
+					setUrlState({ selected_log: "" });
+				}
+				refetchLogs();
+				refetchStats();
+				refetchHistogram();
+			} catch (err) {
+				setError(getErrorMessage(err));
+			}
+		},
+		[deleteLogs, urlState.selected_log, setUrlState, refetchLogs, refetchStats, refetchHistogram],
+	);
+
+	const handlePollToggle = useCallback(
+		(enabled: boolean) => {
+			setUrlState({ polling: enabled });
+			if (enabled) {
+				refetchLogs();
+				refetchStats();
+				refetchHistogram();
+			}
+		},
+		[setUrlState, refetchLogs, refetchStats, refetchHistogram],
+	);
+
+	// Period selection: store relative period + fresh timestamps in URL (bypasses setFilters
+	// so userModifiedTimeRange stays false and tab-focus refresh keeps working)
+	const handlePeriodChange = useCallback(
+		(p: string, from: Date, to: Date) => {
+			setUrlState({
+				period: p,
+				start_time: Math.floor(from.getTime() / 1000),
+				end_time: Math.floor(to.getTime() / 1000),
+				offset: 0,
+			});
+		},
+		[setUrlState],
+	);
+
+	const statCards = useMemo(
+		() => [
+			{
+				title: "Total Requests",
+				value: <NumberFlow value={stats?.total_requests ?? 0} format={COMPACT_NUMBER_FORMAT} />,
+				icon: <BarChart className="size-4" />,
+			},
+			{
+				title: "Success Rate",
+				value: <NumberFlow value={stats?.success_rate ?? 0} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="%" />,
+				icon: <CheckCircle className="size-4" />,
+				description:
+					"Success rate as perceived by the system. Each fallback counts as a separate attempt. Retries on the same request are counted as one attempt.",
+			},
+			{
+				title: "User Success Rate",
+				value: (
+					<NumberFlow
+						value={stats?.user_facing_success_rate ?? 0}
+						format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
+						suffix="%"
+					/>
+				),
+				icon: <CheckCircle className="size-4" />,
+				description: "Success rate as perceived by the end user. It includes fallback chains as one request.",
+			},
+			{
+				title: "Avg Latency",
+				value: (
+					<NumberFlow value={stats?.average_latency ?? 0} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="ms" />
+				),
+				icon: <Clock className="size-4" />,
+			},
+			{
+				title: "Total Tokens",
+				value: <NumberFlow value={stats?.total_tokens ?? 0} format={COMPACT_NUMBER_FORMAT} />,
+				icon: <Hash className="size-4" />,
+			},
+			{
+				title: "Total Cost",
+				value: (
+					<NumberFlow
+						value={stats?.total_cost ?? 0}
+						format={{
+							...COMPACT_NUMBER_FORMAT,
+							style: "currency",
+							currency: "USD",
+						}}
+					/>
+				),
+				icon: <DollarSign className="size-4" />,
+			},
+		],
+		[stats],
+	);
+
+	const { data: filterData } = useGetAvailableFilterDataQuery();
+
+	// Get metadata keys from filterdata API so columns always show even with no data on current page
+	const metadataKeys = useMemo(() => {
+		if (!filterData?.metadata_keys) return [];
+		return Object.keys(filterData.metadata_keys).sort();
+	}, [filterData?.metadata_keys]);
+
+	const columns = useMemo(() => createColumns(handleDelete, hasDeleteAccess, metadataKeys), [handleDelete, hasDeleteAccess, metadataKeys]);
+
+	const columnIds = useMemo(
+		() => columns.map((col) => ("id" in col && col.id ? col.id : "accessorKey" in col ? String(col.accessorKey) : "")).filter(Boolean),
+		[columns],
+	);
+
+	const COLUMN_LABELS: Record<string, string> = useMemo(
+		() => ({
+			timestamp: "Time",
+			request_type: "Type",
+			input: "Message",
+			provider: "Provider",
+			model: "Model",
+			latency: "Latency",
+			tokens: "Tokens",
+			cost: "Cost",
+		}),
+		[],
+	);
+
+	const {
+		entries: columnEntries,
+		columnOrder,
+		columnVisibility,
+		columnPinning,
+		toggleVisibility: toggleColumnVisibility,
+		togglePin: toggleColumnPin,
+		reorder: reorderColumns,
+		reset: resetColumns,
+	} = useColumnConfig({ columnIds, paramName: "cols" });
+
+	// Navigation for log detail sheet
+	const logs = logsData?.logs ?? [];
+	const totalItems = logsData?.stats?.total_requests ?? 0;
+	const selectedLogFromData = useMemo(
+		() => (selectedLogId ? (logs.find((l) => l.id === selectedLogId) ?? null) : null),
+		[selectedLogId, logs],
+	);
+
+	useEffect(() => {
+		if (!selectedLogId || selectedLogFromData) {
+			setFetchedLog(null);
+			activeLogFetchId.current = null;
+			return;
+		}
+		const fetchId = selectedLogId;
+		activeLogFetchId.current = fetchId;
+		triggerGetLogById(selectedLogId).then((result) => {
+			if (activeLogFetchId.current === fetchId) {
+				if (result.data) {
+					setFetchedLog(result.data);
+				} else if (result.error) {
+					setError(getErrorMessage(result.error));
+				}
+			}
+		});
+	}, [selectedLogId, selectedLogFromData, triggerGetLogById]);
+
+	const selectedLog = selectedLogFromData ?? fetchedLog;
+
+	const selectedLogIndex = useMemo(() => (selectedLogId ? logs.findIndex((l) => l.id === selectedLogId) : -1), [selectedLogId, logs]);
+
+	const handleLogNavigate = useCallback(
+		(direction: "prev" | "next") => {
+			const currentLogId = selectedLogId || "";
+			if (direction === "prev") {
+				if (selectedLogIndex > 0) {
+					// Navigate to previous log on current page
+					setUrlState({ selected_log: logs[selectedLogIndex - 1].id });
+				} else if (pagination.offset > 0) {
+					// Go to previous page and select the last item
+					const newOffset = Math.max(0, pagination.offset - pagination.limit);
+					setUrlState({ offset: newOffset, selected_log: "" });
+					// Fetch previous page, then select last log
+					triggerGetLogs({
+						filters,
+						pagination: { ...pagination, offset: newOffset },
+					}).then((result) => {
+						if (result.data?.logs?.length) {
+							const lastLog = result.data.logs[result.data.logs.length - 1];
+							setUrlState({ selected_log: lastLog.id });
+						} else if (result.error) {
+							setUrlState({
+								offset: pagination.offset,
+								selected_log: currentLogId,
+							});
+							setError(getErrorMessage(result.error));
+						}
+					});
+				}
+			} else {
+				if (selectedLogIndex >= 0 && selectedLogIndex < logs.length - 1) {
+					// Navigate to next log on current page
+					setUrlState({ selected_log: logs[selectedLogIndex + 1].id });
+				} else if (pagination.offset + pagination.limit < totalItems) {
+					// Go to next page and select the first item
+					const newOffset = pagination.offset + pagination.limit;
+					setUrlState({ offset: newOffset, selected_log: "" });
+					// Fetch next page, then select first log
+					triggerGetLogs({
+						filters,
+						pagination: { ...pagination, offset: newOffset },
+					}).then((result) => {
+						if (result.data?.logs?.length) {
+							const firstLog = result.data.logs[0];
+							setUrlState({ selected_log: firstLog.id });
+						} else if (result.error) {
+							setUrlState({
+								offset: pagination.offset,
+								selected_log: currentLogId,
+							});
+							setError(getErrorMessage(result.error));
+						}
+					});
+				}
+			}
+		},
+		[selectedLogId, selectedLogIndex, logs, pagination, totalItems, filters, setUrlState, triggerGetLogs],
+	);
+
+	return (
+		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(100vh_-_16px)]">
+			{logsIsLoading ? (
+				<FullPageLoader />
+			) : showEmptyState ? (
+				<EmptyState error={error ?? (logsError ? getErrorMessage(logsError as Parameters<typeof getErrorMessage>[0]) : null)} />
+			) : (
+				<div className="bg-background flex h-full w-full grow gap-3">
+					{/* Sidebar Filters */}
+					<LogsFilterSidebar filters={filters} onFiltersChange={setFilters} />
+
+					{/* Main Content */}
+					<div className="bg-card flex min-w-0 flex-1 flex-col gap-2 overflow-hidden rounded-l-md p-4 pb-2">
+						<div className="shrink-0">
+							<LogsHeaderView
+								filters={filters}
+								onFiltersChange={setFilters}
+								fetchLogs={async () => {
+									await refetchLogs();
+								}}
+								fetchStats={async () => {
+									await refetchStats();
+								}}
+								fetchHistogram={async () => {
+									await refetchHistogram();
+								}}
+								loading={logsIsFetching}
+								polling={polling}
+								onPollToggle={handlePollToggle}
+								period={period}
+								onPeriodChange={handlePeriodChange}
+								columnEntries={columnEntries}
+								columnLabels={COLUMN_LABELS}
+								onToggleColumnVisibility={toggleColumnVisibility}
+								onResetColumns={resetColumns}
+							/>
+						</div>
+						<div className="grid shrink-0 grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+							{statCards.map((card) => (
+								<Card key={card.title} className="py-4 shadow-none">
+									<CardContent
+										className={`flex items-center justify-between px-4 transition-opacity duration-200 ${statsIsFetching ? "opacity-50" : "opacity-100"}`}
+									>
+										<div className="w-full min-w-0">
+											<div className="text-muted-foreground flex items-center gap-1 text-xs">
+												<span className="truncate">{card.title}</span>
+												{"description" in card && card.description && (
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<button
+																type="button"
+																aria-label={`${card.title} info`}
+																data-testid={`logs-metric-info-${card.title.toLowerCase().replace(/\s+/g, "-")}`}
+																className="inline-flex items-center"
+															>
+																<Info className="size-3 cursor-help" />
+															</button>
+														</TooltipTrigger>
+														<TooltipContent className="max-w-72 text-left text-xs text-wrap">{card.description}</TooltipContent>
+													</Tooltip>
+												)}
+											</div>
+											<div className="truncate font-mono text-xl font-medium sm:text-2xl">{card.value}</div>
+										</div>
+									</CardContent>
+								</Card>
+							))}
+						</div>
+
+						<div className="shrink-0">
+							<LogsVolumeChart
+								data={histogram ?? null}
+								loading={histogramIsLoading}
+								onTimeRangeChange={handleTimeRangeChange}
+								onResetZoom={handleResetZoom}
+								isZoomed={isZoomed}
+								startTime={urlState.start_time}
+								endTime={urlState.end_time}
+								isOpen={isChartOpen}
+								onOpenChange={setIsChartOpen}
+							/>
+						</div>
+
+						{(error || !!logsError) && (
+							<Alert variant="destructive" className="shrink-0">
+								<AlertCircle className="h-4 w-4" />
+								<AlertDescription>
+									{error ?? (logsError ? getErrorMessage(logsError as Parameters<typeof getErrorMessage>[0]) : "")}
+								</AlertDescription>
+							</Alert>
+						)}
+
+						<div className="min-h-0 flex-1">
+							<LogsDataTable
+								columns={columns}
+								data={logs}
+								loading={logsIsFetching}
+								totalItems={totalItems}
+								pagination={pagination}
+								onPaginationChange={setPagination}
+								onRowClick={(row, columnId) => {
+									if (columnId === "actions") return;
+									setUrlState({ selected_log: row.id }, { history: "replace" });
+									setSelectedSessionId(null);
+									setSessionHighlightedLogId(null);
+								}}
+								polling={polling}
+								onRefresh={refetchLogs}
+								columnEntries={columnEntries}
+								columnOrder={columnOrder}
+								columnVisibility={columnVisibility}
+								columnPinning={columnPinning}
+								onToggleColumnVisibility={toggleColumnVisibility}
+								onTogglePin={toggleColumnPin}
+								onReorderColumns={reorderColumns}
+							/>
+						</div>
+					</div>
+
+					{/* Log Detail Sheet */}
+					<LogDetailSheet
+						log={selectedLog}
+						open={selectedLog !== null}
+						onOpenChange={(open) => !open && setUrlState({ selected_log: "" })}
+						handleDelete={handleDelete}
+						onNavigate={handleLogNavigate}
+						hasPrev={selectedLogIndex > 0 || (selectedLogIndex !== -1 && pagination.offset > 0)}
+						hasNext={selectedLogIndex !== -1 && (selectedLogIndex < logs.length - 1 || pagination.offset + pagination.limit < totalItems)}
+						onFilterByParentRequestId={handleFilterByParentRequestId}
+						onViewSession={(sessionId, logId) => {
+							setUrlState({ selected_log: "" }, { history: "replace" });
+							setSessionHighlightedLogId(logId);
+							setSelectedSessionId(sessionId);
+						}}
+					/>
+					<SessionDetailsSheet
+						sessionId={selectedSessionId}
+						highlightedLogId={sessionHighlightedLogId}
+						open={selectedSessionId !== null}
+						onOpenChange={handleSessionSheetOpenChange}
+						onLogClick={(log) => {
+							setSelectedSessionId(null);
+							setUrlState({ selected_log: log.id }, { history: "replace" });
+						}}
+						onFilterByParentRequestId={handleFilterByParentRequestId}
+					/>
+				</div>
+			)}
+		</div>
+	);
 }

--- a/ui/app/workspace/logs/sheets/sessionDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/sessionDetailsSheet.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { useWebSocket } from "@/hooks/useWebSocket";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import type { ProviderName } from "@/lib/constants/logs";
 import { RequestTypeColors, RequestTypeLabels, Status, StatusBarColors } from "@/lib/constants/logs";
@@ -51,7 +50,6 @@ interface SessionDetailsSheetProps {
 	highlightedLogId?: string | null;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	liveEnabled: boolean;
 	onLogClick?: (log: LogEntry) => void;
 	onFilterByParentRequestId?: (parentRequestId: string) => void;
 }
@@ -61,7 +59,6 @@ export function SessionDetailsSheet({
 	highlightedLogId,
 	open,
 	onOpenChange,
-	liveEnabled,
 	onLogClick,
 	onFilterByParentRequestId,
 }: SessionDetailsSheetProps) {
@@ -74,7 +71,6 @@ export function SessionDetailsSheet({
 	const totalCountRef = useRef(totalCount);
 	const [hasMore, setHasMore] = useState(false);
 	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
-	const { subscribe } = useWebSocket();
 	const { data: sessionSummary } = useGetLogSessionSummaryByIdQuery(sessionId || "", {
 		skip: !open || !sessionId,
 		pollingInterval: 5000,
@@ -183,34 +179,6 @@ export function SessionDetailsSheet({
 		loadSessionPage(0, true);
 	}, [open, sessionId, sortOrder, loadSessionPage]);
 
-	useEffect(() => {
-		if (!open || !sessionId || !liveEnabled) {
-			return;
-		}
-		const unsubscribe = subscribe("log", (data) => {
-			const log = data.payload as LogEntry;
-			const operation = data.operation as "create" | "update";
-			if (!log?.parent_request_id || log.parent_request_id !== sessionId) {
-				return;
-			}
-
-			setSessionLogs((prev) => {
-				const idx = prev.findIndex((item) => item.id === log.id);
-				if (idx >= 0) {
-					const next = [...prev];
-					next[idx] = log;
-					return sortSessionLogs(next);
-				}
-				return sortSessionLogs([...prev, log]);
-			});
-
-			if (operation === "create") {
-				setTotalCount((prev) => prev + 1);
-				setHasMore((prev) => prev || fetchedCountRef.current < totalCountRef.current + 1);
-			}
-		});
-		return unsubscribe;
-	}, [open, sessionId, liveEnabled, subscribe, sortSessionLogs]);
 
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>

--- a/ui/app/workspace/logs/views/emptyState.tsx
+++ b/ui/app/workspace/logs/views/emptyState.tsx
@@ -70,11 +70,10 @@ function CodeBlock({ code, language, onLanguageChange, showLanguageSelect = fals
 }
 
 interface EmptyStateProps {
-	isSocketConnected: boolean;
 	error: string | null;
 }
 
-export function EmptyState({ isSocketConnected, error }: EmptyStateProps) {
+export function EmptyState({ error }: EmptyStateProps) {
 	const [language, setLanguage] = useState<Language>("python");
 
 	// Generate examples dynamically using the port utility
@@ -256,17 +255,6 @@ const result = await chain.invoke({ input: "What is LangChain?" });`,
 					<div>
 						<h3 className="text-lg font-semibold">Integrate under 60 seconds</h3>
 						<p className="text-muted-foreground text-sm">Send your first request to get started</p>
-					</div>
-					<div className="ml-auto">
-						{isSocketConnected && (
-							<div className="inline-flex items-center rounded-full border border-green-200 bg-green-50 px-3 py-1 text-xs font-medium text-green-700 sm:px-4 sm:text-sm">
-								<span className="relative mr-2 flex h-2 w-2 sm:mr-3">
-									<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75"></span>
-									<span className="relative inline-flex h-2 w-2 rounded-full bg-green-600"></span>
-								</span>
-								<span>Listening for logs...</span>
-							</div>
-						)}
 					</div>
 				</div>
 

--- a/ui/app/workspace/logs/views/logsHeaderView.tsx
+++ b/ui/app/workspace/logs/views/logsHeaderView.tsx
@@ -6,50 +6,22 @@ import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { getErrorMessage, useRecalculateLogCostsMutation } from "@/lib/store";
 import type { LogFilters as LogFiltersType } from "@/lib/types/logs";
-import { Calculator, MoreVertical, Pause, Play, Search } from "lucide-react";
+import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
+import { Calculator, MoreVertical, Radio, RefreshCw, Search } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-
-const LOG_TIME_PERIODS = [
-	{ label: "Last hour", value: "1h" },
-	{ label: "Last 6 hours", value: "6h" },
-	{ label: "Last 24 hours", value: "24h" },
-	{ label: "Last 7 days", value: "7d" },
-	{ label: "Last 30 days", value: "30d" },
-];
-
-function getRangeForPeriod(period: string): { from: Date; to: Date } {
-	const to = new Date();
-	const from = new Date(to.getTime());
-	switch (period) {
-		case "1h":
-			from.setHours(from.getHours() - 1);
-			break;
-		case "6h":
-			from.setHours(from.getHours() - 6);
-			break;
-		case "24h":
-			from.setHours(from.getHours() - 24);
-			break;
-		case "7d":
-			from.setDate(from.getDate() - 7);
-			break;
-		case "30d":
-			from.setDate(from.getDate() - 30);
-			break;
-		default:
-			from.setHours(from.getHours() - 24);
-	}
-	return { from, to };
-}
 
 interface LogsHeaderViewProps {
 	filters: LogFiltersType;
 	onFiltersChange: (filters: LogFiltersType) => void;
-	liveEnabled: boolean;
-	onLiveToggle: (enabled: boolean) => void;
 	fetchLogs: () => Promise<void>;
 	fetchStats: () => Promise<void>;
+	fetchHistogram: () => Promise<void>;
+	loading?: boolean;
+	polling: boolean;
+	onPollToggle: (enabled: boolean) => void;
+	period: string;
+	onPeriodChange: (period: string, from: Date, to: Date) => void;
 	/** Column config for the ColumnConfigDropdown */
 	columnEntries: ColumnConfigEntry[];
 	columnLabels: Record<string, string>;
@@ -60,10 +32,14 @@ interface LogsHeaderViewProps {
 export function LogsHeaderView({
 	filters,
 	onFiltersChange,
-	liveEnabled,
-	onLiveToggle,
 	fetchLogs,
 	fetchStats,
+	fetchHistogram,
+	loading = false,
+	polling,
+	onPollToggle,
+	period,
+	onPeriodChange,
 	columnEntries,
 	columnLabels,
 	onToggleColumnVisibility,
@@ -83,22 +59,17 @@ export function LogsHeaderView({
 		setEndTime(filters.end_time ? new Date(filters.end_time) : undefined);
 	}, [filters.start_time, filters.end_time]);
 
-	// Keep filtersRef in sync so debounced search always merges with latest filters (search within filtered results)
 	useEffect(() => {
 		filtersRef.current = filters;
 	}, [filters]);
 
-	// Sync localSearch when filters.content_search changes externally (e.g. URL restore)
 	useEffect(() => {
 		setLocalSearch(filters.content_search || "");
 	}, [filters.content_search]);
 
-	// Cleanup timeout on unmount
 	useEffect(() => {
 		return () => {
-			if (searchTimeoutRef.current) {
-				clearTimeout(searchTimeoutRef.current);
-			}
+			if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
 		};
 	}, []);
 
@@ -120,12 +91,7 @@ export function LogsHeaderView({
 	const handleSearchChange = useCallback(
 		(value: string) => {
 			setLocalSearch(value);
-
-			if (searchTimeoutRef.current) {
-				clearTimeout(searchTimeoutRef.current);
-			}
-
-			// Use filtersRef.current so search is applied on top of current filters (search within filtered results)
+			if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
 			searchTimeoutRef.current = setTimeout(() => {
 				onFiltersChange({ ...filtersRef.current, content_search: value });
 			}, 500);
@@ -135,18 +101,30 @@ export function LogsHeaderView({
 
 	return (
 		<div className="flex grow items-center justify-between space-x-2">
-			<Button variant={"outline"} size="sm" className="h-7.5" onClick={() => onLiveToggle(!liveEnabled)}>
-				{liveEnabled ? (
-					<>
-						<Pause className="h-4 w-4" />
-						Live updates
-					</>
-				) : (
-					<>
-						<Play className="h-4 w-4" />
-						Live updates
-					</>
-				)}
+			<Button
+				data-testid="logs-refresh-btn"
+				variant="outline"
+				size="sm"
+				className="h-7.5 disabled:opacity-100"
+				onClick={() => {
+					fetchLogs();
+					fetchStats();
+					fetchHistogram();
+				}}
+				disabled={loading}
+			>
+				<RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+				Refresh
+			</Button>
+			<Button
+				data-testid="logs-live-btn"
+				variant={polling ? "default" : "outline"}
+				size="sm"
+				className="h-7.5"
+				onClick={() => onPollToggle(!polling)}
+			>
+				{polling ? <Radio className="h-4 w-4 animate-pulse" /> : <Radio className="h-4 w-4" />}
+				Live
 			</Button>
 			<div className="border-input flex h-7.5 flex-1 items-center gap-2 rounded-sm border">
 				<Search className="mr-0.5 ml-2 size-4" />
@@ -162,6 +140,7 @@ export function LogsHeaderView({
 			<DateTimePickerWithRange
 				triggerTestId="filter-date-range"
 				dateTime={{ from: startTime, to: endTime }}
+				predefinedPeriod={period || undefined}
 				onDateTimeUpdate={(p) => {
 					setStartTime(p.from);
 					setEndTime(p.to);
@@ -171,17 +150,14 @@ export function LogsHeaderView({
 						end_time: p.to?.toISOString(),
 					});
 				}}
-				preDefinedPeriods={LOG_TIME_PERIODS}
+				preDefinedPeriods={TIME_PERIODS}
 				onPredefinedPeriodChange={(periodValue) => {
 					if (!periodValue) return;
 					const { from, to } = getRangeForPeriod(periodValue);
 					setStartTime(from);
 					setEndTime(to);
-					onFiltersChange({
-						...filters,
-						start_time: from.toISOString(),
-						end_time: to.toISOString(),
-					});
+					// Relative period: store it in URL and update timestamps via parent
+					onPeriodChange(periodValue, from, to);
 				}}
 			/>
 			<Popover open={openMoreActionsPopover} onOpenChange={setOpenMoreActionsPopover}>

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -1,342 +1,279 @@
 import {
-  buildPinStyle,
-  type ColumnConfigEntry,
-  DraggableColumnHeader,
-  PIN_SHADOW_LEFT,
-  PIN_SHADOW_RIGHT,
-  useHeaderCellRefs,
-  usePinOffsets,
+	buildPinStyle,
+	type ColumnConfigEntry,
+	DraggableColumnHeader,
+	PIN_SHADOW_LEFT,
+	PIN_SHADOW_RIGHT,
+	useHeaderCellRefs,
+	usePinOffsets,
 } from "@/components/table";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { useTablePageSize } from "@/hooks/useTablePageSize";
 import type { LogEntry, Pagination } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import type {
-  ColumnOrderState,
-  ColumnPinningState,
-  VisibilityState,
-} from "@tanstack/react-table";
-import {
-  ColumnDef,
-  flexRender,
-  getCoreRowModel,
-  SortingState,
-  useReactTable,
-} from "@tanstack/react-table";
-import { ChevronLeft, ChevronRight, Pause, RefreshCw, X } from "lucide-react";
+import type { ColumnOrderState, ColumnPinningState, VisibilityState } from "@tanstack/react-table";
+import { ColumnDef, flexRender, getCoreRowModel, SortingState, useReactTable } from "@tanstack/react-table";
+import { ChevronLeft, ChevronRight, Loader2, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 interface DataTableProps {
-  columns: ColumnDef<LogEntry>[];
-  data: LogEntry[];
-  totalItems: number;
-  loading?: boolean;
-  pagination: Pagination;
-  onPaginationChange: (pagination: Pagination) => void;
-  onRowClick?: (log: LogEntry, columnId: string) => void;
-  isSocketConnected: boolean;
-  liveEnabled: boolean;
-  /** Column config — computed by the parent via useColumnConfig */
-  columnEntries: ColumnConfigEntry[];
-  columnOrder: ColumnOrderState;
-  columnVisibility: VisibilityState;
-  columnPinning: ColumnPinningState;
-  onToggleColumnVisibility: (id: string) => void;
-  onTogglePin: (id: string, side: "left" | "right") => void;
-  onReorderColumns: (entries: ColumnConfigEntry[]) => void;
+	columns: ColumnDef<LogEntry>[];
+	data: LogEntry[];
+	totalItems: number;
+	pagination: Pagination;
+	onPaginationChange: (pagination: Pagination) => void;
+	onRowClick?: (log: LogEntry, columnId: string) => void;
+	polling: boolean;
+	loading?: boolean;
+	onRefresh: () => void;
+	/** Column config — computed by the parent via useColumnConfig */
+	columnEntries: ColumnConfigEntry[];
+	columnOrder: ColumnOrderState;
+	columnVisibility: VisibilityState;
+	columnPinning: ColumnPinningState;
+	onToggleColumnVisibility: (id: string) => void;
+	onTogglePin: (id: string, side: "left" | "right") => void;
+	onReorderColumns: (entries: ColumnConfigEntry[]) => void;
 }
 
 export function LogsDataTable({
-  columns,
-  data,
-  totalItems,
-  loading = false,
-  pagination,
-  onPaginationChange,
-  onRowClick,
-  isSocketConnected,
-  liveEnabled,
-  columnEntries,
-  columnOrder,
-  columnVisibility,
-  columnPinning,
-  onToggleColumnVisibility,
-  onTogglePin,
-  onReorderColumns,
+	columns,
+	data,
+	totalItems,
+	pagination,
+	onPaginationChange,
+	onRowClick,
+	polling,
+	loading,
+	onRefresh,
+	columnEntries,
+	columnOrder,
+	columnVisibility,
+	columnPinning,
+	onToggleColumnVisibility,
+	onTogglePin,
+	onReorderColumns,
 }: DataTableProps) {
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: pagination.sort_by, desc: pagination.order === "desc" },
-  ]);
-  const tableContainerRef = useRef<HTMLDivElement>(null);
-  const calculatedPageSize = useTablePageSize(tableContainerRef);
+	const [sorting, setSorting] = useState<SortingState>([{ id: pagination.sort_by, desc: pagination.order === "desc" }]);
+	const tableContainerRef = useRef<HTMLDivElement>(null);
+	const calculatedPageSize = useTablePageSize(tableContainerRef);
 
-  const fixedColumnIds = useMemo(() => new Set<string>([]), []);
+	const fixedColumnIds = useMemo(() => new Set<string>([]), []);
 
-  // Measure actual header cell widths for pixel-perfect pin offsets
-  const { headerCellRefs, setHeaderCellRef } = useHeaderCellRefs();
-  const pinOffsets = usePinOffsets(headerCellRefs, columnPinning);
+	// Measure actual header cell widths for pixel-perfect pin offsets
+	const { headerCellRefs, setHeaderCellRef } = useHeaderCellRefs();
+	const pinOffsets = usePinOffsets(headerCellRefs, columnPinning);
 
-  // Shadow on the edge of pinned groups
-  const lastLeftPinId = columnPinning.left?.at(-1);
-  const firstRightPinId = columnPinning.right?.at(0);
+	// Shadow on the edge of pinned groups
+	const lastLeftPinId = columnPinning.left?.at(-1);
+	const firstRightPinId = columnPinning.right?.at(0);
 
-  // Handle native drag-and-drop reorder
-  const handleColumnDrop = useCallback(
-    (draggedId: string, targetId: string) => {
-      const newEntries = [...columnEntries];
-      const draggedIdx = newEntries.findIndex((e) => e.id === draggedId);
-      const targetIdx = newEntries.findIndex((e) => e.id === targetId);
-      if (draggedIdx === -1 || targetIdx === -1) return;
-      const [moved] = newEntries.splice(draggedIdx, 1);
-      newEntries.splice(targetIdx, 0, moved);
-      onReorderColumns(newEntries);
-    },
-    [columnEntries, onReorderColumns],
-  );
+	// Handle native drag-and-drop reorder
+	const handleColumnDrop = useCallback(
+		(draggedId: string, targetId: string) => {
+			const newEntries = [...columnEntries];
+			const draggedIdx = newEntries.findIndex((e) => e.id === draggedId);
+			const targetIdx = newEntries.findIndex((e) => e.id === targetId);
+			if (draggedIdx === -1 || targetIdx === -1) return;
+			const [moved] = newEntries.splice(draggedIdx, 1);
+			newEntries.splice(targetIdx, 0, moved);
+			onReorderColumns(newEntries);
+		},
+		[columnEntries, onReorderColumns],
+	);
 
-  // Refs to avoid stale closures in the page size effect
-  const paginationRef = useRef(pagination);
-  const onPaginationChangeRef = useRef(onPaginationChange);
-  paginationRef.current = pagination;
-  onPaginationChangeRef.current = onPaginationChange;
+	// Refs to avoid stale closures in the page size effect
+	const paginationRef = useRef(pagination);
+	const onPaginationChangeRef = useRef(onPaginationChange);
+	paginationRef.current = pagination;
+	onPaginationChangeRef.current = onPaginationChange;
 
-  useEffect(() => {
-    if (
-      calculatedPageSize &&
-      calculatedPageSize > paginationRef.current.limit
-    ) {
-      onPaginationChangeRef.current({
-        ...paginationRef.current,
-        limit: calculatedPageSize,
-        offset: 0,
-      });
-    }
-  }, [calculatedPageSize]);
+	useEffect(() => {
+		if (calculatedPageSize && calculatedPageSize > paginationRef.current.limit) {
+			onPaginationChangeRef.current({
+				...paginationRef.current,
+				limit: calculatedPageSize,
+				offset: 0,
+			});
+		}
+	}, [calculatedPageSize]);
 
-  const handleSortingChange = (
-    updaterOrValue: SortingState | ((old: SortingState) => SortingState),
-  ) => {
-    const newSorting =
-      typeof updaterOrValue === "function"
-        ? updaterOrValue(sorting)
-        : updaterOrValue;
-    setSorting(newSorting);
-    if (newSorting.length > 0) {
-      const { id, desc } = newSorting[0];
-      onPaginationChange({
-        ...pagination,
-        sort_by: id as "timestamp" | "latency" | "tokens" | "cost",
-        order: desc ? "desc" : "asc",
-      });
-    }
-  };
+	const handleSortingChange = (updaterOrValue: SortingState | ((old: SortingState) => SortingState)) => {
+		const newSorting = typeof updaterOrValue === "function" ? updaterOrValue(sorting) : updaterOrValue;
+		setSorting(newSorting);
+		if (newSorting.length > 0) {
+			const { id, desc } = newSorting[0];
+			onPaginationChange({
+				...pagination,
+				sort_by: id as "timestamp" | "latency" | "tokens" | "cost",
+				order: desc ? "desc" : "asc",
+			});
+		}
+	};
 
-  const table = useReactTable({
-    data,
-    columns,
-    getCoreRowModel: getCoreRowModel(),
-    manualPagination: true,
-    manualSorting: true,
-    manualFiltering: true,
-    pageCount: Math.ceil(totalItems / pagination.limit),
-    state: {
-      sorting,
-      columnOrder,
-      columnVisibility,
-      columnPinning,
-    },
-    onSortingChange: handleSortingChange,
-  });
+	const table = useReactTable({
+		data,
+		columns,
+		getCoreRowModel: getCoreRowModel(),
+		manualPagination: true,
+		manualSorting: true,
+		manualFiltering: true,
+		pageCount: Math.ceil(totalItems / pagination.limit),
+		state: {
+			sorting,
+			columnOrder,
+			columnVisibility,
+			columnPinning,
+		},
+		onSortingChange: handleSortingChange,
+	});
 
-  const hasItems = totalItems > 0;
-  const currentPage = hasItems ? Math.floor(pagination.offset / pagination.limit) + 1 : 0;
-  const totalPages = hasItems ? Math.ceil(totalItems / pagination.limit) : 0;
-  const startItem = hasItems ? pagination.offset + 1 : 0;
-  const endItem = hasItems ? Math.min(pagination.offset + pagination.limit, totalItems) : 0;
+	const hasItems = totalItems > 0;
+	const currentPage = hasItems ? Math.floor(pagination.offset / pagination.limit) + 1 : 0;
+	const totalPages = hasItems ? Math.ceil(totalItems / pagination.limit) : 0;
+	const startItem = hasItems ? pagination.offset + 1 : 0;
+	const endItem = hasItems ? Math.min(pagination.offset + pagination.limit, totalItems) : 0;
 
-  const goToPage = (page: number) => {
-    const newOffset = (page - 1) * pagination.limit;
-    onPaginationChange({
-      ...pagination,
-      offset: newOffset,
-    });
-  };
+	const goToPage = (page: number) => {
+		const newOffset = (page - 1) * pagination.limit;
+		onPaginationChange({
+			...pagination,
+			offset: newOffset,
+		});
+	};
 
-  return (
-    <div className="flex h-full flex-col gap-2">
-      <div
-        ref={tableContainerRef}
-        className="min-h-0 flex-1 overflow-hidden rounded-sm border"
-      >
-        <Table containerClassName="h-full overflow-auto">
-          <thead
-            className={cn(
-              "[&_tr]:border-b px-2 sticky top-0 z-10 bg-[#f9f9f9] dark:bg-[#27272a]",
-            )}
-          >
-            {table.getHeaderGroups().map((headerGroup) => (
-              <tr
-                key={headerGroup.id}
-                className="hover:bg-muted/50 dark:hover:bg-muted/75 data-[state=selected]:bg-muted border-b transition-colors"
-              >
-                {headerGroup.headers.map((header) => (
-                  <DraggableColumnHeader
-                    key={header.id}
-                    header={header}
-                    isConfigurable={!fixedColumnIds.has(header.column.id)}
-                    pinStyle={buildPinStyle(header.column, pinOffsets)}
-                    pinnedHeaderClassName="bg-[#f9f9f9] dark:bg-[#27272a]"
-                    className={cn(
-                      header.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
-                      header.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
-                    )}
-                    onHide={onToggleColumnVisibility}
-                    onPin={onTogglePin}
-                    onDrop={handleColumnDrop}
-                    cellRef={setHeaderCellRef(header.column.id)}
-                  />
-                ))}
-              </tr>
-            ))}
-          </thead>
-          <TableBody>
-            {loading ? (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-12 text-center"
-                >
-                  <div className="flex items-center justify-center gap-2">
-                    <RefreshCw className="h-4 w-4 animate-spin" />
-                    Loading logs...
-                  </div>
-                </TableCell>
-              </TableRow>
-            ) : (
-              <>
-                <TableRow className="hover:bg-transparent">
-                  <TableCell
-                    colSpan={columns.length}
-                    className="h-12 text-center"
-                  >
-                    <div className="flex items-center justify-center gap-2">
-                      {!isSocketConnected ? (
-                        <>
-                          <X className="h-4 w-4" />
-                          Not connected to socket, please refresh the page.
-                        </>
-                      ) : liveEnabled ? (
-                        <>
-                          <RefreshCw className="h-4 w-4 animate-spin" />
-                          Listening for logs...
-                        </>
-                      ) : (
-                        <>
-                          <Pause className="h-4 w-4" />
-                          Live updates paused
-                        </>
-                      )}
-                    </div>
-                  </TableCell>
-                </TableRow>
-                {table.getRowModel().rows.length ? (
-                  table.getRowModel().rows.map((row) => (
-                    <TableRow
-                      key={row.id}
-                      className="hover:bg-muted/50 group/table-row min-h-[40px] cursor-pointer"
-                    >
-                      {row.getVisibleCells().map((cell) => {
-                        const pinned = cell.column.getIsPinned();
-                        const size = cell.column.getSize();
-                        return (
-                          <TableCell
-                            onClick={() =>
-                              onRowClick?.(row.original, cell.column.id)
-                            }
-                            key={cell.id}
-                            style={{
-                              width: size,
-                              minWidth: size,
-                              maxWidth: size,
-                              ...buildPinStyle(cell.column, pinOffsets),
-                            }}
-                            className={cn(
-                              "py-1.5 align-middle",
-                              pinned && "bg-card",
-                              cell.column.id === lastLeftPinId &&
-                                PIN_SHADOW_LEFT,
-                              cell.column.id === firstRightPinId &&
-                                PIN_SHADOW_RIGHT,
-                              "group-hover/table-row:bg-[#f7f7f7] dark:group-hover/table-row:bg-[#232327]",
-                            )}
-                          >
-                            {flexRender(
-                              cell.column.columnDef.cell,
-                              cell.getContext(),
-                            )}
-                          </TableCell>
-                        );
-                      })}
-                    </TableRow>
-                  ))
-                ) : (
-                  <TableRow>
-                    <TableCell
-                      colSpan={columns.length}
-                      className="h-24 text-center"
-                    >
-                      No results found. Try adjusting your filters and/or time
-                      range.
-                    </TableCell>
-                  </TableRow>
-                )}
-              </>
-            )}
-          </TableBody>
-        </Table>
-      </div>
+	return (
+		<div className="flex h-full flex-col gap-2">
+			<div ref={tableContainerRef} className="min-h-0 flex-1 overflow-hidden rounded-sm border">
+				<Table containerClassName="h-full overflow-auto">
+					<thead className={cn("[&_tr]:border-b px-2 sticky top-0 z-10 bg-[#f9f9f9] dark:bg-[#27272a]")}>
+						{table.getHeaderGroups().map((headerGroup) => (
+							<tr
+								key={headerGroup.id}
+								className="hover:bg-muted/50 dark:hover:bg-muted/75 data-[state=selected]:bg-muted border-b transition-colors"
+							>
+								{headerGroup.headers.map((header) => (
+									<DraggableColumnHeader
+										key={header.id}
+										header={header}
+										isConfigurable={!fixedColumnIds.has(header.column.id)}
+										pinStyle={buildPinStyle(header.column, pinOffsets)}
+										pinnedHeaderClassName="bg-[#f9f9f9] dark:bg-[#27272a]"
+										className={cn(
+											header.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
+											header.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
+										)}
+										onHide={onToggleColumnVisibility}
+										onPin={onTogglePin}
+										onDrop={handleColumnDrop}
+										cellRef={setHeaderCellRef(header.column.id)}
+									/>
+								))}
+							</tr>
+						))}
+					</thead>
+					<TableBody>
+						<TableRow className="hover:bg-transparent">
+							<TableCell colSpan={columns.length} className="h-12 text-center">
+								<div className="text-muted-foreground flex items-center justify-center gap-2 text-sm">
+									{polling ? (
+										<>
+											<RefreshCw className="h-4 w-4 animate-spin" />
+											Waiting for new logs...
+										</>
+									) : (
+										<Button
+											type="button"
+											onClick={onRefresh}
+											data-testid="logs-table-refresh-btn"
+											className="hover:text-foreground inline-flex items-center gap-1.5 transition-colors"
+											variant={"ghost"}
+										>
+											{loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+											Refresh
+										</Button>
+									)}
+								</div>
+							</TableCell>
+						</TableRow>
+						{table.getRowModel().rows.length ? (
+							table.getRowModel().rows.map((row) => (
+								<TableRow key={row.id} className="hover:bg-muted/50 group/table-row min-h-[40px] cursor-pointer">
+									{row.getVisibleCells().map((cell) => {
+										const pinned = cell.column.getIsPinned();
+										const size = cell.column.getSize();
+										return (
+											<TableCell
+												onClick={() => onRowClick?.(row.original, cell.column.id)}
+												key={cell.id}
+												style={{
+													width: size,
+													minWidth: size,
+													maxWidth: size,
+													...buildPinStyle(cell.column, pinOffsets),
+												}}
+												className={cn(
+													"py-1.5 align-middle",
+													pinned && "bg-card",
+													cell.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
+													cell.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
+													"group-hover/table-row:bg-[#f7f7f7] dark:group-hover/table-row:bg-[#232327]",
+												)}
+											>
+												{flexRender(cell.column.columnDef.cell, cell.getContext())}
+											</TableCell>
+										);
+									})}
+								</TableRow>
+							))
+						) : (
+							<TableRow>
+								<TableCell colSpan={columns.length} className="h-24 text-center">
+									No results found. Try adjusting your filters and/or time range.
+								</TableCell>
+							</TableRow>
+						)}
+					</TableBody>
+				</Table>
+			</div>
 
-      {/* Pagination Footer */}
-      <div
-        className="flex shrink-0 items-center justify-between text-xs"
-        data-testid="pagination"
-      >
-        <div className="text-muted-foreground flex items-center gap-2">
-          {startItem.toLocaleString()}-{endItem.toLocaleString()} of{" "}
-          {totalItems.toLocaleString()} entries
-        </div>
+			{/* Pagination Footer */}
+			<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
+				<div className="text-muted-foreground flex items-center gap-2">
+					{startItem.toLocaleString()}-{endItem.toLocaleString()} of {totalItems.toLocaleString()} entries
+				</div>
 
-        <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => goToPage(currentPage - 1)}
-            disabled={currentPage <= 1}
-            data-testid="prev-page"
-            aria-label="Previous page"
-          >
-            <ChevronLeft className="size-3" />
-          </Button>
+				<div className="flex items-center gap-2">
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => goToPage(currentPage - 1)}
+						disabled={currentPage <= 1}
+						data-testid="prev-page"
+						aria-label="Previous page"
+					>
+						<ChevronLeft className="size-3" />
+					</Button>
 
-          <div className="flex items-center gap-1">
-            <span>Page</span>
-            <span>{currentPage}</span>
-            <span>of {totalPages}</span>
-          </div>
+					<div className="flex items-center gap-1">
+						<span>Page</span>
+						<span>{currentPage}</span>
+						<span>of {totalPages}</span>
+					</div>
 
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => goToPage(currentPage + 1)}
-            disabled={totalPages === 0 || currentPage >= totalPages}
-            data-testid="next-page"
-            aria-label="Next page"
-          >
-            <ChevronRight className="size-3" />
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={() => goToPage(currentPage + 1)}
+						disabled={totalPages === 0 || currentPage >= totalPages}
+						data-testid="next-page"
+						aria-label="Next page"
+					>
+						<ChevronRight className="size-3" />
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
 }

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -3,13 +3,15 @@ import FullPageLoader from "@/components/fullPageLoader";
 import { useColumnConfig } from "@/components/table";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent } from "@/components/ui/card";
-import { useWebSocket } from "@/hooks/useWebSocket";
-import { getErrorMessage, useDeleteMCPLogsMutation, useLazyGetMCPLogsQuery, useLazyGetMCPLogsStatsQuery } from "@/lib/store";
-import type { MCPToolLogEntry, MCPToolLogFilters, MCPToolLogStats, Pagination } from "@/lib/types/logs";
+import { getErrorMessage, useDeleteMCPLogsMutation, useGetMCPLogsQuery, useGetMCPLogsStatsQuery } from "@/lib/store";
+import { useLazyGetMCPLogsQuery } from "@/lib/store/apis/mcpLogsApi";
+import type { MCPToolLogEntry, MCPToolLogFilters, Pagination } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
 import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
+import { getRangeForPeriod } from "@/lib/utils/timeRange";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import NumberFlow from "@number-flow/react";
+import { useLocation } from "@tanstack/react-router";
 import { AlertCircle, CheckCircle, Clock, DollarSign, Hash } from "lucide-react";
 import { parseAsArrayOf, parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -20,19 +22,14 @@ import { MCPLogDetailSheet } from "./views/mcpLogDetailsSheet";
 import { MCPLogsDataTable } from "./views/mcpLogsTable";
 
 export default function MCPLogsPage() {
-	const [logs, setLogs] = useState<MCPToolLogEntry[]>([]);
-	const [totalItems, setTotalItems] = useState(0);
-	const [stats, setStats] = useState<MCPToolLogStats | null>(null);
-	const [initialLoading, setInitialLoading] = useState(true);
-	const [fetchingLogs, setFetchingLogs] = useState(false);
-	const [fetchingStats, setFetchingStats] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [showEmptyState, setShowEmptyState] = useState(false);
+	const hasCheckedEmptyState = useRef(false);
 	const hasDeleteAccess = useRbac(RbacResource.Logs, RbacOperation.Delete);
 
-	const [triggerGetLogs] = useLazyGetMCPLogsQuery();
-	const [triggerGetStats] = useLazyGetMCPLogsStatsQuery();
 	const [deleteLogs] = useDeleteMCPLogsMutation();
+	// Lazy query kept only for handleLogNavigate (fetches adjacent pages on demand)
+	const [triggerGetLogs] = useLazyGetMCPLogsQuery();
 
 	// Track if user has manually modified the time range
 	const userModifiedTimeRange = useRef<boolean>(false);
@@ -40,12 +37,11 @@ export default function MCPLogsPage() {
 	// Capture initial defaults on mount to detect shared URLs with custom time ranges
 	const initialDefaults = useRef(dateUtils.getDefaultTimeRange());
 
-	// Memoize default time range to prevent recalculation on every render
-	// This is crucial to avoid triggering re-fetches when the sheet opens/closes
 	const defaultTimeRange = useMemo(() => dateUtils.getDefaultTimeRange(), []);
-
-	// Get fresh default time range for refresh logic
 	const getDefaultTimeRange = () => dateUtils.getDefaultTimeRange();
+
+	const { search } = useLocation();
+	const hasExplicitTimeRange = (search as Record<string, unknown>)?.start_time && (search as Record<string, unknown>)?.end_time;
 
 	// URL state management
 	const [urlState, setUrlState] = useQueryStates(
@@ -61,7 +57,8 @@ export default function MCPLogsPage() {
 			offset: parseAsInteger.withDefault(0),
 			sort_by: parseAsString.withDefault("timestamp"),
 			order: parseAsString.withDefault("desc"),
-			live_enabled: parseAsBoolean.withDefault(true),
+			polling: parseAsBoolean.withDefault(true).withOptions({ clearOnDefault: false }),
+			period: parseAsString.withDefault(hasExplicitTimeRange ? "" : "1h").withOptions({ clearOnDefault: false }),
 			selected_log: parseAsString.withDefault(""),
 		},
 		{
@@ -70,35 +67,42 @@ export default function MCPLogsPage() {
 		},
 	);
 
-	// Derive selectedLog from URL param
 	const selectedLogId = urlState.selected_log || null;
-	const selectedLog = useMemo(() => (selectedLogId ? (logs.find((l) => l.id === selectedLogId) ?? null) : null), [selectedLogId, logs]);
+	const polling = urlState.polling;
 
-	// Refresh time range defaults on page focus/visibility
+	// Refresh time range on page focus/visibility
 	useEffect(() => {
 		const refreshDefaultsIfStale = () => {
-			// Skip refresh if user has manually modified the time range
-			if (userModifiedTimeRange.current) {
+			if (urlState.period) {
+				const { from, to } = getRangeForPeriod(urlState.period);
+				setUrlState(
+					{
+						start_time: Math.floor(from.getTime() / 1000),
+						end_time: Math.floor(to.getTime() / 1000),
+						period: urlState.period ?? "",
+					},
+					{ history: "replace" },
+				);
 				return;
 			}
 
-			// Check if current time range matches the initial defaults (within tolerance)
+			if (userModifiedTimeRange.current) return;
+
 			const startTimeDiff = Math.abs(urlState.start_time - initialDefaults.current.startTime);
 			const endTimeDiff = Math.abs(urlState.end_time - initialDefaults.current.endTime);
-			const tolerance = 5; // 5 seconds tolerance for slight timing differences
-
-			// Only refresh if current values match the initial defaults
-			// This preserves shared URLs with custom time ranges
+			const tolerance = 5;
 			if (startTimeDiff <= tolerance && endTimeDiff <= tolerance) {
 				const defaults = getDefaultTimeRange();
 				const currentEndDiff = Math.abs(urlState.end_time - defaults.endTime);
-				// If end time is more than 5 minutes old, refresh both
 				if (currentEndDiff > 300) {
-					setUrlState({
-						start_time: defaults.startTime,
-						end_time: defaults.endTime,
-					});
-					// Update baseline so subsequent focus events compare against refreshed defaults
+					setUrlState(
+						{
+							start_time: defaults.startTime,
+							end_time: defaults.endTime,
+							period: urlState.period ?? "",
+						},
+						{ history: "replace" },
+					);
 					initialDefaults.current.startTime = defaults.startTime;
 					initialDefaults.current.endTime = defaults.endTime;
 				}
@@ -106,14 +110,9 @@ export default function MCPLogsPage() {
 		};
 
 		const handleVisibilityChange = () => {
-			if (!document.hidden) {
-				refreshDefaultsIfStale();
-			}
+			if (!document.hidden) refreshDefaultsIfStale();
 		};
-
-		const handleFocus = () => {
-			refreshDefaultsIfStale();
-		};
+		const handleFocus = () => refreshDefaultsIfStale();
 
 		document.addEventListener("visibilitychange", handleVisibilityChange);
 		window.addEventListener("focus", handleFocus);
@@ -121,9 +120,30 @@ export default function MCPLogsPage() {
 			document.removeEventListener("visibilitychange", handleVisibilityChange);
 			window.removeEventListener("focus", handleFocus);
 		};
-	}, [urlState.start_time, urlState.end_time, setUrlState]);
+	}, [urlState.period, urlState.start_time, urlState.end_time, setUrlState]);
 
-	// Convert URL state to filters and pagination
+	// Refresh the time window every 5s while live polling is on and a relative period is active.
+	// Updating start_time/end_time changes RTK args → triggers a refetch without needing pollingInterval.
+	useEffect(() => {
+		if (!polling || !urlState.period) return;
+
+		const id = setInterval(() => {
+			if (document.hidden) return;
+			const { from, to } = getRangeForPeriod(urlState.period);
+			setUrlState(
+				{
+					start_time: Math.floor(from.getTime() / 1000),
+					end_time: Math.floor(to.getTime() / 1000),
+					period: urlState.period ?? "",
+				},
+				{ history: "replace" },
+			);
+		}, 5000);
+
+		return () => clearInterval(id);
+	}, [polling, urlState.period, setUrlState]);
+
+	// Convert URL state to filters and pagination for API calls
 	const filters: MCPToolLogFilters = useMemo(
 		() => ({
 			tool_names: urlState.tool_names,
@@ -134,7 +154,6 @@ export default function MCPLogsPage() {
 			start_time: dateUtils.toISOString(urlState.start_time),
 			end_time: dateUtils.toISOString(urlState.end_time),
 		}),
-		// Only re-derive filters when filter-related URL params change (not pagination)
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[
 			urlState.tool_names,
@@ -157,17 +176,79 @@ export default function MCPLogsPage() {
 		[urlState.limit, urlState.offset, urlState.sort_by, urlState.order],
 	);
 
-	const liveEnabled = urlState.live_enabled;
+	// Non-lazy RTK Query hooks
+	const {
+		data: logsData,
+		isLoading: logsIsLoading,
+		isFetching: logsIsFetching,
+		error: logsError,
+		refetch: refetchLogs,
+	} = useGetMCPLogsQuery(
+		{ filters, pagination },
+		{
+			// When a relative period is active, the setInterval above updates URL timestamps → RTK
+			// detects arg changes and refetches automatically; no separate pollingInterval needed.
+			pollingInterval: showEmptyState ? 3000 : polling && !urlState.period ? 5000 : 0,
+			refetchOnMountOrArgChange: true,
+			skipPollingIfUnfocused: true,
+		},
+	);
+
+	const {
+		data: statsData,
+		isFetching: statsIsFetching,
+		refetch: refetchStats,
+	} = useGetMCPLogsStatsQuery({ filters }, { refetchOnMountOrArgChange: true });
+
+	const refreshAllData = useCallback(() => {
+		refetchLogs();
+		refetchStats();
+	}, [refetchLogs, refetchStats]);
+
+	// Derive data directly from RTK
+	const logs = logsData?.logs ?? [];
+	const totalItems = logsData?.stats?.total_executions ?? 0;
+
+	const selectedLog = useMemo(() => (selectedLogId ? (logs.find((l) => l.id === selectedLogId) ?? null) : null), [selectedLogId, logs]);
+
+	// Set showEmptyState on first response; clear it as soon as logs appear.
+	useEffect(() => {
+		if (!logsData) return;
+		if (!hasCheckedEmptyState.current) {
+			setShowEmptyState(!logsData.has_logs);
+			hasCheckedEmptyState.current = true;
+		} else if (showEmptyState && logsData.has_logs) {
+			setShowEmptyState(false);
+		}
+	}, [logsData, showEmptyState]);
+
+	// On mount: freshen period timestamps if stale
+	useEffect(() => {
+		if (urlState.period) {
+			const { from, to } = getRangeForPeriod(urlState.period);
+			const freshEnd = Math.floor(to.getTime() / 1000);
+			if (Math.abs(urlState.end_time - freshEnd) > 60) {
+				setUrlState(
+					{
+						start_time: Math.floor(from.getTime() / 1000),
+						end_time: freshEnd,
+						period: urlState.period ?? "",
+					},
+					{ history: "replace" },
+				);
+			}
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	// Helper to update filters in URL
 	const setFilters = useCallback(
 		(newFilters: MCPToolLogFilters) => {
-			// Mark time range as user-modified if start_time or end_time is being set
-			if (newFilters.start_time !== undefined || newFilters.end_time !== undefined) {
-				userModifiedTimeRange.current = true;
-			}
+			const timeChanged = newFilters.start_time !== undefined || newFilters.end_time !== undefined;
+			if (timeChanged) userModifiedTimeRange.current = true;
 
 			setUrlState({
+				...(timeChanged && { period: "" }),
 				tool_names: newFilters.tool_names || [],
 				server_labels: newFilters.server_labels || [],
 				status: newFilters.status || [],
@@ -196,258 +277,79 @@ export default function MCPLogsPage() {
 
 	const handleDelete = useCallback(
 		async (log: MCPToolLogEntry) => {
-			// Guard against unauthorized delete attempts
-			if (!hasDeleteAccess) {
-				throw new Error("No delete access");
-			}
-
+			if (!hasDeleteAccess) throw new Error("No delete access");
 			try {
 				await deleteLogs({ ids: [log.id] }).unwrap();
-				setLogs((prevLogs) => prevLogs.filter((l) => l.id !== log.id));
-				setTotalItems((prev) => prev - 1);
 				if (urlState.selected_log === log.id) {
 					setUrlState({ selected_log: "" });
 				}
+				refreshAllData();
 			} catch (err) {
 				const errorMessage = getErrorMessage(err);
 				setError(errorMessage);
 				throw new Error(errorMessage);
 			}
 		},
-		[deleteLogs, hasDeleteAccess, urlState.selected_log, setUrlState],
+		[deleteLogs, hasDeleteAccess, urlState.selected_log, setUrlState, refreshAllData],
 	);
 
-	// Ref to track latest state for WebSocket callbacks
-	const latest = useRef({ logs, filters, pagination, showEmptyState, liveEnabled });
-	useEffect(() => {
-		latest.current = { logs, filters, pagination, showEmptyState, liveEnabled };
-	}, [logs, filters, pagination, showEmptyState, liveEnabled]);
-
-	// Helper to check if a log matches current filters
-	const matchesFilters = (log: MCPToolLogEntry, filters: MCPToolLogFilters, applyTimeFilters = true): boolean => {
-		if (filters.tool_names?.length && !filters.tool_names.includes(log.tool_name)) {
-			return false;
-		}
-		if (filters.server_labels?.length && (!log.server_label || !filters.server_labels.includes(log.server_label))) {
-			return false;
-		}
-		if (filters.status?.length && !filters.status.includes(log.status)) {
-			return false;
-		}
-		if (filters.virtual_key_ids?.length && (!log.virtual_key_id || !filters.virtual_key_ids.includes(log.virtual_key_id))) {
-			return false;
-		}
-		if (filters.start_time && new Date(log.timestamp) < new Date(filters.start_time)) {
-			return false;
-		}
-		if (applyTimeFilters && filters.end_time && new Date(log.timestamp) > new Date(filters.end_time)) {
-			return false;
-		}
-		return true;
-	};
-
-	// Handle WebSocket log messages
-	const handleMCPLogMessage = useCallback((log: MCPToolLogEntry, operation: "create" | "update") => {
-		const { logs, filters, pagination, showEmptyState, liveEnabled } = latest.current;
-
-		// Exit empty state if we now have logs
-		if (showEmptyState) {
-			setShowEmptyState(false);
-		}
-
-		if (operation === "create") {
-			// Only prepend new log if on first page and sorted by timestamp desc
-			if (pagination.offset === 0 && pagination.sort_by === "timestamp" && pagination.order === "desc") {
-				if (!matchesFilters(log, filters, !liveEnabled)) {
-					return;
-				}
-
-				setLogs((prevLogs: MCPToolLogEntry[]) => {
-					// Prevent duplicates
-					if (prevLogs.some((existingLog) => existingLog.id === log.id)) {
-						return prevLogs;
-					}
-
-					const updatedLogs = [log, ...prevLogs];
-					if (updatedLogs.length > pagination.limit) {
-						updatedLogs.pop();
-					}
-					return updatedLogs;
-				});
-
-				setTotalItems((prev: number) => prev + 1);
-			}
-		} else if (operation === "update") {
-			const logExists = logs.some((existingLog) => existingLog.id === log.id);
-
-			if (!logExists) {
-				// Fallback: if log doesn't exist, treat as create
-				if (pagination.offset === 0 && pagination.sort_by === "timestamp" && pagination.order === "desc") {
-					if (matchesFilters(log, filters, !liveEnabled)) {
-						setLogs((prevLogs: MCPToolLogEntry[]) => {
-							if (prevLogs.some((existingLog) => existingLog.id === log.id)) {
-								return prevLogs.map((existingLog) => (existingLog.id === log.id ? log : existingLog));
-							}
-
-							const updatedLogs = [log, ...prevLogs];
-							if (updatedLogs.length > pagination.limit) {
-								updatedLogs.pop();
-							}
-							return updatedLogs;
-						});
-					}
-				}
-			} else {
-				// Update existing log
-				setLogs((prevLogs: MCPToolLogEntry[]) => {
-					return prevLogs.map((existingLog) => (existingLog.id === log.id ? log : existingLog));
-				});
-
-				// Update stats for completed requests
-				if (log.status === "success" || log.status === "error") {
-					setStats((prevStats) => {
-						if (!prevStats) return prevStats;
-
-						const newStats = { ...prevStats };
-						const completed_executions = prevStats.total_executions + 1;
-						newStats.total_executions = completed_executions;
-
-						// Update success rate
-						const successCount = (prevStats.success_rate / 100) * prevStats.total_executions;
-						const newSuccessCount = log.status === "success" ? successCount + 1 : successCount;
-						newStats.success_rate = (newSuccessCount / completed_executions) * 100;
-
-						// Update average latency
-						if (log.latency) {
-							const totalLatency = prevStats.average_latency * prevStats.total_executions;
-							newStats.average_latency = (totalLatency + log.latency) / completed_executions;
-						}
-
-						// Update total cost
-						newStats.total_cost = (Number(newStats.total_cost) || 0) + Number(log.cost ?? 0);
-
-						return newStats;
-					});
-				}
-			}
-		}
-	}, []);
-
-	const { isConnected: isSocketConnected, subscribe } = useWebSocket();
-
-	// Subscribe to MCP log messages - only when live updates are enabled
-	useEffect(() => {
-		if (!liveEnabled) {
-			return;
-		}
-
-		const unsubscribe = subscribe("mcp_log", (data) => {
-			const { payload, operation } = data;
-			handleMCPLogMessage(payload, operation);
-		});
-
-		return unsubscribe;
-	}, [handleMCPLogMessage, subscribe, liveEnabled]);
-
-	// Fetch logs
-	const fetchLogs = useCallback(async () => {
-		setFetchingLogs(true);
-		setError(null);
-		try {
-			const result = await triggerGetLogs({ filters, pagination }).unwrap();
-			setLogs(result.logs || []);
-			setTotalItems(result.stats?.total_executions || 0);
-
-			if (initialLoading) {
-				setShowEmptyState(result.has_logs === false);
-			}
-		} catch (err) {
-			setError(getErrorMessage(err));
-			setLogs([]);
-			setTotalItems(0);
-			setShowEmptyState(true);
-		} finally {
-			setFetchingLogs(false);
-		}
-	}, [filters, pagination, triggerGetLogs, initialLoading]);
-
-	const fetchStats = useCallback(async () => {
-		setFetchingStats(true);
-		try {
-			const result = await triggerGetStats({ filters }).unwrap();
-			setStats(result);
-		} catch (err) {
-			console.error("Failed to fetch stats:", err);
-		} finally {
-			setFetchingStats(false);
-		}
-	}, [filters, triggerGetStats]);
-
-	// Helper to toggle live updates
-	const handleLiveToggle = useCallback(
-		(enabled: boolean) => {
-			setUrlState({ live_enabled: enabled });
-			// When re-enabling, refetch logs to get latest data
-			if (enabled) {
-				fetchLogs();
-			}
+	const handlePeriodChange = useCallback(
+		(p: string, from: Date, to: Date) => {
+			setUrlState({
+				period: p,
+				start_time: Math.floor(from.getTime() / 1000),
+				end_time: Math.floor(to.getTime() / 1000),
+				offset: 0,
+			});
 		},
-		[setUrlState, fetchLogs],
+		[setUrlState],
 	);
 
-	// Initial load
-	useEffect(() => {
-		const initialLoad = async () => {
-			await fetchLogs();
-			fetchStats();
-			setInitialLoading(false);
-		};
-		initialLoad();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
-
-	// Fetch logs when filters or pagination change
-	useEffect(() => {
-		if (!initialLoading) {
-			fetchLogs();
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [filters, pagination, initialLoading]);
-
-	// Fetch stats when filters change
-	useEffect(() => {
-		if (!initialLoading) {
-			fetchStats();
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [filters, initialLoading]);
+	const handlePollToggle = useCallback(
+		(enabled: boolean) => {
+			setUrlState({ polling: enabled });
+			if (enabled) refreshAllData();
+		},
+		[setUrlState, refreshAllData],
+	);
 
 	const statCards = useMemo(
 		() => [
 			{
 				title: "Total Executions",
-				value: <NumberFlow value={stats?.total_executions ?? 0} format={COMPACT_NUMBER_FORMAT} />,
+				value: <NumberFlow value={statsData?.total_executions ?? 0} format={COMPACT_NUMBER_FORMAT} />,
 				icon: <Hash className="size-4" />,
 			},
 			{
 				title: "Success Rate",
-				value: <NumberFlow value={stats?.success_rate ?? 0} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="%" />,
+				value: (
+					<NumberFlow value={statsData?.success_rate ?? 0} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="%" />
+				),
 				icon: <CheckCircle className="size-4" />,
 			},
 			{
 				title: "Avg Latency",
 				value: (
-					<NumberFlow value={stats?.average_latency ?? 0} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="ms" />
+					<NumberFlow value={statsData?.average_latency ?? 0} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="ms" />
 				),
 				icon: <Clock className="size-4" />,
 			},
 			{
 				title: "Total Cost",
-				value: <NumberFlow value={stats?.total_cost ?? 0} format={{ ...COMPACT_NUMBER_FORMAT, style: "currency", currency: "USD" }} />,
+				value: (
+					<NumberFlow
+						value={statsData?.total_cost ?? 0}
+						format={{
+							...COMPACT_NUMBER_FORMAT,
+							style: "currency",
+							currency: "USD",
+						}}
+					/>
+				),
 				icon: <DollarSign className="size-4" />,
 			},
 		],
-		[stats],
+		[statsData],
 	);
 
 	const columns = useMemo(() => createMCPColumns(handleDelete, hasDeleteAccess), [handleDelete, hasDeleteAccess]);
@@ -477,9 +379,12 @@ export default function MCPLogsPage() {
 		togglePin: toggleColumnPin,
 		reorder: reorderColumns,
 		reset: resetColumns,
-	} = useColumnConfig({ columnIds, paramName: "mcp_cols", fixedColumns: { left: [], right: [] } });
+	} = useColumnConfig({
+		columnIds,
+		paramName: "mcp_cols",
+		fixedColumns: { left: [], right: [] },
+	});
 
-	// Navigation for log detail sheet
 	const selectedLogIndex = useMemo(() => (selectedLogId ? logs.findIndex((l) => l.id === selectedLogId) : -1), [selectedLogId, logs]);
 
 	const handleLogNavigate = useCallback(
@@ -529,25 +434,14 @@ export default function MCPLogsPage() {
 		[selectedLogId, selectedLogIndex, logs, pagination, totalItems, filters, setUrlState, triggerGetLogs],
 	);
 
+	const displayError = error ?? (logsError ? getErrorMessage(logsError as Parameters<typeof getErrorMessage>[0]) : null);
+
 	return (
 		<div className="dark:bg-card bg-white">
-			{initialLoading ? (
+			{logsIsLoading ? (
 				<FullPageLoader />
 			) : showEmptyState ? (
-				<MCPEmptyState
-					error={error}
-					statusIndicator={
-						isSocketConnected && (
-							<div className="inline-flex items-center rounded-full border border-green-200 bg-green-50 px-3 py-1 text-xs font-medium text-green-700 sm:px-4 sm:text-sm">
-								<span className="relative mr-2 flex h-2 w-2 sm:mr-3">
-									<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75"></span>
-									<span className="relative inline-flex h-2 w-2 rounded-full bg-green-600"></span>
-								</span>
-								<span>Listening for tool executions...</span>
-							</div>
-						)
-					}
-				/>
+				<MCPEmptyState error={displayError} />
 			) : (
 				<div className="no-padding-parent no-border-parent bg-background flex h-[calc(100vh_-_16px)] w-full gap-3">
 					{/* Sidebar Filters */}
@@ -559,8 +453,12 @@ export default function MCPLogsPage() {
 							<McpHeaderView
 								filters={filters}
 								onFiltersChange={setFilters}
-								liveEnabled={liveEnabled}
-								onLiveToggle={handleLiveToggle}
+								period={urlState.period}
+								onPeriodChange={handlePeriodChange}
+								polling={polling}
+								onPollToggle={handlePollToggle}
+								onRefresh={refreshAllData}
+								loading={logsIsFetching}
 								columnEntries={columnEntries}
 								columnLabels={MCP_COLUMN_LABELS}
 								onToggleColumnVisibility={toggleColumnVisibility}
@@ -573,7 +471,7 @@ export default function MCPLogsPage() {
 								{statCards.map((card) => (
 									<Card key={card.title} className="py-4 shadow-none">
 										<CardContent
-											className={`flex items-center justify-between px-4 transition-opacity duration-200 ${fetchingStats ? "opacity-50" : "opacity-100"}`}
+											className={`flex items-center justify-between px-4 transition-opacity duration-200 ${statsIsFetching ? "opacity-50" : "opacity-100"}`}
 										>
 											<div className="w-full min-w-0">
 												<div className="text-muted-foreground text-xs">{card.title}</div>
@@ -584,11 +482,10 @@ export default function MCPLogsPage() {
 								))}
 							</div>
 
-							{/* Error Alert */}
-							{error && (
+							{displayError && (
 								<Alert variant="destructive" className="shrink-0">
 									<AlertCircle className="h-4 w-4" />
-									<AlertDescription>{error}</AlertDescription>
+									<AlertDescription>{displayError}</AlertDescription>
 								</Alert>
 							)}
 						</div>
@@ -597,15 +494,15 @@ export default function MCPLogsPage() {
 							columns={columns}
 							data={logs}
 							totalItems={totalItems}
-							loading={fetchingLogs}
+							loading={logsIsFetching}
 							pagination={pagination}
 							onPaginationChange={setPagination}
 							onRowClick={(row, columnId) => {
 								if (columnId === "actions") return;
 								setUrlState({ selected_log: row.id }, { history: "replace" });
 							}}
-							isSocketConnected={isSocketConnected}
-							liveEnabled={liveEnabled}
+							onRefresh={refreshAllData}
+							polling={polling}
 							columnEntries={columnEntries}
 							columnOrder={columnOrder}
 							columnVisibility={columnVisibility}

--- a/ui/app/workspace/mcp-logs/views/mcpHeaderView.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpHeaderView.tsx
@@ -3,47 +3,19 @@ import { Button } from "@/components/ui/button";
 import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
 import { Input } from "@/components/ui/input";
 import type { MCPToolLogFilters } from "@/lib/types/logs";
-import { Pause, Play, Search } from "lucide-react";
+import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
+import { Radio, RefreshCw, Search } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-
-const LOG_TIME_PERIODS = [
-	{ label: "Last hour", value: "1h" },
-	{ label: "Last 6 hours", value: "6h" },
-	{ label: "Last 24 hours", value: "24h" },
-	{ label: "Last 7 days", value: "7d" },
-	{ label: "Last 30 days", value: "30d" },
-];
-
-function getRangeForPeriod(period: string): { from: Date; to: Date } {
-	const to = new Date();
-	const from = new Date(to.getTime());
-	switch (period) {
-		case "1h":
-			from.setHours(from.getHours() - 1);
-			break;
-		case "6h":
-			from.setHours(from.getHours() - 6);
-			break;
-		case "24h":
-			from.setHours(from.getHours() - 24);
-			break;
-		case "7d":
-			from.setDate(from.getDate() - 7);
-			break;
-		case "30d":
-			from.setDate(from.getDate() - 30);
-			break;
-		default:
-			from.setHours(from.getHours() - 24);
-	}
-	return { from, to };
-}
 
 interface McpHeaderViewProps {
 	filters: MCPToolLogFilters;
 	onFiltersChange: (filters: MCPToolLogFilters) => void;
-	liveEnabled: boolean;
-	onLiveToggle: (enabled: boolean) => void;
+	period: string;
+	onPeriodChange: (period: string, from: Date, to: Date) => void;
+	polling: boolean;
+	onPollToggle: (enabled: boolean) => void;
+	onRefresh: () => void;
+	loading?: boolean;
 	/** Column config for the ColumnConfigDropdown */
 	columnEntries: ColumnConfigEntry[];
 	columnLabels: Record<string, string>;
@@ -54,8 +26,12 @@ interface McpHeaderViewProps {
 export function McpHeaderView({
 	filters,
 	onFiltersChange,
-	liveEnabled,
-	onLiveToggle,
+	period,
+	onPeriodChange,
+	polling,
+	onPollToggle,
+	onRefresh,
+	loading = false,
 	columnEntries,
 	columnLabels,
 	onToggleColumnVisibility,
@@ -67,38 +43,26 @@ export function McpHeaderView({
 	const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 	const filtersRef = useRef<MCPToolLogFilters>(filters);
 
-	// Keep filtersRef in sync with filters prop
 	useEffect(() => {
 		filtersRef.current = filters;
 	}, [filters]);
-
-	// Sync localSearch when filters.content_search changes externally
 	useEffect(() => {
 		setLocalSearch(filters.content_search || "");
 	}, [filters.content_search]);
-
 	useEffect(() => {
 		setStartTime(filters.start_time ? new Date(filters.start_time) : undefined);
 		setEndTime(filters.end_time ? new Date(filters.end_time) : undefined);
 	}, [filters.start_time, filters.end_time]);
-
-	// Cleanup timeout on unmount
 	useEffect(() => {
 		return () => {
-			if (searchTimeoutRef.current) {
-				clearTimeout(searchTimeoutRef.current);
-			}
+			if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
 		};
 	}, []);
 
 	const handleSearchChange = useCallback(
 		(value: string) => {
 			setLocalSearch(value);
-
-			if (searchTimeoutRef.current) {
-				clearTimeout(searchTimeoutRef.current);
-			}
-
+			if (searchTimeoutRef.current) clearTimeout(searchTimeoutRef.current);
 			searchTimeoutRef.current = setTimeout(() => {
 				onFiltersChange({ ...filtersRef.current, content_search: value });
 			}, 500);
@@ -108,18 +72,26 @@ export function McpHeaderView({
 
 	return (
 		<div className="flex grow items-center justify-between space-x-2">
-			<Button variant={"outline"} size="sm" className="h-7.5" onClick={() => onLiveToggle(!liveEnabled)}>
-				{liveEnabled ? (
-					<>
-						<Pause className="h-4 w-4" />
-						Live updates
-					</>
-				) : (
-					<>
-						<Play className="h-4 w-4" />
-						Live updates
-					</>
-				)}
+			<Button
+				variant="outline"
+				size="sm"
+				className="h-7.5 disabled:opacity-100"
+				onClick={onRefresh}
+				disabled={loading}
+				data-testid="mcp-logs-header-refresh-btn"
+			>
+				<RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+				Refresh
+			</Button>
+			<Button
+				variant={polling ? "default" : "outline"}
+				size="sm"
+				className="h-7.5"
+				onClick={() => onPollToggle(!polling)}
+				data-testid="mcp-logs-header-live-btn"
+			>
+				{polling ? <Radio className="h-4 w-4 animate-pulse" /> : <Radio className="h-4 w-4" />}
+				Live
 			</Button>
 			<div className="border-input flex h-7.5 flex-1 items-center gap-2 rounded-sm border">
 				<Search className="mr-0.5 ml-2 size-4" />
@@ -133,6 +105,7 @@ export function McpHeaderView({
 			</div>
 			<DateTimePickerWithRange
 				dateTime={{ from: startTime, to: endTime }}
+				predefinedPeriod={period || undefined}
 				onDateTimeUpdate={(p) => {
 					setStartTime(p.from);
 					setEndTime(p.to);
@@ -142,17 +115,13 @@ export function McpHeaderView({
 						end_time: p.to?.toISOString(),
 					});
 				}}
-				preDefinedPeriods={LOG_TIME_PERIODS}
+				preDefinedPeriods={TIME_PERIODS}
 				onPredefinedPeriodChange={(periodValue) => {
 					if (!periodValue) return;
 					const { from, to } = getRangeForPeriod(periodValue);
 					setStartTime(from);
 					setEndTime(to);
-					onFiltersChange({
-						...filters,
-						start_time: from.toISOString(),
-						end_time: to.toISOString(),
-					});
+					onPeriodChange(periodValue, from, to);
 				}}
 			/>
 			<ColumnConfigDropdown

--- a/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
@@ -13,7 +13,7 @@ import type { MCPToolLogEntry, Pagination } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
 import type { ColumnOrderState, ColumnPinningState, VisibilityState } from "@tanstack/react-table";
 import { ColumnDef, flexRender, getCoreRowModel, SortingState, useReactTable } from "@tanstack/react-table";
-import { ChevronLeft, ChevronRight, Pause, RefreshCw, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
 interface DataTableProps {
@@ -24,8 +24,8 @@ interface DataTableProps {
 	pagination: Pagination;
 	onPaginationChange: (pagination: Pagination) => void;
 	onRowClick?: (log: MCPToolLogEntry, columnId: string) => void;
-	isSocketConnected: boolean;
-	liveEnabled: boolean;
+	onRefresh?: () => void;
+	polling?: boolean;
 	/** Column config — computed by the parent via useColumnConfig */
 	columnEntries: ColumnConfigEntry[];
 	columnOrder: ColumnOrderState;
@@ -44,8 +44,8 @@ export function MCPLogsDataTable({
 	pagination,
 	onPaginationChange,
 	onRowClick,
-	isSocketConnected,
-	liveEnabled,
+	onRefresh,
+	polling = false,
 	columnEntries,
 	columnOrder,
 	columnVisibility,
@@ -159,72 +159,54 @@ export function MCPLogsDataTable({
 							))}
 						</thead>
 						<TableBody>
-							{loading ? (
+							<TableRow className="hover:bg-transparent">
+								<TableCell colSpan={columns.length} className="h-12 text-center">
+									<div className="text-muted-foreground flex items-center justify-center gap-2 text-sm">
+										{polling ? (
+											<>
+												<RefreshCw className="h-4 w-4 animate-spin" />
+												Waiting for new MCP logs...
+											</>
+										) : (
+											<Button variant="ghost" size="sm" onClick={onRefresh} disabled={loading} data-testid="mcp-logs-table-refresh-btn">
+												<RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+												Refresh
+											</Button>
+										)}
+									</div>
+								</TableCell>
+							</TableRow>
+							{table.getRowModel().rows.length ? (
+								table.getRowModel().rows.map((row) => (
+									<TableRow key={row.id} className="hover:bg-muted/50 group/table-row h-12 cursor-pointer">
+										{row.getVisibleCells().map((cell) => {
+											const pinned = cell.column.getIsPinned();
+											const size = cell.column.getSize();
+											return (
+												<TableCell
+													onClick={() => onRowClick?.(row.original, cell.column.id)}
+													key={cell.id}
+													style={{ width: size, minWidth: size, maxWidth: size, ...buildPinStyle(cell.column, pinOffsets) }}
+													className={cn(
+														"overflow-hidden",
+														pinned && "bg-card",
+														cell.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
+														cell.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
+														"group-hover/table-row:bg-[#f7f7f7] dark:group-hover/table-row:bg-[#232327]",
+													)}
+												>
+													{flexRender(cell.column.columnDef.cell, cell.getContext())}
+												</TableCell>
+											);
+										})}
+									</TableRow>
+								))
+							) : (
 								<TableRow>
-									<TableCell colSpan={columns.length} className="h-12 text-center">
-										<div className="flex items-center justify-center gap-2">
-											<RefreshCw className="h-4 w-4 animate-spin" />
-											Loading logs...
-										</div>
+									<TableCell colSpan={columns.length} className="h-24 text-center">
+										No results found. Try adjusting your filters and/or time range.
 									</TableCell>
 								</TableRow>
-							) : (
-								<>
-									<TableRow className="hover:bg-transparent">
-										<TableCell colSpan={columns.length} className="h-12 text-center">
-											<div className="flex items-center justify-center gap-2">
-												{!isSocketConnected ? (
-													<>
-														<X className="h-4 w-4" />
-														Not connected to socket, please refresh the page.
-													</>
-												) : liveEnabled ? (
-													<>
-														<RefreshCw className="h-4 w-4 animate-spin" />
-														Listening for logs...
-													</>
-												) : (
-													<>
-														<Pause className="h-4 w-4" />
-														Live updates paused
-													</>
-												)}
-											</div>
-										</TableCell>
-									</TableRow>
-									{table.getRowModel().rows.length ? (
-										table.getRowModel().rows.map((row) => (
-											<TableRow key={row.id} className="hover:bg-muted/50 group/table-row h-12 cursor-pointer">
-												{row.getVisibleCells().map((cell) => {
-													const pinned = cell.column.getIsPinned();
-													const size = cell.column.getSize();
-													return (
-														<TableCell
-															onClick={() => onRowClick?.(row.original, cell.column.id)}
-															key={cell.id}
-															style={{ width: size, minWidth: size, maxWidth: size, ...buildPinStyle(cell.column, pinOffsets) }}
-															className={cn(
-																"overflow-hidden",
-																pinned && "bg-card",
-																cell.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
-																cell.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
-																"group-hover/table-row:bg-[#f7f7f7] dark:group-hover/table-row:bg-[#232327]",
-															)}
-														>
-															{flexRender(cell.column.columnDef.cell, cell.getContext())}
-														</TableCell>
-													);
-												})}
-											</TableRow>
-										))
-									) : (
-										<TableRow>
-											<TableCell colSpan={columns.length} className="h-24 text-center">
-												No results found. Try adjusting your filters and/or time range.
-											</TableCell>
-										</TableRow>
-									)}
-								</>
 							)}
 						</TableBody>
 					</Table>

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -306,9 +306,14 @@ const SidebarItemView = ({
 								const currentParams = new URLSearchParams(search);
 								const startTime = currentParams.get("start_time");
 								const endTime = currentParams.get("end_time");
-								if (startTime && endTime) {
+								const period = currentParams.get("period");
+								if ((startTime && endTime) || period) {
+									const params = new URLSearchParams();
+									if (startTime) params.set("start_time", startTime);
+									if (endTime) params.set("end_time", endTime);
+									if (period) params.set("period", period);
 									const sep = baseHref.includes("?") ? "&" : "?";
-									return `${baseHref}${sep}start_time=${startTime}&end_time=${endTime}`;
+									return `${baseHref}${sep}${params.toString()}`;
 								}
 							}
 							return baseHref;

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -5,840 +5,836 @@ import { RoutingRule } from "./routingRules";
 
 // Speech and Transcription types
 export interface VoiceConfig {
-  speaker: string;
-  voice: string;
+	speaker: string;
+	voice: string;
 }
 
 export interface SpeechInput {
-  input: string;
+	input: string;
 }
 
 export interface TranscriptionInput {
-  file: string; // base64 encoded (send empty string when using input_audio)
+	file: string; // base64 encoded (send empty string when using input_audio)
 }
 
 export interface AudioTokenDetails {
-  text_tokens: number;
-  audio_tokens: number;
+	text_tokens: number;
+	audio_tokens: number;
 }
 
 export interface AudioLLMUsage {
-  input_tokens: number;
-  input_tokens_details?: AudioTokenDetails;
-  output_tokens: number;
-  total_tokens: number;
+	input_tokens: number;
+	input_tokens_details?: AudioTokenDetails;
+	output_tokens: number;
+	total_tokens: number;
 }
 
 export interface TranscriptionWord {
-  word: string;
-  start: number;
-  end: number;
+	word: string;
+	start: number;
+	end: number;
 }
 
 export interface TranscriptionSegment {
-  id: number;
-  seek: number;
-  start: number;
-  end: number;
-  text: string;
-  tokens: number[];
-  temperature: number;
-  avg_logprob: number;
-  compression_ratio: number;
-  no_speech_prob: number;
+	id: number;
+	seek: number;
+	start: number;
+	end: number;
+	text: string;
+	tokens: number[];
+	temperature: number;
+	avg_logprob: number;
+	compression_ratio: number;
+	no_speech_prob: number;
 }
 
 export interface TranscriptionLogProb {
-  token: string;
-  logprob: number;
-  bytes: number[];
+	token: string;
+	logprob: number;
+	bytes: number[];
 }
 
 export interface TranscriptionUsage {
-  type: string; // "tokens" or "duration"
-  input_tokens?: number;
-  input_token_details?: AudioTokenDetails;
-  output_tokens?: number;
-  total_tokens?: number;
-  seconds?: number; // For duration-based usage
+	type: string; // "tokens" or "duration"
+	input_tokens?: number;
+	input_token_details?: AudioTokenDetails;
+	output_tokens?: number;
+	total_tokens?: number;
+	seconds?: number; // For duration-based usage
 }
 
 export interface BifrostSpeech {
-  usage?: AudioLLMUsage;
-  audio: string; // base64 encoded audio data
+	usage?: AudioLLMUsage;
+	audio: string; // base64 encoded audio data
 }
 
 export interface BifrostTranscribe {
-  text: string;
-  logprobs?: TranscriptionLogProb[];
-  usage?: TranscriptionUsage;
-  // Non-streaming specific fields
-  task?: string; // e.g., "transcribe"
-  language?: string; // e.g., "english"
-  duration?: number; // Duration in seconds
-  words?: TranscriptionWord[];
-  segments?: TranscriptionSegment[];
+	text: string;
+	logprobs?: TranscriptionLogProb[];
+	usage?: TranscriptionUsage;
+	// Non-streaming specific fields
+	task?: string; // e.g., "transcribe"
+	language?: string; // e.g., "english"
+	duration?: number; // Duration in seconds
+	words?: TranscriptionWord[];
+	segments?: TranscriptionSegment[];
 }
 
 // Model and related types for list models response
 export interface Model {
-  id: string;
-  canonical_slug?: string;
-  name?: string;
-  alias?: string;
-  created?: number;
-  context_length?: number;
-  max_input_tokens?: number;
-  max_output_tokens?: number;
-  architecture?: Architecture;
-  pricing?: Pricing;
-  top_provider?: TopProvider;
-  per_request_limits?: PerRequestLimits;
-  supported_parameters?: string[];
-  default_parameters?: DefaultParameters;
-  hugging_face_id?: string;
-  description?: string;
-  owned_by?: string;
-  supported_methods?: string[];
+	id: string;
+	canonical_slug?: string;
+	name?: string;
+	alias?: string;
+	created?: number;
+	context_length?: number;
+	max_input_tokens?: number;
+	max_output_tokens?: number;
+	architecture?: Architecture;
+	pricing?: Pricing;
+	top_provider?: TopProvider;
+	per_request_limits?: PerRequestLimits;
+	supported_parameters?: string[];
+	default_parameters?: DefaultParameters;
+	hugging_face_id?: string;
+	description?: string;
+	owned_by?: string;
+	supported_methods?: string[];
 }
 
 export interface Architecture {
-  modality?: string;
-  tokenizer?: string;
-  instruct_type?: string;
-  input_modalities?: string[];
-  output_modalities?: string[];
+	modality?: string;
+	tokenizer?: string;
+	instruct_type?: string;
+	input_modalities?: string[];
+	output_modalities?: string[];
 }
 
 export interface Pricing {
-  prompt?: string;
-  completion?: string;
-  request?: string;
-  image?: string;
-  web_search?: string;
-  internal_reasoning?: string;
-  input_cache_read?: string;
-  input_cache_write?: string;
+	prompt?: string;
+	completion?: string;
+	request?: string;
+	image?: string;
+	web_search?: string;
+	internal_reasoning?: string;
+	input_cache_read?: string;
+	input_cache_write?: string;
 }
 
 export interface TopProvider {
-  is_moderated?: boolean;
-  context_length?: number;
-  max_completion_tokens?: number;
+	is_moderated?: boolean;
+	context_length?: number;
+	max_completion_tokens?: number;
 }
 
 export interface PerRequestLimits {
-  prompt_tokens?: number;
-  completion_tokens?: number;
+	prompt_tokens?: number;
+	completion_tokens?: number;
 }
 
 export interface DefaultParameters {
-  temperature?: number;
-  top_p?: number;
-  frequency_penalty?: number;
+	temperature?: number;
+	top_p?: number;
+	frequency_penalty?: number;
 }
 
 // Message content types
 export type MessageContentType =
-  | "text"
-  | "image_url"
-  | "input_audio"
-  | "input_text"
-  | "input_file"
-  | "output_text"
-  | "refusal"
-  | "reasoning";
+	| "text"
+	| "image_url"
+	| "input_audio"
+	| "input_text"
+	| "input_file"
+	| "output_text"
+	| "refusal"
+	| "reasoning";
 
 export interface ContentBlock {
-  type: MessageContentType;
-  text?: string;
-  image_url?: {
-    url: string;
-    detail?: string;
-  };
-  input_audio?: {
-    data: string;
-    format?: string;
-  };
+	type: MessageContentType;
+	text?: string;
+	image_url?: {
+		url: string;
+		detail?: string;
+	};
+	input_audio?: {
+		data: string;
+		format?: string;
+	};
 }
 
 export type ChatMessageContent = string | ContentBlock[];
 
 export interface ChatMessage {
-  role: "assistant" | "user" | "system" | "chatbot" | "tool";
-  content: ChatMessageContent;
-  tool_call_id?: string;
-  refusal?: string;
-  annotations?: Annotation[];
-  tool_calls?: ToolCall[]; // For backward compatibility, tool calls are now in the content
-  reasoning?: string;
-  reasoning_details?: ReasoningDetails[];
-  audio?: ChatAudioMessageAudio;
+	role: "assistant" | "user" | "system" | "chatbot" | "tool";
+	content: ChatMessageContent;
+	tool_call_id?: string;
+	refusal?: string;
+	annotations?: Annotation[];
+	tool_calls?: ToolCall[]; // For backward compatibility, tool calls are now in the content
+	reasoning?: string;
+	reasoning_details?: ReasoningDetails[];
+	audio?: ChatAudioMessageAudio;
 }
 
 export interface ChatAudioMessageAudio {
-  id: string;
-  data: string;
-  expires_at: number;
-  transcript: string;
+	id: string;
+	data: string;
+	expires_at: number;
+	transcript: string;
 }
 
 export interface ReasoningDetails {
-  index: number;
-  type: "reasoning.summary" | "reasoning.encrypted" | "reasoning.text";
-  summary?: string;
-  text?: string;
-  signature?: string;
-  data?: string;
+	index: number;
+	type: "reasoning.summary" | "reasoning.encrypted" | "reasoning.text";
+	summary?: string;
+	text?: string;
+	signature?: string;
+	data?: string;
 }
 
 export interface BifrostEmbedding {
-  index: number;
-  object: string;
-  embedding: string | number[] | number[][];
+	index: number;
+	object: string;
+	embedding: string | number[] | number[][];
 }
 
 export interface RerankDocument {
-  text: string;
-  id?: string;
-  meta?: Record<string, unknown>;
+	text: string;
+	id?: string;
+	meta?: Record<string, unknown>;
 }
 
 export interface RerankResult {
-  index: number;
-  relevance_score: number;
-  document?: RerankDocument;
+	index: number;
+	relevance_score: number;
+	document?: RerankDocument;
 }
 
 export interface BifrostImageGenerationData {
-  url?: string;
-  b64_json?: string;
-  revised_prompt?: string;
-  index?: number;
+	url?: string;
+	b64_json?: string;
+	revised_prompt?: string;
+	index?: number;
 }
 
 export interface ImageMessageData {
-  url?: string;
-  b64_json?: string;
-  prompt?: string;
-  revised_prompt?: string;
-  index?: number;
-  output_format?: string;
+	url?: string;
+	b64_json?: string;
+	prompt?: string;
+	revised_prompt?: string;
+	index?: number;
+	output_format?: string;
 }
 
 export interface OCRDocument {
-  type: "document_url" | "image_url";
-  document_url?: string;
-  image_url?: string;
+	type: "document_url" | "image_url";
+	document_url?: string;
+	image_url?: string;
 }
 
 export interface OCRPageImage {
-  id: string;
-  top_left_x: number;
-  top_left_y: number;
-  bottom_right_x: number;
-  bottom_right_y: number;
-  image_base64?: string;
+	id: string;
+	top_left_x: number;
+	top_left_y: number;
+	bottom_right_x: number;
+	bottom_right_y: number;
+	image_base64?: string;
 }
 
 export interface OCRPageDimensions {
-  dpi: number;
-  height: number;
-  width: number;
+	dpi: number;
+	height: number;
+	width: number;
 }
 
 export interface OCRPage {
-  index: number;
-  markdown: string;
-  images?: OCRPageImage[];
-  dimensions?: OCRPageDimensions;
+	index: number;
+	markdown: string;
+	images?: OCRPageImage[];
+	dimensions?: OCRPageDimensions;
 }
 
 export interface OCRUsageInfo {
-  pages_processed: number;
-  doc_size_bytes: number;
+	pages_processed: number;
+	doc_size_bytes: number;
 }
 
 export interface BifrostOCRResponse {
-  model: string;
-  pages: OCRPage[];
-  usage_info?: OCRUsageInfo;
-  document_annotation?: string;
+	model: string;
+	pages: OCRPage[];
+	usage_info?: OCRUsageInfo;
+	document_annotation?: string;
 }
 
 export interface BifrostImageGenerationOutput {
-  id?: string;
-  created?: number;
-  model?: string;
-  data: BifrostImageGenerationData[];
-  background?: string;
-  output_format?: string;
-  quality?: string;
-  size?: string;
-  usage?: {
-    input_tokens?: number;
-    total_tokens?: number;
-    output_tokens?: number;
-  };
+	id?: string;
+	created?: number;
+	model?: string;
+	data: BifrostImageGenerationData[];
+	background?: string;
+	output_format?: string;
+	quality?: string;
+	size?: string;
+	usage?: {
+		input_tokens?: number;
+		total_tokens?: number;
+		output_tokens?: number;
+	};
 }
 
 export interface VideoCreateError {
-  code?: string;
-  message?: string;
+	code?: string;
+	message?: string;
 }
 
 export interface VideoObject {
-  id: string;
-  object: string;
-  model: string;
-  status: string;
-  created_at: number;
-  completed_at?: number;
-  expires_at?: number;
-  progress?: number;
-  prompt: string;
-  remixed_from_video_id?: string;
-  seconds: number;
-  size: string;
-  error?: VideoCreateError;
-  url?: string;
+	id: string;
+	object: string;
+	model: string;
+	status: string;
+	created_at: number;
+	completed_at?: number;
+	expires_at?: number;
+	progress?: number;
+	prompt: string;
+	remixed_from_video_id?: string;
+	seconds: number;
+	size: string;
+	error?: VideoCreateError;
+	url?: string;
 }
 
 export interface VideoOutput {
-  type: string;
-  url?: string;
-  base64?: string;
-  content_type?: string;
+	type: string;
+	url?: string;
+	base64?: string;
+	content_type?: string;
 }
 export interface BifrostVideoGenerationOutput {
-  videos: VideoOutput[];
-  id?: string;
-  completed_at?: number;
-  created_at?: number;
-  error?: VideoCreateError;
-  expires_at?: number;
-  model?: string;
-  object?: string;
-  progress?: number;
-  prompt?: string;
-  remixed_from_video_id?: string;
-  seconds?: number;
-  size?: string;
-  status?: string;
+	videos: VideoOutput[];
+	id?: string;
+	completed_at?: number;
+	created_at?: number;
+	error?: VideoCreateError;
+	expires_at?: number;
+	model?: string;
+	object?: string;
+	progress?: number;
+	prompt?: string;
+	remixed_from_video_id?: string;
+	seconds?: number;
+	size?: string;
+	status?: string;
 }
 
 export interface BifrostVideoDownloadOutput {
-  video_id: string;
-  content_type?: string;
+	video_id: string;
+	content_type?: string;
 }
 
 export interface BifrostVideoDeleteOutput {
-  id: string;
-  deleted: boolean;
-  object?: string;
+	id: string;
+	deleted: boolean;
+	object?: string;
 }
 
 export interface BifrostVideoListOutput {
-  object: string;
-  data: VideoObject[];
-  first_id?: string;
-  has_more?: boolean;
-  last_id?: string;
+	object: string;
+	data: VideoObject[];
+	first_id?: string;
+	has_more?: boolean;
+	last_id?: string;
 }
 
 // Tool related types
 export interface FunctionParameters {
-  type: string;
-  description?: string;
-  required?: string[];
-  properties?: Record<string, unknown>;
-  enum?: string[];
-  additionalProperties?: boolean;
+	type: string;
+	description?: string;
+	required?: string[];
+	properties?: Record<string, unknown>;
+	enum?: string[];
+	additionalProperties?: boolean;
 }
 
 export interface Function {
-  name: string;
-  description?: string;
-  parameters?: FunctionParameters;
-  strict?: boolean;
+	name: string;
+	description?: string;
+	parameters?: FunctionParameters;
+	strict?: boolean;
 }
 
 export interface Tool {
-  id?: string;
-  type: string;
-  function: Function;
+	id?: string;
+	type: string;
+	function: Function;
 }
 
 export interface FunctionCall {
-  name?: string;
-  arguments: string; // stringified JSON
+	name?: string;
+	arguments: string; // stringified JSON
 }
 
 export interface ToolCall {
-  type?: string;
-  id?: string;
-  function: FunctionCall;
+	type?: string;
+	id?: string;
+	function: FunctionCall;
 }
 
 // Model parameters types
 export interface ModelParameters {
-  tool_choice?: unknown; // Can be string or object
-  tools?: Tool[];
-  instructions?: string;
-  temperature?: number;
-  top_p?: number;
-  top_k?: number;
-  max_tokens?: number;
-  stop_sequences?: string[];
-  presence_penalty?: number;
-  frequency_penalty?: number;
-  parallel_tool_calls?: boolean;
-  extra_params?: Record<string, unknown>;
+	tool_choice?: unknown; // Can be string or object
+	tools?: Tool[];
+	instructions?: string;
+	temperature?: number;
+	top_p?: number;
+	top_k?: number;
+	max_tokens?: number;
+	stop_sequences?: string[];
+	presence_penalty?: number;
+	frequency_penalty?: number;
+	parallel_tool_calls?: boolean;
+	extra_params?: Record<string, unknown>;
 }
 
 // Token usage types
 export interface TokenDetails {
-  cached_read_tokens?: number;
-  cached_write_tokens?: number;
-  audio_tokens?: number;
+	cached_read_tokens?: number;
+	cached_write_tokens?: number;
+	audio_tokens?: number;
 }
 
 export interface CompletionTokensDetails {
-  reasoning_tokens?: number;
-  audio_tokens?: number;
-  accepted_prediction_tokens?: number;
-  rejected_prediction_tokens?: number;
+	reasoning_tokens?: number;
+	audio_tokens?: number;
+	accepted_prediction_tokens?: number;
+	rejected_prediction_tokens?: number;
 }
 
 export interface LLMUsage {
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
-  prompt_tokens_details?: TokenDetails;
-  completion_tokens_details?: CompletionTokensDetails;
+	prompt_tokens: number;
+	completion_tokens: number;
+	total_tokens: number;
+	prompt_tokens_details?: TokenDetails;
+	completion_tokens_details?: CompletionTokensDetails;
 }
 
 export interface CacheDebug {
-  cache_hit: boolean;
-  cache_id?: string;
-  hit_type?: string;
-  requested_provider?: string;
-  requested_model?: string;
-  provider_used?: string;
-  model_used?: string;
-  input_tokens?: number;
-  threshold?: number;
-  similarity?: number;
+	cache_hit: boolean;
+	cache_id?: string;
+	hit_type?: string;
+	requested_provider?: string;
+	requested_model?: string;
+	provider_used?: string;
+	model_used?: string;
+	input_tokens?: number;
+	threshold?: number;
+	similarity?: number;
 }
 
 // Error types
 export interface ErrorField {
-  type?: string;
-  code?: string;
-  message: string;
-  error?: unknown;
-  param?: unknown;
-  event_id?: string;
+	type?: string;
+	code?: string;
+	message: string;
+	error?: unknown;
+	param?: unknown;
+	event_id?: string;
 }
 
 export interface BifrostError {
-  event_id?: string;
-  type?: string;
-  is_bifrost_error: boolean;
-  status_code?: number;
-  error: ErrorField;
+	event_id?: string;
+	type?: string;
+	is_bifrost_error: boolean;
+	status_code?: number;
+	error: ErrorField;
 }
 
 // Citation and Annotation types
 export interface Citation {
-  start_index: number;
-  end_index: number;
-  title: string;
-  url?: string;
-  sources?: unknown;
-  type?: string;
+	start_index: number;
+	end_index: number;
+	title: string;
+	url?: string;
+	sources?: unknown;
+	type?: string;
 }
 
 export interface Annotation {
-  type: string;
-  url_citation: Citation;
+	type: string;
+	url_citation: Citation;
 }
 
 export interface PluginLogEntry {
-  plugin_name: string;
-  level: "debug" | "info" | "warn" | "error";
-  message: string;
-  timestamp: number;
+	plugin_name: string;
+	level: "debug" | "info" | "warn" | "error";
+	message: string;
+	timestamp: number;
 }
 
 export interface ImageEditInput {
-  images?: Array<{ image: string | null }> | null; // null when stripped by large-payload threshold
-  prompt: string;
+	images?: Array<{ image: string | null }> | null; // null when stripped by large-payload threshold
+	prompt: string;
 }
 
 export interface ImageVariationInput {
-  image: { image: string | null }; // image bytes null when stripped by large-payload threshold
+	image: { image: string | null }; // image bytes null when stripped by large-payload threshold
 }
 
 // Main LogEntry interface matching backend
 export interface KeyAttemptRecord {
-  attempt: number;
-  key_id: string;
-  key_name: string;
-  fail_reason?: string | null; // null/undefined on the final (successful or last) attempt
+	attempt: number;
+	key_id: string;
+	key_name: string;
+	fail_reason?: string | null; // null/undefined on the final (successful or last) attempt
 }
 
 export interface LogEntry {
-  id: string;
-  object: string; // text.completion, chat.completion, embedding, audio.speech, audio.transcription
-  parent_request_id?: string;
-  timestamp: string; // ISO string format from Go time.Time
-  provider: string;
-  model: string;
-  alias?: string; // Set when model was resolved via alias mapping; the original name the caller used
-  number_of_retries: number;
-  fallback_index: number;
-  attempt_trail?: KeyAttemptRecord[]; // Per-attempt key selection history
-  selected_key_id?: string | null;
-  selected_prompt_id?: string; // Selected prompt ID (prompts plugin)
-  selected_prompt_name?: string; // Resolved prompt display name (prompts plugin)
-  selected_prompt_version?: string; // Resolved prompt version number as string (prompts plugin)
-  team_name?: string;
-  team_id?: string;
-  customer_name?: string;
-  customer_id?: string;
-  business_unit_id?: string;
-  business_unit_name?: string;
-  user_id?: string;
-  user_name?: string;
-  virtual_key_id?: string;
-  routing_engines_used?: string[];
-  routing_rule_id?: string;
-  routing_engine_logs?: string; // Human-readable routing decision logs
-  plugin_logs?: string; // JSON string of plugin execution logs grouped by plugin name
-  selected_key?: DBKey;
-  virtual_key?: VirtualKey;
-  routing_rule?: RoutingRule;
-  input_history: ChatMessage[];
-  responses_input_history: ResponsesMessage[];
-  content_summary?: string;
-  output_message?: ChatMessage;
-  responses_output?: ResponsesMessage[];
-  embedding_output?: BifrostEmbedding[];
-  rerank_output?: RerankResult[];
-  ocr_input?: OCRDocument;
-  ocr_output?: BifrostOCRResponse;
-  image_generation_output?: BifrostImageGenerationOutput;
-  video_generation_output?: BifrostVideoGenerationOutput;
-  video_retrieve_output?: BifrostVideoGenerationOutput;
-  video_download_output?: BifrostVideoDownloadOutput;
-  video_list_output?: BifrostVideoListOutput;
-  video_delete_output?: BifrostVideoDeleteOutput;
-  params?: ModelParameters;
-  speech_input?: SpeechInput;
-  transcription_input?: TranscriptionInput;
-  image_generation_input?: { prompt: string };
-  image_edit_input?: ImageEditInput;
-  image_variation_input?: ImageVariationInput;
-  video_generation_input?: { prompt: string };
-  speech_output?: BifrostSpeech;
-  transcription_output?: BifrostTranscribe;
-  list_models_output?: Model[];
-  tools?: Tool[];
-  tool_calls?: ToolCall[];
-  latency?: number;
-  token_usage?: LLMUsage;
-  cache_debug?: CacheDebug;
-  cost?: number; // Cost in dollars (total cost of the request - includes cache lookup cost)
-  status: string; // "success" or "error"
-  error_details?: BifrostError;
-  stream: boolean; // true if this was a streaming response
-  created_at: string; // ISO string format from Go time.Time - when the log was first created
-  raw_request?: string; // Raw provider request
-  raw_response?: string; // Raw provider response
-  is_large_payload_request?: boolean; // true if request used large payload streaming
-  is_large_payload_response?: boolean; // true if response used large payload streaming
-  passthrough_request_body?: string; // Raw passthrough request body (UTF-8)
-  passthrough_response_body?: string; // Raw passthrough response body (UTF-8)
-  metadata?: Record<string, string>; // JSON metadata (e.g., isAsyncRequest)
+	id: string;
+	object: string; // text.completion, chat.completion, embedding, audio.speech, audio.transcription
+	parent_request_id?: string;
+	timestamp: string; // ISO string format from Go time.Time
+	provider: string;
+	model: string;
+	alias?: string; // Set when model was resolved via alias mapping; the original name the caller used
+	number_of_retries: number;
+	fallback_index: number;
+	attempt_trail?: KeyAttemptRecord[]; // Per-attempt key selection history
+	selected_key_id?: string | null;
+	selected_prompt_id?: string; // Selected prompt ID (prompts plugin)
+	selected_prompt_name?: string; // Resolved prompt display name (prompts plugin)
+	selected_prompt_version?: string; // Resolved prompt version number as string (prompts plugin)
+	team_name?: string;
+	team_id?: string;
+	customer_name?: string;
+	customer_id?: string;
+	business_unit_id?: string;
+	business_unit_name?: string;
+	user_id?: string;
+	user_name?: string;
+	virtual_key_id?: string;
+	routing_engines_used?: string[];
+	routing_rule_id?: string;
+	routing_engine_logs?: string; // Human-readable routing decision logs
+	plugin_logs?: string; // JSON string of plugin execution logs grouped by plugin name
+	selected_key?: DBKey;
+	virtual_key?: VirtualKey;
+	routing_rule?: RoutingRule;
+	input_history: ChatMessage[];
+	responses_input_history: ResponsesMessage[];
+	content_summary?: string;
+	output_message?: ChatMessage;
+	responses_output?: ResponsesMessage[];
+	embedding_output?: BifrostEmbedding[];
+	rerank_output?: RerankResult[];
+	ocr_input?: OCRDocument;
+	ocr_output?: BifrostOCRResponse;
+	image_generation_output?: BifrostImageGenerationOutput;
+	video_generation_output?: BifrostVideoGenerationOutput;
+	video_retrieve_output?: BifrostVideoGenerationOutput;
+	video_download_output?: BifrostVideoDownloadOutput;
+	video_list_output?: BifrostVideoListOutput;
+	video_delete_output?: BifrostVideoDeleteOutput;
+	params?: ModelParameters;
+	speech_input?: SpeechInput;
+	transcription_input?: TranscriptionInput;
+	image_generation_input?: { prompt: string };
+	image_edit_input?: ImageEditInput;
+	image_variation_input?: ImageVariationInput;
+	video_generation_input?: { prompt: string };
+	speech_output?: BifrostSpeech;
+	transcription_output?: BifrostTranscribe;
+	list_models_output?: Model[];
+	tools?: Tool[];
+	tool_calls?: ToolCall[];
+	latency?: number;
+	token_usage?: LLMUsage;
+	cache_debug?: CacheDebug;
+	cost?: number; // Cost in dollars (total cost of the request - includes cache lookup cost)
+	status: string; // "success" or "error"
+	error_details?: BifrostError;
+	stream: boolean; // true if this was a streaming response
+	created_at: string; // ISO string format from Go time.Time - when the log was first created
+	raw_request?: string; // Raw provider request
+	raw_response?: string; // Raw provider response
+	is_large_payload_request?: boolean; // true if request used large payload streaming
+	is_large_payload_response?: boolean; // true if response used large payload streaming
+	passthrough_request_body?: string; // Raw passthrough request body (UTF-8)
+	passthrough_response_body?: string; // Raw passthrough response body (UTF-8)
+	metadata?: Record<string, string>; // JSON metadata (e.g., isAsyncRequest)
 }
 
 export interface LogFilters {
-  providers?: string[];
-  models?: string[];
-  aliases?: string[];
-  parent_request_id?: string;
-  selected_key_ids?: string[];
-  virtual_key_ids?: string[];
-  routing_rule_ids?: string[];
-  routing_engine_used?: string[]; // For filtering by routing engine (routing-rule, governance, loadbalancing)
-  status?: string[];
-  objects?: string[]; // For filtering by request type (chat.completion, text.completion, embedding)
-  start_time?: string; // RFC3339 format
-  end_time?: string; // RFC3339 format
-  min_latency?: number;
-  max_latency?: number;
-  min_tokens?: number;
-  max_tokens?: number;
-  missing_cost_only?: boolean;
-  content_search?: string;
-  metadata_filters?: Record<string, string>; // key=metadataKey, value=metadataValue for filtering by metadata
-  user_ids?: string[];
-  team_ids?: string[];
-  customer_ids?: string[];
-  business_unit_ids?: string[];
+	providers?: string[];
+	models?: string[];
+	aliases?: string[];
+	parent_request_id?: string;
+	selected_key_ids?: string[];
+	virtual_key_ids?: string[];
+	routing_rule_ids?: string[];
+	routing_engine_used?: string[]; // For filtering by routing engine (routing-rule, governance, loadbalancing)
+	status?: string[];
+	objects?: string[]; // For filtering by request type (chat.completion, text.completion, embedding)
+	start_time?: string; // RFC3339 format
+	end_time?: string; // RFC3339 format
+	min_latency?: number;
+	max_latency?: number;
+	min_tokens?: number;
+	max_tokens?: number;
+	missing_cost_only?: boolean;
+	content_search?: string;
+	metadata_filters?: Record<string, string>; // key=metadataKey, value=metadataValue for filtering by metadata
+	user_ids?: string[];
+	team_ids?: string[];
+	customer_ids?: string[];
+	business_unit_ids?: string[];
 }
 
 export interface Pagination {
-  limit: number;
-  offset: number;
-  sort_by: "timestamp" | "latency" | "tokens" | "cost";
-  order: "asc" | "desc";
+	limit: number;
+	offset: number;
+	sort_by: "timestamp" | "latency" | "tokens" | "cost";
+	order: "asc" | "desc";
 }
 
 export interface LogStats {
-  total_requests: number;
-  success_rate: number;
-  user_facing_success_rate: number;
-  user_facing_total_requests: number;
-  average_latency: number;
-  total_tokens: number;
-  total_cost: number;
+	total_requests: number;
+	success_rate: number;
+	user_facing_success_rate: number;
+	user_facing_total_requests: number;
+	average_latency: number;
+	total_tokens: number;
+	total_cost: number;
 }
 
 export interface LogSessionDetailResponse {
-  session_id: string;
-  logs: LogEntry[];
-  pagination: Pagination & { total_count?: number };
-  count: number;
-  returned_count: number;
-  has_more: boolean;
+	session_id: string;
+	logs: LogEntry[];
+	pagination: Pagination & { total_count?: number };
+	count: number;
+	returned_count: number;
+	has_more: boolean;
 }
 
 export interface LogSessionSummaryResponse {
-  session_id: string;
-  count: number;
-  total_cost: number;
-  total_tokens: number;
-  started_at?: string;
-  latest_at?: string;
-  duration_ms: number;
+	session_id: string;
+	count: number;
+	total_cost: number;
+	total_tokens: number;
+	started_at?: string;
+	latest_at?: string;
+	duration_ms: number;
 }
 
 export interface HistogramBucket {
-  timestamp: string;
-  count: number;
-  success: number;
-  error: number;
+	timestamp: string;
+	count: number;
+	success: number;
+	error: number;
 }
 
 export interface LogsHistogramResponse {
-  buckets: HistogramBucket[];
-  bucket_size_seconds: number;
+	buckets: HistogramBucket[];
+	bucket_size_seconds: number;
 }
 
 // Token histogram types
 export interface TokenHistogramBucket {
-  timestamp: string;
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
-  cached_read_tokens: number;
+	timestamp: string;
+	prompt_tokens: number;
+	completion_tokens: number;
+	total_tokens: number;
+	cached_read_tokens: number;
 }
 
 export interface TokenHistogramResponse {
-  buckets: TokenHistogramBucket[];
-  bucket_size_seconds: number;
+	buckets: TokenHistogramBucket[];
+	bucket_size_seconds: number;
 }
 
 // Cost histogram types
 export interface CostHistogramBucket {
-  timestamp: string;
-  total_cost: number;
-  by_model: Record<string, number>;
+	timestamp: string;
+	total_cost: number;
+	by_model: Record<string, number>;
 }
 
 export interface CostHistogramResponse {
-  buckets: CostHistogramBucket[];
-  bucket_size_seconds: number;
-  models: string[];
+	buckets: CostHistogramBucket[];
+	bucket_size_seconds: number;
+	models: string[];
 }
 
 // Model usage histogram types
 export interface ModelUsageStats {
-  total: number;
-  success: number;
-  error: number;
+	total: number;
+	success: number;
+	error: number;
 }
 
 export interface ModelHistogramBucket {
-  timestamp: string;
-  by_model: Record<string, ModelUsageStats>;
+	timestamp: string;
+	by_model: Record<string, ModelUsageStats>;
 }
 
 export interface ModelHistogramResponse {
-  buckets: ModelHistogramBucket[];
-  bucket_size_seconds: number;
-  models: string[];
+	buckets: ModelHistogramBucket[];
+	bucket_size_seconds: number;
+	models: string[];
 }
 
 // Latency histogram types
 export interface LatencyHistogramBucket {
-  timestamp: string;
-  avg_latency: number;
-  p90_latency: number;
-  p95_latency: number;
-  p99_latency: number;
-  total_requests: number;
+	timestamp: string;
+	avg_latency: number;
+	p90_latency: number;
+	p95_latency: number;
+	p99_latency: number;
+	total_requests: number;
 }
 
 export interface LatencyHistogramResponse {
-  buckets: LatencyHistogramBucket[];
-  bucket_size_seconds: number;
+	buckets: LatencyHistogramBucket[];
+	bucket_size_seconds: number;
 }
 
 // Provider-level histogram types
 
 export interface ProviderCostHistogramBucket {
-  timestamp: string;
-  total_cost: number;
-  by_provider: Record<string, number>;
+	timestamp: string;
+	total_cost: number;
+	by_provider: Record<string, number>;
 }
 
 export interface ProviderCostHistogramResponse {
-  buckets: ProviderCostHistogramBucket[];
-  bucket_size_seconds: number;
-  providers: string[];
+	buckets: ProviderCostHistogramBucket[];
+	bucket_size_seconds: number;
+	providers: string[];
 }
 
 export interface ProviderTokenStats {
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
+	prompt_tokens: number;
+	completion_tokens: number;
+	total_tokens: number;
 }
 
 export interface ProviderTokenHistogramBucket {
-  timestamp: string;
-  by_provider: Record<string, ProviderTokenStats>;
+	timestamp: string;
+	by_provider: Record<string, ProviderTokenStats>;
 }
 
 export interface ProviderTokenHistogramResponse {
-  buckets: ProviderTokenHistogramBucket[];
-  bucket_size_seconds: number;
-  providers: string[];
+	buckets: ProviderTokenHistogramBucket[];
+	bucket_size_seconds: number;
+	providers: string[];
 }
 
 export interface ProviderLatencyStats {
-  avg_latency: number;
-  p90_latency: number;
-  p95_latency: number;
-  p99_latency: number;
-  total_requests: number;
+	avg_latency: number;
+	p90_latency: number;
+	p95_latency: number;
+	p99_latency: number;
+	total_requests: number;
 }
 
 export interface ProviderLatencyHistogramBucket {
-  timestamp: string;
-  by_provider: Record<string, ProviderLatencyStats>;
+	timestamp: string;
+	by_provider: Record<string, ProviderLatencyStats>;
 }
 
 export interface ProviderLatencyHistogramResponse {
-  buckets: ProviderLatencyHistogramBucket[];
-  bucket_size_seconds: number;
-  providers: string[];
+	buckets: ProviderLatencyHistogramBucket[];
+	bucket_size_seconds: number;
+	providers: string[];
 }
 
 export interface LogsResponse {
-  logs: LogEntry[];
-  pagination: Pagination;
-  stats: LogStats;
+	logs: LogEntry[];
+	pagination: Pagination;
+	stats: LogStats;
 }
 
 export interface RecalculateCostResponse {
-  total_matched: number;
-  updated: number;
-  skipped: number;
-  remaining: number;
+	total_matched: number;
+	updated: number;
+	skipped: number;
+	remaining: number;
 }
 
 // Responses API types (for responses_output field)
 
 // Message roles for responses
-export type ResponsesMessageRoleType =
-  | "assistant"
-  | "user"
-  | "system"
-  | "developer";
+export type ResponsesMessageRoleType = "assistant" | "user" | "system" | "developer";
 
 // Message types for responses
 export type ResponsesMessageType =
-  | "message"
-  | "file_search_call"
-  | "computer_call"
-  | "computer_call_output"
-  | "web_search_call"
-  | "web_fetch_call"
-  | "function_call"
-  | "function_call_output"
-  | "code_interpreter_call"
-  | "local_shell_call"
-  | "local_shell_call_output"
-  | "mcp_call"
-  | "custom_tool_call"
-  | "custom_tool_call_output"
-  | "image_generation_call"
-  | "mcp_list_tools"
-  | "mcp_approval_request"
-  | "mcp_approval_responses"
-  | "reasoning"
-  | "item_reference"
-  | "refusal";
+	| "message"
+	| "file_search_call"
+	| "computer_call"
+	| "computer_call_output"
+	| "web_search_call"
+	| "web_fetch_call"
+	| "function_call"
+	| "function_call_output"
+	| "code_interpreter_call"
+	| "local_shell_call"
+	| "local_shell_call_output"
+	| "mcp_call"
+	| "custom_tool_call"
+	| "custom_tool_call_output"
+	| "image_generation_call"
+	| "mcp_list_tools"
+	| "mcp_approval_request"
+	| "mcp_approval_responses"
+	| "reasoning"
+	| "item_reference"
+	| "refusal";
 
 // Content block types for responses
 export type ResponsesMessageContentBlockType =
-  | "input_text"
-  | "input_image"
-  | "input_file"
-  | "input_audio"
-  | "output_text"
-  | "refusal"
-  | "reasoning_text";
+	| "input_text"
+	| "input_image"
+	| "input_file"
+	| "input_audio"
+	| "output_text"
+	| "refusal"
+	| "reasoning_text";
 
 // Content blocks for responses messages
 export interface ResponsesMessageContentBlock {
-  type: ResponsesMessageContentBlockType;
-  file_id?: string;
-  text?: string;
-  image_url?: string;
-  detail?: string; // "low" | "high" | "auto"
-  file_data?: string; // Base64 encoded file data
-  file_url?: string;
-  filename?: string;
-  input_audio?: {
-    format: string; // "mp3" or "wav"
-    data: string; // base64 encoded audio data
-  };
-  annotations?: Array<{
-    type: string;
-    index?: number;
-    file_id?: string;
-    start_index?: number;
-    end_index?: number;
-    filename?: string;
-    title?: string;
-    url?: string;
-    container_id?: string;
-  }>;
-  logprobs?: Array<{
-    bytes: number[];
-    logprob: number;
-    token: string;
-    top_logprobs: Array<{
-      bytes: number[];
-      logprob: number;
-      token: string;
-    }>;
-  }>;
-  refusal?: string;
+	type: ResponsesMessageContentBlockType;
+	file_id?: string;
+	text?: string;
+	image_url?: string;
+	detail?: string; // "low" | "high" | "auto"
+	file_data?: string; // Base64 encoded file data
+	file_url?: string;
+	filename?: string;
+	input_audio?: {
+		format: string; // "mp3" or "wav"
+		data: string; // base64 encoded audio data
+	};
+	annotations?: Array<{
+		type: string;
+		index?: number;
+		file_id?: string;
+		start_index?: number;
+		end_index?: number;
+		filename?: string;
+		title?: string;
+		url?: string;
+		container_id?: string;
+	}>;
+	logprobs?: Array<{
+		bytes: number[];
+		logprob: number;
+		token: string;
+		top_logprobs: Array<{
+			bytes: number[];
+			logprob: number;
+			token: string;
+		}>;
+	}>;
+	refusal?: string;
 }
 
 // Message content - can be string or array of blocks
@@ -846,132 +842,129 @@ export type ResponsesMessageContent = string | ResponsesMessageContentBlock[];
 
 // Tool message structure
 export interface ResponsesToolMessage {
-  call_id?: string;
-  name?: string;
-  arguments?: string;
-  // Tool-specific fields would be added here based on tool type
-  [key: string]: any; // For tool-specific properties
+	call_id?: string;
+	name?: string;
+	arguments?: string;
+	// Tool-specific fields would be added here based on tool type
+	[key: string]: any; // For tool-specific properties
 }
 
 // Reasoning content
 export interface ResponsesReasoningSummary {
-  type: "summary_text";
-  text: string;
+	type: "summary_text";
+	text: string;
 }
 
 export interface ResponsesReasoning {
-  summary: ResponsesReasoningSummary[];
-  encrypted_content?: string;
+	summary: ResponsesReasoningSummary[];
+	encrypted_content?: string;
 }
 
 // Main response message structure
 export interface ResponsesMessage {
-  id?: string;
-  type?: ResponsesMessageType;
-  status?: string; // "in_progress" | "completed" | "incomplete" | "interpreting" | "failed"
-  role?: ResponsesMessageRoleType;
-  content?: ResponsesMessageContent;
-  // Tool message fields (merged when type indicates tool usage)
-  call_id?: string;
-  name?: string;
-  arguments?: string;
-  // Reasoning fields (merged when type is "reasoning")
-  summary?: ResponsesReasoningSummary[];
-  encrypted_content?: string;
-  // Additional tool-specific fields
-  [key: string]: any;
-  output?:
-    | string
-    | ResponsesMessageContentBlock[]
-    | ResponsesComputerToolCallOutputData;
+	id?: string;
+	type?: ResponsesMessageType;
+	status?: string; // "in_progress" | "completed" | "incomplete" | "interpreting" | "failed"
+	role?: ResponsesMessageRoleType;
+	content?: ResponsesMessageContent;
+	// Tool message fields (merged when type indicates tool usage)
+	call_id?: string;
+	name?: string;
+	arguments?: string;
+	// Reasoning fields (merged when type is "reasoning")
+	summary?: ResponsesReasoningSummary[];
+	encrypted_content?: string;
+	// Additional tool-specific fields
+	[key: string]: any;
+	output?: string | ResponsesMessageContentBlock[] | ResponsesComputerToolCallOutputData;
 }
 
 export interface ResponsesComputerToolCallOutputData {
-  type: "computer_screenshot";
-  file_id?: string;
-  image_url?: string;
+	type: "computer_screenshot";
+	file_id?: string;
+	image_url?: string;
 }
 
 // Stream options for responses
 export interface ResponsesStreamOptions {
-  include_obfuscation?: boolean;
+	include_obfuscation?: boolean;
 }
 
 // Text configuration
 export interface ResponsesTextConfig {
-  format?: {
-    type: "text" | "json_schema" | "json_object";
-    json_schema?: {
-      name: string;
-      schema: Record<string, any>;
-      type: string;
-      description?: string;
-      strict?: boolean;
-    };
-  };
-  verbosity?: "low" | "medium" | "high";
+	format?: {
+		type: "text" | "json_schema" | "json_object";
+		json_schema?: {
+			name: string;
+			schema: Record<string, any>;
+			type: string;
+			description?: string;
+			strict?: boolean;
+		};
+	};
+	verbosity?: "low" | "medium" | "high";
 }
 
 // Tool choice configuration
 export type ResponsesToolChoiceType =
-  | "none"
-  | "auto"
-  | "any"
-  | "required"
-  | "function"
-  | "allowed_tools"
-  | "file_search"
-  | "web_search_preview"
-  | "computer_use_preview"
-  | "code_interpreter"
-  | "image_generation"
-  | "mcp"
-  | "custom";
+	| "none"
+	| "auto"
+	| "any"
+	| "required"
+	| "function"
+	| "allowed_tools"
+	| "file_search"
+	| "web_search_preview"
+	| "computer_use_preview"
+	| "code_interpreter"
+	| "image_generation"
+	| "mcp"
+	| "custom";
 
 export interface ResponsesToolChoiceStruct {
-  type: ResponsesToolChoiceType;
-  mode?: "none" | "auto" | "required";
-  name?: string;
-  server_label?: string;
-  tools?: Array<{
-    type: string;
-    name?: string;
-    server_label?: string;
-  }>;
+	type: ResponsesToolChoiceType;
+	mode?: "none" | "auto" | "required";
+	name?: string;
+	server_label?: string;
+	tools?: Array<{
+		type: string;
+		name?: string;
+		server_label?: string;
+	}>;
 }
 
 export type ResponsesToolChoice = string | ResponsesToolChoiceStruct;
 
 // Tool configuration
 export interface ResponsesToolFunction {
-  parameters?: {
-    type: string;
-    description?: string;
-    required?: string[];
-    properties?: Record<string, unknown>;
-    enum?: string[];
-  };
-  strict?: boolean;
+	parameters?: {
+		type: string;
+		description?: string;
+		required?: string[];
+		properties?: Record<string, unknown>;
+		enum?: string[];
+	};
+	strict?: boolean;
 }
 
 export interface ResponsesTool {
-  type: string;
-  name?: string;
-  description?: string;
-  // Tool-specific configurations
-  function?: ResponsesToolFunction;
-  // Other tool type configs would be added here
-  [key: string]: any;
+	type: string;
+	name?: string;
+	description?: string;
+	// Tool-specific configurations
+	function?: ResponsesToolFunction;
+	// Other tool type configs would be added here
+	[key: string]: any;
 }
 
 // Reasoning parameters
 export interface ResponsesParametersReasoning {
-  effort?: "minimal" | "low" | "medium" | "high";
-  /**
-   * @deprecated Use `summary` instead
-   */
-  generate_summary?: string;
-  summary?: "auto" | "concise" | "detailed";
+	effort?: "minimal" | "low" | "medium" | "high";
+	/**
+	 * @deprecated Use `summary` instead
+	 */
+	generate_summary?: string;
+	summary?: "auto" | "concise" | "detailed";
 }
 
 // Response conversation structure
@@ -982,48 +975,48 @@ export type ResponsesResponseInstructions = string | ResponsesMessage[];
 
 // Response prompt structure
 export interface ResponsesPrompt {
-  id: string;
-  variables: Record<string, any>;
-  version?: string;
+	id: string;
+	variables: Record<string, any>;
+	version?: string;
 }
 
 // Response usage information
 export interface ResponsesResponseInputTokens {
-  cached_read_tokens: number;
-  cached_write_tokens: number;
+	cached_read_tokens: number;
+	cached_write_tokens: number;
 }
 
 export interface ResponsesResponseOutputTokens {
-  reasoning_tokens: number;
+	reasoning_tokens: number;
 }
 
 export interface ResponsesExtendedResponseUsage {
-  input_tokens: number;
-  input_tokens_details?: ResponsesResponseInputTokens;
-  output_tokens: number;
-  output_tokens_details?: ResponsesResponseOutputTokens;
+	input_tokens: number;
+	input_tokens_details?: ResponsesResponseInputTokens;
+	output_tokens: number;
+	output_tokens_details?: ResponsesResponseOutputTokens;
 }
 
 export interface ResponsesResponseUsage extends ResponsesExtendedResponseUsage {
-  total_tokens: number;
+	total_tokens: number;
 }
 
 // Response error structure
 export interface ResponsesResponseError {
-  code: string;
-  message: string;
+	code: string;
+	message: string;
 }
 
 // Response incomplete details
 export interface ResponsesResponseIncompleteDetails {
-  reason: string;
+	reason: string;
 }
 
 // WebSocket message types
 export interface WebSocketLogMessage {
-  type: "log";
-  operation: "create" | "update";
-  payload: LogEntry;
+	type: "log";
+	operation: "create" | "update";
+	payload: LogEntry;
 }
 
 // ============================================================================
@@ -1032,197 +1025,197 @@ export interface WebSocketLogMessage {
 
 // MCP Tool Log Entry - represents a single MCP tool execution
 export interface MCPToolLogEntry {
-  id: string;
-  llm_request_id?: string; // Links to the LLM request that triggered this tool call
-  timestamp: string; // ISO string format
-  tool_name: string;
-  server_label?: string; // MCP server that provided the tool
-  virtual_key_id?: string;
-  virtual_key_name?: string;
-  arguments?: Record<string, unknown> | string; // JSON parsed tool arguments
-  result?: Record<string, unknown> | string; // JSON parsed tool result
-  error_details?: BifrostError;
-  latency?: number; // Execution time in milliseconds
-  cost?: number; // Cost in dollars (per execution cost)
-  status: string; // "processing", "success", or "error"
-  metadata?: Record<string, string>;
-  created_at: string; // ISO string format
-  virtual_key?: VirtualKey;
+	id: string;
+	llm_request_id?: string; // Links to the LLM request that triggered this tool call
+	timestamp: string; // ISO string format
+	tool_name: string;
+	server_label?: string; // MCP server that provided the tool
+	virtual_key_id?: string;
+	virtual_key_name?: string;
+	arguments?: Record<string, unknown> | string; // JSON parsed tool arguments
+	result?: Record<string, unknown> | string; // JSON parsed tool result
+	error_details?: BifrostError;
+	latency?: number; // Execution time in milliseconds
+	cost?: number; // Cost in dollars (per execution cost)
+	status: string; // "processing", "success", or "error"
+	metadata?: Record<string, string>;
+	created_at: string; // ISO string format
+	virtual_key?: VirtualKey;
 }
 
 // MCP Tool Log Filters
 export interface MCPToolLogFilters {
-  tool_names?: string[];
-  server_labels?: string[];
-  status?: string[];
-  virtual_key_ids?: string[];
-  llm_request_ids?: string[];
-  start_time?: string; // RFC3339 format
-  end_time?: string; // RFC3339 format
-  min_latency?: number;
-  max_latency?: number;
-  content_search?: string;
+	tool_names?: string[];
+	server_labels?: string[];
+	status?: string[];
+	virtual_key_ids?: string[];
+	llm_request_ids?: string[];
+	start_time?: string; // RFC3339 format
+	end_time?: string; // RFC3339 format
+	min_latency?: number;
+	max_latency?: number;
+	content_search?: string;
 }
 
 // MCP Tool Log Statistics
 export interface MCPToolLogStats {
-  total_executions: number;
-  success_rate: number;
-  average_latency: number;
-  total_cost: number; // Total cost in dollars
+	total_executions: number;
+	success_rate: number;
+	average_latency: number;
+	total_cost: number; // Total cost in dollars
 }
 
 // MCP Tool Log Search Response
 export interface MCPToolLogsResponse {
-  logs: MCPToolLogEntry[];
-  pagination: Pagination;
-  stats: MCPToolLogStats;
-  has_logs: boolean;
+	logs: MCPToolLogEntry[];
+	pagination: Pagination;
+	stats: MCPToolLogStats;
+	has_logs: boolean;
 }
 
 // MCP Tool Log Filter Data Response
 export interface MCPToolLogFilterData {
-  tool_names: string[];
-  server_labels: string[];
-  virtual_keys: VirtualKey[];
+	tool_names: string[];
+	server_labels: string[];
+	virtual_keys: VirtualKey[];
 }
 
 // WebSocket message types for MCP tool logs
 export interface WebSocketMCPToolLogMessage {
-  type: "mcp_log";
-  operation: "create" | "update";
-  payload: MCPToolLogEntry;
+	type: "mcp_log";
+	operation: "create" | "update";
+	payload: MCPToolLogEntry;
 }
 
 // MCP histogram types
 
 export interface MCPHistogramBucket {
-  timestamp: string;
-  count: number;
-  success: number;
-  error: number;
+	timestamp: string;
+	count: number;
+	success: number;
+	error: number;
 }
 
 export interface MCPHistogramResponse {
-  buckets: MCPHistogramBucket[];
-  bucket_size_seconds: number;
+	buckets: MCPHistogramBucket[];
+	bucket_size_seconds: number;
 }
 
 export interface MCPCostHistogramBucket {
-  timestamp: string;
-  total_cost: number;
+	timestamp: string;
+	total_cost: number;
 }
 
 export interface MCPCostHistogramResponse {
-  buckets: MCPCostHistogramBucket[];
-  bucket_size_seconds: number;
+	buckets: MCPCostHistogramBucket[];
+	bucket_size_seconds: number;
 }
 
 export interface MCPTopTool {
-  tool_name: string;
-  count: number;
-  cost: number;
+	tool_name: string;
+	count: number;
+	cost: number;
 }
 
 export interface MCPTopToolsResponse {
-  tools: MCPTopTool[];
+	tools: MCPTopTool[];
 }
 
 // Model Rankings types
 export interface ModelRankingTrend {
-  has_previous_period: boolean;
-  requests_trend: number;
-  tokens_trend: number;
-  cost_trend: number;
-  latency_trend: number;
+	has_previous_period: boolean;
+	requests_trend: number;
+	tokens_trend: number;
+	cost_trend: number;
+	latency_trend: number;
 }
 
 export interface ModelRankingEntry {
-  model: string;
-  provider: string;
-  total_requests: number;
-  success_count: number;
-  success_rate: number;
-  total_tokens: number;
-  total_cost: number;
-  avg_latency: number;
-  trend: ModelRankingTrend;
+	model: string;
+	provider: string;
+	total_requests: number;
+	success_count: number;
+	success_rate: number;
+	total_tokens: number;
+	total_cost: number;
+	avg_latency: number;
+	trend: ModelRankingTrend;
 }
 
 export interface ModelRankingsResponse {
-  rankings: ModelRankingEntry[];
+	rankings: ModelRankingEntry[];
 }
 
 export interface UserRankingTrend {
-  has_previous_period: boolean;
-  requests_trend: number;
-  tokens_trend: number;
-  cost_trend: number;
+	has_previous_period: boolean;
+	requests_trend: number;
+	tokens_trend: number;
+	cost_trend: number;
 }
 
 export interface UserRankingEntry {
-  user_id: string;
-  total_requests: number;
-  total_tokens: number;
-  total_cost: number;
-  trend: UserRankingTrend;
+	user_id: string;
+	total_requests: number;
+	total_tokens: number;
+	total_cost: number;
+	trend: UserRankingTrend;
 }
 
 export interface UserRankingsResponse {
-  rankings: UserRankingEntry[];
+	rankings: UserRankingEntry[];
 }
 
 // Date utility functions for URL state management
 export const dateUtils = {
-  /**
-   * Converts a Date object to Unix timestamp (seconds)
-   */
-  toUnixTimestamp: (date: Date | undefined): number | undefined => {
-    if (!date) return undefined;
-    return Math.floor(date.getTime() / 1000);
-  },
+	/**
+	 * Converts a Date object to Unix timestamp (seconds)
+	 */
+	toUnixTimestamp: (date: Date | undefined): number | undefined => {
+		if (!date) return undefined;
+		return Math.floor(date.getTime() / 1000);
+	},
 
-  /**
-   * Converts Unix timestamp (seconds) to Date object
-   */
-  fromUnixTimestamp: (timestamp: number | undefined): Date | undefined => {
-    if (timestamp === undefined) return undefined;
-    return new Date(timestamp * 1000);
-  },
+	/**
+	 * Converts Unix timestamp (seconds) to Date object
+	 */
+	fromUnixTimestamp: (timestamp: number | undefined): Date | undefined => {
+		if (timestamp === undefined) return undefined;
+		return new Date(timestamp * 1000);
+	},
 
-  /**
-   * Gets the Unix timestamp for 24 hours ago
-   */
-  get24HoursAgo: (): number => {
-    const date = new Date();
-    date.setHours(date.getHours() - 24);
-    return Math.floor(date.getTime() / 1000);
-  },
+	/**
+	 * Gets the Unix timestamp for 24 hours ago
+	 */
+	get24HoursAgo: (): number => {
+		const date = new Date();
+		date.setHours(date.getHours() - 24);
+		return Math.floor(date.getTime() / 1000);
+	},
 
-  /**
-   * Gets the current Unix timestamp
-   */
-  getCurrentTimestamp: (): number => {
-    return Math.floor(Date.now() / 1000);
-  },
+	/**
+	 * Gets the current Unix timestamp
+	 */
+	getCurrentTimestamp: (): number => {
+		return Math.floor(Date.now() / 1000);
+	},
 
-  /**
-   * Converts Unix timestamp to ISO string for API calls
-   */
-  toISOString: (timestamp: number | undefined): string | undefined => {
-    if (timestamp === undefined) return undefined;
-    return new Date(timestamp * 1000).toISOString();
-  },
+	/**
+	 * Converts Unix timestamp to ISO string for API calls
+	 */
+	toISOString: (timestamp: number | undefined): string | undefined => {
+		if (timestamp === undefined) return undefined;
+		return new Date(timestamp * 1000).toISOString();
+	},
 
-  /**
-   * Gets default time range (last 24 hours to now) as Unix timestamps
-   * Returns fresh timestamps on each call to avoid stale defaults
-   */
-  getDefaultTimeRange: (): { startTime: number; endTime: number } => {
-    const endTime = Math.floor(Date.now() / 1000);
-    const date = new Date();
-    date.setHours(date.getHours() - 24);
-    const startTime = Math.floor(date.getTime() / 1000);
-    return { startTime, endTime };
-  },
+	/**
+	 * Gets default time range (last 1 hours to now) as Unix timestamps
+	 * Returns fresh timestamps on each call to avoid stale defaults
+	 */
+	getDefaultTimeRange: (): { startTime: number; endTime: number } => {
+		const endTime = Math.floor(Date.now() / 1000);
+		const date = new Date();
+		date.setHours(date.getHours() - 1);
+		const startTime = Math.floor(date.getTime() / 1000);
+		return { startTime, endTime };
+	},
 };

--- a/ui/lib/utils/timeRange.ts
+++ b/ui/lib/utils/timeRange.ts
@@ -1,0 +1,44 @@
+export const TIME_PERIODS = [
+	{ label: "Last hour", value: "1h" },
+	{ label: "Last 6 hours", value: "6h" },
+	{ label: "Last 24 hours", value: "24h" },
+	{ label: "Last 7 days", value: "7d" },
+	{ label: "Last 30 days", value: "30d" },
+];
+
+export type TimePeriod = (typeof TIME_PERIODS)[number]["value"];
+
+/** Returns a fresh { from, to } Date pair for the given relative period string. */
+export function getRangeForPeriod(period: string): { from: Date; to: Date } {
+	const to = new Date();
+	const from = new Date(to.getTime());
+	switch (period) {
+		case "1h":
+			from.setHours(from.getHours() - 1);
+			break;
+		case "6h":
+			from.setHours(from.getHours() - 6);
+			break;
+		case "24h":
+			from.setHours(from.getHours() - 24);
+			break;
+		case "7d":
+			from.setDate(from.getDate() - 7);
+			break;
+		case "30d":
+			from.setDate(from.getDate() - 30);
+			break;
+		default:
+			from.setHours(from.getHours() - 24);
+	}
+	return { from, to };
+}
+
+/** Returns unix timestamps (seconds) for the given relative period string. */
+export function getUnixRangeForPeriod(period: string): { start: number; end: number } {
+	const { from, to } = getRangeForPeriod(period);
+	return {
+		start: Math.floor(from.getTime() / 1000),
+		end: Math.floor(to.getTime() / 1000),
+	};
+}


### PR DESCRIPTION
## Summary

Replaces the WebSocket-driven live update model on the Logs and MCP Logs pages with RTK Query's built-in polling. Instead of manually managing local state arrays and patching them on every WebSocket message, the pages now use non-lazy RTK Query hooks (`useGetLogsQuery`, `useGetLogsStatsQuery`, `useGetLogsHistogramQuery`, `useGetMCPLogsQuery`, `useGetMCPLogsStatsQuery`) that poll every 5 seconds when live mode is active. A relative time period (e.g. `24h`, `7d`) is now persisted in the URL alongside the resolved Unix timestamps, so the window stays fresh across tab focus events and page refreshes without losing the user's intent.

## Changes

- **RTK Query polling replaces WebSocket state patching**: All manual `setLogs`, `setStats`, `setHistogram`, and `matchesFilters` logic is removed. RTK handles caching, deduplication, and refetching automatically.
- **`period` added to URL state** on Logs, MCP Logs, and Dashboard pages. When a relative period is active, a `setInterval` updates the stored Unix timestamps every 5 seconds so RTK detects argument changes and refetches. When an absolute custom range is selected, `period` is cleared.
- **Live toggle replaced with separate Refresh + Live buttons**: The header now shows a `Refresh` button (manual refetch with spinner) and a `Live` toggle button (enables/disables polling). The old "Live updates / Pause" single button is removed.
- **WebSocket subscription removed from `SessionDetailsSheet`**: The `liveEnabled` prop and `subscribe("log", ...)` effect are removed; the sheet's polling interval on `useGetLogSessionSummaryByIdQuery` handles freshness.
- **`ui/lib/utils/timeRange.ts` extracted**: `TIME_PERIODS`, `getRangeForPeriod`, and `getUnixRangeForPeriod` are consolidated into a shared utility, removing duplicated inline implementations from `logsHeaderView.tsx` and `mcpHeaderView.tsx`.
- **Empty state detection simplified**: A `hasCheckedEmptyState` ref gates the first-response check; subsequent responses only clear the empty state once logs appear, avoiding flicker.
- **`EmptyState` and `MCPEmptyState` cleaned up**: The WebSocket connection status indicator ("Listening for logs…" badge) is removed since it was tied to the now-removed socket subscription.
- **`LogsDataTable` and `MCPLogsDataTable` updated**: `isSocketConnected` and `liveEnabled` props replaced with `polling` and `onRefresh`. The status row now shows a spinner when polling is on, or a Refresh button when it is off.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm build
```

1. Open the Logs page — verify logs load and the stat cards populate.
2. Toggle the **Live** button off and confirm polling stops; click **Refresh** to manually refetch.
3. Select a predefined period (e.g. "Last 7 days") and refresh the page — confirm the same period is restored from the URL and timestamps are updated.
4. Select a custom date range — confirm `period` is cleared from the URL and the range is preserved on refresh.
5. Switch to the MCP Logs page and repeat steps 2–4.
6. Open the Dashboard and confirm the predefined period pill remains selected after a page refresh.
7. Verify the empty state page no longer shows a WebSocket connection badge.

## Screenshots/Recordings

Before: Single "Live updates / Pause" toggle button; WebSocket badge on empty state.
After: Separate "Refresh" and "Live" buttons; period persisted in URL; no WebSocket badge.

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

No auth, secrets, or PII changes. Polling uses the same authenticated RTK Query endpoints as before.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable