### PR TITLE
feat: removes ListModels call from rate limit and quota check

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -425,11 +425,14 @@ func (bifrost *Bifrost) ListModelsRequest(ctx *schemas.BifrostContext, req *sche
 		ctx = bifrost.ctx
 	}
 
+	reqCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+	reqCtx.SetValue(schemas.BifrostContextKeySkipBudgetAndRateLimits, true)
+
 	bifrostReq := bifrost.getBifrostRequest()
 	bifrostReq.RequestType = schemas.ListModelsRequest
 	bifrostReq.ListModelsRequest = req
 
-	resp, err := bifrost.handleRequest(ctx, bifrostReq)
+	resp, err := bifrost.handleRequest(reqCtx, bifrostReq)
 	if err != nil {
 		return nil, err
 	}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -212,6 +212,7 @@ const (
 	BifrostContextKeyParentMCPRequestID                  BifrostContextKey = "bf-parent-mcp-request-id"                         // string (parent request ID for nested tool calls from executeCode)
 	BifrostContextKeyStructuredOutputToolName            BifrostContextKey = "bifrost-structured-output-tool-name"              // string (to store the name of the structured output tool (set by bifrost))
 	BifrostContextKeyUserAgent                           BifrostContextKey = "bifrost-user-agent"                               // string (set by bifrost)
+	BifrostContextKeySkipBudgetAndRateLimits             BifrostContextKey = "bifrost-skip-budget-and-rate-limits"              // bool (set by bifrost for read-only requests like list models that don't consume quota)
 	BifrostContextKeyTraceID                             BifrostContextKey = "bifrost-trace-id"                                 // string (trace ID for distributed tracing - set by tracing middleware)
 	BifrostContextKeySpanID                              BifrostContextKey = "bifrost-span-id"                                  // string (current span ID for child span creation - set by tracer)
 	BifrostContextKeyParentSpanID                        BifrostContextKey = "bifrost-parent-span-id"                           // string (parent span ID from W3C traceparent header - set by tracing middleware)

--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -21,6 +21,7 @@ var reservedKeys = []any{
 	BifrostContextKeyNumberOfRetries,
 	BifrostContextKeyFallbackIndex,
 	BifrostContextKeySkipKeySelection,
+	BifrostContextKeySkipBudgetAndRateLimits,
 	BifrostContextKeyURLPath,
 	BifrostContextKeyDeferTraceCompletion,
 	BifrostContextKeyAttemptTrail,

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1128,18 +1128,22 @@ func (p *GovernancePlugin) EvaluateGovernanceRequest(ctx *schemas.BifrostContext
 		}
 	}
 
+	// Read-only metadata calls (e.g. list models) set this flag to skip budget/rate-limit
+	// checks while still enforcing VK identity (existence, active status, provider/model filtering).
+	skipBudgetsAndRateLimits := bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipBudgetAndRateLimits)
+
 	// Step 1: Evaluate virtual key (identity + VK-level budget/rate-limit hierarchy).
 	// Short-circuits with VirtualKeyBlocked / ProviderBlocked / ModelBlocked before
 	// we touch Customer / Team / User.
 	if result.Decision == DecisionAllow && evaluationRequest.VirtualKey != "" {
-		skipVKBudgetLimit := evaluationRequest.UserID != ""
+		skipVKBudgetLimit := evaluationRequest.UserID != "" || skipBudgetsAndRateLimits
 		result = p.resolver.EvaluateVirtualKeyRequest(ctx, evaluationRequest.VirtualKey, evaluationRequest.Provider, evaluationRequest.Model, requestType, skipVKBudgetLimit)
 	}
 
 	// Step 2: Customer-level budget (customer attached directly to VK, or via the VK's team).
 	// Fall back to the loaded relation IDs so VKs populated via joins without FK
 	// pointer columns still participate in customer-level enforcement.
-	if result.Decision == DecisionAllow && hierarchyVK != nil {
+	if !skipBudgetsAndRateLimits && result.Decision == DecisionAllow && hierarchyVK != nil {
 		var customerID string
 		switch {
 		case hierarchyVK.CustomerID != nil:
@@ -1158,7 +1162,7 @@ func (p *GovernancePlugin) EvaluateGovernanceRequest(ctx *schemas.BifrostContext
 
 	// Step 3: Team-level budget. Fall back to vk.Team.ID when the FK pointer is nil
 	// but the relation is populated.
-	if result.Decision == DecisionAllow && hierarchyVK != nil {
+	if !skipBudgetsAndRateLimits && result.Decision == DecisionAllow && hierarchyVK != nil {
 		var teamID string
 		switch {
 		case hierarchyVK.TeamID != nil:
@@ -1172,7 +1176,7 @@ func (p *GovernancePlugin) EvaluateGovernanceRequest(ctx *schemas.BifrostContext
 	}
 
 	// Step 4: User-level governance (enterprise-only).
-	if result.Decision == DecisionAllow {
+	if !skipBudgetsAndRateLimits && result.Decision == DecisionAllow {
 		result = p.resolver.EvaluateUserRequest(ctx, evaluationRequest.UserID, evaluationRequest)
 	}
 


### PR DESCRIPTION
## Summary

Read-only requests like `ListModels` do not consume any quota, yet they were previously subject to the full budget and rate-limit evaluation pipeline. This PR introduces a context flag that bypasses budget and rate-limit checks for such requests while still enforcing virtual key identity, active status, and provider/model filtering.

## Changes

- Added a new `BifrostContextKeySkipBudgetAndRateLimits` context key (`"bifrost-skip-budget-and-rate-limits"`) to signal that a request should skip quota enforcement.
- `ListModelsRequest` now sets this flag on the context before processing.
- In `GovernancePlugin.EvaluateGovernanceRequest`, the flag is read once and used to skip customer-level, team-level, and user-level budget/rate-limit evaluation (Steps 2–4), as well as the VK-level budget/rate-limit check (Step 1). Virtual key identity and provider/model filtering are still enforced regardless of the flag.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

- Issue a `ListModels` request using a virtual key that has an exhausted budget or an active rate limit. The request should succeed and return the model list rather than being blocked.
- Issue a `ListModels` request using an invalid or inactive virtual key. The request should still be rejected, confirming that identity checks remain enforced.
- Issue a standard chat/completion request with an exhausted budget. The request should still be blocked, confirming that the flag only applies to `ListModels`.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The skip flag is set internally by Bifrost for read-only metadata requests and is not user-controllable. Virtual key identity, active status, and provider/model access filtering are still enforced, so there is no path for an unauthorized key to exploit this bypass.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable