### PR TITLE
fix(http): nil stream converters panic; GenAI transcription stream SSE

### DIFF
--- a/core/providers/gemini/transcription.go
+++ b/core/providers/gemini/transcription.go
@@ -231,3 +231,43 @@ func ToGeminiTranscriptionResponse(bifrostResp *schemas.BifrostTranscriptionResp
 	genaiResp.Candidates = []*Candidate{candidate}
 	return genaiResp
 }
+
+// ToGeminiTranscriptionStreamResponses converts a Bifrost transcription streaming chunk to
+// Gemini streamGenerateContent JSON (GenerateContentResponse) for GenAI HTTP SSE clients.
+func ToGeminiTranscriptionStreamResponses(resp *schemas.BifrostTranscriptionStreamResponse) *GenerateContentResponse {
+	if resp == nil {
+		return nil
+	}
+	switch resp.Type {
+	case schemas.TranscriptionStreamResponseTypeDelta:
+		text := ""
+		if resp.Delta != nil {
+			text = *resp.Delta
+		}
+		if text == "" {
+			return nil
+		}
+		return &GenerateContentResponse{
+			Candidates: []*Candidate{{
+				Content: &Content{
+					Parts: []*Part{{Text: text}},
+					Role:  string(RoleModel),
+				},
+			}},
+		}
+	case schemas.TranscriptionStreamResponseTypeDone:
+		gen := ToGeminiTranscriptionResponse(&schemas.BifrostTranscriptionResponse{
+			Text:  resp.Text,
+			Usage: resp.Usage,
+		})
+		if gen == nil {
+			gen = &GenerateContentResponse{}
+		}
+		if len(gen.Candidates) > 0 {
+			gen.Candidates[0].FinishReason = FinishReasonStop
+		}
+		return gen
+	default:
+		return nil
+	}
+}

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -273,6 +273,19 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 				}
 				return "", geminiResponse, nil
 			},
+			TranscriptionStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostTranscriptionStreamResponse) (string, interface{}, error) {
+				if resp == nil {
+					return "", nil, nil
+				}
+				if resp.ExtraFields.RawResponse != nil {
+					return "", resp.ExtraFields.RawResponse, nil
+				}
+				geminiResponse := gemini.ToGeminiTranscriptionStreamResponses(resp)
+				if geminiResponse == nil {
+					return "", nil, nil
+				}
+				return "", geminiResponse, nil
+			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
 				return gemini.ToGeminiError(err)
 			},

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2502,17 +2502,41 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 
 				switch {
 				case chunk.BifrostTextCompletionResponse != nil:
-					eventType, convertedResponse, err = config.StreamConfig.TextStreamResponseConverter(bifrostCtx, chunk.BifrostTextCompletionResponse)
+					if config.StreamConfig.TextStreamResponseConverter == nil {
+						eventType, convertedResponse, err = "", nil, fmt.Errorf("text stream response converter is not configured")
+					} else {
+						eventType, convertedResponse, err = config.StreamConfig.TextStreamResponseConverter(bifrostCtx, chunk.BifrostTextCompletionResponse)
+					}
 				case chunk.BifrostChatResponse != nil:
-					eventType, convertedResponse, err = config.StreamConfig.ChatStreamResponseConverter(bifrostCtx, chunk.BifrostChatResponse)
+					if config.StreamConfig.ChatStreamResponseConverter == nil {
+						eventType, convertedResponse, err = "", nil, fmt.Errorf("chat stream response converter is not configured")
+					} else {
+						eventType, convertedResponse, err = config.StreamConfig.ChatStreamResponseConverter(bifrostCtx, chunk.BifrostChatResponse)
+					}
 				case chunk.BifrostResponsesStreamResponse != nil:
-					eventType, convertedResponse, err = config.StreamConfig.ResponsesStreamResponseConverter(bifrostCtx, chunk.BifrostResponsesStreamResponse)
+					if config.StreamConfig.ResponsesStreamResponseConverter == nil {
+						eventType, convertedResponse, err = "", nil, fmt.Errorf("responses stream response converter is not configured")
+					} else {
+						eventType, convertedResponse, err = config.StreamConfig.ResponsesStreamResponseConverter(bifrostCtx, chunk.BifrostResponsesStreamResponse)
+					}
 				case chunk.BifrostSpeechStreamResponse != nil:
-					eventType, convertedResponse, err = config.StreamConfig.SpeechStreamResponseConverter(bifrostCtx, chunk.BifrostSpeechStreamResponse)
+					if config.StreamConfig.SpeechStreamResponseConverter == nil {
+						eventType, convertedResponse, err = "", nil, fmt.Errorf("speech stream response converter is not configured")
+					} else {
+						eventType, convertedResponse, err = config.StreamConfig.SpeechStreamResponseConverter(bifrostCtx, chunk.BifrostSpeechStreamResponse)
+					}
 				case chunk.BifrostTranscriptionStreamResponse != nil:
-					eventType, convertedResponse, err = config.StreamConfig.TranscriptionStreamResponseConverter(bifrostCtx, chunk.BifrostTranscriptionStreamResponse)
+					if config.StreamConfig.TranscriptionStreamResponseConverter == nil {
+						eventType, convertedResponse, err = "", nil, fmt.Errorf("transcription stream response converter is not configured")
+					} else {
+						eventType, convertedResponse, err = config.StreamConfig.TranscriptionStreamResponseConverter(bifrostCtx, chunk.BifrostTranscriptionStreamResponse)
+					}
 				case chunk.BifrostImageGenerationStreamResponse != nil:
-					eventType, convertedResponse, err = config.StreamConfig.ImageGenerationStreamResponseConverter(bifrostCtx, chunk.BifrostImageGenerationStreamResponse)
+					if config.StreamConfig.ImageGenerationStreamResponseConverter == nil {
+						eventType, convertedResponse, err = "", nil, fmt.Errorf("image generation stream response converter is not configured")
+					} else {
+						eventType, convertedResponse, err = config.StreamConfig.ImageGenerationStreamResponseConverter(bifrostCtx, chunk.BifrostImageGenerationStreamResponse)
+					}
 				default:
 					requestType := safeGetRequestType(chunk)
 					convertedResponse, err = nil, fmt.Errorf("no response converter found for request type: %s", requestType)


### PR DESCRIPTION
## Summary
Bifrost (embedded in aihub) crashed with `SIGSEGV` during Gemini `:streamGenerateContent` **transcription** streaming: `handleStreaming` invoked a **nil** `*StreamResponseConverter` function pointer.

## Changes
1. **router.go**: Before calling `StreamConfig.*StreamResponseConverter`, check each converter is non-nil; if missing, return a logged error instead of panicking the process.
2. **genai.go**: Add **`TranscriptionStreamResponseConverter`** to GenAI `StreamConfig` (alongside the existing responses stream converter). Prefer passthrough via `ExtraFields.RawResponse` when set; otherwise use the gemini mapper.
3. **transcription.go**: Add `ToGeminiTranscriptionStreamResponses` to map Bifrost transcription stream chunks (delta/done) to `GenerateContentResponse`-shaped JSON for SSE clients.

## Root cause
GenAI `StreamConfig` only registered `ResponsesStreamResponseConverter`, not `TranscriptionStreamResponseConverter`. The pipeline still emitted `BifrostTranscriptionStreamResponse` chunks; the `switch` hit that case and called a nil function.

## Verification
- `cd core && go test ./providers/gemini/... -short` passes.
