### PR TITLE
fix(server): hot-reload EnforceAuthOnInference setting in governance plugin

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -58,6 +58,7 @@ type BaseGovernancePlugin interface {
 	PostMCPHook(ctx *schemas.BifrostContext, resp *schemas.BifrostMCPResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostMCPResponse, *schemas.BifrostError, error)
 	Cleanup() error
 	GetGovernanceStore() GovernanceStore
+	UpdateEnforceAuthOnInference(enforceAuthOnInference bool)
 }
 
 // GovernancePlugin implements the main governance plugin with hierarchical budget system

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -697,6 +697,12 @@ func (s *BifrostHTTPServer) ReloadClientConfigFromConfigStore(ctx context.Contex
 	if s.AuthMiddleware != nil {
 		s.AuthMiddleware.UpdateWhitelistedRoutes(config.WhitelistedRoutes)
 	}
+	// Reloading governance plugin's enforce auth setting (fixes hot-reload for EnforceAuthOnInference)
+	if plugin, err := s.getGovernancePlugin(); err != nil {
+		logger.Warn("governance plugin not found during config reload, EnforceAuthOnInference not updated: %v", err)
+	} else {
+		plugin.UpdateEnforceAuthOnInference(config.EnforceAuthOnInference)
+	}
 	// Reloading config in bifrost client
 	if s.Client != nil {
 		account := lib.NewBaseAccount(s.Config)


### PR DESCRIPTION
Fixes #3132

## Summary

The "Enforce Virtual Keys on Inference" toggle in the WebUI Security settings did not take effect until the Docker container was restarted. The root cause was a stale pointer in the governance plugin after `ReloadClientConfigFromConfigStore` replaced the entire `ClientConfig` struct.

## Changes

- Added `UpdateEnforceAuthOnInference` to the `BaseGovernancePlugin` interface (already implemented by `GovernancePlugin`)
- Called `plugin.UpdateEnforceAuthOnInference(config.EnforceAuthOnInference)` in `ReloadClientConfigFromConfigStore` after config reload, mirroring the existing pattern for `AuthMiddleware.UpdateWhitelistedRoutes`

**Root cause**: The governance plugin was initialized with `IsVkMandatory: &s.Config.ClientConfig.EnforceAuthOnInference` — a pointer to the field. When `*s.Config.ClientConfig = *config` replaced the struct during hot-reload, this pointer continued pointing at the old struct's field, so the plugin never saw the updated value.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Start Bifrost with Docker, configure via WebUI
2. Go to Config → Security → "Enforce Virtual Keys on Inference"
3. Toggle the setting ON/OFF
4. Verify the change takes effect immediately without restarting the container

```sh
go test ./plugins/governance/... -count=1
go test ./transports/bifrost-http/server/... -count=1
```

## Screenshots/Recordings

N/A — no UI changes.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Fixes #3132

## Security considerations

No security implications. This fix ensures the existing security setting (Enforce Virtual Keys on Inference) works correctly during hot-reload as originally intended.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
