### PR TITLE
feat: add Kubernetes pod-discovery RBAC templates and bump Helm chart to 2.1.9

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.8
+version: 2.1.9
 appVersion: "1.5.0-prerelease4"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,16 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.8
+**Latest Version:** 2.1.9
 
 ## Changelog
+
+### 2.1.9
+
+- Added Kubernetes pod-discovery RBAC templates for cluster discovery:
+  - Added `templates/rbac.yaml` to render a namespaced `Role`/`RoleBinding` for pod `get/list/watch`.
+  - Added `rbac.podDiscovery.enabled` to `values.yaml` and `values.schema.json` for controlled enablement (defaults to `true`).
+  - RBAC resources render only when `rbac.podDiscovery.enabled`, `bifrost.cluster.enabled`, and `bifrost.cluster.discovery.enabled` are true, with discovery `type: kubernetes`.
 
 ### 2.1.8
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1356,6 +1356,15 @@ Call this template at the beginning of deployment/stateful templates
 {{- end }}
 {{- end }}
 
+{{/* Validate RBAC pod discovery + service account configuration */}}
+{{- if and .Values.rbac .Values.rbac.podDiscovery .Values.rbac.podDiscovery.enabled }}
+{{- if and .Values.bifrost.cluster.enabled .Values.bifrost.cluster.discovery.enabled (eq .Values.bifrost.cluster.discovery.type "kubernetes") }}
+{{- if and (not .Values.serviceAccount.create) (not .Values.serviceAccount.name) }}
+{{- fail "ERROR: rbac.podDiscovery.enabled requires either serviceAccount.create=true or an explicit serviceAccount.name when serviceAccount.create=false." }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{/* Validate external Weaviate when vector store type is weaviate */}}
 {{- if and .Values.vectorStore.enabled (eq .Values.vectorStore.type "weaviate") }}
 {{- if .Values.vectorStore.weaviate.external.enabled }}

--- a/helm-charts/bifrost/templates/rbac.yaml
+++ b/helm-charts/bifrost/templates/rbac.yaml
@@ -1,0 +1,38 @@
+{{- /*
+Create pod-discovery RBAC only when all of these are true:
+1) rbac.podDiscovery.enabled
+2) cluster mode is enabled
+3) cluster discovery is enabled
+4) discovery type is kubernetes
+*/ -}}
+{{- if and .Values.rbac.podDiscovery.enabled .Values.bifrost.cluster.enabled .Values.bifrost.cluster.discovery.enabled (eq .Values.bifrost.cluster.discovery.type "kubernetes") -}}
+{{- $podDiscoveryRoleName := printf "%s-pod-discovery" (include "bifrost.fullname" . | trunc 49 | trimSuffix "-") -}}
+{{- $discoveryNamespace := .Values.bifrost.cluster.discovery.k8sNamespace | default .Release.Namespace -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $podDiscoveryRoleName }}
+  namespace: {{ $discoveryNamespace }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $podDiscoveryRoleName }}
+  namespace: {{ $discoveryNamespace }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bifrost.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $podDiscoveryRoleName }}
+{{- end -}}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -60,6 +60,22 @@
         }
       }
     },
+    "rbac": {
+      "type": "object",
+      "properties": {
+        "podDiscovery": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Create namespaced Role/RoleBinding for Kubernetes pod discovery when cluster discovery type is kubernetes"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "deploymentAnnotations": {
       "type": "object"
     },

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -34,6 +34,15 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+rbac:
+  podDiscovery:
+    # Create Role/RoleBinding to allow pod discovery in-cluster.
+    # This is rendered only when:
+    # - bifrost.cluster.enabled=true
+    # - bifrost.cluster.discovery.enabled=true
+    # - bifrost.cluster.discovery.type=kubernetes
+    enabled: true
+
 # Annotations to add to the deployment metadata
 # Useful for tools like Keel (keel.sh) for automatic image updates
 # Example:

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -2,6 +2,27 @@ apiVersion: v1
 entries:
   bifrost:
     - apiVersion: v2
+      appVersion: 1.5.0-prerelease4
+      created: "2026-04-28T18:30:00.000000+00:00"
+      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+      digest: ""
+      home: https://www.getmaxim.ai/bifrost
+      icon: https://www.getbifrost.ai/favicon.png
+      keywords:
+        - ai
+        - gateway
+        - llm
+      maintainers:
+        - email: support@getbifrost.ai
+          name: Bifrost Team
+      name: bifrost
+      sources:
+        - https://github.com/maximhq/bifrost
+      type: application
+      urls:
+        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.9.tgz
+      version: 2.1.9
+    - apiVersion: v2
       appVersion: 1.5.0-prerelease5
       created: "2026-04-26T12:40:00.000000+00:00"
       description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers


### PR DESCRIPTION
## Summary

Adds Kubernetes RBAC support for pod-based cluster discovery in the Bifrost Helm chart. When Bifrost is configured to use Kubernetes-native cluster discovery, the chart now optionally renders a namespaced `Role` and `RoleBinding` granting the Bifrost `ServiceAccount` permission to `get`, `list`, and `watch` pods.

## Changes

- Added `templates/rbac.yaml` that conditionally renders a namespaced `Role`/`RoleBinding` for pod discovery, gated on `rbac.podDiscovery.enabled`, `bifrost.cluster.enabled`, `bifrost.cluster.discovery.enabled`, and `bifrost.cluster.discovery.type=kubernetes` all being true simultaneously.
- Bound the `RoleBinding` to the Bifrost `ServiceAccount` using the `bifrost.serviceAccountName` chart helper to prevent name mismatches.
- Added `rbac.podDiscovery.enabled` (defaults to `true`) to `values.yaml` and the corresponding schema definition to `values.schema.json`.
- Bumped chart version from `2.1.8` to `2.1.9` and updated `index.yaml` and `README.md` accordingly.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy the chart with Kubernetes cluster discovery enabled and verify RBAC resources are created:

```sh
helm upgrade --install bifrost ./helm-charts/bifrost \
  --set image.tag=v2.0 \
  --set bifrost.cluster.enabled=true \
  --set bifrost.cluster.discovery.enabled=true \
  --set bifrost.cluster.discovery.type=kubernetes 

# Verify Role and RoleBinding were created
kubectl get role,rolebinding -l app.kubernetes.io/instance=bifrost

# Verify RBAC resources are NOT rendered when discovery type is not kubernetes
helm template bifrost ./helm-charts/bifrost \
  --set image.tag=v2.0 \
  --set bifrost.cluster.enabled=true \
  --set bifrost.cluster.discovery.enabled=true \
  --set bifrost.cluster.discovery.type=dns \
  --set rbac.podDiscovery.enabled=true | grep -c "Role" # should return 0

# Verify RBAC resources are NOT rendered when podDiscovery is disabled
helm template bifrost ./helm-charts/bifrost \
  --set image.tag=v2.0 \
  --set bifrost.cluster.enabled=true \
  --set bifrost.cluster.discovery.enabled=true \
  --set bifrost.cluster.discovery.type=kubernetes \
  --set rbac.podDiscovery.enabled=false | grep -c "Role" # should return 0
  
# Verify RBAC resources are rendered when podDiscovery is enabled or uses default
helm template bifrost ./helm-charts/bifrost \
  --set image.tag=v2.0 \
  --set bifrost.cluster.enabled=true \
  --set bifrost.cluster.discovery.enabled=true \
  --set bifrost.cluster.discovery.type=kubernetes \
  --set rbac.podDiscovery.enabled=true | grep -c "Role" # should return 0
```

####  

Sample deployment

Before this change:

```
helm upgrade --install bifrost ./helm-charts/bifrost \
  -n user-playground-dmc --create-namespace \
  --set image.repository=bifrost-enterprise \
  --set image.tag=latest-local \
  --set replicaCount=3 \
  --set storage.mode=postgres \
  --set storage.configStore.type=postgres \
  --set storage.logsStore.type=postgres \
  --set postgresql.enabled=true \
  --set bifrost.cluster.enabled=true \
  --set bifrost.cluster.gossip.port=7946 \
  --set bifrost.cluster.gossip.config.timeoutSeconds=10 \
  --set bifrost.cluster.gossip.config.successThreshold=3 \
  --set bifrost.cluster.gossip.config.failureThreshold=3 \
  --set bifrost.cluster.discovery.enabled=true \
  --set bifrost.cluster.discovery.type=kubernetes \
  --set bifrost.cluster.discovery.k8sNamespace=user-playground-dmc \
  --set bifrost.cluster.discovery.k8sLabelSelector=app.kubernetes.io/name=bifrost
  
# Check logs
kubectl logs -n user-playground-dmc -l app.kubernetes.io/name=bifrost --tail=200
# You should see: discovery failed: error listing pods: pods is forbidden: User "system:serviceaccount:..."
```

After the change, you should be able to see the deployment work and the cluster discovered automatically

```
helm upgrade --install bifrost ./helm-charts/bifrost \
  -n user-playground-dmc \
  --reuse-values \
```

## Breaking changes

- [x] No

## Security considerations

The `Role` is namespaced and grants only `get`, `list`, and `watch` on `pods` — no write permissions are granted. RBAC rendering is opt-out (`enabled: true` by default) but only activates when Kubernetes cluster discovery is explicitly configured, limiting unintended privilege grants.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicableould 