### PR TITLE
fix: exclude `oauth_client_id` and `oauth_client_secret` from config field validation

### DIFF
--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -15801,6 +15801,8 @@ var excludedGoFields = map[string]map[string]bool{
 		"is_code_mode_client":   true, // Internal
 		"auth_type":             true, // Internal
 		"oauth_config_id":       true, // Internal
+		"oauth_client_id":       true, // Response-only: populated on GET from oauth config, not stored
+		"oauth_client_secret":   true, // Response-only: populated on GET from oauth config, not stored
 		"is_ping_available":     true, // Runtime state
 		"tool_sync_interval":    true, // Internal
 		"tool_pricing":          true, // Internal


### PR DESCRIPTION
## Summary

Excludes `oauth_client_id` and `oauth_client_secret` from config field validation tests, as these fields are response-only values populated at read time from the OAuth config and are not stored directly.

## Changes

- Added `oauth_client_id` and `oauth_client_secret` to the `excludedGoFields` map so they are skipped during config round-trip or completeness tests
- These fields are populated dynamically on GET requests from the associated OAuth config and should not be expected to be present as stored configuration fields

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/...
```

The test that validates Go config fields should pass without flagging `oauth_client_id` or `oauth_client_secret` as missing or unexpected.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

`oauth_client_id` and `oauth_client_secret` are OAuth credentials. Explicitly marking them as response-only and not stored reinforces that these values are not persisted directly in configuration, reducing the risk of accidental secret storage or leakage through config serialization paths.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable