### PR TITLE
feat: add `x-bf-dim-*` unified dimension headers forwarded to logs, traces, Prometheus, and Maxim tags

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -285,6 +285,7 @@ const (
 	BifrostContextKeyCompatShouldDropParams              BifrostContextKey = "bifrost-compat-should-drop-params"          // bool (per-request override from x-bf-compat header)
 	BifrostContextKeyCompatShouldConvertParams           BifrostContextKey = "bifrost-compat-should-convert-params"       // bool (per-request override from x-bf-compat header)
 	BifrostContextKeyAttemptTrail                        BifrostContextKey = "bifrost-attempt-trail"                      // []KeyAttemptRecord (set by bifrost - DO NOT SET THIS MANUALLY) - per-attempt key selection history
+	BifrostContextKeyDimensions                          BifrostContextKey = "bifrost-dimensions"                         // map[string]string (set by HTTP transport from x-bf-dim-* headers) BifrostContextKeyDimensions holds per-request key/value dimensions supplied via x-bf-dim-<key> request headers. These dimensions are forwarded to internal logs (as metadata)
 )
 
 const (

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -412,6 +412,18 @@ func (p *LoggerPlugin) captureLoggingHeaders(ctx *schemas.BifrostContext) map[st
 		}
 	}
 
+	// Include x-bf-dim-* dimensions in metadata.
+	if dims, ok := ctx.Value(schemas.BifrostContextKeyDimensions).(map[string]string); ok {
+		for k, v := range dims {
+			if metadata == nil {
+				metadata = make(map[string]interface{})
+			}
+			if _, exists := metadata[k]; !exists {
+				metadata[k] = v
+			}
+		}
+	}
+
 	return metadata
 }
 

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -552,6 +552,8 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.B
 	generationID, hasGenerationID := ctx.Value(GenerationIDKey).(string)
 	traceID, hasTraceID := ctx.Value(TraceIDKey).(string)
 	tags, hasTags := ctx.Value(TagsKey).(map[string]string)
+	// Also capture x-bf-dim-* dimensions to forward as tags
+	dims, hasDims := ctx.Value(schemas.BifrostContextKeyDimensions).(map[string]string)
 
 	isFinalChunk := bifrost.IsFinalChunk(ctx)
 
@@ -662,6 +664,20 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.B
 				}
 				if traceID != "" {
 					logger.AddTagToTrace(traceID, key, value)
+				}
+			}
+		}
+		// add x-bf-dim-* dimensions as tags (lower priority than explicit x-bf-maxim-* tags)
+		if hasDims {
+			for key, value := range dims {
+				// Only add if not already set by x-bf-maxim-* (to avoid overriding explicit tags)
+				if _, alreadyInTags := tags[key]; !alreadyInTags {
+					if generationID != "" {
+						logger.AddTagToGeneration(generationID, key, value)
+					}
+					if traceID != "" {
+						logger.AddTagToTrace(traceID, key, value)
+					}
 				}
 			}
 		}

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -435,8 +435,28 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		"customer_name":       customerName,
 	}
 
-	// Get all custom prometheus labels from context BEFORE the goroutine
+	// Get all custom prometheus labels from context BEFORE the goroutine.
+	// Resolution order (first match wins):
+	//   1. x-bf-dim-* headers (canonical; set by HTTP transport as BifrostContextKeyDimensions)
+	//   2. x-bf-prom-* headers (deprecated; kept for backward compatibility)
+	//   3. Direct BifrostContextKey lookup (Go SDK usage — documented API)
+	dims, _ := ctx.Value(schemas.BifrostContextKeyDimensions).(map[string]string)
+	requestHeaders, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
 	for _, key := range p.customLabels {
+		if dims != nil {
+			if v, ok := dims[key]; ok {
+				labelValues[key] = v
+				continue
+			}
+		}
+		// support for to be deprecated x-bf-prom-* headers
+		if requestHeaders != nil {
+			if v, ok := requestHeaders["x-bf-prom-"+key]; ok {
+				labelValues[key] = v
+				continue
+			}
+		}
+		// fallback: direct context key (Go SDK usage, documented API)
 		if value := ctx.Value(schemas.BifrostContextKey(key)); value != nil {
 			if strValue, ok := value.(string); ok {
 				labelValues[key] = strValue

--- a/plugins/telemetry/utils.go
+++ b/plugins/telemetry/utils.go
@@ -27,8 +27,9 @@ func getPrometheusLabelValues(expectedLabels []string, headerValues map[string]s
 }
 
 // collectPrometheusKeyValues collects all metrics for a request including:
-// - Default metrics (path, method, status, request size)
-// - Custom prometheus headers (x-bf-prom-*)
+// - Default metrics (path, method, status)
+// - Custom dimension headers (x-bf-dim-*) — the canonical header prefix
+// - Deprecated custom prometheus headers (x-bf-prom-*) — kept for backward compatibility
 // Returns a map of all label values
 func collectPrometheusKeyValues(ctx *fasthttp.RequestCtx) map[string]string {
 	path := string(ctx.Path())
@@ -40,13 +41,23 @@ func collectPrometheusKeyValues(ctx *fasthttp.RequestCtx) map[string]string {
 		"method": method,
 	}
 
-	// Collect custom prometheus headers
+	// Collect custom dimension and prometheus headers
 	ctx.Request.Header.All()(func(key, value []byte) bool {
 		keyStr := strings.ToLower(string(key))
-		if strings.HasPrefix(keyStr, "x-bf-prom-") {
-			labelName := strings.TrimPrefix(keyStr, "x-bf-prom-")
-			labelValues[labelName] = string(value)
-			ctx.SetUserValue(keyStr, string(value))
+		// x-bf-dim-* (canonical; replaces x-bf-prom-*)
+		if labelName, ok := strings.CutPrefix(keyStr, "x-bf-dim-"); ok && labelName != "" {
+			if labelName != "path" && labelName != "method" { // it was prepoulated in the context
+				labelValues[labelName] = string(value)
+				ctx.SetUserValue(keyStr, string(value))
+			}
+		}
+		// x-bf-prom-* (deprecated; kept for backward compatibility)
+		if labelName, ok := strings.CutPrefix(keyStr, "x-bf-prom-"); ok && labelName != "" {
+			// Only set if not already provided via x-bf-dim-* (x-bf-dim takes precedence)
+			if _, alreadySet := labelValues[labelName]; !alreadySet && labelName != "path" && labelName != "method" {
+				labelValues[labelName] = string(value)
+				ctx.SetUserValue(keyStr, string(value))
+			}
 		}
 		return true
 	})

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -968,6 +968,22 @@ type TracingMiddleware struct {
 	tracer atomic.Pointer[tracing.Tracer]
 }
 
+func attachDimensionAttributesToHTTPSpan(ctx *fasthttp.RequestCtx, setAttribute func(key string, value any)) {
+	if ctx == nil || setAttribute == nil {
+		return
+	}
+	// Root HTTP span starts before ConvertToBifrostContext, so read x-bf-dim-* directly.
+	ctx.Request.Header.All()(func(key, value []byte) bool {
+		keyStr := strings.ToLower(string(key))
+		if labelName, ok := strings.CutPrefix(keyStr, "x-bf-dim-"); ok && labelName != "" {
+			if labelName != "path" && labelName != "method" {
+				setAttribute(labelName, string(value))
+			}
+		}
+		return true
+	})
+}
+
 // NewTracingMiddleware creates a new tracing middleware
 func NewTracingMiddleware(tracer *tracing.Tracer) *TracingMiddleware {
 	tm := &TracingMiddleware{
@@ -1033,6 +1049,9 @@ func (m *TracingMiddleware) Middleware() schemas.BifrostHTTPMiddleware {
 			// Create root span for the HTTP request
 			spanCtx, rootSpan := tracer.StartSpan(ctx, string(ctx.RequestURI()), schemas.SpanKindHTTPRequest)
 			if rootSpan != nil {
+				attachDimensionAttributesToHTTPSpan(ctx, func(key string, value any) {
+					tracer.SetAttribute(rootSpan, key, value)
+				})
 				tracer.SetAttribute(rootSpan, "http.method", string(ctx.Method()))
 				tracer.SetAttribute(rootSpan, "http.url", string(ctx.RequestURI()))
 				tracer.SetAttribute(rootSpan, "http.user_agent", string(ctx.Request.Header.UserAgent()))

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -68,10 +68,15 @@ func ParseSessionIDFromBaggage(header string) string {
 // preserving important header values for monitoring and tracing purposes.
 //
 // The function processes several types of special headers:
-// 1. Prometheus Headers (x-bf-prom-*):
-//   - All headers prefixed with 'x-bf-prom-' are copied to the context
-//   - The prefix is stripped and the remainder becomes the context key
-//   - Example: 'x-bf-prom-latency' becomes 'latency' in the context
+// 1. Dimension Headers (x-bf-dim-*):
+//   - All headers prefixed with 'x-bf-dim-' are collected into a map[string]string stored under
+//     schemas.BifrostContextKeyDimensions and are forwarded to all observability integrations
+//     (internal logs, OTEL spans, Prometheus custom labels, Datadog, etc.).
+//   - The prefix is stripped and the remainder becomes the dimension key.
+//   - Example: 'x-bf-dim-environment' with value 'production' stores {"environment": "production"}.
+//
+// 1a. Prometheus Headers (x-bf-prom-*) [DEPRECATED — use x-bf-dim-* instead]:
+//   - All headers prefixed with 'x-bf-prom-' are still accepted for backward compatibility.
 //
 // 2. Maxim Tracing Headers (x-bf-maxim-*):
 //   - Specifically handles 'x-bf-maxim-traceID' and 'x-bf-maxim-generationID'
@@ -177,6 +182,8 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 	})
 	// Initialize tags map for collecting maxim tags
 	maximTags := make(map[string]string)
+	// Initialize dimensions map for x-bf-dim-* headers
+	dimensions := make(map[string]string)
 	// Initialize extra headers map for headers prefixed with x-bf-eh-
 	extraHeaders := make(map[string][]string)
 	// Initialize extra headers map for headers in the mcp header combined allowlist
@@ -217,8 +224,15 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 			}
 			return true
 		}
-		if labelName, ok := strings.CutPrefix(keyStr, "x-bf-prom-"); ok {
-			bifrostCtx.SetValue(schemas.BifrostContextKey(labelName), string(value))
+		if labelName, ok := strings.CutPrefix(keyStr, "x-bf-dim-"); ok && labelName != "" {
+			if labelName != "path" && labelName != "method" {
+				dimensions[labelName] = string(value)
+			}
+			return true
+		}
+		if labelName, ok := strings.CutPrefix(keyStr, "x-bf-prom-"); ok && labelName != "" {
+			// x-bf-prom-* is Prometheus-only and must not flow into unified dimensions
+			// (logs/OTEL/Maxim/etc). Prometheus plugin reads headers directly.
 			return true
 		}
 		// Checking for maxim headers
@@ -509,6 +523,11 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, allowDirectKeys bool, mat
 	// Store the collected maxim tags in the context
 	if len(maximTags) > 0 {
 		bifrostCtx.SetValue(schemas.BifrostContextKey(maxim.TagsKey), maximTags)
+	}
+
+	// Store collected dimensions (x-bf-dim-* only) in the context
+	if len(dimensions) > 0 {
+		bifrostCtx.SetValue(schemas.BifrostContextKeyDimensions, dimensions)
 	}
 
 	// Store collected extra headers in the context if any were found

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -273,3 +273,87 @@ func TestConvertToBifrostContext_EmptyBaggageSessionIDIgnored(t *testing.T) {
 		t.Fatalf("parent request id should be unset, got %#v", got)
 	}
 }
+
+func TestConvertToBifrostContext_DimHeadersDoNotOverrideReservedContextKeys(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-request-id", "trusted-request-id")
+	ctx.Request.Header.Set("x-bf-dim-request-id", "attacker-request-id")
+	ctx.Request.Header.Set("x-bf-dim-x-bf-vk", "attacker-vk")
+	ctx.Request.Header.Set("x-bf-prom-x-bf-vk", "attacker-vk")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, false, nil, schemas.WhiteList{})
+	defer cancel()
+
+	// request-id must remain from trusted source, not from x-bf-dim-request-id.
+	if got, _ := bifrostCtx.Value(schemas.BifrostContextKeyRequestID).(string); got != "trusted-request-id" {
+		t.Fatalf("request-id = %q, want %q", got, "trusted-request-id")
+	}
+	// Virtual key must not be set through x-bf-dim-x-bf-vk.
+	if got := bifrostCtx.Value(schemas.BifrostContextKeyVirtualKey); got != nil {
+		t.Fatalf("virtual key should not be set via x-bf-dim-*, got %#v", got)
+	}
+
+	// Dimension values are still captured in the dedicated dimensions map.
+	dimensions, ok := bifrostCtx.Value(schemas.BifrostContextKeyDimensions).(map[string]string)
+	if !ok {
+		t.Fatal("expected dimensions map in context")
+	}
+	if dimensions["request-id"] != "attacker-request-id" {
+		t.Fatalf("dimensions[request-id] = %q, want %q", dimensions["request-id"], "attacker-request-id")
+	}
+	if dimensions["x-bf-vk"] != "attacker-vk" {
+		t.Fatalf("dimensions[x-bf-vk] = %q, want %q", dimensions["x-bf-vk"], "attacker-vk")
+	}
+}
+
+func TestConvertToBifrostContext_PromHeadersDoNotOverrideReservedContextKeys(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-request-id", "trusted-request-id")
+	ctx.Request.Header.Set("x-bf-prom-request-id", "attacker-request-id")
+	ctx.Request.Header.Set("x-bf-prom-x-bf-vk", "attacker-vk")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, false, nil, schemas.WhiteList{})
+	defer cancel()
+
+	// request-id must remain from trusted source, not from x-bf-prom-request-id.
+	if got, _ := bifrostCtx.Value(schemas.BifrostContextKeyRequestID).(string); got != "trusted-request-id" {
+		t.Fatalf("request-id = %q, want %q", got, "trusted-request-id")
+	}
+	// Virtual key must not be set through x-bf-prom-x-bf-vk.
+	if got := bifrostCtx.Value(schemas.BifrostContextKeyVirtualKey); got != nil {
+		t.Fatalf("virtual key should not be set via x-bf-prom-*, got %#v", got)
+	}
+	// Legacy x-bf-prom-* headers are not mirrored into global context keyspace.
+	if got := bifrostCtx.Value(schemas.BifrostContextKey("request-id")); got != "trusted-request-id" {
+		t.Fatalf("global request-id key should remain trusted value, got %#v", got)
+	}
+
+	// Legacy x-bf-prom-* must not be included in unified dimensions.
+	if dimensions, ok := bifrostCtx.Value(schemas.BifrostContextKeyDimensions).(map[string]string); ok && len(dimensions) > 0 {
+		t.Fatalf("expected no unified dimensions from x-bf-prom-*, got %#v", dimensions)
+	}
+}
+
+func TestConvertToBifrostContext_DimAndPromCanCoexistWithoutCrossing(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.Set("x-bf-prom-team", "legacy-team")
+	ctx.Request.Header.Set("x-bf-dim-team", "platform")
+	ctx.Request.Header.Set("x-bf-dim-environment", "prod")
+
+	bifrostCtx, cancel := ConvertToBifrostContext(ctx, false, nil, schemas.WhiteList{})
+	defer cancel()
+
+	dimensions, ok := bifrostCtx.Value(schemas.BifrostContextKeyDimensions).(map[string]string)
+	if !ok {
+		t.Fatal("expected dimensions map in context")
+	}
+	if dimensions["team"] != "platform" {
+		t.Fatalf("dimensions[team] = %q, want %q", dimensions["team"], "platform")
+	}
+	if dimensions["environment"] != "prod" {
+		t.Fatalf("dimensions[environment] = %q, want %q", dimensions["environment"], "prod")
+	}
+	if len(dimensions) != 2 {
+		t.Fatalf("expected only dim headers in unified dimensions, got %#v", dimensions)
+	}
+}


### PR DESCRIPTION
## Summary

Introduces a unified `x-bf-dim-*` header prefix as the canonical way to attach per-request dimensions (key/value pairs) that are automatically forwarded to all observability backends — internal logs, OpenTelemetry spans, Prometheus custom labels, and Maxim tags. Previously, separate header prefixes (`x-bf-prom-*`, `x-bf-maxim-*`, etc.) were required to target each backend individually. The `x-bf-prom-*` prefix is retained for backward compatibility but is now deprecated in favour of `x-bf-dim-*`.

## Changes

- Added `BifrostContextKeyDimensions` context key to hold a `map[string]string` of dimensions parsed from `x-bf-dim-*` request headers.
- HTTP transport (`ConvertToBifrostContext`) now collects `x-bf-dim-*` headers into the unified dimensions map. `x-bf-prom-*` headers continue to work for Prometheus but are not merged into the dimensions map and no longer write arbitrary keys into the global context keyspace.
- Added `attachDimensionAttributesToSpan` helper that reads the dimensions map from context and sets each entry as a span attribute. This is called on every span created in `executeRequestWithRetries`, fallback handling, plugin pre/post hooks (LLM and MCP), and streaming post-hook finalization.
- Root HTTP span in `TracingMiddleware` reads `x-bf-dim-*` headers directly (before `ConvertToBifrostContext` runs) and attaches them as span attributes via `attachDimensionAttributesToHTTPSpan`.
- Logging plugin (`captureLoggingHeaders`) includes dimensions in request metadata at lower priority — existing values captured via configured logging headers take precedence.
- Maxim plugin (`PostLLMHook`) forwards dimensions as tags on both generations and traces, at lower priority than explicit `x-bf-maxim-*` tags.
- Telemetry/Prometheus plugin (`PostLLMHook`, `collectPrometheusKeyValues`) resolves custom label values from the dimensions map first; `x-bf-prom-*` values are only applied if the same key was not already provided via `x-bf-dim-*`.
- Added tests covering that `x-bf-dim-*` and `x-bf-prom-*` headers cannot override reserved context keys, that the two prefixes coexist without crossing, and that legacy `x-bf-prom-*` headers are not included in the unified dimensions map.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins

## How to test

Send a request to the Bifrost HTTP transport with one or more `x-bf-dim-*` headers and verify the dimension appears in all configured observability backends.

```sh
# Run all tests
go test ./...

# Example request
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "x-bf-dim-environment: production" \
  -H "x-bf-dim-team: platform" \
  -H "Content-Type: application/json" \
  -d '{"model": "gpt-4o", "messages": [{"role": "user", "content": "Hello"}]}'
```

Expected outcomes:
- OTEL traces include `environment=production` and `team=platform` span attributes on all internal spans.
- Internal logs include `environment` and `team` in request metadata.
- Prometheus metrics include the dimension values for any matching `custom_labels` configuration.
- Maxim generations and traces are tagged with `environment` and `team`.

Existing `x-bf-prom-*` requests should continue to behave identically to before.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

`x-bf-prom-*` headers continue to work without any changes required. The new `x-bf-dim-*` prefix is purely additive.

## Related issues

## Security considerations

Dimension keys and values are sourced from request headers and stored in context, spans, logs, and metrics. No secrets or PII should be sent via `x-bf-dim-*` headers, as values will be visible across all observability backends.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable