### PR TITLE
transports/bifrost-http: surface routed identity as x-bifrost-* response headers

### DIFF
--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -943,7 +943,12 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 	// for providers to respect cancellation.
 	var response interface{}
 	var err error
-	var providerResponseHeaders map[string]string
+	// bifrostExtraFields snapshots the routed identity (provider, original/resolved
+	// model) plus the upstream provider's response headers from whichever Bifrost
+	// response variant the case below populates. The common footer below surfaces
+	// the routed identity as `x-bifrost-*` response headers and forwards the
+	// upstream provider headers verbatim.
+	var bifrostExtraFields schemas.BifrostResponseExtraFields
 
 	switch {
 	case bifrostReq.ListModelsRequest != nil:
@@ -986,7 +991,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 		}
 
 		response, err = config.ListModelsResponseConverter(bifrostCtx, listModelsResponse)
-		providerResponseHeaders = listModelsResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = listModelsResponse.ExtraFields
 	case bifrostReq.TextCompletionRequest != nil:
 		textCompletionResponse, bifrostErr := g.client.TextCompletionRequest(bifrostCtx, bifrostReq.TextCompletionRequest)
 		if bifrostErr != nil {
@@ -1010,7 +1015,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 
 		// Convert Bifrost response to integration-specific format and send
 		response, err = config.TextResponseConverter(bifrostCtx, textCompletionResponse)
-		providerResponseHeaders = textCompletionResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = textCompletionResponse.ExtraFields
 	case bifrostReq.ChatRequest != nil:
 		chatResponse, bifrostErr := g.client.ChatCompletionRequest(bifrostCtx, bifrostReq.ChatRequest)
 		if bifrostErr != nil {
@@ -1034,7 +1039,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 
 		// Convert Bifrost response to integration-specific format and send
 		response, err = config.ChatResponseConverter(bifrostCtx, chatResponse)
-		providerResponseHeaders = chatResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = chatResponse.ExtraFields
 	case bifrostReq.ResponsesRequest != nil:
 		responsesResponse, bifrostErr := g.client.ResponsesRequest(bifrostCtx, bifrostReq.ResponsesRequest)
 		if bifrostErr != nil {
@@ -1058,7 +1063,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 
 		// Convert Bifrost response to integration-specific format and send
 		response, err = config.ResponsesResponseConverter(bifrostCtx, responsesResponse)
-		providerResponseHeaders = responsesResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = responsesResponse.ExtraFields
 	case bifrostReq.EmbeddingRequest != nil:
 		embeddingResponse, bifrostErr := g.client.EmbeddingRequest(bifrostCtx, bifrostReq.EmbeddingRequest)
 		if bifrostErr != nil {
@@ -1079,7 +1084,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Bifrost response is nil after post-request callback"))
 			return
 		}
-		providerResponseHeaders = embeddingResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = embeddingResponse.ExtraFields
 		// Convert Bifrost response to integration-specific format and send
 		response, err = config.EmbeddingResponseConverter(bifrostCtx, embeddingResponse)
 	case bifrostReq.RerankRequest != nil:
@@ -1098,7 +1103,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Bifrost response is nil after post-request callback"))
 			return
 		}
-		providerResponseHeaders = rerankResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = rerankResponse.ExtraFields
 		if config.RerankResponseConverter != nil {
 			response, err = config.RerankResponseConverter(bifrostCtx, rerankResponse)
 		} else {
@@ -1121,7 +1126,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 			g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "bifrost response is nil after post-request callback"))
 			return
 		}
-		providerResponseHeaders = ocrResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = ocrResponse.ExtraFields
 		if config.OCRResponseConverter != nil {
 			response, err = config.OCRResponseConverter(bifrostCtx, ocrResponse)
 		} else {
@@ -1147,7 +1152,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 			return
 		}
 
-		providerResponseHeaders = speechResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = speechResponse.ExtraFields
 
 		if g.tryStreamLargeResponse(ctx, bifrostCtx) {
 			return
@@ -1195,15 +1200,13 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 
 		// Convert Bifrost response to integration-specific format and send
 		response, err = config.TranscriptionResponseConverter(bifrostCtx, transcriptionResponse)
-		providerResponseHeaders = transcriptionResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = transcriptionResponse.ExtraFields
 
 		// If converter returns raw bytes, write directly with provider headers.
 		// Used for plain-text transcription formats (text, srt, vtt).
 		if err == nil {
 			if rawBytes, ok := response.([]byte); ok {
-				for key, value := range providerResponseHeaders {
-					ctx.Response.Header.Set(key, value)
-				}
+				applyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 				ctx.SetStatusCode(fasthttp.StatusOK)
 				ctx.SetBody(rawBytes)
 				return
@@ -1241,7 +1244,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 
 		// Convert Bifrost response to integration-specific format and send
 		response, err = config.ImageGenerationResponseConverter(bifrostCtx, imageGenerationResponse)
-		providerResponseHeaders = imageGenerationResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = imageGenerationResponse.ExtraFields
 	case bifrostReq.ImageEditRequest != nil:
 		imageEditResponse, bifrostErr := g.client.ImageEditRequest(bifrostCtx, bifrostReq.ImageEditRequest)
 		if bifrostErr != nil {
@@ -1274,7 +1277,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 
 		// Convert Bifrost response to integration-specific format and send
 		response, err = config.ImageGenerationResponseConverter(bifrostCtx, imageEditResponse)
-		providerResponseHeaders = imageEditResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = imageEditResponse.ExtraFields
 	case bifrostReq.ImageVariationRequest != nil:
 		imageVariationResponse, bifrostErr := g.client.ImageVariationRequest(bifrostCtx, bifrostReq.ImageVariationRequest)
 		if bifrostErr != nil {
@@ -1307,7 +1310,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 
 		// Convert Bifrost response to integration-specific format and send
 		response, err = config.ImageGenerationResponseConverter(bifrostCtx, imageVariationResponse)
-		providerResponseHeaders = imageVariationResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = imageVariationResponse.ExtraFields
 	case bifrostReq.VideoGenerationRequest != nil:
 		videoGenerationResponse, bifrostErr := g.client.VideoGenerationRequest(bifrostCtx, bifrostReq.VideoGenerationRequest)
 		if bifrostErr != nil {
@@ -1333,7 +1336,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 		}
 
 		response, err = config.VideoGenerationResponseConverter(bifrostCtx, videoGenerationResponse)
-		providerResponseHeaders = videoGenerationResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = videoGenerationResponse.ExtraFields
 	case bifrostReq.VideoRetrieveRequest != nil:
 		videoRetrieveResponse, bifrostErr := g.client.VideoRetrieveRequest(bifrostCtx, bifrostReq.VideoRetrieveRequest)
 		if bifrostErr != nil {
@@ -1358,7 +1361,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 			return
 		}
 		response, err = config.VideoGenerationResponseConverter(bifrostCtx, videoRetrieveResponse)
-		providerResponseHeaders = videoRetrieveResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = videoRetrieveResponse.ExtraFields
 	case bifrostReq.VideoDownloadRequest != nil:
 		videoDownloadResponse, bifrostErr := g.client.VideoDownloadRequest(bifrostCtx, bifrostReq.VideoDownloadRequest)
 		if bifrostErr != nil {
@@ -1384,7 +1387,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 		}
 
 		response, err = config.VideoDownloadResponseConverter(bifrostCtx, videoDownloadResponse)
-		providerResponseHeaders = videoDownloadResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = videoDownloadResponse.ExtraFields
 
 		// If converter returns binary content, write directly with content-type.
 		if err == nil {
@@ -1424,7 +1427,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 		}
 
 		response, err = config.VideoDeleteResponseConverter(bifrostCtx, videoDeleteResponse)
-		providerResponseHeaders = videoDeleteResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = videoDeleteResponse.ExtraFields
 	case bifrostReq.VideoRemixRequest != nil:
 		videoRemixResponse, bifrostErr := g.client.VideoRemixRequest(bifrostCtx, bifrostReq.VideoRemixRequest)
 		if bifrostErr != nil {
@@ -1450,7 +1453,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 		}
 
 		response, err = config.VideoGenerationResponseConverter(bifrostCtx, videoRemixResponse)
-		providerResponseHeaders = videoRemixResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = videoRemixResponse.ExtraFields
 	case bifrostReq.VideoListRequest != nil:
 
 		// extract provider from header
@@ -1484,7 +1487,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 		}
 
 		response, err = config.VideoListResponseConverter(bifrostCtx, videoListResponse)
-		providerResponseHeaders = videoListResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = videoListResponse.ExtraFields
 
 	case bifrostReq.CountTokensRequest != nil:
 		countTokensResponse, bifrostErr := g.client.CountTokensRequest(bifrostCtx, bifrostReq.CountTokensRequest)
@@ -1513,7 +1516,7 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 			return
 		}
 		response, err = config.CountTokensResponseConverter(bifrostCtx, countTokensResponse)
-		providerResponseHeaders = countTokensResponse.ExtraFields.ProviderResponseHeaders
+		bifrostExtraFields = countTokensResponse.ExtraFields
 	default:
 		g.sendError(ctx, bifrostCtx, config.ErrorConverter, newBifrostError(nil, "Invalid request type"))
 		return
@@ -1524,10 +1527,9 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 		return
 	}
 
-	// Forward provider response headers only after conversion succeeds
-	for key, value := range providerResponseHeaders {
-		ctx.Response.Header.Set(key, value)
-	}
+	// Forward upstream provider response headers (filtered) plus the bifrost-level
+	// `x-bifrost-*` routing identity headers, only after conversion succeeds.
+	applyBifrostResponseHeaders(ctx, bifrostCtx, bifrostExtraFields)
 
 	if g.tryStreamLargeResponse(ctx, bifrostCtx) {
 		return

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -222,6 +222,60 @@ func (g *GenericRouter) sendError(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.
 	ctx.SetBody(errorBody)
 }
 
+// HTTP response header names for the routed identity. Set on every successful
+// response from any integration so callers can recover the actual provider /
+// model that handled the request — even when the integration converts the
+// body to a provider-native shape (Anthropic, OpenAI, Bedrock) that has no
+// place to surface Bifrost's `extra_fields`.
+//
+// Header values are derived from BifrostResponseExtraFields (populated by
+// PopulateExtraFields at the end of every request path, including after
+// fallback / routing-rule resolution). FallbackIndex is read from the
+// BifrostContext because it isn't a field on the response struct.
+//
+// Naming follows the existing `x-bf-*` request-side convention (see
+// `x-bf-vk`, `x-bf-key-id`, etc.).
+const (
+	HeaderBifrostProvider       = "x-bifrost-provider"
+	HeaderBifrostOriginalModel  = "x-bifrost-original-model"
+	HeaderBifrostResolvedModel  = "x-bifrost-resolved-model"
+	HeaderBifrostFallbackIndex  = "x-bifrost-fallback-index"
+	HeaderBifrostRequestType    = "x-bifrost-request-type"
+)
+
+// applyBifrostResponseHeaders writes both the upstream provider response
+// headers (forwarded verbatim) and the bifrost-level `x-bifrost-*` routing
+// identity headers onto the fasthttp response. Empty fields are skipped so
+// the headers never appear with a blank value. Safe to call when the case
+// didn't populate `extra` — the zero value for ExtraFields produces no
+// headers.
+func applyBifrostResponseHeaders(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, extra schemas.BifrostResponseExtraFields) {
+	for key, value := range extra.ProviderResponseHeaders {
+		ctx.Response.Header.Set(key, value)
+	}
+	if extra.Provider != "" {
+		ctx.Response.Header.Set(HeaderBifrostProvider, string(extra.Provider))
+	}
+	if extra.OriginalModelRequested != "" {
+		ctx.Response.Header.Set(HeaderBifrostOriginalModel, extra.OriginalModelRequested)
+	}
+	if extra.ResolvedModelUsed != "" {
+		ctx.Response.Header.Set(HeaderBifrostResolvedModel, extra.ResolvedModelUsed)
+	}
+	if extra.RequestType != "" {
+		ctx.Response.Header.Set(HeaderBifrostRequestType, string(extra.RequestType))
+	}
+	// Fallback index lives on the request context, not the response struct.
+	// 0 = primary provider succeeded; non-zero = which fallback fired
+	// (1-indexed). Only emit when non-zero so the absence of the header is
+	// the unambiguous "no fallback fired" signal.
+	if bifrostCtx != nil {
+		if idx, ok := bifrostCtx.Value(schemas.BifrostContextKeyFallbackIndex).(int); ok && idx > 0 {
+			ctx.Response.Header.Set(HeaderBifrostFallbackIndex, strconv.Itoa(idx))
+		}
+	}
+}
+
 // sendSuccess sends a successful response with HTTP 200 status and JSON body.
 func (g *GenericRouter) sendSuccess(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, errorConverter ErrorConverter, response interface{}, extraHeaders map[string]string) {
 	ctx.SetStatusCode(fasthttp.StatusOK)

--- a/transports/bifrost-http/integrations/utils_test.go
+++ b/transports/bifrost-http/integrations/utils_test.go
@@ -275,3 +275,77 @@ func TestSendStreamError_ForwardsProviderHeaders(t *testing.T) {
 	assert.Equal(t, "req-123", string(ctx.Response.Header.Peek("x-amzn-requestid")))
 	assert.Equal(t, "ValidationException", string(ctx.Response.Header.Peek("x-amzn-errortype")))
 }
+
+// TestApplyBifrostResponseHeaders covers the routed-identity headers added so
+// drop-in integration callers (Anthropic SDK against `/anthropic/v1/messages`,
+// OpenAI SDK against `/openai/v1/chat/completions`, etc.) can recover the
+// actual provider/model that handled the request — including after fallback
+// or routing-rule resolution. The body shape they get back has no place to
+// surface this; headers do.
+func TestApplyBifrostResponseHeaders(t *testing.T) {
+	t.Run("routed identity emits all headers", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newTestBifrostContext()
+
+		extra := schemas.BifrostResponseExtraFields{
+			Provider:               schemas.Bedrock,
+			OriginalModelRequested: "claude-sonnet-4-6",
+			ResolvedModelUsed:      "us.anthropic.claude-sonnet-4-6",
+			RequestType:            schemas.ChatCompletionRequest,
+			ProviderResponseHeaders: map[string]string{
+				"x-amzn-requestid": "req-789",
+			},
+		}
+
+		applyBifrostResponseHeaders(ctx, bifrostCtx, extra)
+
+		assert.Equal(t, "bedrock", string(ctx.Response.Header.Peek(HeaderBifrostProvider)))
+		assert.Equal(t, "claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostOriginalModel)))
+		assert.Equal(t, "us.anthropic.claude-sonnet-4-6", string(ctx.Response.Header.Peek(HeaderBifrostResolvedModel)))
+		assert.Equal(t, string(schemas.ChatCompletionRequest), string(ctx.Response.Header.Peek(HeaderBifrostRequestType)))
+		assert.Equal(t, "req-789", string(ctx.Response.Header.Peek("x-amzn-requestid")))
+		// No fallback fired — header must be absent.
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
+	})
+
+	t.Run("fallback index from context emits when non-zero", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newTestBifrostContext()
+		bifrostCtx.SetValue(schemas.BifrostContextKeyFallbackIndex, 2)
+
+		extra := schemas.BifrostResponseExtraFields{
+			Provider:          schemas.Anthropic,
+			ResolvedModelUsed: "claude-haiku-4-5",
+		}
+
+		applyBifrostResponseHeaders(ctx, bifrostCtx, extra)
+
+		assert.Equal(t, "2", string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
+	})
+
+	t.Run("zero-value extra writes no headers", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newTestBifrostContext()
+
+		applyBifrostResponseHeaders(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{})
+
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostProvider)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostOriginalModel)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostResolvedModel)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostRequestType)))
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)))
+	})
+
+	t.Run("primary-provider success (FallbackIndex=0) does not emit fallback header", func(t *testing.T) {
+		ctx := &fasthttp.RequestCtx{}
+		bifrostCtx := newTestBifrostContext()
+		bifrostCtx.SetValue(schemas.BifrostContextKeyFallbackIndex, 0)
+
+		applyBifrostResponseHeaders(ctx, bifrostCtx, schemas.BifrostResponseExtraFields{
+			Provider: schemas.OpenAI,
+		})
+
+		assert.Empty(t, string(ctx.Response.Header.Peek(HeaderBifrostFallbackIndex)),
+			"FallbackIndex=0 means primary succeeded; absence of header is the signal")
+	})
+}


### PR DESCRIPTION
## Why

When a caller talks to Bifrost via one of the drop-in integrations (`/anthropic/v1/messages`, `/openai/v1/chat/completions`, `/bedrock/...`, etc.) the response converter flattens Bifrost's internal `BifrostResponse` down to a provider-native shape so the upstream SDK sees something it understands. That conversion drops `extra_fields`, which is where Bifrost stores the post-routing / post-fallback identity:

- `Provider` — the provider that actually ran (e.g. `bedrock` after a fallback from Anthropic).
- `OriginalModelRequested` — the model the caller sent.
- `ResolvedModelUsed` — final identifier reaching the provider API, after both routing-rule resolution and key-level alias resolution (per [`docs/providers/aliasing-models.mdx`](https://github.com/maximhq/bifrost/blob/main/docs/providers/aliasing-models.mdx)).

Today, a caller using the Anthropic SDK pointed at Bifrost has no way to recover any of this — so for usage tracking, billing attribution, or routing observability they're stuck either:

- switching to the native `/v1/chat/completions` endpoint (giving up the SDK's typing / retry / streaming primitives), or
- subscribing to the tracer interface and correlating to outbound HTTP requests via request id (high coupling, awkward).

## What

Surface the routed identity as response headers on every successful response from the integrations:

| Header | Source | When emitted |
|---|---|---|
| `x-bifrost-provider` | `ExtraFields.Provider` | always (when non-empty) |
| `x-bifrost-original-model` | `ExtraFields.OriginalModelRequested` | always (when non-empty) |
| `x-bifrost-resolved-model` | `ExtraFields.ResolvedModelUsed` | always (when non-empty) |
| `x-bifrost-request-type` | `ExtraFields.RequestType` | always (when non-empty) |
| `x-bifrost-fallback-index` | `BifrostContextKeyFallbackIndex` | only when `> 0` — absence of header = primary succeeded |

Naming follows the existing `x-bf-*` request-side convention (`x-bf-vk`, `x-bf-key-id`, etc.).

## How

Two-file change in `transports/bifrost-http/integrations`:

1. **`router.go`** — replace the per-case `providerResponseHeaders` capture in `GenericRouter.handleRequest` with a single `bifrostExtraFields` snapshot of the whole `ExtraFields` value. Same number of assignments in the switch, but now we can read both `ProviderResponseHeaders` and the routing identity from one source.
2. **`utils.go`** — new `applyBifrostResponseHeaders(ctx, bifrostCtx, extra)` helper that forwards the upstream provider headers verbatim (existing behaviour) and writes the new `x-bifrost-*` headers. Empty fields are skipped so headers never appear with a blank value. Safe to call even when the case didn't populate `extra` — the zero value produces no headers.

Net diff: **+157 / -27 lines**, mostly tests.

```
 transports/bifrost-http/integrations/router.go     | 56 ++++++++--------
 transports/bifrost-http/integrations/utils.go      | 54 ++++++++++++++++
 transports/bifrost-http/integrations/utils_test.go | 74 ++++++++++++++++++++++
```

## Scope notes

- **Unary path only.** Every request type that flowed through the common header-forwarding footer (chat completions, responses, embeddings, rerank, OCR, count tokens, image gen / edit / variation, video gen / retrieve / download / delete / remix / list, transcription, list models, text completion) gets the headers.
- **Streaming SSE is intentionally not touched** in this PR. Routed identity for streaming is more awkward because the `BifrostResponse` arrives chunk-by-chunk after headers are flushed. Worth a follow-up — either pre-resolve from `BifrostContext` before the first chunk, or use a transport pre-write hook. Filing as a separate issue if this lands well.
- **No SDK contract change.** Clients that don't care ignore the headers. Headers don't appear on error responses (only on `200 OK` from the integrations) — happy to extend if maintainers want them on error paths too, since `BifrostError` also has `ExtraFields.{Provider, OriginalModelRequested, ResolvedModelUsed}`.

## Tests

`TestApplyBifrostResponseHeaders` (4 sub-tests) covers:

- full identity emission with all fields populated
- fallback index emission from context when non-zero
- zero-value `ExtraFields` produces no headers (defensive against cases that don't populate)
- primary-success case (`FallbackIndex=0`) emits no fallback header — absence is the unambiguous signal

```
$ go test -run TestApplyBifrostResponseHeaders ./integrations/ -v
=== RUN   TestApplyBifrostResponseHeaders
=== RUN   TestApplyBifrostResponseHeaders/routed_identity_emits_all_headers
=== RUN   TestApplyBifrostResponseHeaders/fallback_index_from_context_emits_when_non-zero
=== RUN   TestApplyBifrostResponseHeaders/zero-value_extra_writes_no_headers
=== RUN   TestApplyBifrostResponseHeaders/primary-provider_success_(FallbackIndex=0)_does_not_emit_fallback_header
--- PASS: TestApplyBifrostResponseHeaders (0.00s)
PASS
```

Full integrations package suite still passes.

## Use case (context for why I care)

We use Bifrost as a model gateway with routing rules + fallback. When a caller asks for `claude-sonnet-4-6`, our routing rules + fallback chain might land on Anthropic direct, Bedrock-via-Anthropic, or Vertex-via-Anthropic — with the SDK seeing only what looks like an Anthropic response. Our usage-tracking and cost-attribution layer needs the actual `(provider, model)` that ran to (a) avoid persisting `bifrost/...` as a permanent canonical identity, and (b) compute cost against the right per-token rates if/when route-dependent pricing matters. These headers give us that without having to reach for the native API or the tracer plugin.

Happy to iterate on naming, scope (errors? streaming?), or implementation approach.

Made with [Cursor](https://cursor.com)