### PR TITLE
fix: drop function.strict for Anthropic tools

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -78,10 +78,10 @@ func convertFunctionToolToAnthropic(tool schemas.ChatTool) AnthropicTool {
 	if tool.EagerInputStreaming != nil {
 		anthropicTool.EagerInputStreaming = tool.EagerInputStreaming
 	}
-	// ChatToolFunction.Strict is the canonical neutral slot for Anthropic's strict.
-	if tool.Function.Strict != nil {
-		anthropicTool.Strict = tool.Function.Strict
-	}
+	// OpenAI's function.strict is intentionally not forwarded as Anthropic's
+	// top-level tool.strict. The Anthropic docs for Bifrost's tool conversion
+	// specify dropping OpenAI function.strict fields, and some Anthropic-hosted
+	// providers reject tools.*.strict outright.
 	return anthropicTool
 }
 

--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -122,7 +122,7 @@ func TestToAnthropicResponsesRequest_DropsFunctionStrict(t *testing.T) {
 	strict := true
 	toolName := "strict_openai_tool"
 	bifrostReq := &schemas.BifrostResponsesRequest{
-		Provider: schemas.Vertex,
+		Provider: schemas.Anthropic,
 		Model:    "claude-sonnet-4-20250514",
 		Input: []schemas.ResponsesMessage{{
 			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),

--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -79,6 +79,86 @@ func TestToAnthropicChatRequest_PreservesPropertyOrder(t *testing.T) {
 	}
 }
 
+func TestToAnthropicChatRequest_DropsFunctionStrict(t *testing.T) {
+	strict := true
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-sonnet-4-20250514",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("test")},
+		}},
+		Params: &schemas.ChatParameters{
+			Tools: []schemas.ChatTool{{
+				Type: schemas.ChatToolTypeFunction,
+				Function: &schemas.ChatToolFunction{
+					Name:   "strict_openai_tool",
+					Strict: &strict,
+					Parameters: &schemas.ToolFunctionParameters{
+						Type:       "object",
+						Properties: &schemas.OrderedMap{},
+					},
+				},
+			}},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+	result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(result.Tools))
+	}
+	if result.Tools[0].Strict != nil {
+		t.Fatalf("expected OpenAI function.strict to be dropped, got %v", *result.Tools[0].Strict)
+	}
+}
+
+func TestToAnthropicResponsesRequest_DropsFunctionStrict(t *testing.T) {
+	strict := true
+	toolName := "strict_openai_tool"
+	bifrostReq := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Vertex,
+		Model:    "claude-sonnet-4-20250514",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("test")},
+		}},
+		Params: &schemas.ResponsesParameters{
+			Tools: []schemas.ResponsesTool{{
+				Type:        schemas.ResponsesToolTypeFunction,
+				Name:        &toolName,
+				Description: schemas.Ptr("strict should not reach Anthropic"),
+				ResponsesToolFunction: &schemas.ResponsesToolFunction{
+					Strict: &strict,
+					Parameters: &schemas.ToolFunctionParameters{
+						Type:       "object",
+						Properties: &schemas.OrderedMap{},
+					},
+				},
+			}},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+	result, err := ToAnthropicResponsesRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(result.Tools))
+	}
+	if result.Tools[0].Strict != nil {
+		t.Fatalf("expected OpenAI function.strict to be dropped, got %v", *result.Tools[0].Strict)
+	}
+}
+
 func TestToAnthropicChatRequest_CachingDeterminism(t *testing.T) {
 	makeReq := func(props *schemas.OrderedMap) *schemas.BifrostChatRequest {
 		return &schemas.BifrostChatRequest{

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -5105,10 +5105,10 @@ func convertBifrostToolToAnthropic(model string, tool *schemas.ResponsesTool, pr
 		anthropicTool.Description = tool.Description
 	}
 
-	// Convert parameters and strict from ToolFunction
-	if tool.ResponsesToolFunction != nil {
-		anthropicTool.Strict = tool.ResponsesToolFunction.Strict
-	}
+	// Convert parameters from ToolFunction. OpenAI's function.strict is
+	// intentionally dropped rather than mapped to Anthropic's top-level
+	// tool.strict; Bifrost's Anthropic tool-conversion docs promise that
+	// behavior, and hosted Anthropic providers such as Vertex reject it.
 	if tool.ResponsesToolFunction != nil && tool.ResponsesToolFunction.Parameters != nil {
 		anthropicTool.InputSchema = tool.ResponsesToolFunction.Parameters
 	} else {


### PR DESCRIPTION
## Summary

Fixes Anthropic tool conversion so OpenAI `function.strict` is dropped instead of being forwarded as Anthropic `tools[].strict`.

## Changes

- Stop mapping `ChatToolFunction.Strict` to Anthropic tool `strict`
- Stop mapping `ResponsesToolFunction.Strict` to Anthropic tool `strict`
- Add focused chat and Responses conversion tests covering the drop behavior

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./providers/anthropic -run 'TestToAnthropic(Chat|Responses)Request_DropsFunctionStrict' -count=1
```

Local note: this command could not complete in my environment because the workspace has only ~220MB free and Go needs to download/unpack the `go1.26.2` toolchain required by `core/go.mod`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes #3233

## Security considerations

No security impact. This only removes an unsupported provider field during request conversion.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified formatting with gofmt
- [ ] I verified tests pass locally
