### PR TITLE
fix: default provider key `id` from `name` if `id` is absent in Helm

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.7
+version: 2.1.8
 appVersion: "1.5.0-prerelease4"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,15 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.7
+**Latest Version:** 2.1.8
 
 ## Changelog
+
+### 2.1.8
+
+- Added provider key backward compatibility in Helm rendering:
+  - If `bifrost.providers.<provider>.keys[].id` is omitted and `name` is present, Helm now auto-populates `id = name`.
+  - This preserves legacy values files that only defined key names while still supporting `governance.virtualKeys[].provider_configs[].key_ids`.
 
 ### 2.1.7
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -378,6 +378,9 @@ false
 {{- $keys := list }}
 {{- range $key := $providerConfig.keys }}
 {{- $keyCopy := deepCopy $key }}
+{{- if and (not (hasKey $keyCopy "id")) (hasKey $keyCopy "name") $keyCopy.name }}
+{{- $_ := set $keyCopy "id" $keyCopy.name }}
+{{- end }}
 {{- if not (hasKey $keyCopy "weight") }}
 {{- $_ := set $keyCopy "weight" 1 }}
 {{- end }}

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -2,6 +2,27 @@ apiVersion: v1
 entries:
   bifrost:
     - apiVersion: v2
+      appVersion: 1.5.0-prerelease5
+      created: "2026-04-26T12:40:00.000000+00:00"
+      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+      digest: ""
+      home: https://www.getmaxim.ai/bifrost
+      icon: https://www.getbifrost.ai/favicon.png
+      keywords:
+        - ai
+        - gateway
+        - llm
+      maintainers:
+        - email: support@getbifrost.ai
+          name: Bifrost Team
+      name: bifrost
+      sources:
+        - https://github.com/maximhq/bifrost
+      type: application
+      urls:
+        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.8.tgz
+      version: 2.1.8
+    - apiVersion: v2
       appVersion: 1.5.0-prerelease4
       created: "2026-04-24T15:00:00.000000+00:00"
       description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
@@ -712,4 +733,4 @@ entries:
       urls:
         - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
       version: 1.3.36
-generated: "2026-04-24T15:00:00.000000+00:00"
+generated: "2026-04-26T12:40:00.000000+00:00"


### PR DESCRIPTION
## Summary

When a provider key has a `name` field but no `id` field, the `id` is not being set, which can cause issues downstream. This PR ensures that if a key has a `name` but is missing an `id`, the `name` value is automatically used as the `id`.

## Changes

- In the Bifrost Helm chart `_helpers.tpl`, added logic to automatically populate the `id` field from the `name` field when iterating over provider config keys, if `id` is absent and `name` is present and non-empty.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy the Bifrost Helm chart with a provider key configuration that includes a `name` field but omits the `id` field. Verify that the rendered manifest contains the `id` field populated with the value from `name`.

```sh
helm template ./helm-charts/bifrost --set 'providerConfig.keys[0].name=my-key'
```

Confirm the output includes `id: my-key` for the key entry.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only affects how key metadata fields are defaulted during Helm template rendering.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable