### PR TITLE
feat: replace `Select` with `ComboboxSelect` in routing rules to support search and selection

### DIFF
--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Button } from "@/components/ui/button";
+import { ComboboxSelect } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ModelMultiselect } from "@/components/ui/modelMultiselect";
@@ -367,46 +368,31 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 									{scope === "team" ? "Team" : scope === "customer" ? "Customer" : "Virtual Key"} <span className="text-red-500">*</span>
 								</Label>
 								{scope === "team" && teamsData.teams.length > 0 && (
-									<Select value={scopeId || ""} onValueChange={(value) => setValue("scope_id", value)}>
-										<SelectTrigger className="w-full">
-											<SelectValue placeholder="Select a team..." />
-										</SelectTrigger>
-										<SelectContent>
-											{teamsData.teams.map((team) => (
-												<SelectItem key={team.id} value={team.id}>
-													{team.name}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
+									<ComboboxSelect
+										options={teamsData.teams.map((team) => ({ label: team.name, value: team.id }))}
+										value={scopeId || null}
+										onValueChange={(value) => setValue("scope_id", value ?? "")}
+										placeholder="Select a team..."
+										noPortal
+									/>
 								)}
 								{scope === "customer" && customersData.customers.length > 0 && (
-									<Select value={scopeId || ""} onValueChange={(value) => setValue("scope_id", value)}>
-										<SelectTrigger className="w-full">
-											<SelectValue placeholder="Select a customer..." />
-										</SelectTrigger>
-										<SelectContent>
-											{customersData.customers.map((customer) => (
-												<SelectItem key={customer.id} value={customer.id}>
-													{customer.name}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
+									<ComboboxSelect
+										options={customersData.customers.map((customer) => ({ label: customer.name, value: customer.id }))}
+										value={scopeId || null}
+										onValueChange={(value) => setValue("scope_id", value ?? "")}
+										placeholder="Select a customer..."
+										noPortal
+									/>
 								)}
 								{scope === "virtual_key" && vksData.virtual_keys.length > 0 && (
-									<Select value={scopeId || ""} onValueChange={(value) => setValue("scope_id", value)}>
-										<SelectTrigger className="w-full">
-											<SelectValue placeholder="Select a virtual key..." />
-										</SelectTrigger>
-										<SelectContent>
-											{vksData.virtual_keys.map((vk) => (
-												<SelectItem key={vk.id} value={vk.id}>
-													{vk.name}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
+									<ComboboxSelect
+										options={vksData.virtual_keys.map((vk) => ({ label: vk.name, value: vk.id }))}
+										value={scopeId || null}
+										onValueChange={(value) => setValue("scope_id", value ?? "")}
+										placeholder="Select a virtual key..."
+										noPortal
+									/>
 								)}
 								{((scope === "team" && teamsData.teams.length === 0) ||
 									(scope === "customer" && customersData.customers.length === 0) ||

--- a/ui/components/ui/combobox.tsx
+++ b/ui/components/ui/combobox.tsx
@@ -171,11 +171,13 @@ function ComboboxInput({
 function ComboboxContent({
 	className,
 	children,
+	noPortalForContent,
 	...props
 }: {
 	className?: string;
 	children?: React.ReactNode;
 	anchor?: React.RefObject<HTMLElement | null>;
+	noPortalForContent?: boolean;
 	[key: string]: any;
 }) {
 	const { filter } = useComboboxContext();
@@ -185,6 +187,7 @@ function ComboboxContent({
 			className={cn("w-[var(--radix-popover-trigger-width)] p-0", className)}
 			align="start"
 			sideOffset={4}
+			noPortal={noPortalForContent}
 			onOpenAutoFocus={(e) => e.preventDefault()}
 			{...props}
 		>
@@ -306,7 +309,7 @@ interface ComboboxSelectMultiProps extends ComboboxSelectBaseProps {
 	onValueChange?: (value: string[]) => void;
 }
 
-type ComboboxSelectProps = ComboboxSelectSingleProps | ComboboxSelectMultiProps;
+type ComboboxSelectProps = (ComboboxSelectSingleProps | ComboboxSelectMultiProps) & { noPortal?: boolean };
 
 function ComboboxSelect(props: ComboboxSelectProps) {
 	const {
@@ -316,6 +319,7 @@ function ComboboxSelect(props: ComboboxSelectProps) {
 		disableSearch = false,
 		className,
 		emptyMessage = "No results found.",
+		noPortal
 	} = props;
 
 	const [open, setOpen] = React.useState(false);
@@ -379,7 +383,7 @@ function ComboboxSelect(props: ComboboxSelectProps) {
 						<ChevronDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
 					</Button>
 				</PopoverTrigger>
-				<PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start" sideOffset={1}>
+				<PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start" sideOffset={1} noPortal={noPortal}>
 					<CommandPrimitive filter={() => 1}>
 						{!disableSearch && (
 							<div className="flex items-center border-b px-3">
@@ -465,7 +469,7 @@ function ComboboxSelect(props: ComboboxSelectProps) {
 					</div>
 				</Button>
 			</PopoverTrigger>
-			<PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start" sideOffset={4}>
+			<PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start" sideOffset={4} noPortal={noPortal}>
 				<CommandPrimitive filter={() => 1}>
 					{!disableSearch && (
 						<div className="flex items-center border-b px-3">
@@ -514,7 +518,8 @@ export {
 	ComboboxLabel,
 	ComboboxList,
 	ComboboxSelect,
-	ComboboxSeparator,
+	ComboboxSeparator
 };
 
 export type { ComboboxSelectOption, ComboboxSelectProps };
+

--- a/ui/components/ui/popover.tsx
+++ b/ui/components/ui/popover.tsx
@@ -11,7 +11,21 @@ function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimiti
 	return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
 }
 
-function PopoverContent({ className, align = "center", sideOffset = 4, ...props }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+function PopoverContent({ className, align = "center", sideOffset = 4, noPortal, ...props }: React.ComponentProps<typeof PopoverPrimitive.Content> & { noPortal?: boolean }) {
+	if (noPortal) {
+		return (
+			<PopoverPrimitive.Content
+				data-slot="popover-content"
+				align={align}
+				sideOffset={sideOffset}
+				className={cn(
+					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-sm border p-4 shadow-md outline-hidden",
+					className,
+				)}
+				{...props}
+			/>
+		);
+	}
 	return (
 		<PopoverPrimitive.Portal>
 			<PopoverPrimitive.Content


### PR DESCRIPTION
## Summary

Replaces the basic `Select` dropdowns in the routing rule sheet's scope selector with `ComboboxSelect` components, enabling search/filter functionality when selecting teams, customers, or virtual keys. To support rendering these comboboxes inside a sheet (where portal-based rendering causes z-index or overflow issues), a `noPortal` prop was added to `PopoverContent` and propagated through `ComboboxSelect` and `ComboboxContent`.

## Changes

- Replaced `Select`/`SelectTrigger`/`SelectContent`/`SelectItem` usage in `routingRuleSheet.tsx` with `ComboboxSelect` for team, customer, and virtual key scope selectors, passing `noPortal` to prevent portal rendering conflicts inside the sheet.
- Added a `noPortal` prop to `PopoverContent` that, when set, renders `PopoverPrimitive.Content` directly without wrapping it in `PopoverPrimitive.Portal`.
- Exposed `noPortal` on `ComboboxSelect` and `ComboboxContent` so the portal-bypass behavior can be controlled from the call site.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the routing rules sheet and create or edit a rule with a scope of **Team**, **Customer**, or **Virtual Key**.
2. Confirm the scope selector renders as a searchable combobox rather than a plain dropdown.
3. Type a partial name in the combobox search field and verify the list filters correctly.
4. Confirm the dropdown opens and closes without z-index or clipping issues inside the sheet.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Add before/after screenshots showing the old `Select` dropdown vs. the new searchable `ComboboxSelect`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable