### PR TITLE
fix: filter out unconfigured providers in default routing

### DIFF
--- a/transports/bifrost-http/handlers/webrtc_realtime_test.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime_test.go
@@ -18,9 +18,9 @@ type testHandlerStore struct {
 	kv *kvstore.Store
 }
 
-func (s testHandlerStore) ShouldAllowDirectKeys() bool                                { return true }
-func (s testHandlerStore) GetHeaderMatcher() *lib.HeaderMatcher                       { return nil }
-func (s testHandlerStore) GetAvailableProviders(model string) []schemas.ModelProvider { return nil }
+func (s testHandlerStore) ShouldAllowDirectKeys() bool                               { return true }
+func (s testHandlerStore) GetHeaderMatcher() *lib.HeaderMatcher                      { return nil }
+func (s testHandlerStore) GetProvidersForModel(model string) []schemas.ModelProvider { return nil }
 func (s testHandlerStore) GetStreamChunkInterceptor() lib.StreamChunkInterceptor {
 	return nil
 }
@@ -30,7 +30,7 @@ func (s testHandlerStore) GetKVStore() *kvstore.Store                       { re
 func (s testHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList { return nil }
 func (s testHandlerStore) ShouldAllowPerRequestStorageOverride() bool       { return false }
 func (s testHandlerStore) ShouldAllowPerRequestRawOverride() bool           { return false }
-func (s testHandlerStore) GetMCPExternalBaseURL() string                       { return "" }
+func (s testHandlerStore) GetMCPExternalBaseURL() string                    { return "" }
 
 func TestResolveRealtimeSDPTarget_BaseRouteRequiresProviderPrefix(t *testing.T) {
 	_, _, _, err := resolveRealtimeSDPTarget("/v1/realtime", []byte(`{"model":"gpt-4o-realtime-preview"}`))

--- a/transports/bifrost-http/handlers/wsresponses_test.go
+++ b/transports/bifrost-http/handlers/wsresponses_test.go
@@ -26,7 +26,7 @@ func (s testWSHandlerStore) GetHeaderMatcher() *lib.HeaderMatcher {
 	return nil
 }
 
-func (s testWSHandlerStore) GetAvailableProviders(model string) []schemas.ModelProvider {
+func (s testWSHandlerStore) GetProvidersForModel(model string) []schemas.ModelProvider {
 	return nil
 }
 
@@ -52,7 +52,7 @@ func (s testWSHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList {
 
 func (s testWSHandlerStore) ShouldAllowPerRequestStorageOverride() bool { return false }
 func (s testWSHandlerStore) ShouldAllowPerRequestRawOverride() bool     { return false }
-func (s testWSHandlerStore) GetMCPExternalBaseURL() string                 { return "" }
+func (s testWSHandlerStore) GetMCPExternalBaseURL() string              { return "" }
 
 type timeoutNetError struct{}
 

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -30,7 +30,7 @@ func (m *mockHandlerStore) GetHeaderMatcher() *lib.HeaderMatcher {
 	return m.headerMatcher
 }
 
-func (m *mockHandlerStore) GetAvailableProviders(model string) []schemas.ModelProvider {
+func (m *mockHandlerStore) GetProvidersForModel(model string) []schemas.ModelProvider {
 	return m.availableProviders
 }
 

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -745,7 +745,7 @@ func (g *GenericRouter) createHandler(config RouteConfig) fasthttp.RequestHandle
 			}
 			extractedProvider, extractedModel := schemas.ParseModelString(model, "")
 			if extractedProvider == "" {
-				availableProviders := g.handlerStore.GetAvailableProviders(extractedModel)
+				availableProviders := g.handlerStore.GetProvidersForModel(extractedModel)
 				availableProvidersStrs := make([]string, len(availableProviders))
 				for i, p := range availableProviders {
 					availableProvidersStrs[i] = string(p)

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -64,8 +64,8 @@ type HandlerStore interface {
 	ShouldAllowDirectKeys() bool
 	// GetHeaderMatcher returns the precompiled header matcher for header filtering
 	GetHeaderMatcher() *HeaderMatcher
-	// GetAvailableProviders returns the list of available providers for the given model
-	GetAvailableProviders(model string) []schemas.ModelProvider
+	// GetProvidersForModel returns the list of providers that can serve a given model.
+	GetProvidersForModel(model string) []schemas.ModelProvider
 	// GetStreamChunkInterceptor returns the interceptor for streaming chunks.
 	// Returns nil if no plugins are loaded or streaming interception is not needed.
 	GetStreamChunkInterceptor() StreamChunkInterceptor
@@ -3389,11 +3389,20 @@ func (c *Config) GetProvidersForModel(model string) []schemas.ModelProvider {
 	if c.ModelCatalog == nil {
 		return []schemas.ModelProvider{}
 	}
-	providers := c.ModelCatalog.GetProvidersForModel(model)
-	slices.SortFunc(providers, func(a, b schemas.ModelProvider) int {
+	providersInCatalog := c.ModelCatalog.GetProvidersForModel(model)
+	// Filter out the providers which are not present in the configured provider list for the client
+	c.Mu.RLock()
+	defer c.Mu.RUnlock()
+	allowedProviders := make([]schemas.ModelProvider, 0, len(providersInCatalog))
+	for configuredProvider := range c.Providers {
+		if slices.Contains(providersInCatalog, configuredProvider) {
+			allowedProviders = append(allowedProviders, configuredProvider)
+		}
+	}
+	slices.SortFunc(allowedProviders, func(a, b schemas.ModelProvider) int {
 		return strings.Compare(string(a), string(b))
 	})
-	return providers
+	return allowedProviders
 }
 
 // GetPluginOrder returns the names of all base plugins in their sorted placement order.
@@ -4900,30 +4909,6 @@ func semanticCacheConfigDimension(configMap map[string]interface{}) (int, bool, 
 	default:
 		return 0, false, fmt.Errorf("semantic_cache plugin 'dimension' field must be numeric, got %T", dimensionVal)
 	}
-}
-func (c *Config) GetAvailableProviders(model string) []schemas.ModelProvider {
-	c.Mu.RLock()
-	defer c.Mu.RUnlock()
-	availableProviders := []schemas.ModelProvider{}
-	if c.ModelCatalog != nil {
-		availableProviders = c.ModelCatalog.GetProvidersForModel(model)
-	} else {
-		// Return all providers that have at least one key with a non-empty value.
-		for provider, config := range c.Providers {
-			// Check if the provider has at least one key with a non-empty value. If so, add the provider to the list.
-			// If the provider allows empty keys, add the provider to the list.
-			for _, key := range config.Keys {
-				if key.Value.GetValue() != "" || bifrost.CanProviderKeyValueBeEmpty(provider) {
-					if key.Enabled != nil && !*key.Enabled {
-						continue
-					}
-					availableProviders = append(availableProviders, provider)
-					break
-				}
-			}
-		}
-	}
-	return availableProviders
 }
 
 func DeepCopy[T any](in T) (T, error) {

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -18,13 +18,13 @@ type testHandlerStore struct {
 	matcher         *HeaderMatcher
 }
 
-func (s testHandlerStore) ShouldAllowDirectKeys() bool                            { return s.allowDirectKeys }
-func (s testHandlerStore) GetHeaderMatcher() *HeaderMatcher                       { return s.matcher }
-func (s testHandlerStore) GetAvailableProviders(_ string) []schemas.ModelProvider { return nil }
-func (s testHandlerStore) GetStreamChunkInterceptor() StreamChunkInterceptor      { return nil }
-func (s testHandlerStore) GetAsyncJobExecutor() *logstore.AsyncJobExecutor        { return nil }
-func (s testHandlerStore) GetAsyncJobResultTTL() int                              { return 0 }
-func (s testHandlerStore) GetKVStore() *kvstore.Store                             { return nil }
+func (s testHandlerStore) ShouldAllowDirectKeys() bool                           { return s.allowDirectKeys }
+func (s testHandlerStore) GetHeaderMatcher() *HeaderMatcher                      { return s.matcher }
+func (s testHandlerStore) GetProvidersForModel(_ string) []schemas.ModelProvider { return nil }
+func (s testHandlerStore) GetStreamChunkInterceptor() StreamChunkInterceptor     { return nil }
+func (s testHandlerStore) GetAsyncJobExecutor() *logstore.AsyncJobExecutor       { return nil }
+func (s testHandlerStore) GetAsyncJobResultTTL() int                             { return 0 }
+func (s testHandlerStore) GetKVStore() *kvstore.Store                            { return nil }
 func (s testHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList {
 	return schemas.WhiteList{}
 }


### PR DESCRIPTION
## Summary

Renames `GetAvailableProviders` to `GetProvidersForModel` across the codebase and consolidates the two separate implementations into a single method on `Config`. The new implementation filters catalog providers against the client's configured provider list, ensuring only providers that are both in the model catalog and explicitly configured are returned.

## Changes

- Renamed `GetAvailableProviders` to `GetProvidersForModel` on the `HandlerStore` interface and all implementing types to better reflect the method's intent.
- Removed the standalone `GetAvailableProviders` method from `Config`, which had a fallback path that iterated over configured providers when no model catalog was present.
- Updated `GetProvidersForModel` on `Config` to intersect catalog-returned providers with the client's configured provider list, so only providers that are both catalogued for the model and actively configured are surfaced.
- Updated all test stubs to implement the renamed interface method.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/...
```

## Breaking changes

- [x] Yes
- [ ] No

Any external implementations of the `HandlerStore` interface must rename `GetAvailableProviders` to `GetProvidersForModel`. Additionally, the fallback behavior that returned all configured providers when no model catalog was present has been removed; a model catalog is now required for provider resolution.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable