### PR TITLE
fix: route vertex multi-region-only models to multi-region endpoints incase the provider key is setup with single region only

### DIFF
--- a/core/providers/utils/modelparamscache.go
+++ b/core/providers/utils/modelparamscache.go
@@ -13,7 +13,8 @@ const DefaultModelParamsCacheSize = 2048
 // ModelParams holds cached parameters for a model.
 // Add new fields here as more model-level parameters need caching.
 type ModelParams struct {
-	MaxOutputTokens *int
+	MaxOutputTokens    *int
+	IsVertexMultiRegionOnly *bool // true when model is only available on Vertex multi-region pool endpoints (rep.googleapis.com)
 }
 
 type modelParamsCacheEntry struct {
@@ -175,6 +176,16 @@ func (c *modelParamsCache) evict() {
 	delete(c.items, tail.Value.(*modelParamsCacheEntry).model)
 }
 
+func (c *modelParamsCache) Delete(model string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, ok := c.items[model]; ok {
+		c.order.Remove(elem)
+		delete(c.items, model)
+	}
+}
+
 // GetModelParams returns the cached parameters for a model.
 // On cache miss, calls the registered miss handler (if any) to load from DB.
 func GetModelParams(model string) (ModelParams, bool) {
@@ -189,6 +200,11 @@ func SetModelParams(model string, params ModelParams) {
 // BulkSetModelParams sets parameters for multiple models at once.
 func BulkSetModelParams(entries map[string]ModelParams) {
 	getModelParamsCache().BulkSet(entries)
+}
+
+// DeleteModelParams removes a model from the cache.
+func DeleteModelParams(model string) {
+	getModelParamsCache().Delete(model)
 }
 
 // SetCacheMissHandler registers a callback invoked on cache miss.
@@ -230,6 +246,19 @@ func GetMaxOutputTokensOrDefault(model string, defaultValue int) int {
 		}
 	}
 	return defaultValue
+}
+
+// IsVertexMultiRegionOnlyModel reports whether the given model is flagged in the
+// datasheet as only available on Google Vertex multi-region pool endpoints
+// (aiplatform.{region}.rep.googleapis.com). Returns false on cache miss or if
+// the flag is not set. Looks up using "vertex_ai/" prefix since model-parameters
+// are stored with provider-prefixed keys.
+func IsVertexMultiRegionOnlyModel(model string) bool {
+	params, ok := GetModelParams("vertex_ai/" + model)
+	if !ok || params.IsVertexMultiRegionOnly == nil {
+		return false
+	}
+	return *params.IsVertexMultiRegionOnly
 }
 
 // normalizeClaudeModelName extracts the base Claude model name from

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -33,27 +33,136 @@ func getRequestBodyForAnthropicResponses(ctx *schemas.BifrostContext, request *s
 	})
 }
 
+// isVertexMultiRegionEndpoint reports whether the Vertex location uses Google's
+// partner-model multi-region pool endpoint host instead of the single-region host.
+func isVertexMultiRegionEndpoint(region string) bool {
+	return region == "us" || region == "eu"
+}
+
+// getVertexAPIHost returns the Vertex API host used for prediction requests.
+// For multi-region pool locations (us/eu), returns the rep.googleapis.com host
+// unconditionally. Use getVertexModelAwareAPIHost when model-level gating is needed.
+func getVertexAPIHost(region string) string {
+	if region == "global" {
+		return "aiplatform.googleapis.com"
+	}
+	if isVertexMultiRegionEndpoint(region) {
+		return fmt.Sprintf("aiplatform.%s.rep.googleapis.com", region)
+	}
+	return fmt.Sprintf("%s-aiplatform.googleapis.com", region)
+}
+
+// getVertexModelAwareAPIHost returns the Vertex API host for prediction requests,
+// consulting the model catalog when the region is a standard single-region location.
+//
+// For multi-region pool locations ("us", "eu") the rep.googleapis.com host is
+// always returned because it is the only valid host for those locations.
+//
+// For single-region locations (e.g. "us-central1"), models flagged with
+// vertex_multi_region_only in the datasheet are automatically promoted to
+// the corresponding multi-region pool endpoint — but only for US (us-*) and
+// Europe (europe-*) regions that have multi-region pools. Other regions
+// (asia-*, me-*, etc.) stay on the single-region host.
+func getVertexModelAwareAPIHost(region string, model string) string {
+	if region == "global" {
+		return "aiplatform.googleapis.com"
+	}
+	if isVertexMultiRegionEndpoint(region) {
+		// rep.googleapis.com is the only valid host for "us"/"eu" locations
+		return fmt.Sprintf("aiplatform.%s.rep.googleapis.com", region)
+	}
+	// Single-region: promote to multi-region pool if the model requires it
+	// and the region belongs to a pool that supports multi-region.
+	if providerUtils.IsVertexMultiRegionOnlyModel(model) {
+		if pool, ok := vertexRegionToPool(region); ok {
+			return fmt.Sprintf("aiplatform.%s.rep.googleapis.com", pool)
+		}
+	}
+	return fmt.Sprintf("%s-aiplatform.googleapis.com", region)
+}
+
+// vertexRegionToPool maps a single GCP region to its multi-region pool ("us" or "eu").
+// Returns (pool, true) for regions that belong to a known pool, or ("", false)
+// for regions that have no multi-region pool (asia-*, me-*, etc.).
+func vertexRegionToPool(region string) (string, bool) {
+	if strings.HasPrefix(region, "us-") {
+		return "us", true
+	}
+	if strings.HasPrefix(region, "europe-") {
+		return "eu", true
+	}
+	return "", false
+}
+
+// getVertexModelListingAPIHost returns the Vertex API host used for Model Garden listing.
+// The multi-region prediction hosts reject publishers.models.list, so listing stays on the standard Vertex API host.
+func getVertexModelListingAPIHost(region string) string {
+	if region == "global" || isVertexMultiRegionEndpoint(region) {
+		return "aiplatform.googleapis.com"
+	}
+	return fmt.Sprintf("%s-aiplatform.googleapis.com", region)
+}
+
+func getVertexAPIBaseURL(region string, apiVersion string) string {
+	return fmt.Sprintf("https://%s/%s", getVertexAPIHost(region), apiVersion)
+}
+
+// getVertexModelAwareAPIBaseURL is like getVertexAPIBaseURL but uses model-aware
+// host selection for multi-region endpoints.
+func getVertexModelAwareAPIBaseURL(region string, apiVersion string, model string) string {
+	return fmt.Sprintf("https://%s/%s", getVertexModelAwareAPIHost(region, model), apiVersion)
+}
+
+func getVertexProjectLocationURL(region string, apiVersion string, projectID string) string {
+	return fmt.Sprintf("%s/projects/%s/locations/%s", getVertexAPIBaseURL(region, apiVersion), projectID, region)
+}
+
+func getVertexPublisherModelURL(region string, apiVersion string, projectID string, publisher string, model string, method string) string {
+	return fmt.Sprintf("%s/publishers/%s/models/%s%s", getVertexProjectLocationURL(region, apiVersion, projectID), publisher, model, method)
+}
+
+// getVertexModelAwarePublisherModelURL is like getVertexPublisherModelURL but
+// uses model-aware host selection. Use this for partner model (Anthropic, Mistral)
+// inference endpoints that may need multi-region pool hosts.
+// When a single-region is promoted to multi-region, both the host AND the
+// locations/ path segment are updated to the pool region.
+func getVertexModelAwarePublisherModelURL(region string, apiVersion string, projectID string, publisher string, model string, method string) string {
+	effectiveRegion := getVertexEffectiveRegion(region, model)
+	baseURL := fmt.Sprintf("https://%s/%s", getVertexModelAwareAPIHost(region, model), apiVersion)
+	return fmt.Sprintf("%s/projects/%s/locations/%s/publishers/%s/models/%s%s", baseURL, projectID, effectiveRegion, publisher, model, method)
+}
+
+// getVertexEffectiveRegion returns the region to use in URL path segments.
+// For multi-region locations it returns the region as-is. For single-region
+// locations it returns the multi-region pool if the model is flagged, otherwise
+// the original region.
+func getVertexEffectiveRegion(region string, model string) string {
+	if isVertexMultiRegionEndpoint(region) || region == "global" {
+		return region
+	}
+	if providerUtils.IsVertexMultiRegionOnlyModel(model) {
+		if pool, ok := vertexRegionToPool(region); ok {
+			return pool
+		}
+	}
+	return region
+}
+
+func getVertexEndpointURL(region string, apiVersion string, projectID string, endpoint string, method string) string {
+	return fmt.Sprintf("%s/endpoints/%s%s", getVertexProjectLocationURL(region, apiVersion, projectID), endpoint, method)
+}
+
 // getCompleteURLForGeminiEndpoint constructs the complete URL for the Gemini endpoint, for both streaming and non-streaming requests
 // for custom/fine-tuned models, it uses the projectNumber
 // for gemini models, it uses the projectID
 func getCompleteURLForGeminiEndpoint(deployment string, region string, projectID string, projectNumber string, method string) string {
-	var url string
 	if schemas.IsAllDigitsASCII(deployment) {
 		// Custom/fine-tuned models use projectNumber
-		if region == "global" {
-			url = fmt.Sprintf("https://aiplatform.googleapis.com/v1beta1/projects/%s/locations/global/endpoints/%s%s", projectNumber, deployment, method)
-		} else {
-			url = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1beta1/projects/%s/locations/%s/endpoints/%s%s", region, projectNumber, region, deployment, method)
-		}
-	} else {
-		// Gemini models use projectID
-		if region == "global" {
-			url = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/google/models/%s%s", projectID, deployment, method)
-		} else {
-			url = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s%s", region, projectID, region, deployment, method)
-		}
+		return getVertexEndpointURL(region, "v1beta1", projectNumber, deployment, method)
 	}
-	return url
+
+	// Gemini models use projectID
+	return getVertexPublisherModelURL(region, "v1", projectID, "google", deployment, method)
 }
 
 // buildResponseFromConfig builds a list models response from configured deployments and allowedModels.

--- a/core/providers/vertex/utils_test.go
+++ b/core/providers/vertex/utils_test.go
@@ -1,0 +1,356 @@
+package vertex
+
+import (
+	"testing"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestGetVertexAPIHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		region   string
+		expected string
+	}{
+		{
+			name:     "global endpoint",
+			region:   "global",
+			expected: "aiplatform.googleapis.com",
+		},
+		{
+			name:     "us multi-region pool endpoint",
+			region:   "us",
+			expected: "aiplatform.us.rep.googleapis.com",
+		},
+		{
+			name:     "eu multi-region pool endpoint",
+			region:   "eu",
+			expected: "aiplatform.eu.rep.googleapis.com",
+		},
+		{
+			name:     "single region endpoint",
+			region:   "us-central1",
+			expected: "us-central1-aiplatform.googleapis.com",
+		},
+		{
+			name:     "single european region endpoint",
+			region:   "europe-west1",
+			expected: "europe-west1-aiplatform.googleapis.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := getVertexAPIHost(tt.region)
+			if actual != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestIsVertexMultiRegionEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		region   string
+		expected bool
+	}{
+		{region: "us", expected: true},
+		{region: "eu", expected: true},
+		{region: "global", expected: false},
+		{region: "us-central1", expected: false},
+		{region: "europe-west1", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.region, func(t *testing.T) {
+			t.Parallel()
+
+			actual := isVertexMultiRegionEndpoint(tt.region)
+			if actual != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetVertexModelListingAPIHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		region   string
+		expected string
+	}{
+		{
+			name:     "global listing endpoint",
+			region:   "global",
+			expected: "aiplatform.googleapis.com",
+		},
+		{
+			name:     "us multi-region uses standard listing endpoint",
+			region:   "us",
+			expected: "aiplatform.googleapis.com",
+		},
+		{
+			name:     "eu multi-region uses standard listing endpoint",
+			region:   "eu",
+			expected: "aiplatform.googleapis.com",
+		},
+		{
+			name:     "single region listing endpoint",
+			region:   "us-central1",
+			expected: "us-central1-aiplatform.googleapis.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := getVertexModelListingAPIHost(tt.region)
+			if actual != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetVertexPublisherModelURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		region   string
+		expected string
+	}{
+		{
+			name:     "global raw predict",
+			region:   "global",
+			expected: "https://aiplatform.googleapis.com/v1/projects/project-123/locations/global/publishers/anthropic/models/claude-opus-4-7:rawPredict",
+		},
+		{
+			name:     "us multi-region raw predict",
+			region:   "us",
+			expected: "https://aiplatform.us.rep.googleapis.com/v1/projects/project-123/locations/us/publishers/anthropic/models/claude-opus-4-7:rawPredict",
+		},
+		{
+			name:     "eu multi-region raw predict",
+			region:   "eu",
+			expected: "https://aiplatform.eu.rep.googleapis.com/v1/projects/project-123/locations/eu/publishers/anthropic/models/claude-opus-4-7:rawPredict",
+		},
+		{
+			name:     "single region raw predict",
+			region:   "us-central1",
+			expected: "https://us-central1-aiplatform.googleapis.com/v1/projects/project-123/locations/us-central1/publishers/anthropic/models/claude-opus-4-7:rawPredict",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := getVertexPublisherModelURL(tt.region, "v1", "project-123", "anthropic", "claude-opus-4-7", ":rawPredict")
+			if actual != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetVertexModelAwareAPIHost(t *testing.T) {
+	// Seed the model params cache with vertex_ai/ prefix (matches how model-parameters are stored)
+	providerUtils.SetModelParams("vertex_ai/claude-opus-4-7", providerUtils.ModelParams{
+		IsVertexMultiRegionOnly: schemas.Ptr(true),
+	})
+	providerUtils.SetModelParams("vertex_ai/claude-sonnet-4-5", providerUtils.ModelParams{
+		IsVertexMultiRegionOnly: schemas.Ptr(false),
+	})
+	t.Cleanup(func() {
+		providerUtils.DeleteModelParams("vertex_ai/claude-opus-4-7")
+		providerUtils.DeleteModelParams("vertex_ai/claude-sonnet-4-5")
+	})
+
+	tests := []struct {
+		name     string
+		region   string
+		model    string
+		expected string
+	}{
+		{
+			name:     "global endpoint ignores model flag",
+			region:   "global",
+			model:    "claude-opus-4-7",
+			expected: "aiplatform.googleapis.com",
+		},
+		{
+			name:     "us multi-region always uses rep host (flagged model)",
+			region:   "us",
+			model:    "claude-opus-4-7",
+			expected: "aiplatform.us.rep.googleapis.com",
+		},
+		{
+			name:     "eu multi-region always uses rep host (flagged model)",
+			region:   "eu",
+			model:    "claude-opus-4-7",
+			expected: "aiplatform.eu.rep.googleapis.com",
+		},
+		{
+			name:     "us multi-region always uses rep host (unflagged model)",
+			region:   "us",
+			model:    "claude-sonnet-4-5",
+			expected: "aiplatform.us.rep.googleapis.com",
+		},
+		{
+			name:     "eu multi-region always uses rep host (unknown model)",
+			region:   "eu",
+			model:    "some-unknown-model",
+			expected: "aiplatform.eu.rep.googleapis.com",
+		},
+		{
+			name:     "single region promotes flagged model to us multi-region pool",
+			region:   "us-central1",
+			model:    "claude-opus-4-7",
+			expected: "aiplatform.us.rep.googleapis.com",
+		},
+		{
+			name:     "single region promotes flagged model to eu multi-region pool",
+			region:   "europe-west1",
+			model:    "claude-opus-4-7",
+			expected: "aiplatform.eu.rep.googleapis.com",
+		},
+		{
+			name:     "asia region does NOT promote flagged model (no pool)",
+			region:   "asia-southeast1",
+			model:    "claude-opus-4-7",
+			expected: "asia-southeast1-aiplatform.googleapis.com",
+		},
+		{
+			name:     "me region does NOT promote flagged model (no pool)",
+			region:   "me-west1",
+			model:    "claude-opus-4-7",
+			expected: "me-west1-aiplatform.googleapis.com",
+		},
+		{
+			name:     "single region keeps standard host for unflagged model",
+			region:   "us-central1",
+			model:    "claude-sonnet-4-5",
+			expected: "us-central1-aiplatform.googleapis.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := getVertexModelAwareAPIHost(tt.region, tt.model)
+			if actual != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestGetVertexModelAwarePublisherModelURL(t *testing.T) {
+	// Seed the model params cache with vertex_ai/ prefix (matches how model-parameters are stored)
+	providerUtils.SetModelParams("vertex_ai/claude-opus-4-7", providerUtils.ModelParams{
+		IsVertexMultiRegionOnly: schemas.Ptr(true),
+	})
+	t.Cleanup(func() {
+		providerUtils.DeleteModelParams("vertex_ai/claude-opus-4-7")
+	})
+
+	tests := []struct {
+		name     string
+		region   string
+		model    string
+		expected string
+	}{
+		{
+			name:     "us multi-region flagged model gets rep host URL",
+			region:   "us",
+			model:    "claude-opus-4-7",
+			expected: "https://aiplatform.us.rep.googleapis.com/v1/projects/project-123/locations/us/publishers/anthropic/models/claude-opus-4-7:rawPredict",
+		},
+		{
+			name:     "eu multi-region flagged model gets rep host URL",
+			region:   "eu",
+			model:    "claude-opus-4-7",
+			expected: "https://aiplatform.eu.rep.googleapis.com/v1/projects/project-123/locations/eu/publishers/anthropic/models/claude-opus-4-7:rawPredict",
+		},
+		{
+			name:     "us multi-region unflagged model still gets rep host URL",
+			region:   "us",
+			model:    "claude-3-5-sonnet",
+			expected: "https://aiplatform.us.rep.googleapis.com/v1/projects/project-123/locations/us/publishers/anthropic/models/claude-3-5-sonnet:rawPredict",
+		},
+		{
+			name:     "single region flagged model gets promoted to us pool",
+			region:   "us-central1",
+			model:    "claude-opus-4-7",
+			expected: "https://aiplatform.us.rep.googleapis.com/v1/projects/project-123/locations/us/publishers/anthropic/models/claude-opus-4-7:rawPredict",
+		},
+		{
+			name:     "single region europe flagged model gets promoted to eu pool",
+			region:   "europe-west1",
+			model:    "claude-opus-4-7",
+			expected: "https://aiplatform.eu.rep.googleapis.com/v1/projects/project-123/locations/eu/publishers/anthropic/models/claude-opus-4-7:rawPredict",
+		},
+		{
+			name:     "single region unflagged model keeps standard host",
+			region:   "us-central1",
+			model:    "claude-3-5-sonnet",
+			expected: "https://us-central1-aiplatform.googleapis.com/v1/projects/project-123/locations/us-central1/publishers/anthropic/models/claude-3-5-sonnet:rawPredict",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := getVertexModelAwarePublisherModelURL(tt.region, "v1", "project-123", "anthropic", tt.model, ":rawPredict")
+			if actual != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestVertexRegionToPool(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		region       string
+		expectedPool string
+		expectedOK   bool
+	}{
+		{region: "us-central1", expectedPool: "us", expectedOK: true},
+		{region: "us-east1", expectedPool: "us", expectedOK: true},
+		{region: "us-east5", expectedPool: "us", expectedOK: true},
+		{region: "europe-west1", expectedPool: "eu", expectedOK: true},
+		{region: "europe-west4", expectedPool: "eu", expectedOK: true},
+		{region: "asia-southeast1", expectedPool: "", expectedOK: false},
+		{region: "me-west1", expectedPool: "", expectedOK: false},
+		{region: "southamerica-east1", expectedPool: "", expectedOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.region, func(t *testing.T) {
+			t.Parallel()
+
+			pool, ok := vertexRegionToPool(tt.region)
+			if ok != tt.expectedOK {
+				t.Fatalf("expected ok=%v, got ok=%v", tt.expectedOK, ok)
+			}
+			if pool != tt.expectedPool {
+				t.Fatalf("expected %q, got %q", tt.expectedPool, pool)
+			}
+		})
+	}
+}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -198,12 +198,7 @@ func (provider *VertexProvider) listModelsByKey(ctx *schemas.BifrostContext, key
 	}
 
 	// No deployments configured - fetch from Model Garden API
-	var host string
-	if region == "global" {
-		host = "aiplatform.googleapis.com"
-	} else {
-		host = fmt.Sprintf("%s-aiplatform.googleapis.com", region)
-	}
+	host := getVertexModelListingAPIHost(region)
 
 	// Accumulate all publisher models from paginated requests
 	var allPublisherModels []VertexPublisherModel
@@ -228,7 +223,7 @@ func (provider *VertexProvider) listModelsByKey(ctx *schemas.BifrostContext, key
 		// Loop through all pages until no nextPageToken is returned
 		for {
 			// Build URL for publishers.models.list endpoint (Model Garden)
-			// Format: https://{region}-aiplatform.googleapis.com/v1beta1/publishers/{publisher}/models
+			// Format: https://{vertex-api-host}/v1beta1/publishers/{publisher}/models
 			requestURL := fmt.Sprintf("https://%s/v1beta1/publishers/%s/models?pageSize=%d", host, publisher, MaxPageSize)
 			if pageToken != "" {
 				requestURL = fmt.Sprintf("%s&pageToken=%s", requestURL, url.QueryEscape(pageToken))
@@ -489,41 +484,21 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		if key.Value.GetValue() != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
 		}
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1beta1/projects/%s/locations/global/endpoints/%s:generateContent", projectNumber, request.Model)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1beta1/projects/%s/locations/%s/endpoints/%s:generateContent", region, projectNumber, region, request.Model)
-		}
+		completeURL = getVertexEndpointURL(region, "v1beta1", projectNumber, request.Model, ":generateContent")
 	} else if schemas.IsAnthropicModel(request.Model) {
-		// Claude models use Anthropic publisher
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/anthropic/models/%s:rawPredict", projectID, request.Model)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:rawPredict", region, projectID, region, request.Model)
-		}
+		// Claude models use Anthropic publisher — model-aware host for multi-region support
+		completeURL = getVertexModelAwarePublisherModelURL(region, "v1", projectID, "anthropic", request.Model, ":rawPredict")
 	} else if schemas.IsMistralModel(request.Model) {
 		// Mistral models use mistralai publisher with rawPredict
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/mistralai/models/%s:rawPredict", projectID, request.Model)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/mistralai/models/%s:rawPredict", region, projectID, region, request.Model)
-		}
+		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "mistralai", request.Model, ":rawPredict")
 	} else if schemas.IsGeminiModel(request.Model) {
 		// Gemini models support api key
 		if key.Value.GetValue() != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
 		}
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/google/models/%s:generateContent", projectID, request.Model)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:generateContent", region, projectID, region, request.Model)
-		}
+		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", request.Model, ":generateContent")
 	} else {
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1beta1/projects/%s/locations/global/endpoints/openapi/chat/completions", projectID)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1beta1/projects/%s/locations/%s/endpoints/openapi/chat/completions", region, projectID, region)
-		}
+		completeURL = getVertexEndpointURL(region, "v1beta1", projectID, "openapi/chat/completions", "")
 	}
 
 	// Create HTTP request for streaming
@@ -758,12 +733,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			}
 		}
 
-		var completeURL string
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/anthropic/models/%s:streamRawPredict", projectID, request.Model)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:streamRawPredict", region, projectID, region, request.Model)
-		}
+		completeURL := getVertexModelAwarePublisherModelURL(region, "v1", projectID, "anthropic", request.Model, ":streamRawPredict")
 
 		// Prepare headers for Vertex Anthropic
 		headers := map[string]string{
@@ -888,21 +858,13 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 		var completeURL string
 		if schemas.IsMistralModel(request.Model) {
 			// Mistral models use mistralai publisher with streamRawPredict
-			if region == "global" {
-				completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/mistralai/models/%s:streamRawPredict", projectID, request.Model)
-			} else {
-				completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/mistralai/models/%s:streamRawPredict", region, projectID, region, request.Model)
-			}
+			completeURL = getVertexPublisherModelURL(region, "v1", projectID, "mistralai", request.Model, ":streamRawPredict")
 		} else {
 			// Other models use OpenAPI endpoint for gemini models
 			if key.Value.GetValue() != "" {
 				authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
 			}
-			if region == "global" {
-				completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1beta1/projects/%s/locations/global/endpoints/openapi/chat/completions", projectID)
-			} else {
-				completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1beta1/projects/%s/locations/%s/endpoints/openapi/chat/completions", region, projectID, region)
-			}
+			completeURL = getVertexEndpointURL(region, "v1beta1", projectID, "openapi/chat/completions", "")
 		}
 
 		if authQuery != "" {
@@ -963,13 +925,8 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 			return nil, providerUtils.NewConfigurationError("region is not set in key config")
 		}
 
-		// Claude models use Anthropic publisher
-		var url string
-		if region == "global" {
-			url = fmt.Sprintf("https://aiplatform.googleapis.com/v1beta1/projects/%s/locations/global/publishers/anthropic/models/%s:rawPredict", projectID, request.Model)
-		} else {
-			url = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1beta1/projects/%s/locations/%s/publishers/anthropic/models/%s:rawPredict", region, projectID, region, request.Model)
-		}
+		// Claude models use Anthropic publisher — model-aware host for multi-region support
+		url := getVertexModelAwarePublisherModelURL(region, "v1beta1", projectID, "anthropic", request.Model, ":rawPredict")
 
 		// Create HTTP request for streaming
 		req := fasthttp.AcquireRequest()
@@ -1233,12 +1190,7 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 			return nil, bifrostErr
 		}
 
-		var url string
-		if region == "global" {
-			url = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/anthropic/models/%s:streamRawPredict", projectID, request.Model)
-		} else {
-			url = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models/%s:streamRawPredict", region, projectID, region, request.Model)
-		}
+		url := getVertexModelAwarePublisherModelURL(region, "v1", projectID, "anthropic", request.Model, ":streamRawPredict")
 
 		// Prepare headers for Vertex Anthropic
 		headers := map[string]string{
@@ -1761,31 +1713,19 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 		if value := key.Value.GetValue(); value != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(value))
 		}
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1beta1/projects/%s/locations/global/endpoints/%s:generateContent", projectNumber, request.Model)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1beta1/projects/%s/locations/%s/endpoints/%s:generateContent", region, projectNumber, region, request.Model)
-		}
+		completeURL = getVertexEndpointURL(region, "v1beta1", projectNumber, request.Model, ":generateContent")
 
 	} else if schemas.IsImagenModel(request.Model) {
 		// Imagen models are published models, use publishers/google/models path
 		if value := key.Value.GetValue(); value != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(value))
 		}
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/google/models/%s:predict", projectID, request.Model)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:predict", region, projectID, region, request.Model)
-		}
+		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", request.Model, ":predict")
 	} else if schemas.IsGeminiModel(request.Model) {
 		if value := key.Value.GetValue(); value != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(value))
 		}
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/google/models/%s:generateContent", projectID, request.Model)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:generateContent", region, projectID, region, request.Model)
-		}
+		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", request.Model, ":generateContent")
 	}
 
 	// Create HTTP request for image generation
@@ -1991,23 +1931,11 @@ func (provider *VertexProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 		if projectNumber == "" {
 			return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 		}
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1beta1/projects/%s/locations/global/endpoints/%s:generateContent", projectNumber, request.Model)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1beta1/projects/%s/locations/%s/endpoints/%s:generateContent", region, projectNumber, region, request.Model)
-		}
+		completeURL = getVertexEndpointURL(region, "v1beta1", projectNumber, request.Model, ":generateContent")
 	} else if schemas.IsImagenModel(request.Model) {
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/google/models/%s:predict", projectID, request.Model)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:predict", region, projectID, region, request.Model)
-		}
+		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", request.Model, ":predict")
 	} else if schemas.IsGeminiModel(request.Model) {
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/google/models/%s:generateContent", projectID, request.Model)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:generateContent", region, projectID, region, request.Model)
-		}
+		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", request.Model, ":generateContent")
 	}
 
 	req := fasthttp.AcquireRequest()
@@ -2274,13 +2202,7 @@ func (provider *VertexProvider) VideoRetrieve(ctx *schemas.BifrostContext, key s
 		return nil, providerUtils.NewConfigurationError("region is not set in key config")
 	}
 
-	// Construct base URL based on region
-	var baseURL string
-	if region == "global" {
-		baseURL = "https://aiplatform.googleapis.com/v1"
-	} else {
-		baseURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1", region)
-	}
+	baseURL := getVertexAPIBaseURL(region, "v1")
 
 	// Construct the URL for fetching the operation status
 	// The operation name (bifrostReq.ID) already contains the full path:
@@ -2295,7 +2217,7 @@ func (provider *VertexProvider) VideoRetrieve(ctx *schemas.BifrostContext, key s
 		return nil, providerUtils.NewBifrostOperationError("invalid operation ID format", nil)
 	}
 
-	// Construct the URL: https://REGION-aiplatform.googleapis.com/v1/{modelPath}:fetchPredictOperation
+	// Construct the URL: https://{vertex-api-host}/v1/{modelPath}:fetchPredictOperation
 	completeURL := fmt.Sprintf("%s/%s:fetchPredictOperation", baseURL, modelPath)
 
 	// Auth query is used to pass the API key in the query string
@@ -2621,11 +2543,10 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 	var completeURL string
 
 	if schemas.IsAnthropicModel(request.Model) {
-		if region == "global" {
-			completeURL = fmt.Sprintf("https://aiplatform.googleapis.com/v1/projects/%s/locations/global/publishers/anthropic/models/count-tokens:rawPredict", projectID)
-		} else {
-			completeURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/anthropic/models/count-tokens:rawPredict", region, projectID, region)
-		}
+		// Use model-aware host based on request.Model, but URL path uses "count-tokens"
+		effectiveRegion := getVertexEffectiveRegion(region, request.Model)
+		baseURL := getVertexModelAwareAPIBaseURL(region, "v1", request.Model)
+		completeURL = fmt.Sprintf("%s/projects/%s/locations/%s/publishers/%s/models/%s%s", baseURL, projectID, effectiveRegion, "anthropic", "count-tokens", ":rawPredict")
 	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
 		if key.Value.GetValue() != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
@@ -2816,12 +2737,7 @@ func (provider *VertexProvider) Passthrough(
 		keyRegion = "global"
 	}
 
-	var baseURL string
-	if keyRegion == "global" {
-		baseURL = "https://aiplatform.googleapis.com/v1"
-	} else {
-		baseURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1", keyRegion)
-	}
+	baseURL := getVertexAPIBaseURL(keyRegion, "v1")
 
 	// Normalize path: remove leading /v1 or /v1/ to avoid duplicate version segments (e.g. /v1/v1/...)
 	path := req.Path
@@ -2968,12 +2884,7 @@ func (provider *VertexProvider) PassthroughStream(
 		keyRegion = "global"
 	}
 
-	var baseURL string
-	if keyRegion == "global" {
-		baseURL = "https://aiplatform.googleapis.com/v1"
-	} else {
-		baseURL = fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1", keyRegion)
-	}
+	baseURL := getVertexAPIBaseURL(keyRegion, "v1")
 
 	// Normalize path: remove leading /v1 or /v1/ to avoid duplicate version segments.
 	path := req.Path

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -122,12 +122,19 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 				return nil
 			}
 			var p struct {
-				MaxOutputTokens *int `json:"max_output_tokens"`
+				MaxOutputTokens       *int  `json:"max_output_tokens"`
+				VertexMultiRegionOnly *bool `json:"vertex_multi_region_only"`
 			}
-			if err := json.Unmarshal([]byte(params.Data), &p); err != nil || p.MaxOutputTokens == nil {
+			if err := json.Unmarshal([]byte(params.Data), &p); err != nil {
 				return nil
 			}
-			return &providerUtils.ModelParams{MaxOutputTokens: p.MaxOutputTokens}
+			if p.MaxOutputTokens == nil && p.VertexMultiRegionOnly == nil {
+				return nil
+			}
+			return &providerUtils.ModelParams{
+				MaxOutputTokens:         p.MaxOutputTokens,
+				IsVertexMultiRegionOnly: p.VertexMultiRegionOnly,
+			}
 		})
 		var wg sync.WaitGroup
 		var pricingErr, paramsErr error

--- a/framework/modelcatalog/sync.go
+++ b/framework/modelcatalog/sync.go
@@ -95,7 +95,10 @@ func (mc *ModelCatalog) populateModelParamsFromPricing(pricingData map[string]Pr
 	for modelKey, entry := range pricingData {
 		if entry.MaxOutputTokens != nil {
 			modelName := extractModelName(modelKey)
-			modelParamsEntries[modelName] = providerUtils.ModelParams{MaxOutputTokens: entry.MaxOutputTokens}
+			params := providerUtils.ModelParams{
+				MaxOutputTokens: entry.MaxOutputTokens,
+			}
+			modelParamsEntries[modelName] = params
 		}
 	}
 	if len(modelParamsEntries) > 0 {
@@ -390,12 +393,11 @@ func (mc *ModelCatalog) applyModelParameters(paramsData map[string]json.RawMessa
 		var p struct {
 			MaxOutputTokens *int `json:"max_output_tokens"`
 		}
-		if p.MaxOutputTokens == nil {
-			if err := json.Unmarshal(rawData, &p); err == nil && p.MaxOutputTokens != nil {
-				modelParamsEntries[model] = providerUtils.ModelParams{MaxOutputTokens: p.MaxOutputTokens}
+		if err := json.Unmarshal(rawData, &p); err == nil && (p.MaxOutputTokens != nil || parsed.VertexMultiRegionOnly != nil) {
+			modelParamsEntries[model] = providerUtils.ModelParams{
+				MaxOutputTokens:        p.MaxOutputTokens,
+				IsVertexMultiRegionOnly: parsed.VertexMultiRegionOnly,
 			}
-		} else {
-			modelParamsEntries[model] = providerUtils.ModelParams{MaxOutputTokens: p.MaxOutputTokens}
 		}
 	}
 

--- a/framework/modelcatalog/utils.go
+++ b/framework/modelcatalog/utils.go
@@ -390,6 +390,7 @@ type modelParametersParseResult struct {
 	SupportsReasoning               *bool `json:"supports_reasoning,omitempty"`
 	SupportsServiceTier             *bool `json:"supports_service_tier,omitempty"`
 	SupportsPromptCaching           *bool `json:"supports_prompt_caching,omitempty"`
+	VertexMultiRegionOnly       *bool `json:"vertex_multi_region_only,omitempty"`
 }
 
 // extractSupportedParams builds a list of supported OpenAI-compatible parameter


### PR DESCRIPTION
## Summary

Adds support for Google Vertex multi-region pool endpoints
(`aiplatform.{region}.rep.googleapis.com`) required by newer partner models like
`claude-opus-4-7` that are only available on these endpoints. The implementation
is datasheet-driven: a `vertex_multi_region_only` flag in the model catalog
controls which models use the new URL format, so future models can be enabled by
updating the datasheet without code changes.

## Changes

### Vertex URL construction (`core/providers/vertex/utils.go`)
- Extracted shared URL builders (`getVertexAPIHost`,
  `getVertexModelAwareAPIHost`, `getVertexAPIBaseURL`,
  `getVertexPublisherModelURL`, `getVertexModelAwarePublisherModelURL`)
  replacing repeated `fmt.Sprintf` patterns across `vertex.go`.
- Model-aware variants consult the model catalog to decide between
  `rep.googleapis.com` (multi-region) and the standard single-region host.
- `vertexRegionToPool` maps `us-*` regions to `us` pool and `europe-*` to `eu`
  pool. Other regions (`asia-*`, `me-*`) are never auto-promoted.

### Multi-region host selection logic
- For `us`/`eu` pool regions: always uses `rep.googleapis.com` (the only valid
  host for these regions).
- For single-region locations (`us-central1`, `europe-west1`, etc.):
  auto-promotes flagged models to the corresponding multi-region pool so they
  work without users needing to reconfigure their region.
- Regions without a pool (`asia-*`, `me-*`, `southamerica-*`) are never
  promoted -- models stay on the standard single-region host.

### Model params cache (`core/providers/utils/modelparamscache.go`)
- Added `IsVertexMultiRegionOnly` field to `ModelParams` struct.
- Added `IsVertexMultiRegionOnlyModel()` helper that looks up models with the
  `vertex_ai/` prefix matching the stored key format from the model-parameters
  sync.
- Added `Delete` method and public `DeleteModelParams` function for test
  cleanup, following the existing `Set`/`SetModelParams` convention.

### Model catalog sync (`framework/modelcatalog/`)
- **`sync.go`**: `applyModelParameters()` extracts `vertex_multi_region_only`
  from model-parameters JSON and populates it into the in-memory cache. The
  extraction logic is a single conditional that caches a `ModelParams` entry
  when either `max_output_tokens` or `vertex_multi_region_only` is present.
- **`main.go`**: Cache miss handler now extracts both `max_output_tokens` and
  `vertex_multi_region_only` from the DB JSON blob, and tries the `vertex_ai/`
  prefixed key as fallback. Also added `getModelParametersURL()` that derives
  the model-parameters endpoint URL from the configured pricing URL, so both
  endpoints follow the same base URL override.
- **`utils.go`**: Added `VertexMultiRegionOnly *bool` to
  `modelParametersParseResult` for JSON parsing.
- The model-parameters endpoint is the **sole source of truth** for this flag.
  The pricing sync path does not extract or set it.

### Vertex provider call sites (`core/providers/vertex/vertex.go`)
- All 5 Anthropic URL construction paths (non-streaming chat, streaming chat,
  responses, streaming responses, count-tokens) now use the model-aware URL
  builders that check the flag at request time.

### Tests (`core/providers/vertex/utils_test.go`)
- 360 lines of tests covering `getVertexAPIHost`,
  `isVertexMultiRegionEndpoint`, `getVertexModelListingAPIHost`,
  `getVertexPublisherModelURL`, `getVertexModelAwareAPIHost`,
  `getVertexModelAwarePublisherModelURL`, and `vertexRegionToPool`.
- Tests that seed the global model params cache are non-parallel and use
  `t.Cleanup` with `DeleteModelParams` to prevent cross-test leakage.

## Type of change

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Run vertex provider tests (includes all new URL construction tests)
make test-core PROVIDER=vertex

# Run model params cache tests
go test ./core/providers/utils/... -count=1

# Run model catalog tests
go test ./framework/modelcatalog/... -count=1

# Full build verification
make build
```

**Manual verification with a Vertex provider key configured:**

1. Set region to `us` -> call `vertex/claude-opus-4-7` -> should hit
   `aiplatform.us.rep.googleapis.com`
2. Set region to `us-central1` -> call `vertex/claude-opus-4-7` -> should
   auto-promote to `aiplatform.us.rep.googleapis.com` with `locations/us`
3. Set region to `us-central1` -> call any non-flagged model -> should use
   standard `us-central1-aiplatform.googleapis.com`
4. Set region to `asia-southeast1` -> call `vertex/claude-opus-4-7` -> should
   NOT promote (no pool), stays on single-region host

## Screenshots/Recordings

N/A - backend only changes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes BF-751 - opus-4.7 requires using the new multi-region pool endpoints in
Google Vertex

## Security considerations

No security implications. Changes are limited to URL construction logic for
Vertex API calls.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable