### PR TITLE
feat: add `provider_key_name` alias for routing targets and pricing overrides, resolved to `key_id` at config load time

### DIFF
--- a/examples/k8s/examples/values-governance-teams.yaml
+++ b/examples/k8s/examples/values-governance-teams.yaml
@@ -25,3 +25,4 @@ bifrost:
         customer_id: "customer-acme"
         budget_id: "budget-team-default"
         rate_limit_id: "rl-team-default"
+

--- a/examples/k8s/examples/values-providers.yaml
+++ b/examples/k8s/examples/values-providers.yaml
@@ -18,9 +18,6 @@ bifrost:
         extra_headers:
           x-bf-example-header-enabled: "true"
           x-bf-example-header-value: "example"
-        # Per-beta-header support overrides (true/false).
-        beta_header_overrides:
-          output-128k-2025-02-19: true
       # Debug/response visibility controls
       send_back_raw_request: true
       send_back_raw_response: true
@@ -75,6 +72,9 @@ bifrost:
       #   type: "none"
       # custom_provider_config:
       #   base_provider_type: "anthropic"
+      # Per-beta-header support overrides (true/false). Applicable for Anthropic only.
+      # beta_header_overrides:
+        # output-128k-2025-02-19: true
       keys:
         - name: "anthropic-key"
           value: "env.ANTHROPIC_API_KEY"

--- a/examples/k8s/examples/values-with-routing-rules-pricing.yaml
+++ b/examples/k8s/examples/values-with-routing-rules-pricing.yaml
@@ -184,19 +184,39 @@ bifrost:
               value: "gpt-4o-mini"
       - id: "route-vk-team-specific"
         name: "VK specific fallback route"
-        description: "Route high-tier key traffic to OpenAI primary."
+        description: "UI-friendly chained rule: remap OpenAI mini traffic, then re-evaluate."
         enabled: true
-        # CEL variables use snake_case (see routing engine); virtual_key_id is the VK id from governance.virtualKeys.
-        # No query here: virtual_key_id is not in the dashboard field list, so use cel_expression only for this condition.
-        cel_expression: 'virtual_key_id == "vk-routing-demo"'
+        chain_rule: true
+        # UI-supported CEL fields example (model/provider are available in Query Builder).
+        cel_expression: "model == 'gpt-4o-mini' && provider == 'openai'"
         targets:
           - provider: "openai"
             model: "gpt-4o-mini"
+            # provider_key_name is resolved to internal key_id at config load time.
+            # This matches "bifrost.providers.openai.keys[].name" below.
+            provider_key_name: "openai-limited-key"
             weight: 0.7
-          - weight: 0.3
+          - provider: "anthropic"
+            model: "claude-3-5-sonnet-latest"
+            weight: 0.3
+        fallbacks:
+          - "openai/gpt-4o-mini"
+          - "anthropic/claude-3-5-sonnet-latest"
         scope: "virtual_key"
         scope_id: "vk-routing-demo"
         priority: 1
+        # Optional dashboard rule-builder state (react-querybuilder). Runtime uses cel_expression only.
+        query:
+          combinator: and
+          rules:
+            - id: route-mini-model-openai
+              field: model
+              operator: "="
+              value: "gpt-4o-mini"
+            - id: route-mini-provider-openai
+              field: provider
+              operator: "="
+              value: "openai"
 
     # Runtime pricing patches used by the model catalog.
     pricingOverrides:
@@ -229,6 +249,15 @@ bifrost:
           - "chat_completion"
           - "responses"
         pricing_patch: "{\"input_cost_per_token\":0.00000040,\"output_cost_per_token\":0.00000120}"
+      - id: "override-provider-key-by-name-exact"
+        name: "Provider key exact override by key name"
+        scope_kind: "provider_key"
+        provider_key_name: "openai-limited-key"
+        match_type: "exact"
+        pattern: "gpt-4o-mini"
+        request_types:
+          - "chat_completion"
+        pricing_patch: "{\"input_cost_per_token\":0.00000045,\"output_cost_per_token\":0.00000135}"
 
   # Access profile model policy fields (all_models_allowed + allowed_models).
   accessProfiles:

--- a/framework/configstore/tables/pricingoverride.go
+++ b/framework/configstore/tables/pricingoverride.go
@@ -16,6 +16,7 @@ type TablePricingOverride struct {
 	VirtualKeyID     *string   `gorm:"type:varchar(255);index:idx_pricing_override_scope" json:"virtual_key_id,omitempty"`
 	ProviderID       *string   `gorm:"type:varchar(255);index:idx_pricing_override_scope" json:"provider_id,omitempty"`
 	ProviderKeyID    *string   `gorm:"type:varchar(255);index:idx_pricing_override_scope" json:"provider_key_id,omitempty"`
+	ProviderKeyName  *string   `gorm:"-" json:"provider_key_name,omitempty"` // config-only alias; resolved to provider_key_id during load
 	MatchType        string    `gorm:"type:varchar(20);index:idx_pricing_override_match;not null" json:"match_type"`
 	Pattern          string    `gorm:"type:varchar(255);not null" json:"pattern"`
 	RequestTypesJSON string    `gorm:"type:text" json:"-"`

--- a/framework/configstore/tables/routing_rules.go
+++ b/framework/configstore/tables/routing_rules.go
@@ -88,11 +88,12 @@ func (r *TableRoutingRule) AfterFind(tx *gorm.DB) error {
 // the probability of each target being selected and must sum to 1 across all targets in a rule.
 // The composite (RuleID, Provider, Model, KeyID) is unique to prevent duplicate target configs.
 type TableRoutingTarget struct {
-	RuleID   string  `gorm:"type:varchar(255);not null;index;uniqueIndex:idx_routing_target_config" json:"-"`
-	Provider *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"provider,omitempty"` // nil = use incoming provider
-	Model    *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"model,omitempty"`    // nil = use incoming model
-	KeyID    *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"key_id,omitempty"`   // nil = no key pin
-	Weight   float64 `gorm:"not null;default:1" json:"weight"`                                                  // must sum to 1 across all targets in a rule
+	RuleID          string  `gorm:"type:varchar(255);not null;index;uniqueIndex:idx_routing_target_config" json:"-"`
+	Provider        *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"provider,omitempty"` // nil = use incoming provider
+	Model           *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"model,omitempty"`    // nil = use incoming model
+	KeyID           *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"key_id,omitempty"`   // persisted key pin
+	ProviderKeyName *string `gorm:"-" json:"provider_key_name,omitempty"`                                               // config-only alias; resolved to key_id during load
+	Weight          float64 `gorm:"not null;default:1" json:"weight"`                                                  // must sum to 1 across all targets in a rule
 }
 
 // TableName for TableRoutingTarget

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1174,9 +1174,9 @@
                           "type": "string",
                           "description": "Target model name"
                         },
-                        "key_id": {
+                        "provider_key_name": {
                           "type": "string",
-                          "description": "Optional API key UUID to pin for this target"
+                          "description": "Optional provider key name. Resolved to internal key_id at config load time."
                         },
                         "weight": {
                           "type": "number",
@@ -1281,8 +1281,8 @@
                     "description": "Scope level for this override"
                   },
                   "virtual_key_id": { "type": "string", "description": "Virtual key ID (required for virtual_key* scopes)" },
-                  "provider_id": { "type": "string", "description": "Provider ID (required for provider* scopes)" },
-                  "provider_key_id": { "type": "string", "description": "Provider key ID (required for provider_key and virtual_key_provider_key scopes)" },
+                  "provider_id": { "type": "string", "description": "Provider name (required for provider* scopes; field key remains provider_id for compatibility)" },
+                  "provider_key_name": { "type": "string", "description": "Provider key name alias. Resolved to internal provider key ID at config load time." },
                   "match_type": {
                     "type": "string",
                     "enum": ["exact", "wildcard"],

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -516,11 +516,21 @@ bifrost:
       #   targets:
       #     - provider: "azure"
       #       model: ""              # Empty means use original model
+      #       provider_key_name: ""  # Optional provider key name (resolved to internal key_id at load time)
       #       weight: 1.0
       #   fallbacks: ["openai"]
       #   scope: "global"           # Options: global, team, customer, virtual_key
       #   scope_id: ""              # Required for non-global scopes
       #   priority: 0               # Lower = evaluated first
+    pricingOverrides: []
+      # - id: "override-1"
+      #   name: "Provider key pricing override"
+      #   scope_kind: "provider_key" # global|provider|provider_key|virtual_key|virtual_key_provider|virtual_key_provider_key
+      #   provider_key_name: ""      # Optional provider key name alias (resolved to internal provider key ID at load time)
+      #   match_type: "exact"        # exact|wildcard
+      #   pattern: "gpt-4o-mini"
+      #   request_types: ["chat_completion"]
+      #   pricing_patch: "{\"input_cost_per_token\":0.000001,\"output_cost_per_token\":0.000002}"
     authConfig:
       adminUsername: ""
       adminPassword: ""

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1125,6 +1125,12 @@ func mergeMCPConfig(ctx context.Context, config *Config, configData *ConfigData,
 
 // loadGovernanceConfig loads and merges governance config from file
 func loadGovernanceConfig(ctx context.Context, config *Config, configData *ConfigData) {
+	if configData.Governance != nil {
+		if err := resolveGovernanceKeyReferences(ctx, config, configData.Governance); err != nil {
+			logger.Fatal("failed to resolve governance key references: %v", err)
+		}
+	}
+
 	var governanceConfig *configstore.GovernanceConfig
 	var err error
 	// Checking from the store
@@ -1154,6 +1160,127 @@ func loadGovernanceConfig(ctx context.Context, config *Config, configData *Confi
 	} else {
 		logger.Debug("no governance config in store or config file")
 	}
+}
+
+func resolveGovernanceKeyReferences(ctx context.Context, config *Config, governanceConfig *configstore.GovernanceConfig) error {
+	if governanceConfig == nil {
+		return nil
+	}
+
+	usesNameRefs := false
+	for i := range governanceConfig.RoutingRules {
+		for j := range governanceConfig.RoutingRules[i].Targets {
+			target := &governanceConfig.RoutingRules[i].Targets[j]
+			if target.ProviderKeyName != nil && strings.TrimSpace(*target.ProviderKeyName) != "" {
+				usesNameRefs = true
+				break
+			}
+		}
+		if usesNameRefs {
+			break
+		}
+	}
+	if !usesNameRefs {
+		for i := range governanceConfig.PricingOverrides {
+			override := &governanceConfig.PricingOverrides[i]
+			if override.ProviderKeyName != nil && strings.TrimSpace(*override.ProviderKeyName) != "" {
+				usesNameRefs = true
+				break
+			}
+		}
+	}
+	if !usesNameRefs {
+		return nil
+	}
+	if config.ConfigStore == nil {
+		return fmt.Errorf("provider_key_name references require config store for key lookup")
+	}
+
+	return config.ConfigStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+		resolveProviderKeyIDByProviderAndName := func(provider string, keyName string) (string, error) {
+			var key configstoreTables.TableKey
+			err := tx.WithContext(ctx).
+				Model(&configstoreTables.TableKey{}).
+				Select("key_id").
+				Where("LOWER(provider) = LOWER(?) AND name = ?", provider, keyName).
+				First(&key).Error
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return "", fmt.Errorf("provider key not found for provider=%q name=%q", provider, keyName)
+			}
+			if err != nil {
+				return "", err
+			}
+			return key.KeyID, nil
+		}
+
+		resolveProviderKeyIDByName := func(keyName string) (string, error) {
+			var key configstoreTables.TableKey
+			err := tx.WithContext(ctx).
+				Model(&configstoreTables.TableKey{}).
+				Select("key_id").
+				Where("name = ?", keyName).
+				First(&key).Error
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return "", fmt.Errorf("provider key not found for name=%q", keyName)
+			}
+			if err != nil {
+				return "", err
+			}
+			return key.KeyID, nil
+		}
+
+		for i := range governanceConfig.RoutingRules {
+			for j := range governanceConfig.RoutingRules[i].Targets {
+				target := &governanceConfig.RoutingRules[i].Targets[j]
+				keyName := ""
+				if target.ProviderKeyName != nil {
+					keyName = strings.TrimSpace(*target.ProviderKeyName)
+				}
+				if keyName == "" {
+					target.ProviderKeyName = nil
+					continue
+				}
+				if target.KeyID != nil && strings.TrimSpace(*target.KeyID) != "" {
+					return fmt.Errorf("routing rule %q target cannot set key_id together with provider_key_name", governanceConfig.RoutingRules[i].ID)
+				}
+				if target.Provider == nil || strings.TrimSpace(*target.Provider) == "" {
+					return fmt.Errorf("routing rule %q target provider_key_name requires provider to be set", governanceConfig.RoutingRules[i].ID)
+				}
+
+				keyID, err := resolveProviderKeyIDByProviderAndName(*target.Provider, keyName)
+				if err != nil {
+					return fmt.Errorf("routing rule %q target provider_key_name resolution failed: %w", governanceConfig.RoutingRules[i].ID, err)
+				}
+				target.KeyID = bifrost.Ptr(keyID)
+				target.ProviderKeyName = nil
+			}
+		}
+
+		for i := range governanceConfig.PricingOverrides {
+			override := &governanceConfig.PricingOverrides[i]
+			if override.ProviderKeyName == nil {
+				continue
+			}
+
+			keyName := strings.TrimSpace(*override.ProviderKeyName)
+			if keyName == "" {
+				override.ProviderKeyName = nil
+				continue
+			}
+			if override.ProviderKeyID != nil && strings.TrimSpace(*override.ProviderKeyID) != "" {
+				return fmt.Errorf("pricing override %q cannot set both provider_key_id and provider_key_name", override.ID)
+			}
+
+			keyID, err := resolveProviderKeyIDByName(keyName)
+			if err != nil {
+				return fmt.Errorf("pricing override %q provider_key_name resolution failed: %w", override.ID, err)
+			}
+			override.ProviderKeyID = bifrost.Ptr(keyID)
+			override.ProviderKeyName = nil
+		}
+
+		return nil
+	})
 }
 
 // mergeGovernanceConfig merges governance config from file with store

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1586,10 +1586,10 @@
           "minLength": 1,
           "description": "Target model name. Omit to use the incoming request model"
         },
-        "key_id": {
+        "provider_key_name": {
           "type": "string",
           "minLength": 1,
-          "description": "Optional API key UUID to pin for this target. Omit for load-balanced key selection"
+          "description": "Optional provider key name. Resolved to internal key_id at config load time. Requires provider."
         },
         "weight": {
           "type": "number",
@@ -3775,11 +3775,11 @@
         },
         "provider_id": {
           "type": "string",
-          "description": "Provider ID (required for provider* scopes)"
+          "description": "Provider name (required for provider* scopes; field key remains provider_id for compatibility)"
         },
-        "provider_key_id": {
+        "provider_key_name": {
           "type": "string",
-          "description": "Provider key ID (required for provider_key and virtual_key_provider_key scopes)"
+          "description": "Provider key name alias. Resolved to internal provider key ID at config load time."
         },
         "match_type": {
           "type": "string",


### PR DESCRIPTION
## Summary

Introduces `provider_key_name` as a human-readable alias for `provider_key_id`/`key_id` in routing rule targets and pricing overrides. Previously, configs required knowing the internal UUID of a provider key; now a key's name can be specified directly and is resolved to its UUID at config load time via a database lookup.

## Changes

- Added `ProviderKeyName` field (GORM-ignored, config-only) to `TableRoutingTarget` and `TablePricingOverride`, resolved to `KeyID`/`ProviderKeyID` during governance config load.
- Added `resolveGovernanceKeyReferences` function that performs DB lookups within a transaction to resolve key names to UUIDs before the governance config is merged into the store. Routing targets require `provider` to be set alongside `provider_key_name`; pricing overrides resolve by name alone. Conflicts between `provider_key_name` and the explicit UUID fields are treated as fatal errors.
- Moved `beta_header_overrides` in the providers example config to be scoped under Anthropic only, with a comment clarifying it is Anthropic-specific.
- Added `chain_rule: true`, explicit `provider`/`model` on all targets, `provider_key_name` usage, `fallbacks`, and a `query` block (react-querybuilder state) to the `route-vk-team-specific` routing rule example.
- Added `provider_key` scoped pricing override examples using both `provider_key_id` (UUID) and `provider_key_name` (name alias).
- Reduced the default PostgreSQL persistence size in the storage example from 8Gi to 2Gi.
- Updated JSON schemas (`config.schema.json` and `values.schema.json`) to replace `key_id` with `provider_key_name` on routing targets and add `provider_key_name` to pricing overrides.
- Added `pricingOverrides` stub to `values.yaml` with commented examples.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Configure a routing rule target with `provider_key_name` pointing to an existing provider key name and verify it resolves to the correct `key_id` at startup.
2. Configure a pricing override with `provider_key_name` and confirm it resolves to the correct `provider_key_id`.
3. Verify that setting both `provider_key_name` and the explicit UUID field (`key_id` or `provider_key_id`) on the same entry causes a fatal error at startup.
4. Verify that a routing target with `provider_key_name` but no `provider` set causes a fatal error at startup.
5. Verify that an unknown `provider_key_name` causes a fatal error at startup.

```sh
go test ./...
```

## Breaking changes

- [x] Yes
- [ ] No

The `key_id` field on routing targets has been replaced by `provider_key_name` in the JSON schema. Any existing configs using `key_id` directly on a routing target will no longer match the schema. Migrate by replacing `key_id` with `provider_key_name` (using the key's name) or by pinning the UUID through the database directly.

## Related issues

## Security considerations

Key name-to-UUID resolution is performed inside a database transaction at config load time. No key secrets or values are exposed; only internal UUIDs are resolved and stored in memory.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable