### PR TITLE
feat: move trial expiry indicator from sidebar to sticky `TrialExpiryBanner` component

### DIFF
--- a/ui/app/clientLayout.tsx
+++ b/ui/app/clientLayout.tsx
@@ -3,6 +3,7 @@ import NotAvailableBanner from "@/components/notAvailableBanner";
 import ProgressProvider from "@/components/progressBar";
 import Sidebar from "@/components/sidebar";
 import { ThemeProvider } from "@/components/themeProvider";
+import TrialExpiryBanner from "@/components/trialExpiryBanner";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { useStoreSync } from "@/hooks/useStoreSync";
 import { WebSocketProvider } from "@/hooks/useWebSocket";
@@ -11,7 +12,7 @@ import { BifrostConfig } from "@/lib/types/config";
 import { RbacProvider } from "@enterprise/lib/contexts/rbacContext";
 import { useLocation } from "@tanstack/react-router";
 import { NuqsAdapter } from "nuqs/adapters/tanstack-router";
-import { Suspense, lazy, useEffect } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { CookiesProvider } from "react-cookie";
 import { toast, Toaster } from "sonner";
 
@@ -44,6 +45,7 @@ function AppContent({ children }: { children: React.ReactNode }) {
 				<SidebarProvider>
 					<Sidebar />
 					<div className="dark:bg-card custom-scrollbar content-container my-[0.5rem] mr-[0.5rem] h-[calc(100dvh-1rem)] w-full min-w-xl overflow-auto rounded-md border border-gray-200 bg-white px-10 dark:border-zinc-800">
+						<TrialExpiryBanner />
 						<main className="custom-scrollbar content-container-inner relative mx-auto flex flex-col overflow-y-hidden p-4">
 							{isLoading ? <FullPageLoader /> : <FullPage config={bifrostConfig}>{children}</FullPage>}
 						</main>

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -295,6 +295,22 @@ div.content-container:has(.no-border-parent) {
 	@apply border-0!;
 }
 
+/* // trial-notification-banner style*/
+
+#trial-notification-banner {
+	width: calc(100% + 80px);
+	margin-left: -40px;
+}
+
+div.content-container:has(.no-padding-parent) #trial-notification-banner {
+	width: 100%;
+	margin-left: 0;
+}
+
+div.content-container:has(.no-border-parent) #trial-notification-banner {
+	border: 1px solid transparent;
+}
+
 /* ReactFlow Controls — follow Bifrost colour schema */
 
 .react-flow__controls {

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -28,7 +28,6 @@ import {
   Settings,
   Settings2Icon,
   ShieldCheck,
-  ShieldUser,
   Shuffle,
   SlidersHorizontal,
   Telescope,
@@ -38,7 +37,7 @@ import {
   UserRoundCheck,
   Users,
   Wallet,
-  WalletCards,
+  WalletCards
 } from "lucide-react";
 
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -58,7 +57,7 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import { useWebSocket } from "@/hooks/useWebSocket";
-import { IS_ENTERPRISE, TRIAL_EXPIRY } from "@/lib/constants/config";
+import { IS_ENTERPRISE } from "@/lib/constants/config";
 import {
   useGetCoreConfigQuery,
   useGetLatestReleaseQuery,
@@ -71,7 +70,6 @@ import type { UserInfo } from "@enterprise/lib/store/utils/tokenManager";
 import { getUserInfo } from "@enterprise/lib/store/utils/tokenManager";
 import { BooksIcon, DiscordLogoIcon, GithubLogoIcon } from "@phosphor-icons/react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
-import { differenceInDays } from "date-fns";
 import { ChevronRight } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -252,15 +250,14 @@ const SidebarItemView = ({
 
   const isHighlighted = !hasSubItems && highlightedUrl === item.url;
 
-  const buttonClassName = `relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${
-    isHighlighted
-      ? "bg-sidebar-accent text-accent-foreground border-primary/20"
-      : isActive || isAnySubItemActive
-        ? "bg-sidebar-accent text-primary border-primary/20"
-        : item.hasAccess
-          ? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
-          : "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-  } `;
+  const buttonClassName = `relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${isHighlighted
+    ? "bg-sidebar-accent text-accent-foreground border-primary/20"
+    : isActive || isAnySubItemActive
+      ? "bg-sidebar-accent text-primary border-primary/20"
+      : item.hasAccess
+        ? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
+        : "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
+    } `;
 
   const innerContent = (
     <div className="flex w-full items-center justify-between">
@@ -455,15 +452,14 @@ const SidebarItemView = ({
               ? subItemHref.startsWith(highlightedUrl)
               : false;
             const SubItemIcon = subItem.icon;
-            const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${
-              isSubItemHighlighted
-                ? "bg-sidebar-accent text-accent-foreground"
-                : isSubItemActive
-                  ? "bg-sidebar-accent text-primary font-medium"
-                  : subItem.hasAccess === false
-                    ? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-                    : "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
-            }`;
+            const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${isSubItemHighlighted
+              ? "bg-sidebar-accent text-accent-foreground"
+              : isSubItemActive
+                ? "bg-sidebar-accent text-primary font-medium"
+                : subItem.hasAccess === false
+                  ? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
+                  : "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
+              }`;
             const subInner = (
               <div className="flex w-full items-center gap-2">
                 {SubItemIcon && (
@@ -835,14 +831,14 @@ export default function AppSidebar() {
       },
       ...(isDbConnected
         ? [
-            {
-              title: "Prompt Repository",
-              url: "/workspace/prompt-repo",
-              icon: FolderGit,
-              description: "Prompt repository",
-              hasAccess: hasPromptRepositoryAccess,
-            },
-          ]
+          {
+            title: "Prompt Repository",
+            url: "/workspace/prompt-repo",
+            icon: FolderGit,
+            description: "Prompt repository",
+            hasAccess: hasPromptRepositoryAccess,
+          },
+        ]
         : []),
       {
         title: "Evals",
@@ -889,14 +885,14 @@ export default function AppSidebar() {
           },
           ...(IS_ENTERPRISE
             ? [
-                {
-                  title: "Proxy",
-                  url: "/workspace/config/proxy",
-                  icon: Globe,
-                  description: "Proxy configuration",
-                  hasAccess: hasSettingsAccess,
-                },
-              ]
+              {
+                title: "Proxy",
+                url: "/workspace/config/proxy",
+                icon: Globe,
+                description: "Proxy configuration",
+                hasAccess: hasSettingsAccess,
+              },
+            ]
             : []),
           {
             title: "API Keys",
@@ -1253,14 +1249,6 @@ export default function AppSidebar() {
     }
   };
 
-  const trialDaysRemaining = useMemo(() => {
-    if (IS_ENTERPRISE && TRIAL_EXPIRY) {
-      const daysRemaining = differenceInDays(new Date(TRIAL_EXPIRY), new Date());
-      return daysRemaining > 0 ? daysRemaining : 0;
-    }
-    return null;
-  }, []);
-
   const { state: sidebarState, toggleSidebar } = useSidebar();
 
   return (
@@ -1429,16 +1417,6 @@ export default function AppSidebar() {
           </div>
           <div className="mx-auto flex flex-col items-center gap-1 group-data-[collapsible=icon]:hidden">
             <div className="font-mono text-xs">{version ?? ""}</div>
-            {trialDaysRemaining !== null && (
-              <div
-                className={cn(
-                  "text-xs",
-                  trialDaysRemaining < 3 ? "text-red-500" : "text-muted-foreground",
-                )}
-              >
-                {trialDaysRemaining} {trialDaysRemaining === 1 ? "day" : "days"} remaining
-              </div>
-            )}
           </div>
         </div>
       </SidebarContent>

--- a/ui/components/trialExpiryBanner.tsx
+++ b/ui/components/trialExpiryBanner.tsx
@@ -1,0 +1,50 @@
+import { TRIAL_EXPIRY } from "@/lib/constants/config";
+import { cn } from "@/lib/utils";
+import { differenceInDays } from "date-fns";
+import { AlertTriangle } from "lucide-react";
+
+export default function TrialExpiryBanner() {
+	if (!TRIAL_EXPIRY) return null;
+
+	const daysRemaining = differenceInDays(TRIAL_EXPIRY, new Date());
+	const expired = daysRemaining < 0;
+	if (!expired && daysRemaining > 7) return null;
+	const critical = !expired && daysRemaining <= 3;
+
+	const subject = expired
+		? "I need help with my expired enterprise trial"
+		: "I need help extending my enterprise trial";
+	const supportHref = `mailto:contact@getmaxim.ai?subject=${encodeURIComponent(subject)}`;
+
+	return (
+		<div
+			id="trial-notification-banner"
+			className={cn(
+				"sticky top-0 z-10 flex w-full items-center justify-center gap-2 rounded-tl-md rounded-tr-md px-4 py-2 text-xs font-medium",
+				expired || critical
+					? "bg-red-500/10 text-red-700 dark:text-red-400"
+					: "bg-amber-500/10 text-amber-700 dark:text-amber-400",
+			)}
+			role="status"
+		>
+			<AlertTriangle className="h-3.5 w-3.5" strokeWidth={2} />
+			{expired ? (
+				<span>
+					Your Bifrost Enterprise Trial has expired.{" "}
+					<a href={supportHref} className="font-semibold underline underline-offset-2">
+						Contact us
+					</a>{" "}
+					if you need any assistance.
+				</span>
+			) : (
+				<span>
+					Your Bifrost Enterprise Trial expires in {daysRemaining} {daysRemaining === 1 ? "day" : "days"}.{" "}
+					<a href={supportHref} className="font-semibold underline underline-offset-2">
+						Contact us
+					</a>{" "}
+					if you need any assistance.
+				</span>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Replaces the inline trial countdown text in the sidebar footer with a dedicated `TrialExpiryBanner` component rendered at the top of the main content area. The banner provides clearer, more prominent visibility of trial status and includes a direct support contact link for both active and expired trials.

## Changes

- Added `TrialExpiryBanner` component that renders a sticky top banner inside the content container, showing days remaining or an expiry notice with a mailto support link
- Banner styling adapts based on urgency: amber for active trials within 7 days, red for critical (≤ 3 days) or expired trials
- Banner is suppressed entirely when `TRIAL_EXPIRY` is unset or more than 7 days remain
- Removed the trial countdown display from the sidebar footer along with its associated `differenceInDays` and `TRIAL_EXPIRY` imports from `sidebar.tsx`
- Added CSS rules for `#trial-notification-banner` to handle full-bleed width compensation (`calc(100% + 80px)` / `-40px` margin) and edge cases for no-padding and no-border parent layouts

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Expected outcomes:
- Amber banner shown when trial has between 4–7 days remaining
- Red banner shown when trial has 3 or fewer days remaining or has expired
- No banner shown when `TRIAL_EXPIRY` is unset or more than 7 days remain
- Support mailto link opens with a pre-filled subject line appropriate to the trial state

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable