### PR TITLE
feat: adds container creation cost support

### DIFF
--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1574,13 +1574,13 @@ type ChatCompletionTokensDetails struct {
 }
 
 type BifrostCost struct {
-	InputTokensCost     float64 `json:"input_tokens_cost,omitempty"`
-	OutputTokensCost    float64 `json:"output_tokens_cost,omitempty"`
-	ReasoningTokensCost float64 `json:"reasoning_tokens_cost,omitempty"`
-	CitationTokensCost  float64 `json:"citation_tokens_cost,omitempty"`
-	SearchQueriesCost   float64 `json:"search_queries_cost,omitempty"`
-	RequestCost         float64 `json:"request_cost,omitempty"`
-	TotalCost           float64 `json:"total_cost,omitempty"`
+	InputTokensCost             float64 `json:"input_tokens_cost,omitempty"`
+	OutputTokensCost            float64 `json:"output_tokens_cost,omitempty"`
+	ReasoningTokensCost         float64 `json:"reasoning_tokens_cost,omitempty"`
+	CitationTokensCost          float64 `json:"citation_tokens_cost,omitempty"`
+	SearchQueriesCost           float64 `json:"search_queries_cost,omitempty"`
+	RequestCost                 float64 `json:"request_cost,omitempty"`
+	TotalCost                   float64 `json:"total_cost,omitempty"`
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for BifrostCost.

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -177,7 +177,11 @@ type costInput struct {
 	videoSeconds        *int
 	ocrProcessedPages   *int
 	ocrIsAnnotated      *bool
-	tier                serviceTier
+	// containerIdentifierString, when non-empty, replaces the actual requested/resolved
+	// model names during pricing lookup. Used for request types whose cost is not
+	// tied to a specific model. Currently only used for container creates.
+	containerIdentifierString string
+	tier                      serviceTier
 }
 
 // GetPricingEntryForModel returns the pricing data
@@ -266,6 +270,14 @@ func (mc *ModelCatalog) computeCacheEmbeddingCost(cacheDebug *schemas.BifrostCac
 	return float64(*cacheDebug.InputTokens) * tieredInputRate(pricing, *cacheDebug.InputTokens, serviceTier{})
 }
 
+// computeContainerCreationCost returns the cost for creating a container from an already-resolved pricing entry.
+func computeContainerCreationCost(pricing *configstoreTables.TableModelPricing) float64 {
+	if pricing == nil || pricing.CodeInterpreterCostPerSession == nil {
+		return 0
+	}
+	return *pricing.CodeInterpreterCostPerSession
+}
+
 // calculateBaseCost extracts usage from the response and routes to the appropriate compute function.
 func (mc *ModelCatalog) calculateBaseCost(result *schemas.BifrostResponse, scopes PricingLookupScopes) float64 {
 	extraFields := result.GetExtraFields()
@@ -287,15 +299,23 @@ func (mc *ModelCatalog) calculateBaseCost(result *schemas.BifrostResponse, scope
 	}
 
 	// If no usage data at all, nothing to price
-	if input.usage == nil && input.audioSeconds == nil && input.audioTokenDetails == nil && input.imageUsage == nil && input.videoSeconds == nil && input.audioTextInputChars == 0 && input.ocrProcessedPages == nil {
+	if input.usage == nil && input.audioSeconds == nil && input.audioTokenDetails == nil && input.imageUsage == nil && input.videoSeconds == nil && input.audioTextInputChars == 0 && input.ocrProcessedPages == nil && input.containerIdentifierString == "" {
 		return 0
 	}
 
 	// Normalize stream request types to their base type for pricing lookup
 	requestType = normalizeStreamRequestType(requestType)
 
+	// When a pricing model override is set, use it in place of the actual requested/resolved
+	// model names during pricing lookup (e.g. container creates always look up "container").
+	lookupModel, lookupResolved := originalModelRequested, resolvedModelUsed
+	if input.containerIdentifierString != "" {
+		lookupModel = input.containerIdentifierString
+		lookupResolved = input.containerIdentifierString
+	}
+
 	// Resolve pricing entry with deployment fallback
-	pricing := mc.resolvePricing(provider, originalModelRequested, resolvedModelUsed, requestType, scopes)
+	pricing := mc.resolvePricing(provider, lookupModel, lookupResolved, requestType, scopes)
 	if pricing == nil {
 		return 0
 	}
@@ -318,6 +338,8 @@ func (mc *ModelCatalog) calculateBaseCost(result *schemas.BifrostResponse, scope
 		return computeVideoCost(pricing, input.usage, input.videoSeconds, input.tier)
 	case schemas.OCRRequest:
 		return computeOCRCost(pricing, input.ocrProcessedPages, input.ocrIsAnnotated)
+	case schemas.ContainerCreateRequest:
+		return computeContainerCreationCost(pricing)
 	default:
 		return 0
 	}
@@ -402,6 +424,13 @@ func extractCostInput(result *schemas.BifrostResponse) costInput {
 		input.ocrProcessedPages = &pages
 		isAnnotated := result.OCRResponse.DocumentAnnotation != nil && *result.OCRResponse.DocumentAnnotation != ""
 		input.ocrIsAnnotated = &isAnnotated
+
+	case result.ContainerCreateResponse != nil:
+		if memLimit := result.ContainerCreateResponse.MemoryLimit; memLimit != "" {
+			input.containerIdentifierString = "container-" + memLimit
+		} else {
+			input.containerIdentifierString = "container"
+		}
 	}
 
 	return input
@@ -1221,6 +1250,24 @@ func (mc *ModelCatalog) getBasePricing(model, provider string, requestType schem
 		pricing, ok = mc.pricingData[makeKey(model, provider, normalizeRequestType(schemas.ImageGenerationRequest))]
 		if ok {
 			return &pricing, true
+		}
+	}
+
+	// Lookup fallback chain for container_create:
+	// 1. Try chat mode for the same model (e.g. "container-1g" in chat mode)
+	// 2. Try the base "container" model in chat mode (default rate when no memory-specific entry exists)
+	if requestType == schemas.ContainerCreateRequest {
+		mc.logger.Debug("primary lookup failed, trying chat mode for container create pricing")
+		pricing, ok = mc.pricingData[makeKey(model, provider, normalizeRequestType(schemas.ChatCompletionRequest))]
+		if ok {
+			return &pricing, true
+		}
+		if model != "container" {
+			mc.logger.Debug("memory-specific container pricing not found, falling back to base container entry")
+			pricing, ok = mc.pricingData[makeKey("container", provider, normalizeRequestType(schemas.ChatCompletionRequest))]
+			if ok {
+				return &pricing, true
+			}
 		}
 	}
 

--- a/framework/modelcatalog/pricing_test.go
+++ b/framework/modelcatalog/pricing_test.go
@@ -2428,3 +2428,168 @@ func TestComputeImageCost_BothHaveTokens_IgnoresPerImage(t *testing.T) {
 	// Output: 800 * $0.000015 = $0.012 (tokens present, per-image ignored)
 	assert.InDelta(t, 0.013, cost, 1e-12)
 }
+
+func TestCalculateCost_ResponsesWithCodeInterpreter(t *testing.T) {
+	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("gpt-4.1", "openai", "chat"): chatPricing(0.000002, 0.000008),
+	})
+
+	ciType := schemas.ResponsesMessageTypeCodeInterpreterCall
+	resp := &schemas.BifrostResponse{
+		ResponsesResponse: &schemas.BifrostResponsesResponse{
+			Usage: &schemas.ResponsesResponseUsage{
+				InputTokens:  579,
+				OutputTokens: 334,
+				TotalTokens:  913,
+			},
+			Output: []schemas.ResponsesMessage{
+				{Type: &ciType},
+				{Type: &ciType},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            schemas.ResponsesRequest,
+				Provider:               schemas.OpenAI,
+				OriginalModelRequested: "gpt-4.1",
+				ResolvedModelUsed:      "gpt-4.1",
+			},
+		},
+	}
+
+	cost := mc.CalculateCost(resp, nil)
+	// Token cost only: 579*0.000002 + 334*0.000008 = 0.001158 + 0.002672 = 0.003830
+	// Session cost is now tracked via ContainerCreateRequest, not per-response
+	assert.InDelta(t, 0.003830, cost, 1e-6)
+}
+
+// ---------------------------------------------------------------------------
+// computeContainerCreationCost
+// ---------------------------------------------------------------------------
+
+func TestComputeContainerCreationCost_Basic(t *testing.T) {
+	p := configstoreTables.TableModelPricing{
+		Model:                         "container",
+		Provider:                      "openai",
+		Mode:                          "chat",
+		CodeInterpreterCostPerSession: bifrost.Ptr(0.03),
+	}
+	assert.InDelta(t, 0.03, computeContainerCreationCost(&p), 1e-12)
+}
+
+func TestComputeContainerCreationCost_NilPricing(t *testing.T) {
+	assert.Equal(t, 0.0, computeContainerCreationCost(nil))
+}
+
+func TestComputeContainerCreationCost_NilRate(t *testing.T) {
+	p := configstoreTables.TableModelPricing{
+		Model:    "container",
+		Provider: "openai",
+		Mode:     "chat",
+	}
+	assert.Equal(t, 0.0, computeContainerCreationCost(&p))
+}
+
+// ---------------------------------------------------------------------------
+// ContainerCreateRequest end-to-end via CalculateCost
+// ---------------------------------------------------------------------------
+
+func TestCalculateCost_ContainerCreate_NoMemoryLimit(t *testing.T) {
+	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("container", "openai", "chat"): {
+			Model:                         "container",
+			Provider:                      "openai",
+			Mode:                          "chat",
+			CodeInterpreterCostPerSession: bifrost.Ptr(0.03),
+		},
+	})
+
+	resp := &schemas.BifrostResponse{
+		ContainerCreateResponse: &schemas.BifrostContainerCreateResponse{
+			ID:   "cntr_abc123",
+			Name: "test-container",
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ContainerCreateRequest,
+				Provider:    schemas.OpenAI,
+			},
+		},
+	}
+
+	cost := mc.CalculateCost(resp, nil)
+	assert.InDelta(t, 0.03, cost, 1e-12)
+}
+
+func TestCalculateCost_ContainerCreate_MemorySpecificEntry(t *testing.T) {
+	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("container", "openai", "chat"): {
+			Model:                         "container",
+			Provider:                      "openai",
+			Mode:                          "chat",
+			CodeInterpreterCostPerSession: bifrost.Ptr(0.03),
+		},
+		makeKey("container-4g", "openai", "chat"): {
+			Model:                         "container-4g",
+			Provider:                      "openai",
+			Mode:                          "chat",
+			CodeInterpreterCostPerSession: bifrost.Ptr(0.12),
+		},
+	})
+
+	resp := &schemas.BifrostResponse{
+		ContainerCreateResponse: &schemas.BifrostContainerCreateResponse{
+			ID:          "cntr_abc123",
+			Name:        "test-container",
+			MemoryLimit: "4g",
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ContainerCreateRequest,
+				Provider:    schemas.OpenAI,
+			},
+		},
+	}
+
+	cost := mc.CalculateCost(resp, nil)
+	assert.InDelta(t, 0.12, cost, 1e-12)
+}
+
+func TestCalculateCost_ContainerCreate_FallsBackToBaseEntry(t *testing.T) {
+	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("container", "openai", "chat"): {
+			Model:                         "container",
+			Provider:                      "openai",
+			Mode:                          "chat",
+			CodeInterpreterCostPerSession: bifrost.Ptr(0.03),
+		},
+	})
+
+	resp := &schemas.BifrostResponse{
+		ContainerCreateResponse: &schemas.BifrostContainerCreateResponse{
+			ID:          "cntr_abc123",
+			Name:        "test-container",
+			MemoryLimit: "4g",
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ContainerCreateRequest,
+				Provider:    schemas.OpenAI,
+			},
+		},
+	}
+
+	// No container-4g entry — should fall back to base "container" rate
+	cost := mc.CalculateCost(resp, nil)
+	assert.InDelta(t, 0.03, cost, 1e-12)
+}
+
+func TestCalculateCost_ContainerCreate_NoPricingEntry(t *testing.T) {
+	mc := testCatalogWithPricing(nil)
+
+	resp := &schemas.BifrostResponse{
+		ContainerCreateResponse: &schemas.BifrostContainerCreateResponse{
+			ID:   "cntr_abc123",
+			Name: "test-container",
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.ContainerCreateRequest,
+				Provider:    schemas.OpenAI,
+			},
+		},
+	}
+
+	cost := mc.CalculateCost(resp, nil)
+	assert.Equal(t, 0.0, cost)
+}

--- a/framework/modelcatalog/utils.go
+++ b/framework/modelcatalog/utils.go
@@ -97,6 +97,8 @@ func normalizeRequestType(reqType schemas.RequestType) string {
 		baseType = "video_generation"
 	case schemas.OCRRequest:
 		baseType = "ocr"
+	case schemas.ContainerCreateRequest:
+		baseType = "container_create"
 	}
 
 	return baseType

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -599,6 +599,7 @@ export function LogDetailView({
     resolvedSelectedPromptName ?? log.selected_prompt_name ?? "";
 
   const isContainer = isContainerOperation(log.object);
+  const showTabs = !isContainer;
   const isPassthrough = isPassthroughOperation(log.object);
   const passthroughParams = isPassthrough
     ? (log.params as {
@@ -1574,18 +1575,20 @@ export function LogDetailView({
           )}
         </div>
       </details>
-      <Tabs defaultValue="messages" className="gap-2">
+      <Tabs defaultValue={showTabs ? "messages" : "plugins"} className="gap-2">
         <TabsList className="bg-muted/60 h-10 w-fit">
-          <TabsTrigger value="messages" className="px-3">
-            Messages
-            {log.input_history?.length ? (
-              <span className="bg-background text-muted-foreground ml-1.5 rounded-sm border px-2 py-0.5 text-[10px] tabular-nums">
-                {log.input_history.length + (log.output_message ? 1 : 0)}
-              </span>
-            ) : null}
-          </TabsTrigger>
+          {showTabs && (
+            <TabsTrigger value="messages" className="px-3">
+              Messages
+              {log.input_history?.length ? (
+                <span className="bg-background text-muted-foreground ml-1.5 rounded-sm border px-2 py-0.5 text-[10px] tabular-nums">
+                  {log.input_history.length + (log.output_message ? 1 : 0)}
+                </span>
+              ) : null}
+            </TabsTrigger>
+          )}
 
-          {!isPassthrough && !log.list_models_output && (
+          {showTabs && !isPassthrough && !log.list_models_output && (
             <TabsTrigger value="tools" className="px-3">
               Tools
               {log.params?.tools?.length ? (
@@ -1595,14 +1598,16 @@ export function LogDetailView({
               ) : null}
             </TabsTrigger>
           )}
-          <TabsTrigger value="routing" className="px-3">
-            Routing
-            {log.routing_engine_logs ? (
-              <span className="bg-background text-muted-foreground ml-1.5 rounded-sm border px-2 py-0.5 text-[10px] tabular-nums">
-                {log.routing_engine_logs.split("\n").filter(Boolean).length}
-              </span>
-            ) : null}
-          </TabsTrigger>
+          {showTabs && (
+            <TabsTrigger value="routing" className="px-3">
+              Routing
+              {log.routing_engine_logs ? (
+                <span className="bg-background text-muted-foreground ml-1.5 rounded-sm border px-2 py-0.5 text-[10px] tabular-nums">
+                  {log.routing_engine_logs.split("\n").filter(Boolean).length}
+                </span>
+              ) : null}
+            </TabsTrigger>
+          )}
           <TabsTrigger value="plugins" className="px-3">
             Plugin Logs
             {pluginLogCount > 0 ? (
@@ -2506,7 +2511,7 @@ export function LogDetailView({
           )}
           {rawResponse && log.status !== "processing" && (
             <>
-              <div className="text-muted-foreground text-[12px]">
+              <div className="text-muted-foreground text-[12px] pt-4">
                 Raw Response from{" "}
                 <span className="text-foreground font-medium capitalize">
                   {log.provider}


### PR DESCRIPTION
## Summary

Adds cost tracking for `ContainerCreateRequest` operations. Container creation costs are priced per-session using a `CodeInterpreterCostPerSession` rate, with support for memory-limit-specific pricing entries (e.g. `container-4g`) that fall back to a base `container` entry when no memory-specific rate is configured.

## Changes

- Added `CodeInterpreterSessionCost` field to `BifrostCost` to surface container session costs in the response.
- Introduced `computeContainerCreationCost` which reads `CodeInterpreterCostPerSession` from a resolved pricing entry.
- Added `pricingModelOverride` to `costInput` so container create requests bypass model-based pricing lookup and instead resolve against a synthetic key (`container` or `container-<memoryLimit>`).
- Extended `extractCostInput` to populate `pricingModelOverride` from `ContainerCreateResponse.MemoryLimit`.
- Added a fallback lookup chain in `getBasePricing` for `ContainerCreateRequest`: tries the memory-specific entry first, then falls back to the base `container` entry in chat mode.
- Registered `ContainerCreateRequest` in `GetPricingEntryForModel` and mapped it to `container_create` in `normalizeRequestType`.
- Fixed the log detail view so that container operation logs skip the Messages, Tools, and Routing tabs (which are irrelevant for container ops) and default directly to the Plugin Logs tab. Also added top padding to the raw response section for container logs.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/... -run TestCalculateCost_ContainerCreate
go test ./framework/modelcatalog/... -run TestComputeContainerCreationCost
go test ./...
```

To validate end-to-end:
1. Configure a pricing entry for `container` (and optionally `container-4g`) with `code_interpreter_cost_per_session` set.
2. Issue a `ContainerCreateRequest` with and without a `MemoryLimit`.
3. Confirm the returned `BifrostCost.code_interpreter_session_cost` reflects the correct per-session rate, and that a memory-specific request falls back to the base rate when no memory-specific entry exists.

For the UI, open a container operation log and confirm that only the Plugin Logs tab is shown (Messages, Tools, and Routing tabs are hidden).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable