### PR TITLE
helm chart fixes

### DIFF
--- a/.github/workflows/scripts/validate-helm-config-fields.sh
+++ b/.github/workflows/scripts/validate-helm-config-fields.sh
@@ -39,12 +39,10 @@ report_result() {
 # Usage: render_config <values-file>
 render_config() {
   local values_file=$1
-  helm template bifrost "$CHART_DIR" \
-    --set image.tag=v1.0.0 \
-    -f "$values_file" \
-    > "$TMPDIR/rendered.yaml" 2>"$TMPDIR/render-err.txt"
-  local rc=$?
-  if [ "$rc" -ne 0 ]; then
+  if ! helm template bifrost "$CHART_DIR" \
+       --set image.tag=v1.0.0 \
+       -f "$values_file" \
+       > "$TMPDIR/rendered.yaml" 2>"$TMPDIR/render-err.txt"; then
     echo -e "${RED}    Render failed:${NC}"
     head -5 "$TMPDIR/render-err.txt" | sed 's/^/      /'
     return 1
@@ -162,7 +160,6 @@ bifrost:
     disableDbPingsInHealth: true
     logRetentionDays: 30
     enforceGovernanceHeader: true
-    allowDirectKeys: true
     maxRequestBodySizeMb: 50
     compat:
       convertTextToChat: true
@@ -202,7 +199,6 @@ assert_field_value 'client.disable_content_logging' '.client.disable_content_log
 assert_field_value 'client.disable_db_pings_in_health' '.client.disable_db_pings_in_health' 'true'
 assert_field_value 'client.log_retention_days' '.client.log_retention_days' '30'
 assert_field_value 'client.enforce_governance_header' '.client.enforce_governance_header' 'true'
-assert_field_value 'client.allow_direct_keys' '.client.allow_direct_keys' 'true'
 assert_field_value 'client.max_request_body_size_mb' '.client.max_request_body_size_mb' '50'
 assert_field_value 'client.compat.convert_text_to_chat' '.client.compat.convert_text_to_chat' 'true'
 assert_field_value 'client.compat.convert_chat_to_responses' '.client.compat.convert_chat_to_responses' 'true'

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.13
+version: 2.1.14
 appVersion: "1.5.0-prerelease7"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -4,9 +4,14 @@
 
 Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost) - a high-performance AI gateway with unified interface for multiple providers.
 
-**Latest Version:** 2.1.13
+**Latest Version:** 2.1.14
 
 ## Changelog
+
+### 2.1.14
+
+- Removed the obsolete `bifrost.client.allowDirectKeys` assertion from `validate-helm-config-fields.sh`. The field was deleted from the chart schema and codebase in a prior release, so the test was rendering an invalid values file and helm was rejecting it via `additionalProperties: false`.
+- Hardened `render_config()` in `validate-helm-config-fields.sh` so a failing `helm template` actually surfaces its stderr instead of being swallowed by the script's `set -e` (the previous post-hoc `$?` check was unreachable).
 
 ### 2.1.13
 

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,27 @@ entries:
   bifrost:
     - apiVersion: v2
       appVersion: 1.5.0-prerelease7
+      created: "2026-05-07T00:00:00.000000+00:00"
+      description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
+      digest: ""
+      home: https://www.getmaxim.ai/bifrost
+      icon: https://www.getbifrost.ai/favicon.png
+      keywords:
+        - ai
+        - gateway
+        - llm
+      maintainers:
+        - email: support@getbifrost.ai
+          name: Bifrost Team
+      name: bifrost
+      sources:
+        - https://github.com/maximhq/bifrost
+      type: application
+      urls:
+        - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.14.tgz
+      version: 2.1.14
+    - apiVersion: v2
+      appVersion: 1.5.0-prerelease7
       created: "2026-05-02T00:00:00.000000+00:00"
       description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
       digest: ""


### PR DESCRIPTION
## Summary

Fixes a broken CI validation script that was referencing a deleted Helm chart field (`allowDirectKeys`), causing `helm template` to fail due to `additionalProperties: false` in the schema. Also patches a silent failure bug in `render_config()` where a failed `helm template` invocation was not properly surfacing its error output.

## Changes

- Removed the `bifrost.client.allowDirectKeys` values entry and its corresponding `assert_field_value` assertion from `validate-helm-config-fields.sh`, as the field was removed from the chart schema and codebase in a prior release but the test was still attempting to render it, causing helm to reject the values file.
- Refactored `render_config()` to use `if ! helm template ...` instead of capturing `$?` after the fact, which was unreachable under `set -e` and was silently swallowing render errors instead of printing them.
- Bumped chart version to `2.1.14` and updated `index.yaml` and `README.md` accordingly.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Run the validation script directly against the chart
bash .github/workflows/scripts/validate-helm-config-fields.sh
```

Expected outcome: all assertions pass and no `helm template` render failures are reported.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable