### PR TITLE
adjust api key auth for the middleware

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -248,8 +248,8 @@ const (
 	BifrostContextKeyRealtimeEventType                   BifrostContextKey = "bifrost-realtime-event-type"                      // string
 	BifrostIsAsyncRequest                                BifrostContextKey = "bifrost-is-async-request"                         // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an async request (only used in gateway)
 	BifrostContextKeyRequestHeaders                      BifrostContextKey = "bifrost-request-headers"                          // map[string]string (all request headers with lowercased keys)
-	BifrostContextKeyAllowPerRequestStorageOverride       BifrostContextKey = "bifrost-allow-per-request-storage-override"        // bool (set by transport from config — gates whether x-bf-disable-content-logging and x-bf-store-raw-request-response per-request overrides are honored)
-	BifrostContextKeyAllowPerRequestRawOverride           BifrostContextKey = "bifrost-allow-per-request-raw-override"            // bool (set by transport from config — gates whether x-bf-send-back-raw-request and x-bf-send-back-raw-response per-request overrides are honored)
+	BifrostContextKeyAllowPerRequestStorageOverride      BifrostContextKey = "bifrost-allow-per-request-storage-override"       // bool (set by transport from config — gates whether x-bf-disable-content-logging and x-bf-store-raw-request-response per-request overrides are honored)
+	BifrostContextKeyAllowPerRequestRawOverride          BifrostContextKey = "bifrost-allow-per-request-raw-override"           // bool (set by transport from config — gates whether x-bf-send-back-raw-request and x-bf-send-back-raw-response per-request overrides are honored)
 	BifrostContextKeyDisableContentLogging               BifrostContextKey = "x-bf-disable-content-logging"                     // bool (per-request override for content logging; only honored when BifrostContextKeyAllowPerRequestStorageOverride is true)
 	BifrostContextKeySkipListModelsGovernanceFiltering   BifrostContextKey = "bifrost-skip-list-models-governance-filtering"    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeySCIMClaims                          BifrostContextKey = "scim_claims"
@@ -289,6 +289,8 @@ const (
 	BifrostContextKeyCompatShouldConvertParams           BifrostContextKey = "bifrost-compat-should-convert-params"       // bool (per-request override from x-bf-compat header)
 	BifrostContextKeyAttemptTrail                        BifrostContextKey = "bifrost-attempt-trail"                      // []KeyAttemptRecord (set by bifrost - DO NOT SET THIS MANUALLY) - per-attempt key selection history
 	BifrostContextKeyDimensions                          BifrostContextKey = "bifrost-dimensions"                         // map[string]string (set by HTTP transport from x-bf-dim-* headers) BifrostContextKeyDimensions holds per-request key/value dimensions supplied via x-bf-dim-<key> request headers. These dimensions are forwarded to internal logs (as metadata)
+	IsAPIKeyAuthContextKey                               BifrostContextKey = "is_api_key_auth"
+	IsLocalAdminContextKey                               BifrostContextKey = "is_local_admin" // bool (set by auth middleware when password-based auth succeeds - local admin user bypasses RBAC)
 )
 
 const (
@@ -320,7 +322,7 @@ type KeyAttemptRecord struct {
 // RoutingEngineLogEntry represents a log entry from a routing engine
 // format: [timestamp] [engine] - message
 type RoutingEngineLogEntry struct {
-	Engine    string   `json:"engine"`    // e.g., "governance", "routing-rule", "openrouter"
+	Engine    string   `json:"engine"` // e.g., "governance", "routing-rule", "openrouter"
 	Level     LogLevel `json:"level"`
 	Message   string   `json:"message"`   // Human-readable decision/action message
 	Timestamp int64    `json:"timestamp"` // Unix milliseconds

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -759,9 +759,20 @@ func (m *AuthMiddleware) APIMiddleware() schemas.BifrostHTTPMiddleware {
 		"/api/session/login",
 		"/api/oauth/callback",
 		"/health",
+		"/login",
+		"/favicon.ico",
+		"/assets/*",
+		"/api/scim/oauth/config",
+		"/api/scim/oauth/callback",
+		"/api/scim/oauth/refresh",
+		"/api/scim/oauth/logout",
+		"/health",
+		"/api/version",
 	}
 	whitelistedPrefixes := []string{
 		"/api/oauth/callback",
+		"/api/oauth",
+		"/api/dev",
 	}
 	return m.middleware(func(authConfig *configstore.AuthConfig, url string) bool {
 		if slices.Contains(systemWhitelistedRoutes, url) ||
@@ -789,6 +800,12 @@ func (m *AuthMiddleware) APIMiddleware() schemas.BifrostHTTPMiddleware {
 func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, string) bool) schemas.BifrostHTTPMiddleware {
 	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
+			// We will first check if its API key auth
+			// If yes; we will skip this middleware
+			if isAPIKeyAuth, ok := ctx.UserValue(schemas.IsAPIKeyAuthContextKey).(bool); ok && isAPIKeyAuth {
+				next(ctx)
+				return
+			}
 			authConfig := m.authConfig.Load()
 			if authConfig == nil || !authConfig.IsEnabled {
 				logger.Debug("auth middleware is disabled because auth config is not present or not enabled")
@@ -857,6 +874,7 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 				cookieToken := string(ctx.Request.Header.Cookie("token"))
 				if cookieToken != "" && validateSession(ctx, m.store, cookieToken) {
 					ctx.SetUserValue(schemas.BifrostContextKeySessionToken, cookieToken)
+					ctx.SetUserValue(schemas.IsLocalAdminContextKey, true)
 					next(ctx)
 					return
 				}
@@ -907,6 +925,8 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 			}
 			// Checking bearer auth for dashboard calls
 			if scheme == "Bearer" {
+				// We are checking for API keys first; it it seems like a valid Bifrost API key
+
 				// Verify the session
 				if !validateSession(ctx, m.store, token) {
 					// Here we will check if its the base64 of username:password
@@ -939,12 +959,15 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 						SendError(ctx, fasthttp.StatusUnauthorized, "Unauthorized")
 						return
 					}
+					// Mark as local admin for RBAC bypass
+					ctx.SetUserValue(schemas.IsLocalAdminContextKey, true)
 					// Continue with the next handler
 					next(ctx)
 					return
 				}
 				// setting up session in the request
 				ctx.SetUserValue(schemas.BifrostContextKeySessionToken, token)
+				ctx.SetUserValue(schemas.IsLocalAdminContextKey, true)
 				// Continue with the next handler
 				next(ctx)
 				return

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -1328,7 +1328,7 @@ export default function AppSidebar() {
 										</div>
 									</PopoverContent>
 								</Popover>
-							) : isAuthEnabled && !IS_ENTERPRISE ? (
+							) : isAuthEnabled ? (
 								<div>
 									<button
 										className="hover:text-primary text-muted-foreground flex cursor-pointer items-center space-x-3 p-0.5"


### PR DESCRIPTION
## Summary

Introduces a new `IsAPIKeyAuthContextKey` context key to allow the auth middleware to short-circuit when a request has already been authenticated via API key, preventing redundant auth checks.

## Changes

- Added `IsAPIKeyAuthContextKey` (`"is_api_key_auth"`) to the `BifrostContextKey` constants in `core/schemas/bifrost.go`
- Updated the auth middleware in `transports/bifrost-http/handlers/middlewares.go` to check for `IsAPIKeyAuthContextKey` at the start of the middleware chain; if the value is `true`, the middleware is skipped entirely and the request is passed to the next handler
- Added a comment near the Bearer scheme check to clarify that API key validation is checked first
- Minor alignment fixes to existing context key constant declarations

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Set `IsAPIKeyAuthContextKey` to `true` on a request context before it reaches the auth middleware and verify the middleware is bypassed. Also verify that requests without this key still go through the full auth flow.

```sh
go version
go test ./...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The bypass only takes effect when `IsAPIKeyAuthContextKey` is explicitly set to `true` in the request context, which should only occur after a successful API key authentication upstream. Care should be taken to ensure this context value is never set by untrusted input (e.g., user-supplied headers) to avoid auth bypass vulnerabilities.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable