### PR TITLE
chore: adds debug loggins in logging plugin lifecycle

### DIFF
--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -441,6 +441,8 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 
 	createdTimestamp := time.Now().UTC()
 
+	p.logger.Debug("PreLLMHook: request %s type=%q", requestID, req.RequestType)
+
 	// If request type is streaming we create a stream accumulator via the tracer
 	// Skip for passthrough streams — they carry raw bytes, not LLM response chunks
 	if bifrost.IsStreamRequestType(req.RequestType) && req.RequestType != schemas.PassthroughStreamRequest {
@@ -703,6 +705,8 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 
 	isFinalChunk := bifrost.IsFinalChunk(ctx)
 
+	p.logger.Debug("PostLLMHook: request %s type=%q isFinalChunk=%v hasError=%v", requestID, requestType, isFinalChunk, bifrostErr != nil)
+
 	// Retrieve pending input data from PreLLMHook
 	var pendingVal any
 	var hasPending bool
@@ -711,6 +715,9 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	} else {
 		pendingVal, hasPending = p.pendingLogsEntries.Load(requestID)
 	}
+
+	p.logger.Debug("PostLLMHook: pending data lookup for request %s: found=%v", requestID, hasPending)
+
 	if !hasPending {
 		// If we have an error (e.g., cancellation/timeout), still write a minimal error entry
 		// so the error is visible in logs. Without PreLLMHook's DB insert, silently returning
@@ -750,6 +757,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	// Fallback to request type from pending data if request type is not set
 	if requestType == "" {
 		requestType = schemas.RequestType(pending.InitialData.Object)
+		p.logger.Warn("PostLLMHook: request type missing from response extra fields for request %s, falling back to pre-hook value %q", requestID, requestType)
 	}
 
 	var tracer schemas.Tracer


### PR DESCRIPTION
## Summary

Adds debug and warning log statements to the `PreLLMHook` and `PostLLMHook` methods in the logging plugin to improve observability and make it easier to trace request lifecycle issues.

## Changes

- Added a `Debug` log in `PreLLMHook` to record the request ID and request type at the start of hook execution.
- Added a `Debug` log in `PostLLMHook` to record the request ID, request type, whether it is the final chunk, and whether an error is present.
- Added a `Debug` log in `PostLLMHook` after the pending data lookup to indicate whether pre-hook data was found for the given request.
- Added a `Warn` log in `PostLLMHook` when the request type is missing from the response's extra fields and a fallback to the pre-hook value is used, making this silent fallback visible in logs.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the logging plugin tests and observe log output at debug level during a request to confirm the new log lines appear at the expected points in the hook lifecycle.

```sh
go test ./plugins/logging/...
```

Enable debug-level logging in your environment and send a request through the logging plugin. Verify that `PreLLMHook` and `PostLLMHook` emit the expected debug lines, and that the warning fires when the request type is absent from response extra fields.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

The logged fields (request ID, request type, chunk/error flags) do not include PII or secrets. No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable