### PR TITLE
feat: add `disabled` field to MCP clients for toggling connection and workers without removal

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3738,6 +3738,25 @@ func (bifrost *Bifrost) ReconnectMCPClient(id string) error {
 	return bifrost.MCPManager.ReconnectClient(id)
 }
 
+// DisableMCPClient shuts down an MCP client's connection, health monitor, and tool
+// syncer without removing it. The client entry is kept in a "disabled" state so it
+// can be re-enabled via EnableMCPClient.
+func (bifrost *Bifrost) DisableMCPClient(id string) error {
+	if bifrost.MCPManager == nil {
+		return fmt.Errorf("mcp is not configured in this bifrost instance")
+	}
+	return bifrost.MCPManager.DisableClient(id)
+}
+
+// EnableMCPClient reconnects a previously disabled MCP client and restarts its
+// health monitor and tool syncer.
+func (bifrost *Bifrost) EnableMCPClient(id string) error {
+	if bifrost.MCPManager == nil {
+		return fmt.Errorf("mcp is not configured in this bifrost instance")
+	}
+	return bifrost.MCPManager.EnableClient(id)
+}
+
 // VerifyPerUserOAuthConnection delegates to the MCP manager to verify an MCP
 // server using a temporary access token and discover available tools. The
 // connection is closed after verification. If the MCP manager is not yet

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -109,6 +109,33 @@ func (m *MCPManager) AddClient(config *schemas.MCPClientConfig) error {
 		return fmt.Errorf("client %s already exists", config.Name)
 	}
 
+	// Disabled clients get a dormant placeholder — no connection, no workers.
+	if config.Disabled {
+		clientState := &schemas.MCPClientState{
+			Name:            config.Name,
+			ExecutionConfig: config,
+			State:           schemas.MCPConnectionStateDisabled,
+			ToolMap:         make(map[string]schemas.ChatTool),
+			ToolNameMapping: make(map[string]string),
+			ConnectionInfo:  &schemas.MCPClientConnectionInfo{Type: config.ConnectionType},
+		}
+		// Persisted tools for per_user_oauth survive restarts in ExecutionConfig.
+		if config.AuthType == schemas.MCPAuthTypePerUserOauth && len(config.DiscoveredTools) > 0 {
+			for toolName, tool := range config.DiscoveredTools {
+				clientState.ToolMap[toolName] = tool
+			}
+			clientState.ToolNameMapping = config.DiscoveredToolNameMapping
+			if config.ConnectionString != nil {
+				url := config.ConnectionString.GetValue()
+				clientState.ConnectionInfo.ConnectionURL = &url
+			}
+		}
+		m.clientMap[config.ID] = clientState
+		m.mu.Unlock()
+		m.logger.Debug("%s MCP client '%s' registered in disabled state", MCPLogPrefix, config.Name)
+		return nil
+	}
+
 	// Create placeholder entry
 	m.clientMap[config.ID] = &schemas.MCPClientState{
 		Name:            config.Name,
@@ -141,10 +168,10 @@ func (m *MCPManager) AddClient(config *schemas.MCPClientConfig) error {
 				}
 				client.ToolNameMapping = config.DiscoveredToolNameMapping
 				client.State = schemas.MCPConnectionStateConnected
-				m.logger.Info("%s Per-user OAuth MCP client '%s' restored with %d tools", MCPLogPrefix, config.Name, len(config.DiscoveredTools))
+				m.logger.Debug("%s Per-user OAuth MCP client '%s' restored with %d tools", MCPLogPrefix, config.Name, len(config.DiscoveredTools))
 			} else {
 				client.State = schemas.MCPConnectionStatePendingTools
-				m.logger.Info("%s Per-user OAuth MCP client '%s' registered (connection deferred to runtime)", MCPLogPrefix, config.Name)
+				m.logger.Debug("%s Per-user OAuth MCP client '%s' registered (connection deferred to runtime)", MCPLogPrefix, config.Name)
 			}
 		}
 		m.mu.Unlock()
@@ -306,6 +333,142 @@ func (m *MCPManager) removeClientUnsafe(id string) error {
 	return nil
 }
 
+// DisableClient shuts down a client's connection, health monitor, and tool syncer
+// without removing it from the manager. The client entry is kept in clientMap with
+// state MCPConnectionStateDisabled so it can be re-enabled later.
+//
+// Parameters:
+//   - id: ID of the client to disable
+//
+// Returns:
+//   - error: Any error that occurred during disable
+func (m *MCPManager) DisableClient(id string) error {
+	// The internal in-process client must never be disabled:
+	if id == BifrostMCPClientKey {
+		return fmt.Errorf("cannot disable internal bifrost client")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	clientState, ok := m.clientMap[id]
+	if !ok {
+		return fmt.Errorf("client %s not found", id)
+	}
+	if clientState.State == schemas.MCPConnectionStateDisabled {
+		return fmt.Errorf("client %s is already disabled", clientState.ExecutionConfig.Name)
+	}
+
+	m.logger.Debug("%s Disabling MCP client '%s'", MCPLogPrefix, clientState.ExecutionConfig.Name)
+
+	m.healthMonitorManager.StopMonitoring(id)
+	m.toolSyncManager.StopSyncing(id)
+
+	if clientState.CancelFunc != nil {
+		clientState.CancelFunc()
+		clientState.CancelFunc = nil
+	}
+	if clientState.Conn != nil {
+		if err := clientState.Conn.Close(); err != nil {
+			m.logger.Error("%s Failed to close connection for MCP client '%s': %v", MCPLogPrefix, clientState.ExecutionConfig.Name, err)
+		}
+		clientState.Conn = nil
+	}
+
+	// Per-user OAuth clients have no persistent connection — their ToolMap holds
+	// tools discovered via OAuth that can only be recovered by re-running the OAuth
+	// flow. Preserve the ToolMap so re-enabling restores tools immediately.
+	if clientState.ExecutionConfig.AuthType != schemas.MCPAuthTypePerUserOauth {
+		clientState.ToolMap = make(map[string]schemas.ChatTool)
+		clientState.ToolNameMapping = make(map[string]string)
+	}
+	clientState.State = schemas.MCPConnectionStateDisabled
+	clientState.ExecutionConfig.Disabled = true
+	m.logger.Debug("%s MCP client '%s' disabled successfully", MCPLogPrefix, clientState.ExecutionConfig.Name)
+	return nil
+}
+
+// EnableClient re-enables a previously disabled MCP client by reconnecting it
+// and restarting its health monitor and tool syncer.
+//
+// Parameters:
+//   - id: ID of the client to enable
+//
+// Returns:
+//   - error: Any error that occurred during enable or connection
+func (m *MCPManager) EnableClient(id string) error {
+	m.mu.Lock()
+	clientState, ok := m.clientMap[id]
+	if !ok {
+		m.mu.Unlock()
+		return fmt.Errorf("client %s not found", id)
+	}
+	if clientState.State != schemas.MCPConnectionStateDisabled {
+		m.mu.Unlock()
+		return fmt.Errorf("client %s is not disabled (current state: %s)", clientState.ExecutionConfig.Name, clientState.State)
+	}
+
+	clientState.ExecutionConfig.Disabled = false
+	configCopy := clientState.ExecutionConfig
+	m.mu.Unlock()
+
+	m.logger.Debug("%s Enabling MCP client '%s'", MCPLogPrefix, configCopy.Name)
+
+	// Per-user OAuth clients have no persistent connection — auth is per-request.
+	// Mirror the AddClient early-return path: just restore the runtime state based
+	// on whether tools were previously discovered.
+	if configCopy.AuthType == schemas.MCPAuthTypePerUserOauth {
+		m.mu.Lock()
+		if cs, exists := m.clientMap[id]; exists {
+			if len(cs.ToolMap) > 0 {
+				cs.State = schemas.MCPConnectionStateConnected
+			} else {
+				cs.State = schemas.MCPConnectionStatePendingTools
+			}
+		}
+		m.mu.Unlock()
+		m.logger.Debug("%s Per-user OAuth MCP client '%s' enabled (no persistent connection)", MCPLogPrefix, configCopy.Name)
+		return nil
+	}
+
+	// Guard against concurrent reconnects for the same client from any caller
+	// (health monitor, manual API call, etc.). LoadOrStore is atomic — whichever
+	// caller arrives second gets the "already in progress" error immediately.
+	if _, alreadyReconnecting := m.reconnectingClients.LoadOrStore(id, true); alreadyReconnecting {
+		return fmt.Errorf("reconnect already in progress for this client")
+	}
+	defer m.reconnectingClients.Delete(id)
+
+	if err := m.connectToMCPClient(configCopy); err != nil {
+		// Connection failed — leave the entry as Disconnected so the health monitor can
+		// recover it, but only if the client has not been disabled in the meantime.
+		m.mu.Lock()
+		alreadyDisabled := false
+		if cs, exists := m.clientMap[id]; exists {
+			if cs.State == schemas.MCPConnectionStateDisabled {
+				alreadyDisabled = true
+			} else {
+				cs.State = schemas.MCPConnectionStateDisconnected
+			}
+		}
+		m.mu.Unlock()
+
+		if !alreadyDisabled {
+			isPingAvailable := true
+			if configCopy.IsPingAvailable != nil {
+				isPingAvailable = *configCopy.IsPingAvailable
+			}
+			monitor := NewClientHealthMonitor(m, id, DefaultHealthCheckInterval, isPingAvailable, m.logger)
+			m.healthMonitorManager.StartMonitoring(monitor)
+		}
+
+		return fmt.Errorf("failed to connect MCP client '%s': %w", configCopy.Name, err)
+	}
+
+	m.logger.Debug("%s MCP client '%s' enabled successfully", MCPLogPrefix, configCopy.Name)
+	return nil
+}
+
 // UpdateClient updates an existing MCP client's configuration and refreshes its tool list.
 // It updates the client's execution config with new settings and retrieves updated tools
 // from the MCP server if the client is connected.
@@ -371,6 +534,7 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 		IsPingAvailable:       updatedConfig.IsPingAvailable,
 		ToolSyncInterval:      updatedConfig.ToolSyncInterval,
 		AllowOnAllVirtualKeys: updatedConfig.AllowOnAllVirtualKeys,
+		Disabled:              updatedConfig.Disabled,
 	}
 
 	// Atomically replace the config pointer
@@ -540,6 +704,15 @@ func (m *MCPManager) connectToMCPClient(config *schemas.MCPClientConfig) error {
 
 	// Initialize or validate client entry
 	if existingClient, exists := m.clientMap[config.ID]; exists {
+		// If the client is disabled and the caller is not explicitly re-enabling it
+		// (EnableClient sets config.Disabled = false before calling here; ReconnectClient
+		// and the health-monitor path leave it as-is), bail out now — before we overwrite
+		// the Disabled entry — so the Disabled state is preserved.
+		if existingClient.State == schemas.MCPConnectionStateDisabled && config.Disabled {
+			m.mu.Unlock()
+			return fmt.Errorf("client %s is disabled", config.Name)
+		}
+
 		// Client entry exists from config, check for existing connection, if it does then close
 		if existingClient.CancelFunc != nil {
 			existingClient.CancelFunc()
@@ -729,6 +902,23 @@ func (m *MCPManager) connectToMCPClient(config *schemas.MCPClientConfig) error {
 
 	// Verify client still exists (could have been cleaned up during heavy operations)
 	if client, exists := m.clientMap[config.ID]; exists {
+		// If the client was disabled while we were doing the whole connection process
+		// roll back the newly established connection and abort — do not overwrite the Disabled state.
+		// This is a rare edge case where the client was disabled while we were doing the whole connection process
+		if client.State == schemas.MCPConnectionStateDisabled {
+			m.mu.Unlock()
+			if (config.ConnectionType == schemas.MCPConnectionTypeSSE || config.ConnectionType == schemas.MCPConnectionTypeSTDIO) && cancel != nil {
+				cancel()
+			}
+			if externalClient != nil {
+				if closeErr := externalClient.Close(); closeErr != nil {
+					m.logger.Warn("%s Failed to close external client during disable rollback: %v", MCPLogPrefix, closeErr)
+				}
+			}
+			m.logger.Debug("%s [%s] Client was disabled during connection setup; rolling back", MCPLogPrefix, config.Name)
+			return fmt.Errorf("client %s was disabled during connection setup", config.Name)
+		}
+
 		// Store the external client connection and details
 		client.Conn = externalClient
 		client.ConnectionInfo = connectionInfo
@@ -774,9 +964,12 @@ func (m *MCPManager) connectToMCPClient(config *schemas.MCPClientConfig) error {
 	if config.ConnectionType == schemas.MCPConnectionTypeSSE && externalClient != nil {
 		externalClient.OnConnectionLost(func(err error) {
 			m.logger.Warn("%s SSE connection lost for MCP server '%s': %v", MCPLogPrefix, config.Name, err)
-			// Update state to disconnected
+			// Update state to disconnected, but never overwrite a disabled state.
+			// DisableClient calls Conn.Close() while holding m.mu; the SSE library
+			// fires OnConnectionLost after the lock is released, by which point
+			// State is already Disabled — do not clobber it.
 			m.mu.Lock()
-			if client, exists := m.clientMap[config.ID]; exists {
+			if client, exists := m.clientMap[config.ID]; exists && client.State != schemas.MCPConnectionStateDisabled {
 				client.State = schemas.MCPConnectionStateDisconnected
 			}
 			m.mu.Unlock()

--- a/core/mcp/healthmonitor.go
+++ b/core/mcp/healthmonitor.go
@@ -145,13 +145,22 @@ func (chm *ClientHealthMonitor) performHealthCheck() {
 	// don't race with removeClientUnsafe zeroing it under the write lock.
 	chm.manager.mu.RLock()
 	clientState, exists := chm.manager.clientMap[chm.clientID]
+	var isDisabled bool
 	var conn *client.Client
 	if exists && clientState != nil {
 		conn = clientState.Conn
+		isDisabled = clientState.State == schemas.MCPConnectionStateDisabled
 	}
 	chm.manager.mu.RUnlock()
 
 	if !exists {
+		chm.Stop()
+		return
+	}
+
+	// Do not health-check intentionally disabled clients
+	// Health monitoring is already stopped for disabled clients. This is just a sanity check.
+	if isDisabled {
 		chm.Stop()
 		return
 	}
@@ -210,6 +219,17 @@ func (chm *ClientHealthMonitor) attemptReconnect() {
 
 	chm.logger.Debug("%s Attempting to reconnect MCP client %s...", MCPLogPrefix, chm.clientID)
 
+	// Do not attempt reconnect if the client has been intentionally disabled
+	// Health monitoring is already stopped for disabled clients. This is just a sanity check.
+	chm.manager.mu.RLock()
+	clientState, exists := chm.manager.clientMap[chm.clientID]
+	isDisabled := exists && clientState != nil && clientState.State == schemas.MCPConnectionStateDisabled
+	chm.manager.mu.RUnlock()
+	if isDisabled {
+		chm.logger.Debug("%s Skipping reconnect for disabled MCP client %s", MCPLogPrefix, chm.clientID)
+		return
+	}
+
 	if err := chm.manager.ReconnectClient(chm.clientID); err != nil {
 		chm.logger.Warn("%s Failed to reconnect MCP client %s: %v", MCPLogPrefix, chm.clientID, err)
 		return
@@ -224,6 +244,14 @@ func (chm *ClientHealthMonitor) updateClientState(state schemas.MCPConnectionSta
 	chm.manager.mu.Lock()
 	clientState, exists := chm.manager.clientMap[chm.clientID]
 	if !exists {
+		chm.manager.mu.Unlock()
+		return
+	}
+
+	// Never overwrite a disabled state. DisableClient is authoritative: a health
+	// check tick or reconnect callback that races with DisableClient must not
+	// flip the client back to Disconnected/Connected.
+	if clientState.State == schemas.MCPConnectionStateDisabled {
 		chm.manager.mu.Unlock()
 		return
 	}

--- a/core/mcp/interface.go
+++ b/core/mcp/interface.go
@@ -62,6 +62,12 @@ type MCPManagerInterface interface {
 	// ReconnectClient reconnects an MCP client by ID
 	ReconnectClient(id string) error
 
+	// DisableClient shuts down a client's connection and workers without removing it
+	DisableClient(id string) error
+
+	// EnableClient reconnects a disabled client and restarts its workers
+	EnableClient(id string) error
+
 	// VerifyPerUserOAuthConnection creates a temporary MCP connection using a
 	// test access token to verify connectivity and discover tools. The connection
 	// is closed after verification.

--- a/core/mcp/utils.go
+++ b/core/mcp/utils.go
@@ -79,6 +79,12 @@ func (m *MCPManager) GetToolPerClient(ctx context.Context) map[string][]schemas.
 
 		m.logger.Debug("%s Evaluating client %s (ID: %s) for tools", MCPLogPrefix, clientName, clientID)
 
+		// Skip intentionally disabled clients
+		if client.State == schemas.MCPConnectionStateDisabled {
+			m.logger.Debug("%s Skipping disabled MCP client %s", MCPLogPrefix, clientName)
+			continue
+		}
+
 		// Apply client filtering logic - check both ID and Name for compatibility
 		if !shouldIncludeClient(clientName, includeClients, m.logger) {
 			m.logger.Debug("%s Skipping MCP client %s: not in include clients list", MCPLogPrefix, clientName)

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -175,6 +175,7 @@ type MCPClientConfig struct {
 	IsPingAvailable       *bool              `json:"is_ping_available,omitempty"`  // Whether the MCP server supports ping for health checks (nil/true = ping; false = listTools). Defaults to true.
 	ToolSyncInterval      time.Duration      `json:"tool_sync_interval,omitempty"` // Per-client override for tool sync interval (0 = use global, negative = disabled)
 	ToolPricing           map[string]float64 `json:"tool_pricing,omitempty"`       // Tool pricing for each tool (cost per execution)
+	Disabled              bool               `json:"disabled"`                     // Whether the client is intentionally disabled (stops connection and workers)
 	ConfigHash            string             `json:"-"`                            // Config hash for reconciliation (not serialized)
 	AllowOnAllVirtualKeys bool               `json:"allow_on_all_virtual_keys"`    // Whether to allow the MCP client to run on all virtual keys
 
@@ -360,6 +361,7 @@ const (
 	MCPConnectionStateDisconnected MCPConnectionState = "disconnected"  // Client is not connected
 	MCPConnectionStateError        MCPConnectionState = "error"         // Client is in an error state, and cannot be used
 	MCPConnectionStatePendingTools MCPConnectionState = "pending_tools" // Connected but tools not yet populated
+	MCPConnectionStateDisabled     MCPConnectionState = "disabled"      // Client is intentionally disabled by the user
 )
 
 // MCPClientState represents a connected MCP client with its configuration and tools.

--- a/docs/mcp/connecting-to-servers.mdx
+++ b/docs/mcp/connecting-to-servers.mdx
@@ -921,6 +921,44 @@ if err != nil {
 
 ---
 
+## Disabling and Re-enabling Clients
+
+You can temporarily disable an MCP client without removing it. When disabled, Bifrost shuts down the client's connection, health monitor, and tool syncer. The client entry is preserved and its tools are invisible to inference requests until it is re-enabled.
+
+<Tabs>
+<Tab title="Web UI">
+
+Use the **Enabled** toggle in the MCP Server Catalog table to disable or re-enable a client with a single click. The toggle shows a loading spinner while the API call is in flight and automatically reflects the updated state.
+
+![MCP client enable/disable toggle in the server catalog table](/images/placeholder-mcp-disable-toggle.png)
+
+</Tab>
+<Tab title="Gateway API">
+
+```bash
+# Disable a client
+curl -X PUT http://localhost:8080/api/mcp/client/{id} \
+  -H "Content-Type: application/json" \
+  -d '{"disabled": true}'
+
+# Re-enable a client (reconnects automatically)
+curl -X PUT http://localhost:8080/api/mcp/client/{id} \
+  -H "Content-Type: application/json" \
+  -d '{"disabled": false}'
+```
+
+</Tab>
+<Tab title="config.json">
+
+The `disabled` field is a runtime API state and **cannot** be set in `config.json`. Clients defined in `config.json` always start enabled. Use the Web UI or Gateway API to disable a client after it has been created.
+
+</Tab>
+</Tabs>
+
+The `disabled` state persists across restarts — a disabled client is loaded into memory on boot but its connection is not established until it is explicitly re-enabled. Config changes (name, tools, headers) sent in the same PUT request as a `disabled` change are applied before the connection is shut down or re-established.
+
+---
+
 ## Naming Conventions
 
 MCP client names have specific requirements:

--- a/docs/openapi/paths/management/mcp.yaml
+++ b/docs/openapi/paths/management/mcp.yaml
@@ -126,6 +126,7 @@ client-by-id:
       Updates an existing MCP client's configuration.
       Unlike client creation, tool_pricing can be included to set per-tool execution costs since tools are already fetched.
       Optionally provide vk_configs to manage which virtual keys have access to this MCP server and with which tools. When provided, this fully replaces all existing VK assignments in a single atomic transaction.
+      Set disabled: true to shut down the client's connection and workers without removing it. Set disabled: false to reconnect a previously disabled client.
     tags:
       - MCP
     parameters:

--- a/docs/openapi/schemas/management/mcp.yaml
+++ b/docs/openapi/schemas/management/mcp.yaml
@@ -17,8 +17,14 @@ MCPConnectionType:
 
 MCPConnectionState:
   type: string
-  enum: [connected, disconnected, error]
-  description: Connection state of an MCP client
+  enum: [connected, disconnected, error, pending_tools, disabled]
+  description: |
+    Connection state of an MCP client:
+    - connected: Client is connected and ready to use
+    - disconnected: Client is not connected (will be auto-recovered by health monitor)
+    - error: Client is in an unrecoverable error state
+    - pending_tools: Connected but tools not yet populated (per-user OAuth clients)
+    - disabled: Client has been intentionally disabled; no connection or workers are active
 
 MCPStdioConfig:
   type: object
@@ -242,6 +248,13 @@ MCPClientUpdateRequest:
         When true, this MCP client's tools are accessible to all virtual keys without requiring
         explicit per-key assignment. All tools are allowed by default. If a virtual key has an
         explicit MCP config for this client, that config takes precedence and overrides this behaviour.
+    disabled:
+      type: boolean
+      default: false
+      description: |
+        When true, the client's connection, health monitor, and tool syncer are shut down.
+        The client entry is preserved so it can be re-enabled later by sending disabled: false.
+        Disabled clients do not expose tools to inference requests.
     vk_configs:
       type: array
       items:
@@ -342,6 +355,12 @@ MCPClientConfig:
         When true, this MCP client's tools are accessible to all virtual keys without requiring
         explicit per-key assignment. All tools are allowed by default. If a virtual key has an
         explicit MCP config for this client, that config takes precedence and overrides this behaviour.
+    disabled:
+      type: boolean
+      default: false
+      description: |
+        Whether the client is intentionally disabled.
+        When true, the client has no active connection or workers and its tools are not available for inference.
 
 ChatToolFunction:
   type: object

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1239,6 +1239,9 @@ func GenerateMCPClientHash(m tables.TableMCPClient) (string, error) {
 			}
 		}
 	}
+
+	// will enable it in the future with a migration
+	// hash.Write([]byte("disabled:" + strconv.FormatBool(m.Disabled)))
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -632,6 +632,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddAllowPerRequestRawOverrideColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddMCPClientDisabledColumn(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -7245,6 +7248,41 @@ func migrationSplitMCPExternalBaseURL(ctx context.Context, db *gorm.DB) error {
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running split_mcp_external_base_url_into_server_client migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddMCPClientDisabledColumn adds the disabled column to the config_mcp_clients table
+func migrationAddMCPClientDisabledColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_mcp_client_disabled_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TableMCPClient{}, "disabled") {
+				if err := mg.AddColumn(&tables.TableMCPClient{}, "disabled"); err != nil {
+					return fmt.Errorf("failed to add disabled column: %w", err)
+				}
+				// Initialize existing rows with false (default value)
+				if err := tx.Exec("UPDATE config_mcp_clients SET disabled = false WHERE disabled IS NULL").Error; err != nil {
+					return fmt.Errorf("failed to initialize disabled column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasColumn(&tables.TableMCPClient{}, "disabled") {
+				if err := mg.DropColumn(&tables.TableMCPClient{}, "disabled"); err != nil {
+					return fmt.Errorf("failed to drop disabled column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_mcp_client_disabled_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1247,6 +1247,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 					ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
 					ToolPricing:               dbClient.ToolPricing,
 					AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
+					Disabled:                  dbClient.Disabled,
 					DiscoveredTools:           dbClient.DiscoveredTools,
 					DiscoveredToolNameMapping: dbClient.DiscoveredToolNameMapping,
 				}
@@ -1285,6 +1286,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 			IsPingAvailable:           dbClient.IsPingAvailable,
 			ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
 			AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
+			Disabled:                  dbClient.Disabled,
 			ToolPricing:               dbClient.ToolPricing,
 			DiscoveredTools:           dbClient.DiscoveredTools,
 			DiscoveredToolNameMapping: dbClient.DiscoveredToolNameMapping,
@@ -1369,6 +1371,7 @@ func (s *RDBConfigStore) GetMCPClientConfigByID(ctx context.Context, id string) 
 		IsPingAvailable:           dbClient.IsPingAvailable,
 		ToolSyncInterval:          time.Duration(dbClient.ToolSyncInterval) * time.Second,
 		AllowOnAllVirtualKeys:     dbClient.AllowOnAllVirtualKeys,
+		Disabled:                  dbClient.Disabled,
 		ToolPricing:               dbClient.ToolPricing,
 		DiscoveredTools:           dbClient.DiscoveredTools,
 		DiscoveredToolNameMapping: dbClient.DiscoveredToolNameMapping,
@@ -1423,6 +1426,7 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 			// DiscoveredTools has json:"-" so deepCopy loses it; use original clientConfig
 			DiscoveredTools:           clientConfig.DiscoveredTools,
 			DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
+			Disabled:                  clientConfigCopy.Disabled,
 		}
 		if err := tx.WithContext(ctx).Create(&dbClient).Error; err != nil {
 			return s.parseGormError(err)
@@ -1527,6 +1531,7 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 			"tool_pricing_json":          string(toolPricingJSON),
 			"tool_sync_interval":         clientConfigCopy.ToolSyncInterval,
 			"allow_on_all_virtual_keys":  clientConfigCopy.AllowOnAllVirtualKeys,
+			"disabled":                   clientConfigCopy.Disabled,
 			"updated_at":                 time.Now(),
 		}
 		if encrypt.IsEnabled() {

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -38,6 +38,7 @@ type TableMCPClient struct {
 	OauthConfig   *TableOauthConfig `gorm:"foreignKey:OauthConfigID;references:ID;constraint:OnDelete:CASCADE" json:"-"` // Gorm relationship
 
 	AllowOnAllVirtualKeys bool `gorm:"default:false" json:"allow_on_all_virtual_keys"` // Whether to allow the MCP client to run on all virtual keys
+	Disabled              bool `gorm:"default:false" json:"disabled"`                  // Whether the client is intentionally disabled
 
 	// Config hash is used to detect the changes synced from config.json file
 	// Every time we sync the config.json file, we will update the config hash

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -27,6 +27,8 @@ type MCPManager interface {
 	RemoveMCPClient(ctx context.Context, id string) error
 	UpdateMCPClient(ctx context.Context, id string, updatedConfig *schemas.MCPClientConfig) error
 	ReconnectMCPClient(ctx context.Context, id string) error
+	DisableMCPClient(ctx context.Context, id string) error
+	EnableMCPClient(ctx context.Context, id string) error
 	// VerifyPerUserOAuthConnection verifies an MCP server using a temporary access
 	// token and discovers available tools. The connection is closed after verification.
 	VerifyPerUserOAuthConnection(ctx context.Context, config *schemas.MCPClientConfig, accessToken string) (map[string]schemas.ChatTool, map[string]string, error)
@@ -295,6 +297,7 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, 
 			ToolSyncInterval:      time.Duration(dbClient.ToolSyncInterval) * time.Second,
 			ToolPricing:           dbClient.ToolPricing,
 			AllowOnAllVirtualKeys: dbClient.AllowOnAllVirtualKeys,
+			Disabled:              dbClient.Disabled,
 		}
 		// Enrich VK assignments using the pre-fetched batch result (no extra DB call per client)
 		vkConfigs := []MCPVKConfigResponse{}
@@ -347,6 +350,18 @@ func (h *MCPHandler) reconnectMCPClient(ctx *fasthttp.RequestCtx) {
 	if err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid id: %v", err))
 		return
+	}
+	// Reject reconnect requests for disabled clients — the client must be enabled first.
+	if h.store.MCPConfig != nil {
+		for _, client := range h.store.MCPConfig.ClientConfigs {
+			if client.ID == id {
+				if client.Disabled {
+					SendError(ctx, fasthttp.StatusBadRequest, "cannot reconnect a disabled MCP client: enable the client first")
+					return
+				}
+				break
+			}
+		}
 	}
 	if err := h.mcpManager.ReconnectMCPClient(ctx, id); err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to reconnect MCP client: %v", err))
@@ -791,8 +806,11 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		ToolSyncInterval:      toolSyncInterval,
 		ToolPricing:           req.ToolPricing,
 		AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
+		Disabled:              req.Disabled,
 	}
-	// Update MCP client in memory
+
+	// Update MCP client config in memory (always — applies name/tools/header changes,
+	// and also triggers disable/enable lifecycle if the Disabled flag toggled)
 	if err := h.mcpManager.UpdateMCPClient(ctx, id, schemasConfig); err != nil {
 		// Rollback DB update to keep DB and memory in sync
 		if h.store.ConfigStore != nil && oldDBConfig != nil {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1261,6 +1261,7 @@ func mcpClientConfigToTable(clientConfig *schemas.MCPClientConfig) (configstoreT
 		ToolSyncInterval:          int(clientConfig.ToolSyncInterval / time.Second),
 		ToolPricing:               clientConfig.ToolPricing,
 		AllowOnAllVirtualKeys:     clientConfig.AllowOnAllVirtualKeys,
+		Disabled:                  clientConfig.Disabled,
 		DiscoveredTools:           clientConfig.DiscoveredTools,
 		DiscoveredToolNameMapping: clientConfig.DiscoveredToolNameMapping,
 		ConfigHash:                clientConfig.ConfigHash,
@@ -4535,10 +4536,13 @@ func (c *Config) UpdateMCPClient(ctx context.Context, id string, updatedConfig *
 	if !found {
 		return fmt.Errorf("MCP client '%s' not found", id)
 	}
+	oldDisabled := oldConfig.Disabled
 	// Check if client is registered in Bifrost (can be not registered if client initialization failed)
+	clientRegistered := false
 	if clients, err := c.client.GetMCPClients(); err == nil && len(clients) > 0 {
 		for _, client := range clients {
 			if client.Config.ID == id {
+				clientRegistered = true
 				if err := c.client.UpdateMCPClient(id, updatedConfig); err != nil {
 					// Rollback in-memory changes
 					c.MCPConfig.ClientConfigs[configIndex] = oldConfig
@@ -4583,6 +4587,27 @@ func (c *Config) UpdateMCPClient(ctx context.Context, id string, updatedConfig *
 	c.MCPConfig.ClientConfigs[configIndex].IsPingAvailable = updatedConfig.IsPingAvailable
 	c.MCPConfig.ClientConfigs[configIndex].ToolSyncInterval = updatedConfig.ToolSyncInterval
 	c.MCPConfig.ClientConfigs[configIndex].AllowOnAllVirtualKeys = updatedConfig.AllowOnAllVirtualKeys
+	c.MCPConfig.ClientConfigs[configIndex].Disabled = updatedConfig.Disabled
+
+	// Handle disable/enable lifecycle when the Disabled flag toggles and the client
+	// is registered at runtime. We call the core bifrost methods directly (not the
+	// Config wrappers) to avoid a redundant DB write — the caller is responsible for
+	// persisting the disabled flag to the DB before calling UpdateMCPClient.
+	if oldDisabled != updatedConfig.Disabled && clientRegistered {
+		if updatedConfig.Disabled {
+			if err := c.client.DisableMCPClient(id); err != nil {
+				// Rollback the in-memory Disabled flag so the runtime view stays
+				// consistent with what the caller can observe.
+				c.MCPConfig.ClientConfigs[configIndex].Disabled = oldDisabled
+				return fmt.Errorf("failed to disable MCP client: %w", err)
+			}
+		} else {
+			if err := c.client.EnableMCPClient(id); err != nil {
+				c.MCPConfig.ClientConfigs[configIndex].Disabled = oldDisabled
+				return fmt.Errorf("failed to enable MCP client: %w", err)
+			}
+		}
+	}
 	return nil
 }
 
@@ -4621,6 +4646,77 @@ func (c *Config) RemoveMCPClient(ctx context.Context, id string) error {
 		}
 	}
 	return nil
+}
+
+// DisableMCPClient persists disabled=true to the DB and shuts down the client's
+// connection, health monitor, and tool syncer at runtime.
+func (c *Config) DisableMCPClient(ctx context.Context, id string) error {
+	if c.client == nil {
+		return fmt.Errorf("bifrost client not set")
+	}
+
+	if c.ConfigStore == nil {
+		return fmt.Errorf("config store not set")
+	}
+
+	dbClient, err := c.ConfigStore.GetMCPClientByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("MCP client '%s' not found: %w", id, err)
+	}
+	if err := c.client.DisableMCPClient(id); err != nil {
+		return fmt.Errorf("failed to disable MCP client: %w", err)
+	}
+
+	dbClient.Disabled = true
+	if err := c.ConfigStore.UpdateMCPClientConfig(ctx, id, dbClient); err != nil {
+		_ = c.client.EnableMCPClient(id) // rollback
+		return fmt.Errorf("failed to persist disabled state: %w", err)
+	}
+
+	c.muMCP.Lock()
+	defer c.muMCP.Unlock()
+	if c.MCPConfig != nil {
+		for _, cc := range c.MCPConfig.ClientConfigs {
+			if cc.ID == id {
+				cc.Disabled = true
+				break
+			}
+		}
+	}
+	return nil
+}
+
+// EnableMCPClient persists disabled=false to the DB and reconnects the client
+// at runtime, restarting its health monitor and tool syncer.
+func (c *Config) EnableMCPClient(ctx context.Context, id string) error {
+	if c.client == nil {
+		return fmt.Errorf("bifrost client not set")
+	}
+	if c.ConfigStore == nil {
+		return fmt.Errorf("config store not set")
+	}
+
+	dbClient, err := c.ConfigStore.GetMCPClientByID(ctx, id)
+	if err != nil {
+		return fmt.Errorf("MCP client '%s' not found: %w", id, err)
+	}
+	dbClient.Disabled = false
+	if err := c.ConfigStore.UpdateMCPClientConfig(ctx, id, dbClient); err != nil {
+		return fmt.Errorf("failed to persist enabled state: %w", err)
+	}
+
+	c.muMCP.Lock()
+	if c.MCPConfig != nil {
+		for _, cc := range c.MCPConfig.ClientConfigs {
+			if cc.ID == id {
+				cc.Disabled = false
+				break
+			}
+		}
+	}
+	c.muMCP.Unlock()
+
+	return c.client.EnableMCPClient(id)
 }
 
 // RedactMCPClientConfig creates a redacted copy of a MCPClientConfig configuration.

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -97,6 +97,8 @@ type ServerCallbacks interface {
 	// SetClientTools updates the tool map for an existing client.
 	SetClientTools(clientID string, tools map[string]schemas.ChatTool, toolNameMapping map[string]string)
 	ReconnectMCPClient(ctx context.Context, id string) error
+	DisableMCPClient(ctx context.Context, id string) error
+	EnableMCPClient(ctx context.Context, id string) error
 }
 
 // BifrostHTTPServer represents a HTTP server instance.
@@ -225,6 +227,28 @@ func (s *BifrostHTTPServer) RemoveMCPClient(ctx context.Context, id string) erro
 	}
 	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
 		logger.Warn("failed to sync MCP servers after removing client: %v", err)
+	}
+	return nil
+}
+
+// DisableMCPClient shuts down an MCP client's connection and workers without removing it.
+func (s *BifrostHTTPServer) DisableMCPClient(ctx context.Context, id string) error {
+	if err := s.Config.DisableMCPClient(ctx, id); err != nil {
+		return err
+	}
+	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
+		logger.Warn("failed to sync MCP servers after disabling client: %v", err)
+	}
+	return nil
+}
+
+// EnableMCPClient reconnects a disabled MCP client and restarts its health monitor and tool syncer.
+func (s *BifrostHTTPServer) EnableMCPClient(ctx context.Context, id string) error {
+	if err := s.Config.EnableMCPClient(ctx, id); err != nil {
+		return err
+	}
+	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
+		logger.Warn("failed to sync MCP servers after enabling client: %v", err)
 	}
 	return nil
 }

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2835,6 +2835,11 @@
           "type": "boolean",
           "description": "When true, this MCP server is accessible to all virtual keys without requiring explicit per-key assignment. All tools are allowed by default. If a virtual key has an explicit MCP config for this server, that config takes precedence and overrides this behaviour.",
           "default": false
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "When true, this MCP client is disabled (connection and workers are stopped while preserving configuration).",
+          "default": false
         }
       },
       "required": ["name", "connection_type"],

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -141,6 +141,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			is_code_mode_client: mcpClient.config.is_code_mode_client || false,
 			is_ping_available: mcpClient.config.is_ping_available === true || mcpClient.config.is_ping_available === undefined,
 			allow_on_all_virtual_keys: mcpClient.config.allow_on_all_virtual_keys || false,
+			disabled: mcpClient.config.disabled || false,
 			headers: mcpClient.config.headers,
 			tools_to_execute: mcpClient.config.tools_to_execute || [],
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
@@ -157,6 +158,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			is_code_mode_client: mcpClient.config.is_code_mode_client || false,
 			is_ping_available: mcpClient.config.is_ping_available === true || mcpClient.config.is_ping_available === undefined,
 			allow_on_all_virtual_keys: mcpClient.config.allow_on_all_virtual_keys || false,
+			disabled: mcpClient.config.disabled || false,
 			headers: mcpClient.config.headers,
 			tools_to_execute: mcpClient.config.tools_to_execute || [],
 			tools_to_auto_execute: mcpClient.config.tools_to_auto_execute || [],
@@ -175,6 +177,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 					is_code_mode_client: data.is_code_mode_client,
 					is_ping_available: data.is_ping_available,
 					allow_on_all_virtual_keys: data.allow_on_all_virtual_keys,
+					disabled: data.disabled,
 					headers: data.headers ?? {},
 					tools_to_execute: data.tools_to_execute,
 					tools_to_auto_execute: data.tools_to_auto_execute,
@@ -420,6 +423,37 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 													checked={field.value === true}
 													onCheckedChange={field.onChange}
 													data-testid="mcpclient-allow-on-all-virtual-keys-switch"
+												/>
+											</FormControl>
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="disabled"
+									render={({ field }) => (
+										<FormItem className="flex items-center justify-between rounded-lg border p-4">
+											<div className="flex items-center gap-2">
+												<FormLabel>Disable Client</FormLabel>
+												<TooltipProvider>
+													<Tooltip>
+														<TooltipTrigger asChild>
+															<Info className="text-muted-foreground h-4 w-4 cursor-help" />
+														</TooltipTrigger>
+														<TooltipContent className="max-w-xs">
+															<p>
+																When enabled, the client's connection, health monitor, and tool syncer are shut down. Tools from this
+																client will not be available for inference until it is re-enabled.
+															</p>
+														</TooltipContent>
+													</Tooltip>
+												</TooltipProvider>
+											</div>
+											<FormControl>
+												<Switch
+													checked={field.value === true}
+													onCheckedChange={field.onChange}
+													data-testid="mcpclient-disabled-switch"
 												/>
 											</FormControl>
 										</FormItem>

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -197,13 +197,14 @@ export default function MCPClientsTable({
 							<TableHead className="font-semibold">Enabled Tools</TableHead>
 							<TableHead className="font-semibold">Auto-execute Tools</TableHead>
 							<TableHead className="font-semibold">State</TableHead>
+							<TableHead className="font-semibold">Enabled</TableHead>
 							<TableHead className="w-20 text-right"></TableHead>
 						</TableRow>
 					</TableHeader>
 					<TableBody>
 						{mcpClients.length === 0 ? (
 							<TableRow>
-								<TableCell colSpan={8} className="h-24 text-center">
+								<TableCell colSpan={9} className="h-24 text-center">
 									<span className="text-muted-foreground text-sm">No matching MCP servers found.</span>
 								</TableCell>
 							</TableRow>
@@ -261,22 +262,27 @@ export default function MCPClientsTable({
 										<TableCell>
 											<Badge className={MCP_STATUS_COLORS[c.state]}>{c.state}</Badge>
 										</TableCell>
+										<TableCell>
+											<Badge variant={c.config.disabled ? "secondary" : "default"}>
+												{c.config.disabled ? "Disabled" : "Enabled"}
+											</Badge>
+										</TableCell>
 										<TableCell className="space-x-2 text-right" onClick={(e) => e.stopPropagation()}>
-											<span title={isPerUserOAuth ? "Reconnect not supported for per-user OAuth clients" : "Reconnect"}>
-												<Button
-													variant="ghost"
-													size="icon"
-													aria-label={isPerUserOAuth ? "Reconnect not supported for per-user OAuth clients" : "Reconnect"}
-													onClick={() => handleReconnect(c)}
-													disabled={isPerUserOAuth || reconnectingClients.includes(c.config.client_id) || !hasUpdateMCPClientAccess}
-												>
-													{reconnectingClients.includes(c.config.client_id) ? (
-														<Loader2 className="h-4 w-4 animate-spin" />
-													) : (
-														<RefreshCcw className="h-4 w-4" />
-													)}
-												</Button>
-											</span>
+									<span title={isPerUserOAuth ? "Reconnect not supported for per-user OAuth clients" : c.config.disabled ? "Enable the client before reconnecting" : "Reconnect"}>
+											<Button
+												variant="ghost"
+												size="icon"
+												aria-label={isPerUserOAuth ? "Reconnect not supported for per-user OAuth clients" : c.config.disabled ? "Enable the client before reconnecting" : "Reconnect"}
+												onClick={() => handleReconnect(c)}
+												disabled={isPerUserOAuth || c.config.disabled || reconnectingClients.includes(c.config.client_id) || !hasUpdateMCPClientAccess}
+											>
+												{reconnectingClients.includes(c.config.client_id) ? (
+													<Loader2 className="h-4 w-4 animate-spin" />
+												) : (
+													<RefreshCcw className="h-4 w-4" />
+												)}
+											</Button>
+										</span>
 
 											<AlertDialog>
 												<AlertDialogTrigger asChild>

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -95,11 +95,13 @@ export const DefaultPerformanceConfig = {
 	buffer_size: 5000,
 } satisfies ConcurrencyAndBufferSize;
 
-export const MCP_STATUS_COLORS = {
+export const MCP_STATUS_COLORS: Record<string, string> = {
 	connected: "bg-green-100 text-green-800",
 	error: "bg-red-100 text-red-800",
 	disconnected: "bg-gray-100 text-gray-800",
-} as const;
+	pending_tools: "bg-yellow-100 text-yellow-800",
+	disabled: "bg-orange-100 text-orange-800",
+};
 
 // Mapping of what IS supported by each base provider
 export const PROVIDER_SUPPORTED_REQUESTS: Record<BaseProvider, string[]> = {

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -76,6 +76,12 @@ export const mcpApi = baseApi.injectEndpoints({
 									if (data.is_ping_available !== undefined) draft.clients[index].config.is_ping_available = data.is_ping_available;
 									if (data.tool_pricing !== undefined) draft.clients[index].config.tool_pricing = data.tool_pricing;
 									if (data.tool_sync_interval !== undefined) draft.clients[index].config.tool_sync_interval = data.tool_sync_interval;
+									if (data.disabled !== undefined) {
+										draft.clients[index].config.disabled = data.disabled;
+										if (data.disabled) {
+											draft.clients[index].state = "disabled";
+										}
+									}
 								}
 							}),
 						);

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -3,7 +3,7 @@ import { EnvVar } from "./schemas";
 
 export type MCPConnectionType = "http" | "stdio" | "sse";
 
-export type MCPConnectionState = "connected" | "disconnected" | "error";
+export type MCPConnectionState = "connected" | "disconnected" | "error" | "pending_tools" | "disabled";
 
 export type MCPAuthType = "none" | "headers" | "oauth" | "per_user_oauth";
 
@@ -42,6 +42,7 @@ export interface MCPClientConfig {
 	tool_sync_interval?: number; // Per-client override in minutes (0 = use global, -1 = disabled)
 	allowed_extra_headers?: string[]; // Allowlist of x-bf-eh-* headers forwarded to this MCP server. ["*"] = allow all.
 	allow_on_all_virtual_keys?: boolean; // When true, available to all VKs with all tools allowed by default; explicit VK config overrides this
+	disabled?: boolean; // When true, connection/workers are shut down; tools are unavailable until re-enabled
 }
 
 export interface MCPVKConfigResponse {
@@ -106,6 +107,7 @@ export interface UpdateMCPClientRequest {
 	tool_sync_interval?: number; // Per-client override in minutes (0 = use global, -1 = disabled)
 	allowed_extra_headers?: string[]; // Allowlist of x-bf-eh-* headers forwarded to this MCP server. ["*"] = allow all.
 	allow_on_all_virtual_keys?: boolean; // When true, available to all VKs with all tools allowed by default; explicit VK config overrides this
+	disabled?: boolean; // Set to true to shut down connection/workers; false to reconnect
 	vk_configs?: MCPVKConfig[]; // When provided, replaces all VK assignments for this MCP client
 }
 

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1049,6 +1049,7 @@ export const mcpClientUpdateSchema = z.object({
   is_code_mode_client: z.boolean().optional(),
   is_ping_available: z.boolean().optional(),
   allow_on_all_virtual_keys: z.boolean().optional(),
+  disabled: z.boolean().optional(),
   name: z
     .string()
     .min(1, "Name is required")


### PR DESCRIPTION
## Summary

Adds the ability to temporarily disable an MCP client without removing it. When disabled, the client's connection, health monitor, and tool syncer are shut down, and its tools become invisible to inference requests. The client entry is preserved in a `disabled` state and can be re-enabled at any time, automatically reconnecting and restarting all workers.

## Changes

- Added `MCPConnectionStateDisabled` connection state and a `Disabled` boolean field to `MCPClientConfig` and the database table (`config_mcp_clients`)
- Implemented `DisableClient` and `EnableClient` on `MCPManager`: disable tears down the connection, cancels the context, stops the health monitor and tool syncer, and clears the tool map (preserving it for per-user OAuth clients); enable reconnects and restarts workers, falling back to `disconnected` + health monitor recovery if the initial connection fails
- Added `DisableMCPClient` / `EnableMCPClient` to the `Bifrost` core, `MCPManagerInterface`, HTTP handler, server callbacks, and `Config` layer, with DB persistence on each toggle
- The `updateMCPClient` HTTP handler detects a `disabled` field change and calls disable/enable after applying all other config changes, so name/tool/header updates are always applied first
- Health monitor and reconnect logic now short-circuit for disabled clients as a safety guard
- `GetToolPerClient` skips disabled clients so their tools are never surfaced to inference
- Added a database migration (`add_mcp_client_disabled_column`) to backfill the new column
- Disabled clients loaded from the DB or `config.json` on boot are registered as dormant placeholders with no connection or workers
- `connectToMCPClient` detects if a client was disabled during the async connection setup and rolls back the newly established connection rather than overwriting the disabled state
- UI: added an "Enabled" column with a badge to the MCP clients table, disabled the reconnect button for disabled clients, added a "Disable Client" toggle switch in the client edit sheet, extended `MCPConnectionState` and `MCP_STATUS_COLORS` to include `pending_tools` and `disabled`, and wired `disabled` through the update request schema and form state
- Documentation updated with a disable/enable section covering the Web UI toggle, Gateway API `PUT` examples, and a note that `config.json` does not support the `disabled` field at load time; OpenAPI schema updated to include `pending_tools` and `disabled` in `MCPConnectionState` and `disabled` in `MCPClientUpdateRequest` and `MCPClientConfig`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./...

# UI
cd ui
pnpm i
pnpm build
```

1. Create an MCP client via the Gateway API or Web UI.
2. Send `PUT /api/mcp/client/{id}` with `{"disabled": true}` and confirm the response shows `state: disabled`.
3. Issue an inference request that would normally use the client's tools and confirm no tools from that client appear.
4. Send `PUT /api/mcp/client/{id}` with `{"disabled": false}` and confirm the client reconnects and tools are available again.
5. Restart the server with a disabled client in the DB and confirm it boots without establishing a connection.
6. In the Web UI, verify the "Enabled" column badge and the "Disable Client" toggle in the edit sheet reflect and update the disabled state correctly.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth surfaces introduced. The `disabled` field is a runtime operational flag with no credential or PII exposure.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable