### PR TITLE
fixed index stream length for indexing

### DIFF
--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -2084,17 +2084,18 @@ var performanceIndexes = []performanceIndexDef{
 	{
 		table: "logs",
 		name:  "idx_logs_content_summary_fts",
-		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_content_summary_fts ON logs USING GIN (to_tsvector('simple', content_summary)) WHERE content_summary IS NOT NULL",
+		// left() caps input characters to stay within to_tsvector's 1MB output limit.
+		sql: "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_content_summary_fts ON logs USING GIN (to_tsvector('simple', left(content_summary, 800000))) WHERE content_summary IS NOT NULL",
 	},
 	{
 		table: "mcp_tool_logs",
 		name:  "idx_mcp_logs_arguments_fts",
-		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_arguments_fts ON mcp_tool_logs USING GIN (to_tsvector('simple', arguments)) WHERE arguments IS NOT NULL",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_arguments_fts ON mcp_tool_logs USING GIN (to_tsvector('simple', left(arguments, 800000))) WHERE arguments IS NOT NULL",
 	},
 	{
 		table: "mcp_tool_logs",
 		name:  "idx_mcp_logs_result_fts",
-		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_result_fts ON mcp_tool_logs USING GIN (to_tsvector('simple', result)) WHERE result IS NOT NULL",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_result_fts ON mcp_tool_logs USING GIN (to_tsvector('simple', left(result, 800000))) WHERE result IS NOT NULL",
 	},
 	{
 		table: "logs",

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2978,7 +2978,8 @@
         }
       },
       "required":[
-        "name"
+        "name",
+        "weight"
       ],
       "oneOf": [
         {


### PR DESCRIPTION
## Summary

GIN full-text search indexes on large text columns were failing because `to_tsvector` has a 1MB output limit. Passing unbounded column values could exceed this limit and cause index creation to error. This PR caps input to `to_tsvector` using `left(..., 800000)` to stay safely within that limit.

Additionally, `weight` is now enforced as a required field in the Helm chart values schema for the relevant object type.

## Changes

- Wrapped `content_summary`, `arguments`, and `result` columns in `left(..., 800000)` within their respective `to_tsvector` GIN index definitions to prevent exceeding PostgreSQL's 1MB tsvector output limit.
- Added `weight` to the `required` array in `helm-charts/bifrost/values.schema.json` to enforce its presence alongside `name`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Verify that the performance indexes are created successfully on a database containing rows with large `content_summary`, `arguments`, or `result` values (e.g., values exceeding 1MB in character length). Index creation should complete without a `string is too long for tsvector` error.

```sh
go test ./framework/logstore/...
```

For the Helm schema change, validate a values file that omits `weight` is rejected by schema validation, and one that includes both `name` and `weight` passes.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. The `left()` truncation only affects indexing behavior and does not alter stored data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable