### PR TITLE
fix: hide "no results" row while loading and minor logs UI cleanup

### DIFF
--- a/ui/app/workspace/logs/sheets/sessionDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/sessionDetailsSheet.tsx
@@ -11,8 +11,8 @@ import { getErrorMessage } from "@/lib/store";
 import { useGetLogSessionSummaryByIdQuery, useLazyGetLogSessionByIdQuery } from "@/lib/store/apis/logsApi";
 import { LogEntry } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import { ArrowDown, ArrowUp, Loader2 } from "lucide-react";
 import { format } from "date-fns";
+import { ArrowDown, ArrowUp, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { LogMessageCell } from "../views/columns";
@@ -287,7 +287,7 @@ export function SessionDetailsSheet({
 											</Badge>
 										</TableCell>
 										<TableCell className="max-w-[360px]">
-											<LogMessageCell log={log} maxWidth="max-w-[360px]" />
+											<LogMessageCell log={log} contentClassName="max-w-[360px]" />
 										</TableCell>
 										<TableCell>
 											<Badge variant="secondary" className="font-mono text-xs uppercase">

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -168,10 +168,10 @@ export function getMessage(log?: LogEntry) {
 
 export function LogMessageCell({
   log,
-  maxWidth = "max-w-[400px]",
+  contentClassName = "max-w-full",
 }: {
   log: LogEntry;
-  maxWidth?: string;
+  contentClassName?: string;
 }) {
   const input = getMessage(log);
   const isLargePayload =
@@ -190,13 +190,12 @@ export function LogMessageCell({
         </span>
       )}
       {realtimeMessages &&
-      (realtimeMessages.tool ||
-        realtimeMessages.user ||
-        realtimeMessages.assistantToolCall ||
-        realtimeMessages.assistant) ? (
+        (realtimeMessages.tool ||
+          realtimeMessages.user ||
+          realtimeMessages.assistantToolCall ||
+          realtimeMessages.assistant) ? (
         <div
-          className={cn(maxWidth, "font-mono text-sm font-normal leading-5")}
-          title={input || "-"}
+          className={cn(contentClassName, "font-mono text-sm font-normal leading-5")}
         >
           {realtimeMessages.tool ? (
             <div className="truncate">Tool Result: {realtimeMessages.tool}</div>
@@ -217,8 +216,7 @@ export function LogMessageCell({
         </div>
       ) : (
         <div
-          className={cn(maxWidth, "truncate font-mono text-[12px] font-normal")}
-          title={input || "-"}
+          className={cn(contentClassName, "truncate font-mono text-[12px] font-normal")}
         >
           {input ||
             (isLargePayload
@@ -293,13 +291,13 @@ export const createColumns = (
             className={cn(
               "font-mono text-[11px] py-0.5 px-1.5 uppercase",
               RequestTypeColors[
-                row.original.object as keyof typeof RequestTypeColors
+              row.original.object as keyof typeof RequestTypeColors
               ],
             )}
           >
             {
               RequestTypeLabels[
-                row.original.object as keyof typeof RequestTypeLabels
+              row.original.object as keyof typeof RequestTypeLabels
               ]
             }
           </Badge>

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -230,7 +230,7 @@ export function LogsDataTable({
 									})}
 								</TableRow>
 							))
-						) : (
+						) : loading ? null : (
 							<TableRow>
 								<TableCell colSpan={columns.length} className="h-24 text-center">
 									No results found. Try adjusting your filters and/or time range.

--- a/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
@@ -201,7 +201,7 @@ export function MCPLogsDataTable({
 										})}
 									</TableRow>
 								))
-							) : (
+							) : loading ? null : (
 								<TableRow>
 									<TableCell colSpan={columns.length} className="h-24 text-center">
 										No results found. Try adjusting your filters and/or time range.

--- a/ui/components/filters/logsFilterSidebar.tsx
+++ b/ui/components/filters/logsFilterSidebar.tsx
@@ -68,7 +68,7 @@ export function LogsFilterSidebar({ filters, onFiltersChange }: LogsSidebarProps
 			<button
 				type="button"
 				onClick={toggleCollapsed}
-				className="bg-card group flex h-full w-10 shrink-0 cursor-pointer flex-col items-center gap-3 rounded-r-md py-3 text-sm font-medium"
+				className="bg-card group flex h-full w-10 shrink-0 cursor-pointer flex-col items-center gap-3 rounded-r-md py-4 text-sm font-medium"
 				title="Show filters"
 				aria-label="Show filters"
 			>

--- a/ui/components/filters/mcpFilterSidebar.tsx
+++ b/ui/components/filters/mcpFilterSidebar.tsx
@@ -65,7 +65,7 @@ export function MCPFilterSidebar({ filters, onFiltersChange }: MCPFilterSidebarP
 			<button
 				type="button"
 				onClick={toggleCollapsed}
-				className="bg-card group flex h-full w-10 shrink-0 cursor-pointer flex-col items-center gap-3 rounded-r-md py-3 text-sm font-medium"
+				className="bg-card group flex h-full w-10 shrink-0 cursor-pointer flex-col items-center gap-3 rounded-r-md py-4 text-sm font-medium"
 				title="Show filters"
 				aria-label="Show filters"
 			>

--- a/ui/lib/constants/icons.tsx
+++ b/ui/lib/constants/icons.tsx
@@ -1,5 +1,6 @@
 import { Landmark, Network, Shuffle } from "lucide-react";
 import { useTheme } from "next-themes";
+import { cn } from "../utils";
 
 type IconSize = "xs" | "sm" | "md" | "lg" | "xl" | number;
 type IconProps = {
@@ -775,7 +776,7 @@ export const RenderProviderIcon = ({
   const { resolvedTheme } = useTheme();
   const IconComponent = ProviderIcons[provider];
   return IconComponent
-    ? IconComponent({ ...props, theme: resolvedTheme })
+    ? IconComponent({ ...props, theme: resolvedTheme, className: cn("w-5 h-5 shrink-0", props.className) })
     : null;
 };
 


### PR DESCRIPTION
## Summary

Fixes a few minor UI polish issues in the logs views, including a flash of "No results found" during loading, incorrect prop naming on `LogMessageCell`, missing `title` tooltips being removed intentionally, and inconsistent icon sizing for provider icons.

## Changes

- Renamed `maxWidth` prop to `contentClassName` on `LogMessageCell` to better reflect its purpose and allow more flexible class composition. Updated the call site in `sessionDetailsSheet.tsx` accordingly.
- Suppressed the "No results found" empty state in `LogsDataTable` and `MCPLogsDataTable` while data is still loading, preventing a flash of the empty message before results arrive.
- Removed `title` tooltip attributes from `LogMessageCell` content divs.
- Fixed provider icons rendered via `RenderProviderIcon` to consistently use `w-5 h-5 shrink-0` sizing.
- Adjusted the collapsed filter sidebar toggle button padding from `py-3` to `py-4` in both `LogsFilterSidebar` and `MCPFilterSidebar` for better visual alignment.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Navigate to the Logs view and apply filters that return no results — confirm the "No results found" message does not flash before data loads.
2. Open a session details sheet and verify the log message column renders correctly without overflow issues.
3. Check that provider icons render at a consistent size across the UI.
4. Collapse the filter sidebar and verify the toggle button alignment looks correct.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable