### PR TITLE
doc: fixes typo in migration docs

### DIFF
--- a/docs/migration-guides/v1.5.0.mdx
+++ b/docs/migration-guides/v1.5.0.mdx
@@ -307,7 +307,7 @@ curl -X DELETE localhost:8080/api/providers/openai/keys/key-2
 
 ---
 
-## Breaking Change 8: Compact Plugin Restructured
+## Breaking Change 8: Compat Plugin Restructured
 
 The `enable_litellm_fallbacks` option has been removed and replaced with three granular options.
 
@@ -765,7 +765,7 @@ Ensure no list mixes `"*"` with specific values (e.g., `["*", "gpt-4o"]`) and no
 Stop sending `keys` in provider create/update payloads and stop reading `keys` from provider responses. Use `/api/providers/{provider}/keys` for all key operations.
 </Step>
 
-<Step title="Update compact plugin config">
+<Step title="Update compat plugin config">
 Replace `enable_litellm_fallbacks` with the appropriate combination of `convert_text_to_chat`, `convert_chat_to_responses`, and `should_drop_params`.
 </Step>
 


### PR DESCRIPTION
## Summary

Fixes two minor issues in the v1.5.0 migration guide: a typo in a section heading and a missing newline at the end of the file.

## Changes

- Corrected "Compact Plugin Restructured" to "Compat Plugin Restructured" in Breaking Change 8
- Added missing newline at end of file

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered migration guide at `docs/migration-guides/v1.5.0.mdx` and confirm the heading reads "Compat Plugin Restructured".

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable