### PR TITLE
chore: wrap Sidebar in Suspense and reorder className attributes

### DIFF
--- a/ui/app/clientLayout.tsx
+++ b/ui/app/clientLayout.tsx
@@ -14,7 +14,7 @@ import { RbacProvider } from "@enterprise/lib/contexts/rbacContext";
 import dynamic from "next/dynamic";
 import { usePathname } from "next/navigation";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { CookiesProvider } from "react-cookie";
 import { toast, Toaster } from "sonner";
 
@@ -40,9 +40,11 @@ function AppContent({ children }: { children: React.ReactNode }) {
 			<CookiesProvider>
 				<StoreSyncInitializer />
 				<SidebarProvider>
-					<Sidebar />
-					<div className="dark:bg-card custom-scrollbar my-[0.5rem] mr-[0.5rem] h-[calc(100dvh-1rem)] w-full min-w-xl overflow-auto rounded-md border border-gray-200 bg-white px-10 dark:border-zinc-800 content-container">
-						<main className="custom-scrollbar relative mx-auto flex flex-col overflow-y-hidden p-4 content-container-inner">
+					<Suspense>
+						<Sidebar />
+					</Suspense>
+					<div className="dark:bg-card custom-scrollbar content-container my-[0.5rem] mr-[0.5rem] h-[calc(100dvh-1rem)] w-full min-w-xl overflow-auto rounded-md border border-gray-200 bg-white px-10 dark:border-zinc-800">
+						<main className="custom-scrollbar content-container-inner relative mx-auto flex flex-col overflow-y-hidden p-4">
 							{isLoading ? <FullPageLoader /> : <FullPage config={bifrostConfig}>{children}</FullPage>}
 						</main>
 					</div>


### PR DESCRIPTION
## Summary

Wraps the `Sidebar` component in a `Suspense` boundary to prevent rendering issues caused by missing suspense context, and fixes Tailwind class ordering for `content-container` and `content-container-inner` elements.

## Changes

- Wrapped `<Sidebar />` in a `<Suspense>` boundary to handle async rendering within the sidebar without propagating suspension to the rest of the layout
- Reordered Tailwind utility classes on the content container `div` and `main` elements to place custom class names (`content-container`, `content-container-inner`) in a consistent position

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Load the application and verify the sidebar renders correctly without any suspense-related errors in the console.
2. Navigate between routes and confirm the sidebar and main content area display as expected.

## Screenshots/Recordings

Before/after screenshots of the sidebar and content layout to confirm no visual regressions.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable