### PR TITLE
fix(gemini): follow redirects when downloading video from Gemini File…

### DIFF
--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -2390,6 +2390,48 @@ func (provider *GeminiProvider) VideoDownload(ctx *schemas.BifrostContext, key s
 		if bifrostErr != nil {
 			return nil, bifrostErr
 		}
+		// Follow redirects (Google Gemini Files API returns 302 for video downloads)
+		maxRedirects := 5
+		for i := 0; i < maxRedirects && (resp.StatusCode() == fasthttp.StatusFound || resp.StatusCode() == fasthttp.StatusMovedPermanently || resp.StatusCode() == fasthttp.StatusTemporaryRedirect || resp.StatusCode() == fasthttp.StatusPermanentRedirect); i++ {
+			redirectURL := string(resp.Header.Peek("Location"))
+			if redirectURL == "" {
+				break
+			}
+
+			// Validate redirect host to prevent API key leakage to untrusted domains
+			parsedURL, parseErr := url.Parse(redirectURL)
+			if parseErr != nil || (parsedURL.Host != "" && !strings.HasSuffix(parsedURL.Host, ".googleapis.com") && !strings.HasSuffix(parsedURL.Host, ".google.com")) {
+				provider.logger.Error(fmt.Sprintf("refusing to follow redirect to untrusted host: %s", parsedURL.Host))
+				return nil, providerUtils.NewBifrostOperationError(
+					fmt.Sprintf("video download redirect to untrusted host: %s", parsedURL.Host),
+					nil,
+				)
+			}
+
+			// Log redirect without exposing query params (may contain signed tokens)
+			provider.logger.Info(fmt.Sprintf("following video download redirect %d to host: %s, path: %s", i+1, parsedURL.Host, parsedURL.Path))
+
+			// Drain previous wait before issuing next request
+			if wait != nil {
+				wait()
+			}
+
+			req.SetRequestURI(redirectURL)
+			req.Header.SetMethod(http.MethodGet)
+			// Re-attach API key header for redirected request (only to trusted Google hosts)
+			if key.Value.GetValue() != "" {
+				req.Header.Set("x-goog-api-key", key.Value.GetValue())
+			}
+			resp.Reset()
+			latency, bifrostErr, wait = providerUtils.MakeRequestWithContext(ctx, provider.client, req, resp)
+			if bifrostErr != nil {
+				if wait != nil {
+					wait()
+				}
+				return nil, bifrostErr
+			}
+		}
+		defer wait()
 		if resp.StatusCode() != fasthttp.StatusOK {
 			// log full error
 			provider.logger.Error("failed to download video: " + string(resp.Body()))


### PR DESCRIPTION
…s API

Google Gemini Files API returns HTTP 302 redirect when downloading video files. The download URL redirects from /v1beta/files/{id}:download to /download/v1beta/files/{id}:download.

The current VideoDownload() code makes a single request and treats any non-200 status as an error, causing 'failed to download video: HTTP 302'.

This fix adds a redirect-following loop (max 5 redirects) that:
1. Detects 301/302/307/308 status codes
2. Extracts the Location header
3. Re-attaches the x-goog-api-key header (required for auth on redirected URL)
4. Makes a new request to the redirect URL

Tested with veo-3.1-generate-preview aTested with veo-3.nerate-preview models.

## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


