### PR TITLE
core changelog

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,4 @@
+- fix: concurrent map panic in PluginPipeline during streaming — guarded postHookTimings with streamingMu and fixed double-pool-release race
+- feat: auto-resolve incoming model for provider-only fallbacks in routing rules
+- fix: drops empty thinking blocks from Anthropic requests to prevent HTTP 400 errors on Claude Code requests
+- feat: adds dedicated streaming HTTP client per provider to eliminate timeouts on long-lived SSE connections


### PR DESCRIPTION
## Summary

This PR addresses two bugs and introduces two features to improve stability and correctness in streaming, routing, and provider integrations.

## Changes

- Fixed a concurrent map panic in `PluginPipeline` during streaming by guarding `postHookTimings` with `streamingMu` and resolving a double-pool-release race condition
- Fixed empty thinking blocks being sent in Anthropic requests, which caused HTTP 400 errors on Claude Code requests
- Added auto-resolution of incoming model for provider-only fallbacks in routing rules, enabling cleaner fallback configurations
- Added a dedicated streaming HTTP client per provider to prevent timeouts on long-lived SSE connections

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (Next.js)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

- Verify concurrent streaming requests through a `PluginPipeline` do not panic
- Verify long-lived SSE connections to providers do not time out prematurely
- Verify Claude Code requests with thinking blocks do not return HTTP 400 errors
- Verify routing rules with provider-only fallbacks correctly resolve the incoming model

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications introduced by these changes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable