### PR TITLE
feat: enforce unique `governance_teams.name` with deduplication migration

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -635,6 +635,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddMCPClientDisabledColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationUniqueTeamNames(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationDropAllowDirectKeysColumn(ctx, db); err != nil {
 		return err
 	}
@@ -7376,3 +7379,60 @@ func migrationAddMCPClientDisabledColumn(ctx context.Context, db *gorm.DB) error
 	return nil
 }
 
+// migrationUniqueTeamNames deduplicates governance_teams.name and adds a unique
+// index. Duplicate rows (same name, different ID) have a short UUID suffix
+// appended so no data is lost. The struct tag uniqueIndex makes GORM enforce
+// this on new rows going forward.
+func migrationUniqueTeamNames(ctx context.Context, db *gorm.DB) error {
+	return RunSingleMigration(ctx, db, &migrator.Migration{
+		ID: "gov_unique_team_names",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+
+			// Find all names that appear more than once.
+			type dupRow struct {
+				Name string
+			}
+			var dups []dupRow
+			if err := tx.Raw(`
+				SELECT name FROM governance_teams
+				GROUP BY name HAVING COUNT(*) > 1
+			`).Scan(&dups).Error; err != nil {
+				return fmt.Errorf("find duplicate team names: %w", err)
+			}
+
+			for _, d := range dups {
+				// oldest row keeps the original name
+				type row struct {
+					ID string
+				}
+				var rows []row
+				if err := tx.Raw(`
+					SELECT id FROM governance_teams
+					WHERE name = ?
+					ORDER BY created_at ASC, id ASC
+				`, d.Name).Scan(&rows).Error; err != nil {
+					return fmt.Errorf("fetch duplicates for %q: %w", d.Name, err)
+				}
+				for _, r := range rows[1:] {
+					newName := d.Name + "-" + r.ID[:8]
+					if err := tx.Exec(`UPDATE governance_teams SET name = ? WHERE id = ?`, newName, r.ID).Error; err != nil {
+						return fmt.Errorf("rename duplicate team %s: %w", r.ID, err)
+					}
+				}
+			}
+
+			// Add the unique index. Skip if it already exists.
+			if !tx.Migrator().HasIndex(&tables.TableTeam{}, "idx_governance_teams_name") {
+				if err := tx.Migrator().CreateIndex(&tables.TableTeam{}, "Name"); err != nil {
+					return fmt.Errorf("create unique index on governance_teams.name: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			_ = tx.Migrator().DropIndex(&tables.TableTeam{}, "idx_governance_teams_name")
+			return nil
+		},
+	})
+}

--- a/framework/configstore/tables/team.go
+++ b/framework/configstore/tables/team.go
@@ -10,7 +10,7 @@ import (
 // TableTeam represents a team entity with budget, rate limit and customer association
 type TableTeam struct {
 	ID          string  `gorm:"primaryKey;type:varchar(255)" json:"id"`
-	Name        string  `gorm:"type:varchar(255);not null" json:"name"`
+	Name        string  `gorm:"type:varchar(255);not null;uniqueIndex" json:"name"`
 	CustomerID  *string `gorm:"type:varchar(255);index" json:"customer_id,omitempty"` // A team can belong to a customer
 	RateLimitID *string `gorm:"type:varchar(255);index" json:"rate_limit_id,omitempty"`
 


### PR DESCRIPTION
## Summary

Team names in `governance_teams` were not enforced to be unique at the database level. This PR adds a unique constraint on `governance_teams.name` and includes a migration that safely deduplicates any existing rows before applying the index.

## Changes

- Added `uniqueIndex` to the `Name` field on `TableTeam`, enforcing uniqueness for all new rows going forward.
- Added migration `gov_unique_team_names` that:
  - Identifies any existing duplicate team names.
  - Keeps the oldest row's name intact and appends a short UUID suffix (first 8 characters of the row ID) to all newer duplicates, preserving all data.
  - Creates the unique index `idx_governance_teams_name` if it does not already exist.
  - Provides a rollback that drops the index.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
```

- Seed a database with duplicate team names and run the migration. Verify that duplicate rows are renamed with a `-<id[:8]>` suffix and that the unique index is present afterward.
- Attempt to insert two teams with the same name after migration and confirm a unique constraint violation is returned.

## Breaking changes

- [x] Yes
- [ ] No

Any code that previously created teams with duplicate names will now receive a unique constraint error. Existing duplicates are automatically renamed during migration with a `-<id[:8]>` suffix appended to the name.

## Related issues

## Security considerations

No direct security implications. Enforcing unique team names reduces the risk of ambiguous team resolution in authorization and governance logic.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable