### PR TITLE
v1.4.23 cut

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -9,3 +9,10 @@
 - fix: delete fallbacks from outgoing Anthropic requests
 - feat: claude-opus-4-7 compatibility
 - fix: token usage for vllm
+- feat: adds dedicated streaming HTTP client per provider to eliminate timeouts on long-lived SSE connections
+- fix: drops empty thinking blocks from Anthropic requests to prevent HTTP 400 errors on Claude Code requests
+- fix: concurrent map panic in PluginPipeline during streaming — guarded postHookTimings with streamingMu and fixed double-pool-release race
+- fix: stream cancellation safety — guarded channel sends and finalizer protection prevent goroutine leaks on client disconnect
+- feat: add support for Anthropic structured output and response format (thanks [@emirhanmutlu-natuvion](https://github.com/emirhanmutlu-natuvion)!)
+- feat: preserve MCP tool annotations in bidirectional MCP-to-Bifrost schema conversion
+- fix: prevent send on closed channel panic in provider queue shutdown

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,1 +1,5 @@
+- chore: upgraded core to v1.4.20
 - feat: automatically add incoming model to empty fallbacks in routing rules
+- fix: preserve context values in async requests
+- fix: capture responses streaming API errors
+- fix: allow custom providers without list-models endpoint to accept any model

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,1 +1,28 @@
-- feat: add support for dynamically selecting incoming model for fallbacks in routing rules
+## ✨ Features
+
+- **Dedicated Streaming Client** — Each provider now uses a separate HTTP client for streaming requests with read-timeout cleared, eliminating premature SSE/EventStream termination on long-running responses; per-chunk idle detection is enforced via `NewIdleTimeoutReader`
+- **Anthropic Structured Outputs** — Added `response_format` and structured output support for Anthropic models across chat completions and Responses API, including JSON-schema and JSON-object formats with order-preserving merge of additional model request fields (thanks [@emirhanmutlu-natuvion](https://github.com/emirhanmutlu-natuvion)!)
+- **MCP Tool Annotations** — Preserve MCP tool annotations (`title`, `readOnly`, `destructive`, `idempotent`, `openWorld`) in bidirectional conversion between MCP tools and Bifrost chat tools so agents can reason about tool behavior
+- **Claude Opus 4.7 Support** — Added compatibility for Claude Opus 4.7, including adaptive thinking, task-budgets beta header, `display` parameter handling, and "xhigh" effort mapping
+- **Routing Rules Auto-resolve Model** — Provider-only fallbacks now automatically inherit the incoming model, removing the need to repeat model names in fallback config
+
+## 🐞 Fixed
+
+- **Anthropic Empty Thinking Blocks** — Strip `thinking`-typed content blocks with empty `"thinking"` fields before sending to Anthropic, preventing HTTP 400 errors from Claude Code requests
+- **Plugin Timer Concurrent Map Panic** — Added `streamingMu sync.Mutex` to `PluginPipeline` to guard `postHookTimings` across concurrent goroutines during streaming; also fixed a double-pool-release race on streaming errors
+- **Stream Cancellation Safety** — Guarded channel sends and finalizer protection prevent goroutine leaks when clients disconnect mid-stream
+- **Gemini Tool Outputs** — Handle content block tool outputs in Responses API path for `function_call_output` messages (thanks [@tom-diacono](https://github.com/tom-diacono)!)
+- **Gemini Thinking Level** — Preserved `thinkingLevel` parameters across round-trip conversions and corrected finish reason mapping
+- **Bedrock Streaming** — Emit `message_stop` event for Anthropic invoke stream and case-insensitive `anthropic-beta` header merging (thanks [@tefimov](https://github.com/tefimov)!)
+- **Bedrock Tool Images** — Preserve image content blocks in tool results when converting Anthropic Messages to Bedrock Converse API (thanks [@Edward-Upton](https://github.com/Edward-Upton)!)
+- **OpenAI Tool Result Output** — Flatten array-form `tool_result` content into a string before marshaling for the Responses API so strict upstreams no longer reject with HTTP 400 (thanks [@martingiguere](https://github.com/martingiguere)!)
+- **vLLM Token Usage** — Treat `delta.content=""` same as `nil` in streaming so the synthesis chunk retains `finish_reason`, restoring token usage in logs and UI
+- **Anthropic WebSearch** — Removed the Claude Code user agent restriction so WebSearch tool arguments flow for all clients
+- **Anthropic Request Fallbacks** — Dropped fallback fields from outgoing Anthropic requests to avoid schema validation errors
+- **Responses Streaming Errors** — Capture errors mid-stream in the Responses API so clients see failures instead of silent termination
+- **Async Context Propagation** — Preserve context values in async requests so downstream handlers retain request-scoped data
+- **Custom Providers** — Allow custom providers without a list-models endpoint to accept any model rather than restricting on virtual key registration
+- **OTEL Plugin** — Default `insecure` to `true` in config.json and include fallbacks in emitted OTEL metrics
+- **Logs UI** — Switched from WebSocket push to polling for log updates; fixed polling mechanism and defaults the time range to the last hour in logs and dashboard
+- **Helm mcpClientConfig** — Fixed templating for `mcpClientConfig` (thanks [@crust3780](https://github.com/crust3780)!)
+- **Payload Marshalling** — Removed unnecessary marshalling of payload in the transport path


### PR DESCRIPTION
## Summary

This release brings stability and correctness improvements across the core, framework, and transports layers — addressing concurrency panics, stream lifecycle issues, and provider-specific bugs — alongside new features including dedicated streaming HTTP clients, Anthropic structured output support, MCP tool annotation preservation, and Claude Opus 4.7 compatibility.

## Changes

- **Dedicated streaming HTTP client per provider** — Each provider now uses a separate HTTP client with read-timeout cleared for SSE connections, with per-chunk idle detection via `NewIdleTimeoutReader`, eliminating premature stream termination on long-running responses
- **Anthropic structured outputs** — Added `response_format` and structured output support (JSON-schema and JSON-object) for Anthropic models across chat completions and Responses API, with order-preserving merge of additional model request fields
- **MCP tool annotations** — `title`, `readOnly`, `destructive`, `idempotent`, and `openWorld` annotations are now preserved in bidirectional MCP-to-Bifrost schema conversion
- **Claude Opus 4.7 compatibility** — Added adaptive thinking, task-budgets beta header, `display` parameter handling, and `xhigh` effort mapping
- **Concurrent map panic fix** — Added `streamingMu sync.Mutex` to `PluginPipeline` to guard `postHookTimings` during streaming; fixed a double-pool-release race on streaming errors
- **Stream cancellation safety** — Guarded channel sends and finalizer protection prevent goroutine leaks on client disconnect
- **Anthropic empty thinking blocks** — Strip `thinking`-typed content blocks with empty `"thinking"` fields before sending to Anthropic to prevent HTTP 400 errors from Claude Code requests
- **Provider queue shutdown** — Prevent send-on-closed-channel panic during provider queue shutdown
- **Bedrock streaming** — Emit `message_stop` event for Anthropic invoke stream and case-insensitive `anthropic-beta` header merging
- **Bedrock tool images** — Preserve image content blocks in tool results when converting Anthropic Messages to Bedrock Converse API
- **OpenAI tool result output** — Flatten array-form `tool_result` content into a string before marshaling for the Responses API to prevent HTTP 400 rejections
- **vLLM token usage** — Treat `delta.content=""` same as `nil` in streaming so the synthesis chunk retains `finish_reason`, restoring token usage in logs and UI
- **Gemini tool outputs and thinking level** — Handle `function_call_output` in Responses API path and preserve `thinkingLevel` across round-trip conversions with corrected finish reason mapping
- **Async context propagation** — Preserve context values in async requests so downstream handlers retain request-scoped data
- **Custom providers** — Allow custom providers without a list-models endpoint to accept any model
- **Routing rules auto-resolve** — Provider-only fallbacks now automatically inherit the incoming model
- **OTEL plugin** — Default `insecure` to `true` in config and include fallbacks in emitted metrics
- **Logs UI** — Switched from WebSocket push to polling for log updates; defaults time range to the last hour
- **Helm `mcpClientConfig`** — Fixed templating for `mcpClientConfig`
- **Payload marshalling** — Removed unnecessary marshalling of payload in the transport path

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

- Validate SSE streams on long-running Anthropic/Gemini/Bedrock requests do not time out prematurely
- Send a Claude Code request with thinking blocks and confirm no HTTP 400 is returned
- Confirm concurrent streaming requests do not produce concurrent map write panics
- Disconnect a streaming client mid-response and confirm no goroutine leaks or panics
- Send a request with Anthropic structured output (`response_format`) and confirm a valid JSON-schema response
- Confirm vLLM streaming responses include token usage in logs

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Contributors: [@emirhanmutlu-natuvion](https://github.com/emirhanmutlu-natuvion), [@tom-diacono](https://github.com/tom-diacono), [@tefimov](https://github.com/tefimov), [@Edward-Upton](https://github.com/Edward-Upton), [@martingiguere](https://github.com/martingiguere), [@crust3780](https://github.com/crust3780)

## Security considerations

No new auth, secrets, or PII handling introduced. The removal of the Claude Code user agent restriction for WebSearch tool arguments should be reviewed to confirm it aligns with intended access control policy.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable