### PR TITLE
fix: adds base_url to network_config for backward compatibility

### DIFF
--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -900,7 +900,14 @@
                     "default": 50
                   }
                 },
-                "required": ["host", "port", "user", "password", "db_name", "ssl_mode"],
+                "required": [
+                  "host",
+                  "port",
+                  "user",
+                  "password",
+                  "db_name",
+                  "ssl_mode"
+                ],
                 "additionalProperties": false
               }
             }
@@ -991,7 +998,14 @@
                     "default": 50
                   }
                 },
-                "required": ["host", "port", "user", "password", "db_name", "ssl_mode"],
+                "required": [
+                  "host",
+                  "port",
+                  "user",
+                  "password",
+                  "db_name",
+                  "ssl_mode"
+                ],
                 "additionalProperties": false
               }
             }
@@ -2593,7 +2607,7 @@
           "description": "API keys for this provider"
         },
         "network_config": {
-          "$ref": "#/$defs/network_config_without_base_url"
+          "$ref": "#/$defs/network_config"
         },
         "concurrency_and_buffer_size": {
           "$ref": "#/$defs/concurrency_and_buffer_size"
@@ -2617,7 +2631,6 @@
           "$ref": "#/$defs/custom_provider_config"
         }
       },
-      "required": ["keys"],
       "additionalProperties": false
     },
     "provider_with_sgl_config": {
@@ -2632,7 +2645,7 @@
           "description": "API keys for this provider"
         },
         "network_config": {
-          "$ref": "#/$defs/network_config_without_base_url"
+          "$ref": "#/$defs/network_config"
         },
         "concurrency_and_buffer_size": {
           "$ref": "#/$defs/concurrency_and_buffer_size"
@@ -2656,7 +2669,6 @@
           "$ref": "#/$defs/custom_provider_config"
         }
       },
-      "required": ["keys"],
       "additionalProperties": false
     },
     "mcp_client_config": {
@@ -2899,14 +2911,10 @@
             },
             "oneOf": [
               {
-                "required": [
-                  "mcp_client_id"
-                ]
+                "required": ["mcp_client_id"]
               },
               {
-                "required": [
-                  "mcp_client_name"
-                ]
+                "required": ["mcp_client_name"]
               }
             ],
             "additionalProperties": false
@@ -3225,7 +3233,11 @@
                   "description": "Number of failed probes before marking as failed"
                 }
               },
-              "required": ["timeout_seconds", "success_threshold", "failure_threshold"],
+              "required": [
+                "timeout_seconds",
+                "success_threshold",
+                "failure_threshold"
+              ],
               "additionalProperties": false
             }
           },
@@ -3639,11 +3651,7 @@
           "description": "Reset window, e.g. \"1M\", \"1h\""
         }
       },
-      "required": [
-        "id",
-        "max_limit",
-        "reset_duration"
-      ],
+      "required": ["id", "max_limit", "reset_duration"],
       "additionalProperties": false
     },
     "rate_limit_line": {
@@ -3735,9 +3743,7 @@
           }
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     },
     "access_profile_provider_config": {
@@ -3769,9 +3775,7 @@
           "$ref": "#/$defs/rate_limit_line"
         }
       },
-      "required": [
-        "provider_name"
-      ],
+      "required": ["provider_name"],
       "additionalProperties": false
     },
     "access_profile_mcp_tool_group": {
@@ -3783,9 +3787,7 @@
           "description": "MCP tool group ID"
         }
       },
-      "required": [
-        "tool_group_id"
-      ],
+      "required": ["tool_group_id"],
       "additionalProperties": false
     },
     "access_profile_mcp_server": {
@@ -3796,9 +3798,7 @@
           "description": "MCP server identifier"
         }
       },
-      "required": [
-        "mcp_server_id"
-      ],
+      "required": ["mcp_server_id"],
       "additionalProperties": false
     },
     "access_profile_mcp_tool_override": {
@@ -3818,11 +3818,7 @@
           "description": "Override action"
         }
       },
-      "required": [
-        "mcp_client_id",
-        "tool_name",
-        "action"
-      ],
+      "required": ["mcp_client_id", "tool_name", "action"],
       "additionalProperties": false
     },
     "audit_logs_config": {
@@ -4000,7 +3996,14 @@
           "description": "Internal hash for change detection (auto-managed)"
         }
       },
-      "required": ["id", "name", "scope_kind", "match_type", "pattern", "request_types"],
+      "required": [
+        "id",
+        "name",
+        "scope_kind",
+        "match_type",
+        "pattern",
+        "request_types"
+      ],
       "additionalProperties": false
     },
     "pricing_override_match_type": {


### PR DESCRIPTION
## Summary

Cleans up formatting in `config.schema.json` and relaxes constraints on provider configurations by removing the `keys` requirement and allowing `network_config` (with base URL) for certain providers.

## Changes

- Removed `"required": ["keys"]` from `provider_with_sgl_config` and the adjacent provider config definition, making API keys optional for those providers
- Switched `network_config` references from `network_config_without_base_url` to `network_config` for those same providers, allowing a `base_url` to be specified
- Reformatted several `required` arrays from single-line to multi-line style (and vice versa) for consistency and readability throughout the schema

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate the schema changes by running any existing schema validation tests or linting the JSON schema directly.

```sh
go test ./transports/...
```

Confirm that provider configurations without `keys` are accepted and that `base_url` can be specified in `network_config` for the affected provider types.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. The relaxation of `keys` as a required field applies only to specific provider config types where authentication may be handled differently (e.g., via base URL or alternative mechanisms).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable