### PR TITLE
feat: adds missing anthropic params / handling in Vertex

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -446,7 +446,7 @@ func (provider *AnthropicProvider) ChatCompletion(ctx *schemas.BifrostContext, k
 		// Feature gating keyed to schemas.Anthropic (not provider.GetProviderKey())
 		// so custom Anthropic aliases get the same feature lookup as the typed
 		// path above (line 445), keeping raw and typed behavior in lockstep.
-		sanitized, rawErr := stripUnsupportedFieldsFromRawBody(jsonData, schemas.Anthropic, request.Model)
+		sanitized, rawErr := StripUnsupportedFieldsFromRawBody(jsonData, schemas.Anthropic, request.Model)
 		if rawErr != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, rawErr)
 		}
@@ -539,7 +539,7 @@ func (provider *AnthropicProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 		// Feature gating keyed to schemas.Anthropic (not provider.GetProviderKey())
 		// to keep raw and typed paths in lockstep on custom aliases — mirrors
 		// the typed path's hardcoded schemas.Anthropic at line 548.
-		sanitized, rawErr := stripUnsupportedFieldsFromRawBody(jsonData, schemas.Anthropic, request.Model)
+		sanitized, rawErr := StripUnsupportedFieldsFromRawBody(jsonData, schemas.Anthropic, request.Model)
 		if rawErr != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, rawErr)
 		}

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -319,7 +319,7 @@ func stripUnsupportedAnthropicFields(req *AnthropicMessageRequest, provider sche
 	}
 }
 
-// stripUnsupportedFieldsFromRawBody is the raw-JSON equivalent of
+// StripUnsupportedFieldsFromRawBody is the raw-JSON equivalent of
 // StripUnsupportedAnthropicFields. It mutates the request body bytes using
 // sjson/gjson (preserving key order for prompt caching) so the raw-body
 // passthrough path has behavioural parity with the typed conversion path.
@@ -338,7 +338,7 @@ func stripUnsupportedAnthropicFields(req *AnthropicMessageRequest, provider sche
 // Unknown providers: safe default — no stripping (parity with the typed helper).
 // Unknown edit types in context_management: left in place for the provider
 // to reject (parity with the typed helper).
-func stripUnsupportedFieldsFromRawBody(jsonBody []byte, provider schemas.ModelProvider, model string) ([]byte, error) {
+func StripUnsupportedFieldsFromRawBody(jsonBody []byte, provider schemas.ModelProvider, model string) ([]byte, error) {
 	if len(jsonBody) == 0 {
 		return jsonBody, nil
 	}
@@ -713,7 +713,7 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 		// Feature gating keyed to schemas.Anthropic (not providerName) to match
 		// the typed path below which also hardcodes schemas.Anthropic — ensures
 		// custom Anthropic aliases get identical feature lookup in both modes.
-		jsonBody, err = stripUnsupportedFieldsFromRawBody(jsonBody, schemas.Anthropic, "")
+		jsonBody, err = StripUnsupportedFieldsFromRawBody(jsonBody, schemas.Anthropic, "")
 		if err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
 		}

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -1268,7 +1268,7 @@ func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 			"cache_control":{"type":"ephemeral","ttl":"5m","scope":"user"},
 			"output_config":{"task_budget":{"type":"tokens","total":20000}}
 		}`)
-		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1292,7 +1292,7 @@ func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 			"mcp_servers":[{"type":"url","url":"u","name":"n"}],
 			"tools":[{"name":"t1","strict":true,"input_examples":[{"input":{"a":1}}],"cache_control":{"type":"ephemeral","scope":"user"}}]
 		}`)
-		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Vertex, "claude-sonnet-4-6")
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.Vertex, "claude-sonnet-4-6")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1314,7 +1314,7 @@ func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 			"model":"claude-opus-4-6",
 			"tools":[{"name":"t1","input_examples":[{"input":{"a":1}}],"defer_loading":true,"allowed_callers":["direct"]}]
 		}`)
-		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1332,7 +1332,7 @@ func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 		// Model gate: fast-mode is Opus 4.6 only per docs. Even on Anthropic
 		// direct where FastMode=true, targeting a different model must strip.
 		input := []byte(`{"model":"claude-sonnet-4-6","speed":"fast"}`)
-		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Anthropic, "claude-sonnet-4-6")
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.Anthropic, "claude-sonnet-4-6")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1344,7 +1344,7 @@ func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 	t.Run("anthropic_direct_is_noop", func(t *testing.T) {
 		// Anthropic supports everything — body should survive untouched.
 		input := []byte(`{"model":"claude-opus-4-6","speed":"fast","mcp_servers":[{"type":"url","url":"u","name":"n"}],"container":{"id":"c"},"tools":[{"name":"t","defer_loading":true,"input_examples":[{"input":{"a":1}}]}]}`)
-		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Anthropic, "claude-opus-4-6")
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.Anthropic, "claude-opus-4-6")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1363,7 +1363,7 @@ func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 			"system":[{"type":"text","text":"hi","cache_control":{"type":"ephemeral","scope":"user"}}],
 			"messages":[{"role":"user","content":[{"type":"text","text":"q","cache_control":{"type":"ephemeral","scope":"global"}}]}]
 		}`)
-		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1376,7 +1376,7 @@ func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 
 	t.Run("unknown_provider_is_safe_noop", func(t *testing.T) {
 		input := []byte(`{"model":"claude-opus-4-6","speed":"fast"}`)
-		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.ModelProvider("custom"), "claude-opus-4-6")
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.ModelProvider("custom"), "claude-opus-4-6")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1389,7 +1389,7 @@ func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 		// Skills=false provider (Bedrock), ContainerBasic=true.
 		// skills:[] is a caller oversight — strip the empty key, preserve container.
 		input := []byte(`{"model":"claude-opus-4-6","container":{"id":"c-1","skills":[]}}`)
-		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1404,7 +1404,7 @@ func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 	t.Run("container_nonempty_skills_drops_whole_container", func(t *testing.T) {
 		// Non-empty skills signals caller intent; provider doesn't support — drop container.
 		input := []byte(`{"model":"claude-opus-4-6","container":{"id":"c-1","skills":[{"skill_id":"s","type":"anthropic"}]}}`)
-		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.Bedrock, "claude-opus-4-6")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1417,7 +1417,7 @@ func TestStripUnsupportedFieldsFromRawBody(t *testing.T) {
 		// On Anthropic direct (Skills=true), the empty skills array must be preserved
 		// as-is — our strip logic only fires when !features.Skills.
 		input := []byte(`{"model":"claude-opus-4-6","container":{"id":"c-1","skills":[]}}`)
-		result, err := stripUnsupportedFieldsFromRawBody(input, schemas.Anthropic, "claude-opus-4-6")
+		result, err := StripUnsupportedFieldsFromRawBody(input, schemas.Anthropic, "claude-opus-4-6")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -9,7 +9,19 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, deployment string, isStreaming bool, isCountTokens bool, betaHeaderOverrides map[string]bool, providerExtraHeaders map[string]string) ([]byte, *schemas.BifrostError) {
+func enrichBifrostOperationError(
+	ctx *schemas.BifrostContext,
+	message string,
+	err error,
+	requestBody []byte,
+	responseBody []byte,
+	sendBackRawRequest bool,
+	sendBackRawResponse bool,
+) *schemas.BifrostError {
+	return providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(message, err), requestBody, responseBody, sendBackRawRequest, sendBackRawResponse)
+}
+
+func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, deployment string, isStreaming bool, isCountTokens bool, betaHeaderOverrides map[string]bool, providerExtraHeaders map[string]string, shouldSendBackRawRequest bool, shouldSendBackRawResponse bool) ([]byte, *schemas.BifrostError) {
 	// Large payload mode: body streams directly from the LP reader — skip all body building
 	// (matches CheckContextAndGetRequestBody guard).
 	if providerUtils.IsLargePayloadPassthroughEnabled(ctx) {
@@ -26,74 +38,89 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 		if isCountTokens {
 			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "max_tokens")
 			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 			}
 			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "temperature")
 			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 			}
 			jsonBody, err = providerUtils.SetJSONField(jsonBody, "model", deployment)
 			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 			}
 		} else {
 			// Add max_tokens if not present
 			if !providerUtils.JSONFieldExists(jsonBody, "max_tokens") {
 				jsonBody, err = providerUtils.SetJSONField(jsonBody, "max_tokens", providerUtils.GetMaxOutputTokensOrDefault(deployment, anthropic.AnthropicDefaultMaxTokens))
 				if err != nil {
-					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+					return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 				}
 			}
 			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "model")
 			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 			}
 			// Add stream if streaming
 			if isStreaming {
 				jsonBody, err = providerUtils.SetJSONField(jsonBody, "stream", true)
 				if err != nil {
-					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+					return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 				}
 			}
 		}
 
+		// Strip auto-injectable server-side tools to prevent conflicts with API auto-injection
+		jsonBody, err = anthropic.StripAutoInjectableTools(jsonBody)
+		if err != nil {
+			return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
+		}
+
 		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "region")
 		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-		}
-		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "fallbacks")
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+			return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 		}
 
 		// Remap unsupported tool versions for Vertex (e.g., web_search_20260209 → web_search_20250305)
 		jsonBody, err = anthropic.RemapRawToolVersionsForProvider(jsonBody, schemas.Vertex)
 		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(err.Error(), nil)
+			return nil, enrichBifrostOperationError(ctx, err.Error(), nil, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
+		}
+
+		// Strip unsupported fields for Vertex — parity with the typed path's stripUnsupportedAnthropicFields.
+		jsonBody, err = anthropic.StripUnsupportedFieldsFromRawBody(jsonBody, schemas.Vertex, "")
+		if err != nil {
+			return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 		}
 
 		// Add anthropic_version if not present
 		if !providerUtils.JSONFieldExists(jsonBody, "anthropic_version") {
 			jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_version", DefaultVertexAnthropicVersion)
 			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 			}
+		}
+
+		// Probe-unmarshal to auto-inject any beta headers required by fields that survived stripping.
+		// Mirrors the Anthropic typed path so raw-body callers don't need to specify headers manually.
+		var probe anthropic.AnthropicMessageRequest
+		if unmarshalErr := schemas.Unmarshal(jsonBody, &probe); unmarshalErr == nil {
+			anthropic.AddMissingBetaHeadersToContext(ctx, &probe, schemas.Vertex)
 		}
 	} else {
 		// Validate tools are supported by Vertex
 		if request.Params != nil && request.Params.Tools != nil {
 			if toolErr := anthropic.ValidateToolsForProvider(request.Params.Tools, schemas.Vertex); toolErr != nil {
-				return nil, providerUtils.NewBifrostOperationError(toolErr.Error(), nil)
+				return nil, enrichBifrostOperationError(ctx, toolErr.Error(), nil, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 			}
 		}
 
 		// Convert request to Anthropic format
 		reqBody, convErr := anthropic.ToAnthropicResponsesRequest(ctx, request)
 		if convErr != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, convErr)
+			return nil, enrichBifrostOperationError(ctx, schemas.ErrRequestBodyConversion, convErr, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 		}
 		if reqBody == nil {
-			return nil, providerUtils.NewBifrostOperationError("request body is not provided", nil)
+			return nil, enrichBifrostOperationError(ctx, "request body is not provided", nil, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 		}
 		reqBody.Model = deployment
 
@@ -109,44 +136,61 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 		// Marshal struct to JSON bytes
 		jsonBody, err = providerUtils.MarshalSorted(reqBody)
 		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+			return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
+		}
+
+		if passthrough, _ := ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams).(bool); passthrough {
+			extraParams := reqBody.GetExtraParams()
+			if len(extraParams) > 0 {
+				// Use MergeExtraParamsIntoJSON which preserves key order
+				jsonBody, err = providerUtils.MergeExtraParamsIntoJSON(jsonBody, extraParams)
+				if err != nil {
+					return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
+				}
+			}
 		}
 
 		// Add anthropic_version if not present (using sjson to preserve order)
 		if !providerUtils.JSONFieldExists(jsonBody, "anthropic_version") {
 			jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_version", DefaultVertexAnthropicVersion)
 			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 			}
 		}
 
 		if isCountTokens {
 			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "max_tokens")
 			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 			}
 			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "temperature")
 			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 			}
 		} else {
 			// Remove model field for Vertex API (it's in URL)
 			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "model")
 			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 			}
 		}
 
 		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "region")
 		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+			return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 		}
+	}
+
+	// Delete fallbacks field (both raw and typed paths)
+	jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "fallbacks")
+	if err != nil {
+		return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 	}
 
 	if betaHeaders := anthropic.FilterBetaHeadersForProvider(anthropic.MergeBetaHeaders(providerExtraHeaders, ctx), schemas.Vertex, betaHeaderOverrides); len(betaHeaders) > 0 {
 		jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_beta", betaHeaders)
 		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+			return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
 		}
 	}
 

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -947,7 +947,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 // Responses performs a responses request to the Vertex API.
 func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	if schemas.IsAnthropicModel(request.Model) {
-		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, request.Model, false, false, provider.networkConfig.BetaHeaderOverrides, provider.networkConfig.ExtraHeaders)
+		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, request.Model, false, false, provider.networkConfig.BetaHeaderOverrides, provider.networkConfig.ExtraHeaders, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
@@ -1227,7 +1227,7 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 			return nil, providerUtils.NewConfigurationError("project ID is not set")
 		}
 
-		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, request.Model, true, false, provider.networkConfig.BetaHeaderOverrides, provider.networkConfig.ExtraHeaders)
+		jsonBody, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, request.Model, true, false, provider.networkConfig.BetaHeaderOverrides, provider.networkConfig.ExtraHeaders, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
@@ -2580,7 +2580,7 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 	)
 
 	if schemas.IsAnthropicModel(request.Model) {
-		jsonBody, bifrostErr = getRequestBodyForAnthropicResponses(ctx, request, request.Model, false, true, provider.networkConfig.BetaHeaderOverrides, provider.networkConfig.ExtraHeaders)
+		jsonBody, bifrostErr = getRequestBodyForAnthropicResponses(ctx, request, request.Model, false, true, provider.networkConfig.BetaHeaderOverrides, provider.networkConfig.ExtraHeaders, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}


### PR DESCRIPTION
## Summary

Exports `StripUnsupportedFieldsFromRawBody` from the Anthropic package so it can be called by the Vertex provider, and applies it (along with several other parity fixes) to the Vertex raw-body path for Anthropic Responses requests.

## Changes

- Renamed `stripUnsupportedFieldsFromRawBody` → `StripUnsupportedFieldsFromRawBody` in `core/providers/anthropic/utils.go` to make it accessible outside the package.
- Updated all call sites in `anthropic.go`, `utils.go`, and `utils_test.go` to use the exported name.
- Added `StripUnsupportedFieldsFromRawBody` call in the Vertex raw-body path for Anthropic Responses requests, bringing it to parity with the typed conversion path's `stripUnsupportedAnthropicFields` behavior.
- Added `StripAutoInjectableTools` stripping in the Vertex raw-body path to prevent conflicts with API auto-injection.
- Added a probe-unmarshal step after field stripping to auto-inject required beta headers into the context, mirroring the Anthropic typed path so raw-body callers don't need to specify headers manually.
- Moved the `fallbacks` field deletion outside the raw/typed branch split so it applies to both paths consistently.
- Added extra params merging (`MergeExtraParamsIntoJSON`) in the typed path when `BifrostContextKeyPassthroughExtraParams` is set.
- Introduced `enrichBifrostOperationError` helper in `vertex/utils.go` to attach request/response body context to operation errors, replacing bare `NewBifrostOperationError` calls throughout `getRequestBodyForAnthropicResponses`.
- Propagated `sendBackRawRequest` and `sendBackRawResponse` flags from the provider into `getRequestBodyForAnthropicResponses` for all three call sites (`Responses`, `ResponsesStream`, `CountTokens`).

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/...
go test ./core/providers/vertex/...
go test ./...
```

Verify that raw-body Anthropic Responses requests routed through Vertex correctly strip Vertex-unsupported fields (e.g., `mcp_servers`, `speed`, unsupported `cache_control` scopes) and that beta headers are automatically injected without requiring manual specification by the caller.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII implications. The exported function retains the same behavior as the previously unexported version.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable