### PR TITLE
fix: resolve request type from pending data before streaming chunk processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ dev-pulse: install-ui install-pulse setup-workspace $(if $(DEBUG),install-delve)
 	if [ -n "$(DEBUG)" ]; then \
 		$(ECHO) "$(CYAN)Starting with pulse + delve debugger on port 2345...$(NC)"; \
 		$(ECHO) "$(YELLOW)Attach your debugger to localhost:2345$(NC)"; \
-		BIFROST_UI_DEV=true pulse -- \
+		PORT="$(PORT)" BIFROST_UI_DEV=true pulse -- \
 			-host "$(HOST)" \
 			-port "$(PORT)" \
 			-log-style "$(LOG_STYLE)" \
@@ -207,7 +207,7 @@ dev-pulse: install-ui install-pulse setup-workspace $(if $(DEBUG),install-delve)
 			$(if $(PROMETHEUS_LABELS),-prometheus-labels "$(PROMETHEUS_LABELS)") \
 			$(if $(APP_DIR),-app-dir "$(APP_DIR)"); \
 	else \
-		BIFROST_UI_DEV=true pulse -- \
+		PORT="$(PORT)" BIFROST_UI_DEV=true pulse -- \
 			-host "$(HOST)" \
 			-port "$(PORT)" \
 			-log-style "$(LOG_STYLE)" \

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
 - feat: Standardizes tool stripping and anthropic integration handling against anthropic, vertex and azure
 - fix: drops empty thinking block for anthropic provider for claude code
+- feat: add support for cache creation details for claude models

--- a/core/internal/llmtests/response_validation.go
+++ b/core/internal/llmtests/response_validation.go
@@ -584,6 +584,24 @@ func validateChatToolCalls(t *testing.T, response *schemas.BifrostChatResponse, 
 
 // validateChatTechnicalFields checks technical aspects of the chat response
 func validateChatTechnicalFields(t *testing.T, response *schemas.BifrostChatResponse, expectations ResponseExpectations, result *ValidationResult) {
+	// Strict checks: these fields must always be populated
+	if response.ExtraFields.RequestType == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "ExtraFields.RequestType is empty")
+	}
+	if response.ExtraFields.Provider == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "ExtraFields.Provider is empty")
+	}
+	if strings.TrimSpace(response.ExtraFields.OriginalModelRequested) == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "ExtraFields.OriginalModelRequested is empty")
+	}
+	if strings.TrimSpace(response.ExtraFields.ResolvedModelUsed) == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "ExtraFields.ResolvedModelUsed is empty")
+	}
+
 	// Check usage stats
 	if expectations.ShouldHaveUsageStats {
 		if response.Usage == nil {
@@ -976,6 +994,24 @@ func validateResponsesToolCalls(t *testing.T, response *schemas.BifrostResponses
 
 // validateResponsesTechnicalFields checks technical aspects of the Responses API response
 func validateResponsesTechnicalFields(t *testing.T, response *schemas.BifrostResponsesResponse, expectations ResponseExpectations, result *ValidationResult) {
+	// Strict checks: these fields must always be populated
+	if response.ExtraFields.RequestType == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "ExtraFields.RequestType is empty")
+	}
+	if response.ExtraFields.Provider == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "ExtraFields.Provider is empty")
+	}
+	if strings.TrimSpace(response.ExtraFields.OriginalModelRequested) == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "ExtraFields.OriginalModelRequested is empty")
+	}
+	if strings.TrimSpace(response.ExtraFields.ResolvedModelUsed) == "" {
+		result.Passed = false
+		result.Errors = append(result.Errors, "ExtraFields.ResolvedModelUsed is empty")
+	}
+
 	// Check usage stats
 	if expectations.ShouldHaveUsageStats {
 		if response.Usage == nil {

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -798,6 +798,17 @@ func HandleAnthropicChatCompletionStreaming(
 					if usageToProcess.CacheCreationInputTokens > usage.PromptTokensDetails.CachedWriteTokens {
 						usage.PromptTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
 					}
+					if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
+						if usage.PromptTokensDetails.CachedWriteTokenDetails == nil {
+							usage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+						}
+						if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
+							usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
+						}
+						if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
+							usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
+						}
+					}
 				}
 			}
 			if event.Message != nil {
@@ -1255,6 +1266,17 @@ func HandleAnthropicResponsesStream(
 					}
 					if usageToProcess.CacheCreationInputTokens > usage.InputTokensDetails.CachedWriteTokens {
 						usage.InputTokensDetails.CachedWriteTokens = usageToProcess.CacheCreationInputTokens
+					}
+					if usageToProcess.CacheCreation.Ephemeral5mInputTokens > 0 || usageToProcess.CacheCreation.Ephemeral1hInputTokens > 0 {
+						if usage.InputTokensDetails.CachedWriteTokenDetails == nil {
+							usage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+						}
+						if usageToProcess.CacheCreation.Ephemeral5mInputTokens > usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m {
+							usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = usageToProcess.CacheCreation.Ephemeral5mInputTokens
+						}
+						if usageToProcess.CacheCreation.Ephemeral1hInputTokens > usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h {
+							usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = usageToProcess.CacheCreation.Ephemeral1hInputTokens
+						}
 					}
 				}
 			}

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -868,13 +868,20 @@ func (response *AnthropicMessageResponse) ToBifrostChatResponse(ctx *schemas.Bif
 
 	// Convert usage information
 	if response.Usage != nil {
+		promptTokensDetails := &schemas.ChatPromptTokensDetails{
+			CachedReadTokens:  response.Usage.CacheReadInputTokens,
+			CachedWriteTokens: response.Usage.CacheCreationInputTokens,
+		}
+		if response.Usage.CacheCreation.Ephemeral5mInputTokens > 0 || response.Usage.CacheCreation.Ephemeral1hInputTokens > 0 {
+			promptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{
+				CachedWriteTokens5m: response.Usage.CacheCreation.Ephemeral5mInputTokens,
+				CachedWriteTokens1h: response.Usage.CacheCreation.Ephemeral1hInputTokens,
+			}
+		}
 		bifrostResponse.Usage = &schemas.BifrostLLMUsage{
-			PromptTokens: response.Usage.InputTokens + response.Usage.CacheReadInputTokens + response.Usage.CacheCreationInputTokens,
-			PromptTokensDetails: &schemas.ChatPromptTokensDetails{
-				CachedReadTokens:  response.Usage.CacheReadInputTokens,
-				CachedWriteTokens: response.Usage.CacheCreationInputTokens,
-			},
-			CompletionTokens: response.Usage.OutputTokens,
+			PromptTokens:        response.Usage.InputTokens + response.Usage.CacheReadInputTokens + response.Usage.CacheCreationInputTokens,
+			PromptTokensDetails: promptTokensDetails,
+			CompletionTokens:    response.Usage.OutputTokens,
 		}
 		bifrostResponse.Usage.TotalTokens = bifrostResponse.Usage.PromptTokens + bifrostResponse.Usage.CompletionTokens
 		// Forward service tier from usage to response
@@ -916,6 +923,12 @@ func ToAnthropicChatResponse(bifrostResp *schemas.BifrostChatResponse) *Anthropi
 		if bifrostResp.Usage.PromptTokensDetails != nil && bifrostResp.Usage.PromptTokensDetails.CachedWriteTokens > 0 {
 			anthropicResp.Usage.CacheCreationInputTokens = bifrostResp.Usage.PromptTokensDetails.CachedWriteTokens
 			anthropicResp.Usage.InputTokens = anthropicResp.Usage.InputTokens - bifrostResp.Usage.PromptTokensDetails.CachedWriteTokens
+		}
+		if bifrostResp.Usage.PromptTokensDetails != nil && bifrostResp.Usage.PromptTokensDetails.CachedWriteTokenDetails != nil {
+			anthropicResp.Usage.CacheCreation = AnthropicUsageCacheCreation{
+				Ephemeral5mInputTokens: bifrostResp.Usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m,
+				Ephemeral1hInputTokens: bifrostResp.Usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h,
+			}
 		}
 		// Forward service tier
 		if bifrostResp.ServiceTier != nil {

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -280,10 +280,17 @@ func (chunk *AnthropicStreamEvent) ToBifrostResponsesStream(ctx context.Context,
 						TotalTokens:  chunk.Message.Usage.InputTokens + chunk.Message.Usage.OutputTokens,
 					}
 					if chunk.Message.Usage.CacheReadInputTokens > 0 || chunk.Message.Usage.CacheCreationInputTokens > 0 {
-						response.Usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{
+						inputTokensDetails := &schemas.ResponsesResponseInputTokens{
 							CachedReadTokens:  chunk.Message.Usage.CacheReadInputTokens,
 							CachedWriteTokens: chunk.Message.Usage.CacheCreationInputTokens,
 						}
+						if chunk.Message.Usage.CacheCreation.Ephemeral5mInputTokens > 0 || chunk.Message.Usage.CacheCreation.Ephemeral1hInputTokens > 0 {
+							inputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{
+								CachedWriteTokens5m: chunk.Message.Usage.CacheCreation.Ephemeral5mInputTokens,
+								CachedWriteTokens1h: chunk.Message.Usage.CacheCreation.Ephemeral1hInputTokens,
+							}
+						}
+						response.Usage.InputTokensDetails = inputTokensDetails
 						// Bifrost convention: InputTokens includes cached tokens
 						response.Usage.InputTokens += chunk.Message.Usage.CacheReadInputTokens + chunk.Message.Usage.CacheCreationInputTokens
 						response.Usage.TotalTokens += chunk.Message.Usage.CacheReadInputTokens + chunk.Message.Usage.CacheCreationInputTokens
@@ -2615,6 +2622,12 @@ func ConvertAnthropicUsageToBifrostUsage(anthropicUsage *AnthropicUsage) *schema
 			bifrostUsage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
 		}
 		bifrostUsage.InputTokensDetails.CachedWriteTokens = anthropicUsage.CacheCreationInputTokens
+		if anthropicUsage.CacheCreation.Ephemeral5mInputTokens > 0 || anthropicUsage.CacheCreation.Ephemeral1hInputTokens > 0 {
+			bifrostUsage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{
+				CachedWriteTokens5m: anthropicUsage.CacheCreation.Ephemeral5mInputTokens,
+				CachedWriteTokens1h: anthropicUsage.CacheCreation.Ephemeral1hInputTokens,
+			}
+		}
 		bifrostUsage.InputTokens = bifrostUsage.InputTokens + anthropicUsage.CacheCreationInputTokens
 		bifrostUsage.TotalTokens = bifrostUsage.TotalTokens + anthropicUsage.CacheCreationInputTokens
 	}
@@ -2662,10 +2675,11 @@ func ConvertBifrostUsageToAnthropicUsage(bifrostUsage *schemas.ResponsesResponse
 		if bifrostUsage.InputTokensDetails.CachedWriteTokens > 0 {
 			anthropicUsage.CacheCreationInputTokens = bifrostUsage.InputTokensDetails.CachedWriteTokens
 			anthropicUsage.InputTokens = anthropicUsage.InputTokens - bifrostUsage.InputTokensDetails.CachedWriteTokens
-			// Populate the cache_creation breakdown — default to ephemeral (5m) since
-			// the Bifrost internal format doesn't distinguish TTL variants.
-			anthropicUsage.CacheCreation = AnthropicUsageCacheCreation{
-				Ephemeral5mInputTokens: bifrostUsage.InputTokensDetails.CachedWriteTokens,
+			if bifrostUsage.InputTokensDetails.CachedWriteTokenDetails != nil {
+				anthropicUsage.CacheCreation = AnthropicUsageCacheCreation{
+					Ephemeral5mInputTokens: bifrostUsage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m,
+					Ephemeral1hInputTokens: bifrostUsage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h,
+				}
 			}
 		}
 	}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -1270,6 +1270,19 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 						if streamEvent.Usage.CacheWriteInputTokens > usage.PromptTokensDetails.CachedWriteTokens {
 							usage.PromptTokensDetails.CachedWriteTokens = streamEvent.Usage.CacheWriteInputTokens
 						}
+						if streamEvent.Usage.CacheDetails != nil {
+							if usage.PromptTokensDetails.CachedWriteTokenDetails == nil {
+								usage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+							}
+							for _, cacheDetail := range *streamEvent.Usage.CacheDetails {
+								if cacheDetail.TTL == BedrockCacheWriteTTL5m {
+									usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = cacheDetail.InputTokens
+								}
+								if cacheDetail.TTL == BedrockCacheWriteTTL1h {
+									usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = cacheDetail.InputTokens
+								}
+							}
+						}
 					}
 				}
 
@@ -1642,6 +1655,19 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 						}
 						if streamEvent.Usage.CacheWriteInputTokens > usage.InputTokensDetails.CachedWriteTokens {
 							usage.InputTokensDetails.CachedWriteTokens = streamEvent.Usage.CacheWriteInputTokens
+						}
+						if streamEvent.Usage.CacheDetails != nil {
+							if usage.InputTokensDetails.CachedWriteTokenDetails == nil {
+								usage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+							}
+							for _, cacheDetail := range *streamEvent.Usage.CacheDetails {
+								if cacheDetail.TTL == BedrockCacheWriteTTL5m {
+									usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = cacheDetail.InputTokens
+								}
+								if cacheDetail.TTL == BedrockCacheWriteTTL1h {
+									usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = cacheDetail.InputTokens
+								}
+							}
 						}
 					}
 				}

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -234,20 +234,32 @@ func (response *BedrockConverseResponse) ToBifrostChatResponse(ctx context.Conte
 				usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{}
 			}
 			usage.PromptTokensDetails.CachedWriteTokens = response.Usage.CacheWriteInputTokens
+			if response.Usage.CacheDetails != nil {
+				if usage.PromptTokensDetails.CachedWriteTokenDetails == nil {
+					usage.PromptTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+				}
+				for _, cacheDetail := range *response.Usage.CacheDetails {
+					if cacheDetail.TTL == BedrockCacheWriteTTL5m {
+						usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = cacheDetail.InputTokens
+					}
+					if cacheDetail.TTL == BedrockCacheWriteTTL1h {
+						usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = cacheDetail.InputTokens
+					}
+				}
+			}
 			usage.PromptTokens = usage.PromptTokens + response.Usage.CacheWriteInputTokens
 		}
 	}
 
 	// Create the final Bifrost response
 	bifrostResponse := &schemas.BifrostChatResponse{
-		ID:      uuid.New().String(),
-		Model:   model,
-		Object:  "chat.completion",
-		Choices: choices,
-		Usage:   usage,
-		Created: int(time.Now().Unix()),
-		ExtraFields: schemas.BifrostResponseExtraFields{
-		},
+		ID:          uuid.New().String(),
+		Model:       model,
+		Object:      "chat.completion",
+		Choices:     choices,
+		Usage:       usage,
+		Created:     int(time.Now().Unix()),
+		ExtraFields: schemas.BifrostResponseExtraFields{},
 	}
 
 	if response.ServiceTier != nil && response.ServiceTier.Type != "" {

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2027,6 +2027,19 @@ func (response *BedrockConverseResponse) ToBifrostResponsesResponse(ctx *schemas
 				bifrostResp.Usage.InputTokensDetails = &schemas.ResponsesResponseInputTokens{}
 			}
 			bifrostResp.Usage.InputTokensDetails.CachedWriteTokens = response.Usage.CacheWriteInputTokens
+			if response.Usage.CacheDetails != nil {
+				if bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails == nil {
+					bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails = &schemas.ChatCachedWriteTokenDetails{}
+				}
+				for _, cacheDetail := range *response.Usage.CacheDetails {
+					if cacheDetail.TTL == BedrockCacheWriteTTL5m {
+						bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m = cacheDetail.InputTokens
+					}
+					if cacheDetail.TTL == BedrockCacheWriteTTL1h {
+						bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h = cacheDetail.InputTokens
+					}
+				}
+			}
 			bifrostResp.Usage.InputTokens = bifrostResp.Usage.InputTokens + response.Usage.CacheWriteInputTokens
 		}
 	}
@@ -2102,6 +2115,22 @@ func ToBedrockConverseResponse(bifrostResp *schemas.BifrostResponsesResponse) (*
 			}
 			if bifrostResp.Usage.InputTokensDetails.CachedWriteTokens > 0 {
 				bedrockResp.Usage.CacheWriteInputTokens = bifrostResp.Usage.InputTokensDetails.CachedWriteTokens
+				if bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails != nil {
+					var cacheDetails []BedrockCacheWriteDetails
+					if bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m > 0 {
+						cacheDetails = append(cacheDetails, BedrockCacheWriteDetails{
+							InputTokens: bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens5m,
+							TTL:         BedrockCacheWriteTTL5m,
+						})
+					}
+					if bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h > 0 {
+						cacheDetails = append(cacheDetails, BedrockCacheWriteDetails{
+							InputTokens: bifrostResp.Usage.InputTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h,
+							TTL:         BedrockCacheWriteTTL1h,
+						})
+					}
+					bedrockResp.Usage.CacheDetails = &cacheDetails
+				}
 				bedrockResp.Usage.InputTokens = bedrockResp.Usage.InputTokens - bifrostResp.Usage.InputTokensDetails.CachedWriteTokens
 			}
 		}

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -397,8 +397,21 @@ type BedrockTokenUsage struct {
 	OutputTokens int `json:"outputTokens"` // Number of output tokens
 	TotalTokens  int `json:"totalTokens"`  // Total tokens (input + output + cached tokens)
 	// Number of cached input tokens read from the cache; excluded from inputTokens.
-	CacheReadInputTokens  int `json:"cacheReadInputTokens"`
-	CacheWriteInputTokens int `json:"cacheWriteInputTokens"` // Number of cached tokens written
+	CacheReadInputTokens  int                         `json:"cacheReadInputTokens"`
+	CacheWriteInputTokens int                         `json:"cacheWriteInputTokens"`  // Number of cached tokens written
+	CacheDetails          *[]BedrockCacheWriteDetails `json:"cacheDetails,omitempty"` // Cache details
+}
+
+type BedrockCacheWriteTTL string
+
+const (
+	BedrockCacheWriteTTL5m BedrockCacheWriteTTL = "5m"
+	BedrockCacheWriteTTL1h BedrockCacheWriteTTL = "1h"
+)
+
+type BedrockCacheWriteDetails struct {
+	InputTokens int                  `json:"inputTokens"` // Number of input tokens written to the cache
+	TTL         BedrockCacheWriteTTL `json:"ttl"`         // Time to live for the cache
 }
 
 // BedrockConverseMetrics represents response metrics

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -270,122 +270,6 @@ func (provider *MistralProvider) Speech(ctx *schemas.BifrostContext, key schemas
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechRequest, provider.GetProviderKey())
 }
 
-// Rerank is not supported by the Mistral provider.
-func (provider *MistralProvider) Rerank(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostRerankRequest) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
-	return nil, providerUtils.NewUnsupportedOperationError(schemas.RerankRequest, provider.GetProviderKey())
-}
-
-// OCR performs an OCR request to the Mistral API.
-// It sends a JSON request to Mistral's OCR endpoint and returns the extracted content.
-func (provider *MistralProvider) OCR(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostOCRRequest) (*schemas.BifrostOCRResponse, *schemas.BifrostError) {
-	// Convert Bifrost request to Mistral format
-	mistralReq := ToMistralOCRRequest(request)
-	if mistralReq == nil {
-		return nil, providerUtils.NewBifrostOperationError("ocr request input is not provided", nil)
-	}
-
-	// Marshal request body
-	requestBody, err := sonic.Marshal(mistralReq)
-	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-	}
-
-	// Merge extra params into JSON payload
-	if len(mistralReq.ExtraParams) > 0 {
-		requestBody, err = providerUtils.MergeExtraParamsIntoJSON(requestBody, mistralReq.ExtraParams)
-		if err != nil {
-			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
-		}
-	}
-
-	// Create HTTP request
-	req := fasthttp.AcquireRequest()
-	resp := fasthttp.AcquireResponse()
-	defer fasthttp.ReleaseRequest(req)
-	defer fasthttp.ReleaseResponse(resp)
-
-	// Set extra headers from network config
-	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/ocr"))
-	req.Header.SetMethod(http.MethodPost)
-	req.Header.SetContentType("application/json")
-	if key.Value.GetValue() != "" {
-		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
-	}
-
-	req.SetBody(requestBody)
-
-	// Set raw request if enabled
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		request.RawRequestBody = requestBody
-	}
-
-	// Make request
-	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
-	defer wait()
-	if bifrostErr != nil {
-		return nil, bifrostErr
-	}
-
-	// Handle error response
-	if resp.StatusCode() != fasthttp.StatusOK {
-		return nil, ParseMistralError(resp)
-	}
-
-	responseBody, err := providerUtils.CheckAndDecodeBody(resp)
-	if err != nil {
-		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
-	}
-
-	// Check for empty response
-	trimmed := strings.TrimSpace(string(responseBody))
-	if len(trimmed) == 0 {
-		return nil, &schemas.BifrostError{
-			IsBifrostError: true,
-			Error: &schemas.ErrorField{
-				Message: schemas.ErrProviderResponseEmpty,
-			},
-		}
-	}
-
-	copiedResponseBody := append([]byte(nil), responseBody...)
-
-	// Parse Mistral's OCR response
-	var mistralResponse MistralOCRResponse
-	if err := sonic.Unmarshal(copiedResponseBody, &mistralResponse); err != nil {
-		if providerUtils.IsHTMLResponse(resp, copiedResponseBody) {
-			return nil, &schemas.BifrostError{
-				IsBifrostError: false,
-				Error: &schemas.ErrorField{
-					Message: schemas.ErrProviderResponseHTML,
-					Error:   errors.New(string(copiedResponseBody)),
-				},
-			}
-		}
-		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err)
-	}
-
-	// Convert to Bifrost format
-	response := mistralResponse.ToBifrostOCRResponse()
-	if response == nil {
-		return nil, providerUtils.NewBifrostOperationError("failed to convert ocr response", nil)
-	}
-
-	// Set extra fields
-	response.ExtraFields.Latency = latency.Milliseconds()
-
-	// Set raw response if enabled
-	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
-		var rawResponse interface{}
-		if err := sonic.Unmarshal(copiedResponseBody, &rawResponse); err == nil {
-			response.ExtraFields.RawResponse = rawResponse
-		}
-	}
-
-	return response, nil
-}
-
 // SpeechStream is not supported by the Mistral provider.
 func (provider *MistralProvider) SpeechStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostSpeechRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	return nil, providerUtils.NewUnsupportedOperationError(schemas.SpeechStreamRequest, provider.GetProviderKey())
@@ -638,7 +522,7 @@ func (provider *MistralProvider) TranscriptionStream(ctx *schemas.BifrostContext
 			}
 
 			chunkIndex++
-			provider.processTranscriptionStreamEvent(ctx, postHookRunner, currentEvent, currentData, request.Model, providerName, chunkIndex, startTime, &lastChunkTime, responseChan, postHookSpanFinalizer)
+			provider.processTranscriptionStreamEvent(ctx, postHookRunner, currentEvent, currentData, chunkIndex, startTime, &lastChunkTime, responseChan, postHookSpanFinalizer)
 			// Break on terminal stream indicator (covers both done events and error events
 			// that processTranscriptionStreamEvent signals via context).
 			if ended, _ := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator).(bool); ended {
@@ -656,8 +540,6 @@ func (provider *MistralProvider) processTranscriptionStreamEvent(
 	postHookRunner schemas.PostHookRunner,
 	eventType string,
 	jsonData string,
-	model string,
-	providerName schemas.ModelProvider,
 	chunkIndex int,
 	startTime time.Time,
 	lastChunkTime *time.Time,
@@ -721,6 +603,122 @@ func (provider *MistralProvider) processTranscriptionStreamEvent(
 	}
 
 	providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, nil, nil, response, nil), responseChan, postHookSpanFinalizer)
+}
+
+// Rerank is not supported by the Mistral provider.
+func (provider *MistralProvider) Rerank(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostRerankRequest) (*schemas.BifrostRerankResponse, *schemas.BifrostError) {
+	return nil, providerUtils.NewUnsupportedOperationError(schemas.RerankRequest, provider.GetProviderKey())
+}
+
+// OCR performs an OCR request to the Mistral API.
+// It sends a JSON request to Mistral's OCR endpoint and returns the extracted content.
+func (provider *MistralProvider) OCR(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostOCRRequest) (*schemas.BifrostOCRResponse, *schemas.BifrostError) {
+	// Convert Bifrost request to Mistral format
+	mistralReq := ToMistralOCRRequest(request)
+	if mistralReq == nil {
+		return nil, providerUtils.NewBifrostOperationError("ocr request input is not provided", nil)
+	}
+
+	// Marshal request body
+	requestBody, err := sonic.Marshal(mistralReq)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+	}
+
+	// Merge extra params into JSON payload
+	if len(mistralReq.ExtraParams) > 0 {
+		requestBody, err = providerUtils.MergeExtraParamsIntoJSON(requestBody, mistralReq.ExtraParams)
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
+		}
+	}
+
+	// Create HTTP request
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	// Set extra headers from network config
+	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
+
+	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/ocr"))
+	req.Header.SetMethod(http.MethodPost)
+	req.Header.SetContentType("application/json")
+	if key.Value.GetValue() != "" {
+		req.Header.Set("Authorization", "Bearer "+key.Value.GetValue())
+	}
+
+	req.SetBody(requestBody)
+
+	// Set raw request if enabled
+	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
+		request.RawRequestBody = requestBody
+	}
+
+	// Make request
+	latency, bifrostErr, wait := providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+	defer wait()
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	// Handle error response
+	if resp.StatusCode() != fasthttp.StatusOK {
+		return nil, ParseMistralError(resp)
+	}
+
+	responseBody, err := providerUtils.CheckAndDecodeBody(resp)
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, err)
+	}
+
+	// Check for empty response
+	trimmed := strings.TrimSpace(string(responseBody))
+	if len(trimmed) == 0 {
+		return nil, &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: &schemas.ErrorField{
+				Message: schemas.ErrProviderResponseEmpty,
+			},
+		}
+	}
+
+	copiedResponseBody := append([]byte(nil), responseBody...)
+
+	// Parse Mistral's OCR response
+	var mistralResponse MistralOCRResponse
+	if err := sonic.Unmarshal(copiedResponseBody, &mistralResponse); err != nil {
+		if providerUtils.IsHTMLResponse(resp, copiedResponseBody) {
+			return nil, &schemas.BifrostError{
+				IsBifrostError: false,
+				Error: &schemas.ErrorField{
+					Message: schemas.ErrProviderResponseHTML,
+					Error:   errors.New(string(copiedResponseBody)),
+				},
+			}
+		}
+		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err)
+	}
+
+	// Convert to Bifrost format
+	response := mistralResponse.ToBifrostOCRResponse()
+	if response == nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to convert ocr response", nil)
+	}
+
+	// Set extra fields
+	response.ExtraFields.Latency = latency.Milliseconds()
+
+	// Set raw response if enabled
+	if providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse) {
+		var rawResponse interface{}
+		if err := sonic.Unmarshal(copiedResponseBody, &rawResponse); err == nil {
+			response.ExtraFields.RawResponse = rawResponse
+		}
+	}
+
+	return response, nil
 }
 
 // BatchCreate is not supported by Mistral provider.

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1503,19 +1503,26 @@ type ChatPromptTokensDetails struct {
 	ImageTokens int `json:"image_tokens,omitempty"`
 
 	// For Providers which don't separate between cache creation and cache read tokens (like Openai, Gemini, etc), this is the total number of cached tokens read.
-	CachedReadTokens  int `json:"cached_read_tokens,omitempty"`
-	CachedWriteTokens int `json:"cached_write_tokens,omitempty"`
+	CachedReadTokens        int                          `json:"cached_read_tokens,omitempty"`
+	CachedWriteTokens       int                          `json:"cached_write_tokens,omitempty"`
+	CachedWriteTokenDetails *ChatCachedWriteTokenDetails `json:"cached_write_token_details,omitempty"`
+}
+
+type ChatCachedWriteTokenDetails struct {
+	CachedWriteTokens5m int `json:"cached_write_tokens_5m"`
+	CachedWriteTokens1h int `json:"cached_write_tokens_1h"`
 }
 
 // UnmarshalJSON maps OpenAI's cached_tokens into CachedReadTokens for compatibility.
 func (d *ChatPromptTokensDetails) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		TextTokens        int  `json:"text_tokens"`
-		AudioTokens       int  `json:"audio_tokens"`
-		ImageTokens       int  `json:"image_tokens"`
-		CachedReadTokens  int  `json:"cached_read_tokens"`
-		CachedWriteTokens int  `json:"cached_write_tokens"`
-		CachedTokens      *int `json:"cached_tokens"`
+		TextTokens              int                          `json:"text_tokens"`
+		AudioTokens             int                          `json:"audio_tokens"`
+		ImageTokens             int                          `json:"image_tokens"`
+		CachedReadTokens        int                          `json:"cached_read_tokens"`
+		CachedWriteTokens       int                          `json:"cached_write_tokens"`
+		CachedWriteTokenDetails *ChatCachedWriteTokenDetails `json:"cached_write_token_details"`
+		CachedTokens            *int                         `json:"cached_tokens"`
 	}
 	if err := Unmarshal(data, &raw); err != nil {
 		return err
@@ -1525,6 +1532,7 @@ func (d *ChatPromptTokensDetails) UnmarshalJSON(data []byte) error {
 	d.ImageTokens = raw.ImageTokens
 	d.CachedReadTokens = raw.CachedReadTokens
 	d.CachedWriteTokens = raw.CachedWriteTokens
+	d.CachedWriteTokenDetails = raw.CachedWriteTokenDetails
 	// OpenAI spec providers send just cached_tokens, not separate read and write tokens and we handle them as read tokens in pricing calculations.
 	if raw.CachedTokens != nil && raw.CachedReadTokens == 0 && raw.CachedWriteTokens == 0 {
 		d.CachedReadTokens = *raw.CachedTokens
@@ -1535,20 +1543,22 @@ func (d *ChatPromptTokensDetails) UnmarshalJSON(data []byte) error {
 // MarshalJSON emits cached_tokens (read+write) alongside the individual fields for OpenAI spec compatibility.
 func (d ChatPromptTokensDetails) MarshalJSON() ([]byte, error) {
 	type raw struct {
-		TextTokens        int `json:"text_tokens,omitempty"`
-		AudioTokens       int `json:"audio_tokens,omitempty"`
-		ImageTokens       int `json:"image_tokens,omitempty"`
-		CachedReadTokens  int `json:"cached_read_tokens,omitempty"`
-		CachedWriteTokens int `json:"cached_write_tokens,omitempty"`
-		CachedTokens      int `json:"cached_tokens"`
+		TextTokens              int                          `json:"text_tokens,omitempty"`
+		AudioTokens             int                          `json:"audio_tokens,omitempty"`
+		ImageTokens             int                          `json:"image_tokens,omitempty"`
+		CachedReadTokens        int                          `json:"cached_read_tokens,omitempty"`
+		CachedWriteTokens       int                          `json:"cached_write_tokens,omitempty"`
+		CachedWriteTokenDetails *ChatCachedWriteTokenDetails `json:"cached_write_token_details,omitempty"`
+		CachedTokens            int                          `json:"cached_tokens"`
 	}
 	return MarshalSorted(raw{
-		TextTokens:        d.TextTokens,
-		AudioTokens:       d.AudioTokens,
-		ImageTokens:       d.ImageTokens,
-		CachedReadTokens:  d.CachedReadTokens,
-		CachedWriteTokens: d.CachedWriteTokens,
-		CachedTokens:      d.CachedReadTokens + d.CachedWriteTokens,
+		TextTokens:              d.TextTokens,
+		AudioTokens:             d.AudioTokens,
+		ImageTokens:             d.ImageTokens,
+		CachedReadTokens:        d.CachedReadTokens,
+		CachedWriteTokens:       d.CachedWriteTokens,
+		CachedWriteTokenDetails: d.CachedWriteTokenDetails,
+		CachedTokens:            d.CachedReadTokens + d.CachedWriteTokens,
 	})
 }
 

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -463,19 +463,21 @@ type ResponsesResponseInputTokens struct {
 	ImageTokens int `json:"image_tokens,omitempty"` // Tokens for image input
 
 	// For Providers which don't separate between cache creation and cache read tokens (like Openai, Gemini, etc), this is the total number of cached tokens read.
-	CachedReadTokens  int `json:"cached_read_tokens"`
-	CachedWriteTokens int `json:"cached_write_tokens"`
+	CachedReadTokens        int                          `json:"cached_read_tokens"`
+	CachedWriteTokens       int                          `json:"cached_write_tokens"`
+	CachedWriteTokenDetails *ChatCachedWriteTokenDetails `json:"cached_write_token_details,omitempty"`
 }
 
 // UnmarshalJSON maps OpenAI's cached_tokens into CachedReadTokens for compatibility.
 func (d *ResponsesResponseInputTokens) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		TextTokens        int  `json:"text_tokens"`
-		AudioTokens       int  `json:"audio_tokens"`
-		ImageTokens       int  `json:"image_tokens"`
-		CachedReadTokens  int  `json:"cached_read_tokens"`
-		CachedWriteTokens int  `json:"cached_write_tokens"`
-		CachedTokens      *int `json:"cached_tokens"`
+		TextTokens              int                          `json:"text_tokens"`
+		AudioTokens             int                          `json:"audio_tokens"`
+		ImageTokens             int                          `json:"image_tokens"`
+		CachedReadTokens        int                          `json:"cached_read_tokens"`
+		CachedWriteTokens       int                          `json:"cached_write_tokens"`
+		CachedWriteTokenDetails *ChatCachedWriteTokenDetails `json:"cached_write_token_details"`
+		CachedTokens            *int                         `json:"cached_tokens"`
 	}
 	if err := Unmarshal(data, &raw); err != nil {
 		return err
@@ -485,6 +487,7 @@ func (d *ResponsesResponseInputTokens) UnmarshalJSON(data []byte) error {
 	d.ImageTokens = raw.ImageTokens
 	d.CachedReadTokens = raw.CachedReadTokens
 	d.CachedWriteTokens = raw.CachedWriteTokens
+	d.CachedWriteTokenDetails = raw.CachedWriteTokenDetails
 	// OpenAI spec providers send just cached_tokens, not separate read and write tokens and we handle them as read tokens in pricing calculations.
 	if raw.CachedTokens != nil && raw.CachedReadTokens == 0 && raw.CachedWriteTokens == 0 {
 		d.CachedReadTokens = *raw.CachedTokens
@@ -495,20 +498,22 @@ func (d *ResponsesResponseInputTokens) UnmarshalJSON(data []byte) error {
 // MarshalJSON emits cached_tokens (read+write) alongside the individual fields for OpenAI spec compatibility.
 func (d ResponsesResponseInputTokens) MarshalJSON() ([]byte, error) {
 	type raw struct {
-		TextTokens        int `json:"text_tokens,omitempty"`
-		AudioTokens       int `json:"audio_tokens,omitempty"`
-		ImageTokens       int `json:"image_tokens,omitempty"`
-		CachedReadTokens  int `json:"cached_read_tokens"`
-		CachedWriteTokens int `json:"cached_write_tokens"`
-		CachedTokens      int `json:"cached_tokens"`
+		TextTokens              int                          `json:"text_tokens,omitempty"`
+		AudioTokens             int                          `json:"audio_tokens,omitempty"`
+		ImageTokens             int                          `json:"image_tokens,omitempty"`
+		CachedReadTokens        int                          `json:"cached_read_tokens"`
+		CachedWriteTokens       int                          `json:"cached_write_tokens"`
+		CachedWriteTokenDetails *ChatCachedWriteTokenDetails `json:"cached_write_token_details,omitempty"`
+		CachedTokens            int                          `json:"cached_tokens"`
 	}
 	return MarshalSorted(raw{
-		TextTokens:        d.TextTokens,
-		AudioTokens:       d.AudioTokens,
-		ImageTokens:       d.ImageTokens,
-		CachedReadTokens:  d.CachedReadTokens,
-		CachedWriteTokens: d.CachedWriteTokens,
-		CachedTokens:      d.CachedReadTokens + d.CachedWriteTokens,
+		TextTokens:              d.TextTokens,
+		AudioTokens:             d.AudioTokens,
+		ImageTokens:             d.ImageTokens,
+		CachedReadTokens:        d.CachedReadTokens,
+		CachedWriteTokens:       d.CachedWriteTokens,
+		CachedWriteTokenDetails: d.CachedWriteTokenDetails,
+		CachedTokens:            d.CachedReadTokens + d.CachedWriteTokens,
 	})
 }
 

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -54,6 +54,10 @@
       "description": "OpenAI Responses API compatible endpoints"
     },
     {
+      "name": "OCR",
+      "description": "Optical character recognition for documents and images"
+    },
+    {
       "name": "Rerank",
       "description": "Document reranking by relevance to a query"
     },
@@ -1511,6 +1515,72 @@
                       "$ref": "#/components/schemas/BifrostResponseExtraFields"
                     }
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/ocr": {
+      "post": {
+        "operationId": "performOCR",
+        "summary": "Perform OCR",
+        "description": "Extracts text and content from documents or images using optical character recognition.\nSupports PDF URLs, base64-encoded documents, and image URLs.\n",
+        "tags": [
+          "OCR"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OCRRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OCRResponse"
                 }
               }
             }
@@ -7852,6 +7922,270 @@
         "operationId": "getAsyncImageVariationJob",
         "summary": "Get async image variation job",
         "description": "Retrieves the status and result of an async image variation job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
+        "tags": [
+          "Async Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AsyncJobId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job completed (successfully or with failure)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Job is still pending or processing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found or expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/async/rerank": {
+      "post": {
+        "operationId": "createAsyncRerank",
+        "summary": "Create async rerank",
+        "description": "Submits a rerank request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\n",
+        "tags": [
+          "Async Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AsyncResultTTL"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RerankRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Job accepted for processing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/async/rerank/{job_id}": {
+      "get": {
+        "operationId": "getAsyncRerankJob",
+        "summary": "Get async rerank job",
+        "description": "Retrieves the status and result of an async rerank job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
+        "tags": [
+          "Async Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AsyncJobId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job completed (successfully or with failure)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Job is still pending or processing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Job not found or expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/async/ocr": {
+      "post": {
+        "operationId": "createAsyncOCR",
+        "summary": "Create async OCR job",
+        "description": "Submits an OCR request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\n",
+        "tags": [
+          "Async Jobs"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AsyncResultTTL"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OCRRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Job accepted for processing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AsyncJobResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "BasicAuth": []
+          },
+          {
+            "VirtualKeyAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
+    },
+    "/v1/async/ocr/{job_id}": {
+      "get": {
+        "operationId": "getAsyncOCRJob",
+        "summary": "Get async OCR job",
+        "description": "Retrieves the status and result of an async OCR job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
         "tags": [
           "Async Jobs"
         ],
@@ -46669,6 +47003,426 @@
           },
           "extra_fields": {
             "$ref": "#/components/schemas/BifrostResponseExtraFields"
+          }
+        }
+      },
+      "OCRRequest": {
+        "type": "object",
+        "required": [
+          "model",
+          "document"
+        ],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "Model in provider/model format",
+            "example": "mistral/mistral-ocr-latest"
+          },
+          "id": {
+            "type": "string",
+            "description": "Optional unique identifier for the request"
+          },
+          "document": {
+            "$ref": "#/components/schemas/OCRDocument"
+          },
+          "fallbacks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Fallback models in provider/model format"
+          },
+          "include_image_base64": {
+            "type": "boolean",
+            "description": "Whether to include base64-encoded images in the response"
+          },
+          "pages": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "description": "Specific page indices to process (0-based)"
+          },
+          "image_limit": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Maximum number of images to extract per page"
+          },
+          "image_min_size": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Minimum image size in pixels to extract"
+          },
+          "table_format": {
+            "type": "string",
+            "description": "Format for extracted tables (e.g., \"markdown\", \"html\")"
+          },
+          "extract_header": {
+            "type": "boolean",
+            "description": "Whether to extract page headers"
+          },
+          "extract_footer": {
+            "type": "boolean",
+            "description": "Whether to extract page footers"
+          },
+          "confidence_scores_granularity": {
+            "type": "string",
+            "enum": [
+              "page",
+              "block",
+              "word",
+              "document"
+            ],
+            "description": "Granularity of confidence scores to include in the response"
+          },
+          "bbox_annotation_format": {
+            "type": "object",
+            "description": "Format for bounding box annotations. Supports text, json_object, and json_schema modes.",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "text",
+                  "json_object",
+                  "json_schema"
+                ],
+                "description": "The format type"
+              },
+              "json_schema": {
+                "type": "object",
+                "description": "JSON schema definition (required when type is json_schema)",
+                "properties": {
+                  "schema": {
+                    "type": "object",
+                    "description": "The JSON schema"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the schema"
+                  },
+                  "strict": {
+                    "type": "boolean",
+                    "description": "Whether to enforce strict validation"
+                  }
+                }
+              }
+            },
+            "oneOf": [
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "text",
+                      "json_object"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "type",
+                  "json_schema"
+                ],
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "json_schema"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "document_annotation_format": {
+            "type": "object",
+            "description": "Format for document-level annotations. Supports text, json_object, and json_schema modes.",
+            "required": [
+              "type"
+            ],
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "text",
+                  "json_object",
+                  "json_schema"
+                ],
+                "description": "The format type"
+              },
+              "json_schema": {
+                "type": "object",
+                "description": "JSON schema definition (required when type is json_schema)",
+                "properties": {
+                  "schema": {
+                    "type": "object",
+                    "description": "The JSON schema"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Name of the schema"
+                  },
+                  "strict": {
+                    "type": "boolean",
+                    "description": "Whether to enforce strict validation"
+                  }
+                }
+              }
+            },
+            "oneOf": [
+              {
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "text",
+                      "json_object"
+                    ]
+                  }
+                }
+              },
+              {
+                "required": [
+                  "type",
+                  "json_schema"
+                ],
+                "properties": {
+                  "type": {
+                    "enum": [
+                      "json_schema"
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "document_annotation_prompt": {
+            "type": "string",
+            "description": "Custom prompt for document annotation"
+          }
+        }
+      },
+      "OCRDocument": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "document_url",
+              "image_url"
+            ],
+            "description": "Type of document input:\n- `document_url`: A PDF URL or base64 data URL\n- `image_url`: An image URL\n"
+          },
+          "document_url": {
+            "type": "string",
+            "description": "URL or base64 data URL of the document (required when type is document_url)"
+          },
+          "image_url": {
+            "type": "string",
+            "description": "URL of the image to process (required when type is image_url)"
+          }
+        },
+        "oneOf": [
+          {
+            "required": [
+              "type",
+              "document_url"
+            ],
+            "properties": {
+              "type": {
+                "enum": [
+                  "document_url"
+                ]
+              }
+            }
+          },
+          {
+            "required": [
+              "type",
+              "image_url"
+            ],
+            "properties": {
+              "type": {
+                "enum": [
+                  "image_url"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "OCRResponse": {
+        "type": "object",
+        "required": [
+          "model",
+          "pages"
+        ],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "Model used to perform OCR"
+          },
+          "pages": {
+            "type": "array",
+            "description": "Processed pages with extracted content",
+            "items": {
+              "$ref": "#/components/schemas/OCRPage"
+            }
+          },
+          "usage_info": {
+            "$ref": "#/components/schemas/OCRUsageInfo"
+          },
+          "document_annotation": {
+            "type": "string",
+            "description": "Document-level annotation if requested"
+          },
+          "extra_fields": {
+            "$ref": "#/components/schemas/BifrostResponseExtraFields"
+          }
+        }
+      },
+      "OCRPage": {
+        "type": "object",
+        "required": [
+          "index",
+          "markdown"
+        ],
+        "properties": {
+          "index": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Zero-based page index"
+          },
+          "markdown": {
+            "type": "string",
+            "description": "Extracted text content in Markdown format"
+          },
+          "images": {
+            "type": "array",
+            "description": "Images extracted from this page",
+            "items": {
+              "$ref": "#/components/schemas/OCRPageImage"
+            }
+          },
+          "dimensions": {
+            "$ref": "#/components/schemas/OCRPageDimensions"
+          },
+          "tables": {
+            "type": "array",
+            "description": "Tables extracted from this page (present when table_format is set)",
+            "nullable": true,
+            "items": {
+              "type": "object"
+            }
+          },
+          "header": {
+            "type": "string",
+            "nullable": true,
+            "description": "Header content extracted from this page (present when extract_header is true)"
+          },
+          "footer": {
+            "type": "string",
+            "nullable": true,
+            "description": "Footer content extracted from this page (present when extract_footer is true)"
+          },
+          "confidence_scores": {
+            "type": "object",
+            "nullable": true,
+            "description": "Confidence scores for this page (present when confidence_scores_granularity is set)",
+            "properties": {
+              "average_page_confidence_score": {
+                "type": "number",
+                "description": "Average confidence score for the page"
+              },
+              "minimum_page_confidence_score": {
+                "type": "number",
+                "description": "Minimum confidence score for the page"
+              },
+              "word_confidence_scores": {
+                "type": "array",
+                "description": "Per-word confidence scores",
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        }
+      },
+      "OCRPageImage": {
+        "type": "object",
+        "required": [
+          "id",
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the image within the page"
+          },
+          "top_left_x": {
+            "type": "number",
+            "description": "X coordinate of the top-left corner of the image bounding box"
+          },
+          "top_left_y": {
+            "type": "number",
+            "description": "Y coordinate of the top-left corner of the image bounding box"
+          },
+          "bottom_right_x": {
+            "type": "number",
+            "description": "X coordinate of the bottom-right corner of the image bounding box"
+          },
+          "bottom_right_y": {
+            "type": "number",
+            "description": "Y coordinate of the bottom-right corner of the image bounding box"
+          },
+          "image_base64": {
+            "type": "string",
+            "description": "Base64-encoded image data (present when include_image_base64 is true)"
+          }
+        }
+      },
+      "OCRPageDimensions": {
+        "type": "object",
+        "required": [
+          "dpi",
+          "height",
+          "width"
+        ],
+        "properties": {
+          "dpi": {
+            "type": "integer",
+            "description": "Dots per inch of the page"
+          },
+          "height": {
+            "type": "integer",
+            "description": "Page height in pixels"
+          },
+          "width": {
+            "type": "integer",
+            "description": "Page width in pixels"
+          }
+        }
+      },
+      "OCRUsageInfo": {
+        "type": "object",
+        "required": [
+          "pages_processed",
+          "doc_size_bytes"
+        ],
+        "properties": {
+          "pages_processed": {
+            "type": "integer",
+            "description": "Number of pages processed"
+          },
+          "doc_size_bytes": {
+            "type": "integer",
+            "description": "Size of the processed document in bytes"
           }
         }
       },

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -78,6 +78,8 @@ tags:
     description: Text completion generation
   - name: Responses
     description: OpenAI Responses API compatible endpoints
+  - name: OCR
+    description: Optical character recognition for documents and images
   - name: Rerank
     description: Document reranking by relevance to a query
   - name: Embeddings
@@ -147,6 +149,8 @@ paths:
     $ref: './paths/inference/text-completions.yaml#/text-completions'
   /v1/responses:
     $ref: './paths/inference/responses.yaml#/responses'
+  /v1/ocr:
+    $ref: './paths/inference/ocr.yaml#/ocr'
   /v1/rerank:
     $ref: './paths/inference/rerank.yaml#/rerank'
   /v1/embeddings:
@@ -233,6 +237,14 @@ paths:
     $ref: './paths/inference/async.yaml#/async-image-edit-job'
   /v1/async/images/variations/{job_id}:
     $ref: './paths/inference/async.yaml#/async-image-variation-job'
+  /v1/async/rerank:
+    $ref: './paths/inference/async.yaml#/async-rerank'
+  /v1/async/rerank/{job_id}:
+    $ref: './paths/inference/async.yaml#/async-rerank-job'
+  /v1/async/ocr:
+    $ref: './paths/inference/ocr.yaml#/async-ocr'
+  /v1/async/ocr/{job_id}:
+    $ref: './paths/inference/ocr.yaml#/async-ocr-job'
 
   # ==================== OpenAI Integration ====================
   # Chat Completions
@@ -957,6 +969,22 @@ components:
       $ref: './schemas/inference/files.yaml#/FileUploadResponse'
     FileListResponse:
       $ref: './schemas/inference/files.yaml#/FileListResponse'
+
+    # ==================== OCR ====================
+    OCRRequest:
+      $ref: './schemas/inference/ocr.yaml#/OCRRequest'
+    OCRDocument:
+      $ref: './schemas/inference/ocr.yaml#/OCRDocument'
+    OCRResponse:
+      $ref: './schemas/inference/ocr.yaml#/OCRResponse'
+    OCRPage:
+      $ref: './schemas/inference/ocr.yaml#/OCRPage'
+    OCRPageImage:
+      $ref: './schemas/inference/ocr.yaml#/OCRPageImage'
+    OCRPageDimensions:
+      $ref: './schemas/inference/ocr.yaml#/OCRPageDimensions'
+    OCRUsageInfo:
+      $ref: './schemas/inference/ocr.yaml#/OCRUsageInfo'
 
     # ==================== OpenAI Integration ====================
     OpenAIChatRequest:

--- a/docs/openapi/paths/inference/async.yaml
+++ b/docs/openapi/paths/inference/async.yaml
@@ -636,13 +636,82 @@ async-image-variation-job:
             schema:
               $ref: '../../schemas/inference/common.yaml#/BifrostError'
 
-# --- Shared parameters ---
-
     security:
     - BearerAuth: []
     - BasicAuth: []
     - VirtualKeyAuth: []
     - ApiKeyAuth: []
+async-rerank:
+  post:
+    operationId: createAsyncRerank
+    summary: Create async rerank
+    description: |
+      Submits a rerank request for asynchronous execution. Returns a job ID immediately
+      with HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.
+    tags:
+    - Async Jobs
+    parameters:
+    - $ref: '#/components/parameters/AsyncResultTTL'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/inference/rerank.yaml#/RerankRequest'
+    responses:
+      '202':
+        description: Job accepted for processing
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/async.yaml#/AsyncJobResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+async-rerank-job:
+  get:
+    operationId: getAsyncRerankJob
+    summary: Get async rerank job
+    description: |
+      Retrieves the status and result of an async rerank job.
+      Returns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.
+    tags:
+    - Async Jobs
+    parameters:
+    - $ref: '#/components/parameters/AsyncJobId'
+    responses:
+      '200':
+        description: Job completed (successfully or with failure)
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/async.yaml#/AsyncJobResponse'
+      '202':
+        description: Job is still pending or processing
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/async.yaml#/AsyncJobResponse'
+      '404':
+        description: Job not found or expired
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+
+# --- Shared parameters ---
+
 components:
   parameters:
     AsyncJobId:

--- a/docs/openapi/paths/inference/ocr.yaml
+++ b/docs/openapi/paths/inference/ocr.yaml
@@ -1,0 +1,103 @@
+# OCR Endpoints
+
+ocr:
+  post:
+    operationId: performOCR
+    summary: Perform OCR
+    description: |
+      Extracts text and content from documents or images using optical character recognition.
+      Supports PDF URLs, base64-encoded documents, and image URLs.
+    tags:
+    - OCR
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/inference/ocr.yaml#/OCRRequest'
+    responses:
+      '200':
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/ocr.yaml#/OCRResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+
+async-ocr:
+  post:
+    operationId: createAsyncOCR
+    summary: Create async OCR job
+    description: |
+      Submits an OCR request for asynchronous execution. Returns a job ID immediately
+      with HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.
+    tags:
+    - Async Jobs
+    parameters:
+    - $ref: '../../openapi.yaml#/components/parameters/AsyncResultTTL'
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/inference/ocr.yaml#/OCRRequest'
+    responses:
+      '202':
+        description: Job accepted for processing
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/async.yaml#/AsyncJobResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []
+
+async-ocr-job:
+  get:
+    operationId: getAsyncOCRJob
+    summary: Get async OCR job
+    description: |
+      Retrieves the status and result of an async OCR job.
+      Returns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.
+    tags:
+    - Async Jobs
+    parameters:
+    - $ref: '../../openapi.yaml#/components/parameters/AsyncJobId'
+    responses:
+      '200':
+        description: Job completed (successfully or with failure)
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/async.yaml#/AsyncJobResponse'
+      '202':
+        description: Job is still pending or processing
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/async.yaml#/AsyncJobResponse'
+      '404':
+        description: Job not found or expired
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+    security:
+    - BearerAuth: []
+    - BasicAuth: []
+    - VirtualKeyAuth: []
+    - ApiKeyAuth: []

--- a/docs/openapi/schemas/inference/ocr.yaml
+++ b/docs/openapi/schemas/inference/ocr.yaml
@@ -1,0 +1,286 @@
+# OCR API schemas
+
+OCRRequest:
+  type: object
+  required:
+    - model
+    - document
+  properties:
+    model:
+      type: string
+      description: Model in provider/model format
+      example: mistral/mistral-ocr-latest
+    id:
+      type: string
+      description: Optional unique identifier for the request
+    document:
+      $ref: "#/OCRDocument"
+    fallbacks:
+      type: array
+      items:
+        type: string
+      description: Fallback models in provider/model format
+    include_image_base64:
+      type: boolean
+      description: Whether to include base64-encoded images in the response
+    pages:
+      type: array
+      items:
+        type: integer
+        minimum: 0
+      description: Specific page indices to process (0-based)
+    image_limit:
+      type: integer
+      minimum: 1
+      description: Maximum number of images to extract per page
+    image_min_size:
+      type: integer
+      minimum: 1
+      description: Minimum image size in pixels to extract
+    table_format:
+      type: string
+      description: Format for extracted tables (e.g., "markdown", "html")
+    extract_header:
+      type: boolean
+      description: Whether to extract page headers
+    extract_footer:
+      type: boolean
+      description: Whether to extract page footers
+    confidence_scores_granularity:
+      type: string
+      enum:
+        - page
+        - block
+        - word
+        - document
+      description: Granularity of confidence scores to include in the response
+    bbox_annotation_format:
+      type: object
+      description: "Format for bounding box annotations. Supports text, json_object, and json_schema modes."
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - text
+            - json_object
+            - json_schema
+          description: The format type
+        json_schema:
+          type: object
+          description: JSON schema definition (required when type is json_schema)
+          properties:
+            schema:
+              type: object
+              description: The JSON schema
+            name:
+              type: string
+              description: Name of the schema
+            strict:
+              type: boolean
+              description: Whether to enforce strict validation
+      oneOf:
+        - properties:
+            type:
+              enum: [text, json_object]
+        - required: [type, json_schema]
+          properties:
+            type:
+              enum: [json_schema]
+    document_annotation_format:
+      type: object
+      description: "Format for document-level annotations. Supports text, json_object, and json_schema modes."
+      required:
+        - type
+      properties:
+        type:
+          type: string
+          enum:
+            - text
+            - json_object
+            - json_schema
+          description: The format type
+        json_schema:
+          type: object
+          description: JSON schema definition (required when type is json_schema)
+          properties:
+            schema:
+              type: object
+              description: The JSON schema
+            name:
+              type: string
+              description: Name of the schema
+            strict:
+              type: boolean
+              description: Whether to enforce strict validation
+      oneOf:
+        - properties:
+            type:
+              enum: [text, json_object]
+        - required: [type, json_schema]
+          properties:
+            type:
+              enum: [json_schema]
+    document_annotation_prompt:
+      type: string
+      description: Custom prompt for document annotation
+
+OCRDocument:
+  type: object
+  properties:
+    type:
+      type: string
+      enum:
+        - document_url
+        - image_url
+      description: |
+        Type of document input:
+        - `document_url`: A PDF URL or base64 data URL
+        - `image_url`: An image URL
+    document_url:
+      type: string
+      description: URL or base64 data URL of the document (required when type is document_url)
+    image_url:
+      type: string
+      description: URL of the image to process (required when type is image_url)
+  oneOf:
+    - required: [type, document_url]
+      properties:
+        type:
+          enum: [document_url]
+    - required: [type, image_url]
+      properties:
+        type:
+          enum: [image_url]
+
+OCRResponse:
+  type: object
+  required:
+    - model
+    - pages
+  properties:
+    model:
+      type: string
+      description: Model used to perform OCR
+    pages:
+      type: array
+      description: Processed pages with extracted content
+      items:
+        $ref: "#/OCRPage"
+    usage_info:
+      $ref: "#/OCRUsageInfo"
+    document_annotation:
+      type: string
+      description: Document-level annotation if requested
+    extra_fields:
+      $ref: "./common.yaml#/BifrostResponseExtraFields"
+
+OCRPage:
+  type: object
+  required:
+    - index
+    - markdown
+  properties:
+    index:
+      type: integer
+      minimum: 0
+      description: Zero-based page index
+    markdown:
+      type: string
+      description: Extracted text content in Markdown format
+    images:
+      type: array
+      description: Images extracted from this page
+      items:
+        $ref: "#/OCRPageImage"
+    dimensions:
+      $ref: "#/OCRPageDimensions"
+    tables:
+      type: array
+      description: Tables extracted from this page (present when table_format is set)
+      nullable: true
+      items:
+        type: object
+    header:
+      type: string
+      nullable: true
+      description: Header content extracted from this page (present when extract_header is true)
+    footer:
+      type: string
+      nullable: true
+      description: Footer content extracted from this page (present when extract_footer is true)
+    confidence_scores:
+      type: object
+      nullable: true
+      description: Confidence scores for this page (present when confidence_scores_granularity is set)
+      properties:
+        average_page_confidence_score:
+          type: number
+          description: Average confidence score for the page
+        minimum_page_confidence_score:
+          type: number
+          description: Minimum confidence score for the page
+        word_confidence_scores:
+          type: array
+          description: Per-word confidence scores
+          items:
+            type: number
+
+OCRPageImage:
+  type: object
+  required:
+    - id
+    - top_left_x
+    - top_left_y
+    - bottom_right_x
+    - bottom_right_y
+  properties:
+    id:
+      type: string
+      description: Unique identifier for the image within the page
+    top_left_x:
+      type: number
+      description: X coordinate of the top-left corner of the image bounding box
+    top_left_y:
+      type: number
+      description: Y coordinate of the top-left corner of the image bounding box
+    bottom_right_x:
+      type: number
+      description: X coordinate of the bottom-right corner of the image bounding box
+    bottom_right_y:
+      type: number
+      description: Y coordinate of the bottom-right corner of the image bounding box
+    image_base64:
+      type: string
+      description: Base64-encoded image data (present when include_image_base64 is true)
+
+OCRPageDimensions:
+  type: object
+  required:
+    - dpi
+    - height
+    - width
+  properties:
+    dpi:
+      type: integer
+      description: Dots per inch of the page
+    height:
+      type: integer
+      description: Page height in pixels
+    width:
+      type: integer
+      description: Page width in pixels
+
+OCRUsageInfo:
+  type: object
+  required:
+    - pages_processed
+    - doc_size_bytes
+  properties:
+    pages_processed:
+      type: integer
+      description: Number of pages processed
+    doc_size_bytes:
+      type: integer
+      description: Size of the processed document in bytes

--- a/docs/providers/supported-providers/mistral.mdx
+++ b/docs/providers/supported-providers/mistral.mdx
@@ -1,35 +1,42 @@
 ---
 title: "Mistral"
-description: "Mistral API conversion guide - parameter mapping, message handling, tool support, transcription, and streaming behavior"
+description: "Mistral API conversion guide - parameter mapping, message handling, tool support, transcription, OCR, and streaming behavior"
 icon: "m"
 ---
 
 ## Overview
 
 Mistral is an **OpenAI-compatible provider** with custom compatibility handling for specific features. Bifrost converts requests to Mistral's expected format while supporting their unique API endpoints. Key characteristics:
+
 - **OpenAI-compatible format** - Chat and streaming endpoints
 - **Transcription API** - Native audio transcription support
+- **OCR API** - Native document and image OCR support
 - **Tool calling support** - Function definitions with string-based tool choice
 - **Streaming support** - Server-Sent Events for chat and transcription
 - **Parameter compatibility** - max_completion_tokens → max_tokens conversion
 
 ### Supported Operations
 
-| Operation | Non-Streaming | Streaming | Endpoint |
-|-----------|---------------|-----------|----------|
-| Chat Completions | ✅ | ✅ | `/v1/chat/completions` |
-| Responses API | ✅ | ✅ | `/v1/chat/completions` |
-| Transcriptions (STT) | ✅ | ✅ | `/v1/audio/transcriptions` |
-| Embeddings | ✅ | - | `/v1/embeddings` |
-| List Models | ✅ | - | `/v1/models` |
-| Image Generation | ❌ | ❌ | - |
-| Text Completions | ❌ | ❌ | - |
-| Speech (TTS) | ❌ | ❌ | - |
-| Files | ❌ | ❌ | - |
-| Batch | ❌ | ❌ | - |
+| Operation            | Non-Streaming | Streaming | Endpoint                   |
+| -------------------- | ------------- | --------- | -------------------------- |
+| Chat Completions     | ✅            | ✅        | `/v1/chat/completions`     |
+| Responses API        | ✅            | ✅        | `/v1/chat/completions`     |
+| Transcriptions (STT) | ✅            | ✅        | `/v1/audio/transcriptions` |
+| OCR                  | ✅            | -         | `/v1/ocr`                  |
+| Embeddings           | ✅            | -         | `/v1/embeddings`           |
+| List Models          | ✅            | -         | `/v1/models`               |
+| Image Generation     | ❌            | ❌        | -                          |
+| Text Completions     | ❌            | ❌        | -                          |
+| Speech (TTS)         | ❌            | ❌        | -                          |
+| Files                | ❌            | ❌        | -                          |
+| Batch                | ❌            | ❌        | -                          |
 
 <Note>
-**Unsupported Operations** (❌): Text Completions, Speech (TTS), Files, and Batch are not supported by the upstream Mistral API. Image Generation is not currently supported by Bifrost's Mistral integration (Mistral API supports image generation, but Bifrost has not yet implemented this feature). These return `UnsupportedOperationError`.
+  **Unsupported Operations** (❌): Text Completions, Speech (TTS), Files, and
+  Batch are not supported by the upstream Mistral API. Image Generation is not
+  currently supported by Bifrost's Mistral integration (Mistral API supports
+  image generation, but Bifrost has not yet implemented this feature). These
+  return `UnsupportedOperationError`.
 </Note>
 
 ---
@@ -42,20 +49,21 @@ Mistral supports most OpenAI chat completion parameters with some conversions. F
 
 ### Parameter Mapping & Conversions
 
-| Parameter | OpenAI | Mistral | Notes |
-|-----------|--------|---------|-------|
-| `max_completion_tokens` | ✅ | `max_tokens` | **Conversion required** |
-| `temperature` | ✅ | ✅ | Direct pass-through |
-| `top_p` | ✅ | ✅ | Direct pass-through |
-| `stop` | ✅ | ✅ | Stop sequences |
-| `tools` | ✅ | ✅ | Function definitions |
-| `tool_choice` | String only | String only | **Limitations apply** |
-| `user` | ✅ | ✅ | Max 64 characters |
-| `frequency_penalty`, `presence_penalty` | ✅ | ✅ | Direct pass-through |
+| Parameter                               | OpenAI      | Mistral      | Notes                   |
+| --------------------------------------- | ----------- | ------------ | ----------------------- |
+| `max_completion_tokens`                 | ✅          | `max_tokens` | **Conversion required** |
+| `temperature`                           | ✅          | ✅           | Direct pass-through     |
+| `top_p`                                 | ✅          | ✅           | Direct pass-through     |
+| `stop`                                  | ✅          | ✅           | Stop sequences          |
+| `tools`                                 | ✅          | ✅           | Function definitions    |
+| `tool_choice`                           | String only | String only  | **Limitations apply**   |
+| `user`                                  | ✅          | ✅           | Max 64 characters       |
+| `frequency_penalty`, `presence_penalty` | ✅          | ✅           | Direct pass-through     |
 
 ### Critical Conversions
 
 **max_completion_tokens → max_tokens:**
+
 ```json
 // Bifrost request
 {"max_completion_tokens": 4096}
@@ -66,6 +74,7 @@ Mistral supports most OpenAI chat completion parameters with some conversions. F
 
 **Tool Choice Simplification:**
 Mistral only supports simple string tool choice, not structured constraints:
+
 ```json
 // OpenAI supports specific tool forcing
 {"tool_choice": {"type": "function", "function": {"name": "specific_tool"}}}
@@ -77,6 +86,7 @@ Mistral only supports simple string tool choice, not structured constraints:
 ### Filtered Parameters
 
 Removed for Mistral compatibility:
+
 - `prompt_cache_key` - Not supported
 - `cache_control` - Stripped from content blocks
 - `verbosity` - Anthropic-specific
@@ -86,6 +96,7 @@ Removed for Mistral compatibility:
 ## Message Conversion
 
 Full OpenAI message support:
+
 - All roles: user, assistant, system, tool, developer
 - Content types: text, images, audio, files
 
@@ -93,16 +104,17 @@ Full OpenAI message support:
 
 Tool definitions supported with constraints:
 
-| Aspect | Support | Notes |
-|--------|---------|-------|
-| Function definitions | ✅ | Full parameter schema support |
-| Tool choice "auto" | ✅ | Default mode |
-| Tool choice "any" | ✅ | Requires any tool |
-| Tool choice "none" | ✅ | No tools |
-| Specific tool forcing | ❌ | Not supported - simplified to "any" |
-| Parallel tools | ✅ | Multiple tools in one turn |
+| Aspect                | Support | Notes                               |
+| --------------------- | ------- | ----------------------------------- |
+| Function definitions  | ✅      | Full parameter schema support       |
+| Tool choice "auto"    | ✅      | Default mode                        |
+| Tool choice "any"     | ✅      | Requires any tool                   |
+| Tool choice "none"    | ✅      | No tools                            |
+| Specific tool forcing | ❌      | Not supported - simplified to "any" |
+| Parallel tools        | ✅      | Multiple tools in one turn          |
 
 **Limitation Caveat:**
+
 ```go
 // Bifrost allows specifying a specific tool
 {
@@ -121,6 +133,7 @@ Tool definitions supported with constraints:
 ## Response Conversion
 
 Standard OpenAI-compatible response:
+
 - `choices[].message.content` - Response text
 - `choices[].message.tool_calls` - Function calls
 - `usage` - Token counts (prompt_tokens, completion_tokens)
@@ -148,15 +161,15 @@ Mistral provides native audio transcription with streaming support.
 
 ### Parameter Mapping
 
-| Parameter | Bifrost | Mistral | Notes |
-|-----------|---------|---------|-------|
-| `file` | Binary audio | Multipart form | Converted to multipart |
-| `model` | Model name | model | |
-| `language` | ISO-639-1 | language | Optional language hint |
-| `prompt` | Optional | prompt | Context for recognition |
-| `response_format` | Format type | response_format | json, text, etc. |
-| `temperature` | float | temperature | Sampling temperature |
-| `timestamp_granularities` | Array | Array field | Segment/word timestamps |
+| Parameter                 | Bifrost      | Mistral         | Notes                   |
+| ------------------------- | ------------ | --------------- | ----------------------- |
+| `file`                    | Binary audio | Multipart form  | Converted to multipart  |
+| `model`                   | Model name   | model           |                         |
+| `language`                | ISO-639-1    | language        | Optional language hint  |
+| `prompt`                  | Optional     | prompt          | Context for recognition |
+| `response_format`         | Format type  | response_format | json, text, etc.        |
+| `temperature`             | float        | temperature     | Sampling temperature    |
+| `timestamp_granularities` | Array        | Array field     | Segment/word timestamps |
 
 ### Multipart Form Structure
 
@@ -182,21 +195,25 @@ en
   "text": "transcribed text",
   "language": "en",
   "duration": 3.5,
-  "segments": [{
-    "id": 0,
-    "start": 0.0,
-    "end": 1.5,
-    "text": "transcribed segment",
-    "temperature": 0.0,
-    "avg_logprob": -0.45,
-    "compression_ratio": 1.2,
-    "no_speech_prob": 0.001
-  }],
-  "words": [{
-    "word": "transcribed",
-    "start": 0.0,
-    "end": 0.8
-  }]
+  "segments": [
+    {
+      "id": 0,
+      "start": 0.0,
+      "end": 1.5,
+      "text": "transcribed segment",
+      "temperature": 0.0,
+      "avg_logprob": -0.45,
+      "compression_ratio": 1.2,
+      "no_speech_prob": 0.001
+    }
+  ],
+  "words": [
+    {
+      "word": "transcribed",
+      "start": 0.0,
+      "end": 0.8
+    }
+  ]
 }
 ```
 
@@ -204,12 +221,12 @@ en
 
 Mistral supports SSE streaming for transcription with custom event types:
 
-| Event Type | Content | Notes |
-|-----------|---------|-------|
-| `transcription.language` | Language code | Language detected |
-| `transcription.text.delta` | Text delta | Incremental text |
-| `transcription.segment` | Full segment | Complete segment data |
-| `transcription.done` | Final usage | Completion with tokens |
+| Event Type                 | Content       | Notes                  |
+| -------------------------- | ------------- | ---------------------- |
+| `transcription.language`   | Language code | Language detected      |
+| `transcription.text.delta` | Text delta    | Incremental text       |
+| `transcription.segment`    | Full segment  | Complete segment data  |
+| `transcription.done`       | Final usage   | Completion with tokens |
 
 ---
 
@@ -217,18 +234,49 @@ Mistral supports SSE streaming for transcription with custom event types:
 
 Mistral supports text embeddings:
 
-| Parameter | Notes |
-|-----------|-------|
-| `input` | Text or array of texts |
-| `model` | Embedding model name |
-| `dimensions` | Custom output dimensions (optional) |
-| `encoding_format` | "float" or "base64" |
+| Parameter         | Notes                               |
+| ----------------- | ----------------------------------- |
+| `input`           | Text or array of texts              |
+| `model`           | Embedding model name                |
+| `dimensions`      | Custom output dimensions (optional) |
+| `encoding_format` | "float" or "base64"                 |
 
 Response returns embedding vectors with token usage.
 
 ---
 
-# 5. List Models
+# 5. OCR
+
+Mistral provides native OCR support for extracting text and content from documents and images via the `mistral-ocr-latest` model.
+
+## Request Parameters
+
+| Parameter                    | Notes                                                      |
+| ---------------------------- | ---------------------------------------------------------- |
+| `model`                      | OCR model name (e.g., `mistral/mistral-ocr-latest`)        |
+| `document`                   | Document input — see document types below                  |
+| `include_image_base64`       | Return extracted images as base64                          |
+| `pages`                      | Specific page indices to process (0-based)                 |
+| `image_limit`                | Max images to extract per page                             |
+| `image_min_size`             | Minimum image size in pixels to extract                    |
+| `table_format`               | Format for extracted tables (e.g., `"markdown"`, `"html"`) |
+| `extract_header`             | Extract page headers                                       |
+| `extract_footer`             | Extract page footers                                       |
+| `confidence_scores_granularity` | Confidence detail level: `page`, `block`, `word`, or `document` |
+| `bbox_annotation_format`     | Format for bounding box annotations                        |
+| `document_annotation_format` | Format for document-level annotations                      |
+| `document_annotation_prompt` | Custom prompt for document annotation                      |
+
+### Document Types
+
+| `type`         | Required field | Use case                   |
+| -------------- | -------------- | -------------------------- |
+| `document_url` | `document_url` | PDF URL or base64 data URL |
+| `image_url`    | `image_url`    | Image URL                  |
+
+---
+
+# 6. List Models
 
 Lists available Mistral models with context length and capabilities.
 
@@ -236,30 +284,28 @@ Lists available Mistral models with context length and capabilities.
 
 ## Unsupported Features
 
-| Feature | Reason |
-|---------|--------|
-| Text Completions | Not offered by Mistral API |
+| Feature          | Reason                                                                 |
+| ---------------- | ---------------------------------------------------------------------- |
+| Text Completions | Not offered by Mistral API                                             |
 | Image Generation | Not yet implemented in Bifrost integration (Mistral API supports this) |
-| Speech/TTS | Not offered by Mistral API |
-| File Management | Not offered by Mistral API |
-| Batch Operations | Not offered by Mistral API |
+| Speech/TTS       | Not offered by Mistral API                                             |
+| File Management  | Not offered by Mistral API                                             |
+| Batch Operations | Not offered by Mistral API                                             |
 
 ---
 
 ## Caveats
 
 <Accordion title="Cache Control Stripped">
-**Severity**: Medium
-**Behavior**: Cache control directives removed from messages
-**Impact**: Prompt caching features unavailable
-**Code**: Stripped during JSON marshaling
+  **Severity**: Medium **Behavior**: Cache control directives removed from
+  messages **Impact**: Prompt caching features unavailable **Code**: Stripped
+  during JSON marshaling
 </Accordion>
 
 <Accordion title="Parameter Filtering">
-**Severity**: Low
-**Behavior**: OpenAI-specific parameters filtered
-**Impact**: prompt_cache_key, verbosity, store removed
-**Code**: filterOpenAISpecificParameters
+  **Severity**: Low **Behavior**: OpenAI-specific parameters filtered
+  **Impact**: prompt_cache_key, verbosity, store removed **Code**:
+  filterOpenAISpecificParameters
 </Accordion>
 
 <Accordion title="User Field Size Limit">

--- a/docs/providers/supported-providers/overview.mdx
+++ b/docs/providers/supported-providers/overview.mdx
@@ -7,64 +7,71 @@ icon: "circle-info"
 ## Overview
 
 Bifrost supports a wide range of AI providers, all accessible through a consistent OpenAI-compatible interface. This standardization allows you to switch between providers without modifying your application code, as all responses follow the same structure regardless of the underlying provider.
- 
-Bifrost can also act as a provider-compatible gateway (for example, <u>[Anthropic](../../integrations/anthropic-sdk/overview)</u>, <u>[Google Gemini](../../integrations/genai-sdk/overview)</u>, <u>Cohere</u>, <u>[Bedrock](../../integrations/bedrock-sdk/overview)</u>, and others), exposing provider-specific endpoints so you can use existing provider SDKs or integrations with no code changes, see [What is an integration?](../../integrations/what-is-an-integration) for details.
 
+Bifrost can also act as a provider-compatible gateway (for example, <u>[Anthropic](../../integrations/anthropic-sdk/overview)</u>, <u>[Google Gemini](../../integrations/genai-sdk/overview)</u>, <u>Cohere</u>, <u>[Bedrock](../../integrations/bedrock-sdk/overview)</u>, and others), exposing provider-specific endpoints so you can use existing provider SDKs or integrations with no code changes, see [What is an integration?](../../integrations/what-is-an-integration) for details.
 
 ## Provider Support Matrix
 
 The following table summarizes which operations are supported by each provider via Bifrost’s unified interface.
 
-| Provider | Models | Text | Text (stream) | Chat | Chat (stream) | Responses | Responses (stream) | Images | Images (stream) | Image Edit | Image Edit (stream) | Image Variation | Embeddings | TTS | TTS (stream) | STT | STT (stream) | Files | Batch | Count tokens |
-|----------|--------|------|----------------|------|---------------|-----------|--------------------|--------|-----------------|------------|---------------------|-----------------|------------|-----|-------------|-----|--------------|-------|-------|--------------|
-| Anthropic (`anthropic/<model>`) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Azure (`azure/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
-| Bedrock (`bedrock/<model>`) | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ |
-| Cerebras (`cerebras/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Cohere (`cohere/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| Elevenlabs (`elevenlabs/<model>`) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Fireworks (`fireworks/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Gemini (`gemini/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Groq (`groq/<model>`) | ✅ | 🟡 | 🟡 | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Hugging Face (`huggingface/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Mistral (`mistral/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| Nebius (`nebius/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Ollama (`ollama/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| OpenAI (`openai/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| OpenRouter (`openrouter/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Parasail (`parasail/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Perplexity (`perplexity/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Replicate (`replicate/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
-| SGL (`sgl/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Vertex AI (`vertex/<model>`) | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
-| vLLM (`vllm/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| xAI (`xai/<model>`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-
+| Provider                             | Models | Text | Text (stream) | Chat | Chat (stream) | Responses | Responses (stream) | Images | Images (stream) | Image Edit | Image Edit (stream) | Image Variation | Embeddings | TTS | TTS (stream) | STT | STT (stream) | Files | Batch | Count tokens | Rerank | OCR | Video | Video Remix | Containers | Passthrough | Passthrough (stream) |
+| ------------------------------------ | ------ | ---- | ------------- | ---- | ------------- | --------- | ------------------ | ------ | --------------- | ---------- | ------------------- | --------------- | ---------- | --- | ------------ | --- | ------------ | ----- | ----- | ------------ | ------ | --- | ----- | ----------- | ---------- | ----------- | -------------------- |
+| Anthropic (`anthropic/<model>`)      | ✅     | ✅   | ❌            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ✅    | ✅    | ✅           | ❌     | ❌  | ❌    | ❌          | ❌         | ✅          | ✅                   |
+| Azure (`azure/<model>`)              | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ✅     | ✅              | ✅         | ✅                  | ❌              | ✅         | ✅  | ✅           | ✅  | ❌           | ✅    | ✅    | ❌           | ❌     | ❌  | ✅    | ❌          | ❌         | ✅          | ✅                   |
+| Bedrock (`bedrock/<model>`)          | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ✅     | ❌              | ✅         | ❌                  | ✅              | ✅         | ❌  | ❌           | ❌  | ❌           | ✅    | ✅    | ✅           | ✅     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Cerebras (`cerebras/<model>`)        | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Cohere (`cohere/<model>`)            | ✅     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ✅           | ✅     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Elevenlabs (`elevenlabs/<model>`)    | ✅     | ❌   | ❌            | ❌   | ❌            | ❌        | ❌                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ✅  | ✅           | ✅  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Fireworks (`fireworks/<model>`)      | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Gemini (`gemini/<model>`)            | ✅     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ✅     | ❌              | ✅         | ❌                  | ❌              | ✅         | ✅  | ✅           | ✅  | ✅           | ✅    | ✅    | ✅           | ❌     | ❌  | ✅    | ❌          | ❌         | ✅          | ✅                   |
+| Groq (`groq/<model>`)                | ✅     | 🟡   | 🟡            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ✅  | ❌           | ✅  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Hugging Face (`huggingface/<model>`) | ✅     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ✅     | ✅              | ✅         | ✅                  | ❌              | ✅         | ✅  | ❌           | ✅  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Mistral (`mistral/<model>`)          | ✅     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ✅  | ✅           | ❌    | ❌    | ❌           | ❌     | ✅  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Nebius (`nebius/<model>`)            | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ✅     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Ollama (`ollama/<model>`)            | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| OpenAI (`openai/<model>`)            | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ✅     | ✅              | ✅         | ✅                  | ✅              | ✅         | ✅  | ✅           | ✅  | ✅           | ✅    | ✅    | ✅           | ❌     | ❌  | ✅    | ✅          | ✅         | ✅          | ✅                   |
+| OpenRouter (`openrouter/<model>`)    | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Parasail (`parasail/<model>`)        | ✅     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Perplexity (`perplexity/<model>`)    | ❌     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Replicate (`replicate/<model>`)      | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ✅     | ✅              | ✅         | ✅                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ✅    | ❌    | ❌           | ❌     | ❌  | ✅    | ❌          | ❌         | ❌          | ❌                   |
+| Runway (`runway/<model>`)            | ❌     | ❌   | ❌            | ❌   | ❌            | ❌        | ❌                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ✅    | ❌          | ❌         | ❌          | ❌                   |
+| SGL (`sgl/<model>`)                  | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| Vertex AI (`vertex/<model>`)         | ✅     | ❌   | ❌            | ✅   | ✅            | ✅        | ✅                 | ✅     | ❌              | ✅         | ❌                  | ❌              | ✅         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ✅           | ✅     | ❌  | ✅    | ❌          | ❌         | ✅          | ✅                   |
+| vLLM (`vllm/<model>`)                | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ❌     | ❌              | ❌         | ❌                  | ❌              | ✅         | ❌  | ❌           | ✅  | ✅           | ❌    | ❌    | ❌           | ✅     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
+| xAI (`xai/<model>`)                  | ✅     | ✅   | ✅            | ✅   | ✅            | ✅        | ✅                 | ✅     | ❌              | ❌         | ❌                  | ❌              | ❌         | ❌  | ❌           | ❌  | ❌           | ❌    | ❌    | ❌           | ❌     | ❌  | ❌    | ❌          | ❌         | ❌          | ❌                   |
 
 - 🟡 Not supported by the downstream provider, but internally implemented by Bifrost as a fallback.
 - ❌ Not supported by the downstream provider, hence not supported by Bifrost.
 - ✅ Fully supported by the downstream provider, or internally implemented by Bifrost.
 
-
 <Note>
-Some operations are not supported by the downstream provider, and their internal implementation in Bifrost is optional. 🟡
-Like Text completions are not supported by Groq, but Bifrost can emulate them internally using the Chat Completions API. This feature is disabled by default, but it can be enabled by setting `compat.convert_text_to_chat` to `true` in the client configuration.
-We do not promote using such fallbacks, since text completions and chat completions are fundamentally different. However, this option is available to help users migrating from LiteLLM (which does support these fallbacks).
+  Some operations are not supported by the downstream provider, and their
+  internal implementation in Bifrost is optional. 🟡 Like Text completions are
+  not supported by Groq, but Bifrost can emulate them internally using the Chat
+  Completions API. This feature is disabled by default, but it can be enabled by
+  setting `compat.convert_text_to_chat` to `true` in the client configuration.
+  We do not promote using such fallbacks, since text completions and chat
+  completions are fundamentally different. However, this option is available to
+  help users migrating from LiteLLM (which does support these fallbacks).
 </Note>
 
-
 Notes:
+
 - "Models" refers to the list models operation (`/v1/models`).
 - "Text" refers to the classic text completion interface (`/v1/completions`).
 - "Responses" refers to the OpenAI-style Responses API (`/v1/responses`). Depending on the provider, Bifrost either uses a native responses endpoint or maps to an equivalent chat API.
-- Reranking (`/v1/rerank`) is currently supported for Cohere, Bedrock, Vertex AI, and vLLM. See each provider page for model-specific requirements.
 - "Images" refers to the Image Generation API (`/v1/images/generations`).
 - "Image Edit" refers to the Image Edit API (`/v1/images/edits`).
 - "Image Variation" refers to the Image Variation API (`/v1/images/variations`).
 - TTS corresponds to `/v1/audio/speech` and STT to `/v1/audio/transcriptions`.
 - "Files" refers to the Files API operations (`/v1/files`) for uploading, listing, retrieving, and deleting files.
 - "Batch" refers to the Batch API operations (`/v1/batches`) for creating, listing, retrieving, canceling, and getting results of batch jobs.
-
+- "Rerank" refers to the Rerank APIs (`/v1/rerank`, `/v1/async/rerank`, `/v1/async/rerank/{job_id}`). See each provider page for model-specific requirements.
+- "OCR" refers to the OCR APIs (`/v1/ocr`, `/v1/async/ocr`, `/v1/async/ocr/{job_id}`) for optical character recognition on documents and images.
+- "Video" refers to Video API operations for generating, retrieving, downloading, deleting, and listing videos.
+- "Video Remix" refers to the video remix operation, which generates a new video by transforming an existing one.
+- "Containers" refers to the Containers API operations for creating, listing, retrieving, and deleting containers and container files.
+- "Passthrough" refers to the Passthrough API, which forwards requests directly to the provider without Bifrost's transformation layer.
 
 ## Response Format
 
@@ -134,7 +141,6 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
 </Tab>
 </Tabs>
 
-
 ## Custom Providers
 
 In addition to the built-in providers, Bifrost supports custom provider configurations. Custom providers allow you to create multiple instances of the same base provider with different configurations, request type restrictions, and access patterns. This is useful for environment-specific configurations, role-based access control, and feature testing.
@@ -159,6 +165,7 @@ Provider information is included in the `extra_fields` section of each response,
 Bifrost can optionally return the raw request that was sent to the provider and the raw response received back. This is useful for debugging, auditing, and understanding how Bifrost transforms requests between different provider formats.
 
 **What's included:**
+
 - **`raw_request`** - The exact request body (JSON/data structure) that was sent to the provider's API endpoint
 - **`raw_response`** - The exact response body received from the provider (before Bifrost's normalization)
 - **Provider transformation details** - Shows exactly how Bifrost converted your input to provider-specific format
@@ -188,15 +195,19 @@ Bifrost can optionally return the raw request that was sent to the provider and 
 ```
 
 **Use cases:**
+
 - **Debugging** - Verify how your request was transformed for the specific provider
 - **Auditing** - Track exactly what was sent to external APIs
 - **Cost analysis** - See actual token counts before Bifrost's normalization
 - **Integration testing** - Validate provider-specific transformations
 
 **Configuration options:**
+
 - **[Go SDK Provider Configuration](../../quickstart/go-sdk/provider-configuration)** - Configure `SendBackRawResponse` and other provider settings
 - **[Gateway Provider Configuration](../../quickstart/gateway/provider-configuration)** - Configure `send_back_raw_response` via API, UI, or config file
 
 <Note>
-Enabling raw request/response may increase response payload size and has minimal performance impact. Use it selectively in debugging/testing environments or when you need audit trails.
+  Enabling raw request/response may increase response payload size and has
+  minimal performance impact. Use it selectively in debugging/testing
+  environments or when you need audit trails.
 </Note>

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,1 +1,2 @@
 - fix: Fixes OTEL exporting in `framework/tracing/llmspan.go` to show input and output messages correctly
+- feat: add support for cache creation cost above 1 hour

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -417,11 +417,12 @@ func responsesUsageToBifrostUsage(u *schemas.ResponsesResponseUsage) *schemas.Bi
 	// Map token details for cache and search query pricing
 	if u.InputTokensDetails != nil {
 		usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{
-			TextTokens:        u.InputTokensDetails.TextTokens,
-			AudioTokens:       u.InputTokensDetails.AudioTokens,
-			ImageTokens:       u.InputTokensDetails.ImageTokens,
-			CachedReadTokens:  u.InputTokensDetails.CachedReadTokens,
-			CachedWriteTokens: u.InputTokensDetails.CachedWriteTokens,
+			TextTokens:              u.InputTokensDetails.TextTokens,
+			AudioTokens:             u.InputTokensDetails.AudioTokens,
+			ImageTokens:             u.InputTokensDetails.ImageTokens,
+			CachedReadTokens:        u.InputTokensDetails.CachedReadTokens,
+			CachedWriteTokens:       u.InputTokensDetails.CachedWriteTokens,
+			CachedWriteTokenDetails: u.InputTokensDetails.CachedWriteTokenDetails,
 		}
 	}
 	if u.OutputTokensDetails != nil {
@@ -485,15 +486,20 @@ func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schema
 	// Extract cached token counts
 	cachedReadTokens := 0
 	cachedWriteTokens := 0
+	cachedWriteTokensAbove1hr := 0
 	if usage.PromptTokensDetails != nil {
 		cachedReadTokens = usage.PromptTokensDetails.CachedReadTokens
 		cachedWriteTokens = usage.PromptTokensDetails.CachedWriteTokens
+		if usage.PromptTokensDetails.CachedWriteTokenDetails != nil {
+			cachedWriteTokensAbove1hr = usage.PromptTokensDetails.CachedWriteTokenDetails.CachedWriteTokens1h
+		}
 	}
 
 	inputRate := tieredInputRate(pricing, totalTokens, tier)
 	outputRate := tieredOutputRate(pricing, totalTokens, tier)
 	cacheReadInputRate := tieredCacheReadInputTokenRate(pricing, totalTokens, tier)
 	cacheCreationInputRate := tieredCacheCreationInputTokenRate(pricing, totalTokens, tier)
+	cacheCreationInputAbove1hrInputRate := tieredCacheCreationInputAbove1hrTokenRate(pricing, totalTokens, tier)
 
 	// Clamp cached token counts to avoid negative billing on malformed provider payloads
 	if cachedReadTokens > promptTokens {
@@ -501,6 +507,10 @@ func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schema
 	}
 	if cachedWriteTokens > promptTokens-cachedReadTokens {
 		cachedWriteTokens = promptTokens - cachedReadTokens
+	}
+	// Should not happen, but just in case
+	if cachedWriteTokensAbove1hr > cachedWriteTokens {
+		cachedWriteTokensAbove1hr = cachedWriteTokens
 	}
 
 	// Input cost: non-cached tokens at regular rate
@@ -514,7 +524,10 @@ func computeTextCost(pricing *configstoreTables.TableModelPricing, usage *schema
 
 	// Add cached write tokens at cache creation rate
 	if cachedWriteTokens > 0 {
-		inputCost += float64(cachedWriteTokens) * cacheCreationInputRate
+		if cachedWriteTokensAbove1hr > 0 {
+			inputCost += float64(cachedWriteTokensAbove1hr) * cacheCreationInputAbove1hrInputRate
+		}
+		inputCost += float64(cachedWriteTokens-cachedWriteTokensAbove1hr) * cacheCreationInputRate
 	}
 
 	outputCost := float64(completionTokens) * outputRate
@@ -1008,6 +1021,16 @@ func tieredCacheCreationInputTokenRate(pricing *configstoreTables.TableModelPric
 		return *pricing.CacheCreationInputTokenCost
 	}
 	return tieredInputRate(pricing, totalTokens, tier)
+}
+
+func tieredCacheCreationInputAbove1hrTokenRate(pricing *configstoreTables.TableModelPricing, totalTokens int, tier serviceTier) float64 {
+	if totalTokens > TokenTierAbove200K && pricing.CacheCreationInputTokenCostAbove1hrAbove200kTokens != nil {
+		return *pricing.CacheCreationInputTokenCostAbove1hrAbove200kTokens
+	}
+	if pricing.CacheCreationInputTokenCostAbove1hr != nil {
+		return *pricing.CacheCreationInputTokenCostAbove1hr
+	}
+	return tieredCacheCreationInputTokenRate(pricing, totalTokens, tier)
 }
 
 func safeTotalTokens(usage *schemas.BifrostLLMUsage) int {

--- a/framework/modelcatalog/pricing_test.go
+++ b/framework/modelcatalog/pricing_test.go
@@ -151,6 +151,249 @@ func TestComputeTextCost_WithCachedPromptTokens(t *testing.T) {
 	assert.InDelta(t, 0.0096, cost, 1e-12)
 }
 
+func TestComputeTextCost_With1hrCacheCreationTokens(t *testing.T) {
+	// claude-3-5-sonnet-20241022-v2:0 on Bedrock:
+	// input=$3/M, output=$15/M, cache_creation=$3.75/M, cache_creation_1hr=$7.50/M, cache_read=$0.3/M
+	p := chatPricing(0.000003, 0.000015)
+	p.CacheReadInputTokenCost = bifrost.Ptr(3e-7)
+	p.CacheCreationInputTokenCost = bifrost.Ptr(0.00000375)
+	p.CacheCreationInputTokenCostAbove1hr = bifrost.Ptr(0.0000075)
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     2000,
+		CompletionTokens: 500,
+		TotalTokens:      2500,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedWriteTokens: 1000,
+			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
+				CachedWriteTokens1h: 600, // 600 at 1hr rate, 400 at standard rate
+			},
+		},
+	}
+
+	cost := computeTextCost(&p, usage, serviceTier{})
+
+	// Input (non-cached): (2000-1000)*0.000003 = 0.003
+	// Cache creation (1hr): 600*0.0000075 = 0.0045
+	// Cache creation (standard): 400*0.00000375 = 0.0015
+	// Output: 500*0.000015 = 0.0075
+	// Total: 0.003 + 0.0045 + 0.0015 + 0.0075 = 0.0165
+	assert.InDelta(t, 0.0165, cost, 1e-12)
+}
+
+func TestComputeTextCost_StandardCacheCreationPricingLesserThan1hr(t *testing.T) {
+	// Standard (5-min TTL) cache creation is cheaper than 1hr TTL cache creation.
+	// 1hr rate ($7.50/M) is 2x the standard rate ($3.75/M).
+	p := chatPricing(0.000003, 0.000015)
+	p.CacheCreationInputTokenCost = bifrost.Ptr(0.00000375)
+	p.CacheCreationInputTokenCostAbove1hr = bifrost.Ptr(0.0000075)
+
+	base := &schemas.BifrostLLMUsage{
+		PromptTokens:     2000,
+		CompletionTokens: 500,
+		TotalTokens:      2500,
+	}
+
+	usageStandard := *base
+	usageStandard.PromptTokensDetails = &schemas.ChatPromptTokensDetails{
+		CachedWriteTokens: 1000,
+	}
+
+	usage1hr := *base
+	usage1hr.PromptTokensDetails = &schemas.ChatPromptTokensDetails{
+		CachedWriteTokens: 1000,
+		CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
+			CachedWriteTokens1h: 1000, // all 1000 tokens at 1hr rate
+		},
+	}
+
+	costStandard := computeTextCost(&p, &usageStandard, serviceTier{})
+	cost1hr := computeTextCost(&p, &usage1hr, serviceTier{})
+
+	assert.Less(t, costStandard, cost1hr, "standard cache creation should cost less than 1hr cache creation")
+}
+
+func TestComputeTextCost_1hrCacheCreationFallsBackToStandardWhenAbove1hrRateAbsent(t *testing.T) {
+	// claude-3-5-haiku on Bedrock has no cache_creation_input_token_cost_above_1hr entry.
+	// Tokens marked as 1hr cache writes must fall back to the standard cache creation rate.
+	p := chatPricing(8e-7, 0.000004)
+	p.CacheReadInputTokenCost = bifrost.Ptr(8e-8)
+	p.CacheCreationInputTokenCost = bifrost.Ptr(0.000001)
+	// CacheCreationInputTokenCostAbove1hr intentionally left nil
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     2000,
+		CompletionTokens: 500,
+		TotalTokens:      2500,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedWriteTokens: 1000,
+			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
+				CachedWriteTokens1h: 1000, // all 1hr tokens, but no above_1hr rate configured
+			},
+		},
+	}
+
+	cost := computeTextCost(&p, usage, serviceTier{})
+
+	// Input (non-cached): (2000-1000)*8e-7 = 0.0008
+	// Cache creation (1hr fallback → standard 0.000001): 1000*0.000001 = 0.001
+	// Output: 500*0.000004 = 0.002
+	// Total: 0.0008 + 0.001 + 0.002 = 0.0038
+	assert.InDelta(t, 0.0038, cost, 1e-12)
+}
+
+func TestComputeTextCost_CacheWriteTokenDetailsNil_FallsBackToStandardCreationRate(t *testing.T) {
+	// CachedWriteTokens is set but CachedWriteTokenDetails is nil.
+	// All write tokens must use the standard cache creation rate even though above_1hr is configured.
+	p := chatPricing(0.000003, 0.000015)
+	p.CacheCreationInputTokenCost = bifrost.Ptr(0.00000375)
+	p.CacheCreationInputTokenCostAbove1hr = bifrost.Ptr(0.0000075) // present but must not be used
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     2000,
+		CompletionTokens: 500,
+		TotalTokens:      2500,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedWriteTokens:       1000,
+			CachedWriteTokenDetails: nil,
+		},
+	}
+
+	cost := computeTextCost(&p, usage, serviceTier{})
+
+	// Input (non-cached): (2000-1000)*0.000003 = 0.003
+	// Cache creation (standard, no 1hr details): 1000*0.00000375 = 0.00375
+	// Output: 500*0.000015 = 0.0075
+	// Total: 0.003 + 0.00375 + 0.0075 = 0.01425
+	assert.InDelta(t, 0.01425, cost, 1e-12)
+}
+
+func TestComputeTextCost_CacheWriteTokenDetails1hZero_FallsBackToStandardCreationRate(t *testing.T) {
+	// CachedWriteTokenDetails is present but CachedWriteTokens1h is 0 (e.g. all tokens
+	// used 5-min TTL). All write tokens must use the standard cache creation rate.
+	p := chatPricing(0.000003, 0.000015)
+	p.CacheCreationInputTokenCost = bifrost.Ptr(0.00000375)
+	p.CacheCreationInputTokenCostAbove1hr = bifrost.Ptr(0.0000075) // present but must not be used
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     2000,
+		CompletionTokens: 500,
+		TotalTokens:      2500,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedWriteTokens: 1000,
+			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
+				CachedWriteTokens1h: 0,
+			},
+		},
+	}
+
+	cost := computeTextCost(&p, usage, serviceTier{})
+
+	// Input (non-cached): (2000-1000)*0.000003 = 0.003
+	// Cache creation (standard, 1h count is 0): 1000*0.00000375 = 0.00375
+	// Output: 500*0.000015 = 0.0075
+	// Total: 0.003 + 0.00375 + 0.0075 = 0.01425
+	assert.InDelta(t, 0.01425, cost, 1e-12)
+}
+
+func TestComputeTextCost_1hrCacheCreationAbove200k_UsesAbove1hrAbove200kRate(t *testing.T) {
+	// claude-3-5-sonnet-20241022-v2:0 on Bedrock has all four cache creation tiers.
+	// When totalTokens > 200k and CachedWriteTokens1h > 0, the above_1hr_above_200k rate
+	// ($15/M) must be used — the most specific tier wins.
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	p.CacheCreationInputTokenCost = bifrost.Ptr(0.00000375)
+	p.CacheCreationInputTokenCostAbove200kTokens = bifrost.Ptr(0.0000075)
+	p.CacheCreationInputTokenCostAbove1hr = bifrost.Ptr(0.0000075)
+	p.CacheCreationInputTokenCostAbove1hrAbove200kTokens = bifrost.Ptr(0.000015)
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 25000,
+		TotalTokens:      205000, // above 200k threshold
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedWriteTokens: 10000,
+			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
+				CachedWriteTokens1h: 10000,
+			},
+		},
+	}
+
+	cost := computeTextCost(&p, usage, serviceTier{})
+
+	// Input rate (>200k): 0.000006; output rate (>200k): 0.00003
+	// Input (non-cached): (180000-10000)*0.000006 = 170000*0.000006 = 1.02
+	// Cache creation 1hr above 200k: 10000*0.000015 = 0.15
+	// Output: 25000*0.00003 = 0.75
+	// Total: 1.02 + 0.15 + 0.75 = 1.92
+	assert.InDelta(t, 1.92, cost, 1e-9)
+}
+
+func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToAbove1hrWhenAbove200kRateAbsent(t *testing.T) {
+	// When CacheCreationInputTokenCostAbove1hrAbove200kTokens is absent but
+	// CacheCreationInputTokenCostAbove1hr is present, the 1hr rate must be used
+	// even for >200k requests.
+	p := chatPricing(0.000003, 0.000015)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000006)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.00003)
+	p.CacheCreationInputTokenCost = bifrost.Ptr(0.00000375)
+	p.CacheCreationInputTokenCostAbove200kTokens = bifrost.Ptr(0.0000075)
+	p.CacheCreationInputTokenCostAbove1hr = bifrost.Ptr(0.000009) // distinct from above_200k to make fallback unambiguous
+	// CacheCreationInputTokenCostAbove1hrAbove200kTokens intentionally left nil
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 25000,
+		TotalTokens:      205000,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedWriteTokens: 10000,
+			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
+				CachedWriteTokens1h: 10000,
+			},
+		},
+	}
+
+	cost := computeTextCost(&p, usage, serviceTier{})
+
+	// Cache creation 1hr (no above_200k_1hr rate, uses above_1hr): 10000*0.000009 = 0.09
+	// Input (non-cached): 170000*0.000006 = 1.02
+	// Output: 25000*0.00003 = 0.75
+	// Total: 1.02 + 0.09 + 0.75 = 1.86
+	assert.InDelta(t, 1.86, cost, 1e-9)
+}
+
+func TestComputeTextCost_1hrCacheCreationAbove200k_FallsBackToStandardAbove200kWhenNo1hrRates(t *testing.T) {
+	// When neither above_1hr field is present, 1hr tokens on a >200k request fall back
+	// to the standard above_200k cache creation rate.
+	p := chatPricing(8e-7, 0.000004)
+	p.InputCostPerTokenAbove200kTokens = bifrost.Ptr(0.0000016)
+	p.OutputCostPerTokenAbove200kTokens = bifrost.Ptr(0.000008)
+	p.CacheCreationInputTokenCost = bifrost.Ptr(0.000001)
+	p.CacheCreationInputTokenCostAbove200kTokens = bifrost.Ptr(0.000002)
+	// Neither CacheCreationInputTokenCostAbove1hr nor Above1hrAbove200k is set
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     180000,
+		CompletionTokens: 25000,
+		TotalTokens:      205000,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{
+			CachedWriteTokens: 10000,
+			CachedWriteTokenDetails: &schemas.ChatCachedWriteTokenDetails{
+				CachedWriteTokens1h: 10000,
+			},
+		},
+	}
+
+	cost := computeTextCost(&p, usage, serviceTier{})
+
+	// Cache creation (1hr → no 1hr rates → standard above_200k): 10000*0.000002 = 0.02
+	// Input (non-cached): 170000*0.0000016 = 0.272
+	// Output: 25000*0.000008 = 0.2
+	// Total: 0.272 + 0.02 + 0.2 = 0.492
+	assert.InDelta(t, 0.492, cost, 1e-9)
+}
+
 func TestComputeTextCost_Tiered200k(t *testing.T) {
 	// Claude 3.5 Sonnet Bedrock 200k tier: input=$6/M, output=$30/M
 	p := chatPricing(0.000003, 0.000015)

--- a/plugins/governance/changelog.md
+++ b/plugins/governance/changelog.md
@@ -1,0 +1,1 @@
+- feat: automatically add incoming model to empty fallbacks in routing rules

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -939,9 +939,23 @@ func (p *GovernancePlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *s
 		// Append routing-rule to routing engines used
 		schemas.AppendToContextList(ctx, schemas.BifrostContextKeyRoutingEnginesUsed, schemas.RoutingEngineRoutingRule)
 
-		// Add fallbacks if present
+		// Add fallbacks if present; fill in the incoming model for fallbacks that omit it
 		if len(decision.Fallbacks) > 0 {
-			body["fallbacks"] = decision.Fallbacks
+			resolvedFallbacks := make([]string, 0, len(decision.Fallbacks))
+			for _, fb := range decision.Fallbacks {
+				fbProvider, fbModel := schemas.ParseModelString(fb, "")
+				trimmedFbProvider := strings.TrimSpace(string(fbProvider))
+				trimmedFbModel := strings.TrimSpace(fbModel)
+				if trimmedFbProvider == "" {
+					continue
+				}
+				if trimmedFbModel == "" && model != "" {
+					resolvedFallbacks = append(resolvedFallbacks, trimmedFbProvider+"/"+model)
+				} else {
+					resolvedFallbacks = append(resolvedFallbacks, trimmedFbProvider+"/"+trimmedFbModel)
+				}
+			}
+			body["fallbacks"] = resolvedFallbacks
 		}
 
 		// Pin specific API key by ID if the routing rule specifies one

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -703,6 +703,55 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 
 	isFinalChunk := bifrost.IsFinalChunk(ctx)
 
+	// Retrieve pending input data from PreLLMHook
+	var pendingVal any
+	var hasPending bool
+	if !bifrost.IsStreamRequestType(requestType) || isFinalChunk || bifrostErr != nil {
+		pendingVal, hasPending = p.pendingLogsEntries.LoadAndDelete(requestID)
+	} else {
+		pendingVal, hasPending = p.pendingLogsEntries.Load(requestID)
+	}
+	if !hasPending {
+		// If we have an error (e.g., cancellation/timeout), still write a minimal error entry
+		// so the error is visible in logs. Without PreLLMHook's DB insert, silently returning
+		// here means the error is completely lost.
+		if bifrostErr != nil {
+			p.logger.Warn("no pending log data found for request %s, writing minimal error entry", requestID)
+			entry := &logstore.Log{
+				ID:        requestID,
+				Provider:  string(bifrostErr.ExtraFields.Provider),
+				Status:    "error",
+				Object:    string(requestType),
+				Stream:    bifrost.IsStreamRequestType(requestType),
+				Timestamp: time.Now().UTC(),
+				CreatedAt: time.Now().UTC(),
+			}
+			applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
+			if data, err := sonic.Marshal(bifrostErr); err == nil {
+				entry.ErrorDetails = string(data)
+			}
+			entry.ErrorDetailsParsed = bifrostErr
+			applyLargePayloadPreviewsToEntry(ctx, entry, contentLoggingEnabled)
+			p.storeOrEnqueueEntry(ctx, entry, p.makePostWriteCallback(nil))
+		} else {
+			p.logger.Warn("no pending log data found for request %s, skipping log write", requestID)
+		}
+		return result, bifrostErr, nil
+	}
+
+	pending := pendingVal.(*PendingLogData)
+	if requestType == schemas.RealtimeRequest {
+		if resolvedRealtimeSessionID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyRealtimeSessionID); resolvedRealtimeSessionID != "" {
+			pending.ParentRequestID = resolvedRealtimeSessionID
+		}
+	}
+
+	// Should never happen, but just in case
+	// Fallback to request type from pending data if request type is not set
+	if requestType == "" {
+		requestType = schemas.RequestType(pending.InitialData.Object)
+	}
+
 	var tracer schemas.Tracer
 	var traceID string
 	if bifrost.IsStreamRequestType(requestType) && requestType != schemas.PassthroughStreamRequest && requestType != schemas.RealtimeRequest {
@@ -728,42 +777,6 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	// Extract routing engine logs from context before entering goroutine
 	routingEngineLogs := formatRoutingEngineLogs(ctx.GetRoutingEngineLogs())
 
-	// Retrieve pending input data from PreLLMHook
-	pendingVal, hasPending := p.pendingLogsEntries.LoadAndDelete(requestID)
-	if !hasPending {
-		// If we have an error (e.g., cancellation/timeout), still write a minimal error entry
-		// so the error is visible in logs. Without PreLLMHook's DB insert, silently returning
-		// here means the error is completely lost.
-		if bifrostErr != nil {
-			p.logger.Warn("no pending log data found for request %s, writing minimal error entry", requestID)
-			entry := &logstore.Log{
-				ID:        requestID,
-				Provider:  string(bifrostErr.ExtraFields.Provider),
-				Status:    "error",
-				Stream:    bifrost.IsStreamRequestType(requestType),
-				Timestamp: time.Now().UTC(),
-				CreatedAt: time.Now().UTC(),
-			}
-			applyModelAlias(entry, bifrostErr.ExtraFields.OriginalModelRequested, bifrostErr.ExtraFields.ResolvedModelUsed)
-			if data, err := sonic.Marshal(bifrostErr); err == nil {
-				entry.ErrorDetails = string(data)
-			}
-			entry.ErrorDetailsParsed = bifrostErr
-			applyLargePayloadPreviewsToEntry(ctx, entry, contentLoggingEnabled)
-			p.storeOrEnqueueEntry(ctx, entry, p.makePostWriteCallback(nil))
-		} else {
-			p.logger.Warn("no pending log data found for request %s, skipping log write", requestID)
-		}
-		return result, bifrostErr, nil
-	}
-
-	pending := pendingVal.(*PendingLogData)
-	if requestType == schemas.RealtimeRequest {
-		if resolvedRealtimeSessionID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyRealtimeSessionID); resolvedRealtimeSessionID != "" {
-			pending.ParentRequestID = resolvedRealtimeSessionID
-		}
-	}
-
 	// Build the complete log entry with input (from PreLLMHook) + output (from PostLLMHook)
 	entry := buildCompleteLogEntryFromPending(pending)
 	// Apply common output fields
@@ -781,7 +794,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	// Path A: Error with nil result
 	if result == nil && bifrostErr != nil {
 		entry.Status = "error"
-		applyModelAlias(entry, bifrostErr.ExtraFields.OriginalModelRequested, bifrostErr.ExtraFields.ResolvedModelUsed)
+		applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
 		if bifrost.IsStreamRequestType(requestType) {
 			entry.Stream = true
 		}
@@ -886,7 +899,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	// Path C: Non-streaming response
 	if bifrostErr != nil {
 		entry.Status = "error"
-		applyModelAlias(entry, bifrostErr.ExtraFields.OriginalModelRequested, bifrostErr.ExtraFields.ResolvedModelUsed)
+		applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
 		// Serialize error details immediately since bifrostErr may be released
 		// back to the pool before the async batch writer processes this entry.
 		// Also set ErrorDetailsParsed for UI callback (JSON serialization uses this field).

--- a/pulse.yaml
+++ b/pulse.yaml
@@ -9,7 +9,7 @@ services:
     ignore: ["*_test.go"]
     kill_timeout: 10s
     proxy:
-      addr: ":${PORT}"
+      addr: ":${PORT:-8080}"
     healthcheck:
       path: /health
       interval: 2s

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -3180,6 +3180,10 @@ func (h *GovernanceHandler) createRoutingRule(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 400, err.Error())
 		return
 	}
+	if err := validateRoutingFallbacks(req.Fallbacks); err != nil {
+		SendError(ctx, 400, err.Error())
+		return
+	}
 
 	// Set defaults and normalize scope/scope_id
 	scope := req.Scope
@@ -3321,6 +3325,10 @@ func (h *GovernanceHandler) updateRoutingRule(ctx *fasthttp.RequestCtx) {
 		rule.ParsedQuery = req.Query
 	}
 	if req.Fallbacks != nil {
+		if err := validateRoutingFallbacks(req.Fallbacks); err != nil {
+			SendError(ctx, 400, err.Error())
+			return
+		}
 		rule.ParsedFallbacks = req.Fallbacks
 	}
 	if req.Scope != nil && *req.Scope != "" {
@@ -3811,6 +3819,21 @@ func validateRoutingTargets(targets []RoutingTarget) error {
 	}
 	if math.Abs(total-1.0) > 0.001 {
 		return fmt.Errorf("target weights must sum to 1, got %.4f", total)
+	}
+	return nil
+}
+
+// validateRoutingFallbacks ensures each fallback parses to a non-empty known provider via
+// schemas.ParseModelString (e.g. "openai/gpt-4o", or "azure/" to use the incoming model).
+func validateRoutingFallbacks(fallbacks []string) error {
+	for i, fb := range fallbacks {
+		if strings.TrimSpace(fb) == "" {
+			return fmt.Errorf("fallbacks[%d] must not be empty", i)
+		}
+		provider, _ := schemas.ParseModelString(fb, "")
+		if provider == "" {
+			return fmt.Errorf("fallbacks[%d] %q is invalid: must use a known provider prefix (e.g. \"openai/gpt-4o\" or \"azure/\" for the incoming model)", i, fb)
+		}
 	}
 	return nil
 }

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -188,17 +188,17 @@ func TestBudgetRemovalRequestDetection(t *testing.T) {
 		},
 		{
 			name: "max limit present is not removal",
-			req:  &UpdateBudgetRequest{MaxLimit: bifrostFloat(10)},
+			req:  &UpdateBudgetRequest{MaxLimit: schemas.Ptr(10.0)},
 			want: false,
 		},
 		{
 			name: "reset duration only is not removal",
-			req:  &UpdateBudgetRequest{ResetDuration: bifrostString("1h")},
+			req:  &UpdateBudgetRequest{ResetDuration: schemas.Ptr("1h")},
 			want: false,
 		},
 		{
 			name: "calendar aligned only is treated as removal",
-			req:  &UpdateBudgetRequest{CalendarAligned: bifrostBool(true)},
+			req:  &UpdateBudgetRequest{CalendarAligned: schemas.Ptr(true)},
 			want: true,
 		},
 	}
@@ -230,19 +230,19 @@ func TestRateLimitRemovalRequestDetection(t *testing.T) {
 		},
 		{
 			name: "token limit present is not removal",
-			req:  &UpdateRateLimitRequest{TokenMaxLimit: bifrostInt64(100)},
+			req:  &UpdateRateLimitRequest{TokenMaxLimit: schemas.Ptr(int64(100))},
 			want: false,
 		},
 		{
 			name: "request limit present is not removal",
-			req:  &UpdateRateLimitRequest{RequestMaxLimit: bifrostInt64(10)},
+			req:  &UpdateRateLimitRequest{RequestMaxLimit: schemas.Ptr(int64(10))},
 			want: false,
 		},
 		{
 			name: "durations only is not removal",
 			req: &UpdateRateLimitRequest{
-				TokenResetDuration:   bifrostString("1h"),
-				RequestResetDuration: bifrostString("1h"),
+				TokenResetDuration:   schemas.Ptr("1h"),
+				RequestResetDuration: schemas.Ptr("1h"),
 			},
 			want: false,
 		},
@@ -320,18 +320,31 @@ func TestCollectProviderConfigDeleteIDs(t *testing.T) {
 	}
 }
 
-func bifrostFloat(v float64) *float64 {
-	return &v
-}
+func TestValidateRoutingFallbacks(t *testing.T) {
 
-func bifrostInt64(v int64) *int64 {
-	return &v
-}
-
-func bifrostString(v string) *string {
-	return &v
-}
-
-func bifrostBool(v bool) *bool {
-	return &v
+	tests := []struct {
+		name    string
+		fbs     []string
+		wantErr bool
+	}{
+		{name: "nil", fbs: nil, wantErr: false},
+		{name: "empty", fbs: []string{}, wantErr: false},
+		{name: "provider model", fbs: []string{"openai/gpt-4o"}, wantErr: false},
+		{name: "provider slash incoming model", fbs: []string{"azure/"}, wantErr: false},
+		{name: "bare known provider name rejected", fbs: []string{"openrouter"}, wantErr: true},
+		{name: "bare model rejected", fbs: []string{"gpt-4o"}, wantErr: true},
+		{name: "empty element", fbs: []string{"openai/gpt-4o", ""}, wantErr: true},
+		{name: "huggingface namespace not a provider prefix", fbs: []string{"meta-llama/Llama-3.1-8B"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRoutingFallbacks(tt.fbs)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -127,9 +127,9 @@ type ConfigData struct {
 	// from config.json. Omitting this field or setting it to 2 uses v1.5.0+ semantics:
 	// empty = deny all, ["*"] = allow all. Setting it to 1 restores v1.4.x semantics:
 	// empty = allow all (equivalent to ["*"]).
-	Version           int                                   `json:"version,omitempty"`
-	Client            *configstore.ClientConfig             `json:"client"`
-	EncryptionKey     *schemas.EnvVar                       `json:"encryption_key"`
+	Version       int                       `json:"version,omitempty"`
+	Client        *configstore.ClientConfig `json:"client"`
+	EncryptionKey *schemas.EnvVar           `json:"encryption_key"`
 	// Deprecated: Use GovernanceConfig.AuthConfig instead
 	AuthConfig        *configstore.AuthConfig               `json:"auth_config,omitempty"`
 	Providers         map[string]configstore.ProviderConfig `json:"providers"`
@@ -2132,15 +2132,6 @@ func buildMCPPricingDataFromConfig(ctx context.Context, configData *ConfigData) 
 	return mcpPricingData
 }
 
-// redactURL truncates a URL for safe logging, avoiding leakage of tokens or
-// credentials that may be embedded in query parameters or paths.
-func redactURL(u string) string {
-	if len(u) <= 8 {
-		return "***"
-	}
-	return u[:8] + "..."
-}
-
 // ResolveFrameworkPricingConfig resolves framework pricing configuration.
 //
 // Precedence order (highest → lowest): DB > config.json > built-in defaults.
@@ -2219,17 +2210,13 @@ func ResolveFrameworkPricingConfig(
 
 	resolvedPricingURL := &defaultPricingURL
 	resolvedSyncSeconds := &defaultSyncSeconds
-	urlSource := "default"
-	intervalSource := "default"
 
 	if filePricingURL != nil {
 		resolvedPricingURL = filePricingURL
-		urlSource = "file"
 		logger.Debug("pricing_url resolved from file")
 	}
 	if fileSyncSeconds != nil {
 		resolvedSyncSeconds = fileSyncSeconds
-		intervalSource = "file"
 		logger.Debug("pricing_sync_interval resolved from file: %d seconds", *fileSyncSeconds)
 	}
 
@@ -2240,11 +2227,7 @@ func ResolveFrameworkPricingConfig(
 	if dbConfig != nil {
 		configID = dbConfig.ID
 		if dbConfig.PricingURL != nil {
-			if filePricingURL != nil && *filePricingURL != *dbConfig.PricingURL {
-				logger.Info("pricing_url overridden by DB: file=%s db=%s", redactURL(*filePricingURL), redactURL(*dbConfig.PricingURL))
-			}
 			resolvedPricingURL = dbConfig.PricingURL
-			urlSource = "db"
 		} else if !skipURLBackfill {
 			// DB row exists but URL field is NULL — backfill with resolved value.
 			// Skip backfill when the resolved URL is an unresolved env reference
@@ -2264,14 +2247,12 @@ func ResolveFrameworkPricingConfig(
 				logger.Warn("pricing_sync_interval in DB is below minimum (%d seconds), clamping to %d seconds — backfilling", val, modelcatalog.MinimumPricingSyncIntervalSec)
 				clamped := modelcatalog.MinimumPricingSyncIntervalSec
 				resolvedSyncSeconds = &clamped
-				intervalSource = "db"
 				needsDBUpdate = true
 			} else {
 				if fileSyncSeconds != nil && *fileSyncSeconds != *dbConfig.PricingSyncInterval {
 					logger.Info("pricing_sync_interval overridden by DB: file=%d db=%d seconds", *fileSyncSeconds, *dbConfig.PricingSyncInterval)
 				}
 				resolvedSyncSeconds = dbConfig.PricingSyncInterval
-				intervalSource = "db"
 			}
 		} else {
 			// DB row exists but interval field is NULL — backfill.
@@ -2290,16 +2271,11 @@ func ResolveFrameworkPricingConfig(
 	if resolvedPricingURL == nil {
 		logger.Warn("invariant violation: pricing_url resolved to nil — falling back to default %q", defaultPricingURL)
 		resolvedPricingURL = &defaultPricingURL
-		urlSource = "default(invariant-fallback)"
 	}
 	if resolvedSyncSeconds == nil {
 		logger.Warn("invariant violation: pricing_sync_interval resolved to nil — falling back to default %d seconds", defaultSyncSeconds)
 		resolvedSyncSeconds = &defaultSyncSeconds
-		intervalSource = "default(invariant-fallback)"
 	}
-
-	logger.Info("resolved pricing config: url=%s (source: %s) sync_interval=%d seconds (source: %s)",
-		redactURL(*resolvedPricingURL), urlSource, *resolvedSyncSeconds, intervalSource)
 
 	return &configstoreTables.TableFrameworkConfig{
 			ID:                  configID,

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+- feat: add support for cache creation cost above 1 hour

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,2 @@
 - feat: add support for cache creation cost above 1 hour
+- feat: add support for dynamically selecting incoming model for fallbacks in routing rules

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -233,9 +233,9 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 		const submitPromise =
 			isEditing && editingRule
 				? updateRoutingRule({
-						id: editingRule.id,
-						data: payload,
-					}).unwrap()
+					id: editingRule.id,
+					data: payload,
+				}).unwrap()
 				: createRoutingRule(payload).unwrap();
 
 		submitPromise
@@ -413,10 +413,10 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 							{((scope === "team" && teamsData.teams.length === 0) ||
 								(scope === "customer" && customersData.customers.length === 0) ||
 								(scope === "virtual_key" && vksData.virtual_keys.length === 0)) && (
-								<p className="text-muted-foreground text-sm">
-									No {scope === "team" ? "teams" : scope === "customer" ? "customers" : "virtual keys"} available
-								</p>
-							)}
+									<p className="text-muted-foreground text-sm">
+										No {scope === "team" ? "teams" : scope === "customer" ? "customers" : "virtual keys"} available
+									</p>
+								)}
 							{errors.scope_id && <p className="text-destructive text-sm">{errors.scope_id.message}</p>}
 						</div>
 					)}
@@ -497,7 +497,11 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 					{/* Fallbacks */}
 					<div className="space-y-3">
 						<div className="flex items-center justify-between">
-							<Label>Fallbacks</Label>
+							<div>
+								<Label>Fallbacks</Label>								<p className="text-muted-foreground text-xs mt-0.5">
+									Provider is required, but model is optional. Leave model empty to use the incoming request value.
+								</p>
+							</div>
 							<Button
 								type="button"
 								variant="outline"
@@ -564,7 +568,7 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 													provider={fbProvider || undefined}
 													value={fbModel}
 													onChange={handleModelChange}
-													placeholder="Select model..."
+													placeholder="Incoming (optional)"
 													isSingleSelect
 													disabled={!fbProvider}
 													className="!h-9 !min-h-9 w-full"


### PR DESCRIPTION
## Summary

Fixes a bug in the logging plugin's `PostLLMHook` where the pending log entry was not being loaded before the tracer and streaming chunk logic ran. This caused error log entries to miss the `Object` field and use stale model alias values, and also meant the request type fallback from pending data was never applied before the streaming early-return path.

## Changes

- Moved the `pendingLogsEntries.LoadAndDelete` call to occur before the tracer initialization and streaming chunk early-return logic, ensuring pending data is always available when needed.
- Added `Object` field (populated from `requestType`) to error log entries so the request type is correctly recorded on failure paths.
- Changed `applyModelAlias` in the error path to use `originalModelRequested` and `resolvedModelUsed` local variables instead of `bifrostErr.ExtraFields` fields, aligning it with how the success path works.
- Added a fallback that resets `requestType` to the value stored in `pending.InitialData.Object` if they differ, guarding against cases where a plugin modifies the request type mid-pipeline.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger a request that results in an LLM error and verify the logged entry contains a populated `Object` field and correct model alias values. Also verify that streaming requests still accumulate chunks correctly and only write to the DB on the final chunk.

```sh
go test ./plugins/logging/...
```

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable