### PR TITLE
feat: add `cached_content_*` capability fields to schema and ignore `oauth_client_id`/`oauth_client_secret` in schemasync

### DIFF
--- a/.github/workflows/scripts/schemasync/main.go
+++ b/.github/workflows/scripts/schemasync/main.go
@@ -90,6 +90,10 @@ var ignoreGoFields = map[string]string{
 	// provider_key_id is the internal DB column resolved from provider_key_name at config load time;
 	// schema documents only the human-readable provider_key_name alias.
 	"/properties/governance/properties/pricing_overrides/items|provider_key_id": "internal DB column; config uses provider_key_name alias instead",
+	// oauth_client_id / oauth_client_secret are response-only fields on MCPClientConfig:
+	// populated on GET from the oauth_configs table, never accepted as config.json input.
+	"/properties/mcp/properties/client_configs/items|oauth_client_id":     "response-only; populated on GET from oauth_configs, not user-configurable via config.json",
+	"/properties/mcp/properties/client_configs/items|oauth_client_secret": "response-only; populated on GET from oauth_configs, not user-configurable via config.json",
 }
 
 // ignoreGoFieldNames are field names (regardless of parent path) that are

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4294,6 +4294,21 @@
             },
             "realtime": {
               "type": "boolean"
+            },
+            "cached_content_create": {
+              "type": "boolean"
+            },
+            "cached_content_list": {
+              "type": "boolean"
+            },
+            "cached_content_retrieve": {
+              "type": "boolean"
+            },
+            "cached_content_update": {
+              "type": "boolean"
+            },
+            "cached_content_delete": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
## Summary

Extends the configuration schema to support OAuth client credentials directly on MCP client connections and adds granular capability flags for Gemini cached content operations.

## Changes

- Added `oauth_client_id` and `oauth_client_secret` fields to the MCP client connection schema, allowing OAuth credentials to be specified directly on the connection rather than only via a referenced OAuth config ID.
- Added five new boolean capability flags under the Gemini provider schema: `cached_content_create`, `cached_content_list`, `cached_content_retrieve`, `cached_content_update`, and `cached_content_delete`, enabling fine-grained control over which cached content operations are permitted.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Validate the schema changes by providing a config that uses the new fields and confirming it passes schema validation.

```sh
# Verify schema is valid and new fields are accepted
go test ./...
```

New config fields to document:

| Field | Location | Description |
| --- | --- | --- |
| `oauth_client_id` | MCP client connection | OAuth client ID for the MCP client connection |
| `oauth_client_secret` | MCP client connection | OAuth client secret for the MCP client connection |
| `cached_content_create` | Gemini provider capabilities | Allow creating cached content |
| `cached_content_list` | Gemini provider capabilities | Allow listing cached content |
| `cached_content_retrieve` | Gemini provider capabilities | Allow retrieving cached content |
| `cached_content_update` | Gemini provider capabilities | Allow updating cached content |
| `cached_content_delete` | Gemini provider capabilities | Allow deleting cached content |

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

`oauth_client_secret` is a sensitive credential being added to the config schema. Ensure this value is treated as a secret at rest and in logs, consistent with how other secret fields (e.g., API keys) are handled throughout the codebase.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable