### PR TITLE
chore: sync teams table search, pagination, and dialog state to URL query params

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/user-groups/teamsView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/user-groups/teamsView.tsx
@@ -3,7 +3,8 @@ import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { useEffect, useRef, useState } from "react";
+import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
+import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 
 const POLLING_INTERVAL = 5000;
@@ -15,13 +16,16 @@ export function TeamsView() {
 	const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
 	const shownErrorsRef = useRef(new Set<string>());
 
-	const [search, setSearch] = useState("");
-	const [offset, setOffset] = useState(0);
-	const debouncedSearch = useDebouncedValue(search, 300);
+	const [urlState, setUrlState] = useQueryStates(
+		{
+			search: parseAsString.withDefault(""),
+			offset: parseAsInteger.withDefault(0),
+			selected_team: parseAsString.withDefault(""),
+		},
+		{ history: "push" },
+	);
 
-	useEffect(() => {
-		setOffset(0);
-	}, [debouncedSearch]);
+	const debouncedSearch = useDebouncedValue(urlState.search, 300);
 
 	const {
 		data: virtualKeysData,
@@ -46,7 +50,7 @@ export function TeamsView() {
 	} = useGetTeamsQuery(
 		{
 			limit: PAGE_SIZE,
-			offset,
+			offset: urlState.offset,
 			search: debouncedSearch || undefined,
 		},
 		{
@@ -59,9 +63,9 @@ export function TeamsView() {
 
 	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
 	useEffect(() => {
-		if (!teamsData || offset < teamsTotal) return;
-		setOffset(teamsTotal === 0 ? 0 : Math.floor((teamsTotal - 1) / PAGE_SIZE) * PAGE_SIZE);
-	}, [teamsTotal, offset]);
+		if (!teamsData || urlState.offset < teamsTotal) return;
+		setUrlState({ offset: teamsTotal === 0 ? 0 : Math.floor((teamsTotal - 1) / PAGE_SIZE) * PAGE_SIZE });
+	}, [teamsTotal, urlState.offset]);
 
 	const isLoading = vkLoading || customersLoading || teamsLoading;
 
@@ -93,12 +97,16 @@ export function TeamsView() {
 				totalCount={teamsData?.total_count || 0}
 				customers={customersData?.customers || []}
 				virtualKeys={virtualKeysData?.virtual_keys || []}
-				search={search}
+				search={urlState.search}
 				debouncedSearch={debouncedSearch}
-				onSearchChange={setSearch}
-				offset={offset}
+				onSearchChange={(val) => setUrlState({ search: val || null, offset: 0 }, { history: "replace" })}
+				offset={urlState.offset}
 				limit={PAGE_SIZE}
-				onOffsetChange={setOffset}
+				onOffsetChange={(newOffset) => setUrlState({ offset: newOffset })}
+				selectedTeamId={urlState.selected_team || null}
+				onTeamAdd={() => setUrlState({ selected_team: "new" })}
+				onTeamSelect={(team) => { setUrlState({ selected_team: team?.id ?? null }) }}
+				onDialogClose={() => setUrlState({ selected_team: null })}
 			/>
 		</div>
 	);

--- a/ui/app/workspace/governance/views/teamsTable.tsx
+++ b/ui/app/workspace/governance/views/teamsTable.tsx
@@ -22,7 +22,7 @@ import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Input } from "@/components/ui/input";
 import { ChevronLeft, ChevronRight, Edit, Plus, Search, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect } from "react";
 import { toast } from "sonner";
 import TeamDialog from "./teamDialog";
 import { TeamsEmptyState } from "./teamsEmptyState";
@@ -43,6 +43,10 @@ interface TeamsTableProps {
 	offset: number;
 	limit: number;
 	onOffsetChange: (offset: number) => void;
+	selectedTeamId: string | null;
+	onTeamAdd: () => void;
+	onTeamSelect: (team: Team | null) => void;
+	onDialogClose: () => void;
 }
 
 export default function TeamsTable({
@@ -56,9 +60,23 @@ export default function TeamsTable({
 	offset,
 	limit,
 	onOffsetChange,
+	selectedTeamId,
+	onTeamAdd,
+	onTeamSelect,
+	onDialogClose,
 }: TeamsTableProps) {
-	const [showTeamDialog, setShowTeamDialog] = useState(false);
-	const [editingTeam, setEditingTeam] = useState<Team | null>(null);
+	const showTeamDialog = selectedTeamId !== null && selectedTeamId !== "";
+	const editingTeam = selectedTeamId && selectedTeamId !== "new"
+		? teams.find((t) => t.id === selectedTeamId) ?? null
+		: null;
+
+	// If a team ID is in the URL but can't be resolved (deleted or filtered out),
+	// clear it so we don't silently open the dialog in "create" mode.
+	useEffect(() => {
+		if (selectedTeamId && selectedTeamId !== "new" && !editingTeam) {
+			onDialogClose();
+		}
+	}, [selectedTeamId, editingTeam, onDialogClose]);
 
 	const hasCreateAccess = useRbac(RbacResource.Teams, RbacOperation.Create);
 	const hasUpdateAccess = useRbac(RbacResource.Teams, RbacOperation.Update);
@@ -76,18 +94,15 @@ export default function TeamsTable({
 	};
 
 	const handleAddTeam = () => {
-		setEditingTeam(null);
-		setShowTeamDialog(true);
+		onTeamAdd();
 	};
 
 	const handleEditTeam = (team: Team) => {
-		setEditingTeam(team);
-		setShowTeamDialog(true);
+		onTeamSelect(team);
 	};
 
 	const handleTeamSaved = () => {
-		setShowTeamDialog(false);
-		setEditingTeam(null);
+		onDialogClose();
 	};
 
 	const getVirtualKeysForTeam = (teamId: string) => {
@@ -108,7 +123,7 @@ export default function TeamsTable({
 			<>
 				<TooltipProvider>
 					{showTeamDialog && (
-						<TeamDialog team={editingTeam} customers={customers} onSave={handleTeamSaved} onCancel={() => setShowTeamDialog(false)} />
+						<TeamDialog team={editingTeam} customers={customers} onSave={handleTeamSaved} onCancel={onDialogClose} />
 					)}
 					<TeamsEmptyState onAddClick={handleAddTeam} canCreate={hasCreateAccess} />
 				</TooltipProvider>
@@ -120,7 +135,7 @@ export default function TeamsTable({
 		<>
 			<TooltipProvider>
 				{showTeamDialog && (
-					<TeamDialog team={editingTeam} customers={customers} onSave={handleTeamSaved} onCancel={() => setShowTeamDialog(false)} />
+					<TeamDialog team={editingTeam} customers={customers} onSave={handleTeamSaved} onCancel={onDialogClose} />
 				)}
 
 				<div className="space-y-4">


### PR DESCRIPTION
## Summary

Team dialog state (open/closed, which team is being edited) and search/pagination state are now stored in the URL query string instead of local React state. This allows users to share or bookmark a URL that preserves their current search, page, and open dialog context, and enables browser back/forward navigation through those states.

## Changes

- Replaced `useState` for `search`, `offset`, and team dialog state in `TeamsView` with `useQueryStates` from `nuqs`, persisting `search`, `offset`, and `selected_team` as URL query parameters with `history: "push"`.
- The `selected_team` param encodes dialog state: absent/empty means closed, `"new"` means the add-team dialog is open, and a team ID means the edit dialog for that team is open.
- Lifted dialog open/close and team selection callbacks out of `TeamsTable` into `TeamsView`, removing the local `showTeamDialog` and `editingTeam` state from `TeamsTable`.
- `TeamsTable` now derives `showTeamDialog` and `editingTeam` from the `selectedTeamId` prop, making it a controlled component with no internal dialog state.
- Resetting `offset` to `0` on search change is now handled inline when calling `setUrlState` rather than via a separate `useEffect`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Teams governance page.
2. Type in the search box and confirm the `search` query param updates in the URL.
3. Page through results and confirm `offset` updates in the URL.
4. Click "Add Team" and confirm `selected_team=new` appears in the URL; close the dialog and confirm it is removed.
5. Click the edit button on a team and confirm `selected_team=<team_id>` appears in the URL; close the dialog and confirm it is removed.
6. Use the browser back button after opening/closing dialogs or changing pages and confirm state is restored correctly.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII implications. Query params are read-only reflections of UI state.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable