### PR TITLE
feat: add semantic cache (Redis/Weaviate) and client-config Helm example layers

### DIFF
--- a/examples/k8s/examples/README.md
+++ b/examples/k8s/examples/README.md
@@ -8,6 +8,9 @@ These examples are split into composable value files so you can combine them wit
 - `values-storage-sqlite.yaml` - Storage layer for SQLite StatefulSet mode
 - `values-storage-postgres.yaml` - Storage layer for Postgres mode (chart-managed Postgres)
 - `values-providers.yaml` - Provider keys layer (`openai` + `anthropic`)
+- `values-client-configs.yaml` - Client settings layer (non-MCP, non-model client config options)
+- `values-semantic-search-redis.yaml` - Semantic cache + Redis vector store layer
+- `values-semantic-search-weaviate.yaml` - Semantic cache + Weaviate vector store layer
 - `values-mcp-routing.yaml` - MCP + routing layer (latest `mcp.*` globals, MCP client config, chain rule/fallback examples)
 - `values-governance-teams.yaml` - Governance base layer (budgets, rate limits, customers, teams)
 - `values-with-routing-rules-pricing.yaml` - Advanced governance layer (virtual keys, routing rules, pricing overrides, access profile)
@@ -89,6 +92,40 @@ helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
   --wait \
   --timeout 5m
 
+# Client settings stack (SQLite + providers + client-config overlay)
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-sqlite.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/examples/values-client-configs.yaml \
+  --wait \
+  --timeout 5m
+
+# Semantic search stack (Redis vector store)
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-sqlite.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/examples/values-semantic-search-redis.yaml \
+  --wait \
+  --timeout 5m
+
+# Note: this Redis semantic layer uses Redis Stack (search-enabled) because
+# semantic cache requires FT.* commands (RediSearch module). Redis Stack
+# auto-loads search modules at startup.
+
+# Semantic search stack (Weaviate vector store)
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-sqlite.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/examples/values-semantic-search-weaviate.yaml \
+  --wait \
+  --timeout 5m
+
 # MCP + routing stack (SQLite + providers + MCP/routing overlay)
 helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
   --namespace "${NAMESPACE}" \
@@ -108,6 +145,67 @@ helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
   -f examples/k8s/examples/values-governance-teams.yaml \
   -f examples/k8s/examples/values-with-routing-rules-pricing.yaml \
   -f examples/k8s/examples/values-with-pod-label.yaml \
+  --wait \
+  --timeout 5m
+  
+```
+
+## Dashboard auth env vars
+
+`values-client-configs.yaml` enables dashboard auth and uses:
+
+- `env.BIFROST_ADMIN_USERNAME`
+- `env.BIFROST_ADMIN_PASSWORD`
+
+Create a secret and inject it via `envFrom`:
+
+```bash
+kubectl -n "${NAMESPACE}" create secret generic bifrost-admin-auth \
+  --from-literal=BIFROST_ADMIN_USERNAME=admin \
+  --from-literal=BIFROST_ADMIN_PASSWORD='change-me' \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+```yaml
+# Add this in your layered values (or pass with --set/--set-file)
+envFrom:
+  - secretRef:
+      name: bifrost-admin-auth
+```
+
+Then include `examples/k8s/examples/values-client-configs.yaml` in your Helm command.
+
+## Local image deploy commands
+
+If you built a local image (for example `bifrost-local:v1.5.0-prerelease21`) and want
+to run with `image.pullPolicy=Never`, use commands like:
+
+```bash
+# Semantic search + Redis + client config (local image)
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-sqlite.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/examples/values-client-configs.yaml \
+  -f examples/k8s/examples/values-semantic-search-redis.yaml \
+  --set image.repository=bifrost-local \
+  --set image.tag=v1.5.0-prerelease21 \
+  --set image.pullPolicy=Never \
+  --wait \
+  --timeout 5m
+
+# Semantic search + Weaviate + client config (local image)
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-sqlite.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/examples/values-client-configs.yaml \
+  -f examples/k8s/examples/values-semantic-search-weaviate.yaml \
+  --set image.repository=bifrost-local \
+  --set image.tag=v1.5.0-prerelease21 \
+  --set image.pullPolicy=Never \
   --wait \
   --timeout 5m
 ```

--- a/examples/k8s/examples/values-client-configs.yaml
+++ b/examples/k8s/examples/values-client-configs.yaml
@@ -1,0 +1,58 @@
+# Client configuration example layer (non-MCP, non-model settings).
+# Merge with examples/k8s/examples/values.yaml when testing.
+bifrost:
+  # Dashboard/API auth (password protect dashboard) using env-backed credentials.
+  # The chart renders these into config.json auth_config.admin_username/admin_password.
+  authConfig:
+    isEnabled: true
+    disableAuthOnInference: false
+    adminUsername: "env.BIFROST_ADMIN_USERNAME"
+    adminPassword: "env.BIFROST_ADMIN_PASSWORD"
+
+  client:
+    dropExcessRequests: true
+    disableDbPingsInHealth: true
+    initialPoolSize: 301
+    allowedOrigins:
+      - "*"
+      - "https://app.example.com"
+    enableLogging: true
+    disableContentLogging: false
+    logRetentionDays: 365
+    # Deprecated in transport schema; prefer enforceAuthOnInference.
+    enforceSCIMAuth: false
+    allowDirectKeys: true
+    maxRequestBodySizeMb: 101
+    compat:
+      convertTextToChat: true
+      convertChatToResponses: true
+      shouldDropParams: true
+      shouldConvertParams: true
+    prometheusLabels:
+      - "env:dev"
+      - "team:platform"
+    headerFilterConfig:
+      allowlist:
+        - "x-trace-id"
+      denylist:
+        - "authorization"
+    asyncJobResultTTL: 3623
+    requiredHeaders:
+      - "x-request-id"
+    loggingHeaders:
+      - "x-request-id"
+      - "x-session-id"
+    whitelistedRoutes:
+      - "/health"
+      - "/readyz"
+    hideDeletedVirtualKeysInFilters: true
+    allowedHeaders:
+      - "x-request-id"
+      - "x-session-id"
+      - "x-correlation-id"
+    routingChainMaxDepth: 10
+
+# Inject dashboard auth env vars used by bifrost.authConfig above.
+envFrom:
+  - secretRef:
+      name: bifrost-admin-auth

--- a/examples/k8s/examples/values-semantic-search-redis.yaml
+++ b/examples/k8s/examples/values-semantic-search-redis.yaml
@@ -1,0 +1,28 @@
+# Semantic search/cache layer using Redis vector store (chart-managed).
+# Merge with values.yaml + storage + providers layers.
+bifrost:
+  plugins:
+    semanticCache:
+      enabled: true
+      version: 1
+      config:
+        provider: "openai"
+        # Embedding provider keys for semantic cache.
+        keys:
+          - "env.OPENAI_API_KEY"
+        embedding_model: "text-embedding-3-small"
+        dimension: 1536
+        threshold: 0.8
+        ttl: "5m"
+        conversation_history_threshold: 3
+        cache_by_model: true
+        cache_by_provider: true
+        exclude_system_prompt: true
+        cleanup_on_shutdown: false
+        vector_store_namespace: "bifrost-semantic-cache"
+
+vectorStore:
+  enabled: true
+  type: redis
+  redis:
+    enabled: true

--- a/examples/k8s/examples/values-semantic-search-weaviate.yaml
+++ b/examples/k8s/examples/values-semantic-search-weaviate.yaml
@@ -1,0 +1,28 @@
+# Semantic search/cache layer using Weaviate vector store (chart-managed).
+# Merge with values.yaml + storage + providers layers.
+bifrost:
+  plugins:
+    semanticCache:
+      enabled: true
+      version: 1
+      config:
+        provider: "openai"
+        # Embedding provider keys for semantic cache.
+        keys:
+          - "env.OPENAI_API_KEY"
+        embedding_model: "text-embedding-3-small"
+        dimension: 1536
+        threshold: 0.8
+        ttl: "5m"
+        conversation_history_threshold: 3
+        cache_by_model: true
+        cache_by_provider: true
+        exclude_system_prompt: false
+        cleanup_on_shutdown: false
+        vector_store_namespace: "bifrost-semantic-cache"
+
+vectorStore:
+  enabled: true
+  type: weaviate
+  weaviate:
+    enabled: true

--- a/helm-charts/bifrost/templates/redis-deployment.yaml
+++ b/helm-charts/bifrost/templates/redis-deployment.yaml
@@ -39,7 +39,11 @@ spec:
             {{- end }}
           {{- if .Values.vectorStore.redis.auth.enabled }}
           command:
+            {{- if contains "redis-stack" .Values.vectorStore.redis.image.repository }}
+            - redis-stack-server
+            {{- else }}
             - redis-server
+            {{- end }}
             - --requirepass
             - $(REDIS_PASSWORD)
           {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3004,7 +3004,7 @@
           ]
         },
         "url": {
-          "oneOf": [
+          "anyOf": [
             {
               "type": "string",
               "pattern": "^env\\.[A-Za-z0-9_]+$"

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -869,8 +869,8 @@ vectorStore:
 
     # Redis image configuration
     image:
-      repository: redis
-      tag: "7-alpine"
+      repository: redis/redis-stack-server
+      tag: "7.2.0-v20"
       pullPolicy: IfNotPresent
 
     # Redis subchart configuration (when redis.enabled is true)


### PR DESCRIPTION
## Summary

Adds three new composable Helm value files for client configuration, Redis-backed semantic cache, and Weaviate-backed semantic cache. The default Redis image is also updated to `redis/redis-stack-server` to ensure RediSearch (`FT.*`) commands are available out of the box for semantic cache functionality.

## Changes

- Added `values-client-configs.yaml` covering non-MCP, non-model client settings including auth config, logging, header filtering, CORS origins, routing chain depth, and other `bifrost.client.*` options. Dashboard auth credentials are injected via a Kubernetes secret referenced through `envFrom`.
- Added `values-semantic-search-redis.yaml` enabling the semantic cache plugin with a chart-managed Redis Stack vector store. Includes a note that Redis Stack (with the RediSearch module loaded) is required for `FT.*` commands.
- Added `values-semantic-search-weaviate.yaml` enabling the semantic cache plugin with a chart-managed Weaviate vector store.
- Updated the default Redis image from `redis:7-alpine` to `redis/redis-stack-server:7.2.0-v20` so semantic cache works without additional module configuration.
- Updated `redis-deployment.yaml` to use `redis-stack-server` as the entrypoint command when the image repository contains `redis-stack`, falling back to `redis-server` otherwise.
- Changed the `vectorStore.url` JSON schema validation from `oneOf` to `anyOf` to allow broader matching.
- Extended `README.md` with helm install commands for the new stacks, dashboard auth secret setup instructions, and local image deploy examples.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
# Client config stack
helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
  --namespace "${NAMESPACE}" \
  -f examples/k8s/examples/values.yaml \
  -f examples/k8s/examples/values-storage-sqlite.yaml \
  -f examples/k8s/examples/values-providers.yaml \
  -f examples/k8s/examples/values-client-configs.yaml \
  --wait --timeout 5m

# Semantic cache with Redis Stack
helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
  --namespace "${NAMESPACE}" \
  -f examples/k8s/examples/values.yaml \
  -f examples/k8s/examples/values-storage-sqlite.yaml \
  -f examples/k8s/examples/values-providers.yaml \
  -f examples/k8s/examples/values-semantic-search-redis.yaml \
  --wait --timeout 5m

# Semantic cache with Weaviate
helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
  --namespace "${NAMESPACE}" \
  -f examples/k8s/examples/values.yaml \
  -f examples/k8s/examples/values-storage-sqlite.yaml \
  -f examples/k8s/examples/values-providers.yaml \
  -f examples/k8s/examples/values-semantic-search-weaviate.yaml \
  --wait --timeout 5m
```

Before testing `values-client-configs.yaml`, create the required secret:

```sh
kubectl -n "${NAMESPACE}" create secret generic bifrost-admin-auth \
  --from-literal=BIFROST_ADMIN_USERNAME=admin \
  --from-literal=BIFROST_ADMIN_PASSWORD='change-me' \
  --dry-run=client -o yaml | kubectl apply -f -
```

Verify the Redis pod starts with `redis-stack-server` and that semantic cache queries return cache hits after the first request.

## Breaking changes

- [x] Yes
- [ ] No

The default Redis image has changed from `redis:7-alpine` to `redis/redis-stack-server:7.2.0-v20`. Existing deployments using the default Redis image will have their Redis pod recreated with the new image on the next `helm upgrade`. Deployments that explicitly pin `vectorStore.redis.image.repository` and `vectorStore.redis.image.tag` are unaffected.

## Related issues

## Security considerations

Dashboard admin credentials (`BIFROST_ADMIN_USERNAME`, `BIFROST_ADMIN_PASSWORD`) must be stored in a Kubernetes secret and injected via `envFrom`. They should never be hardcoded in values files committed to source control.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable