### PR TITLE
fix: drops messages with empty text or signature and adds conversion of thinking block for openai bedrock models

### DIFF
--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1814,8 +1814,6 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 							})
 						}
 					} else {
-						// Non-Anthropic, non-Nova models: budget_tokens only
-						minBudgetTokens := MinimumReasoningMaxTokens
 						modelDefaultMaxTokens := providerUtils.GetMaxOutputTokensOrDefault(bifrostReq.Model, DefaultCompletionMaxTokens)
 						defaultMaxTokens := modelDefaultMaxTokens
 						if inferenceConfig.MaxTokens != nil {
@@ -1823,11 +1821,11 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 						} else {
 							inferenceConfig.MaxTokens = schemas.Ptr(modelDefaultMaxTokens)
 						}
-						budgetTokens, err := providerUtils.GetBudgetTokensFromReasoningEffort(*bifrostReq.Params.Reasoning.Effort, minBudgetTokens, defaultMaxTokens)
+						budgetTokens, err := providerUtils.GetBudgetTokensFromReasoningEffort(*bifrostReq.Params.Reasoning.Effort, MinimumReasoningMaxTokens, defaultMaxTokens)
 						if err != nil {
 							return nil, err
 						}
-						bedrockReq.AdditionalModelRequestFields.Set("reasoning_config", map[string]any{
+						bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", map[string]any{
 							"type":          "enabled",
 							"budget_tokens": budgetTokens,
 						})
@@ -1842,7 +1840,7 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 							"type": "disabled",
 						})
 					} else {
-						bedrockReq.AdditionalModelRequestFields.Set("reasoning_config", map[string]any{
+						bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", map[string]any{
 							"type": "disabled",
 						})
 					}

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -205,7 +205,7 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 
 				bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", config)
 			} else {
-				bedrockReq.AdditionalModelRequestFields.Set("reasoning_config", map[string]any{
+				bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", map[string]any{
 					"type":          "enabled",
 					"budget_tokens": tokenBudget,
 				})
@@ -285,7 +285,7 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 					"type": "disabled",
 				})
 			} else {
-				bedrockReq.AdditionalModelRequestFields.Set("reasoning_config", map[string]any{
+				bedrockReq.AdditionalModelRequestFields.Set("reasoningConfig", map[string]any{
 					"type": "disabled",
 				})
 			}

--- a/plugins/compat/dropparams.go
+++ b/plugins/compat/dropparams.go
@@ -184,6 +184,13 @@ func dropUnsupportedParams(ctx *schemas.BifrostContext, req *schemas.BifrostRequ
 		}
 	}
 
+	if req.ResponsesRequest != nil && req.ResponsesRequest.Input != nil {
+		if req.ResponsesRequest.Provider == schemas.Bedrock && !schemas.IsAnthropicModel(req.ResponsesRequest.Model) {
+			droppedKeys := applyBedrockResponsesCompatibility(req.ResponsesRequest)
+			dropped = append(dropped, droppedKeys...)
+		}
+	}
+
 	if req.ResponsesRequest != nil {
 		// all anthropic models support cache_control
 		// for bedrock models cache_control is converted to cachePoint
@@ -309,6 +316,33 @@ func dropCacheControlFromResponsesMessages(req *schemas.BifrostResponsesRequest)
 				dropped = append(dropped, fmt.Sprintf("tools[%d].cache_control", i))
 			}
 		}
+	}
+	return dropped
+}
+
+// applyBedrockResponsesCompatibility sanitizes messages for OpenAI-compatible Bedrock models:
+// - drops empty text content blocks
+// - strips reasoning signatures (Anthropic-specific, not supported by OpenAI models)
+func applyBedrockResponsesCompatibility(req *schemas.BifrostResponsesRequest) []string {
+	var dropped []string
+	for i := range req.Input {
+		msg := &req.Input[i]
+		if msg.Content == nil || msg.Content.ContentBlocks == nil {
+			continue
+		}
+		kept := msg.Content.ContentBlocks[:0]
+		for j, block := range msg.Content.ContentBlocks {
+			if block.Text != nil && *block.Text == "" {
+				dropped = append(dropped, fmt.Sprintf("input[%d].content.content_blocks[%d]", i, j))
+				continue
+			}
+			if block.Signature != nil {
+				msg.Content.ContentBlocks[j].Signature = nil
+				dropped = append(dropped, fmt.Sprintf("input[%d].content.content_blocks[%d].signature", i, j))
+			}
+			kept = append(kept, msg.Content.ContentBlocks[j])
+		}
+		msg.Content.ContentBlocks = kept
 	}
 	return dropped
 }


### PR DESCRIPTION
## Summary

Fixes reasoning config field naming for non-Anthropic Bedrock models and adds message compatibility sanitization for OpenAI-compatible Bedrock models via the Responses API.

## Changes

- Renamed `reasoning_config` to `reasoningConfig` in `responses.go` and `utils.go` to match the correct field name expected by non-Anthropic Bedrock models
- Removed an unnecessary intermediate variable (`minBudgetTokens`) in the reasoning effort conversion path in `responses.go`, inlining `MinimumReasoningMaxTokens` directly
- Added `applyBedrockResponsesCompatibility` in `plugins/compat/dropparams.go` that sanitizes Responses API input messages for non-Anthropic Bedrock models by dropping empty text content blocks and stripping Anthropic-specific reasoning signatures
- The new compatibility function is invoked automatically when the provider is Bedrock and the model is not an Anthropic model

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Send a request targeting a non-Anthropic model on Bedrock with reasoning parameters set. Verify that:

- The outgoing request contains `reasoningConfig` (not `reasoning_config`)
- Empty text blocks and reasoning signatures are stripped from input messages before the request is forwarded
- Tested on these following models in claude code:

```
"model": "bedrock/anthropic.claude-3-haiku-20240307-v1:0"
"model": "bedrock/openai.gpt-oss-120b-1:0"
"model": "bedrock/mistral.magistral-small-2509"
"model": "bedrock/deepseek.v3.2"
"model": "bedrock/google.gemma-3-27b-it"
"model": "bedrock/minimax.minimax-m2"
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. The change only affects field naming and message sanitization for non-Anthropic Bedrock models.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable