### PR TITLE
fix: add `usageMetadata` parsing to Gemini embedding response

### DIFF
--- a/core/providers/gemini/embedding.go
+++ b/core/providers/gemini/embedding.go
@@ -159,6 +159,10 @@ func ToBifrostEmbeddingResponse(geminiResp *GeminiEmbeddingResponse, model strin
 		// Set total tokens same as prompt tokens for embeddings
 		bifrostResp.Usage.TotalTokens = bifrostResp.Usage.PromptTokens
 	}
+	if geminiResp.Usage != nil {
+		bifrostResp.Usage.PromptTokens = int(geminiResp.Usage.PromptTokenCount)
+		bifrostResp.Usage.TotalTokens = int(geminiResp.Usage.TotalTokenCount)
+	}
 
 	return bifrostResp
 }

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -1455,8 +1455,9 @@ type FunctionResponse struct {
 
 // GeminiEmbeddingResponse represents a Google GenAI embedding response.
 type GeminiEmbeddingResponse struct {
-	Embeddings []GeminiEmbedding     `json:"embeddings"`
-	Metadata   *EmbedContentMetadata `json:"metadata,omitempty"`
+	Embeddings []GeminiEmbedding                     `json:"embeddings"`
+	Metadata   *EmbedContentMetadata                 `json:"metadata,omitempty"`
+	Usage      *GenerateContentResponseUsageMetadata `json:"usageMetadata,omitempty"`
 }
 
 // GeminiEmbedding represents a single embedding in the response


### PR DESCRIPTION
## Summary

Gemini embedding responses were not correctly reflecting token usage from the API. This PR fixes token count reporting for Gemini embeddings by parsing the `usageMetadata` field returned in the response.

## Changes

- Added `Usage` field (`usageMetadata`) to `GeminiEmbeddingResponse` to capture token metadata returned by the Gemini API.
- Updated `ToBifrostEmbeddingResponse` to populate `PromptTokens` and `TotalTokens` from the Gemini response's usage metadata when present, overriding any previously estimated values.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send an embedding request through the Gemini provider and verify that the returned usage metadata (`prompt_tokens`, `total_tokens`) reflects the actual token counts reported by the Gemini API rather than estimated or zeroed values.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable