### PR TITLE
fix: governance budgets in model providers not saving after restart with UI fixes

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -411,6 +411,25 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 	} else {
 		txDB = s.DB()
 	}
+	// Pre-fetch governance FK references for all existing providers in one query.
+	// ProviderConfig carries no governance fields, so without this the upsert
+	// below would write NULL into budget_id/rate_limit_id on every startup.
+	// If the columns don't exist yet, the fetch simply returns nothing
+	governanceFKs := make(map[string]tables.TableProvider)
+	var existingProviders []tables.TableProvider
+
+	if s.doesColumnExist(ctx, "providers", "budget_id") &&
+		s.doesColumnExist(ctx, "providers", "rate_limit_id") {
+		if err := txDB.WithContext(ctx).
+			Select("name", "budget_id", "rate_limit_id").
+			Find(&existingProviders).Error; err != nil {
+			return fmt.Errorf("failed to prefetch provider governance fks: %w", err)
+		}
+		for _, p := range existingProviders {
+			governanceFKs[p.Name] = p
+		}
+	}
+
 	for providerName, providerConfig := range providers {
 		dbProvider := tables.TableProvider{
 			Name:                     string(providerName),
@@ -427,7 +446,15 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 			Description:              providerConfig.Description,
 		}
 
-		// Upsert provider (create or update if exists)
+		// Carry over governance FKs from the existing row so UpdateAll never
+		// overwrites them with NULL. New providers (not in governanceFKs) correctly
+		// start with nil governance — governance is never set via the file sync path.
+		if existing, ok := governanceFKs[string(providerName)]; ok {
+			dbProvider.BudgetID = existing.BudgetID
+			dbProvider.RateLimitID = existing.RateLimitID
+		}
+
+		// Upsert provider (create or update if exists).
 		if err := txDB.WithContext(ctx).Clauses(
 			clause.OnConflict{
 				Columns:   []clause.Column{{Name: "name"}},
@@ -4013,6 +4040,10 @@ func (s *RDBConfigStore) RetryOnNotFound(ctx context.Context, fn func(ctx contex
 // doesTableExist checks if a table exists in the database.
 func (s *RDBConfigStore) doesTableExist(ctx context.Context, tableName string) bool {
 	return s.DB().WithContext(ctx).Migrator().HasTable(tableName)
+}
+
+func (s *RDBConfigStore) doesColumnExist(ctx context.Context, tableName, columnName string) bool {
+	return s.DB().WithContext(ctx).Migrator().HasColumn(tableName, columnName)
 }
 
 // removeNullKeys removes null keys from the database.

--- a/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
@@ -101,7 +101,7 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 					<SheetTitle>
 						<div className="font-lg flex items-center gap-2">
 							<div className="flex items-center">
-								<Provider provider={provider.name} size={24} />
+								<Provider provider={provider.name} size={24} className="mt-0" />
 							</div>
 							Provider configuration
 						</div>

--- a/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
@@ -276,7 +276,7 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 				)}
 
 				{/* Form Actions */}
-				<div className="flex justify-end space-x-2">
+				<div className="flex justify-end space-x-2 mb-6">
 					<Button
 						type="button"
 						variant="outline"

--- a/ui/app/workspace/providers/fragments/performanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/performanceFormFragment.tsx
@@ -144,7 +144,7 @@ export function PerformanceFormFragment({ provider }: PerformanceFormFragmentPro
 				</div>
 
 				{/* Form Actions */}
-				<div className="flex justify-end space-x-2">
+				<div className="flex justify-end space-x-2 mb-6">
 					<Button
 						type="submit"
 						disabled={!form.formState.isDirty || !hasUpdateProviderAccess || isUpdatingProvider}

--- a/ui/app/workspace/providers/fragments/proxyFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/proxyFormFragment.tsx
@@ -216,7 +216,7 @@ export function ProxyFormFragment({ provider }: ProxyFormFragmentProps) {
 				</div>
 
 				{/* Form Actions */}
-				<div className="flex justify-end space-x-2">
+				<div className="flex justify-end space-x-2 mb-6">
 					<Button
 						type="button"
 						variant="outline"

--- a/ui/components/provider.tsx
+++ b/ui/components/provider.tsx
@@ -1,15 +1,17 @@
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { getProviderLabel } from "@/lib/constants/logs";
+import { cn } from "@/lib/utils";
 
 interface ProviderProps {
 	provider: string;
 	size?: number;
+	className?: string;
 }
 
-export default function Provider({ provider, size = 16 }: ProviderProps) {
+export default function Provider({ provider, size = 16, className }: ProviderProps) {
 	return (
-		<div className="flex items-center gap-1">
-			<RenderProviderIcon provider={provider as ProviderIconType} size={size} className="mt-0.5" />
+			<div className="flex items-center gap-1">
+			<RenderProviderIcon provider={provider as ProviderIconType} size={size} className={cn("mt-0.5", className)} />
 			<span>{getProviderLabel(provider)}</span>
 		</div>
 	);


### PR DESCRIPTION
## Summary

Fixes a bug where provider governance foreign keys (`budget_id` and `rate_limit_id`) were being overwritten with `NULL` on every application startup during the file-sync upsert path. Also includes minor UI polish for the provider configuration sheet.

## Changes

- Pre-fetches existing `budget_id` and `rate_limit_id` values for all providers before the upsert loop in `UpdateProvidersConfig`, then carries those values forward so the `OnConflict` update never nullifies governance FK references set via the UI or API.
- New providers not yet in the database correctly start with `nil` governance fields, since governance is never set through the file-sync path.
- Added a `className` prop to the `Provider` component so callers can override the default icon margin, and passed `mt-0` from `ProviderConfigSheet` to fix icon alignment in the sheet header.
- Added `mb-6` bottom margin to the form action button rows in the governance, performance, and proxy form fragments to prevent buttons from being clipped at the bottom of the sheet.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure a provider via the UI and assign a budget or rate limit to it.
2. Restart the application so `UpdateProvidersConfig` runs on startup.
3. Verify the provider still has its `budget_id` and `rate_limit_id` intact and that governance settings are not lost.

```sh
go test ./framework/configstore/...
```

For UI changes, open the provider configuration sheet and confirm:

- The provider icon is correctly aligned in the sheet header.
- The save/cancel buttons in the governance, performance, and proxy tabs are fully visible without being cut off at the bottom.

## Screenshots/Recordings

Before: Provider icon had extra top margin in the sheet header; form action buttons were clipped at the bottom of the sheet.  
After: Icon is flush, buttons have adequate bottom spacing.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None. The change only reads and preserves existing FK values; no new data is exposed or stored.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable