### PR TITLE
adds id to the schema for base_key

### DIFF
--- a/examples/configs/withvirtualkeys/config.json
+++ b/examples/configs/withvirtualkeys/config.json
@@ -2,9 +2,7 @@
   "$schema": "https://www.getbifrost.ai/schema",
   "client": {
     "allow_direct_keys": false,
-    "allowed_origins": [
-      "*"
-    ],
+    "allowed_origins": ["*"],
     "disable_content_logging": false,
     "drop_excess_requests": false,
     "enable_logging": true,
@@ -39,33 +37,20 @@
         "name": "prod-assistant-us-key-01-configurations",
         "provider_configs": [
           {
-            "key_ids": [
-              "key-azure-us-1-prod"
-            ],
-            "allowed_models": [
-              "*"
-            ],
+            "key_ids": ["key-azure-us-1-prod"],
+            "allowed_models": ["*"],
             "provider": "azure",
             "weight": 0.5
           },
           {
-            "key_ids": [
-              "key-vertex-us-east1-prod",
-              "key-vertex-global-prod"
-            ],
-            "allowed_models": [
-              "*"
-            ],
+            "key_ids": ["key-vertex-us-east1-prod", "key-vertex-global-prod"],
+            "allowed_models": ["*"],
             "provider": "vertex",
             "weight": 0.5
           },
           {
-            "key_ids": [
-              "key-openai-us-1-prod"
-            ],
-            "allowed_models": [
-              "*"
-            ],
+            "key_ids": ["key-openai-us-1-prod"],
+            "allowed_models": ["*"],
             "provider": "openai",
             "weight": 0.5
           }
@@ -78,33 +63,20 @@
         "name": "prod-assistant-eu-key-01-configurations",
         "provider_configs": [
           {
-            "key_ids": [
-              "key-azure-eu-1-prod"
-            ],
-            "allowed_models": [
-              "*"
-            ],
+            "key_ids": ["key-azure-eu-1-prod"],
+            "allowed_models": ["*"],
             "provider": "azure",
             "weight": 0.5
           },
           {
-            "key_ids": [
-              "key-vertex-eu-west1-prod",
-              "key-vertex-global-prod"
-            ],
-            "allowed_models": [
-              "*"
-            ],
+            "key_ids": ["key-vertex-eu-west1-prod", "key-vertex-global-prod"],
+            "allowed_models": ["*"],
             "provider": "vertex",
             "weight": 0.5
           },
           {
-            "key_ids": [
-              "key-bedrock-eu-central-1-prod"
-            ],
-            "allowed_models": [
-              "*"
-            ],
+            "key_ids": ["key-bedrock-eu-central-1-prod"],
+            "allowed_models": ["*"],
             "provider": "bedrock",
             "weight": 0.5
           }
@@ -138,15 +110,7 @@
             "api_version": "2025-03-01-preview",
             "endpoint": "https://orca-prod-us-east-1.openai.azure.com/"
           },
-          "models": [
-            "gpt-4.1",
-            "gpt-4.1-mini",
-            "gpt-4o",
-            "gpt-4o-mini",
-            "gpt-5",
-            "gpt-5-mini",
-            "gpt-5.1"
-          ],
+          "models": ["gpt-4.1", "gpt-4.1-mini", "gpt-4o", "gpt-4o-mini", "gpt-5", "gpt-5-mini", "gpt-5.1"],
           "name": "azure-us-key-1-prod",
           "value": "env.AZURE_OPENAI_API_KEY_US_EAST_1",
           "weight": 1
@@ -157,15 +121,7 @@
             "api_version": "2025-03-01-preview",
             "endpoint": "https://orca-prod-us-east-2.openai.azure.com/"
           },
-          "models": [
-            "gpt-4.1",
-            "gpt-4.1-mini",
-            "gpt-4o",
-            "gpt-4o-mini",
-            "gpt-5",
-            "gpt-5-mini",
-            "gpt-5.1"
-          ],
+          "models": ["gpt-4.1", "gpt-4.1-mini", "gpt-4o", "gpt-4o-mini", "gpt-5", "gpt-5-mini", "gpt-5.1"],
           "name": "azure-us-key-2-prod",
           "value": "env.AZURE_OPENAI_API_KEY_US_EAST_2",
           "weight": 1
@@ -176,15 +132,7 @@
             "api_version": "2025-03-01-preview",
             "endpoint": "https://orca-prod-eu-central-1.openai.azure.com/"
           },
-          "models": [
-            "gpt-4.1",
-            "gpt-4.1-mini",
-            "gpt-4o",
-            "gpt-4o-mini",
-            "gpt-5",
-            "gpt-5-mini",
-            "gpt-5.1"
-          ],
+          "models": ["gpt-4.1", "gpt-4.1-mini", "gpt-4o", "gpt-4o-mini", "gpt-5", "gpt-5-mini", "gpt-5.1"],
           "name": "azure-eu-key-1-prod",
           "value": "env.AZURE_OPENAI_API_KEY_EU_CENTRAL_1",
           "weight": 1
@@ -200,9 +148,7 @@
             "region": "us-east-1",
             "secret_key": "env.AWS_SECRET_ACCESS_KEY_US_EAST_1"
           },
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "name": "bedrock-us-east-1-prod",
           "weight": 1
         },
@@ -213,9 +159,7 @@
             "region": "us-west-2",
             "secret_key": "env.AWS_SECRET_ACCESS_KEY_US_WEST_2"
           },
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "name": "bedrock-us-west-2-prod",
           "weight": 1
         },
@@ -226,9 +170,7 @@
             "region": "eu-central-1",
             "secret_key": "env.AWS_SECRET_ACCESS_KEY_EU_CENTRAL_1"
           },
-          "models": [
-            "*"
-          ],
+          "models": ["*"],
           "name": "bedrock-eu-central-1-prod",
           "weight": 1
         }
@@ -238,11 +180,7 @@
       "keys": [
         {
           "id": "key-vertex-us-east1-prod",
-          "models": [
-            "google/gemini-2.5-pro",
-            "google/gemini-2.5-flash-lite",
-            "google/gemini-2.5-flash"
-          ],
+          "models": ["google/gemini-2.5-pro", "google/gemini-2.5-flash-lite", "google/gemini-2.5-flash"],
           "name": "vertex-us-east1-prod",
           "vertex_key_config": {
             "auth_credentials": "env.VERTEX_CREDENTIALS_US_EAST1",
@@ -253,11 +191,7 @@
         },
         {
           "id": "key-vertex-eu-west1-prod",
-          "models": [
-            "google/gemini-2.5-pro",
-            "google/gemini-2.5-flash-lite",
-            "google/gemini-2.5-flash"
-          ],
+          "models": ["google/gemini-2.5-pro", "google/gemini-2.5-flash-lite", "google/gemini-2.5-flash"],
           "name": "vertex-europe-west1-prod",
           "vertex_key_config": {
             "auth_credentials": "env.VERTEX_CREDENTIALS_EUROPE_WEST1",
@@ -268,11 +202,7 @@
         },
         {
           "id": "key-vertex-us-west1-prod",
-          "models": [
-            "google/gemini-2.5-pro",
-            "google/gemini-2.5-flash-lite",
-            "google/gemini-2.5-flash"
-          ],
+          "models": ["google/gemini-2.5-pro", "google/gemini-2.5-flash-lite", "google/gemini-2.5-flash"],
           "name": "vertex-us-west1-prod",
           "vertex_key_config": {
             "auth_credentials": "env.VERTEX_CREDENTIALS_US_WEST1",
@@ -283,10 +213,7 @@
         },
         {
           "id": "key-vertex-global-prod",
-          "models": [
-            "google/gemini-3-pro-preview",
-            "google/gemini-3-flash-preview"
-          ],
+          "models": ["google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
           "name": "vertex-global-prod",
           "vertex_key_config": {
             "auth_credentials": "env.VERTEX_CREDENTIALS_GLOBAL",
@@ -304,9 +231,7 @@
           "name": "openai-us-key-1-prod",
           "value": "env.OPENAI_API_KEY_US_EAST_1",
           "weight": 1,
-          "models": [
-            "*"
-          ]
+          "models": ["*"]
         }
       ]
     }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -516,9 +516,8 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 				// KeyID not found, try fallback lookup by Name (handles config reload with new UUID)
 				result = txDB.WithContext(ctx).Where("name = ?", dbKey.Name).First(&existingKey)
 				if result.Error == nil {
-					// Found by name - update existing key, preserve original KeyID
+					// Found by name - update existing key; use incoming KeyID (may be user-supplied)
 					dbKey.ID = existingKey.ID                             // Keep the same database ID
-					dbKey.KeyID = existingKey.KeyID                       // Preserve original KeyID
 					dbKey.ProviderID = existingKey.ProviderID             // Preserve the existing ProviderID
 					dbKey.Enabled = existingKey.Enabled                   // Preserve the existing Enabled status
 					dbKey.Status = existingKey.Status                     // Preserve status (UI-managed)

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -137,8 +137,8 @@ func TestUpdateProvidersConfig_UpdateExistingByKeyID(t *testing.T) {
 }
 
 func TestUpdateProvidersConfig_UpdateExistingByName_FallbackFix(t *testing.T) {
-	// This test verifies the fix for the unique constraint violation issue
-	// when a new UUID is generated for a key that already exists by name
+	// This test verifies that when a key is found by name (KeyID not in DB),
+	// the incoming KeyID is used (user-supplied IDs are respected, not discarded)
 	store := setupRDBTestStore(t)
 	ctx := context.Background()
 
@@ -158,12 +158,12 @@ func TestUpdateProvidersConfig_UpdateExistingByName_FallbackFix(t *testing.T) {
 	err := store.UpdateProvidersConfig(ctx, providers)
 	require.NoError(t, err)
 
-	// Simulate config reload with NEW UUID (as happens when loading from config file)
+	// Simulate user adding an explicit ID to an existing key (user-supplied ID)
 	providers["openai"] = ProviderConfig{
 		Keys: []schemas.Key{
 			{
-				ID:     "new-uuid-from-config-reload", // Different UUID!
-				Name:   "openai-primary",              // Same name
+				ID:     "user-supplied-id", // User-supplied ID replaces original UUID
+				Name:   "openai-primary",   // Same name
 				Value:  *schemas.NewEnvVar("sk-test-key-v2"),
 				Weight: 1.5,
 			},
@@ -172,12 +172,12 @@ func TestUpdateProvidersConfig_UpdateExistingByName_FallbackFix(t *testing.T) {
 	err = store.UpdateProvidersConfig(ctx, providers)
 	require.NoError(t, err, "Should not fail with unique constraint violation")
 
-	// Verify key was updated (not duplicated) and original KeyID preserved
+	// Verify key was updated (not duplicated) and user-supplied KeyID was applied
 	result, err := store.GetProvidersConfig(ctx)
 	require.NoError(t, err)
 	assert.Len(t, result["openai"].Keys, 1, "Should have exactly one key, not duplicated")
 	assert.Equal(t, "sk-test-key-v2", result["openai"].Keys[0].Value.Val, "Value should be updated")
-	assert.Equal(t, "original-uuid", result["openai"].Keys[0].ID, "Original KeyID should be preserved")
+	assert.Equal(t, "user-supplied-id", result["openai"].Keys[0].ID, "User-supplied KeyID should be applied")
 }
 
 func TestUpdateProvidersConfig_MultipleKeys(t *testing.T) {

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -2801,6 +2801,10 @@
     "providerKey": {
       "type": "object",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the key"
+        },
         "name": {
           "type": "string"
         },

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -804,6 +804,14 @@ func processProvider(
 ) error {
 	provider := schemas.ModelProvider(strings.ToLower(providerName))
 
+	// Capture user-supplied IDs before UUID generation so they can be preserved
+	// through the merge/reconcile logic (which otherwise always prefers the DB UUID).
+	userSuppliedKeyIDs := make(map[string]string, len(providerCfgInFile.Keys))
+	for _, key := range providerCfgInFile.Keys {
+		if key.ID != "" {
+			userSuppliedKeyIDs[key.Name] = key.ID
+		}
+	}
 	// Process environment variables in keys (including key-level configs)
 	for i, providerKeyInFile := range providerCfgInFile.Keys {
 		if providerKeyInFile.ID == "" {
@@ -820,7 +828,7 @@ func processProvider(
 	}
 	providerCfgInFile.ConfigHash = fileProviderConfigHash
 	// Merge with existing config using hash-based reconciliation
-	mergeProviderWithHash(provider, providerCfgInFile, providersInConfigStore)
+	mergeProviderWithHash(provider, providerCfgInFile, providersInConfigStore, userSuppliedKeyIDs)
 	return nil
 }
 
@@ -829,6 +837,7 @@ func mergeProviderWithHash(
 	provider schemas.ModelProvider,
 	providerCfgInFile configstore.ProviderConfig,
 	providersInConfigStore map[schemas.ModelProvider]configstore.ProviderConfig,
+	userSuppliedKeyIDs map[string]string,
 ) {
 	existingCfg, exists := providersInConfigStore[provider]
 	if !exists {
@@ -840,13 +849,13 @@ func mergeProviderWithHash(
 	if existingCfg.ConfigHash != providerCfgInFile.ConfigHash {
 		// Hash mismatch - config.json was changed, sync from file
 		logger.Debug("config hash mismatch for provider %s, syncing from config file", provider)
-		mergedKeys := mergeProviderKeys(provider, providerCfgInFile.Keys, existingCfg.Keys)
+		mergedKeys := mergeProviderKeys(provider, providerCfgInFile.Keys, existingCfg.Keys, userSuppliedKeyIDs)
 		providerCfgInFile.Keys = mergedKeys
 		providersInConfigStore[provider] = providerCfgInFile
 	} else {
 		// Provider hash matches - but still check individual keys
 		logger.Debug("config hash matches for provider %s, checking individual keys", provider)
-		mergedKeys := reconcileProviderKeys(provider, providerCfgInFile.Keys, existingCfg.Keys)
+		mergedKeys := reconcileProviderKeys(provider, providerCfgInFile.Keys, existingCfg.Keys, userSuppliedKeyIDs)
 		existingCfg.Keys = mergedKeys
 		providersInConfigStore[provider] = existingCfg
 	}
@@ -854,7 +863,7 @@ func mergeProviderWithHash(
 
 // mergeProviderKeys syncs keys when provider hash has changed (file is source of truth).
 // Keys in file are kept, keys only in DB are removed.
-func mergeProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []schemas.Key) []schemas.Key {
+func mergeProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []schemas.Key, userSuppliedKeyIDs map[string]string) []schemas.Key {
 	mergedKeys := fileKeys
 	for _, dbKey := range dbKeys {
 		found := false
@@ -864,7 +873,9 @@ func mergeProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []schema
 			if err != nil {
 				logger.Warn("failed to generate key hash for file key %s (%s): %v, falling back to name comparison", fileKey.Name, provider, err)
 				if fileKey.Name == dbKey.Name {
-					fileKeys[i].ID = dbKey.ID
+					if _, hasUserID := userSuppliedKeyIDs[fileKeys[i].Name]; !hasUserID {
+						fileKeys[i].ID = dbKey.ID
+					}
 					fileKeys[i].Status = dbKey.Status
 					fileKeys[i].Description = dbKey.Description
 					found = true
@@ -877,7 +888,9 @@ func mergeProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []schema
 			// Use stored ConfigHash for comparison if available
 			if dbKey.ConfigHash != "" {
 				if fileKeyHash == dbKey.ConfigHash || fileKey.Name == dbKey.Name {
-					fileKeys[i].ID = dbKey.ID
+					if _, hasUserID := userSuppliedKeyIDs[fileKeys[i].Name]; !hasUserID {
+						fileKeys[i].ID = dbKey.ID
+					}
 					fileKeys[i].Status = dbKey.Status
 					fileKeys[i].Description = dbKey.Description
 					found = true
@@ -905,7 +918,9 @@ func mergeProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []schema
 				if err != nil {
 					logger.Warn("failed to generate key hash for db key %s (%s): %v, falling back to name comparison", dbKey.Name, provider, err)
 					if fileKey.Name == dbKey.Name {
-						fileKeys[i].ID = dbKey.ID
+						if _, hasUserID := userSuppliedKeyIDs[fileKeys[i].Name]; !hasUserID {
+							fileKeys[i].ID = dbKey.ID
+						}
 						fileKeys[i].Status = dbKey.Status
 						fileKeys[i].Description = dbKey.Description
 						found = true
@@ -914,7 +929,9 @@ func mergeProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []schema
 					continue
 				}
 				if fileKeyHash == dbKeyHash || fileKey.Name == dbKey.Name {
-					fileKeys[i].ID = dbKey.ID
+					if _, hasUserID := userSuppliedKeyIDs[fileKeys[i].Name]; !hasUserID {
+						fileKeys[i].ID = dbKey.ID
+					}
 					fileKeys[i].Status = dbKey.Status
 					fileKeys[i].Description = dbKey.Description
 					found = true
@@ -931,7 +948,7 @@ func mergeProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []schema
 }
 
 // reconcileProviderKeys reconciles keys when provider hash matches
-func reconcileProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []schemas.Key) []schemas.Key {
+func reconcileProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []schemas.Key, userSuppliedKeyIDs map[string]string) []schemas.Key {
 	mergedKeys := make([]schemas.Key, 0)
 	fileKeysByName := make(map[string]int) // name -> index in file keys
 	for i, fileKey := range fileKeys {
@@ -944,6 +961,9 @@ func reconcileProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []sc
 			fileKeyHash, err := configstore.GenerateKeyHash(fileKey)
 			if err != nil {
 				logger.Warn("failed to generate key hash for file key %s (%s): %v", fileKey.Name, provider, err)
+				if userID, hasUserID := userSuppliedKeyIDs[dbKey.Name]; hasUserID && dbKey.ID != userID {
+					dbKey.ID = userID
+				}
 				mergedKeys = append(mergedKeys, dbKey)
 				delete(fileKeysByName, dbKey.Name)
 				continue
@@ -954,11 +974,16 @@ func reconcileProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []sc
 			if dbKey.ConfigHash != "" {
 				if fileKeyHash == dbKey.ConfigHash {
 					// File unchanged - keep DB version (preserves user updates)
+					if userID, hasUserID := userSuppliedKeyIDs[dbKey.Name]; hasUserID && dbKey.ID != userID {
+						dbKey.ID = userID
+					}
 					mergedKeys = append(mergedKeys, dbKey)
 				} else {
 					// File changed - use file version but preserve ID and set ConfigHash
 					logger.Debug("key %s changed in config file for provider %s, updating", fileKey.Name, provider)
-					fileKey.ID = dbKey.ID
+					if _, hasUserID := userSuppliedKeyIDs[fileKey.Name]; !hasUserID {
+						fileKey.ID = dbKey.ID
+					}
 					fileKey.ConfigHash = fileKeyHash
 					fileKey.Status = dbKey.Status
 					fileKey.Description = dbKey.Description
@@ -985,6 +1010,9 @@ func reconcileProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []sc
 				})
 				if err != nil {
 					logger.Warn("failed to generate key hash for db key %s (%s): %v", dbKey.Name, provider, err)
+					if userID, hasUserID := userSuppliedKeyIDs[dbKey.Name]; hasUserID && dbKey.ID != userID {
+						dbKey.ID = userID
+					}
 					mergedKeys = append(mergedKeys, dbKey)
 					delete(fileKeysByName, dbKey.Name)
 					continue
@@ -992,13 +1020,18 @@ func reconcileProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []sc
 				if fileKeyHash != dbKeyHash {
 					// Key changed in file - use file version but preserve ID and set ConfigHash
 					logger.Debug("key %s changed in config file for provider %s, updating", fileKey.Name, provider)
-					fileKey.ID = dbKey.ID
+					if _, hasUserID := userSuppliedKeyIDs[fileKey.Name]; !hasUserID {
+						fileKey.ID = dbKey.ID
+					}
 					fileKey.ConfigHash = fileKeyHash
 					fileKey.Status = dbKey.Status
 					fileKey.Description = dbKey.Description
 					mergedKeys = append(mergedKeys, fileKey)
 				} else {
 					// Key unchanged - keep DB version
+					if userID, hasUserID := userSuppliedKeyIDs[dbKey.Name]; hasUserID && dbKey.ID != userID {
+						dbKey.ID = userID
+					}
 					mergedKeys = append(mergedKeys, dbKey)
 				}
 			}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2054,6 +2054,10 @@
     "base_key": {
       "type": "object",
       "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the key"
+        },
         "name": {
           "type": "string",
           "description": "Name of the key"
@@ -2899,14 +2903,10 @@
             },
             "oneOf": [
               {
-                "required": [
-                  "mcp_client_id"
-                ]
+                "required": ["mcp_client_id"]
               },
               {
-                "required": [
-                  "mcp_client_name"
-                ]
+                "required": ["mcp_client_name"]
               }
             ],
             "additionalProperties": false
@@ -3639,11 +3639,7 @@
           "description": "Reset window, e.g. \"1M\", \"1h\""
         }
       },
-      "required": [
-        "id",
-        "max_limit",
-        "reset_duration"
-      ],
+      "required": ["id", "max_limit", "reset_duration"],
       "additionalProperties": false
     },
     "rate_limit_line": {
@@ -3735,9 +3731,7 @@
           }
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "additionalProperties": false
     },
     "access_profile_provider_config": {
@@ -3769,9 +3763,7 @@
           "$ref": "#/$defs/rate_limit_line"
         }
       },
-      "required": [
-        "provider_name"
-      ],
+      "required": ["provider_name"],
       "additionalProperties": false
     },
     "access_profile_mcp_tool_group": {
@@ -3783,9 +3775,7 @@
           "description": "MCP tool group ID"
         }
       },
-      "required": [
-        "tool_group_id"
-      ],
+      "required": ["tool_group_id"],
       "additionalProperties": false
     },
     "access_profile_mcp_server": {
@@ -3796,9 +3786,7 @@
           "description": "MCP server identifier"
         }
       },
-      "required": [
-        "mcp_server_id"
-      ],
+      "required": ["mcp_server_id"],
       "additionalProperties": false
     },
     "access_profile_mcp_tool_override": {
@@ -3818,11 +3806,7 @@
           "description": "Override action"
         }
       },
-      "required": [
-        "mcp_client_id",
-        "tool_name",
-        "action"
-      ],
+      "required": ["mcp_client_id", "tool_name", "action"],
       "additionalProperties": false
     },
     "audit_logs_config": {


### PR DESCRIPTION
## Summary

When a key is found in the database by name (because its ID is not present), the previous behavior discarded the incoming `id` from the config file and preserved the original database UUID. This PR changes that behavior so that user-supplied `id` values in `config.json` are respected and applied, allowing operators to define stable, human-readable key identifiers that persist across config reloads.

## Changes

- Removed the line in `rdb.go` that forced `dbKey.KeyID = existingKey.KeyID` during name-based fallback lookup, so incoming user-supplied IDs are now written to the database instead of being silently discarded.
- Updated `mergeProviderKeys` and `reconcileProviderKeys` in `config.go` to check whether a key has a user-supplied ID before overwriting it with the DB UUID during merge/reconcile operations.
- Added a `userSuppliedKeyIDs` map captured before UUID generation in `processProvider`, passed through to both merge functions so user intent is preserved end-to-end.
- Updated tests in `rdb_test.go` to reflect the new behavior: the test now asserts that a user-supplied ID is applied rather than that the original UUID is preserved.
- Added the `id` field to the `base_key` definition in `config.schema.json` and to `providerKey` in `values.schema.json` so user-supplied IDs are recognized as valid schema properties.
- Reformatted inline JSON arrays in the `withvirtualkeys` example config for compactness and added a trailing newline.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... ./transports/bifrost-http/...
```

1. Define a key in `config.json` with an explicit `id` field (e.g., `"id": "my-stable-key-id"`).
2. Start Bifrost and allow the config to be loaded into the database.
3. Restart or reload the config and confirm the key retains `my-stable-key-id` rather than reverting to a generated UUID.
4. Confirm that keys without an explicit `id` still receive and retain auto-generated UUIDs as before.

## Breaking changes

- [x] Yes
- [ ] No

Previously, when a key was matched by name during a config reload, the database UUID was always preserved. Now, if the config file specifies an explicit `id` for that key, it will overwrite the stored UUID. Operators who relied on the database UUID remaining stable across reloads should be aware that adding an `id` field to a key in `config.json` will update the stored ID.

## Related issues

## Security considerations

No new secrets, auth flows, or PII handling introduced. Key values continue to be resolved from environment variables.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable