### PR TITLE
enterprise release: doc updates

### DIFF
--- a/docs/changelogs/ent-v1.3.21.mdx
+++ b/docs/changelogs/ent-v1.3.21.mdx
@@ -1,0 +1,75 @@
+---
+title: "v1.3.21"
+description: "Enterprise v1.3.21"
+---
+
+<Update label="Bifrost Enterprise" description="v1.3.21">
+
+## Changelog
+
+This patch release fixes a governance gossip reliability issue where peers could prematurely expire a node's usage snapshot during idle periods, and completes the Go 1.26.2 build toolchain rollout across all environment images.
+
+## ✨ Features
+
+- **Governance Heartbeat Gossip** - Governance broadcast manager now refreshes unchanged usage snapshots every 10s, preventing peers from expiring this node's state via the 30s stale-node TTL when budgets and rate limits are idle
+- **Reliable Governance Broadcast Path** - Governance gossip now uses the reliable `Broadcast` path instead of `BroadcastNoACK`, so oversized payloads can fall back to ACK/retry rather than being silently dropped
+
+## 🐞 Fixed
+
+- **Stale Governance State on Idle Clusters** - Fixed a window where a quiet node's budget/rate-limit snapshot could be evicted from peers during periods of unchanged usage, causing transient gaps in cluster-wide governance enforcement
+
+## 🛠️ Build
+
+- **Go 1.26.2 Across All Env Images** - Bumped the Go toolchain in the root `Makefile`, the `examples/plugins/hello-world` Makefile, and every `infra/envs/*/Dockerfile` to Go 1.26.2, completing the toolchain alignment started in v1.3.20
+
+## 📀 Base OSS version
+
+`transports/v1.4.24`
+
+## 🔌 If you are compiling plugin against this release - use following deps
+
+```
+module github.com/maximhq/bifrost-enterprise
+
+go 1.26.2
+
+require (
+	cloud.google.com/go/bigquery v1.74.0
+	github.com/DataDog/datadog-go/v5 v5.6.0
+	github.com/DataDog/dd-trace-go/v2 v2.4.0
+	github.com/aws/aws-sdk-go-v2/config v1.32.11
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.4
+	github.com/bytedance/sonic v1.15.0
+	github.com/coreos/go-oidc/v3 v3.12.0
+	github.com/fasthttp/router v1.5.4
+	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/google/cel-go v0.26.1
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/grandcat/zeroconf v1.0.0
+	github.com/hashicorp/consul/api v1.22.0
+	github.com/hashicorp/memberlist v0.5.4
+	github.com/maximhq/bifrost/core v1.4.23
+	github.com/maximhq/bifrost/framework v1.2.40
+	github.com/maximhq/bifrost/plugins/governance v1.4.40
+	github.com/maximhq/bifrost/transports v1.4.24
+	github.com/nakabonne/tstorage v0.3.6
+	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.40.0
+	github.com/tetratelabs/wazero v1.11.0
+	github.com/valyala/fasthttp v1.68.0
+	go.etcd.io/etcd/client/v3 v3.6.6
+	golang.org/x/crypto v0.49.0
+	golang.org/x/oauth2 v0.36.0
+	google.golang.org/api v0.274.0
+	google.golang.org/protobuf v1.36.11
+	gorm.io/driver/sqlite v1.6.0
+	gorm.io/gorm v1.31.1
+	k8s.io/api v0.34.1
+	k8s.io/apimachinery v0.34.1
+	k8s.io/client-go v0.34.1
+)
+```
+
+</Update>

--- a/docs/changelogs/ent-v1.4.0-prerelease3.mdx
+++ b/docs/changelogs/ent-v1.4.0-prerelease3.mdx
@@ -1,0 +1,88 @@
+---
+title: "v1.4.0-prerelease3"
+description: "Enterprise v1.4.0-prerelease3"
+---
+
+<Update label="Bifrost Enterprise" description="v1.4.0-prerelease3">
+
+## Changelog
+
+This release hardens SSO/SCIM security, adds cluster synchronization for routing rules, introduces reliable replication, and picks up OSS Azure passthrough, new pricing tiers, and a set of streaming/async safety fixes.
+
+## ✨ Features
+
+- **Reliable Replication** - New replication logic for more dependable state propagation across cluster nodes
+- **Routing Rule Cluster Sync** - Routing rules now synchronize across the cluster via dedicated message handling, keeping all nodes in agreement
+- **Leader-Only Cluster Pricing Sync** - Only the cluster leader fetches pricing URLs, then broadcasts DB reloads to followers - cuts redundant fetches and keeps pricing consistent
+- **Terraform Account ID** - Account ID surfaced for Terraform integrations
+- **Azure Passthrough** - Native Azure passthrough support added upstream
+- **OAuth MCP Hints** - OAuth MCP client creation response now includes next-step hints for a smoother setup flow
+- **272k Token Tier Pricing** - Pricing support for the 272k token tier
+- **Flex & Priority Tier Pricing** - Pricing support for flex and priority service tiers
+- **Dockerfile Upgrades** - Base image and tooling upgrades across environment Dockerfiles
+
+## 🐞 Fixed
+
+- **SSO Role Enforcement** - SSO login is now denied when the user has no role claims and no matching group-to-role mapping; removed the Okta Org Auth Server special case that auto-granted Admin to the first user (security hardening)
+- **SCIM Provider Fixes** - Broad fixes across SCIM controller, mapping, and Entra/Google/Keycloak/Okta/SailPoint/Zitadel providers; new SCIM tables, migrations, and config-store wiring
+- **LB Routing for GenAI & Bedrock** - Load balancing routing fixes for GenAI and Bedrock integrations
+- **Streaming Post-Hook Race** - Fixed a race where fasthttp `RequestCtx` could be recycled before transport post-hooks finished in streaming goroutines; request/response snapshots are now captured eagerly
+- **Async User Values** - User values are now propagated through all async inference handlers and job submissions
+- **Trace Completer Safety** - Trace completer accepts transport logs as a parameter instead of reading from a potentially recycled context
+- **Async Log Store Exceptions** - Fixed exception handling in async log store jobs
+- **Model Alias Tracking** - Split `ModelRequested` into `OriginalModelRequested` and `ResolvedModelUsed` for accurate alias resolution tracking
+- **MCP Tool Discovery** - Added discovered tools and tool-name mapping columns to MCP clients
+- **Guardrails Plugin** - Guardrail plugin cleanup and Bedrock guardrail adjustments
+
+## 📀 Base OSS version
+
+`transports/v1.5.0-prerelease3`
+
+## 🔌 If you are compiling plugin against this release - use following deps
+
+```
+module github.com/maximhq/bifrost-enterprise
+
+go 1.26.2
+
+require (
+	cloud.google.com/go/bigquery v1.74.0
+	github.com/DataDog/datadog-go/v5 v5.6.0
+	github.com/DataDog/dd-trace-go/v2 v2.4.0
+	github.com/aws/aws-sdk-go-v2/config v1.32.11
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.1
+	github.com/bytedance/sonic v1.15.0
+	github.com/coreos/go-oidc/v3 v3.12.0
+	github.com/fasthttp/router v1.5.4
+	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/google/cel-go v0.26.1
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/grandcat/zeroconf v1.0.0
+	github.com/hashicorp/consul/api v1.22.0
+	github.com/hashicorp/memberlist v0.5.4
+	github.com/maximhq/bifrost/core v1.5.2
+	github.com/maximhq/bifrost/framework v1.3.2
+	github.com/maximhq/bifrost/plugins/governance v1.5.2
+	github.com/maximhq/bifrost/plugins/logging v1.5.2
+	github.com/maximhq/bifrost/transports v1.5.0-prerelease3
+	github.com/nakabonne/tstorage v0.3.6
+	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.40.0
+	github.com/tetratelabs/wazero v1.11.0
+	github.com/valyala/fasthttp v1.68.0
+	go.etcd.io/etcd/client/v3 v3.6.6
+	golang.org/x/crypto v0.49.0
+	golang.org/x/oauth2 v0.36.0
+	google.golang.org/api v0.274.0
+	google.golang.org/protobuf v1.36.11
+	gorm.io/driver/sqlite v1.6.0
+	gorm.io/gorm v1.31.1
+	k8s.io/api v0.34.1
+	k8s.io/apimachinery v0.34.1
+	k8s.io/client-go v0.34.1
+)
+```
+
+</Update>

--- a/docs/changelogs/ent-v1.4.0-prerelease7.mdx
+++ b/docs/changelogs/ent-v1.4.0-prerelease7.mdx
@@ -1,0 +1,147 @@
+---
+title: "v1.4.0-prerelease7"
+description: "Enterprise v1.4.0-prerelease7"
+---
+
+<Update label="Bifrost Enterprise" description="v1.4.0-prerelease7">
+
+## Changelog
+
+This release introduces username/password authentication for non-SSO deployments, end-to-end file/image handling and env-var support for guardrails, a token-driven SCIM group restriction model that removes platform-wide group enrichment, and a new React Flow cluster topology view - all on top of OSS base `transports/v1.5.0-prerelease7` which adds passthrough streaming accumulation, auto-resolve provider, and unified `x-bf-dim-*` dimension headers.
+
+## ✨ Features
+
+### Authentication & Identity
+
+- **Username/Password Authentication** - First-class password auth mode alongside SSO via `BIFROST_ADMIN_USERNAME`/`BIFROST_ADMIN_PASSWORD`; new `GET /api/auth/type` endpoint, session middleware, `EntityTypeAuthConfig` cluster gossip, and an `auth_mode` aware login UI. Enabling a SCIM provider wipes all password sessions and auth config.
+- **Token-Driven SCIM Group Restriction** - Removed platform-wide group enrichment across Entra, Okta, Google, Keycloak, SailPoint, and Zitadel; team attachment is now driven exclusively by claims present in the IdP token, eliminating cross-tenant group leakage and unnecessary directory API calls.
+- **Okta Issuer URL Hardening** - `IsOrgAuthServer` and `NormalizeIssuerURL` now properly parse issuer URLs and treat `/oauth2` (without an auth-server id) as a malformed Custom URL, promoting it to `/oauth2/default` instead of misclassifying as Org Authorization Server.
+- **Entra Cloud Default** - Entra SCIM provider defaults the `Cloud` field to `"commercial"` when omitted, preventing nil dereferences from incomplete configs.
+
+### Guardrails
+
+- **File & Image Block Support** - Added `GuardrailFileRequestBlock` and `Files` field to `GuardrailRequestBlock` so non-image attachments flow through the extraction pipeline; nil-pointer panics in `extractRequestBlocks`/`extractResponseBlocks` fixed; `data:image/...` base64 URIs decoded inline without HTTP fetch; SSRF-blocked URL test coverage added.
+- **Env Var Support for Guardrails** - Guardrail provider config fields (Azure, Bedrock, GraySwan, regex, etc.) now resolve from environment variables via `env.VAR_NAME` for secure secret injection.
+- **Bedrock ARN Auto-Derivation** - Region and guardrail ID can be inferred directly from the guardrail ARN when region is omitted, simplifying Bedrock guardrail configuration.
+- **Sheet Click-Outside Protection** - All guardrail configuration sheets now use `onInteractOutside={(e) => e.preventDefault()}` to avoid accidental dismissal on outside clicks.
+
+### Cluster & UX
+
+- **React Flow Cluster Graph** - Cluster Nodes page replaces the table with an interactive React Flow graph: nodes laid out in a circle with edges colored by reachability, leader badges, automatic background diagnostic on leader change, and draggable/zoomable canvas. Single-node clusters render the simplified card.
+- **Sticky Sheet Headers/Footers** - Sheet panels (cluster view, MCP tool group, access profile, etc.) now have sticky headers and footers with refactored layout.
+- **Combobox Filters** - Team and business unit filters use `ComboboxSelect` for searchable selection.
+- **Virtual Key UX in Team Detail** - Replaced infinite scroll with a load-more button and added copy-to-clipboard for virtual keys.
+
+### Routing & Loadbalancing
+
+- **Passthrough Bypass for LB & Governance** - Both load balancing and governance plugins now short-circuit `HTTPTransportPreHook` for passthrough paths so requests bypass governance enforcement and rebalancing as intended.
+
+### From OSS `transports/v1.5.0-prerelease7`
+
+- **Passthrough Streaming Accumulation** - Accumulator for passthrough streaming responses enables proper logging and cost tracking on raw provider streams.
+- **Auto-Resolve Provider** - Inference and integration routes auto-resolve the provider when no provider prefix is given on the model name.
+- **Per-Request Content Logging Overrides** - Opt-in per-request overrides for content logging and raw request/response visibility, with DB migrations and live-reload.
+- **Unified `x-bf-dim-*` Headers** - New unified dimension headers automatically forwarded to logs, traces, Prometheus, and Maxim tags.
+- **VK-Scoped Model Lists** - Model list endpoints now scoped to virtual-key-allowed providers and models via request headers.
+- **MCP Reverse Proxy OAuth** - External base URL support for reverse-proxy MCP OAuth flows.
+- **Routing Rules Scope Cache** - Routing rules cached per scope upfront; new model-catalog routing engine label and icon.
+- **`schemas.Duration` Type** - Go duration string support for MCP, Redis, Weaviate, and mocker duration fields.
+- **OpenAI Realtime Audio (Base64)** - Audio base64 encoding support for the OpenAI realtime provider.
+- **Local Cache Hit Rate Speedometer** - Dashboard speedometer showing local cache hit rate.
+- **OTEL Finish Reasons** - Finish reasons added to OTEL root spans, with correct model and provider names propagated.
+
+## 🐞 Fixed
+
+### Enterprise
+
+- **Team Details Sheet** - Members and virtual keys now render correctly in the team detail sheet.
+- **Access Profile Migrations** - Fixed migrations for enterprise access profiles.
+- **Zitadel `ProjectID`** - Use `GetValue()` for `ProjectID` in user grants query to avoid type mismatches.
+- **Bedrock Guardrail ID** - Corrected guardrail-id handling in the Bedrock guardrails plugin.
+- **Provider Config Normalization** - Provider config is now normalized after update to keep stored credentials and aliases consistent.
+- **GraySwan Form** - Added missing `enabled` field to GraySwan config form, removed duplicate form fields, and fixed the verify flow to send `policy_ids` as an array (split from CSV); `violation_threshold` defaults to `0.5` only when the key is absent, not when explicitly zero.
+- **Nil Pointer in New DB** - Fixed nil pointer dereference triggered when initializing a fresh database.
+- **Okta SCIM Enable Toggle** - Treat Okta informational warnings as non-blocking so the SCIM enable toggle no longer fails on benign warnings.
+- **Inline Credential Preserve Checks** - Replaced `shouldPreserveStoredCredential` with inline env-var and redaction checks across guardrail config handlers, with shared utility coverage.
+- **Loadbalancer Logging** - Cleaned up loadbalancer log levels and message clarity.
+- **Access Profile Field Styling** - Removed stray `mr-2` from icons and corrected access profile field labels.
+- **OSS Ref Branch Selection** - Removed `SKIP_TAG_CHECK` as a bypass for OSS tag validation; only `SKIP_OSS_TAG_CHECK` controls the bypass now, restoring distinct semantics for the two flags.
+
+### From OSS `transports/v1.5.0-prerelease7`
+
+- **OTEL Cost Info & I/O Messages** - Cost info in OTEL calls and response tools fixed; input/output messages propagated to root span.
+- **Migrations Conflict Resolution** - Fixed migration conflicts.
+- **WebSocket `/responses`** - Improved logging, cost tracking, and VK stripping for WebSocket responses.
+- **MarshalJSON Auto-Redaction Removed** - Explicit redaction now applied to env-backed fields in `ProxyConfig`, `ClientConfig`, and `AzureKeyConfig` instead of MarshalJSON-based auto-redaction.
+- **Vertex `google/` Prefix** - Strip `google/` prefix from Vertex model IDs across all request types.
+- **Vertex Multi-Region Routing** - Multi-region-only models route to multi-region endpoints when the provider key is configured for a single region only.
+- **OAuth Token `expires_at`** - `expires_at` now nullable; refresh/reconnect guarded on nil expiry.
+- **OpenAI Responses Tool Fields** - Tool fields preserved in OpenAI responses.
+- **Semantic Cache Determinism** - Deterministic request hashing and `CacheDebug` propagation in streaming.
+- **Streaming Pool-Reuse Corruption** - Snapshot `RequestType` before closure to prevent pool-reuse corruption in streaming requests.
+- **Self-Looping Chain Rules** - Chain rules with self-loops continue evaluating subsequent rules instead of halting.
+- **Default Routing Provider Filter** - Filter out unconfigured providers in default routing.
+- **Ollama/SGL Network Config Fallback** - Fall back to network config if key config URL is not set for Ollama and SGL; `base_url` added to `network_config` for backward compatibility.
+- **Streaming Pipeline `RawRequest`** - `RawRequest` propagated through the streaming pipeline; pool leak fixed.
+- **Logging Streaming Errors** - Improved streaming error handling in the logging plugin.
+- **`governance_budgets` Join** - Corrected join condition to use `virtual_key_id`.
+- **`resolvePeriod` UTC** - Fixed UTC handling in `resolvePeriod` time calculation.
+- **Semanticcache Provider Keys** - Inherit provider keys from the global client in the semanticcache plugin.
+
+## 📀 Base OSS version
+
+`transports/v1.5.0-prerelease7`
+
+## 🔌 If you are compiling plugin against this release - use following deps
+
+```
+module github.com/maximhq/bifrost-enterprise
+
+go 1.26.2
+
+require (
+	cloud.google.com/go/bigquery v1.74.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/DataDog/datadog-go/v5 v5.6.0
+	github.com/DataDog/dd-trace-go/v2 v2.4.0
+	github.com/aws/aws-sdk-go-v2 v1.41.5
+	github.com/aws/aws-sdk-go-v2/config v1.32.11
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.1
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
+	github.com/bytedance/sonic v1.15.0
+	github.com/coreos/go-oidc/v3 v3.12.0
+	github.com/fasthttp/router v1.5.4
+	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/google/cel-go v0.26.1
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/grandcat/zeroconf v1.0.0
+	github.com/hashicorp/consul/api v1.22.0
+	github.com/hashicorp/memberlist v0.5.4
+	github.com/maximhq/bifrost/core v1.5.6
+	github.com/maximhq/bifrost/framework v1.3.6
+	github.com/maximhq/bifrost/plugins/governance v1.5.6
+	github.com/maximhq/bifrost/plugins/prompts v1.0.6
+	github.com/maximhq/bifrost/transports v1.5.0-prerelease7
+	github.com/nakabonne/tstorage v0.3.6
+	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.40.0
+	github.com/tetratelabs/wazero v1.11.0
+	github.com/valyala/fasthttp v1.68.0
+	go.etcd.io/etcd/client/v3 v3.6.6
+	golang.org/x/crypto v0.49.0
+	golang.org/x/oauth2 v0.36.0
+	google.golang.org/api v0.274.0
+	google.golang.org/grpc v1.80.0
+	google.golang.org/protobuf v1.36.11
+	gorm.io/driver/sqlite v1.6.0
+	gorm.io/gorm v1.31.1
+	k8s.io/api v0.34.1
+	k8s.io/apimachinery v0.34.1
+	k8s.io/client-go v0.34.1
+)
+```
+
+</Update>

--- a/docs/changelogs/ent-v1.4.0.mdx
+++ b/docs/changelogs/ent-v1.4.0.mdx
@@ -1,0 +1,112 @@
+---
+title: "v1.4.0"
+description: "Enterprise v1.4.0"
+---
+
+<Update label="Bifrost Enterprise" description="v1.4.0">
+
+## Changelog
+
+This release unifies the API authentication path so password-mode admin and API-key auth share the OSS `AuthMiddleware`/RBAC pipeline, splits SCIM provider configuration into per-provider forms, keeps governance usage snapshots alive across idle periods, and pulls in OSS base `transports/v1.5.0-prerelease8` with `objectStorageExcludeFields`, MCP server/client URL split, and a stack of provider correctness fixes (Anthropic routing, Bedrock structured-output streaming, SGL extra-params passthrough).
+
+## ✨ Features
+
+### Authentication & API Surface
+
+- **Unified API Auth Pipeline** - Removed the enterprise `SessionMiddleware` in favor of the OSS `AuthMiddleware.APIMiddleware()` on API routes; password-mode admin sessions and API-key auth now flow through the same middleware chain and share `schemas.IsLocalAdminContextKey` / `schemas.IsAPIKeyAuthContextKey` from core, eliminating the previous duplicated context-key constants.
+- **RBAC Always Initialized** - RBAC controller and permission cache are now bootstrapped unconditionally (no longer gated on the SCIM controller being present), so API-key permission checks and local-admin RBAC bypass work in non-SSO deployments.
+- **Auth Middleware Context Keys (OSS)** - Core v1.5.7 adds `IsAPIKeyAuthContextKey` (short-circuit when API-key auth already passed) and `IsLocalAdminContextKey` (bypass RBAC when auth is disabled).
+
+### SCIM & Identity
+
+- **Per-Provider SCIM Config Forms** - The single SCIM config form has been split into dedicated forms per provider (Entra, Google, Keycloak, Okta, SailPoint, Zitadel), each with its own validation and field set, replacing the shared switch-case form for better maintainability.
+- **Dedicated SCIM `config_hash` Migration** - Added `addSCIMProviderConfigHashColumn` (id `ent_add_scim_provider_config_hash_column`) so installations that already ran `ent_add_config_hash_columns` still receive the column on `enterprise_scim_providers`. Migration also reordered to run alongside other config-hash migrations, before access-profile migrations.
+
+### Governance & Cluster
+
+- **Governance Snapshot Heartbeat** - Added a 10s heartbeat for unchanged governance usage snapshots, tracking `lastBroadcastAt` per node so peers don't expire idle nodes' usage state under the 30s stale-node TTL. Cluster-wide budget and rate-limit enforcement no longer falls back to a partial local view when a node's usage simply stops changing.
+
+### OSS Base (transports/v1.5.0-prerelease8)
+
+- **`objectStorageExcludeFields`** - Configurable list of log payload fields that stay in the database instead of being offloaded to object storage.
+- **MCP External Base URL Split** - MCP external base URL split into separate server and client URL fields for clearer reverse-proxy configuration.
+- **Schema Normalizer** - New `NormalizeSchemaForAnthropicRaw` (gjson/sjson) avoids `map[string]interface{}` round-trips during Anthropic schema preparation.
+- **Bedrock Structured Output** - New `extractJSONSchemaObject` helper unifies composite and decomposed JSON schema fields for OpenAI-compat structured output on Bedrock.
+- **Provider Capability Matrix** - Re-enabled `ContextEditing` and `ContextManagementField` for Vertex; disabled `TaskBudgets` for Azure (not documented upstream); `claude-4.6-sonnet` mapped for the Bedrock test account.
+
+### Infrastructure
+
+- **New Customer Envs** - Added `bluestaq` and `onbe` Terraform/Docker scaffolding (hub backend, perimeter, terraform.tfvars); refreshed `falconx` and `constructor` Dockerfiles.
+
+## 🐞 Fixed
+
+- **API Middleware Wiring** - Auth middleware now runs before RBAC on API routes so `IsLocalAdminContextKey` is set before RBAC evaluates; cluster-message handler updated to use the unified `s.AuthMiddleware` reference.
+- **Prompts Plugin Missing Header** - Prompts plugin's deployment resolver no longer returns an error when `x-bf-prompt-id` is absent - missing header is treated as "plugin not needed for this request" instead of a failure.
+- **SCIM Teams Page Styling** - Fixed layout/style regressions on the SCIM teams pages (`usersView` and `usersTable`).
+- **Anthropic Integration Routing (OSS)** - Skip model catalog routing when loadbalancer or governance routing has already set the provider.
+- **SGL Extra Params Passthrough (OSS)** - SGL provider now sets `BifrostContextKeyPassthroughExtraParams`, so SGLang vLLM-style extra-body params (`chat_template_kwargs`, `guided_json`, `guided_regex`, `separate_reasoning`) are no longer dropped.
+- **Bedrock Structured-Output Streaming (OSS)** - Suppress non-tool content events (text deltas, reasoning, non-tool content-block starts) in structured-output mode so prose/preamble no longer corrupts the assembled JSON.
+- **MCP Tool Field Resolution (OSS)** - Resolve `tools_to_execute` and `tools_to_auto_execute` from existing config before validation on MCP client update.
+- **Auth Config Disabled Context (OSS)** - Update request context correctly when auth config is disabled.
+- **`BifrostError` String Output (OSS)** - Added `String()` method so logged errors render as JSON instead of decimal byte dumps.
+- **Streaming Latency Validation (OSS)** - Zero-millisecond latency values are now accepted (valid for sub-millisecond cache hits).
+- **`NewUnsupportedOperationError` Context (OSS)** - Now populates `Provider` and `RequestType` in `ExtraFields`.
+- **SCIM Page Layout (OSS)** - Added `no-scrollbar` utility class and applied `no-padding-parent` to the SCIM page.
+
+## 📀 Base OSS version
+
+`transports/v1.5.0-prerelease8`
+
+## 🔌 If you are compiling plugin against this release - use following deps
+
+```
+module github.com/maximhq/bifrost-enterprise
+
+go 1.26.2
+
+require (
+	cloud.google.com/go/bigquery v1.74.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/DataDog/datadog-go/v5 v5.6.0
+	github.com/DataDog/dd-trace-go/v2 v2.4.0
+	github.com/aws/aws-sdk-go-v2 v1.41.5
+	github.com/aws/aws-sdk-go-v2/config v1.32.11
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
+	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.50.1
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
+	github.com/bytedance/sonic v1.15.0
+	github.com/coreos/go-oidc/v3 v3.12.0
+	github.com/fasthttp/router v1.5.4
+	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/google/cel-go v0.26.1
+	github.com/google/uuid v1.6.0
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
+	github.com/grandcat/zeroconf v1.0.0
+	github.com/hashicorp/consul/api v1.22.0
+	github.com/hashicorp/memberlist v0.5.4
+	github.com/maximhq/bifrost/core v1.5.8-0.20260501201305-734f02d4cd7d
+	github.com/maximhq/bifrost/framework v1.3.8-0.20260501201305-734f02d4cd7d
+	github.com/maximhq/bifrost/plugins/governance v1.5.8-0.20260501201305-734f02d4cd7d
+	github.com/maximhq/bifrost/plugins/prompts v1.0.8-0.20260501201305-734f02d4cd7d
+	github.com/maximhq/bifrost/transports v1.5.0-prerelease8.0.20260501201305-734f02d4cd7d
+	github.com/nakabonne/tstorage v0.3.6
+	github.com/stretchr/testify v1.11.1
+	github.com/testcontainers/testcontainers-go v0.40.0
+	github.com/tetratelabs/wazero v1.11.0
+	github.com/valyala/fasthttp v1.68.0
+	go.etcd.io/etcd/client/v3 v3.6.6
+	golang.org/x/crypto v0.49.0
+	golang.org/x/oauth2 v0.36.0
+	google.golang.org/api v0.274.0
+	google.golang.org/grpc v1.80.0
+	google.golang.org/protobuf v1.36.11
+	gorm.io/driver/sqlite v1.6.0
+	gorm.io/gorm v1.31.1
+	k8s.io/api v0.34.1
+	k8s.io/apimachinery v0.34.1
+	k8s.io/client-go v0.34.1
+)
+```
+
+</Update>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -697,24 +697,38 @@
             "item": "Enterprise",
             "icon": "building",
             "pages": [
-              "changelogs/ent-v1.4.0-prerelease6",
-              "changelogs/ent-v1.4.0-prerelease5",
-              "changelogs/ent-v1.3.20",
-              "changelogs/ent-v1.4.0-prerelease4",
-              "changelogs/ent-v1.3.19",
-              "changelogs/ent-v1.3.18",
-              "changelogs/ent-v1.4.0-prerelease2",
-              "changelogs/ent-v1.3.17",
-              "changelogs/ent-v1.4.0-prerelease1",
-              "changelogs/ent-v1.3.16",
-              "changelogs/ent-v1.3.15",
-              "changelogs/ent-v1.3.14",
-              "changelogs/ent-v1.3.13",
-              "changelogs/ent-v1.3.12",
-              "changelogs/ent-v1.3.11",
-              "changelogs/ent-v1.3.10",
-              "changelogs/ent-v1.3.9",
-              "changelogs/ent-v1.3.8"
+              "changelogs/ent-v1.4.0",
+              "changelogs/ent-v1.4.0-prerelease7",
+              {
+                "group": "April 2026",
+                "pages": [
+                  "changelogs/ent-v1.3.21",
+                  "changelogs/ent-v1.4.0-prerelease6",
+                  "changelogs/ent-v1.4.0-prerelease5",
+                  "changelogs/ent-v1.3.20",
+                  "changelogs/ent-v1.4.0-prerelease4",
+                  "changelogs/ent-v1.3.19",
+                  "changelogs/ent-v1.4.0-prerelease3",
+                  "changelogs/ent-v1.3.18",
+                  "changelogs/ent-v1.4.0-prerelease2",
+                  "changelogs/ent-v1.3.17",
+                  "changelogs/ent-v1.4.0-prerelease1"
+                ]
+              },
+              {
+                "group": "March 2026",
+                "pages": [
+                  "changelogs/ent-v1.3.16",
+                  "changelogs/ent-v1.3.15",
+                  "changelogs/ent-v1.3.14",
+                  "changelogs/ent-v1.3.13",
+                  "changelogs/ent-v1.3.12",
+                  "changelogs/ent-v1.3.11",
+                  "changelogs/ent-v1.3.10",
+                  "changelogs/ent-v1.3.9",
+                  "changelogs/ent-v1.3.8"
+                ]
+              }
             ]
           },
           {


### PR DESCRIPTION
## Summary

Adds changelog documentation for three new Bifrost Enterprise releases — `v1.3.21`, `v1.4.0-prerelease3`, `v1.4.0-prerelease7`, and `v1.4.0` — and reorganizes the Enterprise changelog navigation in `docs.json` into monthly groups (April 2026, March 2026) with the two newest releases pinned at the top.

## Changes

- Added `ent-v1.3.21.mdx`: governance heartbeat gossip fix (10s refresh to prevent 30s TTL expiry on idle nodes), reliable `Broadcast` path for governance gossip, and Go 1.26.2 toolchain rollout across all env images.
- Added `ent-v1.4.0-prerelease3.mdx`: SSO/SCIM security hardening, cluster routing rule sync, leader-only pricing sync, Azure passthrough, OAuth MCP hints, new pricing tiers (272k, flex, priority), streaming/async safety fixes, and model alias tracking split.
- Added `ent-v1.4.0-prerelease7.mdx`: username/password auth mode, token-driven SCIM group restriction removing platform-wide group enrichment, file/image guardrail support with env-var injection, Bedrock ARN auto-derivation, React Flow cluster topology graph, passthrough bypass for LB and governance, and all OSS `transports/v1.5.0-prerelease7` fixes (passthrough streaming accumulation, auto-resolve provider, unified `x-bf-dim-*` headers, semantic cache determinism, etc.).
- Added `ent-v1.4.0.mdx`: unified API auth pipeline merging password-mode and API-key auth through OSS `AuthMiddleware`, always-on RBAC initialization, per-provider SCIM config forms, governance snapshot heartbeat, `objectStorageExcludeFields`, MCP server/client URL split, Bedrock structured-output streaming fix, Anthropic integration routing fix, and SGL extra-params passthrough fix.
- Reorganized `docs.json` Enterprise changelog navigation: `v1.4.0` and `v1.4.0-prerelease7` pinned at the top, remaining entries grouped under "April 2026" and "March 2026" collapsible sections.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Navigate to the Enterprise changelog section of the docs site and verify:
- `v1.4.0` and `v1.4.0-prerelease7` appear at the top of the Enterprise changelog list.
- "April 2026" group contains `v1.3.21`, `v1.4.0-prerelease6` through `v1.4.0-prerelease1`, and `v1.3.17`–`v1.3.20`.
- "March 2026" group contains `v1.3.8`–`v1.3.16`.
- Each new changelog page renders correctly with its features, fixes, and plugin dependency blocks.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None — documentation-only change.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable