### PR TITLE
fix: remove duplicate `GetOauthConfigsByIDs` from `MockConfigStore`

### DIFF
--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1146,10 +1146,6 @@ func (m *MockConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.
 	return nil
 }
 
-func (m *MockConfigStore) GetOauthConfigsByIDs(ctx context.Context, ids []string) (map[string]*tables.TableOauthConfig, error) {
-	return nil, nil
-}
-
 // OAuth token
 func (m *MockConfigStore) GetOauthTokenByID(ctx context.Context, id string) (*tables.TableOauthToken, error) {
 	return nil, nil


### PR DESCRIPTION
## Summary

Removes a duplicate `GetOauthConfigsByIDs` stub from the mock config store in the bifrost-http transport tests, as it is already defined by mockstore.

## Changes

- Remove a duplicate mock GetOauthConfigsByIDs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/...
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable