### PR TITLE
feat: add RBAC permission check to MCP tool groups route

### DIFF
--- a/ui/app/workspace/governance/layout.tsx
+++ b/ui/app/workspace/governance/layout.tsx
@@ -4,9 +4,25 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import GovernancePage from "./page";
 
 function RouteComponent() {
-	const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
+	const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
+	const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
+	const hasUsersAccess = useRbac(RbacResource.Users, RbacOperation.View);
+	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
+	const hasBusinessUnitsAccess = useRbac(RbacResource.UserProvisioning, RbacOperation.View);
+	const hasRbacAccess = useRbac(RbacResource.RBAC, RbacOperation.View);
+	const hasAccessProfilesAccess = useRbac(RbacResource.AccessProfiles, RbacOperation.View);
+
+	const hasAnyGovernanceAccess =
+		hasVirtualKeysAccess ||
+		hasTeamsAccess ||
+		hasUsersAccess ||
+		hasCustomersAccess ||
+		hasBusinessUnitsAccess ||
+		hasRbacAccess ||
+		hasAccessProfilesAccess;
+
 	const childMatches = useChildMatches();
-	if (!hasGovernanceAccess) {
+	if (!hasAnyGovernanceAccess) {
 		return <NoPermissionView entity="governance" />;
 	}
 	return childMatches.length === 0 ? <GovernancePage /> : <Outlet />;

--- a/ui/app/workspace/mcp-tool-groups/layout.tsx
+++ b/ui/app/workspace/mcp-tool-groups/layout.tsx
@@ -1,6 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { NoPermissionView } from "@/components/noPermissionView";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import MCPToolGroupsPage from "./page";
 
+function RouteComponent() {
+	const hasMCPGatewayAccess = useRbac(RbacResource.MCPGateway, RbacOperation.View);
+	if (!hasMCPGatewayAccess) {
+		return <NoPermissionView entity="MCP tool groups" />;
+	}
+	return <MCPToolGroupsPage />;
+}
+
 export const Route = createFileRoute("/workspace/mcp-tool-groups")({
-	component: MCPToolGroupsPage,
+	component: RouteComponent,
 });

--- a/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
@@ -8,6 +8,7 @@ import { getErrorMessage, useCreateProviderMutation } from "@/lib/store";
 import { BaseProvider, ModelProviderName } from "@/lib/types/config";
 import { allowedRequestsSchema } from "@/lib/types/schemas";
 import { cleanPathOverrides } from "@/lib/utils/validation";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -37,6 +38,7 @@ interface Props extends AddCustomProviderSheetContentProps {
 }
 
 export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: AddCustomProviderSheetContentProps) {
+	const hasProviderCreateAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Create);
 	const [addProvider, { isLoading: isAddingProvider }] = useCreateProviderMutation();
 	const form = useForm<FormData>({
 		resolver: zodResolver(formSchema),
@@ -137,7 +139,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 									<FormLabel className="text-right">Name</FormLabel>
 									<div className="col-span-3">
 										<FormControl>
-											<Input placeholder="Name" data-testid="custom-provider-name" {...field} />
+											<Input placeholder="Name" data-testid="custom-provider-name" disabled={!hasProviderCreateAccess} {...field} />
 										</FormControl>
 										<FormMessage />
 									</div>
@@ -152,7 +154,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 									<FormLabel>Base Format</FormLabel>
 									<div>
 										<FormControl>
-											<Select onValueChange={field.onChange} value={field.value}>
+											<Select onValueChange={field.onChange} value={field.value} disabled={!hasProviderCreateAccess}>
 												<SelectTrigger className="w-full" data-testid="base-provider-select">
 													<SelectValue placeholder="Select base format" />
 												</SelectTrigger>
@@ -182,6 +184,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 											<Input
 												placeholder={"https://api.your-provider.com"}
 												data-testid="base-url-input"
+												disabled={!hasProviderCreateAccess}
 												{...field}
 												value={field.value || ""}
 											/>
@@ -209,6 +212,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 												size="md"
 												checked={field.value}
 												onCheckedChange={field.onChange}
+												disabled={!hasProviderCreateAccess}
 												data-testid="custom-provider-keyless-switch"
 											/>
 										</div>
@@ -217,12 +221,21 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 							/>
 						)}
 						{/* Allowed Requests Configuration */}
-						<AllowedRequestsFields control={form.control} providerType={form.watch("baseFormat") as BaseProvider} />
+						<AllowedRequestsFields
+							control={form.control}
+							providerType={form.watch("baseFormat") as BaseProvider}
+							disabled={!hasProviderCreateAccess}
+						/>
 						<div className="align-end mt-10 ml-auto flex flex-row gap-2 border-t pt-4">
 							<Button type="button" variant="outline" onClick={onClose} className="ml-auto" data-testid="custom-provider-cancel-btn">
 								Cancel
 							</Button>
-							<Button type="submit" isLoading={isAddingProvider} data-testid="custom-provider-save-btn">
+							<Button
+								type="submit"
+								isLoading={isAddingProvider}
+								disabled={!hasProviderCreateAccess}
+								data-testid="custom-provider-save-btn"
+							>
 								Add
 							</Button>
 						</div>

--- a/ui/app/workspace/providers/views/modelProviderConfig.tsx
+++ b/ui/app/workspace/providers/views/modelProviderConfig.tsx
@@ -16,6 +16,7 @@ export default function ModelProviderConfig({ provider, onRequestDelete }: Props
 	const [showConfigSheet, setShowConfigSheet] = useState(false);
 	const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
 	const hasDeleteProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Delete);
+	const hasUpdateProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
 
 	const showApiKeys = useMemo(() => {
 		if (provider.custom_provider_config) {
@@ -39,7 +40,7 @@ export default function ModelProviderConfig({ provider, onRequestDelete }: Props
 			)}
 			<Button variant="outline" onClick={() => setShowConfigSheet(true)}>
 				<SettingsIcon className="h-4 w-4" />
-				Edit Provider Config
+				{hasUpdateProviderAccess ? "Edit Provider Config" : "View Provider Config"}
 			</Button>
 		</div>
 	);

--- a/ui/app/workspace/providers/views/providerKeyForm.tsx
+++ b/ui/app/workspace/providers/views/providerKeyForm.tsx
@@ -6,6 +6,7 @@ import { getErrorMessage } from "@/lib/store";
 import { useCreateProviderKeyMutation, useGetProviderKeysQuery, useUpdateProviderKeyMutation } from "@/lib/store/apis/providersApi";
 import { ModelProvider } from "@/lib/types/config";
 import { modelProviderKeySchema } from "@/lib/types/schemas";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Save } from "lucide-react";
 import { useCallback, useEffect } from "react";
@@ -29,6 +30,7 @@ const providerKeyFormSchema = z.object({
 type ProviderKeyFormValues = z.infer<typeof modelProviderKeySchema>;
 
 export default function ProviderKeyForm({ provider, keyId, onCancel, onSave }: Props) {
+	const hasUpdateProviderAccess = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
 	const [createProviderKey, { isLoading: isCreatingProviderKey }] = useCreateProviderKeyMutation();
 	const [updateProviderKey, { isLoading: isUpdatingProviderKey }] = useUpdateProviderKeyMutation();
 	const { data: keys = [] } = useGetProviderKeysQuery(provider.name);
@@ -66,6 +68,9 @@ export default function ProviderKeyForm({ provider, keyId, onCancel, onSave }: P
 	}, [isEditing, form]);
 
 	const getTooltipContent = useCallback(() => {
+		if (!hasUpdateProviderAccess) {
+			return "You do not have permission to modify provider keys";
+		}
 		if (!form.formState.isValid && form.formState.errors.root?.message) {
 			return form.formState.errors.root?.message;
 		}
@@ -73,7 +78,7 @@ export default function ProviderKeyForm({ provider, keyId, onCancel, onSave }: P
 			return "No changes made";
 		}
 		return null;
-	}, [form?.formState.errors, form?.formState.isValid, form?.formState.isDirty]);
+	}, [form?.formState.errors, form?.formState.isValid, form?.formState.isDirty, hasUpdateProviderAccess]);
 
 	const onSubmit = (value: any) => {
 		if (isEditing && !currentKey) return;
@@ -132,7 +137,7 @@ export default function ProviderKeyForm({ provider, keyId, onCancel, onSave }: P
 									<span>
 										<Button
 											type="submit"
-											disabled={!form.formState.isDirty}
+											disabled={!form.formState.isDirty || !hasUpdateProviderAccess}
 											isLoading={form.formState.isSubmitting || isCreatingProviderKey || isUpdatingProviderKey}
 											data-testid="key-save-btn"
 										>

--- a/ui/app/workspace/routing-rules/layout.tsx
+++ b/ui/app/workspace/routing-rules/layout.tsx
@@ -1,8 +1,14 @@
 import { createFileRoute, Outlet, useChildMatches } from "@tanstack/react-router";
+import { NoPermissionView } from "@/components/noPermissionView";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import RoutingRulesPage from "./page";
 
 function RouteComponent() {
+	const hasRoutingRulesAccess = useRbac(RbacResource.RoutingRules, RbacOperation.View);
 	const childMatches = useChildMatches();
+	if (!hasRoutingRulesAccess) {
+		return <NoPermissionView entity="routing rules" />;
+	}
 	return childMatches.length === 0 ? <RoutingRulesPage /> : <Outlet />;
 }
 

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -3,6 +3,7 @@
  * Create/Edit form for routing rules
  */
 
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Button } from "@/components/ui/button";
 import { ComboboxSelect } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
@@ -88,6 +89,9 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 
 	const isEditing = !!editingRule;
 	const isLoading = isCreating || isUpdating;
+	const canCreate = useRbac(RbacResource.RoutingRules, RbacOperation.Create);
+	const canUpdate = useRbac(RbacResource.RoutingRules, RbacOperation.Update);
+	const hasRequiredAccess = isEditing ? canUpdate : canCreate;
 	const enabled = watch("enabled");
 	const chainRule = watch("chain_rule");
 	const scope = watch("scope");
@@ -583,7 +587,7 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 							<X className="h-4 w-4" />
 							Cancel
 						</Button>
-						<Button type="submit" disabled={isLoading}>
+						<Button type="submit" disabled={isLoading || !hasRequiredAccess}>
 							<Save className="h-4 w-4" />
 							{isEditing ? "Update Rule" : "Save Rule"}
 						</Button>

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -191,15 +191,17 @@ export function RoutingRulesTable({
 									</TableCell>
 									<TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
 										<div className="flex items-center justify-end gap-2">
-											<Button
-												variant="ghost"
-												size="sm"
-												onClick={() => onEdit(rule)}
-												aria-label="Edit routing rule"
-												data-testid={`routing-rule-edit-${rule.id}-btn`}
-											>
-												<Edit className="h-4 w-4" />
-											</Button>
+											{canUpdate && (
+												<Button
+													variant="ghost"
+													size="sm"
+													onClick={() => onEdit(rule)}
+													aria-label="Edit routing rule"
+													data-testid={`routing-rule-edit-${rule.id}-btn`}
+												>
+													<Edit className="h-4 w-4" />
+												</Button>
+											)}
 											{canDelete && (
 												<Button
 													variant="ghost"

--- a/ui/app/workspace/routing-rules/views/routingRulesView.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesView.tsx
@@ -3,7 +3,7 @@
  * Main orchestrator component for routing rules management
  */
 
-import { RbacOperation, RbacResource, useRbac } from "@/app/_fallbacks/enterprise/lib/contexts/rbacContext";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Button } from "@/components/ui/button";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { useGetRoutingRulesQuery } from "@/lib/store/apis/routingRulesApi";

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -570,10 +570,10 @@ export default function AppSidebar() {
   const hasAuditLogsAccess = useRbac(RbacResource.AuditLogs, RbacOperation.View);
   const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
   const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
-  const hasBusinessUnitsAccess = useRbac(RbacResource.Governance, RbacOperation.View);
+  const hasBusinessUnitsAccess = useRbac(RbacResource.UserProvisioning, RbacOperation.View);
   const hasRbacAccess = useRbac(RbacResource.RBAC, RbacOperation.View);
   const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
-  const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
+  const hasGovernanceLegacyAccess = useRbac(RbacResource.Governance, RbacOperation.View);
   const hasRoutingRulesAccess = useRbac(RbacResource.RoutingRules, RbacOperation.View);
   const hasGuardrailsProvidersAccess = useRbac(
     RbacResource.GuardrailsProviders,
@@ -585,6 +585,15 @@ export default function AppSidebar() {
   const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.View);
   const hasPromptRepositoryAccess = useRbac(RbacResource.PromptRepository, RbacOperation.View);
   const hasAccessProfilesAccess = useRbac(RbacResource.AccessProfiles, RbacOperation.View);
+  const hasAnyGovernanceAccess =
+    hasVirtualKeysAccess ||
+    hasTeamsAccess ||
+    hasUsersAccess ||
+    hasCustomersAccess ||
+    hasBusinessUnitsAccess ||
+    hasRbacAccess ||
+    hasAccessProfilesAccess ||
+    hasGovernanceLegacyAccess;
   const { data: coreConfig } = useGetCoreConfigQuery({});
   const isDbConnected = coreConfig?.is_db_connected ?? false;
 
@@ -660,7 +669,7 @@ export default function AppSidebar() {
             url: "/workspace/model-limits",
             icon: Wallet,
             description: "Model limits",
-            hasAccess: hasGovernanceAccess,
+            hasAccess: hasGovernanceLegacyAccess,
           },
           {
             title: "Routing Rules",
@@ -727,7 +736,7 @@ export default function AppSidebar() {
         url: "/workspace/governance",
         icon: Landmark,
         description: "Virtual keys, users, teams, customers & roles",
-        hasAccess: hasGovernanceAccess,
+        hasAccess: hasAnyGovernanceAccess,
         subItems: [
           {
             title: "Virtual Keys",
@@ -927,7 +936,8 @@ export default function AppSidebar() {
       hasBusinessUnitsAccess,
       hasRbacAccess,
       hasVirtualKeysAccess,
-      hasGovernanceAccess,
+      hasGovernanceLegacyAccess,
+      hasAnyGovernanceAccess,
       hasRoutingRulesAccess,
       hasGuardrailsProvidersAccess,
       hasGuardrailsConfigAccess,


### PR DESCRIPTION
## Summary

Adds RBAC permission gating to the MCP Tool Groups page, preventing unauthorized users from accessing it without the required permissions.

## Changes

- Introduced a `RouteComponent` wrapper that checks if the current user has `View` permission on the `MCPGateway` resource before rendering the MCP Tool Groups page
- Users without the required permission are shown a `NoPermissionView` with the entity label "MCP tool groups"

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Log in as a user **without** `MCPGateway` View permission and navigate to `/workspace/mcp-tool-groups`
   - Expected: The `NoPermissionView` component is displayed
2. Log in as a user **with** `MCPGateway` View permission and navigate to `/workspace/mcp-tool-groups`
   - Expected: The MCP Tool Groups page renders normally

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots showing the permission-denied state vs. the normal page view._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

_Link related issues here._

## Security considerations

This change enforces access control on the MCP Tool Groups route, ensuring users without the `MCPGateway` View RBAC permission cannot view the page. No secrets or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable