### PR TITLE
feat: add optional schema option for postgres config and logs stores

### DIFF
--- a/docs/deployment-guides/config-json/storage.mdx
+++ b/docs/deployment-guides/config-json/storage.mdx
@@ -83,8 +83,17 @@ Production-grade storage suitable for high-availability and high-throughput depl
 | `password` | - | Database password (supports `env.` prefix). Leave empty for IAM role auth. |
 | `db_name` | - | Database name |
 | `ssl_mode` | - | `"disable"`, `"require"`, `"verify-ca"`, `"verify-full"` |
+| `schema` | connection `search_path` (usually `public`) | Optional Postgres schema. Auto-created on startup if missing (DB user needs `CREATE` on the database in that case). |
 | `max_idle_conns` | `5` | Maximum idle connections in the pool |
 | `max_open_conns` | `50` | Maximum open connections to the database |
+
+<Note>
+**Custom `schema`.**
+
+- If the schema already exists, grant the DB user `USAGE` and `CREATE` on that schema. Otherwise, grant the DB user `CREATE` on the database so Bifrost can create the schema on startup.
+- Schema should be owned by the Bifrost DB user. Untrusted users with `CREATE` on schemas earlier in `search_path` can shadow Bifrost's tables.
+- Name format: `[a-zA-Z_][a-zA-Z0-9_]*`, max 63 chars. Set per store.
+</Note>
 
 </Tab>
 

--- a/framework/configstore/postgres.go
+++ b/framework/configstore/postgres.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/pgsetup"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
@@ -17,15 +18,9 @@ type PostgresConfig struct {
 	Password     *schemas.EnvVar `json:"password"`
 	DBName       *schemas.EnvVar `json:"db_name"`
 	SSLMode      *schemas.EnvVar `json:"ssl_mode"`
+	Schema       *schemas.EnvVar `json:"schema,omitempty"`
 	MaxIdleConns int             `json:"max_idle_conns"`
 	MaxOpenConns int             `json:"max_open_conns"`
-}
-
-// buildPostgresDSN assembles a libpq-style DSN from the validated config.
-func buildPostgresDSN(config *PostgresConfig) string {
-	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
-		config.Host.GetValue(), config.Port.GetValue(), config.User.GetValue(),
-		config.Password.GetValue(), config.DBName.GetValue(), config.SSLMode.GetValue())
 }
 
 // openPostresConnection opens a *gorm.DB against the configured Postgres instance
@@ -100,7 +95,19 @@ func newPostgresConfigStore(ctx context.Context, config *PostgresConfig, logger 
 	if config.SSLMode == nil || config.SSLMode.GetValue() == "" {
 		return nil, fmt.Errorf("postgres ssl mode is required")
 	}
-	dsn := buildPostgresDSN(config)
+	schema, err := pgsetup.ResolveSchema(config.Schema)
+	if err != nil {
+		return nil, err
+	}
+	dsn := pgsetup.BuildDSN(pgsetup.DSN{
+		Host:     config.Host.GetValue(),
+		Port:     config.Port.GetValue(),
+		User:     config.User.GetValue(),
+		Password: config.Password.GetValue(),
+		DBName:   config.DBName.GetValue(),
+		SSLMode:  config.SSLMode.GetValue(),
+		Schema:   schema,
+	})
 
 	// Throwaway pool for schema migrations. Closing it before the runtime pool
 	// opens guarantees no cached prepared-plan survives the DDL.
@@ -108,11 +115,23 @@ func newPostgresConfigStore(ctx context.Context, config *PostgresConfig, logger 
 	if err != nil {
 		return nil, err
 	}
+	if err := pgsetup.EnsureSchema(mDb, schema); err != nil {
+		closeDbConn(mDb, logger)
+		return nil, err
+	}
 	if err := triggerMigrations(ctx, mDb); err != nil {
 		closeDbConn(mDb, logger)
 		return nil, err
 	}
-	closeDbConn(mDb, logger)
+	// Strict close: a half-closed migration pool weakens the guarantee that no
+	// cached prepared-plan survives the DDL. Treat close failure as fatal.
+	mSqlDb, err := mDb.DB()
+	if err != nil {
+		return nil, fmt.Errorf("resolve migration db pool: %w", err)
+	}
+	if err := mSqlDb.Close(); err != nil {
+		return nil, fmt.Errorf("close migration db connection: %w", err)
+	}
 
 	// Runtime pool. Opens against post-migration schema.
 	db, err := openPostresConnection(dsn, logger)

--- a/framework/logstore/postgres.go
+++ b/framework/logstore/postgres.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/pgsetup"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -19,6 +20,7 @@ type PostgresConfig struct {
 	Password     *schemas.EnvVar `json:"password"`
 	DBName       *schemas.EnvVar `json:"db_name"`
 	SSLMode      *schemas.EnvVar `json:"ssl_mode"`
+	Schema       *schemas.EnvVar `json:"schema,omitempty"`
 	MaxIdleConns int             `json:"max_idle_conns"`
 	MaxOpenConns int             `json:"max_open_conns"`
 }
@@ -54,7 +56,19 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 	if config.SSLMode == nil || config.SSLMode.GetValue() == "" {
 		return nil, fmt.Errorf("postgres ssl mode is required")
 	}
-	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s", config.Host.GetValue(), config.Port.GetValue(), config.User.GetValue(), config.Password.GetValue(), config.DBName.GetValue(), config.SSLMode.GetValue())
+	schema, err := pgsetup.ResolveSchema(config.Schema)
+	if err != nil {
+		return nil, err
+	}
+	dsn := pgsetup.BuildDSN(pgsetup.DSN{
+		Host:     config.Host.GetValue(),
+		Port:     config.Port.GetValue(),
+		User:     config.User.GetValue(),
+		Password: config.Password.GetValue(),
+		DBName:   config.DBName.GetValue(),
+		SSLMode:  config.SSLMode.GetValue(),
+		Schema:   schema,
+	})
 
 	openPool := func() (*gorm.DB, error) {
 		return gorm.Open(postgres.New(postgres.Config{DSN: dsn}), &gorm.Config{
@@ -93,6 +107,11 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 	if pgVersionNum < 160000 {
 		_ = closePool(mDb)
 		return nil, fmt.Errorf("postgres version is lower than 16, please upgrade to 16 or higher")
+	}
+
+	if err := pgsetup.EnsureSchema(mDb, schema); err != nil {
+		_ = closePool(mDb)
+		return nil, err
 	}
 
 	if err := triggerMigrations(ctx, mDb); err != nil {

--- a/framework/pgsetup/pgsetup.go
+++ b/framework/pgsetup/pgsetup.go
@@ -1,0 +1,94 @@
+// Package pgsetup provides Postgres connection bootstrap helpers: DSN assembly,
+// schema-name validation, and idempotent schema creation.
+package pgsetup
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"gorm.io/gorm"
+)
+
+var schemaNamePattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// ResolveSchema returns the validated schema name, or an empty string when unset.
+func ResolveSchema(s *schemas.EnvVar) (string, error) {
+	if s == nil {
+		return "", nil
+	}
+	name := s.GetValue()
+	if name == "" {
+		return "", nil
+	}
+	if len(name) > 63 {
+		return "", fmt.Errorf("postgres schema name exceeds 63 characters: %q", name)
+	}
+	if !schemaNamePattern.MatchString(name) {
+		return "", fmt.Errorf("postgres schema name must match [a-zA-Z_][a-zA-Z0-9_]*: %q", name)
+	}
+	return name, nil
+}
+
+// DSN holds the connection settings shared across stores.
+type DSN struct {
+	Host     string
+	Port     string
+	User     string
+	Password string
+	DBName   string
+	SSLMode  string
+	Schema   string
+}
+
+// escapeDSNValue quotes a libpq DSN value, escaping `\` and `'` when needed.
+func escapeDSNValue(v string) string {
+	if v == "" {
+		return "''"
+	}
+	if !strings.ContainsAny(v, " \t\n\r\v\f'\\") {
+		return v
+	}
+	v = strings.ReplaceAll(v, `\`, `\\`)
+	v = strings.ReplaceAll(v, `'`, `\'`)
+	return "'" + v + "'"
+}
+
+// BuildDSN renders a libpq DSN, prepending Schema to search_path when set.
+func BuildDSN(d DSN) string {
+	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
+		escapeDSNValue(d.Host),
+		escapeDSNValue(d.Port),
+		escapeDSNValue(d.User),
+		escapeDSNValue(d.Password),
+		escapeDSNValue(d.DBName),
+		escapeDSNValue(d.SSLMode),
+	)
+	if d.Schema != "" && d.Schema != "public" {
+		dsn += fmt.Sprintf(` search_path="%s",public`, d.Schema)
+	}
+	return dsn
+}
+
+// EnsureSchema creates the named schema if missing. No-op when name is empty.
+// Skips CREATE when the schema already exists. Pass name through ResolveSchema first.
+func EnsureSchema(db *gorm.DB, name string) error {
+	if name == "" {
+		return nil
+	}
+	var exists bool
+	if err := db.Raw(
+		`SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_namespace WHERE nspname = ?)`,
+		name,
+	).Scan(&exists).Error; err != nil {
+		return fmt.Errorf("failed to check postgres schema %q: %w", name, err)
+	}
+	if exists {
+		return nil
+	}
+	if err := db.Exec(fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %q`, name)).Error; err != nil {
+		return fmt.Errorf("failed to create postgres schema %q (DB user needs CREATE on the database, or pre-create the schema and grant USAGE+CREATE on it): %w", name, err)
+	}
+	return nil
+}

--- a/framework/pgsetup/pgsetup_test.go
+++ b/framework/pgsetup/pgsetup_test.go
@@ -1,0 +1,288 @@
+package pgsetup
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+const postgresDSN = "host=localhost user=bifrost password=bifrost_password dbname=bifrost port=5432 sslmode=disable"
+
+// TestResolveSchema covers ResolveSchema's handling of nil/empty inputs, valid
+// identifiers, regex rejection, and the 63-character length boundary.
+func TestResolveSchema(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   *schemas.EnvVar
+		want    string
+		wantErr bool
+	}{
+		{name: "nil", input: nil, want: ""},
+		{name: "empty value", input: &schemas.EnvVar{Val: ""}, want: ""},
+		{name: "valid simple", input: &schemas.EnvVar{Val: "bifrost"}, want: "bifrost"},
+		{name: "valid with underscore", input: &schemas.EnvVar{Val: "bif_rost_2"}, want: "bif_rost_2"},
+		{name: "valid leading underscore", input: &schemas.EnvVar{Val: "_internal"}, want: "_internal"},
+		{name: "starts with digit", input: &schemas.EnvVar{Val: "1bifrost"}, wantErr: true},
+		{name: "contains hyphen", input: &schemas.EnvVar{Val: "foo-bar"}, wantErr: true},
+		{name: "contains space", input: &schemas.EnvVar{Val: "foo bar"}, wantErr: true},
+		{name: "sql injection attempt", input: &schemas.EnvVar{Val: `foo"; DROP TABLE x;--`}, wantErr: true},
+		{name: "too long", input: &schemas.EnvVar{Val: strings.Repeat("a", 64)}, wantErr: true},
+		{name: "max length boundary", input: &schemas.EnvVar{Val: strings.Repeat("a", 63)}, want: strings.Repeat("a", 63)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveSchema(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestBuildDSN exercises BuildDSN's search_path handling (none, public, custom,
+// mixed-case) and password escaping for whitespace, quotes, and backslashes.
+func TestBuildDSN(t *testing.T) {
+	base := DSN{
+		Host:     "localhost",
+		Port:     "5432",
+		User:     "bifrost",
+		Password: "secret",
+		DBName:   "bifrost",
+		SSLMode:  "disable",
+	}
+
+	t.Run("no schema", func(t *testing.T) {
+		got := BuildDSN(base)
+		assert.NotContains(t, got, "search_path")
+		assert.Contains(t, got, "host=localhost")
+		assert.Contains(t, got, "dbname=bifrost")
+	})
+
+	t.Run("public schema is implicit", func(t *testing.T) {
+		d := base
+		d.Schema = "public"
+		got := BuildDSN(d)
+		assert.NotContains(t, got, "search_path")
+	})
+
+	t.Run("custom schema leads search_path", func(t *testing.T) {
+		d := base
+		d.Schema = "tenant_a"
+		got := BuildDSN(d)
+		assert.Contains(t, got, `search_path="tenant_a",public`)
+	})
+
+	t.Run("mixed-case schema preserves case via double quotes", func(t *testing.T) {
+		d := base
+		d.Schema = "TenantA"
+		got := BuildDSN(d)
+		assert.Contains(t, got, `search_path="TenantA",public`)
+	})
+
+	t.Run("password with space is quoted", func(t *testing.T) {
+		d := base
+		d.Password = "p ass"
+		got := BuildDSN(d)
+		assert.Contains(t, got, `password='p ass'`)
+	})
+
+	t.Run("password with quote and backslash is escaped", func(t *testing.T) {
+		d := base
+		d.Password = `a'b\c`
+		got := BuildDSN(d)
+		assert.Contains(t, got, `password='a\'b\\c'`)
+	})
+
+	t.Run("empty password becomes empty quoted", func(t *testing.T) {
+		d := base
+		d.Password = ""
+		got := BuildDSN(d)
+		assert.Contains(t, got, `password=''`)
+	})
+}
+
+// TestEscapeDSNValue covers escapeDSNValue's libpq quoting and escape rules
+// for empty, plain, whitespace, quote, and backslash inputs.
+func TestEscapeDSNValue(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", "''"},
+		{"plain", "plain"},
+		{"with space", "'with space'"},
+		{"with\ttab", "'with\ttab'"},
+		{"a'b", `'a\'b'`},
+		{`a\b`, `'a\\b'`},
+		{`mix 'and\stuff`, `'mix \'and\\stuff'`},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, escapeDSNValue(tt.in), "input=%q", tt.in)
+	}
+}
+
+// trySetupPostgresDB connects to Postgres or returns nil when unavailable.
+func trySetupPostgresDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(postgres.Open(postgresDSN), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		return nil
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil
+	}
+	if err := sqlDB.Ping(); err != nil {
+		_ = sqlDB.Close()
+		return nil
+	}
+	return db
+}
+
+// TestEnsureSchema verifies the empty-name no-op path and that EnsureSchema
+// creates a missing schema and is idempotent on a second call.
+func TestEnsureSchema(t *testing.T) {
+	db := trySetupPostgresDB(t)
+	if db == nil {
+		t.Skip("Postgres not available, skipping test")
+	}
+	dbSQL, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, dbSQL.Close()) })
+
+	t.Run("empty name is no-op", func(t *testing.T) {
+		require.NoError(t, EnsureSchema(db, ""))
+	})
+
+	t.Run("creates missing schema and is idempotent", func(t *testing.T) {
+		const name = "pgsetup_test_schema"
+		t.Cleanup(func() {
+			assert.NoError(t, db.Exec(`DROP SCHEMA IF EXISTS `+name+` CASCADE`).Error)
+		})
+		require.NoError(t, db.Exec(`DROP SCHEMA IF EXISTS `+name+` CASCADE`).Error)
+
+		require.NoError(t, EnsureSchema(db, name))
+		assert.True(t, schemaExists(t, db, name))
+
+		// Second call must not fail and must not re-issue CREATE for an existing schema.
+		require.NoError(t, EnsureSchema(db, name))
+	})
+}
+
+// TestBuildDSN_IntegrationCustomSchema connects to a real Postgres with a
+// mixed-case schema set in the DSN and verifies that an unqualified CREATE
+// TABLE lands in that schema (not `public`).
+func TestBuildDSN_IntegrationCustomSchema(t *testing.T) {
+	probe := trySetupPostgresDB(t)
+	if probe == nil {
+		t.Skip("Postgres not available, skipping test")
+	}
+	probeSQL, err := probe.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, probeSQL.Close()) })
+
+	const schemaName = "PgsetupIT_TenantA"
+	const dropSQL = `DROP SCHEMA IF EXISTS "PgsetupIT_TenantA" CASCADE`
+	require.NoError(t, probe.Exec(dropSQL).Error)
+	t.Cleanup(func() {
+		assert.NoError(t, probe.Exec(dropSQL).Error)
+	})
+
+	dsn := BuildDSN(DSN{
+		Host:     "localhost",
+		Port:     "5432",
+		User:     "bifrost",
+		Password: "bifrost_password",
+		DBName:   "bifrost",
+		SSLMode:  "disable",
+		Schema:   schemaName,
+	})
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	dbSQL, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, dbSQL.Close()) })
+
+	require.NoError(t, EnsureSchema(db, schemaName))
+	require.NoError(t, db.Exec(`CREATE TABLE search_path_probe (id int)`).Error)
+
+	var landed string
+	require.NoError(t, db.Raw(
+		`SELECT n.nspname FROM pg_class c
+		 JOIN pg_namespace n ON n.oid = c.relnamespace
+		 WHERE c.relname = 'search_path_probe' AND n.nspname = ?`,
+		schemaName,
+	).Scan(&landed).Error)
+	assert.Equal(t, schemaName, landed,
+		"unqualified CREATE TABLE landed in %q, expected %q (search_path quoting may be wrong)", landed, schemaName)
+}
+
+// TestBuildDSN_IntegrationSpecialCharPassword connects to Postgres as a role
+// whose password contains whitespace, single quotes, and backslashes.
+func TestBuildDSN_IntegrationSpecialCharPassword(t *testing.T) {
+	probe := trySetupPostgresDB(t)
+	if probe == nil {
+		t.Skip("Postgres not available, skipping test")
+	}
+	probeSQL, err := probe.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, probeSQL.Close()) })
+
+	const role = "pgsetup_it_specialchars"
+	const password = `pa ss'word\x`
+	// PG SQL literal: double the single quote, leave backslash literal.
+	const createSQL = `CREATE ROLE pgsetup_it_specialchars LOGIN PASSWORD 'pa ss''word\x'`
+	const dropSQL = `DROP ROLE IF EXISTS pgsetup_it_specialchars`
+	require.NoError(t, probe.Exec(dropSQL).Error)
+	require.NoError(t, probe.Exec(createSQL).Error)
+	t.Cleanup(func() {
+		assert.NoError(t, probe.Exec(dropSQL).Error)
+	})
+
+	dsn := BuildDSN(DSN{
+		Host:     "localhost",
+		Port:     "5432",
+		User:     role,
+		Password: password,
+		DBName:   "bifrost",
+		SSLMode:  "disable",
+	})
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	dbSQL, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, dbSQL.Close()) })
+
+	require.NoError(t, dbSQL.Ping(), "libpq rejected the DSN — escapeDSNValue output is wrong")
+
+	var who string
+	require.NoError(t, db.Raw(`SELECT current_user`).Scan(&who).Error)
+	assert.Equal(t, role, who, "authenticated as wrong user — password escaping likely truncated the value")
+}
+
+// schemaExists returns true when a schema with the given name is present in
+// information_schema.schemata.
+func schemaExists(t *testing.T, db *gorm.DB, name string) bool {
+	t.Helper()
+	var exists bool
+	require.NoError(t, db.Raw(
+		`SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = ?)`,
+		name,
+	).Scan(&exists).Error)
+	return exists
+}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -931,6 +931,24 @@
                     "type": "string",
                     "description": "Database SSL mode"
                   },
+                  "schema": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "maxLength": 0
+                      },
+                      {
+                        "type": "string",
+                        "maxLength": 63,
+                        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$"
+                      }
+                    ],
+                    "description": "Optional Postgres schema (supports `env.` prefix, or empty/unset for the connection default). Auto-created on startup if missing (DB user needs CREATE on the database). If it already exists, schema-level USAGE and CREATE are enough. Defaults to the connection's search_path (typically `public`)."
+                  },
                   "max_idle_conns": {
                     "type": "integer",
                     "description": "Maximum number of idle connections in the pool (default: 5)",
@@ -1028,6 +1046,24 @@
                   "ssl_mode": {
                     "type": "string",
                     "description": "Database SSL mode"
+                  },
+                  "schema": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "maxLength": 0
+                      },
+                      {
+                        "type": "string",
+                        "maxLength": 63,
+                        "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+                      },
+                      {
+                        "type": "string",
+                        "pattern": "^env\\.[A-Za-z_][A-Za-z0-9_]*$"
+                      }
+                    ],
+                    "description": "Optional Postgres schema (supports `env.` prefix, or empty/unset for the connection default). Auto-created on startup if missing (DB user needs CREATE on the database). If it already exists, schema-level USAGE and CREATE are enough. Defaults to the connection's search_path (typically `public`)."
                   },
                   "max_idle_conns": {
                     "type": "integer",


### PR DESCRIPTION
## Summary

Adds an optional `schema` field to the PostgreSQL config for `config_store` and `logs_store` so Bifrost's tables can live in a non `public` schema. Useful when sharing a database with other tenants or apps.

## Changes

- New `framework/pgsetup` package holding the shared bits (DSN, schema name validation, schema creation) for both stores.
- `EnsureSchema` checks `information_schema.schemata` and only runs `CREATE SCHEMA` when the schema is absent. `CREATE SCHEMA IF NOT EXISTS` still demands `CREATE` on the database, which would block users who pre-create the schema and only grant schema level rights.
- Schema names must match `[a-zA-Z_][a-zA-Z0-9_]*` and stay under 63 characters. Validated before being interpolated into raw SQL.
- When a custom schema is set, the DSN appends `search_path=<schema>,public` so DDL goes to the schema and `pgcrypto` style functions still resolve.
- `configstore/postgres.go` and `logstore/postgres.go` route through `pgsetup`. Old `buildPostgresDSN` helper removed.
- `transports/config.schema.json` and `docs/deployment-guides/config-json/storage.mdx` updated.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Unit tests
go -C framework test ./pgsetup/...

# Full integration tests (requires Postgres on :5432)
docker compose -f framework/docker-compose.yml up -d postgres
go -C framework test ./pgsetup/... ./configstore/... ./logstore/...
```

Manual checks:

1. `schema` unset: falls back to `public`, no change in behavior.
2. New `schema` value, DB user with `CREATE` on the database: schema is auto-created, tables land inside it.
3. Schema pre-created, DB user only has schema level `USAGE` + `CREATE`: startup succeeds (this case currently fails on `main`).
4. Invalid name (`foo-bar`, over 63 chars): startup fails with a validation error.
5. `config_store` and `logs_store` on the same database with different `schema` values: no cross-talk.

No new environment variables.

## Screenshots/Recordings

N/A.

## Breaking changes

- [ ] Yes
- [x] No

`schema` is optional. Configs that omit it behave the same as before.

## Related issues

N/A

## Security considerations

- Schema name is set in `config.json` by the deployer and validated against a strict identifier pattern with a 63-character cap before being used in DDL.
- Docs note that the schema should be owned by the Bifrost DB user, and that untrusted users with `CREATE` on schemas earlier in `search_path` could shadow Bifrost's tables.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


