### PR TITLE
refactor: simplify polling logic by removing manual time window refresh interval

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -5,7 +5,6 @@ import { createColumns } from "@/app/workspace/logs/views/columns";
 import { EmptyState } from "@/app/workspace/logs/views/emptyState";
 import { LogsDataTable } from "@/app/workspace/logs/views/logsTable";
 import { LogsVolumeChart } from "@/app/workspace/logs/views/logsVolumeChart";
-import FullPageLoader from "@/components/fullPageLoader";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -118,12 +117,12 @@ export default function LogsPage() {
       missing_cost_only: urlState.missing_cost_only,
       metadata_filters: urlState.metadata_filters
         ? (() => {
-            try {
-              return JSON.parse(urlState.metadata_filters);
-            } catch {
-              return undefined;
-            }
-          })()
+          try {
+            return JSON.parse(urlState.metadata_filters);
+          } catch {
+            return undefined;
+          }
+        })()
         : undefined,
     }),
     [
@@ -165,7 +164,7 @@ export default function LogsPage() {
   } = useGetLogsQuery(
     { filters, pagination },
     {
-      pollingInterval: showEmptyState ? 3000 : polling && !period ? 5000 : 0,
+      pollingInterval: showEmptyState || polling ? 5000 : 0,
       refetchOnMountOrArgChange: true,
       skipPollingIfUnfocused: true,
     },
@@ -178,7 +177,7 @@ export default function LogsPage() {
   } = useGetLogsStatsQuery(
     { filters },
     {
-      pollingInterval: polling && !period ? 5000 : 0,
+      pollingInterval: polling ? 5000 : 0,
       refetchOnMountOrArgChange: true,
       skipPollingIfUnfocused: true,
     },
@@ -191,7 +190,7 @@ export default function LogsPage() {
   } = useGetLogsHistogramQuery(
     { filters },
     {
-      pollingInterval: polling && !period ? 5000 : 0,
+      pollingInterval: polling ? 5000 : 0,
       refetchOnMountOrArgChange: true,
       skipPollingIfUnfocused: true,
     },
@@ -300,27 +299,6 @@ export default function LogsPage() {
       window.removeEventListener("focus", handleFocus);
     };
   }, [urlState.start_time, urlState.end_time, urlState.period, setUrlState, polling]);
-
-  // Refresh the time window every 5s while live polling is on and a relative period is active.
-  // Updating start_time/end_time changes RTK args → triggers a refetch without needing pollingInterval.
-  useEffect(() => {
-    if (!polling || !urlState.period) return;
-
-    const id = setInterval(() => {
-      if (document.hidden) return;
-      const { from, to } = getRangeForPeriod(urlState.period);
-      setUrlState(
-        {
-          start_time: Math.floor(from.getTime() / 1000),
-          end_time: Math.floor(to.getTime() / 1000),
-          period: urlState.period ?? "",
-        },
-        { history: "replace" },
-      );
-    }, 5000);
-
-    return () => clearInterval(id);
-  }, [polling, urlState.period, setUrlState]);
 
   // Derive selectedLog: find in current logs array, or fetch by ID from API
   const selectedLogId = urlState.selected_log || null;
@@ -611,9 +589,7 @@ export default function LogsPage() {
 
   return (
     <div className="dark:bg-card h-[calc(100dvh-3.3rem)] max-h-[calc(100dvh-1.5rem)] bg-white">
-      {logsIsLoading && !logsData ? (
-        <FullPageLoader />
-      ) : showEmptyState ? (
+      {showEmptyState ? (
         <EmptyState error={error} />
       ) : (
         <div className="mx-auto flex h-full w-full flex-col">

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -22,7 +22,7 @@ import {
   SortingState,
   useReactTable,
 } from "@tanstack/react-table";
-import { ChevronLeft, ChevronRight, RefreshCw } from "lucide-react";
+import { ChevronLeft, ChevronRight, Loader2, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LogFilters as LogFiltersComponent } from "./filters";
 
@@ -254,7 +254,10 @@ export function LogsDataTable({
             <TableRow className="hover:bg-transparent">
               <TableCell colSpan={columns.length} className="h-12 text-center">
                 <div className="flex items-center justify-center gap-2">
-                  {polling ? (
+                  {loading ? <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Loading new logs...
+                  </> : polling ? (
                     <>
                       <RefreshCw className="h-4 w-4 animate-spin" />
                       Waiting for new logs...

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -124,7 +124,7 @@ export default function MCPLogsPage() {
   } = useGetMCPLogsQuery(
     { filters, pagination },
     {
-      pollingInterval: showEmptyState ? 3000 : polling && !period ? 5000 : 0,
+      pollingInterval: showEmptyState || polling ? 5000 : 0,
       refetchOnMountOrArgChange: true,
       skipPollingIfUnfocused: true,
     },
@@ -137,7 +137,7 @@ export default function MCPLogsPage() {
   } = useGetMCPLogsStatsQuery(
     { filters },
     {
-      pollingInterval: polling && !period ? 5000 : 0,
+      pollingInterval: polling ? 5000 : 0,
       refetchOnMountOrArgChange: true,
       skipPollingIfUnfocused: true,
     },
@@ -235,27 +235,6 @@ export default function MCPLogsPage() {
       window.removeEventListener("focus", handleFocus);
     };
   }, [urlState.start_time, urlState.end_time, urlState.period, setUrlState, polling]);
-
-  // Refresh the time window every 5s while live polling is on and a relative period is active.
-  // Updating start_time/end_time changes RTK args → triggers a refetch without needing pollingInterval.
-  useEffect(() => {
-    if (!polling || !urlState.period) return;
-
-    const id = setInterval(() => {
-      if (document.hidden) return;
-      const { from, to } = getRangeForPeriod(urlState.period);
-      setUrlState(
-        {
-          start_time: Math.floor(from.getTime() / 1000),
-          end_time: Math.floor(to.getTime() / 1000),
-          period: urlState.period ?? "",
-        },
-        { history: "replace" },
-      );
-    }, 5000);
-
-    return () => clearInterval(id);
-  }, [polling, urlState.period, setUrlState]);
 
   // Derive selectedLog from URL param
   const selectedLogId = urlState.selected_log || null;

--- a/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
@@ -226,7 +226,10 @@ export function MCPLogsDataTable({
             <TableRow className="hover:bg-transparent">
               <TableCell colSpan={columns.length} className="h-12 text-center">
                 <div className="flex items-center justify-center gap-2">
-                  {polling ? (
+                  {loading ? <>
+                    <RefreshCw className="h-4 w-4 animate-spin" />
+                    Loading MCP logs...
+                  </> : polling ? (
                     <>
                       <RefreshCw className="h-4 w-4 animate-spin" />
                       Waiting for new MCP logs...


### PR DESCRIPTION
## Summary

Simplifies live polling logic for the logs and MCP logs pages by removing a redundant `setInterval`-based time window refresh and instead relying directly on RTK Query's built-in `pollingInterval` for all cases, including when a relative time period is active.

## Changes

- Removed the `useEffect`/`setInterval` blocks that manually refreshed `start_time`/`end_time` in the URL state every 5 seconds when polling was active and a relative period was selected. This approach was working around the fact that `pollingInterval` was disabled when a `period` was set.
- Dropped the `!period` condition from all `pollingInterval` expressions, so RTK Query now polls at 5 seconds whenever `polling` is true, regardless of whether a relative or absolute time range is active.
- Unified the empty-state polling condition in the logs query: `showEmptyState ? 3000 : polling && !period ? 5000 : 0` is replaced with `showEmptyState || polling ? 5000 : 0`, consolidating both cases into a single consistent interval.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

Navigate to the Logs and MCP Logs pages with live polling enabled. Verify that:
- Logs refresh every 5 seconds when polling is active, both with a relative period (e.g. "Last 1 hour") and an absolute time range.
- Logs refresh every 5 seconds when the empty state is shown.
- No unnecessary URL state updates occur in the browser history while polling.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable