### PR TITLE
refactor: replace `Select` with `ComboboxSelect` in pricing overrides and virtual keys filters

### DIFF
--- a/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { CodeEditor } from "@/components/ui/codeEditor";
+import { ComboboxSelect } from "@/components/ui/combobox";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -814,33 +815,23 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 														<FormLabel>
 															Virtual key <span className="text-red-500">*</span>
 														</FormLabel>
-														<Select
-															value={field.value || "__none__"}
-															onValueChange={(value) => {
-																field.onChange(value === "__none__" ? "" : value);
-																setValue("providerID", "");
-																setValue("providerKeyID", "");
-																clearErrors("virtualKeyID");
-															}}
-														>
-															<FormControl>
-																<SelectTrigger
-																	data-testid="pricing-override-virtual-key-select"
-																	className="w-full"
-																	disabled={isVirtualKeysLoading || !!virtualKeysError}
-																>
-																	<SelectValue placeholder={isVirtualKeysLoading ? "Loading..." : "Select virtual key"} />
-																</SelectTrigger>
-															</FormControl>
-															<SelectContent>
-																<SelectItem value="__none__">Select virtual key</SelectItem>
-																{virtualKeys.map((vk) => (
-																	<SelectItem key={vk.id} value={vk.id}>
-																		{vk.name}
-																	</SelectItem>
-																))}
-															</SelectContent>
-														</Select>
+														<FormControl>
+															<ComboboxSelect
+																data-testid="pricing-override-virtual-key-select"
+																options={virtualKeys.map((vk) => ({ label: vk.name, value: vk.id }))}
+																value={field.value || null}
+																onValueChange={(value) => {
+																	field.onChange(value ?? "");
+																	setValue("providerID", "");
+																	setValue("providerKeyID", "");
+																	clearErrors("virtualKeyID");
+																}}
+																placeholder={isVirtualKeysLoading ? "Loading..." : "Select virtual key"}
+																disabled={isVirtualKeysLoading || !!virtualKeysError}
+																noPortal
+																className="h-9"
+															/>
+														</FormControl>
 														{virtualKeysError ? (
 															<p className="text-destructive mt-1 text-xs">
 																Failed to load virtual keys: {getErrorMessage(virtualKeysError)}
@@ -911,27 +902,17 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 													render={({ field }) => (
 														<FormItem>
 															<FormLabel>Provider key</FormLabel>
-															<Select
-																value={field.value || "__none__"}
-																onValueChange={(value) => field.onChange(value === "__none__" ? "" : value)}
-															>
-																<FormControl>
-																	<SelectTrigger
-																		data-testid="pricing-override-provider-key-select"
-																		className="w-full"
-																	>
-																		<SelectValue placeholder="All provider keys" />
-																	</SelectTrigger>
-																</FormControl>
-																<SelectContent>
-																	<SelectItem value="__none__">All provider keys</SelectItem>
-																	{providerScopedKeyOptions.map((option) => (
-																		<SelectItem key={option.id} value={option.id}>
-																			{option.label}
-																		</SelectItem>
-																	))}
-																</SelectContent>
-															</Select>
+															<FormControl>
+																<ComboboxSelect
+																	data-testid="pricing-override-provider-key-select"
+																	options={providerScopedKeyOptions.map((option) => ({ label: option.label, value: option.id }))}
+																	value={field.value || null}
+																	onValueChange={(value) => field.onChange(value ?? "")}
+																	placeholder="All provider keys"
+																	noPortal
+																	className="h-9"
+																/>
+															</FormControl>
 														</FormItem>
 													)}
 												/>

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -695,7 +695,7 @@ export default function LogsPage() {
 						log={selectedLog}
 						open={selectedLog !== null}
 						onOpenChange={(open) => !open && setUrlState({ selected_log: "" })}
-						handleDelete={handleDelete}
+						handleDelete={hasDeleteAccess ? handleDelete : undefined}
 						onNavigate={handleLogNavigate}
 						hasPrev={selectedLogIndex > 0 || (selectedLogIndex !== -1 && pagination.offset > 0)}
 						hasNext={selectedLogIndex !== -1 && (selectedLogIndex < logs.length - 1 || pagination.offset + pagination.limit < totalItems)}

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -296,7 +296,7 @@ const messageRoleLabel: Record<MessageRole, string> = {
   user: "User",
   assistant: "Assistant",
   reasoning: "Reasoning",
-  tool: "Tool",
+  tool: "Tool Result",
 };
 
 function RoutingDecisionLogs({ logs }: { logs: string }) {
@@ -337,7 +337,7 @@ function RoutingDecisionLogs({ logs }: { logs: string }) {
                     className={cn(
                       "inline-block w-24 shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold uppercase",
                       RoutingEngineUsedColors[
-                        scope as keyof typeof RoutingEngineUsedColors
+                      scope as keyof typeof RoutingEngineUsedColors
                       ] ?? "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
                     )}
                   >
@@ -464,9 +464,6 @@ export function LogDetailView({
   headerAction,
   onFilterByParentRequestId,
 }: LogDetailViewProps) {
-  const { copy: copyRequestId } = useCopyToClipboard({
-    successMessage: "Request ID copied",
-  });
   const { copy: copyBody } = useCopyToClipboard({
     successMessage: "Request body copied to clipboard",
     errorMessage: "Failed to copy request body",
@@ -533,7 +530,7 @@ export function LogDetailView({
           {headerAction}
           <span className="text-foreground font-medium">Request details</span>
         </div>
-        {handleDelete && onClose ? (
+        {onClose ? (
           <AlertDialog>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -563,8 +560,8 @@ export function LogDetailView({
                   <Download className="h-4 w-4" />
                   Export as JSON
                 </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <AlertDialogTrigger asChild>
+
+                {handleDelete ? <><DropdownMenuSeparator /><AlertDialogTrigger asChild>
                   <DropdownMenuItem
                     variant="destructive"
                     data-testid="logdetails-delete-item"
@@ -572,7 +569,8 @@ export function LogDetailView({
                     <Trash2 className="h-4 w-4" />
                     Delete log
                   </DropdownMenuItem>
-                </AlertDialogTrigger>
+                </AlertDialogTrigger> </> : null
+                }
               </DropdownMenuContent>
             </DropdownMenu>
             <AlertDialogContent>
@@ -592,7 +590,7 @@ export function LogDetailView({
                 <AlertDialogAction
                   data-testid="logdetails-delete-confirm-button"
                   onClick={() => {
-                    handleDelete(log);
+                    if (handleDelete) handleDelete(log);
                     onClose();
                   }}
                 >
@@ -2297,6 +2295,7 @@ const copyRequestBody = async (
   try {
     const isChat =
       log.object === "chat.completion" ||
+      log.object === "chat_completion" ||
       log.object === "chat.completion.chunk";
     const isResponses =
       log.object === "response" || log.object === "response.completion.chunk";

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -12,7 +12,7 @@ interface LogDetailSheetProps {
 	log: LogEntry | null;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	handleDelete: (log: LogEntry) => void;
+	handleDelete?: (log: LogEntry) => void;
 	onNavigate?: (direction: "prev" | "next") => void;
 	hasPrev?: boolean;
 	hasNext?: boolean;

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -439,7 +439,7 @@ export default function MCPLogsPage() {
 						log={selectedLog}
 						open={selectedLogId !== null}
 						onOpenChange={(open) => !open && setUrlState({ selected_log: "" }, { history: "replace" })}
-						handleDelete={handleDelete}
+						handleDelete={hasDeleteAccess ? handleDelete : undefined}
 						onNavigate={handleLogNavigate}
 						hasPrev={selectedLogIndex > 0 || (selectedLogIndex !== -1 && pagination.offset > 0)}
 						hasNext={selectedLogIndex !== -1 && (selectedLogIndex < logs.length - 1 || pagination.offset + pagination.limit < totalItems)}

--- a/ui/app/workspace/mcp-logs/views/columns.tsx
+++ b/ui/app/workspace/mcp-logs/views/columns.tsx
@@ -3,8 +3,8 @@ import { Button } from "@/components/ui/button";
 import { Status, StatusBarColors, Statuses } from "@/lib/constants/logs";
 import type { MCPToolLogEntry } from "@/lib/types/logs";
 import { ColumnDef } from "@tanstack/react-table";
-import { ArrowUpDown, Trash2 } from "lucide-react";
 import { format, isValid } from "date-fns";
+import { ArrowUpDown, Trash2 } from "lucide-react";
 
 // Helper function to validate status and return a safe Status value
 const getValidatedStatus = (status: string): Status => {
@@ -20,98 +20,99 @@ export const createMCPColumns = (
 	handleDelete: (log: MCPToolLogEntry) => Promise<void>,
 	hasDeleteAccess: boolean,
 ): ColumnDef<MCPToolLogEntry>[] => [
-	{
-		accessorKey: "status",
-		header: "",
-		size: 8,
-		maxSize: 8,
-		cell: ({ row }) => {
-			const status = getValidatedStatus(row.original.status);
-			return <div className={`h-full min-h-[24px] w-1 rounded-sm ${StatusBarColors[status]}`} />;
+		{
+			accessorKey: "status",
+			header: "",
+			size: 8,
+			maxSize: 8,
+			cell: ({ row }) => {
+				const status = getValidatedStatus(row.original.status);
+				return <div className={`h-full min-h-[24px] w-1 rounded-sm ${StatusBarColors[status]}`} />;
+			},
 		},
-	},
-	{
-		accessorKey: "timestamp",
-		header: ({ column }) => (
-			<Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-				Time
-				<ArrowUpDown className="ml-2 h-4 w-4" />
-			</Button>
-		),
-		size: 230,
-		cell: ({ row }) => {
-			const timestamp = row.original.timestamp;
-			const date = new Date(timestamp);
-			return <div className="truncate text-xs">{isValid(date) ? format(date, "yyyy-MM-dd hh:mm:ss aa (XXX)") : "Invalid date"}</div>;
-		},
-	},
-	{
-		accessorKey: "tool_name",
-		header: "Tool Name",
-		size: 300,
-		cell: ({ row }) => {
-			const toolName = row.getValue("tool_name") as string;
-			return <span className="block max-w-full truncate font-mono text-sm">{toolName}</span>;
-		},
-	},
-	{
-		accessorKey: "server_label",
-		header: "Server",
-		size: 150,
-		cell: ({ row }) => {
-			const serverLabel = row.getValue("server_label") as string;
-			return serverLabel ? (
-				<Badge variant="secondary" className="font-mono">
-					{serverLabel}
-				</Badge>
-			) : (
-				<span className="text-muted-foreground">-</span>
-			);
-		},
-	},
-	{
-		accessorKey: "latency",
-		header: ({ column }) => (
-			<Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
-				Latency
-				<ArrowUpDown className="ml-2 h-4 w-4" />
-			</Button>
-		),
-		size: 120,
-		cell: ({ row }) => {
-			const latency = row.original.latency;
-			return (
-				<div className="pl-4 font-mono text-sm">{latency === undefined || latency === null ? "N/A" : `${latency.toLocaleString()}ms`}</div>
-			);
-		},
-	},
-	{
-		accessorKey: "cost",
-		header: "Cost",
-		size: 120,
-		cell: ({ row }) => {
-			const cost = row.original.cost;
-			const isValidNumber = typeof cost === "number" && Number.isFinite(cost);
-			return <div className="font-mono text-sm">{isValidNumber ? `${cost.toFixed(4)}` : "N/A"}</div>;
-		},
-	},
-	{
-		id: "actions",
-		size: 72,
-		cell: ({ row }) => {
-			const log = row.original;
-			return (
-				<Button
-					variant="outline"
-					size="icon"
-					className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30"
-					onClick={() => void handleDelete(log)}
-					disabled={!hasDeleteAccess}
-					aria-label="Delete log"
-				>
-					<Trash2 />
+		{
+			accessorKey: "timestamp",
+			header: ({ column }) => (
+				<Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+					Time
+					<ArrowUpDown className="ml-2 h-4 w-4" />
 				</Button>
-			);
+			),
+			size: 230,
+			cell: ({ row }) => {
+				const timestamp = row.original.timestamp;
+				const date = new Date(timestamp);
+				return <div className="truncate text-xs">{isValid(date) ? format(date, "yyyy-MM-dd hh:mm:ss aa (XXX)") : "Invalid date"}</div>;
+			},
 		},
-	},
-];
+		{
+			accessorKey: "tool_name",
+			header: "Tool Name",
+			size: 300,
+			cell: ({ row }) => {
+				const toolName = row.getValue("tool_name") as string;
+				return <span className="block max-w-full truncate font-mono text-sm">{toolName}</span>;
+			},
+		},
+		{
+			accessorKey: "server_label",
+			header: "Server",
+			size: 150,
+			cell: ({ row }) => {
+				const serverLabel = row.getValue("server_label") as string;
+				return serverLabel ? (
+					<Badge variant="secondary" className="font-mono">
+						{serverLabel}
+					</Badge>
+				) : (
+					<span className="text-muted-foreground">-</span>
+				);
+			},
+		},
+		{
+			accessorKey: "latency",
+			header: ({ column }) => (
+				<Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
+					Latency
+					<ArrowUpDown className="ml-2 h-4 w-4" />
+				</Button>
+			),
+			size: 120,
+			cell: ({ row }) => {
+				const latency = row.original.latency;
+				return (
+					<div className="pl-4 font-mono text-sm">{latency === undefined || latency === null ? "N/A" : `${latency.toLocaleString()}ms`}</div>
+				);
+			},
+		},
+		{
+			accessorKey: "cost",
+			header: "Cost",
+			size: 120,
+			cell: ({ row }) => {
+				const cost = row.original.cost;
+				const isValidNumber = typeof cost === "number" && Number.isFinite(cost);
+				return <div className="font-mono text-sm">{isValidNumber ? `${cost.toFixed(4)}` : "N/A"}</div>;
+			},
+		},
+		{
+			id: "actions",
+			size: 72,
+			cell: ({ row }) => {
+				const log = row.original;
+				return (
+					<Button
+						variant="outline"
+						size="icon"
+						data-testid="log-delete-btn"
+						aria-label="Delete log"
+						className="text-secondary-foreground/30 hover:bg-destructive/10 hover:text-destructive border-destructive/10"
+						onClick={() => void handleDelete(log)}
+						disabled={!hasDeleteAccess}
+					>
+						<Trash2 />
+					</Button>
+				);
+			},
+		},
+	];

--- a/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
@@ -15,11 +15,11 @@ import { CodeEditor } from "@/components/ui/codeEditor";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { downloadAsJson } from "@/lib/utils/browser-download";
 import { Status, StatusColors, Statuses } from "@/lib/constants/logs";
 import type { MCPToolLogEntry } from "@/lib/types/logs";
-import { ChevronDown, ChevronUp, Download, MoreVertical, Trash2 } from "lucide-react";
+import { downloadAsJson } from "@/lib/utils/browser-download";
 import { addMilliseconds, format, isValid } from "date-fns";
+import { ChevronDown, ChevronUp, Download, MoreVertical, Trash2 } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { toast } from "sonner";
@@ -28,7 +28,7 @@ interface MCPLogDetailSheetProps {
 	log: MCPToolLogEntry | null;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
-	handleDelete: (log: MCPToolLogEntry) => Promise<void>;
+	handleDelete?: (log: MCPToolLogEntry) => Promise<void>;
 	onNavigate?: (direction: "prev" | "next") => void;
 	hasPrev?: boolean;
 	hasNext?: boolean;
@@ -128,13 +128,15 @@ export function MCPLogDetailSheet({
 									<Download className="h-4 w-4" />
 									Export as JSON
 								</DropdownMenuItem>
-								<DropdownMenuSeparator />
-								<AlertDialogTrigger asChild>
-									<DropdownMenuItem variant="destructive">
-										<Trash2 className="h-4 w-4" />
-										Delete log
-									</DropdownMenuItem>
-								</AlertDialogTrigger>
+								{handleDelete ? <>
+									<DropdownMenuSeparator />
+									<AlertDialogTrigger asChild>
+										<DropdownMenuItem variant="destructive">
+											<Trash2 className="h-4 w-4" />
+											Delete log
+										</DropdownMenuItem>
+									</AlertDialogTrigger>
+								</> : null}
 							</DropdownMenuContent>
 						</DropdownMenu>
 						<AlertDialogContent>
@@ -147,6 +149,7 @@ export function MCPLogDetailSheet({
 								<AlertDialogAction
 									onClick={async (e) => {
 										e.preventDefault();
+										if (!handleDelete) return;
 										try {
 											await handleDelete(log);
 											setDeleteDialogOpen(false);

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -520,9 +520,9 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 													onBlur={() => {
 														const parsed = allowedExtraHeadersRaw.trim()
 															? allowedExtraHeadersRaw
-																	.split(",")
-																	.map((h) => h.trim())
-																	.filter(Boolean)
+																.split(",")
+																.map((h) => h.trim())
+																.filter(Boolean)
 															: [];
 														field.onChange(parsed);
 														field.onBlur();
@@ -858,11 +858,11 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 															Add Virtual Key
 														</Button>
 													</PopoverTrigger>
-													<PopoverContent side="top" align="end" className="w-56 p-0">
+													<PopoverContent side="top" align="end" className="w-56 p-0" noPortal>
 														<div className="pb-1">
 															<Input
 																data-testid="mcpclient-virtualkey-search-input"
-																placeholder="Search virtual keys..."
+																placeholder="Start typing to search…"
 																value={vkSearch}
 																onChange={(e) => setVKSearch(e.target.value)}
 																onKeyDown={(e) => {

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -12,10 +12,10 @@ import {
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ComboboxSelect } from "@/components/ui/combobox";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
@@ -543,33 +543,23 @@ export default function VirtualKeysTable({
 							data-testid="vk-search-input"
 						/>
 					</div>
-					<Select value={customerFilter} onValueChange={(val) => onCustomerFilterChange(val === "all" ? "" : val)}>
-						<SelectTrigger className="w-[180px]" data-testid="vk-customer-filter">
-							<SelectValue placeholder="All Customers" />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem value="all">All Customers</SelectItem>
-							{customers.map((c) => (
-								<SelectItem key={c.id} value={c.id}>
-									{c.name}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
+					<ComboboxSelect
+						data-testid="vk-customer-filter"
+						options={customers.map((c) => ({ label: c.name, value: c.id }))}
+						value={customerFilter || null}
+						onValueChange={(val) => onCustomerFilterChange(val ?? "")}
+						placeholder="All Customers"
+						className="w-[180px] h-9"
+					/>
 					{customerFilter && teamFilter && <span className="text-muted-foreground text-xs font-medium">or</span>}
-					<Select value={teamFilter} onValueChange={(val) => onTeamFilterChange(val === "all" ? "" : val)}>
-						<SelectTrigger className="w-[180px]" data-testid="vk-team-filter">
-							<SelectValue placeholder="All Teams" />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem value="all">All Teams</SelectItem>
-							{teams.map((t) => (
-								<SelectItem key={t.id} value={t.id}>
-									{t.name}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
+					<ComboboxSelect
+						data-testid="vk-team-filter"
+						options={teams.map((t) => ({ label: t.name, value: t.id }))}
+						value={teamFilter || null}
+						onValueChange={(val) => onTeamFilterChange(val ?? "")}
+						placeholder="All Teams"
+						className="w-[180px] h-9"
+					/>
 				</div>
 
 				<div className="rounded-sm border">


### PR DESCRIPTION
## Summary

Replaces `Select` dropdown components with `ComboboxSelect` in the virtual key filter, pricing override sheet, and MCP client sheet to provide searchable/filterable dropdowns instead of plain selects.

## Changes

- Replaced the Virtual Key and Provider Key `Select` dropdowns in `pricingOverrideSheet.tsx` with `ComboboxSelect`, enabling search and using `noPortal` to avoid z-index/overflow issues inside the sheet.
- Replaced the Customer and Team filter `Select` dropdowns in `virtualKeysTable.tsx` with `ComboboxSelect` for consistent searchable filtering.
- Added `noPortal` to the virtual key `PopoverContent` in `mcpClientSheet.tsx` to fix portal-related rendering issues, and updated the search placeholder text to "Start typing to search…".
- Fixed indentation of a chained method call in `mcpClientSheet.tsx`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Virtual Keys page and verify the Customer and Team filters are searchable comboboxes that correctly filter the table.
2. Open the Custom Pricing overrides sheet and verify the Virtual Key and Provider Key dropdowns are searchable and function correctly (selecting a virtual key clears provider fields).
3. Open the MCP Client sheet and verify the "Add Virtual Key" popover renders correctly within the sheet without overflow or z-index issues.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable