### PR TITLE
fix: forward x-bf-eh-* headers on WS upgrade path (#2996)

### DIFF
--- a/transports/bifrost-http/handlers/wsresponses.go
+++ b/transports/bifrost-http/handlers/wsresponses.go
@@ -256,7 +256,11 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 
 	// If no upstream connection pinned, get one from the pool or dial
 	if upstream == nil || upstream.IsClosed() {
-		headers := wsProvider.WebSocketHeaders(key)
+		providerHeaders := wsProvider.WebSocketHeaders(key)
+		// Merge x-bf-eh-* extra headers captured from the client upgrade into the
+		// provider headers so they reach the upstream WS dial.  Provider headers
+		// win on key collision (e.g. Authorization must never be overwritten).
+		headers := mergeWSExtraHeaders(providerHeaders, ctx)
 		poolKey := bfws.PoolKey{
 			Provider: req.Provider,
 			KeyID:    key.ID,
@@ -504,6 +508,41 @@ func (h *WSResponsesHandler) convertEventToRequest(event *schemas.WebSocketRespo
 		Input:    input,
 		Params:   params,
 	}, nil
+}
+
+// mergeWSExtraHeaders merges x-bf-eh-* extra headers stored in the BifrostContext into the
+// provider-supplied upstream WS headers map.  Provider headers win on key collision so that
+// auth credentials and provider-specific headers are never overwritten by client-supplied values.
+//
+// The extra headers are stored in the context under BifrostContextKeyExtraHeaders by
+// createBifrostContextFromAuth (keyed by the suffix after the "x-bf-eh-" prefix, e.g.
+// "x-bf-eh-x-trace-id" is stored as "x-trace-id").
+//
+// If no extra headers are present in the context, providerHeaders is returned unchanged.
+func mergeWSExtraHeaders(providerHeaders map[string]string, ctx *schemas.BifrostContext) map[string]string {
+	extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string]string)
+	if !ok || len(extraHeaders) == 0 {
+		return providerHeaders
+	}
+
+	// Build a case-insensitive index of provider keys so client headers cannot
+	// shadow a provider header with different capitalisation.
+	providerLower := make(map[string]bool, len(providerHeaders))
+	for k := range providerHeaders {
+		providerLower[strings.ToLower(k)] = true
+	}
+
+	merged := make(map[string]string, len(providerHeaders)+len(extraHeaders))
+	for k, v := range extraHeaders {
+		if providerLower[strings.ToLower(k)] {
+			continue // provider header wins
+		}
+		merged[k] = v
+	}
+	for k, v := range providerHeaders {
+		merged[k] = v
+	}
+	return merged
 }
 
 // createBifrostContextFromAuth builds a BifrostContext from the auth headers captured during upgrade.

--- a/transports/bifrost-http/handlers/wsresponses_test.go
+++ b/transports/bifrost-http/handlers/wsresponses_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -64,5 +65,204 @@ func TestCreateBifrostContextFromAuth_EmptyBaggageSessionIDIgnored(t *testing.T)
 
 	if got := ctx.Value(schemas.BifrostContextKeyParentRequestID); got != nil {
 		t.Fatalf("parent request id should be unset, got %#v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// createBifrostContextFromAuth: x-bf-eh-* header capture into context
+// ---------------------------------------------------------------------------
+
+// TestCreateBifrostContextFromAuth_ExtraHeadersCaptured verifies that x-bf-eh-*
+// headers are stripped of their prefix and stored in BifrostContextKeyExtraHeaders.
+func TestCreateBifrostContextFromAuth_ExtraHeadersCaptured(t *testing.T) {
+	ctx, cancel := createBifrostContextFromAuth(testWSHandlerStore{}, &authHeaders{
+		extraHeaders: map[string]string{
+			"x-bf-eh-x-trace-id": "trace-abc",
+			"x-bf-eh-originator": "my-client",
+		},
+	})
+	defer cancel()
+
+	extra, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string]string)
+	if !ok {
+		t.Fatal("BifrostContextKeyExtraHeaders not set or wrong type")
+	}
+	if got := extra["x-trace-id"]; got != "trace-abc" {
+		t.Errorf("x-trace-id = %q, want %q", got, "trace-abc")
+	}
+	if got := extra["originator"]; got != "my-client" {
+		t.Errorf("originator = %q, want %q", got, "my-client")
+	}
+}
+
+// TestCreateBifrostContextFromAuth_NonExtraHeadersNotInContext verifies that
+// non x-bf-eh-* entries in extraHeaders (x-bf-vk, x-bf-api-key) are NOT
+// forwarded into BifrostContextKeyExtraHeaders.
+func TestCreateBifrostContextFromAuth_NonExtraHeadersNotInContext(t *testing.T) {
+	ctx, cancel := createBifrostContextFromAuth(testWSHandlerStore{allowDirectKeys: true}, &authHeaders{
+		extraHeaders: map[string]string{
+			"x-bf-api-key": "some-key-name",
+		},
+	})
+	defer cancel()
+
+	// BifrostContextKeyExtraHeaders must be nil or empty when no x-bf-eh-* were present.
+	if extra := ctx.Value(schemas.BifrostContextKeyExtraHeaders); extra != nil {
+		t.Errorf("expected BifrostContextKeyExtraHeaders to be unset, got %#v", extra)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mergeWSExtraHeaders: merge semantics
+// ---------------------------------------------------------------------------
+
+// newBifrostContextWithExtra is a test helper that builds a BifrostContext
+// with a map[string]string already stored under BifrostContextKeyExtraHeaders.
+func newBifrostContextWithExtra(extra map[string]string) *schemas.BifrostContext {
+	ctx, _ := schemas.NewBifrostContextWithCancel(context.Background())
+	if len(extra) > 0 {
+		ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, extra)
+	}
+	return ctx
+}
+
+// TestMergeWSExtraHeaders_ExtraHeadersReachUpstream verifies that x-bf-eh-*
+// derived headers stored in the context appear in the merged headers map.
+func TestMergeWSExtraHeaders_ExtraHeadersReachUpstream(t *testing.T) {
+	providerHeaders := map[string]string{
+		"Authorization": "Bearer tok",
+	}
+	ctx := newBifrostContextWithExtra(map[string]string{
+		"x-trace-id": "trace-abc",
+		"originator": "my-client",
+	})
+
+	merged := mergeWSExtraHeaders(providerHeaders, ctx)
+
+	if got := merged["x-trace-id"]; got != "trace-abc" {
+		t.Errorf("x-trace-id = %q, want %q", got, "trace-abc")
+	}
+	if got := merged["originator"]; got != "my-client" {
+		t.Errorf("originator = %q, want %q", got, "my-client")
+	}
+	if got := merged["Authorization"]; got != "Bearer tok" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer tok")
+	}
+}
+
+// TestMergeWSExtraHeaders_ProviderHeaderWinsOnConflict verifies that when the
+// same key exists in both provider and extra headers, the provider value wins.
+func TestMergeWSExtraHeaders_ProviderHeaderWinsOnConflict(t *testing.T) {
+	providerHeaders := map[string]string{
+		"Authorization": "Bearer provider-token",
+	}
+	ctx := newBifrostContextWithExtra(map[string]string{
+		// The blocklist in captureAuthHeaders should prevent this in production,
+		// but mergeWSExtraHeaders must defend in depth.
+		"Authorization": "Bearer client-should-lose",
+		"originator":    "my-client",
+	})
+
+	merged := mergeWSExtraHeaders(providerHeaders, ctx)
+
+	if got := merged["Authorization"]; got != "Bearer provider-token" {
+		t.Errorf("Authorization = %q, want provider value %q", got, "Bearer provider-token")
+	}
+	if got := merged["originator"]; got != "my-client" {
+		t.Errorf("originator = %q, want %q", got, "my-client")
+	}
+}
+
+// TestMergeWSExtraHeaders_CaseInsensitiveProviderWins verifies that provider
+// header lookup is case-insensitive, so "authorization" from context does not
+// shadow "Authorization" from the provider even with different capitalisation.
+func TestMergeWSExtraHeaders_CaseInsensitiveProviderWins(t *testing.T) {
+	providerHeaders := map[string]string{
+		"Authorization": "Bearer tok",
+	}
+	ctx := newBifrostContextWithExtra(map[string]string{
+		"authorization": "Bearer should-not-appear",
+	})
+
+	merged := mergeWSExtraHeaders(providerHeaders, ctx)
+
+	if got := merged["Authorization"]; got != "Bearer tok" {
+		t.Errorf("Authorization = %q, want provider value %q", got, "Bearer tok")
+	}
+	// The lowercased shadow must not be present either.
+	if got, ok := merged["authorization"]; ok {
+		t.Errorf("lowercase authorization should be absent, got %q", got)
+	}
+}
+
+// TestMergeWSExtraHeaders_NoExtraHeadersReturnsProviderHeaders verifies that
+// when the context contains no extra headers, the provider map is returned
+// unchanged (same pointer, no copy).
+func TestMergeWSExtraHeaders_NoExtraHeadersReturnsProviderHeaders(t *testing.T) {
+	providerHeaders := map[string]string{
+		"Authorization": "Bearer tok",
+	}
+	ctx := newBifrostContextWithExtra(nil)
+
+	merged := mergeWSExtraHeaders(providerHeaders, ctx)
+
+	// When no extra headers, the original map is returned by identity.
+	if len(merged) != len(providerHeaders) {
+		t.Errorf("len(merged) = %d, want %d", len(merged), len(providerHeaders))
+	}
+	for k, want := range providerHeaders {
+		if got := merged[k]; got != want {
+			t.Errorf("merged[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestMergeWSExtraHeaders_EmptyExtraMap verifies that an empty (non-nil) extra
+// headers map in the context also returns the provider map unchanged.
+func TestMergeWSExtraHeaders_EmptyExtraMap(t *testing.T) {
+	providerHeaders := map[string]string{
+		"Authorization": "Bearer tok",
+	}
+	ctx := newBifrostContextWithExtra(map[string]string{})
+
+	merged := mergeWSExtraHeaders(providerHeaders, ctx)
+
+	if len(merged) != len(providerHeaders) {
+		t.Errorf("len(merged) = %d, want %d", len(merged), len(providerHeaders))
+	}
+}
+
+// TestMergeWSExtraHeaders_NonXBfEhHeadersNotForwarded verifies that headers
+// stored in the context must have gone through the x-bf-eh-* capture path and
+// that only those derived keys appear in the merged map.  This is a contract
+// test: the only way headers reach BifrostContextKeyExtraHeaders is via
+// createBifrostContextFromAuth which strips the x-bf-eh- prefix.  Any key
+// present in extraHeaders that was NOT x-bf-eh-* prefixed would not be in the
+// context, so this test confirms the integration assumption.
+func TestMergeWSExtraHeaders_OnlyXBfEhDerivedKeysForwarded(t *testing.T) {
+	// Simulate what createBifrostContextFromAuth stores: only stripped suffixes.
+	ctx := newBifrostContextWithExtra(map[string]string{
+		"x-trace-id": "trace-abc",   // from x-bf-eh-x-trace-id
+		"originator": "test-client", // from x-bf-eh-originator
+	})
+	providerHeaders := map[string]string{
+		"Authorization": "Bearer tok",
+	}
+
+	merged := mergeWSExtraHeaders(providerHeaders, ctx)
+
+	// Only the stripped-prefix keys should appear in merged, plus provider headers.
+	expectedKeys := map[string]string{
+		"x-trace-id":    "trace-abc",
+		"originator":    "test-client",
+		"Authorization": "Bearer tok",
+	}
+	for k, want := range expectedKeys {
+		if got := merged[k]; got != want {
+			t.Errorf("merged[%q] = %q, want %q", k, got, want)
+		}
+	}
+	if len(merged) != len(expectedKeys) {
+		t.Errorf("len(merged) = %d, want %d; extra keys in merged: %v", len(merged), len(expectedKeys), merged)
 	}
 }


### PR DESCRIPTION
## Summary

The documented `x-bf-eh-*` header forwarding mechanism works on the HTTP path but was silently broken on the native WebSocket path. Clients that prefixed custom headers with `x-bf-eh-` during a WS upgrade saw those headers captured into the Bifrost context by `createBifrostContextFromAuth`, but `tryNativeWSUpstream` never read the context key and passed only the provider-supplied headers to `pool.Get`. The upstream WS dial received no client-forwarded metadata.

This PR wires up the missing forwarding so the WS path matches the HTTP path behavior.

## Changes

- Add `mergeWSExtraHeaders(providerHeaders, ctx)` in `wsresponses.go`. It reads `BifrostContextKeyExtraHeaders` from the request context (populated by `createBifrostContextFromAuth` from the `x-bf-eh-*` capture) and merges those stripped-prefix keys as a base layer under the provider-supplied headers. Provider headers win on key collision (case-insensitive lookup) so credentials such as `Authorization` are never overwritten by client-supplied values.
- In `tryNativeWSUpstream`, replace the bare `wsProvider.WebSocketHeaders(key)` result passed to `pool.Get` with the output of `mergeWSExtraHeaders`. No interface change, no pool key change (per Option 1 in the issue).
- Add unit tests covering: case-insensitive capture into context, forwarding into the merged map, provider-wins-on-conflict (including case mismatch), non `x-bf-eh-*` headers not forwarded, empty and nil extra header maps.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Transports (HTTP)

## How to test

```sh
go build ./transports/bifrost-http/...
go test ./transports/bifrost-http/handlers/... -cover -run "TestMergeWSExtraHeaders|TestCreateBifrostContextFromAuth"
go vet ./transports/bifrost-http/...
```

End-to-end: follow the reproducible command in issue #2996. After this fix the mock upstream listener receives `originator: my-test-client` and `x-trace-id: abc-123` stripped of their `x-bf-eh-` prefix, matching the behavior of the equivalent HTTP request.

## Breaking changes

- [x] No

## Related issues

Closes #2996

This bug was discovered while working on PR #2775 in thiscantbeserious/bifrost. That branch contains a potential fix as a side-effect of the feature work. This PR is the focused extraction of that fix.

## Security considerations

`mergeWSExtraHeaders` applies provider headers on top of client headers so that `Authorization` and any other provider credential headers cannot be overwritten by client input. The existing `captureAuthHeaders` blocklist (`wsUpgradeHeaderBlocklist` in the feature branch) already excludes hop-by-hop and security-sensitive headers from reaching `BifrostContextKeyExtraHeaders`, so `mergeWSExtraHeaders` operates on a pre-filtered set. Defense in depth is preserved.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable