### PR TITLE
feat: extracts region from model name while passing bedrock models

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -182,16 +182,13 @@ var retryableBedrockExceptions = map[string]int{
 // completeRequest sends a request to Bedrock's API and handles the response.
 // It constructs the API URL, sets up AWS authentication, and processes the response.
 // Returns the response body, request latency, or an error if the request fails.
-func (provider *BedrockProvider) completeRequest(ctx *schemas.BifrostContext, jsonData []byte, path string, key schemas.Key) ([]byte, time.Duration, map[string]string, *schemas.BifrostError) {
+func (provider *BedrockProvider) completeRequest(ctx *schemas.BifrostContext, jsonData []byte, path string, key schemas.Key, model string) ([]byte, time.Duration, map[string]string, *schemas.BifrostError) {
 	config := key.BedrockKeyConfig
-
-	region := DefaultBedrockRegion
-	if config.Region != nil && config.Region.GetValue() != "" {
-		region = config.Region.GetValue()
-	}
+	region := resolveBedrockRegion(key, model)
 
 	// Create the request with the JSON body
-	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s", region, path), bytes.NewBuffer(jsonData))
+	requestURL := fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s", region, path)
+	req, err := http.NewRequestWithContext(ctx, "POST", requestURL, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return nil, 0, nil, &schemas.BifrostError{
 			IsBifrostError: true,
@@ -415,16 +412,12 @@ func (provider *BedrockProvider) completeAgentRuntimeRequest(ctx *schemas.Bifros
 // It formats the request, sends it to Bedrock, and returns the response.
 // Returns the response body and an error if the request fails.
 func (provider *BedrockProvider) makeStreamingRequest(ctx *schemas.BifrostContext, jsonData []byte, key schemas.Key, model string, action string) (*http.Response, *schemas.BifrostError) {
-	// Format the path with proper model identifier for streaming
-	path := provider.getModelPath(action, model, key)
-
-	region := DefaultBedrockRegion
-	if key.BedrockKeyConfig.Region != nil && key.BedrockKeyConfig.Region.GetValue() != "" {
-		region = key.BedrockKeyConfig.Region.GetValue()
-	}
+	// Parse region and path in one pass to avoid running the regex twice.
+	path, region := provider.getModelPathAndRegion(action, model, key)
 
 	// Create HTTP request for streaming
-	req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s", region, path), bytes.NewReader(jsonData))
+	requestURL := fmt.Sprintf("https://bedrock-runtime.%s.amazonaws.com/model/%s", region, path)
+	req, reqErr := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(jsonData))
 	if reqErr != nil {
 		return nil, providerUtils.NewBifrostOperationError("error creating request", reqErr)
 	}
@@ -822,8 +815,8 @@ func (provider *BedrockProvider) TextCompletion(ctx *schemas.BifrostContext, key
 		return nil, bifrostErr
 	}
 
-	path := provider.getModelPath("invoke", request.Model, key)
-	body, latency, providerResponseHeaders, err := provider.completeRequest(ctx, jsonData, path, key)
+	path, _ := provider.getModelPathAndRegion("invoke", request.Model, key)
+	body, latency, providerResponseHeaders, err := provider.completeRequest(ctx, jsonData, path, key, request.Model)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
@@ -1047,10 +1040,10 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 	}
 
 	// Format the path with proper model identifier
-	path := provider.getModelPath("converse", request.Model, key)
+	path, _ := provider.getModelPathAndRegion("converse", request.Model, key)
 
 	// Create the signed request
-	responseBody, latency, providerResponseHeaders, bifrostErr := provider.completeRequest(ctx, jsonData, path, key)
+	responseBody, latency, providerResponseHeaders, bifrostErr := provider.completeRequest(ctx, jsonData, path, key, request.Model)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
@@ -1426,10 +1419,10 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 	}
 
 	// Format the path with proper model identifier
-	path := provider.getModelPath("converse", request.Model, key)
+	path, _ := provider.getModelPathAndRegion("converse", request.Model, key)
 
 	// Create the signed request
-	responseBody, latency, providerResponseHeaders, bifrostErr := provider.completeRequest(ctx, jsonData, path, key)
+	responseBody, latency, providerResponseHeaders, bifrostErr := provider.completeRequest(ctx, jsonData, path, key, request.Model)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
@@ -1799,8 +1792,8 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 		if bifrostError != nil {
 			return nil, bifrostError
 		}
-		path = provider.getModelPath("invoke", request.Model, key)
-		rawResponse, latency, providerResponseHeaders, bifrostError = provider.completeRequest(ctx, jsonData, path, key)
+		path, _ = provider.getModelPathAndRegion("invoke", request.Model, key)
+		rawResponse, latency, providerResponseHeaders, bifrostError = provider.completeRequest(ctx, jsonData, path, key, request.Model)
 
 	case "cohere":
 		jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
@@ -1812,8 +1805,8 @@ func (provider *BedrockProvider) Embedding(ctx *schemas.BifrostContext, key sche
 		if bifrostError != nil {
 			return nil, bifrostError
 		}
-		path = provider.getModelPath("invoke", request.Model, key)
-		rawResponse, latency, providerResponseHeaders, bifrostError = provider.completeRequest(ctx, jsonData, path, key)
+		path, _ = provider.getModelPathAndRegion("invoke", request.Model, key)
+		rawResponse, latency, providerResponseHeaders, bifrostError = provider.completeRequest(ctx, jsonData, path, key, request.Model)
 
 	default:
 		return nil, providerUtils.NewConfigurationError("unsupported embedding model type")
@@ -1965,7 +1958,7 @@ func (provider *BedrockProvider) ImageGeneration(ctx *schemas.BifrostContext, ke
 	var providerResponseHeaders map[string]string
 	var path string
 
-	path = provider.getModelPath("invoke", request.Model, key)
+	path, _ = provider.getModelPathAndRegion("invoke", request.Model, key)
 
 	jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
 		ctx,
@@ -1979,7 +1972,7 @@ func (provider *BedrockProvider) ImageGeneration(ctx *schemas.BifrostContext, ke
 	if bifrostError != nil {
 		return nil, bifrostError
 	}
-	rawResponse, latency, providerResponseHeaders, bifrostError = provider.completeRequest(ctx, jsonData, path, key)
+	rawResponse, latency, providerResponseHeaders, bifrostError = provider.completeRequest(ctx, jsonData, path, key, request.Model)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
@@ -2038,7 +2031,7 @@ func (provider *BedrockProvider) ImageEdit(ctx *schemas.BifrostContext, key sche
 	var bifrostError *schemas.BifrostError
 
 	// Stability AI routing and task-type inference use the actual model ID.
-	path := provider.getModelPath("invoke", request.Model, key)
+	path, _ := provider.getModelPathAndRegion("invoke", request.Model, key)
 
 	jsonData, bifrostError = providerUtils.CheckContextAndGetRequestBody(
 		ctx,
@@ -2054,7 +2047,7 @@ func (provider *BedrockProvider) ImageEdit(ctx *schemas.BifrostContext, key sche
 	}
 
 	// Make API request (same URL as image generation)
-	rawResponse, latency, providerResponseHeaders, bifrostError := provider.completeRequest(ctx, jsonData, path, key)
+	rawResponse, latency, providerResponseHeaders, bifrostError := provider.completeRequest(ctx, jsonData, path, key, request.Model)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
@@ -2120,8 +2113,8 @@ func (provider *BedrockProvider) ImageVariation(ctx *schemas.BifrostContext, key
 	}
 
 	// Make API request (same URL as image generation)
-	path := provider.getModelPath("invoke", request.Model, key)
-	rawResponse, latency, providerResponseHeaders, bifrostError := provider.completeRequest(ctx, jsonData, path, key)
+	path, _ := provider.getModelPathAndRegion("invoke", request.Model, key)
+	rawResponse, latency, providerResponseHeaders, bifrostError := provider.completeRequest(ctx, jsonData, path, key, request.Model)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}
@@ -3513,14 +3506,35 @@ func (provider *BedrockProvider) BatchResults(ctx *schemas.BifrostContext, keys 
 	return batchResultsResp, nil
 }
 
-func (provider *BedrockProvider) getModelPath(basePath string, model string, key schemas.Key) string {
-	path := fmt.Sprintf("%s/%s", model, basePath)
-	// If ARN is present, Bedrock expects the ARN-scoped identifier
-	if key.BedrockKeyConfig != nil && key.BedrockKeyConfig.ARN != nil && key.BedrockKeyConfig.ARN.GetValue() != "" {
-		encodedModelIdentifier := url.PathEscape(fmt.Sprintf("%s/%s", key.BedrockKeyConfig.ARN.GetValue(), model))
-		path = fmt.Sprintf("%s/%s", encodedModelIdentifier, basePath)
+// resolveBedrockRegion returns the AWS region to use for a request.
+// the priority is: model string region > key configured region > default region
+func resolveBedrockRegion(key schemas.Key, model string) string {
+	if region, _ := parseBedrockRegionAndModel(model); region != "" {
+		return region
 	}
-	return path
+	if key.BedrockKeyConfig != nil && key.BedrockKeyConfig.Region != nil && key.BedrockKeyConfig.Region.GetValue() != "" {
+		return key.BedrockKeyConfig.Region.GetValue()
+	}
+	return DefaultBedrockRegion
+}
+
+// getModelPathAndRegion is a helper that calls parseBedrockRegionAndModel
+// once and returns both the request path and the AWS signing region
+func (provider *BedrockProvider) getModelPathAndRegion(basePath, model string, key schemas.Key) (path, region string) {
+	r, bareModel := parseBedrockRegionAndModel(model)
+	if r == "" {
+		if key.BedrockKeyConfig != nil && key.BedrockKeyConfig.Region != nil && key.BedrockKeyConfig.Region.GetValue() != "" {
+			r = key.BedrockKeyConfig.Region.GetValue()
+		} else {
+			r = DefaultBedrockRegion
+		}
+	}
+	p := fmt.Sprintf("%s/%s", bareModel, basePath)
+	if key.BedrockKeyConfig != nil && key.BedrockKeyConfig.ARN != nil && key.BedrockKeyConfig.ARN.GetValue() != "" {
+		encodedModelIdentifier := url.PathEscape(fmt.Sprintf("%s/%s", key.BedrockKeyConfig.ARN.GetValue(), bareModel))
+		p = fmt.Sprintf("%s/%s", encodedModelIdentifier, basePath)
+	}
+	return p, r
 }
 
 func (provider *BedrockProvider) CountTokens(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostCountTokensResponse, *schemas.BifrostError) {
@@ -3544,10 +3558,10 @@ func (provider *BedrockProvider) CountTokens(ctx *schemas.BifrostContext, key sc
 	}
 
 	// Format the path with proper model identifier
-	path := provider.getModelPath("count-tokens", request.Model, key)
+	path, _ := provider.getModelPathAndRegion("count-tokens", request.Model, key)
 
 	// Send the request
-	responseBody, latency, providerResponseHeaders, bifrostErr := provider.completeRequest(ctx, jsonData, path, key)
+	responseBody, latency, providerResponseHeaders, bifrostErr := provider.completeRequest(ctx, jsonData, path, key, request.Model)
 	if providerResponseHeaders != nil {
 		ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, providerResponseHeaders)
 	}

--- a/core/providers/bedrock/region_test.go
+++ b/core/providers/bedrock/region_test.go
@@ -1,0 +1,126 @@
+package bedrock
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseBedrockRegionAndModel(t *testing.T) {
+	cases := []struct {
+		input      string
+		wantRegion string
+		wantModel  string
+	}{
+		{"eu-north-1/moonshotai.kimi-k2.5", "eu-north-1", "moonshotai.kimi-k2.5"},
+		{"us-east-1/amazon.nova-lite-v1:0", "us-east-1", "amazon.nova-lite-v1:0"},
+		{"ap-southeast-2/anthropic.claude-3-5-sonnet-20241022-v2:0", "ap-southeast-2", "anthropic.claude-3-5-sonnet-20241022-v2:0"},
+		// GovCloud regions (multi-segment directional part)
+		{"us-gov-east-1/amazon.nova-lite-v1:0", "us-gov-east-1", "amazon.nova-lite-v1:0"},
+		{"us-gov-west-1/anthropic.claude-v2", "us-gov-west-1", "anthropic.claude-v2"},
+		// Commitment-tier format: region is stripped, remainder (including slash) is the bare model ID
+		{"eu-central-1/1-month-commitment/anthropic.claude-v1", "eu-central-1", "1-month-commitment/anthropic.claude-v1"},
+		{"us-east-1/6-month-commitment/amazon.nova-lite-v1:0", "us-east-1", "6-month-commitment/amazon.nova-lite-v1:0"},
+		// Model namespace prefix must be preserved as-is (not treated as a region)
+		{"meta-llama/Llama-3.1-8B", "", "meta-llama/Llama-3.1-8B"},
+		{"moonshotai.kimi-k2.5", "", "moonshotai.kimi-k2.5"},
+		{"anthropic.claude-3-5-sonnet-20241022-v2:0", "", "anthropic.claude-3-5-sonnet-20241022-v2:0"},
+		// Commitment strings alone must not match (start with digit)
+		{"1-month-commitment/anthropic.claude-v1", "", "1-month-commitment/anthropic.claude-v1"},
+		// ARN strings must not be split
+		{"arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0", "", "arn:aws:bedrock:us-east-1::foundation-model/amazon.nova-lite-v1:0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			gotRegion, gotModel := parseBedrockRegionAndModel(tc.input)
+			assert.Equal(t, tc.wantRegion, gotRegion)
+			assert.Equal(t, tc.wantModel, gotModel)
+		})
+	}
+}
+
+func TestGetModelPathStripsRegion(t *testing.T) {
+	provider := &BedrockProvider{}
+	key := schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{}}
+
+	cases := []struct {
+		model    string
+		basePath string
+		wantPath string
+	}{
+		{"eu-north-1/moonshotai.kimi-k2.5", "converse", "moonshotai.kimi-k2.5/converse"},
+		{"us-east-1/amazon.nova-lite-v1:0", "converse", "amazon.nova-lite-v1:0/converse"},
+		{"us-gov-east-1/amazon.nova-lite-v1:0", "converse", "amazon.nova-lite-v1:0/converse"},
+		{"eu-central-1/1-month-commitment/anthropic.claude-v1", "converse", "1-month-commitment/anthropic.claude-v1/converse"},
+		{"moonshotai.kimi-k2.5", "converse", "moonshotai.kimi-k2.5/converse"},
+		{"meta-llama/Llama-3.1-8B", "converse", "meta-llama/Llama-3.1-8B/converse"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			got, _ := provider.getModelPathAndRegion(tc.basePath, tc.model, key)
+			assert.Equal(t, tc.wantPath, got)
+		})
+	}
+}
+
+func TestGetModelPathStripsRegionWithARN(t *testing.T) {
+	provider := &BedrockProvider{}
+	arn := "arn:aws:bedrock:us-east-1::foundation-model"
+	key := schemas.Key{
+		BedrockKeyConfig: &schemas.BedrockKeyConfig{
+			ARN: schemas.NewEnvVar(arn),
+		},
+	}
+
+	cases := []struct {
+		model    string
+		wantPath string
+	}{
+		{
+			// Region prefix must be stripped; only bareModel appears inside the ARN path.
+			model:    "eu-north-1/anthropic.claude-v2",
+			wantPath: url.PathEscape(arn+"/anthropic.claude-v2") + "/converse",
+		},
+		{
+			// No region prefix — model used as-is inside the ARN path.
+			model:    "anthropic.claude-v2",
+			wantPath: url.PathEscape(arn+"/anthropic.claude-v2") + "/converse",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			got, _ := provider.getModelPathAndRegion("converse", tc.model, key)
+			assert.Equal(t, tc.wantPath, got)
+		})
+	}
+}
+
+func TestResolveBedrockRegion(t *testing.T) {
+	configuredRegion := "ap-southeast-1"
+	key := schemas.Key{
+		BedrockKeyConfig: &schemas.BedrockKeyConfig{
+			Region: schemas.NewEnvVar(configuredRegion),
+		},
+	}
+	keyNoRegion := schemas.Key{BedrockKeyConfig: &schemas.BedrockKeyConfig{}}
+
+	cases := []struct {
+		desc       string
+		key        schemas.Key
+		model      string
+		wantRegion string
+	}{
+		{"model region overrides key config", key, "eu-north-1/moonshotai.kimi-k2.5", "eu-north-1"},
+		{"key config used when no model region", key, "moonshotai.kimi-k2.5", configuredRegion},
+		{"default used when neither configured", keyNoRegion, "moonshotai.kimi-k2.5", DefaultBedrockRegion},
+		{"model region overrides even when key has region", key, "us-west-2/amazon.nova-lite-v1:0", "us-west-2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := resolveBedrockRegion(tc.key, tc.model)
+			assert.Equal(t, tc.wantRegion, got)
+		})
+	}
+}

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -17,6 +17,24 @@ import (
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
+// awsRegionRegex matches valid AWS region identifiers (e.g. "us-east-1", "eu-north-1", "us-gov-east-1").
+// (?:-[a-z]+)+ allows multi-segment directional parts so GovCloud regions (us-gov-east-1) are
+// recognised alongside standard single-segment ones (eu-north-1, ap-southeast-2).
+var awsRegionRegex = regexp.MustCompile(`^[a-z]{2,3}(?:-[a-z]+)+-\d+$`)
+
+// parseBedrockRegionAndModel splits a model string that optionally carries an AWS region prefix
+// into its region and bare model ID components.
+// If no region prefix is present the returned region is empty and bareModel equals model.
+func parseBedrockRegionAndModel(model string) (region, bareModel string) {
+	if idx := strings.IndexByte(model, '/'); idx > 0 {
+		prefix := model[:idx]
+		if awsRegionRegex.MatchString(prefix) {
+			return prefix, model[idx+1:]
+		}
+	}
+	return "", model
+}
+
 var (
 	invalidCharRegex = regexp.MustCompile(`[^a-zA-Z0-9\s\-\(\)\[\]]`)
 	multiSpaceRegex  = regexp.MustCompile(`\s{2,}`)


### PR DESCRIPTION
## Summary

Adds support for embedding an AWS region prefix directly in the Bedrock model string (e.g. `"eu-north-1/moonshotai.kimi-k2.5"`). This allows per-request region routing without requiring a separate key configuration, which is particularly useful for cross-region inference and models only available in specific regions.

## Changes

- Introduced `parseBedrockRegionAndModel` in `utils.go` that uses a regex (`awsRegionRegex`) to detect a valid AWS region prefix (including GovCloud regions like `us-gov-east-1`) at the start of a model string and splits it into `(region, bareModel)`.
- Added `resolveBedrockRegion` which applies a priority order: region embedded in the model string → key's configured region → `DefaultBedrockRegion`.
- Updated `completeRequest` and `makeStreamingRequest` to accept the model string and call `resolveBedrockRegion` instead of duplicating the region-resolution logic inline.
- Updated `getModelPath` to strip any embedded region prefix before constructing the URL path, ensuring the region does not appear in the model path segment. ARN-scoped paths also use the stripped bare model ID.
- All call sites of `completeRequest` now pass `request.Model` as the additional argument.
- Added `region_test.go` covering `parseBedrockRegionAndModel`, `getModelPath`, and `resolveBedrockRegion` with cases for standard regions, GovCloud regions, commitment-tier model strings, non-region prefixes (e.g. `meta-llama/...`), and ARN strings.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/...
```

To validate end-to-end, configure a Bedrock key without a region and pass a model string with an embedded region prefix such as `"eu-north-1/moonshotai.kimi-k2.5"`. The request should be routed to `bedrock-runtime.eu-north-1.amazonaws.com` and the model path should not contain the region segment.

Priority order to verify:
1. Model string with region prefix → uses that region regardless of key config.
2. Model string without prefix, key has region → uses key region.
3. Model string without prefix, key has no region → uses `DefaultBedrockRegion`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new secrets or credentials are introduced. The region value parsed from the model string is validated against a strict regex before use, preventing arbitrary host injection in the constructed request URL.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable