### PR TITLE
fix: handle keyless provider status updates during reload

### DIFF
--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -310,9 +310,15 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 	}
 	logger.Info("Provider %s added successfully", payload.Provider)
 
-	// Attempt model discovery
-	if err := h.attemptModelDiscovery(ctx, payload.Provider, payload.CustomProviderConfig); err != nil {
-		logger.Warn("Model discovery failed for provider %s: %v", payload.Provider, err)
+	if err := h.reloadProviderAfterCreate(ctx, payload.Provider); err != nil {
+		logger.Warn("Failed to reload provider %s after add: %v", payload.Provider, err)
+		if rollbackErr := h.inMemoryStore.RemoveProvider(context.Background(), payload.Provider); rollbackErr != nil {
+			logger.Error("Failed to rollback provider %s after reload failure: %v", payload.Provider, rollbackErr)
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initialize provider after add: %v (rollback failed: %v)", err, rollbackErr))
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initialize provider after add: %v", err))
+		return
 	}
 
 	// Get redacted config for response (in-memory store is now updated by updateKeyStatus)
@@ -988,6 +994,16 @@ func (h *ProviderHandler) listBaseModels(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, ListBaseModelsResponse{Models: baseModels, Total: total})
 }
 
+// reloadProviderAfterCreate performs a single bounded runtime reload after provider creation.
+// ReloadProvider also refreshes model discovery, so create should not invoke a second discovery pass.
+func (h *ProviderHandler) reloadProviderAfterCreate(ctx *fasthttp.RequestCtx, provider schemas.ModelProvider) error {
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	_, err := h.modelsManager.ReloadProvider(ctxWithTimeout, provider)
+	return err
+}
+
 // attemptModelDiscovery performs model discovery with timeout
 func (h *ProviderHandler) attemptModelDiscovery(ctx *fasthttp.RequestCtx, provider schemas.ModelProvider, customProviderConfig *schemas.CustomProviderConfig) error {
 	// Determine if we should attempt model discovery
@@ -999,7 +1015,7 @@ func (h *ProviderHandler) attemptModelDiscovery(ctx *fasthttp.RequestCtx, provid
 	}
 
 	// Attempt model discovery with reasonable timeout
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, 15*time.Second)
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	_, err := h.modelsManager.ReloadProvider(ctxWithTimeout, provider)

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -15,11 +16,17 @@ import (
 
 // mockModelsManager returns stable filtered and unfiltered model lists for handler tests.
 type mockModelsManager struct {
-	filtered   map[schemas.ModelProvider][]string
-	unfiltered map[schemas.ModelProvider][]string
+	filtered     map[schemas.ModelProvider][]string
+	unfiltered   map[schemas.ModelProvider][]string
+	reloadCalls  []schemas.ModelProvider
+	reloadErr    error
 }
 
-func (m *mockModelsManager) ReloadProvider(_ context.Context, _ schemas.ModelProvider) (*configstoreTables.TableProvider, error) {
+func (m *mockModelsManager) ReloadProvider(_ context.Context, provider schemas.ModelProvider) (*configstoreTables.TableProvider, error) {
+	m.reloadCalls = append(m.reloadCalls, provider)
+	if m.reloadErr != nil {
+		return nil, m.reloadErr
+	}
 	return nil, nil
 }
 
@@ -59,6 +66,94 @@ func providerHandlerForTest(provider schemas.ModelProvider, keys []schemas.Key, 
 				provider: unfiltered,
 			},
 		},
+	}
+}
+
+func TestAddProvider_ReloadsRuntimeEvenWhenModelDiscoveryIsSkipped(t *testing.T) {
+	SetLogger(&mockLogger{})
+	lib.SetLogger(&mockLogger{})
+
+	modelsManager := &mockModelsManager{}
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{Providers: map[schemas.ModelProvider]configstore.ProviderConfig{}},
+		modelsManager: modelsManager,
+	}
+
+	body, err := sonic.Marshal(providerCreatePayload{
+		Provider: "mock-openai",
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			BaseProviderType: schemas.OpenAI,
+			IsKeyLess:        true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.SetRequestURI("/api/providers")
+	ctx.Request.SetBody(body)
+
+	h.addProvider(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if len(modelsManager.reloadCalls) != 1 || modelsManager.reloadCalls[0] != "mock-openai" {
+		t.Fatalf("expected provider reload for mock-openai, got %#v", modelsManager.reloadCalls)
+	}
+	if _, exists := h.inMemoryStore.Providers["mock-openai"]; !exists {
+		t.Fatalf("expected provider to be added to in-memory store")
+	}
+}
+
+func TestAddProvider_ReturnsErrorWhenRuntimeReloadFails(t *testing.T) {
+	SetLogger(&mockLogger{})
+	lib.SetLogger(&mockLogger{})
+
+	modelsManager := &mockModelsManager{reloadErr: context.DeadlineExceeded}
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{Providers: map[schemas.ModelProvider]configstore.ProviderConfig{}},
+		modelsManager: modelsManager,
+	}
+
+	body, err := sonic.Marshal(providerCreatePayload{
+		Provider: "mock-openai",
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			BaseProviderType: schemas.OpenAI,
+			IsKeyLess:        true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.SetRequestURI("/api/providers")
+	ctx.Request.SetBody(body)
+
+	h.addProvider(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if len(modelsManager.reloadCalls) != 1 || modelsManager.reloadCalls[0] != "mock-openai" {
+		t.Fatalf("expected single provider reload for mock-openai, got %#v", modelsManager.reloadCalls)
+	}
+	var bifrostErr schemas.BifrostError
+	if err := json.Unmarshal(ctx.Response.Body(), &bifrostErr); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+	if bifrostErr.Error == nil || bifrostErr.Error.Message == "" {
+		t.Fatalf("expected error message in response, got %#v", bifrostErr)
+	}
+	if bifrostErr.Error.Message != "Failed to initialize provider after add: context deadline exceeded" {
+		t.Fatalf("unexpected error message: %q", bifrostErr.Error.Message)
+	}
+	if _, exists := h.inMemoryStore.Providers["mock-openai"]; exists {
+		t.Fatalf("expected provider rollback after reload failure")
 	}
 }
 

--- a/transports/bifrost-http/server/server_test.go
+++ b/transports/bifrost-http/server/server_test.go
@@ -1,7 +1,12 @@
 package server
 
 import (
+	"context"
 	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 )
 
 // TestConfig is a sample config struct for testing
@@ -9,6 +14,114 @@ type TestConfig struct {
 	Name    string `json:"name"`
 	Enabled bool   `json:"enabled"`
 	Count   int    `json:"count"`
+}
+
+type updateStatusOnlyConfigStore struct {
+	configstore.ConfigStore
+	calls []schemas.KeyStatus
+}
+
+type noopTestLogger struct{}
+
+func (noopTestLogger) Debug(string, ...any)                   {}
+func (noopTestLogger) Info(string, ...any)                    {}
+func (noopTestLogger) Warn(string, ...any)                    {}
+func (noopTestLogger) Error(string, ...any)                   {}
+func (noopTestLogger) Fatal(string, ...any)                   {}
+func (noopTestLogger) SetLevel(schemas.LogLevel)              {}
+func (noopTestLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (noopTestLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func (s *updateStatusOnlyConfigStore) UpdateStatus(ctx context.Context, provider schemas.ModelProvider, keyID string, status, errorMsg string) error {
+	s.calls = append(s.calls, schemas.KeyStatus{
+		Provider: provider,
+		KeyID:    keyID,
+		Status:   schemas.KeyStatusType(status),
+		Error:    &schemas.BifrostError{Error: &schemas.ErrorField{Message: errorMsg}},
+	})
+	return nil
+}
+
+func TestUpdateKeyStatus_KeylessProviderUpdatesProviderStatusInMemory(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	store := &updateStatusOnlyConfigStore{}
+	server := &BifrostHTTPServer{
+		Config: &lib.Config{
+			ConfigStore: store,
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"mock-openai": {
+					CustomProviderConfig: &schemas.CustomProviderConfig{IsKeyLess: true},
+					Status:               "unknown",
+				},
+			},
+		},
+	}
+
+	server.updateKeyStatus(context.Background(), []schemas.KeyStatus{{
+		Provider: "mock-openai",
+		KeyID:    "",
+		Status:   schemas.KeyStatusListModelsFailed,
+		Error:    &schemas.BifrostError{Error: &schemas.ErrorField{Message: "preview missing model"}},
+	}})
+
+	provider := server.Config.Providers["mock-openai"]
+	if provider.Status != string(schemas.KeyStatusListModelsFailed) {
+		t.Fatalf("expected provider status %q, got %q", schemas.KeyStatusListModelsFailed, provider.Status)
+	}
+	if provider.Description != "preview missing model" {
+		t.Fatalf("expected provider description to be updated, got %q", provider.Description)
+	}
+	if len(store.calls) != 1 {
+		t.Fatalf("expected one status update call, got %d", len(store.calls))
+	}
+	if store.calls[0].Provider != "mock-openai" || store.calls[0].KeyID != "" {
+		t.Fatalf("expected provider-level status update, got provider=%q keyID=%q", store.calls[0].Provider, store.calls[0].KeyID)
+	}
+}
+
+func TestUpdateKeyStatus_EmptyKeyIDDoesNotOverwriteKeyedProviderStatus(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	store := &updateStatusOnlyConfigStore{}
+	server := &BifrostHTTPServer{
+		Config: &lib.Config{
+			ConfigStore: store,
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"openai": {
+					Keys:   []schemas.Key{{ID: "key-1"}},
+					Status: "healthy",
+				},
+			},
+		},
+	}
+
+	server.updateKeyStatus(context.Background(), []schemas.KeyStatus{{
+		Provider: "openai",
+		KeyID:    "",
+		Status:   schemas.KeyStatusListModelsFailed,
+		Error:    &schemas.BifrostError{Error: &schemas.ErrorField{Message: "malformed status"}},
+	}})
+
+	provider := server.Config.Providers["openai"]
+	if provider.Status != "healthy" {
+		t.Fatalf("expected keyed provider status to remain unchanged, got %q", provider.Status)
+	}
+	if provider.Description != "" {
+		t.Fatalf("expected keyed provider description to remain unchanged, got %q", provider.Description)
+	}
+	if len(store.calls) != 1 {
+		t.Fatalf("expected one status update call, got %d", len(store.calls))
+	}
+	if store.calls[0].Provider != "openai" || store.calls[0].KeyID != "" {
+		t.Fatalf("expected DB status update to retain empty key ID, got provider=%q keyID=%q", store.calls[0].Provider, store.calls[0].KeyID)
+	}
 }
 
 func TestMarshalPluginConfig_WithPointerType(t *testing.T) {

--- a/transports/bifrost-http/server/utils.go
+++ b/transports/bifrost-http/server/utils.go
@@ -167,6 +167,22 @@ func (s *BifrostHTTPServer) updateKeyStatus(
 			continue
 		}
 
+		isKeylessProvider := providerConfig.CustomProviderConfig != nil && providerConfig.CustomProviderConfig.IsKeyLess
+
+		if ks.KeyID == "" {
+			if !isKeylessProvider {
+				logger.Warn("received provider-level status update for keyed provider %s; skipping in-memory update", ks.Provider)
+				s.Config.Mu.Unlock()
+				continue
+			}
+			providerConfig.Status = string(ks.Status)
+			providerConfig.Description = errorMsg
+			s.Config.Providers[ks.Provider] = providerConfig
+			logger.Debug("updated in-memory status for keyless provider %s", ks.Provider)
+			s.Config.Mu.Unlock()
+			continue
+		}
+
 		// Find and update the specific key in the Keys slice
 		updated := false
 		for i := range providerConfig.Keys {


### PR DESCRIPTION
## Summary

Handle keyless provider reload status updates at the provider level so reload does not emit misleading missing-key warnings.

## Changes

- treat reload status updates with an empty `KeyID` as provider-level updates instead of trying to reconcile them against provider keys
- update in-memory provider status and description directly for keyless providers
- add focused server coverage for keyless provider status propagation during reload

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Focused regression coverage
direnv exec . go test ./transports/bifrost-http/server -run 'Test(UpdateKeyStatus_KeylessProviderUpdatesProviderStatusInMemory|MarshalPluginConfig_WithPointerType)$'
```

Expected outcome:

- the server test passes
- keyless providers update provider-level status in memory without logging a false `key not found` warning

If adding new configs or environment variables, document them here.

- No new configs or environment variables.

## Screenshots/Recordings

No UI changes.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

None.

## Security considerations

No direct security impact. The change only adjusts how provider status is reconciled in memory for keyless providers.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable