### PR TITLE
refactor: remove log callback wiring from WebSocket handler

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4049,10 +4049,20 @@ func (bifrost *Bifrost) RunStreamPreHooks(ctx *schemas.BifrostContext, req *sche
 		bifrost.releasePluginPipeline(pipeline)
 	}
 
+	// Capture provider/model from the original request for early-exit paths below.
+	// RequestType, Provider, OriginalModelRequested, and ResolvedModelUsed are always
+	// overwritten around RunPostLLMHooks — plugin modifications to these 4 fields are
+	// no-ops by design; proper request metadata is preserved and tampering is discouraged.
+	reqProvider, reqModel, _ := req.GetRequestFields()
+
 	preReq, shortCircuit, preCount := pipeline.RunLLMPreHooks(ctx, req)
 	if preReq == nil && shortCircuit == nil {
 		bifrostErr := newBifrostErrorFromMsg("bifrost request after plugin hooks cannot be nil")
+		bifrostErr.PopulateExtraFields(req.RequestType, reqProvider, reqModel, reqModel)
 		_, bifrostErr = pipeline.RunPostLLMHooks(ctx, nil, bifrostErr, preCount)
+		if bifrostErr != nil {
+			bifrostErr.PopulateExtraFields(req.RequestType, reqProvider, reqModel, reqModel)
+		}
 		drainAndAttachPluginLogs(ctx)
 		if traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string); ok && strings.TrimSpace(traceID) != "" {
 			tracer.CompleteAndFlushTrace(strings.TrimSpace(traceID))
@@ -4062,7 +4072,11 @@ func (bifrost *Bifrost) RunStreamPreHooks(ctx *schemas.BifrostContext, req *sche
 	}
 	if shortCircuit != nil {
 		if shortCircuit.Error != nil {
+			shortCircuit.Error.PopulateExtraFields(req.RequestType, reqProvider, reqModel, reqModel)
 			_, bifrostErr := pipeline.RunPostLLMHooks(ctx, nil, shortCircuit.Error, preCount)
+			if bifrostErr != nil {
+				bifrostErr.PopulateExtraFields(req.RequestType, reqProvider, reqModel, reqModel)
+			}
 			drainAndAttachPluginLogs(ctx)
 			if traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string); ok && strings.TrimSpace(traceID) != "" {
 				tracer.CompleteAndFlushTrace(strings.TrimSpace(traceID))
@@ -4074,7 +4088,13 @@ func (bifrost *Bifrost) RunStreamPreHooks(ctx *schemas.BifrostContext, req *sche
 			return nil, shortCircuit.Error
 		}
 		if shortCircuit.Response != nil {
+			shortCircuit.Response.PopulateExtraFields(req.RequestType, reqProvider, reqModel, reqModel)
 			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, shortCircuit.Response, nil, preCount)
+			if bifrostErr != nil {
+				bifrostErr.PopulateExtraFields(req.RequestType, reqProvider, reqModel, reqModel)
+			} else if resp != nil {
+				resp.PopulateExtraFields(req.RequestType, reqProvider, reqModel, reqModel)
+			}
 			drainAndAttachPluginLogs(ctx)
 			if traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string); ok && strings.TrimSpace(traceID) != "" {
 				tracer.CompleteAndFlushTrace(strings.TrimSpace(traceID))
@@ -4104,7 +4124,13 @@ func (bifrost *Bifrost) RunStreamPreHooks(ctx *schemas.BifrostContext, req *sche
 		if IsFinalChunk(ctx) {
 			drainAndAttachPluginLogs(ctx)
 		}
-		return resp, bifrostErr
+		if bifrostErr != nil {
+			bifrostErr.PopulateExtraFields(req.RequestType, wsProvider, wsModel, wsModel)
+			return nil, bifrostErr
+		} else if resp != nil {
+			resp.PopulateExtraFields(req.RequestType, wsProvider, wsModel, wsModel)
+		}
+		return resp, nil
 	}
 
 	return &WSStreamHooks{
@@ -4191,11 +4217,25 @@ func (bifrost *Bifrost) RunRealtimeTurnPreHooks(ctx *schemas.BifrostContext, req
 		}
 	}
 
+	provider, model, _ = preReq.GetRequestFields()
+
 	return &RealtimeTurnHooks{
 		PostHookRunner: func(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+			if result != nil {
+				result.PopulateExtraFields(schemas.RealtimeRequest, provider, model, model)
+			}
+			if err != nil {
+				err.PopulateExtraFields(schemas.RealtimeRequest, provider, model, model)
+			}
 			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, result, err, preCount)
 			drainAndAttachPluginLogs(ctx)
-			return resp, bifrostErr
+			if bifrostErr != nil {
+				bifrostErr.PopulateExtraFields(schemas.RealtimeRequest, provider, model, model)
+				return nil, bifrostErr
+			} else if resp != nil {
+				resp.PopulateExtraFields(schemas.RealtimeRequest, provider, model, model)
+			}
+			return resp, nil
 		},
 		Cleanup: cleanup,
 	}, nil
@@ -4598,24 +4638,37 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	pipeline := bifrost.getPluginPipeline()
 	defer bifrost.releasePluginPipeline(pipeline)
 
+	// RequestType, Provider, OriginalModelRequested, and ResolvedModelUsed are always
+	// overwritten around RunPostLLMHooks — plugin modifications to these 4 fields are
+	// no-ops by design; proper request metadata is preserved and tampering is discouraged.
 	preReq, shortCircuit, preCount := pipeline.RunLLMPreHooks(ctx, req)
 	if shortCircuit != nil {
 		// Handle short-circuit with response (success case)
 		if shortCircuit.Response != nil {
+			shortCircuit.Response.PopulateExtraFields(req.RequestType, provider, model, model)
 			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, shortCircuit.Response, nil, preCount)
-			drainAndAttachPluginLogs(ctx)
 			if bifrostErr != nil {
 				bifrostErr.PopulateExtraFields(req.RequestType, provider, model, model)
+			} else if resp != nil {
+				resp.PopulateExtraFields(req.RequestType, provider, model, model)
+			}
+			drainAndAttachPluginLogs(ctx)
+			if bifrostErr != nil {
 				return nil, bifrostErr
 			}
 			return resp, nil
 		}
 		// Handle short-circuit with error
 		if shortCircuit.Error != nil {
+			shortCircuit.Error.PopulateExtraFields(req.RequestType, provider, model, model)
 			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, nil, shortCircuit.Error, preCount)
-			drainAndAttachPluginLogs(ctx)
 			if bifrostErr != nil {
 				bifrostErr.PopulateExtraFields(req.RequestType, provider, model, model)
+			} else if resp != nil {
+				resp.PopulateExtraFields(req.RequestType, provider, model, model)
+			}
+			drainAndAttachPluginLogs(ctx)
+			if bifrostErr != nil {
 				return nil, bifrostErr
 			}
 			return resp, nil
@@ -4626,6 +4679,8 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 		bifrostErr.PopulateExtraFields(req.RequestType, provider, model, model)
 		return nil, bifrostErr
 	}
+
+	provider, model, _ = preReq.GetRequestFields()
 
 	msg := bifrost.getChannelMessage(*preReq)
 	msg.Context = ctx
@@ -4651,6 +4706,7 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 				RequestType:            req.RequestType,
 				Provider:               provider,
 				OriginalModelRequested: model,
+				ResolvedModelUsed:      model,
 			}
 			return nil, bifrostErr
 		}
@@ -4708,6 +4764,11 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	select {
 	case result = <-msg.Response:
 		resp, bifrostErr := pipeline.RunPostLLMHooks(msg.Context, result, nil, pluginCount)
+		if bifrostErr != nil {
+			bifrostErr.PopulateExtraFields(req.RequestType, provider, model, model)
+		} else if resp != nil {
+			resp.PopulateExtraFields(req.RequestType, provider, model, model)
+		}
 		drainAndAttachPluginLogs(msg.Context)
 		if bifrostErr != nil {
 			bifrost.releaseChannelMessage(msg)
@@ -4732,6 +4793,11 @@ func (bifrost *Bifrost) tryRequest(ctx *schemas.BifrostContext, req *schemas.Bif
 	case bifrostErrVal := <-msg.Err:
 		bifrostErrPtr := &bifrostErrVal
 		resp, bifrostErrPtr = pipeline.RunPostLLMHooks(msg.Context, nil, bifrostErrPtr, pluginCount)
+		if bifrostErrPtr != nil {
+			bifrostErrPtr.PopulateExtraFields(req.RequestType, provider, model, model)
+		} else if resp != nil {
+			resp.PopulateExtraFields(req.RequestType, provider, model, model)
+		}
 		drainAndAttachPluginLogs(msg.Context)
 		bifrost.releaseChannelMessage(msg)
 		// Strip raw fields on error path too.
@@ -4823,14 +4889,22 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		}
 	}()
 
+	// RequestType, Provider, OriginalModelRequested, and ResolvedModelUsed are always
+	// overwritten around RunPostLLMHooks — plugin modifications to these 4 fields are
+	// no-ops by design; proper request metadata is preserved and tampering is discouraged.
 	preReq, shortCircuit, preCount := pipeline.RunLLMPreHooks(ctx, req)
 	if shortCircuit != nil {
 		// Handle short-circuit with response (success case)
 		if shortCircuit.Response != nil {
+			shortCircuit.Response.PopulateExtraFields(req.RequestType, provider, model, model)
 			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, shortCircuit.Response, nil, preCount)
-			drainAndAttachPluginLogs(ctx)
 			if bifrostErr != nil {
 				bifrostErr.PopulateExtraFields(req.RequestType, provider, model, model)
+			} else if resp != nil {
+				resp.PopulateExtraFields(req.RequestType, provider, model, model)
+			}
+			drainAndAttachPluginLogs(ctx)
+			if bifrostErr != nil {
 				return nil, bifrostErr
 			}
 			return newBifrostMessageChan(resp), nil
@@ -4842,11 +4916,23 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 
 			// Create a post hook runner cause pipeline object is put back in the pool on defer
 			pipelinePostHookRunner := func(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+				if result != nil {
+					result.PopulateExtraFields(req.RequestType, provider, model, model)
+				}
+				if err != nil {
+					err.PopulateExtraFields(req.RequestType, provider, model, model)
+				}
 				resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, result, err, preCount)
 				if IsFinalChunk(ctx) {
 					drainAndAttachPluginLogs(ctx)
 				}
-				return resp, bifrostErr
+				if bifrostErr != nil {
+					bifrostErr.PopulateExtraFields(req.RequestType, provider, model, model)
+					return nil, bifrostErr
+				} else if resp != nil {
+					resp.PopulateExtraFields(req.RequestType, provider, model, model)
+				}
+				return resp, nil
 			}
 
 			go func() {
@@ -4909,10 +4995,15 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		}
 		// Handle short-circuit with error
 		if shortCircuit.Error != nil {
+			shortCircuit.Error.PopulateExtraFields(req.RequestType, provider, model, model)
 			resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, nil, shortCircuit.Error, preCount)
-			drainAndAttachPluginLogs(ctx)
 			if bifrostErr != nil {
 				bifrostErr.PopulateExtraFields(req.RequestType, provider, model, model)
+			} else if resp != nil {
+				resp.PopulateExtraFields(req.RequestType, provider, model, model)
+			}
+			drainAndAttachPluginLogs(ctx)
+			if bifrostErr != nil {
 				return nil, bifrostErr
 			}
 			return newBifrostMessageChan(resp), nil
@@ -4923,6 +5014,8 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		bifrostErr.PopulateExtraFields(req.RequestType, provider, model, model)
 		return nil, bifrostErr
 	}
+
+	provider, model, _ = preReq.GetRequestFields()
 
 	msg := bifrost.getChannelMessage(*preReq)
 	msg.Context = ctx
@@ -5013,6 +5106,11 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 		ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 		// On error we will complete post-hooks
 		recoveredResp, recoveredErr := pipeline.RunPostLLMHooks(ctx, nil, &bifrostErrVal, len(*bifrost.llmPlugins.Load()))
+		if recoveredErr != nil {
+			recoveredErr.PopulateExtraFields(req.RequestType, provider, model, model)
+		} else if recoveredResp != nil {
+			recoveredResp.PopulateExtraFields(req.RequestType, provider, model, model)
+		}
 		drainAndAttachPluginLogs(ctx)
 		bifrost.releaseChannelMessage(msg)
 		if recoveredErr != nil {

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -857,6 +857,9 @@ func (r *BifrostResponse) GetExtraFields() *BifrostResponseExtraFields {
 	return &BifrostResponseExtraFields{}
 }
 
+// PopulateExtraFields sets RequestType, Provider, OriginalModelRequested, and ResolvedModelUsed on the
+// active sub-response. Core always calls this both before and after RunPostLLMHooks, so any plugin
+// modifications to these 4 fields are no-ops — tampering with them inside plugins is discouraged.
 func (r *BifrostResponse) PopulateExtraFields(requestType RequestType, provider ModelProvider, originalModelRequested string, resolvedModelUsed string) {
 	if r == nil {
 		return
@@ -1181,6 +1184,9 @@ type BifrostError struct {
 	ExtraFields    BifrostErrorExtraFields `json:"extra_fields"`
 }
 
+// PopulateExtraFields sets RequestType, Provider, OriginalModelRequested, and ResolvedModelUsed on the
+// error's ExtraFields. Core always calls this both before and after RunPostLLMHooks, so any plugin
+// modifications to these 4 fields are no-ops — tampering with them inside plugins is discouraged.
 func (e *BifrostError) PopulateExtraFields(requestType RequestType, provider ModelProvider, originalModelRequested string, resolvedModelUsed string) {
 	if e == nil {
 		return

--- a/transports/bifrost-http/handlers/websocket.go
+++ b/transports/bifrost-http/handlers/websocket.go
@@ -12,7 +12,6 @@ import (
 	"github.com/fasthttp/router"
 	"github.com/fasthttp/websocket"
 	"github.com/maximhq/bifrost/core/schemas"
-	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
@@ -158,124 +157,6 @@ func (h *WebSocketHandler) sendMessageSafely(client *WebSocketClient, messageTyp
 	}
 
 	return err
-}
-
-// BroadcastLogUpdate sends a log update to all connected WebSocket clients
-func (h *WebSocketHandler) BroadcastLogUpdate(logEntry *logstore.Log) {
-	// Nil guard to prevent panics
-	if logEntry == nil {
-		return
-	}
-
-	// Add panic recovery to prevent server crashes
-	defer func() {
-		if r := recover(); r != nil {
-			logger.Error("panic in BroadcastLogUpdate: %v", r)
-		}
-	}()
-
-	// Determine operation type based on log status and timestamp
-	operationType := "update"
-	if logEntry.Status == "processing" && logEntry.CreatedAt.Equal(logEntry.Timestamp) {
-		operationType = "create"
-	}
-
-	// Trim payload for table view to keep websocket updates lightweight, but keep
-	// full realtime turns so the live table/detail sheet can still render the
-	// combined tool/user/assistant turn shape without waiting for a refresh.
-	if logEntry.Object != "realtime.turn" {
-		if len(logEntry.InputHistoryParsed) > 1 {
-			logEntry.InputHistoryParsed = logEntry.InputHistoryParsed[len(logEntry.InputHistoryParsed)-1:]
-		}
-		if len(logEntry.ResponsesInputHistoryParsed) > 1 {
-			logEntry.ResponsesInputHistoryParsed = logEntry.ResponsesInputHistoryParsed[len(logEntry.ResponsesInputHistoryParsed)-1:]
-		}
-		logEntry.OutputMessageParsed = nil
-		logEntry.ResponsesOutputParsed = nil
-		logEntry.EmbeddingOutputParsed = nil
-		logEntry.RerankOutputParsed = nil
-		logEntry.ParamsParsed = nil
-		logEntry.ToolsParsed = nil
-		logEntry.ToolCallsParsed = nil
-		logEntry.SpeechOutputParsed = nil
-		logEntry.TranscriptionOutputParsed = nil
-		logEntry.ImageGenerationOutputParsed = nil
-		logEntry.ListModelsOutputParsed = nil
-		logEntry.CacheDebugParsed = nil
-	}
-	if len(logEntry.ResponsesInputHistoryParsed) > 1 {
-		logEntry.ResponsesInputHistoryParsed = logEntry.ResponsesInputHistoryParsed[len(logEntry.ResponsesInputHistoryParsed)-1:]
-	}
-	logEntry.OutputMessageParsed = nil
-	logEntry.ResponsesOutputParsed = nil
-	logEntry.EmbeddingOutputParsed = nil
-	logEntry.RerankOutputParsed = nil
-	logEntry.OCROutputParsed = nil
-	logEntry.ParamsParsed = nil
-	logEntry.ToolsParsed = nil
-	logEntry.ToolCallsParsed = nil
-	logEntry.SpeechOutputParsed = nil
-	logEntry.TranscriptionOutputParsed = nil
-	logEntry.ImageGenerationOutputParsed = nil
-	logEntry.ListModelsOutputParsed = nil
-	logEntry.CacheDebugParsed = nil
-
-	message := struct {
-		Type      string        `json:"type"`
-		Operation string        `json:"operation"` // "create" or "update"
-		Payload   *logstore.Log `json:"payload"`
-	}{
-		Type:      "log",
-		Operation: operationType,
-		Payload:   logEntry,
-	}
-
-	data, err := sonic.Marshal(message)
-	if err != nil {
-		logger.Error("failed to marshal log entry: %v", err)
-		return
-	}
-
-	h.BroadcastMarshaledMessage(data)
-}
-
-// BroadcastMCPLogUpdate sends an MCP tool log update to all connected WebSocket clients
-func (h *WebSocketHandler) BroadcastMCPLogUpdate(logEntry *logstore.MCPToolLog) {
-	// Nil guard to prevent panics
-	if logEntry == nil {
-		return
-	}
-
-	// Add panic recovery to prevent server crashes
-	defer func() {
-		if r := recover(); r != nil {
-			logger.Error("panic in BroadcastMCPLogUpdate: %v", r)
-		}
-	}()
-
-	// Determine operation type based on log status and timestamp
-	operationType := "update"
-	if logEntry.Status == "processing" && logEntry.CreatedAt.Equal(logEntry.Timestamp) {
-		operationType = "create"
-	}
-
-	message := struct {
-		Type      string               `json:"type"`
-		Operation string               `json:"operation"` // "create" or "update"
-		Payload   *logstore.MCPToolLog `json:"payload"`
-	}{
-		Type:      "mcp_log",
-		Operation: operationType,
-		Payload:   logEntry,
-	}
-
-	data, err := sonic.Marshal(message)
-	if err != nil {
-		logger.Error("failed to marshal MCP log entry: %v", err)
-		return
-	}
-
-	h.BroadcastMarshaledMessage(data)
 }
 
 // BroadcastUpdatesToClients sends a store update notification to all connected WebSocket clients

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -97,8 +97,6 @@ type ServerCallbacks interface {
 	// SetClientTools updates the tool map for an existing client.
 	SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string)
 	ReconnectMCPClient(ctx context.Context, id string) error
-	// Logging related callbacks
-	NewLogEntryAdded(ctx context.Context, logEntry *logstore.Log) error
 }
 
 // BifrostHTTPServer represents a HTTP server instance.
@@ -217,15 +215,6 @@ func (s *BifrostHTTPServer) UpdateMCPClient(ctx context.Context, id string, upda
 	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
 		logger.Warn("failed to sync MCP servers after editing client: %v", err)
 	}
-	return nil
-}
-
-// NewLogEntryAdded broadcasts a new log entry to the websocket clients
-func (s *BifrostHTTPServer) NewLogEntryAdded(_ context.Context, logEntry *logstore.Log) error {
-	if s.WebSocketHandler == nil {
-		return nil
-	}
-	s.WebSocketHandler.BroadcastLogUpdate(logEntry)
 	return nil
 }
 
@@ -1085,15 +1074,6 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	logger.Debug("initializing websocket server")
 	if s.WebSocketHandler == nil {
 		s.WebSocketHandler = handlers.NewWebSocketHandler(s.Ctx, s.Config.ClientConfig.AllowedOrigins)
-	}
-	if loggerPlugin != nil {
-		loggerPlugin.SetLogCallback(func(ctx context.Context, logEntry *logstore.Log) {
-			err := s.NewLogEntryAdded(ctx, logEntry)
-			if err != nil {
-				logger.Error("failed to add log entry: %v", err)
-			}
-		})
-		loggerPlugin.SetMCPToolLogCallback(s.WebSocketHandler.BroadcastMCPLogUpdate)
 	}
 	// Start WebSocket heartbeat
 	s.WebSocketHandler.StartHeartbeat()


### PR DESCRIPTION
## Summary

Removes the WebSocket-based log broadcasting logic from the HTTP transport layer. Previously, log entries and MCP tool logs were pushed to WebSocket clients via callbacks registered on the logger plugin. This coupling between the logger plugin and the WebSocket handler has been removed.

## Changes

- Removed `BroadcastLogUpdate` and `BroadcastMCPLogUpdate` methods from `WebSocketHandler`, which handled trimming and marshaling log entries before broadcasting them to connected clients.
- Removed `NewLogEntryAdded` from the `ServerCallbacks` interface and its implementation on `BifrostHTTPServer`.
- Removed the logger plugin callback registration in `RegisterAPIRoutes` that wired log events to WebSocket broadcasts.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Verify that the server starts without errors and that WebSocket connections for non-log events (e.g., store update notifications via `BroadcastUpdatesToClients`) continue to function correctly.

```sh
go test ./...
```

Confirm that log entries are no longer pushed over WebSocket connections and that removing this behavior does not cause panics or regressions in other WebSocket functionality.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

`NewLogEntryAdded` has been removed from the `ServerCallbacks` interface. Any external implementations of `ServerCallbacks` must remove this method.

## Related issues

N/A

## Security considerations

No security implications. The removed code handled internal log broadcasting and did not involve auth, secrets, or PII handling beyond what the logger plugin already managed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable