### PR TITLE
fix(logging): handle WebSocketResponsesRequest in convertToProcessedStreamResponse

### DIFF
--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -655,7 +655,7 @@ func convertToProcessedStreamResponse(result *schemas.StreamAccumulatorResult, r
 		streamType = streaming.StreamTypeText
 	case schemas.ChatCompletionStreamRequest:
 		streamType = streaming.StreamTypeChat
-	case schemas.ResponsesStreamRequest:
+	case schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest:
 		streamType = streaming.StreamTypeResponses
 	case schemas.SpeechStreamRequest:
 		streamType = streaming.StreamTypeAudio

--- a/plugins/logging/utils_test.go
+++ b/plugins/logging/utils_test.go
@@ -1,0 +1,95 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/streaming"
+)
+
+// TestConvertToProcessedStreamResponseWebSocketResponsesRequest verifies that
+// WebSocketResponsesRequest routes to StreamTypeResponses, not StreamTypeChat.
+func TestConvertToProcessedStreamResponseWebSocketResponsesRequest(t *testing.T) {
+	result := &schemas.StreamAccumulatorResult{
+		RequestID:      "req-ws-001",
+		RequestedModel: "gpt-4o",
+		Provider:       schemas.OpenAI,
+		Status:         "success",
+	}
+
+	got := convertToProcessedStreamResponse(result, schemas.WebSocketResponsesRequest)
+
+	if got == nil {
+		t.Fatal("expected non-nil ProcessedStreamResponse")
+	}
+	if got.StreamType != streaming.StreamTypeResponses {
+		t.Errorf("StreamType = %q, want %q", got.StreamType, streaming.StreamTypeResponses)
+	}
+}
+
+// TestConvertToProcessedStreamResponseResponsesStreamRequest verifies the existing
+// ResponsesStreamRequest case still routes to StreamTypeResponses (regression guard).
+func TestConvertToProcessedStreamResponseResponsesStreamRequest(t *testing.T) {
+	result := &schemas.StreamAccumulatorResult{
+		RequestID:      "req-resp-001",
+		RequestedModel: "gpt-4o",
+		Provider:       schemas.OpenAI,
+		Status:         "success",
+	}
+
+	got := convertToProcessedStreamResponse(result, schemas.ResponsesStreamRequest)
+
+	if got == nil {
+		t.Fatal("expected non-nil ProcessedStreamResponse")
+	}
+	if got.StreamType != streaming.StreamTypeResponses {
+		t.Errorf("StreamType = %q, want %q", got.StreamType, streaming.StreamTypeResponses)
+	}
+}
+
+// TestConvertToProcessedStreamResponseWebSocketMatchesResponsesStream verifies that
+// WebSocketResponsesRequest and ResponsesStreamRequest produce equivalent StreamType values.
+func TestConvertToProcessedStreamResponseWebSocketMatchesResponsesStream(t *testing.T) {
+	result := &schemas.StreamAccumulatorResult{
+		RequestID:      "req-compare-001",
+		RequestedModel: "gpt-4o",
+		Provider:       schemas.OpenAI,
+		Status:         "success",
+	}
+
+	wsResp := convertToProcessedStreamResponse(result, schemas.WebSocketResponsesRequest)
+	httpResp := convertToProcessedStreamResponse(result, schemas.ResponsesStreamRequest)
+
+	if wsResp == nil || httpResp == nil {
+		t.Fatal("expected non-nil responses for both request types")
+	}
+	if wsResp.StreamType != httpResp.StreamType {
+		t.Errorf("StreamType mismatch: WebSocketResponsesRequest=%q, ResponsesStreamRequest=%q",
+			wsResp.StreamType, httpResp.StreamType)
+	}
+}
+
+// TestConvertToProcessedStreamResponseNilResult verifies nil input returns nil output.
+func TestConvertToProcessedStreamResponseNilResult(t *testing.T) {
+	got := convertToProcessedStreamResponse(nil, schemas.WebSocketResponsesRequest)
+	if got != nil {
+		t.Errorf("expected nil for nil input, got %v", got)
+	}
+}
+
+// TestConvertToProcessedStreamResponseDefaultFallback verifies unknown request types
+// still route to StreamTypeChat (existing behaviour).
+func TestConvertToProcessedStreamResponseDefaultFallback(t *testing.T) {
+	result := &schemas.StreamAccumulatorResult{
+		RequestID: "req-unknown-001",
+	}
+
+	got := convertToProcessedStreamResponse(result, schemas.RequestType("unknown_type"))
+
+	if got == nil {
+		t.Fatal("expected non-nil ProcessedStreamResponse")
+	}
+	if got.StreamType != streaming.StreamTypeChat {
+		t.Errorf("StreamType = %q, want %q (default fallback)", got.StreamType, streaming.StreamTypeChat)
+	}
+}


### PR DESCRIPTION
## Summary

`convertToProcessedStreamResponse` in `plugins/logging/utils.go` has a switch on `requestType` that covers six request types but is missing a case for `schemas.WebSocketResponsesRequest`. Requests routed through the native-WS Responses path fall through to `default` and get stored under `streaming.StreamTypeChat` instead of `streaming.StreamTypeResponses`. This mis-labels the accumulated chunk data in the log store, causing downstream consumers that branch on stream type to receive incorrectly shaped content for WebSocket Responses streams.

Root cause: `schemas.WebSocketResponsesRequest` was added after the switch was written and the case was never added.

## Changes

- `plugins/logging/utils.go`: extend the `ResponsesStreamRequest` case to also match `schemas.WebSocketResponsesRequest`, routing it to `streaming.StreamTypeResponses`.
- `plugins/logging/utils_test.go`: add five unit tests covering the new case, a regression guard for the existing `ResponsesStreamRequest` arm, a parity assertion between both types, nil-input safety, and the default fallback.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Plugins

## How to test

```sh
go build ./plugins/logging/...
go test ./plugins/logging/... -cover -run TestConvertToProcessed
go vet ./plugins/logging/...
```

Expected: all five `TestConvertToProcessed*` tests pass. `WebSocketResponsesRequest` and `ResponsesStreamRequest` both resolve to `streaming.StreamTypeResponses`.

Runtime validation requires #2997 and #2999 to land first (those PRs restore the WS log row write path on main). Once they are in, the steps from the issue reproduce the correct `stream_type = responses` in the stored row.

## Screenshots/Recordings

N/A (logging internals, no UI change)

## Breaking changes

- [x] No

## Related issues

Closes #3000

Related: #2997 and #2999 are prerequisites for runtime observation of this defect (they restore the WS log row write path on main). This bug was discovered while working on PR #2775 in thiscantbeserious/bifrost. That branch contains the fix extracted here as a side effect of the feature work.

## Security considerations

None. This change only affects how an existing log accumulation result is categorised by stream type.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable