### PR TITLE
fix: make custom provider sheet header and footer sticky with proper padding and scrollable content area

### DIFF
--- a/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
@@ -124,13 +124,13 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 
 	return (
 		<>
-			<SheetHeader className="flex shrink-0 flex-col items-start">
+			<SheetHeader className="flex shrink-0 flex-col items-start px-8 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10">
 				<SheetTitle>Add Custom Provider</SheetTitle>
 				<SheetDescription>Enter the details of your custom provider.</SheetDescription>
 			</SheetHeader>
 			<Form {...form}>
-				<form onSubmit={form.handleSubmit(onSubmit)} className="flex min-h-0 flex-1 flex-col overflow-hidden">
-					<div className="custom-scrollbar min-h-0 flex-1 space-y-4 overflow-y-auto">
+				<form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col">
+					<div className="min-h-0 flex-1 space-y-4 px-8 pb-4">
 						<FormField
 							control={form.control}
 							name="name"
@@ -226,19 +226,19 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 							providerType={form.watch("baseFormat") as BaseProvider}
 							disabled={!hasProviderCreateAccess}
 						/>
-						<div className="align-end mt-10 ml-auto flex flex-row gap-2 border-t pt-4">
-							<Button type="button" variant="outline" onClick={onClose} className="ml-auto" data-testid="custom-provider-cancel-btn">
-								Cancel
-							</Button>
-							<Button
-								type="submit"
-								isLoading={isAddingProvider}
-								disabled={!hasProviderCreateAccess}
-								data-testid="custom-provider-save-btn"
-							>
-								Add
-							</Button>
-						</div>
+					</div>
+					<div className="w-full ml-auto flex flex-row gap-2 bg-card sticky bottom-0 border-t px-8 py-4">
+						<Button type="button" variant="outline" onClick={onClose} className="ml-auto" data-testid="custom-provider-cancel-btn">
+							Cancel
+						</Button>
+						<Button
+							type="submit"
+							isLoading={isAddingProvider}
+							disabled={!hasProviderCreateAccess}
+							data-testid="custom-provider-save-btn"
+						>
+							Add
+						</Button>
 					</div>
 				</form>
 			</Form>
@@ -249,7 +249,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 export default function AddCustomProviderSheet(props: Props) {
 	return (
 		<Sheet open={props.show} onOpenChange={(open) => !open && props.onClose()}>
-			<SheetContent className="custom-scrollbar flex flex-col p-8 sm:max-w-3xl" data-testid="custom-provider-sheet">
+			<SheetContent data-testid="custom-provider-sheet" className="p-0 pt-4">
 				<AddCustomProviderSheetContent {...props} />
 			</SheetContent>
 		</Sheet>


### PR DESCRIPTION
## Summary

Fixes the layout of the "Add Custom Provider" sheet so that the header and action buttons remain sticky while the form content scrolls independently.

## Changes

- Made the sheet header sticky at the top with a background so it doesn't visually merge with scrolling content beneath it
- Moved the Cancel/Add action buttons outside the scrollable form area and made them sticky at the bottom of the sheet
- Removed overflow handling from the form itself, allowing the sheet container to manage scrolling naturally
- Removed padding from the `SheetContent` wrapper (`p-0 pt-4`) and applied padding directly to the header and content sections for more precise layout control

## Type of change

- [ ] Bug fix
- [x] Refactor
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Workspace Providers page
2. Open the "Add Custom Provider" sheet
3. Verify the header ("Add Custom Provider") remains visible and sticky as you scroll through the form
4. Verify the Cancel and Add buttons remain visible and sticky at the bottom as you scroll
5. Confirm the form content scrolls independently between the sticky header and footer

## Screenshots/Recordings

Add before/after screenshots showing the sticky header and footer behavior in the sheet.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable