### PR TITLE
fix: native WebSocket /responses reliability issues

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4123,6 +4123,9 @@ func (bifrost *Bifrost) RunStreamPreHooks(ctx *schemas.BifrostContext, req *sche
 		resp, bifrostErr := pipeline.RunPostLLMHooks(ctx, result, err, preCount)
 		if IsFinalChunk(ctx) {
 			drainAndAttachPluginLogs(ctx)
+			if traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string); ok && strings.TrimSpace(traceID) != "" {
+				tracer.CompleteAndFlushTrace(strings.TrimSpace(traceID))
+			}
 		}
 		if bifrostErr != nil {
 			bifrostErr.PopulateExtraFields(req.RequestType, wsProvider, wsModel, wsModel)

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -761,6 +761,63 @@ func (ma *MockAccount) SetKeysForProvider(provider schemas.ModelProvider, keys [
 	ma.keys[provider] = keys
 }
 
+type countingTracer struct {
+	schemas.NoOpTracer
+	flushed atomic.Int32
+}
+
+func (t *countingTracer) CreateTrace(_ string, _ ...string) string {
+	return "trace-ws-final"
+}
+
+func (t *countingTracer) CompleteAndFlushTrace(_ string) {
+	t.flushed.Add(1)
+}
+
+func TestRunStreamPreHooks_FinalChunkFlushesTrace(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	account := NewMockAccount()
+	tracer := &countingTracer{}
+
+	client, err := Init(ctx, schemas.BifrostConfig{
+		Account: account,
+		Tracer:  tracer,
+		Logger:  NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Error initializing Bifrost: %v", err)
+	}
+	defer client.Shutdown()
+
+	hooks, bifrostErr := client.RunStreamPreHooks(ctx, &schemas.BifrostRequest{
+		RequestType: schemas.WebSocketResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Provider: schemas.OpenAI,
+			Model:    "gpt-4o-mini",
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("RunStreamPreHooks returned error: %v", bifrostErr)
+	}
+	defer hooks.Cleanup()
+
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+	_, bifrostErr = hooks.PostHookRunner(ctx, &schemas.BifrostResponse{
+		ResponsesResponse: &schemas.BifrostResponsesResponse{
+			Object:    "response",
+			CreatedAt: int(time.Now().Unix()),
+			Model:     "gpt-4o-mini",
+		},
+	}, nil)
+	if bifrostErr != nil {
+		t.Fatalf("PostHookRunner returned error: %v", bifrostErr)
+	}
+
+	if tracer.flushed.Load() != 1 {
+		t.Fatalf("expected trace flush count 1, got %d", tracer.flushed.Load())
+	}
+}
+
 // mockKVStore implements schemas.KVStore for session stickiness tests.
 type mockKVStore struct {
 	mu   sync.RWMutex

--- a/framework/streaming/accumulator.go
+++ b/framework/streaming/accumulator.go
@@ -397,7 +397,7 @@ func (a *Accumulator) ProcessStreamingResponse(ctx *schemas.BifrostContext, resu
 
 	isAudioStreaming := requestType == schemas.SpeechStreamRequest || requestType == schemas.TranscriptionStreamRequest
 	isChatStreaming := requestType == schemas.ChatCompletionStreamRequest || requestType == schemas.TextCompletionStreamRequest
-	isResponsesStreaming := requestType == schemas.ResponsesStreamRequest
+	isResponsesStreaming := requestType == schemas.ResponsesStreamRequest || requestType == schemas.WebSocketResponsesRequest
 	// Edit images/ Image variation requests will be added here
 	isImageStreaming := requestType == schemas.ImageGenerationStreamRequest || requestType == schemas.ImageEditStreamRequest
 

--- a/framework/streaming/accumulator_test.go
+++ b/framework/streaming/accumulator_test.go
@@ -659,3 +659,68 @@ func TestGetLastAudioAndTranscriptionChunksSafe(t *testing.T) {
 		t.Errorf("Expected transcription chunk index 3, got %d", lastTranscription.ChunkIndex)
 	}
 }
+
+func TestProcessStreamingResponseSupportsWebSocketResponsesRequest(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+	accumulator := NewAccumulator(nil, logger)
+
+	requestID := "test-ws-responses-request"
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyAccumulatorID, requestID)
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+
+	chunk := &ResponsesStreamChunk{
+		ChunkIndex: 0,
+		Timestamp:  time.Now(),
+		StreamResponse: &schemas.BifrostResponsesStreamResponse{
+			Type: "response.completed",
+			Response: &schemas.BifrostResponsesResponse{
+				Usage: &schemas.ResponsesResponseUsage{
+					InputTokens:  12,
+					OutputTokens: 7,
+					TotalTokens:  19,
+				},
+			},
+		},
+		TokenUsage: &schemas.BifrostLLMUsage{
+			PromptTokens:     12,
+			CompletionTokens: 7,
+			TotalTokens:      19,
+		},
+	}
+	if err := accumulator.addResponsesStreamChunk(requestID, chunk, true); err != nil {
+		t.Fatalf("addResponsesStreamChunk() error = %v", err)
+	}
+
+	responseID := "resp_ws_123"
+	response := &schemas.BifrostResponse{
+		ResponsesResponse: &schemas.BifrostResponsesResponse{
+			ID: &responseID,
+			Usage: &schemas.ResponsesResponseUsage{
+				InputTokens:  12,
+				OutputTokens: 7,
+				TotalTokens:  19,
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            schemas.WebSocketResponsesRequest,
+				Provider:               schemas.OpenAI,
+				OriginalModelRequested: "gpt-4o-mini",
+				ChunkIndex:             0,
+			},
+		},
+	}
+
+	processed, err := accumulator.ProcessStreamingResponse(ctx, response, nil)
+	if err != nil {
+		t.Fatalf("ProcessStreamingResponse() error = %v", err)
+	}
+	if processed == nil {
+		t.Fatal("expected processed response, got nil")
+	}
+	if processed.Data == nil || processed.Data.TokenUsage == nil {
+		t.Fatal("expected token usage to be accumulated for websocket responses")
+	}
+	if processed.Data.TokenUsage.TotalTokens != 19 {
+		t.Fatalf("expected total tokens 19, got %d", processed.Data.TokenUsage.TotalTokens)
+	}
+}

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -250,6 +250,24 @@ func TestStoreOrEnqueueRetryPreservesAllEntries(t *testing.T) {
 	}
 }
 
+func TestConvertToProcessedStreamResponseUsesResponsesStreamTypeForWebSocketResponses(t *testing.T) {
+	result := &schemas.StreamAccumulatorResult{
+		RequestID:      "req-ws-3000",
+		RequestedModel: "gpt-4o-mini",
+		ResolvedModel:  "gpt-4o-mini",
+		Provider:       schemas.OpenAI,
+		Status:         "success",
+	}
+
+	processed := convertToProcessedStreamResponse(result, schemas.WebSocketResponsesRequest)
+	if processed == nil {
+		t.Fatal("expected processed stream response, got nil")
+	}
+	if processed.StreamType != "responses" {
+		t.Fatalf("expected stream type responses, got %s", processed.StreamType)
+	}
+}
+
 func TestApplyRealtimeOutputToEntryBackfillsUserTranscriptFromRawRequest(t *testing.T) {
 	plugin := &LoggerPlugin{}
 	entry := &logstore.Log{}

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -655,7 +655,7 @@ func convertToProcessedStreamResponse(result *schemas.StreamAccumulatorResult, r
 		streamType = streaming.StreamTypeText
 	case schemas.ChatCompletionStreamRequest:
 		streamType = streaming.StreamTypeChat
-	case schemas.ResponsesStreamRequest:
+	case schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest:
 		streamType = streaming.StreamTypeResponses
 	case schemas.SpeechStreamRequest:
 		streamType = streaming.StreamTypeAudio

--- a/transports/bifrost-http/handlers/wsresponses.go
+++ b/transports/bifrost-http/handlers/wsresponses.go
@@ -2,7 +2,10 @@ package handlers
 
 import (
 	"context"
+	"errors"
+	"net"
 	"strings"
+	"time"
 
 	"github.com/bytedance/sonic"
 	"github.com/fasthttp/router"
@@ -174,7 +177,7 @@ func (h *WSResponsesHandler) handleResponseCreate(session *bfws.Session, auth *a
 	// Store override: default to store=true (Codex sends false by default but expects true).
 	// If DisableStore is set in provider config, force store=false.
 	// If client explicitly sets store, respect that value unless DisableStore overrides it.
-	provider, modelName := schemas.ParseModelString(event.Model, "")
+	provider, modelName := schemas.ParseModelString(event.Model, schemas.OpenAI)
 	if provider == "" || modelName == "" {
 		writeWSError(session, 400, "invalid_request_error", "failed to parse model string")
 		return
@@ -290,6 +293,16 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 		return true
 	}
 
+	finalizeTerminalPostHooks := func(bifrostErr *schemas.BifrostError) {
+		if bifrostErr == nil {
+			return
+		}
+		ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+		if _, postErr := hooks.PostHookRunner(ctx, nil, bifrostErr); postErr != nil {
+			logger.Warn("failed to finalize WS post-hooks for %s: %v", req.Provider, postErr)
+		}
+	}
+
 	// Forward the raw event to upstream
 	if err := upstream.WriteMessage(ws.TextMessage, rawEvent); err != nil {
 		logger.Warn("upstream WS write failed for %s: %v, falling back to HTTP bridge", req.Provider, err)
@@ -301,20 +314,45 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 	// Retrieve tracer and traceID for chunk accumulation
 	tracer, _ := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer)
 	traceID, _ := ctx.Value(schemas.BifrostContextKeyTraceID).(string)
+	streamIdleTimeout := resolveWSStreamIdleTimeout(h.config, req.Provider)
 
 	// Read response events from upstream and relay to client, running post-hooks per chunk
 	forwardedAny := false
 	for {
+		if err := upstream.SetReadDeadline(time.Now().Add(streamIdleTimeout)); err != nil {
+			// Fail closed: if we can't arm the idle timeout, don't risk hanging forever.
+			logger.Warn("failed to set upstream WS read deadline for %s: %v, treating as terminal", req.Provider, err)
+			h.pool.Discard(upstream)
+			session.SetUpstream(nil)
+			finalizeTerminalPostHooks(newBifrostError(502, "upstream_connection_error", "failed to arm upstream read deadline"))
+			writeWSError(session, 502, "upstream_connection_error", "upstream websocket connection error")
+			return true
+		}
+
 		msgType, data, readErr := upstream.ReadMessage()
 		if readErr != nil {
+			if isWSReadTimeout(readErr) {
+				logger.Warn("upstream WS idle timeout for %s after %s", req.Provider, streamIdleTimeout)
+				h.pool.Discard(upstream)
+				session.SetUpstream(nil)
+				finalizeTerminalPostHooks(newBifrostError(504, "upstream_timeout", "upstream websocket stream timed out"))
+				writeWSError(session, 504, "upstream_timeout", "upstream websocket stream timed out")
+				return true
+			}
+
 			logger.Warn("upstream WS read failed for %s: %v, falling back to HTTP bridge", req.Provider, readErr)
 			h.pool.Discard(upstream)
 			session.SetUpstream(nil)
 			if !forwardedAny {
 				return false
 			}
+			finalizeTerminalPostHooks(newBifrostError(502, "upstream_connection_error", "upstream websocket stream interrupted"))
 			writeWSError(session, 502, "upstream_connection_error", "upstream websocket stream interrupted")
 			return true
+		}
+
+		if err := upstream.SetReadDeadline(time.Time{}); err != nil {
+			logger.Warn("failed to clear upstream WS read deadline for %s: %v", req.Provider, err)
 		}
 
 		streamResp := parseUpstreamWSEvent(data, req.Provider, req.Model)
@@ -343,6 +381,12 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 		if writeErr := session.WriteMessage(msgType, data); writeErr != nil {
 			h.pool.Discard(upstream)
 			session.SetUpstream(nil)
+			// Only finalize post-hooks if they haven't already run for this chunk.
+			// When isTerminal && streamResp != nil, PostHookRunner already ran above (line 366),
+			// so calling finalizeTerminalPostHooks again would double-fire the end-of-stream signal.
+			if streamResp == nil || !isTerminal {
+				finalizeTerminalPostHooks(newBifrostError(499, "client_connection_error", "client websocket connection interrupted"))
+			}
 			return true
 		}
 		forwardedAny = true
@@ -351,6 +395,38 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 			h.trackResponseID(session, data)
 			return true
 		}
+	}
+}
+
+func resolveWSStreamIdleTimeout(config *lib.Config, provider schemas.ModelProvider) time.Duration {
+	idleTimeoutSeconds := schemas.DefaultStreamIdleTimeoutInSeconds
+	if config != nil {
+		if providerCfg, err := config.GetProviderConfigRaw(provider); err == nil && providerCfg != nil &&
+			providerCfg.NetworkConfig != nil && providerCfg.NetworkConfig.StreamIdleTimeoutInSeconds > 0 {
+			idleTimeoutSeconds = providerCfg.NetworkConfig.StreamIdleTimeoutInSeconds
+		}
+	}
+	if idleTimeoutSeconds <= 0 {
+		idleTimeoutSeconds = schemas.DefaultStreamIdleTimeoutInSeconds
+	}
+	return time.Duration(idleTimeoutSeconds) * time.Second
+}
+
+func isWSReadTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+func newBifrostError(statusCode int, errType, message string) *schemas.BifrostError {
+	return &schemas.BifrostError{
+		StatusCode: schemas.Ptr(statusCode),
+		Error: &schemas.ErrorField{
+			Type:    schemas.Ptr(errType),
+			Message: message,
+		},
 	}
 }
 
@@ -419,7 +495,7 @@ func (h *WSResponsesHandler) trackResponseID(session *bfws.Session, data []byte)
 
 // convertEventToRequest converts a WebSocket response.create event to a BifrostResponsesRequest.
 func (h *WSResponsesHandler) convertEventToRequest(event *schemas.WebSocketResponsesEvent) (*schemas.BifrostResponsesRequest, error) {
-	provider, modelName := schemas.ParseModelString(event.Model, "")
+	provider, modelName := schemas.ParseModelString(event.Model, schemas.OpenAI)
 	if provider == "" || modelName == "" {
 		return nil, errModelFormat
 	}

--- a/transports/bifrost-http/handlers/wsresponses_test.go
+++ b/transports/bifrost-http/handlers/wsresponses_test.go
@@ -1,12 +1,17 @@
 package handlers
 
 import (
+	"errors"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/stretchr/testify/assert"
 )
 
 type testWSHandlerStore struct {
@@ -43,6 +48,56 @@ func (s testWSHandlerStore) GetKVStore() *kvstore.Store {
 
 func (s testWSHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList {
 	return nil
+}
+
+type timeoutNetError struct{}
+
+func (timeoutNetError) Error() string   { return "i/o timeout" }
+func (timeoutNetError) Timeout() bool   { return true }
+func (timeoutNetError) Temporary() bool { return false }
+
+func TestResolveWSStreamIdleTimeoutUsesProviderOverride(t *testing.T) {
+	cfg := &lib.Config{
+		Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+			schemas.OpenAI: {
+				NetworkConfig: &schemas.NetworkConfig{StreamIdleTimeoutInSeconds: 7},
+			},
+		},
+	}
+
+	timeout := resolveWSStreamIdleTimeout(cfg, schemas.OpenAI)
+	assert.Equal(t, 7*time.Second, timeout)
+}
+
+func TestResolveWSStreamIdleTimeoutFallsBackToDefault(t *testing.T) {
+	timeout := resolveWSStreamIdleTimeout(&lib.Config{}, schemas.OpenAI)
+	assert.Equal(t, time.Duration(schemas.DefaultStreamIdleTimeoutInSeconds)*time.Second, timeout)
+}
+
+func TestIsWSReadTimeout(t *testing.T) {
+	assert.True(t, isWSReadTimeout(timeoutNetError{}))
+	assert.False(t, isWSReadTimeout(net.UnknownNetworkError("unknown")))
+	assert.False(t, isWSReadTimeout(errors.New("boom")))
+	assert.False(t, isWSReadTimeout(nil))
+}
+
+func TestNewBifrostError(t *testing.T) {
+	bifrostErr := newBifrostError(504, "upstream_timeout", "upstream websocket stream timed out")
+	if bifrostErr == nil {
+		t.Fatal("expected bifrost error, got nil")
+	}
+	if bifrostErr.StatusCode == nil || *bifrostErr.StatusCode != 504 {
+		t.Fatalf("status code = %#v, want 504", bifrostErr.StatusCode)
+	}
+	if bifrostErr.Error == nil {
+		t.Fatal("expected error field, got nil")
+	}
+	if bifrostErr.Error.Type == nil || *bifrostErr.Error.Type != "upstream_timeout" {
+		t.Fatalf("error type = %#v, want upstream_timeout", bifrostErr.Error.Type)
+	}
+	if bifrostErr.Error.Message != "upstream websocket stream timed out" {
+		t.Fatalf("error message = %q, want upstream websocket stream timed out", bifrostErr.Error.Message)
+	}
 }
 
 func TestCreateBifrostContextFromAuth_BaggageSessionIDSetsGrouping(t *testing.T) {

--- a/transports/bifrost-http/websocket/connection.go
+++ b/transports/bifrost-http/websocket/connection.go
@@ -4,6 +4,8 @@
 package websocket
 
 import (
+	"errors"
+	"net"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -26,7 +28,8 @@ type UpstreamConn struct {
 	writeMu sync.Mutex
 	readMu  sync.Mutex
 
-	closed atomic.Bool
+	closed     atomic.Bool
+	validating atomic.Bool // guards concurrent ValidateIdleHeartbeat calls
 }
 
 // newUpstreamConn creates a new UpstreamConn wrapping the given websocket connection.
@@ -43,11 +46,17 @@ func newUpstreamConn(conn *ws.Conn, provider schemas.ModelProvider, keyID, endpo
 }
 
 // WriteMessage sends a message to the upstream provider. Thread-safe.
+// Closes the connection immediately on fatal write errors so resources are
+// released deterministically rather than waiting for the caller to call Close.
 func (c *UpstreamConn) WriteMessage(messageType int, data []byte) error {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
 	c.lastUsed.Store(time.Now().UnixNano())
-	return c.conn.WriteMessage(messageType, data)
+	writeErr := c.conn.WriteMessage(messageType, data)
+	if writeErr != nil && isConnectionDead(writeErr) {
+		_ = c.Close()
+	}
+	return writeErr
 }
 
 // WriteJSON sends a JSON-encoded message to the upstream provider. Thread-safe.
@@ -59,11 +68,17 @@ func (c *UpstreamConn) WriteJSON(v interface{}) error {
 }
 
 // ReadMessage reads a message from the upstream provider. Thread-safe.
+// Closes the connection immediately on fatal read errors so resources are
+// released deterministically rather than waiting for the caller to call Close.
 func (c *UpstreamConn) ReadMessage() (messageType int, p []byte, err error) {
 	c.readMu.Lock()
 	defer c.readMu.Unlock()
 	c.lastUsed.Store(time.Now().UnixNano())
-	return c.conn.ReadMessage()
+	msgType, data, readErr := c.conn.ReadMessage()
+	if readErr != nil && isConnectionDead(readErr) {
+		_ = c.Close()
+	}
+	return msgType, data, readErr
 }
 
 // Close closes the underlying WebSocket connection.
@@ -119,12 +134,121 @@ func (c *UpstreamConn) SetPongHandler(h func(appData string) error) {
 	c.conn.SetPongHandler(h)
 }
 
-// WritePing sends a ping message to the upstream. Thread-safe.
-func (c *UpstreamConn) WritePing(data []byte) error {
+// WritePing sends a ping control frame to the upstream with an explicit deadline.
+// Uses WriteControl instead of WriteMessage so the deadline is actually enforced
+// (WriteMessage ignores SetWriteDeadline in fasthttp/websocket).
+func (c *UpstreamConn) WritePing(data []byte, deadline time.Time) error {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
 	c.lastUsed.Store(time.Now().UnixNano())
-	return c.conn.WriteMessage(ws.PingMessage, data)
+	return c.conn.WriteControl(ws.PingMessage, data, deadline)
+}
+
+// ValidateIdleHeartbeat probes an idle connection with a ping/pong round trip.
+// It returns true only when the connection stays usable for reuse.
+// The probe intentionally does NOT update lastUsed so that the pool's idle
+// timer reflects real application activity, not background health checks.
+//
+// Instead of blocking for the full timeout on healthy connections, it polls with
+// short read deadlines and returns as soon as the pong handler fires. This keeps
+// borrow-path latency low and avoids stalling the heartbeat sweep.
+func (c *UpstreamConn) ValidateIdleHeartbeat(timeout time.Duration) bool {
+	if c == nil || c.IsClosed() {
+		return false
+	}
+	// Prevent concurrent validation from heartbeat loop and borrow path.
+	if !c.validating.CompareAndSwap(false, true) {
+		return false // another goroutine is already probing this conn
+	}
+	defer c.validating.Store(false)
+
+	// Preserve the pre-probe idle timestamp so that heartbeat probes do not
+	// artificially extend the connection's idle lifetime.
+	savedLastUsed := c.lastUsed.Load()
+	defer c.lastUsed.Store(savedLastUsed)
+
+	var gotPong atomic.Bool
+	c.SetPongHandler(func(string) error {
+		gotPong.Store(true)
+		return nil
+	})
+	defer c.SetPongHandler(func(string) error { return nil })
+
+	if err := c.WritePing(nil, time.Now().Add(timeout)); err != nil {
+		_ = c.Close()
+		return false
+	}
+
+	// Poll with short read deadlines so we return as soon as the pong handler
+	// fires, rather than blocking for the full timeout on healthy connections.
+	// In fasthttp/websocket, pong frames are consumed internally by ReadMessage
+	// (the handler fires, then ReadMessage continues waiting for data frames),
+	// so we use short iterations to check gotPong between reads.
+	const pollInterval = 10 * time.Millisecond
+	deadline := time.Now().Add(timeout)
+
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		d := pollInterval
+		if remaining < d {
+			d = remaining
+		}
+
+		_ = c.SetReadDeadline(time.Now().Add(d))
+		_, _, err := c.ReadMessage()
+
+		if gotPong.Load() {
+			_ = c.SetReadDeadline(time.Time{})
+			return true
+		}
+
+		if err != nil {
+			if isHeartbeatTimeout(err) {
+				continue // poll again until total deadline
+			}
+			// Non-timeout error (close frame, EOF, etc.)
+			_ = c.Close()
+			return false
+		}
+
+		// Idle pooled connections should not have buffered application frames.
+		_ = c.Close()
+		return false
+	}
+
+	// Total timeout expired without receiving pong.
+	_ = c.Close()
+	return false
+}
+
+// isHeartbeatTimeout reports whether err is a net.Error timeout, which indicates
+// the read deadline fired before any data arrived (expected during ping/pong probes).
+func isHeartbeatTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+// isConnectionDead returns true for errors that indicate the connection is permanently broken
+// (close frames, EOF, broken pipe) so callers can mark IsClosed() early.
+func isConnectionDead(err error) bool {
+	if err == nil {
+		return false
+	}
+	if ws.IsCloseError(err, ws.CloseNormalClosure, ws.CloseGoingAway,
+		ws.CloseAbnormalClosure, ws.CloseNoStatusReceived) {
+		return true
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	msg := err.Error()
+	return msg == "EOF" || msg == "unexpected EOF"
 }
 
 // Dial creates a new WebSocket connection to the given URL with the provided headers.

--- a/transports/bifrost-http/websocket/pool.go
+++ b/transports/bifrost-http/websocket/pool.go
@@ -2,10 +2,18 @@ package websocket
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
+)
+
+const (
+	idleHeartbeatTimeout = 1 * time.Second
+	borrowProbeTimeout   = 250 * time.Millisecond
 )
 
 // PoolKey uniquely identifies a group of upstream connections.
@@ -21,6 +29,8 @@ type Pool struct {
 	mu       sync.Mutex
 	idle     map[PoolKey][]*UpstreamConn
 	inFlight int
+	probing  int                    // connections temporarily removed from idle for heartbeat validation
+	probingPerKey map[PoolKey]int   // per-key probing count for MaxIdlePerKey enforcement
 
 	config *schemas.WSPoolConfig
 
@@ -35,11 +45,13 @@ func NewPool(config *schemas.WSPoolConfig) *Pool {
 	}
 	config.CheckAndSetDefaults()
 	p := &Pool{
-		idle:   make(map[PoolKey][]*UpstreamConn),
-		config: config,
-		done:   make(chan struct{}),
+		idle:          make(map[PoolKey][]*UpstreamConn),
+		probingPerKey: make(map[PoolKey]int),
+		config:        config,
+		done:          make(chan struct{}),
 	}
 	go p.evictLoop()
+	go p.heartbeatLoop()
 	return p
 }
 
@@ -62,7 +74,7 @@ func (p *Pool) Get(key PoolKey, headers map[string]string) (*UpstreamConn, error
 
 		p.mu.Unlock()
 
-		if conn.IsClosed() || p.isExpired(conn) {
+		if conn.IsClosed() || p.isExpired(conn) || !conn.ValidateIdleHeartbeat(borrowProbeTimeout) {
 			conn.Close()
 			p.mu.Lock()
 			conns = p.idle[key]
@@ -80,7 +92,7 @@ func (p *Pool) Get(key PoolKey, headers map[string]string) (*UpstreamConn, error
 	for _, c := range p.idle {
 		totalIdle += len(c)
 	}
-	if totalIdle+p.inFlight >= p.config.MaxTotalConnections {
+	if totalIdle+p.inFlight+p.probing >= p.config.MaxTotalConnections {
 		p.mu.Unlock()
 		return nil, fmt.Errorf("pool capacity exhausted: %d idle + %d in-flight >= %d max", totalIdle, p.inFlight, p.config.MaxTotalConnections)
 	}
@@ -130,7 +142,7 @@ func (p *Pool) Return(conn *UpstreamConn) {
 	}
 
 	conns := p.idle[key]
-	if len(conns) >= p.config.MaxIdlePerKey {
+	if len(conns)+p.probingPerKey[key] >= p.config.MaxIdlePerKey {
 		conn.Close()
 		return
 	}
@@ -167,14 +179,61 @@ func (p *Pool) Close() {
 	}
 }
 
+// dial establishes a new WebSocket connection to the upstream endpoint
+// identified by key, forwarding the supplied HTTP headers during the handshake.
 func (p *Pool) dial(key PoolKey, headers map[string]string) (*UpstreamConn, error) {
-	wsConn, _, err := Dial(key.Endpoint, headers)
+	wsConn, resp, err := Dial(key.Endpoint, headers)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial upstream websocket %s: %w", key.Endpoint, err)
+		return nil, fmt.Errorf("failed to dial upstream websocket %s: %w", key.Endpoint, wrapHandshakeError(resp, err))
 	}
 	return newUpstreamConn(wsConn, key.Provider, key.KeyID, key.Endpoint), nil
 }
 
+// wrapHandshakeError enriches a dial error with the HTTP status and a body
+// snippet from the handshake response so callers get actionable diagnostics.
+func wrapHandshakeError(resp *http.Response, err error) error {
+	if resp == nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	status := strings.TrimSpace(resp.Status)
+	if status == "" {
+		status = fmt.Sprintf("status %d", resp.StatusCode)
+	}
+
+	bodySnippet := readHandshakeBodySnippet(resp.Body)
+	if bodySnippet == "" {
+		return fmt.Errorf("upstream handshake failed with %s: %w", status, err)
+	}
+	return fmt.Errorf("upstream handshake failed with %s: %s: %w", status, bodySnippet, err)
+}
+
+// readHandshakeBodySnippet reads up to 512 bytes from body and returns the
+// trimmed result. It is used to attach a short error excerpt to failed
+// WebSocket handshake diagnostics.
+func readHandshakeBodySnippet(body io.Reader) string {
+	if body == nil {
+		return ""
+	}
+
+	const maxSnippetBytes = 512
+
+	limited := io.LimitReader(body, maxSnippetBytes)
+	snippet, err := io.ReadAll(limited)
+	if err != nil {
+		return ""
+	}
+
+	trimmed := strings.TrimSpace(string(snippet))
+	if trimmed == "" {
+		return ""
+	}
+	return trimmed
+}
+
+// isExpired reports whether conn has exceeded the pool's maximum connection
+// lifetime or has been idle longer than the configured idle timeout.
 func (p *Pool) isExpired(conn *UpstreamConn) bool {
 	maxLifetime := time.Duration(p.config.MaxConnectionLifetimeSeconds) * time.Second
 	if conn.Age() >= maxLifetime {
@@ -199,6 +258,110 @@ func (p *Pool) evictLoop() {
 	}
 }
 
+// heartbeatLoop periodically probes all idle connections with ping/pong
+// round trips, removing any that fail to respond.
+func (p *Pool) heartbeatLoop() {
+	ticker := time.NewTicker(p.heartbeatInterval())
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.done:
+			return
+		case <-ticker.C:
+			p.refreshIdleConnections()
+		}
+	}
+}
+
+// heartbeatInterval returns the delay between heartbeat sweeps, derived as
+// one-third of the idle timeout and clamped to [5s, 30s].
+func (p *Pool) heartbeatInterval() time.Duration {
+	idleTimeout := time.Duration(p.config.IdleTimeoutSeconds) * time.Second
+	if idleTimeout <= 0 {
+		idleTimeout = time.Duration(schemas.DefaultWSIdleTimeoutSeconds) * time.Second
+	}
+	interval := idleTimeout / 3
+	if interval > 30*time.Second {
+		interval = 30 * time.Second
+	}
+	if interval < 5*time.Second {
+		interval = 5 * time.Second
+	}
+	return interval
+}
+
+// refreshIdleConnections atomically removes all idle connections from the pool,
+// probes each one outside the lock via ValidateIdleHeartbeat, and re-inserts
+// survivors. Connections are tracked via the probing counter while removed so
+// that capacity checks in Get and Return remain accurate.
+func (p *Pool) refreshIdleConnections() {
+	type idleConn struct {
+		key  PoolKey
+		conn *UpstreamConn
+	}
+
+	// Remove all idle connections from the pool under the lock so that a
+	// concurrent Get() cannot check out a connection that the sweeper is
+	// about to probe. This avoids probing in-flight sockets.
+	// Track them via the probing counter so capacity checks remain accurate.
+	p.mu.Lock()
+	var candidates []idleConn
+	for key, conns := range p.idle {
+		count := len(conns)
+		for _, conn := range conns {
+			candidates = append(candidates, idleConn{key: key, conn: conn})
+		}
+		p.probing += count
+		p.probingPerKey[key] += count
+		delete(p.idle, key)
+	}
+	p.mu.Unlock()
+
+	if len(candidates) == 0 {
+		return
+	}
+
+	// Probe each candidate outside the lock. Collect survivors vs dead.
+	var alive []idleConn
+	for _, candidate := range candidates {
+		conn := candidate.conn
+		if conn == nil || conn.IsClosed() || p.isExpired(conn) || !conn.ValidateIdleHeartbeat(idleHeartbeatTimeout) {
+			if conn != nil {
+				conn.Close()
+			}
+			continue
+		}
+		alive = append(alive, candidate)
+	}
+
+	// Clear the probing counters and re-insert survivors under the lock.
+	// This block must always run — even when len(alive) == 0 — otherwise
+	// the probing counters leak and permanently inflate the capacity check
+	// in Get(), eventually causing spurious "capacity exhausted" errors.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.probing -= len(candidates)
+	for _, candidate := range candidates {
+		p.probingPerKey[candidate.key]--
+		if p.probingPerKey[candidate.key] <= 0 {
+			delete(p.probingPerKey, candidate.key)
+		}
+	}
+	if p.closed || len(alive) == 0 {
+		for _, candidate := range alive {
+			candidate.conn.Close()
+		}
+		return
+	}
+	for _, candidate := range alive {
+		conns := p.idle[candidate.key]
+		p.idle[candidate.key] = append(conns, candidate.conn)
+	}
+}
+
+// evictExpired removes and closes all idle connections that have exceeded the
+// maximum lifetime or idle timeout.
 func (p *Pool) evictExpired() {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/transports/bifrost-http/websocket/pool_test.go
+++ b/transports/bifrost-http/websocket/pool_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -128,6 +129,27 @@ func TestPoolClose(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestPoolDialIncludesHandshakeDetails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("invalid websocket token"))
+	}))
+	defer server.Close()
+
+	config := &schemas.WSPoolConfig{}
+	config.CheckAndSetDefaults()
+	pool := NewPool(config)
+	defer pool.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	key := PoolKey{Provider: schemas.OpenAI, KeyID: "test-key", Endpoint: wsURL}
+
+	_, err := pool.Get(key, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401 Unauthorized")
+	assert.Contains(t, err.Error(), "invalid websocket token")
+}
+
 func TestPoolExpiredConnection(t *testing.T) {
 	server := startTestWSServer(t)
 	defer server.Close()
@@ -157,4 +179,64 @@ func TestPoolExpiredConnection(t *testing.T) {
 	require.NotNil(t, conn2)
 	assert.NotSame(t, conn, conn2)
 	pool.Discard(conn2)
+}
+
+func TestPoolGetSkipsStaleIdleConnection(t *testing.T) {
+	var connectionCount atomic.Int32
+	serverClosed := make(chan struct{})
+	upgrader := ws.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		connectionCount.Add(1)
+		current := connectionCount.Load()
+		if current == 1 {
+			_ = conn.WriteControl(ws.CloseMessage, ws.FormatCloseMessage(ws.CloseNormalClosure, "done"), time.Now().Add(time.Second))
+			_ = conn.Close()
+			close(serverClosed)
+			return
+		}
+		defer conn.Close()
+		for {
+			mt, msg, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			_ = conn.WriteMessage(mt, msg)
+		}
+	}))
+	defer server.Close()
+
+	config := &schemas.WSPoolConfig{
+		MaxIdlePerKey:                5,
+		MaxTotalConnections:          10,
+		IdleTimeoutSeconds:           300,
+		MaxConnectionLifetimeSeconds: 3600,
+	}
+	pool := NewPool(config)
+	defer pool.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	key := PoolKey{Provider: schemas.OpenAI, KeyID: "test-key", Endpoint: wsURL}
+
+	conn, err := pool.Get(key, nil)
+	require.NoError(t, err)
+	pool.Return(conn)
+
+	// Wait for the server to finish sending the close frame before the next
+	// borrow attempt so the close is in the client's TCP receive buffer.
+	select {
+	case <-serverClosed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not close the first connection in time")
+	}
+
+	freshConn, err := pool.Get(key, nil)
+	require.NoError(t, err)
+	require.NotNil(t, freshConn)
+	assert.NotSame(t, conn, freshConn)
+	assert.EqualValues(t, 2, connectionCount.Load())
+	pool.Discard(freshConn)
 }


### PR DESCRIPTION
## Summary

Fixes a cluster of native WebSocket `/responses` reliability and observability
bugs. Each fix is surgically scoped to its existing responsibility layer — no
transport redesign, no new config keys, no schema changes.

## Changes

### #2994 — Preserve upstream WS handshake diagnostics

- Pool dial helper now captures upstream HTTP status and a bounded body snippet
  on handshake failure instead of discarding them.
- File: `transports/bifrost-http/websocket/pool.go`

### #2998 — Enforce idle timeout on native WS upstream reads

- Native WS read loop now sets a per-read deadline using existing
  `StreamIdleTimeoutInSeconds` config.
- Timeout produces a clean terminal WS error (`upstream_timeout`) instead of
  hanging indefinitely.
- File: `transports/bifrost-http/handlers/wsresponses.go`

### #2999 — Flush trace on successful final WS chunk

- Happy-path WS stream post-hook now calls `CompleteAndFlushTrace`, aligning
  with existing early-exit branches.
- File: `core/bifrost.go`

### #3000 — Classify WS `/responses` logs correctly

- Logging stream-type mapper now maps `WebSocketResponsesRequest` to
  `StreamTypeResponses` instead of falling back to `StreamTypeChat`.
- File: `plugins/logging/utils.go`

### #3001 — Accept WS `/responses` in accumulator routing

- Streaming accumulator now accepts `WebSocketResponsesRequest` through the
  existing responses-stream path.
- File: `framework/streaming/accumulator.go`

### #3002 — Stale pooled WS connection detection

- Added background heartbeat loop for idle pooled WS connections
  (ping/pong-based).
- Added borrow-time validation before returning idle connections from the pool.
- Stale connections are discarded before reuse instead of being handed out dead.
- Files: `transports/bifrost-http/websocket/pool.go`,
  `transports/bifrost-http/websocket/connection.go`

### #3003 — Ensure post-hooks fire on terminal native WS exits

- Native WS handler now finalizes post-hooks on true terminal exits (timeout,
  upstream read failure after forwarding, client write failure).
- HTTP-bridge fallback paths are left unchanged to avoid premature finalization.
- File: `transports/bifrost-http/handlers/wsresponses.go`

### Additional: WS `/responses` model parsing parity

- Both model parse points in the WS handler now default to OpenAI provider,
  matching the HTTP `/responses` integration behavior.
- File: `transports/bifrost-http/handlers/wsresponses.go`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Core tests (includes trace flush regression)
go test ./core -run TestRunStreamPreHooks_FinalChunkFlushesTrace -count=1

# WebSocket transport tests (pool heartbeat, stale conn, handler)
go test ./transports/bifrost-http/websocket
go test ./transports/bifrost-http/handlers

# Streaming accumulator tests (WS responses routing)
go test ./framework/streaming

# Logging plugin tests (stream type classification)
go test ./plugins/logging
```

Manual smoke tests (require running Bifrost + valid OpenAI config):

```sh
# Happy path WS /responses
npx tsx examples/responses/websocket.ts --model=<your-model>

# Idle reuse across turns
npx tsx examples/responses/websocket_idle_reuse.ts --model=<your-model> --turns=3 --idle-ms=35000

# Abrupt client disconnect
npx tsx examples/responses/websocket_client_abort.ts --model=<your-model> --close-after-deltas=1 --abort-after-ms=5000
```

## Screenshots/Recordings

N/A — backend-only changes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #2994 Closes #2998 Closes #2999 Closes #3000 Closes #3001 Closes #3002
Closes #3003

## Security considerations

None. No auth, secrets, PII, or sandboxing changes.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
