### PR TITLE
fix: persist provider key request timeout override

### DIFF
--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -120,25 +120,26 @@ func (bl BlackList) Validate() error {
 // Key represents an API key and its associated configuration for a provider.
 // It contains the key value, supported models, and a weight for load balancing.
 type Key struct {
-	ID                 string              `json:"id"`                             // The unique identifier for the key (used by bifrost to identify the key)
-	Name               string              `json:"name"`                           // The name of the key (used by users to identify the key, not used by bifrost)
-	Value              EnvVar              `json:"value"`                          // The actual API key value
-	Models             WhiteList           `json:"models"`                         // List of models this key can access
-	BlacklistedModels  BlackList           `json:"blacklisted_models"`             // List of models this key cannot access
-	Weight             float64             `json:"weight"`                         // Weight for load balancing between multiple keys
-	Aliases            KeyAliases          `json:"aliases,omitempty"`              // Mapping of model identifiers to inference profiles
-	AzureKeyConfig     *AzureKeyConfig     `json:"azure_key_config,omitempty"`     // Azure-specific key configuration
-	VertexKeyConfig    *VertexKeyConfig    `json:"vertex_key_config,omitempty"`    // Vertex-specific key configuration
-	BedrockKeyConfig   *BedrockKeyConfig   `json:"bedrock_key_config,omitempty"`   // AWS Bedrock-specific key configuration
-	VLLMKeyConfig      *VLLMKeyConfig      `json:"vllm_key_config,omitempty"`      // vLLM-specific key configuration
-	ReplicateKeyConfig *ReplicateKeyConfig `json:"replicate_key_config,omitempty"` // Replicate-specific key configuration
-	OllamaKeyConfig    *OllamaKeyConfig    `json:"ollama_key_config,omitempty"`    // Ollama-specific key configuration
-	SGLKeyConfig       *SGLKeyConfig       `json:"sgl_key_config,omitempty"`       // SGLang-specific key configuration
-	Enabled            *bool               `json:"enabled,omitempty"`              // Whether the key is active (default:true)
-	UseForBatchAPI     *bool               `json:"use_for_batch_api,omitempty"`    // Whether this key can be used for batch API operations (default:false for new keys, migrated keys default to true)
-	ConfigHash         string              `json:"config_hash,omitempty"`          // Hash of config.json version, used for change detection
-	Status             KeyStatusType       `json:"status,omitempty"`               // Status of key
-	Description        string              `json:"description,omitempty"`          // Description of key
+	ID                      string              `json:"id"`                             // The unique identifier for the key (used by bifrost to identify the key)
+	Name                    string              `json:"name"`                           // The name of the key (used by users to identify the key, not used by bifrost)
+	Value                   EnvVar              `json:"value"`                          // The actual API key value
+	Models                  WhiteList           `json:"models"`                         // List of models this key can access
+	BlacklistedModels       BlackList           `json:"blacklisted_models"`             // List of models this key cannot access
+	Weight                  float64             `json:"weight"`                         // Weight for load balancing between multiple keys
+	Aliases                 KeyAliases          `json:"aliases,omitempty"`              // Mapping of model identifiers to inference profiles
+	AzureKeyConfig          *AzureKeyConfig     `json:"azure_key_config,omitempty"`     // Azure-specific key configuration
+	VertexKeyConfig         *VertexKeyConfig    `json:"vertex_key_config,omitempty"`    // Vertex-specific key configuration
+	BedrockKeyConfig        *BedrockKeyConfig   `json:"bedrock_key_config,omitempty"`   // AWS Bedrock-specific key configuration
+	VLLMKeyConfig           *VLLMKeyConfig      `json:"vllm_key_config,omitempty"`      // vLLM-specific key configuration
+	ReplicateKeyConfig      *ReplicateKeyConfig `json:"replicate_key_config,omitempty"` // Replicate-specific key configuration
+	OllamaKeyConfig         *OllamaKeyConfig    `json:"ollama_key_config,omitempty"`    // Ollama-specific key configuration
+	SGLKeyConfig            *SGLKeyConfig       `json:"sgl_key_config,omitempty"`       // SGLang-specific key configuration
+	Enabled                 *bool               `json:"enabled,omitempty"`              // Whether the key is active (default:true)
+	UseForBatchAPI          *bool               `json:"use_for_batch_api,omitempty"`    // Whether this key can be used for batch API operations (default:false for new keys, migrated keys default to true)
+	RequestTimeoutInSeconds *int                `json:"request_timeout_in_seconds"`     // Optional request timeout override for this provider key
+	ConfigHash              string              `json:"config_hash,omitempty"`          // Hash of config.json version, used for change detection
+	Status                  KeyStatusType       `json:"status,omitempty"`               // Status of key
+	Description             string              `json:"description,omitempty"`          // Description of key
 }
 
 type KeyAliases map[string]string

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -839,13 +839,15 @@ func TestResponsesTool_RoundTrip_AnthropicFields(t *testing.T) {
 // forward stray fields from a different shape.
 func TestChatTool_MarshalJSON_EnforcesUnion(t *testing.T) {
 	t.Run("function_type_clears_custom_and_server_tool_fields", func(t *testing.T) {
+		maxUses := 5
+
 		tool := ChatTool{
 			Type:     ChatToolTypeFunction,
 			Function: &ChatToolFunction{Name: "get_weather"},
 			// Mixed state: server-tool + custom fields also populated.
 			Custom:         &ChatToolCustom{},
 			Name:           "leaked_name",
-			MaxUses:        Ptr(5),
+			MaxUses:        &maxUses,
 			DisplayWidthPx: Ptr(1280),
 			MCPServerName:  "leaked_server",
 		}
@@ -861,13 +863,15 @@ func TestChatTool_MarshalJSON_EnforcesUnion(t *testing.T) {
 	})
 
 	t.Run("custom_type_clears_function_and_server_tool_fields", func(t *testing.T) {
+		maxUses := 5
+
 		tool := ChatTool{
 			Type:   ChatToolTypeCustom,
 			Custom: &ChatToolCustom{Format: &ChatToolCustomFormat{Type: "text"}},
 			Name:   "my_custom",
 			// Leaks
 			Function: &ChatToolFunction{Name: "should_be_stripped"},
-			MaxUses:  Ptr(5),
+			MaxUses:  &maxUses,
 		}
 		data, err := Marshal(tool)
 		require.NoError(t, err)
@@ -882,10 +886,12 @@ func TestChatTool_MarshalJSON_EnforcesUnion(t *testing.T) {
 	})
 
 	t.Run("server_tool_type_clears_function_and_custom", func(t *testing.T) {
+		maxUses := 5
+
 		tool := ChatTool{
 			Type:           "web_search_20260209",
 			Name:           "web_search",
-			MaxUses:        Ptr(5),
+			MaxUses:        &maxUses,
 			AllowedCallers: []string{"direct"},
 			// Leaks
 			Function: &ChatToolFunction{Name: "should_be_stripped"},

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -843,11 +843,11 @@ func TestChatTool_MarshalJSON_EnforcesUnion(t *testing.T) {
 			Type:     ChatToolTypeFunction,
 			Function: &ChatToolFunction{Name: "get_weather"},
 			// Mixed state: server-tool + custom fields also populated.
-			Custom:        &ChatToolCustom{},
-			Name:          "leaked_name",
-			MaxUses:       Ptr(5),
+			Custom:         &ChatToolCustom{},
+			Name:           "leaked_name",
+			MaxUses:        Ptr(5),
 			DisplayWidthPx: Ptr(1280),
-			MCPServerName: "leaked_server",
+			MCPServerName:  "leaked_server",
 		}
 		data, err := Marshal(tool)
 		require.NoError(t, err)
@@ -874,8 +874,8 @@ func TestChatTool_MarshalJSON_EnforcesUnion(t *testing.T) {
 		raw := string(data)
 
 		assert.Contains(t, raw, `"type":"custom"`)
-		assert.Contains(t, raw, `"my_custom"`)    // custom tool retains top-level Name
-		assert.Contains(t, raw, `"format"`)       // custom's format field
+		assert.Contains(t, raw, `"my_custom"`) // custom tool retains top-level Name
+		assert.Contains(t, raw, `"format"`)    // custom's format field
 		assert.NotContains(t, raw, `"function"`)
 		assert.NotContains(t, raw, `"should_be_stripped"`)
 		assert.NotContains(t, raw, `"max_uses"`)
@@ -883,9 +883,9 @@ func TestChatTool_MarshalJSON_EnforcesUnion(t *testing.T) {
 
 	t.Run("server_tool_type_clears_function_and_custom", func(t *testing.T) {
 		tool := ChatTool{
-			Type:    "web_search_20260209",
-			Name:    "web_search",
-			MaxUses: Ptr(5),
+			Type:           "web_search_20260209",
+			Name:           "web_search",
+			MaxUses:        Ptr(5),
 			AllowedCallers: []string{"direct"},
 			// Leaks
 			Function: &ChatToolFunction{Name: "should_be_stripped"},
@@ -1353,4 +1353,11 @@ func TestSonic_ChatTool_DeepCopy_NilAnnotationsStaysNil(t *testing.T) {
 	copied := DeepCopyChatTool(original)
 
 	assert.Nil(t, copied.Annotations, "Annotations should stay nil when original has none")
+}
+
+func TestSonic_Key_NilRequestTimeoutSerializesAsNull(t *testing.T) {
+	key := Key{}
+	output, err := Marshal(key)
+	require.NoError(t, err)
+	assert.Contains(t, string(output), `"request_timeout_in_seconds":null`)
 }

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -451,12 +451,13 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			blacklistedModels = []string{} // Match models: empty JSON array, not null
 		}
 		redactedConfig.Keys[i] = schemas.Key{
-			ID:                key.ID,
-			Name:              key.Name,
-			Models:            models,
-			BlacklistedModels: blacklistedModels,
-			Weight:            key.Weight,
-			ConfigHash:        key.ConfigHash,
+			ID:                      key.ID,
+			Name:                    key.Name,
+			Models:                  models,
+			BlacklistedModels:       blacklistedModels,
+			Weight:                  key.Weight,
+			RequestTimeoutInSeconds: key.RequestTimeoutInSeconds,
+			ConfigHash:              key.ConfigHash,
 		}
 		if key.Enabled != nil {
 			enabled := *key.Enabled
@@ -760,6 +761,14 @@ func GenerateKeyHash(key schemas.Key) (string, error) {
 	}
 	if useForBatchAPI {
 		hash.Write([]byte("useForBatchAPI:true"))
+	}
+	if key.RequestTimeoutInSeconds != nil {
+		data, err := sonic.Marshal(key.RequestTimeoutInSeconds)
+		if err != nil {
+			return "", err
+		}
+		hash.Write([]byte("requestTimeoutInSeconds:"))
+		hash.Write(data)
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }

--- a/framework/configstore/clientconfig_redaction_test.go
+++ b/framework/configstore/clientconfig_redaction_test.go
@@ -158,6 +158,24 @@ func TestProviderConfig_Redacted_DoesNotMutateOriginal(t *testing.T) {
 		"Redacted() or MarshalJSON mutated the original key Value")
 }
 
+func TestProviderConfig_Redacted_PreservesRequestTimeoutOverride(t *testing.T) {
+	timeout := 45
+	config := ProviderConfig{
+		Keys: []schemas.Key{{
+			ID:                      "k1",
+			Name:                    "test",
+			Value:                   *schemas.NewEnvVar("sk-test"),
+			RequestTimeoutInSeconds: &timeout,
+		}},
+	}
+
+	redacted := config.Redacted()
+	require.NotNil(t, redacted)
+	require.Len(t, redacted.Keys, 1)
+	require.NotNil(t, redacted.Keys[0].RequestTimeoutInSeconds)
+	assert.Equal(t, 45, *redacted.Keys[0].RequestTimeoutInSeconds)
+}
+
 // TestProviderConfig_Redacted_FullJSONHasNoLeakedEnvSecrets is a high-level smoke
 // test: build a config containing env-backed values across multiple provider types
 // and assert that no resolved secret string appears anywhere in the marshaled

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -710,6 +710,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationDropAllowDirectKeysColumnDDL(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddKeyRequestTimeoutColumn(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -7523,6 +7526,33 @@ func migrationUniqueTeamNames(ctx context.Context, db *gorm.DB) error {
 		},
 		Rollback: func(tx *gorm.DB) error {
 			_ = tx.Migrator().DropIndex(&tables.TableTeam{}, "idx_governance_teams_name")
+			return nil
+		},
+	})
+}
+
+// migrationAddKeyRequestTimeoutColumn adds an optional per-provider-key request timeout override.
+func migrationAddKeyRequestTimeoutColumn(ctx context.Context, db *gorm.DB) error {
+	return RunSingleMigration(ctx, db, &migrator.Migration{
+		ID: "add_key_request_timeout_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TableKey{}, "request_timeout_in_seconds") {
+				if err := mg.AddColumn(&tables.TableKey{}, "RequestTimeoutInSeconds"); err != nil {
+					return fmt.Errorf("failed to add request_timeout_in_seconds column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasColumn(&tables.TableKey{}, "request_timeout_in_seconds") {
+				if err := mg.DropColumn(&tables.TableKey{}, "request_timeout_in_seconds"); err != nil {
+					return fmt.Errorf("failed to drop request_timeout_in_seconds column: %w", err)
+				}
+			}
 			return nil
 		},
 	})

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -1163,6 +1163,7 @@ func TestTriggerMigrations_FreshDB(t *testing.T) {
 	for _, table := range criticalTables {
 		assert.True(t, migrator.HasTable(table), "table should exist: %T", table)
 	}
+	assert.True(t, migrator.HasColumn(&tables.TableKey{}, "request_timeout_in_seconds"), "TableKey should include request_timeout_in_seconds")
 }
 
 func TestTriggerMigrations_Idempotent(t *testing.T) {
@@ -1184,6 +1185,7 @@ func TestTriggerMigrations_Idempotent(t *testing.T) {
 	// Tables should still be intact
 	assert.True(t, db.Migrator().HasTable(&tables.TableProvider{}), "TableProvider should still exist")
 	assert.True(t, db.Migrator().HasTable(&tables.TableKey{}), "TableKey should still exist")
+	assert.True(t, db.Migrator().HasColumn(&tables.TableKey{}, "request_timeout_in_seconds"), "TableKey request_timeout_in_seconds should still exist")
 	assert.True(t, db.Migrator().HasTable(&tables.TableVirtualKey{}), "TableVirtualKey should still exist")
 }
 

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -123,52 +123,54 @@ func toolSyncIntervalDurationToStoredSeconds(interval time.Duration) (int, error
 // schemaKeyFromTableKey converts a database key to a schema key.
 func schemaKeyFromTableKey(dbKey tables.TableKey) schemas.Key {
 	return schemas.Key{
-		ID:                 dbKey.KeyID,
-		Name:               dbKey.Name,
-		Value:              dbKey.Value,
-		Models:             dbKey.Models,
-		BlacklistedModels:  dbKey.BlacklistedModels,
-		Weight:             getWeight(dbKey.Weight),
-		Enabled:            dbKey.Enabled,
-		UseForBatchAPI:     dbKey.UseForBatchAPI,
-		AzureKeyConfig:     dbKey.AzureKeyConfig,
-		VertexKeyConfig:    dbKey.VertexKeyConfig,
-		BedrockKeyConfig:   dbKey.BedrockKeyConfig,
-		Aliases:            dbKey.Aliases,
-		VLLMKeyConfig:      dbKey.VLLMKeyConfig,
-		ReplicateKeyConfig: dbKey.ReplicateKeyConfig,
-		OllamaKeyConfig:    dbKey.OllamaKeyConfig,
-		SGLKeyConfig:       dbKey.SGLKeyConfig,
-		ConfigHash:         dbKey.ConfigHash,
-		Status:             schemas.KeyStatusType(dbKey.Status),
-		Description:        dbKey.Description,
+		ID:                      dbKey.KeyID,
+		Name:                    dbKey.Name,
+		Value:                   dbKey.Value,
+		Models:                  dbKey.Models,
+		BlacklistedModels:       dbKey.BlacklistedModels,
+		Weight:                  getWeight(dbKey.Weight),
+		Enabled:                 dbKey.Enabled,
+		UseForBatchAPI:          dbKey.UseForBatchAPI,
+		AzureKeyConfig:          dbKey.AzureKeyConfig,
+		VertexKeyConfig:         dbKey.VertexKeyConfig,
+		BedrockKeyConfig:        dbKey.BedrockKeyConfig,
+		Aliases:                 dbKey.Aliases,
+		VLLMKeyConfig:           dbKey.VLLMKeyConfig,
+		ReplicateKeyConfig:      dbKey.ReplicateKeyConfig,
+		OllamaKeyConfig:         dbKey.OllamaKeyConfig,
+		SGLKeyConfig:            dbKey.SGLKeyConfig,
+		RequestTimeoutInSeconds: dbKey.RequestTimeoutInSeconds,
+		ConfigHash:              dbKey.ConfigHash,
+		Status:                  schemas.KeyStatusType(dbKey.Status),
+		Description:             dbKey.Description,
 	}
 }
 
 // tableKeyFromSchemaKey converts a schema key to a database key.
 func tableKeyFromSchemaKey(provider tables.TableProvider, key schemas.Key) (tables.TableKey, error) {
 	dbKey := tables.TableKey{
-		Provider:           provider.Name,
-		ProviderID:         provider.ID,
-		KeyID:              key.ID,
-		Name:               key.Name,
-		Value:              key.Value,
-		Models:             key.Models,
-		BlacklistedModels:  key.BlacklistedModels,
-		Weight:             &key.Weight,
-		Enabled:            key.Enabled,
-		UseForBatchAPI:     key.UseForBatchAPI,
-		AzureKeyConfig:     key.AzureKeyConfig,
-		VertexKeyConfig:    key.VertexKeyConfig,
-		BedrockKeyConfig:   key.BedrockKeyConfig,
-		Aliases:            key.Aliases,
-		VLLMKeyConfig:      key.VLLMKeyConfig,
-		ReplicateKeyConfig: key.ReplicateKeyConfig,
-		OllamaKeyConfig:    key.OllamaKeyConfig,
-		SGLKeyConfig:       key.SGLKeyConfig,
-		ConfigHash:         key.ConfigHash,
-		Status:             string(key.Status),
-		Description:        key.Description,
+		Provider:                provider.Name,
+		ProviderID:              provider.ID,
+		KeyID:                   key.ID,
+		Name:                    key.Name,
+		Value:                   key.Value,
+		Models:                  key.Models,
+		BlacklistedModels:       key.BlacklistedModels,
+		Weight:                  &key.Weight,
+		Enabled:                 key.Enabled,
+		UseForBatchAPI:          key.UseForBatchAPI,
+		AzureKeyConfig:          key.AzureKeyConfig,
+		VertexKeyConfig:         key.VertexKeyConfig,
+		BedrockKeyConfig:        key.BedrockKeyConfig,
+		Aliases:                 key.Aliases,
+		VLLMKeyConfig:           key.VLLMKeyConfig,
+		ReplicateKeyConfig:      key.ReplicateKeyConfig,
+		OllamaKeyConfig:         key.OllamaKeyConfig,
+		SGLKeyConfig:            key.SGLKeyConfig,
+		RequestTimeoutInSeconds: key.RequestTimeoutInSeconds,
+		ConfigHash:              key.ConfigHash,
+		Status:                  string(key.Status),
+		Description:             key.Description,
 	}
 
 	if key.AzureKeyConfig != nil {
@@ -550,27 +552,28 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 				}
 			}
 			dbKey := tables.TableKey{
-				Provider:           dbProvider.Name,
-				ProviderID:         dbProvider.ID,
-				KeyID:              key.ID,
-				Name:               key.Name,
-				Value:              key.Value,
-				Models:             key.Models,
-				BlacklistedModels:  key.BlacklistedModels,
-				Weight:             &key.Weight,
-				Enabled:            key.Enabled,
-				UseForBatchAPI:     key.UseForBatchAPI,
-				AzureKeyConfig:     key.AzureKeyConfig,
-				VertexKeyConfig:    key.VertexKeyConfig,
-				BedrockKeyConfig:   key.BedrockKeyConfig,
-				Aliases:            key.Aliases,
-				VLLMKeyConfig:      key.VLLMKeyConfig,
-				ReplicateKeyConfig: key.ReplicateKeyConfig,
-				OllamaKeyConfig:    key.OllamaKeyConfig,
-				SGLKeyConfig:       key.SGLKeyConfig,
-				ConfigHash:         keyHash,
-				Status:             string(key.Status),
-				Description:        key.Description,
+				Provider:                dbProvider.Name,
+				ProviderID:              dbProvider.ID,
+				KeyID:                   key.ID,
+				Name:                    key.Name,
+				Value:                   key.Value,
+				Models:                  key.Models,
+				BlacklistedModels:       key.BlacklistedModels,
+				Weight:                  &key.Weight,
+				Enabled:                 key.Enabled,
+				UseForBatchAPI:          key.UseForBatchAPI,
+				AzureKeyConfig:          key.AzureKeyConfig,
+				VertexKeyConfig:         key.VertexKeyConfig,
+				BedrockKeyConfig:        key.BedrockKeyConfig,
+				Aliases:                 key.Aliases,
+				VLLMKeyConfig:           key.VLLMKeyConfig,
+				ReplicateKeyConfig:      key.ReplicateKeyConfig,
+				OllamaKeyConfig:         key.OllamaKeyConfig,
+				SGLKeyConfig:            key.SGLKeyConfig,
+				RequestTimeoutInSeconds: key.RequestTimeoutInSeconds,
+				ConfigHash:              keyHash,
+				Status:                  string(key.Status),
+				Description:             key.Description,
 			}
 
 			// Handle Azure config
@@ -779,27 +782,28 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 			return fmt.Errorf("failed to generate key hash: %w", err)
 		}
 		dbKey := tables.TableKey{
-			Provider:           dbProvider.Name,
-			ProviderID:         dbProvider.ID,
-			KeyID:              key.ID,
-			Name:               key.Name,
-			Value:              key.Value,
-			Models:             key.Models,
-			BlacklistedModels:  key.BlacklistedModels,
-			Weight:             &key.Weight,
-			Enabled:            key.Enabled,
-			UseForBatchAPI:     key.UseForBatchAPI,
-			AzureKeyConfig:     key.AzureKeyConfig,
-			VertexKeyConfig:    key.VertexKeyConfig,
-			BedrockKeyConfig:   key.BedrockKeyConfig,
-			Aliases:            key.Aliases,
-			VLLMKeyConfig:      key.VLLMKeyConfig,
-			ReplicateKeyConfig: key.ReplicateKeyConfig,
-			OllamaKeyConfig:    key.OllamaKeyConfig,
-			SGLKeyConfig:       key.SGLKeyConfig,
-			ConfigHash:         keyHash,
-			Status:             string(key.Status),
-			Description:        key.Description,
+			Provider:                dbProvider.Name,
+			ProviderID:              dbProvider.ID,
+			KeyID:                   key.ID,
+			Name:                    key.Name,
+			Value:                   key.Value,
+			Models:                  key.Models,
+			BlacklistedModels:       key.BlacklistedModels,
+			Weight:                  &key.Weight,
+			Enabled:                 key.Enabled,
+			UseForBatchAPI:          key.UseForBatchAPI,
+			AzureKeyConfig:          key.AzureKeyConfig,
+			VertexKeyConfig:         key.VertexKeyConfig,
+			BedrockKeyConfig:        key.BedrockKeyConfig,
+			Aliases:                 key.Aliases,
+			VLLMKeyConfig:           key.VLLMKeyConfig,
+			ReplicateKeyConfig:      key.ReplicateKeyConfig,
+			OllamaKeyConfig:         key.OllamaKeyConfig,
+			SGLKeyConfig:            key.SGLKeyConfig,
+			RequestTimeoutInSeconds: key.RequestTimeoutInSeconds,
+			ConfigHash:              keyHash,
+			Status:                  string(key.Status),
+			Description:             key.Description,
 		}
 
 		// Handle Azure config
@@ -919,27 +923,28 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 	// Create keys for this provider
 	for _, key := range configCopy.Keys {
 		dbKey := tables.TableKey{
-			Provider:           dbProvider.Name,
-			ProviderID:         dbProvider.ID,
-			KeyID:              key.ID,
-			Name:               key.Name,
-			Value:              key.Value,
-			Models:             key.Models,
-			BlacklistedModels:  key.BlacklistedModels,
-			Weight:             &key.Weight,
-			Enabled:            key.Enabled,
-			UseForBatchAPI:     key.UseForBatchAPI,
-			AzureKeyConfig:     key.AzureKeyConfig,
-			VertexKeyConfig:    key.VertexKeyConfig,
-			BedrockKeyConfig:   key.BedrockKeyConfig,
-			Aliases:            key.Aliases,
-			VLLMKeyConfig:      key.VLLMKeyConfig,
-			ReplicateKeyConfig: key.ReplicateKeyConfig,
-			OllamaKeyConfig:    key.OllamaKeyConfig,
-			SGLKeyConfig:       key.SGLKeyConfig,
-			ConfigHash:         key.ConfigHash,
-			Status:             string(key.Status),
-			Description:        key.Description,
+			Provider:                dbProvider.Name,
+			ProviderID:              dbProvider.ID,
+			KeyID:                   key.ID,
+			Name:                    key.Name,
+			Value:                   key.Value,
+			Models:                  key.Models,
+			BlacklistedModels:       key.BlacklistedModels,
+			Weight:                  &key.Weight,
+			Enabled:                 key.Enabled,
+			UseForBatchAPI:          key.UseForBatchAPI,
+			AzureKeyConfig:          key.AzureKeyConfig,
+			VertexKeyConfig:         key.VertexKeyConfig,
+			BedrockKeyConfig:        key.BedrockKeyConfig,
+			Aliases:                 key.Aliases,
+			VLLMKeyConfig:           key.VLLMKeyConfig,
+			ReplicateKeyConfig:      key.ReplicateKeyConfig,
+			OllamaKeyConfig:         key.OllamaKeyConfig,
+			SGLKeyConfig:            key.SGLKeyConfig,
+			RequestTimeoutInSeconds: key.RequestTimeoutInSeconds,
+			ConfigHash:              key.ConfigHash,
+			Status:                  string(key.Status),
+			Description:             key.Description,
 		}
 		// Handle Azure config
 		if key.AzureKeyConfig != nil {
@@ -2490,12 +2495,12 @@ func (s *RDBConfigStore) GetKeysByProvider(ctx context.Context, provider string)
 func (s *RDBConfigStore) GetAllRedactedKeys(ctx context.Context, ids []string) ([]schemas.Key, error) {
 	var keys []tables.TableKey
 	if len(ids) > 0 {
-		err := s.DB().WithContext(ctx).Select("id, key_id, name, models_json, blacklisted_models_json, weight").Where("key_id IN ?", ids).Find(&keys).Error
+		err := s.DB().WithContext(ctx).Select("id, key_id, name, models_json, blacklisted_models_json, weight, request_timeout_in_seconds").Where("key_id IN ?", ids).Find(&keys).Error
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		err := s.DB().WithContext(ctx).Select("id, key_id, name, models_json, blacklisted_models_json, weight").Find(&keys).Error
+		err := s.DB().WithContext(ctx).Select("id, key_id, name, models_json, blacklisted_models_json, weight, request_timeout_in_seconds").Find(&keys).Error
 		if err != nil {
 			return nil, err
 		}
@@ -2511,11 +2516,12 @@ func (s *RDBConfigStore) GetAllRedactedKeys(ctx context.Context, ids []string) (
 			blacklisted = []string{}
 		}
 		redactedKeys[i] = schemas.Key{
-			ID:                key.KeyID,
-			Name:              key.Name,
-			Models:            models,
-			BlacklistedModels: blacklisted,
-			Weight:            getWeight(key.Weight),
+			ID:                      key.KeyID,
+			Name:                    key.Name,
+			Models:                  models,
+			BlacklistedModels:       blacklisted,
+			Weight:                  getWeight(key.Weight),
+			RequestTimeoutInSeconds: key.RequestTimeoutInSeconds,
 		}
 	}
 	return redactedKeys, nil

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -240,9 +240,40 @@ func TestProviderKeyCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, storedKey)
 	assert.Equal(t, "sk-test-key-v1", storedKey.Value.Val)
+	assert.Nil(t, storedKey.RequestTimeoutInSeconds)
+
+	timeout := 45
+	keyWithTimeout := schemas.Key{
+		ID:                      "key-uuid-2",
+		Name:                    "openai-timeout",
+		Value:                   *schemas.NewEnvVar("sk-test-key-timeout"),
+		Weight:                  1.0,
+		RequestTimeoutInSeconds: &timeout,
+	}
+
+	err = store.CreateProviderKey(ctx, "openai", keyWithTimeout)
+	require.NoError(t, err)
+
+	storedKeyWithTimeout, err := store.GetProviderKey(ctx, "openai", keyWithTimeout.ID)
+	require.NoError(t, err)
+	require.NotNil(t, storedKeyWithTimeout)
+	require.NotNil(t, storedKeyWithTimeout.RequestTimeoutInSeconds)
+	assert.Equal(t, 45, *storedKeyWithTimeout.RequestTimeoutInSeconds)
+
+	invalidTimeout := 0
+	err = store.CreateProviderKey(ctx, "openai", schemas.Key{
+		ID:                      "key-uuid-invalid-timeout",
+		Name:                    "openai-invalid-timeout",
+		Value:                   *schemas.NewEnvVar("sk-test-key-invalid-timeout"),
+		Weight:                  1.0,
+		RequestTimeoutInSeconds: &invalidTimeout,
+	})
+	require.Error(t, err)
 
 	key.Value = *schemas.NewEnvVar("sk-test-key-v2")
 	key.Weight = 2.0
+	updatedTimeout := 60
+	key.RequestTimeoutInSeconds = &updatedTimeout
 
 	err = store.UpdateProviderKey(ctx, "openai", key.ID, key)
 	require.NoError(t, err)
@@ -252,6 +283,20 @@ func TestProviderKeyCRUD(t *testing.T) {
 	require.NotNil(t, storedKey)
 	assert.Equal(t, "sk-test-key-v2", storedKey.Value.Val)
 	assert.Equal(t, 2.0, storedKey.Weight)
+	require.NotNil(t, storedKey.RequestTimeoutInSeconds)
+	assert.Equal(t, 60, *storedKey.RequestTimeoutInSeconds)
+
+	key.RequestTimeoutInSeconds = nil
+	err = store.UpdateProviderKey(ctx, "openai", key.ID, key)
+	require.NoError(t, err)
+
+	storedKey, err = store.GetProviderKey(ctx, "openai", key.ID)
+	require.NoError(t, err)
+	require.NotNil(t, storedKey)
+	assert.Nil(t, storedKey.RequestTimeoutInSeconds)
+
+	err = store.DeleteProviderKey(ctx, "openai", keyWithTimeout.ID)
+	require.NoError(t, err)
 
 	err = store.DeleteProviderKey(ctx, "openai", key.ID)
 	require.NoError(t, err)

--- a/framework/configstore/tables/key.go
+++ b/framework/configstore/tables/key.go
@@ -73,6 +73,8 @@ type TableKey struct {
 	// Batch API configuration
 	UseForBatchAPI *bool `gorm:"default:false" json:"use_for_batch_api,omitempty"` // Whether this key can be used for batch API operations
 
+	RequestTimeoutInSeconds *int `gorm:"column:request_timeout_in_seconds" json:"request_timeout_in_seconds"` // Optional request timeout override for this provider key
+
 	Status      string `gorm:"type:varchar(50);default:'unknown'" json:"status"`
 	Description string `gorm:"type:text" json:"description,omitempty"`
 
@@ -123,6 +125,9 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 	if k.UseForBatchAPI == nil {
 		useForBatchAPI := false // DB default
 		k.UseForBatchAPI = &useForBatchAPI
+	}
+	if k.RequestTimeoutInSeconds != nil && *k.RequestTimeoutInSeconds < 1 {
+		return fmt.Errorf("request_timeout_in_seconds must be at least 1")
 	}
 	// IMPORTANT: All *EnvVar fields assigned from provider config structs (AzureKeyConfig,
 	// VertexKeyConfig, BedrockKeyConfig) MUST be value-copied before assignment. The caller

--- a/transports/bifrost-http/handlers/provider_keys.go
+++ b/transports/bifrost-http/handlers/provider_keys.go
@@ -108,6 +108,11 @@ func (h *ProviderHandler) createProviderKey(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	if err := validateProviderKeyRequestTimeout(key); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
+		return
+	}
+
 	if err := key.BlacklistedModels.Validate(); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid blacklisted_models: %v", err))
 		return
@@ -226,6 +231,11 @@ func (h *ProviderHandler) updateProviderKey(ctx *fasthttp.RequestCtx) {
 
 	if err := mergedKey.Aliases.Validate(); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid aliases: %v", err))
+		return
+	}
+
+	if err := validateProviderKeyRequestTimeout(mergedKey); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -490,6 +500,13 @@ func validateProviderKeyURL(provider schemas.ModelProvider, key schemas.Key) err
 		if key.SGLKeyConfig == nil || !key.SGLKeyConfig.URL.IsSet() {
 			return fmt.Errorf("sgl_key_config.url is required for SGL keys")
 		}
+	}
+	return nil
+}
+
+func validateProviderKeyRequestTimeout(key schemas.Key) error {
+	if key.RequestTimeoutInSeconds != nil && *key.RequestTimeoutInSeconds < 1 {
+		return fmt.Errorf("request_timeout_in_seconds must be at least 1")
 	}
 	return nil
 }

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -164,6 +164,24 @@ func boolPtr(v bool) *bool {
 	return &v
 }
 
+func intPtr(v int) *int {
+	return &v
+}
+
+func TestValidateProviderKeyRequestTimeout(t *testing.T) {
+	if err := validateProviderKeyRequestTimeout(schemas.Key{}); err != nil {
+		t.Fatalf("expected nil timeout to be valid, got %v", err)
+	}
+
+	if err := validateProviderKeyRequestTimeout(schemas.Key{RequestTimeoutInSeconds: intPtr(1)}); err != nil {
+		t.Fatalf("expected positive timeout to be valid, got %v", err)
+	}
+
+	if err := validateProviderKeyRequestTimeout(schemas.Key{RequestTimeoutInSeconds: intPtr(0)}); err == nil {
+		t.Fatalf("expected zero timeout to be invalid")
+	}
+}
+
 func TestListModels_UnknownKeysDoNotFilter(t *testing.T) {
 	SetLogger(&mockLogger{})
 

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -965,21 +965,22 @@ func mergeProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []schema
 			} else {
 				// No stored hash (legacy) - fall back to generating fresh hash
 				dbKeyHash, err := configstore.GenerateKeyHash(schemas.Key{
-					Name:               dbKey.Name,
-					Value:              dbKey.Value,
-					Models:             dbKey.Models,
-					BlacklistedModels:  dbKey.BlacklistedModels,
-					Weight:             dbKey.Weight,
-					AzureKeyConfig:     dbKey.AzureKeyConfig,
-					VertexKeyConfig:    dbKey.VertexKeyConfig,
-					BedrockKeyConfig:   dbKey.BedrockKeyConfig,
-					ReplicateKeyConfig: dbKey.ReplicateKeyConfig,
-					Aliases:            dbKey.Aliases,
-					VLLMKeyConfig:      dbKey.VLLMKeyConfig,
-					OllamaKeyConfig:    dbKey.OllamaKeyConfig,
-					SGLKeyConfig:       dbKey.SGLKeyConfig,
-					Enabled:            dbKey.Enabled,
-					UseForBatchAPI:     dbKey.UseForBatchAPI,
+					Name:                    dbKey.Name,
+					Value:                   dbKey.Value,
+					Models:                  dbKey.Models,
+					BlacklistedModels:       dbKey.BlacklistedModels,
+					Weight:                  dbKey.Weight,
+					AzureKeyConfig:          dbKey.AzureKeyConfig,
+					VertexKeyConfig:         dbKey.VertexKeyConfig,
+					BedrockKeyConfig:        dbKey.BedrockKeyConfig,
+					ReplicateKeyConfig:      dbKey.ReplicateKeyConfig,
+					Aliases:                 dbKey.Aliases,
+					VLLMKeyConfig:           dbKey.VLLMKeyConfig,
+					OllamaKeyConfig:         dbKey.OllamaKeyConfig,
+					SGLKeyConfig:            dbKey.SGLKeyConfig,
+					Enabled:                 dbKey.Enabled,
+					UseForBatchAPI:          dbKey.UseForBatchAPI,
+					RequestTimeoutInSeconds: dbKey.RequestTimeoutInSeconds,
 				})
 				if err != nil {
 					logger.Warn("failed to generate key hash for db key %s (%s): %v, falling back to name comparison", dbKey.Name, provider, err)
@@ -1046,21 +1047,22 @@ func reconcileProviderKeys(provider schemas.ModelProvider, fileKeys, dbKeys []sc
 			} else {
 				// No stored hash (legacy) - fall back to generating fresh hash for comparison
 				dbKeyHash, err := configstore.GenerateKeyHash(schemas.Key{
-					Name:               dbKey.Name,
-					Value:              dbKey.Value,
-					Models:             dbKey.Models,
-					BlacklistedModels:  dbKey.BlacklistedModels,
-					Weight:             dbKey.Weight,
-					AzureKeyConfig:     dbKey.AzureKeyConfig,
-					VertexKeyConfig:    dbKey.VertexKeyConfig,
-					BedrockKeyConfig:   dbKey.BedrockKeyConfig,
-					ReplicateKeyConfig: dbKey.ReplicateKeyConfig,
-					Aliases:            dbKey.Aliases,
-					VLLMKeyConfig:      dbKey.VLLMKeyConfig,
-					OllamaKeyConfig:    dbKey.OllamaKeyConfig,
-					SGLKeyConfig:       dbKey.SGLKeyConfig,
-					Enabled:            dbKey.Enabled,
-					UseForBatchAPI:     dbKey.UseForBatchAPI,
+					Name:                    dbKey.Name,
+					Value:                   dbKey.Value,
+					Models:                  dbKey.Models,
+					BlacklistedModels:       dbKey.BlacklistedModels,
+					Weight:                  dbKey.Weight,
+					AzureKeyConfig:          dbKey.AzureKeyConfig,
+					VertexKeyConfig:         dbKey.VertexKeyConfig,
+					BedrockKeyConfig:        dbKey.BedrockKeyConfig,
+					ReplicateKeyConfig:      dbKey.ReplicateKeyConfig,
+					Aliases:                 dbKey.Aliases,
+					VLLMKeyConfig:           dbKey.VLLMKeyConfig,
+					OllamaKeyConfig:         dbKey.OllamaKeyConfig,
+					SGLKeyConfig:            dbKey.SGLKeyConfig,
+					Enabled:                 dbKey.Enabled,
+					UseForBatchAPI:          dbKey.UseForBatchAPI,
+					RequestTimeoutInSeconds: dbKey.RequestTimeoutInSeconds,
 				})
 				if err != nil {
 					logger.Warn("failed to generate key hash for db key %s (%s): %v", dbKey.Name, provider, err)
@@ -4416,14 +4418,15 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 				blacklisted = []string{}
 			}
 			configStoreKey := configstoreTables.TableKey{
-				KeyID:             key.ID,
-				Name:              key.Name,
-				Value:             *key.Value.Redacted(),
-				Models:            models,
-				BlacklistedModels: blacklisted,
-				Weight:            bifrost.Ptr(key.Weight),
-				Provider:          string(providerKey),
-				ConfigHash:        key.ConfigHash,
+				KeyID:                   key.ID,
+				Name:                    key.Name,
+				Value:                   *key.Value.Redacted(),
+				Models:                  models,
+				BlacklistedModels:       blacklisted,
+				Weight:                  bifrost.Ptr(key.Weight),
+				Provider:                string(providerKey),
+				RequestTimeoutInSeconds: key.RequestTimeoutInSeconds,
+				ConfigHash:              key.ConfigHash,
 			}
 			if key.AzureKeyConfig != nil {
 				cfg := *key.AzureKeyConfig // safe copy

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2144,6 +2144,11 @@
           "description": "Whether this key can be used for batch API operations (default: false)",
           "default": false
         },
+        "request_timeout_in_seconds": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Optional request timeout override for this provider key. If unset, the provider-level timeout is inherited."
+        },
         "aliases": {
           "type": "object",
           "additionalProperties": {


### PR DESCRIPTION
## Summary

Adds backend support for configuring an optional request timeout override on provider API keys.

This allows each provider key to store its own `request_timeout_in_seconds` value while preserving the existing provider-level timeout behavior when the field is unset. This change only adds schema, validation, persistence, config hashing, and API read/write support. Runtime timeout application will be handled separately.

## Changes

* Added `request_timeout_in_seconds` as an optional nullable field on provider API keys.
* Added DB persistence for the new field on provider keys.
* Added an idempotent migration for the nullable `request_timeout_in_seconds` column.
* Added validation so values must be `>= 1` when provided.
* Preserved `nil`, missing, and null semantics so unset keys continue to inherit provider-level timeout behavior.
* Updated provider key schema conversion paths so the field round-trips correctly.
* Included the field in provider key config hashing so timeout changes are detected.
* Preserved the field in redacted provider-key API responses.
* Updated `transports/config.schema.json` to allow the field in config-based provider key definitions.

Notable design decisions:

* The field uses pointer/null semantics instead of `0` as an unset value.
* No provider-level timeout default is copied into provider keys.
* Provider-key update behavior remains full replacement. Omitting `request_timeout_in_seconds` clears the override.
* Runtime timeout behavior was intentionally not changed in this PR to avoid mutating shared provider clients or introducing request-scoped timeout logic prematurely.

## Type of change

* [ ] Bug fix
* [x] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

## Affected areas

* [x] Core (Go)
* [x] Transports (HTTP)
* [ ] Providers/Integrations
* [ ] Plugins
* [ ] UI (React)
* [ ] Docs

## How to test

Focused backend tests:

```sh
cd framework

go test ./configstore -run 'TestProviderKeyCRUD|TestTriggerMigrations_FreshDB|TestTriggerMigrations_Idempotent|TestProviderConfig_Redacted_PreservesRequestTimeoutOverride' -timeout 120s

go test ./configstore -timeout 120s
```

```sh
cd transports/bifrost-http

go test ./handlers -run 'TestValidateProviderKeyRequestTimeout|TestAddProvider|TestListModels' -timeout 120s

go test ./lib -run 'Test.*Provider.*Key|Test.*Key.*Hash|Test.*Reconcile' -timeout 120s
```

```sh
jq empty transports/config.schema.json
git diff --cached --check
```

Local embedded-server verification:

```sh
make run LOCAL=1 PORT=9090 HOST=127.0.0.1 APP_DIR=/tmp/bifrost-timeout-e2e-pr1 LOG_LEVEL=debug
```

Create a provider key through the running server:

```sh
curl -s -X POST "http://127.0.0.1:9090/api/providers/ollama/keys" \
  -H "Content-Type: application/json" \
  -d '{
    "id": "ss-proof-timeout-key",
    "name": "ss-proof-timeout-key",
    "value": "",
    "models": ["*"],
    "weight": 1,
    "ollama_key_config": {
      "url": "http://127.0.0.1:11434"
    },
    "request_timeout_in_seconds": 45
  }' | jq
```

Expected result:

```json
"request_timeout_in_seconds": 45
```

Also verified:

* Embedded server loads on `http://127.0.0.1:9090`.
* `/health` returns `{"status":"ok"}`.
* Creating a provider key without `request_timeout_in_seconds` returns `null`.
* Creating a provider key with `request_timeout_in_seconds: 45` persists and returns `45`.
* Updating the field to `60` persists correctly.
* Omitting the field during full replacement clears it back to `null`.
* Creating or updating with `request_timeout_in_seconds: 0` returns HTTP `400`.
* Restarting the server with the same app directory preserves the stored value.

No new environment variables were added.

## Screenshots/Recordings

Local E2E verification screenshot attached.

The screenshot shows a provider key being created through the running embedded server on port `9090` with:

```json
"request_timeout_in_seconds": 45
```

The response returns the same field, proving the new backend schema, validation, persistence, and redacted API serialization path works.


<img width="1170" height="813" alt="Screenshot 2026-05-07 145209" src="https://github.com/user-attachments/assets/9274d2e6-aefa-4cf0-aedc-61620ea70007" />



## Breaking changes

* [ ] Yes
* [x] No

Existing provider keys continue to work without this field. When unset, timeout behavior remains unchanged and continues to inherit provider-level timeout configuration.

## Related issues



## Security considerations

No new secrets or sensitive fields were added.

Provider key values and provider-specific secret/config values continue to use existing redaction behavior. The new `request_timeout_in_seconds` field is non-sensitive and is intentionally preserved in redacted API responses.

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [x] I added/updated tests where appropriate
* [ ] I updated documentation where needed
* [ ] I verified builds succeed (Go and UI)
* [ ] I verified the CI pipeline passes locally if applicable
