### PR TITLE
fix(core,logging): fix shortcircuit stream finality detection, stream flag, and trace flush

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4946,51 +4946,69 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 				}()
 				defer close(outputStream)
 
-				for streamMsg := range shortCircuit.Stream {
-					if streamMsg == nil {
-						continue
-					}
+				// Use lookahead pattern to detect final chunk deterministically.
+				// Read one chunk ahead so we know whether the current chunk is final.
+				var current *schemas.BifrostStreamChunk
+				for {
+					next, ok := <-shortCircuit.Stream
+					if current != nil {
+						// Process current chunk with finality determined by whether next exists
+						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, !ok)
 
 					bifrostResponse := &schemas.BifrostResponse{}
-					if streamMsg.BifrostTextCompletionResponse != nil {
-						bifrostResponse.TextCompletionResponse = streamMsg.BifrostTextCompletionResponse
+					if current.BifrostTextCompletionResponse != nil {
+						bifrostResponse.TextCompletionResponse = current.BifrostTextCompletionResponse
 					}
-					if streamMsg.BifrostChatResponse != nil {
-						bifrostResponse.ChatResponse = streamMsg.BifrostChatResponse
+					if current.BifrostChatResponse != nil {
+						bifrostResponse.ChatResponse = current.BifrostChatResponse
 					}
-					if streamMsg.BifrostResponsesStreamResponse != nil {
-						bifrostResponse.ResponsesStreamResponse = streamMsg.BifrostResponsesStreamResponse
+					if current.BifrostResponsesStreamResponse != nil {
+						bifrostResponse.ResponsesStreamResponse = current.BifrostResponsesStreamResponse
 					}
-					if streamMsg.BifrostSpeechStreamResponse != nil {
-						bifrostResponse.SpeechStreamResponse = streamMsg.BifrostSpeechStreamResponse
+					if current.BifrostSpeechStreamResponse != nil {
+						bifrostResponse.SpeechStreamResponse = current.BifrostSpeechStreamResponse
 					}
-					if streamMsg.BifrostTranscriptionStreamResponse != nil {
-						bifrostResponse.TranscriptionStreamResponse = streamMsg.BifrostTranscriptionStreamResponse
+					if current.BifrostTranscriptionStreamResponse != nil {
+						bifrostResponse.TranscriptionStreamResponse = current.BifrostTranscriptionStreamResponse
 					}
-					if streamMsg.BifrostImageGenerationStreamResponse != nil {
-						bifrostResponse.ImageGenerationStreamResponse = streamMsg.BifrostImageGenerationStreamResponse
+					if current.BifrostImageGenerationStreamResponse != nil {
+						bifrostResponse.ImageGenerationStreamResponse = current.BifrostImageGenerationStreamResponse
 					}
 
-					// Run post hooks on the stream message
-					processedResponse, processedError := pipelinePostHookRunner(ctx, bifrostResponse, streamMsg.BifrostError)
-
-					// Build the client-facing chunk via the shared helper, which strips raw
-					// request/response fields when in logging-only mode without mutating the
-					// shared processedResponse or processedError objects.
-					streamResponse := providerUtils.BuildClientStreamChunk(ctx, processedResponse, processedError)
-
-					// Guarded send: if the consumer abandons outputStream (client
-					// disconnect, ctx cancel), drain the upstream shortCircuit.Stream
-					// so its producer can exit cleanly instead of blocking on its send.
-					select {
-					case outputStream <- streamResponse:
-					case <-ctx.Done():
-						for range shortCircuit.Stream {
+					// Populate extra fields so plugins (e.g. logging) can read requestType/provider/model
+						bifrostResponse.PopulateExtraFields(req.RequestType, provider, model, model)
+						if current.BifrostError != nil {
+							current.BifrostError.PopulateExtraFields(req.RequestType, provider, model, model)
 						}
-						return
-					}
 
-					// TODO: Release the processed response immediately after use
+						// Run post hooks on the stream message
+						processedResponse, processedError := pipelinePostHookRunner(ctx, bifrostResponse, current.BifrostError)
+
+						// Build the client-facing chunk via the shared helper, which strips raw
+						// request/response fields when in logging-only mode without mutating the
+						// shared processedResponse or processedError objects.
+						streamResponse := providerUtils.BuildClientStreamChunk(ctx, processedResponse, processedError)
+
+						// Guarded send: if the consumer abandons outputStream (client
+						// disconnect, ctx cancel), drain the upstream shortCircuit.Stream
+						// so its producer can exit cleanly instead of blocking on its send.
+						select {
+						case outputStream <- streamResponse:
+						case <-ctx.Done():
+							for range shortCircuit.Stream {
+							}
+							return
+						}
+
+						// TODO: Release the processed response immediately after use
+					}
+					if !ok {
+						break
+					}
+					if next == nil {
+						continue // Skip nil chunks
+					}
+					current = next
 				}
 			}()
 

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4941,19 +4941,22 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 			go func() {
 				defer func() {
 					drainAndAttachPluginLogs(ctx) // ensure logs are drained even if stream closes without a final chunk
+					if traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string); ok && traceID != "" {
+						tracer.CompleteAndFlushTrace(strings.TrimSpace(traceID))
+					}
 					pipeline.FinalizeStreamingPostHookSpans(ctx)
 					bifrost.releasePluginPipeline(pipeline)
 				}()
 				defer close(outputStream)
 
-				// Use lookahead pattern to detect final chunk deterministically.
-				// Read one chunk ahead so we know whether the current chunk is final.
-				var current *schemas.BifrostStreamChunk
-				for {
-					next, ok := <-shortCircuit.Stream
-					if current != nil {
-						// Process current chunk with finality determined by whether next exists
-						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, !ok)
+			// Use lookahead pattern to detect final chunk deterministically.
+			// Read one chunk ahead so we know whether the current chunk is final.
+			var current *schemas.BifrostStreamChunk
+			for {
+				next, ok := <-shortCircuit.Stream
+				if current != nil {
+					// Process current chunk with finality determined by whether next exists
+					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, !ok)
 
 					bifrostResponse := &schemas.BifrostResponse{}
 					if current.BifrostTextCompletionResponse != nil {
@@ -4976,40 +4979,40 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 					}
 
 					// Populate extra fields so plugins (e.g. logging) can read requestType/provider/model
-						bifrostResponse.PopulateExtraFields(req.RequestType, provider, model, model)
-						if current.BifrostError != nil {
-							current.BifrostError.PopulateExtraFields(req.RequestType, provider, model, model)
+					bifrostResponse.PopulateExtraFields(req.RequestType, provider, model, model)
+					if current.BifrostError != nil {
+						current.BifrostError.PopulateExtraFields(req.RequestType, provider, model, model)
+					}
+
+					// Run post hooks on the stream message
+					processedResponse, processedError := pipelinePostHookRunner(ctx, bifrostResponse, current.BifrostError)
+
+					// Build the client-facing chunk via the shared helper, which strips raw
+					// request/response fields when in logging-only mode without mutating the
+					// shared processedResponse or processedError objects.
+					streamResponse := providerUtils.BuildClientStreamChunk(ctx, processedResponse, processedError)
+
+					// Guarded send: if the consumer abandons outputStream (client
+					// disconnect, ctx cancel), drain the upstream shortCircuit.Stream
+					// so its producer can exit cleanly instead of blocking on its send.
+					select {
+					case outputStream <- streamResponse:
+					case <-ctx.Done():
+						for range shortCircuit.Stream {
 						}
-
-						// Run post hooks on the stream message
-						processedResponse, processedError := pipelinePostHookRunner(ctx, bifrostResponse, current.BifrostError)
-
-						// Build the client-facing chunk via the shared helper, which strips raw
-						// request/response fields when in logging-only mode without mutating the
-						// shared processedResponse or processedError objects.
-						streamResponse := providerUtils.BuildClientStreamChunk(ctx, processedResponse, processedError)
-
-						// Guarded send: if the consumer abandons outputStream (client
-						// disconnect, ctx cancel), drain the upstream shortCircuit.Stream
-						// so its producer can exit cleanly instead of blocking on its send.
-						select {
-						case outputStream <- streamResponse:
-						case <-ctx.Done():
-							for range shortCircuit.Stream {
-							}
-							return
-						}
-
-						// TODO: Release the processed response immediately after use
+						return
 					}
-					if !ok {
-						break
-					}
-					if next == nil {
-						continue // Skip nil chunks
-					}
-					current = next
+
+					// TODO: Release the processed response immediately after use
 				}
+				if !ok {
+					break
+				}
+				if next == nil {
+					continue // Skip nil chunks
+				}
+				current = next
+			}
 			}()
 
 			return outputStream, nil

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4941,10 +4941,10 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 			go func() {
 				defer func() {
 					drainAndAttachPluginLogs(ctx) // ensure logs are drained even if stream closes without a final chunk
-					if traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string); ok && traceID != "" {
+					pipeline.FinalizeStreamingPostHookSpans(ctx)
+					if traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string); ok && strings.TrimSpace(traceID) != "" {
 						tracer.CompleteAndFlushTrace(strings.TrimSpace(traceID))
 					}
-					pipeline.FinalizeStreamingPostHookSpans(ctx)
 					bifrost.releasePluginPipeline(pipeline)
 				}()
 				defer close(outputStream)

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -925,6 +925,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		}
 	} else if result != nil {
 		entry.Status = "success"
+		entry.Stream = bifrost.IsStreamRequestType(requestType)
 		extraFields := result.GetExtraFields()
 		applyModelAlias(entry, extraFields.OriginalModelRequested, extraFields.ResolvedModelUsed)
 		if requestType == schemas.RealtimeRequest {

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -377,19 +377,19 @@ func (plugin *Plugin) buildStreamingResponseFromResult(ctx *schemas.BifrostConte
 			}
 
 			// Unmarshal the chunk as BifrostResponse
-		var cachedResponse schemas.BifrostResponse
-		if err := json.Unmarshal([]byte(chunkStr), &cachedResponse); err != nil {
-			plugin.logger.Warn("%s Failed to unmarshal stream chunk %d, skipping: %v", PluginLoggerPrefix, i, err)
-			continue
-		}
+			var cachedResponse schemas.BifrostResponse
+			if err := json.Unmarshal([]byte(chunkStr), &cachedResponse); err != nil {
+				plugin.logger.Warn("%s Failed to unmarshal stream chunk %d, skipping: %v", PluginLoggerPrefix, i, err)
+				continue
+			}
 
-		// Ensure RequestType is set on every chunk so downstream consumers
-		// (logging, telemetry, etc.) correctly identify this as a streaming response.
-		if ef := cachedResponse.GetExtraFields(); ef != nil && ef.RequestType == "" {
-			ef.RequestType = req.RequestType
-		}
+			// Ensure RequestType is set on every chunk so downstream consumers
+			// (logging, telemetry, etc.) correctly identify this as a streaming response.
+			if ef := cachedResponse.GetExtraFields(); ef != nil && ef.RequestType == "" {
+				ef.RequestType = req.RequestType
+			}
 
-		// Add cache debug to only the last chunk
+			// Add cache debug to only the last chunk
 			if i == len(streamArray)-1 {
 				extraFields := cachedResponse.GetExtraFields()
 				cacheDebug := schemas.BifrostCacheDebug{

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -377,21 +377,20 @@ func (plugin *Plugin) buildStreamingResponseFromResult(ctx *schemas.BifrostConte
 			}
 
 			// Unmarshal the chunk as BifrostResponse
-			var cachedResponse schemas.BifrostResponse
-			if err := json.Unmarshal([]byte(chunkStr), &cachedResponse); err != nil {
-				plugin.logger.Warn("%s Failed to unmarshal stream chunk %d, skipping: %v", PluginLoggerPrefix, i, err)
-				continue
-			}
+		var cachedResponse schemas.BifrostResponse
+		if err := json.Unmarshal([]byte(chunkStr), &cachedResponse); err != nil {
+			plugin.logger.Warn("%s Failed to unmarshal stream chunk %d, skipping: %v", PluginLoggerPrefix, i, err)
+			continue
+		}
 
-			// Ensure RequestType is set on every chunk so downstream consumers
-			// (logging, telemetry, etc.) correctly identify this as a streaming response.
-			if ef := cachedResponse.GetExtraFields(); ef != nil && ef.RequestType == "" {
-				ef.RequestType = req.RequestType
-			}
+		// Ensure RequestType is set on every chunk so downstream consumers
+		// (logging, telemetry, etc.) correctly identify this as a streaming response.
+		if ef := cachedResponse.GetExtraFields(); ef != nil && ef.RequestType == "" {
+			ef.RequestType = req.RequestType
+		}
 
-			// Add cache debug to only the last chunk
+		// Add cache debug to only the last chunk
 			if i == len(streamArray)-1 {
-				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				extraFields := cachedResponse.GetExtraFields()
 				cacheDebug := schemas.BifrostCacheDebug{
 					CacheHit:          true,


### PR DESCRIPTION
## Summary

Three bugs in the shortcircuit stream path caused cached streaming responses to be logged as non-streaming, IsFinalChunk to be non-deterministic, and traces to be dropped.

## Changes

- `core/bifrost.go`: Replace `for streamMsg := range` with a lookahead pattern — read one chunk ahead to determine finality by channel closure rather than relying on producer-set context flag. Explicitly set `BifrostContextKeyStreamEndIndicator` per chunk.
- `core/bifrost.go`: Add `CompleteAndFlushTrace` to the shortcircuit goroutine's defer block, matching the non-shortcircuit stream path.
- `plugins/logging/main.go`: Set `entry.Stream` in Path C using `IsStreamRequestType(requestType)`, so streaming requests that fall through to Path C are correctly recorded.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Enable semantic cache with streaming.
2. Send an identical streaming request twice.
3. Verify the second (cached) log entry shows `stream=true`.
4. Verify traces are completed for cached streaming requests.

```sh
make test-mcp
cd plugins/logging && go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Closes #3047

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


