### PR TITLE
docs: fix cross-references after breaking change renumbering

### DIFF
--- a/docs/enterprise/migration-guides/v1.4.0.mdx
+++ b/docs/enterprise/migration-guides/v1.4.0.mdx
@@ -15,18 +15,22 @@ Enterprise v1.4.0 is a major release built on top of OSS v1.5.0. It inherits eve
 
 Enterprise v1.4.0 ships with the full v1.5.0 OSS base, so every breaking change from that release applies. The largest are summarized below; see the [OSS v1.5.0 Migration Guide](/migration-guides/v1.5.0) for full before/after examples and per-field details.
 
-| # | Change | What you must do |
-|---|--------|------------------|
+| OSS # | Change | What you must do |
+|-------|--------|------------------|
 | 1 | **Empty array now means "deny all"** | Replace `[]` with `["*"]` on every `models`, `allowed_models`, `key_ids`, and `tools_to_execute` field |
 | 2 | **`allowed_keys` renamed to `key_ids`** | Rename in `config.json` and any REST API consumers; no automatic database migration |
 | 3 | **VK `provider_configs: []` is deny-by-default** | Add at least one provider config per Virtual Key |
-| 4 | **Provider Keys API separated** | Stop sending `keys` in provider create/update payloads; use `/api/providers/{provider}/keys` |
-| 5 | **Compat plugin restructured** | Replace `enable_litellm_fallbacks` with `convert_text_to_chat`, `convert_chat_to_responses`, `should_drop_params` |
-| 6 | **Provider `deployments` removed** | Move Azure/Bedrock/Vertex/Replicate `deployments` maps into the top-level `aliases` field |
-| 7 | **WhiteList validation** | Lists cannot mix `["*"]` with specific values, and cannot contain duplicates |
-| 8 | **`weight` is now nullable** | Update API consumers to handle `null` |
-| 9 | **`selected_key_id` cleared on terminal retry failures** | Read `attempt_trail` for failure attribution |
-| 10 | **Direct Key Bypass removed (HTTP + Go SDK)** | Drop `allow_direct_keys` from `config.json`; migrate header-passed provider keys to Bifrost-managed keys + virtual keys; replace any Go SDK usage of `BifrostContextKeyDirectKey` with `BifrostContextKeyAPIKeyID` / `BifrostContextKeyAPIKeyName` |
+| 4 | **WhiteList validation** | Lists cannot mix `["*"]` with specific values, and cannot contain duplicates |
+| 5 | **`weight` is now nullable** | Update API consumers to handle `null` |
+| 6 | **VK `budget` changed to multi-budget `budgets`** | Update API integrations from singular `"budget": {...}` to `"budgets": [{...}]` on Virtual Keys and provider configs; existing budgets are migrated automatically |
+| 7 | **Provider Keys API separated** | Stop sending `keys` in provider create/update payloads; use `/api/providers/{provider}/keys` |
+| 8 | **Compat plugin restructured** | Replace `enable_litellm_fallbacks` with `convert_text_to_chat`, `convert_chat_to_responses`, `should_drop_params` |
+| 9 | **Replicate image edits removed from generations endpoint** | Switch image editing calls from `/v1/images/generations` to `/v1/images/edits` on Replicate |
+| 10 | **Provider `deployments` removed** | Move Azure/Bedrock/Vertex/Replicate `deployments` maps into the top-level `aliases` field |
+| 11 | **Go SDK `ExtraFields.ModelRequested` renamed** | Replace with `OriginalModelRequested` and `ResolvedModelUsed` |
+| 12 | **Go SDK `StreamAccumulatorResult.Model` renamed** | Replace with `RequestedModel` and `ResolvedModel` |
+| 13 | **`selected_key_id` cleared on terminal retry failures** | Read `attempt_trail` for failure attribution |
+| 14 | **Direct Key Bypass removed (HTTP + Go SDK)** | Drop `allow_direct_keys` from `config.json`; migrate header-passed provider keys to Bifrost-managed keys + virtual keys; replace any Go SDK usage of `BifrostContextKeyDirectKey` with `BifrostContextKeyAPIKeyID` / `BifrostContextKeyAPIKeyName` |
 
 The automatic database migration on startup converts existing records to the new semantics. Only `config.json` and any REST API integrations need manual updates.
 
@@ -159,7 +163,7 @@ Snapshot your config store database (Postgres dump or SQLite file copy) before s
 </Step>
 
 <Step title="Apply the OSS v1.5.0 migration steps">
-Work through the [OSS v1.5.0 Migration Guide](/migration-guides/v1.5.0) checklist: update `models`, `allowed_models`, `key_ids`, `tools_to_execute`, rename `allowed_keys` to `key_ids`, ensure every VK has at least one provider config, migrate provider key management to dedicated endpoints, remove `allow_direct_keys`, migrate HTTP header-key callers to Bifrost-managed keys + virtual keys, migrate Go SDK `BifrostContextKeyDirectKey` callers to `BifrostContextKeyAPIKeyID`/`BifrostContextKeyAPIKeyName`, and update Go SDK references.
+Work through the [OSS v1.5.0 Migration Guide](/migration-guides/v1.5.0) checklist: update `models`, `allowed_models`, `key_ids`, `tools_to_execute`, rename `allowed_keys` to `key_ids`, migrate `budget` to `budgets` on Virtual Keys and provider configs, ensure every VK has at least one provider config, migrate provider key management to dedicated endpoints, remove `allow_direct_keys`, migrate HTTP header-key callers to Bifrost-managed keys + virtual keys, migrate Go SDK `BifrostContextKeyDirectKey` callers to `BifrostContextKeyAPIKeyID`/`BifrostContextKeyAPIKeyName`, and update Go SDK references.
 </Step>
 
 <Step title="Open the gRPC cluster port (10102/TCP) on every node">

--- a/docs/migration-guides/v1.5.0.mdx
+++ b/docs/migration-guides/v1.5.0.mdx
@@ -824,7 +824,7 @@ Rename to `OriginalModelRequested`/`ResolvedModelUsed` on ExtraFields, and `Requ
 
 **Calls authenticating with raw provider keys started failing with auth errors**
 
-The HTTP gateway no longer extracts provider keys from `Authorization` / `x-api-key` / `x-goog-api-key` headers (or `x-bf-bedrock-*` / `x-bf-azure-endpoint` on the Bedrock and Azure integrations). Either issue a virtual key (`sk-bf-*`) per caller and have them send that, or register the provider credentials as a Bifrost-managed key and route via virtual keys. See [Breaking Change 13](#breaking-change-13-direct-key-bypass-removed-http-gateway-and-go-sdk).
+The HTTP gateway no longer extracts provider keys from `Authorization` / `x-api-key` / `x-goog-api-key` headers (or `x-bf-bedrock-*` / `x-bf-azure-endpoint` on the Bedrock and Azure integrations). Either issue a virtual key (`sk-bf-*`) per caller and have them send that, or register the provider credentials as a Bifrost-managed key and route via virtual keys. See [Breaking Change 14](#breaking-change-14-direct-key-bypass-removed-http-gateway-and-go-sdk).
 
 **Virtual Key response missing `budgets` field**
 
@@ -832,4 +832,4 @@ If you are creating Virtual Keys via the API using the old singular `budget` fie
 
 **Go SDK build error: `undefined: schemas.BifrostContextKeyDirectKey`**
 
-The constant is removed in v1.5.0. Register the key on your `Account` implementation (or via `POST /api/providers/{provider}/keys` if you use the database-backed config store) and pin it per request with `BifrostContextKeyAPIKeyID` or `BifrostContextKeyAPIKeyName`. See [Breaking Change 13](#breaking-change-13-direct-key-bypass-removed-http-gateway-and-go-sdk) for a before/after example.
+The constant is removed in v1.5.0. Register the key on your `Account` implementation (or via `POST /api/providers/{provider}/keys` if you use the database-backed config store) and pin it per request with `BifrostContextKeyAPIKeyID` or `BifrostContextKeyAPIKeyName`. See [Breaking Change 14](#breaking-change-14-direct-key-bypass-removed-http-gateway-and-go-sdk) for a before/after example.


### PR DESCRIPTION
## Summary

Fix broken anchor links in the v1.5.0 migration guide and align the enterprise
v1.4.0 migration guide's OSS summary table with the updated v1.5.0 breaking
change numbering.

## Changes

- Fixed two internal anchor links in `docs/migration-guides/v1.5.0.mdx` that
  still referenced `#breaking-change-13` after the renumbering to
  `#breaking-change-14`
- Reordered the enterprise v1.4.0 OSS summary table to match the sequential
  numbering in the v1.5.0 guide (was jumbled: 1,2,3,4=Keys
  API,5=Compat,6=Deployments,7=WhiteList,8=Weight...)
- Added 4 missing OSS breaking changes to the enterprise summary table:
  budget-to-budgets (6), Replicate image edits (9), Go SDK ExtraFields rename
  (11), Go SDK StreamAccumulatorResult rename (12)
- Renamed the table header from `#` to `OSS #` for clarity
- Added `budget` to `budgets` migration step to the enterprise checklist

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify anchor links in the v1.5.0 migration guide resolve correctly. Confirm the
enterprise v1.4.0 summary table numbers match the corresponding OSS breaking
change headings.

## Screenshots/Recordings

N/A - documentation only.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

None.

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
