### PR TITLE
fix: guard scoped context deadlines

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+[fix]: guard scoped context deadlines after plugin scope release [@ragokan](https://github.com/ragokan)

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -77,6 +77,9 @@ func NewBifrostContext(parent context.Context, deadline time.Time) *BifrostConte
 	if parent == nil {
 		parent = context.Background()
 	}
+	if parentCtx, ok := parent.(*BifrostContext); ok && parentCtx.valueDelegate != nil {
+		parent = parentCtx.valueDelegate
+	}
 	ctx := &BifrostContext{
 		parent:                parent,
 		deadline:              deadline,
@@ -197,8 +200,17 @@ func (bc *BifrostContext) cancel(err error) {
 // For scoped contexts, delegates to the root context.
 // If both this context and the parent have deadlines, the earlier one is returned.
 func (bc *BifrostContext) Deadline() (time.Time, bool) {
+	if bc == nil {
+		return time.Time{}, false
+	}
 	if bc.valueDelegate != nil {
 		return bc.valueDelegate.Deadline()
+	}
+	if bc.parent == nil {
+		if bc.hasDeadline {
+			return bc.deadline, true
+		}
+		return time.Time{}, false
 	}
 	parentDeadline, parentHasDeadline := bc.parent.Deadline()
 

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -77,7 +77,11 @@ func NewBifrostContext(parent context.Context, deadline time.Time) *BifrostConte
 	if parent == nil {
 		parent = context.Background()
 	}
-	if parentCtx, ok := parent.(*BifrostContext); ok && parentCtx.valueDelegate != nil {
+	for {
+		parentCtx, ok := parent.(*BifrostContext)
+		if !ok || parentCtx.valueDelegate == nil {
+			break
+		}
 		parent = parentCtx.valueDelegate
 	}
 	ctx := &BifrostContext{
@@ -200,9 +204,6 @@ func (bc *BifrostContext) cancel(err error) {
 // For scoped contexts, delegates to the root context.
 // If both this context and the parent have deadlines, the earlier one is returned.
 func (bc *BifrostContext) Deadline() (time.Time, bool) {
-	if bc == nil {
-		return time.Time{}, false
-	}
 	if bc.valueDelegate != nil {
 		return bc.valueDelegate.Deadline()
 	}

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -204,6 +204,9 @@ func (bc *BifrostContext) cancel(err error) {
 // For scoped contexts, delegates to the root context.
 // If both this context and the parent have deadlines, the earlier one is returned.
 func (bc *BifrostContext) Deadline() (time.Time, bool) {
+	if bc == nil {
+		return time.Time{}, false
+	}
 	if bc.valueDelegate != nil {
 		return bc.valueDelegate.Deadline()
 	}

--- a/core/schemas/context_test.go
+++ b/core/schemas/context_test.go
@@ -209,6 +209,11 @@ func TestNewBifrostContext_NilParent(t *testing.T) {
 }
 
 func TestBifrostContext_DeadlineWithClearedParent(t *testing.T) {
+	var nilCtx *BifrostContext
+	if _, ok := nilCtx.Deadline(); ok {
+		t.Fatal("nil BifrostContext should not report a deadline")
+	}
+
 	deadline, ok := (&BifrostContext{}).Deadline()
 	if ok {
 		t.Errorf("Context with cleared parent should not have deadline, got %v", deadline)

--- a/core/schemas/context_test.go
+++ b/core/schemas/context_test.go
@@ -208,6 +208,70 @@ func TestNewBifrostContext_NilParent(t *testing.T) {
 	}
 }
 
+func TestBifrostContext_DeadlineWithClearedParent(t *testing.T) {
+	deadline, ok := (&BifrostContext{}).Deadline()
+	if ok {
+		t.Errorf("Context with cleared parent should not have deadline, got %v", deadline)
+	}
+}
+
+func TestBifrostContext_DeadlineWithClearedParentAndOwnDeadline(t *testing.T) {
+	expected := time.Now().Add(time.Hour)
+	ctx := &BifrostContext{
+		deadline:    expected,
+		hasDeadline: true,
+	}
+
+	actual, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("Context with own deadline should report a deadline")
+	}
+	if !actual.Equal(expected) {
+		t.Errorf("Expected deadline %v, got %v", expected, actual)
+	}
+}
+
+func TestNewBifrostContext_ReleasedPluginScopeParent(t *testing.T) {
+	root := NewBifrostContext(context.Background(), NoDeadline)
+	defer root.Cancel()
+
+	name := "released-scope"
+	released := root.WithPluginScope(&name)
+	released.ReleasePluginScope()
+
+	ctx := NewBifrostContext(released, NoDeadline)
+	defer ctx.Cancel()
+
+	if _, ok := ctx.Deadline(); ok {
+		t.Error("Context with released plugin scope parent should not have deadline")
+	}
+}
+
+func TestNewBifrostContext_ScopedParentSurvivesScopeRelease(t *testing.T) {
+	expectedDeadline := time.Now().Add(time.Hour)
+	root := NewBifrostContext(context.Background(), expectedDeadline)
+	defer root.Cancel()
+	root.SetValue(BifrostContextKeyTraceID, "trace-123")
+
+	name := "scoped-parent"
+	scoped := root.WithPluginScope(&name)
+	ctx := NewBifrostContext(scoped, NoDeadline)
+	defer ctx.Cancel()
+
+	scoped.ReleasePluginScope()
+
+	actualDeadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("Context with scoped parent should retain root deadline")
+	}
+	if !actualDeadline.Equal(expectedDeadline) {
+		t.Errorf("Expected deadline %v, got %v", expectedDeadline, actualDeadline)
+	}
+	if traceID := ctx.Value(BifrostContextKeyTraceID); traceID != "trace-123" {
+		t.Errorf("Expected trace ID from root context, got %v", traceID)
+	}
+}
+
 // Plugin logging tests
 
 func TestPluginLog_NoScopeIsNoop(t *testing.T) {

--- a/core/schemas/context_test.go
+++ b/core/schemas/context_test.go
@@ -272,6 +272,34 @@ func TestNewBifrostContext_ScopedParentSurvivesScopeRelease(t *testing.T) {
 	}
 }
 
+func TestNewBifrostContext_NestedScopedParentSurvivesScopeRelease(t *testing.T) {
+	expectedDeadline := time.Now().Add(time.Hour)
+	root := NewBifrostContext(context.Background(), expectedDeadline)
+	defer root.Cancel()
+	root.SetValue(BifrostContextKeyTraceID, "trace-123")
+
+	nameA := "scoped-parent-a"
+	nameB := "scoped-parent-b"
+	scopedA := root.WithPluginScope(&nameA)
+	scopedB := scopedA.WithPluginScope(&nameB)
+	ctx := NewBifrostContext(scopedB, NoDeadline)
+	defer ctx.Cancel()
+
+	scopedB.ReleasePluginScope()
+	scopedA.ReleasePluginScope()
+
+	actualDeadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("Context with nested scoped parent should retain root deadline")
+	}
+	if !actualDeadline.Equal(expectedDeadline) {
+		t.Errorf("Expected deadline %v, got %v", expectedDeadline, actualDeadline)
+	}
+	if traceID := ctx.Value(BifrostContextKeyTraceID); traceID != "trace-123" {
+		t.Errorf("Expected trace ID from root context, got %v", traceID)
+	}
+}
+
 // Plugin logging tests
 
 func TestPluginLog_NoScopeIsNoop(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix a `BifrostContext` panic that can occur when a child context is created from a scoped plugin context and that scoped context is later released back to the pool.

Fixes #3178.

## Changes

- `NewBifrostContext` now unwraps scoped `BifrostContext` parents to their root context, so child contexts do not retain pooled scoped contexts after `ReleasePluginScope()`.
- `(*BifrostContext).Deadline()` now safely handles nil receivers and cleared parents while preserving its own configured deadline.
- Added regression tests for cleared parents, released scoped parents, and scoped-parent child contexts surviving scope release.
- Added a `core/changelog.md` entry for the fix.

Design trade-off: this keeps the existing scoped-context pool behavior, but avoids storing scoped pooled contexts as child parents.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

From `core/`:

```sh
go test ./schemas -run 'TestBifrostContext_DeadlineWithClearedParent|TestBifrostContext_DeadlineWithClearedParentAndOwnDeadline|TestNewBifrostContext_ReleasedPluginScopeParent|TestNewBifrostContext_ScopedParentSurvivesScopeRelease|TestNewBifrostContext_NestedScopedParentSurvivesScopeRelease' -count=1
go test ./schemas -count=1
go test -race ./schemas -count=1
```

Expected outcome: all commands pass.

No new configs or environment variables were added.

## Screenshots/Recordings

Not applicable; this is a Go core fix with no UI changes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes #3178.

## Security considerations

No new auth, secret, PII, sandboxing, or network behavior is introduced. The change only hardens context parent/deadline handling.

## Checklist

- [x] I read the available contributing guidelines (`docs/contributing/raising-a-pr.mdx`, `docs/contributing/code-conventions.mdx`); `docs/contributing/README.md` was not present on `main`
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed (`core/changelog.md`; no docs page needed)
- [ ] I verified builds succeed (Go and UI) - not run; change is scoped to `core/schemas`
- [ ] I verified the CI pipeline passes locally if applicable - not run; focused package tests and race test passed locally