### PR TITLE
scout fixes

### DIFF
--- a/docs/cli-agents/claude-code.mdx
+++ b/docs/cli-agents/claude-code.mdx
@@ -6,6 +6,15 @@ icon: "star-of-life"
 
 [Claude Code](https://www.claude.com/product/claude-code) brings AI-powered coding capabilities directly to your terminal.
 
+**Tested on Claude Code versions:**
+
+| Version | Released   |
+| ------- | ---------- |
+| 2.1.132 | 2026-05-06 |
+| 2.1.131 | 2026-05-06 |
+| 2.1.129 | 2026-05-05 |
+| 2.1.128 | 2026-05-04 |
+
 <Note>
   If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost
   with Claude Code, try switching to `*` or adding the specific headers required by your client. By default, Bifrost

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -1,7 +1,10 @@
 # --- UI Build Stage: Build the React + Vite frontend ---
-  FROM node:25-alpine3.23@sha256:cf38e1f3c28ac9d81cdc0c51d8220320b3b618780e44ef96a39f76f7dbfef023 AS ui-builder
+  FROM node:25-alpine3.23@sha256:bdf2cca6fe3dabd014ea60163eca3f0f7015fbd5c7ee1b0e9ccb4ced6eb02ef4 AS ui-builder
   WORKDIR /app
-  
+
+  # Apply latest alpine security patches before installing packages
+  RUN apk upgrade --no-cache
+
   # Copy UI package files and install dependencies
   COPY ui/package*.json ./
   RUN npm ci
@@ -17,8 +20,9 @@
   FROM golang:1.26.2-alpine3.23@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
   WORKDIR /app
   
-  # Install dependencies including gcc for CGO and sqlite
-  RUN apk add --no-cache gcc musl-dev sqlite-dev binutils binutils-gold
+  # Install dependencies including gcc for CGO and sqlite (with latest security patches)
+  RUN apk upgrade --no-cache && \
+    apk add --no-cache gcc musl-dev sqlite-dev binutils binutils-gold
   
   # Set environment for CGO-enabled build (required for go-sqlite3)
   ENV CGO_ENABLED=1 GOOS=linux
@@ -47,14 +51,15 @@
   RUN test -f /app/main || (echo "Build failed" && exit 1)
   
   # --- Runtime Stage: Minimal runtime image ---
-  FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+  FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
   WORKDIR /app
   
   # Install runtime dependencies for CGO-enabled binary
   # musl: C standard library (required for CGO binaries)
   # libgcc: GCC runtime library
   # ca-certificates: For HTTPS connections
-  RUN apk add --no-cache musl libgcc ca-certificates wget zlib=1.3.2-r0
+  RUN apk upgrade --no-cache && \
+    apk add --no-cache musl libgcc ca-certificates wget zlib
   
   # Create data directory and set up user
   COPY --from=builder /app/main .


### PR DESCRIPTION
## Summary

Updates the transports Dockerfile to apply the latest Alpine security patches across all build stages and upgrades the runtime base image from Alpine 3.23.3 to 3.23.4.

## Changes

- Updated the `ui-builder` stage base image digest and added `apk upgrade --no-cache` to apply latest Alpine security patches before installing packages
- Added `apk upgrade --no-cache` to the `builder` stage before installing build dependencies
- Upgraded the runtime base image from `alpine:3.23.3` to `alpine:3.23.4` with its updated digest
- Added `apk upgrade --no-cache` to the runtime stage and removed the pinned version constraint on `zlib` (changed from `zlib=1.3.2-r0` to `zlib`) to allow the latest patched version to be installed

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
docker build -f transports/Dockerfile transports/
```

Verify the image builds successfully and that no known CVEs are present in the resulting image using a scanner such as `docker scout` or `trivy`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

This PR ensures all Alpine packages across every Dockerfile stage receive the latest security patches by running `apk upgrade` before package installation. The runtime stage also unpins `zlib` from a specific version, allowing future security patch releases to be picked up automatically on rebuild.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable