### PR TITLE
Enable passthrough fallback for OpenAI routes

### DIFF
--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -2879,7 +2879,7 @@ func OpenAIRealtimeClientSecretPaths(pathPrefix string) []string {
 	return paths
 }
 
-// NewOpenAIRouter creates a new OpenAIRouter with the given bifrost client.
+// NewOpenAIRouter creates a new OpenAIRouter with OpenAI compatibility passthrough enabled.
 func NewOpenAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *OpenAIRouter {
 	routes := CreateOpenAIRouteConfigs("/openai", handlerStore)
 	routes = append(routes, CreateOpenAIListModelsRouteConfigs("/openai", handlerStore)...)

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -2889,7 +2889,12 @@ func NewOpenAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, log
 	routes = append(routes, CreateOpenAIContainerFileRouteConfigs("/openai", handlerStore)...)
 
 	return &OpenAIRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, routes, &PassthroughConfig{
+			Provider: schemas.OpenAI,
+			StripPrefix: []string{
+				"/openai",
+			},
+		}, logger),
 	}
 }
 

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -13,6 +13,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewOpenAIRouterEnablesOpenAICompatibilityPassthrough(t *testing.T) {
+	router := NewOpenAIRouter(nil, &mockHandlerStore{allowDirectKeys: true}, nil)
+
+	require.NotNil(t, router.GenericRouter)
+	require.NotNil(t, router.passthroughCfg)
+	assert.Equal(t, schemas.OpenAI, router.passthroughCfg.Provider)
+	assert.Equal(t, []string{"/openai"}, router.passthroughCfg.StripPrefix)
+}
+
 func TestParsePassthroughBody_MultipartExtractsModelAfterFilePart(t *testing.T) {
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestNewOpenAIRouterEnablesOpenAICompatibilityPassthrough verifies unmatched OpenAI-compatible routes fall back to provider passthrough.
 func TestNewOpenAIRouterEnablesOpenAICompatibilityPassthrough(t *testing.T) {
 	router := NewOpenAIRouter(nil, &mockHandlerStore{allowDirectKeys: true}, nil)
 


### PR DESCRIPTION
`/openai` already has first-class routes for the common OpenAI APIs, but requests that are only available through OpenAI compatibility passthrough were not being forwarded.

That means flows like `client.responses.retrieve(...)` for background response jobs can hit Bifrost's OpenAI base URL and get the transport 404 page instead of being proxied to OpenAI.

This PR enables the existing passthrough fallback on the OpenAI router:

- unmatched `/openai/*` requests are forwarded through the OpenAI passthrough provider
- `/openai` is stripped before forwarding, so `/openai/v1/responses/{id}` becomes the provider path `/v1/responses/{id}`
- existing explicit OpenAI routes still stay registered before the catch-all passthrough
- adds a small router test so the OpenAI router cannot lose this passthrough config again

Fixes #3121.

Validation:

```bash
git diff --check
GOFLAGS='-vet=off' go test ./integrations -run 'TestNewOpenAIRouterEnablesOpenAICompatibilityPassthrough|TestParsePassthroughBody_MultipartExtractsModelAfterFilePart'
```

I used `GOFLAGS='-vet=off'` for the targeted test because this checkout pulls a very large dependency graph and the runner repeatedly ran out of disk while writing vet temp files. The package tests themselves passed after cleaning the build/module caches.
