### PR TITLE
feat: adds cached token details in Responses API in OTEL exports

### DIFF
--- a/core/schemas/trace.go
+++ b/core/schemas/trace.go
@@ -257,9 +257,11 @@ const (
 	AttrPromptTokenDetailsText        = "gen_ai.usage.prompt_token_details.text_tokens"
 	AttrPromptTokenDetailsAudio       = "gen_ai.usage.prompt_token_details.audio_tokens"
 	AttrPromptTokenDetailsImage       = "gen_ai.usage.prompt_token_details.image_tokens"
-	AttrPromptTokenDetailsCachedRead  = "gen_ai.usage.prompt_token_details.cached_read_tokens"
-	AttrPromptTokenDetailsCachedWrite = "gen_ai.usage.prompt_token_details.cached_write_tokens"
-	AttrCompletionTokenDetailsText    = "gen_ai.usage.completion_token_details.text_tokens"
+	AttrPromptTokenDetailsCachedRead    = "gen_ai.usage.prompt_token_details.cached_read_tokens"
+	AttrPromptTokenDetailsCachedWrite   = "gen_ai.usage.prompt_token_details.cached_write_tokens"
+	AttrPromptTokenDetailsCachedWrite5m = "gen_ai.usage.prompt_token_details.cached_write_tokens_5m"
+	AttrPromptTokenDetailsCachedWrite1h = "gen_ai.usage.prompt_token_details.cached_write_tokens_1h"
+	AttrCompletionTokenDetailsText      = "gen_ai.usage.completion_token_details.text_tokens"
 	AttrCompletionTokenDetailsAudio   = "gen_ai.usage.completion_token_details.audio_tokens"
 	AttrCompletionTokenDetailsImage   = "gen_ai.usage.completion_token_details.image_tokens"
 	AttrCompletionTokenDetailsReason  = "gen_ai.usage.completion_token_details.reasoning_tokens"
@@ -281,6 +283,7 @@ const (
 	AttrOutputMessages = "gen_ai.output.messages"
 
 	// Bifrost Context Attributes
+	AttrRequestID       = "gen_ai.request_id"
 	AttrVirtualKeyID    = "gen_ai.virtual_key_id"
 	AttrVirtualKeyName  = "gen_ai.virtual_key_name"
 	AttrSelectedKeyID   = "gen_ai.selected_key_id"
@@ -370,6 +373,21 @@ const (
 	// Transcription Response Attributes
 	AttrInputTokenDetailsText  = "gen_ai.usage.input_token_details.text_tokens"
 	AttrInputTokenDetailsAudio = "gen_ai.usage.input_token_details.audio_tokens"
+
+	// Responses API usage detail attributes
+	AttrInputTokenDetailsImage        = "gen_ai.usage.input_token_details.image_tokens"
+	AttrInputTokenDetailsCachedRead   = "gen_ai.usage.input_token_details.cached_read_tokens"
+	AttrInputTokenDetailsCachedWrite  = "gen_ai.usage.input_token_details.cached_write_tokens"
+	AttrInputTokenDetailsCachedWrite5m = "gen_ai.usage.input_token_details.cached_write_tokens_5m"
+	AttrInputTokenDetailsCachedWrite1h = "gen_ai.usage.input_token_details.cached_write_tokens_1h"
+	AttrOutputTokenDetailsText        = "gen_ai.usage.output_token_details.text_tokens"
+	AttrOutputTokenDetailsAudio       = "gen_ai.usage.output_token_details.audio_tokens"
+	AttrOutputTokenDetailsImage       = "gen_ai.usage.output_token_details.image_tokens"
+	AttrOutputTokenDetailsReason      = "gen_ai.usage.output_token_details.reasoning_tokens"
+	AttrOutputTokenDetailsAccept      = "gen_ai.usage.output_token_details.accepted_prediction_tokens"
+	AttrOutputTokenDetailsReject      = "gen_ai.usage.output_token_details.rejected_prediction_tokens"
+	AttrOutputTokenDetailsCite        = "gen_ai.usage.output_token_details.citation_tokens"
+	AttrOutputTokenDetailsSearch      = "gen_ai.usage.output_token_details.num_search_queries"
 
 	// File Operation Attributes
 	AttrFileID             = "gen_ai.file.id"

--- a/framework/tracing/llmspan.go
+++ b/framework/tracing/llmspan.go
@@ -269,6 +269,18 @@ func PopulateChatResponseAttributes(resp *schemas.BifrostChatResponse, attrs map
 			if resp.Usage.PromptTokensDetails.CachedWriteTokens > 0 {
 				attrs[schemas.AttrPromptTokenDetailsCachedWrite] = resp.Usage.PromptTokensDetails.CachedWriteTokens
 			}
+			if d := resp.Usage.PromptTokensDetails.CachedWriteTokenDetails; d != nil {
+				if d.CachedWriteTokens5m > 0 {
+					attrs[schemas.AttrPromptTokenDetailsCachedWrite5m] = d.CachedWriteTokens5m
+				}
+				if d.CachedWriteTokens1h > 0 {
+					attrs[schemas.AttrPromptTokenDetailsCachedWrite1h] = d.CachedWriteTokens1h
+				}
+			}
+		}
+
+		if resp.Usage.Cost != nil {
+			attrs[schemas.AttrUsageCost] = resp.Usage.Cost.TotalCost
 		}
 
 		if resp.Usage.CompletionTokensDetails != nil {
@@ -784,6 +796,63 @@ func PopulateResponsesResponseAttributes(resp *schemas.BifrostResponsesResponse,
 		attrs[schemas.AttrInputTokens] = resp.Usage.InputTokens
 		attrs[schemas.AttrOutputTokens] = resp.Usage.OutputTokens
 		attrs[schemas.AttrTotalTokens] = resp.Usage.TotalTokens
+
+		if resp.Usage.Cost != nil {
+			attrs[schemas.AttrUsageCost] = resp.Usage.Cost.TotalCost
+		}
+
+		if d := resp.Usage.InputTokensDetails; d != nil {
+			if d.TextTokens > 0 {
+				attrs[schemas.AttrInputTokenDetailsText] = d.TextTokens
+			}
+			if d.AudioTokens > 0 {
+				attrs[schemas.AttrInputTokenDetailsAudio] = d.AudioTokens
+			}
+			if d.ImageTokens > 0 {
+				attrs[schemas.AttrInputTokenDetailsImage] = d.ImageTokens
+			}
+			if d.CachedReadTokens > 0 {
+				attrs[schemas.AttrInputTokenDetailsCachedRead] = d.CachedReadTokens
+			}
+			if d.CachedWriteTokens > 0 {
+				attrs[schemas.AttrInputTokenDetailsCachedWrite] = d.CachedWriteTokens
+			}
+			if wd := d.CachedWriteTokenDetails; wd != nil {
+				if wd.CachedWriteTokens5m > 0 {
+					attrs[schemas.AttrInputTokenDetailsCachedWrite5m] = wd.CachedWriteTokens5m
+				}
+				if wd.CachedWriteTokens1h > 0 {
+					attrs[schemas.AttrInputTokenDetailsCachedWrite1h] = wd.CachedWriteTokens1h
+				}
+			}
+		}
+
+		if d := resp.Usage.OutputTokensDetails; d != nil {
+			if d.TextTokens > 0 {
+				attrs[schemas.AttrOutputTokenDetailsText] = d.TextTokens
+			}
+			if d.AudioTokens > 0 {
+				attrs[schemas.AttrOutputTokenDetailsAudio] = d.AudioTokens
+			}
+			if d.ImageTokens != nil && *d.ImageTokens > 0 {
+				attrs[schemas.AttrOutputTokenDetailsImage] = *d.ImageTokens
+			}
+			if d.ReasoningTokens > 0 {
+				attrs[schemas.AttrOutputTokenDetailsReason] = d.ReasoningTokens
+			}
+			if d.AcceptedPredictionTokens > 0 {
+				attrs[schemas.AttrOutputTokenDetailsAccept] = d.AcceptedPredictionTokens
+			}
+			if d.RejectedPredictionTokens > 0 {
+				attrs[schemas.AttrOutputTokenDetailsReject] = d.RejectedPredictionTokens
+			}
+			if d.CitationTokens != nil && *d.CitationTokens > 0 {
+				attrs[schemas.AttrOutputTokenDetailsCite] = *d.CitationTokens
+			}
+			if d.NumSearchQueries != nil && *d.NumSearchQueries > 0 {
+				attrs[schemas.AttrOutputTokenDetailsSearch] = *d.NumSearchQueries
+			}
+		}
 	}
 }
 

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -74,8 +74,13 @@ func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceS
 	otelSpans := make([]*Span, 0, len(trace.Spans))
 	for _, span := range trace.Spans {
 		otelSpan := p.convertSpanToOTELSpan(trace.TraceID, span)
-		if span == trace.RootSpan && len(p.instanceAttrs) > 0 {
-			otelSpan.Attributes = append(otelSpan.Attributes, p.instanceAttrs...)
+		if span == trace.RootSpan {
+			if requestID := trace.GetRequestID(); requestID != "" {
+				otelSpan.Attributes = append(otelSpan.Attributes, kvStr(schemas.AttrRequestID, requestID))
+			}
+			if len(p.instanceAttrs) > 0 {
+				otelSpan.Attributes = append(otelSpan.Attributes, p.instanceAttrs...)
+			}
 		}
 		otelSpans = append(otelSpans, otelSpan)
 	}


### PR DESCRIPTION
## Summary

Extends tracing span attribute coverage for both the Chat and Responses APIs to include granular token usage details and cost, ensuring observability data captures the full breakdown of token consumption reported by providers.

## Changes

- Added `AttrPromptTokenDetailsCachedWrite5m` and `AttrPromptTokenDetailsCachedWrite1h` schema constants to represent time-bucketed cached write tokens for the Chat API.
- Added a full set of Responses API input/output token detail schema constants: image tokens, cached read/write tokens (including 5m/1h buckets), reasoning tokens, accepted/rejected prediction tokens, citation tokens, and search query counts.
- Populated `AttrUsageCost` from `resp.Usage.Cost.TotalCost` in both `PopulateChatResponseAttributes` and `PopulateResponsesResponseAttributes`.
- Populated all newly defined input and output token detail attributes in `PopulateResponsesResponseAttributes` when the corresponding detail fields are non-nil and non-zero.
- Populated the `CachedWriteTokenDetails` sub-fields (5m and 1h buckets) in `PopulateChatResponseAttributes`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

Verify that spans emitted for Chat and Responses API calls include the new token detail attributes (e.g., `gen_ai.usage.prompt_token_details.cached_write_tokens_5m`, `gen_ai.usage.input_token_details.image_tokens`, `gen_ai.usage.output_token_details.reasoning_tokens`, `gen_ai.usage.cost`) when the provider returns those fields with non-zero values.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Changes are limited to read-only attribute population from existing response structs.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable