### PR TITLE
fix: Fixes OTEL exporting to show input and output messages correctly

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+- fix: Fixes OTEL exporting in `framework/tracing/llmspan.go` to show input and output messages correctly

--- a/framework/tracing/llmspan.go
+++ b/framework/tracing/llmspan.go
@@ -202,7 +202,9 @@ func PopulateChatRequestAttributes(req *schemas.BifrostChatRequest, attrs map[st
 		attrs[schemas.AttrMessageCount] = len(req.Input)
 		messages := extractChatMessages(req.Input)
 		if len(messages) > 0 {
-			attrs[schemas.AttrInputMessages] = messages
+			if data, err := schemas.MarshalString(messages); err == nil {
+				attrs[schemas.AttrInputMessages] = data
+			}
 		}
 	}
 }
@@ -229,7 +231,9 @@ func PopulateChatResponseAttributes(resp *schemas.BifrostChatResponse, attrs map
 	// Extract output messages
 	outputMessages := extractChatResponseMessages(resp)
 	if len(outputMessages) > 0 {
-		attrs[schemas.AttrOutputMessages] = outputMessages
+		if data, err := schemas.MarshalString(outputMessages); err == nil {
+			attrs[schemas.AttrOutputMessages] = data
+		}
 	}
 
 	// Extract finish reason from first choice
@@ -563,7 +567,9 @@ func PopulateResponsesRequestAttributes(req *schemas.BifrostResponsesRequest, at
 		attrs[schemas.AttrMessageCount] = len(req.Input)
 		inputMessages := extractResponsesInputMessages(req.Input)
 		if len(inputMessages) > 0 {
-			attrs[schemas.AttrInputMessages] = inputMessages
+			if data, err := schemas.MarshalString(inputMessages); err == nil {
+				attrs[schemas.AttrInputMessages] = data
+			}
 		}
 	}
 
@@ -619,18 +625,34 @@ func PopulateResponsesRequestAttributes(req *schemas.BifrostResponsesRequest, at
 		}
 	}
 	if req.Params.Tools != nil {
-		tools := make([]string, len(req.Params.Tools))
-		for i, tool := range req.Params.Tools {
-			tools[i] = string(tool.Type)
+		type toolInfo struct {
+			Name        string `json:"name"`
+			Description string `json:"description,omitempty"`
 		}
-		attrs[schemas.AttrTools] = strings.Join(tools, ",")
+		tools := make([]toolInfo, 0, len(req.Params.Tools))
+		for _, tool := range req.Params.Tools {
+			if tool.Name != nil {
+				info := toolInfo{Name: *tool.Name}
+				if tool.Description != nil {
+					info.Description = *tool.Description
+				}
+				tools = append(tools, info)
+			} else {
+				tools = append(tools, toolInfo{Name: string(tool.Type)})
+			}
+		}
+		if data, err := schemas.MarshalString(tools); err == nil {
+			attrs[schemas.AttrTools] = data
+		}
 	}
 	if req.Params.Truncation != nil {
 		attrs[schemas.AttrTruncation] = *req.Params.Truncation
 	}
 	// ExtraParams
 	for k, v := range req.Params.ExtraParams {
-		attrs[k] = fmt.Sprintf("%v", v)
+		if data, err := schemas.MarshalString(v); err == nil {
+			attrs[k] = data
+		}
 	}
 }
 
@@ -653,7 +675,9 @@ func PopulateResponsesResponseAttributes(resp *schemas.BifrostResponsesResponse,
 	// Extract output messages (includes reasoning)
 	outputMessages := extractResponsesOutputMessages(resp)
 	if len(outputMessages) > 0 {
-		attrs[schemas.AttrOutputMessages] = outputMessages
+		if data, err := schemas.MarshalString(outputMessages); err == nil {
+			attrs[schemas.AttrOutputMessages] = data
+		}
 	}
 
 	// Additional response fields


### PR DESCRIPTION
## Summary

Input and output message attributes in tracing spans are now serialized to JSON strings before being stored, rather than being stored as raw Go slices/structs. This ensures compatibility with OpenTelemetry attribute value constraints, which require scalar or homogeneous slice types rather than arbitrary objects.

## Changes

- `AttrInputMessages` and `AttrOutputMessages` span attributes are now marshaled to JSON strings via `schemas.MarshalString` before assignment in both the Chat and Responses tracing paths
- If marshaling fails, the attribute is silently omitted rather than storing an incompatible type, preventing potential panics or export errors downstream

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/tracing/...
```

Verify that trace spans exported for chat and responses requests/responses contain `input.messages` and `output.messages` as JSON-encoded strings rather than raw Go objects. Confirm that tracing exporters (e.g., OTLP) accept and correctly transmit these attributes without type errors.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Message content serialized into trace attributes may contain sensitive user data. Ensure tracing exporters and backends are configured appropriately to handle PII in span attributes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable