### PR TITLE
fix: remove raw request passthrough, set SSE headers, and improve passthrough log detail view

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -2590,6 +2591,8 @@ func (provider *AnthropicProvider) Passthrough(
 		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err)
 	}
 
+	originalHeaders := make(map[string]string, len(headers))
+	maps.Copy(originalHeaders, headers)
 	for k := range headers {
 		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
 			delete(headers, k)
@@ -2600,12 +2603,10 @@ func (provider *AnthropicProvider) Passthrough(
 		StatusCode: resp.StatusCode(),
 		Headers:    headers,
 		Body:       body,
-	}
-
-	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
-
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &bifrostResponse.ExtraFields)
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency:                 latency.Milliseconds(),
+			ProviderResponseHeaders: originalHeaders,
+		},
 	}
 
 	return bifrostResponse, nil
@@ -2692,10 +2693,6 @@ func (provider *AnthropicProvider) PassthroughStream(
 
 	extraFields := schemas.BifrostResponseExtraFields{}
 	statusCode := resp.StatusCode()
-
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &extraFields)
-	}
 
 	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
 	go func() {

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -2750,6 +2750,8 @@ func (provider *AzureProvider) Passthrough(
 		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err)
 	}
 
+	originalHeaders := make(map[string]string, len(headers))
+	maps.Copy(originalHeaders, headers)
 	// Remove wire-level encoding headers after decoding; downstream should recalculate them for the buffered body.
 	for k := range headers {
 		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
@@ -2761,12 +2763,10 @@ func (provider *AzureProvider) Passthrough(
 		StatusCode: resp.StatusCode(),
 		Headers:    headers,
 		Body:       body,
-	}
-
-	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
-
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &bifrostResponse.ExtraFields)
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency:                 latency.Milliseconds(),
+			ProviderResponseHeaders: originalHeaders,
+		},
 	}
 
 	return bifrostResponse, nil
@@ -2844,9 +2844,6 @@ func (provider *AzureProvider) PassthroughStream(
 	stopCancellation := providerUtils.SetupStreamCancellation(ctx, rawBodyStream, provider.logger)
 
 	extraFields := schemas.BifrostResponseExtraFields{}
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &extraFields)
-	}
 	statusCode := resp.StatusCode()
 
 	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -4091,6 +4092,8 @@ func (provider *GeminiProvider) Passthrough(
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err)
 	}
+	originalHeaders := make(map[string]string, len(headers))
+	maps.Copy(originalHeaders, headers)
 	for k := range headers {
 		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
 			delete(headers, k)
@@ -4101,12 +4104,10 @@ func (provider *GeminiProvider) Passthrough(
 		StatusCode: resp.StatusCode(),
 		Headers:    headers,
 		Body:       body,
-	}
-
-	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
-
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &bifrostResponse.ExtraFields)
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency:                 latency.Milliseconds(),
+			ProviderResponseHeaders: originalHeaders,
+		},
 	}
 
 	return bifrostResponse, nil
@@ -4193,10 +4194,6 @@ func (provider *GeminiProvider) PassthroughStream(
 
 	extraFields := schemas.BifrostResponseExtraFields{}
 	statusCode := resp.StatusCode()
-
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &extraFields)
-	}
 
 	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
 	go func() {

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -6888,6 +6888,8 @@ func (provider *OpenAIProvider) Passthrough(
 		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err)
 	}
 
+	originalHeaders := make(map[string]string, len(headers))
+	maps.Copy(originalHeaders, headers)
 	// Remove wire-level encoding headers after decoding; downstream should recalculate them for the buffered body.
 	for k := range headers {
 		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
@@ -6899,12 +6901,10 @@ func (provider *OpenAIProvider) Passthrough(
 		StatusCode: resp.StatusCode(),
 		Headers:    headers,
 		Body:       body,
-	}
-
-	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
-
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &bifrostResponse.ExtraFields)
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency:                 latency.Milliseconds(),
+			ProviderResponseHeaders: originalHeaders,
+		},
 	}
 
 	return bifrostResponse, nil
@@ -6995,9 +6995,6 @@ func (provider *OpenAIProvider) PassthroughStream(
 	stopCancellation := providerUtils.SetupStreamCancellation(ctx, rawBodyStream, provider.logger)
 
 	extraFields := schemas.BifrostResponseExtraFields{}
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &extraFields)
-	}
 	statusCode := resp.StatusCode()
 
 	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -2930,6 +2931,8 @@ func (provider *VertexProvider) Passthrough(
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err)
 	}
+	originalHeaders := make(map[string]string, len(headers))
+	maps.Copy(originalHeaders, headers)
 	for k := range headers {
 		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
 			delete(headers, k)
@@ -2939,13 +2942,10 @@ func (provider *VertexProvider) Passthrough(
 		StatusCode: resp.StatusCode(),
 		Headers:    headers,
 		Body:       body,
-	}
-
-	bifrostResponse.ExtraFields.ProviderResponseHeaders = headers
-	bifrostResponse.ExtraFields.Latency = latency.Milliseconds()
-
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &bifrostResponse.ExtraFields)
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency:                 latency.Milliseconds(),
+			ProviderResponseHeaders: originalHeaders,
+		},
 	}
 
 	return bifrostResponse, nil
@@ -3102,10 +3102,6 @@ func (provider *VertexProvider) PassthroughStream(
 
 	extraFields := schemas.BifrostResponseExtraFields{}
 	statusCode := resp.StatusCode()
-
-	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
-		providerUtils.ParseAndSetRawRequestIfJSON(fasthttpReq, &extraFields)
-	}
 
 	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
 	go func() {

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2813,11 +2813,16 @@ func (g *GenericRouter) handlePassthroughStream(
 	ctx.SetUserValue(schemas.BifrostContextKeyDeferTraceCompletion, true)
 
 	ctx.SetStatusCode(passthroughResp.StatusCode)
-	ctx.SetConnectionClose()
+	ctx.SetContentType("text/event-stream")
+	ctx.Response.Header.Set("Cache-Control", "no-cache")
+	ctx.Response.Header.Set("Connection", "keep-alive")
+	ctx.Response.Header.Set("X-Accel-Buffering", "no")
 	for k, v := range passthroughResp.Headers {
 		switch strings.ToLower(k) {
-		case "connection", "transfer-encoding", "content-length", "set-cookie", "proxy-authenticate", "www-authenticate":
-			// drop — content-length is invalid for a streaming response
+		case "connection", "transfer-encoding", "content-length", "content-type",
+			"cache-control", "x-accel-buffering",
+			"set-cookie", "proxy-authenticate", "www-authenticate":
+			// drop — streaming invariants are set explicitly above; upstream must not override them
 		default:
 			ctx.Response.Header.Set(k, v)
 		}

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -487,13 +487,15 @@ export function LogDetailView({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  onClick={() => copyRequestBody(log, copyBody)}
-                  data-testid="logdetails-copy-request-body-button"
-                >
-                  <Clipboard className="h-4 w-4" />
-                  Copy request body
-                </DropdownMenuItem>
+                {!isPassthrough && (
+                  <DropdownMenuItem
+                    onClick={() => copyRequestBody(log, copyBody)}
+                    data-testid="logdetails-copy-request-body-button"
+                  >
+                    <Clipboard className="h-4 w-4" />
+                    Copy request body
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuItem
                   onClick={() => downloadAsJson(log, `log-${log.id ?? "export"}.json`)}
                   data-testid="logdetails-export-log-button"
@@ -1378,14 +1380,16 @@ export function LogDetailView({
               </span>
             ) : null}
           </TabsTrigger>
-          <TabsTrigger value="tools" className="px-3">
-            Tools
-            {log.params?.tools?.length ? (
-              <span className="bg-background text-muted-foreground ml-1.5 rounded-sm border px-2 py-0.5 text-[10px] tabular-nums">
-                {log.params.tools.length}
-              </span>
-            ) : null}
-          </TabsTrigger>
+          {!isPassthrough && (
+            <TabsTrigger value="tools" className="px-3">
+              Tools
+              {log.params?.tools?.length ? (
+                <span className="bg-background text-muted-foreground ml-1.5 rounded-sm border px-2 py-0.5 text-[10px] tabular-nums">
+                  {log.params.tools.length}
+                </span>
+              ) : null}
+            </TabsTrigger>
+          )}
           <TabsTrigger value="routing" className="px-3">
             Routing
             {log.routing_engine_logs ? (
@@ -1402,9 +1406,11 @@ export function LogDetailView({
               </span>
             ) : null}
           </TabsTrigger>
-          <TabsTrigger value="raw" className="px-3">
-            Raw JSON
-          </TabsTrigger>
+          {!isPassthrough && (
+            <TabsTrigger value="raw" className="px-3">
+              Raw JSON
+            </TabsTrigger>
+          )}
         </TabsList>
 
         <TabsContent value="messages" className="space-y-4">
@@ -1446,7 +1452,92 @@ export function LogDetailView({
             />
           )}
 
-          {((log.input_history && log.input_history.length > 0) ||
+          {isPassthrough && passthroughRequestBody && (
+            <CollapsibleBox
+              title="Request Body"
+              onCopy={() => {
+                try {
+                  return JSON.stringify(
+                    JSON.parse(passthroughRequestBody || ""),
+                    null,
+                    2,
+                  );
+                } catch {
+                  return passthroughRequestBody || "";
+                }
+              }}
+            >
+              <CodeEditor
+                className="z-0 w-full"
+                shouldAdjustInitialHeight={true}
+                maxHeight={450}
+                wrap={true}
+                code={(() => {
+                  try {
+                    return JSON.stringify(
+                      JSON.parse(passthroughRequestBody || ""),
+                      null,
+                      2,
+                    );
+                  } catch {
+                    return passthroughRequestBody || "";
+                  }
+                })()}
+                lang="json"
+                readonly={true}
+                options={{
+                  scrollBeyondLastLine: false,
+                  lineNumbers: "off",
+                  alwaysConsumeMouseWheel: false,
+                }}
+              />
+            </CollapsibleBox>
+          )}
+          {isPassthrough &&
+            passthroughResponseBody &&
+            log.status !== "processing" && (
+              <CollapsibleBox
+                title="Response Body"
+                onCopy={() => {
+                  try {
+                    return JSON.stringify(
+                      JSON.parse(passthroughResponseBody || ""),
+                      null,
+                      2,
+                    );
+                  } catch {
+                    return passthroughResponseBody || "";
+                  }
+                }}
+              >
+                <CodeEditor
+                  className="z-0 w-full"
+                  shouldAdjustInitialHeight={true}
+                  maxHeight={450}
+                  wrap={true}
+                  code={(() => {
+                    try {
+                      return JSON.stringify(
+                        JSON.parse(passthroughResponseBody || ""),
+                        null,
+                        2,
+                      );
+                    } catch {
+                      return passthroughResponseBody || "";
+                    }
+                  })()}
+                  lang="json"
+                  readonly={true}
+                  options={{
+                    scrollBeyondLastLine: false,
+                    lineNumbers: "off",
+                    alwaysConsumeMouseWheel: false,
+                  }}
+                />
+              </CollapsibleBox>
+            )}
+
+          {!isPassthrough && ((log.input_history && log.input_history.length > 0) ||
             (log.output_message && !log.error_details?.error.message)) && (
             <div className="bg-card rounded-sm border p-5">
               {log.input_history?.map((message, index) => {
@@ -1919,90 +2010,6 @@ export function LogDetailView({
         </TabsContent>
 
         <TabsContent value="raw" className="space-y-3">
-          {isPassthrough && passthroughRequestBody && (
-            <CollapsibleBox
-              title="Request Body"
-              onCopy={() => {
-                try {
-                  return JSON.stringify(
-                    JSON.parse(passthroughRequestBody || ""),
-                    null,
-                    2,
-                  );
-                } catch {
-                  return passthroughRequestBody || "";
-                }
-              }}
-            >
-              <CodeEditor
-                className="z-0 w-full"
-                shouldAdjustInitialHeight={true}
-                maxHeight={450}
-                wrap={true}
-                code={(() => {
-                  try {
-                    return JSON.stringify(
-                      JSON.parse(passthroughRequestBody || ""),
-                      null,
-                      2,
-                    );
-                  } catch {
-                    return passthroughRequestBody || "";
-                  }
-                })()}
-                lang="json"
-                readonly={true}
-                options={{
-                  scrollBeyondLastLine: false,
-                  lineNumbers: "off",
-                  alwaysConsumeMouseWheel: false,
-                }}
-              />
-            </CollapsibleBox>
-          )}
-          {isPassthrough &&
-            passthroughResponseBody &&
-            log.status !== "processing" && (
-              <CollapsibleBox
-                title="Response Body"
-                onCopy={() => {
-                  try {
-                    return JSON.stringify(
-                      JSON.parse(passthroughResponseBody || ""),
-                      null,
-                      2,
-                    );
-                  } catch {
-                    return passthroughResponseBody || "";
-                  }
-                }}
-              >
-                <CodeEditor
-                  className="z-0 w-full"
-                  shouldAdjustInitialHeight={true}
-                  maxHeight={450}
-                  wrap={true}
-                  code={(() => {
-                    try {
-                      return JSON.stringify(
-                        JSON.parse(passthroughResponseBody || ""),
-                        null,
-                        2,
-                      );
-                    } catch {
-                      return passthroughResponseBody || "";
-                    }
-                  })()}
-                  lang="json"
-                  readonly={true}
-                  options={{
-                    scrollBeyondLastLine: false,
-                    lineNumbers: "off",
-                    alwaysConsumeMouseWheel: false,
-                  }}
-                />
-              </CollapsibleBox>
-            )}
           {rawRequest && (
             <>
               <div className="text-muted-foreground text-[12px]">


### PR DESCRIPTION
## Summary

Removes the `SendBackRawRequest` mechanism from passthrough flows across all providers and replaces it with always-on `ProviderResponseHeaders` population in `ExtraFields`. Additionally fixes passthrough streaming responses to use proper SSE headers, and improves the log detail UI to correctly handle passthrough logs by hiding irrelevant tabs and showing request/response bodies instead.

## Changes

- Removed all `ShouldSendBackRawRequest` / `ParseAndSetRawRequestIfJSON` calls from `Passthrough` and `PassthroughStream` in the Anthropic, Azure, Gemini, OpenAI, and Vertex providers. The raw request echo behavior is no longer conditionally applied.
- `ExtraFields` in `Passthrough` responses is now initialized inline with both `Latency` and `ProviderResponseHeaders` set unconditionally, making header propagation consistent across all providers (previously Vertex was the only one setting `ProviderResponseHeaders`).
- Fixed passthrough streaming HTTP responses to set `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`, and `X-Accel-Buffering: no` headers explicitly, replacing the previous `SetConnectionClose()` call. `content-type` is now also dropped from the upstream header forwarding list to avoid overriding the explicitly set value.
- In the log detail view, the **Tools** and **Raw JSON** tabs are now hidden for passthrough logs. Passthrough logs instead show collapsible **Request Body** and **Response Body** code editors (with pretty-printed JSON where applicable) in the messages tab, and the standard message/output history is suppressed for passthrough entries.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Send a passthrough request to each provider (Anthropic, Azure, Gemini, OpenAI, Vertex) and verify:
1. The response includes `ProviderResponseHeaders` in `ExtraFields` without needing any `sendBackRawRequest` flag set.
2. Streaming passthrough responses return `Content-Type: text/event-stream` and the other SSE headers.
3. In the UI log detail view, passthrough logs show Request Body and Response Body panels instead of the Tools/Raw JSON tabs.

## Screenshots/Recordings

Before: Passthrough log detail showed Tools and Raw JSON tabs with no request/response body display.  
After: Passthrough log detail hides Tools and Raw JSON tabs and renders collapsible Request Body and Response Body editors.

## Breaking changes

- [x] Yes
- [ ] No

The `SendBackRawRequest` / `ParseAndSetRawRequestIfJSON` behavior is removed from passthrough flows. Any consumers relying on the echoed raw request body in `ExtraFields` for passthrough responses will no longer receive it.

## Related issues

## Security considerations

Removing the raw request echo from passthrough responses reduces the risk of inadvertently reflecting sensitive request data (e.g., API keys in headers or bodies) back to callers.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable