### PR TITLE
feat: add `GetTeamByName` lookup to config store interface and RDB implementation

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -7286,3 +7286,4 @@ func migrationAddMCPClientDisabledColumn(ctx context.Context, db *gorm.DB) error
 	}
 	return nil
 }
+

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2833,6 +2833,26 @@ func (s *RDBConfigStore) GetTeam(ctx context.Context, id string) (*tables.TableT
 	return &team, nil
 }
 
+// GetTeamByName retrieves a team by name. When customerID is non-empty the lookup is scoped to that customer
+func (s *RDBConfigStore) GetTeamByName(ctx context.Context, name string, customerID string) (*tables.TableTeam, error) {
+	var team tables.TableTeam
+	q := s.DB().WithContext(ctx).
+		Select(teamSelectWithVKCount).
+		Preload("Customer").Preload("Budgets").Preload("RateLimit").
+		Where("name = ?", name)
+	if customerID != "" {
+		q = q.Where("customer_id = ?", customerID)
+	}
+
+	if err := q.First(&team).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &team, nil
+}
+
 // CreateTeam creates a new team in the database.
 func (s *RDBConfigStore) CreateTeam(ctx context.Context, team *tables.TableTeam, tx ...*gorm.DB) error {
 	var txDB *gorm.DB

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -173,6 +173,7 @@ type ConfigStore interface {
 	GetTeams(ctx context.Context, customerID string) ([]tables.TableTeam, error)
 	GetTeamsPaginated(ctx context.Context, params TeamsQueryParams) ([]tables.TableTeam, int64, error)
 	GetTeam(ctx context.Context, id string) (*tables.TableTeam, error)
+	GetTeamByName(ctx context.Context, name string, customerID string) (*tables.TableTeam, error)
 	CreateTeam(ctx context.Context, team *tables.TableTeam, tx ...*gorm.DB) error
 	UpdateTeam(ctx context.Context, team *tables.TableTeam, tx ...*gorm.DB) error
 	DeleteTeam(ctx context.Context, id string) error

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -754,6 +754,10 @@ func (m *MockConfigStore) GetTeam(ctx context.Context, id string) (*tables.Table
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetTeamByName(ctx context.Context, name string, customerID string) (*tables.TableTeam, error) {
+	return nil, nil
+}
+
 func (m *MockConfigStore) GetTeams(ctx context.Context, customerID string) ([]tables.TableTeam, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Summary

Adds a `GetTeamByName` method for looking up teams by name, complementing the existing `GetTeam` lookup by ID.

## Changes

- Added `GetTeamByName` to the `ConfigStore` interface, allowing teams to be retrieved by name.
- Implemented `GetTeamByName` in the RDB config store with the same preloads and select behavior as `GetTeam`, returning `ErrNotFound` when no match exists.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
```

- Confirm `GetTeamByName` returns the correct team record when a matching name exists.
- Confirm `GetTeamByName` returns `ErrNotFound` when no team with the given name exists.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth, secrets, or PII handling introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable