### PR TITLE
v1.4.24-docker-fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ _build-with-docker: # Internal target for Docker-based cross-compilation
 				-e GOOS=$(TARGET_OS) \
 				-e GOARCH=$(TARGET_ARCH) \
 				 $(if $(LOCAL),,-e GOWORK=off) \
-				golang:1.26.1-alpine3.23 \
+				golang:1.26.2-alpine3.23 \
 				sh -c "apk add --no-cache gcc musl-dev && \
 				go build \
 					-ldflags='-w -s -X main.Version=v$(VERSION)' \
@@ -250,7 +250,7 @@ _build-with-docker: # Internal target for Docker-based cross-compilation
 				-e GOOS=$(TARGET_OS) \
 				-e GOARCH=$(TARGET_ARCH) \
 				 $(if $(LOCAL),,-e GOWORK=off) \
-				golang:1.26.1-alpine3.23 \
+				golang:1.26.2-alpine3.23 \
 				sh -c "apk add --no-cache gcc musl-dev && \
 				go build \
 					-ldflags='-w -s -extldflags "-static" -X main.Version=v$(VERSION)' \

--- a/docs/plugins/building-dynamic-binary.mdx
+++ b/docs/plugins/building-dynamic-binary.mdx
@@ -113,7 +113,7 @@ COPY ui/ ./
 RUN npm run build-enterprise
 
 # --- Go Build Stage: Compile the Go binary ---
-FROM golang:1.26.1-alpine3.23 AS builder
+FROM golang:1.26.2-alpine3.23 AS builder
 WORKDIR /app
 
 # Install dependencies including gcc for CGO and sqlite
@@ -229,7 +229,7 @@ COPY ui/ ./
 RUN npm run build-enterprise
 
 # --- Go Build Stage: Compile the Go binary ---
-FROM golang:1.26.1-bookworm AS builder
+FROM golang:1.26.2-bookworm AS builder
 WORKDIR /app
 
 # Install dependencies including gcc for CGO and sqlite
@@ -397,7 +397,7 @@ Plugins **must** be built with the **exact same environment** as your Bifrost bi
 docker run --rm \
   -v "$PWD:/work" \
   -w /work \
-  golang:1.26.1-alpine3.23 \
+  golang:1.26.2-alpine3.23 \
   sh -c "apk add --no-cache gcc musl-dev && \
          go build -buildmode=plugin -o myplugin.so main.go"
 
@@ -405,7 +405,7 @@ docker run --rm \
 docker run --rm \
   -v "$PWD:/work" \
   -w /work \
-  golang:1.26.1-bookworm \
+  golang:1.26.2-bookworm \
   sh -c "apt-get update && apt-get install -y gcc && \
          go build -buildmode=plugin -o myplugin.so main.go"
 ```

--- a/examples/plugins/hello-world/Makefile
+++ b/examples/plugins/hello-world/Makefile
@@ -127,7 +127,7 @@ _build-with-docker: # Internal target for Docker-based cross-compilation
 			-e CGO_ENABLED=1 \
 			-e GOOS=$(TARGET_OS) \
 			-e GOARCH=$(TARGET_ARCH) \
-			golang:1.26.1-alpine3.23 \
+			golang:1.26.2-alpine3.23 \
 			sh -c "apk add --no-cache gcc musl-dev && \
 				go build -buildmode=plugin -ldflags='-w -s' -trimpath -o $(OUTPUT) main.go"; \
 		echo "$(COLOR_SUCCESS)✓ Plugin built successfully: $(OUTPUT) ($(TARGET_OS)/$(TARGET_ARCH))$(COLOR_RESET)"; \

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -1,39 +1,39 @@
 # --- UI Build Stage: Build the Next.js frontend ---
   FROM node:25-alpine3.23@sha256:cf38e1f3c28ac9d81cdc0c51d8220320b3b618780e44ef96a39f76f7dbfef023 AS ui-builder
   WORKDIR /app
-  
+
   # Copy UI package files and install dependencies
   COPY ui/package*.json ./
   RUN npm ci
-  
+
   # Copy UI source code
   COPY ui/ ./
-  
+
   # Build UI (skip the copy-build step)
   RUN npx next build
   RUN node scripts/fix-paths.js
   # Skip the copy-build step since we'll copy the files in the Go build stage
-  
+
   # --- Go Build Stage: Compile the Go binary ---
-  FROM golang:1.26.1-alpine3.23@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS builder
+  FROM golang:1.26.2-alpine3.23@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
   WORKDIR /app
-  
+
   # Install dependencies including gcc for CGO and sqlite
   RUN apk add --no-cache gcc musl-dev sqlite-dev binutils binutils-gold
-  
+
   # Set environment for CGO-enabled build (required for go-sqlite3)
   ENV CGO_ENABLED=1 GOOS=linux
-  
+
   COPY transports/go.mod transports/go.sum ./
   RUN ls
   RUN cat go.mod
   RUN go mod download
-  
+
   # Copy source code and dependencies
   COPY transports/ ./
-  
+
   COPY --from=ui-builder /app/out ./bifrost-http/ui
-  
+
   # Build the binary with CGO enabled and static SQLite linking
   ENV GOWORK=off
   ARG VERSION=unknown
@@ -43,38 +43,38 @@
     -tags "sqlite_static" \
     -o /app/main \
     ./bifrost-http
-  
+
   # Verify build succeeded
   RUN test -f /app/main || (echo "Build failed" && exit 1)
-  
+
   # --- Runtime Stage: Minimal runtime image ---
   FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
   WORKDIR /app
-  
+
   # Install runtime dependencies for CGO-enabled binary
   # musl: C standard library (required for CGO binaries)
   # libgcc: GCC runtime library
   # ca-certificates: For HTTPS connections
   RUN apk add --no-cache musl libgcc ca-certificates wget zlib=1.3.2-r0
-  
+
   # Create data directory and set up user
   COPY --from=builder /app/main .
   COPY --from=builder /app/docker-entrypoint.sh .
-  
+
   # Getting arguments
   ARG ARG_APP_PORT=8080
   ARG ARG_APP_HOST=0.0.0.0
   ARG ARG_LOG_LEVEL=info
   ARG ARG_LOG_STYLE=json
   ARG ARG_APP_DIR=/app/data
-  
+
   # Environment variables with defaults (can be overridden at runtime)
   ENV APP_PORT=$ARG_APP_PORT \
     APP_HOST=$ARG_APP_HOST \
     LOG_LEVEL=$ARG_LOG_LEVEL \
     LOG_STYLE=$ARG_LOG_STYLE \
     APP_DIR=$ARG_APP_DIR
-  
+
   # Go runtime performance tuning (override at runtime for your workload)
   # GOGC: GC target percentage. Higher = less frequent GC, more memory usage.
   #       Default: 100. For high-throughput with available memory, try 200-400.
@@ -84,23 +84,23 @@
   # Note: GOMAXPROCS is automatically detected from cgroup CPU limits via automaxprocs.
   ENV GOGC="" \
     GOMEMLIMIT=""
-  
-  
+
+
   RUN mkdir -p $APP_DIR/logs && \
     adduser -D -s /bin/sh appuser && \
     chown -R appuser:appuser /app && \
     chmod +x /app/docker-entrypoint.sh
   USER appuser
-  
-  
+
+
   # Declare volume for data persistence
   VOLUME ["/app/data"]
   EXPOSE $APP_PORT
-  
+
   # Health check for container status monitoring
   HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 -O /dev/null http://127.0.0.1:${APP_PORT}/health || exit 1
-  
+
   # Use entrypoint script that handles volume permissions and argument processing
   ENTRYPOINT ["/app/docker-entrypoint.sh"]
   CMD ["/app/main"]

--- a/transports/Dockerfile.local
+++ b/transports/Dockerfile.local
@@ -4,35 +4,35 @@
 # --- UI Build Stage: Build the Next.js frontend ---
   FROM node:25-alpine3.23@sha256:cf38e1f3c28ac9d81cdc0c51d8220320b3b618780e44ef96a39f76f7dbfef023 AS ui-builder
   WORKDIR /app
-  
+
   # Copy UI package files and install dependencies
   COPY ui/package*.json ./
   RUN npm ci
-  
+
   # Copy UI source code
   COPY ui/ ./
-  
+
   # Build UI (skip the copy-build step)
   RUN npx next build
   RUN node scripts/fix-paths.js
   # Skip the copy-build step since we'll copy the files in the Go build stage
-  
+
   # --- Go Build Stage: Compile the Go binary using local modules ---
-  FROM golang:1.26.1-alpine3.23@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS builder
+  FROM golang:1.26.2-alpine3.23@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
   WORKDIR /build
-  
+
   # Install dependencies including gcc for CGO and sqlite
   RUN apk add --no-cache gcc musl-dev sqlite-dev binutils binutils-gold
-  
+
   # Set environment for CGO-enabled build (required for go-sqlite3)
   ENV CGO_ENABLED=1 GOOS=linux
-  
+
   # Copy all local modules
   COPY core/ ./core/
   COPY framework/ ./framework/
   COPY plugins/ ./plugins/
   COPY transports/ ./transports/
-  
+
   # Set up go workspace to resolve local module dependencies
   RUN go work init && \
     go work use ./core && \
@@ -47,13 +47,13 @@
     go work use ./plugins/semanticcache && \
     go work use ./plugins/telemetry && \
     go work use ./transports
-  
+
   # Download external (non-local) dependencies
   RUN cd /build/transports && go mod download
-  
+
   # Copy UI build output into transports
   COPY --from=ui-builder /app/out ./transports/bifrost-http/ui
-  
+
   # Build the binary with CGO enabled and static SQLite linking
   ARG VERSION=unknown
   RUN cd /build/transports && \
@@ -63,54 +63,54 @@
       -tags "sqlite_static" \
       -o /app/main \
       ./bifrost-http
-  
+
   # Verify build succeeded
   RUN test -f /app/main || (echo "Build failed" && exit 1)
-  
+
   # --- Runtime Stage: Minimal runtime image ---
   FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
   WORKDIR /app
-  
+
   # Install runtime dependencies for CGO-enabled binary
   # musl: C standard library (required for CGO binaries)
   # libgcc: GCC runtime library
   # ca-certificates: For HTTPS connections
   RUN apk add --no-cache musl libgcc ca-certificates wget zlib=1.3.2-r0
-  
+
   # Create data directory and set up user
   COPY --from=builder /app/main .
   COPY --from=builder /build/transports/docker-entrypoint.sh .
-  
+
   # Getting arguments
   ARG ARG_APP_PORT=8080
   ARG ARG_APP_HOST=0.0.0.0
   ARG ARG_LOG_LEVEL=info
   ARG ARG_LOG_STYLE=json
   ARG ARG_APP_DIR=/app/data
-  
+
   # Environment variables with defaults (can be overridden at runtime)
   ENV APP_PORT=$ARG_APP_PORT \
     APP_HOST=$ARG_APP_HOST \
     LOG_LEVEL=$ARG_LOG_LEVEL \
     LOG_STYLE=$ARG_LOG_STYLE \
     APP_DIR=$ARG_APP_DIR
-  
-  
+
+
   RUN mkdir -p $APP_DIR/logs && \
     adduser -D -s /bin/sh appuser && \
     chown -R appuser:appuser /app && \
     chmod +x /app/docker-entrypoint.sh
   USER appuser
-  
-  
+
+
   # Declare volume for data persistence
   VOLUME ["/app/data"]
   EXPOSE $APP_PORT
-  
+
   # Health check for container status monitoring
   HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD wget --no-verbose --tries=1 -O /dev/null http://127.0.0.1:${APP_PORT}/health || exit 1
-  
+
   # Use entrypoint script that handles volume permissions and argument processing
   ENTRYPOINT ["/app/docker-entrypoint.sh"]
   CMD ["/app/main"]


### PR DESCRIPTION
## Summary

Bumps the Go base image from `golang:1.26.1` to `golang:1.26.2` across all build targets to pick up the latest patch release.

## Changes

- Updated the Go builder image to `golang:1.26.2-alpine3.23` and `golang:1.26.2-bookworm` (with updated SHA256 digests) in all Dockerfiles, Makefiles, and documentation examples.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [x] Docs

## How to test

```sh
# Verify the correct Go version is used during Docker builds
docker build -f transports/Dockerfile .
docker build -f transports/Dockerfile.local .

# Verify plugin example builds correctly
cd examples/plugins/hello-world && make build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Updating to a newer Go patch release may include security fixes in the Go toolchain. No changes to auth, secrets, or runtime behavior.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable