### PR TITLE
chore: updates helm index

### DIFF
--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.10
-appVersion: "1.5.0-prerelease4"
+version: 2.1.11
+appVersion: "1.5.0-prerelease7"
 keywords:
   - ai
   - gateway

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -8,6 +8,23 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 ## Changelog
 
+### 2.1.11
+
+- Added `description` and `default` fields to numerous properties that previously had neither, including `initialPoolSize`, `disableDbPingsInHealth`, `logRetentionDays`, `asyncJobResultTTL`, `mcpAgentDepth`, `mcpToolExecutionTimeout`, `hideDeletedVirtualKeysInFilters`, `mcpDisableAutoToolInject`, and MCP `toolManagerConfig` fields
+- Added `additionalProperties: false` to multiple objects (`bifrost.config`, `bifrost.pricing`, `proxyConfig`, `concurrencyConfig`, `providerConfig`, `credentialsSecret`, and auth provider configs) to reject unknown keys at validation time
+- Added three new `bifrost.client` fields:
+    - `allowPerRequestContentStorageOverride` — controls whether per-request headers can override content logging behavior
+    - `allowPerRequestRawOverride` — controls whether per-request headers can override raw provider request/response passthrough
+    - `mcpExternalBaseUrl` — public base URL for OAuth callbacks and discovery metadata behind a reverse proxy, supporting both string and env-var object forms
+- Added two new `bifrost.cluster.discovery` fields:
+    - `bindPort` — port to bind for cluster communication
+    - `dialTimeout` — timeout for discovery dial operations as a Go duration string
+- Changed `allowedOrigins` items from `oneOf` to `anyOf` and removed the redundant `not: { const: "*" }` constraint on the URI branch
+- Tightened the env-var pattern to require a valid identifier start character (`[A-Za-z_]`) for proxyConfig.url
+- Expanded `toolSyncInterval` to accept either a Go duration string (with a stricter regex) or a legacy integer (nanoseconds) for backward compatibility.
+- Marked `enforceGovernanceHeader` as deprecated in its description
+- Added `mdnsService` description for local network discovery
+
 ### 2.1.10
 
 - Added `bifrost.cluster.grpc` block for the cluster gRPC counter-sync transport (enterprise):
@@ -837,4 +854,3 @@ kubectl get secret bifrost -o yaml
 This project is licensed under the Apache 2.0 License - see the [LICENSE](../LICENSE) file for details.
 
 Built with ❤️ by [Maxim](https://github.com/maximhq)
-

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -249,6 +249,12 @@ false
 {{- if hasKey .Values.bifrost.client "disableContentLogging" }}
 {{- $_ := set $client "disable_content_logging" .Values.bifrost.client.disableContentLogging }}
 {{- end }}
+{{- if hasKey .Values.bifrost.client "allowPerRequestContentStorageOverride" }}
+{{- $_ := set $client "allow_per_request_content_storage_override" .Values.bifrost.client.allowPerRequestContentStorageOverride }}
+{{- end }}
+{{- if hasKey .Values.bifrost.client "allowPerRequestRawOverride" }}
+{{- $_ := set $client "allow_per_request_raw_override" .Values.bifrost.client.allowPerRequestRawOverride }}
+{{- end }}
 {{- if .Values.bifrost.client.logRetentionDays }}
 {{- $_ := set $client "log_retention_days" .Values.bifrost.client.logRetentionDays }}
 {{- end }}
@@ -302,6 +308,24 @@ false
 {{- end }}
 {{- if .Values.bifrost.client.routingChainMaxDepth }}
 {{- $_ := set $client "routing_chain_max_depth" .Values.bifrost.client.routingChainMaxDepth }}
+{{- end }}
+{{- if hasKey .Values.bifrost.client "mcpExternalBaseUrl" }}
+{{- $mcpExternalBaseUrl := .Values.bifrost.client.mcpExternalBaseUrl }}
+{{- if kindIs "map" $mcpExternalBaseUrl }}
+{{- $envVar := dict }}
+{{- if hasKey $mcpExternalBaseUrl "value" }}
+{{- $_ := set $envVar "value" $mcpExternalBaseUrl.value }}
+{{- end }}
+{{- if hasKey $mcpExternalBaseUrl "envVar" }}
+{{- $_ := set $envVar "env_var" $mcpExternalBaseUrl.envVar }}
+{{- end }}
+{{- if hasKey $mcpExternalBaseUrl "fromEnv" }}
+{{- $_ := set $envVar "from_env" $mcpExternalBaseUrl.fromEnv }}
+{{- end }}
+{{- $_ := set $client "mcp_external_base_url" $envVar }}
+{{- else }}
+{{- $_ := set $client "mcp_external_base_url" $mcpExternalBaseUrl }}
+{{- end }}
 {{- end }}
 {{- $_ := set $config "client" $client }}
 {{- end }}
@@ -557,6 +581,12 @@ false
 {{- end }}
 {{- if $serviceName }}
 {{- $_ := set $discovery "service_name" $serviceName }}
+{{- end }}
+{{- if .Values.bifrost.cluster.discovery.bindPort }}
+{{- $_ := set $discovery "bind_port" .Values.bifrost.cluster.discovery.bindPort }}
+{{- end }}
+{{- if .Values.bifrost.cluster.discovery.dialTimeout }}
+{{- $_ := set $discovery "dial_timeout" .Values.bifrost.cluster.discovery.dialTimeout }}
 {{- end }}
 {{- if .Values.bifrost.cluster.discovery.allowedAddressSpace }}
 {{- $_ := set $discovery "allowed_address_space" .Values.bifrost.cluster.discovery.allowedAddressSpace }}
@@ -952,7 +982,7 @@ false
 {{- $_ := set $mcpConfig "tool_manager_config" $tmConfig }}
 {{- end }}
 {{- end }}
-{{- if .Values.bifrost.mcp.toolSyncInterval }}
+{{- if hasKey .Values.bifrost.mcp "toolSyncInterval" }}
 {{- $_ := set $mcpConfig "tool_sync_interval" .Values.bifrost.mcp.toolSyncInterval }}
 {{- end }}
 {{- if .Values.bifrost.mcp.toolGroups }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -18,11 +18,7 @@
         },
         "pullPolicy": {
           "type": "string",
-          "enum": [
-            "Always",
-            "IfNotPresent",
-            "Never"
-          ],
+          "enum": ["Always", "IfNotPresent", "Never"],
           "description": "Image pull policy"
         },
         "tag": {
@@ -99,11 +95,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "ClusterIP",
-            "NodePort",
-            "LoadBalancer"
-          ]
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
         },
         "port": {
           "type": "integer",
@@ -145,11 +137,7 @@
                     },
                     "pathType": {
                       "type": "string",
-                      "enum": [
-                        "Prefix",
-                        "Exact",
-                        "ImplementationSpecific"
-                      ]
+                      "enum": ["Prefix", "Exact", "ImplementationSpecific"]
                     }
                   }
                 }
@@ -238,19 +226,11 @@
         },
         "logLevel": {
           "type": "string",
-          "enum": [
-            "debug",
-            "info",
-            "warn",
-            "error"
-          ]
+          "enum": ["debug", "info", "warn", "error"]
         },
         "logStyle": {
           "type": "string",
-          "enum": [
-            "json",
-            "text"
-          ]
+          "enum": ["json", "text"]
         },
         "encryptionKey": {
           "type": "string",
@@ -260,8 +240,13 @@
           "type": "object",
           "description": "Reference to an existing Kubernetes secret holding the encryption key. Takes precedence over `encryptionKey` when `name` is set.",
           "properties": {
-            "name": { "type": "string" },
-            "key": { "type": "string", "default": "encryption-key" }
+            "name": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string",
+              "default": "encryption-key"
+            }
           },
           "additionalProperties": false
         },
@@ -270,9 +255,11 @@
         },
         "client": {
           "type": "object",
+          "description": "Client configuration settings",
           "properties": {
             "dropExcessRequests": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether to drop excess requests when pool is full"
             },
             "initialPoolSize": {
               "type": "integer",
@@ -296,7 +283,8 @@
               }
             },
             "enableLogging": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Enable request/response logging"
             },
             "disableContentLogging": {
               "type": "boolean"
@@ -312,42 +300,61 @@
               "type": "boolean"
             },
             "allowDirectKeys": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Allow provider keys"
             },
             "maxRequestBodySizeMb": {
               "type": "integer",
-              "minimum": 1
+              "minimum": 1,
+              "description": "Maximum request body size in MB"
             },
             "compat": {
               "type": "object",
-              "additionalProperties": false,
+              "description": "Compat plugin configuration for request type conversion, parameter dropping, and parameter value conversion",
               "properties": {
-                "convertTextToChat": { "type": "boolean" },
-                "convertChatToResponses": { "type": "boolean" },
-                "shouldDropParams": { "type": "boolean" },
-                "shouldConvertParams": { "type": "boolean" }
-              }
+                "convertTextToChat": {
+                  "type": "boolean",
+                  "description": "Convert text completion requests to chat for models that only support chat"
+                },
+                "convertChatToResponses": {
+                  "type": "boolean",
+                  "description": "Convert chat completion requests to responses for models that only support responses"
+                },
+                "shouldDropParams": {
+                  "type": "boolean",
+                  "description": "Drop unsupported parameters based on model catalog allowlist"
+                },
+                "shouldConvertParams": {
+                  "type": "boolean",
+                  "description": "Converts model parameter values that are not supported by the model."
+                }
+              },
+              "additionalProperties": false
             },
             "prometheusLabels": {
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "description": "Labels to use for Prometheus metrics"
             },
             "headerFilterConfig": {
               "type": "object",
+              "description": "Global header filtering configuration for x-bf-eh-* headers forwarded to LLM providers",
               "properties": {
                 "allowlist": {
                   "type": "array",
                   "items": {
                     "type": "string"
-                  }
+                  },
+                  "description": "If non-empty, only these headers (from x-bf-eh-* prefix) are allowed to be forwarded"
                 },
                 "denylist": {
                   "type": "array",
                   "items": {
                     "type": "string"
-                  }
+                  },
+                  "description": "Headers to always block from being forwarded"
                 }
               }
             },
@@ -512,12 +519,14 @@
             },
             "toolGroups": {
               "type": "array",
+              "description": "Enterprise MCP tool groups with optional governance associations",
               "items": {
                 "$ref": "#/$defs/mcpToolGroupConfig"
               }
             }
           },
-          "additionalProperties": false
+          "additionalProperties": false,
+          "description": "Model Context Protocol configuration"
         },
         "plugins": {
           "type": "object",
@@ -533,7 +542,9 @@
                   "properties": {
                     "custom_labels": {
                       "type": "array",
-                      "items": { "type": "string" },
+                      "items": {
+                        "type": "string"
+                      },
                       "description": "Custom labels to add to all metrics"
                     },
                     "push_gateway": {
@@ -605,7 +616,9 @@
                     },
                     "required_headers": {
                       "type": "array",
-                      "items": { "type": "string" },
+                      "items": {
+                        "type": "string"
+                      },
                       "description": "Headers that must be present in requests"
                     },
                     "is_enterprise": {
@@ -657,18 +670,14 @@
                   {
                     "properties": {
                       "config": {
-                        "required": [
-                          "api_key"
-                        ]
+                        "required": ["api_key"]
                       }
                     }
                   },
                   {
                     "properties": {
                       "secretRef": {
-                        "required": [
-                          "name"
-                        ]
+                        "required": ["name"]
                       }
                     }
                   }
@@ -773,9 +782,7 @@
               "then": {
                 "properties": {
                   "config": {
-                    "required": [
-                      "dimension"
-                    ]
+                    "required": ["dimension"]
                   }
                 }
               }
@@ -800,19 +807,12 @@
                     },
                     "trace_type": {
                       "type": "string",
-                      "enum": [
-                        "genai_extension",
-                        "vercel",
-                        "open_inference"
-                      ],
+                      "enum": ["genai_extension", "vercel", "open_inference"],
                       "description": "Type of trace to use for the OTEL collector"
                     },
                     "protocol": {
                       "type": "string",
-                      "enum": [
-                        "http",
-                        "grpc"
-                      ],
+                      "enum": ["http", "grpc"],
                       "description": "Protocol to use for the OTEL collector"
                     },
                     "metrics_enabled": {
@@ -833,7 +833,9 @@
                     },
                     "headers": {
                       "type": "object",
-                      "additionalProperties": { "type": "string" },
+                      "additionalProperties": {
+                        "type": "string"
+                      },
                       "description": "Custom headers for the collector (supports env.VAR_NAME prefix)"
                     },
                     "tls_ca_cert": {
@@ -868,11 +870,7 @@
               "then": {
                 "properties": {
                   "config": {
-                    "required": [
-                      "collector_url",
-                      "trace_type",
-                      "protocol"
-                    ]
+                    "required": ["collector_url", "trace_type", "protocol"]
                   }
                 }
               }
@@ -941,10 +939,7 @@
                     "description": "Position within placement group. Lower = earlier execution"
                   }
                 },
-                "required": [
-                  "name",
-                  "enabled"
-                ]
+                "required": ["name", "enabled"]
               }
             }
           }
@@ -994,34 +989,21 @@
                 "allOf": [
                   {
                     "not": {
-                      "required": [
-                        "virtual_key_id",
-                        "provider_config_id"
-                      ]
+                      "required": ["virtual_key_id", "provider_config_id"]
                     }
                   },
                   {
                     "not": {
-                      "required": [
-                        "virtual_key_id",
-                        "team_id"
-                      ]
+                      "required": ["virtual_key_id", "team_id"]
                     }
                   },
                   {
                     "not": {
-                      "required": [
-                        "provider_config_id",
-                        "team_id"
-                      ]
+                      "required": ["provider_config_id", "team_id"]
                     }
                   }
                 ],
-                "required": [
-                  "id",
-                  "max_limit",
-                  "reset_duration"
-                ]
+                "required": ["id", "max_limit", "reset_duration"]
               }
             },
             "rateLimits": {
@@ -1071,9 +1053,7 @@
                     "description": "Last time request counter was reset"
                   }
                 },
-                "required": [
-                  "id"
-                ],
+                "required": ["id"],
                 "additionalProperties": false
               }
             },
@@ -1095,10 +1075,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "id",
-                  "name"
-                ]
+                "required": ["id", "name"]
               }
             },
             "teams": {
@@ -1134,10 +1111,7 @@
                     "type": "object"
                   }
                 },
-                "required": [
-                  "id",
-                  "name"
-                ]
+                "required": ["id", "name"]
               }
             },
             "businessUnits": {
@@ -1173,10 +1147,7 @@
                     }
                   }
                 },
-                "required": [
-                  "id",
-                  "name"
-                ]
+                "required": ["id", "name"]
               }
             },
             "virtualKeys": {
@@ -1238,10 +1209,7 @@
                     }
                   }
                 },
-                "required": [
-                  "id",
-                  "name"
-                ]
+                "required": ["id", "name"]
               }
             },
             "routingRules": {
@@ -1349,11 +1317,21 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "id": { "type": "string" },
-                  "model_name": { "type": "string" },
-                  "provider": { "type": "string" },
-                  "budget_id": { "type": "string" },
-                  "rate_limit_id": { "type": "string" }
+                  "id": {
+                    "type": "string"
+                  },
+                  "model_name": {
+                    "type": "string"
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "budget_id": {
+                    "type": "string"
+                  },
+                  "rate_limit_id": {
+                    "type": "string"
+                  }
                 },
                 "required": ["id", "model_name"]
               }
@@ -1364,12 +1342,25 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "name": { "type": "string", "description": "Provider name" },
-                  "budget_id": { "type": "string" },
-                  "rate_limit_id": { "type": "string" },
-                  "send_back_raw_request": { "type": "boolean" },
-                  "send_back_raw_response": { "type": "boolean" },
-                  "store_raw_request_response": { "type": "boolean" }
+                  "name": {
+                    "type": "string",
+                    "description": "Provider name"
+                  },
+                  "budget_id": {
+                    "type": "string"
+                  },
+                  "rate_limit_id": {
+                    "type": "string"
+                  },
+                  "send_back_raw_request": {
+                    "type": "boolean"
+                  },
+                  "send_back_raw_response": {
+                    "type": "boolean"
+                  },
+                  "store_raw_request_response": {
+                    "type": "boolean"
+                  }
                 },
                 "required": ["name"]
               }
@@ -1380,32 +1371,72 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "id": { "type": "string", "description": "Unique pricing override ID" },
-                  "name": { "type": "string", "description": "Human-readable name for this override" },
+                  "id": {
+                    "type": "string",
+                    "description": "Unique pricing override ID"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Human-readable name for this override"
+                  },
                   "scope_kind": {
                     "type": "string",
-                    "enum": ["global", "provider", "provider_key", "virtual_key", "virtual_key_provider", "virtual_key_provider_key"],
+                    "enum": [
+                      "global",
+                      "provider",
+                      "provider_key",
+                      "virtual_key",
+                      "virtual_key_provider",
+                      "virtual_key_provider_key"
+                    ],
                     "description": "Scope level for this override"
                   },
-                  "virtual_key_id": { "type": "string", "description": "Virtual key ID (required for virtual_key* scopes)" },
-                  "provider_id": { "type": "string", "description": "Provider name (required for provider* scopes; field key remains provider_id for compatibility)" },
-                  "provider_key_name": { "type": "string", "description": "Provider key name alias. Resolved to internal provider key ID at config load time." },
+                  "virtual_key_id": {
+                    "type": "string",
+                    "description": "Virtual key ID (required for virtual_key* scopes)"
+                  },
+                  "provider_id": {
+                    "type": "string",
+                    "description": "Provider name (required for provider* scopes; field key remains provider_id for compatibility)"
+                  },
+                  "provider_key_name": {
+                    "type": "string",
+                    "description": "Provider key name alias. Resolved to internal provider key ID at config load time."
+                  },
                   "match_type": {
                     "type": "string",
                     "enum": ["exact", "wildcard"],
                     "description": "How the pattern is matched against model names"
                   },
-                  "pattern": { "type": "string", "description": "Model name pattern to match" },
+                  "pattern": {
+                    "type": "string",
+                    "description": "Model name pattern to match"
+                  },
                   "request_types": {
                     "type": "array",
                     "minItems": 1,
-                    "items": { "type": "string" },
+                    "items": {
+                      "type": "string"
+                    },
                     "description": "Request types this override applies to"
                   },
-                  "pricing_patch": { "type": "string", "description": "JSON-encoded pricing fields to override" },
-                  "config_hash": { "type": "string", "description": "Internal hash for change detection (auto-managed)" }
+                  "pricing_patch": {
+                    "type": "string",
+                    "description": "JSON-encoded pricing fields to override"
+                  },
+                  "config_hash": {
+                    "type": "string",
+                    "description": "Internal hash for change detection (auto-managed)"
+                  }
                 },
-                "required": ["id", "name", "scope_kind", "match_type", "pattern", "request_types"]
+                "required": [
+                  "id",
+                  "name",
+                  "scope_kind",
+                  "match_type",
+                  "pattern",
+                  "request_types"
+                ]
               }
             }
           },
@@ -1413,42 +1444,52 @@
         },
         "cluster": {
           "type": "object",
+          "description": "Cluster mode configuration",
           "properties": {
             "enabled": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether cluster mode is enabled"
             },
             "peers": {
               "type": "array",
+              "description": "List of peer addresses",
               "items": {
-                "type": "string"
+                "type": "string",
+                "description": "Peer address in host:port format"
               }
             },
             "region": {
               "type": "string",
-              "description": "Region for cluster deployment"
+              "description": "Region label for cluster deployment (runtime default: unknown)"
             },
             "gossip": {
               "type": "object",
+              "description": "Gossip protocol configuration",
               "properties": {
                 "port": {
                   "type": "integer",
                   "minimum": 1,
-                  "maximum": 65535
+                  "maximum": 65535,
+                  "description": "Port for gossip communication"
                 },
                 "config": {
                   "type": "object",
+                  "description": "Gossip protocol settings",
                   "properties": {
                     "timeoutSeconds": {
                       "type": "integer",
-                      "minimum": 1
+                      "minimum": 1,
+                      "description": "Timeout for operations in seconds"
                     },
                     "successThreshold": {
                       "type": "integer",
-                      "minimum": 1
+                      "minimum": 1,
+                      "description": "Number of successful probes required"
                     },
                     "failureThreshold": {
                       "type": "integer",
-                      "minimum": 1
+                      "minimum": 1,
+                      "description": "Number of failed probes before marking as failed"
                     }
                   },
                   "required": [
@@ -1458,10 +1499,7 @@
                   ]
                 }
               },
-              "required": [
-                "port",
-                "config"
-              ]
+              "required": ["port", "config"]
             },
             "grpc": {
               "type": "object",
@@ -1482,9 +1520,11 @@
             },
             "discovery": {
               "type": "object",
+              "description": "Auto-discovery configuration for cluster nodes",
               "properties": {
                 "enabled": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "description": "Whether auto-discovery is enabled"
                 },
                 "type": {
                   "type": "string",
@@ -1507,19 +1547,23 @@
                   "type": "array",
                   "items": {
                     "type": "string"
-                  }
+                  },
+                  "description": "CIDR notation for allowed address spaces (e.g., ['10.0.0.0/8', '192.168.0.0/16'])"
                 },
                 "k8sNamespace": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Kubernetes namespace for service discovery"
                 },
                 "k8sLabelSelector": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Kubernetes label selector for filtering pods"
                 },
                 "dnsNames": {
                   "type": "array",
                   "items": {
                     "type": "string"
-                  }
+                  },
+                  "description": "DNS names to resolve for node discovery"
                 },
                 "udpBroadcastPort": {
                   "type": "integer",
@@ -1528,13 +1572,15 @@
                   "description": "UDP broadcast port (0 means not configured)"
                 },
                 "consulAddress": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Consul server address for service discovery"
                 },
                 "etcdEndpoints": {
                   "type": "array",
                   "items": {
                     "type": "string"
-                  }
+                  },
+                  "description": "Etcd endpoints for service discovery"
                 },
                 "mdnsService": {
                   "type": "string"
@@ -1560,9 +1606,7 @@
                 }
               },
               "then": {
-                "required": [
-                  "type"
-                ]
+                "required": ["type"]
               }
             }
           },
@@ -1574,28 +1618,25 @@
             }
           },
           "then": {
-            "required": [
-              "gossip"
-            ]
+            "required": ["gossip"]
           }
         },
         "scim": {
           "type": "object",
+          "description": "SAML/SCIM (System for Cross-domain Identity Management) configuration",
           "properties": {
             "enabled": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Whether SAML/SCIM authentication is enabled"
             },
             "provider": {
               "type": "string",
-              "enum": [
-                "",
-                "okta",
-                "entra"
-              ],
+              "enum": ["", "okta", "entra"],
               "description": "SCIM/SSO provider type (empty when not configured)"
             },
             "config": {
-              "type": "object"
+              "type": "object",
+              "description": "Provider-specific configuration"
             }
           },
           "allOf": [
@@ -1609,31 +1650,34 @@
                     "const": "okta"
                   }
                 },
-                "required": [
-                  "enabled",
-                  "provider"
-                ]
+                "required": ["enabled", "provider"]
               },
               "then": {
                 "properties": {
                   "config": {
                     "type": "object",
+                    "description": "Okta JWT authentication configuration",
                     "properties": {
                       "issuerUrl": {
                         "type": "string",
-                        "format": "uri"
+                        "format": "uri",
+                        "description": "Okta issuer URL (e.g., https://your-domain.okta.com/oauth2/default)"
                       },
                       "clientId": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Okta application client ID"
                       },
                       "clientSecret": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Okta client secret"
                       },
                       "apiToken": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Okta API token for Admin API access"
                       },
                       "audience": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "JWT audience for validation (optional)"
                       },
                       "userIdField": {
                         "type": "string"
@@ -1665,35 +1709,38 @@
                     "const": "entra"
                   }
                 },
-                "required": [
-                  "enabled",
-                  "provider"
-                ]
+                "required": ["enabled", "provider"]
               },
               "then": {
                 "properties": {
                   "config": {
                     "type": "object",
+                    "description": "Microsoft Entra ID (formerly Azure AD) JWT authentication configuration",
                     "properties": {
                       "tenantId": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Azure tenant ID or 'common' for multi-tenant applications"
                       },
                       "clientId": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Application (client) ID from Azure portal"
                       },
                       "clientSecret": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Client secret (optional, required for token revocation)"
                       },
                       "cloud": {
                         "type": "string",
                         "enum": ["commercial", "gcc-high", "dod"]
                       },
                       "audience": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "JWT audience for validation (default: clientId)"
                       },
                       "appIdUri": {
                         "type": "string",
-                        "format": "uri"
+                        "format": "uri",
+                        "description": "App ID URI for v1.0 tokens (e.g., api://{clientId})"
                       },
                       "userIdField": {
                         "type": "string"
@@ -1705,10 +1752,7 @@
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "tenantId",
-                      "clientId"
-                    ]
+                    "required": ["tenantId", "clientId"]
                   }
                 }
               }
@@ -1731,26 +1775,33 @@
         },
         "guardrails": {
           "type": "object",
+          "description": "Guardrails configuration for content moderation and policy enforcement",
           "properties": {
             "rules": {
               "type": "array",
+              "description": "List of guardrail rules",
               "items": {
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Unique identifier for the rule"
                   },
                   "name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of the guardrail rule"
                   },
                   "description": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Description of what the rule does"
                   },
                   "enabled": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Whether this rule is enabled"
                   },
                   "cel_expression": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "CEL (Common Expression Language) expression for rule evaluation"
                   },
                   "query": {
                     "description": "Visual rule builder state for the management UI (react-querybuilder). Omitted unless exported from the dashboard. Not evaluated at runtime (cel_expression is).",
@@ -1770,7 +1821,8 @@
                             "type": "array",
                             "items": {
                               "type": "object"
-                            }
+                            },
+                            "description": "Leaf rules and/or nested combinator+rules groups from the query builder."
                           }
                         },
                         "additionalProperties": true
@@ -1779,26 +1831,26 @@
                   },
                   "apply_to": {
                     "type": "string",
-                    "enum": [
-                      "input",
-                      "output",
-                      "both"
-                    ]
+                    "enum": ["input", "output", "both"],
+                    "description": "When to apply the guardrail (input, output, or both)"
                   },
                   "sampling_rate": {
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 100
+                    "maximum": 100,
+                    "description": "Percentage of requests to apply this rule to (0-100)"
                   },
                   "timeout": {
                     "type": "integer",
-                    "minimum": 0
+                    "minimum": 0,
+                    "description": "Timeout in milliseconds for rule execution"
                   },
                   "provider_config_ids": {
                     "type": "array",
                     "items": {
                       "type": "integer"
-                    }
+                    },
+                    "description": "IDs of provider configurations to use with this rule"
                   }
                 },
                 "required": [
@@ -1813,20 +1865,25 @@
             },
             "providers": {
               "type": "array",
+              "description": "List of guardrail provider configurations",
               "items": {
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "description": "Unique identifier for the provider config"
                   },
                   "provider_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of the guardrail provider (e.g., 'bedrock', 'azure')"
                   },
                   "policy_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Name of the specific policy to use"
                   },
                   "enabled": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Whether this provider config is enabled"
                   },
                   "timeout": {
                     "type": "integer",
@@ -1834,15 +1891,11 @@
                     "description": "Timeout in milliseconds for provider execution"
                   },
                   "config": {
-                    "type": "object"
+                    "type": "object",
+                    "description": "Provider-specific configuration"
                   }
                 },
-                "required": [
-                  "id",
-                  "provider_name",
-                  "policy_name",
-                  "enabled"
-                ],
+                "required": ["id", "provider_name", "policy_name", "enabled"],
                 "additionalProperties": false
               }
             }
@@ -1855,21 +1908,35 @@
           "items": {
             "type": "object",
             "properties": {
-              "name": { "type": "string" },
-              "description": { "type": "string" },
-              "is_active": { "type": "boolean" },
+              "name": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "is_active": {
+                "type": "boolean"
+              },
               "tags": {
                 "type": "array",
-                "items": { "type": "string" }
+                "items": {
+                  "type": "string"
+                }
               },
               "budgets": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "id": { "type": "string" },
-                    "max_limit": { "type": "number" },
-                    "reset_duration": { "type": "string" }
+                    "id": {
+                      "type": "string"
+                    },
+                    "max_limit": {
+                      "type": "number"
+                    },
+                    "reset_duration": {
+                      "type": "string"
+                    }
                   },
                   "required": ["id", "max_limit", "reset_duration"],
                   "additionalProperties": false
@@ -1878,11 +1945,21 @@
               "rate_limit": {
                 "type": "object",
                 "properties": {
-                  "id": { "type": "string" },
-                  "token_max_limit": { "type": "integer" },
-                  "token_reset_duration": { "type": "string" },
-                  "request_max_limit": { "type": "integer" },
-                  "request_reset_duration": { "type": "string" }
+                  "id": {
+                    "type": "string"
+                  },
+                  "token_max_limit": {
+                    "type": "integer"
+                  },
+                  "token_reset_duration": {
+                    "type": "string"
+                  },
+                  "request_max_limit": {
+                    "type": "integer"
+                  },
+                  "request_reset_duration": {
+                    "type": "string"
+                  }
                 },
                 "required": ["id"],
                 "additionalProperties": false
@@ -1892,20 +1969,32 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "provider_name": { "type": "string" },
-                    "all_models_allowed": { "type": "boolean" },
+                    "provider_name": {
+                      "type": "string"
+                    },
+                    "all_models_allowed": {
+                      "type": "boolean"
+                    },
                     "allowed_models": {
                       "type": "array",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "budgets": {
                       "type": "array",
                       "items": {
                         "type": "object",
                         "properties": {
-                          "id": { "type": "string" },
-                          "max_limit": { "type": "number" },
-                          "reset_duration": { "type": "string" }
+                          "id": {
+                            "type": "string"
+                          },
+                          "max_limit": {
+                            "type": "number"
+                          },
+                          "reset_duration": {
+                            "type": "string"
+                          }
                         },
                         "required": ["id", "max_limit", "reset_duration"],
                         "additionalProperties": false
@@ -1914,11 +2003,21 @@
                     "rate_limit": {
                       "type": "object",
                       "properties": {
-                        "id": { "type": "string" },
-                        "token_max_limit": { "type": "integer" },
-                        "token_reset_duration": { "type": "string" },
-                        "request_max_limit": { "type": "integer" },
-                        "request_reset_duration": { "type": "string" }
+                        "id": {
+                          "type": "string"
+                        },
+                        "token_max_limit": {
+                          "type": "integer"
+                        },
+                        "token_reset_duration": {
+                          "type": "string"
+                        },
+                        "request_max_limit": {
+                          "type": "integer"
+                        },
+                        "request_reset_duration": {
+                          "type": "string"
+                        }
                       },
                       "additionalProperties": false
                     }
@@ -1932,7 +2031,9 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "tool_group_id": { "type": "integer" }
+                    "tool_group_id": {
+                      "type": "integer"
+                    }
                   },
                   "required": ["tool_group_id"],
                   "additionalProperties": false
@@ -1943,7 +2044,9 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "mcp_server_id": { "type": "string" }
+                    "mcp_server_id": {
+                      "type": "string"
+                    }
                   },
                   "required": ["mcp_server_id"],
                   "additionalProperties": false
@@ -1954,8 +2057,12 @@
                 "items": {
                   "type": "object",
                   "properties": {
-                    "mcp_client_id": { "type": "string" },
-                    "tool_name": { "type": "string" },
+                    "mcp_client_id": {
+                      "type": "string"
+                    },
+                    "tool_name": {
+                      "type": "string"
+                    },
                     "action": {
                       "type": "string",
                       "enum": ["include", "exclude"]
@@ -2018,7 +2125,7 @@
         },
         "websocket": {
           "type": "object",
-          "description": "Optional tuning for the WebSocket gateway (Responses API WebSocket Mode, Realtime API)",
+          "description": "Optional tuning for the WebSocket gateway (Responses API WebSocket Mode, Realtime API). WebSocket is always enabled; these fields override the high defaults.",
           "properties": {
             "maxConnectionsPerUser": {
               "type": "integer",
@@ -2071,10 +2178,7 @@
       "properties": {
         "mode": {
           "type": "string",
-          "enum": [
-            "sqlite",
-            "postgres"
-          ]
+          "enum": ["sqlite", "postgres"]
         },
         "persistence": {
           "type": "object",
@@ -2087,11 +2191,7 @@
             },
             "accessMode": {
               "type": "string",
-              "enum": [
-                "ReadWriteOnce",
-                "ReadWriteMany",
-                "ReadOnlyMany"
-              ]
+              "enum": ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"]
             },
             "size": {
               "type": "string"
@@ -2109,11 +2209,7 @@
             },
             "type": {
               "type": "string",
-              "enum": [
-                "",
-                "sqlite",
-                "postgres"
-              ]
+              "enum": ["", "sqlite", "postgres"]
             },
             "maxIdleConns": {
               "type": "integer",
@@ -2133,11 +2229,7 @@
             },
             "type": {
               "type": "string",
-              "enum": [
-                "",
-                "sqlite",
-                "postgres"
-              ]
+              "enum": ["", "sqlite", "postgres"]
             },
             "maxIdleConns": {
               "type": "integer",
@@ -2214,7 +2306,9 @@
               },
               "if": {
                 "properties": {
-                  "enabled": { "const": true }
+                  "enabled": {
+                    "const": true
+                  }
                 },
                 "required": ["enabled"]
               },
@@ -2281,13 +2375,7 @@
             }
           },
           "then": {
-            "required": [
-              "host",
-              "port",
-              "user",
-              "database",
-              "sslMode"
-            ]
+            "required": ["host", "port", "user", "database", "sslMode"]
           }
         },
         "image": {
@@ -2301,11 +2389,7 @@
             },
             "pullPolicy": {
               "type": "string",
-              "enum": [
-                "Always",
-                "IfNotPresent",
-                "Never"
-              ]
+              "enum": ["Always", "IfNotPresent", "Never"]
             }
           }
         },
@@ -2360,13 +2444,7 @@
         },
         "type": {
           "type": "string",
-          "enum": [
-            "none",
-            "weaviate",
-            "redis",
-            "qdrant",
-            "pinecone"
-          ]
+          "enum": ["none", "weaviate", "redis", "qdrant", "pinecone"]
         },
         "weaviate": {
           "type": "object",
@@ -2382,10 +2460,7 @@
                 },
                 "scheme": {
                   "type": "string",
-                  "enum": [
-                    "http",
-                    "https"
-                  ]
+                  "enum": ["http", "https"]
                 },
                 "host": {
                   "type": "string",
@@ -2427,10 +2502,7 @@
                 }
               },
               "then": {
-                "required": [
-                  "scheme",
-                  "host"
-                ]
+                "required": ["scheme", "host"]
               }
             },
             "replicas": {
@@ -2567,9 +2639,7 @@
                 }
               },
               "then": {
-                "required": [
-                  "host"
-                ]
+                "required": ["host"]
               }
             },
             "image": {
@@ -2633,9 +2703,7 @@
                 }
               },
               "then": {
-                "required": [
-                  "host"
-                ]
+                "required": ["host"]
               }
             },
             "image": {
@@ -2687,9 +2755,7 @@
                 }
               },
               "then": {
-                "required": [
-                  "indexHost"
-                ]
+                "required": ["indexHost"]
               }
             }
           }
@@ -2711,9 +2777,7 @@
             "type": "object"
           }
         },
-        "required": [
-          "name"
-        ]
+        "required": ["name"]
       }
     },
     "envFrom": {
@@ -2732,18 +2796,23 @@
   "$defs": {
     "authConfig": {
       "type": "object",
+      "description": "Authentication configuration. Deprecated: Use governance.auth_config instead.",
       "properties": {
         "adminUsername": {
-          "type": "string"
+          "type": "string",
+          "description": "Admin username"
         },
         "adminPassword": {
-          "type": "string"
+          "type": "string",
+          "description": "Admin password"
         },
         "isEnabled": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether authentication is enabled"
         },
         "disableAuthOnInference": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Whether authentication is disabled on inference"
         },
         "existingSecret": {
           "type": "string"
@@ -2801,15 +2870,23 @@
           "type": "object",
           "description": "Custom provider configuration",
           "properties": {
-            "is_key_less": { "type": "boolean" },
-            "base_provider_type": { "type": "string" },
+            "is_key_less": {
+              "type": "boolean"
+            },
+            "base_provider_type": {
+              "type": "string"
+            },
             "allowed_requests": {
               "type": "object",
-              "additionalProperties": { "type": "boolean" }
+              "additionalProperties": {
+                "type": "boolean"
+              }
             },
             "request_path_overrides": {
               "type": "object",
-              "additionalProperties": { "type": "string" }
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           },
           "required": ["base_provider_type"]
@@ -2820,16 +2897,19 @@
           "items": {
             "type": "object",
             "properties": {
-              "model_pattern": { "type": "string" },
-              "match_type": { "type": "string", "enum": ["exact", "wildcard", "regex"] }
+              "model_pattern": {
+                "type": "string"
+              },
+              "match_type": {
+                "type": "string",
+                "enum": ["exact", "wildcard", "regex"]
+              }
             },
             "required": ["model_pattern", "match_type"]
           }
         }
       },
-      "required": [
-        "keys"
-      ]
+      "required": ["keys"]
     },
     "providerKey": {
       "type": "object",
@@ -2874,10 +2954,7 @@
               "description": "Azure API version"
             }
           },
-          "required": [
-            "endpoint",
-            "api_version"
-          ],
+          "required": ["endpoint", "api_version"],
           "additionalProperties": false
         },
         "vertex_key_config": {
@@ -2907,10 +2984,7 @@
               "description": "Model to deployment mappings"
             }
           },
-          "required": [
-            "project_id",
-            "region"
-          ],
+          "required": ["project_id", "region"],
           "additionalProperties": false
         },
         "bedrock_key_config": {
@@ -2986,9 +3060,7 @@
               "additionalProperties": false
             }
           },
-          "required": [
-            "region"
-          ],
+          "required": ["region"],
           "additionalProperties": false
         },
         "vllm_key_config": {
@@ -3003,25 +3075,27 @@
               "description": "Exact model name served on this VLLM instance"
             }
           },
-          "required": [
-            "url",
-            "model_name"
-          ],
+          "required": ["url", "model_name"],
           "additionalProperties": false
         }
       },
-      "required":[
-        "name",
-        "weight"
-      ],
+      "required": ["name", "weight"],
       "oneOf": [
         {
           "not": {
             "anyOf": [
-              { "required": ["azure_key_config"] },
-              { "required": ["vertex_key_config"] },
-              { "required": ["bedrock_key_config"] },
-              { "required": ["vllm_key_config"] }
+              {
+                "required": ["azure_key_config"]
+              },
+              {
+                "required": ["vertex_key_config"]
+              },
+              {
+                "required": ["bedrock_key_config"]
+              },
+              {
+                "required": ["vllm_key_config"]
+              }
             ]
           }
         },
@@ -3029,9 +3103,15 @@
           "required": ["azure_key_config"],
           "not": {
             "anyOf": [
-              { "required": ["vertex_key_config"] },
-              { "required": ["bedrock_key_config"] },
-              { "required": ["vllm_key_config"] }
+              {
+                "required": ["vertex_key_config"]
+              },
+              {
+                "required": ["bedrock_key_config"]
+              },
+              {
+                "required": ["vllm_key_config"]
+              }
             ]
           }
         },
@@ -3039,9 +3119,15 @@
           "required": ["vertex_key_config"],
           "not": {
             "anyOf": [
-              { "required": ["azure_key_config"] },
-              { "required": ["bedrock_key_config"] },
-              { "required": ["vllm_key_config"] }
+              {
+                "required": ["azure_key_config"]
+              },
+              {
+                "required": ["bedrock_key_config"]
+              },
+              {
+                "required": ["vllm_key_config"]
+              }
             ]
           }
         },
@@ -3049,9 +3135,15 @@
           "required": ["bedrock_key_config"],
           "not": {
             "anyOf": [
-              { "required": ["azure_key_config"] },
-              { "required": ["vertex_key_config"] },
-              { "required": ["vllm_key_config"] }
+              {
+                "required": ["azure_key_config"]
+              },
+              {
+                "required": ["vertex_key_config"]
+              },
+              {
+                "required": ["vllm_key_config"]
+              }
             ]
           }
         },
@@ -3059,9 +3151,15 @@
           "required": ["vllm_key_config"],
           "not": {
             "anyOf": [
-              { "required": ["azure_key_config"] },
-              { "required": ["vertex_key_config"] },
-              { "required": ["bedrock_key_config"] }
+              {
+                "required": ["azure_key_config"]
+              },
+              {
+                "required": ["vertex_key_config"]
+              },
+              {
+                "required": ["bedrock_key_config"]
+              }
             ]
           }
         }
@@ -3072,21 +3170,25 @@
       "properties": {
         "base_url": {
           "type": "string",
-          "format": "uri"
+          "format": "uri",
+          "description": "Base URL for the provider (optional, required for Ollama)"
         },
         "extra_headers": {
           "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "Additional headers to send with requests"
         },
         "default_request_timeout_in_seconds": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 1,
+          "description": "Default request timeout in seconds"
         },
         "max_retries": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "description": "Maximum number of retries"
         },
         "retry_backoff_initial_ms": {
           "type": "integer",
@@ -3102,13 +3204,13 @@
         },
         "ca_cert_pem": {
           "type": "string",
-          "description": "PEM-encoded CA certificate to trust for provider endpoint connections. Supports inline PEM or env.VAR_NAME."
+          "description": "PEM-encoded CA certificate to trust for provider endpoint connections (e.g. self-signed or internal CA). Supports inline PEM or env.VAR_NAME."
         },
         "stream_idle_timeout_in_seconds": {
           "type": "integer",
           "minimum": 5,
           "maximum": 3600,
-          "description": "Idle timeout per stream chunk in seconds (default: 60)"
+          "description": "Idle timeout per stream chunk in seconds. If no data is received for this many seconds, the stream is closed. Default: 60."
         },
         "max_conns_per_host": {
           "type": "integer",
@@ -3118,7 +3220,7 @@
         },
         "enforce_http2": {
           "type": "boolean",
-          "description": "Force HTTP/2 on provider connections (relevant for net/http-based providers like Bedrock)."
+          "description": "Force HTTP/2 on provider connections (relevant for Bedrock and other net/http-based providers)"
         },
         "beta_header_overrides": {
           "type": "object",
@@ -3132,29 +3234,25 @@
       "properties": {
         "concurrency": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 1,
+          "description": "Number of concurrent requests"
         },
         "buffer_size": {
           "type": "integer",
-          "minimum": 1
+          "minimum": 1,
+          "description": "Buffer size for requests"
         }
       },
-      "required": [
-        "concurrency",
-        "buffer_size"
-      ]
+      "required": ["concurrency", "buffer_size"]
     },
     "proxyConfig": {
       "type": "object",
+      "description": "Proxy configuration for provider connections",
       "properties": {
         "type": {
           "type": "string",
-          "enum": [
-            "none",
-            "http",
-            "socks5",
-            "environment"
-          ]
+          "enum": ["none", "http", "socks5", "environment"],
+          "description": "Type of proxy to use"
         },
         "url": {
           "anyOf": [
@@ -3170,7 +3268,7 @@
               }
             }
           ],
-          "description": "URL of the proxy server (supports env.VAR_NAME)"
+          "description": "URL of the proxy server (supports env.VAR_NAME or a literal URI)"
         },
         "username": {
           "type": "string",
@@ -3182,12 +3280,10 @@
         },
         "ca_cert_pem": {
           "type": "string",
-          "description": "PEM-encoded CA certificate to trust for TLS connections through the proxy (supports env.VAR_NAME)"
+          "description": "PEM-encoded CA certificate to trust for TLS connections through the proxy (for SSL-intercepting proxies, supports env.VAR_NAME)"
         }
       },
-      "required": [
-        "type"
-      ]
+      "required": ["type"]
     },
     "mcpClientConfig": {
       "type": "object",
@@ -3205,12 +3301,7 @@
         },
         "connectionType": {
           "type": "string",
-          "enum": [
-            "stdio",
-            "websocket",
-            "http",
-            "sse"
-          ]
+          "enum": ["stdio", "websocket", "http", "sse"]
         },
         "connectionString": {
           "type": "string",
@@ -3220,8 +3311,13 @@
           "type": "object",
           "description": "Reference to an existing Kubernetes secret holding the MCP connection_string. Chart injects BIFROST_MCP_<NAME>_CONNECTION_STRING and rewrites connection_string in config.json.",
           "properties": {
-            "name": { "type": "string" },
-            "connectionStringKey": { "type": "string", "default": "connection-string" }
+            "name": {
+              "type": "string"
+            },
+            "connectionStringKey": {
+              "type": "string",
+              "default": "connection-string"
+            }
           },
           "additionalProperties": false
         },
@@ -3236,7 +3332,9 @@
         },
         "headers": {
           "type": "object",
-          "additionalProperties": { "type": "string" },
+          "additionalProperties": {
+            "type": "string"
+          },
           "description": "Headers for auth"
         },
         "stdioConfig": {
@@ -3258,9 +3356,7 @@
               }
             }
           },
-          "required": [
-            "command"
-          ]
+          "required": ["command"]
         },
         "websocketConfig": {
           "type": "object",
@@ -3270,9 +3366,7 @@
               "format": "uri"
             }
           },
-          "required": [
-            "url"
-          ]
+          "required": ["url"]
         },
         "httpConfig": {
           "type": "object",
@@ -3282,18 +3376,20 @@
               "format": "uri"
             }
           },
-          "required": [
-            "url"
-          ]
+          "required": ["url"]
         },
         "toolsToExecute": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Include-only list of tools to execute"
         },
         "toolsToAutoExecute": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Auto-execute list of tools"
         },
         "toolSyncInterval": {
@@ -3314,7 +3410,9 @@
         },
         "allowedExtraHeaders": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Allowlist of request-level headers that callers may forward to this MCP server. Use ['*'] to allow all headers."
         },
         "allowOnAllVirtualKeys": {
@@ -3323,10 +3421,7 @@
           "default": false
         }
       },
-      "required": [
-        "name",
-        "connectionType"
-      ],
+      "required": ["name", "connectionType"],
       "allOf": [
         {
           "if": {
@@ -3337,9 +3432,7 @@
             }
           },
           "then": {
-            "required": [
-              "stdioConfig"
-            ]
+            "required": ["stdioConfig"]
           }
         },
         {
@@ -3351,9 +3444,7 @@
             }
           },
           "then": {
-            "required": [
-              "websocketConfig"
-            ]
+            "required": ["websocketConfig"]
           }
         },
         {
@@ -3365,9 +3456,7 @@
             }
           },
           "then": {
-            "required": [
-              "httpConfig"
-            ]
+            "required": ["httpConfig"]
           }
         },
         {
@@ -3379,9 +3468,7 @@
             }
           },
           "then": {
-            "required": [
-              "connectionString"
-            ]
+            "required": ["connectionString"]
           }
         }
       ]
@@ -3390,29 +3477,36 @@
       "type": "object",
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Tool group name"
         },
         "description": {
-          "type": "string"
+          "type": "string",
+          "description": "Tool group description"
         },
         "enabled": {
           "type": "boolean",
+          "description": "Whether tool group is enabled",
           "default": true
         },
         "tools": {
           "type": "array",
           "minItems": 1,
+          "description": "MCP tools included in this group",
           "items": {
             "type": "object",
             "properties": {
               "mcpClientId": {
-                "type": "string"
+                "type": "string",
+                "description": "MCP client ID"
               },
               "mcpClientName": {
-                "type": "string"
+                "type": "string",
+                "description": "MCP client name (resolved to client_id at startup)"
               },
               "toolNames": {
                 "type": "array",
+                "description": "Tool names to allow. Empty means all tools from this MCP client.",
                 "items": {
                   "type": "string"
                 }
@@ -3431,27 +3525,39 @@
         },
         "virtualKeyIds": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "teamIds": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "customerIds": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "userIds": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "providerNames": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "apiKeyIds": {
           "type": "array",
-          "items": { "type": "integer" }
+          "items": {
+            "type": "integer"
+          }
         }
       },
       "required": ["name", "tools"],
@@ -3637,9 +3743,18 @@
                         "items": {
                           "type": "object",
                           "properties": {
-                            "bucket_name": { "type": "string", "description": "S3 bucket name" },
-                            "prefix": { "type": "string", "description": "S3 key prefix for batch files" },
-                            "is_default": { "type": "boolean", "description": "Whether this is the default bucket for batch operations" }
+                            "bucket_name": {
+                              "type": "string",
+                              "description": "S3 bucket name"
+                            },
+                            "prefix": {
+                              "type": "string",
+                              "description": "S3 key prefix for batch files"
+                            },
+                            "is_default": {
+                              "type": "boolean",
+                              "description": "Whether this is the default bucket for batch operations"
+                            }
                           },
                           "required": ["bucket_name"],
                           "additionalProperties": false
@@ -3669,10 +3784,18 @@
               {
                 "not": {
                   "anyOf": [
-                    { "required": ["azure_key_config"] },
-                    { "required": ["vertex_key_config"] },
-                    { "required": ["bedrock_key_config"] },
-                    { "required": ["vllm_key_config"] }
+                    {
+                      "required": ["azure_key_config"]
+                    },
+                    {
+                      "required": ["vertex_key_config"]
+                    },
+                    {
+                      "required": ["bedrock_key_config"]
+                    },
+                    {
+                      "required": ["vllm_key_config"]
+                    }
                   ]
                 }
               },
@@ -3680,9 +3803,15 @@
                 "required": ["azure_key_config"],
                 "not": {
                   "anyOf": [
-                    { "required": ["vertex_key_config"] },
-                    { "required": ["bedrock_key_config"] },
-                    { "required": ["vllm_key_config"] }
+                    {
+                      "required": ["vertex_key_config"]
+                    },
+                    {
+                      "required": ["bedrock_key_config"]
+                    },
+                    {
+                      "required": ["vllm_key_config"]
+                    }
                   ]
                 }
               },
@@ -3690,9 +3819,15 @@
                 "required": ["vertex_key_config"],
                 "not": {
                   "anyOf": [
-                    { "required": ["azure_key_config"] },
-                    { "required": ["bedrock_key_config"] },
-                    { "required": ["vllm_key_config"] }
+                    {
+                      "required": ["azure_key_config"]
+                    },
+                    {
+                      "required": ["bedrock_key_config"]
+                    },
+                    {
+                      "required": ["vllm_key_config"]
+                    }
                   ]
                 }
               },
@@ -3700,9 +3835,15 @@
                 "required": ["bedrock_key_config"],
                 "not": {
                   "anyOf": [
-                    { "required": ["azure_key_config"] },
-                    { "required": ["vertex_key_config"] },
-                    { "required": ["vllm_key_config"] }
+                    {
+                      "required": ["azure_key_config"]
+                    },
+                    {
+                      "required": ["vertex_key_config"]
+                    },
+                    {
+                      "required": ["vllm_key_config"]
+                    }
                   ]
                 }
               },
@@ -3710,9 +3851,15 @@
                 "required": ["vllm_key_config"],
                 "not": {
                   "anyOf": [
-                    { "required": ["azure_key_config"] },
-                    { "required": ["vertex_key_config"] },
-                    { "required": ["bedrock_key_config"] }
+                    {
+                      "required": ["azure_key_config"]
+                    },
+                    {
+                      "required": ["vertex_key_config"]
+                    },
+                    {
+                      "required": ["bedrock_key_config"]
+                    }
                   ]
                 }
               }
@@ -3720,9 +3867,7 @@
           }
         }
       },
-      "required": [
-        "provider"
-      ],
+      "required": ["provider"],
       "additionalProperties": false
     }
   }

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -263,41 +263,58 @@
             },
             "initialPoolSize": {
               "type": "integer",
-              "minimum": 1
+              "minimum": 1,
+              "description": "Initial size of the connection pool",
+              "default": 300
             },
             "allowedOrigins": {
               "type": "array",
-              "description": "CORS allowed origins (supports \"*\" or URI strings)",
               "items": {
-                "oneOf": [
+                "anyOf": [
                   {
                     "type": "string",
                     "const": "*"
                   },
                   {
                     "type": "string",
-                    "format": "uri",
-                    "not": { "const": "*" }
+                    "format": "uri"
                   }
                 ]
-              }
+              },
+              "description": "CORS allowed origins (supports \"*\" or URI strings)"
             },
             "enableLogging": {
               "type": "boolean",
               "description": "Enable request/response logging"
             },
             "disableContentLogging": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Disable logging of sensitive content (inputs, outputs, embeddings, etc.)"
+            },
+            "allowPerRequestContentStorageOverride": {
+              "type": "boolean",
+              "description": "Allow individual requests to override content storage via the x-bf-disable-content-logging header or context key, and to opt in to raw-byte persistence in logs via x-bf-store-raw-request-response. When false (default), the global disable_content_logging setting is authoritative and per-request storage overrides are ignored. Does not control sending raw bytes back to callers.",
+              "default": false
+            },
+            "allowPerRequestRawOverride": {
+              "type": "boolean",
+              "description": "Allow individual requests to send raw provider request/response bytes back to the caller via the x-bf-send-back-raw-request and x-bf-send-back-raw-response headers. When false (default), the provider-level send_back_raw_request/response settings are authoritative and per-request overrides are ignored. Does not affect raw-byte persistence in logs.",
+              "default": false
             },
             "disableDbPingsInHealth": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Disable DB pings in health check",
+              "default": false
             },
             "logRetentionDays": {
               "type": "integer",
-              "minimum": 1
+              "minimum": 1,
+              "description": "Number of days to retain logs",
+              "default": 365
             },
             "enforceGovernanceHeader": {
-              "type": "boolean"
+              "type": "boolean",
+              "description": "Deprecated: use enforceAuthOnInference"
             },
             "allowDirectKeys": {
               "type": "boolean",
@@ -356,7 +373,8 @@
                   },
                   "description": "Headers to always block from being forwarded"
                 }
-              }
+              },
+              "additionalProperties": false
             },
             "enforceAuthOnInference": {
               "type": "boolean",
@@ -376,12 +394,14 @@
             "mcpAgentDepth": {
               "type": "integer",
               "minimum": 1,
-              "description": "DEPRECATED: Maximum depth for MCP agent mode tool execution. Use bifrost.mcp.toolManagerConfig.maxAgentDepth."
+              "description": "DEPRECATED: Maximum depth for MCP agent mode tool execution. Use bifrost.mcp.toolManagerConfig.maxAgentDepth.",
+              "default": 10
             },
             "mcpToolExecutionTimeout": {
               "type": "integer",
               "minimum": 1,
-              "description": "DEPRECATED: Timeout for individual MCP tool execution in seconds. Use bifrost.mcp.toolManagerConfig.toolExecutionTimeout."
+              "description": "DEPRECATED: Timeout for individual MCP tool execution in seconds. Use bifrost.mcp.toolManagerConfig.toolExecutionTimeout.",
+              "default": 30
             },
             "mcpCodeModeBindingLevel": {
               "type": "string",
@@ -395,43 +415,69 @@
             },
             "asyncJobResultTTL": {
               "type": "integer",
-              "minimum": 1,
-              "description": "Default TTL for async job results in seconds"
+              "description": "Default TTL for async job results in seconds (default: 3600 = 1 hour)",
+              "default": 3600,
+              "minimum": 1
             },
             "requiredHeaders": {
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "description": "Headers that must be present on every request"
+              "description": "Headers that must be present on every request. Requests missing any of these headers are rejected with 400. Case-insensitive matching."
             },
             "loggingHeaders": {
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "description": "Headers to capture in log metadata"
+              "description": "Headers to capture in log metadata. Values are extracted from incoming requests and stored in the metadata field of log entries."
             },
             "whitelistedRoutes": {
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "description": "Routes that bypass auth middleware"
+              "description": "Routes that bypass auth middleware. Requests to these exact paths skip authentication checks."
             },
             "hideDeletedVirtualKeysInFilters": {
               "type": "boolean",
-              "description": "When true, deleted virtual keys are omitted from logs and MCP logs filter data"
+              "description": "When true, deleted virtual keys are omitted from logs and MCP logs filter data.",
+              "default": false
             },
             "mcpDisableAutoToolInject": {
               "type": "boolean",
-              "description": "DEPRECATED: When true, MCP tools are not automatically injected into requests. Use bifrost.mcp.toolManagerConfig.disableAutoToolInject."
+              "description": "DEPRECATED: When true, MCP tools are not automatically injected into requests. Use bifrost.mcp.toolManagerConfig.disableAutoToolInject.",
+              "default": false
             },
             "routingChainMaxDepth": {
               "type": "integer",
               "minimum": 1,
               "description": "Maximum depth for routing rule chain evaluation",
               "default": 10
+            },
+            "mcpExternalBaseUrl": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "string"
+                    },
+                    "envVar": {
+                      "type": "string"
+                    },
+                    "fromEnv": {
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Public base URL for OAuth callbacks and discovery metadata when Bifrost runs behind a reverse proxy (e.g. \"https://api.example.com\"). Supports env var syntax: \"env.MY_VAR\"."
             }
           },
           "additionalProperties": false
@@ -444,15 +490,20 @@
               "properties": {
                 "pricingUrl": {
                   "type": "string",
-                  "description": "Custom pricing URL (optional, can be empty)"
+                  "description": "Custom pricing URL (optional, can be empty)",
+                  "format": "uri"
                 },
                 "pricingSyncInterval": {
                   "type": "integer",
+                  "description": "Pricing sync interval in seconds. Default is 24 hours. Minimum is 3600 seconds (1 hour).",
+                  "default": 86400,
                   "minimum": 3600
                 }
-              }
+              },
+              "additionalProperties": false
             }
-          }
+          },
+          "additionalProperties": false
         },
         "providers": {
           "type": "object",
@@ -488,18 +539,23 @@
               "type": "array",
               "items": {
                 "$ref": "#/$defs/mcpClientConfig"
-              }
+              },
+              "description": "MCP client configurations"
             },
             "toolManagerConfig": {
               "type": "object",
               "properties": {
                 "toolExecutionTimeout": {
                   "type": "integer",
-                  "minimum": 1
+                  "description": "Tool execution timeout in seconds",
+                  "minimum": 1,
+                  "default": 30
                 },
                 "maxAgentDepth": {
                   "type": "integer",
-                  "minimum": 1
+                  "description": "Max agent depth",
+                  "minimum": 1,
+                  "default": 10
                 },
                 "codeModeBindingLevel": {
                   "type": "string",
@@ -508,14 +564,22 @@
                 },
                 "disableAutoToolInject": {
                   "type": "boolean",
-                  "description": "When true, MCP tools are not automatically injected into requests. Tools are only included when explicitly specified.",
+                  "description": "When true, MCP tools are not automatically injected into requests. Tools are only included when explicitly specified via request context filters or headers, such as x-bf-mcp-include-tools or x-bf-mcp-include-clients.",
                   "default": false
                 }
               }
             },
             "toolSyncInterval": {
-              "type": "string",
-              "description": "Global default interval for syncing tools from MCP servers (Go duration string, e.g. '10m', '1h', '0s' to use runtime default)"
+              "description": "Global default interval for syncing tools from MCP servers (Go duration string, e.g. '10m', '1h', '0s' to use runtime default). Legacy numeric nanoseconds are also supported for backward compatibility.",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "pattern": "^-?(?:\\d+(?:\\.\\d+)?(?:ns|us|\u00b5s|ms|s|m|h))+$"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
             },
             "toolGroups": {
               "type": "array",
@@ -738,7 +802,7 @@
                       "oneOf": [
                         {
                           "type": "string",
-                          "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$"
+                          "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$"
                         },
                         {
                           "type": "integer",
@@ -1496,10 +1560,12 @@
                     "timeoutSeconds",
                     "successThreshold",
                     "failureThreshold"
-                  ]
+                  ],
+                  "additionalProperties": false
                 }
               },
-              "required": ["port", "config"]
+              "required": ["port", "config"],
+              "additionalProperties": false
             },
             "grpc": {
               "type": "object",
@@ -1543,6 +1609,16 @@
                   "type": "string",
                   "description": "Service name for discovery backends (required for consul/etcd/udp; used as default for mdns)"
                 },
+                "bindPort": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "Port to bind for cluster communication"
+                },
+                "dialTimeout": {
+                  "type": "string",
+                  "description": "Timeout for discovery dial operations as a Go duration string (e.g. '5s', '1m')"
+                },
                 "allowedAddressSpace": {
                   "type": "array",
                   "items": {
@@ -1583,7 +1659,8 @@
                   "description": "Etcd endpoints for service discovery"
                 },
                 "mdnsService": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "mDNS service name for local network discovery"
                 }
               },
               "allOf": [
@@ -1639,6 +1716,8 @@
               "description": "Provider-specific configuration"
             }
           },
+          "required": ["enabled"],
+          "additionalProperties": false,
           "allOf": [
             {
               "if": {
@@ -1680,13 +1759,19 @@
                         "description": "JWT audience for validation (optional)"
                       },
                       "userIdField": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "JWT claim field for user ID (default: 'sub')",
+                        "default": "sub"
                       },
                       "teamIdsField": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "JWT claim field for team IDs (default: 'groups')",
+                        "default": "groups"
                       },
                       "rolesField": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "JWT claim field for roles (default: 'roles')",
+                        "default": "roles"
                       }
                     },
                     "required": [
@@ -1694,7 +1779,8 @@
                       "clientId",
                       "clientSecret",
                       "apiToken"
-                    ]
+                    ],
+                    "additionalProperties": false
                   }
                 }
               }
@@ -1731,7 +1817,9 @@
                       },
                       "cloud": {
                         "type": "string",
-                        "enum": ["commercial", "gcc-high", "dod"]
+                        "enum": ["commercial", "gcc-high", "dod"],
+                        "default": "commercial",
+                        "description": "Cloud environment: 'commercial' (default), 'gcc-high' for US Government GCC High, or 'dod' for Department of Defense"
                       },
                       "audience": {
                         "type": "string",
@@ -1743,16 +1831,23 @@
                         "description": "App ID URI for v1.0 tokens (e.g., api://{clientId})"
                       },
                       "userIdField": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "JWT claim field for user ID (default: 'oid')",
+                        "default": "oid"
                       },
                       "teamIdsField": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "JWT claim field for team IDs (default: 'groups')",
+                        "default": "groups"
                       },
                       "rolesField": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "JWT claim field for roles (default: 'roles')",
+                        "default": "roles"
                       }
                     },
-                    "required": ["tenantId", "clientId"]
+                    "required": ["tenantId", "clientId"],
+                    "additionalProperties": false
                   }
                 }
               }
@@ -2167,9 +2262,11 @@
                   "description": "Maximum lifetime of a connection in seconds",
                   "default": 7200
                 }
-              }
+              },
+              "additionalProperties": false
             }
-          }
+          },
+          "additionalProperties": false
         }
       }
     },
@@ -2480,7 +2577,7 @@
                 },
                 "timeout": {
                   "type": "string",
-                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
                   "description": "Timeout for Weaviate operations (e.g., '5s')"
                 },
                 "className": {
@@ -2596,32 +2693,32 @@
                 },
                 "connMaxLifetime": {
                   "type": "string",
-                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
                   "description": "Connection maximum lifetime (e.g., '30m')"
                 },
                 "connMaxIdleTime": {
                   "type": "string",
-                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
                   "description": "Connection maximum idle time (e.g., '5m')"
                 },
                 "dialTimeout": {
                   "type": "string",
-                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
                   "description": "Timeout for socket connection (e.g., '5s')"
                 },
                 "readTimeout": {
                   "type": "string",
-                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
                   "description": "Timeout for socket reads (e.g., '3s')"
                 },
                 "writeTimeout": {
                   "type": "string",
-                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
                   "description": "Timeout for socket writes (e.g., '3s')"
                 },
                 "contextTimeout": {
                   "type": "string",
-                  "pattern": "^[0-9]+(ns|us|µs|ms|s|m|h)$",
+                  "pattern": "^[0-9]+(ns|us|\u00b5s|ms|s|m|h)$",
                   "description": "Timeout for Redis/Valkey operations (e.g., '10s')"
                 },
                 "existingSecret": {
@@ -2823,7 +2920,8 @@
         "passwordKey": {
           "type": "string"
         }
-      }
+      },
+      "additionalProperties": false
     },
     "pluginBase": {
       "type": "object",
@@ -3192,11 +3290,13 @@
         },
         "retry_backoff_initial_ms": {
           "type": "integer",
-          "minimum": 100
+          "minimum": 100,
+          "description": "Initial retry backoff in milliseconds"
         },
         "retry_backoff_max_ms": {
           "type": "integer",
-          "minimum": 100
+          "minimum": 100,
+          "description": "Maximum retry backoff in milliseconds"
         },
         "insecure_skip_verify": {
           "type": "boolean",
@@ -3224,10 +3324,13 @@
         },
         "beta_header_overrides": {
           "type": "object",
-          "additionalProperties": { "type": "boolean" },
-          "description": "Override default Anthropic beta header support per provider. Keys are header prefixes, values are true (supported) or false (unsupported)."
+          "additionalProperties": {
+            "type": "boolean"
+          },
+          "description": "Override default Anthropic beta header support per provider. Keys are header prefixes (e.g. 'redact-thinking-'), values are true (supported) or false (unsupported). Headers not listed use the built-in defaults."
         }
-      }
+      },
+      "additionalProperties": false
     },
     "concurrencyConfig": {
       "type": "object",
@@ -3243,7 +3346,8 @@
           "description": "Buffer size for requests"
         }
       },
-      "required": ["concurrency", "buffer_size"]
+      "required": ["concurrency", "buffer_size"],
+      "additionalProperties": false
     },
     "proxyConfig": {
       "type": "object",
@@ -3255,17 +3359,15 @@
           "description": "Type of proxy to use"
         },
         "url": {
-          "anyOf": [
+          "oneOf": [
             {
               "type": "string",
-              "pattern": "^env\\.[A-Za-z0-9_]+$"
+              "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$"
             },
             {
               "type": "string",
               "format": "uri",
-              "not": {
-                "pattern": "^env\\.[A-Za-z0-9_]+$"
-              }
+              "not": { "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$" }
             }
           ],
           "description": "URL of the proxy server (supports env.VAR_NAME or a literal URI)"
@@ -3283,7 +3385,8 @@
           "description": "PEM-encoded CA certificate to trust for TLS connections through the proxy (for SSL-intercepting proxies, supports env.VAR_NAME)"
         }
       },
-      "required": ["type"]
+      "required": ["type"],
+      "additionalProperties": false
     },
     "mcpClientConfig": {
       "type": "object",
@@ -3512,7 +3615,7 @@
                 }
               }
             },
-            "anyOf": [
+            "oneOf": [
               {
                 "required": ["mcpClientId"]
               },

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -2,6 +2,48 @@ apiVersion: v1
 entries:
   bifrost:
     - apiVersion: v2
+      appVersion: 1.5.0-prerelease7
+      created: "2026-04-29T18:30:00.000000+00:00"
+      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+      digest: ""
+      home: https://www.getmaxim.ai/bifrost
+      icon: https://www.getbifrost.ai/favicon.png
+      keywords:
+        - ai
+        - gateway
+        - llm
+      maintainers:
+        - email: support@getbifrost.ai
+          name: Bifrost Team
+      name: bifrost
+      sources:
+        - https://github.com/maximhq/bifrost
+      type: application
+      urls:
+        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.11.tgz
+      version: 2.1.11
+    - apiVersion: v2
+      appVersion: 1.5.0-prerelease4
+      created: "2026-04-29T18:30:00.000000+00:00"
+      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+      digest: ""
+      home: https://www.getmaxim.ai/bifrost
+      icon: https://www.getbifrost.ai/favicon.png
+      keywords:
+        - ai
+        - gateway
+        - llm
+      maintainers:
+        - email: support@getbifrost.ai
+          name: Bifrost Team
+      name: bifrost
+      sources:
+        - https://github.com/maximhq/bifrost
+      type: application
+      urls:
+        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.10.tgz
+      version: 2.1.10
+    - apiVersion: v2
       appVersion: 1.5.0-prerelease4
       created: "2026-04-28T18:30:00.000000+00:00"
       description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers


### PR DESCRIPTION
## Summary

Bumps the Bifrost Helm chart from version `2.1.10` to `2.1.11` and updates the chart index and README changelog to reflect the new release.

## Changes

- Bumped chart version to `2.1.11` and `appVersion` to `1.5.0-prerelease7` in `Chart.yaml`
- Added `2.1.11` entry to `helm-charts/index.yaml` pointing to the new `.tgz` artifact
- Documented the following changes in the README changelog:
    - Added `description` and `default` fields to previously undocumented properties (`initialPoolSize`, `disableDbPingsInHealth`, `logRetentionDays`, `asyncJobResultTTL`, `mcpAgentDepth`, `mcpToolExecutionTimeout`, `hideDeletedVirtualKeysInFilters`, `mcpDisableAutoToolInject`, MCP `toolManagerConfig` fields)
    - Added `additionalProperties: false` to several objects (`bifrost.config`, `bifrost.pricing`, `proxyConfig`, `concurrencyConfig`, `providerConfig`, `credentialsSecret`, and auth provider configs) to enforce strict schema validation
    - Added three new `bifrost.client` fields: `allowPerRequestContentStorageOverride`, `allowPerRequestRawOverride`, and `mcpExternalBaseUrl`
    - Added two new `bifrost.cluster.discovery` fields: `bindPort` and `dialTimeout`
    - Changed `allowedOrigins` items from `oneOf` to `anyOf` and removed the redundant `not: { const: "*" }` constraint on the URI branch
    - Tightened the env-var pattern for `proxyConfig.url` to require a valid identifier start character
    - Expanded `toolSyncInterval` to accept either a Go duration string or a legacy integer for backward compatibility
    - Marked `enforceGovernanceHeader` as deprecated
    - Added `mdnsService` description for local network discovery

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
helm repo update
helm search repo bifrost --versions | grep 2.1.11
helm install bifrost <repo>/bifrost --version 2.1.11 --dry-run
```

Verify the chart renders without errors and the version reported matches `2.1.11`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The addition of `additionalProperties: false` to schema objects tightens validation and reduces the risk of unintended configuration keys being silently accepted.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable