### PR TITLE
feat: add `mcp_client_id` to OAuth configs, clean up orphaned OAuth records, and cancel prior pending flows on re-auth

### DIFF
--- a/core/schemas/oauth.go
+++ b/core/schemas/oauth.go
@@ -57,6 +57,7 @@ type OAuth2Config struct {
 	Scopes          []string `json:"scopes,omitempty"`           // Optional: Can be discovered
 	ServerURL       string   `json:"server_url"`                 // MCP server URL for OAuth discovery (required if URLs not provided)
 	UseDiscovery    bool     `json:"use_discovery,omitempty"`    // Deprecated: Discovery now happens automatically when URLs are missing
+	MCPClientID     string   `json:"mcp_client_id,omitempty"`    // client_id of the MCP client initiating this flow; used to cancel prior pending flows
 }
 
 // OauthToken represents OAuth access and refresh tokens

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -635,13 +635,22 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddMCPClientDisabledColumn(ctx, db); err != nil {
 		return err
 	}
+	return nil
 	if err := migrationUniqueTeamNames(ctx, db); err != nil {
 		return err
 	}
 	if err := migrationDropAllowDirectKeysColumn(ctx, db); err != nil {
 		return err
 	}
-	return nil
+	if err := migrationCleanupOrphanedOAuthRecords(ctx, db); err != nil {
+		return err
+	}
+	if err := migrationAddMCPClientIDToOauthConfigs(ctx, db); err != nil {
+		return err
+	}
+	if err := migrationAddTokenIDFKToOauthConfigs(ctx, db); err != nil {
+		return err
+	}
 }
 
 func migrationAddStoreRawRequestResponseColumn(ctx context.Context, db *gorm.DB) error {
@@ -7435,4 +7444,240 @@ func migrationUniqueTeamNames(ctx context.Context, db *gorm.DB) error {
 			return nil
 		},
 	})
+}
+
+// migrationCleanupOrphanedOAuthRecords deletes stale OAuth records that were left behind
+// by abandoned flows, failed rotations, and missing cascade deletes on MCP client removal.
+func migrationCleanupOrphanedOAuthRecords(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "cleanup_orphaned_oauth_records",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+
+			// 1. Delete oauth_user_tokens whose mcp_client_id no longer exists.
+			if err := tx.Exec(`
+				DELETE FROM oauth_user_tokens
+				WHERE mcp_client_id NOT IN (
+					SELECT client_id FROM config_mcp_clients
+				)
+			`).Error; err != nil {
+				return fmt.Errorf("failed to clean up orphaned oauth_user_tokens: %w", err)
+			}
+
+			// 2. Delete oauth_user_sessions whose mcp_client_id no longer exists.
+			if err := tx.Exec(`
+				DELETE FROM oauth_user_sessions
+				WHERE mcp_client_id NOT IN (
+					SELECT client_id FROM config_mcp_clients
+				)
+			`).Error; err != nil {
+				return fmt.Errorf("failed to clean up orphaned oauth_user_sessions: %w", err)
+			}
+
+			// 3. Delete oauth_tokens owned by orphaned oauth_configs (configs not referenced
+			//    by any MCP client). Must run before step 4 so the tokens are gone before
+			//    their parent configs are deleted.
+			if err := tx.Exec(`
+				DELETE FROM oauth_tokens
+				WHERE id IN (
+					SELECT token_id FROM oauth_configs
+					WHERE token_id IS NOT NULL
+					AND id NOT IN (
+						SELECT oauth_config_id FROM config_mcp_clients WHERE oauth_config_id IS NOT NULL
+					)
+				)
+			`).Error; err != nil {
+				return fmt.Errorf("failed to clean up oauth_tokens of orphaned oauth_configs: %w", err)
+			}
+
+			// 4. Delete oauth_configs that are not referenced by any MCP client AND are
+			//    not in-flight pending flows (status != 'pending' or past expiry).
+			//    Excluding pending-and-unexpired rows avoids wiping OAuth handshakes
+			//    that are actively waiting for the user to complete authorization.
+			if err := tx.Exec(`
+				DELETE FROM oauth_configs
+				WHERE id NOT IN (
+					SELECT oauth_config_id FROM config_mcp_clients WHERE oauth_config_id IS NOT NULL
+				)
+				AND NOT (status = 'pending' AND expires_at > NOW())
+			`).Error; err != nil {
+				return fmt.Errorf("failed to clean up orphaned oauth_configs: %w", err)
+			}
+
+			// 5. Catch-all: delete any oauth_tokens now unreferenced by any oauth_config
+			//    (e.g. pre-existing orphans from before this fix).
+			if err := tx.Exec(`
+				DELETE FROM oauth_tokens
+				WHERE id NOT IN (
+					SELECT token_id FROM oauth_configs WHERE token_id IS NOT NULL
+				)
+			`).Error; err != nil {
+				return fmt.Errorf("failed to clean up remaining orphaned oauth_tokens: %w", err)
+			}
+
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			// Data cleanup is irreversible.
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running cleanup_orphaned_oauth_records migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddMCPClientIDToOauthConfigs adds the mcp_client_id column to oauth_configs and
+// enforces proper FK constraints on all three OAuth tables that reference config_mcp_clients.
+func migrationAddMCPClientIDToOauthConfigs(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_mcp_client_id_to_oauth_configs_and_fks",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			// 1. Add mcp_client_id column to oauth_configs
+			if !mg.HasColumn(&tables.TableOauthConfig{}, "mcp_client_id") {
+				if err := mg.AddColumn(&tables.TableOauthConfig{}, "MCPClientID"); err != nil {
+					return fmt.Errorf("failed to add mcp_client_id to oauth_configs: %w", err)
+				}
+			}
+
+			// 2. Backfill mcp_client_id for existing oauth_configs that are currently the
+			//    active config of an MCP client. This lets the CASCADE FK cover historical rows.
+			if err := tx.Exec(`
+				UPDATE oauth_configs
+				SET mcp_client_id = c.client_id
+				FROM config_mcp_clients c
+				WHERE c.oauth_config_id = oauth_configs.id
+				  AND oauth_configs.mcp_client_id IS NULL
+			`).Error; err != nil {
+				return fmt.Errorf("failed to backfill mcp_client_id on oauth_configs: %w", err)
+			}
+
+			// 3. FK constraints — Postgres only (SQLite lacks ALTER TABLE ADD CONSTRAINT support).
+			//    Application-level deletion code in DeleteMCPClientConfig enforces the same
+			//    invariants on SQLite.
+			if tx.Dialector.Name() != "postgres" {
+				return nil
+			}
+
+			type fkDef struct {
+				name      string
+				table     string
+				column    string
+				refTable  string
+				refColumn string
+				onDelete  string
+			}
+
+			// newFKs are constraints that don't exist yet and need to be created.
+			newFKs := []fkDef{
+				{
+					// oauth_configs.mcp_client_id → config_mcp_clients(client_id)
+					// CASCADE: deleting an MCP client deletes its orphaned/rotation oauth_configs.
+					name:      "fk_oauth_configs_mcp_client",
+					table:     "oauth_configs",
+					column:    "mcp_client_id",
+					refTable:  "config_mcp_clients",
+					refColumn: "client_id",
+					onDelete:  "CASCADE",
+				},
+				{
+					// oauth_user_tokens.mcp_client_id → config_mcp_clients(client_id)
+					// CASCADE: deleting an MCP client deletes all per-user tokens for it.
+					name:      "fk_oauth_user_tokens_mcp_client",
+					table:     "oauth_user_tokens",
+					column:    "mcp_client_id",
+					refTable:  "config_mcp_clients",
+					refColumn: "client_id",
+					onDelete:  "CASCADE",
+				},
+				{
+					// oauth_user_sessions.mcp_client_id → config_mcp_clients(client_id)
+					// CASCADE: deleting an MCP client deletes all pending per-user sessions.
+					name:      "fk_oauth_user_sessions_mcp_client",
+					table:     "oauth_user_sessions",
+					column:    "mcp_client_id",
+					refTable:  "config_mcp_clients",
+					refColumn: "client_id",
+					onDelete:  "CASCADE",
+				},
+			}
+
+			for _, fk := range newFKs {
+				if err := tx.Exec(fmt.Sprintf(
+					"ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s(%s) ON DELETE %s",
+					fk.table, fk.name, fk.column, fk.refTable, fk.refColumn, fk.onDelete,
+				)).Error; err != nil {
+					return fmt.Errorf("failed to add FK constraint %s: %w", fk.name, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if tx.Dialector.Name() == "postgres" {
+				for _, constraint := range []struct{ table, name string }{
+					{"oauth_configs", "fk_oauth_configs_mcp_client"},
+					{"oauth_user_tokens", "fk_oauth_user_tokens_mcp_client"},
+					{"oauth_user_sessions", "fk_oauth_user_sessions_mcp_client"},
+				} {
+					if err := tx.Exec(fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s", constraint.table, constraint.name)).Error; err != nil {
+						return fmt.Errorf("failed to drop FK %s: %w", constraint.name, err)
+					}
+				}
+			}
+			mg := tx.Migrator()
+			if mg.HasColumn(&tables.TableOauthConfig{}, "mcp_client_id") {
+				if err := mg.DropColumn(&tables.TableOauthConfig{}, "MCPClientID"); err != nil {
+					return fmt.Errorf("failed to drop mcp_client_id from oauth_configs: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_mcp_client_id_to_oauth_configs_and_fks migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddTokenIDFKToOauthConfigs adds a proper FK constraint on oauth_configs.token_id
+// referencing oauth_tokens.id with ON DELETE SET NULL. This prevents dangling token_id
+// references if an oauth_token is deleted independently, while keeping the application-level
+// deletion order (token first, then config) in DeleteOauthConfig.
+func migrationAddTokenIDFKToOauthConfigs(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_token_id_fk_to_oauth_configs",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if tx.Dialector.Name() != "postgres" {
+				return nil
+			}
+			// ON DELETE SET NULL: if an oauth_token is deleted, null the reference on oauth_configs
+			// rather than leaving a dangling pointer.
+			if err := tx.Exec(
+				"ALTER TABLE oauth_configs ADD CONSTRAINT fk_oauth_configs_token_id " +
+					"FOREIGN KEY (token_id) REFERENCES oauth_tokens(id) ON DELETE SET NULL",
+			).Error; err != nil {
+				return fmt.Errorf("failed to add FK constraint fk_oauth_configs_token_id: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if tx.Dialector.Name() == "postgres" {
+				if err := tx.Exec("ALTER TABLE oauth_configs DROP CONSTRAINT IF EXISTS fk_oauth_configs_token_id").Error; err != nil {
+					return fmt.Errorf("failed to drop FK fk_oauth_configs_token_id: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_token_id_fk_to_oauth_configs migration: %s", err.Error())
+	}
+	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1637,13 +1637,33 @@ func (s *RDBConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) e
 			return err
 		}
 
-		// Delete any virtual key MCP configs that reference this client
+		// Delete any virtual key MCP configs (no FK cascade covers this table)
 		if err := tx.WithContext(ctx).Where("mcp_client_id = ?", existingClient.ID).Delete(&tables.TableVirtualKeyMCPConfig{}).Error; err != nil {
 			return err
 		}
 
-		// Delete the client (this will also handle foreign key cascades)
-		return tx.WithContext(ctx).Delete(&existingClient).Error
+		// Collect token IDs from all oauth_configs for this client before deletion.
+		// DB cascades (fk_oauth_configs_mcp_client) delete the configs themselves, but
+		// there is no cascade from oauth_configs to oauth_tokens, so we must delete tokens explicitly.
+		var tokenIDs []string
+		tx.WithContext(ctx).Model(&tables.TableOauthConfig{}).
+			Where("mcp_client_id = ? AND token_id IS NOT NULL", existingClient.ClientID).
+			Pluck("token_id", &tokenIDs)
+
+		// Delete the MCP client — DB cascades handle oauth_user_tokens, oauth_user_sessions,
+		// and oauth_configs (all keyed by mcp_client_id) on Postgres.
+		if err := tx.WithContext(ctx).Delete(&existingClient).Error; err != nil {
+			return err
+		}
+
+		// Delete orphaned oauth_tokens; no cascade reaches them from oauth_configs.
+		if len(tokenIDs) > 0 {
+			if err := tx.WithContext(ctx).Where("id IN ?", tokenIDs).Delete(&tables.TableOauthToken{}).Error; err != nil {
+				return err
+			}
+		}
+
+		return nil
 	})
 }
 
@@ -4278,6 +4298,56 @@ func (s *RDBConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.T
 	return nil
 }
 
+// DeleteOauthConfig deletes an OAuth config and its associated token by config ID.
+func (s *RDBConfigStore) DeleteOauthConfig(ctx context.Context, id string) error {
+	return s.DB().Transaction(func(tx *gorm.DB) error {
+		var config tables.TableOauthConfig
+		if err := tx.WithContext(ctx).Where("id = ?", id).First(&config).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
+			}
+			return fmt.Errorf("failed to find oauth config: %w", err)
+		}
+		if config.TokenID != nil {
+			if err := tx.WithContext(ctx).Where("id = ?", *config.TokenID).Delete(&tables.TableOauthToken{}).Error; err != nil {
+				return fmt.Errorf("failed to delete oauth token: %w", err)
+			}
+		}
+		if err := tx.WithContext(ctx).Delete(&config).Error; err != nil {
+			return fmt.Errorf("failed to delete oauth config: %w", err)
+		}
+		return nil
+	})
+}
+
+// DeletePendingOauthConfigsByMCPClient deletes all oauth_configs in "pending" status for a given MCP client,
+// along with their associated tokens. Used to cancel abandoned or superseded OAuth flows before starting a new one.
+func (s *RDBConfigStore) DeletePendingOauthConfigsByMCPClient(ctx context.Context, mcpClientID string) error {
+	return s.DB().Transaction(func(tx *gorm.DB) error {
+		var configs []tables.TableOauthConfig
+		if err := tx.WithContext(ctx).Where("mcp_client_id = ? AND status = 'pending'", mcpClientID).Find(&configs).Error; err != nil {
+			return fmt.Errorf("failed to find pending oauth configs: %w", err)
+		}
+		for _, cfg := range configs {
+			if cfg.TokenID != nil {
+				if err := tx.WithContext(ctx).Where("id = ?", *cfg.TokenID).Delete(&tables.TableOauthToken{}).Error; err != nil {
+					return fmt.Errorf("failed to delete oauth token for config %s: %w", cfg.ID, err)
+				}
+			}
+		}
+		if len(configs) > 0 {
+			ids := make([]string, len(configs))
+			for i, cfg := range configs {
+				ids[i] = cfg.ID
+			}
+			if err := tx.WithContext(ctx).Where("id IN ?", ids).Delete(&tables.TableOauthConfig{}).Error; err != nil {
+				return fmt.Errorf("failed to delete pending oauth configs: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
 // UpdateOauthToken updates an existing OAuth token
 func (s *RDBConfigStore) UpdateOauthToken(ctx context.Context, token *tables.TableOauthToken) error {
 	result := s.DB().WithContext(ctx).Save(token)
@@ -4490,6 +4560,25 @@ func (s *RDBConfigStore) UpdateOauthUserToken(ctx context.Context, token *tables
 		return fmt.Errorf("failed to update oauth user token: %w", result.Error)
 	}
 	return nil
+}
+
+// MigrateOauthUserTokensToConfig re-points all per-user tokens and sessions that reference
+// oldConfigID to newConfigID. Used during per-user OAuth credential rotation so that existing
+// user tokens can still be refreshed after the old template config is removed.
+func (s *RDBConfigStore) MigrateOauthUserTokensToConfig(ctx context.Context, oldConfigID, newConfigID string) error {
+	return s.DB().Transaction(func(tx *gorm.DB) error {
+		if err := tx.WithContext(ctx).Model(&tables.TableOauthUserToken{}).
+			Where("oauth_config_id = ?", oldConfigID).
+			Update("oauth_config_id", newConfigID).Error; err != nil {
+			return fmt.Errorf("failed to migrate oauth_user_tokens to new config: %w", err)
+		}
+		if err := tx.WithContext(ctx).Model(&tables.TableOauthUserSession{}).
+			Where("oauth_config_id = ?", oldConfigID).
+			Update("oauth_config_id", newConfigID).Error; err != nil {
+			return fmt.Errorf("failed to migrate oauth_user_sessions to new config: %w", err)
+		}
+		return nil
+	})
 }
 
 // DeleteOauthUserToken deletes a per-user OAuth token by its ID

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -302,6 +302,8 @@ type ConfigStore interface {
 	GetOauthConfigByTokenID(ctx context.Context, tokenID string) (*tables.TableOauthConfig, error)
 	CreateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error
 	UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error
+	DeleteOauthConfig(ctx context.Context, id string) error
+	DeletePendingOauthConfigsByMCPClient(ctx context.Context, mcpClientID string) error
 
 	// OAuth token CRUD
 	GetOauthTokenByID(ctx context.Context, id string) (*tables.TableOauthToken, error)
@@ -325,6 +327,7 @@ type ConfigStore interface {
 	UpdateOauthUserToken(ctx context.Context, token *tables.TableOauthUserToken) error
 	DeleteOauthUserToken(ctx context.Context, id string) error
 	DeleteOauthUserTokensByMCPClient(ctx context.Context, mcpClientID string) error
+	MigrateOauthUserTokensToConfig(ctx context.Context, oldConfigID, newConfigID string) error
 
 	// Per-user OAuth Authorization Server CRUD (Bifrost as OAuth server)
 	GetPerUserOAuthClientByClientID(ctx context.Context, clientID string) (*tables.TablePerUserOAuthClient, error)

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -34,7 +34,7 @@ type TableMCPClient struct {
 
 	// OAuth authentication fields
 	AuthType      string            `gorm:"type:varchar(20);default:'headers'" json:"auth_type"`                         // "none", "headers", "oauth"
-	OauthConfigID *string           `gorm:"type:varchar(255);index;constraint:OnDelete:CASCADE" json:"oauth_config_id"`  // Foreign key to oauth_configs.ID with CASCADE delete
+	OauthConfigID *string           `gorm:"type:varchar(255);index;constraint:OnDelete:CASCADE" json:"oauth_config_id"`  // Foreign key to oauth_configs.ID — deleting the config also removes this MCP client
 	OauthConfig   *TableOauthConfig `gorm:"foreignKey:OauthConfigID;references:ID;constraint:OnDelete:CASCADE" json:"-"` // Gorm relationship
 
 	AllowOnAllVirtualKeys bool `gorm:"default:false" json:"allow_on_all_virtual_keys"` // Whether to allow the MCP client to run on all virtual keys

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -28,6 +28,7 @@ type TableOauthConfig struct {
 	ServerURL           string          `gorm:"type:text" json:"server_url"`                     // MCP server URL for OAuth discovery
 	UseDiscovery        bool            `gorm:"default:false" json:"use_discovery"`              // Flag to enable OAuth discovery
 	MCPClientConfigJSON *string         `gorm:"type:text" json:"-"`                              // JSON serialized MCPClientConfig for multi-instance support (pending MCP client waiting for OAuth completion)
+	MCPClientID         *string   `gorm:"type:varchar(255);index" json:"mcp_client_id,omitempty"`            // client_id of the MCP client that initiated this flow (FK enforced via migration on Postgres)
 	EncryptionStatus    string          `gorm:"type:varchar(20);default:'plain_text'" json:"-"`
 	CreatedAt           time.Time       `gorm:"index;not null" json:"created_at"`
 	UpdatedAt           time.Time       `gorm:"index;not null" json:"updated_at"`

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -458,8 +458,20 @@ func (p *OAuth2Provider) InitiateOAuthFlow(ctx context.Context, config *schemas.
 		return nil, fmt.Errorf("failed to serialize scopes: %w", err)
 	}
 
+	// Cancel any prior pending flows for this MCP client before starting a new one.
+	// This prevents accumulation of stale pending oauth_configs from abandoned or retried flows.
+	if config.MCPClientID != "" {
+		if err := p.configStore.DeletePendingOauthConfigsByMCPClient(ctx, config.MCPClientID); err != nil {
+			logger.Warn("Failed to cancel prior pending OAuth flows for MCP client", "mcp_client_id", config.MCPClientID, "error", err)
+		}
+	}
+
 	// Create oauth_config record (using dynamically registered or user-provided client_id)
 	expiresAt := time.Now().Add(15 * time.Minute)
+	var mcpClientID *string
+	if config.MCPClientID != "" {
+		mcpClientID = &config.MCPClientID
+	}
 	oauthConfigRecord := &tables.TableOauthConfig{
 		ID:              oauthConfigID,
 		ClientID:        schemas.NewEnvVar(clientID), // May be from dynamic registration
@@ -476,6 +488,7 @@ func (p *OAuth2Provider) InitiateOAuthFlow(ctx context.Context, config *schemas.
 		ServerURL:       config.ServerURL,
 		UseDiscovery:    config.UseDiscovery,
 		ExpiresAt:       expiresAt,
+		MCPClientID:     mcpClientID,
 	}
 
 	if err := p.configStore.CreateOauthConfig(ctx, oauthConfigRecord); err != nil {

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -532,6 +532,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			RedirectURI:     redirectURI,
 			Scopes:          req.OauthConfig.Scopes,
 			ServerURL:       req.ConnectionString.GetValue(),
+			// MCPClientID intentionally omitted: client doesn't exist in DB yet
 		})
 		if err != nil {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initiate OAuth flow: %v", err))
@@ -615,14 +616,15 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		// ServerURL comes from ConnectionString (MCP server URL for OAuth discovery)
 		// ClientID is optional - will be obtained via dynamic registration if not provided
 		flowInitiation, err := h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
-			ClientID:        req.OauthConfig.ClientID,
-			ClientSecret:    req.OauthConfig.ClientSecret,
-			AuthorizeURL:    req.OauthConfig.AuthorizeURL,
-			TokenURL:        req.OauthConfig.TokenURL,
-			RegistrationURL: req.OauthConfig.RegistrationURL,
-			RedirectURI:     redirectURI,
-			Scopes:          req.OauthConfig.Scopes,
-			ServerURL:       req.ConnectionString.GetValue(),
+			ClientID:        req.OauthConfig.ClientID,        // Optional: auto-generated if empty
+			ClientSecret:    req.OauthConfig.ClientSecret,    // Optional: for PKCE or dynamic registration
+			AuthorizeURL:    req.OauthConfig.AuthorizeURL,    // Optional: discovered if empty
+			TokenURL:        req.OauthConfig.TokenURL,        // Optional: discovered if empty
+			RegistrationURL: req.OauthConfig.RegistrationURL, // Optional: discovered if empty
+			RedirectURI:     redirectURI,                     // Use server's own callback URL
+			Scopes:          req.OauthConfig.Scopes,          // Optional: discovered if empty
+			ServerURL:       req.ConnectionString.GetValue(), // MCP server URL for OAuth discovery
+			// MCPClientID intentionally omitted: client doesn't exist in DB yet
 		})
 		if err != nil {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initiate OAuth flow: %v", err))
@@ -1462,6 +1464,29 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		// Set discovered tools on the client
 		h.mcpManager.SetClientTools(mcpClientConfig.ID, tools, toolNameMapping)
 
+		// For new clients, backfill mcp_client_id on the oauth_config now that the client exists,
+		// so the CASCADE FK covers it on future MCP client deletion.
+		if !isUpdateFlow && h.store.ConfigStore != nil {
+			if oauthCfg, err := h.store.ConfigStore.GetOauthConfigByID(ctx, oauthConfigID); err == nil && oauthCfg != nil {
+				oauthCfg.MCPClientID = &mcpClientConfig.ID
+				if err := h.store.ConfigStore.UpdateOauthConfig(ctx, oauthCfg); err != nil {
+					logger.Warn(fmt.Sprintf("[OAuth Complete] Failed to backfill mcp_client_id on oauth config %s: %v", oauthConfigID, err))
+				}
+			}
+		}
+
+		// After successful credential rotation, migrate existing user tokens/sessions to the new
+		// template config so their refresh paths continue to work, then delete the old config.
+		if isUpdateFlow && existingDBConfig.OauthConfigID != nil && *existingDBConfig.OauthConfigID != oauthConfigID {
+			oldConfigID := *existingDBConfig.OauthConfigID
+			if migrateErr := h.store.ConfigStore.MigrateOauthUserTokensToConfig(ctx, oldConfigID, oauthConfigID); migrateErr != nil {
+				logger.Warn(fmt.Sprintf("[OAuth Complete] Failed to migrate user tokens to new OAuth config %s: %v", oauthConfigID, migrateErr))
+			}
+			if delErr := h.store.ConfigStore.DeleteOauthConfig(ctx, oldConfigID); delErr != nil {
+				logger.Warn(fmt.Sprintf("[OAuth Complete] Failed to delete old OAuth config %s after per-user rotation: %v", oldConfigID, delErr))
+			}
+		}
+
 		logger.Debug(fmt.Sprintf("[OAuth Complete] Per-user OAuth MCP client verified and created: %s (%d tools)", mcpClientConfig.ID, len(tools)))
 		message := fmt.Sprintf("OAuth configuration verified successfully. %d tools discovered. Each user will authenticate individually when using this MCP server.", len(tools))
 		if isUpdateFlow {
@@ -1507,6 +1532,12 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to reconnect MCP client with updated OAuth credentials: %v", err))
 			return
 		}
+		// Delete old oauth config (and its token) now that the new one is live
+		if existingDBConfig.OauthConfigID != nil && *existingDBConfig.OauthConfigID != oauthConfigID {
+			if delErr := h.store.ConfigStore.DeleteOauthConfig(ctx, *existingDBConfig.OauthConfigID); delErr != nil {
+				logger.Warn(fmt.Sprintf("[OAuth Complete] Failed to delete old OAuth config %s after rotation: %v", *existingDBConfig.OauthConfigID, delErr))
+			}
+		}
 	} else {
 		if h.store.ConfigStore != nil {
 			if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, mcpClientConfig); err != nil {
@@ -1525,6 +1556,17 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			logger.Error(fmt.Sprintf("[OAuth Complete] Failed to connect MCP client: %v", err))
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to connect MCP client: %v", err))
 			return
+		}
+	}
+
+	// For new clients, backfill mcp_client_id on the oauth_config now that the client exists,
+	// so the CASCADE FK covers it on future MCP client deletion.
+	if !isUpdateFlow && h.store.ConfigStore != nil {
+		if oauthCfg, err := h.store.ConfigStore.GetOauthConfigByID(ctx, oauthConfigID); err == nil && oauthCfg != nil {
+			oauthCfg.MCPClientID = &mcpClientConfig.ID
+			if err := h.store.ConfigStore.UpdateOauthConfig(ctx, oauthCfg); err != nil {
+				logger.Warn(fmt.Sprintf("[OAuth Complete] Failed to backfill mcp_client_id on oauth config %s: %v", oauthConfigID, err))
+			}
 		}
 	}
 

--- a/transports/bifrost-http/handlers/oauth2.go
+++ b/transports/bifrost-http/handlers/oauth2.go
@@ -192,14 +192,15 @@ func (h *OAuthHandler) revokeOAuthConfig(ctx *fasthttp.RequestCtx) {
 
 // OAuthInitiationRequest represents the request to initiate an OAuth flow
 type OAuthInitiationRequest struct {
-	ClientID        *schemas.EnvVar `json:"client_id"`
-	ClientSecret    *schemas.EnvVar `json:"client_secret"`
-	AuthorizeURL    string          `json:"authorize_url"`
-	TokenURL        string          `json:"token_url"`
-	RegistrationURL string          `json:"registration_url"`
-	RedirectURI     string          `json:"redirect_uri"`
-	Scopes          []string        `json:"scopes"`
-	ServerURL       string          `json:"server_url"` // For OAuth discovery
+	ClientID        string   `json:"client_id"`
+	ClientSecret    string   `json:"client_secret"`
+	AuthorizeURL    string   `json:"authorize_url"`
+	TokenURL        string   `json:"token_url"`
+	RegistrationURL string   `json:"registration_url"`
+	RedirectURI     string   `json:"redirect_uri"`
+	Scopes          []string `json:"scopes"`
+	ServerURL       string   `json:"server_url"` // For OAuth discovery
+	MCPClientID     string   `json:"mcp_client_id"`
 }
 
 // InitiateOAuthFlow initiates an OAuth flow and returns the authorization URL
@@ -232,6 +233,7 @@ func (h *OAuthHandler) InitiateOAuthFlow(ctx context.Context, req OAuthInitiatio
 		RedirectURI:     req.RedirectURI,
 		Scopes:          req.Scopes,
 		ServerURL:       req.ServerURL,
+		MCPClientID:     req.MCPClientID,
 	}
 
 	return h.oauthProvider.InitiateOAuthFlow(ctx, config)


### PR DESCRIPTION
## Summary

Stale OAuth records (abandoned flows, failed credential rotations, orphaned configs after MCP client deletion) were accumulating in the database with no cleanup path. This PR introduces proper lifecycle management for OAuth configs by tracking which MCP client initiated each flow, cleaning up prior pending flows before starting new ones, deleting old configs after successful credential rotation, and backfilling the database with migrations to remove existing orphaned records and enforce referential integrity.

## Changes

- Added `MCPClientID` field to `OAuth2Config` schema and `TableOauthConfig` table so each OAuth config is traceable back to the MCP client that initiated it.
- When an OAuth flow is initiated for an existing MCP client (update flow), any prior pending `oauth_configs` for that client are deleted before the new flow begins, preventing accumulation of stale records.
- After a successful credential rotation (OAuth complete), the old `oauth_config` and its associated token are explicitly deleted now that the new config is live.
- `DeleteMCPClientConfig` now explicitly deletes per-user OAuth tokens, per-user OAuth sessions, and stale (non-active) OAuth configs for the client before removing the client row, rather than relying solely on DB-level cascades.
- Added `DeleteOauthConfig` and `DeletePendingOauthConfigsByMCPClient` to the `ConfigStore` interface and `RDBConfigStore`.
- Added two new migrations:
  - `cleanup_orphaned_oauth_records`: one-time cleanup of existing orphaned `oauth_user_tokens`, `oauth_user_sessions`, `oauth_tokens`, and `oauth_configs` rows.
  - `add_mcp_client_id_to_oauth_configs_and_fks`: adds the `mcp_client_id` column to `oauth_configs` and, on Postgres, adds `ON DELETE CASCADE` foreign keys for `oauth_user_tokens` and `oauth_user_sessions`, and `ON DELETE SET NULL` for `oauth_configs`.
- `MCPClientID` is intentionally omitted when initiating OAuth during the initial `addMCPClient` flow since the client does not yet exist in the database at that point.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

1. Add an MCP client with OAuth configured and abandon the flow mid-way. Verify no orphaned `oauth_configs` rows remain after the next flow is initiated.
2. Update an existing OAuth MCP client's credentials. Verify the old `oauth_config` and its token are deleted after the callback completes.
3. Delete an MCP client that has OAuth configured. Verify all associated `oauth_user_tokens`, `oauth_user_sessions`, and `oauth_configs` rows are removed.
4. Run migrations against an existing database with orphaned records and confirm the `cleanup_orphaned_oauth_records` migration removes them.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Orphaned OAuth tokens and configs containing sensitive credential material are now reliably deleted rather than left indefinitely in the database, reducing the attack surface from stale credentials.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable