### PR TITLE
fix: fix table name for provider governance display issue

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -417,9 +417,10 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 	// If the columns don't exist yet, the fetch simply returns nothing
 	governanceFKs := make(map[string]tables.TableProvider)
 	var existingProviders []tables.TableProvider
+	providerTableName := tables.TableProvider{}.TableName()
 
-	if s.doesColumnExist(ctx, "providers", "budget_id") &&
-		s.doesColumnExist(ctx, "providers", "rate_limit_id") {
+	if s.doesColumnExist(ctx, providerTableName, "budget_id") &&
+		s.doesColumnExist(ctx, providerTableName, "rate_limit_id") {
 		if err := txDB.WithContext(ctx).
 			Select("name", "budget_id", "rate_limit_id").
 			Find(&existingProviders).Error; err != nil {


### PR DESCRIPTION
## Summary

Replaces hardcoded table name strings with the dynamic table name derived from `tables.TableProvider{}.TableName()` when checking for column existence in `UpdateProvidersConfig`.

## Changes

- The string literal `"providers"` passed to `doesColumnExist` is replaced with the result of `tables.TableProvider{}.TableName()`, ensuring the table name used for column existence checks stays consistent with the actual table name defined on the model.

## Type of change

- [ ] Bug fix
- [x] Refactor
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Verify that provider config updates continue to function correctly, particularly in environments where the `budget_id` and `rate_limit_id` columns may or may not exist.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable