### PR TITLE
docs: update codex docs to inform non-openai models are not supported via openai websockets integration

### DIFF
--- a/docs/cli-agents/codex-cli.mdx
+++ b/docs/cli-agents/codex-cli.mdx
@@ -40,7 +40,7 @@ Always run `codex` from the same terminal session where you exported variables, 
 
 ## Using Non-OpenAI models
 
-Codex CLI defaults to [websocket mode](https://developers.openai.com/api/docs/guides/websocket-mode) for the Responses API and automatically falls back to HTTPS if the websocket connection fails. Currently non-OpenAI are not supported via the Websocket mode. If you are using non-OpenAI models, you must enable HTTPs mode.
+Codex CLI defaults to [websocket mode](https://developers.openai.com/api/docs/guides/websocket-mode) for the Responses API and automatically falls back to HTTPS if the WebSocket connection fails. Non-OpenAI models are not supported in WebSocket mode, because in this mode, the server is expected to maintain the conversation context. If you are using non-OpenAI models, you must enable HTTPS mode.
 
 To enable https for Codex CLI by default, add these settings in your `config.toml`: 
 

--- a/docs/cli-agents/codex-cli.mdx
+++ b/docs/cli-agents/codex-cli.mdx
@@ -38,7 +38,11 @@ model = "openai/gpt-5.4"
 
 Always run `codex` from the same terminal session where you exported variables, or restart the terminal after changing your profile. GUI-launched terminals or IDEs may not pick up shell-profile exports unless the environment is configured there as well.
 
-Codex CLI defaults to [websocket mode](https://developers.openai.com/api/docs/guides/websocket-mode) for the Responses API and automatically falls back to HTTPS if the websocket connection fails. To enable https for Codex CLI by default, add these settings in your `config.toml`: 
+## Using Non-OpenAI models
+
+Codex CLI defaults to [websocket mode](https://developers.openai.com/api/docs/guides/websocket-mode) for the Responses API and automatically falls back to HTTPS if the websocket connection fails. Currently non-OpenAI are not supported via the Websocket mode. If you are using non-OpenAI models, you must enable HTTPs mode.
+
+To enable https for Codex CLI by default, add these settings in your `config.toml`: 
 
 ```toml
 


### PR DESCRIPTION
## Summary

Clarifies that non-OpenAI models are not supported via WebSocket mode in Codex CLI and that HTTPS mode must be explicitly enabled when using them.

## Changes

- Added a dedicated "Using Non-OpenAI models" section header to improve discoverability of this requirement
- Added an explicit note that non-OpenAI models are unsupported via WebSocket mode and require HTTPS mode to be enabled
- Removed trailing newline inconsistency at end of file

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated `docs/cli-agents/codex-cli.mdx` to confirm the new section header and WebSocket/HTTPS clarification appear correctly in the rendered documentation.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable