### PR TITLE
chore: bump bifrost Helm chart version to 2.1.4

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.3
+version: 2.1.4
 appVersion: "1.5.0-prerelease5"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,7 +4,7 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.2
+**Latest Version:** 2.1.4
 
 ## Changelog
 


### PR DESCRIPTION
## Summary

Bumps the Bifrost Helm chart version from `2.1.3` to `2.1.4` and corrects the latest version reference in the README from `2.1.2` to `2.1.4`.

## Changes

- Helm chart `version` field updated to `2.1.4`
- README "Latest Version" badge/reference corrected to reflect `2.1.4`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
helm lint helm-charts/bifrost
helm template helm-charts/bifrost
```

Verify the chart version reported is `2.1.4`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable