### PR TITLE
refactor: move raw request extraction to final chunk processing in streaming accumulator

### DIFF
--- a/framework/streaming/accumulator.go
+++ b/framework/streaming/accumulator.go
@@ -55,7 +55,6 @@ func (a *Accumulator) putChatStreamChunk(chunk *ChatStreamChunk) {
 	chunk.FinishReason = nil
 	chunk.TokenUsage = nil
 	chunk.RawResponse = nil
-	chunk.RawRequest = nil
 	a.chatStreamChunkPool.Put(chunk)
 }
 

--- a/framework/streaming/chat.go
+++ b/framework/streaming/chat.go
@@ -414,9 +414,6 @@ func (a *Accumulator) processAccumulatedChatStreamingChunks(requestID string, re
 			data.Cost = lastChunk.Cost
 		}
 		data.FinishReason = lastChunk.FinishReason
-		if lastChunk.RawRequest != nil {
-			data.RawRequest = lastChunk.RawRequest
-		}
 	}
 	// Merge LogProbs from all chunks
 	if len(accumulator.ChatStreamChunks) > 0 {
@@ -508,9 +505,6 @@ func (a *Accumulator) processChatStreamingResponse(ctx *schemas.BifrostContext, 
 				chunk.Cost = bifrost.Ptr(cost)
 			}
 			chunk.SemanticCacheDebug = result.GetExtraFields().CacheDebug
-			if result.TextCompletionResponse.ExtraFields.RawRequest != nil {
-				chunk.RawRequest = bifrost.Ptr(fmt.Sprintf("%v", result.TextCompletionResponse.ExtraFields.RawRequest))
-			}
 		}
 	} else if result != nil && result.ChatResponse != nil {
 		// Extract delta and other information
@@ -537,10 +531,6 @@ func (a *Accumulator) processChatStreamingResponse(ctx *schemas.BifrostContext, 
 				chunk.Cost = bifrost.Ptr(cost)
 			}
 			chunk.SemanticCacheDebug = result.GetExtraFields().CacheDebug
-			// Set RawRequest on final chunk so it's available in processAccumulatedChatStreamingChunks
-			if result.ChatResponse.ExtraFields.RawRequest != nil {
-				chunk.RawRequest = bifrost.Ptr(fmt.Sprintf("%v", result.ChatResponse.ExtraFields.RawRequest))
-			}
 		}
 	}
 	if addErr := a.addChatStreamChunk(requestID, chunk, isFinalChunk); addErr != nil {
@@ -564,20 +554,22 @@ func (a *Accumulator) processChatStreamingResponse(ctx *schemas.BifrostContext, 
 			a.logger.Error("failed to process accumulated chunks for request %s: %v", requestID, processErr)
 			return nil, processErr
 		}
+		var rawRequest interface{}
+		if result != nil {
+			if result.ChatResponse != nil && result.ChatResponse.ExtraFields.RawRequest != nil {
+				rawRequest = result.ChatResponse.ExtraFields.RawRequest
+			} else if result.TextCompletionResponse != nil && result.TextCompletionResponse.ExtraFields.RawRequest != nil {
+				rawRequest = result.TextCompletionResponse.ExtraFields.RawRequest
+			}
+		}
 		return &ProcessedStreamResponse{
-			RequestID:  requestID,
-			StreamType: streamType,
-			Provider:   provider,
+			RequestID:      requestID,
+			StreamType:     streamType,
+			Provider:       provider,
 			RequestedModel: model,
 			ResolvedModel:  resolvedModel,
-			Data:       data,
-			RawRequest: func() *interface{} {
-				if data.RawRequest == nil {
-					return nil
-				}
-				var raw any = *data.RawRequest
-				return &raw
-			}(),
+			Data:           data,
+			RawRequest:     &rawRequest,
 		}, nil
 	}
 	// Non-final chunk: skip expensive rebuild since no consumer uses intermediate data.

--- a/framework/streaming/types.go
+++ b/framework/streaming/types.go
@@ -44,7 +44,6 @@ type AccumulatedData struct {
 	FinishReason          *string
 	LogProbs              *schemas.BifrostLogProbs
 	RawResponse           *string
-	RawRequest            *string
 }
 
 // AudioStreamChunk represents a single streaming chunk
@@ -85,7 +84,6 @@ type ChatStreamChunk struct {
 	ErrorDetails       *schemas.BifrostError                  // Error if any
 	ChunkIndex         int                                    // Index of the chunk in the stream
 	RawResponse        *string                                // Raw response if available
-	RawRequest         *string                                // Raw request if available (final chunk only)
 }
 
 // ResponsesStreamChunk represents a single responses streaming chunk


### PR DESCRIPTION
## Summary

Refactors how `RawRequest` is propagated through the streaming pipeline. Previously, `RawRequest` was stored as a string on intermediate `ChatStreamChunk` and `AccumulatedData` objects and carried through the chunk accumulation process. This approach was fragile and required special-casing to extract the value from the final chunk. The new approach reads `RawRequest` directly from the result's `ExtraFields` at the point where the final accumulated response is constructed, eliminating unnecessary intermediate storage.

## Changes

- Removed `RawRequest` field from `ChatStreamChunk` and `AccumulatedData` types, since it no longer needs to be threaded through intermediate streaming state.
- Removed logic that set `RawRequest` on the final chunk during `processChatStreamingResponse` and extracted it in `processAccumulatedChatStreamingChunks`.
- Added direct extraction of `RawRequest` from `result.ChatResponse.ExtraFields` or `result.TextCompletionResponse.ExtraFields` at the final response construction site in `processChatStreamingResponse`.
- Simplified the `RawRequest` field assignment in `ProcessedStreamResponse` — it now directly takes the address of the extracted value rather than going through a string conversion and nil-check closure.
- Removed the `chunk.RawRequest = nil` reset in `putChatStreamChunk` since the field no longer exists.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Verify that streaming chat responses still include the correct `RawRequest` value in the final `ProcessedStreamResponse`, and that intermediate chunks are unaffected.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. `RawRequest` data is handled the same way as before; only the internal propagation path has changed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable