### PR TITLE
feat: add external base url support for reverse proxy mcp oauth

### DIFF
--- a/docs/deployment-guides/config-json/client.mdx
+++ b/docs/deployment-guides/config-json/client.mdx
@@ -52,6 +52,38 @@ Set `disable_content_logging: true` for HIPAA / PCI compliance workloads where m
 
 ---
 
+## Reverse Proxy
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mcp_external_base_url` | string or EnvVar | — | Public base URL advertised for OAuth callbacks and discovery metadata |
+
+When Bifrost runs behind a reverse proxy, the OAuth callback URL and well-known discovery endpoints (`/.well-known/oauth-authorization-server`, etc.) are built from the incoming `Host` header — which is your proxy's internal address, not its public address. Set `mcp_external_base_url` to override this with the proxy's public URL.
+
+The field supports env var syntax so the URL can be injected at runtime:
+
+```json
+{
+  "client": {
+    "mcp_external_base_url": "env.BIFROST_EXTERNAL_URL"
+  }
+}
+```
+
+Or as a plain URL:
+
+```json
+{
+  "client": {
+    "mcp_external_base_url": "https://api.yourcompany.com"
+  }
+}
+```
+
+This setting is also configurable via the UI (**MCP Gateway → MCP Settings**) and the management API, with no restart required.
+
+---
+
 ## Security & CORS
 
 | Field | Type | Default | Description |
@@ -249,6 +281,8 @@ A top-level `auth_config` is also accepted for backwards compatibility, but `gov
     "disable_content_logging": false,
     "log_retention_days": 90,
     "logging_headers": ["x-request-id", "x-user-id"],
+
+    "mcp_external_base_url": "env.BIFROST_EXTERNAL_URL",
 
     "allowed_origins": ["https://app.yourcompany.com"],
     "allow_direct_keys": false,

--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -77,6 +77,7 @@ Controls the worker pool, logging pipeline, security, and SDK shims. All fields 
 | `async_job_result_ttl` | integer | `3600` | TTL for async job results in seconds |
 | `disable_db_pings_in_health` | boolean | `false` | Exclude DB connectivity from `/health` |
 | `routing_chain_max_depth` | integer | `10` | Max routing rule chain evaluation depth |
+| `mcp_external_base_url` | string \| EnvVar | — | Public base URL for OAuth callbacks/discovery when behind a reverse proxy; supports `"env.MY_VAR"` |
 
 Full documentation: [Client Configuration](/deployment-guides/config-json/client).
 

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -52596,6 +52596,30 @@
                   "type": "string"
                 },
                 "description": "Headers to capture in log metadata. Values are extracted from incoming requests and stored in the metadata field of log entries. Case-insensitive matching. No restart required."
+              },
+              "mcp_external_base_url": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "Plain URL or env var reference (e.g. \"env.MY_VAR\")"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      },
+                      "env_var": {
+                        "type": "string"
+                      },
+                      "from_env": {
+                        "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ],
+                "description": "Public base URL for OAuth callbacks and discovery metadata when Bifrost runs behind a reverse proxy. Overrides the host derived from the incoming request. Supports env var syntax (\"env.MY_VAR\"). Configurable via UI, API, or config.json.\n"
               }
             }
           },
@@ -52841,6 +52865,30 @@
                   "type": "string"
                 },
                 "description": "Headers to capture in log metadata. Values are extracted from incoming requests and stored in the metadata field of log entries. Case-insensitive matching. No restart required."
+              },
+              "mcp_external_base_url": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "Plain URL or env var reference (e.g. \"env.MY_VAR\")"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      },
+                      "env_var": {
+                        "type": "string"
+                      },
+                      "from_env": {
+                        "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ],
+                "description": "Public base URL for OAuth callbacks and discovery metadata when Bifrost runs behind a reverse proxy. Overrides the host derived from the incoming request. Supports env var syntax (\"env.MY_VAR\"). Configurable via UI, API, or config.json.\n"
               }
             }
           },

--- a/docs/openapi/schemas/management/config.yaml
+++ b/docs/openapi/schemas/management/config.yaml
@@ -94,6 +94,23 @@ ClientConfig:
       items:
         type: string
       description: Headers to capture in log metadata. Values are extracted from incoming requests and stored in the metadata field of log entries. Case-insensitive matching. No restart required.
+    mcp_external_base_url:
+      oneOf:
+        - type: string
+          description: Plain URL or env var reference (e.g. "env.MY_VAR")
+        - type: object
+          properties:
+            value:
+              type: string
+            env_var:
+              type: string
+            from_env:
+              type: boolean
+          additionalProperties: false
+      description: >
+        Public base URL for OAuth callbacks and discovery metadata when Bifrost runs behind a
+        reverse proxy. Overrides the host derived from the incoming request. Supports env var
+        syntax ("env.MY_VAR"). Configurable via UI, API, or config.json.
 
 FrameworkConfig:
   type: object

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -75,6 +75,7 @@ type ClientConfig struct {
 	WhitelistedRoutes                     []string                         `json:"whitelisted_routes,omitempty"`         // Routes that bypass auth middleware
 	HideDeletedVirtualKeysInFilters       bool                             `json:"hide_deleted_virtual_keys_in_filters"` // Hide deleted virtual keys from logs/MCP filter data
 	RoutingChainMaxDepth                  int                              `json:"routing_chain_max_depth"`              // Maximum depth for routing rule chain evaluation (default: 10)
+	MCPExternalBaseURL                    *schemas.EnvVar                  `json:"mcp_external_base_url,omitempty"`      // Public base URL for OAuth callbacks/discovery when behind a reverse proxy; supports env var syntax ("env.MY_VAR")
 	ConfigHash                            string                           `json:"-"`                                    // Config hash for reconciliation (not serialized)
 }
 
@@ -310,6 +311,14 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 			}
 			hash.Write([]byte("headerFilterConfig.denylist:"))
 			hash.Write(data)
+		}
+	}
+
+	if c.MCPExternalBaseURL.IsSet() {
+		if c.MCPExternalBaseURL.IsFromEnv() {
+			hash.Write([]byte("externalBaseURL:env:" + c.MCPExternalBaseURL.EnvVar))
+		} else {
+			hash.Write([]byte("externalBaseURL:val:" + c.MCPExternalBaseURL.GetValue()))
 		}
 	}
 

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -617,6 +617,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationConvertMCPClientToolSyncIntervalMinutesToSeconds(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddMCPExternalBaseURLColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationMakeOAuthTokenExpiryNullable(ctx, db); err != nil {
 		return err
 	}
@@ -7068,6 +7071,36 @@ func migrationAddOCRPricingColumns(ctx context.Context, db *gorm.DB) error {
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_ocr_pricing_columns migration: %s", err.Error())
+	}
+	return nil
+}
+
+func migrationAddMCPExternalBaseURLColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_mcp_external_base_url_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TableClientConfig{}, "mcp_external_base_url") {
+				if err := mg.AddColumn(&tables.TableClientConfig{}, "MCPExternalBaseURL"); err != nil {
+					return fmt.Errorf("failed to add mcp_external_base_url column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasColumn(&tables.TableClientConfig{}, "mcp_external_base_url") {
+				if err := mg.DropColumn(&tables.TableClientConfig{}, "mcp_external_base_url"); err != nil {
+					return fmt.Errorf("failed to drop mcp_external_base_url column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_mcp_external_base_url_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -136,6 +136,20 @@ func tableKeyFromSchemaKey(provider tables.TableProvider, key schemas.Key) (tabl
 	return dbKey, nil
 }
 
+// mcpExternalBaseURLToString converts an *schemas.EnvVar to its storage string form.
+// Stores "env.MY_VAR" when sourced from an env var, or the raw URL otherwise.
+func mcpExternalBaseURLToString(e *schemas.EnvVar) string {
+	if e == nil {
+		return ""
+	}
+	if v, err := e.Value(); err == nil {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
 // UpdateClientConfig updates the client configuration in the database.
 func (s *RDBConfigStore) UpdateClientConfig(ctx context.Context, config *ClientConfig) error {
 	dbConfig := tables.TableClientConfig{
@@ -168,6 +182,7 @@ func (s *RDBConfigStore) UpdateClientConfig(ctx context.Context, config *ClientC
 		WhitelistedRoutes:               config.WhitelistedRoutes,
 		HideDeletedVirtualKeysInFilters: config.HideDeletedVirtualKeysInFilters,
 		RoutingChainMaxDepth:            config.RoutingChainMaxDepth,
+		MCPExternalBaseURL:                 mcpExternalBaseURLToString(config.MCPExternalBaseURL),
 		HeaderFilterConfig:              config.HeaderFilterConfig,
 		ConfigHash:                      config.ConfigHash,
 	}
@@ -378,6 +393,7 @@ func (s *RDBConfigStore) GetClientConfig(ctx context.Context) (*ClientConfig, er
 		WhitelistedRoutes:               dbConfig.WhitelistedRoutes,
 		HideDeletedVirtualKeysInFilters: dbConfig.HideDeletedVirtualKeysInFilters,
 		RoutingChainMaxDepth:            dbConfig.RoutingChainMaxDepth,
+		MCPExternalBaseURL:                 schemas.NewEnvVar(dbConfig.MCPExternalBaseURL),
 		HeaderFilterConfig:              dbConfig.HeaderFilterConfig,
 		ConfigHash:                      dbConfig.ConfigHash,
 	}, nil

--- a/framework/configstore/tables/clientconfig.go
+++ b/framework/configstore/tables/clientconfig.go
@@ -35,6 +35,7 @@ type TableClientConfig struct {
 	LoggingHeadersJSON              string `gorm:"type:text" json:"-"`                                        // JSON serialized []string
 	HideDeletedVirtualKeysInFilters bool   `gorm:"default:false" json:"hide_deleted_virtual_keys_in_filters"` // Hide deleted virtual keys in logs filter dropdowns
 	RoutingChainMaxDepth            int    `gorm:"default:10" json:"routing_chain_max_depth"`                 // Maximum depth for routing rule chain evaluation (default: 10)
+	MCPExternalBaseURL                 string `gorm:"type:varchar(512)" json:"mcp_external_base_url,omitempty"` // Public base URL for OAuth callbacks/discovery when behind a reverse proxy
 	WhitelistedRoutesJSON           string `gorm:"type:text" json:"-"`                                        // JSON serialized []string
 
 	// Compat plugin feature flags

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -423,6 +423,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		updatedConfig.RoutingChainMaxDepth = payload.ClientConfig.RoutingChainMaxDepth
 	}
 
+	// Update external base URL for OAuth callbacks/discovery (nil clears the override).
+	updatedConfig.MCPExternalBaseURL = payload.ClientConfig.MCPExternalBaseURL
+
 	// Handle HeaderFilterConfig changes
 	if !headerFilterConfigEqual(payload.ClientConfig.HeaderFilterConfig, currentConfig.HeaderFilterConfig) {
 		// Validate that no security headers are in the allowlist or denylist

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -439,12 +439,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			return
 		}
 
-		scheme := "http"
-		if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
-			scheme = "https"
-		}
-		host := string(ctx.Host())
-		redirectURI := fmt.Sprintf("%s://%s/api/oauth/callback", scheme, host)
+		redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalBaseURL()) + "/api/oauth/callback"
 
 		flowInitiation, err := h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
 			ClientID:        req.OauthConfig.ClientID,
@@ -532,13 +527,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		}
 
 		// Build redirect URI - use Bifrost's own callback endpoint
-		// Extract the base URL from the current request
-		scheme := "http"
-		if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
-			scheme = "https"
-		}
-		host := string(ctx.Host())
-		redirectURI := fmt.Sprintf("%s://%s/api/oauth/callback", scheme, host)
+		redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalBaseURL()) + "/api/oauth/callback"
 
 		// Initiate OAuth flow
 		// ServerURL comes from ConnectionString (MCP server URL for OAuth discovery)

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -463,12 +463,7 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*se
 
 	// If per_user_oauth MCP clients are configured and no valid auth, return 401 with discovery
 	if clients := h.config.GetPerUserOAuthMCPClients(); len(clients) > 0 && userOauthSession == nil && vk == "" {
-		scheme := "http"
-		if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
-			scheme = "https"
-		}
-		host := string(ctx.Host())
-		resourceMetadataURL := fmt.Sprintf("%s://%s/.well-known/oauth-protected-resource", scheme, host)
+		resourceMetadataURL := lib.BuildBaseURL(ctx, h.config.GetMCPExternalBaseURL()) + "/.well-known/oauth-protected-resource"
 		ctx.Response.Header.Set("WWW-Authenticate",
 			fmt.Sprintf(`Bearer resource_metadata="%s"`, resourceMetadataURL))
 		return nil, nil, fmt.Errorf("oauth authentication required for mcp access")

--- a/transports/bifrost-http/handlers/oauth2_metadata.go
+++ b/transports/bifrost-http/handlers/oauth2_metadata.go
@@ -6,8 +6,6 @@
 package handlers
 
 import (
-	"fmt"
-
 	"github.com/fasthttp/router"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
@@ -47,12 +45,7 @@ func (h *OAuthMetadataHandler) handleProtectedResourceMetadata(ctx *fasthttp.Req
 		sendStringError(ctx, fasthttp.StatusNotFound, "Not Found")
 		return
 	}
-	scheme := "http"
-	if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
-		scheme = "https"
-	}
-	host := string(ctx.Host())
-	baseURL := fmt.Sprintf("%s://%s", scheme, host)
+	baseURL := lib.BuildBaseURL(ctx, h.store.GetMCPExternalBaseURL())
 
 	SendJSON(ctx, map[string]interface{}{
 		"resource":                 baseURL + "/mcp",
@@ -72,12 +65,7 @@ func (h *OAuthMetadataHandler) handleAuthorizationServerMetadata(ctx *fasthttp.R
 		sendStringError(ctx, fasthttp.StatusNotFound, "Not Found")
 		return
 	}
-	scheme := "http"
-	if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
-		scheme = "https"
-	}
-	host := string(ctx.Host())
-	baseURL := fmt.Sprintf("%s://%s", scheme, host)
+	baseURL := lib.BuildBaseURL(ctx, h.store.GetMCPExternalBaseURL())
 
 	SendJSON(ctx, map[string]interface{}{
 		"issuer":                                baseURL,

--- a/transports/bifrost-http/handlers/oauth2_per_user.go
+++ b/transports/bifrost-http/handlers/oauth2_per_user.go
@@ -505,12 +505,7 @@ func (h *PerUserOAuthHandler) handleUpstreamAuthorize(ctx *fasthttp.RequestCtx) 
 	}
 
 	// Build redirect URI (Bifrost's callback endpoint).
-	scheme := "http"
-	if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
-		scheme = "https"
-	}
-	host := string(ctx.Host())
-	redirectURI := fmt.Sprintf("%s://%s/api/oauth/callback", scheme, host)
+	redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalBaseURL()) + "/api/oauth/callback"
 	var vkId *string
 	if virtualKeyID != "" {
 		vkId = &virtualKeyID

--- a/transports/bifrost-http/handlers/webrtc_realtime_test.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime_test.go
@@ -30,6 +30,7 @@ func (s testHandlerStore) GetKVStore() *kvstore.Store                       { re
 func (s testHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList { return nil }
 func (s testHandlerStore) ShouldAllowPerRequestStorageOverride() bool       { return false }
 func (s testHandlerStore) ShouldAllowPerRequestRawOverride() bool           { return false }
+func (s testHandlerStore) GetMCPExternalBaseURL() string                       { return "" }
 
 func TestResolveRealtimeSDPTarget_BaseRouteRequiresProviderPrefix(t *testing.T) {
 	_, _, _, err := resolveRealtimeSDPTarget("/v1/realtime", []byte(`{"model":"gpt-4o-realtime-preview"}`))

--- a/transports/bifrost-http/handlers/wsresponses_test.go
+++ b/transports/bifrost-http/handlers/wsresponses_test.go
@@ -51,7 +51,8 @@ func (s testWSHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList {
 }
 
 func (s testWSHandlerStore) ShouldAllowPerRequestStorageOverride() bool { return false }
-func (s testWSHandlerStore) ShouldAllowPerRequestRawOverride() bool    { return false }
+func (s testWSHandlerStore) ShouldAllowPerRequestRawOverride() bool     { return false }
+func (s testWSHandlerStore) GetMCPExternalBaseURL() string                 { return "" }
 
 type timeoutNetError struct{}
 

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -62,6 +62,10 @@ func (m *mockHandlerStore) ShouldAllowPerRequestRawOverride() bool {
 	return false
 }
 
+func (m *mockHandlerStore) GetMCPExternalBaseURL() string {
+	return ""
+}
+
 // Ensure mockHandlerStore implements lib.HandlerStore
 var _ lib.HandlerStore = (*mockHandlerStore)(nil)
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -83,6 +83,9 @@ type HandlerStore interface {
 	ShouldAllowPerRequestStorageOverride() bool
 	// ShouldAllowPerRequestRawOverride returns whether per-request overrides for raw request/response visibility are permitted
 	ShouldAllowPerRequestRawOverride() bool
+	// GetMCPExternalBaseURL returns the configured external base URL for OAuth callbacks/metadata,
+	// or empty string if not configured (falls back to dynamic Host-header-based URL).
+	GetMCPExternalBaseURL() string
 }
 
 // Retry backoff constants for validation
@@ -3252,6 +3255,12 @@ func (c *Config) ShouldAllowPerRequestStorageOverride() bool {
 // ShouldAllowPerRequestRawOverride returns whether per-request raw request/response overrides are permitted.
 func (c *Config) ShouldAllowPerRequestRawOverride() bool {
 	return c.ClientConfig.AllowPerRequestRawOverride
+}
+
+// GetMCPExternalBaseURL returns the configured external base URL for OAuth callbacks and metadata,
+// or empty string if not configured. Resolves env var references automatically.
+func (c *Config) GetMCPExternalBaseURL() string {
+	return c.ClientConfig.MCPExternalBaseURL.GetValue()
 }
 
 // GetHeaderMatcher returns the precompiled header matcher for header filtering.

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -607,13 +608,13 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 	}
 
 	// Build and set OAuth redirect URI for per-user OAuth flows
-	scheme := "http"
-	if ctx.IsTLS() || string(ctx.Request.Header.Peek("X-Forwarded-Proto")) == "https" {
-		scheme = "https"
+	var externalBaseURL string
+	if store != nil {
+		externalBaseURL = store.GetMCPExternalBaseURL()
 	}
-	host := string(ctx.Host())
-	if host != "" {
-		bifrostCtx.SetValue(schemas.BifrostContextKeyOAuthRedirectURI, fmt.Sprintf("%s://%s/api/oauth/callback", scheme, host))
+	baseURL := BuildBaseURL(ctx, externalBaseURL)
+	if baseURL != "" {
+		bifrostCtx.SetValue(schemas.BifrostContextKeyOAuthRedirectURI, baseURL+"/api/oauth/callback")
 	}
 
 	if allowDirectKeys {
@@ -663,6 +664,31 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 	bifrostCtx.SetValue(schemas.BifrostContextKeyAllowPerRequestStorageOverride, allowPerRequestStorageOverride)
 	bifrostCtx.SetValue(schemas.BifrostContextKeyAllowPerRequestRawOverride, allowPerRequestRawOverride)
 	return bifrostCtx, cancel
+}
+
+// BuildBaseURL returns the effective base URL for OAuth callbacks and metadata discovery.
+// When externalBaseURL is non-empty (set via config/UI/API), it takes priority so that
+// deployments behind a reverse proxy advertise the proxy's public URL rather than the
+// internal Host header seen by Bifrost.
+func BuildBaseURL(ctx *fasthttp.RequestCtx, externalBaseURL string) string {
+	if override := strings.TrimRight(strings.TrimSpace(externalBaseURL), "/"); override != "" {
+		if parsed, err := url.Parse(override); err == nil && parsed.Scheme != "" && parsed.Host != "" {
+			return override
+		}
+	}
+	scheme := "http"
+	xfProto := strings.ToLower(strings.TrimSpace(string(ctx.Request.Header.Peek("X-Forwarded-Proto"))))
+	if comma := strings.IndexByte(xfProto, ','); comma >= 0 {
+		xfProto = strings.TrimSpace(xfProto[:comma])
+	}
+	if ctx.IsTLS() || xfProto == "https" {
+		scheme = "https"
+	}
+	host := string(ctx.Host())
+	if host == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s://%s", scheme, host)
 }
 
 // BuildHTTPRequestFromFastHTTP creates an HTTPRequest from fasthttp context for streaming handlers.

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -30,6 +30,7 @@ func (s testHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList {
 }
 func (s testHandlerStore) ShouldAllowPerRequestStorageOverride() bool { return false }
 func (s testHandlerStore) ShouldAllowPerRequestRawOverride() bool     { return false }
+func (s testHandlerStore) GetMCPExternalBaseURL() string                 { return "" }
 
 func TestParseSessionIDFromBaggage(t *testing.T) {
 	tests := []struct {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -227,6 +227,23 @@
           "minimum": 1,
           "description": "Maximum depth for routing rule chain evaluation",
           "default": 10
+        },
+        "mcp_external_base_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "value": { "type": "string" },
+                "env_var": { "type": "string" },
+                "from_env": { "type": "boolean" }
+              },
+              "additionalProperties": false
+            }
+          ],
+          "description": "Public base URL for OAuth callbacks and discovery metadata when Bifrost runs behind a reverse proxy (e.g. \"https://api.example.com\"). Supports env var syntax: \"env.MY_VAR\"."
         }
       },
       "additionalProperties": false

--- a/ui/app/workspace/config/views/mcpView.tsx
+++ b/ui/app/workspace/config/views/mcpView.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { EnvVarInput } from "@/components/ui/envVarInput";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -14,6 +15,7 @@ import {
   useUpdateCoreConfigMutation,
 } from "@/lib/store";
 import { CoreConfig, DefaultCoreConfig } from "@/lib/types/config";
+import { EnvVar } from "@/lib/types/schemas";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -57,6 +59,10 @@ export default function MCPView() {
 
   const hasChanges = useMemo(() => {
     if (!config) return false;
+    const externalBaseURLChanged =
+      (localConfig.mcp_external_base_url?.value ?? "") !== (config.mcp_external_base_url?.value ?? "") ||
+      (localConfig.mcp_external_base_url?.env_var ?? "") !== (config.mcp_external_base_url?.env_var ?? "") ||
+      (localConfig.mcp_external_base_url?.from_env ?? false) !== (config.mcp_external_base_url?.from_env ?? false);
     return (
       localConfig.mcp_agent_depth !== config.mcp_agent_depth ||
       localConfig.mcp_tool_execution_timeout !==
@@ -66,7 +72,8 @@ export default function MCPView() {
       localConfig.mcp_tool_sync_interval !==
         (config.mcp_tool_sync_interval ?? 10) ||
       localConfig.mcp_disable_auto_tool_inject !==
-        (config.mcp_disable_auto_tool_inject ?? false)
+        (config.mcp_disable_auto_tool_inject ?? false) ||
+      externalBaseURLChanged
     );
   }, [config, localConfig]);
 
@@ -318,6 +325,29 @@ export default function MCPView() {
               </div>
             )}
           </div>
+        </div>
+        {/* External Base URL */}
+        <div className="space-y-2 rounded-sm border p-4">
+          <div className="space-y-0.5">
+            <label htmlFor="external-base-url" className="text-sm font-medium">
+              External Base URL
+            </label>
+            <p className="text-muted-foreground text-sm">
+              Override the base URL used for OAuth callbacks and discovery metadata (
+              <code className="text-xs">/.well-known/oauth-authorization-server</code>, etc.) when Bifrost runs behind a reverse proxy.
+              Supports env var syntax (e.g. <code className="text-xs">env.BIFROST_EXTERNAL_URL</code>).
+            </p>
+          </div>
+          <EnvVarInput
+            id="external-base-url"
+            data-testid="mcp-external-base-url-input"
+            placeholder="https://api.example.com or env.BIFROST_EXTERNAL_URL"
+            value={localConfig.mcp_external_base_url}
+            onChange={(value: EnvVar) =>
+              setLocalConfig((prev) => ({ ...prev, mcp_external_base_url: value }))
+            }
+            disabled={!hasSettingsUpdateAccess}
+          />
         </div>
       </div>
       <div className="flex justify-end pt-2">

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -494,6 +494,7 @@ export interface CoreConfig {
 	hide_deleted_virtual_keys_in_filters: boolean;
 	routing_chain_max_depth: number;
 	header_filter_config?: GlobalHeaderFilterConfig;
+	mcp_external_base_url?: EnvVar;
 }
 
 export const DefaultCoreConfig: CoreConfig = {


### PR DESCRIPTION
## Summary

When Bifrost runs behind a reverse proxy, OAuth callback URLs and well-known discovery endpoints (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource`) were being built from the incoming `Host` header, which reflects the proxy's internal address rather than its public-facing URL. This PR introduces `mcp_external_base_url` to override that derived URL with the proxy's public base URL.

## Changes

- Added `mcp_external_base_url` field to `ClientConfig` (Go struct, DB table, JSON schema, OpenAPI schema, and config.schema.json) supporting both plain URL strings and env var references (`"env.MY_VAR"`).
- Introduced `lib.BuildBaseURL(ctx, externalBaseURL)` as a single helper that centralizes base URL resolution — using the configured override when present, falling back to the `X-Forwarded-Proto`/`Host`-derived URL otherwise. Replaced all inline scheme+host construction across `mcp.go`, `mcpserver.go`, `oauth2_metadata.go`, `oauth2_per_user.go`, and `ctx.go` with calls to this helper.
- Added a DB migration (`migrationAddMCPExternalBaseURLColumn`) to add the `mcp_external_base_url` column to the client config table.
- Wired `GetMCPExternalBaseURL()` into the `HandlerStore` interface and implemented it on `Config`; updated all test stubs accordingly.
- Exposed the setting in the management API config update handler so it can be changed without a restart.
- Added an **External Base URL** field to the UI under **Config → Client Settings** (MCP view) using `EnvVarInput`, with change detection and RBAC gating.
- Documented the field in `docs/deployment-guides/config-json/client.mdx` and `schema-reference.mdx` with usage examples for both plain URL and env var forms.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./...

# UI
cd ui
pnpm i
pnpm build
```

**Manual validation:**

1. Deploy Bifrost behind a reverse proxy (e.g. nginx) where the public URL differs from the internal `Host` header.
2. Set `mcp_external_base_url` in `config.json` or via the UI (**Config → Client Settings → Proxy Settings**):
   ```json
   { "client": { "mcp_external_base_url": "https://api.yourcompany.com" } }
   ```
3. Trigger an MCP OAuth flow and confirm the redirect URI and `/.well-known/oauth-authorization-server` issuer both reflect `https://api.yourcompany.com` rather than the internal host.
4. Test env var form: set `mcp_external_base_url` to `"env.BIFROST_EXTERNAL_URL"`, export the env var, and confirm the resolved URL is used.
5. Clear the field and confirm fallback to the `Host`-header-derived URL.

**New config field:**

| Field | Type | Description |
|---|---|---|
| `mcp_external_base_url` | `string \| EnvVar` | Public base URL for OAuth callbacks and discovery metadata when behind a reverse proxy. Supports `"env.MY_VAR"` syntax. |

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `mcp_external_base_url` value is used to construct OAuth redirect URIs and discovery metadata URLs. Only trusted administrators with config update access can set this value (RBAC-gated in the UI; management API access required via API). Env var references are resolved server-side and never exposed to clients.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable