### PR TITLE
fix: fix migrations for conflicts

### DIFF
--- a/framework/migrator/migrator.go
+++ b/framework/migrator/migrator.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const (
@@ -593,7 +594,7 @@ func (g *Gormigrate) insertMigration(id string) error {
 	v.FieldByName("Sequence").SetInt(seq)
 	v.FieldByName("AppliedAt").Set(reflect.ValueOf(time.Now()))
 	v.FieldByName("Status").SetString("success")
-	return g.tx.Table(g.options.TableName).Create(record).Error
+	return g.tx.Table(g.options.TableName).Clauses(clause.OnConflict{DoNothing: true}).Create(record).Error
 }
 
 func (g *Gormigrate) begin() {


### PR DESCRIPTION
## Summary

When a migration record already exists in the database, the `insertMigration` function would fail with a conflict error. This PR adds an `ON CONFLICT DO NOTHING` clause to the migration record insertion to gracefully handle duplicate entries without returning an error.

## Changes

- Added `clause.OnConflict{DoNothing: true}` to the `Create` call in `insertMigration`, preventing failures when a migration record with the same ID has already been inserted (e.g., in concurrent or retry scenarios).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/migrator/...
```

Verify that running migrations in a scenario where a migration record already exists (e.g., a retry or concurrent execution) does not produce a conflict error and completes successfully.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

No security implications. This change only affects how duplicate migration records are handled at the database level.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable