### PR TITLE
transport changelog

### DIFF
--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,28 @@
+## ✨ Features
+
+- **Dedicated Streaming Client** — Each provider now uses a separate HTTP client for streaming requests with read-timeout cleared, eliminating premature SSE/EventStream termination on long-running responses; per-chunk idle detection is enforced via `NewIdleTimeoutReader`
+- **Anthropic Structured Outputs** — Added `response_format` and structured output support for Anthropic models across chat completions and Responses API, including JSON-schema and JSON-object formats with order-preserving merge of additional model request fields (thanks [@emirhanmutlu-natuvion](https://github.com/emirhanmutlu-natuvion)!)
+- **MCP Tool Annotations** — Preserve MCP tool annotations (`title`, `readOnly`, `destructive`, `idempotent`, `openWorld`) in bidirectional conversion between MCP tools and Bifrost chat tools so agents can reason about tool behavior
+- **Claude Opus 4.7 Support** — Added compatibility for Claude Opus 4.7, including adaptive thinking, task-budgets beta header, `display` parameter handling, and "xhigh" effort mapping
+- **Routing Rules Auto-resolve Model** — Provider-only fallbacks now automatically inherit the incoming model, removing the need to repeat model names in fallback config
+
+## 🐞 Fixed
+
+- **Anthropic Empty Thinking Blocks** — Strip `thinking`-typed content blocks with empty `"thinking"` fields before sending to Anthropic, preventing HTTP 400 errors from Claude Code requests
+- **Plugin Timer Concurrent Map Panic** — Added `streamingMu sync.Mutex` to `PluginPipeline` to guard `postHookTimings` across concurrent goroutines during streaming; also fixed a double-pool-release race on streaming errors
+- **Stream Cancellation Safety** — Guarded channel sends and finalizer protection prevent goroutine leaks when clients disconnect mid-stream
+- **Gemini Tool Outputs** — Handle content block tool outputs in Responses API path for `function_call_output` messages (thanks [@tom-diacono](https://github.com/tom-diacono)!)
+- **Gemini Thinking Level** — Preserved `thinkingLevel` parameters across round-trip conversions and corrected finish reason mapping
+- **Bedrock Streaming** — Emit `message_stop` event for Anthropic invoke stream and case-insensitive `anthropic-beta` header merging (thanks [@tefimov](https://github.com/tefimov)!)
+- **Bedrock Tool Images** — Preserve image content blocks in tool results when converting Anthropic Messages to Bedrock Converse API (thanks [@Edward-Upton](https://github.com/Edward-Upton)!)
+- **OpenAI Tool Result Output** — Flatten array-form `tool_result` content into a string before marshaling for the Responses API so strict upstreams no longer reject with HTTP 400 (thanks [@martingiguere](https://github.com/martingiguere)!)
+- **vLLM Token Usage** — Treat `delta.content=""` same as `nil` in streaming so the synthesis chunk retains `finish_reason`, restoring token usage in logs and UI
+- **Anthropic WebSearch** — Removed the Claude Code user agent restriction so WebSearch tool arguments flow for all clients
+- **Anthropic Request Fallbacks** — Dropped fallback fields from outgoing Anthropic requests to avoid schema validation errors
+- **Responses Streaming Errors** — Capture errors mid-stream in the Responses API so clients see failures instead of silent termination
+- **Async Context Propagation** — Preserve context values in async requests so downstream handlers retain request-scoped data
+- **Custom Providers** — Allow custom providers without a list-models endpoint to accept any model rather than restricting on virtual key registration
+- **OTEL Plugin** — Default `insecure` to `true` in config.json and include fallbacks in emitted OTEL metrics
+- **Logs UI** — Switched from WebSocket push to polling for log updates; fixed polling mechanism and defaults the time range to the last hour in logs and dashboard
+- **Helm mcpClientConfig** — Fixed templating for `mcpClientConfig` (thanks [@crust3780](https://github.com/crust3780)!)
+- **Payload Marshalling** — Removed unnecessary marshalling of payload in the transport path


### PR DESCRIPTION
## Summary

This PR consolidates a broad set of fixes and new capabilities across the transports layer, providers, plugins, and UI. It addresses streaming reliability issues, adds structured output support for Anthropic, preserves MCP tool annotations, and resolves a range of provider-specific bugs reported by the community.

## Changes

- **Dedicated streaming HTTP client** per provider with read-timeout cleared and `NewIdleTimeoutReader` for per-chunk idle detection, preventing premature SSE/EventStream termination
- **Anthropic structured outputs** (`response_format`, JSON-schema, JSON-object) added for chat completions and Responses API with order-preserving merge of additional model fields
- **MCP tool annotations** (`title`, `readOnly`, `destructive`, `idempotent`, `openWorld`) preserved in bidirectional MCP ↔ Bifrost tool conversion
- **Claude Opus 4.7** support with adaptive thinking, task-budgets beta header, `display` parameter, and `xhigh` effort mapping
- **Routing rules auto-resolve model** so provider-only fallbacks inherit the incoming model automatically
- **Anthropic empty thinking blocks** stripped before sending to prevent HTTP 400 errors from Claude Code
- **Plugin timer concurrent map panic** resolved by adding `streamingMu sync.Mutex` to `PluginPipeline`; also fixed a double-pool-release race on streaming errors
- **Stream cancellation safety** with guarded channel sends and finalizer protection to prevent goroutine leaks on client disconnect
- **Gemini tool outputs** now handle `function_call_output` content blocks in the Responses API path
- **Gemini `thinkingLevel`** preserved across round-trips with corrected finish reason mapping
- **Bedrock streaming** emits `message_stop` for Anthropic invoke stream; case-insensitive `anthropic-beta` header merging
- **Bedrock tool images** preserve image content blocks in tool results when converting to Converse API
- **OpenAI tool result output** flattens array-form `tool_result` content to a string for Responses API compatibility
- **vLLM token usage** restored by treating `delta.content=""` the same as `nil` in streaming synthesis
- **Anthropic WebSearch** restriction on Claude Code user agent removed
- **Anthropic request fallbacks** dropped from outgoing requests to avoid schema validation errors
- **Responses API streaming errors** now surfaced to clients instead of silently terminating
- **Async context propagation** preserves request-scoped values for downstream handlers
- **Custom providers** without a list-models endpoint now accept any model
- **OTEL plugin** defaults `insecure` to `true` and includes fallbacks in emitted metrics
- **Logs UI** switched from WebSocket push to polling; fixed polling mechanism and defaults time range to last hour
- **Helm `mcpClientConfig`** templating fixed
- **Payload marshalling** removed unnecessary marshalling in the transport path

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [x] UI (Next.js)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Streaming behavior can be validated by sending long-running requests to Anthropic, Gemini, and Bedrock providers and confirming responses complete without premature termination. Structured output can be tested by passing `response_format` with a JSON schema to an Anthropic model endpoint.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

See individual contributor references in the changelog for linked community reports.

## Security considerations

No new auth, secrets, or PII handling introduced. The OTEL plugin now defaults `insecure: true` in `config.json` — operators in production environments should explicitly set `insecure: false` when connecting to a secured OTEL collector.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable