### PR TITLE
adds missing changelogs

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,10 @@
-
+- feat: add `IsAPIKeyAuthContextKey` and `IsLocalAdminContextKey` context keys for middleware to short-circuit on API-key auth and bypass RBAC when auth is fully disabled
+- feat: add `NormalizeSchemaForAnthropicRaw` (gjson/sjson) so JSON schema normalization avoids a `map[string]interface{}` round-trip
+- feat: add `extractJSONSchemaObject` helper in Bedrock utils to unify composite and decomposed JSON schema fields for OpenAI-compat structured output
+- fix: skip model catalog routing if loadbalancer or governance routing has already set the provider in anthropic integration
+- fix: set extra params passthrough for SGL provider so SGLang vLLM-style extra-body parameters are no longer dropped (thanks [@hensapir](https://github.com/hensapir)!)
+- fix: suppress non-tool content events in Bedrock structured-output streaming so prose/preamble no longer corrupts the assembled JSON
+- fix: enrich `NewUnsupportedOperationError` with provider and request type in `ExtraFields`
+- fix: allow zero-millisecond streaming latency values (was previously rejected as invalid)
+- fix: add `String()` method on `BifrostError` so logged errors no longer dump raw bytes as decimal
+- chore: re-enable Vertex `ContextEditing` and `ContextManagementField`; disable Azure `TaskBudgets` in the feature-support matrix; add `claude-4.6-sonnet` mapping for the Bedrock test account

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -10,7 +10,15 @@
 - **Auth Config Disabled Context** - Update request context correctly when auth config is disabled
 - **MCP Tool Field Resolution** - Resolve `tools_to_execute` and `tools_to_auto_execute` from existing config before validation in MCP client update
 - **SCIM Page Layout** - Added `no-scrollbar` utility class and applied `no-padding-parent` to the SCIM page
+- **SGL Extra Params Passthrough** - SGL provider now sets `BifrostContextKeyPassthroughExtraParams`, so SGLang vLLM-style extra-body params (`chat_template_kwargs`, `guided_json`, `guided_regex`, `separate_reasoning`) are no longer silently dropped (thanks [@hensapir](https://github.com/hensapir)!)
+- **Bedrock Structured-Output Streaming** - Suppress non-tool content events (text deltas, reasoning, non-tool content-block starts) when structured output mode is active, preventing prose from corrupting the assembled JSON
+- **`BifrostError` String Output** - Added `String()` method so logged errors render as JSON instead of decimal byte dumps
+- **Streaming Latency Validation** - Allow zero-millisecond latency values (valid for sub-millisecond cache hits)
+- **`NewUnsupportedOperationError` Context** - Now populates `Provider` and `RequestType` in `ExtraFields`
 
 ## 🔧 Maintenance
 
 - **Streaming Accumulator Raw Request** - Moved raw request extraction to final chunk processing in the streaming accumulator
+- **Provider Capability Matrix** - Re-enabled `ContextEditing` and `ContextManagementField` for Vertex; disabled `TaskBudgets` for Azure (not documented upstream); added `claude-4.6-sonnet` support to Bedrock test account
+- **Schema Normalizer** - Added raw-byte JSON schema normalizer (`NormalizeSchemaForAnthropicRaw`) to avoid map round-trips during Anthropic schema preparation
+- **Auth Middleware Context Keys** - Added `IsAPIKeyAuthContextKey` (short-circuit when API-key auth already passed) and `IsLocalAdminContextKey` (bypass RBAC when auth is disabled)


### PR DESCRIPTION
## Summary

This PR delivers a batch of bug fixes, new features, and maintenance improvements across the core library and transports layer, addressing issues with structured-output streaming corruption, dropped extra parameters for the SGL provider, error logging readability, and auth middleware context handling.

## Changes

- Added `IsAPIKeyAuthContextKey` and `IsLocalAdminContextKey` context keys to allow middleware to short-circuit on API-key auth and bypass RBAC when auth is fully disabled
- Added `NormalizeSchemaForAnthropicRaw` using gjson/sjson to avoid a `map[string]interface{}` round-trip during Anthropic schema preparation
- Added `extractJSONSchemaObject` helper in Bedrock utils to unify composite and decomposed JSON schema fields for OpenAI-compat structured output
- Fixed Anthropic integration to skip model catalog routing when loadbalancer or governance routing has already set the provider
- Fixed SGL provider to set `BifrostContextKeyPassthroughExtraParams` so SGLang vLLM-style extra-body parameters (`chat_template_kwargs`, `guided_json`, `guided_regex`, `separate_reasoning`) are no longer silently dropped (thanks [@hensapir](https://github.com/hensapir)!)
- Fixed Bedrock structured-output streaming to suppress non-tool content events (text deltas, reasoning, non-tool content-block starts), preventing prose/preamble from corrupting the assembled JSON
- Fixed `NewUnsupportedOperationError` to populate `Provider` and `RequestType` in `ExtraFields`
- Fixed streaming latency validation to allow zero-millisecond values, which are valid for sub-millisecond cache hits
- Added `String()` method on `BifrostError` so logged errors render as JSON instead of raw decimal byte dumps
- Re-enabled `ContextEditing` and `ContextManagementField` for Vertex; disabled `TaskBudgets` for Azure (not documented upstream); added `claude-4.6-sonnet` mapping for the Bedrock test account

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

- Validate SGL extra-body params (`guided_json`, `chat_template_kwargs`, etc.) are forwarded correctly to SGLang endpoints
- Validate Bedrock structured-output streaming does not include prose/preamble in the assembled JSON output
- Confirm `BifrostError` values log as JSON strings rather than byte arrays
- Confirm zero-millisecond streaming latency values are accepted without validation errors
- Verify API-key auth and local admin context keys correctly short-circuit middleware flows

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The new `IsLocalAdminContextKey` bypasses RBAC when auth is fully disabled. This is intentional for local/admin deployments but should be reviewed to ensure it cannot be set by untrusted callers in production auth configurations.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable