### PR TITLE
fix: standardize `ChartCard` height and layout using fixed height and flex grow

### DIFF
--- a/ui/app/workspace/dashboard/components/charts/chartCard.tsx
+++ b/ui/app/workspace/dashboard/components/charts/chartCard.tsx
@@ -9,7 +9,6 @@ interface ChartCardProps {
   headerActions?: ReactNode;
   loading?: boolean;
   testId?: string;
-  height?: string;
   className?: string;
 }
 
@@ -19,16 +18,15 @@ export function ChartCard({
   headerActions,
   loading,
   testId,
-  height = "200px",
   className,
 }: ChartCardProps) {
   if (loading) {
     return (
       <Card
-        className={cn("min-w-0 rounded-sm p-2 shadow-none", className)}
+        className={cn("min-w-0 rounded-sm p-2 shadow-none h-[330px]", className)}
         data-testid={testId}
       >
-        <div className="mb-2 space-y-2">
+        <div className="shrink-0 space-y-2">
           <span className="text-primary pl-2 text-sm font-medium">{title}</span>
           {headerActions && (
             <div
@@ -40,7 +38,7 @@ export function ChartCard({
           )}
         </div>
         <div
-          style={{ height }}
+          className="grow"
           data-testid={testId ? `${testId}-chart-skeleton` : undefined}
         >
           <Skeleton className="h-full w-full" />
@@ -51,10 +49,10 @@ export function ChartCard({
 
   return (
     <Card
-      className={cn("min-w-0 rounded-sm p-2 shadow-none", className)}
+      className={cn("min-w-0 rounded-sm p-2 shadow-none h-[330px]", className)}
       data-testid={testId}
     >
-      <div className="mb-2 space-y-2">
+      <div className="shrink-0 space-y-2">
         <span className="text-primary pl-2 text-sm font-medium">{title}</span>
         {headerActions && (
           <div
@@ -65,7 +63,7 @@ export function ChartCard({
           </div>
         )}
       </div>
-      <div style={{ height }}>{children}</div>
+      <div className="grow">{children}</div>
     </Card>
   );
 }

--- a/ui/app/workspace/dashboard/components/charts/externalCacheTokenMeterChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/externalCacheTokenMeterChart.tsx
@@ -46,8 +46,8 @@ export default function ExternalCacheTokenMeterChart({ data }: ExternalCacheToke
 
 	return (
 		<ChartErrorBoundary resetKey={`${data?.buckets?.length ?? 0}-${totalCachedRead}-${totalPromptTokens}`}>
-			<div className="grid h-full grid-rows-[104px_auto_auto] items-start overflow-hidden">
-				<div ref={ref} className="relative h-[104px] w-full">
+			<div className="grid h-full grid-rows-[104px_auto] items-start overflow-hidden pt-8">
+				<div ref={ref} className="relative grow h-full w-full">
 					{!hasData && <div className="text-muted-foreground flex h-full items-center justify-center text-sm">No data available</div>}
 					{hasData && gaugeGeometry && (
 						<>
@@ -76,9 +76,10 @@ export default function ExternalCacheTokenMeterChart({ data }: ExternalCacheToke
 						</>
 					)}
 				</div>
+
 				{hasData && (
-					<>
-						<div className="flex flex-col items-center pt-1 leading-none">
+					<div>
+						<div className="flex flex-col items-center pt-1 leading-none shrink-0">
 							<div className="text-muted-foreground text-3xl font-semibold tracking-tight">{percentage.toFixed(1)}%</div>
 							<div className="mt-1 flex items-center gap-1 text-[11px] text-zinc-400">
 								<span>of input tokens cached by provider</span>
@@ -97,7 +98,7 @@ export default function ExternalCacheTokenMeterChart({ data }: ExternalCacheToke
 								</Tooltip>
 							</div>
 						</div>
-						<div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 pt-2 text-[11px] leading-none">
+						<div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 pt-2 text-[11px] leading-none shrink-0">
 							<span className="flex items-center gap-1.5">
 								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: METER_COLORS.cached }} />
 								<span className="text-primary">Cached: {formatTokenCount(totalCachedRead)}</span>
@@ -107,7 +108,7 @@ export default function ExternalCacheTokenMeterChart({ data }: ExternalCacheToke
 								<span className="text-muted-foreground">Input: {formatTokenCount(totalPromptTokens)}</span>
 							</span>
 						</div>
-					</>
+					</div>
 				)}
 			</div>
 		</ChartErrorBoundary>

--- a/ui/app/workspace/dashboard/components/charts/localCacheTokenMeterChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/localCacheTokenMeterChart.tsx
@@ -45,7 +45,7 @@ export default function LocalCacheTokenMeterChart({ data }: LocalCacheTokenMeter
 
 	return (
 		<ChartErrorBoundary resetKey={`${directHits}-${semanticHits}-${totalRequests}`}>
-			<div className="grid h-full grid-rows-[104px_auto_auto] items-start overflow-hidden">
+			<div className="grid h-full grid-rows-[104px_auto] items-start overflow-hidden pt-8">
 				<div ref={ref} className="relative h-[104px] w-full">
 					{!hasData && <div className="text-muted-foreground flex h-full items-center justify-center text-sm">No data available</div>}
 					{hasData && gaugeGeometry && (
@@ -77,7 +77,7 @@ export default function LocalCacheTokenMeterChart({ data }: LocalCacheTokenMeter
 					)}
 				</div>
 				{hasData && (
-					<>
+					<div>
 						<div className="flex flex-col items-center pt-1 leading-none">
 							<div className="text-muted-foreground text-3xl font-semibold tracking-tight">{percentage.toFixed(1)}%</div>
 							<div className="mt-1 text-[11px] text-zinc-400">of requests served from local cache</div>
@@ -92,7 +92,7 @@ export default function LocalCacheTokenMeterChart({ data }: LocalCacheTokenMeter
 								<span className="text-primary">Semantic: {semanticHits}</span>
 							</span>
 						</div>
-					</>
+					</div>
 				)}
 			</div>
 		</ChartErrorBoundary>

--- a/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
+++ b/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
@@ -180,7 +180,7 @@ function TopModelsChart({
 	}, [rankingsData, displayModels]);
 
 	return (
-		<ChartCard title="Top Models" loading={loadingModels} testId="dashboard-rankings-top-models" height="100%" className="z-[1]">
+		<ChartCard title="Top Models" loading={loadingModels} testId="dashboard-rankings-top-models" className="h-full z-[1]">
 			<div style={{ height: 200, marginBottom: 6 }}>
 				{chartData.length > 0 ? (
 					<ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}`}>


### PR DESCRIPTION
## Summary

Fixes inconsistent chart card heights across the dashboard by replacing dynamic `height` prop-based sizing with fixed Tailwind utility classes, ensuring all chart cards render at a uniform `330px` height with proper flex-based content distribution.

## Changes

- Removed the `height` prop from `ChartCard` and replaced inline `style={{ height }}` with a fixed `h-[330px]` class on the card and `grow` on the content container, so charts fill available space consistently regardless of content
- Updated the header `div` from `mb-2` to `shrink-0` to prevent it from being compressed when the content area grows
- Adjusted `ExternalCacheTokenMeterChart` and `LocalCacheTokenMeterChart` grid layouts from `grid-rows-[104px_auto_auto]` to `grid-rows-[104px_auto]` and added `pt-8` padding to better align gauge content within the fixed card height
- Replaced React Fragment wrappers (`<>`) with `<div>` wrappers in the cache meter charts to allow `shrink-0` to apply correctly to stat rows
- Updated `TopModelsChart` to pass `className="h-full"` instead of `height="100%"` to align with the new sizing approach

## Type of change

- [ ] Bug fix
- [x] Refactor
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Navigate to the workspace dashboard and verify that all chart cards render at a consistent height, the loading skeleton fills the card correctly, and the gauge charts (external and local cache token meters) display without layout overflow or misalignment.

## Screenshots/Recordings

Before/after screenshots of the dashboard chart cards showing uniform card heights are recommended.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable