### PR TITLE
chore: adds ollama and vllm key configs in llmtests

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -27,77 +27,77 @@ const ProviderOpenAICustom = schemas.ModelProvider("openai-custom")
 
 // TestScenarios defines the comprehensive test scenarios
 type TestScenarios struct {
-	TextCompletion             bool
-	TextCompletionStream       bool
-	SimpleChat                 bool
-	CompletionStream           bool
-	MultiTurnConversation      bool
-	ToolCalls                  bool
-	ToolCallsStreaming         bool // Streaming tool calls functionality
-	MultipleToolCalls          bool
-	MultipleToolCallsStreaming bool // Streaming multiple tool calls (some providers only return 1 tool call in streaming)
-	End2EndToolCalling         bool
-	AutomaticFunctionCall      bool
-	ImageURL                   bool
-	ImageBase64                bool
-	MultipleImages             bool
-	FileBase64                 bool
-	FileURL                    bool
-	CompleteEnd2End            bool
-	SpeechSynthesis            bool // Text-to-speech functionality
-	SpeechSynthesisStream      bool // Streaming text-to-speech functionality
-	Transcription              bool // Speech-to-text functionality
-	TranscriptionStream        bool // Streaming speech-to-text functionality
-	Embedding                  bool // Embedding functionality
-	Reasoning                  bool // Reasoning/thinking functionality via Responses API
-	PromptCaching              bool // Prompt caching functionality
-	ListModels                 bool // List available models functionality
-	ImageGeneration            bool // Image generation functionality
-	ImageGenerationStream      bool // Streaming image generation functionality
-	ImageEdit                  bool // Image edit functionality
-	ImageEditStream            bool // Streaming image edit functionality
-	ImageVariation             bool // Image variation functionality
-	ImageVariationStream       bool // Streaming image variation functionality (if supported)
-	VideoGeneration            bool // Video generation functionality
-	VideoRetrieve              bool // Video retrieve functionality
-	VideoRemix                 bool // Video remix functionality (OpenAI only)
-	VideoDownload              bool // Video download functionality
-	VideoList                  bool // Video list functionality
-	VideoDelete                bool // Video delete functionality
-	BatchCreate                bool // Batch API create functionality
-	BatchList                  bool // Batch API list functionality
-	BatchRetrieve              bool // Batch API retrieve functionality
-	BatchCancel                bool // Batch API cancel functionality
-	BatchResults               bool // Batch API results functionality
-	FileUpload                 bool // File API upload functionality
-	FileList                   bool // File API list functionality
-	FileRetrieve               bool // File API retrieve functionality
-	FileDelete                 bool // File API delete functionality
-	FileContent                bool // File API content download functionality
-	FileBatchInput             bool // Whether batch create supports file-based input (InputFileID)
-	CountTokens                bool // Count tokens functionality
-	ChatAudio                  bool // Chat completion with audio input/output functionality
-	StructuredOutputs          bool // Structured outputs (JSON schema) functionality
-	WebSearchTool              bool // Web search tool functionality
-	ContainerCreate            bool // Container API create functionality
-	ContainerList              bool // Container API list functionality
-	ContainerRetrieve          bool // Container API retrieve functionality
-	ContainerDelete            bool // Container API delete functionality
-	ContainerFileCreate        bool // Container File API create functionality
-	ContainerFileList          bool // Container File API list functionality
-	ContainerFileRetrieve      bool // Container File API retrieve functionality
-	ContainerFileContent       bool // Container File API content functionality
-	ContainerFileDelete        bool // Container File API delete functionality
-	PassThroughExtraParams     bool // Pass through extra params functionality
-	Rerank                     bool // Rerank functionality
-	PassthroughAPI             bool // Raw HTTP passthrough API (Passthrough + PassthroughStream)
-	WebSocketResponses         bool // WebSocket Responses API mode
-	Realtime                   bool // Realtime API (bidirectional audio/text)
-	Compaction                 bool // Server-side compaction (context management)
-	InterleavedThinking        bool // Interleaved thinking between tool calls (beta)
-	FastMode                   bool // Fast mode for Opus 4.6 (beta: research preview)
-	EagerInputStreaming           bool // Fine-grained tool input streaming (Anthropic fine-grained-tool-streaming-2025-05-14)
-	ServerToolsViaOpenAIEndpoint  bool // Anthropic server-tool shapes in tools[] via /v1/chat/completions (web_search / web_fetch / code_execution)
+	TextCompletion               bool
+	TextCompletionStream         bool
+	SimpleChat                   bool
+	CompletionStream             bool
+	MultiTurnConversation        bool
+	ToolCalls                    bool
+	ToolCallsStreaming           bool // Streaming tool calls functionality
+	MultipleToolCalls            bool
+	MultipleToolCallsStreaming   bool // Streaming multiple tool calls (some providers only return 1 tool call in streaming)
+	End2EndToolCalling           bool
+	AutomaticFunctionCall        bool
+	ImageURL                     bool
+	ImageBase64                  bool
+	MultipleImages               bool
+	FileBase64                   bool
+	FileURL                      bool
+	CompleteEnd2End              bool
+	SpeechSynthesis              bool // Text-to-speech functionality
+	SpeechSynthesisStream        bool // Streaming text-to-speech functionality
+	Transcription                bool // Speech-to-text functionality
+	TranscriptionStream          bool // Streaming speech-to-text functionality
+	Embedding                    bool // Embedding functionality
+	Reasoning                    bool // Reasoning/thinking functionality via Responses API
+	PromptCaching                bool // Prompt caching functionality
+	ListModels                   bool // List available models functionality
+	ImageGeneration              bool // Image generation functionality
+	ImageGenerationStream        bool // Streaming image generation functionality
+	ImageEdit                    bool // Image edit functionality
+	ImageEditStream              bool // Streaming image edit functionality
+	ImageVariation               bool // Image variation functionality
+	ImageVariationStream         bool // Streaming image variation functionality (if supported)
+	VideoGeneration              bool // Video generation functionality
+	VideoRetrieve                bool // Video retrieve functionality
+	VideoRemix                   bool // Video remix functionality (OpenAI only)
+	VideoDownload                bool // Video download functionality
+	VideoList                    bool // Video list functionality
+	VideoDelete                  bool // Video delete functionality
+	BatchCreate                  bool // Batch API create functionality
+	BatchList                    bool // Batch API list functionality
+	BatchRetrieve                bool // Batch API retrieve functionality
+	BatchCancel                  bool // Batch API cancel functionality
+	BatchResults                 bool // Batch API results functionality
+	FileUpload                   bool // File API upload functionality
+	FileList                     bool // File API list functionality
+	FileRetrieve                 bool // File API retrieve functionality
+	FileDelete                   bool // File API delete functionality
+	FileContent                  bool // File API content download functionality
+	FileBatchInput               bool // Whether batch create supports file-based input (InputFileID)
+	CountTokens                  bool // Count tokens functionality
+	ChatAudio                    bool // Chat completion with audio input/output functionality
+	StructuredOutputs            bool // Structured outputs (JSON schema) functionality
+	WebSearchTool                bool // Web search tool functionality
+	ContainerCreate              bool // Container API create functionality
+	ContainerList                bool // Container API list functionality
+	ContainerRetrieve            bool // Container API retrieve functionality
+	ContainerDelete              bool // Container API delete functionality
+	ContainerFileCreate          bool // Container File API create functionality
+	ContainerFileList            bool // Container File API list functionality
+	ContainerFileRetrieve        bool // Container File API retrieve functionality
+	ContainerFileContent         bool // Container File API content functionality
+	ContainerFileDelete          bool // Container File API delete functionality
+	PassThroughExtraParams       bool // Pass through extra params functionality
+	Rerank                       bool // Rerank functionality
+	PassthroughAPI               bool // Raw HTTP passthrough API (Passthrough + PassthroughStream)
+	WebSocketResponses           bool // WebSocket Responses API mode
+	Realtime                     bool // Realtime API (bidirectional audio/text)
+	Compaction                   bool // Server-side compaction (context management)
+	InterleavedThinking          bool // Interleaved thinking between tool calls (beta)
+	FastMode                     bool // Fast mode for Opus 4.6 (beta: research preview)
+	EagerInputStreaming          bool // Fine-grained tool input streaming (Anthropic fine-grained-tool-streaming-2025-05-14)
+	ServerToolsViaOpenAIEndpoint bool // Anthropic server-tool shapes in tools[] via /v1/chat/completions (web_search / web_fetch / code_execution)
 }
 
 // ComprehensiveTestConfig extends TestConfig with additional scenarios
@@ -339,7 +339,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 			},
 		}, nil
 	case schemas.Vertex:
-		//https://aiplatform.googleapis.com/v1/projects/maxim-development-433105/locations/global/publishers/google/models/veo-3.1-generate-preview:fetchPredictOperation
+		// https://aiplatform.googleapis.com/v1/projects/maxim-development-433105/locations/global/publishers/google/models/veo-3.1-generate-preview:fetchPredictOperation
 
 		return []schemas.Key{
 			{
@@ -498,6 +498,28 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 				Models:         []string{},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
+			},
+		}, nil
+	case schemas.Ollama:
+		return []schemas.Key{
+			{
+				Models:         []string{"*"},
+				Weight:         1.0,
+				UseForBatchAPI: bifrost.Ptr(true),
+				OllamaKeyConfig: &schemas.OllamaKeyConfig{
+					URL: *schemas.NewEnvVar("env.OLLAMA_BASE_URL"),
+				},
+			},
+		}, nil
+	case schemas.VLLM:
+		return []schemas.Key{
+			{
+				Models:         []string{"*"},
+				Weight:         1.0,
+				UseForBatchAPI: bifrost.Ptr(true),
+				VLLMKeyConfig: &schemas.VLLMKeyConfig{
+					URL: *schemas.NewEnvVar("env.VLLM_BASE_URL"),
+				},
 			},
 		}, nil
 	default:
@@ -1494,7 +1516,8 @@ var AllProviderConfigs = []ComprehensiveTestConfig{
 			ImageGeneration:            true,
 			ImageGenerationStream:      false,
 		},
-	}, {
+	},
+	{
 		Provider:           schemas.VLLM,
 		ChatModel:          "Qwen/Qwen3-0.6B",
 		TextModel:          "Qwen/Qwen3-0.6B",

--- a/core/internal/llmtests/tests.go
+++ b/core/internal/llmtests/tests.go
@@ -131,7 +131,8 @@ func RunAllComprehensiveTests(t *testing.T, client *bifrost.Bifrost, ctx context
 
 	// Execute all test scenarios WITH raw request/response enabled
 	t.Run("WithRawRequestResponse", func(t *testing.T) {
-		rawCtx := context.WithValue(ctx, schemas.BifrostContextKeySendBackRawRequest, true)
+		rawCtx := context.WithValue(ctx, schemas.BifrostContextKeyAllowPerRequestRawOverride, true)
+		rawCtx = context.WithValue(rawCtx, schemas.BifrostContextKeySendBackRawRequest, true)
 		rawCtx = context.WithValue(rawCtx, schemas.BifrostContextKeySendBackRawResponse, true)
 		rawConfig := testConfig
 		rawConfig.ExpectRawRequestResponse = true


### PR DESCRIPTION
## Summary

Adds Ollama and VLLM key configuration support to the comprehensive test account setup and fixes the raw request/response context initialization in the test runner to also set the `BifrostContextKeyAllowPerRequestRawOverride` flag.

## Changes

- Added an `Ollama` case to `GetKeysForProvider` that returns a key config using `OllamaKeyConfig` with a base URL sourced from the `OLLAMA_BASE_URL` environment variable
- Added a `VLLM` case to `GetKeysForProvider` that returns a key config using `VLLMKeyConfig` with a base URL sourced from the `VLLM_BASE_URL` environment variable
- Added `context.WithValue` for `BifrostContextKeyAllowPerRequestRawOverride` before setting the raw request/response flags in `RunAllComprehensiveTests`, ensuring per-request raw overrides are permitted when testing raw request/response behavior
- Fixed alignment of `TestScenarios` struct fields and minor comment/formatting issues in the Vertex case and provider config list

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Set the `OLLAMA_BASE_URL` and `VLLM_BASE_URL` environment variables to running instances, then run the respective provider test suites:

```sh
export OLLAMA_BASE_URL=http://your-ollama-host:11434
export VLLM_BASE_URL=http://your-vllm-host:8000
go test ./core/internal/llmtests/... -run TestOllama -v
go test ./core/internal/llmtests/... -run TestVLLM -v
```

The Ollama and VLLM provider tests should now correctly resolve keys and the `WithRawRequestResponse` sub-test should pass without requiring manual override enablement.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The Ollama and VLLM base URLs are sourced from environment variables (`env.OLLAMA_BASE_URL` and `env.VLLM_BASE_URL`) and are not hardcoded, keeping endpoint configuration out of source code.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable