### PR TITLE
fix(semanticcache): deterministic request hashing and CacheDebug propagation in streaming

### DIFF
--- a/core/schemas/tracer.go
+++ b/core/schemas/tracer.go
@@ -24,6 +24,7 @@ type StreamAccumulatorResult struct {
 	OutputMessages        []ResponsesMessage              // For responses API
 	TokenUsage            *BifrostLLMUsage                // Token usage
 	Cost                  *float64                        // Cost in dollars
+	CacheDebug            *BifrostCacheDebug              // Semantic cache debug info if available
 	ErrorDetails          *BifrostError                   // Error details if any
 	AudioOutput           *BifrostSpeechResponse          // For speech streaming
 	TranscriptionOutput   *BifrostTranscriptionResponse   // For transcription streaming

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -336,6 +336,7 @@ func (t *Tracer) ProcessStreamingChunk(traceID string, isFinalChunk bool, result
 		accResult.OutputMessages = processedResp.Data.OutputMessages
 		accResult.TokenUsage = processedResp.Data.TokenUsage
 		accResult.Cost = processedResp.Data.Cost
+		accResult.CacheDebug = processedResp.Data.CacheDebug
 		accResult.ErrorDetails = processedResp.Data.ErrorDetails
 		accResult.AudioOutput = processedResp.Data.AudioOutput
 		accResult.TranscriptionOutput = processedResp.Data.TranscriptionOutput

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -368,6 +368,11 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 		entry.Cost = streamResponse.Data.Cost
 	}
 
+	// Cache
+	if streamResponse.Data.CacheDebug != nil {
+		entry.CacheDebugParsed = streamResponse.Data.CacheDebug
+	}
+
 	if p.disableContentLogging == nil || !*p.disableContentLogging {
 		// Transcription output
 		if streamResponse.Data.TranscriptionOutput != nil {
@@ -380,10 +385,6 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 		// Image generation output
 		if streamResponse.Data.ImageGenerationOutput != nil {
 			entry.ImageGenerationOutputParsed = streamResponse.Data.ImageGenerationOutput
-		}
-		// Cache debug
-		if streamResponse.Data.CacheDebug != nil {
-			entry.CacheDebugParsed = streamResponse.Data.CacheDebug
 		}
 		// Output message
 		if streamResponse.Data.OutputMessage != nil {

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -679,6 +679,7 @@ func convertToProcessedStreamResponse(result *schemas.StreamAccumulatorResult, r
 		OutputMessages:        result.OutputMessages,
 		ErrorDetails:          result.ErrorDetails,
 		TokenUsage:            result.TokenUsage,
+		CacheDebug:            result.CacheDebug,
 		Cost:                  result.Cost,
 		AudioOutput:           result.AudioOutput,
 		TranscriptionOutput:   result.TranscriptionOutput,

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -137,6 +137,7 @@ func convertAccResultToProcessedStreamResponse(accResult *schemas.StreamAccumula
 			TranscriptionOutput: accResult.TranscriptionOutput,
 			FinishReason:        accResult.FinishReason,
 			RawResponse:         accResult.RawResponse,
+			CacheDebug:          accResult.CacheDebug,
 		},
 		RawRequest: &accResult.RawRequest,
 	}

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -290,14 +290,16 @@ func (plugin *Plugin) buildResponseFromResult(ctx *schemas.BifrostContext, req *
 		similarity = *result.Score
 	}
 
-	if hasValidStreamingResponse && !hasValidSingleResponse {
-		// Handle streaming response
-		return plugin.buildStreamingResponseFromResult(ctx, req, result, streamResponses, cacheType, threshold, similarity, inputTokens)
-	} else if hasValidSingleResponse && !hasValidStreamingResponse {
-		// Handle single response
+	isStreamRequest := bifrost.IsStreamRequestType(req.RequestType)
+
+	if isStreamRequest && hasValidStreamingResponse {
+		return plugin.buildStreamingResponseFromResult(ctx, req, result, streamChunks, cacheType, threshold, similarity, inputTokens)
+	} else if !isStreamRequest && hasValidSingleResponse {
 		return plugin.buildSingleResponseFromResult(ctx, req, result, singleResponse, cacheType, threshold, similarity, inputTokens)
 	} else {
-		return nil, fmt.Errorf("cached result has invalid response data: both or neither response/stream_chunks are present (response: %v, stream_chunks: %v)", singleResponse, streamResponses)
+		plugin.logger.Warn("%s Cache entry format mismatch for request %s (isStream=%t, hasSingle=%t, hasStream=%t), treating as miss",
+			PluginLoggerPrefix, result.ID, isStreamRequest, hasValidSingleResponse, hasValidStreamingResponse)
+		return nil, nil
 	}
 }
 
@@ -349,14 +351,8 @@ func (plugin *Plugin) buildSingleResponseFromResult(ctx *schemas.BifrostContext,
 }
 
 // buildStreamingResponseFromResult constructs a streaming response from cached data
-func (plugin *Plugin) buildStreamingResponseFromResult(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, result vectorstore.SearchResult, streamData interface{}, cacheType CacheType, threshold float64, similarity float64, inputTokens int) (*schemas.LLMPluginShortCircuit, error) {
+func (plugin *Plugin) buildStreamingResponseFromResult(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, result vectorstore.SearchResult, streamArray []interface{}, cacheType CacheType, threshold float64, similarity float64, inputTokens int) (*schemas.LLMPluginShortCircuit, error) {
 	requestedProvider, requestedModel, _ := req.GetRequestFields()
-
-	// Parse stream_chunks
-	streamArray, err := plugin.parseStreamChunks(streamData)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse stream_chunks: %w", err)
-	}
 
 	// Mark cache-hit once to avoid concurrent ctx writes
 	ctx.SetValue(isCacheHitKey, true)
@@ -387,7 +383,13 @@ func (plugin *Plugin) buildStreamingResponseFromResult(ctx *schemas.BifrostConte
 				continue
 			}
 
-			// Add cache debug to only the last chunk and set stream end indicator
+			// Ensure RequestType is set on every chunk so downstream consumers
+			// (logging, telemetry, etc.) correctly identify this as a streaming response.
+			if ef := cachedResponse.GetExtraFields(); ef != nil && ef.RequestType == "" {
+				ef.RequestType = req.RequestType
+			}
+
+			// Add cache debug to only the last chunk
 			if i == len(streamArray)-1 {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				extraFields := cachedResponse.GetExtraFields()

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -117,33 +117,21 @@ func (plugin *Plugin) generateEmbedding(ctx *schemas.BifrostContext, text string
 //   - string: Hexadecimal representation of the xxhash
 //   - error: Any error that occurred during request normalization or hashing
 func (plugin *Plugin) generateRequestHash(req *schemas.BifrostRequest) (string, error) {
-	// Create a hash input structure that includes both input and parameters
-	hashInput := struct {
-		Input  interface{} `json:"input"`
-		Params interface{} `json:"params,omitempty"`
-		Stream bool        `json:"stream,omitempty"`
-	}{
-		Input:  plugin.getNormalizedInputForCaching(req),
-		Stream: bifrost.IsStreamRequestType(req.RequestType),
+	// Build canonical metadata first to ensure deterministic hashing
+	metadata, err := plugin.buildRequestMetadataForCaching(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to build metadata for request hash: %w", err)
 	}
 
-	switch req.RequestType {
-	case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
-		hashInput.Params = req.TextCompletionRequest.Params
-	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
-		hashInput.Params = req.ChatRequest.Params
-	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest:
-		hashInput.Params = req.ResponsesRequest.Params
-	case schemas.SpeechRequest, schemas.SpeechStreamRequest:
-		if req.SpeechRequest != nil {
-			hashInput.Params = req.SpeechRequest.Params
-		}
-	case schemas.EmbeddingRequest:
-		hashInput.Params = req.EmbeddingRequest.Params
-	case schemas.TranscriptionRequest, schemas.TranscriptionStreamRequest:
-		hashInput.Params = req.TranscriptionRequest.Params
-	case schemas.ImageGenerationRequest, schemas.ImageGenerationStreamRequest:
-		hashInput.Params = req.ImageGenerationRequest.Params
+	// Create a hash input structure that includes both input and canonical parameters
+	hashInput := struct {
+		Input  interface{}            `json:"input"`
+		Params map[string]interface{} `json:"params,omitempty"`
+		Stream bool                   `json:"stream,omitempty"`
+	}{
+		Input:  plugin.getNormalizedInputForCaching(req),
+		Params: metadata,
+		Stream: bifrost.IsStreamRequestType(req.RequestType),
 	}
 
 	// Marshal to JSON with deeply sorted keys for deterministic hashing

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -127,11 +127,9 @@ func (plugin *Plugin) generateRequestHash(req *schemas.BifrostRequest) (string, 
 	hashInput := struct {
 		Input  interface{}            `json:"input"`
 		Params map[string]interface{} `json:"params,omitempty"`
-		Stream bool                   `json:"stream,omitempty"`
 	}{
 		Input:  plugin.getNormalizedInputForCaching(req),
 		Params: metadata,
-		Stream: bifrost.IsStreamRequestType(req.RequestType),
 	}
 
 	// Marshal to JSON with deeply sorted keys for deterministic hashing


### PR DESCRIPTION
## Summary

Fixes two bugs in `plugins/semanticcache` that together caused the semantic cache to be effectively non-functional for direct-mode hits and invisible in logs for streaming hits.

## Changes

- **`plugins/semanticcache/utils.go`** — `generateRequestHash()` was hashing raw typed params structs (`ChatParameters`, etc.) whose `map[string]interface{}` fields have non-deterministic iteration order in Go. `MarshalDeeplySorted` couldn't fully canonicalize them, so byte-identical requests produced different hashes and the cache never hit. Fix: reuse `buildRequestMetadataForCaching()` (already canonical) for the `params` field of the hash input.
- **`plugins/semanticcache/search.go`** — Cached streaming chunks had no `RequestType` set, causing logging/telemetry to misidentify the request type. Also tightens `buildResponseFromResult` to treat stream/single format mismatches as a cache miss with a warning instead of a hard error.
- **`core/schemas/tracer.go`, `framework/tracing/tracer.go`, `plugins/logging/main.go`, `plugins/logging/utils.go`** — `CacheDebug` was set on the final chunk's `ExtraFields` but the accumulator path (`StreamAccumulatorResult → convertToProcessedStreamResponse → applyStreamingOutputToEntry`) didn't carry it through. Added `CacheDebug` to `StreamAccumulatorResult` and wired it through the full path. Eagerly serialize in `PostLLMHook` to avoid a GORM `BeforeCreate` race on the async write path.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
make test-plugins
```

## Breaking changes

- [ ] Yes
- [x] No*

> **Note:** Existing semantic cache entries written before this fix will become unreachable after deploy — the hash schema changed shape (canonical metadata map instead of typed structs, `stream` moved into `params`). Since the previous hashing was non-deterministic, those entries were already effectively unmatchable. A one-time cache flush after deploy is recommended.

## Related issues

Closes: #2912, #2791, #3049

## Security considerations
None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


