### PR TITLE
refactor: remove log callback wiring from WebSocket handler

### DIFF
--- a/transports/bifrost-http/handlers/websocket.go
+++ b/transports/bifrost-http/handlers/websocket.go
@@ -12,7 +12,6 @@ import (
 	"github.com/fasthttp/router"
 	"github.com/fasthttp/websocket"
 	"github.com/maximhq/bifrost/core/schemas"
-	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
@@ -158,106 +157,6 @@ func (h *WebSocketHandler) sendMessageSafely(client *WebSocketClient, messageTyp
 	}
 
 	return err
-}
-
-// BroadcastLogUpdate sends a log update to all connected WebSocket clients
-func (h *WebSocketHandler) BroadcastLogUpdate(logEntry *logstore.Log) {
-	// Nil guard to prevent panics
-	if logEntry == nil {
-		return
-	}
-
-	// Add panic recovery to prevent server crashes
-	defer func() {
-		if r := recover(); r != nil {
-			logger.Error("panic in BroadcastLogUpdate: %v", r)
-		}
-	}()
-
-	// Determine operation type based on log status and timestamp
-	operationType := "update"
-	if logEntry.Status == "processing" && logEntry.CreatedAt.Equal(logEntry.Timestamp) {
-		operationType = "create"
-	}
-
-	// Trim payload for table view: keep only the last input message and nil out
-	// large output fields that the table never renders.
-	if len(logEntry.InputHistoryParsed) > 1 {
-		logEntry.InputHistoryParsed = logEntry.InputHistoryParsed[len(logEntry.InputHistoryParsed)-1:]
-	}
-	if len(logEntry.ResponsesInputHistoryParsed) > 1 {
-		logEntry.ResponsesInputHistoryParsed = logEntry.ResponsesInputHistoryParsed[len(logEntry.ResponsesInputHistoryParsed)-1:]
-	}
-	logEntry.OutputMessageParsed = nil
-	logEntry.ResponsesOutputParsed = nil
-	logEntry.EmbeddingOutputParsed = nil
-	logEntry.RerankOutputParsed = nil
-	logEntry.OCROutputParsed = nil
-	logEntry.ParamsParsed = nil
-	logEntry.ToolsParsed = nil
-	logEntry.ToolCallsParsed = nil
-	logEntry.SpeechOutputParsed = nil
-	logEntry.TranscriptionOutputParsed = nil
-	logEntry.ImageGenerationOutputParsed = nil
-	logEntry.ListModelsOutputParsed = nil
-	logEntry.CacheDebugParsed = nil
-
-	message := struct {
-		Type      string        `json:"type"`
-		Operation string        `json:"operation"` // "create" or "update"
-		Payload   *logstore.Log `json:"payload"`
-	}{
-		Type:      "log",
-		Operation: operationType,
-		Payload:   logEntry,
-	}
-
-	data, err := sonic.Marshal(message)
-	if err != nil {
-		logger.Error("failed to marshal log entry: %v", err)
-		return
-	}
-
-	h.BroadcastMarshaledMessage(data)
-}
-
-// BroadcastMCPLogUpdate sends an MCP tool log update to all connected WebSocket clients
-func (h *WebSocketHandler) BroadcastMCPLogUpdate(logEntry *logstore.MCPToolLog) {
-	// Nil guard to prevent panics
-	if logEntry == nil {
-		return
-	}
-
-	// Add panic recovery to prevent server crashes
-	defer func() {
-		if r := recover(); r != nil {
-			logger.Error("panic in BroadcastMCPLogUpdate: %v", r)
-		}
-	}()
-
-	// Determine operation type based on log status and timestamp
-	operationType := "update"
-	if logEntry.Status == "processing" && logEntry.CreatedAt.Equal(logEntry.Timestamp) {
-		operationType = "create"
-	}
-
-	message := struct {
-		Type      string               `json:"type"`
-		Operation string               `json:"operation"` // "create" or "update"
-		Payload   *logstore.MCPToolLog `json:"payload"`
-	}{
-		Type:      "mcp_log",
-		Operation: operationType,
-		Payload:   logEntry,
-	}
-
-	data, err := sonic.Marshal(message)
-	if err != nil {
-		logger.Error("failed to marshal MCP log entry: %v", err)
-		return
-	}
-
-	h.BroadcastMarshaledMessage(data)
 }
 
 // BroadcastUpdatesToClients sends a store update notification to all connected WebSocket clients

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -91,8 +91,6 @@ type ServerCallbacks interface {
 	UpdateMCPClient(ctx context.Context, id string, updatedConfig *schemas.MCPClientConfig) error
 	UpdateMCPToolManagerConfig(ctx context.Context, maxAgentDepth int, toolExecutionTimeoutInSeconds int, codeModeBindingLevel string) error
 	ReconnectMCPClient(ctx context.Context, id string) error
-	// Logging related callbacks
-	NewLogEntryAdded(ctx context.Context, logEntry *logstore.Log) error
 }
 
 // BifrostHTTPServer represents a HTTP server instance.
@@ -207,15 +205,6 @@ func (s *BifrostHTTPServer) UpdateMCPClient(ctx context.Context, id string, upda
 	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
 		logger.Warn("failed to sync MCP servers after editing client: %v", err)
 	}
-	return nil
-}
-
-// NewLogEntryAdded broadcasts a new log entry to the websocket clients
-func (s *BifrostHTTPServer) NewLogEntryAdded(_ context.Context, logEntry *logstore.Log) error {
-	if s.WebSocketHandler == nil {
-		return nil
-	}
-	s.WebSocketHandler.BroadcastLogUpdate(logEntry)
 	return nil
 }
 
@@ -1002,15 +991,6 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	logger.Debug("initializing websocket server")
 	if s.WebSocketHandler == nil {
 		s.WebSocketHandler = handlers.NewWebSocketHandler(s.Ctx, s.Config.ClientConfig.AllowedOrigins)
-	}
-	if loggerPlugin != nil {
-		loggerPlugin.SetLogCallback(func(ctx context.Context, logEntry *logstore.Log) {
-			err := s.NewLogEntryAdded(ctx, logEntry)
-			if err != nil {
-				logger.Error("failed to add log entry: %v", err)
-			}
-		})
-		loggerPlugin.SetMCPToolLogCallback(s.WebSocketHandler.BroadcastMCPLogUpdate)
 	}
 	// Start WebSocket heartbeat
 	s.WebSocketHandler.StartHeartbeat()

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -37,6 +37,7 @@ import type {
 import { dateUtils } from "@/lib/types/logs";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { type ChartType } from "./components/charts/chartTypeToggle";
 import { ModelFilterSelect } from "./components/charts/modelFilterSelect";
 import { ExportPopover } from "./components/exportPopover";
@@ -149,12 +150,15 @@ export default function DashboardPage() {
 	// MCP filter data
 	const { data: mcpFilterData } = useGetMCPAvailableFilterDataQuery();
 
+	const rawSearchParams = useSearchParams();
+	const hasExplicitTimeRange = rawSearchParams.has("start_time") && rawSearchParams.has("end_time");
+
 	// URL state management
 	const [urlState, setUrlState] = useQueryStates(
 		{
 			start_time: parseAsInteger.withDefault(DEFAULT_START_TIME),
 			end_time: parseAsInteger.withDefault(DEFAULT_END_TIME),
-			period: parseAsString.withDefault("24h"),
+			period: parseAsString.withDefault(hasExplicitTimeRange ? "" : "24h"),
 			tab: parseAsString.withDefault("overview"),
 			virtual_key_ids: parseAsString.withDefault(""),
 			providers: parseAsString.withDefault(""),

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -9,58 +9,45 @@ import FullPageLoader from "@/components/fullPageLoader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useWebSocket } from "@/hooks/useWebSocket";
 import {
 	getErrorMessage,
 	useDeleteLogsMutation,
 	useGetAvailableFilterDataQuery,
-	useLazyGetLogsHistogramQuery,
-	useLazyGetLogsQuery,
-	useLazyGetLogsStatsQuery,
 } from "@/lib/store";
-import { useLazyGetLogByIdQuery } from "@/lib/store/apis/logsApi";
+import {
+	useGetLogsQuery,
+	useGetLogsStatsQuery,
+	useGetLogsHistogramQuery,
+	useLazyGetLogsQuery,
+	useLazyGetLogByIdQuery,
+} from "@/lib/store/apis/logsApi";
 import type {
-	ChatMessage,
-	ChatMessageContent,
-	ContentBlock,
 	LogEntry,
 	LogFilters,
-	LogsHistogramResponse,
-	LogStats,
 	Pagination,
 } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
+import { getRangeForPeriod } from "@/lib/utils/timeRange";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { AlertCircle, BarChart, CheckCircle, Clock, DollarSign, Hash } from "lucide-react";
 import { parseAsArrayOf, parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
 
 export default function LogsPage() {
-	const [logs, setLogs] = useState<LogEntry[]>([]);
-	const [totalItems, setTotalItems] = useState(0); // changes with filters
-	const [stats, setStats] = useState<LogStats | null>(null);
-	const [histogram, setHistogram] = useState<LogsHistogramResponse | null>(null);
-	const [initialLoading, setInitialLoading] = useState(true); // on initial load
-	const [fetchingLogs, setFetchingLogs] = useState(false); // on pagination/filters change
-	const [fetchingStats, setFetchingStats] = useState(false); // on stats fetch
-	const [fetchingHistogram, setFetchingHistogram] = useState(false); // on histogram fetch
 	const [error, setError] = useState<string | null>(null);
 	const [showEmptyState, setShowEmptyState] = useState(false);
+	const hasCheckedEmptyState = useRef(false);
 
 	const hasDeleteAccess = useRbac(RbacResource.Logs, RbacOperation.Delete);
 
-	// RTK Query lazy hooks for manual triggering
+	// RTK Query lazy hooks for navigation only
 	const [triggerGetLogs] = useLazyGetLogsQuery();
-	const [triggerGetStats] = useLazyGetLogsStatsQuery();
-	const [triggerGetHistogram] = useLazyGetLogsHistogramQuery();
 	const [deleteLogs] = useDeleteLogsMutation();
 
 	const [isChartOpen, setIsChartOpen] = useState(true);
 	const [triggerGetLogById] = useLazyGetLogByIdQuery();
 	const [fetchedLog, setFetchedLog] = useState<LogEntry | null>(null);
-
-	// Debouncing for streaming updates (client-side)
-	const streamingUpdateTimeouts = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
 
 	// Track if user has manually modified the time range
 	const userModifiedTimeRange = useRef<boolean>(false);
@@ -69,11 +56,16 @@ export default function LogsPage() {
 	const initialDefaults = useRef(dateUtils.getDefaultTimeRange());
 
 	// Memoize default time range to prevent recalculation on every render
-	// This is crucial to avoid triggering refetches when the sheet opens/closes
 	const defaultTimeRange = useMemo(() => dateUtils.getDefaultTimeRange(), []);
 
 	// Get fresh default time range for refresh logic
 	const getDefaultTimeRange = () => dateUtils.getDefaultTimeRange();
+
+	// Check raw URL params before nuqs applies defaults — if both time bounds are
+	// already present (carried over from another page), skip the "24h" period default
+	// so the mount effect doesn't overwrite the custom range.
+	const rawSearchParams = useSearchParams();
+	const hasExplicitTimeRange = rawSearchParams.has("start_time") && rawSearchParams.has("end_time");
 
 	// URL state management with nuqs - all filters and pagination in URL
 	const [urlState, setUrlState] = useQueryStates(
@@ -89,11 +81,12 @@ export default function LogsPage() {
 			content_search: parseAsString.withDefault(""),
 			start_time: parseAsInteger.withDefault(defaultTimeRange.startTime),
 			end_time: parseAsInteger.withDefault(defaultTimeRange.endTime),
-			limit: parseAsInteger.withDefault(25), // Default fallback, actual value calculated based on table height
+			limit: parseAsInteger.withDefault(25),
 			offset: parseAsInteger.withDefault(0),
 			sort_by: parseAsString.withDefault("timestamp"),
 			order: parseAsString.withDefault("desc"),
-			live_enabled: parseAsBoolean.withDefault(true),
+			polling: parseAsBoolean.withDefault(true).withOptions({ clearOnDefault: false }),
+			period: parseAsString.withDefault(hasExplicitTimeRange ? "" : "24h").withOptions({ clearOnDefault: false }),
 			missing_cost_only: parseAsBoolean.withDefault(false),
 			metadata_filters: parseAsString.withDefault(""),
 			selected_log: parseAsString.withDefault(""),
@@ -103,6 +96,158 @@ export default function LogsPage() {
 			shallow: false,
 		},
 	);
+
+	// Convert URL state to filters and pagination for API calls
+	const filters: LogFilters = useMemo(
+		() => ({
+			providers: urlState.providers,
+			models: urlState.models,
+			status: urlState.status,
+			objects: urlState.objects,
+			selected_key_ids: urlState.selected_key_ids,
+			virtual_key_ids: urlState.virtual_key_ids,
+			routing_rule_ids: urlState.routing_rule_ids,
+			routing_engine_used: urlState.routing_engine_used,
+			content_search: urlState.content_search,
+			start_time: dateUtils.toISOString(urlState.start_time),
+			end_time: dateUtils.toISOString(urlState.end_time),
+			missing_cost_only: urlState.missing_cost_only,
+			metadata_filters: urlState.metadata_filters ? (() => {
+				try {
+					return JSON.parse(urlState.metadata_filters);
+				} catch {
+					return undefined;
+				}
+			})() : undefined,
+		}),
+		[
+			urlState.providers, urlState.models, urlState.status, urlState.objects,
+			urlState.selected_key_ids, urlState.virtual_key_ids, urlState.routing_rule_ids,
+			urlState.routing_engine_used, urlState.content_search,
+			urlState.start_time, urlState.end_time,
+			urlState.missing_cost_only, urlState.metadata_filters,
+		],
+	);
+
+	const pagination: Pagination = useMemo(
+		() => ({
+			limit: urlState.limit,
+			offset: urlState.offset,
+			sort_by: urlState.sort_by as "timestamp" | "latency" | "tokens" | "cost",
+			order: urlState.order as "asc" | "desc",
+		}),
+		[urlState.limit, urlState.offset, urlState.sort_by, urlState.order],
+	);
+
+	const polling = urlState.polling;
+	const period = urlState.period;
+
+	// RTK Query hooks with polling
+	const { data: logsData, isLoading: logsIsLoading, isFetching: logsIsFetching, refetch: refetchLogs } =
+		useGetLogsQuery(
+			{ filters, pagination },
+			{
+				pollingInterval: showEmptyState ? 3000 : (polling ? 5000 : 0),
+				refetchOnMountOrArgChange: true,
+				skipPollingIfUnfocused: true,
+			}
+		);
+
+	const { data: statsData, isFetching: statsIsFetching, refetch: refetchStats } =
+		useGetLogsStatsQuery(
+			{ filters },
+			{ pollingInterval: polling ? 5000 : 0, refetchOnMountOrArgChange: true, skipPollingIfUnfocused: true }
+		);
+
+	const { data: histogram, isFetching: histogramIsFetching, refetch: refetchHistogram } =
+		useGetLogsHistogramQuery(
+			{ filters },
+			{ pollingInterval: polling ? 5000 : 0, refetchOnMountOrArgChange: true, skipPollingIfUnfocused: true }
+		);
+
+	const logs = logsData?.logs ?? [];
+	const totalItems = logsData?.stats?.total_requests ?? 0;
+	const stats = statsData ?? null;
+	const histogramData = histogram ?? null;
+
+	// showEmptyState effect — only set once on first data, then transition out
+	useEffect(() => {
+		if (!logsData) return;
+		if (!hasCheckedEmptyState.current) {
+			setShowEmptyState(!logsData.has_logs);
+			hasCheckedEmptyState.current = true;
+		} else if (showEmptyState && logsData.has_logs) {
+			setShowEmptyState(false);
+		}
+	}, [logsData, showEmptyState]);
+
+	// Freshen period timestamps on mount
+	useEffect(() => {
+		if (urlState.period) {
+			const { from, to } = getRangeForPeriod(urlState.period);
+			const freshEnd = Math.floor(to.getTime() / 1000);
+			if (Math.abs(urlState.end_time - freshEnd) > 60) {
+				setUrlState({ start_time: Math.floor(from.getTime() / 1000), end_time: freshEnd }, { history: "replace" });
+			}
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	// Refresh time range defaults on page focus/visibility
+	useEffect(() => {
+		const refreshDefaultsIfStale = () => {
+			// If there's a period set, update timestamps to keep the window fresh
+			if (urlState.period) {
+				const { from, to } = getRangeForPeriod(urlState.period);
+				setUrlState({ start_time: Math.floor(from.getTime() / 1000), end_time: Math.floor(to.getTime() / 1000) }, { history: "replace" });
+				return;
+			}
+
+			// Skip refresh if user has manually modified the time range
+			if (userModifiedTimeRange.current) {
+				return;
+			}
+
+			// Check if current time range matches the initial defaults (within tolerance)
+			const startTimeDiff = Math.abs(urlState.start_time - initialDefaults.current.startTime);
+			const endTimeDiff = Math.abs(urlState.end_time - initialDefaults.current.endTime);
+			const tolerance = 5; // 5 seconds tolerance for slight timing differences
+
+			// Only refresh if current values match the initial defaults
+			// This preserves shared URLs with custom time ranges
+			if (startTimeDiff <= tolerance && endTimeDiff <= tolerance) {
+				const defaults = getDefaultTimeRange();
+				const currentEndDiff = Math.abs(urlState.end_time - defaults.endTime);
+				// If end time is more than 5 minutes old, refresh both
+				if (currentEndDiff > 300) {
+					setUrlState({
+						start_time: defaults.startTime,
+						end_time: defaults.endTime,
+					}, { history: "replace" });
+					// Update baseline so subsequent focus events compare against refreshed defaults
+					initialDefaults.current.startTime = defaults.startTime;
+					initialDefaults.current.endTime = defaults.endTime;
+				}
+			}
+		};
+
+		const handleVisibilityChange = () => {
+			if (!document.hidden) {
+				refreshDefaultsIfStale();
+			}
+		};
+
+		const handleFocus = () => {
+			refreshDefaultsIfStale();
+		};
+
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+		window.addEventListener("focus", handleFocus);
+		return () => {
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+			window.removeEventListener("focus", handleFocus);
+		};
+	}, [urlState.start_time, urlState.end_time, urlState.period, setUrlState]);
 
 	// Derive selectedLog: find in current logs array, or fetch by ID from API
 	const selectedLogId = urlState.selected_log || null;
@@ -134,109 +279,14 @@ export default function LogsPage() {
 
 	const selectedLog = selectedLogFromData ?? fetchedLog;
 
-	// Refresh time range defaults on page focus/visibility
-	useEffect(() => {
-		const refreshDefaultsIfStale = () => {
-			// Skip refresh if user has manually modified the time range
-			if (userModifiedTimeRange.current) {
-				return;
-			}
-
-			// Check if current time range matches the initial defaults (within tolerance)
-			const startTimeDiff = Math.abs(urlState.start_time - initialDefaults.current.startTime);
-			const endTimeDiff = Math.abs(urlState.end_time - initialDefaults.current.endTime);
-			const tolerance = 5; // 5 seconds tolerance for slight timing differences
-
-			// Only refresh if current values match the initial defaults
-			// This preserves shared URLs with custom time ranges
-			if (startTimeDiff <= tolerance && endTimeDiff <= tolerance) {
-				const defaults = getDefaultTimeRange();
-				const currentEndDiff = Math.abs(urlState.end_time - defaults.endTime);
-				// If end time is more than 5 minutes old, refresh both
-				if (currentEndDiff > 300) {
-					setUrlState({
-						start_time: defaults.startTime,
-						end_time: defaults.endTime,
-					});
-					// Update baseline so subsequent focus events compare against refreshed defaults
-					initialDefaults.current.startTime = defaults.startTime;
-					initialDefaults.current.endTime = defaults.endTime;
-				}
-			}
-		};
-
-		const handleVisibilityChange = () => {
-			if (!document.hidden) {
-				refreshDefaultsIfStale();
-			}
-		};
-
-		const handleFocus = () => {
-			refreshDefaultsIfStale();
-		};
-
-		document.addEventListener("visibilitychange", handleVisibilityChange);
-		window.addEventListener("focus", handleFocus);
-		return () => {
-			document.removeEventListener("visibilitychange", handleVisibilityChange);
-			window.removeEventListener("focus", handleFocus);
-		};
-	}, [urlState.start_time, urlState.end_time, setUrlState]);
-
-	// Convert URL state to filters and pagination for API calls
-	const filters: LogFilters = useMemo(
-		() => ({
-			providers: urlState.providers,
-			models: urlState.models,
-			status: urlState.status,
-			objects: urlState.objects,
-			selected_key_ids: urlState.selected_key_ids,
-			virtual_key_ids: urlState.virtual_key_ids,
-			routing_rule_ids: urlState.routing_rule_ids,
-			routing_engine_used: urlState.routing_engine_used,
-			content_search: urlState.content_search,
-			start_time: dateUtils.toISOString(urlState.start_time),
-			end_time: dateUtils.toISOString(urlState.end_time),
-			missing_cost_only: urlState.missing_cost_only,
-			metadata_filters: urlState.metadata_filters ? (() => {
-				try {
-					return JSON.parse(urlState.metadata_filters);
-				} catch {
-					return undefined;
-				}
-			})() : undefined,
-		}),
-		// Only re-derive filters when filter-related URL params change (not pagination)
-		[
-			urlState.providers, urlState.models, urlState.status, urlState.objects,
-			urlState.selected_key_ids, urlState.virtual_key_ids, urlState.routing_rule_ids,
-			urlState.routing_engine_used, urlState.content_search,
-			urlState.start_time, urlState.end_time,
-			urlState.missing_cost_only, urlState.metadata_filters,
-		],
-	);
-
-	const pagination: Pagination = useMemo(
-		() => ({
-			limit: urlState.limit,
-			offset: urlState.offset,
-			sort_by: urlState.sort_by as "timestamp" | "latency" | "tokens" | "cost",
-			order: urlState.order as "asc" | "desc",
-		}),
-		[urlState.limit, urlState.offset, urlState.sort_by, urlState.order],
-	);
-
-	const liveEnabled = urlState.live_enabled;
-
 	// Helper to update filters in URL
 	const setFilters = useCallback(
 		(newFilters: LogFilters) => {
-			// Mark time range as user-modified only if start_time or end_time actually changed
-			if (newFilters.start_time !== filters.start_time || newFilters.end_time !== filters.end_time) {
-				userModifiedTimeRange.current = true;
-			}
+			const timeChanged = newFilters.start_time !== filters.start_time || newFilters.end_time !== filters.end_time;
+			if (timeChanged) userModifiedTimeRange.current = true;
 
 			setUrlState({
+				...(timeChanged && { period: "" }),
 				providers: newFilters.providers || [],
 				models: newFilters.models || [],
 				status: newFilters.status || [],
@@ -296,471 +346,82 @@ export default function LogsPage() {
 	const isZoomed = useMemo(() => {
 		const currentRange = urlState.end_time - urlState.start_time;
 		const defaultRange = 24 * 60 * 60; // 24 hours in seconds
-		// Consider zoomed if range is less than 90% of default (to account for minor differences)
 		return currentRange < defaultRange * 0.9;
 	}, [urlState.start_time, urlState.end_time]);
-
-	const latest = useRef({ logs, filters, pagination, showEmptyState, liveEnabled });
-	useEffect(() => {
-		latest.current = { logs, filters, pagination, showEmptyState, liveEnabled };
-	}, [logs, filters, pagination, showEmptyState, liveEnabled]);
 
 	const handleDelete = useCallback(
 		async (log: LogEntry) => {
 			try {
 				await deleteLogs({ ids: [log.id] }).unwrap();
-				setLogs((prevLogs) => prevLogs.filter((l) => l.id !== log.id));
-				setTotalItems((prev) => prev - 1);
-				// Clear selected log if it was the deleted one
-				if (urlState.selected_log === log.id) {
-					setUrlState({ selected_log: "" });
-				}
+				if (urlState.selected_log === log.id) setUrlState({ selected_log: "" });
+				refetchLogs();
 			} catch (error) {
 				setError(getErrorMessage(error));
 			}
 		},
-		[deleteLogs, urlState.selected_log, setUrlState],
+		[deleteLogs, urlState.selected_log, setUrlState, refetchLogs],
 	);
 
-	const handleLogMessage = useCallback((log: LogEntry, operation: "create" | "update") => {
-		const { logs, filters, pagination, showEmptyState, liveEnabled } = latest.current;
-		// If we were in empty state, exit it since we now have logs
-		if (showEmptyState) {
-			setShowEmptyState(false);
+	const handleRefresh = useCallback(() => {
+		if (period) {
+			const { from, to } = getRangeForPeriod(period);
+			setUrlState({
+				start_time: Math.floor(from.getTime() / 1000),
+				end_time: Math.floor(to.getTime() / 1000),
+			});
+		} else {
+			refetchLogs();
+			refetchStats();
+			refetchHistogram();
 		}
+	}, [period, setUrlState, refetchLogs, refetchStats, refetchHistogram]);
 
-		if (operation === "create") {
-			// Handle new log creation
-			// Only prepend the new log if we're on the first page and sorted by timestamp desc
-			if (pagination.offset === 0 && pagination.sort_by === "timestamp" && pagination.order === "desc") {
-				// Check if the log matches current filters
-				if (!matchesFilters(log, filters, !liveEnabled)) {
-					return;
-				}
-
-				setLogs((prevLogs: LogEntry[]) => {
-					// Check if log already exists (prevent duplicates)
-					if (prevLogs.some((existingLog) => existingLog.id === log.id)) {
-						return prevLogs;
-					}
-
-					// Remove the last log if we're at the page limit
-					const updatedLogs = [log, ...prevLogs];
-					if (updatedLogs.length > pagination.limit) {
-						updatedLogs.pop();
-					}
-					return updatedLogs;
-				});
-
-				// Update fetchedLog if it matches (for real-time detail sheet updates when log is not on current page)
-				setFetchedLog((prev) => {
-					if (prev && prev.id === log.id) {
-						return log;
-					}
-					return prev;
-				});
-
-				setTotalItems((prev: number) => prev + 1);
-			}
-		} else if (operation === "update") {
-			// Handle log updates with debouncing for streaming
-
-			// Check if the log exists in our current list
-			const logExists = logs.some((existingLog) => existingLog.id === log.id);
-
-			if (!logExists) {
-				// Fallback: if log doesn't exist, treat as create (e.g., user was on different page when created)
-				if (pagination.offset === 0 && pagination.sort_by === "timestamp" && pagination.order === "desc") {
-					// Check if the log matches current filters
-					if (matchesFilters(log, filters, !liveEnabled)) {
-						setLogs((prevLogs: LogEntry[]) => {
-							// Double-check it doesn't exist (race condition protection)
-							if (prevLogs.some((existingLog) => existingLog.id === log.id)) {
-								return prevLogs.map((existingLog) => (existingLog.id === log.id ? log : existingLog));
-							}
-
-							// Add as new log
-							const updatedLogs = [log, ...prevLogs];
-							if (updatedLogs.length > pagination.limit) {
-								updatedLogs.pop();
-							}
-							return updatedLogs;
-						});
-					}
-				}
-			} else {
-				// Normal update flow for existing logs
-				if (log.stream) {
-					// For streaming logs, debounce updates to avoid UI thrashing
-					const existingTimeout = streamingUpdateTimeouts.current.get(log.id);
-					if (existingTimeout) {
-						clearTimeout(existingTimeout);
-					}
-
-					const timeout = setTimeout(() => {
-						updateExistingLog(log);
-						streamingUpdateTimeouts.current.delete(log.id);
-					}, 100); // 100ms debounce for streaming updates
-
-					streamingUpdateTimeouts.current.set(log.id, timeout);
-				} else {
-					// For non-streaming updates, update immediately
-					updateExistingLog(log);
-				}
-
-				// Update stats for completed requests
-				if (log.status == "success" || log.status == "error") {
-					setStats((prevStats) => {
-						if (!prevStats) return prevStats;
-
-						const newStats = { ...prevStats };
-						newStats.total_requests += 1;
-
-						// Update success rate
-						const successCount = (prevStats.success_rate / 100) * prevStats.total_requests;
-						const newSuccessCount = log.status === "success" ? successCount + 1 : successCount;
-						newStats.success_rate = (newSuccessCount / newStats.total_requests) * 100;
-
-						// Update average latency
-						if (log.latency) {
-							const totalLatency = prevStats.average_latency * prevStats.total_requests;
-							newStats.average_latency = (totalLatency + log.latency) / newStats.total_requests;
-						}
-
-						// Update total tokens
-						if (log.token_usage) {
-							newStats.total_tokens += log.token_usage.total_tokens;
-						}
-
-						// Update total cost
-						if (log.cost) {
-							newStats.total_cost += log.cost;
-						}
-
-						return newStats;
-					});
-
-					// Update histogram for completed requests
-					setHistogram((prevHistogram) => {
-						if (!prevHistogram || typeof prevHistogram.bucket_size_seconds !== "number" || prevHistogram.bucket_size_seconds <= 0) {
-							return prevHistogram;
-						}
-
-						const logTime = new Date(log.timestamp).getTime();
-						const bucketSizeMs = prevHistogram.bucket_size_seconds * 1000;
-						const bucketTime = Math.floor(logTime / bucketSizeMs) * bucketSizeMs;
-
-						const updatedBuckets = [...prevHistogram.buckets];
-						const bucketIndex = updatedBuckets.findIndex((b) => {
-							const bTime = new Date(b.timestamp).getTime();
-							return Math.floor(bTime / bucketSizeMs) * bucketSizeMs === bucketTime;
-						});
-
-						if (bucketIndex >= 0) {
-							// Update existing bucket
-							updatedBuckets[bucketIndex] = {
-								...updatedBuckets[bucketIndex],
-								count: updatedBuckets[bucketIndex].count + 1,
-								success: updatedBuckets[bucketIndex].success + (log.status === "success" ? 1 : 0),
-								error: updatedBuckets[bucketIndex].error + (log.status === "error" ? 1 : 0),
-							};
-						} else {
-							// Create new bucket for this timestamp
-							const newBucket = {
-								timestamp: new Date(bucketTime).toISOString(),
-								count: 1,
-								success: log.status === "success" ? 1 : 0,
-								error: log.status === "error" ? 1 : 0,
-							};
-							// Insert in sorted order
-							const insertIndex = updatedBuckets.findIndex((b) => new Date(b.timestamp).getTime() > bucketTime);
-							if (insertIndex === -1) {
-								updatedBuckets.push(newBucket);
-							} else {
-								updatedBuckets.splice(insertIndex, 0, newBucket);
-							}
-						}
-
-						return { ...prevHistogram, buckets: updatedBuckets };
-					});
-				}
-			}
-		}
-	}, []);
-
-	const updateExistingLog = useCallback((updatedLog: LogEntry) => {
-		setLogs((prevLogs: LogEntry[]) => {
-			return prevLogs.map((existingLog) => (existingLog.id === updatedLog.id ? updatedLog : existingLog));
-		});
-
-		// Update fetchedLog if it matches the updated log (for real-time detail sheet updates when log is not on current page)
-		setFetchedLog((prev) => {
-			if (prev && prev.id === updatedLog.id) {
-				return updatedLog;
-			}
-			return prev;
-		});
-	}, []);
-
-	const { isConnected: isSocketConnected, subscribe } = useWebSocket();
-
-	// Subscribe to log messages - only when live updates are enabled
-	useEffect(() => {
-		if (!liveEnabled) {
-			return;
-		}
-
-		const unsubscribe = subscribe("log", (data) => {
-			const { payload, operation } = data;
-			handleLogMessage(payload, operation);
-		});
-
-		return unsubscribe;
-	}, [handleLogMessage, subscribe, liveEnabled]);
-
-	// Cleanup timeouts on unmount
-	useEffect(() => {
-		return () => {
-			streamingUpdateTimeouts.current.forEach((timeout) => clearTimeout(timeout));
-			streamingUpdateTimeouts.current.clear();
-		};
-	}, []);
-
-	const fetchLogs = useCallback(async () => {
-		setFetchingLogs(true);
-		setError(null);
-
-		try {
-			const result = await triggerGetLogs({ filters, pagination });
-
-			if (result.error) {
-				const errorMessage = getErrorMessage(result.error);
-				setError(errorMessage);
-				setLogs([]);
-				setTotalItems(0);
-			} else if (result.data) {
-				setLogs(result.data.logs || []);
-				setTotalItems(result.data.stats.total_requests);
-			}
-
-			// Only set showEmptyState on initial load and only based on total logs
-			if (initialLoading) {
-				// Check if there are any logs globally, not just in the current filter
-				setShowEmptyState(result.data ? !result.data.has_logs : true);
-			}
-		} catch {
-			setError("Cannot fetch logs. Please check if logs are enabled in your Bifrost config.");
-			setLogs([]);
-			setTotalItems(0);
-			setShowEmptyState(true);
-		} finally {
-			setFetchingLogs(false);
-		}
-
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [filters, pagination]);
-
-	const fetchStats = useCallback(async () => {
-		setFetchingStats(true);
-
-		try {
-			const result = await triggerGetStats({ filters });
-
-			if (result.error) {
-				// Don't show error for stats failure, just log it
-				console.error("Failed to fetch stats:", result.error);
-			} else if (result.data) {
-				setStats(result.data);
-			}
-		} catch (error) {
-			console.error("Failed to fetch stats:", error);
-		} finally {
-			setFetchingStats(false);
-		}
-	}, [filters, triggerGetStats]);
-
-	const fetchHistogram = useCallback(async () => {
-		setFetchingHistogram(true);
-
-		try {
-			const result = await triggerGetHistogram({ filters });
-
-			if (result.error) {
-				// Don't show error for histogram failure, just log it
-				console.error("Failed to fetch histogram:", result.error);
-			} else if (result.data) {
-				setHistogram(result.data);
-			}
-		} catch (error) {
-			console.error("Failed to fetch histogram:", error);
-		} finally {
-			setFetchingHistogram(false);
-		}
-	}, [filters, triggerGetHistogram]);
-
-	// Helper to toggle live updates
-	const handleLiveToggle = useCallback(
+	const handlePollToggle = useCallback(
 		(enabled: boolean) => {
-			setUrlState({ live_enabled: enabled });
-			// When re-enabling, refetch logs to get latest data
+			setUrlState({ polling: enabled });
 			if (enabled) {
-				fetchLogs();
+				handleRefresh();
 			}
 		},
-		[setUrlState, fetchLogs],
+		[setUrlState, handleRefresh],
 	);
 
-	// Fetch logs when filters or pagination change
-	useEffect(() => {
-		if (!initialLoading) {
-			fetchLogs();
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [filters, pagination, initialLoading]);
-
-	// Fetch stats and histogram when filters change (but not pagination)
-	useEffect(() => {
-		if (!initialLoading) {
-			fetchStats();
-			fetchHistogram();
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [filters, initialLoading]);
-
-	// Initial load
-	useEffect(() => {
-		const initialLoad = async () => {
-			// Load logs and stats in parallel, don't wait for stats to show the page
-			await fetchLogs();
-			fetchStats(); // Don't await - let it load in background
-			fetchHistogram(); // Don't await - let it load in background
-			setInitialLoading(false);
-		};
-		initialLoad();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
-
-	const getMessageText = (content: ChatMessageContent): string => {
-		if (typeof content === "string") {
-			return content;
-		}
-		if (Array.isArray(content)) {
-			return content.reduce((acc: string, block: ContentBlock) => {
-				if (block.type === "text" && block.text) {
-					return acc + block.text;
-				}
-				return acc;
-			}, "");
-		}
-		return "";
-	};
-
-	// Helper function to check if a log matches the current filters
-	const matchesFilters = (log: LogEntry, filters: LogFilters, applyTimeFilters = true): boolean => {
-		if (filters.missing_cost_only && typeof log.cost === "number" && log.cost > 0) {
-			return false;
-		}
-		if (filters.providers?.length && !filters.providers.includes(log.provider)) {
-			return false;
-		}
-		if (filters.models?.length && !filters.models.includes(log.model)) {
-			return false;
-		}
-		if (filters.status?.length && !filters.status.includes(log.status)) {
-			return false;
-		}
-		if (filters.objects?.length && !filters.objects.includes(log.object)) {
-			return false;
-		}
-		if (filters.selected_key_ids?.length && !filters.selected_key_ids.includes(log.selected_key_id)) {
-			return false;
-		}
-		if (filters.virtual_key_ids?.length) {
-			if (!log.virtual_key_id || !filters.virtual_key_ids.includes(log.virtual_key_id)) {
-				return false;
-			}
-		}
-		if (filters.routing_rule_ids?.length) {
-			if (!log.routing_rule_id || !filters.routing_rule_ids.includes(log.routing_rule_id)) {
-				return false;
-			}
-		}
-		if (filters.routing_engine_used?.length) {
-			if (!log.routing_engines_used || !log.routing_engines_used.some((engine) => filters.routing_engine_used!.includes(engine))) {
-				return false;
-			}
-		}
-		if (filters.start_time && new Date(log.timestamp) < new Date(filters.start_time)) {
-			return false;
-		}
-		if (applyTimeFilters && filters.end_time && new Date(log.timestamp) > new Date(filters.end_time)) {
-			return false;
-		}
-		if (filters.min_latency && (!log.latency || log.latency < filters.min_latency)) {
-			return false;
-		}
-		if (filters.max_latency && (!log.latency || log.latency > filters.max_latency)) {
-			return false;
-		}
-		if (filters.min_tokens && (!log.token_usage || log.token_usage.total_tokens < filters.min_tokens)) {
-			return false;
-		}
-		if (filters.max_tokens && (!log.token_usage || log.token_usage.total_tokens > filters.max_tokens)) {
-			return false;
-		}
-		if (filters.metadata_filters) {
-			for (const [key, value] of Object.entries(filters.metadata_filters)) {
-				const metadataValue = log.metadata?.[key];
-				if (metadataValue === undefined || String(metadataValue) !== value) {
-					return false;
-				}
-			}
-		}
-		if (filters.content_search) {
-			const search = filters.content_search.toLowerCase();
-			const content = [
-				...(log.input_history || []).map((msg: ChatMessage) => getMessageText(msg.content)),
-				log.output_message ? getMessageText(log.output_message.content) : "",
-			]
-				.join(" ")
-				.toLowerCase();
-
-			if (!content.includes(search)) {
-				return false;
-			}
-		}
-		return true;
-	};
+	const handlePeriodChange = useCallback(
+		(p: string, from: Date, to: Date) => {
+			setUrlState({ period: p, start_time: Math.floor(from.getTime() / 1000), end_time: Math.floor(to.getTime() / 1000), offset: 0 });
+		},
+		[setUrlState],
+	);
 
 	const statCards = useMemo(
 		() => [
 			{
 				title: "Total Requests",
-				value: fetchingStats ? <Skeleton className="h-8 w-20" /> : stats?.total_requests.toLocaleString() || "-",
+				value: statsIsFetching ? <Skeleton className="h-8 w-20" /> : stats?.total_requests.toLocaleString() || "-",
 				icon: <BarChart className="size-4" />,
 			},
 			{
 				title: "Success Rate",
-				value: fetchingStats ? <Skeleton className="h-8 w-16" /> : stats ? `${stats.success_rate.toFixed(2)}%` : "-",
+				value: statsIsFetching ? <Skeleton className="h-8 w-16" /> : stats ? `${stats.success_rate.toFixed(2)}%` : "-",
 				icon: <CheckCircle className="size-4" />,
 			},
 			{
 				title: "Avg Latency",
-				value: fetchingStats ? <Skeleton className="h-8 w-20" /> : stats ? `${stats.average_latency.toFixed(2)}ms` : "-",
+				value: statsIsFetching ? <Skeleton className="h-8 w-20" /> : stats ? `${stats.average_latency.toFixed(2)}ms` : "-",
 				icon: <Clock className="size-4" />,
 			},
 			{
 				title: "Total Tokens",
-				value: fetchingStats ? <Skeleton className="h-8 w-24" /> : stats?.total_tokens.toLocaleString() || "-",
+				value: statsIsFetching ? <Skeleton className="h-8 w-24" /> : stats?.total_tokens.toLocaleString() || "-",
 				icon: <Hash className="size-4" />,
 			},
 			{
 				title: "Total Cost",
-				value: fetchingStats ? <Skeleton className="h-8 w-20" /> : stats ? `$${(stats.total_cost ?? 0).toFixed(4)}` : "-",
+				value: statsIsFetching ? <Skeleton className="h-8 w-20" /> : stats ? `$${(stats.total_cost ?? 0).toFixed(4)}` : "-",
 				icon: <DollarSign className="size-4" />,
 			},
 		],
-		[stats, fetchingStats],
+		[stats, statsIsFetching],
 	);
 
 	// Get metadata keys from filterdata API so columns always show even with no data on current page
@@ -783,13 +444,10 @@ export default function LogsPage() {
 			const currentLogId = selectedLogId || "";
 			if (direction === "prev") {
 				if (selectedLogIndex > 0) {
-					// Navigate to previous log on current page
 					setUrlState({ selected_log: logs[selectedLogIndex - 1].id });
 				} else if (pagination.offset > 0) {
-					// Go to previous page and select the last item
 					const newOffset = Math.max(0, pagination.offset - pagination.limit);
 					setUrlState({ offset: newOffset, selected_log: "" });
-					// Fetch previous page, then select last log
 					triggerGetLogs({
 						filters,
 						pagination: { ...pagination, offset: newOffset },
@@ -805,13 +463,10 @@ export default function LogsPage() {
 				}
 			} else {
 				if (selectedLogIndex >= 0 && selectedLogIndex < logs.length - 1) {
-					// Navigate to next log on current page
 					setUrlState({ selected_log: logs[selectedLogIndex + 1].id });
 				} else if (pagination.offset + pagination.limit < totalItems) {
-					// Go to next page and select the first item
 					const newOffset = pagination.offset + pagination.limit;
 					setUrlState({ offset: newOffset, selected_log: "" });
-					// Fetch next page, then select first log
 					triggerGetLogs({
 						filters,
 						pagination: { ...pagination, offset: newOffset },
@@ -832,10 +487,10 @@ export default function LogsPage() {
 
 	return (
 		<div className="dark:bg-card h-[calc(100dvh-3.3rem)] max-h-[calc(100dvh-1.5rem)] bg-white">
-			{initialLoading ? (
+			{logsIsLoading && !logsData ? (
 				<FullPageLoader />
 			) : showEmptyState ? (
-				<EmptyState isSocketConnected={isSocketConnected} error={error} />
+				<EmptyState error={error} />
 			) : (
 				<div className="mx-auto flex h-full w-full flex-col">
 					<div className="flex flex-1 flex-col gap-2 overflow-hidden">
@@ -856,8 +511,8 @@ export default function LogsPage() {
 						{/* Volume Chart */}
 						<div className="shrink-0">
 							<LogsVolumeChart
-								data={histogram}
-								loading={fetchingHistogram}
+								data={histogramData}
+								loading={histogramIsFetching}
 								onTimeRangeChange={handleTimeRangeChange}
 								onResetZoom={handleResetZoom}
 								isZoomed={isZoomed}
@@ -881,7 +536,7 @@ export default function LogsPage() {
 								columns={columns}
 								data={logs}
 								totalItems={totalItems}
-								loading={fetchingLogs}
+								loading={logsIsFetching}
 								filters={filters}
 								pagination={pagination}
 								onFiltersChange={setFilters}
@@ -890,11 +545,11 @@ export default function LogsPage() {
 									if (columnId === "actions") return;
 									setUrlState({ selected_log: row.id }, { history: "replace" });
 								}}
-								isSocketConnected={isSocketConnected}
-								liveEnabled={liveEnabled}
-								onLiveToggle={handleLiveToggle}
-								fetchLogs={fetchLogs}
-								fetchStats={fetchStats}
+								polling={polling}
+								onPollToggle={handlePollToggle}
+								onRefresh={handleRefresh}
+								period={period}
+								onPeriodChange={handlePeriodChange}
 								metadataKeys={metadataKeys}
 							/>
 						</div>

--- a/ui/app/workspace/logs/views/emptyState.tsx
+++ b/ui/app/workspace/logs/views/emptyState.tsx
@@ -72,11 +72,10 @@ function CodeBlock({ code, language, onLanguageChange, showLanguageSelect = fals
 }
 
 interface EmptyStateProps {
-	isSocketConnected: boolean;
 	error: string | null;
 }
 
-export function EmptyState({ isSocketConnected, error }: EmptyStateProps) {
+export function EmptyState({ error }: EmptyStateProps) {
 	const [language, setLanguage] = useState<Language>("python");
 
 	// Generate examples dynamically using the port utility
@@ -258,17 +257,6 @@ const result = await chain.invoke({ input: "What is LangChain?" });`,
 					<div>
 						<h3 className="text-lg font-semibold">Integrate under 60 seconds</h3>
 						<p className="text-muted-foreground text-sm">Send your first request to get started</p>
-					</div>
-					<div className="ml-auto">
-						{isSocketConnected && (
-							<div className="inline-flex items-center rounded-full border border-green-200 bg-green-50 px-3 py-1 text-xs font-medium text-green-700 sm:px-4 sm:text-sm">
-								<span className="relative mr-2 flex h-2 w-2 sm:mr-3">
-									<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75"></span>
-									<span className="relative inline-flex h-2 w-2 rounded-full bg-green-600"></span>
-								</span>
-								<span>Listening for logs...</span>
-							</div>
-						)}
 					</div>
 				</div>
 

--- a/ui/app/workspace/logs/views/filters.tsx
+++ b/ui/app/workspace/logs/views/filters.tsx
@@ -6,56 +6,24 @@ import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { getErrorMessage, useRecalculateLogCostsMutation } from "@/lib/store";
 import type { LogFilters as LogFiltersType } from "@/lib/types/logs";
-import { Calculator, MoreVertical, Pause, Play, Search } from "lucide-react";
+import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
+import { Calculator, MoreVertical, Radio, RefreshCw, Search } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 export { dateToRfc3339Local } from "@/lib/utils/date";
 
-/** Predefined time periods for the logs date range picker (matches E2E test labels) */
-const LOG_TIME_PERIODS = [
-	{ label: "Last hour", value: "1h" },
-	{ label: "Last 6 hours", value: "6h" },
-	{ label: "Last 24 hours", value: "24h" },
-	{ label: "Last 7 days", value: "7d" },
-	{ label: "Last 30 days", value: "30d" },
-];
-
-function getRangeForPeriod(period: string): { from: Date; to: Date } {
-	const to = new Date();
-	const from = new Date(to.getTime());
-	switch (period) {
-		case "1h":
-			from.setHours(from.getHours() - 1);
-			break;
-		case "6h":
-			from.setHours(from.getHours() - 6);
-			break;
-		case "24h":
-			from.setHours(from.getHours() - 24);
-			break;
-		case "7d":
-			from.setDate(from.getDate() - 7);
-			break;
-		case "30d":
-			from.setDate(from.getDate() - 30);
-			break;
-		default:
-			from.setHours(from.getHours() - 24);
-	}
-	return { from, to };
-}
-
 interface LogFiltersProps {
 	filters: LogFiltersType;
 	onFiltersChange: (filters: LogFiltersType) => void;
-	liveEnabled: boolean;
-	onLiveToggle: (enabled: boolean) => void;
-	fetchLogs: () => Promise<void>;
-	fetchStats: () => Promise<void>;
+	polling: boolean;
+	onPollToggle: (enabled: boolean) => void;
+	onRefresh: () => void;
+	period: string;
+	onPeriodChange: (period: string, from: Date, to: Date) => void;
 }
 
-export function LogFilters({ filters, onFiltersChange, liveEnabled, onLiveToggle, fetchLogs, fetchStats }: LogFiltersProps) {
+export function LogFilters({ filters, onFiltersChange, polling, onPollToggle, onRefresh, period, onPeriodChange }: LogFiltersProps) {
 	const [openMoreActionsPopover, setOpenMoreActionsPopover] = useState(false);
 	const [localSearch, setLocalSearch] = useState(filters.content_search || "");
 	const searchTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
@@ -94,8 +62,7 @@ export function LogFilters({ filters, onFiltersChange, liveEnabled, onLiveToggle
 	const handleRecalculateCosts = useCallback(async () => {
 		try {
 			const response = await recalculateCosts({ filters }).unwrap();
-			await fetchLogs();
-			await fetchStats();
+			onRefresh();
 			setOpenMoreActionsPopover(false);
 			toast.success(`Recalculated costs for ${response.updated} logs`, {
 				description: `${response.updated} logs updated, ${response.skipped} logs skipped, ${response.remaining} logs remaining`,
@@ -104,7 +71,7 @@ export function LogFilters({ filters, onFiltersChange, liveEnabled, onLiveToggle
 		} catch (err) {
 			toast.error(getErrorMessage(err));
 		}
-	}, [filters, recalculateCosts, fetchLogs, fetchStats]);
+	}, [filters, recalculateCosts, onRefresh]);
 
 	const handleSearchChange = useCallback(
 		(value: string) => {
@@ -148,18 +115,13 @@ export function LogFilters({ filters, onFiltersChange, liveEnabled, onLiveToggle
 
 	return (
 		<div className="flex items-center justify-between space-x-2">
-			<Button variant={"outline"} size="sm" className="h-7.5" onClick={() => onLiveToggle(!liveEnabled)}>
-				{liveEnabled ? (
-					<>
-						<Pause className="h-4 w-4" />
-						Live updates
-					</>
-				) : (
-					<>
-						<Play className="h-4 w-4" />
-						Live updates
-					</>
-				)}
+			<Button variant="outline" size="sm" className="h-7.5" onClick={onRefresh}>
+				<RefreshCw className="h-4 w-4" />
+				Refresh
+			</Button>
+			<Button variant={polling ? "default" : "outline"} size="sm" className="h-7.5" onClick={() => onPollToggle(!polling)}>
+				{polling ? <Radio className="h-4 w-4 animate-pulse" /> : <Radio className="h-4 w-4" />}
+				Live
 			</Button>
 			<div className="border-input flex h-7.5 flex-1 items-center gap-2 rounded-sm border">
 				<Search className="mr-0.5 ml-2 size-4" />
@@ -178,26 +140,20 @@ export function LogFilters({ filters, onFiltersChange, liveEnabled, onLiveToggle
 					from: startTime,
 					to: endTime,
 				}}
-				onDateTimeUpdate={(p) => {
-					setStartTime(p.from);
-					setEndTime(p.to);
-					onFiltersChange({
-						...filters,
-						start_time: p.from?.toISOString(),
-						end_time: p.to?.toISOString(),
-					});
-				}}
-				preDefinedPeriods={LOG_TIME_PERIODS}
+				predefinedPeriod={period || undefined}
+				preDefinedPeriods={[...TIME_PERIODS]}
 				onPredefinedPeriodChange={(periodValue) => {
 					if (!periodValue) return;
 					const { from, to } = getRangeForPeriod(periodValue);
 					setStartTime(from);
 					setEndTime(to);
-					onFiltersChange({
-						...filters,
-						start_time: from.toISOString(),
-						end_time: to.toISOString(),
-					});
+					onPeriodChange(periodValue, from, to);
+				}}
+				onDateTimeUpdate={(p) => {
+					setStartTime(p.from);
+					setEndTime(p.to);
+					onPeriodChange("", p.from ?? new Date(), p.to ?? new Date());
+					onFiltersChange({ ...filters, start_time: p.from?.toISOString(), end_time: p.to?.toISOString() });
 				}}
 			/>
 			<FilterPopover filters={filters} onFilterChange={handleFilterChange} onMetadataFilterChange={handleMetadataFilterChange} showMissingCost />
@@ -210,11 +166,11 @@ export function LogFilters({ filters, onFiltersChange, liveEnabled, onLiveToggle
 				<PopoverContent className="bg-accent w-[250px] p-2" align="end">
 					<Command>
 						<CommandList>
-							<CommandItem className="hover:bg-accent/50 cursor-pointer" onSelect={handleRecalculateCosts}>
+							<CommandItem className="hover:bg-accent/50 cursor-pointer" onSelect={handleRecalculateCosts} disabled={recalculating}>
 								<Calculator className="text-muted-foreground size-4" />
 								<div className="flex flex-col">
 									<span className="text-sm">Recalculate costs</span>
-									<span className="text-muted-foreground text-xs">For all logs that don't have a cost</span>
+									<span className="text-muted-foreground text-xs">For all logs that don&apos;t have a cost</span>
 								</div>
 							</CommandItem>
 						</CommandList>

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -1,318 +1,347 @@
 "use client";
 
+import {
+  buildPinStyle,
+  ColumnConfigDropdown,
+  DraggableColumnHeader,
+  PIN_SHADOW_LEFT,
+  PIN_SHADOW_RIGHT,
+  useColumnConfig,
+  useHeaderCellRefs,
+  usePinOffsets,
+} from "@/components/table";
 import { Button } from "@/components/ui/button";
-import { buildPinStyle, ColumnConfigDropdown, DraggableColumnHeader, PIN_SHADOW_LEFT, PIN_SHADOW_RIGHT, useColumnConfig, useHeaderCellRefs, usePinOffsets } from "@/components/table";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { useTablePageSize } from "@/hooks/useTablePageSize";
 import type { LogEntry, LogFilters, Pagination } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import { ColumnDef, flexRender, getCoreRowModel, SortingState, useReactTable } from "@tanstack/react-table";
-import { ChevronLeft, ChevronRight, Pause, RefreshCw, X } from "lucide-react";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LogFilters as LogFiltersComponent } from "./filters";
 
 const COLUMN_LABELS: Record<string, string> = {
-	timestamp: "Time",
-	request_type: "Type",
-	input: "Message",
-	provider: "Provider",
-	model: "Model",
-	latency: "Latency",
-	tokens: "Tokens",
-	cost: "Cost",
+  timestamp: "Time",
+  request_type: "Type",
+  input: "Message",
+  provider: "Provider",
+  model: "Model",
+  latency: "Latency",
+  tokens: "Tokens",
+  cost: "Cost",
 };
 
-
 interface DataTableProps {
-	columns: ColumnDef<LogEntry>[];
-	data: LogEntry[];
-	totalItems: number;
-	loading?: boolean;
-	filters: LogFilters;
-	pagination: Pagination;
-	onFiltersChange: (filters: LogFilters) => void;
-	onPaginationChange: (pagination: Pagination) => void;
-	onRowClick?: (log: LogEntry, columnId: string) => void;
-	isSocketConnected: boolean;
-	liveEnabled: boolean;
-	onLiveToggle: (enabled: boolean) => void;
-	fetchLogs: () => Promise<void>;
-	fetchStats: () => Promise<void>;
-	metadataKeys?: string[];
+  columns: ColumnDef<LogEntry>[];
+  data: LogEntry[];
+  totalItems: number;
+  loading?: boolean;
+  filters: LogFilters;
+  pagination: Pagination;
+  onFiltersChange: (filters: LogFilters) => void;
+  onPaginationChange: (pagination: Pagination) => void;
+  onRowClick?: (log: LogEntry, columnId: string) => void;
+  polling: boolean;
+  onPollToggle: (enabled: boolean) => void;
+  onRefresh: () => void;
+  period: string;
+  onPeriodChange: (period: string, from: Date, to: Date) => void;
+  metadataKeys?: string[];
 }
 
 export function LogsDataTable({
-	columns,
-	data,
-	totalItems,
-	loading = false,
-	filters,
-	pagination,
-	onFiltersChange,
-	onPaginationChange,
-	onRowClick,
-	isSocketConnected,
-	liveEnabled,
-	onLiveToggle,
-	fetchLogs,
-	fetchStats,
-	metadataKeys = [],
+  columns,
+  data,
+  totalItems,
+  loading = false,
+  filters,
+  pagination,
+  onFiltersChange,
+  onPaginationChange,
+  onRowClick,
+  polling,
+  onPollToggle,
+  onRefresh,
+  period,
+  onPeriodChange,
+  metadataKeys = [],
 }: DataTableProps) {
-	const [sorting, setSorting] = useState<SortingState>([{ id: pagination.sort_by, desc: pagination.order === "desc" }]);
-	const tableContainerRef = useRef<HTMLDivElement>(null);
-	const calculatedPageSize = useTablePageSize(tableContainerRef);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: pagination.sort_by, desc: pagination.order === "desc" },
+  ]);
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+  const calculatedPageSize = useTablePageSize(tableContainerRef);
 
-	const columnIds = useMemo(
-		() => columns.map((col) => ("id" in col && col.id ? col.id : "accessorKey" in col ? String(col.accessorKey) : "")).filter(Boolean),
-		[columns],
-	);
+  const columnIds = useMemo(
+    () =>
+      columns
+        .map((col) =>
+          "id" in col && col.id ? col.id : "accessorKey" in col ? String(col.accessorKey) : "",
+        )
+        .filter(Boolean),
+    [columns],
+  );
 
-	const fixedColumnIds = useMemo(() => new Set<string>([]), []);
+  const fixedColumnIds = useMemo(() => new Set<string>([]), []);
 
-	// Column config: order, visibility, pinning — persisted in URL
-	const { entries, columnOrder, columnVisibility, columnPinning, toggleVisibility, togglePin, reorder, reset } = useColumnConfig({
-		columnIds,
-		paramName: "cols",
-	});
+  // Column config: order, visibility, pinning — persisted in URL
+  const {
+    entries,
+    columnOrder,
+    columnVisibility,
+    columnPinning,
+    toggleVisibility,
+    togglePin,
+    reorder,
+    reset,
+  } = useColumnConfig({
+    columnIds,
+    paramName: "cols",
+  });
 
-	// Measure actual header cell widths for pixel-perfect pin offsets
-	const { headerCellRefs, setHeaderCellRef } = useHeaderCellRefs();
-	const pinOffsets = usePinOffsets(headerCellRefs, columnPinning);
+  // Measure actual header cell widths for pixel-perfect pin offsets
+  const { headerCellRefs, setHeaderCellRef } = useHeaderCellRefs();
+  const pinOffsets = usePinOffsets(headerCellRefs, columnPinning);
 
-	// Shadow on the edge of pinned groups
-	const lastLeftPinId = columnPinning.left?.at(-1);
-	const firstRightPinId = columnPinning.right?.at(0);
+  // Shadow on the edge of pinned groups
+  const lastLeftPinId = columnPinning.left?.at(-1);
+  const firstRightPinId = columnPinning.right?.at(0);
 
-	// Build labels including dynamic metadata columns
-	const columnLabels = useMemo(() => {
-		const labels = { ...COLUMN_LABELS };
-		for (const key of metadataKeys) {
-			labels[`metadata_${key}`] = key.charAt(0).toUpperCase() + key.slice(1);
-		}
-		return labels;
-	}, [metadataKeys]);
+  // Build labels including dynamic metadata columns
+  const columnLabels = useMemo(() => {
+    const labels = { ...COLUMN_LABELS };
+    for (const key of metadataKeys) {
+      labels[`metadata_${key}`] = key.charAt(0).toUpperCase() + key.slice(1);
+    }
+    return labels;
+  }, [metadataKeys]);
 
-	// Handle native drag-and-drop reorder
-	const handleColumnDrop = useCallback(
-		(draggedId: string, targetId: string) => {
-			const newEntries = [...entries];
-			const draggedIdx = newEntries.findIndex((e) => e.id === draggedId);
-			const targetIdx = newEntries.findIndex((e) => e.id === targetId);
-			if (draggedIdx === -1 || targetIdx === -1) return;
-			const [moved] = newEntries.splice(draggedIdx, 1);
-			newEntries.splice(targetIdx, 0, moved);
-			reorder(newEntries);
-		},
-		[entries, reorder],
-	);
+  // Handle native drag-and-drop reorder
+  const handleColumnDrop = useCallback(
+    (draggedId: string, targetId: string) => {
+      const newEntries = [...entries];
+      const draggedIdx = newEntries.findIndex((e) => e.id === draggedId);
+      const targetIdx = newEntries.findIndex((e) => e.id === targetId);
+      if (draggedIdx === -1 || targetIdx === -1) return;
+      const [moved] = newEntries.splice(draggedIdx, 1);
+      newEntries.splice(targetIdx, 0, moved);
+      reorder(newEntries);
+    },
+    [entries, reorder],
+  );
 
-	// Refs to avoid stale closures in the page size effect
-	const paginationRef = useRef(pagination);
-	const onPaginationChangeRef = useRef(onPaginationChange);
-	paginationRef.current = pagination;
-	onPaginationChangeRef.current = onPaginationChange;
+  // Refs to avoid stale closures in the page size effect
+  const paginationRef = useRef(pagination);
+  const onPaginationChangeRef = useRef(onPaginationChange);
+  paginationRef.current = pagination;
+  onPaginationChangeRef.current = onPaginationChange;
 
-	useEffect(() => {
-		if (calculatedPageSize && calculatedPageSize > paginationRef.current.limit) {
-			onPaginationChangeRef.current({
-				...paginationRef.current,
-				limit: calculatedPageSize,
-				offset: 0,
-			});
-		}
-	}, [calculatedPageSize]);
+  useEffect(() => {
+    if (calculatedPageSize && calculatedPageSize > paginationRef.current.limit) {
+      onPaginationChangeRef.current({
+        ...paginationRef.current,
+        limit: calculatedPageSize,
+        offset: 0,
+      });
+    }
+  }, [calculatedPageSize]);
 
-	const handleSortingChange = (updaterOrValue: SortingState | ((old: SortingState) => SortingState)) => {
-		const newSorting = typeof updaterOrValue === "function" ? updaterOrValue(sorting) : updaterOrValue;
-		setSorting(newSorting);
-		if (newSorting.length > 0) {
-			const { id, desc } = newSorting[0];
-			onPaginationChange({
-				...pagination,
-				sort_by: id as "timestamp" | "latency" | "tokens" | "cost",
-				order: desc ? "desc" : "asc",
-			});
-		}
-	};
+  const handleSortingChange = (
+    updaterOrValue: SortingState | ((old: SortingState) => SortingState),
+  ) => {
+    const newSorting =
+      typeof updaterOrValue === "function" ? updaterOrValue(sorting) : updaterOrValue;
+    setSorting(newSorting);
+    if (newSorting.length > 0) {
+      const { id, desc } = newSorting[0];
+      onPaginationChange({
+        ...pagination,
+        sort_by: id as "timestamp" | "latency" | "tokens" | "cost",
+        order: desc ? "desc" : "asc",
+      });
+    }
+  };
 
-	const table = useReactTable({
-		data,
-		columns,
-		getCoreRowModel: getCoreRowModel(),
-		manualPagination: true,
-		manualSorting: true,
-		manualFiltering: true,
-		pageCount: Math.ceil(totalItems / pagination.limit),
-		state: {
-			sorting,
-			columnOrder,
-			columnVisibility,
-			columnPinning,
-		},
-		onSortingChange: handleSortingChange,
-	});
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+    manualSorting: true,
+    manualFiltering: true,
+    pageCount: Math.ceil(totalItems / pagination.limit),
+    state: {
+      sorting,
+      columnOrder,
+      columnVisibility,
+      columnPinning,
+    },
+    onSortingChange: handleSortingChange,
+  });
 
-	const currentPage = Math.floor(pagination.offset / pagination.limit) + 1;
-	const totalPages = Math.ceil(totalItems / pagination.limit);
-	const startItem = pagination.offset + 1;
-	const endItem = Math.min(pagination.offset + pagination.limit, totalItems);
+  const currentPage = Math.floor(pagination.offset / pagination.limit) + 1;
+  const totalPages = Math.ceil(totalItems / pagination.limit);
+  const startItem = pagination.offset + 1;
+  const endItem = Math.min(pagination.offset + pagination.limit, totalItems);
 
-	const goToPage = (page: number) => {
-		const newOffset = (page - 1) * pagination.limit;
-		onPaginationChange({
-			...pagination,
-			offset: newOffset,
-		});
-	};
+  const goToPage = (page: number) => {
+    const newOffset = (page - 1) * pagination.limit;
+    onPaginationChange({
+      ...pagination,
+      offset: newOffset,
+    });
+  };
 
-	return (
-		<div className="flex h-full flex-col gap-2">
-			<div className="flex shrink-0 items-center gap-2">
-				<div className="flex-1">
-					<LogFiltersComponent
-						filters={filters}
-						onFiltersChange={onFiltersChange}
-						liveEnabled={liveEnabled}
-						onLiveToggle={onLiveToggle}
-						fetchLogs={fetchLogs}
-						fetchStats={fetchStats}
-					/>
-				</div>
-				<ColumnConfigDropdown
-					entries={entries}
-					labels={columnLabels}
-					onToggleVisibility={toggleVisibility}
-					onReset={reset}
-				/>
-			</div>
+  return (
+    <div className="flex h-full flex-col gap-2">
+      <div className="flex shrink-0 items-center gap-2">
+        <div className="flex-1">
+          <LogFiltersComponent
+            filters={filters}
+            onFiltersChange={onFiltersChange}
+            polling={polling}
+            onPollToggle={onPollToggle}
+            onRefresh={onRefresh}
+            period={period}
+            onPeriodChange={onPeriodChange}
+          />
+        </div>
+        <ColumnConfigDropdown
+          entries={entries}
+          labels={columnLabels}
+          onToggleVisibility={toggleVisibility}
+          onReset={reset}
+        />
+      </div>
 
-			<div ref={tableContainerRef} className="min-h-0 flex-1 overflow-hidden rounded-sm border">
-				<Table containerClassName="h-full overflow-auto">
-					<thead className={cn("[&_tr]:border-b px-2 sticky top-0 z-10 bg-[#f9f9f9] dark:bg-[#27272a]")}>
-						{table.getHeaderGroups().map((headerGroup) => (
-							<tr
-								key={headerGroup.id}
-								className="hover:bg-muted/50 dark:hover:bg-muted/75 data-[state=selected]:bg-muted border-b transition-colors"
-							>
-								{headerGroup.headers.map((header) => (
-									<DraggableColumnHeader
-										key={header.id}
-										header={header}
-										isConfigurable={!fixedColumnIds.has(header.column.id)}
-										pinStyle={buildPinStyle(header.column, pinOffsets)}
-										pinnedHeaderClassName="bg-[#f9f9f9] dark:bg-[#27272a]"
-										className={cn(
-											header.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
-											header.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
-										)}
-										onHide={toggleVisibility}
-										onPin={togglePin}
-										onDrop={handleColumnDrop}
-										cellRef={setHeaderCellRef(header.column.id)}
-									/>
-								))}
-							</tr>
-						))}
-					</thead>
-					<TableBody>
-						{loading ? (
-							<TableRow>
-								<TableCell colSpan={columns.length} className="h-24 text-center">
-									<div className="flex items-center justify-center gap-2">
-										<RefreshCw className="h-4 w-4 animate-spin" />
-										Loading logs...
-									</div>
-								</TableCell>
-							</TableRow>
-						) : (
-							<>
-								<TableRow className="hover:bg-transparent">
-									<TableCell colSpan={columns.length} className="h-12 text-center">
-										<div className="flex items-center justify-center gap-2">
-											{!isSocketConnected ? (
-												<>
-													<X className="h-4 w-4" />
-													Not connected to socket, please refresh the page.
-												</>
-											) : liveEnabled ? (
-												<>
-													<RefreshCw className="h-4 w-4 animate-spin" />
-													Listening for logs...
-												</>
-											) : (
-												<>
-													<Pause className="h-4 w-4" />
-													Live updates paused
-												</>
-											)}
-										</div>
-									</TableCell>
-								</TableRow>
-								{table.getRowModel().rows.length ? (
-									table.getRowModel().rows.map((row) => (
-										<TableRow key={row.id} className="hover:bg-muted/50 h-12 cursor-pointer group/table-row">
-											{row.getVisibleCells().map((cell) => {
-												const pinned = cell.column.getIsPinned();
-												return (
-													<TableCell
-														onClick={() => onRowClick?.(row.original, cell.column.id)}
-														key={cell.id}
-														style={buildPinStyle(cell.column, pinOffsets)}
-														className={cn(
-															pinned && "bg-card",
-															cell.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
-															cell.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
-															"group-hover/table-row:bg-[#f7f7f7] dark:group-hover/table-row:bg-[#232327]",
-														)}
-													>
-														{flexRender(cell.column.columnDef.cell, cell.getContext())}
-													</TableCell>
-												);
-											})}
-										</TableRow>
-									))
-								) : (
-									<TableRow>
-										<TableCell colSpan={columns.length} className="h-24 text-center">
-											No results found. Try adjusting your filters and/or time range.
-										</TableCell>
-									</TableRow>
-								)}
-							</>
-						)}
-					</TableBody>
-				</Table>
-			</div>
+      <div ref={tableContainerRef} className="min-h-0 flex-1 overflow-hidden rounded-sm border">
+        <Table containerClassName="h-full overflow-auto">
+          <thead
+            className={cn("[&_tr]:border-b px-2 sticky top-0 z-10 bg-[#f9f9f9] dark:bg-[#27272a]")}
+          >
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr
+                key={headerGroup.id}
+                className="hover:bg-muted/50 dark:hover:bg-muted/75 data-[state=selected]:bg-muted border-b transition-colors"
+              >
+                {headerGroup.headers.map((header) => (
+                  <DraggableColumnHeader
+                    key={header.id}
+                    header={header}
+                    isConfigurable={!fixedColumnIds.has(header.column.id)}
+                    pinStyle={buildPinStyle(header.column, pinOffsets)}
+                    pinnedHeaderClassName="bg-[#f9f9f9] dark:bg-[#27272a]"
+                    className={cn(
+                      header.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
+                      header.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
+                    )}
+                    onHide={toggleVisibility}
+                    onPin={togglePin}
+                    onDrop={handleColumnDrop}
+                    cellRef={setHeaderCellRef(header.column.id)}
+                  />
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <TableBody>
+            <TableRow className="hover:bg-transparent">
+              <TableCell colSpan={columns.length} className="h-12 text-center">
+                <div className="flex items-center justify-center gap-2">
+                  {polling ? (
+                    <>
+                      <RefreshCw className="h-4 w-4 animate-spin" />
+                      Waiting for new logs...
+                    </>
+                  ) : (
+                    <Button variant="ghost" size="sm" onClick={onRefresh} disabled={loading}>
+                      <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+                      Refresh
+                    </Button>
+                  )}
+                </div>
+              </TableCell>
+            </TableRow>
+            {table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  className="hover:bg-muted/50 h-12 cursor-pointer group/table-row"
+                >
+                  {row.getVisibleCells().map((cell) => {
+                    const pinned = cell.column.getIsPinned();
+                    return (
+                      <TableCell
+                        onClick={() => onRowClick?.(row.original, cell.column.id)}
+                        key={cell.id}
+                        style={buildPinStyle(cell.column, pinOffsets)}
+                        className={cn(
+                          pinned && "bg-card",
+                          cell.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
+                          cell.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
+                          "group-hover/table-row:bg-[#f7f7f7] dark:group-hover/table-row:bg-[#232327]",
+                        )}
+                      >
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results found. Try adjusting your filters and/or time range.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
 
-			{/* Pagination Footer */}
-			<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-				<div className="text-muted-foreground flex items-center gap-2">
-					{startItem.toLocaleString()}-{endItem.toLocaleString()} of {totalItems.toLocaleString()} entries
-				</div>
+      {/* Pagination Footer */}
+      <div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
+        <div className="text-muted-foreground flex items-center gap-2">
+          {startItem.toLocaleString()}-{endItem.toLocaleString()} of {totalItems.toLocaleString()}{" "}
+          entries
+        </div>
 
-				<div className="flex items-center gap-2">
-					<Button variant="ghost" size="sm" onClick={() => goToPage(currentPage - 1)} disabled={currentPage <= 1} data-testid="prev-page" aria-label="Previous page">
-						<ChevronLeft className="size-3" />
-					</Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => goToPage(currentPage - 1)}
+            disabled={currentPage <= 1}
+            data-testid="prev-page"
+            aria-label="Previous page"
+          >
+            <ChevronLeft className="size-3" />
+          </Button>
 
-					<div className="flex items-center gap-1">
-						<span>Page</span>
-						<span>{currentPage}</span>
-						<span>of {totalPages}</span>
-					</div>
+          <div className="flex items-center gap-1">
+            <span>Page</span>
+            <span>{currentPage}</span>
+            <span>of {totalPages}</span>
+          </div>
 
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => goToPage(currentPage + 1)}
-						disabled={totalPages === 0 || currentPage >= totalPages}
-						data-testid="next-page"
-						aria-label="Next page"
-					>
-						<ChevronRight className="size-3" />
-					</Button>
-				</div>
-			</div>
-		</div>
-	);
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => goToPage(currentPage + 1)}
+            disabled={totalPages === 0 || currentPage >= totalPages}
+            data-testid="next-page"
+            aria-label="Next page"
+          >
+            <ChevronRight className="size-3" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/ui/app/workspace/logs/views/logsVolumeChart.tsx
+++ b/ui/app/workspace/logs/views/logsVolumeChart.tsx
@@ -6,429 +6,492 @@ import { Skeleton } from "@/components/ui/skeleton";
 import type { HistogramBucket, LogsHistogramResponse } from "@/lib/types/logs";
 import { ChevronDown, RotateCcw } from "lucide-react";
 import { Component, type ErrorInfo, type ReactNode, useCallback, useMemo, useState } from "react";
-import { Bar, BarChart, CartesianGrid, ReferenceArea, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ReferenceArea,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 // Empty chart placeholder when data fails to render
 function EmptyChart() {
-	return (
-		<ResponsiveContainer width="100%" height="100%">
-			<BarChart
-				data={[
-					{ name: "", value: 0 },
-					{ name: " ", value: 0 },
-				]}
-			>
-				<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
-				<XAxis dataKey="name" tick={{ fontSize: 13, className: "fill-zinc-500", dy: 5 }} tickLine={false} axisLine={false} />
-				<YAxis tick={{ fontSize: 13, className: "fill-zinc-500" }} tickLine={false} axisLine={false} width={40} domain={[0, 1]} />
-			</BarChart>
-		</ResponsiveContainer>
-	);
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart
+        data={[
+          { name: "", value: 0 },
+          { name: " ", value: 0 },
+        ]}
+      >
+        <CartesianGrid
+          strokeDasharray="3 3"
+          vertical={false}
+          className="stroke-zinc-200 dark:stroke-zinc-700"
+        />
+        <XAxis
+          dataKey="name"
+          tick={{ fontSize: 13, className: "fill-zinc-500", dy: 5 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          tick={{ fontSize: 13, className: "fill-zinc-500" }}
+          tickLine={false}
+          axisLine={false}
+          width={40}
+          domain={[0, 1]}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
 }
 
 // Error boundary to catch Recharts rendering errors
-class ChartErrorBoundary extends Component<{ children: ReactNode; resetKey?: string }, { hasError: boolean }> {
-	constructor(props: { children: ReactNode; resetKey?: string }) {
-		super(props);
-		this.state = { hasError: false };
-	}
+class ChartErrorBoundary extends Component<
+  { children: ReactNode; resetKey?: string },
+  { hasError: boolean }
+> {
+  constructor(props: { children: ReactNode; resetKey?: string }) {
+    super(props);
+    this.state = { hasError: false };
+  }
 
-	static getDerivedStateFromError(_: Error) {
-		return { hasError: true };
-	}
+  static getDerivedStateFromError(_: Error) {
+    return { hasError: true };
+  }
 
-	static getDerivedStateFromProps(props: { resetKey?: string }, state: { hasError: boolean; prevResetKey?: string }) {
-		// Reset error state when resetKey changes
-		if (props.resetKey !== state.prevResetKey) {
-			return { hasError: false, prevResetKey: props.resetKey };
-		}
-		return null;
-	}
+  static getDerivedStateFromProps(
+    props: { resetKey?: string },
+    state: { hasError: boolean; prevResetKey?: string },
+  ) {
+    // Reset error state when resetKey changes
+    if (props.resetKey !== state.prevResetKey) {
+      return { hasError: false, prevResetKey: props.resetKey };
+    }
+    return null;
+  }
 
-	componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
-		console.warn("Chart rendering error:", error.message);
-	}
+  componentDidCatch(error: Error, _errorInfo: ErrorInfo) {
+    console.warn("Chart rendering error:", error.message);
+  }
 
-	render() {
-		if (this.state.hasError) {
-			return <EmptyChart />;
-		}
-		return this.props.children;
-	}
+  render() {
+    if (this.state.hasError) {
+      return <EmptyChart />;
+    }
+    return this.props.children;
+  }
 }
 
 interface LogsVolumeChartProps {
-	data: LogsHistogramResponse | null;
-	loading?: boolean;
-	onTimeRangeChange: (startTime: number, endTime: number) => void;
-	onResetZoom?: () => void;
-	isZoomed?: boolean;
-	startTime: number; // Unix timestamp in seconds
-	endTime: number; // Unix timestamp in seconds
-	isOpen: boolean;
-	onOpenChange: (open: boolean) => void;
+  data: LogsHistogramResponse | null;
+  loading?: boolean;
+  onTimeRangeChange: (startTime: number, endTime: number) => void;
+  onResetZoom?: () => void;
+  isZoomed?: boolean;
+  startTime: number; // Unix timestamp in seconds
+  endTime: number; // Unix timestamp in seconds
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
 // Format timestamp based on bucket size
 function formatTimestamp(timestamp: string, bucketSizeSeconds: number): string {
-	const date = new Date(timestamp);
+  const date = new Date(timestamp);
 
-	if (bucketSizeSeconds >= 86400) {
-		// Daily buckets: "Jan 20"
-		return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-	} else if (bucketSizeSeconds >= 3600) {
-		// Hourly buckets: "10:00"
-		return date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
-	} else {
-		// Sub-hourly: "10:15"
-		return date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
-	}
+  if (bucketSizeSeconds >= 86400) {
+    // Daily buckets: "Jan 20"
+    return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  } else if (bucketSizeSeconds >= 3600) {
+    // Hourly buckets: "10:00"
+    return date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+  } else {
+    // Sub-hourly: "10:15"
+    return date.toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+  }
 }
 
 // Format full timestamp for tooltip
 function formatFullTimestamp(timestamp: string): string {
-	const date = new Date(timestamp);
-	return date.toLocaleString("en-US", {
-		month: "short",
-		day: "numeric",
-		hour: "2-digit",
-		minute: "2-digit",
-		hour12: false,
-	});
+  const date = new Date(timestamp);
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
 }
 
 // Custom tooltip component
 function CustomTooltip({ active, payload, label }: any) {
-	if (!active || !payload || !payload.length) return null;
+  if (!active || !payload || !payload.length) return null;
 
-	const data = payload[0]?.payload as HistogramBucket & { formattedTime: string };
-	if (!data) return null;
+  const data = payload[0]?.payload as HistogramBucket & { formattedTime: string };
+  if (!data) return null;
 
-	return (
-		<div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
-			<div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
-			<div className="space-y-1 text-sm">
-				<div className="mt-2 flex items-center justify-between gap-4">
-					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-blue-500" />
-						<span className="text-zinc-600 dark:text-zinc-400">Total</span>
-					</span>
-					<span className="font-medium">{data.count.toLocaleString()}</span>
-				</div>
-				<div className="flex items-center justify-between gap-4">
-					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-emerald-500" />
-						<span className="text-zinc-600 dark:text-zinc-400">Success</span>
-					</span>
-					<span className="font-medium text-emerald-600 dark:text-emerald-400">{data.success.toLocaleString()}</span>
-				</div>
-				<div className="flex items-center justify-between gap-4">
-					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-red-500" />
-						<span className="text-zinc-600 dark:text-zinc-400">Error</span>
-					</span>
-					<span className="font-medium text-red-600 dark:text-red-400">{data.error.toLocaleString()}</span>
-				</div>
-			</div>
-		</div>
-	);
+  return (
+    <div className="rounded-sm border border-zinc-200 bg-white px-3 py-2 shadow-lg dark:border-zinc-700 dark:bg-zinc-900">
+      <div className="mb-1 text-xs text-zinc-500">{formatFullTimestamp(data.timestamp)}</div>
+      <div className="space-y-1 text-sm">
+        <div className="mt-2 flex items-center justify-between gap-4">
+          <span className="flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full bg-blue-500" />
+            <span className="text-zinc-600 dark:text-zinc-400">Total</span>
+          </span>
+          <span className="font-medium">{data.count.toLocaleString()}</span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <span className="flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full bg-emerald-500" />
+            <span className="text-zinc-600 dark:text-zinc-400">Success</span>
+          </span>
+          <span className="font-medium text-emerald-600 dark:text-emerald-400">
+            {data.success.toLocaleString()}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <span className="flex items-center gap-1.5">
+            <span className="h-2 w-2 rounded-full bg-red-500" />
+            <span className="text-zinc-600 dark:text-zinc-400">Error</span>
+          </span>
+          <span className="font-medium text-red-600 dark:text-red-400">
+            {data.error.toLocaleString()}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export function LogsVolumeChart({
-	data,
-	loading,
-	onTimeRangeChange,
-	onResetZoom,
-	isZoomed,
-	startTime,
-	endTime,
-	isOpen,
-	onOpenChange,
+  data,
+  loading,
+  onTimeRangeChange,
+  onResetZoom,
+  isZoomed,
+  startTime,
+  endTime,
+  isOpen,
+  onOpenChange,
 }: LogsVolumeChartProps) {
-	// State for drag selection
-	const [refAreaLeft, setRefAreaLeft] = useState<number | null>(null);
-	const [refAreaRight, setRefAreaRight] = useState<number | null>(null);
-	const [isSelecting, setIsSelecting] = useState(false);
+  // State for drag selection
+  const [refAreaLeft, setRefAreaLeft] = useState<number | null>(null);
+  const [refAreaRight, setRefAreaRight] = useState<number | null>(null);
+  const [isSelecting, setIsSelecting] = useState(false);
 
-	// Transform data for chart, filling in empty buckets for the full time range
-	const chartData = useMemo(() => {
-		// Need bucket_size_seconds and valid time range
-		if (!data?.bucket_size_seconds || !startTime || !endTime || startTime >= endTime) {
-			return [];
-		}
+  // Transform data for chart, filling in empty buckets for the full time range
+  const chartData = useMemo(() => {
+    // Need bucket_size_seconds and valid time range
+    if (!data?.bucket_size_seconds || !startTime || !endTime || startTime >= endTime) {
+      return [];
+    }
 
-		const bucketSizeMs = data.bucket_size_seconds * 1000;
+    const bucketSizeMs = data.bucket_size_seconds * 1000;
 
-		// Align start time to bucket boundary
-		const minTime = Math.floor((startTime * 1000) / bucketSizeMs) * bucketSizeMs;
-		const maxTime = endTime * 1000;
+    // Align start time to bucket boundary
+    const minTime = Math.floor((startTime * 1000) / bucketSizeMs) * bucketSizeMs;
+    const maxTime = endTime * 1000;
 
-		// Safety: limit maximum number of buckets to prevent performance issues
-		const maxBuckets = 500;
-		const estimatedBuckets = Math.ceil((maxTime - minTime) / bucketSizeMs);
+    // Safety: limit maximum number of buckets to prevent performance issues
+    const maxBuckets = 500;
+    const estimatedBuckets = Math.ceil((maxTime - minTime) / bucketSizeMs);
 
-		if (estimatedBuckets > maxBuckets) {
-			// If too many buckets, just return the original data without filling
-			const result = (data.buckets || []).map((bucket, index) => ({
-				...bucket,
-				index,
-				formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
-			}));
-			// Ensure at least 2 data points for Recharts
-			if (result.length === 1) {
-				const nextTimestamp = new Date(new Date(result[0].timestamp).getTime() + bucketSizeMs).toISOString();
-				result.push({
-					timestamp: nextTimestamp,
-					count: 0,
-					success: 0,
-					error: 0,
-					index: 1,
-					formattedTime: formatTimestamp(nextTimestamp, data.bucket_size_seconds),
-				});
-			}
-			return result;
-		}
+    if (estimatedBuckets > maxBuckets) {
+      // If too many buckets, just return the original data without filling
+      const result = (data.buckets || []).map((bucket, index) => ({
+        ...bucket,
+        index,
+        formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+      }));
+      // Ensure at least 2 data points for Recharts
+      if (result.length === 1) {
+        const nextTimestamp = new Date(
+          new Date(result[0].timestamp).getTime() + bucketSizeMs,
+        ).toISOString();
+        result.push({
+          timestamp: nextTimestamp,
+          count: 0,
+          success: 0,
+          error: 0,
+          index: 1,
+          formattedTime: formatTimestamp(nextTimestamp, data.bucket_size_seconds),
+        });
+      }
+      return result;
+    }
 
-		// First, create all empty buckets for the time range
-		const filledBuckets: Array<HistogramBucket & { formattedTime: string; index: number }> = [];
-		for (let time = minTime, idx = 0; time <= maxTime; time += bucketSizeMs, idx++) {
-			const timestamp = new Date(time).toISOString();
-			filledBuckets.push({
-				timestamp,
-				count: 0,
-				success: 0,
-				error: 0,
-				index: idx,
-				formattedTime: formatTimestamp(timestamp, data.bucket_size_seconds),
-			});
-		}
+    // First, create all empty buckets for the time range
+    const filledBuckets: Array<HistogramBucket & { formattedTime: string; index: number }> = [];
+    for (let time = minTime, idx = 0; time <= maxTime; time += bucketSizeMs, idx++) {
+      const timestamp = new Date(time).toISOString();
+      filledBuckets.push({
+        timestamp,
+        count: 0,
+        success: 0,
+        error: 0,
+        index: idx,
+        formattedTime: formatTimestamp(timestamp, data.bucket_size_seconds),
+      });
+    }
 
-		// Then, place API buckets at their correct positions using index calculation
-		// This is more robust than exact timestamp matching
-		for (const bucket of data.buckets || []) {
-			const bucketTime = new Date(bucket.timestamp).getTime();
-			// Calculate the index for this bucket based on its offset from minTime
-			const bucketIndex = Math.round((bucketTime - minTime) / bucketSizeMs);
+    // Then, place API buckets at their correct positions using index calculation
+    // This is more robust than exact timestamp matching
+    for (const bucket of data.buckets || []) {
+      const bucketTime = new Date(bucket.timestamp).getTime();
+      // Calculate the index for this bucket based on its offset from minTime
+      const bucketIndex = Math.round((bucketTime - minTime) / bucketSizeMs);
 
-			if (bucketIndex >= 0 && bucketIndex < filledBuckets.length) {
-				filledBuckets[bucketIndex] = {
-					...bucket,
-					index: bucketIndex,
-					formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
-				};
-			}
-		}
+      if (bucketIndex >= 0 && bucketIndex < filledBuckets.length) {
+        filledBuckets[bucketIndex] = {
+          ...bucket,
+          index: bucketIndex,
+          formattedTime: formatTimestamp(bucket.timestamp, data.bucket_size_seconds),
+        };
+      }
+    }
 
-		// Ensure at least 2 data points for Recharts
-		if (filledBuckets.length === 1) {
-			const nextTimestamp = new Date(new Date(filledBuckets[0].timestamp).getTime() + bucketSizeMs).toISOString();
-			filledBuckets.push({
-				timestamp: nextTimestamp,
-				count: 0,
-				success: 0,
-				error: 0,
-				index: 1,
-				formattedTime: formatTimestamp(nextTimestamp, data.bucket_size_seconds),
-			});
-		}
+    // Ensure at least 2 data points for Recharts
+    if (filledBuckets.length === 1) {
+      const nextTimestamp = new Date(
+        new Date(filledBuckets[0].timestamp).getTime() + bucketSizeMs,
+      ).toISOString();
+      filledBuckets.push({
+        timestamp: nextTimestamp,
+        count: 0,
+        success: 0,
+        error: 0,
+        index: 1,
+        formattedTime: formatTimestamp(nextTimestamp, data.bucket_size_seconds),
+      });
+    }
 
-		return filledBuckets;
-	}, [data, startTime, endTime]);
+    return filledBuckets;
+  }, [data, startTime, endTime]);
 
-	// Handle mouse down on chart (start selection)
-	const handleMouseDown = useCallback((e: any) => {
-		if (e?.activeTooltipIndex !== undefined) {
-			setRefAreaLeft(e.activeTooltipIndex);
-			setIsSelecting(true);
-		}
-	}, []);
+  // Handle mouse down on chart (start selection)
+  const handleMouseDown = useCallback((e: any) => {
+    if (e?.activeTooltipIndex !== undefined) {
+      setRefAreaLeft(e.activeTooltipIndex);
+      setIsSelecting(true);
+    }
+  }, []);
 
-	// Handle mouse move on chart (during selection)
-	const handleMouseMove = useCallback(
-		(e: any) => {
-			if (isSelecting && e?.activeTooltipIndex !== undefined) {
-				setRefAreaRight(e.activeTooltipIndex);
-			}
-		},
-		[isSelecting],
-	);
+  // Handle mouse move on chart (during selection)
+  const handleMouseMove = useCallback(
+    (e: any) => {
+      if (isSelecting && e?.activeTooltipIndex !== undefined) {
+        setRefAreaRight(e.activeTooltipIndex);
+      }
+    },
+    [isSelecting],
+  );
 
-	// Handle mouse up on chart (end selection)
-	const handleMouseUp = useCallback(() => {
-		if (refAreaLeft === null || refAreaRight === null || !data?.bucket_size_seconds || chartData.length === 0) {
-			setRefAreaLeft(null);
-			setRefAreaRight(null);
-			setIsSelecting(false);
-			return;
-		}
+  // Handle mouse up on chart (end selection)
+  const handleMouseUp = useCallback(() => {
+    if (
+      refAreaLeft === null ||
+      refAreaRight === null ||
+      !data?.bucket_size_seconds ||
+      chartData.length === 0
+    ) {
+      setRefAreaLeft(null);
+      setRefAreaRight(null);
+      setIsSelecting(false);
+      return;
+    }
 
-		// Get the buckets by index
-		const leftBucket = chartData[refAreaLeft];
-		const rightBucket = chartData[refAreaRight];
+    // Get the buckets by index
+    const leftBucket = chartData[refAreaLeft];
+    const rightBucket = chartData[refAreaRight];
 
-		if (leftBucket && rightBucket) {
-			const leftTime = new Date(leftBucket.timestamp).getTime() / 1000;
-			const rightTime = new Date(rightBucket.timestamp).getTime() / 1000 + data.bucket_size_seconds;
+    if (leftBucket && rightBucket) {
+      const leftStart = new Date(leftBucket.timestamp).getTime() / 1000;
+      const rightStart = new Date(rightBucket.timestamp).getTime() / 1000;
 
-			// Ensure left < right
-			const selectionStart = Math.min(leftTime, rightTime);
-			const selectionEnd = Math.max(leftTime, rightTime);
+      // Normalize drag direction and include full trailing bucket
+      const selectionStart = Math.min(leftStart, rightStart);
+      const selectionEnd = Math.max(leftStart, rightStart) + data.bucket_size_seconds;
 
-			// Only trigger if selection spans at least one bucket
-			if (selectionEnd - selectionStart >= data.bucket_size_seconds) {
-				onTimeRangeChange(selectionStart, selectionEnd);
-			}
-		}
+      // Only trigger if selection spans at least one bucket
+      if (selectionEnd - selectionStart >= data.bucket_size_seconds) {
+        onTimeRangeChange(selectionStart, selectionEnd);
+      }
+    }
 
-		setRefAreaLeft(null);
-		setRefAreaRight(null);
-		setIsSelecting(false);
-	}, [refAreaLeft, refAreaRight, data, chartData, onTimeRangeChange]);
+    setRefAreaLeft(null);
+    setRefAreaRight(null);
+    setIsSelecting(false);
+  }, [refAreaLeft, refAreaRight, data, chartData, onTimeRangeChange]);
 
-	// Handle click on a bar (zoom into that bucket)
-	const handleBarClick = useCallback(
-		(barData: any) => {
-			if (!data || !barData?.timestamp) return;
+  // Handle click on a bar (zoom into that bucket)
+  const handleBarClick = useCallback(
+    (barData: any) => {
+      if (!data || !barData?.timestamp) return;
 
-			const bucket = barData as HistogramBucket;
-			const startTime = new Date(bucket.timestamp).getTime() / 1000;
-			const endTime = startTime + data.bucket_size_seconds;
+      const bucket = barData as HistogramBucket;
+      const startTime = new Date(bucket.timestamp).getTime() / 1000;
+      const endTime = startTime + data.bucket_size_seconds;
 
-			onTimeRangeChange(startTime, endTime);
-		},
-		[data, onTimeRangeChange],
-	);
+      onTimeRangeChange(startTime, endTime);
+    },
+    [data, onTimeRangeChange],
+  );
 
-	if (loading) {
-		return (
-			<Card className="gap-0 rounded-sm px-2 py-2 shadow-none">
-				<div className="flex items-center justify-between">
-					<div className="flex items-center gap-2">
-						<ChevronDown className="text-muted-foreground h-4 w-4" />
-						<span className="text-muted-foreground text-sm font-medium">Request Volume</span>
-					</div>
-					<div className="mr-2 flex items-center gap-4">
-						<div className="flex items-center gap-3 text-xs">
-							<span className="flex items-center gap-1.5">
-								<span className="h-2 w-2 rounded-full bg-emerald-500" />
-								<span className="text-muted-foreground">Success</span>
-							</span>
-							<span className="flex items-center gap-1.5">
-								<span className="h-2 w-2 rounded-full bg-red-500" />
-								<span className="text-muted-foreground">Error</span>
-							</span>
-						</div>
-					</div>
-				</div>
-				<div className="" style={{ height: "131px", marginTop: 4 }}>
-					<Skeleton className="h-full w-full" />
-				</div>
-			</Card>
-		);
-	}
+  if (loading) {
+    return (
+      <Card className="gap-0 rounded-sm px-2 py-2 shadow-none">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <ChevronDown className="text-muted-foreground h-4 w-4" />
+            <span className="text-muted-foreground text-sm font-medium">Request Volume</span>
+          </div>
+          <div className="mr-2 flex items-center gap-4">
+            <div className="flex items-center gap-3 text-xs">
+              <span className="flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-emerald-500" />
+                <span className="text-muted-foreground">Success</span>
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="h-2 w-2 rounded-full bg-red-500" />
+                <span className="text-muted-foreground">Error</span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="" style={{ height: "136px" }}>
+          <Skeleton className="h-full w-full" />
+        </div>
+      </Card>
+    );
+  }
 
-	// Check if we have valid data for the chart
-	const hasValidData = data && startTime && endTime && chartData.length >= 2;
+  // Check if we have valid data for the chart
+  const hasValidData = data && startTime && endTime && chartData.length >= 2;
 
-	return (
-		<Card className="rounded-sm px-2 py-2 shadow-none">
-			<Collapsible open={isOpen} onOpenChange={onOpenChange}>
-				<div className="flex items-center justify-between">
-					<CollapsibleTrigger className="flex items-center gap-2 hover:opacity-80">
-						<ChevronDown className={`text-muted-foreground h-4 w-4 transition-transform duration-200 ${isOpen ? "" : "-rotate-90"}`} />
-						<span className="text-muted-foreground text-sm font-medium">Request Volume</span>
-					</CollapsibleTrigger>
-					<div className="mr-2 flex items-center gap-4">
-						{isOpen && (
-							<div className="flex items-center gap-3 text-xs">
-								<span className="flex items-center gap-1.5">
-									<span className="h-2 w-2 rounded-full bg-emerald-500" />
-									<span className="text-muted-foreground">Success</span>
-								</span>
-								<span className="flex items-center gap-1.5">
-									<span className="h-2 w-2 rounded-full bg-red-500" />
-									<span className="text-muted-foreground">Error</span>
-								</span>
-							</div>
-						)}
-						{isZoomed && onResetZoom && (
-							<button
-								onClick={onResetZoom}
-								className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs transition-colors"
-							>
-								<RotateCcw className="h-3 w-3" />
-								Reset zoom
-							</button>
-						)}
-					</div>
-				</div>
-				<CollapsibleContent className="data-[state=closed]:animate-collapse-up data-[state=open]:animate-collapse-down overflow-hidden">
-					<div className="mt-2 h-32 select-none">
-						{hasValidData ? (
-							<ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}`}>
-								<ResponsiveContainer width="100%" height="100%">
-									<BarChart
-										data={chartData}
-										margin={{ top: 6, right: 4, left: 12, bottom: 0 }}
-										onMouseDown={handleMouseDown}
-										onMouseMove={handleMouseMove}
-										onMouseUp={handleMouseUp}
-										onMouseLeave={handleMouseUp}
-										barCategoryGap={1}
-									>
-										<CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-zinc-200 dark:stroke-zinc-700" />
-										<XAxis
-											dataKey="index"
-											type="number"
-											domain={[-0.5, chartData.length - 0.5]}
-											tick={{ fontSize: 13, className: "fill-zinc-500", dy: 5 }}
-											tickLine={true}
-											axisLine={false}
-											tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
-											interval="preserveStartEnd"
-										/>
-										<YAxis
-											tick={{ fontSize: 13, className: "fill-zinc-500" }}
-											tickLine={false}
-											axisLine={false}
-											width={40}
-											tickFormatter={(v) => v.toLocaleString()}
-											domain={[0, (dataMax: number) => Math.max(dataMax, 5)]}
-											allowDataOverflow={false}
-										/>
-										<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
-										<Bar
-											dataKey="success"
-											stackId="requests"
-											barSize={30}
-											fill="#10b981"
-											fillOpacity={0.7}
-											radius={[0, 0, 0, 0]}
-											cursor="pointer"
-											onClick={(data: any) => handleBarClick(data)}
-										/>
-										<Bar
-											dataKey="error"
-											stackId="requests"
-											fill="#ef4444"
-											barSize={30}
-											fillOpacity={0.7}
-											radius={[2, 2, 0, 0]}
-											cursor="pointer"
-											onClick={(data: any) => handleBarClick(data)}
-										/>
-										{refAreaLeft !== null && refAreaRight !== null && chartData[refAreaLeft] && chartData[refAreaRight] && (
-											<ReferenceArea x1={refAreaLeft} x2={refAreaRight} strokeOpacity={0.3} fill="#6366f1" fillOpacity={0.2} />
-										)}
-									</BarChart>
-								</ResponsiveContainer>
-							</ChartErrorBoundary>
-						) : (
-							<EmptyChart />
-						)}
-					</div>
-				</CollapsibleContent>
-			</Collapsible>
-		</Card>
-	);
+  return (
+    <>
+      <Card className="rounded-sm px-2 py-2 shadow-none">
+        <Collapsible open={isOpen} onOpenChange={onOpenChange}>
+          <div className="flex items-center justify-between">
+            <CollapsibleTrigger className="flex items-center gap-2 hover:opacity-80">
+              <ChevronDown
+                className={`text-muted-foreground h-4 w-4 transition-transform duration-200 ${isOpen ? "" : "-rotate-90"}`}
+              />
+              <span className="text-muted-foreground text-sm font-medium">Request Volume</span>
+            </CollapsibleTrigger>
+            <div className="mr-2 flex items-center gap-4">
+              {isOpen && (
+                <div className="flex items-center gap-3 text-xs">
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-2 w-2 rounded-full bg-emerald-500" />
+                    <span className="text-muted-foreground">Success</span>
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-2 w-2 rounded-full bg-red-500" />
+                    <span className="text-muted-foreground">Error</span>
+                  </span>
+                </div>
+              )}
+              {isZoomed && onResetZoom && (
+                <button
+                  onClick={onResetZoom}
+                  className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs transition-colors"
+                >
+                  <RotateCcw className="h-3 w-3" />
+                  Reset zoom
+                </button>
+              )}
+            </div>
+          </div>
+          <CollapsibleContent className="data-[state=closed]:animate-collapse-up data-[state=open]:animate-collapse-down overflow-hidden">
+            <div className="mt-2 h-32 select-none">
+              {hasValidData ? (
+                <ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}`}>
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart
+                      data={chartData}
+                      margin={{ top: 6, right: 4, left: 12, bottom: 0 }}
+                      onMouseDown={handleMouseDown}
+                      onMouseMove={handleMouseMove}
+                      onMouseUp={handleMouseUp}
+                      onMouseLeave={handleMouseUp}
+                      barCategoryGap={1}
+                    >
+                      <CartesianGrid
+                        strokeDasharray="3 3"
+                        vertical={false}
+                        className="stroke-zinc-200 dark:stroke-zinc-700"
+                      />
+                      <XAxis
+                        dataKey="index"
+                        type="number"
+                        domain={[-0.5, chartData.length - 0.5]}
+                        tick={{ fontSize: 13, className: "fill-zinc-500", dy: 5 }}
+                        tickLine={true}
+                        axisLine={false}
+                        tickFormatter={(idx) => chartData[Math.round(idx)]?.formattedTime || ""}
+                        interval="preserveStartEnd"
+                      />
+                      <YAxis
+                        tick={{ fontSize: 13, className: "fill-zinc-500" }}
+                        tickLine={false}
+                        axisLine={false}
+                        width={40}
+                        tickFormatter={(v) => v.toLocaleString()}
+                        domain={[0, (dataMax: number) => Math.max(dataMax, 5)]}
+                        allowDataOverflow={false}
+                      />
+                      <Tooltip
+                        content={<CustomTooltip />}
+                        cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }}
+                      />
+                      <Bar
+                        dataKey="success"
+                        stackId="requests"
+                        barSize={30}
+                        fill="#10b981"
+                        fillOpacity={0.7}
+                        radius={[0, 0, 0, 0]}
+                        cursor="pointer"
+                        onClick={(data: any) => handleBarClick(data)}
+                      />
+                      <Bar
+                        dataKey="error"
+                        stackId="requests"
+                        fill="#ef4444"
+                        barSize={30}
+                        fillOpacity={0.7}
+                        radius={[2, 2, 0, 0]}
+                        cursor="pointer"
+                        onClick={(data: any) => handleBarClick(data)}
+                      />
+                      {refAreaLeft !== null &&
+                        refAreaRight !== null &&
+                        chartData[refAreaLeft] &&
+                        chartData[refAreaRight] && (
+                          <ReferenceArea
+                            x1={refAreaLeft}
+                            x2={refAreaRight}
+                            strokeOpacity={0.3}
+                            fill="#6366f1"
+                            fillOpacity={0.2}
+                          />
+                        )}
+                    </BarChart>
+                  </ResponsiveContainer>
+                </ChartErrorBoundary>
+              ) : (
+                <EmptyChart />
+              )}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      </Card>
+    </>
+  );
 }

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -4,12 +4,14 @@ import FullPageLoader from "@/components/fullPageLoader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useWebSocket } from "@/hooks/useWebSocket";
-import { getErrorMessage, useDeleteMCPLogsMutation, useLazyGetMCPLogsQuery, useLazyGetMCPLogsStatsQuery } from "@/lib/store";
-import type { MCPToolLogEntry, MCPToolLogFilters, MCPToolLogStats, Pagination } from "@/lib/types/logs";
+import { getErrorMessage, useDeleteMCPLogsMutation } from "@/lib/store";
+import { useGetMCPLogsQuery, useGetMCPLogsStatsQuery, useLazyGetMCPLogsQuery } from "@/lib/store/apis/mcpLogsApi";
+import type { MCPToolLogEntry, MCPToolLogFilters, Pagination } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
+import { getRangeForPeriod } from "@/lib/utils/timeRange";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { AlertCircle, CheckCircle, Clock, DollarSign, Hash } from "lucide-react";
+import { useSearchParams } from "next/navigation";
 import { parseAsArrayOf, parseAsBoolean, parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createMCPColumns } from "./views/columns";
@@ -18,18 +20,13 @@ import { MCPLogDetailSheet } from "./views/mcpLogDetailsSheet";
 import { MCPLogsDataTable } from "./views/mcpLogsTable";
 
 export default function MCPLogsPage() {
-	const [logs, setLogs] = useState<MCPToolLogEntry[]>([]);
-	const [totalItems, setTotalItems] = useState(0);
-	const [stats, setStats] = useState<MCPToolLogStats | null>(null);
-	const [initialLoading, setInitialLoading] = useState(true);
-	const [fetchingLogs, setFetchingLogs] = useState(false);
-	const [fetchingStats, setFetchingStats] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [showEmptyState, setShowEmptyState] = useState(false);
+	const hasCheckedEmptyState = useRef(false);
 	const hasDeleteAccess = useRbac(RbacResource.Logs, RbacOperation.Delete);
 
+	// Navigation-only lazy hook
 	const [triggerGetLogs] = useLazyGetMCPLogsQuery();
-	const [triggerGetStats] = useLazyGetMCPLogsStatsQuery();
 	const [deleteLogs] = useDeleteMCPLogsMutation();
 
 	// Track if user has manually modified the time range
@@ -39,11 +36,13 @@ export default function MCPLogsPage() {
 	const initialDefaults = useRef(dateUtils.getDefaultTimeRange());
 
 	// Memoize default time range to prevent recalculation on every render
-	// This is crucial to avoid triggering re-fetches when the sheet opens/closes
 	const defaultTimeRange = useMemo(() => dateUtils.getDefaultTimeRange(), []);
 
 	// Get fresh default time range for refresh logic
 	const getDefaultTimeRange = () => dateUtils.getDefaultTimeRange();
+
+	const rawSearchParams = useSearchParams();
+	const hasExplicitTimeRange = rawSearchParams.has("start_time") && rawSearchParams.has("end_time");
 
 	// URL state management
 	const [urlState, setUrlState] = useQueryStates(
@@ -59,7 +58,8 @@ export default function MCPLogsPage() {
 			offset: parseAsInteger.withDefault(0),
 			sort_by: parseAsString.withDefault("timestamp"),
 			order: parseAsString.withDefault("desc"),
-			live_enabled: parseAsBoolean.withDefault(true),
+			polling: parseAsBoolean.withDefault(true).withOptions({ clearOnDefault: false }),
+			period: parseAsString.withDefault(hasExplicitTimeRange ? "" : "24h").withOptions({ clearOnDefault: false }),
 			selected_log: parseAsString.withDefault(""),
 		},
 		{
@@ -68,16 +68,102 @@ export default function MCPLogsPage() {
 		},
 	);
 
-	// Derive selectedLog from URL param
-	const selectedLogId = urlState.selected_log || null;
-	const selectedLog = useMemo(
-		() => (selectedLogId ? logs.find((l) => l.id === selectedLogId) ?? null : null),
-		[selectedLogId, logs],
+	// Convert URL state to filters and pagination
+	const filters: MCPToolLogFilters = useMemo(
+		() => ({
+			tool_names: urlState.tool_names,
+			server_labels: urlState.server_labels,
+			status: urlState.status,
+			virtual_key_ids: urlState.virtual_key_ids,
+			content_search: urlState.content_search,
+			start_time: dateUtils.toISOString(urlState.start_time),
+			end_time: dateUtils.toISOString(urlState.end_time),
+		}),
+		[
+			urlState.tool_names,
+			urlState.server_labels,
+			urlState.status,
+			urlState.virtual_key_ids,
+			urlState.content_search,
+			urlState.start_time,
+			urlState.end_time,
+		],
 	);
+
+	const pagination: Pagination = useMemo(
+		() => ({
+			limit: urlState.limit,
+			offset: urlState.offset,
+			sort_by: urlState.sort_by as "timestamp" | "latency",
+			order: urlState.order as "asc" | "desc",
+		}),
+		[urlState.limit, urlState.offset, urlState.sort_by, urlState.order],
+	);
+
+	const polling = urlState.polling;
+	const period = urlState.period;
+
+	// RTK Query hooks with polling
+	const {
+		data: logsData,
+		isLoading: logsIsLoading,
+		isFetching: logsIsFetching,
+		refetch: refetchLogs,
+	} = useGetMCPLogsQuery(
+		{ filters, pagination },
+		{
+			pollingInterval: showEmptyState ? 3000 : polling ? 5000 : 0,
+			refetchOnMountOrArgChange: true,
+			skipPollingIfUnfocused: true,
+		},
+	);
+
+	const {
+		data: statsData,
+		isFetching: statsIsFetching,
+		refetch: refetchStats,
+	} = useGetMCPLogsStatsQuery(
+		{ filters },
+		{ pollingInterval: polling ? 5000 : 0, refetchOnMountOrArgChange: true, skipPollingIfUnfocused: true },
+	);
+
+	const logs = logsData?.logs ?? [];
+	const totalItems = logsData?.stats?.total_executions ?? 0;
+	const stats = statsData ?? null;
+
+	// showEmptyState effect — only set once on first data, then transition out
+	useEffect(() => {
+		if (!logsData) return;
+		if (!hasCheckedEmptyState.current) {
+			setShowEmptyState(!logsData.has_logs);
+			hasCheckedEmptyState.current = true;
+		} else if (showEmptyState && logsData.has_logs) {
+			setShowEmptyState(false);
+		}
+	}, [logsData, showEmptyState]);
+
+	// Freshen period timestamps on mount
+	useEffect(() => {
+		if (urlState.period) {
+			const { from, to } = getRangeForPeriod(urlState.period);
+			const freshEnd = Math.floor(to.getTime() / 1000);
+			if (Math.abs(urlState.end_time - freshEnd) > 60) {
+				setUrlState({ start_time: Math.floor(from.getTime() / 1000), end_time: freshEnd }, { history: "replace" });
+			}
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
 
 	// Refresh time range defaults on page focus/visibility
 	useEffect(() => {
 		const refreshDefaultsIfStale = () => {
+			// If there's a period set, update timestamps to keep the window fresh
+			if (urlState.period) {
+				const { from, to } = getRangeForPeriod(urlState.period);
+				setUrlState({ start_time: Math.floor(from.getTime() / 1000), end_time: Math.floor(to.getTime() / 1000) }, { history: "replace" });
+				return;
+			}
+
 			// Skip refresh if user has manually modified the time range
 			if (userModifiedTimeRange.current) {
 				return;
@@ -86,20 +172,16 @@ export default function MCPLogsPage() {
 			// Check if current time range matches the initial defaults (within tolerance)
 			const startTimeDiff = Math.abs(urlState.start_time - initialDefaults.current.startTime);
 			const endTimeDiff = Math.abs(urlState.end_time - initialDefaults.current.endTime);
-			const tolerance = 5; // 5 seconds tolerance for slight timing differences
+			const tolerance = 5;
 
-			// Only refresh if current values match the initial defaults
-			// This preserves shared URLs with custom time ranges
 			if (startTimeDiff <= tolerance && endTimeDiff <= tolerance) {
 				const defaults = getDefaultTimeRange();
 				const currentEndDiff = Math.abs(urlState.end_time - defaults.endTime);
-				// If end time is more than 5 minutes old, refresh both
 				if (currentEndDiff > 300) {
 					setUrlState({
 						start_time: defaults.startTime,
 						end_time: defaults.endTime,
-					});
-					// Update baseline so subsequent focus events compare against refreshed defaults
+					}, { history: "replace" });
 					initialDefaults.current.startTime = defaults.startTime;
 					initialDefaults.current.endTime = defaults.endTime;
 				}
@@ -122,49 +204,20 @@ export default function MCPLogsPage() {
 			document.removeEventListener("visibilitychange", handleVisibilityChange);
 			window.removeEventListener("focus", handleFocus);
 		};
-	}, [urlState.start_time, urlState.end_time, setUrlState]);
+	}, [urlState.start_time, urlState.end_time, urlState.period, setUrlState]);
 
-	// Convert URL state to filters and pagination
-	const filters: MCPToolLogFilters = useMemo(
-		() => ({
-			tool_names: urlState.tool_names,
-			server_labels: urlState.server_labels,
-			status: urlState.status,
-			virtual_key_ids: urlState.virtual_key_ids,
-			content_search: urlState.content_search,
-			start_time: dateUtils.toISOString(urlState.start_time),
-			end_time: dateUtils.toISOString(urlState.end_time),
-		}),
-		// Only re-derive filters when filter-related URL params change (not pagination)
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[
-			urlState.tool_names, urlState.server_labels, urlState.status,
-			urlState.virtual_key_ids, urlState.content_search,
-			urlState.start_time, urlState.end_time,
-		],
-	);
-
-	const pagination: Pagination = useMemo(
-		() => ({
-			limit: urlState.limit,
-			offset: urlState.offset,
-			sort_by: urlState.sort_by as "timestamp" | "latency",
-			order: urlState.order as "asc" | "desc",
-		}),
-		[urlState.limit, urlState.offset, urlState.sort_by, urlState.order],
-	);
-
-	const liveEnabled = urlState.live_enabled;
+	// Derive selectedLog from URL param
+	const selectedLogId = urlState.selected_log || null;
+	const selectedLog = useMemo(() => (selectedLogId ? (logs.find((l) => l.id === selectedLogId) ?? null) : null), [selectedLogId, logs]);
 
 	// Helper to update filters in URL
 	const setFilters = useCallback(
 		(newFilters: MCPToolLogFilters) => {
-			// Mark time range as user-modified if start_time or end_time is being set
-			if (newFilters.start_time !== undefined || newFilters.end_time !== undefined) {
-				userModifiedTimeRange.current = true;
-			}
+			const timeChanged = newFilters.start_time !== filters.start_time || newFilters.end_time !== filters.end_time;
+			if (timeChanged) userModifiedTimeRange.current = true;
 
 			setUrlState({
+				...(timeChanged && { period: "" }),
 				tool_names: newFilters.tool_names || [],
 				server_labels: newFilters.server_labels || [],
 				status: newFilters.status || [],
@@ -175,7 +228,7 @@ export default function MCPLogsPage() {
 				offset: 0,
 			});
 		},
-		[setUrlState],
+		[setUrlState, filters],
 	);
 
 	// Helper to update pagination in URL
@@ -193,267 +246,85 @@ export default function MCPLogsPage() {
 
 	const handleDelete = useCallback(
 		async (log: MCPToolLogEntry) => {
-			// Guard against unauthorized delete attempts
 			if (!hasDeleteAccess) {
 				throw new Error("No delete access");
 			}
 
 			try {
 				await deleteLogs({ ids: [log.id] }).unwrap();
-				setLogs((prevLogs) => prevLogs.filter((l) => l.id !== log.id));
-				setTotalItems((prev) => prev - 1);
 				if (urlState.selected_log === log.id) {
 					setUrlState({ selected_log: "" });
 				}
+				refetchLogs();
 			} catch (err) {
 				const errorMessage = getErrorMessage(err);
 				setError(errorMessage);
 				throw new Error(errorMessage);
 			}
 		},
-		[deleteLogs, hasDeleteAccess, urlState.selected_log, setUrlState],
+		[deleteLogs, hasDeleteAccess, urlState.selected_log, setUrlState, refetchLogs],
 	);
 
-	// Ref to track latest state for WebSocket callbacks
-	const latest = useRef({ logs, filters, pagination, showEmptyState, liveEnabled });
-	useEffect(() => {
-		latest.current = { logs, filters, pagination, showEmptyState, liveEnabled };
-	}, [logs, filters, pagination, showEmptyState, liveEnabled]);
-
-	// Helper to check if a log matches current filters
-	const matchesFilters = (log: MCPToolLogEntry, filters: MCPToolLogFilters, applyTimeFilters = true): boolean => {
-		if (filters.tool_names?.length && !filters.tool_names.includes(log.tool_name)) {
-			return false;
+	const handleRefresh = useCallback(() => {
+		if (period) {
+			const { from, to } = getRangeForPeriod(period);
+			setUrlState({
+				start_time: Math.floor(from.getTime() / 1000),
+				end_time: Math.floor(to.getTime() / 1000),
+			});
+		} else {
+			refetchLogs();
+			refetchStats();
 		}
-		if (filters.server_labels?.length && (!log.server_label || !filters.server_labels.includes(log.server_label))) {
-			return false;
-		}
-		if (filters.status?.length && !filters.status.includes(log.status)) {
-			return false;
-		}
-		if (filters.virtual_key_ids?.length && (!log.virtual_key_id || !filters.virtual_key_ids.includes(log.virtual_key_id))) {
-			return false;
-		}
-		if (filters.start_time && new Date(log.timestamp) < new Date(filters.start_time)) {
-			return false;
-		}
-		if (applyTimeFilters && filters.end_time && new Date(log.timestamp) > new Date(filters.end_time)) {
-			return false;
-		}
-		return true;
-	};
+	}, [period, setUrlState, refetchLogs, refetchStats]);
 
-	// Handle WebSocket log messages
-	const handleMCPLogMessage = useCallback((log: MCPToolLogEntry, operation: "create" | "update") => {
-		const { logs, filters, pagination, showEmptyState, liveEnabled } = latest.current;
-
-		// Exit empty state if we now have logs
-		if (showEmptyState) {
-			setShowEmptyState(false);
-		}
-
-		if (operation === "create") {
-			// Only prepend new log if on first page and sorted by timestamp desc
-			if (pagination.offset === 0 && pagination.sort_by === "timestamp" && pagination.order === "desc") {
-				if (!matchesFilters(log, filters, !liveEnabled)) {
-					return;
-				}
-
-				setLogs((prevLogs: MCPToolLogEntry[]) => {
-					// Prevent duplicates
-					if (prevLogs.some((existingLog) => existingLog.id === log.id)) {
-						return prevLogs;
-					}
-
-					const updatedLogs = [log, ...prevLogs];
-					if (updatedLogs.length > pagination.limit) {
-						updatedLogs.pop();
-					}
-					return updatedLogs;
-				});
-
-	
-				setTotalItems((prev: number) => prev + 1);
-			}
-		} else if (operation === "update") {
-			const logExists = logs.some((existingLog) => existingLog.id === log.id);
-
-			if (!logExists) {
-				// Fallback: if log doesn't exist, treat as create
-				if (pagination.offset === 0 && pagination.sort_by === "timestamp" && pagination.order === "desc") {
-					if (matchesFilters(log, filters, !liveEnabled)) {
-						setLogs((prevLogs: MCPToolLogEntry[]) => {
-							if (prevLogs.some((existingLog) => existingLog.id === log.id)) {
-								return prevLogs.map((existingLog) => (existingLog.id === log.id ? log : existingLog));
-							}
-
-							const updatedLogs = [log, ...prevLogs];
-							if (updatedLogs.length > pagination.limit) {
-								updatedLogs.pop();
-							}
-							return updatedLogs;
-						});
-					}
-				}
-			} else {
-				// Update existing log
-				setLogs((prevLogs: MCPToolLogEntry[]) => {
-					return prevLogs.map((existingLog) => (existingLog.id === log.id ? log : existingLog));
-				});
-
-	
-				// Update stats for completed requests
-				if (log.status === "success" || log.status === "error") {
-					setStats((prevStats) => {
-						if (!prevStats) return prevStats;
-
-						const newStats = { ...prevStats };
-						const completed_executions = prevStats.total_executions + 1;
-						newStats.total_executions = completed_executions;
-
-						// Update success rate
-						const successCount = (prevStats.success_rate / 100) * prevStats.total_executions;
-						const newSuccessCount = log.status === "success" ? successCount + 1 : successCount;
-						newStats.success_rate = (newSuccessCount / completed_executions) * 100;
-
-						// Update average latency
-						if (log.latency) {
-							const totalLatency = prevStats.average_latency * prevStats.total_executions;
-							newStats.average_latency = (totalLatency + log.latency) / completed_executions;
-						}
-
-						// Update total cost
-						newStats.total_cost = (Number(newStats.total_cost) || 0) + Number(log.cost ?? 0);
-
-						return newStats;
-					});
-				}
-			}
-		}
-	}, []);
-
-	const { isConnected: isSocketConnected, subscribe } = useWebSocket();
-
-	// Subscribe to MCP log messages - only when live updates are enabled
-	useEffect(() => {
-		if (!liveEnabled) {
-			return;
-		}
-
-		const unsubscribe = subscribe("mcp_log", (data) => {
-			const { payload, operation } = data;
-			handleMCPLogMessage(payload, operation);
-		});
-
-		return unsubscribe;
-	}, [handleMCPLogMessage, subscribe, liveEnabled]);
-
-	// Fetch logs
-	const fetchLogs = useCallback(async () => {
-		setFetchingLogs(true);
-		setError(null);
-		try {
-			const result = await triggerGetLogs({ filters, pagination }).unwrap();
-			setLogs(result.logs || []);
-			setTotalItems(result.stats?.total_executions || 0);
-
-			if (initialLoading) {
-				setShowEmptyState(result.has_logs === false);
-			}
-		} catch (err) {
-			setError(getErrorMessage(err));
-			setLogs([]);
-			setTotalItems(0);
-			setShowEmptyState(true);
-		} finally {
-			setFetchingLogs(false);
-		}
-	}, [filters, pagination, triggerGetLogs, initialLoading]);
-
-	const fetchStats = useCallback(async () => {
-		setFetchingStats(true);
-		try {
-			const result = await triggerGetStats({ filters }).unwrap();
-			setStats(result);
-		} catch (err) {
-			console.error("Failed to fetch stats:", err);
-		} finally {
-			setFetchingStats(false);
-		}
-	}, [filters, triggerGetStats]);
-
-	// Helper to toggle live updates
-	const handleLiveToggle = useCallback(
+	const handlePollToggle = useCallback(
 		(enabled: boolean) => {
-			setUrlState({ live_enabled: enabled });
-			// When re-enabling, refetch logs to get latest data
+			setUrlState({ polling: enabled });
 			if (enabled) {
-				fetchLogs();
+				handleRefresh();
 			}
 		},
-		[setUrlState, fetchLogs],
+		[setUrlState, handleRefresh],
 	);
 
-	// Initial load
-	useEffect(() => {
-		const initialLoad = async () => {
-			await fetchLogs();
-			fetchStats();
-			setInitialLoading(false);
-		};
-		initialLoad();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
-
-	// Fetch logs when filters or pagination change
-	useEffect(() => {
-		if (!initialLoading) {
-			fetchLogs();
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [filters, pagination, initialLoading]);
-
-	// Fetch stats when filters change
-	useEffect(() => {
-		if (!initialLoading) {
-			fetchStats();
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [filters, initialLoading]);
+	const handlePeriodChange = useCallback(
+		(p: string, from: Date, to: Date) => {
+			setUrlState({ period: p, start_time: Math.floor(from.getTime() / 1000), end_time: Math.floor(to.getTime() / 1000), offset: 0 });
+		},
+		[setUrlState],
+	);
 
 	const statCards = useMemo(
 		() => [
 			{
 				title: "Total Executions",
-				value: fetchingStats ? <Skeleton className="h-8 w-20" /> : stats?.total_executions.toLocaleString() || "-",
+				value: statsIsFetching ? <Skeleton className="h-8 w-20" /> : stats?.total_executions.toLocaleString() || "-",
 				icon: <Hash className="size-4" />,
 			},
 			{
 				title: "Success Rate",
-				value: fetchingStats ? <Skeleton className="h-8 w-16" /> : stats ? `${stats.success_rate.toFixed(2)}%` : "-",
+				value: statsIsFetching ? <Skeleton className="h-8 w-16" /> : stats ? `${stats.success_rate.toFixed(2)}%` : "-",
 				icon: <CheckCircle className="size-4" />,
 			},
 			{
 				title: "Avg Latency",
-				value: fetchingStats ? <Skeleton className="h-8 w-20" /> : stats ? `${stats.average_latency.toFixed(2)}ms` : "-",
+				value: statsIsFetching ? <Skeleton className="h-8 w-20" /> : stats ? `${stats.average_latency.toFixed(2)}ms` : "-",
 				icon: <Clock className="size-4" />,
 			},
 			{
 				title: "Total Cost",
-				value: fetchingStats ? <Skeleton className="h-8 w-20" /> : stats ? `$${(stats.total_cost ?? 0).toFixed(4)}` : "-",
+				value: statsIsFetching ? <Skeleton className="h-8 w-20" /> : stats ? `$${(stats.total_cost ?? 0).toFixed(4)}` : "-",
 				icon: <DollarSign className="size-4" />,
 			},
 		],
-		[stats, fetchingStats],
+		[stats, statsIsFetching],
 	);
 
 	const columns = useMemo(() => createMCPColumns(handleDelete, hasDeleteAccess), [handleDelete, hasDeleteAccess]);
 
 	// Navigation for log detail sheet
-	const selectedLogIndex = useMemo(
-		() => (selectedLogId ? logs.findIndex((l) => l.id === selectedLogId) : -1),
-		[selectedLogId, logs],
-	);
+	const selectedLogIndex = useMemo(() => (selectedLogId ? logs.findIndex((l) => l.id === selectedLogId) : -1), [selectedLogId, logs]);
 
 	const handleLogNavigate = useCallback(
 		(direction: "prev" | "next") => {
@@ -504,23 +375,10 @@ export default function MCPLogsPage() {
 
 	return (
 		<div className="dark:bg-card bg-white">
-			{initialLoading ? (
+			{logsIsLoading && !logsData ? (
 				<FullPageLoader />
 			) : showEmptyState ? (
-				<MCPEmptyState
-					error={error}
-					statusIndicator={
-						isSocketConnected && (
-							<div className="inline-flex items-center rounded-full border border-green-200 bg-green-50 px-3 py-1 text-xs font-medium text-green-700 sm:px-4 sm:text-sm">
-								<span className="relative mr-2 flex h-2 w-2 sm:mr-3">
-									<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75"></span>
-									<span className="relative inline-flex h-2 w-2 rounded-full bg-green-600"></span>
-								</span>
-								<span>Listening for tool executions...</span>
-							</div>
-						)
-					}
-				/>
+				<MCPEmptyState error={error} />
 			) : (
 				<div className="mx-auto w-full space-y-6">
 					<div className="space-y-6">
@@ -529,7 +387,7 @@ export default function MCPLogsPage() {
 							{statCards.map((card) => (
 								<Card key={card.title} className="py-4 shadow-none">
 									<CardContent className="flex items-center justify-between px-4">
-										<div className="min-w-0 w-full">
+										<div className="w-full min-w-0">
 											<div className="text-muted-foreground text-xs">{card.title}</div>
 											<div className="truncate font-mono text-xl font-medium sm:text-2xl">{card.value}</div>
 										</div>
@@ -550,7 +408,7 @@ export default function MCPLogsPage() {
 							columns={columns}
 							data={logs}
 							totalItems={totalItems}
-							loading={fetchingLogs}
+							loading={logsIsFetching}
 							filters={filters}
 							pagination={pagination}
 							onFiltersChange={setFilters}
@@ -559,11 +417,11 @@ export default function MCPLogsPage() {
 								if (columnId === "actions") return;
 								setUrlState({ selected_log: row.id }, { history: "replace" });
 							}}
-							isSocketConnected={isSocketConnected}
-							liveEnabled={liveEnabled}
-							onLiveToggle={handleLiveToggle}
-							fetchLogs={fetchLogs}
-							fetchStats={fetchStats}
+							polling={polling}
+							onPollToggle={handlePollToggle}
+							onRefresh={handleRefresh}
+							period={period}
+							onPeriodChange={handlePeriodChange}
 						/>
 					</div>
 

--- a/ui/app/workspace/mcp-logs/views/filters.tsx
+++ b/ui/app/workspace/mcp-logs/views/filters.tsx
@@ -7,17 +7,21 @@ import { Statuses } from "@/lib/constants/logs";
 import { useGetMCPLogsFilterDataQuery } from "@/lib/store";
 import type { MCPToolLogFilters } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import { Check, FilterIcon, Pause, Play, Search } from "lucide-react";
+import { getRangeForPeriod, TIME_PERIODS } from "@/lib/utils/timeRange";
+import { Check, FilterIcon, Radio, RefreshCw, Search } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 interface MCPLogFiltersProps {
 	filters: MCPToolLogFilters;
 	onFiltersChange: (filters: MCPToolLogFilters) => void;
-	liveEnabled: boolean;
-	onLiveToggle: (enabled: boolean) => void;
+	polling: boolean;
+	onPollToggle: (enabled: boolean) => void;
+	onRefresh: () => void;
+	period: string;
+	onPeriodChange: (period: string, from: Date, to: Date) => void;
 }
 
-export function MCPLogFilters({ filters, onFiltersChange, liveEnabled, onLiveToggle }: MCPLogFiltersProps) {
+export function MCPLogFilters({ filters, onFiltersChange, polling, onPollToggle, onRefresh, period, onPeriodChange }: MCPLogFiltersProps) {
 	const [openFiltersPopover, setOpenFiltersPopover] = useState(false);
 	const [localSearch, setLocalSearch] = useState(filters.content_search || "");
 	const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
@@ -150,18 +154,13 @@ export function MCPLogFilters({ filters, onFiltersChange, liveEnabled, onLiveTog
 
 	return (
 		<div className="flex items-center justify-between space-x-2">
-			<Button variant={"outline"} size="sm" className="h-7.5" onClick={() => onLiveToggle(!liveEnabled)}>
-				{liveEnabled ? (
-					<>
-						<Pause className="h-4 w-4" />
-						Live updates
-					</>
-				) : (
-					<>
-						<Play className="h-4 w-4" />
-						Live updates
-					</>
-				)}
+			<Button variant="outline" size="sm" className="h-7.5" onClick={onRefresh}>
+				<RefreshCw className="h-4 w-4" />
+				Refresh
+			</Button>
+			<Button variant={polling ? "default" : "outline"} size="sm" className="h-7.5" onClick={() => onPollToggle(!polling)}>
+				{polling ? <Radio className="h-4 w-4 animate-pulse" /> : <Radio className="h-4 w-4" />}
+				Live
 			</Button>
 			<div className="border-input flex h-7.5 flex-1 items-center gap-2 rounded-sm border">
 				<Search className="mr-0.5 ml-2 size-4" />
@@ -179,14 +178,20 @@ export function MCPLogFilters({ filters, onFiltersChange, liveEnabled, onLiveTog
 					from: startTime,
 					to: endTime,
 				}}
+				predefinedPeriod={period || undefined}
+				preDefinedPeriods={[...TIME_PERIODS]}
+				onPredefinedPeriodChange={(periodValue) => {
+					if (!periodValue) return;
+					const { from, to } = getRangeForPeriod(periodValue);
+					setStartTime(from);
+					setEndTime(to);
+					onPeriodChange(periodValue, from, to);
+				}}
 				onDateTimeUpdate={(p) => {
 					setStartTime(p.from);
 					setEndTime(p.to);
-					onFiltersChange({
-						...filters,
-						start_time: p.from?.toISOString(),
-						end_time: p.to?.toISOString(),
-					});
+					onPeriodChange("", p.from ?? new Date(), p.to ?? new Date());
+					onFiltersChange({ ...filters, start_time: p.from?.toISOString(), end_time: p.to?.toISOString() });
 				}}
 			/>
 			<Popover open={openFiltersPopover} onOpenChange={setOpenFiltersPopover}>

--- a/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
@@ -1,287 +1,319 @@
 "use client";
 
+import {
+  buildPinStyle,
+  ColumnConfigDropdown,
+  DraggableColumnHeader,
+  PIN_SHADOW_LEFT,
+  PIN_SHADOW_RIGHT,
+  useColumnConfig,
+  useHeaderCellRefs,
+  usePinOffsets,
+} from "@/components/table";
 import { Button } from "@/components/ui/button";
-import { buildPinStyle, ColumnConfigDropdown, DraggableColumnHeader, PIN_SHADOW_LEFT, PIN_SHADOW_RIGHT, useColumnConfig, useHeaderCellRefs, usePinOffsets } from "@/components/table";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import type { MCPToolLogEntry, MCPToolLogFilters, Pagination } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import { ColumnDef, flexRender, getCoreRowModel, SortingState, useReactTable } from "@tanstack/react-table";
-import { ChevronLeft, ChevronRight, Pause, RefreshCw, X } from "lucide-react";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { MCPLogFilters } from "./filters";
 
 const COLUMN_LABELS: Record<string, string> = {
-	timestamp: "Time",
-	tool_name: "Tool Name",
-	server_label: "Server",
-	latency: "Latency",
-	cost: "Cost",
+  timestamp: "Time",
+  tool_name: "Tool Name",
+  server_label: "Server",
+  latency: "Latency",
+  cost: "Cost",
 };
 
 interface DataTableProps {
-	columns: ColumnDef<MCPToolLogEntry>[];
-	data: MCPToolLogEntry[];
-	totalItems: number;
-	loading?: boolean;
-	filters: MCPToolLogFilters;
-	pagination: Pagination;
-	onFiltersChange: (filters: MCPToolLogFilters) => void;
-	onPaginationChange: (pagination: Pagination) => void;
-	onRowClick?: (log: MCPToolLogEntry, columnId: string) => void;
-	isSocketConnected: boolean;
-	liveEnabled: boolean;
-	onLiveToggle: (enabled: boolean) => void;
-	fetchLogs: () => Promise<void>;
-	fetchStats: () => Promise<void>;
+  columns: ColumnDef<MCPToolLogEntry>[];
+  data: MCPToolLogEntry[];
+  totalItems: number;
+  loading?: boolean;
+  filters: MCPToolLogFilters;
+  pagination: Pagination;
+  onFiltersChange: (filters: MCPToolLogFilters) => void;
+  onPaginationChange: (pagination: Pagination) => void;
+  onRowClick?: (log: MCPToolLogEntry, columnId: string) => void;
+  polling: boolean;
+  onPollToggle: (enabled: boolean) => void;
+  onRefresh: () => void;
+  period: string;
+  onPeriodChange: (period: string, from: Date, to: Date) => void;
 }
 
 export function MCPLogsDataTable({
-	columns,
-	data,
-	totalItems,
-	loading = false,
-	filters,
-	pagination,
-	onFiltersChange,
-	onPaginationChange,
-	onRowClick,
-	isSocketConnected,
-	liveEnabled,
-	onLiveToggle,
+  columns,
+  data,
+  totalItems,
+  loading = false,
+  filters,
+  pagination,
+  onFiltersChange,
+  onPaginationChange,
+  onRowClick,
+  polling,
+  onPollToggle,
+  onRefresh,
+  period,
+  onPeriodChange,
 }: DataTableProps) {
-	const [sorting, setSorting] = useState<SortingState>([{ id: pagination.sort_by, desc: pagination.order === "desc" }]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: pagination.sort_by, desc: pagination.order === "desc" },
+  ]);
 
-	// Derive all column IDs from column definitions
-	const columnIds = useMemo(
-		() => columns.map((col) => ("id" in col && col.id ? col.id : "accessorKey" in col ? String(col.accessorKey) : "")).filter(Boolean),
-		[columns],
-	);
+  // Derive all column IDs from column definitions
+  const columnIds = useMemo(
+    () =>
+      columns
+        .map((col) =>
+          "id" in col && col.id ? col.id : "accessorKey" in col ? String(col.accessorKey) : "",
+        )
+        .filter(Boolean),
+    [columns],
+  );
 
-	const fixedColumnIds = useMemo(() => new Set<string>([]), []);
+  const fixedColumnIds = useMemo(() => new Set<string>([]), []);
 
-	// Column config: order, visibility, pinning — persisted in URL
-	const { entries, columnOrder, columnVisibility, columnPinning, toggleVisibility, togglePin, reorder, reset } = useColumnConfig({
-		columnIds,
-		paramName: "mcp_cols",
-		fixedColumns: { left: [], right: [] },
-	});
+  // Column config: order, visibility, pinning — persisted in URL
+  const {
+    entries,
+    columnOrder,
+    columnVisibility,
+    columnPinning,
+    toggleVisibility,
+    togglePin,
+    reorder,
+    reset,
+  } = useColumnConfig({
+    columnIds,
+    paramName: "mcp_cols",
+    fixedColumns: { left: [], right: [] },
+  });
 
-	// Measure actual header cell widths for pixel-perfect pin offsets
-	const { headerCellRefs, setHeaderCellRef } = useHeaderCellRefs();
-	const pinOffsets = usePinOffsets(headerCellRefs, columnPinning);
+  // Measure actual header cell widths for pixel-perfect pin offsets
+  const { headerCellRefs, setHeaderCellRef } = useHeaderCellRefs();
+  const pinOffsets = usePinOffsets(headerCellRefs, columnPinning);
 
-	// Shadow on the edge of pinned groups
-	const lastLeftPinId = columnPinning.left?.at(-1);
-	const firstRightPinId = columnPinning.right?.at(0);
+  // Shadow on the edge of pinned groups
+  const lastLeftPinId = columnPinning.left?.at(-1);
+  const firstRightPinId = columnPinning.right?.at(0);
 
-	// Handle native drag-and-drop reorder
-	const handleColumnDrop = useCallback(
-		(draggedId: string, targetId: string) => {
-			const newEntries = [...entries];
-			const draggedIdx = newEntries.findIndex((e) => e.id === draggedId);
-			const targetIdx = newEntries.findIndex((e) => e.id === targetId);
-			if (draggedIdx === -1 || targetIdx === -1) return;
-			const [moved] = newEntries.splice(draggedIdx, 1);
-			newEntries.splice(targetIdx, 0, moved);
-			reorder(newEntries);
-		},
-		[entries, reorder],
-	);
+  // Handle native drag-and-drop reorder
+  const handleColumnDrop = useCallback(
+    (draggedId: string, targetId: string) => {
+      const newEntries = [...entries];
+      const draggedIdx = newEntries.findIndex((e) => e.id === draggedId);
+      const targetIdx = newEntries.findIndex((e) => e.id === targetId);
+      if (draggedIdx === -1 || targetIdx === -1) return;
+      const [moved] = newEntries.splice(draggedIdx, 1);
+      newEntries.splice(targetIdx, 0, moved);
+      reorder(newEntries);
+    },
+    [entries, reorder],
+  );
 
-	const handleSortingChange = (updaterOrValue: SortingState | ((old: SortingState) => SortingState)) => {
-		const newSorting = typeof updaterOrValue === "function" ? updaterOrValue(sorting) : updaterOrValue;
-		setSorting(newSorting);
-		if (newSorting.length > 0) {
-			const { id, desc } = newSorting[0];
-			onPaginationChange({
-				...pagination,
-				sort_by: id as "timestamp" | "latency",
-				order: desc ? "desc" : "asc",
-			});
-		}
-	};
+  const handleSortingChange = (
+    updaterOrValue: SortingState | ((old: SortingState) => SortingState),
+  ) => {
+    const newSorting =
+      typeof updaterOrValue === "function" ? updaterOrValue(sorting) : updaterOrValue;
+    setSorting(newSorting);
+    if (newSorting.length > 0) {
+      const { id, desc } = newSorting[0];
+      onPaginationChange({
+        ...pagination,
+        sort_by: id as "timestamp" | "latency",
+        order: desc ? "desc" : "asc",
+      });
+    }
+  };
 
-	const table = useReactTable({
-		data,
-		columns,
-		getCoreRowModel: getCoreRowModel(),
-		manualPagination: true,
-		manualSorting: true,
-		manualFiltering: true,
-		pageCount: Math.ceil(totalItems / pagination.limit),
-		state: {
-			sorting,
-			columnOrder,
-			columnVisibility,
-			columnPinning,
-		},
-		onSortingChange: handleSortingChange,
-	});
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+    manualSorting: true,
+    manualFiltering: true,
+    pageCount: Math.ceil(totalItems / pagination.limit),
+    state: {
+      sorting,
+      columnOrder,
+      columnVisibility,
+      columnPinning,
+    },
+    onSortingChange: handleSortingChange,
+  });
 
-	const currentPage = Math.floor(pagination.offset / pagination.limit) + 1;
-	const totalPages = Math.ceil(totalItems / pagination.limit);
-	const startItem = pagination.offset + 1;
-	const endItem = Math.min(pagination.offset + pagination.limit, totalItems);
+  const currentPage = Math.floor(pagination.offset / pagination.limit) + 1;
+  const totalPages = Math.ceil(totalItems / pagination.limit);
+  const startItem = pagination.offset + 1;
+  const endItem = Math.min(pagination.offset + pagination.limit, totalItems);
 
-	// Display values that handle the case when totalItems is 0
-	const startItemDisplay = totalItems === 0 ? 0 : startItem;
-	const endItemDisplay = totalItems === 0 ? 0 : endItem;
+  // Display values that handle the case when totalItems is 0
+  const startItemDisplay = totalItems === 0 ? 0 : startItem;
+  const endItemDisplay = totalItems === 0 ? 0 : endItem;
 
-	const goToPage = (page: number) => {
-		const newOffset = (page - 1) * pagination.limit;
-		onPaginationChange({
-			...pagination,
-			offset: newOffset,
-		});
-	};
+  const goToPage = (page: number) => {
+    const newOffset = (page - 1) * pagination.limit;
+    onPaginationChange({
+      ...pagination,
+      offset: newOffset,
+    });
+  };
 
-	return (
-		<div className="space-y-2">
-			<div className="flex items-center gap-2">
-				<div className="flex-1">
-					<MCPLogFilters filters={filters} onFiltersChange={onFiltersChange} liveEnabled={liveEnabled} onLiveToggle={onLiveToggle} />
-				</div>
-				<ColumnConfigDropdown
-					entries={entries}
-					labels={COLUMN_LABELS}
-					onToggleVisibility={toggleVisibility}
-					onReset={reset}
-				/>
-			</div>
-			<div className="max-h-[calc(100vh-16.5rem)] rounded-sm border">
-				<Table containerClassName="max-h-[calc(100vh-16.5rem)]">
-					<thead className={cn("sticky top-0 z-10 bg-[#f9f9f9] dark:bg-[#27272a] px-2 [&_tr]:border-b")}>
-						{table.getHeaderGroups().map((headerGroup) => (
-							<tr
-								key={headerGroup.id}
-								className="hover:bg-muted/50 dark:hover:bg-muted/75 data-[state=selected]:bg-muted border-b transition-colors"
-							>
-								{headerGroup.headers.map((header) => (
-									<DraggableColumnHeader
-										key={header.id}
-										header={header}
-										isConfigurable={!fixedColumnIds.has(header.column.id)}
-										pinStyle={buildPinStyle(header.column, pinOffsets)}
-										pinnedHeaderClassName="bg-[#f9f9f9] dark:bg-[#27272a]"
-										className={cn(
-											header.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
-											header.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
-										)}
-										onHide={toggleVisibility}
-										onPin={togglePin}
-										onDrop={handleColumnDrop}
-										cellRef={setHeaderCellRef(header.column.id)}
-									/>
-								))}
-							</tr>
-						))}
-					</thead>
-					<TableBody>
-						{loading ? (
-							<TableRow>
-								<TableCell colSpan={columns.length} className="h-24 text-center">
-									<div className="flex items-center justify-center gap-2">
-										<RefreshCw className="h-4 w-4 animate-spin" />
-										Loading logs...
-									</div>
-								</TableCell>
-							</TableRow>
-						) : (
-							<>
-								<TableRow className="hover:bg-transparent">
-									<TableCell colSpan={columns.length} className="h-12 text-center">
-										<div className="flex items-center justify-center gap-2">
-											{!isSocketConnected ? (
-												<>
-													<X className="h-4 w-4" />
-													Not connected to socket, please refresh the page.
-												</>
-											) : liveEnabled ? (
-												<>
-													<RefreshCw className="h-4 w-4 animate-spin" />
-													Listening for logs...
-												</>
-											) : (
-												<>
-													<Pause className="h-4 w-4" />
-													Live updates paused
-												</>
-											)}
-										</div>
-									</TableCell>
-								</TableRow>
-								{table.getRowModel().rows.length ? (
-									table.getRowModel().rows.map((row) => (
-										<TableRow key={row.id} className="hover:bg-muted/50 h-12 cursor-pointer group/table-row">
-											{row.getVisibleCells().map((cell) => {
-												const pinned = cell.column.getIsPinned();
-												return (
-													<TableCell
-														onClick={() => onRowClick?.(row.original, cell.column.id)}
-														key={cell.id}
-														style={buildPinStyle(cell.column, pinOffsets)}
-														className={cn(
-															pinned && "bg-card",
-															cell.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
-															cell.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
-															"group-hover/table-row:bg-[#f7f7f7] dark:group-hover/table-row:bg-[#232327]",
-														)}
-													>
-														{flexRender(cell.column.columnDef.cell, cell.getContext())}
-													</TableCell>
-												);
-											})}
-										</TableRow>
-									))
-								) : (
-									<TableRow>
-										<TableCell colSpan={columns.length} className="h-24 text-center">
-											No results found. Try adjusting your filters and/or time range.
-										</TableCell>
-									</TableRow>
-								)}
-							</>
-						)}
-					</TableBody>
-				</Table>
-			</div>
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <div className="flex-1">
+          <MCPLogFilters
+            filters={filters}
+            onFiltersChange={onFiltersChange}
+            polling={polling}
+            onPollToggle={onPollToggle}
+            onRefresh={onRefresh}
+            period={period}
+            onPeriodChange={onPeriodChange}
+          />
+        </div>
+        <ColumnConfigDropdown
+          entries={entries}
+          labels={COLUMN_LABELS}
+          onToggleVisibility={toggleVisibility}
+          onReset={reset}
+        />
+      </div>
+      <div className="max-h-[calc(100vh-16.5rem)] rounded-sm border">
+        <Table containerClassName="max-h-[calc(100vh-16.5rem)]">
+          <thead
+            className={cn("sticky top-0 z-10 bg-[#f9f9f9] dark:bg-[#27272a] px-2 [&_tr]:border-b")}
+          >
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr
+                key={headerGroup.id}
+                className="hover:bg-muted/50 dark:hover:bg-muted/75 data-[state=selected]:bg-muted border-b transition-colors"
+              >
+                {headerGroup.headers.map((header) => (
+                  <DraggableColumnHeader
+                    key={header.id}
+                    header={header}
+                    isConfigurable={!fixedColumnIds.has(header.column.id)}
+                    pinStyle={buildPinStyle(header.column, pinOffsets)}
+                    pinnedHeaderClassName="bg-[#f9f9f9] dark:bg-[#27272a]"
+                    className={cn(
+                      header.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
+                      header.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
+                    )}
+                    onHide={toggleVisibility}
+                    onPin={togglePin}
+                    onDrop={handleColumnDrop}
+                    cellRef={setHeaderCellRef(header.column.id)}
+                  />
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <TableBody>
+            <TableRow className="hover:bg-transparent">
+              <TableCell colSpan={columns.length} className="h-12 text-center">
+                <div className="flex items-center justify-center gap-2">
+                  {polling ? (
+                    <>
+                      <RefreshCw className="h-4 w-4 animate-spin" />
+                      Waiting for new MCP logs...
+                    </>
+                  ) : (
+                    <Button variant="ghost" size="sm" onClick={onRefresh} disabled={loading}>
+                      <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+                      Refresh
+                    </Button>
+                  )}
+                </div>
+              </TableCell>
+            </TableRow>
+            {table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  className="hover:bg-muted/50 h-12 cursor-pointer group/table-row"
+                >
+                  {row.getVisibleCells().map((cell) => {
+                    const pinned = cell.column.getIsPinned();
+                    return (
+                      <TableCell
+                        onClick={() => onRowClick?.(row.original, cell.column.id)}
+                        key={cell.id}
+                        style={buildPinStyle(cell.column, pinOffsets)}
+                        className={cn(
+                          pinned && "bg-card",
+                          cell.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
+                          cell.column.id === firstRightPinId && PIN_SHADOW_RIGHT,
+                          "group-hover/table-row:bg-[#f7f7f7] dark:group-hover/table-row:bg-[#232327]",
+                        )}
+                      >
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center">
+                  No results found. Try adjusting your filters and/or time range.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
 
-			{/* Pagination Footer */}
-			<div className="flex items-center justify-between text-xs" data-testid="pagination">
-				<div className="text-muted-foreground flex items-center gap-2">
-					{startItemDisplay.toLocaleString()}-{endItemDisplay.toLocaleString()} of {totalItems.toLocaleString()} entries
-				</div>
+      {/* Pagination Footer */}
+      <div className="flex items-center justify-between text-xs" data-testid="pagination">
+        <div className="text-muted-foreground flex items-center gap-2">
+          {startItemDisplay.toLocaleString()}-{endItemDisplay.toLocaleString()} of{" "}
+          {totalItems.toLocaleString()} entries
+        </div>
 
-				<div className="flex items-center gap-2">
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => goToPage(currentPage - 1)}
-						disabled={currentPage <= 1}
-						data-testid="prev-page"
-						aria-label="Previous page"
-					>
-						<ChevronLeft className="size-3" />
-					</Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => goToPage(currentPage - 1)}
+            disabled={currentPage <= 1}
+            data-testid="prev-page"
+            aria-label="Previous page"
+          >
+            <ChevronLeft className="size-3" />
+          </Button>
 
-					<div className="flex items-center gap-1">
-						<span>Page</span>
-						<span>{currentPage}</span>
-						<span>of {totalPages}</span>
-					</div>
+          <div className="flex items-center gap-1">
+            <span>Page</span>
+            <span>{currentPage}</span>
+            <span>of {totalPages}</span>
+          </div>
 
-					<Button
-						variant="ghost"
-						size="sm"
-						onClick={() => goToPage(currentPage + 1)}
-						disabled={totalPages === 0 || currentPage >= totalPages}
-						data-testid="next-page"
-						aria-label="Next page"
-					>
-						<ChevronRight className="size-3" />
-					</Button>
-				</div>
-			</div>
-		</div>
-	);
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => goToPage(currentPage + 1)}
+            disabled={totalPages === 0 || currentPage >= totalPages}
+            data-testid="next-page"
+            aria-label="Next page"
+          >
+            <ChevronRight className="size-3" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -72,7 +72,7 @@ import moment from "moment";
 import { useTheme } from "next-themes";
 import Image from "next/image";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useCookies } from "react-cookie";
 import { ThemeToggle } from "./themeToggle";
@@ -184,6 +184,7 @@ const SidebarItemView = ({
 	expandSidebar,
 	highlightedUrl,
 	prefetchRoute,
+	buildUrl,
 }: {
 	item: SidebarItem;
 	isActive: boolean;
@@ -197,6 +198,7 @@ const SidebarItemView = ({
 	expandSidebar: () => void;
 	highlightedUrl?: string;
 	prefetchRoute: (url: string) => void;
+	buildUrl: (targetUrl: string) => string;
 }) => {
 	const hasSubItems = "subItems" in item && item.subItems && item.subItems.length > 0;
 	const isAnySubItemActive =
@@ -230,7 +232,7 @@ const SidebarItemView = ({
 			openInNewTab(url);
 			return;
 		}
-		router.push(url);
+		router.push(buildUrl(url));
 	};
 
 	const handleSubItemClick = (subItem: SidebarItem, e?: React.MouseEvent) => {
@@ -239,7 +241,7 @@ const SidebarItemView = ({
 			openInNewTab(url);
 			return;
 		}
-		router.push(url);
+		router.push(buildUrl(url));
 	};
 
 	const isHighlighted = !hasSubItems && highlightedUrl === item.url;
@@ -371,9 +373,12 @@ const compareVersions = (v1: string, v2: string): number => {
 	return 0;
 };
 
+const TIME_AWARE_PATHS = ["/workspace/dashboard", "/workspace/logs", "/workspace/mcp-logs"];
+
 export default function AppSidebar() {
 	const pathname = usePathname();
 	const router = useRouter();
+	const searchParams = useSearchParams();
 	const [mounted, setMounted] = useState(false);
 	const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
 	const [areCardsEmpty, setAreCardsEmpty] = useState(false);
@@ -791,6 +796,26 @@ export default function AppSidebar() {
 		[router],
 	);
 
+	const buildUrl = useCallback(
+		(targetUrl: string): string => {
+			const fromTimeAware = TIME_AWARE_PATHS.some((p) => pathname.startsWith(p));
+			const toTimeAware = TIME_AWARE_PATHS.some((p) => targetUrl.startsWith(p));
+			if (!fromTimeAware || !toTimeAware) return targetUrl;
+
+			const params = new URLSearchParams();
+			const start = searchParams.get("start_time");
+			const end = searchParams.get("end_time");
+			const period = searchParams.get("period");
+			if (start) params.set("start_time", start);
+			if (end) params.set("end_time", end);
+			if (period) params.set("period", period);
+
+			const qs = params.toString();
+			return qs ? `${targetUrl}?${qs}` : targetUrl;
+		},
+		[pathname, searchParams],
+	);
+
 	// Get user info from localStorage (for enterprise SCIM OAuth)
 	const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
 
@@ -905,7 +930,7 @@ export default function AppSidebar() {
 					if (target.isExternal || e.metaKey || e.ctrlKey) {
 						window.open(url, "_blank", "noopener,noreferrer");
 					} else {
-						router.push(url);
+						router.push(buildUrl(url));
 					}
 					setSearchQuery("");
 					setFocusedIndex(-1);
@@ -917,7 +942,7 @@ export default function AppSidebar() {
 				searchInputRef.current?.blur();
 			}
 		},
-		[navigableItems, focusedIndex, router],
+		[navigableItems, focusedIndex, router, buildUrl],
 	);
 
 	// Auto-scroll focused item into view
@@ -1126,6 +1151,7 @@ export default function AppSidebar() {
 									expandSidebar={() => toggleSidebar()}
 									highlightedUrl={highlightedUrl}
 									prefetchRoute={prefetchRoute}
+									buildUrl={buildUrl}
 								/>
 								);
 							})}

--- a/ui/lib/utils/timeRange.ts
+++ b/ui/lib/utils/timeRange.ts
@@ -1,0 +1,39 @@
+export const TIME_PERIODS = [
+	{ label: "Last hour", value: "1h" },
+	{ label: "Last 6 hours", value: "6h" },
+	{ label: "Last 24 hours", value: "24h" },
+	{ label: "Last 7 days", value: "7d" },
+	{ label: "Last 30 days", value: "30d" },
+] as const;
+
+export type TimePeriod = (typeof TIME_PERIODS)[number]["value"];
+
+export function getRangeForPeriod(period: string): { from: Date; to: Date } {
+	const to = new Date();
+	const from = new Date(to.getTime());
+	switch (period) {
+		case "1h":
+			from.setHours(from.getHours() - 1);
+			break;
+		case "6h":
+			from.setHours(from.getHours() - 6);
+			break;
+		case "24h":
+			from.setHours(from.getHours() - 24);
+			break;
+		case "7d":
+			from.setDate(from.getDate() - 7);
+			break;
+		case "30d":
+			from.setDate(from.getDate() - 30);
+			break;
+		default:
+			from.setHours(from.getHours() - 24);
+	}
+	return { from, to };
+}
+
+export function getUnixRangeForPeriod(period: string): { start: number; end: number } {
+	const { from, to } = getRangeForPeriod(period);
+	return { start: Math.floor(from.getTime() / 1000), end: Math.floor(to.getTime() / 1000) };
+}


### PR DESCRIPTION
## Summary

Removes the WebSocket-based real-time log broadcasting mechanism from the HTTP transport layer. Previously, log entries and MCP tool logs were pushed to connected WebSocket clients via callbacks registered on the logger plugin. This coupling between the logger plugin and the WebSocket handler has been removed.

## Changes

- Removed `BroadcastLogUpdate` and `BroadcastMCPLogUpdate` methods from `WebSocketHandler`, which were responsible for trimming and serializing log entries before broadcasting them to clients.
- Removed `NewLogEntryAdded` from the `ServerCallbacks` interface and its implementation on `BifrostHTTPServer`.
- Removed the logger plugin callback registration that wired log events to WebSocket broadcasts during route registration.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

Verify that the server starts without errors and that WebSocket connections still function for non-log broadcast events (e.g., store update notifications via `BroadcastUpdatesToClients`).

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

`NewLogEntryAdded` has been removed from the `ServerCallbacks` interface. Any external implementations of this interface must remove the method. Real-time log streaming to WebSocket clients is no longer supported via this mechanism.

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable