### PR TITLE
feat: add opt-in per-request overrides for content logging and raw request/response visibility

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5526,16 +5526,24 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 
 		// Step 1: compute effective value for each flag (provider config ← per-request override).
 		effectiveSendBackReq := config.SendBackRawRequest
-		if override, ok := req.Context.Value(schemas.BifrostContextKeySendBackRawRequest).(bool); ok {
-			effectiveSendBackReq = override
+		allowRawOverride, _ := req.Context.Value(schemas.BifrostContextKeyAllowPerRequestRawOverride).(bool)
+		if allowRawOverride {
+			if override, ok := req.Context.Value(schemas.BifrostContextKeySendBackRawRequest).(bool); ok {
+				effectiveSendBackReq = override
+			}
 		}
 		effectiveSendBackResp := config.SendBackRawResponse
-		if override, ok := req.Context.Value(schemas.BifrostContextKeySendBackRawResponse).(bool); ok {
-			effectiveSendBackResp = override
+		if allowRawOverride {
+			if override, ok := req.Context.Value(schemas.BifrostContextKeySendBackRawResponse).(bool); ok {
+				effectiveSendBackResp = override
+			}
 		}
 		effectiveStore := config.StoreRawRequestResponse
-		if override, ok := req.Context.Value(schemas.BifrostContextKeyStoreRawRequestResponse).(bool); ok {
-			effectiveStore = override
+		allowStorageOverride, _ := req.Context.Value(schemas.BifrostContextKeyAllowPerRequestStorageOverride).(bool)
+		if allowStorageOverride {
+			if override, ok := req.Context.Value(schemas.BifrostContextKeyStoreRawRequestResponse).(bool); ok {
+				effectiveStore = override
+			}
 		}
 
 		// Step 2: derive per-side capture and strip flags.

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -248,6 +248,9 @@ const (
 	BifrostContextKeyRealtimeEventType                   BifrostContextKey = "bifrost-realtime-event-type"                      // string
 	BifrostIsAsyncRequest                                BifrostContextKey = "bifrost-is-async-request"                         // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an async request (only used in gateway)
 	BifrostContextKeyRequestHeaders                      BifrostContextKey = "bifrost-request-headers"                          // map[string]string (all request headers with lowercased keys)
+	BifrostContextKeyAllowPerRequestStorageOverride       BifrostContextKey = "bifrost-allow-per-request-storage-override"        // bool (set by transport from config — gates whether x-bf-disable-content-logging and x-bf-store-raw-request-response per-request overrides are honored)
+	BifrostContextKeyAllowPerRequestRawOverride           BifrostContextKey = "bifrost-allow-per-request-raw-override"            // bool (set by transport from config — gates whether x-bf-send-back-raw-request and x-bf-send-back-raw-response per-request overrides are honored)
+	BifrostContextKeyDisableContentLogging               BifrostContextKey = "x-bf-disable-content-logging"                     // bool (per-request override for content logging; only honored when BifrostContextKeyAllowPerRequestStorageOverride is true)
 	BifrostContextKeySkipListModelsGovernanceFiltering   BifrostContextKey = "bifrost-skip-list-models-governance-filtering"    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeySCIMClaims                          BifrostContextKey = "scim_claims"
 	BifrostContextKeyUserID                              BifrostContextKey = "bifrost-user-id"   // string (to store the user ID (set by enterprise auth middleware - DO NOT SET THIS MANUALLY))

--- a/docs/openapi/schemas/management/config.yaml
+++ b/docs/openapi/schemas/management/config.yaml
@@ -31,6 +31,14 @@ ClientConfig:
     disable_content_logging:
       type: boolean
       description: Whether content logging is disabled
+    allow_per_request_content_storage_override:
+      type: boolean
+      default: false
+      description: Allow individual requests to override content storage via the x-bf-disable-content-logging header or context key. When false (default), per-request overrides are ignored.
+    allow_per_request_raw_override:
+      type: boolean
+      default: false
+      description: Allow individual requests to override raw request/response visibility via the x-bf-send-back-raw-request and x-bf-send-back-raw-response headers. When false (default), provider-level settings are authoritative and per-request overrides are ignored.
     enforce_auth_on_inference:
       type: boolean
       description: Whether to enforce virtual key authentication on inference requests

--- a/docs/providers/request-options.mdx
+++ b/docs/providers/request-options.mdx
@@ -8,36 +8,36 @@ Bifrost provides request options that control behavior, enable features, and pas
 
 ## Complete Reference
 
-| Context Key | Header | Type | Description |
-|-------------|--------|------|-------------|
-| `BifrostContextKeyVirtualKey` | `x-bf-vk` | `string` | Virtual key identifier for governance |
-| `BifrostContextKeyAPIKeyName` | `x-bf-api-key` | `string` | Explicit API key name selection |
-| `BifrostContextKeyAPIKeyID` | `x-bf-api-key-id` | `string` | Explicit API key ID selection (takes priority over name) |
-| `BifrostContextKeySessionID` | `x-bf-session-id` | `string` | Session ID for key stickiness (requires KV store) |
-| `BifrostContextKeySessionTTL` | `x-bf-session-ttl` | `time.Duration` | Session-to-key cache TTL (duration string or seconds) |
-| `BifrostContextKeyRequestID` | `x-request-id` | `string` | Custom request ID for tracking |
-| `BifrostContextKeySendBackRawRequest` | `x-bf-send-back-raw-request` | `bool` | Include raw provider request in the response |
-| `BifrostContextKeySendBackRawResponse` | `x-bf-send-back-raw-response` | `bool` | Include raw provider response in the response |
-| `BifrostContextKeyStoreRawRequestResponse` | `x-bf-store-raw-request-response` | `bool` | Persist raw request/response in log records |
-| `BifrostContextKeyPassthroughExtraParams` | `x-bf-passthrough-extra-params` | `bool` | Enable passthrough for extra parameters |
-| `BifrostContextKeyExtraHeaders` | `x-bf-eh-*` | `map[string][]string` | Custom headers forwarded to provider |
-| `BifrostContextKeyDirectKey` | `-` | `schemas.Key` | Direct key credentials (Go SDK only) |
-| `BifrostContextKeySkipKeySelection` | `-` | `bool` | Skip key selection process (Go SDK only) |
-| `BifrostContextKeyURLPath` | `-` | `string` | Custom URL path appended to provider base URL (Go SDK only) |
-| `BifrostContextKeyUseRawRequestBody` | `-` | `bool` | Use raw request body (Go SDK only, requires RawRequestBody field) |
-| `semanticcache.CacheKey` | `x-bf-cache-key` | `string` | Custom cache key |
-| `semanticcache.CacheTTLKey` | `x-bf-cache-ttl` | `time.Duration` | Cache TTL (duration string or seconds) |
-| `semanticcache.CacheThresholdKey` | `x-bf-cache-threshold` | `float64` | Similarity threshold (0.0-1.0) |
-| `semanticcache.CacheTypeKey` | `x-bf-cache-type` | `string` | Cache type |
-| `semanticcache.CacheNoStoreKey` | `x-bf-cache-no-store` | `bool` | Prevent caching |
-| `mcp-include-clients` | `x-bf-mcp-include-clients` | `[]string` | Filter MCP clients (comma-separated). |
-| `mcp-include-tools` | `x-bf-mcp-include-tools` | `[]string` | Filter MCP tools (`clientName-toolName` format, comma-separated) |
-| `BifrostContextKeyMCPExtraHeaders` | *(any header in a client's `allowed_extra_headers`)* | `map[string][]string` | Headers forwarded to MCP servers at tool execution time, filtered per-client against `allowed_extra_headers` |
-| `maxim.TraceIDKey` | `x-bf-maxim-trace-id` | `string` | Maxim trace ID |
-| `maxim.GenerationIDKey` | `x-bf-maxim-generation-id` | `string` | Maxim generation ID |
-| `maxim.TagsKey` | `x-bf-maxim-*` | `map[string]string` | Maxim tags (custom tag names) |
-| `BifrostContextKey(labelName)` | `x-bf-prom-*` | `string` | Prometheus metric labels |
-
+| Context Key                                | Header                                               | Type                  | Description                                                                                                                           |
+| ------------------------------------------ | ---------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `BifrostContextKeyVirtualKey`              | `x-bf-vk`                                            | `string`              | Virtual key identifier for governance                                                                                                 |
+| `BifrostContextKeyAPIKeyName`              | `x-bf-api-key`                                       | `string`              | Explicit API key name selection                                                                                                       |
+| `BifrostContextKeyAPIKeyID`                | `x-bf-api-key-id`                                    | `string`              | Explicit API key ID selection (takes priority over name)                                                                              |
+| `BifrostContextKeySessionID`               | `x-bf-session-id`                                    | `string`              | Session ID for key stickiness (requires KV store)                                                                                     |
+| `BifrostContextKeySessionTTL`              | `x-bf-session-ttl`                                   | `time.Duration`       | Session-to-key cache TTL (duration string or seconds)                                                                                 |
+| `BifrostContextKeyRequestID`               | `x-request-id`                                       | `string`              | Custom request ID for tracking                                                                                                        |
+| `BifrostContextKeySendBackRawRequest`      | `x-bf-send-back-raw-request`                         | `bool`                | Include raw provider request in the response                                                                                          |
+| `BifrostContextKeySendBackRawResponse`     | `x-bf-send-back-raw-response`                        | `bool`                | Include raw provider response in the response                                                                                         |
+| `BifrostContextKeyStoreRawRequestResponse` | `x-bf-store-raw-request-response`                    | `bool`                | Persist raw request/response in log records                                                                                           |
+| `BifrostContextKeyDisableContentLogging`   | `x-bf-disable-content-logging`                       | `bool`                | Per-request override for content logging; only honored when `allow_per_request_content_storage_override` is enabled in logging config |
+| `BifrostContextKeyPassthroughExtraParams`  | `x-bf-passthrough-extra-params`                      | `bool`                | Enable passthrough for extra parameters                                                                                               |
+| `BifrostContextKeyExtraHeaders`            | `x-bf-eh-*`                                          | `map[string][]string` | Custom headers forwarded to provider                                                                                                  |
+| `BifrostContextKeyDirectKey`               | `-`                                                  | `schemas.Key`         | Direct key credentials (Go SDK only)                                                                                                  |
+| `BifrostContextKeySkipKeySelection`        | `-`                                                  | `bool`                | Skip key selection process (Go SDK only)                                                                                              |
+| `BifrostContextKeyURLPath`                 | `-`                                                  | `string`              | Custom URL path appended to provider base URL (Go SDK only)                                                                           |
+| `BifrostContextKeyUseRawRequestBody`       | `-`                                                  | `bool`                | Use raw request body (Go SDK only, requires RawRequestBody field)                                                                     |
+| `semanticcache.CacheKey`                   | `x-bf-cache-key`                                     | `string`              | Custom cache key                                                                                                                      |
+| `semanticcache.CacheTTLKey`                | `x-bf-cache-ttl`                                     | `time.Duration`       | Cache TTL (duration string or seconds)                                                                                                |
+| `semanticcache.CacheThresholdKey`          | `x-bf-cache-threshold`                               | `float64`             | Similarity threshold (0.0-1.0)                                                                                                        |
+| `semanticcache.CacheTypeKey`               | `x-bf-cache-type`                                    | `string`              | Cache type                                                                                                                            |
+| `semanticcache.CacheNoStoreKey`            | `x-bf-cache-no-store`                                | `bool`                | Prevent caching                                                                                                                       |
+| `mcp-include-clients`                      | `x-bf-mcp-include-clients`                           | `[]string`            | Filter MCP clients (comma-separated).                                                                                                 |
+| `mcp-include-tools`                        | `x-bf-mcp-include-tools`                             | `[]string`            | Filter MCP tools (`clientName-toolName` format, comma-separated)                                                                      |
+| `BifrostContextKeyMCPExtraHeaders`         | _(any header in a client's `allowed_extra_headers`)_ | `map[string][]string` | Headers forwarded to MCP servers at tool execution time, filtered per-client against `allowed_extra_headers`                          |
+| `maxim.TraceIDKey`                         | `x-bf-maxim-trace-id`                                | `string`              | Maxim trace ID                                                                                                                        |
+| `maxim.GenerationIDKey`                    | `x-bf-maxim-generation-id`                           | `string`              | Maxim generation ID                                                                                                                   |
+| `maxim.TagsKey`                            | `x-bf-maxim-*`                                       | `map[string]string`   | Maxim tags (custom tag names)                                                                                                         |
+| `BifrostContextKey(labelName)`             | `x-bf-prom-*`                                        | `string`              | Prometheus metric labels                                                                                                              |
 
 ## Request Configuration Options
 
@@ -70,11 +70,12 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKeyVirtualKey, "sk-bf-*")
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
@@ -105,7 +106,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -113,11 +115,12 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKeyAPIKeyID, "key-uuid-1234")
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
@@ -140,7 +143,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -148,19 +152,20 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKeyAPIKeyName, "premium-key")
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
 ### Session Stickiness (Session ID)
 
-**Context Key:** `BifrostContextKeySessionID`  
-**Header:** `x-bf-session-id`  
-**Type:** `string`  
+**Context Key:** `BifrostContextKeySessionID`
+**Header:** `x-bf-session-id`
+**Type:** `string`
 **Required:** No
 
 Bind a session to a specific API key so that requests with the same session ID consistently use the same key. Useful for predictable rate-limit buckets, cost attribution per user, and consistent model routing per session.
@@ -181,7 +186,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -189,19 +195,20 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKeySessionID, "user-123-session-abc")
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
 ### Session TTL
 
-**Context Key:** `BifrostContextKeySessionTTL`  
-**Header:** `x-bf-session-ttl`  
-**Type:** `time.Duration` (header value: duration string like `"30m"` or `"1h"`, or seconds as integer)  
+**Context Key:** `BifrostContextKeySessionTTL`
+**Header:** `x-bf-session-ttl`
+**Type:** `time.Duration` (header value: duration string like `"30m"` or `"1h"`, or seconds as integer)
 **Required:** No
 
 Optional. Controls how long the session-to-key binding is cached. If not set, Bifrost uses 1 hour. The TTL is refreshed on each request so active sessions do not expire.
@@ -219,7 +226,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -228,19 +236,20 @@ ctx = context.WithValue(ctx, schemas.BifrostContextKeySessionID, "user-123-sessi
 ctx = context.WithValue(ctx, schemas.BifrostContextKeySessionTTL, 30*time.Minute)
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
 ### Request ID
 
-**Context Key:** `BifrostContextKeyRequestID`  
-**Header:** `x-request-id`  
-**Type:** `string`  
+**Context Key:** `BifrostContextKeyRequestID`
+**Header:** `x-request-id`
+**Type:** `string`
 **Required:** No
 
 Set a custom request ID for tracking and correlation. If not provided, Bifrost generates a UUID.
@@ -255,7 +264,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -263,22 +273,27 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKeyRequestID, "req-12345-abc")
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
 ### Send Back Raw Request
 
-**Context Key:** `BifrostContextKeySendBackRawRequest`  
-**Header:** `x-bf-send-back-raw-request`  
-**Type:** `bool` (header values: `"true"` or `"false"`)  
+**Context Key:** `BifrostContextKeySendBackRawRequest`
+**Header:** `x-bf-send-back-raw-request`
+**Type:** `bool` (header values: `"true"` or `"false"`)
 **Required:** No
 
 Include the exact JSON body sent to the provider alongside Bifrost's standardized response. Accepts `"true"` or `"false"` — either value fully overrides the provider-level `send_back_raw_request` config for this request.
+
+<Warning>
+Per-request overrides are **disabled by default**. You must first enable `allow_per_request_raw_override` in your logging configuration (or in the UI under **Logs Settings**) before this header or context key has any effect. This flag controls only what is **sent back to the caller** — it does not affect log storage. To persist raw bytes in logs, use `x-bf-store-raw-request-response` (gated by `allow_per_request_content_storage_override`).
+</Warning>
 
 <Tabs>
 <Tab title="Gateway (cURL)">
@@ -290,7 +305,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -298,16 +314,17 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKeySendBackRawRequest, true)
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
 
 // Access raw request
 if response.ChatResponse != nil {
-    rawReq := response.ChatResponse.ExtraFields.RawRequest
+rawReq := response.ChatResponse.ExtraFields.RawRequest
 }
-```
+
+````
 </Tab>
 </Tabs>
 
@@ -324,7 +341,7 @@ The raw request appears in `extra_fields.raw_request`:
         }
     }
 }
-```
+````
 
 ### Send Back Raw Response
 
@@ -334,6 +351,10 @@ The raw request appears in `extra_fields.raw_request`:
 **Required:** No
 
 Include the original provider response alongside Bifrost's standardized response format. Accepts `"true"` or `"false"` — either value fully overrides the provider-level `send_back_raw_response` config for this request.
+
+<Warning>
+Per-request overrides are **disabled by default**. You must first enable `allow_per_request_raw_override` in your logging configuration (or in the UI under **Logs Settings**) before this header or context key has any effect. This flag controls only what is **sent back to the caller** — it does not affect log storage. To persist raw bytes in logs, use `x-bf-store-raw-request-response` (gated by `allow_per_request_content_storage_override`).
+</Warning>
 
 <Tabs>
 <Tab title="Gateway (cURL)">
@@ -353,16 +374,17 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKeySendBackRawResponse, true)
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
 
 // Access raw response
 if response.ChatResponse != nil {
-    rawResp := response.ChatResponse.ExtraFields.RawResponse
+rawResp := response.ChatResponse.ExtraFields.RawResponse
 }
-```
+
+````
 </Tab>
 </Tabs>
 
@@ -379,7 +401,7 @@ The raw response appears in `extra_fields.raw_response`:
         }
     }
 }
-```
+````
 
 ### Store Raw Request/Response
 
@@ -391,6 +413,10 @@ The raw response appears in `extra_fields.raw_response`:
 Persist the raw provider request and response in the log record. Accepts `"true"` or `"false"` — either value fully overrides the provider-level `store_raw_request_response` config for this request.
 
 This is orthogonal to the send-back flags: enabling this does not affect whether raw data appears in the API response, and enabling send-back does not automatically store raw data in logs. Use this when you want observability into provider payloads without necessarily exposing them to the caller, or combine it with `x-bf-send-back-raw-*` to do both.
+
+<Warning>
+Per-request overrides are **disabled by default**. You must first enable `allow_per_request_content_storage_override` in your logging configuration (or in the UI under **Logs Settings**) before this header or context key has any effect. Note that this is gated by the **content storage** override, not the raw override — `allow_per_request_raw_override` only gates `x-bf-send-back-raw-request` and `x-bf-send-back-raw-response` (sending raw bytes back to the caller).
+</Warning>
 
 <Tabs>
 <Tab title="Gateway (cURL)">
@@ -410,13 +436,14 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKeyStoreRawRequestResponse, true)
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
 // Raw data is persisted in the log record.
 // ExtraFields.RawRequest/RawResponse are nil unless send-back flags are also enabled.
-```
+
+````
 </Tab>
 </Tabs>
 
@@ -426,11 +453,66 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
 `x-bf-store-raw-request-response` and `x-bf-send-back-raw-*` are orthogonal — you can enable any combination. Enabling store does not send data back to the caller; enabling send-back does not persist data in logs. Enable both to do both.
 </Note>
 
+### Disable Content Logging (Per-Request)
+
+**Context Key:** `BifrostContextKeyDisableContentLogging`
+**Header:** `x-bf-disable-content-logging`
+**Type:** `bool` (header values: `"true"` or `"false"`)
+**Required:** No
+
+Override the logging plugin's global `disable_content_logging` config for a single request. When set to `true`, messages, parameters, tool arguments, and tool results are omitted from the log record for that request. When set to `false`, content is recorded even if the global toggle is off.
+
+This is useful when you need to suppress sensitive data (e.g. PII, credentials) for specific requests while keeping content logging enabled globally.
+
+<Warning>
+Per-request overrides are **disabled by default**. You must first enable `allow_per_request_content_storage_override` in your logging configuration (or in the UI under **Logs Settings**) before this header or context key has any effect. When the toggle is off, the global `disable_content_logging` setting is authoritative and this value is ignored.
+</Warning>
+
+<Tabs>
+<Tab title="Gateway (cURL)">
+```bash
+# Suppress content for this request only
+curl --location 'http://localhost:8080/v1/chat/completions' \
+--header 'x-bf-disable-content-logging: true' \
+--header 'Content-Type: application/json' \
+--data '{
+    "model": "openai/gpt-4o-mini",
+    "messages": [{"role": "user", "content": "Sensitive data here"}]
+}'
+````
+
+</Tab>
+<Tab title="Go SDK">
+```go
+ctx := context.Background()
+bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+
+// Suppress content logging for this request
+bfCtx.SetValue(schemas.BifrostContextKeyDisableContentLogging, true)
+
+response, err := client.ChatCompletionRequest(bfCtx, &schemas.BifrostChatRequest{
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
+})
+
+````
+</Tab>
+</Tabs>
+
+**Prerequisite:** `allow_per_request_content_storage_override` must be `true` in the logging plugin config (set in `config.json` or via the UI).
+
+**Precedence (when override is enabled):** The per-request value takes precedence over the global `disable_content_logging` setting. A value of `true` suppresses content; `false` forces content on.
+
+<Note>
+This flag affects only what is written to the log record (messages, params, tool results, raw request/response). Token counts, latency, cost, status, and routing metadata are always logged regardless of this setting.
+</Note>
+
 ### Passthrough Extra Parameters
 
-**Context Key:** `BifrostContextKeyPassthroughExtraParams`  
-**Header:** `x-bf-passthrough-extra-params`  
-**Type:** `bool` (header value: `"true"`)  
+**Context Key:** `BifrostContextKeyPassthroughExtraParams`
+**Header:** `x-bf-passthrough-extra-params`
+**Type:** `bool` (header value: `"true"`)
 **Required:** No
 
 Enable passthrough mode for extra parameters. When enabled, any parameters in `extra_params` (or provider-specific extra parameter fields) will be merged directly into the request sent to the provider.
@@ -450,7 +532,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
         "b": 123
     }
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -458,20 +541,21 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKeyPassthroughExtraParams, true)
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
-    Params: &schemas.ChatParameters{
-        ExtraParams: map[string]interface{}{
-            "custom_param":  "value",
-            "nested_param": map[string]interface{}{
-                "a": "value",
-                "b": 123,
-            },
-        },
-    },
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
+Params: &schemas.ChatParameters{
+ExtraParams: map[string]interface{}{
+"custom_param": "value",
+"nested_param": map[string]interface{}{
+"a": "value",
+"b": 123,
+},
+},
+},
 })
-```
+
+````
 </Tab>
 </Tabs>
 
@@ -483,9 +567,9 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
 
 ### Direct Key (Go SDK Only)
 
-**Context Key:** `BifrostContextKeyDirectKey`  
-**Header:** `-` (not available via HTTP)  
-**Type:** `schemas.Key`  
+**Context Key:** `BifrostContextKeyDirectKey`
+**Header:** `-` (not available via HTTP)
+**Type:** `schemas.Key`
 **Required:** No
 
 Bypass key selection and provide credentials directly. Useful for dynamic key scenarios.
@@ -504,7 +588,7 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
     Model:    "gpt-4o",
     Input:    messages,
 })
-```
+````
 
 ### Skip Key Selection (Go SDK Only)
 
@@ -574,12 +658,14 @@ response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, sch
 ```
 
 <Note>
-When using raw request body, Bifrost bypasses its request conversion and sends your payload directly to the provider. You're responsible for ensuring the payload matches the provider's expected format.
+  When using raw request body, Bifrost bypasses its request conversion and sends
+  your payload directly to the provider. You're responsible for ensuring the
+  payload matches the provider's expected format.
 </Note>
 
 ## Custom Headers
 
-### Extra Headers (x-bf-eh-*)
+### Extra Headers (x-bf-eh-\*)
 
 **Context Key:** `BifrostContextKeyExtraHeaders`  
 **Header Pattern:** `x-bf-eh-{header-name}`  
@@ -611,11 +697,12 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKeyExtraHeaders, extraHeaders)
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
@@ -633,9 +720,9 @@ These options control semantic caching behavior.
 
 ### Cache Key
 
-**Context Key:** `semanticcache.CacheKey`  
-**Header:** `x-bf-cache-key`  
-**Type:** `string`  
+**Context Key:** `semanticcache.CacheKey`
+**Header:** `x-bf-cache-key`
+**Type:** `string`
 **Required:** No
 
 Specify a custom cache key for semantic cache lookups.
@@ -650,7 +737,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -658,19 +746,20 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, semanticcache.CacheKey, "custom-key-123")
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
 ### Cache TTL
 
-**Context Key:** `semanticcache.CacheTTLKey`  
-**Header:** `x-bf-cache-ttl`  
-**Type:** `time.Duration` (header value: duration string like `"30s"` or `"5m"`, or seconds as integer)  
+**Context Key:** `semanticcache.CacheTTLKey`
+**Header:** `x-bf-cache-ttl`
+**Type:** `time.Duration` (header value: duration string like `"30s"` or `"5m"`, or seconds as integer)
 **Required:** No
 
 Set a custom time-to-live for cached responses.
@@ -685,7 +774,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -693,11 +783,12 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, semanticcache.CacheTTLKey, 5*time.Minute)
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
@@ -705,9 +796,9 @@ Accepts duration strings (`"30s"`, `"5m"`, `"1h"`) or plain numbers (treated as 
 
 ### Cache Threshold
 
-**Context Key:** `semanticcache.CacheThresholdKey`  
-**Header:** `x-bf-cache-threshold`  
-**Type:** `float64` (range: 0.0 to 1.0)  
+**Context Key:** `semanticcache.CacheThresholdKey`
+**Header:** `x-bf-cache-threshold`
+**Type:** `float64` (range: 0.0 to 1.0)
 **Required:** No
 
 Set the similarity threshold for semantic cache matching.
@@ -722,7 +813,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -730,19 +822,20 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, semanticcache.CacheThresholdKey, 0.85)
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
 ### Cache Type
 
-**Context Key:** `semanticcache.CacheTypeKey`  
-**Header:** `x-bf-cache-type`  
-**Type:** `semanticcache.CacheType` (string)  
+**Context Key:** `semanticcache.CacheTypeKey`
+**Header:** `x-bf-cache-type`
+**Type:** `semanticcache.CacheType` (string)
 **Required:** No
 
 Specify the cache type for this request.
@@ -757,7 +850,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -765,19 +859,20 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, semanticcache.CacheTypeKey, semanticcache.CacheTypeSemantic)
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
 ### Cache No Store
 
-**Context Key:** `semanticcache.CacheNoStoreKey`  
-**Header:** `x-bf-cache-no-store`  
-**Type:** `bool` (header value: `"true"`)  
+**Context Key:** `semanticcache.CacheNoStoreKey`
+**Header:** `x-bf-cache-no-store`
+**Type:** `bool` (header value: `"true"`)
 **Required:** No
 
 Prevent caching of this request/response.
@@ -792,7 +887,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -800,11 +896,12 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, semanticcache.CacheNoStoreKey, true)
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
@@ -814,9 +911,9 @@ These options control MCP client and tool filtering.
 
 ### Include Clients
 
-**Context Key:** `mcp-include-clients`  
-**Header:** `x-bf-mcp-include-clients`  
-**Type:** `[]string` (comma-separated values)  
+**Context Key:** `mcp-include-clients`
+**Header:** `x-bf-mcp-include-clients`
+**Type:** `[]string` (comma-separated values)
 **Required:** No
 
 Filter MCP clients to include only the specified ones.
@@ -831,7 +928,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -839,11 +937,12 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKey("mcp-include-clients"), []string{"client1", "client2"})
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
@@ -866,7 +965,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -874,11 +974,12 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, schemas.BifrostContextKey("mcp-include-tools"), []string{"gmail-send_email", "filesystem-read_file"})
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
@@ -888,9 +989,9 @@ These options enable Maxim observability integration and tag propagation.
 
 ### Maxim Trace ID
 
-**Context Key:** `maxim.TraceIDKey`  
-**Header:** `x-bf-maxim-trace-id`  
-**Type:** `string`  
+**Context Key:** `maxim.TraceIDKey`
+**Header:** `x-bf-maxim-trace-id`
+**Type:** `string`
 **Required:** No
 
 Set the Maxim trace ID for distributed tracing.
@@ -905,7 +1006,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -913,19 +1015,20 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, maxim.TraceIDKey, "trace-12345")
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
 ### Maxim Generation ID
 
-**Context Key:** `maxim.GenerationIDKey`  
-**Header:** `x-bf-maxim-generation-id`  
-**Type:** `string`  
+**Context Key:** `maxim.GenerationIDKey`
+**Header:** `x-bf-maxim-generation-id`
+**Type:** `string`
 **Required:** No
 
 Set the Maxim generation ID for request correlation.
@@ -940,7 +1043,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -948,19 +1052,20 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, maxim.GenerationIDKey, "gen-12345")
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
 ### Maxim Tags (x-bf-maxim-*)
 
-**Context Key:** `maxim.TagsKey`  
-**Header Pattern:** `x-bf-maxim-{tag-name}`  
-**Type:** `map[string]string`  
+**Context Key:** `maxim.TagsKey`
+**Header Pattern:** `x-bf-maxim-{tag-name}`
+**Type:** `map[string]string`
 **Required:** No
 
 Add custom tags to Maxim traces. Any header starting with `x-bf-maxim-` that isn't a reserved header becomes a tag.
@@ -976,7 +1081,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -988,19 +1094,20 @@ ctx := context.Background()
 ctx = context.WithValue(ctx, maxim.TagsKey, tags)
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
-```
+
+````
 </Tab>
 </Tabs>
 
 ## Prometheus Options
 
-**Context Key:** `BifrostContextKey(labelName)`  
-**Header Pattern:** `x-bf-prom-{label-name}`  
-**Type:** `string`  
+**Context Key:** `BifrostContextKey(labelName)`
+**Header Pattern:** `x-bf-prom-{label-name}`
+**Type:** `string`
 **Required:** No
 
 Add custom labels to Prometheus metrics. The `x-bf-prom-` prefix is stripped and the remainder becomes the label name.
@@ -1016,7 +1123,8 @@ curl --location 'http://localhost:8080/v1/chat/completions' \
     "model": "openai/gpt-4o-mini",
     "messages": [{"role": "user", "content": "Hello!"}]
 }'
-```
+````
+
 </Tab>
 <Tab title="Go SDK">
 ```go
@@ -1025,10 +1133,11 @@ ctx = context.WithValue(ctx, schemas.BifrostContextKey("environment"), "producti
 ctx = context.WithValue(ctx, schemas.BifrostContextKey("team"), "engineering")
 
 response, err := client.ChatCompletionRequest(schemas.NewBifrostContext(ctx, schemas.NoDeadline), &schemas.BifrostChatRequest{
-    Provider: schemas.OpenAI,
-    Model:    "gpt-4o-mini",
-    Input:    messages,
+Provider: schemas.OpenAI,
+Model: "gpt-4o-mini",
+Input: messages,
 })
+
 ```
 </Tab>
 </Tabs>
@@ -1048,7 +1157,7 @@ Bifrost maintains a security denylist of headers that are **never** forwarded to
 - `x-bf-api-key` (when used via `x-bf-eh-*`)
 - `x-bf-vk` (when used via `x-bf-eh-*`)
 
-## Internal Context Keys 
+## Internal Context Keys
 <Warning>
 These context keys are read-only and set when request is completed. **Do not set these values.**
 </Warning>
@@ -1069,3 +1178,4 @@ The following context keys are set by Bifrost internally.
 - **[Go SDK Context Keys](../quickstart/go-sdk/context-keys)** - Programmatic context key usage
 - **[Virtual Keys](../features/governance/virtual-keys)** - Virtual key usage and governance
 - **[Semantic Cache](../features/semantic-caching)** - Caching configuration
+```

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -46,34 +46,36 @@ type CompatConfig struct {
 // ClientConfig represents the core configuration for Bifrost HTTP transport and the Bifrost Client.
 // It includes settings for excess request handling, Prometheus metrics, and initial pool size.
 type ClientConfig struct {
-	DropExcessRequests              bool                             `json:"drop_excess_requests"`    // Drop excess requests if the provider queue is full
-	InitialPoolSize                 int                              `json:"initial_pool_size"`       // The initial pool size for the bifrost client
-	PrometheusLabels                []string                         `json:"prometheus_labels"`       // The labels to be used for prometheus metrics
-	EnableLogging                   *bool                            `json:"enable_logging"`          // Enable logging of requests and responses
-	DisableContentLogging           bool                             `json:"disable_content_logging"` // Disable logging of content
-	DisableDBPingsInHealth          bool                             `json:"disable_db_pings_in_health"`
-	LogRetentionDays                int                              `json:"log_retention_days" validate:"min=1"`  // Number of days to retain logs (minimum 1 day)
-	EnforceAuthOnInference          bool                             `json:"enforce_auth_on_inference"`            // Require auth (VK, API key, or user token) on inference endpoints
-	EnforceGovernanceHeader         bool                             `json:"enforce_governance_header,omitempty"`  // Deprecated: use EnforceAuthOnInference
-	EnforceSCIMAuth                 bool                             `json:"enforce_scim_auth,omitempty"`          // Deprecated: use EnforceAuthOnInference
-	AllowDirectKeys                 bool                             `json:"allow_direct_keys"`                    // Allow direct keys to be used for requests
-	AllowedOrigins                  []string                         `json:"allowed_origins,omitempty"`            // Additional allowed origins for CORS and WebSocket (localhost is always allowed)
-	AllowedHeaders                  []string                         `json:"allowed_headers,omitempty"`            // Additional allowed headers for CORS and WebSocket
-	MaxRequestBodySizeMB            int                              `json:"max_request_body_size_mb"`             // The maximum request body size in MB
-	Compat                          CompatConfig                     `json:"compat"`                               // Compat plugin configuration
-	MCPAgentDepth                   int                              `json:"mcp_agent_depth"`                      // The maximum depth for MCP agent mode tool execution
-	MCPToolExecutionTimeout         int                              `json:"mcp_tool_execution_timeout"`           // The timeout for individual tool execution in seconds
-	MCPCodeModeBindingLevel         string                           `json:"mcp_code_mode_binding_level"`          // Code mode binding level: "server" or "tool"
-	MCPToolSyncInterval             int                              `json:"mcp_tool_sync_interval"`               // Global tool sync interval in minutes (default: 10, 0 = disabled)
-	MCPDisableAutoToolInject        bool                             `json:"mcp_disable_auto_tool_inject"`         // When true, MCP tools are not injected into requests by default
-	HeaderFilterConfig              *tables.GlobalHeaderFilterConfig `json:"header_filter_config,omitempty"`       // Global header filtering configuration for x-bf-eh-* headers
-	AsyncJobResultTTL               int                              `json:"async_job_result_ttl"`                 // Default TTL for async job results in seconds (default: 3600 = 1 hour)
-	RequiredHeaders                 []string                         `json:"required_headers,omitempty"`           // Headers that must be present on every request (case-insensitive)
-	LoggingHeaders                  []string                         `json:"logging_headers,omitempty"`            // Headers to capture in log metadata
-	WhitelistedRoutes               []string                         `json:"whitelisted_routes,omitempty"`         // Routes that bypass auth middleware
-	HideDeletedVirtualKeysInFilters bool                             `json:"hide_deleted_virtual_keys_in_filters"` // Hide deleted virtual keys from logs/MCP filter data
-	RoutingChainMaxDepth            int                              `json:"routing_chain_max_depth"`              // Maximum depth for routing rule chain evaluation (default: 10)
-	ConfigHash                      string                           `json:"-"`                                    // Config hash for reconciliation (not serialized)
+	DropExcessRequests                    bool                             `json:"drop_excess_requests"`                       // Drop excess requests if the provider queue is full
+	InitialPoolSize                       int                              `json:"initial_pool_size"`                          // The initial pool size for the bifrost client
+	PrometheusLabels                      []string                         `json:"prometheus_labels"`                          // The labels to be used for prometheus metrics
+	EnableLogging                         *bool                            `json:"enable_logging"`                             // Enable logging of requests and responses
+	DisableContentLogging                 bool                             `json:"disable_content_logging"`                    // Disable logging of content
+	AllowPerRequestContentStorageOverride bool                             `json:"allow_per_request_content_storage_override"` // Allow per-request override of content storage via x-bf-disable-content-logging header/context
+	AllowPerRequestRawOverride            bool                             `json:"allow_per_request_raw_override"`             // Allow per-request override of raw request/response visibility via x-bf-send-back-raw-request and x-bf-send-back-raw-response headers
+	DisableDBPingsInHealth                bool                             `json:"disable_db_pings_in_health"`
+	LogRetentionDays                      int                              `json:"log_retention_days" validate:"min=1"`  // Number of days to retain logs (minimum 1 day)
+	EnforceAuthOnInference                bool                             `json:"enforce_auth_on_inference"`            // Require auth (VK, API key, or user token) on inference endpoints
+	EnforceGovernanceHeader               bool                             `json:"enforce_governance_header,omitempty"`  // Deprecated: use EnforceAuthOnInference
+	EnforceSCIMAuth                       bool                             `json:"enforce_scim_auth,omitempty"`          // Deprecated: use EnforceAuthOnInference
+	AllowDirectKeys                       bool                             `json:"allow_direct_keys"`                    // Allow direct keys to be used for requests
+	AllowedOrigins                        []string                         `json:"allowed_origins,omitempty"`            // Additional allowed origins for CORS and WebSocket (localhost is always allowed)
+	AllowedHeaders                        []string                         `json:"allowed_headers,omitempty"`            // Additional allowed headers for CORS and WebSocket
+	MaxRequestBodySizeMB                  int                              `json:"max_request_body_size_mb"`             // The maximum request body size in MB
+	Compat                                CompatConfig                     `json:"compat"`                               // Compat plugin configuration
+	MCPAgentDepth                         int                              `json:"mcp_agent_depth"`                      // The maximum depth for MCP agent mode tool execution
+	MCPToolExecutionTimeout               int                              `json:"mcp_tool_execution_timeout"`           // The timeout for individual tool execution in seconds
+	MCPCodeModeBindingLevel               string                           `json:"mcp_code_mode_binding_level"`          // Code mode binding level: "server" or "tool"
+	MCPToolSyncInterval                   int                              `json:"mcp_tool_sync_interval"`               // Global tool sync interval in minutes (default: 10, 0 = disabled)
+	MCPDisableAutoToolInject              bool                             `json:"mcp_disable_auto_tool_inject"`         // When true, MCP tools are not injected into requests by default
+	HeaderFilterConfig                    *tables.GlobalHeaderFilterConfig `json:"header_filter_config,omitempty"`       // Global header filtering configuration for x-bf-eh-* headers
+	AsyncJobResultTTL                     int                              `json:"async_job_result_ttl"`                 // Default TTL for async job results in seconds (default: 3600 = 1 hour)
+	RequiredHeaders                       []string                         `json:"required_headers,omitempty"`           // Headers that must be present on every request (case-insensitive)
+	LoggingHeaders                        []string                         `json:"logging_headers,omitempty"`            // Headers to capture in log metadata
+	WhitelistedRoutes                     []string                         `json:"whitelisted_routes,omitempty"`         // Routes that bypass auth middleware
+	HideDeletedVirtualKeysInFilters       bool                             `json:"hide_deleted_virtual_keys_in_filters"` // Hide deleted virtual keys from logs/MCP filter data
+	RoutingChainMaxDepth                  int                              `json:"routing_chain_max_depth"`              // Maximum depth for routing rule chain evaluation (default: 10)
+	ConfigHash                            string                           `json:"-"`                                    // Config hash for reconciliation (not serialized)
 }
 
 // GenerateClientConfigHash generates a SHA256 hash of the client configuration.
@@ -172,6 +174,15 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 	// Only hash non-default value to avoid legacy config hash churn on upgrade.
 	if c.MCPDisableAutoToolInject {
 		hash.Write([]byte("mcpDisableAutoToolInject:true"))
+	}
+
+	// Only hash non-default value to avoid legacy config hash churn on upgrade.
+	if c.AllowPerRequestContentStorageOverride {
+		hash.Write([]byte("allowPerRequestContentStorageOverride:true"))
+	}
+
+	if c.AllowPerRequestRawOverride {
+		hash.Write([]byte("allowPerRequestRawOverride:true"))
 	}
 
 	if c.AsyncJobResultTTL > 0 {

--- a/plugins/logging/changelog.md
+++ b/plugins/logging/changelog.md
@@ -1,0 +1,1 @@
+- feat: added per-request content logging toggle that overrides the global setting

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -106,6 +106,37 @@ func applyLargePayloadPreviewsToEntry(ctx *schemas.BifrostContext, entry *logsto
 	}
 }
 
+// sanitizeErrorForLogging returns a shallow copy of err with ExtraFields.RawRequest and
+// RawResponse cleared when raw-byte persistence is disabled, preventing raw bytes from
+// leaking into entry.ErrorDetails via JSON serialization.
+func sanitizeErrorForLogging(err *schemas.BifrostError, contentLoggingEnabled, shouldStoreRaw bool) *schemas.BifrostError {
+	if err == nil {
+		return nil
+	}
+	if contentLoggingEnabled && shouldStoreRaw {
+		return err
+	}
+	cloned := *err
+	cloned.ExtraFields.RawRequest = nil
+	cloned.ExtraFields.RawResponse = nil
+	return &cloned
+}
+
+// contentLoggingEnabled returns true if content (messages, params, tool results) should be
+// recorded for this request. The BifrostContextKeyDisableContentLogging per-request override is
+// only honored when BifrostContextKeyAllowPerRequestStorageOverride is true in context (set by
+// ConvertToBifrostContext from allow_per_request_content_storage_override config).
+func (p *LoggerPlugin) contentLoggingEnabled(ctx *schemas.BifrostContext) bool {
+	if ctx != nil {
+		if perRequestAllowed, _ := ctx.Value(schemas.BifrostContextKeyAllowPerRequestStorageOverride).(bool); perRequestAllowed {
+			if override, ok := ctx.Value(schemas.BifrostContextKeyDisableContentLogging).(bool); ok {
+				return !override
+			}
+		}
+	}
+	return p.disableContentLogging == nil || !*p.disableContentLogging
+}
+
 // scheduleDeferredUsageUpdate schedules a deferred usage update for the request.
 func (p *LoggerPlugin) scheduleDeferredUsageUpdate(ctx *schemas.BifrostContext, requestID string, usageAlreadyPresent bool) {
 	if usageAlreadyPresent || ctx == nil {
@@ -475,7 +506,7 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 		initialData.Object = "realtime.turn"
 	}
 
-	if p.disableContentLogging == nil || !*p.disableContentLogging {
+	if p.contentLoggingEnabled(ctx) {
 		inputHistory, responsesInputHistory := p.extractInputHistory(req)
 		initialData.InputHistory = inputHistory
 		initialData.ResponsesInputHistory = responsesInputHistory
@@ -713,7 +744,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 
 	requestType, _, originalModelRequested, resolvedModelUsed := bifrost.GetResponseFields(result, bifrostErr)
 	shouldStoreRaw, _ := ctx.Value(schemas.BifrostContextKeyShouldStoreRawInLogs).(bool)
-	contentLoggingEnabled := p.disableContentLogging == nil || !*p.disableContentLogging
+	contentLoggingEnabled := p.contentLoggingEnabled(ctx)
 
 	isFinalChunk := bifrost.IsFinalChunk(ctx)
 
@@ -746,7 +777,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 				CreatedAt: time.Now().UTC(),
 			}
 			applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
-			if data, err := sonic.Marshal(bifrostErr); err == nil {
+			if data, err := sonic.Marshal(sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)); err == nil {
 				entry.ErrorDetails = string(data)
 			}
 			entry.ErrorDetailsParsed = bifrostErr
@@ -827,7 +858,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			traceID != "" {
 			if accResult := tracer.ProcessStreamingChunk(traceID, true, result, bifrostErr); accResult != nil {
 				if streamResponse := convertToProcessedStreamResponse(accResult, requestType); streamResponse != nil {
-					p.applyStreamingOutputToEntry(entry, streamResponse, shouldStoreRaw)
+					p.applyStreamingOutputToEntry(entry, streamResponse, shouldStoreRaw, contentLoggingEnabled)
 				}
 			}
 			tracer.CleanupStreamAccumulator(traceID)
@@ -836,7 +867,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		// Serialize error details immediately since bifrostErr may be released
 		// back to the pool before the async batch writer processes this entry.
 		// Also set ErrorDetailsParsed for UI callback (JSON serialization uses this field).
-		if data, err := sonic.Marshal(bifrostErr); err == nil {
+		if data, err := sonic.Marshal(sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)); err == nil {
 			entry.ErrorDetails = string(data)
 		}
 		entry.ErrorDetailsParsed = bifrostErr
@@ -875,7 +906,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			entry.Status = "error"
 			entry.Stream = true
 			applyModelAlias(entry, originalModelRequested, resolvedModelUsed)
-			if data, err := sonic.Marshal(bifrostErr); err == nil {
+			if data, err := sonic.Marshal(sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)); err == nil {
 				entry.ErrorDetails = string(data)
 			}
 			entry.ErrorDetailsParsed = bifrostErr
@@ -887,7 +918,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		} else if isFinalChunk {
 			// Apply streaming output fields to the entry
 			entry.Stream = true
-			p.applyStreamingOutputToEntry(entry, streamResponse, shouldStoreRaw)
+			p.applyStreamingOutputToEntry(entry, streamResponse, shouldStoreRaw, contentLoggingEnabled)
 		}
 		if entry.ErrorDetails != "" || entry.ErrorDetailsParsed != nil {
 			entry.Status = "error"
@@ -926,7 +957,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		// Serialize error details immediately since bifrostErr may be released
 		// back to the pool before the async batch writer processes this entry.
 		// Also set ErrorDetailsParsed for UI callback (JSON serialization uses this field).
-		if data, err := sonic.Marshal(bifrostErr); err == nil {
+		if data, err := sonic.Marshal(sanitizeErrorForLogging(bifrostErr, contentLoggingEnabled, shouldStoreRaw)); err == nil {
 			entry.ErrorDetails = string(data)
 		}
 		entry.ErrorDetailsParsed = bifrostErr
@@ -940,9 +971,9 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		extraFields := result.GetExtraFields()
 		applyModelAlias(entry, extraFields.OriginalModelRequested, extraFields.ResolvedModelUsed)
 		if requestType == schemas.RealtimeRequest {
-			p.applyRealtimeOutputToEntry(entry, result, shouldStoreRaw)
+			p.applyRealtimeOutputToEntry(entry, result, shouldStoreRaw, contentLoggingEnabled)
 		} else {
-			p.applyNonStreamingOutputToEntry(entry, result, shouldStoreRaw)
+			p.applyNonStreamingOutputToEntry(entry, result, shouldStoreRaw, contentLoggingEnabled)
 		}
 		// Flip status for passthrough error responses (4xx/5xx from provider)
 		if isPassthroughErrorResponse(result) {
@@ -1161,7 +1192,7 @@ func (p *LoggerPlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 		}
 
 		// Set arguments if content logging is enabled
-		if p.disableContentLogging == nil || !*p.disableContentLogging {
+		if p.contentLoggingEnabled(ctx) {
 			entry.ArgumentsParsed = arguments
 		}
 
@@ -1262,7 +1293,7 @@ func (p *LoggerPlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schemas.Bi
 		} else if resp != nil {
 			updates["status"] = "success"
 			// Store result if content logging is enabled
-			if p.disableContentLogging == nil || !*p.disableContentLogging {
+			if p.contentLoggingEnabled(ctx) {
 				var result interface{}
 				if resp.ChatMessage != nil {
 					// For ChatMessage, try to parse the content as JSON if it's a string

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -147,6 +147,7 @@ func (p *LoggerPlugin) updateLogEntry(
 	cacheDebug *schemas.BifrostCacheDebug,
 	routingEngineLogs string,
 	data *UpdateLogData,
+	contentLoggingEnabled bool,
 ) error {
 	updates := make(map[string]interface{})
 	if selectedKeyID != "" {
@@ -177,7 +178,6 @@ func (p *LoggerPlugin) updateLogEntry(
 	if routingEngineLogs != "" {
 		updates["routing_engine_logs"] = routingEngineLogs
 	}
-	contentLoggingEnabled := p.disableContentLogging == nil || !*p.disableContentLogging
 	tempEntry := &logstore.Log{}
 	needsSerialization := false
 
@@ -294,12 +294,12 @@ func (p *LoggerPlugin) updateLogEntry(
 	if data.IsLargePayloadResponse {
 		updates["is_large_payload_response"] = true
 		// Large payload preview is already a string — skip sonic.Marshal.
-		if p.disableContentLogging == nil || !*p.disableContentLogging {
+		if contentLoggingEnabled {
 			if str, ok := data.RawResponse.(string); ok {
 				updates["raw_response"] = str
 			}
 		}
-	} else if (p.disableContentLogging == nil || !*p.disableContentLogging) && data.RawResponse != nil {
+	} else if contentLoggingEnabled && data.RawResponse != nil {
 		rawResponseBytes, err := sonic.Marshal(data.RawResponse)
 		if err != nil {
 			p.logger.Error("failed to marshal raw response: %v", err)
@@ -332,7 +332,7 @@ func (p *LoggerPlugin) makePostWriteCallback(enrichFn func(*logstore.Log)) func(
 
 // applyStreamingOutputToEntry applies accumulated streaming data to a log entry.
 // shouldStoreRaw gates whether raw request/response bytes are written to the entry.
-func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamResponse *streaming.ProcessedStreamResponse, shouldStoreRaw bool) {
+func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamResponse *streaming.ProcessedStreamResponse, shouldStoreRaw bool, contentLoggingEnabled bool) {
 	if streamResponse.Data == nil {
 		return
 	}
@@ -378,7 +378,17 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 		entry.StopReason = streamResponse.Data.FinishReason
 	}
 
-	if p.disableContentLogging == nil || !*p.disableContentLogging {
+	// Cache
+	if streamResponse.Data.CacheDebug != nil {
+		entry.CacheDebugParsed = streamResponse.Data.CacheDebug
+	}
+
+	// Finish/stop reason - always persist regardless of content logging settings
+	if streamResponse.Data.FinishReason != nil {
+		entry.StopReason = streamResponse.Data.FinishReason
+	}
+
+	if contentLoggingEnabled {
 		// Transcription output
 		if streamResponse.Data.TranscriptionOutput != nil {
 			entry.TranscriptionOutputParsed = streamResponse.Data.TranscriptionOutput
@@ -430,7 +440,7 @@ func isPassthroughErrorResponse(result *schemas.BifrostResponse) bool {
 
 // applyNonStreamingOutputToEntry applies non-streaming response data to a log entry.
 // shouldStoreRaw gates whether raw request/response bytes are written to the entry.
-func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, result *schemas.BifrostResponse, shouldStoreRaw bool) {
+func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, result *schemas.BifrostResponse, shouldStoreRaw bool, contentLoggingEnabled bool) {
 	if result == nil {
 		return
 	}
@@ -493,7 +503,7 @@ func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, resul
 		entry.StopReason = result.ResponsesResponse.StopReason
 	}
 
-	if p.disableContentLogging == nil || !*p.disableContentLogging {
+	if contentLoggingEnabled {
 		if shouldStoreRaw {
 			if extraFields.RawRequest != nil {
 				rawRequestBytes, err := sonic.Marshal(extraFields.RawRequest)
@@ -565,7 +575,7 @@ func (p *LoggerPlugin) applyNonStreamingOutputToEntry(entry *logstore.Log, resul
 	}
 }
 
-func (p *LoggerPlugin) applyRealtimeOutputToEntry(entry *logstore.Log, result *schemas.BifrostResponse, shouldStoreRaw bool) {
+func (p *LoggerPlugin) applyRealtimeOutputToEntry(entry *logstore.Log, result *schemas.BifrostResponse, shouldStoreRaw bool, contentLoggingEnabled bool) {
 	if result == nil || result.ResponsesResponse == nil {
 		return
 	}
@@ -582,8 +592,6 @@ func (p *LoggerPlugin) applyRealtimeOutputToEntry(entry *logstore.Log, result *s
 		entry.CompletionTokens = bifrostUsage.CompletionTokens
 		entry.TotalTokens = bifrostUsage.TotalTokens
 	}
-
-	contentLoggingEnabled := p.disableContentLogging == nil || !*p.disableContentLogging
 
 	if contentLoggingEnabled {
 		if outputMessage := extractRealtimeOutputMessage(result.ResponsesResponse.Output); outputMessage != nil {

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -75,7 +75,7 @@ func TestUpdateLogEntryPreservesResponsesInputContentSummary(t *testing.T) {
 		}},
 	}
 
-	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", update); err != nil {
+	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", update, true); err != nil {
 		t.Fatalf("updateLogEntry() error = %v", err)
 	}
 
@@ -121,7 +121,7 @@ func TestUpdateLogEntryUpdatesContentSummaryForChatOutput(t *testing.T) {
 		},
 	}
 
-	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", update); err != nil {
+	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", update, true); err != nil {
 		t.Fatalf("updateLogEntry() error = %v", err)
 	}
 
@@ -136,11 +136,9 @@ func TestUpdateLogEntryUpdatesContentSummaryForChatOutput(t *testing.T) {
 
 func TestUpdateLogEntrySuppressesChatOutputWhenContentLoggingDisabled(t *testing.T) {
 	store := newTestStore(t)
-	disableContentLogging := true
 	plugin := &LoggerPlugin{
-		store:                 store,
-		logger:                testLogger{},
-		disableContentLogging: &disableContentLogging,
+		store:  store,
+		logger: testLogger{},
 	}
 
 	requestID := "req-chat-disabled"
@@ -166,7 +164,7 @@ func TestUpdateLogEntrySuppressesChatOutputWhenContentLoggingDisabled(t *testing
 		},
 	}
 
-	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", update); err != nil {
+	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", update, false); err != nil {
 		t.Fatalf("updateLogEntry() error = %v", err)
 	}
 
@@ -292,7 +290,7 @@ func TestApplyRealtimeOutputToEntryBackfillsUserTranscriptFromRawRequest(t *test
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result, true)
+	plugin.applyRealtimeOutputToEntry(entry, result, true, true)
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error = %v", err)
 	}
@@ -341,7 +339,7 @@ func TestApplyRealtimeOutputToEntryBackfillsMissingTranscriptPlaceholder(t *test
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result, true)
+	plugin.applyRealtimeOutputToEntry(entry, result, true, true)
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error = %v", err)
 	}
@@ -381,7 +379,7 @@ func TestApplyRealtimeOutputToEntryBackfillsDoneMissingTranscriptPlaceholder(t *
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result, true)
+	plugin.applyRealtimeOutputToEntry(entry, result, true, true)
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error = %v", err)
 	}
@@ -421,7 +419,7 @@ func TestApplyRealtimeOutputToEntryBackfillsRetrievedUserAndToolHistory(t *testi
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result, true)
+	plugin.applyRealtimeOutputToEntry(entry, result, true, true)
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error = %v", err)
 	}
@@ -462,7 +460,7 @@ func TestApplyRealtimeOutputToEntryBackfillsCreatedUserAndToolHistory(t *testing
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result, true)
+	plugin.applyRealtimeOutputToEntry(entry, result, true, true)
 
 	if len(entry.InputHistoryParsed) != 2 {
 		t.Fatalf("len(InputHistoryParsed) = %d, want 2", len(entry.InputHistoryParsed))
@@ -513,7 +511,7 @@ func TestApplyRealtimeOutputToEntryBackfillsAddedUserAndToolHistory(t *testing.T
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result, true)
+	plugin.applyRealtimeOutputToEntry(entry, result, true, true)
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error = %v", err)
 	}
@@ -576,7 +574,7 @@ func TestApplyRealtimeOutputToEntryMergesRawTranscriptIntoStructuredRealtimeHist
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result, true)
+	plugin.applyRealtimeOutputToEntry(entry, result, true, true)
 	if err := entry.SerializeFields(); err != nil {
 		t.Fatalf("SerializeFields() error = %v", err)
 	}
@@ -628,7 +626,7 @@ func TestApplyRealtimeOutputToEntryDoesNotPersistRawWhenShouldStoreRawFalse(t *t
 		},
 	}
 
-	plugin.applyRealtimeOutputToEntry(entry, result, false)
+	plugin.applyRealtimeOutputToEntry(entry, result, false, true)
 
 	if entry.RawRequest != "" {
 		t.Fatalf("expected RawRequest to remain empty when shouldStoreRaw=false, got %q", entry.RawRequest)
@@ -641,5 +639,204 @@ func TestApplyRealtimeOutputToEntryDoesNotPersistRawWhenShouldStoreRawFalse(t *t
 	}
 	if entry.InputHistoryParsed[0].Role != schemas.ChatMessageRoleUser {
 		t.Fatalf("InputHistoryParsed[0].Role = %q, want user", entry.InputHistoryParsed[0].Role)
+	}
+}
+
+// TestContentLoggingEnabledHelper verifies precedence: ctx override > global config > default-enabled.
+func TestContentLoggingEnabledHelper(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name                  string
+		globalDisable         *bool
+		ctxOverride           *bool // nil = don't set the key
+		want                  bool
+	}{
+		{"no config no override → enabled", nil, nil, true},
+		{"global disable=false no override → enabled", boolPtr(false), nil, true},
+		{"global disable=true no override → disabled", boolPtr(true), nil, false},
+		{"ctx override=false global disable=true → enabled", boolPtr(true), boolPtr(false), true},
+		{"ctx override=true global disable=false → disabled", boolPtr(false), boolPtr(true), false},
+		{"ctx override=true nil global → disabled", nil, boolPtr(true), false},
+		{"ctx override=false nil global → enabled", nil, boolPtr(false), true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &LoggerPlugin{disableContentLogging: tc.globalDisable}
+
+			var ctx *schemas.BifrostContext
+			if tc.ctxOverride != nil {
+				ctx = schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+				ctx.SetValue(schemas.BifrostContextKeyAllowPerRequestStorageOverride, true)
+				ctx.SetValue(schemas.BifrostContextKeyDisableContentLogging, *tc.ctxOverride)
+			}
+
+			got := p.contentLoggingEnabled(ctx)
+			if got != tc.want {
+				t.Errorf("contentLoggingEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestContentLoggingEnabledHelperNilCtx verifies nil context falls back to global config.
+func TestContentLoggingEnabledHelperNilCtx(t *testing.T) {
+	disabled := true
+	p := &LoggerPlugin{disableContentLogging: &disabled}
+	if p.contentLoggingEnabled(nil) {
+		t.Error("expected false with nil ctx and global disable=true")
+	}
+}
+
+// TestUpdateLogEntryPerRequestOverrideEnablesContent verifies that passing contentLoggingEnabled=true
+// to updateLogEntry stores output even when the plugin's global toggle is disabled.
+func TestUpdateLogEntryPerRequestOverrideEnablesContent(t *testing.T) {
+	store := newTestStore(t)
+	disabled := true
+	plugin := &LoggerPlugin{
+		store:                 store,
+		logger:                testLogger{},
+		disableContentLogging: &disabled, // global: off
+	}
+
+	requestID := "req-per-request-enable"
+	now := time.Now().UTC()
+	if err := plugin.insertInitialLogEntry(context.Background(), requestID, "", now, 0, nil, &InitialLogData{
+		Object:   "chat_completion",
+		Provider: "openai",
+		Model:    "gpt-4o-mini",
+	}); err != nil {
+		t.Fatalf("insertInitialLogEntry() error = %v", err)
+	}
+
+	chatText := "should be stored via per-request override"
+	update := &UpdateLogData{
+		Status: "success",
+		ChatOutput: &schemas.ChatMessage{
+			Role:    schemas.ChatMessageRoleAssistant,
+			Content: &schemas.ChatMessageContent{ContentStr: &chatText},
+		},
+	}
+
+	// Explicitly pass true — simulates the per-request ctx override enabling content logging
+	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", update, true); err != nil {
+		t.Fatalf("updateLogEntry() error = %v", err)
+	}
+
+	logEntry, err := store.FindByID(context.Background(), requestID)
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if logEntry.OutputMessage == "" {
+		t.Error("expected output_message to be stored when contentLoggingEnabled=true override is used")
+	}
+}
+
+// TestUpdateLogEntryPerRequestOverrideDisablesContent verifies that passing contentLoggingEnabled=false
+// suppresses output even when the plugin's global toggle is enabled.
+func TestUpdateLogEntryPerRequestOverrideDisablesContent(t *testing.T) {
+	store := newTestStore(t)
+	plugin := &LoggerPlugin{
+		store:  store,
+		logger: testLogger{},
+		// global: nil → content logging on by default
+	}
+
+	requestID := "req-per-request-disable"
+	now := time.Now().UTC()
+	if err := plugin.insertInitialLogEntry(context.Background(), requestID, "", now, 0, nil, &InitialLogData{
+		Object:   "chat_completion",
+		Provider: "openai",
+		Model:    "gpt-4o-mini",
+	}); err != nil {
+		t.Fatalf("insertInitialLogEntry() error = %v", err)
+	}
+
+	chatText := "should NOT be stored"
+	update := &UpdateLogData{
+		Status: "success",
+		ChatOutput: &schemas.ChatMessage{
+			Role:    schemas.ChatMessageRoleAssistant,
+			Content: &schemas.ChatMessageContent{ContentStr: &chatText},
+		},
+	}
+
+	// Explicitly pass false — simulates x-bf-disable-content-logging: true on this request
+	if err := plugin.updateLogEntry(context.Background(), requestID, "", "", 10, "", "", "", "", 0, nil, "", update, false); err != nil {
+		t.Fatalf("updateLogEntry() error = %v", err)
+	}
+
+	logEntry, err := store.FindByID(context.Background(), requestID)
+	if err != nil {
+		t.Fatalf("FindByID() error = %v", err)
+	}
+	if logEntry.OutputMessage != "" {
+		t.Errorf("expected output_message to be suppressed, got %q", logEntry.OutputMessage)
+	}
+}
+
+// TestApplyNonStreamingOutputToEntryContentLoggingDisabled verifies that output fields are
+// suppressed when contentLoggingEnabled=false.
+func TestApplyNonStreamingOutputToEntryContentLoggingDisabled(t *testing.T) {
+	plugin := &LoggerPlugin{}
+	entry := &logstore.Log{}
+
+	chatText := "should not appear"
+	result := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+						Message: &schemas.ChatMessage{
+							Role:    schemas.ChatMessageRoleAssistant,
+							Content: &schemas.ChatMessageContent{ContentStr: &chatText},
+						},
+					},
+				},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ChatCompletionRequest,
+			},
+		},
+	}
+
+	plugin.applyNonStreamingOutputToEntry(entry, result, false, false)
+
+	if entry.OutputMessageParsed != nil {
+		t.Error("expected OutputMessageParsed to be nil when contentLoggingEnabled=false")
+	}
+}
+
+// TestApplyNonStreamingOutputToEntryContentLoggingEnabled verifies that output fields are
+// stored when contentLoggingEnabled=true regardless of the global plugin config.
+func TestApplyNonStreamingOutputToEntryContentLoggingEnabled(t *testing.T) {
+	disabled := true
+	plugin := &LoggerPlugin{disableContentLogging: &disabled} // global off, but explicit true passed
+	entry := &logstore.Log{}
+
+	chatText := "should appear"
+	result := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+						Message: &schemas.ChatMessage{
+							Role:    schemas.ChatMessageRoleAssistant,
+							Content: &schemas.ChatMessageContent{ContentStr: &chatText},
+						},
+					},
+				},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ChatCompletionRequest,
+			},
+		},
+	}
+
+	plugin.applyNonStreamingOutputToEntry(entry, result, false, true)
+
+	if entry.OutputMessageParsed == nil {
+		t.Error("expected OutputMessageParsed to be set when contentLoggingEnabled=true")
 	}
 }

--- a/transports/bifrost-http/handlers/asyncinference.go
+++ b/transports/bifrost-http/handlers/asyncinference.go
@@ -111,7 +111,7 @@ func (h *AsyncHandler) asyncTextCompletion(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -148,7 +148,7 @@ func (h *AsyncHandler) asyncChatCompletion(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -185,7 +185,7 @@ func (h *AsyncHandler) asyncResponses(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -218,7 +218,7 @@ func (h *AsyncHandler) asyncEmbeddings(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -255,7 +255,7 @@ func (h *AsyncHandler) asyncSpeech(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -292,7 +292,7 @@ func (h *AsyncHandler) asyncTranscription(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -329,7 +329,7 @@ func (h *AsyncHandler) asyncImageGeneration(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -366,7 +366,7 @@ func (h *AsyncHandler) asyncImageEdit(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -398,7 +398,7 @@ func (h *AsyncHandler) asyncImageVariation(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -430,7 +430,7 @@ func (h *AsyncHandler) asyncRerank(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
 		return
@@ -462,7 +462,7 @@ func (h *AsyncHandler) asyncOCR(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to convert context")
 		return
@@ -498,7 +498,7 @@ func (h *AsyncHandler) getJob(operationType schemas.RequestType) fasthttp.Reques
 		}
 
 		// Get the requesting user's VK for auth check
-		bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+		bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 		if bifrostCtx == nil {
 			SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 			return

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -721,7 +721,7 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 	provider := string(ctx.QueryArgs().Peek("provider"))
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel() // Ensure cleanup on function exit
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -854,7 +854,7 @@ func (h *CompletionHandler) textCompletion(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
 	}
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -965,7 +965,7 @@ func (h *CompletionHandler) chatCompletion(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -1059,7 +1059,7 @@ func (h *CompletionHandler) responses(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -1133,7 +1133,7 @@ func (h *CompletionHandler) embeddings(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -1226,7 +1226,7 @@ func (h *CompletionHandler) rerank(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -1316,7 +1316,7 @@ func (h *CompletionHandler) ocr(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -1388,7 +1388,7 @@ func (h *CompletionHandler) speech(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -1515,7 +1515,7 @@ func (h *CompletionHandler) transcription(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -1555,7 +1555,7 @@ func (h *CompletionHandler) countTokens(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -1965,7 +1965,7 @@ func (h *CompletionHandler) imageGeneration(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		cancel()
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -2173,7 +2173,7 @@ func (h *CompletionHandler) imageEdit(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -2316,7 +2316,7 @@ func (h *CompletionHandler) imageVariation(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
@@ -2385,7 +2385,7 @@ func (h *CompletionHandler) videoGeneration(ctx *fasthttp.RequestCtx) {
 		Fallbacks: fallbacks,
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	if bifrostCtx == nil {
 		cancel()
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -2439,7 +2439,7 @@ func (h *CompletionHandler) videoRetrieve(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -2497,7 +2497,7 @@ func (h *CompletionHandler) videoDownload(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -2559,7 +2559,7 @@ func (h *CompletionHandler) videoList(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -2610,7 +2610,7 @@ func (h *CompletionHandler) videoDelete(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -2687,7 +2687,7 @@ func (h *CompletionHandler) videoRemix(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -2755,7 +2755,7 @@ func (h *CompletionHandler) batchCreate(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -2815,7 +2815,7 @@ func (h *CompletionHandler) batchList(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -2861,7 +2861,7 @@ func (h *CompletionHandler) batchRetrieve(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -2907,7 +2907,7 @@ func (h *CompletionHandler) batchCancel(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -2953,7 +2953,7 @@ func (h *CompletionHandler) batchResults(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3042,7 +3042,7 @@ func (h *CompletionHandler) fileUpload(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3108,7 +3108,7 @@ func (h *CompletionHandler) fileList(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3154,7 +3154,7 @@ func (h *CompletionHandler) fileRetrieve(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3200,7 +3200,7 @@ func (h *CompletionHandler) fileDelete(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3246,7 +3246,7 @@ func (h *CompletionHandler) fileContent(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3307,7 +3307,7 @@ func (h *CompletionHandler) containerCreate(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3366,7 +3366,7 @@ func (h *CompletionHandler) containerList(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3413,7 +3413,7 @@ func (h *CompletionHandler) containerRetrieve(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3460,7 +3460,7 @@ func (h *CompletionHandler) containerDelete(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3557,7 +3557,7 @@ func (h *CompletionHandler) containerFileCreate(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3617,7 +3617,7 @@ func (h *CompletionHandler) containerFileList(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3672,7 +3672,7 @@ func (h *CompletionHandler) containerFileRetrieve(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3727,7 +3727,7 @@ func (h *CompletionHandler) containerFileContent(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -3782,7 +3782,7 @@ func (h *CompletionHandler) containerFileDelete(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore.ShouldAllowDirectKeys(), h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")

--- a/transports/bifrost-http/handlers/mcpinference.go
+++ b/transports/bifrost-http/handlers/mcpinference.go
@@ -60,7 +60,7 @@ func (h *MCPInferenceHandler) executeChatMCPTool(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, false, h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.config)
 	defer cancel() // Ensure cleanup on function exit
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
@@ -93,7 +93,7 @@ func (h *MCPInferenceHandler) executeResponsesMCPTool(ctx *fasthttp.RequestCtx) 
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, false, h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.config)
 	defer cancel() // Ensure cleanup on function exit
 	if bifrostCtx == nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -112,7 +112,7 @@ func (h *MCPServerHandler) handleMCPServer(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, false, h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.config)
 	defer cancel()
 
 	injectMCPSessionIdentity(bifrostCtx, session)
@@ -153,7 +153,7 @@ func (h *MCPServerHandler) handleMCPServerSSE(ctx *fasthttp.RequestCtx) {
 	ctx.Response.Header.Set("Connection", "keep-alive")
 
 	// Convert context
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, false, h.config.GetHeaderMatcher(), h.config.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.config)
 
 	injectMCPSessionIdentity(bifrostCtx, session)
 

--- a/transports/bifrost-http/handlers/realtime_client_secrets.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets.go
@@ -86,12 +86,7 @@ func (h *RealtimeClientSecretsHandler) handleRequest(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(
-		ctx,
-		h.handlerStore.ShouldAllowDirectKeys(),
-		h.config.GetHeaderMatcher(),
-		h.config.GetMCPHeaderCombinedAllowlist(),
-	)
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	bifrostCtx.SetValue(schemas.BifrostContextKeyHTTPRequestType, schemas.RealtimeRequest)
 	if route.DefaultProvider == schemas.OpenAI {

--- a/transports/bifrost-http/handlers/webrtc_realtime.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime.go
@@ -252,12 +252,7 @@ func (h *WebRTCRealtimeHandler) runWebRTCRelay(
 	sdpOffer string,
 	exchangeSDP func(ctx *schemas.BifrostContext, key schemas.Key, upstreamOffer string) (string, *schemas.BifrostError),
 ) {
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(
-		ctx,
-		h.handlerStore.ShouldAllowDirectKeys(),
-		h.config.GetHeaderMatcher(),
-		h.config.GetMCPHeaderCombinedAllowlist(),
-	)
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
 	bifrostCtx.SetValue(schemas.BifrostContextKeyHTTPRequestType, schemas.RealtimeRequest)
 	if strings.HasPrefix(string(ctx.Path()), "/openai") {

--- a/transports/bifrost-http/handlers/webrtc_realtime_test.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime_test.go
@@ -28,6 +28,8 @@ func (s testHandlerStore) GetAsyncJobExecutor() *logstore.AsyncJobExecutor  { re
 func (s testHandlerStore) GetAsyncJobResultTTL() int                        { return 0 }
 func (s testHandlerStore) GetKVStore() *kvstore.Store                       { return s.kv }
 func (s testHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList { return nil }
+func (s testHandlerStore) ShouldAllowPerRequestStorageOverride() bool       { return false }
+func (s testHandlerStore) ShouldAllowPerRequestRawOverride() bool           { return false }
 
 func TestResolveRealtimeSDPTarget_BaseRouteRequiresProviderPrefix(t *testing.T) {
 	_, _, _, err := resolveRealtimeSDPTarget("/v1/realtime", []byte(`{"model":"gpt-4o-realtime-preview"}`))

--- a/transports/bifrost-http/handlers/wsresponses_test.go
+++ b/transports/bifrost-http/handlers/wsresponses_test.go
@@ -50,6 +50,9 @@ func (s testWSHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList {
 	return nil
 }
 
+func (s testWSHandlerStore) ShouldAllowPerRequestStorageOverride() bool { return false }
+func (s testWSHandlerStore) ShouldAllowPerRequestRawOverride() bool    { return false }
+
 type timeoutNetError struct{}
 
 func (timeoutNetError) Error() string   { return "i/o timeout" }

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -54,6 +54,14 @@ func (m *mockHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList {
 	return m.mcpHeaderCombinedAllowlist
 }
 
+func (m *mockHandlerStore) ShouldAllowPerRequestStorageOverride() bool {
+	return false
+}
+
+func (m *mockHandlerStore) ShouldAllowPerRequestRawOverride() bool {
+	return false
+}
+
 // Ensure mockHandlerStore implements lib.HandlerStore
 var _ lib.HandlerStore = (*mockHandlerStore)(nil)
 

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -616,7 +616,7 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 		var rawBody []byte
 
 		// Execute the request through Bifrost
-		bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, g.handlerStore.ShouldAllowDirectKeys(), g.handlerStore.GetHeaderMatcher(), g.handlerStore.GetMCPHeaderCombinedAllowlist())
+		bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, g.handlerStore)
 
 		// Set integration type to context
 		bifrostCtx.SetValue(schemas.BifrostContextKeyIntegrationType, string(config.Type))
@@ -2683,7 +2683,7 @@ func (g *GenericRouter) handlePassthrough(ctx *fasthttp.RequestCtx) {
 		return true
 	})
 
-	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, g.handlerStore.ShouldAllowDirectKeys(), g.handlerStore.GetHeaderMatcher(), g.handlerStore.GetMCPHeaderCombinedAllowlist())
+	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, g.handlerStore)
 	if directKey := ctx.UserValue(string(schemas.BifrostContextKeyDirectKey)); directKey != nil {
 		if key, ok := directKey.(schemas.Key); ok {
 			bifrostCtx.SetValue(schemas.BifrostContextKeyDirectKey, key)

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -79,6 +79,10 @@ type HandlerStore interface {
 	GetKVStore() *kvstore.Store
 	// GetMCPHeaderCombinedAllowlist returns the combined allowlist for MCP headers
 	GetMCPHeaderCombinedAllowlist() schemas.WhiteList
+	// ShouldAllowPerRequestStorageOverride returns whether per-request overrides for content storage are permitted
+	ShouldAllowPerRequestStorageOverride() bool
+	// ShouldAllowPerRequestRawOverride returns whether per-request overrides for raw request/response visibility are permitted
+	ShouldAllowPerRequestRawOverride() bool
 }
 
 // Retry backoff constants for validation
@@ -3253,6 +3257,16 @@ func (c *Config) GetProviderConfigRaw(provider schemas.ModelProvider) (*configst
 // reads are atomic and won't cause panics.
 func (c *Config) ShouldAllowDirectKeys() bool {
 	return c.ClientConfig.AllowDirectKeys
+}
+
+// ShouldAllowPerRequestStorageOverride returns whether per-request content storage overrides are permitted.
+func (c *Config) ShouldAllowPerRequestStorageOverride() bool {
+	return c.ClientConfig.AllowPerRequestContentStorageOverride
+}
+
+// ShouldAllowPerRequestRawOverride returns whether per-request raw request/response overrides are permitted.
+func (c *Config) ShouldAllowPerRequestRawOverride() bool {
+	return c.ClientConfig.AllowPerRequestRawOverride
 }
 
 // GetHeaderMatcher returns the precompiled header matcher for header filtering.

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -120,22 +120,34 @@ func ParseSessionIDFromBaggage(header string) string {
 
 // Parameters:
 //   - ctx: The FastHTTP request context containing the original headers
-//   - allowDirectKeys: Whether to allow direct API key usage from headers
+//   - store: HandlerStore providing per-request policy flags and header matchers
 //
 // Returns:
-//   - *context.Context: A new cancellable context.Context containing the propagated values
+//   - *schemas.BifrostContext: A new cancellable context containing the propagated values
 //   - context.CancelFunc: Function to cancel the context (should be called when request completes)
 //
 // Example Usage:
 //
 //	fastCtx := &fasthttp.RequestCtx{...}
-//	bifrostCtx, cancel := ConvertToBifrostContext(fastCtx, true, nil)
+//	bifrostCtx, cancel := ConvertToBifrostContext(fastCtx, handlerStore)
 //	defer cancel() // Ensure cleanup
 //	// bifrostCtx now contains propagated header values including Prometheus metrics,
 //	// Maxim tracing data, MCP filters, governance keys, API keys, cache settings,
 //	// session stickiness, and extra headers
 
-func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, matcher *HeaderMatcher, mcpHeaderCombinedAllowlist schemas.WhiteList) (*schemas.BifrostContext, context.CancelFunc) {
+func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*schemas.BifrostContext, context.CancelFunc) {
+	allowDirectKeys := false
+	var matcher *HeaderMatcher
+	mcpHeaderCombinedAllowlist := schemas.WhiteList{}
+	allowPerRequestStorageOverride := false
+	allowPerRequestRawOverride := false
+	if store != nil {
+		allowDirectKeys = store.ShouldAllowDirectKeys()
+		matcher = store.GetHeaderMatcher()
+		mcpHeaderCombinedAllowlist = store.GetMCPHeaderCombinedAllowlist()
+		allowPerRequestStorageOverride = store.ShouldAllowPerRequestStorageOverride()
+		allowPerRequestRawOverride = store.ShouldAllowPerRequestRawOverride()
+	}
 	// Reuse a shared request-scoped context when available.
 	var bifrostCtx *schemas.BifrostContext
 	var cancel context.CancelFunc
@@ -404,7 +416,7 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 				return true
 			}
 			// Apply configurable header filter
-			if !matcher.ShouldAllow(labelName) {
+			if matcher != nil && !matcher.ShouldAllow(labelName) {
 				return true
 			}
 			// Append header value (allow multiple values for the same header)
@@ -415,7 +427,7 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 		// in the allowlist can be forwarded directly without the x-bf-eh- prefix.
 		// This enables forwarding arbitrary headers like "anthropic-beta" directly.
 		// Only applies when allowlist is non-empty (backward compatible).
-		if matcher.HasAllowlist() {
+		if matcher != nil && matcher.HasAllowlist() {
 			if matcher.MatchesAllow(keyStr) {
 				// Skip reserved x-bf-* headers (handled separately)
 				if strings.HasPrefix(keyStr, "x-bf-") {
@@ -473,6 +485,12 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 		if keyStr == "x-bf-passthrough-extra-params" {
 			if valueStr := string(value); valueStr == "true" {
 				bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+			}
+			return true
+		}
+		if keyStr == "x-bf-disable-content-logging" {
+			if b, err := strconv.ParseBool(string(value)); err == nil {
+				bifrostCtx.SetValue(schemas.BifrostContextKeyDisableContentLogging, b)
 			}
 			return true
 		}
@@ -608,6 +626,8 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 			bifrostCtx.SetValue(schemas.BifrostContextKeyDirectKey, key)
 		}
 	}
+	bifrostCtx.SetValue(schemas.BifrostContextKeyAllowPerRequestStorageOverride, allowPerRequestStorageOverride)
+	bifrostCtx.SetValue(schemas.BifrostContextKeyAllowPerRequestRawOverride, allowPerRequestRawOverride)
 	return bifrostCtx, cancel
 }
 

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -5,10 +5,29 @@ import (
 	"testing"
 
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/kvstore"
+	"github.com/maximhq/bifrost/framework/logstore"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/valyala/fasthttp"
 )
+
+// testHandlerStore is a minimal HandlerStore for ctx tests.
+type testHandlerStore struct {
+	allowDirectKeys bool
+	matcher         *HeaderMatcher
+}
+
+func (s testHandlerStore) ShouldAllowDirectKeys() bool                       { return s.allowDirectKeys }
+func (s testHandlerStore) GetHeaderMatcher() *HeaderMatcher                  { return s.matcher }
+func (s testHandlerStore) GetAvailableProviders() []schemas.ModelProvider    { return nil }
+func (s testHandlerStore) GetStreamChunkInterceptor() StreamChunkInterceptor { return nil }
+func (s testHandlerStore) GetAsyncJobExecutor() *logstore.AsyncJobExecutor   { return nil }
+func (s testHandlerStore) GetAsyncJobResultTTL() int                         { return 0 }
+func (s testHandlerStore) GetKVStore() *kvstore.Store                        { return nil }
+func (s testHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList  { return schemas.WhiteList{} }
+func (s testHandlerStore) ShouldAllowPerRequestStorageOverride() bool        { return false }
+func (s testHandlerStore) ShouldAllowPerRequestRawOverride() bool            { return false }
 
 func TestParseSessionIDFromBaggage(t *testing.T) {
 	tests := []struct {
@@ -39,7 +58,7 @@ func TestConvertToBifrostContext_ReusesSharedContext(t *testing.T) {
 	base.SetValue(schemas.BifrostContextKeyRequestID, "req-shared")
 	ctx.SetUserValue(FastHTTPUserValueBifrostContext, base)
 
-	converted, cancel := ConvertToBifrostContext(ctx, false, nil, schemas.WhiteList{})
+	converted, cancel := ConvertToBifrostContext(ctx, testHandlerStore{})
 	defer cancel()
 
 	if converted == nil {
@@ -59,13 +78,13 @@ func TestConvertToBifrostContext_ReusesSharedContext(t *testing.T) {
 func TestConvertToBifrostContext_SecondCallReturnsSameSharedContext(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 
-	first, cancelFirst := ConvertToBifrostContext(ctx, false, nil, schemas.WhiteList{})
+	first, cancelFirst := ConvertToBifrostContext(ctx, testHandlerStore{})
 	defer cancelFirst()
 	if first == nil {
 		t.Fatal("expected first context to be non-nil")
 	}
 
-	second, cancelSecond := ConvertToBifrostContext(ctx, false, nil, schemas.WhiteList{})
+	second, cancelSecond := ConvertToBifrostContext(ctx, testHandlerStore{})
 	defer cancelSecond()
 	if second == nil {
 		t.Fatal("expected second context to be non-nil")
@@ -92,7 +111,7 @@ func TestConvertToBifrostContext_StarAllowlistSecurityHeadersBlocked(t *testing.
 	ctx.Request.Header.Set("x-bf-eh-connection", "should-be-blocked")
 	ctx.Request.Header.Set("x-bf-eh-proxy-authorization", "should-be-blocked")
 
-	bifrostCtx, cancel := ConvertToBifrostContext(ctx, false, matcher, schemas.WhiteList{})
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{matcher: matcher})
 	defer cancel()
 
 	extraHeaders, _ := bifrostCtx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
@@ -126,7 +145,7 @@ func TestConvertToBifrostContext_StarAllowlistDirectForwardingSecurityBlocked(t 
 	// Security headers sent directly — should be blocked
 	ctx.Request.Header.Set("proxy-authorization", "should-be-blocked")
 
-	bifrostCtx, cancel := ConvertToBifrostContext(ctx, false, matcher, schemas.WhiteList{})
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{matcher: matcher})
 	defer cancel()
 
 	extraHeaders, _ := bifrostCtx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
@@ -163,7 +182,7 @@ func TestConvertToBifrostContext_PrefixWildcardDirectForwarding(t *testing.T) {
 	// Header not matching the pattern
 	ctx.Request.Header.Set("openai-version", "should-not-forward")
 
-	bifrostCtx, cancel := ConvertToBifrostContext(ctx, false, matcher, schemas.WhiteList{})
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{matcher: matcher})
 	defer cancel()
 
 	extraHeaders, _ := bifrostCtx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
@@ -191,7 +210,7 @@ func TestConvertToBifrostContext_WildcardAllowlistFiltering(t *testing.T) {
 	ctx.Request.Header.Set("x-bf-eh-anthropic-version", "2024-01-01")
 	ctx.Request.Header.Set("x-bf-eh-openai-version", "should-be-blocked")
 
-	bifrostCtx, cancel := ConvertToBifrostContext(ctx, false, matcher, schemas.WhiteList{})
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{matcher: matcher})
 	defer cancel()
 
 	extraHeaders, _ := bifrostCtx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
@@ -219,7 +238,7 @@ func TestConvertToBifrostContext_WildcardDenylistBlocking(t *testing.T) {
 	ctx.Request.Header.Set("x-bf-eh-x-internal-secret", "blocked-value")
 	ctx.Request.Header.Set("x-bf-eh-custom-header", "allowed-value")
 
-	bifrostCtx, cancel := ConvertToBifrostContext(ctx, false, matcher, schemas.WhiteList{})
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{matcher: matcher})
 	defer cancel()
 
 	extraHeaders, _ := bifrostCtx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
@@ -240,7 +259,7 @@ func TestConvertToBifrostContext_NilMatcher(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.Header.Set("x-bf-eh-custom-header", "allowed-value")
 
-	bifrostCtx, cancel := ConvertToBifrostContext(ctx, false, nil, schemas.WhiteList{})
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{})
 	defer cancel()
 
 	extraHeaders, _ := bifrostCtx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
@@ -254,7 +273,7 @@ func TestConvertToBifrostContext_BaggageSessionIDSetsGrouping(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.Header.Set("baggage", "foo=bar, session-id=rt-123, baz=qux")
 
-	bifrostCtx, cancel := ConvertToBifrostContext(ctx, false, nil, schemas.WhiteList{})
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{})
 	defer cancel()
 
 	if got, _ := bifrostCtx.Value(schemas.BifrostContextKeyParentRequestID).(string); got != "rt-123" {
@@ -266,7 +285,7 @@ func TestConvertToBifrostContext_EmptyBaggageSessionIDIgnored(t *testing.T) {
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.Header.Set("baggage", "session-id=   ")
 
-	bifrostCtx, cancel := ConvertToBifrostContext(ctx, false, nil, schemas.WhiteList{})
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, testHandlerStore{})
 	defer cancel()
 
 	if got := bifrostCtx.Value(schemas.BifrostContextKeyParentRequestID); got != nil {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -68,6 +68,16 @@
           "type": "boolean",
           "description": "Disable logging of sensitive content (inputs, outputs, embeddings, etc.)"
         },
+        "allow_per_request_content_storage_override": {
+          "type": "boolean",
+          "description": "Allow individual requests to override content storage via the x-bf-disable-content-logging header or context key, and to opt in to raw-byte persistence in logs via x-bf-store-raw-request-response. When false (default), the global disable_content_logging setting is authoritative and per-request storage overrides are ignored. Does not control sending raw bytes back to callers — see allow_per_request_raw_override.",
+          "default": false
+        },
+        "allow_per_request_raw_override": {
+          "type": "boolean",
+          "description": "Allow individual requests to send raw provider request/response bytes back to the caller via the x-bf-send-back-raw-request and x-bf-send-back-raw-response headers. When false (default), the provider-level send_back_raw_request/response settings are authoritative and per-request overrides are ignored. Does not affect raw-byte persistence in logs — see allow_per_request_content_storage_override.",
+          "default": false
+        },
         "disable_db_pings_in_health": {
           "type": "boolean",
           "description": "Disable DB pings in health check",
@@ -1258,6 +1268,11 @@
                     "disable_content_logging": {
                       "type": "boolean",
                       "description": "Disable logging of request and response content"
+                    },
+                    "allow_per_request_content_storage_override": {
+                      "type": "boolean",
+                      "description": "Allow individual requests to override content storage via the x-bf-disable-content-logging header or context key, and to opt in to raw-byte persistence in logs via x-bf-store-raw-request-response. When false (default), per-request storage overrides are ignored. Does not control sending raw bytes back to callers — see allow_per_request_raw_override.",
+                      "default": false
                     },
                     "logging_headers": {
                       "type": "array",

--- a/ui/app/workspace/config/views/loggingView.tsx
+++ b/ui/app/workspace/config/views/loggingView.tsx
@@ -31,6 +31,8 @@ export default function LoggingView() {
 		return (
 			localConfig.enable_logging !== config.enable_logging ||
 			localConfig.disable_content_logging !== config.disable_content_logging ||
+			localConfig.allow_per_request_content_storage_override !== config.allow_per_request_content_storage_override ||
+			localConfig.allow_per_request_raw_override !== config.allow_per_request_raw_override ||
 			localConfig.log_retention_days !== config.log_retention_days ||
 			localConfig.hide_deleted_virtual_keys_in_filters !== config.hide_deleted_virtual_keys_in_filters ||
 			JSON.stringify(localConfig.logging_headers || []) !== JSON.stringify(config.logging_headers || [])
@@ -129,6 +131,50 @@ export default function LoggingView() {
 						{needsRestart && <RestartWarning />}
 					</div>
 				)}
+
+				{/* Allow Per-Request Content Storage Override - Only show when logging is enabled */}
+				{localConfig.enable_logging && bifrostConfig?.is_logs_connected && (
+					<div className="flex items-center justify-between space-x-2 rounded-lg border p-4">
+						<div className="space-y-0.5">
+							<label htmlFor="allow-per-request-content-storage-override" className="text-sm font-medium">
+								Allow Per-Request Content Storage Override
+							</label>
+							<p className="text-muted-foreground text-sm">
+								When enabled, individual requests can override the global content logging setting using the{" "}
+								<code className="text-xs">x-bf-disable-content-logging</code> header or context key, and can opt-in to persisting raw provider bytes in logs using the{" "}
+								<code className="text-xs">x-bf-store-raw-request-response</code> header. Raw data is not stored by default — each request must explicitly opt in. Does not control sending raw bytes back to callers — see Allow Per-Request Raw Override.
+							</p>
+						</div>
+						<Switch
+							id="allow-per-request-content-storage-override"
+							data-testid="workspace-content-storage-override-switch"
+							size="md"
+							checked={localConfig.allow_per_request_content_storage_override}
+							onCheckedChange={(checked) => handleConfigChange("allow_per_request_content_storage_override", checked)}
+						/>
+					</div>
+				)}
+
+				{/* Allow Per-Request Raw Override */}
+				<div className="flex items-center justify-between space-x-2 rounded-lg border p-4">
+						<div className="space-y-0.5">
+							<label htmlFor="allow-per-request-raw-override" className="text-sm font-medium">
+								Allow Per-Request Raw Override
+							</label>
+							<p className="text-muted-foreground text-sm">
+								When enabled, individual requests can send raw provider request/response bytes back to the caller using the{" "}
+								<code className="text-xs">x-bf-send-back-raw-request</code> and{" "}
+								<code className="text-xs">x-bf-send-back-raw-response</code> headers. Does not affect log storage — raw-byte persistence in logs is controlled by Allow Per-Request Content Storage Override.
+							</p>
+						</div>
+						<Switch
+							id="allow-per-request-raw-override"
+							data-testid="workspace-raw-override-switch"
+							size="md"
+							checked={localConfig.allow_per_request_raw_override}
+							onCheckedChange={(checked) => handleConfigChange("allow_per_request_raw_override", checked)}
+						/>
+					</div>
 
 				{/* Log Retention Days */}
 				{localConfig.enable_logging && bifrostConfig?.is_logs_connected && (

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -472,6 +472,8 @@ export interface CoreConfig {
 	prometheus_labels: string[];
 	enable_logging: boolean;
 	disable_content_logging: boolean;
+	allow_per_request_content_storage_override: boolean;
+	allow_per_request_raw_override: boolean;
 	disable_db_pings_in_health: boolean;
 	log_retention_days: number;
 	enforce_auth_on_inference: boolean;
@@ -500,6 +502,8 @@ export const DefaultCoreConfig: CoreConfig = {
 	prometheus_labels: [],
 	enable_logging: true,
 	disable_content_logging: false,
+	allow_per_request_content_storage_override: false,
+	allow_per_request_raw_override: false,
 	disable_db_pings_in_health: false,
 	log_retention_days: 365,
 	enforce_auth_on_inference: false,


### PR DESCRIPTION
## Summary

Adds two opt-in configuration flags — `allow_per_request_content_storage_override` and `allow_per_request_raw_override` — that gate whether per-request context keys and HTTP headers can override the global content logging and raw request/response visibility settings. When enabled, callers can suppress sensitive content (e.g. PII, credentials) from log records on specific requests via `x-bf-disable-content-logging`, or override raw capture behavior via `x-bf-send-back-raw-request`/`x-bf-send-back-raw-response`, without changing global configuration. When disabled (the default), provider-level and global settings remain authoritative and per-request overrides are silently ignored.

## Changes

- Added `BifrostContextKeyDisableContentLogging`, `BifrostContextKeyAllowPerRequestStorageOverride`, and `BifrostContextKeyAllowPerRequestRawOverride` to the `BifrostContextKey` enum.
- Introduced a `contentLoggingEnabled(ctx)` helper on `LoggerPlugin` that checks the per-request context override (only when `BifrostContextKeyAllowPerRequestStorageOverride` is set) before falling back to the global `disableContentLogging` config. This replaces all inline `p.disableContentLogging == nil || !*p.disableContentLogging` checks throughout the logging plugin.
- Propagated the resolved `contentLoggingEnabled` bool as an explicit parameter to `updateLogEntry`, `applyStreamingOutputToEntry`, `applyNonStreamingOutputToEntry`, and `applyRealtimeOutputToEntry`, removing the redundant local re-evaluation inside `applyRealtimeOutputToEntry`.
- Gated the existing `BifrostContextKeySendBackRawRequest`, `BifrostContextKeySendBackRawResponse`, and `BifrostContextKeyStoreRawRequestResponse` per-request overrides in `requestWorker` behind the new `BifrostContextKeyAllowPerRequestRawOverride` flag.
- Added `AllowPerRequestContentStorageOverride` and `AllowPerRequestRawOverride` fields to `ClientConfig` with corresponding hash entries, `Config` accessor methods, and two new methods on the `HandlerStore` interface (`ShouldAllowPerRequestStorageOverride`, `ShouldAllowPerRequestRawOverride`).
- Refactored `ConvertToBifrostContext` to accept a `HandlerStore` instead of individual parameters, propagating the new override flags into the bifrost context at request ingress.
- Added UI toggles for both new flags in the Logs Settings view and updated the `CoreConfig` TypeScript type and defaults.
- Added tests covering all precedence combinations (no config, global on/off, ctx override on/off, nil ctx), as well as integration-style tests for `updateLogEntry` and the apply-output helpers verifying both suppression and force-enable behavior.
- Documented the new `x-bf-disable-content-logging` option in `docs/providers/request-options.mdx` with cURL and Go SDK examples, precedence rules, and a prerequisite callout for `allow_per_request_content_storage_override`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
go test ./plugins/logging/... ./transports/bifrost-http/lib/...
```

To validate end-to-end via the gateway, first enable `allow_per_request_content_storage_override` in your logging config, then send a chat completion request with the header and confirm the log record omits message content while still recording token counts and latency:

```sh
curl --location 'http://localhost:8080/v1/chat/completions' \
  --header 'x-bf-disable-content-logging: true' \
  --header 'Content-Type: application/json' \
  --data '{
    "model": "openai/gpt-4o-mini",
    "messages": [{"role": "user", "content": "Sensitive data here"}]
  }'
```

The resulting log record should have empty `input_history`, `output_message`, and `raw_request`/`raw_response` fields, while `total_tokens`, `latency`, and routing metadata remain populated.

To verify the gate is enforced, send the same request without enabling `allow_per_request_content_storage_override` — the header should be ignored and content should appear in the log record as normal.

## Breaking changes

- [x] No

## Security considerations

Both override flags default to `false`, meaning existing deployments are unaffected on upgrade. The per-request override is applied only at log-write time and does not affect what is sent to the upstream provider. Operators should consider carefully before enabling `allow_per_request_raw_override`, as it permits callers to request that raw provider payloads be returned in API responses.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable