### PR TITLE
feat: add Go duration string support for `tool_sync_interval` and hash-based MCP client config reconciliation

### DIFF
--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -4,8 +4,14 @@
 package schemas
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"strconv"
 	"strings"
 	"time"
 
@@ -60,6 +66,51 @@ type MCPConfig struct {
 	// ReleasePluginPipeline releases a plugin pipeline back to the pool.
 	// This should be called after the plugin pipeline is no longer needed.
 	ReleasePluginPipeline func(pipeline interface{}) `json:"-"`
+}
+
+// UnmarshalJSON supports Go duration strings (e.g. "10m") for tool_sync_interval.
+// Numeric values remain supported for backward compatibility (treated as raw nanoseconds).
+func (c *MCPConfig) UnmarshalJSON(data []byte) error {
+	type alias MCPConfig
+	aux := &struct {
+		ToolSyncInterval *json.Number `json:"tool_sync_interval,omitempty"`
+		*alias
+	}{alias: (*alias)(c)}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(aux); err == nil {
+		if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+			return errors.New("trailing JSON data")
+		}
+		if aux.ToolSyncInterval == nil {
+			return nil
+		}
+		dur, parseErr := parseFlexibleDurationField(*aux.ToolSyncInterval, "tool_sync_interval")
+		if parseErr != nil {
+			return parseErr
+		}
+		c.ToolSyncInterval = dur
+		return nil
+	}
+
+	// Allow Go duration strings while keeping numeric tokens as json.Number.
+	auxStr := &struct {
+		ToolSyncInterval *string `json:"tool_sync_interval,omitempty"`
+		*alias
+	}{alias: (*alias)(c)}
+	if err := json.Unmarshal(data, auxStr); err != nil {
+		return err
+	}
+	if auxStr.ToolSyncInterval == nil {
+		return nil
+	}
+	dur, err := parseFlexibleDurationField(*auxStr.ToolSyncInterval, "tool_sync_interval")
+	if err != nil {
+		return err
+	}
+	c.ToolSyncInterval = dur
+	return nil
 }
 
 type MCPToolManagerConfig struct {
@@ -128,6 +179,102 @@ type MCPClientConfig struct {
 	// Discovered tools for per-user OAuth clients (persisted so they survive restart)
 	DiscoveredTools           map[string]ChatTool `json:"-"` // Discovered tool schemas keyed by prefixed name
 	DiscoveredToolNameMapping map[string]string   `json:"-"` // Mapping from sanitized tool names to original MCP names
+}
+
+// UnmarshalJSON supports Go duration strings (e.g. "10m") for tool_sync_interval.
+// Numeric values remain supported for backward compatibility (treated as raw nanoseconds).
+func (c *MCPClientConfig) UnmarshalJSON(data []byte) error {
+	type alias MCPClientConfig
+	aux := &struct {
+		ToolSyncInterval *json.Number `json:"tool_sync_interval,omitempty"`
+		*alias
+	}{alias: (*alias)(c)}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(aux); err == nil {
+		if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+			return errors.New("trailing JSON data")
+		}
+		if aux.ToolSyncInterval == nil {
+			return nil
+		}
+		dur, parseErr := parseFlexibleDurationField(*aux.ToolSyncInterval, "tool_sync_interval")
+		if parseErr != nil {
+			return parseErr
+		}
+		c.ToolSyncInterval = dur
+		return nil
+	}
+
+	// Allow Go duration strings while keeping numeric tokens as json.Number.
+	auxStr := &struct {
+		ToolSyncInterval *string `json:"tool_sync_interval,omitempty"`
+		*alias
+	}{alias: (*alias)(c)}
+	if err := json.Unmarshal(data, auxStr); err != nil {
+		return err
+	}
+	if auxStr.ToolSyncInterval == nil {
+		return nil
+	}
+	dur, err := parseFlexibleDurationField(*auxStr.ToolSyncInterval, "tool_sync_interval")
+	if err != nil {
+		return err
+	}
+	c.ToolSyncInterval = dur
+	return nil
+}
+
+func parseFlexibleDurationField(v any, fieldName string) (time.Duration, error) {
+	switch t := v.(type) {
+	case string:
+		d, err := time.ParseDuration(strings.TrimSpace(t))
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s duration %q: %w", fieldName, t, err)
+		}
+		return d, nil
+	case json.Number:
+		raw := strings.TrimSpace(t.String())
+		if raw == "" {
+			return 0, fmt.Errorf("invalid %s: empty numeric value", fieldName)
+		}
+		if strings.Contains(raw, ".") {
+			return 0, fmt.Errorf("invalid %s value %q: fractional numeric values are not allowed; use an integer nanosecond value or a duration string like \"10m\"", fieldName, raw)
+		}
+
+		// Keep parity with JavaScript-safe integer range for config interchange.
+		const maxSafeJSONInt int64 = 9007199254740991
+		const minSafeJSONInt int64 = -9007199254740991
+
+		var ns int64
+		if strings.ContainsAny(raw, "eE") {
+			rat := new(big.Rat)
+			if _, ok := rat.SetString(raw); !ok {
+				return 0, fmt.Errorf("invalid %s value %q: expected an integer nanosecond value", fieldName, raw)
+			}
+			if rat.Denom().Cmp(big.NewInt(1)) != 0 {
+				return 0, fmt.Errorf("invalid %s value %q: fractional numeric values are not allowed; use an integer nanosecond value or a duration string like \"10m\"", fieldName, raw)
+			}
+			if !rat.Num().IsInt64() {
+				return 0, fmt.Errorf("invalid %s value %q: out of int64 range for nanoseconds", fieldName, raw)
+			}
+			ns = rat.Num().Int64()
+		} else {
+			parsed, err := strconv.ParseInt(raw, 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid %s value %q: expected an integer nanosecond value", fieldName, raw)
+			}
+			ns = parsed
+		}
+
+		if ns < minSafeJSONInt || ns > maxSafeJSONInt {
+			return 0, fmt.Errorf("invalid %s value %q: exceeds safe integer range", fieldName, raw)
+		}
+		return time.Duration(ns), nil
+	default:
+		return 0, fmt.Errorf("invalid %s type %T: expected duration string (e.g. \"10m\") or number", fieldName, v)
+	}
 }
 
 // NewMCPClientConfigFromMap creates a new MCP client config from a map[string]any.

--- a/core/schemas/mcp_json_test.go
+++ b/core/schemas/mcp_json_test.go
@@ -1,0 +1,63 @@
+package schemas
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytedance/sonic"
+)
+
+func TestMCPConfigUnmarshalToolSyncIntervalString(t *testing.T) {
+	raw := []byte(`{"tool_sync_interval":"10m"}`)
+	var cfg MCPConfig
+	if err := sonic.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if cfg.ToolSyncInterval != 10*time.Minute {
+		t.Fatalf("expected 10m, got %v", cfg.ToolSyncInterval)
+	}
+}
+
+func TestMCPClientConfigUnmarshalToolSyncIntervalString(t *testing.T) {
+	raw := []byte(`{"name":"demo","connection_type":"stdio","tool_sync_interval":"30s"}`)
+	var cfg MCPClientConfig
+	if err := sonic.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if cfg.ToolSyncInterval != 30*time.Second {
+		t.Fatalf("expected 30s, got %v", cfg.ToolSyncInterval)
+	}
+}
+
+func TestMCPConfigUnmarshalToolSyncIntervalInvalidString(t *testing.T) {
+	raw := []byte(`{"tool_sync_interval":"not-a-duration"}`)
+	var cfg MCPConfig
+	if err := sonic.Unmarshal(raw, &cfg); err == nil {
+		t.Fatal("expected unmarshal error for invalid duration, got nil")
+	}
+}
+
+func TestMCPConfigUnmarshalToolSyncIntervalIntegerNumber(t *testing.T) {
+	raw := []byte(`{"tool_sync_interval":60000000000}`)
+	var cfg MCPConfig
+	if err := sonic.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if cfg.ToolSyncInterval != time.Minute {
+		t.Fatalf("expected 1m, got %v", cfg.ToolSyncInterval)
+	}
+}
+
+func TestMCPConfigUnmarshalToolSyncIntervalRejectsFractionalNumber(t *testing.T) {
+	raw := []byte(`{"tool_sync_interval":1.5}`)
+	var cfg MCPConfig
+	err := sonic.Unmarshal(raw, &cfg)
+	if err == nil {
+		t.Fatal("expected error for fractional numeric duration, got nil")
+	}
+	if !strings.Contains(err.Error(), "fractional numeric values are not allowed") {
+		t.Fatalf("expected fractional-value error, got: %v", err)
+	}
+}
+

--- a/docs/deployment-guides/helm/client.mdx
+++ b/docs/deployment-guides/helm/client.mdx
@@ -248,16 +248,21 @@ bifrost:
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `bifrost.client.mcpAgentDepth` | Maximum tool-call recursion depth for MCP agent mode | `10` |
-| `bifrost.client.mcpToolExecutionTimeout` | Timeout per tool execution in seconds | `30` |
-| `bifrost.client.mcpCodeModeBindingLevel` | Code mode binding level (`server` or `tool`) | `""` |
-| `bifrost.client.mcpToolSyncInterval` | Global tool sync interval in minutes (`0` = disabled) | `0` |
+| `bifrost.mcp.toolManagerConfig.maxAgentDepth` | Maximum tool-call recursion depth for MCP agent mode | `10` |
+| `bifrost.mcp.toolManagerConfig.toolExecutionTimeout` | Timeout per tool execution in seconds | `30` |
+| `bifrost.mcp.toolManagerConfig.codeModeBindingLevel` | Code mode binding level (`server` or `tool`) | `server` |
+| `bifrost.mcp.toolManagerConfig.disableAutoToolInject` | Disable automatic MCP tool injection | `false` |
+| `bifrost.mcp.toolSyncInterval` | Global tool sync interval as a Go duration string (for example `10m`). Use `0s` to use the runtime default (it does **not** disable sync). This differs from legacy `bifrost.client.mcpToolSyncInterval: 0`, which represented disabled behavior. | `10m` |
 
 ```yaml
 bifrost:
-  client:
-    mcpAgentDepth: 15
-    mcpToolExecutionTimeout: 60
+  mcp:
+    toolSyncInterval: "15m"
+    toolManagerConfig:
+      maxAgentDepth: 15
+      toolExecutionTimeout: 60
+      codeModeBindingLevel: "tool"
+      disableAutoToolInject: false
 ```
 
 ---
@@ -298,8 +303,13 @@ bifrost:
     prometheusLabels:
       - name: "environment"
         value: "production"
-    mcpAgentDepth: 10
-    mcpToolExecutionTimeout: 30
+  mcp:
+    toolSyncInterval: "10m"
+    toolManagerConfig:
+      maxAgentDepth: 10
+      toolExecutionTimeout: 30
+      codeModeBindingLevel: "server"
+      disableAutoToolInject: false
 ```
 
 ```bash

--- a/examples/k8s/examples/README.md
+++ b/examples/k8s/examples/README.md
@@ -8,6 +8,7 @@ These examples are split into composable value files so you can combine them wit
 - `values-storage-sqlite.yaml` - Storage layer for SQLite StatefulSet mode
 - `values-storage-postgres.yaml` - Storage layer for Postgres mode (chart-managed Postgres)
 - `values-providers.yaml` - Provider keys layer (`openai` + `anthropic`)
+- `values-mcp-routing.yaml` - MCP + routing layer (latest `mcp.*` globals, MCP client config, chain rule/fallback examples)
 - `values-governance-teams.yaml` - Governance base layer (budgets, rate limits, customers, teams)
 - `values-with-routing-rules-pricing.yaml` - Advanced governance layer (virtual keys, routing rules, pricing overrides, access profile)
 - `values-with-pod-label.yaml` - Pod label overlay for StatefulSet template change testing
@@ -85,6 +86,16 @@ helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
   -f examples/k8s/examples/values-providers.yaml \
   -f examples/k8s/examples/values-governance-teams.yaml \
   -f examples/k8s/examples/values-with-routing-rules-pricing.yaml \
+  --wait \
+  --timeout 5m
+
+# MCP + routing stack (SQLite + providers + MCP/routing overlay)
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-sqlite.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/examples/values-mcp-routing.yaml \
   --wait \
   --timeout 5m
 

--- a/examples/k8s/examples/values-mcp-routing.yaml
+++ b/examples/k8s/examples/values-mcp-routing.yaml
@@ -1,0 +1,136 @@
+bifrost:
+  # MCP (Model Context Protocol) example layer using latest mcp.* settings
+  mcp:
+    enabled: true
+    # Global MCP tool sync interval as Go duration string.
+    toolSyncInterval: "15m"
+    clientConfigs:
+      # This one is best for quickly seeing entries in MCP Catalog/Registry UI.
+      # It does not depend on npx/node inside the Bifrost container.
+      - name: "echo_http"
+        connectionType: "http"
+        httpConfig:
+          url: "https://mcpplaygroundonline.com/mcp-echo-server"
+        authType: "none"
+        allowOnAllVirtualKeys: true
+        toolsToExecute:
+          - "*"
+      - name: "github_tools"
+        connectionType: "stdio"
+        allowOnAllVirtualKeys: true
+        toolsToExecute:
+          - "*"
+        stdioConfig:
+          command: "npx"
+          args:
+            - "-y"
+            - "@modelcontextprotocol/server-github"
+          envs:
+            - "GITHUB_PERSONAL_ACCESS_TOKEN=env.GITHUB_PERSONAL_ACCESS_TOKEN"
+      - name: "filesystem_tools"
+        connectionType: "stdio"
+        allowOnAllVirtualKeys: true
+        toolsToExecute:
+          - "*"
+        stdioConfig:
+          command: "npx"
+          args:
+            - "-y"
+            - "@modelcontextprotocol/server-filesystem"
+            - "/app/data"
+          envs: []
+    toolManagerConfig:
+      # Tool execution timeout in seconds
+      toolExecutionTimeout: 23
+      # Maximum MCP agent execution depth
+      maxAgentDepth: 14
+      # How tools are exposed in VFS: "server" or "tool"
+      codeModeBindingLevel: "server"
+      # When true, tools are injected only when explicitly requested
+      disableAutoToolInject: false
+
+  governance:
+    budgets:
+      - id: "budget-mcp-default"
+        max_limit: 600
+        reset_duration: "1M"
+    rateLimits:
+      - id: "rl-mcp-default"
+        token_max_limit: 200000
+        token_reset_duration: "1d"
+        request_max_limit: 5000
+        request_reset_duration: "1h"
+    customers:
+      - id: "customer-mcp-demo"
+        name: "MCP Demo Customer"
+        budget_id: "budget-mcp-default"
+        rate_limit_id: "rl-mcp-default"
+    teams:
+      - id: "team-mcp-demo"
+        name: "MCP Demo Team"
+        customer_id: "customer-mcp-demo"
+        budget_id: "budget-mcp-default"
+        rate_limit_id: "rl-mcp-default"
+    virtualKeys:
+      - id: "vk-mcp-demo"
+        name: "MCP Demo Key"
+        value: "sk-bf-mcp-demo"
+        is_active: true
+        team_id: "team-mcp-demo"
+        rate_limit_id: "rl-mcp-default"
+
+    # Keep routing config compatible with released schema versions.
+    routingRules:
+      - id: "route-mcp-openai-mini"
+        name: "MCP route OpenAI mini"
+        description: "UI-friendly MCP routing rule."
+        enabled: true
+        chain_rule: true
+        cel_expression: "model == 'gpt-4o-mini' && provider == 'openai'"
+        targets:
+          - provider: "openai"
+            model: "gpt-4o-mini"
+            weight: 0.7
+          - provider: "anthropic"
+            model: "claude-3-5-sonnet-latest"
+            weight: 0.3
+        fallbacks:
+          - "openai/gpt-4o-mini"
+          - "anthropic/claude-3-5-sonnet-latest"
+        scope: "global"
+        priority: 10
+        query:
+          combinator: and
+          rules:
+            - id: route-mini-model
+              field: model
+              operator: "="
+              value: "gpt-4o-mini"
+            - id: route-mini-provider
+              field: provider
+              operator: "="
+              value: "openai"
+      - id: "route-vk-scoped-anthropic"
+        name: "VK scoped Anthropic route"
+        description: "Example scoped rule with virtual_key scope and no query metadata."
+        enabled: false
+        chain_rule: false
+        cel_expression: "provider == 'anthropic'"
+        targets:
+          - provider: "anthropic"
+            model: "claude-3-5-sonnet-latest"
+            weight: 1
+        scope: "virtual_key"
+        scope_id: "vk-mcp-demo"
+        priority: 20
+
+    pricingOverrides:
+      - id: "override-global-mini"
+        name: "Global mini pricing override"
+        scope_kind: "global"
+        match_type: "exact"
+        pattern: "gpt-4o-mini"
+        request_types:
+          - "chat_completion"
+          - "responses"
+        pricing_patch: "{\"input_cost_per_token\":0.00000050,\"output_cost_per_token\":0.00000150}"

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1138,12 +1138,9 @@ func GeneratePricingOverrideHash(p tables.TablePricingOverride) (string, error) 
 
 // GenerateMCPClientHash generates a SHA256 hash for an MCP client.
 // This is used to detect changes to MCP clients between config.json and database.
-// Skips: ID (autoIncrement), CreatedAt, UpdatedAt (dynamic fields)
+// Skips: ID (autoIncrement), ClientID (system-assigned), CreatedAt, UpdatedAt (dynamic fields)
 func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 	hash := sha256.New()
-
-	// Hash ClientID
-	hash.Write([]byte(m.ClientID))
 
 	// Hash Name
 	hash.Write([]byte(m.Name))

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -614,6 +614,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddOCRPricingColumns(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationConvertMCPClientToolSyncIntervalMinutesToSeconds(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -3658,6 +3661,39 @@ func migrationAddToolSyncIntervalColumns(ctx context.Context, db *gorm.DB) error
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while running tool sync interval migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationConvertMCPClientToolSyncIntervalMinutesToSeconds converts legacy
+// config_mcp_clients.tool_sync_interval values from minutes to seconds.
+// Legacy storage used minutes; runtime now persists seconds to preserve
+// sub-minute precision. We only convert positive values; 0 means "use global"
+// and negative values mean "disabled".
+func migrationConvertMCPClientToolSyncIntervalMinutesToSeconds(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "convert_mcp_client_tool_sync_interval_minutes_to_seconds",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return tx.Exec(`
+				UPDATE config_mcp_clients
+				SET tool_sync_interval = tool_sync_interval * 60
+				WHERE tool_sync_interval > 0
+			`).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			// Best-effort rollback for migrated rows.
+			return tx.Exec(`
+				UPDATE config_mcp_clients
+				SET tool_sync_interval = tool_sync_interval / 60
+				WHERE tool_sync_interval > 0
+				AND tool_sync_interval % 60 = 0
+			`).Error
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running mcp client tool sync interval unit conversion migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -41,6 +41,16 @@ func getWeight(w *float64) float64 {
 	return *w
 }
 
+func toolSyncIntervalDurationToStoredSeconds(interval time.Duration) (int, error) {
+	if interval < 0 {
+		return 0, fmt.Errorf("tool_sync_interval must be non-negative, got %q", interval.String())
+	}
+	if interval%time.Second != 0 {
+		return 0, fmt.Errorf("tool_sync_interval must be a whole number of seconds, got %q", interval.String())
+	}
+	return int(interval / time.Second), nil
+}
+
 // schemaKeyFromTableKey converts a database key to a schema key.
 func schemaKeyFromTableKey(dbKey tables.TableKey) schemas.Key {
 	return schemas.Key{
@@ -1212,7 +1222,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 					Headers:                   dbClient.Headers,
 					AllowedExtraHeaders:       dbClient.AllowedExtraHeaders,
 					IsPingAvailable:           dbClient.IsPingAvailable,
-					ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Minute,
+					ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
 					ToolPricing:               dbClient.ToolPricing,
 					AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
 					DiscoveredTools:           dbClient.DiscoveredTools,
@@ -1251,7 +1261,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 			Headers:                   dbClient.Headers,
 			AllowedExtraHeaders:       dbClient.AllowedExtraHeaders,
 			IsPingAvailable:           dbClient.IsPingAvailable,
-			ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Minute,
+			ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
 			AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
 			ToolPricing:               dbClient.ToolPricing,
 			DiscoveredTools:           dbClient.DiscoveredTools,
@@ -1335,7 +1345,7 @@ func (s *RDBConfigStore) GetMCPClientConfigByID(ctx context.Context, id string) 
 		Headers:                   dbClient.Headers,
 		AllowedExtraHeaders:       dbClient.AllowedExtraHeaders,
 		IsPingAvailable:           dbClient.IsPingAvailable,
-		ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Minute,
+		ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
 		AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
 		ToolPricing:               dbClient.ToolPricing,
 		DiscoveredTools:           dbClient.DiscoveredTools,
@@ -1368,6 +1378,10 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 			return err
 		}
 		// Create new client
+		toolSyncIntervalSec, err := toolSyncIntervalDurationToStoredSeconds(clientConfigCopy.ToolSyncInterval)
+		if err != nil {
+			return err
+		}
 		dbClient := tables.TableMCPClient{
 			ClientID:              clientConfigCopy.ID,
 			Name:                  clientConfigCopy.Name,
@@ -1382,7 +1396,7 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 			Headers:               clientConfigCopy.Headers,
 			AllowedExtraHeaders:   clientConfigCopy.AllowedExtraHeaders,
 			IsPingAvailable:       clientConfigCopy.IsPingAvailable,
-			ToolSyncInterval:      int(clientConfigCopy.ToolSyncInterval.Minutes()),
+			ToolSyncInterval:      toolSyncIntervalSec,
 			AllowOnAllVirtualKeys: clientConfigCopy.AllowOnAllVirtualKeys,
 			// DiscoveredTools has json:"-" so deepCopy loses it; use original clientConfig
 			DiscoveredTools:           clientConfig.DiscoveredTools,
@@ -1452,6 +1466,15 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		if err != nil {
 			return fmt.Errorf("failed to marshal allowed_extra_headers: %w", err)
 		}
+		var stdioConfigJSON *string
+		if clientConfigCopy.StdioConfig != nil {
+			stdioData, marshalErr := json.Marshal(clientConfigCopy.StdioConfig)
+			if marshalErr != nil {
+				return fmt.Errorf("failed to marshal stdio_config: %w", marshalErr)
+			}
+			stdioStr := string(stdioData)
+			stdioConfigJSON = &stdioStr
+		}
 
 		if clientConfigCopy.ToolPricing == nil {
 			clientConfigCopy.ToolPricing = map[string]float64{}
@@ -1486,6 +1509,29 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		}
 		if encrypt.IsEnabled() {
 			updates["encryption_status"] = encryptionStatusEncrypted
+		}
+		// Config-file driven reconciliation passes ConfigHash. In this mode we should
+		// also sync connection/auth metadata from config.json and persist the hash.
+		if clientConfigCopy.ConfigHash != "" {
+			connectionStringToPersist := clientConfigCopy.ConnectionString
+			if encrypt.IsEnabled() && connectionStringToPersist != nil &&
+				!connectionStringToPersist.IsFromEnv() && connectionStringToPersist.GetValue() != "" {
+				// Mirror TableMCPClient.BeforeSave behavior for map-based Updates.
+				cs := *connectionStringToPersist
+				encryptedConnString, encErr := encrypt.Encrypt(cs.Val)
+				if encErr != nil {
+					return fmt.Errorf("failed to encrypt mcp connection string: %w", encErr)
+				}
+				cs.Val = encryptedConnString
+				connectionStringToPersist = &cs
+			}
+
+			updates["config_hash"] = clientConfigCopy.ConfigHash
+			updates["connection_type"] = clientConfigCopy.ConnectionType
+			updates["connection_string"] = connectionStringToPersist
+			updates["stdio_config_json"] = stdioConfigJSON
+			updates["auth_type"] = clientConfigCopy.AuthType
+			updates["oauth_config_id"] = clientConfigCopy.OauthConfigID
 		}
 
 		// Only update is_ping_available if explicitly provided (non-nil)

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -26,7 +26,7 @@ type TableMCPClient struct {
 	AllowedExtraHeadersJSON string          `gorm:"type:text" json:"-"`                              // JSON serialized []string
 	IsPingAvailable         *bool           `gorm:"default:true" json:"is_ping_available,omitempty"` // Whether the MCP server supports ping for health checks
 	ToolPricingJSON         string          `gorm:"type:text" json:"-"`                              // JSON serialized map[string]float64
-	ToolSyncInterval        int             `gorm:"default:0" json:"tool_sync_interval"`             // Per-client tool sync interval in minutes (0 = use global, -1 = disabled)
+	ToolSyncInterval        int             `gorm:"default:0" json:"tool_sync_interval"`             // Per-client tool sync interval in seconds (0 = use global, negative = disabled)
 
 	// Per-user OAuth: discovered tools persisted so they survive restart
 	DiscoveredToolsJSON       string `gorm:"type:text" json:"-"`                              // JSON serialized map[string]schemas.ChatTool

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -494,6 +494,23 @@ bifrost:
 | `bifrost.mcp.clientConfigs` | Array of MCP client configurations | `[]` |
 | `bifrost.mcp.toolManagerConfig.toolExecutionTimeout` | Tool execution timeout in seconds | `30` |
 | `bifrost.mcp.toolManagerConfig.maxAgentDepth` | Maximum agent depth | `10` |
+| `bifrost.mcp.toolManagerConfig.codeModeBindingLevel` | Code mode binding level (`server` or `tool`) | `server` |
+| `bifrost.mcp.toolManagerConfig.disableAutoToolInject` | Disable automatic MCP tool injection | `false` |
+| `bifrost.mcp.toolSyncInterval` | Global MCP tool sync interval. Prefer a Go duration string (for example, `10m`); legacy numeric nanoseconds are still supported for backward compatibility, but string format is recommended. | `10m` |
+
+#### MCP Migration Guide (`client.mcp*` -> `mcp.*`)
+
+Prefer MCP settings under `bifrost.mcp` going forward. Older `bifrost.client.mcp*`
+keys are retained for backward compatibility, but new configs should migrate to the
+`mcp.toolManagerConfig` and `mcp.toolSyncInterval` fields.
+
+| Old key | New key |
+|---------|---------|
+| `bifrost.client.mcpAgentDepth` | `bifrost.mcp.toolManagerConfig.maxAgentDepth` |
+| `bifrost.client.mcpToolExecutionTimeout` | `bifrost.mcp.toolManagerConfig.toolExecutionTimeout` |
+| `bifrost.client.mcpCodeModeBindingLevel` | `bifrost.mcp.toolManagerConfig.codeModeBindingLevel` |
+| `bifrost.client.mcpDisableAutoToolInject` | `bifrost.mcp.toolManagerConfig.disableAutoToolInject` |
+| `bifrost.client.mcpToolSyncInterval` | `bifrost.mcp.toolSyncInterval` |
 
 ### Ingress Configuration
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -353,22 +353,22 @@
             "mcpAgentDepth": {
               "type": "integer",
               "minimum": 1,
-              "description": "Maximum depth for MCP agent mode tool execution"
+              "description": "DEPRECATED: Maximum depth for MCP agent mode tool execution. Use bifrost.mcp.toolManagerConfig.maxAgentDepth."
             },
             "mcpToolExecutionTimeout": {
               "type": "integer",
               "minimum": 1,
-              "description": "Timeout for individual MCP tool execution in seconds"
+              "description": "DEPRECATED: Timeout for individual MCP tool execution in seconds. Use bifrost.mcp.toolManagerConfig.toolExecutionTimeout."
             },
             "mcpCodeModeBindingLevel": {
               "type": "string",
               "enum": ["server", "tool"],
-              "description": "Code mode binding level for MCP tools"
+              "description": "DEPRECATED: Code mode binding level for MCP tools. Use bifrost.mcp.toolManagerConfig.codeModeBindingLevel."
             },
             "mcpToolSyncInterval": {
               "type": "integer",
               "minimum": 0,
-              "description": "Global tool sync interval in minutes (0 = disabled)"
+              "description": "DEPRECATED: Global tool sync interval in minutes (0 = disabled). Use bifrost.mcp.toolSyncInterval."
             },
             "asyncJobResultTTL": {
               "type": "integer",
@@ -402,7 +402,7 @@
             },
             "mcpDisableAutoToolInject": {
               "type": "boolean",
-              "description": "When true, MCP tools are not automatically injected into requests. Tools are only included when explicitly specified via request context filters or headers."
+              "description": "DEPRECATED: When true, MCP tools are not automatically injected into requests. Use bifrost.mcp.toolManagerConfig.disableAutoToolInject."
             },
             "routingChainMaxDepth": {
               "type": "integer",
@@ -492,7 +492,7 @@
             },
             "toolSyncInterval": {
               "type": "string",
-              "description": "Global default interval for syncing tools from MCP servers (Go duration, e.g. '10m', '1h')"
+              "description": "Global default interval for syncing tools from MCP servers (Go duration string, e.g. '10m', '1h', '0s' to use runtime default)"
             }
           },
           "additionalProperties": false

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -210,10 +210,12 @@ bifrost:
     # requiredHeaders: []            # Headers that must be present on every request
     # loggingHeaders: []             # Headers to capture in log metadata
     # allowedHeaders: []             # Additional allowed headers for CORS and WebSocket
-    # mcpAgentDepth: 10              # Maximum depth for MCP agent mode tool execution
-    # mcpToolExecutionTimeout: 30    # Timeout for individual MCP tool execution in seconds
-    # mcpCodeModeBindingLevel: ""    # Code mode binding level (server or tool)
-    # mcpToolSyncInterval: 0         # Global tool sync interval in minutes (0 = disabled)
+    # Deprecated MCP global settings (use bifrost.mcp.toolManagerConfig and bifrost.mcp.toolSyncInterval instead):
+    # mcpAgentDepth: 10
+    # mcpToolExecutionTimeout: 30
+    # mcpCodeModeBindingLevel: "server"
+    # mcpToolSyncInterval: 10
+    # mcpDisableAutoToolInject: false
     # hideDeletedVirtualKeysInFilters: false  # Omit deleted virtual keys from logs/MCP filter data
     # whitelistedRoutes: []           # Routes that bypass auth middleware
     # routingChainMaxDepth: 10        # Maximum depth for routing rule chain evaluation
@@ -338,12 +340,13 @@ bifrost:
       #   secretRef:
       #     name: ""                               # k8s secret name
       #     connectionStringKey: "connection-string"  # key within the secret
-    # toolSyncInterval: "10m"   # Global tool sync interval (Go duration)
+    # toolSyncInterval: "10m"   # Global tool sync interval (Go duration string, e.g. "10m", "1h", "0s")
     # Tool manager configuration
     toolManagerConfig:
       toolExecutionTimeout: 30
       maxAgentDepth: 10
-      # codeModeBindingLevel: ""  # Code mode binding level (server or tool)
+      # codeModeBindingLevel: "server"  # Code mode binding level (server or tool)
+      # disableAutoToolInject: false    # Disable automatic MCP tool injection
 
   # Plugins configuration
   # Plugin version must be >= 1 (schema minimum). Use values > 1 to force DB-backed plugin config replacement on upgrade.

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/fasthttp/router"
 	bifrost "github.com/maximhq/bifrost/core"
@@ -279,6 +280,11 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		updatedConfig.MCPDisableAutoToolInject = payload.ClientConfig.MCPDisableAutoToolInject
 		shouldReloadMCPToolManagerConfig = true
 	}
+	// MCPToolSyncInterval supports 0 (disabled), so compare against current value
+	// instead of a > 0 guard used by other numeric fields.
+	if payload.ClientConfig.MCPToolSyncInterval != currentConfig.MCPToolSyncInterval {
+		updatedConfig.MCPToolSyncInterval = payload.ClientConfig.MCPToolSyncInterval
+	}
 
 	// Reload MCP tool manager config with all current values in one call
 	if shouldReloadMCPToolManagerConfig && h.store.MCPConfig != nil {
@@ -287,6 +293,17 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to update mcp tool manager config: %v", err))
 			return
 		}
+	}
+	// Keep in-memory MCP config aligned with client-config-backed MCP settings.
+	if h.store.MCPConfig != nil {
+		if h.store.MCPConfig.ToolManagerConfig == nil {
+			h.store.MCPConfig.ToolManagerConfig = &schemas.MCPToolManagerConfig{}
+		}
+		h.store.MCPConfig.ToolSyncInterval = time.Duration(updatedConfig.MCPToolSyncInterval) * time.Second
+		h.store.MCPConfig.ToolManagerConfig.MaxAgentDepth = updatedConfig.MCPAgentDepth
+		h.store.MCPConfig.ToolManagerConfig.ToolExecutionTimeout = time.Duration(updatedConfig.MCPToolExecutionTimeout) * time.Second
+		h.store.MCPConfig.ToolManagerConfig.CodeModeBindingLevel = schemas.CodeModeBindingLevel(updatedConfig.MCPCodeModeBindingLevel)
+		h.store.MCPConfig.ToolManagerConfig.DisableAutoToolInject = updatedConfig.MCPDisableAutoToolInject
 	}
 
 	if !slices.Equal(payload.ClientConfig.PrometheusLabels, currentConfig.PrometheusLabels) {
@@ -374,6 +391,10 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	}
 	if payload.ClientConfig.MCPToolExecutionTimeout > 0 {
 		updatedConfig.MCPToolExecutionTimeout = payload.ClientConfig.MCPToolExecutionTimeout
+	}
+	// 0 is a valid value (disabled), so persist it when changed.
+	if payload.ClientConfig.MCPToolSyncInterval != currentConfig.MCPToolSyncInterval {
+		updatedConfig.MCPToolSyncInterval = payload.ClientConfig.MCPToolSyncInterval
 	}
 	// Only update MCPCodeModeBindingLevel if payload is non-empty to avoid clearing stored value
 	if payload.ClientConfig.MCPCodeModeBindingLevel != "" {

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -292,7 +292,7 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, 
 			Headers:               dbClient.Headers,
 			AllowedExtraHeaders:   dbClient.AllowedExtraHeaders,
 			IsPingAvailable:       &isPingAvailable,
-			ToolSyncInterval:      time.Duration(dbClient.ToolSyncInterval) * time.Minute,
+			ToolSyncInterval:      time.Duration(dbClient.ToolSyncInterval) * time.Second,
 			ToolPricing:           dbClient.ToolPricing,
 			AllowOnAllVirtualKeys: dbClient.AllowOnAllVirtualKeys,
 		}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1059,7 +1059,7 @@ func loadMCPConfig(ctx context.Context, config *Config, configData *ConfigData) 
 
 	if config.MCPConfig != nil {
 		// Merge with config file if present
-		if configData.MCP != nil && len(configData.MCP.ClientConfigs) > 0 {
+		if configData.MCP != nil {
 			mergeMCPConfig(ctx, config, configData, config.MCPConfig)
 		}
 	} else if configData.MCP != nil {
@@ -1080,6 +1080,7 @@ func loadMCPConfig(ctx context.Context, config *Config, configData *ConfigData) 
 			}
 		}
 	}
+	applyMCPGlobalSettingsToClientConfig(ctx, config, configData.MCP)
 }
 
 // mergeMCPConfig merges MCP config from file with store
@@ -1091,16 +1092,47 @@ func mergeMCPConfig(ctx context.Context, config *Config, configData *ConfigData,
 	}
 	tempMCPConfig := configData.MCP
 	config.MCPConfig = tempMCPConfig
-	// Merge ClientConfigs arrays by ClientID or Name
+	// Merge client configs by name with hash-based reconciliation.
 	clientConfigsToAdd := make([]*schemas.MCPClientConfig, 0)
+	clientConfigsToUpdate := make([]configstoreTables.TableMCPClient, 0)
 	for _, newClientConfig := range tempMCPConfig.ClientConfigs {
+		if newClientConfig == nil {
+			continue
+		}
 		if newClientConfig.ID == "" {
 			newClientConfig.ID = uuid.NewString()
 		}
+		fileClientRow, err := mcpClientConfigToTable(newClientConfig)
+		if err != nil {
+			logger.Warn("invalid MCP client config for %q: %v", newClientConfig.Name, err)
+			continue
+		}
+		fileHash, err := configstore.GenerateMCPClientHash(fileClientRow)
+		if err != nil {
+			logger.Warn("failed to generate MCP client hash for %q: %v", newClientConfig.Name, err)
+			continue
+		}
+		newClientConfig.ConfigHash = fileHash
+		fileClientRow.ConfigHash = fileHash
+
 		found := false
-		for _, existingClientConfig := range mcpConfig.ClientConfigs {
+		for i, existingClientConfig := range mcpConfig.ClientConfigs {
+			if existingClientConfig == nil {
+				continue
+			}
 			if newClientConfig.Name != "" && existingClientConfig.Name == newClientConfig.Name {
 				found = true
+				if existingClientConfig.ConfigHash != fileHash {
+					logger.Debug("config hash mismatch for MCP client %q, syncing from config file", newClientConfig.Name)
+					newClientConfig.ID = existingClientConfig.ID
+					newClientConfig.ConfigHash = fileHash
+					fileClientRow.ClientID = existingClientConfig.ID
+					fileClientRow.ConfigHash = fileHash
+					clientConfigsToUpdate = append(clientConfigsToUpdate, fileClientRow)
+					mcpConfig.ClientConfigs[i] = newClientConfig
+				} else {
+					logger.Debug("config hash matches for MCP client %q, keeping DB config", newClientConfig.Name)
+				}
 				break
 			}
 		}
@@ -1108,11 +1140,11 @@ func mergeMCPConfig(ctx context.Context, config *Config, configData *ConfigData,
 			clientConfigsToAdd = append(clientConfigsToAdd, newClientConfig)
 		}
 	}
-	// Add new client configs to existing ones
+	// Add new client configs to existing ones.
 	config.MCPConfig.ClientConfigs = append(mcpConfig.ClientConfigs, clientConfigsToAdd...)
-	// Update store with merged config
-	if config.ConfigStore != nil && len(clientConfigsToAdd) > 0 {
-		logger.Debug("updating MCP config in store with %d new client configs", len(clientConfigsToAdd))
+	// Persist additions and config-driven updates.
+	if config.ConfigStore != nil && (len(clientConfigsToAdd) > 0 || len(clientConfigsToUpdate) > 0) {
+		logger.Debug("updating MCP config in store with %d new clients and %d updated clients", len(clientConfigsToAdd), len(clientConfigsToUpdate))
 		for _, clientConfig := range clientConfigsToAdd {
 			if clientConfig != nil {
 				if err := config.ConfigStore.CreateMCPClientConfig(ctx, clientConfig); err != nil {
@@ -1120,7 +1152,105 @@ func mergeMCPConfig(ctx context.Context, config *Config, configData *ConfigData,
 				}
 			}
 		}
+		for i := range clientConfigsToUpdate {
+			update := clientConfigsToUpdate[i]
+			if err := config.ConfigStore.UpdateMCPClientConfig(ctx, update.ClientID, &update); err != nil {
+				logger.Warn("failed to update MCP client config %q: %v", update.Name, err)
+			}
+		}
 	}
+}
+
+func applyMCPGlobalSettingsToClientConfig(ctx context.Context, config *Config, mcpCfg *schemas.MCPConfig) {
+	if config == nil || config.ClientConfig == nil || mcpCfg == nil {
+		return
+	}
+
+	changed := false
+	if mcpCfg.ToolManagerConfig != nil {
+		if mcpCfg.ToolManagerConfig.MaxAgentDepth > 0 && config.ClientConfig.MCPAgentDepth != mcpCfg.ToolManagerConfig.MaxAgentDepth {
+			config.ClientConfig.MCPAgentDepth = mcpCfg.ToolManagerConfig.MaxAgentDepth
+			changed = true
+		}
+		toolTimeoutSec := int(mcpCfg.ToolManagerConfig.ToolExecutionTimeout / time.Second)
+		if toolTimeoutSec > 0 && config.ClientConfig.MCPToolExecutionTimeout != toolTimeoutSec {
+			config.ClientConfig.MCPToolExecutionTimeout = toolTimeoutSec
+			changed = true
+		}
+		if mcpCfg.ToolManagerConfig.CodeModeBindingLevel != "" {
+			codeModeLevel := string(mcpCfg.ToolManagerConfig.CodeModeBindingLevel)
+			if config.ClientConfig.MCPCodeModeBindingLevel != codeModeLevel {
+				config.ClientConfig.MCPCodeModeBindingLevel = codeModeLevel
+				changed = true
+			}
+		}
+		if config.ClientConfig.MCPDisableAutoToolInject != mcpCfg.ToolManagerConfig.DisableAutoToolInject {
+			config.ClientConfig.MCPDisableAutoToolInject = mcpCfg.ToolManagerConfig.DisableAutoToolInject
+			changed = true
+		}
+	}
+	if mcpCfg.ToolSyncInterval == 0 {
+		if config.ClientConfig.MCPToolSyncInterval != 0 {
+			config.ClientConfig.MCPToolSyncInterval = 0
+			changed = true
+		}
+	} else if mcpCfg.ToolSyncInterval > 0 {
+		if mcpCfg.ToolSyncInterval%time.Second != 0 {
+			logger.Warn(
+				"ignoring mcp.tool_sync_interval %q: must be a whole number of seconds",
+				mcpCfg.ToolSyncInterval.String(),
+			)
+		} else {
+			syncSeconds := int(mcpCfg.ToolSyncInterval / time.Second)
+			if config.ClientConfig.MCPToolSyncInterval != syncSeconds {
+				config.ClientConfig.MCPToolSyncInterval = syncSeconds
+				changed = true
+			}
+		}
+	}
+
+	if changed && config.ConfigStore != nil {
+		if err := config.ConfigStore.UpdateClientConfig(ctx, config.ClientConfig); err != nil {
+			logger.Warn("failed to update client config with MCP global settings: %v", err)
+		}
+	}
+}
+
+func mcpClientConfigToTable(clientConfig *schemas.MCPClientConfig) (configstoreTables.TableMCPClient, error) {
+	if clientConfig == nil {
+		return configstoreTables.TableMCPClient{}, nil
+	}
+	if clientConfig.ToolSyncInterval%time.Second != 0 {
+		return configstoreTables.TableMCPClient{}, fmt.Errorf(
+			"tool_sync_interval must be a whole number of seconds, got %q",
+			clientConfig.ToolSyncInterval.String(),
+		)
+	}
+	authType := string(clientConfig.AuthType)
+	if authType == "" {
+		authType = string(schemas.MCPAuthTypeHeaders)
+	}
+	return configstoreTables.TableMCPClient{
+		ClientID:                  clientConfig.ID,
+		Name:                      clientConfig.Name,
+		IsCodeModeClient:          clientConfig.IsCodeModeClient,
+		ConnectionType:            string(clientConfig.ConnectionType),
+		ConnectionString:          clientConfig.ConnectionString,
+		StdioConfig:               clientConfig.StdioConfig,
+		AuthType:                  authType,
+		OauthConfigID:             clientConfig.OauthConfigID,
+		ToolsToExecute:            clientConfig.ToolsToExecute,
+		ToolsToAutoExecute:        clientConfig.ToolsToAutoExecute,
+		Headers:                   clientConfig.Headers,
+		AllowedExtraHeaders:       clientConfig.AllowedExtraHeaders,
+		IsPingAvailable:           clientConfig.IsPingAvailable,
+		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
+		ToolPricing:               clientConfig.ToolPricing,
+		AllowOnAllVirtualKeys:     clientConfig.AllowOnAllVirtualKeys,
+		DiscoveredTools:           clientConfig.DiscoveredTools,
+		DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
+		ConfigHash:                clientConfig.ConfigHash,
+	}, nil
 }
 
 // loadGovernanceConfig loads and merges governance config from file

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -2002,6 +2002,69 @@ func TestLoadConfig_MCP_Merge(t *testing.T) {
 	}
 }
 
+func TestMergeMCPConfig_HashReconciliationUpdatesAndCreates(t *testing.T) {
+	ctx := context.Background()
+	initTestLogger()
+	store := NewMockConfigStore()
+
+	existing := &schemas.MCPClientConfig{
+		ID:             "mcp-existing",
+		Name:           "echo_http",
+		ConnectionType: schemas.MCPConnectionTypeHTTP,
+		ToolsToExecute: schemas.WhiteList{"read"},
+	}
+	existingTable, err := mcpClientConfigToTable(existing)
+	require.NoError(t, err)
+	existingHash, err := configstore.GenerateMCPClientHash(existingTable)
+	require.NoError(t, err)
+	existing.ConfigHash = existingHash
+
+	store.mcpConfig = &schemas.MCPConfig{
+		ClientConfigs: []*schemas.MCPClientConfig{existing},
+	}
+
+	fileMCP := &schemas.MCPConfig{
+		ClientConfigs: []*schemas.MCPClientConfig{
+			{
+				Name:           "echo_http",
+				ConnectionType: schemas.MCPConnectionTypeHTTP,
+				ToolsToExecute: schemas.WhiteList{"*"},
+			},
+			{
+				Name:           "filesystem_tools",
+				ConnectionType: schemas.MCPConnectionTypeSTDIO,
+				StdioConfig: &schemas.MCPStdioConfig{
+					Command: "npx",
+				},
+				ToolsToExecute: schemas.WhiteList{"*"},
+			},
+		},
+	}
+
+	cfg := &Config{ConfigStore: store}
+	mergeMCPConfig(ctx, cfg, &ConfigData{MCP: fileMCP}, store.mcpConfig)
+
+	require.Len(t, store.mcpClientConfigUpdates, 1, "expected one updated MCP client")
+	require.Equal(t, "mcp-existing", store.mcpClientConfigUpdates[0].ID)
+	require.Equal(t, "echo_http", store.mcpClientConfigUpdates[0].Config.Name)
+	require.Equal(t, schemas.WhiteList{"*"}, store.mcpClientConfigUpdates[0].Config.ToolsToExecute)
+	require.NotEmpty(t, store.mcpClientConfigUpdates[0].Config.ConfigHash)
+
+	require.Len(t, store.mcpConfigsCreated, 1, "expected one created MCP client")
+	require.Equal(t, "filesystem_tools", store.mcpConfigsCreated[0].Name)
+	require.NotEmpty(t, store.mcpConfigsCreated[0].ID)
+	require.NotEmpty(t, store.mcpConfigsCreated[0].ConfigHash)
+
+	require.Len(t, cfg.MCPConfig.ClientConfigs, 2)
+	byName := map[string]*schemas.MCPClientConfig{}
+	for _, client := range cfg.MCPConfig.ClientConfigs {
+		byName[client.Name] = client
+	}
+	require.Equal(t, "mcp-existing", byName["echo_http"].ID, "updated client should preserve DB client_id")
+	require.NotEmpty(t, byName["echo_http"].ConfigHash)
+	require.NotEmpty(t, byName["filesystem_tools"].ConfigHash)
+}
+
 // TestLoadConfig_Governance_Merge tests governance config merge from DB and file
 func TestLoadConfig_Governance_Merge(t *testing.T) {
 	// Setup DB governance config
@@ -11887,12 +11950,12 @@ func TestGenerateMCPClientHash(t *testing.T) {
 		t.Error("Same MCP should produce same hash")
 	}
 
-	// Different ClientID should produce different hash
+	// Different ClientID should produce the same hash (ClientID is system-assigned)
 	mcp2 := mcp1
 	mcp2.ClientID = "mcp-2"
 	hash2, _ := configstore.GenerateMCPClientHash(mcp2)
-	if hash1 == hash2 {
-		t.Error("Different ClientID should produce different hash")
+	if hash1 != hash2 {
+		t.Error("Different ClientID should not affect hash")
 	}
 
 	// Different Name should produce different hash

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -187,29 +187,29 @@
         "mcp_agent_depth": {
           "type": "integer",
           "minimum": 1,
-          "description": "Maximum depth for MCP agent mode tool execution",
+          "description": "DEPRECATED: Maximum depth for MCP agent mode tool execution. Use mcp.tool_manager_config.max_agent_depth.",
           "default": 10
         },
         "mcp_tool_execution_timeout": {
           "type": "integer",
           "minimum": 1,
-          "description": "Timeout for individual MCP tool execution in seconds",
+          "description": "DEPRECATED: Timeout for individual MCP tool execution in seconds. Use mcp.tool_manager_config.tool_execution_timeout.",
           "default": 30
         },
         "mcp_code_mode_binding_level": {
           "type": "string",
           "enum": ["server", "tool"],
-          "description": "Code mode binding level for MCP tools"
+          "description": "DEPRECATED: Code mode binding level for MCP tools. Use mcp.tool_manager_config.code_mode_binding_level."
         },
         "mcp_tool_sync_interval": {
           "type": "integer",
           "minimum": 0,
-          "description": "Global tool sync interval in minutes (0 = disabled)",
+          "description": "DEPRECATED: Global tool sync interval in minutes (0 = disabled). Use mcp.tool_sync_interval.",
           "default": 10
         },
         "mcp_disable_auto_tool_inject": {
           "type": "boolean",
-          "description": "When true, MCP tools are not automatically injected into requests. Tools are only included when explicitly specified via request context filters or headers, such as x-bf-mcp-include-tools or x-bf-mcp-include-clients.",
+          "description": "DEPRECATED: When true, MCP tools are not automatically injected into requests. Use mcp.tool_manager_config.disable_auto_tool_inject.",
           "default": false
         },
         "routing_chain_max_depth": {
@@ -678,8 +678,16 @@
           "$ref": "#/$defs/mcp_tool_manager_config"
         },
         "tool_sync_interval": {
-          "type": "string",
-          "description": "Global default interval for syncing tools from MCP servers (Go duration, e.g. '10m', '1h')"
+          "description": "Global default interval for syncing tools from MCP servers (Go duration string, e.g. '10m', '1h', '0s' to use runtime default). Legacy numeric nanoseconds are also supported for backward compatibility.",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^-?(?:\\d+(?:\\.\\d+)?(?:ns|us|µs|ms|s|m|h))+$"
+            },
+            {
+              "type": "integer"
+            }
+          ]
         }
       },
       "additionalProperties": false
@@ -2674,8 +2682,16 @@
           "description": "Auto-execute list of tools. ['*'] means all, [] means none."
         },
         "tool_sync_interval": {
-          "type": "string",
-          "description": "Per-client override for tool sync interval (Go duration, e.g. '10m', '1h', 0 = use global, negative = disabled)"
+          "description": "Per-client override for tool sync interval. Prefer Go duration strings (e.g. '10m', '-1s', '0s' = use global). Legacy integer nanoseconds are also supported for backward compatibility.",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^-?(?:\\d+(?:\\.\\d+)?(?:ns|us|µs|ms|s|m|h))+$"
+            },
+            {
+              "type": "integer"
+            }
+          ]
         },
         "allowed_extra_headers": {
           "type": "array",


### PR DESCRIPTION
## Summary

This PR improves MCP configuration handling by introducing Go duration string support for `tool_sync_interval` fields, adding hash-based reconciliation for config-file-driven MCP client updates, and migrating MCP global settings from the legacy `client.mcp*` flat keys to the structured `mcp.*` namespace.

## Changes

- **Go duration string support for `tool_sync_interval`**: Custom `UnmarshalJSON` implementations on `MCPConfig` and `MCPClientConfig` now accept human-readable duration strings (e.g. `"10m"`, `"1h"`) in addition to raw numeric nanosecond values (retained for backward compatibility). A shared `parseFlexibleDurationField` helper handles both cases.

- **Hash-based MCP client config reconciliation**: `mergeMCPConfig` now computes a content hash for each MCP client config declared in the config file. When a named client already exists in the DB but its hash differs from the file, the DB record is updated to reflect the file's current state (connection type, auth, stdio config, etc.). Previously, only new clients were added; existing ones were never updated from the file.

- **`UpdateMCPClientConfig` persists connection metadata on hash-driven updates**: When a `ConfigHash` is present on the update payload, the RDB store now also syncs `connection_type`, `connection_string`, `stdio_config_json`, `auth_type`, and `oauth_config_id` to the DB row.

- **`applyMCPGlobalSettingsToClientConfig`**: A new function propagates `mcp.toolManagerConfig` and `mcp.toolSyncInterval` values from the structured MCP config block into the flat `ClientConfig` fields, keeping both representations in sync and persisting changes to the store.

- **`loadMCPConfig` merge condition relaxed**: The merge path is now entered whenever `configData.MCP` is non-nil, not only when it contains client configs, so global MCP settings (e.g. `toolSyncInterval`, `toolManagerConfig`) are applied even when no client configs are declared.

- **In-memory `MCPConfig` kept aligned on HTTP config updates**: The `updateConfig` handler now mirrors `MCPAgentDepth`, `MCPToolExecutionTimeout`, `MCPCodeModeBindingLevel`, `MCPDisableAutoToolInject`, and `MCPToolSyncInterval` back into the live `MCPConfig` struct after a client config update, preventing drift between the two representations.

- **`MCPToolSyncInterval` update logic corrected**: The handler now uses a change-comparison guard instead of a `> 0` guard, so a value of `0` (disabled) can be explicitly set and persisted.

- **Helm and schema deprecations**: `bifrost.client.mcp*` Helm values and their `config.schema.json` counterparts are marked deprecated in favor of `bifrost.mcp.toolManagerConfig.*` and `bifrost.mcp.toolSyncInterval`. A migration table is added to the Helm README and deployment guide.

- **New `values-mcp-routing.yaml` example**: A composable Helm values file demonstrating MCP client configs, tool manager settings, governance objects, routing rules, and pricing overrides using the current `mcp.*` schema.

- **`mcpClientConfigToTable` helper extracted**: Conversion from `MCPClientConfig` to the table row type is now a standalone function, reused by both the merge path and the new hash reconciliation path.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./core/schemas/... ./transports/bifrost-http/lib/... ./transports/bifrost-http/handlers/...
```

- Set `tool_sync_interval: "10m"` (string) in a config file and confirm it parses without error.
- Set `tool_sync_interval: 600000000000` (numeric nanoseconds) and confirm backward-compatible parsing.
- Set an invalid value such as `tool_sync_interval: "not-a-duration"` and confirm an error is returned.
- Declare an MCP client in `config.json`, start the service, then change a field (e.g. `tools_to_execute`), restart, and confirm the DB row is updated to match the file.
- Declare only `mcp.toolSyncInterval` and `mcp.toolManagerConfig` without any `clientConfigs` and confirm the values are applied to `ClientConfig` and persisted.

## Breaking changes

- [ ] Yes
- [x] No

Legacy `bifrost.client.mcp*` Helm keys and `client.mcp_*` config.json fields continue to work. The new `mcp.*` namespace is preferred but not required.

## Related issues

## Security considerations

No new secrets, auth flows, or PII handling introduced. Config hash values are derived from non-sensitive structural fields only.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable