### PR TITLE
fix(telemetry): show last attempted key labels for failed requests

### DIFF
--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -402,6 +402,11 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	numberOfRetries := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyNumberOfRetries)
 	fallbackIndex := bifrost.GetIntFromContext(ctx, schemas.BifrostContextKeyFallbackIndex)
 	attemptTrail, _ := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord)
+	if selectedKeyID == "" && len(attemptTrail) > 0 {
+		last := attemptTrail[len(attemptTrail)-1]
+		selectedKeyID = last.KeyID
+		selectedKeyName = last.KeyName
+	}
 	// Get routing engines array and join into comma-separated string
 	routingEngines := []string{}
 	if engines, ok := ctx.Value(schemas.BifrostContextKeyRoutingEnginesUsed).([]string); ok {


### PR DESCRIPTION
## Summary

When an LLM request fails, `core/bifrost.go` intentionally clears `BifrostContextKeySelectedKeyID/Name` so `selected_key` only reflects a key that served a successful response. As a side effect, the telemetry plugin recorded empty strings for `selected_key_id`/`selected_key_name` labels on failed requests, making it impossible to attribute failures to specific keys in metrics dashboards.
## Changes
- In `plugins/telemetry/main.go`: when `selectedKeyID` is empty, fall back to the last entry in `attemptTrail` to recover key ID and name before recording metrics labels.
- Design note: `attemptTrail` is the authoritative record of attempted keys per `core/bifrost.go`. The last entry represents the key associated with the final (failed) attempt. Metric labels for failed requests will now show this key rather than an empty string.
## Type of change
- [x] Bug fix
## Affected areas
- [x] Plugins
## How to test
1. Configure a provider with an invalid/expired key.
2. Send a request through Bifrost — it should fail.
3. Check Prometheus metrics (e.g. `bifrost_requests_total`) — verify `selected_key_id` and `selected_key_name` labels are populated for the failed request.
```sh
cd plugins/telemetry
go test ./...
```
Breaking changes
- [x] No

### Related issues

Related to #3040 (same root cause, telemetry counterpart of the logging fix).

### Security considerations

None. Key ID and name are already stored in attemptTrail; this change only reads from it.

### Checklist
- [x] I read docs/contributing/README.md and followed the guidelines
- [x] I verified builds succeed (Go and UI)