### PR TITLE
fix(gemini): normalize JSON Schema union types for Vertex compatibility

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -834,6 +834,9 @@ func TestBifrostToGeminiToolConversion(t *testing.T) {
 				require.Len(t, idProp.AnyOf, 2, "anyOf should have 2 options")
 				assert.Equal(t, gemini.Type("string"), idProp.AnyOf[0].Type)
 				assert.Equal(t, gemini.Type("integer"), idProp.AnyOf[1].Type)
+
+				// Validate that sibling fields are stripped because Gemini rejects them
+				assert.Empty(t, idProp.Description, "description should be stripped from anyOf per Gemini validation rules")
 			},
 		},
 		{
@@ -2081,6 +2084,86 @@ func TestBifrostResponsesToGeminiToolConversion(t *testing.T) {
 				// Enum validation
 				sortProp := fd.Parameters.Properties["sort_order"]
 				assert.Equal(t, []string{"asc", "desc"}, sortProp.Enum)
+			},
+		},
+		{
+			name: "ResponsesAPI_ToolAnyOfWithSiblingFields",
+			input: &schemas.BifrostResponsesRequest{
+				Provider: schemas.Gemini,
+				Model:    "gemini-2.0-flash",
+				Input: []schemas.ResponsesMessage{
+					{
+						Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Content: &schemas.ResponsesMessageContent{
+							ContentStr: schemas.Ptr("Call the tool with a nullable parameter"),
+						},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					Tools: []schemas.ResponsesTool{
+						{
+							Type:        schemas.ResponsesToolTypeFunction,
+							Name:        schemas.Ptr("get_process"),
+							Description: schemas.Ptr("Get process info"),
+							ResponsesToolFunction: &schemas.ResponsesToolFunction{
+								Parameters: &schemas.ToolFunctionParameters{
+									Type: "object",
+									Properties: schemas.NewOrderedMapFromPairs(
+										schemas.KV("pid", map[string]interface{}{
+											"type": "integer",
+										}),
+										schemas.KV("timeout_secs", map[string]interface{}{
+											"anyOf": []interface{}{
+												map[string]interface{}{"type": "integer"},
+												map[string]interface{}{"type": "null"},
+											},
+											"description": "Optional timeout",
+										}),
+									),
+									Required: []string{"pid"},
+								},
+							},
+						},
+					},
+				},
+			},
+			validate: func(t *testing.T, result *gemini.GeminiGenerationRequest) {
+				require.Len(t, result.Tools, 1)
+				fd := result.Tools[0].FunctionDeclarations[0]
+				require.NotNil(t, fd.Parameters)
+
+				timeoutProp := fd.Parameters.Properties["timeout_secs"]
+				require.NotNil(t, timeoutProp, "timeout_secs should be converted")
+				require.Len(t, timeoutProp.AnyOf, 2, "anyOf should be preserved")
+				assert.Equal(t, gemini.Type("integer"), timeoutProp.AnyOf[0].Type)
+				assert.Equal(t, gemini.Type("null"), timeoutProp.AnyOf[1].Type)
+				assert.Empty(t, timeoutProp.Description, "Gemini rejects sibling fields alongside anyOf")
+				assert.Empty(t, timeoutProp.Type, "Gemini rejects type alongside anyOf")
+
+				payload, err := json.Marshal(result)
+				require.NoError(t, err)
+
+				var raw map[string]interface{}
+				require.NoError(t, json.Unmarshal(payload, &raw))
+				tools, ok := raw["tools"].([]interface{})
+				require.True(t, ok)
+				tool, ok := tools[0].(map[string]interface{})
+				require.True(t, ok)
+				functionDeclarations, ok := tool["functionDeclarations"].([]interface{})
+				require.True(t, ok)
+				functionDeclaration, ok := functionDeclarations[0].(map[string]interface{})
+				require.True(t, ok)
+				parameters, ok := functionDeclaration["parameters"].(map[string]interface{})
+				require.True(t, ok)
+				properties, ok := parameters["properties"].(map[string]interface{})
+				require.True(t, ok)
+				timeoutSchema, ok := properties["timeout_secs"].(map[string]interface{})
+				require.True(t, ok)
+
+				assert.Contains(t, timeoutSchema, "anyOf")
+				assert.NotContains(t, timeoutSchema, "description")
+				assert.NotContains(t, timeoutSchema, "type")
 			},
 		},
 		{

--- a/core/providers/gemini/uniontype_test.go
+++ b/core/providers/gemini/uniontype_test.go
@@ -1,0 +1,304 @@
+package gemini
+
+import (
+	"encoding/json"
+	"testing"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConvertPropertyToSchema_UnionType verifies that JSON Schema union types
+// (e.g. "type": ["integer", "null"]) in tool parameter properties are correctly
+// normalized to Gemini-compatible schemas. Gemini/Vertex AI rejects array-typed
+// type fields with "schema didn't specify the schema type field".
+func TestConvertPropertyToSchema_UnionType(t *testing.T) {
+	tests := []struct {
+		name           string
+		propJSON       string
+		wantType       Type
+		wantNullable   *bool
+		wantAnyOfLen   int
+		wantAnyOfTypes []Type // optional: ordered types expected inside AnyOf
+	}{
+		{
+			// Case A — simple string type: must be unchanged (no regression)
+			name:     "plain string type is unchanged",
+			propJSON: `{"type": "integer"}`,
+			wantType: Type("integer"),
+		},
+		{
+			// Case B — ["integer","null"]: single non-null + null → Type + Nullable
+			name:         "integer null — becomes Type+Nullable",
+			propJSON:     `{"type": ["integer", "null"], "description": "Timeout in seconds"}`,
+			wantType:     Type("integer"),
+			wantNullable: boolPtr(true),
+		},
+		{
+			// Case B — ["string","null"]: same as above for string
+			name:         "string null — becomes Type+Nullable",
+			propJSON:     `{"type": ["string", "null"]}`,
+			wantType:     Type("string"),
+			wantNullable: boolPtr(true),
+		},
+		{
+			// Case B — null-first ordering must not matter
+			name:         "null first order should not matter",
+			propJSON:     `{"type": ["null", "string"]}`,
+			wantType:     Type("string"),
+			wantNullable: boolPtr(true),
+		},
+		{
+			// Case C — ["integer","string"]: multiple non-null types → anyOf, no Nullable
+			name:           "multiple non-null types become anyOf",
+			propJSON:       `{"type": ["integer", "string"]}`,
+			wantType:       Type(""),
+			wantAnyOfLen:   2,
+			wantAnyOfTypes: []Type{Type("integer"), Type("string")},
+		},
+		{
+			// Case D — ["integer","string","null"]: multiple non-null + null → anyOf + Nullable
+			name:           "multiple non-null types with null become anyOf and Nullable",
+			propJSON:       `{"type": ["integer", "string", "null"]}`,
+			wantType:       Type(""),
+			wantNullable:   boolPtr(true),
+			wantAnyOfLen:   2,
+			wantAnyOfTypes: []Type{Type("integer"), Type("string")},
+		},
+		{
+			// Case E — ["null"] only: edge case, must produce TypeNULL not empty
+			name:     "only null type becomes TypeNULL",
+			propJSON: `{"type": ["null"]}`,
+			wantType: TypeNULL,
+		},
+		{
+			// Dedup — duplicate non-null types must not produce duplicate anyOf entries
+			name:           "duplicate types are deduplicated",
+			propJSON:       `{"type": ["integer", "integer", "null"]}`,
+			wantType:       Type("integer"),
+			wantNullable:   boolPtr(true),
+			wantAnyOfLen:   0, // single non-null after dedup → Type+Nullable, not anyOf
+		},
+		{
+			// All-invalid elements ([1,2] after JSON decode becomes []interface{}{float64,float64}).
+			// No usable type strings at all — Type must remain empty, NOT TypeNULL.
+			name:     "all-invalid non-string elements leave Type empty",
+			propJSON: `{"type": [1, 2]}`,
+			wantType: Type(""),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var rawProp interface{}
+			require.NoError(t, json.Unmarshal([]byte(tc.propJSON), &rawProp))
+
+			schema := convertPropertyToSchema(rawProp)
+			require.NotNil(t, schema)
+
+			assert.Equal(t, tc.wantType, schema.Type)
+			assert.Equal(t, tc.wantNullable, schema.Nullable)
+			if tc.wantAnyOfLen > 0 {
+				require.Len(t, schema.AnyOf, tc.wantAnyOfLen)
+				if len(tc.wantAnyOfTypes) > 0 {
+					for i, wantT := range tc.wantAnyOfTypes {
+						assert.Equal(t, wantT, schema.AnyOf[i].Type, "anyOf[%d].Type", i)
+					}
+				}
+			} else {
+				assert.Empty(t, schema.AnyOf, "AnyOf must be empty for simple type")
+			}
+		})
+	}
+}
+
+// TestConvertBifrostToolsToGemini_UnionTypeProperty is the end-to-end test
+// that reproduces the Goose+Vertex bug: a tool parameter with
+// "type": ["integer", "null"] must produce a non-empty Gemini type field.
+func TestConvertBifrostToolsToGemini_UnionTypeProperty(t *testing.T) {
+	toolJSON := `{
+		"type": "function",
+		"function": {
+			"name": "run_with_timeout",
+			"description": "Run something with a timeout",
+			"parameters": {
+				"type": "object",
+				"properties": {
+					"timeout_secs": {
+						"type": ["integer", "null"],
+						"description": "Timeout in seconds"
+					},
+					"command": {
+						"type": "string",
+						"description": "Command to run"
+					}
+				},
+				"required": ["command"]
+			}
+		}
+	}`
+
+	var chatTool schemas.ChatTool
+	require.NoError(t, json.Unmarshal([]byte(toolJSON), &chatTool))
+
+	geminiTools := convertBifrostToolsToGemini([]schemas.ChatTool{chatTool})
+	require.Len(t, geminiTools, 1)
+	require.Len(t, geminiTools[0].FunctionDeclarations, 1)
+
+	fd := geminiTools[0].FunctionDeclarations[0]
+	require.NotNil(t, fd.Parameters)
+
+	timeoutSchema, ok := fd.Parameters.Properties["timeout_secs"]
+	require.True(t, ok, "timeout_secs property must be present")
+
+	// Before the fix this was "" — Vertex AI rejected with
+	// "parameters.timeout_secs schema didn't specify the schema type field"
+	assert.NotEmpty(t, timeoutSchema.Type, "Type must not be empty for union-typed property")
+	assert.Equal(t, Type("integer"), timeoutSchema.Type)
+	require.NotNil(t, timeoutSchema.Nullable)
+	assert.True(t, *timeoutSchema.Nullable)
+
+	// The non-union "command" property must be unaffected
+	commandSchema, ok := fd.Parameters.Properties["command"]
+	require.True(t, ok)
+	assert.Equal(t, Type("string"), commandSchema.Type)
+	assert.Nil(t, commandSchema.Nullable)
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestExtractUnionTypes directly tests the extractUnionTypes helper for both
+// []interface{} and []string inputs.
+func TestExtractUnionTypes(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         interface{}
+		wantNonNull   []string
+		wantHasNull   bool
+	}{
+		{
+			name:        "[]interface{} integer+null",
+			input:       []interface{}{"integer", "null"},
+			wantNonNull: []string{"integer"},
+			wantHasNull: true,
+		},
+		{
+			name:        "[]string integer+null",
+			input:       []string{"integer", "null"},
+			wantNonNull: []string{"integer"},
+			wantHasNull: true,
+		},
+		{
+			name:        "[]string dedup",
+			input:       []string{"string", "string", "null"},
+			wantNonNull: []string{"string"},
+			wantHasNull: true,
+		},
+		{
+			name:        "[]interface{} all-invalid non-string elements",
+			input:       []interface{}{float64(1), float64(2)},
+			wantNonNull: nil,
+			wantHasNull: false,
+		},
+		{
+			name:        "[]string null-only",
+			input:       []string{"null"},
+			wantNonNull: nil,
+			wantHasNull: true,
+		},
+		{
+			name:        "[]interface{} multi-type without null",
+			input:       []interface{}{"integer", "string"},
+			wantNonNull: []string{"integer", "string"},
+			wantHasNull: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nonNull, hasNull := extractUnionTypes(tc.input)
+			assert.Equal(t, tc.wantNonNull, nonNull)
+			assert.Equal(t, tc.wantHasNull, hasNull)
+		})
+	}
+}
+
+// TestConvertPropertyToSchema_StringSlice verifies that a Go caller passing
+// []string{"integer","null"} (rather than the JSON-decoded []interface{} form)
+// is also handled correctly.
+func TestConvertPropertyToSchema_StringSlice(t *testing.T) {
+	// Build the prop map directly as a Go caller would.
+	prop := map[string]interface{}{
+		"type":        []string{"integer", "null"},
+		"description": "direct Go caller path",
+	}
+	schema := convertPropertyToSchema(prop)
+	require.NotNil(t, schema)
+	assert.Equal(t, Type("integer"), schema.Type)
+	require.NotNil(t, schema.Nullable)
+	assert.True(t, *schema.Nullable)
+}
+
+// TestConvertBifrostToolsToGemini_WirePayload verifies that the final
+// serialized JSON bytes sent to Gemini/Vertex are correct for union-typed
+// tool parameters. The original bug manifested at the serialization level
+// (empty "type" field rejected by Vertex), so struct-level checks alone
+// are not sufficient.
+func TestConvertBifrostToolsToGemini_WirePayload(t *testing.T) {
+	tests := []struct {
+		name          string
+		propertyJSON  string
+		propertyName  string
+		wantContains  []string // substrings that must appear in the wire JSON
+		wantAbsent    []string // substrings that must NOT appear in the wire JSON
+	}{
+		{
+			name:         "nullable type produces type+nullable fields not array",
+			propertyJSON: `"timeout_secs":{"type":["integer","null"],"description":"Timeout"}`,
+			propertyName: "timeout_secs",
+			// Vertex requires a single string "type"; array would be rejected
+			wantContains: []string{`"type":"integer"`, `"nullable":true`},
+			wantAbsent:   []string{`"type":["integer"`, `"type":["null"`},
+		},
+		{
+			name:         "plain string type passes through unchanged",
+			propertyJSON: `"command":{"type":"string","description":"Command to run"}`,
+			propertyName: "command",
+			wantContains: []string{`"type":"string"`},
+			wantAbsent:   []string{`"nullable"`, `"anyOf"`},
+		},
+		{
+			name:         "multi-type union produces anyOf not array type",
+			propertyJSON: `"value":{"type":["integer","string"]}`,
+			propertyName: "value",
+			wantContains: []string{`"anyOf":[{"type":"integer"},{"type":"string"}]`},
+			wantAbsent:   []string{`"type":["integer"`, `"type":["string"`},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			toolJSON := `{"type":"function","function":{"name":"test_fn","parameters":{"type":"object","properties":{` +
+				tc.propertyJSON + `}}}}`
+
+			var chatTool schemas.ChatTool
+			require.NoError(t, json.Unmarshal([]byte(toolJSON), &chatTool))
+
+			geminiTools := convertBifrostToolsToGemini([]schemas.ChatTool{chatTool})
+			require.Len(t, geminiTools, 1)
+
+			// Serialize to the exact bytes that would be sent to Vertex
+			wire, err := providerUtils.MarshalSorted(geminiTools[0])
+			require.NoError(t, err)
+			wireStr := string(wire)
+
+			for _, want := range tc.wantContains {
+				assert.Contains(t, wireStr, want, "wire JSON must contain %q", want)
+			}
+			for _, absent := range tc.wantAbsent {
+				assert.NotContains(t, wireStr, absent, "wire JSON must not contain %q", absent)
+			}
+		})
+	}
+}

--- a/core/providers/gemini/uniontype_test.go
+++ b/core/providers/gemini/uniontype_test.go
@@ -59,13 +59,19 @@ func TestConvertPropertyToSchema_UnionType(t *testing.T) {
 			wantAnyOfTypes: []Type{Type("integer"), Type("string")},
 		},
 		{
-			// Case D — ["integer","string","null"]: multiple non-null + null → anyOf + Nullable
-			name:           "multiple non-null types with null become anyOf and Nullable",
+			// Case D — ["integer","string","null"]: multiple non-null + null → anyOf with null branch
+			name:           "multiple non-null types with null become anyOf with null branch",
 			propJSON:       `{"type": ["integer", "string", "null"]}`,
 			wantType:       Type(""),
-			wantNullable:   boolPtr(true),
-			wantAnyOfLen:   2,
-			wantAnyOfTypes: []Type{Type("integer"), Type("string")},
+			wantAnyOfLen:   3,
+			wantAnyOfTypes: []Type{Type("integer"), Type("string"), Type("null")},
+		},
+		{
+			name:           "explicit nullable with anyOf is folded into null branch",
+			propJSON:       `{"anyOf": [{"type": "integer"}, {"type": "string"}], "nullable": true}`,
+			wantType:       Type(""),
+			wantAnyOfLen:   3,
+			wantAnyOfTypes: []Type{Type("integer"), Type("string"), Type("null")},
 		},
 		{
 			// Case E — ["null"] only: edge case, must produce TypeNULL not empty
@@ -75,11 +81,11 @@ func TestConvertPropertyToSchema_UnionType(t *testing.T) {
 		},
 		{
 			// Dedup — duplicate non-null types must not produce duplicate anyOf entries
-			name:           "duplicate types are deduplicated",
-			propJSON:       `{"type": ["integer", "integer", "null"]}`,
-			wantType:       Type("integer"),
-			wantNullable:   boolPtr(true),
-			wantAnyOfLen:   0, // single non-null after dedup → Type+Nullable, not anyOf
+			name:         "duplicate types are deduplicated",
+			propJSON:     `{"type": ["integer", "integer", "null"]}`,
+			wantType:     Type("integer"),
+			wantNullable: boolPtr(true),
+			wantAnyOfLen: 0, // single non-null after dedup → Type+Nullable, not anyOf
 		},
 		{
 			// All-invalid elements ([1,2] after JSON decode becomes []interface{}{float64,float64}).
@@ -169,14 +175,37 @@ func TestConvertBifrostToolsToGemini_UnionTypeProperty(t *testing.T) {
 
 func boolPtr(b bool) *bool { return &b }
 
+func TestConvertFunctionParametersToSchema_AnyOfNullable(t *testing.T) {
+	params := schemas.ToolFunctionParameters{
+		AnyOf: []schemas.OrderedMap{
+			*schemas.NewOrderedMapFromPairs(schemas.KV("type", "integer")),
+			*schemas.NewOrderedMapFromPairs(schemas.KV("type", "string")),
+		},
+		Nullable: boolPtr(true),
+	}
+
+	schema := convertFunctionParametersToSchema(params)
+	require.NotNil(t, schema)
+	require.Len(t, schema.AnyOf, 3)
+	assert.Equal(t, Type("integer"), schema.AnyOf[0].Type)
+	assert.Equal(t, Type("string"), schema.AnyOf[1].Type)
+	assert.Equal(t, Type("null"), schema.AnyOf[2].Type)
+	assert.Nil(t, schema.Nullable)
+
+	wire, err := providerUtils.MarshalSorted(schema)
+	require.NoError(t, err)
+	assert.Contains(t, string(wire), `"anyOf":[{"type":"integer"},{"type":"string"},{"type":"null"}]`)
+	assert.NotContains(t, string(wire), `"nullable":true`)
+}
+
 // TestExtractUnionTypes directly tests the extractUnionTypes helper for both
 // []interface{} and []string inputs.
 func TestExtractUnionTypes(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         interface{}
-		wantNonNull   []string
-		wantHasNull   bool
+		name        string
+		input       interface{}
+		wantNonNull []string
+		wantHasNull bool
 	}{
 		{
 			name:        "[]interface{} integer+null",
@@ -247,11 +276,11 @@ func TestConvertPropertyToSchema_StringSlice(t *testing.T) {
 // are not sufficient.
 func TestConvertBifrostToolsToGemini_WirePayload(t *testing.T) {
 	tests := []struct {
-		name          string
-		propertyJSON  string
-		propertyName  string
-		wantContains  []string // substrings that must appear in the wire JSON
-		wantAbsent    []string // substrings that must NOT appear in the wire JSON
+		name         string
+		propertyJSON string
+		propertyName string
+		wantContains []string // substrings that must appear in the wire JSON
+		wantAbsent   []string // substrings that must NOT appear in the wire JSON
 	}{
 		{
 			name:         "nullable type produces type+nullable fields not array",
@@ -274,6 +303,13 @@ func TestConvertBifrostToolsToGemini_WirePayload(t *testing.T) {
 			propertyName: "value",
 			wantContains: []string{`"anyOf":[{"type":"integer"},{"type":"string"}]`},
 			wantAbsent:   []string{`"type":["integer"`, `"type":["string"`},
+		},
+		{
+			name:         "multi-type nullable union folds null into anyOf",
+			propertyJSON: `"value":{"type":["integer","string","null"]}`,
+			propertyName: "value",
+			wantContains: []string{`"anyOf":[{"type":"integer"},{"type":"string"},{"type":"null"}]`},
+			wantAbsent:   []string{`"type":["integer"`, `"nullable":true`},
 		},
 	}
 

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -1285,8 +1285,7 @@ func applyUnionType(schema *Schema, nonNullTypes []string, hasNull bool) {
 	case 1:
 		schema.Type = Type(nonNullTypes[0])
 		if hasNull {
-			trueVal := true
-			schema.Nullable = &trueVal
+			schema.Nullable = schemas.Ptr(true)
 		}
 	default:
 		anyOfSchemas := make([]*Schema, 0, len(nonNullTypes))
@@ -1294,8 +1293,7 @@ func applyUnionType(schema *Schema, nonNullTypes []string, hasNull bool) {
 			anyOfSchemas = append(anyOfSchemas, &Schema{Type: Type(t)})
 		}
 		if hasNull {
-			trueVal := true
-			schema.Nullable = &trueVal
+			schema.Nullable = schemas.Ptr(true)
 		}
 		schema.AnyOf = anyOfSchemas
 	}

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -1210,6 +1210,12 @@ func convertFunctionParametersToSchema(params schemas.ToolFunctionParameters) *S
 	// Note: Gemini doesn't have native allOf support, but we can still attempt to pass it through AnyOf
 	// This is a best-effort conversion as allOf semantics differ from anyOf
 
+	// Gemini requires any_of to be the only populated schema-composition field.
+	// Unsupported siblings must be removed or folded before sending.
+	if len(schema.AnyOf) > 0 {
+		return schemaWithAnyOfOnly(schema.AnyOf, params.Nullable)
+	}
+
 	// String validation fields
 	if params.Format != nil {
 		schema.Format = *params.Format
@@ -1270,7 +1276,7 @@ func extractUnionTypes(v interface{}) (nonNullTypes []string, hasNull bool) {
 // Gemini/Vertex normalisation rules:
 //
 //	["T", "null"]      → Type=T,  Nullable=true
-//	["T1", "T2", ...]  → anyOf:[{type:T1},{type:T2},...], optionally Nullable
+//	["T1", "T2", ...]  → anyOf:[{type:T1},{type:T2},...], optionally with a null branch
 //	["null"]           → Type=TypeNULL
 //	[1, 2]             → no type set (all elements were non-string; invalid input)
 func applyUnionType(schema *Schema, nonNullTypes []string, hasNull bool) {
@@ -1293,10 +1299,28 @@ func applyUnionType(schema *Schema, nonNullTypes []string, hasNull bool) {
 			anyOfSchemas = append(anyOfSchemas, &Schema{Type: Type(t)})
 		}
 		if hasNull {
-			schema.Nullable = schemas.Ptr(true)
+			schema.AnyOf = append(anyOfSchemas, &Schema{Type: Type("null")})
+			return
 		}
 		schema.AnyOf = anyOfSchemas
 	}
+}
+
+func schemaWithAnyOfOnly(anyOf []*Schema, nullable *bool) *Schema {
+	if nullable != nil && *nullable {
+		hasNull := false
+		for _, item := range anyOf {
+			if item != nil && strings.EqualFold(string(item.Type), "null") {
+				hasNull = true
+				break
+			}
+		}
+		if !hasNull {
+			anyOf = append(anyOf, &Schema{Type: Type("null")})
+		}
+	}
+
+	return &Schema{AnyOf: anyOf}
 }
 
 // convertPropertyToSchema recursively converts a property to Gemini Schema
@@ -1483,6 +1507,12 @@ func convertPropertyToSchema(prop interface{}) *Schema {
 				schema.Nullable = &nullableBool
 			}
 		}
+	}
+
+	// Gemini requires any_of to be the only populated schema-composition field.
+	// Unsupported siblings must be removed or folded before sending.
+	if len(schema.AnyOf) > 0 {
+		return schemaWithAnyOfOnly(schema.AnyOf, schema.Nullable)
 	}
 
 	return schema

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -1246,6 +1246,61 @@ func convertFunctionParametersToSchema(params schemas.ToolFunctionParameters) *S
 	return schema
 }
 
+// extractUnionTypes parses a JSON Schema "type" value into the set of non-null
+// type strings and a boolean indicating whether "null" was present. It reuses
+// extractTypesFromValue for supported input shapes; duplicates are deduplicated.
+func extractUnionTypes(v interface{}) (nonNullTypes []string, hasNull bool) {
+	seen := make(map[string]struct{})
+	for _, s := range extractTypesFromValue(v) {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		if s == "null" {
+			hasNull = true
+		} else {
+			nonNullTypes = append(nonNullTypes, s)
+		}
+	}
+
+	return nonNullTypes, hasNull
+}
+
+// applyUnionType applies the result of extractUnionTypes to a Schema, following
+// Gemini/Vertex normalisation rules:
+//
+//	["T", "null"]      → Type=T,  Nullable=true
+//	["T1", "T2", ...]  → anyOf:[{type:T1},{type:T2},...], optionally Nullable
+//	["null"]           → Type=TypeNULL
+//	[1, 2]             → no type set (all elements were non-string; invalid input)
+func applyUnionType(schema *Schema, nonNullTypes []string, hasNull bool) {
+	switch len(nonNullTypes) {
+	case 0:
+		// Only "null" was in the array (or all elements were invalid non-string values).
+		// Emit TypeNULL only when "null" was explicitly present.
+		if hasNull {
+			schema.Type = TypeNULL
+		}
+		// Otherwise leave Type as zero-value — the array carried no usable type info.
+	case 1:
+		schema.Type = Type(nonNullTypes[0])
+		if hasNull {
+			trueVal := true
+			schema.Nullable = &trueVal
+		}
+	default:
+		anyOfSchemas := make([]*Schema, 0, len(nonNullTypes))
+		for _, t := range nonNullTypes {
+			anyOfSchemas = append(anyOfSchemas, &Schema{Type: Type(t)})
+		}
+		if hasNull {
+			trueVal := true
+			schema.Nullable = &trueVal
+		}
+		schema.AnyOf = anyOfSchemas
+	}
+}
+
 // convertPropertyToSchema recursively converts a property to Gemini Schema
 func convertPropertyToSchema(prop interface{}) *Schema {
 	schema := &Schema{}
@@ -1262,8 +1317,17 @@ func convertPropertyToSchema(prop interface{}) *Schema {
 	}
 	if propMap != nil {
 		if propType, exists := propMap["type"]; exists {
-			if typeStr, ok := propType.(string); ok {
-				schema.Type = Type(typeStr)
+			switch v := propType.(type) {
+			case string:
+				schema.Type = Type(v)
+			case []interface{}, []string:
+				// Handle JSON Schema union types like ["integer", "null"].
+				// Gemini/Vertex AI does not support array-typed "type" fields in
+				// tool parameter schemas (Vertex rejects with "schema didn't specify
+				// the schema type field"), so we normalise to the closest supported
+				// form via extractUnionTypes + applyUnionType.
+				nonNullTypes, hasNull := extractUnionTypes(v)
+				applyUnionType(schema, nonNullTypes, hasNull)
 			}
 		}
 


### PR DESCRIPTION
## Summary

This change fixes an incompatibility between Bifrost and Vertex AI when handling JSON Schema union types in tool and function parameters.

Previously, schemas containing union types such as:

"type": ["integer", "null"]

were not correctly normalized before being sent to the Gemini or Vertex provider. This resulted in invalid schemas where the `type` field was effectively missing, causing Vertex to reject requests with a 400 error.

This PR introduces proper normalization of union types to ensure compatibility with Gemini and Vertex AI.

---

## Previous Behavior

Bifrost assumed that the JSON Schema `type` field was always a string. When an array was provided:

"type": ["integer", "null"]

the conversion logic failed silently because:
- The type assertion for string did not match
- No fallback handling existed for arrays
- The resulting schema had an empty `type` field

This led to requests being rejected by Vertex with errors such as:

parameters.<field> schema didn't specify the schema type field

As a result:
- Tool-based requests using nullable or union types failed
- Compatibility with OpenAPI-style schemas and external tools like Goose was broken

---

## Current Behavior

The schema conversion logic now correctly handles JSON Schema union types.

Supported transformations:

- "type": "integer"
  -> unchanged

- "type": ["integer", "null"]
  -> type: "integer", nullable: true

- "type": ["string", "null"]
  -> type: "string", nullable: true

- "type": ["integer", "string"]
  -> anyOf: [{type: "integer"}, {type: "string"}]

- "type": ["integer", "string", "null"]
  -> anyOf: [...], nullable: true

- "type": ["null"]
  -> type: "null"

Additional improvements:
- Duplicate types are deduplicated
- Order of types does not affect output
- Invalid non-string entries are ignored safely

---

## Validation

The fix has been validated through both unit tests and real end-to-end requests.

### Unit Tests
- Coverage for all union type cases
- Edge cases including ordering and duplicates
- End-to-end tool schema conversion validation

### End-to-End Verification

A real request using:

"type": ["integer", "null"]

was successfully processed through Bifrost and accepted by Gemini (gemini-2.5-flash), resulting in a valid tool call:

"tool_calls": [
  {
    "function": {
      "name": "get_process",
      "arguments": {
        "pid": 42,
        "timeout_secs": null
      }
    }
  }
]

This confirms:
- Schema is correctly normalized
- Vertex accepts the transformed schema
- Tool execution works as expected

(See attached screenshot)


<img width="1600" height="830" alt="image" src="https://github.com/user-attachments/assets/42a9cdb9-0b2e-45cc-9cf6-8597565ed935" />



---

## Impact

- Fixes a compatibility issue with Vertex AI
- Enables support for OpenAPI-style schemas with nullable and union types
- Improves interoperability with external tooling that emits JSON Schema arrays
- No breaking changes to existing behavior
- No observable impact on performance

---

## Type of change

- [x] Bug fix

---

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

---

## How to test

 execute:

curl -s -X POST http://localhost:9090/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gemini/gemini-2.5-flash",
    "messages": [
      {
        "role": "user",
        "content": "Call get_process with pid 42 and timeout_secs null"
      }
    ],
    "tools": [
      {
        "type": "function",
        "function": {
          "name": "get_process",
          "parameters": {
            "type": "object",
            "properties": {
              "pid": { "type": "integer" },
              "timeout_secs": { "type": ["integer", "null"] }
            },
            "required": ["pid"]
          }
        }
      }
    ],
    "tool_choice": "auto"
  }'

Expected:
- Response contains tool_calls
- No schema validation error
- timeout_secs handled as null

---

## Breaking changes

- [x] No

---

## Related issues

Fixes: #3141 

---

## Security considerations

No changes to authentication, data handling, or external interfaces. Schema normalization is internal.

---

## Checklist

- [x] Tests added and passing
- [x] No regressions observed
- [x] Verified with real provider
- [x] Builds succeed