### PR TITLE
chore: show password dashboard on none authtype and docs change

### DIFF
--- a/docs/quickstart/gateway/setting-up-auth.mdx
+++ b/docs/quickstart/gateway/setting-up-auth.mdx
@@ -4,8 +4,6 @@ description: "Learn how to enable basic authentication for the Bifrost dashboard
 icon: "lock"
 ---
 
-<Note>This feature is only available in OSS. For enterprise builds you can setup [SCIM](/enterprise/scim)</Note>
-
 ## Overview
 
 Bifrost provides built-in authentication to protect your dashboard and admin API endpoints. When enabled, users must log in with credentials before accessing the dashboard or making admin API calls. This feature helps secure your Bifrost instance, especially when deployed in production environments.

--- a/ui/app/workspace/config/views/securityView.tsx
+++ b/ui/app/workspace/config/views/securityView.tsx
@@ -26,7 +26,7 @@ export default function SecurityView() {
 	const [updateCoreConfig, { isLoading }] = useUpdateCoreConfigMutation();
 	const [localConfig, setLocalConfig] = useState<CoreConfig>(DefaultCoreConfig);
 	const showPasswordSection =
-		!IS_ENTERPRISE || (!authTypeLoading && !authTypeError && authType?.type === "password");
+		!IS_ENTERPRISE || (!authTypeLoading && !authTypeError && authType?.type !== "sso");
 
 	const [localValues, setLocalValues] = useState<{
 		allowed_origins: string;


### PR DESCRIPTION
## Summary

Fixes the password section visibility logic in the Security view so that enterprise users who authenticate via password (rather than SSO) can still access and configure the password settings. Previously, the check required the auth type to explicitly equal `"password"`, which would hide the section for any non-`"password"` enterprise auth type. The new check hides the section only when SSO is active.

Also removes an outdated note from the auth setup documentation that incorrectly stated basic authentication was only available in OSS builds.

## Changes

- Updated `showPasswordSection` condition in `securityView.tsx` to use `authType?.type !== "sso"` instead of `authType?.type === "password"`, allowing enterprise users with password-based auth to see the password configuration section
- Removed the OSS-only note from `setting-up-auth.mdx` that no longer accurately reflects feature availability

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

1. Run Bifrost in enterprise mode with password-based authentication configured
2. Navigate to the Security settings view
3. Verify the password configuration section is visible
4. Switch to SSO-based authentication and confirm the password section is hidden

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new security implications. This change restores access to password configuration for enterprise users who are not using SSO.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable