### PR TITLE
fix: normalize null text fields in PydanticAI responses stream chunks

### DIFF
--- a/transports/bifrost-http/integrations/pydanticai.go
+++ b/transports/bifrost-http/integrations/pydanticai.go
@@ -1,6 +1,9 @@
 package integrations
 
 import (
+	"strings"
+
+	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
@@ -19,7 +22,7 @@ func NewPydanticAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore,
 	routes := []RouteConfig{}
 	// Add OpenAI routes to Pydantic AI for OpenAI API compatibility
 	// Supports: chat completions, embeddings, speech, transcriptions, responses
-	routes = append(routes, CreateOpenAIRouteConfigs("/pydanticai", handlerStore)...)
+	routes = append(routes, withPydanticResponsesNullNormalization(CreateOpenAIRouteConfigs("/pydanticai", handlerStore))...)
 	// Add Anthropic routes to Pydantic AI for Anthropic API compatibility
 	// Supports: messages API (Claude models)
 	routes = append(routes, CreateAnthropicRouteConfigs("/pydanticai", logger)...)
@@ -35,4 +38,98 @@ func NewPydanticAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore,
 	return &PydanticAIRouter{
 		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
 	}
+}
+
+func withPydanticResponsesNullNormalization(routes []RouteConfig) []RouteConfig {
+	for i := range routes {
+		if !strings.Contains(routes[i].Path, "/responses") {
+			continue
+		}
+
+		if routes[i].ResponsesResponseConverter != nil {
+			routes[i].ResponsesResponseConverter = func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponsesResponse) (interface{}, error) {
+				// For pydantic responses endpoint, prefer normalized bifrost output
+				// instead of raw passthrough, to keep null handling consistent.
+				return resp.WithDefaults(), nil
+			}
+		}
+
+		if routes[i].StreamConfig != nil && routes[i].StreamConfig.ResponsesStreamResponseConverter != nil {
+			// Match non-stream behavior: prefer normalized output (raw->normalizePydanticResponsesRawStreamChunk, typed->resp.WithDefaults()+ensurePydanticResponsesStreamTextFields).
+			routes[i].StreamConfig.ResponsesStreamResponseConverter = func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponsesStreamResponse) (string, interface{}, error) {
+				if resp == nil {
+					return "", nil, nil
+				}
+
+				if resp.ExtraFields.RawResponse != nil {
+					normalizedRaw := normalizePydanticResponsesRawStreamChunk(resp.ExtraFields.RawResponse)
+					if normalizedRawString, ok := normalizedRaw.(string); ok {
+						return string(resp.Type), normalizedRawString, nil
+					}
+				}
+
+				normalized := resp.WithDefaults()
+				ensurePydanticResponsesStreamTextFields(normalized)
+				return string(resp.Type), normalized, nil
+			}
+		}
+	}
+
+	return routes
+}
+
+func ensurePydanticResponsesStreamTextFields(resp *schemas.BifrostResponsesStreamResponse) {
+	if resp == nil {
+		return
+	}
+
+	switch resp.Type {
+	case schemas.ResponsesStreamResponseTypeOutputTextDelta:
+		if resp.Delta == nil {
+			resp.Delta = bifrost.Ptr("")
+		}
+	case schemas.ResponsesStreamResponseTypeOutputTextDone:
+		if resp.Text == nil {
+			resp.Text = bifrost.Ptr("")
+		}
+	}
+}
+
+func normalizePydanticResponsesRawStreamChunk(raw interface{}) interface{} {
+	rawString, ok := raw.(string)
+	if !ok {
+		return raw
+	}
+
+	var chunk map[string]interface{}
+	if err := sonic.UnmarshalString(rawString, &chunk); err != nil {
+		return raw
+	}
+
+	changed := false
+	if chunkType, ok := chunk["type"].(string); ok {
+		switch schemas.ResponsesStreamResponseType(chunkType) {
+		case schemas.ResponsesStreamResponseTypeOutputTextDelta:
+			if value, exists := chunk["delta"]; exists && value == nil {
+				chunk["delta"] = ""
+				changed = true
+			}
+		case schemas.ResponsesStreamResponseTypeOutputTextDone:
+			if value, exists := chunk["text"]; exists && value == nil {
+				chunk["text"] = ""
+				changed = true
+			}
+		}
+	}
+
+	if !changed {
+		return raw
+	}
+
+	normalized, err := sonic.MarshalString(chunk)
+	if err != nil {
+		return raw
+	}
+
+	return normalized
 }


### PR DESCRIPTION
## Summary

PydanticAI's responses endpoint requires that `delta` and `text` fields in streaming chunks are never `null` — they must be empty strings when absent. This PR adds null normalization for the PydanticAI `/responses` route to ensure compatibility with PydanticAI's strict field expectations.

## Changes

- Wraps OpenAI route configs for the PydanticAI integration with `withPydanticResponsesNullNormalization`, which intercepts the responses and streaming response converters specifically for `/responses` routes.
- For non-streaming responses, the converter now returns `resp.WithDefaults()` instead of raw passthrough to ensure consistent null handling.
- For streaming responses, `delta` fields on `output_text.delta` events and `text` fields on `output_text.done` events are coerced from `null` to `""` — both in the structured response and in raw JSON passthrough chunks.
- Raw stream chunks are parsed, patched, and re-serialized using `sonic` only when a null-to-empty-string substitution is actually needed, avoiding unnecessary allocations on unaffected chunks.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a streaming and non-streaming request to the PydanticAI `/responses` endpoint and verify that `delta` and `text` fields in the response are empty strings rather than `null` when no value is present.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Changes are limited to response normalization logic within the PydanticAI integration layer.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable