### PR TITLE
fix: fixed shell declaration on nonFHS systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ NC=\033[0m # No Color
 ECHO := printf '%b\n'
 
 # nvm requires bash-compatible shell semantics; /bin/sh is dash on some Linux distros.
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # Ensures the Node version pinned in .nvmrc is active before any npm/node call.
 # nvm is a shell function, so each recipe that needs it must inline this snippet


### PR DESCRIPTION
## Summary

Currently, the bash call to the Makefile is broken if it is not in /bin (like NixOS).  It would be better to get it via env.

## Changes

Now bash is taken from env

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```
nix develop
make <any command>
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues
Closes #3034

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


