### PR TITLE
docs: add budget-to-budgets breaking change to v1.5.0 migration guide

### DIFF
--- a/docs/migration-guides/v1.5.0.mdx
+++ b/docs/migration-guides/v1.5.0.mdx
@@ -167,7 +167,86 @@ The `weight` field on a Virtual Key provider config was previously a required `f
 
 ---
 
-## Breaking Change 6: Provider Keys API Separated
+## Breaking Change 6: Virtual Key `budget` Changed to Multi-Budget `budgets`
+
+The budget model on Virtual Keys and provider configs has been restructured from a single budget to support multiple budgets with different reset intervals.
+
+In v1.4.x, a Virtual Key had a single `budget_id` foreign key pointing to one budget, and each provider config also had a single `budget_id`. In v1.5.0, the association is inverted: budgets now reference their parent via `virtual_key_id` or `provider_config_id`, and both Virtual Keys and provider configs support an array of budgets.
+
+The database migration runs automatically on startup, converting existing single-budget associations into the new multi-budget structure.
+
+### API request changes
+
+**Creating a Virtual Key with a budget:**
+
+**Before:**
+```json
+{
+  "name": "my-key",
+  "budget": {
+    "max_limit": 100.0,
+    "reset_duration": "1d"
+  }
+}
+```
+
+**After:**
+```json
+{
+  "name": "my-key",
+  "budgets": [
+    { "max_limit": 100.0, "reset_duration": "1d" },
+    { "max_limit": 500.0, "reset_duration": "1M" }
+  ]
+}
+```
+
+**Provider config budgets:**
+
+**Before:**
+```json
+{
+  "provider": "openai",
+  "budget": { "max_limit": 50.0, "reset_duration": "1h" }
+}
+```
+
+**After:**
+```json
+{
+  "provider": "openai",
+  "budgets": [
+    { "max_limit": 50.0, "reset_duration": "1h" }
+  ]
+}
+```
+
+### API response changes
+
+| Field | v1.4.x | v1.5.0 |
+|---|---|---|
+| Virtual Key `budget_id` | Present | **Removed** |
+| Virtual Key `budget` | Single object | **Removed** - replaced by `budgets` array |
+| Virtual Key `budgets` | Not present | Array of budget objects |
+| Provider config `budget_id` | Present | **Removed** |
+| Provider config `budget` | Single object | **Removed** - replaced by `budgets` array |
+| Provider config `budgets` | Not present | Array of budget objects |
+
+<Note>
+`calendar_aligned` has moved from the budget level to the Virtual Key level. It now applies uniformly to all budgets under a VK.
+</Note>
+
+### Viewing budget for a given key
+
+Budgets are returned as part of the Virtual Key response on all admin endpoints:
+
+- `GET /api/governance/virtual-keys` - list all VKs (includes `budgets` on each VK and each provider config)
+- `GET /api/governance/virtual-keys/{id}` - get a single VK with full budget details
+- `GET /api/governance/virtual-keys/quota` - self-service endpoint (authenticate with the VK value via `x-bf-vk` header)
+
+---
+
+## Breaking Change 7: Provider Keys API Separated
 
 Provider key management now has dedicated endpoints. The `keys` field has been removed from all provider API requests and responses.
 
@@ -228,7 +307,7 @@ curl -X DELETE localhost:8080/api/providers/openai/keys/key-2
 
 ---
 
-## Breaking Change 7: Compact Plugin Restructured
+## Breaking Change 8: Compact Plugin Restructured
 
 The `enable_litellm_fallbacks` option has been removed and replaced with three granular options.
 
@@ -264,7 +343,7 @@ The `enable_litellm_fallbacks` option has been removed and replaced with three g
 
 ---
 
-## Breaking Change 8: Replicate Image Edits Removed from Generations Endpoint
+## Breaking Change 9: Replicate Image Edits Removed from Generations Endpoint
 
 The `/v1/images/generations` endpoint on the Replicate provider no longer accepts image editing parameters (source image, mask). It now only handles text-to-image generation.
 
@@ -276,7 +355,7 @@ Support for image editing via `/v1/images/edits` on Replicate is also being remo
 
 ---
 
-## Breaking Change 9: Provider `deployments` removed - migrate to `aliases`
+## Breaking Change 10: Provider `deployments` removed - migrate to `aliases`
 
 Provider deployment mappings should now live in the top-level `aliases` field on each key. Aliases work across all providers and map any model name to a provider-specific identifier (deployment name, inference profile ARN, fine-tuned model ID, etc.).
 
@@ -420,7 +499,7 @@ The Replicate key config is also restructured. The `deployments` map is gone. A 
 
 ---
 
-## Breaking Change 10: Go SDK - `ExtraFields` Model Fields Renamed
+## Breaking Change 11: Go SDK - `ExtraFields` Model Fields Renamed
 
 `ModelRequested string` has been replaced by two fields on `BifrostResponseExtraFields` and `BifrostErrorExtraFields`.
 
@@ -449,7 +528,7 @@ The same rename applies to `BifrostErrorExtraFields`.
 
 ---
 
-## Breaking Change 11: Go SDK - `StreamAccumulatorResult` Field Renamed
+## Breaking Change 12: Go SDK - `StreamAccumulatorResult` Field Renamed
 
 `Model string` has been replaced by two fields on `StreamAccumulatorResult` (returned by tracer streaming accumulation methods).
 
@@ -466,7 +545,7 @@ result.ResolvedModel  // actual model identifier used by the provider
 
 ---
 
-## Breaking Change 12: `selected_key_id` Cleared on Terminal Retry Failures
+## Breaking Change 13: `selected_key_id` Cleared on Terminal Retry Failures
 
 With the introduction of multi-key retry rotation, `selected_key_id` (and `selected_key_name`) in the request context are **cleared when all retry attempts fail**. Previously, these fields always reflected the key that was selected for the request, even on error.
 
@@ -521,7 +600,7 @@ Single-key, pinned (`x-bf-key-id` / `x-bf-key-name`), and session-sticky request
 
 ---
 
-## Breaking Change 13: Direct Key Bypass Removed (HTTP Gateway and Go SDK)
+## Breaking Change 14: Direct Key Bypass Removed (HTTP Gateway and Go SDK)
 
 The "Direct Key Bypass" feature has been **removed entirely** in v1.5.0, on both surfaces:
 
@@ -670,6 +749,10 @@ Any Virtual Key with `"provider_configs": []` or no `provider_configs` will bloc
 Replace `"tools_to_execute": []` with `"tools_to_execute": ["*"]`. Ensure every VK that needs MCP access has at least one `mcp_configs` entry.
 </Step>
 
+<Step title="Migrate budget to budgets on Virtual Keys">
+Update any API integration that creates or updates Virtual Keys or provider configs to use the `budgets` array instead of the singular `budget` object. Existing budgets are migrated automatically on startup.
+</Step>
+
 <Step title="Handle nullable weight in API consumers">
 Update any client code that processes `weight` to accept `null` in addition to numbers.
 </Step>
@@ -742,6 +825,10 @@ Rename to `OriginalModelRequested`/`ResolvedModelUsed` on ExtraFields, and `Requ
 **Calls authenticating with raw provider keys started failing with auth errors**
 
 The HTTP gateway no longer extracts provider keys from `Authorization` / `x-api-key` / `x-goog-api-key` headers (or `x-bf-bedrock-*` / `x-bf-azure-endpoint` on the Bedrock and Azure integrations). Either issue a virtual key (`sk-bf-*`) per caller and have them send that, or register the provider credentials as a Bifrost-managed key and route via virtual keys. See [Breaking Change 13](#breaking-change-13-direct-key-bypass-removed-http-gateway-and-go-sdk).
+
+**Virtual Key response missing `budgets` field**
+
+If you are creating Virtual Keys via the API using the old singular `budget` field, it will be ignored. Use the new `budgets` array format instead. If the VK was migrated from v1.4.x, the automatic migration should have converted the existing budget. Check that the migration ran successfully on startup.
 
 **Go SDK build error: `undefined: schemas.BifrostContextKeyDirectKey`**
 


### PR DESCRIPTION
## Summary

Document the budget-to-budgets breaking change in the v1.5.0 migration guide.
The restructuring from single `budget` to multi-budget `budgets` array on
Virtual Keys and provider configs was missing from the migration guide.

## Changes

- Added Breaking Change 6: Virtual Key `budget` changed to multi-budget
  `budgets`, with before/after API request examples, response field changes
  table, and admin endpoint listing for viewing budgets
- Renumbered existing Breaking Changes 6-13 to 7-14
- Added migration checklist step for migrating `budget` to `budgets` on Virtual
  Keys and provider configs
- Added troubleshooting entry for missing `budgets` field in API responses

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the migration guide renders correctly on the docs site. Confirm that all
breaking change anchors and cross-references within the document are consistent
after renumbering.

## Screenshots/Recordings

N/A - documentation only.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

None

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
