### PR TITLE
chore: restore `onAsyncCheckedChange` for provider key toggle to await update

### DIFF
--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -232,9 +232,9 @@ export default function ModelProviderKeysTableView({ provider, className, header
 												checked={isKeyEnabled}
 												size="md"
 												disabled={!hasUpdateProviderAccess || togglingKeyIds.has(key.id)}
-												onCheckedChange={(checked) => {
+												onAsyncCheckedChange={async (checked) => {
 													setTogglingKeyIds((prev) => new Set(prev).add(key.id));
-													updateProviderKey({
+													await updateProviderKey({
 														provider: provider.name,
 														keyId: key.id,
 														key: { ...key, enabled: checked },


### PR DESCRIPTION
## Summary

Fixes a race condition where the toggle state for provider keys could update before the async `updateProviderKey` call completes, potentially causing inconsistent UI behavior.

## Changes

- Switched from `onCheckedChange` to `onAsyncCheckedChange` on the provider key toggle, and awaited the `updateProviderKey` call so the toggling state is properly held until the update resolves.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the workspace providers page.
2. Toggle a model provider key enabled/disabled.
3. Verify the toggle remains in a loading/disabled state until the API call completes, and that the final state reflects the server response.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable