### PR TITLE
refactor: send relative period to backend instead of computing timestamps client-side

### DIFF
--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -186,11 +186,17 @@ export default function DashboardPage() {
 	const selectedMcpToolNames = useMemo(() => parseCsvParam(urlState.mcp_tool_names), [urlState.mcp_tool_names]);
 	const selectedMcpServerLabels = useMemo(() => parseCsvParam(urlState.mcp_server_labels), [urlState.mcp_server_labels]);
 
-	// Derived filter for API calls
+	// Derived filter for API calls.
+	// When period is set, send it so the backend computes the window fresh on every request.
+	// For custom absolute ranges (period === "") use the stored URL timestamps.
 	const filters: LogFilters = useMemo(
 		() => ({
-			start_time: dateUtils.toISOString(urlState.start_time),
-			end_time: dateUtils.toISOString(urlState.end_time),
+			...(urlState.period
+				? { period: urlState.period }
+				: {
+					start_time: dateUtils.toISOString(urlState.start_time),
+					end_time: dateUtils.toISOString(urlState.end_time),
+				}),
 			...(selectedProviders.length > 0 && { providers: selectedProviders }),
 			...(selectedModels.length > 0 && { models: selectedModels }),
 			...(selectedKeyIds.length > 0 && { selected_key_ids: selectedKeyIds }),
@@ -208,10 +214,11 @@ export default function DashboardPage() {
 			...(missingCostOnly && { missing_cost_only: true }),
 			...(metadataFilters &&
 				Object.keys(metadataFilters).length > 0 && {
-					metadata_filters: metadataFilters,
-				}),
+				metadata_filters: metadataFilters,
+			}),
 		}),
 		[
+			urlState.period,
 			urlState.start_time,
 			urlState.end_time,
 			selectedProviders,
@@ -227,11 +234,15 @@ export default function DashboardPage() {
 		],
 	);
 
-	// MCP filters
+	// MCP filters — same period-first logic as filters above.
 	const mcpFilters: MCPToolLogFilters = useMemo(
 		() => ({
-			start_time: dateUtils.toISOString(urlState.start_time),
-			end_time: dateUtils.toISOString(urlState.end_time),
+			...(urlState.period
+				? { period: urlState.period }
+				: {
+					start_time: dateUtils.toISOString(urlState.start_time),
+					end_time: dateUtils.toISOString(urlState.end_time),
+				}),
 			...(selectedMcpToolNames.length > 0 && {
 				tool_names: selectedMcpToolNames,
 			}),
@@ -239,7 +250,7 @@ export default function DashboardPage() {
 				server_labels: selectedMcpServerLabels,
 			}),
 		}),
-		[urlState.start_time, urlState.end_time, selectedMcpToolNames, selectedMcpServerLabels],
+		[urlState.period, urlState.start_time, urlState.end_time, selectedMcpToolNames, selectedMcpServerLabels],
 	);
 
 	// Model lists for each chart's legend (must match what the chart component actually renders)
@@ -510,6 +521,7 @@ export default function DashboardPage() {
 				...(timeChanged && { period: "" }),
 				start_time: newStartTime,
 				end_time: newEndTime,
+				period: urlState.period,
 				providers: (newFilters.providers || []).join(","),
 				models: (newFilters.models || []).join(","),
 				selected_key_ids: (newFilters.selected_key_ids || []).join(","),
@@ -525,7 +537,7 @@ export default function DashboardPage() {
 						: "",
 			});
 		},
-		[setUrlState, urlState.start_time, urlState.end_time],
+		[setUrlState, urlState.start_time, urlState.end_time, urlState.period],
 	);
 
 	// Date range for picker

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -6,7 +6,6 @@ import { LogsHeaderView } from "@/app/workspace/logs/views/logsHeaderView";
 import { LogsDataTable } from "@/app/workspace/logs/views/logsTable";
 import { LogsVolumeChart } from "@/app/workspace/logs/views/logsVolumeChart";
 import { LogsFilterSidebar } from "@/components/filters/logsFilterSidebar";
-import FullPageLoader from "@/components/fullPageLoader";
 import { useColumnConfig } from "@/components/table";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent } from "@/components/ui/card";
@@ -23,7 +22,6 @@ import { useLazyGetLogByIdQuery, useLazyGetLogsQuery } from "@/lib/store/apis/lo
 import type { LogEntry, LogFilters, Pagination } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
 import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
-import { getRangeForPeriod } from "@/lib/utils/timeRange";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import NumberFlow from "@number-flow/react";
 import { useLocation } from "@tanstack/react-router";
@@ -62,15 +60,9 @@ export default function LogsPage() {
 	// Track if user has manually modified the time range
 	const userModifiedTimeRange = useRef<boolean>(false);
 
-	// Capture initial defaults on mount to detect shared URLs with custom time ranges
-	const initialDefaults = useRef(dateUtils.getDefaultTimeRange());
-
 	// Memoize default time range to prevent recalculation on every render
 	// This is crucial to avoid triggering refetches when the sheet opens/closes
 	const defaultTimeRange = useMemo(() => dateUtils.getDefaultTimeRange(), []);
-
-	// Get fresh default time range for refresh logic
-	const getDefaultTimeRange = () => dateUtils.getDefaultTimeRange();
 
 	const { search } = useLocation();
 	const hasExplicitTimeRange = (search as Record<string, unknown>)?.start_time && (search as Record<string, unknown>)?.end_time;
@@ -116,82 +108,6 @@ export default function LogsPage() {
 	const activeLogFetchId = useRef<string | null>(null);
 	const polling = urlState.polling;
 
-	// Refresh time range on page focus/visibility
-	useEffect(() => {
-		const refreshDefaultsIfStale = () => {
-			if (!polling) return
-			if (urlState.period) {
-				const { from, to } = getRangeForPeriod(urlState.period);
-				setUrlState(
-					{
-						start_time: Math.floor(from.getTime() / 1000),
-						end_time: Math.floor(to.getTime() / 1000),
-						period: urlState.period ?? "",
-					},
-					{ history: "replace" },
-				);
-				return;
-			}
-
-			// Absolute custom range: skip refresh if user explicitly set it
-			if (userModifiedTimeRange.current) return;
-
-			// Only slide back to default 1h if the timestamps still match the initial defaults
-			const startTimeDiff = Math.abs(urlState.start_time - initialDefaults.current.startTime);
-			const endTimeDiff = Math.abs(urlState.end_time - initialDefaults.current.endTime);
-			const tolerance = 5;
-			if (startTimeDiff <= tolerance && endTimeDiff <= tolerance) {
-				const defaults = getDefaultTimeRange();
-				const currentEndDiff = Math.abs(urlState.end_time - defaults.endTime);
-				if (currentEndDiff > 300) {
-					setUrlState(
-						{
-							start_time: defaults.startTime,
-							end_time: defaults.endTime,
-							period: urlState.period ?? "",
-						},
-						{ history: "replace" },
-					);
-					initialDefaults.current.startTime = defaults.startTime;
-					initialDefaults.current.endTime = defaults.endTime;
-				}
-			}
-		};
-
-		const handleVisibilityChange = () => {
-			if (!document.hidden) refreshDefaultsIfStale();
-		};
-		const handleFocus = () => refreshDefaultsIfStale();
-
-		document.addEventListener("visibilitychange", handleVisibilityChange);
-		window.addEventListener("focus", handleFocus);
-		return () => {
-			document.removeEventListener("visibilitychange", handleVisibilityChange);
-			window.removeEventListener("focus", handleFocus);
-		};
-	}, [urlState.period, urlState.start_time, urlState.end_time, setUrlState, polling]);
-
-	// Refresh the time window every 5s while live polling is on and a relative period is active.
-	// Updating start_time/end_time changes RTK args → triggers a refetch without needing pollingInterval.
-	useEffect(() => {
-		if (!polling || !urlState.period) return;
-
-		const id = setInterval(() => {
-			if (document.hidden) return;
-			const { from, to } = getRangeForPeriod(urlState.period);
-			setUrlState(
-				{
-					start_time: Math.floor(from.getTime() / 1000),
-					end_time: Math.floor(to.getTime() / 1000),
-					period: urlState.period ?? "",
-				},
-				{ history: "replace" },
-			);
-		}, 5000);
-
-		return () => clearInterval(id);
-	}, [polling, urlState.period, setUrlState]);
-
 	// Convert URL state to filters and pagination for API calls
 	const filters: LogFilters = useMemo(
 		() => ({
@@ -210,8 +126,6 @@ export default function LogsPage() {
 			customer_ids: urlState.customer_ids,
 			business_unit_ids: urlState.business_unit_ids,
 			content_search: urlState.content_search,
-			start_time: dateUtils.toISOString(urlState.start_time),
-			end_time: dateUtils.toISOString(urlState.end_time),
 			missing_cost_only: urlState.missing_cost_only,
 			metadata_filters: urlState.metadata_filters
 				? (() => {
@@ -222,6 +136,11 @@ export default function LogsPage() {
 					}
 				})()
 				: undefined,
+			// Use a period if present
+			...(urlState.period ? { period: urlState.period } : {
+				start_time: dateUtils.toISOString(urlState.start_time),
+				end_time: dateUtils.toISOString(urlState.end_time),
+			})
 		}),
 		// Only re-derive filters when filter-related URL params change (not pagination)
 		[
@@ -240,10 +159,11 @@ export default function LogsPage() {
 			urlState.business_unit_ids,
 			urlState.content_search,
 			urlState.parent_request_id,
-			urlState.start_time,
-			urlState.end_time,
 			urlState.missing_cost_only,
 			urlState.metadata_filters,
+			urlState.start_time,
+			urlState.end_time,
+			urlState.period,
 		],
 	);
 
@@ -318,6 +238,7 @@ export default function LogsPage() {
 				start_time: startTime,
 				end_time: endTime,
 				offset: 0,
+				polling: false
 			});
 		},
 		[setUrlState],
@@ -337,28 +258,23 @@ export default function LogsPage() {
 	// Check if user has zoomed (time range is different from default 1h)
 	const isZoomed = useMemo(() => {
 		const currentRange = urlState.end_time - urlState.start_time;
-		const defaultRange = 24 * 60 * 60; // 24 hours in seconds
+		const defaultRange = 1 * 60 * 60; // 1 hours in seconds
 		// Consider zoomed if range is less than 90% of default (to account for minor differences)
 		return currentRange < defaultRange * 0.9;
 	}, [urlState.start_time, urlState.end_time]);
 
-	// Non-lazy RTK Query hooks — RTK handles caching, deduplication, and loading states.
-	// pollingInterval is only set for the no-period case; period polling is handled by
-	// a setInterval that updates URL timestamps, which changes args and triggers RTK to refetch.
 	const {
 		data: logsData,
-		isLoading: logsIsLoading,
 		isFetching: logsIsFetching,
 		error: logsError,
 		refetch: refetchLogs,
 	} = useGetLogsQuery(
-		{ filters, pagination },
 		{
-			// Poll every 5s on the empty state page so we transition as soon as the first log arrives.
-			// When a relative period is active, the setInterval above updates URL timestamps → RTK
-			// detects arg changes and refetches automatically; no separate pollingInterval needed.
-			pollingInterval: showEmptyState ? 5000 : polling && !period ? 5000 : 0,
-			refetchOnMountOrArgChange: true,
+			filters,
+			pagination,
+		},
+		{
+			pollingInterval: showEmptyState || polling ? 10000 : 0,
 			skipPollingIfUnfocused: true,
 		},
 	);
@@ -368,10 +284,11 @@ export default function LogsPage() {
 		isFetching: statsIsFetching,
 		refetch: refetchStats,
 	} = useGetLogsStatsQuery(
-		{ filters },
 		{
-			pollingInterval: polling && !period ? 5000 : 0,
-			refetchOnMountOrArgChange: true,
+			filters,
+		},
+		{
+			pollingInterval: polling ? 10000 : 0,
 			skipPollingIfUnfocused: true,
 		},
 	);
@@ -381,10 +298,11 @@ export default function LogsPage() {
 		isLoading: histogramIsLoading,
 		refetch: refetchHistogram,
 	} = useGetLogsHistogramQuery(
-		{ filters },
 		{
-			pollingInterval: polling && !period ? 5000 : 0,
-			refetchOnMountOrArgChange: true,
+			filters
+		},
+		{
+			pollingInterval: polling ? 10000 : 0,
 			skipPollingIfUnfocused: true,
 		},
 	);
@@ -399,26 +317,6 @@ export default function LogsPage() {
 			setShowEmptyState(false);
 		}
 	}, [logsData, showEmptyState]);
-
-	// On mount: if period is set and stored timestamps are stale, freshen them so the
-	// initial query uses the correct window (RTK will refetch when args change).
-	useEffect(() => {
-		if (urlState.period) {
-			const { from, to } = getRangeForPeriod(urlState.period);
-			const freshEnd = Math.floor(to.getTime() / 1000);
-			if (Math.abs(urlState.end_time - freshEnd) > 60) {
-				setUrlState(
-					{
-						start_time: Math.floor(from.getTime() / 1000),
-						end_time: freshEnd,
-						period: urlState.period ?? "",
-					},
-					{ history: "replace" },
-				);
-			}
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
 
 	const handleFilterByParentRequestId = useCallback(
 		(parentRequestId: string) => {
@@ -465,13 +363,22 @@ export default function LogsPage() {
 	// Period selection: store relative period + fresh timestamps in URL (bypasses setFilters
 	// so userModifiedTimeRange stays false and tab-focus refresh keeps working)
 	const handlePeriodChange = useCallback(
-		(p: string, from: Date, to: Date) => {
-			setUrlState({
-				period: p,
-				start_time: Math.floor(from.getTime() / 1000),
-				end_time: Math.floor(to.getTime() / 1000),
-				offset: 0,
-			});
+		(p?: string, from?: Date, to?: Date) => {
+			if (p) {
+				setUrlState({
+					period: p,
+					offset: 0,
+					polling: true
+				});
+			} else if (from && to) {
+				setUrlState({
+					start_time: Math.floor(from.getTime() / 1000),
+					end_time: Math.floor(to.getTime() / 1000),
+					offset: 0,
+					polling: false,
+					period: ""
+				});
+			}
 		},
 		[setUrlState],
 	);
@@ -663,9 +570,7 @@ export default function LogsPage() {
 
 	return (
 		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(100vh_-_16px)]">
-			{logsIsLoading ? (
-				<FullPageLoader />
-			) : showEmptyState ? (
+			{showEmptyState ? (
 				<EmptyState error={error ?? (logsError ? getErrorMessage(logsError as Parameters<typeof getErrorMessage>[0]) : null)} />
 			) : (
 				<div className="bg-background flex h-full w-full grow gap-3">
@@ -739,6 +644,7 @@ export default function LogsPage() {
 								isZoomed={isZoomed}
 								startTime={urlState.start_time}
 								endTime={urlState.end_time}
+								period={urlState.period}
 								isOpen={isChartOpen}
 								onOpenChange={setIsChartOpen}
 							/>

--- a/ui/app/workspace/logs/views/logsHeaderView.tsx
+++ b/ui/app/workspace/logs/views/logsHeaderView.tsx
@@ -21,7 +21,7 @@ interface LogsHeaderViewProps {
 	polling: boolean;
 	onPollToggle: (enabled: boolean) => void;
 	period: string;
-	onPeriodChange: (period: string, from: Date, to: Date) => void;
+	onPeriodChange: (period?: string, from?: Date, to?: Date) => void;
 	/** Column config for the ColumnConfigDropdown */
 	columnEntries: ColumnConfigEntry[];
 	columnLabels: Record<string, string>;
@@ -144,11 +144,7 @@ export function LogsHeaderView({
 				onDateTimeUpdate={(p) => {
 					setStartTime(p.from);
 					setEndTime(p.to);
-					onFiltersChange({
-						...filters,
-						start_time: p.from?.toISOString(),
-						end_time: p.to?.toISOString(),
-					});
+					onPeriodChange(undefined, p.from, p.to);
 				}}
 				preDefinedPeriods={TIME_PERIODS}
 				onPredefinedPeriodChange={(periodValue) => {

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -177,7 +177,10 @@ export function LogsDataTable({
 						<TableRow className="hover:bg-transparent">
 							<TableCell colSpan={columns.length} className="h-12 text-center">
 								<div className="text-muted-foreground flex items-center justify-center gap-2 text-sm">
-									{polling ? (
+									{loading ? <>
+										<RefreshCw className="h-4 w-4 animate-spin" />
+										Loading logs...
+									</> : polling ? (
 										<>
 											<RefreshCw className="h-4 w-4 animate-spin" />
 											Waiting for new logs...

--- a/ui/app/workspace/logs/views/logsVolumeChart.tsx
+++ b/ui/app/workspace/logs/views/logsVolumeChart.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/ui/collapsible";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { HistogramBucket, LogsHistogramResponse } from "@/lib/types/logs";
+import { getUnixRangeForPeriod } from "@/lib/utils/timeRange";
 import { ChevronDown, RotateCcw } from "lucide-react";
 import {
   Component,
@@ -114,6 +115,7 @@ interface LogsVolumeChartProps {
   startTime: number; // Unix timestamp in seconds
   endTime: number; // Unix timestamp in seconds
   isOpen: boolean;
+  period?: string,
   onOpenChange: (open: boolean) => void;
 }
 
@@ -217,6 +219,7 @@ export function LogsVolumeChart({
   startTime,
   endTime,
   isOpen,
+  period,
   onOpenChange,
 }: LogsVolumeChartProps) {
   // State for drag selection
@@ -224,14 +227,23 @@ export function LogsVolumeChart({
   const [refAreaRight, setRefAreaRight] = useState<number | null>(null);
   const [isSelecting, setIsSelecting] = useState(false);
 
+  const effectingTimeRange = useMemo(() => {
+    if (period) {
+      const { start, end } = getUnixRangeForPeriod(period)
+      return { startTime: start, endTime: end }
+    }
+
+    return { startTime, endTime }
+  }, [period, startTime, endTime])
+
   // Transform data for chart, filling in empty buckets for the full time range
   const chartData = useMemo(() => {
     // Need bucket_size_seconds and valid time range
     if (
       !data?.bucket_size_seconds ||
-      !startTime ||
-      !endTime ||
-      startTime >= endTime
+      !effectingTimeRange.startTime ||
+      !effectingTimeRange.endTime ||
+      effectingTimeRange.startTime >= effectingTimeRange.endTime
     ) {
       return [];
     }
@@ -240,8 +252,8 @@ export function LogsVolumeChart({
 
     // Align start time to bucket boundary
     const minTime =
-      Math.floor((startTime * 1000) / bucketSizeMs) * bucketSizeMs;
-    const maxTime = endTime * 1000;
+      Math.floor((effectingTimeRange.startTime * 1000) / bucketSizeMs) * bucketSizeMs;
+    const maxTime = effectingTimeRange.endTime * 1000;
 
     // Safety: limit maximum number of buckets to prevent performance issues
     const maxBuckets = 500;
@@ -332,7 +344,7 @@ export function LogsVolumeChart({
     }
 
     return filledBuckets;
-  }, [data, startTime, endTime]);
+  }, [data, effectingTimeRange.startTime, effectingTimeRange.endTime]);
 
   // Handle mouse down on chart (start selection)
   const handleMouseDown = useCallback((e: ChartMouseEvent) => {
@@ -404,7 +416,7 @@ export function LogsVolumeChart({
   );
 
   // Check if we have valid data for the chart
-  const hasValidData = data && startTime && endTime && chartData.length >= 2;
+  const hasValidData = data && effectingTimeRange.startTime && effectingTimeRange.endTime && chartData.length >= 2;
 
   return (
     <Card className="rounded-sm px-2 py-2 shadow-none">
@@ -452,7 +464,7 @@ export function LogsVolumeChart({
               <Skeleton className="h-full w-full" />
             ) : hasValidData ? (
               <ChartErrorBoundary
-                resetKey={`${startTime}-${endTime}-${chartData.length}`}
+                resetKey={`${effectingTimeRange.startTime}-${effectingTimeRange.endTime}-${chartData.length}`}
               >
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -8,7 +8,6 @@ import { useLazyGetMCPLogsQuery } from "@/lib/store/apis/mcpLogsApi";
 import type { MCPToolLogEntry, MCPToolLogFilters, Pagination } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
 import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
-import { getRangeForPeriod } from "@/lib/utils/timeRange";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import NumberFlow from "@number-flow/react";
 import { useLocation } from "@tanstack/react-router";
@@ -34,11 +33,7 @@ export default function MCPLogsPage() {
 	// Track if user has manually modified the time range
 	const userModifiedTimeRange = useRef<boolean>(false);
 
-	// Capture initial defaults on mount to detect shared URLs with custom time ranges
-	const initialDefaults = useRef(dateUtils.getDefaultTimeRange());
-
 	const defaultTimeRange = useMemo(() => dateUtils.getDefaultTimeRange(), []);
-	const getDefaultTimeRange = () => dateUtils.getDefaultTimeRange();
 
 	const { search } = useLocation();
 	const hasExplicitTimeRange = (search as Record<string, unknown>)?.start_time && (search as Record<string, unknown>)?.end_time;
@@ -70,81 +65,10 @@ export default function MCPLogsPage() {
 	const selectedLogId = urlState.selected_log || null;
 	const polling = urlState.polling;
 
-	// Refresh time range on page focus/visibility
-	useEffect(() => {
-		const refreshDefaultsIfStale = () => {
-			if (!polling) return
-			if (urlState.period) {
-				const { from, to } = getRangeForPeriod(urlState.period);
-				setUrlState(
-					{
-						start_time: Math.floor(from.getTime() / 1000),
-						end_time: Math.floor(to.getTime() / 1000),
-						period: urlState.period ?? "",
-					},
-					{ history: "replace" },
-				);
-				return;
-			}
 
-			if (userModifiedTimeRange.current) return;
-
-			const startTimeDiff = Math.abs(urlState.start_time - initialDefaults.current.startTime);
-			const endTimeDiff = Math.abs(urlState.end_time - initialDefaults.current.endTime);
-			const tolerance = 5;
-			if (startTimeDiff <= tolerance && endTimeDiff <= tolerance) {
-				const defaults = getDefaultTimeRange();
-				const currentEndDiff = Math.abs(urlState.end_time - defaults.endTime);
-				if (currentEndDiff > 300) {
-					setUrlState(
-						{
-							start_time: defaults.startTime,
-							end_time: defaults.endTime,
-							period: urlState.period ?? "",
-						},
-						{ history: "replace" },
-					);
-					initialDefaults.current.startTime = defaults.startTime;
-					initialDefaults.current.endTime = defaults.endTime;
-				}
-			}
-		};
-
-		const handleVisibilityChange = () => {
-			if (!document.hidden) refreshDefaultsIfStale();
-		};
-		const handleFocus = () => refreshDefaultsIfStale();
-
-		document.addEventListener("visibilitychange", handleVisibilityChange);
-		window.addEventListener("focus", handleFocus);
-		return () => {
-			document.removeEventListener("visibilitychange", handleVisibilityChange);
-			window.removeEventListener("focus", handleFocus);
-		};
-	}, [urlState.period, urlState.start_time, urlState.end_time, setUrlState, polling]);
-
-	// Refresh the time window every 5s while live polling is on and a relative period is active.
-	// Updating start_time/end_time changes RTK args → triggers a refetch without needing pollingInterval.
-	useEffect(() => {
-		if (!polling || !urlState.period) return;
-
-		const id = setInterval(() => {
-			if (document.hidden) return;
-			const { from, to } = getRangeForPeriod(urlState.period);
-			setUrlState(
-				{
-					start_time: Math.floor(from.getTime() / 1000),
-					end_time: Math.floor(to.getTime() / 1000),
-					period: urlState.period ?? "",
-				},
-				{ history: "replace" },
-			);
-		}, 5000);
-
-		return () => clearInterval(id);
-	}, [polling, urlState.period, setUrlState]);
-
-	// Convert URL state to filters and pagination for API calls
+	// Convert URL state to filters and pagination for API calls.
+	// When period is set, send it to the backend so the server computes the time window fresh
+	// on every request. For custom absolute ranges (period === "") use the stored timestamps.
 	const filters: MCPToolLogFilters = useMemo(
 		() => ({
 			tool_names: urlState.tool_names,
@@ -152,16 +76,20 @@ export default function MCPLogsPage() {
 			status: urlState.status,
 			virtual_key_ids: urlState.virtual_key_ids,
 			content_search: urlState.content_search,
-			start_time: dateUtils.toISOString(urlState.start_time),
-			end_time: dateUtils.toISOString(urlState.end_time),
+			...(urlState.period
+				? { period: urlState.period }
+				: {
+					start_time: dateUtils.toISOString(urlState.start_time),
+					end_time: dateUtils.toISOString(urlState.end_time),
+				}),
 		}),
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[
 			urlState.tool_names,
 			urlState.server_labels,
 			urlState.status,
 			urlState.virtual_key_ids,
 			urlState.content_search,
+			urlState.period,
 			urlState.start_time,
 			urlState.end_time,
 		],
@@ -177,7 +105,6 @@ export default function MCPLogsPage() {
 		[urlState.limit, urlState.offset, urlState.sort_by, urlState.order],
 	);
 
-	// Non-lazy RTK Query hooks
 	const {
 		data: logsData,
 		isLoading: logsIsLoading,
@@ -187,10 +114,7 @@ export default function MCPLogsPage() {
 	} = useGetMCPLogsQuery(
 		{ filters, pagination },
 		{
-			// When a relative period is active, the setInterval above updates URL timestamps → RTK
-			// detects arg changes and refetches automatically; no separate pollingInterval needed.
-			pollingInterval: showEmptyState ? 3000 : polling && !urlState.period ? 5000 : 0,
-			refetchOnMountOrArgChange: true,
+			pollingInterval: showEmptyState || polling ? 10000 : 0,
 			skipPollingIfUnfocused: true,
 		},
 	);
@@ -199,7 +123,13 @@ export default function MCPLogsPage() {
 		data: statsData,
 		isFetching: statsIsFetching,
 		refetch: refetchStats,
-	} = useGetMCPLogsStatsQuery({ filters }, { refetchOnMountOrArgChange: true });
+	} = useGetMCPLogsStatsQuery(
+		{ filters },
+		{
+			pollingInterval: polling ? 10000 : 0,
+			skipPollingIfUnfocused: true,
+		},
+	);
 
 	const refreshAllData = useCallback(() => {
 		refetchLogs();
@@ -222,25 +152,6 @@ export default function MCPLogsPage() {
 			setShowEmptyState(false);
 		}
 	}, [logsData, showEmptyState]);
-
-	// On mount: freshen period timestamps if stale
-	useEffect(() => {
-		if (urlState.period) {
-			const { from, to } = getRangeForPeriod(urlState.period);
-			const freshEnd = Math.floor(to.getTime() / 1000);
-			if (Math.abs(urlState.end_time - freshEnd) > 60) {
-				setUrlState(
-					{
-						start_time: Math.floor(from.getTime() / 1000),
-						end_time: freshEnd,
-						period: urlState.period ?? "",
-					},
-					{ history: "replace" },
-				);
-			}
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, []);
 
 	// Helper to update filters in URL
 	const setFilters = useCallback(
@@ -295,13 +206,22 @@ export default function MCPLogsPage() {
 	);
 
 	const handlePeriodChange = useCallback(
-		(p: string, from: Date, to: Date) => {
-			setUrlState({
-				period: p,
-				start_time: Math.floor(from.getTime() / 1000),
-				end_time: Math.floor(to.getTime() / 1000),
-				offset: 0,
-			});
+		(p?: string, from?: Date, to?: Date) => {
+			if (p) {
+				setUrlState({
+					period: p,
+					offset: 0,
+					polling: true
+				});
+			} else if (from && to) {
+				setUrlState({
+					start_time: Math.floor(from.getTime() / 1000),
+					end_time: Math.floor(to.getTime() / 1000),
+					offset: 0,
+					polling: false,
+					period: ""
+				});
+			}
 		},
 		[setUrlState],
 	);

--- a/ui/app/workspace/mcp-logs/views/mcpHeaderView.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpHeaderView.tsx
@@ -11,7 +11,7 @@ interface McpHeaderViewProps {
 	filters: MCPToolLogFilters;
 	onFiltersChange: (filters: MCPToolLogFilters) => void;
 	period: string;
-	onPeriodChange: (period: string, from: Date, to: Date) => void;
+	onPeriodChange: (period?: string, from?: Date, to?: Date) => void;
 	polling: boolean;
 	onPollToggle: (enabled: boolean) => void;
 	onRefresh: () => void;
@@ -109,11 +109,7 @@ export function McpHeaderView({
 				onDateTimeUpdate={(p) => {
 					setStartTime(p.from);
 					setEndTime(p.to);
-					onFiltersChange({
-						...filters,
-						start_time: p.from?.toISOString(),
-						end_time: p.to?.toISOString(),
-					});
+					onPeriodChange(undefined, p.from, p.to);
 				}}
 				preDefinedPeriods={TIME_PERIODS}
 				onPredefinedPeriodChange={(periodValue) => {

--- a/ui/components/filters/logsFilterSidebar.tsx
+++ b/ui/components/filters/logsFilterSidebar.tsx
@@ -43,7 +43,7 @@ export function LogsFilterSidebar({ filters, onFiltersChange }: LogsSidebarProps
 	}, []);
 
 	const activeFilterCount = useMemo(() => {
-		const excludedKeys = ["start_time", "end_time", "content_search", "metadata_filters"];
+		const excludedKeys = ["start_time", "end_time", "content_search", "metadata_filters", "period", "polling"];
 		let count = Object.entries(filters).reduce((c, [key, value]) => {
 			if (excludedKeys.includes(key)) return c;
 			if (Array.isArray(value)) return c + value.length;

--- a/ui/components/filters/mcpFilterSidebar.tsx
+++ b/ui/components/filters/mcpFilterSidebar.tsx
@@ -43,7 +43,7 @@ export function MCPFilterSidebar({ filters, onFiltersChange }: MCPFilterSidebarP
 	}, []);
 
 	const activeFilterCount = useMemo(() => {
-		const excludedKeys = ["start_time", "end_time", "content_search"];
+		const excludedKeys = ["start_time", "end_time", "content_search", "period", "polling"];
 		let count = Object.entries(filters).reduce((c, [key, value]) => {
 			if (excludedKeys.includes(key)) return c;
 			if (Array.isArray(value)) return c + value.length;

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -54,8 +54,12 @@ function buildFilterParams(filters: LogFilters): Record<string, string | number>
 	if (filters.routing_engine_used && filters.routing_engine_used.length > 0) {
 		params.routing_engine_used = filters.routing_engine_used.join(",");
 	}
-	if (filters.start_time) params.start_time = filters.start_time;
-	if (filters.end_time) params.end_time = filters.end_time;
+	if (filters.period) {
+		params.period = filters.period;
+	} else {
+		if (filters.start_time) params.start_time = filters.start_time;
+		if (filters.end_time) params.end_time = filters.end_time;
+	}
 	if (filters.min_latency !== undefined) params.min_latency = filters.min_latency;
 	if (filters.max_latency !== undefined) params.max_latency = filters.max_latency;
 	if (filters.min_tokens !== undefined) params.min_tokens = filters.min_tokens;

--- a/ui/lib/store/apis/mcpLogsApi.ts
+++ b/ui/lib/store/apis/mcpLogsApi.ts
@@ -28,8 +28,12 @@ function buildMCPFilterParams(filters: MCPToolLogFilters): Record<string, string
 	if (filters.llm_request_ids && filters.llm_request_ids.length > 0) {
 		params.llm_request_ids = filters.llm_request_ids.join(",");
 	}
-	if (filters.start_time) params.start_time = filters.start_time;
-	if (filters.end_time) params.end_time = filters.end_time;
+	if (filters.period) {
+		params.period = filters.period;
+	} else {
+		if (filters.start_time) params.start_time = filters.start_time;
+		if (filters.end_time) params.end_time = filters.end_time;
+	}
 	if (filters.min_latency !== undefined) params.min_latency = filters.min_latency;
 	if (filters.max_latency !== undefined) params.max_latency = filters.max_latency;
 	if (filters.content_search) params.content_search = filters.content_search;
@@ -75,8 +79,12 @@ export const mcpLogsApi = baseApi.injectEndpoints({
 				if (filters.llm_request_ids && filters.llm_request_ids.length > 0) {
 					params.llm_request_ids = filters.llm_request_ids.join(",");
 				}
-				if (filters.start_time) params.start_time = filters.start_time;
-				if (filters.end_time) params.end_time = filters.end_time;
+				if (filters.period) {
+					params.period = filters.period;
+				} else {
+					if (filters.start_time) params.start_time = filters.start_time;
+					if (filters.end_time) params.end_time = filters.end_time;
+				}
 				if (filters.min_latency) params.min_latency = filters.min_latency;
 				if (filters.max_latency) params.max_latency = filters.max_latency;
 				if (filters.content_search) params.content_search = filters.content_search;
@@ -115,8 +123,12 @@ export const mcpLogsApi = baseApi.injectEndpoints({
 				if (filters.llm_request_ids && filters.llm_request_ids.length > 0) {
 					params.llm_request_ids = filters.llm_request_ids.join(",");
 				}
-				if (filters.start_time) params.start_time = filters.start_time;
-				if (filters.end_time) params.end_time = filters.end_time;
+				if (filters.period) {
+					params.period = filters.period;
+				} else {
+					if (filters.start_time) params.start_time = filters.start_time;
+					if (filters.end_time) params.end_time = filters.end_time;
+				}
 				if (filters.min_latency) params.min_latency = filters.min_latency;
 				if (filters.max_latency) params.max_latency = filters.max_latency;
 				if (filters.content_search) params.content_search = filters.content_search;

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -576,6 +576,7 @@ export interface LogFilters {
 	objects?: string[]; // For filtering by request type (chat.completion, text.completion, embedding)
 	start_time?: string; // RFC3339 format
 	end_time?: string; // RFC3339 format
+	period?: string; // relative period ("1h","6h","24h","7d","30d"); computed server-side, takes precedence over start_time/end_time
 	min_latency?: number;
 	max_latency?: number;
 	min_tokens?: number;
@@ -1052,6 +1053,7 @@ export interface MCPToolLogFilters {
 	llm_request_ids?: string[];
 	start_time?: string; // RFC3339 format
 	end_time?: string; // RFC3339 format
+	period?: string; // relative period ("1h","6h","24h","7d","30d"); computed server-side, takes precedence over start_time/end_time
 	min_latency?: number;
 	max_latency?: number;
 	content_search?: string;


### PR DESCRIPTION
## Summary

Replaces the client-side `setInterval` + URL timestamp mutation approach for live polling with a simpler, backend-driven model. When a relative period (e.g. `"1h"`, `"24h"`) is active, the period string is now sent directly to the backend, which computes the time window fresh on every request. RTK Query's built-in `pollingInterval` handles all polling uniformly, eliminating the need to manually update `start_time`/`end_time` in the URL to trigger refetches.

Additionally, the full-page loader that blocked rendering during initial load has been removed. Loading state is now surfaced inline inside the table with a "Loading logs..." spinner row.

## Changes

- Removed `setInterval`-based effects that updated `start_time`/`end_time` in the URL to force RTK refetches when a relative period was active
- Removed focus/visibility `useEffect` handlers that re-synced URL timestamps on tab return
- When `urlState.period` is set, filters now pass `{ period }` to the API instead of `{ start_time, end_time }`; absolute custom ranges continue to use stored timestamps
- Simplified `pollingInterval` conditions from `polling && !period ? 5000 : 0` to `polling ? 5000 : 0` across logs, stats, and histogram queries
- Added `period` to `LogFilters` and `MCPToolLogFilters` types; API param builders send `period` exclusively when present, skipping `start_time`/`end_time`
- Removed `FullPageLoader` from the logs page; initial loading is now shown as an inline spinner row inside `LogsDataTable` and `MCPLogsDataTable`
- Added `pollingInterval` and `skipPollingIfUnfocused` to `useGetMCPLogsStatsQuery`, which previously had no polling configured
- Fixed `isZoomed` default range comparison from 24 hours to 1 hour to match the actual default time window

## Type of change

- [x] Refactor

## Affected areas

- [x] UI (React)

## How to test

1. Navigate to the Logs page with live polling enabled and a relative period selected (e.g., "Last 1 hour")
2. Confirm data refreshes every 5 seconds without URL timestamp changes in the browser history
3. Switch to a custom absolute time range and confirm `start_time`/`end_time` are sent instead of `period`
4. On initial page load, confirm an inline "Loading logs..." message appears in the table instead of a full-page spinner
5. Repeat steps 1–4 on the MCP Logs page and confirm polling behavior is consistent

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable