### PR TITLE
feat: Standardizes tool stripping and anthropic integration handling against anthropic, vertex and azure

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- feat: Standardizes tool stripping and anthropic integration handling against anthropic, vertex and azure

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -937,7 +937,7 @@ func (provider *AnthropicProvider) Responses(ctx *schemas.BifrostContext, key sc
 	if err := providerUtils.CheckOperationAllowed(schemas.Anthropic, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
 		return nil, err
 	}
-	jsonBody, err := getRequestBodyForResponses(ctx, request, false, nil)
+	jsonBody, err := getRequestBodyForResponses(ctx, request, false, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -1002,7 +1002,7 @@ func (provider *AnthropicProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 	}
 
 	// Convert to Anthropic format using the centralized converter
-	jsonBody, err := getRequestBodyForResponses(ctx, request, true, nil)
+	jsonBody, err := getRequestBodyForResponses(ctx, request, true, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -2402,7 +2402,7 @@ func (provider *AnthropicProvider) CountTokens(ctx *schemas.BifrostContext, key 
 	if err := providerUtils.CheckOperationAllowed(schemas.Anthropic, provider.customProviderConfig, schemas.CountTokensRequest); err != nil {
 		return nil, err
 	}
-	jsonBody, err := getRequestBodyForResponses(ctx, request, false, []string{"max_tokens", "temperature"})
+	jsonBody, err := getRequestBodyForResponses(ctx, request, false, []string{"max_tokens", "temperature"}, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	if err != nil {
 		return nil, err
 	}

--- a/core/providers/anthropic/request_builder.go
+++ b/core/providers/anthropic/request_builder.go
@@ -1,0 +1,317 @@
+package anthropic
+
+import (
+	"fmt"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// AnthropicRequestBuildConfig controls how BuildAnthropicResponsesRequestBody
+// assembles the final JSON payload. Each Anthropic-family provider (Anthropic
+// native, Azure, Vertex) fills in only the fields relevant to it and leaves
+// the rest as zero values.
+type AnthropicRequestBuildConfig struct {
+	// Provider is used for feature-gating (field stripping, header injection,
+	// tool validation). Required.
+	Provider schemas.ModelProvider
+
+	// Deployment overrides the model field. When empty the model is read from
+	// the request and normalised via ParseModelString (Anthropic native path).
+	// Azure and Vertex set this to the deployment/model name.
+	Deployment string
+
+	// DeleteModelField removes "model" from the output JSON body.
+	// Vertex passes model in the request URL, not the body.
+	// Ignored when IsCountTokens is true — count-tokens calls retain the model
+	// field so the provider can route to the correct endpoint.
+	DeleteModelField bool
+
+	// DeleteRegionField removes the "region" field (Vertex only).
+	DeleteRegionField bool
+
+	IsStreaming bool
+
+	// IsCountTokens enables token-counting mode (Vertex only): strips
+	// max_tokens and temperature from the body and keeps (or sets) the model
+	// field.
+	IsCountTokens bool
+
+	// ExcludeFields lists JSON top-level keys to remove from the final body in
+	// both the raw and typed paths. Used by Anthropic's count-tokens call to
+	// strip max_tokens and temperature after typed conversion.
+	ExcludeFields []string
+
+	// AddAnthropicVersion injects "anthropic_version" into the body when the
+	// field is absent (Vertex only).
+	AddAnthropicVersion bool
+	AnthropicVersion    string
+
+	// StripCacheControlScope calls SetStripCacheControlScope(true) on the
+	// typed request struct before marshalling (Vertex typed path).
+	StripCacheControlScope bool
+
+	// RemapToolVersions runs RemapRawToolVersionsForProvider on the raw body to
+	// downgrade unsupported tool type versions (Vertex raw path).
+	RemapToolVersions bool
+
+	// InjectBetaHeadersIntoBody serialises filtered beta headers into the JSON
+	// body as "anthropic_beta". Vertex embeds beta headers in the body rather
+	// than HTTP request headers.
+	InjectBetaHeadersIntoBody bool
+	BetaHeaderOverrides       map[string]bool
+	ProviderExtraHeaders      map[string]string
+
+	// ValidateTools runs ValidateToolsForProvider before typed conversion,
+	// returning an error for any tool unsupported by the provider (Azure,
+	// Vertex).
+	ValidateTools bool
+
+	// ShouldSendBackRawRequest / ShouldSendBackRawResponse control whether raw
+	// request/response bytes are attached to BifrostError.ExtraFields via
+	// providerUtils.EnrichError. Vertex honours per-provider send-back flags;
+	// Anthropic and Azure leave both false.
+	ShouldSendBackRawRequest  bool
+	ShouldSendBackRawResponse bool
+}
+
+// BuildAnthropicResponsesRequestBody is the single implementation of the
+// Anthropic-family request-body assembly pipeline, shared by the Anthropic,
+// Azure, and Vertex providers. Provider-specific behaviour is encoded in the
+// supplied AnthropicRequestBuildConfig; the shared steps (large-payload guard,
+// raw-vs-typed branching, field stripping, beta-header injection, fallbacks
+// deletion) are handled here.
+func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, cfg AnthropicRequestBuildConfig) ([]byte, *schemas.BifrostError) {
+	if providerUtils.IsLargePayloadPassthroughEnabled(ctx) {
+		return nil, nil
+	}
+
+	newErr := func(msg string, err error, reqBody []byte) *schemas.BifrostError {
+		return providerUtils.EnrichError(
+			ctx,
+			providerUtils.NewBifrostOperationError(msg, err),
+			reqBody,
+			nil,
+			cfg.ShouldSendBackRawRequest,
+			cfg.ShouldSendBackRawResponse,
+		)
+	}
+
+	var jsonBody []byte
+	var err error
+
+	if useRawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && useRawBody {
+		jsonBody = request.GetRawRequestBody()
+
+		if cfg.IsCountTokens {
+			// Token-counting mode: strip max_tokens / temperature and set model.
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "max_tokens")
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "temperature")
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "model", cfg.Deployment)
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+		} else {
+			// Normal path: handle model field per provider.
+			if cfg.Deployment != "" {
+				if cfg.DeleteModelField {
+					// Vertex: model lives in the URL.
+					jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "model")
+					if err != nil {
+						return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+					}
+				} else {
+					// Azure: replace model with deployment name.
+					jsonBody, err = providerUtils.SetJSONField(jsonBody, "model", cfg.Deployment)
+					if err != nil {
+						return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+					}
+				}
+			} else {
+				// Anthropic native: normalise the model string via ParseModelString.
+				if modelResult := providerUtils.GetJSONField(jsonBody, "model"); modelResult.Exists() {
+					if modelStr := modelResult.String(); modelStr != "" {
+						_, model := schemas.ParseModelString(modelStr, schemas.Anthropic)
+						jsonBody, err = providerUtils.SetJSONField(jsonBody, "model", model)
+						if err != nil {
+							return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+						}
+					}
+				}
+			}
+
+			// Ensure max_tokens is present.
+			if !providerUtils.JSONFieldExists(jsonBody, "max_tokens") {
+				modelForTokens := cfg.Deployment
+				if modelForTokens == "" {
+					if r := providerUtils.GetJSONField(jsonBody, "model"); r.Exists() {
+						modelForTokens = r.String()
+					}
+				}
+				jsonBody, err = providerUtils.SetJSONField(jsonBody, "max_tokens", providerUtils.GetMaxOutputTokensOrDefault(modelForTokens, AnthropicDefaultMaxTokens))
+				if err != nil {
+					return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+				}
+			}
+
+		}
+
+		if cfg.IsStreaming {
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "stream", true)
+		} else {
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "stream")
+		}
+		if err != nil {
+			return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+		}
+
+		jsonBody, err = StripAutoInjectableTools(jsonBody)
+		if err != nil {
+			return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+		}
+
+		if cfg.RemapToolVersions {
+			jsonBody, err = RemapRawToolVersionsForProvider(jsonBody, cfg.Provider)
+			if err != nil {
+				return nil, newErr(err.Error(), nil, jsonBody)
+			}
+		}
+
+		if cfg.DeleteRegionField {
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "region")
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+		}
+
+		jsonBody, err = StripUnsupportedFieldsFromRawBody(jsonBody, cfg.Provider, request.Model)
+		if err != nil {
+			return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+		}
+
+		if cfg.AddAnthropicVersion && !providerUtils.JSONFieldExists(jsonBody, "anthropic_version") {
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_version", cfg.AnthropicVersion)
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+		}
+
+		// Probe-unmarshal to auto-inject beta headers required by fields that
+		// survived stripping, so raw-body callers don't need to supply headers
+		// manually.
+		var probe AnthropicMessageRequest
+		if unmarshalErr := schemas.Unmarshal(jsonBody, &probe); unmarshalErr == nil {
+			AddMissingBetaHeadersToContext(ctx, &probe, cfg.Provider)
+		}
+
+		for _, field := range cfg.ExcludeFields {
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, field)
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+		}
+	} else {
+		if cfg.ValidateTools && request.Params != nil && request.Params.Tools != nil {
+			if toolErr := ValidateToolsForProvider(request.Params.Tools, cfg.Provider); toolErr != nil {
+				return nil, newErr(toolErr.Error(), nil, jsonBody)
+			}
+		}
+
+		reqBody, convErr := ToAnthropicResponsesRequest(ctx, request)
+		if convErr != nil {
+			return nil, newErr(schemas.ErrRequestBodyConversion, convErr, jsonBody)
+		}
+		if reqBody == nil {
+			return nil, newErr("request body is not provided", nil, jsonBody)
+		}
+
+		if cfg.Deployment != "" {
+			reqBody.Model = cfg.Deployment
+		}
+
+		if cfg.StripCacheControlScope {
+			reqBody.SetStripCacheControlScope(true)
+		}
+
+		if cfg.IsStreaming {
+			reqBody.Stream = schemas.Ptr(true)
+		}
+
+		AddMissingBetaHeadersToContext(ctx, reqBody, cfg.Provider)
+
+		jsonBody, err = providerUtils.MarshalSorted(reqBody)
+		if err != nil {
+			return nil, newErr(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err), jsonBody)
+		}
+
+		if ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
+			extraParams := reqBody.GetExtraParams()
+			if len(extraParams) > 0 {
+				jsonBody, err = providerUtils.MergeExtraParamsIntoJSON(jsonBody, extraParams)
+				if err != nil {
+					return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+				}
+			}
+		}
+
+		if cfg.AddAnthropicVersion && !providerUtils.JSONFieldExists(jsonBody, "anthropic_version") {
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_version", cfg.AnthropicVersion)
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+		}
+
+		if cfg.IsCountTokens {
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "max_tokens")
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "temperature")
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+		} else if cfg.DeleteModelField {
+			// Vertex: model is in the URL, remove it from the body.
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "model")
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+		}
+
+		if cfg.DeleteRegionField {
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "region")
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+		}
+
+		for _, field := range cfg.ExcludeFields {
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, field)
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+		}
+	}
+
+	jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "fallbacks")
+	if err != nil {
+		return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+	}
+
+	if cfg.InjectBetaHeadersIntoBody {
+		if betaHeaders := FilterBetaHeadersForProvider(MergeBetaHeaders(cfg.ProviderExtraHeaders, ctx), cfg.Provider, cfg.BetaHeaderOverrides); len(betaHeaders) > 0 {
+			jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_beta", betaHeaders)
+			if err != nil {
+				return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+			}
+		}
+	}
+
+	return jsonBody, nil
+}

--- a/core/providers/anthropic/request_builder_test.go
+++ b/core/providers/anthropic/request_builder_test.go
@@ -1,0 +1,705 @@
+package anthropic
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func makeSimpleInput(text string) []schemas.ResponsesMessage {
+	role := schemas.ResponsesInputMessageRoleUser
+	return []schemas.ResponsesMessage{
+		{
+			Role:    &role,
+			Content: &schemas.ResponsesMessageContent{ContentStr: &text},
+		},
+	}
+}
+
+func TestBuildAnthropicResponsesRequestBody_RawBodyPath(t *testing.T) {
+	t.Run("anthropic_native_normalizes_model", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Anthropic,
+			Model:          "anthropic/claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"anthropic/claude-sonnet-4-5","max_tokens":1024,"messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider: schemas.Anthropic,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		modelVal := providerUtils.GetJSONField(result, "model").String()
+		if modelVal != "claude-sonnet-4-5" {
+			t.Errorf("expected model to be normalized to 'claude-sonnet-4-5', got %q", modelVal)
+		}
+	})
+
+	t.Run("vertex_deletes_model_field", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Vertex,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:         schemas.Vertex,
+			Deployment:       "claude-sonnet-4-5",
+			DeleteModelField: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if providerUtils.JSONFieldExists(result, "model") {
+			t.Error("expected model field to be deleted for Vertex")
+		}
+	})
+
+	t.Run("azure_replaces_model_with_deployment", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Azure,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:   schemas.Azure,
+			Deployment: "my-azure-deployment",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		modelVal := providerUtils.GetJSONField(result, "model").String()
+		if modelVal != "my-azure-deployment" {
+			t.Errorf("expected model to be 'my-azure-deployment', got %q", modelVal)
+		}
+	})
+
+	t.Run("adds_max_tokens_if_missing", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Anthropic,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider: schemas.Anthropic,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !providerUtils.JSONFieldExists(result, "max_tokens") {
+			t.Error("expected max_tokens to be added")
+		}
+	})
+
+	t.Run("adds_stream_when_streaming", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Anthropic,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:    schemas.Anthropic,
+			IsStreaming: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		streamVal := providerUtils.GetJSONField(result, "stream").Bool()
+		if !streamVal {
+			t.Error("expected stream to be true")
+		}
+	})
+
+	t.Run("deletes_region_field_when_configured", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Vertex,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"region":"us-central1","messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:          schemas.Vertex,
+			Deployment:        "claude-sonnet-4-5",
+			DeleteModelField:  true,
+			DeleteRegionField: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if providerUtils.JSONFieldExists(result, "region") {
+			t.Error("expected region field to be deleted")
+		}
+	})
+
+	t.Run("adds_anthropic_version_when_configured", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Vertex,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:            schemas.Vertex,
+			Deployment:          "claude-sonnet-4-5",
+			DeleteModelField:    true,
+			AddAnthropicVersion: true,
+			AnthropicVersion:    "vertex-2023-10-16",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		versionVal := providerUtils.GetJSONField(result, "anthropic_version").String()
+		if versionVal != "vertex-2023-10-16" {
+			t.Errorf("expected anthropic_version 'vertex-2023-10-16', got %q", versionVal)
+		}
+	})
+
+	t.Run("excludes_specified_fields", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Anthropic,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"temperature":0.7,"messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:      schemas.Anthropic,
+			ExcludeFields: []string{"temperature"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if providerUtils.JSONFieldExists(result, "temperature") {
+			t.Error("expected temperature to be excluded")
+		}
+	})
+
+	t.Run("always_deletes_fallbacks", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Anthropic,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"fallbacks":["claude-haiku-4-5"],"messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider: schemas.Anthropic,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if providerUtils.JSONFieldExists(result, "fallbacks") {
+			t.Error("expected fallbacks to be deleted")
+		}
+	})
+
+	t.Run("injects_beta_headers_into_body", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+		ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
+			"anthropic-beta": {AnthropicCompactionBetaHeader},
+		})
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Vertex,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:                  schemas.Vertex,
+			Deployment:                "claude-sonnet-4-5",
+			DeleteModelField:          true,
+			InjectBetaHeadersIntoBody: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !providerUtils.JSONFieldExists(result, "anthropic_beta") {
+			t.Error("expected anthropic_beta to be injected into body")
+		}
+	})
+}
+
+func TestBuildAnthropicResponsesRequestBody_CountTokensMode(t *testing.T) {
+	t.Run("count_tokens_strips_max_tokens_and_temperature_raw", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Vertex,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"temperature":0.7,"messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:      schemas.Vertex,
+			Deployment:    "claude-sonnet-4-5",
+			IsCountTokens: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if providerUtils.JSONFieldExists(result, "max_tokens") {
+			t.Error("expected max_tokens to be stripped in count-tokens mode")
+		}
+		if providerUtils.JSONFieldExists(result, "temperature") {
+			t.Error("expected temperature to be stripped in count-tokens mode")
+		}
+		if !providerUtils.JSONFieldExists(result, "model") {
+			t.Error("expected model to be retained in count-tokens mode")
+		}
+	})
+
+	t.Run("count_tokens_sets_deployment_as_model", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Vertex,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"old-model","max_tokens":1024,"messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:      schemas.Vertex,
+			Deployment:    "new-deployment",
+			IsCountTokens: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		modelVal := providerUtils.GetJSONField(result, "model").String()
+		if modelVal != "new-deployment" {
+			t.Errorf("expected model 'new-deployment', got %q", modelVal)
+		}
+	})
+}
+
+func TestBuildAnthropicResponsesRequestBody_TypedPath(t *testing.T) {
+	t.Run("typed_path_basic_request", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Anthropic,
+			Model:    "claude-sonnet-4-5",
+			Input:    makeSimpleInput("Hello, world!"),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider: schemas.Anthropic,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !providerUtils.JSONFieldExists(result, "model") {
+			t.Error("expected model to be present")
+		}
+		if !providerUtils.JSONFieldExists(result, "messages") {
+			t.Error("expected messages to be present")
+		}
+	})
+
+	t.Run("typed_path_with_streaming", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Anthropic,
+			Model:    "claude-sonnet-4-5",
+			Input:    makeSimpleInput("Hello!"),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:    schemas.Anthropic,
+			IsStreaming: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		streamVal := providerUtils.GetJSONField(result, "stream").Bool()
+		if !streamVal {
+			t.Error("expected stream to be true")
+		}
+	})
+
+	t.Run("typed_path_vertex_deletes_model", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Vertex,
+			Model:    "claude-sonnet-4-5",
+			Input:    makeSimpleInput("Hello!"),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:         schemas.Vertex,
+			Deployment:       "claude-sonnet-4-5",
+			DeleteModelField: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if providerUtils.JSONFieldExists(result, "model") {
+			t.Error("expected model to be deleted for Vertex")
+		}
+	})
+
+	t.Run("typed_path_adds_anthropic_version", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Vertex,
+			Model:    "claude-sonnet-4-5",
+			Input:    makeSimpleInput("Hello!"),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:            schemas.Vertex,
+			Deployment:          "claude-sonnet-4-5",
+			DeleteModelField:    true,
+			AddAnthropicVersion: true,
+			AnthropicVersion:    "vertex-2023-10-16",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		versionVal := providerUtils.GetJSONField(result, "anthropic_version").String()
+		if versionVal != "vertex-2023-10-16" {
+			t.Errorf("expected anthropic_version 'vertex-2023-10-16', got %q", versionVal)
+		}
+	})
+
+	t.Run("typed_path_count_tokens_strips_fields", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+		temp := 0.7
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Vertex,
+			Model:    "claude-sonnet-4-5",
+			Input:    makeSimpleInput("Hello!"),
+			Params: &schemas.ResponsesParameters{
+				Temperature: &temp,
+			},
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:      schemas.Vertex,
+			Deployment:    "claude-sonnet-4-5",
+			IsCountTokens: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if providerUtils.JSONFieldExists(result, "max_tokens") {
+			t.Error("expected max_tokens to be stripped in count-tokens mode")
+		}
+		if providerUtils.JSONFieldExists(result, "temperature") {
+			t.Error("expected temperature to be stripped in count-tokens mode")
+		}
+	})
+
+	t.Run("typed_path_validates_tools_when_configured", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Bedrock,
+			Model:    "claude-sonnet-4-5",
+			Input:    makeSimpleInput("Hello!"),
+			Params: &schemas.ResponsesParameters{
+				Tools: []schemas.ResponsesTool{
+					{Type: schemas.ResponsesToolTypeWebSearch},
+				},
+			},
+		}
+
+		_, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:      schemas.Bedrock,
+			ValidateTools: true,
+		})
+		if err == nil {
+			t.Error("expected error for unsupported tool on Bedrock")
+		}
+	})
+}
+
+func TestBuildAnthropicResponsesRequestBody_LargePayloadPassthrough(t *testing.T) {
+	t.Run("returns_nil_when_large_payload_enabled", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyLargePayloadMode, true)
+		ctx.SetValue(schemas.BifrostContextKeyLargePayloadReader, io.NopCloser(strings.NewReader(`{"model":"claude-sonnet-4-5"}`)))
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Anthropic,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"claude-sonnet-4-5"}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider: schemas.Anthropic,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != nil {
+			t.Error("expected nil result when large payload passthrough enabled")
+		}
+	})
+}
+
+func TestDoesWebSearchOrFetchAutoInjectCodeExecution(t *testing.T) {
+	tests := []struct {
+		toolType string
+		expected bool
+	}{
+		{string(AnthropicToolTypeWebSearch20250305), false},
+		{string(AnthropicToolTypeWebSearch20260209), true},
+		{string(AnthropicToolTypeWebFetch20250910), false},
+		{string(AnthropicToolTypeWebFetch20260209), true},
+		{string(AnthropicToolTypeWebFetch20260309), true},
+		{"web_search_unknown", true},
+		{"web_fetch_unknown", true},
+		{"unknown_type", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.toolType, func(t *testing.T) {
+			got := doesWebSearchOrFetchAutoInjectCodeExecution(tt.toolType)
+			if got != tt.expected {
+				t.Errorf("doesWebSearchOrFetchAutoInjectCodeExecution(%q) = %v, want %v", tt.toolType, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStripAutoInjectableTools_VersionAware(t *testing.T) {
+	t.Run("web_search_20250305_does_not_trigger_code_execution_strip", func(t *testing.T) {
+		input := []byte(`{"tools":[{"type":"code_execution_20250825","name":"code_execution"},{"type":"web_search_20250305","name":"web_search"}]}`)
+		result, err := StripAutoInjectableTools(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		tools := providerUtils.GetJSONField(result, "tools")
+		arr := tools.Array()
+		if len(arr) != 2 {
+			t.Errorf("expected 2 tools (code_execution preserved with old web_search), got %d", len(arr))
+		}
+	})
+
+	t.Run("web_search_20260209_triggers_code_execution_strip", func(t *testing.T) {
+		input := []byte(`{"tools":[{"type":"code_execution_20250825","name":"code_execution"},{"type":"web_search_20260209","name":"web_search"}]}`)
+		result, err := StripAutoInjectableTools(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		tools := providerUtils.GetJSONField(result, "tools")
+		arr := tools.Array()
+		if len(arr) != 1 {
+			t.Errorf("expected 1 tool (code_execution stripped), got %d", len(arr))
+		}
+		if arr[0].Get("name").String() != "web_search" {
+			t.Errorf("expected remaining tool to be 'web_search', got %q", arr[0].Get("name").String())
+		}
+	})
+
+	t.Run("web_fetch_20250910_does_not_trigger_code_execution_strip", func(t *testing.T) {
+		input := []byte(`{"tools":[{"type":"code_execution_20250825","name":"code_execution"},{"type":"web_fetch_20250910","name":"web_fetch"}]}`)
+		result, err := StripAutoInjectableTools(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		tools := providerUtils.GetJSONField(result, "tools")
+		arr := tools.Array()
+		if len(arr) != 2 {
+			t.Errorf("expected 2 tools (code_execution preserved with old web_fetch), got %d", len(arr))
+		}
+	})
+
+	t.Run("web_fetch_20260209_triggers_code_execution_strip", func(t *testing.T) {
+		input := []byte(`{"tools":[{"type":"code_execution_20250825","name":"code_execution"},{"type":"web_fetch_20260209","name":"web_fetch"}]}`)
+		result, err := StripAutoInjectableTools(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		tools := providerUtils.GetJSONField(result, "tools")
+		arr := tools.Array()
+		if len(arr) != 1 {
+			t.Errorf("expected 1 tool (code_execution stripped), got %d", len(arr))
+		}
+	})
+
+	t.Run("web_fetch_20260309_triggers_code_execution_strip", func(t *testing.T) {
+		input := []byte(`{"tools":[{"type":"code_execution_20250825","name":"code_execution"},{"type":"web_fetch_20260309","name":"web_fetch"}]}`)
+		result, err := StripAutoInjectableTools(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		tools := providerUtils.GetJSONField(result, "tools")
+		arr := tools.Array()
+		if len(arr) != 1 {
+			t.Errorf("expected 1 tool (code_execution stripped), got %d", len(arr))
+		}
+	})
+
+	t.Run("mixed_old_and_new_web_tools_first_match_wins", func(t *testing.T) {
+		input := []byte(`{"tools":[{"type":"code_execution_20250825","name":"code_execution"},{"type":"web_search_20250305","name":"old_search"},{"type":"web_search_20260209","name":"new_search"}]}`)
+		result, err := StripAutoInjectableTools(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		tools := providerUtils.GetJSONField(result, "tools")
+		arr := tools.Array()
+		if len(arr) != 3 {
+			t.Errorf("expected 3 tools (first web tool is old version, no strip), got %d", len(arr))
+		}
+	})
+
+	t.Run("new_web_fetch_first_strips_code_execution", func(t *testing.T) {
+		input := []byte(`{"tools":[{"type":"code_execution_20250825","name":"code_execution"},{"type":"web_fetch_20260209","name":"new_fetch"},{"type":"web_search_20250305","name":"old_search"}]}`)
+		result, err := StripAutoInjectableTools(input)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		tools := providerUtils.GetJSONField(result, "tools")
+		arr := tools.Array()
+		if len(arr) != 2 {
+			t.Errorf("expected 2 tools (code_execution stripped due to new web_fetch), got %d", len(arr))
+		}
+	})
+}
+
+func TestAnthropicToolTypeString(t *testing.T) {
+	tests := []struct {
+		toolType AnthropicToolType
+		expected string
+	}{
+		{AnthropicToolTypeWebSearch20250305, "web_search_20250305"},
+		{AnthropicToolTypeWebSearch20260209, "web_search_20260209"},
+		{AnthropicToolTypeWebFetch20250910, "web_fetch_20250910"},
+		{AnthropicToolTypeWebFetch20260209, "web_fetch_20260209"},
+		{AnthropicToolTypeWebFetch20260309, "web_fetch_20260309"},
+		{AnthropicToolTypeComputer20251124, "computer_20251124"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			got := string(tt.toolType)
+			if got != tt.expected {
+				t.Errorf("AnthropicToolType.String() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildAnthropicResponsesRequestBody_StripCacheControlScope(t *testing.T) {
+	t.Run("typed_path_strips_cache_control_scope_when_configured", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Vertex,
+			Model:    "claude-sonnet-4-5",
+			Input:    makeSimpleInput("Hello!"),
+		}
+
+		_, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:               schemas.Vertex,
+			Deployment:             "claude-sonnet-4-5",
+			StripCacheControlScope: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestBuildAnthropicResponsesRequestBody_RemapToolVersions(t *testing.T) {
+	t.Run("raw_path_remaps_tool_versions_when_configured", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(nil, time.Time{})
+		ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider:       schemas.Vertex,
+			Model:          "claude-sonnet-4-5",
+			RawRequestBody: []byte(`{"model":"claude-sonnet-4-5","max_tokens":1024,"tools":[{"type":"web_search_20260209","name":"web_search"}],"messages":[{"role":"user","content":"hello"}]}`),
+		}
+
+		result, err := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider:          schemas.Vertex,
+			Deployment:        "claude-sonnet-4-5",
+			DeleteModelField:  true,
+			RemapToolVersions: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		tools := providerUtils.GetJSONField(result, "tools")
+		if !tools.Exists() {
+			t.Fatal("expected tools to exist")
+		}
+		arr := tools.Array()
+		if len(arr) == 0 {
+			t.Fatal("expected at least one tool")
+		}
+		toolType := arr[0].Get("type").String()
+		if toolType == "web_search_20260209" {
+			t.Error("expected tool type to be remapped from web_search_20260209")
+		}
+	})
+}

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -87,17 +87,18 @@ const (
 // ProviderFeatureSupport defines which Anthropic features a given provider supports.
 //
 // Authoritative sources (verified 2026-04-17):
-//   A  = Anthropic feature-availability table:
-//        https://platform.claude.com/docs/en/build-with-claude/overview
-//   B-header = AWS Bedrock user guide beta-header list:
-//        https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html
-//   B-platform = https://platform.claude.com/docs/en/build-with-claude/claude-on-amazon-bedrock
-//   V-platform = https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai
-//   Az-platform = https://platform.claude.com/docs/en/build-with-claude/claude-in-microsoft-foundry
-//   MCP-excl = MCP connector explicit Bedrock/Vertex exclusion:
-//        https://platform.claude.com/docs/en/agents-and-tools/mcp-connector
-//   Advisor-excl = Advisor tool Claude-API-only:
-//        https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool
+//
+//	A  = Anthropic feature-availability table:
+//	     https://platform.claude.com/docs/en/build-with-claude/overview
+//	B-header = AWS Bedrock user guide beta-header list:
+//	     https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html
+//	B-platform = https://platform.claude.com/docs/en/build-with-claude/claude-on-amazon-bedrock
+//	V-platform = https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai
+//	Az-platform = https://platform.claude.com/docs/en/build-with-claude/claude-in-microsoft-foundry
+//	MCP-excl = MCP connector explicit Bedrock/Vertex exclusion:
+//	     https://platform.claude.com/docs/en/agents-and-tools/mcp-connector
+//	Advisor-excl = Advisor tool Claude-API-only:
+//	     https://platform.claude.com/docs/en/agents-and-tools/tool-use/advisor-tool
 type ProviderFeatureSupport struct {
 	WebSearch           bool // web_search server tool (cite: A)
 	WebSearchDynamic    bool // web_search_20260209 dynamic filtering (cite: A)
@@ -837,29 +838,29 @@ func (mc *AnthropicContent) UnmarshalJSON(data []byte) error {
 type AnthropicContentBlockType string
 
 const (
-	AnthropicContentBlockTypeText                               AnthropicContentBlockType = "text"
-	AnthropicContentBlockTypeImage                              AnthropicContentBlockType = "image"
-	AnthropicContentBlockTypeDocument                           AnthropicContentBlockType = "document"
-	AnthropicContentBlockTypeSearchResult                       AnthropicContentBlockType = "search_result"
-	AnthropicContentBlockTypeToolUse                            AnthropicContentBlockType = "tool_use"
-	AnthropicContentBlockTypeServerToolUse                      AnthropicContentBlockType = "server_tool_use"
-	AnthropicContentBlockTypeToolResult                         AnthropicContentBlockType = "tool_result"
-	AnthropicContentBlockTypeWebSearchToolResult                AnthropicContentBlockType = "web_search_tool_result"
-	AnthropicContentBlockTypeWebSearchToolResultError           AnthropicContentBlockType = "web_search_tool_result_error"
-	AnthropicContentBlockTypeWebSearchResult                    AnthropicContentBlockType = "web_search_result"
-	AnthropicContentBlockTypeWebFetchToolResult                 AnthropicContentBlockType = "web_fetch_tool_result"
-	AnthropicContentBlockTypeCodeExecutionToolResult            AnthropicContentBlockType = "code_execution_tool_result"
-	AnthropicContentBlockTypeBashCodeExecutionToolResult        AnthropicContentBlockType = "bash_code_execution_tool_result"
-	AnthropicContentBlockTypeTextEditorCodeExecutionToolResult  AnthropicContentBlockType = "text_editor_code_execution_tool_result"
-	AnthropicContentBlockTypeToolSearchToolResult               AnthropicContentBlockType = "tool_search_tool_result"
-	AnthropicContentBlockTypeToolReference                      AnthropicContentBlockType = "tool_reference"
-	AnthropicContentBlockTypeContainerUpload                    AnthropicContentBlockType = "container_upload"
-	AnthropicContentBlockTypeAdvisorToolResult                  AnthropicContentBlockType = "advisor_tool_result"
-	AnthropicContentBlockTypeMCPToolUse                         AnthropicContentBlockType = "mcp_tool_use"
-	AnthropicContentBlockTypeMCPToolResult                      AnthropicContentBlockType = "mcp_tool_result"
-	AnthropicContentBlockTypeThinking                           AnthropicContentBlockType = "thinking"
-	AnthropicContentBlockTypeRedactedThinking                   AnthropicContentBlockType = "redacted_thinking"
-	AnthropicContentBlockTypeCompaction                         AnthropicContentBlockType = "compaction"
+	AnthropicContentBlockTypeText                              AnthropicContentBlockType = "text"
+	AnthropicContentBlockTypeImage                             AnthropicContentBlockType = "image"
+	AnthropicContentBlockTypeDocument                          AnthropicContentBlockType = "document"
+	AnthropicContentBlockTypeSearchResult                      AnthropicContentBlockType = "search_result"
+	AnthropicContentBlockTypeToolUse                           AnthropicContentBlockType = "tool_use"
+	AnthropicContentBlockTypeServerToolUse                     AnthropicContentBlockType = "server_tool_use"
+	AnthropicContentBlockTypeToolResult                        AnthropicContentBlockType = "tool_result"
+	AnthropicContentBlockTypeWebSearchToolResult               AnthropicContentBlockType = "web_search_tool_result"
+	AnthropicContentBlockTypeWebSearchToolResultError          AnthropicContentBlockType = "web_search_tool_result_error"
+	AnthropicContentBlockTypeWebSearchResult                   AnthropicContentBlockType = "web_search_result"
+	AnthropicContentBlockTypeWebFetchToolResult                AnthropicContentBlockType = "web_fetch_tool_result"
+	AnthropicContentBlockTypeCodeExecutionToolResult           AnthropicContentBlockType = "code_execution_tool_result"
+	AnthropicContentBlockTypeBashCodeExecutionToolResult       AnthropicContentBlockType = "bash_code_execution_tool_result"
+	AnthropicContentBlockTypeTextEditorCodeExecutionToolResult AnthropicContentBlockType = "text_editor_code_execution_tool_result"
+	AnthropicContentBlockTypeToolSearchToolResult              AnthropicContentBlockType = "tool_search_tool_result"
+	AnthropicContentBlockTypeToolReference                     AnthropicContentBlockType = "tool_reference"
+	AnthropicContentBlockTypeContainerUpload                   AnthropicContentBlockType = "container_upload"
+	AnthropicContentBlockTypeAdvisorToolResult                 AnthropicContentBlockType = "advisor_tool_result"
+	AnthropicContentBlockTypeMCPToolUse                        AnthropicContentBlockType = "mcp_tool_use"
+	AnthropicContentBlockTypeMCPToolResult                     AnthropicContentBlockType = "mcp_tool_result"
+	AnthropicContentBlockTypeThinking                          AnthropicContentBlockType = "thinking"
+	AnthropicContentBlockTypeRedactedThinking                  AnthropicContentBlockType = "redacted_thinking"
+	AnthropicContentBlockTypeCompaction                        AnthropicContentBlockType = "compaction"
 )
 
 // AnthropicToolCallerType identifies which agentic caller produced a tool
@@ -869,9 +870,9 @@ const (
 type AnthropicToolCallerType string
 
 const (
-	AnthropicToolCallerTypeDirect                 AnthropicToolCallerType = "direct"
-	AnthropicToolCallerTypeCodeExecution20250825  AnthropicToolCallerType = "code_execution_20250825"
-	AnthropicToolCallerTypeCodeExecution20260120  AnthropicToolCallerType = "code_execution_20260120"
+	AnthropicToolCallerTypeDirect                AnthropicToolCallerType = "direct"
+	AnthropicToolCallerTypeCodeExecution20250825 AnthropicToolCallerType = "code_execution_20250825"
+	AnthropicToolCallerTypeCodeExecution20260120 AnthropicToolCallerType = "code_execution_20260120"
 )
 
 // AnthropicToolCaller represents the "caller" union on tool-use and
@@ -926,17 +927,17 @@ type AnthropicContentBlock struct {
 	EncryptedStdout *string `json:"encrypted_stdout,omitempty"`
 
 	// text_editor_code_execution_tool_result variants
-	FileType     *string  `json:"file_type,omitempty"`    // view_result: "text"|"image"|"pdf"
-	StartLine    *int     `json:"start_line,omitempty"`   // view_result
-	NumLines     *int     `json:"num_lines,omitempty"`    // view_result
-	TotalLines   *int     `json:"total_lines,omitempty"`  // view_result
+	FileType     *string  `json:"file_type,omitempty"`      // view_result: "text"|"image"|"pdf"
+	StartLine    *int     `json:"start_line,omitempty"`     // view_result
+	NumLines     *int     `json:"num_lines,omitempty"`      // view_result
+	TotalLines   *int     `json:"total_lines,omitempty"`    // view_result
 	IsFileUpdate *bool    `json:"is_file_update,omitempty"` // create_result
-	OldStart     *int     `json:"old_start,omitempty"`    // str_replace_result
-	OldLines     *int     `json:"old_lines,omitempty"`    // str_replace_result
-	NewStart     *int     `json:"new_start,omitempty"`    // str_replace_result
-	NewLines     *int     `json:"new_lines,omitempty"`    // str_replace_result
-	Lines        []string `json:"lines,omitempty"`        // str_replace_result
-	ErrorMessage *string  `json:"error_message,omitempty"` // text_editor error variant
+	OldStart     *int     `json:"old_start,omitempty"`      // str_replace_result
+	OldLines     *int     `json:"old_lines,omitempty"`      // str_replace_result
+	NewStart     *int     `json:"new_start,omitempty"`      // str_replace_result
+	NewLines     *int     `json:"new_lines,omitempty"`      // str_replace_result
+	Lines        []string `json:"lines,omitempty"`          // str_replace_result
+	ErrorMessage *string  `json:"error_message,omitempty"`  // text_editor error variant
 
 	// tool_search_tool_result success variant
 	ToolReferences []AnthropicContentBlock `json:"tool_references,omitempty"` // tool_search_tool_search_result (array of tool_reference blocks)
@@ -959,7 +960,7 @@ type AnthropicContentBlock struct {
 //   - "url"            → URL
 //   - "text"           → MediaType ("text/plain") + Data
 //   - "content_block"  → Content (nested string OR array of inner blocks);
-//                        recursive ContentBlockSource used inside DocumentBlockParam
+//     recursive ContentBlockSource used inside DocumentBlockParam
 //   - "file"           → FileID (requires files-api-2025-04-14 beta)
 //
 // The struct is a superset — only the fields relevant to Type should be set
@@ -1159,7 +1160,7 @@ const (
 
 	// Web search
 	AnthropicToolTypeWebSearch20250305 AnthropicToolType = "web_search_20250305"
-	AnthropicToolTypeWebSearch20260209 AnthropicToolType = "web_search_20260209" // Dynamic filtering (Opus 4.6 / Sonnet 4.6)
+	AnthropicToolTypeWebSearch20260209 AnthropicToolType = "web_search_20260209" // Dynamic filtering (Opus 4.6 / Sonnet 4.6) - auto injects code_execution
 
 	// Web fetch
 	AnthropicToolTypeWebFetch20250910 AnthropicToolType = "web_fetch_20250910"

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -661,133 +661,16 @@ func setEffortOnOutputConfig(req *AnthropicMessageRequest, effort string) {
 	req.OutputConfig.Effort = &effort
 }
 
-func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, isStreaming bool, excludeFields []string) ([]byte, *schemas.BifrostError) {
-	// Large payload mode: body streams directly from the LP reader in completeRequest/
-	// setAnthropicRequestBody — skip all body building here (matches CheckContextAndGetRequestBody).
-	if providerUtils.IsLargePayloadPassthroughEnabled(ctx) {
-		return nil, nil
-	}
-
-	var jsonBody []byte
-	var err error
-
-	// Check if raw request body should be used
-	if useRawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && useRawBody {
-		jsonBody = request.GetRawRequestBody()
-
-		// Update model with provider model (using gjson/sjson to preserve key order for prompt caching)
-		if modelResult := providerUtils.GetJSONField(jsonBody, "model"); modelResult.Exists() {
-			if modelStr := modelResult.String(); modelStr != "" {
-				_, model := schemas.ParseModelString(modelStr, schemas.Anthropic)
-				jsonBody, err = providerUtils.SetJSONField(jsonBody, "model", model)
-				if err != nil {
-					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-				}
-			}
-		}
-		// Add max_tokens if not present
-		if !providerUtils.JSONFieldExists(jsonBody, "max_tokens") {
-			defaultMaxTokens := AnthropicDefaultMaxTokens
-			if modelResult := providerUtils.GetJSONField(jsonBody, "model"); modelResult.Exists() {
-				defaultMaxTokens = providerUtils.GetMaxOutputTokensOrDefault(modelResult.String(), AnthropicDefaultMaxTokens)
-			}
-			jsonBody, err = providerUtils.SetJSONField(jsonBody, "max_tokens", defaultMaxTokens)
-			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-			}
-		}
-		// Add stream if streaming
-		if isStreaming {
-			jsonBody, err = providerUtils.SetJSONField(jsonBody, "stream", true)
-			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-			}
-		}
-		// Strip auto-injectable server-side tools to prevent conflicts with API auto-injection
-		jsonBody, err = StripAutoInjectableTools(jsonBody)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-		}
-		// Sanitize raw-body fields the target provider does not support.
-		// Behavioural parity with StripUnsupportedAnthropicFields on the typed path.
-		// Feature gating keyed to schemas.Anthropic (not providerName) to match
-		// the typed path below which also hardcodes schemas.Anthropic — ensures
-		// custom Anthropic aliases get identical feature lookup in both modes.
-		jsonBody, err = StripUnsupportedFieldsFromRawBody(jsonBody, schemas.Anthropic, "")
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-		}
-		// Auto-inject matching anthropic-beta headers for fields the sanitizer
-		// preserved (speed, task_budget, cache_control.scope, input_examples,
-		// defer_loading, allowed_callers, eager_input_streaming, mcp_servers,
-		// structured outputs, etc). Without this, raw-body callers who supply
-		// gated fields but not headers would 400 upstream. Single source of
-		// truth: probe-unmarshal into the typed struct and reuse the typed
-		// path's header walker.
-		var probe AnthropicMessageRequest
-		if err := schemas.Unmarshal(jsonBody, &probe); err == nil {
-			AddMissingBetaHeadersToContext(ctx, &probe, schemas.Anthropic)
-		}
-		// Remove excluded fields
-		for _, field := range excludeFields {
-			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, field)
-			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-			}
-		}
-	} else {
-		// Convert request to Anthropic format
-		reqBody, convErr := ToAnthropicResponsesRequest(ctx, request)
-		if convErr != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, convErr)
-		}
-		if reqBody == nil {
-			return nil, providerUtils.NewBifrostOperationError("request body is not provided", nil)
-		}
-		AddMissingBetaHeadersToContext(ctx, reqBody, schemas.Anthropic)
-		if isStreaming {
-			reqBody.Stream = schemas.Ptr(true)
-		}
-		// Marshal struct to JSON bytes
-		jsonBody, err = providerUtils.MarshalSorted(reqBody)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err))
-		}
-		// Merge ExtraParams into the JSON if passthrough is enabled
-		if ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams) != nil && ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams) == true {
-			extraParams := reqBody.GetExtraParams()
-			if len(extraParams) > 0 {
-				// Use MergeExtraParamsIntoJSON which preserves key order
-				jsonBody, err = providerUtils.MergeExtraParamsIntoJSON(jsonBody, extraParams)
-				if err != nil {
-					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-				}
-			}
-			// Remove excluded fields after merging (using sjson to preserve order)
-			for _, field := range excludeFields {
-				jsonBody, err = providerUtils.DeleteJSONField(jsonBody, field)
-				if err != nil {
-					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-				}
-			}
-		} else if len(excludeFields) > 0 {
-			// Remove excluded fields using sjson to preserve key order
-			for _, field := range excludeFields {
-				jsonBody, err = providerUtils.DeleteJSONField(jsonBody, field)
-				if err != nil {
-					return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-				}
-			}
-		}
-	}
-
-	// delete fallbacks field
-	jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "fallbacks")
-	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-	}
-
-	return jsonBody, nil
+// getRequestBodyForResponses serializes a BifrostResponsesRequest into the Anthropic wire format.
+// It delegates to BuildAnthropicResponsesRequestBody with the appropriate provider and streaming config.
+func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, isStreaming bool, excludeFields []string, shouldSendBackRawRequest bool, shouldSendBackRawResponse bool) ([]byte, *schemas.BifrostError) {
+	return BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+		Provider:                  schemas.Anthropic,
+		IsStreaming:               isStreaming,
+		ExcludeFields:             excludeFields,
+		ShouldSendBackRawRequest:  shouldSendBackRawRequest,
+		ShouldSendBackRawResponse: shouldSendBackRawResponse,
+	})
 }
 
 // AddMissingBetaHeadersToContext analyzes the Anthropic request and adds missing beta headers to the context.
@@ -1070,6 +953,27 @@ var unsupportedRawToolTypes = map[schemas.ModelProvider][]string{
 	},
 }
 
+// doesWebSearchOrFetchAutoInjectCodeExecution reports whether the given web search/fetch tool type
+// automatically injects a code-execution beta header. Newer tool versions (2026-02-09 and later)
+// require it; older ones do not. Defaults to true for unrecognized types to preserve backward compatibility.
+func doesWebSearchOrFetchAutoInjectCodeExecution(toolType string) bool {
+	switch toolType {
+	case string(AnthropicToolTypeWebSearch20250305):
+		return false
+	case string(AnthropicToolTypeWebSearch20260209):
+		return true
+	case string(AnthropicToolTypeWebFetch20260309):
+		return true
+	case string(AnthropicToolTypeWebFetch20250910):
+		return false
+	case string(AnthropicToolTypeWebFetch20260209):
+		return true
+	}
+
+	// Keeping it for backward compatibility as this always used to be true
+	return true
+}
+
 // StripAutoInjectableTools removes code_execution tools from the raw JSON body's tools array
 // when web_search or web_fetch tools are also present. The Anthropic API auto-injects
 // code_execution when web_search_20260209 or web_fetch_20260209 is included in the request,
@@ -1089,16 +993,16 @@ func StripAutoInjectableTools(jsonBody []byte) ([]byte, error) {
 
 	// Check if web_search or web_fetch is present — only then does Anthropic
 	// auto-inject code_execution, causing a conflict if it's also explicit.
-	hasWebSearchOrFetch := false
+	hasWebSearchOrFetchWithAutoInjectableCodeExecution := false
 	for _, tool := range tools {
 		toolType := tool.Get("type").String()
 		if strings.HasPrefix(toolType, "web_search_") || strings.HasPrefix(toolType, "web_fetch_") {
-			hasWebSearchOrFetch = true
+			hasWebSearchOrFetchWithAutoInjectableCodeExecution = doesWebSearchOrFetchAutoInjectCodeExecution(toolType)
 			break
 		}
 	}
 
-	if !hasWebSearchOrFetch {
+	if !hasWebSearchOrFetchWithAutoInjectableCodeExecution {
 		return jsonBody, nil
 	}
 

--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -1605,8 +1605,9 @@ func TestStripAutoInjectableTools(t *testing.T) {
 	})
 
 	t.Run("code_execution_and_web_search_only_strips_code_execution", func(t *testing.T) {
-		// When only code_execution + web_search, strip code_execution, keep web_search
-		input := []byte(`{"model":"test","tools":[{"type":"code_execution_20250825","name":"code_execution"},{"type":"web_search_20250305","name":"web_search"}]}`)
+		// When only code_execution + web_search (newer version), strip code_execution, keep web_search
+		// Note: web_search_20260209 auto-injects code_execution, so explicit code_execution is stripped
+		input := []byte(`{"model":"test","tools":[{"type":"code_execution_20250825","name":"code_execution"},{"type":"web_search_20260209","name":"web_search"}]}`)
 		result, err := StripAutoInjectableTools(input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -1788,7 +1789,7 @@ func TestGetRequestBodyForResponses_RawBodyStripsFallbacks(t *testing.T) {
 		RawRequestBody: rawBody,
 	}
 
-	result, bifrostErr := getRequestBodyForResponses(ctx, request, false, nil)
+	result, bifrostErr := getRequestBodyForResponses(ctx, request, false, nil, false, false)
 	if bifrostErr != nil {
 		t.Fatalf("unexpected error: %v", bifrostErr)
 	}

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -687,7 +687,7 @@ func (provider *AzureProvider) Responses(ctx *schemas.BifrostContext, key schema
 	var jsonData []byte
 	var bifrostErr *schemas.BifrostError
 	if schemas.IsAnthropicModel(request.Model) {
-		jsonData, bifrostErr = getRequestBodyForAnthropicResponses(ctx, request, request.Model, false)
+		jsonData, bifrostErr = getRequestBodyForAnthropicResponses(ctx, request, request.Model, false, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	} else {
 		jsonData, bifrostErr = providerUtils.CheckContextAndGetRequestBody(
 			ctx,
@@ -779,7 +779,7 @@ func (provider *AzureProvider) ResponsesStream(ctx *schemas.BifrostContext, post
 		authHeader["anthropic-version"] = AzureAnthropicAPIVersionDefault
 		url = fmt.Sprintf("%s/anthropic/v1/messages", key.AzureKeyConfig.Endpoint.GetValue())
 
-		jsonData, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, request.Model, true)
+		jsonData, bifrostErr := getRequestBodyForAnthropicResponses(ctx, request, request.Model, true, provider.sendBackRawRequest, provider.sendBackRawResponse)
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}

--- a/core/providers/azure/utils.go
+++ b/core/providers/azure/utils.go
@@ -1,82 +1,27 @@
 package azure
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
-	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, deployment string, isStreaming bool) ([]byte, *schemas.BifrostError) {
-	// Large payload mode: body streams directly from the LP reader — skip all body building
-	// (matches CheckContextAndGetRequestBody guard).
-	if providerUtils.IsLargePayloadPassthroughEnabled(ctx) {
-		return nil, nil
-	}
-
-	var jsonBody []byte
-	var err error
-
-	// Check if raw request body should be used
-	if useRawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && useRawBody {
-		jsonBody = request.GetRawRequestBody()
-
-		// Add max_tokens if not present (using sjson to preserve key order for prompt caching)
-		if !providerUtils.JSONFieldExists(jsonBody, "max_tokens") {
-			jsonBody, err = providerUtils.SetJSONField(jsonBody, "max_tokens", providerUtils.GetMaxOutputTokensOrDefault(deployment, anthropic.AnthropicDefaultMaxTokens))
-			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-			}
-		}
-		// Replace model with deployment
-		jsonBody, err = providerUtils.SetJSONField(jsonBody, "model", deployment)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-		}
-		// Delete fallbacks field
-		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "fallbacks")
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-		}
-		// Add stream if streaming
-		if isStreaming {
-			jsonBody, err = providerUtils.SetJSONField(jsonBody, "stream", true)
-			if err != nil {
-				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-			}
-		}
-	} else {
-		// Convert request to Anthropic format
-		request.Model = deployment
-		reqBody, convErr := anthropic.ToAnthropicResponsesRequest(ctx, request)
-		if convErr != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrRequestBodyConversion, convErr)
-		}
-		if reqBody == nil {
-			return nil, providerUtils.NewBifrostOperationError("request body is not provided", nil)
-		}
-
-		if isStreaming {
-			reqBody.Stream = schemas.Ptr(true)
-		}
-
-		// Add provider-aware beta headers for Azure
-		anthropic.AddMissingBetaHeadersToContext(ctx, reqBody, schemas.Azure)
-
-		// Marshal struct to JSON bytes, preserving field order
-		jsonBody, err = providerUtils.MarshalSorted(reqBody)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, fmt.Errorf("failed to marshal request body: %w", err))
-		}
-	}
-
-	return jsonBody, nil
+// getRequestBodyForAnthropicResponses serializes a BifrostResponsesRequest into the Anthropic wire format for Azure.
+// It delegates to BuildAnthropicResponsesRequestBody with the Azure provider and the target deployment name.
+func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, deployment string, isStreaming bool, shouldSendBackRawRequest bool, shouldSendBackRawResponse bool) ([]byte, *schemas.BifrostError) {
+	return anthropic.BuildAnthropicResponsesRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
+		Provider:                  schemas.Azure,
+		Deployment:                deployment,
+		IsStreaming:               isStreaming,
+		ValidateTools:             true,
+		ShouldSendBackRawRequest:  shouldSendBackRawRequest,
+		ShouldSendBackRawResponse: shouldSendBackRawResponse,
+	})
 }
 
-// getCleanedScopes returns cleaned scopes or default scope if none are valid.
-// It filters out empty/whitespace-only strings and returns the default scope if no valid scopes remain.
+// getAzureScopes returns the configured scopes or the default scope if none are valid.
+// It filters out empty/whitespace-only strings.
 func getAzureScopes(configuredScopes []string) []string {
 	scopes := []string{DefaultAzureScope}
 	if len(configuredScopes) > 0 {

--- a/core/providers/cohere/embedding_test.go
+++ b/core/providers/cohere/embedding_test.go
@@ -79,7 +79,6 @@ func TestToCohereEmbeddingRequestBodyIncludesModelForDirectCohere(t *testing.T) 
 		func() (providerUtils.RequestBodyWithExtraParams, error) {
 			return ToCohereEmbeddingRequest(bifrostReq), nil
 		},
-		schemas.Cohere,
 	)
 	require.Nil(t, bifrostErr)
 	assert.JSONEq(t, `{

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -9,192 +9,28 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-func enrichBifrostOperationError(
-	ctx *schemas.BifrostContext,
-	message string,
-	err error,
-	requestBody []byte,
-	responseBody []byte,
-	sendBackRawRequest bool,
-	sendBackRawResponse bool,
-) *schemas.BifrostError {
-	return providerUtils.EnrichError(ctx, providerUtils.NewBifrostOperationError(message, err), requestBody, responseBody, sendBackRawRequest, sendBackRawResponse)
-}
-
+// getRequestBodyForAnthropicResponses serializes a BifrostResponsesRequest into the Anthropic wire format for Vertex AI.
+// Compared to the native Anthropic path, it strips model/region fields, remaps tool versions, injects beta headers
+// into the request body (rather than HTTP headers), and pins the Anthropic API version to DefaultVertexAnthropicVersion.
 func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest, deployment string, isStreaming bool, isCountTokens bool, betaHeaderOverrides map[string]bool, providerExtraHeaders map[string]string, shouldSendBackRawRequest bool, shouldSendBackRawResponse bool) ([]byte, *schemas.BifrostError) {
-	// Large payload mode: body streams directly from the LP reader — skip all body building
-	// (matches CheckContextAndGetRequestBody guard).
-	if providerUtils.IsLargePayloadPassthroughEnabled(ctx) {
-		return nil, nil
-	}
-
-	var jsonBody []byte
-	var err error
-
-	// Check if raw request body should be used
-	if useRawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && useRawBody {
-		jsonBody = request.GetRawRequestBody()
-
-		if isCountTokens {
-			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "max_tokens")
-			if err != nil {
-				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-			}
-			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "temperature")
-			if err != nil {
-				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-			}
-			jsonBody, err = providerUtils.SetJSONField(jsonBody, "model", deployment)
-			if err != nil {
-				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-			}
-		} else {
-			// Add max_tokens if not present
-			if !providerUtils.JSONFieldExists(jsonBody, "max_tokens") {
-				jsonBody, err = providerUtils.SetJSONField(jsonBody, "max_tokens", providerUtils.GetMaxOutputTokensOrDefault(deployment, anthropic.AnthropicDefaultMaxTokens))
-				if err != nil {
-					return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-				}
-			}
-			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "model")
-			if err != nil {
-				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-			}
-			// Add stream if streaming
-			if isStreaming {
-				jsonBody, err = providerUtils.SetJSONField(jsonBody, "stream", true)
-				if err != nil {
-					return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-				}
-			}
-		}
-
-		// Strip auto-injectable server-side tools to prevent conflicts with API auto-injection
-		jsonBody, err = anthropic.StripAutoInjectableTools(jsonBody)
-		if err != nil {
-			return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-		}
-
-		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "region")
-		if err != nil {
-			return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-		}
-
-		// Remap unsupported tool versions for Vertex (e.g., web_search_20260209 → web_search_20250305)
-		jsonBody, err = anthropic.RemapRawToolVersionsForProvider(jsonBody, schemas.Vertex)
-		if err != nil {
-			return nil, enrichBifrostOperationError(ctx, err.Error(), nil, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-		}
-
-		// Strip unsupported fields for Vertex — parity with the typed path's stripUnsupportedAnthropicFields.
-		jsonBody, err = anthropic.StripUnsupportedFieldsFromRawBody(jsonBody, schemas.Vertex, "")
-		if err != nil {
-			return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-		}
-
-		// Add anthropic_version if not present
-		if !providerUtils.JSONFieldExists(jsonBody, "anthropic_version") {
-			jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_version", DefaultVertexAnthropicVersion)
-			if err != nil {
-				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-			}
-		}
-
-		// Probe-unmarshal to auto-inject any beta headers required by fields that survived stripping.
-		// Mirrors the Anthropic typed path so raw-body callers don't need to specify headers manually.
-		var probe anthropic.AnthropicMessageRequest
-		if unmarshalErr := schemas.Unmarshal(jsonBody, &probe); unmarshalErr == nil {
-			anthropic.AddMissingBetaHeadersToContext(ctx, &probe, schemas.Vertex)
-		}
-	} else {
-		// Validate tools are supported by Vertex
-		if request.Params != nil && request.Params.Tools != nil {
-			if toolErr := anthropic.ValidateToolsForProvider(request.Params.Tools, schemas.Vertex); toolErr != nil {
-				return nil, enrichBifrostOperationError(ctx, toolErr.Error(), nil, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-			}
-		}
-
-		// Convert request to Anthropic format
-		reqBody, convErr := anthropic.ToAnthropicResponsesRequest(ctx, request)
-		if convErr != nil {
-			return nil, enrichBifrostOperationError(ctx, schemas.ErrRequestBodyConversion, convErr, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-		}
-		if reqBody == nil {
-			return nil, enrichBifrostOperationError(ctx, "request body is not provided", nil, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-		}
-		reqBody.Model = deployment
-
-		if isStreaming {
-			reqBody.Stream = schemas.Ptr(true)
-		}
-
-		reqBody.SetStripCacheControlScope(true)
-
-		// Add provider-aware beta headers
-		anthropic.AddMissingBetaHeadersToContext(ctx, reqBody, schemas.Vertex)
-
-		// Marshal struct to JSON bytes
-		jsonBody, err = providerUtils.MarshalSorted(reqBody)
-		if err != nil {
-			return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-		}
-
-		if passthrough, _ := ctx.Value(schemas.BifrostContextKeyPassthroughExtraParams).(bool); passthrough {
-			extraParams := reqBody.GetExtraParams()
-			if len(extraParams) > 0 {
-				// Use MergeExtraParamsIntoJSON which preserves key order
-				jsonBody, err = providerUtils.MergeExtraParamsIntoJSON(jsonBody, extraParams)
-				if err != nil {
-					return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-				}
-			}
-		}
-
-		// Add anthropic_version if not present (using sjson to preserve order)
-		if !providerUtils.JSONFieldExists(jsonBody, "anthropic_version") {
-			jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_version", DefaultVertexAnthropicVersion)
-			if err != nil {
-				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-			}
-		}
-
-		if isCountTokens {
-			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "max_tokens")
-			if err != nil {
-				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-			}
-			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "temperature")
-			if err != nil {
-				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-			}
-		} else {
-			// Remove model field for Vertex API (it's in URL)
-			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "model")
-			if err != nil {
-				return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-			}
-		}
-
-		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "region")
-		if err != nil {
-			return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-		}
-	}
-
-	// Delete fallbacks field (both raw and typed paths)
-	jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "fallbacks")
-	if err != nil {
-		return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-	}
-
-	if betaHeaders := anthropic.FilterBetaHeadersForProvider(anthropic.MergeBetaHeaders(providerExtraHeaders, ctx), schemas.Vertex, betaHeaderOverrides); len(betaHeaders) > 0 {
-		jsonBody, err = providerUtils.SetJSONField(jsonBody, "anthropic_beta", betaHeaders)
-		if err != nil {
-			return nil, enrichBifrostOperationError(ctx, schemas.ErrProviderRequestMarshal, err, jsonBody, nil, shouldSendBackRawRequest, shouldSendBackRawResponse)
-		}
-	}
-
-	return jsonBody, nil
+	return anthropic.BuildAnthropicResponsesRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
+		Provider:                  schemas.Vertex,
+		Deployment:                deployment,
+		DeleteModelField:          true,
+		DeleteRegionField:         true,
+		IsStreaming:               isStreaming,
+		IsCountTokens:             isCountTokens,
+		AddAnthropicVersion:       true,
+		AnthropicVersion:          DefaultVertexAnthropicVersion,
+		StripCacheControlScope:    true,
+		RemapToolVersions:         true,
+		InjectBetaHeadersIntoBody: true,
+		BetaHeaderOverrides:       betaHeaderOverrides,
+		ProviderExtraHeaders:      providerExtraHeaders,
+		ValidateTools:             true,
+		ShouldSendBackRawRequest:  shouldSendBackRawRequest,
+		ShouldSendBackRawResponse: shouldSendBackRawResponse,
+	})
 }
 
 // getCompleteURLForGeminiEndpoint constructs the complete URL for the Gemini endpoint, for both streaming and non-streaming requests


### PR DESCRIPTION
## Summary

The three Anthropic-family providers (Anthropic native, Azure, Vertex) each had their own copy of the request-body assembly pipeline for the Responses API. This PR consolidates all three into a single shared function, `BuildAnthropicResponsesRequestBody`, controlled by an `AnthropicRequestBuildConfig` struct. Each provider now delegates to this shared implementation with only the flags relevant to it set.

## Changes

- Introduced `AnthropicRequestBuildConfig` and `BuildAnthropicResponsesRequestBody` in a new `request_builder.go` file. The config struct encodes all provider-specific behaviour (model field handling, region stripping, tool version remapping, beta header injection into body, `anthropic_version` injection, cache-control scope stripping, count-tokens mode, tool validation, and raw-request/response send-back flags).
- Replaced the ~130-line `getRequestBodyForResponses` in `anthropic/utils.go` with a thin wrapper that calls `BuildAnthropicResponsesRequestBody` with `schemas.Anthropic` config.
- Replaced the ~80-line `getRequestBodyForAnthropicResponses` in `azure/utils.go` with a thin wrapper that calls `BuildAnthropicResponsesRequestBody` with `schemas.Azure` config and `ValidateTools: true`.
- Replaced the ~165-line `getRequestBodyForAnthropicResponses` in `vertex/utils.go` with a thin wrapper that calls `BuildAnthropicResponsesRequestBody` with the full Vertex config (model/region deletion, tool remapping, beta header body injection, `anthropic_version` pinning, cache-control scope stripping).
- Removed the now-redundant `enrichBifrostOperationError` helper from `vertex/utils.go`; error enrichment is handled inside `BuildAnthropicResponsesRequestBody` via `providerUtils.EnrichError`.
- `getRequestBodyForResponses` (Anthropic native) and its callers now thread `sendBackRawRequest`/`sendBackRawResponse` flags through to the shared builder so errors can carry raw payloads consistently.
- Fixed `StripAutoInjectableTools` to be version-aware: only `web_search_20260209`, `web_fetch_20260209`, and `web_fetch_20260309` trigger `code_execution` stripping; older tool versions (`web_search_20250305`, `web_fetch_20250910`) do not. Added `doesWebSearchOrFetchAutoInjectCodeExecution` to encode this logic.
- Added comprehensive tests in `request_builder_test.go` covering the raw-body path, typed path, count-tokens mode, large-payload passthrough, tool stripping version awareness, and beta header injection.
- Updated an existing test in `utils_test.go` to use `web_search_20260209` (the version that actually triggers stripping) to match the corrected behaviour.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/... ./core/providers/azure/... ./core/providers/vertex/...
```

Verify that Responses, ResponsesStream, and CountTokens calls work end-to-end for Anthropic native, Azure Anthropic, and Vertex Anthropic deployments. Confirm that raw-body requests with `BifrostContextKeyUseRawRequestBody` produce correctly shaped payloads for each provider (model field present/absent, region stripped, tool versions remapped, beta headers injected into body for Vertex).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth flows, secrets handling, or PII exposure introduced. The raw-request/response send-back flags were already present per-provider; this change ensures they are consistently forwarded through the shared builder.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable