### PR TITLE
fix: flush tracer on WS responses final chunk

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4123,6 +4123,9 @@ func (bifrost *Bifrost) RunStreamPreHooks(ctx *schemas.BifrostContext, req *sche
 		resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, result, err, preCount)
 		if IsFinalChunk(ctx) {
 			drainAndAttachPluginLogs(ctx)
+			if traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string); ok && strings.TrimSpace(traceID) != "" {
+				tracer.CompleteAndFlushTrace(strings.TrimSpace(traceID))
+			}
 		}
 		if bifrostErr != nil {
 			bifrostErr.PopulateExtraFields(req.RequestType, wsProvider, wsModel, wsModel)

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -2640,3 +2640,132 @@ func TestPluginPipelineStreamingRace(t *testing.T) {
 
 	wg.Wait()
 }
+
+// recordingTracer wraps NoOpTracer and counts CompleteAndFlushTrace calls.
+type recordingTracer struct {
+	schemas.NoOpTracer
+	mu         sync.Mutex
+	flushed    []string
+	createOnce sync.Once
+	traceID    string
+}
+
+func (r *recordingTracer) CreateTrace(_ string, _ ...string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.traceID = "test-trace-id"
+	return r.traceID
+}
+
+func (r *recordingTracer) CompleteAndFlushTrace(traceID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.flushed = append(r.flushed, traceID)
+}
+
+func (r *recordingTracer) flushedIDs() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.flushed))
+	copy(out, r.flushed)
+	return out
+}
+
+// minimalBifrost returns a Bifrost instance with no providers and no plugins,
+// suitable for testing RunStreamPreHooks without network calls.
+func minimalBifrost(t *testing.T, tracer schemas.Tracer) *Bifrost {
+	t.Helper()
+	account := NewMockAccount()
+	cfg := schemas.BifrostConfig{
+		Account: account,
+		Logger:  NewDefaultLogger(schemas.LogLevelError),
+		Tracer:  tracer,
+	}
+	bf, err := Init(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	return bf
+}
+
+// TestRunStreamPreHooks_PostHookRunner_FlushesTracerOnFinalChunk asserts that
+// the postHookRunner returned by RunStreamPreHooks calls CompleteAndFlushTrace
+// when the context carries BifrostContextKeyStreamEndIndicator = true.
+//
+// This is the regression test for the bug described in issue #2999: the
+// happy-path WS postHookRunner was missing the CompleteAndFlushTrace call,
+// which left audit log rows stuck in memory and never written to the store.
+func TestRunStreamPreHooks_PostHookRunner_FlushesTracerOnFinalChunk(t *testing.T) {
+	rec := &recordingTracer{}
+	bf := minimalBifrost(t, rec)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.WebSocketResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4o",
+		},
+	}
+
+	hooks, bifrostErr := bf.RunStreamPreHooks(ctx, req)
+	if bifrostErr != nil {
+		t.Fatalf("RunStreamPreHooks returned unexpected error: %+v", bifrostErr)
+	}
+	if hooks == nil {
+		t.Fatal("RunStreamPreHooks returned nil hooks")
+	}
+	defer hooks.Cleanup()
+
+	// Verify no flush has happened yet (stream is not finished).
+	if ids := rec.flushedIDs(); len(ids) != 0 {
+		t.Fatalf("expected no flush before final chunk, got %v", ids)
+	}
+
+	// Mark context as final chunk and invoke postHookRunner.
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+	hooks.PostHookRunner(ctx, nil, nil)
+
+	// The tracer must have been flushed exactly once with the correct traceID.
+	ids := rec.flushedIDs()
+	if len(ids) != 1 {
+		t.Fatalf("expected exactly 1 CompleteAndFlushTrace call, got %d: %v", len(ids), ids)
+	}
+	if ids[0] != "test-trace-id" {
+		t.Errorf("expected traceID %q, got %q", "test-trace-id", ids[0])
+	}
+}
+
+// TestRunStreamPreHooks_PostHookRunner_NoFlushOnNonFinalChunk asserts that
+// the postHookRunner does NOT call CompleteAndFlushTrace for non-final chunks.
+func TestRunStreamPreHooks_PostHookRunner_NoFlushOnNonFinalChunk(t *testing.T) {
+	rec := &recordingTracer{}
+	bf := minimalBifrost(t, rec)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.WebSocketResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4o",
+		},
+	}
+
+	hooks, bifrostErr := bf.RunStreamPreHooks(ctx, req)
+	if bifrostErr != nil {
+		t.Fatalf("RunStreamPreHooks returned unexpected error: %+v", bifrostErr)
+	}
+	if hooks == nil {
+		t.Fatal("RunStreamPreHooks returned nil hooks")
+	}
+	defer hooks.Cleanup()
+
+	// Invoke without setting the stream end indicator — this is a mid-stream chunk.
+	hooks.PostHookRunner(ctx, nil, nil)
+
+	if ids := rec.flushedIDs(); len(ids) != 0 {
+		t.Fatalf("expected no CompleteAndFlushTrace call on non-final chunk, got %v", ids)
+	}
+}


### PR DESCRIPTION
## Summary

For native WebSocket streaming, the `postHookRunner` closure returned by `RunStreamPreHooks` called `drainAndAttachPluginLogs` on the final chunk but never called `tracer.CompleteAndFlushTrace`. The logging plugin accumulates completed entries in an in-memory `pendingLogsToInject` map keyed by trace ID. That map is only drained to the store when `CompleteAndFlushTrace` runs. Every native-WS response therefore left its log entry stuck in memory and no row was written to the `logs` table.

Root cause: a single missing `CompleteAndFlushTrace` call in the happy-path branch of `RunStreamPreHooks`. All early-exit paths in the same function and the sibling `RunRealtimeTurnPreHooks` already call it correctly. The HTTP streaming path also flushes correctly.

## Changes

- `core/bifrost.go`: add `tracer.CompleteAndFlushTrace(traceID)` inside the `postHookRunner` closure when `IsFinalChunk(ctx)` is true, after `drainAndAttachPluginLogs`. Mirrors the pattern used on every other exit path in the same function.
- `core/bifrost_test.go`: add `TestRunStreamPreHooks_PostHookRunner_FlushesTracerOnFinalChunk` and `TestRunStreamPreHooks_PostHookRunner_NoFlushOnNonFinalChunk` using a recording tracer to assert the call happens exactly once on the final chunk and not on mid-stream chunks.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go build ./core/... ./transports/...
go test ./core/... -run TestRunStreamPreHooks
go vet ./core/...
```

Expected: both new tests pass, build and vet are clean.

End-to-end: start Bifrost, route a WebSocket Responses request through a mock upstream that sends a terminal `response.completed` frame, then check the `logs` table. Before this fix the row was never written. After this fix a row appears.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

Closes #2999

This bug was discovered while working on PR #2775 (OpenAI OAuth passthrough). The PR branch contains the fix that is being extracted here.

## Security considerations

None. This change only adds a missing trace flush call.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable