### PR TITLE
fixes otel conversion from built in trace

### DIFF
--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -81,8 +81,8 @@ func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceS
 			Attributes: p.getResourceAttributes(),
 		},
 		ScopeSpans: []*ScopeSpan{{
-			Scope:  p.getInstrumentationScope(),
-			Spans:  otelSpans,
+			Scope: p.getInstrumentationScope(),
+			Spans: otelSpans,
 		}},
 	}
 }
@@ -210,6 +210,20 @@ func anyToKeyValue(key string, value any) *KeyValue {
 			vals[i] = &AnyValue{Value: &DoubleValue{DoubleValue: n}}
 		}
 		return kvAny(key, arrValue(vals...))
+	case []any:
+		if len(v) == 0 {
+			return nil
+		}
+		vals := make([]*AnyValue, 0, len(v))
+		for _, item := range v {
+			if kv := anyToKeyValue("_", item); kv != nil {
+				vals = append(vals, kv.Value)
+			}
+		}
+		if len(vals) == 0 {
+			return nil
+		}
+		return kvAny(key, arrValue(vals...))
 	case map[string]any:
 		if len(v) == 0 {
 			return nil
@@ -223,8 +237,15 @@ func anyToKeyValue(key string, value any) *KeyValue {
 		}
 		return kvAny(key, listValue(kvList...))
 	default:
-		// For any other type, convert to string
-		return kvStr(key, fmt.Sprintf("%v", v))
+		data, err := schemas.MarshalSorted(v)
+		if err != nil {
+			return kvStr(key, fmt.Sprintf("%v", v))
+		}
+		var generic any
+		if err := schemas.Unmarshal(data, &generic); err != nil {
+			return kvStr(key, string(data))
+		}
+		return anyToKeyValue(key, generic)
 	}
 }
 


### PR DESCRIPTION
## Summary

Improves the OpenTelemetry attribute conversion logic to correctly handle `[]any` (mixed/untyped arrays) and unknown struct types when converting trace data to OTEL resource spans.

## Changes

- Added a `[]any` case in `anyToKeyValue` to handle heterogeneous or untyped arrays, recursively converting each element and skipping nil results
- Replaced the `default` fallback in `anyToKeyValue` — instead of immediately stringifying unknown types, the value is now marshaled and unmarshaled into a generic type, allowing it to be re-processed through the typed conversion path. Falls back to string conversion only if marshaling or unmarshaling fails
- Fixed minor alignment inconsistency in `ScopeSpan` struct literal

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/otel/...
```

Verify that traces containing attributes with `[]any` values or complex/nested struct types are correctly serialized as OTEL array or map attributes rather than being stringified.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The marshal/unmarshal round-trip in the `default` case uses internal schema utilities and does not expose any external input directly. No PII or secrets concerns introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable