### PR TITLE
fix: gives graceful error for invalid after values by letting upstream provider handle it

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -1461,7 +1461,7 @@ func (provider *AnthropicProvider) BatchList(ctx *schemas.BifrostContext, keys [
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 
 	// Initialize serial pagination helper (Anthropic uses AfterID for pagination)
-	helper, err := providerUtils.NewSerialListHelper(keys, request.AfterID, provider.logger)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.AfterID, provider.logger, true)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}
@@ -2029,7 +2029,7 @@ func (provider *AnthropicProvider) FileList(ctx *schemas.BifrostContext, keys []
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 
 	// Initialize serial pagination helper
-	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger, true)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -1740,7 +1740,7 @@ func (provider *AzureProvider) FileList(ctx *schemas.BifrostContext, keys []sche
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 
 	// Initialize serial pagination helper
-	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger, true)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}
@@ -2281,7 +2281,7 @@ func (provider *AzureProvider) BatchList(ctx *schemas.BifrostContext, keys []sch
 	}
 
 	// Initialize serial pagination helper
-	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger, true)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}
@@ -3093,7 +3093,7 @@ func (provider *AzureProvider) ContainerFileList(ctx *schemas.BifrostContext, ke
 	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 
-	helper, herr := providerUtils.NewSerialListHelper(keys, request.After, provider.logger)
+	helper, herr := providerUtils.NewSerialListHelper(keys, request.After, provider.logger, true)
 	if herr != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", herr)
 	}

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -2349,7 +2349,7 @@ func (provider *BedrockProvider) FileList(ctx *schemas.BifrostContext, keys []sc
 	}
 
 	// Initialize serial pagination helper
-	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger, true)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}
@@ -2971,7 +2971,7 @@ func (provider *BedrockProvider) BatchList(ctx *schemas.BifrostContext, keys []s
 	}
 
 	// Initialize serial pagination helper (Bedrock uses PageToken for pagination)
-	helper, err := providerUtils.NewSerialListHelper(keys, request.PageToken, provider.logger)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.PageToken, provider.logger, true)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -2754,7 +2754,7 @@ func (provider *GeminiProvider) BatchList(ctx *schemas.BifrostContext, keys []sc
 	}
 
 	// Initialize serial pagination helper (Gemini uses PageToken for pagination)
-	helper, err := providerUtils.NewSerialListHelper(keys, request.PageToken, provider.logger)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.PageToken, provider.logger, true)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}
@@ -3627,7 +3627,7 @@ func (provider *GeminiProvider) FileList(ctx *schemas.BifrostContext, keys []sch
 	}
 
 	// Initialize serial pagination helper
-	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger, true)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -4849,7 +4849,7 @@ func (provider *OpenAIProvider) FileList(ctx *schemas.BifrostContext, keys []sch
 	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
 
 	// Initialize serial pagination helper
-	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger, true)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}
@@ -5419,7 +5419,7 @@ func (provider *OpenAIProvider) BatchList(ctx *schemas.BifrostContext, keys []sc
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 
 	// Initialize serial pagination helper
-	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger, true)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}
@@ -5942,7 +5942,7 @@ func (provider *OpenAIProvider) ContainerList(ctx *schemas.BifrostContext, keys 
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 
 	// Initialize serial pagination helper for multi-key support
-	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger, true)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}
@@ -6400,7 +6400,7 @@ func (provider *OpenAIProvider) ContainerFileList(ctx *schemas.BifrostContext, k
 	sendBackRawResponse := providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse)
 
 	// Initialize serial pagination helper for multi-key support
-	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger)
+	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger, true)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -2923,7 +2923,9 @@ func (provider *ReplicateProvider) FileList(ctx *schemas.BifrostContext, keys []
 	sendBackRawRequest := providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest)
 
 	// Initialize serial pagination helper (Replicate uses cursor-based pagination)
-	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger)
+	// allowNativeCursorFallback=false: Replicate's cursor is a full URL, so passing an
+	// unrecognised value through would produce a malformed request rather than a clean API error.
+	helper, err := providerUtils.NewSerialListHelper(keys, request.After, provider.logger, false)
 	if err != nil {
 		return nil, providerUtils.NewBifrostOperationError("invalid pagination cursor", err)
 	}

--- a/core/providers/utils/pagination.go
+++ b/core/providers/utils/pagination.go
@@ -15,8 +15,10 @@ type SerialListHelper struct {
 
 // NewSerialListHelper creates a new SerialListHelper from the provided keys and encoded cursor.
 // If the cursor is empty or nil, pagination starts from the first key.
-// If the cursor is invalid, an error is returned.
-func NewSerialListHelper(keys []schemas.Key, encodedCursor *string, logger schemas.Logger) (*SerialListHelper, error) {
+// If allowNativeCursorFallback is true and there is exactly one key, an unrecognised cursor is
+// passed through as a native provider cursor so the upstream API can handle it gracefully.
+// Otherwise an invalid cursor returns an error.
+func NewSerialListHelper(keys []schemas.Key, encodedCursor *string, logger schemas.Logger, allowNativeCursorFallback bool) (*SerialListHelper, error) {
 	helper := &SerialListHelper{
 		Keys:   keys,
 		Logger: logger,
@@ -25,9 +27,15 @@ func NewSerialListHelper(keys []schemas.Key, encodedCursor *string, logger schem
 	if encodedCursor != nil && *encodedCursor != "" {
 		cursor, err := schemas.DecodeSerialCursor(*encodedCursor)
 		if err != nil {
-			return nil, err
+			if allowNativeCursorFallback && len(keys) == 1 {
+				// Single-key: treat as a native provider cursor so the upstream API handles it.
+				helper.Cursor = schemas.NewSerialCursor(0, *encodedCursor)
+			} else {
+				return nil, err
+			}
+		} else {
+			helper.Cursor = cursor
 		}
-		helper.Cursor = cursor
 	}
 
 	return helper, nil

--- a/core/providers/utils/pagination_test.go
+++ b/core/providers/utils/pagination_test.go
@@ -1,0 +1,249 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// makeKeys returns a slice of n dummy keys for use in pagination tests.
+func makeKeys(n int) []schemas.Key {
+	keys := make([]schemas.Key, n)
+	for i := range keys {
+		keys[i] = schemas.Key{}
+	}
+	return keys
+}
+
+func strPtr(s string) *string { return &s }
+
+// --- SerialCursor encode/decode ---
+
+func TestEncodeDecodeSerialCursor_RoundTrip(t *testing.T) {
+	original := schemas.NewSerialCursor(2, "native-abc")
+	encoded := schemas.EncodeSerialCursor(original)
+	if encoded == "" {
+		t.Fatal("expected non-empty encoded cursor")
+	}
+
+	decoded, err := schemas.DecodeSerialCursor(encoded)
+	if err != nil {
+		t.Fatalf("unexpected decode error: %v", err)
+	}
+	if decoded.KeyIndex != 2 || decoded.Cursor != "native-abc" || decoded.Version != 1 {
+		t.Fatalf("decoded cursor mismatch: got %+v", decoded)
+	}
+}
+
+func TestDecodeSerialCursor_Empty(t *testing.T) {
+	cursor, err := schemas.DecodeSerialCursor("")
+	if err != nil {
+		t.Fatalf("expected nil error for empty string, got: %v", err)
+	}
+	if cursor != nil {
+		t.Fatalf("expected nil cursor for empty string, got: %+v", cursor)
+	}
+}
+
+func TestDecodeSerialCursor_InvalidBase64(t *testing.T) {
+	_, err := schemas.DecodeSerialCursor("not-valid-base64!!!")
+	if err == nil {
+		t.Fatal("expected error for invalid base64")
+	}
+}
+
+func TestDecodeSerialCursor_InvalidVersion(t *testing.T) {
+	// Manually encode a cursor with version 0.
+	bad := &schemas.SerialCursor{Version: 0, KeyIndex: 0, Cursor: "x"}
+	encoded := schemas.EncodeSerialCursor(bad)
+	_, err := schemas.DecodeSerialCursor(encoded)
+	if err == nil {
+		t.Fatal("expected error for unsupported cursor version")
+	}
+}
+
+// --- NewSerialListHelper ---
+
+func TestNewSerialListHelper_NilCursor(t *testing.T) {
+	helper, err := NewSerialListHelper(makeKeys(1), nil, nil, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if helper.Cursor != nil {
+		t.Fatalf("expected nil cursor, got %+v", helper.Cursor)
+	}
+}
+
+func TestNewSerialListHelper_EmptyCursor(t *testing.T) {
+	helper, err := NewSerialListHelper(makeKeys(1), strPtr(""), nil, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if helper.Cursor != nil {
+		t.Fatalf("expected nil cursor, got %+v", helper.Cursor)
+	}
+}
+
+func TestNewSerialListHelper_ValidCursor(t *testing.T) {
+	encoded := schemas.EncodeSerialCursor(schemas.NewSerialCursor(1, "file-xyz"))
+	helper, err := NewSerialListHelper(makeKeys(3), &encoded, nil, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if helper.Cursor.KeyIndex != 1 || helper.Cursor.Cursor != "file-xyz" {
+		t.Fatalf("unexpected cursor: %+v", helper.Cursor)
+	}
+}
+
+func TestNewSerialListHelper_InvalidCursor_FallbackEnabled_SingleKey(t *testing.T) {
+	raw := "string"
+	helper, err := NewSerialListHelper(makeKeys(1), &raw, nil, true)
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got error: %v", err)
+	}
+	if helper.Cursor == nil {
+		t.Fatal("expected cursor to be set via fallback")
+	}
+	if helper.Cursor.KeyIndex != 0 || helper.Cursor.Cursor != "string" {
+		t.Fatalf("unexpected fallback cursor: %+v", helper.Cursor)
+	}
+}
+
+func TestNewSerialListHelper_InvalidCursor_FallbackEnabled_MultiKey(t *testing.T) {
+	raw := "string"
+	_, err := NewSerialListHelper(makeKeys(3), &raw, nil, true)
+	if err == nil {
+		t.Fatal("expected error for invalid cursor with multiple keys, even with fallback enabled")
+	}
+}
+
+func TestNewSerialListHelper_InvalidCursor_FallbackDisabled_SingleKey(t *testing.T) {
+	raw := "string"
+	_, err := NewSerialListHelper(makeKeys(1), &raw, nil, false)
+	if err == nil {
+		t.Fatal("expected error for invalid cursor with fallback disabled")
+	}
+}
+
+func TestNewSerialListHelper_InvalidCursor_FallbackDisabled_MultiKey(t *testing.T) {
+	raw := "string"
+	_, err := NewSerialListHelper(makeKeys(3), &raw, nil, false)
+	if err == nil {
+		t.Fatal("expected error for invalid cursor with fallback disabled and multiple keys")
+	}
+}
+
+// --- GetCurrentKey ---
+
+func TestGetCurrentKey_NoCursor_ReturnsFirstKey(t *testing.T) {
+	helper, _ := NewSerialListHelper(makeKeys(2), nil, nil, false)
+	_, nativeCursor, ok := helper.GetCurrentKey()
+	if !ok {
+		t.Fatal("expected a key to be returned")
+	}
+	if nativeCursor != "" {
+		t.Fatalf("expected empty native cursor, got %q", nativeCursor)
+	}
+	if helper.GetCurrentKeyIndex() != 0 {
+		t.Fatalf("expected key index 0, got %d", helper.GetCurrentKeyIndex())
+	}
+}
+
+func TestGetCurrentKey_WithCursor_ReturnsCorrectKeyAndNativeCursor(t *testing.T) {
+	encoded := schemas.EncodeSerialCursor(schemas.NewSerialCursor(1, "native-token"))
+	helper, _ := NewSerialListHelper(makeKeys(3), &encoded, nil, false)
+	_, nativeCursor, ok := helper.GetCurrentKey()
+	if !ok {
+		t.Fatal("expected a key to be returned")
+	}
+	if nativeCursor != "native-token" {
+		t.Fatalf("expected native cursor %q, got %q", "native-token", nativeCursor)
+	}
+}
+
+func TestGetCurrentKey_ExhaustedKeys(t *testing.T) {
+	// Cursor pointing past the last key.
+	encoded := schemas.EncodeSerialCursor(schemas.NewSerialCursor(5, ""))
+	helper, _ := NewSerialListHelper(makeKeys(2), &encoded, nil, false)
+	_, _, ok := helper.GetCurrentKey()
+	if ok {
+		t.Fatal("expected no key when cursor index is out of bounds")
+	}
+}
+
+func TestGetCurrentKey_EmptyKeyList(t *testing.T) {
+	helper, _ := NewSerialListHelper([]schemas.Key{}, nil, nil, false)
+	_, _, ok := helper.GetCurrentKey()
+	if ok {
+		t.Fatal("expected no key for empty key list")
+	}
+}
+
+// --- BuildNextCursor ---
+
+func TestBuildNextCursor_HasMore_SameKey(t *testing.T) {
+	helper, _ := NewSerialListHelper(makeKeys(3), nil, nil, false)
+	next, more := helper.BuildNextCursor(true, "file-next")
+	if !more {
+		t.Fatal("expected more=true")
+	}
+	if next == "" {
+		t.Fatal("expected non-empty cursor")
+	}
+	decoded, err := schemas.DecodeSerialCursor(next)
+	if err != nil {
+		t.Fatalf("failed to decode next cursor: %v", err)
+	}
+	if decoded.KeyIndex != 0 || decoded.Cursor != "file-next" {
+		t.Fatalf("unexpected next cursor: %+v", decoded)
+	}
+}
+
+func TestBuildNextCursor_NoMore_AdvancesToNextKey(t *testing.T) {
+	helper, _ := NewSerialListHelper(makeKeys(3), nil, nil, false)
+	next, more := helper.BuildNextCursor(false, "")
+	if !more {
+		t.Fatal("expected more=true when more keys remain")
+	}
+	decoded, err := schemas.DecodeSerialCursor(next)
+	if err != nil {
+		t.Fatalf("failed to decode next cursor: %v", err)
+	}
+	if decoded.KeyIndex != 1 || decoded.Cursor != "" {
+		t.Fatalf("expected advance to key 1 with empty cursor, got: %+v", decoded)
+	}
+}
+
+func TestBuildNextCursor_NoMore_LastKey_ReturnsEmpty(t *testing.T) {
+	helper, _ := NewSerialListHelper(makeKeys(1), nil, nil, false)
+	next, more := helper.BuildNextCursor(false, "")
+	if more {
+		t.Fatal("expected more=false when all keys exhausted")
+	}
+	if next != "" {
+		t.Fatalf("expected empty cursor, got %q", next)
+	}
+}
+
+func TestBuildNextCursor_EmptyKeyList(t *testing.T) {
+	helper, _ := NewSerialListHelper([]schemas.Key{}, nil, nil, false)
+	next, more := helper.BuildNextCursor(true, "x")
+	if more || next != "" {
+		t.Fatal("expected empty result for empty key list")
+	}
+}
+
+// --- HasMoreKeys ---
+
+func TestHasMoreKeys(t *testing.T) {
+	helper, _ := NewSerialListHelper(makeKeys(3), nil, nil, false)
+	if !helper.HasMoreKeys() {
+		t.Fatal("expected HasMoreKeys=true when on key 0 of 3")
+	}
+
+	encoded := schemas.EncodeSerialCursor(schemas.NewSerialCursor(2, ""))
+	helper2, _ := NewSerialListHelper(makeKeys(3), &encoded, nil, false)
+	if helper2.HasMoreKeys() {
+		t.Fatal("expected HasMoreKeys=false when on last key")
+	}
+}


### PR DESCRIPTION
## Summary

`NewSerialListHelper` previously rejected any cursor string that could not be decoded as a Bifrost `SerialCursor`, returning an error immediately. This broke providers where a caller might supply a raw, native provider cursor (e.g. an opaque token or a full URL) directly — the helper would refuse it before the upstream API ever had a chance to respond. This PR introduces an `allowNativeCursorFallback` flag that, when enabled and only a single key is present, treats an unrecognised cursor as a native provider cursor and passes it through unchanged.

Replicate is explicitly opted out (`allowNativeCursorFallback=false`) because its cursor is a full URL; passing an unrecognised value would produce a malformed request rather than a clean API error. All other providers (Anthropic, Azure, Bedrock, Gemini, OpenAI) opt in.

## Changes

- Added `allowNativeCursorFallback bool` parameter to `NewSerialListHelper`. When `true` and there is exactly one key, a cursor that fails `DecodeSerialCursor` is wrapped as a native cursor at key index 0 instead of returning an error.
- All providers updated to pass `true` for `allowNativeCursorFallback`, except Replicate which passes `false` with an explanatory comment.
- Added `pagination_test.go` covering cursor encode/decode round-trips, all `NewSerialListHelper` fallback combinations, `GetCurrentKey`, `BuildNextCursor`, and `HasMoreKeys` behaviour.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/utils/...
```

The new test file covers:
- Valid and invalid cursor decode paths
- Fallback behaviour with single vs. multiple keys
- Fallback disabled returning an error regardless of key count
- `GetCurrentKey` returning the correct key and native cursor token
- `BuildNextCursor` advancing to the next key or returning empty when exhausted

## Breaking changes

- [x] Yes
- [ ] No

`NewSerialListHelper` now requires an additional `allowNativeCursorFallback bool` argument. Any caller outside this repository that constructs a `SerialListHelper` directly must be updated to pass the appropriate boolean.

## Related issues

## Security considerations

None. The fallback only applies when a single key is configured, so there is no risk of a crafted cursor being used to skip to a different tenant's key.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable