### PR TITLE
fix: strip `google/` prefix from Vertex model IDs across all request types

### DIFF
--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -14,6 +14,8 @@ func ToGeminiChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*Gem
 		return nil, nil
 	}
 
+	bifrostReq.Model = NormalizeModelName(bifrostReq.Model)
+
 	// Create the base Gemini generation request
 	geminiReq := &GeminiGenerationRequest{
 		Model: bifrostReq.Model,

--- a/core/providers/gemini/images.go
+++ b/core/providers/gemini/images.go
@@ -394,6 +394,8 @@ func ToGeminiImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 		return nil
 	}
 
+	bifrostReq.Model = NormalizeModelName(bifrostReq.Model)
+
 	// Create the base Gemini generation request
 	geminiReq := &GeminiGenerationRequest{
 		Model: bifrostReq.Model,
@@ -492,6 +494,8 @@ func ToImagenImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 	if bifrostReq == nil || bifrostReq.Input == nil {
 		return nil
 	}
+
+	bifrostReq.Model = NormalizeModelName(bifrostReq.Model)
 
 	// Create instances array with prompt
 	prompt := bifrostReq.Input.Prompt
@@ -639,7 +643,6 @@ func convertOutputFormatToMimeType(outputFormat string) string {
 	}
 }
 
-
 // ToBifrostImageGenerationResponse converts an Imagen response to Bifrost format
 func (response *GeminiImagenResponse) ToBifrostImageGenerationResponse() *schemas.BifrostImageGenerationResponse {
 	if response == nil {
@@ -733,6 +736,8 @@ func ToGeminiImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 	if bifrostReq == nil || bifrostReq.Input == nil || len(bifrostReq.Input.Images) == 0 {
 		return nil
 	}
+
+	bifrostReq.Model = NormalizeModelName(bifrostReq.Model)
 
 	// Create the base Gemini generation request
 	geminiReq := &GeminiGenerationRequest{
@@ -926,6 +931,8 @@ func ToImagenImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 	if bifrostReq == nil || bifrostReq.Input == nil || len(bifrostReq.Input.Images) == 0 {
 		return nil
 	}
+
+	bifrostReq.Model = NormalizeModelName(bifrostReq.Model)
 
 	req := &GeminiImagenRequest{
 		Parameters: GeminiImagenParameters{},

--- a/core/providers/gemini/models_test.go
+++ b/core/providers/gemini/models_test.go
@@ -39,3 +39,58 @@ func TestToGeminiListModelsResponse_UsesNativeModelResourceName(t *testing.T) {
 		assert.Equal(t, "models/gemini-2.5-flash", converted.Models[1].Name)
 	}
 }
+
+func TestNormalizeModelName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "strips google prefix for gemini model",
+			input: "google/gemini-2.5-pro",
+			want:  "gemini-2.5-pro",
+		},
+		{
+			name:  "strips google prefix for veo model",
+			input: "google/veo-3.0-generate-preview",
+			want:  "veo-3.0-generate-preview",
+		},
+		{
+			name:  "strips google prefix for imagen model",
+			input: "google/imagen-4.0-generate-001",
+			want:  "imagen-4.0-generate-001",
+		},
+		{
+			name:  "strips google prefix for gemma model",
+			input: "google/gemma-3-27b-it",
+			want:  "gemma-3-27b-it",
+		},
+		{
+			name:  "trims spaces before normalizing",
+			input: "  google/gemini-2.5-flash  ",
+			want:  "gemini-2.5-flash",
+		},
+		{
+			name:  "keeps unknown google model unchanged",
+			input: "google/custom-model",
+			want:  "google/custom-model",
+		},
+		{
+			name:  "keeps non google prefixed model unchanged",
+			input: "openai/gpt-4o",
+			want:  "openai/gpt-4o",
+		},
+		{
+			name:  "matches google prefix case-insensitively",
+			input: "Google/gemini-2.5-flash",
+			want:  "gemini-2.5-flash",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, NormalizeModelName(tc.input))
+		})
+	}
+}

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -76,6 +76,8 @@ func ToGeminiResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*Gem
 		return nil, nil
 	}
 
+	bifrostReq.Model = NormalizeModelName(bifrostReq.Model)
+
 	// Create the base Gemini generation request
 	geminiReq := &GeminiGenerationRequest{
 		Model: bifrostReq.Model,

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -2139,6 +2139,17 @@ func buildJSONSchemaFromMap(schemaMap map[string]interface{}) *schemas.Responses
 	return jsonSchema
 }
 
+func NormalizeModelName(model string) string {
+	model = strings.TrimSpace(model)
+	if len(model) >= len("google/") && strings.EqualFold(model[:len("google/")], "google/") {
+		strippedModel := model[len("google/"):]
+		if schemas.IsGeminiModel(strippedModel) || schemas.IsVeoModel(strippedModel) || schemas.IsImagenModel(strippedModel) || schemas.IsGemmaModel(strippedModel) {
+			return strippedModel
+		}
+	}
+	return model
+}
+
 // buildOpenAIResponseFormat builds OpenAI response_format for JSON types
 func buildOpenAIResponseFormat(responseJsonSchema interface{}, responseSchema *Schema) *schemas.ResponsesTextConfig {
 	name := "json_response"

--- a/core/providers/gemini/videos.go
+++ b/core/providers/gemini/videos.go
@@ -84,6 +84,8 @@ func ToGeminiVideoGenerationRequest(bifrostReq *schemas.BifrostVideoGenerationRe
 		return nil, fmt.Errorf("bifrost request or input is nil")
 	}
 
+	bifrostReq.Model = NormalizeModelName(bifrostReq.Model)
+
 	// Create the instance with prompt
 	instance := &GeminiVideoGenerationInstance{
 		Prompt: bifrostReq.Input.Prompt,
@@ -216,8 +218,10 @@ func ToGeminiVideoGenerationRequest(bifrostReq *schemas.BifrostVideoGenerationRe
 
 // ToBifrostVideoGenerationResponse converts Gemini operation response to Bifrost format
 func ToBifrostVideoGenerationResponse(operation *GenerateVideosOperation, model string) (*schemas.BifrostVideoGenerationResponse, *schemas.BifrostError) {
+	model = NormalizeModelName(model)
+
 	if operation == nil {
-		return nil, providerUtils.NewBifrostOperationError("operation is nil",  nil)
+		return nil, providerUtils.NewBifrostOperationError("operation is nil", nil)
 	}
 
 	response := &schemas.BifrostVideoGenerationResponse{

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
+	"github.com/maximhq/bifrost/core/providers/gemini"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -164,6 +165,7 @@ func getVertexEndpointURL(region string, apiVersion string, projectID string, en
 // for custom/fine-tuned models, it uses the projectNumber
 // for gemini models, it uses the projectID
 func getCompleteURLForGeminiEndpoint(deployment string, region string, projectID string, projectNumber string, method string) string {
+	deployment = gemini.NormalizeModelName(deployment)
 	if schemas.IsAllDigitsASCII(deployment) {
 		// Custom/fine-tuned models use projectNumber
 		return getVertexEndpointURL(region, "v1beta1", projectNumber, deployment, method)

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -410,7 +410,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 				if err != nil {
 					return nil, fmt.Errorf("failed to delete model field: %w", err)
 				}
-			} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+			} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
 				reqBody, err := gemini.ToGeminiChatCompletionRequest(request)
 				if err != nil {
 					return nil, err
@@ -498,12 +498,12 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 	} else if schemas.IsMistralModel(request.Model) {
 		// Mistral models use mistralai publisher with rawPredict
 		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "mistralai", request.Model, ":rawPredict")
-	} else if schemas.IsGeminiModel(request.Model) {
+	} else if schemas.IsGeminiModel(request.Model) || schemas.IsGemmaModel(request.Model) {
 		// Gemini models support api key
 		if key.Value.GetValue() != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
 		}
-		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", request.Model, ":generateContent")
+		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", gemini.NormalizeModelName(request.Model), ":generateContent")
 	} else {
 		completeURL = getVertexEndpointURL(region, "v1beta1", projectID, "openapi/chat/completions", "")
 	}
@@ -613,7 +613,7 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 		}
 
 		return response, nil
-	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
 		geminiResponse := gemini.GenerateContentResponse{}
 
 		rawRequest, rawResponse, bifrostErr := providerUtils.HandleProviderResponse(responseBody, &geminiResponse, jsonBody, providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest), providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse))
@@ -784,7 +784,7 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			provider.logger,
 			postHookSpanFinalizer,
 		)
-	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
 		// Use Gemini-style streaming for Gemini models
 		jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 			ctx,
@@ -1037,7 +1037,7 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 		}
 
 		return response, nil
-	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
 		jsonBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 			ctx,
 			request,
@@ -1241,7 +1241,7 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 			provider.logger,
 			postHookSpanFinalizer,
 		)
-	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
 		region := key.VertexKeyConfig.Region.GetValue()
 		if region == "" {
 			return nil, providerUtils.NewConfigurationError("region is not set in key config")
@@ -1734,12 +1734,12 @@ func (provider *VertexProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 		if value := key.Value.GetValue(); value != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(value))
 		}
-		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", request.Model, ":predict")
+		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", gemini.NormalizeModelName(request.Model), ":predict")
 	} else if schemas.IsGeminiModel(request.Model) {
 		if value := key.Value.GetValue(); value != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(value))
 		}
-		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", request.Model, ":generateContent")
+		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", gemini.NormalizeModelName(request.Model), ":generateContent")
 	}
 
 	// Create HTTP request for image generation
@@ -1945,11 +1945,11 @@ func (provider *VertexProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 		if projectNumber == "" {
 			return nil, providerUtils.NewConfigurationError("project number is not set for fine-tuned models")
 		}
-		completeURL = getVertexEndpointURL(region, "v1beta1", projectNumber, request.Model, ":generateContent")
+		completeURL = getVertexEndpointURL(region, "v1beta1", projectNumber, gemini.NormalizeModelName(request.Model), ":generateContent")
 	} else if schemas.IsImagenModel(request.Model) {
-		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", request.Model, ":predict")
+		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", gemini.NormalizeModelName(request.Model), ":predict")
 	} else if schemas.IsGeminiModel(request.Model) {
-		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", request.Model, ":generateContent")
+		completeURL = getVertexPublisherModelURL(region, "v1", projectID, "google", gemini.NormalizeModelName(request.Model), ":generateContent")
 	}
 
 	req := fasthttp.AcquireRequest()
@@ -2561,7 +2561,7 @@ func (provider *VertexProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 		effectiveRegion := getVertexEffectiveRegion(region, request.Model)
 		baseURL := getVertexModelAwareAPIBaseURL(region, "v1", request.Model)
 		completeURL = fmt.Sprintf("%s/projects/%s/locations/%s/publishers/%s/models/%s%s", baseURL, projectID, effectiveRegion, "anthropic", "count-tokens", ":rawPredict")
-	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+	} else if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) || schemas.IsGemmaModel(request.Model) {
 		if key.Value.GetValue() != "" {
 			authQuery = fmt.Sprintf("key=%s", url.QueryEscape(key.Value.GetValue()))
 		}

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -835,8 +835,8 @@ func DeepCopyChatTool(original ChatTool) ChatTool {
 
 		if original.Function.Parameters != nil {
 			copyParams := &ToolFunctionParameters{
-				Type:     original.Function.Parameters.Type,
-				keyOrder: original.Function.Parameters.keyOrder,
+				Type:                original.Function.Parameters.Type,
+				keyOrder:            original.Function.Parameters.keyOrder,
 				explicitEmptyObject: original.Function.Parameters.explicitEmptyObject,
 			}
 
@@ -1279,6 +1279,10 @@ func IsGeminiModel(model string) bool {
 
 func IsVeoModel(model string) bool {
 	return strings.Contains(model, "veo")
+}
+
+func IsGemmaModel(model string) bool {
+	return strings.Contains(model, "gemma")
 }
 
 // IsImagenModel checks if the model is an Imagen model.


### PR DESCRIPTION
## Summary

Model IDs passed to the Vertex provider sometimes include a `google/` prefix (e.g. `google/gemini-2.0-flash`), which is a common convention in provider-agnostic routing but is not accepted by Vertex AI's publisher/model URLs. This PR strips that prefix before any Vertex API call is made, preventing request failures caused by malformed model identifiers.

## Changes

- Introduced `normalizeVertexModel` in `utils.go` that trims whitespace and strips a leading `google/` prefix from model strings.
- Applied `normalizeVertexModel` at the entry point of every public Vertex provider method: `ChatCompletion`, `ChatCompletionStream`, `Responses`, `ResponsesStream`, `Embedding`, `Rerank`, `ImageGeneration`, `ImageEdit`, `VideoGeneration`, `CountTokens`, and the internal `getCompleteURLForGeminiEndpoint` URL builder.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a request to any Vertex-backed endpoint using a model ID with the `google/` prefix (e.g. `google/gemini-2.0-flash`) and confirm the request succeeds and is routed to the correct Vertex endpoint.

```sh
go test ./core/providers/vertex/...
```

Verify that requests using bare model IDs (e.g. `gemini-2.0-flash`) continue to work as before.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The normalization only trims a known, benign string prefix and whitespace from the model identifier.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable