### PR TITLE
fix(plugins/logging): correctly record error status for failed streaming requests

### DIFF
--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -854,6 +854,9 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			entry.Stream = true
 			p.applyStreamingOutputToEntry(entry, streamResponse, shouldStoreRaw)
 		}
+		if entry.ErrorDetails != "" || entry.ErrorDetailsParsed != nil {
+			entry.Status = "error"
+		}
 		// Backfill passthrough status_code from response (streaming path)
 		if result != nil && result.PassthroughResponse != nil {
 			if params, ok := entry.ParamsParsed.(*schemas.PassthroughLogParams); ok {

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -351,10 +351,6 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 		entry.Latency = &latF
 	}
 
-	entry.Status = "success"
-	latF := float64(streamResponse.Data.Latency)
-	entry.Latency = &latF
-
 	// Update model and alias from resolved/requested model pair.
 	applyModelAlias(entry, streamResponse.RequestedModel, streamResponse.ResolvedModel)
 
@@ -399,9 +395,14 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 		if shouldStoreRaw {
 			// Raw request
 			if streamResponse.RawRequest != nil && *streamResponse.RawRequest != nil {
-				rawRequestBytes, err := sonic.Marshal(*streamResponse.RawRequest)
-				if err == nil {
-					entry.RawRequest = string(rawRequestBytes)
+				switch raw := (*streamResponse.RawRequest).(type) {
+				case string:
+					entry.RawRequest = strings.TrimSpace(raw)
+				default:
+					rawRequestBytes, err := sonic.Marshal(raw)
+					if err == nil {
+						entry.RawRequest = string(rawRequestBytes)
+					}
 				}
 			}
 			// Raw response


### PR DESCRIPTION
## Summary
Two bugs in the logging plugin caused failed streaming requests to be recorded as `status: success`. This PR fixes both and also corrects double-encoding of `RawRequest` when it is already a plain string.
## Changes
- `operations.go`: remove duplicate unconditional `entry.Status = "success"` assignment at the end of `applyStreamingOutputToEntry` that overwrote any error status set earlier in the same function.
- `main.go`: after `applyStreamingOutputToEntry`, backfill `entry.Status = "error"` when `ErrorDetails` or `ErrorDetailsParsed` is set — matching the behaviour of the non-streaming path.
- `operations.go`: handle `RawRequest` as string or JSON to avoid unnecessary marshaling of already-serialized content.
## Type of change
- [x] Bug fix
## Affected areas
- [x] Plugins
## How to test
1. Send a streaming request through Bifrost that results in an error.
2. Check the log entry — `status` should be `error`.

```sh
cd plugins/logging
go test ./...
```

## Breaking changes
- [x] No

## Related issues
Closes #3043

## Security considerations
None.

### Checklist
- [x] I read docs/contributing/README.md and followed the guidelines
- [x] I verified builds succeed (Go and UI)