### PR TITLE
feat: support `env.*` references for proxy and TLS config fields (`ca_cert_pem`, `url`, `username`, `password`)

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -96,17 +96,21 @@ func NewBedrockProvider(config *schemas.ProviderConfig, logger schemas.Logger) (
 	}
 
 	// Apply TLS settings from NetworkConfig
-	if config.NetworkConfig.InsecureSkipVerify || config.NetworkConfig.CACertPEM != "" {
+	caCertPEM := ""
+	if config.NetworkConfig.CACertPEM != nil {
+		caCertPEM = config.NetworkConfig.CACertPEM.GetValue()
+	}
+	if config.NetworkConfig.InsecureSkipVerify || caCertPEM != "" {
 		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
 		if config.NetworkConfig.InsecureSkipVerify {
 			tlsConfig.InsecureSkipVerify = true
 		}
-		if config.NetworkConfig.CACertPEM != "" {
+		if caCertPEM != "" {
 			certPool, err := x509.SystemCertPool()
 			if err != nil {
 				certPool = x509.NewCertPool()
 			}
-			if !certPool.AppendCertsFromPEM([]byte(config.NetworkConfig.CACertPEM)) {
+			if !certPool.AppendCertsFromPEM([]byte(caCertPEM)) {
 				return nil, fmt.Errorf("failed to parse CA certificate PEM")
 			}
 			tlsConfig.RootCAs = certPool

--- a/core/providers/bedrock/transport_test.go
+++ b/core/providers/bedrock/transport_test.go
@@ -637,7 +637,7 @@ func TestBedrockTransportTLSCACert(t *testing.T) {
 	config := &schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
 			DefaultRequestTimeoutInSeconds: 30,
-			CACertPEM:                      testCACert,
+			CACertPEM:                      schemas.NewEnvVar(testCACert),
 			EnforceHTTP2:                   true,
 		},
 	}

--- a/core/providers/utils/proxy_test.go
+++ b/core/providers/utils/proxy_test.go
@@ -1,0 +1,94 @@
+package utils
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+func TestConfigureProxy_HTTPProxy_WithLiteralURL_ConfiguresDialer(t *testing.T) {
+	client := &fasthttp.Client{}
+	logger := testLogger{}
+	cfg := &schemas.ProxyConfig{
+		Type: schemas.HTTPProxy,
+		URL:  schemas.NewEnvVar("http://127.0.0.1:1"),
+	}
+
+	ConfigureProxy(client, cfg, logger)
+
+	if client.Dial == nil {
+		t.Fatal("expected dialer to be configured for literal HTTP proxy URL")
+	}
+	_, err := client.Dial("example.com:80")
+	if err == nil {
+		t.Fatal("expected dial via test proxy to fail")
+	}
+	if !strings.Contains(err.Error(), "127.0.0.1:1") {
+		t.Fatalf("expected dial error to include proxy address, got: %v", err)
+	}
+}
+
+func TestConfigureProxy_HTTPProxy_WithEnvURL_ConfiguresDialer(t *testing.T) {
+	t.Setenv("BIFROST_TEST_PROXY_URL", "http://127.0.0.1:1")
+
+	client := &fasthttp.Client{}
+	logger := testLogger{}
+	cfg := &schemas.ProxyConfig{
+		Type: schemas.HTTPProxy,
+		URL:  schemas.NewEnvVar("env.BIFROST_TEST_PROXY_URL"),
+	}
+
+	ConfigureProxy(client, cfg, logger)
+
+	if client.Dial == nil {
+		t.Fatal("expected dialer to be configured for env-backed HTTP proxy URL")
+	}
+	_, err := client.Dial("example.com:80")
+	if err == nil {
+		t.Fatal("expected dial via test proxy to fail")
+	}
+	if !strings.Contains(err.Error(), "127.0.0.1:1") {
+		t.Fatalf("expected dial error to include proxy address from env value, got: %v", err)
+	}
+}
+
+func TestConfigureProxy_HTTPProxy_WithEmptyEnvValue_FailsFast(t *testing.T) {
+	t.Setenv("BIFROST_TEST_PROXY_URL_EMPTY", "")
+
+	client := &fasthttp.Client{}
+	logger := testLogger{}
+	cfg := &schemas.ProxyConfig{
+		Type: schemas.HTTPProxy,
+		URL:  schemas.NewEnvVar("env.BIFROST_TEST_PROXY_URL_EMPTY"),
+	}
+
+	ConfigureProxy(client, cfg, logger)
+
+	if client.Dial == nil {
+		t.Fatal("expected fail-fast dialer when env-backed proxy URL resolves empty")
+	}
+	_, err := client.Dial("example.com:80")
+	if err == nil {
+		t.Fatal("expected dial to fail with explicit configuration error")
+	}
+	if !strings.Contains(err.Error(), "proxy.url") || !strings.Contains(err.Error(), "env.BIFROST_TEST_PROXY_URL_EMPTY") {
+		t.Fatalf("expected explicit proxy env configuration error, got: %v", err)
+	}
+}
+
+func TestConfigureProxy_HTTPProxy_WithUnsetLiteralURL_KeepsDefaultBehavior(t *testing.T) {
+	client := &fasthttp.Client{}
+	logger := testLogger{}
+	cfg := &schemas.ProxyConfig{
+		Type: schemas.HTTPProxy,
+		URL:  nil,
+	}
+
+	ConfigureProxy(client, cfg, logger)
+
+	if client.Dial != nil {
+		t.Fatal("expected dialer to remain unset when literal proxy URL is not provided")
+	}
+}

--- a/core/providers/utils/tls_test.go
+++ b/core/providers/utils/tls_test.go
@@ -90,7 +90,7 @@ func TestConfigureTLS_AppliesCACertPEM(t *testing.T) {
 	logger := testLogger{}
 	caPEM := validTestCertPEM(t)
 
-	result := ConfigureTLS(client, schemas.NetworkConfig{CACertPEM: caPEM}, logger)
+	result := ConfigureTLS(client, schemas.NetworkConfig{CACertPEM: schemas.NewEnvVar(caPEM)}, logger)
 
 	if result != client {
 		t.Error("ConfigureTLS should return the same client")
@@ -107,7 +107,7 @@ func TestConfigureTLS_HandlesInvalidCACertPEM(t *testing.T) {
 	client := &fasthttp.Client{}
 	logger := testLogger{}
 
-	result := ConfigureTLS(client, schemas.NetworkConfig{CACertPEM: "not-valid-pem"}, logger)
+	result := ConfigureTLS(client, schemas.NetworkConfig{CACertPEM: schemas.NewEnvVar("not-valid-pem")}, logger)
 
 	if result != client {
 		t.Error("ConfigureTLS should return the same client even when CACertPEM is invalid")
@@ -133,7 +133,7 @@ func TestConfigureTLS_MergesWithExistingTLSConfig(t *testing.T) {
 	logger := testLogger{}
 	caPEM := validTestCertPEM(t)
 
-	result := ConfigureTLS(client, schemas.NetworkConfig{CACertPEM: caPEM}, logger)
+	result := ConfigureTLS(client, schemas.NetworkConfig{CACertPEM: schemas.NewEnvVar(caPEM)}, logger)
 
 	if result != client {
 		t.Error("ConfigureTLS should return the same client")
@@ -153,7 +153,7 @@ func TestConfigureTLS_InsecureSkipVerifyAndCACertPEM(t *testing.T) {
 
 	result := ConfigureTLS(client, schemas.NetworkConfig{
 		InsecureSkipVerify: true,
-		CACertPEM:          caPEM,
+		CACertPEM:          schemas.NewEnvVar(caPEM),
 	}, logger)
 
 	if result != client {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -293,37 +293,55 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 	case schemas.NoProxy:
 		return client
 	case schemas.HTTPProxy:
-		if proxyConfig.URL == "" {
+		if proxyConfig.URL != nil && proxyConfig.URL.IsFromEnv() && proxyConfig.URL.GetValue() == "" {
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.EnvVar)
+			getLogger().Error(errMsg)
+			client.Dial = dialErrorFunc(errMsg)
+			return client
+		}
+		proxyURLValue := proxyConfig.URL.GetValue()
+		if proxyURLValue == "" {
 			getLogger().Warn("Warning: HTTP proxy URL is required for setting up proxy")
 			return client
 		}
-		proxyURL := proxyConfig.URL
-		if proxyConfig.Username != "" && proxyConfig.Password != "" {
-			parsedURL, err := url.Parse(proxyConfig.URL)
+		proxyURL := proxyURLValue
+		proxyUsername := proxyConfig.Username.GetValue()
+		proxyPassword := proxyConfig.Password.GetValue()
+		if proxyUsername != "" && proxyPassword != "" {
+			parsedURL, err := url.Parse(proxyURLValue)
 			if err != nil {
 				getLogger().Warn("Invalid proxy configuration: invalid HTTP proxy URL")
 				return client
 			}
 			// Set user and password in the parsed URL
-			parsedURL.User = url.UserPassword(proxyConfig.Username, proxyConfig.Password)
+			parsedURL.User = url.UserPassword(proxyUsername, proxyPassword)
 			proxyURL = parsedURL.String()
 		}
 		dialFunc = fasthttpproxy.FasthttpHTTPDialer(proxyURL)
 	case schemas.Socks5Proxy:
-		if proxyConfig.URL == "" {
+		if proxyConfig.URL != nil && proxyConfig.URL.IsFromEnv() && proxyConfig.URL.GetValue() == "" {
+			errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.url", proxyConfig.URL.EnvVar)
+			getLogger().Error(errMsg)
+			client.Dial = dialErrorFunc(errMsg)
+			return client
+		}
+		proxyURLValue := proxyConfig.URL.GetValue()
+		if proxyURLValue == "" {
 			getLogger().Warn("Warning: SOCKS5 proxy URL is required for setting up proxy")
 			return client
 		}
-		proxyURL := proxyConfig.URL
+		proxyURL := proxyURLValue
 		// Add authentication if provided
-		if proxyConfig.Username != "" && proxyConfig.Password != "" {
-			parsedURL, err := url.Parse(proxyConfig.URL)
+		proxyUsername := proxyConfig.Username.GetValue()
+		proxyPassword := proxyConfig.Password.GetValue()
+		if proxyUsername != "" && proxyPassword != "" {
+			parsedURL, err := url.Parse(proxyURLValue)
 			if err != nil {
 				getLogger().Warn("Invalid proxy configuration: invalid SOCKS5 proxy URL")
 				return client
 			}
 			// Set user and password in the parsed URL
-			parsedURL.User = url.UserPassword(proxyConfig.Username, proxyConfig.Password)
+			parsedURL.User = url.UserPassword(proxyUsername, proxyPassword)
 			proxyURL = parsedURL.String()
 		}
 		dialFunc = fasthttpproxy.FasthttpSocksDialer(proxyURL)
@@ -340,8 +358,15 @@ func ConfigureProxy(client *fasthttp.Client, proxyConfig *schemas.ProxyConfig, l
 	}
 
 	// Configure custom CA certificate if provided
-	if proxyConfig.CACertPEM != "" {
-		tlsConfig, err := createTLSConfigWithCA(proxyConfig.CACertPEM)
+	if proxyConfig.CACertPEM != nil && proxyConfig.CACertPEM.IsFromEnv() && proxyConfig.CACertPEM.GetValue() == "" {
+		errMsg := fmt.Sprintf("invalid proxy configuration: %s references %q but it resolved to an empty value", "proxy.ca_cert_pem", proxyConfig.CACertPEM.EnvVar)
+		getLogger().Error(errMsg)
+		client.Dial = dialErrorFunc(errMsg)
+		return client
+	}
+	proxyCACertPEM := proxyConfig.CACertPEM.GetValue()
+	if proxyCACertPEM != "" {
+		tlsConfig, err := createTLSConfigWithCA(proxyCACertPEM)
 		if err != nil {
 			getLogger().Warn("Failed to configure custom CA certificate: %v", err)
 		} else {
@@ -376,7 +401,15 @@ func createTLSConfigWithCA(caCertPEM string) (*tls.Config, error) {
 // ConfigureTLS applies TLS settings from NetworkConfig to the fasthttp client.
 // It merges with any existing TLSConfig (e.g., from ConfigureProxy).
 func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, logger schemas.Logger) *fasthttp.Client {
-	if !networkConfig.InsecureSkipVerify && networkConfig.CACertPEM == "" {
+	if networkConfig.CACertPEM != nil && networkConfig.CACertPEM.IsFromEnv() && networkConfig.CACertPEM.GetValue() == "" {
+		errMsg := fmt.Sprintf("invalid provider configuration: %s references %q but it resolved to an empty value", "network_config.ca_cert_pem", networkConfig.CACertPEM.EnvVar)
+		logger.Error(errMsg)
+		client.Dial = dialErrorFunc(errMsg)
+		return client
+	}
+
+	caCertPEM := networkConfig.CACertPEM.GetValue()
+	if !networkConfig.InsecureSkipVerify && caCertPEM == "" {
 		return client
 	}
 
@@ -392,15 +425,15 @@ func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, 
 		tlsConfig.InsecureSkipVerify = true
 	}
 
-	if networkConfig.CACertPEM != "" {
-		caTLSConfig, err := createTLSConfigWithCA(networkConfig.CACertPEM)
+	if caCertPEM != "" {
+		caTLSConfig, err := createTLSConfigWithCA(caCertPEM)
 		if err != nil {
 			logger.Warn("Failed to configure custom CA certificate for provider: %v", err)
 		} else {
 			if tlsConfig.RootCAs != nil {
 				tlsConfig.RootCAs = tlsConfig.RootCAs.Clone()
 				// Merge: append network CA to existing pool (e.g. from proxy)
-				if !tlsConfig.RootCAs.AppendCertsFromPEM([]byte(networkConfig.CACertPEM)) {
+				if !tlsConfig.RootCAs.AppendCertsFromPEM([]byte(caCertPEM)) {
 					logger.Warn("Failed to append CA certificate to existing TLS config")
 				}
 			} else {
@@ -411,6 +444,12 @@ func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, 
 
 	client.TLSConfig = tlsConfig
 	return client
+}
+
+func dialErrorFunc(message string) fasthttp.DialFunc {
+	return func(_ string) (net.Conn, error) {
+		return nil, fmt.Errorf("%s", message)
+	}
 }
 
 // hopByHopHeaders are HTTP/1.1 headers that must not be forwarded by proxies.

--- a/core/schemas/envvar.go
+++ b/core/schemas/envvar.go
@@ -95,8 +95,8 @@ func (e *EnvVar) IsRedacted() bool {
 			return true
 		}
 	}
-	// Check if its string <redacted>
-	if e.Val == "<redacted>" {
+	// Check for <redacted> sentinel (case-insensitive for compatibility)
+	if strings.EqualFold(e.Val, "<redacted>") {
 		return true
 	}
 	return false

--- a/core/schemas/envvar_test.go
+++ b/core/schemas/envvar_test.go
@@ -408,6 +408,11 @@ func TestEnvVar_IsRedacted(t *testing.T) {
 			input:    EnvVar{Val: "sk-test-key"},
 			expected: false,
 		},
+		{
+			name:     "uppercase redacted sentinel",
+			input:    EnvVar{Val: "<REDACTED>"},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -60,7 +60,7 @@ type NetworkConfig struct {
 	RetryBackoffInitial            time.Duration     `json:"retry_backoff_initial"`                    // Initial backoff duration (stored as nanoseconds, JSON as milliseconds)
 	RetryBackoffMax                time.Duration     `json:"retry_backoff_max"`                        // Maximum backoff duration (stored as nanoseconds, JSON as milliseconds)
 	InsecureSkipVerify             bool              `json:"insecure_skip_verify,omitempty"`           // Disables TLS certificate verification for provider connections
-	CACertPEM                      string            `json:"ca_cert_pem,omitempty"`                    // PEM-encoded CA certificate to trust for provider endpoint connections
+	CACertPEM                      *EnvVar           `json:"ca_cert_pem,omitempty"`                    // PEM-encoded CA certificate to trust for provider endpoint connections (supports env.*)
 	StreamIdleTimeoutInSeconds     int               `json:"stream_idle_timeout_in_seconds,omitempty"` // Idle timeout per stream chunk (0 = use default 60s)
 	MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`             // Max TCP connections per provider host (default: 5000)
 	EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`                  // Force HTTP/2 on provider connections (relevant for net/http-based providers like Bedrock)
@@ -80,7 +80,7 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 		RetryBackoffInitial            int64             `json:"retry_backoff_initial"` // milliseconds in JSON
 		RetryBackoffMax                int64             `json:"retry_backoff_max"`     // milliseconds in JSON
 		InsecureSkipVerify             bool              `json:"insecure_skip_verify,omitempty"`
-		CACertPEM                      string            `json:"ca_cert_pem,omitempty"`
+		CACertPEM                      *EnvVar           `json:"ca_cert_pem,omitempty"`
 		StreamIdleTimeoutInSeconds     int               `json:"stream_idle_timeout_in_seconds,omitempty"`
 		MaxConnsPerHost                int               `json:"max_conns_per_host,omitempty"`
 		EnforceHTTP2                   bool              `json:"enforce_http2,omitempty"`
@@ -145,11 +145,17 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 		RetryBackoffInitial:        int64(nc.RetryBackoffInitial / time.Millisecond),
 		RetryBackoffMax:            int64(nc.RetryBackoffMax / time.Millisecond),
 		InsecureSkipVerify:         nc.InsecureSkipVerify,
-		CACertPEM:                  nc.CACertPEM,
 		StreamIdleTimeoutInSeconds: nc.StreamIdleTimeoutInSeconds,
 		MaxConnsPerHost:            nc.MaxConnsPerHost,
 		EnforceHTTP2:               nc.EnforceHTTP2,
 		BetaHeaderOverrides:        nc.BetaHeaderOverrides,
+	}
+	if nc.CACertPEM != nil {
+		if nc.CACertPEM.IsFromEnv() {
+			alias.CACertPEM = nc.CACertPEM.EnvVar
+		} else {
+			alias.CACertPEM = nc.CACertPEM.GetValue()
+		}
 	}
 
 	return json.Marshal(alias)
@@ -161,8 +167,8 @@ func (nc *NetworkConfig) Redacted() *NetworkConfig {
 		return nil
 	}
 	redacted := *nc
-	if nc.CACertPEM != "" {
-		redacted.CACertPEM = "<REDACTED>"
+	if nc.CACertPEM != nil && nc.CACertPEM.IsSet() {
+		redacted.CACertPEM = nc.CACertPEM.Redacted()
 	}
 	return &redacted
 }
@@ -206,16 +212,13 @@ const (
 // ProxyConfig holds the configuration for proxy settings.
 type ProxyConfig struct {
 	Type      ProxyType `json:"type"`        // Type of proxy to use
-	URL       string    `json:"url"`         // URL of the proxy server
-	Username  string    `json:"username"`    // Username for proxy authentication
-	Password  string    `json:"password"`    // Password for proxy authentication
-	CACertPEM string    `json:"ca_cert_pem"` // PEM-encoded CA certificate to trust for TLS connections through the proxy
+	URL       *EnvVar   `json:"url"`         // URL of the proxy server (supports env.*)
+	Username  *EnvVar   `json:"username"`    // Username for proxy authentication (supports env.*)
+	Password  *EnvVar   `json:"password"`    // Password for proxy authentication (supports env.*)
+	CACertPEM *EnvVar   `json:"ca_cert_pem"` // PEM-encoded CA certificate to trust for TLS connections through the proxy (supports env.*)
 }
 
-// IsRedactedValue returns true if the value is redacted.
-func (pc *ProxyConfig) IsRedactedValue(value string) bool {
-	return value == "<REDACTED>" || value == "********"
-}
+
 
 // Redacted returns a redacted copy of the proxy configuration.
 func (pc *ProxyConfig) Redacted() *ProxyConfig {
@@ -225,11 +228,19 @@ func (pc *ProxyConfig) Redacted() *ProxyConfig {
 		URL:      pc.URL,
 		Username: pc.Username,
 	}
-	if pc.Password != "" {
-		redactedConfig.Password = "<REDACTED>"
+	if pc.Password != nil && pc.Password.IsSet() {
+		if pc.Password.IsFromEnv() {
+			redactedConfig.Password = pc.Password
+		} else {
+			redactedConfig.Password = NewEnvVar("<REDACTED>")
+		}
 	}
-	if pc.CACertPEM != "" {
-		redactedConfig.CACertPEM = "<REDACTED>"
+	if pc.CACertPEM != nil && pc.CACertPEM.IsSet() {
+		if pc.CACertPEM.IsFromEnv() {
+			redactedConfig.CACertPEM = pc.CACertPEM
+		} else {
+			redactedConfig.CACertPEM = NewEnvVar("<REDACTED>")
+		}
 	}
 	return &redactedConfig
 }

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -1113,7 +1113,7 @@ func TestNetworkConfig_TLSFieldsRoundTrip(t *testing.T) {
 		DefaultRequestTimeoutInSeconds: 60,
 		MaxRetries:                     3,
 		InsecureSkipVerify:             true,
-		CACertPEM:                      "-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----",
+		CACertPEM:                      NewEnvVar("-----BEGIN CERTIFICATE-----\nMIIB...\n-----END CERTIFICATE-----"),
 	}
 
 	data, err := json.Marshal(nc)
@@ -1124,7 +1124,7 @@ func TestNetworkConfig_TLSFieldsRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, nc.InsecureSkipVerify, decoded.InsecureSkipVerify, "insecure_skip_verify should round-trip")
-	assert.Equal(t, nc.CACertPEM, decoded.CACertPEM, "ca_cert_pem should round-trip")
+	assert.Equal(t, nc.CACertPEM.GetValue(), decoded.CACertPEM.GetValue(), "ca_cert_pem should round-trip")
 	assert.Contains(t, string(data), `"insecure_skip_verify":true`)
 	assert.Contains(t, string(data), `"ca_cert_pem"`)
 }

--- a/examples/k8s/examples/README.md
+++ b/examples/k8s/examples/README.md
@@ -1,0 +1,111 @@
+# Layered Helm Values Examples
+
+These examples are split into composable value files so you can combine them with multiple `-f` flags.
+
+## Files
+
+- `values.yaml` - Base layer with shared image tag
+- `values-storage-sqlite.yaml` - Storage layer for SQLite StatefulSet mode
+- `values-storage-postgres.yaml` - Storage layer for Postgres mode (chart-managed Postgres)
+- `values-providers.yaml` - Provider keys layer (`openai` + `anthropic`)
+- `values-governance-teams.yaml` - Governance base layer (budgets, rate limits, customers, teams)
+- `values-with-routing-rules-pricing.yaml` - Advanced governance layer (virtual keys, routing rules, pricing overrides, access profile)
+- `values-with-pod-label.yaml` - Pod label overlay for StatefulSet template change testing
+
+## Prerequisites
+
+- A reachable Kubernetes cluster
+- `kubectl` configured for that cluster
+- `helm` installed
+
+## TLS options for providers
+
+`values-providers.yaml` includes provider `network_config` fields for TLS:
+
+- `insecure_skip_verify` (optional, default false)
+- `ca_cert_pem` (optional; inline PEM or `env.VAR_NAME`)
+
+Helm values example:
+
+```yaml
+bifrost:
+  providers:
+    openai:
+      network_config:
+        insecure_skip_verify: false
+        ca_cert_pem: "env.OPENAI_CA_CERT_PEM"
+```
+
+Equivalent `config.json` example:
+
+```json
+{
+  "providers": {
+    "openai": {
+      "network_config": {
+        "insecure_skip_verify": false,
+        "ca_cert_pem": "env.OPENAI_CA_CERT_PEM"
+      }
+    }
+  }
+}
+```
+
+## Deploy with layered `-f`
+
+```bash
+NAMESPACE="bifrost-examples"
+RELEASE_NAME="bifrost-statefulset-upgrade"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+# SQLite base stack
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-sqlite.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  --wait \
+  --timeout 5m
+
+# Postgres base stack
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-postgres.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  --wait \
+  --timeout 5m
+
+# Full governance stack (SQLite + providers + teams + routing/pricing)
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-sqlite.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/examples/values-governance-teams.yaml \
+  -f examples/k8s/examples/values-with-routing-rules-pricing.yaml \
+  --wait \
+  --timeout 5m
+
+# Add pod-label overlay on top of the same stack
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-sqlite.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/examples/values-governance-teams.yaml \
+  -f examples/k8s/examples/values-with-routing-rules-pricing.yaml \
+  -f examples/k8s/examples/values-with-pod-label.yaml \
+  --wait \
+  --timeout 5m
+```
+
+## Validate upgrade safety
+
+1. Run:
+   `helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost --namespace "${NAMESPACE}" -f examples/k8s/examples/values.yaml -f examples/k8s/examples/values-storage-sqlite.yaml -f examples/k8s/examples/values-providers.yaml -f examples/k8s/examples/values-with-pod-label.yaml --wait --timeout 5m`
+2. Change `image.tag` in `values.yaml` (for example to a newer tag).
+3. Run the same `helm upgrade --install ...` command again to perform an upgrade.
+
+The second run should complete without StatefulSet immutable-field errors related to `volumeClaimTemplates`.

--- a/examples/k8s/examples/secrets-providers-sample.yaml
+++ b/examples/k8s/examples/secrets-providers-sample.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bifrost-provider-secrets-sample
+  namespace: bifrost-examples
+type: Opaque
+stringData:
+  # Provider keys used in examples/k8s/examples/values-providers.yaml
+  OPENAI_API_KEY: "sk-openai-sample-key"
+  ANTHROPIC_API_KEY: "sk-ant-sample-key"
+
+  # Proxy settings used by examples/k8s/examples/values-providers.yaml
+  OPENAI_PROXY_URL: "http://proxy.example.internal:8080"
+  OPENAI_PROXY_USERNAME: "proxy-user"
+  OPENAI_PROXY_PASSWORD: "proxy-password"
+  # Optional CA fields intentionally omitted in this sample.
+  # Add OPENAI_PROXY_CA_CERT_PEM / OPENAI_CA_CERT_PEM only with valid PEM content.

--- a/examples/k8s/examples/values-governance-teams.yaml
+++ b/examples/k8s/examples/values-governance-teams.yaml
@@ -1,0 +1,27 @@
+bifrost:
+  governance:
+    budgets:
+      - id: "budget-team-default"
+        max_limit: 250
+        reset_duration: "1M"
+        calendar_aligned: true
+
+    rateLimits:
+      - id: "rl-team-default"
+        token_max_limit: 200000
+        token_reset_duration: "1d"
+        request_max_limit: 5000
+        request_reset_duration: "1h"
+
+    customers:
+      - id: "customer-acme"
+        name: "Acme Corp"
+        budget_id: "budget-team-default"
+        rate_limit_id: "rl-team-default"
+
+    teams:
+      - id: "team-platform"
+        name: "Platform Team"
+        customer_id: "customer-acme"
+        budget_id: "budget-team-default"
+        rate_limit_id: "rl-team-default"

--- a/examples/k8s/examples/values-providers.yaml
+++ b/examples/k8s/examples/values-providers.yaml
@@ -1,0 +1,120 @@
+bifrost:
+  providers:
+    # Primary provider
+    openai:
+      network_config:
+        base_url: "https://api.openai.com/v1"
+        default_request_timeout_in_seconds: 58
+        stream_idle_timeout_in_seconds: 59
+        max_retries: 7
+        retry_backoff_initial_ms: 100
+        retry_backoff_max_ms: 70000
+        max_conns_per_host: 8000
+        enforce_http2: true
+        insecure_skip_verify: false
+        # Optional for secure TLS verification with a custom CA (inline PEM or env-backed).
+        ca_cert_pem: "env.OPENAI_CA_CERT_PEM"
+        # Header key/value pairs forwarded to provider requests.
+        extra_headers:
+          x-bf-example-header-enabled: "true"
+          x-bf-example-header-value: "example"
+        # Per-beta-header support overrides (true/false).
+        beta_header_overrides:
+          output-128k-2025-02-19: true
+      # Debug/response visibility controls
+      send_back_raw_request: true
+      send_back_raw_response: true
+      # Persist raw request/response in internal logs only.
+      store_raw_request_response: true
+      concurrency_and_buffer_size:
+        concurrency: 100
+        buffer_size: 1000
+      # Proxy options:
+      # - type: "http" and url: "http://proxy.example:8080"
+      # - type: "socks5" and url: "socks5://proxy.example:1080"
+      # - type: "environment" to use HTTP_PROXY/HTTPS_PROXY/NO_PROXY
+      proxy_config:
+        type: "http"
+        url: "env.OPENAI_PROXY_URL"
+        username: "env.OPENAI_PROXY_USERNAME"
+        password: "env.OPENAI_PROXY_PASSWORD"
+        ca_cert_pem: "env.OPENAI_PROXY_CA_CERT_PEM"
+      keys:
+        - name: "openai-key"
+          value: "env.OPENAI_API_KEY"
+          weight: 1
+          models:
+            - "*"
+          use_for_batch_api: true
+          aliases: {
+            gpt-4o-mini: "gpt-4o-mini-2024-07-18"
+          }
+          # Optional key-scoped config blocks (provider specific)
+          # azure_key_config:
+          #   endpoint: "https://your-resource.openai.azure.com"
+          #   api_version: "2024-02-15-preview"
+          # bedrock_key_config:
+          #   region: "us-east-1"
+          # vertex_key_config:
+          #   project_id: "your-gcp-project-id"
+          #   region: "us-central1"
+          # vllm_key_config:
+          #   url: "http://vllm.default.svc.cluster.local:8000/v1"
+          #   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+    # Secondary provider
+    anthropic:
+      network_config: {}
+      send_back_raw_request: false
+      send_back_raw_response: false
+      store_raw_request_response: false
+      # Optional provider-level blocks:
+      # concurrency_and_buffer_size:
+      #   concurrency: 100
+      #   buffer_size: 1000
+      # proxy_config:
+      #   type: "none"
+      # custom_provider_config:
+      #   base_provider_type: "anthropic"
+      keys:
+        - name: "anthropic-key"
+          value: "env.ANTHROPIC_API_KEY"
+          weight: 1
+          models:
+            - "*"
+          use_for_batch_api: false
+          aliases: {}
+          # Optional key-scoped config blocks (provider specific)
+          # azure_key_config:
+          #   endpoint: "https://your-resource.openai.azure.com"
+          #   api_version: "2024-02-15-preview"
+          # bedrock_key_config:
+          #   region: "us-east-1"
+          # vertex_key_config:
+          #   project_id: "your-gcp-project-id"
+          #   region: "us-central1"
+          # vllm_key_config:
+          #   url: "http://vllm.default.svc.cluster.local:8000/v1"
+          #   model_name: "meta-llama/Meta-Llama-3.1-8B-Instruct"
+
+  # Governance examples: max spend + reset period + rate limits.
+  governance:
+    budgets:
+      - id: "budget-provider-openai"
+        max_limit: 500
+        reset_duration: "1M"
+    rateLimits:
+      - id: "rl-provider-openai"
+        token_max_limit: 120000
+        token_reset_duration: "1d"
+        request_max_limit: 2500
+        request_reset_duration: "1h"
+    providers:
+      - name: "openai"
+        budget_id: "budget-provider-openai"
+        rate_limit_id: "rl-provider-openai"
+
+# Inject provider/proxy env vars from a Kubernetes Secret.
+# Apply examples/k8s/examples/secrets-providers-sample.yaml first.
+envFrom:
+  - secretRef:
+      name: bifrost-provider-secrets-sample

--- a/examples/k8s/examples/values-storage-postgres.yaml
+++ b/examples/k8s/examples/values-storage-postgres.yaml
@@ -1,0 +1,35 @@
+storage:
+  mode: postgres
+  configStore:
+    enabled: true
+    type: postgres
+  logsStore:
+    enabled: true
+    type: postgres
+
+postgresql:
+  enabled: true
+  external:
+    enabled: false
+  auth:
+    username: "bifrost"
+    password: "bifrost"
+    database: "bifrost"
+  primary:
+    persistence:
+      enabled: true
+      size: 2Gi
+
+# Prevent Bifrost from starting before Postgres is ready.
+initContainers:
+  - name: wait-for-postgresql
+    image: postgres:16-alpine
+    imagePullPolicy: IfNotPresent
+    command:
+      - sh
+      - -c
+      - |
+        until pg_isready -h "bifrost-statefulset-upgrade-postgresql" -p 5432 -U "bifrost"; do
+          echo "waiting for postgresql..."
+          sleep 2
+        done

--- a/examples/k8s/examples/values-storage-sqlite.yaml
+++ b/examples/k8s/examples/values-storage-sqlite.yaml
@@ -1,0 +1,5 @@
+storage:
+  mode: sqlite
+  persistence:
+    enabled: true
+    size: 2Gi

--- a/examples/k8s/examples/values-with-pod-label.yaml
+++ b/examples/k8s/examples/values-with-pod-label.yaml
@@ -1,0 +1,3 @@
+# Optional overlay to verify StatefulSet pod template deltas.
+podLabels:
+  example.bifrost.ai/upgrade-safe: "true"

--- a/examples/k8s/examples/values-with-routing-rules-pricing.yaml
+++ b/examples/k8s/examples/values-with-routing-rules-pricing.yaml
@@ -1,0 +1,247 @@
+image:
+  # Update this if you want to test another release.
+  tag: "v1.5.0-prerelease5"
+
+# SQLite + persistence + no existingClaim => StatefulSet path
+storage:
+  mode: sqlite
+  persistence:
+    enabled: true
+    size: 2Gi
+
+bifrost:
+  providers:
+    # Example provider with model limit on a specific key.
+    openai:
+      keys:
+        - name: "openai-limited-key"
+          value: "env.OPENAI_API_KEY"
+          weight: 1
+          use_for_batch_api: true
+          models:
+            - "gpt-4o-mini"
+          aliases:
+            gpt-4o-mini: "gpt-4o-mini-2024-07-18"
+        - name: "openai-fallback-key"
+          value: "env.OPENAI_API_KEY_2"
+          weight: 1
+          models:
+            - "*"
+    anthropic:
+      keys:
+        - name: "anthropic-key"
+          value: "env.ANTHROPIC_API_KEY"
+          weight: 1
+
+  governance:
+    # Cost controls used by teams, virtual keys, models, and providers.
+    budgets:
+      - id: "budget-team-default"
+        max_limit: 250
+        reset_duration: "1M"
+        calendar_aligned: true
+      - id: "budget-vk-premium"
+        max_limit: 1000
+        reset_duration: "1M"
+      # Provider-scoped budget (applies to openai via governance.providers below).
+      - id: "budget-provider-openai"
+        max_limit: 500
+        reset_duration: "1M"
+      # Model-scoped budget (applies specifically to gpt-4o-mini via modelConfigs).
+      - id: "budget-model-gpt4o-mini"
+        max_limit: 120
+        reset_duration: "1M"
+      # Another model budget to show per-model differentiation.
+      - id: "budget-model-claude-sonnet"
+        max_limit: 400
+        reset_duration: "1M"
+
+    # Request/token throttling profiles that can be referenced by entities.
+    rateLimits:
+      - id: "rl-team-default"
+        token_max_limit: 200000
+        token_reset_duration: "1d"
+        request_max_limit: 5000
+        request_reset_duration: "1h"
+      # Provider-scoped rate limit for openai.
+      - id: "rl-provider-openai"
+        token_max_limit: 120000
+        token_reset_duration: "1d"
+        request_max_limit: 2500
+        request_reset_duration: "1h"
+      # Model-scoped rate limit for gpt-4o-mini.
+      - id: "rl-model-gpt4o-mini"
+        token_max_limit: 40000
+        token_reset_duration: "1d"
+        request_max_limit: 800
+        request_reset_duration: "1h"
+      # Model-scoped rate limit for claude sonnet.
+      - id: "rl-model-claude-sonnet"
+        token_max_limit: 71000
+        token_reset_duration: "1d"
+        request_max_limit: 1300
+        request_reset_duration: "1h"
+
+    # Optional business hierarchy for governance scoping.
+    customers:
+      - id: "customer-acme"
+        name: "Acme Corp"
+        budget_id: "budget-team-default"
+        rate_limit_id: "rl-team-default"
+
+    teams:
+      - id: "team-platform"
+        name: "Platform Team"
+        customer_id: "customer-acme"
+        budget_id: "budget-team-default"
+        rate_limit_id: "rl-team-default"
+
+    # Example virtual keys with explicit VK -> provider_config relationships.
+    virtualKeys:
+      - id: "vk-routing-demo"
+        name: "Routing Demo Key"
+        description: "VK used to test model-limited provider_configs + routing."
+        value: "sk-bf-demo-routing-key"
+        is_active: true
+        team_id: "team-platform"
+        rate_limit_id: "rl-team-default"
+        provider_configs:
+          - provider: "openai"
+            weight: 1
+            rate_limit_id: "rl-model-gpt4o-mini"
+            allowed_models:
+              - "gpt-4o-mini"
+          - provider: "anthropic"
+            weight: 1
+            rate_limit_id: "rl-model-claude-sonnet"
+            allowed_models:
+              - "claude-3-5-sonnet-latest"
+      - id: "vk-multi-provider-demo"
+        name: "Multi Provider Demo Key"
+        description: "VK with multiple provider_configs to stress Helm/config sync."
+        value: "sk-bf-demo-multiprovider-key"
+        is_active: true
+        team_id: "team-platform"
+        rate_limit_id: "rl-team-default"
+        provider_configs:
+          - provider: "openai"
+            weight: 0.6
+            allowed_models:
+              - "gpt-4o-mini"
+              - "gpt-4o"
+          - provider: "anthropic"
+            weight: 0.4
+            allowed_models:
+              - "claude-3-5-sonnet-latest"
+
+    # Per-model governance bindings.
+    modelConfigs:
+      - id: "mc-openai-mini"
+        model_name: "gpt-4o-mini"
+        provider: "openai"
+        budget_id: "budget-model-gpt4o-mini"
+        rate_limit_id: "rl-model-gpt4o-mini"
+      - id: "mc-anthropic-sonnet"
+        model_name: "claude-3-5-sonnet-latest"
+        provider: "anthropic"
+        budget_id: "budget-model-claude-sonnet"
+        rate_limit_id: "rl-model-claude-sonnet"
+
+    # Provider-level governance defaults.
+    providers:
+      - name: "openai"
+        budget_id: "budget-provider-openai"
+        rate_limit_id: "rl-provider-openai"
+      - name: "anthropic"
+        budget_id: "budget-vk-premium"
+
+    # Dynamic request routing rules (CEL + weighted targets + scope).
+    routingRules:
+      - id: "route-openai-mini-to-anthropic"
+        name: "Route GPT-4o-mini to Anthropic Sonnet"
+        description: "Example routing rule to test provider/model remapping."
+        enabled: true
+        cel_expression: "model == 'gpt-4o-mini'"
+        chain_rule: false
+        targets:
+          - provider: "anthropic"
+            model: "claude-3-5-sonnet-latest"
+            weight: 1
+        # Fallbacks are tried in order; use "provider" or "provider/model" (e.g. openai/gpt-4o-mini).
+        fallbacks:
+          - "openai/gpt-4o-mini"
+          - "anthropic/claude-3-5-sonnet"
+        scope: "global"
+        priority: 10
+        # Optional dashboard rule-builder state (react-querybuilder). Runtime uses cel_expression only.
+        # Shape must include combinator and rules[]; each rule uses field / operator / value from the CEL builder.
+        query:
+          combinator: and
+          rules:
+            - id: route-mini-model
+              field: model
+              operator: "="
+              value: "gpt-4o-mini"
+      - id: "route-vk-team-specific"
+        name: "VK specific fallback route"
+        description: "Route high-tier key traffic to OpenAI primary."
+        enabled: true
+        # CEL variables use snake_case (see routing engine); virtual_key_id is the VK id from governance.virtualKeys.
+        # No query here: virtual_key_id is not in the dashboard field list, so use cel_expression only for this condition.
+        cel_expression: 'virtual_key_id == "vk-routing-demo"'
+        targets:
+          - provider: "openai"
+            model: "gpt-4o-mini"
+            weight: 0.7
+          - weight: 0.3
+        scope: "virtual_key"
+        scope_id: "vk-routing-demo"
+        priority: 1
+
+    # Runtime pricing patches used by the model catalog.
+    pricingOverrides:
+      - id: "override-openai-mini-chat"
+        name: "Override GPT-4o-mini chat pricing"
+        scope_kind: "global"
+        match_type: "exact"
+        pattern: "gpt-4o-mini"
+        request_types:
+          - "chat_completion"
+          - "responses"
+        pricing_patch: "{\"input_cost_per_token\":0.00000050,\"output_cost_per_token\":0.00000150}"
+      - id: "override-anthropic-provider-wildcard"
+        name: "Anthropic wildcard override"
+        scope_kind: "provider"
+        provider_id: "anthropic"
+        match_type: "wildcard"
+        pattern: "claude-*"
+        request_types:
+          - "chat_completion"
+        pricing_patch: "{\"input_cost_per_token\":0.00000250,\"output_cost_per_token\":0.00000750}"
+      - id: "override-vk-provider-key-exact"
+        name: "Virtual key provider exact override"
+        scope_kind: "virtual_key_provider"
+        virtual_key_id: "vk-routing-demo"
+        provider_id: "openai"
+        match_type: "exact"
+        pattern: "gpt-4o-mini"
+        request_types:
+          - "chat_completion"
+          - "responses"
+        pricing_patch: "{\"input_cost_per_token\":0.00000040,\"output_cost_per_token\":0.00000120}"
+
+  # Access profile model policy fields (all_models_allowed + allowed_models).
+  accessProfiles:
+    - name: "model-policy-profile"
+      description: "Example access profile with model allow-list."
+      is_active: true
+      provider_configs:
+        - provider_name: "openai"
+          all_models_allowed: false
+          allowed_models:
+            - "gpt-4o-mini"
+            - "gpt-4o"
+
+# Keep pod-label delta to exercise StatefulSet template upgrades.
+podLabels:
+  example.bifrost.ai/upgrade-safe: "true"

--- a/examples/k8s/examples/values.yaml
+++ b/examples/k8s/examples/values.yaml
@@ -1,0 +1,3 @@
+image:
+  # Base image tag shared by all layered example files.
+  tag: "v1.5.0-prerelease5"

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -56,6 +56,13 @@ func rawRow(t *testing.T, db *gorm.DB, table string, id any) map[string]any {
 	return row
 }
 
+func envVarPtrValue(v *schemas.EnvVar) string {
+	if v == nil {
+		return ""
+	}
+	return v.GetValue()
+}
+
 // ============================================================================
 // TableKey encryption tests
 // ============================================================================
@@ -258,7 +265,7 @@ func TestTableProvider_ProxyConfigEncryptDecrypt(t *testing.T) {
 	db := setupTestDB(t)
 
 	proxyConfig := &schemas.ProxyConfig{
-		URL: "https://proxy.example.com",
+		URL: schemas.NewEnvVar("https://proxy.example.com"),
 	}
 
 	provider := &TableProvider{
@@ -278,7 +285,7 @@ func TestTableProvider_ProxyConfigEncryptDecrypt(t *testing.T) {
 	var found TableProvider
 	require.NoError(t, db.First(&found, provider.ID).Error)
 	require.NotNil(t, found.ProxyConfig)
-	assert.Equal(t, "https://proxy.example.com", found.ProxyConfig.URL)
+	assert.Equal(t, "https://proxy.example.com", envVarPtrValue(found.ProxyConfig.URL))
 }
 
 func TestTableProvider_NoProxyConfig_NoEncryption(t *testing.T) {
@@ -964,21 +971,22 @@ func TestTableProvider_UpdatePreservesDecryption(t *testing.T) {
 
 	provider := &TableProvider{
 		Name:        "update-provider",
-		ProxyConfig: &schemas.ProxyConfig{URL: "https://proxy-v1.example.com"},
+		ProxyConfig: &schemas.ProxyConfig{URL: schemas.NewEnvVar("https://proxy-v1.example.com")},
 	}
 	require.NoError(t, db.Create(provider).Error)
 
 	var found TableProvider
 	require.NoError(t, db.First(&found, provider.ID).Error)
-	assert.Equal(t, "https://proxy-v1.example.com", found.ProxyConfig.URL)
+	require.NotNil(t, found.ProxyConfig)
+	assert.Equal(t, "https://proxy-v1.example.com", envVarPtrValue(found.ProxyConfig.URL))
 
-	found.ProxyConfig = &schemas.ProxyConfig{URL: "https://proxy-v2.example.com"}
+	found.ProxyConfig = &schemas.ProxyConfig{URL: schemas.NewEnvVar("https://proxy-v2.example.com")}
 	require.NoError(t, db.Save(&found).Error)
 
 	var found2 TableProvider
 	require.NoError(t, db.First(&found2, provider.ID).Error)
 	require.NotNil(t, found2.ProxyConfig)
-	assert.Equal(t, "https://proxy-v2.example.com", found2.ProxyConfig.URL)
+	assert.Equal(t, "https://proxy-v2.example.com", envVarPtrValue(found2.ProxyConfig.URL))
 }
 
 func TestTablePlugin_UpdatePreservesDecryption(t *testing.T) {
@@ -1423,8 +1431,8 @@ func TestTableProvider_EncryptionDisabled_StoresPlaintext(t *testing.T) {
 	provider := &TableProvider{
 		Name: "disabled-provider",
 		ProxyConfig: &schemas.ProxyConfig{
-			URL:      "https://proxy.example.com",
-			Password: "proxy-secret",
+			URL:      schemas.NewEnvVar("https://proxy.example.com"),
+			Password: schemas.NewEnvVar("proxy-secret"),
 		},
 	}
 
@@ -1439,7 +1447,7 @@ func TestTableProvider_EncryptionDisabled_StoresPlaintext(t *testing.T) {
 	var found TableProvider
 	require.NoError(t, db.First(&found, provider.ID).Error)
 	require.NotNil(t, found.ProxyConfig)
-	assert.Equal(t, "proxy-secret", found.ProxyConfig.Password)
+	assert.Equal(t, "proxy-secret", envVarPtrValue(found.ProxyConfig.Password))
 }
 
 func TestTablePlugin_EncryptionDisabled_StoresPlaintext(t *testing.T) {

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -328,6 +328,52 @@ false
 {{- $providers := dict }}
 {{- range $providerName, $providerConfig := .Values.bifrost.providers }}
 {{- $providerCopy := deepCopy $providerConfig }}
+{{- if $providerConfig.network_config }}
+{{- $networkConfig := dict }}
+{{- if $providerConfig.network_config.base_url }}
+{{- $_ := set $networkConfig "base_url" $providerConfig.network_config.base_url }}
+{{- end }}
+{{- if $providerConfig.network_config.extra_headers }}
+{{- $_ := set $networkConfig "extra_headers" $providerConfig.network_config.extra_headers }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "default_request_timeout_in_seconds" }}
+{{- $_ := set $networkConfig "default_request_timeout_in_seconds" $providerConfig.network_config.default_request_timeout_in_seconds }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "max_retries" }}
+{{- $_ := set $networkConfig "max_retries" $providerConfig.network_config.max_retries }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "retry_backoff_initial" }}
+{{- $_ := set $networkConfig "retry_backoff_initial" $providerConfig.network_config.retry_backoff_initial }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "retry_backoff_initial_ms" }}
+{{- $_ := set $networkConfig "retry_backoff_initial" $providerConfig.network_config.retry_backoff_initial_ms }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "retry_backoff_max" }}
+{{- $_ := set $networkConfig "retry_backoff_max" $providerConfig.network_config.retry_backoff_max }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "retry_backoff_max_ms" }}
+{{- $_ := set $networkConfig "retry_backoff_max" $providerConfig.network_config.retry_backoff_max_ms }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "insecure_skip_verify" }}
+{{- $_ := set $networkConfig "insecure_skip_verify" $providerConfig.network_config.insecure_skip_verify }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "ca_cert_pem" }}
+{{- $_ := set $networkConfig "ca_cert_pem" $providerConfig.network_config.ca_cert_pem }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "stream_idle_timeout_in_seconds" }}
+{{- $_ := set $networkConfig "stream_idle_timeout_in_seconds" $providerConfig.network_config.stream_idle_timeout_in_seconds }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "max_conns_per_host" }}
+{{- $_ := set $networkConfig "max_conns_per_host" $providerConfig.network_config.max_conns_per_host }}
+{{- end }}
+{{- if hasKey $providerConfig.network_config "enforce_http2" }}
+{{- $_ := set $networkConfig "enforce_http2" $providerConfig.network_config.enforce_http2 }}
+{{- end }}
+{{- if $providerConfig.network_config.beta_header_overrides }}
+{{- $_ := set $networkConfig "beta_header_overrides" $providerConfig.network_config.beta_header_overrides }}
+{{- end }}
+{{- $_ := set $providerCopy "network_config" $networkConfig }}
+{{- end }}
 {{- if $providerConfig.keys }}
 {{- $keys := list }}
 {{- range $key := $providerConfig.keys }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2937,19 +2937,19 @@
         },
         "retry_backoff_initial_ms": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 100
         },
         "retry_backoff_max_ms": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 100
         },
         "insecure_skip_verify": {
           "type": "boolean",
-          "description": "Disable TLS certificate verification for provider connections"
+          "description": "Disable TLS certificate verification for provider connections. This bypasses server certificate validation and should be used only as a last resort when a trusted CA chain cannot be configured. Prefer ca_cert_pem for self-signed or private CA deployments."
         },
         "ca_cert_pem": {
           "type": "string",
-          "description": "PEM-encoded CA certificate to trust for provider endpoint connections"
+          "description": "PEM-encoded CA certificate to trust for provider endpoint connections. Supports inline PEM or env.VAR_NAME."
         },
         "stream_idle_timeout_in_seconds": {
           "type": "integer",
@@ -2962,6 +2962,10 @@
           "minimum": 1,
           "maximum": 10000,
           "description": "Maximum number of TCP connections per provider host. For HTTP/2 (e.g. Bedrock), each connection supports ~100 concurrent streams. Default: 5000."
+        },
+        "enforce_http2": {
+          "type": "boolean",
+          "description": "Force HTTP/2 on provider connections (relevant for net/http-based providers like Bedrock)."
         },
         "beta_header_overrides": {
           "type": "object",
@@ -3000,17 +3004,32 @@
           ]
         },
         "url": {
-          "type": "string",
-          "format": "uri"
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^env\\.[A-Za-z0-9_]+$"
+            },
+            {
+              "type": "string",
+              "format": "uri",
+              "not": {
+                "pattern": "^env\\.[A-Za-z0-9_]+$"
+              }
+            }
+          ],
+          "description": "URL of the proxy server (supports env.VAR_NAME)"
         },
         "username": {
-          "type": "string"
+          "type": "string",
+          "description": "Username for proxy authentication (supports env.VAR_NAME)"
         },
         "password": {
-          "type": "string"
+          "type": "string",
+          "description": "Password for proxy authentication (supports env.VAR_NAME)"
         },
         "ca_cert_pem": {
-          "type": "string"
+          "type": "string",
+          "description": "PEM-encoded CA certificate to trust for TLS connections through the proxy (supports env.VAR_NAME)"
         }
       },
       "required": [

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -383,6 +383,19 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		oldConfigRaw = &configstore.ProviderConfig{}
 	}
 
+	oldRedactedConfig, err := h.inMemoryStore.GetProviderConfigRedacted(provider)
+	if err != nil {
+		if !errors.Is(err, lib.ErrNotFound) {
+			logger.Warn("Failed to get old redacted config for provider %s: %v", provider, err)
+			SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+			return
+		}
+	}
+
+	if oldRedactedConfig == nil {
+		oldRedactedConfig = &configstore.ProviderConfig{}
+	}
+
 	// Construct ProviderConfig from individual fields (keys are managed separately via /keys endpoints)
 	config := configstore.ProviderConfig{
 		Keys:                     oldConfigRaw.Keys,
@@ -428,16 +441,24 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 
 	config.ConcurrencyAndBufferSize = &payload.ConcurrencyAndBufferSize
 	// Merge network config - restore ca_cert_pem if the redacted placeholder was sent back
-	if oldConfigRaw.NetworkConfig != nil && (nc.CACertPEM == "<REDACTED>" || nc.CACertPEM == "********") {
-		nc.CACertPEM = oldConfigRaw.NetworkConfig.CACertPEM
+	if oldConfigRaw.NetworkConfig != nil && oldRedactedConfig.NetworkConfig != nil && nc.CACertPEM != nil {
+		if nc.CACertPEM.IsRedacted() && nc.CACertPEM.Equals(oldRedactedConfig.NetworkConfig.CACertPEM) {
+			nc.CACertPEM = oldConfigRaw.NetworkConfig.CACertPEM
+		}
 	}
 	config.NetworkConfig = &nc
 	// Merge proxy config - preserve secrets if redacted values were sent back
-	if payload.ProxyConfig != nil && oldConfigRaw.ProxyConfig != nil {
-		if payload.ProxyConfig.IsRedactedValue(payload.ProxyConfig.Password) {
+	if payload.ProxyConfig != nil && oldConfigRaw.ProxyConfig != nil && oldRedactedConfig.ProxyConfig != nil {
+		if payload.ProxyConfig.URL != nil && payload.ProxyConfig.URL.IsRedacted() && payload.ProxyConfig.URL.Equals(oldRedactedConfig.ProxyConfig.URL) {
+			payload.ProxyConfig.URL = oldConfigRaw.ProxyConfig.URL
+		}
+		if payload.ProxyConfig.Username != nil && payload.ProxyConfig.Username.IsRedacted() && payload.ProxyConfig.Username.Equals(oldRedactedConfig.ProxyConfig.Username) {
+			payload.ProxyConfig.Username = oldConfigRaw.ProxyConfig.Username
+		}
+		if payload.ProxyConfig.Password != nil && payload.ProxyConfig.Password.IsRedacted() && payload.ProxyConfig.Password.Equals(oldRedactedConfig.ProxyConfig.Password) {
 			payload.ProxyConfig.Password = oldConfigRaw.ProxyConfig.Password
 		}
-		if payload.ProxyConfig.IsRedactedValue(payload.ProxyConfig.CACertPEM) {
+		if payload.ProxyConfig.CACertPEM != nil && payload.ProxyConfig.CACertPEM.IsRedacted() && payload.ProxyConfig.CACertPEM.Equals(oldRedactedConfig.ProxyConfig.CACertPEM) {
 			payload.ProxyConfig.CACertPEM = oldConfigRaw.ProxyConfig.CACertPEM
 		}
 	}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -2285,7 +2285,7 @@ func TestGenerateProviderConfigHash(t *testing.T) {
 		SendBackRawResponse: true,
 		ProxyConfig: &schemas.ProxyConfig{
 			Type: schemas.HTTPProxy,
-			URL:  "http://proxy.example.com:8080",
+			URL:  schemas.NewEnvVar("http://proxy.example.com:8080"),
 		},
 	}
 
@@ -2974,7 +2974,7 @@ func TestProviderHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewEnvVar("sk-123"), Weight: 1}},
 		ProxyConfig: &schemas.ProxyConfig{
 			Type: "http",
-			URL:  "http://proxy.example.com",
+			URL:  schemas.NewEnvVar("http://proxy.example.com"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -3052,7 +3052,7 @@ func TestProviderHashComparison_OptionalFieldsPresence(t *testing.T) {
 		},
 		ProxyConfig: &schemas.ProxyConfig{
 			Type: "http",
-			URL:  "http://proxy.example.com",
+			URL:  schemas.NewEnvVar("http://proxy.example.com"),
 		},
 		CustomProviderConfig: &schemas.CustomProviderConfig{
 			BaseProviderType: "openai",
@@ -3295,7 +3295,7 @@ func TestProviderHashComparison_FieldRemoved(t *testing.T) {
 		},
 		ProxyConfig: &schemas.ProxyConfig{
 			Type: "http",
-			URL:  "http://proxy.example.com",
+			URL:  schemas.NewEnvVar("http://proxy.example.com"),
 		},
 		SendBackRawResponse: true,
 	}
@@ -3312,7 +3312,7 @@ func TestProviderHashComparison_FieldRemoved(t *testing.T) {
 		},
 		ProxyConfig: &schemas.ProxyConfig{
 			Type: "http",
-			URL:  "http://proxy.example.com",
+			URL:  schemas.NewEnvVar("http://proxy.example.com"),
 		},
 		SendBackRawResponse: true,
 	}
@@ -3335,7 +3335,7 @@ func TestProviderHashComparison_FieldRemoved(t *testing.T) {
 		// ConcurrencyAndBufferSize: nil (removed)
 		ProxyConfig: &schemas.ProxyConfig{
 			Type: "http",
-			URL:  "http://proxy.example.com",
+			URL:  schemas.NewEnvVar("http://proxy.example.com"),
 		},
 		SendBackRawResponse: true,
 	}
@@ -3384,7 +3384,7 @@ func TestProviderHashComparison_FieldRemoved(t *testing.T) {
 		},
 		ProxyConfig: &schemas.ProxyConfig{
 			Type: "http",
-			URL:  "http://proxy.example.com",
+			URL:  schemas.NewEnvVar("http://proxy.example.com"),
 		},
 		SendBackRawResponse: false, // Changed to false
 	}
@@ -3408,7 +3408,7 @@ func TestProviderHashComparison_FieldRemoved(t *testing.T) {
 		},
 		ProxyConfig: &schemas.ProxyConfig{
 			Type: "http",
-			URL:  "http://proxy.example.com",
+			URL:  schemas.NewEnvVar("http://proxy.example.com"),
 		},
 		SendBackRawResponse: true,
 	}
@@ -13586,7 +13586,7 @@ func TestGenerateProviderHash_RuntimeVsMigrationParity(t *testing.T) {
 	t.Run("ProxyConfig_GORMRoundTrip", func(t *testing.T) {
 		proxyConfig := &schemas.ProxyConfig{
 			Type: schemas.HTTPProxy,
-			URL:  "http://proxy.example.com:8080",
+			URL:  schemas.NewEnvVar("http://proxy.example.com:8080"),
 		}
 
 		providerToSave := tables.TableProvider{

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1852,12 +1852,12 @@
         },
         "retry_backoff_initial": {
           "type": "integer",
-          "minimum": 0,
+          "minimum": 100,
           "description": "Initial retry backoff in milliseconds"
         },
         "retry_backoff_max": {
           "type": "integer",
-          "minimum": 0,
+          "minimum": 100,
           "description": "Maximum retry backoff in milliseconds"
         },
         "enforce_http2": {
@@ -1870,7 +1870,7 @@
         },
         "ca_cert_pem": {
           "type": "string",
-          "description": "PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA)"
+          "description": "PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA). Supports inline PEM or env.VAR_NAME."
         },
         "stream_idle_timeout_in_seconds": {
           "type": "integer",
@@ -1916,12 +1916,12 @@
         },
         "retry_backoff_initial": {
           "type": "integer",
-          "minimum": 0,
+          "minimum": 100,
           "description": "Initial retry backoff in milliseconds"
         },
         "retry_backoff_max": {
           "type": "integer",
-          "minimum": 0,
+          "minimum": 100,
           "description": "Maximum retry backoff in milliseconds"
         },
         "enforce_http2": {
@@ -2980,21 +2980,29 @@
           "description": "Type of proxy to use"
         },
         "url": {
-          "type": "string",
-          "format": "uri",
-          "description": "URL of the proxy server"
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$"
+            },
+            {
+              "type": "string",
+              "format": "uri"
+            }
+          ],
+          "description": "URL of the proxy server (supports env.VAR_NAME or a literal URI)"
         },
         "username": {
           "type": "string",
-          "description": "Username for proxy authentication"
+          "description": "Username for proxy authentication (supports env.VAR_NAME)"
         },
         "password": {
           "type": "string",
-          "description": "Password for proxy authentication"
+          "description": "Password for proxy authentication (supports env.VAR_NAME)"
         },
         "ca_cert_pem": {
           "type": "string",
-          "description": "PEM-encoded CA certificate to trust for TLS connections through the proxy (for SSL-intercepting proxies)"
+          "description": "PEM-encoded CA certificate to trust for TLS connections through the proxy (for SSL-intercepting proxies, supports env.VAR_NAME)"
         }
       },
       "required": ["type"],

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -1,15 +1,16 @@
 import { Button } from "@/components/ui/button";
+import { EnvVarInput } from "@/components/ui/envVarInput";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
-import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { DefaultNetworkConfig } from "@/lib/constants/config";
 import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
 import { useUpdateProviderMutation } from "@/lib/store/apis/providersApi";
 import { ModelProvider, isKnownProvider } from "@/lib/types/config";
-import { networkOnlyFormSchema, type NetworkOnlyFormSchema } from "@/lib/types/schemas";
+import { networkOnlyFormSchema, type EnvVar, type NetworkOnlyFormSchema } from "@/lib/types/schemas";
+import { toEnvVarFormValue, toOptionalEnvVarPayload } from "@/lib/utils/envVarForm";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
@@ -72,7 +73,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				retry_backoff_initial: provider.network_config?.retry_backoff_initial ?? DefaultNetworkConfig.retry_backoff_initial,
 				retry_backoff_max: provider.network_config?.retry_backoff_max ?? DefaultNetworkConfig.retry_backoff_max,
 				insecure_skip_verify: provider.network_config?.insecure_skip_verify ?? DefaultNetworkConfig.insecure_skip_verify,
-				ca_cert_pem: provider.network_config?.ca_cert_pem ?? DefaultNetworkConfig.ca_cert_pem,
+				ca_cert_pem: toEnvVarFormValue(provider.network_config?.ca_cert_pem as EnvVar | string | undefined),
 				stream_idle_timeout_in_seconds:
 					provider.network_config?.stream_idle_timeout_in_seconds ?? DefaultNetworkConfig.stream_idle_timeout_in_seconds,
 				max_conns_per_host: provider.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
@@ -106,7 +107,7 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				retry_backoff_initial: data.network_config?.retry_backoff_initial ?? 500,
 				retry_backoff_max: data.network_config?.retry_backoff_max ?? 10000,
 				insecure_skip_verify: data.network_config?.insecure_skip_verify ?? false,
-				ca_cert_pem: data.network_config?.ca_cert_pem?.trim() || undefined,
+				ca_cert_pem: toOptionalEnvVarPayload(data.network_config?.ca_cert_pem),
 				stream_idle_timeout_in_seconds:
 					data.network_config?.stream_idle_timeout_in_seconds ?? DefaultNetworkConfig.stream_idle_timeout_in_seconds,
 				max_conns_per_host: data.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
@@ -138,10 +139,11 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 				retry_backoff_initial: provider.network_config?.retry_backoff_initial ?? DefaultNetworkConfig.retry_backoff_initial,
 				retry_backoff_max: provider.network_config?.retry_backoff_max ?? DefaultNetworkConfig.retry_backoff_max,
 				insecure_skip_verify: provider.network_config?.insecure_skip_verify ?? DefaultNetworkConfig.insecure_skip_verify,
-				ca_cert_pem: provider.network_config?.ca_cert_pem ?? DefaultNetworkConfig.ca_cert_pem,
+				ca_cert_pem: toEnvVarFormValue(provider.network_config?.ca_cert_pem as EnvVar | string | undefined),
 				stream_idle_timeout_in_seconds:
 					provider.network_config?.stream_idle_timeout_in_seconds ?? DefaultNetworkConfig.stream_idle_timeout_in_seconds,
 				max_conns_per_host: provider.network_config?.max_conns_per_host ?? DefaultNetworkConfig.max_conns_per_host,
+				enforce_http2: provider.network_config?.enforce_http2 ?? DefaultNetworkConfig.enforce_http2,
 			},
 		});
 	}, [form, provider.name, provider.network_config]);
@@ -447,18 +449,23 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 									<FormItem>
 										<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
 										<FormControl>
-											<Textarea
-												placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
+											<EnvVarInput
+												variant="textarea"
+												placeholder={`-----BEGIN CERTIFICATE-----
+...
+-----END CERTIFICATE----- or env.OPENAI_CA_CERT_PEM`}
 												className="font-mono text-xs"
 												rows={6}
+												hideValueWhenEnv
+												redactNonEnvValue
 												{...field}
-												value={field.value || ""}
+												value={field.value}
 												disabled={!hasUpdateProviderAccess}
 												data-testid="network-config-ca-cert-pem"
 											/>
 										</FormControl>
 										<FormDescription>
-											PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA)
+											PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA).
 										</FormDescription>
 										<FormMessage />
 									</FormItem>

--- a/ui/app/workspace/providers/fragments/proxyFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/proxyFormFragment.tsx
@@ -1,12 +1,12 @@
 import { Button } from "@/components/ui/button";
+import { EnvVarInput } from "@/components/ui/envVarInput";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 import { getErrorMessage, setProviderFormDirtyState, useAppDispatch } from "@/lib/store";
 import { useUpdateProviderMutation } from "@/lib/store/apis/providersApi";
 import { ModelProvider } from "@/lib/types/config";
-import { proxyOnlyFormSchema, type ProxyOnlyFormSchema } from "@/lib/types/schemas";
+import { proxyOnlyFormSchema, type EnvVar, type ProxyOnlyFormSchema } from "@/lib/types/schemas";
+import { toEnvVarFormValue, toOptionalEnvVarPayload } from "@/lib/utils/envVarForm";
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -30,26 +30,26 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 		defaultValues: {
 			proxy_config: {
 				type: provider.proxy_config?.type,
-				url: provider.proxy_config?.url || "",
-				username: provider.proxy_config?.username || "",
-				password: provider.proxy_config?.password || "",
-				ca_cert_pem: provider.proxy_config?.ca_cert_pem || "",
+				url: toEnvVarFormValue(provider.proxy_config?.url as EnvVar | string | undefined),
+				username: toEnvVarFormValue(provider.proxy_config?.username as EnvVar | string | undefined),
+				password: toEnvVarFormValue(provider.proxy_config?.password as EnvVar | string | undefined),
+				ca_cert_pem: toEnvVarFormValue(provider.proxy_config?.ca_cert_pem as EnvVar | string | undefined),
 			},
 		},
 	});
 
 	useEffect(() => {
 		dispatch(setProviderFormDirtyState(form.formState.isDirty));
-	}, [form.formState.isDirty]);
+	}, [form.formState.isDirty, dispatch]);
 
 	useEffect(() => {
 		form.reset({
 			proxy_config: {
 				type: provider.proxy_config?.type,
-				url: provider.proxy_config?.url || "",
-				username: provider.proxy_config?.username || "",
-				password: provider.proxy_config?.password || "",
-				ca_cert_pem: provider.proxy_config?.ca_cert_pem || "",
+				url: toEnvVarFormValue(provider.proxy_config?.url as EnvVar | string | undefined),
+				username: toEnvVarFormValue(provider.proxy_config?.username as EnvVar | string | undefined),
+				password: toEnvVarFormValue(provider.proxy_config?.password as EnvVar | string | undefined),
+				ca_cert_pem: toEnvVarFormValue(provider.proxy_config?.ca_cert_pem as EnvVar | string | undefined),
 			},
 		});
 	}, [form, provider.name, provider.proxy_config]);
@@ -61,10 +61,10 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 			buildProviderUpdatePayload(provider, {
 				proxy_config: {
 					type: data.proxy_config?.type ?? "none",
-					url: data.proxy_config?.url || undefined,
-					username: data.proxy_config?.username || undefined,
-					password: data.proxy_config?.password || undefined,
-					ca_cert_pem: data.proxy_config?.ca_cert_pem || undefined,
+					url: toOptionalEnvVarPayload(data.proxy_config?.url),
+					username: toOptionalEnvVarPayload(data.proxy_config?.username),
+					password: toOptionalEnvVarPayload(data.proxy_config?.password),
+					ca_cert_pem: toOptionalEnvVarPayload(data.proxy_config?.ca_cert_pem),
 				},
 			}),
 		)
@@ -127,11 +127,12 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 										<FormItem>
 											<FormLabel>Proxy URL</FormLabel>
 											<FormControl>
-												<Input
-													placeholder="http://proxy.example.com"
+												<EnvVarInput
+													placeholder="http://proxy.example.com or env.OPENAI_PROXY_URL"
 													{...field}
-													value={field.value || ""}
+													value={field.value}
 													disabled={!hasUpdateProviderAccess}
+													data-testid="env-var-proxy-url"
 												/>
 											</FormControl>
 											<FormMessage />
@@ -146,7 +147,13 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 											<FormItem>
 												<FormLabel>Username</FormLabel>
 												<FormControl>
-													<Input placeholder="Proxy username" {...field} value={field.value || ""} disabled={!hasUpdateProviderAccess} />
+													<EnvVarInput
+														placeholder="Proxy username or env.OPENAI_PROXY_USERNAME"
+														{...field}
+														value={field.value}
+														disabled={!hasUpdateProviderAccess}
+														data-testid="env-var-proxy-username"
+													/>
 												</FormControl>
 												<FormMessage />
 											</FormItem>
@@ -159,12 +166,15 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 											<FormItem>
 												<FormLabel>Password</FormLabel>
 												<FormControl>
-													<Input
+													<EnvVarInput
 														type="password"
-														placeholder="Proxy password"
+														placeholder="Proxy password or env.OPENAI_PROXY_PASSWORD"
+														hideValueWhenEnv
+														redactNonEnvValue
 														{...field}
-														value={field.value || ""}
+														value={field.value}
 														disabled={!hasUpdateProviderAccess}
+														data-testid="env-var-proxy-password"
 													/>
 												</FormControl>
 												<FormMessage />
@@ -179,17 +189,22 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 										<FormItem>
 											<FormLabel>CA Certificate (PEM) (Optional)</FormLabel>
 											<FormControl>
-												<Textarea
-													placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
+												<EnvVarInput
+													variant="textarea"
+													placeholder="-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE----- or env.OPENAI_PROXY_CA_CERT_PEM"
 													className="font-mono text-xs"
 													rows={6}
+													hideValueWhenEnv
+													redactNonEnvValue
 													{...field}
-													value={field.value || ""}
+													value={field.value}
 													disabled={!hasUpdateProviderAccess}
+													data-testid="env-var-proxy-ca-cert-pem"
 												/>
 											</FormControl>
 											<FormDescription>
-												PEM-encoded CA certificate to trust for TLS connections through SSL-intercepting proxies
+												PEM-encoded CA certificate to trust for TLS connections through SSL-intercepting proxies. You can also use
+												<code> env.YOUR_PROXY_CA_CERT_VAR</code>.
 											</FormDescription>
 											<FormMessage />
 										</FormItem>
@@ -206,7 +221,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 						type="button"
 						variant="outline"
 						onClick={() => {
-							onSubmit({ proxy_config: { type: "none", url: "" } });
+							onSubmit({ proxy_config: { type: "none" } });
 						}}
 						disabled={!hasUpdateProviderAccess || isUpdatingProvider || !provider.proxy_config || provider.proxy_config.type === "none"}
 					>

--- a/ui/components/ui/envVarInput.tsx
+++ b/ui/components/ui/envVarInput.tsx
@@ -10,6 +10,11 @@ type BaseEnvVarInputProps = {
 	inputClassName?: string;
 	variant?: "input" | "textarea";
 	rows?: number;
+	hideValueWhenEnv?: boolean;
+	maskNonEnvValue?: boolean;
+	redactNonEnvValue?: boolean;
+	maskVisiblePrefix?: number;
+	maskVisibleSuffix?: number;
 };
 
 type InputVariantProps = BaseEnvVarInputProps & {
@@ -22,10 +27,37 @@ type TextareaVariantProps = BaseEnvVarInputProps & {
 
 export type EnvVarInputProps = InputVariantProps | TextareaVariantProps;
 
+const maskValue = (value: string, visiblePrefix: number, visibleSuffix: number) => {
+	if (!value) return "";
+	if (visiblePrefix <= 0 && visibleSuffix <= 0) {
+		return "****";
+	}
+	if (value.length <= visiblePrefix + visibleSuffix) {
+		return `${value.slice(0, 1)}****${value.slice(-1)}`;
+	}
+	const prefix = visiblePrefix > 0 ? value.slice(0, visiblePrefix) : "";
+	const suffix = visibleSuffix > 0 ? value.slice(-visibleSuffix) : "";
+	return `${prefix}****${suffix}`;
+};
+
 export const EnvVarInput = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, EnvVarInputProps>(
-	({ className, value, onChange, inputClassName, variant = "input", rows, ...props }, ref) => {
-		// Extract display value from EnvVar object
-		const displayValue = value?.value ?? "";
+	(
+		{
+			className,
+			value,
+			onChange,
+			inputClassName,
+			variant = "input",
+			rows,
+			hideValueWhenEnv = false,
+			maskNonEnvValue = false,
+			redactNonEnvValue = false,
+			maskVisiblePrefix = 4,
+			maskVisibleSuffix = 4,
+			...props
+		},
+		ref,
+	) => {
 		const hasChanged = useRef(false);
 		const isUserChange = useRef(false);
 
@@ -41,9 +73,30 @@ export const EnvVarInput = React.forwardRef<HTMLInputElement | HTMLTextAreaEleme
 
 		// Show badge when value is from env (server-synced or user-typed)
 		const showBadge = value?.from_env && value?.env_var;
+		const rawValue = value?.value ?? "";
+		const displayValue =
+			showBadge && hideValueWhenEnv && !hasChanged.current
+				? ""
+				: redactNonEnvValue && !showBadge && !hasChanged.current && rawValue
+					? "<REDACTED>"
+				: maskNonEnvValue && !showBadge && !hasChanged.current
+					? maskValue(rawValue, maskVisiblePrefix, maskVisibleSuffix)
+					: rawValue;
 
 		const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-			const newValue = e.target.value;
+			const inputValue = e.target.value;
+			const isMaskedOrPlaceholder =
+				!hasChanged.current &&
+				displayValue !== rawValue &&
+				(displayValue === "<REDACTED>" || (displayValue.length > 0 && !showBadge));
+			let newValue = inputValue;
+			if (isMaskedOrPlaceholder) {
+				if (inputValue === displayValue) {
+					newValue = "";
+				} else if (displayValue && inputValue.startsWith(displayValue)) {
+					newValue = inputValue.slice(displayValue.length);
+				}
+			}
 			hasChanged.current = true;
 			isUserChange.current = true;
 			// Auto-detect env var prefix

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -84,7 +84,7 @@ export const DefaultNetworkConfig = {
 	retry_backoff_initial: 1000,
 	retry_backoff_max: 10000,
 	insecure_skip_verify: false,
-	ca_cert_pem: "",
+	ca_cert_pem: { value: "", env_var: "", from_env: false },
 	stream_idle_timeout_in_seconds: 60,
 	max_conns_per_host: 5000,
 	enforce_http2: false,

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -1,4 +1,5 @@
 import { KnownProvidersNames } from "@/lib/constants/logs";
+import { envVarSchema } from "@/lib/types/schemas";
 import { isValidAliases, isValidVertexAuthCredentials } from "@/lib/utils/validation";
 import { z } from "zod";
 
@@ -36,6 +37,11 @@ const NetworkConfigSchema = z
 		max_retries: z.number().min(0, "Max retries cannot be negative"),
 		retry_backoff_initial: z.number(),
 		retry_backoff_max: z.number(),
+		insecure_skip_verify: z.boolean().optional(),
+		ca_cert_pem: z.union([z.string(), envVarSchema]).optional(),
+		stream_idle_timeout_in_seconds: z.number().int().min(5).max(3600).optional(),
+		max_conns_per_host: z.number().int().min(1).max(10000).optional(),
+		enforce_http2: z.boolean().optional(),
 	})
 	.refine((v) => v.retry_backoff_initial <= v.retry_backoff_max, {
 		message: "Initial backoff must be <= max backoff",

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -174,7 +174,7 @@ export interface NetworkConfig {
 	retry_backoff_initial: number; // Duration in milliseconds
 	retry_backoff_max: number; // Duration in milliseconds
 	insecure_skip_verify?: boolean;
-	ca_cert_pem?: string;
+	ca_cert_pem?: EnvVar;
 	stream_idle_timeout_in_seconds?: number;
 	max_conns_per_host?: number;
 	enforce_http2?: boolean;
@@ -193,10 +193,10 @@ export type ProxyType = "none" | "http" | "socks5" | "environment";
 // ProxyConfig matching Go's schemas.ProxyConfig
 export interface ProxyConfig {
 	type: ProxyType;
-	url?: string;
-	username?: string;
-	password?: string;
-	ca_cert_pem?: string;
+	url?: EnvVar;
+	username?: EnvVar;
+	password?: EnvVar;
+	ca_cert_pem?: EnvVar;
 }
 
 // Request types matching Go's schemas.RequestType

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -306,9 +306,9 @@ export const networkConfigSchema = z
 			.max(3600, "Timeout must be less than 3600 seconds"),
 		max_retries: z.number().min(0, "Max retries must be greater than 0").max(10, "Max retries must be less than 10"),
 		retry_backoff_initial: z.number().min(100),
-		retry_backoff_max: z.number().min(1000),
+		retry_backoff_max: z.number().min(100),
 		insecure_skip_verify: z.boolean().optional(),
-		ca_cert_pem: z.string().optional(),
+		ca_cert_pem: envVarSchema.optional(),
 		stream_idle_timeout_in_seconds: z
 			.number()
 			.int("Stream idle timeout must be a whole number of seconds")
@@ -360,7 +360,7 @@ export const networkFormConfigSchema = z
 			.min(100, "Retry backoff max must be at least 100ms")
 			.max(1000000, "Retry backoff max must be at most 1000000ms"),
 		insecure_skip_verify: z.boolean().optional(),
-		ca_cert_pem: z.string().optional(),
+		ca_cert_pem: envVarSchema.optional(),
 		stream_idle_timeout_in_seconds: z.coerce
 			.number("Stream idle timeout must be a number")
 			.int("Stream idle timeout must be a whole number of seconds")
@@ -393,20 +393,23 @@ export const proxyTypeSchema = z.enum(["none", "http", "socks5", "environment"])
 export const proxyConfigSchema = z
 	.object({
 		type: proxyTypeSchema,
-		url: z.url("Must be a valid URL"),
-		username: z.string().optional(),
-		password: z.string().optional(),
-		ca_cert_pem: z.string().optional(),
+		url: envVarSchema.optional(),
+		username: envVarSchema.optional(),
+		password: envVarSchema.optional(),
+		ca_cert_pem: envVarSchema.optional(),
 	})
-	.refine((data) => !(data.type === "http" || data.type === "socks5") || (data.url && data.url.trim().length > 0), {
+	.refine((data) => !(data.type === "http" || data.type === "socks5") || data.url?.from_env === true || (data.url?.value && data.url.value.trim().length > 0), {
 		message: "Proxy URL is required when using HTTP or SOCKS5 proxy",
 		path: ["url"],
 	})
 	.refine(
 		(data) => {
-			if ((data.type === "http" || data.type === "socks5") && data.url?.trim()) {
+			if ((data.type === "http" || data.type === "socks5") && data.url?.value?.trim()) {
+				if (data.url.from_env || data.url.env_var?.startsWith("env.")) {
+					return true;
+				}
 				try {
-					new URL(data.url);
+					new URL(data.url.value);
 					return true;
 				} catch {
 					return false;
@@ -421,10 +424,10 @@ export const proxyConfigSchema = z
 export const proxyFormConfigSchema = z
 	.object({
 		type: proxyTypeSchema,
-		url: z.string().optional(),
-		username: z.string().optional(),
-		password: z.string().optional(),
-		ca_cert_pem: z.string().optional(),
+		url: envVarSchema.optional(),
+		username: envVarSchema.optional(),
+		password: envVarSchema.optional(),
+		ca_cert_pem: envVarSchema.optional(),
 	})
 	.refine(
 		(data) => {
@@ -433,8 +436,10 @@ export const proxyFormConfigSchema = z
 			}
 			// URL is required when proxy type is http or socks5
 			if (data.type === "http" || data.type === "socks5") {
-				// Check for URL existence, non-empty, and valid format
-				if (!data.url || data.url.trim().length === 0) return false;
+				// Env-backed URLs may have empty resolved value before env resolution.
+				if (data.url?.from_env || data.url?.env_var?.startsWith("env.")) return true;
+				// Literal URLs must be non-empty.
+				if (!data.url?.value || data.url.value.trim().length === 0) return false;
 			}
 			return true;
 		},
@@ -446,9 +451,12 @@ export const proxyFormConfigSchema = z
 	.refine(
 		(data) => {
 			// URL must be valid format when provided and proxy type requires it
-			if ((data.type === "http" || data.type === "socks5") && data.url && data.url.trim().length > 0) {
+			if ((data.type === "http" || data.type === "socks5") && data.url?.value && data.url.value.trim().length > 0) {
+				if (data.url.from_env || data.url.env_var?.startsWith("env.")) {
+					return true;
+				}
 				try {
-					new URL(data.url);
+					new URL(data.url.value);
 					return true;
 				} catch {
 					return false;

--- a/ui/lib/utils/envVarForm.ts
+++ b/ui/lib/utils/envVarForm.ts
@@ -1,0 +1,33 @@
+import { type EnvVar } from "@/lib/types/schemas";
+
+export const emptyEnvVar = (): EnvVar => ({ value: "", env_var: "", from_env: false });
+
+export const toEnvVarFormValue = (field?: EnvVar | string): EnvVar => {
+	if (!field) return emptyEnvVar();
+	if (typeof field === "string") {
+		const value = field.trim();
+		if (!value) return emptyEnvVar();
+		const isEnvRef = value.startsWith("env.");
+		return {
+			value,
+			env_var: isEnvRef ? value : "",
+			from_env: isEnvRef,
+		};
+	}
+	return {
+		value: field.value || "",
+		env_var: field.env_var || "",
+		from_env: field.from_env ?? false,
+	};
+};
+
+export const toOptionalEnvVarPayload = (field?: { value?: string; env_var?: string; from_env?: boolean }) => {
+	const envVar = field?.env_var?.trim();
+	const value = field?.value?.trim();
+	if (!value && !(field?.from_env && envVar)) return undefined;
+	return {
+		value: value || "",
+		env_var: envVar || "",
+		from_env: field?.from_env ?? false,
+	};
+};


### PR DESCRIPTION
## Summary

Sensitive configuration fields for proxy and network TLS settings (`ProxyConfig.URL`, `ProxyConfig.Username`, `ProxyConfig.Password`, `ProxyConfig.CACertPEM`, and `NetworkConfig.CACertPEM`) previously accepted plain strings. This PR migrates all of those fields to the `*EnvVar` type, enabling values to be sourced from environment variables using the `env.VAR_NAME` syntax instead of requiring inline secrets in configuration files.

## Changes

- `NetworkConfig.CACertPEM` changed from `string` to `*EnvVar`; all call sites updated to use `.GetValue()` for resolution
- `ProxyConfig.URL`, `Username`, `Password`, and `CACertPEM` changed from `string` to `*EnvVar`
- `Redacted()` methods on both `NetworkConfig` and `ProxyConfig` updated to preserve env-backed references (showing the `env.VAR_NAME` reference rather than `<REDACTED>`) while still redacting inline literal values
- `MarshalJSON` for `NetworkConfig` updated to serialize env-backed values as their reference string and literal values as their resolved string
- Provider update handler updated to correctly detect and restore redacted `CACertPEM` and proxy secrets when a client sends back placeholder values
- UI `ProxyConfig` and `NetworkConfig` TypeScript types updated to use `EnvVar` instead of `string` for the affected fields
- Zod schemas for proxy and network config updated to validate `EnvVar` objects; URL format validation skips env-backed references
- `EnvVarInput` component extended with `hideValueWhenEnv`, `redactNonEnvValue`, `maskNonEnvValue`, and masking options; proxy and network form fragments migrated from plain `Input`/`Textarea` to `EnvVarInput`
- New `toEnvVarFormValue` and `toOptionalEnvVarPayload` utilities added to normalize between server responses (which may return plain strings or `EnvVar` objects) and form state
- Helm `_helpers.tpl` updated to explicitly pass through all `network_config` fields including `ca_cert_pem` and `enforce_http2`; Helm and transport JSON schemas updated with improved descriptions and corrected `retry_backoff` minimums (0 → 100)
- New layered Helm values example files added under `examples/k8s/examples/` covering SQLite, Postgres, providers, governance, routing rules, pricing overrides, and pod-label overlays

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./core/providers/bedrock/...
go test ./core/providers/utils/...
go test ./core/schemas/...
go test ./framework/configstore/tables/...
go test ./transports/bifrost-http/lib/...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

To validate env-backed config, set a config value using the `env.` prefix:

```json
{
  "providers": {
    "openai": {
      "network_config": {
        "ca_cert_pem": "env.OPENAI_CA_CERT_PEM"
      },
      "proxy_config": {
        "type": "http",
        "url": "env.OPENAI_PROXY_URL",
        "password": "env.OPENAI_PROXY_PASSWORD"
      }
    }
  }
}
```

Set the corresponding environment variables and confirm the resolved values are used at runtime. Confirm that `Redacted()` output preserves the `env.VAR_NAME` reference and does not replace it with `<REDACTED>`.

## Screenshots/Recordings

The proxy and network config forms now render `EnvVarInput` components for URL, username, password, and CA certificate fields. Env-backed fields show a badge and hide the resolved value; inline sensitive values display as `<REDACTED>` until edited.

## Breaking changes

- [x] Yes
- [ ] No

`ProxyConfig.URL`, `Username`, `Password`, `CACertPEM`, and `NetworkConfig.CACertPEM` are now `*EnvVar` instead of `string`. Any code constructing these structs directly must wrap literal values with `schemas.NewEnvVar(value)`. Existing JSON configs using plain string values for these fields will continue to deserialize correctly as the `EnvVar` type accepts both plain strings and `env.VAR_NAME` references.

## Related issues

N/A

## Security considerations

Inline secrets (proxy passwords, CA certificates) are no longer required in configuration files; they can be injected via environment variables. The `Redacted()` path preserves `env.VAR_NAME` references so audit logs do not expose variable names as redacted, while still masking literal inline values. The UI `EnvVarInput` component hides resolved env values and shows `<REDACTED>` for inline sensitive fields to avoid leaking secrets through the browser.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable