### PR TITLE
fix: updates log details view to show input images from user messages

### DIFF
--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,0 +1,1 @@
+- fix: Fixes OTEL exporting in `framework/tracing/llmspan.go` to show input and output messages correctly

--- a/framework/tracing/llmspan.go
+++ b/framework/tracing/llmspan.go
@@ -202,7 +202,9 @@ func PopulateChatRequestAttributes(req *schemas.BifrostChatRequest, attrs map[st
 		attrs[schemas.AttrMessageCount] = len(req.Input)
 		messages := extractChatMessages(req.Input)
 		if len(messages) > 0 {
-			attrs[schemas.AttrInputMessages] = messages
+			if data, err := schemas.MarshalString(messages); err == nil {
+				attrs[schemas.AttrInputMessages] = data
+			}
 		}
 	}
 }
@@ -229,7 +231,9 @@ func PopulateChatResponseAttributes(resp *schemas.BifrostChatResponse, attrs map
 	// Extract output messages
 	outputMessages := extractChatResponseMessages(resp)
 	if len(outputMessages) > 0 {
-		attrs[schemas.AttrOutputMessages] = outputMessages
+		if data, err := schemas.MarshalString(outputMessages); err == nil {
+			attrs[schemas.AttrOutputMessages] = data
+		}
 	}
 
 	// Extract finish reason from first choice
@@ -563,7 +567,9 @@ func PopulateResponsesRequestAttributes(req *schemas.BifrostResponsesRequest, at
 		attrs[schemas.AttrMessageCount] = len(req.Input)
 		inputMessages := extractResponsesInputMessages(req.Input)
 		if len(inputMessages) > 0 {
-			attrs[schemas.AttrInputMessages] = inputMessages
+			if data, err := schemas.MarshalString(inputMessages); err == nil {
+				attrs[schemas.AttrInputMessages] = data
+			}
 		}
 	}
 
@@ -619,18 +625,34 @@ func PopulateResponsesRequestAttributes(req *schemas.BifrostResponsesRequest, at
 		}
 	}
 	if req.Params.Tools != nil {
-		tools := make([]string, len(req.Params.Tools))
-		for i, tool := range req.Params.Tools {
-			tools[i] = string(tool.Type)
+		type toolInfo struct {
+			Name        string `json:"name"`
+			Description string `json:"description,omitempty"`
 		}
-		attrs[schemas.AttrTools] = strings.Join(tools, ",")
+		tools := make([]toolInfo, 0, len(req.Params.Tools))
+		for _, tool := range req.Params.Tools {
+			if tool.Name != nil {
+				info := toolInfo{Name: *tool.Name}
+				if tool.Description != nil {
+					info.Description = *tool.Description
+				}
+				tools = append(tools, info)
+			} else {
+				tools = append(tools, toolInfo{Name: string(tool.Type)})
+			}
+		}
+		if data, err := schemas.MarshalString(tools); err == nil {
+			attrs[schemas.AttrTools] = data
+		}
 	}
 	if req.Params.Truncation != nil {
 		attrs[schemas.AttrTruncation] = *req.Params.Truncation
 	}
 	// ExtraParams
 	for k, v := range req.Params.ExtraParams {
-		attrs[k] = fmt.Sprintf("%v", v)
+		if data, err := schemas.MarshalString(v); err == nil {
+			attrs[k] = data
+		}
 	}
 }
 
@@ -653,7 +675,9 @@ func PopulateResponsesResponseAttributes(resp *schemas.BifrostResponsesResponse,
 	// Extract output messages (includes reasoning)
 	outputMessages := extractResponsesOutputMessages(resp)
 	if len(outputMessages) > 0 {
-		attrs[schemas.AttrOutputMessages] = outputMessages
+		if data, err := schemas.MarshalString(outputMessages); err == nil {
+			attrs[schemas.AttrOutputMessages] = data
+		}
 	}
 
 	// Additional response fields

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -44,7 +44,7 @@ import {
   RoutingEngineUsedLabels,
   Status
 } from "@/lib/constants/logs";
-import { LogEntry, ResponsesMessage } from "@/lib/types/logs";
+import { ContentBlock, LogEntry, ResponsesMessage, ResponsesMessageContentBlock } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
 import { downloadAsJson } from "@/lib/utils/browser-download";
 import { Link } from "@tanstack/react-router";
@@ -1490,6 +1490,22 @@ export function LogDetailView({
                         audioFormat={audioFormat}
                       />
                     )}
+                    {text &&
+                      Array.isArray(message.content) &&
+                      (message.content as ContentBlock[])
+                        .filter((b) => b.type === "image_url")
+                        .map((b, i) => {
+                          const src = b.image_url?.url;
+                          if (!src) return null;
+                          return (
+                            <img
+                              key={`${i}-${src}`}
+                              src={src}
+                              alt="Attached image"
+                              className="mt-2 max-w-full rounded border"
+                            />
+                          );
+                        })}
                     {hasToolCalls && text ? (
                       <div className="text-muted-foreground mt-2 text-[11px]">
                         {message.tool_calls!
@@ -1596,6 +1612,12 @@ export function LogDetailView({
                           {msg.type || "—"}
                         </div>
                       )}
+                      {Array.isArray(msg.content) &&
+                        msg.content
+                          .filter((b) => b?.type === "input_image" && b.image_url)
+                          .map((b, i) => (
+                            <img key={`${i}-${b.image_url}`} src={b.image_url} alt="Attached image" className="mt-2 max-w-full rounded border" />
+                          ))}
                     </MessageRow>
                   );
                 })}

--- a/ui/app/workspace/logs/views/logChatMessageView.tsx
+++ b/ui/app/workspace/logs/views/logChatMessageView.tsx
@@ -42,21 +42,10 @@ function ContentBlockView({ block }: { block: ContentBlock; index: number }) {
 
 	// Handle image content
 	if (block.image_url) {
-		const jsonContent = JSON.stringify(block.image_url, null, 2);
-		return (
-			<CollapsibleBox title={blockType} onCopy={() => jsonContent} collapsedHeight={100}>
-				<CodeEditor
-					className="z-0 w-full"
-					shouldAdjustInitialHeight={true}
-					maxHeight={150}
-					wrap={true}
-					code={jsonContent}
-					lang="json"
-					readonly={true}
-					options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
-				/>
-			</CollapsibleBox>
-		);
+		const src = block.image_url.url;
+		if (src) {
+			return <img src={src} alt="Attached image" className="max-w-full rounded border" />;
+		}
 	}
 
 	// Handle audio content


### PR DESCRIPTION
## Summary

Images attached to log messages were not being rendered visually in the log detail view. Instead, image content blocks were displayed as raw JSON in a collapsible code editor, making it difficult to inspect attached images at a glance.

## Changes

- Replaced the JSON/code editor rendering of `image_url` content blocks in `logChatMessageView.tsx` with an inline `<img>` tag that renders the image directly.
- Added inline image rendering in `logDetailView.tsx` for `image_url`\-type content blocks in chat messages and `input_image`\-type content blocks in Responses API messages.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Create a log entry that includes a message with an attached image (via `image_url` or `input_image` content block).
2. Open the log detail view for that entry.
3. Verify the image renders inline within the message row rather than as a JSON blob.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Image content blocks were shown as collapsed JSON in a code editor.
After: Images are rendered inline as `<img>` elements with rounded borders.

After screenshots:

![image.png](https://app.graphite.com/user-attachments/assets/5e276a34-2cd0-479f-bf47-08a508df864f.png)



## Breaking changes

- [x] No

## Related issues

## Security considerations

Image sources are rendered directly from log data. Ensure that only trusted or sanitized URLs are stored in log entries to avoid rendering arbitrary external content.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable