### PR TITLE
feat: add `version` field support to built-in plugins for DB-backed Helm deployments

### DIFF
--- a/docs/deployment-guides/helm.mdx
+++ b/docs/deployment-guides/helm.mdx
@@ -5,7 +5,7 @@ icon: "server"
 ---
 
 <Note>
-**Latest Chart Version:** 2.1.0 | [View on Artifact Hub](https://artifacthub.io/packages/helm/bifrost/bifrost)
+**Latest Chart Version**: [View on Artifact Hub](https://artifacthub.io/packages/helm/bifrost/bifrost)
 </Note>
 
 <Tabs>
@@ -179,10 +179,13 @@ bifrost:
   plugins:
     telemetry:
       enabled: true
+      version: 1
     logging:
       enabled: true
+      version: 1
     governance:
       enabled: true
+      version: 1
 ```
 
 ```bash
@@ -441,14 +444,18 @@ bifrost:
   plugins:
     telemetry:
       enabled: true
+      version: 1
     logging:
       enabled: true
+      version: 1
     governance:
       enabled: true
+      version: 1
       config:
         is_vk_mandatory: true
     semanticCache:
       enabled: true
+      version: 1
       config:
         provider: "openai"
         embedding_model: "text-embedding-3-small"
@@ -470,6 +477,10 @@ helm install bifrost bifrost/bifrost -f enterprise.yaml
 ```
 
 Next steps: jump to [Next Steps](#next-steps).
+
+<Note>
+For DB-backed deployments, built-in plugins support a top-level `version` field (for example: `telemetry`, `logging`, `governance`, `semanticCache`, `otel`, `maxim`, `datadog`). Increase this number when you want config from Helm to overwrite an older plugin record in the DB.
+</Note>
 
 ## Enterprise Support
 

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.4
-appVersion: "1.5.0-prerelease5"
+version: 2.1.5
+appVersion: "1.5.0-prerelease4"
 keywords:
   - ai
   - gateway

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -861,10 +861,14 @@ false
 {{- /* Plugins - as array per schema */ -}}
 {{- $plugins := list }}
 {{- if .Values.bifrost.plugins.telemetry.enabled }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "telemetry" "config" .Values.bifrost.plugins.telemetry.config) }}
+{{- $plugin := dict "enabled" true "name" "telemetry" "config" .Values.bifrost.plugins.telemetry.config }}
+{{- if hasKey .Values.bifrost.plugins.telemetry "version" }}{{- $_ := set $plugin "version" (.Values.bifrost.plugins.telemetry.version | int) }}{{- end }}
+{{- $plugins = append $plugins $plugin }}
 {{- end }}
 {{- if .Values.bifrost.plugins.logging.enabled }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "logging" "config" .Values.bifrost.plugins.logging.config) }}
+{{- $plugin := dict "enabled" true "name" "logging" "config" .Values.bifrost.plugins.logging.config }}
+{{- if hasKey .Values.bifrost.plugins.logging "version" }}{{- $_ := set $plugin "version" (.Values.bifrost.plugins.logging.version | int) }}{{- end }}
+{{- $plugins = append $plugins $plugin }}
 {{- end }}
 {{- if .Values.bifrost.plugins.governance.enabled }}
 {{- $governanceConfig := dict }}
@@ -877,7 +881,9 @@ false
 {{- if hasKey .Values.bifrost.plugins.governance.config "is_enterprise" }}
 {{- $_ := set $governanceConfig "is_enterprise" .Values.bifrost.plugins.governance.config.is_enterprise }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "governance" "config" $governanceConfig) }}
+{{- $plugin := dict "enabled" true "name" "governance" "config" $governanceConfig }}
+{{- if hasKey .Values.bifrost.plugins.governance "version" }}{{- $_ := set $plugin "version" (.Values.bifrost.plugins.governance.version | int) }}{{- end }}
+{{- $plugins = append $plugins $plugin }}
 {{- end }}
 {{- if .Values.bifrost.plugins.maxim.enabled }}
 {{- $maximConfig := dict }}
@@ -889,7 +895,9 @@ false
 {{- if .Values.bifrost.plugins.maxim.config.log_repo_id }}
 {{- $_ := set $maximConfig "log_repo_id" .Values.bifrost.plugins.maxim.config.log_repo_id }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "maxim" "config" $maximConfig) }}
+{{- $plugin := dict "enabled" true "name" "maxim" "config" $maximConfig }}
+{{- if hasKey .Values.bifrost.plugins.maxim "version" }}{{- $_ := set $plugin "version" (.Values.bifrost.plugins.maxim.version | int) }}{{- end }}
+{{- $plugins = append $plugins $plugin }}
 {{- end }}
 {{- if .Values.bifrost.plugins.semanticCache.enabled }}
 {{- $scConfig := dict }}
@@ -936,7 +944,9 @@ false
 {{- if hasKey $inputConfig "cleanup_on_shutdown" }}
 {{- $_ := set $scConfig "cleanup_on_shutdown" $inputConfig.cleanup_on_shutdown }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "semantic_cache" "config" $scConfig) }}
+{{- $plugin := dict "enabled" true "name" "semantic_cache" "config" $scConfig }}
+{{- if hasKey .Values.bifrost.plugins.semanticCache "version" }}{{- $_ := set $plugin "version" (.Values.bifrost.plugins.semanticCache.version | int) }}{{- end }}
+{{- $plugins = append $plugins $plugin }}
 {{- end }}
 {{- if .Values.bifrost.plugins.otel.enabled }}
 {{- $otelConfig := dict }}
@@ -971,7 +981,9 @@ false
 {{- if hasKey $inputConfig "insecure" }}
 {{- $_ := set $otelConfig "insecure" $inputConfig.insecure }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "otel" "config" $otelConfig) }}
+{{- $plugin := dict "enabled" true "name" "otel" "config" $otelConfig }}
+{{- if hasKey .Values.bifrost.plugins.otel "version" }}{{- $_ := set $plugin "version" (.Values.bifrost.plugins.otel.version | int) }}{{- end }}
+{{- $plugins = append $plugins $plugin }}
 {{- end }}
 {{- if .Values.bifrost.plugins.datadog.enabled }}
 {{- $datadogConfig := dict }}
@@ -994,14 +1006,16 @@ false
 {{- if hasKey $inputConfig "enable_traces" }}
 {{- $_ := set $datadogConfig "enable_traces" $inputConfig.enable_traces }}
 {{- end }}
-{{- $plugins = append $plugins (dict "enabled" true "name" "datadog" "config" $datadogConfig) }}
+{{- $plugin := dict "enabled" true "name" "datadog" "config" $datadogConfig }}
+{{- if hasKey .Values.bifrost.plugins.datadog "version" }}{{- $_ := set $plugin "version" (.Values.bifrost.plugins.datadog.version | int) }}{{- end }}
+{{- $plugins = append $plugins $plugin }}
 {{- end }}
 {{- /* Custom plugins */ -}}
 {{- if .Values.bifrost.plugins.custom }}
 {{- range .Values.bifrost.plugins.custom }}
 {{- $customPlugin := dict "enabled" .enabled "name" .name }}
 {{- if .path }}{{- $_ := set $customPlugin "path" .path }}{{- end }}
-{{- if .version }}{{- $_ := set $customPlugin "version" .version }}{{- end }}
+{{- if hasKey . "version" }}{{- $_ := set $customPlugin "version" (.version | int) }}{{- end }}
 {{- if .config }}{{- $_ := set $customPlugin "config" .config }}{{- end }}
 {{- if .placement }}{{- $_ := set $customPlugin "placement" .placement }}{{- end }}
 {{- if .order }}{{- $_ := set $customPlugin "order" (.order | int) }}{{- end }}
@@ -1088,6 +1102,50 @@ Validation template - validates required fields from config.schema.json
 Call this template at the beginning of deployment/stateful templates
 */}}
 {{- define "bifrost.validate" -}}
+
+{{/* Validate semantic cache plugin when enabled */}}
+{{- if and .Values.bifrost.plugins.telemetry.enabled (hasKey .Values.bifrost.plugins.telemetry "version") (lt (int .Values.bifrost.plugins.telemetry.version) 1) }}
+{{- fail "ERROR: bifrost.plugins.telemetry.version must be >= 1. Bump to >1 to force DB-backed plugin config updates." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.telemetry.enabled (hasKey .Values.bifrost.plugins.telemetry "version") (gt (int .Values.bifrost.plugins.telemetry.version) 32767) }}
+{{- fail "ERROR: bifrost.plugins.telemetry.version must be <= 32767." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.logging.enabled (hasKey .Values.bifrost.plugins.logging "version") (lt (int .Values.bifrost.plugins.logging.version) 1) }}
+{{- fail "ERROR: bifrost.plugins.logging.version must be >= 1. Bump to >1 to force DB-backed plugin config updates." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.logging.enabled (hasKey .Values.bifrost.plugins.logging "version") (gt (int .Values.bifrost.plugins.logging.version) 32767) }}
+{{- fail "ERROR: bifrost.plugins.logging.version must be <= 32767." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.governance.enabled (hasKey .Values.bifrost.plugins.governance "version") (lt (int .Values.bifrost.plugins.governance.version) 1) }}
+{{- fail "ERROR: bifrost.plugins.governance.version must be >= 1. Bump to >1 to force DB-backed plugin config updates." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.governance.enabled (hasKey .Values.bifrost.plugins.governance "version") (gt (int .Values.bifrost.plugins.governance.version) 32767) }}
+{{- fail "ERROR: bifrost.plugins.governance.version must be <= 32767." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.maxim.enabled (hasKey .Values.bifrost.plugins.maxim "version") (lt (int .Values.bifrost.plugins.maxim.version) 1) }}
+{{- fail "ERROR: bifrost.plugins.maxim.version must be >= 1. Bump to >1 to force DB-backed plugin config updates." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.maxim.enabled (hasKey .Values.bifrost.plugins.maxim "version") (gt (int .Values.bifrost.plugins.maxim.version) 32767) }}
+{{- fail "ERROR: bifrost.plugins.maxim.version must be <= 32767." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.semanticCache.enabled (hasKey .Values.bifrost.plugins.semanticCache "version") (lt (int .Values.bifrost.plugins.semanticCache.version) 1) }}
+{{- fail "ERROR: bifrost.plugins.semanticCache.version must be >= 1. Bump to >1 to force DB-backed plugin config updates." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.semanticCache.enabled (hasKey .Values.bifrost.plugins.semanticCache "version") (gt (int .Values.bifrost.plugins.semanticCache.version) 32767) }}
+{{- fail "ERROR: bifrost.plugins.semanticCache.version must be <= 32767." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.otel.enabled (hasKey .Values.bifrost.plugins.otel "version") (lt (int .Values.bifrost.plugins.otel.version) 1) }}
+{{- fail "ERROR: bifrost.plugins.otel.version must be >= 1. Bump to >1 to force DB-backed plugin config updates." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.otel.enabled (hasKey .Values.bifrost.plugins.otel "version") (gt (int .Values.bifrost.plugins.otel.version) 32767) }}
+{{- fail "ERROR: bifrost.plugins.otel.version must be <= 32767." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.datadog.enabled (hasKey .Values.bifrost.plugins.datadog "version") (lt (int .Values.bifrost.plugins.datadog.version) 1) }}
+{{- fail "ERROR: bifrost.plugins.datadog.version must be >= 1. Bump to >1 to force DB-backed plugin config updates." }}
+{{- end }}
+{{- if and .Values.bifrost.plugins.datadog.enabled (hasKey .Values.bifrost.plugins.datadog "version") (gt (int .Values.bifrost.plugins.datadog.version) 32767) }}
+{{- fail "ERROR: bifrost.plugins.datadog.version must be <= 32767." }}
+{{- end }}
 
 {{/* Validate semantic cache plugin when enabled */}}
 {{- if .Values.bifrost.plugins.semanticCache.enabled }}
@@ -1375,6 +1433,12 @@ Call this template at the beginning of deployment/stateful templates
 {{- end }}
 {{- if not (hasKey $plugin "enabled") }}
 {{- fail (printf "ERROR: bifrost.plugins.custom[%d].enabled is required for plugin '%s'." $idx $plugin.name) }}
+{{- end }}
+{{- if and (hasKey $plugin "version") (lt (int $plugin.version) 1) }}
+{{- fail (printf "ERROR: bifrost.plugins.custom[%d].version must be >= 1 for plugin '%s'." $idx $plugin.name) }}
+{{- end }}
+{{- if and (hasKey $plugin "version") (gt (int $plugin.version) 32767) }}
+{{- fail (printf "ERROR: bifrost.plugins.custom[%d].version must be <= 32767 for plugin '%s'." $idx $plugin.name) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -346,9 +346,11 @@ bifrost:
       # codeModeBindingLevel: ""  # Code mode binding level (server or tool)
 
   # Plugins configuration
+  # Plugin version must be >= 1 (schema minimum). Use values > 1 to force DB-backed plugin config replacement on upgrade.
   plugins:
     telemetry:
       enabled: false
+      version: 1
       config:
         custom_labels: []
         # push_gateway:
@@ -363,12 +365,14 @@ bifrost:
 
     logging:
       enabled: false
+      version: 1
       config:
         disable_content_logging: false
         logging_headers: []
 
     governance:
       enabled: false
+      version: 1
       config:
         is_vk_mandatory: false
         required_headers: []
@@ -376,6 +380,7 @@ bifrost:
 
     maxim:
       enabled: false
+      version: 1
       config:
         api_key: ""
         log_repo_id: ""
@@ -386,6 +391,7 @@ bifrost:
 
     semanticCache:
       enabled: false
+      version: 1
       config:
         # Semantic caching mode (dimension > 1): requires provider, keys, and embedding_model
         # Direct caching mode (dimension: 1): hash-based exact matching, no embedding provider needed
@@ -404,6 +410,7 @@ bifrost:
 
     otel:
       enabled: false
+      version: 1
       config:
         service_name: "bifrost"
         collector_url: ""
@@ -421,6 +428,7 @@ bifrost:
 
     datadog:
       enabled: false
+      version: 1
       config:
         service_name: "bifrost"
         agent_addr: "localhost:8126"
@@ -434,7 +442,7 @@ bifrost:
       # - name: "my-custom-plugin"
       #   enabled: true
       #   path: "/plugins/my-plugin.so"
-      #   version: 1
+      #   version: 1 # must be >= 1; increase to force DB-backed plugin config replacement
       #   config:
       #     key: value
 


### PR DESCRIPTION
## Summary

Adds a `version` field to all built-in Helm plugins to support DB-backed deployments where Helm config needs to overwrite existing plugin records stored in the database.

## Changes

- Added a `version: 1` default to all built-in plugins (`telemetry`, `logging`, `governance`, `maxim`, `semanticCache`, `otel`, `datadog`) in `values.yaml`
- Updated `_helpers.tpl` to conditionally include the `version` field (as an integer) when set for each plugin
- Bumped chart version to `2.1.5`
- Removed the hardcoded "Latest Chart Version: 2.1.0" text from the Helm deployment guide, replacing it with a dynamic link to Artifact Hub
- Added `version: 1` to plugin config examples in the deployment guide
- Added a note in the deployment guide explaining that incrementing `version` causes Helm config to overwrite older plugin records in the DB

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Deploy Bifrost with a DB-backed configuration and set `version: 1` on a plugin. Modify the plugin config and increment `version` to `2`, then upgrade the Helm release and verify the updated config overwrites the existing DB record.

```sh
helm upgrade bifrost bifrost/bifrost -f values.yaml
```

Confirm the rendered plugin config includes the `version` field as an integer in the generated ConfigMap/Secret.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable