### PR TITLE
feat: split mcp external base url into separate server and client URL fields

### DIFF
--- a/docs/deployment-guides/config-json/client.mdx
+++ b/docs/deployment-guides/config-json/client.mdx
@@ -54,18 +54,31 @@ Set `disable_content_logging: true` for HIPAA / PCI compliance workloads where m
 
 ## Reverse Proxy
 
+When Bifrost runs behind a reverse proxy, the OAuth URLs it advertises and uses are built from the incoming `Host` header by default - which is the proxy's internal address, not its public one. Two settings let you override this with the proxy's public URL.
+
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `mcp_external_base_url` | string or EnvVar | - | Public base URL advertised for OAuth callbacks and discovery metadata |
+| `mcp_external_server_url` | string or EnvVar | - | Public base URL Bifrost advertises in OAuth server metadata |
+| `mcp_external_client_url` | string or EnvVar | - | Public base URL Bifrost uses as the `redirect_uri` against upstream MCP servers |
 
-When Bifrost runs behind a reverse proxy, the OAuth callback URL and well-known discovery endpoints (`/.well-known/oauth-authorization-server`, etc.) are built from the incoming `Host` header - which is your proxy's internal address, not its public address. Set `mcp_external_base_url` to override this with the proxy's public URL.
+Both fields support env var syntax (`"env.MY_VAR"`). When unset, the field falls back to the incoming `Host` header.
 
-The field supports env var syntax so the URL can be injected at runtime:
+### The two roles
+
+Bifrost participates in OAuth in two directions, and each URL controls one direction:
+
+- **Server URL** is what *downstream MCP clients* read about Bifrost. It is the `issuer` in `/.well-known/oauth-authorization-server`, the `resource` in `/.well-known/oauth-protected-resource`, and the URL inside the `WWW-Authenticate` header on `/mcp`. Example: Claude Code connects to `https://bifrost.example.com/mcp` and discovers the authorize/token endpoints from this URL.
+- **Client URL** is what Bifrost hands to *upstream OAuth providers* as its own callback. It is the `redirect_uri` Bifrost registers with Notion, Jira, GitHub, etc. when it acts as an OAuth client to an MCP server. Upstream providers redirect the user's browser to `<client URL>/api/oauth/callback` after login.
+
+### Common case - one public URL
+
+Most deployments sit behind a single proxy and want both URLs to be the same. Set both to the same value:
 
 ```json
 {
   "client": {
-    "mcp_external_base_url": "env.BIFROST_EXTERNAL_URL"
+    "mcp_external_server_url": "env.BIFROST_EXTERNAL_URL",
+    "mcp_external_client_url": "env.BIFROST_EXTERNAL_URL"
   }
 }
 ```
@@ -75,12 +88,37 @@ Or as a plain URL:
 ```json
 {
   "client": {
-    "mcp_external_base_url": "https://api.yourcompany.com"
+    "mcp_external_server_url": "https://api.yourcompany.com",
+    "mcp_external_client_url": "https://api.yourcompany.com"
   }
 }
 ```
 
-This setting is also configurable via the UI (**MCP Gateway → MCP Settings**) and the management API, with no restart required.
+### Asymmetric case - different URLs per role
+
+Set them independently when the management/discovery surface and the OAuth callback surface live behind different proxies. For example, when the management UI and `/.well-known` endpoints are exposed on an internal-auth-protected hostname, but upstream OAuth providers need to redirect to a publicly reachable hostname:
+
+```json
+{
+  "client": {
+    "mcp_external_server_url": "https://internal.yourcompany.com",
+    "mcp_external_client_url": "https://oauth.yourcompany.com"
+  }
+}
+```
+
+You can also set just one and leave the other empty - the unset side falls back to the request's `Host` header.
+
+### When to use which
+
+| Scenario | Server URL | Client URL |
+|----------|------------|------------|
+| Single public proxy fronting Bifrost (most common) | proxy URL | same proxy URL |
+| Management/discovery on one hostname, OAuth callbacks on another | discovery hostname | callback hostname |
+| Bifrost reachable internally but upstream providers need a public callback | leave empty | public callback URL |
+| No reverse proxy (development) | leave empty | leave empty |
+
+These settings are also configurable via the UI (**MCP Gateway → MCP Settings**) and the management API, with no restart required.
 
 ---
 
@@ -282,7 +320,8 @@ A top-level `auth_config` is also accepted for backwards compatibility, but `gov
     "log_retention_days": 90,
     "logging_headers": ["x-request-id", "x-user-id"],
 
-    "mcp_external_base_url": "env.BIFROST_EXTERNAL_URL",
+    "mcp_external_server_url": "env.BIFROST_EXTERNAL_URL",
+    "mcp_external_client_url": "env.BIFROST_EXTERNAL_URL",
 
     "allowed_origins": ["https://app.yourcompany.com"],
     "allow_direct_keys": false,

--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -77,7 +77,8 @@ Controls the worker pool, logging pipeline, security, and SDK shims. All fields 
 | `async_job_result_ttl` | integer | `3600` | TTL for async job results in seconds |
 | `disable_db_pings_in_health` | boolean | `false` | Exclude DB connectivity from `/health` |
 | `routing_chain_max_depth` | integer | `10` | Max routing rule chain evaluation depth |
-| `mcp_external_base_url` | string \| EnvVar | - | Public base URL for OAuth callbacks/discovery when behind a reverse proxy; supports `"env.MY_VAR"` |
+| `mcp_external_server_url` | string \| EnvVar | - | Public base URL advertised in OAuth server metadata (`.well-known`, `WWW-Authenticate`); supports `"env.MY_VAR"` |
+| `mcp_external_client_url` | string \| EnvVar | - | Public base URL used as `redirect_uri` against upstream MCP OAuth providers; supports `"env.MY_VAR"` |
 
 Full documentation: [Client Configuration](/deployment-guides/config-json/client).
 

--- a/docs/mcp/gateway-url.mdx
+++ b/docs/mcp/gateway-url.mdx
@@ -303,6 +303,15 @@ The client then fetches the OAuth metadata and kicks off a consent flow where th
 
 See [Per-User OAuth →](./per-user-oauth) for the full flow and identity options.
 
+### Public URL configuration when behind a proxy
+
+The `WWW-Authenticate` URL above and the `redirect_uri` Bifrost hands to upstream OAuth providers (Notion, Jira, etc.) are both built from the request's `Host` header by default. Behind a reverse proxy that's the proxy's internal address, not its public one. Two settings override this:
+
+- `mcp_external_server_url` - what Bifrost advertises in `.well-known` metadata and `WWW-Authenticate` (read by downstream MCP clients).
+- `mcp_external_client_url` - what Bifrost registers as the `redirect_uri` with upstream OAuth providers.
+
+In most setups both are the same public URL. They can differ when the management/discovery surface and the OAuth callback surface live behind different proxies. See [Reverse Proxy configuration →](../deployment-guides/config-json/client#reverse-proxy) for the full reference and examples.
+
 ---
 
 ## Security Considerations

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -75,7 +75,8 @@ type ClientConfig struct {
 	WhitelistedRoutes                     []string                         `json:"whitelisted_routes,omitempty"`         // Routes that bypass auth middleware
 	HideDeletedVirtualKeysInFilters       bool                             `json:"hide_deleted_virtual_keys_in_filters"` // Hide deleted virtual keys from logs/MCP filter data
 	RoutingChainMaxDepth                  int                              `json:"routing_chain_max_depth"`              // Maximum depth for routing rule chain evaluation (default: 10)
-	MCPExternalBaseURL                    *schemas.EnvVar                  `json:"mcp_external_base_url,omitempty"`      // Public base URL for OAuth callbacks/discovery when behind a reverse proxy; supports env var syntax ("env.MY_VAR")
+	MCPExternalServerURL                  *schemas.EnvVar                  `json:"mcp_external_server_url,omitempty"`    // Public base URL advertised in OAuth server metadata (.well-known, WWW-Authenticate). Supports env var syntax ("env.MY_VAR")
+	MCPExternalClientURL                  *schemas.EnvVar                  `json:"mcp_external_client_url,omitempty"`    // Public base URL used as redirect_uri when Bifrost acts as an OAuth client to upstream MCP servers. Supports env var syntax ("env.MY_VAR")
 	ConfigHash                            string                           `json:"-"`                                    // Config hash for reconciliation (not serialized)
 }
 
@@ -314,11 +315,19 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 		}
 	}
 
-	if c.MCPExternalBaseURL.IsSet() {
-		if c.MCPExternalBaseURL.IsFromEnv() {
-			hash.Write([]byte("externalBaseURL:env:" + c.MCPExternalBaseURL.EnvVar))
+	if c.MCPExternalServerURL.IsSet() {
+		if c.MCPExternalServerURL.IsFromEnv() {
+			hash.Write([]byte("externalServerURL:env:" + c.MCPExternalServerURL.EnvVar))
 		} else {
-			hash.Write([]byte("externalBaseURL:val:" + c.MCPExternalBaseURL.GetValue()))
+			hash.Write([]byte("externalServerURL:val:" + c.MCPExternalServerURL.GetValue()))
+		}
+	}
+
+	if c.MCPExternalClientURL.IsSet() {
+		if c.MCPExternalClientURL.IsFromEnv() {
+			hash.Write([]byte("externalClientURL:env:" + c.MCPExternalClientURL.EnvVar))
+		} else {
+			hash.Write([]byte("externalClientURL:val:" + c.MCPExternalClientURL.GetValue()))
 		}
 	}
 
@@ -328,8 +337,11 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 // Redacted returns a copy of ClientConfig with any env-backed EnvVar fields masked.
 func (c *ClientConfig) Redacted() ClientConfig {
 	out := *c
-	if c.MCPExternalBaseURL != nil && c.MCPExternalBaseURL.IsFromEnv() {
-		out.MCPExternalBaseURL = c.MCPExternalBaseURL.Redacted()
+	if c.MCPExternalServerURL != nil && c.MCPExternalServerURL.IsFromEnv() {
+		out.MCPExternalServerURL = c.MCPExternalServerURL.Redacted()
+	}
+	if c.MCPExternalClientURL != nil && c.MCPExternalClientURL.IsFromEnv() {
+		out.MCPExternalClientURL = c.MCPExternalClientURL.Redacted()
 	}
 	return out
 }

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -620,6 +620,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddMCPExternalBaseURLColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationSplitMCPExternalBaseURL(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationMakeOAuthTokenExpiryNullable(ctx, db); err != nil {
 		return err
 	}
@@ -7157,8 +7160,11 @@ func migrationAddMCPExternalBaseURLColumn(ctx context.Context, db *gorm.DB) erro
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
 			mg := tx.Migrator()
+			// Use raw SQL — the Go field for this column has since been split into
+			// MCPExternalServerURL/MCPExternalClientURL by a follow-up migration, so
+			// we can no longer reference the original field name on the struct.
 			if !mg.HasColumn(&tables.TableClientConfig{}, "mcp_external_base_url") {
-				if err := mg.AddColumn(&tables.TableClientConfig{}, "MCPExternalBaseURL"); err != nil {
+				if err := tx.Exec("ALTER TABLE config_client ADD COLUMN mcp_external_base_url VARCHAR(512)").Error; err != nil {
 					return fmt.Errorf("failed to add mcp_external_base_url column: %w", err)
 				}
 			}
@@ -7168,7 +7174,7 @@ func migrationAddMCPExternalBaseURLColumn(ctx context.Context, db *gorm.DB) erro
 			tx = tx.WithContext(ctx)
 			mg := tx.Migrator()
 			if mg.HasColumn(&tables.TableClientConfig{}, "mcp_external_base_url") {
-				if err := mg.DropColumn(&tables.TableClientConfig{}, "mcp_external_base_url"); err != nil {
+				if err := tx.Exec("ALTER TABLE config_client DROP COLUMN mcp_external_base_url").Error; err != nil {
 					return fmt.Errorf("failed to drop mcp_external_base_url column: %w", err)
 				}
 			}
@@ -7177,6 +7183,68 @@ func migrationAddMCPExternalBaseURLColumn(ctx context.Context, db *gorm.DB) erro
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_mcp_external_base_url_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+func migrationSplitMCPExternalBaseURL(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "split_mcp_external_base_url_into_server_client",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TableClientConfig{}, "mcp_external_server_url") {
+				if err := mg.AddColumn(&tables.TableClientConfig{}, "MCPExternalServerURL"); err != nil {
+					return fmt.Errorf("failed to add mcp_external_server_url column: %w", err)
+				}
+			}
+			if !mg.HasColumn(&tables.TableClientConfig{}, "mcp_external_client_url") {
+				if err := mg.AddColumn(&tables.TableClientConfig{}, "MCPExternalClientURL"); err != nil {
+					return fmt.Errorf("failed to add mcp_external_client_url column: %w", err)
+				}
+			}
+			// Backfill: existing deployments treated mcp_external_base_url as applying
+			// to both roles, so copy it into both new columns to preserve behavior.
+			if mg.HasColumn(&tables.TableClientConfig{}, "mcp_external_base_url") {
+				if err := tx.Exec(
+					"UPDATE config_client SET mcp_external_server_url = mcp_external_base_url, mcp_external_client_url = mcp_external_base_url WHERE mcp_external_base_url IS NOT NULL AND mcp_external_base_url != ''",
+				).Error; err != nil {
+					return fmt.Errorf("failed to backfill mcp_external_*_url columns: %w", err)
+				}
+				if err := tx.Exec("ALTER TABLE config_client DROP COLUMN mcp_external_base_url").Error; err != nil {
+					return fmt.Errorf("failed to drop mcp_external_base_url column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TableClientConfig{}, "mcp_external_base_url") {
+				if err := tx.Exec("ALTER TABLE config_client ADD COLUMN mcp_external_base_url VARCHAR(512)").Error; err != nil {
+					return fmt.Errorf("failed to recreate mcp_external_base_url column: %w", err)
+				}
+			}
+			if mg.HasColumn(&tables.TableClientConfig{}, "mcp_external_server_url") {
+				if err := tx.Exec(
+					"UPDATE config_client SET mcp_external_base_url = mcp_external_server_url WHERE mcp_external_server_url IS NOT NULL AND mcp_external_server_url != ''",
+				).Error; err != nil {
+					return fmt.Errorf("failed to backfill mcp_external_base_url from mcp_external_server_url: %w", err)
+				}
+				if err := mg.DropColumn(&tables.TableClientConfig{}, "mcp_external_server_url"); err != nil {
+					return fmt.Errorf("failed to drop mcp_external_server_url column: %w", err)
+				}
+			}
+			if mg.HasColumn(&tables.TableClientConfig{}, "mcp_external_client_url") {
+				if err := mg.DropColumn(&tables.TableClientConfig{}, "mcp_external_client_url"); err != nil {
+					return fmt.Errorf("failed to drop mcp_external_client_url column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running split_mcp_external_base_url_into_server_client migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -136,9 +136,9 @@ func tableKeyFromSchemaKey(provider tables.TableProvider, key schemas.Key) (tabl
 	return dbKey, nil
 }
 
-// mcpExternalBaseURLToString converts an *schemas.EnvVar to its storage string form.
+// mcpExternalURLToString converts an *schemas.EnvVar to its storage string form.
 // Stores "env.MY_VAR" when sourced from an env var, or the raw URL otherwise.
-func mcpExternalBaseURLToString(e *schemas.EnvVar) string {
+func mcpExternalURLToString(e *schemas.EnvVar) string {
 	if e == nil {
 		return ""
 	}
@@ -182,7 +182,8 @@ func (s *RDBConfigStore) UpdateClientConfig(ctx context.Context, config *ClientC
 		WhitelistedRoutes:                     config.WhitelistedRoutes,
 		HideDeletedVirtualKeysInFilters:       config.HideDeletedVirtualKeysInFilters,
 		RoutingChainMaxDepth:                  config.RoutingChainMaxDepth,
-		MCPExternalBaseURL:                    mcpExternalBaseURLToString(config.MCPExternalBaseURL),
+		MCPExternalServerURL:                  mcpExternalURLToString(config.MCPExternalServerURL),
+		MCPExternalClientURL:                  mcpExternalURLToString(config.MCPExternalClientURL),
 		HeaderFilterConfig:                    config.HeaderFilterConfig,
 		AllowPerRequestContentStorageOverride: config.AllowPerRequestContentStorageOverride,
 		AllowPerRequestRawOverride:            config.AllowPerRequestRawOverride,
@@ -395,7 +396,8 @@ func (s *RDBConfigStore) GetClientConfig(ctx context.Context) (*ClientConfig, er
 		WhitelistedRoutes:                     dbConfig.WhitelistedRoutes,
 		HideDeletedVirtualKeysInFilters:       dbConfig.HideDeletedVirtualKeysInFilters,
 		RoutingChainMaxDepth:                  dbConfig.RoutingChainMaxDepth,
-		MCPExternalBaseURL:                    schemas.NewEnvVar(dbConfig.MCPExternalBaseURL),
+		MCPExternalServerURL:                  schemas.NewEnvVar(dbConfig.MCPExternalServerURL),
+		MCPExternalClientURL:                  schemas.NewEnvVar(dbConfig.MCPExternalClientURL),
 		HeaderFilterConfig:                    dbConfig.HeaderFilterConfig,
 		AllowPerRequestContentStorageOverride: dbConfig.AllowPerRequestContentStorageOverride,
 		AllowPerRequestRawOverride:            dbConfig.AllowPerRequestRawOverride,

--- a/framework/configstore/tables/clientconfig.go
+++ b/framework/configstore/tables/clientconfig.go
@@ -35,7 +35,8 @@ type TableClientConfig struct {
 	LoggingHeadersJSON                    string `gorm:"type:text" json:"-"`                                              // JSON serialized []string
 	HideDeletedVirtualKeysInFilters       bool   `gorm:"default:false" json:"hide_deleted_virtual_keys_in_filters"`       // Hide deleted virtual keys in logs filter dropdowns
 	RoutingChainMaxDepth                  int    `gorm:"default:10" json:"routing_chain_max_depth"`                       // Maximum depth for routing rule chain evaluation (default: 10)
-	MCPExternalBaseURL                    string `gorm:"type:varchar(512)" json:"mcp_external_base_url,omitempty"`        // Public base URL for OAuth callbacks/discovery when behind a reverse proxy
+	MCPExternalServerURL                  string `gorm:"type:varchar(512)" json:"mcp_external_server_url,omitempty"`      // Public base URL advertised in OAuth server metadata (.well-known, WWW-Authenticate)
+	MCPExternalClientURL                  string `gorm:"type:varchar(512)" json:"mcp_external_client_url,omitempty"`      // Public base URL used as redirect_uri when Bifrost acts as an OAuth client to upstream MCP servers
 	WhitelistedRoutesJSON                 string `gorm:"type:text" json:"-"`                                              // JSON serialized []string
 	AllowPerRequestContentStorageOverride bool   `gorm:"default:false" json:"allow_per_request_content_storage_override"` // Allow per-request override for content storage (e.g. long-term vs ephemeral)
 	AllowPerRequestRawOverride            bool   `gorm:"default:false" json:"allow_per_request_raw_override"`             // Allow per-request override for raw request/response storage

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -428,8 +428,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		updatedConfig.RoutingChainMaxDepth = payload.ClientConfig.RoutingChainMaxDepth
 	}
 
-	// Update external base URL for OAuth callbacks/discovery (nil clears the override).
-	updatedConfig.MCPExternalBaseURL = payload.ClientConfig.MCPExternalBaseURL
+	// Update external base URLs for OAuth server metadata and client redirect_uri (nil clears each override).
+	updatedConfig.MCPExternalServerURL = payload.ClientConfig.MCPExternalServerURL
+	updatedConfig.MCPExternalClientURL = payload.ClientConfig.MCPExternalClientURL
 
 	// Handle HeaderFilterConfig changes
 	if !headerFilterConfigEqual(payload.ClientConfig.HeaderFilterConfig, currentConfig.HeaderFilterConfig) {

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -439,7 +439,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			return
 		}
 
-		redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalBaseURL()) + "/api/oauth/callback"
+		redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
 
 		flowInitiation, err := h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
 			ClientID:        req.OauthConfig.ClientID,
@@ -527,7 +527,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		}
 
 		// Build redirect URI - use Bifrost's own callback endpoint
-		redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalBaseURL()) + "/api/oauth/callback"
+		redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
 
 		// Initiate OAuth flow
 		// ServerURL comes from ConnectionString (MCP server URL for OAuth discovery)

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -463,7 +463,7 @@ func (h *MCPServerHandler) getMCPServerForRequest(ctx *fasthttp.RequestCtx) (*se
 
 	// If per_user_oauth MCP clients are configured and no valid auth, return 401 with discovery
 	if clients := h.config.GetPerUserOAuthMCPClients(); len(clients) > 0 && userOauthSession == nil && vk == "" {
-		resourceMetadataURL := lib.BuildBaseURL(ctx, h.config.GetMCPExternalBaseURL()) + "/.well-known/oauth-protected-resource"
+		resourceMetadataURL := lib.BuildBaseURL(ctx, h.config.GetMCPExternalServerURL()) + "/.well-known/oauth-protected-resource"
 		ctx.Response.Header.Set("WWW-Authenticate",
 			fmt.Sprintf(`Bearer resource_metadata="%s"`, resourceMetadataURL))
 		return nil, nil, fmt.Errorf("oauth authentication required for mcp access")

--- a/transports/bifrost-http/handlers/oauth2_metadata.go
+++ b/transports/bifrost-http/handlers/oauth2_metadata.go
@@ -45,7 +45,7 @@ func (h *OAuthMetadataHandler) handleProtectedResourceMetadata(ctx *fasthttp.Req
 		sendStringError(ctx, fasthttp.StatusNotFound, "Not Found")
 		return
 	}
-	baseURL := lib.BuildBaseURL(ctx, h.store.GetMCPExternalBaseURL())
+	baseURL := lib.BuildBaseURL(ctx, h.store.GetMCPExternalServerURL())
 
 	SendJSON(ctx, map[string]interface{}{
 		"resource":                 baseURL + "/mcp",
@@ -65,7 +65,7 @@ func (h *OAuthMetadataHandler) handleAuthorizationServerMetadata(ctx *fasthttp.R
 		sendStringError(ctx, fasthttp.StatusNotFound, "Not Found")
 		return
 	}
-	baseURL := lib.BuildBaseURL(ctx, h.store.GetMCPExternalBaseURL())
+	baseURL := lib.BuildBaseURL(ctx, h.store.GetMCPExternalServerURL())
 
 	SendJSON(ctx, map[string]interface{}{
 		"issuer":                                baseURL,

--- a/transports/bifrost-http/handlers/oauth2_per_user.go
+++ b/transports/bifrost-http/handlers/oauth2_per_user.go
@@ -505,7 +505,7 @@ func (h *PerUserOAuthHandler) handleUpstreamAuthorize(ctx *fasthttp.RequestCtx) 
 	}
 
 	// Build redirect URI (Bifrost's callback endpoint).
-	redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalBaseURL()) + "/api/oauth/callback"
+	redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
 	var vkId *string
 	if virtualKeyID != "" {
 		vkId = &virtualKeyID

--- a/transports/bifrost-http/handlers/webrtc_realtime_test.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime_test.go
@@ -30,7 +30,8 @@ func (s testHandlerStore) GetKVStore() *kvstore.Store                       { re
 func (s testHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList { return nil }
 func (s testHandlerStore) ShouldAllowPerRequestStorageOverride() bool       { return false }
 func (s testHandlerStore) ShouldAllowPerRequestRawOverride() bool           { return false }
-func (s testHandlerStore) GetMCPExternalBaseURL() string                    { return "" }
+func (s testHandlerStore) GetMCPExternalServerURL() string                  { return "" }
+func (s testHandlerStore) GetMCPExternalClientURL() string                  { return "" }
 
 func TestResolveRealtimeSDPTarget_BaseRouteRequiresProviderPrefix(t *testing.T) {
 	_, _, _, err := resolveRealtimeSDPTarget("/v1/realtime", []byte(`{"model":"gpt-4o-realtime-preview"}`))

--- a/transports/bifrost-http/handlers/wsresponses_test.go
+++ b/transports/bifrost-http/handlers/wsresponses_test.go
@@ -52,7 +52,8 @@ func (s testWSHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList {
 
 func (s testWSHandlerStore) ShouldAllowPerRequestStorageOverride() bool { return false }
 func (s testWSHandlerStore) ShouldAllowPerRequestRawOverride() bool     { return false }
-func (s testWSHandlerStore) GetMCPExternalBaseURL() string              { return "" }
+func (s testWSHandlerStore) GetMCPExternalServerURL() string            { return "" }
+func (s testWSHandlerStore) GetMCPExternalClientURL() string            { return "" }
 
 type timeoutNetError struct{}
 

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -62,7 +62,11 @@ func (m *mockHandlerStore) ShouldAllowPerRequestRawOverride() bool {
 	return false
 }
 
-func (m *mockHandlerStore) GetMCPExternalBaseURL() string {
+func (m *mockHandlerStore) GetMCPExternalServerURL() string {
+	return ""
+}
+
+func (m *mockHandlerStore) GetMCPExternalClientURL() string {
 	return ""
 }
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -83,9 +83,14 @@ type HandlerStore interface {
 	ShouldAllowPerRequestStorageOverride() bool
 	// ShouldAllowPerRequestRawOverride returns whether per-request overrides for raw request/response visibility are permitted
 	ShouldAllowPerRequestRawOverride() bool
-	// GetMCPExternalBaseURL returns the configured external base URL for OAuth callbacks/metadata,
-	// or empty string if not configured (falls back to dynamic Host-header-based URL).
-	GetMCPExternalBaseURL() string
+	// GetMCPExternalServerURL returns the configured external base URL for OAuth server-side
+	// metadata (.well-known endpoints, WWW-Authenticate header), or empty string if not configured
+	// (falls back to dynamic Host-header-based URL).
+	GetMCPExternalServerURL() string
+	// GetMCPExternalClientURL returns the configured external base URL Bifrost uses as the
+	// redirect_uri when acting as an OAuth client to upstream MCP servers, or empty string
+	// if not configured (falls back to dynamic Host-header-based URL).
+	GetMCPExternalClientURL() string
 }
 
 // Retry backoff constants for validation
@@ -3257,10 +3262,18 @@ func (c *Config) ShouldAllowPerRequestRawOverride() bool {
 	return c.ClientConfig.AllowPerRequestRawOverride
 }
 
-// GetMCPExternalBaseURL returns the configured external base URL for OAuth callbacks and metadata,
-// or empty string if not configured. Resolves env var references automatically.
-func (c *Config) GetMCPExternalBaseURL() string {
-	return c.ClientConfig.MCPExternalBaseURL.GetValue()
+// GetMCPExternalServerURL returns the configured external base URL for OAuth server-side
+// metadata (.well-known endpoints, WWW-Authenticate header), or empty string if not configured.
+// Resolves env var references automatically.
+func (c *Config) GetMCPExternalServerURL() string {
+	return c.ClientConfig.MCPExternalServerURL.GetValue()
+}
+
+// GetMCPExternalClientURL returns the configured external base URL Bifrost uses as the
+// redirect_uri when acting as an OAuth client to upstream MCP servers, or empty string
+// if not configured. Resolves env var references automatically.
+func (c *Config) GetMCPExternalClientURL() string {
+	return c.ClientConfig.MCPExternalClientURL.GetValue()
 }
 
 // GetHeaderMatcher returns the precompiled header matcher for header filtering.

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -607,12 +607,13 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 		bifrostCtx.SetValue(schemas.BifrostContextKeyMCPUserID, mcpUserID)
 	}
 
-	// Build and set OAuth redirect URI for per-user OAuth flows
-	var externalBaseURL string
+	// Build and set OAuth redirect URI for per-user OAuth flows. Bifrost is acting as
+	// the OAuth client to upstream MCP servers here, so use the client-side override.
+	var externalClientURL string
 	if store != nil {
-		externalBaseURL = store.GetMCPExternalBaseURL()
+		externalClientURL = store.GetMCPExternalClientURL()
 	}
-	baseURL := BuildBaseURL(ctx, externalBaseURL)
+	baseURL := BuildBaseURL(ctx, externalClientURL)
 	if baseURL != "" {
 		bifrostCtx.SetValue(schemas.BifrostContextKeyOAuthRedirectURI, baseURL+"/api/oauth/callback")
 	}

--- a/transports/bifrost-http/lib/ctx_test.go
+++ b/transports/bifrost-http/lib/ctx_test.go
@@ -30,7 +30,8 @@ func (s testHandlerStore) GetMCPHeaderCombinedAllowlist() schemas.WhiteList {
 }
 func (s testHandlerStore) ShouldAllowPerRequestStorageOverride() bool { return false }
 func (s testHandlerStore) ShouldAllowPerRequestRawOverride() bool     { return false }
-func (s testHandlerStore) GetMCPExternalBaseURL() string              { return "" }
+func (s testHandlerStore) GetMCPExternalServerURL() string            { return "" }
+func (s testHandlerStore) GetMCPExternalClientURL() string            { return "" }
 
 func TestParseSessionIDFromBaggage(t *testing.T) {
 	tests := []struct {

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -228,7 +228,7 @@
           "description": "Maximum depth for routing rule chain evaluation",
           "default": 10
         },
-        "mcp_external_base_url": {
+        "mcp_external_server_url": {
           "anyOf": [
             {
               "type": "string"
@@ -243,7 +243,24 @@
               "additionalProperties": false
             }
           ],
-          "description": "Public base URL for OAuth callbacks and discovery metadata when Bifrost runs behind a reverse proxy (e.g. \"https://api.example.com\"). Supports env var syntax: \"env.MY_VAR\"."
+          "description": "Public base URL Bifrost advertises when acting as an OAuth server/resource (well-known metadata, WWW-Authenticate). Set when Bifrost runs behind a reverse proxy. Supports env var syntax: \"env.MY_VAR\"."
+        },
+        "mcp_external_client_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "value": { "type": "string" },
+                "env_var": { "type": "string" },
+                "from_env": { "type": "boolean" }
+              },
+              "additionalProperties": false
+            }
+          ],
+          "description": "Public base URL Bifrost uses as the redirect_uri when acting as an OAuth client to upstream MCP servers (Notion, Jira, etc.). Set when Bifrost's callback endpoint is reached via a different URL than its server-side metadata. Supports env var syntax: \"env.MY_VAR\"."
         }
       },
       "additionalProperties": false

--- a/ui/app/workspace/config/views/mcpView.tsx
+++ b/ui/app/workspace/config/views/mcpView.tsx
@@ -20,6 +20,11 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
+const envVarEquals = (a?: EnvVar, b?: EnvVar) =>
+  (a?.value ?? "") === (b?.value ?? "") &&
+  (a?.env_var ?? "") === (b?.env_var ?? "") &&
+  (a?.from_env ?? false) === (b?.from_env ?? false);
+
 export default function MCPView() {
   const hasSettingsUpdateAccess = useRbac(
     RbacResource.Settings,
@@ -59,10 +64,14 @@ export default function MCPView() {
 
   const hasChanges = useMemo(() => {
     if (!config) return false;
-    const externalBaseURLChanged =
-      (localConfig.mcp_external_base_url?.value ?? "") !== (config.mcp_external_base_url?.value ?? "") ||
-      (localConfig.mcp_external_base_url?.env_var ?? "") !== (config.mcp_external_base_url?.env_var ?? "") ||
-      (localConfig.mcp_external_base_url?.from_env ?? false) !== (config.mcp_external_base_url?.from_env ?? false);
+    const serverURLChanged = !envVarEquals(
+      localConfig.mcp_external_server_url,
+      config.mcp_external_server_url,
+    );
+    const clientURLChanged = !envVarEquals(
+      localConfig.mcp_external_client_url,
+      config.mcp_external_client_url,
+    );
     return (
       localConfig.mcp_agent_depth !== config.mcp_agent_depth ||
       localConfig.mcp_tool_execution_timeout !==
@@ -73,7 +82,8 @@ export default function MCPView() {
         (config.mcp_tool_sync_interval ?? 10) ||
       localConfig.mcp_disable_auto_tool_inject !==
         (config.mcp_disable_auto_tool_inject ?? false) ||
-      externalBaseURLChanged
+      serverURLChanged ||
+      clientURLChanged
     );
   }, [config, localConfig]);
 
@@ -119,6 +129,14 @@ export default function MCPView() {
       ...prev,
       mcp_disable_auto_tool_inject: checked,
     }));
+  }, []);
+
+  const handleServerURLChange = useCallback((value: EnvVar) => {
+    setLocalConfig((prev) => ({ ...prev, mcp_external_server_url: value }));
+  }, []);
+
+  const handleClientURLChange = useCallback((value: EnvVar) => {
+    setLocalConfig((prev) => ({ ...prev, mcp_external_client_url: value }));
   }, []);
 
   const handleSave = useCallback(async () => {
@@ -326,28 +344,64 @@ export default function MCPView() {
             )}
           </div>
         </div>
-        {/* External Base URL */}
-        <div className="space-y-2 rounded-sm border p-4">
+        {/* External Base URLs */}
+        <div className="space-y-4 rounded-sm border p-4">
           <div className="space-y-0.5">
-            <label htmlFor="external-base-url" className="text-sm font-medium">
-              External Base URL
-            </label>
+            <h3 className="text-sm font-medium">External Base URLs</h3>
             <p className="text-muted-foreground text-sm">
-              Override the base URL used for OAuth callbacks and discovery metadata (
-              <code className="text-xs">/.well-known/oauth-authorization-server</code>, etc.) when Bifrost runs behind a reverse proxy.
-              Supports env var syntax (e.g. <code className="text-xs">env.BIFROST_EXTERNAL_URL</code>).
+              Override Bifrost's public base URL when it runs behind a reverse proxy. In most setups
+              both URLs are the same — leave them blank to derive the URL from the incoming{" "}
+              <code className="text-xs">Host</code> header. Both fields support env var syntax (e.g.{" "}
+              <code className="text-xs">env.BIFROST_EXTERNAL_URL</code>).
             </p>
           </div>
-          <EnvVarInput
-            id="external-base-url"
-            data-testid="mcp-external-base-url-input"
-            placeholder="https://api.example.com or env.BIFROST_EXTERNAL_URL"
-            value={localConfig.mcp_external_base_url}
-            onChange={(value: EnvVar) =>
-              setLocalConfig((prev) => ({ ...prev, mcp_external_base_url: value }))
-            }
-            disabled={!hasSettingsUpdateAccess}
-          />
+
+          <div className="space-y-2">
+            <div className="space-y-0.5">
+              <label htmlFor="external-server-url" className="text-sm font-medium">
+                Server URL
+              </label>
+              <p className="text-muted-foreground text-sm">
+                Advertised in OAuth server metadata that <strong>downstream clients</strong> read about
+                Bifrost — e.g. <code className="text-xs">/.well-known/oauth-authorization-server</code>{" "}
+                and the <code className="text-xs">WWW-Authenticate</code> header on{" "}
+                <code className="text-xs">/mcp</code>. Example: Claude Code connects to{" "}
+                <code className="text-xs">https://bifrost.example.com/mcp</code> and discovers the
+                authorize/token endpoints from this URL.
+              </p>
+            </div>
+            <EnvVarInput
+              id="external-server-url"
+              data-testid="mcp-external-server-url-input"
+              placeholder="https://bifrost.example.com or env.BIFROST_EXTERNAL_URL"
+              value={localConfig.mcp_external_server_url}
+              onChange={handleServerURLChange}
+              disabled={!hasSettingsUpdateAccess}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <div className="space-y-0.5">
+              <label htmlFor="external-client-url" className="text-sm font-medium">
+                Client URL
+              </label>
+              <p className="text-muted-foreground text-sm">
+                Used as the <code className="text-xs">redirect_uri</code> Bifrost registers with{" "}
+                <strong>upstream OAuth providers</strong> when it acts as a client to an MCP server.
+                Example: when a user connects an MCP server like Notion or Jira, this is the URL
+                Notion/Jira will redirect the browser to after login (
+                <code className="text-xs">{"<URL>/api/oauth/callback"}</code>).
+              </p>
+            </div>
+            <EnvVarInput
+              id="external-client-url"
+              data-testid="mcp-external-client-url-input"
+              placeholder="https://bifrost.example.com or env.BIFROST_OAUTH_REDIRECT_URL"
+              value={localConfig.mcp_external_client_url}
+              onChange={handleClientURLChange}
+              disabled={!hasSettingsUpdateAccess}
+            />
+          </div>
         </div>
       </div>
       <div className="flex justify-end pt-2">

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -494,7 +494,8 @@ export interface CoreConfig {
 	hide_deleted_virtual_keys_in_filters: boolean;
 	routing_chain_max_depth: number;
 	header_filter_config?: GlobalHeaderFilterConfig;
-	mcp_external_base_url?: EnvVar;
+	mcp_external_server_url?: EnvVar;
+	mcp_external_client_url?: EnvVar;
 }
 
 export const DefaultCoreConfig: CoreConfig = {


### PR DESCRIPTION
## Summary

`mcp_external_base_url` served two distinct roles — advertising Bifrost's own OAuth metadata to downstream clients, and registering a `redirect_uri` with upstream OAuth providers. These roles need independent control when the management/discovery surface and the OAuth callback surface are reachable via different hostnames. This PR splits the single field into two: `mcp_external_server_url` and `mcp_external_client_url`.

## Changes

- `mcp_external_base_url` is replaced by `mcp_external_server_url` (controls `.well-known` metadata and `WWW-Authenticate`) and `mcp_external_client_url` (controls the `redirect_uri` sent to upstream OAuth providers like Notion, Jira, GitHub).
- A database migration backfills both new columns from the old `mcp_external_base_url` value to preserve existing behavior, then drops the old column. The previous migration that added `mcp_external_base_url` is updated to use raw SQL since the Go struct field no longer exists.
- All handler call sites that previously called `GetMCPExternalBaseURL()` now call the appropriate method — `GetMCPExternalServerURL()` for metadata/`WWW-Authenticate` paths and `GetMCPExternalClientURL()` for callback/redirect paths.
- The `HandlerStore` interface gains `GetMCPExternalServerURL()` and `GetMCPExternalClientURL()` in place of `GetMCPExternalBaseURL()`, with all test stubs updated accordingly.
- The UI settings panel is updated to show two labeled inputs with distinct descriptions explaining each role.
- The JSON schema, TypeScript types, and documentation are updated to reflect the new fields, including a reference table covering common deployment scenarios.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./...

# UI
cd ui
pnpm i
pnpm build
```

**Upgrade path validation:**
1. Deploy a build that has `mcp_external_base_url` set in the database.
2. Apply this build — the migration should copy the value into both `mcp_external_server_url` and `mcp_external_client_url`, then drop `mcp_external_base_url`.
3. Verify `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource` return the server URL.
4. Initiate an upstream OAuth flow (e.g. add an MCP server with OAuth) and confirm the `redirect_uri` in the authorization request uses the client URL.

**New config fields:**

| Field | Role |
|---|---|
| `mcp_external_server_url` | URL in `.well-known` metadata and `WWW-Authenticate` header |
| `mcp_external_client_url` | `redirect_uri` registered with upstream OAuth providers |

Both support `"env.MY_VAR"` syntax. When unset, each falls back to the incoming `Host` header.

## Breaking changes

- [x] Yes
- [ ] No

`mcp_external_base_url` is removed from the config struct, JSON schema, and database. The database migration handles existing rows automatically. Any external tooling or scripts that write `mcp_external_base_url` directly to the config API or database must be updated to use `mcp_external_server_url` and `mcp_external_client_url`.

## Security considerations

The split ensures that in asymmetric proxy deployments, the OAuth callback endpoint (`redirect_uri`) can be restricted to a dedicated publicly reachable hostname while the management/discovery surface remains on an internally protected hostname, reducing the attack surface for OAuth redirect abuse.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable