### PR TITLE
fix: use simple-query protocol for migration pools to prevent cached plan errors

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -3509,8 +3509,10 @@ compare_postgres_snapshots() {
     # calendar_aligned was dropped from governance_budgets in prerelease2 (add_multi_budget_tables) but
     # re-added in prerelease4 (migrateCalendarAlignedToBudgetsAndRateLimitsTable) - no longer dropped
     # enable_litellm_fallbacks (dropped from config_client in latest cut - behavior moved elsewhere)
+    # allow_direct_keys (dropped from config_client in v1.5.0 - direct-keys-only mode removed; HTTP header
+    # pass-through is no longer accepted)
     if [ "$table" = "config_client" ]; then
-      dropped_columns="$dropped_columns enable_litellm_fallbacks"
+      dropped_columns="$dropped_columns enable_litellm_fallbacks allow_direct_keys"
     fi
 
     local before_col_array

--- a/framework/configstore/encryption_test.go
+++ b/framework/configstore/encryption_test.go
@@ -455,7 +455,7 @@ func TestEncryptPlaintextOAuthConfigs_EncryptsAndDecryptsCorrectly(t *testing.T)
 	// GORM hooks should decrypt on read
 	var found tables.TableOauthConfig
 	require.NoError(t, db.Where("id = ?", "cfg-batch-1").First(&found).Error)
-	assert.Equal(t, "batch-client-secret", found.ClientSecret)
+	assert.Equal(t, "batch-client-secret", found.ClientSecret.GetValue())
 	assert.Equal(t, "batch-verifier", found.CodeVerifier)
 }
 

--- a/framework/configstore/postgres.go
+++ b/framework/configstore/postgres.go
@@ -102,9 +102,16 @@ func newPostgresConfigStore(ctx context.Context, config *PostgresConfig, logger 
 	}
 	dsn := buildPostgresDSN(config)
 
+	// Migration-only DSN. Forces pgx into simple-query protocol on the migration
+	// pool so no statement plan is ever cached server-side; that makes SQLSTATE
+	// 0A000 ("cached plan must not change result type") structurally impossible
+	// when a migration mixes DDL with subsequent SELECTs against the same table.
+	// Runtime pools keep the default cache-statement mode for performance.
+	migrationDSN := dsn + " default_query_exec_mode=simple_protocol"
+
 	// Throwaway pool for schema migrations. Closing it before the runtime pool
 	// opens guarantees no cached prepared-plan survives the DDL.
-	mDb, err := openPostresConnection(dsn, logger)
+	mDb, err := openPostresConnection(migrationDSN, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +137,7 @@ func newPostgresConfigStore(ctx context.Context, config *PostgresConfig, logger 
 	// migrateOnFreshFn: downstream consumers (e.g. bifrost-enterprise) run
 	// their migrations via this hook on a throwaway pool that closes after fn.
 	d.migrateOnFreshFn = func(ctx context.Context, fn func(context.Context, *gorm.DB) error) error {
-		tempDB, err := openPostresConnection(dsn, logger)
+		tempDB, err := openPostresConnection(migrationDSN, logger)
 		if err != nil {
 			return err
 		}

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -538,7 +538,7 @@ func TestTableOauthConfig_EmptySecret_NoError(t *testing.T) {
 
 	var found TableOauthConfig
 	require.NoError(t, db.First(&found, "id = ?", "oauth-cfg-empty").Error)
-	assert.Equal(t, "", found.ClientSecret)
+	assert.Equal(t, "", found.ClientSecret.GetValue())
 	assert.Equal(t, "", found.CodeVerifier)
 }
 

--- a/framework/logstore/postgres.go
+++ b/framework/logstore/postgres.go
@@ -56,8 +56,15 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 	}
 	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s", config.Host.GetValue(), config.Port.GetValue(), config.User.GetValue(), config.Password.GetValue(), config.DBName.GetValue(), config.SSLMode.GetValue())
 
-	openPool := func() (*gorm.DB, error) {
-		return gorm.Open(postgres.New(postgres.Config{DSN: dsn}), &gorm.Config{
+	// Migration-only DSN. Forces pgx into simple-query protocol on the throwaway
+	// migration pool so no statement plan is ever cached server-side; that makes
+	// SQLSTATE 0A000 ("cached plan must not change result type") structurally
+	// impossible when a migration mixes DDL with subsequent SELECTs against the
+	// same table. Runtime pool keeps the default cache-statement mode.
+	migrationDSN := dsn + " default_query_exec_mode=simple_protocol"
+
+	openPool := func(connDSN string) (*gorm.DB, error) {
+		return gorm.Open(postgres.New(postgres.Config{DSN: connDSN}), &gorm.Config{
 			Logger: newGormLogger(logger),
 		})
 	}
@@ -78,7 +85,7 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 
 	// Throwaway pool for the version gate and schema migrations. Closing it
 	// before the runtime pool opens guarantees no cached plan survives DDL.
-	mDb, err := openPool()
+	mDb, err := openPool(migrationDSN)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +111,7 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 	}
 
 	// Runtime pool. Opens against post-migration schema.
-	db, err := openPool()
+	db, err := openPool(dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3352,7 +3352,7 @@ func (c *Config) GetPerUserOAuthMCPClients() map[string]string {
 	}
 	result := make(map[string]string)
 	for _, client := range c.MCPConfig.ClientConfigs {
-		if client != nil && client.AuthType == schemas.MCPAuthTypePerUserOauth {
+		if client != nil && client.AuthType == schemas.MCPAuthTypePerUserOauth && !client.Disabled {
 			result[client.ID] = client.Name
 		}
 	}


### PR DESCRIPTION
## Summary

This PR addresses a `SQLSTATE 0A000` ("cached plan must not change result type") error that can occur when migrations mix DDL with subsequent SELECTs against the same table. It also removes the `allow_direct_keys` column from `config_client` as part of dropping direct-keys-only mode, fixes disabled MCP clients being included in per-user OAuth client listings, and updates `ClientSecret` access to use `.GetValue()`.

## Changes

- Introduces a migration-only DSN that appends `default_query_exec_mode=simple_protocol` for both the configstore and logstore migration pools. This forces pgx into simple-query protocol, preventing server-side statement plan caching during migrations. Runtime pools continue using the default cached-statement mode for performance.
- Drops `allow_direct_keys` from `config_client` in the migration snapshot comparison script, reflecting its removal in v1.5.0 when direct-keys-only mode and HTTP header pass-through were removed.
- Filters out disabled MCP clients in `GetPerUserOAuthMCPClients` so disabled clients are no longer returned.
- Updates `ClientSecret` field access in encryption tests to use `.GetValue()` to match the current type interface.
- Removes the now-unused `GetOauthConfigsByIDs` method from `MockConfigStore`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
go test ./framework/logstore/...
go test ./transports/bifrost-http/lib/...
```

Run migration tests via the CI script to confirm `allow_direct_keys` is correctly recognized as a dropped column and no snapshot comparison failures occur.

## Breaking changes

- [x] Yes
- [ ] No

The `allow_direct_keys` column is dropped from `config_client`. Any deployments relying on this column or direct-keys-only mode must migrate away from that configuration. HTTP header pass-through for direct keys is no longer accepted.

## Related issues

## Security considerations

Removal of `allow_direct_keys` and direct-keys-only mode eliminates a code path that accepted raw API keys via HTTP headers, reducing the attack surface for key exposure through header pass-through.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable