### PR TITLE
refactor: move virtual key validation and context attachment before passthrough check

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -346,12 +346,42 @@ func (p *GovernancePlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req
 	virtualKeyValue := parseVirtualKeyFromHTTPRequest(req)
 	hasRoutingRules := p.store.HasRoutingRules(ctx)
 
-	if strings.Contains(req.Path, "passthrough") {
+	// If no virtual key and no routing rules configured, skip all processing
+	if virtualKeyValue == nil && !hasRoutingRules {
 		return nil, nil
 	}
 
-	// If no virtual key and no routing rules configured, skip all processing
-	if virtualKeyValue == nil && !hasRoutingRules {
+	// Only unmarshal if we have VK or routing rules
+	var payload map[string]any
+	var virtualKey *configstoreTables.TableVirtualKey
+	var ok bool
+	var needsMarshal bool
+
+	// Process virtual key if provided
+	if virtualKeyValue != nil {
+		virtualKey, ok = p.store.GetVirtualKey(ctx, *virtualKeyValue)
+		if !ok || virtualKey == nil || !virtualKey.IsActive {
+			return nil, nil
+		}
+	}
+
+	// Attaching team and customer based on the virtual key
+	if virtualKey != nil {
+		if virtualKey.TeamID != nil {
+			ctx.SetValue(schemas.BifrostContextKeyGovernanceTeamID, *virtualKey.TeamID)
+		}
+		if virtualKey.Team != nil {
+			ctx.SetValue(schemas.BifrostContextKeyGovernanceTeamName, virtualKey.Team.Name)
+		}
+		if virtualKey.CustomerID != nil {
+			ctx.SetValue(schemas.BifrostContextKeyGovernanceCustomerID, *virtualKey.CustomerID)
+		}
+		if virtualKey.Customer != nil {
+			ctx.SetValue(schemas.BifrostContextKeyGovernanceCustomerName, virtualKey.Customer.Name)
+		}
+	}
+
+	if strings.Contains(req.Path, "passthrough") {
 		return nil, nil
 	}
 
@@ -363,12 +393,6 @@ func (p *GovernancePlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req
 		}
 		return p.governLargePayload(ctx, req, virtualKeyValue, hasRoutingRules)
 	}
-
-	// Only unmarshal if we have VK or routing rules
-	var payload map[string]any
-	var virtualKey *configstoreTables.TableVirtualKey
-	var ok bool
-	var needsMarshal bool
 
 	contentType := req.CaseInsensitiveHeaderLookup("Content-Type")
 	lowerCT := strings.ToLower(contentType)
@@ -397,30 +421,6 @@ func (p *GovernancePlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req
 		if err != nil {
 			p.logger.Error("failed to unmarshal request body: %v", err)
 			return nil, nil
-		}
-	}
-
-	// Process virtual key if provided
-	if virtualKeyValue != nil {
-		virtualKey, ok = p.store.GetVirtualKey(ctx, *virtualKeyValue)
-		if !ok || virtualKey == nil || !virtualKey.IsActive {
-			return nil, nil
-		}
-	}
-
-	// Attaching team and customer based on the virtual key
-	if virtualKey != nil {
-		if virtualKey.TeamID != nil {
-			ctx.SetValue(schemas.BifrostContextKeyGovernanceTeamID, *virtualKey.TeamID)
-		}
-		if virtualKey.Team != nil {
-			ctx.SetValue(schemas.BifrostContextKeyGovernanceTeamName, virtualKey.Team.Name)
-		}
-		if virtualKey.CustomerID != nil {
-			ctx.SetValue(schemas.BifrostContextKeyGovernanceCustomerID, *virtualKey.CustomerID)
-		}
-		if virtualKey.Customer != nil {
-			ctx.SetValue(schemas.BifrostContextKeyGovernanceCustomerName, virtualKey.Customer.Name)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Virtual key validation and team/customer context attachment now occur before the passthrough path check, ensuring that metadata is correctly populated on the context even for passthrough requests that use a virtual key.

## Changes

- Moved virtual key lookup and validation (including the inactive key early-return) to execute before the `passthrough` path check, so that team and customer IDs/names are attached to the context regardless of whether the request is a passthrough.
- The `payload`, `virtualKey`, `ok`, and `needsMarshal` variable declarations were relocated accordingly to maintain correct scoping after the reorder.
- Previously, passthrough requests with a valid virtual key would skip team/customer context attachment entirely, which could cause missing metadata downstream.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Plugins

## How to test

1. Configure a virtual key with an associated team and/or customer.
2. Send a request to a passthrough endpoint using that virtual key.
3. Verify that `BifrostContextKeyGovernanceTeamID`, `BifrostContextKeyGovernanceTeamName`, `BifrostContextKeyGovernanceCustomerID`, and `BifrostContextKeyGovernanceCustomerName` are correctly set on the context after the pre-hook runs.
4. Verify that requests with no virtual key and no routing rules still return early without processing.
5. Verify that requests using an inactive virtual key still return early.

```sh
go test ./plugins/governance/...
```

## Breaking changes

- [x] No

## Security considerations

No new auth mechanisms introduced. The existing virtual key active/inactive check is preserved and now runs earlier in the flow, which is strictly more restrictive for passthrough paths.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable