### PR TITLE
fix: websocket responses working and improve websocket responses logging and cost tracking

### DIFF
--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -1154,7 +1154,7 @@ func (mc *ModelCatalog) getBasePricing(model, provider string, requestType schem
 		}
 
 		// Lookup in chat if responses not found
-		if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.RealtimeRequest {
+		if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.WebSocketResponsesRequest || requestType == schemas.RealtimeRequest {
 			mc.logger.Debug("secondary lookup failed, trying vertex provider for the same model in chat completion")
 			pricing, ok = mc.pricingData[makeKey(model, "vertex", normalizeRequestType(schemas.ChatCompletionRequest))]
 			if ok {
@@ -1174,7 +1174,7 @@ func (mc *ModelCatalog) getBasePricing(model, provider string, requestType schem
 			}
 
 			// Lookup in chat if responses not found
-			if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.RealtimeRequest {
+			if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.WebSocketResponsesRequest || requestType == schemas.RealtimeRequest {
 				mc.logger.Debug("secondary lookup failed, trying vertex provider for the same model in chat completion")
 				pricing, ok = mc.pricingData[makeKey(modelWithoutProvider, "vertex", normalizeRequestType(schemas.ChatCompletionRequest))]
 				if ok {
@@ -1194,7 +1194,7 @@ func (mc *ModelCatalog) getBasePricing(model, provider string, requestType schem
 			}
 
 			// Lookup in chat if responses not found
-			if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.RealtimeRequest {
+			if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.WebSocketResponsesRequest || requestType == schemas.RealtimeRequest {
 				mc.logger.Debug("secondary lookup failed, trying chat provider for the same model in chat completion")
 				pricing, ok = mc.pricingData[makeKey("anthropic."+model, provider, normalizeRequestType(schemas.ChatCompletionRequest))]
 				if ok {
@@ -1205,7 +1205,7 @@ func (mc *ModelCatalog) getBasePricing(model, provider string, requestType schem
 	}
 
 	// Lookup in chat if responses not found
-	if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.RealtimeRequest {
+	if requestType == schemas.ResponsesRequest || requestType == schemas.ResponsesStreamRequest || requestType == schemas.WebSocketResponsesRequest || requestType == schemas.RealtimeRequest {
 		mc.logger.Debug("primary lookup failed, trying chat provider for the same model in chat completion")
 		pricing, ok = mc.pricingData[makeKey(model, provider, normalizeRequestType(schemas.ChatCompletionRequest))]
 		if ok {

--- a/framework/modelcatalog/pricing_test.go
+++ b/framework/modelcatalog/pricing_test.go
@@ -1436,6 +1436,29 @@ func TestCalculateCost_StreamRequestTypeNormalized(t *testing.T) {
 	assert.InDelta(t, 0.0125, cost, 1e-12)
 }
 
+func TestCalculateCost_WebSocketResponsesFallsBackToChatPricing(t *testing.T) {
+	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
+	})
+
+	resp := &schemas.BifrostResponse{
+		ResponsesStreamResponse: &schemas.BifrostResponsesStreamResponse{
+			Response: &schemas.BifrostResponsesResponse{
+				Usage: &schemas.ResponsesResponseUsage{InputTokens: 1000, OutputTokens: 500, TotalTokens: 1500},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            schemas.WebSocketResponsesRequest,
+				Provider:               schemas.OpenAI,
+				OriginalModelRequested: "gpt-4o",
+				ResolvedModelUsed:      "gpt-4o",
+			},
+		},
+	}
+
+	cost := mc.CalculateCost(resp, nil)
+	assert.InDelta(t, 0.0125, cost, 1e-12)
+}
+
 func TestCalculateCost_NoPricingData(t *testing.T) {
 	mc := testCatalogWithPricing(nil)
 	resp := makeChatResponse(schemas.OpenAI, "unknown-model", &schemas.BifrostLLMUsage{

--- a/framework/modelcatalog/utils.go
+++ b/framework/modelcatalog/utils.go
@@ -79,7 +79,7 @@ func normalizeRequestType(reqType schemas.RequestType) string {
 		baseType = "completion"
 	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
 		baseType = "chat"
-	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest, schemas.RealtimeRequest:
+	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest, schemas.RealtimeRequest:
 		baseType = "responses"
 	case schemas.EmbeddingRequest:
 		baseType = "embedding"
@@ -110,7 +110,7 @@ func normalizeStreamRequestType(rt schemas.RequestType) schemas.RequestType {
 		return schemas.TextCompletionRequest
 	case schemas.ChatCompletionStreamRequest:
 		return schemas.ChatCompletionRequest
-	case schemas.ResponsesStreamRequest:
+	case schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest:
 		return schemas.ResponsesRequest
 	case schemas.RealtimeRequest:
 		return schemas.RealtimeRequest

--- a/transports/bifrost-http/handlers/wsresponses.go
+++ b/transports/bifrost-http/handlers/wsresponses.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"strings"
@@ -139,9 +140,10 @@ func (h *WSResponsesHandler) eventLoop(conn *ws.Conn, session *bfws.Session, aut
 	for {
 		_, message, err := conn.ReadMessage()
 		if err != nil {
-			if ws.IsUnexpectedCloseError(err, ws.CloseGoingAway, ws.CloseNormalClosure) {
-				logger.Warn("websocket read error: %v", err)
+			if isExpectedResponsesClientClose(err, session) {
+				return
 			}
+			logger.Warn("websocket read error: %v", err)
 			return
 		}
 
@@ -210,9 +212,21 @@ func (h *WSResponsesHandler) handleResponseCreate(session *bfws.Session, auth *a
 		writeWSError(session, 500, "server_error", "failed to create request context")
 		return
 	}
+	if parentRequestID, _ := bifrostCtx.Value(schemas.BifrostContextKeyParentRequestID).(string); parentRequestID == "" {
+		bifrostCtx.SetValue(schemas.BifrostContextKeyParentRequestID, session.ID())
+	}
+
+	// Rewrite the raw event for upstream: strip provider/ prefix from model,
+	// apply store override. The original bytes contain the bifrost-format model
+	// (e.g. "openai/gpt-5.5") which upstream providers don't understand.
+	upstreamEvent, rewriteErr := rewriteUpstreamEvent(message, bifrostReq.Model, event.Store)
+	if rewriteErr != nil {
+		logger.Warn("failed to rewrite upstream event: %v, using original", rewriteErr)
+		upstreamEvent = message
+	}
 
 	// Try native WS upstream first
-	if h.tryNativeWSUpstream(session, bifrostCtx, bifrostReq, message) {
+	if h.tryNativeWSUpstream(session, bifrostCtx, bifrostReq, upstreamEvent) {
 		cancel()
 		return
 	}
@@ -392,6 +406,7 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 		forwardedAny = true
 
 		if isTerminal {
+			session.MarkResponsesTurnCompleted()
 			h.trackResponseID(session, data)
 			return true
 		}
@@ -418,6 +433,27 @@ func isWSReadTimeout(err error) bool {
 	}
 	var netErr net.Error
 	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+func isExpectedResponsesClientClose(err error, session *bfws.Session) bool {
+	if err == nil {
+		return true
+	}
+	if !ws.IsUnexpectedCloseError(err, ws.CloseGoingAway, ws.CloseNormalClosure) {
+		return true
+	}
+	if session != nil && session.HasCompletedResponsesTurn() && isResponsesEOFClose(err) {
+		return true
+	}
+	return false
+}
+
+func isResponsesEOFClose(err error) bool {
+	var closeErr *ws.CloseError
+	if !errors.As(err, &closeErr) {
+		return false
+	}
+	return closeErr.Code == ws.CloseAbnormalClosure || closeErr.Code == ws.CloseNoStatusReceived
 }
 
 func newBifrostError(statusCode int, errType, message string) *schemas.BifrostError {
@@ -466,6 +502,11 @@ func parseUpstreamWSEvent(data []byte, provider schemas.ModelProvider, model str
 	streamResp.ExtraFields.RequestType = schemas.ResponsesStreamRequest
 	streamResp.ExtraFields.Provider = provider
 	streamResp.ExtraFields.OriginalModelRequested = model
+	// Use SequenceNumber as ChunkIndex so each event gets a unique index.
+	// Without this, all chunks default to ChunkIndex=0 and the accumulator's
+	// dedup (ResponsesChunksSeen) drops every chunk after the first — losing
+	// output text, token usage, and cost data from the logs.
+	streamResp.ExtraFields.ChunkIndex = streamResp.SequenceNumber
 	return &streamResp
 }
 
@@ -668,6 +709,10 @@ func (h *WSResponsesHandler) executeHTTPBridge(
 	req *schemas.BifrostResponsesRequest,
 ) {
 	defer cancel()
+	// Flush the trace after the stream completes so the log entry is persisted
+	// to the log store. Without this, the trace is created by tryStreamRequest
+	// but never flushed — logs won't appear in the dashboard.
+	defer completeTrace(ctx)
 
 	stream, bifrostErr := h.client.ResponsesStreamRequest(ctx, req)
 	if bifrostErr != nil {
@@ -691,12 +736,15 @@ func (h *WSResponsesHandler) executeHTTPBridge(
 			return
 		}
 
-		// Track last response ID for session chaining
+		// Track terminal responses for session chaining and close classification.
 		if chunk.BifrostResponsesStreamResponse != nil &&
-			chunk.BifrostResponsesStreamResponse.Response != nil &&
-			chunk.BifrostResponsesStreamResponse.Response.ID != nil &&
-			*chunk.BifrostResponsesStreamResponse.Response.ID != "" {
-			session.SetLastResponseID(*chunk.BifrostResponsesStreamResponse.Response.ID)
+			isTerminalStreamType(chunk.BifrostResponsesStreamResponse.Type) {
+			session.MarkResponsesTurnCompleted()
+			if chunk.BifrostResponsesStreamResponse.Response != nil &&
+				chunk.BifrostResponsesStreamResponse.Response.ID != nil &&
+				*chunk.BifrostResponsesStreamResponse.Response.ID != "" {
+				session.SetLastResponseID(*chunk.BifrostResponsesStreamResponse.Response.ID)
+			}
 		}
 	}
 }
@@ -758,6 +806,51 @@ var wsResponsesKnownFields = map[string]bool{
 	"metadata":             true,
 	"text":                 true,
 	"truncation":           true,
+}
+
+// rewriteUpstreamEvent modifies the raw JSON event for upstream consumption:
+// - Replaces "model" with provider-native name (strips provider/ prefix)
+// - Applies store override if modified
+// Uses json.RawMessage to preserve all other field values exactly as-is.
+// Re-marshaling via a map may reorder object fields; Responses JSON is
+// order-insensitive, and this path only preserves semantics, not byte order.
+func rewriteUpstreamEvent(rawEvent []byte, nativeModel string, store *bool) ([]byte, error) {
+	var m map[string]json.RawMessage
+	if err := sonic.Unmarshal(rawEvent, &m); err != nil {
+		return nil, err
+	}
+
+	modelBytes, err := sonic.Marshal(nativeModel)
+	if err != nil {
+		return nil, err
+	}
+	m["model"] = json.RawMessage(modelBytes)
+
+	if store != nil {
+		storeBytes, err := sonic.Marshal(*store)
+		if err != nil {
+			return nil, err
+		}
+		m["store"] = json.RawMessage(storeBytes)
+	}
+
+	return sonic.Marshal(m)
+}
+
+// completeTrace flushes the trace so the log entry is persisted to the log store.
+func completeTrace(ctx *schemas.BifrostContext) {
+	if ctx == nil {
+		return
+	}
+	tracer, ok := ctx.Value(schemas.BifrostContextKeyTracer).(schemas.Tracer)
+	if !ok || tracer == nil {
+		return
+	}
+	traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string)
+	if !ok || traceID == "" {
+		return
+	}
+	tracer.CompleteAndFlushTrace(traceID)
 }
 
 var (

--- a/transports/bifrost-http/websocket/session.go
+++ b/transports/bifrost-http/websocket/session.go
@@ -28,6 +28,10 @@ type Session struct {
 	// LastResponseID tracks the most recent response ID for previous_response_id chaining.
 	lastResponseID string
 
+	// responsesCompleted is true once at least one Responses WS turn has reached
+	// a terminal event. EOF after that point is just client disconnect cleanup.
+	responsesCompleted bool
+
 	// providerSessionID tracks the upstream provider's session identifier when exposed.
 	providerSessionID string
 
@@ -128,6 +132,7 @@ func (s *Session) SetLastResponseID(id string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.lastResponseID = id
+	s.responsesCompleted = true
 }
 
 // LastResponseID returns the last response ID.
@@ -135,6 +140,20 @@ func (s *Session) LastResponseID() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.lastResponseID
+}
+
+// HasCompletedResponsesTurn reports whether this session already completed a Responses WS turn.
+func (s *Session) HasCompletedResponsesTurn() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.responsesCompleted
+}
+
+// MarkResponsesTurnCompleted records terminal completion even when no response ID is available.
+func (s *Session) MarkResponsesTurnCompleted() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.responsesCompleted = true
 }
 
 // SetProviderSessionID stores the upstream provider session identifier when available.


### PR DESCRIPTION
## Summary

Fix WebSocket Responses native forwarding and logging so Codex-style sessions
persist complete logs, group related turns, suppress expected post-completion
disconnect warnings, and calculate cost correctly.

## Changes

- Rewrite native WebSocket upstream `response.create` payloads so Bifrost-style
  model names such as `openai/gpt-5.5` are forwarded to providers as native
  model names such as `gpt-5.5`, while preserving unknown fields.
- Flush HTTP bridge traces after the bridged Responses stream completes so
  created log state is persisted to the log store.
- Use upstream `sequence_number` as the stream chunk index for native WS events
  so the Responses stream accumulator does not drop later chunks as duplicates.
- Set a stable parent request ID for each WebSocket Responses session,
  preferring a baggage session ID and falling back to the Bifrost WebSocket
  session ID.
- Track completed Responses WS turns and treat `1006 unexpected EOF` as expected
  only after a terminal turn has completed.
- Treat `websocket_responses` as Responses-style pricing input and include it in
  Responses-to-chat pricing fallbacks so WebSocket Responses usage computes
  non-zero cost.
- Added a regression test for WebSocket Responses stream cost calculation
  through chat pricing fallback.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the Go build and targeted test suites. Expected outcome: all commands pass.

```sh
direnv exec . make build LOCAL=1
direnv exec . go test ./transports/bifrost-http/handlers/ -count=1 -timeout 120s
direnv exec . go test ./framework/streaming/ -count=1 -timeout 120s
direnv exec . go test ./plugins/logging/ -count=1 -timeout 120s
direnv exec . go test ./framework/modelcatalog -run 'TestCalculateCost_WebSocketResponsesFallsBackToChatPricing|TestGetPricing_ResponsesStreamFallsBackToChat|TestCalculateCost_StreamRequestTypeNormalized' -count=1 -timeout 120s
```

No new configs or environment variables were added.

## Screenshots/Recordings

Not applicable; this PR does not include UI changes.

## Breaking changes

- [ ] Yes
- [x] No

No breaking changes expected.

## Related issues

N/A

## Security considerations

No new auth, secrets, PII, or sandboxing behavior is introduced. The WebSocket
path continues to use the existing virtual key/direct key handling and forwards
only existing request/auth context.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
