### PR TITLE
feat: support OAuth credential rotation (`client_id`/`client_secret`) for existing MCP clients via edit flow

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -3837,6 +3837,14 @@ func (bifrost *Bifrost) UpdateMCPClient(id string, updatedConfig *schemas.MCPCli
 	return bifrost.MCPManager.UpdateClient(id, updatedConfig)
 }
 
+// UpdateMCPClientConnection reconnects an existing MCP client using updated headers
+func (bifrost *Bifrost) UpdateMCPClientConnection(id string, newConfig *schemas.MCPClientConfig) error {
+	if bifrost.MCPManager == nil {
+		return fmt.Errorf("mcp is not configured in this bifrost instance")
+	}
+	return bifrost.MCPManager.UpdateClientConnection(id, newConfig)
+}
+
 // ReconnectMCPClient attempts to reconnect an MCP client if it is disconnected.
 //
 // Parameters:

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -47,6 +47,12 @@ func (m *MCPManager) GetClients() []schemas.MCPClientState {
 // Returns:
 //   - error: Any error that occurred during reconnection
 func (m *MCPManager) ReconnectClient(id string) error {
+	// Acquire per-client reconnect/update guard before reading config snapshot.
+	if _, alreadyReconnecting := m.reconnectingClients.LoadOrStore(id, true); alreadyReconnecting {
+		return fmt.Errorf("reconnect already in progress for this client")
+	}
+	defer m.reconnectingClients.Delete(id)
+
 	m.mu.Lock()
 	client, ok := m.clientMap[id]
 	if !ok {
@@ -61,14 +67,6 @@ func (m *MCPManager) ReconnectClient(id string) error {
 	}
 	config := client.ExecutionConfig
 	m.mu.Unlock()
-
-	// Guard against concurrent reconnects for the same client from any caller
-	// (health monitor, manual API call, etc.). LoadOrStore is atomic — whichever
-	// caller arrives second gets the "already in progress" error immediately.
-	if _, alreadyReconnecting := m.reconnectingClients.LoadOrStore(id, true); alreadyReconnecting {
-		return fmt.Errorf("reconnect already in progress for this client")
-	}
-	defer m.reconnectingClients.Delete(id)
 
 	// Reconnect using the client's configuration
 	// Retry logic is handled internally by connectToMCPClient
@@ -347,6 +345,11 @@ func (m *MCPManager) DisableClient(id string) error {
 	if id == BifrostMCPClientKey {
 		return fmt.Errorf("cannot disable internal bifrost client")
 	}
+	// Use LoadOrStore (not Load) so the check and the sentinel insertion are atomic.
+	if _, alreadyInFlight := m.reconnectingClients.LoadOrStore(id, true); alreadyInFlight {
+		return fmt.Errorf("reconnect or connection credential update already in progress for MCP client %s", id)
+	}
+	defer m.reconnectingClients.Delete(id)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -482,6 +485,11 @@ func (m *MCPManager) EnableClient(id string) error {
 // Returns:
 //   - error: Any error that occurred during client update or tool retrieval
 func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientConfig) error {
+	if _, alreadyInFlight := m.reconnectingClients.LoadOrStore(id, true); alreadyInFlight {
+		return fmt.Errorf("reconnect or connection credential update already in progress for MCP client %s", id)
+	}
+	defer m.reconnectingClients.Delete(id)
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -506,8 +514,25 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 	if updatedConfig.InProcessServer != nil && updatedConfig.InProcessServer != client.ExecutionConfig.InProcessServer {
 		return fmt.Errorf("in-process server cannot be updated for client %s", id)
 	}
+	// Normalize empty AuthType to "headers" — both are semantically identical
+	oldAuthType := client.ExecutionConfig.AuthType
+	if oldAuthType == "" {
+		oldAuthType = schemas.MCPAuthTypeHeaders
+	}
+	newAuthType := updatedConfig.AuthType
+	if newAuthType == "" {
+		newAuthType = schemas.MCPAuthTypeHeaders
+	}
+	if newAuthType != oldAuthType {
+		return fmt.Errorf("auth_type cannot be updated for client %s", id)
+	}
 
 	oldName := client.ExecutionConfig.Name
+
+	oauthConfigID := client.ExecutionConfig.OauthConfigID
+	if updatedConfig.OauthConfigID != nil {
+		oauthConfigID = updatedConfig.OauthConfigID
+	}
 
 	// Create a new config struct (immutable pattern) to avoid race conditions
 	// with concurrent reads. Any snapshot holding the old ExecutionConfig pointer
@@ -519,7 +544,7 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 		ConnectionString: client.ExecutionConfig.ConnectionString,
 		StdioConfig:      client.ExecutionConfig.StdioConfig,
 		AuthType:         client.ExecutionConfig.AuthType,
-		OauthConfigID:    client.ExecutionConfig.OauthConfigID,
+		OauthConfigID:    oauthConfigID,
 		State:            client.ExecutionConfig.State,
 		InProcessServer:  client.ExecutionConfig.InProcessServer,
 		ConfigHash:       client.ExecutionConfig.ConfigHash,
@@ -571,6 +596,73 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 
 		// Also update the client Name field
 		client.Name = updatedConfig.Name
+	}
+
+	return nil
+}
+
+// UpdateClientConnection updates auth-related fields (headers) for an existing MCP client by
+// closing the current connection and establishing a new one so the new credentials are verified
+// before being committed. Non-credential metadata (name, tools, etc.) is preserved from the
+// current execution config.
+//
+// On failure the clientMap entry is left in Disconnected state but its ExecutionConfig is restored
+// to the previous value, allowing the health monitor to recover the client using the old credentials.
+//
+// Parameters:
+//   - id: ID of the client whose credentials should be updated
+//   - newConfig: Partial config carrying the updated auth fields (Headers). All other fields
+//     are ignored and taken from the current execution config.
+//
+// Returns:
+//   - error: Any connection error; nil on success
+func (m *MCPManager) UpdateClientConnection(id string, newConfig *schemas.MCPClientConfig) error {
+	if newConfig == nil {
+		return fmt.Errorf("newConfig must not be nil")
+	}
+	// Hold the per-client reconnect guard for the entire read + long reconnect so
+	// UpdateClient/DisableClient cannot mutate ExecutionConfig while a failed reconnect
+	// restores the pre-attempt snapshot.
+	if _, alreadyReconnecting := m.reconnectingClients.LoadOrStore(id, true); alreadyReconnecting {
+		return fmt.Errorf("reconnect already in progress for this client")
+	}
+	defer m.reconnectingClients.Delete(id)
+
+	m.mu.RLock()
+	client, ok := m.clientMap[id]
+	if !ok {
+		m.mu.RUnlock()
+		return fmt.Errorf("client %s not found", id)
+	}
+	// Per-user OAuth clients have no persistent connection — reconnect is not applicable.
+	if client.ExecutionConfig != nil && client.ExecutionConfig.AuthType == schemas.MCPAuthTypePerUserOauth {
+		m.mu.RUnlock()
+		return fmt.Errorf("connection update is not supported for per_user_oauth clients")
+	}
+	if client.ExecutionConfig == nil {
+		m.mu.RUnlock()
+		return fmt.Errorf("client %s has no execution config; cannot update connection", id)
+	}
+	// Snapshot old execution config and build the merged config while still holding the
+	// read lock so the struct copy is consistent with what the map currently holds.
+	oldConfig := client.ExecutionConfig
+	mergedConfig := *oldConfig
+	if newConfig.Headers != nil {
+		mergedConfig.Headers = maps.Clone(newConfig.Headers)
+	}
+	if newConfig.OauthConfigID != nil {
+		mergedConfig.OauthConfigID = newConfig.OauthConfigID
+	}
+	m.mu.RUnlock()
+
+	// connectToMCPClient will close the current connection and create a new clientMap entry.
+	if err := m.connectToMCPClient(&mergedConfig); err != nil {
+		m.mu.Lock()
+		if cs, exists := m.clientMap[id]; exists {
+			cs.ExecutionConfig = oldConfig
+		}
+		m.mu.Unlock()
+		return fmt.Errorf("failed to reconnect with updated credentials: %w", err)
 	}
 
 	return nil

--- a/core/mcp/interface.go
+++ b/core/mcp/interface.go
@@ -59,6 +59,10 @@ type MCPManagerInterface interface {
 	// UpdateClient updates an existing MCP client configuration
 	UpdateClient(id string, updatedConfig *schemas.MCPClientConfig) error
 
+	// UpdateClientConnection reconnects an existing MCP client using updated
+	// auth-related connection fields (for example, headers and OAuth config).
+	UpdateClientConnection(id string, newConfig *schemas.MCPClientConfig) error
+
 	// ReconnectClient reconnects an MCP client by ID
 	ReconnectClient(id string) error
 

--- a/docs/mcp/connecting-to-servers.mdx
+++ b/docs/mcp/connecting-to-servers.mdx
@@ -112,6 +112,10 @@ Use OAuth 2.0 for secure, user-based authentication with automatic token refresh
 - Admin-managed third-party connections
 - Compliance with OAuth 2.0 standards
 
+<Note>
+For existing MCP clients, the edit flow supports rotating OAuth credentials (`client_id` and `client_secret`) while preserving the same client ID. Connection type, auth type, and connection URL remain immutable after creation.
+</Note>
+
 #### Per-User OAuth
 
 Use per-user OAuth when each end-user should access the upstream service under their own account (e.g., each user's personal Notion workspace or GitHub repos). Bifrost acts as an OAuth 2.1 Authorization Server - users authenticate through a consent flow and their tokens are stored per-identity.

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1509,6 +1509,22 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		if err != nil {
 			return fmt.Errorf("failed to marshal tool_pricing: %w", err)
 		}
+		discoveredToolsJSON := ""
+		if clientConfig.DiscoveredTools != nil {
+			data, marshalErr := json.Marshal(clientConfig.DiscoveredTools)
+			if marshalErr != nil {
+				return fmt.Errorf("failed to marshal discovered_tools: %w", marshalErr)
+			}
+			discoveredToolsJSON = string(data)
+		}
+		toolNameMappingJSON := ""
+		if clientConfig.DiscoveredToolNameMapping != nil {
+			data, marshalErr := json.Marshal(clientConfig.DiscoveredToolNameMapping)
+			if marshalErr != nil {
+				return fmt.Errorf("failed to marshal tool_name_mapping: %w", marshalErr)
+			}
+			toolNameMappingJSON = string(data)
+		}
 
 		headersJSONStr := string(headersJSON)
 		if encrypt.IsEnabled() && headersJSONStr != "" && headersJSONStr != "{}" {
@@ -1536,6 +1552,15 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		}
 		if encrypt.IsEnabled() {
 			updates["encryption_status"] = encryptionStatusEncrypted
+		}
+		if clientConfigCopy.OauthConfigID != nil {
+			updates["oauth_config_id"] = clientConfigCopy.OauthConfigID
+		}
+		if discoveredToolsJSON != "" {
+			updates["discovered_tools_json"] = discoveredToolsJSON
+		}
+		if toolNameMappingJSON != "" {
+			updates["tool_name_mapping_json"] = toolNameMappingJSON
 		}
 		// Config-file driven reconciliation passes ConfigHash. In this mode we should
 		// also sync connection/auth metadata from config.json and persist the hash.

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -5,9 +5,11 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fasthttp/router"
@@ -26,6 +28,8 @@ type MCPManager interface {
 	AddMCPClient(ctx context.Context, clientConfig *schemas.MCPClientConfig) error
 	RemoveMCPClient(ctx context.Context, id string) error
 	UpdateMCPClient(ctx context.Context, id string, updatedConfig *schemas.MCPClientConfig) error
+	// UpdateMCPClientConnection reconnects an existing MCP client using updated headers
+	UpdateMCPClientConnection(ctx context.Context, id string, newConfig *schemas.MCPClientConfig) error
 	ReconnectMCPClient(ctx context.Context, id string) error
 	DisableMCPClient(ctx context.Context, id string) error
 	EnableMCPClient(ctx context.Context, id string) error
@@ -401,6 +405,7 @@ type MCPClientUpdateRequest struct {
 	VKConfigs          *[]MCPVKConfigRequest `json:"vk_configs,omitempty"`
 	ToolsToExecute     *schemas.WhiteList    `json:"tools_to_execute,omitempty"`
 	ToolsToAutoExecute *schemas.WhiteList    `json:"tools_to_auto_execute,omitempty"`
+	OauthConfig        *OAuthConfigRequest   `json:"oauth_config,omitempty"`
 }
 
 // addMCPClient handles POST /api/mcp/client - Add a new MCP client
@@ -721,6 +726,23 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusNotFound, "MCP client not found")
 		return
 	}
+	// connection_type and auth_type and connection string are permanently immutable
+	if req.ConnectionType != "" && req.ConnectionType != string(existingConfig.ConnectionType) {
+		SendError(ctx, fasthttp.StatusBadRequest, "connection_type cannot be changed for an existing MCP client")
+		return
+	}
+	if req.AuthType != "" && req.AuthType != string(existingConfig.AuthType) {
+		SendError(ctx, fasthttp.StatusBadRequest, "auth_type cannot be changed for an existing MCP client")
+		return
+	}
+	if req.ConnectionString != nil && !req.ConnectionString.Equals(existingConfig.ConnectionString) {
+		SendError(ctx, fasthttp.StatusBadRequest, "connection_string cannot be changed for an existing MCP client")
+		return
+	}
+	if req.StdioConfig != nil && !stdioConfigsEqual(req.StdioConfig, existingConfig.StdioConfig) {
+		SendError(ctx, fasthttp.StatusBadRequest, "stdio_config cannot be changed for an existing MCP client")
+		return
+	}
 
 	// Resolve tools_to_execute and tools_to_auto_execute.
 	resolvedToolsToExecute := existingConfig.ToolsToExecute
@@ -753,10 +775,85 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid allowed_extra_headers: %v", err))
 		return
 	}
+
+	shouldRotateOAuthConfig := req.OauthConfig != nil && (existingConfig.AuthType == schemas.MCPAuthTypeOauth || existingConfig.AuthType == schemas.MCPAuthTypePerUserOauth)
+	oauthClientID := ""
+	oauthClientSecret := ""
+	oauthAuthorizeURL := ""
+	oauthTokenURL := ""
+	oauthRegistrationURL := ""
+	oauthScopes := []string{}
+	if req.OauthConfig != nil && !shouldRotateOAuthConfig {
+		SendError(ctx, fasthttp.StatusBadRequest, "oauth_config can only be updated for MCP clients using auth_type 'oauth' or 'per_user_oauth'")
+		return
+	}
+	if shouldRotateOAuthConfig && req.Disabled {
+		SendError(ctx, fasthttp.StatusBadRequest, "oauth credentials cannot be rotated while disabling a client; send these as two separate requests")
+		return
+	}
+	if shouldRotateOAuthConfig {
+		oauthClientID = strings.TrimSpace(req.OauthConfig.ClientID)
+		oauthClientSecret = strings.TrimSpace(req.OauthConfig.ClientSecret)
+		oauthAuthorizeURL = strings.TrimSpace(req.OauthConfig.AuthorizeURL)
+		oauthTokenURL = strings.TrimSpace(req.OauthConfig.TokenURL)
+		oauthRegistrationURL = strings.TrimSpace(req.OauthConfig.RegistrationURL)
+		oauthScopes = req.OauthConfig.Scopes
+		if oauthClientID == "" && oauthClientSecret == "" {
+			SendError(ctx, fasthttp.StatusBadRequest, "oauth_config.client_id or oauth_config.client_secret is required when updating OAuth credentials")
+			return
+		}
+		var existingOauthConfig *configstoreTables.TableOauthConfig
+		if existingConfig.OauthConfigID != nil && *existingConfig.OauthConfigID != "" {
+			existingOauthConfig, err = h.store.ConfigStore.GetOauthConfigByID(ctx, *existingConfig.OauthConfigID)
+			if err != nil {
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get existing OAuth config: %v", err))
+				return
+			}
+			if existingOauthConfig != nil {
+				if oauthAuthorizeURL == "" {
+					oauthAuthorizeURL = strings.TrimSpace(existingOauthConfig.AuthorizeURL)
+				}
+				if oauthTokenURL == "" {
+					oauthTokenURL = strings.TrimSpace(existingOauthConfig.TokenURL)
+				}
+				if oauthRegistrationURL == "" && existingOauthConfig.RegistrationURL != nil {
+					oauthRegistrationURL = strings.TrimSpace(*existingOauthConfig.RegistrationURL)
+				}
+				if len(oauthScopes) == 0 && strings.TrimSpace(existingOauthConfig.Scopes) != "" {
+					var existingScopes []string
+					if err := json.Unmarshal([]byte(existingOauthConfig.Scopes), &existingScopes); err != nil {
+						SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to parse existing OAuth scopes: %v", err))
+						return
+					}
+					oauthScopes = existingScopes
+				}
+			}
+		}
+
+		if oauthClientID == "" {
+			if existingOauthConfig == nil || strings.TrimSpace(existingOauthConfig.ClientID) == "" {
+				SendError(ctx, fasthttp.StatusBadRequest, "existing OAuth client_id not found; provide oauth_config.client_id")
+				return
+			}
+			oauthClientID = strings.TrimSpace(existingOauthConfig.ClientID)
+		}
+
+		requiresDiscoveryOrRegistration := oauthClientID == "" || oauthAuthorizeURL == "" || oauthTokenURL == ""
+		if requiresDiscoveryOrRegistration && (existingConfig.ConnectionString == nil || existingConfig.ConnectionString.GetValue() == "") {
+			SendError(ctx, fasthttp.StatusBadRequest, "existing connection_string is required when OAuth discovery or dynamic registration is needed")
+			return
+		}
+	}
 	// Merge redacted values - preserve old values if incoming values are redacted and unchanged
 	merged := mergeMCPRedactedValues(&req.TableMCPClient, existingConfig, h.store.RedactMCPClientConfig(existingConfig))
 	req.TableMCPClient = *merged
-	// Save existing DB config before update so we can rollback if memory update fails
+
+	hasHeadersChange := !headersEqual(req.Headers, existingConfig.Headers)
+
+	clientWillBeDisabled := req.Disabled || existingConfig.Disabled
+	isPerUserOAuth := existingConfig.AuthType == schemas.MCPAuthTypePerUserOauth
+	willAttemptReconnect := hasHeadersChange && !clientWillBeDisabled && !isPerUserOAuth
+
 	var oldDBConfig *configstoreTables.TableMCPClient
 	if h.store.ConfigStore != nil {
 		var err error
@@ -766,15 +863,20 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 			return
 		}
 	}
-	// Persist changes to config store.
+
 	req.TableMCPClient.ToolsToExecute = resolvedToolsToExecute
 	req.TableMCPClient.ToolsToAutoExecute = resolvedToolsToAutoExecute
+	dbUpdateRecord := req.TableMCPClient
+	if willAttemptReconnect && oldDBConfig != nil {
+		dbUpdateRecord.Headers = oldDBConfig.Headers
+	}
 	if h.store.ConfigStore != nil {
-		if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, id, &req.TableMCPClient); err != nil {
+		if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, id, &dbUpdateRecord); err != nil {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to update mcp client config in store: %v", err))
 			return
 		}
 	}
+
 	toolSyncInterval := mcp.DefaultToolSyncInterval
 	if req.ToolSyncInterval != 0 {
 		toolSyncInterval = time.Duration(req.ToolSyncInterval) * time.Minute
@@ -789,6 +891,10 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		}
 	}
 	// Convert to schemas.MCPClientConfig for runtime bifrost client (without tool_pricing)
+	headersForTrack1 := req.Headers
+	if willAttemptReconnect {
+		headersForTrack1 = existingConfig.Headers
+	}
 	schemasConfig := &schemas.MCPClientConfig{
 		ID:                    req.ClientID,
 		Name:                  req.Name,
@@ -798,7 +904,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		StdioConfig:           existingConfig.StdioConfig,
 		ToolsToExecute:        resolvedToolsToExecute,
 		ToolsToAutoExecute:    resolvedToolsToAutoExecute,
-		Headers:               req.Headers,
+		Headers:               headersForTrack1,
 		AllowedExtraHeaders:   req.AllowedExtraHeaders,
 		AuthType:              existingConfig.AuthType,
 		OauthConfigID:         existingConfig.OauthConfigID,
@@ -810,7 +916,6 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Update MCP client config in memory (always — applies name/tools/header changes,
-	// and also triggers disable/enable lifecycle if the Disabled flag toggled)
 	if err := h.mcpManager.UpdateMCPClient(ctx, id, schemasConfig); err != nil {
 		// Rollback DB update to keep DB and memory in sync
 		if h.store.ConfigStore != nil && oldDBConfig != nil {
@@ -917,6 +1022,82 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
+	if willAttemptReconnect {
+		newCredsConfig := &schemas.MCPClientConfig{
+			Headers: req.TableMCPClient.Headers,
+		}
+		if err := h.mcpManager.UpdateMCPClientConnection(ctx, id, newCredsConfig); err != nil {
+			logger.Error(fmt.Sprintf(
+				"[PARTIAL SUCCESS] Non-credential fields for MCP client %s were updated successfully "+
+					"but the credential (headers) update failed — old headers retained: %v",
+				id, err,
+			))
+			SendJSON(ctx, map[string]any{
+				"status":           "partial_success",
+				"message":          "Non-credential fields updated successfully. Credential (headers) update failed — old headers are retained.",
+				"credential_error": err.Error(),
+			})
+			return
+		}
+
+		dbUpdateRecord.Headers = req.TableMCPClient.Headers
+		if h.store.ConfigStore != nil {
+			if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, id, &dbUpdateRecord); err != nil {
+				logger.Error(fmt.Sprintf(
+					"[PARTIAL SUCCESS] MCP client %s reconnected with new headers but failed to persist them to DB: %v. "+
+						"Headers are live but will revert on restart.",
+					id, err,
+				))
+				SendJSON(ctx, map[string]any{
+					"status":            "partial_success",
+					"message":           "MCP client reconnected with new headers but the DB update failed — headers are live but will revert on restart.",
+					"persistence_error": err.Error(),
+				})
+				return
+			}
+		}
+	}
+
+	if shouldRotateOAuthConfig {
+		redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
+		serverURL := ""
+		if existingConfig.ConnectionString != nil {
+			serverURL = existingConfig.ConnectionString.GetValue()
+		}
+		flowInitiation, err := h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
+			ClientID:        oauthClientID,
+			ClientSecret:    oauthClientSecret,
+			AuthorizeURL:    oauthAuthorizeURL,
+			TokenURL:        oauthTokenURL,
+			RegistrationURL: oauthRegistrationURL,
+			RedirectURI:     redirectURI,
+			Scopes:          oauthScopes,
+			ServerURL:       serverURL,
+		})
+		if err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initiate OAuth flow: %v", err))
+			return
+		}
+
+		pendingConfig := *schemasConfig
+		pendingConfig.OauthConfigID = &flowInitiation.OauthConfigID
+		pendingConfig.Headers = req.Headers
+		if err := h.oauthHandler.StorePendingMCPClient(flowInitiation.OauthConfigID, pendingConfig); err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to store pending MCP client update: %v", err))
+			return
+		}
+
+		SendJSON(ctx, map[string]any{
+			"status":          "pending_oauth",
+			"message":         "MCP client updated. OAuth re-authorization is required to apply credential rotation.",
+			"oauth_config_id": flowInitiation.OauthConfigID,
+			"authorize_url":   flowInitiation.AuthorizeURL,
+			"expires_at":      flowInitiation.ExpiresAt,
+			"mcp_client_id":   req.ClientID,
+		})
+		return
+	}
+
 	SendJSON(ctx, map[string]any{
 		"status":  "success",
 		"message": "MCP client edited successfully",
@@ -977,6 +1158,49 @@ func validateAllowedExtraHeaders(allowedExtraHeaders schemas.WhiteList) error {
 		return fmt.Errorf("invalid allowed_extra_headers: %w", err)
 	}
 	return nil
+}
+
+// stdioConfigsEqual returns true when a and b represent the same STDIO configuration.
+// A nil config is only equal to another nil config.
+func stdioConfigsEqual(a, b *schemas.MCPStdioConfig) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Command != b.Command {
+		return false
+	}
+	if len(a.Args) != len(b.Args) || len(a.Envs) != len(b.Envs) {
+		return false
+	}
+	for i, arg := range a.Args {
+		if b.Args[i] != arg {
+			return false
+		}
+	}
+	for i, env := range a.Envs {
+		if b.Envs[i] != env {
+			return false
+		}
+	}
+	return true
+}
+
+// headersEqual returns true when two header maps represent the same set of name→value pairs.
+func headersEqual(a, b map[string]schemas.EnvVar) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok {
+			return false
+		}
+		avCopy := av
+		if !avCopy.Equals(&bv) {
+			return false
+		}
+	}
+	return true
 }
 
 func validateToolsToAutoExecute(toolsToAutoExecute schemas.WhiteList, toolsToExecute schemas.WhiteList) error {
@@ -1051,6 +1275,48 @@ func mergeMCPRedactedValues(incoming *configstoreTables.TableMCPClient, oldRaw, 
 	return merged
 }
 
+// updateMCPClientWithRetry calls mcpManager.UpdateMCPClient with a short retry loop
+func (h *MCPHandler) updateMCPClientWithRetry(ctx context.Context, id string, config *schemas.MCPClientConfig) error {
+	const maxAttempts = 3
+	const retryDelay = 500 * time.Millisecond
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		lastErr = h.mcpManager.UpdateMCPClient(ctx, id, config)
+		if lastErr == nil {
+			return nil
+		}
+		if !strings.Contains(lastErr.Error(), "reconnect") || attempt == maxAttempts {
+			return lastErr
+		}
+		logger.Warn(fmt.Sprintf("[OAuth Complete] UpdateMCPClient attempt %d/%d for client %s blocked by in-flight reconnect; retrying in %s: %v",
+			attempt, maxAttempts, id, retryDelay, lastErr))
+		time.Sleep(retryDelay)
+	}
+	return lastErr
+}
+
+// updateMCPClientConnectionWithRetry calls mcpManager.UpdateMCPClientConnection with a short retry loop.
+func (h *MCPHandler) updateMCPClientConnectionWithRetry(ctx context.Context, id string, config *schemas.MCPClientConfig) error {
+	const maxAttempts = 3
+	const retryDelay = 500 * time.Millisecond
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		lastErr = h.mcpManager.UpdateMCPClientConnection(ctx, id, config)
+		if lastErr == nil {
+			return nil
+		}
+		if !strings.Contains(lastErr.Error(), "reconnect") || attempt == maxAttempts {
+			return lastErr
+		}
+		logger.Warn(fmt.Sprintf("[OAuth Complete] UpdateMCPClientConnection attempt %d/%d for client %s blocked by in-flight reconnect; retrying in %s: %v",
+			attempt, maxAttempts, id, retryDelay, lastErr))
+		time.Sleep(retryDelay)
+	}
+	return lastErr
+}
+
 // completeMCPClientOAuth handles POST /api/mcp/client/{id}/complete-oauth - Complete MCP client creation after OAuth authorization
 // The {id} parameter is the oauth_config_id returned from the initial addMCPClient call
 func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
@@ -1096,6 +1362,17 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	// If pending config points to an existing client, this is an OAuth credential update.
+	var existingDBConfig *configstoreTables.TableMCPClient
+	if h.store.ConfigStore != nil {
+		existingDBConfig, err = h.store.ConfigStore.GetMCPClientByID(ctx, mcpClientConfig.ID)
+		if err != nil && !errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get existing mcp client config: %v", err))
+			return
+		}
+	}
+	isUpdateFlow := existingDBConfig != nil
+
 	// Handle per-user OAuth completion: verify connection with admin's temp token,
 	// discover tools, create client (without persistent connection), discard token.
 	if mcpClientConfig.AuthType == schemas.MCPAuthTypePerUserOauth {
@@ -1120,7 +1397,113 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		mcpClientConfig.DiscoveredTools = tools
 		mcpClientConfig.DiscoveredToolNameMapping = toolNameMapping
 
-		// Persist MCP client config in config store (BeforeSave hook serializes DiscoveredTools)
+		if isUpdateFlow {
+			oldDBConfig := *existingDBConfig
+			updateReq := &configstoreTables.TableMCPClient{
+				ClientID:                  mcpClientConfig.ID,
+				Name:                      mcpClientConfig.Name,
+				IsCodeModeClient:          mcpClientConfig.IsCodeModeClient,
+				ConnectionType:            string(mcpClientConfig.ConnectionType),
+				ConnectionString:          mcpClientConfig.ConnectionString,
+				StdioConfig:               mcpClientConfig.StdioConfig,
+				AuthType:                  string(mcpClientConfig.AuthType),
+				OauthConfigID:             mcpClientConfig.OauthConfigID,
+				ToolsToExecute:            mcpClientConfig.ToolsToExecute,
+				ToolsToAutoExecute:        mcpClientConfig.ToolsToAutoExecute,
+				Headers:                   mcpClientConfig.Headers,
+				AllowedExtraHeaders:       mcpClientConfig.AllowedExtraHeaders,
+				IsPingAvailable:           mcpClientConfig.IsPingAvailable,
+				ToolPricing:               mcpClientConfig.ToolPricing,
+				ToolSyncInterval:          int(mcpClientConfig.ToolSyncInterval / time.Second),
+				AllowOnAllVirtualKeys:     mcpClientConfig.AllowOnAllVirtualKeys,
+				DiscoveredTools:           mcpClientConfig.DiscoveredTools,
+				DiscoveredToolNameMapping: mcpClientConfig.DiscoveredToolNameMapping,
+				Disabled:                  mcpClientConfig.Disabled,
+			}
+			if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, mcpClientConfig.ID, updateReq); err != nil {
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to update MCP config: %v", err))
+				return
+			}
+			if err := h.updateMCPClientWithRetry(ctx, mcpClientConfig.ID, mcpClientConfig); err != nil {
+				if rollbackErr := h.store.ConfigStore.UpdateMCPClientConfig(ctx, mcpClientConfig.ID, &oldDBConfig); rollbackErr != nil {
+					logger.Error(fmt.Sprintf("Failed to rollback MCP client DB update: %v. please restart bifrost to keep core and database in sync", rollbackErr))
+				}
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to update MCP client: %v", err))
+				return
+			}
+		} else {
+			// Persist MCP client config in config store (BeforeSave hook serializes DiscoveredTools)
+			if h.store.ConfigStore != nil {
+				if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, mcpClientConfig); err != nil {
+					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
+					return
+				}
+			}
+
+			// Add MCP client to manager (skips connection for per_user_oauth)
+			if err := h.mcpManager.AddMCPClient(ctx, mcpClientConfig); err != nil {
+				// Clean up DB entry on failure
+				if h.store.ConfigStore != nil {
+					if delErr := h.store.ConfigStore.DeleteMCPClientConfig(ctx, mcpClientConfig.ID); delErr != nil {
+						logger.Error(fmt.Sprintf("Failed to delete MCP client config from database: %v. please restart bifrost to keep core and database in sync", delErr))
+						SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to delete MCP client config from database: %v. please restart bifrost to keep core and database in sync", delErr))
+						return
+					}
+				}
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to register MCP client: %v", err))
+				return
+			}
+		}
+
+		// Set discovered tools on the client
+		h.mcpManager.SetClientTools(mcpClientConfig.ID, tools, toolNameMapping)
+
+		logger.Debug(fmt.Sprintf("[OAuth Complete] Per-user OAuth MCP client verified and created: %s (%d tools)", mcpClientConfig.ID, len(tools)))
+		message := fmt.Sprintf("OAuth configuration verified successfully. %d tools discovered. Each user will authenticate individually when using this MCP server.", len(tools))
+		if isUpdateFlow {
+			message = fmt.Sprintf("OAuth credentials updated and verified successfully. %d tools discovered.", len(tools))
+		}
+		SendJSON(ctx, map[string]any{"status": "success", "message": message, "tools_count": len(tools)})
+		return
+	}
+
+	// Standard server-level OAuth completion
+	if isUpdateFlow {
+		oldDBConfig := *existingDBConfig
+		updateReq := &configstoreTables.TableMCPClient{
+			ClientID:                  mcpClientConfig.ID,
+			Name:                      mcpClientConfig.Name,
+			IsCodeModeClient:          mcpClientConfig.IsCodeModeClient,
+			ConnectionType:            string(mcpClientConfig.ConnectionType),
+			ConnectionString:          mcpClientConfig.ConnectionString,
+			StdioConfig:               mcpClientConfig.StdioConfig,
+			AuthType:                  string(mcpClientConfig.AuthType),
+			OauthConfigID:             mcpClientConfig.OauthConfigID,
+			ToolsToExecute:            mcpClientConfig.ToolsToExecute,
+			ToolsToAutoExecute:        mcpClientConfig.ToolsToAutoExecute,
+			Headers:                   mcpClientConfig.Headers,
+			AllowedExtraHeaders:       mcpClientConfig.AllowedExtraHeaders,
+			IsPingAvailable:           mcpClientConfig.IsPingAvailable,
+			ToolPricing:               mcpClientConfig.ToolPricing,
+			ToolSyncInterval:          int(mcpClientConfig.ToolSyncInterval / time.Second),
+			AllowOnAllVirtualKeys:     mcpClientConfig.AllowOnAllVirtualKeys,
+			DiscoveredTools:           mcpClientConfig.DiscoveredTools,
+			DiscoveredToolNameMapping: mcpClientConfig.DiscoveredToolNameMapping,
+			Disabled:                  mcpClientConfig.Disabled,
+		}
+		if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, mcpClientConfig.ID, updateReq); err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to update MCP config: %v", err))
+			return
+		}
+		if err := h.updateMCPClientConnectionWithRetry(ctx, mcpClientConfig.ID, mcpClientConfig); err != nil {
+			if rollbackErr := h.store.ConfigStore.UpdateMCPClientConfig(ctx, mcpClientConfig.ID, &oldDBConfig); rollbackErr != nil {
+				logger.Error(fmt.Sprintf("Failed to rollback MCP client DB update: %v. please restart bifrost to keep core and database in sync", rollbackErr))
+			}
+			logger.Error(fmt.Sprintf("Failed to reconnect MCP client after OAuth DB update for client %s: %v", mcpClientConfig.ID, err))
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to reconnect MCP client with updated OAuth credentials: %v", err))
+			return
+		}
+	} else {
 		if h.store.ConfigStore != nil {
 			if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, mcpClientConfig); err != nil {
 				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
@@ -1128,45 +1511,17 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			}
 		}
 
-		// Add MCP client to manager (skips connection for per_user_oauth)
+		// Add MCP client to Bifrost and connect
 		if err := h.mcpManager.AddMCPClient(ctx, mcpClientConfig); err != nil {
-			// Clean up DB entry on failure
 			if h.store.ConfigStore != nil {
 				if delErr := h.store.ConfigStore.DeleteMCPClientConfig(ctx, mcpClientConfig.ID); delErr != nil {
-					logger.Error(fmt.Sprintf("Failed to delete MCP client config from database: %v. please restart bifrost to keep core and database in sync", delErr))
-					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to delete MCP client config from database: %v. please restart bifrost to keep core and database in sync", delErr))
-					return
+					logger.Warn(fmt.Sprintf("Failed to rollback MCP client config after add failure: %v", delErr))
 				}
 			}
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to register MCP client: %v", err))
+			logger.Error(fmt.Sprintf("[OAuth Complete] Failed to connect MCP client: %v", err))
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to connect MCP client: %v", err))
 			return
 		}
-
-		// Set discovered tools on the client
-		h.mcpManager.SetClientTools(mcpClientConfig.ID, tools, toolNameMapping)
-
-		logger.Debug(fmt.Sprintf("[OAuth Complete] Per-user OAuth MCP client verified and created: %s (%d tools)", mcpClientConfig.ID, len(tools)))
-		SendJSON(ctx, map[string]any{
-			"status":      "success",
-			"message":     fmt.Sprintf("OAuth configuration verified successfully. %d tools discovered. Each user will authenticate individually when using this MCP server.", len(tools)),
-			"tools_count": len(tools),
-		})
-		return
-	}
-
-	// Standard server-level OAuth completion
-	if h.store.ConfigStore != nil {
-		if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, mcpClientConfig); err != nil {
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
-			return
-		}
-	}
-
-	// Add MCP client to Bifrost (this will save to database and connect)
-	if err := h.mcpManager.AddMCPClient(ctx, mcpClientConfig); err != nil {
-		logger.Error(fmt.Sprintf("[OAuth Complete] Failed to connect MCP client: %v", err))
-		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to connect MCP client: %v", err))
-		return
 	}
 
 	// Clear pending MCP client config from oauth_config (cleanup)
@@ -1176,8 +1531,9 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 	}
 
 	logger.Debug(fmt.Sprintf("[OAuth Complete] MCP client connected successfully: %s", mcpClientConfig.ID))
-	SendJSON(ctx, map[string]any{
-		"status":  "success",
-		"message": "MCP client connected successfully with OAuth",
-	})
+	message := "MCP client connected successfully with OAuth"
+	if isUpdateFlow {
+		message = "MCP client OAuth credentials updated successfully"
+	}
+	SendJSON(ctx, map[string]any{"status": "success", "message": message})
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -4611,6 +4611,67 @@ func (c *Config) UpdateMCPClient(ctx context.Context, id string, updatedConfig *
 	return nil
 }
 
+// UpdateMCPClientConnection updates the auth credentials (headers) for an existing MCP client.
+// It delegates the actual reconnection (with the new credentials) to the Bifrost client.
+func (c *Config) UpdateMCPClientConnection(ctx context.Context, id string, newConfig *schemas.MCPClientConfig) error {
+	if c.client == nil {
+		return fmt.Errorf("bifrost client not set")
+	}
+
+	c.muMCP.RLock()
+	if c.MCPConfig == nil {
+		c.muMCP.RUnlock()
+		return fmt.Errorf("in-memory MCPConfig absent; cannot update MCP client connection")
+	}
+	found := false
+	for _, cc := range c.MCPConfig.ClientConfigs {
+		if cc == nil {
+			continue
+		}
+		if cc.ID == id {
+			found = true
+			break
+		}
+	}
+	c.muMCP.RUnlock()
+	if !found {
+		return fmt.Errorf("MCP client %s not found in in-memory MCP config", id)
+	}
+
+	// Attempt the credential swap on the runtime side first.
+	// If this fails, nothing in our in-memory config has changed.
+	if err := c.client.UpdateMCPClientConnection(id, newConfig); err != nil {
+		return fmt.Errorf("failed to update MCP client credentials: %w", err)
+	}
+
+	// Reconnect succeeded — mirror the new credentials into the in-memory config
+	// so that subsequent reads of MCPConfig reflect the live state.
+	c.muMCP.Lock()
+	defer c.muMCP.Unlock()
+	if c.MCPConfig != nil {
+		found := false
+		for _, cc := range c.MCPConfig.ClientConfigs {
+			if cc == nil {
+				continue
+			}
+			if cc.ID == id {
+				found = true
+				if newConfig.Headers != nil {
+					cc.Headers = maps.Clone(newConfig.Headers)
+				}
+				if newConfig.OauthConfigID != nil {
+					cc.OauthConfigID = newConfig.OauthConfigID
+				}
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("MCP client %s not found in in-memory config after successful reconnect", id)
+		}
+	}
+	return nil
+}
+
 // RemoveMCPClient removes an MCP client from the configuration.
 // This method is called when an MCP client is removed via the HTTP API.
 //

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -91,6 +91,8 @@ type ServerCallbacks interface {
 	AddMCPClient(ctx context.Context, clientConfig *schemas.MCPClientConfig) error
 	RemoveMCPClient(ctx context.Context, id string) error
 	UpdateMCPClient(ctx context.Context, id string, updatedConfig *schemas.MCPClientConfig) error
+	// UpdateMCPClientConnection reconnects an existing MCP client using updated headers
+	UpdateMCPClientConnection(ctx context.Context, id string, newConfig *schemas.MCPClientConfig) error
 	UpdateMCPToolManagerConfig(ctx context.Context, maxAgentDepth int, toolExecutionTimeoutInSeconds int, codeModeBindingLevel string, disableAutoToolInject bool) error
 	// VerifyPerUserOAuthConnection verifies an MCP server using a temporary token and discovers tools.
 	VerifyPerUserOAuthConnection(ctx context.Context, config *schemas.MCPClientConfig, accessToken string) (map[string]schemas.ChatTool, map[string]string, error)
@@ -216,6 +218,17 @@ func (s *BifrostHTTPServer) UpdateMCPClient(ctx context.Context, id string, upda
 	}
 	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
 		logger.Warn("failed to sync MCP servers after editing client: %v", err)
+	}
+	return nil
+}
+
+// UpdateMCPClientConnection reconnects an existing MCP client using updated headers
+func (s *BifrostHTTPServer) UpdateMCPClientConnection(ctx context.Context, id string, newConfig *schemas.MCPClientConfig) error {
+	if err := s.Config.UpdateMCPClientConnection(ctx, id, newConfig); err != nil {
+		return err
+	}
+	if err := s.MCPServerHandler.SyncAllMCPServers(ctx); err != nil {
+		logger.Warn("failed to sync MCP servers after updating client connection: %v", err)
 	}
 	return nil
 }

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -24,6 +24,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { ChevronDown, ChevronRight, Info, Plus, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
+import { OAuth2Authorizer } from "./oauth2Authorizer";
 
 interface MCPClientSheetProps {
 	mcpClient: MCPClient;
@@ -64,6 +65,12 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 	const [vkConfigs, setVKConfigs] = useState<MCPVKConfig[]>([]);
 	const [vkConfigsDirty, setVKConfigsDirty] = useState(false);
 	const [allowedExtraHeadersRaw, setAllowedExtraHeadersRaw] = useState<string>((mcpClient.config.allowed_extra_headers || []).join(", "));
+	const [oauthFlow, setOauthFlow] = useState<{
+		authorizeUrl: string;
+		oauthConfigId: string;
+		mcpClientId: string;
+		isPerUserOauth?: boolean;
+	} | null>(null);
 	// Persists names for newly added VKs so they survive search result changes
 	const [localVKNames, setLocalVKNames] = useState<Record<string, string>>({});
 
@@ -103,6 +110,8 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 		],
 		[allToolNames],
 	);
+	const supportsOAuthCredentialUpdate =
+		mcpClient.config.auth_type === "oauth" || mcpClient.config.auth_type === "per_user_oauth";
 
 	const addVKConfig = (vkId: string) => {
 		const name = vksData?.virtual_keys?.find((vk) => vk.id === vkId)?.name;
@@ -148,8 +157,10 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			tool_pricing: mcpClient.config.tool_pricing || {},
 			tool_sync_interval: toolSyncIntervalToMinutes(mcpClient.config.tool_sync_interval),
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
+			oauth_config: undefined,
 		},
 	});
+	const isDisabled = form.watch("disabled");
 
 	// Reset form when mcpClient changes
 	useEffect(() => {
@@ -165,12 +176,16 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			tool_pricing: mcpClient.config.tool_pricing || {},
 			tool_sync_interval: toolSyncIntervalToMinutes(mcpClient.config.tool_sync_interval),
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
+			oauth_config: undefined,
 		});
 	}, [form, mcpClient]);
 
 	const onSubmit = async (data: MCPClientUpdateSchema) => {
 		try {
-			await updateMCPClient({
+			const oauthClientID = data.oauth_config?.client_id?.trim() || "";
+			const oauthClientSecret = data.oauth_config?.client_secret?.trim() || "";
+			const shouldRotateOAuthCredentials = supportsOAuthCredentialUpdate && (oauthClientID.length > 0 || oauthClientSecret.length > 0);
+			const response = await updateMCPClient({
 				id: mcpClient.config.client_id,
 				data: {
 					name: data.name,
@@ -184,9 +199,25 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 					tool_pricing: data.tool_pricing,
 					tool_sync_interval: data.tool_sync_interval ?? 0,
 					allowed_extra_headers: data.allowed_extra_headers,
+					oauth_config: shouldRotateOAuthCredentials
+						? {
+								client_id: oauthClientID,
+								client_secret: oauthClientSecret || undefined,
+							}
+						: undefined,
 					vk_configs: vkConfigsDirty ? vkConfigs : undefined,
 				},
 			}).unwrap();
+
+			if (response.status === "pending_oauth" && response.authorize_url) {
+				setOauthFlow({
+					authorizeUrl: response.authorize_url,
+					oauthConfigId: response.oauth_config_id,
+					mcpClientId: response.mcp_client_id,
+					isPerUserOauth: mcpClient.config.auth_type === "per_user_oauth",
+				});
+				return;
+			}
 
 			toast({
 				title: "Success",
@@ -452,7 +483,12 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 											<FormControl>
 												<Switch
 													checked={field.value === true}
-													onCheckedChange={field.onChange}
+													onCheckedChange={(checked) => {
+														field.onChange(checked);
+														if (checked) {
+															form.setValue("oauth_config", undefined);
+														}
+													}}
 													data-testid="mcpclient-disabled-switch"
 												/>
 											</FormControl>
@@ -571,41 +607,69 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 									)}
 								/>
 							</div>
-							{/* Client Configuration */}
-							<div className="space-y-4">
-								<h3 className="font-semibold">Configuration</h3>
-								<div className="rounded-sm border">
-									<div className="bg-muted/50 text-muted-foreground border-b px-6 py-2 text-xs font-medium">Client ConnectionConfig</div>
-									<CodeEditor
-										className="z-0 w-full"
-										shouldAdjustInitialHeight={true}
-										maxHeight={300}
-										wrap={true}
-										code={JSON.stringify(
-											(() => {
-												const {
-													client_id: _client_id,
-													name: _name,
-													tools_to_execute: _tools_to_execute,
-													headers: _headers,
-													...rest
-												} = mcpClient.config;
-												return rest;
-											})(),
-											null,
-											2,
-										)}
-										lang="json"
-										readonly={true}
-										options={{
-											scrollBeyondLastLine: false,
-											collapsibleBlocks: true,
-											lineNumbers: "off",
-											alwaysConsumeMouseWheel: false,
-										}}
-									/>
+							{supportsOAuthCredentialUpdate ? (
+								<div className="space-y-4">
+									<h3 className="font-semibold">OAuth Credentials</h3>
+									{isDisabled ? (
+										<div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+											<Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+											<p>
+												OAuth credentials cannot be rotated while the client is disabled. Re-enable the client to update credentials.
+											</p>
+										</div>
+									) : (
+										<p className="text-muted-foreground text-sm">
+											Update OAuth client credentials only. Connection type, auth type, and connection URL cannot be changed.
+										</p>
+									)}
+									<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+										<FormField
+											control={form.control}
+											name="oauth_config.client_id"
+											render={({ field }) => (
+												<FormItem className="flex flex-col gap-2">
+													<FormLabel>Client ID</FormLabel>
+													<FormControl>
+														<Input
+															data-testid="mcpclient-input-oauth-client-id"
+															placeholder="Enter new OAuth client ID"
+															disabled={isDisabled}
+															{...field}
+															value={field.value || ""}
+														/>
+													</FormControl>
+													{!isDisabled && (
+														<p className="text-muted-foreground text-xs">
+															Leave empty to keep existing credentials unchanged.
+														</p>
+													)}
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+										<FormField
+											control={form.control}
+											name="oauth_config.client_secret"
+											render={({ field }) => (
+												<FormItem className="flex flex-col gap-2">
+													<FormLabel>Client Secret</FormLabel>
+													<FormControl>
+														<Input
+															data-testid="mcpclient-input-oauth-client-secret"
+															type="password"
+															placeholder="Enter new OAuth client secret"
+															disabled={isDisabled}
+															{...field}
+															value={field.value || ""}
+														/>
+													</FormControl>
+													<FormMessage />
+												</FormItem>
+											)}
+										/>
+									</div>
 								</div>
-							</div>
+							) : null}
 							{/* Tools Section */}
 							<div className="space-y-4 pb-10">
 								<div className="flex items-center justify-between">
@@ -1030,6 +1094,24 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 					</form>
 				</Form>
 			</SheetContent>
+			{oauthFlow && (
+				<OAuth2Authorizer
+					open={!!oauthFlow}
+					onClose={() => setOauthFlow(null)}
+					onSuccess={() => {
+						toast({ title: "Success", description: "MCP client OAuth credentials updated successfully" });
+						onSubmitSuccess();
+						onClose();
+					}}
+					onError={(error) => {
+						toast({ title: "Error", description: error, variant: "destructive" });
+					}}
+					authorizeUrl={oauthFlow.authorizeUrl}
+					oauthConfigId={oauthFlow.oauthConfigId}
+					mcpClientId={oauthFlow.mcpClientId}
+					isPerUserOauth={oauthFlow.isPerUserOauth}
+				/>
+			)}
 		</Sheet>
 	);
 }

--- a/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
+++ b/ui/app/workspace/mcp-registry/views/oauth2Authorizer.tsx
@@ -30,6 +30,9 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	const popupRef = useRef<Window | null>(null);
 	const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
 	const isCompletingRef = useRef(false);
+	// Set to true when the user cancels so in-flight async callbacks do not
+	// invoke onSuccess / onError / onClose after the dialog is dismissed.
+	const cancelledRef = useRef(false);
 
 	// RTK Query hooks
 	const [getOAuthStatus] = useLazyGetOAuthConfigStatusQuery();
@@ -45,6 +48,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 
 	// Handle successful OAuth completion
 	const handleOAuthComplete = useCallback(async () => {
+		if (cancelledRef.current) return;
 		// Guard against concurrent calls (race between postMessage and polling)
 		if (isCompletingRef.current) return;
 		isCompletingRef.current = true;
@@ -58,12 +62,14 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 		// Use oauthConfigId instead of mcpClientId for multi-instance support
 		try {
 			await completeOAuth(oauthConfigId).unwrap();
+			if (cancelledRef.current) return;
 			setStatus("success");
 			onSuccess();
 			setTimeout(() => {
-				onClose();
+				if (!cancelledRef.current) onClose();
 			}, 1000);
 		} catch (error) {
+			if (cancelledRef.current) return;
 			const errMsg = getErrorMessage(error);
 			setStatus("failed");
 			setErrorMessage(errMsg);
@@ -78,6 +84,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 			if (popupRef.current && !popupRef.current.closed) {
 				popupRef.current.close();
 			}
+			if (cancelledRef.current) return;
 			setStatus("failed");
 			setErrorMessage(reason);
 			onError(reason);
@@ -87,8 +94,10 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 
 	// Check OAuth status (called by postMessage or polling)
 	const checkOAuthStatus = useCallback(async () => {
+		if (cancelledRef.current) return;
 		try {
 			const result = await getOAuthStatus(oauthConfigId).unwrap();
+			if (cancelledRef.current) return;
 
 			if (result.status === "authorized") {
 				stopPolling();
@@ -135,8 +144,9 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 
 	// Open popup and start polling
 	const openPopup = useCallback(() => {
-		// Reset completion guard for each fresh OAuth attempt
+		// Reset completion and cancelled guards for each fresh OAuth attempt
 		isCompletingRef.current = false;
+		cancelledRef.current = false;
 
 		// Close any existing popup
 		if (popupRef.current && !popupRef.current.closed) {
@@ -214,6 +224,7 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	};
 
 	const handleCancel = () => {
+		cancelledRef.current = true;
 		stopPolling();
 		isCompletingRef.current = false;
 		if (popupRef.current && !popupRef.current.closed) {
@@ -223,8 +234,25 @@ export const OAuth2Authorizer: React.FC<OAuth2AuthorizerProps> = ({
 	};
 
 	return (
-		<Dialog open={open}>
-			<DialogContent className="sm:max-w-md" onPointerDownOutside={(e) => e.preventDefault()} onEscapeKeyDown={(e) => e.preventDefault()}>
+		<Dialog
+			open={open}
+			onOpenChange={(nextOpen) => {
+				if (!nextOpen) {
+					handleCancel();
+				}
+			}}
+		>
+			<DialogContent
+				className="sm:max-w-md"
+				onPointerDownOutside={(e) => {
+					e.preventDefault();
+					handleCancel();
+				}}
+				onEscapeKeyDown={(e) => {
+					e.preventDefault();
+					handleCancel();
+				}}
+			>
 				<DialogHeader>
 					<DialogTitle>{status === "confirm" ? "Test OAuth Configuration" : "OAuth Authorization"}</DialogTitle>
 					<DialogDescription>

--- a/ui/lib/store/apis/mcpApi.ts
+++ b/ui/lib/store/apis/mcpApi.ts
@@ -10,6 +10,7 @@ import {
 import { baseApi } from "./baseApi";
 
 type CreateMCPClientResponse = { status: "success"; message: string } | OAuthFlowResponse;
+type UpdateMCPClientResponse = { status: "success"; message: string } | OAuthFlowResponse;
 
 export const mcpApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
@@ -49,7 +50,7 @@ export const mcpApi = baseApi.injectEndpoints({
 		}),
 
 		// Update existing MCP client
-		updateMCPClient: builder.mutation<any, { id: string; data: UpdateMCPClientRequest }>({
+		updateMCPClient: builder.mutation<UpdateMCPClientResponse, { id: string; data: UpdateMCPClientRequest }>({
 			query: ({ id, data }) => ({
 				url: `/mcp/client/${id}`,
 				method: "PUT",
@@ -57,7 +58,11 @@ export const mcpApi = baseApi.injectEndpoints({
 			}),
 			async onQueryStarted({ id, data }, { dispatch, getState, queryFulfilled }) {
 				try {
-					await queryFulfilled;
+					const { data: response } = await queryFulfilled;
+					if (response.status === "pending_oauth") {
+						dispatch(mcpApi.util.invalidateTags(["MCPClients"]));
+						return;
+					}
 					const queries = (getState() as any).api.queries;
 					for (const entry of Object.values(queries) as any[]) {
 						if (entry?.endpointName !== "getMCPClients" || entry?.status !== "fulfilled") continue;

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -25,6 +25,12 @@ export interface OAuthConfig {
 	server_url?: string; // MCP server URL for OAuth discovery (automatically set from connection_string)
 }
 
+/** OAuth fields allowed on MCP client update (e.g. client_secret-only rotation). */
+export interface OAuthConfigUpdate {
+	client_id?: string;
+	client_secret?: string;
+}
+
 export interface MCPClientConfig {
 	client_id: string; // Maps to ClientID in TableMCPClient
 	name: string;
@@ -108,6 +114,7 @@ export interface UpdateMCPClientRequest {
 	allowed_extra_headers?: string[]; // Allowlist of x-bf-eh-* headers forwarded to this MCP server. ["*"] = allow all.
 	allow_on_all_virtual_keys?: boolean; // When true, available to all VKs with all tools allowed by default; explicit VK config overrides this
 	disabled?: boolean; // Set to true to shut down connection/workers; false to reconnect
+	oauth_config?: OAuthConfigUpdate; // Only supported for existing oauth/per_user_oauth clients (credential rotation)
 	vk_configs?: MCPVKConfig[]; // When provided, replaces all VK assignments for this MCP client
 }
 

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1114,6 +1114,12 @@ export const mcpClientUpdateSchema = z.object({
       },
       { message: "Wildcard '*' cannot be combined with specific header names" },
     ),
+  oauth_config: z
+    .object({
+      client_id: z.string().trim().min(1, "OAuth Client ID cannot be empty").optional(),
+      client_secret: z.string().trim().min(1, "OAuth Client Secret cannot be empty").optional(),
+    })
+    .optional(),
 });
 
 // Global proxy type schema


### PR DESCRIPTION
## Summary

Adds support for rotating OAuth credentials (`client_id` and `client_secret`) on existing MCP clients without requiring the client to be deleted and recreated. The edit flow now initiates a new OAuth authorization flow when updated credentials are provided, preserving the existing connection type, auth type, and connection URL as immutable fields.

## Changes

- `MCPClientUpdateRequest` now accepts an optional `oauth_config` field containing `client_id` and `client_secret` for credential rotation, restricted to clients with `auth_type` of `oauth` or `per_user_oauth`.
- The `updateMCPClient` handler enforces immutability of `connection_type`, `auth_type`, `connection_string`, and `stdio_config` on PUT requests, returning a 400 if any of these are supplied with a differing value.
- When OAuth credentials are provided, the handler initiates a new OAuth flow and returns a `pending_oauth` status with an `authorize_url`, mirroring the creation flow.
- `completeMCPClientOAuth` now detects whether the pending config maps to an existing client (`isUpdateFlow`) and branches into update vs. create paths for both standard and per-user OAuth, including rollback on manager update failure.
- `UpdateMCPClientConfig` in the RDB config store now persists `oauth_config_id`, `discovered_tools_json`, and `tool_name_mapping_json` when provided.
- The UI edit sheet renders OAuth credential input fields (`client_id`, `client_secret`) for OAuth-type clients, triggers the `OAuth2Authorizer` dialog on a `pending_oauth` response, and handles success/error callbacks.
- `updateMCPClient` API mutation is typed as `UpdateMCPClientResponse` (union of success and `OAuthFlowResponse`) and skips the optimistic cache patch when the response is `pending_oauth`.
- The `OAuth2Authorizer` dialog now responds to `onOpenChange` so clicking outside or pressing Escape triggers the cancel handler.
- Documentation updated to note that `client_id` and `client_secret` can be rotated via the edit flow while connection metadata remains immutable.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

1. Create an MCP client with `auth_type: oauth` or `auth_type: per_user_oauth`.
2. Open the edit sheet for that client in the UI; confirm the **OAuth Credentials** section is visible with `Client ID` and `Client Secret` inputs.
3. Enter a new `client_id` (and optionally a new `client_secret`) and save.
4. Confirm the UI opens the `OAuth2Authorizer` dialog with the new authorization URL.
5. Complete the OAuth flow and confirm the success toast appears and the client list refreshes.
6. Attempt to supply only a new `client_secret` (no `client_id`) and confirm the backend resolves the existing `client_id` from the stored OAuth config.
7. Attempt to change `connection_type`, `auth_type`, `connection_string`, or `stdio_config` via the API and confirm a 400 is returned.
8. Confirm that clients with non-OAuth auth types do not show the OAuth Credentials section in the UI.

```sh
go test ./...

cd ui
pnpm i
pnpm build
```

## Breaking changes

- [x] Yes
- [ ] No

PUT `/api/mcp/client/:id` now returns a 400 if `connection_type`, `auth_type`, `connection_string`, or `stdio_config` are included in the request body with values that differ from the stored config. Callers that previously sent these fields expecting them to be silently ignored must remove them.

## Security considerations

OAuth `client_secret` values are handled as sensitive inputs (password-type field in the UI, trimmed and never logged). The rotation flow reuses the existing OAuth config encryption path. Only clients whose stored `auth_type` is `oauth` or `per_user_oauth` are permitted to submit credential updates, preventing credential injection on non-OAuth clients.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable