### PR TITLE
fix: hide delete option in log detail views when user lacks delete access

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -695,7 +695,7 @@ export default function LogsPage() {
 						log={selectedLog}
 						open={selectedLog !== null}
 						onOpenChange={(open) => !open && setUrlState({ selected_log: "" })}
-						handleDelete={handleDelete}
+						handleDelete={hasDeleteAccess ? handleDelete : undefined}
 						onNavigate={handleLogNavigate}
 						hasPrev={selectedLogIndex > 0 || (selectedLogIndex !== -1 && pagination.offset > 0)}
 						hasNext={selectedLogIndex !== -1 && (selectedLogIndex < logs.length - 1 || pagination.offset + pagination.limit < totalItems)}

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -296,7 +296,7 @@ const messageRoleLabel: Record<MessageRole, string> = {
   user: "User",
   assistant: "Assistant",
   reasoning: "Reasoning",
-  tool: "Tool",
+  tool: "Tool Result",
 };
 
 function RoutingDecisionLogs({ logs }: { logs: string }) {
@@ -337,7 +337,7 @@ function RoutingDecisionLogs({ logs }: { logs: string }) {
                     className={cn(
                       "inline-block w-24 shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold uppercase",
                       RoutingEngineUsedColors[
-                        scope as keyof typeof RoutingEngineUsedColors
+                      scope as keyof typeof RoutingEngineUsedColors
                       ] ?? "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
                     )}
                   >
@@ -464,9 +464,6 @@ export function LogDetailView({
   headerAction,
   onFilterByParentRequestId,
 }: LogDetailViewProps) {
-  const { copy: copyRequestId } = useCopyToClipboard({
-    successMessage: "Request ID copied",
-  });
   const { copy: copyBody } = useCopyToClipboard({
     successMessage: "Request body copied to clipboard",
     errorMessage: "Failed to copy request body",
@@ -533,7 +530,7 @@ export function LogDetailView({
           {headerAction}
           <span className="text-foreground font-medium">Request details</span>
         </div>
-        {handleDelete && onClose ? (
+        {onClose ? (
           <AlertDialog>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -563,8 +560,8 @@ export function LogDetailView({
                   <Download className="h-4 w-4" />
                   Export as JSON
                 </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <AlertDialogTrigger asChild>
+
+                {handleDelete ? <><DropdownMenuSeparator /><AlertDialogTrigger asChild>
                   <DropdownMenuItem
                     variant="destructive"
                     data-testid="logdetails-delete-item"
@@ -572,7 +569,8 @@ export function LogDetailView({
                     <Trash2 className="h-4 w-4" />
                     Delete log
                   </DropdownMenuItem>
-                </AlertDialogTrigger>
+                </AlertDialogTrigger> </> : null
+                }
               </DropdownMenuContent>
             </DropdownMenu>
             <AlertDialogContent>
@@ -592,7 +590,7 @@ export function LogDetailView({
                 <AlertDialogAction
                   data-testid="logdetails-delete-confirm-button"
                   onClick={() => {
-                    handleDelete(log);
+                    if (handleDelete) handleDelete(log);
                     onClose();
                   }}
                 >
@@ -2297,6 +2295,7 @@ const copyRequestBody = async (
   try {
     const isChat =
       log.object === "chat.completion" ||
+      log.object === "chat_completion" ||
       log.object === "chat.completion.chunk";
     const isResponses =
       log.object === "response" || log.object === "response.completion.chunk";

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -12,7 +12,7 @@ interface LogDetailSheetProps {
 	log: LogEntry | null;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	handleDelete: (log: LogEntry) => void;
+	handleDelete?: (log: LogEntry) => void;
 	onNavigate?: (direction: "prev" | "next") => void;
 	hasPrev?: boolean;
 	hasNext?: boolean;

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -439,7 +439,7 @@ export default function MCPLogsPage() {
 						log={selectedLog}
 						open={selectedLogId !== null}
 						onOpenChange={(open) => !open && setUrlState({ selected_log: "" }, { history: "replace" })}
-						handleDelete={handleDelete}
+						handleDelete={hasDeleteAccess ? handleDelete : undefined}
 						onNavigate={handleLogNavigate}
 						hasPrev={selectedLogIndex > 0 || (selectedLogIndex !== -1 && pagination.offset > 0)}
 						hasNext={selectedLogIndex !== -1 && (selectedLogIndex < logs.length - 1 || pagination.offset + pagination.limit < totalItems)}

--- a/ui/app/workspace/mcp-logs/views/columns.tsx
+++ b/ui/app/workspace/mcp-logs/views/columns.tsx
@@ -3,8 +3,8 @@ import { Button } from "@/components/ui/button";
 import { Status, StatusBarColors, Statuses } from "@/lib/constants/logs";
 import type { MCPToolLogEntry } from "@/lib/types/logs";
 import { ColumnDef } from "@tanstack/react-table";
-import { ArrowUpDown, Trash2 } from "lucide-react";
 import { format, isValid } from "date-fns";
+import { ArrowUpDown, Trash2 } from "lucide-react";
 
 // Helper function to validate status and return a safe Status value
 const getValidatedStatus = (status: string): Status => {
@@ -20,98 +20,99 @@ export const createMCPColumns = (
 	handleDelete: (log: MCPToolLogEntry) => Promise<void>,
 	hasDeleteAccess: boolean,
 ): ColumnDef<MCPToolLogEntry>[] => [
-	{
-		accessorKey: "status",
-		header: "",
-		size: 8,
-		maxSize: 8,
-		cell: ({ row }) => {
-			const status = getValidatedStatus(row.original.status);
-			return <div className={`h-full min-h-[24px] w-1 rounded-sm ${StatusBarColors[status]}`} />;
+		{
+			accessorKey: "status",
+			header: "",
+			size: 8,
+			maxSize: 8,
+			cell: ({ row }) => {
+				const status = getValidatedStatus(row.original.status);
+				return <div className={`h-full min-h-[24px] w-1 rounded-sm ${StatusBarColors[status]}`} />;
+			},
 		},
-	},
-	{
-		accessorKey: "timestamp",
-		header: ({ column }) => (
-			<Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-				Time
-				<ArrowUpDown className="ml-2 h-4 w-4" />
-			</Button>
-		),
-		size: 230,
-		cell: ({ row }) => {
-			const timestamp = row.original.timestamp;
-			const date = new Date(timestamp);
-			return <div className="truncate text-xs">{isValid(date) ? format(date, "yyyy-MM-dd hh:mm:ss aa (XXX)") : "Invalid date"}</div>;
-		},
-	},
-	{
-		accessorKey: "tool_name",
-		header: "Tool Name",
-		size: 300,
-		cell: ({ row }) => {
-			const toolName = row.getValue("tool_name") as string;
-			return <span className="block max-w-full truncate font-mono text-sm">{toolName}</span>;
-		},
-	},
-	{
-		accessorKey: "server_label",
-		header: "Server",
-		size: 150,
-		cell: ({ row }) => {
-			const serverLabel = row.getValue("server_label") as string;
-			return serverLabel ? (
-				<Badge variant="secondary" className="font-mono">
-					{serverLabel}
-				</Badge>
-			) : (
-				<span className="text-muted-foreground">-</span>
-			);
-		},
-	},
-	{
-		accessorKey: "latency",
-		header: ({ column }) => (
-			<Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-				Latency
-				<ArrowUpDown className="ml-2 h-4 w-4" />
-			</Button>
-		),
-		size: 120,
-		cell: ({ row }) => {
-			const latency = row.original.latency;
-			return (
-				<div className="pl-4 font-mono text-sm">{latency === undefined || latency === null ? "N/A" : `${latency.toLocaleString()}ms`}</div>
-			);
-		},
-	},
-	{
-		accessorKey: "cost",
-		header: "Cost",
-		size: 120,
-		cell: ({ row }) => {
-			const cost = row.original.cost;
-			const isValidNumber = typeof cost === "number" && Number.isFinite(cost);
-			return <div className="font-mono text-sm">{isValidNumber ? `${cost.toFixed(4)}` : "N/A"}</div>;
-		},
-	},
-	{
-		id: "actions",
-		size: 72,
-		cell: ({ row }) => {
-			const log = row.original;
-			return (
-				<Button
-					variant="outline"
-					size="icon"
-					className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30"
-					onClick={() => void handleDelete(log)}
-					disabled={!hasDeleteAccess}
-					aria-label="Delete log"
-				>
-					<Trash2 />
+		{
+			accessorKey: "timestamp",
+			header: ({ column }) => (
+				<Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+					Time
+					<ArrowUpDown className="ml-2 h-4 w-4" />
 				</Button>
-			);
+			),
+			size: 230,
+			cell: ({ row }) => {
+				const timestamp = row.original.timestamp;
+				const date = new Date(timestamp);
+				return <div className="truncate text-xs">{isValid(date) ? format(date, "yyyy-MM-dd hh:mm:ss aa (XXX)") : "Invalid date"}</div>;
+			},
 		},
-	},
-];
+		{
+			accessorKey: "tool_name",
+			header: "Tool Name",
+			size: 300,
+			cell: ({ row }) => {
+				const toolName = row.getValue("tool_name") as string;
+				return <span className="block max-w-full truncate font-mono text-sm">{toolName}</span>;
+			},
+		},
+		{
+			accessorKey: "server_label",
+			header: "Server",
+			size: 150,
+			cell: ({ row }) => {
+				const serverLabel = row.getValue("server_label") as string;
+				return serverLabel ? (
+					<Badge variant="secondary" className="font-mono">
+						{serverLabel}
+					</Badge>
+				) : (
+					<span className="text-muted-foreground">-</span>
+				);
+			},
+		},
+		{
+			accessorKey: "latency",
+			header: ({ column }) => (
+				<Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+					Latency
+					<ArrowUpDown className="ml-2 h-4 w-4" />
+				</Button>
+			),
+			size: 120,
+			cell: ({ row }) => {
+				const latency = row.original.latency;
+				return (
+					<div className="pl-4 font-mono text-sm">{latency === undefined || latency === null ? "N/A" : `${latency.toLocaleString()}ms`}</div>
+				);
+			},
+		},
+		{
+			accessorKey: "cost",
+			header: "Cost",
+			size: 120,
+			cell: ({ row }) => {
+				const cost = row.original.cost;
+				const isValidNumber = typeof cost === "number" && Number.isFinite(cost);
+				return <div className="font-mono text-sm">{isValidNumber ? `${cost.toFixed(4)}` : "N/A"}</div>;
+			},
+		},
+		{
+			id: "actions",
+			size: 72,
+			cell: ({ row }) => {
+				const log = row.original;
+				return (
+					<Button
+						variant="outline"
+						size="icon"
+						data-testid="log-delete-btn"
+						aria-label="Delete log"
+						className="text-secondary-foreground/30 hover:bg-destructive/10 hover:text-destructive border-destructive/10"
+						onClick={() => void handleDelete(log)}
+						disabled={!hasDeleteAccess}
+					>
+						<Trash2 />
+					</Button>
+				);
+			},
+		},
+	];

--- a/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
@@ -15,11 +15,11 @@ import { CodeEditor } from "@/components/ui/codeEditor";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { downloadAsJson } from "@/lib/utils/browser-download";
 import { Status, StatusColors, Statuses } from "@/lib/constants/logs";
 import type { MCPToolLogEntry } from "@/lib/types/logs";
-import { ChevronDown, ChevronUp, Download, MoreVertical, Trash2 } from "lucide-react";
+import { downloadAsJson } from "@/lib/utils/browser-download";
 import { addMilliseconds, format, isValid } from "date-fns";
+import { ChevronDown, ChevronUp, Download, MoreVertical, Trash2 } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { toast } from "sonner";
@@ -28,7 +28,7 @@ interface MCPLogDetailSheetProps {
 	log: MCPToolLogEntry | null;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	handleDelete: (log: MCPToolLogEntry) => Promise<void>;
+	handleDelete?: (log: MCPToolLogEntry) => Promise<void>;
 	onNavigate?: (direction: "prev" | "next") => void;
 	hasPrev?: boolean;
 	hasNext?: boolean;
@@ -128,13 +128,15 @@ export function MCPLogDetailSheet({
 									<Download className="h-4 w-4" />
 									Export as JSON
 								</DropdownMenuItem>
-								<DropdownMenuSeparator />
-								<AlertDialogTrigger asChild>
-									<DropdownMenuItem variant="destructive">
-										<Trash2 className="h-4 w-4" />
-										Delete log
-									</DropdownMenuItem>
-								</AlertDialogTrigger>
+								{handleDelete ? <>
+									<DropdownMenuSeparator />
+									<AlertDialogTrigger asChild>
+										<DropdownMenuItem variant="destructive">
+											<Trash2 className="h-4 w-4" />
+											Delete log
+										</DropdownMenuItem>
+									</AlertDialogTrigger>
+								</> : null}
 							</DropdownMenuContent>
 						</DropdownMenu>
 						<AlertDialogContent>
@@ -147,6 +149,7 @@ export function MCPLogDetailSheet({
 								<AlertDialogAction
 									onClick={async (e) => {
 										e.preventDefault();
+										if (!handleDelete) return;
 										try {
 											await handleDelete(log);
 											setDeleteDialogOpen(false);


### PR DESCRIPTION
## Summary

The delete log button in the log detail view and MCP log detail sheet is now conditionally rendered based on whether the current user has delete access. Previously, the delete option was always shown in the dropdown menu regardless of permissions. This change hides the "Delete log" menu item entirely when the user lacks delete access, rather than relying solely on a disabled button state.

## Changes

- `handleDelete` prop is now optional (`handleDelete?`) in `LogDetailSheetProps` and `MCPLogDetailSheetProps`, allowing it to be passed as `undefined` when the user lacks delete access
- In `logs/page.tsx` and `mcp-logs/page.tsx`, `handleDelete` is passed as `undefined` when `hasDeleteAccess` is false, otherwise the handler is passed normally
- The "Delete log" dropdown menu item and its separator are conditionally rendered only when `handleDelete` is defined, hiding the option entirely for users without delete access
- The dropdown menu itself remains visible (for export/other actions) regardless of delete access
- The `tool` message role label was renamed from `"Tool"` to `"Tool Result"` for clarity
- `copyRequestId` clipboard hook was removed as it was unused
- `copyRequestBody` now also handles the `"chat_completion"` object type when determining request format
- Various indentation and formatting fixes throughout `logDetailView.tsx`
- The MCP log table delete button styling was updated to use more subtle default colors (`text-secondary-foreground/30`, `border-destructive/10`) that become destructive-colored on hover, and a `data-testid` attribute was added

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Log in as a user **without** delete access to logs.
2. Open a log detail sheet from the Logs or MCP Logs page.
3. Open the dropdown menu (⋮) — confirm the "Delete log" option and its separator are **not** present.
4. Log in as a user **with** delete access.
5. Open a log detail sheet and open the dropdown menu — confirm the "Delete log" option **is** present and functional.
6. Confirm the "Export as JSON" option is available in both cases.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

Before: The "Delete log" menu item was always visible in the dropdown, regardless of user permissions.

After: The "Delete log" menu item and its separator are hidden entirely when the user does not have delete access.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

This change improves UI-level access control by not exposing the delete action to users who lack the necessary permissions. Server-side authorization should still enforce delete restrictions independently.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable