### PR TITLE
fix: set full viewport height on governance users page container

### DIFF
--- a/ui/app/workspace/governance/users/page.tsx
+++ b/ui/app/workspace/governance/users/page.tsx
@@ -2,7 +2,7 @@ import UsersView from "@enterprise/components/user-groups/usersView";
 
 export default function GovernanceUsersPage() {
 	return (
-		<div className="mx-auto w-full max-w-7xl">
+		<div className="mx-auto w-full max-w-7xl h-[calc(100dvh-50px)]">
 			<UsersView />
 		</div>
 	);


### PR DESCRIPTION
## Summary

Fixes the Governance Users page layout so it fills the available viewport height without overflowing or leaving unused space below the top navigation bar.

## Changes

- Added `h-[calc(100dvh-50px)]` to the wrapper `div` on the Governance Users page, constraining its height to the full dynamic viewport height minus the 50px top bar.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to **Workspace → Governance → Users**.
2. Verify the users view fills the available vertical space below the top navigation bar without scrolling issues or extra whitespace.

## Screenshots/Recordings

Add before/after screenshots showing the corrected page height behavior.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable