### PR TITLE
feat: add `schemas.Duration` type with Go duration string support for MCP, Redis, Weaviate, and mocker duration fields

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -331,7 +331,7 @@ func Init(ctx context.Context, config schemas.BifrostConfig) (*Bifrost, error) {
 			if mcpConfig.ToolManagerConfig != nil {
 				codeModeConfig = &mcp.CodeModeConfig{
 					BindingLevel:         mcpConfig.ToolManagerConfig.CodeModeBindingLevel,
-					ToolExecutionTimeout: mcpConfig.ToolManagerConfig.ToolExecutionTimeout,
+					ToolExecutionTimeout: time.Duration(mcpConfig.ToolManagerConfig.ToolExecutionTimeout),
 				}
 			}
 			codeMode := starlark.NewStarlarkCodeMode(codeModeConfig, bifrost.logger)
@@ -3786,7 +3786,7 @@ func (bifrost *Bifrost) UpdateToolManagerConfig(maxAgentDepth int, toolExecution
 
 	bifrost.MCPManager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:         maxAgentDepth,
-		ToolExecutionTimeout:  time.Duration(toolExecutionTimeoutInSeconds) * time.Second,
+		ToolExecutionTimeout:  schemas.Duration(time.Duration(toolExecutionTimeoutInSeconds) * time.Second),
 		CodeModeBindingLevel:  schemas.CodeModeBindingLevel(codeModeBindingLevel),
 		DisableAutoToolInject: disableAutoToolInject,
 	})

--- a/core/internal/mcptests/agent_limits_test.go
+++ b/core/internal/mcptests/agent_limits_test.go
@@ -25,7 +25,7 @@ func TestAgent_MaxDepthEnforcement(t *testing.T) {
 	// Update tool manager config to set MaxAgentDepth = 5
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        5,
-		ToolExecutionTimeout: 30 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(30 * time.Second),
 	})
 
 	ctx := createTestContext()
@@ -100,7 +100,7 @@ func TestAgent_MaxDepthCustomValue(t *testing.T) {
 	// Set MaxAgentDepth = 3
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        3,
-		ToolExecutionTimeout: 30 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(30 * time.Second),
 	})
 
 	ctx := createTestContext()
@@ -166,7 +166,7 @@ func TestAgent_MaxDepthReached_ChatFormat(t *testing.T) {
 
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        2,
-		ToolExecutionTimeout: 30 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(30 * time.Second),
 	}) // Max depth = 2
 
 	ctx := createTestContext()
@@ -226,7 +226,7 @@ func TestAgent_MaxDepthReached_ResponsesFormat(t *testing.T) {
 
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        2,
-		ToolExecutionTimeout: 30 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(30 * time.Second),
 	}) // Max depth = 2
 
 	ctx := createTestContext()
@@ -301,7 +301,7 @@ func TestAgent_MaxDepth_CodeMode(t *testing.T) {
 	manager := setupMCPManager(t, codeModeClient, httpClient)
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        3,
-		ToolExecutionTimeout: 30 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(30 * time.Second),
 	}) // Max depth = 3
 
 	ctx := createTestContext()
@@ -387,7 +387,7 @@ func TestAgent_MaxDepth_CodeMode_ChatFormat(t *testing.T) {
 	manager := setupMCPManager(t, codeModeClient, httpClient)
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        2,
-		ToolExecutionTimeout: 30 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(30 * time.Second),
 	})
 
 	ctx := createTestContext()
@@ -461,7 +461,7 @@ func TestAgent_MaxDepth_CodeMode_ResponsesFormat(t *testing.T) {
 	manager := setupMCPManager(t, codeModeClient, httpClient)
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        2,
-		ToolExecutionTimeout: 30 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(30 * time.Second),
 	})
 
 	ctx := createTestContext()
@@ -965,7 +965,7 @@ func TestAgent_MaxDepthAndTimeout(t *testing.T) {
 	// Set both max depth and timeout
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        3,
-		ToolExecutionTimeout: 5 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(5 * time.Second),
 	}) // Max depth = 3, timeout = 5 seconds
 
 	ctx := createTestContext()
@@ -1039,7 +1039,7 @@ func TestAgent_MaxDepthZero(t *testing.T) {
 	// Set max depth = 0 (should not allow any iterations)
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        0,
-		ToolExecutionTimeout: 30 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(30 * time.Second),
 	})
 
 	ctx := createTestContext()
@@ -1156,7 +1156,7 @@ func TestAgent_IterationTracking(t *testing.T) {
 
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        10,
-		ToolExecutionTimeout: 30 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(30 * time.Second),
 	})
 
 	ctx := createTestContext()

--- a/core/internal/mcptests/codemode_agent_test.go
+++ b/core/internal/mcptests/codemode_agent_test.go
@@ -534,7 +534,7 @@ func TestCodeModeAgent_MaxDepth(t *testing.T) {
 	manager := setupMCPManager(t, codeModeClient, httpClient)
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        3,
-		ToolExecutionTimeout: 30 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(30 * time.Second),
 	})
 
 	ctx := createTestContext()
@@ -607,7 +607,7 @@ func TestCodeModeAgent_MaxDepth_ChatFormat(t *testing.T) {
 	manager := setupMCPManager(t, codeModeClient, httpClient)
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        2,
-		ToolExecutionTimeout: 30 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(30 * time.Second),
 	})
 
 	ctx := createTestContext()
@@ -679,7 +679,7 @@ func TestCodeModeAgent_MaxDepth_ResponsesFormat(t *testing.T) {
 	manager := setupMCPManager(t, codeModeClient, httpClient)
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        2,
-		ToolExecutionTimeout: 30 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(30 * time.Second),
 	})
 
 	ctx := createTestContext()
@@ -750,7 +750,7 @@ func TestCodeModeAgent_Timeout(t *testing.T) {
 	manager := setupMCPManager(t, codeModeClient)
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        10,
-		ToolExecutionTimeout: 2 * time.Second, // Short timeout
+		ToolExecutionTimeout: schemas.Duration(2 * time.Second), // Short timeout
 	})
 
 	ctx := createTestContext()
@@ -814,7 +814,7 @@ func TestCodeModeAgent_Timeout_ChatFormat(t *testing.T) {
 	manager := setupMCPManager(t, codeModeClient)
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        10,
-		ToolExecutionTimeout: 1 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(1 * time.Second),
 	})
 
 	ctx := createTestContext()
@@ -876,7 +876,7 @@ func TestCodeModeAgent_Timeout_ResponsesFormat(t *testing.T) {
 	manager := setupMCPManager(t, codeModeClient)
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
 		MaxAgentDepth:        10,
-		ToolExecutionTimeout: 1 * time.Second,
+		ToolExecutionTimeout: schemas.Duration(1 * time.Second),
 	})
 
 	ctx := createTestContext()

--- a/core/internal/mcptests/error_handling_protocol_test.go
+++ b/core/internal/mcptests/error_handling_protocol_test.go
@@ -364,7 +364,7 @@ func TestErrorHandling_STDIO_TimeoutScenario(t *testing.T) {
 
 	// Set a short timeout for this test
 	manager.UpdateToolManagerConfig(&schemas.MCPToolManagerConfig{
-		ToolExecutionTimeout: 2 * time.Second, // 2 second timeout
+		ToolExecutionTimeout: schemas.Duration(2 * time.Second), // 2 second timeout
 	})
 
 	err := manager.AddClient(&errorServerConfig)

--- a/core/mcp/mcp.go
+++ b/core/mcp/mcp.go
@@ -72,7 +72,7 @@ func NewMCPManager(ctx context.Context, config schemas.MCPConfig, oauth2Provider
 	// Set default values
 	if config.ToolManagerConfig == nil {
 		config.ToolManagerConfig = &schemas.MCPToolManagerConfig{
-			ToolExecutionTimeout: schemas.DefaultToolExecutionTimeout,
+			ToolExecutionTimeout: schemas.Duration(schemas.DefaultToolExecutionTimeout),
 			MaxAgentDepth:        schemas.DefaultMaxAgentDepth,
 		}
 	}

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -119,7 +119,7 @@ func NewToolsManagerWithCodeMode(
 ) *ToolsManager {
 	if config == nil {
 		config = &schemas.MCPToolManagerConfig{
-			ToolExecutionTimeout: schemas.DefaultToolExecutionTimeout,
+			ToolExecutionTimeout: schemas.Duration(schemas.DefaultToolExecutionTimeout),
 			MaxAgentDepth:        schemas.DefaultMaxAgentDepth,
 			CodeModeBindingLevel: schemas.CodeModeBindingLevelServer,
 		}
@@ -128,7 +128,7 @@ func NewToolsManagerWithCodeMode(
 		config.MaxAgentDepth = schemas.DefaultMaxAgentDepth
 	}
 	if config.ToolExecutionTimeout <= 0 {
-		config.ToolExecutionTimeout = schemas.DefaultToolExecutionTimeout
+		config.ToolExecutionTimeout = schemas.Duration(schemas.DefaultToolExecutionTimeout)
 	}
 	// Default to server-level binding if not specified
 	if config.CodeModeBindingLevel == "" {
@@ -155,11 +155,11 @@ func NewToolsManagerWithCodeMode(
 	}
 
 	// Initialize atomic values
-	manager.toolExecutionTimeout.Store(config.ToolExecutionTimeout)
+	manager.toolExecutionTimeout.Store(time.Duration(config.ToolExecutionTimeout))
 	manager.maxAgentDepth.Store(int32(config.MaxAgentDepth))
 	manager.disableAutoToolInject.Store(config.DisableAutoToolInject)
 
-	manager.logger.Info("%s tool manager initialized with tool execution timeout: %v, max agent depth: %d, and code mode binding level: %s", MCPLogPrefix, config.ToolExecutionTimeout, config.MaxAgentDepth, config.CodeModeBindingLevel)
+	manager.logger.Info("%s tool manager initialized with tool execution timeout: %v, max agent depth: %d, and code mode binding level: %s", MCPLogPrefix, config.ToolExecutionTimeout.D(), config.MaxAgentDepth, config.CodeModeBindingLevel)
 	return manager
 }
 
@@ -814,7 +814,7 @@ func (m *ToolsManager) UpdateConfig(config *schemas.MCPToolManagerConfig) {
 		return
 	}
 	if config.ToolExecutionTimeout > 0 {
-		m.toolExecutionTimeout.Store(config.ToolExecutionTimeout)
+		m.toolExecutionTimeout.Store(time.Duration(config.ToolExecutionTimeout))
 	}
 	if config.MaxAgentDepth > 0 {
 		m.maxAgentDepth.Store(int32(config.MaxAgentDepth))
@@ -824,13 +824,13 @@ func (m *ToolsManager) UpdateConfig(config *schemas.MCPToolManagerConfig) {
 	if m.codeMode != nil && (config.CodeModeBindingLevel != "" || config.ToolExecutionTimeout > 0) {
 		m.codeMode.UpdateConfig(&CodeModeConfig{
 			BindingLevel:         config.CodeModeBindingLevel,
-			ToolExecutionTimeout: config.ToolExecutionTimeout,
+			ToolExecutionTimeout: time.Duration(config.ToolExecutionTimeout),
 		})
 	}
 
 	m.disableAutoToolInject.Store(config.DisableAutoToolInject)
 
-	m.logger.Info("%s tool manager configuration updated with tool execution timeout: %v, max agent depth: %d, and code mode binding level: %s", MCPLogPrefix, config.ToolExecutionTimeout, config.MaxAgentDepth, config.CodeModeBindingLevel)
+	m.logger.Info("%s tool manager configuration updated with tool execution timeout: %v, max agent depth: %d, and code mode binding level: %s", MCPLogPrefix, config.ToolExecutionTimeout.D(), config.MaxAgentDepth, config.CodeModeBindingLevel)
 }
 
 // executeToolWithUserToken creates a temporary MCP connection using the user's

--- a/core/schemas/duration.go
+++ b/core/schemas/duration.go
@@ -1,0 +1,78 @@
+package schemas
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Duration is a time.Duration value that accepts both human-readable duration
+// strings and plain integer nanosecond values on JSON unmarshal, providing
+// backward compatibility with the default Go JSON encoding of time.Duration.
+//
+// Accepted unmarshal formats:
+//   - String: "5s", "500ms", "1m30s", "2h", "0s" — parsed via time.ParseDuration
+//   - Integer: nanosecond count, identical to the default Go JSON encoding of
+//     time.Duration (e.g. 5000000000 = 5s)
+//
+// MarshalJSON is intentionally NOT overridden. The type marshals as its
+// underlying int64 nanosecond value (identical to time.Duration), preserving the
+// existing JSON API contract for all consumers that read these fields as integers.
+type Duration time.Duration
+
+// D returns the underlying time.Duration value.
+func (d Duration) D() time.Duration {
+	return time.Duration(d)
+}
+
+// String returns a human-readable representation of the duration.
+func (d Duration) String() string {
+	return time.Duration(d).String()
+}
+
+// UnmarshalJSON implements json.Unmarshaler. Accepts both a Go duration string
+// (e.g. "5s", "500ms") and an integer nanosecond value for backward
+// compatibility. MarshalJSON is NOT overridden — values encode as int64
+// nanoseconds, identical to time.Duration.
+func (d *Duration) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		return nil
+	}
+	dur, err := ParseFlexibleDuration(data, "duration")
+	if err != nil {
+		return err
+	}
+	*d = Duration(dur)
+	return nil
+}
+
+// ParseFlexibleDuration parses a JSON token (raw bytes) as a time.Duration.
+//
+// Supported formats:
+//   - JSON string "5s", "500ms", "1m30s" — forwarded to time.ParseDuration
+//   - JSON integer (e.g. 5000000000) — treated as nanoseconds, identical to the
+//     default Go JSON encoding of time.Duration
+//
+// fieldName is used only in error messages (e.g. "context_timeout").
+func ParseFlexibleDuration(data json.RawMessage, fieldName string) (time.Duration, error) {
+	if len(data) == 0 || string(data) == "null" {
+		return 0, nil
+	}
+	if data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return 0, err
+		}
+		dur, err := time.ParseDuration(s)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s %q: use a Go duration string like \"5s\", \"500ms\", \"1m30s\"", fieldName, s)
+		}
+		return dur, nil
+	}
+	// Numeric: nanoseconds — backward compatible with the default time.Duration JSON encoding.
+	var n int64
+	if err := json.Unmarshal(data, &n); err != nil {
+		return 0, fmt.Errorf("invalid %s: expected a duration string (e.g. \"5s\") or integer nanoseconds: %w", fieldName, err)
+	}
+	return time.Duration(n), nil
+}

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -114,7 +114,9 @@ func (c *MCPConfig) UnmarshalJSON(data []byte) error {
 }
 
 type MCPToolManagerConfig struct {
-	ToolExecutionTimeout  time.Duration        `json:"tool_execution_timeout"`
+	// ToolExecutionTimeout accepts a Go duration string (e.g. "30s", "2m") or an
+	// integer nanosecond value for backward compatibility.
+	ToolExecutionTimeout  Duration             `json:"tool_execution_timeout"`
 	MaxAgentDepth         int                  `json:"max_agent_depth"`
 	CodeModeBindingLevel  CodeModeBindingLevel `json:"code_mode_binding_level,omitempty"`  // How tools are exposed in VFS: "server" or "tool"
 	DisableAutoToolInject bool                 `json:"disable_auto_tool_inject,omitempty"` // When true, MCP tools are not injected into requests by default

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -4,6 +4,7 @@ package schemas
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"maps"
 	"time"
 )
@@ -44,13 +45,10 @@ const (
 // NetworkConfig represents the network configuration for provider connections.
 // ExtraHeaders is automatically copied during provider initialization to prevent data races.
 //
-// RetryBackoffInitial and RetryBackoffMax are stored internally as time.Duration (nanoseconds),
-// but are serialized/deserialized to/from JSON as milliseconds (integers).
-// This means:
-//   - In JSON: values are represented as milliseconds (e.g., 1000 means 1000ms)
-//   - In Go: values are time.Duration (e.g., 1000ms = 1000000000 nanoseconds)
-//   - When unmarshaling from JSON: a value of 1000 is interpreted as 1000ms, not 1000ns
-//   - When marshaling to JSON: a time.Duration is converted to milliseconds
+// RetryBackoffInitial and RetryBackoffMax are stored internally as time.Duration (nanoseconds).
+// They accept two JSON formats for backward compatibility:
+//   - Duration string: "500ms", "5s", "1m" — parsed via time.ParseDuration (preferred)
+//   - Integer: treated as milliseconds (legacy format, e.g. 500 means 500ms)
 type NetworkConfig struct {
 	// BaseURL is supported for OpenAI, Anthropic, Cohere, Mistral, and Ollama providers (required for Ollama)
 	BaseURL                        string            `json:"base_url,omitempty"`                       // Base URL for the provider (optional)
@@ -68,8 +66,11 @@ type NetworkConfig struct {
 }
 
 // UnmarshalJSON customizes JSON unmarshaling for NetworkConfig.
-// RetryBackoffInitial and RetryBackoffMax are interpreted as milliseconds in JSON,
-// but stored as time.Duration (nanoseconds) internally.
+//
+// RetryBackoffInitial and RetryBackoffMax accept two formats:
+//   - Duration string (preferred): "500ms", "5s", "1m" — parsed via time.ParseDuration
+//   - Integer (legacy): treated as milliseconds for backward compatibility
+//     (e.g. 500 → 500ms, matching the original behavior)
 func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 	// Use an alias type to avoid infinite recursion
 	type NetworkConfigAlias struct {
@@ -77,8 +78,8 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 		ExtraHeaders                   map[string]string `json:"extra_headers,omitempty"`
 		DefaultRequestTimeoutInSeconds int               `json:"default_request_timeout_in_seconds"`
 		MaxRetries                     int               `json:"max_retries"`
-		RetryBackoffInitial            int64             `json:"retry_backoff_initial"` // milliseconds in JSON
-		RetryBackoffMax                int64             `json:"retry_backoff_max"`     // milliseconds in JSON
+		RetryBackoffInitial            json.RawMessage   `json:"retry_backoff_initial"` // string ("500ms") or int (milliseconds)
+		RetryBackoffMax                json.RawMessage   `json:"retry_backoff_max"`     // string ("5s") or int (milliseconds)
 		InsecureSkipVerify             bool              `json:"insecure_skip_verify,omitempty"`
 		CACertPEM                      *EnvVar           `json:"ca_cert_pem,omitempty"`
 		StreamIdleTimeoutInSeconds     int               `json:"stream_idle_timeout_in_seconds,omitempty"`
@@ -92,7 +93,7 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	// Copy all fields
+	// Copy all non-duration fields
 	nc.BaseURL = alias.BaseURL
 	nc.ExtraHeaders = alias.ExtraHeaders
 	nc.DefaultRequestTimeoutInSeconds = alias.DefaultRequestTimeoutInSeconds
@@ -104,16 +105,56 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 	nc.EnforceHTTP2 = alias.EnforceHTTP2
 	nc.BetaHeaderOverrides = alias.BetaHeaderOverrides
 
-	// Convert milliseconds to time.Duration (nanoseconds)
-	// Only convert if value is greater than 0
-	if alias.RetryBackoffInitial > 0 {
-		nc.RetryBackoffInitial = time.Duration(alias.RetryBackoffInitial) * time.Millisecond
+	// Parse RetryBackoffInitial: string → ParseDuration, integer → milliseconds (legacy)
+	if len(alias.RetryBackoffInitial) > 0 && string(alias.RetryBackoffInitial) != "null" {
+		dur, err := parseNetworkBackoffDuration(alias.RetryBackoffInitial, "retry_backoff_initial")
+		if err != nil {
+			return err
+		}
+		if dur > 0 {
+			nc.RetryBackoffInitial = dur
+		}
 	}
-	if alias.RetryBackoffMax > 0 {
-		nc.RetryBackoffMax = time.Duration(alias.RetryBackoffMax) * time.Millisecond
+
+	// Parse RetryBackoffMax: string → ParseDuration, integer → milliseconds (legacy)
+	if len(alias.RetryBackoffMax) > 0 && string(alias.RetryBackoffMax) != "null" {
+		dur, err := parseNetworkBackoffDuration(alias.RetryBackoffMax, "retry_backoff_max")
+		if err != nil {
+			return err
+		}
+		if dur > 0 {
+			nc.RetryBackoffMax = dur
+		}
 	}
 
 	return nil
+}
+
+// parseNetworkBackoffDuration parses a retry backoff JSON value.
+// Strings are parsed via time.ParseDuration.
+// Integers are treated as milliseconds for backward compatibility with the
+// original NetworkConfig JSON format.
+func parseNetworkBackoffDuration(data json.RawMessage, fieldName string) (time.Duration, error) {
+	if len(data) == 0 || string(data) == "null" {
+		return 0, nil
+	}
+	if data[0] == '"' {
+		var s string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return 0, err
+		}
+		dur, err := time.ParseDuration(s)
+		if err != nil {
+			return 0, fmt.Errorf("invalid %s %q: use a Go duration string like \"500ms\", \"5s\", \"1m\"", fieldName, s)
+		}
+		return dur, nil
+	}
+	// Integer: milliseconds (original legacy format)
+	var ms int64
+	if err := json.Unmarshal(data, &ms); err != nil {
+		return 0, fmt.Errorf("invalid %s: expected a duration string (e.g. \"500ms\") or integer milliseconds: %w", fieldName, err)
+	}
+	return time.Duration(ms) * time.Millisecond, nil
 }
 
 // MarshalJSON customizes JSON marshaling for NetworkConfig.

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1232,7 +1232,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 			return &schemas.MCPConfig{
 				ClientConfigs: clientConfigs,
 				ToolManagerConfig: &schemas.MCPToolManagerConfig{
-					ToolExecutionTimeout: 30 * time.Second, // default from TableClientConfig
+					ToolExecutionTimeout: schemas.Duration(30 * time.Second), // default from TableClientConfig
 					MaxAgentDepth:        10,               // default from TableClientConfig
 				},
 			}, nil
@@ -1240,7 +1240,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 		return nil, err
 	}
 	toolManagerConfig := schemas.MCPToolManagerConfig{
-		ToolExecutionTimeout:  time.Duration(clientConfig.MCPToolExecutionTimeout) * time.Second,
+		ToolExecutionTimeout:  schemas.Duration(time.Duration(clientConfig.MCPToolExecutionTimeout) * time.Second),
 		MaxAgentDepth:         clientConfig.MCPAgentDepth,
 		CodeModeBindingLevel:  schemas.CodeModeBindingLevel(clientConfig.MCPCodeModeBindingLevel),
 		DisableAutoToolInject: clientConfig.MCPDisableAutoToolInject,

--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -41,17 +41,19 @@ type RedisConfig struct {
 	// Cluster mode
 	ClusterMode *schemas.EnvVar `json:"cluster_mode,omitempty"` // Use Redis Cluster client (default: false)
 
-	// Connection pool and timeout settings (passed directly to Redis client)
-	PoolSize        int           `json:"pool_size,omitempty"`          // Maximum number of socket connections (optional)
-	MaxActiveConns  int           `json:"max_active_conns,omitempty"`   // Maximum number of active connections (optional)
-	MinIdleConns    int           `json:"min_idle_conns,omitempty"`     // Minimum number of idle connections (optional)
-	MaxIdleConns    int           `json:"max_idle_conns,omitempty"`     // Maximum number of idle connections (optional)
-	ConnMaxLifetime time.Duration `json:"conn_max_lifetime,omitempty"`  // Connection maximum lifetime (optional)
-	ConnMaxIdleTime time.Duration `json:"conn_max_idle_time,omitempty"` // Connection maximum idle time (optional)
-	DialTimeout     time.Duration `json:"dial_timeout,omitempty"`       // Timeout for socket connection (optional)
-	ReadTimeout     time.Duration `json:"read_timeout,omitempty"`       // Timeout for socket reads (optional)
-	WriteTimeout    time.Duration `json:"write_timeout,omitempty"`      // Timeout for socket writes (optional)
-	ContextTimeout  time.Duration `json:"context_timeout,omitempty"`    // Timeout for Redis operations (optional)
+	// Connection pool and timeout settings (passed directly to Redis client).
+	// All duration fields accept either a Go duration string (e.g. "5s", "500ms",
+	// "1m30s") or a plain integer nanosecond value for backward compatibility.
+	PoolSize        int             `json:"pool_size,omitempty"`          // Maximum number of socket connections (optional)
+	MaxActiveConns  int             `json:"max_active_conns,omitempty"`   // Maximum number of active connections (optional)
+	MinIdleConns    int             `json:"min_idle_conns,omitempty"`     // Minimum number of idle connections (optional)
+	MaxIdleConns    int             `json:"max_idle_conns,omitempty"`     // Maximum number of idle connections (optional)
+	ConnMaxLifetime schemas.Duration `json:"conn_max_lifetime,omitempty"`  // Connection maximum lifetime (optional)
+	ConnMaxIdleTime schemas.Duration `json:"conn_max_idle_time,omitempty"` // Connection maximum idle time (optional)
+	DialTimeout     schemas.Duration `json:"dial_timeout,omitempty"`       // Timeout for socket connection (optional)
+	ReadTimeout     schemas.Duration `json:"read_timeout,omitempty"`       // Timeout for socket reads (optional)
+	WriteTimeout    schemas.Duration `json:"write_timeout,omitempty"`      // Timeout for socket writes (optional)
+	ContextTimeout  schemas.Duration `json:"context_timeout,omitempty"`    // Timeout for Redis operations (optional)
 }
 
 // RedisStore represents the Redis vector store.
@@ -71,7 +73,7 @@ func (s *RedisStore) Ping(ctx context.Context) error {
 
 // CreateNamespace creates a new namespace in the Redis vector store.
 func (s *RedisStore) CreateNamespace(ctx context.Context, namespace string, dimension int, properties map[string]VectorStoreProperties) error {
-	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
+	ctx, cancel := withTimeout(ctx, time.Duration(s.config.ContextTimeout))
 	defer cancel()
 
 	// Check if index already exists
@@ -133,7 +135,7 @@ func (s *RedisStore) CreateNamespace(ctx context.Context, namespace string, dime
 
 // GetChunk retrieves a chunk from the Redis vector store.
 func (s *RedisStore) GetChunk(ctx context.Context, namespace string, id string) (SearchResult, error) {
-	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
+	ctx, cancel := withTimeout(ctx, time.Duration(s.config.ContextTimeout))
 	defer cancel()
 
 	if strings.TrimSpace(id) == "" {
@@ -170,7 +172,7 @@ func (s *RedisStore) GetChunk(ctx context.Context, namespace string, id string) 
 
 // GetChunks retrieves multiple chunks from the Redis vector store.
 func (s *RedisStore) GetChunks(ctx context.Context, namespace string, ids []string) ([]SearchResult, error) {
-	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
+	ctx, cancel := withTimeout(ctx, time.Duration(s.config.ContextTimeout))
 	defer cancel()
 
 	if len(ids) == 0 {
@@ -234,7 +236,7 @@ func (s *RedisStore) GetChunks(ctx context.Context, namespace string, ids []stri
 
 // GetAll retrieves all chunks from the Redis vector store.
 func (s *RedisStore) GetAll(ctx context.Context, namespace string, queries []Query, selectFields []string, cursor *string, limit int64) ([]SearchResult, *string, error) {
-	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
+	ctx, cancel := withTimeout(ctx, time.Duration(s.config.ContextTimeout))
 	defer cancel()
 
 	// Set default limit if not provided
@@ -1126,7 +1128,7 @@ func buildRedisQueryCondition(query Query, fieldTypes map[string]VectorStoreProp
 
 // GetNearest retrieves the nearest chunks from the Redis vector store.
 func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []float32, queries []Query, selectFields []string, threshold float64, limit int64) ([]SearchResult, error) {
-	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
+	ctx, cancel := withTimeout(ctx, time.Duration(s.config.ContextTimeout))
 	defer cancel()
 
 	// Build Redis query from the provided queries
@@ -1236,7 +1238,7 @@ func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []
 
 // Add stores a new chunk in the Redis vector store.
 func (s *RedisStore) Add(ctx context.Context, namespace string, id string, embedding []float32, metadata map[string]interface{}) error {
-	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
+	ctx, cancel := withTimeout(ctx, time.Duration(s.config.ContextTimeout))
 	defer cancel()
 
 	if strings.TrimSpace(id) == "" {
@@ -1290,7 +1292,7 @@ func (s *RedisStore) Add(ctx context.Context, namespace string, id string, embed
 
 // Delete deletes a chunk from the Redis vector store.
 func (s *RedisStore) Delete(ctx context.Context, namespace string, id string) error {
-	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
+	ctx, cancel := withTimeout(ctx, time.Duration(s.config.ContextTimeout))
 	defer cancel()
 
 	if strings.TrimSpace(id) == "" {
@@ -1316,7 +1318,7 @@ func (s *RedisStore) Delete(ctx context.Context, namespace string, id string) er
 
 // DeleteAll deletes all chunks from the Redis vector store.
 func (s *RedisStore) DeleteAll(ctx context.Context, namespace string, queries []Query) ([]DeleteResult, error) {
-	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
+	ctx, cancel := withTimeout(ctx, time.Duration(s.config.ContextTimeout))
 	defer cancel()
 
 	return s.deleteAllBySnapshot(ctx, namespace, queries)
@@ -1464,7 +1466,7 @@ func (s *RedisStore) getAllMatchingIDs(ctx context.Context, namespace string, qu
 
 // DeleteNamespace deletes a namespace from the Redis vector store.
 func (s *RedisStore) DeleteNamespace(ctx context.Context, namespace string) error {
-	ctx, cancel := withTimeout(ctx, s.config.ContextTimeout)
+	ctx, cancel := withTimeout(ctx, time.Duration(s.config.ContextTimeout))
 	defer cancel()
 
 	// Drop the index using FT.DROPINDEX
@@ -1701,11 +1703,11 @@ func newRedisStore(_ context.Context, config RedisConfig, logger schemas.Logger)
 			MaxActiveConns:  config.MaxActiveConns,
 			MinIdleConns:    config.MinIdleConns,
 			MaxIdleConns:    config.MaxIdleConns,
-			ConnMaxLifetime: config.ConnMaxLifetime,
-			ConnMaxIdleTime: config.ConnMaxIdleTime,
-			DialTimeout:     config.DialTimeout,
-			ReadTimeout:     config.ReadTimeout,
-			WriteTimeout:    config.WriteTimeout,
+			ConnMaxLifetime: time.Duration(config.ConnMaxLifetime),
+			ConnMaxIdleTime: time.Duration(config.ConnMaxIdleTime),
+			DialTimeout:     time.Duration(config.DialTimeout),
+			ReadTimeout:     time.Duration(config.ReadTimeout),
+			WriteTimeout:    time.Duration(config.WriteTimeout),
 		})
 	} else {
 		client = redis.NewClient(&redis.Options{
@@ -1719,11 +1721,11 @@ func newRedisStore(_ context.Context, config RedisConfig, logger schemas.Logger)
 			MaxActiveConns:  config.MaxActiveConns,
 			MinIdleConns:    config.MinIdleConns,
 			MaxIdleConns:    config.MaxIdleConns,
-			ConnMaxLifetime: config.ConnMaxLifetime,
-			ConnMaxIdleTime: config.ConnMaxIdleTime,
-			DialTimeout:     config.DialTimeout,
-			ReadTimeout:     config.ReadTimeout,
-			WriteTimeout:    config.WriteTimeout,
+			ConnMaxLifetime: time.Duration(config.ConnMaxLifetime),
+			ConnMaxIdleTime: time.Duration(config.ConnMaxIdleTime),
+			DialTimeout:     time.Duration(config.DialTimeout),
+			ReadTimeout:     time.Duration(config.ReadTimeout),
+			WriteTimeout:    time.Duration(config.WriteTimeout),
 		})
 	}
 

--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -64,7 +64,7 @@ func NewRedisTestSetup(t *testing.T) *RedisTestSetup {
 		UseTLS:             useTLS,
 		InsecureSkipVerify: insecureSkipVerify,
 		ClusterMode:        clusterMode,
-		ContextTimeout:     timeout,
+		ContextTimeout:     schemas.Duration(timeout),
 	}
 
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelInfo)
@@ -524,7 +524,7 @@ func TestRedisStore_ExecuteSearch_DisableScanFallbackOnQuerySyntaxError(t *testi
 		client: client,
 		logger: bifrost.NewDefaultLogger(schemas.LogLevelDebug),
 		config: RedisConfig{
-			ContextTimeout: time.Second,
+			ContextTimeout: schemas.Duration(time.Second),
 		},
 		namespaceFieldTypes: make(map[string]map[string]VectorStorePropertyType),
 	}

--- a/framework/vectorstore/weaviate.go
+++ b/framework/vectorstore/weaviate.go
@@ -33,7 +33,9 @@ type WeaviateConfig struct {
 	Headers map[string]string `json:"headers,omitempty"` // Additional headers
 
 	// Connection settings
-	Timeout time.Duration `json:"timeout,omitempty"` // Request timeout (optional)
+	// Timeout accepts either a Go duration string (e.g. "5s", "30s") or an
+	// integer nanosecond value for backward compatibility.
+	Timeout schemas.Duration `json:"timeout,omitempty"` // Request timeout (optional)
 }
 
 type WeaviateGrpcConfig struct {
@@ -455,7 +457,7 @@ func newWeaviateStore(ctx context.Context, config *WeaviateConfig, logger schema
 	testCtx := ctx
 	if config.Timeout > 0 {
 		var cancel context.CancelFunc
-		testCtx, cancel = context.WithTimeout(ctx, config.Timeout)
+		testCtx, cancel = context.WithTimeout(ctx, time.Duration(config.Timeout))
 		defer cancel()
 	}
 

--- a/framework/vectorstore/weaviate_test.go
+++ b/framework/vectorstore/weaviate_test.go
@@ -48,7 +48,7 @@ func NewTestSetup(t *testing.T) *TestSetup {
 		Scheme:  scheme,
 		Host:    host,
 		APIKey:  schemas.NewEnvVar("env.WEAVIATE_API_KEY"),
-		Timeout: timeout,
+		Timeout: schemas.Duration(timeout),
 	}
 
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelInfo)

--- a/plugins/mocker/main.go
+++ b/plugins/mocker/main.go
@@ -123,9 +123,11 @@ type ErrorResponse struct {
 
 // Latency defines latency simulation settings
 type Latency struct {
-	Min  time.Duration `json:"min"`  // Minimum latency as time.Duration (e.g., 100*time.Millisecond, NOT raw int)
-	Max  time.Duration `json:"max"`  // Maximum latency as time.Duration (e.g., 500*time.Millisecond, NOT raw int)
-	Type string        `json:"type"` // Latency type: "fixed" or "uniform"
+	// Min and Max accept Go duration strings (e.g. "100ms", "1s") or integer
+	// nanosecond values for backward compatibility.
+	Min  schemas.Duration `json:"min"`  // Minimum latency
+	Max  schemas.Duration `json:"max"`  // Maximum latency
+	Type string           `json:"type"` // Latency type: "fixed" or "uniform"
 }
 
 // SizeRange defines request size constraints in bytes
@@ -360,13 +362,13 @@ func validateLatency(latency Latency) error {
 	}
 
 	// Min latency should be non-negative
-	if latency.Min < 0 {
+	if latency.Min.D() < 0 {
 		return fmt.Errorf("minimum latency cannot be negative")
 	}
 
 	// For uniform type, max should be >= min
 	if latency.Type == LatencyTypeUniform {
-		if latency.Max < latency.Min {
+		if latency.Max.D() < latency.Min.D() {
 			return fmt.Errorf("maximum latency (%v) cannot be less than minimum latency (%v)", latency.Max, latency.Min)
 		}
 	}
@@ -1028,17 +1030,17 @@ func (p *MockerPlugin) getLatency(rule *MockRule) *Latency {
 func (p *MockerPlugin) calculateLatency(latency *Latency) time.Duration {
 	switch latency.Type {
 	case LatencyTypeFixed:
-		return latency.Min
+		return latency.Min.D()
 	case LatencyTypeUniform:
-		if latency.Max <= latency.Min {
-			return latency.Min
+		if latency.Max.D() <= latency.Min.D() {
+			return latency.Min.D()
 		}
 		// Calculate random duration between Min and Max
-		diff := latency.Max - latency.Min
-		return latency.Min + time.Duration(rand.Float64()*float64(diff))
+		diff := latency.Max.D() - latency.Min.D()
+		return latency.Min.D() + time.Duration(rand.Float64()*float64(diff))
 	default:
 		// Default to fixed latency
-		return latency.Min
+		return latency.Min.D()
 	}
 }
 

--- a/plugins/semanticcache/test_utils.go
+++ b/plugins/semanticcache/test_utils.go
@@ -38,7 +38,7 @@ func getWeaviateConfigFromEnv() vectorstore.WeaviateConfig {
 		Scheme:  scheme,
 		Host:    host,
 		APIKey:  apiKey,
-		Timeout: time.Duration(timeout) * time.Second,
+		Timeout: schemas.Duration(time.Duration(timeout) * time.Second),
 	}
 }
 
@@ -66,7 +66,7 @@ func getRedisConfigFromEnv() vectorstore.RedisConfig {
 		Username:       username,
 		Password:       password,
 		DB:             db,
-		ContextTimeout: timeout,
+		ContextTimeout: schemas.Duration(timeout),
 	}
 }
 

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -301,7 +301,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		}
 		h.store.MCPConfig.ToolSyncInterval = time.Duration(updatedConfig.MCPToolSyncInterval) * time.Second
 		h.store.MCPConfig.ToolManagerConfig.MaxAgentDepth = updatedConfig.MCPAgentDepth
-		h.store.MCPConfig.ToolManagerConfig.ToolExecutionTimeout = time.Duration(updatedConfig.MCPToolExecutionTimeout) * time.Second
+		h.store.MCPConfig.ToolManagerConfig.ToolExecutionTimeout = schemas.Duration(time.Duration(updatedConfig.MCPToolExecutionTimeout) * time.Second)
 		h.store.MCPConfig.ToolManagerConfig.CodeModeBindingLevel = schemas.CodeModeBindingLevel(updatedConfig.MCPCodeModeBindingLevel)
 		h.store.MCPConfig.ToolManagerConfig.DisableAutoToolInject = updatedConfig.MCPDisableAutoToolInject
 	}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1172,10 +1172,14 @@ func applyMCPGlobalSettingsToClientConfig(ctx context.Context, config *Config, m
 			config.ClientConfig.MCPAgentDepth = mcpCfg.ToolManagerConfig.MaxAgentDepth
 			changed = true
 		}
-		toolTimeoutSec := int(mcpCfg.ToolManagerConfig.ToolExecutionTimeout / time.Second)
-		if toolTimeoutSec > 0 && config.ClientConfig.MCPToolExecutionTimeout != toolTimeoutSec {
-			config.ClientConfig.MCPToolExecutionTimeout = toolTimeoutSec
-			changed = true
+		if d := mcpCfg.ToolManagerConfig.ToolExecutionTimeout.D(); d > 0 {
+			// Ceiling-round to whole seconds: any sub-second value (e.g. 500ms) becomes 1s
+			// rather than being truncated to 0 and silently treated as "unset".
+			toolTimeoutSec := int(math.Ceil(d.Seconds()))
+			if config.ClientConfig.MCPToolExecutionTimeout != toolTimeoutSec {
+				config.ClientConfig.MCPToolExecutionTimeout = toolTimeoutSec
+				changed = true
+			}
 		}
 		if mcpCfg.ToolManagerConfig.CodeModeBindingLevel != "" {
 			codeModeLevel := string(mcpCfg.ToolManagerConfig.CodeModeBindingLevel)


### PR DESCRIPTION
## Summary

Introduces a custom `schemas.Duration` type that accepts both human-readable duration strings (e.g. `"5s"`, `"500ms"`) and the previous integer-based encoding on JSON unmarshal, while marshaling as its underlying `int64` nanosecond value to preserve the existing JSON API contract. This replaces bare `time.Duration` fields in config structs across MCP, Redis, Weaviate, and the Mocker plugin.

## Changes

- Added `schemas.Duration` — a `time.Duration` wrapper with a custom `UnmarshalJSON` that accepts either a Go duration string or an integer (nanoseconds). `MarshalJSON` is intentionally not overridden, preserving the existing integer encoding for all consumers.
- Added `ParseFlexibleDuration` helper for reuse across unmarshalers.
- Replaced `time.Duration` with `schemas.Duration` on `MCPToolManagerConfig.ToolExecutionTimeout`, `RedisConfig` timeout and pool duration fields, `WeaviateConfig.Timeout`, and `Latency.Min`/`Max` in the Mocker plugin.
- Updated `NetworkConfig.RetryBackoffInitial` and `RetryBackoffMax` unmarshaling to accept duration strings in addition to the existing integer-milliseconds legacy format via a dedicated `parseNetworkBackoffDuration` helper.
- All call sites that pass these values to APIs expecting `time.Duration` now explicitly convert via `time.Duration(...)` or `.D()`.
- Log statements updated to call `.D()` so the underlying `time.Duration` stringer formats correctly.
- Sub-second `ToolExecutionTimeout` values are now ceiling-rounded to whole seconds when syncing to client config, preventing silent truncation to zero.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/...
go test ./framework/vectorstore/...
go test ./plugins/...
go test ./transports/...
```

Verify that existing configs using integer values (e.g. `"tool_execution_timeout": 30000000000`) continue to deserialize correctly, and that new string-format configs (e.g. `"tool_execution_timeout": "30s"`) are also accepted.

## Breaking changes

- [ ] Yes
- [x] No

Existing integer-encoded duration values in JSON configs remain fully supported. The marshaled output continues to emit integers (nanoseconds), identical to the previous behavior.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable