### PR TITLE
feat: example files for virtual keys

### DIFF
--- a/examples/k8s/examples/values-providers.yaml
+++ b/examples/k8s/examples/values-providers.yaml
@@ -3,7 +3,7 @@ bifrost:
     # Primary provider
     openai:
       network_config:
-        base_url: "https://api.openai.com/v1"
+        base_url: "https://api.openai.com"
         default_request_timeout_in_seconds: 58
         stream_idle_timeout_in_seconds: 59
         max_retries: 7
@@ -25,7 +25,7 @@ bifrost:
       store_raw_request_response: true
       concurrency_and_buffer_size:
         concurrency: 100
-        buffer_size: 1000
+        buffer_size: 10000
       # Proxy options:
       # - type: "http" and url: "http://proxy.example:8080"
       # - type: "socks5" and url: "socks5://proxy.example:1080"
@@ -43,9 +43,7 @@ bifrost:
           models:
             - "*"
           use_for_batch_api: true
-          aliases: {
-            gpt-4o-mini: "gpt-4o-mini-2024-07-18"
-          }
+          aliases: { gpt-4o-mini: "gpt-4o-mini-2024-07-18" }
           # Optional key-scoped config blocks (provider specific)
           # azure_key_config:
           #   endpoint: "https://your-resource.openai.azure.com"
@@ -74,7 +72,7 @@ bifrost:
       #   base_provider_type: "anthropic"
       # Per-beta-header support overrides (true/false). Applicable for Anthropic only.
       # beta_header_overrides:
-        # output-128k-2025-02-19: true
+      # output-128k-2025-02-19: true
       keys:
         - name: "anthropic-key"
           value: "env.ANTHROPIC_API_KEY"

--- a/examples/k8s/examples/values-virtual-keys.yaml
+++ b/examples/k8s/examples/values-virtual-keys.yaml
@@ -1,0 +1,70 @@
+# Virtual key examples.
+#
+# Usage:
+#   helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
+#     --namespace "${NAMESPACE}" \
+#     -f examples/k8s/examples/values.yaml \
+#     -f examples/k8s/examples/values-storage-sqlite.yaml \
+#     -f examples/k8s/examples/values-providers.yaml \
+#     -f examples/k8s/examples/values-governance-teams.yaml \
+#     -f examples/k8s/examples/values-virtual-keys.yaml \
+#     --wait \
+#     --timeout 5m
+
+bifrost:
+  governance:
+    virtualKeys:
+      - id: "vk-openai-mini"
+        name: "OpenAI Mini Virtual Key"
+        description: "Team-scoped VK restricted to OpenAI gpt-4o-mini."
+        value: "sk-bf-example-openai-mini"
+        is_active: true
+        team_id: "team-platform"
+        rate_limit_id: "rl-team-default"
+        provider_configs:
+          - provider: "openai"
+            allowed_models:
+              - "gpt-4o-mini"
+            # In Helm/config.json these are provider key names (unique), not database IDs.
+            key_ids:
+              - "openai-key"
+
+      - id: "vk-multi-provider"
+        name: "Multi Provider Virtual Key"
+        description: "Customer-scoped VK that allows selected OpenAI and Anthropic models."
+        value: "sk-bf-example-multi-provider"
+        is_active: true
+        customer_id: "customer-acme"
+        rate_limit_id: "rl-team-default"
+        provider_configs:
+          - provider: "anthropic"
+            weight: 0.3
+            allowed_models:
+              - "*"
+            key_ids:
+              - "anthropic-key"
+          - provider: "openai"
+            weight: 0.7
+            allowed_models:
+              - "gpt-4o-mini"
+              - "gpt-4o"
+            key_ids:
+              - "openai-key"
+
+      # - id: "vk-with-mcp"
+      #   name: "Virtual Key With MCP"
+      #   description: "VK scoped to OpenAI plus a named MCP client/tool allow-list."
+      #   value: "sk-bf-example-mcp"
+      #   is_active: true
+      #   team_id: "team-platform"
+      #   provider_configs:
+      #     - provider: "openai"
+      #       allowed_models:
+      #         - "*"
+      #       key_ids:
+      #         - "openai-key"
+      #   mcp_configs:
+      #     - mcp_client_name: "filesystem"
+      #       tools_to_execute:
+      #         - "read_file"
+      #         - "list_directory"


### PR DESCRIPTION
## Summary

Adds a new Helm values example file for virtual key configuration and fixes several minor issues in the existing providers values example.

## Changes

- Added `examples/k8s/examples/values-virtual-keys.yaml` with two active virtual key examples:
    - A team-scoped virtual key restricted to OpenAI `gpt-4o-mini`
    - A customer-scoped virtual key with weighted routing across OpenAI and Anthropic models
    - A commented-out example showing MCP client/tool allow-list configuration
- Corrected the OpenAI `base_url` from `https://api.openai.com/v1` to `https://api.openai.com`
- Increased the OpenAI provider `buffer_size` from `1000` to `10000`
- Collapsed the `aliases` block to a single line for consistency
- Fixed indentation on the Anthropic `beta_header_overrides` comment
- Added a trailing newline to the providers values file

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy using the full Helm values stack including the new virtual keys file:

```sh
helm upgrade --install "${RELEASE_NAME}" ./helm-charts/bifrost \
  --namespace "${NAMESPACE}" \
  -f examples/k8s/examples/values.yaml \
  -f examples/k8s/examples/values-storage-sqlite.yaml \
  -f examples/k8s/examples/values-providers.yaml \
  -f examples/k8s/examples/values-governance-teams.yaml \
  -f examples/k8s/examples/values-virtual-keys.yaml \
  --wait \
  --timeout 5m
```

Verify that virtual keys `vk-openai-mini` and `vk-multi-provider` are created and active, and that requests using `sk-bf-example-openai-mini` and `sk-bf-example-multi-provider` are routed to the correct providers and models.

## Screenshots/Recordings

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Virtual key values in the example files are placeholder strings (`sk-bf-example-*`) and do not contain real credentials. Actual provider keys continue to be sourced from environment variables via Kubernetes secrets.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable