### PR TITLE
fix: forward extra headers on responses websocket upstreams

### DIFF
--- a/transports/bifrost-http/handlers/wsrealtime.go
+++ b/transports/bifrost-http/handlers/wsrealtime.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -200,7 +201,7 @@ func (h *WSRealtimeHandler) runRealtimeSession(
 		Provider: providerKey,
 		KeyID:    key.ID,
 		Endpoint: wsURL,
-	}, rtProvider.RealtimeHeaders(key))
+	}, mapToHTTPHeader(rtProvider.RealtimeHeaders(key)))
 	if err != nil {
 		clientConn.writeRealtimeError(newRealtimeWireBifrostError(502, "server_error", err.Error()))
 		return
@@ -650,6 +651,14 @@ func extractRealtimeSubprotocolAPIKey(ctx *fasthttp.RequestCtx) string {
 		}
 	}
 	return ""
+}
+
+func mapToHTTPHeader(headers map[string]string) http.Header {
+	merged := http.Header{}
+	for key, value := range headers {
+		merged.Set(key, value)
+	}
+	return merged
 }
 
 func newRealtimeWireBifrostError(status int, code, message string) *schemas.BifrostError {

--- a/transports/bifrost-http/handlers/wsresponses.go
+++ b/transports/bifrost-http/handlers/wsresponses.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"net/http"
 	"strings"
 	"time"
 
@@ -111,7 +112,7 @@ type authHeaders struct {
 	apiKey        string
 	googAPIKey    string
 	baggage       string
-	extraHeaders  map[string]string
+	headers       map[string][]string
 }
 
 // captureAuthHeaders captures the auth headers from the request.
@@ -122,15 +123,12 @@ func captureAuthHeaders(ctx *fasthttp.RequestCtx) *authHeaders {
 		apiKey:        string(ctx.Request.Header.Peek("x-api-key")),
 		googAPIKey:    string(ctx.Request.Header.Peek("x-goog-api-key")),
 		baggage:       string(ctx.Request.Header.Peek("baggage")),
-		extraHeaders:  make(map[string]string),
+		headers:       make(map[string][]string),
 	}
 
 	for key, value := range ctx.Request.Header.All() {
-		k := string(key)
-		lk := strings.ToLower(k)
-		if strings.HasPrefix(lk, "x-bf-") {
-			ah.extraHeaders[k] = string(value)
-		}
+		k := strings.ToLower(string(key))
+		ah.headers[k] = append(ah.headers[k], string(value))
 	}
 	return ah
 }
@@ -262,23 +260,36 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 
 	wsURL := wsProvider.WebSocketResponsesURL(key)
 	upstream := session.Upstream()
+	upstreamFromPool := true
 
-	// Validate the pinned upstream matches the current request's provider/key
+	// Validate the pinned upstream matches the current request's provider/key.
+	hasForwardedHeaders := hasWebSocketForwardedHeaders(ctx)
 	if upstream != nil && !upstream.IsClosed() &&
-		(upstream.Provider() != req.Provider || upstream.KeyID() != key.ID) {
+		(upstream.Provider() != req.Provider || upstream.KeyID() != key.ID || hasForwardedHeaders) {
 		h.pool.Discard(upstream)
 		session.SetUpstream(nil)
 		upstream = nil
 	}
 
-	// If no upstream connection pinned, get one from the pool or dial
-	if upstream == nil || upstream.IsClosed() {
-		headers := wsProvider.WebSocketHeaders(key)
+	// If request-scoped headers are present, do not use the shared pool: pooling
+	// those dials either leaks metadata across clients or explodes pool key cardinality.
+	if hasForwardedHeaders {
+		headers := mergeWebSocketHeaders(ctx, wsProvider.WebSocketHeaders(key))
+		upstream, err = bfws.DialUpstream(wsURL, headers, req.Provider, key.ID)
+		if err != nil {
+			logger.Warn("failed to dial upstream WS connection for %s with forwarded headers: %v, falling back to HTTP bridge", req.Provider, err)
+			return false
+		}
+		upstreamFromPool = false
+		defer upstream.Close()
+	} else if upstream == nil || upstream.IsClosed() {
 		poolKey := bfws.PoolKey{
 			Provider: req.Provider,
 			KeyID:    key.ID,
 			Endpoint: wsURL,
 		}
+
+		headers := mergeWebSocketHeaders(ctx, wsProvider.WebSocketHeaders(key))
 
 		upstream, err = h.pool.Get(poolKey, headers)
 		if err != nil {
@@ -286,6 +297,15 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 			return false
 		}
 		session.SetUpstream(upstream)
+	}
+
+	closeUpstream := func() {
+		if upstreamFromPool {
+			h.pool.Discard(upstream)
+		} else if upstream != nil {
+			upstream.Close()
+		}
+		session.SetUpstream(nil)
 	}
 
 	// Run plugin pre-hooks before forwarding to upstream
@@ -320,8 +340,7 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 	// Forward the raw event to upstream
 	if err := upstream.WriteMessage(ws.TextMessage, rawEvent); err != nil {
 		logger.Warn("upstream WS write failed for %s: %v, falling back to HTTP bridge", req.Provider, err)
-		h.pool.Discard(upstream)
-		session.SetUpstream(nil)
+		closeUpstream()
 		return false
 	}
 
@@ -336,8 +355,7 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 		if err := upstream.SetReadDeadline(time.Now().Add(streamIdleTimeout)); err != nil {
 			// Fail closed: if we can't arm the idle timeout, don't risk hanging forever.
 			logger.Warn("failed to set upstream WS read deadline for %s: %v, treating as terminal", req.Provider, err)
-			h.pool.Discard(upstream)
-			session.SetUpstream(nil)
+			closeUpstream()
 			finalizeTerminalPostHooks(newBifrostError(502, "upstream_connection_error", "failed to arm upstream read deadline"))
 			writeWSError(session, 502, "upstream_connection_error", "upstream websocket connection error")
 			return true
@@ -347,16 +365,14 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 		if readErr != nil {
 			if isWSReadTimeout(readErr) {
 				logger.Warn("upstream WS idle timeout for %s after %s", req.Provider, streamIdleTimeout)
-				h.pool.Discard(upstream)
-				session.SetUpstream(nil)
+				closeUpstream()
 				finalizeTerminalPostHooks(newBifrostError(504, "upstream_timeout", "upstream websocket stream timed out"))
 				writeWSError(session, 504, "upstream_timeout", "upstream websocket stream timed out")
 				return true
 			}
 
 			logger.Warn("upstream WS read failed for %s: %v, falling back to HTTP bridge", req.Provider, readErr)
-			h.pool.Discard(upstream)
-			session.SetUpstream(nil)
+			closeUpstream()
 			if !forwardedAny {
 				return false
 			}
@@ -385,16 +401,14 @@ func (h *WSResponsesHandler) tryNativeWSUpstream(
 
 			_, postErr := hooks.PostHookRunner(ctx, resp, nil)
 			if postErr != nil {
-				h.pool.Discard(upstream)
-				session.SetUpstream(nil)
+				closeUpstream()
 				writeWSBifrostError(session, postErr)
 				return true
 			}
 		}
 
 		if writeErr := session.WriteMessage(msgType, data); writeErr != nil {
-			h.pool.Discard(upstream)
-			session.SetUpstream(nil)
+			closeUpstream()
 			// Only finalize post-hooks if they haven't already run for this chunk.
 			// When isTerminal && streamResp != nil, PostHookRunner already ran above (line 366),
 			// so calling finalizeTerminalPostHooks again would double-fire the end-of-stream signal.
@@ -626,6 +640,9 @@ func (h *WSResponsesHandler) convertEventToRequest(event *schemas.WebSocketRespo
 // createBifrostContextFromAuth builds a BifrostContext from the auth headers captured during upgrade.
 func createBifrostContextFromAuth(handlerStore lib.HandlerStore, auth *authHeaders) (*schemas.BifrostContext, context.CancelFunc) {
 	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	if auth == nil {
+		return ctx, cancel
+	}
 
 	if sessionID := lib.ParseSessionIDFromBaggage(auth.baggage); sessionID != "" {
 		ctx.SetValue(schemas.BifrostContextKeyParentRequestID, sessionID)
@@ -641,7 +658,7 @@ func createBifrostContextFromAuth(handlerStore lib.HandlerStore, auth *authHeade
 			token := strings.TrimPrefix(auth.authorization, "Bearer ")
 			if strings.HasPrefix(token, "sk-bf-") {
 				ctx.SetValue(schemas.BifrostContextKeyVirtualKey, token)
-			} else if handlerStore.ShouldAllowDirectKeys() {
+			} else if handlerStore != nil && handlerStore.ShouldAllowDirectKeys() {
 				key := schemas.Key{
 					ID:     "header-provided",
 					Value:  *schemas.NewEnvVar(token),
@@ -655,7 +672,7 @@ func createBifrostContextFromAuth(handlerStore lib.HandlerStore, auth *authHeade
 	if auth.apiKey != "" {
 		if strings.HasPrefix(auth.apiKey, "sk-bf-") {
 			ctx.SetValue(schemas.BifrostContextKeyVirtualKey, auth.apiKey)
-		} else if handlerStore.ShouldAllowDirectKeys() {
+		} else if handlerStore != nil && handlerStore.ShouldAllowDirectKeys() {
 			key := schemas.Key{
 				ID:     "header-provided",
 				Value:  *schemas.NewEnvVar(auth.apiKey),
@@ -668,7 +685,7 @@ func createBifrostContextFromAuth(handlerStore lib.HandlerStore, auth *authHeade
 	if auth.googAPIKey != "" {
 		if strings.HasPrefix(auth.googAPIKey, "sk-bf-") {
 			ctx.SetValue(schemas.BifrostContextKeyVirtualKey, auth.googAPIKey)
-		} else if handlerStore.ShouldAllowDirectKeys() {
+		} else if handlerStore != nil && handlerStore.ShouldAllowDirectKeys() {
 			key := schemas.Key{
 				ID:     "header-provided",
 				Value:  *schemas.NewEnvVar(auth.googAPIKey),
@@ -680,25 +697,89 @@ func createBifrostContextFromAuth(handlerStore lib.HandlerStore, auth *authHeade
 	}
 
 	// Forward x-bf-* headers
-	for k, v := range auth.extraHeaders {
-		lk := strings.ToLower(k)
-		switch {
-		case lk == "x-bf-vk":
-			// Already handled above
-		case lk == "x-bf-api-key":
-			ctx.SetValue(schemas.BifrostContextKeyAPIKeyName, v)
-		case strings.HasPrefix(lk, "x-bf-eh-"):
-			suffix := strings.TrimPrefix(lk, "x-bf-eh-")
-			existing, _ := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string]string)
-			if existing == nil {
-				existing = make(map[string]string)
+	matcher := (*lib.HeaderMatcher)(nil)
+	if handlerStore != nil {
+		matcher = handlerStore.GetHeaderMatcher()
+	}
+	extraHeaders := make(map[string][]string)
+	for k, values := range auth.headers {
+		for _, v := range values {
+			switch {
+			case k == "x-bf-vk":
+				// Already handled above
+			case k == "x-bf-api-key":
+				ctx.SetValue(schemas.BifrostContextKeyAPIKeyName, v)
+			case strings.HasPrefix(k, "x-bf-eh-"):
+				addForwardedHeader(extraHeaders, matcher, strings.TrimPrefix(k, "x-bf-eh-"), v)
+			case matcher != nil && matcher.HasAllowlist() && matcher.MatchesAllow(k):
+				if !strings.HasPrefix(k, "x-bf-") && !isSecurityDeniedExtraHeader(k) && !matcher.MatchesDeny(k) {
+					extraHeaders[k] = append(extraHeaders[k], v)
+				}
 			}
-			existing[suffix] = v
-			ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, existing)
 		}
+	}
+	if len(extraHeaders) > 0 {
+		ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, extraHeaders)
 	}
 
 	return ctx, cancel
+}
+
+func addForwardedHeader(extraHeaders map[string][]string, matcher *lib.HeaderMatcher, name string, value string) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" || isSecurityDeniedExtraHeader(name) {
+		return
+	}
+	if matcher != nil && !matcher.ShouldAllow(name) {
+		return
+	}
+	extraHeaders[name] = append(extraHeaders[name], value)
+}
+
+func isSecurityDeniedExtraHeader(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if strings.HasPrefix(name, "sec-websocket-") {
+		return true
+	}
+	switch name {
+	case "authorization", "proxy-authorization", "cookie", "host", "content-length", "connection", "transfer-encoding",
+		"upgrade", "origin", "x-api-key", "x-goog-api-key", "x-bf-api-key", "x-bf-api-key-id", "x-bf-vk":
+		return true
+	default:
+		return false
+	}
+}
+
+func mergeWebSocketHeaders(ctx *schemas.BifrostContext, providerHeaders map[string]string) http.Header {
+	merged := http.Header{}
+	for key, value := range providerHeaders {
+		merged.Set(key, value)
+	}
+	if extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string); ok {
+		for key, values := range extraHeaders {
+			if len(values) == 0 || isSecurityDeniedExtraHeader(key) {
+				continue
+			}
+			merged.Del(key)
+			for _, value := range values {
+				merged.Add(key, value)
+			}
+		}
+	}
+	return merged
+}
+
+func hasWebSocketForwardedHeaders(ctx *schemas.BifrostContext) bool {
+	extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+	if !ok {
+		return false
+	}
+	for key, values := range extraHeaders {
+		if len(values) > 0 && !isSecurityDeniedExtraHeader(key) {
+			return true
+		}
+	}
+	return false
 }
 
 // executeHTTPBridge runs the response through the existing streaming inference pipeline.

--- a/transports/bifrost-http/handlers/wsresponses_test.go
+++ b/transports/bifrost-http/handlers/wsresponses_test.go
@@ -8,14 +8,17 @@ import (
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/stretchr/testify/assert"
+	"github.com/valyala/fasthttp"
 )
 
 type testWSHandlerStore struct {
 	allowDirectKeys bool
+	matcher         *lib.HeaderMatcher
 }
 
 func (s testWSHandlerStore) ShouldAllowDirectKeys() bool {
@@ -23,7 +26,7 @@ func (s testWSHandlerStore) ShouldAllowDirectKeys() bool {
 }
 
 func (s testWSHandlerStore) GetHeaderMatcher() *lib.HeaderMatcher {
-	return nil
+	return s.matcher
 }
 
 func (s testWSHandlerStore) GetProvidersForModel(model string) []schemas.ModelProvider {
@@ -125,4 +128,135 @@ func TestCreateBifrostContextFromAuth_EmptyBaggageSessionIDIgnored(t *testing.T)
 	if got := ctx.Value(schemas.BifrostContextKeyParentRequestID); got != nil {
 		t.Fatalf("parent request id should be unset, got %#v", got)
 	}
+}
+
+func TestCreateBifrostContextFromAuth_ForwardsPrefixedHeaders(t *testing.T) {
+	ctx, cancel := createBifrostContextFromAuth(testWSHandlerStore{}, &authHeaders{
+		headers: map[string][]string{
+			"x-bf-eh-originator": {"my-test-client"},
+			"x-bf-eh-x-trace-id": {"abc-123"},
+			"x-bf-eh-cookie":     {"blocked"},
+		},
+	})
+	defer cancel()
+
+	extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+	if !ok {
+		t.Fatal("expected websocket extra headers in context")
+	}
+	assert.Equal(t, []string{"my-test-client"}, extraHeaders["originator"])
+	assert.Equal(t, []string{"abc-123"}, extraHeaders["x-trace-id"])
+	assert.NotContains(t, extraHeaders, "cookie")
+}
+
+func TestCreateBifrostContextFromAuth_AppliesHeaderFilterAndDirectAllowlist(t *testing.T) {
+	matcher := lib.NewHeaderMatcher(&configstoreTables.GlobalHeaderFilterConfig{
+		Allowlist: []string{"originator", "anthropic-*"},
+		Denylist:  []string{"anthropic-secret"},
+	})
+	ctx, cancel := createBifrostContextFromAuth(testWSHandlerStore{matcher: matcher}, &authHeaders{
+		headers: map[string][]string{
+			"x-bf-eh-originator":       {"allowed-prefix"},
+			"x-bf-eh-x-trace-id":       {"blocked-by-allowlist"},
+			"anthropic-beta":           {"allowed-direct"},
+			"anthropic-secret":         {"blocked-by-denylist"},
+			"x-bf-eh-anthropic-secret": {"blocked-prefix-denylist"},
+		},
+	})
+	defer cancel()
+
+	extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+	if !ok {
+		t.Fatal("expected websocket extra headers in context")
+	}
+	assert.Equal(t, []string{"allowed-prefix"}, extraHeaders["originator"])
+	assert.Equal(t, []string{"allowed-direct"}, extraHeaders["anthropic-beta"])
+	assert.NotContains(t, extraHeaders, "x-trace-id")
+	assert.NotContains(t, extraHeaders, "anthropic-secret")
+}
+
+func TestCaptureAuthHeaders_PreservesDuplicateHeaderValues(t *testing.T) {
+	var req fasthttp.Request
+	req.Header.Set("Host", "example.test")
+	req.Header.Add("x-bf-eh-x-trace-id", "trace-a")
+	req.Header.Add("x-bf-eh-x-trace-id", "trace-b")
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
+
+	auth := captureAuthHeaders(ctx)
+	assert.Equal(t, []string{"trace-a", "trace-b"}, auth.headers["x-bf-eh-x-trace-id"])
+}
+
+func TestCreateBifrostContextFromAuth_PreservesMultipleForwardedHeaderValues(t *testing.T) {
+	ctx, cancel := createBifrostContextFromAuth(testWSHandlerStore{}, &authHeaders{
+		headers: map[string][]string{
+			"x-bf-eh-x-trace-id": {"trace-a", "trace-b"},
+		},
+	})
+	defer cancel()
+
+	extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+	if !ok {
+		t.Fatal("expected websocket extra headers in context")
+	}
+	assert.Equal(t, []string{"trace-a", "trace-b"}, extraHeaders["x-trace-id"])
+}
+
+func TestCreateBifrostContextFromAuth_BlocksWebSocketHandshakeForwardedHeaders(t *testing.T) {
+	matcher := lib.NewHeaderMatcher(&configstoreTables.GlobalHeaderFilterConfig{
+		Allowlist: []string{"*"},
+	})
+	ctx, cancel := createBifrostContextFromAuth(testWSHandlerStore{matcher: matcher}, &authHeaders{
+		headers: map[string][]string{
+			"x-bf-eh-upgrade":                {"websocket"},
+			"x-bf-eh-sec-websocket-protocol": {"realtime"},
+			"sec-websocket-extensions":       {"permessage-deflate"},
+			"x-bf-eh-originator":             {"safe"},
+		},
+	})
+	defer cancel()
+
+	extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyExtraHeaders).(map[string][]string)
+	if !ok {
+		t.Fatal("expected websocket extra headers in context")
+	}
+	assert.Equal(t, []string{"safe"}, extraHeaders["originator"])
+	assert.NotContains(t, extraHeaders, "upgrade")
+	assert.NotContains(t, extraHeaders, "sec-websocket-protocol")
+	assert.NotContains(t, extraHeaders, "sec-websocket-extensions")
+}
+
+func TestMergeWebSocketHeaders_ForwardedHeadersOverrideProviderHeadersAndPreserveValues(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
+		"originator":    {"my-test-client"},
+		"authorization": {"Bearer malicious"},
+		"x-static":      {"client-value-1", "client-value-2"},
+	})
+
+	merged := mergeWebSocketHeaders(ctx, map[string]string{
+		"Authorization": "Bearer provider-key",
+		"x-static":      "provider-value",
+	})
+
+	assert.Equal(t, []string{"my-test-client"}, merged.Values("originator"))
+	assert.Equal(t, []string{"Bearer provider-key"}, merged.Values("Authorization"))
+	assert.Equal(t, []string{"client-value-1", "client-value-2"}, merged.Values("x-static"))
+	assert.NotContains(t, merged.Values("Authorization"), "Bearer malicious")
+}
+
+func TestHasWebSocketForwardedHeaders(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, time.Time{})
+	assert.False(t, hasWebSocketForwardedHeaders(ctx))
+
+	ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
+		"authorization": {"Bearer malicious"},
+	})
+	assert.False(t, hasWebSocketForwardedHeaders(ctx))
+
+	ctx.SetValue(schemas.BifrostContextKeyExtraHeaders, map[string][]string{
+		"x-trace-id": {"abc-123"},
+	})
+	assert.True(t, hasWebSocketForwardedHeaders(ctx))
 }

--- a/transports/bifrost-http/websocket/connection.go
+++ b/transports/bifrost-http/websocket/connection.go
@@ -5,6 +5,7 @@ package websocket
 
 import (
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"sync"
@@ -251,14 +252,19 @@ func isConnectionDead(err error) bool {
 	return msg == "EOF" || msg == "unexpected EOF"
 }
 
+// DialUpstream creates a new upstream connection without adding it to the pool.
+func DialUpstream(url string, headers http.Header, provider schemas.ModelProvider, keyID string) (*UpstreamConn, error) {
+	wsConn, resp, err := Dial(url, headers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial upstream websocket %s: %w", url, wrapHandshakeError(resp, err))
+	}
+	return newUpstreamConn(wsConn, provider, keyID, url), nil
+}
+
 // Dial creates a new WebSocket connection to the given URL with the provided headers.
-func Dial(url string, headers map[string]string) (*ws.Conn, *http.Response, error) {
+func Dial(url string, headers http.Header) (*ws.Conn, *http.Response, error) {
 	dialer := ws.Dialer{
 		HandshakeTimeout: 10 * time.Second,
 	}
-	h := http.Header{}
-	for k, v := range headers {
-		h.Set(k, v)
-	}
-	return dialer.Dial(url, h)
+	return dialer.Dial(url, headers)
 }

--- a/transports/bifrost-http/websocket/pool.go
+++ b/transports/bifrost-http/websocket/pool.go
@@ -26,11 +26,11 @@ type PoolKey struct {
 // Pool manages a pool of upstream WebSocket connections keyed by (provider, keyID, endpoint).
 // Idle connections are cached for reuse. Connections exceeding max lifetime are discarded.
 type Pool struct {
-	mu       sync.Mutex
-	idle     map[PoolKey][]*UpstreamConn
-	inFlight int
-	probing  int                    // connections temporarily removed from idle for heartbeat validation
-	probingPerKey map[PoolKey]int   // per-key probing count for MaxIdlePerKey enforcement
+	mu            sync.Mutex
+	idle          map[PoolKey][]*UpstreamConn
+	inFlight      int
+	probing       int             // connections temporarily removed from idle for heartbeat validation
+	probingPerKey map[PoolKey]int // per-key probing count for MaxIdlePerKey enforcement
 
 	config *schemas.WSPoolConfig
 
@@ -58,7 +58,7 @@ func NewPool(config *schemas.WSPoolConfig) *Pool {
 // Get retrieves an idle connection for the given key, or dials a new one.
 // The returned connection is removed from the idle pool and must be returned
 // via Return or discarded via Discard.
-func (p *Pool) Get(key PoolKey, headers map[string]string) (*UpstreamConn, error) {
+func (p *Pool) Get(key PoolKey, headers http.Header) (*UpstreamConn, error) {
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
@@ -181,7 +181,7 @@ func (p *Pool) Close() {
 
 // dial establishes a new WebSocket connection to the upstream endpoint
 // identified by key, forwarding the supplied HTTP headers during the handshake.
-func (p *Pool) dial(key PoolKey, headers map[string]string) (*UpstreamConn, error) {
+func (p *Pool) dial(key PoolKey, headers http.Header) (*UpstreamConn, error) {
 	wsConn, resp, err := Dial(key.Endpoint, headers)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial upstream websocket %s: %w", key.Endpoint, wrapHandshakeError(resp, err))

--- a/transports/bifrost-http/websocket/pool_test.go
+++ b/transports/bifrost-http/websocket/pool_test.go
@@ -150,6 +150,37 @@ func TestPoolDialIncludesHandshakeDetails(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid websocket token")
 }
 
+func TestDialUpstreamCloseDoesNotAffectPoolCapacityCounters(t *testing.T) {
+	server := startTestWSServer(t)
+	defer server.Close()
+
+	config := &schemas.WSPoolConfig{
+		MaxIdlePerKey:                1,
+		MaxTotalConnections:          1,
+		IdleTimeoutSeconds:           300,
+		MaxConnectionLifetimeSeconds: 3600,
+	}
+	pool := NewPool(config)
+	defer pool.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	unpooled, err := DialUpstream(wsURL, nil, schemas.OpenAI, "test-key")
+	require.NoError(t, err)
+	require.NotNil(t, unpooled)
+	require.NoError(t, unpooled.Close())
+
+	pool.mu.Lock()
+	inFlight := pool.inFlight
+	pool.mu.Unlock()
+	assert.Equal(t, 0, inFlight)
+
+	key := PoolKey{Provider: schemas.OpenAI, KeyID: "test-key", Endpoint: wsURL}
+	pooled, err := pool.Get(key, nil)
+	require.NoError(t, err)
+	require.NotNil(t, pooled)
+	pool.Discard(pooled)
+}
+
 func TestPoolExpiredConnection(t *testing.T) {
 	server := startTestWSServer(t)
 	defer server.Close()


### PR DESCRIPTION
## Summary

Fix native Responses WebSocket header forwarding so request-scoped `x-bf-eh-*` and allowlisted headers reach upstream handshakes with HTTP transport parity.

## Changes

- Capture WebSocket upgrade headers into the Bifrost context as `map[string][]string`, matching the normal HTTP inference path.
- Preserve duplicate WebSocket upgrade header lines during capture so multi-value `x-bf-eh-*` forwarding is not truncated before context conversion.
- Forward `x-bf-eh-*` headers by stripping the prefix and applying header filter rules before upstream dial.
- Support direct `HeaderFilterConfig` allowlist forwarding for WebSocket upgrade headers.
- Preserve multi-value forwarded headers by changing the shared WebSocket pool/dial path to accept `http.Header`.
- Apply provider/static WebSocket headers first and request-forwarded headers afterward, matching HTTP override semantics.
- Block security-sensitive forwarded headers before they can override upstream auth or connection-critical headers.
- Deny WebSocket handshake-control headers (`upgrade`, `origin`, and `sec-websocket-*`) from the forwarded-header mechanism, even when wildcard allowlists are configured.
- Bypass the shared WebSocket pool when request-forwarded headers are present to avoid metadata leakage and high-cardinality pool keys.
- Keep the no-forwarded-header path on the existing pool so normal WebSocket reuse remains unchanged.
- Add unit coverage for prefixed forwarding, duplicate/multi-value capture, direct allowlist/denylist behavior, handshake-header blocking, merge ordering, multi-value preservation, forwarded-header pool bypass detection, and unpooled cleanup not touching pool capacity counters.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Focused Go tests:

```sh
direnv exec . go test ./transports/bifrost-http/handlers ./transports/bifrost-http/websocket
```

Expected outcome:

```text
ok  github.com/maximhq/bifrost/transports/bifrost-http/handlers
ok  github.com/maximhq/bifrost/transports/bifrost-http/websocket
```

Additional unit coverage validates duplicate upgrade header capture, multi-value context forwarding, denial of WebSocket handshake-control headers even under wildcard header allowlists, and direct unpooled upstream cleanup without decrementing pool `inFlight` capacity counters.

No new configs or environment variables were added.

## Screenshots/Recordings

Not applicable; this is a backend transport bug fix.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #2996

Linear: BF-722

## Security considerations

This PR handles client-controlled headers during WebSocket upgrades. Security-sensitive headers such as auth, cookies, host, content length, connection control, Bifrost control headers, and WebSocket handshake-control headers (`upgrade`, `origin`, `sec-websocket-*`) are denied before forwarding. When request-scoped forwarded headers are present, the upstream WebSocket connection bypasses the shared pool so metadata from one client/request cannot be reused for another request and high-cardinality trace/request headers do not exhaust idle pool capacity. Unpooled upstreams are closed directly instead of discarded through the pool, so pool capacity counters remain accurate.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable