### PR TITLE
fix: broadcast provider config changes to cluster for keyless providers

### DIFF
--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -503,10 +503,20 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to update provider: %v", err))
 		return
 	}
-	// Attempt model discovery
-	err = h.attemptModelDiscovery(ctx, provider, payload.CustomProviderConfig)
-	if err != nil {
-		logger.Warn("Model discovery failed for provider %s: %v", provider, err)
+	// Attempt model discovery (also triggers cluster broadcast via ReloadProvider).
+	// For keyless providers, model discovery is skipped but we still need to
+	// call ReloadProvider directly so the config change is broadcast to cluster peers.
+	if payload.CustomProviderConfig != nil && payload.CustomProviderConfig.IsKeyLess {
+		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		if _, reloadErr := h.modelsManager.ReloadProvider(ctxWithTimeout, provider); reloadErr != nil {
+			logger.Warn("ReloadProvider failed for keyless provider %s: %v", provider, reloadErr)
+		}
+	} else {
+		err = h.attemptModelDiscovery(ctx, provider, payload.CustomProviderConfig)
+		if err != nil {
+			logger.Warn("Model discovery failed for provider %s: %v", provider, err)
+		}
 	}
 
 	// Get redacted config for response (in-memory store is now updated by updateKeyStatus)


### PR DESCRIPTION
## Summary

Fix cluster replication for keyless custom provider config changes. When
updating a keyless provider's config, other nodes in the cluster were never
notified because the broadcast was only triggered through
`attemptModelDiscovery`, which returns early for keyless providers.

## Changes

- In `updateProvider` handler, keyless providers now call `ReloadProvider`
  directly (which triggers the gossip broadcast) instead of going through
  `attemptModelDiscovery` (which skips keyless providers entirely).
- Non-keyless providers continue to use `attemptModelDiscovery` as before — no
  behavior change for them.

The root cause: `attemptModelDiscovery` has a guard that skips keyless providers
since they have no keys to discover models with. But `ReloadProvider` (called
inside `attemptModelDiscovery`) is also the only thing that triggers the gossip
broadcast to cluster peers. So skipping model discovery also accidentally
skipped the broadcast.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/...
```

Manual validation in a clustered deployment:

1. Create a keyless custom provider
2. Update its config (e.g. change base URL, concurrency, network settings)
3. Send multiple requests that round-robin across cluster nodes
4. All nodes should reflect the updated config immediately (previously only the
   node that received the API call would update)

No new configs or environment variables were added.

## Screenshots/Recordings

Not applicable; backend-only fix.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No auth, secrets, PII, or sandboxing behavior was changed. This only adds a
`ReloadProvider` call for keyless providers in the update handler, matching the
behavior non-keyless providers already had.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
