### PR TITLE
fix: use immutable-safe labels for bifrost StatefulSet volumeClaimTemplates

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.5
+version: 2.1.6
 appVersion: "1.5.0-prerelease4"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,45 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.4
+**Latest Version:** 2.1.6
 
 ## Changelog
+
+### 2.1.6
+
+- Updated StatefulSet PVC template labels to be immutable-safe:
+  - `spec.volumeClaimTemplates.metadata.labels` now uses stable selector labels (without chart/app version labels).
+- Upgrade impact:
+  - Existing SQLite StatefulSets created from older chart templates may require a one-time StatefulSet recreation during upgrade because `spec.volumeClaimTemplates` is immutable in Kubernetes.
+- Migration notes (only if upgrade fails with StatefulSet immutable-field error):
+  1. Identify StatefulSet name and namespace for your Helm release.
+  2. Delete only the StatefulSet while preserving dependents:
+     - `kubectl delete statefulset <statefulset-name> -n <namespace> --cascade=orphan`
+  3. Run Helm upgrade:
+     - `helm upgrade <release-name> bifrost/bifrost -n <namespace> -f <values-file> --set image.tag=<tag>`
+  4. If needed, re-apply/recreate the StatefulSet from the upgraded chart manifests.
+  5. Verify PVCs are preserved and pods become healthy:
+     - `kubectl get pvc -n <namespace>`
+     - `kubectl get pods -n <namespace>`
+
+### 2.1.5
+
+- Added `version` field support for built-in plugins in DB-backed Helm deployments.
+- Added default `version: 1` for built-in plugins in `values.yaml`:
+  - `telemetry`, `logging`, `governance`, `maxim`, `semanticCache`, `otel`, `datadog`
+- Updated `_helpers.tpl` to include plugin `version` in rendered config when set, cast as integer.
+- Updated Helm/deployment docs:
+  - Removed hardcoded chart version text and linked to Artifact Hub.
+  - Added plugin `version` examples and guidance that incrementing `version` forces DB-backed plugin config overwrite on upgrade.
+
+### 2.1.4
+
+- Added stricter cluster discovery validation in Helm templates:
+  - Require `bifrost.cluster.discovery.serviceName` when `bifrost.cluster.discovery.type` is `consul`, `etcd`, or `udp`.
+  - For `udp` discovery, require both:
+    - `bifrost.cluster.discovery.udpBroadcastPort`
+    - `bifrost.cluster.discovery.allowedAddressSpace`
+- Added/updated template fail-fast errors so invalid discovery config is rejected at render time instead of failing later at runtime.
 
 ### 2.1.3
 

--- a/helm-charts/bifrost/templates/stateful.yaml
+++ b/helm-charts/bifrost/templates/stateful.yaml
@@ -286,7 +286,13 @@ spec:
     - metadata:
         name: data
         labels:
-          {{- include "bifrost.labels" . | nindent 10 }}
+          {{- /*
+              Keep volumeClaimTemplates labels immutable-safe.
+              Do not include bifrost.labels here because chart/app version labels
+              change between releases and StatefulSet volumeClaimTemplates are immutable.
+          */}}
+          {{- include "bifrost.selectorLabels" . | nindent 10 }}
+          app.kubernetes.io/component: server
       spec:
         accessModes:
           - {{ .Values.storage.persistence.accessMode }}

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -476,7 +476,7 @@ bifrost:
       # - id: "vk-1"
       #   name: "Virtual Key 1"
       #   description: "Virtual key description"
-      #   value: "vk-..."           # Optional - auto-generated if omitted
+      #   value: "sk-bf-..."           # Optional - auto-generated if omitted
       #   is_active: true
       #   team_id: "team-1"        # Mutually exclusive with customer_id
       #   customer_id: ""          # Mutually exclusive with team_id


### PR DESCRIPTION
## Summary

Fixes a Kubernetes StatefulSet update failure caused by mutable labels being included in `volumeClaimTemplates`. Since `volumeClaimTemplates` are immutable after creation, including labels that change between releases (such as chart version or app version) causes StatefulSet updates to fail.

## Changes

- Replaced `bifrost.labels` with `bifrost.selectorLabels` in the `volumeClaimTemplates` section of the StatefulSet, since selector labels are stable across releases
- Added an explicit `app.kubernetes.io/component: server` label to preserve component identification without relying on the version-bearing labels

## Type of change

- [x] Bug fix

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy the Bifrost Helm chart, then upgrade to a new chart version and verify the StatefulSet updates successfully without an immutability conflict error from Kubernetes.

```sh
helm upgrade bifrost ./helm-charts/bifrost
```

Expected: upgrade completes without `field is immutable` errors on the StatefulSet.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable