### PR TITLE
refactor: semantic cache plugin

### DIFF
--- a/.claude/skills/docs-writer/SKILL.md
+++ b/.claude/skills/docs-writer/SKILL.md
@@ -176,7 +176,7 @@ grep -n 'func.*create\|func.*update\|func.*delete\|func.*get' transports/bifrost
 | `plugins.go` | `/api/plugins` | CRUD plugins |
 | `config.go` | `/api/config` | GET/PUT config |
 | `config.go` | `/api/proxy-config` | GET/PUT proxy config |
-| `cache.go` | `/api/cache/clear/{requestId}` | DELETE cache |
+| `cache.go` | `/api/cache/clear/{cacheId}` | DELETE cache |
 | `session.go` | `/api/session/*` | Login/logout/auth check |
 | `oauth2.go` | `/api/oauth/*` | OAuth callback/status |
 

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ transports/schema/config.schema.json
 *.db
 *.db-shm
 *.db-wal
+transports/bifrost-http/v1.5.x
 
 # Test reports
 test-reports

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -1412,6 +1412,10 @@ type BifrostCacheDebug struct {
 	// Semantic cache only (only when cache is hit)
 	Threshold  *float64 `json:"threshold,omitempty"`
 	Similarity *float64 `json:"similarity,omitempty"`
+
+	// CacheHitLatency is the time in milliseconds spent serving the cache hit
+	// (lookup + response build). Only set when CacheHit is true.
+	CacheHitLatency *int64 `json:"cache_hit_latency,omitempty"`
 }
 
 const (

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -132,6 +132,41 @@ func (bc *BifrostContext) WithValue(key any, value any) *BifrostContext {
 	return bc
 }
 
+// Root returns the underlying root BifrostContext. For root contexts this is
+// the receiver itself; for plugin-scoped contexts it is the underlying root
+// that scoped Value/SetValue calls delegate to.
+//
+// PLUGIN AUTHORS: capture Root() synchronously inside Pre/PostLLMHook (or
+// any other hook) when you need to write to the context from a goroutine
+// that outlives the hook. The plugin-scoped *BifrostContext passed into your
+// hook is reclaimed by an internal sync.Pool the moment the hook returns —
+// any later SetValue/Value call on it lands in detached storage that nobody
+// downstream can read (and can leak into a future pool reuse). The root,
+// in contrast, lives for the entire request, so a pointer captured here is
+// safe to use for the lifetime of the request even after your hook returns.
+//
+// Example:
+//
+//	func (p *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req ...) (...) {
+//	    rootCtx := ctx.Root() // capture before the scope is released
+//	    go func() {
+//	        // ... long-running work that produces stream chunks ...
+//	        rootCtx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+//	    }()
+//	    return req, &schemas.LLMPluginShortCircuit{Stream: ch}, nil
+//	}
+func (bc *BifrostContext) Root() *BifrostContext {
+	// Unwrap the full delegation chain. A scoped context can in principle be
+	// derived from another scoped context (e.g. nested plugin scopes), and
+	// stopping at the first valueDelegate would return an intermediate pooled
+	// scope — which loses the async-safety guarantee as soon as that
+	// intermediate scope is released.
+	for bc != nil && bc.valueDelegate != nil {
+		bc = bc.valueDelegate
+	}
+	return bc
+}
+
 // BlockRestrictedWrites returns true if restricted writes are blocked.
 func (bc *BifrostContext) BlockRestrictedWrites() {
 	bc.blockRestrictedWrites.Store(true)

--- a/core/schemas/context_test.go
+++ b/core/schemas/context_test.go
@@ -376,6 +376,40 @@ func TestPluginLog_PoolReuse(t *testing.T) {
 	}
 }
 
+// TestRoot_UnwrapsChainedValueDelegates verifies Root() walks the entire
+// delegate chain. A naive single-step unwrap would return an intermediate
+// pooled scope, which loses the async-safety guarantee as soon as that
+// intermediate scope is recycled.
+func TestRoot_UnwrapsChainedValueDelegates(t *testing.T) {
+	root := NewBifrostContext(context.Background(), NoDeadline)
+
+	a := "outer"
+	b := "inner"
+	outer := root.WithPluginScope(&a)
+	// Manually build a second scoped context whose delegate is the first
+	// scoped context — simulates a plugin that derives its own scope from
+	// an already-scoped ctx.
+	inner := &BifrostContext{
+		parent:        outer.parent,
+		done:          outer.done,
+		pluginScope:   &b,
+		valueDelegate: outer,
+	}
+
+	got := inner.Root()
+	if got != root {
+		t.Fatalf("Root() did not walk the chain to the request root: got %p, want %p", got, root)
+	}
+	if got.valueDelegate != nil {
+		t.Fatalf("Root() returned a context with a non-nil valueDelegate: %+v", got)
+	}
+
+	// Sanity: Root() on a non-scoped context returns itself.
+	if root.Root() != root {
+		t.Fatal("Root() on a non-scoped context should return the receiver")
+	}
+}
+
 // TestNewBifrostContext_DerivedFromReleasedScope_NoPanic locks in the
 // deterministic half of the scoped-parent-release bug: a derived BifrostContext
 // must not deref a pool-released scoped ancestor when its accessors are called.

--- a/docs/features/semantic-caching.mdx
+++ b/docs/features/semantic-caching.mdx
@@ -169,7 +169,9 @@ bifrostConfig := schemas.BifrostConfig{
 **Cache Settings**:
 - **TTL (seconds)**: How long cached responses are kept (default: 300 s).
 - **Similarity Threshold**: Cosine similarity cutoff for a cache hit (0–1, default: 0.8).
-- **Dimension**: Vector dimension matching your embedding model (e.g. 1536 for `text-embedding-3-small`).
+- **Dimension**: Vector size produced by the embedding model — must match the model exactly. Common values: `1536` for OpenAI `text-embedding-3-small`, `3072` for `text-embedding-3-large`, `768` for many Cohere/Voyage models. Use `1` only in direct-only mode (no provider).
+
+> **Heads up**: a vector store namespace can only hold vectors of *one* dimension. Whenever you change the embedding **provider**, **model**, or **dimension**, make sure the new dimension still matches what the model produces — otherwise writes to the existing namespace will fail and reads will silently miss. The namespace is **not** recreated automatically; either point `vector_store_namespace` at a fresh name or drop the existing class/index in your vector store before saving.
 
 **Conversation Settings**:
 - **Conversation History Threshold**: Skip caching when the conversation has more than this many messages (default: 3).
@@ -612,6 +614,7 @@ Example HTTP Response:
   "extra_fields": {
     "cache_debug": {
       "cache_hit": false,
+      "cache_id": "550e8500-e29b-41d4-a725-446655440001",
       "provider_used": "openai",
       "model_used": "gpt-4o-mini",
       "input_tokens": 20
@@ -620,22 +623,21 @@ Example HTTP Response:
 }
 ```
 
-
-These variables allow you to detect cached responses and get the cache entry ID needed for clearing specific entries.
+`cache_debug` is populated on both hits and misses. `cache_id` is the storage ID of the entry — use it to invalidate the entry later. The embedding-related fields (`provider_used`, `model_used`, `input_tokens`) are only present when semantic search actually ran.
 
 ### Clear Specific Cache Entry
 
-Use the request ID from cached responses to clear specific entries:
+Use the `cache_id` from `cache_debug` to clear a specific entry:
 
 <Tabs group="cache-clear">
 
 <Tab title="Go SDK">
 
 ```go
-// Clear specific entry by request ID
-err := plugin.ClearCacheForRequestID("550e8400-e29b-41d4-a716-446655440000")
+// Clear specific entry by cache ID (read from response.ExtraFields.CacheDebug.CacheID)
+err := plugin.ClearCacheForCacheID("550e8500-e29b-41d4-a725-446655440001")
 
-// Clear all entries for a cache key  
+// Clear all entries for a cache key
 err := plugin.ClearCacheForKey("support-session-456")
 ```
 
@@ -644,8 +646,8 @@ err := plugin.ClearCacheForKey("support-session-456")
 <Tab title="HTTP API">
 
 ```bash
-# Clear specific cached entry by request ID
-curl -X DELETE http://localhost:8080/api/cache/clear/550e8400-e29b-41d4-a716-446655440000
+# Clear specific cached entry by cache ID
+curl -X DELETE http://localhost:8080/api/cache/clear/550e8500-e29b-41d4-a725-446655440001
 
 # Clear all entries for a cache key
 curl -X DELETE http://localhost:8080/api/cache/clear-by-key/support-session-456
@@ -665,7 +667,7 @@ The semantic cache automatically handles cleanup to prevent storage bloat:
 - **Namespace Isolation**: Each Bifrost instance uses isolated vector store namespaces to prevent conflicts
 
 **Manual Cleanup Options:**
-- Clear specific entries by request ID (see examples above)
+- Clear specific entries by cache ID (see examples above)
 - Clear all entries for a cache key
 - Restart Bifrost to clear all cache data
 
@@ -674,7 +676,11 @@ The semantic cache namespace and all its cache entries are deleted when Bifrost 
 </Warning>
 
 <Warning>
-**Dimension Changes**: If you update the `dimension` config, the existing namespace will contain data with mixed dimensions, causing retrieval issues. To avoid this, either use a different `vector_store_namespace` or set `cleanup_on_shutdown: true` before restarting.
+**Dimension / Provider / Model Changes**: A vector store namespace can only hold vectors of **one** dimension. If you change `dimension` (or switch to an embedding `provider`/`model` that produces a different vector size), the existing namespace is **not** recreated automatically — `CreateNamespace` is a no-op when the class/collection already exists. Subsequent writes will fail (vector-size mismatch) and reads will silently miss. Before saving the change, either:
+
+- point `vector_store_namespace` at a fresh name, or
+- drop the existing class/index in your vector store, or
+- set `cleanup_on_shutdown: true` and restart so the old namespace is removed first.
 </Warning>
 
 ---

--- a/docs/migration-guides/v1.5.0.mdx
+++ b/docs/migration-guides/v1.5.0.mdx
@@ -690,6 +690,67 @@ The supported `BifrostContextKeyAPIKeyID` / `BifrostContextKeyAPIKeyName` path c
 
 ---
 
+## Breaking Change 15: Semantic Cache Clear API is Now Cache-ID Based
+
+The semantic cache "clear by request ID" API has been removed. Storage IDs in the cache are deterministic UUIDv5 hashes derived from the request payload (so the same prompt across many requests maps to a single cache entry), which made the previous request-ID-based delete unable to match anything written by the direct-search path.
+
+The replacement is keyed on the cache entry's storage ID, which is now stamped on every response in `extra_fields.cache_debug.cache_id` — on cache hits **and** cache misses. Hold onto that ID from the response if you ever need to invalidate the entry.
+
+### REST API
+
+| Before (v1.4.x) | After (v1.5.0) |
+|---|---|
+| `DELETE /api/cache/clear/{requestId}` | `DELETE /api/cache/clear/{cacheId}` |
+
+The path parameter name and meaning both changed. The cache key endpoint (`DELETE /api/cache/clear-by-key/{cacheKey}`) is unchanged.
+
+**Before:**
+```bash
+curl -X DELETE localhost:8080/api/cache/clear/req-aaa-bbb-ccc
+```
+
+**After:**
+```bash
+# Read the cache ID from a prior response
+CACHE_ID=$(curl ... | jq -r '.extra_fields.cache_debug.cache_id')
+
+curl -X DELETE localhost:8080/api/cache/clear/$CACHE_ID
+```
+
+### Go SDK
+
+The `ClearCacheForRequestID` method on `*semanticcache.Plugin` has been removed and replaced by `ClearCacheForCacheID`.
+
+**Before:**
+```go
+err := plugin.ClearCacheForRequestID(requestID)
+```
+
+**After:**
+```go
+// On hit or miss, the storage ID is exposed via CacheDebug.CacheID
+cacheID := response.ExtraFields.CacheDebug.CacheID
+if cacheID != nil {
+    err := plugin.ClearCacheForCacheID(*cacheID)
+}
+```
+
+### Why the rename
+
+A single cache entry is reused across many request IDs (that is the point of caching). A request-ID-based delete only ever made sense for the original writer of the entry, and even that broke once direct search switched to deterministic storage IDs. The cache ID is the only stable handle that works for both writers and readers, so the API now reflects that.
+
+### CacheDebug on misses
+
+`extra_fields.cache_debug` is now populated on cache misses too — previously it was only emitted when semantic search ran. The new fields on a miss:
+
+- `cache_hit: false`
+- `cache_id`: the storage ID where the entry was written (use this with `ClearCacheForCacheID`)
+- `provider_used` / `model_used` / `input_tokens`: only present when semantic search actually ran (i.e. embedding model was invoked)
+
+If you parse `cache_debug` and assumed it was either absent or had `cache_hit: true`, update your consumer to handle the `cache_hit: false` shape.
+
+---
+
 ## Opting Out: `version: 1` Compatibility Mode
 
 If you are not ready to adopt the new deny-by-default semantics, you can add a single field to `config.json` to restore v1.4.x behavior for all allow-list fields loaded from that file:
@@ -787,6 +848,10 @@ If your code reads `selected_key_id` / `selected_key_name` from the request cont
 
 <Step title="Migrate direct-key callers off both surfaces">
 Remove `allow_direct_keys` from `config.json` and any `PUT /api/config` payloads. Audit HTTP callers that sent provider keys in `Authorization` / `x-api-key` / `x-goog-api-key` / `x-bf-bedrock-*` / `x-bf-azure-endpoint` headers — those keys are no longer forwarded. Audit Go SDK callers for any reference to `schemas.BifrostContextKeyDirectKey` — the constant is removed and code referencing it will not compile. Replace both flavours with a Bifrost-managed provider key, optionally pinned per request via `BifrostContextKeyAPIKeyID` / `BifrostContextKeyAPIKeyName` (Go SDK) or a virtual key (`sk-bf-*`, HTTP).
+</Step>
+
+<Step title="Switch semantic cache invalidation to cache IDs">
+Replace `DELETE /api/cache/clear/{requestId}` with `DELETE /api/cache/clear/{cacheId}`, and replace `plugin.ClearCacheForRequestID(...)` with `plugin.ClearCacheForCacheID(...)`. Read the cache ID from `extra_fields.cache_debug.cache_id` on the response (now populated on misses too).
 </Step>
 </Steps>
 

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -41914,20 +41914,20 @@
         }
       }
     },
-    "/api/cache/clear/{requestId}": {
+    "/api/cache/clear/{cacheId}": {
       "delete": {
-        "operationId": "clearCacheByRequestId",
-        "summary": "Clear cache by request ID",
-        "description": "Clears cache entries associated with a specific request ID.",
+        "operationId": "clearCacheByCacheId",
+        "summary": "Clear cache entry by cache ID",
+        "description": "Deletes a single cache entry by its storage ID. Read the cache ID from\n`extra_fields.cache_debug.cache_id` on a prior response — it is populated\non both cache hits and cache misses.\n",
         "tags": [
           "Cache"
         ],
         "parameters": [
           {
-            "name": "requestId",
+            "name": "cacheId",
             "in": "path",
             "required": true,
-            "description": "Request ID to clear cache for",
+            "description": "Storage ID of the cache entry to delete",
             "schema": {
               "type": "string"
             }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -788,8 +788,8 @@ paths:
     $ref: './paths/management/prompts.yaml#/sessions-commit'
 
   # Cache
-  /api/cache/clear/{requestId}:
-    $ref: './paths/management/cache.yaml#/clear-by-request-id'
+  /api/cache/clear/{cacheId}:
+    $ref: './paths/management/cache.yaml#/clear-by-cache-id'
   /api/cache/clear-by-key/{cacheKey}:
     $ref: './paths/management/cache.yaml#/clear-by-cache-key'
 

--- a/docs/openapi/paths/management/cache.yaml
+++ b/docs/openapi/paths/management/cache.yaml
@@ -1,15 +1,18 @@
-clear-by-request-id:
+clear-by-cache-id:
   delete:
-    operationId: clearCacheByRequestId
-    summary: Clear cache by request ID
-    description: Clears cache entries associated with a specific request ID.
+    operationId: clearCacheByCacheId
+    summary: Clear cache entry by cache ID
+    description: |
+      Deletes a single cache entry by its storage ID. Read the cache ID from
+      `extra_fields.cache_debug.cache_id` on a prior response — it is populated
+      on both cache hits and cache misses.
     tags:
       - Cache
     parameters:
-      - name: requestId
+      - name: cacheId
         in: path
         required: true
-        description: Request ID to clear cache for
+        description: Storage ID of the cache entry to delete
         schema:
           type: string
     responses:

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -634,7 +634,8 @@ func canUseMatViewFilters(f SearchFilters) bool {
 		f.MinLatency == nil && f.MaxLatency == nil &&
 		f.MinTokens == nil && f.MaxTokens == nil &&
 		f.MinCost == nil && f.MaxCost == nil &&
-		!f.MissingCostOnly
+		!f.MissingCostOnly &&
+		len(f.CacheHitTypes) == 0
 }
 
 // canUseMatView checks both that materialized views are ready (created and

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -192,6 +192,29 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 		// cost is null and status is not error
 		baseQuery = baseQuery.Where("(cost IS NULL OR cost <= 0) AND status NOT IN ('error')")
 	}
+	if len(filters.CacheHitTypes) > 0 {
+		// Only keep allowed values to avoid passing arbitrary input into the JSON path expression.
+		valid := make([]string, 0, len(filters.CacheHitTypes))
+		for _, t := range filters.CacheHitTypes {
+			if t == "direct" || t == "semantic" {
+				valid = append(valid, t)
+			}
+		}
+		if len(valid) > 0 {
+			if s.db.Dialector.Name() == "postgres" {
+				// Match the same loose-JSON guard used by aggregateCacheHits so the regex extract is safe.
+				baseQuery = baseQuery.Where(
+					"cache_debug IS NOT NULL AND cache_debug <> '' AND cache_debug ~ '^\\s*\\{.*\\}\\s*$' AND substring(cache_debug from '\"hit_type\"[[:space:]]*:[[:space:]]*\"([^\"]+)\"') IN ?",
+					valid,
+				)
+			} else {
+				baseQuery = baseQuery.Where(
+					"cache_debug IS NOT NULL AND cache_debug != '' AND json_valid(cache_debug) AND json_extract(cache_debug, '$.hit_type') IN ?",
+					valid,
+				)
+			}
+		}
+	}
 	if filters.ContentSearch != "" {
 		dialect := s.db.Dialector.Name()
 		if dialect == "postgres" {
@@ -642,7 +665,7 @@ func (s *RDBLogStore) listSelectColumns() string {
 		"business_unit_id", "business_unit_name",
 		"speech_input", "transcription_input", "image_generation_input", "video_generation_input",
 		"latency", "token_usage", "cost", "status", "error_details", "stream",
-		"content_summary", "metadata",
+		"content_summary", "metadata", "cache_debug",
 		"is_large_payload_request", "is_large_payload_response",
 		"prompt_tokens", "completion_tokens", "total_tokens",
 		"created_at",

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -68,6 +68,7 @@ type SearchFilters struct {
 	MinCost           *float64          `json:"min_cost,omitempty"`
 	MaxCost           *float64          `json:"max_cost,omitempty"`
 	MissingCostOnly   bool              `json:"missing_cost_only,omitempty"`
+	CacheHitTypes     []string          `json:"cache_hit_types,omitempty"` // For filtering by local-cache hit type ("direct", "semantic")
 	ContentSearch     string            `json:"content_search,omitempty"`
 	MetadataFilters   map[string]string `json:"metadata_filters,omitempty"` // key=metadataKey, value=metadataValue for filtering by metadata
 }

--- a/framework/modelcatalog/sync.go
+++ b/framework/modelcatalog/sync.go
@@ -395,7 +395,7 @@ func (mc *ModelCatalog) applyModelParameters(paramsData map[string]json.RawMessa
 		}
 		if err := json.Unmarshal(rawData, &p); err == nil && (p.MaxOutputTokens != nil || parsed.VertexMultiRegionOnly != nil) {
 			modelParamsEntries[model] = providerUtils.ModelParams{
-				MaxOutputTokens:        p.MaxOutputTokens,
+				MaxOutputTokens:         p.MaxOutputTokens,
 				IsVertexMultiRegionOnly: parsed.VertexMultiRegionOnly,
 			}
 		}

--- a/framework/vectorstore/weaviate.go
+++ b/framework/vectorstore/weaviate.go
@@ -476,6 +476,12 @@ func newWeaviateStore(ctx context.Context, config *WeaviateConfig, logger schema
 }
 
 func (s *WeaviateStore) CreateNamespace(ctx context.Context, className string, dimension int, properties map[string]VectorStoreProperties) error {
+	// Reject names Weaviate would silently auto-capitalize: writes via REST
+	// route fine, but the GraphQL read path is case-strict and breaks.
+	if err := validateClassName(className); err != nil {
+		return err
+	}
+
 	// Check if class exists
 	exists, err := s.client.Schema().ClassExistenceChecker().
 		WithClassName(className).
@@ -636,4 +642,21 @@ func convertOperator(op QueryOperator) filters.WhereOperator {
 		// Default to Equal if unknown
 		return filters.Equal
 	}
+}
+
+// validateClassName enforces Weaviate's class-name rule that the first
+// character must be an uppercase ASCII letter. Weaviate's REST endpoints
+// silently auto-capitalize a lowercase first character on class creation,
+// which means writes appear to succeed under the user-supplied name but
+// GraphQL reads (which are case-strict) then fail with "Did you mean
+// <Capitalized>?". Surface this at config-save time instead.
+func validateClassName(name string) error {
+	if name == "" {
+		return nil
+	}
+	first := name[0]
+	if first < 'A' || first > 'Z' {
+		return fmt.Errorf("Weaviate requires class names to start with an uppercase letter (A-Z); got %q. Try %q", name, strings.ToUpper(name[:1])+name[1:])
+	}
+	return nil
 }

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -830,10 +830,16 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 
 	// Build the complete log entry with input (from PreLLMHook) + output (from PostLLMHook)
 	entry := buildCompleteLogEntryFromPending(pending)
-	// Apply common output fields
+	// Apply common output fields. For cache hits, prefer the cache-serve
+	// latency stamped by the semantic cache plugin over the original provider
+	// latency preserved in the cached response.
 	var latency int64
 	if result != nil {
-		latency = result.GetExtraFields().Latency
+		ef := result.GetExtraFields()
+		latency = ef.Latency
+		if ef.CacheDebug != nil && ef.CacheDebug.CacheHit && ef.CacheDebug.CacheHitLatency != nil {
+			latency = *ef.CacheDebug.CacheHitLatency
+		}
 	}
 	applyOutputFieldsToEntry(entry, selectedKeyID, selectedKeyName, virtualKeyID, virtualKeyName, routingRuleID, routingRuleName, selectedPromptID, selectedPromptName, selectedPromptVersion, teamID, teamName, customerID, customerName, userID, userName, businessUnitID, businessUnitName, numberOfRetries, latency, attemptTrail)
 	entry.MetadataParsed = pending.InitialData.Metadata

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -378,16 +378,6 @@ func (p *LoggerPlugin) applyStreamingOutputToEntry(entry *logstore.Log, streamRe
 		entry.StopReason = streamResponse.Data.FinishReason
 	}
 
-	// Cache
-	if streamResponse.Data.CacheDebug != nil {
-		entry.CacheDebugParsed = streamResponse.Data.CacheDebug
-	}
-
-	// Finish/stop reason - always persist regardless of content logging settings
-	if streamResponse.Data.FinishReason != nil {
-		entry.StopReason = streamResponse.Data.FinishReason
-	}
-
 	// Passthrough status code
 	if streamResponse.Data.PassthroughOutput != nil {
 		if params, ok := entry.ParamsParsed.(*schemas.PassthroughLogParams); ok {

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -7,11 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"sync"
 	"time"
-
-	"github.com/google/uuid"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -21,6 +18,13 @@ import (
 // Config contains configuration for the semantic cache plugin.
 // The VectorStore abstraction handles the underlying storage implementation and its defaults.
 // Only specify values you want to override from the semantic cache defaults.
+//
+// Modes:
+//   - Semantic mode: set Provider + EmbeddingModel + Dimension > 0. Both direct
+//     hash matching and embedding-based similarity search are enabled.
+//   - Direct-only mode: set Provider="" and Dimension=1. The plugin disables
+//     semantic search entirely; cache lookups go through the deterministic
+//     direct hash path. Dimension=1 keeps stores that require a vector happy.
 type Config struct {
 	// Embedding Model settings - REQUIRED for semantic caching
 	Provider       schemas.ModelProvider `json:"provider"`
@@ -29,9 +33,9 @@ type Config struct {
 	// Plugin behavior settings
 	CleanUpOnShutdown    bool          `json:"cleanup_on_shutdown,omitempty"`    // Clean up cache on shutdown (default: false)
 	TTL                  time.Duration `json:"ttl,omitempty"`                    // Time-to-live for cached responses (default: 5min)
-	Threshold            float64       `json:"threshold,omitempty"`              // Cosine similarity threshold for semantic matching (default: 0.8)
+	Threshold            float64       `json:"threshold,omitempty"`              // Cosine similarity threshold for semantic matching (0 = unset → default 0.8)
 	VectorStoreNamespace string        `json:"vector_store_namespace,omitempty"` // Namespace for vector store (optional)
-	Dimension            int           `json:"dimension"`                        // Dimension for vector store
+	Dimension            int           `json:"dimension"`                        // Dimension for vector store (must be > 0 when Provider is set; use 1 for direct-only mode)
 
 	// Advanced caching behavior
 	DefaultCacheKey              string `json:"default_cache_key,omitempty"`              // Default cache key used when no per-request key is provided (optional, caching is disabled when empty and no per-request key is set)
@@ -41,117 +45,125 @@ type Config struct {
 	ExcludeSystemPrompt          *bool  `json:"exclude_system_prompt,omitempty"`          // Exclude system prompt in cache key (default: false)
 }
 
-// UnmarshalJSON implements custom JSON unmarshaling for semantic cache Config.
-// It supports TTL parsing from both string durations ("1m", "1hr") and numeric seconds for configurable cache behavior.
+// UnmarshalJSON implements custom JSON unmarshaling for Config so TTL accepts
+// either a duration string ("1m", "1h") or a JSON number (seconds). All other
+// fields decode through the default path via a type alias, so adding a new
+// field on Config does not require touching this method.
 func (c *Config) UnmarshalJSON(data []byte) error {
-	// Define a temporary struct to avoid infinite recursion
-	type TempConfig struct {
-		Provider                     string      `json:"provider"`
-		EmbeddingModel               string      `json:"embedding_model,omitempty"`
-		CleanUpOnShutdown            bool        `json:"cleanup_on_shutdown,omitempty"`
-		Dimension                    int         `json:"dimension"`
-		TTL                          interface{} `json:"ttl,omitempty"`
-		Threshold                    float64     `json:"threshold,omitempty"`
-		VectorStoreNamespace         string      `json:"vector_store_namespace,omitempty"`
-		DefaultCacheKey              string      `json:"default_cache_key,omitempty"`
-		ConversationHistoryThreshold int         `json:"conversation_history_threshold,omitempty"`
-		CacheByModel                 *bool       `json:"cache_by_model,omitempty"`
-		CacheByProvider              *bool       `json:"cache_by_provider,omitempty"`
-		ExcludeSystemPrompt          *bool       `json:"exclude_system_prompt,omitempty"`
-	}
-
-	var temp TempConfig
-	if err := json.Unmarshal(data, &temp); err != nil {
+	// alias suppresses Config's UnmarshalJSON to avoid infinite recursion.
+	// The outer TTL (json.RawMessage) shadows alias.TTL because the json
+	// package picks the shallower field on a name conflict.
+	type alias Config
+	aux := &struct {
+		TTL json.RawMessage `json:"ttl,omitempty"`
+		*alias
+	}{alias: (*alias)(c)}
+	if err := json.Unmarshal(data, aux); err != nil {
 		return fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
-	// Set simple fields
-	c.Provider = schemas.ModelProvider(temp.Provider)
-	c.EmbeddingModel = temp.EmbeddingModel
-	c.CleanUpOnShutdown = temp.CleanUpOnShutdown
-	c.Dimension = temp.Dimension
-	c.CacheByModel = temp.CacheByModel
-	c.CacheByProvider = temp.CacheByProvider
-	c.VectorStoreNamespace = temp.VectorStoreNamespace
-	c.ConversationHistoryThreshold = temp.ConversationHistoryThreshold
-	c.Threshold = temp.Threshold
-	c.DefaultCacheKey = temp.DefaultCacheKey
-	c.ExcludeSystemPrompt = temp.ExcludeSystemPrompt
-	// Handle TTL field with custom parsing for VectorStore-backed cache behavior
-	if temp.TTL != nil {
-		switch v := temp.TTL.(type) {
-		case string:
-			// Try parsing as duration string (e.g., "1m", "1hr") for semantic cache TTL
-			duration, err := time.ParseDuration(v)
-			if err != nil {
-				return fmt.Errorf("failed to parse TTL duration string '%s': %w", v, err)
-			}
-			c.TTL = duration
-		case int:
-			// Handle integer seconds for semantic cache TTL
-			c.TTL = time.Duration(v) * time.Second
-		default:
-			// Try converting to string and parsing as number for semantic cache TTL
-			ttlStr := fmt.Sprintf("%v", v)
-			if seconds, err := strconv.ParseFloat(ttlStr, 64); err == nil {
-				c.TTL = time.Duration(seconds * float64(time.Second))
-			} else {
-				return fmt.Errorf("unsupported TTL type: %T (value: %v)", v, v)
-			}
-		}
+	if len(aux.TTL) == 0 || string(aux.TTL) == "null" {
+		return nil
 	}
 
+	// Try string first ("1m"); fall back to a JSON number (seconds).
+	var s string
+	if err := json.Unmarshal(aux.TTL, &s); err == nil {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return fmt.Errorf("failed to parse TTL duration string '%s': %w", s, err)
+		}
+		c.TTL = d
+	} else {
+		var seconds float64
+		if err := json.Unmarshal(aux.TTL, &seconds); err != nil {
+			return fmt.Errorf("unsupported TTL value: %s", string(aux.TTL))
+		}
+		c.TTL = time.Duration(seconds * float64(time.Second))
+	}
+	if c.TTL < 0 {
+		return fmt.Errorf("TTL must be non-negative, got %v", c.TTL)
+	}
 	return nil
 }
 
-// StreamChunk represents a single chunk from a streaming response
+// StreamChunk is one chunk from a streaming response, retained until the
+// stream completes so it can be persisted as part of the cache entry.
 type StreamChunk struct {
-	Timestamp    time.Time                // When chunk was received
-	Response     *schemas.BifrostResponse // The actual response chunk
-	FinishReason *string                  // If this is the final chunk
+	// Timestamp records when this chunk arrived at PostLLMHook. Used by the
+	// reaper to drop accumulators stuck without a final chunk.
+	Timestamp time.Time
+	// Response is the chunk payload as delivered by the provider.
+	Response *schemas.BifrostResponse
 }
 
-// StreamAccumulator manages accumulation of streaming chunks for caching
+// StreamAccumulator collects the chunks of a single streaming response so
+// they can be flushed as one cache entry on the final chunk.
 type StreamAccumulator struct {
-	RequestID      string         // The request ID
-	StorageID      string         // The final cache entry ID
-	Chunks         []*StreamChunk // All chunks for this stream
-	IsComplete     bool           // Whether the stream is complete
-	HasError       bool           // Whether any chunk in the stream had an error
-	FinalTimestamp time.Time      // When the stream completed
-	Embedding      []float32      // Embedding for the original request
-	Metadata       map[string]any // Metadata for caching
-	TTL            time.Duration  // TTL for this cache entry
-	mu             sync.Mutex     // Protects chunk operations
+	// mu serializes Chunks/IsComplete updates across the per-chunk PostLLMHook
+	// invocations and the periodic reaper.
+	mu sync.Mutex
+	// RequestID is the BifrostContext request ID this accumulator is keyed by.
+	RequestID string
+	// StorageID is the cache entry ID the accumulated stream will be written under.
+	StorageID string
+	// Chunks holds every chunk seen so far, in arrival order.
+	Chunks []*StreamChunk
+	// LastSeenAt records the arrival time of the most recent chunk. The reaper
+	// uses this so a long-running stream isn't evicted mid-flight; first-chunk
+	// time alone would falsely flag still-active streams as abandoned.
+	LastSeenAt time.Time
+	// IsComplete is set when the final chunk has been observed; further final
+	// chunks are no-ops to keep flush idempotent.
+	IsComplete bool
+	// Embedding is the request embedding to attach to the cache entry, or nil
+	// for direct-only writes.
+	Embedding []float32
+	// Metadata is the unified metadata captured at first-chunk time and reused
+	// at flush. expires_at is locked in here, so TTL is fixed at first chunk.
+	Metadata map[string]any
+	// TTL is retained for symmetry with Metadata; the effective expiry is the
+	// expires_at value already baked into Metadata.
+	TTL time.Duration
 }
 
-// EmbeddingRequestExecutor is a function that executes a request and returns a response and an error.
-// It maps to .EmbeddingRequest() of the bifrost client.
+// EmbeddingRequestExecutor invokes the embedding endpoint on the bifrost
+// client. The plugin calls it on cache misses to compute the request
+// embedding for semantic similarity search and storage. It mirrors the
+// signature of bifrost.Client.EmbeddingRequest.
 type EmbeddingRequestExecutor func(ctx *schemas.BifrostContext, req *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError)
 
-// Plugin implements the schemas.LLMPlugin interface for semantic caching.
-// It caches responses using a two-tier approach: direct hash matching for exact requests
-// and semantic similarity search for related content. The plugin supports configurable caching behavior
-// via the VectorStore abstraction, including TTL management and streaming response handling.
-//
-// Fields:
-//   - store: VectorStore instance for semantic cache operations
-//   - config: Plugin configuration including semantic cache and caching settings
-//   - logger: Logger instance for plugin operations
+// Plugin implements schemas.LLMPlugin for semantic caching. It serves cached
+// responses via two complementary lookup paths: a direct O(1) hash match on
+// (provider, model, cache_key, request_hash, params_hash) for exact replays,
+// and an embedding-based similarity search for semantically related content.
+// Streaming responses are accumulated chunk-by-chunk and stored as a single
+// entry on the final chunk; TTL bookkeeping is per-entry via expires_at.
 type Plugin struct {
 	store                    vectorstore.VectorStore
 	config                   *Config
 	logger                   schemas.Logger
 	embeddingRequestExecutor EmbeddingRequestExecutor
-	streamAccumulators       sync.Map // Track stream accumulators by request ID
-	waitGroup                sync.WaitGroup
+	// streamAccumulators maps request ID → its in-progress *StreamAccumulator.
+	streamAccumulators sync.Map
+	// cacheStates maps request ID → its *cacheState (see state.go) for the
+	// span between PreLLMHook and PostLLMHook.
+	cacheStates sync.Map
+	// writersWg tracks short-lived per-request goroutines (the async cache
+	// writes spawned in PostLLMHook). WaitForPendingOperations blocks on this
+	// — tests use it to flush writes before asserting on the store.
+	writersWg sync.WaitGroup
+	// cleanupWg tracks the long-running background loops (stream + cacheState
+	// reapers). Only Cleanup blocks on this, after closing stopCh.
+	cleanupWg sync.WaitGroup
+	// stopCh is closed by Cleanup to signal the background reaper loops to exit.
+	stopCh chan struct{}
 }
 
 // Plugin constants
 const (
 	PluginName                          string        = "semantic_cache"
 	DefaultVectorStoreNamespace         string        = "BifrostSemanticCachePlugin"
-	PluginLoggerPrefix                  string        = "[Semantic Cache]"
 	CacheConnectionTimeout              time.Duration = 5 * time.Second
 	CreateNamespaceTimeout              time.Duration = 30 * time.Second
 	CacheSetTimeout                     time.Duration = 30 * time.Second
@@ -160,13 +172,14 @@ const (
 	DefaultConversationHistoryThreshold int           = 3
 )
 
-var SelectFields = []string{"request_hash", "response", "stream_chunks", "expires_at", "cache_key", "provider", "model"}
+// SelectFields enumerates the properties projected back from the vector store
+// on a cache hit. params_hash and from_bifrost_semantic_cache_plugin are
+// filter-only (used in WHERE-style queries to narrow matches) and intentionally
+// omitted from this projection — keep them defined in VectorStoreProperties
+// below so the store creates the columns/indexes, but don't fetch them.
+var SelectFields = []string{"response", "stream_chunks", "expires_at", "cache_key", "provider", "model"}
 
 var VectorStoreProperties = map[string]vectorstore.VectorStoreProperties{
-	"request_hash": {
-		DataType:    vectorstore.VectorStorePropertyTypeString,
-		Description: "The hash of the request",
-	},
 	"response": {
 		DataType:    vectorstore.VectorStorePropertyTypeString,
 		Description: "The response from the provider",
@@ -201,24 +214,15 @@ var VectorStoreProperties = map[string]vectorstore.VectorStoreProperties{
 	},
 }
 
+// Per-request context keys. Callers set these on BifrostContext before the
+// request enters Bifrost; the plugin reads them in Pre/PostLLMHook. CacheKey
+// (or Config.DefaultCacheKey) is the only one required for caching to engage.
 const (
-	CacheKey          schemas.BifrostContextKey = "semantic_cache_key"        // To set the cache key for a request - REQUIRED for all requests
-	CacheTTLKey       schemas.BifrostContextKey = "semantic_cache_ttl"        // To explicitly set the TTL for a request
-	CacheThresholdKey schemas.BifrostContextKey = "semantic_cache_threshold"  // To explicitly set the threshold for a request
-	CacheTypeKey      schemas.BifrostContextKey = "semantic_cache_cache_type" // To explicitly set the cache type for a request
-	CacheNoStoreKey   schemas.BifrostContextKey = "semantic_cache_no_store"   // To explicitly disable storing the response in the cache
-
-	// context keys for internal usage
-	requestIDKey              schemas.BifrostContextKey = "semantic_cache_request_id"
-	requestStorageIDKey       schemas.BifrostContextKey = "semantic_cache_request_storage_id"
-	requestHashKey            schemas.BifrostContextKey = "semantic_cache_request_hash"
-	requestEmbeddingKey       schemas.BifrostContextKey = "semantic_cache_embedding"
-	requestEmbeddingTokensKey schemas.BifrostContextKey = "semantic_cache_embedding_tokens"
-	requestParamsHashKey      schemas.BifrostContextKey = "semantic_cache_params_hash"
-	requestModelKey           schemas.BifrostContextKey = "semantic_cache_model"
-	requestProviderKey        schemas.BifrostContextKey = "semantic_cache_provider"
-	isCacheHitKey             schemas.BifrostContextKey = "semantic_cache_is_cache_hit"
-	cacheHitTypeKey           schemas.BifrostContextKey = "semantic_cache_cache_hit_type"
+	CacheKey          schemas.BifrostContextKey = "semantic_cache-key"        // String. Required (or DefaultCacheKey) — bucket entries under a tenant/feature scope.
+	CacheTTLKey       schemas.BifrostContextKey = "semantic_cache-ttl"        // time.Duration. Per-request override of Config.TTL.
+	CacheThresholdKey schemas.BifrostContextKey = "semantic_cache-threshold"  // float64. Per-request override of the semantic similarity threshold.
+	CacheTypeKey      schemas.BifrostContextKey = "semantic_cache-cache_type" // CacheType. Narrow lookup to a single path (direct or semantic).
+	CacheNoStoreKey   schemas.BifrostContextKey = "semantic_cache-no_store"   // bool. Skip writing the response to cache (still served from cache on hit).
 )
 
 type CacheType string
@@ -228,20 +232,12 @@ const (
 	CacheTypeSemantic CacheType = "semantic"
 )
 
-// Init creates a new semantic cache plugin instance with the provided configuration.
-// It uses the VectorStore abstraction for cache operations and returns a configured plugin.
+// Init validates the configuration, creates the namespace in the underlying
+// VectorStore, starts the background reaper goroutines, and returns a plugin
+// ready to be wired into the Bifrost plugin pipeline.
 //
-// The VectorStore handles the underlying storage implementation and its defaults.
-// The plugin only sets defaults for its own behavior (TTL, cache key generation, etc.).
-//
-// Parameters:
-//   - config: Semantic cache and plugin configuration (CacheKey is required)
-//   - logger: Logger instance for the plugin
-//   - store: VectorStore instance for cache operations
-//
-// Returns:
-//   - schemas.LLMPlugin: A configured semantic cache plugin instance
-//   - error: Any error that occurred during plugin initialization
+// Note: Init mutates *config in place to fill in defaults — TTL, Threshold,
+// CacheBy* — so the caller sees the resolved values after this returns.
 func Init(ctx context.Context, config *Config, logger schemas.Logger, store vectorstore.VectorStore) (schemas.LLMPlugin, error) {
 	if config == nil {
 		return nil, fmt.Errorf("config is required")
@@ -249,43 +245,51 @@ func Init(ctx context.Context, config *Config, logger schemas.Logger, store vect
 	if store == nil {
 		return nil, fmt.Errorf("store is required")
 	}
+	if config.Dimension < 0 {
+		return nil, fmt.Errorf("dimension must be non-negative, got %d", config.Dimension)
+	}
+	if config.Provider != "" && config.Dimension <= 0 {
+		return nil, fmt.Errorf("dimension must be > 0 when provider is set (got dimension=%d, provider=%q)", config.Dimension, config.Provider)
+	}
 	// Set plugin-specific defaults
 	if config.VectorStoreNamespace == "" {
-		logger.Debug(PluginLoggerPrefix + " Vector store namespace is not set, using default of " + DefaultVectorStoreNamespace)
+		logger.Debug("Vector store namespace is not set, using default of %s", DefaultVectorStoreNamespace)
 		config.VectorStoreNamespace = DefaultVectorStoreNamespace
 	}
 	if config.TTL == 0 {
-		logger.Debug(PluginLoggerPrefix + " TTL is not set, using default of 5 minutes")
+		logger.Debug("TTL is not set, using default of %v", DefaultCacheTTL)
 		config.TTL = DefaultCacheTTL
 	}
 	if config.Threshold == 0 {
-		logger.Debug(PluginLoggerPrefix + " Threshold is not set, using default of " + strconv.FormatFloat(DefaultCacheThreshold, 'f', -1, 64))
+		logger.Debug("Threshold is not set, using default of %v", DefaultCacheThreshold)
 		config.Threshold = DefaultCacheThreshold
 	}
 	if config.ConversationHistoryThreshold == 0 {
-		logger.Debug(PluginLoggerPrefix + " Conversation history threshold is not set, using default of " + strconv.Itoa(DefaultConversationHistoryThreshold))
+		logger.Debug("Conversation history threshold is not set, using default of %d", DefaultConversationHistoryThreshold)
 		config.ConversationHistoryThreshold = DefaultConversationHistoryThreshold
 	}
 
 	// Set cache behavior defaults
 	if config.CacheByModel == nil {
+		logger.Debug("CacheByModel is not set, defaulting to true")
 		config.CacheByModel = new(true)
 	}
 	if config.CacheByProvider == nil {
+		logger.Debug("CacheByProvider is not set, defaulting to true")
 		config.CacheByProvider = new(true)
 	}
 
 	plugin := &Plugin{
-		store:     store,
-		config:    config,
-		logger:    logger,
-		waitGroup: sync.WaitGroup{},
+		store:  store,
+		config: config,
+		logger: logger,
+		stopCh: make(chan struct{}),
 	}
 
 	if config.Provider == "" && config.Dimension == 1 {
-		logger.Info(PluginLoggerPrefix + " Starting in direct-only mode (dimension=1, no embedding provider)")
+		logger.Info("Starting in direct-only mode (dimension=1, no embedding provider)")
 	} else if config.Provider == "" {
-		logger.Warn(PluginLoggerPrefix + " Incomplete semantic mode config: missing provider, falling back to direct search only")
+		logger.Warn("Incomplete semantic mode config: missing provider, falling back to direct search only")
 	}
 
 	createCtx, cancel := context.WithTimeout(ctx, CreateNamespaceTimeout)
@@ -294,382 +298,281 @@ func Init(ctx context.Context, config *Config, logger schemas.Logger, store vect
 		return nil, fmt.Errorf("failed to create namespace for semantic cache: %w", err)
 	}
 
+	plugin.cleanupWg.Add(1)
+	go plugin.runStreamCleanupLoop()
+
+	plugin.cleanupWg.Add(1)
+	go plugin.runCacheStateCleanupLoop()
+
 	return plugin, nil
 }
 
-// GetName returns the canonical name of the semantic cache plugin.
-// This name is used for plugin identification and logging purposes.
-//
-// Returns:
-//   - string: The plugin name for semantic cache
+// GetName returns the canonical name used for plugin identification and logging.
 func (plugin *Plugin) GetName() string {
 	return PluginName
 }
 
-// HTTPTransportPreHook is not used for this plugin
+// HTTPTransportPreHook is not used by the semantic cache plugin.
 func (plugin *Plugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest) (*schemas.HTTPResponse, error) {
 	return nil, nil
 }
 
-// HTTPTransportPostHook is not used for this plugin
+// HTTPTransportPostHook is not used by the semantic cache plugin.
 func (plugin *Plugin) HTTPTransportPostHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, resp *schemas.HTTPResponse) error {
 	return nil
 }
 
-// HTTPTransportStreamChunkHook passes through streaming chunks unchanged
+// HTTPTransportStreamChunkHook passes streaming chunks through unchanged.
 func (plugin *Plugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostContext, req *schemas.HTTPRequest, chunk *schemas.BifrostStreamChunk) (*schemas.BifrostStreamChunk, error) {
 	return chunk, nil
 }
 
-// PreLLMHook is called before a request is processed by Bifrost.
-// It performs a two-stage cache lookup: first direct hash matching, then semantic similarity search.
-// Uses UUID-based keys for entries stored in the VectorStore.
-//
-// Parameters:
-//   - ctx: Pointer to the schemas.BifrostContext
-//   - req: The incoming Bifrost request
-//
-// Returns:
-//   - *schemas.BifrostRequest: The original request
-//   - *schemas.BifrostResponse: Cached response if found, nil otherwise
-//   - error: Any error that occurred during cache lookup
+// PreLLMHook performs the cache lookup before the request reaches the
+// provider. It runs the direct hash path first (cheapest), falls back to
+// semantic similarity search when configured, and short-circuits the
+// pipeline with a cached response on hit. On miss, it leaves per-request
+// state on the plugin keyed by request ID for PostLLMHook to consume when
+// the upstream response arrives.
 func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
-	provider, model, _ := req.GetRequestFields()
-	// Get the cache key from the context
-	var cacheKey string
-	var ok bool
-
-	cacheKey, ok = ctx.Value(CacheKey).(string)
-	if !ok || cacheKey == "" {
-		if plugin.config.DefaultCacheKey != "" {
-			cacheKey = plugin.config.DefaultCacheKey
-			plugin.logger.Debug(PluginLoggerPrefix + " Using default cache key: " + cacheKey)
-		} else {
-			plugin.logger.Debug(PluginLoggerPrefix + " No cache key found in context, continuing without caching")
-			return req, nil, nil
-		}
+	cacheKey, ok := plugin.resolveCacheKey(ctx)
+	if !ok {
+		return req, nil, nil
 	}
 
-	// Clear request-scoped semantic cache state up front in case the context is reused.
-	plugin.clearRequestScopedContext(ctx)
+	// Without a request ID we have nowhere to anchor per-request state. The
+	// framework always stamps this before plugin hooks run; direct callers
+	// (tests, custom integrations) must set it too.
+	requestID, ok := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
+	if !ok || requestID == "" {
+		return req, nil, nil
+	}
 
 	if !isSemanticCacheSupportedRequestType(req.RequestType) {
-		plugin.logger.Debug(PluginLoggerPrefix + " Skipping caching for unsupported request type: " + string(req.RequestType))
 		return req, nil, nil
 	}
 
-	if plugin.isConversationHistoryThresholdExceeded(req) {
-		plugin.logger.Debug(PluginLoggerPrefix + " Skipping caching for request with conversation history threshold exceeded")
+	// Create state up front so a reused/retried request ID never inherits stale fields.
+	state := plugin.createCacheState(requestID)
+
+	if plugin.isConversationHistoryThresholdExceeded(state, req) {
+		plugin.clearCacheState(requestID)
 		return req, nil, nil
 	}
 
-	// Generate UUID for this request
-	requestID := uuid.New().String()
+	performDirectSearch, performSemanticSearch := plugin.resolveCacheTypes(ctx)
 
-	// Store request ID, model, and provider in context for PostLLMHook
-	ctx.SetValue(requestIDKey, requestID)
-	ctx.SetValue(requestModelKey, model)
-	ctx.SetValue(requestProviderKey, provider)
-
-	performDirectSearch, performSemanticSearch := true, true
-	if ctx.Value(CacheTypeKey) != nil {
-		cacheTypeVal, ok := ctx.Value(CacheTypeKey).(CacheType)
-		if !ok {
-			plugin.logger.Warn(PluginLoggerPrefix + " Cache type is not a CacheType, using all available cache types")
-		} else {
-			performDirectSearch = cacheTypeVal == CacheTypeDirect
-			performSemanticSearch = cacheTypeVal == CacheTypeSemantic
-		}
+	// Compute metadata + paramsHash once and reuse across both search paths.
+	metadata, err := plugin.buildRequestMetadataForCaching(state, req)
+	if err != nil {
+		plugin.clearCacheState(requestID)
+		plugin.logger.Debug("metadata build failed, caching disabled for this request: %v", err)
+		return req, nil, nil
 	}
+	paramsHash, err := hashMap(metadata)
+	if err != nil {
+		plugin.clearCacheState(requestID)
+		plugin.logger.Debug("params hash failed, caching disabled for this request: %v", err)
+		return req, nil, nil
+	}
+	state.ParamsHash = paramsHash
 
 	if performDirectSearch {
-		shortCircuit, err := plugin.performDirectSearch(ctx, req, cacheKey)
+		shortCircuit, err := plugin.performDirectSearch(ctx, state, req, cacheKey, metadata, paramsHash)
 		if err != nil {
-			plugin.logger.Warn(PluginLoggerPrefix + " Direct search failed: " + err.Error() + " (" + describeRequestShape(req) + ")")
-			// Don't return - continue to semantic search fallback
-			shortCircuit = nil // Ensure we don't use an invalid shortCircuit
-		}
-
-		if shortCircuit != nil {
+			msg := fmt.Sprintf("direct search failed (vector store unreachable?): %v", err)
+			plugin.logger.Warn(msg)
+			ctx.Log(schemas.LogLevelWarn, msg)
+		} else if shortCircuit != nil {
 			return req, shortCircuit, nil
 		}
 	}
 
-	if performSemanticSearch && plugin.embeddingRequestExecutor != nil {
-		if req.EmbeddingRequest != nil || req.TranscriptionRequest != nil {
-			plugin.logger.Debug(PluginLoggerPrefix + " Skipping semantic search for embedding/transcription input")
-			// For vector stores that require vectors, set a zero vector placeholder
-			// This allows direct hash matching to work without the overhead of generating embeddings
-			if plugin.store.RequiresVectors() && plugin.config.Dimension > 0 {
-				zeroVector := make([]float32, plugin.config.Dimension)
-				ctx.SetValue(requestEmbeddingKey, zeroVector)
-				plugin.logger.Debug(PluginLoggerPrefix + " Using zero vector placeholder for embedding/transcription request storage")
+	if performSemanticSearch {
+		// Suppress semantic for ineligible cases (no executor, or request
+		// types whose input cannot itself be embedded).
+		semanticEligible := plugin.embeddingRequestExecutor != nil &&
+			req.EmbeddingRequest == nil &&
+			req.TranscriptionRequest == nil
+		if !semanticEligible {
+			plugin.setZeroVectorIfRequired(state)
+		} else {
+			shortCircuit, err := plugin.performSemanticSearch(ctx, state, req, cacheKey, paramsHash)
+			if err != nil {
+				// Embedding failures (rate-limit, auth, timeout) are
+				// operationally important — surface at Warn and on the response.
+				msg := fmt.Sprintf("semantic search skipped: %v", err)
+				plugin.logger.Warn(msg)
+				ctx.Log(schemas.LogLevelWarn, msg)
+			} else if shortCircuit != nil {
+				return req, shortCircuit, nil
 			}
-			return req, nil, nil
 		}
-
-		// Try semantic search as fallback
-		shortCircuit, err := plugin.performSemanticSearch(ctx, req, cacheKey)
-		if err != nil {
-			plugin.logger.Debug(PluginLoggerPrefix + " Semantic search skipped: " + err.Error() + " (" + describeRequestShape(req) + ")")
-			return req, nil, nil
-		}
-
-		if shortCircuit != nil {
-			return req, shortCircuit, nil
-		}
-	} else if !performSemanticSearch && plugin.store.RequiresVectors() && plugin.embeddingRequestExecutor != nil {
-		// Vector store requires vectors but we're in direct-only mode
-		// Generate embeddings for storage purposes (not for searching)
-		if req.EmbeddingRequest != nil || req.TranscriptionRequest != nil {
-			plugin.logger.Debug(PluginLoggerPrefix + " Skipping embedding generation for embedding/transcription input")
-			// For vector stores that require vectors, set a zero vector placeholder
-			// This allows direct hash matching to work without the overhead of generating embeddings
-			if plugin.config.Dimension > 0 {
-				zeroVector := make([]float32, plugin.config.Dimension)
-				ctx.SetValue(requestEmbeddingKey, zeroVector)
-				plugin.logger.Debug(PluginLoggerPrefix + " Using zero vector placeholder for embedding/transcription request storage")
-			}
-			return req, nil, nil
-		}
-
-		// Use zero vector for direct-only cache type to prevent semantic search matches
-		// This preserves cache type isolation - direct-only entries won't be found by semantic search
-		if plugin.config.Dimension > 0 {
-			zeroVector := make([]float32, plugin.config.Dimension)
-			ctx.SetValue(requestEmbeddingKey, zeroVector)
-			plugin.logger.Debug(PluginLoggerPrefix + " Using zero vector for direct-only cache storage (preserves isolation)")
-		}
+	} else if !performSemanticSearch {
+		// Direct-only mode. If the vector store requires vectors for every entry
+		// (Qdrant, Pinecone) we write a zero vector. Note: this collapses all
+		// direct-only entries onto the same point in vector space, so a
+		// semantic search across cache types under the same cache_key/params
+		// could surface them. params_hash filtering is the actual isolation.
+		plugin.setZeroVectorIfRequired(state)
 	}
 
 	return req, nil, nil
 }
 
-// PostLLMHook is called after a response is received from a provider.
-// It caches responses in the VectorStore using UUID-based keys with unified metadata structure
-// including provider, model, request hash, and TTL. Handles both single and streaming responses.
-//
-// The function performs the following operations:
-// 1. Checks configurable caching behavior and skips caching for unsuccessful responses if configured
-// 2. Retrieves the request hash and ID from the context (set during PreLLMHook)
-// 3. Marshals the response for storage
-// 4. Stores the unified cache entry in the VectorStore asynchronously (non-blocking)
-//
-// The VectorStore Add operation runs in a separate goroutine to avoid blocking the response.
-// The function gracefully handles errors and continues without caching if any step fails,
-// ensuring that response processing is never interrupted by caching issues.
-//
-// Parameters:
-//   - ctx: Pointer to the schemas.BifrostContext containing the request hash and ID
-//   - res: The response from the provider to be cached
-//   - bifrostErr: The error from the provider, if any (used for success determination)
-//
-// Returns:
-//   - *schemas.BifrostResponse: The original response, unmodified
-//   - *schemas.BifrostError: The original error, unmodified
-//   - error: Any error that occurred during caching preparation (always nil as errors are handled gracefully)
+// resolveCacheKey returns the per-request cache key (or the configured default)
+// and a bool indicating whether the caller should proceed with caching.
+func (plugin *Plugin) resolveCacheKey(ctx *schemas.BifrostContext) (string, bool) {
+	if cacheKey, ok := ctx.Value(CacheKey).(string); ok && cacheKey != "" {
+		return cacheKey, true
+	}
+	if plugin.config.DefaultCacheKey != "" {
+		return plugin.config.DefaultCacheKey, true
+	}
+	return "", false
+}
+
+// resolveCacheTypes returns whether direct and semantic search paths should
+// run for this request. Defaults both to true; an explicit CacheTypeKey on
+// the context narrows to just one.
+func (plugin *Plugin) resolveCacheTypes(ctx *schemas.BifrostContext) (direct bool, semantic bool) {
+	direct, semantic = true, true
+	ctxVal := ctx.Value(CacheTypeKey)
+	if ctxVal == nil {
+		return
+	}
+	cacheTypeVal, ok := ctxVal.(CacheType)
+	if !ok {
+		msg := fmt.Sprintf("CacheTypeKey is not a CacheType (got %T), using all available cache types", ctxVal)
+		plugin.logger.Warn(msg)
+		ctx.Log(schemas.LogLevelWarn, msg)
+		return
+	}
+	direct = cacheTypeVal == CacheTypeDirect
+	semantic = cacheTypeVal == CacheTypeSemantic
+	return
+}
+
+// setZeroVectorIfRequired writes a zero embedding placeholder when the store
+// mandates a vector per entry. See PreLLMHook for the isolation caveat.
+func (plugin *Plugin) setZeroVectorIfRequired(state *cacheState) {
+	if !plugin.store.RequiresVectors() || plugin.config.Dimension <= 0 {
+		return
+	}
+	state.Embeddings = make([]float32, plugin.config.Dimension)
+}
+
+// PostLLMHook caches the upstream response keyed by the storageID resolved
+// in PreLLMHook (deterministic directCacheID for direct hits, request UUID
+// otherwise). The store write runs in a goroutine tracked by writersWg with
+// its own background context + CacheSetTimeout, so client cancellation
+// after the response is delivered doesn't drop the cache write. Returns the
+// response unmodified — caching never alters the request flow.
 func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
 	if bifrostErr != nil {
+		// We rely on errors always arriving as the final chunk for streams, so
+		// we abort caching here without further bookkeeping. Any partial
+		// accumulator from a prior chunk gets reaped by the periodic cleanup.
 		return res, bifrostErr, nil
 	}
 
-	// Skip caching for large payloads — body is too large to materialize for cache storage
-	if isLargePayload, ok := ctx.Value(schemas.BifrostContextKeyLargePayloadMode).(bool); ok && isLargePayload {
-		plugin.logger.Debug(PluginLoggerPrefix + " Skipping semantic cache for large payload request")
-		return res, nil, nil
-	}
-	if isLargeResponse, ok := ctx.Value(schemas.BifrostContextKeyLargeResponseMode).(bool); ok && isLargeResponse {
-		plugin.logger.Debug(PluginLoggerPrefix + " Skipping semantic cache for large payload response")
-		return res, nil, nil
-	}
-
-	isCacheHit := ctx.Value(isCacheHitKey)
-	if isCacheHit != nil {
-		isCacheHitValue, ok := isCacheHit.(bool)
-		if ok && isCacheHitValue {
-			return res, nil, nil
-		}
-	}
-
-	// Check if caching is explicitly disabled
-	noStore := ctx.Value(CacheNoStoreKey)
-	if noStore != nil {
-		noStoreValue, ok := noStore.(bool)
-		if ok && noStoreValue {
-			plugin.logger.Debug(PluginLoggerPrefix + " Caching is explicitly disabled for this request, continuing without caching")
-			return res, nil, nil
-		}
-	}
-
-	// Get the cache key from context
-	cacheKey, ok := ctx.Value(CacheKey).(string)
-	if !ok || cacheKey == "" {
-		if plugin.config.DefaultCacheKey != "" {
-			cacheKey = plugin.config.DefaultCacheKey
-		} else {
-			return res, nil, nil
-		}
-	}
-
-	// Get the request ID from context
-	requestID, ok := ctx.Value(requestIDKey).(string)
+	requestID, ok := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
 	if !ok {
 		return res, nil, nil
-	}
-	storageID := requestID
-	// When direct lookup prepared a deterministic storage ID, reuse it here so
-	// default-mode traffic warms the GetChunk fast path instead of only the
-	// legacy search path.
-	if v, ok := ctx.Value(requestStorageIDKey).(string); ok && v != "" {
-		storageID = v
-	}
-	// Check cache type to optimize embedding handling
-	var embedding []float32
-	var hash string
-	var shouldStoreEmbeddings = true
-	var shouldStoreHash = true
-
-	if ctx.Value(CacheTypeKey) != nil {
-		cacheTypeVal, ok := ctx.Value(CacheTypeKey).(CacheType)
-		if ok {
-			if cacheTypeVal == CacheTypeDirect {
-				// For direct-only caching, skip embedding operations entirely
-				// unless the vector store requires vectors for all entries
-				if plugin.store.RequiresVectors() {
-					// Vector stores like Qdrant and Pinecone require vectors for all entries
-					// Keep embeddings enabled for storage, but lookups will still use direct hash matching
-					plugin.logger.Debug(PluginLoggerPrefix + " Vector store requires vectors, keeping embedding generation enabled for storage")
-				} else {
-					shouldStoreEmbeddings = false
-					plugin.logger.Debug(PluginLoggerPrefix + " Skipping embedding operations for direct-only cache type")
-				}
-			} else if cacheTypeVal == CacheTypeSemantic {
-				shouldStoreHash = false
-				plugin.logger.Debug(PluginLoggerPrefix + " Skipping hash operations for semantic cache type")
-			}
-		}
-	}
-
-	if shouldStoreHash {
-		// Get the hash from context
-		hash, ok = ctx.Value(requestHashKey).(string)
-		if !ok {
-			plugin.logger.Warn(PluginLoggerPrefix + " Hash is not a string. Continuing without caching")
-			return res, nil, nil
-		}
 	}
 
 	extraFields := res.GetExtraFields()
 	requestType := extraFields.RequestType
+	cacheDebug := extraFields.CacheDebug
 
-	// Get embedding from context if available and needed
-	// For embedding/transcription requests, we still need to retrieve the zero vector placeholder
-	// if the vector store requires vectors for all entries
-	isEmbeddingOrTranscription := requestType == schemas.EmbeddingRequest || requestType == schemas.TranscriptionRequest
-	needsEmbedding := shouldStoreEmbeddings && !isEmbeddingOrTranscription
-	needsZeroVector := isEmbeddingOrTranscription && plugin.store.RequiresVectors()
-
-	if needsEmbedding || needsZeroVector {
-		embeddingValue := ctx.Value(requestEmbeddingKey)
-		if embeddingValue != nil {
-			embedding, ok = embeddingValue.([]float32)
-			if !ok {
-				plugin.logger.Warn(PluginLoggerPrefix + " Embedding is not a []float32, continuing without caching")
-				return res, nil, nil
-			}
+	// Final-chunk signaling for cache replays: stampCacheDebugForHit only
+	// stamps CacheDebug.CacheHit=true on the LAST replay chunk (see search.go).
+	// When we see that stamp, we set the stream-end indicator on the root ctx
+	// synchronously — same goroutine as the rest of the post-hook chain. This
+	// MUST run before shouldSkipCaching, otherwise we early-return without
+	// setting the indicator and downstream plugins (logging) never see
+	// isFinalChunk=true on the final replay chunk.
+	//
+	// Why not set the indicator from the cache replay goroutine instead? It
+	// races: the producer can advance to its next iteration (and SetValue)
+	// while the receiver is still running PostLLMHooks for the previous
+	// chunk, poisoning that chunk's IsFinalChunk read.
+	if bifrost.IsStreamRequestType(requestType) && cacheDebug != nil && cacheDebug.CacheHit {
+		ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+	}
+	if plugin.shouldSkipCaching(ctx, res) {
+		// Clear state on the same condition the defer at the end of this
+		// function uses — otherwise the early return below leaks *cacheState
+		// (notably the ~6 KB Embeddings slice) until the periodic reaper
+		// runs. Non-final stream chunks of an in-flight short-circuit replay
+		// keep their state because they need it for later chunks.
+		if !bifrost.IsStreamRequestType(requestType) || bifrost.IsFinalChunk(ctx) {
+			plugin.clearCacheState(requestID)
 		}
-		// Note: embedding can be nil for direct cache hits or when semantic search is disabled
-		// This is fine - we can still cache using direct hash matching (unless store requires vectors)
-	}
-
-	// Get the provider from context
-	provider, ok := ctx.Value(requestProviderKey).(schemas.ModelProvider)
-	if !ok {
-		plugin.logger.Warn(PluginLoggerPrefix + " Provider is not a schemas.ModelProvider, continuing without caching")
 		return res, nil, nil
 	}
 
-	// Get the model from context
-	model, ok := ctx.Value(requestModelKey).(string)
+	cacheKey, ok := plugin.resolveCacheKey(ctx)
 	if !ok {
-		plugin.logger.Warn(PluginLoggerPrefix + " Model is not a string, continuing without caching")
 		return res, nil, nil
 	}
-
+	provider := extraFields.Provider
+	model := extraFields.OriginalModelRequested
+	isStream := bifrost.IsStreamRequestType(requestType)
 	isFinalChunk := bifrost.IsFinalChunk(ctx)
 
-	// Get the input tokens from context (can be nil if not set)
-	inputTokens, ok := ctx.Value(requestEmbeddingTokensKey).(int)
-	if ok {
-		isStreamRequest := bifrost.IsStreamRequestType(requestType)
-
-		if !isStreamRequest || (isStreamRequest && isFinalChunk) {
-			if extraFields.CacheDebug == nil {
-				extraFields.CacheDebug = &schemas.BifrostCacheDebug{}
-			}
-			extraFields.CacheDebug.CacheHit = false
-			extraFields.CacheDebug.ProviderUsed = bifrost.Ptr(string(plugin.config.Provider))
-			extraFields.CacheDebug.ModelUsed = bifrost.Ptr(plugin.config.EmbeddingModel)
-			extraFields.CacheDebug.InputTokens = &inputTokens
-		}
+	state := plugin.getCacheState(requestID)
+	if state == nil || state.ParamsHash == "" {
+		// PreLLMHook bailed before computing the params hash (unsupported
+		// request type, conversation-history threshold, metadata error,
+		// etc.). Caching now would write an entry without params_hash that
+		// no future lookup can match.
+		return res, nil, nil
 	}
 
-	cacheTTL := plugin.config.TTL
-
-	ttlValue := ctx.Value(CacheTTLKey)
-	if ttlValue != nil {
-		// Get the request TTL from the context
-		ttl, ok := ttlValue.(time.Duration)
-		if !ok {
-			plugin.logger.Warn(PluginLoggerPrefix + " TTL is not a time.Duration, using default TTL")
-		} else {
-			cacheTTL = ttl
+	// Free state once the request is fully observed. For non-streams that's
+	// after this PostLLMHook returns; for streams, only on the final chunk.
+	defer func() {
+		if !isStream || isFinalChunk {
+			plugin.clearCacheState(requestID)
 		}
+	}()
+
+	// PreLLMHook short-circuited from cache; chunks here are the cached
+	// replay, not a fresh upstream response. shouldSkipCaching only catches
+	// the FINAL chunk (the only one carrying CacheDebug.CacheHit=true via
+	// stampCacheDebugForHit) — without this guard the non-final chunks
+	// would slip into addStreamingResponse and trigger a duplicate write
+	// at the same directCacheID (Weaviate 422 "id already exists").
+	if state.ShortCircuited {
+		return res, nil, nil
 	}
 
-	// Get metadata from context BEFORE goroutine to avoid race conditions
-	// when the same context is reused across multiple requests
-	paramsHash, _ := ctx.Value(requestParamsHashKey).(string)
+	storageID, embedding, shouldStoreEmbeddings := plugin.resolveStorageIDAndEmbedding(ctx, state, requestID, requestType)
 
-	// Snapshot the response synchronously for the non-streaming cache path.
-	// Marshaling inside the cache goroutine races with the framework returning
-	// res upstream and downstream consumers mutating it (CacheDebug, etc.).
-	// Streaming uses a chunk accumulator that snapshots per-chunk separately.
-	var singleResponseData []byte
-	if !bifrost.IsStreamRequestType(requestType) {
-		var marshalErr error
-		singleResponseData, marshalErr = json.Marshal(res)
-		if marshalErr != nil {
-			plugin.logger.Warn("%s Failed to snapshot response for caching: %v", PluginLoggerPrefix, marshalErr)
-			return res, nil, nil
-		}
+	plugin.stampCacheDebugForMiss(state, extraFields, storageID, isStream, isFinalChunk)
+
+	cacheTTL := plugin.resolveTTL(ctx)
+	paramsHash := state.ParamsHash
+
+	embeddingToStore := embedding
+	if !shouldStoreEmbeddings {
+		embeddingToStore = nil
 	}
 
-	// Cache everything in a unified VectorEntry asynchronously to avoid blocking the response
-	plugin.waitGroup.Add(1)
+	plugin.writersWg.Add(1)
 	go func() {
-		defer plugin.waitGroup.Done()
-		// Create a background context with timeout for the cache operation
+		defer plugin.writersWg.Done()
 		cacheCtx, cancel := context.WithTimeout(context.Background(), CacheSetTimeout)
 		defer cancel()
 
-		// Build unified metadata with provider, model, and all params
-		unifiedMetadata := plugin.buildUnifiedMetadata(provider, model, paramsHash, hash, cacheKey, cacheTTL)
-
-		// Handle streaming vs non-streaming responses
-		// Pass nil for embedding if we're in direct-only mode to optimize storage
-		embeddingToStore := embedding
-		if !shouldStoreEmbeddings {
-			embeddingToStore = nil
-		}
-
-		if bifrost.IsStreamRequestType(requestType) {
-			if err := plugin.addStreamingResponse(cacheCtx, requestID, storageID, res, bifrostErr, embeddingToStore, unifiedMetadata, cacheTTL, isFinalChunk); err != nil {
-				plugin.logger.Warn("%s Failed to cache streaming response: %v", PluginLoggerPrefix, err)
+		unifiedMetadata := plugin.buildUnifiedMetadata(provider, model, paramsHash, cacheKey, cacheTTL)
+		if isStream {
+			if err := plugin.addStreamingResponse(cacheCtx, requestID, storageID, res, embeddingToStore, unifiedMetadata, cacheTTL, isFinalChunk); err != nil {
+				plugin.logger.Warn("Failed to cache streaming response (namespace=%s, id=%s): %v. The cache_id stamped on the response will not resolve on subsequent lookups.", plugin.config.VectorStoreNamespace, storageID, err)
 			}
 		} else {
-			if err := plugin.addSingleResponse(cacheCtx, storageID, singleResponseData, embeddingToStore, unifiedMetadata, cacheTTL); err != nil {
-				plugin.logger.Warn("%s Failed to cache single response: %v", PluginLoggerPrefix, err)
+			if err := plugin.addNonStreamingResponse(cacheCtx, storageID, res, embeddingToStore, unifiedMetadata, cacheTTL); err != nil {
+				plugin.logger.Warn("Failed to cache single response (namespace=%s, id=%s): %v. The cache_id stamped on the response will not resolve on subsequent lookups.", plugin.config.VectorStoreNamespace, storageID, err)
 			}
 		}
 	}()
@@ -677,35 +580,113 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 	return res, nil, nil
 }
 
-// WaitForPendingOperations blocks until all pending cache operations (goroutines) complete.
-// This is useful in tests to ensure cache entries are stored before checking for cache hits.
-func (plugin *Plugin) WaitForPendingOperations() {
-	plugin.waitGroup.Wait()
+// shouldSkipCaching returns true if the response cannot or should not be
+// written to the cache (large payload mode, cache hit replay, or explicit
+// no-store).
+func (plugin *Plugin) shouldSkipCaching(ctx *schemas.BifrostContext, res *schemas.BifrostResponse) bool {
+	if isLargePayload, ok := ctx.Value(schemas.BifrostContextKeyLargePayloadMode).(bool); ok && isLargePayload {
+		return true
+	}
+	if isLargeResponse, ok := ctx.Value(schemas.BifrostContextKeyLargeResponseMode).(bool); ok && isLargeResponse {
+		return true
+	}
+	if cacheDebug := res.GetExtraFields().CacheDebug; cacheDebug != nil && cacheDebug.CacheHit {
+		return true
+	}
+	if noStore, ok := ctx.Value(CacheNoStoreKey).(bool); ok && noStore {
+		return true
+	}
+	return false
 }
 
-// Cleanup performs cleanup operations for the semantic cache plugin.
-// It removes all cached entries created by this plugin from the VectorStore only if CleanUpOnShutdown is true.
-// Identifies cache entries by the presence of semantic cache-specific fields (request_hash, cache_key).
-//
-// The function performs the following operations:
-// 1. Checks if cleanup is enabled via CleanUpOnShutdown config
-// 2. Retrieves all entries and filters client-side to identify cache entries
-// 3. Deletes all matching cache entries from the VectorStore in batches
-//
-// This method should be called when shutting down the application to ensure
-// proper resource cleanup if configured to do so.
-//
-// Returns:
-//   - error: Any error that occurred during cleanup operations
-func (plugin *Plugin) Cleanup() error {
-	plugin.waitGroup.Wait()
+// resolveStorageIDAndEmbedding picks the storage ID (deterministic directCacheID
+// when direct search ran, else the request UUID) and resolves the embedding
+// from per-request state. shouldStoreEmbeddings is false for explicit
+// direct-only requests on stores that don't require vectors — those entries
+// skip the embedding column entirely.
+func (plugin *Plugin) resolveStorageIDAndEmbedding(ctx *schemas.BifrostContext, state *cacheState, requestID string, requestType schemas.RequestType) (storageID string, embedding []float32, shouldStoreEmbeddings bool) {
+	storageID = requestID
+	if state.DirectCacheID != "" {
+		storageID = state.DirectCacheID
+	}
 
-	// Clean up old stream accumulators first
+	shouldStoreEmbeddings = true
+	if cacheTypeVal, isCacheType := ctx.Value(CacheTypeKey).(CacheType); isCacheType && cacheTypeVal == CacheTypeDirect && !plugin.store.RequiresVectors() {
+		shouldStoreEmbeddings = false
+	}
+
+	isEmbeddingOrTranscription := requestType == schemas.EmbeddingRequest || requestType == schemas.TranscriptionRequest
+	needsEmbedding := shouldStoreEmbeddings && !isEmbeddingOrTranscription
+	needsZeroVector := isEmbeddingOrTranscription && plugin.store.RequiresVectors()
+
+	if needsEmbedding || needsZeroVector {
+		// embedding may still be nil — fine for direct hash matching unless the
+		// store requires vectors (in which case Add will reject downstream).
+		embedding = state.Embeddings
+	}
+	return storageID, embedding, shouldStoreEmbeddings
+}
+
+// stampCacheDebugForMiss attaches cache miss telemetry to the response. It
+// always sets CacheHit=false and CacheID to the storage ID where the entry
+// will be written, so the caller can later invalidate via ClearCacheForCacheID.
+// Embedding-cost fields (ProviderUsed/ModelUsed/InputTokens) are only stamped
+// when semantic search actually ran. For streams, only the final chunk is
+// stamped to avoid duplicating telemetry.
+func (plugin *Plugin) stampCacheDebugForMiss(state *cacheState, extraFields *schemas.BifrostResponseExtraFields, storageID string, isStream, isFinalChunk bool) {
+	if isStream && !isFinalChunk {
+		return
+	}
+	if extraFields.CacheDebug == nil {
+		extraFields.CacheDebug = &schemas.BifrostCacheDebug{}
+	}
+	cd := extraFields.CacheDebug
+	cd.CacheHit = false
+	cd.CacheID = bifrost.Ptr(storageID)
+	if state.EmbeddingsInputTokens > 0 {
+		inputTokens := state.EmbeddingsInputTokens
+		cd.ProviderUsed = bifrost.Ptr(string(plugin.config.Provider))
+		cd.ModelUsed = bifrost.Ptr(plugin.config.EmbeddingModel)
+		cd.InputTokens = &inputTokens
+	}
+}
+
+// resolveTTL returns the per-request TTL override if present, else the plugin default.
+func (plugin *Plugin) resolveTTL(ctx *schemas.BifrostContext) time.Duration {
+	if v := ctx.Value(CacheTTLKey); v != nil {
+		if ttl, ok := v.(time.Duration); ok {
+			return ttl
+		}
+		plugin.logger.Warn("TTL is not a time.Duration, using default TTL")
+	}
+	return plugin.config.TTL
+}
+
+// WaitForPendingOperations blocks until all pending cache operations (goroutines) complete.
+// This is useful in tests to ensure cache entries are stored before checking for cache hits.
+// It does NOT wait on background loops — those only exit on Cleanup.
+func (plugin *Plugin) WaitForPendingOperations() {
+	plugin.writersWg.Wait()
+}
+
+// Cleanup signals the background loops to stop and waits for in-flight cache
+// writes to drain before returning. When CleanUpOnShutdown is true, it then
+// deletes every entry tagged from_bifrost_semantic_cache_plugin and drops
+// the namespace — useful for ephemeral test environments. The default is to
+// leave entries in place so they can serve subsequent process restarts.
+func (plugin *Plugin) Cleanup() error {
+	close(plugin.stopCh)
+	plugin.writersWg.Wait()
+	plugin.cleanupWg.Wait()
+
+	// Final sweep: the periodic reaper only fires once per streamCleanupInterval,
+	// so any abandoned accumulator added in the window between the last tick
+	// and stopCh is still in memory. This call evicts those before we return.
 	plugin.cleanupOldStreamAccumulators()
 
 	// Only clean up cache entries if configured to do so
 	if !plugin.config.CleanUpOnShutdown {
-		plugin.logger.Debug(PluginLoggerPrefix + " Cleanup on shutdown is disabled, skipping cache cleanup")
+		plugin.logger.Debug("Cleanup on shutdown is disabled, skipping cache cleanup")
 		return nil
 	}
 
@@ -713,7 +694,7 @@ func (plugin *Plugin) Cleanup() error {
 	ctx, cancel := context.WithTimeout(context.Background(), CacheSetTimeout)
 	defer cancel()
 
-	plugin.logger.Debug(PluginLoggerPrefix + " Starting cleanup of cache entries...")
+	plugin.logger.Debug("Starting cleanup of cache entries...")
 
 	// Delete all cache entries created by this plugin
 	queries := []vectorstore.Query{
@@ -731,10 +712,10 @@ func (plugin *Plugin) Cleanup() error {
 
 	for _, result := range results {
 		if result.Status == vectorstore.DeleteStatusError {
-			plugin.logger.Warn("%s Failed to delete cache entry: %s", PluginLoggerPrefix, result.Error)
+			plugin.logger.Warn("Failed to delete cache entry: %s", result.Error)
 		}
 	}
-	plugin.logger.Info("%s Cleanup completed - deleted all cache entries", PluginLoggerPrefix)
+	plugin.logger.Debug("Cleanup completed - deleted all cache entries")
 
 	if err := plugin.store.DeleteNamespace(ctx, plugin.config.VectorStoreNamespace); err != nil {
 		return fmt.Errorf("failed to delete namespace: %w", err)
@@ -743,27 +724,17 @@ func (plugin *Plugin) Cleanup() error {
 	return nil
 }
 
-// SetEmbeddingRequestExecutor sets the embedding request executor for the plugin.
-// Needs to be set before the plugin is used.
-//
-// Parameters:
-//   - executor: The embedding request executor to set
+// SetEmbeddingRequestExecutor wires up the function the plugin uses to call
+// out to the embedding provider. Must be set before the plugin starts
+// serving traffic; semantic search is silently skipped while it's nil.
 func (plugin *Plugin) SetEmbeddingRequestExecutor(executor EmbeddingRequestExecutor) {
 	plugin.embeddingRequestExecutor = executor
 }
 
-// Public Methods for External Use
-
-// ClearCacheForKey deletes cache entries for a specific cache key.
-// Uses the unified VectorStore interface for deletion of all entries with the given cache key.
-//
-// Parameters:
-//   - cacheKey: The specific cache key to delete
-//
-// Returns:
-//   - error: Any error that occurred during cache key deletion
+// ClearCacheForKey deletes every entry written under the given cache_key.
+// Use this to invalidate a tenant or feature scope in bulk. Per-entry
+// deletion is available via ClearCacheForCacheID.
 func (plugin *Plugin) ClearCacheForKey(cacheKey string) error {
-	// Delete all entries with "cache_key" equal to the given cacheKey
 	queries := []vectorstore.Query{
 		{
 			Field:    "cache_key",
@@ -781,52 +752,35 @@ func (plugin *Plugin) ClearCacheForKey(cacheKey string) error {
 	defer cancel()
 	results, err := plugin.store.DeleteAll(ctx, plugin.config.VectorStoreNamespace, queries)
 	if err != nil {
-		plugin.logger.Warn("%s Failed to delete cache entries for key '%s': %v", PluginLoggerPrefix, cacheKey, err)
+		plugin.logger.Warn("Failed to delete cache entries for key '%s': %v", cacheKey, err)
 		return err
 	}
 
 	for _, result := range results {
 		if result.Status == vectorstore.DeleteStatusError {
-			plugin.logger.Warn("%s Failed to delete cache entry for key %s: %s", PluginLoggerPrefix, result.ID, result.Error)
+			plugin.logger.Warn("Failed to delete cache entry for key %s: %s", result.ID, result.Error)
 		}
 	}
 
-	plugin.logger.Debug(fmt.Sprintf("%s Deleted all cache entries for key %s", PluginLoggerPrefix, cacheKey))
+	plugin.logger.Debug("Deleted all cache entries for key %s", cacheKey)
 
 	return nil
 }
 
-// ClearCacheForRequestID deletes cache entries for a specific request ID.
-// Uses the unified VectorStore interface to delete the single entry by its UUID.
-//
-// Parameters:
-//   - requestID: The UUID-based request ID to delete cache entries for
-//
-// Returns:
-//   - error: Any error that occurred during cache key deletion
-func (plugin *Plugin) ClearCacheForRequestID(requestID string) error {
-	// With the unified VectorStore interface, we delete the single entry by its UUID
+// ClearCacheForCacheID deletes a single cache entry by its storage ID. The
+// caller obtains the ID from BifrostResponse.ExtraFields.CacheDebug.CacheID,
+// which is stamped on both cache hits and cache misses — so the same handle
+// works whether the request wrote the entry or read it.
+func (plugin *Plugin) ClearCacheForCacheID(cacheID string) error {
+	if cacheID == "" {
+		return fmt.Errorf("cache ID is required")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), CacheSetTimeout)
 	defer cancel()
-	if err := plugin.store.Delete(ctx, plugin.config.VectorStoreNamespace, requestID); err != nil {
-		plugin.logger.Warn("%s Failed to delete cache entry: %v", PluginLoggerPrefix, err)
+	if err := plugin.store.Delete(ctx, plugin.config.VectorStoreNamespace, cacheID); err != nil {
+		plugin.logger.Warn("Failed to delete cache entry %s: %v", cacheID, err)
 		return err
 	}
-
-	plugin.logger.Debug(fmt.Sprintf("%s Deleted cache entry for key %s", PluginLoggerPrefix, requestID))
-
+	plugin.logger.Debug("Deleted cache entry %s", cacheID)
 	return nil
-}
-
-func (plugin *Plugin) clearRequestScopedContext(ctx *schemas.BifrostContext) {
-	ctx.ClearValue(requestIDKey)
-	ctx.ClearValue(requestStorageIDKey)
-	ctx.ClearValue(requestHashKey)
-	ctx.ClearValue(requestParamsHashKey)
-	ctx.ClearValue(requestModelKey)
-	ctx.ClearValue(requestProviderKey)
-	ctx.ClearValue(requestEmbeddingKey)
-	ctx.ClearValue(requestEmbeddingTokensKey)
-	ctx.ClearValue(isCacheHitKey)
-	ctx.ClearValue(cacheHitTypeKey)
 }

--- a/plugins/semanticcache/main_test.go
+++ b/plugins/semanticcache/main_test.go
@@ -1,0 +1,39 @@
+package semanticcache
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/vectorstore"
+)
+
+// TestMain drops the shared test namespace BEFORE the run starts (in case a
+// previous run was interrupted and left stale entries) AND once after — both
+// matter: tests share one namespace + one cache_key prefix per t.Name(),
+// so stale writes from a prior interrupted run would surface as spurious
+// cache hits on the first request of the next run.
+func TestMain(m *testing.M) {
+	dropSharedTestNamespace() // pre-run sweep
+	code := m.Run()
+	dropSharedTestNamespace() // post-run sweep
+	os.Exit(code)
+}
+
+func dropSharedTestNamespace() {
+	cfg := getWeaviateConfigFromEnv()
+	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Type:    vectorstore.VectorStoreTypeWeaviate,
+		Config:  cfg,
+		Enabled: true,
+	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	if err != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_ = store.DeleteNamespace(ctx, SharedTestNamespace)
+}

--- a/plugins/semanticcache/plugin_api_test.go
+++ b/plugins/semanticcache/plugin_api_test.go
@@ -1,0 +1,378 @@
+package semanticcache
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/vectorstore"
+)
+
+// observableStore is a fuller mock than directFastPathStore — it records all
+// Delete / DeleteAll / DeleteNamespace calls so the tests can assert on the
+// public Clear* APIs and on Cleanup teardown behavior.
+type observableStore struct {
+	mu                sync.Mutex
+	chunks            map[string]vectorstore.SearchResult
+	addIDs            []string
+	deleteIDs         []string
+	deleteAllQueries  [][]vectorstore.Query
+	namespaceDeletes  int
+	deleteAllErr      error
+	deleteErr         error
+	deleteAllResults  []vectorstore.DeleteResult
+}
+
+func newObservableStore() *observableStore {
+	return &observableStore{chunks: make(map[string]vectorstore.SearchResult)}
+}
+
+func (s *observableStore) Ping(ctx context.Context) error { return nil }
+func (s *observableStore) CreateNamespace(ctx context.Context, ns string, dim int, props map[string]vectorstore.VectorStoreProperties) error {
+	return nil
+}
+func (s *observableStore) DeleteNamespace(ctx context.Context, ns string) error {
+	s.mu.Lock()
+	s.namespaceDeletes++
+	s.mu.Unlock()
+	return nil
+}
+func (s *observableStore) GetChunk(ctx context.Context, ns string, id string) (vectorstore.SearchResult, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.chunks[id]
+	if !ok {
+		return vectorstore.SearchResult{}, vectorstore.ErrNotFound
+	}
+	return r, nil
+}
+func (s *observableStore) GetChunks(ctx context.Context, ns string, ids []string) ([]vectorstore.SearchResult, error) {
+	return nil, vectorstore.ErrNotSupported
+}
+func (s *observableStore) GetAll(ctx context.Context, ns string, q []vectorstore.Query, sf []string, cur *string, lim int64) ([]vectorstore.SearchResult, *string, error) {
+	return nil, nil, vectorstore.ErrNotSupported
+}
+func (s *observableStore) GetNearest(ctx context.Context, ns string, v []float32, q []vectorstore.Query, sf []string, th float64, lim int64) ([]vectorstore.SearchResult, error) {
+	return nil, vectorstore.ErrNotSupported
+}
+func (s *observableStore) RequiresVectors() bool { return false }
+func (s *observableStore) Add(ctx context.Context, ns string, id string, e []float32, m map[string]interface{}) error {
+	s.mu.Lock()
+	s.addIDs = append(s.addIDs, id)
+	s.chunks[id] = vectorstore.SearchResult{ID: id, Properties: m}
+	s.mu.Unlock()
+	return nil
+}
+func (s *observableStore) Delete(ctx context.Context, ns string, id string) error {
+	s.mu.Lock()
+	s.deleteIDs = append(s.deleteIDs, id)
+	delete(s.chunks, id)
+	err := s.deleteErr
+	s.mu.Unlock()
+	return err
+}
+func (s *observableStore) DeleteAll(ctx context.Context, ns string, queries []vectorstore.Query) ([]vectorstore.DeleteResult, error) {
+	s.mu.Lock()
+	s.deleteAllQueries = append(s.deleteAllQueries, queries)
+	results := s.deleteAllResults
+	err := s.deleteAllErr
+	s.mu.Unlock()
+	return results, err
+}
+func (s *observableStore) Close(ctx context.Context, ns string) error { return nil }
+
+func newTestPlugin(t *testing.T, store vectorstore.VectorStore, cleanupOnShutdown bool) *Plugin {
+	t.Helper()
+	cfg := getDefaultTestConfig()
+	cfg.CleanUpOnShutdown = cleanupOnShutdown
+	return &Plugin{
+		store:  store,
+		config: cfg,
+		logger: bifrost.NewDefaultLogger(schemas.LogLevelDebug),
+		stopCh: make(chan struct{}),
+	}
+}
+
+// -----------------------------------------------------------------------------
+// ClearCacheForCacheID
+// -----------------------------------------------------------------------------
+
+func TestClearCacheForCacheID_EmptyIDRejected(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+	if err := plugin.ClearCacheForCacheID(""); err == nil {
+		t.Fatal("expected error for empty cache ID")
+	}
+}
+
+func TestClearCacheForCacheID_PointDelete(t *testing.T) {
+	store := newObservableStore()
+	plugin := newTestPlugin(t, store, false)
+
+	if err := plugin.ClearCacheForCacheID("cache-abc"); err != nil {
+		t.Fatalf("ClearCacheForCacheID failed: %v", err)
+	}
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.deleteIDs) != 1 || store.deleteIDs[0] != "cache-abc" {
+		t.Fatalf("expected single Delete call for 'cache-abc', got %v", store.deleteIDs)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// ClearCacheForKey
+// -----------------------------------------------------------------------------
+
+func TestClearCacheForKey_FiltersByCacheKeyAndPluginMarker(t *testing.T) {
+	store := newObservableStore()
+	plugin := newTestPlugin(t, store, false)
+
+	if err := plugin.ClearCacheForKey("session-42"); err != nil {
+		t.Fatalf("ClearCacheForKey failed: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.deleteAllQueries) != 1 {
+		t.Fatalf("expected one DeleteAll call, got %d", len(store.deleteAllQueries))
+	}
+	queries := store.deleteAllQueries[0]
+	gotKey, gotMarker := false, false
+	for _, q := range queries {
+		if q.Field == "cache_key" && q.Value == "session-42" && q.Operator == vectorstore.QueryOperatorEqual {
+			gotKey = true
+		}
+		if q.Field == "from_bifrost_semantic_cache_plugin" && q.Value == true {
+			gotMarker = true
+		}
+	}
+	if !gotKey {
+		t.Errorf("expected cache_key=session-42 filter, got %+v", queries)
+	}
+	if !gotMarker {
+		t.Errorf("expected from_bifrost_semantic_cache_plugin=true filter, got %+v", queries)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// stampCacheDebugForMiss
+// -----------------------------------------------------------------------------
+
+func TestStampCacheDebugForMiss_AlwaysSetsCacheID(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+	state := &cacheState{}
+	extra := &schemas.BifrostResponseExtraFields{}
+
+	plugin.stampCacheDebugForMiss(state, extra, "stored-id-123", false, false)
+
+	if extra.CacheDebug == nil {
+		t.Fatal("expected CacheDebug to be stamped on miss")
+	}
+	if extra.CacheDebug.CacheHit {
+		t.Fatal("expected CacheHit=false on miss")
+	}
+	if extra.CacheDebug.CacheID == nil || *extra.CacheDebug.CacheID != "stored-id-123" {
+		t.Fatalf("expected CacheID=stored-id-123, got %v", extra.CacheDebug.CacheID)
+	}
+	// No semantic search ran → embedding fields should be unset.
+	if extra.CacheDebug.ProviderUsed != nil || extra.CacheDebug.InputTokens != nil {
+		t.Fatalf("expected embedding fields nil on direct-only miss, got %+v", extra.CacheDebug)
+	}
+}
+
+func TestStampCacheDebugForMiss_AddsTelemetryWhenSemanticRan(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+	state := &cacheState{EmbeddingsInputTokens: 42}
+	extra := &schemas.BifrostResponseExtraFields{}
+
+	plugin.stampCacheDebugForMiss(state, extra, "id-x", false, false)
+
+	if extra.CacheDebug.InputTokens == nil || *extra.CacheDebug.InputTokens != 42 {
+		t.Fatalf("expected InputTokens=42, got %v", extra.CacheDebug.InputTokens)
+	}
+	if extra.CacheDebug.ProviderUsed == nil {
+		t.Fatal("expected ProviderUsed to be stamped when semantic ran")
+	}
+}
+
+func TestStampCacheDebugForMiss_StreamSkipsNonFinalChunks(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+	state := &cacheState{}
+	extra := &schemas.BifrostResponseExtraFields{}
+
+	plugin.stampCacheDebugForMiss(state, extra, "id-y", true, false) // mid-stream
+
+	if extra.CacheDebug != nil {
+		t.Fatal("expected mid-stream chunk to NOT be stamped")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Cleanup
+// -----------------------------------------------------------------------------
+
+func TestCleanup_SkipsEntryDeletionWhenDisabled(t *testing.T) {
+	store := newObservableStore()
+	plugin := newTestPlugin(t, store, false) // CleanUpOnShutdown=false
+
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup failed: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.deleteAllQueries) != 0 {
+		t.Errorf("expected no DeleteAll calls when cleanup disabled, got %d", len(store.deleteAllQueries))
+	}
+	if store.namespaceDeletes != 0 {
+		t.Errorf("expected no DeleteNamespace calls when cleanup disabled, got %d", store.namespaceDeletes)
+	}
+}
+
+func TestCleanup_DeletesEntriesAndNamespaceWhenEnabled(t *testing.T) {
+	store := newObservableStore()
+	plugin := newTestPlugin(t, store, true) // CleanUpOnShutdown=true
+
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup failed: %v", err)
+	}
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.deleteAllQueries) != 1 {
+		t.Fatalf("expected one DeleteAll call, got %d", len(store.deleteAllQueries))
+	}
+	if store.namespaceDeletes != 1 {
+		t.Fatalf("expected one DeleteNamespace call, got %d", store.namespaceDeletes)
+	}
+}
+
+func TestCleanup_DrainsPendingWriters(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+
+	var done atomic.Bool
+	plugin.writersWg.Add(1)
+	go func() {
+		defer plugin.writersWg.Done()
+		time.Sleep(50 * time.Millisecond)
+		done.Store(true)
+	}()
+
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup failed: %v", err)
+	}
+	if !done.Load() {
+		t.Fatal("expected Cleanup to wait for pending writers to finish")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// cacheState reaper
+// -----------------------------------------------------------------------------
+
+func TestCleanupOldCacheStates_ReapsOldEntries(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+
+	plugin.cacheStates.Store("old-1", &cacheState{CreatedAt: time.Now().Add(-2 * cacheStateMaxAge)})
+	plugin.cacheStates.Store("old-2", &cacheState{CreatedAt: time.Now().Add(-2 * cacheStateMaxAge)})
+	plugin.cacheStates.Store("recent", &cacheState{CreatedAt: time.Now()})
+
+	plugin.cleanupOldCacheStates()
+
+	if _, ok := plugin.cacheStates.Load("old-1"); ok {
+		t.Error("expected old-1 to be reaped")
+	}
+	if _, ok := plugin.cacheStates.Load("old-2"); ok {
+		t.Error("expected old-2 to be reaped")
+	}
+	if _, ok := plugin.cacheStates.Load("recent"); !ok {
+		t.Error("expected recent to be preserved")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Stream accumulator reaper
+// -----------------------------------------------------------------------------
+
+func TestCleanupOldStreamAccumulators_ReapsByLastSeenAt(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+
+	plugin.streamAccumulators.Store("old", &StreamAccumulator{
+		RequestID:  "old",
+		LastSeenAt: time.Now().Add(-2 * streamAccumulatorMaxAge),
+	})
+	plugin.streamAccumulators.Store("recent", &StreamAccumulator{
+		RequestID:  "recent",
+		LastSeenAt: time.Now(),
+	})
+
+	plugin.cleanupOldStreamAccumulators()
+
+	if _, ok := plugin.streamAccumulators.Load("old"); ok {
+		t.Error("expected old accumulator to be reaped")
+	}
+	if _, ok := plugin.streamAccumulators.Load("recent"); !ok {
+		t.Error("expected recent accumulator to be preserved")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Replay goroutine cancellation (buildStreamingResponseFromResult)
+// -----------------------------------------------------------------------------
+
+func TestBuildStreamingResponseFromResult_ConsumerAbandonment(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+
+	// Build a cached entry with multiple chunks.
+	chunkJSON := `{"chat_response":{"choices":[]}}`
+	streamArray := []string{chunkJSON, chunkJSON, chunkJSON, chunkJSON, chunkJSON}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionStreamRequest,
+		ChatRequest: CreateBasicChatRequest("hi", 0.7, 50),
+	}
+	ctx := newBaseTestContext()
+	state := &cacheState{}
+
+	sc, err := plugin.buildStreamingResponseFromResult(
+		ctx, state, req,
+		vectorstore.SearchResult{ID: "stream-id"},
+		streamArray, CacheTypeSemantic, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("buildStreamingResponseFromResult failed: %v", err)
+	}
+	if sc == nil || sc.Stream == nil {
+		t.Fatal("expected a stream short-circuit")
+	}
+
+	// Read one chunk, then cancel ctx — the replay goroutine should exit
+	// (close the channel) instead of blocking on its send forever.
+	// Guard the first receive so a regression that stalls the producer
+	// fails fast instead of hanging until the suite-level timeout.
+	select {
+	case _, ok := <-sc.Stream:
+		if !ok {
+			t.Fatal("expected first replay chunk before cancellation, channel closed early")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("replay goroutine did not emit the first chunk")
+	}
+	ctx.Cancel()
+
+	// Drain remaining; channel must close within a reasonable bound.
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-sc.Stream:
+			if !ok {
+				return // channel closed → replay goroutine exited cleanly ✓
+			}
+		case <-timeout:
+			t.Fatal("replay goroutine did not exit after ctx.Cancel()")
+		}
+	}
+}

--- a/plugins/semanticcache/plugin_cache_type_test.go
+++ b/plugins/semanticcache/plugin_cache_type_test.go
@@ -2,7 +2,6 @@ package semanticcache
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -14,24 +13,25 @@ import (
 
 // TestCacheTypeDirectOnly tests that CacheTypeKey set to "direct" only performs direct hash matching
 func TestCacheTypeDirectOnly(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	// First, cache a response using CacheTypeDirect so it is stored under the deterministic ID
-	ctx1 := CreateContextWithCacheKeyAndType("test-cache-type-direct", CacheTypeDirect)
+	ctx1 := CreateContextWithCacheKeyAndType(t, "test-cache-type-direct", CacheTypeDirect)
 	testRequest := CreateBasicChatRequest("What is Bifrost?", 0.7, 50)
 
 	t.Log("Making first request to populate cache...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
 	WaitForCache(setup.Plugin)
 
 	// Now test with CacheTypeKey set to direct only
-	ctx2 := CreateContextWithCacheKeyAndType("test-cache-type-direct", CacheTypeDirect)
+	ctx2 := CreateContextWithCacheKeyAndType(t, "test-cache-type-direct", CacheTypeDirect)
 
 	t.Log("Making second request with CacheTypeKey=direct...")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
@@ -47,17 +47,18 @@ func TestCacheTypeDirectOnly(t *testing.T) {
 
 // TestCacheTypeSemanticOnly tests that CacheTypeKey set to "semantic" only performs semantic search
 func TestCacheTypeSemanticOnly(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	// First, cache a response using normal behavior
-	ctx1 := CreateContextWithCacheKey("test-cache-type-semantic")
+	ctx1 := CreateContextWithCacheKey(t, "test-cache-type-semantic")
 	testRequest := CreateBasicChatRequest("Explain machine learning concepts", 0.7, 50)
 
 	t.Log("Making first request to populate cache...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
@@ -67,7 +68,7 @@ func TestCacheTypeSemanticOnly(t *testing.T) {
 	similarRequest := CreateBasicChatRequest("Can you explain concepts in machine learning", 0.7, 50)
 
 	// Try with semantic-only search
-	ctx2 := CreateContextWithCacheKeyAndType("test-cache-type-semantic", CacheTypeSemantic)
+	ctx2 := CreateContextWithCacheKeyAndType(t, "test-cache-type-semantic", CacheTypeSemantic)
 
 	t.Log("Making second request with similar content and CacheTypeKey=semantic...")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, similarRequest)
@@ -79,9 +80,14 @@ func TestCacheTypeSemanticOnly(t *testing.T) {
 		}
 	}
 
-	// This might be a cache hit if semantic similarity is high enough
-	// The test validates that semantic search is attempted
-	if response2.ExtraFields.CacheDebug != nil && response2.ExtraFields.CacheDebug.CacheHit {
+	// This might be a cache hit if semantic similarity is high enough.
+	// Hit/miss is similarity-dependent, but CacheDebug must be stamped either
+	// way — semantic search ran. This catches a regression where the stamping
+	// stops without making the test flake on similarity scores.
+	if response2.ExtraFields.CacheDebug == nil {
+		t.Fatal("expected CacheDebug to be stamped on the response (semantic search should have run)")
+	}
+	if response2.ExtraFields.CacheDebug.CacheHit {
 		AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}, "semantic")
 		t.Log("✅ CacheTypeKey=semantic correctly found semantic match")
 	} else {
@@ -94,24 +100,25 @@ func TestCacheTypeSemanticOnly(t *testing.T) {
 
 // TestCacheTypeDirectWithSemanticFallback tests the default behavior (both direct and semantic)
 func TestCacheTypeDirectWithSemanticFallback(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	// Cache a response first
-	ctx1 := CreateContextWithCacheKey("test-cache-type-fallback")
+	ctx1 := CreateContextWithCacheKey(t, "test-cache-type-fallback")
 	testRequest := CreateBasicChatRequest("Define artificial intelligence", 0.7, 50)
 
 	t.Log("Making first request to populate cache...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
 	WaitForCache(setup.Plugin)
 
 	// Test exact match (should hit direct cache)
-	ctx2 := CreateContextWithCacheKey("test-cache-type-fallback")
+	ctx2 := CreateContextWithCacheKey(t, "test-cache-type-fallback")
 
 	t.Log("Making second identical request (should hit direct cache)...")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
@@ -133,8 +140,12 @@ func TestCacheTypeDirectWithSemanticFallback(t *testing.T) {
 		t.Fatalf("Third request failed: %v", err3)
 	}
 
-	// May or may not be a cache hit depending on semantic similarity
-	if response3.ExtraFields.CacheDebug != nil && response3.ExtraFields.CacheDebug.CacheHit {
+	// May or may not be a cache hit depending on semantic similarity, but
+	// CacheDebug must be stamped (regression guard).
+	if response3.ExtraFields.CacheDebug == nil {
+		t.Fatal("expected CacheDebug to be stamped on the response")
+	}
+	if response3.ExtraFields.CacheDebug.CacheHit {
 		AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3}, "semantic")
 		t.Log("✅ Default behavior correctly found semantic match")
 	} else {
@@ -145,49 +156,66 @@ func TestCacheTypeDirectWithSemanticFallback(t *testing.T) {
 	t.Log("✅ Default behavior correctly attempts both direct and semantic search")
 }
 
-// TestCacheTypeInvalidValue tests behavior with invalid CacheTypeKey values
+// TestCacheTypeInvalidValue tests behavior with invalid CacheTypeKey values:
+// the plugin must fall back to default behavior (try both direct + semantic)
+// rather than disable caching entirely.
 func TestCacheTypeInvalidValue(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	// Create context with invalid cache type
-	ctx := CreateContextWithCacheKey("test-invalid-cache-type")
-	ctx = ctx.WithValue(CacheTypeKey, "invalid_type")
-
 	testRequest := CreateBasicChatRequest("Test invalid cache type", 0.7, 50)
 
-	t.Log("Making request with invalid CacheTypeKey value...")
-	response, err := setup.Client.ChatCompletionRequest(ctx, testRequest)
+	// First request with invalid CacheTypeKey — must be a miss but ALSO must
+	// have caused the response to be cached (fallback to default behavior).
+	ctx1 := CreateContextWithCacheKey(t, "test-invalid-cache-type")
+	ctx1 = ctx1.WithValue(CacheTypeKey, "invalid_type")
+
+	t.Log("Making first request with invalid CacheTypeKey value...")
+	response1, err := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err)
 	}
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-	// Should fall back to default behavior (both direct and semantic)
-	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response})
+	WaitForCache(setup.Plugin)
 
-	t.Log("✅ Invalid CacheTypeKey value falls back to default behavior")
+	// Second identical request — fallback should mean the entry was written
+	// the first time, so this must hit (proves the invalid value didn't
+	// disable caching as a side effect).
+	ctx2 := CreateContextWithCacheKey(t, "test-invalid-cache-type")
+	ctx2 = ctx2.WithValue(CacheTypeKey, "invalid_type")
+	t.Log("Making second identical request — must hit cache, proving fallback to default cached the first call...")
+	response2, err := setup.Client.ChatCompletionRequest(ctx2, testRequest)
+	if err != nil {
+		t.Fatalf("Second request failed: %v", err)
+	}
+	AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}, string(CacheTypeDirect))
+
+	t.Log("✅ Invalid CacheTypeKey value falls back to default behavior (caching works)")
 }
 
 // TestCacheTypeWithEmbeddingRequests tests CacheTypeKey behavior with embedding requests
 func TestCacheTypeWithEmbeddingRequests(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	embeddingRequest := CreateEmbeddingRequest([]string{"Test embedding with cache type"})
 
 	// Cache first request
-	ctx1 := CreateContextWithCacheKey("test-embedding-cache-type")
+	ctx1 := CreateContextWithCacheKey(t, "test-embedding-cache-type")
 	t.Log("Making first embedding request...")
 	response1, err1 := setup.Client.EmbeddingRequest(ctx1, embeddingRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response1})
 
 	WaitForCache(setup.Plugin)
 
 	// Test with direct-only cache type
-	ctx2 := CreateContextWithCacheKeyAndType("test-embedding-cache-type", CacheTypeDirect)
+	ctx2 := CreateContextWithCacheKeyAndType(t, "test-embedding-cache-type", CacheTypeDirect)
 	t.Log("Making second embedding request with CacheTypeKey=direct...")
 	response2, err2 := setup.Client.EmbeddingRequest(ctx2, embeddingRequest)
 	if err2 != nil {
@@ -200,7 +228,7 @@ func TestCacheTypeWithEmbeddingRequests(t *testing.T) {
 	AssertCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response2}, "direct")
 
 	// Test with semantic-only cache type (should not find semantic match for embeddings)
-	ctx3 := CreateContextWithCacheKeyAndType("test-embedding-cache-type", CacheTypeSemantic)
+	ctx3 := CreateContextWithCacheKeyAndType(t, "test-embedding-cache-type", CacheTypeSemantic)
 	t.Log("Making third embedding request with CacheTypeKey=semantic...")
 	response3, err3 := setup.Client.EmbeddingRequest(ctx3, embeddingRequest)
 	if err3 != nil {
@@ -214,24 +242,25 @@ func TestCacheTypeWithEmbeddingRequests(t *testing.T) {
 
 // TestCacheTypePerformanceCharacteristics tests that different cache types have expected performance
 func TestCacheTypePerformanceCharacteristics(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	testRequest := CreateBasicChatRequest("Performance test for cache types", 0.7, 50)
 
 	// Cache first request using CacheTypeDirect so it is stored under the deterministic ID
-	ctx1 := CreateContextWithCacheKeyAndType("test-cache-performance", CacheTypeDirect)
+	ctx1 := CreateContextWithCacheKeyAndType(t, "test-cache-performance", CacheTypeDirect)
 	t.Log("Making first request to populate cache...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
 	WaitForCache(setup.Plugin)
 
 	// Test direct-only performance
-	ctx2 := CreateContextWithCacheKeyAndType("test-cache-performance", CacheTypeDirect)
+	ctx2 := CreateContextWithCacheKeyAndType(t, "test-cache-performance", CacheTypeDirect)
 	start2 := time.Now()
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	duration2 := time.Since(start2)
@@ -243,7 +272,7 @@ func TestCacheTypePerformanceCharacteristics(t *testing.T) {
 	t.Logf("Direct cache lookup took: %v", duration2)
 
 	// Test default behavior (both direct and semantic) performance
-	ctx3 := CreateContextWithCacheKey("test-cache-performance")
+	ctx3 := CreateContextWithCacheKey(t, "test-cache-performance")
 	start3 := time.Now()
 	response3, err3 := setup.Client.ChatCompletionRequest(ctx3, testRequest)
 	duration3 := time.Since(start3)
@@ -254,8 +283,17 @@ func TestCacheTypePerformanceCharacteristics(t *testing.T) {
 
 	t.Logf("Default cache lookup took: %v", duration3)
 
-	// Both should be fast since they hit direct cache
-	// Direct-only might be slightly faster as it doesn't need to prepare for semantic fallback
+	// Both lookups hit direct cache so both must be substantially faster than
+	// a real upstream call. Compare against an upper bound rather than each
+	// other (relative comparisons flake under CI load); 1s is generous and
+	// still proves a cached lookup didn't silently hit the network.
+	const upperBoundForCacheLookup = 1 * time.Second
+	if duration2 > upperBoundForCacheLookup {
+		t.Errorf("direct-only cache lookup took %v, expected < %v (provider likely called)", duration2, upperBoundForCacheLookup)
+	}
+	if duration3 > upperBoundForCacheLookup {
+		t.Errorf("default-mode cache lookup took %v, expected < %v (provider likely called)", duration3, upperBoundForCacheLookup)
+	}
 	t.Log("✅ Cache type performance characteristics validated")
 }
 
@@ -367,7 +405,7 @@ func TestDirectCacheHitPreservesCachedProviderMetadataAcrossProviders(t *testing
 	const cacheKey = "cross-provider-direct-single"
 	const prompt = "Explain green threading in Go in one short sentence."
 
-	seedCtx := CreateContextWithCacheKeyAndType(cacheKey, CacheTypeDirect)
+	seedCtx := CreateContextWithCacheKeyAndType(t, cacheKey, CacheTypeDirect)
 	seedReq := newCrossProviderChatRequest(schemas.OpenAI, "gpt-5.2", schemas.ChatCompletionRequest, prompt)
 
 	_, shortCircuit, err := plugin.PreLLMHook(seedCtx, seedReq)
@@ -407,7 +445,7 @@ func TestDirectCacheHitPreservesCachedProviderMetadataAcrossProviders(t *testing
 	}
 	plugin.WaitForPendingOperations()
 
-	hitCtx := CreateContextWithCacheKeyAndType(cacheKey, CacheTypeDirect)
+	hitCtx := CreateContextWithCacheKeyAndType(t, cacheKey, CacheTypeDirect)
 	hitReq := newCrossProviderChatRequest(schemas.Anthropic, "claude-sonnet-4-6", schemas.ChatCompletionRequest, prompt)
 
 	_, shortCircuit, err = plugin.PreLLMHook(hitCtx, hitReq)
@@ -461,7 +499,7 @@ func TestStreamingDirectCacheHitPreservesCachedProviderMetadataAcrossProviders(t
 	const cacheKey = "cross-provider-direct-stream"
 	const prompt = "Explain green threading in Go in one short sentence."
 
-	seedCtx := CreateContextWithCacheKeyAndType(cacheKey, CacheTypeDirect)
+	seedCtx := CreateContextWithCacheKeyAndType(t, cacheKey, CacheTypeDirect)
 	seedReq := newCrossProviderChatRequest(schemas.OpenAI, "gpt-5.2", schemas.ChatCompletionStreamRequest, prompt)
 
 	_, shortCircuit, err := plugin.PreLLMHook(seedCtx, seedReq)
@@ -514,7 +552,7 @@ func TestStreamingDirectCacheHitPreservesCachedProviderMetadataAcrossProviders(t
 		plugin.WaitForPendingOperations()
 	}
 
-	hitCtx := CreateContextWithCacheKeyAndType(cacheKey, CacheTypeDirect)
+	hitCtx := CreateContextWithCacheKeyAndType(t, cacheKey, CacheTypeDirect)
 	hitReq := newCrossProviderChatRequest(schemas.Anthropic, "claude-sonnet-4-6", schemas.ChatCompletionStreamRequest, prompt)
 
 	_, shortCircuit, err = plugin.PreLLMHook(hitCtx, hitReq)
@@ -564,6 +602,29 @@ func TestStreamingDirectCacheHitPreservesCachedProviderMetadataAcrossProviders(t
 	}
 }
 
+// runDirectSearchForTest is a small helper for the unit tests that directly
+// exercise performDirectSearch. It builds the metadata + paramsHash + state
+// the way PreLLMHook would and then calls the search.
+func runDirectSearchForTest(t *testing.T, plugin *Plugin, ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (*cacheState, *schemas.LLMPluginShortCircuit, error) {
+	t.Helper()
+	requestID, _ := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
+	if requestID == "" {
+		t.Fatal("test context is missing request ID")
+	}
+	state := plugin.createCacheState(requestID)
+	metadata, err := plugin.buildRequestMetadataForCaching(state, req)
+	if err != nil {
+		t.Fatalf("buildRequestMetadataForCaching failed: %v", err)
+	}
+	paramsHash, err := hashMap(metadata)
+	if err != nil {
+		t.Fatalf("hashMap failed: %v", err)
+	}
+	state.ParamsHash = paramsHash
+	sc, err := plugin.performDirectSearch(ctx, state, req, cacheKey, metadata, paramsHash)
+	return state, sc, err
+}
+
 func TestCacheTypeDirectUsesChunkLookup(t *testing.T) {
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	store := newDirectFastPathStore()
@@ -578,10 +639,15 @@ func TestCacheTypeDirectUsesChunkLookup(t *testing.T) {
 		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
 	}
 
-	ctx := CreateContextWithCacheKeyAndType("chunk-fast-path", CacheTypeDirect)
-	directID, err := plugin.prepareDirectCacheLookup(ctx, req, "chunk-fast-path")
+	// First pass: warm the deterministic cache ID and learn what it is.
+	ctx := CreateContextWithCacheKeyAndType(t, "chunk-fast-path", CacheTypeDirect)
+	state, _, err := runDirectSearchForTest(t, plugin, ctx, req, "chunk-fast-path")
 	if err != nil {
-		t.Fatalf("prepareDirectCacheLookup failed: %v", err)
+		t.Fatalf("performDirectSearch failed: %v", err)
+	}
+	directID := state.DirectCacheID
+	if directID == "" {
+		t.Fatal("expected DirectCacheID to be populated")
 	}
 
 	cachedContent := "cached response"
@@ -614,15 +680,18 @@ func TestCacheTypeDirectUsesChunkLookup(t *testing.T) {
 		},
 	}
 
-	shortCircuit, err := plugin.performDirectChunkLookup(ctx, req, "chunk-fast-path")
+	// Second pass: should hit the chunk we just stored, via point-fetch only.
+	priorChunkCalls := store.getChunkCalls
+	ctx2 := CreateContextWithCacheKeyAndType(t, "chunk-fast-path", CacheTypeDirect)
+	_, shortCircuit, err := runDirectSearchForTest(t, plugin, ctx2, req, "chunk-fast-path")
 	if err != nil {
-		t.Fatalf("performDirectChunkLookup failed: %v", err)
+		t.Fatalf("second performDirectSearch failed: %v", err)
 	}
 	if shortCircuit == nil || shortCircuit.Response == nil || shortCircuit.Response.ChatResponse == nil {
 		t.Fatal("expected direct chunk lookup to return cached response")
 	}
-	if store.getChunkCalls != 1 {
-		t.Fatalf("expected one GetChunk call, got %d", store.getChunkCalls)
+	if store.getChunkCalls != priorChunkCalls+1 {
+		t.Fatalf("expected one additional GetChunk call, got %d total", store.getChunkCalls)
 	}
 	if store.getAllCalls != 0 {
 		t.Fatalf("expected no GetAll calls, got %d", store.getAllCalls)
@@ -646,22 +715,22 @@ func TestDefaultDirectSearchSetsStorageIDForDeterministicWrites(t *testing.T) {
 		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
 	}
 
-	ctx := CreateContextWithCacheKey("default-mode")
-	_, err := plugin.performDirectSearch(ctx, req, "default-mode")
-	if err != nil && !errors.Is(err, vectorstore.ErrNotSupported) {
+	ctx := CreateContextWithCacheKey(t, "default-mode")
+	state, _, err := runDirectSearchForTest(t, plugin, ctx, req, "default-mode")
+	if err != nil {
 		t.Fatalf("performDirectSearch failed: %v", err)
 	}
-
-	storageID, _ := ctx.Value(requestStorageIDKey).(string)
-	if storageID == "" {
-		t.Fatal("expected default direct search to set requestStorageIDKey")
+	if state.DirectCacheID == "" {
+		t.Fatal("expected default direct search to populate state.DirectCacheID")
 	}
 	if store.getChunkCalls != 1 {
 		t.Fatalf("expected one GetChunk call, got %d", store.getChunkCalls)
 	}
 }
 
-func TestPreLLMHookClearsStaleStorageIDOnReusedContext(t *testing.T) {
+// TestPreLLMHookResetsStateOnReusedRequestID verifies that a second PreLLMHook
+// call for the same request ID overwrites any prior state instead of inheriting it.
+func TestPreLLMHookResetsStateOnReusedRequestID(t *testing.T) {
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 	store := newDirectFastPathStore()
 	config := getDefaultTestConfig()
@@ -677,19 +746,29 @@ func TestPreLLMHookClearsStaleStorageIDOnReusedContext(t *testing.T) {
 		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
 	}
 
-	ctx := CreateContextWithCacheKey("reused-context")
-	ctx.SetValue(requestStorageIDKey, "stale-storage-id")
+	ctx := CreateContextWithCacheKey(t, "reused-context")
+	requestID, _ := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
+	// Seed stale state under the same request ID.
+	stale := plugin.createCacheState(requestID)
+	stale.DirectCacheID = "stale-storage-id"
+	stale.ParamsHash = "stale-params-hash"
 
 	if _, _, err := plugin.PreLLMHook(ctx, req); err != nil {
 		t.Fatalf("PreLLMHook failed: %v", err)
 	}
 
-	storageID, _ := ctx.Value(requestStorageIDKey).(string)
-	if storageID == "" {
-		t.Fatal("expected PreLLMHook to replace stale requestStorageIDKey with a deterministic id")
+	state := plugin.getCacheState(requestID)
+	if state == nil {
+		t.Fatal("expected cache state to be present after PreLLMHook")
 	}
-	if storageID == "stale-storage-id" {
-		t.Fatal("expected PreLLMHook to clear stale requestStorageIDKey before setting a deterministic id")
+	if state == stale {
+		t.Fatal("expected PreLLMHook to replace the stale state object")
+	}
+	if state.DirectCacheID == "" {
+		t.Fatal("expected PreLLMHook to populate a deterministic DirectCacheID")
+	}
+	if state.DirectCacheID == "stale-storage-id" {
+		t.Fatal("expected PreLLMHook to clear stale DirectCacheID before populating a new one")
 	}
 }
 
@@ -707,16 +786,17 @@ func TestCacheTypeDirectStoresDeterministicID(t *testing.T) {
 		RequestType: schemas.ChatCompletionRequest,
 		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
 	}
-	ctx := CreateContextWithCacheKeyAndType("deterministic-store", CacheTypeDirect)
-	ctx.SetValue(requestIDKey, "request-uuid")
-	ctx.SetValue(requestProviderKey, schemas.OpenAI)
-	ctx.SetValue(requestModelKey, req.ChatRequest.Model)
+	ctx := CreateContextWithCacheKeyAndType(t, "deterministic-store", CacheTypeDirect)
 
-	directID, err := plugin.prepareDirectCacheLookup(ctx, req, "deterministic-store")
-	if err != nil {
-		t.Fatalf("prepareDirectCacheLookup failed: %v", err)
+	if _, _, err := plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook failed: %v", err)
 	}
-	ctx.SetValue(requestStorageIDKey, directID)
+	requestID, _ := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
+	state := plugin.getCacheState(requestID)
+	if state == nil || state.DirectCacheID == "" {
+		t.Fatal("expected PreLLMHook to populate state.DirectCacheID")
+	}
+	directID := state.DirectCacheID
 
 	content := "stored response"
 	response := &schemas.BifrostResponse{
@@ -749,8 +829,8 @@ func TestCacheTypeDirectStoresDeterministicID(t *testing.T) {
 	if store.addIDs[0] != directID {
 		t.Fatalf("expected deterministic storage id %q, got %q", directID, store.addIDs[0])
 	}
-	if store.addIDs[0] == "request-uuid" {
-		t.Fatal("expected storage id to differ from request UUID")
+	if store.addIDs[0] == requestID {
+		t.Fatal("expected storage id to differ from request ID")
 	}
 }
 
@@ -762,6 +842,24 @@ func TestPostLLMHookUsesDeterministicStorageIDOutsideDirectMode(t *testing.T) {
 		config: getDefaultTestConfig(),
 		logger: logger,
 	}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
+	}
+
+	// Default mode (no CacheTypeKey) should still produce a deterministic
+	// storage ID via the direct-search path that PreLLMHook always runs.
+	ctx := CreateContextWithCacheKey(t, "default-mode-store")
+	if _, _, err := plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook failed: %v", err)
+	}
+	requestID, _ := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
+	state := plugin.getCacheState(requestID)
+	if state == nil || state.DirectCacheID == "" {
+		t.Fatal("expected default-mode PreLLMHook to populate state.DirectCacheID")
+	}
+	directID := state.DirectCacheID
 
 	content := "stored response"
 	response := &schemas.BifrostResponse{
@@ -782,16 +880,6 @@ func TestPostLLMHookUsesDeterministicStorageIDOutsideDirectMode(t *testing.T) {
 	}
 	response.ChatResponse.ExtraFields.RequestType = schemas.ChatCompletionRequest
 
-	ctx := CreateContextWithCacheKey("default-mode-store")
-	ctx.SetValue(requestIDKey, "request-uuid")
-	ctx.SetValue(requestProviderKey, schemas.OpenAI)
-	ctx.SetValue(requestModelKey, "openai/gpt-4o-mini")
-	ctx.SetValue(requestHashKey, "request-hash")
-	ctx.SetValue(requestParamsHashKey, "params-hash")
-
-	directID := plugin.generateDirectCacheID(schemas.OpenAI, "openai/gpt-4o-mini", "default-mode-store", "request-hash", "params-hash")
-	ctx.SetValue(requestStorageIDKey, directID)
-
 	if _, _, err := plugin.PostLLMHook(ctx, response, nil); err != nil {
 		t.Fatalf("PostLLMHook failed: %v", err)
 	}
@@ -803,67 +891,6 @@ func TestPostLLMHookUsesDeterministicStorageIDOutsideDirectMode(t *testing.T) {
 	}
 	if store.addIDs[0] != directID {
 		t.Fatalf("expected PostLLMHook to use deterministic storage id outside direct mode, got %q", store.addIDs[0])
-	}
-}
-
-func TestPerformDirectSearchDisablesScanFallbackForLegacyLookup(t *testing.T) {
-	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
-	store := newDirectFastPathStore()
-	plugin := &Plugin{
-		store:  store,
-		config: getDefaultTestConfig(),
-		logger: logger,
-	}
-
-	req := &schemas.BifrostRequest{
-		RequestType: schemas.ChatCompletionRequest,
-		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
-	}
-
-	ctx := CreateContextWithCacheKey("legacy-no-scan")
-	_, err := plugin.performDirectSearch(ctx, req, "legacy-no-scan")
-	if err != nil && !errors.Is(err, vectorstore.ErrNotSupported) {
-		t.Fatalf("performDirectSearch failed: %v", err)
-	}
-
-	if store.getAllCalls != 1 {
-		t.Fatalf("expected one legacy GetAll call, got %d", store.getAllCalls)
-	}
-	if !vectorstore.IsScanFallbackDisabled(store.lastGetAllCtx) {
-		t.Fatal("expected legacy direct lookup to disable scan fallback")
-	}
-}
-
-func TestPerformLegacyDirectSearchTreatsQuerySyntaxErrorAsMiss(t *testing.T) {
-	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
-	store := newDirectFastPathStore()
-	store.getAllErr = vectorstore.ErrQuerySyntax
-	plugin := &Plugin{
-		store:  store,
-		config: getDefaultTestConfig(),
-		logger: logger,
-	}
-
-	req := &schemas.BifrostRequest{
-		RequestType: schemas.ChatCompletionRequest,
-		ChatRequest: CreateBasicChatRequest("What is Bifrost?", 0.7, 50),
-	}
-
-	ctx := CreateContextWithCacheKey("legacy-query-syntax")
-	_, err := plugin.prepareDirectCacheLookup(ctx, req, "legacy-query-syntax")
-	if err != nil {
-		t.Fatalf("prepareDirectCacheLookup failed: %v", err)
-	}
-
-	shortCircuit, err := plugin.performLegacyDirectSearch(ctx, req, "legacy-query-syntax")
-	if err != nil {
-		t.Fatalf("performLegacyDirectSearch failed: %v", err)
-	}
-	if shortCircuit != nil {
-		t.Fatal("expected query syntax incompatibility to be treated as a miss")
-	}
-	if store.getAllCalls != 1 {
-		t.Fatalf("expected one legacy GetAll call, got %d", store.getAllCalls)
 	}
 }
 

--- a/plugins/semanticcache/plugin_conversation_config_test.go
+++ b/plugins/semanticcache/plugin_conversation_config_test.go
@@ -14,7 +14,7 @@ func TestConversationHistoryThresholdBasic(t *testing.T) {
 	setup := CreateTestSetupWithConversationThreshold(t, 2)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-conversation-threshold-basic")
+	ctx := CreateContextWithCacheKey(t, "test-conversation-threshold-basic")
 
 	// Test 1: Conversation with exactly 2 messages (should cache)
 	conversation1 := BuildConversationHistory("",
@@ -25,7 +25,7 @@ func TestConversationHistoryThresholdBasic(t *testing.T) {
 	t.Log("Testing conversation with exactly 2 messages (at threshold)...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx, request1)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Fresh request
 
@@ -53,17 +53,18 @@ func TestConversationHistoryThresholdBasic(t *testing.T) {
 	t.Log("Testing conversation with 5 messages (exceeds threshold)...")
 	response3, err3 := setup.Client.ChatCompletionRequest(ctx, request2)
 	if err3 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err3)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3}) // Should not cache
 
 	WaitForCache(setup.Plugin)
 
-	// Verify it was NOT cached
+	// Verify it was NOT cached. The first call already succeeded, so any error
+	// here is a real regression rather than upstream flakiness — fail fast.
 	t.Log("Verifying conversation exceeding threshold was not cached...")
 	response4, err4 := setup.Client.ChatCompletionRequest(ctx, request2)
 	if err4 != nil {
-		return // Test will be skipped by retry function
+		t.Fatalf("verification request failed: %v", err4)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response4}) // Should still be fresh (not cached)
 
@@ -76,7 +77,7 @@ func TestConversationHistoryThresholdWithSystemPrompt(t *testing.T) {
 	setup := CreateTestSetupWithConversationThreshold(t, 3)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-threshold-system-prompt")
+	ctx := CreateContextWithCacheKey(t, "test-threshold-system-prompt")
 
 	// System prompt + 2 user/assistant pairs = 5 messages total > 3
 	conversation := BuildConversationHistory(
@@ -89,16 +90,17 @@ func TestConversationHistoryThresholdWithSystemPrompt(t *testing.T) {
 	t.Log("Testing conversation with system prompt (5 total messages > 3 threshold)...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx, request)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Should not cache (exceeds threshold)
 
 	WaitForCache(setup.Plugin)
 
-	// Verify not cached
+	// Verify not cached. First call already succeeded, so failures here
+	// indicate a real regression rather than upstream flakiness.
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx, request)
 	if err2 != nil {
-		return // Test will be skipped by retry function
+		t.Fatalf("verification request failed: %v", err2)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}) // Should not be cached
 
@@ -111,7 +113,7 @@ func TestConversationHistoryThresholdWithExcludeSystemPrompt(t *testing.T) {
 	setup := CreateTestSetupWithThresholdAndExcludeSystem(t, 3, true)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-threshold-exclude-system")
+	ctx := CreateContextWithCacheKey(t, "test-threshold-exclude-system")
 
 	// Create conversation with exactly 3 non-system messages to test threshold boundary
 	// System + 1.5 user/assistant pairs = 4 messages total
@@ -133,7 +135,7 @@ func TestConversationHistoryThresholdWithExcludeSystemPrompt(t *testing.T) {
 
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx, request)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Fresh request, should not hit cache
 
@@ -172,7 +174,7 @@ func TestConversationHistoryThresholdDifferentValues(t *testing.T) {
 			setup := CreateTestSetupWithConversationThreshold(t, tc.threshold)
 			defer setup.Cleanup()
 
-			ctx := CreateContextWithCacheKey("test-threshold-" + tc.name)
+			ctx := CreateContextWithCacheKey(t, "test-threshold-" + tc.name)
 
 			// Build conversation with specified number of messages
 			var conversation []schemas.ChatMessage
@@ -194,7 +196,7 @@ func TestConversationHistoryThresholdDifferentValues(t *testing.T) {
 
 			response1, err1 := setup.Client.ChatCompletionRequest(ctx, request)
 			if err1 != nil {
-				return // Test will be skipped by retry function
+				t.Skipf("upstream request error, skipping test: %v", err1)
 			}
 			AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Always fresh first time
 
@@ -202,7 +204,7 @@ func TestConversationHistoryThresholdDifferentValues(t *testing.T) {
 
 			response2, err2 := setup.Client.ChatCompletionRequest(ctx, request)
 			if err2 != nil {
-				return // Test will be skipped by retry function
+				t.Fatalf("verification request failed: %v", err2)
 			}
 
 			if tc.shouldCache {
@@ -222,7 +224,7 @@ func TestExcludeSystemPromptBasic(t *testing.T) {
 	setup := CreateTestSetupWithExcludeSystemPrompt(t, true)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-exclude-system-basic")
+	ctx := CreateContextWithCacheKey(t, "test-exclude-system-basic")
 
 	// Create two conversations with different system prompts but same user/assistant messages
 	conversation1 := BuildConversationHistory(
@@ -241,7 +243,7 @@ func TestExcludeSystemPromptBasic(t *testing.T) {
 	t.Log("Caching conversation with system prompt 1...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx, request1)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
@@ -268,7 +270,7 @@ func TestExcludeSystemPromptComparison(t *testing.T) {
 	setup1 := CreateTestSetupWithExcludeSystemPrompt(t, false)
 	defer setup1.Cleanup()
 
-	ctx1 := CreateContextWithCacheKey("test-exclude-system-false")
+	ctx1 := CreateContextWithCacheKey(t, "test-exclude-system-false")
 
 	conversation1 := BuildConversationHistory(
 		"You are helpful",
@@ -286,7 +288,7 @@ func TestExcludeSystemPromptComparison(t *testing.T) {
 	t.Log("Testing ExcludeSystemPrompt=false...")
 	response1, err1 := setup1.Client.ChatCompletionRequest(ctx1, request1)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
@@ -315,12 +317,12 @@ func TestExcludeSystemPromptComparison(t *testing.T) {
 	setup2 := CreateTestSetupWithExcludeSystemPrompt(t, true)
 	defer setup2.Cleanup()
 
-	ctx2 := CreateContextWithCacheKey("test-exclude-system-true")
+	ctx2 := CreateContextWithCacheKey(t, "test-exclude-system-true")
 
 	t.Log("Testing ExcludeSystemPrompt=true...")
 	response3, err3 := setup2.Client.ChatCompletionRequest(ctx2, request1)
 	if err3 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err3)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3})
 
@@ -341,7 +343,7 @@ func TestExcludeSystemPromptWithMultipleSystemMessages(t *testing.T) {
 	setup := CreateTestSetupWithExcludeSystemPrompt(t, true)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-multiple-system-messages")
+	ctx := CreateContextWithCacheKey(t, "test-multiple-system-messages")
 
 	// Manually create conversation with multiple system messages
 	conversation1 := []schemas.ChatMessage{
@@ -388,7 +390,7 @@ func TestExcludeSystemPromptWithMultipleSystemMessages(t *testing.T) {
 	t.Log("Caching conversation with multiple system messages...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx, request1)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
@@ -414,7 +416,7 @@ func TestExcludeSystemPromptWithNoSystemMessages(t *testing.T) {
 	setup := CreateTestSetupWithExcludeSystemPrompt(t, true)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-no-system-messages")
+	ctx := CreateContextWithCacheKey(t, "test-no-system-messages")
 
 	// Conversation with no system messages
 	conversation := []schemas.ChatMessage{
@@ -433,7 +435,7 @@ func TestExcludeSystemPromptWithNoSystemMessages(t *testing.T) {
 	t.Log("Testing conversation with no system messages...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx, request)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 

--- a/plugins/semanticcache/plugin_core_test.go
+++ b/plugins/semanticcache/plugin_core_test.go
@@ -10,12 +10,17 @@ import (
 	"github.com/maximhq/bifrost/framework/vectorstore"
 )
 
-// TestSemanticCacheBasicFunctionality tests the core caching functionality
+// TestSemanticCacheBasicFunctionality tests the core caching functionality.
+//
+// Intentionally NOT parallel: the assertions at the bottom of this function
+// enforce wall-clock comparisons (cache must be faster than upstream, with at
+// least 1.5× speedup). Running this in parallel with other integration tests
+// causes CPU/network contention that flakes those ratios.
 func TestSemanticCacheBasicFunctionality(t *testing.T) {
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-basic-value")
+	ctx := CreateContextWithCacheKey(t, "test-basic-value")
 
 	// Create test request
 	testRequest := CreateBasicChatRequest(
@@ -32,7 +37,7 @@ func TestSemanticCacheBasicFunctionality(t *testing.T) {
 	duration1 := time.Since(start1)
 
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	if response1 == nil || len(response1.Choices) == 0 || response1.Choices[0].Message.Content.ContentStr == nil {
@@ -106,13 +111,14 @@ func TestSemanticCacheBasicFunctionality(t *testing.T) {
 
 // TestSemanticSearch tests the semantic similarity search functionality
 func TestSemanticSearch(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	// Lower threshold for more flexible matching
 	setup.Config.Threshold = 0.5
 
-	ctx := CreateContextWithCacheKey("semantic-test-value")
+	ctx := CreateContextWithCacheKey(t, "semantic-test-value")
 
 	// First request - this will be cached
 	firstRequest := CreateBasicChatRequest(
@@ -127,7 +133,7 @@ func TestSemanticSearch(t *testing.T) {
 	duration1 := time.Since(start1)
 
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	if response1 == nil || len(response1.Choices) == 0 || response1.Choices[0].Message.Content.ContentStr == nil {
@@ -209,7 +215,7 @@ func TestSemanticSearch(t *testing.T) {
 func TestToFloat32Embedding(t *testing.T) {
 	input := []float64{0.12345678901234568, -0.875, 1.5}
 
-	got := toFloat32Embedding(input)
+	got := float64ToFloat32Embedding(input)
 
 	if len(got) != len(input) {
 		t.Fatalf("expected %d elements, got %d", len(input), len(got))
@@ -246,13 +252,14 @@ func TestFlattenToFloat32Embedding(t *testing.T) {
 
 // TestDirectVsSemanticSearch tests the difference between direct hash matching and semantic search
 func TestDirectVsSemanticSearch(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	// Lower threshold for more flexible semantic matching
 	setup.Config.Threshold = 0.2
 
-	ctx := CreateContextWithCacheKey("direct-vs-semantic-test")
+	ctx := CreateContextWithCacheKey(t, "direct-vs-semantic-test")
 
 	// Test Case 1: Exact same request (should use direct hash matching)
 	t.Log("=== Test Case 1: Exact Same Request (Direct Hash Match) ===")
@@ -266,7 +273,7 @@ func TestDirectVsSemanticSearch(t *testing.T) {
 	t.Log("Making first request...")
 	_, err1 := setup.Client.ChatCompletionRequest(ctx, exactRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	WaitForCache(setup.Plugin)
@@ -330,10 +337,11 @@ func TestDirectVsSemanticSearch(t *testing.T) {
 
 // TestNoCacheScenarios tests scenarios where caching should NOT occur
 func TestNoCacheScenarios(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("no-cache-test")
+	ctx := CreateContextWithCacheKey(t, "no-cache-test")
 
 	// Test Case 1: Different parameters should NOT cache hit
 	t.Log("=== Test Case 1: Different Parameters ===")
@@ -344,7 +352,7 @@ func TestNoCacheScenarios(t *testing.T) {
 	request1 := CreateBasicChatRequest(basePrompt, 0.1, 50)
 	_, err1 := setup.Client.ChatCompletionRequest(ctx, request1)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	WaitForCache(setup.Plugin)
@@ -353,7 +361,7 @@ func TestNoCacheScenarios(t *testing.T) {
 	request2 := CreateBasicChatRequest(basePrompt, 0.9, 50) // Different temperature
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx, request2)
 	if err2 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err2)
 	}
 
 	// Should NOT be cached
@@ -365,17 +373,28 @@ func TestNoCacheScenarios(t *testing.T) {
 	request3 := CreateBasicChatRequest(basePrompt, 0.1, 200) // Different max_tokens
 	response3, err3 := setup.Client.ChatCompletionRequest(ctx, request3)
 	if err3 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err3)
 	}
-
-	// Should NOT be cached
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3})
+
+	WaitForCache(setup.Plugin)
+
+	// Make request3 a SECOND time. The miss above could be a miss for the
+	// wrong reason (e.g. caching disabled entirely). A second-call hit
+	// confirms (a) request3's params produce a distinct cache_key from the
+	// earlier requests AND (b) caching itself is functioning under this ctx.
+	response3Again, err := setup.Client.ChatCompletionRequest(ctx, request3)
+	if err != nil {
+		t.Fatalf("Repeat of request3 failed: %v", err)
+	}
+	AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3Again}, string(CacheTypeDirect))
 
 	t.Log("✅ No cache scenarios test completed!")
 }
 
 // TestCacheConfiguration tests different cache configuration options
 func TestCacheConfiguration(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		config           *Config
@@ -408,7 +427,10 @@ func TestCacheConfiguration(t *testing.T) {
 				EmbeddingModel: "text-embedding-3-small",
 				Dimension:      1536,
 				Threshold:      0.8,
-				TTL:            1 * time.Hour, // Custom TTL
+				// Short TTL so the test can verify expiry is honored.
+				// 1h would only verify the configured value didn't crash;
+				// it can't distinguish "TTL applied" from "default TTL applied".
+				TTL: 2 * time.Second,
 			},
 			expectedBehavior: "custom_ttl",
 		},
@@ -419,19 +441,22 @@ func TestCacheConfiguration(t *testing.T) {
 			setup := NewTestSetupWithConfig(t, tt.config)
 			defer setup.Cleanup()
 
-			ctx := CreateContextWithCacheKey("config-test-" + tt.name)
+			ctx := CreateContextWithCacheKey(t, "config-test-"+tt.name)
 
 			// Basic functionality test with the configuration
 			testRequest := CreateBasicChatRequest("Test configuration: "+tt.name, 0.5, 50)
 
-			_, err1 := setup.Client.ChatCompletionRequest(ctx, testRequest)
+			response1, err1 := setup.Client.ChatCompletionRequest(ctx, testRequest)
 			if err1 != nil {
-				return // Test will be skipped by retry function
+				t.Skipf("upstream request error, skipping test: %v", err1)
 			}
+			AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
 			WaitForCache(setup.Plugin)
 
-			_, err2 := setup.Client.ChatCompletionRequest(ctx, testRequest)
+			// Second identical request must hit (regardless of which config —
+			// all three configs cache identical requests via the direct path).
+			response2, err2 := setup.Client.ChatCompletionRequest(ctx, testRequest)
 			if err2 != nil {
 				if err2.Error != nil {
 					t.Fatalf("Second request failed: %v", err2.Error.Message)
@@ -439,8 +464,32 @@ func TestCacheConfiguration(t *testing.T) {
 					t.Fatalf("Second request failed: %v", err2)
 				}
 			}
+			AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}, string(CacheTypeDirect))
 
-			t.Logf("✅ Configuration test '%s' completed", tt.name)
+			// Per-config behavioral check.
+			switch tt.expectedBehavior {
+			case "strict_matching":
+				// Threshold=0.95 should still allow direct hits on identical
+				// content (threshold only gates semantic search). Verified above.
+			case "loose_matching":
+				// Same — direct path doesn't use threshold. The relevant check
+				// is that the cache actually wrote (verified above).
+			case "custom_ttl":
+				// Verify Config.TTL was actually honored: wait past expiry
+				// and confirm a third request misses. If the plugin had
+				// fallen back to the default TTL, this would still hit.
+				time.Sleep(tt.config.TTL + 1*time.Second)
+				response3, err3 := setup.Client.ChatCompletionRequest(ctx, testRequest)
+				if err3 != nil {
+					if err3.Error != nil {
+						t.Fatalf("Post-expiry request failed: %v", err3.Error.Message)
+					} else {
+						t.Fatalf("Post-expiry request failed: %v", err3)
+					}
+				}
+				AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3})
+			}
+			t.Logf("✅ Configuration test '%s' completed (cache write + read verified)", tt.name)
 		})
 	}
 }
@@ -510,7 +559,7 @@ func (m *MockUnsupportedStore) Close(ctx context.Context, namespace string) erro
 
 // TestInvalidProviderRejection tests that providers without embedding support are rejected during initialization
 func TestInvalidProviderRejection(t *testing.T) {
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx := newBaseTestContext()
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 
 	// Create a mock vector store for testing
@@ -551,7 +600,7 @@ func TestInvalidProviderRejection(t *testing.T) {
 
 // TestValidProviderAccepted tests that providers with embedding support are accepted during initialization
 func TestValidProviderAccepted(t *testing.T) {
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx := newBaseTestContext()
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
 
 	// Create a mock vector store for testing

--- a/plugins/semanticcache/plugin_cross_cache_test.go
+++ b/plugins/semanticcache/plugin_cross_cache_test.go
@@ -8,24 +8,25 @@ import (
 
 // TestCrossCacheTypeAccessibility tests that entries cached one way are accessible another way
 func TestCrossCacheTypeAccessibility(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	testRequest := CreateBasicChatRequest("What is artificial intelligence?", 0.7, 100)
 
 	// Test 1: Cache with default behavior (both direct + semantic)
-	ctx1 := CreateContextWithCacheKey("test-cross-cache-access")
+	ctx1 := CreateContextWithCacheKey(t, "test-cross-cache-access")
 	t.Log("Caching with default behavior (both direct + semantic)...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
 	WaitForCache(setup.Plugin)
 
 	// Test 2: Retrieve with direct-only cache type
-	ctx2 := CreateContextWithCacheKeyAndType("test-cross-cache-access", CacheTypeDirect)
+	ctx2 := CreateContextWithCacheKeyAndType(t, "test-cross-cache-access", CacheTypeDirect)
 	t.Log("Retrieving with CacheTypeKey=direct...")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	if err2 != nil {
@@ -38,7 +39,7 @@ func TestCrossCacheTypeAccessibility(t *testing.T) {
 	AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}, "direct") // Should find direct match
 
 	// Test 3: Retrieve with semantic-only cache type
-	ctx3 := CreateContextWithCacheKeyAndType("test-cross-cache-access", CacheTypeSemantic)
+	ctx3 := CreateContextWithCacheKeyAndType(t, "test-cross-cache-access", CacheTypeSemantic)
 	t.Log("Retrieving with CacheTypeKey=semantic...")
 	response3, err3 := setup.Client.ChatCompletionRequest(ctx3, testRequest)
 	if err3 != nil {
@@ -51,6 +52,7 @@ func TestCrossCacheTypeAccessibility(t *testing.T) {
 
 // TestCacheTypeIsolation tests that entries cached separately by type behave correctly
 func TestCacheTypeIsolation(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -60,22 +62,22 @@ func TestCacheTypeIsolation(t *testing.T) {
 	clearTestKeysWithStore(t, setup.Store)
 
 	// Test 1: Cache with direct-only
-	ctx1 := CreateContextWithCacheKeyAndType("test-cache-isolation", CacheTypeDirect)
+	ctx1 := CreateContextWithCacheKeyAndType(t, "test-cache-isolation", CacheTypeDirect)
 	t.Log("Caching with CacheTypeKey=direct only...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Fresh request
 
 	WaitForCache(setup.Plugin)
 
 	// Test 2: Try to retrieve with semantic-only (should miss because no semantic entry)
-	ctx2 := CreateContextWithCacheKeyAndType("test-cache-isolation", CacheTypeSemantic)
+	ctx2 := CreateContextWithCacheKeyAndType(t, "test-cache-isolation", CacheTypeSemantic)
 	t.Log("Retrieving same request with CacheTypeKey=semantic (should miss)...")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	if err2 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err2)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}) // Should miss - no semantic cache entry
 
@@ -90,7 +92,7 @@ func TestCacheTypeIsolation(t *testing.T) {
 	AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3}, "direct") // Should hit direct cache
 
 	// Test 4: Default behavior (should find the direct cache)
-	ctx4 := CreateContextWithCacheKey("test-cache-isolation")
+	ctx4 := CreateContextWithCacheKey(t, "test-cache-isolation")
 	t.Log("Retrieving with default behavior (should find direct cache)...")
 	response4, err4 := setup.Client.ChatCompletionRequest(ctx4, testRequest)
 	if err4 != nil {
@@ -103,17 +105,18 @@ func TestCacheTypeIsolation(t *testing.T) {
 
 // TestCacheTypeFallbackBehavior tests whether cache types fallback to each other
 func TestCacheTypeFallbackBehavior(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	// Cache an entry with default behavior
 	originalRequest := CreateBasicChatRequest("Explain machine learning", 0.7, 100)
-	ctx1 := CreateContextWithCacheKey("test-fallback-behavior")
+	ctx1 := CreateContextWithCacheKey(t, "test-fallback-behavior")
 
 	t.Log("Caching with default behavior...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, originalRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
@@ -121,19 +124,19 @@ func TestCacheTypeFallbackBehavior(t *testing.T) {
 
 	// Test similar request with direct-only (should miss direct, no fallback, but should cache response)
 	similarRequest := CreateBasicChatRequest("Explain machine learning concepts", 0.7, 100)
-	ctx2 := CreateContextWithCacheKeyAndType("test-fallback-behavior", CacheTypeDirect)
+	ctx2 := CreateContextWithCacheKeyAndType(t, "test-fallback-behavior", CacheTypeDirect)
 
 	t.Log("Testing similar request with CacheTypeKey=direct (should miss, make request, cache without embeddings)...")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, similarRequest)
 	if err2 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err2)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}) // Should miss - no direct match, no semantic search
 
 	WaitForCache(setup.Plugin) // Let the response get cached
 
 	// Test same similar request with semantic-only (should hit original entry)
-	ctx3 := CreateContextWithCacheKeyAndType("test-fallback-behavior", CacheTypeSemantic)
+	ctx3 := CreateContextWithCacheKeyAndType(t, "test-fallback-behavior", CacheTypeSemantic)
 
 	t.Log("Testing similar request with CacheTypeKey=semantic (should find semantic match from step 1)...")
 	response3, err3 := setup.Client.ChatCompletionRequest(ctx3, similarRequest)
@@ -141,8 +144,12 @@ func TestCacheTypeFallbackBehavior(t *testing.T) {
 		t.Fatalf("Third request failed: %v", err3)
 	}
 
-	// Should find semantic match from step 1's cached entry (which has embeddings)
-	if response3.ExtraFields.CacheDebug != nil && response3.ExtraFields.CacheDebug.CacheHit {
+	// Should find semantic match from step 1's cached entry (which has embeddings).
+	// Hit is similarity-dependent; CacheDebug must be stamped either way.
+	if response3.ExtraFields.CacheDebug == nil {
+		t.Fatal("expected CacheDebug to be stamped on the response")
+	}
+	if response3.ExtraFields.CacheDebug.CacheHit {
 		AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3}, "semantic")
 		t.Log("✅ Semantic search found similar entry from step 1")
 	} else {
@@ -153,7 +160,7 @@ func TestCacheTypeFallbackBehavior(t *testing.T) {
 	// Test a different similar request with default behavior (try both, fallback to semantic)
 	// Use a slightly different request to avoid hitting the cached response from step 2
 	differentSimilarRequest := CreateBasicChatRequest("Explain the basics of machine learning", 0.7, 100)
-	ctx4 := CreateContextWithCacheKey("test-fallback-behavior")
+	ctx4 := CreateContextWithCacheKey(t, "test-fallback-behavior")
 
 	t.Log("Testing different similar request with default behavior (direct miss -> semantic fallback)...")
 	response4, err4 := setup.Client.ChatCompletionRequest(ctx4, differentSimilarRequest)
@@ -161,8 +168,12 @@ func TestCacheTypeFallbackBehavior(t *testing.T) {
 		t.Fatalf("Fourth request failed: %v", err4)
 	}
 
-	// Should try direct first (miss), then semantic (might hit)
-	if response4.ExtraFields.CacheDebug != nil && response4.ExtraFields.CacheDebug.CacheHit {
+	// Should try direct first (miss), then semantic (might hit). CacheDebug
+	// must be stamped either way.
+	if response4.ExtraFields.CacheDebug == nil {
+		t.Fatal("expected CacheDebug to be stamped on the response")
+	}
+	if response4.ExtraFields.CacheDebug.CacheHit {
 		AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response4}, "semantic")
 		t.Log("✅ Default behavior found semantic fallback")
 	} else {
@@ -175,17 +186,18 @@ func TestCacheTypeFallbackBehavior(t *testing.T) {
 
 // TestMultipleCacheEntriesPriority tests behavior when multiple cache entries exist
 func TestMultipleCacheEntriesPriority(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	testRequest := CreateBasicChatRequest("What is deep learning?", 0.7, 100)
 
 	// Create cache entry with default behavior first
-	ctx1 := CreateContextWithCacheKey("test-cache-priority")
+	ctx1 := CreateContextWithCacheKey(t, "test-cache-priority")
 	t.Log("Creating cache entry with default behavior...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 	originalContent := *response1.Choices[0].Message.Content.ContentStr
@@ -211,7 +223,7 @@ func TestMultipleCacheEntriesPriority(t *testing.T) {
 	}
 
 	// Test with direct-only access
-	ctx2 := CreateContextWithCacheKeyAndType("test-cache-priority", CacheTypeDirect)
+	ctx2 := CreateContextWithCacheKeyAndType(t, "test-cache-priority", CacheTypeDirect)
 	t.Log("Accessing with CacheTypeKey=direct...")
 	response3, err3 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	if err3 != nil {
@@ -220,7 +232,7 @@ func TestMultipleCacheEntriesPriority(t *testing.T) {
 	AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3}, "direct") // Should find direct cache
 
 	// Test with semantic-only access
-	ctx3 := CreateContextWithCacheKeyAndType("test-cache-priority", CacheTypeSemantic)
+	ctx3 := CreateContextWithCacheKeyAndType(t, "test-cache-priority", CacheTypeSemantic)
 	t.Log("Accessing with CacheTypeKey=semantic...")
 	response4, err4 := setup.Client.ChatCompletionRequest(ctx3, testRequest)
 	if err4 != nil {
@@ -233,6 +245,7 @@ func TestMultipleCacheEntriesPriority(t *testing.T) {
 
 // TestCrossCacheTypeWithDifferentParameters tests cache type behavior with parameter variations
 func TestCrossCacheTypeWithDifferentParameters(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -240,19 +253,19 @@ func TestCrossCacheTypeWithDifferentParameters(t *testing.T) {
 
 	// Cache with specific parameters
 	request1 := CreateBasicChatRequest(baseMessage, 0.7, 100)
-	ctx1 := CreateContextWithCacheKey("test-cross-cache-params")
+	ctx1 := CreateContextWithCacheKey(t, "test-cross-cache-params")
 
 	t.Log("Caching with temp=0.7, max_tokens=100...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, request1)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
 	WaitForCache(setup.Plugin)
 
 	// Test same parameters with direct-only
-	ctx2 := CreateContextWithCacheKeyAndType("test-cross-cache-params", CacheTypeDirect)
+	ctx2 := CreateContextWithCacheKeyAndType(t, "test-cross-cache-params", CacheTypeDirect)
 	t.Log("Retrieving same parameters with CacheTypeKey=direct...")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, request1)
 	if err2 != nil {
@@ -269,18 +282,18 @@ func TestCrossCacheTypeWithDifferentParameters(t *testing.T) {
 	t.Log("Testing different parameters (should miss)...")
 	response3, err3 := setup.Client.ChatCompletionRequest(ctx2, request3)
 	if err3 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err3)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3}) // Should miss due to different params
 
 	// Test semantic search with different parameters
-	ctx4 := CreateContextWithCacheKeyAndType("test-cross-cache-params", CacheTypeSemantic)
+	ctx4 := CreateContextWithCacheKeyAndType(t, "test-cross-cache-params", CacheTypeSemantic)
 	similarRequest := CreateBasicChatRequest("Can you explain quantum computing", 0.5, 200)
 
 	t.Log("Testing semantic search with different params and similar message...")
 	response4, err4 := setup.Client.ChatCompletionRequest(ctx4, similarRequest)
 	if err4 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err4)
 	}
 	// Should miss semantic search due to different parameters (params_hash different)
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response4})
@@ -290,26 +303,27 @@ func TestCrossCacheTypeWithDifferentParameters(t *testing.T) {
 
 // TestCacheTypeErrorHandling tests error scenarios with cache types
 func TestCacheTypeErrorHandling(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	testRequest := CreateBasicChatRequest("Test error handling", 0.7, 50)
 
 	// Test invalid cache type (should fallback to default)
-	ctx1 := CreateContextWithCacheKey("test-cache-error-handling")
+	ctx1 := CreateContextWithCacheKey(t, "test-cache-error-handling")
 	ctx1 = ctx1.WithValue(CacheTypeKey, "invalid_cache_type")
 
 	t.Log("Testing invalid cache type (should fallback to default behavior)...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Should work with fallback behavior
 
 	WaitForCache(setup.Plugin)
 
 	// Test nil cache type (should use default)
-	ctx2 := CreateContextWithCacheKey("test-cache-error-handling")
+	ctx2 := CreateContextWithCacheKey(t, "test-cache-error-handling")
 	ctx2 = ctx2.WithValue(CacheTypeKey, nil)
 
 	t.Log("Testing nil cache type (should use default behavior)...")

--- a/plugins/semanticcache/plugin_default_cache_key_test.go
+++ b/plugins/semanticcache/plugin_default_cache_key_test.go
@@ -1,7 +1,6 @@
 package semanticcache
 
 import (
-	"context"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -10,21 +9,22 @@ import (
 // TestDefaultCacheKey_CachesWithoutPerRequestKey verifies that when DefaultCacheKey
 // is configured, requests without an explicit cache key are cached automatically.
 func TestDefaultCacheKey_CachesWithoutPerRequestKey(t *testing.T) {
+	t.Parallel()
 	config := getDefaultTestConfig()
-	config.DefaultCacheKey = "test-default-key"
+	config.DefaultCacheKey = keyForTest(t, "test-default-key")
 
 	setup := NewTestSetupWithConfig(t, config)
 	defer setup.Cleanup()
 
 	// Context with NO per-request cache key
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx := newBaseTestContext()
 
 	testRequest := CreateBasicChatRequest("What is Bifrost? Answer in one short sentence.", 0.7, 50)
 
 	t.Log("Making first request without per-request cache key (should use default and be cached)...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	if response1 == nil || len(response1.Choices) == 0 || response1.Choices[0].Message.Content.ContentStr == nil {
@@ -37,7 +37,7 @@ func TestDefaultCacheKey_CachesWithoutPerRequestKey(t *testing.T) {
 	WaitForCache(setup.Plugin)
 
 	t.Log("Making second identical request without per-request cache key (should hit cache)...")
-	ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx2 := newBaseTestContext()
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	if err2 != nil {
 		if err2.Error != nil {
@@ -53,8 +53,9 @@ func TestDefaultCacheKey_CachesWithoutPerRequestKey(t *testing.T) {
 // TestDefaultCacheKey_PerRequestKeyOverridesDefault verifies that an explicit
 // per-request cache key takes precedence over the configured default.
 func TestDefaultCacheKey_PerRequestKeyOverridesDefault(t *testing.T) {
+	t.Parallel()
 	config := getDefaultTestConfig()
-	config.DefaultCacheKey = "test-default-key"
+	config.DefaultCacheKey = keyForTest(t, "test-default-key")
 
 	setup := NewTestSetupWithConfig(t, config)
 	defer setup.Cleanup()
@@ -62,16 +63,16 @@ func TestDefaultCacheKey_PerRequestKeyOverridesDefault(t *testing.T) {
 	testRequest := CreateBasicChatRequest("What is the capital of France?", 0.5, 50)
 
 	// Cache with the default key (no per-request key)
-	ctx1 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx1 := newBaseTestContext()
 	_, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	WaitForCache(setup.Plugin)
 
 	// Verify the cache was actually populated with the default key
-	ctxDefault2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctxDefault2 := newBaseTestContext()
 	responseDefault2, errDefault2 := setup.Client.ChatCompletionRequest(ctxDefault2, testRequest)
 	if errDefault2 != nil {
 		if errDefault2.Error != nil {
@@ -82,7 +83,7 @@ func TestDefaultCacheKey_PerRequestKeyOverridesDefault(t *testing.T) {
 	AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: responseDefault2}, string(CacheTypeDirect))
 
 	// Same request but with a DIFFERENT per-request key — should miss
-	ctx2 := CreateContextWithCacheKey("override-key")
+	ctx2 := CreateContextWithCacheKey(t, "override-key")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	if err2 != nil {
 		if err2.Error != nil {
@@ -98,20 +99,21 @@ func TestDefaultCacheKey_PerRequestKeyOverridesDefault(t *testing.T) {
 // TestDefaultCacheKey_EmptyDefault_NoCaching verifies that when DefaultCacheKey
 // is empty (default zero value), requests without a per-request key bypass caching.
 func TestDefaultCacheKey_EmptyDefault_NoCaching(t *testing.T) {
+	t.Parallel()
 	config := getDefaultTestConfig()
 	// DefaultCacheKey is intentionally left empty (zero value)
 
 	setup := NewTestSetupWithConfig(t, config)
 	defer setup.Cleanup()
 
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx := newBaseTestContext()
 
 	testRequest := CreateBasicChatRequest("What is deep learning", 0.7, 50)
 
 	t.Log("Making first request without any cache key and no default (should not cache)...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
@@ -119,7 +121,7 @@ func TestDefaultCacheKey_EmptyDefault_NoCaching(t *testing.T) {
 	WaitForCache(setup.Plugin)
 
 	t.Log("Making second identical request (should still not cache)...")
-	ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx2 := newBaseTestContext()
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	if err2 != nil {
 		if err2.Error != nil {

--- a/plugins/semanticcache/plugin_edge_cases_test.go
+++ b/plugins/semanticcache/plugin_edge_cases_test.go
@@ -1,7 +1,6 @@
 package semanticcache
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -11,6 +10,7 @@ import (
 
 // TestParameterVariations tests that different parameters don't cache hit inappropriately
 func TestParameterVariations(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -45,7 +45,7 @@ func TestParameterVariations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create a fresh context for each subtest to avoid context pollution
-			ctx := CreateContextWithCacheKey("param-variations-test")
+			ctx := CreateContextWithCacheKey(t, "param-variations-test")
 
 			// Clear cache for this subtest
 			clearTestKeysWithStore(t, setup.Store)
@@ -53,7 +53,7 @@ func TestParameterVariations(t *testing.T) {
 			// Make first request
 			_, err1 := setup.Client.ChatCompletionRequest(ctx, tt.request1)
 			if err1 != nil {
-				return // Test will be skipped by retry function
+				t.Skipf("upstream request error, skipping test: %v", err1)
 			}
 
 			WaitForCache(setup.Plugin)
@@ -80,10 +80,11 @@ func TestParameterVariations(t *testing.T) {
 
 // TestToolVariations tests caching behavior with different tool configurations
 func TestToolVariations(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("tool-variations-test")
+	ctx := CreateContextWithCacheKey(t, "tool-variations-test")
 
 	// Base request without tools
 	baseRequest := &schemas.BifrostChatRequest{
@@ -190,7 +191,7 @@ func TestToolVariations(t *testing.T) {
 	t.Log("Making request with tools...")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx, requestWithTools)
 	if err2 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err2)
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2})
@@ -210,7 +211,7 @@ func TestToolVariations(t *testing.T) {
 	t.Log("Making request with different tools...")
 	response4, err4 := setup.Client.ChatCompletionRequest(ctx, requestWithDifferentTools)
 	if err4 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err4)
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response4})
@@ -220,6 +221,7 @@ func TestToolVariations(t *testing.T) {
 
 // TestContentVariations tests caching behavior with different content types
 func TestContentVariations(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -349,14 +351,13 @@ func TestContentVariations(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Logf("Testing content variation: %s", tt.name)
 
-			// Create a fresh context for each subtest to avoid context pollution
-			ctx := CreateContextWithCacheKey("content-variations-test")
+			// Use a per-subtest cache key so subtests don't share entries.
+			ctx := CreateContextWithCacheKey(t, "content-variations-"+tt.name)
 
 			// Make first request
 			_, err1 := setup.Client.ChatCompletionRequest(ctx, tt.request)
 			if err1 != nil {
-				t.Logf("⚠️  First %s request failed: %v", tt.name, err1)
-				return // Skip this test case
+				t.Skipf("upstream request error, skipping %s: %v", tt.name, err1)
 			}
 
 			WaitForCache(setup.Plugin)
@@ -376,6 +377,7 @@ func TestContentVariations(t *testing.T) {
 
 // TestBoundaryParameterValues tests edge case parameter values
 func TestBoundaryParameterValues(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -454,25 +456,40 @@ func TestBoundaryParameterValues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Logf("Testing boundary parameters: %s", tt.name)
 
-			// Create a fresh context for each subtest to avoid context pollution
-			ctx := CreateContextWithCacheKey("boundary-params-test")
+			// Per-subtest cache key so subtests don't share entries.
+			ctx := CreateContextWithCacheKey(t, "boundary-params-"+tt.name)
 
-			_, err := setup.Client.ChatCompletionRequest(ctx, tt.request)
-			if err != nil {
-				t.Logf("⚠️  %s request failed (may be expected): %v", tt.name, err)
-			} else {
-				t.Logf("✅ %s handled gracefully", tt.name)
+			// First request must succeed (boundary values are valid OpenAI
+			// inputs); a real failure here is a regression, not "expected".
+			response1, err1 := setup.Client.ChatCompletionRequest(ctx, tt.request)
+			if err1 != nil {
+				t.Skipf("upstream request error, skipping %s: %v", tt.name, err1)
 			}
+			AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
+
+			WaitForCache(setup.Plugin)
+
+			// Second identical request must hit — proves boundary params
+			// don't break cache key generation or storage.
+			response2, err2 := setup.Client.ChatCompletionRequest(ctx, tt.request)
+			if err2 != nil {
+				t.Fatalf("Second %s request failed: %v", tt.name, err2)
+			}
+			AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}, string(CacheTypeDirect))
+			t.Logf("✅ %s parameters cached correctly", tt.name)
 		})
 	}
 }
 
 // TestSemanticSimilarityEdgeCases tests edge cases in semantic similarity matching
 func TestSemanticSimilarityEdgeCases(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	setup.Config.Threshold = 0.9
+	// Threshold tuned for the prompt pairs below; 0.9 is too strict for
+	// semantically-similar-but-different-phrasing pairs and produces flakes.
+	setup.Config.Threshold = 0.7
 
 	// Test case: Similar questions with different wording
 	similarTests := []struct {
@@ -510,7 +527,7 @@ func TestSemanticSimilarityEdgeCases(t *testing.T) {
 	for i, test := range similarTests {
 		t.Run(test.description, func(t *testing.T) {
 			// Create a fresh context for each subtest to avoid context pollution
-			ctx := CreateContextWithCacheKey("semantic-edge-test")
+			ctx := CreateContextWithCacheKey(t, "semantic-edge-test")
 
 			// Clear cache for this subtest
 			clearTestKeysWithStore(t, setup.Store)
@@ -519,7 +536,7 @@ func TestSemanticSimilarityEdgeCases(t *testing.T) {
 			request1 := CreateBasicChatRequest(test.prompt1, 0.1, 50)
 			_, err1 := setup.Client.ChatCompletionRequest(ctx, request1)
 			if err1 != nil {
-				return // Test will be skipped by retry function
+				t.Skipf("upstream request error, skipping test: %v", err1)
 			}
 
 			// Wait for cache to be written
@@ -558,7 +575,7 @@ func TestSemanticSimilarityEdgeCases(t *testing.T) {
 				if semanticMatch {
 					t.Logf("✅ Test %d: Semantic match found as expected for '%s'", i+1, test.description)
 				} else {
-					t.Logf("ℹ️  Test %d: No semantic match found for '%s', check with threshold: %f and found similarity: %f", i+1, test.description, cacheThresholdFloat, cacheSimilarityFloat)
+					t.Errorf("❌ Test %d: Expected semantic match for '%s' but none found (threshold=%f, similarity=%f)", i+1, test.description, cacheThresholdFloat, cacheSimilarityFloat)
 				}
 			} else {
 				if semanticMatch {
@@ -573,6 +590,7 @@ func TestSemanticSimilarityEdgeCases(t *testing.T) {
 
 // TestErrorHandlingEdgeCases tests various error scenarios
 func TestErrorHandlingEdgeCases(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -580,23 +598,33 @@ func TestErrorHandlingEdgeCases(t *testing.T) {
 
 	// Test without cache key (should not crash and bypass cache)
 	t.Run("Request without cache key", func(t *testing.T) {
-		ctxNoKey := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctxNoKey := newBaseTestContext()
 
-		response, err := setup.Client.ChatCompletionRequest(ctxNoKey, testRequest)
+		response1, err := setup.Client.ChatCompletionRequest(ctxNoKey, testRequest)
 		if err != nil {
 			t.Errorf("Request without cache key failed: %v", err)
 			return
 		}
+		AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
-		// Should bypass cache since there's no cache key
-		AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response})
-		t.Log("✅ Request without cache key correctly bypassed cache")
+		WaitForCache(setup.Plugin)
+
+		// Second identical request must also miss — proves the first wasn't
+		// silently cached against a default key.
+		ctxNoKey2 := newBaseTestContext()
+		response2, err := setup.Client.ChatCompletionRequest(ctxNoKey2, testRequest)
+		if err != nil {
+			t.Errorf("Second request without cache key failed: %v", err)
+			return
+		}
+		AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2})
+		t.Log("✅ Request without cache key correctly bypassed cache (verified across two calls)")
 	})
 
 	// Test with invalid cache key type
 	t.Run("Request with invalid cache key type", func(t *testing.T) {
 		// First establish a cached response with valid context
-		validCtx := CreateContextWithCacheKey("error-handling-test")
+		validCtx := CreateContextWithCacheKey(t, "error-handling-test")
 		_, err := setup.Client.ChatCompletionRequest(validCtx, testRequest)
 		if err != nil {
 			t.Fatalf("First request with valid cache key failed: %v", err)
@@ -605,7 +633,7 @@ func TestErrorHandlingEdgeCases(t *testing.T) {
 		WaitForCache(setup.Plugin)
 
 		// Now test with invalid key type - should bypass cache
-		ctxInvalidKey := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline).WithValue(CacheKey, 12345)
+		ctxInvalidKey := newBaseTestContext().WithValue(CacheKey, 12345)
 
 		response, err := setup.Client.ChatCompletionRequest(ctxInvalidKey, testRequest)
 		if err != nil {

--- a/plugins/semanticcache/plugin_embedding_test.go
+++ b/plugins/semanticcache/plugin_embedding_test.go
@@ -9,10 +9,11 @@ import (
 
 // TestEmbeddingRequestsCaching tests that embedding requests are properly cached using direct hash matching
 func TestEmbeddingRequestsCaching(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-embedding-cache")
+	ctx := CreateContextWithCacheKey(t, "test-embedding-cache")
 
 	// Create embedding request
 	embeddingRequest := CreateEmbeddingRequest([]string{
@@ -28,7 +29,7 @@ func TestEmbeddingRequestsCaching(t *testing.T) {
 	duration1 := time.Since(start1)
 
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	if response1 == nil || len(response1.Data) == 0 {
@@ -76,33 +77,48 @@ func TestEmbeddingRequestsCaching(t *testing.T) {
 
 // TestEmbeddingRequestsNoCacheWithoutCacheKey tests that embedding requests without cache key are not cached
 func TestEmbeddingRequestsNoCacheWithoutCacheKey(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	// Don't set cache key in context
-	ctx := CreateContextWithCacheKey("")
+	// Don't set cache key in context. CreateContextWithCacheKey(t, "") would
+	// still populate CacheKey from t.Name() and turn this into a keyed
+	// request — using a base context keeps CacheKey unset so we exercise
+	// the cache-disabled path.
+	ctx := newBaseTestContext()
 
 	embeddingRequest := CreateEmbeddingRequest([]string{"Test embedding without cache key"})
 
-	t.Log("Making embedding request without cache key...")
-
-	response, err := setup.Client.EmbeddingRequest(ctx, embeddingRequest)
+	t.Log("Making first embedding request without cache key...")
+	response1, err := setup.Client.EmbeddingRequest(ctx, embeddingRequest)
 	if err != nil {
 		t.Fatalf("Embedding request failed: %v", err)
 	}
+	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response1})
 
-	// Should not be cached
-	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response})
+	WaitForCache(setup.Plugin)
+
+	// Real check: a second identical request must ALSO miss. If the cache
+	// silently keyed off something else (e.g. a default key), this would
+	// surface as a hit and fail the assertion.
+	t.Log("Making second identical request — must also miss because nothing was cached...")
+	ctx2 := newBaseTestContext()
+	response2, err := setup.Client.EmbeddingRequest(ctx2, embeddingRequest)
+	if err != nil {
+		t.Fatalf("Second embedding request failed: %v", err)
+	}
+	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response2})
 
 	t.Log("✅ Embedding requests without cache key are properly not cached")
 }
 
 // TestEmbeddingRequestsDifferentTexts tests that different embedding texts produce different cache entries
 func TestEmbeddingRequestsDifferentTexts(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-embedding-different")
+	ctx := CreateContextWithCacheKey(t, "test-embedding-different")
 
 	// Create two different embedding requests
 	request1 := CreateEmbeddingRequest([]string{"First set of texts"})
@@ -111,7 +127,7 @@ func TestEmbeddingRequestsDifferentTexts(t *testing.T) {
 	t.Log("Making first embedding request...")
 	response1, err1 := setup.Client.EmbeddingRequest(ctx, request1)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response1})
 
@@ -120,7 +136,7 @@ func TestEmbeddingRequestsDifferentTexts(t *testing.T) {
 	t.Log("Making second different embedding request...")
 	response2, err2 := setup.Client.EmbeddingRequest(ctx, request2)
 	if err2 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err2)
 	}
 	// Should not be a cache hit since texts are different
 	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response2})
@@ -130,19 +146,20 @@ func TestEmbeddingRequestsDifferentTexts(t *testing.T) {
 
 // TestEmbeddingRequestsCacheExpiration tests TTL functionality for embedding requests
 func TestEmbeddingRequestsCacheExpiration(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	// Set very short TTL for testing
 	shortTTL := 5 * time.Second
-	ctx := CreateContextWithCacheKeyAndTTL("test-embedding-ttl", shortTTL)
+	ctx := CreateContextWithCacheKeyAndTTL(t, "test-embedding-ttl", shortTTL)
 
 	embeddingRequest := CreateEmbeddingRequest([]string{"TTL test embedding"})
 
 	t.Log("Making first embedding request with short TTL...")
 	response1, err1 := setup.Client.EmbeddingRequest(ctx, embeddingRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response1})
 
@@ -160,12 +177,15 @@ func TestEmbeddingRequestsCacheExpiration(t *testing.T) {
 	AssertCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response2}, "direct")
 
 	t.Logf("Waiting for TTL expiration (%v)...", shortTTL)
-	time.Sleep(shortTTL + 1*time.Second) // Wait for TTL to expire
+	// expires_at is stored at second-precision Unix(); a 1s buffer can land
+	// on the same boundary as the entry's expiry under load. 2s is the
+	// minimum margin that's robust to seconds-level rounding + a slow CI.
+	time.Sleep(shortTTL + 2*time.Second)
 
 	t.Log("Making third request after TTL expiration...")
 	response3, err3 := setup.Client.EmbeddingRequest(ctx, embeddingRequest)
 	if err3 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err3)
 	}
 	// Should not be a cache hit since TTL expired
 	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response3})

--- a/plugins/semanticcache/plugin_image_generation_test.go
+++ b/plugins/semanticcache/plugin_image_generation_test.go
@@ -11,6 +11,10 @@ import (
 // TestImageGenerationCacheBasicFunctionality tests basic image generation caching
 func TestImageGenerationCacheBasicFunctionality(t *testing.T) {
 	if testing.Short() {
+		t.Skipf("skipping %s in -short mode (gpt-image-1 calls take ~15-65s)", "TestImageGenerationCacheBasicFunctionality")
+	}
+	t.Parallel()
+	if testing.Short() {
 		t.Skip("skipping integration test in -short mode")
 	}
 	if os.Getenv("OPENAI_API_KEY") == "" {
@@ -19,7 +23,7 @@ func TestImageGenerationCacheBasicFunctionality(t *testing.T) {
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-image-gen-value")
+	ctx := CreateContextWithCacheKey(t, "test-image-gen-value")
 
 	// Create test image generation request
 	testRequest := CreateImageGenerationRequest(
@@ -117,6 +121,10 @@ func TestImageGenerationCacheBasicFunctionality(t *testing.T) {
 // TestImageGenerationSemanticSearch tests semantic similarity search for image generation
 func TestImageGenerationSemanticSearch(t *testing.T) {
 	if testing.Short() {
+		t.Skipf("skipping %s in -short mode (gpt-image-1 calls take ~15-65s)", "TestImageGenerationSemanticSearch")
+	}
+	t.Parallel()
+	if testing.Short() {
 		t.Skip("skipping integration test in -short mode")
 	}
 	if os.Getenv("OPENAI_API_KEY") == "" {
@@ -132,7 +140,7 @@ func TestImageGenerationSemanticSearch(t *testing.T) {
 	setup := NewTestSetupWithConfig(t, config)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("image-semantic-test-value")
+	ctx := CreateContextWithCacheKey(t, "image-semantic-test-value")
 
 	// First request - this will be cached
 	firstRequest := CreateImageGenerationRequest(
@@ -235,6 +243,10 @@ func TestImageGenerationSemanticSearch(t *testing.T) {
 // TestImageGenerationDifferentParameters tests that different parameters are cached separately
 func TestImageGenerationDifferentParameters(t *testing.T) {
 	if testing.Short() {
+		t.Skipf("skipping %s in -short mode (gpt-image-1 calls take ~15-65s)", "TestImageGenerationDifferentParameters")
+	}
+	t.Parallel()
+	if testing.Short() {
 		t.Skip("skipping integration test in -short mode")
 	}
 	if os.Getenv("OPENAI_API_KEY") == "" {
@@ -243,7 +255,7 @@ func TestImageGenerationDifferentParameters(t *testing.T) {
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("image-params-test")
+	ctx := CreateContextWithCacheKey(t, "image-params-test")
 
 	basePrompt := "A cute cat sitting on a windowsill"
 
@@ -293,6 +305,10 @@ func TestImageGenerationDifferentParameters(t *testing.T) {
 // TestImageGenerationStreamCaching tests streaming image generation caching
 func TestImageGenerationStreamCaching(t *testing.T) {
 	if testing.Short() {
+		t.Skipf("skipping %s in -short mode (gpt-image-1 calls take ~15-65s)", "TestImageGenerationStreamCaching")
+	}
+	t.Parallel()
+	if testing.Short() {
 		t.Skip("skipping integration test in -short mode")
 	}
 	if os.Getenv("OPENAI_API_KEY") == "" {
@@ -301,7 +317,7 @@ func TestImageGenerationStreamCaching(t *testing.T) {
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("image-stream-test")
+	ctx := CreateContextWithCacheKey(t, "image-stream-test")
 
 	// Create test image generation request
 	testRequest := CreateImageGenerationRequest(

--- a/plugins/semanticcache/plugin_integration_test.go
+++ b/plugins/semanticcache/plugin_integration_test.go
@@ -1,7 +1,6 @@
 package semanticcache
 
 import (
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -13,11 +12,12 @@ import (
 
 // TestSemanticCacheBasicFlow tests the complete semantic cache flow
 func TestSemanticCacheBasicFlow(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx.SetValue(CacheKey, "test-cache-enabled")
+	ctx := newBaseTestContext()
+	ctx.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
 
 	// Test request
 	request := &schemas.BifrostRequest{
@@ -107,8 +107,8 @@ func TestSemanticCacheBasicFlow(t *testing.T) {
 	t.Log("Testing second identical request (expecting cache hit)...")
 
 	// Reset context for second request
-	ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx2.SetValue(CacheKey, "test-cache-enabled")
+	ctx2 := newBaseTestContext()
+	ctx2.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
 
 	modifiedReq2, shortCircuit2, err := setup.Plugin.PreLLMHook(ctx2, request)
 	if err != nil {
@@ -158,11 +158,12 @@ func TestSemanticCacheBasicFlow(t *testing.T) {
 
 // TestSemanticCacheStrictFiltering tests that the cache respects parameter differences
 func TestSemanticCacheStrictFiltering(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx.SetValue(CacheKey, "test-cache-enabled")
+	ctx := newBaseTestContext()
+	ctx.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
 
 	// Base request
 	baseRequest := &schemas.BifrostRequest{
@@ -231,8 +232,8 @@ func TestSemanticCacheStrictFiltering(t *testing.T) {
 	// Second request with different temperature - should be cache miss
 	t.Log("Testing second request with temperature=0.5 (expecting cache miss)...")
 
-	ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx2.SetValue(CacheKey, "test-cache-enabled")
+	ctx2 := newBaseTestContext()
+	ctx2.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
 
 	modifiedRequest := &schemas.BifrostRequest{
 		RequestType: schemas.ChatCompletionRequest,
@@ -268,8 +269,8 @@ func TestSemanticCacheStrictFiltering(t *testing.T) {
 	// Third request with different model - should be cache miss
 	t.Log("Testing third request with different model (expecting cache miss)...")
 
-	ctx3 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx3.SetValue(CacheKey, "test-cache-enabled")
+	ctx3 := newBaseTestContext()
+	ctx3.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
 
 	modifiedRequest2 := &schemas.BifrostRequest{
 		RequestType: schemas.ChatCompletionRequest,
@@ -306,11 +307,12 @@ func TestSemanticCacheStrictFiltering(t *testing.T) {
 
 // TestSemanticCacheStreamingFlow tests streaming response caching
 func TestSemanticCacheStreamingFlow(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx.SetValue(CacheKey, "test-cache-enabled")
+	ctx := newBaseTestContext()
+	ctx.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
 
 	request := &schemas.BifrostRequest{
 		RequestType: schemas.ChatCompletionStreamRequest,
@@ -356,9 +358,19 @@ func TestSemanticCacheStreamingFlow(t *testing.T) {
 
 	for i, chunk := range chunks {
 		var finishReason *string
-		if i == len(chunks)-1 {
+		isFinal := i == len(chunks)-1
+		if isFinal {
 			finishReason = bifrost.Ptr("stop")
 		}
+
+		// Bifrost's stream pipeline sets this on the final chunk before
+		// invoking PostLLMHook (see core/bifrost.go where it stamps
+		// BifrostContextKeyStreamEndIndicator=true). The cache plugin's
+		// PostLLMHook flushes the accumulator only when IsFinalChunk(ctx)
+		// returns true, so a hand-rolled stream simulation must mirror
+		// that — otherwise the entry is never written and the second
+		// request misses.
+		ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, isFinal)
 
 		chunkResponse := &schemas.BifrostResponse{
 			ChatResponse: &schemas.BifrostChatResponse{
@@ -395,8 +407,8 @@ func TestSemanticCacheStreamingFlow(t *testing.T) {
 	// Test cache retrieval for streaming
 	t.Log("Testing streaming cache retrieval...")
 
-	ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx2.SetValue(CacheKey, "test-cache-enabled")
+	ctx2 := newBaseTestContext()
+	ctx2.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
 
 	_, shortCircuit2, err := setup.Plugin.PreLLMHook(ctx2, request)
 	if err != nil {
@@ -404,10 +416,8 @@ func TestSemanticCacheStreamingFlow(t *testing.T) {
 	}
 
 	if shortCircuit2 == nil {
-		t.Log("⚠️ Expected streaming cache hit, but got cache miss - this may be expected with the new unified storage")
-		return
+		t.Fatal("expected streaming cache hit on identical second request after the first stream was fully accumulated and stored")
 	}
-
 	if shortCircuit2.Stream == nil {
 		t.Fatal("Cache hit but stream is nil")
 	}
@@ -434,12 +444,13 @@ func TestSemanticCacheStreamingFlow(t *testing.T) {
 
 // TestSemanticCache_NoCacheWhenKeyMissing verifies cache is disabled when cache key is missing from context
 func TestSemanticCache_NoCacheWhenKeyMissing(t *testing.T) {
+	t.Parallel()
 	t.Log("Testing cache behavior when cache key is missing...")
 
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx := newBaseTestContext()
 	// Don't set the cache key - cache should be disabled
 
 	request := &schemas.BifrostRequest{
@@ -473,12 +484,13 @@ func TestSemanticCache_NoCacheWhenKeyMissing(t *testing.T) {
 
 // TestSemanticCache_CustomTTLHandling verifies cache respects custom TTL values from context
 func TestSemanticCache_CustomTTLHandling(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	// Configure plugin with custom TTL key
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx.SetValue(CacheKey, "test-cache-enabled")
+	ctx := newBaseTestContext()
+	ctx.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
 	ctx.SetValue(CacheTTLKey, 1*time.Minute) // Custom TTL
 
 	request := &schemas.BifrostRequest{
@@ -538,20 +550,37 @@ func TestSemanticCache_CustomTTLHandling(t *testing.T) {
 
 	WaitForCache(setup.Plugin)
 
-	t.Log("✅ Custom TTL configuration test passed!")
+	// Read back: a second identical request must hit AND the entry's TTL
+	// must reflect the per-request override (1 minute), not the plugin
+	// default (5 minutes). expires_at is exposed via cache_debug isn't
+	// directly readable, but we can confirm the entry is present.
+	ctx2 := newBaseTestContext()
+	ctx2.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
+	ctx2.SetValue(CacheTTLKey, 1*time.Minute)
+	_, sc2, err := setup.Plugin.PreLLMHook(ctx2, request)
+	if err != nil {
+		t.Fatalf("Second PreLLMHook failed: %v", err)
+	}
+	if sc2 == nil || sc2.Response == nil {
+		t.Fatal("expected cache hit on second identical request with custom TTL")
+	}
+	if cd := sc2.Response.GetExtraFields().CacheDebug; cd == nil || !cd.CacheHit {
+		t.Fatal("expected CacheDebug.CacheHit=true on hit")
+	}
+	t.Log("✅ Custom TTL configuration test passed (entry written and retrievable)")
 }
 
 // TestSemanticCache_CustomThresholdHandling verifies cache respects custom similarity threshold from context
 func TestSemanticCache_CustomThresholdHandling(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	// Configure plugin with custom threshold key
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx.SetValue(CacheKey, "test-cache-enabled")
-	ctx.SetValue(CacheThresholdKey, 0.95) // Very high threshold
-
-	request := &schemas.BifrostRequest{
+	// Seed an entry with the DEFAULT threshold (0.8) so a follow-up
+	// request can attempt semantic search against it.
+	seedCtx := newBaseTestContext()
+	seedCtx.SetValue(CacheKey, keyForTest(t, "threshold-seed"))
+	seedReq := &schemas.BifrostRequest{
 		RequestType: schemas.ChatCompletionRequest,
 		ChatRequest: &schemas.BifrostChatRequest{
 			Provider: schemas.OpenAI,
@@ -567,21 +596,57 @@ func TestSemanticCache_CustomThresholdHandling(t *testing.T) {
 		},
 	}
 
-	// Test that custom threshold is used (this would need semantic search to be fully testable)
-	_, shortCircuit, err := setup.Plugin.PreLLMHook(ctx, request)
+	_, sc1, err := setup.Plugin.PreLLMHook(seedCtx, seedReq)
 	if err != nil {
-		t.Fatalf("PreLLMHook failed: %v", err)
+		t.Fatalf("seed PreLLMHook failed: %v", err)
 	}
-
-	if shortCircuit != nil {
-		t.Fatal("Expected cache miss with high threshold, but got cache hit")
+	if sc1 != nil {
+		t.Fatal("Expected initial cache miss")
 	}
+	seedRes := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ID: "threshold-test",
+			Choices: []schemas.BifrostResponseChoice{{
+				ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+					Message: &schemas.ChatMessage{
+						Role:    "assistant",
+						Content: &schemas.ChatMessageContent{ContentStr: bifrost.Ptr("seed response")},
+					},
+				},
+			}},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				Provider: schemas.OpenAI, OriginalModelRequested: "gpt-4o-mini", RequestType: schemas.ChatCompletionRequest,
+			},
+		},
+	}
+	if _, _, err := setup.Plugin.PostLLMHook(seedCtx, seedRes, nil); err != nil {
+		t.Fatalf("seed PostLLMHook failed: %v", err)
+	}
+	WaitForCache(setup.Plugin)
 
-	t.Log("✅ Custom threshold configuration test passed!")
+	// Identical-content request with a HIGH threshold (0.95) MUST still hit
+	// via the direct path (direct hashing ignores threshold). Threshold only
+	// gates semantic search; a same-input request matches the deterministic
+	// directCacheID regardless. This proves the override doesn't break direct.
+	hitCtx := newBaseTestContext()
+	hitCtx.SetValue(CacheKey, keyForTest(t, "threshold-seed"))
+	hitCtx.SetValue(CacheThresholdKey, 0.95)
+	_, sc2, err := setup.Plugin.PreLLMHook(hitCtx, seedReq)
+	if err != nil {
+		t.Fatalf("hit PreLLMHook failed: %v", err)
+	}
+	if sc2 == nil || sc2.Response == nil {
+		t.Fatal("expected direct cache hit even with high threshold (direct ignores threshold)")
+	}
+	if cd := sc2.Response.GetExtraFields().CacheDebug; cd == nil || cd.HitType == nil || *cd.HitType != string(CacheTypeDirect) {
+		t.Fatalf("expected hit_type=direct, got cache_debug=%+v", cd)
+	}
+	t.Log("✅ Custom threshold override tracked through PreLLMHook without breaking direct path")
 }
 
 // TestSemanticCache_ProviderModelCachingFlags verifies cache behavior with provider/model caching flags
 func TestSemanticCache_ProviderModelCachingFlags(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -589,8 +654,8 @@ func TestSemanticCache_ProviderModelCachingFlags(t *testing.T) {
 	setup.Config.CacheByProvider = bifrost.Ptr(false)
 	setup.Config.CacheByModel = bifrost.Ptr(false)
 
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx.SetValue(CacheKey, "test-cache-enabled")
+	ctx := newBaseTestContext()
+	ctx.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
 
 	request1 := &schemas.BifrostRequest{
 		RequestType: schemas.ChatCompletionRequest,
@@ -666,29 +731,36 @@ func TestSemanticCache_ProviderModelCachingFlags(t *testing.T) {
 		},
 	}
 
-	ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx2.SetValue(CacheKey, "test-cache-enabled")
+	ctx2 := newBaseTestContext()
+	ctx2.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
 
 	_, shortCircuit2, err := setup.Plugin.PreLLMHook(ctx2, request2)
 	if err != nil {
 		t.Fatalf("Second PreLLMHook failed: %v", err)
 	}
 
-	// With provider/model caching disabled, we might get cache hits across different providers/models
-	// This behavior depends on the exact implementation of hash generation
-	t.Logf("Cache behavior with disabled provider/model flags: hit=%v", shortCircuit2 != nil)
-
-	t.Log("✅ Provider/model caching flags test passed!")
+	// CacheByProvider=false + CacheByModel=false means provider and model are
+	// stripped from the directCacheID input. Same content + same cache_key
+	// must produce the SAME directCacheID, so the second request MUST hit
+	// even though it specifies a completely different provider/model.
+	if shortCircuit2 == nil || shortCircuit2.Response == nil {
+		t.Fatal("expected cache hit across providers/models when CacheByProvider+CacheByModel=false")
+	}
+	if cd := shortCircuit2.Response.GetExtraFields().CacheDebug; cd == nil || !cd.CacheHit {
+		t.Fatalf("expected CacheDebug.CacheHit=true, got %+v", cd)
+	}
+	t.Log("✅ CacheByProvider=false + CacheByModel=false correctly shares entries across providers/models")
 }
 
 // TestSemanticCache_ConfigurationEdgeCases verifies edge cases in configuration handling
 func TestSemanticCache_ConfigurationEdgeCases(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	// Test with invalid TTL type in context
-	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx.SetValue(CacheKey, "test-cache-enabled")
+	ctx := newBaseTestContext()
+	ctx.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
 	ctx.SetValue(CacheTTLKey, "not-a-duration") // Invalid TTL type
 
 	request := &schemas.BifrostRequest{
@@ -712,25 +784,63 @@ func TestSemanticCache_ConfigurationEdgeCases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PreLLMHook failed with invalid TTL: %v", err)
 	}
-
 	if shortCircuit != nil {
 		t.Fatal("Unexpected cache hit with invalid TTL")
 	}
 
-	// Test with invalid threshold type
-	ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-	ctx2.SetValue(CacheKey, "test-cache-enabled")
-	ctx2.SetValue(CacheThresholdKey, "not-a-float") // Invalid threshold type
+	// Plugin must FALL BACK to its default TTL — verify by writing then
+	// reading the entry. If the invalid TTL caused caching to silently
+	// disable, the second request would miss.
+	res := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ID: "edge-ttl",
+			Choices: []schemas.BifrostResponseChoice{{
+				ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+					Message: &schemas.ChatMessage{Role: "assistant", Content: &schemas.ChatMessageContent{ContentStr: bifrost.Ptr("ok")}},
+				},
+			}},
+			ExtraFields: schemas.BifrostResponseExtraFields{Provider: schemas.OpenAI, OriginalModelRequested: "gpt-4o-mini", RequestType: schemas.ChatCompletionRequest},
+		},
+	}
+	if _, _, err := setup.Plugin.PostLLMHook(ctx, res, nil); err != nil {
+		t.Fatalf("PostLLMHook failed: %v", err)
+	}
+	WaitForCache(setup.Plugin)
 
-	// Should handle invalid threshold gracefully
-	_, shortCircuit2, err := setup.Plugin.PreLLMHook(ctx2, request)
+	ctxRead := newBaseTestContext()
+	ctxRead.SetValue(CacheKey, keyForTest(t, "test-cache-enabled"))
+	ctxRead.SetValue(CacheTTLKey, "not-a-duration")
+	if _, sc, err := setup.Plugin.PreLLMHook(ctxRead, request); err != nil {
+		t.Fatalf("read PreLLMHook failed: %v", err)
+	} else if sc == nil {
+		t.Fatal("expected cache hit — invalid TTL should have fallen back to default and entry should be retrievable")
+	}
+
+	// Test with invalid threshold type — same expectation: fallback works.
+	ctx2 := newBaseTestContext()
+	ctx2.SetValue(CacheKey, keyForTest(t, "test-cache-threshold-edge"))
+	ctx2.SetValue(CacheThresholdKey, "not-a-float")
+
+	_, sc2, err := setup.Plugin.PreLLMHook(ctx2, request)
 	if err != nil {
 		t.Fatalf("PreLLMHook failed with invalid threshold: %v", err)
 	}
+	if sc2 != nil {
+		t.Fatal("Unexpected cache hit on first call with invalid threshold")
+	}
+	if _, _, err := setup.Plugin.PostLLMHook(ctx2, res, nil); err != nil {
+		t.Fatalf("PostLLMHook failed: %v", err)
+	}
+	WaitForCache(setup.Plugin)
 
-	if shortCircuit2 != nil {
-		t.Fatal("Unexpected cache hit with invalid threshold")
+	ctx2Read := newBaseTestContext()
+	ctx2Read.SetValue(CacheKey, keyForTest(t, "test-cache-threshold-edge"))
+	ctx2Read.SetValue(CacheThresholdKey, "still-not-a-float")
+	if _, sc, err := setup.Plugin.PreLLMHook(ctx2Read, request); err != nil {
+		t.Fatalf("threshold read PreLLMHook failed: %v", err)
+	} else if sc == nil {
+		t.Fatal("expected cache hit — invalid threshold should have fallen back to default")
 	}
 
-	t.Log("✅ Configuration edge cases test passed!")
+	t.Log("✅ Configuration edge cases test passed (invalid TTL/threshold fall back gracefully)")
 }

--- a/plugins/semanticcache/plugin_nil_content_test.go
+++ b/plugins/semanticcache/plugin_nil_content_test.go
@@ -1,6 +1,7 @@
 package semanticcache
 
 import (
+	"strings"
 	"testing"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -87,18 +88,33 @@ func TestExtractTextForEmbedding_NilContent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// This should not panic
-			text, hash, err := plugin.extractTextForEmbedding(tt.request)
-			// We don't care about the error — the important thing is no panic
-			t.Logf("text=%q, hash=%q, err=%v", text, hash, err)
+			// Primary contract: must not panic on nil-content messages.
+			// Secondary: returned text must not contain stringification
+			// artifacts, and the all-nil case must surface as an error.
+			text, err := plugin.extractTextForEmbedding(nil, tt.request)
+			if strings.Contains(text, "<nil>") || strings.Contains(text, "%!") {
+				t.Fatalf("extractTextForEmbedding produced a stringification artifact: %q", text)
+			}
+			if tt.name == "ChatRequest where all messages have nil Content" {
+				if err == nil {
+					t.Fatalf("expected error when no message has text content, got text=%q", text)
+				}
+				if text != "" {
+					t.Fatalf("expected empty text when all content is nil, got %q", text)
+				}
+			}
 		})
 	}
 }
 
-func TestPrepareDirectCacheLookup_ResponsesStreamRequest(t *testing.T) {
+// TestPreLLMHookSeedsDirectCacheIDForResponsesStream verifies the streaming
+// Responses path runs through PreLLMHook → performDirectSearch and stamps a
+// deterministic DirectCacheID on the per-request cacheState.
+func TestPreLLMHookSeedsDirectCacheIDForResponsesStream(t *testing.T) {
 	plugin := &Plugin{
 		config: getDefaultTestConfig(),
 		logger: bifrost.NewDefaultLogger(schemas.LogLevelDebug),
+		store:  newDirectFastPathStore(),
 	}
 
 	req := &schemas.BifrostRequest{
@@ -106,26 +122,32 @@ func TestPrepareDirectCacheLookup_ResponsesStreamRequest(t *testing.T) {
 		ResponsesRequest: CreateStreamingResponsesRequest("Explain cache invalidation", 0.2, 200),
 	}
 
-	ctx := CreateContextWithCacheKey("responses-stream-direct")
-	directID, err := plugin.prepareDirectCacheLookup(ctx, req, "responses-stream-direct")
-	if err != nil {
-		t.Fatalf("prepareDirectCacheLookup failed: %v", err)
+	ctx := CreateContextWithCacheKeyAndType(t, "responses-stream-direct", CacheTypeDirect)
+	if _, _, err := plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook failed: %v", err)
 	}
-	if directID == "" {
-		t.Fatal("expected deterministic direct cache id")
+
+	requestID, _ := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
+	state := plugin.getCacheState(requestID)
+	if state == nil {
+		t.Fatal("expected cache state to be created")
 	}
-	if got, _ := ctx.Value(requestHashKey).(string); got == "" {
-		t.Fatal("expected request hash to be stored in context")
+	if state.DirectCacheID == "" {
+		t.Fatal("expected DirectCacheID to be populated by direct search")
 	}
-	if got, _ := ctx.Value(requestParamsHashKey).(string); got == "" {
-		t.Fatal("expected params hash to be stored in context")
+	if state.ParamsHash == "" {
+		t.Fatal("expected ParamsHash to be populated")
 	}
 }
 
-func TestPrepareDirectCacheLookup_UnsupportedRequestTypeFailsClosed(t *testing.T) {
+// TestPreLLMHookFailsClosedForUnsupportedRequestType verifies the plugin
+// short-circuits early for unsupported request types and never populates
+// state fields that downstream caching logic would read.
+func TestPreLLMHookFailsClosedForUnsupportedRequestType(t *testing.T) {
 	plugin := &Plugin{
 		config: getDefaultTestConfig(),
 		logger: bifrost.NewDefaultLogger(schemas.LogLevelDebug),
+		store:  newDirectFastPathStore(),
 	}
 
 	req := &schemas.BifrostRequest{
@@ -138,29 +160,36 @@ func TestPrepareDirectCacheLookup_UnsupportedRequestTypeFailsClosed(t *testing.T
 		},
 	}
 
-	ctx := CreateContextWithCacheKey("unsupported-direct")
-	directID, err := plugin.prepareDirectCacheLookup(ctx, req, "unsupported-direct")
-	if err == nil {
-		t.Fatal("expected prepareDirectCacheLookup to reject unsupported request type")
+	ctx := CreateContextWithCacheKey(t, "unsupported-direct")
+	if _, shortCircuit, err := plugin.PreLLMHook(ctx, req); err != nil || shortCircuit != nil {
+		t.Fatalf("PreLLMHook unexpected: shortCircuit=%v err=%v", shortCircuit, err)
 	}
-	if directID != "" {
-		t.Fatalf("expected no direct cache id, got %q", directID)
-	}
-	if got, _ := ctx.Value(requestHashKey).(string); got != "" {
-		t.Fatalf("expected request hash to remain unset, got %q", got)
-	}
-	if got, _ := ctx.Value(requestParamsHashKey).(string); got != "" {
-		t.Fatalf("expected params hash to remain unset, got %q", got)
-	}
-	if got, _ := ctx.Value(requestStorageIDKey).(string); got != "" {
-		t.Fatalf("expected storage id to remain unset, got %q", got)
+
+	requestID, _ := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
+	state := plugin.getCacheState(requestID)
+	// Unsupported types create the state slot (reset happens up front) but
+	// never populate the caching fields.
+	if state != nil {
+		if state.DirectCacheID != "" {
+			t.Fatalf("expected DirectCacheID unset, got %q", state.DirectCacheID)
+		}
+		if state.ParamsHash != "" {
+			t.Fatalf("expected ParamsHash unset, got %q", state.ParamsHash)
+		}
+		if state.Embeddings != nil {
+			t.Fatalf("expected Embeddings unset, got %v", state.Embeddings)
+		}
 	}
 }
 
+// TestPreLLMHookSkipsUnsupportedCountTokensRequest verifies CountTokensRequest
+// (which is not in the supported set) flows through PreLLMHook without
+// short-circuiting and without populating cache fields.
 func TestPreLLMHookSkipsUnsupportedCountTokensRequest(t *testing.T) {
 	plugin := &Plugin{
 		config: getDefaultTestConfig(),
 		logger: bifrost.NewDefaultLogger(schemas.LogLevelDebug),
+		store:  newDirectFastPathStore(),
 	}
 
 	req := &schemas.BifrostRequest{
@@ -179,18 +208,7 @@ func TestPreLLMHookSkipsUnsupportedCountTokensRequest(t *testing.T) {
 		},
 	}
 
-	ctx := CreateContextWithCacheKey("count-tokens-test")
-	ctx.SetValue(requestIDKey, "stale-request-id")
-	ctx.SetValue(requestStorageIDKey, "stale-storage-id")
-	ctx.SetValue(requestHashKey, "stale-request-hash")
-	ctx.SetValue(requestParamsHashKey, "stale-params-hash")
-	ctx.SetValue(requestModelKey, "stale-model")
-	ctx.SetValue(requestProviderKey, schemas.OpenAI)
-	ctx.SetValue(requestEmbeddingKey, []float32{1, 2, 3})
-	ctx.SetValue(requestEmbeddingTokensKey, 99)
-	ctx.SetValue(isCacheHitKey, true)
-	ctx.SetValue(cacheHitTypeKey, CacheTypeDirect)
-
+	ctx := CreateContextWithCacheKey(t, "count-tokens-test")
 	modifiedReq, shortCircuit, err := plugin.PreLLMHook(ctx, req)
 	if err != nil {
 		t.Fatalf("PreLLMHook failed: %v", err)
@@ -201,35 +219,12 @@ func TestPreLLMHookSkipsUnsupportedCountTokensRequest(t *testing.T) {
 	if shortCircuit != nil {
 		t.Fatal("expected no short-circuit for unsupported count tokens request")
 	}
-	if got, _ := ctx.Value(requestIDKey).(string); got != "" {
-		t.Fatalf("expected requestIDKey to remain unset, got %q", got)
-	}
-	if got, _ := ctx.Value(requestHashKey).(string); got != "" {
-		t.Fatalf("expected requestHashKey to remain unset, got %q", got)
-	}
-	if got, _ := ctx.Value(requestParamsHashKey).(string); got != "" {
-		t.Fatalf("expected requestParamsHashKey to remain unset, got %q", got)
-	}
-	if got, _ := ctx.Value(requestStorageIDKey).(string); got != "" {
-		t.Fatalf("expected requestStorageIDKey to remain unset, got %q", got)
-	}
-	if got, _ := ctx.Value(requestModelKey).(string); got != "" {
-		t.Fatalf("expected requestModelKey to remain unset, got %q", got)
-	}
-	if got, ok := ctx.Value(requestProviderKey).(schemas.ModelProvider); ok && got != "" {
-		t.Fatalf("expected requestProviderKey to remain unset, got %q", got)
-	}
-	if got := ctx.Value(requestEmbeddingKey); got != nil {
-		t.Fatalf("expected requestEmbeddingKey to remain unset, got %#v", got)
-	}
-	if got, ok := ctx.Value(requestEmbeddingTokensKey).(int); ok && got != 0 {
-		t.Fatalf("expected requestEmbeddingTokensKey to remain unset, got %d", got)
-	}
-	if got, ok := ctx.Value(isCacheHitKey).(bool); ok && got {
-		t.Fatal("expected isCacheHitKey to remain unset")
-	}
-	if got, ok := ctx.Value(cacheHitTypeKey).(CacheType); ok && got != "" {
-		t.Fatalf("expected cacheHitTypeKey to remain unset, got %q", got)
+
+	requestID, _ := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
+	if state := plugin.getCacheState(requestID); state != nil {
+		if state.DirectCacheID != "" || state.ParamsHash != "" || state.Embeddings != nil {
+			t.Fatalf("expected unsupported request to leave state empty, got %+v", state)
+		}
 	}
 }
 
@@ -276,9 +271,19 @@ func TestGetNormalizedInputForCaching_NilContent(t *testing.T) {
 		},
 	}
 
-	// This should not panic
+	// Must not panic, and must return a non-nil filtered messages slice
+	// of the right element type (we built a ChatCompletionRequest).
 	result := plugin.getNormalizedInputForCaching(request)
-	t.Logf("result type: %T", result)
+	if result == nil {
+		t.Fatal("getNormalizedInputForCaching returned nil for a valid Chat request")
+	}
+	msgs, ok := result.([]schemas.ChatMessage)
+	if !ok {
+		t.Fatalf("expected []schemas.ChatMessage, got %T", result)
+	}
+	if len(msgs) != len(request.ChatRequest.Input) {
+		t.Fatalf("normalized message count %d differs from input %d (filtering changed unexpectedly)", len(msgs), len(request.ChatRequest.Input))
+	}
 }
 
 // createResponsesRequestWithNilContent builds a BifrostResponsesRequest with a nil Content message for testing.

--- a/plugins/semanticcache/plugin_no_mutation_test.go
+++ b/plugins/semanticcache/plugin_no_mutation_test.go
@@ -1,0 +1,198 @@
+package semanticcache
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/vectorstore"
+)
+
+// requestCapturer is an LLMPlugin that records the request it sees in
+// PreLLMHook. Placed AFTER semantic_cache in the plugin chain it observes
+// the request post-cache-plugin-mutation; we then assert that nothing
+// landed in the request that originated from cache-side normalization
+// (lowercase, whitespace-trim, system-prompt filtering, etc.).
+//
+// This complements the in-process unit tests because those exercise the
+// helpers that DO normalize (getNormalizedInputForCaching) — what we want
+// here is a contract test on the request that flows downstream.
+type requestCapturer struct {
+	mu       sync.Mutex
+	captured *schemas.BifrostRequest
+}
+
+func (p *requestCapturer) GetName() string { return "test-request-capturer" }
+func (p *requestCapturer) Cleanup() error  { return nil }
+
+func (p *requestCapturer) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
+	p.mu.Lock()
+	// Snapshot the request via JSON round-trip so any later mutation by the
+	// pipeline (none expected, but be defensive) can't retroactively change
+	// what the test sees.
+	data, err := json.Marshal(req)
+	if err == nil {
+		var snapshot schemas.BifrostRequest
+		if jerr := json.Unmarshal(data, &snapshot); jerr == nil {
+			p.captured = &snapshot
+		}
+	}
+	if p.captured == nil {
+		p.captured = req // fall back to direct reference
+	}
+	p.mu.Unlock()
+	return req, nil, nil
+}
+
+func (p *requestCapturer) PostLLMHook(_ *schemas.BifrostContext, resp *schemas.BifrostResponse, e *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	return resp, e, nil
+}
+
+// TestCachingDoesNotMutateRequestSentToProvider runs through the full plugin
+// pipeline against the real OpenAI API and asserts that nothing the cache
+// plugin does internally (text normalization, system-prompt filtering,
+// metadata extraction, embedding generation) leaks into the request that
+// reaches the provider.
+//
+// The test is gated on OPENAI_API_KEY because we need a real round-trip; the
+// in-process mocker would short-circuit before the request body is finalized.
+func TestCachingDoesNotMutateRequestSentToProvider(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real-LLM test in -short mode")
+	}
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		t.Skip("OPENAI_API_KEY not set; needed for live LLM contract test")
+	}
+	t.Parallel()
+
+	// Stand up the cache plugin against the shared Weaviate test namespace,
+	// same as the rest of the integration suite.
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelError)
+	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Type:    vectorstore.VectorStoreTypeWeaviate,
+		Config:  getWeaviateConfigFromEnv(),
+		Enabled: true,
+	}, logger)
+	if err != nil {
+		t.Skipf("Weaviate not available: %v", err)
+	}
+	cfg := &Config{
+		Provider:                     schemas.OpenAI,
+		EmbeddingModel:               "text-embedding-3-small",
+		Dimension:                    1536,
+		Threshold:                    0.8,
+		ConversationHistoryThreshold: DefaultConversationHistoryThreshold,
+		VectorStoreNamespace:         SharedTestNamespace,
+		// Do NOT clean up on shutdown — other parallel tests share the namespace.
+		CleanUpOnShutdown: false,
+	}
+	if err := ensureSharedTestNamespace(context.Background(), store, cfg.Dimension); err != nil {
+		t.Fatalf("ensureSharedTestNamespace: %v", err)
+	}
+	cachePlugin, err := Init(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), cfg, logger, store)
+	if err != nil {
+		t.Fatalf("cache plugin Init: %v", err)
+	}
+
+	capturer := &requestCapturer{}
+
+	// Real OpenAI provider, no mocker — the request must travel end-to-end.
+	bctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	client, err := bifrost.Init(bctx, schemas.BifrostConfig{
+		Account: &BaseAccount{},
+		// Order matters: cache runs first, capturer second so it sees the
+		// request as it flows out of the cache plugin.
+		LLMPlugins: []schemas.LLMPlugin{cachePlugin, capturer},
+		Logger:     logger,
+	})
+	if err != nil {
+		t.Fatalf("bifrost.Init: %v", err)
+	}
+	defer client.Shutdown()
+	cachePlugin.(*Plugin).SetEmbeddingRequestExecutor(client.EmbeddingRequest)
+
+	// Content carefully chosen to surface normalization if it ever leaks:
+	//   - leading/trailing whitespace (would be stripped by strings.TrimSpace)
+	//   - mixed case (would be lowercased)
+	//   - a system prompt (would be stripped if ExcludeSystemPrompt leaked)
+	systemContent := "  RESPOND with a SINGLE word.  "
+	userContent := "   Hello, World!   PRESERVE_THIS_VERBATIM.   "
+
+	chatReq := &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o-mini",
+		Input: []schemas.ChatMessage{
+			{
+				Role: schemas.ChatMessageRoleSystem,
+				Content: &schemas.ChatMessageContent{
+					ContentStr: bifrost.Ptr(systemContent),
+				},
+			},
+			{
+				Role: schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{
+					ContentStr: bifrost.Ptr(userContent),
+				},
+			},
+		},
+		Params: &schemas.ChatParameters{
+			Temperature:         bifrost.Ptr(0.0),
+			MaxCompletionTokens: bifrost.Ptr(5),
+		},
+	}
+
+	ctx := newBaseTestContext()
+	ctx.SetValue(CacheKey, keyForTest(t, ""))
+
+	// Take a JSON snapshot of the original input as the test sent it.
+	originalJSON, err := json.Marshal(chatReq)
+	if err != nil {
+		t.Fatalf("marshal original: %v", err)
+	}
+
+	if _, llmErr := client.ChatCompletionRequest(ctx, chatReq); llmErr != nil {
+		// Even if OpenAI errors, the request was already captured by the
+		// time the provider call fired. Continue with the assertion.
+		t.Logf("upstream LLM error (expected to still proceed with assertion): %v", llmErr)
+	}
+
+	capturer.mu.Lock()
+	captured := capturer.captured
+	capturer.mu.Unlock()
+	if captured == nil {
+		t.Fatal("capturer never recorded a request — pipeline order or plugin wiring is wrong")
+	}
+
+	// 1) The chat input the provider saw must be byte-for-byte identical to
+	//    what the caller passed in.
+	capturedJSON, err := json.Marshal(captured.ChatRequest)
+	if err != nil {
+		t.Fatalf("marshal captured: %v", err)
+	}
+	var origMap, capMap map[string]any
+	_ = json.Unmarshal(originalJSON, &origMap)
+	_ = json.Unmarshal(capturedJSON, &capMap)
+	if !reflect.DeepEqual(origMap["input"], capMap["input"]) {
+		t.Fatalf("chat input mutated by cache plugin\noriginal: %s\ncaptured: %s", originalJSON, capturedJSON)
+	}
+
+	// 2) Belt-and-suspenders: explicit spot checks on the fields most likely
+	//    to be mangled by normalization regressions, with clear failure messages.
+	if len(captured.ChatRequest.Input) != len(chatReq.Input) {
+		t.Fatalf("system prompt was filtered out: captured=%d messages, original=%d", len(captured.ChatRequest.Input), len(chatReq.Input))
+	}
+	if got := *captured.ChatRequest.Input[0].Content.ContentStr; got != systemContent {
+		t.Fatalf("system content was modified: got %q, want %q", got, systemContent)
+	}
+	if got := *captured.ChatRequest.Input[1].Content.ContentStr; got != userContent {
+		t.Fatalf("user content was modified: got %q, want %q", got, userContent)
+	}
+	if captured.ChatRequest.Input[0].Role != schemas.ChatMessageRoleSystem {
+		t.Fatalf("system role was rewritten: got %q", captured.ChatRequest.Input[0].Role)
+	}
+}

--- a/plugins/semanticcache/plugin_no_store_test.go
+++ b/plugins/semanticcache/plugin_no_store_test.go
@@ -8,17 +8,18 @@ import (
 
 // TestCacheNoStoreBasicFunctionality tests that CacheNoStoreKey prevents caching
 func TestCacheNoStoreBasicFunctionality(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	testRequest := CreateBasicChatRequest("What is artificial intelligence?", 0.7, 100)
 
 	// Test 1: Normal caching (control test)
-	ctx1 := CreateContextWithCacheKey("test-no-store-control")
+	ctx1 := CreateContextWithCacheKey(t, "test-no-store-control")
 	t.Log("Making normal request (should be cached)...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1}) // Fresh request
 
@@ -37,11 +38,11 @@ func TestCacheNoStoreBasicFunctionality(t *testing.T) {
 	AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}, "direct") // Should be cached
 
 	// Test 2: NoStore = true (should not cache)
-	ctx2 := CreateContextWithCacheKeyAndNoStore("test-no-store-disabled", true)
+	ctx2 := CreateContextWithCacheKeyAndNoStore(t, "test-no-store-disabled", true)
 	t.Log("Making request with CacheNoStoreKey=true (should not be cached)...")
 	response3, err3 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	if err3 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err3)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3}) // Fresh request
 
@@ -51,16 +52,16 @@ func TestCacheNoStoreBasicFunctionality(t *testing.T) {
 	t.Log("Verifying no-store request was not cached...")
 	response4, err4 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	if err4 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err4)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response4}) // Should still be fresh (not cached)
 
 	// Test 3: NoStore = false (should cache normally)
-	ctx3 := CreateContextWithCacheKeyAndNoStore("test-no-store-enabled", false)
+	ctx3 := CreateContextWithCacheKeyAndNoStore(t, "test-no-store-enabled", false)
 	t.Log("Making request with CacheNoStoreKey=false (should be cached)...")
 	response5, err5 := setup.Client.ChatCompletionRequest(ctx3, testRequest)
 	if err5 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err5)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response5}) // Fresh request
 
@@ -79,6 +80,7 @@ func TestCacheNoStoreBasicFunctionality(t *testing.T) {
 
 // TestCacheNoStoreWithDifferentRequestTypes tests NoStore with various request types
 func TestCacheNoStoreWithDifferentRequestTypes(t *testing.T) {
+	t.Parallel()
 	t.Skip("Skipping Embedding Tests")
 
 	setup := NewTestSetup(t)
@@ -86,12 +88,12 @@ func TestCacheNoStoreWithDifferentRequestTypes(t *testing.T) {
 
 	// Test with chat completion
 	chatRequest := CreateBasicChatRequest("Test no-store with chat", 0.7, 50)
-	ctx1 := CreateContextWithCacheKeyAndNoStore("test-no-store-chat", true)
+	ctx1 := CreateContextWithCacheKeyAndNoStore(t, "test-no-store-chat", true)
 
 	t.Log("Testing no-store with chat completion...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, chatRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
@@ -100,18 +102,18 @@ func TestCacheNoStoreWithDifferentRequestTypes(t *testing.T) {
 	// Verify not cached
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx1, chatRequest)
 	if err2 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err2)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}) // Should not be cached
 
 	// Test with embedding request
 	embeddingRequest := CreateEmbeddingRequest([]string{"Test no-store with embeddings"})
-	ctx2 := CreateContextWithCacheKeyAndNoStore("test-no-store-embedding", true)
+	ctx2 := CreateContextWithCacheKeyAndNoStore(t, "test-no-store-embedding", true)
 
 	t.Log("Testing no-store with embedding request...")
 	response3, err3 := setup.Client.EmbeddingRequest(ctx2, embeddingRequest)
 	if err3 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err3)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response3})
 
@@ -120,7 +122,7 @@ func TestCacheNoStoreWithDifferentRequestTypes(t *testing.T) {
 	// Verify not cached
 	response4, err4 := setup.Client.EmbeddingRequest(ctx2, embeddingRequest)
 	if err4 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err4)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{EmbeddingResponse: response4}) // Should not be cached
 
@@ -129,6 +131,7 @@ func TestCacheNoStoreWithDifferentRequestTypes(t *testing.T) {
 
 // TestCacheNoStoreWithConversationHistory tests NoStore with conversation context
 func TestCacheNoStoreWithConversationHistory(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -141,12 +144,12 @@ func TestCacheNoStoreWithConversationHistory(t *testing.T) {
 	request := CreateConversationRequest(messages, 0.7, 100)
 
 	// Test with no-store enabled
-	ctx := CreateContextWithCacheKeyAndNoStore("test-no-store-conversation", true)
+	ctx := CreateContextWithCacheKeyAndNoStore(t, "test-no-store-conversation", true)
 
 	t.Log("Testing no-store with conversation history...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx, request)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
@@ -155,7 +158,7 @@ func TestCacheNoStoreWithConversationHistory(t *testing.T) {
 	// Verify not cached (same conversation should not hit cache)
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx, request)
 	if err2 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err2)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}) // Should not be cached due to no-store
 
@@ -164,20 +167,21 @@ func TestCacheNoStoreWithConversationHistory(t *testing.T) {
 
 // TestCacheNoStoreWithCacheTypes tests NoStore interaction with CacheTypeKey
 func TestCacheNoStoreWithCacheTypes(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	testRequest := CreateBasicChatRequest("Test no-store with cache types", 0.7, 50)
 
 	// Test no-store with direct cache type
-	ctx1 := CreateContextWithCacheKey("test-no-store-cache-types")
+	ctx1 := CreateContextWithCacheKey(t, "test-no-store-cache-types")
 	ctx1 = ctx1.WithValue(CacheNoStoreKey, true)
 	ctx1 = ctx1.WithValue(CacheTypeKey, CacheTypeDirect)
 
 	t.Log("Testing no-store with CacheTypeKey=direct...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
@@ -186,19 +190,19 @@ func TestCacheNoStoreWithCacheTypes(t *testing.T) {
 	// Should not be cached
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err2 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err2)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}) // No-store should override cache type
 
 	// Test no-store with semantic cache type
-	ctx2 := CreateContextWithCacheKey("test-no-store-cache-types")
+	ctx2 := CreateContextWithCacheKey(t, "test-no-store-cache-types")
 	ctx2 = ctx2.WithValue(CacheNoStoreKey, true)
 	ctx2 = ctx2.WithValue(CacheTypeKey, CacheTypeSemantic)
 
 	t.Log("Testing no-store with CacheTypeKey=semantic...")
 	response3, err3 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	if err3 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err3)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3})
 
@@ -207,7 +211,7 @@ func TestCacheNoStoreWithCacheTypes(t *testing.T) {
 	// Should not be cached
 	response4, err4 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	if err4 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err4)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response4}) // No-store should override cache type
 
@@ -216,19 +220,20 @@ func TestCacheNoStoreWithCacheTypes(t *testing.T) {
 
 // TestCacheNoStoreErrorHandling tests error scenarios with NoStore
 func TestCacheNoStoreErrorHandling(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	testRequest := CreateBasicChatRequest("Test no-store error handling", 0.7, 50)
 
 	// Test with invalid no-store value (non-boolean)
-	ctx1 := CreateContextWithCacheKey("test-no-store-errors")
+	ctx1 := CreateContextWithCacheKey(t, "test-no-store-errors")
 	ctx1 = ctx1.WithValue(CacheNoStoreKey, "invalid")
 
 	t.Log("Testing no-store with invalid value (should cache normally)...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
@@ -246,13 +251,13 @@ func TestCacheNoStoreErrorHandling(t *testing.T) {
 	AssertCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2}, "direct") // Should be cached (invalid value ignored)
 
 	// Test with nil value (should cache normally)
-	ctx2 := CreateContextWithCacheKey("test-no-store-nil")
+	ctx2 := CreateContextWithCacheKey(t, "test-no-store-nil")
 	ctx2 = ctx2.WithValue(CacheNoStoreKey, nil)
 
 	t.Log("Testing no-store with nil value (should cache normally)...")
 	response3, err3 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	if err3 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err3)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response3})
 
@@ -270,24 +275,25 @@ func TestCacheNoStoreErrorHandling(t *testing.T) {
 
 // TestCacheNoStoreReadButNoWrite tests that NoStore allows reading cache but prevents writing
 func TestCacheNoStoreReadButNoWrite(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	testRequest := CreateBasicChatRequest("Describe Isaac Newton's three laws of motion", 0.7, 50)
 
 	// Step 1: Cache a response normally
-	ctx1 := CreateContextWithCacheKey("test-no-store-read")
+	ctx1 := CreateContextWithCacheKey(t, "test-no-store-read")
 	t.Log("Caching response normally...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx1, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})
 
 	WaitForCache(setup.Plugin)
 
 	// Step 2: Try to read with no-store enabled (should still read from cache)
-	ctx2 := CreateContextWithCacheKeyAndNoStore("test-no-store-read", true)
+	ctx2 := CreateContextWithCacheKeyAndNoStore(t, "test-no-store-read", true)
 	t.Log("Reading with no-store enabled (should still hit cache for reads)...")
 	response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
 	if err2 != nil {

--- a/plugins/semanticcache/plugin_normalization_test.go
+++ b/plugins/semanticcache/plugin_normalization_test.go
@@ -9,6 +9,7 @@ import (
 // TestTextNormalizationDirectCache tests that text normalization works correctly
 // for direct cache (hash-based) matching across all input types
 func TestTextNormalizationDirectCache(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
@@ -22,7 +23,7 @@ func TestTextNormalizationDirectCache(t *testing.T) {
 }
 
 func testChatCompletionNormalization(t *testing.T, setup *TestSetup) {
-	ctx := CreateContextWithCacheKey("test-chat-normalization")
+	ctx := CreateContextWithCacheKey(t, "test-chat-normalization")
 
 	// Test cases with different case and whitespace variations
 	testCases := []struct {
@@ -93,7 +94,10 @@ func testChatCompletionNormalization(t *testing.T, setup *TestSetup) {
 	t.Logf("Making first request with user: '%s', system: '%s'", testCases[0].userMsg, testCases[0].systemMsg)
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx, requests[0])
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		if isTransientUpstreamError(err1) {
+			t.Skipf("transient upstream error, skipping test: %v", err1)
+		}
+		t.Fatalf("upstream request failed: %v", err1)
 	}
 
 	if response1 == nil || len(response1.Choices) == 0 {
@@ -124,7 +128,7 @@ func testChatCompletionNormalization(t *testing.T, setup *TestSetup) {
 }
 
 func testSpeechNormalization(t *testing.T, setup *TestSetup) {
-	ctx := CreateContextWithCacheKey("test-speech-normalization")
+	ctx := CreateContextWithCacheKey(t, "test-speech-normalization")
 
 	// Test cases with different case and whitespace variations for speech input
 	testCases := []struct {
@@ -151,7 +155,10 @@ func testSpeechNormalization(t *testing.T, setup *TestSetup) {
 	t.Logf("Making first speech request with: '%s'", testCases[0].input)
 	response1, err1 := setup.Client.SpeechRequest(ctx, requests[0])
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		if isTransientUpstreamError(err1) {
+			t.Skipf("transient upstream error, skipping test: %v", err1)
+		}
+		t.Fatalf("upstream request failed: %v", err1)
 	}
 
 	if response1 == nil {
@@ -183,10 +190,11 @@ func testSpeechNormalization(t *testing.T, setup *TestSetup) {
 
 // TestChatCompletionContentBlocksNormalization tests normalization for content blocks
 func TestChatCompletionContentBlocksNormalization(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-content-blocks-normalization")
+	ctx := CreateContextWithCacheKey(t, "test-content-blocks-normalization")
 
 	// Test cases with content blocks having different text normalization
 	testCases := []struct {
@@ -245,7 +253,10 @@ func TestChatCompletionContentBlocksNormalization(t *testing.T) {
 	t.Logf("Making first request with content blocks: %v", testCases[0].textBlocks)
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx, requests[0])
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		if isTransientUpstreamError(err1) {
+			t.Skipf("transient upstream error, skipping test: %v", err1)
+		}
+		t.Fatalf("upstream request failed: %v", err1)
 	}
 
 	if response1 == nil || len(response1.Choices) == 0 {
@@ -277,17 +288,21 @@ func TestChatCompletionContentBlocksNormalization(t *testing.T) {
 
 // TestNormalizationWithSemanticCache tests that normalization works with semantic cache as well
 func TestNormalizationWithSemanticCache(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-normalization-semantic")
+	ctx := CreateContextWithCacheKey(t, "test-normalization-semantic")
 
 	// Make first request with original text
 	originalRequest := CreateBasicChatRequest("What is Machine Learning?", 0.5, 50)
 	t.Log("Making first request with original text...")
 	response1, err1 := setup.Client.ChatCompletionRequest(ctx, originalRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		if isTransientUpstreamError(err1) {
+			t.Skipf("transient upstream error, skipping test: %v", err1)
+		}
+		t.Fatalf("upstream request failed: %v", err1)
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response1})

--- a/plugins/semanticcache/plugin_paths_test.go
+++ b/plugins/semanticcache/plugin_paths_test.go
@@ -1,0 +1,572 @@
+package semanticcache
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/vectorstore"
+)
+
+// -----------------------------------------------------------------------------
+// PostLLMHook error path
+// -----------------------------------------------------------------------------
+
+func TestPostLLMHook_SkipsOnBifrostError(t *testing.T) {
+	store := newObservableStore()
+	plugin := newTestPlugin(t, store, false)
+
+	ctx := newBaseTestContext()
+	ctx.SetValue(CacheKey, keyForTest(t, ""))
+
+	// Drive a normal PreLLMHook so cacheState exists.
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("hello", 0.7, 50),
+	}
+	if _, _, err := plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook failed: %v", err)
+	}
+
+	// Pass a non-nil bifrost error to PostLLMHook.
+	bifrostErr := &schemas.BifrostError{
+		Error: &schemas.ErrorField{Message: "upstream blew up"},
+	}
+	res := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ExtraFields: schemas.BifrostResponseExtraFields{RequestType: schemas.ChatCompletionRequest},
+		},
+	}
+	if _, _, err := plugin.PostLLMHook(ctx, res, bifrostErr); err != nil {
+		t.Fatalf("PostLLMHook failed: %v", err)
+	}
+	plugin.WaitForPendingOperations()
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if len(store.addIDs) != 0 {
+		t.Fatalf("expected zero cache writes on error response, got %d", len(store.addIDs))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// shouldSkipCaching paths
+// -----------------------------------------------------------------------------
+
+func TestShouldSkipCaching_LargePayloadMode(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+
+	ctx := newBaseTestContext()
+	ctx.SetValue(schemas.BifrostContextKeyLargePayloadMode, true)
+	res := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{}}
+
+	if !plugin.shouldSkipCaching(ctx, res) {
+		t.Fatal("expected LargePayloadMode to skip caching")
+	}
+}
+
+func TestShouldSkipCaching_LargeResponseMode(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+
+	ctx := newBaseTestContext()
+	ctx.SetValue(schemas.BifrostContextKeyLargeResponseMode, true)
+	res := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{}}
+
+	if !plugin.shouldSkipCaching(ctx, res) {
+		t.Fatal("expected LargeResponseMode to skip caching")
+	}
+}
+
+func TestShouldSkipCaching_CacheHitReplay(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+
+	ctx := newBaseTestContext()
+	res := &schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				CacheDebug: &schemas.BifrostCacheDebug{CacheHit: true},
+			},
+		},
+	}
+
+	if !plugin.shouldSkipCaching(ctx, res) {
+		t.Fatal("expected cache-hit replay to skip re-caching")
+	}
+}
+
+func TestShouldSkipCaching_NoStoreFlag(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+
+	ctx := newBaseTestContext()
+	ctx.SetValue(CacheNoStoreKey, true)
+	res := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{}}
+
+	if !plugin.shouldSkipCaching(ctx, res) {
+		t.Fatal("expected CacheNoStoreKey=true to skip caching")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Init validation
+// -----------------------------------------------------------------------------
+
+func TestInit_RejectsNilConfig(t *testing.T) {
+	if _, err := Init(context.Background(), nil, bifrost.NewDefaultLogger(schemas.LogLevelError), newObservableStore()); err == nil {
+		t.Fatal("expected error for nil config")
+	}
+}
+
+func TestInit_RejectsNilStore(t *testing.T) {
+	cfg := &Config{Provider: schemas.OpenAI, EmbeddingModel: "text-embedding-3-small", Dimension: 1536}
+	if _, err := Init(context.Background(), cfg, bifrost.NewDefaultLogger(schemas.LogLevelError), nil); err == nil {
+		t.Fatal("expected error for nil store")
+	}
+}
+
+func TestInit_RejectsNegativeDimension(t *testing.T) {
+	cfg := &Config{Dimension: -1}
+	if _, err := Init(context.Background(), cfg, bifrost.NewDefaultLogger(schemas.LogLevelError), newObservableStore()); err == nil || !strings.Contains(err.Error(), "dimension") {
+		t.Fatalf("expected dimension error, got %v", err)
+	}
+}
+
+func TestInit_RejectsZeroDimensionWithProvider(t *testing.T) {
+	cfg := &Config{Provider: schemas.OpenAI, EmbeddingModel: "text-embedding-3-small", Dimension: 0}
+	if _, err := Init(context.Background(), cfg, bifrost.NewDefaultLogger(schemas.LogLevelError), newObservableStore()); err == nil || !strings.Contains(err.Error(), "dimension") {
+		t.Fatalf("expected dimension error when provider set with zero dimension, got %v", err)
+	}
+}
+
+func TestInit_AllowsDirectOnlyMode(t *testing.T) {
+	// Provider="" + Dimension=1 is the documented direct-only mode.
+	cfg := &Config{Dimension: 1}
+	plugin, err := Init(context.Background(), cfg, bifrost.NewDefaultLogger(schemas.LogLevelError), newObservableStore())
+	if err != nil {
+		t.Fatalf("expected direct-only mode to init successfully, got %v", err)
+	}
+	if plugin == nil {
+		t.Fatal("expected non-nil plugin in direct-only mode")
+	}
+	_ = plugin.Cleanup()
+}
+
+// -----------------------------------------------------------------------------
+// PreLLMHook fallback when embedding executor missing
+// -----------------------------------------------------------------------------
+
+func TestPreLLMHook_FallsBackToDirectWhenExecutorMissing(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+	// Intentionally do NOT set plugin.embeddingRequestExecutor.
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("hello", 0.7, 50),
+	}
+	ctx := CreateContextWithCacheKey(t, "")
+
+	// PreLLMHook should not error, should not panic, and direct search should
+	// still populate state.DirectCacheID.
+	_, sc, err := plugin.PreLLMHook(ctx, req)
+	if err != nil {
+		t.Fatalf("PreLLMHook failed: %v", err)
+	}
+	if sc != nil {
+		t.Fatalf("expected miss (empty store), got short-circuit %+v", sc)
+	}
+
+	requestID, _ := ctx.Value(schemas.BifrostContextKeyRequestID).(string)
+	state := plugin.getCacheState(requestID)
+	if state == nil || state.DirectCacheID == "" {
+		t.Fatal("expected DirectCacheID populated even without embedding executor")
+	}
+	if state.Embeddings != nil {
+		t.Fatalf("expected no embedding generated when executor missing, got %v", state.Embeddings)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Expired-entry full lifecycle
+// -----------------------------------------------------------------------------
+
+func TestExpiredEntry_DetectedAndDeleted(t *testing.T) {
+	store := newObservableStore()
+	plugin := newTestPlugin(t, store, false)
+
+	// Plant an already-expired entry under a deterministic ID.
+	expiredID := "expired-id-1"
+	chunkJSON, _ := json.Marshal(&schemas.BifrostResponse{
+		ChatResponse: &schemas.BifrostChatResponse{},
+	})
+	store.chunks[expiredID] = vectorstore.SearchResult{
+		ID: expiredID,
+		Properties: map[string]interface{}{
+			"response":   string(chunkJSON),
+			"expires_at": time.Now().Add(-1 * time.Minute).Unix(),
+		},
+	}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("hi", 0.7, 50),
+	}
+	ctx := newBaseTestContext()
+	state := &cacheState{}
+
+	sc, err := plugin.buildResponseFromResult(
+		ctx, state, req,
+		store.chunks[expiredID],
+		CacheTypeDirect, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("buildResponseFromResult failed: %v", err)
+	}
+	if sc != nil {
+		t.Fatal("expected expired entry to surface as a miss (nil short-circuit)")
+	}
+
+	// The async delete is tracked on writersWg, so this drain must observe it.
+	plugin.WaitForPendingOperations()
+
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	found := false
+	for _, id := range store.deleteIDs {
+		if id == expiredID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected expired entry %q to be deleted, got delete log %v", expiredID, store.deleteIDs)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// WebSocketResponsesRequest support
+// -----------------------------------------------------------------------------
+
+func TestIsSemanticCacheSupportedRequestType_WebSocket(t *testing.T) {
+	if !isSemanticCacheSupportedRequestType(schemas.WebSocketResponsesRequest) {
+		t.Fatal("WebSocketResponsesRequest should be supported")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// UnmarshalJSON rejection paths
+// -----------------------------------------------------------------------------
+
+func TestUnmarshalJSON_RejectsUnsupportedTTLType(t *testing.T) {
+	var c Config
+	if err := c.UnmarshalJSON([]byte(`{"provider":"openai","ttl":true}`)); err == nil {
+		t.Fatal("expected error for boolean TTL")
+	}
+}
+
+func TestUnmarshalJSON_RejectsNegativeTTL(t *testing.T) {
+	var c Config
+	if err := c.UnmarshalJSON([]byte(`{"provider":"openai","ttl":-5}`)); err == nil || !strings.Contains(err.Error(), "non-negative") {
+		t.Fatalf("expected non-negative TTL error, got %v", err)
+	}
+}
+
+func TestUnmarshalJSON_RejectsMalformedJSON(t *testing.T) {
+	var c Config
+	if err := c.UnmarshalJSON([]byte(`{not valid json`)); err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestUnmarshalJSON_RejectsBadDurationString(t *testing.T) {
+	var c Config
+	if err := c.UnmarshalJSON([]byte(`{"provider":"openai","ttl":"forever"}`)); err == nil {
+		t.Fatal("expected error for unparseable duration string")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Stream replay cancellation variants
+// -----------------------------------------------------------------------------
+
+func TestStreamReplay_CancelImmediately(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+	chunk := `{"chat_response":{"choices":[]}}`
+	streamArray := []string{chunk, chunk, chunk}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionStreamRequest,
+		ChatRequest: CreateBasicChatRequest("hi", 0.7, 50),
+	}
+	ctx := newBaseTestContext()
+	state := &cacheState{}
+
+	sc, err := plugin.buildStreamingResponseFromResult(
+		ctx, state, req,
+		vectorstore.SearchResult{ID: "stream-1"},
+		streamArray, CacheTypeSemantic, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("buildStreamingResponseFromResult failed: %v", err)
+	}
+	ctx.Cancel() // cancel before reading any chunks
+
+	// Channel must close within a short window.
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-sc.Stream:
+			if !ok {
+				return // channel closed cleanly
+			}
+		case <-timeout:
+			t.Fatal("replay goroutine did not exit after immediate cancel")
+		}
+	}
+}
+
+func TestStreamReplay_FullDrain(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+	chunk := `{"chat_response":{"choices":[]}}`
+	streamArray := []string{chunk, chunk, chunk}
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionStreamRequest,
+		ChatRequest: CreateBasicChatRequest("hi", 0.7, 50),
+	}
+	ctx := newBaseTestContext()
+	state := &cacheState{}
+
+	sc, err := plugin.buildStreamingResponseFromResult(
+		ctx, state, req,
+		vectorstore.SearchResult{ID: "stream-2"},
+		streamArray, CacheTypeSemantic, nil, nil, nil,
+	)
+	if err != nil {
+		t.Fatalf("buildStreamingResponseFromResult failed: %v", err)
+	}
+
+	count := 0
+	for chunk := range sc.Stream {
+		if chunk == nil {
+			t.Fatal("received nil chunk")
+		}
+		count++
+	}
+	if count != len(streamArray) {
+		t.Fatalf("expected %d chunks, got %d", len(streamArray), count)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Plugin-log emission on failure paths (ctx.Log)
+// -----------------------------------------------------------------------------
+
+// scopedTestContext returns a plugin-scoped BifrostContext so ctx.Log entries
+// land on the per-request log store and can be inspected via GetPluginLogs.
+// In production the framework wraps every plugin hook this way.
+func scopedTestContext(t testing.TB, suffix string) *schemas.BifrostContext {
+	t.Helper()
+	root := CreateContextWithCacheKey(t, suffix)
+	name := PluginName
+	return root.WithPluginScope(&name)
+}
+
+func TestPreLLMHook_EmitsPluginLogOnEmbeddingFailure(t *testing.T) {
+	store := newObservableStore()
+	plugin := newTestPlugin(t, store, false)
+	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return nil, &schemas.BifrostError{Error: &schemas.ErrorField{Message: "rate limit exceeded"}}
+	})
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("test prompt", 0.7, 50),
+	}
+	ctx := scopedTestContext(t, "")
+
+	if _, _, err := plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook failed: %v", err)
+	}
+
+	logs := ctx.GetPluginLogs()
+	if len(logs) == 0 {
+		t.Fatal("expected at least one plugin log entry on embedding failure, got none")
+	}
+	var found bool
+	for _, l := range logs {
+		if l.PluginName != PluginName {
+			continue
+		}
+		if strings.Contains(l.Message, "semantic search skipped") && strings.Contains(l.Message, "rate limit") {
+			if l.Level != schemas.LogLevelWarn {
+				t.Errorf("expected Warn level for embedding failure, got %s", l.Level)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a Warn plugin log mentioning semantic search skipped + the upstream error, got %+v", logs)
+	}
+}
+
+// pluginLogContains is a small assertion helper: returns true if any log
+// entry from PluginName matches the substring at the given level (or any
+// level if level is "").
+func pluginLogContains(logs []schemas.PluginLogEntry, level schemas.LogLevel, substr string) bool {
+	for _, l := range logs {
+		if l.PluginName != PluginName {
+			continue
+		}
+		if level != "" && l.Level != level {
+			continue
+		}
+		if strings.Contains(l.Message, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPreLLMHook_NoDebugLogsOnFlow(t *testing.T) {
+	// We deliberately do not emit Debug-level plugin logs for normal cache
+	// flow (hit/miss). cache_debug already conveys that. Only Warn-level
+	// failure logs should appear on the response.
+	store := newObservableStore()
+	plugin := newTestPlugin(t, store, false)
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("first request", 0.7, 50),
+	}
+	ctx := scopedTestContext(t, "")
+	if _, _, err := plugin.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook failed: %v", err)
+	}
+
+	logs := ctx.GetPluginLogs()
+	for _, l := range logs {
+		if l.PluginName != PluginName {
+			continue
+		}
+		if l.Level == schemas.LogLevelDebug {
+			t.Fatalf("expected no Debug plugin logs on normal flow, got %+v", l)
+		}
+	}
+}
+
+func TestResolveCacheTypes_EmitsPluginLogOnInvalidValue(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+	ctx := scopedTestContext(t, "")
+	ctx.SetValue(CacheTypeKey, "not-a-cache-type") // wrong type
+
+	plugin.resolveCacheTypes(ctx)
+
+	logs := ctx.GetPluginLogs()
+	var found bool
+	for _, l := range logs {
+		if l.PluginName == PluginName && strings.Contains(l.Message, "CacheTypeKey is not a CacheType") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected plugin log warning about invalid CacheTypeKey, got %+v", logs)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// generateEmbedding handles all EmbeddingStruct representations
+// -----------------------------------------------------------------------------
+
+func TestGenerateEmbedding_AcceptsInt8Array(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return &schemas.BifrostEmbeddingResponse{
+			Data: []schemas.EmbeddingData{{
+				Embedding: schemas.EmbeddingStruct{
+					EmbeddingInt8Array: []int8{-128, -1, 0, 1, 127},
+				},
+			}},
+		}, nil
+	})
+
+	ctx := scopedTestContext(t, "")
+	emb, _, err := plugin.generateEmbedding(ctx, "anything")
+	if err != nil {
+		t.Fatalf("generateEmbedding failed for int8 input: %v", err)
+	}
+	want := []float32{-128, -1, 0, 1, 127}
+	if !reflect.DeepEqual(emb, want) {
+		t.Fatalf("int8 → float32 conversion: want %v, got %v", want, emb)
+	}
+}
+
+func TestGenerateEmbedding_AcceptsInt32Array(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return &schemas.BifrostEmbeddingResponse{
+			Data: []schemas.EmbeddingData{{
+				Embedding: schemas.EmbeddingStruct{
+					EmbeddingInt32Array: []int32{0, 100000, -100000},
+				},
+			}},
+		}, nil
+	})
+
+	ctx := scopedTestContext(t, "")
+	emb, _, err := plugin.generateEmbedding(ctx, "anything")
+	if err != nil {
+		t.Fatalf("generateEmbedding failed for int32 input: %v", err)
+	}
+	want := []float32{0, 100000, -100000}
+	if !reflect.DeepEqual(emb, want) {
+		t.Fatalf("int32 → float32 conversion: want %v, got %v", want, emb)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Concurrent PreLLMHook on same requestID — last writer wins, no panic
+// -----------------------------------------------------------------------------
+
+func TestPreLLMHook_ConcurrentSameRequestID(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore(), false)
+
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: CreateBasicChatRequest("hi", 0.7, 50),
+	}
+
+	requestID := "shared-request-id"
+	const N = 8
+	var wg sync.WaitGroup
+	var panics atomic.Int32
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panics.Add(1)
+				}
+			}()
+			ctx := newBaseTestContext()
+			ctx.SetValue(schemas.BifrostContextKeyRequestID, requestID)
+			ctx.SetValue(CacheKey, keyForTest(t, ""))
+			_, _, _ = plugin.PreLLMHook(ctx, req)
+		}()
+	}
+	wg.Wait()
+
+	if panics.Load() != 0 {
+		t.Fatalf("expected zero panics under concurrent PreLLMHook, got %d", panics.Load())
+	}
+	// State for the shared requestID should exist (one of them won).
+	if state := plugin.getCacheState(requestID); state == nil {
+		t.Fatal("expected cache state to exist after concurrent PreLLMHook")
+	}
+}

--- a/plugins/semanticcache/plugin_responses_test.go
+++ b/plugins/semanticcache/plugin_responses_test.go
@@ -9,10 +9,11 @@ import (
 
 // TestResponsesAPIBasicFunctionality tests the core caching functionality with Responses API
 func TestResponsesAPIBasicFunctionality(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-responses-basic")
+	ctx := CreateContextWithCacheKey(t, "test-responses-basic")
 
 	// Create test request
 	testRequest := CreateBasicResponsesRequest(
@@ -29,7 +30,7 @@ func TestResponsesAPIBasicFunctionality(t *testing.T) {
 	duration1 := time.Since(start1)
 
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	if response1 == nil || len(response1.Output) == 0 {
@@ -94,10 +95,11 @@ func TestResponsesAPIBasicFunctionality(t *testing.T) {
 
 // TestResponsesAPIDifferentParameters tests that different parameters produce different cache entries
 func TestResponsesAPIDifferentParameters(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-responses-params")
+	ctx := CreateContextWithCacheKey(t, "test-responses-params")
 	basePrompt := "Explain quantum computing"
 
 	tests := []struct {
@@ -140,7 +142,7 @@ func TestResponsesAPIDifferentParameters(t *testing.T) {
 			// Make first request
 			_, err1 := setup.Client.ResponsesRequest(ctx, tt.request1)
 			if err1 != nil {
-				return // Test will be skipped by retry function
+				t.Skipf("upstream request error, skipping test: %v", err1)
 			}
 
 			WaitForCache(setup.Plugin)
@@ -168,17 +170,18 @@ func TestResponsesAPIDifferentParameters(t *testing.T) {
 
 // TestResponsesAPISemanticMatching tests semantic similarity matching with Responses API
 func TestResponsesAPISemanticMatching(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKeyAndType("test-responses-semantic", CacheTypeSemantic)
+	ctx := CreateContextWithCacheKeyAndType(t, "test-responses-semantic", CacheTypeSemantic)
 
 	// First request
 	originalRequest := CreateBasicResponsesRequest("What is machine learning?", 0.5, 500)
 	t.Log("Making first Responses request with original text...")
 	response1, err1 := setup.Client.ResponsesRequest(ctx, originalRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
@@ -203,10 +206,11 @@ func TestResponsesAPISemanticMatching(t *testing.T) {
 
 // TestResponsesAPIWithInstructions tests caching with system instructions
 func TestResponsesAPIWithInstructions(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-responses-instructions")
+	ctx := CreateContextWithCacheKey(t, "test-responses-instructions")
 
 	// Create request with instructions
 	request1 := CreateResponsesRequestWithInstructions(
@@ -219,7 +223,7 @@ func TestResponsesAPIWithInstructions(t *testing.T) {
 	t.Log("Making first Responses request with instructions...")
 	response1, err1 := setup.Client.ResponsesRequest(ctx, request1)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
@@ -250,19 +254,20 @@ func TestResponsesAPIWithInstructions(t *testing.T) {
 
 // TestResponsesAPICacheExpiration tests TTL functionality for Responses API requests
 func TestResponsesAPICacheExpiration(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	// Set very short TTL for testing
 	shortTTL := 5 * time.Second
-	ctx := CreateContextWithCacheKeyAndTTL("test-responses-ttl", shortTTL)
+	ctx := CreateContextWithCacheKeyAndTTL(t, "test-responses-ttl", shortTTL)
 
 	responsesRequest := CreateBasicResponsesRequest("TTL test for Responses API", 0.5, 500)
 
 	t.Log("Making first Responses request with short TTL...")
 	response1, err1 := setup.Client.ResponsesRequest(ctx, responsesRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
 
@@ -285,7 +290,7 @@ func TestResponsesAPICacheExpiration(t *testing.T) {
 	t.Log("Making third Responses request after TTL expiration...")
 	response3, err3 := setup.Client.ResponsesRequest(ctx, responsesRequest)
 	if err3 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err3)
 	}
 	// Should not be a cache hit since TTL expired
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response3})
@@ -295,39 +300,52 @@ func TestResponsesAPICacheExpiration(t *testing.T) {
 
 // TestResponsesAPIWithoutCacheKey tests that Responses requests without cache key are not cached
 func TestResponsesAPIWithoutCacheKey(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	// Don't set cache key in context
-	ctx := CreateContextWithCacheKey("")
+	// Don't set cache key in context. CreateContextWithCacheKey(t, "") would
+	// still populate CacheKey from t.Name(); using a base context keeps it
+	// unset so we exercise the cache-disabled path.
+	ctx := newBaseTestContext()
 
 	responsesRequest := CreateBasicResponsesRequest("Test Responses without cache key", 0.5, 500)
 
-	t.Log("Making Responses request without cache key...")
-
-	response, err := setup.Client.ResponsesRequest(ctx, responsesRequest)
+	t.Log("Making first Responses request without cache key...")
+	response1, err := setup.Client.ResponsesRequest(ctx, responsesRequest)
 	if err != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err)
 	}
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
 
-	// Should not be cached
-	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response})
+	WaitForCache(setup.Plugin)
+
+	// A second identical request must also miss — proves the first one
+	// was not silently cached against some default key.
+	t.Log("Making second identical request — must also miss because nothing was cached...")
+	ctx2 := newBaseTestContext()
+	response2, err := setup.Client.ResponsesRequest(ctx2, responsesRequest)
+	if err != nil {
+		t.Skipf("upstream request error, skipping test: %v", err)
+	}
+	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response2})
 
 	t.Log("✅ Responses requests without cache key are properly not cached")
 }
 
 // TestResponsesAPINoStoreFlag tests that Responses requests with no-store flag are not cached
 func TestResponsesAPINoStoreFlag(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
 	responsesRequest := CreateBasicResponsesRequest("Test no-store with Responses API", 0.7, 500)
-	ctx := CreateContextWithCacheKeyAndNoStore("test-no-store-responses", true)
+	ctx := CreateContextWithCacheKeyAndNoStore(t, "test-no-store-responses", true)
 
 	t.Log("Testing no-store with Responses API...")
 	response1, err1 := setup.Client.ResponsesRequest(ctx, responsesRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})
 
@@ -336,79 +354,86 @@ func TestResponsesAPINoStoreFlag(t *testing.T) {
 	// Verify not cached
 	response2, err2 := setup.Client.ResponsesRequest(ctx, responsesRequest)
 	if err2 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err2)
 	}
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response2}) // Should not be cached
 
 	t.Log("✅ Responses API no-store flag working correctly")
 }
 
-// TestResponsesAPIStreaming tests streaming Responses API requests
+// TestResponsesAPIStreaming tests streaming Responses API caching by warming
+// the cache with a streaming request and replaying it with a second identical
+// streaming request that must be served from cache.
 func TestResponsesAPIStreaming(t *testing.T) {
-	t.Log("Responses streaming not supported yet")
-
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-responses-streaming")
+	ctx := CreateContextWithCacheKey(t, "test-responses-streaming")
 	prompt := "Explain the basics of quantum computing in simple terms"
 
-	// Make non-streaming request first
-	t.Log("Making non-streaming Responses request...")
-	nonStreamRequest := CreateBasicResponsesRequest(prompt, 0.5, 500)
-	_, err1 := setup.Client.ResponsesRequest(ctx, nonStreamRequest)
+	// Warm the cache with a streaming request — the plugin accumulates the
+	// chunks and stores them on the final chunk.
+	t.Log("Warming cache with first streaming Responses request...")
+	streamRequest := CreateStreamingResponsesRequest(prompt, 0.5, 500)
+	stream1, err1 := setup.Client.ResponsesStreamRequest(ctx, streamRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
+	}
+	chunkCount1 := 0
+	for streamMsg := range stream1 {
+		if streamMsg.BifrostError != nil {
+			t.Fatalf("Error in first stream: %v", streamMsg.BifrostError)
+		}
+		if streamMsg.BifrostResponsesStreamResponse != nil {
+			chunkCount1++
+		}
+	}
+	if chunkCount1 == 0 {
+		t.Fatal("first streaming request produced no chunks")
 	}
 
 	WaitForCache(setup.Plugin)
 
-	// Make streaming request with same prompt and parameters
-	t.Log("Making streaming Responses request with same prompt...")
-	streamRequest := CreateStreamingResponsesRequest(prompt, 0.5, 500)
-	stream, err2 := setup.Client.ResponsesStreamRequest(ctx, streamRequest)
+	// Second identical streaming request — must be served from cache. We
+	// require AT LEAST ONE chunk with CacheHit=true (the final chunk gets
+	// the cache_debug stamp during replay).
+	t.Log("Replaying — second identical streaming request must serve from cache...")
+	ctx2 := CreateContextWithCacheKey(t, "test-responses-streaming")
+	stream2, err2 := setup.Client.ResponsesStreamRequest(ctx2, streamRequest)
 	if err2 != nil {
-		t.Fatalf("Streaming Responses request failed: %v", err2)
+		t.Fatalf("Second streaming Responses request failed: %v", err2)
 	}
 
-	var streamResponses []schemas.BifrostResponsesStreamResponse
-	for streamMsg := range stream {
+	cacheHitFound := false
+	chunkCount2 := 0
+	for streamMsg := range stream2 {
 		if streamMsg.BifrostError != nil {
-			t.Fatalf("Error in Responses stream: %v", streamMsg.BifrostError)
+			t.Fatalf("Error in second stream: %v", streamMsg.BifrostError)
 		}
 		if streamMsg.BifrostResponsesStreamResponse != nil {
-			streamResponses = append(streamResponses, *streamMsg.BifrostResponsesStreamResponse)
+			chunkCount2++
+			if cd := streamMsg.BifrostResponsesStreamResponse.ExtraFields.CacheDebug; cd != nil && cd.CacheHit {
+				cacheHitFound = true
+			}
 		}
 	}
-
-	if len(streamResponses) == 0 {
-		t.Fatal("No streaming responses received")
+	if chunkCount2 == 0 {
+		t.Fatal("replay produced no chunks")
 	}
-
-	// Check if any of the streaming responses was served from cache
-	cacheHitFound := false
-	for _, resp := range streamResponses {
-		if resp.ExtraFields.CacheDebug != nil && resp.ExtraFields.CacheDebug.CacheHit {
-			cacheHitFound = true
-			break
-		}
-	}
-
 	if !cacheHitFound {
-		t.Log("⚠️  No cache hit detected in streaming responses - this could be expected behavior")
-	} else {
-		t.Log("✓ Cache hit detected in streaming Responses API")
+		t.Fatal("expected at least one chunk with CacheDebug.CacheHit=true on streaming replay")
 	}
-
-	t.Log("✅ Streaming Responses API test completed")
+	t.Log("✅ Streaming Responses API replay served from cache")
 }
 
 // TestResponsesAPIComplexParameters tests complex parameter handling
 func TestResponsesAPIComplexParameters(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-responses-complex-params")
+	ctx := CreateContextWithCacheKey(t, "test-responses-complex-params")
 
 	// Create request with various complex parameters
 	request := CreateBasicResponsesRequest("Test complex parameters", 0.8, 500)
@@ -421,7 +446,7 @@ func TestResponsesAPIComplexParameters(t *testing.T) {
 	t.Log("Making first Responses request with complex parameters...")
 	response1, err1 := setup.Client.ResponsesRequest(ctx, request)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	AssertNoCacheHit(t, &schemas.BifrostResponse{ResponsesResponse: response1})

--- a/plugins/semanticcache/plugin_streaming_test.go
+++ b/plugins/semanticcache/plugin_streaming_test.go
@@ -9,10 +9,11 @@ import (
 
 // TestStreamingCacheBasicFunctionality tests streaming response caching
 func TestStreamingCacheBasicFunctionality(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("test-stream-value")
+	ctx := CreateContextWithCacheKey(t, "test-stream-value")
 
 	// Create a test streaming request
 	testRequest := CreateStreamingChatRequest(
@@ -27,7 +28,7 @@ func TestStreamingCacheBasicFunctionality(t *testing.T) {
 	start1 := time.Now()
 	stream1, err1 := setup.Client.ChatCompletionStreamRequest(ctx, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	var responses1 []schemas.BifrostChatResponse
@@ -115,10 +116,11 @@ func TestStreamingCacheBasicFunctionality(t *testing.T) {
 
 // TestStreamingVsNonStreaming tests that streaming and non-streaming requests are cached separately
 func TestStreamingVsNonStreaming(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("stream-vs-non-test")
+	ctx := CreateContextWithCacheKey(t, "stream-vs-non-test")
 
 	prompt := "What is the meaning of life?"
 
@@ -127,7 +129,7 @@ func TestStreamingVsNonStreaming(t *testing.T) {
 	nonStreamRequest := CreateBasicChatRequest(prompt, 0.5, 50)
 	nonStreamResponse, err1 := setup.Client.ChatCompletionRequest(ctx, nonStreamRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	WaitForCache(setup.Plugin)
@@ -184,10 +186,11 @@ func TestStreamingVsNonStreaming(t *testing.T) {
 
 // TestStreamingChunkOrdering tests that cached streaming responses maintain proper chunk ordering
 func TestStreamingChunkOrdering(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("chunk-order-test")
+	ctx := CreateContextWithCacheKey(t, "chunk-order-test")
 
 	// Request that should generate multiple chunks
 	testRequest := CreateStreamingChatRequest(
@@ -199,7 +202,7 @@ func TestStreamingChunkOrdering(t *testing.T) {
 	t.Log("Making first streaming request to establish cache...")
 	stream1, err1 := setup.Client.ChatCompletionStreamRequest(ctx, testRequest)
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	var originalChunks []schemas.BifrostChatResponse
@@ -213,6 +216,9 @@ func TestStreamingChunkOrdering(t *testing.T) {
 	}
 
 	if len(originalChunks) < 2 {
+		// Stream chunking is at the provider's discretion — under load OpenAI
+		// occasionally bundles a short reply into a single delivered chunk.
+		// Ordering is not testable in that case; skip rather than fail.
 		t.Skipf("Need at least 2 chunks to test ordering, got %d", len(originalChunks))
 	}
 
@@ -273,10 +279,11 @@ func TestStreamingChunkOrdering(t *testing.T) {
 
 // TestSpeechSynthesisStreaming tests speech synthesis streaming caching
 func TestSpeechSynthesisStreaming(t *testing.T) {
+	t.Parallel()
 	setup := NewTestSetup(t)
 	defer setup.Cleanup()
 
-	ctx := CreateContextWithCacheKey("speech-stream-test")
+	ctx := CreateContextWithCacheKey(t, "speech-stream-test")
 
 	// Create speech synthesis request
 	speechRequest := CreateSpeechRequest(
@@ -290,7 +297,7 @@ func TestSpeechSynthesisStreaming(t *testing.T) {
 	duration1 := time.Since(start1)
 
 	if err1 != nil {
-		return // Test will be skipped by retry function
+		t.Skipf("upstream request error, skipping test: %v", err1)
 	}
 
 	if response1 == nil {

--- a/plugins/semanticcache/plugin_vectorstore_test.go
+++ b/plugins/semanticcache/plugin_vectorstore_test.go
@@ -1,7 +1,6 @@
 package semanticcache
 
 import (
-	"context"
 	"os"
 	"strings"
 	"testing"
@@ -47,27 +46,31 @@ func getVectorStoreTestCases() []VectorStoreTestCase {
 	}
 }
 
-// getDefaultTestConfig returns the default test configuration
+// getDefaultTestConfig returns the default test configuration. Mirrors the
+// defaults Init applies, which matters for unit tests that construct Plugin
+// directly without going through Init.
 func getDefaultTestConfig() *Config {
 	return &Config{
-		Provider:          schemas.OpenAI,
-		EmbeddingModel:    "text-embedding-3-small",
-		Dimension:         1536,
-		Threshold:         0.8,
-		CleanUpOnShutdown: true,
+		Provider:                     schemas.OpenAI,
+		EmbeddingModel:               "text-embedding-3-small",
+		Dimension:                    1536,
+		Threshold:                    0.8,
+		CleanUpOnShutdown:            true,
+		ConversationHistoryThreshold: DefaultConversationHistoryThreshold,
 	}
 }
 
 // TestSemanticCache_AllVectorStores_BasicFlow tests the basic cache flow across all vector stores
 func TestSemanticCache_AllVectorStores_BasicFlow(t *testing.T) {
+	t.Parallel()
 	for _, tc := range getVectorStoreTestCases() {
 		t.Run(tc.Name, func(t *testing.T) {
 			skipIfNoAPIKey(t, tc.StoreType)
 			setup := NewTestSetupWithVectorStore(t, getDefaultTestConfig(), tc.StoreType)
 			defer setup.Cleanup()
 
-			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-			ctx.SetValue(CacheKey, "test-"+strings.ToLower(tc.Name)+"-basic")
+			ctx := newBaseTestContext()
+			ctx.SetValue(CacheKey, keyForTest(t, "test-"+strings.ToLower(tc.Name)+"-basic"))
 
 			// Test request
 			request := &schemas.BifrostRequest{
@@ -146,8 +149,8 @@ func TestSemanticCache_AllVectorStores_BasicFlow(t *testing.T) {
 			// Second request - should be a cache hit
 			t.Logf("[%s] Testing second identical request (expecting cache hit)...", tc.Name)
 
-			ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-			ctx2.SetValue(CacheKey, "test-"+strings.ToLower(tc.Name)+"-basic")
+			ctx2 := newBaseTestContext()
+			ctx2.SetValue(CacheKey, keyForTest(t, "test-"+strings.ToLower(tc.Name)+"-basic"))
 
 			_, shortCircuit2, err := setup.Plugin.PreLLMHook(ctx2, request)
 			if err != nil {
@@ -170,6 +173,7 @@ func TestSemanticCache_AllVectorStores_BasicFlow(t *testing.T) {
 
 // TestSemanticCache_AllVectorStores_DirectHashMatch tests direct hash matching across all vector stores
 func TestSemanticCache_AllVectorStores_DirectHashMatch(t *testing.T) {
+	t.Parallel()
 	for _, tc := range getVectorStoreTestCases() {
 		t.Run(tc.Name, func(t *testing.T) {
 			skipIfNoAPIKey(t, tc.StoreType)
@@ -181,7 +185,7 @@ func TestSemanticCache_AllVectorStores_DirectHashMatch(t *testing.T) {
 			testRunID := uuid.New().String()[:8]
 			cacheKey := "test-" + strings.ToLower(tc.Name) + "-direct-" + testRunID
 
-			ctx := CreateContextWithCacheKeyAndType(cacheKey, CacheTypeDirect)
+			ctx := CreateContextWithCacheKeyAndType(t, cacheKey, CacheTypeDirect)
 
 			testRequest := CreateBasicChatRequest("Direct hash test for "+tc.Name+" "+testRunID, 0.7, 50)
 
@@ -196,7 +200,7 @@ func TestSemanticCache_AllVectorStores_DirectHashMatch(t *testing.T) {
 			WaitForCache(setup.Plugin)
 
 			// Second request with direct-only cache type
-			ctx2 := CreateContextWithCacheKeyAndType(cacheKey, CacheTypeDirect)
+			ctx2 := CreateContextWithCacheKeyAndType(t, cacheKey, CacheTypeDirect)
 
 			t.Logf("[%s] Making second request with CacheTypeDirect...", tc.Name)
 			response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
@@ -212,6 +216,7 @@ func TestSemanticCache_AllVectorStores_DirectHashMatch(t *testing.T) {
 
 // TestSemanticCache_AllVectorStores_NamespaceIsolation tests that different cache keys are isolated
 func TestSemanticCache_AllVectorStores_NamespaceIsolation(t *testing.T) {
+	t.Parallel()
 	for _, tc := range getVectorStoreTestCases() {
 		t.Run(tc.Name, func(t *testing.T) {
 			skipIfNoAPIKey(t, tc.StoreType)
@@ -225,7 +230,7 @@ func TestSemanticCache_AllVectorStores_NamespaceIsolation(t *testing.T) {
 			cacheKey2 := "test-" + strings.ToLower(tc.Name) + "-namespace-2-" + testRunID
 
 			// Cache with first key
-			ctx1 := CreateContextWithCacheKey(cacheKey1)
+			ctx1 := CreateContextWithCacheKey(t, cacheKey1)
 			testRequest := CreateBasicChatRequest("Namespace isolation test for "+tc.Name+" "+testRunID, 0.7, 50)
 
 			t.Logf("[%s] Making request with cache key 1...", tc.Name)
@@ -239,7 +244,7 @@ func TestSemanticCache_AllVectorStores_NamespaceIsolation(t *testing.T) {
 			WaitForCache(setup.Plugin)
 
 			// Try with different cache key - should miss
-			ctx2 := CreateContextWithCacheKey(cacheKey2)
+			ctx2 := CreateContextWithCacheKey(t, cacheKey2)
 
 			t.Logf("[%s] Making same request with different cache key (expecting miss)...", tc.Name)
 			response2, err2 := setup.Client.ChatCompletionRequest(ctx2, testRequest)
@@ -251,7 +256,7 @@ func TestSemanticCache_AllVectorStores_NamespaceIsolation(t *testing.T) {
 			AssertNoCacheHit(t, &schemas.BifrostResponse{ChatResponse: response2})
 
 			// Try with original key - should hit
-			ctx3 := CreateContextWithCacheKey(cacheKey1)
+			ctx3 := CreateContextWithCacheKey(t, cacheKey1)
 
 			t.Logf("[%s] Making same request with original cache key (expecting hit)...", tc.Name)
 			response3, err3 := setup.Client.ChatCompletionRequest(ctx3, testRequest)
@@ -267,14 +272,15 @@ func TestSemanticCache_AllVectorStores_NamespaceIsolation(t *testing.T) {
 
 // TestSemanticCache_AllVectorStores_ParameterFiltering tests that different parameters don't share cache
 func TestSemanticCache_AllVectorStores_ParameterFiltering(t *testing.T) {
+	t.Parallel()
 	for _, tc := range getVectorStoreTestCases() {
 		t.Run(tc.Name, func(t *testing.T) {
 			skipIfNoAPIKey(t, tc.StoreType)
 			setup := NewTestSetupWithVectorStore(t, getDefaultTestConfig(), tc.StoreType)
 			defer setup.Cleanup()
 
-			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-			ctx.SetValue(CacheKey, "test-"+strings.ToLower(tc.Name)+"-params")
+			ctx := newBaseTestContext()
+			ctx.SetValue(CacheKey, keyForTest(t, "test-"+strings.ToLower(tc.Name)+"-params"))
 
 			// First request with temperature=0.7
 			request1 := &schemas.BifrostRequest{
@@ -342,8 +348,8 @@ func TestSemanticCache_AllVectorStores_ParameterFiltering(t *testing.T) {
 			// Second request with different temperature - should be cache miss
 			t.Logf("[%s] Testing second request with temperature=0.5 (expecting cache miss)...", tc.Name)
 
-			ctx2 := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
-			ctx2.SetValue(CacheKey, "test-"+strings.ToLower(tc.Name)+"-params")
+			ctx2 := newBaseTestContext()
+			ctx2.SetValue(CacheKey, keyForTest(t, "test-"+strings.ToLower(tc.Name)+"-params"))
 
 			request2 := &schemas.BifrostRequest{
 				RequestType: schemas.ChatCompletionRequest,
@@ -381,6 +387,7 @@ func TestSemanticCache_AllVectorStores_ParameterFiltering(t *testing.T) {
 
 // TestSemanticCache_AllVectorStores_EmbeddingRequest tests embedding request caching across all vector stores
 func TestSemanticCache_AllVectorStores_EmbeddingRequest(t *testing.T) {
+	t.Parallel()
 	for _, tc := range getVectorStoreTestCases() {
 		t.Run(tc.Name, func(t *testing.T) {
 			skipIfNoAPIKey(t, tc.StoreType)
@@ -395,7 +402,7 @@ func TestSemanticCache_AllVectorStores_EmbeddingRequest(t *testing.T) {
 			embeddingRequest := CreateEmbeddingRequest([]string{"Test embedding with " + tc.Name + " " + testRunID})
 
 			// Cache first request
-			ctx1 := CreateContextWithCacheKey(cacheKey)
+			ctx1 := CreateContextWithCacheKey(t, cacheKey)
 			t.Logf("[%s] Making first embedding request...", tc.Name)
 			response1, err1 := setup.Client.EmbeddingRequest(ctx1, embeddingRequest)
 			if err1 != nil {
@@ -407,7 +414,7 @@ func TestSemanticCache_AllVectorStores_EmbeddingRequest(t *testing.T) {
 			WaitForCache(setup.Plugin)
 
 			// Second request - should be cache hit
-			ctx2 := CreateContextWithCacheKey(cacheKey)
+			ctx2 := CreateContextWithCacheKey(t, cacheKey)
 			t.Logf("[%s] Making second embedding request (expecting cache hit)...", tc.Name)
 			response2, err2 := setup.Client.EmbeddingRequest(ctx2, embeddingRequest)
 			if err2 != nil {

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -9,89 +9,32 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
+	"github.com/google/uuid"
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/vectorstore"
 )
 
-func (plugin *Plugin) prepareDirectCacheLookup(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (string, error) {
-	hash, err := plugin.generateRequestHash(req)
+// performDirectSearch does an O(1) point fetch on the deterministic directCacheID
+// derived from (provider, model, cacheKey, request_hash, params_hash). Caller
+// supplies the prebuilt metadata + paramsHash so we don't recompute them when
+// semantic search runs as well.
+func (plugin *Plugin) performDirectSearch(ctx *schemas.BifrostContext, state *cacheState, req *schemas.BifrostRequest, cacheKey string, metadata map[string]interface{}, paramsHash string) (*schemas.LLMPluginShortCircuit, error) {
+	requestHash, err := plugin.generateRequestHash(req, metadata)
 	if err != nil {
-		return "", fmt.Errorf("failed to generate request hash: %w", err)
+		return nil, fmt.Errorf("failed to generate request hash: %w", err)
 	}
-
-	plugin.logger.Debug(PluginLoggerPrefix + " Generated Hash for Request: " + hash)
-
-	paramsHash, err := plugin.computeRequestParamsHash(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to compute direct lookup params hash: %w", err)
-	}
-
-	ctx.SetValue(requestHashKey, hash)
-	ctx.SetValue(requestParamsHashKey, paramsHash)
 
 	provider, model, _ := req.GetRequestFields()
-	directCacheID := plugin.generateDirectCacheID(provider, model, cacheKey, hash, paramsHash)
-
-	return directCacheID, nil
-}
-
-func (plugin *Plugin) performLegacyDirectSearch(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (*schemas.LLMPluginShortCircuit, error) {
-	hash, _ := ctx.Value(requestHashKey).(string)
-	paramsHash, _ := ctx.Value(requestParamsHashKey).(string)
-
-	provider, model, _ := req.GetRequestFields()
-
-	filters := []vectorstore.Query{
-		{Field: "request_hash", Operator: vectorstore.QueryOperatorEqual, Value: hash},
-		{Field: "cache_key", Operator: vectorstore.QueryOperatorEqual, Value: cacheKey},
-		{Field: "params_hash", Operator: vectorstore.QueryOperatorEqual, Value: paramsHash},
-		{Field: "from_bifrost_semantic_cache_plugin", Operator: vectorstore.QueryOperatorEqual, Value: true},
-	}
-
-	if plugin.config.CacheByProvider != nil && *plugin.config.CacheByProvider {
-		filters = append(filters, vectorstore.Query{Field: "provider", Operator: vectorstore.QueryOperatorEqual, Value: string(provider)})
-	}
-	if plugin.config.CacheByModel != nil && *plugin.config.CacheByModel {
-		filters = append(filters, vectorstore.Query{Field: "model", Operator: vectorstore.QueryOperatorEqual, Value: model})
-	}
-
-	plugin.logger.Debug(fmt.Sprintf("%s Searching for legacy direct hash match with %d filters", PluginLoggerPrefix, len(filters)))
-
-	selectFields := append([]string(nil), SelectFields...)
-	if bifrost.IsStreamRequestType(req.RequestType) {
-		selectFields = removeField(selectFields, "response")
-	} else {
-		selectFields = removeField(selectFields, "stream_chunks")
-	}
-
-	searchCtx := vectorstore.WithDisableScanFallback(ctx)
-	var cursor *string
-	results, _, err := plugin.store.GetAll(searchCtx, plugin.config.VectorStoreNamespace, filters, selectFields, cursor, 1)
+	directCacheID, err := plugin.generateDirectCacheID(provider, model, cacheKey, requestHash, paramsHash)
 	if err != nil {
-		if errors.Is(err, vectorstore.ErrNotFound) || errors.Is(err, vectorstore.ErrQuerySyntax) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("failed to search for legacy direct hash match: %w", err)
+		return nil, fmt.Errorf("failed to generate direct cache ID: %w", err)
 	}
+	state.DirectCacheID = directCacheID
 
-	if len(results) == 0 {
-		plugin.logger.Debug(PluginLoggerPrefix + " No legacy direct hash match found")
-		return nil, nil
-	}
-
-	result := results[0]
-	plugin.logger.Debug(fmt.Sprintf("%s Found legacy direct hash match with ID: %s", PluginLoggerPrefix, result.ID))
-	return plugin.buildResponseFromResult(ctx, req, result, CacheTypeDirect, 1.0, 0)
-}
-
-func (plugin *Plugin) performDirectChunkLookup(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (*schemas.LLMPluginShortCircuit, error) {
-	directCacheID, err := plugin.prepareDirectCacheLookup(ctx, req, cacheKey)
-	if err != nil {
-		return nil, err
-	}
-	ctx.SetValue(requestStorageIDKey, directCacheID)
-
+	// All filters (cacheKey, provider, model, requestHash, paramsHash) are
+	// encoded into directCacheID, so a Get-by-ID is sufficient.
 	result, err := plugin.store.GetChunk(ctx, plugin.config.VectorStoreNamespace, directCacheID)
 	if err != nil {
 		errMsg := strings.ToLower(err.Error())
@@ -99,93 +42,46 @@ func (plugin *Plugin) performDirectChunkLookup(ctx *schemas.BifrostContext, req 
 			strings.Contains(errMsg, "not found") ||
 			strings.Contains(errMsg, "status code: 404")
 		if isMiss {
-			plugin.logger.Debug(PluginLoggerPrefix + " No direct chunk match found")
 			return nil, nil
 		}
 		return nil, fmt.Errorf("failed to fetch direct cache chunk: %w", err)
 	}
-
-	plugin.logger.Debug(fmt.Sprintf("%s Found direct chunk match with ID: %s", PluginLoggerPrefix, result.ID))
-	return plugin.buildResponseFromResult(ctx, req, result, CacheTypeDirect, 1.0, 0)
-}
-
-func (plugin *Plugin) performDirectSearch(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (*schemas.LLMPluginShortCircuit, error) {
-	shortCircuit, err := plugin.performDirectChunkLookup(ctx, req, cacheKey)
-	if err != nil {
-		return nil, err
-	}
-	if shortCircuit != nil {
-		return shortCircuit, nil
-	}
-
-	return plugin.performLegacyDirectSearch(ctx, req, cacheKey)
-}
-
-// generateEmbeddingsForStorage generates embeddings and stores them in context for PostHook storage.
-// This is used when the vector store requires vectors but we're in direct-only cache mode.
-// Unlike performSemanticSearch, this function does not perform any search - it only generates
-// and stores embeddings so they can be persisted with the cache entry.
-func (plugin *Plugin) generateEmbeddingsForStorage(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) error {
-	// Extract text and metadata for embedding
-	text, paramsHash, err := plugin.extractTextForEmbedding(req)
-	if err != nil {
-		return fmt.Errorf("failed to extract text for embedding: %w", err)
-	}
-
-	// Generate embedding
-	embedding, inputTokens, err := plugin.generateEmbedding(ctx, text)
-	if err != nil {
-		return fmt.Errorf("failed to generate embedding: %w", err)
-	}
-
-	// Store embedding and metadata in context for PostHook
-	ctx.SetValue(requestEmbeddingKey, embedding)
-	ctx.SetValue(requestEmbeddingTokensKey, inputTokens)
-	ctx.SetValue(requestParamsHashKey, paramsHash)
-
-	return nil
+	return plugin.buildResponseFromResult(ctx, state, req, result, CacheTypeDirect, nil, nil)
 }
 
 // performSemanticSearch performs semantic similarity search and returns matching response if found.
-func (plugin *Plugin) performSemanticSearch(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, cacheKey string) (*schemas.LLMPluginShortCircuit, error) {
-	// Extract text and metadata for embedding
-	text, paramsHash, err := plugin.extractTextForEmbedding(req)
+// Caller supplies the prebuilt paramsHash so it isn't recomputed.
+func (plugin *Plugin) performSemanticSearch(ctx *schemas.BifrostContext, state *cacheState, req *schemas.BifrostRequest, cacheKey string, paramsHash string) (*schemas.LLMPluginShortCircuit, error) {
+	text, err := plugin.extractTextForEmbedding(state, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract text for embedding: %w", err)
 	}
 
-	// Generate embedding
 	embedding, inputTokens, err := plugin.generateEmbedding(ctx, text)
 	if err != nil {
+		// Note: silent skip — provider misconfig or transient embedding errors
+		// fall through to the upstream LLM call.
 		return nil, fmt.Errorf("failed to generate embedding: %w", err)
 	}
 
-	// Store embedding and metadata in context for PostLLMHook
-	ctx.SetValue(requestEmbeddingKey, embedding)
-	ctx.SetValue(requestEmbeddingTokensKey, inputTokens)
-	ctx.SetValue(requestParamsHashKey, paramsHash)
+	state.Embeddings = embedding
+	state.EmbeddingsInputTokens = inputTokens
 
 	cacheThreshold := plugin.config.Threshold
-
-	thresholdValue := ctx.Value(CacheThresholdKey)
-	if thresholdValue != nil {
-		threshold, ok := thresholdValue.(float64)
-		if !ok {
-			plugin.logger.Warn(PluginLoggerPrefix + " Threshold is not a float64, using default threshold")
-		} else {
+	if v := ctx.Value(CacheThresholdKey); v != nil {
+		if threshold, ok := v.(float64); ok {
 			cacheThreshold = threshold
+		} else {
+			plugin.logger.Warn("Threshold is not a float64, using default threshold")
 		}
 	}
 
 	provider, model, _ := req.GetRequestFields()
-
-	// Build strict metadata filters as Query slices (provider, model, and all params)
 	strictFilters := []vectorstore.Query{
 		{Field: "cache_key", Operator: vectorstore.QueryOperatorEqual, Value: cacheKey},
 		{Field: "params_hash", Operator: vectorstore.QueryOperatorEqual, Value: paramsHash},
 		{Field: "from_bifrost_semantic_cache_plugin", Operator: vectorstore.QueryOperatorEqual, Value: true},
 	}
-
 	if plugin.config.CacheByProvider != nil && *plugin.config.CacheByProvider {
 		strictFilters = append(strictFilters, vectorstore.Query{Field: "provider", Operator: vectorstore.QueryOperatorEqual, Value: string(provider)})
 	}
@@ -193,96 +89,175 @@ func (plugin *Plugin) performSemanticSearch(ctx *schemas.BifrostContext, req *sc
 		strictFilters = append(strictFilters, vectorstore.Query{Field: "model", Operator: vectorstore.QueryOperatorEqual, Value: model})
 	}
 
-	plugin.logger.Debug(fmt.Sprintf("%s Performing semantic search with %d metadata filters", PluginLoggerPrefix, len(strictFilters)))
-
-	// Make a full copy so we don't mutate the original backing array
-	selectFields := append([]string(nil), SelectFields...)
-	if bifrost.IsStreamRequestType(req.RequestType) {
-		selectFields = removeField(selectFields, "response")
-	} else {
-		selectFields = removeField(selectFields, "stream_chunks")
-	}
-
-	// For semantic search, we want semantic similarity in content but exact parameter matching
+	selectFields := selectFieldsForRequest(req.RequestType)
 	results, err := plugin.store.GetNearest(ctx, plugin.config.VectorStoreNamespace, embedding, strictFilters, selectFields, cacheThreshold, 1)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search semantic cache: %w", err)
 	}
-
 	if len(results) == 0 {
-		plugin.logger.Debug(PluginLoggerPrefix + " No semantic match found")
 		return nil, nil
 	}
-
-	// Found a semantically similar entry
-	result := results[0]
-	plugin.logger.Debug(fmt.Sprintf("%s Found semantic match with ID: %s, Score: %f", PluginLoggerPrefix, result.ID, *result.Score))
-
-	// Build response from cached result
-	return plugin.buildResponseFromResult(ctx, req, result, CacheTypeSemantic, cacheThreshold, inputTokens)
+	return plugin.buildResponseFromResult(ctx, state, req, results[0], CacheTypeSemantic, &cacheThreshold, &inputTokens)
 }
 
-// buildResponseFromResult constructs a LLMPluginShortCircuit response from a cached VectorEntry result
-func (plugin *Plugin) buildResponseFromResult(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, result vectorstore.SearchResult, cacheType CacheType, threshold float64, inputTokens int) (*schemas.LLMPluginShortCircuit, error) {
-	// Extract response data from the result properties
+// selectFieldsStream / selectFieldsNonStream are precomputed at package init
+// because selectFieldsForRequest is called on every cache lookup.
+var (
+	selectFieldsStream    = filterSelectFields("response")
+	selectFieldsNonStream = filterSelectFields("stream_chunks")
+)
+
+// filterSelectFields returns SelectFields with the named field removed. Used
+// at package init to precompute the per-request projection lists.
+func filterSelectFields(skip string) []string {
+	out := make([]string, 0, len(SelectFields))
+	for _, f := range SelectFields {
+		if f != skip {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// selectFieldsForRequest returns the projection list trimmed to the response
+// shape we actually need (single response vs stream chunks).
+func selectFieldsForRequest(requestType schemas.RequestType) []string {
+	if bifrost.IsStreamRequestType(requestType) {
+		return selectFieldsStream
+	}
+	return selectFieldsNonStream
+}
+
+// generateEmbedding generates an embedding for the given text using the configured provider.
+func (plugin *Plugin) generateEmbedding(ctx *schemas.BifrostContext, text string) ([]float32, int, error) {
+	embeddingReq := &schemas.BifrostEmbeddingRequest{
+		Provider: plugin.config.Provider,
+		Model:    plugin.config.EmbeddingModel,
+		Input: &schemas.EmbeddingInput{
+			Text: &text,
+		},
+	}
+
+	embeddingCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+	// Cancel the derived context once we're done. NewBifrostContext starts a
+	// watchCancellation goroutine that holds a reference to ctx (the scoped
+	// plugin context). Without this, that goroutine outlives the plugin call
+	// and may dereference fields on a parent context that has already been
+	// released back to its sync.Pool — see core/schemas.ReleasePluginScope.
+	defer embeddingCtx.Cancel()
+	embeddingCtx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
+	if plugin.embeddingRequestExecutor == nil {
+		return nil, 0, fmt.Errorf("embedding request executor is not configured")
+	}
+	response, err := plugin.embeddingRequestExecutor(embeddingCtx, embeddingReq)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to generate embedding: %v", err)
+	}
+
+	if len(response.Data) == 0 {
+		return nil, 0, fmt.Errorf("no embeddings returned from provider")
+	}
+
+	embedding := response.Data[0].Embedding
+	inputTokens := 0
+	if response.Usage != nil {
+		inputTokens = response.Usage.TotalTokens
+	}
+
+	switch {
+	case embedding.EmbeddingStr != nil:
+		var vals []float32
+		if err := json.Unmarshal([]byte(*embedding.EmbeddingStr), &vals); err != nil {
+			return nil, 0, fmt.Errorf("failed to parse string embedding: %w", err)
+		}
+		return vals, inputTokens, nil
+	case embedding.EmbeddingArray != nil:
+		return float64ToFloat32Embedding(embedding.EmbeddingArray), inputTokens, nil
+	case len(embedding.Embedding2DArray) > 0:
+		return flattenToFloat32Embedding(embedding.Embedding2DArray), inputTokens, nil
+	case embedding.EmbeddingInt8Array != nil:
+		// Quantized int8/binary embedding format. Promote to float32 so the
+		// cosine-similarity path treats it uniformly.
+		return int8ToFloat32Embedding(embedding.EmbeddingInt8Array), inputTokens, nil
+	case embedding.EmbeddingInt32Array != nil:
+		return int32ToFloat32Embedding(embedding.EmbeddingInt32Array), inputTokens, nil
+	}
+	return nil, 0, fmt.Errorf("embedding data is not in expected format")
+}
+
+// generateRequestHash creates an xxhash of the (normalized input, params).
+// Fallbacks are excluded since they only affect error handling.
+func (plugin *Plugin) generateRequestHash(req *schemas.BifrostRequest, params map[string]interface{}) (string, error) {
+	hashInput := map[string]interface{}{
+		"input":  plugin.getNormalizedInputForCaching(req),
+		"params": params,
+	}
+	jsonData, err := schemas.MarshalDeeplySorted(hashInput)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request for hashing: %w", err)
+	}
+	return fmt.Sprintf("%x", xxhash.Sum64(jsonData)), nil
+}
+
+// generateDirectCacheID returns a deterministic UUIDv5 derived from the cache
+// key, request hash, params hash, and (optionally) provider/model. The same
+// inputs always produce the same ID, which is what makes the direct path an
+// O(1) point fetch.
+func (plugin *Plugin) generateDirectCacheID(provider schemas.ModelProvider, model string, cacheKey string, requestHash string, paramsHash string) (string, error) {
+	idInput := struct {
+		CacheKey    string `json:"cache_key"`
+		RequestHash string `json:"request_hash"`
+		ParamsHash  string `json:"params_hash"`
+		Provider    string `json:"provider,omitempty"`
+		Model       string `json:"model,omitempty"`
+	}{
+		CacheKey:    cacheKey,
+		RequestHash: requestHash,
+		ParamsHash:  paramsHash,
+	}
+	if plugin.config.CacheByProvider != nil && *plugin.config.CacheByProvider {
+		idInput.Provider = string(provider)
+	}
+	if plugin.config.CacheByModel != nil && *plugin.config.CacheByModel {
+		idInput.Model = model
+	}
+	data, err := schemas.MarshalDeeplySorted(idInput)
+	if err != nil {
+		return "", err
+	}
+	return uuid.NewSHA1(directCacheNamespace, data).String(), nil
+}
+
+// buildResponseFromResult constructs a LLMPluginShortCircuit response from a cached VectorEntry result.
+//
+// Return contract:
+//   - (shortCircuit, nil): cache hit — caller should return shortCircuit to short-circuit upstream.
+//   - (nil, nil): treat as a miss. Used for both genuine misses and "soft" misses
+//     (expired entry, unparseable expires_at, format mismatch). Caller proceeds to upstream.
+//   - (nil, err): hard error worth logging; caller logs and proceeds to upstream.
+func (plugin *Plugin) buildResponseFromResult(ctx *schemas.BifrostContext, state *cacheState, req *schemas.BifrostRequest, result vectorstore.SearchResult, cacheType CacheType, threshold *float64, inputTokens *int) (*schemas.LLMPluginShortCircuit, error) {
 	properties := result.Properties
 	if properties == nil {
 		return nil, fmt.Errorf("no properties found in cached result")
 	}
 
-	// Check TTL - if entry has expired, delete it and return cache miss
-	if expiresAtRaw, exists := properties["expires_at"]; exists && expiresAtRaw != nil {
-		var expiresAt int64
-		var validType bool
-		switch v := expiresAtRaw.(type) {
-		case string:
-			var err error
-			expiresAt, err = strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				validType = false
-			} else {
-				validType = true
+	if expired, miss := isExpiredEntry(properties); expired {
+		// Async best-effort cleanup of the stale entry. Tracked on writersWg
+		// so WaitForPendingOperations + Cleanup block until it finishes,
+		// avoiding a delete racing with namespace teardown.
+		plugin.writersWg.Add(1)
+		go func() {
+			defer plugin.writersWg.Done()
+			deleteCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := plugin.store.Delete(deleteCtx, plugin.config.VectorStoreNamespace, result.ID); err != nil {
+				plugin.logger.Warn("Failed to delete expired entry %s: %v", result.ID, err)
 			}
-		case float64:
-			expiresAt = int64(v)
-			validType = true
-		case int64:
-			expiresAt = v
-			validType = true
-		case int:
-			expiresAt = int64(v)
-			validType = true
-		}
-		if validType {
-			currentTime := time.Now().Unix()
-			if expiresAt < currentTime {
-				// Entry has expired, delete it asynchronously
-				go func() {
-					deleteCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-					defer cancel()
-					err := plugin.store.Delete(deleteCtx, plugin.config.VectorStoreNamespace, result.ID)
-					if err != nil {
-						plugin.logger.Warn("%s Failed to delete expired entry %s: %v", PluginLoggerPrefix, result.ID, err)
-					}
-				}()
-				// Return nil to indicate cache miss
-				return nil, nil
-			}
-		}
-	}
-
-	// Check if this is a streaming response - need to check for non-null values
-	streamResponses, hasStreamingResponse := properties["stream_chunks"]
-	singleResponse, hasSingleResponse := properties["response"]
-
-	// Consider fields present only if they're not null
-	hasValidSingleResponse := hasSingleResponse && singleResponse != nil
-	hasValidStreamingResponse := hasStreamingResponse && streamResponses != nil
-
-	// Parse stream_chunks
-	streamChunks, err := plugin.parseStreamChunks(streamResponses)
-	if err != nil || len(streamChunks) == 0 {
-		hasValidStreamingResponse = false
+		}()
+		return nil, nil
+	} else if miss {
+		// Unparseable expires_at — treat as miss to be safe.
+		return nil, nil
 	}
 
 	similarity := 0.0
@@ -290,134 +265,118 @@ func (plugin *Plugin) buildResponseFromResult(ctx *schemas.BifrostContext, req *
 		similarity = *result.Score
 	}
 
-	isStreamRequest := bifrost.IsStreamRequestType(req.RequestType)
-
-	if isStreamRequest && hasValidStreamingResponse {
-		return plugin.buildStreamingResponseFromResult(ctx, req, result, streamChunks, cacheType, threshold, similarity, inputTokens)
-	} else if !isStreamRequest && hasValidSingleResponse {
-		return plugin.buildSingleResponseFromResult(ctx, req, result, singleResponse, cacheType, threshold, similarity, inputTokens)
+	isStream := bifrost.IsStreamRequestType(req.RequestType)
+	if isStream {
+		streamResponses, ok := properties["stream_chunks"]
+		if ok && streamResponses != nil {
+			streamChunks, err := plugin.parseStreamChunks(streamResponses)
+			if err == nil && len(streamChunks) > 0 {
+				return plugin.buildStreamingResponseFromResult(ctx, state, req, result, streamChunks, cacheType, threshold, &similarity, inputTokens)
+			}
+		}
 	} else {
-		plugin.logger.Warn("%s Cache entry format mismatch for request %s (isStream=%t, hasSingle=%t, hasStream=%t), treating as miss",
-			PluginLoggerPrefix, result.ID, isStreamRequest, hasValidSingleResponse, hasValidStreamingResponse)
-		return nil, nil
+		singleResponse, ok := properties["response"]
+		if ok && singleResponse != nil {
+			return plugin.buildNonStreamingResponseFromResult(ctx, state, req, result, singleResponse, cacheType, threshold, &similarity, inputTokens)
+		}
 	}
+
+	msg := fmt.Sprintf("cache entry %s format mismatch (isStream=%t), treating as miss — entry may be corrupt", result.ID, isStream)
+	plugin.logger.Warn(msg)
+	ctx.Log(schemas.LogLevelWarn, msg)
+	return nil, nil
 }
 
-// buildSingleResponseFromResult constructs a single response from cached data
-func (plugin *Plugin) buildSingleResponseFromResult(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, result vectorstore.SearchResult, responseData interface{}, cacheType CacheType, threshold float64, similarity float64, inputTokens int) (*schemas.LLMPluginShortCircuit, error) {
+// isExpiredEntry returns (expired, parseFailed). A nil/missing expires_at is
+// treated as never-expires.
+func isExpiredEntry(properties map[string]interface{}) (bool, bool) {
+	expiresAtRaw, exists := properties["expires_at"]
+	if !exists || expiresAtRaw == nil {
+		return false, false
+	}
+	var expiresAt int64
+	switch v := expiresAtRaw.(type) {
+	case string:
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return false, true
+		}
+		expiresAt = parsed
+	case float64:
+		expiresAt = int64(v)
+	case int64:
+		expiresAt = v
+	case int:
+		expiresAt = int64(v)
+	default:
+		return false, true
+	}
+	return expiresAt < time.Now().Unix(), false
+}
+
+// buildNonStreamingResponseFromResult constructs a single response from cached data.
+func (plugin *Plugin) buildNonStreamingResponseFromResult(ctx *schemas.BifrostContext, state *cacheState, req *schemas.BifrostRequest, result vectorstore.SearchResult, responseData interface{}, cacheType CacheType, threshold *float64, similarity *float64, inputTokens *int) (*schemas.LLMPluginShortCircuit, error) {
 	requestedProvider, requestedModel, _ := req.GetRequestFields()
 
 	responseStr, ok := responseData.(string)
 	if !ok {
 		return nil, fmt.Errorf("cached response is not a string")
 	}
-
-	// Unmarshal the cached response
 	var cachedResponse schemas.BifrostResponse
 	if err := json.Unmarshal([]byte(responseStr), &cachedResponse); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal cached response: %w", err)
 	}
 
-	extraFields := cachedResponse.GetExtraFields()
-
-	if extraFields.CacheDebug == nil {
-		extraFields.CacheDebug = &schemas.BifrostCacheDebug{}
-	}
-	extraFields.CacheDebug.CacheHit = true
-	extraFields.CacheDebug.HitType = bifrost.Ptr(string(cacheType))
-	extraFields.CacheDebug.CacheID = bifrost.Ptr(result.ID)
-	extraFields.CacheDebug.RequestedProvider = bifrost.Ptr(string(requestedProvider))
-	extraFields.CacheDebug.RequestedModel = bifrost.Ptr(requestedModel)
-	if cacheType == CacheTypeSemantic {
-		extraFields.CacheDebug.ProviderUsed = bifrost.Ptr(string(plugin.config.Provider))
-		extraFields.CacheDebug.ModelUsed = bifrost.Ptr(plugin.config.EmbeddingModel)
-		extraFields.CacheDebug.Threshold = &threshold
-		extraFields.CacheDebug.Similarity = &similarity
-		extraFields.CacheDebug.InputTokens = &inputTokens
-	} else {
-		extraFields.CacheDebug.ProviderUsed = nil
-		extraFields.CacheDebug.ModelUsed = nil
-		extraFields.CacheDebug.Threshold = nil
-		extraFields.CacheDebug.Similarity = nil
-		extraFields.CacheDebug.InputTokens = nil
-	}
-
-	ctx.SetValue(isCacheHitKey, true)
-	ctx.SetValue(cacheHitTypeKey, cacheType)
-
-	return &schemas.LLMPluginShortCircuit{
-		Response: &cachedResponse,
-	}, nil
+	plugin.stampCacheDebugForHit(state, cachedResponse.GetExtraFields(), result.ID, requestedProvider, requestedModel, cacheType, threshold, similarity, inputTokens)
+	state.ShortCircuited = true
+	return &schemas.LLMPluginShortCircuit{Response: &cachedResponse}, nil
 }
 
-// buildStreamingResponseFromResult constructs a streaming response from cached data
-func (plugin *Plugin) buildStreamingResponseFromResult(ctx *schemas.BifrostContext, req *schemas.BifrostRequest, result vectorstore.SearchResult, streamArray []interface{}, cacheType CacheType, threshold float64, similarity float64, inputTokens int) (*schemas.LLMPluginShortCircuit, error) {
+// buildStreamingResponseFromResult constructs a streaming response from cached data.
+// The replay goroutine guards every send with ctx.Done() so a dropped consumer
+// can't leak the goroutine (and its captured chunks) for the lifetime of the
+// process.
+func (plugin *Plugin) buildStreamingResponseFromResult(ctx *schemas.BifrostContext, state *cacheState, req *schemas.BifrostRequest, result vectorstore.SearchResult, streamArray []string, cacheType CacheType, threshold *float64, similarity *float64, inputTokens *int) (*schemas.LLMPluginShortCircuit, error) {
 	requestedProvider, requestedModel, _ := req.GetRequestFields()
-
-	// Mark cache-hit once to avoid concurrent ctx writes
-	ctx.SetValue(isCacheHitKey, true)
-	ctx.SetValue(cacheHitTypeKey, cacheType)
-
-	// Create stream channel
 	streamChan := make(chan *schemas.BifrostStreamChunk)
+	done := ctx.Done()
 
+	// We deliberately do NOT pre-decode all chunks up front — that would
+	// add O(N) latency before the first chunk is delivered, defeating the
+	// purpose of streaming for long responses. A malformed chunk is
+	// extremely unlikely (we wrote it as JSON ourselves), and on the rare
+	// occasion it happens we log+skip rather than truncate the user's view.
 	go func() {
 		defer close(streamChan)
-
-		// Set cache-hit markers inside the streaming goroutine to avoid races
-		ctx.SetValue(isCacheHitKey, true)
-		ctx.SetValue(cacheHitTypeKey, cacheType)
-
-		// Process each stream chunk
-		for i, chunkData := range streamArray {
-			chunkStr, ok := chunkData.(string)
-			if !ok {
-				plugin.logger.Warn("%s Stream chunk %d is not a string, skipping", PluginLoggerPrefix, i)
-				continue
-			}
-
-			// Unmarshal the chunk as BifrostResponse
+		for i, chunkStr := range streamArray {
 			var cachedResponse schemas.BifrostResponse
 			if err := json.Unmarshal([]byte(chunkStr), &cachedResponse); err != nil {
-				plugin.logger.Warn("%s Failed to unmarshal stream chunk %d, skipping: %v", PluginLoggerPrefix, i, err)
+				plugin.logger.Warn("Failed to unmarshal stream chunk %d, skipping: %v", i, err)
 				continue
 			}
 
 			// Ensure RequestType is set on every chunk so downstream consumers
-			// (logging, telemetry, etc.) correctly identify this as a streaming response.
+			// (logging, telemetry) correctly identify this as a streaming response.
 			if ef := cachedResponse.GetExtraFields(); ef != nil && ef.RequestType == "" {
 				ef.RequestType = req.RequestType
 			}
 
-			// Add cache debug to only the last chunk
 			if i == len(streamArray)-1 {
-				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-				extraFields := cachedResponse.GetExtraFields()
-				cacheDebug := schemas.BifrostCacheDebug{
-					CacheHit:          true,
-					HitType:           bifrost.Ptr(string(cacheType)),
-					CacheID:           bifrost.Ptr(result.ID),
-					RequestedProvider: bifrost.Ptr(string(requestedProvider)),
-					RequestedModel:    bifrost.Ptr(requestedModel),
-				}
-				if cacheType == CacheTypeSemantic {
-					cacheDebug.ProviderUsed = bifrost.Ptr(string(plugin.config.Provider))
-					cacheDebug.ModelUsed = bifrost.Ptr(plugin.config.EmbeddingModel)
-					cacheDebug.Threshold = &threshold
-					cacheDebug.Similarity = &similarity
-					cacheDebug.InputTokens = &inputTokens
-				} else {
-					cacheDebug.ProviderUsed = nil
-					cacheDebug.ModelUsed = nil
-					cacheDebug.Threshold = nil
-					cacheDebug.Similarity = nil
-					cacheDebug.InputTokens = nil
-				}
-				extraFields.CacheDebug = &cacheDebug
+				// stampCacheDebugForHit marks this chunk as the cache-hit final
+				// chunk; cache.PostLLMHook keys off CacheDebug.CacheHit=true to
+				// set BifrostContextKeyStreamEndIndicator on the root ctx
+				// synchronously (same goroutine as logging.PostLLMHook).
+				//
+				// We deliberately do NOT call ctx.Root().SetValue here. Doing
+				// so races against the receiver's PostLLMHook for the previous
+				// chunk: the cache replay can advance to iteration N (and
+				// write the indicator) while the receiver is still running
+				// PostLLMHooks for chunk N-1, poisoning that chunk's
+				// IsFinalChunk read and causing duplicate "final" events.
+				plugin.stampCacheDebugForHit(state, cachedResponse.GetExtraFields(), result.ID, requestedProvider, requestedModel, cacheType, threshold, similarity, inputTokens)
 			}
 
-			// Send chunk to stream
-			streamChan <- &schemas.BifrostStreamChunk{
+			chunk := &schemas.BifrostStreamChunk{
 				BifrostTextCompletionResponse:        cachedResponse.TextCompletionResponse,
 				BifrostChatResponse:                  cachedResponse.ChatResponse,
 				BifrostResponsesStreamResponse:       cachedResponse.ResponsesStreamResponse,
@@ -425,44 +384,63 @@ func (plugin *Plugin) buildStreamingResponseFromResult(ctx *schemas.BifrostConte
 				BifrostTranscriptionStreamResponse:   cachedResponse.TranscriptionStreamResponse,
 				BifrostImageGenerationStreamResponse: cachedResponse.ImageGenerationStreamResponse,
 			}
+
+			select {
+			case streamChan <- chunk:
+			case <-done:
+				return
+			}
 		}
 	}()
 
-	return &schemas.LLMPluginShortCircuit{
-		Stream: streamChan,
-	}, nil
+	state.ShortCircuited = true
+	return &schemas.LLMPluginShortCircuit{Stream: streamChan}, nil
 }
 
-// parseStreamChunks parses stream_chunks data from various formats into []interface{}
-// Handles []interface{}, []string, and JSON string formats
-func (plugin *Plugin) parseStreamChunks(streamData interface{}) ([]interface{}, error) {
-	if streamData == nil {
-		return nil, fmt.Errorf("stream data is nil")
+// stampCacheDebugForHit stamps the cache-hit telemetry on the response. For
+// CacheTypeDirect, the embedding-related fields are explicitly cleared so
+// stale carry-over from semantic hits never leaks through. CacheHitLatency
+// is computed from state.CreatedAt (set at PreLLMHook entry) so consumers
+// can distinguish cache-serve time from the original provider latency
+// preserved in the cached response.
+func (plugin *Plugin) stampCacheDebugForHit(
+	state *cacheState,
+	extraFields *schemas.BifrostResponseExtraFields,
+	cacheID string,
+	requestedProvider schemas.ModelProvider,
+	requestedModel string,
+	cacheType CacheType,
+	threshold *float64,
+	similarity *float64,
+	inputTokens *int,
+) {
+	// GetExtraFields() can return nil for older/corrupted cache entries that
+	// were written without ExtraFields populated. Bail rather than panic —
+	// the chunk will still be delivered, just without CacheDebug telemetry.
+	if extraFields == nil {
+		return
 	}
-
-	switch v := streamData.(type) {
-	case []interface{}:
-		return v, nil
-	case []string:
-		// Convert []string to []interface{}
-		result := make([]interface{}, len(v))
-		for i, s := range v {
-			result[i] = s
-		}
-		return result, nil
-	case string:
-		// Parse JSON string from Redis
-		var stringArray []string
-		if err := json.Unmarshal([]byte(v), &stringArray); err != nil {
-			return nil, fmt.Errorf("failed to parse JSON string: %w", err)
-		}
-		// Convert to []interface{}
-		result := make([]interface{}, len(stringArray))
-		for i, s := range stringArray {
-			result[i] = s
-		}
-		return result, nil
-	default:
-		return nil, fmt.Errorf("unsupported stream data type: %T", streamData)
+	if extraFields.CacheDebug == nil {
+		extraFields.CacheDebug = &schemas.BifrostCacheDebug{}
+	}
+	cd := extraFields.CacheDebug
+	cd.CacheHit = true
+	cd.HitType = bifrost.Ptr(string(cacheType))
+	cd.CacheID = bifrost.Ptr(cacheID)
+	cd.RequestedProvider = bifrost.Ptr(string(requestedProvider))
+	cd.RequestedModel = bifrost.Ptr(requestedModel)
+	cd.CacheHitLatency = bifrost.Ptr(time.Since(state.CreatedAt).Milliseconds())
+	if cacheType == CacheTypeSemantic {
+		cd.ProviderUsed = bifrost.Ptr(string(plugin.config.Provider))
+		cd.ModelUsed = bifrost.Ptr(plugin.config.EmbeddingModel)
+		cd.Threshold = threshold
+		cd.Similarity = similarity
+		cd.InputTokens = inputTokens
+	} else {
+		cd.ProviderUsed = nil
+		cd.ModelUsed = nil
+		cd.Threshold = nil
+		cd.Similarity = nil
+		cd.InputTokens = nil
 	}
 }

--- a/plugins/semanticcache/state.go
+++ b/plugins/semanticcache/state.go
@@ -1,0 +1,110 @@
+package semanticcache
+
+import (
+	"time"
+)
+
+// cacheState holds per-request state for the semantic cache plugin. It's
+// keyed by the request ID and lives between PreLLMHook (where it's populated)
+// and PostLLMHook (where it's consumed and cleared).
+//
+// Centralizes what used to be a set of stringly-typed BifrostContext keys
+// (directCacheID, paramsHash, embeddings, embedding input tokens) into one
+// struct so the lifecycle is explicit and consumers don't have to chase
+// ctx.Value/SetValue calls across files.
+//
+// No mutex is needed: per-request access is serialized — PreLLMHook runs once,
+// PostLLMHook runs once per chunk in order, and the only async path
+// (PostLLMHook's storage goroutine) snapshots the values it needs into locals
+// before launching.
+type cacheState struct {
+	DirectCacheID         string
+	ParamsHash            string
+	Embeddings            []float32
+	EmbeddingsInputTokens int
+
+	// FilteredInput caches getInputForCaching(req) so attachment extraction,
+	// embedding text extraction, and history-threshold checks reuse the same
+	// filtered slice instead of re-filtering on each call.
+	FilteredInput interface{}
+
+	// ShortCircuited is set when PreLLMHook served the response from cache
+	// (returned a non-nil LLMPluginShortCircuit). PostLLMHook uses this to
+	// skip the entire cache-write path: only the FINAL replay chunk carries
+	// CacheDebug.CacheHit=true, so shouldSkipCaching() can't catch the
+	// non-final chunks on its own — without this flag they'd flow into
+	// addStreamingResponse and trigger a duplicate write at the same
+	// directCacheID (Weaviate 422 "id already exists").
+	ShortCircuited bool
+
+	CreatedAt time.Time
+}
+
+// cacheStateMaxAge bounds how long an orphaned cacheState may live in memory
+// before being reaped.
+const cacheStateMaxAge = 60 * time.Minute
+
+// cacheStateCleanupInterval bounds the worst-case staleness of an orphaned
+// state to ~maxAge + interval.
+const cacheStateCleanupInterval = 5 * time.Minute
+
+// createCacheState writes a fresh state for requestID, overwriting any prior.
+// PreLLMHook calls this at the top so retries / reused requestIDs don't
+// inherit stale fields.
+func (p *Plugin) createCacheState(requestID string) *cacheState {
+	state := &cacheState{CreatedAt: time.Now()}
+	p.cacheStates.Store(requestID, state)
+	return state
+}
+
+// getCacheState returns the cacheState for requestID, or nil if none exists.
+func (p *Plugin) getCacheState(requestID string) *cacheState {
+	if v, ok := p.cacheStates.Load(requestID); ok {
+		return v.(*cacheState)
+	}
+	return nil
+}
+
+// clearCacheState drops the cacheState entry for requestID. It's safe to call
+// when no entry exists.
+func (p *Plugin) clearCacheState(requestID string) {
+	p.cacheStates.Delete(requestID)
+}
+
+// runCacheStateCleanupLoop reaps stale cacheStates on a ticker until stopCh
+// is closed. Started by Init, stopped by Cleanup.
+func (p *Plugin) runCacheStateCleanupLoop() {
+	defer p.cleanupWg.Done()
+	ticker := time.NewTicker(cacheStateCleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.stopCh:
+			return
+		case <-ticker.C:
+			p.cleanupOldCacheStates()
+		}
+	}
+}
+
+// cleanupOldCacheStates deletes every cacheState whose CreatedAt is older
+// than cacheStateMaxAge. Entries this old indicate a request that never
+// reached PostLLMHook (client disconnect, framework bug); reaping them
+// bounds memory under abnormal traffic.
+func (p *Plugin) cleanupOldCacheStates() {
+	cutoff := time.Now().Add(-cacheStateMaxAge)
+	var toDelete []string
+	p.cacheStates.Range(func(key, value interface{}) bool {
+		state := value.(*cacheState)
+		if state.CreatedAt.Before(cutoff) {
+			toDelete = append(toDelete, key.(string))
+		}
+		return true
+	})
+	for _, k := range toDelete {
+		p.cacheStates.Delete(k)
+	}
+	if len(toDelete) > 0 {
+		p.logger.Debug("Reaped %d stale cache states", len(toDelete))
+	}
+}

--- a/plugins/semanticcache/stream.go
+++ b/plugins/semanticcache/stream.go
@@ -5,65 +5,81 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"sync"
 	"time"
 )
 
-// Streaming State Management Methods
-
-// createStreamAccumulator creates a new stream accumulator for a request
-func (plugin *Plugin) createStreamAccumulator(requestID string, storageID string, embedding []float32, metadata map[string]interface{}, ttl time.Duration) *StreamAccumulator {
-	return &StreamAccumulator{
-		RequestID:  requestID,
-		StorageID:  storageID,
-		Chunks:     make([]*StreamChunk, 0),
-		IsComplete: false,
-		Embedding:  embedding,
-		Metadata:   metadata,
-		TTL:        ttl,
-		mu:         sync.Mutex{},
+// chunkSortKey returns the (Index, ChunkIndex) tuple used to order
+// accumulated stream chunks before flush. Image-generation responses use
+// both fields; every other response shape uses ChunkIndex with Index=0.
+// Nil chunks/responses sort to the end via a max-int sentinel so they're
+// dropped deterministically by the consumer.
+func chunkSortKey(c *StreamChunk) (int, int) {
+	const sentinel = int(^uint(0) >> 1) // math.MaxInt without the import
+	if c == nil || c.Response == nil {
+		return sentinel, sentinel
 	}
+	r := c.Response
+	switch {
+	case r.TextCompletionResponse != nil:
+		return 0, r.TextCompletionResponse.ExtraFields.ChunkIndex
+	case r.ChatResponse != nil:
+		return 0, r.ChatResponse.ExtraFields.ChunkIndex
+	case r.ResponsesResponse != nil:
+		return 0, r.ResponsesResponse.ExtraFields.ChunkIndex
+	case r.ResponsesStreamResponse != nil:
+		return 0, r.ResponsesStreamResponse.ExtraFields.ChunkIndex
+	case r.SpeechResponse != nil:
+		return 0, r.SpeechResponse.ExtraFields.ChunkIndex
+	case r.SpeechStreamResponse != nil:
+		return 0, r.SpeechStreamResponse.ExtraFields.ChunkIndex
+	case r.TranscriptionResponse != nil:
+		return 0, r.TranscriptionResponse.ExtraFields.ChunkIndex
+	case r.TranscriptionStreamResponse != nil:
+		return 0, r.TranscriptionStreamResponse.ExtraFields.ChunkIndex
+	case r.ImageGenerationStreamResponse != nil:
+		return r.ImageGenerationStreamResponse.Index, r.ImageGenerationStreamResponse.ChunkIndex
+	}
+	return sentinel, sentinel
 }
 
-// getOrCreateStreamAccumulator gets or creates a stream accumulator for a request
+// getOrCreateStreamAccumulator returns the StreamAccumulator for requestID,
+// creating one if none exists. Concurrency-safe: the underlying sync.Map's
+// LoadOrStore guarantees a single accumulator per request even under racing
+// PostLLMHook invocations.
 func (plugin *Plugin) getOrCreateStreamAccumulator(requestID string, storageID string, embedding []float32, metadata map[string]interface{}, ttl time.Duration) *StreamAccumulator {
 	if existing, ok := plugin.streamAccumulators.Load(requestID); ok {
 		return existing.(*StreamAccumulator)
 	}
-
-	newAccumulator := plugin.createStreamAccumulator(requestID, storageID, embedding, metadata, ttl)
+	newAccumulator := &StreamAccumulator{
+		RequestID:  requestID,
+		StorageID:  storageID,
+		Chunks:     make([]*StreamChunk, 0),
+		LastSeenAt: time.Now(),
+		Embedding:  embedding,
+		Metadata:   metadata,
+		TTL:        ttl,
+	}
 	actual, _ := plugin.streamAccumulators.LoadOrStore(requestID, newAccumulator)
 	return actual.(*StreamAccumulator)
 }
 
-// addStreamChunk adds a chunk to the stream accumulator
-func (plugin *Plugin) addStreamChunk(requestID string, chunk *StreamChunk, isFinalChunk bool) error {
-	// Get accumulator (should exist if properly initialized)
+// addStreamChunk appends a chunk to the request's accumulator and refreshes
+// LastSeenAt so the reaper treats the stream as still active.
+func (plugin *Plugin) addStreamChunk(requestID string, chunk *StreamChunk) error {
 	accumulatorInterface, exists := plugin.streamAccumulators.Load(requestID)
 	if !exists {
 		return fmt.Errorf("stream accumulator not found for request %s", requestID)
 	}
-
 	accumulator := accumulatorInterface.(*StreamAccumulator)
 	accumulator.mu.Lock()
 	defer accumulator.mu.Unlock()
-
-	// Add chunk to the list (chunks arrive in order)
 	accumulator.Chunks = append(accumulator.Chunks, chunk)
-
-	// Set FinalTimestamp when FinishReason is present
-	// This handles both normal completion chunks and usage-only last chunks
-	if isFinalChunk {
-		accumulator.FinalTimestamp = chunk.Timestamp
-	}
-
-	plugin.logger.Debug(fmt.Sprintf("%s Added chunk to stream accumulator for request %s", PluginLoggerPrefix, requestID))
-
+	accumulator.LastSeenAt = chunk.Timestamp
 	return nil
 }
 
-// processAccumulatedStream processes all accumulated chunks and caches the complete stream
-// Flow: Collect everything → Check for ANY errors → If no errors, order and send to .Add() → If any errors, drop operation
+// processAccumulatedStream serializes and stores the accumulated chunks as a
+// single cache entry. Called once per stream when the final chunk arrives.
 func (plugin *Plugin) processAccumulatedStream(ctx context.Context, requestID string) error {
 	accumulatorInterface, exists := plugin.streamAccumulators.Load(requestID)
 	if !exists {
@@ -72,130 +88,106 @@ func (plugin *Plugin) processAccumulatedStream(ctx context.Context, requestID st
 
 	accumulator := accumulatorInterface.(*StreamAccumulator)
 	accumulator.mu.Lock()
-
-	// Ensure unlock happens after cleanup
 	defer accumulator.mu.Unlock()
-	// Ensure cleanup happens
 	defer plugin.cleanupStreamAccumulator(requestID)
 
-	// STEP 1: Check if any chunk in the entire stream had an error
-	if accumulator.HasError {
-		plugin.logger.Debug(fmt.Sprintf("%s Stream for request %s had errors, dropping entire operation (not caching)", PluginLoggerPrefix, requestID))
-		return nil
-	}
-
-	// STEP 2: All chunks are clean, now sort and build ordered stream for caching
-	plugin.logger.Debug(fmt.Sprintf("%s Stream for request %s completed successfully, processing %d chunks for caching", PluginLoggerPrefix, requestID, len(accumulator.Chunks)))
-
-	// Sort chunks by their ChunkIndex to ensure proper order (stable + nil-safe)
 	sort.SliceStable(accumulator.Chunks, func(i, j int) bool {
-		if accumulator.Chunks[i].Response == nil || accumulator.Chunks[j].Response == nil {
-			// Push nils to the end deterministically
-			return accumulator.Chunks[j].Response != nil
+		ai, bi := chunkSortKey(accumulator.Chunks[i])
+		aj, bj := chunkSortKey(accumulator.Chunks[j])
+		if ai != aj {
+			return ai < aj
 		}
-		if accumulator.Chunks[i].Response.TextCompletionResponse != nil {
-			return accumulator.Chunks[i].Response.TextCompletionResponse.ExtraFields.ChunkIndex < accumulator.Chunks[j].Response.TextCompletionResponse.ExtraFields.ChunkIndex
-		}
-		if accumulator.Chunks[i].Response.ChatResponse != nil {
-			return accumulator.Chunks[i].Response.ChatResponse.ExtraFields.ChunkIndex < accumulator.Chunks[j].Response.ChatResponse.ExtraFields.ChunkIndex
-		}
-		if accumulator.Chunks[i].Response.ResponsesResponse != nil {
-			return accumulator.Chunks[i].Response.ResponsesResponse.ExtraFields.ChunkIndex < accumulator.Chunks[j].Response.ResponsesResponse.ExtraFields.ChunkIndex
-		}
-		if accumulator.Chunks[i].Response.ResponsesStreamResponse != nil {
-			return accumulator.Chunks[i].Response.ResponsesStreamResponse.ExtraFields.ChunkIndex < accumulator.Chunks[j].Response.ResponsesStreamResponse.ExtraFields.ChunkIndex
-		}
-		if accumulator.Chunks[i].Response.SpeechResponse != nil {
-			return accumulator.Chunks[i].Response.SpeechResponse.ExtraFields.ChunkIndex < accumulator.Chunks[j].Response.SpeechResponse.ExtraFields.ChunkIndex
-		}
-		if accumulator.Chunks[i].Response.SpeechStreamResponse != nil {
-			return accumulator.Chunks[i].Response.SpeechStreamResponse.ExtraFields.ChunkIndex < accumulator.Chunks[j].Response.SpeechStreamResponse.ExtraFields.ChunkIndex
-		}
-		if accumulator.Chunks[i].Response.TranscriptionResponse != nil {
-			return accumulator.Chunks[i].Response.TranscriptionResponse.ExtraFields.ChunkIndex < accumulator.Chunks[j].Response.TranscriptionResponse.ExtraFields.ChunkIndex
-		}
-		if accumulator.Chunks[i].Response.TranscriptionStreamResponse != nil {
-			return accumulator.Chunks[i].Response.TranscriptionStreamResponse.ExtraFields.ChunkIndex < accumulator.Chunks[j].Response.TranscriptionStreamResponse.ExtraFields.ChunkIndex
-		}
-		if accumulator.Chunks[i].Response.ImageGenerationStreamResponse != nil {
-			// For image generation, sort by Index first, then ChunkIndex
-			if accumulator.Chunks[i].Response.ImageGenerationStreamResponse.Index != accumulator.Chunks[j].Response.ImageGenerationStreamResponse.Index {
-				return accumulator.Chunks[i].Response.ImageGenerationStreamResponse.Index < accumulator.Chunks[j].Response.ImageGenerationStreamResponse.Index
-			}
-			return accumulator.Chunks[i].Response.ImageGenerationStreamResponse.ChunkIndex < accumulator.Chunks[j].Response.ImageGenerationStreamResponse.ChunkIndex
-		}
-		return false
+		return bi < bj
 	})
 
-	var streamResponses []string
+	streamResponses := make([]string, 0, len(accumulator.Chunks))
 	for i, chunk := range accumulator.Chunks {
-		if chunk.Response != nil {
-			chunkData, err := json.Marshal(chunk.Response)
-			if err != nil {
-				plugin.logger.Warn("%s Failed to marshal stream chunk %d: %v", PluginLoggerPrefix, i, err)
-				continue
-			}
-			streamResponses = append(streamResponses, string(chunkData))
+		if chunk.Response == nil {
+			continue
 		}
+		chunkData, err := json.Marshal(chunk.Response)
+		if err != nil {
+			plugin.logger.Warn("Failed to marshal stream chunk %d: %v", i, err)
+			continue
+		}
+		streamResponses = append(streamResponses, string(chunkData))
 	}
 
-	// STEP 3: Validate we have valid chunks to cache
 	if len(streamResponses) == 0 {
-		plugin.logger.Warn("%s Stream for request %s has no valid response chunks, skipping cache storage", PluginLoggerPrefix, requestID)
+		plugin.logger.Warn("Stream for request %s has no valid response chunks, skipping cache storage", requestID)
 		return nil
 	}
 
-	// STEP 4: Build final metadata and submit to .Add() method
-	finalMetadata := make(map[string]interface{})
+	finalMetadata := make(map[string]interface{}, len(accumulator.Metadata)+1)
 	for k, v := range accumulator.Metadata {
 		finalMetadata[k] = v
 	}
 	finalMetadata["stream_chunks"] = streamResponses
 
-	// Store complete unified entry using the final cache storage ID.
 	if err := plugin.store.Add(ctx, plugin.config.VectorStoreNamespace, accumulator.StorageID, accumulator.Embedding, finalMetadata); err != nil {
 		return fmt.Errorf("failed to store complete streaming cache entry: %w", err)
 	}
 
-	plugin.logger.Debug(fmt.Sprintf("%s Successfully cached complete stream with %d ordered chunks, ID: %s", PluginLoggerPrefix, len(streamResponses), accumulator.StorageID))
+	plugin.logger.Debug("Cached stream with %d chunks, storageID=%s", len(streamResponses), accumulator.StorageID)
 	return nil
 }
 
-// cleanupStreamAccumulator removes the stream accumulator for a request
+// cleanupStreamAccumulator drops the accumulator for requestID. Safe to call
+// when no entry exists.
 func (plugin *Plugin) cleanupStreamAccumulator(requestID string) {
 	plugin.streamAccumulators.Delete(requestID)
 }
 
-// cleanupOldStreamAccumulators removes stream accumulators older than 5 minutes
+// streamAccumulatorMaxAge is how long a stream accumulator may live without
+// reaching its final chunk before it's reaped by the periodic cleanup.
+const streamAccumulatorMaxAge = 5 * time.Minute
+
+// streamCleanupInterval bounds the worst-case staleness of an abandoned
+// accumulator to ~maxAge + interval.
+const streamCleanupInterval = 1 * time.Minute
+
+// cleanupOldStreamAccumulators reaps accumulators whose most recent chunk is
+// older than streamAccumulatorMaxAge. Called both periodically and at
+// shutdown to prevent abandoned streams (client disconnect, mid-stream
+// error) from accumulating in memory; reaping by LastSeenAt rather than
+// first-chunk time keeps long-running streams alive while they're still
+// receiving chunks.
 func (plugin *Plugin) cleanupOldStreamAccumulators() {
-	fiveMinutesAgo := time.Now().Add(-5 * time.Minute)
-	cleanedCount := 0
-	toDelete := make([]string, 0)
+	cutoff := time.Now().Add(-streamAccumulatorMaxAge)
+	var toDelete []string
 
 	plugin.streamAccumulators.Range(func(key, value interface{}) bool {
 		requestID := key.(string)
 		accumulator := value.(*StreamAccumulator)
-
-		// Check if this accumulator is old (no activity for 5 minutes)
 		accumulator.mu.Lock()
-		if len(accumulator.Chunks) > 0 {
-			firstChunkTime := accumulator.Chunks[0].Timestamp
-			if firstChunkTime.Before(fiveMinutesAgo) {
-				toDelete = append(toDelete, requestID)
-				plugin.logger.Debug(fmt.Sprintf("%s Cleaned up old stream accumulator for request %s", PluginLoggerPrefix, requestID))
-			}
+		if accumulator.LastSeenAt.Before(cutoff) {
+			toDelete = append(toDelete, requestID)
 		}
 		accumulator.mu.Unlock()
 		return true
 	})
 
-	// Delete outside the Range loop to avoid concurrent modification
 	for _, requestID := range toDelete {
 		plugin.streamAccumulators.Delete(requestID)
-		cleanedCount++
 	}
 
-	if cleanedCount > 0 {
-		plugin.logger.Debug(fmt.Sprintf("%s Cleaned up %d old stream accumulators", PluginLoggerPrefix, cleanedCount))
+	if len(toDelete) > 0 {
+		plugin.logger.Debug("Reaped %d stale stream accumulators", len(toDelete))
+	}
+}
+
+// runStreamCleanupLoop runs cleanupOldStreamAccumulators on a ticker until
+// stopCh is closed. Started by Init, stopped by Cleanup.
+func (plugin *Plugin) runStreamCleanupLoop() {
+	defer plugin.cleanupWg.Done()
+	ticker := time.NewTicker(streamCleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-plugin.stopCh:
+			return
+		case <-ticker.C:
+			plugin.cleanupOldStreamAccumulators()
+		}
 	}
 }

--- a/plugins/semanticcache/test_utils.go
+++ b/plugins/semanticcache/test_utils.go
@@ -4,14 +4,63 @@ import (
 	"context"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/vectorstore"
 	mocker "github.com/maximhq/bifrost/plugins/mocker"
 )
+
+// isTransientUpstreamError reports whether a BifrostError reflects a
+// transient upstream condition (timeout, rate-limit, 5xx) where skipping
+// the test is reasonable. All other errors — including missing API keys,
+// client-side issues, or non-HTTP failures — should fail the test rather
+// than mask regressions behind a green skip.
+func isTransientUpstreamError(err *schemas.BifrostError) bool {
+	if err == nil || err.StatusCode == nil {
+		return false
+	}
+	code := *err.StatusCode
+	return code == 408 || code == 425 || code == 429 || code >= 500
+}
+
+// withTestRequestID stamps a fresh BifrostContextKeyRequestID on the context.
+// Unit tests that call PreLLMHook/PostLLMHook directly need this so the plugin
+// can anchor per-request state. In integration tests the framework overwrites
+// it, so setting it here is safe in either path.
+func withTestRequestID(ctx *schemas.BifrostContext) *schemas.BifrostContext {
+	ctx.SetValue(schemas.BifrostContextKeyRequestID, uuid.NewString())
+	return ctx
+}
+
+// keyForTest returns a cache key namespaced by t.Name(). All tests should
+// derive their cache keys via this helper so two tests running in parallel
+// (t.Parallel) cannot see each other's entries through the shared Weaviate
+// namespace — direct lookups encode cache_key into the storage ID and
+// semantic search filters by it.
+//
+// Pass suffix="" for the most common single-key-per-test case. For tests
+// that exercise multiple distinct cache keys (e.g. cross-key isolation
+// tests), pass suffixes to disambiguate within the test.
+func keyForTest(t testing.TB, suffix string) string {
+	t.Helper()
+	if suffix == "" {
+		return t.Name()
+	}
+	return t.Name() + "/" + suffix
+}
+
+// newBaseTestContext returns a BifrostContext with a fresh request ID stamped.
+// Replaces bare schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+// in tests that call plugin.PreLLMHook / PostLLMHook directly — the plugin
+// requires a request ID to anchor per-request state.
+func newBaseTestContext() *schemas.BifrostContext {
+	return withTestRequestID(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline))
+}
 
 // getWeaviateConfigFromEnv retrieves Weaviate configuration from environment variables
 func getWeaviateConfigFromEnv() vectorstore.WeaviateConfig {
@@ -379,10 +428,43 @@ func NewTestSetupWithConfig(t *testing.T, config *Config) *TestSetup {
 	return NewTestSetupWithVectorStore(t, config, vectorstore.VectorStoreTypeWeaviate)
 }
 
+// SharedTestNamespace is the single Weaviate class all parallel tests share.
+// Mirrors production: many concurrent requests hit one namespace, isolated
+// by per-test cache_keys (see keyForTest). Distinct from the plugin's
+// production default so test runs can't collide with a real cache.
+const SharedTestNamespace = "BifrostSemanticCachePluginTest"
+
+var (
+	sharedTestNamespaceOnce sync.Once
+	sharedTestNamespaceErr  error
+)
+
+// ensureSharedTestNamespace creates the shared test class exactly once per
+// test process — sync.Once gates the TOCTOU race between concurrent
+// Plugin.Init calls (each of which would otherwise check-then-create against
+// the shared store and one would lose the race).
+//
+// Subsequent Plugin.Init calls in tests still invoke CreateNamespace, but the
+// vectorstore implementations short-circuit when the class already exists.
+func ensureSharedTestNamespace(ctx context.Context, store vectorstore.VectorStore, dim int) error {
+	sharedTestNamespaceOnce.Do(func() {
+		sharedTestNamespaceErr = store.CreateNamespace(ctx, SharedTestNamespace, dim, VectorStoreProperties)
+	})
+	return sharedTestNamespaceErr
+}
+
 // NewTestSetupWithVectorStore creates a new test setup with custom configuration and vector store type
 func NewTestSetupWithVectorStore(t *testing.T, config *Config, storeType vectorstore.VectorStoreType) *TestSetup {
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelDebug)
+
+	// All tests share one namespace; isolation comes from per-test cache_keys.
+	if config.VectorStoreNamespace == "" {
+		config.VectorStoreNamespace = SharedTestNamespace
+	}
+	// Tests must NOT delete the shared namespace at cleanup — other parallel
+	// tests are still using it. Override any caller default.
+	config.CleanUpOnShutdown = false
 
 	// Get the appropriate config for the vector store type
 	var storeConfig interface{}
@@ -406,6 +488,15 @@ func NewTestSetupWithVectorStore(t *testing.T, config *Config, storeType vectors
 	}, logger)
 	if err != nil {
 		t.Skipf("Vector store %s not available or failed to connect: %v", storeType, err)
+	}
+
+	// Pre-create the shared namespace exactly once across the test process so
+	// concurrent Plugin.Init calls don't lose the TOCTOU race inside the
+	// vector store driver (check-then-create).
+	preCreateCtx, preCreateCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer preCreateCancel()
+	if err := ensureSharedTestNamespace(preCreateCtx, store, config.Dimension); err != nil {
+		t.Fatalf("Failed to create shared test namespace: %v", err)
 	}
 
 	plugin, err := Init(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), config, logger, store)
@@ -534,13 +625,29 @@ func AssertNoCacheHit(t *testing.T, response *schemas.BifrostResponse) {
 	t.Log("✅ Response correctly not served from cache (cache_debug present but CacheHit=false)")
 }
 
-// WaitForCache waits for async cache operations to complete
+// WaitForCache waits for async cache operations to complete.
+//
+// WaitForPendingOperations now drains the writersWg accurately (every
+// PostLLMHook goroutine + the expired-entry async delete is tracked), so the
+// stored entries are guaranteed durable when this returns. The small sleep
+// below is a buffer for vector store index visibility on stores with eventual
+// consistency (Weaviate is usually immediate on single-node, but cloud or
+// multi-shard setups may need a tick to make the entry queryable).
+//
+// Override via SEMCACHE_TEST_INDEX_DELAY_MS for slower stores / CI.
 func WaitForCache(plugin schemas.LLMPlugin) {
 	if p, ok := plugin.(*Plugin); ok {
 		p.WaitForPendingOperations()
 	}
-	// Small buffer for Weaviate index consistency
-	time.Sleep(500 * time.Millisecond)
+	delayMs := 100
+	if v := os.Getenv("SEMCACHE_TEST_INDEX_DELAY_MS"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed >= 0 {
+			delayMs = parsed
+		}
+	}
+	if delayMs > 0 {
+		time.Sleep(time.Duration(delayMs) * time.Millisecond)
+	}
 }
 
 // CreateEmbeddingRequest creates an embedding request for testing
@@ -611,28 +718,30 @@ func CreateImageGenerationRequest(prompt string, size string, quality string) *s
 }
 
 // CreateContextWithCacheKey creates a context with the test cache key
-func CreateContextWithCacheKey(value string) *schemas.BifrostContext {
-	return schemas.NewBifrostContextWithValue(context.Background(), schemas.NoDeadline, CacheKey, value)
+// CreateContextWithCacheKey creates a context with a per-test cache key.
+// suffix may be "" for tests using only one cache key.
+func CreateContextWithCacheKey(t testing.TB, suffix string) *schemas.BifrostContext {
+	return withTestRequestID(schemas.NewBifrostContextWithValue(context.Background(), schemas.NoDeadline, CacheKey, keyForTest(t, suffix)))
 }
 
 // CreateContextWithCacheKeyAndType creates a context with cache key and cache type
-func CreateContextWithCacheKeyAndType(value string, cacheType CacheType) *schemas.BifrostContext {
-	return schemas.NewBifrostContextWithValue(context.Background(), schemas.NoDeadline, CacheKey, value).WithValue(CacheTypeKey, cacheType)
+func CreateContextWithCacheKeyAndType(t testing.TB, suffix string, cacheType CacheType) *schemas.BifrostContext {
+	return withTestRequestID(schemas.NewBifrostContextWithValue(context.Background(), schemas.NoDeadline, CacheKey, keyForTest(t, suffix)).WithValue(CacheTypeKey, cacheType))
 }
 
 // CreateContextWithCacheKeyAndTTL creates a context with cache key and custom TTL
-func CreateContextWithCacheKeyAndTTL(value string, ttl time.Duration) *schemas.BifrostContext {
-	return schemas.NewBifrostContextWithValue(context.Background(), schemas.NoDeadline, CacheKey, value).WithValue(CacheTTLKey, ttl)
+func CreateContextWithCacheKeyAndTTL(t testing.TB, suffix string, ttl time.Duration) *schemas.BifrostContext {
+	return withTestRequestID(schemas.NewBifrostContextWithValue(context.Background(), schemas.NoDeadline, CacheKey, keyForTest(t, suffix)).WithValue(CacheTTLKey, ttl))
 }
 
 // CreateContextWithCacheKeyAndThreshold creates a context with cache key and custom threshold
-func CreateContextWithCacheKeyAndThreshold(value string, threshold float64) *schemas.BifrostContext {
-	return schemas.NewBifrostContext(context.Background(), schemas.NoDeadline).WithValue(CacheKey, value).WithValue(CacheThresholdKey, threshold)
+func CreateContextWithCacheKeyAndThreshold(t testing.TB, suffix string, threshold float64) *schemas.BifrostContext {
+	return withTestRequestID(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline).WithValue(CacheKey, keyForTest(t, suffix)).WithValue(CacheThresholdKey, threshold))
 }
 
 // CreateContextWithCacheKeyAndNoStore creates a context with cache key and no-store flag
-func CreateContextWithCacheKeyAndNoStore(value string, noStore bool) *schemas.BifrostContext {
-	return schemas.NewBifrostContext(context.Background(), schemas.NoDeadline).WithValue(CacheKey, value).WithValue(CacheNoStoreKey, noStore)
+func CreateContextWithCacheKeyAndNoStore(t testing.TB, suffix string, noStore bool) *schemas.BifrostContext {
+	return withTestRequestID(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline).WithValue(CacheKey, keyForTest(t, suffix)).WithValue(CacheNoStoreKey, noStore))
 }
 
 // CreateTestSetupWithConversationThreshold creates a test setup with custom conversation history threshold

--- a/plugins/semanticcache/utils.go
+++ b/plugins/semanticcache/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"sort"
 	"strings"
 	"time"
 
@@ -14,205 +15,11 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// directCacheNamespace is a fixed UUID v5 namespace used for deterministic direct cache ID generation.
-// Using a fixed namespace ensures IDs are reproducible across restarts and store types.
+// directCacheNamespace is a fixed namespace UUID for generating deterministic
+// UUID v5 cache IDs via uuid.NewSHA1, used by generateDirectCacheID. The
+// bytes are arbitrary — they only need to be stable across restarts so the
+// same (cache_key, request_hash, params_hash) tuple maps to the same ID.
 var directCacheNamespace = uuid.MustParse("b1f3c2d4-e5a6-7890-abcd-ef1234567890")
-
-// normalizeText applies consistent normalization to text inputs for better cache hit rates.
-// It converts text to lowercase and trims whitespace to reduce cache misses due to minor variations.
-func normalizeText(text string) string {
-	return strings.ToLower(strings.TrimSpace(text))
-}
-
-// Semantic cache keeps vector-store/search payloads as float32 even though
-// normalized embedding API responses now preserve provider precision as float64.
-func toFloat32Embedding(values []float64) []float32 {
-	if len(values) == 0 {
-		return nil
-	}
-
-	embedding := make([]float32, len(values))
-	for i, value := range values {
-		embedding[i] = float32(value)
-	}
-
-	return embedding
-}
-
-func flattenToFloat32Embedding(values [][]float64) []float32 {
-	total := 0
-	for _, arr := range values {
-		total += len(arr)
-	}
-	if total == 0 {
-		return nil
-	}
-
-	embedding := make([]float32, 0, total)
-	for _, arr := range values {
-		embedding = append(embedding, toFloat32Embedding(arr)...)
-	}
-
-	return embedding
-}
-
-// generateEmbedding generates an embedding for the given text using the configured provider.
-func (plugin *Plugin) generateEmbedding(ctx *schemas.BifrostContext, text string) ([]float32, int, error) {
-	// Create embedding request
-	embeddingReq := &schemas.BifrostEmbeddingRequest{
-		Provider: plugin.config.Provider,
-		Model:    plugin.config.EmbeddingModel,
-		Input: &schemas.EmbeddingInput{
-			Text: &text,
-		},
-	}
-
-	// Create a new context from incoming context. Parent ctx will be used for cancellation.
-	embeddingCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
-	defer embeddingCtx.ReleasePluginScope()
-
-	embeddingCtx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
-
-	if plugin.embeddingRequestExecutor == nil {
-		return nil, 0, fmt.Errorf("embedding request executor is not configured")
-	}
-	response, err := plugin.embeddingRequestExecutor(embeddingCtx, embeddingReq)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to generate embedding: %v", err)
-	}
-
-	// Extract the first embedding from response
-	if len(response.Data) == 0 {
-		return nil, 0, fmt.Errorf("no embeddings returned from provider")
-	}
-
-	// Get the embedding from the first data item
-	embedding := response.Data[0].Embedding
-	inputTokens := 0
-	if response.Usage != nil {
-		inputTokens = response.Usage.TotalTokens
-	}
-
-	if embedding.EmbeddingStr != nil {
-		// decode embedding.EmbeddingStr to []float32
-		var vals []float32
-		if err := json.Unmarshal([]byte(*embedding.EmbeddingStr), &vals); err != nil {
-			return nil, 0, fmt.Errorf("failed to parse string embedding: %w", err)
-		}
-		return vals, inputTokens, nil
-	} else if embedding.EmbeddingArray != nil {
-		return toFloat32Embedding(embedding.EmbeddingArray), inputTokens, nil
-	} else if len(embedding.Embedding2DArray) > 0 {
-		return flattenToFloat32Embedding(embedding.Embedding2DArray), inputTokens, nil
-	}
-
-	return nil, 0, fmt.Errorf("embedding data is not in expected format")
-}
-
-// generateRequestHash creates an xxhash of the request for semantic cache key generation.
-// It normalizes the request by including all relevant fields that affect the response:
-// - Input (chat completion, text completion, etc.)
-// - Parameters (temperature, max_tokens, tools, etc.)
-// - Provider (if CacheByProvider is true)
-// - Model (if CacheByModel is true)
-//
-// Note: Fallbacks are excluded as they only affect error handling, not the actual response.
-//
-// Parameters:
-//   - req: The Bifrost request to hash for semantic cache key generation
-//
-// Returns:
-//   - string: Hexadecimal representation of the xxhash
-//   - error: Any error that occurred during request normalization or hashing
-func (plugin *Plugin) generateRequestHash(req *schemas.BifrostRequest) (string, error) {
-	// Build canonical metadata first to ensure deterministic hashing
-	metadata, err := plugin.buildRequestMetadataForCaching(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to build metadata for request hash: %w", err)
-	}
-
-	// Create a hash input structure that includes both input and canonical parameters
-	hashInput := struct {
-		Input  interface{}            `json:"input"`
-		Params map[string]interface{} `json:"params,omitempty"`
-	}{
-		Input:  plugin.getNormalizedInputForCaching(req),
-		Params: metadata,
-	}
-
-	// Marshal to JSON with deeply sorted keys for deterministic hashing
-	// MarshalDeeplySorted handles OrderedMap and nested map[string]interface{} correctly
-	jsonData, err := schemas.MarshalDeeplySorted(hashInput)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal request for hashing: %w", err)
-	}
-
-	// Generate hash based on configured algorithm
-	hash := xxhash.Sum64(jsonData)
-	return fmt.Sprintf("%x", hash), nil
-}
-
-func (plugin *Plugin) buildRequestMetadataForCaching(req *schemas.BifrostRequest) (map[string]interface{}, error) {
-	metadata := map[string]interface{}{
-		"stream": bifrost.IsStreamRequestType(req.RequestType),
-	}
-
-	switch req.RequestType {
-	case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
-		if req.TextCompletionRequest == nil {
-			return nil, fmt.Errorf("text completion payload is nil (%s)", describeRequestShape(req))
-		}
-		if req.TextCompletionRequest != nil && req.TextCompletionRequest.Params != nil {
-			plugin.extractTextCompletionParametersToMetadata(req.TextCompletionRequest.Params, metadata)
-		}
-	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
-		if req.ChatRequest == nil {
-			return nil, fmt.Errorf("chat payload is nil (%s)", describeRequestShape(req))
-		}
-		if req.ChatRequest != nil && req.ChatRequest.Params != nil {
-			plugin.extractChatParametersToMetadata(req.ChatRequest.Params, metadata)
-		}
-	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest:
-		if req.ResponsesRequest == nil {
-			return nil, fmt.Errorf("responses payload is nil (%s)", describeRequestShape(req))
-		}
-		if req.ResponsesRequest != nil && req.ResponsesRequest.Params != nil {
-			plugin.extractResponsesParametersToMetadata(req.ResponsesRequest.Params, metadata)
-		}
-	case schemas.SpeechRequest, schemas.SpeechStreamRequest:
-		if req.SpeechRequest == nil {
-			return nil, fmt.Errorf("speech payload is nil (%s)", describeRequestShape(req))
-		}
-		if req.SpeechRequest != nil && req.SpeechRequest.Params != nil {
-			plugin.extractSpeechParametersToMetadata(req.SpeechRequest.Params, metadata)
-		}
-	case schemas.EmbeddingRequest:
-		if req.EmbeddingRequest == nil {
-			return nil, fmt.Errorf("embedding payload is nil (%s)", describeRequestShape(req))
-		}
-		if req.EmbeddingRequest != nil && req.EmbeddingRequest.Params != nil {
-			plugin.extractEmbeddingParametersToMetadata(req.EmbeddingRequest.Params, metadata)
-		}
-	case schemas.TranscriptionRequest, schemas.TranscriptionStreamRequest:
-		if req.TranscriptionRequest == nil {
-			return nil, fmt.Errorf("transcription payload is nil (%s)", describeRequestShape(req))
-		}
-		if req.TranscriptionRequest != nil && req.TranscriptionRequest.Params != nil {
-			plugin.extractTranscriptionParametersToMetadata(req.TranscriptionRequest.Params, metadata)
-		}
-	case schemas.ImageGenerationRequest, schemas.ImageGenerationStreamRequest:
-		if req.ImageGenerationRequest == nil {
-			return nil, fmt.Errorf("image generation payload is nil (%s)", describeRequestShape(req))
-		}
-		if req.ImageGenerationRequest != nil && req.ImageGenerationRequest.Params != nil {
-			plugin.extractImageGenerationParametersToMetadata(req.ImageGenerationRequest.Params, metadata)
-		}
-	default:
-		return nil, fmt.Errorf("unsupported request type for semantic caching (%s)", describeRequestShape(req))
-	}
-
-	return metadata, nil
-}
 
 // isSemanticCacheSupportedRequestType reports whether semantic cache supports
 // this request type for cache lookup and storage. Unsupported types are skipped.
@@ -241,153 +48,356 @@ func isSemanticCacheSupportedRequestType(requestType schemas.RequestType) bool {
 	}
 }
 
-func (plugin *Plugin) computeRequestParamsHash(req *schemas.BifrostRequest) (string, error) {
-	metadata, err := plugin.buildRequestMetadataForCaching(req)
+// hashSortedSet returns a deterministic hex hash for an order-insensitive
+// list of items. Some request fields are semantically sets but JSON-encoded
+// as lists (most notably Tools, where MCP's randomized map iteration would
+// otherwise perturb the request hash). The caller supplies a key extractor
+// because shapes differ across fields (e.g. ChatTool.Function.Name vs
+// ResponsesTool.Name). Use this for set-shaped fields large enough to be
+// worth compressing; for short []string sets, prefer sortedStringSet which
+// keeps the metadata human-debuggable.
+func hashSortedSet[T any](items []T, key func(T) string) (string, error) {
+	if len(items) == 0 {
+		return "", nil
+	}
+	sorted := make([]T, len(items))
+	copy(sorted, items)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return key(sorted[i]) < key(sorted[j])
+	})
+	payload := make([]any, len(sorted))
+	for i, t := range sorted {
+		payload[i] = t
+	}
+	itemsJSON, err := schemas.MarshalDeeplySorted(payload)
 	if err != nil {
 		return "", err
 	}
+	return fmt.Sprintf("%x", xxhash.Sum64(itemsJSON)), nil
+}
 
-	hash, err := getMetadataHash(metadata)
+// hashMap returns a deterministic xxhash hex digest of the map. Uses
+// MarshalDeeplySorted because plain json.Marshal doesn't guarantee key
+// ordering on Go maps.
+func hashMap(m map[string]interface{}) (string, error) {
+	jsonData, err := schemas.MarshalDeeplySorted(m)
 	if err != nil {
-		return "", fmt.Errorf("failed to compute params hash (%s): %w", describeRequestShape(req), err)
+		return "", fmt.Errorf("failed to marshal metadata for metadata hash: %w", err)
 	}
-	return hash, nil
+	return fmt.Sprintf("%x", xxhash.Sum64(jsonData)), nil
 }
 
-// describeRequestShape summarizes the request families relevant to semantic
-// cache lookups and diagnostics. It is intentionally scoped to request types
-// that can participate in semantic cache behavior.
-func describeRequestShape(req *schemas.BifrostRequest) string {
-	if req == nil {
-		return "request=nil"
+// sortedStringSet returns a sorted copy of a string slice that is semantically
+// a set (e.g. modalities, stop sequences, include flags). Sorting in place
+// would mutate the caller's parameters, so a copy is returned.
+func sortedStringSet(values []string) []string {
+	if len(values) == 0 {
+		return nil
 	}
-
-	return fmt.Sprintf(
-		"request_type=%s text=%t chat=%t responses=%t embedding=%t speech=%t transcription=%t image=%t",
-		req.RequestType,
-		req.TextCompletionRequest != nil,
-		req.ChatRequest != nil,
-		req.ResponsesRequest != nil,
-		req.EmbeddingRequest != nil,
-		req.SpeechRequest != nil,
-		req.TranscriptionRequest != nil,
-		req.ImageGenerationRequest != nil,
-	)
+	sorted := make([]string, len(values))
+	copy(sorted, values)
+	sort.Strings(sorted)
+	return sorted
 }
 
-// extractTextForEmbedding extracts meaningful text from different input types for embedding generation.
-// Returns the text to embed and metadata for storage.
+// putIfSet writes m[key] = *v when v is non-nil. Used by extract*ParametersToMetadata
+// to collapse the if-nil-set boilerplate that dominates those functions.
+func putIfSet[T any](m map[string]any, key string, v *T) {
+	if v != nil {
+		m[key] = *v
+	}
+}
+
+// putSortedSetIfNonEmpty writes m[key] = sortedStringSet(values) when values
+// has any entries — otherwise leaves the key absent so the resulting metadata
+// hash treats "unset" and "empty" identically.
+func putSortedSetIfNonEmpty(m map[string]any, key string, values []string) {
+	if len(values) > 0 {
+		m[key] = sortedStringSet(values)
+	}
+}
+
+// normalizeText applies consistent normalization to text inputs for better cache hit rates.
+// It converts text to lowercase and trims whitespace to reduce cache misses due to minor variations.
+func normalizeText(text string) string {
+	return strings.ToLower(strings.TrimSpace(text))
+}
+
+// float64ToFloat32Embedding converts a []float64 to a []float32. The semantic cache
+// keeps vector payloads as float32 even though the embedding APIs now
+// preserve full float64 precision — the cosine similarity used at query
+// time is well within float32 range.
+func float64ToFloat32Embedding(values []float64) []float32 {
+	if len(values) == 0 {
+		return nil
+	}
+
+	embedding := make([]float32, len(values))
+	for i, value := range values {
+		embedding[i] = float32(value)
+	}
+
+	return embedding
+}
+
+// int8ToFloat32Embedding promotes a quantized int8 embedding (used for
+// binary/quantized formats by some providers) to float32 so the cache can
+// store and compare it uniformly against float32 entries.
+func int8ToFloat32Embedding(values []int8) []float32 {
+	if len(values) == 0 {
+		return nil
+	}
+	embedding := make([]float32, len(values))
+	for i, value := range values {
+		embedding[i] = float32(value)
+	}
+	return embedding
+}
+
+// int32ToFloat32Embedding promotes a uint8/ubinary-style int32 embedding to
+// float32 for the same reason as int8ToFloat32Embedding.
+func int32ToFloat32Embedding(values []int32) []float32 {
+	if len(values) == 0 {
+		return nil
+	}
+	embedding := make([]float32, len(values))
+	for i, value := range values {
+		embedding[i] = float32(value)
+	}
+	return embedding
+}
+
+// flattenToFloat32Embedding concatenates a 2D embedding (one inner slice per
+// input chunk) into a single flat []float32. Used when the provider returns
+// per-chunk embeddings that we want to store as a single vector.
+func flattenToFloat32Embedding(values [][]float64) []float32 {
+	total := 0
+	for _, arr := range values {
+		total += len(arr)
+	}
+	if total == 0 {
+		return nil
+	}
+
+	embedding := make([]float32, 0, total)
+	for _, arr := range values {
+		embedding = append(embedding, float64ToFloat32Embedding(arr)...)
+	}
+
+	return embedding
+}
+
+// buildRequestMetadataForCaching extracts the canonical, hashable parameter
+// set for the request: anything that should change the cache key when it
+// changes. The returned map is fed to hashMap to derive params_hash, which
+// then anchors both direct and semantic lookups.
+func (plugin *Plugin) buildRequestMetadataForCaching(state *cacheState, req *schemas.BifrostRequest) (map[string]interface{}, error) {
+	metadata := map[string]interface{}{
+		"stream": bifrost.IsStreamRequestType(req.RequestType),
+	}
+
+	if attachments := plugin.extractAttachmentsForCaching(state, req); len(attachments) > 0 {
+		metadata["attachments"] = attachments
+	}
+
+	switch req.RequestType {
+	case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
+		if req.TextCompletionRequest == nil {
+			return nil, fmt.Errorf("text completion payload is nil")
+		}
+		if req.TextCompletionRequest != nil && req.TextCompletionRequest.Params != nil {
+			plugin.extractTextCompletionParametersToMetadata(req.TextCompletionRequest.Params, metadata)
+		}
+	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
+		if req.ChatRequest == nil {
+			return nil, fmt.Errorf("chat payload is nil")
+		}
+		if req.ChatRequest != nil && req.ChatRequest.Params != nil {
+			plugin.extractChatParametersToMetadata(req.ChatRequest.Params, metadata)
+		}
+	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest:
+		if req.ResponsesRequest == nil {
+			return nil, fmt.Errorf("responses payload is nil")
+		}
+		if req.ResponsesRequest != nil && req.ResponsesRequest.Params != nil {
+			plugin.extractResponsesParametersToMetadata(req.ResponsesRequest.Params, metadata)
+		}
+	case schemas.SpeechRequest, schemas.SpeechStreamRequest:
+		if req.SpeechRequest == nil {
+			return nil, fmt.Errorf("speech payload is nil")
+		}
+		if req.SpeechRequest != nil && req.SpeechRequest.Params != nil {
+			plugin.extractSpeechParametersToMetadata(req.SpeechRequest.Params, metadata)
+		}
+	case schemas.EmbeddingRequest:
+		if req.EmbeddingRequest == nil {
+			return nil, fmt.Errorf("embedding payload is nil")
+		}
+		if req.EmbeddingRequest != nil && req.EmbeddingRequest.Params != nil {
+			plugin.extractEmbeddingParametersToMetadata(req.EmbeddingRequest.Params, metadata)
+		}
+	case schemas.TranscriptionRequest, schemas.TranscriptionStreamRequest:
+		if req.TranscriptionRequest == nil {
+			return nil, fmt.Errorf("transcription payload is nil")
+		}
+		if req.TranscriptionRequest != nil && req.TranscriptionRequest.Params != nil {
+			plugin.extractTranscriptionParametersToMetadata(req.TranscriptionRequest.Params, metadata)
+		}
+	case schemas.ImageGenerationRequest, schemas.ImageGenerationStreamRequest:
+		if req.ImageGenerationRequest == nil {
+			return nil, fmt.Errorf("image generation payload is nil")
+		}
+		if req.ImageGenerationRequest != nil && req.ImageGenerationRequest.Params != nil {
+			plugin.extractImageGenerationParametersToMetadata(req.ImageGenerationRequest.Params, metadata)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported request type for semantic caching")
+	}
+
+	return metadata, nil
+}
+
+// extractAttachmentsForCaching collects image/file URLs referenced by the
+// request input in document order. Attachments are part of the cache key —
+// two messages with identical text but different images must not collide.
+// Honors ExcludeSystemPrompt via getInputForCaching. Returns nil for
+// request types without attachment-bearing content blocks.
+func (plugin *Plugin) extractAttachmentsForCaching(state *cacheState, req *schemas.BifrostRequest) []string {
+	switch req.RequestType {
+	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
+		messages, ok := plugin.getInputForCaching(state, req).([]schemas.ChatMessage)
+		if !ok {
+			return nil
+		}
+		var attachments []string
+		for _, msg := range messages {
+			if msg.Content == nil || msg.Content.ContentBlocks == nil {
+				continue
+			}
+			for _, block := range msg.Content.ContentBlocks {
+				if block.ImageURLStruct != nil && block.ImageURLStruct.URL != "" {
+					attachments = append(attachments, block.ImageURLStruct.URL)
+				}
+			}
+		}
+		return attachments
+	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest:
+		messages, ok := plugin.getInputForCaching(state, req).([]schemas.ResponsesMessage)
+		if !ok {
+			return nil
+		}
+		var attachments []string
+		for _, msg := range messages {
+			if msg.Content == nil || msg.Content.ContentBlocks == nil {
+				continue
+			}
+			for _, block := range msg.Content.ContentBlocks {
+				if block.ResponsesInputMessageContentBlockImage != nil && block.ResponsesInputMessageContentBlockImage.ImageURL != nil {
+					attachments = append(attachments, *block.ResponsesInputMessageContentBlockImage.ImageURL)
+				}
+				if block.ResponsesInputMessageContentBlockFile != nil && block.ResponsesInputMessageContentBlockFile.FileURL != nil {
+					attachments = append(attachments, *block.ResponsesInputMessageContentBlockFile.FileURL)
+				}
+			}
+		}
+		return attachments
+	}
+	return nil
+}
+
+// extractChatMessageContent flattens a ChatMessage's content (string or
+// blocks) into a single space-joined string. Returns "" when the message
+// carries no text (e.g. assistant tool-call messages with nil content).
+func extractChatMessageContent(msg schemas.ChatMessage) string {
+	if msg.Content == nil {
+		return ""
+	}
+	if msg.Content.ContentStr != nil {
+		return *msg.Content.ContentStr
+	}
+	if msg.Content.ContentBlocks != nil {
+		var parts []string
+		for _, block := range msg.Content.ContentBlocks {
+			if block.Text != nil {
+				parts = append(parts, *block.Text)
+			}
+		}
+		return strings.Join(parts, " ")
+	}
+	return ""
+}
+
+// extractResponsesMessageContent flattens a ResponsesMessage's content into a
+// single string, mirroring extractChatMessageContent but for the Responses API.
+func extractResponsesMessageContent(msg schemas.ResponsesMessage) string {
+	if msg.Content == nil {
+		return ""
+	}
+	if msg.Content.ContentStr != nil {
+		return *msg.Content.ContentStr
+	}
+	if msg.Content.ContentBlocks != nil {
+		var parts []string
+		for _, block := range msg.Content.ContentBlocks {
+			if block.Text != nil {
+				parts = append(parts, *block.Text)
+			}
+		}
+		return strings.Join(parts, " ")
+	}
+	return ""
+}
+
+// extractTextForEmbedding flattens the request input into a single string
+// suitable for embedding generation. PreLLMHook short-circuits embedding and
+// transcription requests before this is called (their inputs aren't
+// themselves embeddable), so this function only handles request types that
+// reach performSemanticSearch.
 //
 // Text serialization format (for cache consistency):
 //   - Chat API: "role: content"
 //   - Responses API: "role: msgType: content" (when msgType is present), "role: content" (when msgType is empty)
-//
-// Note: Format updated to conditionally include msgType to avoid double colons and maintain consistency.
-func (plugin *Plugin) extractTextForEmbedding(req *schemas.BifrostRequest) (string, string, error) {
-	metadata, err := plugin.buildRequestMetadataForCaching(req)
-	if err != nil {
-		return "", "", err
-	}
-	attachments := []string{}
-
+func (plugin *Plugin) extractTextForEmbedding(state *cacheState, req *schemas.BifrostRequest) (string, error) {
 	switch {
 	case req.TextCompletionRequest != nil:
-		metadataHash, err := getMetadataHash(metadata)
-		if err != nil {
-			return "", "", fmt.Errorf("failed to marshal metadata for metadata hash: %w", err)
-		}
-
-		var textContent string
 		if req.TextCompletionRequest.Input.PromptStr != nil {
-			textContent = normalizeText(*req.TextCompletionRequest.Input.PromptStr)
-		} else if len(req.TextCompletionRequest.Input.PromptArray) > 0 {
-			textContent = normalizeText(strings.Join(req.TextCompletionRequest.Input.PromptArray, " "))
+			return normalizeText(*req.TextCompletionRequest.Input.PromptStr), nil
 		}
-		return textContent, metadataHash, nil
+		if len(req.TextCompletionRequest.Input.PromptArray) > 0 {
+			return normalizeText(strings.Join(req.TextCompletionRequest.Input.PromptArray, " ")), nil
+		}
+		return "", fmt.Errorf("no prompt found in text completion request")
 
 	case req.ChatRequest != nil:
-		reqInput, ok := plugin.getInputForCaching(req).([]schemas.ChatMessage)
+		reqInput, ok := plugin.getInputForCaching(state, req).([]schemas.ChatMessage)
 		if !ok {
-			return "", "", fmt.Errorf("failed to cast request input to chat messages")
+			return "", fmt.Errorf("failed to cast request input to chat messages")
 		}
-
-		// Serialize chat messages for embedding
 		var textParts []string
 		for _, msg := range reqInput {
-			// Extract content as string
-			// Content can be nil for messages like assistant tool-call messages
-			var content string
-			if msg.Content != nil {
-				if msg.Content.ContentStr != nil {
-					content = *msg.Content.ContentStr
-				} else if msg.Content.ContentBlocks != nil {
-					// For content blocks, extract text parts
-					var blockTexts []string
-					for _, block := range msg.Content.ContentBlocks {
-						if block.Text != nil {
-							blockTexts = append(blockTexts, *block.Text)
-						}
-						if block.ImageURLStruct != nil && block.ImageURLStruct.URL != "" {
-							attachments = append(attachments, block.ImageURLStruct.URL)
-						}
-					}
-					content = strings.Join(blockTexts, " ")
-				}
+			content := extractChatMessageContent(msg)
+			if content == "" {
+				continue
 			}
-
-			if content != "" {
-				textParts = append(textParts, fmt.Sprintf("%s: %s", msg.Role, normalizeText(content)))
-			}
+			textParts = append(textParts, fmt.Sprintf("%s: %s", msg.Role, normalizeText(content)))
 		}
-
 		if len(textParts) == 0 {
-			return "", "", fmt.Errorf("no text content found in chat messages")
+			return "", fmt.Errorf("no text content found in chat messages")
 		}
-
-		if len(attachments) > 0 {
-			metadata["attachments"] = attachments
-		}
-
-		metadataHash, err := getMetadataHash(metadata)
-		if err != nil {
-			return "", "", fmt.Errorf("failed to marshal metadata for metadata hash: %w", err)
-		}
-
-		return strings.Join(textParts, "\n"), metadataHash, nil
+		return strings.Join(textParts, "\n"), nil
 
 	case req.ResponsesRequest != nil:
-		reqInput, ok := plugin.getInputForCaching(req).([]schemas.ResponsesMessage)
+		reqInput, ok := plugin.getInputForCaching(state, req).([]schemas.ResponsesMessage)
 		if !ok {
-			return "", "", fmt.Errorf("failed to cast request input to responses messages")
+			return "", fmt.Errorf("failed to cast request input to responses messages")
 		}
-
-		// Serialize chat messages for embedding
 		var textParts []string
 		for _, msg := range reqInput {
-			// Extract content as string
-			// Content can be nil for messages like assistant tool-call messages
-			var content string
-			if msg.Content != nil {
-				if msg.Content.ContentStr != nil {
-					content = normalizeText(*msg.Content.ContentStr)
-				} else if msg.Content.ContentBlocks != nil {
-					// For content blocks, extract text parts
-					var blockTexts []string
-					for _, block := range msg.Content.ContentBlocks {
-						if block.Text != nil {
-							blockTexts = append(blockTexts, normalizeText(*block.Text))
-						}
-						if block.ResponsesInputMessageContentBlockImage != nil && block.ResponsesInputMessageContentBlockImage.ImageURL != nil {
-							attachments = append(attachments, *block.ResponsesInputMessageContentBlockImage.ImageURL)
-						}
-						if block.ResponsesInputMessageContentBlockFile != nil && block.ResponsesInputMessageContentBlockFile.FileURL != nil {
-							attachments = append(attachments, *block.ResponsesInputMessageContentBlockFile.FileURL)
-						}
-					}
-					content = strings.Join(blockTexts, " ")
-				}
+			content := extractResponsesMessageContent(msg)
+			if content == "" {
+				continue
 			}
-
+			content = normalizeText(content)
 			role := ""
 			msgType := ""
 			if msg.Role != nil {
@@ -396,396 +406,291 @@ func (plugin *Plugin) extractTextForEmbedding(req *schemas.BifrostRequest) (stri
 			if msg.Type != nil {
 				msgType = string(*msg.Type)
 			}
-
-			if content != "" {
-				if msgType != "" {
-					textParts = append(textParts, fmt.Sprintf("%s: %s: %s", role, msgType, content))
-				} else {
-					textParts = append(textParts, fmt.Sprintf("%s: %s", role, content))
-				}
+			if msgType != "" {
+				textParts = append(textParts, fmt.Sprintf("%s: %s: %s", role, msgType, content))
+			} else {
+				textParts = append(textParts, fmt.Sprintf("%s: %s", role, content))
 			}
 		}
-
 		if len(textParts) == 0 {
-			return "", "", fmt.Errorf("no text content found in chat messages")
+			return "", fmt.Errorf("no text content found in responses messages")
 		}
-
-		if len(attachments) > 0 {
-			metadata["attachments"] = attachments
-		}
-
-		metadataHash, err := getMetadataHash(metadata)
-		if err != nil {
-			return "", "", fmt.Errorf("failed to marshal metadata for metadata hash: %w", err)
-		}
-
-		return strings.Join(textParts, "\n"), metadataHash, nil
+		return strings.Join(textParts, "\n"), nil
 
 	case req.SpeechRequest != nil:
-		if req.SpeechRequest.Input.Input != "" {
-			metadataHash, err := getMetadataHash(metadata)
-			if err != nil {
-				return "", "", fmt.Errorf("failed to marshal metadata for metadata hash: %w", err)
-			}
-
-			return req.SpeechRequest.Input.Input, metadataHash, nil
+		if req.SpeechRequest.Input.Input == "" {
+			return "", fmt.Errorf("no input text found in speech request")
 		}
-		return "", "", fmt.Errorf("no input text found in speech request")
-
-	case req.EmbeddingRequest != nil:
-		metadataHash, err := getMetadataHash(metadata)
-		if err != nil {
-			return "", "", fmt.Errorf("failed to marshal metadata for metadata hash: %w", err)
-		}
-
-		texts := req.EmbeddingRequest.Input.Texts
-
-		if len(texts) == 0 && req.EmbeddingRequest.Input.Text != nil {
-			texts = []string{*req.EmbeddingRequest.Input.Text}
-		}
-
-		var text string
-		for _, t := range texts {
-			text += t + " "
-		}
-
-		return strings.TrimSpace(text), metadataHash, nil
-
-	case req.TranscriptionRequest != nil:
-		// Skip semantic caching for transcription requests
-		return "", "", fmt.Errorf("transcription requests are not supported for semantic caching")
+		return normalizeText(req.SpeechRequest.Input.Input), nil
 
 	case req.ImageGenerationRequest != nil:
 		if req.ImageGenerationRequest.Input == nil || req.ImageGenerationRequest.Input.Prompt == "" {
-			return "", "", fmt.Errorf("no prompt found in image generation request")
+			return "", fmt.Errorf("no prompt found in image generation request")
 		}
-		metadataHash, err := getMetadataHash(metadata)
-		if err != nil {
-			return "", "", fmt.Errorf("failed to marshal metadata for metadata hash: %w", err)
-		}
-		return normalizeText(req.ImageGenerationRequest.Input.Prompt), metadataHash, nil
+		return normalizeText(req.ImageGenerationRequest.Input.Prompt), nil
 
 	default:
-		return "", "", fmt.Errorf("unsupported input type for semantic caching (%s)", describeRequestShape(req))
+		return "", fmt.Errorf("unsupported input type for semantic caching")
 	}
 }
 
-func getMetadataHash(metadata map[string]interface{}) (string, error) {
-	// Use MarshalDeeplySorted for deterministic hashing - plain json.Marshal
-	// doesn't guarantee key ordering since Go maps have random iteration order
-	metadataJSON, err := schemas.MarshalDeeplySorted(metadata)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal metadata for metadata hash: %w", err)
-	}
-	return fmt.Sprintf("%x", xxhash.Sum64(metadataJSON)), nil
-}
-
-func (plugin *Plugin) generateDirectCacheID(provider schemas.ModelProvider, model string, cacheKey string, requestHash string, paramsHash string) string {
-	idInput := struct {
-		CacheKey    string `json:"cache_key"`
-		RequestHash string `json:"request_hash"`
-		ParamsHash  string `json:"params_hash"`
-		Provider    string `json:"provider,omitempty"`
-		Model       string `json:"model,omitempty"`
-	}{
-		CacheKey:    cacheKey,
-		RequestHash: requestHash,
-		ParamsHash:  paramsHash,
-	}
-
-	if plugin.config.CacheByProvider != nil && *plugin.config.CacheByProvider {
-		idInput.Provider = string(provider)
-	}
-	if plugin.config.CacheByModel != nil && *plugin.config.CacheByModel {
-		idInput.Model = model
-	}
-
-	idJSON, err := schemas.MarshalDeeplySorted(idInput)
-	if err != nil {
-		// Fallback: derive deterministic UUID from concatenated inputs
-		fallbackStr := cacheKey + requestHash + paramsHash
-		if plugin.config.CacheByProvider != nil && *plugin.config.CacheByProvider {
-			fallbackStr += string(provider)
-		}
-		if plugin.config.CacheByModel != nil && *plugin.config.CacheByModel {
-			fallbackStr += model
-		}
-		return uuid.NewSHA1(directCacheNamespace, []byte(fallbackStr)).String()
-	}
-
-	return uuid.NewSHA1(directCacheNamespace, idJSON).String()
-}
-
-// buildUnifiedMetadata constructs the unified metadata structure for VectorEntry
-func (plugin *Plugin) buildUnifiedMetadata(provider schemas.ModelProvider, model string, paramsHash string, requestHash string, cacheKey string, ttl time.Duration) map[string]interface{} {
+// buildUnifiedMetadata builds the property map written alongside the cache
+// entry: the columns the vector store indexes for filtering (cache_key,
+// provider, model, params_hash, expires_at) plus the from_bifrost marker
+// used by Cleanup and ClearCacheForKey to scope deletes. Caller still adds
+// the response payload (response or stream_chunks) before Add.
+func (plugin *Plugin) buildUnifiedMetadata(provider schemas.ModelProvider, model string, paramsHash string, cacheKey string, ttl time.Duration) map[string]interface{} {
 	unifiedMetadata := make(map[string]interface{})
-
-	// Top-level fields (outside params)
 	unifiedMetadata["provider"] = string(provider)
 	unifiedMetadata["model"] = model
-	unifiedMetadata["request_hash"] = requestHash
 	unifiedMetadata["cache_key"] = cacheKey
 	unifiedMetadata["from_bifrost_semantic_cache_plugin"] = true
-
-	// Calculate expiration timestamp (current time + TTL)
-	expiresAt := time.Now().Add(ttl).Unix()
-	unifiedMetadata["expires_at"] = expiresAt
-
-	// Individual param fields will be stored as params_* by the vectorstore
-	// We pass the params map to the vectorstore, and it handles the individual field storage
+	unifiedMetadata["expires_at"] = time.Now().Add(ttl).Unix()
 	if paramsHash != "" {
 		unifiedMetadata["params_hash"] = paramsHash
 	}
-
 	return unifiedMetadata
 }
 
-// addSingleResponse stores a single (non-streaming) response in unified VectorEntry format.
-// responseData is the pre-marshaled JSON of the response; the caller must marshal
-// synchronously before spawning the cache goroutine so the marshal cannot race
-// with downstream mutation of the response struct.
-func (plugin *Plugin) addSingleResponse(ctx context.Context, responseID string, responseData []byte, embedding []float32, metadata map[string]interface{}, ttl time.Duration) error {
-	// Add response field to metadata
+// addNonStreamingResponse marshals the response and writes it as a single
+// cache entry. The metadata map is mutated (response + stream_chunks added)
+// — safe because the calling goroutine owns it. The ttl parameter is
+// retained for symmetry with addStreamingResponse; the actual expiry is
+// already encoded in metadata["expires_at"] by buildUnifiedMetadata.
+func (plugin *Plugin) addNonStreamingResponse(ctx context.Context, responseID string, res *schemas.BifrostResponse, embedding []float32, metadata map[string]interface{}, ttl time.Duration) error {
+	responseData, err := json.Marshal(res)
+	if err != nil {
+		return fmt.Errorf("failed to marshal response: %w", err)
+	}
 	metadata["response"] = string(responseData)
 	metadata["stream_chunks"] = []string{}
 
-	// Store unified entry using new VectorStore interface
 	if err := plugin.store.Add(ctx, plugin.config.VectorStoreNamespace, responseID, embedding, metadata); err != nil {
 		return fmt.Errorf("failed to store unified cache entry: %w", err)
 	}
 
-	plugin.logger.Debug(fmt.Sprintf("%s Successfully cached single response with ID: %s", PluginLoggerPrefix, responseID))
+	plugin.logger.Debug("Successfully cached single response with ID: %s", responseID)
 	return nil
 }
 
-// addStreamingResponse handles streaming response storage by accumulating chunks
-func (plugin *Plugin) addStreamingResponse(ctx context.Context, requestID string, storageID string, res *schemas.BifrostResponse, bifrostErr *schemas.BifrostError, embedding []float32, metadata map[string]interface{}, ttl time.Duration, isFinalChunk bool) error {
-	// Create accumulator if it doesn't exist
+// addStreamingResponse appends one chunk to the per-request accumulator and,
+// when the final chunk arrives, flushes the accumulated stream to the cache.
+// Errors never reach this function: PostLLMHook returns early on bifrostErr
+// (errors are always delivered as the final chunk), so an errored stream
+// simply leaves its accumulator behind for the periodic reaper.
+func (plugin *Plugin) addStreamingResponse(ctx context.Context, requestID string, storageID string, res *schemas.BifrostResponse, embedding []float32, metadata map[string]interface{}, ttl time.Duration, isFinalChunk bool) error {
 	accumulator := plugin.getOrCreateStreamAccumulator(requestID, storageID, embedding, metadata, ttl)
 
-	// Create chunk from current response
 	chunk := &StreamChunk{
 		Timestamp: time.Now(),
 		Response:  res,
 	}
-
-	// Check for finish reason or set error finish reason
-	if bifrostErr != nil {
-		// Error case - mark as final chunk with error
-		chunk.FinishReason = bifrost.Ptr("error")
-	} else if res != nil && res.ChatResponse != nil && len(res.ChatResponse.Choices) > 0 {
-		choice := res.ChatResponse.Choices[0]
-		if choice.ChatStreamResponseChoice != nil {
-			chunk.FinishReason = choice.FinishReason
-		}
-	}
-
-	// Add chunk to accumulator synchronously to maintain order
-	if err := plugin.addStreamChunk(requestID, chunk, isFinalChunk); err != nil {
+	if err := plugin.addStreamChunk(requestID, chunk); err != nil {
 		return fmt.Errorf("failed to add stream chunk: %w", err)
 	}
 
-	// Check if this is the final chunk and gate final processing to ensure single invocation
-	accumulator.mu.Lock()
-	// Check for completion: either FinishReason is present, there's an error, or token usage exists
-	alreadyComplete := accumulator.IsComplete
-
-	// Track if any chunk has an error
-	if bifrostErr != nil {
-		accumulator.HasError = true
+	if !isFinalChunk {
+		return nil
 	}
 
-	if isFinalChunk && !alreadyComplete {
+	// Gate final processing so it runs exactly once even if multiple chunks
+	// race here (shouldn't happen in practice but cheap insurance).
+	accumulator.mu.Lock()
+	alreadyComplete := accumulator.IsComplete
+	if !alreadyComplete {
 		accumulator.IsComplete = true
-		accumulator.FinalTimestamp = chunk.Timestamp
 	}
 	accumulator.mu.Unlock()
 
-	// If this is the final chunk and hasn't been processed yet, process accumulated chunks
-	// Note: processAccumulatedStream will check for errors and skip caching if any errors occurred
-	if isFinalChunk && !alreadyComplete {
-		if processErr := plugin.processAccumulatedStream(ctx, requestID); processErr != nil {
-			plugin.logger.Warn("%s Failed to process accumulated stream for request %s: %v", PluginLoggerPrefix, requestID, processErr)
-		}
+	if alreadyComplete {
+		return nil
 	}
-
+	if err := plugin.processAccumulatedStream(ctx, requestID); err != nil {
+		plugin.logger.Warn("Failed to process accumulated stream for request %s: %v", requestID, err)
+	}
 	return nil
 }
 
-// getInputForCaching extracts request input for hashing/embedding without normalization.
-// For Chat/Responses requests, it filters out system messages if configured but returns shallow copies.
-// For other request types, it returns direct references to the input.
-func (plugin *Plugin) getInputForCaching(req *schemas.BifrostRequest) interface{} {
-	switch req.RequestType {
-	case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
-		return req.TextCompletionRequest.Input
-	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
-		originalMessages := req.ChatRequest.Input
-		filteredMessages := make([]schemas.ChatMessage, 0, len(originalMessages))
-		for _, msg := range originalMessages {
-			// Skip system messages if configured to exclude them
-			if plugin.config.ExcludeSystemPrompt != nil && *plugin.config.ExcludeSystemPrompt && msg.Role == schemas.ChatMessageRoleSystem {
+// parseStreamChunks parses stream_chunks data from the various shapes
+// different vector store drivers hand back (Weaviate's JSON-decoded
+// []interface{}, typed []string, or Redis's JSON-encoded string) into a
+// flat []string of per-chunk JSON payloads.
+//
+// Non-string elements in the []interface{} case are dropped with a warning
+// rather than failing the whole replay — partial cache hits are better than
+// no hit at all.
+func (plugin *Plugin) parseStreamChunks(streamData interface{}) ([]string, error) {
+	if streamData == nil {
+		return nil, fmt.Errorf("stream data is nil")
+	}
+
+	switch v := streamData.(type) {
+	case []string:
+		return v, nil
+	case []interface{}:
+		result := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				plugin.logger.Warn("Stream chunk %d is not a string (got %T), skipping", i, item)
 				continue
 			}
-			filteredMessages = append(filteredMessages, msg)
+			result = append(result, s)
 		}
-		return filteredMessages
-	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest:
-		originalMessages := req.ResponsesRequest.Input
-		filteredMessages := make([]schemas.ResponsesMessage, 0, len(originalMessages))
-		for _, msg := range originalMessages {
-			// Skip system messages if configured to exclude them
-			if plugin.config.ExcludeSystemPrompt != nil && *plugin.config.ExcludeSystemPrompt && msg.Role != nil && *msg.Role == schemas.ResponsesInputMessageRoleSystem {
-				continue
-			}
-			filteredMessages = append(filteredMessages, msg)
+		return result, nil
+	case string:
+		// Redis: stream_chunks stored as a JSON-encoded array of strings.
+		var stringArray []string
+		if err := json.Unmarshal([]byte(v), &stringArray); err != nil {
+			return nil, fmt.Errorf("failed to parse JSON string: %w", err)
 		}
-		return filteredMessages
-	case schemas.SpeechRequest, schemas.SpeechStreamRequest:
-		return req.SpeechRequest.Input.Input
-	case schemas.EmbeddingRequest:
-		return req.EmbeddingRequest.Input
-	case schemas.TranscriptionRequest, schemas.TranscriptionStreamRequest:
-		return req.TranscriptionRequest.Input
-	case schemas.ImageGenerationRequest, schemas.ImageGenerationStreamRequest:
-		return req.ImageGenerationRequest.Input
+		return stringArray, nil
 	default:
-		return nil
+		return nil, fmt.Errorf("unsupported stream data type: %T", streamData)
 	}
 }
 
-// getNormalizedInputForCaching returns a copy of req.Input for hashing/embedding. The input is normalized.
-// It applies text normalization (lowercase + trim) and optionally removes system messages.
-func (plugin *Plugin) getNormalizedInputForCaching(req *schemas.BifrostRequest) interface{} {
+// getInputForCaching extracts request input for hashing/embedding without
+// normalization. For Chat/Responses requests, system messages are filtered
+// out when ExcludeSystemPrompt is enabled — that path returns a fresh slice;
+// otherwise the original slice is returned by reference (no allocation).
+// Other request types always return the underlying input directly.
+//
+// The slice for Chat/Responses is memoized on state so attachment extraction,
+// embedding text extraction, and the history-threshold check reuse the same
+// slice instead of re-walking on each call. State may be nil (tests /
+// pre-state callers), in which case nothing is cached.
+func (plugin *Plugin) getInputForCaching(state *cacheState, req *schemas.BifrostRequest) interface{} {
+	if state != nil && state.FilteredInput != nil {
+		return state.FilteredInput
+	}
+	excludeSystem := plugin.config.ExcludeSystemPrompt != nil && *plugin.config.ExcludeSystemPrompt
+	var out interface{}
 	switch req.RequestType {
 	case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
-		// Create a deep copy of the input to avoid mutating the original request
-		copiedInput := schemas.TextCompletionInput{}
-		if req.TextCompletionRequest.Input.PromptStr != nil {
-			copiedPromptStr := *req.TextCompletionRequest.Input.PromptStr
-			copiedInput.PromptStr = &copiedPromptStr
-		} else if len(req.TextCompletionRequest.Input.PromptArray) > 0 {
-			copiedPromptArray := make([]string, len(req.TextCompletionRequest.Input.PromptArray))
-			copy(copiedPromptArray, req.TextCompletionRequest.Input.PromptArray)
-			copiedInput.PromptArray = copiedPromptArray
-		}
+		out = req.TextCompletionRequest.Input
+	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
+		out = filterChatMessages(req.ChatRequest.Input, excludeSystem)
+	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest:
+		out = filterResponsesMessages(req.ResponsesRequest.Input, excludeSystem)
+	case schemas.SpeechRequest, schemas.SpeechStreamRequest:
+		out = req.SpeechRequest.Input.Input
+	case schemas.EmbeddingRequest:
+		out = req.EmbeddingRequest.Input
+	case schemas.TranscriptionRequest, schemas.TranscriptionStreamRequest:
+		out = req.TranscriptionRequest.Input
+	case schemas.ImageGenerationRequest, schemas.ImageGenerationStreamRequest:
+		out = req.ImageGenerationRequest.Input
+	default:
+		return nil
+	}
+	if state != nil {
+		state.FilteredInput = out
+	}
+	return out
+}
 
-		if copiedInput.PromptStr != nil {
-			normalizedText := normalizeText(*copiedInput.PromptStr)
-			copiedInput.PromptStr = &normalizedText
-		} else if len(copiedInput.PromptArray) > 0 {
-			// Create a copy of the PromptArray and normalize each element
-			normalizedPromptArray := make([]string, len(copiedInput.PromptArray))
-			copy(normalizedPromptArray, copiedInput.PromptArray)
-			for i, prompt := range normalizedPromptArray {
-				normalizedPromptArray[i] = normalizeText(prompt)
-			}
-			copiedInput.PromptArray = normalizedPromptArray
+// filterChatMessages returns msgs unchanged when excludeSystem is false.
+// Otherwise, returns a copy with system messages dropped.
+func filterChatMessages(msgs []schemas.ChatMessage, excludeSystem bool) []schemas.ChatMessage {
+	if !excludeSystem {
+		return msgs
+	}
+	out := make([]schemas.ChatMessage, 0, len(msgs))
+	for _, m := range msgs {
+		if m.Role == schemas.ChatMessageRoleSystem {
+			continue
 		}
-		return copiedInput
+		out = append(out, m)
+	}
+	return out
+}
+
+// filterResponsesMessages returns msgs unchanged when excludeSystem is false.
+// Otherwise, returns a copy with system messages dropped.
+func filterResponsesMessages(msgs []schemas.ResponsesMessage, excludeSystem bool) []schemas.ResponsesMessage {
+	if !excludeSystem {
+		return msgs
+	}
+	out := make([]schemas.ResponsesMessage, 0, len(msgs))
+	for _, m := range msgs {
+		if m.Role != nil && *m.Role == schemas.ResponsesInputMessageRoleSystem {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// getNormalizedInputForCaching returns a copy of req.Input with text fields
+// lowercased + trimmed, suitable for hashing/embedding. System messages are
+// dropped when ExcludeSystemPrompt is enabled.
+//
+// Allocation strategy: the original request must never be mutated, but the
+// returned value only needs to round-trip through json.Marshal — it's hashed,
+// not stored. So we shallow-copy each message struct and rewrite Content
+// (the only field we normalize), sharing all other pointer fields with the
+// original. This avoids the per-call message-graph deep copy that
+// schemas.DeepCopy*Message would otherwise do.
+func (plugin *Plugin) getNormalizedInputForCaching(req *schemas.BifrostRequest) interface{} {
+	excludeSystem := plugin.config.ExcludeSystemPrompt != nil && *plugin.config.ExcludeSystemPrompt
+	switch req.RequestType {
+	case schemas.TextCompletionRequest, schemas.TextCompletionStreamRequest:
+		input := req.TextCompletionRequest.Input
+		out := schemas.TextCompletionInput{}
+		if input.PromptStr != nil {
+			ns := normalizeText(*input.PromptStr)
+			out.PromptStr = &ns
+		} else if len(input.PromptArray) > 0 {
+			arr := make([]string, len(input.PromptArray))
+			for i, p := range input.PromptArray {
+				arr[i] = normalizeText(p)
+			}
+			out.PromptArray = arr
+		}
+		return out
 	case schemas.ChatCompletionRequest, schemas.ChatCompletionStreamRequest:
 		originalMessages := req.ChatRequest.Input
 		normalizedMessages := make([]schemas.ChatMessage, 0, len(originalMessages))
-
 		for _, msg := range originalMessages {
-			// Skip system messages if configured to exclude them
-			if plugin.config.ExcludeSystemPrompt != nil && *plugin.config.ExcludeSystemPrompt && msg.Role == schemas.ChatMessageRoleSystem {
+			if excludeSystem && msg.Role == schemas.ChatMessageRoleSystem {
 				continue
 			}
-
-			// Create a deep copy of the message with normalized content
-			normalizedMsg := schemas.DeepCopyChatMessage(msg)
-
-			// Normalize message content
-			// Content can be nil for messages like assistant tool-call messages
-			if msg.Content != nil {
-				if msg.Content.ContentStr != nil {
-					normalizedContent := normalizeText(*msg.Content.ContentStr)
-					normalizedMsg.Content.ContentStr = &normalizedContent
-				} else if msg.Content.ContentBlocks != nil {
-					// Create a copy of content blocks with normalized text
-					normalizedBlocks := make([]schemas.ChatContentBlock, len(msg.Content.ContentBlocks))
-					for i, block := range msg.Content.ContentBlocks {
-						normalizedBlocks[i] = block
-						if block.Text != nil {
-							normalizedText := normalizeText(*block.Text)
-							normalizedBlocks[i].Text = &normalizedText
-						}
-					}
-					normalizedMsg.Content.ContentBlocks = normalizedBlocks
-				}
-			}
-
-			normalizedMessages = append(normalizedMessages, normalizedMsg)
+			normalizedMessages = append(normalizedMessages, normalizeChatMessage(msg))
 		}
 		return normalizedMessages
 	case schemas.ResponsesRequest, schemas.ResponsesStreamRequest, schemas.WebSocketResponsesRequest:
 		originalMessages := req.ResponsesRequest.Input
 		normalizedMessages := make([]schemas.ResponsesMessage, 0, len(originalMessages))
-
 		for _, msg := range originalMessages {
-			// Skip system messages if configured to exclude them
-			if plugin.config.ExcludeSystemPrompt != nil && *plugin.config.ExcludeSystemPrompt && msg.Role != nil && *msg.Role == schemas.ResponsesInputMessageRoleSystem {
+			if excludeSystem && msg.Role != nil && *msg.Role == schemas.ResponsesInputMessageRoleSystem {
 				continue
 			}
-
-			// Create a deep copy of the message with normalized content
-			normalizedMsg := schemas.DeepCopyResponsesMessage(msg)
-
-			// Create a deep copy of the Content to avoid modifying the original
-			if msg.Content != nil {
-				if msg.Content.ContentStr != nil {
-					normalizedText := normalizeText(*msg.Content.ContentStr)
-					normalizedMsg.Content.ContentStr = &normalizedText
-				} else if msg.Content.ContentBlocks != nil {
-					// Create a copy of content blocks with normalized text
-					normalizedBlocks := make([]schemas.ResponsesMessageContentBlock, len(msg.Content.ContentBlocks))
-					for i, block := range msg.Content.ContentBlocks {
-						normalizedBlocks[i] = block
-						if block.Text != nil {
-							normalizedText := normalizeText(*block.Text)
-							normalizedBlocks[i].Text = &normalizedText
-						}
-					}
-					normalizedMsg.Content.ContentBlocks = normalizedBlocks
-				}
-			}
-
-			normalizedMessages = append(normalizedMessages, normalizedMsg)
+			normalizedMessages = append(normalizedMessages, normalizeResponsesMessage(msg))
 		}
 		return normalizedMessages
 	case schemas.SpeechRequest, schemas.SpeechStreamRequest:
 		return normalizeText(req.SpeechRequest.Input.Input)
 	case schemas.EmbeddingRequest:
-		// Create a deep copy of the input to avoid mutating the original request
-		copiedInput := schemas.EmbeddingInput{}
-		if req.EmbeddingRequest.Input.Text != nil {
-			copiedText := *req.EmbeddingRequest.Input.Text
-			copiedInput.Text = &copiedText
-		} else if len(req.EmbeddingRequest.Input.Texts) > 0 {
-			copiedTexts := make([]string, len(req.EmbeddingRequest.Input.Texts))
-			copy(copiedTexts, req.EmbeddingRequest.Input.Texts)
-			copiedInput.Texts = copiedTexts
-		} else if req.EmbeddingRequest.Input.Embedding != nil {
-			copiedEmbedding := make([]int, len(req.EmbeddingRequest.Input.Embedding))
-			copy(copiedEmbedding, req.EmbeddingRequest.Input.Embedding)
-			copiedInput.Embedding = copiedEmbedding
-		} else if req.EmbeddingRequest.Input.Embeddings != nil {
-			copiedEmbeddings := make([][]int, len(req.EmbeddingRequest.Input.Embeddings))
-			copy(copiedEmbeddings, req.EmbeddingRequest.Input.Embeddings)
-			copiedInput.Embeddings = copiedEmbeddings
-		}
-		if copiedInput.Text != nil {
-			normalizedText := normalizeText(*copiedInput.Text)
-			copiedInput.Text = &normalizedText
-		} else if len(copiedInput.Texts) > 0 {
-			normalizedTexts := make([]string, len(copiedInput.Texts))
-			for i, text := range copiedInput.Texts {
-				normalizedTexts[i] = normalizeText(text)
+		input := req.EmbeddingRequest.Input
+		out := schemas.EmbeddingInput{}
+		if input.Text != nil {
+			ns := normalizeText(*input.Text)
+			out.Text = &ns
+		} else if len(input.Texts) > 0 {
+			arr := make([]string, len(input.Texts))
+			for i, t := range input.Texts {
+				arr[i] = normalizeText(t)
 			}
-			copiedInput.Texts = normalizedTexts
+			out.Texts = arr
+		} else if input.Embedding != nil {
+			// Numeric embeddings aren't text-normalizable but must still appear
+			// in the hash payload, so copy the slice to avoid aliasing.
+			out.Embedding = append([]int(nil), input.Embedding...)
+		} else if input.Embeddings != nil {
+			out.Embeddings = append([][]int(nil), input.Embeddings...)
 		}
-		return copiedInput
+		return out
 	case schemas.TranscriptionRequest, schemas.TranscriptionStreamRequest:
 		return req.TranscriptionRequest.Input
 	case schemas.ImageGenerationRequest, schemas.ImageGenerationStreamRequest:
@@ -800,18 +705,60 @@ func (plugin *Plugin) getNormalizedInputForCaching(req *schemas.BifrostRequest) 
 	}
 }
 
-// removeField removes the first occurrence of target from the slice.
-func removeField(arr []string, target string) []string {
-	for i, v := range arr {
-		if v == target {
-			// remove element at index i
-			return append(arr[:i], arr[i+1:]...)
-		}
+// normalizeChatMessage returns a shallow copy of msg with its Content
+// rewritten so text fields are lowercased + trimmed. Other pointer fields
+// (ToolCalls, Annotations, ChatToolMessage, ChatAssistantMessage) are
+// aliased — safe because we don't mutate them.
+func normalizeChatMessage(msg schemas.ChatMessage) schemas.ChatMessage {
+	out := msg
+	if msg.Content == nil {
+		return out
 	}
-	return arr // unchanged if target not found
+	nc := *msg.Content
+	if msg.Content.ContentStr != nil {
+		ns := normalizeText(*msg.Content.ContentStr)
+		nc.ContentStr = &ns
+	} else if msg.Content.ContentBlocks != nil {
+		blocks := make([]schemas.ChatContentBlock, len(msg.Content.ContentBlocks))
+		for i, b := range msg.Content.ContentBlocks {
+			blocks[i] = b
+			if b.Text != nil {
+				nt := normalizeText(*b.Text)
+				blocks[i].Text = &nt
+			}
+		}
+		nc.ContentBlocks = blocks
+	}
+	out.Content = &nc
+	return out
 }
 
-// extractChatParametersToMetadata extracts Chat API parameters into metadata map
+// normalizeResponsesMessage mirrors normalizeChatMessage for the Responses API.
+func normalizeResponsesMessage(msg schemas.ResponsesMessage) schemas.ResponsesMessage {
+	out := msg
+	if msg.Content == nil {
+		return out
+	}
+	nc := *msg.Content
+	if msg.Content.ContentStr != nil {
+		ns := normalizeText(*msg.Content.ContentStr)
+		nc.ContentStr = &ns
+	} else if msg.Content.ContentBlocks != nil {
+		blocks := make([]schemas.ResponsesMessageContentBlock, len(msg.Content.ContentBlocks))
+		for i, b := range msg.Content.ContentBlocks {
+			blocks[i] = b
+			if b.Text != nil {
+				nt := normalizeText(*b.Text)
+				blocks[i].Text = &nt
+			}
+		}
+		nc.ContentBlocks = blocks
+	}
+	out.Content = &nc
+	return out
+}
+
+// extractChatParametersToMetadata extracts Chat API parameters into metadata map.
 func (plugin *Plugin) extractChatParametersToMetadata(params *schemas.ChatParameters, metadata map[string]interface{}) {
 	if params.ToolChoice != nil {
 		if params.ToolChoice.ChatToolChoiceStr != nil {
@@ -820,87 +767,53 @@ func (plugin *Plugin) extractChatParametersToMetadata(params *schemas.ChatParame
 			metadata["tool_choice"] = params.ToolChoice.ChatToolChoiceStruct.Function.Name
 		}
 	}
-	if params.Temperature != nil {
-		metadata["temperature"] = *params.Temperature
-	}
-	if params.TopP != nil {
-		metadata["top_p"] = *params.TopP
-	}
-	if params.MaxCompletionTokens != nil {
-		metadata["max_tokens"] = *params.MaxCompletionTokens
-	}
-	if params.Stop != nil {
-		metadata["stop_sequences"] = params.Stop
-	}
-	if params.PresencePenalty != nil {
-		metadata["presence_penalty"] = *params.PresencePenalty
-	}
-	if params.FrequencyPenalty != nil {
-		metadata["frequency_penalty"] = *params.FrequencyPenalty
-	}
-	if params.ParallelToolCalls != nil {
-		metadata["parallel_tool_calls"] = *params.ParallelToolCalls
-	}
-	if params.User != nil {
-		metadata["user"] = *params.User
-	}
-	if params.LogitBias != nil {
-		metadata["logit_bias"] = *params.LogitBias
-	}
-	if params.LogProbs != nil {
-		metadata["logprobs"] = *params.LogProbs
-	}
-	if params.Modalities != nil {
-		metadata["modalities"] = params.Modalities
-	}
-	if params.PromptCacheKey != nil {
-		metadata["prompt_cache_key"] = *params.PromptCacheKey
-	}
-	if params.Reasoning != nil && params.Reasoning.Enabled != nil {
-		metadata["reasoning_enabled"] = *params.Reasoning.Enabled
-	}
-	if params.Reasoning != nil && params.Reasoning.Effort != nil {
-		metadata["reasoning_effort"] = *params.Reasoning.Effort
+	putIfSet(metadata, "temperature", params.Temperature)
+	putIfSet(metadata, "top_p", params.TopP)
+	putIfSet(metadata, "max_tokens", params.MaxCompletionTokens)
+	putSortedSetIfNonEmpty(metadata, "stop_sequences", params.Stop)
+	putIfSet(metadata, "presence_penalty", params.PresencePenalty)
+	putIfSet(metadata, "frequency_penalty", params.FrequencyPenalty)
+	putIfSet(metadata, "parallel_tool_calls", params.ParallelToolCalls)
+	putIfSet(metadata, "user", params.User)
+	putIfSet(metadata, "logit_bias", params.LogitBias)
+	putIfSet(metadata, "logprobs", params.LogProbs)
+	putSortedSetIfNonEmpty(metadata, "modalities", params.Modalities)
+	putIfSet(metadata, "prompt_cache_key", params.PromptCacheKey)
+	if params.Reasoning != nil {
+		putIfSet(metadata, "reasoning_enabled", params.Reasoning.Enabled)
+		putIfSet(metadata, "reasoning_effort", params.Reasoning.Effort)
 	}
 	if params.ResponseFormat != nil {
+		// ResponseFormat is a struct pointer that callers expect to round-trip
+		// through JSON; store the pointer directly so MarshalDeeplySorted walks it.
 		metadata["response_format"] = params.ResponseFormat
 	}
-	if params.SafetyIdentifier != nil {
-		metadata["safety_identifier"] = *params.SafetyIdentifier
-	}
-	if params.Seed != nil {
-		metadata["seed"] = *params.Seed
-	}
-	if params.ServiceTier != nil {
-		metadata["service_tier"] = *params.ServiceTier
-	}
-	if params.Store != nil {
-		metadata["store"] = *params.Store
-	}
-	if params.TopLogProbs != nil {
-		metadata["top_logprobs"] = *params.TopLogProbs
-	}
-	if params.Verbosity != nil {
-		metadata["verbosity"] = *params.Verbosity
-	}
+	putIfSet(metadata, "safety_identifier", params.SafetyIdentifier)
+	putIfSet(metadata, "seed", params.Seed)
+	putIfSet(metadata, "service_tier", params.ServiceTier)
+	putIfSet(metadata, "store", params.Store)
+	putIfSet(metadata, "top_logprobs", params.TopLogProbs)
+	putIfSet(metadata, "verbosity", params.Verbosity)
 	if len(params.ExtraParams) > 0 {
 		maps.Copy(metadata, params.ExtraParams)
 	}
 	if len(params.Tools) > 0 {
-		tools := make([]interface{}, len(params.Tools))
-		for i, t := range params.Tools {
-			tools[i] = t
-		}
-		if toolsJSON, err := schemas.MarshalDeeplySorted(tools); err != nil {
-			plugin.logger.Warn("%s Failed to marshal tools for metadata: %v", PluginLoggerPrefix, err)
-		} else {
-			toolHash := xxhash.Sum64(toolsJSON)
-			metadata["tools_hash"] = fmt.Sprintf("%x", toolHash)
+		// Tools are an order-insensitive set; producer-side ordering (notably
+		// MCP's randomized map iteration) must not perturb the request hash.
+		if toolsHash, err := hashSortedSet(params.Tools, func(t schemas.ChatTool) string {
+			if t.Function == nil {
+				return ""
+			}
+			return t.Function.Name
+		}); err != nil {
+			plugin.logger.Warn("Failed to marshal tools for metadata: %v", err)
+		} else if toolsHash != "" {
+			metadata["tools_hash"] = toolsHash
 		}
 	}
 }
 
-// extractResponsesParametersToMetadata extracts Responses API parameters into metadata map
+// extractResponsesParametersToMetadata extracts Responses API parameters into metadata map.
 func (plugin *Plugin) extractResponsesParametersToMetadata(params *schemas.ResponsesParameters, metadata map[string]interface{}) {
 	if params.ToolChoice != nil {
 		if params.ToolChoice.ResponsesToolChoiceStr != nil {
@@ -909,158 +822,86 @@ func (plugin *Plugin) extractResponsesParametersToMetadata(params *schemas.Respo
 			metadata["tool_choice"] = *params.ToolChoice.ResponsesToolChoiceStruct.Name
 		}
 	}
-	if params.Temperature != nil {
-		metadata["temperature"] = *params.Temperature
-	}
-	if params.TopP != nil {
-		metadata["top_p"] = *params.TopP
-	}
-	if params.MaxOutputTokens != nil {
-		metadata["max_tokens"] = *params.MaxOutputTokens
-	}
-	if params.ParallelToolCalls != nil {
-		metadata["parallel_tool_calls"] = *params.ParallelToolCalls
-	}
-	if params.Background != nil {
-		metadata["background"] = *params.Background
-	}
-	if params.Conversation != nil {
-		metadata["conversation"] = *params.Conversation
-	}
-	if params.Include != nil {
-		metadata["include"] = params.Include
-	}
-	if params.Instructions != nil {
-		metadata["instructions"] = *params.Instructions
-	}
-	if params.MaxToolCalls != nil {
-		metadata["max_tool_calls"] = *params.MaxToolCalls
-	}
-	if params.PreviousResponseID != nil {
-		metadata["previous_response_id"] = *params.PreviousResponseID
-	}
-	if params.PromptCacheKey != nil {
-		metadata["prompt_cache_key"] = *params.PromptCacheKey
-	}
+	putIfSet(metadata, "temperature", params.Temperature)
+	putIfSet(metadata, "top_p", params.TopP)
+	putIfSet(metadata, "max_tokens", params.MaxOutputTokens)
+	putIfSet(metadata, "parallel_tool_calls", params.ParallelToolCalls)
+	putIfSet(metadata, "background", params.Background)
+	putIfSet(metadata, "conversation", params.Conversation)
+	putSortedSetIfNonEmpty(metadata, "include", params.Include)
+	putIfSet(metadata, "instructions", params.Instructions)
+	putIfSet(metadata, "max_tool_calls", params.MaxToolCalls)
+	putIfSet(metadata, "previous_response_id", params.PreviousResponseID)
+	putIfSet(metadata, "prompt_cache_key", params.PromptCacheKey)
 	if params.Reasoning != nil {
-		if params.Reasoning.Effort != nil {
-			metadata["reasoning_effort"] = *params.Reasoning.Effort
-		}
-		if params.Reasoning.MaxTokens != nil {
-			metadata["reasoning_max_tokens"] = *params.Reasoning.MaxTokens
-		}
-		if params.Reasoning.Summary != nil {
-			metadata["reasoning_summary"] = *params.Reasoning.Summary
-		}
+		putIfSet(metadata, "reasoning_effort", params.Reasoning.Effort)
+		putIfSet(metadata, "reasoning_max_tokens", params.Reasoning.MaxTokens)
+		putIfSet(metadata, "reasoning_summary", params.Reasoning.Summary)
 	}
-	if params.SafetyIdentifier != nil {
-		metadata["safety_identifier"] = *params.SafetyIdentifier
-	}
-	if params.ServiceTier != nil {
-		metadata["service_tier"] = *params.ServiceTier
-	}
-	if params.Store != nil {
-		metadata["store"] = *params.Store
-	}
+	putIfSet(metadata, "safety_identifier", params.SafetyIdentifier)
+	putIfSet(metadata, "service_tier", params.ServiceTier)
+	putIfSet(metadata, "store", params.Store)
 	if params.Text != nil {
-		if params.Text.Verbosity != nil {
-			metadata["text_verbosity"] = *params.Text.Verbosity
-		}
+		putIfSet(metadata, "text_verbosity", params.Text.Verbosity)
 		if params.Text.Format != nil {
 			metadata["text_format_type"] = params.Text.Format.Type
 		}
 	}
-	if params.TopLogProbs != nil {
-		metadata["top_logprobs"] = *params.TopLogProbs
-	}
-	if params.Truncation != nil {
-		metadata["truncation"] = *params.Truncation
-	}
+	putIfSet(metadata, "top_logprobs", params.TopLogProbs)
+	putIfSet(metadata, "truncation", params.Truncation)
 	if len(params.ExtraParams) > 0 {
 		maps.Copy(metadata, params.ExtraParams)
 	}
 	if len(params.Tools) > 0 {
-		tools := make([]interface{}, len(params.Tools))
-		for i, t := range params.Tools {
-			tools[i] = t
-		}
-		if toolsJSON, err := schemas.MarshalDeeplySorted(tools); err != nil {
-			plugin.logger.Warn("%s Failed to marshal tools for metadata: %v", PluginLoggerPrefix, err)
-		} else {
-			toolHash := xxhash.Sum64(toolsJSON)
-			metadata["tools_hash"] = fmt.Sprintf("%x", toolHash)
+		// Tools are an order-insensitive set; producer-side ordering (notably
+		// MCP's randomized map iteration) must not perturb the request hash.
+		if toolsHash, err := hashSortedSet(params.Tools, func(t schemas.ResponsesTool) string {
+			if t.Name == nil {
+				return ""
+			}
+			return *t.Name
+		}); err != nil {
+			plugin.logger.Warn("Failed to marshal tools for metadata: %v", err)
+		} else if toolsHash != "" {
+			metadata["tools_hash"] = toolsHash
 		}
 	}
 }
 
-// extractTextCompletionParametersToMetadata extracts Text Completion parameters into metadata map
+// extractTextCompletionParametersToMetadata extracts Text Completion parameters into metadata map.
 func (plugin *Plugin) extractTextCompletionParametersToMetadata(params *schemas.TextCompletionParameters, metadata map[string]interface{}) {
-	if params.Temperature != nil {
-		metadata["temperature"] = *params.Temperature
-	}
-	if params.TopP != nil {
-		metadata["top_p"] = *params.TopP
-	}
-	if params.MaxTokens != nil {
-		metadata["max_tokens"] = *params.MaxTokens
-	}
-	if params.Stop != nil {
-		metadata["stop_sequences"] = params.Stop
-	}
-	if params.PresencePenalty != nil {
-		metadata["presence_penalty"] = *params.PresencePenalty
-	}
-	if params.FrequencyPenalty != nil {
-		metadata["frequency_penalty"] = *params.FrequencyPenalty
-	}
-	if params.User != nil {
-		metadata["user"] = *params.User
-	}
-	if params.BestOf != nil {
-		metadata["best_of"] = *params.BestOf
-	}
-	if params.Echo != nil {
-		metadata["echo"] = *params.Echo
-	}
-	if params.LogitBias != nil {
-		metadata["logit_bias"] = *params.LogitBias
-	}
-	if params.LogProbs != nil {
-		metadata["logprobs"] = *params.LogProbs
-	}
-	if params.N != nil {
-		metadata["n"] = *params.N
-	}
-	if params.Seed != nil {
-		metadata["seed"] = *params.Seed
-	}
-	if params.Suffix != nil {
-		metadata["suffix"] = *params.Suffix
-	}
+	putIfSet(metadata, "temperature", params.Temperature)
+	putIfSet(metadata, "top_p", params.TopP)
+	putIfSet(metadata, "max_tokens", params.MaxTokens)
+	putSortedSetIfNonEmpty(metadata, "stop_sequences", params.Stop)
+	putIfSet(metadata, "presence_penalty", params.PresencePenalty)
+	putIfSet(metadata, "frequency_penalty", params.FrequencyPenalty)
+	putIfSet(metadata, "user", params.User)
+	putIfSet(metadata, "best_of", params.BestOf)
+	putIfSet(metadata, "echo", params.Echo)
+	putIfSet(metadata, "logit_bias", params.LogitBias)
+	putIfSet(metadata, "logprobs", params.LogProbs)
+	putIfSet(metadata, "n", params.N)
+	putIfSet(metadata, "seed", params.Seed)
+	putIfSet(metadata, "suffix", params.Suffix)
 	if len(params.ExtraParams) > 0 {
 		maps.Copy(metadata, params.ExtraParams)
 	}
 }
 
-// extractSpeechParametersToMetadata extracts Speech parameters into metadata map
+// extractSpeechParametersToMetadata extracts Speech parameters into metadata map.
 func (plugin *Plugin) extractSpeechParametersToMetadata(params *schemas.SpeechParameters, metadata map[string]interface{}) {
 	if params == nil {
 		return
 	}
-
-	if params.Speed != nil {
-		metadata["speed"] = *params.Speed
-	}
+	putIfSet(metadata, "speed", params.Speed)
 	if params.ResponseFormat != "" {
 		metadata["response_format"] = params.ResponseFormat
 	}
 	if params.Instructions != "" {
 		metadata["instructions"] = params.Instructions
 	}
-	// Check if VoiceConfig.Voice is non-nil before accessing it
-	if params.VoiceConfig.Voice != nil {
-		metadata["voice"] = *params.VoiceConfig.Voice
-	}
+	putIfSet(metadata, "voice", params.VoiceConfig.Voice)
 	if len(params.VoiceConfig.MultiVoiceConfig) > 0 {
 		flattenedVC := make([]string, len(params.VoiceConfig.MultiVoiceConfig))
 		for i, vc := range params.VoiceConfig.MultiVoiceConfig {
@@ -1068,117 +909,97 @@ func (plugin *Plugin) extractSpeechParametersToMetadata(params *schemas.SpeechPa
 		}
 		metadata["multi_voice_count"] = flattenedVC
 	}
+	if len(params.PronunciationDictionaryLocators) > 0 {
+		if hash, err := hashSortedSet(params.PronunciationDictionaryLocators, func(l schemas.SpeechPronunciationDictionaryLocator) string {
+			return l.PronunciationDictionaryID
+		}); err != nil {
+			plugin.logger.Warn("Failed to marshal pronunciation_dictionary_locators for metadata: %v", err)
+		} else if hash != "" {
+			metadata["pronunciation_dictionary_locators_hash"] = hash
+		}
+	}
 	if len(params.ExtraParams) > 0 {
 		maps.Copy(metadata, params.ExtraParams)
 	}
 }
 
-// extractEmbeddingParametersToMetadata extracts Embedding parameters into metadata map
+// extractEmbeddingParametersToMetadata extracts Embedding parameters into metadata map.
 func (plugin *Plugin) extractEmbeddingParametersToMetadata(params *schemas.EmbeddingParameters, metadata map[string]interface{}) {
-	if params.EncodingFormat != nil {
-		metadata["encoding_format"] = *params.EncodingFormat
-	}
-	if params.Dimensions != nil {
-		metadata["dimensions"] = *params.Dimensions
-	}
+	putIfSet(metadata, "encoding_format", params.EncodingFormat)
+	putIfSet(metadata, "dimensions", params.Dimensions)
 	if len(params.ExtraParams) > 0 {
 		maps.Copy(metadata, params.ExtraParams)
 	}
 }
 
-// extractTranscriptionParametersToMetadata extracts Transcription parameters into metadata map
+// extractTranscriptionParametersToMetadata extracts Transcription parameters into metadata map.
 func (plugin *Plugin) extractTranscriptionParametersToMetadata(params *schemas.TranscriptionParameters, metadata map[string]interface{}) {
-	if params.Language != nil {
-		metadata["language"] = *params.Language
-	}
-	if params.ResponseFormat != nil {
-		metadata["response_format"] = *params.ResponseFormat
-	}
-	if params.Prompt != nil {
-		metadata["prompt"] = *params.Prompt
-	}
-	if params.Format != nil {
-		metadata["file_format"] = *params.Format
+	putIfSet(metadata, "language", params.Language)
+	putIfSet(metadata, "response_format", params.ResponseFormat)
+	putIfSet(metadata, "prompt", params.Prompt)
+	putIfSet(metadata, "file_format", params.Format)
+	putSortedSetIfNonEmpty(metadata, "timestamp_granularities", params.TimestampGranularities)
+	putSortedSetIfNonEmpty(metadata, "include", params.Include)
+	if len(params.AdditionalFormats) > 0 {
+		if hash, err := hashSortedSet(params.AdditionalFormats, func(f schemas.TranscriptionAdditionalFormat) string {
+			return string(f.Format)
+		}); err != nil {
+			plugin.logger.Warn("Failed to marshal additional_formats for metadata: %v", err)
+		} else if hash != "" {
+			metadata["additional_formats_hash"] = hash
+		}
 	}
 	if len(params.ExtraParams) > 0 {
 		maps.Copy(metadata, params.ExtraParams)
 	}
 }
 
-// extractImageGenerationParametersToMetadata extracts Image Generation parameters into metadata map
+// extractImageGenerationParametersToMetadata extracts Image Generation parameters into metadata map.
 func (plugin *Plugin) extractImageGenerationParametersToMetadata(params *schemas.ImageGenerationParameters, metadata map[string]interface{}) {
 	if params == nil {
 		return
 	}
-
-	if params.N != nil {
-		metadata["n"] = *params.N
+	putIfSet(metadata, "n", params.N)
+	putIfSet(metadata, "background", params.Background)
+	putIfSet(metadata, "moderation", params.Moderation)
+	putIfSet(metadata, "partial_images", params.PartialImages)
+	putIfSet(metadata, "size", params.Size)
+	putIfSet(metadata, "quality", params.Quality)
+	putIfSet(metadata, "output_compression", params.OutputCompression)
+	putIfSet(metadata, "output_format", params.OutputFormat)
+	putIfSet(metadata, "style", params.Style)
+	putIfSet(metadata, "response_format", params.ResponseFormat)
+	putIfSet(metadata, "seed", params.Seed)
+	putIfSet(metadata, "negative_prompt", params.NegativePrompt)
+	putIfSet(metadata, "num_inference_steps", params.NumInferenceSteps)
+	putIfSet(metadata, "user", params.User)
+	if len(params.InputImages) > 0 {
+		metadata["input_images"] = params.InputImages
 	}
-	if params.Background != nil {
-		metadata["background"] = *params.Background
-	}
-	if params.Moderation != nil {
-		metadata["moderation"] = *params.Moderation
-	}
-	if params.PartialImages != nil {
-		metadata["partial_images"] = *params.PartialImages
-	}
-	if params.Size != nil {
-		metadata["size"] = *params.Size
-	}
-	if params.Quality != nil {
-		metadata["quality"] = *params.Quality
-	}
-	if params.OutputCompression != nil {
-		metadata["output_compression"] = *params.OutputCompression
-	}
-	if params.OutputFormat != nil {
-		metadata["output_format"] = *params.OutputFormat
-	}
-	if params.Style != nil {
-		metadata["style"] = *params.Style
-	}
-	if params.ResponseFormat != nil {
-		metadata["response_format"] = *params.ResponseFormat
-	}
-	if params.Seed != nil {
-		metadata["seed"] = *params.Seed
-	}
-	if params.NegativePrompt != nil {
-		metadata["negative_prompt"] = *params.NegativePrompt
-	}
-	if params.NumInferenceSteps != nil {
-		metadata["num_inference_steps"] = *params.NumInferenceSteps
-	}
-	if params.User != nil {
-		metadata["user"] = *params.User
-	}
-
 	if len(params.ExtraParams) > 0 {
 		maps.Copy(metadata, params.ExtraParams)
 	}
 }
 
-func (plugin *Plugin) isConversationHistoryThresholdExceeded(req *schemas.BifrostRequest) bool {
+// isConversationHistoryThresholdExceeded returns true when the request's
+// conversation history is longer than ConversationHistoryThreshold. Long
+// histories are unlikely to repeat and unlikely to be semantically similar
+// to other requests, so caching them mostly bloats the store; PreLLMHook
+// uses this to skip caching such requests entirely.
+func (plugin *Plugin) isConversationHistoryThresholdExceeded(state *cacheState, req *schemas.BifrostRequest) bool {
 	switch {
 	case req.ChatRequest != nil:
-		input, ok := plugin.getInputForCaching(req).([]schemas.ChatMessage)
+		input, ok := plugin.getInputForCaching(state, req).([]schemas.ChatMessage)
 		if !ok {
 			return false
 		}
-		if len(input) > plugin.config.ConversationHistoryThreshold {
-			return true
-		}
-		return false
+		return len(input) > plugin.config.ConversationHistoryThreshold
 	case req.ResponsesRequest != nil:
-		input, ok := plugin.getInputForCaching(req).([]schemas.ResponsesMessage)
+		input, ok := plugin.getInputForCaching(state, req).([]schemas.ResponsesMessage)
 		if !ok {
 			return false
 		}
-		if len(input) > plugin.config.ConversationHistoryThreshold {
-			return true
-		}
-		return false
+		return len(input) > plugin.config.ConversationHistoryThreshold
 	default:
 		return false
 	}

--- a/transports/bifrost-http/handlers/cache.go
+++ b/transports/bifrost-http/handlers/cache.go
@@ -8,8 +8,16 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+// cacheClearer is the minimal contract the handler needs from the semantic
+// cache plugin. Defined here (rather than imported) so tests can substitute
+// a fake without spinning up a real vector store.
+type cacheClearer interface {
+	ClearCacheForCacheID(cacheID string) error
+	ClearCacheForKey(cacheKey string) error
+}
+
 type CacheHandler struct {
-	plugin *semanticcache.Plugin
+	plugin cacheClearer
 }
 
 func NewCacheHandler(plugin schemas.LLMPlugin) *CacheHandler {
@@ -24,17 +32,17 @@ func NewCacheHandler(plugin schemas.LLMPlugin) *CacheHandler {
 }
 
 func (h *CacheHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
-	r.DELETE("/api/cache/clear/{requestId}", lib.ChainMiddlewares(h.clearCache, middlewares...))
+	r.DELETE("/api/cache/clear/{cacheId}", lib.ChainMiddlewares(h.clearCache, middlewares...))
 	r.DELETE("/api/cache/clear-by-key/{cacheKey}", lib.ChainMiddlewares(h.clearCacheByKey, middlewares...))
 }
 
 func (h *CacheHandler) clearCache(ctx *fasthttp.RequestCtx) {
-	requestID, ok := ctx.UserValue("requestId").(string)
-	if !ok {
-		SendError(ctx, fasthttp.StatusBadRequest, "Invalid request ID")
+	cacheID, ok := ctx.UserValue("cacheId").(string)
+	if !ok || cacheID == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "Invalid cache ID")
 		return
 	}
-	if err := h.plugin.ClearCacheForRequestID(requestID); err != nil {
+	if err := h.plugin.ClearCacheForCacheID(cacheID); err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to clear cache")
 		return
 	}

--- a/transports/bifrost-http/handlers/cache_test.go
+++ b/transports/bifrost-http/handlers/cache_test.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/valyala/fasthttp"
+)
+
+// fakeCacheClearer records calls and returns configured errors so the handler
+// branches can be exercised without a real semantic cache plugin.
+type fakeCacheClearer struct {
+	clearByID    func(string) error
+	clearByKey   func(string) error
+	idCalls      []string
+	keyCalls     []string
+}
+
+func (f *fakeCacheClearer) ClearCacheForCacheID(id string) error {
+	f.idCalls = append(f.idCalls, id)
+	if f.clearByID != nil {
+		return f.clearByID(id)
+	}
+	return nil
+}
+
+func (f *fakeCacheClearer) ClearCacheForKey(key string) error {
+	f.keyCalls = append(f.keyCalls, key)
+	if f.clearByKey != nil {
+		return f.clearByKey(key)
+	}
+	return nil
+}
+
+func newCacheCtx(userKey, userVal string) *fasthttp.RequestCtx {
+	ctx := &fasthttp.RequestCtx{}
+	if userKey != "" {
+		ctx.SetUserValue(userKey, userVal)
+	}
+	return ctx
+}
+
+// -----------------------------------------------------------------------------
+// clearCache (DELETE /api/cache/clear/{cacheId})
+// -----------------------------------------------------------------------------
+
+func TestClearCache_OK(t *testing.T) {
+	clearer := &fakeCacheClearer{}
+	h := &CacheHandler{plugin: clearer}
+
+	ctx := newCacheCtx("cacheId", "abc-123")
+	h.clearCache(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", got, ctx.Response.Body())
+	}
+	if len(clearer.idCalls) != 1 || clearer.idCalls[0] != "abc-123" {
+		t.Fatalf("expected ClearCacheForCacheID('abc-123'), got %v", clearer.idCalls)
+	}
+}
+
+func TestClearCache_RejectsEmptyID(t *testing.T) {
+	clearer := &fakeCacheClearer{}
+	h := &CacheHandler{plugin: clearer}
+
+	ctx := newCacheCtx("cacheId", "")
+	h.clearCache(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusBadRequest {
+		t.Fatalf("expected 400 for empty id, got %d", got)
+	}
+	if len(clearer.idCalls) != 0 {
+		t.Fatalf("expected no Clear calls on bad id, got %v", clearer.idCalls)
+	}
+}
+
+func TestClearCache_MissingUserValue(t *testing.T) {
+	clearer := &fakeCacheClearer{}
+	h := &CacheHandler{plugin: clearer}
+
+	// No user value set at all (simulates a routing misconfiguration).
+	ctx := &fasthttp.RequestCtx{}
+	h.clearCache(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusBadRequest {
+		t.Fatalf("expected 400 when cacheId user value missing, got %d", got)
+	}
+}
+
+func TestClearCache_PluginErrorReturns500(t *testing.T) {
+	clearer := &fakeCacheClearer{
+		clearByID: func(string) error { return errors.New("store unavailable") },
+	}
+	h := &CacheHandler{plugin: clearer}
+
+	ctx := newCacheCtx("cacheId", "abc-123")
+	h.clearCache(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusInternalServerError {
+		t.Fatalf("expected 500 on plugin error, got %d", got)
+	}
+	if !strings.Contains(string(ctx.Response.Body()), "Failed to clear cache") {
+		t.Fatalf("expected 'Failed to clear cache' in body, got %s", ctx.Response.Body())
+	}
+}
+
+// -----------------------------------------------------------------------------
+// clearCacheByKey (DELETE /api/cache/clear-by-key/{cacheKey})
+// -----------------------------------------------------------------------------
+
+func TestClearCacheByKey_OK(t *testing.T) {
+	clearer := &fakeCacheClearer{}
+	h := &CacheHandler{plugin: clearer}
+
+	ctx := newCacheCtx("cacheKey", "session-42")
+	h.clearCacheByKey(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", got, ctx.Response.Body())
+	}
+	if len(clearer.keyCalls) != 1 || clearer.keyCalls[0] != "session-42" {
+		t.Fatalf("expected ClearCacheForKey('session-42'), got %v", clearer.keyCalls)
+	}
+}
+
+func TestClearCacheByKey_PluginErrorReturns500(t *testing.T) {
+	clearer := &fakeCacheClearer{
+		clearByKey: func(string) error { return errors.New("vector store down") },
+	}
+	h := &CacheHandler{plugin: clearer}
+
+	ctx := newCacheCtx("cacheKey", "session-42")
+	h.clearCacheByKey(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusInternalServerError {
+		t.Fatalf("expected 500 on plugin error, got %d", got)
+	}
+}

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -475,6 +475,9 @@ func (h *LoggingHandler) getLogs(ctx *fasthttp.RequestCtx) {
 			filters.MissingCostOnly = val
 		}
 	}
+	if cacheHitTypes := string(ctx.QueryArgs().Peek("cache_hit_types")); cacheHitTypes != "" {
+		filters.CacheHitTypes = parseCommaSeparated(cacheHitTypes)
+	}
 	if contentSearch := string(ctx.QueryArgs().Peek("content_search")); contentSearch != "" {
 		filters.ContentSearch = contentSearch
 	}
@@ -713,6 +716,9 @@ func (h *LoggingHandler) getLogsStats(ctx *fasthttp.RequestCtx) {
 			filters.MissingCostOnly = val
 		}
 	}
+	if cacheHitTypes := string(ctx.QueryArgs().Peek("cache_hit_types")); cacheHitTypes != "" {
+		filters.CacheHitTypes = parseCommaSeparated(cacheHitTypes)
+	}
 	if contentSearch := string(ctx.QueryArgs().Peek("content_search")); contentSearch != "" {
 		filters.ContentSearch = contentSearch
 	}
@@ -868,6 +874,9 @@ func parseHistogramFilters(ctx *fasthttp.RequestCtx) *logstore.SearchFilters {
 		if val, err := strconv.ParseBool(missingCost); err == nil {
 			filters.MissingCostOnly = val
 		}
+	}
+	if cacheHitTypes := string(ctx.QueryArgs().Peek("cache_hit_types")); cacheHitTypes != "" {
+		filters.CacheHitTypes = parseCommaSeparated(cacheHitTypes)
 	}
 	if contentSearch := string(ctx.QueryArgs().Peek("content_search")); contentSearch != "" {
 		filters.ContentSearch = contentSearch

--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -49,33 +49,33 @@ func SecurityHeadersMiddleware() schemas.BifrostHTTPMiddleware {
 func CorsMiddleware(config *lib.Config) schemas.BifrostHTTPMiddleware {
 	return func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
-			startTime := time.Now()
+			// startTime := time.Now()
 			// skip logging if it's a /health check request
 			if slices.IndexFunc(loggingSkipPaths, func(path string) bool {
 				return strings.HasPrefix(string(ctx.RequestURI()), path)
 			}) != -1 {
 				goto corsFlow
 			}
-			defer func() {
-				statusCode := ctx.Response.Header.StatusCode()
-				level := schemas.LogLevelInfo
-				if statusCode >= 500 {
-					level = schemas.LogLevelError
-				} else if statusCode >= 400 {
-					level = schemas.LogLevelWarn
-				}
-				logBuilder := logger.LogHTTPRequest(level, "request completed").
-					Str("http.method", string(ctx.Method())).
-					Str("http.target", string(ctx.RequestURI())).
-					Int("http.status_code", statusCode).
-					Int64("http.request_duration_ms", time.Since(startTime).Milliseconds()).
-					Str("http.remote_addr", ctx.RemoteAddr().String()).
-					Str("http.user_agent", string(ctx.Request.Header.UserAgent()))
-				if traceID, ok := ctx.UserValue(schemas.BifrostContextKeyTraceID).(string); ok && traceID != "" {
-					logBuilder = logBuilder.Str("trace_id", traceID)
-				}
-				logBuilder.Send()
-			}()
+			// defer func() {
+			// 	statusCode := ctx.Response.Header.StatusCode()
+			// 	level := schemas.LogLevelInfo
+			// 	if statusCode >= 500 {
+			// 		level = schemas.LogLevelError
+			// 	} else if statusCode >= 400 {
+			// 		level = schemas.LogLevelWarn
+			// 	}
+			// 	logBuilder := logger.LogHTTPRequest(level, "request completed").
+			// 		Str("http.method", string(ctx.Method())).
+			// 		Str("http.target", string(ctx.RequestURI())).
+			// 		Int("http.status_code", statusCode).
+			// 		Int64("http.request_duration_ms", time.Since(startTime).Milliseconds()).
+			// 		Str("http.remote_addr", ctx.RemoteAddr().String()).
+			// 		Str("http.user_agent", string(ctx.Request.Header.UserAgent()))
+			// 	if traceID, ok := ctx.UserValue(schemas.BifrostContextKeyTraceID).(string); ok && traceID != "" {
+			// 		logBuilder = logBuilder.Str("trace_id", traceID)
+			// 	}
+			// 	logBuilder.Send()
+			// }()
 		corsFlow:
 			origin := string(ctx.Request.Header.Peek("Origin"))
 			allowed := IsOriginAllowed(origin, config.ClientConfig.AllowedOrigins)
@@ -808,7 +808,7 @@ func (m *AuthMiddleware) middleware(shouldSkip func(*configstore.AuthConfig, str
 			}
 			authConfig := m.authConfig.Load()
 			if authConfig == nil || !authConfig.IsEnabled {
-				logger.Debug("auth middleware is disabled because auth config is not present or not enabled")
+				// logger.Debug("auth middleware is disabled because auth config is not present or not enabled")
 				ctx.SetUserValue(schemas.BifrostContextKeySessionToken, "")
 				// Mark as local admin so downstream RBAC bypasses cleanly when
 				// auth is fully disabled; otherwise RBAC 401s and the UI enters

--- a/ui/app/workspace/config/views/pluginsForm.tsx
+++ b/ui/app/workspace/config/views/pluginsForm.tsx
@@ -2,20 +2,32 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ModelMultiselect } from "@/components/ui/modelMultiselect";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
-import { getProviderLabel } from "@/lib/constants/logs";
+import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
+import { EmbeddingSupportedProviders, getProviderLabel } from "@/lib/constants/logs";
 import { getErrorMessage, useCreatePluginMutation, useGetPluginsQuery, useGetProvidersQuery, useUpdatePluginMutation } from "@/lib/store";
-import { CacheConfig, EditorCacheConfig, ModelProviderName } from "@/lib/types/config";
+import { CacheConfig, EditorCacheConfig, ModelProvider, ModelProviderName } from "@/lib/types/config";
 import { SEMANTIC_CACHE_PLUGIN } from "@/lib/types/plugins";
 import { cacheConfigSchema } from "@/lib/types/schemas";
 import { Loader2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
+// Semantic caching needs an embedding-capable provider. Built-in providers are
+// gated by EmbeddingSupportedProviders; custom providers expose support via
+// custom_provider_config.allowed_requests.embedding.
+const supportsEmbedding = (provider: ModelProvider): boolean => {
+	if (provider.custom_provider_config) {
+		return provider.custom_provider_config.allowed_requests?.embedding === true;
+	}
+	return (EmbeddingSupportedProviders as readonly string[]).includes(provider.name);
+};
+
 const defaultCacheConfig: EditorCacheConfig = {
-	ttl_seconds: 300,
+	ttl: 300,
 	threshold: 0.8,
 	conversation_history_threshold: 3,
 	exclude_system_prompt: false,
@@ -23,14 +35,20 @@ const defaultCacheConfig: EditorCacheConfig = {
 	cache_by_provider: true,
 };
 
-const toEditorCacheConfig = (config?: Partial<CacheConfig>): EditorCacheConfig => ({
-	...defaultCacheConfig,
-	...config,
-});
+const toEditorCacheConfig = (config?: Partial<CacheConfig> & { ttl_seconds?: number }): EditorCacheConfig => {
+	const { ttl_seconds, ...rest } = config ?? {};
+	const merged: EditorCacheConfig = { ...defaultCacheConfig, ...rest };
+	// Migration: older saves stored TTL under `ttl_seconds`; the Go plugin only
+	// reads `ttl`, so adopt the legacy value if the new field isn't present.
+	if (rest.ttl === undefined && typeof ttl_seconds === "number") {
+		merged.ttl = ttl_seconds;
+	}
+	return merged;
+};
 
 const normalizeCacheConfigForSave = (config: EditorCacheConfig) => {
 	const normalized: Record<string, unknown> = {
-		ttl_seconds: config.ttl_seconds,
+		ttl: config.ttl,
 		threshold: config.threshold,
 		cache_by_model: config.cache_by_model,
 		cache_by_provider: config.cache_by_provider,
@@ -51,6 +69,8 @@ const normalizeCacheConfigForSave = (config: EditorCacheConfig) => {
 
 	const provider = config.provider?.trim();
 	const embeddingModel = config.embedding_model?.trim();
+	const namespace = config.vector_store_namespace?.trim();
+	const defaultKey = config.default_cache_key?.trim();
 
 	if (provider) {
 		normalized.provider = provider;
@@ -60,6 +80,12 @@ const normalizeCacheConfigForSave = (config: EditorCacheConfig) => {
 	}
 	if (config.dimension !== undefined) {
 		normalized.dimension = config.dimension;
+	}
+	if (namespace) {
+		normalized.vector_store_namespace = namespace;
+	}
+	if (defaultKey) {
+		normalized.default_cache_key = defaultKey;
 	}
 
 	return normalized;
@@ -78,6 +104,7 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 	const { data: providersData, error: providersError, isLoading: providersLoading } = useGetProvidersQuery();
 
 	const providers = useMemo(() => providersData || [], [providersData]);
+	const embeddingProviders = useMemo(() => providers.filter(supportsEmbedding), [providers]);
 
 	useEffect(() => {
 		if (providersError) {
@@ -108,17 +135,23 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 		}
 	}, [semanticCachePlugin]);
 
-	// Update default provider when providers are loaded (only for new configs)
+	// Seed default provider/model/dimension when the providers list loads, but
+	// only for new configs that haven't picked a provider yet — re-running this
+	// effect on subsequent embeddingProviders changes would otherwise clobber
+	// an in-progress user selection.
 	useEffect(() => {
-		if (providers.length > 0 && !semanticCachePlugin?.config) {
-			setCacheConfig((prev) => ({
-				...prev,
-				provider: providers[0].name as ModelProviderName,
-				embedding_model: prev.embedding_model ?? "text-embedding-3-small",
-				dimension: prev.dimension ?? 1536,
-			}));
+		if (embeddingProviders.length > 0 && !semanticCachePlugin?.config) {
+			setCacheConfig((prev) => {
+				if (prev.provider) return prev;
+				return {
+					...prev,
+					provider: embeddingProviders[0].name as ModelProviderName,
+					embedding_model: prev.embedding_model ?? "text-embedding-3-small",
+					dimension: prev.dimension ?? 1536,
+				};
+			});
 		}
-	}, [providers, semanticCachePlugin?.config]);
+	}, [embeddingProviders, semanticCachePlugin?.config]);
 
 	const hasChanges = useMemo(() => {
 		if (originalCacheEnabled !== serverCacheEnabled) return true;
@@ -127,12 +160,14 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 			cacheConfig.provider !== serverCacheConfig.provider ||
 			cacheConfig.embedding_model !== serverCacheConfig.embedding_model ||
 			cacheConfig.dimension !== serverCacheConfig.dimension ||
-			cacheConfig.ttl_seconds !== serverCacheConfig.ttl_seconds ||
+			cacheConfig.ttl !== serverCacheConfig.ttl ||
 			cacheConfig.threshold !== serverCacheConfig.threshold ||
 			cacheConfig.conversation_history_threshold !== serverCacheConfig.conversation_history_threshold ||
 			cacheConfig.exclude_system_prompt !== serverCacheConfig.exclude_system_prompt ||
 			cacheConfig.cache_by_model !== serverCacheConfig.cache_by_model ||
-			cacheConfig.cache_by_provider !== serverCacheConfig.cache_by_provider
+			cacheConfig.cache_by_provider !== serverCacheConfig.cache_by_provider ||
+			(cacheConfig.vector_store_namespace ?? "") !== (serverCacheConfig.vector_store_namespace ?? "") ||
+			(cacheConfig.default_cache_key ?? "") !== (serverCacheConfig.default_cache_key ?? "")
 		);
 	}, [cacheConfig, serverCacheConfig, originalCacheEnabled, serverCacheEnabled]);
 
@@ -219,6 +254,13 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 							{!providersLoading && providers?.length === 0 && (
 								<span className="text-destructive font-medium"> Requires at least one provider to be configured.</span>
 							)}
+							{!providersLoading && providers.length > 0 && embeddingProviders.length === 0 && (
+								<span className="text-destructive font-medium">
+									{" "}
+									Requires at least one provider that supports embedding requests. Configure a built-in embedding provider, or enable the
+									<code className="mx-1">embedding</code>request type on a custom provider.
+								</span>
+							)}
 						</p>
 					</div>
 					<div className="flex items-center gap-2">
@@ -226,22 +268,13 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 							id="enable-caching"
 							size="md"
 							checked={originalCacheEnabled && isVectorStoreEnabled}
-							disabled={!isVectorStoreEnabled || providersLoading || providers.length === 0}
+							disabled={!isVectorStoreEnabled || providersLoading || embeddingProviders.length === 0}
 							onCheckedChange={(checked) => {
 								if (isVectorStoreEnabled) {
 									handleSemanticCacheToggle(checked);
 								}
 							}}
 						/>
-						{(isSemanticCacheEnabled || originalCacheEnabled) && (
-							<Button
-								onClick={handleSave}
-								disabled={!hasChanges || isUpdating || isCreating || hasInvalidProviderBackedDimension}
-								size="sm"
-							>
-								{isUpdating || isCreating ? "Saving..." : "Save"}
-							</Button>
-						)}
 					</div>
 				</div>
 
@@ -267,6 +300,12 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 									embedding model&apos;s real dimension before saving, or remove the provider to stay in direct-only mode.
 								</div>
 							)}
+							<div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+								<b>Heads up:</b> a vector store namespace can only hold vectors of <em>one</em> dimension. Whenever you
+								change the embedding <b>provider</b>, <b>model</b>, or <b>dimension</b>, make sure the <b>dimension</b> still matches what the model produces - otherwise writes to the existing namespace will
+								fail and reads will silently miss. The namespace is <em>not</em> recreated automatically; either use a fresh namespace or drop the existing class/index in your vector store
+								before saving.
+							</div>
 							{/* Provider and Model Settings */}
 							<div className="space-y-4">
 								<h3 className="text-sm font-medium">Provider and Model Settings</h3>
@@ -275,17 +314,25 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 										<Label htmlFor="provider">Configured Providers</Label>
 										<Select
 											value={cacheConfig.provider}
-											onValueChange={(value: ModelProviderName) => updateCacheConfigLocal({ provider: value })}
+											onValueChange={(value: ModelProviderName) =>
+												updateCacheConfigLocal({
+													provider: value,
+													embedding_model: value === cacheConfig.provider ? cacheConfig.embedding_model : "",
+												})
+											}
 										>
 											<SelectTrigger className="w-full">
 												<SelectValue placeholder="Select provider" />
 											</SelectTrigger>
 											<SelectContent>
-												{providers
+												{embeddingProviders
 													.filter((provider) => provider.name)
 													.map((provider) => (
 														<SelectItem key={provider.name} value={provider.name}>
-															{getProviderLabel(provider.name)}
+															<div className="flex items-center gap-2">
+																<RenderProviderIcon provider={provider.name as ProviderIconType} size="sm" className="h-4 w-4" />
+																<span>{getProviderLabel(provider.name)}</span>
+															</div>
 														</SelectItem>
 													))}
 											</SelectContent>
@@ -293,14 +340,21 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 									</div>
 									<div className="space-y-2">
 										<Label htmlFor="embedding_model">Embedding Model*</Label>
-										<Input
-											id="embedding_model"
-											placeholder="text-embedding-3-small"
+										<ModelMultiselect
+											inputId="embedding_model"
+											isSingleSelect
+											provider={cacheConfig.provider || undefined}
 											value={cacheConfig.embedding_model ?? ""}
-											onChange={(e) => updateCacheConfigLocal({ embedding_model: e.target.value })}
+											onChange={(model) => updateCacheConfigLocal({ embedding_model: model })}
+											placeholder={cacheConfig.provider ? "Search or type an embedding model..." : "Select a provider first"}
+											disabled={!cacheConfig.provider}
 										/>
 									</div>
 								</div>
+								<p className="text-muted-foreground text-xs">
+									API keys for the embedding provider will be inherited from the main provider configuration. The semantic cache will use
+									the configured provider&apos;s keys automatically.
+								</p>
 							</div>
 
 							{/* Cache Settings */}
@@ -313,16 +367,16 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 											id="ttl"
 											type="number"
 											min="1"
-											value={cacheConfig.ttl_seconds === undefined || Number.isNaN(cacheConfig.ttl_seconds) ? "" : cacheConfig.ttl_seconds}
+											value={cacheConfig.ttl === undefined || Number.isNaN(cacheConfig.ttl) ? "" : cacheConfig.ttl}
 											onChange={(e) => {
 												const value = e.target.value;
 												if (value === "") {
-													updateCacheConfigLocal({ ttl_seconds: undefined });
+													updateCacheConfigLocal({ ttl: undefined });
 													return;
 												}
 												const parsed = parseInt(value);
 												if (!Number.isNaN(parsed)) {
-													updateCacheConfigLocal({ ttl_seconds: parsed });
+													updateCacheConfigLocal({ ttl: parsed });
 												}
 											}}
 										/>
@@ -368,12 +422,51 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 												}
 											}}
 										/>
+										<p className="text-muted-foreground text-xs">
+											Vector size produced by the embedding model - must match the model exactly (e.g. <code>1536</code> for
+											OpenAI <code>text-embedding-3-small</code>, <code>3072</code> for <code>text-embedding-3-large</code>,
+											<code>768</code> for many Cohere/Voyage models). Use <code>1</code> only in direct-only mode (no provider).
+										</p>
 									</div>
 								</div>
-								<p className="text-muted-foreground text-xs">
-									API keys for the embedding provider will be inherited from the main provider configuration. The semantic cache will use
-									the configured provider&apos;s keys automatically.
-								</p>
+							</div>
+
+							{/* Storage & Cache Key */}
+							<div className="space-y-4">
+								<h3 className="text-sm font-medium">Storage & Cache Key</h3>
+								<div className="grid grid-cols-2 gap-4">
+									<div className="space-y-2">
+										<Label htmlFor="vector_store_namespace">Vector Store Namespace</Label>
+										<Input
+											id="vector_store_namespace"
+											type="text"
+											placeholder="BifrostSemanticCachePlugin"
+											value={cacheConfig.vector_store_namespace ?? ""}
+											onChange={(e) => updateCacheConfigLocal({ vector_store_namespace: e.target.value })}
+										/>
+										<p className="text-muted-foreground text-xs">
+											Bucket/index name where cache entries are stored in the vector store. Leave blank to use the default
+											(<code>BifrostSemanticCachePlugin</code>). Changing the namespace points the plugin at a different (possibly empty) bucket. All previously
+											cached entries become inaccessible - every request will miss until the new namespace is repopulated.
+										</p>
+									</div>
+									<div className="space-y-2">
+										<Label htmlFor="default_cache_key">Default Cache Key</Label>
+										<Input
+											id="default_cache_key"
+											type="text"
+											placeholder="(none)"
+											value={cacheConfig.default_cache_key ?? ""}
+											onChange={(e) => updateCacheConfigLocal({ default_cache_key: e.target.value })}
+										/>
+										<p className="text-muted-foreground text-xs">
+											Fallback value used as the cache partition when a request doesn&apos;t set the <b>x-bf-cache-key</b> header.
+											Cache keys isolate entries: requests that share a key can hit each other&apos;s cached responses, while requests
+											with different keys can&apos;t. Leaving this blank means caching is <b>disabled</b> for any request that doesn&apos;t
+											send the header.
+										</p>
+									</div>
+								</div>
 							</div>
 
 							{/* Conversation Settings */}
@@ -455,6 +548,15 @@ export default function PluginsForm({ isVectorStoreEnabled }: PluginsFormProps) 
 										You can pass <b>x-bf-cache-no-store</b> header with &quot;true&quot; to disable response caching.
 									</li>
 								</ul>
+							</div>
+
+							<div className="flex justify-end pt-2">
+								<Button
+									onClick={handleSave}
+									disabled={!hasChanges || isUpdating || isCreating || hasInvalidProviderBackedDimension}
+								>
+									{isUpdating || isCreating ? "Saving..." : "Save Changes"}
+								</Button>
 							</div>
 						</div>
 					))}

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -95,6 +95,7 @@ export default function LogsPage() {
 			polling: parseAsBoolean.withDefault(true).withOptions({ clearOnDefault: false }),
 			period: parseAsString.withDefault(hasExplicitTimeRange ? "" : "1h").withOptions({ clearOnDefault: false }),
 			missing_cost_only: parseAsBoolean.withDefault(false),
+			cache_hit_types: parseAsArrayOf(parseAsString).withDefault([]),
 			metadata_filters: parseAsString.withDefault(""),
 			selected_log: parseAsString.withDefault(""),
 		},
@@ -129,6 +130,7 @@ export default function LogsPage() {
 			business_unit_ids: urlState.business_unit_ids,
 			content_search: urlState.content_search,
 			missing_cost_only: urlState.missing_cost_only,
+			cache_hit_types: urlState.cache_hit_types,
 			metadata_filters: urlState.metadata_filters
 				? (() => {
 					try {
@@ -163,6 +165,7 @@ export default function LogsPage() {
 			urlState.content_search,
 			urlState.parent_request_id,
 			urlState.missing_cost_only,
+			urlState.cache_hit_types,
 			urlState.metadata_filters,
 			urlState.start_time,
 			urlState.end_time,
@@ -213,6 +216,7 @@ export default function LogsPage() {
 				start_time: newFilters.start_time ? dateUtils.toUnixTimestamp(new Date(newFilters.start_time)) : undefined,
 				end_time: newFilters.end_time ? dateUtils.toUnixTimestamp(new Date(newFilters.end_time)) : undefined,
 				missing_cost_only: newFilters.missing_cost_only ?? false,
+				cache_hit_types: newFilters.cache_hit_types || [],
 				metadata_filters: newFilters.metadata_filters ? JSON.stringify(newFilters.metadata_filters) : "",
 				offset: 0,
 			});

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -398,7 +398,7 @@ function HeroStat({
   );
 }
 
-function CopyInlineButton({ text }: { text: string }) {
+function CopyInlineButton({ text, testId }: { text: string; testId?: string }) {
   const { copy } = useCopyToClipboard({ successMessage: "Copied" });
   return (
     <button
@@ -409,6 +409,7 @@ function CopyInlineButton({ text }: { text: string }) {
       }}
       className="text-muted-foreground hover:bg-muted hover:text-foreground inline-flex h-6 w-6 items-center justify-center rounded-sm transition"
       aria-label="Copy"
+      data-testid={testId}
     >
       <Clipboard className="h-3.5 w-3.5" />
     </button>
@@ -813,6 +814,22 @@ export function LogDetailView({
                   Async
                 </Badge>
               ) : null}
+              {log.cache_debug?.hit_type === "direct" ? (
+                <Badge
+                  variant="outline"
+                  className="rounded-sm bg-indigo-100 px-2 py-0.5 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200"
+                >
+                  Direct Cache
+                </Badge>
+              ) : null}
+              {log.cache_debug?.hit_type === "semantic" ? (
+                <Badge
+                  variant="outline"
+                  className="rounded-sm bg-rose-100 px-2 py-0.5 text-rose-800 dark:bg-rose-900 dark:text-rose-200"
+                >
+                  Semantic Cache
+                </Badge>
+              ) : null}
               {(log.is_large_payload_request ||
                 log.is_large_payload_response) && (
                   <Badge
@@ -824,33 +841,43 @@ export function LogDetailView({
                 )}
             </div>
             <div className="mt-3 flex items-center gap-2">
-              <div className="text-muted-foreground text-[10.5px] font-semibold tracking-wider uppercase">
+              <div className="text-muted-foreground w-24 shrink-0 text-[10.5px] font-semibold tracking-wider uppercase">
                 Request
               </div>
               <code className="text-foreground truncate font-mono text-[13px]">
                 {log.id || "—"}
               </code>
-              {log.id ? <CopyInlineButton text={log.id} /> : null}
+              {log.id ? <CopyInlineButton text={log.id} testId="logdetails-copy-request-id-button" /> : null}
             </div>
-            {(log.routing_rule || log.selected_key) && (
-              <div className="text-muted-foreground mt-1 text-[12px]">
-                {log.routing_rule ? (
-                  <>
-                    matched rule{" "}
-                    <span className="text-foreground font-medium">
-                      &ldquo;{log.routing_rule.name}&rdquo;
-                    </span>
-                  </>
-                ) : null}
-                {log.routing_rule && log.selected_key ? " · " : ""}
-                {log.selected_key ? (
-                  <>
-                    key{" "}
-                    <span className="text-foreground font-mono">
-                      {log.selected_key.name}
-                    </span>
-                  </>
-                ) : null}
+            {log.cache_debug?.cache_id && (
+              <div className="mt-1 flex items-center gap-2">
+                <div className="text-muted-foreground w-24 shrink-0 text-[10.5px] font-semibold tracking-wider uppercase">
+                  Cache {log.cache_debug.cache_hit ? "(hit)" : "(miss)"}
+                </div>
+                <code className="text-foreground truncate font-mono text-[13px]">
+                  {log.cache_debug.cache_id}
+                </code>
+                <CopyInlineButton text={log.cache_debug.cache_id} testId="logdetails-copy-cache-id-button" />
+              </div>
+            )}
+            {log.routing_rule && (
+              <div className="mt-1 flex items-center gap-2">
+                <div className="text-muted-foreground w-24 shrink-0 text-[10.5px] font-semibold tracking-wider uppercase">
+                  Rule
+                </div>
+                <span className="text-foreground truncate text-[13px] font-medium">
+                  &ldquo;{log.routing_rule.name}&rdquo;
+                </span>
+              </div>
+            )}
+            {log.selected_key && (
+              <div className="mt-1 flex items-center gap-2">
+                <div className="text-muted-foreground w-24 shrink-0 text-[10.5px] font-semibold tracking-wider uppercase">
+                  Key
+                </div>
+                <code className="text-foreground truncate font-mono text-[13px]">
+                  {log.selected_key.name}
+                </code>
               </div>
             )}
           </div>

--- a/ui/components/filters/logsFilterSidebar.tsx
+++ b/ui/components/filters/logsFilterSidebar.tsx
@@ -115,6 +115,7 @@ export function LogsFilterSidebar({ filters, onFiltersChange }: LogsSidebarProps
 					<AliasesFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<RoutingEnginesFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<RoutingRulesFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<LocalCachingFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<UserFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<SessionFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<CostFilter filters={filters} onFiltersChange={onFiltersChange} />
@@ -817,6 +818,38 @@ function CostFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentPr
 				onCheckedChange={(checked) => onFiltersChange({ ...filters, missing_cost_only: !!checked })}
 				testId="cost-filter-missing-only-checkbox"
 			/>
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// LocalCachingFilter – filter by semantic-cache hit type (direct / semantic)
+// ---------------------------------------------------------------------------
+
+const LocalCachingOptions: { key: string; label: string }[] = [
+	{ key: "direct", label: "Direct cache" },
+	{ key: "semantic", label: "Semantic cache" },
+];
+
+function LocalCachingFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = (filters.cache_hit_types || []).length > 0;
+	return (
+		<FilterSection title="Local Caching" defaultOpen={defaultOpen || hasActive} testId="local-caching-filter-toggle">
+			{LocalCachingOptions.map((option) => (
+				<CheckboxFilterItem
+					key={option.key}
+					label={option.label}
+					checked={(filters.cache_hit_types || []).includes(option.key)}
+					onCheckedChange={() => {
+						const current = filters.cache_hit_types || [];
+						const next = current.includes(option.key)
+							? current.filter((t) => t !== option.key)
+							: [...current, option.key];
+						onFiltersChange({ ...filters, cache_hit_types: next });
+					}}
+					testId={`local-caching-filter-checkbox-${option.key}`}
+				/>
+			))}
 		</FilterSection>
 	);
 }

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -30,6 +30,25 @@ export type ProviderName = (typeof KnownProvidersNames)[number];
 
 export const ProviderNames: readonly ProviderName[] = KnownProvidersNames;
 
+// Built-in providers whose Bifrost implementation supports embedding requests.
+// Custom providers must instead be checked via custom_provider_config.allowed_requests.embedding.
+export const EmbeddingSupportedProviders: readonly ProviderName[] = [
+	"azure",
+	"bedrock",
+	"cohere",
+	"fireworks",
+	"gemini",
+	"huggingface",
+	"mistral",
+	"nebius",
+	"ollama",
+	"openai",
+	"openrouter",
+	"sgl",
+	"vertex",
+	"vllm",
+] as const;
+
 export const Statuses = ["success", "error", "processing", "cancelled"] as const;
 
 export const RequestTypes = [

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -68,6 +68,9 @@ function buildFilterParams(filters: LogFilters): Record<string, string | number>
 	if (filters.min_tokens !== undefined) params.min_tokens = filters.min_tokens;
 	if (filters.max_tokens !== undefined) params.max_tokens = filters.max_tokens;
 	if (filters.missing_cost_only) params.missing_cost_only = "true";
+	if (filters.cache_hit_types && filters.cache_hit_types.length > 0) {
+		params.cache_hit_types = filters.cache_hit_types.join(",");
+	}
 	if (filters.content_search) params.content_search = filters.content_search;
 	if (filters.user_ids && filters.user_ids.length > 0) {
 		params.user_ids = filters.user_ids.join(",");

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -527,12 +527,14 @@ export const DefaultCoreConfig: CoreConfig = {
 
 // Semantic cache configuration types
 interface BaseCacheConfig {
-	ttl_seconds: number;
+	ttl: number;
 	threshold: number;
 	conversation_history_threshold?: number;
 	exclude_system_prompt?: boolean;
 	cache_by_model: boolean;
 	cache_by_provider: boolean;
+	vector_store_namespace?: string;
+	default_cache_key?: string;
 	created_at?: string;
 	updated_at?: string;
 }

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -585,6 +585,7 @@ export interface LogFilters {
 	min_tokens?: number;
 	max_tokens?: number;
 	missing_cost_only?: boolean;
+	cache_hit_types?: string[]; // For filtering by local-cache hit type ("direct", "semantic")
 	content_search?: string;
 	metadata_filters?: Record<string, string>; // key=metadataKey, value=metadataValue for filtering by metadata
 	user_ids?: string[];

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -701,12 +701,14 @@ export const updateProviderRequestSchema = z.object({
 
 // Cache config schema
 const baseCacheConfigSchema = z.object({
-  ttl_seconds: z.number().int().min(1).default(3600),
+  ttl: z.number().int().min(1).default(3600),
   threshold: z.number().min(0).max(1).default(0.8),
   conversation_history_threshold: z.number().int().min(0).optional(),
   exclude_system_prompt: z.boolean().optional(),
   cache_by_model: z.boolean().default(false),
   cache_by_provider: z.boolean().default(false),
+  vector_store_namespace: z.string().min(1).optional(),
+  default_cache_key: z.string().min(1).optional(),
   created_at: z.string().optional(),
   updated_at: z.string().optional(),
 });


### PR DESCRIPTION
## Summary

This PR refactors the semantic cache plugin to simplify its internal state management, improves cache lookup correctness, and adds a new `cache_hit_types` filter to the logs API and UI. The direct cache lookup path is now a single deterministic point-fetch by a UUIDv5 `directCacheID` (replacing the previous dual-path of chunk lookup + legacy metadata scan), and several context keys are consolidated. The UI gains a "Local Caching" filter sidebar section and cache hit type badges in the log detail view.

## Changes

- **Semantic cache plugin refactor:**
  - Replaced the dual direct-search path (`performDirectChunkLookup` + `performLegacyDirectSearch`) with a single `performDirectSearch` that does an O(1) `GetChunk` by deterministic `directCacheID` (UUIDv5 derived from provider, model, cacheKey, requestHash, paramsHash).
  - `generateDirectCacheID` now returns an error instead of silently falling back to a string concatenation, making failures explicit.
  - `request_hash` is no longer stored as a top-level metadata field; it is encoded into the `directCacheID` instead.
  - Reduced context keys from ~10 to 4 (`directCacheIDKey`, `paramsHashKey`, `embeddingsKey`, `embeddingsInputTokensKey`), removing stale keys like `requestIDKey`, `requestHashKey`, `isCacheHitKey`, and `cacheHitTypeKey`.
  - `shouldSkipCaching` is extracted into its own method; cache-hit detection now reads `CacheDebug.CacheHit` from the response rather than a context flag.
  - `buildUnifiedMetadata` no longer accepts `requestHash` as a parameter.
  - `addSingleResponse` renamed to `addNonStreamingResponse`.
  - `StreamAccumulator` fields `HasError`, `FinalTimestamp`, and `FinishReason` on `StreamChunk` are removed; error streams are handled by early return in `PostLLMHook`.
  - Streaming replay goroutine now guards every send with `ctx.Done()` to prevent goroutine leaks on dropped consumers.
  - A background `runStreamCleanupLoop` goroutine (started by `Init`, stopped by `Cleanup` via `stopCh`) replaces the one-shot cleanup call, periodically reaping stale stream accumulators.
  - `buildResponseFromResult` now accepts `threshold`, `similarity`, and `inputTokens` as pointers, and `attachCacheDebug` is extracted as a shared helper for both streaming and non-streaming paths.
  - `isExpiredEntry` is extracted as a standalone function.
  - `chunkSortKey` replaces the large inline sort comparator in `processAccumulatedStream`.
  - Tools, stop sequences, modalities, include lists, and other order-insensitive set fields are now hashed with `hashSortedSet` / `sortedStringSet` to prevent MCP's randomized map iteration from perturbing the request hash.
  - `extractAttachmentsForCaching` is extracted so attachment URLs are included in the cache key metadata rather than the embedding text.
  - `extractTextForEmbedding` no longer returns a `paramsHash`; callers compute it once via `buildRequestMetadataForCaching` + `hashMap`.
  - `generateEmbedding` moved from `utils.go` to `search.go`.
  - `generateRequestHash` now accepts prebuilt metadata to avoid recomputing it.
  - `removeField` no longer mutates the input slice's backing array.
  - Added `PronunciationDictionaryLocators`, `TimestampGranularities`, `Include`, `AdditionalFormats`, and `InputImages` to their respective parameter metadata extractors.
  - Public context key names changed from `semantic_cache_*` to `semantic_cache-*` (underscore → hyphen separator after the plugin prefix).
  - `SelectFields` no longer includes `request_hash`.
  - `VectorStoreProperties` no longer includes a `request_hash` entry.
  - `CacheByModel` and `CacheByProvider` default-value log messages added.

- **Log filtering — `cache_hit_types`:**
  - Added `CacheHitTypes []string` to `SearchFilters` in `framework/logstore/tables.go`.
  - `applyFilters` in `rdb.go` applies a JSON path filter on `cache_debug` for both SQLite (`json_extract`) and PostgreSQL (`substring` regex) dialects, restricted to the allowlist `["direct", "semantic"]`.
  - `canUseMatViewFilters` excludes queries with `CacheHitTypes` set from the materialized-view fast path.
  - HTTP handlers (`getLogs`, `getLogsStats`, `parseHistogramFilters`) parse a `cache_hit_types` comma-separated query parameter.

- **UI:**
  - Added a "Local Caching" filter section to `LogsFilterSidebar` with checkboxes for "Direct cache" and "Semantic cache".
  - `cache_hit_types` is added to URL state, filter state, and the `buildFilterParams` API helper.
  - Log detail view shows "Direct Cache" (indigo) and "Semantic Cache" (rose) badges based on `cache_debug.hit_type`.
  - Plugins form now filters the provider dropdown to embedding-capable providers only (`EmbeddingSupportedProviders` for built-ins; `custom_provider_config.allowed_requests.embedding` for custom providers), shows an error message when no embedding provider is configured, and disables the toggle accordingly.
  - Embedding model input replaced with `ModelMultiselect` (single-select mode) scoped to the selected provider.
  - Provider dropdown clears the embedding model when the provider changes.
  - Provider icons rendered in the provider dropdown.
  - `EmbeddingSupportedProviders` constant added to `ui/lib/constants/logs.ts`.

- **Misc:**
  - HTTP request logging in `CorsMiddleware` and an auth debug log are commented out.
  - `transports/bifrost-http/v1.5.x` added to `.gitignore`.
  - Minor formatting fixes in `core/schemas/bifrost.go` and `framework/modelcatalog/sync.go`.
  - Missing newline at end of `sync.go` added.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./plugins/semanticcache/...
go test ./framework/logstore/...
go test ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

- Configure the semantic cache plugin with a direct and/or semantic cache type and verify that cache hits are recorded with the correct `hit_type` in `cache_debug`.
- Query `/logs?cache_hit_types=direct` and `/logs?cache_hit_types=semantic` and confirm only matching entries are returned.
- In the UI, open the logs filter sidebar and verify the "Local Caching" section appears with "Direct cache" and "Semantic cache" checkboxes that correctly filter the log list.
- Open a log detail for a cache hit and confirm the appropriate badge ("Direct Cache" or "Semantic Cache") is displayed.
- In the plugins form, verify that only embedding-capable providers appear in the provider dropdown and that the embedding model field uses the model multiselect.

## Breaking changes

- [x] Yes

The public semantic cache context key names have changed from `semantic_cache_*` to `semantic_cache-*`. Any caller setting `CacheKey`, `CacheTTLKey`, `CacheThresholdKey`, `CacheTypeKey`, or `CacheNoStoreKey` via the old string values will no longer be recognized by the plugin. Update all call sites to use the exported constants from the plugin package rather than raw string literals.

`request_hash` is no longer stored as a top-level metadata field in the vector store. Existing cache entries written by prior versions will not be found by the new direct-search path (they will be treated as misses and re-populated).

`ClearCacheForRequestID` is documented as currently broken for entries written by the new direct-search path; callers should not rely on it until the TODO is resolved.

## Related issues

N/A

## Security considerations

The `CacheHitTypes` filter allowlists values to `"direct"` and `"semantic"` before interpolating them into SQL, preventing arbitrary input from reaching the JSON path expression.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable