### PR TITLE
fix: skip matview for non-hour-aligned time window boundaries

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -181,6 +181,16 @@ func startMatViewRefresher(ctx context.Context, db *gorm.DB, interval time.Durat
 // mv_logs_hourly. Per-row filters (content search, metadata, numeric ranges)
 // require the raw logs table.
 func canUseMatViewFilters(f SearchFilters) bool {
+	// mv_logs_hourly is bucketed by date_trunc('hour', timestamp). When the
+	// requested window doesn't align to hour boundaries, summing whole buckets
+	// over-counts the partial leading/trailing hour. Fall back to the raw table
+	// in that case so callers see exact counts.
+	if f.StartTime != nil && !f.StartTime.Truncate(time.Hour).Equal(*f.StartTime) {
+		return false
+	}
+	if f.EndTime != nil && !f.EndTime.Truncate(time.Hour).Equal(*f.EndTime) {
+		return false
+	}
 	return f.ContentSearch == "" &&
 		len(f.MetadataFilters) == 0 &&
 		len(f.RoutingEngineUsed) == 0 &&


### PR DESCRIPTION
## Summary

The materialized view `mv_logs_hourly` buckets data by `date_trunc('hour', timestamp)`. When a query's time window doesn't align to exact hour boundaries, summing whole hourly buckets over-counts the partial leading or trailing hour, producing inaccurate log counts. This fix ensures the raw logs table is used whenever the requested start or end time falls mid-hour.

## Changes

- Added hour-boundary alignment checks in `canUseMatViewFilters`: if `StartTime` or `EndTime` is not truncated to the hour, the function returns `false` and falls back to the raw logs table for exact counts.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Query logs with a time range that does not align to hour boundaries (e.g., `StartTime` at `:30` minutes) and verify that the returned counts match the raw logs table rather than inflated values from the materialized view.

```sh
go test ./framework/logstore/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable