### PR TITLE
feat: add MCP `tool_groups` config with governance bindings and camelCase alias support in Helm

### DIFF
--- a/examples/k8s/enterprise/README.md
+++ b/examples/k8s/enterprise/README.md
@@ -1,0 +1,204 @@
+# Enterprise Helm Overlays
+
+Enterprise overlays in this folder are designed to be layered on top of your current base deployment command.
+
+## Files
+
+- `values-guardrails.yaml` - Guardrails rules + guardrail provider configurations (all supported guardrails fields populated)
+- `values-governance-org-setup.yaml` - Enterprise governance org setup (virtual keys, teams, business units)
+- `values-access-profiles-governance.yaml` - Enterprise access profile setup (global budget, rate limit, provider-level budgets/rate limits)
+- `values-customers-budgets.yaml` - Enterprise customer budgets setup (customers with budget/rate-limit bindings)
+- `values-users-teams.yaml` - Enterprise teams setup (multiple teams + business units + team budgets + virtual keys)
+- `values-governance-multi-customer.yaml` - Consolidated governance example with 2 customers, customer/team budgets, team rate limits, business units, and VK-budget mapping
+- `values-scim.yaml` - Enterprise SCIM/SSO setup (safe-by-default; enable only with real IdP credentials)
+
+## Base command (as deployed)
+
+```bash
+NAMESPACE="bifrost-examples"
+RELEASE_NAME="bifrost-statefulset-upgrade"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "${NAMESPACE}" apply -f examples/k8s/examples/secrets-providers-sample.yaml
+
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-postgres.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/examples/values-mcp-routing.yaml \
+  --set image.repository=bifrost \
+  --set image.tag=latest
+```
+
+## Add enterprise guardrails overlay
+
+```bash
+NAMESPACE="bifrost-examples"
+RELEASE_NAME="bifrost-statefulset-upgrade"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "${NAMESPACE}" apply -f examples/k8s/examples/secrets-providers-sample.yaml
+
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-postgres.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/enterprise/values-guardrails.yaml \
+  --set image.repository=bifrost \
+  --set image.tag=latest \
+  --set image.pullPolicy=IfNotPresent \
+  --wait --timeout 5m
+```
+
+## Add enterprise governance org overlay
+
+```bash
+NAMESPACE="bifrost-examples"
+RELEASE_NAME="bifrost-statefulset-upgrade"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "${NAMESPACE}" apply -f examples/k8s/examples/secrets-providers-sample.yaml
+
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-postgres.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/enterprise/values-governance-org-setup.yaml \
+  --set image.repository=bifrost \
+  --set image.tag=latest \
+  --set image.pullPolicy=IfNotPresent \
+  --wait --timeout 5m
+```
+
+## Add enterprise access profile governance overlay
+
+```bash
+NAMESPACE="bifrost-examples"
+RELEASE_NAME="bifrost-statefulset-upgrade"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "${NAMESPACE}" apply -f examples/k8s/examples/secrets-providers-sample.yaml
+
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-postgres.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/enterprise/values-access-profiles-governance.yaml \
+  --set image.repository=bifrost \
+  --set image.tag=latest \
+  --set image.pullPolicy=IfNotPresent \
+  --wait --timeout 5m
+```
+
+## Add enterprise customers and budgets overlay
+
+```bash
+NAMESPACE="bifrost-examples"
+RELEASE_NAME="bifrost-statefulset-upgrade"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "${NAMESPACE}" apply -f examples/k8s/examples/secrets-providers-sample.yaml
+
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-postgres.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/enterprise/values-customers-budgets.yaml \
+  --set image.repository=bifrost \
+  --set image.tag=latest \
+  --set image.pullPolicy=IfNotPresent \
+  --wait --timeout 5m
+```
+
+## Add enterprise teams overlay
+
+```bash
+NAMESPACE="bifrost-examples"
+RELEASE_NAME="bifrost-statefulset-upgrade"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "${NAMESPACE}" apply -f examples/k8s/examples/secrets-providers-sample.yaml
+
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-postgres.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/enterprise/values-users-teams.yaml \
+  --set image.repository=bifrost \
+  --set image.tag=latest \
+  --set image.pullPolicy=IfNotPresent \
+  --wait --timeout 5m
+```
+
+## Add consolidated multi-customer governance overlay
+
+```bash
+NAMESPACE="bifrost-examples"
+RELEASE_NAME="bifrost-statefulset-upgrade"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "${NAMESPACE}" apply -f examples/k8s/examples/secrets-providers-sample.yaml
+
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-postgres.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/enterprise/values-governance-multi-customer.yaml \
+  --set image.repository=bifrost \
+  --set image.tag=latest \
+  --set image.pullPolicy=IfNotPresent \
+  --wait --timeout 5m
+```
+
+## Add enterprise SCIM overlay
+
+```bash
+NAMESPACE="bifrost-examples"
+RELEASE_NAME="bifrost-statefulset-upgrade"
+
+kubectl create namespace "${NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n "${NAMESPACE}" apply -f examples/k8s/examples/secrets-providers-sample.yaml
+
+helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-postgres.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/enterprise/values-scim.yaml \
+  --set image.repository=bifrost \
+  --set image.tag=latest \
+  --set image.pullPolicy=IfNotPresent \
+  --wait --timeout 5m
+```
+
+## Optional: quick render check
+
+```bash
+helm template "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-postgres.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/examples/values-mcp-routing.yaml \
+  -f examples/k8s/enterprise/values-guardrails.yaml \
+  | rg "guardrails_config|guardrail_rules|guardrail_providers"
+```
+
+```bash
+helm template "${RELEASE_NAME}" ./helm-charts/bifrost \
+  --namespace "${NAMESPACE}" \
+  -f examples/k8s/examples/values.yaml \
+  -f examples/k8s/examples/values-storage-postgres.yaml \
+  -f examples/k8s/examples/values-providers.yaml \
+  -f examples/k8s/enterprise/values-governance-org-setup.yaml \
+  -f examples/k8s/enterprise/values-access-profiles-governance.yaml \
+  -f examples/k8s/enterprise/values-customers-budgets.yaml \
+  | rg "governance|access_profiles|virtual_keys|teams|customers"
+```

--- a/examples/k8s/enterprise/values-access-profiles-governance.yaml
+++ b/examples/k8s/enterprise/values-access-profiles-governance.yaml
@@ -1,0 +1,53 @@
+# Enterprise overlay: access profile governance example.
+# Demonstrates:
+# - Profile-level (global) budget + rate limit
+# - Provider-level model allow-list
+# - Provider-level budget + rate limit overrides
+bifrost:
+  accessProfiles:
+    - name: "enterprise-governed-profile"
+      description: "Access profile with global budget and rate limits"
+      is_active: true
+      tags:
+        - "enterprise"
+        - "governance"
+      budgets:
+        - id: "ap-global-budget"
+          max_limit: 3000
+          reset_duration: "1M"
+      rate_limit:
+        id: "ap-global-rate-limit"
+        token_max_limit: 500000
+        token_reset_duration: "1d"
+        request_max_limit: 25000
+        request_reset_duration: "1h"
+      provider_configs:
+        - provider_name: "openai"
+          all_models_allowed: false
+          allowed_models:
+            - "gpt-4o-mini"
+            - "gpt-4o"
+          budgets:
+            - id: "ap-openai-budget"
+              max_limit: 1800
+              reset_duration: "1M"
+          rate_limit:
+            id: "ap-openai-rate"
+            token_max_limit: 300000
+            token_reset_duration: "1d"
+            request_max_limit: 15000
+            request_reset_duration: "1h"
+        - provider_name: "anthropic"
+          all_models_allowed: false
+          allowed_models:
+            - "claude-3-5-sonnet-latest"
+          budgets:
+            - id: "ap-anthropic-budget"
+              max_limit: 1200
+              reset_duration: "1M"
+          rate_limit:
+            id: "ap-anthropic-rate"
+            token_max_limit: 200000
+            token_reset_duration: "1d"
+            request_max_limit: 10000
+            request_reset_duration: "1h"

--- a/examples/k8s/enterprise/values-customers-budgets.yaml
+++ b/examples/k8s/enterprise/values-customers-budgets.yaml
@@ -1,0 +1,60 @@
+# Enterprise overlay: customer budgets and rate limits.
+# Note: Helm merges arrays by replacement, so this file includes
+# baseline org IDs plus customer-specific entries for composability.
+bifrost:
+  governance:
+    # Budget definitions used by customers in this overlay.
+    budgets:
+      - id: "budget-org-global"
+        max_limit: 5000
+        reset_duration: "1M"
+      - id: "budget-bu-platform"
+        max_limit: 2000
+        reset_duration: "1M"
+      - id: "budget-bu-security"
+        max_limit: 1500
+        reset_duration: "1M"
+      - id: "budget-customer-gold"
+        max_limit: 10000
+        reset_duration: "1M"
+      - id: "budget-customer-silver"
+        max_limit: 4000
+        reset_duration: "1M"
+
+    # Rate limit definitions used by customers in this overlay.
+    rateLimits:
+      - id: "rl-org-default"
+        token_max_limit: 1000000
+        token_reset_duration: "1d"
+        request_max_limit: 50000
+        request_reset_duration: "1h"
+      - id: "rl-power-users"
+        token_max_limit: 300000
+        token_reset_duration: "1d"
+        request_max_limit: 15000
+        request_reset_duration: "1h"
+      - id: "rl-customer-gold"
+        token_max_limit: 1500000
+        token_reset_duration: "1d"
+        request_max_limit: 70000
+        request_reset_duration: "1h"
+      - id: "rl-customer-silver"
+        token_max_limit: 600000
+        token_reset_duration: "1d"
+        request_max_limit: 30000
+        request_reset_duration: "1h"
+
+    # Customer records and their linked budget/rate-limit policies.
+    customers:
+      - id: "customer-enterprise-org"
+        name: "Enterprise Org"
+        budget_id: "budget-org-global"
+        rate_limit_id: "rl-org-default"
+      - id: "customer-gold-acme"
+        name: "Acme Gold"
+        budget_id: "budget-customer-gold"
+        rate_limit_id: "rl-customer-gold"
+      - id: "customer-silver-beta"
+        name: "Beta Silver"
+        budget_id: "budget-customer-silver"
+        rate_limit_id: "rl-customer-silver"

--- a/examples/k8s/enterprise/values-governance-multi-customer.yaml
+++ b/examples/k8s/enterprise/values-governance-multi-customer.yaml
@@ -1,0 +1,116 @@
+bifrost:
+  governance:
+    # All related governance entities are intentionally in one file.
+    # Helm replaces arrays, so keeping them together avoids broken references.
+    budgets:
+      # Keep provider-level governance IDs from values-providers.yaml so
+      # provider budget/rate-limit references remain valid after array replacement.
+      - id: "budget-provider-openai"
+        max_limit: 500
+        reset_duration: "1M"
+      - id: "budget-customer-acme"
+        max_limit: 12000
+        reset_duration: "1M"
+      - id: "budget-customer-beta"
+        max_limit: 6000
+        reset_duration: "1M"
+      - id: "budget-team-acme-platform"
+        max_limit: 4000
+        reset_duration: "1M"
+        team_id: "team-acme-platform"
+      - id: "budget-team-beta-research"
+        max_limit: 2200
+        reset_duration: "1M"
+        team_id: "team-beta-research"
+      - id: "budget-vk-acme-platform-primary"
+        max_limit: 1300
+        reset_duration: "1M"
+        virtual_key_id: "vk-acme-platform-primary"
+
+    rateLimits:
+      - id: "rl-provider-openai"
+        token_max_limit: 120000
+        token_reset_duration: "1d"
+        request_max_limit: 2500
+        request_reset_duration: "1h"
+      - id: "rl-customer-acme"
+        token_max_limit: 1400000
+        token_reset_duration: "1d"
+        request_max_limit: 60000
+        request_reset_duration: "1h"
+      - id: "rl-customer-beta"
+        token_max_limit: 700000
+        token_reset_duration: "1d"
+        request_max_limit: 30000
+        request_reset_duration: "1h"
+      - id: "rl-team-acme-platform"
+        token_max_limit: 280000
+        token_reset_duration: "1d"
+        request_max_limit: 12000
+        request_reset_duration: "1h"
+      - id: "rl-team-beta-research"
+        token_max_limit: 160000
+        token_reset_duration: "1d"
+        request_max_limit: 7000
+        request_reset_duration: "1h"
+
+    customers:
+      - id: "customer-acme-gold"
+        name: "Acme Gold"
+        budget_id: "budget-customer-acme"
+        rate_limit_id: "rl-customer-acme"
+      - id: "customer-beta-silver"
+        name: "Beta Silver"
+        budget_id: "budget-customer-beta"
+        rate_limit_id: "rl-customer-beta"
+
+    providers:
+      - name: "openai"
+        budget_id: "budget-provider-openai"
+        rate_limit_id: "rl-provider-openai"
+
+    teams:
+      - id: "team-acme-platform"
+        name: "Acme Platform Team"
+        customer_id: "customer-acme-gold"
+        rate_limit_id: "rl-team-acme-platform"
+      - id: "team-beta-research"
+        name: "Beta Research Team"
+        customer_id: "customer-beta-silver"
+        rate_limit_id: "rl-team-beta-research"
+
+    businessUnits:
+      - id: "bu-acme-platform"
+        name: "Acme Platform BU"
+        teamIds:
+          - "team-acme-platform"
+      - id: "bu-beta-ai-research"
+        name: "Beta AI Research BU"
+        teamIds:
+          - "team-beta-research"
+
+    virtualKeys:
+      - id: "vk-acme-platform-primary"
+        name: "Acme Platform Primary Key"
+        description: "VK for Acme platform workloads"
+        value: "sk-bf-acme-platform-primary"
+        is_active: true
+        team_id: "team-acme-platform"
+        rate_limit_id: "rl-team-acme-platform"
+        provider_configs:
+          - provider: "openai"
+            weight: 1
+            allowed_models:
+              - "gpt-4o-mini"
+      - id: "vk-beta-research-primary"
+        name: "Beta Research Primary Key"
+        description: "VK for Beta research workloads"
+        value: "sk-bf-beta-research-primary"
+        is_active: true
+        team_id: "team-beta-research"
+        rate_limit_id: "rl-team-beta-research"
+        provider_configs:
+          - provider: "anthropic"
+            weight: 1
+            allowed_models:
+              - "claude-3-5-sonnet-latest"

--- a/examples/k8s/enterprise/values-governance-org-setup.yaml
+++ b/examples/k8s/enterprise/values-governance-org-setup.yaml
@@ -1,0 +1,71 @@
+# Enterprise overlay: governance organization bootstrap.
+# Includes sample customer, teams, business units, and a virtual key.
+bifrost:
+  governance:
+    # Organization-wide and BU-scoped budgets.
+    budgets:
+      - id: "budget-org-global"
+        max_limit: 5000
+        reset_duration: "1M"
+      - id: "budget-bu-platform"
+        max_limit: 2000
+        reset_duration: "1M"
+      - id: "budget-bu-security"
+        max_limit: 1500
+        reset_duration: "1M"
+
+    # Organization-wide and team-scoped throttling.
+    rateLimits:
+      - id: "rl-org-default"
+        token_max_limit: 1000000
+        token_reset_duration: "1d"
+        request_max_limit: 50000
+        request_reset_duration: "1h"
+      - id: "rl-power-users"
+        token_max_limit: 300000
+        token_reset_duration: "1d"
+        request_max_limit: 15000
+        request_reset_duration: "1h"
+
+    # Top-level business customer record.
+    customers:
+      - id: "customer-enterprise-org"
+        name: "Enterprise Org"
+        budget_id: "budget-org-global"
+        rate_limit_id: "rl-org-default"
+
+    # Team structure under the customer.
+    # profile/config/claims are metadata blocks frequently used with SSO/SCIM mappings.
+    # This file intentionally avoids implying users can be created from config.json.
+    teams:
+      - id: "team-platform-core"
+        name: "Platform Core"
+        customer_id: "customer-enterprise-org"
+        budget_id: "budget-bu-platform"
+        rate_limit_id: "rl-power-users"
+        profile:
+          business_units:
+            - id: "bu-platform"
+              name: "Platform Engineering"
+            - id: "bu-security"
+              name: "Security Engineering"
+
+    # Virtual key bound to platform team.
+    virtualKeys:
+      - id: "vk-enterprise-platform"
+        name: "Enterprise Platform Key"
+        description: "Governance-specific virtual key bound to platform team"
+        value: "sk-bf-enterprise-platform"
+        is_active: true
+        team_id: "team-platform-core"
+        rate_limit_id: "rl-power-users"
+        provider_configs:
+          - provider: "openai"
+            weight: 0.7
+            allowed_models:
+              - "gpt-4o-mini"
+              - "gpt-4o"
+          - provider: "anthropic"
+            weight: 0.3
+            allowed_models:
+              - "claude-3-5-sonnet-latest"

--- a/examples/k8s/enterprise/values-guardrails.yaml
+++ b/examples/k8s/enterprise/values-guardrails.yaml
@@ -1,0 +1,234 @@
+# Enterprise overlay: guardrails documentation sample.
+# Shows:
+# - Multiple rules (input/output/both)
+# - Multiple provider types (bedrock/azure/grayswan/regex)
+# - Multiple auth modes (iam_role, keys, api_key, default_credential, entra_id)
+# - Rule-to-provider wiring via provider_config_ids
+bifrost:
+  guardrails:
+    # Guardrail rules:
+    # - cel_expression drives runtime matching
+    # - query is optional UI metadata from rule builder exports
+    rules:
+      - id: 1001
+        name: "regex-pre-filter-input"
+        description: "Fast local regex checks before external guardrail calls"
+        enabled: true
+        cel_expression: "headers[\"test\"] == \"test\""
+        query:
+          combinator: "and"
+          rules:
+            - field: "headers"
+              operator: "="
+              value: "test:test"
+              valueSource: "value"
+        apply_to: "input"
+        sampling_rate: 100
+        timeout: 1200
+        provider_config_ids: [2007]
+      - id: 1002
+        name: "input-managed-guardrails"
+        description: "Input moderation via Azure + Bedrock + GraySwan"
+        enabled: true
+        cel_expression: "headers[\"test\"] == \"test\""
+        query:
+          combinator: "and"
+          rules:
+            - field: "headers"
+              operator: "="
+              value: "test:test"
+              valueSource: "value"
+        apply_to: "input"
+        sampling_rate: 100
+        timeout: 1500
+        provider_config_ids: [2001, 2003, 2005]
+      - id: 1003
+        name: "output-managed-guardrails"
+        description: "Output moderation with alternative auth modes"
+        enabled: true
+        cel_expression: "headers[\"test\"] == \"test\""
+        query:
+          combinator: "and"
+          rules:
+            - field: "headers"
+              operator: "="
+              value: "test:test"
+              valueSource: "value"
+        apply_to: "output"
+        sampling_rate: 90
+        timeout: 1800
+        provider_config_ids: [2002, 2006, 2008, 2009, 2010]
+      - id: 1004
+        name: "both-phases-safety-net"
+        description: "Runs across input and output with mixed providers"
+        enabled: true
+        cel_expression: "headers[\"test\"] == \"test\""
+        query:
+          combinator: "and"
+          rules:
+            - field: "headers"
+              operator: "="
+              value: "test:test"
+              valueSource: "value"
+        apply_to: "both"
+        sampling_rate: 60
+        timeout: 2200
+        provider_config_ids: [2002, 2005, 2007, 2010]
+    # Guardrail provider configurations referenced by rule provider_config_ids.
+    providers:
+      - id: 2001
+        provider_name: "bedrock"
+        policy_name: "bedrock-iam-role"
+        enabled: true
+        timeout: 1000
+        config:
+          auth_type: "iam_role"
+          region: "us-east-1"
+          guardrail_arn: "arn:aws:bedrock:us-east-1:123456789012:guardrail/gr-abc123"
+          guardrail_version: "1"
+      - id: 2002
+        provider_name: "azure"
+        policy_name: "azure-default-credential"
+        enabled: true
+        timeout: 1500
+        config:
+          auth_type: "default_credential"
+          endpoint: "https://example-guardrails.cognitiveservices.azure.com/"
+          scopes:
+            - "https://cognitiveservices.azure.com/.default"
+          analyze_enabled: true
+          analyze_severity_threshold: "high"
+          jailbreak_shield_enabled: true
+          indirect_attack_shield_enabled: true
+          copyright_enabled: false
+          text_blocklist_enabled: false
+      - id: 2003
+        provider_name: "azure"
+        policy_name: "azure-api-key"
+        enabled: true
+        timeout: 1200
+        config:
+          auth_type: "api_key"
+          endpoint: "https://example-guardrails.cognitiveservices.azure.com/"
+          api_key: "${AZURE_CONTENT_SAFETY_KEY}"
+          analyze_enabled: true
+          analyze_severity_threshold: "medium"
+          jailbreak_shield_enabled: true
+          indirect_attack_shield_enabled: false
+          copyright_enabled: false
+          text_blocklist_enabled: true
+          blocklist_names:
+            - "pii-blocklist"
+            - "internal-secrets"
+      - id: 2004
+        provider_name: "azure"
+        policy_name: "azure-entra-id"
+        enabled: false
+        timeout: 1200
+        config:
+          auth_type: "entra_id"
+          endpoint: "https://example-guardrails.cognitiveservices.azure.com/"
+          tenant_id: "${AZURE_TENANT_ID}"
+          client_id: "${AZURE_CLIENT_ID}"
+          client_secret: "${AZURE_CLIENT_SECRET}"
+          scopes:
+            - "https://cognitiveservices.azure.com/.default"
+          analyze_enabled: true
+          analyze_severity_threshold: "low"
+          jailbreak_shield_enabled: false
+          indirect_attack_shield_enabled: true
+          copyright_enabled: false
+          text_blocklist_enabled: false
+      - id: 2005
+        provider_name: "grayswan"
+        policy_name: "grayswan-hybrid-policy"
+        enabled: true
+        timeout: 1400
+        config:
+          api_key: "${GRAYSWAN_API_KEY}"
+          base_url: "https://api.grayswan.ai"
+          violation_threshold: 0.65
+          reasoning_mode: "hybrid"
+          policy_id: "policy-123"
+          policy_ids:
+            - "policy-123"
+            - "policy-456"
+          rules:
+            jailbreak: "block"
+            pii: "block"
+      - id: 2006
+        provider_name: "bedrock"
+        policy_name: "bedrock-access-keys-assume-role"
+        enabled: true
+        timeout: 1000
+        config:
+          auth_type: "keys"
+          access_key: "${AWS_ACCESS_KEY_ID}"
+          secret_key: "${AWS_SECRET_ACCESS_KEY}"
+          session_token: "${AWS_SESSION_TOKEN}"
+          role_arn: "arn:aws:iam::123456789012:role/bifrost-guardrail-role"
+          external_id: "bifrost-guardrails-external-id"
+          session_name: "bifrost-guardrails-session"
+          region: "us-west-2"
+          guardrail_arn: "arn:aws:bedrock:us-west-2:123456789012:guardrail/gr-def456"
+          guardrail_version: "2"
+      - id: 2007
+        provider_name: "regex"
+        policy_name: "regex-inline-redaction"
+        enabled: true
+        timeout: 300
+        config:
+          patterns:
+            - pattern: "(?i)\\bssn\\b"
+              description: "SSN keyword"
+              flags: "i"
+            - pattern: "\\b(?:\\d[ -]?){13,16}\\b"
+              description: "Potential payment card number"
+            - pattern: "(?s)-----BEGIN (?:RSA|EC|OPENSSH) PRIVATE KEY-----.*?-----END (?:RSA|EC|OPENSSH) PRIVATE KEY-----"
+              description: "Private key material"
+              flags: "s"
+      - id: 2008
+        provider_name: "bedrock"
+        policy_name: "bedrock-access-keys-assume-role-alt"
+        enabled: true
+        timeout: 1100
+        config:
+          auth_type: "keys"
+          access_key: "${AWS_ACCESS_KEY_ID_ALT}"
+          secret_key: "${AWS_SECRET_ACCESS_KEY_ALT}"
+          session_token: "${AWS_SESSION_TOKEN_ALT}"
+          role_arn: "arn:aws:iam::123456789012:role/bifrost-guardrail-role-alt"
+          external_id: "bifrost-guardrails-external-id-alt"
+          session_name: "bifrost-guardrails-session-alt"
+          region: "us-east-2"
+          guardrail_arn: "arn:aws:bedrock:us-east-2:123456789012:guardrail/gr-ghi789"
+          guardrail_version: "1"
+      - id: 2009
+        provider_name: "bedrock"
+        policy_name: "bedrock-api-key-guardrail"
+        enabled: true
+        timeout: 1000
+        config:
+          auth_type: "api_key"
+          bedrock_api_key: "${BEDROCK_API_KEY}"
+          region: "us-west-2"
+          guardrail_arn: "gr-jkl012"
+          guardrail_version: "1"
+      - id: 2010
+        provider_name: "azure"
+        policy_name: "azure-api-key-all-true-high"
+        enabled: true
+        timeout: 1300
+        config:
+          auth_type: "api_key"
+          endpoint: "https://example-guardrails.cognitiveservices.azure.com/"
+          api_key: "${AZURE_CONTENT_SAFETY_KEY_ALT}"
+          analyze_enabled: true
+          analyze_severity_threshold: "high"
+          jailbreak_shield_enabled: true
+          indirect_attack_shield_enabled: true
+          copyright_enabled: true
+          text_blocklist_enabled: true
+          blocklist_names:
+            - "pii-blocklist"
+            - "internal-secrets"

--- a/examples/k8s/enterprise/values-mcp-catalog-tooling.yaml
+++ b/examples/k8s/enterprise/values-mcp-catalog-tooling.yaml
@@ -1,0 +1,90 @@
+bifrost:
+  # MCP catalog + runtime settings
+  mcp:
+    enabled: true
+    toolSyncInterval: "5m"
+    clientConfigs:
+      - name: "echo_http"
+        connectionType: "http"
+        httpConfig:
+          url: "https://mcpplaygroundonline.com/mcp-echo-server"
+        authType: "headers"
+        headers:
+          x-demo-auth: "demo-echo-header-value"
+        toolsToExecute:
+          - "echo"
+        allowOnAllVirtualKeys: false
+    toolGroups:
+      - name: "tg-echo-random-7f3"
+        description: "Random demo MCP tool group for echo server"
+        enabled: true
+        tools:
+          # This attaches the MCP server (catalog client) to the tool group.
+          - mcpClientName: "echo_http"
+            toolNames:
+              - "echo"
+        virtualKeyIds:
+          - "vk-acme-platform-primary"
+        teamIds:
+          - "team-acme-platform"
+        customerIds:
+          - "customer-acme-gold"
+        providerNames:
+          - "openai"
+      - name: "tg-echo-server-all-tools"
+        description: "Attach full echo_http server (all tools) to a separate group"
+        enabled: true
+        tools:
+          # Omitting toolNames means all tools from this MCP server.
+          - mcpClientName: "echo_http"
+        virtualKeyIds:
+          - "vk-beta-research-primary"
+        teamIds:
+          - "team-beta-research"
+        customerIds:
+          - "customer-beta-silver"
+        providerNames:
+          - "anthropic"
+    toolManagerConfig:
+      toolExecutionTimeout: 30
+      maxAgentDepth: 10
+      codeModeBindingLevel: "server"
+      disableAutoToolInject: false
+
+  # Virtual-key MCP bindings.
+  # Note: keep full virtualKeys objects here because Helm array merge is replace.
+  governance:
+    virtualKeys:
+      - id: "vk-acme-platform-primary"
+        name: "Acme Platform Primary Key"
+        description: "VK for Acme platform workloads"
+        value: "sk-bf-acme-platform-primary"
+        is_active: true
+        team_id: "team-acme-platform"
+        rate_limit_id: "rl-team-acme-platform"
+        provider_configs:
+          - provider: "openai"
+            weight: 1
+            allowed_models:
+              - "gpt-4o-mini"
+        mcp_configs:
+          - mcp_client_name: "echo_http"
+            tools_to_execute:
+              - "echo"
+
+      - id: "vk-beta-research-primary"
+        name: "Beta Research Primary Key"
+        description: "VK for Beta research workloads"
+        value: "sk-bf-beta-research-primary"
+        is_active: true
+        team_id: "team-beta-research"
+        rate_limit_id: "rl-team-beta-research"
+        provider_configs:
+          - provider: "anthropic"
+            weight: 1
+            allowed_models:
+              - "claude-3-5-sonnet-latest"
+        mcp_configs:
+          - mcp_client_name: "echo_http"
+            tools_to_execute:
+              - "echo"

--- a/examples/k8s/enterprise/values-scim.yaml
+++ b/examples/k8s/enterprise/values-scim.yaml
@@ -1,0 +1,41 @@
+# Enterprise overlay: SCIM/SSO bootstrap configuration.
+# This file is SAFE-BY-DEFAULT (scim.enabled=false) so placeholder values
+# do not crash startup.
+#
+# Notes:
+# - Set bifrost.scim.enabled=true only after real values are provided.
+# - provider must be one of: "entra", "okta"
+# - Replace placeholder values with real tenant/app credentials.
+# - teamIdsField and rolesField should match claims emitted by your IdP.
+#
+# If you want Okta instead, switch provider to "okta" and use the
+# commented example block at the bottom.
+bifrost:
+  scim:
+    enabled: false
+    provider: "entra"
+    config:
+      tenantId: "env.SCIM_ENTRA_TENANT_ID"
+      clientId: "env.SCIM_ENTRA_CLIENT_ID"
+      clientSecret: "env.SCIM_ENTRA_CLIENT_SECRET"
+      cloud: "commercial"
+      audience: "api://bifrost"
+      appIdUri: "api://bifrost"
+      userIdField: "oid"
+      teamIdsField: "groups"
+      rolesField: "roles"
+
+# Okta example (disabled by default)
+# bifrost:
+#   scim:
+#     enabled: true
+#     provider: "okta"
+#     config:
+#       issuerUrl: "https://dev-123456.okta.com/oauth2/default"
+#       clientId: "env.SCIM_OKTA_CLIENT_ID"
+#       clientSecret: "env.SCIM_OKTA_CLIENT_SECRET"
+#       apiToken: "env.SCIM_OKTA_API_TOKEN"
+#       audience: "api://default"
+#       userIdField: "sub"
+#       teamIdsField: "groups"
+#       rolesField: "roles"

--- a/examples/k8s/enterprise/values-users-teams.yaml
+++ b/examples/k8s/enterprise/values-users-teams.yaml
@@ -1,0 +1,130 @@
+# Enterprise overlay: team-oriented governance examples.
+# Purpose:
+# - Demonstrates customer -> team relationships
+# - Demonstrates team budgets/rate limits
+# - Demonstrates team-level business units
+# - Demonstrates virtual key assignment to different teams
+bifrost:
+  governance:
+    # Budget pools referenced by teams.
+    budgets:
+      - id: "budget-team-data-science"
+        max_limit: 1200
+        reset_duration: "1M"
+      - id: "budget-team-platform-ops"
+        max_limit: 1800
+        reset_duration: "1M"
+      - id: "budget-team-security-research"
+        max_limit: 1500
+        reset_duration: "1M"
+      - id: "budget-team-finops"
+        max_limit: 1000
+        reset_duration: "1M"
+      # Virtual-key-owned budget (requires runtime with VK-budget sync ordering fix).
+      - id: "budget-vk-platform-ops"
+        max_limit: 900
+        reset_duration: "1M"
+        virtual_key_id: "vk-platform-ops-secondary"
+
+    # Rate limit policies referenced by teams and virtual keys.
+    rateLimits:
+      - id: "rl-team-data-science"
+        token_max_limit: 180000
+        token_reset_duration: "1d"
+        request_max_limit: 8000
+        request_reset_duration: "1h"
+      - id: "rl-team-platform-ops"
+        token_max_limit: 250000
+        token_reset_duration: "1d"
+        request_max_limit: 12000
+        request_reset_duration: "1h"
+      - id: "rl-team-security-research"
+        token_max_limit: 220000
+        token_reset_duration: "1d"
+        request_max_limit: 10000
+        request_reset_duration: "1h"
+      - id: "rl-team-finops"
+        token_max_limit: 140000
+        token_reset_duration: "1d"
+        request_max_limit: 6000
+        request_reset_duration: "1h"
+
+    # Minimal customer registry for team ownership.
+    customers:
+      - id: "customer-enterprise-org"
+        name: "Enterprise Org"
+
+    # Team definitions:
+    # - customer_id links team to a customer
+    # - budget_id/rate_limit_id applies spend/throttle policy to that team
+    # - profile/config blocks are extensible metadata used by enterprise workflows
+    teams:
+      - id: "team-data-science"
+        name: "Data Science Team"
+        customer_id: "customer-enterprise-org"
+        budget_id: "budget-team-data-science"
+        rate_limit_id: "rl-team-data-science"
+        profile:
+          business_units:
+            - id: "bu-data"
+              name: "Data Business Unit"
+      - id: "team-platform-ops"
+        name: "Platform Ops Team"
+        customer_id: "customer-enterprise-org"
+        budget_id: "budget-team-platform-ops"
+        rate_limit_id: "rl-team-platform-ops"
+        profile:
+          business_units:
+            - id: "bu-platform-ops"
+              name: "Platform Operations"
+      - id: "team-security-research"
+        name: "Security Research Team"
+        customer_id: "customer-enterprise-org"
+        budget_id: "budget-team-security-research"
+        rate_limit_id: "rl-team-security-research"
+        profile:
+          business_units:
+            - id: "bu-security"
+              name: "Security Business Unit"
+      - id: "team-finops"
+        name: "FinOps Team"
+        customer_id: "customer-enterprise-org"
+        budget_id: "budget-team-finops"
+        rate_limit_id: "rl-team-finops"
+        profile:
+          business_units:
+            - id: "bu-finops"
+              name: "Finance Operations"
+
+    # Virtual keys mapped to specific teams.
+    # Team mapping is the practical way to scope budget policy per key.
+    virtualKeys:
+      - id: "vk-data-science-primary"
+        name: "Data Science Team Key"
+        description: "Virtual key for data science workloads"
+        value: "sk-bf-data-science-key"
+        is_active: true
+        team_id: "team-data-science"
+        rate_limit_id: "rl-team-data-science"
+        provider_configs:
+          - provider: "openai"
+            weight: 0.6
+            allowed_models:
+              - "gpt-4o-mini"
+              - "gpt-4o"
+          - provider: "anthropic"
+            weight: 0.4
+            allowed_models:
+              - "claude-3-5-sonnet-latest"
+      - id: "vk-platform-ops-secondary"
+        name: "Platform Ops Team Key"
+        description: "Second virtual key assigned to a different team"
+        value: "sk-bf-platform-ops-key"
+        is_active: true
+        team_id: "team-platform-ops"
+        rate_limit_id: "rl-team-platform-ops"
+        provider_configs:
+          - provider: "openai"
+            weight: 1
+            allowed_models:
+              - "gpt-4o-mini"

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -870,17 +870,25 @@ false
 {{- if $client.headers }}
 {{- $_ := set $cc "headers" $client.headers }}
 {{- end }}
-{{- if $client.tools_to_execute }}
+{{- if hasKey $client "tools_to_execute" }}
 {{- $_ := set $cc "tools_to_execute" $client.tools_to_execute }}
+{{- else if hasKey $client "toolsToExecute" }}
+{{- $_ := set $cc "tools_to_execute" $client.toolsToExecute }}
 {{- end }}
-{{- if $client.tools_to_auto_execute }}
+{{- if hasKey $client "tools_to_auto_execute" }}
 {{- $_ := set $cc "tools_to_auto_execute" $client.tools_to_auto_execute }}
+{{- else if hasKey $client "toolsToAutoExecute" }}
+{{- $_ := set $cc "tools_to_auto_execute" $client.toolsToAutoExecute }}
 {{- end }}
-{{- if $client.auth_type }}
+{{- if hasKey $client "auth_type" }}
 {{- $_ := set $cc "auth_type" $client.auth_type }}
+{{- else if hasKey $client "authType" }}
+{{- $_ := set $cc "auth_type" $client.authType }}
 {{- end }}
-{{- if $client.oauth_config_id }}
+{{- if hasKey $client "oauth_config_id" }}
 {{- $_ := set $cc "oauth_config_id" $client.oauth_config_id }}
+{{- else if hasKey $client "oauthConfigId" }}
+{{- $_ := set $cc "oauth_config_id" $client.oauthConfigId }}
 {{- end }}
 {{- if hasKey $client "isPingAvailable" }}
 {{- $_ := set $cc "is_ping_available" $client.isPingAvailable }}
@@ -931,6 +939,33 @@ false
 {{- end }}
 {{- if .Values.bifrost.mcp.toolSyncInterval }}
 {{- $_ := set $mcpConfig "tool_sync_interval" .Values.bifrost.mcp.toolSyncInterval }}
+{{- end }}
+{{- if .Values.bifrost.mcp.toolGroups }}
+{{- $toolGroups := list }}
+{{- range .Values.bifrost.mcp.toolGroups }}
+{{- $group := dict "name" .name }}
+{{- if hasKey . "enabled" }}{{- $_ := set $group "enabled" .enabled }}{{- end }}
+{{- if .description }}{{- $_ := set $group "description" .description }}{{- end }}
+{{- if .tools }}
+{{- $tools := list }}
+{{- range .tools }}
+{{- $tool := dict }}
+{{- if .mcpClientId }}{{- $_ := set $tool "mcp_client_id" .mcpClientId }}{{- end }}
+{{- if .mcpClientName }}{{- $_ := set $tool "mcp_client_name" .mcpClientName }}{{- end }}
+{{- if .toolNames }}{{- $_ := set $tool "tool_names" .toolNames }}{{- end }}
+{{- $tools = append $tools $tool }}
+{{- end }}
+{{- $_ := set $group "tools" $tools }}
+{{- end }}
+{{- if .virtualKeyIds }}{{- $_ := set $group "virtual_key_ids" .virtualKeyIds }}{{- end }}
+{{- if .teamIds }}{{- $_ := set $group "team_ids" .teamIds }}{{- end }}
+{{- if .customerIds }}{{- $_ := set $group "customer_ids" .customerIds }}{{- end }}
+{{- if .userIds }}{{- $_ := set $group "user_ids" .userIds }}{{- end }}
+{{- if .providerNames }}{{- $_ := set $group "provider_names" .providerNames }}{{- end }}
+{{- if .apiKeyIds }}{{- $_ := set $group "api_key_ids" .apiKeyIds }}{{- end }}
+{{- $toolGroups = append $toolGroups $group }}
+{{- end }}
+{{- $_ := set $mcpConfig "tool_groups" $toolGroups }}
 {{- end }}
 {{- $_ := set $config "mcp" $mcpConfig }}
 {{- end }}
@@ -1508,6 +1543,16 @@ Call this template at the beginning of deployment/stateful templates
 {{- if not $client.httpConfig.url }}
 {{- fail (printf "ERROR: bifrost.mcp.clientConfigs[%d].httpConfig.url is required for client '%s'." $idx $client.name) }}
 {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.bifrost.mcp.toolGroups }}
+{{- range $idx, $group := .Values.bifrost.mcp.toolGroups }}
+{{- if not $group.name }}
+{{- fail (printf "ERROR: bifrost.mcp.toolGroups[%d].name is required." $idx) }}
+{{- end }}
+{{- if not $group.tools }}
+{{- fail (printf "ERROR: bifrost.mcp.toolGroups[%d].tools is required for group '%s'." $idx $group.name) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -413,6 +413,20 @@ false
 {{- if .Values.bifrost.governance.teams }}
 {{- $_ := set $governance "teams" .Values.bifrost.governance.teams }}
 {{- end }}
+{{- if .Values.bifrost.governance.businessUnits }}
+{{- $businessUnits := list }}
+{{- range .Values.bifrost.governance.businessUnits }}
+{{- $bu := dict "id" .id "name" .name }}
+{{- if .budget_id }}{{- $_ := set $bu "budget_id" .budget_id }}{{- end }}
+{{- if .rate_limit_id }}{{- $_ := set $bu "rate_limit_id" .rate_limit_id }}{{- end }}
+{{- if .profile }}{{- $_ := set $bu "profile" .profile }}{{- end }}
+{{- if .config }}{{- $_ := set $bu "config" .config }}{{- end }}
+{{- if .claims }}{{- $_ := set $bu "claims" .claims }}{{- end }}
+{{- if .teamIds }}{{- $_ := set $bu "team_ids" .teamIds }}{{- end }}
+{{- $businessUnits = append $businessUnits $bu }}
+{{- end }}
+{{- $_ := set $governance "business_units" $businessUnits }}
+{{- end }}
 {{- if .Values.bifrost.governance.virtualKeys }}
 {{- $vks := list }}
 {{- range .Values.bifrost.governance.virtualKeys }}
@@ -463,7 +477,7 @@ false
 {{- $_ := set $governance "auth_config" $authConfig }}
 {{- end }}
 {{- end }}
-{{- if or $governance.budgets $governance.rate_limits $governance.customers $governance.teams $governance.virtual_keys $governance.routing_rules $governance.model_configs $governance.providers $governance.pricing_overrides $governance.auth_config }}
+{{- if or $governance.budgets $governance.rate_limits $governance.customers $governance.teams $governance.business_units $governance.virtual_keys $governance.routing_rules $governance.model_configs $governance.providers $governance.pricing_overrides $governance.auth_config }}
 {{- $_ := set $config "governance" $governance }}
 {{- end }}
 {{- end }}
@@ -588,6 +602,7 @@ false
 {{- range .Values.bifrost.guardrails.rules }}
 {{- $rule := dict "id" .id "name" .name "enabled" .enabled "cel_expression" .cel_expression "apply_to" .apply_to }}
 {{- if .description }}{{- $_ := set $rule "description" .description }}{{- end }}
+{{- if hasKey . "query" }}{{- $_ := set $rule "query" .query }}{{- end }}
 {{- if .sampling_rate }}{{- $_ := set $rule "sampling_rate" .sampling_rate }}{{- end }}
 {{- if .timeout }}{{- $_ := set $rule "timeout" .timeout }}{{- end }}
 {{- if .provider_config_ids }}{{- $_ := set $rule "provider_config_ids" .provider_config_ids }}{{- end }}
@@ -1393,6 +1408,18 @@ Call this template at the beginning of deployment/stateful templates
 {{- end }}
 {{- if not $team.name }}
 {{- fail (printf "ERROR: bifrost.governance.teams[%d].name is required for team '%s'." $idx $team.id) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Validate governance business units */}}
+{{- if .Values.bifrost.governance.businessUnits }}
+{{- range $idx, $bu := .Values.bifrost.governance.businessUnits }}
+{{- if not $bu.id }}
+{{- fail (printf "ERROR: bifrost.governance.businessUnits[%d].id is required." $idx) }}
+{{- end }}
+{{- if not $bu.name }}
+{{- fail (printf "ERROR: bifrost.governance.businessUnits[%d].name is required for business unit '%s'." $idx $bu.id) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -493,6 +493,12 @@
             "toolSyncInterval": {
               "type": "string",
               "description": "Global default interval for syncing tools from MCP servers (Go duration string, e.g. '10m', '1h', '0s' to use runtime default)"
+            },
+            "toolGroups": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/mcpToolGroupConfig"
+              }
             }
           },
           "additionalProperties": false
@@ -3345,6 +3351,77 @@
           }
         }
       ]
+    },
+    "mcpToolGroupConfig": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "tools": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "mcpClientId": {
+                "type": "string"
+              },
+              "mcpClientName": {
+                "type": "string"
+              },
+              "toolNames": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "anyOf": [
+              {
+                "required": ["mcpClientId"]
+              },
+              {
+                "required": ["mcpClientName"]
+              }
+            ],
+            "additionalProperties": false
+          }
+        },
+        "virtualKeyIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "teamIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "customerIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "userIds": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "providerNames": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "apiKeyIds": {
+          "type": "array",
+          "items": { "type": "integer" }
+        }
+      },
+      "required": ["name", "tools"],
+      "additionalProperties": false
     },
     "virtualKeyProviderConfig": {
       "type": "object",

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -944,6 +944,23 @@
                   "reset_duration": {
                     "type": "string"
                   },
+                  "virtual_key_id": {
+                    "type": "string",
+                    "description": "Associate this budget to a virtual key (mutually exclusive with provider_config_id and team_id)"
+                  },
+                  "provider_config_id": {
+                    "type": "integer",
+                    "description": "Associate this budget to a virtual key provider config (mutually exclusive with virtual_key_id and team_id)"
+                  },
+                  "team_id": {
+                    "type": "string",
+                    "description": "Associate this budget to a team (mutually exclusive with virtual_key_id and provider_config_id)"
+                  },
+                  "calendar_aligned": {
+                    "type": "boolean",
+                    "description": "Snap budget reset windows to calendar boundaries",
+                    "default": false
+                  },
                   "current_usage": {
                     "type": "number"
                   },
@@ -952,6 +969,32 @@
                     "format": "date-time"
                   }
                 },
+                "allOf": [
+                  {
+                    "not": {
+                      "required": [
+                        "virtual_key_id",
+                        "provider_config_id"
+                      ]
+                    }
+                  },
+                  {
+                    "not": {
+                      "required": [
+                        "virtual_key_id",
+                        "team_id"
+                      ]
+                    }
+                  },
+                  {
+                    "not": {
+                      "required": [
+                        "provider_config_id",
+                        "team_id"
+                      ]
+                    }
+                  }
+                ],
                 "required": [
                   "id",
                   "max_limit",
@@ -1056,6 +1099,9 @@
                   "rate_limit_id": {
                     "type": "string"
                   },
+                  "business_unit_id": {
+                    "type": "string"
+                  },
                   "profile": {
                     "type": "object"
                   },
@@ -1064,6 +1110,45 @@
                   },
                   "claims": {
                     "type": "object"
+                  }
+                },
+                "required": [
+                  "id",
+                  "name"
+                ]
+              }
+            },
+            "businessUnits": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "budget_id": {
+                    "type": "string"
+                  },
+                  "rate_limit_id": {
+                    "type": "string"
+                  },
+                  "profile": {
+                    "type": "object"
+                  },
+                  "config": {
+                    "type": "object"
+                  },
+                  "claims": {
+                    "type": "object"
+                  },
+                  "teamIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 },
                 "required": [
@@ -1628,6 +1713,31 @@
                   "cel_expression": {
                     "type": "string"
                   },
+                  "query": {
+                    "description": "Visual rule builder state for the management UI (react-querybuilder). Omitted unless exported from the dashboard. Not evaluated at runtime (cel_expression is).",
+                    "anyOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "object",
+                        "required": ["combinator", "rules"],
+                        "properties": {
+                          "combinator": {
+                            "type": "string",
+                            "enum": ["and", "or"]
+                          },
+                          "rules": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            }
+                          }
+                        },
+                        "additionalProperties": true
+                      }
+                    ]
+                  },
                   "apply_to": {
                     "type": "string",
                     "enum": [
@@ -1658,7 +1768,8 @@
                   "enabled",
                   "cel_expression",
                   "apply_to"
-                ]
+                ],
+                "additionalProperties": false
               }
             },
             "providers": {
@@ -1692,10 +1803,12 @@
                   "provider_name",
                   "policy_name",
                   "enabled"
-                ]
+                ],
+                "additionalProperties": false
               }
             }
-          }
+          },
+          "additionalProperties": false
         },
         "accessProfiles": {
           "type": "array",

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1824,14 +1824,29 @@ func updateGovernanceConfigInStore(
 ) error {
 	logger.Debug("updating governance config in store with merged items")
 	return config.ConfigStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
-		// Team-owned budgets require team rows to exist first (FK on governance_budgets.team_id).
+		// Owner-scoped budgets require owner rows to exist first:
+		// - team_id -> governance_teams
+		// - virtual_key_id -> governance_virtual_keys
+		// - provider_config_id -> governance_virtual_key_provider_configs
 		pendingTeamBudgetsToAdd := make([]configstoreTables.TableBudget, 0)
+		pendingVirtualKeyBudgetsToAdd := make([]configstoreTables.TableBudget, 0)
+		pendingProviderConfigBudgetsToAdd := make([]configstoreTables.TableBudget, 0)
 		pendingTeamBudgetsToUpdate := make([]configstoreTables.TableBudget, 0)
+		pendingVirtualKeyBudgetsToUpdate := make([]configstoreTables.TableBudget, 0)
+		pendingProviderConfigBudgetsToUpdate := make([]configstoreTables.TableBudget, 0)
 
 		// Create budgets
 		for _, budget := range budgetsToAdd {
 			if budget.TeamID != nil {
 				pendingTeamBudgetsToAdd = append(pendingTeamBudgetsToAdd, budget)
+				continue
+			}
+			if budget.VirtualKeyID != nil {
+				pendingVirtualKeyBudgetsToAdd = append(pendingVirtualKeyBudgetsToAdd, budget)
+				continue
+			}
+			if budget.ProviderConfigID != nil {
+				pendingProviderConfigBudgetsToAdd = append(pendingProviderConfigBudgetsToAdd, budget)
 				continue
 			}
 			if err := config.ConfigStore.CreateBudget(ctx, &budget, tx); err != nil {
@@ -1843,6 +1858,14 @@ func updateGovernanceConfigInStore(
 		for _, budget := range budgetsToUpdate {
 			if budget.TeamID != nil {
 				pendingTeamBudgetsToUpdate = append(pendingTeamBudgetsToUpdate, budget)
+				continue
+			}
+			if budget.VirtualKeyID != nil {
+				pendingVirtualKeyBudgetsToUpdate = append(pendingVirtualKeyBudgetsToUpdate, budget)
+				continue
+			}
+			if budget.ProviderConfigID != nil {
+				pendingProviderConfigBudgetsToUpdate = append(pendingProviderConfigBudgetsToUpdate, budget)
 				continue
 			}
 			if err := config.ConfigStore.UpdateBudget(ctx, &budget, tx); err != nil {
@@ -1941,6 +1964,34 @@ func updateGovernanceConfigInStore(
 			}
 			if err := config.ConfigStore.UpdateVirtualKey(ctx, &virtualKey, tx); err != nil {
 				return fmt.Errorf("failed to update virtual key %s: %w", virtualKey.ID, err)
+			}
+		}
+
+		// Create virtual-key-owned budgets after virtual keys exist.
+		for _, budget := range pendingVirtualKeyBudgetsToAdd {
+			if err := config.ConfigStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return fmt.Errorf("failed to create budget %s: %w", budget.ID, err)
+			}
+		}
+
+		// Update virtual-key-owned budgets after virtual keys exist.
+		for _, budget := range pendingVirtualKeyBudgetsToUpdate {
+			if err := config.ConfigStore.UpdateBudget(ctx, &budget, tx); err != nil {
+				return fmt.Errorf("failed to update budget %s: %w", budget.ID, err)
+			}
+		}
+
+		// Create provider-config-owned budgets after virtual key provider configs exist.
+		for _, budget := range pendingProviderConfigBudgetsToAdd {
+			if err := config.ConfigStore.CreateBudget(ctx, &budget, tx); err != nil {
+				return fmt.Errorf("failed to create budget %s: %w", budget.ID, err)
+			}
+		}
+
+		// Update provider-config-owned budgets after virtual key provider configs exist.
+		for _, budget := range pendingProviderConfigBudgetsToUpdate {
+			if err := config.ConfigStore.UpdateBudget(ctx, &budget, tx); err != nil {
+				return fmt.Errorf("failed to update budget %s: %w", budget.ID, err)
 			}
 		}
 
@@ -2206,12 +2257,25 @@ func createGovernanceConfigInStore(ctx context.Context, config *Config) {
 			return nil
 		}
 
-		// Team-owned budgets require team rows to exist first (FK on governance_budgets.team_id).
+		// Owner-scoped budgets require owner rows to exist first:
+		// - team_id -> governance_teams
+		// - virtual_key_id -> governance_virtual_keys
+		// - provider_config_id -> governance_virtual_key_provider_configs
 		pendingTeamBudgets := make([]*configstoreTables.TableBudget, 0)
+		pendingVirtualKeyBudgets := make([]*configstoreTables.TableBudget, 0)
+		pendingProviderConfigBudgets := make([]*configstoreTables.TableBudget, 0)
 		for i := range config.GovernanceConfig.Budgets {
 			budget := &config.GovernanceConfig.Budgets[i]
 			if budget.TeamID != nil {
 				pendingTeamBudgets = append(pendingTeamBudgets, budget)
+				continue
+			}
+			if budget.VirtualKeyID != nil {
+				pendingVirtualKeyBudgets = append(pendingVirtualKeyBudgets, budget)
+				continue
+			}
+			if budget.ProviderConfigID != nil {
+				pendingProviderConfigBudgets = append(pendingProviderConfigBudgets, budget)
 				continue
 			}
 			if err := createBudget(budget); err != nil {
@@ -2356,6 +2420,20 @@ func createGovernanceConfigInStore(ctx context.Context, config *Config) {
 
 			virtualKey.ProviderConfigs = providerConfigs
 			virtualKey.MCPConfigs = mcpConfigs
+		}
+
+		// Create virtual-key-owned budgets after virtual keys exist.
+		for _, budget := range pendingVirtualKeyBudgets {
+			if err := createBudget(budget); err != nil {
+				return err
+			}
+		}
+
+		// Create provider-config-owned budgets after virtual key provider configs exist.
+		for _, budget := range pendingProviderConfigBudgets {
+			if err := createBudget(budget); err != nil {
+				return err
+			}
 		}
 
 		// Create pricing overrides after virtual keys so that scoped overrides referencing

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -469,6 +469,10 @@
                 "type": "string",
                 "description": "Associated rate limit ID"
               },
+              "business_unit_id": {
+                "type": "string",
+                "description": "Associated business unit ID"
+              },
               "profile": {
                 "type": "object",
                 "description": "Team profile data"
@@ -486,6 +490,52 @@
                 "description": "Computed count of virtual keys associated with this team",
                 "minimum": 0,
                 "readOnly": true
+              }
+            },
+            "required": ["id", "name"],
+            "additionalProperties": false
+          }
+        },
+        "business_units": {
+          "type": "array",
+          "description": "Business unit configurations with optional team assignments",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Business unit ID"
+              },
+              "name": {
+                "type": "string",
+                "description": "Business unit name"
+              },
+              "budget_id": {
+                "type": "string",
+                "description": "Associated budget ID"
+              },
+              "rate_limit_id": {
+                "type": "string",
+                "description": "Associated rate limit ID"
+              },
+              "profile": {
+                "type": "object",
+                "description": "Business unit profile data"
+              },
+              "config": {
+                "type": "object",
+                "description": "Business unit configuration data"
+              },
+              "claims": {
+                "type": "object",
+                "description": "Business unit claims data"
+              },
+              "team_ids": {
+                "type": "array",
+                "description": "Team IDs to assign to this business unit",
+                "items": {
+                  "type": "string"
+                }
               }
             },
             "required": ["id", "name"],
@@ -3371,6 +3421,32 @@
               "cel_expression": {
                 "type": "string",
                 "description": "CEL (Common Expression Language) expression for rule evaluation"
+              },
+              "query": {
+                "description": "Visual rule builder state for the management UI (react-querybuilder). Omitted unless exported from the dashboard. Not evaluated at runtime (cel_expression is).",
+                "anyOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "type": "object",
+                    "required": ["combinator", "rules"],
+                    "properties": {
+                      "combinator": {
+                        "type": "string",
+                        "enum": ["and", "or"]
+                      },
+                      "rules": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        },
+                        "description": "Leaf rules and/or nested combinator+rules groups from the query builder."
+                      }
+                    },
+                    "additionalProperties": true
+                  }
+                ]
               },
               "apply_to": {
                 "type": "string",

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -738,6 +738,13 @@
               "type": "integer"
             }
           ]
+        },
+        "tool_groups": {
+          "type": "array",
+          "description": "Enterprise MCP tool groups with optional governance associations",
+          "items": {
+            "$ref": "#/$defs/mcp_tool_group_config"
+          }
         }
       },
       "additionalProperties": false
@@ -2850,6 +2857,100 @@
           "default": false
         }
       }
+    },
+    "mcp_tool_group_config": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Tool group name"
+        },
+        "description": {
+          "type": "string",
+          "description": "Tool group description"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether tool group is enabled",
+          "default": true
+        },
+        "tools": {
+          "type": "array",
+          "minItems": 1,
+          "description": "MCP tools included in this group",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mcp_client_id": {
+                "type": "string",
+                "description": "MCP client ID"
+              },
+              "mcp_client_name": {
+                "type": "string",
+                "description": "MCP client name (resolved to client_id at startup)"
+              },
+              "tool_names": {
+                "type": "array",
+                "description": "Tool names to allow. Empty means all tools from this MCP client.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "oneOf": [
+              {
+                "required": [
+                  "mcp_client_id"
+                ]
+              },
+              {
+                "required": [
+                  "mcp_client_name"
+                ]
+              }
+            ],
+            "additionalProperties": false
+          }
+        },
+        "virtual_key_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "team_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "customer_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "user_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provider_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "api_key_ids": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        }
+      },
+      "required": ["name", "tools"],
+      "additionalProperties": false
     },
     "weaviate_config": {
       "type": "object",


### PR DESCRIPTION
## Summary

Adds support for MCP tool groups in both the Helm chart and the core config schema. Tool groups allow operators to associate named sets of MCP tools with specific virtual keys, teams, customers, users, providers, and API keys, enabling fine-grained governance over which tools are available to which workloads.

## Changes

- Added `mcp_tool_group_config` definition to `transports/config.schema.json`, including `tool_groups` as a new field under the MCP config block. Each group requires a `name` and `tools` list, with optional governance associations (`virtual_key_ids`, `team_ids`, `customer_ids`, `user_ids`, `provider_names`, `api_key_ids`). Omitting `tool_names` within a tool entry means all tools from that MCP client are included.
- Added `mcpToolGroupConfig` definition to `helm-charts/bifrost/values.schema.json` with camelCase field names, and wired it into the `mcp` block as `toolGroups`.
- Extended `_helpers.tpl` to render `toolGroups` from Helm values into the snake_case `tool_groups` config structure, including resolution of `mcpClientName` → `mcp_client_name` and `toolNames` → `tool_names`.
- Added camelCase fallback aliases in `_helpers.tpl` for existing MCP client config fields (`toolsToExecute`, `toolsToAutoExecute`, `authType`, `oauthConfigId`) so values files can use either convention.
- Added Helm validation in `_helpers.tpl` to fail early if a tool group is missing a `name` or `tools` field.
- Added `examples/k8s/enterprise/values-mcp-catalog-tooling.yaml` demonstrating two tool groups (`tg-echo-random-7f3` and `tg-echo-server-all-tools`) backed by an HTTP MCP echo server, with corresponding virtual key bindings for OpenAI and Anthropic providers.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy the Helm chart with the new example values file and verify the rendered config contains the expected `tool_groups` structure:

```sh
helm template bifrost ./helm-charts/bifrost -f examples/k8s/enterprise/values-mcp-catalog-tooling.yaml | grep -A 40 tool_groups
```

Validate the schema against a config file that includes `tool_groups`:

```sh
# Ensure tool_groups renders correctly and required-field validation fires
helm template bifrost ./helm-charts/bifrost -f examples/k8s/enterprise/values-mcp-catalog-tooling.yaml

# Trigger validation failure by removing a required field (name or tools) from a tool group
# and confirm the expected ERROR message is printed
```

Run existing tests:

```sh
go test ./...
```

**New config fields (`bifrost.mcp.toolGroups`):**

| Field | Type | Required | Description |
|---|---|---|---|
| `name` | string | ✅ | Unique tool group name |
| `tools` | array | ✅ | MCP client + tool name bindings |
| `tools[].mcpClientName` | string | | MCP client name (resolved at startup) |
| `tools[].toolNames` | string[] | | Specific tools to allow; omit for all |
| `virtualKeyIds` | string[] | | Virtual keys this group applies to |
| `teamIds` | string[] | | Teams this group applies to |
| `customerIds` | string[] | | Customers this group applies to |
| `providerNames` | string[] | | Providers this group applies to |

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Tool groups gate which MCP tools are accessible per virtual key, team, customer, and provider. Operators should ensure tool group assignments are reviewed before deployment, particularly for tool groups that omit `toolNames` (granting access to all tools on an MCP server). Virtual key `mcp_configs` continue to enforce per-key tool restrictions independently of group membership.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable