### PR TITLE
[fix]: Skip governance API handler without config store

### DIFF
--- a/transports/bifrost-http/handlers/init.go
+++ b/transports/bifrost-http/handlers/init.go
@@ -10,6 +10,11 @@ func SetLogger(l schemas.Logger) {
 	logger = l
 }
 
+// GetLogger returns the current logger for the application.
+func GetLogger() schemas.Logger {
+	return logger
+}
+
 // SetVersion sets the version for the application.
 func SetVersion(v string) {
 	version = v

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1097,9 +1097,13 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	}
 	governancePlugin, _ := lib.FindPluginAs[schemas.LLMPlugin](s.Config, governancePluginName)
 	if governancePlugin != nil {
-		governanceHandler, err = handlers.NewGovernanceHandler(callbacks, s.Config.ConfigStore)
-		if err != nil {
-			return fmt.Errorf("failed to initialize governance handler: %v", err)
+		if s.Config.ConfigStore != nil {
+			governanceHandler, err = handlers.NewGovernanceHandler(callbacks, s.Config.ConfigStore)
+			if err != nil {
+				return fmt.Errorf("failed to initialize governance handler: %v", err)
+			}
+		} else {
+			logger.Warn("config store is nil, skipping governance API handler initialization")
 		}
 	}
 	var cacheHandler *handlers.CacheHandler

--- a/transports/bifrost-http/server/server_test.go
+++ b/transports/bifrost-http/server/server_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/fasthttp/router"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/plugins/governance"
+	"github.com/maximhq/bifrost/transports/bifrost-http/handlers"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 )
 
@@ -42,6 +45,51 @@ func (s *updateStatusOnlyConfigStore) UpdateStatus(ctx context.Context, provider
 		Error:    &schemas.BifrostError{Error: &schemas.ErrorField{Message: errorMsg}},
 	})
 	return nil
+}
+
+func TestRegisterAPIRoutes_SkipsGovernanceHandlerWithoutConfigStore(t *testing.T) {
+	prevLogger := logger
+	logger = noopTestLogger{}
+	handlers.SetLogger(noopTestLogger{})
+	defer func() { logger = prevLogger }()
+
+	governancePlugin, err := governance.Init(
+		context.Background(),
+		&governance.Config{},
+		logger,
+		nil,
+		&configstore.GovernanceConfig{},
+		nil,
+		nil,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("expected governance plugin to initialize in memory-only mode: %v", err)
+	}
+
+	clientConfig := lib.DefaultClientConfig
+	config := &lib.Config{
+		ConfigStore:      nil,
+		ClientConfig:     &clientConfig,
+		Providers:        map[schemas.ModelProvider]configstore.ProviderConfig{},
+		GovernanceConfig: &configstore.GovernanceConfig{},
+	}
+	if err := config.ReloadPlugin(governancePlugin); err != nil {
+		t.Fatalf("expected governance plugin to load: %v", err)
+	}
+
+	serverCtx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	server := &BifrostHTTPServer{
+		Ctx:    serverCtx,
+		Config: config,
+		Router: router.New(),
+	}
+
+	if err := server.RegisterAPIRoutes(context.Background(), server); err != nil {
+		t.Fatalf("expected API route registration to tolerate nil ConfigStore in file-only mode: %v", err)
+	}
 }
 
 func TestUpdateKeyStatus_KeylessProviderUpdatesProviderStatusInMemory(t *testing.T) {

--- a/transports/bifrost-http/server/server_test.go
+++ b/transports/bifrost-http/server/server_test.go
@@ -49,9 +49,13 @@ func (s *updateStatusOnlyConfigStore) UpdateStatus(ctx context.Context, provider
 
 func TestRegisterAPIRoutes_SkipsGovernanceHandlerWithoutConfigStore(t *testing.T) {
 	prevLogger := logger
+	prevHandlersLogger := handlers.GetLogger()
 	logger = noopTestLogger{}
 	handlers.SetLogger(noopTestLogger{})
-	defer func() { logger = prevLogger }()
+	defer func() {
+		logger = prevLogger
+		handlers.SetLogger(prevHandlersLogger)
+	}()
 
 	governancePlugin, err := governance.Init(
 		context.Background(),

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+[fix]: allow file-only governance startup without config store [@0oAstro](https://github.com/0oAstro)


### PR DESCRIPTION
## Summary

Fixes #3298.

File-only deployments can initialize the governance plugin with an in-memory governance store when `config_store` is disabled, but the HTTP transport still attempted to register the DB-backed governance API handler unconditionally. That made documented file-only configs crash during route registration with `config store is required`.

This changes API route registration so the governance management handler is only registered when a `ConfigStore` exists. In file-only mode, the gateway can continue booting with the in-memory governance plugin, while DB-backed governance management routes remain unavailable as expected.

## Validation

```bash
GOWORK=off go test ./server -run TestRegisterAPIRoutes_SkipsGovernanceHandlerWithoutConfigStore -count=1
GOWORK=off go test ./...
```

The targeted regression passes.

The full `transports/bifrost-http` suite currently reaches an unrelated failure on `origin/main`:

```text
--- FAIL: TestValidateConfigSchema_AzureKeyConfig_MissingApiVersion
    validator_test.go:1377: expected config missing 'api_version' in Azure key config to fail validation
```
