### PR TITLE
fix: fixes namespace in ResponseToolMessage to work correctly with Codex CLI

### DIFF
--- a/core/providers/openai/responses_marshal_test.go
+++ b/core/providers/openai/responses_marshal_test.go
@@ -870,3 +870,40 @@ func TestOpenAIResponsesRequest_MarshalJSON_KeepsAllWhenAllSupported(t *testing.
 		t.Errorf("expected 3 tools preserved, got %d", len(decoded.Tools))
 	}
 }
+
+// TestResponsesToolMessage_NamespaceRoundTrip verifies that the namespace field
+// on function_call items (returned by OpenAI when namespace tools are used) is
+// preserved through unmarshal → marshal without being dropped.
+func TestResponsesToolMessage_NamespaceRoundTrip(t *testing.T) {
+	raw := `{
+		"type": "function_call",
+		"id": "fc_abc123",
+		"call_id": "call_abc123",
+		"name": "get_app_state",
+		"namespace": "mcp__computer_use__",
+		"arguments": "{\"app\":\"Google Chrome\"}",
+		"status": "completed"
+	}`
+
+	var msg schemas.ResponsesMessage
+	if err := sonic.UnmarshalString(raw, &msg); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if msg.ResponsesToolMessage == nil {
+		t.Fatal("ResponsesToolMessage is nil after unmarshal")
+	}
+	if msg.ResponsesToolMessage.Namespace == nil {
+		t.Fatal("namespace field was dropped during unmarshal")
+	}
+	if *msg.ResponsesToolMessage.Namespace != "mcp__computer_use__" {
+		t.Fatalf("namespace mismatch: want %q, got %q", "mcp__computer_use__", *msg.ResponsesToolMessage.Namespace)
+	}
+
+	out, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if !strings.Contains(string(out), `"namespace":"mcp__computer_use__"`) {
+		t.Fatalf("namespace not in marshaled output: %s", string(out))
+	}
+}

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -745,6 +745,7 @@ type ResponsesOutputMessageContentRefusal struct {
 type ResponsesToolMessage struct {
 	CallID    *string                           `json:"call_id,omitempty"` // Common call ID for tool calls and outputs
 	Name      *string                           `json:"name,omitempty"`    // Common name field for tool calls
+	Namespace *string                           `json:"namespace,omitempty"` // Namespace for function_call items (set by OpenAI when namespace tools are used)
 	Arguments *string                           `json:"arguments,omitempty"`
 	Output    *ResponsesToolMessageOutputStruct `json:"output,omitempty"`
 	Action    *ResponsesToolMessageActionStruct `json:"action,omitempty"`


### PR DESCRIPTION
## Summary

OpenAI's Responses API returns a `namespace` field on `function_call` items when namespace tools (e.g., MCP tools) are used. This field was previously not defined on `ResponsesToolMessage`, causing it to be silently dropped during unmarshal/marshal cycles and breaking round-trip fidelity for these tool calls.

## Changes

- Added `Namespace *string` field to `ResponsesToolMessage` in `core/schemas/responses.go` so the `namespace` field from OpenAI `function_call` items is preserved
- Added `TestResponsesToolMessage_NamespaceRoundTrip` to verify that a `function_call` item containing a `namespace` value (e.g., `mcp__computer_use__`) survives a full unmarshal → marshal round-trip without being dropped

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/... -run TestResponsesToolMessage_NamespaceRoundTrip -v
go test ./core/...
```

The new test will fail on the previous code and pass with this fix. Confirm that the marshaled output contains `"namespace":"mcp__computer_use__"` and that the field is not `nil` after unmarshaling.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only adds a passthrough field for data already returned by OpenAI.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable