### PR TITLE
fix: converts role system to role user if only system message is present for non-openai models

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -569,7 +569,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 		msg := messages[i]
 
 		switch msg.Role {
-		case schemas.ChatMessageRoleSystem:
+		case schemas.ChatMessageRoleSystem, schemas.ChatMessageRoleDeveloper:
 			// Handle system message separately
 			if msg.Content != nil {
 				if msg.Content.ContentStr != nil && *msg.Content.ContentStr != "" {
@@ -588,6 +588,17 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 					if len(blocks) > 0 {
 						systemContent = &AnthropicContent{ContentBlocks: blocks}
 					}
+				}
+			}
+			// If only a single system message is present, convert it user message (since openai allows it)
+			if len(messages) == 1 && (messages[0].Role == schemas.ChatMessageRoleSystem || messages[0].Role == schemas.ChatMessageRoleDeveloper) {
+				if systemContent != nil {
+					content := systemContent
+					systemContent = nil
+					anthropicMessages = append(anthropicMessages, AnthropicMessage{
+						Role:    AnthropicMessageRoleUser,
+						Content: *content,
+					})
 				}
 			}
 			i++

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2228,7 +2228,6 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 				params.Include = []string{"web_search_call.action.sources"}
 			}
 		}
-
 	}
 
 	bifrostReq.Params = params
@@ -2836,6 +2835,16 @@ func ConvertAnthropicMessagesToBifrostMessages(ctx *schemas.BifrostContext, anth
 // ConvertBifrostMessagesToAnthropicMessages converts an array of Bifrost ResponsesMessage to Anthropic message format
 // This is the main conversion method from Bifrost to Anthropic - handles all message types and returns messages + system content
 func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifrostMessages []schemas.ResponsesMessage) ([]AnthropicMessage, *AnthropicContent) {
+	// If only a single system message is present, convert it user message (since openai allows it)
+	if len(bifrostMessages) == 1 && bifrostMessages[0].Role != nil && (*bifrostMessages[0].Role == schemas.ResponsesInputMessageRoleSystem || *bifrostMessages[0].Role == schemas.ResponsesInputMessageRoleDeveloper) {
+		if systemContent := convertBifrostMessageToAnthropicSystemContent(&bifrostMessages[0]); systemContent != nil {
+			return []AnthropicMessage{{
+				Role:    AnthropicMessageRoleUser,
+				Content: *systemContent,
+			}}, nil
+		}
+	}
+
 	var anthropicMessages []AnthropicMessage
 	var systemContent *AnthropicContent
 	var pendingToolCalls []AnthropicContentBlock
@@ -2955,7 +2964,7 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 			flushPendingToolCallsWithTracking()
 
 			// Handle system messages separately
-			if msg.Role != nil && *msg.Role == schemas.ResponsesInputMessageRoleSystem {
+			if msg.Role != nil && (*msg.Role == schemas.ResponsesInputMessageRoleSystem || *msg.Role == schemas.ResponsesInputMessageRoleDeveloper) {
 				systemContent = convertBifrostMessageToAnthropicSystemContent(&msg)
 				continue
 			}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2504,6 +2504,17 @@ func (m *ToolCallStateManager) HasPendingResults() bool {
 // Uses a state machine to properly track and manage tool call lifecycles.
 // The ctx is propagated to URL fetches inside content blocks.
 func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessages []schemas.ResponsesMessage) ([]BedrockMessage, []BedrockSystemMessage, error) {
+	// If only a single system message is present, convert it user message (since openai allows it)
+	if len(bifrostMessages) == 1 && bifrostMessages[0].Role != nil && (*bifrostMessages[0].Role == schemas.ResponsesInputMessageRoleSystem || *bifrostMessages[0].Role == schemas.ResponsesInputMessageRoleDeveloper) {
+		msg := bifrostMessages[0]
+		msg.Role = schemas.Ptr(schemas.ResponsesInputMessageRoleUser)
+		if bedrockMsg := convertBifrostMessageToBedrockMessage(ctx, &msg); bedrockMsg != nil {
+			if len(bedrockMsg.Content) > 0 {
+				return []BedrockMessage{*bedrockMsg}, nil, nil
+			}
+		}
+	}
+
 	var bedrockMessages []BedrockMessage
 	var systemMessages []BedrockSystemMessage
 	var pendingReasoningContentBlocks []BedrockContentBlock
@@ -2837,7 +2848,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, bifrostMessage
 			}
 
 			// Convert regular message
-			if role == schemas.ResponsesInputMessageRoleSystem {
+			if role == schemas.ResponsesInputMessageRoleSystem || role == schemas.ResponsesInputMessageRoleDeveloper {
 				// Convert to system message
 				systemMsgs := convertBifrostMessageToBedrockSystemMessages(&msg)
 				systemMessages = append(systemMessages, systemMsgs...)
@@ -3092,7 +3103,6 @@ func convertSingleBedrockMessageToBifrostMessages(ctx *schemas.BifrostContext, m
 					Signature: block.ReasoningContent.ReasoningText.Signature,
 				})
 			}
-
 		} else if block.ToolUse != nil {
 			// Tool use content
 			// Create copies of the values to avoid range loop variable capture

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -588,10 +588,23 @@ func convertMessages(ctx context.Context, bifrostMessages []schemas.ChatMessage)
 	var messages []BedrockMessage
 	var systemMessages []BedrockSystemMessage
 
+	// if only system / developer message is there, convert it to user message (since openai allows it)
+	if len(bifrostMessages) == 1 && (bifrostMessages[0].Role == schemas.ChatMessageRoleSystem || bifrostMessages[0].Role == schemas.ChatMessageRoleDeveloper) {
+		msg := bifrostMessages[0]
+		msg.Role = schemas.ChatMessageRoleUser
+		bedrockMsg, err := convertMessage(ctx, msg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to convert message: %w", err)
+		}
+		if len(bedrockMsg.Content) > 0 {
+			return []BedrockMessage{bedrockMsg}, nil, nil
+		}
+	}
+
 	for i := 0; i < len(bifrostMessages); i++ {
 		msg := bifrostMessages[i]
 		switch msg.Role {
-		case schemas.ChatMessageRoleSystem:
+		case schemas.ChatMessageRoleSystem, schemas.ChatMessageRoleDeveloper:
 			// Convert system message
 			systemMsgs, err := convertSystemMessages(msg)
 			if err != nil {

--- a/core/providers/cohere/chat.go
+++ b/core/providers/cohere/chat.go
@@ -22,9 +22,15 @@ func ToCohereChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*Coh
 
 	// Convert messages to Cohere v2 format
 	var cohereMessages []CohereMessage
+
 	for _, msg := range messages {
+		role := string(msg.Role)
+		// Cohere has no support for role "developer", so we treat it as "system"
+		if msg.Role == schemas.ChatMessageRoleDeveloper {
+			role = string(schemas.ChatMessageRoleSystem)
+		}
 		cohereMsg := CohereMessage{
-			Role: string(msg.Role),
+			Role: role,
 		}
 
 		// Convert content
@@ -94,6 +100,11 @@ func ToCohereChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*Coh
 		}
 
 		cohereMessages = append(cohereMessages, cohereMsg)
+	}
+
+	// If only a single system message is present, convert it to a user message (since openai allows it).
+	if len(cohereMessages) == 1 && (cohereMessages[0].Role == string(schemas.ChatMessageRoleSystem)) {
+		cohereMessages[0].Role = string(schemas.ChatMessageRoleUser)
 	}
 
 	cohereReq.Messages = cohereMessages
@@ -370,9 +381,8 @@ func (response *CohereChatResponse) ToBifrostChatResponse(model string) *schemas
 				ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{},
 			},
 		},
-		Created: int(time.Now().Unix()),
-		ExtraFields: schemas.BifrostResponseExtraFields{
-		},
+		Created:     int(time.Now().Unix()),
+		ExtraFields: schemas.BifrostResponseExtraFields{},
 	}
 
 	// Convert messages

--- a/core/providers/cohere/responses.go
+++ b/core/providers/cohere/responses.go
@@ -1214,6 +1214,16 @@ func (response *CohereChatResponse) ToBifrostResponsesResponse() *schemas.Bifros
 // ConvertBifrostMessagesToCohereMessages converts an array of Bifrost ResponsesMessage to Cohere message format
 // This is the main conversion method from Bifrost to Cohere - handles all message types and returns messages
 func ConvertBifrostMessagesToCohereMessages(bifrostMessages []schemas.ResponsesMessage, params *schemas.ResponsesParameters) []CohereMessage {
+	// If only a single system / developer message is present, convert it to a user message.
+	// Cohere requires a user message to be present in the conversation.
+	if len(bifrostMessages) == 1 && bifrostMessages[0].Role != nil && (*bifrostMessages[0].Role == schemas.ResponsesInputMessageRoleSystem || *bifrostMessages[0].Role == schemas.ResponsesInputMessageRoleDeveloper) {
+		msg := bifrostMessages[0]
+		msg.Role = schemas.Ptr(schemas.ResponsesInputMessageRoleUser)
+		if cohereMsg := convertBifrostMessageToCohereMessage(&msg); cohereMsg != nil {
+			return []CohereMessage{*cohereMsg}
+		}
+	}
+
 	var cohereMessages []CohereMessage
 	var systemContent []string
 	var pendingReasoningContentBlocks []CohereContentBlock
@@ -1234,7 +1244,8 @@ func ConvertBifrostMessagesToCohereMessages(bifrostMessages []schemas.ResponsesM
 				role = string(*msg.Role)
 			}
 
-			if role == "system" {
+			// Cohere has no support for role "developer", so we treat it as "system"
+			if role == "system" || role == "developer" {
 				// Collect system messages separately for Cohere
 				systemMsgs := convertBifrostMessageToCohereSystemContent(&msg)
 				systemContent = append(systemContent, systemMsgs...)

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -68,7 +68,6 @@ func (request *GeminiGenerationRequest) ToBifrostResponsesRequest(ctx *schemas.B
 	bifrostReq.Params = params
 
 	return bifrostReq
-
 }
 
 func ToGeminiResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*GeminiGenerationRequest, error) {
@@ -2495,8 +2494,7 @@ func convertGeminiCandidatesToResponsesOutput(candidates []*Candidate) []schemas
 				},
 			}
 			if len(candidate.GroundingMetadata.WebSearchQueries) > 0 {
-				webSearchmessage.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.Query =
-					schemas.Ptr(candidate.GroundingMetadata.WebSearchQueries[0])
+				webSearchmessage.ResponsesToolMessage.Action.ResponsesWebSearchToolCallAction.Query = schemas.Ptr(candidate.GroundingMetadata.WebSearchQueries[0])
 			}
 
 			sources := []schemas.ResponsesWebSearchToolCallActionSearchSource{}
@@ -2899,6 +2897,32 @@ func convertResponsesToolChoiceToGemini(toolChoice *schemas.ResponsesToolChoice)
 
 // convertResponsesMessagesToGeminiContents converts Responses messages to Gemini contents
 func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessage) ([]Content, *Content, error) {
+	// if only system / developer message is there, convert it to user message (since openai allows it)
+	if len(messages) == 1 && messages[0].Role != nil && (*messages[0].Role == schemas.ResponsesInputMessageRoleSystem || *messages[0].Role == schemas.ResponsesInputMessageRoleDeveloper) {
+		content := Content{Role: "user"}
+		if messages[0].Content != nil {
+			if messages[0].Content.ContentStr != nil && *messages[0].Content.ContentStr != "" {
+				content.Parts = append(content.Parts, &Part{
+					Text: *messages[0].Content.ContentStr,
+				})
+			}
+			if messages[0].Content.ContentBlocks != nil {
+				for _, block := range messages[0].Content.ContentBlocks {
+					part, err := convertContentBlockToGeminiPart(block)
+					if err != nil {
+						return nil, nil, fmt.Errorf("failed to convert system message content block: %w", err)
+					}
+					if part != nil {
+						content.Parts = append(content.Parts, part)
+					}
+				}
+			}
+		}
+		if len(content.Parts) > 0 {
+			return []Content{content}, nil, nil
+		}
+	}
+
 	var contents []Content
 	var systemInstruction *Content
 
@@ -2927,7 +2951,7 @@ func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessag
 		}
 
 		// Handle system messages separately
-		if msg.Role != nil && *msg.Role == schemas.ResponsesInputMessageRoleSystem {
+		if msg.Role != nil && (*msg.Role == schemas.ResponsesInputMessageRoleSystem || *msg.Role == schemas.ResponsesInputMessageRoleDeveloper) {
 			if systemInstruction == nil {
 				systemInstruction = &Content{}
 			}

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -1729,6 +1729,14 @@ func addSpeechConfigToGenerationConfig(config *GenerationConfig, voiceConfig *sc
 
 // convertBifrostMessagesToGemini converts Bifrost messages to Gemini format
 func convertBifrostMessagesToGemini(messages []schemas.ChatMessage) ([]Content, *Content) {
+	// if only system / developer message is there, convert it to user message (since openai allows it)
+	if len(messages) == 1 && (messages[0].Role == schemas.ChatMessageRoleSystem || messages[0].Role == schemas.ChatMessageRoleDeveloper) {
+		content := convertSystemChatMessageToGeminiUserContent(messages[0])
+		if len(content.Parts) > 0 {
+			return []Content{content}, nil
+		}
+	}
+
 	var contents []Content
 	var systemInstruction *Content
 
@@ -1740,7 +1748,8 @@ func convertBifrostMessagesToGemini(messages []schemas.ChatMessage) ([]Content, 
 
 	for i, message := range messages {
 		// Handle system messages separately - Gemini requires them in SystemInstruction field
-		if message.Role == schemas.ChatMessageRoleSystem {
+		// Gemini has no support for role "developer", so we treat it as "system"
+		if message.Role == schemas.ChatMessageRoleSystem || message.Role == schemas.ChatMessageRoleDeveloper {
 			if systemInstruction == nil {
 				systemInstruction = &Content{}
 			}
@@ -2076,6 +2085,33 @@ func convertBifrostMessagesToGemini(messages []schemas.ChatMessage) ([]Content, 
 	}
 
 	return contents, systemInstruction
+}
+
+func convertSystemChatMessageToGeminiUserContent(message schemas.ChatMessage) Content {
+	content := Content{Role: "user"}
+
+	if message.Content == nil {
+		return content
+	}
+
+	if message.Content.ContentStr != nil && *message.Content.ContentStr != "" {
+		content.Parts = append(content.Parts, &Part{
+			Text: *message.Content.ContentStr,
+		})
+		return content
+	}
+
+	if message.Content.ContentBlocks != nil {
+		for _, block := range message.Content.ContentBlocks {
+			if block.Text != nil && *block.Text != "" {
+				content.Parts = append(content.Parts, &Part{
+					Text: *block.Text,
+				})
+			}
+		}
+	}
+
+	return content
 }
 
 // normalizeSchemaTypes recursively normalizes type values from uppercase to lowercase

--- a/plugins/compat/conversion.go
+++ b/plugins/compat/conversion.go
@@ -9,9 +9,6 @@ func applyParameterConversion(req *schemas.BifrostRequest) {
 	if req == nil {
 		return
 	}
-	if req.ChatRequest != nil {
-		normalizeDeveloperRoleForChatRequest(req.ChatRequest)
-	}
 	if req.ResponsesRequest != nil {
 		flattenNamespaceTools(req.ResponsesRequest)
 	}
@@ -47,15 +44,4 @@ func flattenNamespaceTools(req *schemas.BifrostResponsesRequest) {
 		}
 	}
 	req.Params.Tools = flattened
-}
-
-func normalizeDeveloperRoleForChatRequest(req *schemas.BifrostChatRequest) {
-	if req.Provider != schemas.Bedrock && req.Provider != schemas.Vertex && req.Provider != schemas.Gemini {
-		return
-	}
-	for i := range req.Input {
-		if req.Input[i].Role == schemas.ChatMessageRoleDeveloper {
-			req.Input[i].Role = schemas.ChatMessageRoleSystem
-		}
-	}
 }


### PR DESCRIPTION
## Summary

This PR extends `developer` role support across Anthropic, Bedrock, and Gemini providers for both chat completions and responses requests. It also fixes a case where a request containing only a single `system` or `developer` role message would fail on these providers by converting that sole message to a `user` role message instead.

## Changes

- Removed `normalizeDeveloperRoleForChatRequest` from the compat plugin, replacing provider-level role normalization with native `developer` role handling directly in each provider
- Added single-message role conversion logic across Anthropic, Bedrock, and Gemini for both chat and responses paths, so a lone `system` or `developer` message is promoted to `user` rather than being rejected
- Extended `developer` role handling in Anthropic chat, Anthropic responses, Bedrock chat, Bedrock responses, Gemini chat, and Gemini responses to treat `developer` equivalently to `system`
- Added `convertSystemChatMessageToGeminiUserContent` helper in Gemini to handle the single-message conversion case cleanly

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a chat completions or responses request to Anthropic, Bedrock, or Gemini with a single message using the `system` or `developer` role and verify it is successfully converted to a `user` message and processed without error.

```sh
go test ./...
```

Tested on:

```
"model": "openai/gpt-4o",
"model": "bedrock/openai.gpt-oss-120b-1:0",
"model": "gemini/gemini-2.5-flash",
"model": "anthropic/claude-opus-4-6",
"model": "anthropic/claude-sonnet-4-6",
"model": "vertex/gemini-2.5-flash",
"model": "ollama/granite4:350m-h",
"model": "vllm/Qwen/Qwen2.5-1.5B-Instruct",
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Changes are scoped to message role normalization within provider conversion logic.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable