### PR TITLE
fix: use UTC in `resolvePeriod` time calculation

### DIFF
--- a/transports/bifrost-http/handlers/utils.go
+++ b/transports/bifrost-http/handlers/utils.go
@@ -19,7 +19,7 @@ import (
 // unrecognised values. When used in filter parsing, period takes precedence over any explicit
 // start_time/end_time query parameters so every poll always covers the intended window.
 func resolvePeriod(period string) (start, end *time.Time) {
-	now := time.Now()
+	now := time.Now().UTC()
 	var from time.Time
 	switch period {
 	case "1h":


### PR DESCRIPTION
## Summary

`resolvePeriod` was computing time windows using local system time, which could produce inconsistent results depending on the server's timezone. This fix ensures the period resolution always operates in UTC.

## Changes

- `time.Now()` replaced with `time.Now().UTC()` in `resolvePeriod` so that start and end times for period-based filters are always anchored to UTC, regardless of the host system's local timezone.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/...
```

Verify that period-based query parameters (e.g. `period=1h`) return consistent time windows when the server is running in a non-UTC timezone. The resolved `start` and `end` times should always be expressed in UTC.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable