### PR TITLE
fix: drops empty tool calls for anthropic claude code request

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,2 @@
 - feat: Standardizes tool stripping and anthropic integration handling against anthropic, vertex and azure
+- fix: drops empty thinking block for anthropic provider for claude code

--- a/core/providers/anthropic/request_builder.go
+++ b/core/providers/anthropic/request_builder.go
@@ -176,6 +176,11 @@ func BuildAnthropicResponsesRequestBody(ctx *schemas.BifrostContext, request *sc
 			return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
 		}
 
+		jsonBody, err = StripEmptyThinkingBlocks(jsonBody)
+		if err != nil {
+			return nil, newErr(schemas.ErrProviderRequestMarshal, err, jsonBody)
+		}
+
 		if cfg.RemapToolVersions {
 			jsonBody, err = RemapRawToolVersionsForProvider(jsonBody, cfg.Provider)
 			if err != nil {

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -974,6 +974,37 @@ func doesWebSearchOrFetchAutoInjectCodeExecution(toolType string) bool {
 	return true
 }
 
+// StripEmptyThinkingBlocks removes thinking content blocks where
+// "thinking" is an empty string. Anthropic rejects such blocks with a 400.
+func StripEmptyThinkingBlocks(jsonBody []byte) ([]byte, error) {
+	messagesResult := providerUtils.GetJSONField(jsonBody, "messages")
+	if !messagesResult.Exists() || !messagesResult.IsArray() {
+		return jsonBody, nil
+	}
+	var err error
+	for mi, msg := range messagesResult.Array() {
+		contentResult := msg.Get("content")
+		if !contentResult.Exists() || !contentResult.IsArray() {
+			continue
+		}
+		var toStrip []int
+		for ci, block := range contentResult.Array() {
+			if block.Get("type").String() == "thinking" && block.Get("thinking").String() == "" {
+				toStrip = append(toStrip, ci)
+			}
+		}
+		for i := len(toStrip) - 1; i >= 0; i-- {
+			path := fmt.Sprintf("messages.%d.content.%d", mi, toStrip[i])
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to strip empty thinking block at %s: %w", path, err)
+			}
+
+		}
+	}
+	return jsonBody, nil
+}
+
 // StripAutoInjectableTools removes code_execution tools from the raw JSON body's tools array
 // when web_search or web_fetch tools are also present. The Anthropic API auto-injects
 // code_execution when web_search_20260209 or web_fetch_20260209 is included in the request,


### PR DESCRIPTION
## Summary

Anthropic returns a 400 error when a request contains `thinking` content blocks where the `"thinking"` field is an empty string. This PR adds a sanitization step that strips those invalid blocks from the raw JSON body before the request is sent.

## Changes

- Added `StripEmptyThinkingBlocks` which iterates over all message content blocks in the raw JSON body and removes any block with `"type": "thinking"` and an empty `"thinking"` field.
- Wired `StripEmptyThinkingBlocks` into `getRequestBodyForResponses` so it runs after marshalling and before the existing unsupported-field sanitization step.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a request to the Anthropic provider that includes a `thinking` content block with an empty `"thinking"` string and verify the request succeeds rather than returning a 400.

```sh
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. The change only removes malformed content blocks from outbound request bodies.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable