### PR TITLE
feat: scope model list endpoints to VK-allowed providers and models via request headers

### DIFF
--- a/docs/features/governance/virtual-keys.mdx
+++ b/docs/features/governance/virtual-keys.mdx
@@ -565,6 +565,24 @@ curl -X POST http://localhost:8080/v1/chat/completions \
   -d '{"model": "gpt-4o-mini", "messages": [...]}'
 ```
 
+### Listing models with a virtual key
+
+When you call `GET /v1/models` with a virtual key, Bifrost **only lists (and only queries) providers that are allowed by that virtual key**. This avoids unnecessary “provider not allowed” errors in logs and keeps error-rate metrics meaningful.
+
+```bash
+# Lists models across providers allowed by the virtual key
+curl -sS "http://localhost:8080/v1/models" \
+  -H "x-bf-vk: <VIRTUAL_KEY>"
+```
+
+If you specify a provider explicitly via `?provider=...`, that provider must still be allowed by the virtual key or the request will be rejected:
+
+```bash
+# If "anthropic" is not configured/allowed on this virtual key, this returns 403
+curl -sS "http://localhost:8080/v1/models?provider=anthropic" \
+  -H "x-bf-vk: <VIRTUAL_KEY>"
+```
+
 **When `disable_auth_on_inference: false` (auth enabled):**
 
 You must provide both authentication credentials AND the virtual key. Use `x-bf-vk` for the virtual key since the `Authorization` header is used for authentication:

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -175,7 +175,7 @@
       "get": {
         "operationId": "listModels",
         "summary": "List available models",
-        "description": "Lists available models. If provider is not specified, lists all models from all configured providers.\n",
+        "description": "Lists available models. If provider is not specified, lists all models from all configured providers.\n\nIf a virtual key is provided, Bifrost only lists (and only queries) providers allowed by that virtual key.\n",
         "tags": [
           "Models"
         ],

--- a/docs/openapi/paths/inference/models.yaml
+++ b/docs/openapi/paths/inference/models.yaml
@@ -4,6 +4,8 @@ models:
     summary: List available models
     description: |
       Lists available models. If provider is not specified, lists all models from all configured providers.
+
+      If a virtual key is provided, Bifrost only lists (and only queries) providers allowed by that virtual key.
     tags:
     - Models
     parameters:

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
+	governanceplugin "github.com/maximhq/bifrost/plugins/governance"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
@@ -605,6 +606,10 @@ type modelListQuery struct {
 	KeyIDs     []string
 	Limit      int
 	Unfiltered bool
+	// VK-based filtering: populated when a virtual key is found in request headers.
+	// HasVKFilter=true restricts providers/models to those allowed by the VK.
+	HasVKFilter       bool
+	VKProviderConfigs []tables.TableVirtualKeyProviderConfig
 }
 
 type listedModel struct {
@@ -618,10 +623,16 @@ type listedModel struct {
 //   - query: Filter models by name (case-insensitive partial match)
 //   - provider: Filter by specific provider name
 //   - keys: Comma-separated list of provider key UUIDs to filter models accessible by those keys
-//   - vks: Comma-separated list of virtual key UUIDs to filter models accessible by those virtual keys
 //   - limit: Maximum number of results to return (default: 5)
+//
+// Request headers:
+//   - x-bf-vk / Authorization: Bearer / x-api-key / x-goog-api-key: Virtual key (sk-bf-…) to scope
+//     results to providers and models allowed by that virtual key.
 func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
-	query := parseModelListQuery(ctx, 5)
+	query, ok := h.parseModelListQuery(ctx, 5)
+	if !ok {
+		return
+	}
 	allModels, total, err := h.listManagementModels(query)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get providers: %v", err))
@@ -655,8 +666,15 @@ func (h *ProviderHandler) listModels(ctx *fasthttp.RequestCtx) {
 //   - keys: Comma-separated list of key IDs to filter models accessible by those keys
 //   - unfiltered: If true, bypass provider-level model pool restrictions only
 //   - limit: Maximum number of results to return (default: 20)
+//
+// Request headers:
+//   - x-bf-vk / Authorization: Bearer / x-api-key / x-goog-api-key: Virtual key (sk-bf-…) to scope
+//     results to providers and models allowed by that virtual key.
 func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
-	query := parseModelListQuery(ctx, 20)
+	query, ok := h.parseModelListQuery(ctx, 20)
+	if !ok {
+		return
+	}
 
 	modelCatalog := h.inMemoryStore.ModelCatalog
 	if modelCatalog == nil {
@@ -694,8 +712,9 @@ func (h *ProviderHandler) listModelDetails(ctx *fasthttp.RequestCtx) {
 	})
 }
 
-// parseModelListQuery normalizes the management model-list query string.
-func parseModelListQuery(ctx *fasthttp.RequestCtx, defaultLimit int) modelListQuery {
+// parseModelListQuery normalizes the management model-list query string and resolves
+// any virtual key present in the request headers to populate provider/model filters.
+func (h *ProviderHandler) parseModelListQuery(ctx *fasthttp.RequestCtx, defaultLimit int) (modelListQuery, bool) {
 	queryArgs := ctx.QueryArgs()
 	query := modelListQuery{
 		Provider:   schemas.ModelProvider(string(queryArgs.Peek("provider"))),
@@ -722,7 +741,30 @@ func parseModelListQuery(ctx *fasthttp.RequestCtx, defaultLimit int) modelListQu
 		}
 	}
 
-	return query
+	// Resolve virtual key from request headers and populate provider/model filters.
+	if vkValue := governanceplugin.ParseVirtualKeyFromFastHTTPRequest(ctx); vkValue != nil {
+		trimmedVKValue := strings.TrimSpace(*vkValue)
+
+		if h.dbStore == nil {
+			SendError(ctx, fasthttp.StatusServiceUnavailable, "database store unavailable")
+			return query, false
+		}
+
+		vk, err := h.dbStore.GetVirtualKeyByValue(ctx, trimmedVKValue)
+		if err != nil {
+			if !errors.Is(err, configstore.ErrNotFound) {
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to resolve virtual key: %v", err))
+				return query, false
+			}
+		}
+
+		if vk != nil {
+			query.HasVKFilter = true
+			query.VKProviderConfigs = vk.ProviderConfigs
+		}
+	}
+
+	return query, true
 }
 
 // listManagementModels lists models across one or all providers and applies the top-level limit.
@@ -736,6 +778,17 @@ func (h *ProviderHandler) listManagementModels(query modelListQuery) ([]listedMo
 		if err != nil {
 			return nil, 0, err
 		}
+	}
+
+	// When a virtual key is present, restrict the provider list to those explicitly
+	// permitted by the VK. An empty ProviderConfigs means no providers are allowed
+	// (deny-by-default), so we return nothing even if providers are configured.
+	if query.HasVKFilter {
+		providers = slices.DeleteFunc(providers, func(p schemas.ModelProvider) bool {
+			return !slices.ContainsFunc(query.VKProviderConfigs, func(pc tables.TableVirtualKeyProviderConfig) bool {
+				return strings.EqualFold(pc.Provider, string(p))
+			})
+		})
 	}
 
 	models := make([]listedModel, 0)
@@ -759,6 +812,17 @@ func (h *ProviderHandler) listManagementModelsForProvider(
 	models := h.modelsManager.GetModelsForProvider(provider)
 	if query.Unfiltered {
 		models = h.modelsManager.GetUnfilteredModelsForProvider(provider)
+	}
+
+	// Apply VK-level model whitelist filtering.
+	// AllowedModels=["*"] passes all; empty AllowedModels denies all (deny-by-default).
+	if query.HasVKFilter {
+		if idx := slices.IndexFunc(query.VKProviderConfigs, func(pc tables.TableVirtualKeyProviderConfig) bool {
+			return strings.EqualFold(pc.Provider, string(provider))
+		}); idx >= 0 {
+			allowedModels := query.VKProviderConfigs[idx].AllowedModels
+			models = slices.DeleteFunc(models, func(m string) bool { return !allowedModels.IsAllowed(m) })
+		}
 	}
 
 	if len(query.KeyIDs) == 0 || query.Unfiltered {
@@ -850,18 +914,21 @@ func (h *ProviderHandler) getModelParameters(ctx *fasthttp.RequestCtx) {
 // When a non-nil catalog is provided, it also checks whether any allowlisted
 // model resolves to the same base model name as the queried model (alias matching).
 func keyAllowsModelForList(key schemas.Key, model string, catalog *modelcatalog.ModelCatalog) bool {
-	if len(key.BlacklistedModels) > 0 && slices.Contains(key.BlacklistedModels, model) {
+	if key.BlacklistedModels.IsBlocked(model) {
 		return false
 	}
 	if len(key.Models) > 0 {
-		if slices.Contains(key.Models, model) {
+		if key.Models.IsAllowed(model) {
 			return true
 		}
 		// Catalog-aware alias matching: a key allowlisting "gpt-4o-2024-08-06"
 		// should also grant access to its base model "gpt-4o" in listings.
 		if catalog != nil {
 			for _, allowed := range key.Models {
-				if catalog.GetBaseModelName(allowed) == model {
+				if strings.EqualFold(
+					catalog.GetBaseModelName(allowed),
+					catalog.GetBaseModelName(model),
+				) {
 					return true
 				}
 			}

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/bytedance/sonic"
@@ -10,16 +11,17 @@ import (
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
+	governanceplugin "github.com/maximhq/bifrost/plugins/governance"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
 
 // mockModelsManager returns stable filtered and unfiltered model lists for handler tests.
 type mockModelsManager struct {
-	filtered     map[schemas.ModelProvider][]string
-	unfiltered   map[schemas.ModelProvider][]string
-	reloadCalls  []schemas.ModelProvider
-	reloadErr    error
+	filtered    map[schemas.ModelProvider][]string
+	unfiltered  map[schemas.ModelProvider][]string
+	reloadCalls []schemas.ModelProvider
+	reloadErr   error
 }
 
 func (m *mockModelsManager) ReloadProvider(_ context.Context, provider schemas.ModelProvider) (*configstoreTables.TableProvider, error) {
@@ -514,6 +516,353 @@ func TestListModelDetails_UnfilteredIgnoresKeys(t *testing.T) {
 	}
 }
 
+// --- VK-based filtering tests ---
+
+// TestParseVKValueFromRequest verifies that the VK value is extracted from each
+// supported header, in priority order, and that non-VK values are ignored.
+func TestParseVKValueFromRequest(t *testing.T) {
+	const vk = "sk-bf-test-virtual-key"
+
+	cases := []struct {
+		name   string
+		setup  func(*fasthttp.RequestCtx)
+		wantVK string
+	}{
+		{
+			name: "x-bf-vk header",
+			setup: func(ctx *fasthttp.RequestCtx) {
+				ctx.Request.Header.Set("x-bf-vk", vk)
+			},
+			wantVK: vk,
+		},
+		{
+			name: "Authorization Bearer header",
+			setup: func(ctx *fasthttp.RequestCtx) {
+				ctx.Request.Header.Set("Authorization", "Bearer "+vk)
+			},
+			wantVK: vk,
+		},
+		{
+			name: "x-api-key header",
+			setup: func(ctx *fasthttp.RequestCtx) {
+				ctx.Request.Header.Set("x-api-key", vk)
+			},
+			wantVK: vk,
+		},
+		{
+			name: "x-goog-api-key header",
+			setup: func(ctx *fasthttp.RequestCtx) {
+				ctx.Request.Header.Set("x-goog-api-key", vk)
+			},
+			wantVK: vk,
+		},
+		{
+			name:   "no header returns empty string",
+			setup:  func(*fasthttp.RequestCtx) {},
+			wantVK: "",
+		},
+		{
+			name: "non-VK Bearer token returns empty string",
+			setup: func(ctx *fasthttp.RequestCtx) {
+				ctx.Request.Header.Set("Authorization", "Bearer regular-api-key-123")
+			},
+			wantVK: "",
+		},
+		{
+			name: "x-bf-vk takes priority over Authorization",
+			setup: func(ctx *fasthttp.RequestCtx) {
+				ctx.Request.Header.Set("x-bf-vk", vk)
+				ctx.Request.Header.Set("Authorization", "Bearer sk-bf-other")
+			},
+			wantVK: vk,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := &fasthttp.RequestCtx{}
+			tc.setup(ctx)
+			got := governanceplugin.ParseVirtualKeyFromFastHTTPRequest(ctx)
+			gotValue := ""
+			if got != nil {
+				gotValue = *got
+			}
+			if gotValue != tc.wantVK {
+				t.Fatalf("expected %q, got %q", tc.wantVK, gotValue)
+			}
+		})
+	}
+}
+
+// TestListModels_VKFilterRestrictsToAllowedProviderAndModels verifies that when a
+// VK filter is active, only providers listed in VKProviderConfigs are returned and
+// only models passing AllowedModels are included.
+func TestListModels_VKFilterRestrictsToAllowedProviderAndModels(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	// Two providers configured; VK only allows openai with specific models.
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				schemas.OpenAI:    {Keys: []schemas.Key{{ID: "key-a"}}},
+				schemas.Anthropic: {Keys: []schemas.Key{{ID: "key-b"}}},
+			},
+		},
+		modelsManager: &mockModelsManager{
+			filtered: map[schemas.ModelProvider][]string{
+				schemas.OpenAI:    {"gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"},
+				schemas.Anthropic: {"claude-3-5-sonnet", "claude-3-haiku"},
+			},
+		},
+	}
+
+	query := modelListQuery{
+		Limit:       100,
+		HasVKFilter: true,
+		VKProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
+			{
+				Provider:      "openai",
+				AllowedModels: schemas.WhiteList{"gpt-4o", "gpt-4o-mini"},
+			},
+		},
+	}
+
+	models, total, err := h.listManagementModels(query)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("expected total=2, got %d", total)
+	}
+	for _, m := range models {
+		if m.Provider != schemas.OpenAI {
+			t.Fatalf("expected only openai models, got provider %s", m.Provider)
+		}
+	}
+	names := map[string]bool{}
+	for _, m := range models {
+		names[m.Name] = true
+	}
+	if !names["gpt-4o"] || !names["gpt-4o-mini"] {
+		t.Fatalf("expected gpt-4o and gpt-4o-mini, got %v", models)
+	}
+	if names["gpt-3.5-turbo"] {
+		t.Fatalf("gpt-3.5-turbo should be denied by AllowedModels")
+	}
+	if names["claude-3-5-sonnet"] || names["claude-3-haiku"] {
+		t.Fatalf("anthropic models should be excluded by VK provider filter")
+	}
+}
+
+// TestListModels_VKFilterAllowsAllModelsWithWildcard verifies that AllowedModels=["*"]
+// passes all provider models through.
+func TestListModels_VKFilterAllowsAllModelsWithWildcard(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				schemas.OpenAI: {Keys: []schemas.Key{{ID: "key-a"}}},
+			},
+		},
+		modelsManager: &mockModelsManager{
+			filtered: map[schemas.ModelProvider][]string{
+				schemas.OpenAI: {"gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"},
+			},
+		},
+	}
+
+	query := modelListQuery{
+		Limit:       100,
+		HasVKFilter: true,
+		VKProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
+			{Provider: "openai", AllowedModels: schemas.WhiteList{"*"}},
+		},
+	}
+
+	models, total, err := h.listManagementModels(query)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 3 {
+		t.Fatalf("expected all 3 models with wildcard, got total=%d", total)
+	}
+	_ = models
+}
+
+// TestListModels_VKFilterDeniesAllModelsWhenAllowedModelsEmpty verifies deny-by-default:
+// a VK that lists a provider but with an empty AllowedModels returns 0 models.
+func TestListModels_VKFilterDeniesAllModelsWhenAllowedModelsEmpty(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				schemas.OpenAI: {Keys: []schemas.Key{{ID: "key-a"}}},
+			},
+		},
+		modelsManager: &mockModelsManager{
+			filtered: map[schemas.ModelProvider][]string{
+				schemas.OpenAI: {"gpt-4o", "gpt-4o-mini"},
+			},
+		},
+	}
+
+	query := modelListQuery{
+		Limit:       100,
+		HasVKFilter: true,
+		VKProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
+			{Provider: "openai", AllowedModels: schemas.WhiteList{}},
+		},
+	}
+
+	models, total, err := h.listManagementModels(query)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 0 || len(models) != 0 {
+		t.Fatalf("expected 0 models with empty AllowedModels (deny-by-default), got total=%d %v", total, models)
+	}
+}
+
+// TestListModels_VKFilterNoProviderConfigsDeniesAll verifies that a VK with no
+// ProviderConfigs returns 0 models (deny-by-default at provider level).
+func TestListModels_VKFilterNoProviderConfigsDeniesAll(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				schemas.OpenAI:    {},
+				schemas.Anthropic: {},
+			},
+		},
+		modelsManager: &mockModelsManager{
+			filtered: map[schemas.ModelProvider][]string{
+				schemas.OpenAI:    {"gpt-4o"},
+				schemas.Anthropic: {"claude-3-5-sonnet"},
+			},
+		},
+	}
+
+	query := modelListQuery{
+		Limit:             100,
+		HasVKFilter:       true,
+		VKProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{}, // empty
+	}
+
+	models, total, err := h.listManagementModels(query)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 0 || len(models) != 0 {
+		t.Fatalf("expected 0 models when VK has no provider configs, got total=%d", total)
+	}
+}
+
+func TestListModels_VKFilterBlockedExplicitProviderReturnsEmptyResult(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				schemas.OpenAI:    {},
+				schemas.Anthropic: {},
+			},
+		},
+		modelsManager: &mockModelsManager{
+			filtered: map[schemas.ModelProvider][]string{
+				schemas.OpenAI:    {"gpt-4o"},
+				schemas.Anthropic: {"claude-3-5-sonnet"},
+			},
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models?provider=anthropic")
+	query, ok := h.parseModelListQuery(ctx, 5)
+	if !ok {
+		t.Fatalf("expected parseModelListQuery to succeed")
+	}
+	query.HasVKFilter = true
+	query.VKProviderConfigs = []configstoreTables.TableVirtualKeyProviderConfig{
+		{Provider: "openai", AllowedModels: schemas.WhiteList{"*"}},
+	}
+
+	models, total, err := h.listManagementModels(query)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 0 || len(models) != 0 {
+		t.Fatalf("expected blocked explicit provider to return no models, got total=%d models=%#v", total, models)
+	}
+}
+
+func TestParseModelListQuery_VKWithoutDBStoreReturnsServiceUnavailable(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				schemas.OpenAI: {},
+			},
+		},
+		modelsManager: &mockModelsManager{
+			filtered: map[schemas.ModelProvider][]string{
+				schemas.OpenAI: {"gpt-4o", "gpt-4o-mini"},
+			},
+		},
+	}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models")
+	ctx.Request.Header.Set("x-bf-vk", "sk-bf-test-virtual-key")
+
+	query, ok := h.parseModelListQuery(ctx, 5)
+	if ok {
+		t.Fatalf("expected parseModelListQuery to fail without dbStore, got query=%#v", query)
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusServiceUnavailable {
+		t.Fatalf("expected 503 when dbStore is unavailable, got %d", ctx.Response.StatusCode())
+	}
+}
+
+// TestListModels_NoVKFilterReturnsAll verifies that without a VK filter the endpoint
+// returns all providers and models as normal.
+func TestListModels_NoVKFilterReturnsAll(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := &ProviderHandler{
+		inMemoryStore: &lib.Config{
+			Providers: map[schemas.ModelProvider]configstore.ProviderConfig{
+				schemas.OpenAI:    {},
+				schemas.Anthropic: {},
+			},
+		},
+		modelsManager: &mockModelsManager{
+			filtered: map[schemas.ModelProvider][]string{
+				schemas.OpenAI:    {"gpt-4o"},
+				schemas.Anthropic: {"claude-3-5-sonnet"},
+			},
+		},
+	}
+
+	query := modelListQuery{
+		Limit:       100,
+		HasVKFilter: false, // no filter
+	}
+
+	models, total, err := h.listManagementModels(query)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 2 || len(models) != 2 {
+		t.Fatalf("expected 2 models (one per provider), got total=%d", total)
+	}
+}
+
 func TestListModels_UsesCatalogAwareAliasMatchingForKeyAllowlist(t *testing.T) {
 	SetLogger(&mockLogger{})
 
@@ -546,5 +895,88 @@ func TestListModels_UsesCatalogAwareAliasMatchingForKeyAllowlist(t *testing.T) {
 
 	if resp.Total != 1 || len(resp.Models) != 1 || resp.Models[0].Name != "gpt-4o" {
 		t.Fatalf("expected gpt-4o to be matched through alias allowlist, got %#v", resp.Models)
+	}
+}
+
+// TestListModels_KeyModelAllowlistIsCaseInsensitive verifies that key.Models matching
+// uses case-insensitive comparison so "GPT-4O" in the allowlist matches "gpt-4o" in the pool.
+func TestListModels_KeyModelAllowlistIsCaseInsensitive(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		schemas.OpenAI,
+		[]schemas.Key{
+			{ID: "key-a", Models: []string{"GPT-4O", "GPT-4O-MINI"}},
+		},
+		[]string{"gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"},
+		[]string{"gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"},
+	)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models?provider=openai&keys=key-a&limit=10")
+
+	h.listModels(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var resp ListModelsResponse
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Total != 2 {
+		t.Fatalf("expected total=2 (gpt-4o and gpt-4o-mini matched case-insensitively), got total=%d %v", resp.Total, resp.Models)
+	}
+	names := map[string]bool{}
+	for _, m := range resp.Models {
+		names[m.Name] = true
+	}
+	if !names["gpt-4o"] || !names["gpt-4o-mini"] {
+		t.Fatalf("expected gpt-4o and gpt-4o-mini, got %v", resp.Models)
+	}
+	if names["gpt-3.5-turbo"] {
+		t.Fatalf("gpt-3.5-turbo should not be returned (not in key allowlist)")
+	}
+}
+
+// TestListModels_KeyBlacklistIsCaseInsensitive verifies that key.BlacklistedModels uses
+// case-insensitive matching so "GPT-3.5-TURBO" blocks "gpt-3.5-turbo" in the pool.
+func TestListModels_KeyBlacklistIsCaseInsensitive(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	h := providerHandlerForTest(
+		schemas.OpenAI,
+		[]schemas.Key{
+			{ID: "key-a", BlacklistedModels: []string{"GPT-3.5-TURBO"}},
+		},
+		[]string{"gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"},
+		[]string{"gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"},
+	)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("GET")
+	ctx.Request.SetRequestURI("/api/models?provider=openai&keys=key-a&limit=10")
+
+	h.listModels(ctx)
+
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+
+	var resp ListModelsResponse
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Total != 2 {
+		t.Fatalf("expected total=2 (gpt-3.5-turbo blocked case-insensitively), got total=%d %v", resp.Total, resp.Models)
+	}
+	for _, m := range resp.Models {
+		if strings.EqualFold(m.Name, "gpt-3.5-turbo") {
+			t.Fatalf("gpt-3.5-turbo should be blocked by blacklist, got %v", resp.Models)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Model listing endpoints (`/api/models` and `/api/models/details`) previously had no way to scope results to what a virtual key (VK) is permitted to access. This PR adds VK-based filtering so that when a `sk-bf-…` virtual key is supplied in the request headers, only the providers and models explicitly allowed by that VK's configuration are returned. It also fixes model allowlist and blacklist comparisons to be case-insensitive.

## Changes

- `parseModelListQuery` is promoted from a package-level function to a method on `ProviderHandler` so it can access `dbStore` to resolve the virtual key.
- A new `parseVKValueFromRequest` helper extracts a `sk-bf-…` virtual key from `x-bf-vk`, `Authorization: Bearer`, `x-api-key`, or `x-goog-api-key` headers, in that priority order.
- `modelListQuery` gains `HasVKFilter` and `VKProviderConfigs` fields. When populated, `listManagementModels` filters the provider list to only those present in the VK's `ProviderConfigs`, and `listManagementModelsForProvider` further filters models through `AllowedModels`. Both use deny-by-default semantics: an empty `ProviderConfigs` or empty `AllowedModels` returns nothing; `["*"]` passes all models.
- `keyAllowsModelForList` now uses `IsAllowed`/`IsBlocked` methods (which perform case-insensitive matching) instead of `slices.Contains`, and the catalog alias comparison is made case-insensitive via `strings.EqualFold`.
- The `vks` query parameter (comma-separated VK UUIDs) is removed from the `listModels` doc comment in favour of the header-based approach.
- Tests cover: VK header extraction priority, provider-level restriction, model-level whitelist, wildcard passthrough, deny-by-default on empty configs, no-filter passthrough, and case-insensitive key allowlist/blacklist matching.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/...
```

To validate end-to-end:

1. Create a virtual key scoped to a specific provider and model list.
2. Call `GET /api/models` with the VK in any of the supported headers (`x-bf-vk`, `Authorization: Bearer sk-bf-…`, `x-api-key`, or `x-goog-api-key`).
3. Confirm only the permitted provider's models appear in the response.
4. Call the same endpoint without a VK header and confirm all configured providers and models are returned.

```
curl -sS -X GET "http://localhost:8080/v1/models" \
  -H "Authorization: Bearer sk-bf-your-virtual-key" | jq
```

## Breaking changes

- [x] Yes
- [ ] No

The `vks` query parameter for filtering by virtual key UUID is no longer documented or supported on the model listing endpoints. Callers should pass the virtual key value directly via request headers instead.

## Security considerations

Virtual key values (`sk-bf-…`) extracted from headers are looked up against the database before any filtering is applied. An unrecognised or invalid VK silently falls back to no VK filter (the same behaviour as an unauthenticated request to the management endpoint). No VK value is logged or reflected in responses.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable