### PR TITLE
docs: clarify `env.*` unsupported in `guardrails_config` and update examples to use explicit placeholder values

### DIFF
--- a/docs/deployment-guides/config-json/guardrails.mdx
+++ b/docs/deployment-guides/config-json/guardrails.mdx
@@ -8,6 +8,10 @@ icon: "shield-halved"
 Guardrails are an **enterprise-only** feature and require the enterprise Bifrost image.
 </Note>
 
+<Warning>
+`env.*` references are currently **not supported** inside `guardrails_config` (including provider `config` values). Use explicit values in `guardrails_config` for now.
+</Warning>
+
 Guardrails are configured under `guardrails_config` in `config.json`. The configuration has two parts:
 
 - **`guardrail_providers`** — the backend that performs the check. Rules link to providers by `id`.
@@ -63,8 +67,8 @@ Runs entirely in-process with no external dependency. Patterns use RE2 syntax. S
           "guardrail_arn": "arn:aws:bedrock:us-east-1::guardrail/abc123",
           "guardrail_version": "DRAFT",
           "region": "us-east-1",
-          "access_key": "env.AWS_ACCESS_KEY_ID",
-          "secret_key": "env.AWS_SECRET_ACCESS_KEY"
+          "access_key": "YOUR_AWS_ACCESS_KEY_ID",
+          "secret_key": "YOUR_AWS_SECRET_ACCESS_KEY"
         }
       }
     ]
@@ -87,7 +91,7 @@ Runs entirely in-process with no external dependency. Patterns use RE2 syntax. S
         "timeout": 10,
         "config": {
           "endpoint": "https://your-resource.cognitiveservices.azure.com",
-          "api_key": "env.AZURE_CONTENT_SAFETY_KEY",
+          "api_key": "YOUR_AZURE_CONTENT_SAFETY_KEY",
           "analyze_enabled": true,
           "analyze_severity_threshold": "medium",
           "jailbreak_shield_enabled": true,
@@ -118,7 +122,7 @@ Runs entirely in-process with no external dependency. Patterns use RE2 syntax. S
         "enabled": true,
         "timeout": 15,
         "config": {
-          "api_key": "env.GRAYSWAN_API_KEY",
+          "api_key": "YOUR_GRAYSWAN_API_KEY",
           "violation_threshold": 0.7,
           "reasoning_mode": "standard",
           "policy_id": "",
@@ -254,7 +258,7 @@ Rules are CEL expressions that fire when their condition matches. Available CEL 
         "timeout": 10,
         "config": {
           "endpoint": "https://your-resource.cognitiveservices.azure.com",
-          "api_key": "env.AZURE_CONTENT_SAFETY_KEY",
+          "api_key": "YOUR_AZURE_CONTENT_SAFETY_KEY",
           "analyze_enabled": true,
           "analyze_severity_threshold": "medium",
           "jailbreak_shield_enabled": true,

--- a/docs/deployment-guides/helm/guardrails.mdx
+++ b/docs/deployment-guides/helm/guardrails.mdx
@@ -8,6 +8,10 @@ icon: "shield-halved"
 Guardrails are an **enterprise-only** feature. They require the enterprise Bifrost image.
 </Note>
 
+<Warning>
+`env.*` references are currently **not supported** in `bifrost.guardrails` provider `config` values. Use explicit values there for now.
+</Warning>
+
 Guardrails are configured under `bifrost.guardrails` in your values file. The configuration has two parts:
 
 - **`providers`** — the backend that performs the check. Rules link to providers by `id`.
@@ -58,8 +62,8 @@ bifrost:
           guardrail_arn: "arn:aws:bedrock:us-east-1::guardrail/abc123"
           guardrail_version: "DRAFT"          # or a published version number
           region: "us-east-1"
-          access_key: "env.AWS_ACCESS_KEY_ID" # omit to use instance role
-          secret_key: "env.AWS_SECRET_ACCESS_KEY"
+          access_key: "YOUR_AWS_ACCESS_KEY_ID" # omit to use instance role
+          secret_key: "YOUR_AWS_SECRET_ACCESS_KEY"
 ```
 
 </Tab>
@@ -76,7 +80,7 @@ bifrost:
         timeout: 10
         config:
           endpoint: "https://your-resource.cognitiveservices.azure.com"
-          api_key: "env.AZURE_CONTENT_SAFETY_KEY"
+          api_key: "YOUR_AZURE_CONTENT_SAFETY_KEY"
           analyze_enabled: true
           analyze_severity_threshold: "medium"  # low | medium | high
           jailbreak_shield_enabled: true
@@ -99,7 +103,7 @@ bifrost:
         enabled: true
         timeout: 15
         config:
-          api_key: "env.GRAYSWAN_API_KEY"
+          api_key: "YOUR_GRAYSWAN_API_KEY"
           violation_threshold: 0.7        # 0.0–1.0; higher = more permissive
           reasoning_mode: "standard"      # standard | fast
           policy_id: ""                   # optional: single policy ID
@@ -220,7 +224,7 @@ bifrost:
         timeout: 10
         config:
           endpoint: "https://your-resource.cognitiveservices.azure.com"
-          api_key: "env.AZURE_CONTENT_SAFETY_KEY"
+          api_key: "YOUR_AZURE_CONTENT_SAFETY_KEY"
           analyze_enabled: true
           analyze_severity_threshold: "medium"
           jailbreak_shield_enabled: true
@@ -251,12 +255,5 @@ bifrost:
 ```
 
 ```bash
-kubectl create secret generic azure-content-safety \
-  --from-literal=key='your-azure-content-safety-api-key'
-
-helm install bifrost bifrost/bifrost \
-  -f guardrails-values.yaml \
-  --set env[0].name=AZURE_CONTENT_SAFETY_KEY \
-  --set env[0].valueFrom.secretKeyRef.name=azure-content-safety \
-  --set env[0].valueFrom.secretKeyRef.key=key
+helm install bifrost bifrost/bifrost -f guardrails-values.yaml
 ```


### PR DESCRIPTION
## Summary

Documents a current limitation where `env.*` variable references are not supported inside `guardrails_config` provider `config` values. Updates all code examples to use explicit placeholder values instead of `env.*` references, and removes the misleading Helm example that showed how to wire secrets via environment variables (since that pattern doesn't work).

## Changes

- Added a `<Warning>` callout to both the `config.json` and Helm guardrails docs explicitly stating that `env.*` references are not supported in guardrail provider config values
- Replaced all `env.AWS_ACCESS_KEY_ID`, `env.AWS_SECRET_ACCESS_KEY`, `env.AZURE_CONTENT_SAFETY_KEY`, and `env.GRAYSWAN_API_KEY` references in code examples with `YOUR_*` placeholder strings to avoid implying the `env.*` pattern works
- Removed the Helm example that demonstrated injecting secrets via `kubectl create secret` and `--set env[0]...`, as this approach does not function for guardrail provider config values

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation pages for:
- `docs/deployment-guides/config-json/guardrails.mdx`
- `docs/deployment-guides/helm/guardrails.mdx`

Verify the warning callout appears near the top of each page and that no `env.*` references remain in guardrail provider config examples.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change prevents users from following a broken pattern that could lead to credentials being hardcoded unintentionally or misconfigured guardrails silently failing to authenticate. Users should be aware that secrets cannot currently be injected via environment variable references in guardrail provider config and must use explicit values with appropriate secret management outside of the config file.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable