### PR TITLE
fix: compat plugin drops cachePoint for unsupported bedrock model and non-bedrock models

### DIFF
--- a/framework/modelcatalog/utils.go
+++ b/framework/modelcatalog/utils.go
@@ -156,16 +156,16 @@ func convertPricingDataToTableModelPricing(modelKey string, entry PricingEntry) 
 		Architecture:    entry.Architecture,
 
 		// Costs - Text
-		InputCostPerToken:                 entry.InputCostPerToken,
-		OutputCostPerToken:                entry.OutputCostPerToken,
-		InputCostPerTokenBatches:          entry.InputCostPerTokenBatches,
-		OutputCostPerTokenBatches:         entry.OutputCostPerTokenBatches,
-		InputCostPerTokenPriority:         entry.InputCostPerTokenPriority,
-		OutputCostPerTokenPriority:        entry.OutputCostPerTokenPriority,
-		InputCostPerTokenFlex:             entry.InputCostPerTokenFlex,
-		OutputCostPerTokenFlex:            entry.OutputCostPerTokenFlex,
-		InputCostPerTokenAbove200kTokens:         entry.InputCostPerTokenAbove200kTokens,
-		InputCostPerTokenAbove200kTokensPriority: entry.InputCostPerTokenAbove200kTokensPriority,
+		InputCostPerToken:                         entry.InputCostPerToken,
+		OutputCostPerToken:                        entry.OutputCostPerToken,
+		InputCostPerTokenBatches:                  entry.InputCostPerTokenBatches,
+		OutputCostPerTokenBatches:                 entry.OutputCostPerTokenBatches,
+		InputCostPerTokenPriority:                 entry.InputCostPerTokenPriority,
+		OutputCostPerTokenPriority:                entry.OutputCostPerTokenPriority,
+		InputCostPerTokenFlex:                     entry.InputCostPerTokenFlex,
+		OutputCostPerTokenFlex:                    entry.OutputCostPerTokenFlex,
+		InputCostPerTokenAbove200kTokens:          entry.InputCostPerTokenAbove200kTokens,
+		InputCostPerTokenAbove200kTokensPriority:  entry.InputCostPerTokenAbove200kTokensPriority,
 		OutputCostPerTokenAbove200kTokens:         entry.OutputCostPerTokenAbove200kTokens,
 		OutputCostPerTokenAbove200kTokensPriority: entry.OutputCostPerTokenAbove200kTokensPriority,
 		// Costs - 272k Tier
@@ -240,16 +240,16 @@ func convertPricingDataToTableModelPricing(modelKey string, entry PricingEntry) 
 func convertTableModelPricingToPricingData(pricing *configstoreTables.TableModelPricing) *PricingEntry {
 	options := PricingOptions{
 		// Costs - Text
-		InputCostPerToken:                 pricing.InputCostPerToken,
-		OutputCostPerToken:                pricing.OutputCostPerToken,
-		InputCostPerTokenBatches:          pricing.InputCostPerTokenBatches,
-		OutputCostPerTokenBatches:         pricing.OutputCostPerTokenBatches,
-		InputCostPerTokenPriority:         pricing.InputCostPerTokenPriority,
-		OutputCostPerTokenPriority:        pricing.OutputCostPerTokenPriority,
-		InputCostPerTokenFlex:             pricing.InputCostPerTokenFlex,
-		OutputCostPerTokenFlex:            pricing.OutputCostPerTokenFlex,
-		InputCostPerTokenAbove200kTokens:         pricing.InputCostPerTokenAbove200kTokens,
-		InputCostPerTokenAbove200kTokensPriority: pricing.InputCostPerTokenAbove200kTokensPriority,
+		InputCostPerToken:                         pricing.InputCostPerToken,
+		OutputCostPerToken:                        pricing.OutputCostPerToken,
+		InputCostPerTokenBatches:                  pricing.InputCostPerTokenBatches,
+		OutputCostPerTokenBatches:                 pricing.OutputCostPerTokenBatches,
+		InputCostPerTokenPriority:                 pricing.InputCostPerTokenPriority,
+		OutputCostPerTokenPriority:                pricing.OutputCostPerTokenPriority,
+		InputCostPerTokenFlex:                     pricing.InputCostPerTokenFlex,
+		OutputCostPerTokenFlex:                    pricing.OutputCostPerTokenFlex,
+		InputCostPerTokenAbove200kTokens:          pricing.InputCostPerTokenAbove200kTokens,
+		InputCostPerTokenAbove200kTokensPriority:  pricing.InputCostPerTokenAbove200kTokensPriority,
 		OutputCostPerTokenAbove200kTokens:         pricing.OutputCostPerTokenAbove200kTokens,
 		OutputCostPerTokenAbove200kTokensPriority: pricing.OutputCostPerTokenAbove200kTokensPriority,
 		// Costs - 272k Tier
@@ -392,7 +392,7 @@ type modelParametersParseResult struct {
 	SupportsReasoning               *bool `json:"supports_reasoning,omitempty"`
 	SupportsServiceTier             *bool `json:"supports_service_tier,omitempty"`
 	SupportsPromptCaching           *bool `json:"supports_prompt_caching,omitempty"`
-	VertexMultiRegionOnly       *bool `json:"vertex_multi_region_only,omitempty"`
+	VertexMultiRegionOnly           *bool `json:"vertex_multi_region_only,omitempty"`
 }
 
 // extractSupportedParams builds a list of supported OpenAI-compatible parameter
@@ -436,6 +436,8 @@ func extractSupportedParams(parsed *modelParametersParseResult) []string {
 		addParam("service_tier")
 	}
 	if parsed.SupportsPromptCaching != nil && *parsed.SupportsPromptCaching {
+		addParam("cachePoint")
+		addParam("cache_control")
 		addParam("prompt_cache_key")
 		addParam("prompt_cache_retention")
 	}

--- a/plugins/compat/dropparams.go
+++ b/plugins/compat/dropparams.go
@@ -116,6 +116,13 @@ func dropUnsupportedParams(req *schemas.BifrostRequest, supportedParams []string
 		}
 	}
 
+	if req.ChatRequest != nil && req.ChatRequest.Input != nil {
+		if req.ChatRequest.Provider != schemas.Bedrock || !isSupported["cachePoint"] {
+			droppedKeys := dropCachePoint(req.ChatRequest)
+			dropped = append(dropped, droppedKeys...)
+		}
+	}
+
 	if req.ResponsesRequest != nil && req.ResponsesRequest.Params != nil {
 		params := req.ResponsesRequest.Params
 
@@ -173,6 +180,15 @@ func dropUnsupportedParams(req *schemas.BifrostRequest, supportedParams []string
 		}
 		if !isSupported["web_search"] {
 			droppedKeys := dropWebsearchToolCalls(req)
+			dropped = append(dropped, droppedKeys...)
+		}
+	}
+
+	if req.ResponsesRequest != nil {
+		// all anthropic models support cache_control
+		// for bedrock models cache_control is converted to cachePoint
+		if req.ResponsesRequest.Provider == schemas.Bedrock && !isSupported["cache_control"] {
+			droppedKeys := dropCacheControlFromResponsesMessages(req.ResponsesRequest)
 			dropped = append(dropped, droppedKeys...)
 		}
 	}
@@ -237,5 +253,59 @@ func dropWebsearchToolCalls(req *schemas.BifrostRequest) []string {
 		}
 	}
 	req.ResponsesRequest.Params.Tools = kept
+	return dropped
+}
+
+// dropCachePoint drops cache point (only supported by bedrock) from the request
+func dropCachePoint(req *schemas.BifrostChatRequest) []string {
+	dropped := []string{}
+	for i := range req.Input {
+		if req.Input[i].Content != nil && req.Input[i].Content.ContentBlocks != nil {
+			blocks := req.Input[i].Content.ContentBlocks
+			kept := blocks[:0]
+			for j, block := range blocks {
+				if block.CachePoint != nil {
+					dropped = append(dropped, fmt.Sprintf("input[%d].content.content_blocks[%d].cache_point", i, j))
+				} else {
+					kept = append(kept, block)
+				}
+			}
+			req.Input[i].Content.ContentBlocks = kept
+		}
+	}
+	return dropped
+}
+
+// dropCacheControlFromResponsesMessages clears cache_control from all content blocks.
+func dropCacheControlFromResponsesMessages(req *schemas.BifrostResponsesRequest) []string {
+	var dropped []string
+
+	if req.Input != nil {
+		for i := range req.Input {
+			msg := &req.Input[i]
+			if msg.CacheControl != nil {
+				msg.CacheControl = nil
+				dropped = append(dropped, fmt.Sprintf("input[%d].cache_control", i))
+			}
+			if msg.Content == nil || msg.Content.ContentBlocks == nil {
+				continue
+			}
+			for j := range msg.Content.ContentBlocks {
+				if msg.Content.ContentBlocks[j].CacheControl != nil {
+					msg.Content.ContentBlocks[j].CacheControl = nil
+					dropped = append(dropped, fmt.Sprintf("input[%d].content.content_blocks[%d].cache_control", i, j))
+				}
+			}
+		}
+	}
+
+	if req.Params != nil {
+		for i := range req.Params.Tools {
+			if req.Params.Tools[i].CacheControl != nil {
+				req.Params.Tools[i].CacheControl = nil
+				dropped = append(dropped, fmt.Sprintf("tools[%d].cache_control", i))
+			}
+		}
+	}
 	return dropped
 }

--- a/ui/app/workspace/config/views/compatibilityView.tsx
+++ b/ui/app/workspace/config/views/compatibilityView.tsx
@@ -130,7 +130,7 @@ export default function CompatibilityView() {
 				<div className="flex items-center justify-between space-x-2">
 					<div className="space-y-0.5">
 						<label htmlFor="compat-should-convert-params" className="text-sm font-medium">
-							Convert Unsupported Parameter Values
+							Convert Unsupported Param Values
 						</label>
 						<p className="text-muted-foreground text-sm">Converts model parameter values that are not supported by the model.</p>
 					</div>


### PR DESCRIPTION
## Summary

Adds `cachePoint` and `cache_control` as recognized supported params for models with prompt caching enabled, and introduces logic to automatically strip these fields from requests when the model or provider does not support them. For chat requests, `cache_point` content blocks are dropped when the provider is not Bedrock or the model lacks `cachePoint` support. For responses requests, `cache_control` fields are cleared from messages, nested content blocks, and tools when targeting Bedrock models without `cache_control` support.

## Changes

- Added `cachePoint` and `cache_control` to the list of params registered in `extractSupportedParams` when `supports_prompt_caching` is true
- Added `dropCachePoint` to strip `cache_point` content blocks from chat request inputs, returning dropped key paths
- Added `dropCacheControlFromResponsesMessages` to clear `cache_control` from top-level messages, nested content blocks, and tools in responses requests, returning dropped key paths
- Wired both functions into `dropUnsupportedParams` for chat and responses request paths
- Minor UI label text tweak: "Convert Unsupported Parameter Values" → "Convert Unsupported Param Values"
- Aligned struct field indentation in `convertPricingDataToTableModelPricing`, `convertTableModelPricingToPricingData`, and `modelParametersParseResult`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

- Chat completions request with / without `cachePoint` for Bedrock and non-Bedrock models
- Responses request with / without `cache_control` for Bedrock and non-Bedrock models
- Verify that `cache_point` blocks are dropped and logged for non-Bedrock or non-caching-capable models
- Verify that `cache_control` fields are dropped and logged for Bedrock models without `cache_control` support

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No security implications. Prompt caching metadata is structural request data with no auth, secrets, or PII concerns.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable