### PR TITLE
enterprise config field skiplist

### DIFF
--- a/.github/workflows/scripts/schemasync/main.go
+++ b/.github/workflows/scripts/schemasync/main.go
@@ -65,11 +65,31 @@ var ignoreSchemaProps = map[string]string{
 	"/properties/logs_store/properties/object_storage/properties/region":     "not a secret; env.X + envFrom pattern",
 	"/properties/logs_store/properties/object_storage/properties/endpoint":   "not a secret; env.X + envFrom pattern",
 	"/properties/logs_store/properties/object_storage/properties/project_id": "not a secret; env.X + envFrom pattern",
+	// Enterprise-only top-level fields: schema documents them for enterprise
+	// deployments; OSS ConfigData struct does not carry these fields.
+	"/properties/access_profiles":            "enterprise-only; defined in bifrost-enterprise/lib/config.go",
+	"/properties/audit_logs":                 "enterprise-only; defined in bifrost-enterprise/lib/config.go",
+	"/properties/cluster_config":             "enterprise-only; defined in bifrost-enterprise/lib/config.go",
+	"/properties/guardrails_config":          "enterprise-only; defined in bifrost-enterprise/lib/config.go",
+	"/properties/large_payload_optimization": "enterprise-only; defined in bifrost-enterprise/lib/config.go",
+	"/properties/load_balancer_config":       "enterprise-only; defined in bifrost-enterprise/lib/config.go",
+	"/properties/scim_config":                "enterprise-only; defined in bifrost-enterprise/lib/config.go",
+	// Enterprise governance extensions not yet in OSS structs.
+	"/properties/governance/properties/business_units":                          "enterprise-only; business unit governance",
+	"/properties/governance/properties/teams/items/properties/business_unit_id": "enterprise-only; team→business unit association",
+	// Stale schema field: TableTeam uses a budgets[] relationship (team_id FK on
+	// TableBudget), never a singular budget_id foreign key.
+	"/properties/governance/properties/teams/items/properties/budget_id": "stale; teams use budgets[] relation not budget_id",
+	// MCP tool groups are an enterprise governance feature; OSS MCPConfig has no tool_groups field.
+	"/properties/mcp/properties/tool_groups": "enterprise-only; MCP tool group governance",
 }
 
 // ignoreGoFields keys are "schemaPath|fieldName"; value is the reason.
 var ignoreGoFields = map[string]string{
 	"|auth_config": "deprecated; moved to governance.auth_config",
+	// provider_key_id is the internal DB column resolved from provider_key_name at config load time;
+	// schema documents only the human-readable provider_key_name alias.
+	"/properties/governance/properties/pricing_overrides/items|provider_key_id": "internal DB column; config uses provider_key_name alias instead",
 }
 
 // ignoreGoFieldNames are field names (regardless of parent path) that are


### PR DESCRIPTION
## Summary

Extends the schema sync script's ignore lists to account for enterprise-only configuration fields and internal DB columns that exist in the JSON schema but have no corresponding representation in the OSS Go structs.

## Changes

- Added enterprise-only top-level schema paths to `ignoreSchemaProps` (`access_profiles`, `audit_logs`, `cluster_config`, `guardrails_config`, `large_payload_optimization`, `load_balancer_config`, `scim_config`) so the sync tool does not flag them as mismatches against the OSS `ConfigData` struct.
- Added enterprise governance extension paths (`governance.business_units`, `governance.teams[].business_unit_id`) and a stale schema field (`governance.teams[].budget_id`) to `ignoreSchemaProps` with explanatory reasons.
- Added `mcp.tool_groups` to `ignoreSchemaProps` as an enterprise-only MCP governance feature absent from the OSS `MCPConfig` struct.
- Added `governance.pricing_overrides[].provider_key_id` to `ignoreGoFields` because it is an internal DB column resolved at config load time; the schema and user-facing config use the `provider_key_name` alias instead.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the schema sync script and confirm it no longer reports false-positive mismatches for the newly ignored paths.

```sh
go run ./.github/workflows/scripts/schemasync/main.go
```

Expected outcome: no diff errors related to the enterprise-only or internal fields listed above.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. These changes only affect the CI schema validation tooling and do not alter runtime behaviour, secrets handling, or access control.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable