### PR TITLE
fix: update `TableOauthConfig` tests to use `schemas.NewEnvVar` for `ClientID`/`ClientSecret` fields

### DIFF
--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -500,8 +500,8 @@ func TestTableOauthConfig_EncryptDecrypt(t *testing.T) {
 
 	config := &TableOauthConfig{
 		ID:           "oauth-cfg-1",
-		ClientID:     "client-id-public",
-		ClientSecret: "super-secret-client-secret",
+		ClientID:     schemas.NewEnvVar("client-id-public"),
+		ClientSecret: schemas.NewEnvVar("super-secret-client-secret"),
 		RedirectURI:  "https://example.com/callback",
 		State:        "csrf-state-token",
 		CodeVerifier: "pkce-code-verifier-secret",
@@ -517,10 +517,10 @@ func TestTableOauthConfig_EncryptDecrypt(t *testing.T) {
 
 	var found TableOauthConfig
 	require.NoError(t, db.First(&found, "id = ?", "oauth-cfg-1").Error)
-	assert.Equal(t, "super-secret-client-secret", found.ClientSecret)
+	assert.Equal(t, "super-secret-client-secret", found.ClientSecret.GetValue())
 	assert.Equal(t, "pkce-code-verifier-secret", found.CodeVerifier)
 	// Non-sensitive fields should be unchanged
-	assert.Equal(t, "client-id-public", found.ClientID)
+	assert.Equal(t, "client-id-public", found.ClientID.GetValue())
 	assert.Equal(t, "https://example.com/callback", found.RedirectURI)
 }
 
@@ -923,7 +923,7 @@ func TestTableOauthConfig_UpdatePreservesDecryption(t *testing.T) {
 
 	config := &TableOauthConfig{
 		ID:           "oauth-cfg-update",
-		ClientSecret: "original-secret",
+		ClientSecret: schemas.NewEnvVar("original-secret"),
 		RedirectURI:  "https://example.com/callback",
 		State:        "csrf-update",
 		ExpiresAt:    time.Now().Add(15 * time.Minute),
@@ -932,14 +932,14 @@ func TestTableOauthConfig_UpdatePreservesDecryption(t *testing.T) {
 
 	var found TableOauthConfig
 	require.NoError(t, db.First(&found, "id = ?", "oauth-cfg-update").Error)
-	assert.Equal(t, "original-secret", found.ClientSecret)
+	assert.Equal(t, "original-secret", found.ClientSecret.GetValue())
 
-	found.ClientSecret = "rotated-secret"
+	found.ClientSecret = schemas.NewEnvVar("rotated-secret")
 	require.NoError(t, db.Save(&found).Error)
 
 	var found2 TableOauthConfig
 	require.NoError(t, db.First(&found2, "id = ?", "oauth-cfg-update").Error)
-	assert.Equal(t, "rotated-secret", found2.ClientSecret)
+	assert.Equal(t, "rotated-secret", found2.ClientSecret.GetValue())
 }
 
 func TestTableOauthToken_UpdatePreservesDecryption(t *testing.T) {
@@ -1372,7 +1372,7 @@ func TestTableOauthConfig_EncryptionDisabled_StoresPlaintext(t *testing.T) {
 
 	cfg := &TableOauthConfig{
 		ID:           "cfg-dis-1",
-		ClientSecret: "client-secret-plain",
+		ClientSecret: schemas.NewEnvVar("client-secret-plain"),
 		CodeVerifier: "verifier-plain",
 		RedirectURI:  "https://example.com/cb",
 		State:        "csrf-state",
@@ -1392,7 +1392,7 @@ func TestTableOauthConfig_EncryptionDisabled_StoresPlaintext(t *testing.T) {
 	// GORM read should return same plaintext
 	var found TableOauthConfig
 	require.NoError(t, db.Where("id = ?", "cfg-dis-1").First(&found).Error)
-	assert.Equal(t, "client-secret-plain", found.ClientSecret)
+	assert.Equal(t, "client-secret-plain", found.ClientSecret.GetValue())
 	assert.Equal(t, "verifier-plain", found.CodeVerifier)
 }
 

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -110,7 +110,7 @@ func seedFixtures(t *testing.T, store *testConfigStore, tokenURL string) (oauthC
 	oauthConfigID = "test-oauth-config-id"
 	store.oauthConfigs[oauthConfigID] = &tables.TableOauthConfig{
 		ID:          oauthConfigID,
-		ClientID:    "test-client-id",
+		ClientID:    schemas.NewEnvVar("test-client-id"),
 		TokenURL:    tokenURL,
 		RedirectURI: "http://localhost/callback",
 		Scopes:      `["read"]`,

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1141,6 +1141,10 @@ func (m *MockConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.
 	return nil
 }
 
+func (m *MockConfigStore) GetOauthConfigsByIDs(ctx context.Context, ids []string) (map[string]*tables.TableOauthConfig, error) {
+	return nil, nil
+}
+
 // OAuth token
 func (m *MockConfigStore) GetOauthTokenByID(ctx context.Context, id string) (*tables.TableOauthToken, error) {
 	return nil, nil


### PR DESCRIPTION
## Summary

Updates OAuth configuration fields (`ClientID`, `ClientSecret`) to use `schemas.NewEnvVar(...)` instead of raw string literals, aligning these fields with the `EnvVar` type expected by the schema. Also adds a missing `GetOauthConfigsByIDs` method to the `MockConfigStore` in the HTTP transport tests.

## Changes

- Replaced raw string assignments for `ClientID` and `ClientSecret` in OAuth config test fixtures with `schemas.NewEnvVar(...)` to match the correct field type
- Added `GetOauthConfigsByIDs` stub implementation to `MockConfigStore` to satisfy the updated `ConfigStore` interface

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
go test ./framework/oauth2/...
go test ./transports/bifrost-http/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No direct security impact. The change ensures OAuth credentials are consistently represented as `EnvVar` types, which supports environment variable resolution for secrets rather than hardcoded string values — a positive step toward avoiding plaintext secret handling in configuration.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable