### PR TITLE
fix: make OAuth token `expires_at` nullable and guard refresh/reconnect on nil expiry

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -53,6 +53,12 @@ func (m *MCPManager) ReconnectClient(id string) error {
 		m.mu.Unlock()
 		return fmt.Errorf("client %s not found", id)
 	}
+	// Per-user OAuth clients do not maintain a persistent upstream connection.
+	// Reconnect is not applicable because auth is resolved per request/user identity.
+	if client.ExecutionConfig != nil && client.ExecutionConfig.AuthType == schemas.MCPAuthTypePerUserOauth {
+		m.mu.Unlock()
+		return fmt.Errorf("reconnect is not supported for per_user_oauth clients")
+	}
 	config := client.ExecutionConfig
 	m.mu.Unlock()
 

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -617,6 +617,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationConvertMCPClientToolSyncIntervalMinutesToSeconds(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationMakeOAuthTokenExpiryNullable(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -6524,6 +6527,36 @@ func migrationAddPerUserOAuthTables(ctx context.Context, db *gorm.DB) error {
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_per_user_oauth_tables migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationMakeOAuthTokenExpiryNullable makes expires_at nullable for OAuth token tables.
+func migrationMakeOAuthTokenExpiryNullable(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "make_oauth_token_expiry_nullable",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasTable(&tables.TableOauthToken{}) && mg.HasColumn(&tables.TableOauthToken{}, "expires_at") {
+				if err := mg.AlterColumn(&tables.TableOauthToken{}, "ExpiresAt"); err != nil {
+					return fmt.Errorf("failed to alter oauth_tokens.expires_at to nullable: %w", err)
+				}
+			}
+			if mg.HasTable(&tables.TableOauthUserToken{}) && mg.HasColumn(&tables.TableOauthUserToken{}, "expires_at") {
+				if err := mg.AlterColumn(&tables.TableOauthUserToken{}, "ExpiresAt"); err != nil {
+					return fmt.Errorf("failed to alter oauth_user_tokens.expires_at to nullable: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			// Forward-only migration: making expiry nullable is intentionally non-destructive.
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running make_oauth_token_expiry_nullable migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4164,7 +4164,7 @@ func (s *RDBConfigStore) DeleteOauthToken(ctx context.Context, id string) error 
 func (s *RDBConfigStore) GetExpiringOauthTokens(ctx context.Context, before time.Time) ([]*tables.TableOauthToken, error) {
 	var tokens []*tables.TableOauthToken
 	result := s.DB().WithContext(ctx).
-		Where("expires_at < ?", before).
+		Where("expires_at IS NOT NULL AND expires_at < ?", before).
 		Find(&tokens)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get expiring tokens: %w", result.Error)

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -554,7 +554,7 @@ func TestTableOauthToken_EncryptDecrypt(t *testing.T) {
 		AccessToken:  "access-token-secret-value",
 		RefreshToken: "refresh-token-secret-value",
 		TokenType:    "Bearer",
-		ExpiresAt:    time.Now().Add(time.Hour),
+		ExpiresAt:    bifrost.Ptr(time.Now().Add(time.Hour)),
 	}
 
 	require.NoError(t, db.Create(token).Error)
@@ -577,7 +577,7 @@ func TestTableOauthToken_EmptyRefreshToken(t *testing.T) {
 		ID:          "oauth-tok-norefresh",
 		AccessToken: "access-only-token",
 		TokenType:   "Bearer",
-		ExpiresAt:   time.Now().Add(time.Hour),
+		ExpiresAt:   bifrost.Ptr(time.Now().Add(time.Hour)),
 	}
 
 	require.NoError(t, db.Create(token).Error)
@@ -950,7 +950,7 @@ func TestTableOauthToken_UpdatePreservesDecryption(t *testing.T) {
 		AccessToken:  "original-access",
 		RefreshToken: "original-refresh",
 		TokenType:    "Bearer",
-		ExpiresAt:    time.Now().Add(time.Hour),
+		ExpiresAt:    bifrost.Ptr(time.Now().Add(time.Hour)),
 	}
 	require.NoError(t, db.Create(token).Error)
 
@@ -1132,7 +1132,7 @@ func TestTableOauthToken_FindMultipleDecryptsAll(t *testing.T) {
 			AccessToken:  "access-" + id,
 			RefreshToken: "refresh-" + id,
 			TokenType:    "Bearer",
-			ExpiresAt:    time.Now().Add(time.Hour),
+			ExpiresAt:    bifrost.Ptr(time.Now().Add(time.Hour)),
 		}
 		require.NoError(t, db.Create(token).Error)
 	}
@@ -1405,7 +1405,7 @@ func TestTableOauthToken_EncryptionDisabled_StoresPlaintext(t *testing.T) {
 		AccessToken:  "access-plain",
 		RefreshToken: "refresh-plain",
 		TokenType:    "Bearer",
-		ExpiresAt:    time.Now().Add(time.Hour),
+		ExpiresAt:    bifrost.Ptr(time.Now().Add(time.Hour)),
 	}
 
 	require.NoError(t, db.Create(token).Error)

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -87,7 +87,7 @@ type TableOauthToken struct {
 	AccessToken      string     `gorm:"type:text;not null" json:"-"`                 // Encrypted access token
 	RefreshToken     string     `gorm:"type:text" json:"-"`                          // Encrypted refresh token (optional)
 	TokenType        string     `gorm:"type:varchar(50);not null" json:"token_type"` // "Bearer"
-	ExpiresAt        time.Time  `gorm:"index;not null" json:"expires_at"`            // Token expiration
+	ExpiresAt        *time.Time `gorm:"index" json:"expires_at,omitempty"`            // Token expiration (nil means unknown/non-expiring)
 	Scopes           string     `gorm:"type:text" json:"scopes"`                     // JSON array of granted scopes
 	LastRefreshedAt  *time.Time `gorm:"index" json:"last_refreshed_at,omitempty"`    // Track when token was last refreshed
 	EncryptionStatus string     `gorm:"type:varchar(20);default:'plain_text'" json:"-"`
@@ -202,7 +202,7 @@ type TableOauthUserToken struct {
 	AccessToken      string     `gorm:"type:text;not null" json:"-"`                                                         // Encrypted user's OAuth access token
 	RefreshToken     string     `gorm:"type:text" json:"-"`                                                                  // Encrypted user's OAuth refresh token
 	TokenType        string     `gorm:"type:varchar(50);not null" json:"token_type"`                                         // "Bearer"
-	ExpiresAt        time.Time  `gorm:"index;not null" json:"expires_at"`                                                    // Token expiry
+	ExpiresAt        *time.Time `gorm:"index" json:"expires_at,omitempty"`                                                    // Token expiry (nil means unknown/non-expiring)
 	Scopes           string     `gorm:"type:text" json:"scopes"`                                                             // JSON array of granted scopes
 	LastRefreshedAt  *time.Time `gorm:"index" json:"last_refreshed_at,omitempty"`                                            // Last refresh time
 	EncryptionStatus string     `gorm:"type:varchar(20);default:'plain_text'" json:"-"`

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -76,8 +76,8 @@ func (p *OAuth2Provider) GetAccessToken(ctx context.Context, oauthConfigID strin
 		return "", fmt.Errorf("oauth token not found")
 	}
 
-	// Check if token is expired
-	if time.Now().After(token.ExpiresAt) {
+	// Refresh only when the token has known expiry and a refresh token is available.
+	if token.ExpiresAt != nil && time.Now().After(*token.ExpiresAt) && strings.TrimSpace(token.RefreshToken) != "" {
 		// Attempt automatic refresh
 		if err := p.RefreshAccessToken(ctx, oauthConfigID); err != nil {
 			p.markExpiredIfPermanent(ctx, oauthConfig, err)
@@ -88,6 +88,9 @@ func (p *OAuth2Provider) GetAccessToken(ctx context.Context, oauthConfigID strin
 		if err != nil || token == nil {
 			return "", fmt.Errorf("failed to reload token after refresh: %w", err)
 		}
+	}
+	if token.ExpiresAt != nil && time.Now().After(*token.ExpiresAt) {
+		return "", fmt.Errorf("token expired and no refresh token is available; re-authorization required: %w", schemas.ErrOAuth2TokenExpired)
 	}
 
 	// Sanitize and return access token (trim whitespace/newlines that may cause header formatting issues)
@@ -119,6 +122,10 @@ func (p *OAuth2Provider) RefreshAccessToken(ctx context.Context, oauthConfigID s
 		return fmt.Errorf("oauth token not found: %w", err)
 	}
 
+	if strings.TrimSpace(token.RefreshToken) == "" {
+		return fmt.Errorf("no refresh token available")
+	}
+
 	// Call OAuth provider's token endpoint with refresh_token
 	newTokenResponse, err := p.exchangeRefreshToken(
 		ctx,
@@ -130,15 +137,18 @@ func (p *OAuth2Provider) RefreshAccessToken(ctx context.Context, oauthConfigID s
 	if err != nil {
 		return fmt.Errorf("token refresh failed: %w", err)
 	}
-
 	// Update token in database (sanitize tokens to prevent header formatting issues)
 	now := time.Now()
+	token.ExpiresAt = nil
+	if newTokenResponse.ExpiresIn > 0 {
+		exp := now.Add(time.Duration(newTokenResponse.ExpiresIn) * time.Second)
+		token.ExpiresAt = bifrost.Ptr(exp)
+	}
 	token.AccessToken = strings.TrimSpace(newTokenResponse.AccessToken)
 	if newTokenResponse.RefreshToken != "" {
 		token.RefreshToken = strings.TrimSpace(newTokenResponse.RefreshToken)
 	}
-	token.ExpiresAt = now.Add(time.Duration(newTokenResponse.ExpiresIn) * time.Second)
-	token.LastRefreshedAt = &now
+	token.LastRefreshedAt = bifrost.Ptr(now)
 
 	if err := p.configStore.UpdateOauthToken(ctx, token); err != nil {
 		return fmt.Errorf("failed to update token: %w", err)
@@ -165,8 +175,11 @@ func (p *OAuth2Provider) ValidateToken(ctx context.Context, oauthConfigID string
 		return false, nil
 	}
 
-	// Simple expiry check
-	return time.Now().Before(token.ExpiresAt), nil
+	// Tokens with unknown/non-expiring semantics are considered valid until upstream rejection.
+	if token.ExpiresAt == nil {
+		return true, nil
+	}
+	return time.Now().Before(*token.ExpiresAt), nil
 }
 
 // RevokeToken revokes the OAuth token
@@ -544,12 +557,17 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 
 	// Create oauth_token record (sanitize tokens to prevent header formatting issues)
 	tokenID := uuid.New().String()
+	var expiresAt *time.Time
+	if tokenResponse.ExpiresIn > 0 {
+		exp := time.Now().Add(time.Duration(tokenResponse.ExpiresIn) * time.Second)
+		expiresAt = bifrost.Ptr(exp)
+	}
 	tokenRecord := &tables.TableOauthToken{
 		ID:           tokenID,
 		AccessToken:  strings.TrimSpace(tokenResponse.AccessToken),
 		RefreshToken: strings.TrimSpace(tokenResponse.RefreshToken),
 		TokenType:    tokenResponse.TokenType,
-		ExpiresAt:    time.Now().Add(time.Duration(tokenResponse.ExpiresIn) * time.Second),
+		ExpiresAt:    expiresAt,
 		Scopes:       string(scopesJSON),
 	}
 
@@ -939,6 +957,11 @@ func (p *OAuth2Provider) CompleteUserOAuthFlow(ctx context.Context, state string
 	scopesJSON, _ := json.Marshal(scopes)
 
 	// Create per-user OAuth token record, propagating identity from session
+	var expiresAt *time.Time
+	if tokenResponse.ExpiresIn > 0 {
+		exp := time.Now().Add(time.Duration(tokenResponse.ExpiresIn) * time.Second)
+		expiresAt = bifrost.Ptr(exp)
+	}
 	tokenRecord := &tables.TableOauthUserToken{
 		ID:            uuid.New().String(),
 		SessionToken:  sessionToken,
@@ -949,7 +972,7 @@ func (p *OAuth2Provider) CompleteUserOAuthFlow(ctx context.Context, state string
 		AccessToken:   strings.TrimSpace(tokenResponse.AccessToken),
 		RefreshToken:  strings.TrimSpace(tokenResponse.RefreshToken),
 		TokenType:     tokenResponse.TokenType,
-		ExpiresAt:     time.Now().Add(time.Duration(tokenResponse.ExpiresIn) * time.Second),
+		ExpiresAt:     expiresAt,
 		Scopes:        string(scopesJSON),
 	}
 	if err := p.configStore.CreateOauthUserToken(ctx, tokenRecord); err != nil {
@@ -979,8 +1002,8 @@ func (p *OAuth2Provider) GetUserAccessToken(ctx context.Context, sessionToken st
 		return "", fmt.Errorf("per-user oauth token not found for session")
 	}
 
-	// Check if token is expired
-	if time.Now().After(token.ExpiresAt) {
+	// Refresh only when known-expired and refresh token exists.
+	if token.ExpiresAt != nil && time.Now().After(*token.ExpiresAt) && strings.TrimSpace(token.RefreshToken) != "" {
 		if err := p.RefreshUserAccessToken(ctx, sessionToken); err != nil {
 			return "", fmt.Errorf("per-user token expired and refresh failed: %w", err)
 		}
@@ -989,6 +1012,9 @@ func (p *OAuth2Provider) GetUserAccessToken(ctx context.Context, sessionToken st
 		if err != nil || token == nil {
 			return "", fmt.Errorf("failed to reload per-user token after refresh")
 		}
+	}
+	if token.ExpiresAt != nil && time.Now().After(*token.ExpiresAt) {
+		return "", fmt.Errorf("per-user token expired and no refresh token is available; re-authorization required: %w", schemas.ErrOAuth2TokenExpired)
 	}
 
 	accessToken := strings.TrimSpace(token.AccessToken)
@@ -1011,8 +1037,8 @@ func (p *OAuth2Provider) GetUserAccessTokenByIdentity(ctx context.Context, virtu
 		return "", schemas.ErrOAuth2TokenNotFound
 	}
 
-	// Check if token is expired — attempt refresh
-	if time.Now().After(token.ExpiresAt) {
+	// Refresh only when known-expired and refresh token exists.
+	if token.ExpiresAt != nil && time.Now().After(*token.ExpiresAt) && strings.TrimSpace(token.RefreshToken) != "" {
 		if token.SessionToken != "" {
 			if err := p.RefreshUserAccessToken(ctx, token.SessionToken); err != nil {
 				return "", fmt.Errorf("per-user token expired and refresh failed: %w", err)
@@ -1025,6 +1051,9 @@ func (p *OAuth2Provider) GetUserAccessTokenByIdentity(ctx context.Context, virtu
 		} else {
 			return "", fmt.Errorf("per-user token expired and no session token available for refresh")
 		}
+	}
+	if token.ExpiresAt != nil && time.Now().After(*token.ExpiresAt) {
+		return "", fmt.Errorf("per-user token expired and no refresh token is available; re-authorization required: %w", schemas.ErrOAuth2TokenExpired)
 	}
 
 	accessToken := strings.TrimSpace(token.AccessToken)
@@ -1068,12 +1097,16 @@ func (p *OAuth2Provider) RefreshUserAccessToken(ctx context.Context, sessionToke
 
 	// Update token
 	now := time.Now()
+	token.ExpiresAt = nil
+	if newTokenResponse.ExpiresIn > 0 {
+		exp := now.Add(time.Duration(newTokenResponse.ExpiresIn) * time.Second)
+		token.ExpiresAt = bifrost.Ptr(exp)
+	}
 	token.AccessToken = strings.TrimSpace(newTokenResponse.AccessToken)
 	if newTokenResponse.RefreshToken != "" {
 		token.RefreshToken = strings.TrimSpace(newTokenResponse.RefreshToken)
 	}
-	token.ExpiresAt = now.Add(time.Duration(newTokenResponse.ExpiresIn) * time.Second)
-	token.LastRefreshedAt = &now
+	token.LastRefreshedAt = bifrost.Ptr(now)
 
 	if err := p.configStore.UpdateOauthUserToken(ctx, token); err != nil {
 		return fmt.Errorf("failed to update per-user token after refresh: %w", err)

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -85,7 +85,7 @@ func (s *testConfigStore) GetExpiringOauthTokens(_ context.Context, before time.
 	defer s.mu.Unlock()
 	var expiring []*tables.TableOauthToken
 	for _, token := range s.oauthTokens {
-		if token.ExpiresAt.Before(before) {
+		if token.ExpiresAt != nil && token.ExpiresAt.Before(before) {
 			expiring = append(expiring, bifrost.Ptr(*token))
 		}
 	}
@@ -103,7 +103,7 @@ func seedFixtures(t *testing.T, store *testConfigStore, tokenURL string) (oauthC
 		AccessToken:  "old-access-token",
 		RefreshToken: "refresh-token",
 		TokenType:    "bearer",
-		ExpiresAt:    time.Now().Add(1 * time.Minute),
+		ExpiresAt:    bifrost.Ptr(time.Now().Add(1 * time.Minute)),
 		Scopes:       "[]",
 	}
 
@@ -127,6 +127,36 @@ func newTestWorker(store *testConfigStore) *TokenRefreshWorker {
 	provider := NewOAuth2Provider(store, noopLogger)
 	provider.retryBaseDelay = 1 * time.Millisecond // speed up retry backoff in tests
 	return NewTokenRefreshWorker(provider, noopLogger)
+}
+
+func TestTestConfigStore_GetExpiringOauthTokens(t *testing.T) {
+	t.Run("ignores nil expiry tokens", func(t *testing.T) {
+		store := newTestConfigStore()
+		now := time.Now()
+		before := now.Add(5 * time.Minute)
+
+		store.oauthTokens["nil-expiry"] = &tables.TableOauthToken{
+			ID:           "nil-expiry",
+			AccessToken:  "access-token",
+			RefreshToken: "refresh-token",
+			TokenType:    "bearer",
+			ExpiresAt:    nil,
+			Scopes:       "[]",
+		}
+		store.oauthTokens["expiring"] = &tables.TableOauthToken{
+			ID:           "expiring",
+			AccessToken:  "access-token-2",
+			RefreshToken: "refresh-token-2",
+			TokenType:    "bearer",
+			ExpiresAt:    bifrost.Ptr(now.Add(1 * time.Minute)),
+			Scopes:       "[]",
+		}
+
+		tokens, err := store.GetExpiringOauthTokens(context.Background(), before)
+		require.NoError(t, err)
+		require.Len(t, tokens, 1)
+		assert.Equal(t, "expiring", tokens[0].ID)
+	})
 }
 
 func TestTokenRefreshWorker_TransientError_DoesNotMarkExpired(t *testing.T) {

--- a/transports/bifrost-http/handlers/oauth2.go
+++ b/transports/bifrost-http/handlers/oauth2.go
@@ -165,7 +165,9 @@ func (h *OAuthHandler) getOAuthConfigStatus(ctx *fasthttp.RequestCtx) {
 		// Get token metadata
 		token, err := h.store.ConfigStore.GetOauthTokenByID(context.Background(), *oauthConfig.TokenID)
 		if err == nil && token != nil {
-			response["token_expires_at"] = token.ExpiresAt
+			if token.ExpiresAt != nil {
+				response["token_expires_at"] = token.ExpiresAt
+			}
 			response["token_scopes"] = token.Scopes
 		}
 	}

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -209,6 +209,7 @@ export default function MCPClientsTable({
 							</TableRow>
 						) : (
 							mcpClients.map((c: MCPClient) => {
+								const isPerUserOAuth = c.config.auth_type === "per_user_oauth";
 								const enabledToolsCount =
 									c.state == "connected"
 										? c.config.tools_to_execute?.includes("*")
@@ -261,19 +262,21 @@ export default function MCPClientsTable({
 											<Badge className={MCP_STATUS_COLORS[c.state]}>{c.state}</Badge>
 										</TableCell>
 										<TableCell className="space-x-2 text-right" onClick={(e) => e.stopPropagation()}>
-											<Button
-												variant="ghost"
-												size="icon"
-												onClick={() => handleReconnect(c)}
-												disabled={reconnectingClients.includes(c.config.client_id) || !hasUpdateMCPClientAccess}
-												title="Reconnect"
-											>
-												{reconnectingClients.includes(c.config.client_id) ? (
-													<Loader2 className="h-4 w-4 animate-spin" />
-												) : (
-													<RefreshCcw className="h-4 w-4" />
-												)}
-											</Button>
+											<span title={isPerUserOAuth ? "Reconnect not supported for per-user OAuth clients" : "Reconnect"}>
+												<Button
+													variant="ghost"
+													size="icon"
+													aria-label={isPerUserOAuth ? "Reconnect not supported for per-user OAuth clients" : "Reconnect"}
+													onClick={() => handleReconnect(c)}
+													disabled={isPerUserOAuth || reconnectingClients.includes(c.config.client_id) || !hasUpdateMCPClientAccess}
+												>
+													{reconnectingClients.includes(c.config.client_id) ? (
+														<Loader2 className="h-4 w-4 animate-spin" />
+													) : (
+														<RefreshCcw className="h-4 w-4" />
+													)}
+												</Button>
+											</span>
 
 											<AlertDialog>
 												<AlertDialogTrigger asChild>


### PR DESCRIPTION
## Summary

OAuth token expiry (`expires_at`) is now nullable across both `oauth_tokens` and `oauth_user_tokens` tables. This allows tokens issued without an explicit expiry (e.g., from providers that omit `expires_in`) to be stored and used correctly, rather than being treated as immediately or arbitrarily expired. Additionally, reconnect is blocked for per-user OAuth MCP clients, both in the backend and the UI, since those clients resolve auth per-request rather than maintaining a persistent upstream connection.

## Changes

- `ExpiresAt` on `TableOauthToken` and `TableOauthUserToken` changed from `time.Time` (non-null) to `*time.Time` (nullable). A `nil` value means the expiry is unknown or the token is non-expiring.
- A new database migration (`make_oauth_token_expiry_nullable`) alters both token tables to make `expires_at` nullable.
- Token refresh logic now only triggers when `ExpiresAt` is non-nil, the token is past expiry, **and** a refresh token is present. If a token is expired but has no refresh token, a clear re-authorization error is returned instead of silently failing.
- `RefreshAccessToken` and `RefreshUserAccessToken` now guard against being called with no refresh token.
- When completing OAuth flows, `ExpiresAt` is only set if `expires_in > 0` in the token response; otherwise it is left `nil`.
- `GetExpiringOauthTokens` query updated to filter `expires_at IS NOT NULL AND expires_at < ?` to skip tokens with no known expiry.
- `ValidateToken` treats tokens with `nil` expiry as valid.
- The OAuth status API endpoint omits `token_expires_at` from the response when expiry is unknown.
- The MCP client reconnect button in the UI is disabled for `per_user_oauth` clients with an explanatory tooltip, mirroring the backend guard that returns an error for reconnect attempts on those clients.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

- Configure an OAuth provider that does not return `expires_in` in its token response and complete the OAuth flow. Verify the token is stored with a `NULL` `expires_at` and that access tokens are returned without error.
- Verify that a token with a `NULL` `expires_at` is not returned by `GetExpiringOauthTokens` and is not flagged as expired by `ValidateToken`.
- Attempt to reconnect a per-user OAuth MCP client via the API and confirm a `reconnect is not supported for per_user_oauth clients` error is returned.
- In the UI, confirm the reconnect button for a `per_user_oauth` MCP client is disabled and shows the correct tooltip.

## Breaking changes

- [x] Yes
- [ ] No

The `ExpiresAt` field on `TableOauthToken` and `TableOauthUserToken` is now a pointer (`*time.Time`). Any code directly reading this field without a nil check will need to be updated. The database migration handles the schema change automatically.

## Security considerations

Tokens with no known expiry are treated as valid until the upstream provider rejects them. This is intentional for providers that issue long-lived or non-expiring tokens. Expired tokens without a refresh token now return an explicit error requiring re-authorization rather than attempting a refresh with an empty token, preventing malformed refresh requests from being sent to OAuth providers.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable