### PR TITLE
chore: updates sidebar link for compat plugin

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -198,7 +198,7 @@
             "pages": [
               "features/drop-in-replacement",
               "features/retries-and-fallbacks",
-              "features/litellm-compat",
+              "features/compat-plugin",
               "features/keys-management",
               "features/async-inference",
               {

--- a/ui/app/workspace/config/views/compatibilityView.tsx
+++ b/ui/app/workspace/config/views/compatibilityView.tsx
@@ -63,7 +63,7 @@ export default function CompatibilityView() {
 					Configure request conversions and compatibility fallbacks.{" "}
 					<a
 						className="text-primary underline"
-						href="https://docs.getbifrost.ai/features/litellm-compat"
+						href="https://docs.getbifrost.ai/features/compat-plugin"
 						target="_blank"
 						rel="noopener noreferrer"
 						data-testid="litellm-docs-link"


### PR DESCRIPTION
## Summary

Renames the documentation page reference from `litellm-compat` to `compat-plugin` in the docs navigation configuration.

## Changes

- Updated the docs navigation entry to point to `features/compat-plugin` instead of `features/litellm-compat`, reflecting a rename of the compatibility plugin documentation page.

<img width="1512" height="782" alt="Screenshot 2026-04-28 at 12 26 46" src="https://github.com/user-attachments/assets/de51bc02-12b8-4301-98f8-d47b48c2e640" />

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Navigate to the docs site and verify the compatibility plugin page loads correctly under the new path `features/compat-plugin`.

## Breaking changes

- [x] Yes
- [ ] No

Any existing links pointing to `features/litellm-compat` will need to be updated to `features/compat-plugin`.

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable