### PR TITLE
feat: add Entra auth fields (`client_id`, `client_secret`, `tenant_id`, `scopes`) to Azure transport schema and make `api_version` optional

### DIFF
--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2360,9 +2360,31 @@
                 "api_version": {
                   "type": "string",
                   "description": "Azure API version"
+                },
+                "client_id": {
+                  "type": "string",
+                  "description": "Azure client ID for Entra authentication (can use env. prefix)"
+                },
+                "client_secret": {
+                  "type": "string",
+                  "description": "Azure client secret for Entra authentication (can use env. prefix)"
+                },
+                "tenant_id": {
+                  "type": "string",
+                  "description": "Azure tenant ID for Entra authentication (can use env. prefix)"
+                },
+                "scopes": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "description": "OAuth2 scopes for Entra authentication"
                 }
               },
-              "required": ["endpoint", "api_version"],
+              "required": ["endpoint"],
+              "dependentRequired": {
+                "client_id": ["client_secret", "tenant_id"],
+                "client_secret": ["client_id", "tenant_id"],
+                "tenant_id": ["client_id", "client_secret"]
+              },
               "additionalProperties": false
             }
           },


### PR DESCRIPTION
## Summary

Adds support for Azure Entra (service principal) authentication in the transport configuration by introducing optional OAuth2 credential fields and relaxing the `api_version` requirement.

## Changes

- Added `client_id`, `client_secret`, `tenant_id`, and `scopes` fields to the Azure transport config schema to support Entra (service principal) authentication. All fields support the `env.` prefix for environment variable resolution.
- Removed `api_version` from the `required` array, making it optional to accommodate authentication flows where it may not be needed.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Configure an Azure transport with Entra credentials and verify the schema validates correctly:

```json
{
  "endpoint": "https://my-azure-endpoint",
  "client_id": "env.AZURE_CLIENT_ID",
  "client_secret": "env.AZURE_CLIENT_SECRET",
  "tenant_id": "env.AZURE_TENANT_ID",
  "scopes": ["https://cognitiveservices.azure.com/.default"]
}
```

Verify that a config omitting `api_version` passes schema validation, and that configs with unknown properties are still rejected.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`client_secret` is a sensitive credential. Ensure it is always sourced via the `env.` prefix rather than hardcoded in configuration files. Secrets should never be committed to version control.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable