### PR TITLE
feat: support optional `tx` parameter in `DeleteVirtualKey` for external transaction reuse

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2376,10 +2376,16 @@ func (s *RDBConfigStore) GetAllRedactedKeys(ctx context.Context, ids []string) (
 }
 
 // DeleteVirtualKey deletes a virtual key from the database.
-func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string) error {
-	if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string, tx ...*gorm.DB) error {
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.DB()
+	}
+	if err := txDB.WithContext(ctx).Transaction(func(txDB *gorm.DB) error {
 		var virtualKey tables.TableVirtualKey
-		if err := tx.WithContext(ctx).Preload("ProviderConfigs").First(&virtualKey, "id = ?", id).Error; err != nil {
+		if err := txDB.WithContext(ctx).Preload("ProviderConfigs").First(&virtualKey, "id = ?", id).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return ErrNotFound
 			}
@@ -2390,11 +2396,11 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string) error 
 		var providerConfigRateLimitIDs []string
 		for _, pc := range virtualKey.ProviderConfigs {
 			// Delete the keys join table entries
-			if err := tx.WithContext(ctx).Exec("DELETE FROM governance_virtual_key_provider_config_keys WHERE table_virtual_key_provider_config_id = ?", pc.ID).Error; err != nil {
+			if err := txDB.WithContext(ctx).Exec("DELETE FROM governance_virtual_key_provider_config_keys WHERE table_virtual_key_provider_config_id = ?", pc.ID).Error; err != nil {
 				return err
 			}
 			// Delete budgets owned by this provider config
-			if err := tx.WithContext(ctx).Where("provider_config_id = ?", pc.ID).Delete(&tables.TableBudget{}).Error; err != nil {
+			if err := txDB.WithContext(ctx).Where("provider_config_id = ?", pc.ID).Delete(&tables.TableBudget{}).Error; err != nil {
 				return err
 			}
 			if pc.RateLimitID != nil {
@@ -2403,41 +2409,41 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string) error 
 		}
 
 		// Delete all provider configs associated with the virtual key
-		if err := tx.WithContext(ctx).Delete(&tables.TableVirtualKeyProviderConfig{}, "virtual_key_id = ?", id).Error; err != nil {
+		if err := txDB.WithContext(ctx).Delete(&tables.TableVirtualKeyProviderConfig{}, "virtual_key_id = ?", id).Error; err != nil {
 			return err
 		}
 		for _, rateLimitID := range providerConfigRateLimitIDs {
-			if err := tx.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id = ?", rateLimitID).Error; err != nil {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id = ?", rateLimitID).Error; err != nil {
 				return err
 			}
 		}
 		// Delete all MCP configs associated with the virtual key
-		if err := tx.WithContext(ctx).Delete(&tables.TableVirtualKeyMCPConfig{}, "virtual_key_id = ?", id).Error; err != nil {
+		if err := txDB.WithContext(ctx).Delete(&tables.TableVirtualKeyMCPConfig{}, "virtual_key_id = ?", id).Error; err != nil {
 			return err
 		}
 		// Delete per-user OAuth pending flows tied to this VK
-		if err := tx.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TablePerUserOAuthPendingFlow{}).Error; err != nil {
+		if err := txDB.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TablePerUserOAuthPendingFlow{}).Error; err != nil {
 			return err
 		}
 		// Delete per-user OAuth sessions tied to this VK
-		if err := tx.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TablePerUserOAuthSession{}).Error; err != nil {
+		if err := txDB.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TablePerUserOAuthSession{}).Error; err != nil {
 			return err
 		}
 		// Delete upstream OAuth user sessions tied to this VK
-		if err := tx.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableOauthUserSession{}).Error; err != nil {
+		if err := txDB.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableOauthUserSession{}).Error; err != nil {
 			return err
 		}
 		// Delete upstream OAuth user tokens tied to this VK
-		if err := tx.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableOauthUserToken{}).Error; err != nil {
+		if err := txDB.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableOauthUserToken{}).Error; err != nil {
 			return err
 		}
 		// Delete budgets owned by this virtual key
-		if err := tx.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableBudget{}).Error; err != nil {
+		if err := txDB.WithContext(ctx).Where("virtual_key_id = ?", id).Delete(&tables.TableBudget{}).Error; err != nil {
 			return err
 		}
 		rateLimitID := virtualKey.RateLimitID
 		// Delete the virtual key
-		if err := tx.WithContext(ctx).Delete(&tables.TableVirtualKey{}, "id = ?", id).Error; err != nil {
+		if err := txDB.WithContext(ctx).Delete(&tables.TableVirtualKey{}, "id = ?", id).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return ErrNotFound
 			}
@@ -2445,7 +2451,7 @@ func (s *RDBConfigStore) DeleteVirtualKey(ctx context.Context, id string) error 
 		}
 		// Delete the rate limit associated with the virtual key
 		if rateLimitID != nil {
-			if err := tx.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id = ?", *rateLimitID).Error; err != nil {
+			if err := txDB.WithContext(ctx).Delete(&tables.TableRateLimit{}, "id = ?", *rateLimitID).Error; err != nil {
 				return err
 			}
 		}

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -152,7 +152,7 @@ type ConfigStore interface {
 	GetVirtualKeyQuotaByValue(ctx context.Context, value string) (*tables.TableVirtualKey, error)
 	CreateVirtualKey(ctx context.Context, virtualKey *tables.TableVirtualKey, tx ...*gorm.DB) error
 	UpdateVirtualKey(ctx context.Context, virtualKey *tables.TableVirtualKey, tx ...*gorm.DB) error
-	DeleteVirtualKey(ctx context.Context, id string) error
+	DeleteVirtualKey(ctx context.Context, id string, tx ...*gorm.DB) error
 
 	// Virtual key provider config CRUD
 	GetVirtualKeyProviderConfigs(ctx context.Context, virtualKeyID string) ([]tables.TableVirtualKeyProviderConfig, error)

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -787,7 +787,7 @@ func (m *MockConfigStore) UpdateVirtualKey(ctx context.Context, virtualKey *tabl
 	return nil
 }
 
-func (m *MockConfigStore) DeleteVirtualKey(ctx context.Context, id string) error {
+func (m *MockConfigStore) DeleteVirtualKey(ctx context.Context, id string, tx ...*gorm.DB) error {
 	return nil
 }
 
@@ -1148,10 +1148,6 @@ func (m *MockConfigStore) CreateOauthConfig(ctx context.Context, config *tables.
 
 func (m *MockConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error {
 	return nil
-}
-
-func (m *MockConfigStore) GetOauthConfigsByIDs(ctx context.Context, ids []string) (map[string]*tables.TableOauthConfig, error) {
-	return nil, nil
 }
 
 // OAuth token


### PR DESCRIPTION
## Summary

`DeleteVirtualKey` previously could not participate in an externally managed transaction. This PR adds optional transaction passthrough support to `DeleteVirtualKey`, bringing it in line with `CreateVirtualKey` and `UpdateVirtualKey`.

## Changes

- Updated `DeleteVirtualKey` in `RDBConfigStore` to accept an optional `*gorm.DB` variadic argument. When provided, the supplied transaction is used as the base DB; otherwise, it falls back to `s.DB()`.
- Updated the `ConfigStore` interface to reflect the new signature: `DeleteVirtualKey(ctx context.Context, id string, tx ...*gorm.DB) error`.
- Updated `MockConfigStore` in the HTTP transport tests to match the new interface signature.
- Removed a stale `GetOauthConfigsByIDs` stub from `MockConfigStore` that was no longer needed.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
go test ./transports/bifrost-http/...
```

Verify that callers of `DeleteVirtualKey` continue to work without passing a transaction, and that callers that need to participate in an existing transaction can now pass one in and have all deletions execute within that transaction.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

The change is backward-compatible. Existing callers that do not pass a transaction are unaffected.

## Related issues

N/A

## Security considerations

No new auth, secrets, or PII handling introduced. The transaction passthrough does not expose any additional data access beyond what was already permitted by the caller's DB handle.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable