### PR TITLE
add audio base64 encoding support to OpenAI realtime provider

### DIFF
--- a/core/providers/openai/realtime.go
+++ b/core/providers/openai/realtime.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"mime/multipart"
@@ -692,6 +693,10 @@ func (provider *OpenAIProvider) ToProviderRealtimeEvent(bifrostEvent *schemas.Bi
 		if bifrostEvent.Delta.ResponseID != "" && !hasRealtimeExtraParam(bifrostEvent.ExtraParams, "response_id") {
 			out["response_id"] = bifrostEvent.Delta.ResponseID
 		}
+	}
+
+	if len(bifrostEvent.Audio) > 0 && (bifrostEvent.Delta == nil || bifrostEvent.Delta.Audio == "") {
+		out["audio"] = base64.StdEncoding.EncodeToString(bifrostEvent.Audio)
 	}
 
 	return providerUtils.MarshalSorted(out)


### PR DESCRIPTION
This PR fixes an issue with the OpenAI Realtime integration where requests could fail with:

Missing required parameter: 'audio'

In some cases, realtime events were sent without the required audio field, which resulted in repeated API errors and eventually caused connection instability (e.g., ClientConnectionResetError: Cannot write to closing transport).

Root Cause

The audio payload was not always included in the outgoing realtime event when it was available in the BifrostRealtimeEvent, particularly when Delta.Audio was empty.

Fix

Ensure that the audio field is always included when audio data exists by encoding it as base64 before sending:

if len(bifrostEvent.Audio) > 0 && (bifrostEvent.Delta == nil || bifrostEvent.Delta.Audio == "") {
    out["audio"] = base64.StdEncoding.EncodeToString(bifrostEvent.Audio)
}

This guarantees compatibility with the OpenAI Realtime API requirements.

Testing
Verified locally with OpenAI Realtime + LiveKit integration
Confirmed that:
The error Missing required parameter: 'audio' no longer occurs
Connection remains stable without reconnection failures
Audio streaming works as expected
Impact
Fixes realtime audio failures with OpenAI provider
Improves connection stability
Ensures proper request formatting according to API expectations