### PR TITLE
fix: Dockerfile.local now uses local packages

### DIFF
--- a/transports/Dockerfile.local
+++ b/transports/Dockerfile.local
@@ -48,9 +48,6 @@
     go work use ./plugins/telemetry && \
     go work use ./transports
 
-  # Download external (non-local) dependencies
-  RUN cd /build/transports && go mod download
-
   # Copy UI build output into transports
   COPY --from=ui-builder /app/out ./transports/bifrost-http/ui
 


### PR DESCRIPTION
## Summary

Currently Dockerfile.local still downloads external dependencies.  The deleted line is simply not needed.  Dependencies are downloaded without this command

## Changes

Drop `go mod download`, because it downloads external dependencies instead of local ones

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
make docker-image LOCAL=1
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #3035

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


