### PR TITLE
fix: backfill `Model` in embedding response when provider omits it

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5908,6 +5908,7 @@ func (bifrost *Bifrost) handleProviderRequest(provider schemas.Provider, config 
 		if bifrostError != nil {
 			return nil, bifrostError
 		}
+		embeddingResponse.BackfillParams(req.BifrostRequest.EmbeddingRequest)
 		response.EmbeddingResponse = embeddingResponse
 	case schemas.RerankRequest:
 		rerankResponse, bifrostError := provider.Rerank(req.Context, key, req.BifrostRequest.RerankRequest)

--- a/core/schemas/embedding.go
+++ b/core/schemas/embedding.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"fmt"
+	"strings"
 )
 
 type BifrostEmbeddingRequest struct {
@@ -23,6 +24,16 @@ type BifrostEmbeddingResponse struct {
 	Object      string                     `json:"object"` // "list"
 	Usage       *BifrostLLMUsage           `json:"usage"`
 	ExtraFields BifrostResponseExtraFields `json:"extra_fields"`
+}
+
+// BackfillParams copies request metadata into the response when the provider omitted it (e.g. model in JSON).
+func (r *BifrostEmbeddingResponse) BackfillParams(request *BifrostEmbeddingRequest) {
+	if r == nil || request == nil {
+		return
+	}
+	if strings.TrimSpace(r.Model) == "" && strings.TrimSpace(request.Model) != "" {
+		r.Model = request.Model
+	}
 }
 
 // EmbeddingInput represents the input for an embedding request.


### PR DESCRIPTION
## Summary

Some embedding providers omit the `model` field from their response payloads. This PR ensures the model name from the original request is backfilled into the response when the provider leaves it blank, so callers always receive a consistent response with the model field populated.

## Changes

- Added a `BackfillParams` method on `BifrostEmbeddingResponse` that copies the `Model` field from the request into the response if the provider returned an empty value.
- Called `BackfillParams` in the embedding request handler in `bifrost.go` immediately after a successful provider response is received.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send an embedding request to a provider known to omit the `model` field in its response and verify the returned `BifrostEmbeddingResponse` contains the model name from the original request.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This change only copies a non-sensitive model name string from the request into the response.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable