### PR TITLE
test: add roundtrip test for input_audio_buffer.append audio serialization

### DIFF
--- a/core/providers/openai/realtime_test.go
+++ b/core/providers/openai/realtime_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
@@ -557,5 +558,51 @@ func TestToProviderRealtimeEventOmitsReadOnlySessionFieldsOnSessionUpdate(t *tes
 	}
 	if payload.Session["model"] != "gpt-realtime" {
 		t.Fatalf("session.model = %v, want gpt-realtime", payload.Session["model"])
+	}
+}
+
+func TestInputAudioBufferAppendRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	// Simulate raw audio bytes and base64-encode them as OpenAI expects.
+	rawAudio := []byte("fake-pcm-audio-data-bytes")
+	b64Audio := base64.StdEncoding.EncodeToString(rawAudio)
+
+	clientEvent := map[string]interface{}{
+		"type":  "input_audio_buffer.append",
+		"audio": b64Audio,
+	}
+	clientJSON, err := json.Marshal(clientEvent)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	// Step 1: Parse the client event (same path as wsrealtime.go).
+	bifrostEvent, err := schemas.ParseRealtimeEvent(clientJSON)
+	if err != nil {
+		t.Fatalf("ParseRealtimeEvent() error = %v", err)
+	}
+	if len(bifrostEvent.Audio) == 0 {
+		t.Fatal("bifrostEvent.Audio is empty after ParseRealtimeEvent")
+	}
+
+	// Step 2: Convert back to provider format.
+	provider := &OpenAIProvider{}
+	providerJSON, err := provider.ToProviderRealtimeEvent(bifrostEvent)
+	if err != nil {
+		t.Fatalf("ToProviderRealtimeEvent() error = %v", err)
+	}
+
+	// Step 3: Verify the output JSON contains the audio field with correct value.
+	var output map[string]interface{}
+	if err := json.Unmarshal(providerJSON, &output); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	audioStr, ok := output["audio"].(string)
+	if !ok {
+		t.Fatalf("audio field missing or not a string in output: %s", string(providerJSON))
+	}
+	if audioStr != b64Audio {
+		t.Fatalf("audio = %q, want %q", audioStr, b64Audio)
 	}
 }


### PR DESCRIPTION
## Summary

Adds a roundtrip test to verify that `input_audio_buffer.append` events are
correctly parsed from client JSON into the internal `BifrostRealtimeEvent`
representation and then re-serialized back to the OpenAI provider format with
the base64-encoded audio field intact.

## Changes

- Added `TestInputAudioBufferAppendRoundtrip` to `realtime_test.go` to cover the
  full path from raw client event JSON → `ParseRealtimeEvent` →
  `ToProviderRealtimeEvent` → output JSON, asserting that the `audio` field
  survives the roundtrip with the correct base64 value.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/... -run TestInputAudioBufferAppendRoundtrip -v
```

Expected output: the test passes, confirming that the base64 audio value in an
`input_audio_buffer.append` event is preserved end-to-end.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

test cases for PR #2979

## Security considerations

No security implications. The test uses synthetic fake PCM audio bytes and does
not involve real credentials or PII.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

