### PR TITLE
refactor: change `IsActive` and `Enabled` fields to pointer types with nil-as-default semantics

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -3509,8 +3509,10 @@ compare_postgres_snapshots() {
     # calendar_aligned was dropped from governance_budgets in prerelease2 (add_multi_budget_tables) but
     # re-added in prerelease4 (migrateCalendarAlignedToBudgetsAndRateLimitsTable) - no longer dropped
     # enable_litellm_fallbacks (dropped from config_client in latest cut - behavior moved elsewhere)
+    # allow_direct_keys (dropped from config_client in v1.5.0 - direct-keys-only mode removed; HTTP header
+    # pass-through is no longer accepted)
     if [ "$table" = "config_client" ]; then
-      dropped_columns="$dropped_columns enable_litellm_fallbacks"
+      dropped_columns="$dropped_columns enable_litellm_fallbacks allow_direct_keys"
     fi
 
     local before_col_array

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -746,8 +746,8 @@ func GenerateVirtualKeyHash(vk tables.TableVirtualKey) (string, error) {
 	hash.Write([]byte(vk.Description))
 	// Hash Value
 	hash.Write([]byte(vk.Value))
-	// Hash IsActive
-	if vk.IsActive {
+	// Hash IsActive (nil treated as DB default true)
+	if vk.IsActiveValue() {
 		hash.Write([]byte("isActive:true"))
 	} else {
 		hash.Write([]byte("isActive:false"))
@@ -1074,8 +1074,8 @@ func GenerateRoutingRuleHash(r tables.TableRoutingRule) (string, error) {
 	// Hash Description
 	hash.Write([]byte(r.Description))
 
-	// Hash Enabled
-	if r.Enabled {
+	// Hash Enabled (nil treated as DB default true)
+	if r.EnabledValue() {
 		hash.Write([]byte("enabled:true"))
 	} else {
 		hash.Write([]byte("enabled:false"))

--- a/framework/configstore/encryption_test.go
+++ b/framework/configstore/encryption_test.go
@@ -1353,7 +1353,7 @@ func TestEncryptPlaintextRows_SkipsAlreadyEncryptedVirtualKeys(t *testing.T) {
 		ID:       "vk-already-enc",
 		Name:     "already-encrypted-vk",
 		Value:    "vk-secret-already",
-		IsActive: true,
+		IsActive: bifrost.Ptr(true),
 	}
 	require.NoError(t, db.Create(vk).Error)
 

--- a/framework/configstore/encryption_test.go
+++ b/framework/configstore/encryption_test.go
@@ -455,7 +455,7 @@ func TestEncryptPlaintextOAuthConfigs_EncryptsAndDecryptsCorrectly(t *testing.T)
 	// GORM hooks should decrypt on read
 	var found tables.TableOauthConfig
 	require.NoError(t, db.Where("id = ?", "cfg-batch-1").First(&found).Error)
-	assert.Equal(t, "batch-client-secret", found.ClientSecret)
+	assert.Equal(t, "batch-client-secret", found.ClientSecret.GetValue())
 	assert.Equal(t, "batch-verifier", found.CodeVerifier)
 }
 

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -1246,7 +1246,7 @@ func TestFullMigration_VirtualKeyCRUD(t *testing.T) {
 		ID:        "vk-test-001",
 		Name:      "test-virtual-key",
 		Value:     "vk-secret-value-12345",
-		IsActive:  true,
+		IsActive:  bifrost.Ptr(true),
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
@@ -1262,7 +1262,7 @@ func TestFullMigration_VirtualKeyCRUD(t *testing.T) {
 	assert.Equal(t, "vk-test-001", vks[0].ID)
 	assert.Equal(t, "test-virtual-key", vks[0].Name)
 	assert.Equal(t, "vk-secret-value-12345", vks[0].Value) // AfterFind decrypts
-	assert.True(t, vks[0].IsActive)
+	assert.True(t, vks[0].IsActiveValue())
 
 	// Verify encryption at raw DB level
 	var rawValue, rawStatus, rawHash string
@@ -1434,7 +1434,7 @@ func TestFullMigration_EndToEnd(t *testing.T) {
 	} {
 		err := store.CreateVirtualKey(ctx, &tables.TableVirtualKey{
 			ID: vk.id, Name: vk.name, Value: vk.value,
-			IsActive: true, CreatedAt: now, UpdatedAt: now,
+			IsActive: bifrost.Ptr(true), CreatedAt: now, UpdatedAt: now,
 		})
 		require.NoError(t, err, "CreateVirtualKey %s", vk.name)
 	}

--- a/framework/configstore/postgres.go
+++ b/framework/configstore/postgres.go
@@ -102,9 +102,16 @@ func newPostgresConfigStore(ctx context.Context, config *PostgresConfig, logger 
 	}
 	dsn := buildPostgresDSN(config)
 
+	// Migration-only DSN. Forces pgx into simple-query protocol on the migration
+	// pool so no statement plan is ever cached server-side; that makes SQLSTATE
+	// 0A000 ("cached plan must not change result type") structurally impossible
+	// when a migration mixes DDL with subsequent SELECTs against the same table.
+	// Runtime pools keep the default cache-statement mode for performance.
+	migrationDSN := dsn + " default_query_exec_mode=simple_protocol"
+
 	// Throwaway pool for schema migrations. Closing it before the runtime pool
 	// opens guarantees no cached prepared-plan survives the DDL.
-	mDb, err := openPostresConnection(dsn, logger)
+	mDb, err := openPostresConnection(migrationDSN, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +137,7 @@ func newPostgresConfigStore(ctx context.Context, config *PostgresConfig, logger 
 	// migrateOnFreshFn: downstream consumers (e.g. bifrost-enterprise) run
 	// their migrations via this hook on a throwaway pool that closes after fn.
 	d.migrateOnFreshFn = func(ctx context.Context, fn func(context.Context, *gorm.DB) error) error {
-		tempDB, err := openPostresConnection(dsn, logger)
+		tempDB, err := openPostresConnection(migrationDSN, logger)
 		if err != nil {
 			return err
 		}

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -488,7 +488,7 @@ func TestCreateVirtualKey(t *testing.T) {
 		ID:       "vk-test",
 		Name:     "Test Virtual Key",
 		Value:    "vk-test-value-123",
-		IsActive: true,
+		IsActive: schemas.Ptr(true),
 	}
 
 	err := store.CreateVirtualKey(ctx, vk)
@@ -499,7 +499,7 @@ func TestCreateVirtualKey(t *testing.T) {
 	assert.Equal(t, "vk-test", result.ID)
 	assert.Equal(t, "Test Virtual Key", result.Name)
 	assert.Equal(t, "vk-test-value-123", result.Value)
-	assert.True(t, result.IsActive)
+	assert.True(t, result.IsActiveValue())
 }
 
 func TestCreateVirtualKey_WithBudgetAndRateLimit(t *testing.T) {
@@ -533,7 +533,7 @@ func TestCreateVirtualKey_WithBudgetAndRateLimit(t *testing.T) {
 		ID:          vkID,
 		Name:        "VK With References",
 		Value:       "vk-refs-value",
-		IsActive:    true,
+		IsActive:    schemas.Ptr(true),
 		RateLimitID: &rateLimitID,
 	}
 
@@ -561,7 +561,7 @@ func TestCreateVirtualKey_DuplicateName(t *testing.T) {
 		ID:       "vk-1",
 		Name:     "Same Name",
 		Value:    "vk-value-1",
-		IsActive: true,
+		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk1)
 	require.NoError(t, err)
@@ -570,7 +570,7 @@ func TestCreateVirtualKey_DuplicateName(t *testing.T) {
 		ID:       "vk-2",
 		Name:     "Same Name", // Duplicate name
 		Value:    "vk-value-2",
-		IsActive: true,
+		IsActive: schemas.Ptr(true),
 	}
 	err = store.CreateVirtualKey(ctx, vk2)
 	assert.Error(t, err, "Should fail with duplicate name")
@@ -584,7 +584,7 @@ func TestGetVirtualKeyByValue(t *testing.T) {
 		ID:       "vk-lookup",
 		Name:     "Lookup Key",
 		Value:    "vk-unique-value-xyz",
-		IsActive: true,
+		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
 	require.NoError(t, err)
@@ -602,21 +602,21 @@ func TestUpdateVirtualKey(t *testing.T) {
 		ID:       "vk-update",
 		Name:     "Original Name",
 		Value:    "vk-update-value",
-		IsActive: true,
+		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
 	require.NoError(t, err)
 
 	// Update
 	vk.Name = "Updated Name"
-	vk.IsActive = false
+	vk.IsActive = schemas.Ptr(false)
 	err = store.UpdateVirtualKey(ctx, vk)
 	require.NoError(t, err)
 
 	result, err := store.GetVirtualKey(ctx, "vk-update")
 	require.NoError(t, err)
 	assert.Equal(t, "Updated Name", result.Name)
-	assert.False(t, result.IsActive)
+	assert.False(t, result.IsActiveValue())
 }
 
 func TestDeleteVirtualKey(t *testing.T) {
@@ -627,7 +627,7 @@ func TestDeleteVirtualKey(t *testing.T) {
 		ID:       "vk-delete",
 		Name:     "Delete Me",
 		Value:    "vk-delete-value",
-		IsActive: true,
+		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
 	require.NoError(t, err)
@@ -652,7 +652,7 @@ func TestCreateVirtualKeyProviderConfig(t *testing.T) {
 		ID:       "vk-for-pc",
 		Name:     "VK For Provider Config",
 		Value:    "vk-pc-value",
-		IsActive: true,
+		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
 	require.NoError(t, err)
@@ -695,7 +695,7 @@ func TestCreateVirtualKeyProviderConfig_WithKeys(t *testing.T) {
 		ID:       "vk-with-keys",
 		Name:     "VK With Keys",
 		Value:    "vk-keys-value",
-		IsActive: true,
+		IsActive: schemas.Ptr(true),
 	}
 	err = store.CreateVirtualKey(ctx, vk)
 	require.NoError(t, err)
@@ -735,7 +735,7 @@ func TestCreateVirtualKeyProviderConfig_UnresolvedKeys(t *testing.T) {
 		ID:       "vk-unresolved",
 		Name:     "VK Unresolved",
 		Value:    "vk-unresolved-value",
-		IsActive: true,
+		IsActive: schemas.Ptr(true),
 	}
 	err := store.CreateVirtualKey(ctx, vk)
 	require.NoError(t, err)
@@ -777,7 +777,7 @@ func TestUpdateProvider_RemovesStaleVirtualKeyProviderConfigKeyAssociations(t *t
 		ID:       "vk-update-provider-cleanup",
 		Name:     "VK Update Provider Cleanup",
 		Value:    "vk-update-provider-cleanup-value",
-		IsActive: true,
+		IsActive: schemas.Ptr(true),
 	}
 	err = store.CreateVirtualKey(ctx, vk)
 	require.NoError(t, err)
@@ -826,7 +826,7 @@ func TestDeleteProvider_RemovesVirtualKeyProviderConfigs(t *testing.T) {
 		ID:       "vk-delete-provider-cleanup",
 		Name:     "VK Delete Provider Cleanup",
 		Value:    "vk-delete-provider-cleanup-value",
-		IsActive: true,
+		IsActive: schemas.Ptr(true),
 	}
 	err = store.CreateVirtualKey(ctx, vk)
 	require.NoError(t, err)
@@ -1105,7 +1105,7 @@ func TestFullVirtualKeyFlow(t *testing.T) {
 		ID:          integrationVKID,
 		Name:        "Integration Virtual Key",
 		Value:       "vk-integration-xyz",
-		IsActive:    true,
+		IsActive:    schemas.Ptr(true),
 		RateLimitID: &rateLimitID,
 	}
 	err = store.CreateVirtualKey(ctx, vk)

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -538,7 +538,7 @@ func TestTableOauthConfig_EmptySecret_NoError(t *testing.T) {
 
 	var found TableOauthConfig
 	require.NoError(t, db.First(&found, "id = ?", "oauth-cfg-empty").Error)
-	assert.Equal(t, "", found.ClientSecret)
+	assert.Equal(t, "", found.ClientSecret.GetValue())
 	assert.Equal(t, "", found.CodeVerifier)
 }
 

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -414,7 +414,7 @@ func TestTableVirtualKey_EncryptDecrypt(t *testing.T) {
 		ID:       "vk-1",
 		Name:     "test-vk",
 		Value:    "vk-secret-value-xyz",
-		IsActive: true,
+		IsActive: bifrost.Ptr(true),
 	}
 
 	require.NoError(t, db.Create(vk).Error)
@@ -440,7 +440,7 @@ func TestTableVirtualKey_HashComputedBeforeEncryption(t *testing.T) {
 		ID:       "vk-hash",
 		Name:     "hash-test",
 		Value:    "plaintext-value",
-		IsActive: true,
+		IsActive: bifrost.Ptr(true),
 	}
 
 	require.NoError(t, db.Create(vk).Error)
@@ -898,7 +898,7 @@ func TestTableVirtualKey_UpdatePreservesDecryption(t *testing.T) {
 		ID:       "vk-update",
 		Name:     "update-vk",
 		Value:    "original-vk-value",
-		IsActive: true,
+		IsActive: bifrost.Ptr(true),
 	}
 	require.NoError(t, db.Create(vk).Error)
 
@@ -1325,7 +1325,7 @@ func TestTableVirtualKey_EncryptionDisabled_StoresPlaintext(t *testing.T) {
 		ID:       "vk-dis-1",
 		Name:     "disabled-vk",
 		Value:    "vk-plaintext-value",
-		IsActive: true,
+		IsActive: bifrost.Ptr(true),
 	}
 
 	require.NoError(t, db.Create(vk).Error)

--- a/framework/configstore/tables/routing_rules.go
+++ b/framework/configstore/tables/routing_rules.go
@@ -15,7 +15,7 @@ type TableRoutingRule struct {
 	ConfigHash    string `gorm:"type:varchar(255)" json:"config_hash"` // Hash of config.json version, used for change detection
 	Name          string `gorm:"type:varchar(255);not null;uniqueIndex:idx_routing_rule_scope_name" json:"name"`
 	Description   string `gorm:"type:text" json:"description"`
-	Enabled       bool   `gorm:"not null;default:true" json:"enabled"`
+	Enabled       *bool  `gorm:"not null;default:true" json:"enabled,omitempty"` // nil = DB default (true); use EnabledValue() to read
 	CelExpression string `gorm:"type:text;not null" json:"cel_expression"`
 
 	// Routing Targets (output) — 1:many relationship; weights must sum to 1
@@ -44,6 +44,17 @@ type TableRoutingRule struct {
 
 // TableName for TableRoutingRule
 func (TableRoutingRule) TableName() string { return "routing_rules" }
+
+// EnabledValue returns the effective Enabled bool, treating nil as true (DB default).
+func (r *TableRoutingRule) EnabledValue() bool {
+	if r == nil {
+		return false
+	}
+	if r.Enabled == nil {
+		return true
+	}
+	return *r.Enabled
+}
 
 // BeforeSave hook for TableRoutingRule to serialize JSON fields
 func (r *TableRoutingRule) BeforeSave(tx *gorm.DB) error {
@@ -92,7 +103,7 @@ type TableRoutingTarget struct {
 	Provider        *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"provider,omitempty"` // nil = use incoming provider
 	Model           *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"model,omitempty"`    // nil = use incoming model
 	KeyID           *string `gorm:"type:varchar(255);uniqueIndex:idx_routing_target_config" json:"key_id,omitempty"`   // persisted key pin
-	ProviderKeyName *string `gorm:"-" json:"provider_key_name,omitempty"`                                               // config-only alias; resolved to key_id during load
+	ProviderKeyName *string `gorm:"-" json:"provider_key_name,omitempty"`                                              // config-only alias; resolved to key_id during load
 	Weight          float64 `gorm:"not null;default:1" json:"weight"`                                                  // must sum to 1 across all targets in a rule
 }
 

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -200,8 +200,8 @@ type TableVirtualKey struct {
 	ID              string                          `gorm:"primaryKey;type:varchar(255)" json:"id"`
 	Name            string                          `gorm:"uniqueIndex:idx_virtual_key_name;type:varchar(255);not null" json:"name"`
 	Description     string                          `gorm:"type:text" json:"description,omitempty"`
-	Value           string                          `gorm:"uniqueIndex:idx_virtual_key_value;type:text;not null" json:"value"` // The virtual key value
-	IsActive        bool                            `gorm:"default:true" json:"is_active"`
+	Value           string                          `gorm:"uniqueIndex:idx_virtual_key_value;type:text;not null" json:"value"`           // The virtual key value
+	IsActive        *bool                           `gorm:"default:true" json:"is_active,omitempty"`                                     // Nil means true (DB default); false means inactive
 	ProviderConfigs []TableVirtualKeyProviderConfig `gorm:"foreignKey:VirtualKeyID;constraint:OnDelete:CASCADE" json:"provider_configs"` // Empty means no providers allowed (deny-by-default)
 	MCPConfigs      []TableVirtualKeyMCPConfig      `gorm:"foreignKey:VirtualKeyID;constraint:OnDelete:CASCADE" json:"mcp_configs"`
 
@@ -235,6 +235,17 @@ type TableVirtualKey struct {
 
 // TableName sets the table name for each model
 func (TableVirtualKey) TableName() string { return "governance_virtual_keys" }
+
+// IsActiveValue returns the effective IsActive bool, treating nil as true (DB default).
+func (vk *TableVirtualKey) IsActiveValue() bool {
+	if vk == nil {
+		return false
+	}
+	if vk.IsActive == nil {
+		return true
+	}
+	return *vk.IsActive
+}
 
 // BeforeSave is a GORM hook that enforces mutual exclusion (team vs customer), computes
 // a SHA-256 hash of the plaintext value for indexed lookups, and encrypts the virtual key

--- a/framework/logstore/postgres.go
+++ b/framework/logstore/postgres.go
@@ -56,8 +56,15 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 	}
 	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s", config.Host.GetValue(), config.Port.GetValue(), config.User.GetValue(), config.Password.GetValue(), config.DBName.GetValue(), config.SSLMode.GetValue())
 
-	openPool := func() (*gorm.DB, error) {
-		return gorm.Open(postgres.New(postgres.Config{DSN: dsn}), &gorm.Config{
+	// Migration-only DSN. Forces pgx into simple-query protocol on the throwaway
+	// migration pool so no statement plan is ever cached server-side; that makes
+	// SQLSTATE 0A000 ("cached plan must not change result type") structurally
+	// impossible when a migration mixes DDL with subsequent SELECTs against the
+	// same table. Runtime pool keeps the default cache-statement mode.
+	migrationDSN := dsn + " default_query_exec_mode=simple_protocol"
+
+	openPool := func(connDSN string) (*gorm.DB, error) {
+		return gorm.Open(postgres.New(postgres.Config{DSN: connDSN}), &gorm.Config{
 			Logger: newGormLogger(logger),
 		})
 	}
@@ -78,7 +85,7 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 
 	// Throwaway pool for the version gate and schema migrations. Closing it
 	// before the runtime pool opens guarantees no cached plan survives DDL.
-	mDb, err := openPool()
+	mDb, err := openPool(migrationDSN)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +111,7 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 	}
 
 	// Runtime pool. Opens against post-migration schema.
-	db, err := openPool()
+	db, err := openPool(dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/governance/httptransportprehook_test.go
+++ b/plugins/governance/httptransportprehook_test.go
@@ -74,7 +74,7 @@ func TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget(t *testing.T) {
 	routingRule := configstoreTables.TableRoutingRule{
 		ID:            "rule-genai-1",
 		Name:          "genai-repro-rule",
-		Enabled:       true,
+		Enabled:       bifrost.Ptr(true),
 		CelExpression: `model == "probe-genai-model" && provider == ""`,
 		Targets: []configstoreTables.TableRoutingTarget{
 			{
@@ -141,7 +141,7 @@ func TestHTTPTransportPreHook_GenAIRoutingRulePreservesTarget_WithStore(t *testi
 	routingRule := configstoreTables.TableRoutingRule{
 		ID:            "rule-genai-ws-1",
 		Name:          "genai-repro-rule-with-store",
-		Enabled:       true,
+		Enabled:       bifrost.Ptr(true),
 		CelExpression: `model == "probe-genai-model" && provider == ""`,
 		Targets: []configstoreTables.TableRoutingTarget{
 			{
@@ -264,7 +264,7 @@ func TestHTTPTransportPreHook_BedrockRoutingRulePreservesTarget(t *testing.T) {
 	routingRule := configstoreTables.TableRoutingRule{
 		ID:            "rule-bedrock-1",
 		Name:          "bedrock-repro-rule",
-		Enabled:       true,
+		Enabled:       bifrost.Ptr(true),
 		CelExpression: `model == "probe-bedrock-model" && provider == ""`,
 		Targets: []configstoreTables.TableRoutingTarget{
 			{

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -403,7 +403,7 @@ func (p *GovernancePlugin) HTTPTransportPreHook(ctx *schemas.BifrostContext, req
 	// Process virtual key if provided
 	if virtualKeyValue != nil {
 		virtualKey, ok = p.store.GetVirtualKey(ctx, *virtualKeyValue)
-		if !ok || virtualKey == nil || !virtualKey.IsActive {
+		if !ok || virtualKey == nil || !virtualKey.IsActiveValue() {
 			return nil, nil
 		}
 	}
@@ -501,7 +501,7 @@ func (p *GovernancePlugin) governLargePayload(ctx *schemas.BifrostContext, req *
 	var virtualKey *configstoreTables.TableVirtualKey
 	if virtualKeyValue != nil {
 		vk, ok := p.store.GetVirtualKey(ctx, *virtualKeyValue)
-		if !ok || vk == nil || !vk.IsActive {
+		if !ok || vk == nil || !vk.IsActiveValue() {
 			return nil, nil
 		}
 		virtualKey = vk
@@ -1455,7 +1455,7 @@ func (p *GovernancePlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.
 	// This runs independently of EvaluateGovernanceRequest to enforce execution-time allow-list.
 	if virtualKeyValue != "" {
 		vk, ok := p.store.GetVirtualKey(ctx, virtualKeyValue)
-		if !ok || vk == nil || !vk.IsActive {
+		if !ok || vk == nil || !vk.IsActiveValue() {
 			// VK became invalid after initial check - fail closed for security
 			ctx.SetValue(governanceRejectedContextKey, true)
 			return req, &schemas.MCPPluginShortCircuit{Error: &schemas.BifrostError{

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -258,7 +258,7 @@ func (r *BudgetResolver) EvaluateVirtualKeyRequest(ctx *schemas.BifrostContext, 
 		ctx.SetValue(schemas.BifrostContextKeyGovernanceCustomerID, vk.Customer.ID)
 		ctx.SetValue(schemas.BifrostContextKeyGovernanceCustomerName, vk.Customer.Name)
 	}
-	if !vk.IsActive {
+	if !vk.IsActiveValue() {
 		return &EvaluationResult{
 			Decision: DecisionVirtualKeyBlocked,
 			Reason:   "Virtual key is inactive",

--- a/plugins/governance/routing_test.go
+++ b/plugins/governance/routing_test.go
@@ -240,7 +240,7 @@ func TestEvaluateRoutingRules_GlobalRuleMatches(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
 		},
-		Enabled:  true,
+		Enabled:  bifrost.Ptr(true),
 		Scope:    "global",
 		Priority: 0,
 	}
@@ -308,7 +308,7 @@ func TestEvaluateRoutingRules_MultiTargetDeterministicWithPinnedKey(t *testing.T
 				Weight:   0.0,
 			},
 		},
-		Enabled:  true,
+		Enabled:  bifrost.Ptr(true),
 		Scope:    "global",
 		Priority: 0,
 	}
@@ -360,7 +360,7 @@ func TestEvaluateRoutingRules_ScopePrecedence(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4o"), Weight: 1.0},
 		},
-		Enabled:  true,
+		Enabled:  bifrost.Ptr(true),
 		Scope:    "global",
 		Priority: 0,
 	}
@@ -374,7 +374,7 @@ func TestEvaluateRoutingRules_ScopePrecedence(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
 		},
-		Enabled:  true,
+		Enabled:  bifrost.Ptr(true),
 		Scope:    "virtual_key",
 		ScopeID:  bifrost.Ptr("vk-123"),
 		Priority: 10,
@@ -424,7 +424,7 @@ func TestEvaluateRoutingRules_PriorityOrdering(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4o"), Weight: 1.0},
 		},
-		Enabled:  true,
+		Enabled:  bifrost.Ptr(true),
 		Scope:    "global",
 		Priority: 10,
 	}
@@ -438,7 +438,7 @@ func TestEvaluateRoutingRules_PriorityOrdering(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
 		},
-		Enabled:  true,
+		Enabled:  bifrost.Ptr(true),
 		Scope:    "global",
 		Priority: 0,
 	}
@@ -473,7 +473,7 @@ func TestResolveRoutingWithFallback_RuleMatches(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
 		},
-		Enabled:  true,
+		Enabled:  bifrost.Ptr(true),
 		Scope:    "global",
 		Priority: 0,
 	}
@@ -539,7 +539,7 @@ func TestEvaluateRoutingRules_DisabledRulesIgnored(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
 		},
-		Enabled:  false,
+		Enabled:  bifrost.Ptr(false),
 		Scope:    "global",
 		Priority: 10,
 	}
@@ -553,7 +553,7 @@ func TestEvaluateRoutingRules_DisabledRulesIgnored(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4o"), Weight: 1.0},
 		},
-		Enabled:  true,
+		Enabled:  bifrost.Ptr(true),
 		Scope:    "global",
 		Priority: 0,
 	}
@@ -590,7 +590,7 @@ func TestEvaluateRoutingRules_ComplexExpression(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
 		},
-		Enabled:  true,
+		Enabled:  bifrost.Ptr(true),
 		Scope:    "global",
 		Priority: 0,
 	}
@@ -634,7 +634,7 @@ func TestEvaluateRoutingRules_NilVirtualKey(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
 		},
-		Enabled:  true,
+		Enabled:  bifrost.Ptr(true),
 		Scope:    "global",
 		Priority: 0,
 	}
@@ -671,7 +671,7 @@ func TestEvaluateRoutingRules_MissingHeaderGracefully(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
 		},
-		Enabled:  true,
+		Enabled:  bifrost.Ptr(true),
 		Scope:    "global",
 		Priority: 0,
 	}
@@ -716,7 +716,7 @@ func TestEvaluateRoutingRules_ChainRuleReEvaluation(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
 		},
-		Enabled:   true,
+		Enabled:   bifrost.Ptr(true),
 		Scope:     "global",
 		Priority:  0,
 		ChainRule: true,
@@ -731,7 +731,7 @@ func TestEvaluateRoutingRules_ChainRuleReEvaluation(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4"), Weight: 1.0},
 		},
-		Enabled:   true,
+		Enabled:   bifrost.Ptr(true),
 		Scope:     "global",
 		Priority:  1,
 		ChainRule: false,
@@ -774,7 +774,7 @@ func TestEvaluateRoutingRules_TerminalRuleStopsChain(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
 		},
-		Enabled:   true,
+		Enabled:   bifrost.Ptr(true),
 		Scope:     "global",
 		Priority:  0,
 		ChainRule: false,
@@ -789,7 +789,7 @@ func TestEvaluateRoutingRules_TerminalRuleStopsChain(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4"), Weight: 1.0},
 		},
-		Enabled:   true,
+		Enabled:   bifrost.Ptr(true),
 		Scope:     "global",
 		Priority:  1,
 		ChainRule: false,
@@ -832,7 +832,7 @@ func TestEvaluateRoutingRules_SelfLoopContinuesToNextRule(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4o"), Weight: 1.0},
 		},
-		Enabled:   true,
+		Enabled:   bifrost.Ptr(true),
 		Scope:     "global",
 		Priority:  0,
 		ChainRule: true,
@@ -847,7 +847,7 @@ func TestEvaluateRoutingRules_SelfLoopContinuesToNextRule(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("anthropic"), Model: bifrost.Ptr("claude-3"), Weight: 1.0},
 		},
-		Enabled:   true,
+		Enabled:   bifrost.Ptr(true),
 		Scope:     "global",
 		Priority:  1,
 		ChainRule: false,
@@ -888,7 +888,7 @@ func TestEvaluateRoutingRules_SelfLoopAloneTerminates(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4o"), Weight: 1.0},
 		},
-		Enabled:   true,
+		Enabled:   bifrost.Ptr(true),
 		Scope:     "global",
 		Priority:  0,
 		ChainRule: true,
@@ -931,7 +931,7 @@ func TestEvaluateRoutingRules_MaxDepthCutoff(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4-turbo"), Weight: 1.0},
 		},
-		Enabled:   true,
+		Enabled:   bifrost.Ptr(true),
 		Scope:     "global",
 		Priority:  0,
 		ChainRule: true,
@@ -946,7 +946,7 @@ func TestEvaluateRoutingRules_MaxDepthCutoff(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("azure"), Model: bifrost.Ptr("gpt-4"), Weight: 1.0},
 		},
-		Enabled:   true,
+		Enabled:   bifrost.Ptr(true),
 		Scope:     "global",
 		Priority:  1,
 		ChainRule: true,
@@ -961,7 +961,7 @@ func TestEvaluateRoutingRules_MaxDepthCutoff(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("anthropic"), Model: bifrost.Ptr("claude-3"), Weight: 1.0},
 		},
-		Enabled:   true,
+		Enabled:   bifrost.Ptr(true),
 		Scope:     "global",
 		Priority:  2,
 		ChainRule: false,
@@ -1002,7 +1002,7 @@ func TestCompileAndCacheProgram_ValidExpression_Routing(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)
@@ -1029,7 +1029,7 @@ func TestCompileAndCacheProgram_EmptyExpression_Routing(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)
@@ -1051,7 +1051,7 @@ func TestCompileAndCacheProgram_InvalidExpression_Routing(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	_, err = store.GetRoutingProgram(context.Background(), rule)
@@ -1084,7 +1084,7 @@ func TestCompileAndCacheProgram_ListExpression(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)
@@ -1106,7 +1106,7 @@ func TestCompileAndCacheProgram_RegexExpression(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)
@@ -1128,7 +1128,7 @@ func TestCompileAndCacheProgram_HeaderExpression(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)
@@ -1150,7 +1150,7 @@ func TestCompileAndCacheProgram_RateLimitExpression(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)
@@ -1172,7 +1172,7 @@ func TestCompileAndCacheProgram_BudgetExpression(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)
@@ -1194,7 +1194,7 @@ func TestCompileAndCacheProgram_ComplexExpression(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)
@@ -1249,7 +1249,7 @@ func TestEvaluateCELExpression_TrueResult(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)
@@ -1280,7 +1280,7 @@ func TestEvaluateCELExpression_FalseResult(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)
@@ -1311,7 +1311,7 @@ func TestEvaluateCELExpression_ListMembership(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)
@@ -1349,7 +1349,7 @@ func TestEvaluateCELExpression_HeaderAccess(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Weight: 1.0},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -3081,7 +3081,7 @@ func (gs *LocalGovernanceStore) GetScopedRoutingRules(ctx context.Context, scope
 	// Filter by enabled and return
 	var enabledRules []*configstoreTables.TableRoutingRule
 	for _, rule := range rulesList {
-		if rule.Enabled {
+		if rule.EnabledValue() {
 			enabledRules = append(enabledRules, rule)
 		}
 	}

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -738,7 +738,7 @@ func TestGovernanceStore_RoutingRules_CreateAndRetrieve(t *testing.T) {
 		ID:            "1",
 		Name:          "Global Rule",
 		Description:   "Test global routing rule",
-		Enabled:       true,
+		Enabled:       bifrost.Ptr(true),
 		CelExpression: "model == 'gpt-4o'",
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai"), Model: bifrost.Ptr("gpt-4"), Weight: 1.0},
@@ -758,7 +758,7 @@ func TestGovernanceStore_RoutingRules_CreateAndRetrieve(t *testing.T) {
 		ID:            "2",
 		Name:          "Team Rule",
 		Description:   "Test team routing rule",
-		Enabled:       true,
+		Enabled:       bifrost.Ptr(true),
 		CelExpression: "model in ['gpt-4o', 'gpt-4-turbo']",
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("azure"), Weight: 1.0},
@@ -806,7 +806,7 @@ func TestGovernanceStore_RoutingRules_PriorityOrdering(t *testing.T) {
 			Priority: 5,
 			Scope:    "global",
 			ScopeID:  nil,
-			Enabled:  true,
+			Enabled:  bifrost.Ptr(true),
 		},
 		{
 			ID:       "2",
@@ -814,7 +814,7 @@ func TestGovernanceStore_RoutingRules_PriorityOrdering(t *testing.T) {
 			Priority: 20,
 			Scope:    "global",
 			ScopeID:  nil,
-			Enabled:  true,
+			Enabled:  bifrost.Ptr(true),
 		},
 		{
 			ID:       "3",
@@ -822,7 +822,7 @@ func TestGovernanceStore_RoutingRules_PriorityOrdering(t *testing.T) {
 			Priority: 10,
 			Scope:    "global",
 			ScopeID:  nil,
-			Enabled:  true,
+			Enabled:  bifrost.Ptr(true),
 		},
 	}
 
@@ -848,7 +848,7 @@ func TestGovernanceStore_RoutingRules_DisabledRulesFiltered(t *testing.T) {
 	enabledRule := &configstoreTables.TableRoutingRule{
 		ID:      "1",
 		Name:    "Enabled Rule",
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 		Scope:   "global",
 		ScopeID: nil,
 	}
@@ -856,7 +856,7 @@ func TestGovernanceStore_RoutingRules_DisabledRulesFiltered(t *testing.T) {
 	disabledRule := &configstoreTables.TableRoutingRule{
 		ID:      "2",
 		Name:    "Disabled Rule",
-		Enabled: false,
+		Enabled: bifrost.Ptr(false),
 		Scope:   "global",
 		ScopeID: nil,
 	}
@@ -881,7 +881,7 @@ func TestGovernanceStore_RoutingRules_DeleteRule(t *testing.T) {
 	rule := &configstoreTables.TableRoutingRule{
 		ID:      "1",
 		Name:    "Test Rule",
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 		Scope:   "global",
 		ScopeID: nil,
 	}
@@ -985,13 +985,13 @@ func TestGovernanceStore_RoutingRules_MultipleScopes(t *testing.T) {
 
 	// Create rules for different scopes
 	globalRule := &configstoreTables.TableRoutingRule{
-		ID: "1", Name: "Global", Scope: "global", ScopeID: nil, Priority: 10, Enabled: true,
+		ID: "1", Name: "Global", Scope: "global", ScopeID: nil, Priority: 10, Enabled: bifrost.Ptr(true),
 	}
 	customerRule := &configstoreTables.TableRoutingRule{
-		ID: "2", Name: "Customer", Scope: "customer", ScopeID: &customerID, Priority: 20, Enabled: true,
+		ID: "2", Name: "Customer", Scope: "customer", ScopeID: &customerID, Priority: 20, Enabled: bifrost.Ptr(true),
 	}
 	teamRule := &configstoreTables.TableRoutingRule{
-		ID: "3", Name: "Team", Scope: "team", ScopeID: &teamID, Priority: 30, Enabled: true,
+		ID: "3", Name: "Team", Scope: "team", ScopeID: &teamID, Priority: 30, Enabled: bifrost.Ptr(true),
 	}
 
 	require.NoError(t, store.UpdateRoutingRuleInMemory(context.Background(), globalRule))
@@ -1034,7 +1034,7 @@ func TestCompileAndCacheProgram(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai")},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	// First compilation
@@ -1064,7 +1064,7 @@ func TestCompileAndCacheProgram_InvalidExpression(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai")},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	_, err = store.GetRoutingProgram(context.Background(), rule)
@@ -1088,7 +1088,7 @@ func TestCompileAndCacheProgram_CacheInvalidation(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai")},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 		Scope:   "global",
 	}
 
@@ -1121,7 +1121,7 @@ func TestCompileAndCacheProgram_CacheInvalidationOnDelete(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai")},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 		Scope:   "global",
 	}
 
@@ -1149,7 +1149,7 @@ func TestCompileAndCacheProgram_EmptyExpression(t *testing.T) {
 		Targets: []configstoreTables.TableRoutingTarget{
 			{Provider: bifrost.Ptr("openai")},
 		},
-		Enabled: true,
+		Enabled: bifrost.Ptr(true),
 	}
 
 	program, err := store.GetRoutingProgram(context.Background(), rule)

--- a/plugins/governance/test_utils.go
+++ b/plugins/governance/test_utils.go
@@ -82,7 +82,7 @@ func buildVirtualKey(id, value, name string, isActive bool) *configstoreTables.T
 		ID:       id,
 		Value:    value,
 		Name:     name,
-		IsActive: isActive,
+		IsActive: &isActive,
 	}
 }
 

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/fasthttp/router"
 	"github.com/google/uuid"
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -472,10 +473,10 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 			seenDurations[b.ResetDuration] = true
 		}
 	}
-	// Set defaults
-	isActive := true
-	if req.IsActive != nil {
-		isActive = *req.IsActive
+	// Set defaults: nil means "use DB default (true)"
+	isActive := req.IsActive
+	if isActive == nil {
+		isActive = bifrost.Ptr(true)
 	}
 	// Fetch providers from DB to ensure up-to-date data in cluster mode.
 	providerSet := map[schemas.ModelProvider]struct{}{}
@@ -771,7 +772,7 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 			vk.CustomerID = nil
 		}
 		if req.IsActive != nil {
-			vk.IsActive = *req.IsActive
+			vk.IsActive = req.IsActive
 		}
 		if req.CalendarAligned != nil {
 			vk.CalendarAligned = *req.CalendarAligned
@@ -3219,9 +3220,9 @@ func (h *GovernanceHandler) createRoutingRule(ctx *fasthttp.RequestCtx) {
 
 	// Create routing rule
 	// Handle Enabled/ChainRule: nil means use DB default (true/false), otherwise use provided value
-	enabled := true // DB default
-	if req.Enabled != nil {
-		enabled = *req.Enabled
+	enabled := req.Enabled
+	if enabled == nil {
+		enabled = bifrost.Ptr(true)
 	}
 	chainRule := false // DB default
 	if req.ChainRule != nil {
@@ -3290,7 +3291,7 @@ func (h *GovernanceHandler) updateRoutingRule(ctx *fasthttp.RequestCtx) {
 		rule.Description = *req.Description
 	}
 	if req.Enabled != nil {
-		rule.Enabled = *req.Enabled
+		rule.Enabled = req.Enabled
 	}
 	if req.ChainRule != nil {
 		rule.ChainRule = *req.ChainRule
@@ -3866,7 +3867,7 @@ func (h *GovernanceHandler) getVirtualKeyQuota(ctx *fasthttp.RequestCtx) {
 
 	SendJSON(ctx, map[string]interface{}{
 		"virtual_key_name": vk.Name,
-		"is_active":        vk.IsActive,
+		"is_active":        vk.IsActiveValue(),
 		"budgets":          vk.Budgets,
 		"rate_limit":       vk.RateLimit,
 	})

--- a/transports/bifrost-http/handlers/oauth2_consent.go
+++ b/transports/bifrost-http/handlers/oauth2_consent.go
@@ -348,7 +348,7 @@ func (h *ConsentHandler) handleSubmitVK(ctx *fasthttp.RequestCtx) {
 		redirectToIdentityPage(ctx, flowID, "Failed to validate Virtual Key. Please try again.")
 		return
 	}
-	if vk == nil || !vk.IsActive {
+	if vk == nil || !vk.IsActiveValue() {
 		redirectToIdentityPage(ctx, flowID, "Virtual Key not found or inactive. Please check and try again.")
 		return
 	}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3352,7 +3352,7 @@ func (c *Config) GetPerUserOAuthMCPClients() map[string]string {
 	}
 	result := make(map[string]string)
 	for _, client := range c.MCPConfig.ClientConfigs {
-		if client != nil && client.AuthType == schemas.MCPAuthTypePerUserOauth {
+		if client != nil && client.AuthType == schemas.MCPAuthTypePerUserOauth && !client.Disabled {
 			result[client.ID] = client.Name
 		}
 	}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1637,7 +1637,7 @@ func makeVirtualKey(id, name, value string) tables.TableVirtualKey {
 		Name:        name,
 		Description: "Test virtual key",
 		Value:       value,
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 	}
 }
 
@@ -1648,7 +1648,7 @@ func makeVirtualKeyWithTeam(id, name, value, teamID string) tables.TableVirtualK
 		Name:        name,
 		Description: "Test virtual key with team",
 		Value:       value,
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 }
@@ -1660,7 +1660,7 @@ func makeVirtualKeyWithCustomer(id, name, value, customerID string) tables.Table
 		Name:        name,
 		Description: "Test virtual key with customer",
 		Value:       value,
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		CustomerID:  &customerID,
 	}
 }
@@ -1672,7 +1672,7 @@ func makeVirtualKeyWithProviderConfigs(id, name, value string, providerConfigs [
 		Name:            name,
 		Description:     "Test virtual key with provider configs",
 		Value:           value,
-		IsActive:        true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: providerConfigs,
 	}
 }
@@ -6612,7 +6612,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6632,7 +6632,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6651,7 +6651,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "different-name", // Different name
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6670,7 +6670,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_different", // Different value
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6689,7 +6689,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    false, // Different IsActive
+		IsActive: schemas.Ptr(false), // Different IsActive
 		TeamID:      &teamID,
 	}
 
@@ -6709,7 +6709,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &differentTeamID, // Different TeamID
 	}
 
@@ -6728,7 +6728,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Different description", // Different description
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6748,7 +6748,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 		CustomerID:  &customerID, // CustomerID set
 	}
@@ -6769,7 +6769,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 		CustomerID:  &differentCustomerID, // Different CustomerID
 	}
@@ -6790,7 +6790,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &rateLimitID, // RateLimitID set
 	}
@@ -6811,7 +6811,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &differentRateLimitID, // Different RateLimitID
 	}
@@ -6838,7 +6838,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -6870,7 +6870,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -6898,7 +6898,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -6933,7 +6933,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -6959,7 +6959,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -6985,7 +6985,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -7016,7 +7016,7 @@ func TestVirtualKeyHashComparison_MatchingHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7033,7 +7033,7 @@ func TestVirtualKeyHashComparison_MatchingHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &dbTeamID,
 		ConfigHash:  fileHash, // Same hash as file
 	}
@@ -7066,7 +7066,7 @@ func TestVirtualKeyHashComparison_DifferentHash(t *testing.T) {
 		Name:        "old-name", // Old name
 		Description: "Old description",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7083,7 +7083,7 @@ func TestVirtualKeyHashComparison_DifferentHash(t *testing.T) {
 		Name:        "new-name", // Updated name
 		Description: "New description",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &fileTeamID,
 	}
 
@@ -7114,7 +7114,7 @@ func TestVirtualKeyHashComparison_VirtualKeyOnlyInDB(t *testing.T) {
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
 		Value:       "vk_dashboard123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		CustomerID:  &customerID,
 		RateLimitID: &rateLimitID,
 	}
@@ -7132,7 +7132,7 @@ func TestVirtualKeyHashComparison_VirtualKeyOnlyInDB(t *testing.T) {
 			Name:        "file-vk",
 			Description: "From config.json",
 			Value:       "vk_file123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 		},
 	}
 
@@ -7162,7 +7162,7 @@ func TestVirtualKeyHashComparison_NewVirtualKey(t *testing.T) {
 		Name:        "new-vk",
 		Description: "New virtual key from config.json",
 		Value:       "vk_new123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7204,7 +7204,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Name:        "test-vk",
 		Description: "",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 	}
 
 	hashNoOptional, err := configstore.GenerateVirtualKeyHash(vkNoOptional)
@@ -7219,7 +7219,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Name:        "test-vk",
 		Description: "",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7239,7 +7239,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Name:        "test-vk",
 		Description: "",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		CustomerID:  &customerID,
 	}
 
@@ -7263,7 +7263,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Name:        "test-vk",
 		Description: "",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		RateLimitID: &rateLimitID,
 	}
 
@@ -7289,7 +7289,7 @@ func TestVirtualKeyHashComparison_FieldValueChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Base description",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7313,7 +7313,7 @@ func TestVirtualKeyHashComparison_FieldValueChanges(t *testing.T) {
 
 	// Change IsActive
 	vkChangedActive := baseVK
-	vkChangedActive.IsActive = false
+	vkChangedActive.IsActive = schemas.Ptr(false)
 
 	hashChangedActive, err := configstore.GenerateVirtualKeyHash(vkChangedActive)
 	if err != nil {
@@ -7352,7 +7352,7 @@ func TestVirtualKeyHashComparison_RoundTrip(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &rateLimitID,
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
@@ -7382,7 +7382,7 @@ func TestVirtualKeyHashComparison_RoundTrip(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		TeamID:      &reloadTeamID,
 		RateLimitID: &reloadRateLimitID,
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
@@ -8069,7 +8069,7 @@ func TestSQLite_VirtualKey_HashMismatch_FileSync(t *testing.T) {
 			Name:        "modified-name",
 			Description: "Modified description",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 		},
 	}
 	configData2 := makeConfigDataWithVirtualKeysAndDir(providers, vks2, tempDir)
@@ -8122,7 +8122,7 @@ func TestSQLite_VirtualKey_DBOnlyVK_Preserved(t *testing.T) {
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
 		Value:       "vk_dashboard456",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 	}
 	dashboardHash, _ := configstore.GenerateVirtualKeyHash(dashboardVK)
 	dashboardVK.ConfigHash = dashboardHash
@@ -8171,7 +8171,7 @@ func TestSQLite_VirtualKey_WithProviderConfigs(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK with provider configs",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8209,7 +8209,7 @@ func TestSQLite_VirtualKey_WithProviderConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "VK with provider configs",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8264,7 +8264,7 @@ func TestSQLite_VirtualKey_MergePath_WithProviderConfigs(t *testing.T) {
 			Name:        "vk-with-providers",
 			Description: "VK with provider configs added via merge",
 			Value:       "vk_providers456",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8377,7 +8377,7 @@ func TestSQLite_VirtualKey_MergePath_WithProviderConfigKeys(t *testing.T) {
 			Name:        "vk-with-provider-keys",
 			Description: "VK with provider configs referencing keys",
 			Value:       "vk_keys456",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8435,7 +8435,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8452,7 +8452,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8484,7 +8484,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8525,7 +8525,7 @@ func TestSQLite_VKProviderConfig_NewConfig(t *testing.T) {
 			Name:        "vk-with-provider-config",
 			Description: "VK with provider configs",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8596,7 +8596,7 @@ func TestSQLite_VKProviderConfig_KeyReference(t *testing.T) {
 			Name:        "vk-with-provider-ref",
 			Description: "VK with provider config",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8648,7 +8648,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8666,7 +8666,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8698,7 +8698,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8731,7 +8731,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8747,7 +8747,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8763,7 +8763,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8806,7 +8806,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8894,7 +8894,7 @@ func TestSQLite_FullLifecycle_InitialLoad(t *testing.T) {
 				Name:        "test-vk-1",
 				Description: "Test virtual key 1",
 				Value:       "vk_test123",
-				IsActive:    true,
+				IsActive: schemas.Ptr(true),
 				RateLimitID: &rateLimitID,
 				ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 					{
@@ -8909,7 +8909,7 @@ func TestSQLite_FullLifecycle_InitialLoad(t *testing.T) {
 				Name:        "test-vk-2",
 				Description: "Test virtual key 2",
 				Value:       "vk_test456",
-				IsActive:    true,
+				IsActive: schemas.Ptr(true),
 			},
 		},
 	}
@@ -9149,7 +9149,7 @@ func TestSQLite_FullLifecycle_DashboardEdits_ThenFileUnchanged(t *testing.T) {
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
 		Value:       "vk_dashboard456",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 	}
 	dashboardHash, _ := configstore.GenerateVirtualKeyHash(dashboardVK)
 	dashboardVK.ConfigHash = dashboardHash
@@ -9212,7 +9212,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 	}
 
 	// VK with one MCP config
@@ -9221,7 +9221,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    1,
@@ -9236,7 +9236,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    2, // Different client
@@ -9251,7 +9251,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    1,
@@ -9266,7 +9266,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    1,
@@ -9330,7 +9330,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    1,
@@ -9371,7 +9371,7 @@ func TestSQLite_VirtualKey_WithMCPConfigs(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK with MCP config",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 		},
 	}
 
@@ -9460,7 +9460,7 @@ func TestSQLite_VKMCPConfig_Reconciliation(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for MCP reconciliation test",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 		},
 	}
 
@@ -9531,7 +9531,7 @@ func TestSQLite_VKMCPConfig_Reconciliation(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for MCP reconciliation test",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{
 					MCPClientID:    mcpClient2.ID, // Different MCP client - will be created
@@ -9627,7 +9627,7 @@ func TestSQLite_VirtualKey_DashboardProviderConfig_DeletedOnFileChange(t *testin
 			Name:        "test-vk",
 			Description: "VK for dashboard provider config preservation test",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -9691,7 +9691,7 @@ func TestSQLite_VirtualKey_DashboardProviderConfig_DeletedOnFileChange(t *testin
 			Name:        "test-vk",
 			Description: "VK for dashboard provider config preservation test",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -9782,7 +9782,7 @@ func TestSQLite_VirtualKey_DashboardMCPConfig_DeletedOnFileChange(t *testing.T) 
 			Name:        "test-vk",
 			Description: "VK for dashboard MCP config preservation test",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 		},
 	}
 
@@ -9867,7 +9867,7 @@ func TestSQLite_VirtualKey_DashboardMCPConfig_DeletedOnFileChange(t *testing.T) 
 			Name:        "test-vk",
 			Description: "VK for dashboard MCP config preservation test",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{
 					MCPClientID:    mcpClient1.ID,
@@ -9952,7 +9952,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 		},
 	}
 
@@ -9988,7 +9988,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient1.ID, ToolsToExecute: []string{"tool1"}},
 				{MCPClientID: mcpClient2.ID, ToolsToExecute: []string{"tool2"}},
@@ -10020,7 +10020,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient1.ID, ToolsToExecute: []string{"tool1"}},
 				// mcpClient2 removed from file
@@ -10097,7 +10097,7 @@ func TestSQLite_VKMCPConfig_UpdateTools(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{MCPClientID: mcpClient.ID, ToolsToExecute: []string{"tool1", "tool2"}},
 		},
@@ -10122,7 +10122,7 @@ func TestSQLite_VKMCPConfig_UpdateTools(t *testing.T) {
 			Name:        "test-vk",
 			Description: "Test",
 			Value:       "vk_test123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient.ID, ToolsToExecute: []string{"tool3", "tool4", "tool5"}}, // Different tools
 			},
@@ -10194,7 +10194,7 @@ func TestSQLite_VK_ProviderAndMCPConfigs_Combined(t *testing.T) {
 			Name:        "combined-vk",
 			Description: "VK with both provider and MCP configs",
 			Value:       "vk_combined123",
-			IsActive:    true,
+			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -10615,7 +10615,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10647,7 +10647,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            3,
@@ -10679,7 +10679,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            2,
@@ -10739,7 +10739,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10757,7 +10757,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10775,7 +10775,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10821,7 +10821,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10844,7 +10844,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10867,7 +10867,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10918,7 +10918,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -10947,7 +10947,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             3,
@@ -10976,7 +10976,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             2,
@@ -11033,7 +11033,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -11050,7 +11050,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -11067,7 +11067,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -11112,7 +11112,7 @@ func TestGenerateVirtualKeyHash_StableCombinedOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -11154,7 +11154,7 @@ func TestGenerateVirtualKeyHash_StableCombinedOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive:    true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            2,
@@ -12991,7 +12991,7 @@ func TestUpdateGovernanceConfigInStore_RejectsSharedGovernanceIDs(t *testing.T) 
 			ID:       "vk-rl-owner",
 			Name:     "vk-rl-owner",
 			Value:    "vk-rl-owner-value",
-			IsActive: true,
+			IsActive: schemas.Ptr(true),
 		}))
 		require.NoError(t, cfg.ConfigStore.CreateVirtualKeyProviderConfig(ctx, &tables.TableVirtualKeyProviderConfig{
 			VirtualKeyID:  "vk-rl-owner",
@@ -14123,7 +14123,7 @@ func TestVKProviderConfig_WeightZeroPreserved(t *testing.T) {
 		ID:       "vk-zero-weight",
 		Name:     "test-vk",
 		Value:    "vk_test123",
-		IsActive: true,
+		IsActive: schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -14181,7 +14181,7 @@ func TestSQLite_VKProviderConfig_WeightZero_RoundTrip(t *testing.T) {
 			ID:       "vk-zero-weight",
 			Name:     "test-vk",
 			Value:    "vk_abc123",
-			IsActive: true,
+			IsActive: schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -14624,7 +14624,7 @@ func TestGenerateVirtualKeyHash_ProviderConfigRateLimit(t *testing.T) {
 			vk1: tables.TableVirtualKey{
 				ID:       "vk-1",
 				Name:     "test-vk",
-				IsActive: true,
+				IsActive: schemas.Ptr(true),
 				ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 					{
 						Provider:    "openai",
@@ -14636,7 +14636,7 @@ func TestGenerateVirtualKeyHash_ProviderConfigRateLimit(t *testing.T) {
 			vk2: tables.TableVirtualKey{
 				ID:       "vk-1",
 				Name:     "test-vk",
-				IsActive: true,
+				IsActive: schemas.Ptr(true),
 				ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 					{
 						Provider:    "openai",
@@ -14652,7 +14652,7 @@ func TestGenerateVirtualKeyHash_ProviderConfigRateLimit(t *testing.T) {
 			vk1: tables.TableVirtualKey{
 				ID:       "vk-1",
 				Name:     "test-vk",
-				IsActive: true,
+				IsActive: schemas.Ptr(true),
 				ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 					{
 						Provider:    "openai",
@@ -14664,7 +14664,7 @@ func TestGenerateVirtualKeyHash_ProviderConfigRateLimit(t *testing.T) {
 			vk2: tables.TableVirtualKey{
 				ID:       "vk-1",
 				Name:     "test-vk",
-				IsActive: true,
+				IsActive: schemas.Ptr(true),
 				ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 					{
 						Provider:    "openai",
@@ -14680,7 +14680,7 @@ func TestGenerateVirtualKeyHash_ProviderConfigRateLimit(t *testing.T) {
 			vk1: tables.TableVirtualKey{
 				ID:       "vk-1",
 				Name:     "test-vk",
-				IsActive: true,
+				IsActive: schemas.Ptr(true),
 				ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 					{
 						Provider:    "openai",
@@ -14692,7 +14692,7 @@ func TestGenerateVirtualKeyHash_ProviderConfigRateLimit(t *testing.T) {
 			vk2: tables.TableVirtualKey{
 				ID:       "vk-1",
 				Name:     "test-vk",
-				IsActive: true,
+				IsActive: schemas.Ptr(true),
 				ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 					{
 						Provider:    "openai",
@@ -17069,11 +17069,11 @@ func TestSQLite_GetVirtualKeysPaginated(t *testing.T) {
 	}
 
 	vks := []tables.TableVirtualKey{
-		{ID: "vk-1", Name: "alpha-key", Value: "val-1", IsActive: true, TeamID: &team1},
-		{ID: "vk-2", Name: "beta-key", Value: "val-2", IsActive: true, TeamID: &team2},
-		{ID: "vk-3", Name: "alpha-test", Value: "val-3", IsActive: true, CustomerID: &cust1},
-		{ID: "vk-4", Name: "gamma-key", Value: "val-4", IsActive: true, CustomerID: &cust2},
-		{ID: "vk-5", Name: "delta-key", Value: "val-5", IsActive: true, TeamID: &team1},
+		{ID: "vk-1", Name: "alpha-key", Value: "val-1", IsActive: schemas.Ptr(true), TeamID: &team1},
+		{ID: "vk-2", Name: "beta-key", Value: "val-2", IsActive: schemas.Ptr(true), TeamID: &team2},
+		{ID: "vk-3", Name: "alpha-test", Value: "val-3", IsActive: schemas.Ptr(true), CustomerID: &cust1},
+		{ID: "vk-4", Name: "gamma-key", Value: "val-4", IsActive: schemas.Ptr(true), CustomerID: &cust2},
+		{ID: "vk-5", Name: "delta-key", Value: "val-5", IsActive: schemas.Ptr(true), TeamID: &team1},
 	}
 	for i := range vks {
 		err := store.CreateVirtualKey(ctx, &vks[i])


### PR DESCRIPTION
## Summary

`TableVirtualKey.IsActive` and `TableRoutingRule.Enabled` have been changed from `bool` to `*bool` to properly distinguish between an explicitly set value and the absence of one (i.e., relying on the database default of `true`). Previously, a zero-value `bool` was indistinguishable from an intentionally set `false`, which could cause incorrect behavior when inserting records without explicitly setting these fields.

## Changes

- `TableVirtualKey.IsActive` and `TableRoutingRule.Enabled` are now `*bool` with a GORM `default:true` tag. A `nil` value means "use the DB default (true)".
- `IsActiveValue()` and `EnabledValue()` accessor methods were added to both structs, returning the dereferenced value and treating `nil` as `true`.
- All call sites that previously read `.IsActive` or `.Enabled` directly now use the new accessor methods.
- All construction sites (tests and production code) that previously assigned bare `bool` literals now use pointer helpers (`bifrost.Ptr(true)`, `schemas.Ptr(true)`, etc.).
- HTTP handler logic for creating/updating virtual keys and routing rules was updated to pass `*bool` directly rather than dereferencing into a local `bool` variable.
- The `getVirtualKeyQuota` response now uses `IsActiveValue()` to serialize the correct effective value.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
go test ./plugins/governance/...
go test ./transports/bifrost-http/...
```

Verify that virtual keys and routing rules created without an explicit `IsActive`/`Enabled` value are treated as active/enabled by default, and that explicitly setting them to `false` correctly marks them as inactive/disabled.

## Breaking changes

- [x] Yes
- [ ] No

Any code that directly assigns or reads `TableVirtualKey.IsActive` or `TableRoutingRule.Enabled` as a plain `bool` must be updated to use pointer assignment and the new `IsActiveValue()` / `EnabledValue()` accessors respectively.

## Security considerations

The `IsActiveValue()` accessor returns `false` when called on a `nil` receiver, ensuring that a nil virtual key pointer cannot be mistakenly treated as active. This preserves fail-closed behavior in all virtual key validation paths.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable