### PR TITLE
fix: drops empty tool calls for anthropic claude code request

### DIFF
--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -708,6 +708,11 @@ func getRequestBodyForResponses(ctx *schemas.BifrostContext, request *schemas.Bi
 		if err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
 		}
+		// Strip thinking blocks with empty "thinking" field — Anthropic rejects them.
+		jsonBody, err = StripEmptyThinkingBlocks(jsonBody)
+		if err != nil {
+			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err, providerName)
+		}
 		// Sanitize raw-body fields the target provider does not support.
 		// Behavioural parity with StripUnsupportedAnthropicFields on the typed path.
 		// Feature gating keyed to schemas.Anthropic (not providerName) to match
@@ -1068,6 +1073,36 @@ var unsupportedRawToolTypes = map[schemas.ModelProvider][]string{
 		"web_fetch_",     // No web fetch on Bedrock
 		"code_execution", // No code execution on Bedrock
 	},
+}
+
+// StripEmptyThinkingBlocks removes thinking content blocks where
+// "thinking" is an empty string. Anthropic rejects such blocks with a 400.
+func StripEmptyThinkingBlocks(jsonBody []byte) ([]byte, error) {
+	messagesResult := providerUtils.GetJSONField(jsonBody, "messages")
+	if !messagesResult.Exists() || !messagesResult.IsArray() {
+		return jsonBody, nil
+	}
+	var err error
+	for mi, msg := range messagesResult.Array() {
+		contentResult := msg.Get("content")
+		if !contentResult.Exists() || !contentResult.IsArray() {
+			continue
+		}
+		var toStrip []int
+		for ci, block := range contentResult.Array() {
+			if block.Get("type").String() == "thinking" && block.Get("thinking").String() == "" {
+				toStrip = append(toStrip, ci)
+			}
+		}
+		for i := len(toStrip) - 1; i >= 0; i-- {
+			path := fmt.Sprintf("messages.%d.content.%d", mi, toStrip[i])
+			jsonBody, err = providerUtils.DeleteJSONField(jsonBody, path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to strip empty thinking block at %s: %w", path, err)
+			}
+		}
+	}
+	return jsonBody, nil
 }
 
 // StripAutoInjectableTools removes code_execution tools from the raw JSON body's tools array


### PR DESCRIPTION
## Summary

Anthropic returns a `400` error when a request contains `thinking` content blocks where the `"thinking"` field is an empty string. This PR adds a sanitization step that strips those empty thinking blocks from the raw JSON body before the request is sent to Anthropic.

## Changes

- Added `StripEmptyThinkingBlocks` which iterates over all messages in the JSON body and removes any `thinking`\-typed content blocks where the `"thinking"` field is an empty string.
- Integrated `StripEmptyThinkingBlocks` into `getRequestBodyForResponses` so it runs after marshalling and before the existing unsupported-field sanitization on the raw-body path.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

Send a request to Anthropic via Bifrost that includes a `thinking` content block with an empty `"thinking"` field (e.g., a cached or replayed conversation where the thinking content was stripped). Verify the request succeeds instead of returning a `400`.

```sh
go test ./core/providers/anthropic/...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. The change only removes malformed content blocks from outbound request bodies before they are sent to Anthropic.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable