### PR TITLE
feat: add passthrough streaming accumulation

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -2585,18 +2584,11 @@ func (provider *AnthropicProvider) Passthrough(
 	}
 
 	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, headers)
 
 	body, err := providerUtils.CheckAndDecodeBody(resp)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err)
-	}
-
-	originalHeaders := make(map[string]string, len(headers))
-	maps.Copy(originalHeaders, headers)
-	for k := range headers {
-		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
-			delete(headers, k)
-		}
 	}
 
 	bifrostResponse := &schemas.BifrostPassthroughResponse{
@@ -2605,7 +2597,7 @@ func (provider *AnthropicProvider) Passthrough(
 		Body:       body,
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			Latency:                 latency.Milliseconds(),
-			ProviderResponseHeaders: originalHeaders,
+			ProviderResponseHeaders: headers,
 		},
 	}
 
@@ -2673,6 +2665,7 @@ func (provider *AnthropicProvider) PassthroughStream(
 	}
 
 	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, headers)
 
 	bodyStream := resp.BodyStream()
 	if bodyStream == nil {
@@ -2691,7 +2684,9 @@ func (provider *AnthropicProvider) PassthroughStream(
 	// Cancellation must close the raw stream to unblock reads.
 	stopCancellation := providerUtils.SetupStreamCancellation(ctx, rawBodyStream, provider.logger)
 
-	extraFields := schemas.BifrostResponseExtraFields{}
+	extraFields := schemas.BifrostResponseExtraFields{
+		ProviderResponseHeaders: headers,
+	}
 	statusCode := resp.StatusCode()
 
 	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
@@ -2715,33 +2710,25 @@ func (provider *AnthropicProvider) PassthroughStream(
 			if n > 0 {
 				chunk := make([]byte, n)
 				copy(chunk, buf[:n])
-				select {
-				case ch <- &schemas.BifrostStreamChunk{
-					BifrostPassthroughResponse: &schemas.BifrostPassthroughResponse{
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, &schemas.BifrostResponse{
+					PassthroughResponse: &schemas.BifrostPassthroughResponse{
 						StatusCode:  statusCode,
 						Headers:     headers,
 						Body:        chunk,
 						ExtraFields: extraFields,
 					},
-				}:
-				case <-ctx.Done():
-					return
-				}
+				}, ch, postHookSpanFinalizer)
 			}
 			if readErr == io.EOF {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				extraFields.Latency = time.Since(startTime).Milliseconds()
-				finalResp := &schemas.BifrostResponse{
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, &schemas.BifrostResponse{
 					PassthroughResponse: &schemas.BifrostPassthroughResponse{
 						StatusCode:  statusCode,
 						Headers:     headers,
 						ExtraFields: extraFields,
 					},
-				}
-				postHookRunner(ctx, finalResp, nil)
-				if postHookSpanFinalizer != nil {
-					postHookSpanFinalizer(ctx)
-				}
+				}, ch, postHookSpanFinalizer)
 				return
 			}
 			if readErr != nil {

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -2744,19 +2744,11 @@ func (provider *AzureProvider) Passthrough(
 	}
 
 	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, headers)
 
 	body, err := providerUtils.CheckAndDecodeBody(resp)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err)
-	}
-
-	originalHeaders := make(map[string]string, len(headers))
-	maps.Copy(originalHeaders, headers)
-	// Remove wire-level encoding headers after decoding; downstream should recalculate them for the buffered body.
-	for k := range headers {
-		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
-			delete(headers, k)
-		}
 	}
 
 	bifrostResponse := &schemas.BifrostPassthroughResponse{
@@ -2765,7 +2757,7 @@ func (provider *AzureProvider) Passthrough(
 		Body:       body,
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			Latency:                 latency.Milliseconds(),
-			ProviderResponseHeaders: originalHeaders,
+			ProviderResponseHeaders: headers,
 		},
 	}
 
@@ -2833,6 +2825,7 @@ func (provider *AzureProvider) PassthroughStream(
 	}
 
 	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, headers)
 
 	rawBodyStream := resp.BodyStream()
 	if rawBodyStream == nil {
@@ -2843,7 +2836,9 @@ func (provider *AzureProvider) PassthroughStream(
 	bodyStream, stopIdleTimeout := providerUtils.NewIdleTimeoutReader(rawBodyStream, rawBodyStream, providerUtils.GetStreamIdleTimeout(ctx))
 	stopCancellation := providerUtils.SetupStreamCancellation(ctx, rawBodyStream, provider.logger)
 
-	extraFields := schemas.BifrostResponseExtraFields{}
+	extraFields := schemas.BifrostResponseExtraFields{
+		ProviderResponseHeaders: headers,
+	}
 	statusCode := resp.StatusCode()
 
 	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
@@ -2867,33 +2862,25 @@ func (provider *AzureProvider) PassthroughStream(
 			if n > 0 {
 				chunk := make([]byte, n)
 				copy(chunk, buf[:n])
-				select {
-				case ch <- &schemas.BifrostStreamChunk{
-					BifrostPassthroughResponse: &schemas.BifrostPassthroughResponse{
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, &schemas.BifrostResponse{
+					PassthroughResponse: &schemas.BifrostPassthroughResponse{
 						StatusCode:  statusCode,
 						Headers:     headers,
 						Body:        chunk,
 						ExtraFields: extraFields,
 					},
-				}:
-				case <-ctx.Done():
-					return
-				}
+				}, ch, postHookSpanFinalizer)
 			}
 			if readErr == io.EOF {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				extraFields.Latency = time.Since(startTime).Milliseconds()
-				finalResp := &schemas.BifrostResponse{
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, &schemas.BifrostResponse{
 					PassthroughResponse: &schemas.BifrostPassthroughResponse{
 						StatusCode:  statusCode,
 						Headers:     headers,
 						ExtraFields: extraFields,
 					},
-				}
-				postHookRunner(ctx, finalResp, nil)
-				if postHookSpanFinalizer != nil {
-					postHookSpanFinalizer(ctx)
-				}
+				}, ch, postHookSpanFinalizer)
 				return
 			}
 			if readErr != nil {

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -22,8 +21,7 @@ import (
 )
 
 const (
-	BifrostContextKeyResponseFormat  schemas.BifrostContextKey = "bifrost_context_key_response_format"
-	maxStreamPassthroughCaptureBytes                           = 1024 * 1024
+	BifrostContextKeyResponseFormat schemas.BifrostContextKey = "bifrost_context_key_response_format"
 )
 
 type GeminiProvider struct {
@@ -4088,25 +4086,20 @@ func (provider *GeminiProvider) Passthrough(
 	}
 
 	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, headers)
+
 	body, err := providerUtils.CheckAndDecodeBody(resp)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err)
 	}
-	originalHeaders := make(map[string]string, len(headers))
-	maps.Copy(originalHeaders, headers)
-	for k := range headers {
-		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
-			delete(headers, k)
-		}
-	}
-	body = append([]byte(nil), body...)
+
 	bifrostResponse := &schemas.BifrostPassthroughResponse{
 		StatusCode: resp.StatusCode(),
 		Headers:    headers,
 		Body:       body,
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			Latency:                 latency.Milliseconds(),
-			ProviderResponseHeaders: originalHeaders,
+			ProviderResponseHeaders: headers,
 		},
 	}
 
@@ -4174,6 +4167,7 @@ func (provider *GeminiProvider) PassthroughStream(
 	}
 
 	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, headers)
 
 	bodyStream := resp.BodyStream()
 	if bodyStream == nil {
@@ -4192,7 +4186,9 @@ func (provider *GeminiProvider) PassthroughStream(
 	// Cancellation must close the raw stream to unblock reads.
 	stopCancellation := providerUtils.SetupStreamCancellation(ctx, rawBodyStream, provider.logger)
 
-	extraFields := schemas.BifrostResponseExtraFields{}
+	extraFields := schemas.BifrostResponseExtraFields{
+		ProviderResponseHeaders: headers,
+	}
 	statusCode := resp.StatusCode()
 
 	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
@@ -4210,12 +4206,6 @@ func (provider *GeminiProvider) PassthroughStream(
 		defer stopIdleTimeout()
 		defer stopCancellation()
 
-		initialCaptureBytes := 32 * 1024
-		if initialCaptureBytes > maxStreamPassthroughCaptureBytes {
-			initialCaptureBytes = maxStreamPassthroughCaptureBytes
-		}
-		fullResponseBody := make([]byte, 0, initialCaptureBytes)
-		fullResponseBodyTruncated := false
 		terminalDetector := &providerUtils.StreamTerminalDetector{}
 		buf := make([]byte, 4096)
 		for {
@@ -4223,69 +4213,38 @@ func (provider *GeminiProvider) PassthroughStream(
 			if n > 0 {
 				chunk := make([]byte, n)
 				copy(chunk, buf[:n])
-				if !fullResponseBodyTruncated {
-					remaining := maxStreamPassthroughCaptureBytes - len(fullResponseBody)
-					if remaining > 0 {
-						if n <= remaining {
-							fullResponseBody = append(fullResponseBody, chunk...)
-						} else {
-							fullResponseBody = append(fullResponseBody, chunk[:remaining]...)
-							fullResponseBodyTruncated = true
-						}
-					} else {
-						fullResponseBodyTruncated = true
-					}
-				}
-				select {
-				case ch <- &schemas.BifrostStreamChunk{
-					BifrostPassthroughResponse: &schemas.BifrostPassthroughResponse{
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, &schemas.BifrostResponse{
+					PassthroughResponse: &schemas.BifrostPassthroughResponse{
 						StatusCode:  statusCode,
 						Headers:     headers,
 						Body:        chunk,
 						ExtraFields: extraFields,
 					},
-				}:
-				case <-ctx.Done():
-					return
-				}
+				}, ch, postHookSpanFinalizer)
 
 				if terminalDetector.ObserveChunk(chunk) {
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					extraFields.Latency = time.Since(startTime).Milliseconds()
-					var capturedBody []byte
-					if !fullResponseBodyTruncated {
-						capturedBody = append([]byte(nil), fullResponseBody...)
-					}
-					finalResp := &schemas.BifrostResponse{
+					providerUtils.ProcessAndSendResponse(ctx, postHookRunner, &schemas.BifrostResponse{
 						PassthroughResponse: &schemas.BifrostPassthroughResponse{
-							StatusCode:    statusCode,
-							Headers:       headers,
-							Body:          capturedBody,
-							BodyTruncated: fullResponseBodyTruncated,
-							ExtraFields:   extraFields,
+							StatusCode:  statusCode,
+							Headers:     headers,
+							ExtraFields: extraFields,
 						},
-					}
-					postHookRunner(ctx, finalResp, nil)
+					}, ch, postHookSpanFinalizer)
 					return
 				}
 			}
 			if readErr == io.EOF {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				extraFields.Latency = time.Since(startTime).Milliseconds()
-				var capturedBody []byte
-				if !fullResponseBodyTruncated {
-					capturedBody = append([]byte(nil), fullResponseBody...)
-				}
-				finalResp := &schemas.BifrostResponse{
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, &schemas.BifrostResponse{
 					PassthroughResponse: &schemas.BifrostPassthroughResponse{
-						StatusCode:    statusCode,
-						Headers:       headers,
-						Body:          capturedBody,
-						BodyTruncated: fullResponseBodyTruncated,
-						ExtraFields:   extraFields,
+						StatusCode:  statusCode,
+						Headers:     headers,
+						ExtraFields: extraFields,
 					},
-				}
-				postHookRunner(ctx, finalResp, nil)
+				}, ch, postHookSpanFinalizer)
 				return
 			}
 			if readErr != nil {

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -6881,19 +6881,11 @@ func (provider *OpenAIProvider) Passthrough(
 	}
 
 	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, headers)
 
 	body, err := providerUtils.CheckAndDecodeBody(resp)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err)
-	}
-
-	originalHeaders := make(map[string]string, len(headers))
-	maps.Copy(originalHeaders, headers)
-	// Remove wire-level encoding headers after decoding; downstream should recalculate them for the buffered body.
-	for k := range headers {
-		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
-			delete(headers, k)
-		}
 	}
 
 	bifrostResponse := &schemas.BifrostPassthroughResponse{
@@ -6902,7 +6894,7 @@ func (provider *OpenAIProvider) Passthrough(
 		Body:       body,
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			Latency:                 latency.Milliseconds(),
-			ProviderResponseHeaders: originalHeaders,
+			ProviderResponseHeaders: headers,
 		},
 	}
 
@@ -6973,11 +6965,8 @@ func (provider *OpenAIProvider) PassthroughStream(
 		return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderDoRequest, err)
 	}
 
-	headers := make(map[string]string)
-	resp.Header.All()(func(k, v []byte) bool {
-		headers[string(k)] = string(v)
-		return true
-	})
+	headers := providerUtils.ExtractProviderResponseHeaders(resp)
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, headers)
 
 	rawBodyStream := resp.BodyStream()
 	if rawBodyStream == nil {
@@ -6993,7 +6982,9 @@ func (provider *OpenAIProvider) PassthroughStream(
 	// Cancellation must close the raw stream to unblock reads.
 	stopCancellation := providerUtils.SetupStreamCancellation(ctx, rawBodyStream, provider.logger)
 
-	extraFields := schemas.BifrostResponseExtraFields{}
+	extraFields := schemas.BifrostResponseExtraFields{
+		ProviderResponseHeaders: headers,
+	}
 	statusCode := resp.StatusCode()
 
 	ch := make(chan *schemas.BifrostStreamChunk, schemas.DefaultStreamBufferSize)
@@ -7017,33 +7008,25 @@ func (provider *OpenAIProvider) PassthroughStream(
 			if n > 0 {
 				chunk := make([]byte, n)
 				copy(chunk, buf[:n])
-				select {
-				case ch <- &schemas.BifrostStreamChunk{
-					BifrostPassthroughResponse: &schemas.BifrostPassthroughResponse{
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, &schemas.BifrostResponse{
+					PassthroughResponse: &schemas.BifrostPassthroughResponse{
 						StatusCode:  statusCode,
 						Headers:     headers,
 						Body:        chunk,
 						ExtraFields: extraFields,
 					},
-				}:
-				case <-ctx.Done():
-					return
-				}
+				}, ch, postHookSpanFinalizer)
 			}
 			if readErr == io.EOF {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				extraFields.Latency = time.Since(startTime).Milliseconds()
-				finalResp := &schemas.BifrostResponse{
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, &schemas.BifrostResponse{
 					PassthroughResponse: &schemas.BifrostPassthroughResponse{
 						StatusCode:  statusCode,
 						Headers:     headers,
 						ExtraFields: extraFields,
 					},
-				}
-				postHookRunner(ctx, finalResp, nil)
-				if postHookSpanFinalizer != nil {
-					postHookSpanFinalizer(ctx)
-				}
+				}, ch, postHookSpanFinalizer)
 				return
 			}
 			if readErr != nil {

--- a/core/providers/openai/realtime.go
+++ b/core/providers/openai/realtime.go
@@ -217,7 +217,7 @@ func (provider *OpenAIProvider) CreateRealtimeClientSecret(
 		return nil, err
 	}
 
-	normalizedBody, requestedModel, bifrostErr := normalizeRealtimeClientSecretRequest(rawRequest, provider.GetProviderKey(), endpointType)
+	normalizedBody, _, bifrostErr := normalizeRealtimeClientSecretRequest(rawRequest, provider.GetProviderKey(), endpointType)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -251,21 +251,16 @@ func (provider *OpenAIProvider) CreateRealtimeClientSecret(
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err)
 	}
-	for k := range headers {
-		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
-			delete(headers, k)
-		}
-	}
 
 	out := &schemas.BifrostPassthroughResponse{
 		StatusCode: resp.StatusCode(),
 		Headers:    headers,
 		Body:       body,
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			Latency:                 latency.Milliseconds(),
+			ProviderResponseHeaders: headers,
+		},
 	}
-	out.ExtraFields.Provider = provider.GetProviderKey()
-	out.ExtraFields.OriginalModelRequested = requestedModel
-	out.ExtraFields.RequestType = schemas.RealtimeRequest
-	out.ExtraFields.Latency = latency.Milliseconds()
 	if providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest) {
 		providerUtils.ParseAndSetRawRequestIfJSON(req, &out.ExtraFields)
 	}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -1793,6 +1793,7 @@ func BuildClientStreamChunk(ctx context.Context, processedResponse *schemas.Bifr
 		streamResponse.BifrostSpeechStreamResponse = processedResponse.SpeechStreamResponse
 		streamResponse.BifrostTranscriptionStreamResponse = processedResponse.TranscriptionStreamResponse
 		streamResponse.BifrostImageGenerationStreamResponse = processedResponse.ImageGenerationStreamResponse
+		streamResponse.BifrostPassthroughResponse = processedResponse.PassthroughResponse
 		// Strip raw fields from client-facing copies without mutating the shared objects
 		// that PostLLMHook goroutines may still be reading.
 		if drop {
@@ -1855,6 +1856,16 @@ func BuildClientStreamChunk(ctx context.Context, processedResponse *schemas.Bifr
 					cp.ExtraFields.RawResponse = nil
 				}
 				streamResponse.BifrostImageGenerationStreamResponse = &cp
+			}
+			if streamResponse.BifrostPassthroughResponse != nil {
+				cp := *streamResponse.BifrostPassthroughResponse
+				if dropReq {
+					cp.ExtraFields.RawRequest = nil
+				}
+				if dropResp {
+					cp.ExtraFields.RawResponse = nil
+				}
+				streamResponse.BifrostPassthroughResponse = &cp
 			}
 		}
 	}

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -45,8 +44,6 @@ var vertexClientPool sync.Map
 var vertexLocationsPathRe = regexp.MustCompile(`/locations/[^/]+`)
 
 var vertexProjectsPathRe = regexp.MustCompile(`/projects/[^/]+`)
-
-const maxStreamPassthroughCaptureBytes = 1024 * 1024
 
 // vertexBodyProjectsRe matches projects/{project} in body JSON values,
 // where the path may appear as "projects/X (after a JSON quote) or /projects/X (mid-path).
@@ -2861,20 +2858,14 @@ func (provider *VertexProvider) Passthrough(
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("failed to decode response body", err)
 	}
-	originalHeaders := make(map[string]string, len(headers))
-	maps.Copy(originalHeaders, headers)
-	for k := range headers {
-		if strings.EqualFold(k, "Content-Encoding") || strings.EqualFold(k, "Content-Length") {
-			delete(headers, k)
-		}
-	}
+
 	bifrostResponse := &schemas.BifrostPassthroughResponse{
 		StatusCode: resp.StatusCode(),
 		Headers:    headers,
 		Body:       body,
 		ExtraFields: schemas.BifrostResponseExtraFields{
 			Latency:                 latency.Milliseconds(),
-			ProviderResponseHeaders: originalHeaders,
+			ProviderResponseHeaders: headers,
 		},
 	}
 
@@ -3044,8 +3035,6 @@ func (provider *VertexProvider) PassthroughStream(
 		defer stopCancellation()
 		streamStart := time.Now()
 
-		fullResponseBody := make([]byte, 0, maxStreamPassthroughCaptureBytes)
-		fullResponseBodyTruncated := false
 		terminalDetector := &providerUtils.StreamTerminalDetector{}
 		buf := make([]byte, 4096)
 		for {
@@ -3053,31 +3042,14 @@ func (provider *VertexProvider) PassthroughStream(
 			if n > 0 {
 				chunk := make([]byte, n)
 				copy(chunk, buf[:n])
-				if !fullResponseBodyTruncated {
-					remaining := maxStreamPassthroughCaptureBytes - len(fullResponseBody)
-					if remaining > 0 {
-						if n <= remaining {
-							fullResponseBody = append(fullResponseBody, chunk...)
-						} else {
-							fullResponseBody = append(fullResponseBody, chunk[:remaining]...)
-							fullResponseBodyTruncated = true
-						}
-					} else {
-						fullResponseBodyTruncated = true
-					}
-				}
-				select {
-				case ch <- &schemas.BifrostStreamChunk{
-					BifrostPassthroughResponse: &schemas.BifrostPassthroughResponse{
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, &schemas.BifrostResponse{
+					PassthroughResponse: &schemas.BifrostPassthroughResponse{
 						StatusCode:  statusCode,
 						Headers:     headers,
 						Body:        chunk,
 						ExtraFields: extraFields,
 					},
-				}:
-				case <-ctx.Done():
-					return
-				}
+				}, ch, postHookSpanFinalizer)
 
 				// Vertex streamGenerateContent passthrough can emit terminal markers
 				// (finishReason) before the underlying HTTP body is closed.
@@ -3085,38 +3057,26 @@ func (provider *VertexProvider) PassthroughStream(
 				if terminalDetector.ObserveChunk(chunk) {
 					ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 					extraFields.Latency = time.Since(streamStart).Milliseconds()
-					var capturedBody []byte
-					if !fullResponseBodyTruncated {
-						capturedBody = append([]byte(nil), fullResponseBody...)
-					}
-					finalResp := &schemas.BifrostResponse{
+					providerUtils.ProcessAndSendResponse(ctx, postHookRunner, &schemas.BifrostResponse{
 						PassthroughResponse: &schemas.BifrostPassthroughResponse{
 							StatusCode:  statusCode,
 							Headers:     headers,
-							Body:        capturedBody,
 							ExtraFields: extraFields,
 						},
-					}
-					postHookRunner(ctx, finalResp, nil)
+					}, ch, postHookSpanFinalizer)
 					return
 				}
 			}
 			if readErr == io.EOF {
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 				extraFields.Latency = time.Since(streamStart).Milliseconds()
-				var capturedBody []byte
-				if !fullResponseBodyTruncated {
-					capturedBody = append([]byte(nil), fullResponseBody...)
-				}
-				finalResp := &schemas.BifrostResponse{
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, &schemas.BifrostResponse{
 					PassthroughResponse: &schemas.BifrostPassthroughResponse{
 						StatusCode:  statusCode,
 						Headers:     headers,
-						Body:        capturedBody,
 						ExtraFields: extraFields,
 					},
-				}
-				postHookRunner(ctx, finalResp, nil)
+				}, ch, postHookSpanFinalizer)
 				return
 			}
 			if readErr != nil {

--- a/core/schemas/passthrough.go
+++ b/core/schemas/passthrough.go
@@ -11,11 +11,10 @@ type BifrostPassthroughRequest struct {
 }
 
 type BifrostPassthroughResponse struct {
-	StatusCode    int
-	Headers       map[string]string
-	Body          []byte
-	BodyTruncated bool
-	ExtraFields   BifrostResponseExtraFields
+	StatusCode  int
+	Headers     map[string]string
+	Body        []byte
+	ExtraFields BifrostResponseExtraFields
 }
 
 type PassthroughLogParams struct {

--- a/core/schemas/tracer.go
+++ b/core/schemas/tracer.go
@@ -29,6 +29,7 @@ type StreamAccumulatorResult struct {
 	AudioOutput           *BifrostSpeechResponse          // For speech streaming
 	TranscriptionOutput   *BifrostTranscriptionResponse   // For transcription streaming
 	ImageGenerationOutput *BifrostImageGenerationResponse // For image generation streaming
+	PassthroughOutput     *BifrostPassthroughResponse     // For passthrough streaming
 	FinishReason          *string                         // Finish reason
 	RawResponse           *string                         // Raw response
 	RawRequest            interface{}                     // Raw request

--- a/framework/streaming/accumulator.go
+++ b/framework/streaming/accumulator.go
@@ -401,6 +401,7 @@ func (a *Accumulator) ProcessStreamingResponse(ctx *schemas.BifrostContext, resu
 	isResponsesStreaming := requestType == schemas.ResponsesStreamRequest || requestType == schemas.WebSocketResponsesRequest
 	// Edit images/ Image variation requests will be added here
 	isImageStreaming := requestType == schemas.ImageGenerationStreamRequest || requestType == schemas.ImageEditStreamRequest
+	isPassthroughStreaming := requestType == schemas.PassthroughStreamRequest
 
 	if isChatStreaming {
 		// Handle text-based streaming with ordered accumulation
@@ -419,6 +420,9 @@ func (a *Accumulator) ProcessStreamingResponse(ctx *schemas.BifrostContext, resu
 	} else if isImageStreaming {
 		// Handle image streaming
 		return a.processImageStreamingResponse(ctx, result, bifrostErr)
+	} else if isPassthroughStreaming {
+		// Handle passthrough streaming with raw body accumulation
+		return a.processPassthroughStreamingResponse(ctx, result, bifrostErr)
 	}
 	return nil, fmt.Errorf("request type missing/invalid for accumulator: %s", requestType)
 }

--- a/framework/streaming/passthrough.go
+++ b/framework/streaming/passthrough.go
@@ -1,0 +1,122 @@
+package streaming
+
+import (
+	"fmt"
+	"maps"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// processPassthroughStreamingResponse handles accumulation of passthrough streaming responses.
+// Passthrough responses carry raw bytes, so we accumulate the body and metadata across chunks.
+func (a *Accumulator) processPassthroughStreamingResponse(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*ProcessedStreamResponse, error) {
+	// Extract accumulator ID from context
+	requestID, ok := getAccumulatorID(ctx)
+	if !ok || requestID == "" {
+		return nil, fmt.Errorf("accumulator-id not found in context or is empty")
+	}
+
+	_, provider, requestedModel, resolvedModel := bifrost.GetResponseFields(result, bifrostErr)
+	isFinalChunk := bifrost.IsFinalChunk(ctx)
+
+	// Get or create accumulator for this request
+	accumulator := a.getOrCreateStreamAccumulator(requestID)
+	accumulator.mu.Lock()
+	defer accumulator.mu.Unlock()
+
+	// Initialize headers map on first chunk
+	if accumulator.PassthroughHeaders == nil {
+		accumulator.PassthroughHeaders = make(map[string]string)
+	}
+
+	// Update status code if present in this chunk
+	if result != nil && result.PassthroughResponse != nil && result.PassthroughResponse.StatusCode != 0 {
+		accumulator.PassthroughStatusCode = result.PassthroughResponse.StatusCode
+	}
+
+	// Accumulate headers if they are present in this chunk (some providers may send headers in multiple chunks)
+	if result != nil && result.PassthroughResponse != nil && len(result.PassthroughResponse.Headers) > 0 {
+		maps.Copy(accumulator.PassthroughHeaders, result.PassthroughResponse.Headers)
+	}
+
+	// Accumulate the body bytes from this chunk
+	if result != nil && result.PassthroughResponse != nil && len(result.PassthroughResponse.Body) > 0 {
+		// Make a copy of the body bytes to avoid referencing pooled memory
+		bodyBytes := make([]byte, len(result.PassthroughResponse.Body))
+		copy(bodyBytes, result.PassthroughResponse.Body)
+		accumulator.PassthroughBody = append(accumulator.PassthroughBody, bodyBytes...)
+	}
+
+	// For non-final chunks, return early without processing
+	if !isFinalChunk {
+		return &ProcessedStreamResponse{
+			RequestID:      requestID,
+			StreamType:     StreamTypePassthrough,
+			RequestedModel: requestedModel,
+			ResolvedModel:  resolvedModel,
+			Provider:       provider,
+			Data:           nil,
+		}, nil
+	}
+
+	// Mark accumulator as complete
+	if !accumulator.IsComplete {
+		accumulator.IsComplete = true
+		accumulator.FinalTimestamp = time.Now()
+	}
+
+	// Build the accumulated passthrough response
+	passthroughResp := &schemas.BifrostPassthroughResponse{
+		StatusCode: accumulator.PassthroughStatusCode,
+		Headers:    accumulator.PassthroughHeaders,
+		Body:       accumulator.PassthroughBody,
+	}
+
+	// Build accumulated data with the passthrough response
+	data := &AccumulatedData{
+		RequestID:         requestID,
+		Model:             requestedModel,
+		Status:            "success",
+		Stream:            true,
+		StartTimestamp:    accumulator.StartTimestamp,
+		EndTimestamp:      accumulator.FinalTimestamp,
+		PassthroughOutput: passthroughResp,
+	}
+
+	// Set error status if there was an error
+	if bifrostErr != nil {
+		data.Status = "error"
+		data.ErrorDetails = bifrostErr
+	}
+
+	// Set latency and other metadata from final response
+	if result != nil {
+		extraFields := result.GetExtraFields()
+		if extraFields.Latency > 0 {
+			data.Latency = extraFields.Latency
+		}
+		if extraFields.RawResponse != nil {
+			rawResp := fmt.Sprintf("%v", extraFields.RawResponse)
+			data.RawResponse = &rawResp
+		}
+		// Populate extra fields on the passthrough response
+		passthroughResp.ExtraFields = *extraFields
+	}
+
+	var rawRequest interface{}
+	if result != nil && result.PassthroughResponse != nil && result.PassthroughResponse.ExtraFields.RawRequest != nil {
+		rawRequest = result.PassthroughResponse.ExtraFields.RawRequest
+	}
+
+	return &ProcessedStreamResponse{
+		RequestID:      requestID,
+		StreamType:     StreamTypePassthrough,
+		RequestedModel: requestedModel,
+		ResolvedModel:  resolvedModel,
+		Provider:       provider,
+		Data:           data,
+		RawRequest:     &rawRequest,
+	}, nil
+}

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -17,6 +17,7 @@ const (
 	StreamTypeImage         StreamType = "image.generation"
 	StreamTypeTranscription StreamType = "audio.transcription"
 	StreamTypeResponses     StreamType = "responses"
+	StreamTypePassthrough   StreamType = "passthrough"
 )
 
 // AccumulatedData contains the accumulated data for a stream
@@ -39,6 +40,7 @@ type AccumulatedData struct {
 	AudioOutput           *schemas.BifrostSpeechResponse
 	TranscriptionOutput   *schemas.BifrostTranscriptionResponse
 	ImageGenerationOutput *schemas.BifrostImageGenerationResponse
+	PassthroughOutput     *schemas.BifrostPassthroughResponse // For passthrough streaming
 	FinishReason          *string
 	LogProbs              *schemas.BifrostLogProbs
 	RawResponse           *string
@@ -139,6 +141,11 @@ type StreamAccumulator struct {
 
 	// TerminalErrorChunkIndex holds the reserved chunk index for the terminal error (-1 = unset); reused across plugin calls for correct dedup.
 	TerminalErrorChunkIndex int
+
+	// Passthrough streaming accumulation
+	PassthroughBody []byte // Accumulated body bytes from passthrough streaming chunks
+	PassthroughStatusCode int // Status code from passthrough response
+	PassthroughHeaders map[string]string // Headers from passthrough response
 
 	IsComplete     bool
 	FinalTimestamp time.Time

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -411,6 +411,7 @@ func (t *Tracer) ProcessStreamingChunk(traceID string, isFinalChunk bool, result
 		accResult.AudioOutput = processedResp.Data.AudioOutput
 		accResult.TranscriptionOutput = processedResp.Data.TranscriptionOutput
 		accResult.ImageGenerationOutput = processedResp.Data.ImageGenerationOutput
+		accResult.PassthroughOutput = processedResp.Data.PassthroughOutput
 		accResult.FinishReason = processedResp.Data.FinishReason
 		accResult.RawResponse = processedResp.Data.RawResponse
 

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -487,8 +487,7 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 	p.logger.Debug("PreLLMHook: request %s type=%q", requestID, req.RequestType)
 
 	// If request type is streaming we create a stream accumulator via the tracer
-	// Skip for passthrough streams — they carry raw bytes, not LLM response chunks
-	if bifrost.IsStreamRequestType(req.RequestType) && req.RequestType != schemas.PassthroughStreamRequest {
+	if bifrost.IsStreamRequestType(req.RequestType) {
 		tracer, traceID, err := bifrost.GetTracerFromContext(ctx)
 		if err == nil && tracer != nil && traceID != "" {
 			tracer.CreateStreamAccumulator(traceID, createdTimestamp)
@@ -805,7 +804,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 
 	var tracer schemas.Tracer
 	var traceID string
-	if bifrost.IsStreamRequestType(requestType) && requestType != schemas.PassthroughStreamRequest && requestType != schemas.RealtimeRequest {
+	if bifrost.IsStreamRequestType(requestType) && requestType != schemas.RealtimeRequest {
 		var err error
 		tracer, traceID, err = bifrost.GetTracerFromContext(ctx)
 		if err != nil {
@@ -819,7 +818,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	// and skip the write queue entirely. The accumulator work (ProcessStreamingChunk)
 	// is fast (mutex + append). Only final chunks, errors, and non-streaming
 	// responses need a DB write.
-	if bifrost.IsStreamRequestType(requestType) && requestType != schemas.PassthroughStreamRequest && requestType != schemas.RealtimeRequest && !isFinalChunk && result != nil && bifrostErr == nil {
+	if bifrost.IsStreamRequestType(requestType) && requestType != schemas.RealtimeRequest && !isFinalChunk && result != nil && bifrostErr == nil {
 		if tracer != nil && traceID != "" {
 			tracer.ProcessStreamingChunk(traceID, false, result, bifrostErr)
 		}
@@ -852,7 +851,6 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 
 		// For streaming errors, finalize and read accumulated chunks so logs retain pre-error stream metadata
 		if bifrost.IsStreamRequestType(requestType) &&
-			requestType != schemas.PassthroughStreamRequest &&
 			requestType != schemas.RealtimeRequest &&
 			tracer != nil &&
 			traceID != "" {
@@ -895,7 +893,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	// Path B: Streaming final chunk
 	if bifrost.IsStreamRequestType(requestType) && requestType != schemas.RealtimeRequest {
 		var streamResponse *streaming.ProcessedStreamResponse
-		if requestType != schemas.PassthroughStreamRequest && tracer != nil && traceID != "" {
+		if tracer != nil && traceID != "" {
 			accResult := tracer.ProcessStreamingChunk(traceID, isFinalChunk, result, bifrostErr)
 			if accResult != nil {
 				streamResponse = convertToProcessedStreamResponse(accResult, requestType)
@@ -930,9 +928,6 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			}
 			if contentLoggingEnabled && len(result.PassthroughResponse.Body) > 0 {
 				entry.PassthroughResponseBody = string(result.PassthroughResponse.Body)
-				if shouldStoreRaw {
-					entry.RawResponse = string(result.PassthroughResponse.Body)
-				}
 			}
 			// Flip status for passthrough error responses (4xx/5xx from provider)
 			if isPassthroughErrorResponse(result) {
@@ -941,7 +936,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		}
 		applyLargePayloadPreviewsToEntry(ctx, entry, contentLoggingEnabled)
 
-		if requestType != schemas.PassthroughStreamRequest && tracer != nil && traceID != "" {
+		if tracer != nil && traceID != "" {
 			tracer.CleanupStreamAccumulator(traceID)
 		}
 

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -388,6 +388,13 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 		entry.StopReason = streamResponse.Data.FinishReason
 	}
 
+	// Passthrough status code
+	if streamResponse.Data.PassthroughOutput != nil {
+		if params, ok := entry.ParamsParsed.(*schemas.PassthroughLogParams); ok {
+			params.StatusCode = streamResponse.Data.PassthroughOutput.StatusCode
+		}
+	}
+
 	if contentLoggingEnabled {
 		// Transcription output
 		if streamResponse.Data.TranscriptionOutput != nil {
@@ -408,6 +415,10 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 		// Responses output
 		if streamResponse.Data.OutputMessages != nil {
 			entry.ResponsesOutputParsed = streamResponse.Data.OutputMessages
+		}
+		// Passthrough output
+		if streamResponse.Data.PassthroughOutput != nil {
+			entry.PassthroughResponseBody = string(streamResponse.Data.PassthroughOutput.Body)
 		}
 		if shouldStoreRaw {
 			// Raw request

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -671,6 +671,8 @@ func convertToProcessedStreamResponse(result *schemas.StreamAccumulatorResult, r
 		streamType = streaming.StreamTypeTranscription
 	case schemas.ImageGenerationStreamRequest:
 		streamType = streaming.StreamTypeImage
+	case schemas.PassthroughStreamRequest:
+		streamType = streaming.StreamTypePassthrough
 	default:
 		streamType = streaming.StreamTypeChat
 	}
@@ -692,6 +694,7 @@ func convertToProcessedStreamResponse(result *schemas.StreamAccumulatorResult, r
 		AudioOutput:           result.AudioOutput,
 		TranscriptionOutput:   result.TranscriptionOutput,
 		ImageGenerationOutput: result.ImageGenerationOutput,
+		PassthroughOutput:     result.PassthroughOutput,
 		FinishReason:          result.FinishReason,
 		RawResponse:           result.RawResponse,
 	}


### PR DESCRIPTION
## Summary

Passthrough streaming responses were not being processed through the post-hook pipeline or accumulated by the tracer/logging system. This PR routes passthrough stream chunks through the shared `ProcessAndSendResponse` utility, removes the ad-hoc full-body capture buffers, and adds a dedicated accumulator path so that passthrough streams are logged and traced consistently with other stream types.

## Changes

- Replaced inline `select { case ch <- ... }` blocks and manual `postHookRunner`/`postHookSpanFinalizer` calls in the Anthropic, Azure, OpenAI, Gemini, and Vertex `PassthroughStream` implementations with calls to `providerUtils.ProcessAndSendResponse`, matching the pattern used by all other stream types.
- Removed the `maxStreamPassthroughCaptureBytes` cap and the associated full-body accumulation buffers from Gemini and Vertex providers. Body accumulation is now handled by the framework-level accumulator instead of per-provider ad-hoc logic.
- Removed `BodyTruncated` from `BifrostPassthroughResponse` since truncation is no longer performed.
- Added `BifrostPassthroughResponse` propagation in `BuildClientStreamChunk`, including raw-field stripping consistent with other response types.
- Added `PassthroughOutput` to `StreamAccumulatorResult` and `AccumulatedData`.
- Introduced `framework/streaming/passthrough.go` with `processPassthroughStreamingResponse`, which accumulates body bytes, status code, and headers across chunks and produces a `ProcessedStreamResponse` on the final chunk.
- Added `StreamTypePassthrough` constant and wired it into the accumulator's `ProcessStreamingResponse` dispatch.
- Removed the `PassthroughStreamRequest` exclusions from the logging plugin's `PreLLMHook` and `PostLLMHook` so passthrough streams now flow through the same tracer-backed accumulation and log-writing paths as other stream types.
- Passthrough status code and accumulated body are now applied to the log entry via `applyStreamingOutputToEntry`, replacing the previous direct read from the final chunk's `Body` field.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

- Send a passthrough streaming request through each affected provider (Anthropic, Azure, OpenAI, Gemini, Vertex) and verify:
  - All chunks are delivered to the client.
  - Post-hooks are invoked on each chunk and on stream completion.
  - The logging plugin records the full accumulated body and correct status code in the log entry.
  - Tracing spans are finalized correctly at stream end.
- Verify that cancelling the context mid-stream does not deadlock or panic (context cancellation is now handled inside `ProcessAndSendResponse`).

## Breaking changes

- [x] Yes
- [ ] No

`BodyTruncated` has been removed from `BifrostPassthroughResponse`. Any code reading this field will need to be updated. The full response body is now always accumulated without a size cap.

## Related issues

## Security considerations

Removal of the 1 MB capture cap means passthrough streaming responses of arbitrary size will be held in memory by the accumulator until the stream completes. Deployments handling very large passthrough streams should be aware of the increased memory footprint per in-flight request.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable