### PR TITLE
fix: finalize native WS log on parse failure and clean close

### DIFF
--- a/transports/bifrost-http/handlers/wsresponses.go
+++ b/transports/bifrost-http/handlers/wsresponses.go
@@ -304,20 +304,63 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 
 	// Read response events from upstream and relay to client, running post-hooks per chunk
 	forwardedAny := false
+	terminalPostHookFired := false
 	for {
 		msgType, data, readErr := upstream.ReadMessage()
 		if readErr != nil {
-			logger.Warn("upstream WS read failed for %s: %v, falling back to HTTP bridge", req.Provider, readErr)
 			h.pool.Discard(upstream)
 			session.SetUpstream(nil)
+
 			if !forwardedAny {
+				// Nothing was forwarded yet: fall through to HTTP bridge.
+				logger.Warn("upstream WS read failed for %s (no data forwarded): %v, falling back to HTTP bridge", req.Provider, readErr)
 				return false
 			}
-			writeWSError(session, 502, "upstream_connection_error", "upstream websocket stream interrupted")
+
+			// We already forwarded content. If the terminal post-hook has not
+			// fired yet (full struct parse failed or the upstream closed without
+			// sending a recognized terminal event), synthesize a completed event
+			// so the logging plugin writes the DB row and the UI transitions out
+			// of "processing".
+			if !terminalPostHookFired {
+				isClean := ws.IsCloseError(readErr, ws.CloseNormalClosure, ws.CloseGoingAway, ws.CloseNoStatusReceived)
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				synth := synthesizeTerminalStreamResponse(req.Provider, req.Model, schemas.ResponsesStreamResponseTypeCompleted)
+				synthResp := &schemas.BifrostResponse{ResponsesStreamResponse: synth}
+				if tracer != nil && traceID != "" {
+					tracer.AddStreamingChunk(traceID, synthResp)
+				}
+				hooks.PostHookRunner(ctx, synthResp, nil) //nolint:errcheck
+				if isClean {
+					logger.Debug("upstream WS closed cleanly for %s without terminal event; synthesized response.completed for logging", req.Provider)
+				} else {
+					logger.Warn("upstream WS read failed for %s after forwarding data: %v; finalizing log as error", req.Provider, readErr)
+					writeWSError(session, 502, "upstream_connection_error", "upstream websocket stream interrupted")
+				}
+			}
 			return true
 		}
 
 		streamResp := parseUpstreamWSEvent(data, req.Provider, req.Model)
+
+		// When the full parse failed, attempt a lightweight type extraction so
+		// that terminal-event detection works even for event shapes that don't
+		// fully unmarshal (e.g. large response.completed frames or provider-
+		// specific events with unknown nested fields).
+		if streamResp == nil {
+			if rawType := extractStreamEventType(data); rawType != "" {
+				if isTerminalStreamType(rawType) {
+					// Full parse failed but we can still detect the terminal event.
+					// Synthesize a minimal struct so the post-hook and log finalize.
+					streamResp = synthesizeTerminalStreamResponse(req.Provider, req.Model, rawType)
+				} else {
+					logger.Debug("upstream WS event parse failed for type=%q; relaying raw bytes without post-hook", rawType)
+				}
+			} else {
+				logger.Debug("upstream WS event parse failed and type extraction failed; relaying raw bytes without post-hook")
+			}
+		}
+
 		isTerminal := streamResp != nil && isTerminalStreamType(streamResp.Type)
 
 		if isTerminal {
@@ -337,6 +380,9 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 				session.SetUpstream(nil)
 				writeWSBifrostError(session, postErr)
 				return true
+			}
+			if isTerminal {
+				terminalPostHookFired = true
 			}
 		}
 
@@ -391,6 +437,36 @@ func parseUpstreamWSEvent(data []byte, provider schemas.ModelProvider, model str
 	streamResp.ExtraFields.Provider = provider
 	streamResp.ExtraFields.OriginalModelRequested = model
 	return &streamResp
+}
+
+// extractStreamEventType performs a minimal parse of a raw upstream WS event to
+// extract the "type" field without requiring the full BifrostResponsesStreamResponse
+// struct to unmarshal successfully. This is used as a fallback when
+// parseUpstreamWSEvent returns nil (e.g., when the upstream sends events with
+// unknown or incompatible field shapes such as large response.completed frames).
+// Returns an empty string if the JSON is malformed or has no "type" field.
+func extractStreamEventType(data []byte) schemas.ResponsesStreamResponseType {
+	var envelope struct {
+		Type string `json:"type"`
+	}
+	if err := sonic.Unmarshal(data, &envelope); err != nil {
+		return ""
+	}
+	return schemas.ResponsesStreamResponseType(envelope.Type)
+}
+
+// synthesizeTerminalStreamResponse builds a minimal BifrostResponsesStreamResponse
+// with the given terminal event type. It populates ExtraFields so that downstream
+// plugins (logging, tracing) can identify the request type, provider, and model.
+// Used when the full upstream parse fails but we still need to finalize the log.
+func synthesizeTerminalStreamResponse(provider schemas.ModelProvider, model string, eventType schemas.ResponsesStreamResponseType) *schemas.BifrostResponsesStreamResponse {
+	synth := &schemas.BifrostResponsesStreamResponse{
+		Type: eventType,
+	}
+	synth.ExtraFields.RequestType = schemas.ResponsesStreamRequest
+	synth.ExtraFields.Provider = provider
+	synth.ExtraFields.OriginalModelRequested = model
+	return synth
 }
 
 // isTerminalStreamType returns true if the event type signals the end of a response stream.

--- a/transports/bifrost-http/handlers/wsresponses_test.go
+++ b/transports/bifrost-http/handlers/wsresponses_test.go
@@ -66,3 +66,100 @@ func TestCreateBifrostContextFromAuth_EmptyBaggageSessionIDIgnored(t *testing.T)
 		t.Fatalf("parent request id should be unset, got %#v", got)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// extractStreamEventType: lightweight type field extraction
+// ---------------------------------------------------------------------------
+
+func TestExtractStreamEventType_ValidTerminal(t *testing.T) {
+	got := extractStreamEventType([]byte(`{"type":"response.completed","sequence_number":5}`))
+	if got != schemas.ResponsesStreamResponseTypeCompleted {
+		t.Errorf("got %q, want %q", got, schemas.ResponsesStreamResponseTypeCompleted)
+	}
+}
+
+func TestExtractStreamEventType_ValidNonTerminal(t *testing.T) {
+	got := extractStreamEventType([]byte(`{"type":"response.output_text.delta","delta":"hello"}`))
+	if got != schemas.ResponsesStreamResponseTypeOutputTextDelta {
+		t.Errorf("got %q, want %q", got, schemas.ResponsesStreamResponseTypeOutputTextDelta)
+	}
+}
+
+func TestExtractStreamEventType_MalformedJSON(t *testing.T) {
+	got := extractStreamEventType([]byte(`not json at all`))
+	if got != "" {
+		t.Errorf("expected empty string for malformed JSON, got %q", got)
+	}
+}
+
+func TestExtractStreamEventType_MissingTypeField(t *testing.T) {
+	got := extractStreamEventType([]byte(`{"sequence_number":1,"delta":"hello"}`))
+	if got != "" {
+		t.Errorf("expected empty string for missing type field, got %q", got)
+	}
+}
+
+func TestExtractStreamEventType_UnknownExtraFields(t *testing.T) {
+	// Simulates a large or provider-specific event with unknown nested structure.
+	raw := []byte(`{"type":"response.completed","some_unknown_field":{"nested":{"deeply":"yes"}},"another_unknown":null}`)
+	got := extractStreamEventType(raw)
+	if got != schemas.ResponsesStreamResponseTypeCompleted {
+		t.Errorf("got %q, want %q", got, schemas.ResponsesStreamResponseTypeCompleted)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// synthesizeTerminalStreamResponse: minimal struct construction
+// ---------------------------------------------------------------------------
+
+func TestSynthesizeTerminalStreamResponse_FieldsPopulated(t *testing.T) {
+	resp := synthesizeTerminalStreamResponse(schemas.OpenAI, "gpt-4o", schemas.ResponsesStreamResponseTypeCompleted)
+	if resp == nil {
+		t.Fatal("got nil response")
+	}
+	if resp.Type != schemas.ResponsesStreamResponseTypeCompleted {
+		t.Errorf("Type = %q, want %q", resp.Type, schemas.ResponsesStreamResponseTypeCompleted)
+	}
+	if resp.ExtraFields.Provider != schemas.OpenAI {
+		t.Errorf("Provider = %q, want %q", resp.ExtraFields.Provider, schemas.OpenAI)
+	}
+	if resp.ExtraFields.OriginalModelRequested != "gpt-4o" {
+		t.Errorf("OriginalModelRequested = %q, want %q", resp.ExtraFields.OriginalModelRequested, "gpt-4o")
+	}
+	if resp.ExtraFields.RequestType != schemas.ResponsesStreamRequest {
+		t.Errorf("RequestType = %v, want %v", resp.ExtraFields.RequestType, schemas.ResponsesStreamRequest)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isTerminalStreamType: terminal detection
+// ---------------------------------------------------------------------------
+
+func TestIsTerminalStreamType_TerminalTypes(t *testing.T) {
+	terminals := []schemas.ResponsesStreamResponseType{
+		schemas.ResponsesStreamResponseTypeCompleted,
+		schemas.ResponsesStreamResponseTypeFailed,
+		schemas.ResponsesStreamResponseTypeIncomplete,
+		schemas.ResponsesStreamResponseTypeError,
+	}
+	for _, tt := range terminals {
+		if !isTerminalStreamType(tt) {
+			t.Errorf("expected %q to be terminal", tt)
+		}
+	}
+}
+
+func TestIsTerminalStreamType_NonTerminalTypes(t *testing.T) {
+	nonTerminals := []schemas.ResponsesStreamResponseType{
+		schemas.ResponsesStreamResponseTypeOutputTextDelta,
+		schemas.ResponsesStreamResponseTypeCreated,
+		schemas.ResponsesStreamResponseTypeInProgress,
+		schemas.ResponsesStreamResponseType("codex.rate_limits"),
+		schemas.ResponsesStreamResponseType(""),
+	}
+	for _, tt := range nonTerminals {
+		if isTerminalStreamType(tt) {
+			t.Errorf("expected %q to be non-terminal", tt)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Every native-WS request that exchanges frames with an upstream must produce exactly one log row. Two independent code paths in `tryNativeWSUpstream` broke that invariant, leaving log entries stuck in "processing" until the 5-minute TTL sweeper silently evicted them.

**Path A - parse failure:** `parseUpstreamWSEvent` does a full `sonic.Unmarshal` into `BifrostResponsesStreamResponse` and returns `nil` on any error. A frame that is valid JSON but contains nested fields the struct cannot accept (observed with large ~57 KB `response.completed` frames from `chatgpt.com/backend-api/codex`) causes `streamResp` to stay nil. `isTerminal` never becomes true, `StreamEndIndicator` is never set, and PostHookRunner is never called with a terminal response, so the logging plugin never writes the DB row.

**Path B - clean upstream close:** when `ReadMessage` errors after at least one frame has been forwarded but no terminal post-hook has fired yet, the read loop wrote a 502 to the client and returned without calling PostHookRunner. The in-memory pending log entry was later silently evicted by the TTL sweeper with no DB trace.

## Changes

- Add `extractStreamEventType(data []byte)` - performs a minimal single-field unmarshal to read only the `type` key as a fallback when the full struct parse fails. Returns an empty string on malformed JSON or missing `type`.
- Add `synthesizeTerminalStreamResponse(provider, model, eventType)` - builds a minimal `BifrostResponsesStreamResponse` with ExtraFields populated so downstream plugins (logging, tracing) can identify the request type, provider, and model.
- In `tryNativeWSUpstream`: add `terminalPostHookFired` guard. When the upstream WS closes (cleanly or with an error) after forwarding content but before a terminal post-hook fired, synthesize a `response.completed` event, set `StreamEndIndicator=true`, and call PostHookRunner once so the logging plugin writes the DB row. Clean closes (codes 1000, 1001, 1005) do not write a 502 to the client; abnormal closes still do.
- When the full struct parse fails on an in-flight frame, fall back to `extractStreamEventType`. If the raw type is a recognized terminal type, synthesize a minimal struct and fire the terminal post-hook so the log is finalized.
- Unit tests for `extractStreamEventType` (valid terminal, valid non-terminal, malformed JSON, missing type field, unknown nested fields), `synthesizeTerminalStreamResponse` field population, and `isTerminalStreamType` coverage.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other

## Affected areas

- Transports (HTTP) - `transports/bifrost-http/handlers/wsresponses.go`

## How to test

Run the unit tests directly:

```bash
go test ./transports/bifrost-http/handlers/... -run "TestExtractStreamEventType|TestSynthesizeTerminalStreamResponse|TestIsTerminalStreamType" -v
go test ./transports/bifrost-http/handlers/... -cover
go vet ./transports/bifrost-http/...
```

Manual reproduction for Path B (clean close without terminal event):

```bash
cat > /tmp/ws_mock_clean_close.py <<'PY'
import asyncio, json
import websockets

async def handler(ws):
    await ws.send(json.dumps({"type":"response.created","response":{"id":"resp_mock_1","status":"in_progress"},"sequence_number":0}))
    await asyncio.sleep(0.5)
    await ws.close(code=1000, reason="clean close")

async def main():
    async with websockets.serve(handler, "0.0.0.0", 9998):
        await asyncio.Future()

asyncio.run(main())
PY
python3 /tmp/ws_mock_clean_close.py &

sqlite3 bifrost-data/logs.db "SELECT COUNT(*) FROM logs"

printf '{"type":"response.create","model":"openai/gpt-4o","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}]}\n' \
  | websocat -n1 ws://localhost:8080/openai/v1/responses -H='Authorization: Bearer sk-fake-key'

sleep 2
sqlite3 bifrost-data/logs.db "SELECT COUNT(*) FROM logs"
```

Before this fix: count unchanged (no row written). After: count increases by one with status `success`.

## Breaking changes

No.

## Related

Closes #2997

This bug was discovered while working on PR #2775 in thiscantbeserious/bifrost. That branch contains a potential fix as a side-effect of the feature work. The fix has been extracted here as a focused standalone change.