### PR TITLE
feat: add `period` query param support to log filter endpoints

### DIFF
--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -269,13 +269,19 @@ func (h *LoggingHandler) getLogs(ctx *fasthttp.RequestCtx) {
 		filters.RoutingEngineUsed = parseCommaSeparated(routingEngines)
 	}
 	if startTime := string(ctx.QueryArgs().Peek("start_time")); startTime != "" {
-		if t, err := time.Parse(time.RFC3339, startTime); err == nil {
+		if t, err := time.Parse(time.RFC3339Nano, startTime); err == nil {
 			filters.StartTime = &t
 		}
 	}
 	if endTime := string(ctx.QueryArgs().Peek("end_time")); endTime != "" {
-		if t, err := time.Parse(time.RFC3339, endTime); err == nil {
+		if t, err := time.Parse(time.RFC3339Nano, endTime); err == nil {
 			filters.EndTime = &t
+		}
+	}
+	if period := string(ctx.QueryArgs().Peek("period")); period != "" {
+		if start, end := resolvePeriod(period); start != nil {
+			filters.StartTime = start
+			filters.EndTime = end
 		}
 	}
 	if minLatency := string(ctx.QueryArgs().Peek("min_latency")); minLatency != "" {
@@ -498,13 +504,19 @@ func (h *LoggingHandler) getLogsStats(ctx *fasthttp.RequestCtx) {
 		filters.RoutingEngineUsed = parseCommaSeparated(routingEngines)
 	}
 	if startTime := string(ctx.QueryArgs().Peek("start_time")); startTime != "" {
-		if t, err := time.Parse(time.RFC3339, startTime); err == nil {
+		if t, err := time.Parse(time.RFC3339Nano, startTime); err == nil {
 			filters.StartTime = &t
 		}
 	}
 	if endTime := string(ctx.QueryArgs().Peek("end_time")); endTime != "" {
-		if t, err := time.Parse(time.RFC3339, endTime); err == nil {
+		if t, err := time.Parse(time.RFC3339Nano, endTime); err == nil {
 			filters.EndTime = &t
+		}
+	}
+	if period := string(ctx.QueryArgs().Peek("period")); period != "" {
+		if start, end := resolvePeriod(period); start != nil {
+			filters.StartTime = start
+			filters.EndTime = end
 		}
 	}
 	if minLatency := string(ctx.QueryArgs().Peek("min_latency")); minLatency != "" {
@@ -645,13 +657,19 @@ func parseHistogramFilters(ctx *fasthttp.RequestCtx) *logstore.SearchFilters {
 		filters.RoutingEngineUsed = parseCommaSeparated(routingEngines)
 	}
 	if startTime := string(ctx.QueryArgs().Peek("start_time")); startTime != "" {
-		if t, err := time.Parse(time.RFC3339, startTime); err == nil {
+		if t, err := time.Parse(time.RFC3339Nano, startTime); err == nil {
 			filters.StartTime = &t
 		}
 	}
 	if endTime := string(ctx.QueryArgs().Peek("end_time")); endTime != "" {
-		if t, err := time.Parse(time.RFC3339, endTime); err == nil {
+		if t, err := time.Parse(time.RFC3339Nano, endTime); err == nil {
 			filters.EndTime = &t
+		}
+	}
+	if period := string(ctx.QueryArgs().Peek("period")); period != "" {
+		if start, end := resolvePeriod(period); start != nil {
+			filters.StartTime = start
+			filters.EndTime = end
 		}
 	}
 	if minLatency := string(ctx.QueryArgs().Peek("min_latency")); minLatency != "" {
@@ -1303,19 +1321,36 @@ func parseMCPFiltersAndPagination(ctx *fasthttp.RequestCtx) (*logstore.MCPToolLo
 	if llmRequestIDs := string(ctx.QueryArgs().Peek("llm_request_ids")); llmRequestIDs != "" {
 		filters.LLMRequestIDs = parseCommaSeparated(llmRequestIDs)
 	}
+	var startTimeErr, endTimeErr error
 	if startTime := string(ctx.QueryArgs().Peek("start_time")); startTime != "" {
-		t, err := time.Parse(time.RFC3339, startTime)
+		t, err := time.Parse(time.RFC3339Nano, startTime)
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid start_time format: %w", err)
+			startTimeErr = fmt.Errorf("invalid start_time format: %w", err)
+		} else {
+			filters.StartTime = &t
 		}
-		filters.StartTime = &t
 	}
 	if endTime := string(ctx.QueryArgs().Peek("end_time")); endTime != "" {
-		t, err := time.Parse(time.RFC3339, endTime)
+		t, err := time.Parse(time.RFC3339Nano, endTime)
 		if err != nil {
-			return nil, nil, fmt.Errorf("invalid end_time format: %w", err)
+			endTimeErr = fmt.Errorf("invalid end_time format: %w", err)
+		} else {
+			filters.EndTime = &t
 		}
-		filters.EndTime = &t
+	}
+	if period := string(ctx.QueryArgs().Peek("period")); period != "" {
+		if start, end := resolvePeriod(period); start != nil {
+			filters.StartTime = start
+			filters.EndTime = end
+			startTimeErr = nil
+			endTimeErr = nil
+		}
+	}
+	if startTimeErr != nil {
+		return nil, nil, startTimeErr
+	}
+	if endTimeErr != nil {
+		return nil, nil, endTimeErr
 	}
 	if minLatency := string(ctx.QueryArgs().Peek("min_latency")); minLatency != "" {
 		f, err := strconv.ParseFloat(minLatency, 64)
@@ -1406,19 +1441,34 @@ func parseMCPFilters(ctx *fasthttp.RequestCtx) (*logstore.MCPToolLogSearchFilter
 	if llmRequestIDs := string(ctx.QueryArgs().Peek("llm_request_ids")); llmRequestIDs != "" {
 		filters.LLMRequestIDs = parseCommaSeparated(llmRequestIDs)
 	}
+	var timeParseErr error
 	if startTime := string(ctx.QueryArgs().Peek("start_time")); startTime != "" {
-		t, err := time.Parse(time.RFC3339, startTime)
+		t, err := time.Parse(time.RFC3339Nano, startTime)
 		if err != nil {
-			return nil, fmt.Errorf("invalid start_time format: %w", err)
+			timeParseErr = fmt.Errorf("invalid start_time format: %w", err)
+		} else {
+			filters.StartTime = &t
 		}
-		filters.StartTime = &t
 	}
 	if endTime := string(ctx.QueryArgs().Peek("end_time")); endTime != "" {
-		t, err := time.Parse(time.RFC3339, endTime)
+		t, err := time.Parse(time.RFC3339Nano, endTime)
 		if err != nil {
-			return nil, fmt.Errorf("invalid end_time format: %w", err)
+			if timeParseErr == nil {
+				timeParseErr = fmt.Errorf("invalid end_time format: %w", err)
+			}
+		} else {
+			filters.EndTime = &t
 		}
-		filters.EndTime = &t
+	}
+	if period := string(ctx.QueryArgs().Peek("period")); period != "" {
+		if start, end := resolvePeriod(period); start != nil {
+			filters.StartTime = start
+			filters.EndTime = end
+			timeParseErr = nil
+		}
+	}
+	if timeParseErr != nil {
+		return nil, timeParseErr
 	}
 	if minLatency := string(ctx.QueryArgs().Peek("min_latency")); minLatency != "" {
 		f, err := strconv.ParseFloat(minLatency, 64)

--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -7,11 +7,36 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
+
+// resolvePeriod converts a relative period string ("1h","6h","24h","7d","30d") to concrete
+// start/end time pointers computed from the current server time. Returns nil, nil for
+// unrecognised values. When used in filter parsing, period takes precedence over any explicit
+// start_time/end_time query parameters so every poll always covers the intended window.
+func resolvePeriod(period string) (start, end *time.Time) {
+	now := time.Now()
+	var from time.Time
+	switch period {
+	case "1h":
+		from = now.Add(-time.Hour)
+	case "6h":
+		from = now.Add(-6 * time.Hour)
+	case "24h":
+		from = now.Add(-24 * time.Hour)
+	case "7d":
+		from = now.AddDate(0, 0, -7)
+	case "30d":
+		from = now.AddDate(0, 0, -30)
+	default:
+		return nil, nil
+	}
+	return &from, &now
+}
 
 // pluginDisabledKey is a dedicated context key type for marking a plugin as disabled
 // rather than removed. Using a named type instead of a raw string follows Go best practices.


### PR DESCRIPTION
## Summary

Adds support for a `period` query parameter across all log filtering endpoints, allowing callers to specify a relative time window (e.g. `1h`, `6h`, `24h`, `7d`, `30d`) instead of providing explicit `start_time`/`end_time` values. When `period` is supplied, it takes precedence over any explicit time range parameters, ensuring each request always covers the intended rolling window.

## Changes

- Added `resolvePeriod` helper in `utils.go` that maps recognized period strings to concrete `start`/`end` `time.Time` pointers relative to the current server time. Unrecognized values return `nil, nil` and are silently ignored.
- Wired `period` query parameter parsing into `getLogs`, `getLogsStats`, `parseHistogramFilters`, `parseMCPFiltersAndPagination`, and `parseMCPFilters` so all log-querying endpoints support the new parameter consistently.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send requests to any log endpoint with the `period` parameter and verify the returned logs fall within the expected time window:

```sh
# Fetch logs from the last hour
curl "http://localhost:8080/logs?period=1h"

# Fetch logs from the last 7 days
curl "http://localhost:8080/logs?period=7d"

# Verify period takes precedence over explicit time range
curl "http://localhost:8080/logs?start_time=2020-01-01T00:00:00Z&period=24h"

# Run tests
go test ./transports/bifrost-http/...
```

Supported values: `1h`, `6h`, `24h`, `7d`, `30d`. Any other value is ignored and falls back to explicit `start_time`/`end_time` behavior.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII implications. The `period` parameter is resolved server-side using the server clock, so clients cannot manipulate the absolute time range beyond the supported presets.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable