### PR TITLE
fix: hide provider and key action buttons based on RBAC permissions

### DIFF
--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -26,6 +26,9 @@ export enum RbacResource {
 	PromptRepository = "PromptRepository",
 	PromptDeploymentStrategy = "PromptDeploymentStrategy",
 	AccessProfiles = "AccessProfiles",
+	APIKeys = "APIKeys",
+	Inference = "Inference",
+	Metrics = "Metrics",
 }
 
 // RBAC Operation Names (must match backend definitions)

--- a/ui/app/workspace/config/layout.tsx
+++ b/ui/app/workspace/config/layout.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet, useChildMatches } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useChildMatches, useLocation } from "@tanstack/react-router";
 import FullPageLoader from "@/components/fullPageLoader";
 import { NoPermissionView } from "@/components/noPermissionView";
 import { useGetCoreConfigQuery } from "@/lib/store";
@@ -6,11 +6,17 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import ConfigPage from "./page";
 
 function RouteComponent() {
-	const hasConfigAccess = useRbac(RbacResource.Settings, RbacOperation.View);
-	const { isLoading } = useGetCoreConfigQuery({ fromDB: true }, { skip: !hasConfigAccess });
+	const pathname = useLocation({ select: (l) => l.pathname });
+	const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.View);
+	const hasAPIKeysAccess = useRbac(RbacResource.APIKeys, RbacOperation.View);
 	const childMatches = useChildMatches();
 
-	if (!hasConfigAccess) {
+	const isAPIKeysRoute = pathname.startsWith("/workspace/config/api-keys");
+	const requiredAccess = isAPIKeysRoute ? hasAPIKeysAccess : hasSettingsAccess;
+
+	const { isLoading } = useGetCoreConfigQuery({ fromDB: true }, { skip: !requiredAccess });
+
+	if (!requiredAccess) {
 		return <NoPermissionView entity="configuration" />;
 	}
 

--- a/ui/app/workspace/providers/page.tsx
+++ b/ui/app/workspace/providers/page.tsx
@@ -17,8 +17,8 @@ import {
 import { KnownProvider, ModelProviderName, ProviderStatus } from "@/lib/types/config";
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { AlertCircle } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
+import { AlertCircle } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -240,7 +240,7 @@ export default function Providers() {
 									})}
 								</div>
 							)}
-							<div className="pb-4">
+							{hasProviderCreateAccess ? <div className="pb-4">
 								<AddProviderDropdown
 									disabled={!hasProviderCreateAccess}
 									existingInSidebar={existingInSidebarNames}
@@ -248,7 +248,7 @@ export default function Providers() {
 									onSelectKnownProvider={handleSelectKnownProvider}
 									onAddCustomProvider={() => setShowCustomProviderSheet(true)}
 								/>
-							</div>
+							</div> : null}
 						</div>
 					</div>
 				</TooltipProvider>

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -106,7 +106,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 					<div className="flex items-center gap-2">Configured {entityLabelPlural}</div>
 					<div className="flex items-center gap-2">
 						{headerActions}
-						{!isKeyless && (
+						{!isKeyless && hasUpdateProviderAccess ? (
 							<Button
 								disabled={!hasUpdateProviderAccess}
 								data-testid="add-key-btn"
@@ -117,7 +117,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 								<PlusIcon className="h-4 w-4" />
 								Add new {entityLabel}
 							</Button>
-						)}
+						) : null}
 					</div>
 				</CardTitle>
 			</CardHeader>
@@ -152,7 +152,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 										key={key.id}
 										data-testid={`key-row-${key.name}`}
 										className="text-sm transition-colors hover:bg-white"
-										onClick={() => {}}
+										onClick={() => { }}
 									>
 										<TableCell>
 											<div className="flex items-center space-x-2">
@@ -258,34 +258,36 @@ export default function ModelProviderKeysTableView({ provider, className, header
 										</TableCell>
 										<TableCell className="text-right">
 											<div className="flex items-center justify-end space-x-2">
-												<DropdownMenu>
-													<DropdownMenuTrigger asChild>
-														<Button onClick={(e) => e.stopPropagation()} variant="ghost">
-															<EllipsisIcon className="h-5 w-5" />
-														</Button>
-													</DropdownMenuTrigger>
-													<DropdownMenuContent align="end">
-														<DropdownMenuItem
-															onClick={() => {
-																setShowAddNewKeyDialog({ show: true, keyId: key.id });
-															}}
-															disabled={!hasUpdateProviderAccess}
-														>
-															<PencilIcon className="mr-1 h-4 w-4" />
-															Edit
-														</DropdownMenuItem>
-														<DropdownMenuItem
-															variant="destructive"
-															onClick={() => {
-																setShowDeleteKeyDialog({ show: true, keyId: key.id });
-															}}
-															disabled={!hasDeleteProviderAccess}
-														>
-															<TrashIcon className="mr-1 h-4 w-4" />
-															Delete
-														</DropdownMenuItem>
-													</DropdownMenuContent>
-												</DropdownMenu>
+												{hasUpdateProviderAccess || hasDeleteProviderAccess ?
+													<DropdownMenu>
+														<DropdownMenuTrigger asChild>
+															<Button onClick={(e) => e.stopPropagation()} variant="ghost">
+																<EllipsisIcon className="h-5 w-5" />
+															</Button>
+														</DropdownMenuTrigger>
+														<DropdownMenuContent align="end">
+															<DropdownMenuItem
+																onClick={() => {
+																	setShowAddNewKeyDialog({ show: true, keyId: key.id });
+																}}
+																disabled={!hasUpdateProviderAccess}
+															>
+																<PencilIcon className="mr-1 h-4 w-4" />
+																Edit
+															</DropdownMenuItem>
+															<DropdownMenuItem
+																variant="destructive"
+																onClick={() => {
+																	setShowDeleteKeyDialog({ show: true, keyId: key.id });
+																}}
+																disabled={!hasDeleteProviderAccess}
+															>
+																<TrashIcon className="mr-1 h-4 w-4" />
+																Delete
+															</DropdownMenuItem>
+														</DropdownMenuContent>
+													</DropdownMenu> : null
+												}
 											</div>
 										</TableCell>
 									</TableRow>

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -19,10 +19,8 @@ import {
   LogOut,
   Logs,
   Network,
-  PanelLeft,
   PanelLeftClose,
   PanelLeftOpen,
-  PanelRight,
   Plug,
   Puzzle,
   ScrollText,
@@ -67,7 +65,6 @@ import {
   useGetVersionQuery,
   useLogoutMutation,
 } from "@/lib/store";
-import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import type { UserInfo } from "@enterprise/lib/store/utils/tokenManager";
 import { getUserInfo } from "@enterprise/lib/store/utils/tokenManager";
@@ -583,6 +580,7 @@ export default function AppSidebar() {
   const hasClusterConfigAccess = useRbac(RbacResource.Cluster, RbacOperation.View);
   const isAdaptiveRoutingAllowed = useRbac(RbacResource.AdaptiveRouter, RbacOperation.View);
   const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.View);
+  const hasAPIKeyAccess = useRbac(RbacResource.APIKeys, RbacOperation.View);
   const hasPromptRepositoryAccess = useRbac(RbacResource.PromptRepository, RbacOperation.View);
   const hasAccessProfilesAccess = useRbac(RbacResource.AccessProfiles, RbacOperation.View);
   const hasAnyGovernanceAccess =
@@ -625,7 +623,7 @@ export default function AppSidebar() {
             url: "/workspace/mcp-logs",
             icon: MCPIcon,
             description: "MCP tool execution logs",
-            hasAccess: hasLogsAccess,
+            hasAccess: hasMCPGatewayAccess,
           },
           {
             title: "Connectors",
@@ -910,7 +908,7 @@ export default function AppSidebar() {
             url: "/workspace/config/api-keys",
             icon: KeyRound,
             description: "API keys management",
-            hasAccess: hasSettingsAccess,
+            hasAccess: hasAPIKeyAccess,
           },
           {
             title: "Performance Tuning",
@@ -950,11 +948,26 @@ export default function AppSidebar() {
     ],
   );
 
+  const accessibleItems: SidebarItem[] = useMemo(() => {
+    return items
+      .map((item) => {
+        const hadSubItems = !!item.subItems?.length;
+        if (hadSubItems) {
+          const visibleSubItems = item.subItems!.filter((sub) => sub.hasAccess !== false);
+          if (visibleSubItems.length === 0) return null;
+          return { ...item, subItems: visibleSubItems, hasAccess: true };
+        }
+        if (item.hasAccess === false) return null;
+        return item;
+      })
+      .filter(Boolean) as SidebarItem[];
+  }, [items]);
+
   const filteredItems: SidebarItem[] = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
-    if (!query) return items;
+    if (!query) return accessibleItems;
 
-    return items
+    return accessibleItems
       .map((item) => {
         const parentMatches = item.title.toLowerCase().includes(query);
         if (parentMatches) return item;
@@ -970,7 +983,7 @@ export default function AppSidebar() {
         return null;
       })
       .filter(Boolean) as SidebarItem[];
-  }, [items, searchQuery]);
+  }, [accessibleItems, searchQuery]);
 
   const { data: version } = useGetVersionQuery();
   const { resolvedTheme } = useTheme();


### PR DESCRIPTION
## Summary

Improves RBAC enforcement across the configuration and providers UI by hiding action controls entirely when the user lacks the required permissions, rather than rendering them in a disabled state.

## Changes

- The config layout now checks the current route to determine which RBAC resource to evaluate — `APIKeys` for `/workspace/config/api-keys` routes and `Settings` for all others, so users without API key access are not incorrectly blocked from other config pages.
- The "Add Provider" dropdown is now conditionally rendered only when the user has provider create access, instead of always rendering with a disabled state.
- The "Add new key" button in the model provider keys table is now hidden entirely when the user lacks update access, rather than being rendered as disabled.
- The per-row actions dropdown menu (Edit/Delete) in the model provider keys table is now hidden entirely when the user has neither update nor delete access.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Log in as a user with restricted RBAC permissions (no `APIKeys` view access, no provider create/update/delete access).
2. Navigate to `/workspace/config/api-keys` — the no-permission view should be shown.
3. Navigate to another config page — it should load normally.
4. Navigate to the Providers page — the "Add Provider" dropdown should not be visible.
5. Open a provider's key table — the "Add new key" button and the per-row actions menu should not be visible.
6. Log in as a user with full access and verify all controls appear and function as expected.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions.

## Security considerations

These changes tighten UI-level RBAC enforcement by ensuring that action controls are not rendered at all for unauthorized users, reducing the surface area for accidental or misleading interactions. Server-side authorization remains the authoritative enforcement layer.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable