### PR TITLE
fix(bedrock): developer-role, empty-content, and streaming terminal events

### DIFF
--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2933,6 +2933,14 @@ func convertBifrostMessageToBedrockMessage(msg *schemas.ResponsesMessage) *Bedro
 	if err != nil {
 		return nil
 	}
+	// Bedrock Converse rejects messages with null/empty content. Codex CLI emits
+	// placeholder assistant messages with content=[] between tool-call turns,
+	// and historic transcripts may contain messages whose content consisted
+	// entirely of reasoning/metadata blocks that this converter doesn't map.
+	// Drop such messages so upstream callers can emit a coherent sequence.
+	if len(contentBlocks) == 0 {
+		return nil
+	}
 	bedrockMsg.Content = contentBlocks
 
 	return &bedrockMsg

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2800,7 +2800,11 @@ func ConvertBifrostMessagesToBedrockMessages(bifrostMessages []schemas.Responses
 			}
 
 			// Convert regular message
-			if role == schemas.ResponsesInputMessageRoleSystem {
+			// OpenAI's Responses API permits role="developer" as a system-message
+			// variant. Bedrock Converse rejects anything other than user/assistant,
+			// so fold "developer" into the system-message branch. See:
+			// github.com/maximhq/bifrost/issues/2492
+			if role == schemas.ResponsesInputMessageRoleSystem || role == schemas.ResponsesInputMessageRoleDeveloper {
 				// Convert to system message
 				systemMsgs := convertBifrostMessageToBedrockSystemMessages(&msg)
 				systemMessages = append(systemMessages, systemMsgs...)

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -20,6 +20,7 @@ import (
 type BedrockResponsesStreamState struct {
 	ContentIndexToOutputIndex map[int]int    // Maps Bedrock contentBlockIndex to OpenAI output_index
 	ToolArgumentBuffers       map[int]string // Maps output_index to accumulated tool argument JSON
+	TextBuffers               map[int]string // Maps output_index to accumulated assistant text for done events
 	ItemIDs                   map[int]string // Maps output_index to item ID for stable IDs
 	ToolCallIDs               map[int]string // Maps output_index to tool call ID (callID)
 	ToolCallNames             map[int]string // Maps output_index to tool call name
@@ -40,6 +41,7 @@ var bedrockResponsesStreamStatePool = sync.Pool{
 		return &BedrockResponsesStreamState{
 			ContentIndexToOutputIndex: make(map[int]int),
 			ToolArgumentBuffers:       make(map[int]string),
+			TextBuffers:               make(map[int]string),
 			ItemIDs:                   make(map[int]string),
 			ToolCallIDs:               make(map[int]string),
 			ToolCallNames:             make(map[int]string),
@@ -67,6 +69,11 @@ func acquireBedrockResponsesStreamState() *BedrockResponsesStreamState {
 		state.ToolArgumentBuffers = make(map[int]string)
 	} else {
 		clear(state.ToolArgumentBuffers)
+	}
+	if state.TextBuffers == nil {
+		state.TextBuffers = make(map[int]string)
+	} else {
+		clear(state.TextBuffers)
 	}
 	if state.ItemIDs == nil {
 		state.ItemIDs = make(map[int]string)
@@ -123,6 +130,11 @@ func (state *BedrockResponsesStreamState) flush() {
 		state.ToolArgumentBuffers = make(map[int]string)
 	} else {
 		clear(state.ToolArgumentBuffers)
+	}
+	if state.TextBuffers == nil {
+		state.TextBuffers = make(map[int]string)
+	} else {
+		clear(state.TextBuffers)
 	}
 	if state.ItemIDs == nil {
 		state.ItemIDs = make(map[int]string)
@@ -663,6 +675,7 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 			// If this is a text delta for a new content block, also emit the text delta in the same batch
 			if chunk.Delta.Text != nil && *chunk.Delta.Text != "" {
 				text := *chunk.Delta.Text
+				state.TextBuffers[outputIndex] += text
 				itemID := state.ItemIDs[outputIndex]
 				textDeltaResponse := &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeOutputTextDelta,
@@ -689,6 +702,7 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 			// Handle text delta
 			text := *chunk.Delta.Text
 			if text != "" {
+				state.TextBuffers[outputIndex] += text
 				itemID := state.ItemIDs[outputIndex]
 				response := &schemas.BifrostResponsesStreamResponse{
 					Type:           schemas.ResponsesStreamResponseTypeOutputTextDelta,
@@ -965,22 +979,26 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 		} else {
 			// This is likely a text item that needs to be closed
 
-			// Emit output_text.done (without accumulated text, just the event)
-			emptyText := ""
+			// Retrieve accumulated text from the delta buffer so clients that
+			// rehydrate from terminal events see the final message body, not
+			// an empty string.
+			accumulatedText := state.TextBuffers[outputIndex]
+
+			// Emit output_text.done with the accumulated text
 			responses = append(responses, &schemas.BifrostResponsesStreamResponse{
 				Type:           schemas.ResponsesStreamResponseTypeOutputTextDone,
 				SequenceNumber: sequenceNumber + len(responses),
 				OutputIndex:    schemas.Ptr(outputIndex),
 				ContentIndex:   &contentIndex,
 				ItemID:         &itemID,
-				Text:           &emptyText,
+				Text:           &accumulatedText,
 				LogProbs:       []schemas.ResponsesOutputMessageContentTextLogProb{},
 			})
 
 			// Emit content_part.done for text
 			part := &schemas.ResponsesMessageContentBlock{
 				Type: schemas.ResponsesOutputMessageContentTypeText,
-				Text: &emptyText,
+				Text: &accumulatedText,
 				ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
 					LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
 					Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
@@ -995,16 +1013,27 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 				Part:           part,
 			})
 
-			// Emit output_item.done for text
+			// Emit output_item.done for text (include the accumulated content)
 			statusCompleted := "completed"
 			messageType := schemas.ResponsesMessageTypeMessage
 			role := schemas.ResponsesInputMessageRoleAssistant
+			doneContentBlocks := []schemas.ResponsesMessageContentBlock{}
+			if accumulatedText != "" {
+				doneContentBlocks = append(doneContentBlocks, schemas.ResponsesMessageContentBlock{
+					Type: schemas.ResponsesOutputMessageContentTypeText,
+					Text: &accumulatedText,
+					ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+						LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+						Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+					},
+				})
+			}
 			doneItem := &schemas.ResponsesMessage{
 				Type:   &messageType,
 				Role:   &role,
 				Status: &statusCompleted,
 				Content: &schemas.ResponsesMessageContent{
-					ContentBlocks: []schemas.ResponsesMessageContentBlock{},
+					ContentBlocks: doneContentBlocks,
 				},
 			}
 			if itemID != "" {
@@ -1131,6 +1160,43 @@ func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber in
 		} else {
 			response.StopReason = schemas.Ptr("stop")
 		}
+	}
+
+	// Populate Output with the accumulated text items so clients that rehydrate
+	// from response.completed (rather than accumulating deltas themselves) see
+	// the final message body. Tool-call items are materialised separately
+	// during the stream; this reconstructs plain-text items only.
+	for outIdx := 0; outIdx <= state.CurrentOutputIndex; outIdx++ {
+		text, ok := state.TextBuffers[outIdx]
+		if !ok || text == "" {
+			continue
+		}
+		itemID := state.ItemIDs[outIdx]
+		messageType := schemas.ResponsesMessageTypeMessage
+		role := schemas.ResponsesInputMessageRoleAssistant
+		statusCompleted := "completed"
+		textCopy := text
+		item := schemas.ResponsesMessage{
+			Type:   &messageType,
+			Role:   &role,
+			Status: &statusCompleted,
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{
+					{
+						Type: schemas.ResponsesOutputMessageContentTypeText,
+						Text: &textCopy,
+						ResponsesOutputMessageContentText: &schemas.ResponsesOutputMessageContentText{
+							LogProbs:    []schemas.ResponsesOutputMessageContentTextLogProb{},
+							Annotations: []schemas.ResponsesOutputMessageContentTextAnnotation{},
+						},
+					},
+				},
+			},
+		}
+		if itemID != "" {
+			item.ID = &itemID
+		}
+		response.Output = append(response.Output, item)
 	}
 
 	responses = append(responses, &schemas.BifrostResponsesStreamResponse{

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -551,8 +551,10 @@ func convertMessages(bifrostMessages []schemas.ChatMessage) ([]BedrockMessage, [
 	for i := 0; i < len(bifrostMessages); i++ {
 		msg := bifrostMessages[i]
 		switch msg.Role {
-		case schemas.ChatMessageRoleSystem:
-			// Convert system message
+		case schemas.ChatMessageRoleSystem, schemas.ChatMessageRoleDeveloper:
+			// OpenAI's Chat Completions API accepts role="developer" as a
+			// system-message variant. Bedrock Converse rejects it, so fold it
+			// into the system branch. See github.com/maximhq/bifrost/issues/2492
 			systemMsgs, err := convertSystemMessages(msg)
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to convert system message: %w", err)

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -567,6 +567,12 @@ func convertMessages(bifrostMessages []schemas.ChatMessage) ([]BedrockMessage, [
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to convert message: %w", err)
 			}
+			// Bedrock Converse rejects messages with null/empty content. Skip
+			// user/assistant turns that carry no text, tool calls, or reasoning
+			// (e.g. Codex CLI placeholder assistants between tool-call turns).
+			if len(bedrockMsg.Content) == 0 {
+				continue
+			}
 			messages = append(messages, bedrockMsg)
 
 		case schemas.ChatMessageRoleTool:


### PR DESCRIPTION
## Summary

Three related defects in the Bedrock Converse translator that together blocked OpenAI Codex (CLI 0.128.0 and Desktop 0.128.0-alpha.1) from completing a single turn against Bedrock via Bifrost. All three live in `core/providers/bedrock/{responses.go,utils.go}`, all three were discovered in one integration pass, and all three are verified together on `v1.4.24` deployed live.

Keeping them bundled because (a) they're the same class — assumptions about OpenAI's wire format that don't hold for every client, (b) scope is identical (two files, both Bedrock-only), (c) they compound: fixing any one in isolation doesn't unblock Codex.

## Changes

### 1. `developer` role not mapped to `system` (fixes #2492)

OpenAI's Chat Completions and Responses APIs accept `role: "developer"` as a system-message variant (introduced with GPT-5 / reasoning models). Bedrock Converse rejects anything other than `user` / `assistant` in its `messages` array.

```
Value 'developer' at 'messages.N.member.role' failed to satisfy constraint:
Member must satisfy enum value set: [user, assistant]
```

The responses-to-chat fallback in `core/schemas/mux.go` already handles this via `normalizeDeveloperRoleForChatFallback`, and the Gemini provider handles it at `core/providers/gemini/responses.go:2962`. The native Bedrock translators just missed the case.

- `core/providers/bedrock/responses.go`: fold `ResponsesInputMessageRoleDeveloper` into the system-message branch
- `core/providers/bedrock/utils.go`: same for `ChatMessageRoleDeveloper`

### 2. Empty-content messages forwarded to Bedrock

Codex emits placeholder assistant messages with `content: []` between tool-call turns. The translator forwarded these as Bedrock messages with empty Content slices, which Bedrock rejects:

```
Value null at 'messages.N.member.content' failed to satisfy constraint: Member must not be null
```

- `convertBifrostMessageToBedrockMessage` returns `nil` when converted content is empty (caller already handles nil by skipping)
- `convertMessages` skips user/assistant messages whose converted content is empty

### 3. Streaming terminal events dropped accumulated text

The Bedrock responses-stream translator emits per-token `response.output_text.delta` events correctly, but hardcoded `emptyText := ""` on every terminal event:

- `response.output_text.done` — `text=""`
- `response.content_part.done` — `part.text=""`
- `response.output_item.done` — `item.content=[]`
- `response.completed` — `response.output=null`

Clients that accumulate deltas themselves (OpenAI SDK, Codex CLI) were unaffected. Clients that rehydrate from terminal events (Codex Desktop) rendered empty bubbles because the authoritative post-stream state said the message had no content.

- Adds `TextBuffers map[int]string` to `BedrockResponsesStreamState`, populated from both text-delta emit sites
- Terminal event emitters now use accumulated text instead of a hardcoded empty string
- `response.completed` reconstructs plain-text items in `response.Output` from the buffer (tool-call items are materialised separately during the stream and are a pre-existing out-of-scope limitation)

## Diff size

- `core/providers/bedrock/responses.go`: +85 / -7
- `core/providers/bedrock/utils.go`: +10 / -2

## How to test

```bash
# Fix 1: developer role
curl https://<bifrost>/v1/responses \
  -H 'Authorization: Bearer <vk>' -H 'Content-Type: application/json' \
  -d '{
    "model":"bedrock/us.anthropic.claude-opus-4-7",
    "input":[
      {"role":"developer","content":"Speak like a pirate."},
      {"role":"user","content":"Hi"}
    ],
    "max_output_tokens":40
  }'
# Before: HTTP 400 (developer rejected). After: 200 with pirate reply.

# Fix 2: empty assistant content in history
curl https://<bifrost>/v1/responses \
  -H 'Authorization: Bearer <vk>' -H 'Content-Type: application/json' \
  -d '{
    "model":"bedrock/us.anthropic.claude-opus-4-7",
    "input":[
      {"role":"user","content":"hi"},
      {"role":"assistant","content":[]},
      {"role":"user","content":"say pong"}
    ],
    "max_output_tokens":10
  }'
# Before: HTTP 400 (null content). After: 200.

# Fix 3: streaming terminal events
curl -N https://<bifrost>/v1/responses \
  -H 'Authorization: Bearer <vk>' -H 'Content-Type: application/json' \
  -d '{
    "model":"bedrock/us.anthropic.claude-opus-4-7",
    "input":[{"role":"user","content":"say pong"}],
    "max_output_tokens":10, "stream":true
  }'
# Inspect the response.output_text.done / response.completed events.
# Before: text="" / output=null. After: text="pong" / output=[{...content:[{text:"pong"}]...}].
```

End-to-end: Codex Desktop 0.128.0-alpha.1 → Bifrost → Bedrock Opus 4.7 (us-east-1) rendered empty bubbles before; full multi-turn with tool use after.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Providers/Integrations (Bedrock)

## Breaking changes

- [x] No

Each fix strictly expands the set of inputs the translator accepts or enriches the set of outputs it emits. No existing working call pattern changes shape.

## Related issues

Fixes #2492. (#2528 was an earlier attempt at #1 that closed without merging — this PR takes the simpler, single-line approach the Gemini provider and chat fallback already use.)
