### PR TITLE
feat: removes system metrics from prometheus plugin and adds some more needed types

### DIFF
--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -27,7 +27,8 @@ const (
 )
 
 const (
-	startTimeKey schemas.BifrostContextKey = "bf-prom-start-time"
+	startTimeKey         schemas.BifrostContextKey = "bf-prom-start-time"
+	activeRequestTypeKey schemas.BifrostContextKey = "bf-prom-active-req-type"
 )
 
 // PushGatewayConfig holds the configuration for pushing metrics to a Prometheus Push Gateway.
@@ -61,7 +62,8 @@ type BasicAuthConfig struct {
 //   - Error counts
 type PrometheusPlugin struct {
 	pricingManager *modelcatalog.ModelCatalog
-	registry       *prometheus.Registry
+	registry       *prometheus.Registry // Bifrost metrics only — used for push gateway
+	systemRegistry *prometheus.Registry // Go/process collectors — /metrics scraping only
 
 	logger schemas.Logger
 
@@ -85,6 +87,8 @@ type PrometheusPlugin struct {
 	StreamInterTokenLatencySeconds *prometheus.HistogramVec
 	StreamFirstTokenLatencySeconds *prometheus.HistogramVec
 	KeyRotationEventsTotal         *prometheus.CounterVec
+	ActiveRequests                 *prometheus.GaugeVec
+	ProviderKeyUp                  *prometheus.GaugeVec
 	customLabels                   []string
 
 	defaultHTTPLabels    []string
@@ -122,14 +126,16 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		registry = prometheus.NewRegistry()
 	}
 
-	// Create collectors and store references for cleanup
+	// GoCollector and ProcessCollector go into a separate registry so they are served
+	// on /metrics but never pushed to the push gateway (the gateway itself registers
+	// the same metric names and conflicts/spams warnings when they collide).
+	systemRegistry := prometheus.NewRegistry()
 	goCollector := collectors.NewGoCollector()
-	if err := registry.Register(goCollector); err != nil {
+	if err := systemRegistry.Register(goCollector); err != nil {
 		return nil, fmt.Errorf("failed to register Go collector: %v", err)
 	}
-
 	processCollector := collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})
-	if err := registry.Register(processCollector); err != nil {
+	if err := systemRegistry.Register(processCollector); err != nil {
 		return nil, fmt.Errorf("failed to register process collector: %v", err)
 	}
 
@@ -301,10 +307,27 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		[]string{"provider", "requested_model", "key_id", "key_name", "fail_reason"},
 	)
 
+	bifrostActiveRequests := factory.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "bifrost_active_requests",
+			Help: "Number of LLM requests currently in-flight.",
+		},
+		[]string{"method"},
+	)
+
+	bifrostProviderKeyUp := factory.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "bifrost_provider_key_up",
+			Help: "Health of a provider key. 1 = last attempt succeeded, 0 = last attempt failed.",
+		},
+		[]string{"provider", "key_id", "key_name"},
+	)
+
 	plugin := &PrometheusPlugin{
 		logger:                         logger,
 		pricingManager:                 pricingManager,
 		registry:                       registry,
+		systemRegistry:                 systemRegistry,
 		GoCollector:                    goCollector,
 		ProcessCollector:               processCollector,
 		HTTPRequestsTotal:              httpRequestsTotal,
@@ -322,6 +345,8 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		StreamInterTokenLatencySeconds: bifrostStreamInterTokenLatencySeconds,
 		StreamFirstTokenLatencySeconds: bifrostStreamFirstTokenLatencySeconds,
 		KeyRotationEventsTotal:         bifrostKeyRotationEventsTotal,
+		ActiveRequests:                 bifrostActiveRequests,
+		ProviderKeyUp:                  bifrostProviderKeyUp,
 		customLabels:                   filteredCustomLabels,
 		defaultHTTPLabels:              defaultHTTPLabels,
 		defaultBifrostLabels:           defaultBifrostLabels,
@@ -339,6 +364,12 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 
 func (p *PrometheusPlugin) GetRegistry() *prometheus.Registry {
 	return p.registry
+}
+
+// GetMetricsGatherer returns a combined gatherer for the /metrics endpoint,
+// including both Bifrost metrics and Go/process runtime collectors.
+func (p *PrometheusPlugin) GetMetricsGatherer() prometheus.Gatherer {
+	return prometheus.Gatherers{p.registry, p.systemRegistry}
 }
 
 // GetName returns the name of the plugin.
@@ -365,6 +396,8 @@ func (p *PrometheusPlugin) HTTPTransportStreamChunkHook(ctx *schemas.BifrostCont
 // This time is used later in PostLLMHook to calculate request duration.
 func (p *PrometheusPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
 	ctx.SetValue(startTimeKey, time.Now())
+	ctx.SetValue(activeRequestTypeKey, req.RequestType)
+	p.ActiveRequests.WithLabelValues(string(req.RequestType)).Inc()
 	return req, nil, nil
 }
 
@@ -471,6 +504,14 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	streamEndIndicatorValue := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator)
 	isFinalChunk, hasFinalChunkIndicator := streamEndIndicatorValue.(bool)
 
+	// Decrement active requests on the final (or only) call for this request
+	isStreamFinal := !bifrost.IsStreamRequestType(requestType) || (hasFinalChunkIndicator && isFinalChunk)
+	if isStreamFinal {
+		if method, ok := ctx.Value(activeRequestTypeKey).(schemas.RequestType); ok {
+			p.ActiveRequests.WithLabelValues(string(method)).Dec()
+		}
+	}
+
 	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(provider))
 
 	// Calculate cost and record metrics in a separate goroutine to avoid blocking the main thread
@@ -505,7 +546,12 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 				p.KeyRotationEventsTotal.WithLabelValues(
 					string(provider), originalModel, record.KeyID, record.KeyName, *record.FailReason,
 				).Inc()
+				p.ProviderKeyUp.WithLabelValues(string(provider), record.KeyID, record.KeyName).Set(0)
 			}
+		}
+		// Mark the selected key healthy if the request ultimately succeeded
+		if bifrostErr == nil && selectedKeyID != "" {
+			p.ProviderKeyUp.WithLabelValues(string(provider), selectedKeyID, selectedKeyName).Set(1)
 		}
 
 		p.UpstreamRequestsTotal.WithLabelValues(promLabelValues...).Inc()

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1172,8 +1172,7 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	// Add Prometheus /metrics endpoint
 	prometheusPlugin, err := lib.FindPluginAs[*telemetry.PrometheusPlugin](s.Config, telemetry.PluginName)
 	if err == nil && prometheusPlugin.GetRegistry() != nil {
-		// Use the plugin's dedicated registry if available
-		metricsHandler := fasthttpadaptor.NewFastHTTPHandler(promhttp.HandlerFor(prometheusPlugin.GetRegistry(), promhttp.HandlerOpts{}))
+		metricsHandler := fasthttpadaptor.NewFastHTTPHandler(promhttp.HandlerFor(prometheusPlugin.GetMetricsGatherer(), promhttp.HandlerOpts{}))
 		s.Router.GET("/metrics", lib.ChainMiddlewares(metricsHandler, middlewares...))
 	} else {
 		logger.Warn("prometheus plugin not found or registry is nil, skipping metrics endpoint")


### PR DESCRIPTION
## Summary

Adds two new Prometheus gauges (`bifrost_active_requests` and `bifrost_provider_key_up`) and fixes a long-standing issue where Go/process runtime collectors were being pushed to the push gateway, causing metric name collisions and spurious warnings.

## Changes

- Introduced a dedicated `systemRegistry` to hold `GoCollector` and `ProcessCollector`, keeping them separate from the Bifrost-specific `registry` that is pushed to the push gateway. The `/metrics` endpoint now serves both registries via a combined `prometheus.Gatherers`.
- Added `GetMetricsGatherer()` to expose the combined gatherer for the `/metrics` scrape endpoint, while `GetRegistry()` continues to return only the Bifrost registry for push gateway use.
- Added `bifrost_active_requests` gauge (labeled by request method/type) that increments in `PreLLMHook` and decrements in `PostLLMHook` on the final or only response chunk, giving a real-time view of in-flight LLM requests.
- Added `bifrost_provider_key_up` gauge (labeled by provider, key ID, and key name) that is set to `0` when a key rotation failure is recorded and `1` when a request ultimately succeeds on a given key, enabling health-check alerting on individual provider keys.
- Updated the HTTP server's `/metrics` handler to use `GetMetricsGatherer()` instead of `GetRegistry()` so runtime metrics continue to appear in scrape output.
- Added `activeRequestTypeKey` context key to safely carry the request type from `PreLLMHook` through to `PostLLMHook` for accurate gauge decrements.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

1. Start Bifrost with the Prometheus plugin enabled.
2. Send several LLM requests (including streaming ones) and scrape `/metrics`.
3. Verify `bifrost_active_requests` increments during in-flight requests and returns to zero after completion.
4. Verify `bifrost_provider_key_up` reflects `1` for healthy keys and `0` for keys that triggered rotation.
5. If push gateway is configured, confirm Go/process metrics no longer appear in pushed payloads and no collision warnings are logged.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII implications. Gauge labels use existing provider key IDs and names already present in other metrics.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable