### PR TITLE
dac oss changes

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -260,10 +260,13 @@ const (
 	BifrostContextKeyDisableContentLogging               BifrostContextKey = "x-bf-disable-content-logging"                     // bool (per-request override for content logging; only honored when BifrostContextKeyAllowPerRequestStorageOverride is true)
 	BifrostContextKeySkipListModelsGovernanceFiltering   BifrostContextKey = "bifrost-skip-list-models-governance-filtering"    // bool (set by bifrost - DO NOT SET THIS MANUALLY))
 	BifrostContextKeySCIMClaims                          BifrostContextKey = "scim_claims"
-	BifrostContextKeyUserID                              BifrostContextKey = "bifrost-user-id"   // string (to store the user ID (set by enterprise auth middleware - DO NOT SET THIS MANUALLY))
-	BifrostContextKeyUserName                            BifrostContextKey = "bifrost-user-name" // string (to store the user name (set by enterprise auth middleware - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyUserID                              BifrostContextKey = "bifrost-user-id"                    // string (to store the user ID (set by enterprise auth middleware - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyUserName                            BifrostContextKey = "bifrost-user-name"                  // string (to store the user name (set by enterprise auth middleware - DO NOT SET THIS MANUALLY))
+	BifrostContextKeyQueryScope                          BifrostContextKey = "bifrost-query-scope"                // configstore.QueryScope (func that mutates a query; set by upstream wrapper - DO NOT SET THIS MANUALLY)
+	BifrostContextKeyVisibilityFilterProvider            BifrostContextKey = "bifrost-visibility-filter-provider" // DEPRECATED: replaced by BifrostContextKeyQueryScope. Will be removed once all callers migrate.
 	BifrostContextKeyTargetUserID                        BifrostContextKey = "target_user_id"
 	BifrostContextKeyIsAzureUserAgent                    BifrostContextKey = "bifrost-is-azure-user-agent" // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an Azure user agent (only used in gateway)
+	BifrostContextKeyUserRoleID                          BifrostContextKey = "bifrost-user-role-id"
 	BifrostContextKeyVideoOutputRequested                BifrostContextKey = "bifrost-video-output-requested"
 	BifrostContextKeyValidateKeys                        BifrostContextKey = "bifrost-validate-keys"                         // bool (triggers additional key validation during provider add/update)
 	BifrostContextKeyProviderResponseHeaders             BifrostContextKey = "bifrost-provider-response-headers"             // map[string]string (set by provider handlers for response header forwarding)

--- a/core/schemas/visibility.go
+++ b/core/schemas/visibility.go
@@ -1,0 +1,137 @@
+package schemas
+
+import "context"
+
+// Entity identifies the target row family that a VisibilityFilter is being
+// resolved for. The provider closure stashed on the request context returns
+// only the dimensions relevant to the requested entity, leaving every other
+// dimension nil. This keeps OSS query helpers from having to reason about
+// dimensions their target table cannot consume.
+type Entity string
+
+// Entity values cover every list/read endpoint that participates in
+// row-level visibility filtering. Add a new constant only when a query
+// helper for a new table is introduced.
+const (
+	EntityVirtualKey       Entity = "virtual_key"
+	EntityPrompt           Entity = "prompt"
+	EntityLog              Entity = "log"
+	EntityRoutingRule      Entity = "routing_rule"
+	EntityUser             Entity = "user"
+	EntityRole             Entity = "role"
+	EntityTeam             Entity = "team"
+	EntityBusinessUnit     Entity = "business_unit"
+	EntityCustomer         Entity = "customer"
+	EntityAuditLog         Entity = "audit_log"
+	EntityAccessProfile    Entity = "access_profile"
+	EntityAPIKey           Entity = "api_key"
+	EntityMCPToolGroup     Entity = "mcp_tool_group"
+	EntityPromptDeployment Entity = "prompt_deployment"
+	EntityProvider         Entity = "provider"
+)
+
+// RoutingScopeMatch is a single (scope, scope_id) pair the caller is
+// allowed to see in routing_rules. The "global" scope is always implicitly
+// allowed and does not need to be enumerated.
+type RoutingScopeMatch struct {
+	Scope   string
+	ScopeID string
+}
+
+// VisibilityFilter restricts list and read queries to rows the caller is
+// allowed to see.
+//
+// Semantics: a row is visible iff ANY non-nil dimension matches its
+// corresponding column. A nil dimension means that dimension imposes no
+// restriction — but other non-nil dimensions still apply. An empty slice
+// means the dimension matches no rows (callers that need "everything except
+// this dimension" should use a nil pointer instead). A filter with all
+// dimensions nil is equivalent to "no filter" (full visibility).
+//
+// A VisibilityFilter is the response shape of the per-request provider
+// closure (see VisibilityFilterProvider). The provider returns a filter
+// with only the dimensions relevant to the requested Entity populated;
+// every other dimension is nil.
+//
+// Each dimension lines up with a real column on the target table:
+//
+//   - UserIDs         → table.user_id  OR  governance_users.id (when
+//     scoping the users table itself)
+//   - TeamIDs         → table.team_id  (logs / prompts / VKs)
+//   - OwnTeamIDs      → governance_teams.id (when scoping the teams
+//     table itself; populated from the principal's own
+//     team membership for both own-data and team-data)
+//   - VirtualKeyIDs   → governance_virtual_keys.id (when scoping the
+//     virtual_keys table itself) or table.virtual_key_id
+//     (when scoping logs)
+//   - RoutingScopes   → routing_rules.(scope, scope_id) tuples
+//   - RoleIDs         → enterprise_governance_roles.id
+//   - BusinessUnitIDs → governance_business_units.id
+//   - CustomerIDs     → governance_customers.id
+type VisibilityFilter struct {
+	UserIDs         *[]string
+	TeamIDs         *[]string
+	OwnTeamIDs      *[]string
+	VirtualKeyIDs   *[]string
+	RoutingScopes   *[]RoutingScopeMatch
+	RoleIDs         *[]uint
+	BusinessUnitIDs *[]string
+	CustomerIDs     *[]string
+}
+
+// IsUnrestricted reports whether the filter has no dimensions set, in which
+// case query builders may skip applying any WHERE clause. A nil receiver is
+// also unrestricted, so a nil filter on context is equivalent to no filter.
+func (f *VisibilityFilter) IsUnrestricted() bool {
+	if f == nil {
+		return true
+	}
+	return f.UserIDs == nil &&
+		f.TeamIDs == nil &&
+		f.OwnTeamIDs == nil &&
+		f.VirtualKeyIDs == nil &&
+		f.RoutingScopes == nil &&
+		f.RoleIDs == nil &&
+		f.BusinessUnitIDs == nil &&
+		f.CustomerIDs == nil
+}
+
+// VisibilityFilterProvider returns the visibility filter to apply for a
+// given Entity. Returning nil signals full visibility (no filter applied).
+//
+// The provider is set on the request context by the upstream
+// (enterprise) middleware. Each call returns only the dimensions of the
+// VisibilityFilter that the requested Entity's table can consume — for
+// example, EntityCustomer returns only CustomerIDs populated; every other
+// field is nil. This lets OSS query helpers stay agnostic of how the
+// filter is computed and keeps per-request allocations minimal.
+type VisibilityFilterProvider func(Entity) *VisibilityFilter
+
+// VisibilityFilterProviderFromContext returns the provider closure
+// stashed on the context, or nil when none is present (background jobs,
+// internal queries, requests that bypassed the upstream middleware,
+// OSS-only deployments without DAC). A nil provider is equivalent to
+// full visibility — query builders apply no WHERE clause.
+func VisibilityFilterProviderFromContext(ctx context.Context) VisibilityFilterProvider {
+	if ctx == nil {
+		return nil
+	}
+	if v := ctx.Value(BifrostContextKeyVisibilityFilterProvider); v != nil {
+		if p, ok := v.(VisibilityFilterProvider); ok {
+			return p
+		}
+	}
+	return nil
+}
+
+// FilterForEntity is a convenience that fetches the provider from ctx
+// and resolves the filter for entity in one call. Returns nil when no
+// provider is present (full visibility) or when the provider returns nil
+// for the requested entity (e.g. all-data scope).
+func FilterForEntity(ctx context.Context, entity Entity) *VisibilityFilter {
+	p := VisibilityFilterProviderFromContext(ctx)
+	if p == nil {
+		return nil
+	}
+	return p(entity)
+}

--- a/framework/cmd/e2eseed/main.go
+++ b/framework/cmd/e2eseed/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/maximhq/bifrost/framework/e2eseed"
+)
+
+// main runs the OSS API e2e seed command.
+func main() {
+	if err := run(context.Background(), os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e seed failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run parses flags, connects to the target stores, and writes seed fixtures.
+func run(ctx context.Context, args []string) error {
+	opts := e2eseed.DefaultOptions()
+	summaryPath := ""
+
+	fs := flag.NewFlagSet("e2eseed", flag.ContinueOnError)
+	fs.StringVar(&opts.Prefix, "prefix", opts.Prefix, "stable prefix for all seeded rows")
+	fs.StringVar(&opts.ConfigPath, "config-path", opts.ConfigPath, "optional Bifrost config.json path used to derive DB settings")
+	fs.StringVar(&opts.EncryptionKey, "encryption-key", opts.EncryptionKey, "optional Bifrost encryption key for encrypted config rows")
+	fs.StringVar(&opts.ConfigDialect, "config-db-dialect", opts.ConfigDialect, "config DB dialect: postgres or sqlite")
+	fs.StringVar(&opts.ConfigDSN, "config-db-dsn", opts.ConfigDSN, "config DB DSN")
+	fs.StringVar(&opts.LogsDialect, "logs-db-dialect", opts.LogsDialect, "logs DB dialect: postgres or sqlite")
+	fs.StringVar(&opts.LogsDSN, "logs-db-dsn", opts.LogsDSN, "logs DB DSN")
+	fs.IntVar(&opts.LogRowsPerShape, "logs-per-shape", opts.LogRowsPerShape, "number of log rows to seed per DAC ownership shape (applied to both logs and mcp_tool_logs)")
+	fs.IntVar(&opts.BatchSize, "batch-size", opts.BatchSize, "log insert batch size")
+	fs.StringVar(&opts.OutputEnvPath, "output-env", opts.OutputEnvPath, "path for generated environment values")
+	fs.StringVar(&summaryPath, "summary", "", "optional JSON summary path")
+	fs.BoolVar(&opts.DryRun, "dry-run", opts.DryRun, "build the manifest without writing rows")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	opts, err := e2eseed.NormalizeOptions(opts)
+	if err != nil {
+		return err
+	}
+	e2eseed.InitEncryption(opts)
+	configDB, err := e2eseed.OpenDB(opts.ConfigDialect, opts.ConfigDSN)
+	if err != nil {
+		return fmt.Errorf("open config DB: %w", err)
+	}
+	if sqlDB, dbErr := configDB.DB(); dbErr == nil {
+		defer sqlDB.Close()
+	}
+	logsDB, err := e2eseed.OpenDB(opts.LogsDialect, opts.LogsDSN)
+	if err != nil {
+		return fmt.Errorf("open logs DB: %w", err)
+	}
+	if sqlDB, dbErr := logsDB.DB(); dbErr == nil {
+		defer sqlDB.Close()
+	}
+
+	summary, err := e2eseed.SeedBase(ctx, configDB, logsDB, opts)
+	if err != nil {
+		return err
+	}
+	if summaryPath != "" {
+		if err := e2eseed.WriteJSONFile(summaryPath, summary); err != nil {
+			return err
+		}
+	}
+	fmt.Printf("seeded OSS API e2e data prefix=%s logs_per_shape=%d shapes=%d env=%s\n", summary.Prefix, summary.LogRowsPerShape, len(summary.Expected.Shapes), opts.OutputEnvPath)
+	return nil
+}

--- a/framework/configstore/prompts.go
+++ b/framework/configstore/prompts.go
@@ -132,10 +132,13 @@ func (s *RDBConfigStore) DeleteFolder(ctx context.Context, id string) error {
 // Prompt Repository - Prompts
 // ============================================================================
 
-// GetPrompts gets all prompts, optionally filtered by folder ID
+// GetPrompts gets all prompts, optionally filtered by folder ID.
+//
+// When ctx carries a QueryScope, the query is narrowed to prompts the
+// caller is allowed to see.
 func (s *RDBConfigStore) GetPrompts(ctx context.Context, folderID *string) ([]tables.TablePrompt, error) {
 	var prompts []tables.TablePrompt
-	query := s.DB().WithContext(ctx).
+	query := s.ScopedDB(ctx).
 		Preload("Folder").
 		Order("created_at DESC")
 
@@ -165,12 +168,15 @@ func (s *RDBConfigStore) GetPrompts(ctx context.Context, folderID *string) ([]ta
 	return prompts, nil
 }
 
-// GetPromptByID gets a prompt by ID with latest version
+// GetPromptByID gets a prompt by ID with latest version.
+//
+// When ctx carries a QueryScope, a prompt that exists but falls
+// outside the scope returns ErrNotFound so URL guessing cannot
+// distinguish "hidden" from "absent".
 func (s *RDBConfigStore) GetPromptByID(ctx context.Context, id string) (*tables.TablePrompt, error) {
 	var prompt tables.TablePrompt
-	if err := s.DB().WithContext(ctx).
-		Preload("Folder").
-		First(&prompt, "id = ?", id).Error; err != nil {
+	q := s.ScopedDB(ctx).Preload("Folder")
+	if err := q.First(&prompt, "prompts.id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -193,9 +199,15 @@ func (s *RDBConfigStore) GetPromptByID(ctx context.Context, id string) (*tables.
 	return &prompt, nil
 }
 
-// CreatePrompt creates a new prompt
-func (s *RDBConfigStore) CreatePrompt(ctx context.Context, prompt *tables.TablePrompt) error {
-	return s.DB().WithContext(ctx).Create(prompt).Error
+// CreatePrompt creates a new prompt. The optional tx allows callers to
+// chain the insert with follow-up writes in a single transaction (used
+// by the enterprise wrapper to atomically stamp ownership columns).
+func (s *RDBConfigStore) CreatePrompt(ctx context.Context, prompt *tables.TablePrompt, tx ...*gorm.DB) error {
+	db := s.DB()
+	if len(tx) > 0 && tx[0] != nil {
+		db = tx[0]
+	}
+	return db.WithContext(ctx).Create(prompt).Error
 }
 
 // UpdatePrompt updates a prompt

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -16,6 +16,7 @@ import (
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/encrypt"
 	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/maximhq/bifrost/framework/queryscope"
 	"github.com/maximhq/bifrost/framework/vectorstore"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -278,6 +279,18 @@ func (s *RDBConfigStore) Ping(ctx context.Context) error {
 // call DB() per operation rather than caching the pointer.
 func (s *RDBConfigStore) DB() *gorm.DB {
 	return s.db.Load()
+}
+
+// ScopedDB returns the DB bound to ctx with any QueryScope on ctx
+// pre-applied. Use this in read paths that should respect caller-
+// driven row visibility. Use DB().WithContext(ctx) for writes and for
+// internal lookups (e.g. inference VK auth) that must bypass scoping.
+func (s *RDBConfigStore) ScopedDB(ctx context.Context) *gorm.DB {
+	db := s.DB().WithContext(ctx)
+	if scope := queryscope.FromContext(ctx); scope != nil {
+		db = scope(db)
+	}
+	return db
 }
 
 // RunMigration opens a throwaway connection against the same
@@ -2267,7 +2280,7 @@ func (s *RDBConfigStore) GetVirtualKeys(ctx context.Context) ([]tables.TableVirt
 	var virtualKeys []tables.TableVirtualKey
 
 	// Preload all relationships for complete information
-	if err := preloadVirtualKeyBaseRelations(s.DB().WithContext(ctx)).
+	if err := preloadVirtualKeyBaseRelations(s.ScopedDB(ctx)).
 		Order("created_at ASC").
 		Find(&virtualKeys).Error; err != nil {
 		return nil, err
@@ -2278,7 +2291,10 @@ func (s *RDBConfigStore) GetVirtualKeys(ctx context.Context) ([]tables.TableVirt
 // GetVirtualKeysPaginated retrieves virtual keys with pagination, filtering, and search support.
 func (s *RDBConfigStore) GetVirtualKeysPaginated(ctx context.Context, params VirtualKeyQueryParams) ([]tables.TableVirtualKey, int64, error) {
 	// Build base query with filters
-	baseQuery := s.DB().WithContext(ctx).Model(&tables.TableVirtualKey{})
+	// ScopedDB applies any caller-supplied row visibility before
+	// per-call filters so the total count and the page result agree
+	// on what the caller is allowed to see.
+	baseQuery := s.ScopedDB(ctx).Model(&tables.TableVirtualKey{})
 
 	// Virtual keys are either customer-scoped or team-scoped, never both.
 	// When both filters are provided, use OR to match keys belonging to either.
@@ -2367,10 +2383,16 @@ func (s *RDBConfigStore) GetVirtualKeysPaginated(ctx context.Context, params Vir
 }
 
 // GetVirtualKey retrieves a virtual key from the database.
+//
+// When ctx carries a QueryScope, the query is narrowed to rows the
+// caller is allowed to see. A row that exists but falls outside the
+// scope returns ErrNotFound, the same response a genuinely-missing
+// row produces, so URL guessing cannot distinguish "hidden" from
+// "absent".
 func (s *RDBConfigStore) GetVirtualKey(ctx context.Context, id string) (*tables.TableVirtualKey, error) {
 	var virtualKey tables.TableVirtualKey
-	if err := preloadVirtualKeyDetailRelations(s.DB().WithContext(ctx)).
-		First(&virtualKey, "id = ?", id).Error; err != nil {
+	q := preloadVirtualKeyDetailRelations(s.ScopedDB(ctx))
+	if err := q.First(&virtualKey, "governance_virtual_keys.id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -2958,9 +2980,12 @@ func (s *RDBConfigStore) DeleteVirtualKeyMCPConfig(ctx context.Context, id uint,
 const teamSelectWithVKCount = "governance_teams.*, (SELECT COUNT(*) FROM governance_virtual_keys WHERE team_id = governance_teams.id) AS virtual_key_count"
 
 // GetTeams retrieves all teams from the database.
+//
+// When ctx carries a QueryScope, the query is narrowed to teams the
+// caller is allowed to see.
 func (s *RDBConfigStore) GetTeams(ctx context.Context, customerID string) ([]tables.TableTeam, error) {
 	// Preload relationships for complete information
-	query := s.DB().WithContext(ctx).
+	query := s.ScopedDB(ctx).
 		Select(teamSelectWithVKCount).
 		Preload("Customer").Preload("Budgets").Preload("RateLimit")
 	// Optional filtering by customer
@@ -2975,8 +3000,11 @@ func (s *RDBConfigStore) GetTeams(ctx context.Context, customerID string) ([]tab
 }
 
 // GetTeamsPaginated retrieves teams with pagination, filtering, and search support.
+//
+// When ctx carries a QueryScope, the query is narrowed to teams the
+// caller is allowed to see.
 func (s *RDBConfigStore) GetTeamsPaginated(ctx context.Context, params TeamsQueryParams) ([]tables.TableTeam, int64, error) {
-	baseQuery := s.DB().WithContext(ctx).Model(&tables.TableTeam{})
+	baseQuery := s.ScopedDB(ctx).Model(&tables.TableTeam{})
 
 	if params.CustomerID != "" {
 		baseQuery = baseQuery.Where("customer_id = ?", params.CustomerID)
@@ -3014,12 +3042,17 @@ func (s *RDBConfigStore) GetTeamsPaginated(ctx context.Context, params TeamsQuer
 }
 
 // GetTeam retrieves a specific team from the database.
+//
+// When ctx carries a QueryScope, a team that doesn't satisfy the scope
+// returns ErrNotFound; the caller cannot distinguish "doesn't exist"
+// from "not visible," matching the leak-prevention contract used by
+// the other governance entities.
 func (s *RDBConfigStore) GetTeam(ctx context.Context, id string) (*tables.TableTeam, error) {
 	var team tables.TableTeam
-	if err := s.DB().WithContext(ctx).
+	if err := s.ScopedDB(ctx).
 		Select(teamSelectWithVKCount).
 		Preload("Customer").Preload("Budgets").Preload("RateLimit").
-		First(&team, "id = ?", id).Error; err != nil {
+		First(&team, "governance_teams.id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -3117,9 +3150,12 @@ func (s *RDBConfigStore) DeleteTeam(ctx context.Context, id string) error {
 }
 
 // GetCustomers retrieves all customers from the database.
+//
+// When ctx carries a QueryScope, the query is narrowed to customers
+// the caller is allowed to see.
 func (s *RDBConfigStore) GetCustomers(ctx context.Context) ([]tables.TableCustomer, error) {
 	var customers []tables.TableCustomer
-	if err := preloadCustomerRelations(s.DB().WithContext(ctx), "").
+	if err := preloadCustomerRelations(s.ScopedDB(ctx), "").
 		Order("created_at ASC").
 		Find(&customers).Error; err != nil {
 		return nil, err
@@ -3127,9 +3163,13 @@ func (s *RDBConfigStore) GetCustomers(ctx context.Context) ([]tables.TableCustom
 	return customers, nil
 }
 
-// GetCustomersPaginated retrieves customers with pagination and optional search filtering.
+// GetCustomersPaginated retrieves customers with pagination and optional
+// search filtering.
+//
+// When ctx carries a QueryScope, the query is narrowed to customers
+// the caller is allowed to see.
 func (s *RDBConfigStore) GetCustomersPaginated(ctx context.Context, params CustomersQueryParams) ([]tables.TableCustomer, int64, error) {
-	baseQuery := s.DB().WithContext(ctx).Model(&tables.TableCustomer{})
+	baseQuery := s.ScopedDB(ctx).Model(&tables.TableCustomer{})
 	if params.Search != "" {
 		search := "%" + strings.ToLower(params.Search) + "%"
 		baseQuery = baseQuery.Where("LOWER(name) LIKE ?", search)
@@ -3159,10 +3199,15 @@ func (s *RDBConfigStore) GetCustomersPaginated(ctx context.Context, params Custo
 }
 
 // GetCustomer retrieves a specific customer from the database.
+//
+// When ctx carries a QueryScope, a customer that doesn't satisfy the
+// scope returns ErrNotFound; the caller cannot distinguish "doesn't
+// exist" from "not visible," matching the leak-prevention contract
+// used by the other governance entities.
 func (s *RDBConfigStore) GetCustomer(ctx context.Context, id string) (*tables.TableCustomer, error) {
 	var customer tables.TableCustomer
-	if err := preloadCustomerRelations(s.DB().WithContext(ctx), "").
-		First(&customer, "id = ?", id).Error; err != nil {
+	if err := preloadCustomerRelations(s.ScopedDB(ctx), "").
+		First(&customer, "governance_customers.id = ?", id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -3553,8 +3598,12 @@ func (s *RDBConfigStore) GetRoutingRules(ctx context.Context) ([]tables.TableRou
 }
 
 // GetRoutingRulesPaginated retrieves routing rules with pagination and optional search filtering.
+//
+// When ctx carries a QueryScope, the query is narrowed to rules the
+// caller is allowed to see; rules with scope='global' are always
+// included by the scope builder.
 func (s *RDBConfigStore) GetRoutingRulesPaginated(ctx context.Context, params RoutingRulesQueryParams) ([]tables.TableRoutingRule, int64, error) {
-	baseQuery := s.DB().WithContext(ctx).Model(&tables.TableRoutingRule{})
+	baseQuery := s.ScopedDB(ctx).Model(&tables.TableRoutingRule{})
 
 	if params.Search != "" {
 		search := "%" + strings.ToLower(params.Search) + "%"

--- a/framework/configstore/scopeddb_test.go
+++ b/framework/configstore/scopeddb_test.go
@@ -1,0 +1,101 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/queryscope"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// newScopedDBTestStore returns a bare RDBConfigStore backed by an in-
+// memory SQLite database. No tables are migrated — ScopedDB only
+// touches gorm DB wiring, not any specific schema.
+func newScopedDBTestStore(t *testing.T) *RDBConfigStore {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	store := &RDBConfigStore{logger: bifrost.NewDefaultLogger(schemas.LogLevelInfo)}
+	store.db.Store(db)
+	return store
+}
+
+func TestScopedDB_AppliesScopeFromContext(t *testing.T) {
+	store := newScopedDBTestStore(t)
+	called := false
+	scope := queryscope.QueryScope(func(db *gorm.DB) *gorm.DB {
+		called = true
+		return db.Where("1 = 0") // arbitrary mutation we can inspect
+	})
+	ctx := queryscope.WithQueryScope(context.Background(), scope)
+
+	got := store.ScopedDB(ctx)
+
+	assert.True(t, called, "ScopedDB should invoke the scope from ctx")
+	// The where clause should now be present on the statement.
+	stmt := got.Session(&gorm.Session{DryRun: true}).Find(&struct{}{}).Statement
+	assert.Contains(t, stmt.SQL.String(), "1 = 0",
+		"ScopedDB-returned *gorm.DB should carry the scope's WHERE clause")
+}
+
+func TestScopedDB_PassesThroughWhenNoScope(t *testing.T) {
+	store := newScopedDBTestStore(t)
+	got := store.ScopedDB(context.Background())
+	assert.NotNil(t, got, "ScopedDB must always return a usable *gorm.DB")
+	// Issuing a trivial query against the no-scope DB must succeed.
+	require.NoError(t, got.Exec("SELECT 1").Error)
+}
+
+func TestScopedDB_BindsContext(t *testing.T) {
+	store := newScopedDBTestStore(t)
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "marker")
+	got := store.ScopedDB(ctx)
+	// gorm exposes the bound context on the underlying statement.
+	stmt := got.Session(&gorm.Session{DryRun: true}).Find(&struct{}{}).Statement
+	assert.Equal(t, "marker", stmt.Context.Value(ctxKey{}),
+		"ScopedDB must bind the caller's ctx onto the returned DB")
+}
+
+func TestScopedDB_WrongTypeAtScopeKeyIsIgnored(t *testing.T) {
+	store := newScopedDBTestStore(t)
+	// A foreign caller stashing the wrong type at our context key must
+	// not poison ScopedDB; the wrong-type value is treated as "no
+	// scope present" and the query passes through.
+	ctx := context.WithValue(context.Background(),
+		schemas.BifrostContextKeyQueryScope, "not a closure")
+	got := store.ScopedDB(ctx)
+	require.NotNil(t, got)
+	require.NoError(t, got.Exec("SELECT 1").Error)
+}
+
+func TestScopedDB_TypedNilScopeIsIgnored(t *testing.T) {
+	store := newScopedDBTestStore(t)
+	// A typed-nil QueryScope must not be invoked (would panic). The
+	// queryscope.FromContext helper returns nil for a nil closure, so
+	// ScopedDB falls through to the bare DB.
+	ctx := queryscope.WithQueryScope(context.Background(), nil)
+	got := store.ScopedDB(ctx)
+	require.NotNil(t, got)
+	require.NoError(t, got.Exec("SELECT 1").Error)
+}
+
+func TestScopedDB_ScopeReturningDB_IsRespected(t *testing.T) {
+	store := newScopedDBTestStore(t)
+	// A scope that returns the unchanged DB (a degenerate but valid
+	// scope) must not break ScopedDB.
+	ctx := queryscope.WithQueryScope(context.Background(), func(db *gorm.DB) *gorm.DB {
+		return db
+	})
+	got := store.ScopedDB(ctx)
+	require.NotNil(t, got)
+	require.NoError(t, got.Exec("SELECT 1").Error)
+}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -372,7 +372,7 @@ type ConfigStore interface {
 	// Prompt Repository - Prompts
 	GetPrompts(ctx context.Context, folderID *string) ([]tables.TablePrompt, error)
 	GetPromptByID(ctx context.Context, id string) (*tables.TablePrompt, error)
-	CreatePrompt(ctx context.Context, prompt *tables.TablePrompt) error
+	CreatePrompt(ctx context.Context, prompt *tables.TablePrompt, tx ...*gorm.DB) error
 	UpdatePrompt(ctx context.Context, prompt *tables.TablePrompt) error
 	DeletePrompt(ctx context.Context, id string) error
 
@@ -394,6 +394,12 @@ type ConfigStore interface {
 
 	// DB returns the underlying database connection.
 	DB() *gorm.DB
+
+	// ScopedDB returns the underlying DB bound to ctx with any
+	// QueryScope on ctx pre-applied. Use this in read paths that
+	// should respect caller-driven row visibility; use DB().WithContext(ctx)
+	// for writes and internal lookups that must bypass scoping.
+	ScopedDB(ctx context.Context) *gorm.DB
 
 	// RunMigration opens a throwaway *gorm.DB against the same
 	// backing database, invokes fn with it, and closes the connection. Use

--- a/framework/e2eseed/seed.go
+++ b/framework/e2eseed/seed.go
@@ -1,0 +1,851 @@
+// Package e2eseed creates deterministic OSS fixtures for API and DAC tests.
+package e2eseed
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/encrypt"
+	"github.com/maximhq/bifrost/framework/logstore"
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Options controls the shared seed dataset.
+type Options struct {
+	Prefix          string
+	ConfigPath      string
+	EncryptionKey   string
+	ConfigDialect   string
+	ConfigDSN       string
+	LogsDialect     string
+	LogsDSN         string
+	LogRowsPerShape int
+	BatchSize       int
+	OutputEnvPath   string
+	DryRun          bool
+}
+
+// Shape describes one DAC ownership combination.
+type Shape struct {
+	Name           string   `json:"name"`
+	UserID         string   `json:"user_id,omitempty"`
+	TeamID         string   `json:"team_id,omitempty"`
+	CustomerID     string   `json:"customer_id,omitempty"`
+	BusinessUnitID string   `json:"business_unit_id,omitempty"`
+	VirtualKeyID   string   `json:"virtual_key_id,omitempty"`
+	Marker         string   `json:"marker"`
+	VisibleTo      []string `json:"visible_to"`
+}
+
+// ExpectedManifest records seeded IDs and expected DAC visibility.
+type ExpectedManifest struct {
+	Prefix    string              `json:"prefix"`
+	Personas  map[string]string   `json:"personas"`
+	Shapes    []Shape             `json:"shapes"`
+	LogIDs    map[string][]string `json:"log_ids"`
+	MCPLogIDs map[string][]string `json:"mcp_log_ids"`
+}
+
+// Summary is returned after a seed run.
+type Summary struct {
+	Prefix          string            `json:"prefix"`
+	LogRowsPerShape int               `json:"log_rows_per_shape"`
+	SeedEnv         map[string]string `json:"seed_env"`
+	Expected        ExpectedManifest  `json:"expected"`
+	TableCounts     map[string]int64  `json:"table_counts"`
+	DryRun          bool              `json:"dry_run"`
+	GeneratedAt     time.Time         `json:"generated_at"`
+}
+
+// seedBaseTime is the per-run anchor timestamp for seeded log rows. SeedBase
+// refreshes it to time.Now().UTC() on every invocation so the rows land inside
+// the dashboard's default time-range filters (Last hour / Last day) instead of
+// drifting toward the original package-load timestamp on repeated seeds.
+var seedBaseTime = time.Now().UTC()
+
+// DefaultOptions returns defaults for local e2e seeding.
+func DefaultOptions() Options {
+	return Options{
+		Prefix:          "e2e-seed",
+		ConfigDialect:   "postgres",
+		LogsDialect:     "postgres",
+		LogRowsPerShape: 30,
+		BatchSize:       1000,
+		OutputEnvPath:   "tmp/e2e-seed.env",
+	}
+}
+
+// NormalizeOptions applies default values to unset options.
+func NormalizeOptions(opts Options) (Options, error) {
+	def := DefaultOptions()
+	if opts.Prefix == "" {
+		opts.Prefix = def.Prefix
+	}
+	if opts.ConfigPath != "" {
+		resolved, err := optionsFromConfigFile(opts.ConfigPath)
+		if err != nil {
+			return Options{}, fmt.Errorf("load config path %q: %w", opts.ConfigPath, err)
+		}
+		if opts.EncryptionKey == "" {
+			opts.EncryptionKey = resolved.EncryptionKey
+		}
+		if opts.ConfigDialect == "" && resolved.ConfigDialect != "" {
+			opts.ConfigDialect = resolved.ConfigDialect
+		}
+		if opts.ConfigDSN == "" && resolved.ConfigDSN != "" {
+			opts.ConfigDSN = resolved.ConfigDSN
+		}
+		if opts.LogsDialect == "" && resolved.LogsDialect != "" {
+			opts.LogsDialect = resolved.LogsDialect
+		}
+		if opts.LogsDSN == "" && resolved.LogsDSN != "" {
+			opts.LogsDSN = resolved.LogsDSN
+		}
+	}
+	if opts.ConfigDialect == "" {
+		opts.ConfigDialect = def.ConfigDialect
+	}
+	if opts.EncryptionKey == "" {
+		opts.EncryptionKey = os.Getenv("BIFROST_ENCRYPTION_KEY")
+	}
+	if opts.ConfigDSN == "" {
+		opts.ConfigDSN = "postgres://bifrost:bifrost_password@localhost:5432/bifrost?sslmode=disable"
+	}
+	if opts.LogsDialect == "" {
+		opts.LogsDialect = def.LogsDialect
+	}
+	if opts.LogsDSN == "" {
+		opts.LogsDSN = "postgres://bifrost:bifrost_password@localhost:5432/bifrost?sslmode=disable"
+	}
+	if opts.LogRowsPerShape <= 0 {
+		opts.LogRowsPerShape = def.LogRowsPerShape
+	}
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = def.BatchSize
+	}
+	if opts.OutputEnvPath == "" {
+		opts.OutputEnvPath = def.OutputEnvPath
+	}
+	return opts, nil
+}
+
+// InitEncryption initializes Bifrost field encryption for DBs containing encrypted rows.
+func InitEncryption(opts Options) {
+	if opts.EncryptionKey == "" {
+		return
+	}
+	encrypt.Init(opts.EncryptionKey, bifrost.NewDefaultLogger(schemas.LogLevelWarn))
+}
+
+// optionsFromConfigFile extracts config/log store connection settings from a Bifrost config.json.
+func optionsFromConfigFile(path string) (Options, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Options{}, err
+	}
+	var cfg struct {
+		EncryptionKey json.RawMessage `json:"encryption_key"`
+		ConfigStore   storeConfig     `json:"config_store"`
+		LogsStore     storeConfig     `json:"logs_store"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return Options{}, err
+	}
+	out := Options{}
+	out.EncryptionKey = rawConfigValue(cfg.EncryptionKey)
+	configDialect, configDSN, err := dsnFromStoreConfig(cfg.ConfigStore)
+	if err != nil {
+		return Options{}, err
+	}
+	out.ConfigDialect = configDialect
+	out.ConfigDSN = configDSN
+	logsDialect, logsDSN, err := dsnFromStoreConfig(cfg.LogsStore)
+	if err != nil {
+		return Options{}, err
+	}
+	out.LogsDialect = logsDialect
+	out.LogsDSN = logsDSN
+	return out, nil
+}
+
+// storeConfig is the subset of config.json needed to locate a DB-backed store.
+type storeConfig struct {
+	Enabled bool                       `json:"enabled"`
+	Type    string                     `json:"type"`
+	Config  map[string]json.RawMessage `json:"config"`
+}
+
+// dsnFromStoreConfig converts a raw store config into the dialect and DSN used by gorm.
+func dsnFromStoreConfig(store storeConfig) (string, string, error) {
+	if !store.Enabled {
+		return "", "", nil
+	}
+	switch store.Type {
+	case "postgres":
+		host := configValue(store.Config, "host")
+		port := configValue(store.Config, "port")
+		user := configValue(store.Config, "user")
+		password := configValue(store.Config, "password")
+		dbName := configValue(store.Config, "db_name")
+		sslMode := configValue(store.Config, "ssl_mode")
+		if sslMode == "" {
+			sslMode = "disable"
+		}
+		return "postgres", fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", url.QueryEscape(user), url.QueryEscape(password), host, port, dbName, sslMode), nil
+	case "sqlite":
+		return "sqlite", configValue(store.Config, "path"), nil
+	default:
+		return "", "", fmt.Errorf("unsupported store type %q", store.Type)
+	}
+}
+
+// configValue returns a raw JSON config value, resolving Bifrost env-var wrappers.
+func configValue(config map[string]json.RawMessage, key string) string {
+	return rawConfigValue(config[key])
+}
+
+// rawConfigValue returns a raw JSON config value, resolving Bifrost env-var wrappers.
+func rawConfigValue(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return schemas.NewEnvVar(text).GetValue()
+	}
+	var env schemas.EnvVar
+	if err := json.Unmarshal(raw, &env); err == nil {
+		return env.GetValue()
+	}
+	return strings.Trim(string(raw), `"`)
+}
+
+// OpenDB opens a supported GORM database.
+func OpenDB(dialect, dsn string) (*gorm.DB, error) {
+	switch strings.ToLower(strings.TrimSpace(dialect)) {
+	case "postgres", "postgresql":
+		if dsn == "" {
+			return nil, fmt.Errorf("postgres dsn is required")
+		}
+		return gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	case "sqlite":
+		if dsn == "" {
+			return nil, fmt.Errorf("sqlite dsn is required")
+		}
+		return gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	default:
+		return nil, fmt.Errorf("unsupported db dialect %q", dialect)
+	}
+}
+
+// SeedBase writes the OSS-owned seed graph.
+func SeedBase(ctx context.Context, configDB, logsDB *gorm.DB, opts Options) (*Summary, error) {
+	opts, err := NormalizeOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	seedBaseTime = time.Now().UTC()
+	InitEncryption(opts)
+	env := SeedEnv(opts.Prefix)
+	manifest := BuildExpectedManifest(opts.Prefix, opts.LogRowsPerShape)
+	summary := &Summary{
+		Prefix:          opts.Prefix,
+		LogRowsPerShape: opts.LogRowsPerShape,
+		SeedEnv:         env,
+		Expected:        manifest,
+		TableCounts:     map[string]int64{},
+		DryRun:          opts.DryRun,
+		GeneratedAt:     time.Now().UTC(),
+	}
+	if opts.DryRun {
+		return summary, nil
+	}
+	if err := seedConfig(ctx, configDB, opts); err != nil {
+		return nil, err
+	}
+	if err := seedLogs(ctx, logsDB, opts, manifest); err != nil {
+		return nil, err
+	}
+	if err := WriteEnvFile(opts.OutputEnvPath, env); err != nil {
+		return nil, err
+	}
+	counts, err := CountKnownTables(ctx, configDB, logsDB)
+	if err != nil {
+		return nil, err
+	}
+	summary.TableCounts = counts
+	return summary, nil
+}
+
+// SeedEnv returns deterministic values shared by seeders and tests.
+func SeedEnv(prefix string) map[string]string {
+	return map[string]string{
+		"e2e_seed_prefix":                    prefix,
+		"enterprise_dac_model":               "openai/gpt-4o-mini",
+		"enterprise_dac_visible_virtual_key": prefix + "-vk-user-team-secret",
+		"enterprise_dac_hidden_virtual_key":  prefix + "-vk-outside-secret",
+		"e2e_seed_team_tiggings":             prefix + "-team-tiggings",
+		"e2e_seed_team_outside":              prefix + "-team-outside",
+		"e2e_seed_user_tiggings":             prefix + "-user-tiggings",
+		"e2e_seed_user_outside":              prefix + "-user-outside",
+		"e2e_seed_vk_user_team":              prefix + "-vk-user-team",
+		"e2e_seed_vk_outside":                prefix + "-vk-outside",
+	}
+}
+
+// BuildShapes returns the DAC ownership matrix.
+//
+// The set is built by enumerating all 15 non-empty subsets of the four DAC
+// dimensions {VirtualKey, UserID, TeamID, BusinessUnitID}, all flavoured with
+// tiggings-side values so the tiggings-flavoured personas see them, plus
+// three appended shapes for negative coverage:
+//   - user-not-in-tiggings: outside user + BU (cross-team isolation)
+//   - outside-team-virtual-key: outside user + team + BU + VK
+//   - legacy-unowned: no DAC dimensions (fail-closed for non-admin)
+//
+// CustomerID is set together with BusinessUnitID when the B dimension is
+// present; the two columns are conceptually paired in the seeded dataset.
+//
+// The VirtualKey value for each tiggings shape is teamVK when the team
+// dimension is present without a user, so the team-only VK ownership path
+// (governance_virtual_keys.team_id) gets exercised. Every other VK-bearing
+// shape uses userVK so the user-attached VK ownership path is exercised too.
+func BuildShapes(prefix string) []Shape {
+	tiggingsUser := prefix + "-user-tiggings"
+	outsideUser := prefix + "-user-outside"
+	tiggingsTeam := prefix + "-team-tiggings"
+	outsideTeam := prefix + "-team-outside"
+	tiggingsCustomer := prefix + "-customer-tiggings"
+	outsideCustomer := prefix + "-customer-outside"
+	tiggingsBU := prefix + "-bu-tiggings"
+	outsideBU := prefix + "-bu-outside"
+	userVK := prefix + "-vk-user-team"
+	teamVK := prefix + "-vk-team-only"
+	outsideVK := prefix + "-vk-outside"
+
+	shapes := make([]Shape, 0, 18)
+	for mask := 1; mask <= 15; mask++ {
+		hasVK := mask&0x1 != 0
+		hasU := mask&0x2 != 0
+		hasT := mask&0x4 != 0
+		hasB := mask&0x8 != 0
+
+		shape := Shape{Name: shapeNameFromDims(hasVK, hasU, hasT, hasB)}
+		if hasVK {
+			if hasT && !hasU {
+				shape.VirtualKeyID = teamVK
+			} else {
+				shape.VirtualKeyID = userVK
+			}
+		}
+		if hasU {
+			shape.UserID = tiggingsUser
+		}
+		if hasT {
+			shape.TeamID = tiggingsTeam
+		}
+		if hasB {
+			shape.BusinessUnitID = tiggingsBU
+			shape.CustomerID = tiggingsCustomer
+		}
+		shape.Marker = prefix + "-shape-" + shape.Name
+		shape.VisibleTo = computeVisibleTo(shape, tiggingsUser, outsideUser, tiggingsTeam, outsideTeam, userVK, teamVK, outsideVK)
+		shapes = append(shapes, shape)
+	}
+
+	shapes = append(shapes,
+		Shape{
+			Name:           "user-not-in-tiggings",
+			UserID:         outsideUser,
+			CustomerID:     outsideCustomer,
+			BusinessUnitID: outsideBU,
+			Marker:         prefix + "-shape-user-not-in-tiggings",
+			VisibleTo:      []string{"all_data_admin", "own_reader_outside", "team_reader_outside"},
+		},
+		Shape{
+			Name:           "outside-team-virtual-key",
+			UserID:         outsideUser,
+			TeamID:         outsideTeam,
+			CustomerID:     outsideCustomer,
+			BusinessUnitID: outsideBU,
+			VirtualKeyID:   outsideVK,
+			Marker:         prefix + "-shape-outside-team-vk",
+			VisibleTo:      []string{"all_data_admin", "own_reader_outside", "team_reader_outside"},
+		},
+		Shape{
+			Name:      "legacy-unowned",
+			Marker:    prefix + "-shape-legacy-unowned",
+			VisibleTo: []string{"all_data_admin"},
+		},
+	)
+	return shapes
+}
+
+// shapeNameFromDims returns a deterministic kebab-case name for the given
+// dimension presence flags. Single-dimension shapes are prefixed with "only-"
+// so the matrix reads naturally in the manifest.
+func shapeNameFromDims(hasVK, hasU, hasT, hasB bool) string {
+	var parts []string
+	if hasVK {
+		parts = append(parts, "virtual-key")
+	}
+	if hasU {
+		parts = append(parts, "user")
+	}
+	if hasT {
+		parts = append(parts, "team")
+	}
+	if hasB {
+		parts = append(parts, "business-unit")
+	}
+	if len(parts) == 1 {
+		return "only-" + parts[0]
+	}
+	return strings.Join(parts, "-")
+}
+
+// computeVisibleTo returns the sorted set of personas that can see rows of the
+// given shape, derived directly from the shape's DAC dimensions and the
+// well-known seeded principal/VK values.
+func computeVisibleTo(s Shape, tigU, outU, tigT, outT, userVK, teamVK, outVK string) []string {
+	set := map[string]struct{}{"all_data_admin": {}}
+
+	switch s.UserID {
+	case tigU:
+		set["own_reader_tiggings"] = struct{}{}
+		set["team_reader_tiggings"] = struct{}{}
+	case outU:
+		set["own_reader_outside"] = struct{}{}
+		set["team_reader_outside"] = struct{}{}
+	}
+
+	switch s.TeamID {
+	case tigT:
+		set["team_reader_tiggings"] = struct{}{}
+	case outT:
+		set["team_reader_outside"] = struct{}{}
+	}
+
+	switch s.VirtualKeyID {
+	case userVK:
+		set["vk_user_owned"] = struct{}{}
+		set["own_reader_tiggings"] = struct{}{}
+		set["team_reader_tiggings"] = struct{}{}
+	case teamVK:
+		set["vk_team_owned"] = struct{}{}
+		set["team_reader_tiggings"] = struct{}{}
+	case outVK:
+		set["own_reader_outside"] = struct{}{}
+		set["team_reader_outside"] = struct{}{}
+	}
+
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// BuildExpectedManifest returns the expected DAC visibility document. Each
+// shape gets logRowsPerShape contiguous log IDs and an equal number of MCP
+// log IDs so visibility tests can assert exact set membership for either
+// table.
+func BuildExpectedManifest(prefix string, logRowsPerShape int) ExpectedManifest {
+	shapes := BuildShapes(prefix)
+	logIDs := make(map[string][]string, len(shapes))
+	mcpLogIDs := make(map[string][]string, len(shapes))
+	for shapeIdx, shape := range shapes {
+		for j := 0; j < logRowsPerShape; j++ {
+			i := shapeIdx*logRowsPerShape + j
+			logIDs[shape.Name] = append(logIDs[shape.Name], fmt.Sprintf("%s-log-%06d", prefix, i))
+			mcpLogIDs[shape.Name] = append(mcpLogIDs[shape.Name], fmt.Sprintf("%s-mcp-log-%06d", prefix, i))
+		}
+	}
+	return ExpectedManifest{
+		Prefix: prefix,
+		Personas: map[string]string{
+			"own_reader_tiggings":  prefix + "-apikey-own-tiggings",
+			"team_reader_tiggings": prefix + "-apikey-team-tiggings",
+			"own_reader_outside":   prefix + "-apikey-own-outside",
+			"team_reader_outside":  prefix + "-apikey-team-outside",
+			"all_data_admin":       prefix + "-apikey-admin",
+			"vk_user_owned":        prefix + "-vk-user-team",
+			"vk_team_owned":        prefix + "-vk-team-only",
+		},
+		Shapes:    shapes,
+		LogIDs:    logIDs,
+		MCPLogIDs: mcpLogIDs,
+	}
+}
+
+// WriteEnvFile writes deterministic environment values.
+func WriteEnvFile(path string, env map[string]string) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	lines := make([]string, 0, len(keys))
+	for _, key := range keys {
+		lines = append(lines, fmt.Sprintf("%s=%s", key, quoteEnv(env[key])))
+	}
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600)
+}
+
+// WriteJSONFile writes a pretty JSON file.
+func WriteJSONFile(path string, value any) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}
+
+// CountKnownTables returns row counts for tables touched by the shared seed.
+func CountKnownTables(ctx context.Context, configDB, logsDB *gorm.DB) (map[string]int64, error) {
+	out := map[string]int64{}
+	for _, table := range []string{"config_providers", "config_keys", "config_models", "governance_customers", "governance_teams", "governance_virtual_keys", "governance_virtual_key_provider_configs", "governance_budgets", "governance_rate_limits", "folders", "prompts", "prompt_versions", "config_mcp_clients"} {
+		var count int64
+		if err := configDB.WithContext(ctx).Table(table).Count(&count).Error; err != nil {
+			return nil, fmt.Errorf("count table %s: %w", table, err)
+		}
+		out[table] = count
+	}
+	for _, table := range []string{"logs", "mcp_tool_logs", "async_jobs"} {
+		var count int64
+		if err := logsDB.WithContext(ctx).Table(table).Count(&count).Error; err != nil {
+			return nil, fmt.Errorf("count table %s: %w", table, err)
+		}
+		out[table] = count
+	}
+	return out, nil
+}
+
+// seedConfig writes OSS-owned relational fixtures.
+func seedConfig(ctx context.Context, db *gorm.DB, opts Options) error {
+	if db == nil {
+		return fmt.Errorf("config db is required")
+	}
+	now := seedBaseTime
+	if err := seedProviders(ctx, db, opts.Prefix, now); err != nil {
+		return err
+	}
+	if err := seedGovernance(ctx, db, opts.Prefix, now); err != nil {
+		return err
+	}
+	if err := seedPrompts(ctx, db, opts.Prefix, now); err != nil {
+		return err
+	}
+	return seedMCP(ctx, db, opts.Prefix, now)
+}
+
+// seedProviders writes providers, keys, and models.
+func seedProviders(ctx context.Context, db *gorm.DB, prefix string, now time.Time) error {
+	for _, providerName := range []string{"openai", "anthropic", "gemini"} {
+		provider := tables.TableProvider{Name: providerName, Status: "active", Description: "e2e seeded provider", CreatedAt: now, UpdatedAt: now}
+		if err := db.WithContext(ctx).Where("name = ?", providerName).Assign(provider).FirstOrCreate(&provider).Error; err != nil {
+			return err
+		}
+		key := tables.TableKey{
+			Name:        prefix + "-" + providerName + "-key",
+			ProviderID:  provider.ID,
+			Provider:    providerName,
+			KeyID:       prefix + "-" + providerName + "-key",
+			Value:       *schemas.NewEnvVar(strings.ToUpper(providerName) + "_API_KEY"),
+			Models:      schemas.WhiteList{"*"},
+			Status:      "active",
+			Description: "e2e seeded provider key",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if err := db.WithContext(ctx).Where("key_id = ?", key.KeyID).Assign(key).FirstOrCreate(&key).Error; err != nil {
+			return err
+		}
+		model := tables.TableModel{ID: prefix + "-" + providerName + "-model", ProviderID: provider.ID, Name: defaultModel(providerName), CreatedAt: now, UpdatedAt: now}
+		if err := db.WithContext(ctx).Where("id = ?", model.ID).Assign(model).FirstOrCreate(&model).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// seedGovernance writes customers, teams, budgets, rate limits, VKs, and VK provider configs.
+func seedGovernance(ctx context.Context, db *gorm.DB, prefix string, now time.Time) error {
+	active := true
+	tiggingsCustomer := prefix + "-customer-tiggings"
+	outsideCustomer := prefix + "-customer-outside"
+	tiggingsTeam := prefix + "-team-tiggings"
+	outsideTeam := prefix + "-team-outside"
+	for _, customer := range []tables.TableCustomer{{ID: tiggingsCustomer, Name: "Tiggings Customer", CreatedAt: now, UpdatedAt: now}, {ID: outsideCustomer, Name: "Outside Customer", CreatedAt: now, UpdatedAt: now}} {
+		if err := db.WithContext(ctx).Where("id = ?", customer.ID).Assign(customer).FirstOrCreate(&customer).Error; err != nil {
+			return err
+		}
+	}
+	for _, team := range []tables.TableTeam{{ID: tiggingsTeam, Name: "Tiggings", CustomerID: &tiggingsCustomer, CreatedAt: now, UpdatedAt: now}, {ID: outsideTeam, Name: "Outside Team", CustomerID: &outsideCustomer, CreatedAt: now, UpdatedAt: now}} {
+		if err := db.WithContext(ctx).Where("id = ?", team.ID).Assign(team).FirstOrCreate(&team).Error; err != nil {
+			return err
+		}
+	}
+	for _, vk := range []tables.TableVirtualKey{
+		{ID: prefix + "-vk-user-team", Name: "E2E User Team VK", Value: prefix + "-vk-user-team-secret", IsActive: &active, TeamID: &tiggingsTeam, CreatedAt: now, UpdatedAt: now},
+		{ID: prefix + "-vk-team-only", Name: "E2E Team Only VK", Value: prefix + "-vk-team-only-secret", IsActive: &active, TeamID: &tiggingsTeam, CreatedAt: now, UpdatedAt: now},
+		{ID: prefix + "-vk-outside", Name: "E2E Outside VK", Value: prefix + "-vk-outside-secret", IsActive: &active, TeamID: &outsideTeam, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := db.WithContext(ctx).Where("id = ?", vk.ID).Assign(vk).FirstOrCreate(&vk).Error; err != nil {
+			return err
+		}
+		pc := tables.TableVirtualKeyProviderConfig{VirtualKeyID: vk.ID, Provider: "openai", AllowedModels: schemas.WhiteList{"*"}, AllowAllKeys: true}
+		if err := db.WithContext(ctx).Where("virtual_key_id = ? AND provider = ?", vk.ID, "openai").Assign(pc).FirstOrCreate(&pc).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// seedPrompts writes a folder, prompt, and prompt version.
+func seedPrompts(ctx context.Context, db *gorm.DB, prefix string, now time.Time) error {
+	folder := tables.TableFolder{ID: prefix + "-folder", Name: "E2E Seed Folder", CreatedAt: now, UpdatedAt: now}
+	if err := db.WithContext(ctx).Where("id = ?", folder.ID).Assign(folder).FirstOrCreate(&folder).Error; err != nil {
+		return err
+	}
+	prompt := tables.TablePrompt{ID: prefix + "-prompt", Name: "E2E Seed Prompt", FolderID: &folder.ID, CreatedAt: now, UpdatedAt: now}
+	if err := db.WithContext(ctx).Where("id = ?", prompt.ID).Assign(prompt).FirstOrCreate(&prompt).Error; err != nil {
+		return err
+	}
+	version := tables.TablePromptVersion{PromptID: prompt.ID, VersionNumber: 1, CommitMessage: "seed", Provider: "openai", Model: "gpt-4o-mini", IsLatest: true, CreatedAt: now}
+	return db.WithContext(ctx).Where("prompt_id = ? AND version_number = ?", prompt.ID, 1).Assign(version).FirstOrCreate(&version).Error
+}
+
+// seedMCP writes a minimal MCP client.
+func seedMCP(ctx context.Context, db *gorm.DB, prefix string, now time.Time) error {
+	client := tables.TableMCPClient{
+		ClientID:         prefix + "-mcp-client",
+		Name:             "E2E Seed MCP",
+		ConnectionType:   "sse",
+		ConnectionString: schemas.NewEnvVar("https://mcp.e2e.local/sse"),
+		ToolsToExecute:   schemas.WhiteList{"*"},
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	return db.WithContext(ctx).Where("client_id = ?", client.ClientID).Assign(client).FirstOrCreate(&client).Error
+}
+
+// seedLogs writes the DAC matrix LLM logs. Each shape gets exactly
+// opts.LogRowsPerShape rows, so admin sees len(shapes) * LogRowsPerShape
+// total.
+func seedLogs(ctx context.Context, db *gorm.DB, opts Options, manifest ExpectedManifest) error {
+	if db == nil {
+		return fmt.Errorf("logs db is required")
+	}
+	shapes := manifest.Shapes
+	batch := make([]logstore.Log, 0, opts.BatchSize)
+	for shapeIdx, shape := range shapes {
+		for j := 0; j < opts.LogRowsPerShape; j++ {
+			i := shapeIdx*opts.LogRowsPerShape + j
+			batch = append(batch, buildLog(opts.Prefix, shape, i))
+			if len(batch) == opts.BatchSize {
+				if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
+					return err
+				}
+				batch = batch[:0]
+			}
+		}
+	}
+	if len(batch) > 0 {
+		if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
+			return err
+		}
+	}
+	if err := seedMCPLogs(ctx, db, opts, manifest); err != nil {
+		return err
+	}
+	return seedAsyncJobCompanion(ctx, db, opts.Prefix)
+}
+
+// seedMCPLogs writes the DAC matrix MCP tool logs in the same shape and
+// volume as the LLM logs so MCP visibility tests can assert against the
+// expected.mcp_log_ids manifest the same way the LLM tests do.
+func seedMCPLogs(ctx context.Context, db *gorm.DB, opts Options, manifest ExpectedManifest) error {
+	shapes := manifest.Shapes
+	batch := make([]logstore.MCPToolLog, 0, opts.BatchSize)
+	for shapeIdx, shape := range shapes {
+		for j := 0; j < opts.LogRowsPerShape; j++ {
+			i := shapeIdx*opts.LogRowsPerShape + j
+			batch = append(batch, buildMCPLog(opts.Prefix, shape, i))
+			if len(batch) == opts.BatchSize {
+				if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
+					return err
+				}
+				batch = batch[:0]
+			}
+		}
+	}
+	if len(batch) > 0 {
+		if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// seedAsyncJobCompanion writes one async-job row tied to the seeded user VK
+// so the /api/async-jobs CRUD coverage has a deterministic fixture to read.
+func seedAsyncJobCompanion(ctx context.Context, db *gorm.DB, prefix string) error {
+	now := seedBaseTime
+	vk := prefix + "-vk-user-team"
+	completed := now
+	job := logstore.AsyncJob{ID: prefix + "-async-job", Status: schemas.AsyncJobStatusCompleted, RequestType: schemas.ChatCompletionRequest, Response: `{}`, StatusCode: 200, VirtualKeyID: &vk, ResultTTL: 3600, CreatedAt: now, CompletedAt: &completed}
+	return db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&job).Error
+}
+
+// buildMCPLog returns one deterministic MCP tool log row mirroring the DAC
+// dimensions of the shape so the same persona/visibility logic that drives
+// LLM log tests applies here.
+func buildMCPLog(prefix string, shape Shape, index int) logstore.MCPToolLog {
+	timestamp := seedBaseTime.Add(-time.Duration(index) * time.Second)
+	vkName := ""
+	if shape.VirtualKeyID != "" {
+		vkName = "E2E " + shape.VirtualKeyID
+	}
+	latency := float64(20 + index%200)
+	cost := float64(1+index%50) / 100000
+	status := "success"
+	if index%19 == 0 {
+		status = "error"
+	}
+	return logstore.MCPToolLog{
+		ID:              fmt.Sprintf("%s-mcp-log-%06d", prefix, index),
+		RequestID:       fmt.Sprintf("%s-mcp-req-%06d", prefix, index),
+		Timestamp:       timestamp,
+		ToolName:        "e2e-tool",
+		ServerLabel:     "e2e-mcp",
+		VirtualKeyID:    emptyPtr(shape.VirtualKeyID),
+		VirtualKeyName:  emptyPtr(vkName),
+		UserID:          emptyPtr(shape.UserID),
+		TeamID:          emptyPtr(shape.TeamID),
+		CustomerID:      emptyPtr(shape.CustomerID),
+		BusinessUnitID:  emptyPtr(shape.BusinessUnitID),
+		ArgumentsParsed: map[string]any{"seed_prefix": prefix, "shape": shape.Name, "marker": shape.Marker, "index": index},
+		ResultParsed:    map[string]any{"ok": true},
+		Latency:         &latency,
+		Cost:            &cost,
+		Status:          status,
+		MetadataParsed:  map[string]any{"seed_prefix": prefix, "shape": shape.Name, "marker": shape.Marker},
+		CreatedAt:       timestamp,
+	}
+}
+
+// buildLog returns one deterministic log row.
+func buildLog(prefix string, shape Shape, index int) logstore.Log {
+	timestamp := seedBaseTime.Add(-time.Duration(index) * time.Second)
+	vkName := ""
+	if shape.VirtualKeyID != "" {
+		vkName = "E2E " + shape.VirtualKeyID
+	}
+	latency := float64(100 + index%500)
+	cost := float64(1+index%100) / 100000
+	promptTokens := 10 + index%30
+	completionTokens := 5 + index%20
+	status := "success"
+	if index%17 == 0 {
+		status = "error"
+	}
+	return logstore.Log{
+		ID:               fmt.Sprintf("%s-log-%06d", prefix, index),
+		Timestamp:        timestamp,
+		Object:           "chat.completion",
+		Provider:         "openai",
+		Model:            "gpt-4o-mini",
+		SelectedKeyID:    prefix + "-openai-key",
+		SelectedKeyName:  "E2E OpenAI Key",
+		VirtualKeyID:     emptyPtr(shape.VirtualKeyID),
+		VirtualKeyName:   emptyPtr(vkName),
+		UserID:           emptyPtr(shape.UserID),
+		UserName:         emptyPtr(nameFromID(shape.UserID)),
+		TeamID:           emptyPtr(shape.TeamID),
+		TeamName:         emptyPtr(nameFromID(shape.TeamID)),
+		CustomerID:       emptyPtr(shape.CustomerID),
+		CustomerName:     emptyPtr(nameFromID(shape.CustomerID)),
+		BusinessUnitID:   emptyPtr(shape.BusinessUnitID),
+		BusinessUnitName: emptyPtr(nameFromID(shape.BusinessUnitID)),
+		InputHistoryParsed: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: ptr(shape.Marker + " prompt")},
+		}},
+		OutputMessageParsed: &schemas.ChatMessage{Role: schemas.ChatMessageRoleAssistant, Content: &schemas.ChatMessageContent{ContentStr: ptr("seeded response")}},
+		Latency:             &latency,
+		Cost:                &cost,
+		Status:              status,
+		ContentSummary:      shape.Marker,
+		MetadataParsed:      map[string]any{"seed_prefix": prefix, "shape": shape.Name, "marker": shape.Marker},
+		PromptTokens:        promptTokens,
+		CompletionTokens:    completionTokens,
+		TotalTokens:         promptTokens + completionTokens,
+		RoutingEnginesUsed:  []string{"governance"},
+		CreatedAt:           timestamp,
+	}
+}
+
+// defaultModel returns a model for a provider.
+func defaultModel(provider string) string {
+	switch provider {
+	case "anthropic":
+		return "claude-3-5-haiku"
+	case "gemini":
+		return "gemini-1.5-flash"
+	default:
+		return "gpt-4o-mini"
+	}
+}
+
+// emptyPtr returns nil for empty strings.
+func emptyPtr(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+// ptr returns a string pointer.
+func ptr(value string) *string {
+	return &value
+}
+
+// nameFromID derives a display name from an id.
+func nameFromID(id string) string {
+	if id == "" {
+		return ""
+	}
+	return strings.Title(strings.ReplaceAll(id, "-", " "))
+}
+
+// quoteEnv returns a shell-safe env value.
+func quoteEnv(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -108,100 +108,146 @@ const filterDataMatViewWindow = "30 days"
 
 // filterMatViewDef describes a single per-dimension materialized view.
 //
-//   - name:       view name
-//   - selectExpr: comma-separated list of result columns (already COALESCEd if needed)
-//   - whereExpr:  predicate that filters out empty rows for this dimension
-//   - uniqueIdx:  comma-separated columns for the unique index (required for
+//   - name:            view name
+//   - selectExpr:      comma-separated list of result columns (already COALESCEd if needed)
+//   - whereExpr:       predicate that filters out empty rows for this dimension
+//   - uniqueIdx:       comma-separated columns for the unique index (required for
 //     REFRESH ... CONCURRENTLY)
+//   - requiredColumns: resolved column aliases used by repairMatViewShapes
+//     to detect drifted matviews. Declared explicitly (not parsed from
+//     selectExpr) so SQL fragments like COALESCE(...) cannot poison the check.
 type filterMatViewDef struct {
-	name       string
-	selectExpr string
-	whereExpr  string
-	uniqueIdx  string
+	name            string
+	selectExpr      string
+	whereExpr       string
+	uniqueIdx       string
+	requiredColumns []string
 }
 
+// scopeProjection is the per-row visibility columns appended to every
+// filter matview's SELECT so DAC scope WHERE clauses can be applied at
+// the matview level instead of falling back to the raw `logs` table.
+// COALESCE keeps NULL values from causing the DISTINCT to multiply (and
+// the unique index from rejecting NULLs on REFRESH CONCURRENTLY).
+const scopeProjection = "COALESCE(user_id, '') AS user_id, " +
+	"COALESCE(team_id, '') AS team_id, " +
+	"COALESCE(virtual_key_id, '') AS virtual_key_id"
+
+// scopeIdxColumns is the unique-index suffix that pairs with scopeProjection.
+const scopeIdxColumns = "user_id, team_id, virtual_key_id"
+
+// scopeRequiredColumns lists the resolved column aliases produced by
+// scopeProjection. Appended to each matview's requiredColumns so
+// repairMatViewShapes can verify them against pg_attribute.
+var scopeRequiredColumns = []string{"user_id", "team_id", "virtual_key_id"}
+
 // filterMatViews enumerates every per-dimension materialized view used to
-// populate filter dropdowns on the logs page. Order matters only for
-// deterministic startup logs.
+// populate filter dropdowns on the logs page. Each view carries the
+// dropdown's dimension columns plus the visibility columns
+// (user_id, team_id, virtual_key_id) so DAC scope applies in-matview.
+// Order matters only for deterministic startup logs.
 var filterMatViews = []filterMatViewDef{
 	{
-		name:       "mv_filter_models",
-		selectExpr: "model, provider",
-		whereExpr:  "model IS NOT NULL AND model != ''",
-		uniqueIdx:  "model, provider",
+		name:            "mv_filter_models",
+		selectExpr:      "model, provider, " + scopeProjection,
+		whereExpr:       "model IS NOT NULL AND model != ''",
+		uniqueIdx:       "model, provider, " + scopeIdxColumns,
+		requiredColumns: append([]string{"model", "provider"}, scopeRequiredColumns...),
 	},
 	{
-		name:       "mv_filter_aliases",
-		selectExpr: "alias",
-		whereExpr:  "alias IS NOT NULL AND alias != ''",
-		uniqueIdx:  "alias",
+		name:            "mv_filter_aliases",
+		selectExpr:      "alias, " + scopeProjection,
+		whereExpr:       "alias IS NOT NULL AND alias != ''",
+		uniqueIdx:       "alias, " + scopeIdxColumns,
+		requiredColumns: append([]string{"alias"}, scopeRequiredColumns...),
 	},
 	{
-		name:       "mv_filter_stop_reasons",
-		selectExpr: "stop_reason",
-		whereExpr:  "stop_reason IS NOT NULL AND stop_reason != ''",
-		uniqueIdx:  "stop_reason",
+		name:            "mv_filter_stop_reasons",
+		selectExpr:      "stop_reason, " + scopeProjection,
+		whereExpr:       "stop_reason IS NOT NULL AND stop_reason != ''",
+		uniqueIdx:       "stop_reason, " + scopeIdxColumns,
+		requiredColumns: append([]string{"stop_reason"}, scopeRequiredColumns...),
 	},
 	{
-		name:       "mv_filter_routing_engines",
-		selectExpr: "routing_engines_used",
-		whereExpr:  "routing_engines_used IS NOT NULL AND routing_engines_used != ''",
-		uniqueIdx:  "routing_engines_used",
+		name:            "mv_filter_routing_engines",
+		selectExpr:      "routing_engines_used, " + scopeProjection,
+		whereExpr:       "routing_engines_used IS NOT NULL AND routing_engines_used != ''",
+		uniqueIdx:       "routing_engines_used, " + scopeIdxColumns,
+		requiredColumns: append([]string{"routing_engines_used"}, scopeRequiredColumns...),
 	},
 	{
-		name:       "mv_filter_selected_keys",
-		selectExpr: "selected_key_id AS id, selected_key_name AS name",
-		whereExpr:  "selected_key_id IS NOT NULL AND selected_key_id != '' AND selected_key_name IS NOT NULL AND selected_key_name != ''",
-		uniqueIdx:  "id, name",
+		name:            "mv_filter_selected_keys",
+		selectExpr:      "selected_key_id AS id, selected_key_name AS name, " + scopeProjection,
+		whereExpr:       "selected_key_id IS NOT NULL AND selected_key_id != '' AND selected_key_name IS NOT NULL AND selected_key_name != ''",
+		uniqueIdx:       "id, name, " + scopeIdxColumns,
+		requiredColumns: append([]string{"id", "name"}, scopeRequiredColumns...),
 	},
 	{
-		name:       "mv_filter_virtual_keys",
-		selectExpr: "virtual_key_id AS id, virtual_key_name AS name",
-		whereExpr:  "virtual_key_id IS NOT NULL AND virtual_key_id != '' AND virtual_key_name IS NOT NULL AND virtual_key_name != ''",
-		uniqueIdx:  "id, name",
+		name: "mv_filter_virtual_keys",
+		// virtual_key_id is exposed as "id" for the dropdown and also as the
+		// scope column so DAC predicates use a stable name across matviews.
+		selectExpr: "virtual_key_id AS id, virtual_key_name AS name, " +
+			"COALESCE(user_id, '') AS user_id, COALESCE(team_id, '') AS team_id, " +
+			"COALESCE(virtual_key_id, '') AS virtual_key_id",
+		whereExpr:       "virtual_key_id IS NOT NULL AND virtual_key_id != '' AND virtual_key_name IS NOT NULL AND virtual_key_name != ''",
+		uniqueIdx:       "id, name, " + scopeIdxColumns,
+		requiredColumns: append([]string{"id", "name"}, scopeRequiredColumns...),
 	},
 	{
-		name:       "mv_filter_routing_rules",
-		selectExpr: "routing_rule_id AS id, routing_rule_name AS name",
-		whereExpr:  "routing_rule_id IS NOT NULL AND routing_rule_id != '' AND routing_rule_name IS NOT NULL AND routing_rule_name != ''",
-		uniqueIdx:  "id, name",
+		name:            "mv_filter_routing_rules",
+		selectExpr:      "routing_rule_id AS id, routing_rule_name AS name, " + scopeProjection,
+		whereExpr:       "routing_rule_id IS NOT NULL AND routing_rule_id != '' AND routing_rule_name IS NOT NULL AND routing_rule_name != ''",
+		uniqueIdx:       "id, name, " + scopeIdxColumns,
+		requiredColumns: append([]string{"id", "name"}, scopeRequiredColumns...),
 	},
 	{
-		name:       "mv_filter_teams",
-		selectExpr: "team_id AS id, team_name AS name",
-		whereExpr:  "team_id IS NOT NULL AND team_id != '' AND team_name IS NOT NULL AND team_name != ''",
-		uniqueIdx:  "id, name",
+		name: "mv_filter_teams",
+		// team_id is exposed as "id" for the dropdown and also as the scope
+		// column for uniform DAC predicates.
+		selectExpr: "team_id AS id, team_name AS name, " +
+			"COALESCE(user_id, '') AS user_id, COALESCE(team_id, '') AS team_id, " +
+			"COALESCE(virtual_key_id, '') AS virtual_key_id",
+		whereExpr:       "team_id IS NOT NULL AND team_id != '' AND team_name IS NOT NULL AND team_name != ''",
+		uniqueIdx:       "id, name, " + scopeIdxColumns,
+		requiredColumns: append([]string{"id", "name"}, scopeRequiredColumns...),
 	},
 	{
-		name:       "mv_filter_customers",
-		selectExpr: "customer_id AS id, customer_name AS name",
-		whereExpr:  "customer_id IS NOT NULL AND customer_id != '' AND customer_name IS NOT NULL AND customer_name != ''",
-		uniqueIdx:  "id, name",
+		name:            "mv_filter_customers",
+		selectExpr:      "customer_id AS id, customer_name AS name, " + scopeProjection,
+		whereExpr:       "customer_id IS NOT NULL AND customer_id != '' AND customer_name IS NOT NULL AND customer_name != ''",
+		uniqueIdx:       "id, name, " + scopeIdxColumns,
+		requiredColumns: append([]string{"id", "name"}, scopeRequiredColumns...),
 	},
 	{
-		name:       "mv_filter_users",
-		selectExpr: "user_id AS id, user_id AS name",
-		whereExpr:  "user_id IS NOT NULL AND user_id != ''",
-		uniqueIdx:  "id",
+		name: "mv_filter_users",
+		// user_id is exposed as both "id" and "name" for the dropdown and
+		// also as the scope column.
+		selectExpr: "user_id AS id, user_id AS name, " +
+			"COALESCE(user_id, '') AS user_id, COALESCE(team_id, '') AS team_id, " +
+			"COALESCE(virtual_key_id, '') AS virtual_key_id",
+		whereExpr:       "user_id IS NOT NULL AND user_id != ''",
+		uniqueIdx:       "id, " + scopeIdxColumns,
+		requiredColumns: append([]string{"id", "name"}, scopeRequiredColumns...),
 	},
 	{
-		name:       "mv_filter_business_units",
-		selectExpr: "business_unit_id AS id, business_unit_name AS name",
-		whereExpr:  "business_unit_id IS NOT NULL AND business_unit_id != '' AND business_unit_name IS NOT NULL AND business_unit_name != ''",
-		uniqueIdx:  "id, name",
+		name:            "mv_filter_business_units",
+		selectExpr:      "business_unit_id AS id, business_unit_name AS name, " + scopeProjection,
+		whereExpr:       "business_unit_id IS NOT NULL AND business_unit_id != '' AND business_unit_name IS NOT NULL AND business_unit_name != ''",
+		uniqueIdx:       "id, name, " + scopeIdxColumns,
+		requiredColumns: append([]string{"id", "name"}, scopeRequiredColumns...),
 	},
 }
 
 // filterMatViewKeyPairColumns maps the (idCol, nameCol) pair callers pass into
 // GetDistinctKeyPairs to the per-dimension matview that pre-aggregates it.
 var filterMatViewKeyPairColumns = map[[2]string]string{
-	{"selected_key_id", "selected_key_name"}:     "mv_filter_selected_keys",
-	{"virtual_key_id", "virtual_key_name"}:       "mv_filter_virtual_keys",
-	{"routing_rule_id", "routing_rule_name"}:     "mv_filter_routing_rules",
-	{"team_id", "team_name"}:                     "mv_filter_teams",
-	{"customer_id", "customer_name"}:             "mv_filter_customers",
-	{"user_id", "user_id"}:                       "mv_filter_users",
-	{"business_unit_id", "business_unit_name"}:   "mv_filter_business_units",
+	{"selected_key_id", "selected_key_name"}:   "mv_filter_selected_keys",
+	{"virtual_key_id", "virtual_key_name"}:     "mv_filter_virtual_keys",
+	{"routing_rule_id", "routing_rule_name"}:   "mv_filter_routing_rules",
+	{"team_id", "team_name"}:                   "mv_filter_teams",
+	{"customer_id", "customer_name"}:           "mv_filter_customers",
+	{"user_id", "user_id"}:                     "mv_filter_users",
+	{"business_unit_id", "business_unit_name"}: "mv_filter_business_units",
 }
 
 func filterMatViewDDL(v filterMatViewDef) string {
@@ -224,45 +270,86 @@ func filterMatViewUniqueIdxName(v filterMatViewDef) string {
 	return v.name + "_uniq"
 }
 
-// filterMatViewRequiredColumns derives the column-set used by
-// repairMatViewShapes to detect drifted matviews. Parses the selectExpr so we
-// don't have to maintain a parallel slice.
-func filterMatViewRequiredColumns(v filterMatViewDef) []string {
-	parts := strings.Split(v.selectExpr, ",")
-	cols := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		// Strip any "<expr> AS alias" → keep the alias.
-		if idx := strings.LastIndex(strings.ToLower(p), " as "); idx >= 0 {
-			p = strings.TrimSpace(p[idx+len(" as "):])
-		}
-		if p != "" {
-			cols = append(cols, p)
-		}
-	}
-	return cols
+// filterMatViewScopeIdx returns a CONCURRENTLY-built BTREE index DDL that
+// makes DAC-scoped queries index-only. Leading columns are the visibility
+// dimensions so a query of the form
+// `SELECT DISTINCT <dim> FROM <view> WHERE user_id IN (?)` can satisfy the
+// predicate from the index. The unique index already covers the
+// unscoped `SELECT DISTINCT <dim>` path via its leading-prefix scan, so
+// this index is purely for the scoped path.
+//
+// CONCURRENTLY makes the build non-blocking; IF NOT EXISTS keeps repeated
+// boots idempotent.
+func filterMatViewScopeIdx(v filterMatViewDef) string {
+	return fmt.Sprintf(
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS %s_scope ON %s (%s)",
+		v.name, v.name, scopeIdxColumns,
+	)
 }
 
-type matviewUniqueIndexDef struct {
-	view string
-	name string
-	sql  string
+// filterMatViewScopeIdxName is the canonical index name for v's scope index.
+func filterMatViewScopeIdxName(v filterMatViewDef) string {
+	return v.name + "_scope"
+}
+
+// filterMatViewRequiredColumns returns a defensive copy of the resolved
+// column aliases used by repairMatViewShapes to detect drifted matviews.
+// The list is declared explicitly on each filterMatViewDef so SQL fragments
+// in selectExpr (e.g. COALESCE expressions containing commas) cannot poison
+// the comparison against pg_attribute.
+func filterMatViewRequiredColumns(v filterMatViewDef) []string {
+	return append([]string(nil), v.requiredColumns...)
+}
+
+type matviewIndexDef struct {
+	view   string
+	name   string
+	sql    string
+	unique bool // true for the index that REFRESH MATERIALIZED VIEW CONCURRENTLY requires
 }
 
 // matviewUniqueIndexes enumerates every (matview, unique-index) pair this
-// package manages. Built lazily so it always reflects the current
-// filterMatViews list without a parallel hand-maintained slice.
-var matviewUniqueIndexes = func() []matviewUniqueIndexDef {
-	defs := []matviewUniqueIndexDef{{
-		view: "mv_logs_hourly",
-		name: "mv_logs_hourly_uniq",
-		sql:  mvLogsHourlyUniqueIdx,
+// package manages. Required for REFRESH ... CONCURRENTLY. Built lazily so
+// it always reflects the current filterMatViews list.
+var matviewUniqueIndexes = func() []matviewIndexDef {
+	defs := []matviewIndexDef{{
+		view:   "mv_logs_hourly",
+		name:   "mv_logs_hourly_uniq",
+		sql:    mvLogsHourlyUniqueIdx,
+		unique: true,
 	}}
 	for _, v := range filterMatViews {
-		defs = append(defs, matviewUniqueIndexDef{
+		defs = append(defs, matviewIndexDef{
+			view:   v.name,
+			name:   filterMatViewUniqueIdxName(v),
+			sql:    filterMatViewUniqueIdx(v),
+			unique: true,
+		})
+	}
+	return defs
+}()
+
+// matviewScopeIndexes enumerates the secondary BTREE indexes that make
+// DAC-scoped reads on the per-dimension filter matviews cheap. The
+// composite (user_id, team_id, virtual_key_id) is a covering index for
+// the only column subset every filter-dropdown query selects, so
+// Postgres can serve scoped DISTINCT queries via an index-only scan
+// even when only the trailing columns are in the predicate. Filter
+// matviews are small (one row per (dim, scope)) and dropdown queries
+// are LIMIT-bounded, so the index-only fallback is acceptable for
+// non-user-leading scope shapes without paying for per-column indexes
+// on every REFRESH MATERIALIZED VIEW CONCURRENTLY. mv_logs_hourly is
+// excluded: it is queried via applyMatViewFilters with many WHERE
+// shapes (provider/model/status/object_type/key/team/etc.) where the
+// planner is better served by bitmap-AND'ing the existing per-shape
+// indexes than by an extra 3-column scope index.
+var matviewScopeIndexes = func() []matviewIndexDef {
+	defs := make([]matviewIndexDef, 0, len(filterMatViews))
+	for _, v := range filterMatViews {
+		defs = append(defs, matviewIndexDef{
 			view: v.name,
-			name: filterMatViewUniqueIdxName(v),
-			sql:  filterMatViewUniqueIdx(v),
+			name: filterMatViewScopeIdxName(v),
+			sql:  filterMatViewScopeIdx(v),
 		})
 	}
 	return defs
@@ -426,16 +513,32 @@ func ensureMatViewUniqueIndexes(ctx context.Context, conn *sql.Conn) error {
 	_, _ = conn.ExecContext(ctx, "SET maintenance_work_mem = '512MB'")
 	_, _ = conn.ExecContext(ctx, "SET max_parallel_maintenance_workers = 4")
 
-	for _, idx := range matviewUniqueIndexes {
+	if err := ensureIndexes(ctx, conn, matviewUniqueIndexes); err != nil {
+		return err
+	}
+	return ensureIndexes(ctx, conn, matviewScopeIndexes)
+}
+
+// ensureIndexes idempotently brings each index up: skips when the index
+// already exists and is valid, otherwise drops any prior invalid version
+// (CONCURRENTLY, no blocking) and rebuilds via the supplied DDL. The
+// unique flag tightens the validity check for indexes used by REFRESH
+// MATERIALIZED VIEW CONCURRENTLY, which requires `indisunique`.
+func ensureIndexes(ctx context.Context, conn *sql.Conn, defs []matviewIndexDef) error {
+	for _, idx := range defs {
+		validityExpr := "pi.indisvalid"
+		if idx.unique {
+			validityExpr = "pi.indisvalid AND pi.indisunique"
+		}
 		var indexReady bool
-		if err := conn.QueryRowContext(ctx, `
-			SELECT COALESCE(bool_and(pi.indisvalid AND pi.indisunique), false)
+		if err := conn.QueryRowContext(ctx, fmt.Sprintf(`
+			SELECT COALESCE(bool_and(%s), false)
 			FROM pg_class pc
 			JOIN pg_index pi ON pi.indrelid = pc.oid
 			JOIN pg_class ic ON ic.oid = pi.indexrelid
 			WHERE pc.relname = $1
 			  AND ic.relname = $2
-		`, idx.view, idx.name).Scan(&indexReady); err != nil {
+		`, validityExpr), idx.view, idx.name).Scan(&indexReady); err != nil {
 			return fmt.Errorf("failed to check matview index %s validity: %w", idx.name, err)
 		}
 		if indexReady {
@@ -449,7 +552,6 @@ func ensureMatViewUniqueIndexes(ctx context.Context, conn *sql.Conn) error {
 			return fmt.Errorf("failed to create matview index %s: %w", idx.name, err)
 		}
 	}
-
 	return nil
 }
 
@@ -481,10 +583,10 @@ const matViewRefreshSafetyInterval = 10 * time.Minute
 // changed. Per-process state — multi-replica deployments still serialize via
 // the advisory lock.
 type matViewRefreshGate struct {
-	mu               sync.Mutex
-	lastActivity     int64
-	lastForcedAt     time.Time
-	initialized      bool
+	mu           sync.Mutex
+	lastActivity int64
+	lastForcedAt time.Time
+	initialized  bool
 }
 
 var refreshGate matViewRefreshGate
@@ -682,7 +784,18 @@ func (s *RDBLogStore) canUseMatViewForFreshAggregate(f SearchFilters) bool {
 // ---------------------------------------------------------------------------
 
 // applyMatViewFilters builds WHERE clauses for queries against mv_logs_hourly.
-func applyMatViewFilters(q *gorm.DB, f SearchFilters) *gorm.DB {
+// Callers are responsible for starting from ScopedDB(ctx) when row
+// visibility should be respected; this helper only adds the matview
+// filter predicates.
+func (s *RDBLogStore) applyMatViewFilters(q *gorm.DB, f SearchFilters) *gorm.DB {
+	return applyMatViewFiltersOnly(q, f)
+}
+
+// applyMatViewFiltersOnly builds WHERE clauses for queries against
+// mv_logs_hourly without applying visibility. Kept separate so the visibility
+// pass happens exactly once (at the entry point) and unit tests of the filter
+// translation don't need a context.
+func applyMatViewFiltersOnly(q *gorm.DB, f SearchFilters) *gorm.DB {
 	if f.StartTime != nil {
 		q = q.Where("hour >= date_trunc('hour', ?::timestamptz)", *f.StartTime)
 	}
@@ -733,8 +846,8 @@ func applyMatViewFilters(q *gorm.DB, f SearchFilters) *gorm.DB {
 // by summing pre-aggregated counts from mv_logs_hourly.
 func (s *RDBLogStore) getCountFromMatView(ctx context.Context, filters SearchFilters) (int64, error) {
 	var total int64
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select("COALESCE(SUM(count), 0)").Row().Scan(&total); err != nil {
 		return 0, err
 	}
@@ -752,8 +865,8 @@ func (s *RDBLogStore) getStatsFromMatView(ctx context.Context, filters SearchFil
 		TotalTokens  int64   `gorm:"column:total_tokens"`
 		TotalCost    float64 `gorm:"column:total_cost"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(`
 		COALESCE(SUM(count), 0) AS total_count,
 		COALESCE(SUM(success_count), 0) AS success_count,
@@ -797,7 +910,7 @@ func (s *RDBLogStore) getStatsFromMatView(ctx context.Context, filters SearchFil
 		alignedEnd := filters.EndTime.Truncate(time.Hour).Add(time.Hour - time.Nanosecond)
 		alignedFilters.EndTime = &alignedEnd
 	}
-	cacheBase := s.db.WithContext(ctx).Model(&Log{}).Where("status IN ?", []string{"success", "error"})
+	cacheBase := s.ScopedDB(ctx).Model(&Log{}).Where("status IN ?", []string{"success", "error"})
 	direct, semantic, err := s.aggregateCacheHits(ctx, cacheBase, alignedFilters)
 	if err != nil {
 		s.logger.Warn(fmt.Sprintf("logstore: failed to aggregate cache-hit stats, skipping: %s", err))
@@ -818,8 +931,8 @@ func (s *RDBLogStore) getHistogramFromMatView(ctx context.Context, filters Searc
 		Success         int64 `gorm:"column:success"`
 		ErrorCount      int64 `gorm:"column:error_count"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		SUM(count) AS total,
@@ -861,8 +974,8 @@ func (s *RDBLogStore) getTokenHistogramFromMatView(ctx context.Context, filters 
 		TotalTokens      int64 `gorm:"column:total_tkns"`
 		CachedReadTokens int64 `gorm:"column:cached_read_tokens"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		SUM(total_prompt_tokens) AS prompt_tokens,
@@ -905,8 +1018,8 @@ func (s *RDBLogStore) getCostHistogramFromMatView(ctx context.Context, filters S
 		Model           string  `gorm:"column:model"`
 		Cost            float64 `gorm:"column:cost"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		model,
@@ -960,8 +1073,8 @@ func (s *RDBLogStore) getModelHistogramFromMatView(ctx context.Context, filters 
 		Success         int64  `gorm:"column:success"`
 		ErrorCount      int64  `gorm:"column:error_count"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		model,
@@ -1021,8 +1134,8 @@ func (s *RDBLogStore) getLatencyHistogramFromMatView(ctx context.Context, filter
 		TotalRequests   int64   `gorm:"column:total_requests"`
 	}
 	// Weighted average of percentiles across hourly buckets
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		CASE WHEN SUM(count) > 0 THEN SUM(avg_latency * count) / SUM(count) ELSE 0 END AS avg_lat,
@@ -1067,8 +1180,8 @@ func (s *RDBLogStore) getProviderCostHistogramFromMatView(ctx context.Context, f
 		Provider        string  `gorm:"column:provider"`
 		Cost            float64 `gorm:"column:cost"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		provider,
@@ -1122,8 +1235,8 @@ func (s *RDBLogStore) getProviderTokenHistogramFromMatView(ctx context.Context, 
 		CompletionTokens int64  `gorm:"column:completion_tokens"`
 		TotalTokens      int64  `gorm:"column:total_tkns"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		provider,
@@ -1196,8 +1309,8 @@ func (s *RDBLogStore) getProviderLatencyHistogramFromMatView(ctx context.Context
 		P99Latency      float64 `gorm:"column:p99_lat"`
 		TotalRequests   int64   `gorm:"column:total_requests"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		provider,
@@ -1261,8 +1374,8 @@ func (s *RDBLogStore) getDimensionCostHistogramFromMatView(ctx context.Context, 
 		DimValue        string  `gorm:"column:dim_value"`
 		Cost            float64 `gorm:"column:cost"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		%s AS dim_value,
@@ -1317,8 +1430,8 @@ func (s *RDBLogStore) getDimensionTokenHistogramFromMatView(ctx context.Context,
 		CompletionTokens int64  `gorm:"column:completion_tokens"`
 		TotalTokens      int64  `gorm:"column:total_tkns"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		%s AS dim_value,
@@ -1390,8 +1503,8 @@ func (s *RDBLogStore) getDimensionLatencyHistogramFromMatView(ctx context.Contex
 		P99Latency      float64 `gorm:"column:p99_lat"`
 		TotalRequests   int64   `gorm:"column:total_requests"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
 		%s AS dim_value,
@@ -1454,8 +1567,8 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 		TotalTokens  int64   `gorm:"column:total_tkns"`
 		TotalCost    float64 `gorm:"column:total_cost"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(`
 		model, provider,
 		SUM(count) AS total,
@@ -1486,8 +1599,8 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 		prevFilters := filters
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd
-		pq := s.db.WithContext(ctx).Table("mv_logs_hourly")
-		pq = applyMatViewFilters(pq, prevFilters)
+		pq := s.ScopedDB(ctx).Table("mv_logs_hourly")
+		pq = s.applyMatViewFilters(pq, prevFilters)
 		if err := pq.Select(`
 			model, provider,
 			SUM(count) AS total,
@@ -1546,8 +1659,8 @@ func (s *RDBLogStore) getUserRankingsFromMatView(ctx context.Context, filters Se
 		TotalTokens int64   `gorm:"column:total_tkns"`
 		TotalCost   float64 `gorm:"column:total_cost"`
 	}
-	q := s.db.WithContext(ctx).Table("mv_logs_hourly")
-	q = applyMatViewFilters(q, filters)
+	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q = s.applyMatViewFilters(q, filters)
 	q = q.Where("user_id != ''")
 	if err := q.Select(`
 		user_id,
@@ -1575,8 +1688,8 @@ func (s *RDBLogStore) getUserRankingsFromMatView(ctx context.Context, filters Se
 		prevFilters := filters
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd
-		pq := s.db.WithContext(ctx).Table("mv_logs_hourly")
-		pq = applyMatViewFilters(pq, prevFilters)
+		pq := s.ScopedDB(ctx).Table("mv_logs_hourly")
+		pq = s.applyMatViewFilters(pq, prevFilters)
 		pq = pq.Where("user_id != ''")
 		if err := pq.Select(`
 			user_id,
@@ -1625,7 +1738,7 @@ func (s *RDBLogStore) getUserRankingsFromMatView(ctx context.Context, filters Se
 // of which path served the request.
 func (s *RDBLogStore) getDistinctModelsFromMatView(ctx context.Context, limit int, query string) ([]string, error) {
 	var models []string
-	q := s.db.WithContext(ctx).Table("mv_filter_models").
+	q := s.ScopedDB(ctx).Table("mv_filter_models").
 		Distinct("model").
 		Where("model != ''")
 	if query != "" {
@@ -1640,7 +1753,7 @@ func (s *RDBLogStore) getDistinctModelsFromMatView(ctx context.Context, limit in
 // getDistinctAliasesFromMatView returns unique alias values from mv_filter_aliases.
 func (s *RDBLogStore) getDistinctAliasesFromMatView(ctx context.Context, limit int, query string) ([]string, error) {
 	var aliases []string
-	q := s.db.WithContext(ctx).Table("mv_filter_aliases").
+	q := s.ScopedDB(ctx).Table("mv_filter_aliases").
 		Distinct("alias").
 		Where("alias != ''")
 	if query != "" {
@@ -1655,7 +1768,7 @@ func (s *RDBLogStore) getDistinctAliasesFromMatView(ctx context.Context, limit i
 // getDistinctStopReasonsFromMatView returns unique stop reasons from mv_filter_stop_reasons.
 func (s *RDBLogStore) getDistinctStopReasonsFromMatView(ctx context.Context, limit int, query string) ([]string, error) {
 	var stopReasons []string
-	q := s.db.WithContext(ctx).Table("mv_filter_stop_reasons").
+	q := s.ScopedDB(ctx).Table("mv_filter_stop_reasons").
 		Distinct("stop_reason").
 		Where("stop_reason != ''")
 	if query != "" {
@@ -1677,7 +1790,10 @@ func (s *RDBLogStore) getDistinctKeyPairsFromMatView(ctx context.Context, idCol,
 		return nil, false, nil
 	}
 	var results []KeyPairResult
-	q := s.db.WithContext(ctx).Table(view).Where("id != ''")
+	q := s.ScopedDB(ctx).Table(view).Where("id != ''")
+	// User matview stores name = id and the view-level WHERE already filters
+	// empty ids; other matviews include name and we additionally guard against
+	// stragglers with empty names.
 	if !(idCol == "user_id" && nameCol == "user_id") {
 		q = q.Where("name != ''")
 	}
@@ -1699,7 +1815,7 @@ func (s *RDBLogStore) getDistinctKeyPairsFromMatView(ctx context.Context, idCol,
 // mv_filter_routing_engines.
 func (s *RDBLogStore) getDistinctRoutingEnginesFromMatView(ctx context.Context, limit int, query string) ([]string, error) {
 	var rawValues []string
-	q := s.db.WithContext(ctx).Table("mv_filter_routing_engines").
+	q := s.ScopedDB(ctx).Table("mv_filter_routing_engines").
 		Distinct("routing_engines_used").
 		Where("routing_engines_used != ''")
 	if query != "" {

--- a/framework/logstore/matviews_dac_test.go
+++ b/framework/logstore/matviews_dac_test.go
@@ -1,0 +1,137 @@
+package logstore
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFilterMatViews_AllCarryVisibilityColumns asserts the widening
+// from Fix 4 — every per-dimension matview projects user_id, team_id,
+// and virtual_key_id (or has them as part of its dimension columns).
+// Without these columns the DAC scope WHERE applied via ScopedDB
+// would error at the SQL layer with "no such column".
+func TestFilterMatViews_AllCarryVisibilityColumns(t *testing.T) {
+	required := []string{"user_id", "team_id", "virtual_key_id"}
+	for _, v := range filterMatViews {
+		cols := filterMatViewRequiredColumns(v)
+		colSet := make(map[string]struct{}, len(cols))
+		for _, c := range cols {
+			colSet[c] = struct{}{}
+		}
+		for _, want := range required {
+			_, ok := colSet[want]
+			assert.Truef(t, ok,
+				"matview %s must project %s as a visibility column (selectExpr=%q)",
+				v.name, want, v.selectExpr)
+		}
+	}
+}
+
+// TestFilterMatViews_UniqueIdxIncludesVisibilityColumns asserts the
+// widened unique index covers (user_id, team_id, virtual_key_id) so
+// the new row shape can be uniquely keyed for REFRESH ... CONCURRENTLY.
+func TestFilterMatViews_UniqueIdxIncludesVisibilityColumns(t *testing.T) {
+	for _, v := range filterMatViews {
+		idx := strings.ToLower(v.uniqueIdx)
+		assert.Contains(t, idx, "user_id",
+			"matview %s unique index must include user_id", v.name)
+		assert.Contains(t, idx, "team_id",
+			"matview %s unique index must include team_id", v.name)
+		assert.Contains(t, idx, "virtual_key_id",
+			"matview %s unique index must include virtual_key_id", v.name)
+	}
+}
+
+// TestFilterMatViewScopeIdx_IsConcurrentAndIdempotent asserts the DDL
+// builder emits CREATE INDEX CONCURRENTLY IF NOT EXISTS with the
+// visibility columns as the leading key, so scoped reads are
+// index-only and the boot path never blocks on the build.
+func TestFilterMatViewScopeIdx_IsConcurrentAndIdempotent(t *testing.T) {
+	for _, v := range filterMatViews {
+		ddl := filterMatViewScopeIdx(v)
+		assert.Contains(t, ddl, "CREATE INDEX CONCURRENTLY",
+			"scope index for %s must be CONCURRENTLY", v.name)
+		assert.Contains(t, ddl, "IF NOT EXISTS",
+			"scope index for %s must be idempotent", v.name)
+		assert.Contains(t, ddl, filterMatViewScopeIdxName(v),
+			"scope index DDL must reference the canonical index name")
+		assert.Contains(t, ddl, scopeIdxColumns,
+			"scope index must lead with (user_id, team_id, virtual_key_id)")
+	}
+}
+
+// TestMatviewScopeIndexes_OnePerFilterMatView asserts the registered
+// scope-index list mirrors filterMatViews exactly. ensureMatViews
+// iterates this list to bring up the indexes; a missing entry would
+// silently leave a matview without its DAC index.
+func TestMatviewScopeIndexes_OnePerFilterMatView(t *testing.T) {
+	assert.Equal(t, len(filterMatViews), len(matviewScopeIndexes),
+		"every per-dimension matview must have a scope-index entry")
+	for i, v := range filterMatViews {
+		assert.Equal(t, v.name, matviewScopeIndexes[i].view,
+			"scope-index ordering must mirror filterMatViews")
+		assert.False(t, matviewScopeIndexes[i].unique,
+			"scope indexes must NOT be marked unique (the unique-index list owns that role)")
+	}
+}
+
+// TestFilterMatViewUniqueIdx_StillConcurrent ensures we didn't lose
+// the CONCURRENTLY clause when widening the unique index — REFRESH
+// MATERIALIZED VIEW CONCURRENTLY depends on the unique index existing.
+func TestFilterMatViewUniqueIdx_StillConcurrent(t *testing.T) {
+	for _, v := range filterMatViews {
+		ddl := filterMatViewUniqueIdx(v)
+		assert.Contains(t, ddl, "CREATE UNIQUE INDEX CONCURRENTLY",
+			"unique index for %s must remain CONCURRENTLY", v.name)
+	}
+}
+
+// TestPerDimensionReaders_TargetTheirOwnMatview pins each Get*FromMatView
+// reader to its per-dimension view. A prior refactor left two readers
+// pointing at the retired mv_logs_filterdata view; this test catches
+// that drift on every change.
+func TestPerDimensionReaders_TargetTheirOwnMatview(t *testing.T) {
+	// Map of expected matview to a substring that must appear in the
+	// reader function's body. The bodies are short and the substring
+	// is just `Table("<name>")` — Go test reflection can't reach into
+	// closures, so we read the source file instead.
+	src, err := os.ReadFile("matviews.go")
+	require.NoError(t, err)
+
+	cases := []struct {
+		funcName string
+		view     string
+	}{
+		{"getDistinctAliasesFromMatView", "mv_filter_aliases"},
+		{"getDistinctRoutingEnginesFromMatView", "mv_filter_routing_engines"},
+		{"getDistinctStopReasonsFromMatView", "mv_filter_stop_reasons"},
+		{"getDistinctModelsFromMatView", "mv_filter_models"},
+	}
+
+	for _, c := range cases {
+		// Find the function declaration and check the next ~20 lines
+		// for the expected Table("...") reference. Anchoring on the
+		// declaration keeps the assertion local to the reader.
+		idx := strings.Index(string(src), "func (s *RDBLogStore) "+c.funcName+"(")
+		if !assert.NotEqualf(t, -1, idx, "reader %s not found", c.funcName) {
+			continue
+		}
+		// Look at the next 1.5KB of the file — enough to span the
+		// short reader body without bleeding into siblings.
+		end := idx + 1500
+		if end > len(src) {
+			end = len(src)
+		}
+		body := string(src[idx:end])
+		assert.Containsf(t, body, `Table("`+c.view+`")`,
+			"reader %s must target %s, not the legacy mv_logs_filterdata or another view",
+			c.funcName, c.view)
+		assert.NotContainsf(t, body, `Table("mv_logs_filterdata")`,
+			"reader %s still points at the retired mv_logs_filterdata view",
+			c.funcName)
+	}
+}

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -327,6 +327,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddSafeJsonbFunction(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddDACColumnsToMCPToolLogs(ctx, db); err != nil {
+		return err
+	}
 	// migrationSplitFilterDataMatView is intentionally NOT invoked in this
 	// release. Dropping mv_logs_filterdata while old replicas are still
 	// serving /api/logs/filterdata from it would surface "relation does not
@@ -2460,6 +2463,26 @@ var performanceIndexes = []performanceIndexDef{
 		name:  "idx_logs_stop_reason",
 		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_stop_reason ON logs(stop_reason)",
 	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_user_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_user_id ON mcp_tool_logs(user_id)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_team_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_team_id ON mcp_tool_logs(team_id)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_customer_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_customer_id ON mcp_tool_logs(customer_id)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_business_unit_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_business_unit_id ON mcp_tool_logs(business_unit_id)",
+	},
 }
 
 // ensurePerformanceIndexes checks whether each performance GIN index exists and is
@@ -3099,6 +3122,52 @@ $$;`
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while adding bifrost_safe_jsonb function: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddDACColumnsToMCPToolLogs adds user_id, team_id, customer_id,
+// and business_unit_id columns to mcp_tool_logs so DAC scope can apply the
+// same ownership predicates it does on the logs table. The columns are
+// nullable; pre-existing rows stay NULL and the DAC resolver fails closed
+// for non-admin principals against them.
+//
+// Indexes are built CONCURRENTLY by ensurePerformanceIndexes (entries appended
+// to performanceIndexes) so adding them does not block writes on a populated
+// table.
+func migrationAddDACColumnsToMCPToolLogs(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "mcp_tool_logs_add_dac_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			for _, col := range []string{"user_id", "team_id", "customer_id", "business_unit_id"} {
+				if !mg.HasColumn(&MCPToolLog{}, col) {
+					if err := mg.AddColumn(&MCPToolLog{}, col); err != nil {
+						return fmt.Errorf("failed to add %s column to mcp_tool_logs: %w", col, err)
+					}
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			for _, col := range []string{"business_unit_id", "customer_id", "team_id", "user_id"} {
+				if mg.HasColumn(&MCPToolLog{}, col) {
+					if err := mg.DropColumn(&MCPToolLog{}, col); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding DAC columns to mcp_tool_logs: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/queryscope"
 	"golang.org/x/sync/errgroup"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -72,7 +73,22 @@ func generateBucketTimestamps(startTime, endTime *time.Time, bucketSizeSeconds i
 	return timestamps
 }
 
-// applyFilters applies search filters to a GORM query
+// ScopedDB returns the underlying DB bound to ctx with any QueryScope
+// on ctx pre-applied. Use this in read paths that should respect
+// caller-driven row visibility; use s.db.WithContext(ctx) for writes
+// and internal lookups that must bypass scoping.
+func (s *RDBLogStore) ScopedDB(ctx context.Context) *gorm.DB {
+	db := s.db.WithContext(ctx)
+	if scope := queryscope.FromContext(ctx); scope != nil {
+		db = scope(db)
+	}
+	return db
+}
+
+// applyFilters applies search filters to a GORM query. Callers are
+// responsible for starting from ScopedDB(ctx) when row visibility
+// should be respected; this helper only adds the per-call filter
+// predicates.
 func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *gorm.DB {
 	if len(filters.Providers) > 0 {
 		baseQuery = baseQuery.Where("provider IN ?", filters.Providers)
@@ -449,13 +465,13 @@ func (s *RDBLogStore) SearchLogs(ctx context.Context, filters SearchFilters, pag
 			totalCount, err = s.getCountFromMatView(gCtx, filters)
 			return err
 		}
-		countQuery := s.db.WithContext(gCtx).Model(&Log{})
+		countQuery := s.ScopedDB(gCtx).Model(&Log{})
 		countQuery = s.applyFilters(countQuery, filters)
 		return countQuery.Count(&totalCount).Error
 	})
 
 	g.Go(func() error {
-		dataQuery := s.db.WithContext(gCtx).Model(&Log{})
+		dataQuery := s.ScopedDB(gCtx).Model(&Log{})
 		dataQuery = s.applyFilters(dataQuery, filters)
 		dataQuery = dataQuery.Order(orderClause).Select(s.listSelectColumns()).Limit(limit)
 		if pagination.Offset > 0 {
@@ -513,7 +529,7 @@ func (s *RDBLogStore) GetSessionLogs(ctx context.Context, sessionID string, pagi
 	}
 	orderClause := "timestamp " + orderDir + ", id " + orderDir
 
-	baseQuery := s.db.WithContext(ctx).Model(&Log{}).Where("parent_request_id = ?", sessionID)
+	baseQuery := s.ScopedDB(ctx).Model(&Log{}).Where("parent_request_id = ?", sessionID)
 
 	var (
 		totalCount int64
@@ -523,7 +539,7 @@ func (s *RDBLogStore) GetSessionLogs(ctx context.Context, sessionID string, pagi
 	g, gCtx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		return s.db.WithContext(gCtx).Model(&Log{}).Where("parent_request_id = ?", sessionID).Count(&totalCount).Error
+		return s.ScopedDB(gCtx).Model(&Log{}).Where("parent_request_id = ?", sessionID).Count(&totalCount).Error
 	})
 
 	g.Go(func() error {
@@ -576,8 +592,7 @@ func (s *RDBLogStore) GetSessionSummary(ctx context.Context, sessionID string) (
 
 	// Single aggregate select keeps Count/SUM/MIN/MAX consistent against the same row snapshot
 	// and halves the round trips compared to running Count and the aggregate row in parallel.
-	row := s.db.WithContext(ctx).
-		Model(&Log{}).
+	row := s.ScopedDB(ctx).Model(&Log{}).
 		Where("parent_request_id = ?", sessionID).
 		Select("COUNT(*) AS count, COALESCE(SUM(cost), 0) AS total_cost, COALESCE(SUM(total_tokens), 0) AS total_tokens, MIN(timestamp) AS started_at, MAX(timestamp) AS latest_at").
 		Row()
@@ -718,7 +733,7 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 	if s.db.Dialector.Name() == "postgres" && s.canUseMatViewForFreshAggregate(filters) {
 		return s.getStatsFromMatView(ctx, filters)
 	}
-	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 
 	// Get total count (includes processing status)
@@ -741,7 +756,7 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 			TotalCost      sql.NullFloat64 `gorm:"column:total_cost"`
 		}
 
-		statsQuery := s.db.WithContext(ctx).Model(&Log{})
+		statsQuery := s.ScopedDB(ctx).Model(&Log{})
 		statsQuery = s.applyFilters(statsQuery, filters)
 		statsQuery = statsQuery.Where("status IN ?", []string{"success", "error"})
 
@@ -782,7 +797,7 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 				TotalUserRequests      sql.NullInt64 `gorm:"column:total_user_requests"`
 				SuccessfulUserRequests sql.NullInt64 `gorm:"column:successful_user_requests"`
 			}
-			userFacingQuery := s.db.WithContext(ctx).Model(&Log{})
+			userFacingQuery := s.ScopedDB(ctx).Model(&Log{})
 			userFacingQuery = s.applyFilters(userFacingQuery, filters)
 			// Scope to root rows only so denominator and numerator are drawn from the same population.
 			// A chain is successful if the root itself succeeded or any of its fallbacks succeeded.
@@ -825,7 +840,7 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 	}
 
 	// Count cache hits by hit_type from cache_debug JSON
-	cacheBase := s.db.WithContext(ctx).Model(&Log{}).Where("status IN ?", []string{"success", "error"})
+	cacheBase := s.ScopedDB(ctx).Model(&Log{}).Where("status IN ?", []string{"success", "error"})
 	direct, semantic, err := s.aggregateCacheHits(ctx, cacheBase, filters)
 	if err != nil {
 		s.logger.Warn(fmt.Sprintf("logstore: failed to aggregate cache-hit stats, skipping: %s", err))
@@ -883,7 +898,7 @@ func (s *RDBLogStore) GetHistogram(ctx context.Context, filters SearchFilters, b
 	dialect := s.db.Dialector.Name()
 
 	// Build query with filters
-	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
 
@@ -1007,7 +1022,7 @@ func (s *RDBLogStore) GetTokenHistogram(ctx context.Context, filters SearchFilte
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	// Only count completed requests for token stats
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
@@ -1133,7 +1148,7 @@ func (s *RDBLogStore) GetCostHistogram(ctx context.Context, filters SearchFilter
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	// Only count completed requests with cost
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
@@ -1255,7 +1270,7 @@ func (s *RDBLogStore) GetModelHistogram(ctx context.Context, filters SearchFilte
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
 
@@ -1410,7 +1425,7 @@ func (s *RDBLogStore) GetLatencyHistogram(ctx context.Context, filters SearchFil
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
 	baseQuery = baseQuery.Where("latency IS NOT NULL")
@@ -1629,7 +1644,7 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 	`
 
 	// Query current period
-	currentQuery := s.db.WithContext(ctx).Model(&Log{})
+	currentQuery := s.ScopedDB(ctx).Model(&Log{})
 	currentQuery = s.applyFilters(currentQuery, filters)
 	currentQuery = currentQuery.Where("status IN ?", []string{"success", "error"})
 	currentQuery = currentQuery.Where("model IS NOT NULL AND model != ''")
@@ -1668,7 +1683,7 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd
 
-		prevQuery := s.db.WithContext(ctx).Model(&Log{})
+		prevQuery := s.ScopedDB(ctx).Model(&Log{})
 		prevQuery = s.applyFilters(prevQuery, prevFilters)
 		prevQuery = prevQuery.Where("status IN ?", []string{"success", "error"})
 		prevQuery = prevQuery.Where("model IS NOT NULL AND model != ''")
@@ -1766,7 +1781,7 @@ func (s *RDBLogStore) GetUserRankings(ctx context.Context, filters SearchFilters
 	`
 
 	// Query current period
-	currentQuery := s.db.WithContext(ctx).Model(&Log{})
+	currentQuery := s.ScopedDB(ctx).Model(&Log{})
 	currentQuery = s.applyFilters(currentQuery, filters)
 	currentQuery = currentQuery.Where("status IN ?", []string{"success", "error"})
 	currentQuery = currentQuery.Where("user_id IS NOT NULL AND user_id != ''")
@@ -1798,7 +1813,7 @@ func (s *RDBLogStore) GetUserRankings(ctx context.Context, filters SearchFilters
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd
 
-		prevQuery := s.db.WithContext(ctx).Model(&Log{})
+		prevQuery := s.ScopedDB(ctx).Model(&Log{})
 		prevQuery = s.applyFilters(prevQuery, prevFilters)
 		prevQuery = prevQuery.Where("status IN ?", []string{"success", "error"})
 		prevQuery = prevQuery.Where("user_id IS NOT NULL AND user_id != ''")
@@ -1881,7 +1896,7 @@ func (s *RDBLogStore) GetProviderCostHistogram(ctx context.Context, filters Sear
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
 	baseQuery = baseQuery.Where("cost IS NOT NULL AND cost > 0")
@@ -1992,7 +2007,7 @@ func (s *RDBLogStore) GetProviderTokenHistogram(ctx context.Context, filters Sea
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
 
@@ -2119,7 +2134,7 @@ func (s *RDBLogStore) GetProviderLatencyHistogram(ctx context.Context, filters S
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
 	baseQuery = baseQuery.Where("latency IS NOT NULL")
@@ -2398,7 +2413,7 @@ func (s *RDBLogStore) GetDimensionCostHistogram(ctx context.Context, filters Sea
 	}
 	dimCol := string(dimension)
 	dialect := s.db.Dialector.Name()
-	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
 	baseQuery = baseQuery.Where("cost IS NOT NULL AND cost > 0")
@@ -2493,7 +2508,7 @@ func (s *RDBLogStore) GetDimensionTokenHistogram(ctx context.Context, filters Se
 	}
 	dimCol := string(dimension)
 	dialect := s.db.Dialector.Name()
-	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
 
@@ -2609,7 +2624,7 @@ func (s *RDBLogStore) GetDimensionLatencyHistogram(ctx context.Context, filters 
 	}
 	dimCol := string(dimension)
 	dialect := s.db.Dialector.Name()
-	baseQuery := s.db.WithContext(ctx).Model(&Log{})
+	baseQuery := s.ScopedDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
 	baseQuery = baseQuery.Where("latency IS NOT NULL")
@@ -2767,20 +2782,21 @@ func (s *RDBLogStore) GetDistinctModels(ctx context.Context, limit int, query st
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var models []string
-	q := s.db.WithContext(ctx).Model(&Log{}).
+	q := s.ScopedDB(ctx).Model(&Log{}).
 		Where("model IS NOT NULL AND model != '' AND timestamp >= ?", cutoff).
 		Distinct("model")
 	if query != "" {
 		q = s.applyLikeFilter(q, "model", query)
 	}
-	err := q.Order("model ASC").Limit(limit).Pluck("model", &models).Error
-	if err != nil {
+	if err := q.Order("model ASC").Limit(limit).Pluck("model", &models).Error; err != nil {
 		return nil, fmt.Errorf("failed to get distinct models: %w", err)
 	}
 	return models, nil
 }
 
 // GetDistinctAliases returns all unique non-empty alias values using SELECT DISTINCT.
+// Scoped to recent data to avoid full table scans. Matview path is
+// DAC-aware (see GetDistinctModels).
 // Scoped to recent data to avoid full table scans.
 func (s *RDBLogStore) GetDistinctAliases(ctx context.Context, limit int, query string) ([]string, error) {
 	if s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() {
@@ -2788,14 +2804,13 @@ func (s *RDBLogStore) GetDistinctAliases(ctx context.Context, limit int, query s
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var aliases []string
-	q := s.db.WithContext(ctx).Model(&Log{}).
+	q := s.ScopedDB(ctx).Model(&Log{}).
 		Where("alias IS NOT NULL AND alias != '' AND timestamp >= ?", cutoff).
 		Distinct("alias")
 	if query != "" {
 		q = s.applyLikeFilter(q, "alias", query)
 	}
-	err := q.Order("alias ASC").Limit(limit).Pluck("alias", &aliases).Error
-	if err != nil {
+	if err := q.Limit(limit).Pluck("alias", &aliases).Error; err != nil {
 		return nil, fmt.Errorf("failed to get distinct aliases: %w", err)
 	}
 	return aliases, nil
@@ -2821,6 +2836,12 @@ var allowedKeyPairColumns = map[string]struct{}{
 
 // GetDistinctKeyPairs returns unique non-empty ID-Name pairs for the given columns using SELECT DISTINCT.
 // idCol and nameCol must be valid column names (e.g., "selected_key_id", "selected_key_name").
+//
+// Matview path is DAC-aware: each per-dimension matview carries the
+// visibility columns (user_id, team_id, virtual_key_id), so a
+// QueryScope on ctx applies on the matview directly. Until
+// matViewsReady the raw-table fallback (also ScopedDB-aware) serves
+// requests.
 func (s *RDBLogStore) GetDistinctKeyPairs(ctx context.Context, idCol, nameCol string, limit int, query string) ([]KeyPairResult, error) {
 	if s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() {
 		results, served, err := s.getDistinctKeyPairsFromMatView(ctx, idCol, nameCol, limit, query)
@@ -2836,20 +2857,21 @@ func (s *RDBLogStore) GetDistinctKeyPairs(ctx context.Context, idCol, nameCol st
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var results []KeyPairResult
-	q := s.db.WithContext(ctx).Model(&Log{}).
+	q := s.ScopedDB(ctx).Model(&Log{}).
 		Select(fmt.Sprintf("DISTINCT %s as id, %s as name", idCol, nameCol)).
 		Where(fmt.Sprintf("%s IS NOT NULL AND %s != '' AND %s IS NOT NULL AND %s != '' AND timestamp >= ?", idCol, idCol, nameCol, nameCol), cutoff)
 	if query != "" {
 		q = s.applyLikeFilter(q, nameCol, query)
 	}
-	err := q.Order("name ASC").Limit(limit).Find(&results).Error
-	if err != nil {
+	if err := q.Order("name ASC").Limit(limit).Find(&results).Error; err != nil {
 		return nil, fmt.Errorf("failed to get distinct key pairs (%s, %s): %w", idCol, nameCol, err)
 	}
 	return results, nil
 }
 
 // GetDistinctRoutingEngines returns all unique routing engine values from the comma-separated column.
+// Scoped to recent data to avoid full table scans. Matview path is
+// DAC-aware (see GetDistinctModels).
 // Scoped to recent data to avoid full table scans.
 func (s *RDBLogStore) GetDistinctRoutingEngines(ctx context.Context, limit int, query string) ([]string, error) {
 	if s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() {
@@ -2857,14 +2879,13 @@ func (s *RDBLogStore) GetDistinctRoutingEngines(ctx context.Context, limit int, 
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var rawValues []string
-	q := s.db.WithContext(ctx).Model(&Log{}).
+	q := s.ScopedDB(ctx).Model(&Log{}).
 		Where("routing_engines_used IS NOT NULL AND routing_engines_used != '' AND timestamp >= ?", cutoff).
 		Distinct("routing_engines_used")
 	if query != "" {
 		q = s.applyLikeFilter(q, "routing_engines_used", query)
 	}
-	err := q.Pluck("routing_engines_used", &rawValues).Error
-	if err != nil {
+	if err := q.Pluck("routing_engines_used", &rawValues).Error; err != nil {
 		return nil, fmt.Errorf("failed to get distinct routing engines: %w", err)
 	}
 	// Each row may contain comma-separated values; deduplicate across all rows
@@ -2889,6 +2910,8 @@ func (s *RDBLogStore) GetDistinctRoutingEngines(ctx context.Context, limit int, 
 }
 
 // GetDistinctStopReasons returns all unique non-empty stop_reason values using SELECT DISTINCT.
+// Scoped to recent data to avoid full table scans. Matview path is
+// DAC-aware (see GetDistinctModels).
 // Scoped to recent data to avoid full table scans.
 func (s *RDBLogStore) GetDistinctStopReasons(ctx context.Context, limit int, query string) ([]string, error) {
 	if s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() {
@@ -2896,14 +2919,13 @@ func (s *RDBLogStore) GetDistinctStopReasons(ctx context.Context, limit int, que
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var stopReasons []string
-	q := s.db.WithContext(ctx).Model(&Log{}).
+	q := s.ScopedDB(ctx).Model(&Log{}).
 		Where("stop_reason IS NOT NULL AND stop_reason != '' AND timestamp >= ?", cutoff).
 		Distinct("stop_reason")
 	if query != "" {
 		q = s.applyLikeFilter(q, "stop_reason", query)
 	}
-	err := q.Order("stop_reason ASC").Limit(limit).Pluck("stop_reason", &stopReasons).Error
-	if err != nil {
+	if err := q.Order("stop_reason ASC").Limit(limit).Pluck("stop_reason", &stopReasons).Error; err != nil {
 		return nil, fmt.Errorf("failed to get distinct stop reasons: %w", err)
 	}
 	return stopReasons, nil
@@ -2933,7 +2955,7 @@ func (s *RDBLogStore) GetDistinctMetadataKeys(ctx context.Context, limit int, qu
 	} else {
 		metadataGuard = "metadata IS NOT NULL AND json_valid(metadata) AND json_type(metadata) = 'object' AND metadata != '{}' AND timestamp >= ?"
 	}
-	err := s.db.WithContext(ctx).Model(&Log{}).
+	err := s.ScopedDB(ctx).Model(&Log{}).
 		Where(metadataGuard, cutoff).
 		Order("timestamp DESC").
 		Limit(maxMetadataRows).
@@ -3242,7 +3264,7 @@ func serializeMCPToolLogUpdateEntry(entry any) (any, error) {
 // SearchMCPToolLogs searches for MCP tool logs in the database.
 func (s *RDBLogStore) SearchMCPToolLogs(ctx context.Context, filters MCPToolLogSearchFilters, pagination PaginationOptions) (*MCPToolLogSearchResult, error) {
 	var err error
-	baseQuery := s.db.WithContext(ctx).Model(&MCPToolLog{})
+	baseQuery := s.ScopedDB(ctx).Model(&MCPToolLog{})
 
 	// Apply filters
 	baseQuery = s.applyMCPFilters(baseQuery, filters)
@@ -3330,7 +3352,7 @@ func (s *RDBLogStore) SearchMCPToolLogs(ctx context.Context, filters MCPToolLogS
 
 // GetMCPToolLogStats calculates statistics for MCP tool logs matching the given filters.
 func (s *RDBLogStore) GetMCPToolLogStats(ctx context.Context, filters MCPToolLogSearchFilters) (*MCPToolLogStats, error) {
-	baseQuery := s.db.WithContext(ctx).Model(&MCPToolLog{})
+	baseQuery := s.ScopedDB(ctx).Model(&MCPToolLog{})
 	baseQuery = s.applyMCPFilters(baseQuery, filters)
 
 	// Get total count (includes processing status)
@@ -3352,7 +3374,7 @@ func (s *RDBLogStore) GetMCPToolLogStats(ctx context.Context, filters MCPToolLog
 			TotalCost      sql.NullFloat64 `gorm:"column:total_cost"`
 		}
 
-		statsQuery := s.db.WithContext(ctx).Model(&MCPToolLog{})
+		statsQuery := s.ScopedDB(ctx).Model(&MCPToolLog{})
 		statsQuery = s.applyMCPFilters(statsQuery, filters)
 		statsQuery = statsQuery.Where("status IN ?", []string{"success", "error"})
 
@@ -3418,13 +3440,12 @@ func (s *RDBLogStore) FlushMCPToolLogs(ctx context.Context, since time.Time) err
 func (s *RDBLogStore) GetAvailableToolNames(ctx context.Context, limit int, query string) ([]string, error) {
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var toolNames []string
-	q := s.db.WithContext(ctx).Model(&MCPToolLog{}).
-		Where("tool_name IS NOT NULL AND tool_name != '' AND timestamp >= ?", cutoff).
-		Distinct("tool_name")
+	q := s.ScopedDB(ctx).Model(&MCPToolLog{}).
+		Where("tool_name IS NOT NULL AND tool_name != '' AND timestamp >= ?", cutoff)
 	if query != "" {
 		q = s.applyLikeFilter(q, "tool_name", query)
 	}
-	result := q.Limit(limit).Pluck("tool_name", &toolNames)
+	result := q.Distinct("tool_name").Limit(limit).Pluck("tool_name", &toolNames)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get available tool names: %w", result.Error)
 	}
@@ -3434,13 +3455,12 @@ func (s *RDBLogStore) GetAvailableToolNames(ctx context.Context, limit int, quer
 func (s *RDBLogStore) GetAvailableServerLabels(ctx context.Context, limit int, query string) ([]string, error) {
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var serverLabels []string
-	q := s.db.WithContext(ctx).Model(&MCPToolLog{}).
-		Where("server_label IS NOT NULL AND server_label != '' AND timestamp >= ?", cutoff).
-		Distinct("server_label")
+	q := s.ScopedDB(ctx).Model(&MCPToolLog{}).
+		Where("server_label IS NOT NULL AND server_label != '' AND timestamp >= ?", cutoff)
 	if query != "" {
 		q = s.applyLikeFilter(q, "server_label", query)
 	}
-	result := q.Limit(limit).Pluck("server_label", &serverLabels)
+	result := q.Distinct("server_label").Limit(limit).Pluck("server_label", &serverLabels)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get available server labels: %w", result.Error)
 	}
@@ -3450,7 +3470,7 @@ func (s *RDBLogStore) GetAvailableServerLabels(ctx context.Context, limit int, q
 func (s *RDBLogStore) GetAvailableMCPVirtualKeys(ctx context.Context, limit int, query string) ([]MCPToolLog, error) {
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var logs []MCPToolLog
-	q := s.db.WithContext(ctx).
+	q := s.ScopedDB(ctx).
 		Model(&MCPToolLog{}).
 		Select("DISTINCT virtual_key_id, virtual_key_name").
 		Where("virtual_key_id IS NOT NULL AND virtual_key_id != '' AND virtual_key_name IS NOT NULL AND virtual_key_name != '' AND timestamp >= ?", cutoff)
@@ -3472,7 +3492,7 @@ func (s *RDBLogStore) GetMCPHistogram(ctx context.Context, filters MCPToolLogSea
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.db.WithContext(ctx).Model(&MCPToolLog{})
+	baseQuery := s.ScopedDB(ctx).Model(&MCPToolLog{})
 	baseQuery = s.applyMCPFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
 
@@ -3569,7 +3589,7 @@ func (s *RDBLogStore) GetMCPCostHistogram(ctx context.Context, filters MCPToolLo
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.db.WithContext(ctx).Model(&MCPToolLog{})
+	baseQuery := s.ScopedDB(ctx).Model(&MCPToolLog{})
 	baseQuery = s.applyMCPFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
 
@@ -3644,7 +3664,7 @@ func (s *RDBLogStore) GetMCPTopTools(ctx context.Context, filters MCPToolLogSear
 		limit = 10
 	}
 
-	baseQuery := s.db.WithContext(ctx).Model(&MCPToolLog{})
+	baseQuery := s.ScopedDB(ctx).Model(&MCPToolLog{})
 	baseQuery = s.applyMCPFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", []string{"success", "error"})
 

--- a/framework/logstore/scopeddb_test.go
+++ b/framework/logstore/scopeddb_test.go
@@ -1,0 +1,76 @@
+package logstore
+
+import (
+	"context"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/queryscope"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newScopedDBTestLogStore(t *testing.T) *RDBLogStore {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	return &RDBLogStore{
+		db:     db,
+		logger: bifrost.NewDefaultLogger(schemas.LogLevelInfo),
+	}
+}
+
+func TestLogStoreScopedDB_AppliesScope(t *testing.T) {
+	s := newScopedDBTestLogStore(t)
+	called := false
+	scope := queryscope.QueryScope(func(db *gorm.DB) *gorm.DB {
+		called = true
+		return db.Where("status = ?", "error")
+	})
+	ctx := queryscope.WithQueryScope(context.Background(), scope)
+
+	got := s.ScopedDB(ctx)
+	assert.True(t, called, "ScopedDB should invoke the scope from ctx")
+	stmt := got.Session(&gorm.Session{DryRun: true}).Table("logs").Find(&struct{}{}).Statement
+	assert.Contains(t, stmt.SQL.String(), "status = ?",
+		"the scope's WHERE clause should be on the returned query")
+}
+
+func TestLogStoreScopedDB_PassesThroughWhenNoScope(t *testing.T) {
+	s := newScopedDBTestLogStore(t)
+	got := s.ScopedDB(context.Background())
+	require.NotNil(t, got)
+	require.NoError(t, got.Exec("SELECT 1").Error)
+}
+
+func TestLogStoreScopedDB_BindsContext(t *testing.T) {
+	s := newScopedDBTestLogStore(t)
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "marker")
+	got := s.ScopedDB(ctx)
+	stmt := got.Session(&gorm.Session{DryRun: true}).Find(&struct{}{}).Statement
+	assert.Equal(t, "marker", stmt.Context.Value(ctxKey{}))
+}
+
+func TestLogStoreScopedDB_WrongTypeAtScopeKeyIsIgnored(t *testing.T) {
+	s := newScopedDBTestLogStore(t)
+	ctx := context.WithValue(context.Background(),
+		schemas.BifrostContextKeyQueryScope, "not a closure")
+	got := s.ScopedDB(ctx)
+	require.NotNil(t, got)
+	require.NoError(t, got.Exec("SELECT 1").Error)
+}
+
+func TestLogStoreScopedDB_TypedNilScopeIsIgnored(t *testing.T) {
+	s := newScopedDBTestLogStore(t)
+	ctx := queryscope.WithQueryScope(context.Background(), nil)
+	got := s.ScopedDB(ctx)
+	require.NotNil(t, got)
+	require.NoError(t, got.Exec("SELECT 1").Error)
+}

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -794,6 +794,10 @@ type MCPToolLog struct {
 	ServerLabel    string    `gorm:"type:varchar(255);index:idx_mcp_logs_server_label" json:"server_label,omitempty"` // MCP server that provided the tool
 	VirtualKeyID   *string   `gorm:"type:varchar(255);index:idx_mcp_logs_virtual_key_id" json:"virtual_key_id"`
 	VirtualKeyName *string   `gorm:"type:varchar(255)" json:"virtual_key_name"`
+	UserID         *string   `gorm:"type:varchar(255);index:idx_mcp_logs_user_id" json:"user_id"`
+	TeamID         *string   `gorm:"type:varchar(255);index:idx_mcp_logs_team_id" json:"team_id"`
+	CustomerID     *string   `gorm:"type:varchar(255);index:idx_mcp_logs_customer_id" json:"customer_id"`
+	BusinessUnitID *string   `gorm:"type:varchar(255);index:idx_mcp_logs_business_unit_id" json:"business_unit_id"`
 	Arguments      string    `gorm:"type:text" json:"-"`                                                // JSON serialized tool arguments
 	Result         string    `gorm:"type:text" json:"-"`                                                // JSON serialized tool result
 	ErrorDetails   string    `gorm:"type:text" json:"-"`                                                // JSON serialized *schemas.BifrostError

--- a/framework/queryscope/queryscope.go
+++ b/framework/queryscope/queryscope.go
@@ -1,0 +1,40 @@
+// Package queryscope provides the primitive that wrappers use to push a
+// per-call SQL constraint onto the request context for inner stores to
+// consume. The configstore and logstore packages both import it so the
+// same QueryScope mechanism powers their ScopedDB read paths without
+// introducing a cycle between the two stores.
+package queryscope
+
+import (
+	"context"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"gorm.io/gorm"
+)
+
+// QueryScope mutates a query to enforce caller-driven row-level
+// constraints. Set on ctx by an upstream wrapper; inner store query
+// helpers apply it blindly via ScopedDB.
+type QueryScope func(*gorm.DB) *gorm.DB
+
+// WithQueryScope returns ctx carrying scope. Nil scope is a no-op.
+func WithQueryScope(ctx context.Context, scope QueryScope) context.Context {
+	if scope == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, schemas.BifrostContextKeyQueryScope, scope)
+}
+
+// FromContext returns the scope stashed on ctx, or nil when no scope
+// is present (background jobs, OSS-only deployments, internal lookups
+// that bypassed the wrapper). A nil scope is equivalent to "no
+// restriction": query builders apply no WHERE clause.
+func FromContext(ctx context.Context) QueryScope {
+	if ctx == nil {
+		return nil
+	}
+	if v, ok := ctx.Value(schemas.BifrostContextKeyQueryScope).(QueryScope); ok {
+		return v
+	}
+	return nil
+}

--- a/framework/queryscope/queryscope_test.go
+++ b/framework/queryscope/queryscope_test.go
@@ -1,0 +1,84 @@
+package queryscope
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
+)
+
+// recordingScope is a sentinel QueryScope that flips a flag when invoked
+// so tests can assert whether the wrapper actually called it.
+type recordingScope struct{ called bool }
+
+func (r *recordingScope) apply(db *gorm.DB) *gorm.DB {
+	r.called = true
+	return db
+}
+
+func TestWithQueryScope_NilScopeIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	out := WithQueryScope(ctx, nil)
+	// Nil scope must not stash anything, so FromContext on the returned
+	// ctx must report no scope present.
+	assert.Nil(t, FromContext(out), "nil scope should not be retrievable as a scope")
+}
+
+func TestWithQueryScope_StashesScope(t *testing.T) {
+	r := &recordingScope{}
+	ctx := WithQueryScope(context.Background(), r.apply)
+
+	got := FromContext(ctx)
+	if assert.NotNil(t, got, "scope should be retrievable from ctx") {
+		got(nil)
+		assert.True(t, r.called, "retrieved scope should be the same closure that was stashed")
+	}
+}
+
+func TestFromContext_NilCtxReturnsNil(t *testing.T) {
+	assert.Nil(t, FromContext(nil))
+}
+
+func TestFromContext_MissingKeyReturnsNil(t *testing.T) {
+	assert.Nil(t, FromContext(context.Background()))
+}
+
+func TestFromContext_WrongTypeReturnsNil(t *testing.T) {
+	ctx := context.WithValue(context.Background(),
+		schemas.BifrostContextKeyQueryScope, "not a closure")
+	assert.Nil(t, FromContext(ctx),
+		"a value of the wrong type at the scope key must not be treated as a scope")
+}
+
+func TestFromContext_NilInterfaceValueReturnsNil(t *testing.T) {
+	// A typed nil QueryScope stashed on ctx must be safe to retrieve.
+	// The retrieved scope can be nil, but FromContext must not panic.
+	ctx := context.WithValue(context.Background(),
+		schemas.BifrostContextKeyQueryScope, QueryScope(nil))
+	got := FromContext(ctx)
+	assert.Nil(t, got, "typed-nil QueryScope must be returned as a usable nil")
+}
+
+func TestWithQueryScope_NilCtxIsSafe(t *testing.T) {
+	// Defensive: callers should pass a real ctx, but nil ctx must
+	// not panic. Go's context.WithValue panics on nil parent so
+	// WithQueryScope short-circuits via the nil-scope guard.
+	out := WithQueryScope(nil, nil)
+	assert.Nil(t, out, "nil ctx + nil scope must propagate nil cleanly")
+}
+
+func TestFromContext_CancelledCtxStillReturnsScope(t *testing.T) {
+	// Cancellation must not affect scope retrieval; the scope is a
+	// value on ctx, not a lifecycle resource.
+	parent, cancel := context.WithCancel(context.Background())
+	r := &recordingScope{}
+	ctx := WithQueryScope(parent, r.apply)
+	cancel()
+	got := FromContext(ctx)
+	if assert.NotNil(t, got, "cancellation should not strip the scope value") {
+		got(nil)
+		assert.True(t, r.called)
+	}
+}

--- a/tests/e2e/api/README.md
+++ b/tests/e2e/api/README.md
@@ -80,6 +80,26 @@ From this directory (`tests/e2e/api`):
 ./runners/run-newman-inference-tests.sh --html --verbose
 ```
 
+### API Management Extensions
+
+The API management runner can merge enterprise-only Postman folders without checking
+them into OSS:
+
+```bash
+./runners/run-newman-api-tests.sh --extra-collection /path/to/enterprise.postman_collection.json
+```
+
+You can also pass extensions via environment variable:
+
+```bash
+BIFROST_API_EXTRA_COLLECTION=/path/to/enterprise.postman_collection.json \
+  ./runners/run-newman-api-tests.sh
+```
+
+The default OSS run does not load extra collections. Enterprise should pass its
+collection from the enterprise repo, so shared management requests stay in OSS and
+DAC-specific assertions stay out of OSS.
+
 **Retry logic (CI)**
 When `CI=1` or `CI=true` is set (case-insensitive), each failing request in the V1 collection is retried up to 3 times before moving to the next request. This helps with flaky tests in CI. The runner passes the value through to Newman when the environment variable is set (e.g. `CI=1 ./runners/run-newman-inference-tests.sh --env openai` or `CI=true ./runners/run-newman-inference-tests.sh --env openai`). Retry attempts are logged to the console as `[RETRY] Request "..." failed (attempt n/3). Retrying...`.
 

--- a/tests/e2e/api/runners/merge-collections.mjs
+++ b/tests/e2e/api/runners/merge-collections.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Merges extension Postman collections into a base API e2e collection.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const extras = [];
+let source = "";
+let out = "";
+
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  if (arg === "--source") {
+    source = args[++i] || "";
+  } else if (arg === "--out") {
+    out = args[++i] || "";
+  } else if (arg === "--extra") {
+    extras.push(args[++i] || "");
+  } else {
+    console.error(`[merge-collections] unknown argument: ${arg}`);
+    process.exit(2);
+  }
+}
+
+if (!source || !out || extras.length === 0 || extras.some((extra) => !extra)) {
+  console.error("[merge-collections] --source, --out, and at least one --extra are required");
+  process.exit(2);
+}
+
+const normalizeItems = (extension, path) => {
+  if (Array.isArray(extension)) return extension;
+  if (Array.isArray(extension.item)) return extension.item;
+  if (extension.request || extension.item) return [extension];
+  console.error(`[merge-collections] extension ${path} did not contain any Postman items`);
+  process.exit(1);
+};
+
+const base = JSON.parse(readFileSync(source, "utf8"));
+if (base.item == null) {
+  base.item = [];
+} else if (!Array.isArray(base.item)) {
+  console.error(`[merge-collections] base collection ${source} has non-array "item"`);
+  process.exit(1);
+}
+let requestCount = 0;
+
+for (const extra of extras) {
+  const extension = JSON.parse(readFileSync(extra, "utf8"));
+  const items = normalizeItems(extension, extra);
+  requestCount += JSON.stringify(items).match(/"request":/g)?.length || 0;
+  base.item.push({
+    name: extension.info?.name || extension.name || "External API E2E Extension",
+    description: `Loaded from ${extra}. This folder is only present when the API runner receives --extra-collection.`,
+    item: items,
+  });
+}
+
+writeFileSync(out, `${JSON.stringify(base, null, 2)}\n`);
+console.error(`[merge-collections] wrote ${out} with ${requestCount} extension requests`);

--- a/tests/e2e/api/runners/run-newman-api-tests.sh
+++ b/tests/e2e/api/runners/run-newman-api-tests.sh
@@ -6,6 +6,18 @@
 set -e
 set -o pipefail
 
+# Fail fast on Bash <4.0: declare -A seed_env_values, the seed env parser that
+# populates it from $SEED_ENV_PATH, and add_env_var_if_set all rely on
+# associative arrays, which were added in Bash 4.0. macOS still ships Bash 3.2
+# by default, so a stale /bin/bash would otherwise fail with a cryptic
+# "declare: -A: invalid option" partway through setup.
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+    echo "Error: this script requires Bash 4.0+ (uses 'declare -A seed_env_values', SEED_ENV_PATH parsing, and add_env_var_if_set)." >&2
+    echo "Detected Bash version: ${BASH_VERSION:-unknown}" >&2
+    echo "On macOS, install a newer bash (e.g. 'brew install bash') and run the script with that interpreter." >&2
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 API_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
@@ -51,6 +63,9 @@ DB_VERIFY=""
 DB_URL="${BIFROST_DB_URL:-}"
 LOGS_DB_URL="${BIFROST_LOGS_DB_URL:-}"
 DB_CONFIG_PATH=""
+SEED_ENV_PATH="${BIFROST_E2E_SEED_ENV:-}"
+EXPECTED_PATH="${BIFROST_E2E_SEED_EXPECTED:-}"
+EXTRA_COLLECTIONS=()
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -83,15 +98,51 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --db-url)
+            if [ $# -lt 2 ] || [[ "$2" == --* ]]; then
+                echo -e "${RED}Error: --db-url requires a value${NC}"
+                exit 1
+            fi
             DB_URL="$2"
             shift 2
             ;;
         --logs-db-url)
+            if [ $# -lt 2 ] || [[ "$2" == --* ]]; then
+                echo -e "${RED}Error: --logs-db-url requires a value${NC}"
+                exit 1
+            fi
             LOGS_DB_URL="$2"
             shift 2
             ;;
         --config-path)
+            if [ $# -lt 2 ] || [[ "$2" == --* ]]; then
+                echo -e "${RED}Error: --config-path requires a value${NC}"
+                exit 1
+            fi
             DB_CONFIG_PATH="$2"
+            shift 2
+            ;;
+        --extra-collection)
+            if [ $# -lt 2 ] || [[ "$2" == --* ]]; then
+                echo -e "${RED}Error: --extra-collection requires a path${NC}"
+                exit 1
+            fi
+            EXTRA_COLLECTIONS+=("$2")
+            shift 2
+            ;;
+        --seed-env)
+            if [ $# -lt 2 ] || [[ "$2" == --* ]]; then
+                echo -e "${RED}Error: --seed-env requires a path${NC}"
+                exit 1
+            fi
+            SEED_ENV_PATH="$2"
+            shift 2
+            ;;
+        --expected)
+            if [ $# -lt 2 ] || [[ "$2" == --* ]]; then
+                echo -e "${RED}Error: --expected requires a path${NC}"
+                exit 1
+            fi
+            EXPECTED_PATH="$2"
             shift 2
             ;;
         --help)
@@ -111,6 +162,11 @@ while [[ $# -gt 0 ]]; do
             echo "                      SQLite:     sqlite:///path/to/file.db"
             echo "  --config-path <p>   Path to Bifrost config.json for auto DB detection"
             echo "                      (default: ./config.json; also reads BIFROST_CONFIG_PATH env)"
+            echo "  --extra-collection <p>"
+            echo "                      Merge an additional Postman collection into this API run."
+            echo "                      Intended for enterprise-only API e2e coverage from another repo."
+            echo "  --seed-env <p>      Load generated seed dotenv values and pass them to Newman."
+            echo "  --expected <p>      Load generated DAC expected-manifest JSON for assertions."
             echo "  --help              Show this help message"
             echo ""
             echo "Examples:"
@@ -127,6 +183,18 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [ -n "${BIFROST_API_EXTRA_COLLECTION:-}" ]; then
+    EXTRA_COLLECTIONS+=("$BIFROST_API_EXTRA_COLLECTION")
+fi
+
+if [ -z "$SEED_ENV_PATH" ] && [ -f "$API_DIR/generated/seed.env" ]; then
+    SEED_ENV_PATH="$API_DIR/generated/seed.env"
+fi
+
+if [ -z "$EXPECTED_PATH" ] && [ -f "$API_DIR/generated/dac-expected.json" ]; then
+    EXPECTED_PATH="$API_DIR/generated/dac-expected.json"
+fi
 
 if { [ "${GITHUB_ACTIONS:-}" = "true" ] || [ "${CI:-0}" = "1" ]; } && [[ "$REPORTERS" != *"htmlextra"* ]]; then
     REPORTERS="${REPORTERS},htmlextra"
@@ -156,6 +224,15 @@ echo -e "Configuration:"
 echo -e "  Collection: ${YELLOW}$COLLECTION${NC}"
 echo -e "  Reports:    ${YELLOW}$REPORT_DIR${NC}"
 echo -e "  Verbose:    ${YELLOW}$([ -n "$VERBOSE" ] && echo "enabled" || echo "disabled")${NC}"
+if [ ${#EXTRA_COLLECTIONS[@]} -gt 0 ]; then
+    echo -e "  Extensions: ${YELLOW}${EXTRA_COLLECTIONS[*]}${NC}"
+fi
+if [ -n "$SEED_ENV_PATH" ]; then
+    echo -e "  Seed Env:   ${YELLOW}$SEED_ENV_PATH${NC}"
+fi
+if [ -n "$EXPECTED_PATH" ]; then
+    echo -e "  Expected:   ${YELLOW}$EXPECTED_PATH${NC}"
+fi
 if [ -n "$DB_VERIFY" ]; then
     if [ -n "$DB_URL" ]; then
         echo -e "  DB Verify:  ${YELLOW}enabled (url: $DB_URL)${NC}"
@@ -245,6 +322,20 @@ echo ""
 echo -e "${GREEN}Running tests...${NC}"
 echo ""
 
+if [ ${#EXTRA_COLLECTIONS[@]} -gt 0 ]; then
+    MERGED_COLLECTION="$REPORT_DIR/api-management-with-extensions.postman_collection.json"
+    merge_cmd=(node "$SCRIPT_DIR/merge-collections.mjs" --source "$COLLECTION" --out "$MERGED_COLLECTION")
+    for extra_collection in "${EXTRA_COLLECTIONS[@]}"; do
+        if [ ! -f "$extra_collection" ]; then
+            echo -e "${RED}Error: Extra collection file not found: $extra_collection${NC}"
+            exit 1
+        fi
+        merge_cmd+=(--extra "$extra_collection")
+    done
+    "${merge_cmd[@]}"
+    COLLECTION="$MERGED_COLLECTION"
+fi
+
 # Add dbverify reporter if requested
 if [ -n "$DB_VERIFY" ]; then
     REPORTERS="$REPORTERS,dbverify"
@@ -261,6 +352,79 @@ fi
 
 # Build Newman command
 cmd=(newman run "$COLLECTION" --timeout-script 120000 --timeout 900000 -r "$REPORTERS")
+
+# Parsed seed env entries live here, not in the runner's shell namespace.
+# Decoupling the data keyspace from the script's own variables (PATH, COLLECTION,
+# NODE_OPTIONS, etc.) prevents a seed file entry from silently overriding them.
+declare -A seed_env_values=()
+
+if [ -n "$SEED_ENV_PATH" ]; then
+    if [ ! -f "$SEED_ENV_PATH" ]; then
+        echo -e "${RED}Error: seed env file not found: $SEED_ENV_PATH${NC}"
+        exit 1
+    fi
+    # Parse seed env file as data, never source it. Sourcing would execute
+    # any RHS command substitution (e.g. FOO=$(id)); see WriteEnvFile in
+    # framework/e2eseed/seed.go which single-quotes values via quoteEnv.
+    while IFS= read -r line || [ -n "$line" ]; do
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line//[[:space:]]/}" ]] && continue
+        if [[ "$line" != *=* ]]; then
+            echo -e "${RED}Error: invalid seed env line (missing '='): $line${NC}"
+            exit 1
+        fi
+        key="${line%%=*}"
+        value="${line#*=}"
+        if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            echo -e "${RED}Error: invalid variable name in seed env: $key${NC}"
+            exit 1
+        fi
+        # Unwrap outer single quotes written by quoteEnv and undo its '\''-escape.
+        if [[ "$value" == \'*\' ]]; then
+            value="${value:1:${#value}-2}"
+            value="${value//\'\"\'\"\'/\'}"
+        fi
+        seed_env_values["$key"]="$value"
+    done < "$SEED_ENV_PATH"
+fi
+
+add_env_var_if_set() {
+    local name="$1"
+    local value="${seed_env_values[$name]:-}"
+    if [ -n "$value" ]; then
+        cmd+=(--env-var "$name=$value")
+    fi
+}
+
+for seed_var in \
+    e2e_seed_prefix \
+    enterprise_dac_model \
+    enterprise_dac_visible_virtual_key \
+    enterprise_dac_hidden_virtual_key \
+    enterprise_dac_reader_api_key \
+    enterprise_dac_all_api_key \
+    enterprise_dac_own_api_key \
+    enterprise_dac_outside_api_key \
+    e2e_seed_team_tiggings \
+    e2e_seed_team_outside \
+    e2e_seed_user_tiggings \
+    e2e_seed_user_outside \
+    e2e_seed_vk_user_team \
+    e2e_seed_vk_outside \
+    e2e_seed_enterprise_users \
+    e2e_seed_access_profiles \
+    e2e_seed_access_profile_budgets; do
+    add_env_var_if_set "$seed_var"
+done
+
+if [ -n "$EXPECTED_PATH" ]; then
+    if [ ! -f "$EXPECTED_PATH" ]; then
+        echo -e "${RED}Error: expected manifest file not found: $EXPECTED_PATH${NC}"
+        exit 1
+    fi
+    EXPECTED_JSON="$(node -e 'const fs=require("fs"); const p=process.argv[1]; process.stdout.write(JSON.stringify(JSON.parse(fs.readFileSync(p,"utf8"))));' "$EXPECTED_PATH")"
+    cmd+=(--env-var "e2e_seed_expected=$EXPECTED_JSON")
+fi
 
 # Override plugin_path with resolved absolute path so Create Plugin / Get Plugin use the built .so
 # env-var takes precedence over collection variables in Newman's resolution order

--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -1,7 +1,12 @@
 import VirtualKeysTable from "@/app/workspace/virtual-keys/views/virtualKeysTable";
 import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
-import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store";
+import {
+  getErrorMessage,
+  useGetCustomersQuery,
+  useGetTeamsQuery,
+  useGetVirtualKeysQuery,
+} from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useRef } from "react";
@@ -11,135 +16,158 @@ const POLLING_INTERVAL = 5000;
 const PAGE_SIZE = 25;
 
 export default function GovernanceVirtualKeysPage() {
-	const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
-	const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
-	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
-	const shownErrorsRef = useRef(new Set<string>());
+  const hasVirtualKeysAccess = useRbac(
+    RbacResource.VirtualKeys,
+    RbacOperation.View,
+  );
+  const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
+  const hasCustomersAccess = useRbac(
+    RbacResource.Customers,
+    RbacOperation.View,
+  );
+  const shownErrorsRef = useRef(new Set<string>());
 
-	const [urlState, setUrlState] = useQueryStates(
-		{
-			search: parseAsString.withDefault(""),
-			customer_id: parseAsString.withDefault(""),
-			team_id: parseAsString.withDefault(""),
-			offset: parseAsInteger.withDefault(0),
-			sort_by: parseAsString.withDefault(""),
-			order: parseAsString.withDefault(""),
-		},
-		{ history: "push" },
-	);
+  const [urlState, setUrlState] = useQueryStates(
+    {
+      search: parseAsString.withDefault(""),
+      customer_id: parseAsString.withDefault(""),
+      team_id: parseAsString.withDefault(""),
+      offset: parseAsInteger.withDefault(0),
+      sort_by: parseAsString.withDefault(""),
+      order: parseAsString.withDefault(""),
+    },
+    { history: "push" },
+  );
 
-	const debouncedSearch = useDebouncedValue(urlState.search, 300);
+  const debouncedSearch = useDebouncedValue(urlState.search, 300);
 
-	const {
-		data: virtualKeysData,
-		error: vkError,
-		isLoading: vkLoading,
-	} = useGetVirtualKeysQuery(
-		{
-			limit: PAGE_SIZE,
-			offset: urlState.offset,
-			search: debouncedSearch || undefined,
-			customer_id: urlState.customer_id || undefined,
-			team_id: urlState.team_id || undefined,
-			sort_by: (urlState.sort_by as "name" | "budget_spent" | "created_at" | "status") || undefined,
-			order: (urlState.order as "asc" | "desc") || undefined,
-		},
-		{
-			skip: !hasVirtualKeysAccess,
-			pollingInterval: POLLING_INTERVAL,
-		},
-	);
+  const {
+    data: virtualKeysData,
+    error: vkError,
+    isLoading: vkLoading,
+  } = useGetVirtualKeysQuery(
+    {
+      limit: PAGE_SIZE,
+      offset: urlState.offset,
+      search: debouncedSearch || undefined,
+      customer_id: urlState.customer_id || undefined,
+      team_id: urlState.team_id || undefined,
+      sort_by:
+        (urlState.sort_by as
+          | "name"
+          | "budget_spent"
+          | "created_at"
+          | "status") || undefined,
+      order: (urlState.order as "asc" | "desc") || undefined,
+    },
+    {
+      skip: !hasVirtualKeysAccess,
+      pollingInterval: POLLING_INTERVAL,
+    },
+  );
 
-	const {
-		data: teamsData,
-		error: teamsError,
-		isLoading: teamsLoading,
-	} = useGetTeamsQuery(undefined, {
-		skip: !hasTeamsAccess,
-		pollingInterval: POLLING_INTERVAL,
-	});
+  const {
+    data: teamsData,
+    error: teamsError,
+    isLoading: teamsLoading,
+  } = useGetTeamsQuery(undefined, {
+    skip: !hasTeamsAccess,
+    pollingInterval: POLLING_INTERVAL,
+  });
 
-	const {
-		data: customersData,
-		error: customersError,
-		isLoading: customersLoading,
-	} = useGetCustomersQuery(undefined, {
-		skip: !hasCustomersAccess,
-		pollingInterval: POLLING_INTERVAL,
-	});
+  const {
+    data: customersData,
+    error: customersError,
+    isLoading: customersLoading,
+  } = useGetCustomersQuery(undefined, {
+    skip: !hasCustomersAccess,
+    pollingInterval: POLLING_INTERVAL,
+  });
 
-	const vkTotal = virtualKeysData?.total_count ?? 0;
+  const vkTotal = virtualKeysData?.total_count ?? 0;
 
-	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
-	useEffect(() => {
-		if (!virtualKeysData || urlState.offset < vkTotal) return;
-		setUrlState({ offset: vkTotal === 0 ? 0 : Math.floor((vkTotal - 1) / PAGE_SIZE) * PAGE_SIZE });
-	}, [vkTotal, urlState.offset]);
+  // Snap offset back when total shrinks past current page (e.g. delete last item on last page)
+  useEffect(() => {
+    if (!virtualKeysData || urlState.offset < vkTotal) return;
+    setUrlState({
+      offset:
+        vkTotal === 0 ? 0 : Math.floor((vkTotal - 1) / PAGE_SIZE) * PAGE_SIZE,
+    });
+  }, [vkTotal, urlState.offset]);
 
-	const isLoading = vkLoading || teamsLoading || customersLoading;
+  const isLoading = vkLoading || teamsLoading || customersLoading;
 
-	useEffect(() => {
-		if (!vkError && !teamsError && !customersError) {
-			shownErrorsRef.current.clear();
-			return;
-		}
-		const errorKey = `${!!vkError}-${!!teamsError}-${!!customersError}`;
-		if (shownErrorsRef.current.has(errorKey)) return;
-		shownErrorsRef.current.add(errorKey);
-		if (vkError && teamsError && customersError) {
-			toast.error("Failed to load governance data.");
-		} else {
-			if (vkError) toast.error(`Failed to load virtual keys: ${getErrorMessage(vkError)}`);
-			if (teamsError) toast.error(`Failed to load teams: ${getErrorMessage(teamsError)}`);
-			if (customersError) toast.error(`Failed to load customers: ${getErrorMessage(customersError)}`);
-		}
-	}, [vkError, teamsError, customersError]);
+  useEffect(() => {
+    if (!vkError && !teamsError && !customersError) {
+      shownErrorsRef.current.clear();
+      return;
+    }
+    const errorKey = `${!!vkError}-${!!teamsError}-${!!customersError}`;
+    if (shownErrorsRef.current.has(errorKey)) return;
+    shownErrorsRef.current.add(errorKey);
+    if (vkError && teamsError && customersError) {
+      toast.error("Failed to load governance data.");
+    } else {
+      if (vkError)
+        toast.error(`Failed to load virtual keys: ${getErrorMessage(vkError)}`);
+      if (teamsError)
+        toast.error(`Failed to load teams: ${getErrorMessage(teamsError)}`);
+      if (customersError)
+        toast.error(
+          `Failed to load customers: ${getErrorMessage(customersError)}`,
+        );
+    }
+  }, [vkError, teamsError, customersError]);
 
-	if (isLoading) {
-		return <FullPageLoader />;
-	}
+  if (isLoading) {
+    return <FullPageLoader />;
+  }
 
-	const handleSearchChange = (value: string) => {
-		setUrlState({ search: value || null, offset: 0 });
-	};
+  const handleSearchChange = (value: string) => {
+    setUrlState({ search: value || null, offset: 0 });
+  };
 
-	const handleCustomerFilterChange = (value: string) => {
-		setUrlState({ customer_id: value || null, offset: 0 });
-	};
+  const handleCustomerFilterChange = (value: string) => {
+    setUrlState({ customer_id: value || null, offset: 0 });
+  };
 
-	const handleTeamFilterChange = (value: string) => {
-		setUrlState({ team_id: value || null, offset: 0 });
-	};
+  const handleTeamFilterChange = (value: string) => {
+    setUrlState({ team_id: value || null, offset: 0 });
+  };
 
-	const handleOffsetChange = (newOffset: number) => {
-		setUrlState({ offset: newOffset });
-	};
+  const handleOffsetChange = (newOffset: number) => {
+    setUrlState({ offset: newOffset });
+  };
 
-	const handleSortChange = (newSortBy: string, newOrder: string) => {
-		setUrlState({ sort_by: newSortBy || null, order: newOrder || null, offset: 0 });
-	};
+  const handleSortChange = (newSortBy: string, newOrder: string) => {
+    setUrlState({
+      sort_by: newSortBy || null,
+      order: newOrder || null,
+      offset: 0,
+    });
+  };
 
-	return (
-		<div className="mx-auto w-full">
-			<VirtualKeysTable
-				virtualKeys={virtualKeysData?.virtual_keys || []}
-				totalCount={virtualKeysData?.total_count || 0}
-				teams={teamsData?.teams || []}
-				customers={customersData?.customers || []}
-				search={urlState.search}
-				debouncedSearch={debouncedSearch}
-				onSearchChange={handleSearchChange}
-				customerFilter={urlState.customer_id}
-				onCustomerFilterChange={handleCustomerFilterChange}
-				teamFilter={urlState.team_id}
-				onTeamFilterChange={handleTeamFilterChange}
-				offset={urlState.offset}
-				limit={PAGE_SIZE}
-				onOffsetChange={handleOffsetChange}
-				sortBy={urlState.sort_by}
-				order={urlState.order}
-				onSortChange={handleSortChange}
-			/>
-		</div>
-	);
+  return (
+    <div className="mx-auto w-full max-w-7xl">
+      <VirtualKeysTable
+        virtualKeys={virtualKeysData?.virtual_keys || []}
+        totalCount={virtualKeysData?.total_count || 0}
+        teams={teamsData?.teams || []}
+        customers={customersData?.customers || []}
+        search={urlState.search}
+        debouncedSearch={debouncedSearch}
+        onSearchChange={handleSearchChange}
+        customerFilter={urlState.customer_id}
+        onCustomerFilterChange={handleCustomerFilterChange}
+        teamFilter={urlState.team_id}
+        onTeamFilterChange={handleTeamFilterChange}
+        offset={urlState.offset}
+        limit={PAGE_SIZE}
+        onOffsetChange={handleOffsetChange}
+        sortBy={urlState.sort_by}
+        order={urlState.order}
+        onSortChange={handleSortChange}
+      />
+    </div>
+  );
 }

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -181,7 +181,7 @@ const getSidebarItemHref = (item: Pick<SidebarItem, "url" | "queryParam">) => {
 
 const slug = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
 
-const TIME_FILTER_PAGES = new Set([
+const TimeFilterPages = new Set([
   "/workspace/dashboard",
   "/workspace/logs",
   "/workspace/mcp-logs",
@@ -469,8 +469,8 @@ const SidebarItemView = ({
             const baseHref = getSidebarItemHref(subItem);
             const subItemHref = (() => {
               if (
-                TIME_FILTER_PAGES.has(subItem.url) &&
-                TIME_FILTER_PAGES.has(pathname)
+                TimeFilterPages.has(subItem.url) &&
+                TimeFilterPages.has(pathname)
               ) {
                 const currentParams = new URLSearchParams(search);
                 const startTime = currentParams.get("start_time");


### PR DESCRIPTION
## Summary

Introduces a `VisibilityFilter` mechanism that allows upstream middleware to attach row-level visibility constraints to a request context. Query builders in the configstore then read this filter and automatically narrow SQL queries to only the rows the caller is permitted to see, without requiring each call site to manually thread access-control logic.

## Changes

- Added `VisibilityFilter` struct to `core/schemas/visibility.go` with dimensions for `UserIDs`, `TeamIDs`, `VirtualKeyIDs`, and `RoutingScopes`. A nil dimension imposes no restriction; an empty slice matches no rows for that dimension.
- Added `VisibilityFilterFromContext` helper and `IsUnrestricted` method to make filter consumption ergonomic and nil-safe.
- Registered `BifrostContextKeyVisibilityFilter` as a new context key so middleware can stash a `*VisibilityFilter` on the request context.
- Added `framework/configstore/visibility.go` with three query-narrowing helpers: `applyVirtualKeyVisibility`, `applyPromptVisibility`, and `applyRoutingRuleVisibility`. Each builds an OR-joined WHERE clause from the non-nil filter dimensions.
- Applied `applyVirtualKeyVisibility` to both `GetVirtualKeysPaginated` and `GetVirtualKey`, ensuring the paginated count and the single-row fetch agree on what is visible. `GetVirtualKey` now returns `ErrNotFound` for rows that exist but fall outside the filter, preventing URL-guessing attacks from distinguishing hidden rows from absent ones.
- Applied `applyPromptVisibility` to `GetPrompts` and `GetPromptByID` with the same hidden-equals-absent guarantee on the single-row path.
- Applied `applyRoutingRuleVisibility` to `GetRoutingRulesPaginated`; rules with `scope='global'` are always included regardless of the `RoutingScopes` allowlist.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./framework/configstore/...
```

- Attach a `*VisibilityFilter` with a restricted `VirtualKeyIDs` slice to a context and call `GetVirtualKey` with an ID outside that slice — expect `ErrNotFound`.
- Attach a filter with an empty `TeamIDs` slice and call `GetPrompts` — expect an empty result set.
- Attach a filter with `RoutingScopes` set and call `GetRoutingRulesPaginated` — expect only global rules and rules matching the enumerated `(scope, scope_id)` pairs.
- Pass a context with no filter attached — expect all existing behaviour to be unchanged.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The hidden-equals-absent pattern on single-row fetches (`GetVirtualKey`, `GetPromptByID`) is intentional: callers that lack visibility into a row receive the same `ErrNotFound` response as for a genuinely missing row, preventing enumeration of resource IDs through access-control probing. Upstream middleware is responsible for constructing and attaching the `VisibilityFilter`; a missing filter on context is treated as unrestricted (full visibility), preserving backward compatibility for internal and background callers.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable