### PR TITLE
docs: add `cluster_config` reference page and update schema, migration, and Helm docs

### DIFF
--- a/docs/deployment-guides/config-json.mdx
+++ b/docs/deployment-guides/config-json.mdx
@@ -393,6 +393,9 @@ Ready-to-use reference configurations from the [examples/configs](https://github
   <Card title="Plugins" icon="puzzle-piece" href="/deployment-guides/config-json/plugins">
     Semantic cache, OTel, Maxim, Datadog, custom plugins
   </Card>
+  <Card title="Cluster" icon="circle-nodes" href="/deployment-guides/config-json/cluster">
+    Cluster mode with static peers or discovery backends (enterprise)
+  </Card>
   <Card title="Governance" icon="shield-check" href="/deployment-guides/config-json/governance">
     Virtual keys, budgets, rate limits, routing rules, admin auth
   </Card>

--- a/docs/deployment-guides/config-json/cluster.mdx
+++ b/docs/deployment-guides/config-json/cluster.mdx
@@ -1,0 +1,154 @@
+---
+title: "Cluster"
+description: "Configure enterprise cluster mode in config.json using peers or automatic discovery"
+icon: "circle-nodes"
+---
+
+<Warning>
+`cluster_config` is an enterprise capability. OSS builds ignore this section.
+
+</Warning>
+
+`cluster_config` enables multi-node Bifrost enterprise clustering with gossip-based membership and optional automatic node discovery.
+
+You can form a cluster in two ways:
+
+- Define static `peers` (`host:port`)
+- Enable `discovery` with one of: `kubernetes`, `dns`, `udp`, `consul`, `etcd`, `mdns`
+
+<Tip>
+At least one of `peers` or `discovery.enabled: true` must be configured when `cluster_config.enabled` is true.
+</Tip>
+
+---
+
+## Minimal Runnable Configs
+
+```json
+{
+  "cluster_config": {
+    "enabled": true,
+    "discovery": {
+      "enabled": true,
+      "type": "mdns",
+      "service_name": "bifrost-cluster"
+    }
+  }
+}
+```
+
+Use this for local testing. At startup, cluster init requires either:
+
+- non-empty `peers`, or
+- `discovery.enabled: true`
+
+If neither is set, cluster initialization fails.
+
+---
+
+## Static Peers
+
+```json
+{
+  "cluster_config": {
+    "enabled": true,
+    "region": "us-east-1",
+    "peers": [
+      "10.0.1.10:10101",
+      "10.0.1.11:10101"
+    ],
+    "gossip": {
+      "port": 10101,
+      "config": {
+        "timeout_seconds": 10,
+        "success_threshold": 3,
+        "failure_threshold": 3
+      }
+    }
+  }
+}
+```
+
+---
+
+## Discovery Example (etcd)
+
+```json
+{
+  "cluster_config": {
+    "enabled": true,
+    "region": "us-east-1",
+    "gossip": {
+      "port": 10101,
+      "config": {
+        "timeout_seconds": 10,
+        "success_threshold": 3,
+        "failure_threshold": 3
+      }
+    },
+    "discovery": {
+      "enabled": true,
+      "type": "etcd",
+      "service_name": "bifrost-cluster",
+      "etcd_endpoints": [
+        "http://etcd-1:2379",
+        "http://etcd-2:2379"
+      ],
+      "dial_timeout": "10s"
+    }
+  }
+}
+```
+
+---
+
+## Field Reference
+
+### `cluster_config`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | boolean | Enables cluster mode |
+| `region` | string | Region label for this node (defaults to `"unknown"` at runtime when omitted) |
+| `peers` | array of strings | Static peer addresses in `host:port` format |
+| `gossip` | object | Gossip/memberlist settings |
+| `discovery` | object | Automatic node discovery settings |
+
+### `cluster_config.gossip`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `port` | integer | Gossip port for this node |
+| `config.timeout_seconds` | integer | Liveness timeout |
+| `config.success_threshold` | integer | Success count before healthy |
+| `config.failure_threshold` | integer | Failure count before unhealthy |
+
+### `cluster_config.discovery`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | boolean | Enables discovery process |
+| `type` | string | `kubernetes`, `dns`, `udp`, `consul`, `etcd`, `mdns` |
+| `service_name` | string | Service identifier (required for `consul`, `etcd`, `udp`, typically `mdns`; optional for `kubernetes` and `dns`) |
+| `bind_port` | integer | Port appended to discovered hosts if missing |
+| `dial_timeout` | string | Go duration string (`"5s"`, `"30s"`, `"1m"`) |
+| `allowed_address_space` | array of strings | CIDR filters for discovered nodes |
+| `k8s_namespace` | string | Kubernetes namespace for pod discovery |
+| `k8s_label_selector` | string | Kubernetes label selector |
+| `dns_names` | array of strings | DNS names to resolve |
+| `udp_broadcast_port` | integer | UDP broadcast port (required for `udp`) |
+| `consul_address` | string | Consul address |
+| `etcd_endpoints` | array of strings | etcd endpoint URLs |
+| `mdns_service` | string | Optional mDNS service type override (e.g. `"_bifrost-cluster._tcp"`) |
+
+<Note>
+For `discovery.type: "mdns"`, `service_name` is sufficient for most setups. When `mdns_service` is omitted, Bifrost derives the mDNS service type as `"_<service_name>._tcp"`. If you set `mdns_service`, it **overrides** the derived value and is used for both mDNS registration and browsing.
+</Note>
+
+<Warning>
+For `discovery.type: "udp"`, configure both `udp_broadcast_port` and `allowed_address_space`.
+</Warning>
+
+---
+
+For discovery-method deep dives and deployment patterns, see [Enterprise Clustering](/enterprise/clustering).

--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -23,6 +23,7 @@ This page is a concise reference for every top-level key in `config.json`. Click
 | `governance` | object | Admin auth, virtual keys, budgets, rate limits, routing rules, customers, teams | [Governance](/deployment-guides/config-json/governance) |
 | `guardrails_config` | object | Content moderation providers and CEL-based rules *(enterprise only)* | [Guardrails](/deployment-guides/config-json/guardrails) |
 | `access_profiles` | array | Access profile templates for enterprise RBAC/governance controls *(enterprise only)* | [Enterprise Governance](/enterprise/advanced-governance) |
+| `cluster_config` | object | Cluster mode settings: gossip, peers, and auto-discovery backends *(enterprise only)* | [Cluster](/deployment-guides/config-json/cluster) |
 | `config_store` | object | Configuration database backend — SQLite, PostgreSQL, or disabled (file-only mode) | [Storage](/deployment-guides/config-json/storage#config_store) |
 | `logs_store` | object | Request/response log database — SQLite, PostgreSQL + optional S3/GCS offload | [Storage](/deployment-guides/config-json/storage#logs_store) |
 | `vector_store` | object | Vector database for semantic cache — Weaviate, Redis, Qdrant, Pinecone, Valkey | [Storage](/deployment-guides/config-json/storage#vector_store) |
@@ -148,6 +149,22 @@ Enterprise-only. Defines access profile templates that can later be attached to 
   ]
 }
 ```
+
+---
+
+## `cluster_config`
+
+Enterprise-only clustering settings for multi-node deployments.
+
+| Sub-key | Description |
+|---------|-------------|
+| `enabled` | Enables cluster mode |
+| `region` | Region label used by enterprise clustering |
+| `peers` | Static peer list (`host:port`) |
+| `gossip` | Gossip/memberlist port + liveness thresholds |
+| `discovery` | Auto-discovery configuration (`kubernetes`, `dns`, `udp`, `consul`, `etcd`, `mdns`) |
+
+Full documentation: [Cluster](/deployment-guides/config-json/cluster).
 
 ---
 

--- a/docs/deployment-guides/helm/plugins.mdx
+++ b/docs/deployment-guides/helm/plugins.mdx
@@ -258,7 +258,7 @@ Sends distributed traces and push-based metrics to any OTLP-compatible collector
 | `bifrost.plugins.otel.enabled` | Enable OTel tracing | `false` |
 | `bifrost.plugins.otel.config.service_name` | Service name in traces | `"bifrost"` |
 | `bifrost.plugins.otel.config.collector_url` | OTLP collector endpoint | `""` |
-| `bifrost.plugins.otel.config.trace_type` | Trace type (`genai_extension` or `default`) | `"genai_extension"` |
+| `bifrost.plugins.otel.config.trace_type` | Trace type (`genai_extension`, `vercel`, or `open_inference`) | `"genai_extension"` |
 | `bifrost.plugins.otel.config.protocol` | Transport protocol (`grpc` or `http`) | `"grpc"` |
 | `bifrost.plugins.otel.config.metrics_enabled` | Enable OTLP push-based metrics | `false` |
 | `bifrost.plugins.otel.config.metrics_endpoint` | OTLP metrics endpoint | `""` |

--- a/docs/deployment-guides/helm/providers.mdx
+++ b/docs/deployment-guides/helm/providers.mdx
@@ -178,7 +178,7 @@ bifrost:
 
 ### Azure OpenAI
 
-Azure requires `azure_key_config` on every key with `endpoint`, `api_version`, and a `deployments` map (logical model name → Azure deployment name).
+Azure requires `azure_key_config` on every key with `endpoint` and `api_version`. Use top-level `aliases` to map logical model names to Azure deployment names.
 
 Two auth modes are supported:
 
@@ -211,10 +211,10 @@ bifrost:
           azure_key_config:
             endpoint: "env.AZURE_ENDPOINT"
             api_version: "2024-10-21"
-            deployments:
-              gpt-4o: "gpt-4o-prod"
-              gpt-4o-mini: "gpt-4o-mini-prod"
-              text-embedding-3-small: "embeddings-prod"
+          aliases:
+            gpt-4o: "gpt-4o-prod"
+            gpt-4o-mini: "gpt-4o-mini-prod"
+            text-embedding-3-small: "embeddings-prod"
 
   providerSecrets:
     azure-api-key:
@@ -282,8 +282,8 @@ bifrost:
           azure_key_config:
             endpoint: "env.AZURE_ENDPOINT"
             api_version: "2024-10-21"
-            deployments:
-              gpt-4o: "gpt-4o-prod"
+          aliases:
+            gpt-4o: "gpt-4o-prod"
 
   providerSecrets:
     azure-endpoint:
@@ -314,16 +314,16 @@ bifrost:
           azure_key_config:
             endpoint: "env.AZURE_ENDPOINT_EAST"
             api_version: "2024-10-21"
-            deployments:
-              gpt-4o: "gpt-4o-eastus"
+          aliases:
+            gpt-4o: "gpt-4o-eastus"
         - name: "westus"
           value: "env.AZURE_KEY_WEST"
           weight: 1
           azure_key_config:
             endpoint: "env.AZURE_ENDPOINT_WEST"
             api_version: "2024-10-21"
-            deployments:
-              gpt-4o: "gpt-4o-westus"
+          aliases:
+            gpt-4o: "gpt-4o-westus"
 ```
 
 </Tab>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -426,6 +426,7 @@
                   "deployment-guides/config-json/storage",
                   "deployment-guides/config-json/plugins",
                   "deployment-guides/config-json/governance",
+                  "deployment-guides/config-json/cluster",
                   "deployment-guides/config-json/guardrails"
                 ]
               }

--- a/docs/enterprise/clustering.mdx
+++ b/docs/enterprise/clustering.mdx
@@ -96,15 +96,19 @@ The new clustering configuration uses a `cluster_config` object with integrated 
 
 Discovery-specific fields (e.g. `k8s_label_selector`, `consul_address`, `etcd_endpoints`) slot into the `discovery` object alongside `type` — see each method's section below.
 
+<Note>
+At startup, cluster mode requires either a non-empty `peers` list or `discovery.enabled: true`.
+</Note>
+
 ### Common Discovery Configuration Fields
 
 All discovery methods support these common fields:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `enabled` | boolean | Yes | Enable/disable discovery |
+| `enabled` | boolean | No | Enable/disable discovery (must be `true` to use discovery at runtime) |
 | `type` | string | Yes | Discovery type: `kubernetes`, `consul`, `etcd`, `dns`, `udp`, `mdns` |
-| `service_name` | string | Yes | Service name for discovery |
+| `service_name` | string | Conditional | Required for `consul`, `etcd`, `udp`, and typically `mdns`; optional for `kubernetes` and `dns` |
 | `bind_port` | integer | No | Port for cluster communication (default: 10101) |
 | `dial_timeout` | duration | No | Discovery timeout (default: 10s) |
 | `allowed_address_space` | array | No | CIDR ranges to filter discovered nodes (e.g., `["10.0.0.0/8"]`) |

--- a/docs/migration-guides/v1.5.0.mdx
+++ b/docs/migration-guides/v1.5.0.mdx
@@ -276,9 +276,9 @@ Support for image editing via `/v1/images/edits` on Replicate is also being remo
 
 ---
 
-## Breaking Change 9: Provider `deployments` Removed — Migrate to `aliases`
+## Breaking Change 9: Provider `deployments` removed — migrate to `aliases`
 
-The per-provider `deployments` map has been removed from `azure_key_config`, `vertex_key_config`, `bedrock_key_config`, and `replicate_key_config`. A single top-level `aliases` field on each key replaces all of them. Aliases work across all providers and map any model name to a provider-specific identifier (deployment name, inference profile ARN, fine-tuned model ID, etc.).
+Provider deployment mappings should now live in the top-level `aliases` field on each key. Aliases work across all providers and map any model name to a provider-specific identifier (deployment name, inference profile ARN, fine-tuned model ID, etc.).
 
 The database migration runs automatically on startup, migrating existing deployment data into `aliases`. Only `config.json` files need to be updated manually.
 
@@ -325,6 +325,10 @@ The database migration runs automatically on startup, migrating existing deploym
 ```
 
 ### Bedrock
+
+<Warning>
+`bedrock_key_config.deployments` is a legacy field and is **removed** in v1.5.0 config semantics. Some setups/builds may still accept it for backward compatibility, but do not rely on it — migrate to `aliases` to avoid silent breakage and future removal.
+</Warning>
 
 **Before:**
 ```json
@@ -593,7 +597,7 @@ Replace `enable_litellm_fallbacks` with the appropriate combination of `convert_
 </Step>
 
 <Step title="Migrate provider deployments to aliases">
-Remove `deployments` from `azure_key_config`, `vertex_key_config`, `bedrock_key_config`, and `replicate_key_config`. Move those mappings to the top-level `aliases` field on each key. For Replicate, set `use_deployments_endpoint: true` if you were using the deployments endpoint.
+Move deployment mappings from provider-specific `deployments` fields into the top-level `aliases` field on each key. For Replicate, set `use_deployments_endpoint: true` if you were using the deployments endpoint.
 </Step>
 
 <Step title="Update Go SDK references to ExtraFields.ModelRequested">

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2968,7 +2968,7 @@
         },
         "region": {
           "type": "string",
-          "description": "AWS region for cluster deployment (default: us-east-1)"
+          "description": "Region label for cluster deployment (runtime default: unknown)"
         },
         "peers": {
           "type": "array",


### PR DESCRIPTION
## Summary

Adds a dedicated `cluster_config` documentation page for enterprise cluster mode and updates related reference pages to reflect accurate field descriptions, corrected Azure deployment mapping instructions, and clarified migration guidance for provider `aliases`.

## Changes

- Added `docs/deployment-guides/config-json/cluster.mdx` with full field reference, minimal runnable configs, and examples for static peers and etcd-based discovery
- Registered the new cluster page in `docs.json` and added a card linking to it from the config-json index
- Added `cluster_config` entry to the schema reference page with a sub-key table and link to the new page
- Clarified that `cluster_config.region` defaults to `"unknown"` at runtime (not `"us-east-1"`) in both the schema JSON and docs
- Updated `discovery.enabled` and `service_name` field descriptions in `enterprise/clustering.mdx` to reflect that `enabled` is not strictly required and `service_name` conditionality varies by backend
- Added a startup requirement note: cluster mode needs either a non-empty `peers` list or `discovery.enabled: true`
- Corrected Azure provider examples in `helm/providers.mdx` to use top-level `aliases` instead of `azure_key_config.deployments`
- Updated `helm/plugins.mdx` OTel `trace_type` docs to include `vercel` and `open_inference` as valid values alongside `genai_extension`
- Softened the v1.5.0 migration guide language around provider `deployments` removal and added a Bedrock backward-compatibility note

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation to confirm:

- The new Cluster page appears under the config-json section with the `circle-nodes` icon
- The card on the config-json index links correctly to `/deployment-guides/config-json/cluster`
- The schema reference table includes `cluster_config` with a working link
- Azure Helm examples use `aliases` at the key level rather than `deployments` inside `azure_key_config`
- OTel `trace_type` docs list all three valid values

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. All changes are documentation only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable