### PR TITLE
feat: adds finish reasons to root spans and fixes model and provider name in root spans in OTEL

### DIFF
--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -232,6 +232,7 @@ const (
 	AttrResponseID       = "gen_ai.response.id"
 	AttrResponseModel    = "gen_ai.response.model"
 	AttrFinishReason     = "gen_ai.response.finish_reason"
+	AttrFinishReasons    = "gen_ai.response.finish_reasons"
 	AttrSystemFprint     = "gen_ai.response.system_fingerprint"
 	AttrServiceTier      = "gen_ai.response.service_tier"
 	AttrCreated          = "gen_ai.response.created"

--- a/framework/tracing/llmspan.go
+++ b/framework/tracing/llmspan.go
@@ -236,9 +236,15 @@ func PopulateChatResponseAttributes(resp *schemas.BifrostChatResponse, attrs map
 		}
 	}
 
-	// Extract finish reason from first choice
-	if len(resp.Choices) > 0 && resp.Choices[0].FinishReason != nil {
-		attrs[schemas.AttrFinishReason] = *resp.Choices[0].FinishReason
+	// Extract finish reasons from all choices
+	var finishReasons []string
+	for _, choice := range resp.Choices {
+		if choice.FinishReason != nil {
+			finishReasons = append(finishReasons, *choice.FinishReason)
+		}
+	}
+	if len(finishReasons) > 0 {
+		attrs[schemas.AttrFinishReasons] = finishReasons
 	}
 
 	// Usage
@@ -378,15 +384,22 @@ func PopulateTextCompletionResponseAttributes(resp *schemas.BifrostTextCompletio
 		attrs[schemas.AttrSystemFprint] = resp.SystemFingerprint
 	}
 
-	// Extract output text
+	// Extract output text and finish reasons from all choices
 	var outputs []string
+	var finishReasons []string
 	for _, choice := range resp.Choices {
 		if choice.TextCompletionResponseChoice != nil && choice.TextCompletionResponseChoice.Text != nil {
 			outputs = append(outputs, *choice.TextCompletionResponseChoice.Text)
 		}
+		if choice.FinishReason != nil {
+			finishReasons = append(finishReasons, *choice.FinishReason)
+		}
 	}
 	if len(outputs) > 0 {
 		attrs[schemas.AttrOutputMessages] = outputs
+	}
+	if len(finishReasons) > 0 {
+		attrs[schemas.AttrFinishReasons] = finishReasons
 	}
 
 	// Usage

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -179,11 +179,32 @@ func (t *Tracer) PopulateLLMRequestAttributes(handle schemas.SpanHandle, req *sc
 		span.SetAttribute(k, v)
 	}
 
-	// Propagate input messages to root span so observability backends (e.g. Langfuse)
-	// can display Input at the top-level trace without requiring users to drill into llm.call.
+	// Propagate input messages and request model to root span so observability backends (e.g. Langfuse)
+	// can display Input and model name at the top-level trace without requiring users to drill into llm.call.
 	if rootSpan := trace.RootSpan; rootSpan != nil && rootSpan.SpanID != span.SpanID {
-		if v, ok := attrs[schemas.AttrInputMessages]; ok {
+		var inputText string
+		switch req.RequestType {
+		case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
+			if req.ChatRequest != nil && len(req.ChatRequest.Input) > 0 {
+				last := req.ChatRequest.Input[len(req.ChatRequest.Input)-1]
+				inputText = extractMessageContent(last.Content)
+			}
+		case schemas.ResponsesRequest, schemas.ResponsesStreamRequest:
+			if req.ResponsesRequest != nil && len(req.ResponsesRequest.Input) > 0 {
+				last := req.ResponsesRequest.Input[len(req.ResponsesRequest.Input)-1]
+				inputText = extractResponsesMessageTextContent(&last)
+			}
+		}
+		if inputText != "" {
+			rootSpan.SetAttribute(schemas.AttrInputMessages, inputText)
+		} else if v, ok := attrs[schemas.AttrInputMessages]; ok {
 			rootSpan.SetAttribute(schemas.AttrInputMessages, v)
+		}
+		if v, ok := attrs[schemas.AttrRequestModel]; ok {
+			rootSpan.SetAttribute(schemas.AttrRequestModel, v)
+		}
+		if v, ok := attrs[schemas.AttrProviderName]; ok {
+			rootSpan.SetAttribute(schemas.AttrProviderName, v)
 		}
 	}
 }
@@ -204,6 +225,13 @@ func (t *Tracer) PopulateLLMResponseAttributes(ctx *schemas.BifrostContext, hand
 	}
 	respAttrs := PopulateResponseAttributes(resp)
 	for k, v := range respAttrs {
+		if k == schemas.AttrFinishReasons {
+			// llm.call span gets the singular finish_reason (first element only)
+			if reasons, ok := v.([]string); ok && len(reasons) > 0 {
+				span.SetAttribute(schemas.AttrFinishReason, reasons[0])
+			}
+			continue
+		}
 		span.SetAttribute(k, v)
 	}
 	for k, v := range PopulateErrorAttributes(err) {
@@ -215,11 +243,35 @@ func (t *Tracer) PopulateLLMResponseAttributes(ctx *schemas.BifrostContext, hand
 		span.SetAttribute(schemas.AttrUsageCost, cost)
 	}
 
-	// Propagate output messages to root span so observability backends (e.g. Langfuse)
-	// can display Output at the top-level trace without requiring users to drill into llm.call.
+	// Propagate output messages, response model, and finish reasons to root span so observability backends (e.g. Langfuse)
+	// can display Output and model name at the top-level trace without requiring users to drill into llm.call.
 	if rootSpan := trace.RootSpan; rootSpan != nil && rootSpan.SpanID != span.SpanID {
-		if v, ok := respAttrs[schemas.AttrOutputMessages]; ok {
+		var outputText string
+		if resp != nil {
+			if resp.ChatResponse != nil && len(resp.ChatResponse.Choices) > 0 {
+				choice := resp.ChatResponse.Choices[0]
+				if choice.ChatNonStreamResponseChoice != nil && choice.ChatNonStreamResponseChoice.Message != nil {
+					outputText = extractMessageContent(choice.ChatNonStreamResponseChoice.Message.Content)
+				}
+			} else if resp.ResponsesResponse != nil {
+				for _, msg := range extractResponsesOutputMessages(resp.ResponsesResponse) {
+					if msg.Content != "" {
+						outputText = msg.Content
+						break
+					}
+				}
+			}
+		}
+		if outputText != "" {
+			rootSpan.SetAttribute(schemas.AttrOutputMessages, outputText)
+		} else if v, ok := respAttrs[schemas.AttrOutputMessages]; ok {
 			rootSpan.SetAttribute(schemas.AttrOutputMessages, v)
+		}
+		if v, ok := respAttrs[schemas.AttrResponseModel]; ok {
+			rootSpan.SetAttribute(schemas.AttrResponseModel, v)
+		}
+		if v, ok := respAttrs[schemas.AttrFinishReasons]; ok {
+			rootSpan.SetAttribute(schemas.AttrFinishReasons, v)
 		}
 	}
 }

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -73,7 +73,11 @@ func hexToBytes(hexStr string, length int) []byte {
 func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceSpan {
 	otelSpans := make([]*Span, 0, len(trace.Spans))
 	for _, span := range trace.Spans {
-		otelSpans = append(otelSpans, p.convertSpanToOTELSpan(trace.TraceID, span))
+		otelSpan := p.convertSpanToOTELSpan(trace.TraceID, span)
+		if span == trace.RootSpan && len(p.instanceAttrs) > 0 {
+			otelSpan.Attributes = append(otelSpan.Attributes, p.instanceAttrs...)
+		}
+		otelSpans = append(otelSpans, otelSpan)
 	}
 
 	return &ResourceSpan{

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -97,6 +97,7 @@ type OtelPlugin struct {
 	bifrostVersion string
 
 	attributesFromEnvironment []*commonpb.KeyValue
+	instanceAttrs             []*commonpb.KeyValue // machine ID + pod labels, added only to root spans
 
 	client OtelClient
 
@@ -142,6 +143,21 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 			}
 		}
 	}
+
+	// Build instance-level attrs (machine ID + pod labels) — added only to root spans
+	instanceAttrs := make([]*commonpb.KeyValue, 0)
+	if hostname, herr := os.Hostname(); herr == nil && hostname != "" {
+		instanceAttrs = append(instanceAttrs, kvStr("service.instance.id", hostname))
+	}
+	if podName := firstNonEmpty(os.Getenv("MY_POD_NAME"), os.Getenv("POD_NAME")); podName != "" {
+		instanceAttrs = append(instanceAttrs, kvStr("k8s.pod.name", podName))
+	}
+	if podNamespace := firstNonEmpty(os.Getenv("MY_POD_NAMESPACE"), os.Getenv("POD_NAMESPACE"), os.Getenv("NAMESPACE")); podNamespace != "" {
+		instanceAttrs = append(instanceAttrs, kvStr("k8s.namespace.name", podNamespace))
+	}
+	if nodeName := firstNonEmpty(os.Getenv("MY_NODE_NAME"), os.Getenv("NODE_NAME")); nodeName != "" {
+		instanceAttrs = append(instanceAttrs, kvStr("k8s.node.name", nodeName))
+	}
 	// Preparing the plugin
 	p := &OtelPlugin{
 		serviceName:               config.ServiceName,
@@ -152,6 +168,7 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 		pricingManager:            pricingManager,
 		bifrostVersion:            bifrostVersion,
 		attributesFromEnvironment: attributesFromEnvironment,
+		instanceAttrs:             instanceAttrs,
 	}
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	if config.Protocol == ProtocolGRPC {
@@ -464,6 +481,16 @@ func (p *OtelPlugin) Cleanup() error {
 // GetMetricsExporter returns the metrics exporter for external use (e.g., by telemetry plugin)
 func (p *OtelPlugin) GetMetricsExporter() *MetricsExporter {
 	return p.metricsExporter
+}
+
+// firstNonEmpty returns the first non-empty string from the provided values.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // Compile-time check that OtelPlugin implements ObservabilityPlugin


### PR DESCRIPTION
## Summary

Improves tracing attribute coverage by collecting finish reasons from all response choices (rather than only the first), and propagates request/response model names and finish reasons to the root span so observability backends like Langfuse can surface them at the top-level trace.

## Changes

- Added a new `AttrFinishReasons` (`gen_ai.response.finish_reasons`) schema constant to hold finish reasons from all choices as a slice.
- Updated `PopulateChatResponseAttributes` and `PopulateTextCompletionResponseAttributes` to iterate over all choices and collect their finish reasons into `AttrFinishReasons` instead of only reading the first choice into `AttrFinishReason`.
- In `PopulateLLMResponseAttributes`, the `llm.call` span continues to receive the singular `AttrFinishReason` (first element of the slice) for backward compatibility, while the full `AttrFinishReasons` slice is propagated to the root span.
- Propagates `AttrRequestModel` to the root span alongside input messages on the request path.
- Propagates `AttrResponseModel` and `AttrFinishReasons` to the root span alongside output messages on the response path.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

Verify that traces emitted to an observability backend (e.g. Langfuse) show the request model, response model, and finish reasons at the root span level without needing to drill into the `llm.call` child span. For multi-choice responses, confirm that all finish reasons appear in `gen_ai.response.finish_reasons` on the root span, and that the `llm.call` span still carries the singular `gen_ai.response.finish_reason` set to the first choice's value.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable