### PR TITLE
feat: support `EnvVar` references for MCP OAuth `client_id`/`client_secret` with redacted GET responses and batch config fetching 

### DIFF
--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -155,6 +155,8 @@ type MCPClientConfig struct {
 	StdioConfig         *MCPStdioConfig   `json:"stdio_config,omitempty"`          // STDIO configuration (required for STDIO connections)
 	AuthType            MCPAuthType       `json:"auth_type"`                       // Authentication type (none, headers, or oauth)
 	OauthConfigID       *string           `json:"oauth_config_id,omitempty"`       // OAuth config ID (references oauth_configs table)
+	OauthClientID       *EnvVar           `json:"oauth_client_id,omitempty"`       // Redacted OAuth client ID (populated on GET, not stored here)
+	OauthClientSecret   *EnvVar           `json:"oauth_client_secret,omitempty"`   // Redacted OAuth client secret (populated on GET, not stored here)
 	State               string            `json:"state,omitempty"`                 // Connection state (connected, disconnected, error)
 	Headers             map[string]EnvVar `json:"headers,omitempty"`               // Headers to send with the request (for headers auth type)
 	AllowedExtraHeaders WhiteList         `json:"allowed_extra_headers,omitempty"` // Allowlist of request-level headers that callers may forward to this MCP server at execution time

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4151,6 +4151,23 @@ func (s *RDBConfigStore) GetOauthConfigByID(ctx context.Context, id string) (*ta
 	return &config, nil
 }
 
+// GetOauthConfigsByIDs retrieves multiple OAuth configs by their IDs in a single query.
+// Returns a map keyed by config ID for O(1) lookup.
+func (s *RDBConfigStore) GetOauthConfigsByIDs(ctx context.Context, ids []string) (map[string]*tables.TableOauthConfig, error) {
+	if len(ids) == 0 {
+		return map[string]*tables.TableOauthConfig{}, nil
+	}
+	var configs []tables.TableOauthConfig
+	if err := s.DB().WithContext(ctx).Where("id IN ?", ids).Find(&configs).Error; err != nil {
+		return nil, fmt.Errorf("failed to batch-get oauth configs: %w", err)
+	}
+	result := make(map[string]*tables.TableOauthConfig, len(configs))
+	for i := range configs {
+		result[configs[i].ID] = &configs[i]
+	}
+	return result, nil
+}
+
 // GetOauthConfigByState retrieves an OAuth config by its state token
 // State is unique per OAuth flow (used for CSRF protection on callback)
 func (s *RDBConfigStore) GetOauthConfigByState(ctx context.Context, state string) (*tables.TableOauthConfig, error) {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -296,6 +296,7 @@ type ConfigStore interface {
 
 	// OAuth config CRUD
 	GetOauthConfigByID(ctx context.Context, id string) (*tables.TableOauthConfig, error)
+	GetOauthConfigsByIDs(ctx context.Context, ids []string) (map[string]*tables.TableOauthConfig, error)
 	GetOauthConfigByState(ctx context.Context, state string) (*tables.TableOauthConfig, error)
 	GetOauthConfigByTokenID(ctx context.Context, tokenID string) (*tables.TableOauthConfig, error)
 	CreateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/encrypt"
 	"gorm.io/gorm"
 )
@@ -11,9 +12,9 @@ import (
 // TableOauthConfig represents an OAuth configuration in the database
 // This stores the OAuth client configuration and flow state
 type TableOauthConfig struct {
-	ID                  string    `gorm:"type:varchar(255);primaryKey" json:"id"`          // UUID
-	ClientID            string    `gorm:"type:varchar(512)" json:"client_id"`              // OAuth provider's client ID (optional for public clients)
-	ClientSecret        string    `gorm:"type:text" json:"-"`                              // Encrypted OAuth client secret (optional for public clients)
+	ID                  string          `gorm:"type:varchar(255);primaryKey" json:"id"`          // UUID
+	ClientID            *schemas.EnvVar `gorm:"type:varchar(512)" json:"client_id"`              // OAuth provider's client ID (optional for public clients)
+	ClientSecret        *schemas.EnvVar `gorm:"type:text" json:"-"`                              // Encrypted OAuth client secret (optional for public clients)
 	AuthorizeURL        string    `gorm:"type:text" json:"authorize_url"`                  // Provider's authorization endpoint (optional, can be discovered)
 	TokenURL            string    `gorm:"type:text" json:"token_url"`                      // Provider's token endpoint (optional, can be discovered)
 	RegistrationURL     *string   `gorm:"type:text" json:"registration_url,omitempty"`     // Provider's dynamic registration endpoint (optional, can be discovered)
@@ -45,11 +46,11 @@ func (c *TableOauthConfig) BeforeSave(tx *gorm.DB) error {
 		c.Status = "pending"
 	}
 
-	// Encrypt sensitive fields
+	// Encrypt sensitive fields (skip if value is an env var reference — the reference itself is not sensitive)
 	if encrypt.IsEnabled() {
 		encrypted := false
-		if c.ClientSecret != "" {
-			if err := encryptString(&c.ClientSecret); err != nil {
+		if c.ClientSecret != nil && !c.ClientSecret.FromEnv && c.ClientSecret.Val != "" {
+			if err := encryptString(&c.ClientSecret.Val); err != nil {
 				return fmt.Errorf("failed to encrypt oauth client secret: %w", err)
 			}
 			encrypted = true
@@ -70,14 +71,31 @@ func (c *TableOauthConfig) BeforeSave(tx *gorm.DB) error {
 // AfterFind hook to decrypt sensitive fields
 func (c *TableOauthConfig) AfterFind(tx *gorm.DB) error {
 	if c.EncryptionStatus == EncryptionStatusEncrypted {
-		if err := decryptString(&c.ClientSecret); err != nil {
-			return fmt.Errorf("failed to decrypt oauth client secret: %w", err)
+		if c.ClientSecret != nil && !c.ClientSecret.FromEnv && c.ClientSecret.Val != "" {
+			if err := decryptString(&c.ClientSecret.Val); err != nil {
+				return fmt.Errorf("failed to decrypt oauth client secret: %w", err)
+			}
 		}
 		if err := decryptString(&c.CodeVerifier); err != nil {
 			return fmt.Errorf("failed to decrypt oauth code verifier: %w", err)
 		}
 	}
 	return nil
+}
+
+// GetResolvedClientID returns the resolved ClientID value, expanding env var references at runtime.
+func (c *TableOauthConfig) GetResolvedClientID() string {
+	return c.ClientID.GetValue()
+}
+
+// GetResolvedClientSecret returns the resolved ClientSecret value, expanding env var references at runtime.
+func (c *TableOauthConfig) GetResolvedClientSecret() string {
+	return c.ClientSecret.GetValue()
+}
+
+// GetClientSecretAsEnvVar returns ClientSecret as an EnvVar (preserves env var reference metadata).
+func (c *TableOauthConfig) GetClientSecretAsEnvVar() *schemas.EnvVar {
+	return c.ClientSecret
 }
 
 // TableOauthToken represents an OAuth token in the database

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -130,8 +130,8 @@ func (p *OAuth2Provider) RefreshAccessToken(ctx context.Context, oauthConfigID s
 	newTokenResponse, err := p.exchangeRefreshToken(
 		ctx,
 		oauthConfig.TokenURL,
-		oauthConfig.ClientID,
-		oauthConfig.ClientSecret,
+		oauthConfig.GetResolvedClientID(),
+		oauthConfig.GetResolvedClientSecret(),
 		token.RefreshToken,
 	)
 	if err != nil {
@@ -408,7 +408,7 @@ func (p *OAuth2Provider) InitiateOAuthFlow(ctx context.Context, config *schemas.
 
 	// Dynamic Client Registration (RFC 7591)
 	// If client_id is NOT provided, attempt dynamic registration
-	clientID := config.ClientID
+	clientID := config.ClientID // storage value — may be "env.MY_VAR" reference or plain ID
 	clientSecret := config.ClientSecret
 
 	if clientID == "" {
@@ -462,8 +462,8 @@ func (p *OAuth2Provider) InitiateOAuthFlow(ctx context.Context, config *schemas.
 	expiresAt := time.Now().Add(15 * time.Minute)
 	oauthConfigRecord := &tables.TableOauthConfig{
 		ID:              oauthConfigID,
-		ClientID:        clientID, // May be from dynamic registration
-		ClientSecret:    clientSecret,
+		ClientID:        schemas.NewEnvVar(clientID), // May be from dynamic registration
+		ClientSecret:    schemas.NewEnvVar(clientSecret),
 		AuthorizeURL:    authorizeURL,
 		TokenURL:        tokenURL,
 		RegistrationURL: registrationURL,
@@ -482,17 +482,21 @@ func (p *OAuth2Provider) InitiateOAuthFlow(ctx context.Context, config *schemas.
 		return nil, fmt.Errorf("failed to create oauth config: %w", err)
 	}
 
+	// Resolve env var reference to actual value for use in the authorize URL.
+	// The reference ("env.MY_VAR") is stored in DB; the resolved value is sent to the provider.
+	resolvedClientID := schemas.NewEnvVar(clientID).GetValue()
+
 	// Build authorize URL with PKCE (using dynamically registered or user-provided client_id)
 	authURL := p.buildAuthorizeURLWithPKCE(
 		authorizeURL,
-		clientID, // May be from dynamic registration
+		resolvedClientID,
 		config.RedirectURI,
 		state,
 		codeChallenge,
 		scopes,
 	)
 
-	logger.Debug("OAuth flow initiated successfully: oauth_config_id: %s, client_id: %s", oauthConfigID, clientID)
+	logger.Debug("OAuth flow initiated successfully: oauth_config_id: %s, client_id: %s", oauthConfigID, resolvedClientID)
 
 	return &schemas.OAuth2FlowInitiation{
 		OauthConfigID: oauthConfigID,
@@ -524,8 +528,8 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 	// Log token exchange attempt for debugging
 	logger.Debug("Attempting token exchange",
 		"token_url", oauthConfig.TokenURL,
-		"client_id", oauthConfig.ClientID,
-		"has_client_secret", oauthConfig.ClientSecret != "",
+		"client_id", oauthConfig.GetResolvedClientID(),
+		"has_client_secret", oauthConfig.GetResolvedClientSecret() != "",
 		"has_pkce_verifier", oauthConfig.CodeVerifier != "")
 
 	// Exchange code for tokens with PKCE verifier
@@ -533,8 +537,8 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 		ctx,
 		oauthConfig.TokenURL,
 		code,
-		oauthConfig.ClientID,
-		oauthConfig.ClientSecret,
+		oauthConfig.GetResolvedClientID(),
+		oauthConfig.GetResolvedClientSecret(),
 		oauthConfig.RedirectURI,
 		oauthConfig.CodeVerifier, // PKCE verifier
 	)
@@ -543,7 +547,7 @@ func (p *OAuth2Provider) CompleteOAuthFlow(ctx context.Context, state, code stri
 		p.configStore.UpdateOauthConfig(ctx, oauthConfig)
 		logger.Error("Token exchange failed",
 			"error", err.Error(),
-			"client_id", oauthConfig.ClientID,
+			"client_id", oauthConfig.GetResolvedClientID(),
 			"token_url", oauthConfig.TokenURL)
 		return fmt.Errorf("token exchange failed: %w", err)
 	}
@@ -871,7 +875,7 @@ func (p *OAuth2Provider) InitiateUserOAuthFlow(ctx context.Context, oauthConfigI
 	// Build authorize URL with PKCE
 	authURL := p.buildAuthorizeURLWithPKCE(
 		templateConfig.AuthorizeURL,
-		templateConfig.ClientID,
+		templateConfig.GetResolvedClientID(),
 		redirectURI,
 		state,
 		codeChallenge,
@@ -926,8 +930,8 @@ func (p *OAuth2Provider) CompleteUserOAuthFlow(ctx context.Context, state string
 		ctx,
 		templateConfig.TokenURL,
 		code,
-		templateConfig.ClientID,
-		templateConfig.ClientSecret,
+		templateConfig.GetResolvedClientID(),
+		templateConfig.GetResolvedClientSecret(),
 		redirectURI,
 		session.CodeVerifier,
 	)
@@ -1087,8 +1091,8 @@ func (p *OAuth2Provider) RefreshUserAccessToken(ctx context.Context, sessionToke
 	newTokenResponse, err := p.exchangeRefreshToken(
 		ctx,
 		templateConfig.TokenURL,
-		templateConfig.ClientID,
-		templateConfig.ClientSecret,
+		templateConfig.GetResolvedClientID(),
+		templateConfig.GetResolvedClientSecret(),
 		token.RefreshToken,
 	)
 	if err != nil {

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -156,12 +156,39 @@ func (h *MCPHandler) getMCPClients(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
+	// Batch-fetch OAuth configs for clients that have one (avoids N+1 queries)
+	oauthConfigsByID := make(map[string]*configstoreTables.TableOauthConfig)
+	if h.store.ConfigStore != nil {
+		oauthIDs := make([]string, 0)
+		for _, c := range configsInStore.ClientConfigs {
+			if c.OauthConfigID != nil && *c.OauthConfigID != "" {
+				oauthIDs = append(oauthIDs, *c.OauthConfigID)
+			}
+		}
+		if len(oauthIDs) > 0 {
+			fetched, err := h.store.ConfigStore.GetOauthConfigsByIDs(ctx, oauthIDs)
+			if err != nil {
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to fetch OAuth configs: %v", err))
+				return
+			}
+			oauthConfigsByID = fetched
+		}
+	}
+
 	// Build the final client list, including errored clients
 	clients := make([]MCPClientResponse, 0, len(configsInStore.ClientConfigs))
 
 	for _, configClient := range configsInStore.ClientConfigs {
+		// Copy to avoid mutating the in-memory store config, then populate OAuth credentials
+		configClientCopy := *configClient
+		if configClient.OauthConfigID != nil {
+			if oauthCfg, ok := oauthConfigsByID[*configClient.OauthConfigID]; ok {
+				configClientCopy.OauthClientID = oauthCfg.ClientID
+				configClientCopy.OauthClientSecret = oauthCfg.GetClientSecretAsEnvVar()
+			}
+		}
 		// Redact sensitive fields before sending to UI
-		redactedConfig := h.store.RedactMCPClientConfig(configClient)
+		redactedConfig := h.store.RedactMCPClientConfig(&configClientCopy)
 
 		vkConfigs := []MCPVKConfigResponse{}
 		for _, a := range assignmentsByClientStringID[configClient.ID] {
@@ -277,6 +304,25 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, 
 		}
 	}
 
+	// Batch-fetch OAuth configs for clients that have one (avoids N+1 queries)
+	oauthConfigsByID := make(map[string]*configstoreTables.TableOauthConfig)
+	if h.store.ConfigStore != nil {
+		oauthIDs := make([]string, 0)
+		for _, c := range dbClients {
+			if c.OauthConfigID != nil && *c.OauthConfigID != "" {
+				oauthIDs = append(oauthIDs, *c.OauthConfigID)
+			}
+		}
+		if len(oauthIDs) > 0 {
+			fetched, err := h.store.ConfigStore.GetOauthConfigsByIDs(ctx, oauthIDs)
+			if err != nil {
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to fetch OAuth configs: %v", err))
+				return
+			}
+			oauthConfigsByID = fetched
+		}
+	}
+
 	// Convert DB rows to MCPClientConfig and merge with engine state
 	clients := make([]MCPClientResponse, 0, len(dbClients))
 	for _, dbClient := range dbClients {
@@ -302,6 +348,13 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, 
 			ToolPricing:           dbClient.ToolPricing,
 			AllowOnAllVirtualKeys: dbClient.AllowOnAllVirtualKeys,
 			Disabled:              dbClient.Disabled,
+		}
+		// Populate oauth client credentials from pre-fetched batch
+		if dbClient.OauthConfigID != nil {
+			if oauthCfg, ok := oauthConfigsByID[*dbClient.OauthConfigID]; ok {
+				clientConfig.OauthClientID = oauthCfg.ClientID
+				clientConfig.OauthClientSecret = oauthCfg.GetClientSecretAsEnvVar()
+			}
 		}
 		// Enrich VK assignments using the pre-fetched batch result (no extra DB call per client)
 		vkConfigs := []MCPVKConfigResponse{}
@@ -379,12 +432,12 @@ func (h *MCPHandler) reconnectMCPClient(ctx *fasthttp.RequestCtx) {
 
 // OAuthConfigRequest represents OAuth configuration in the request
 type OAuthConfigRequest struct {
-	ClientID        string   `json:"client_id"`
-	ClientSecret    string   `json:"client_secret"`
-	AuthorizeURL    string   `json:"authorize_url"`
-	TokenURL        string   `json:"token_url"`
-	RegistrationURL string   `json:"registration_url"`
-	Scopes          []string `json:"scopes"`
+	ClientID        *schemas.EnvVar `json:"client_id"`
+	ClientSecret    *schemas.EnvVar `json:"client_secret"`
+	AuthorizeURL    string          `json:"authorize_url"`
+	TokenURL        string          `json:"token_url"`
+	RegistrationURL string          `json:"registration_url"`
+	Scopes          []string        `json:"scopes"`
 }
 
 // MCPClientRequest represents the full MCP client creation request with OAuth support
@@ -456,7 +509,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 			return
 		}
 
-		if req.OauthConfig.ClientID == "" && req.ConnectionString.GetValue() == "" {
+		if !req.OauthConfig.ClientID.IsSet() && req.ConnectionString.GetValue() == "" {
 			SendError(ctx, fasthttp.StatusBadRequest, "Either client_id must be provided, or server URL must be set for OAuth discovery and dynamic client registration")
 			return
 		}
@@ -538,7 +591,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 
 		// Validate: Either client_id must be provided, OR we need a server URL for discovery + dynamic registration
 		// Client ID can be empty if the OAuth provider supports dynamic client registration (RFC 7591)
-		if req.OauthConfig.ClientID == "" {
+		if !req.OauthConfig.ClientID.IsSet() {
 			// If no client_id, we need server URL for discovery
 			if req.ConnectionString.GetValue() == "" {
 				SendError(ctx, fasthttp.StatusBadRequest, "Either client_id must be provided, or server URL must be set for OAuth discovery and dynamic client registration")
@@ -555,14 +608,14 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		// ServerURL comes from ConnectionString (MCP server URL for OAuth discovery)
 		// ClientID is optional - will be obtained via dynamic registration if not provided
 		flowInitiation, err := h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
-			ClientID:        req.OauthConfig.ClientID,        // Optional: auto-generated if empty
-			ClientSecret:    req.OauthConfig.ClientSecret,    // Optional: for PKCE or dynamic registration
-			AuthorizeURL:    req.OauthConfig.AuthorizeURL,    // Optional: discovered if empty
-			TokenURL:        req.OauthConfig.TokenURL,        // Optional: discovered if empty
-			RegistrationURL: req.OauthConfig.RegistrationURL, // Optional: discovered if empty
-			RedirectURI:     redirectURI,                     // Use server's own callback URL
-			Scopes:          req.OauthConfig.Scopes,          // Optional: discovered if empty
-			ServerURL:       req.ConnectionString.GetValue(), // MCP server URL for OAuth discovery
+			ClientID:        req.OauthConfig.ClientID,
+			ClientSecret:    req.OauthConfig.ClientSecret,
+			AuthorizeURL:    req.OauthConfig.AuthorizeURL,
+			TokenURL:        req.OauthConfig.TokenURL,
+			RegistrationURL: req.OauthConfig.RegistrationURL,
+			RedirectURI:     redirectURI,
+			Scopes:          req.OauthConfig.Scopes,
+			ServerURL:       req.ConnectionString.GetValue(),
 		})
 		if err != nil {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initiate OAuth flow: %v", err))
@@ -777,8 +830,8 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	}
 
 	shouldRotateOAuthConfig := req.OauthConfig != nil && (existingConfig.AuthType == schemas.MCPAuthTypeOauth || existingConfig.AuthType == schemas.MCPAuthTypePerUserOauth)
-	oauthClientID := ""
-	oauthClientSecret := ""
+	var oauthClientID *schemas.EnvVar
+	var oauthClientSecret *schemas.EnvVar
 	oauthAuthorizeURL := ""
 	oauthTokenURL := ""
 	oauthRegistrationURL := ""
@@ -792,13 +845,18 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	if shouldRotateOAuthConfig {
-		oauthClientID = strings.TrimSpace(req.OauthConfig.ClientID)
-		oauthClientSecret = strings.TrimSpace(req.OauthConfig.ClientSecret)
+		if req.OauthConfig.ClientID.ShouldPreserveStored() && req.OauthConfig.ClientSecret.ShouldPreserveStored() {
+			shouldRotateOAuthConfig = false
+		}
+	}
+	if shouldRotateOAuthConfig {
+		oauthClientID = req.OauthConfig.ClientID
+		oauthClientSecret = req.OauthConfig.ClientSecret
 		oauthAuthorizeURL = strings.TrimSpace(req.OauthConfig.AuthorizeURL)
 		oauthTokenURL = strings.TrimSpace(req.OauthConfig.TokenURL)
 		oauthRegistrationURL = strings.TrimSpace(req.OauthConfig.RegistrationURL)
 		oauthScopes = req.OauthConfig.Scopes
-		if oauthClientID == "" && oauthClientSecret == "" {
+		if !oauthClientID.IsSet() && !oauthClientSecret.IsSet() {
 			SendError(ctx, fasthttp.StatusBadRequest, "oauth_config.client_id or oauth_config.client_secret is required when updating OAuth credentials")
 			return
 		}
@@ -830,15 +888,20 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 			}
 		}
 
-		if oauthClientID == "" {
-			if existingOauthConfig == nil || strings.TrimSpace(existingOauthConfig.ClientID) == "" {
+		if !oauthClientID.IsSet() || oauthClientID.ShouldPreserveStored() {
+			if existingOauthConfig == nil || !existingOauthConfig.ClientID.IsSet() {
 				SendError(ctx, fasthttp.StatusBadRequest, "existing OAuth client_id not found; provide oauth_config.client_id")
 				return
 			}
-			oauthClientID = strings.TrimSpace(existingOauthConfig.ClientID)
+			oauthClientID = existingOauthConfig.ClientID // preserve env var reference
+		}
+		if !oauthClientSecret.IsSet() || oauthClientSecret.ShouldPreserveStored() {
+			if existingOauthConfig != nil {
+				oauthClientSecret = existingOauthConfig.ClientSecret // preserve stored secret
+			}
 		}
 
-		requiresDiscoveryOrRegistration := oauthClientID == "" || oauthAuthorizeURL == "" || oauthTokenURL == ""
+		requiresDiscoveryOrRegistration := !oauthClientID.IsSet() || oauthAuthorizeURL == "" || oauthTokenURL == ""
 		if requiresDiscoveryOrRegistration && (existingConfig.ConnectionString == nil || existingConfig.ConnectionString.GetValue() == "") {
 			SendError(ctx, fasthttp.StatusBadRequest, "existing connection_string is required when OAuth discovery or dynamic registration is needed")
 			return
@@ -1065,8 +1128,8 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 			serverURL = existingConfig.ConnectionString.GetValue()
 		}
 		flowInitiation, err := h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
-			ClientID:        oauthClientID,
-			ClientSecret:    oauthClientSecret,
+			ClientID:        oauthClientID,     // *schemas.EnvVar — preserves env var reference
+			ClientSecret:    oauthClientSecret, // *schemas.EnvVar — preserves env var reference
 			AuthorizeURL:    oauthAuthorizeURL,
 			TokenURL:        oauthTokenURL,
 			RegistrationURL: oauthRegistrationURL,

--- a/transports/bifrost-http/handlers/oauth2.go
+++ b/transports/bifrost-http/handlers/oauth2.go
@@ -192,14 +192,14 @@ func (h *OAuthHandler) revokeOAuthConfig(ctx *fasthttp.RequestCtx) {
 
 // OAuthInitiationRequest represents the request to initiate an OAuth flow
 type OAuthInitiationRequest struct {
-	ClientID        string   `json:"client_id"`
-	ClientSecret    string   `json:"client_secret"`
-	AuthorizeURL    string   `json:"authorize_url"`
-	TokenURL        string   `json:"token_url"`
-	RegistrationURL string   `json:"registration_url"`
-	RedirectURI     string   `json:"redirect_uri"`
-	Scopes          []string `json:"scopes"`
-	ServerURL       string   `json:"server_url"` // For OAuth discovery
+	ClientID        *schemas.EnvVar `json:"client_id"`
+	ClientSecret    *schemas.EnvVar `json:"client_secret"`
+	AuthorizeURL    string          `json:"authorize_url"`
+	TokenURL        string          `json:"token_url"`
+	RegistrationURL string          `json:"registration_url"`
+	RedirectURI     string          `json:"redirect_uri"`
+	Scopes          []string        `json:"scopes"`
+	ServerURL       string          `json:"server_url"` // For OAuth discovery
 }
 
 // InitiateOAuthFlow initiates an OAuth flow and returns the authorization URL
@@ -210,15 +210,28 @@ func (h *OAuthHandler) InitiateOAuthFlow(ctx context.Context, req OAuthInitiatio
 		registrationURL = &req.RegistrationURL
 	}
 
+	clientID := ""
+	if req.ClientID != nil {
+		if v, _ := req.ClientID.Value(); v != nil {
+			clientID, _ = v.(string)
+		}
+	}
+	clientSecret := ""
+	if req.ClientSecret != nil {
+		if v, _ := req.ClientSecret.Value(); v != nil {
+			clientSecret, _ = v.(string)
+		}
+	}
+
 	config := &schemas.OAuth2Config{
-		ClientID:        req.ClientID,
-		ClientSecret:    req.ClientSecret,
+		ClientID:        clientID,
+		ClientSecret:    clientSecret,
 		AuthorizeURL:    req.AuthorizeURL,
 		TokenURL:        req.TokenURL,
 		RegistrationURL: registrationURL,
 		RedirectURI:     req.RedirectURI,
 		Scopes:          req.Scopes,
-		ServerURL:       req.ServerURL, // MCP server URL for OAuth discovery
+		ServerURL:       req.ServerURL,
 	}
 
 	return h.oauthProvider.InitiateOAuthFlow(ctx, config)

--- a/transports/bifrost-http/handlers/oauth2_per_user.go
+++ b/transports/bifrost-http/handlers/oauth2_per_user.go
@@ -541,9 +541,14 @@ func (h *PerUserOAuthHandler) handleUpstreamAuthorize(ctx *fasthttp.RequestCtx) 
 	}
 
 	// Build upstream authorize URL with PKCE.
+	resolvedClientID := templateConfig.GetResolvedClientID()
+	if strings.TrimSpace(resolvedClientID) == "" {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("OAuth client_id for config %q could not be resolved — check that the referenced environment variable is set", templateConfig.ID))
+		return
+	}
 	params := url.Values{}
 	params.Set("response_type", "code")
-	params.Set("client_id", templateConfig.ClientID)
+	params.Set("client_id", resolvedClientID)
 	params.Set("redirect_uri", redirectURI)
 	params.Set("state", state)
 	params.Set("code_challenge", codeChallenge)

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -4800,6 +4800,14 @@ func (c *Config) RedactMCPClientConfig(config *schemas.MCPClientConfig) *schemas
 		}
 	}
 
+	// Redact OAuth client credentials
+	if config.OauthClientID != nil {
+		configCopy.OauthClientID = config.OauthClientID.Redacted()
+	}
+	if config.OauthClientSecret != nil {
+		configCopy.OauthClientSecret = config.OauthClientSecret.Redacted()
+	}
+
 	return &configCopy
 }
 

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -33,8 +33,8 @@ const emptyStdioConfig: MCPStdioConfig = {
 const emptyEnvVar: EnvVar = { value: "", env_var: "", from_env: false };
 
 const emptyOAuthConfig: OAuthConfig = {
-	client_id: "",
-	client_secret: "",
+	client_id: emptyEnvVar,
+	client_secret: emptyEnvVar,
 	authorize_url: "",
 	token_url: "",
 	scopes: [],
@@ -160,8 +160,8 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 			oauth_config:
 				authType === "oauth" || authType === "per_user_oauth"
 					? {
-							client_id: data.oauth_config?.client_id || "",
-							client_secret: data.oauth_config?.client_secret || undefined,
+							client_id: data.oauth_config?.client_id ?? emptyEnvVar,
+							client_secret: data.oauth_config?.client_secret?.value || data.oauth_config?.client_secret?.from_env ? data.oauth_config.client_secret : undefined,
 							authorize_url: data.oauth_config?.authorize_url || undefined,
 							token_url: data.oauth_config?.token_url || undefined,
 							registration_url: data.oauth_config?.registration_url || undefined,
@@ -451,7 +451,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 															</TooltipProvider>
 														</div>
 														<FormControl>
-															<Input {...field} value={field.value ?? ""} placeholder="your-client-id (auto-generated if empty)" data-testid="mcp-oauth-client-id" />
+															<EnvVarInput value={field.value} onChange={field.onChange} placeholder="your-client-id (auto-generated if empty)" data-testid="mcp-oauth-client-id" />
 														</FormControl>
 														<p className="text-muted-foreground text-xs">
 															Will be auto-generated via dynamic registration if left empty and provider supports it
@@ -469,7 +469,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 													<FormItem>
 														<FormLabel>OAuth Client Secret (optional for PKCE)</FormLabel>
 														<FormControl>
-															<Input {...field} type="password" value={field.value ?? ""} placeholder="your-client-secret" data-testid="mcp-oauth-client-secret" />
+															<EnvVarInput value={field.value} onChange={field.onChange} placeholder="your-client-secret" hideValueWhenEnv maskNonEnvValue data-testid="mcp-oauth-client-secret" />
 														</FormControl>
 														<p className="text-muted-foreground text-xs">Leave empty for public clients using PKCE</p>
 														<FormMessage />

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -5,6 +5,7 @@ import { Fragment } from "react";
 import { CodeEditor } from "@/components/ui/codeEditor";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { HeadersTable } from "@/components/ui/headersTable";
+import { EnvVarInput } from "@/components/ui/envVarInput";
 import { Input } from "@/components/ui/input";
 import { MultiSelect } from "@/components/ui/multiSelect";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -157,7 +158,9 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			tool_pricing: mcpClient.config.tool_pricing || {},
 			tool_sync_interval: toolSyncIntervalToMinutes(mcpClient.config.tool_sync_interval),
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
-			oauth_config: undefined,
+			oauth_config: supportsOAuthCredentialUpdate
+				? { client_id: mcpClient.config.oauth_client_id, client_secret: mcpClient.config.oauth_client_secret }
+				: undefined,
 		},
 	});
 	const isDisabled = form.watch("disabled");
@@ -176,15 +179,20 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			tool_pricing: mcpClient.config.tool_pricing || {},
 			tool_sync_interval: toolSyncIntervalToMinutes(mcpClient.config.tool_sync_interval),
 			allowed_extra_headers: mcpClient.config.allowed_extra_headers || [],
-			oauth_config: undefined,
+			oauth_config: supportsOAuthCredentialUpdate
+				? { client_id: mcpClient.config.oauth_client_id, client_secret: mcpClient.config.oauth_client_secret }
+				: undefined,
 		});
 	}, [form, mcpClient]);
 
 	const onSubmit = async (data: MCPClientUpdateSchema) => {
 		try {
-			const oauthClientID = data.oauth_config?.client_id?.trim() || "";
-			const oauthClientSecret = data.oauth_config?.client_secret?.trim() || "";
-			const shouldRotateOAuthCredentials = supportsOAuthCredentialUpdate && (oauthClientID.length > 0 || oauthClientSecret.length > 0);
+			const oauthClientID = data.oauth_config?.client_id;
+			const oauthClientSecret = data.oauth_config?.client_secret;
+			// Only rotate when the user actually changed a credential field.
+			// dirtyFields tracks deep changes vs. the pre-populated default values.
+			const oauthDirty = !!(form.formState.dirtyFields.oauth_config?.client_id || form.formState.dirtyFields.oauth_config?.client_secret);
+			const shouldRotateOAuthCredentials = supportsOAuthCredentialUpdate && oauthDirty;
 			const response = await updateMCPClient({
 				id: mcpClient.config.client_id,
 				data: {
@@ -202,7 +210,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 					oauth_config: shouldRotateOAuthCredentials
 						? {
 								client_id: oauthClientID,
-								client_secret: oauthClientSecret || undefined,
+								client_secret: oauthClientSecret,
 							}
 						: undefined,
 					vk_configs: vkConfigsDirty ? vkConfigs : undefined,
@@ -630,12 +638,12 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 												<FormItem className="flex flex-col gap-2">
 													<FormLabel>Client ID</FormLabel>
 													<FormControl>
-														<Input
+														<EnvVarInput
 															data-testid="mcpclient-input-oauth-client-id"
 															placeholder="Enter new OAuth client ID"
 															disabled={isDisabled}
-															{...field}
-															value={field.value || ""}
+															value={field.value}
+															onChange={field.onChange}
 														/>
 													</FormControl>
 													{!isDisabled && (
@@ -654,13 +662,14 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 												<FormItem className="flex flex-col gap-2">
 													<FormLabel>Client Secret</FormLabel>
 													<FormControl>
-														<Input
+														<EnvVarInput
 															data-testid="mcpclient-input-oauth-client-secret"
-															type="password"
 															placeholder="Enter new OAuth client secret"
 															disabled={isDisabled}
-															{...field}
-															value={field.value || ""}
+															hideValueWhenEnv
+															maskNonEnvValue
+															value={field.value}
+															onChange={field.onChange}
 														/>
 													</FormControl>
 													<FormMessage />

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -16,8 +16,8 @@ export interface MCPStdioConfig {
 }
 
 export interface OAuthConfig {
-	client_id: string;
-	client_secret?: string; // Optional for public clients using PKCE
+	client_id: EnvVar;
+	client_secret?: EnvVar; // Optional for public clients using PKCE
 	authorize_url?: string; // Optional, will be discovered from server_url if not provided
 	token_url?: string; // Optional, will be discovered from server_url if not provided
 	registration_url?: string; // Optional, for dynamic client registration
@@ -27,8 +27,8 @@ export interface OAuthConfig {
 
 /** OAuth fields allowed on MCP client update (e.g. client_secret-only rotation). */
 export interface OAuthConfigUpdate {
-	client_id?: string;
-	client_secret?: string;
+	client_id?: EnvVar;
+	client_secret?: EnvVar;
 }
 
 export interface MCPClientConfig {
@@ -40,6 +40,8 @@ export interface MCPClientConfig {
 	stdio_config?: MCPStdioConfig;
 	auth_type?: MCPAuthType;
 	oauth_config_id?: string;
+	oauth_client_id?: EnvVar;     // Redacted existing client ID (populated on GET for oauth clients)
+	oauth_client_secret?: EnvVar; // Redacted existing client secret (populated on GET for oauth clients)
 	tools_to_execute?: string[];
 	tools_to_auto_execute?: string[];
 	headers?: Record<string, EnvVar>;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1116,8 +1116,8 @@ export const mcpClientUpdateSchema = z.object({
     ),
   oauth_config: z
     .object({
-      client_id: z.string().trim().min(1, "OAuth Client ID cannot be empty").optional(),
-      client_secret: z.string().trim().min(1, "OAuth Client Secret cannot be empty").optional(),
+      client_id: envVarSchema.optional(),
+      client_secret: envVarSchema.optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
## Summary

OAuth `client_id` and `client_secret` fields now support environment variable references (e.g. `env.MY_VAR`) in addition to plain string values. Previously these fields were stored and handled as raw strings, which meant secrets had to be provided as literal values. This change allows credentials to be injected from environment variables at runtime, keeps references intact in the database, and surfaces redacted credential metadata back to callers on GET requests.

## Changes

- `TableOauthConfig.ClientID` changed from `string` to `*schemas.EnvVar` so env var references are preserved in storage and resolved at runtime via `GetResolvedClientID()` / `GetResolvedClientSecret()` helpers.
- `OAuthConfigRequest` and `OAuthConfigUpdate` in the HTTP transport now use `*schemas.EnvVar` instead of `string` for `client_id` and `client_secret`.
- `envVarStorageValue()` helper added to extract the storage representation (env var reference or resolved value) before passing to the OAuth flow initiator.
- `MCPClientConfig` gains two new read-only fields — `OauthClientID` and `OauthClientSecret` — populated on GET responses with redacted credential metadata fetched from the linked OAuth config.
- A `GetOauthConfigsByIDs` batch query was added to avoid N+1 database calls when listing MCP clients with OAuth configs.
- The `BeforeSave` hook skips encryption for `ClientSecret` values that are already env var references, since the reference string itself is not sensitive.
- On update, credential rotation is skipped when both fields carry a redacted/empty placeholder (i.e. the user did not actually change them), preserving existing stored credentials.
- UI form fields for OAuth `client_id` and `client_secret` replaced plain `Input` components with `EnvVarInput`, enabling env var selection. The edit sheet pre-populates these fields from the redacted GET response and uses `dirtyFields` to determine whether rotation should be triggered.
- TypeScript types updated so `OAuthConfig.client_id`, `OAuthConfig.client_secret`, `OAuthConfigUpdate.client_id`, and `OAuthConfigUpdate.client_secret` are all `EnvVar` instead of `string`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Create an MCP client with OAuth auth type, supplying `client_id` as an env var reference (e.g. `env.OAUTH_CLIENT_ID`) and `client_secret` as `env.OAUTH_CLIENT_SECRET`.
2. Verify the reference strings are stored in the database rather than resolved values.
3. Perform a GET on the MCP client list and confirm `oauth_client_id` and `oauth_client_secret` are returned as redacted `EnvVar` objects.
4. In the UI, open the MCP client form and confirm the `EnvVarInput` components appear for both fields and correctly reflect the stored env var reference.
5. Edit the client without changing the credential fields and confirm no credential rotation occurs.
6. Edit the client with a new credential value and confirm rotation is triggered.

```sh
go test ./...

cd ui
pnpm i
pnpm build
```

## Breaking changes

- [x] Yes
- [ ] No

`TableOauthConfig.ClientID` changed from `string` to `*schemas.EnvVar`. Any code that directly accessed `.ClientID` as a string must be updated to use `.GetResolvedClientID()` or dereference the `EnvVar`. The `OAuthConfigRequest` and `OAuthConfigUpdate` API request bodies now expect `client_id` and `client_secret` as `EnvVar` objects rather than plain strings; API clients sending raw strings will need to wrap values in the `EnvVar` structure.

## Related issues

N/A

## Security considerations

- Env var references are stored as-is in the database; the actual secret values are never written to the database when env vars are used.
- Encryption is intentionally skipped for env var reference strings in `BeforeSave`, since the reference itself (e.g. `env.MY_VAR`) is not sensitive.
- Credential values returned on GET are passed through the existing `Redacted()` path, so actual secret values are never exposed in API responses.
- Resolved values are only used in-process at the point of OAuth flow execution.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable