### PR TITLE
fix: correct `governance_budgets` join condition to use `virtual_key_id`

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2149,7 +2149,7 @@ func (s *RDBConfigStore) GetVirtualKeysPaginated(ctx context.Context, params Vir
 		case "name":
 			orderClause = fmt.Sprintf("governance_virtual_keys.name %s, governance_virtual_keys.id ASC", dir)
 		case "budget_spent":
-			orderClause = fmt.Sprintf("COALESCE(governance_budgets.current_usage, 0) %s, governance_virtual_keys.id ASC", dir)
+			orderClause = fmt.Sprintf("COALESCE(vk_budget_totals.total_usage, 0) %s, governance_virtual_keys.id ASC", dir)
 		case "created_at":
 			orderClause = fmt.Sprintf("governance_virtual_keys.created_at %s, governance_virtual_keys.id ASC", dir)
 		case "status":
@@ -2160,7 +2160,14 @@ func (s *RDBConfigStore) GetVirtualKeysPaginated(ctx context.Context, params Vir
 	// Fetch with preloads and pagination
 	query := preloadVirtualKeyBaseRelations(baseQuery)
 	if params.SortBy == "budget_spent" {
-		query = query.Joins("LEFT JOIN governance_budgets ON governance_budgets.id = governance_virtual_keys.budget_id")
+		// A virtual key can have multiple budgets (different reset intervals); take MAX so the
+		// highest-spending budget drives the sort without duplicating rows.
+		query = query.Joins(`LEFT JOIN (
+			SELECT virtual_key_id, MAX(current_usage) AS total_usage
+			FROM governance_budgets
+			WHERE virtual_key_id IS NOT NULL
+			GROUP BY virtual_key_id
+		) AS vk_budget_totals ON vk_budget_totals.virtual_key_id = governance_virtual_keys.id`)
 	}
 	var virtualKeys []tables.TableVirtualKey
 	if err := query.


### PR DESCRIPTION
## Summary

Fixes an incorrect JOIN condition used when sorting virtual keys by `budget_spent`. The previous join was matching on `governance_budgets.id = governance_virtual_keys.budget_id`, but the correct relationship is `governance_budgets.virtual_key_id = governance_virtual_keys.id`.

## Changes

- Corrected the LEFT JOIN condition in `GetVirtualKeysPaginated` to use `governance_budgets.virtual_key_id = governance_virtual_keys.id`, ensuring budget records are properly associated with their virtual keys when sorting by `budget_spent`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Create virtual keys with associated budgets.
2. Call the virtual keys paginated endpoint with `sort_by=budget_spent`.
3. Verify that results are returned correctly and sorted by the actual budget spent values rather than returning incorrect or empty results.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable