### PR TITLE
fix(bedrock): avoid nil key config panic

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -182,7 +182,7 @@ func (provider *BedrockProvider) completeRequest(ctx *schemas.BifrostContext, js
 	config := key.BedrockKeyConfig
 
 	region := DefaultBedrockRegion
-	if config.Region != nil && config.Region.GetValue() != "" {
+	if config != nil && config.Region != nil && config.Region.GetValue() != "" {
 		region = config.Region.GetValue()
 	}
 
@@ -211,6 +211,9 @@ func (provider *BedrockProvider) completeRequest(ctx *schemas.BifrostContext, js
 	if key.Value.GetValue() != "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key.Value.GetValue()))
 	} else {
+		if config == nil {
+			return nil, 0, nil, providerUtils.NewBifrostOperationError("bedrock_key_config is required for AWS request signing", nil)
+		}
 		// Sign the request using either explicit credentials or IAM role authentication
 		if err := signAWSRequest(ctx, req, config.AccessKey, config.SecretKey, config.SessionToken, config.RoleARN, config.ExternalID, config.RoleSessionName, region, bedrockSigningService); err != nil {
 			return nil, 0, nil, err

--- a/core/providers/bedrock/transport_test.go
+++ b/core/providers/bedrock/transport_test.go
@@ -712,3 +712,14 @@ func TestBedrockTransportEnforceHTTP2Disabled(t *testing.T) {
 	assert.NotNil(t, transport.TLSNextProto)
 	assert.Empty(t, transport.TLSNextProto)
 }
+
+func TestCompleteRequestNilBedrockKeyConfigReturnsError(t *testing.T) {
+	provider := &BedrockProvider{}
+
+	require.NotPanics(t, func() {
+		_, _, _, err := provider.completeRequest(testBedrockCtx(), []byte(`{}`), "us.anthropic.claude-sonnet-4-6/converse", schemas.Key{})
+		require.NotNil(t, err)
+		require.NotNil(t, err.Error)
+		assert.Contains(t, err.Error.Message, "bedrock_key_config")
+	})
+}


### PR DESCRIPTION
## Summary
- guard Bedrock request signing when `bedrock_key_config` is absent
- fall back to the default Bedrock region unless a config region is present
- return a clean Bifrost operation error instead of panicking on nil key config

## Tests
- `go test ./providers/bedrock -run 'TestCompleteRequestNilBedrockKeyConfigReturnsError' -count=1` from `core/`

Fixes #2855
