### PR TITLE
fix: write multipart metadata before file uploads

### DIFF
--- a/core/network/multipart_test.go
+++ b/core/network/multipart_test.go
@@ -2,6 +2,8 @@ package network
 
 import (
 	"bytes"
+	"io"
+	"mime"
 	"mime/multipart"
 	"strings"
 	"testing"
@@ -34,6 +36,34 @@ func buildMultipartBody(t *testing.T, fields map[string]string, files map[string
 		t.Fatalf("writer.Close: %v", err)
 	}
 	return buf.Bytes(), writer.FormDataContentType()
+}
+
+func partOrderFromMultipartBody(t *testing.T, contentType string, body []byte) []string {
+	t.Helper()
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("ParseMediaType(%q): %v", contentType, err)
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		t.Fatalf("no boundary in content-type %q", contentType)
+	}
+
+	reader := multipart.NewReader(bytes.NewReader(body), boundary)
+	var order []string
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("NextPart(): %v", err)
+		}
+		order = append(order, part.FormName())
+		_, _ = io.Copy(io.Discard, part)
+		_ = part.Close()
+	}
+	return order
 }
 
 func TestParseMultipartFormFields(t *testing.T) {
@@ -131,6 +161,37 @@ func TestReconstructMultipartBody(t *testing.T) {
 		}
 		if parsed["temperature"] != "0.7" {
 			t.Errorf("temperature = %v, want 0.7", parsed["temperature"])
+		}
+	})
+
+	t.Run("preserves file parts while updating text fields", func(t *testing.T) {
+		body, ct := buildMultipartBody(t,
+			map[string]string{"prompt": "hi"},
+			map[string][]byte{"file": []byte("audio-bytes")},
+		)
+		payload := map[string]any{"model": "whisper-1", "prompt": "updated"}
+		newBody, newCT, err := ReconstructMultipartBody(ct, body, payload)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		order := partOrderFromMultipartBody(t, newCT, newBody)
+		if len(order) != 3 {
+			t.Fatalf("unexpected part count %d: %v", len(order), order)
+		}
+		if order[0] != "prompt" || order[1] != "file" || order[2] != "model" {
+			t.Fatalf("unexpected multipart order %v, want [prompt file model]", order)
+		}
+
+		parsed, err := ParseMultipartFormFields(newCT, newBody)
+		if err != nil {
+			t.Fatalf("failed to parse reconstructed body: %v", err)
+		}
+		if parsed["prompt"] != "updated" {
+			t.Fatalf("prompt = %v, want updated", parsed["prompt"])
+		}
+		if parsed["model"] != "whisper-1" {
+			t.Fatalf("model = %v, want whisper-1", parsed["model"])
 		}
 	})
 

--- a/core/providers/mistral/transcription.go
+++ b/core/providers/mistral/transcription.go
@@ -102,20 +102,7 @@ func createMistralTranscriptionMultipartBody(req *MistralTranscriptionRequest, p
 
 // parseTranscriptionFormDataBodyFromRequest writes the transcription request to a multipart form.
 func parseTranscriptionFormDataBodyFromRequest(writer *multipart.Writer, req *MistralTranscriptionRequest, providerName schemas.ModelProvider) *schemas.BifrostError {
-	// Add file field - Mistral uses "file" as the form field name
-	filename := req.Filename
-	if filename == "" {
-		filename = providerUtils.AudioFilenameFromBytes(req.File)
-	}
-	fileWriter, err := writer.CreateFormFile("file", filename)
-	if err != nil {
-		return providerUtils.NewBifrostOperationError("failed to create form file",  err)
-	}
-	if _, err := fileWriter.Write(req.File); err != nil {
-		return providerUtils.NewBifrostOperationError("failed to write file data",  err)
-	}
-
-	// Add model field (required)
+	// Add model field (required) before the file so upstreams can route without buffering audio bytes.
 	if err := writer.WriteField("model", req.Model); err != nil {
 		return providerUtils.NewBifrostOperationError("failed to write model field",  err)
 	}
@@ -156,6 +143,19 @@ func parseTranscriptionFormDataBodyFromRequest(writer *multipart.Writer, req *Mi
 		if err := writer.WriteField("timestamp_granularities[]", granularity); err != nil {
 			return providerUtils.NewBifrostOperationError("failed to write timestamp_granularities field",  err)
 		}
+	}
+
+	// Add file field last - Mistral uses "file" as the form field name.
+	filename := req.Filename
+	if filename == "" {
+		filename = providerUtils.AudioFilenameFromBytes(req.File)
+	}
+	fileWriter, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		return providerUtils.NewBifrostOperationError("failed to create form file",  err)
+	}
+	if _, err := fileWriter.Write(req.File); err != nil {
+		return providerUtils.NewBifrostOperationError("failed to write file data",  err)
 	}
 
 	// Close the multipart writer to finalize the form

--- a/core/providers/mistral/transcription_test.go
+++ b/core/providers/mistral/transcription_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -66,6 +67,46 @@ func writeUint32LE(b []byte, v uint32) {
 	b[1] = byte(v >> 8)
 	b[2] = byte(v >> 16)
 	b[3] = byte(v >> 24)
+}
+
+func TestParseTranscriptionFormDataBodyFromRequest_OrdersMetadataBeforeFile(t *testing.T) {
+	t.Parallel()
+
+	req := &MistralTranscriptionRequest{
+		Model:          "voxtral-mini-latest",
+		File:           createMinimalAudioFile(),
+		Filename:       "sample.wav",
+		Stream:         schemas.Ptr(true),
+		Language:       schemas.Ptr("en"),
+		Prompt:         schemas.Ptr("hello"),
+		ResponseFormat: schemas.Ptr("json"),
+		Temperature:    schemas.Ptr(0.2),
+		TimestampGranularities: []string{"word", "segment"},
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.Nil(t, parseTranscriptionFormDataBodyFromRequest(writer, req, schemas.Mistral))
+
+	_, params, err := mime.ParseMediaType(writer.FormDataContentType())
+	require.NoError(t, err)
+
+	reader := multipart.NewReader(bytes.NewReader(body.Bytes()), params["boundary"])
+	var order []string
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		order = append(order, part.FormName())
+		require.NoError(t, part.Close())
+	}
+
+	assert.Equal(t,
+		[]string{"model", "stream", "language", "prompt", "response_format", "temperature", "timestamp_granularities[]", "timestamp_granularities[]", "file"},
+		order,
+	)
 }
 
 // TestToMistralTranscriptionRequest tests the Bifrost-to-Mistral request conversion.

--- a/core/providers/openai/images.go
+++ b/core/providers/openai/images.go
@@ -140,42 +140,7 @@ func parseImageEditFormDataBodyFromRequest(writer *multipart.Writer, openaiReq *
 		}
 	}
 
-	// Add image[] fields (one for each image)
-	for i, imageInput := range openaiReq.Input.Images {
-		fieldName := "image[]"
-
-		// Detect and validate MIME type
-		mimeType := http.DetectContentType(imageInput.Image)
-		// Fallback to PNG if content type is undetectable or generic
-		if mimeType == "" || mimeType == "application/octet-stream" {
-			mimeType = "image/png"
-		}
-
-		// Determine filename based on MIME type
-		var filename string
-		switch mimeType {
-		case "image/jpeg":
-			filename = fmt.Sprintf("image%d.jpg", i)
-		case "image/webp":
-			filename = fmt.Sprintf("image%d.webp", i)
-		default:
-			filename = fmt.Sprintf("image%d.png", i)
-		}
-
-		// Create form part with proper Content-Type header (not CreateFormFile which defaults to application/octet-stream)
-		part, err := writer.CreatePart(map[string][]string{
-			"Content-Disposition": {fmt.Sprintf(`form-data; name="%s"; filename="%s"`, fieldName, filename)},
-			"Content-Type":        {mimeType},
-		})
-		if err != nil {
-			return providerUtils.NewBifrostOperationError(fmt.Sprintf("failed to create form part for image %d", i), err)
-		}
-		if _, err := part.Write(imageInput.Image); err != nil {
-			return providerUtils.NewBifrostOperationError(fmt.Sprintf("failed to write image %d data", i), err)
-		}
-	}
-
-	// Add optional parameters
+	// Add optional parameters before file parts so routing metadata arrives first upstream.
 	if openaiReq.N != nil {
 		if err := writer.WriteField("n", strconv.Itoa(*openaiReq.N)); err != nil {
 			return providerUtils.NewBifrostOperationError("failed to write n field", err)
@@ -233,6 +198,41 @@ func parseImageEditFormDataBodyFromRequest(writer *multipart.Writer, openaiReq *
 	if openaiReq.User != nil {
 		if err := writer.WriteField("user", *openaiReq.User); err != nil {
 			return providerUtils.NewBifrostOperationError("failed to write user field", err)
+		}
+	}
+
+	// Add image[] fields (one for each image)
+	for i, imageInput := range openaiReq.Input.Images {
+		fieldName := "image[]"
+
+		// Detect and validate MIME type
+		mimeType := http.DetectContentType(imageInput.Image)
+		// Fallback to PNG if content type is undetectable or generic
+		if mimeType == "" || mimeType == "application/octet-stream" {
+			mimeType = "image/png"
+		}
+
+		// Determine filename based on MIME type
+		var filename string
+		switch mimeType {
+		case "image/jpeg":
+			filename = fmt.Sprintf("image%d.jpg", i)
+		case "image/webp":
+			filename = fmt.Sprintf("image%d.webp", i)
+		default:
+			filename = fmt.Sprintf("image%d.png", i)
+		}
+
+		// Create form part with proper Content-Type header (not CreateFormFile which defaults to application/octet-stream)
+		part, err := writer.CreatePart(map[string][]string{
+			"Content-Disposition": {fmt.Sprintf(`form-data; name="%s"; filename="%s"`, fieldName, filename)},
+			"Content-Type":        {mimeType},
+		})
+		if err != nil {
+			return providerUtils.NewBifrostOperationError(fmt.Sprintf("failed to create form part for image %d", i), err)
+		}
+		if _, err := part.Write(imageInput.Image); err != nil {
+			return providerUtils.NewBifrostOperationError(fmt.Sprintf("failed to write image %d data", i), err)
 		}
 	}
 
@@ -307,27 +307,7 @@ func parseImageVariationFormDataBodyFromRequest(writer *multipart.Writer, openai
 		return providerUtils.NewBifrostOperationError("image is required", nil)
 	}
 
-	// Detect MIME type
-	mimeType := http.DetectContentType(openaiReq.Input.Image.Image)
-	// If still not detected, default to PNG
-	if mimeType == "application/octet-stream" || mimeType == "" {
-		mimeType = "image/png"
-	}
-
-	filename := "image"
-	part, err := writer.CreatePart(map[string][]string{
-		"Content-Disposition": {fmt.Sprintf(`form-data; name="image"; filename="%s"`, filename)},
-		"Content-Type":        {mimeType},
-	})
-	if err != nil {
-		return providerUtils.NewBifrostOperationError("failed to create image part", err)
-	}
-
-	if _, err := part.Write(openaiReq.Input.Image.Image); err != nil {
-		return providerUtils.NewBifrostOperationError("failed to write image data", err)
-	}
-
-	// Add optional parameters
+	// Add optional parameters before the image part so metadata arrives first upstream.
 	if openaiReq.N != nil {
 		if err := writer.WriteField("n", strconv.Itoa(*openaiReq.N)); err != nil {
 			return providerUtils.NewBifrostOperationError("failed to write n field", err)
@@ -350,6 +330,26 @@ func parseImageVariationFormDataBodyFromRequest(writer *multipart.Writer, openai
 		if err := writer.WriteField("user", *openaiReq.User); err != nil {
 			return providerUtils.NewBifrostOperationError("failed to write user field", err)
 		}
+	}
+
+	// Detect MIME type
+	mimeType := http.DetectContentType(openaiReq.Input.Image.Image)
+	// If still not detected, default to PNG
+	if mimeType == "application/octet-stream" || mimeType == "" {
+		mimeType = "image/png"
+	}
+
+	filename := "image"
+	part, err := writer.CreatePart(map[string][]string{
+		"Content-Disposition": {fmt.Sprintf(`form-data; name="image"; filename="%s"`, filename)},
+		"Content-Type":        {mimeType},
+	})
+	if err != nil {
+		return providerUtils.NewBifrostOperationError("failed to create image part", err)
+	}
+
+	if _, err := part.Write(openaiReq.Input.Image.Image); err != nil {
+		return providerUtils.NewBifrostOperationError("failed to write image data", err)
 	}
 
 	// Close the multipart writer

--- a/core/providers/openai/payload_ordering_test.go
+++ b/core/providers/openai/payload_ordering_test.go
@@ -1,6 +1,8 @@
 package openai
 
 import (
+	"bytes"
+	"mime/multipart"
 	"testing"
 
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
@@ -57,3 +59,63 @@ func TestPayloadOrdering_OpenAIChatRequest(t *testing.T) {
 		assert.Equal(t, string(result), string(iter), "non-deterministic marshal output on iteration %d", i)
 	}
 }
+
+func TestParseImageEditFormDataBodyFromRequest_OrdersMetadataBeforeFiles(t *testing.T) {
+	req := &OpenAIImageEditRequest{
+		Model: "gpt-image-1",
+		Input: &schemas.ImageEditInput{
+			Prompt: "edit this",
+			Images: []schemas.ImageInput{{Image: []byte("image-one")}, {Image: []byte("image-two")}},
+		},
+		ImageEditParameters: schemas.ImageEditParameters{
+			N:                 schemas.Ptr(2),
+			Size:              schemas.Ptr("1024x1024"),
+			ResponseFormat:    schemas.Ptr("b64_json"),
+			Quality:           schemas.Ptr("high"),
+			Background:        schemas.Ptr("transparent"),
+			InputFidelity:     schemas.Ptr("high"),
+			PartialImages:     schemas.Ptr(1),
+			OutputFormat:      schemas.Ptr("png"),
+			OutputCompression: schemas.Ptr(80),
+			User:              schemas.Ptr("user-123"),
+			Mask:              []byte("mask-image"),
+		},
+		Stream: schemas.Ptr(true),
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.Nil(t, parseImageEditFormDataBodyFromRequest(writer, req, schemas.OpenAI))
+
+	order := multipartPartOrder(t, writer.FormDataContentType(), body.Bytes())
+	assert.Equal(t,
+		[]string{"model", "prompt", "stream", "n", "size", "response_format", "quality", "background", "input_fidelity", "partial_images", "output_format", "output_compression", "user", "image[]", "image[]", "mask"},
+		order,
+	)
+}
+
+func TestParseImageVariationFormDataBodyFromRequest_OrdersMetadataBeforeFile(t *testing.T) {
+	req := &OpenAIImageVariationRequest{
+		Model: "gpt-image-1",
+		Input: &schemas.ImageVariationInput{
+			Image: schemas.ImageInput{Image: []byte("image-variation")},
+		},
+		ImageVariationParameters: schemas.ImageVariationParameters{
+			N:              schemas.Ptr(3),
+			ResponseFormat: schemas.Ptr("url"),
+			Size:           schemas.Ptr("512x512"),
+			User:           schemas.Ptr("user-456"),
+		},
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.Nil(t, parseImageVariationFormDataBodyFromRequest(writer, req, schemas.OpenAI))
+
+	order := multipartPartOrder(t, writer.FormDataContentType(), body.Bytes())
+	assert.Equal(t,
+		[]string{"model", "n", "response_format", "size", "user", "image"},
+		order,
+	)
+}
+

--- a/core/providers/openai/transcription.go
+++ b/core/providers/openai/transcription.go
@@ -47,20 +47,7 @@ func ToOpenAITranscriptionRequest(bifrostReq *schemas.BifrostTranscriptionReques
 
 // ParseTranscriptionFormDataBodyFromRequest parses the transcription request and writes it to the multipart form.
 func ParseTranscriptionFormDataBodyFromRequest(writer *multipart.Writer, openaiReq *OpenAITranscriptionRequest, providerName schemas.ModelProvider) *schemas.BifrostError {
-	// Add file field
-	filename := openaiReq.Filename
-	if filename == "" {
-		filename = utils.AudioFilenameFromBytes(openaiReq.File)
-	}
-	fileWriter, err := writer.CreateFormFile("file", filename)
-	if err != nil {
-		return utils.NewBifrostOperationError("failed to create form file", err)
-	}
-	if _, err := fileWriter.Write(openaiReq.File); err != nil {
-		return utils.NewBifrostOperationError("failed to write file data", err)
-	}
-
-	// Add model field
+	// Add model field before the file so upstreams can route without buffering the audio payload.
 	if err := writer.WriteField("model", openaiReq.Model); err != nil {
 		return utils.NewBifrostOperationError("failed to write model field", err)
 	}
@@ -106,6 +93,19 @@ func ParseTranscriptionFormDataBodyFromRequest(writer *multipart.Writer, openaiR
 		if err := writer.WriteField("stream", "true"); err != nil {
 			return utils.NewBifrostOperationError("failed to write stream field", err)
 		}
+	}
+
+	// Add file field last so large multipart uploads don't block model discovery upstream.
+	filename := openaiReq.Filename
+	if filename == "" {
+		filename = utils.AudioFilenameFromBytes(openaiReq.File)
+	}
+	fileWriter, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		return utils.NewBifrostOperationError("failed to create form file", err)
+	}
+	if _, err := fileWriter.Write(openaiReq.File); err != nil {
+		return utils.NewBifrostOperationError("failed to write file data", err)
 	}
 
 	// Close the multipart writer

--- a/core/providers/openai/transcription_test.go
+++ b/core/providers/openai/transcription_test.go
@@ -1,0 +1,79 @@
+package openai
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func multipartPartOrder(t *testing.T, contentType string, body []byte) []string {
+	t.Helper()
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("ParseMediaType(%q): %v", contentType, err)
+	}
+	boundary := params["boundary"]
+	if boundary == "" {
+		t.Fatalf("missing boundary in %q", contentType)
+	}
+
+	reader := multipart.NewReader(bytes.NewReader(body), boundary)
+	var order []string
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("NextPart(): %v", err)
+		}
+		order = append(order, part.FormName())
+		_, _ = io.Copy(io.Discard, part)
+		_ = part.Close()
+	}
+	return order
+}
+
+func TestParseTranscriptionFormDataBodyFromRequest_OrdersMetadataBeforeFile(t *testing.T) {
+	language := "en"
+	prompt := "transcribe this"
+	responseFormat := "verbose_json"
+	temperature := 0.2
+	stream := true
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	req := &OpenAITranscriptionRequest{
+		Model:    "whisper-1",
+		File:     []byte("audio-bytes"),
+		Filename: "sample.mp3",
+		TranscriptionParameters: schemas.TranscriptionParameters{
+			Language:               &language,
+			Prompt:                 &prompt,
+			ResponseFormat:         &responseFormat,
+			Temperature:            &temperature,
+			TimestampGranularities: []string{"word"},
+			Include:                []string{"logprobs"},
+		},
+		Stream: &stream,
+	}
+
+	if bifrostErr := ParseTranscriptionFormDataBodyFromRequest(writer, req, schemas.OpenAI); bifrostErr != nil {
+		t.Fatalf("unexpected bifrost error: %v", bifrostErr.Error.Message)
+	}
+
+	order := multipartPartOrder(t, writer.FormDataContentType(), body.Bytes())
+	if len(order) == 0 {
+		t.Fatal("expected multipart parts to be written")
+	}
+	if order[len(order)-1] != "file" {
+		t.Fatalf("expected file part last, got order %v", order)
+	}
+	if order[0] != "model" {
+		t.Fatalf("expected model part first, got order %v", order)
+	}
+}

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -2813,19 +2813,6 @@ func (provider *ReplicateProvider) FileUpload(ctx *schemas.BifrostContext, key s
 		}
 	}
 
-	// Create form file with proper headers
-	h := make(textproto.MIMEHeader)
-	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="content"; filename="%s"`, filename))
-	h.Set("Content-Type", contentType)
-
-	part, err := writer.CreatePart(h)
-	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError("failed to create form file", err)
-	}
-	if _, err := part.Write(request.File); err != nil {
-		return nil, providerUtils.NewBifrostOperationError("failed to write file content", err)
-	}
-
 	// Add filename field if provided
 	if filename != "" {
 		if err := writer.WriteField("filename", filename); err != nil {
@@ -2858,6 +2845,19 @@ func (provider *ReplicateProvider) FileUpload(ctx *schemas.BifrostContext, key s
 				}
 			}
 		}
+	}
+
+	// Create form file with proper headers
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="content"; filename="%s"`, filename))
+	h.Set("Content-Type", contentType)
+
+	part, err := writer.CreatePart(h)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to create form file", err)
+	}
+	if _, err := part.Write(request.File); err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to write file content", err)
 	}
 
 	if err := writer.Close(); err != nil {

--- a/core/providers/replicate/replicate_test.go
+++ b/core/providers/replicate/replicate_test.go
@@ -1,6 +1,12 @@
 package replicate_test
 
 import (
+	"context"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -11,6 +17,80 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type testLogger struct{}
+
+func (l *testLogger) Debug(string, ...any)                     {}
+func (l *testLogger) Info(string, ...any)                      {}
+func (l *testLogger) Warn(string, ...any)                      {}
+func (l *testLogger) Error(string, ...any)                     {}
+func (l *testLogger) Fatal(string, ...any)                     {}
+func (l *testLogger) SetLevel(schemas.LogLevel)               {}
+func (l *testLogger) SetOutputType(schemas.LoggerOutputType)  {}
+func (l *testLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func multipartFieldOrderFromRequest(r *http.Request) ([]string, error) {
+	mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, err
+	}
+	if mediaType != "multipart/form-data" {
+		return nil, assert.AnError
+	}
+
+	reader := multipart.NewReader(r.Body, params["boundary"])
+	var order []string
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		order = append(order, part.FormName())
+		_, _ = io.Copy(io.Discard, part)
+		_ = part.Close()
+	}
+	return order, nil
+}
+
+func TestFileUpload_OrdersMetadataBeforeFile(t *testing.T) {
+	var (
+		order       []string
+		handlerErr error
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		order, handlerErr = multipartFieldOrderFromRequest(r)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"title":"forced error"}`))
+	}))
+	defer server.Close()
+
+	provider, err := replicate.NewReplicateProvider(&schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+	}, &testLogger{})
+	require.NoError(t, err)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	defer ctx.Cancel()
+
+	contentType := "application/json"
+	_, bifrostErr := provider.FileUpload(ctx, schemas.Key{}, &schemas.BifrostFileUploadRequest{
+		Provider:    schemas.Replicate,
+		File:        []byte(`{"hello":"world"}`),
+		Filename:    "payload.json",
+		ContentType: &contentType,
+		ExtraParams: map[string]interface{}{
+			"metadata": map[string]interface{}{"owner": "oss", "purpose": "test"},
+		},
+	})
+	require.NotNil(t, bifrostErr)
+	require.NoError(t, handlerErr)
+	assert.Equal(t, []string{"filename", "type", "metadata", "content"}, order)
+}
 
 func TestReplicate(t *testing.T) {
 	t.Parallel()

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -310,9 +310,15 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 	}
 	logger.Info("Provider %s added successfully", payload.Provider)
 
-	// Attempt model discovery
-	if err := h.attemptModelDiscovery(ctx, payload.Provider, payload.CustomProviderConfig); err != nil {
-		logger.Warn("Model discovery failed for provider %s: %v", payload.Provider, err)
+	if err := h.reloadProviderAfterCreate(ctx, payload.Provider); err != nil {
+		logger.Warn("Failed to reload provider %s after add: %v", payload.Provider, err)
+		if rollbackErr := h.inMemoryStore.RemoveProvider(context.Background(), payload.Provider); rollbackErr != nil {
+			logger.Error("Failed to rollback provider %s after reload failure: %v", payload.Provider, rollbackErr)
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initialize provider after add: %v (rollback failed: %v)", err, rollbackErr))
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initialize provider after add: %v", err))
+		return
 	}
 
 	// Get redacted config for response (in-memory store is now updated by updateKeyStatus)
@@ -988,6 +994,16 @@ func (h *ProviderHandler) listBaseModels(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, ListBaseModelsResponse{Models: baseModels, Total: total})
 }
 
+// reloadProviderAfterCreate performs a single bounded runtime reload after provider creation.
+// ReloadProvider also refreshes model discovery, so create should not invoke a second discovery pass.
+func (h *ProviderHandler) reloadProviderAfterCreate(ctx *fasthttp.RequestCtx, provider schemas.ModelProvider) error {
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	_, err := h.modelsManager.ReloadProvider(ctxWithTimeout, provider)
+	return err
+}
+
 // attemptModelDiscovery performs model discovery with timeout
 func (h *ProviderHandler) attemptModelDiscovery(ctx *fasthttp.RequestCtx, provider schemas.ModelProvider, customProviderConfig *schemas.CustomProviderConfig) error {
 	// Determine if we should attempt model discovery
@@ -999,7 +1015,7 @@ func (h *ProviderHandler) attemptModelDiscovery(ctx *fasthttp.RequestCtx, provid
 	}
 
 	// Attempt model discovery with reasonable timeout
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, 15*time.Second)
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	_, err := h.modelsManager.ReloadProvider(ctxWithTimeout, provider)

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -15,11 +16,17 @@ import (
 
 // mockModelsManager returns stable filtered and unfiltered model lists for handler tests.
 type mockModelsManager struct {
-	filtered   map[schemas.ModelProvider][]string
-	unfiltered map[schemas.ModelProvider][]string
+	filtered     map[schemas.ModelProvider][]string
+	unfiltered   map[schemas.ModelProvider][]string
+	reloadCalls  []schemas.ModelProvider
+	reloadErr    error
 }
 
-func (m *mockModelsManager) ReloadProvider(_ context.Context, _ schemas.ModelProvider) (*configstoreTables.TableProvider, error) {
+func (m *mockModelsManager) ReloadProvider(_ context.Context, provider schemas.ModelProvider) (*configstoreTables.TableProvider, error) {
+	m.reloadCalls = append(m.reloadCalls, provider)
+	if m.reloadErr != nil {
+		return nil, m.reloadErr
+	}
 	return nil, nil
 }
 
@@ -59,6 +66,94 @@ func providerHandlerForTest(provider schemas.ModelProvider, keys []schemas.Key, 
 				provider: unfiltered,
 			},
 		},
+	}
+}
+
+func TestAddProvider_ReloadsRuntimeEvenWhenModelDiscoveryIsSkipped(t *testing.T) {
+	SetLogger(&mockLogger{})
+	lib.SetLogger(&mockLogger{})
+
+	modelsManager := &mockModelsManager{}
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{Providers: map[schemas.ModelProvider]configstore.ProviderConfig{}},
+		modelsManager: modelsManager,
+	}
+
+	body, err := sonic.Marshal(providerCreatePayload{
+		Provider: "mock-openai",
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			BaseProviderType: schemas.OpenAI,
+			IsKeyLess:        true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.SetRequestURI("/api/providers")
+	ctx.Request.SetBody(body)
+
+	h.addProvider(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if len(modelsManager.reloadCalls) != 1 || modelsManager.reloadCalls[0] != "mock-openai" {
+		t.Fatalf("expected provider reload for mock-openai, got %#v", modelsManager.reloadCalls)
+	}
+	if _, exists := h.inMemoryStore.Providers["mock-openai"]; !exists {
+		t.Fatalf("expected provider to be added to in-memory store")
+	}
+}
+
+func TestAddProvider_ReturnsErrorWhenRuntimeReloadFails(t *testing.T) {
+	SetLogger(&mockLogger{})
+	lib.SetLogger(&mockLogger{})
+
+	modelsManager := &mockModelsManager{reloadErr: context.DeadlineExceeded}
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{Providers: map[schemas.ModelProvider]configstore.ProviderConfig{}},
+		modelsManager: modelsManager,
+	}
+
+	body, err := sonic.Marshal(providerCreatePayload{
+		Provider: "mock-openai",
+		CustomProviderConfig: &schemas.CustomProviderConfig{
+			BaseProviderType: schemas.OpenAI,
+			IsKeyLess:        true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal request body: %v", err)
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
+	ctx.Request.SetRequestURI("/api/providers")
+	ctx.Request.SetBody(body)
+
+	h.addProvider(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if len(modelsManager.reloadCalls) != 1 || modelsManager.reloadCalls[0] != "mock-openai" {
+		t.Fatalf("expected single provider reload for mock-openai, got %#v", modelsManager.reloadCalls)
+	}
+	var bifrostErr schemas.BifrostError
+	if err := json.Unmarshal(ctx.Response.Body(), &bifrostErr); err != nil {
+		t.Fatalf("failed to unmarshal error response: %v", err)
+	}
+	if bifrostErr.Error == nil || bifrostErr.Error.Message == "" {
+		t.Fatalf("expected error message in response, got %#v", bifrostErr)
+	}
+	if bifrostErr.Error.Message != "Failed to initialize provider after add: context deadline exceeded" {
+		t.Fatalf("unexpected error message: %q", bifrostErr.Error.Message)
+	}
+	if _, exists := h.inMemoryStore.Providers["mock-openai"]; exists {
+		t.Fatalf("expected provider rollback after reload failure")
 	}
 }
 

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -1,7 +1,9 @@
 package integrations
 
 import (
+	"bytes"
 	"context"
+	"mime/multipart"
 	"testing"
 
 	"github.com/bytedance/sonic"
@@ -10,6 +12,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestParsePassthroughBody_MultipartExtractsModelAfterFilePart(t *testing.T) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	fileWriter, err := writer.CreateFormFile("file", "sample.mp3")
+	require.NoError(t, err)
+	_, err = fileWriter.Write([]byte("audio-bytes"))
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteField("model", "openai/whisper-1"))
+	require.NoError(t, writer.WriteField("stream", "true"))
+	require.NoError(t, writer.Close())
+
+	model, stream := parsePassthroughBody(writer.FormDataContentType(), body.Bytes())
+	assert.Equal(t, "openai/whisper-1", model)
+	assert.True(t, stream)
+}
 
 func TestRequestWithSettableExtraParams_OpenAIChatRequest(t *testing.T) {
 	t.Run("SetExtraParams populates both standalone and embedded ExtraParams", func(t *testing.T) {

--- a/transports/bifrost-http/server/server_test.go
+++ b/transports/bifrost-http/server/server_test.go
@@ -1,7 +1,12 @@
 package server
 
 import (
+	"context"
 	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 )
 
 // TestConfig is a sample config struct for testing
@@ -9,6 +14,114 @@ type TestConfig struct {
 	Name    string `json:"name"`
 	Enabled bool   `json:"enabled"`
 	Count   int    `json:"count"`
+}
+
+type updateStatusOnlyConfigStore struct {
+	configstore.ConfigStore
+	calls []schemas.KeyStatus
+}
+
+type noopTestLogger struct{}
+
+func (noopTestLogger) Debug(string, ...any)                   {}
+func (noopTestLogger) Info(string, ...any)                    {}
+func (noopTestLogger) Warn(string, ...any)                    {}
+func (noopTestLogger) Error(string, ...any)                   {}
+func (noopTestLogger) Fatal(string, ...any)                   {}
+func (noopTestLogger) SetLevel(schemas.LogLevel)              {}
+func (noopTestLogger) SetOutputType(schemas.LoggerOutputType) {}
+func (noopTestLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
+	return schemas.NoopLogEvent
+}
+
+func (s *updateStatusOnlyConfigStore) UpdateStatus(ctx context.Context, provider schemas.ModelProvider, keyID string, status, errorMsg string) error {
+	s.calls = append(s.calls, schemas.KeyStatus{
+		Provider: provider,
+		KeyID:    keyID,
+		Status:   schemas.KeyStatusType(status),
+		Error:    &schemas.BifrostError{Error: &schemas.ErrorField{Message: errorMsg}},
+	})
+	return nil
+}
+
+func TestUpdateKeyStatus_KeylessProviderUpdatesProviderStatusInMemory(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	store := &updateStatusOnlyConfigStore{}
+	server := &BifrostHTTPServer{
+		Config: &lib.Config{
+			ConfigStore: store,
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"mock-openai": {
+					CustomProviderConfig: &schemas.CustomProviderConfig{IsKeyLess: true},
+					Status:               "unknown",
+				},
+			},
+		},
+	}
+
+	server.updateKeyStatus(context.Background(), []schemas.KeyStatus{{
+		Provider: "mock-openai",
+		KeyID:    "",
+		Status:   schemas.KeyStatusListModelsFailed,
+		Error:    &schemas.BifrostError{Error: &schemas.ErrorField{Message: "preview missing model"}},
+	}})
+
+	provider := server.Config.Providers["mock-openai"]
+	if provider.Status != string(schemas.KeyStatusListModelsFailed) {
+		t.Fatalf("expected provider status %q, got %q", schemas.KeyStatusListModelsFailed, provider.Status)
+	}
+	if provider.Description != "preview missing model" {
+		t.Fatalf("expected provider description to be updated, got %q", provider.Description)
+	}
+	if len(store.calls) != 1 {
+		t.Fatalf("expected one status update call, got %d", len(store.calls))
+	}
+	if store.calls[0].Provider != "mock-openai" || store.calls[0].KeyID != "" {
+		t.Fatalf("expected provider-level status update, got provider=%q keyID=%q", store.calls[0].Provider, store.calls[0].KeyID)
+	}
+}
+
+func TestUpdateKeyStatus_EmptyKeyIDDoesNotOverwriteKeyedProviderStatus(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	defer func() { logger = prevLogger }()
+
+	store := &updateStatusOnlyConfigStore{}
+	server := &BifrostHTTPServer{
+		Config: &lib.Config{
+			ConfigStore: store,
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				"openai": {
+					Keys:   []schemas.Key{{ID: "key-1"}},
+					Status: "healthy",
+				},
+			},
+		},
+	}
+
+	server.updateKeyStatus(context.Background(), []schemas.KeyStatus{{
+		Provider: "openai",
+		KeyID:    "",
+		Status:   schemas.KeyStatusListModelsFailed,
+		Error:    &schemas.BifrostError{Error: &schemas.ErrorField{Message: "malformed status"}},
+	}})
+
+	provider := server.Config.Providers["openai"]
+	if provider.Status != "healthy" {
+		t.Fatalf("expected keyed provider status to remain unchanged, got %q", provider.Status)
+	}
+	if provider.Description != "" {
+		t.Fatalf("expected keyed provider description to remain unchanged, got %q", provider.Description)
+	}
+	if len(store.calls) != 1 {
+		t.Fatalf("expected one status update call, got %d", len(store.calls))
+	}
+	if store.calls[0].Provider != "openai" || store.calls[0].KeyID != "" {
+		t.Fatalf("expected DB status update to retain empty key ID, got provider=%q keyID=%q", store.calls[0].Provider, store.calls[0].KeyID)
+	}
 }
 
 func TestMarshalPluginConfig_WithPointerType(t *testing.T) {

--- a/transports/bifrost-http/server/utils.go
+++ b/transports/bifrost-http/server/utils.go
@@ -167,6 +167,22 @@ func (s *BifrostHTTPServer) updateKeyStatus(
 			continue
 		}
 
+		isKeylessProvider := providerConfig.CustomProviderConfig != nil && providerConfig.CustomProviderConfig.IsKeyLess
+
+		if ks.KeyID == "" {
+			if !isKeylessProvider {
+				logger.Warn("received provider-level status update for keyed provider %s; skipping in-memory update", ks.Provider)
+				s.Config.Mu.Unlock()
+				continue
+			}
+			providerConfig.Status = string(ks.Status)
+			providerConfig.Description = errorMsg
+			s.Config.Providers[ks.Provider] = providerConfig
+			logger.Debug("updated in-memory status for keyless provider %s", ks.Provider)
+			s.Config.Mu.Unlock()
+			continue
+		}
+
 		// Find and update the specific key in the Keys slice
 		updated := false
 		for i := range providerConfig.Keys {


### PR DESCRIPTION
## Summary

Make multipart upstream requests send metadata before file content so routing-sensitive backends can identify the target model before large uploads arrive.

## Changes

- reorder OpenAI and Mistral transcription multipart serializers so `model` and other metadata are emitted before binary file parts
- align OpenAI image edit/variation and Replicate file upload multipart builders with the same metadata-first ordering rule
- add regression coverage for multipart ordering across provider serializers, passthrough parsing, and multipart helper behavior while keeping the generic reconstruction path narrow

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# OpenAI multipart ordering coverage
direnv exec . go test ./core/providers/openai -run 'Test(ParseImageEditFormDataBodyFromRequest_OrdersMetadataBeforeFiles|ParseImageVariationFormDataBodyFromRequest_OrdersMetadataBeforeFile|PayloadOrdering_OpenAIChatRequest|ParseTranscriptionFormDataBodyFromRequest_OrdersMetadataBeforeFile)$'

# Mistral transcription coverage
direnv exec . go test ./core/providers/mistral -run 'TestParseTranscriptionFormDataBodyFromRequest_OrdersMetadataBeforeFile|TestTranscriptionWithMockServer|TestTranscriptionStreamWithMockServer'

# Replicate file upload coverage
direnv exec . go test ./core/providers/replicate -run 'TestFileUpload_OrdersMetadataBeforeFile$'

# Multipart helper and passthrough coverage
direnv exec . go test ./core/network -run 'TestReconstructMultipartBody/preserves_file_parts_while_updating_text_fields'
direnv exec . go test ./transports/bifrost-http/integrations -run 'TestParsePassthroughBody_MultipartExtractsModelAfterFilePart$'
```

Expected outcome:

- the targeted tests pass
- large multipart transcription requests no longer fail only because the backend sees the file part before routing metadata

If adding new configs or environment variables, document them here.

- No new configs or environment variables.

## Screenshots/Recordings

No UI changes.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Closes #2642

## Security considerations

No direct security impact. The change only affects multipart field ordering for upstream provider requests.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable