### PR TITLE
fix: replace single `Governance` RBAC check with granular per-resource access checks

### DIFF
--- a/ui/app/workspace/governance/layout.tsx
+++ b/ui/app/workspace/governance/layout.tsx
@@ -4,9 +4,25 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import GovernancePage from "./page";
 
 function RouteComponent() {
-	const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
+	const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
+	const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
+	const hasUsersAccess = useRbac(RbacResource.Users, RbacOperation.View);
+	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
+	const hasBusinessUnitsAccess = useRbac(RbacResource.UserProvisioning, RbacOperation.View);
+	const hasRbacAccess = useRbac(RbacResource.RBAC, RbacOperation.View);
+	const hasAccessProfilesAccess = useRbac(RbacResource.AccessProfiles, RbacOperation.View);
+
+	const hasAnyGovernanceAccess =
+		hasVirtualKeysAccess ||
+		hasTeamsAccess ||
+		hasUsersAccess ||
+		hasCustomersAccess ||
+		hasBusinessUnitsAccess ||
+		hasRbacAccess ||
+		hasAccessProfilesAccess;
+
 	const childMatches = useChildMatches();
-	if (!hasGovernanceAccess) {
+	if (!hasAnyGovernanceAccess) {
 		return <NoPermissionView entity="governance" />;
 	}
 	return childMatches.length === 0 ? <GovernancePage /> : <Outlet />;

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -570,10 +570,10 @@ export default function AppSidebar() {
   const hasAuditLogsAccess = useRbac(RbacResource.AuditLogs, RbacOperation.View);
   const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
   const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
-  const hasBusinessUnitsAccess = useRbac(RbacResource.Governance, RbacOperation.View);
+  const hasBusinessUnitsAccess = useRbac(RbacResource.UserProvisioning, RbacOperation.View);
   const hasRbacAccess = useRbac(RbacResource.RBAC, RbacOperation.View);
   const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
-  const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
+  const hasGovernanceLegacyAccess = useRbac(RbacResource.Governance, RbacOperation.View);
   const hasRoutingRulesAccess = useRbac(RbacResource.RoutingRules, RbacOperation.View);
   const hasGuardrailsProvidersAccess = useRbac(
     RbacResource.GuardrailsProviders,
@@ -585,6 +585,15 @@ export default function AppSidebar() {
   const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.View);
   const hasPromptRepositoryAccess = useRbac(RbacResource.PromptRepository, RbacOperation.View);
   const hasAccessProfilesAccess = useRbac(RbacResource.AccessProfiles, RbacOperation.View);
+  const hasAnyGovernanceAccess =
+    hasVirtualKeysAccess ||
+    hasTeamsAccess ||
+    hasUsersAccess ||
+    hasCustomersAccess ||
+    hasBusinessUnitsAccess ||
+    hasRbacAccess ||
+    hasAccessProfilesAccess ||
+    hasGovernanceLegacyAccess;
   const { data: coreConfig } = useGetCoreConfigQuery({});
   const isDbConnected = coreConfig?.is_db_connected ?? false;
 
@@ -660,7 +669,7 @@ export default function AppSidebar() {
             url: "/workspace/model-limits",
             icon: Wallet,
             description: "Model limits",
-            hasAccess: hasGovernanceAccess,
+            hasAccess: hasGovernanceLegacyAccess,
           },
           {
             title: "Routing Rules",
@@ -727,7 +736,7 @@ export default function AppSidebar() {
         url: "/workspace/governance",
         icon: Landmark,
         description: "Virtual keys, users, teams, customers & roles",
-        hasAccess: hasGovernanceAccess,
+        hasAccess: hasAnyGovernanceAccess,
         subItems: [
           {
             title: "Virtual Keys",
@@ -927,7 +936,8 @@ export default function AppSidebar() {
       hasBusinessUnitsAccess,
       hasRbacAccess,
       hasVirtualKeysAccess,
-      hasGovernanceAccess,
+      hasGovernanceLegacyAccess,
+      hasAnyGovernanceAccess,
       hasRoutingRulesAccess,
       hasGuardrailsProvidersAccess,
       hasGuardrailsConfigAccess,


### PR DESCRIPTION
## Summary

The governance layout previously used a single `RbacResource.Governance` permission check to gate access to the entire governance section. This was replaced with granular per-resource checks so that users with access to any individual governance sub-resource (Virtual Keys, Teams, Users, Customers, Business Units, RBAC, or Access Profiles) are granted entry to the governance area.

## Changes

- Replaced the single `hasGovernanceAccess` check with individual RBAC checks for each governance sub-resource: `VirtualKeys`, `Teams`, `Users`, `Customers`, `UserProvisioning`, `RBAC`, and `AccessProfiles`
- Access to the governance layout is now granted if the user has view permission on **any** of these resources, rather than requiring a single top-level governance permission

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Log in as a user with access to only one governance sub-resource (e.g., Virtual Keys only)
2. Navigate to the governance section
3. Verify the user can access the governance layout without seeing the `NoPermissionView`
4. Log in as a user with no governance sub-resource permissions
5. Verify the `NoPermissionView` is displayed

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Users who previously had no access to the governance section but hold permissions on any individual governance sub-resource will now be able to enter the governance layout. Ensure that individual sub-resource pages still enforce their own RBAC checks to prevent unauthorized data access.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable