### PR TITLE
fix: avoid provider update stalls under high load

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -69,6 +69,9 @@ type Bifrost struct {
 	providers           atomic.Pointer[[]schemas.Provider]  // list of providers
 	requestQueues       sync.Map                            // provider request queues (thread-safe), stores *ProviderQueue
 	waitGroups          sync.Map                            // wait groups for each provider (thread-safe)
+	oldWorkerCleanups   sync.WaitGroup                      // tracks async cleanup of old workers after provider updates
+	retiredWorkerWaits  sync.Map                            // provider old-worker cleanup wait groups (thread-safe), stores *sync.WaitGroup
+	providerLifecycleMu sync.RWMutex                        // prevents provider updates from racing with shutdown cleanup waits
 	providerMutexes     sync.Map                            // mutexes for each provider to prevent concurrent updates (thread-safe)
 	channelMessagePool  sync.Pool                           // Pool for ChannelMessage objects, initial pool size is set in Init
 	responseChannelPool sync.Pool                           // Pool for response channels, initial pool size is set in Init
@@ -3197,6 +3200,15 @@ func (bifrost *Bifrost) RemoveProvider(providerKey schemas.ModelProvider) error 
 	// Step 3b: Final drain sweep — see drainQueueWithErrors for full explanation.
 	bifrost.drainQueueWithErrors(pq)
 
+	// Step 3c: Wait for retired worker generations from earlier provider updates.
+	// They are no longer tracked in bifrost.waitGroups after a new generation is
+	// published, but removing the provider must still wait for their in-flight work.
+	if retiredWaitValue, exists := bifrost.retiredWorkerWaits.Load(providerKey); exists {
+		retiredWaitValue.(*sync.WaitGroup).Wait()
+		bifrost.retiredWorkerWaits.Delete(providerKey)
+		bifrost.logger.Debug("all retired workers for provider %s have stopped", providerKey)
+	}
+
 	// Step 4: Remove the provider from the request queues.
 	bifrost.requestQueues.Delete(providerKey)
 
@@ -3234,15 +3246,19 @@ func (bifrost *Bifrost) RemoveProvider(providerKey schemas.ModelProvider) error 
 // while the transition occurs. In-flight requests will complete before workers are stopped.
 // Buffered requests in the old queue will be transferred to the new queue to prevent loss.
 //
-// Concurrency safety — no-worker window:
-// UpdateProvider holds a per-provider write lock (providerMutex.Lock) for its entire
-// duration. All producer paths (tryRequest, tryStreamRequest) acquire the corresponding
-// read lock inside getProviderQueue before they can look up or enqueue into any queue.
-// This means no producer can observe or enqueue into newPq until UpdateProvider returns
-// and releases the write lock — at which point new workers are already running and
-// consuming newPq. There is therefore no window where newPq is visible to producers
-// but has zero workers.
+// Concurrency safety — update handoff:
+// UpdateProvider holds a per-provider write lock only while publishing the new
+// provider instance, queue, and workers. It starts the new workers before the
+// old queue is signalled closed, then releases the lock before old workers are
+// waited on. This avoids high-load updates blocking new requests behind the
+// provider read lock while slow in-flight old-worker requests finish.
 func (bifrost *Bifrost) UpdateProvider(providerKey schemas.ModelProvider) error {
+	bifrost.providerLifecycleMu.RLock()
+	defer bifrost.providerLifecycleMu.RUnlock()
+	if bifrost.ctx.Err() != nil {
+		return fmt.Errorf("bifrost is shutting down")
+	}
+
 	bifrost.logger.Info(fmt.Sprintf("Updating provider configuration for provider %s", providerKey))
 	// Get the updated configuration from the account
 	providerConfig, err := bifrost.account.GetConfigForProvider(providerKey)
@@ -3252,7 +3268,8 @@ func (bifrost *Bifrost) UpdateProvider(providerKey schemas.ModelProvider) error 
 	if providerConfig == nil {
 		return fmt.Errorf("config is nil for provider %s", providerKey)
 	}
-	// Lock the provider to prevent concurrent access during update
+	// Lock the provider while publishing the new runtime state. The slow cleanup
+	// of old workers happens after unlock so new requests can route to newPq.
 	providerMutex := bifrost.getProviderMutex(providerKey)
 	providerMutex.Lock()
 	defer providerMutex.Unlock()
@@ -3266,29 +3283,91 @@ func (bifrost *Bifrost) UpdateProvider(providerKey schemas.ModelProvider) error 
 	}
 
 	oldPq := oldPqValue.(*ProviderQueue)
+	var oldWaitGroup *sync.WaitGroup
+	if waitGroupValue, exists := bifrost.waitGroups.Load(providerKey); exists {
+		oldWaitGroup = waitGroupValue.(*sync.WaitGroup)
+	}
 
-	bifrost.logger.Debug("gracefully stopping existing workers for provider %s", providerKey)
+	bifrost.logger.Debug("gracefully replacing existing workers for provider %s", providerKey)
 
-	// Step 1: Create new ProviderQueue with updated buffer size
+	// Step 1: Create provider instance before touching live routing state. If
+	// provider construction fails, the old provider/queue continues serving.
+	provider, err := bifrost.createBaseProvider(providerKey, providerConfig)
+	if err != nil {
+		return fmt.Errorf("provider update for %s failed during initialization; old provider is still active: %v", providerKey, err)
+	}
+
+	// Step 2: Create new ProviderQueue and wait group with updated settings.
 	newPq := &ProviderQueue{
 		queue:      make(chan *ChannelMessage, providerConfig.ConcurrencyAndBufferSize.BufferSize),
 		done:       make(chan struct{}),
 		signalOnce: sync.Once{},
 	}
+	newWaitGroup := &sync.WaitGroup{}
 
-	// Step 2: Atomically replace the queue so new producers immediately use newPq.
+	// Step 3: Atomically replace the provider in the providers slice before new
+	// workers start so all fresh worker executions use the updated provider.
+	bifrost.logger.Debug("atomically replacing provider instance in providers slice for %s", providerKey)
+
+	replacementAttempts := 0
+	maxReplacementAttempts := 100 // Prevent infinite loops in high-contention scenarios
+
+	for {
+		replacementAttempts++
+		if replacementAttempts > maxReplacementAttempts {
+			return fmt.Errorf("failed to replace provider %s in providers slice after %d attempts; old provider is still active", providerKey, maxReplacementAttempts)
+		}
+
+		oldPtr := bifrost.providers.Load()
+		var oldSlice []schemas.Provider
+		if oldPtr != nil {
+			oldSlice = *oldPtr
+		}
+
+		newSlice := make([]schemas.Provider, 0, len(oldSlice))
+		oldProviderFound := false
+
+		for _, existingProvider := range oldSlice {
+			if existingProvider.GetProviderKey() != providerKey {
+				newSlice = append(newSlice, existingProvider)
+			} else {
+				oldProviderFound = true
+			}
+		}
+
+		newSlice = append(newSlice, provider)
+
+		if bifrost.providers.CompareAndSwap(oldPtr, &newSlice) {
+			if oldProviderFound {
+				bifrost.logger.Debug("successfully replaced existing provider instance for %s in providers slice", providerKey)
+			} else {
+				bifrost.logger.Debug("successfully added new provider instance for %s to providers slice", providerKey)
+			}
+			break
+		}
+		// Retrying as swapping did not work (likely due to concurrent modification)
+	}
+
+	// Step 4: Publish the new queue/wait group and start new workers before old
+	// workers are stopped. This avoids the update-induced no-worker window while
+	// still preventing new producers from seeing partial state until unlock.
 	bifrost.requestQueues.Store(providerKey, newPq)
+	bifrost.waitGroups.Store(providerKey, newWaitGroup)
 	bifrost.logger.Debug("stored new queue for provider %s, new producers will use it", providerKey)
 
-	// Step 3: Transfer buffered requests from the old queue to the new queue BEFORE
-	// signalling workers to stop. This ensures buffered requests are processed by the
-	// new workers rather than being drained with errors.
-	// Old workers are still running and may consume some items concurrently — that is
-	// fine, they process them normally.
-	// If newPq is full during transfer, all remaining buffered requests are cancelled
-	// immediately rather than blocking — this avoids the deadlock where transfer goroutines
-	// wait for space that only opens once new workers start (which can't happen until
-	// the transfer completes).
+	bifrost.logger.Debug("starting %d new workers for provider %s with buffer size %d",
+		providerConfig.ConcurrencyAndBufferSize.Concurrency,
+		providerKey,
+		providerConfig.ConcurrencyAndBufferSize.BufferSize)
+	for range providerConfig.ConcurrencyAndBufferSize.Concurrency {
+		newWaitGroup.Add(1)
+		go bifrost.requestWorker(provider, providerConfig, newPq, newWaitGroup)
+	}
+
+	// Step 5: Transfer buffered requests from the old queue to the new queue BEFORE
+	// signalling workers to stop. Old workers are still running and may consume some
+	// items concurrently — that is fine, they process them normally. Since new
+	// workers are already running, successful transfers can be processed immediately.
 	transferredCount := 0
 	cancelledCount := 0
 	for {
@@ -3340,123 +3419,34 @@ transferComplete:
 		bifrost.logger.Warn("cancelled %d buffered requests during transfer for provider %s: new queue was full", cancelledCount, providerKey)
 	}
 
-	// Step 4: Signal the old queue is closing. Producers that still hold a reference to
-	// oldPq will detect this via isClosing() and transparently re-route to newPq.
-	// This happens after the transfer so the new queue is already populated before
-	// stale producers attempt their re-route.
+	// Step 6: Register cleanup before signalling the old queue. Otherwise
+	// Shutdown/RemoveProvider can observe no pending old-worker cleanup after the
+	// old wait group is replaced, then return while old in-flight requests run.
+	var retiredWaitGroup *sync.WaitGroup
+	if oldWaitGroup != nil {
+		retiredWaitGroup = bifrost.getRetiredWorkerWaitGroup(providerKey)
+		retiredWaitGroup.Add(1)
+		bifrost.oldWorkerCleanups.Add(1)
+	}
+
+	// Step 7: Signal the old queue is closing. Stale producers that still hold a
+	// reference to oldPq will detect this via isClosing() and re-route to newPq.
 	oldPq.signalClosing()
 	bifrost.logger.Debug("signaled closing for old queue of provider %s", providerKey)
 
-	// Step 5: Wait for all existing workers to finish processing in-flight requests.
-	// Workers exit via oldPq.done (signalled above).
-	waitGroup, exists := bifrost.waitGroups.Load(providerKey)
-	if exists {
-		waitGroup.(*sync.WaitGroup).Wait()
-		bifrost.logger.Debug("all workers for provider %s have stopped", providerKey)
-	}
-
-	// Step 5b: Final drain sweep — see drainQueueWithErrors for full explanation.
-	bifrost.drainQueueWithErrors(oldPq)
-
-	// Step 6: Create new wait group for the updated workers.
-	bifrost.waitGroups.Store(providerKey, &sync.WaitGroup{})
-
-	// Step 7: Create provider instance.
-	provider, err := bifrost.createBaseProvider(providerKey, providerConfig)
-	if err != nil {
-		// Roll back: signal closing, remove from map, then drain.
-		// Order matters: Delete before drainQueueWithErrors so that producers
-		// re-routing via requestQueues.Load find nothing and return "provider
-		// shutting down" immediately, narrowing the TOCTOU window before the sweep.
-		newPq.signalClosing()
-		bifrost.requestQueues.Delete(providerKey)
-		bifrost.waitGroups.Delete(providerKey)
-		bifrost.drainQueueWithErrors(newPq)
-		if sliceErr := bifrost.removeProviderFromSlice(providerKey); sliceErr != nil {
-			bifrost.logger.Error(
-				"UpdateProvider rollback for %s is incomplete — provider was removed from queues "+
-					"but could not be removed from the providers slice: %v. "+
-					"bifrost.providers is now inconsistent. "+
-					"To recover: call RemoveProvider(%s) then AddProvider to re-register it, "+
-					"or restart Bifrost if that fails.",
-				providerKey, sliceErr, providerKey,
-			)
-		}
-		return fmt.Errorf("provider update for %s failed during initialization; provider has been removed — re-add or retry UpdateProvider to restore it: %v", providerKey, err)
-	}
-
-	// Step 8: Atomically replace the provider in the providers slice.
-	// This must happen before starting new workers to prevent stale reads
-	bifrost.logger.Debug("atomically replacing provider instance in providers slice for %s", providerKey)
-
-	replacementAttempts := 0
-	maxReplacementAttempts := 100 // Prevent infinite loops in high-contention scenarios
-
-	for {
-		replacementAttempts++
-		if replacementAttempts > maxReplacementAttempts {
-			newPq.signalClosing()
-			bifrost.requestQueues.Delete(providerKey)
-			bifrost.waitGroups.Delete(providerKey)
-			bifrost.drainQueueWithErrors(newPq)
-			if sliceErr := bifrost.removeProviderFromSlice(providerKey); sliceErr != nil {
-				bifrost.logger.Error(
-					"UpdateProvider rollback for %s is incomplete — provider was removed from queues "+
-						"but could not be removed from the providers slice: %v. "+
-						"bifrost.providers is now inconsistent. "+
-						"To recover: call RemoveProvider(%s) then AddProvider to re-register it, "+
-						"or restart Bifrost if that fails.",
-					providerKey, sliceErr, providerKey,
-				)
-			}
-			return fmt.Errorf("failed to replace provider %s in providers slice after %d attempts; provider has been removed — re-add or retry UpdateProvider to restore it", providerKey, maxReplacementAttempts)
-		}
-
-		oldPtr := bifrost.providers.Load()
-		var oldSlice []schemas.Provider
-		if oldPtr != nil {
-			oldSlice = *oldPtr
-		}
-
-		// Create new slice without the old provider of this key
-		// Use exact capacity to avoid allocations
-		newSlice := make([]schemas.Provider, 0, len(oldSlice))
-		oldProviderFound := false
-
-		for _, existingProvider := range oldSlice {
-			if existingProvider.GetProviderKey() != providerKey {
-				newSlice = append(newSlice, existingProvider)
-			} else {
-				oldProviderFound = true
-			}
-		}
-
-		// Add the new provider
-		newSlice = append(newSlice, provider)
-
-		if bifrost.providers.CompareAndSwap(oldPtr, &newSlice) {
-			if oldProviderFound {
-				bifrost.logger.Debug("successfully replaced existing provider instance for %s in providers slice", providerKey)
-			} else {
-				bifrost.logger.Debug("successfully added new provider instance for %s to providers slice", providerKey)
-			}
-			break
-		}
-		// Retrying as swapping did not work (likely due to concurrent modification)
-	}
-
-	// Step 9: Start new workers with updated concurrency.
-	bifrost.logger.Debug("starting %d new workers for provider %s with buffer size %d",
-		providerConfig.ConcurrencyAndBufferSize.Concurrency,
-		providerKey,
-		providerConfig.ConcurrencyAndBufferSize.BufferSize)
-
-	waitGroupValue, _ := bifrost.waitGroups.Load(providerKey)
-	currentWaitGroup := waitGroupValue.(*sync.WaitGroup)
-
-	for range providerConfig.ConcurrencyAndBufferSize.Concurrency {
-		currentWaitGroup.Add(1)
-		go bifrost.requestWorker(provider, providerConfig, newPq)
+	// Step 8: Cleanup old workers asynchronously. Waiting here under the provider
+	// lock caused high-load provider updates to block new requests until every slow
+	// in-flight old-worker request completed.
+	if oldWaitGroup != nil {
+		go func(pq *ProviderQueue, wg *sync.WaitGroup, cleanupWg *sync.WaitGroup, key schemas.ModelProvider) {
+			defer bifrost.oldWorkerCleanups.Done()
+			defer cleanupWg.Done()
+			wg.Wait()
+			bifrost.logger.Debug("all old workers for provider %s have stopped", key)
+			bifrost.drainQueueWithErrors(pq)
+		}(oldPq, oldWaitGroup, retiredWaitGroup, providerKey)
+	} else {
+		bifrost.drainQueueWithErrors(oldPq)
 	}
 
 	bifrost.logger.Info("successfully updated provider configuration for provider %s", providerKey)
@@ -3479,6 +3469,13 @@ func (bifrost *Bifrost) UpdateDropExcessRequests(value bool) {
 func (bifrost *Bifrost) getProviderMutex(providerKey schemas.ModelProvider) *sync.RWMutex {
 	mutexValue, _ := bifrost.providerMutexes.LoadOrStore(providerKey, &sync.RWMutex{})
 	return mutexValue.(*sync.RWMutex)
+}
+
+// getRetiredWorkerWaitGroup gets or creates a wait group for retired worker
+// generations for the given provider.
+func (bifrost *Bifrost) getRetiredWorkerWaitGroup(providerKey schemas.ModelProvider) *sync.WaitGroup {
+	waitGroupValue, _ := bifrost.retiredWorkerWaits.LoadOrStore(providerKey, &sync.WaitGroup{})
+	return waitGroupValue.(*sync.WaitGroup)
 }
 
 // removeProviderFromSlice atomically removes the provider with the given key
@@ -3912,7 +3909,7 @@ func (bifrost *Bifrost) prepareProvider(providerKey schemas.ModelProvider, confi
 
 	for range config.ConcurrencyAndBufferSize.Concurrency {
 		currentWaitGroup.Add(1)
-		go bifrost.requestWorker(provider, config, pq)
+		go bifrost.requestWorker(provider, config, pq, currentWaitGroup)
 	}
 
 	return nil
@@ -5460,13 +5457,8 @@ func executeRequestWithRetries[T any](
 
 // requestWorker handles incoming requests from the queue for a specific provider.
 // It manages retries, error handling, and response processing.
-func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas.ProviderConfig, pq *ProviderQueue) {
-	defer func() {
-		if waitGroupValue, ok := bifrost.waitGroups.Load(provider.GetProviderKey()); ok {
-			waitGroup := waitGroupValue.(*sync.WaitGroup)
-			waitGroup.Done()
-		}
-	}()
+func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas.ProviderConfig, pq *ProviderQueue, waitGroup *sync.WaitGroup) {
+	defer waitGroup.Done()
 
 	for {
 		var req *ChannelMessage
@@ -7335,6 +7327,9 @@ func getCachedKeyFromStore(kvStore schemas.KVStore, kvKey string, supportedKeys 
 // Shutdown gracefully stops all workers when triggered.
 // It closes all request channels and waits for workers to exit.
 func (bifrost *Bifrost) Shutdown() {
+	bifrost.providerLifecycleMu.Lock()
+	defer bifrost.providerLifecycleMu.Unlock()
+
 	bifrost.logger.Info("closing all request channels...")
 	// Cancel the context if not already done
 	if bifrost.ctx.Err() == nil && bifrost.cancel != nil {
@@ -7355,6 +7350,11 @@ func (bifrost *Bifrost) Shutdown() {
 		waitGroup.Wait()
 		return true
 	})
+
+	// Wait for async cleanup of old workers from provider updates. Those old
+	// wait groups are no longer in bifrost.waitGroups after the new queue is
+	// published, but Shutdown must still wait for their in-flight requests.
+	bifrost.oldWorkerCleanups.Wait()
 
 	// Final drain sweep — same reasoning as RemoveProvider's Step 3b.
 	bifrost.requestQueues.Range(func(key, value interface{}) bool {


### PR DESCRIPTION
## Summary

Fix provider updates under high load so new requests can continue using a freshly published provider queue while old in-flight requests finish in the background.

## Changes

- Reworked provider update handoff to build the new provider instance before changing live routing state.
- Published the new provider queue and wait group, then started new workers before closing the old queue.
- Transferred buffered requests from the old queue to the new queue where possible.
- Cleaned up old workers asynchronously instead of blocking the provider update path.
- Tracked async old-worker cleanup jobs so `Shutdown()` waits for old in-flight requests before returning.
- Ensure provider removal also waits for retired old-worker generations from prior provider updates before returning
- Passed each worker its own wait group so old and new workers can coexist safely during handoff.
- Passed `providerKey` explicitly into the async cleanup closure for clearer capture semantics.
- Trade-off: during the handoff window, old and new workers can briefly coexist, but this avoids blocking new traffic while slow old requests finish.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the focused core tests for provider queue/update behavior:

```sh
direnv exec . go test ./core -run 'TestProviderQueue|TestUpdateProvider'
```

Expected outcome: tests pass successfully.

Manual validation performed:

```sh
# Start delayed mock OpenAI provider and Bifrost, then run sustained load against mock-openai.
# While load is active, update mock-openai provider/key configuration.
```

Expected outcome: provider update completes quickly and new requests continue through the newly published provider queue while old in-flight requests finish in the background. On shutdown, both current workers and async cleanup of old update workers are waited on before shutdown completes.

No new configs or environment variables were added.

## Screenshots/Recordings

Not applicable; this is a Core Go behavior fix with no UI changes.

## Breaking changes

- [ ] Yes
- [x] No

No migration required.

## Related issues

BF-691

## Security considerations

No auth, secrets, PII, or sandboxing behavior was changed. This only changes provider update handoff and shutdown cleanup behavior inside the Core request processing path.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
