### PR TITLE
chore: bump bifrost Helm chart version to 2.1.7

### DIFF
--- a/.github/workflows/scripts/validate-helm-config-fields.sh
+++ b/.github/workflows/scripts/validate-helm-config-fields.sh
@@ -329,8 +329,8 @@ assert_field_value 'providers.openai.network_config.base_url' '.providers.openai
 assert_field 'providers.openai.network_config.extra_headers' '.providers.openai.network_config.extra_headers'
 assert_field_value 'providers.openai.network_config.default_request_timeout_in_seconds' '.providers.openai.network_config.default_request_timeout_in_seconds' '120'
 assert_field_value 'providers.openai.network_config.max_retries' '.providers.openai.network_config.max_retries' '5'
-assert_field_value 'providers.openai.network_config.retry_backoff_initial_ms' '.providers.openai.network_config.retry_backoff_initial_ms' '200'
-assert_field_value 'providers.openai.network_config.retry_backoff_max_ms' '.providers.openai.network_config.retry_backoff_max_ms' '10000'
+assert_field_value 'providers.openai.network_config.retry_backoff_initial' '.providers.openai.network_config.retry_backoff_initial' '200'
+assert_field_value 'providers.openai.network_config.retry_backoff_max' '.providers.openai.network_config.retry_backoff_max' '10000'
 
 # Concurrency config
 assert_field_value 'providers.openai.concurrency_and_buffer_size.concurrency' '.providers.openai.concurrency_and_buffer_size.concurrency' '50'

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.6
+version: 2.1.7
 appVersion: "1.5.0-prerelease4"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,19 +4,43 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.6
+**Latest Version:** 2.1.7
 
 ## Changelog
 
+### 2.1.7
+
+- Added semantic cache Helm layers and examples:
+  - Added Redis deployment template for semantic cache.
+  - Extended Helm values/schema coverage for semantic cache and client-config examples.
+- Added enterprise/governance Helm support:
+  - Added governance `business_units` support in Helm schema/template rendering.
+  - Added deferred virtual-key/provider-config budget ordering handling in Helm rendering.
+- Added MCP tool-groups support in Helm:
+  - Added `mcp.tool_groups` config support with governance bindings.
+  - Added camelCase alias compatibility for related Helm config fields.
+
 ### 2.1.6
 
+- Includes unreleased `2.1.5` changes 
+- Built-in plugin versioning for DB-backed deployments:
+  - Added `version` field support for built-in plugins.
+  - Added default `version: 1` for built-in plugins in `values.yaml` (`telemetry`, `logging`, `governance`, `maxim`, `semanticCache`, `otel`, `datadog`).
+  - Updated `_helpers.tpl` to include plugin `version` in rendered config when set (cast as integer).
 - Updated StatefulSet PVC template labels to be immutable-safe:
   - `spec.volumeClaimTemplates.metadata.labels` now uses stable selector labels (without chart/app version labels).
-- CI / rendered `config.json` checks (`validate-helm-config-fields.sh`):
-  - No longer expect `governance.virtual_keys[].budget_id` in rendered config (not in `config.schema.json`; `governance.budgets[].virtual_key_id` is the supported way to attach a budget to a virtual key).
-  - Fixture and assertions were updated to include a sample `governance.budgets` entry with `virtual_key_id` for coverage.
-  - Tightened `query` validation in `values.schema.json` and `config.schema.json`: `query` now accepts only `null` or an object with `{ combinator, rules }`; invalid user-provided query shapes may now fail Helm/config validation and should be migrated to the new structure.
-- Note: Bifrost HTTP also syncs `governance.model_configs` and `governance.providers` from file into the config store when using DB-backed config, with hash-based reconciliation.
+- Governance schema and validation updates:
+  - Added `governance.budgets[].virtual_key_id` support.
+  - Removed stale `budget_id` references from virtual keys and provider configs in templates/tests.
+  - `validate-helm-config-fields.sh` assertions were updated accordingly.
+- Query/schema compatibility updates:
+  - Tightened `query` validation in `values.schema.json` and `config.schema.json` to valid RuleGroupType shape (`null` or `{ combinator, rules }`).
+- Config/input alias support updates:
+  - Added support for `env.*` references in proxy/TLS fields (`ca_cert_pem`, `url`, `username`, `password`).
+  - Added `provider_key_name` alias for routing targets and pricing overrides (resolved to `key_id` at config load time).
+- MCP config improvements:
+  - Added Go duration string support for `mcp.toolSyncInterval` (legacy numeric nanoseconds still supported).
+  - Added hash-based MCP client config reconciliation for DB-backed config store updates.
 - Upgrade impact:
   - Existing SQLite StatefulSets created from older chart templates may require a one-time StatefulSet recreation during upgrade because `spec.volumeClaimTemplates` is immutable in Kubernetes.
 - Migration notes (only if upgrade fails with StatefulSet immutable-field error):
@@ -30,15 +54,9 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
      - `kubectl get pvc -n <namespace>`
      - `kubectl get pods -n <namespace>`
 
-### 2.1.5
+### 2.1.5 (not released separately)
 
-- Added `version` field support for built-in plugins in DB-backed Helm deployments.
-- Added default `version: 1` for built-in plugins in `values.yaml`:
-  - `telemetry`, `logging`, `governance`, `maxim`, `semanticCache`, `otel`, `datadog`
-- Updated `_helpers.tpl` to include plugin `version` in rendered config when set, cast as integer.
-- Updated Helm/deployment docs:
-  - Removed hardcoded chart version text and linked to Artifact Hub.
-  - Added plugin `version` examples and guidance that incrementing `version` forces DB-backed plugin config overwrite on upgrade.
+- Merged into `2.1.6` release notes above.
 
 ### 2.1.4
 

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,48 @@ entries:
   bifrost:
     - apiVersion: v2
       appVersion: 1.5.0-prerelease4
+      created: "2026-04-24T15:00:00.000000+00:00"
+      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+      digest: ""
+      home: https://www.getmaxim.ai/bifrost
+      icon: https://www.getbifrost.ai/favicon.png
+      keywords:
+        - ai
+        - gateway
+        - llm
+      maintainers:
+        - email: support@getmaxim.ai
+          name: Bifrost Team
+      name: bifrost
+      sources:
+        - https://github.com/maximhq/bifrost
+      type: application
+      urls:
+        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.7.tgz
+      version: 2.1.7
+    - apiVersion: v2
+      appVersion: 1.5.0-prerelease4
+      created: "2026-04-24T12:00:00.000000+00:00"
+      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+      digest: ""
+      home: https://www.getmaxim.ai/bifrost
+      icon: https://www.getbifrost.ai/favicon.png
+      keywords:
+        - ai
+        - gateway
+        - llm
+      maintainers:
+        - email: support@getbifrost.ai
+          name: Bifrost Team
+      name: bifrost
+      sources:
+        - https://github.com/maximhq/bifrost
+      type: application
+      urls:
+        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.6.tgz
+      version: 2.1.6
+    - apiVersion: v2
+      appVersion: 1.5.0-prerelease4
       created: "2026-04-21T12:00:00.000000+00:00"
       description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
       digest: ""
@@ -670,4 +712,4 @@ entries:
       urls:
         - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
       version: 1.3.36
-generated: "2026-04-13T12:00:00.000000+00:00"
+generated: "2026-04-24T15:00:00.000000+00:00"


### PR DESCRIPTION
## Summary

Bumps the Bifrost Helm chart version from `2.1.6` to `2.1.7`.

## Changes

- Incremented the Helm chart version to `2.1.7` to reflect the latest packaging iteration while keeping the `appVersion` at `1.5.0-prerelease4`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
helm lint helm-charts/bifrost
helm template helm-charts/bifrost
```

Verify the chart version reported is `2.1.7`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable