### PR TITLE
feat: unify OAuth flow initiation for `oauth`/`per_user_oauth`, enable credential rotation, and wrap DB writes in transactions

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -835,6 +835,13 @@ func migrationInit(ctx context.Context, db *gorm.DB) error {
 					return err
 				}
 			}
+			// TableMCPClient must be created before TableOauthConfig because
+			// TableOauthConfig.ConfigMCPClient has a FK → config_mcp_clients.
+			if !migrator.HasTable(&tables.TableMCPClient{}) {
+				if err := migrator.CreateTable(&tables.TableMCPClient{}); err != nil {
+					return err
+				}
+			}
 			if !migrator.HasTable(&tables.TableOauthConfig{}) {
 				if err := migrator.CreateTable(&tables.TableOauthConfig{}); err != nil {
 					return err
@@ -842,11 +849,6 @@ func migrationInit(ctx context.Context, db *gorm.DB) error {
 			}
 			if !migrator.HasTable(&tables.TableOauthToken{}) {
 				if err := migrator.CreateTable(&tables.TableOauthToken{}); err != nil {
-					return err
-				}
-			}
-			if !migrator.HasTable(&tables.TableMCPClient{}) {
-				if err := migrator.CreateTable(&tables.TableMCPClient{}); err != nil {
 					return err
 				}
 			}
@@ -3790,15 +3792,9 @@ func migrationAddOAuthTables(ctx context.Context, db *gorm.DB) error {
 				}
 			}
 			// Now update MCPClient table to add auth_type, oauth_config_id columns
-			// (oauth_config_id has FK constraint to oauth_configs table created above)
 			if !migrator.HasColumn(&tables.TableMCPClient{}, "auth_type") {
 				if err := migrator.AddColumn(&tables.TableMCPClient{}, "auth_type"); err != nil {
 					return fmt.Errorf("failed to add auth_type column: %w", err)
-				}
-			}
-			if !migrator.HasColumn(&tables.TableMCPClient{}, "oauth_config_id") {
-				if err := migrator.AddColumn(&tables.TableMCPClient{}, "oauth_config_id"); err != nil {
-					return fmt.Errorf("failed to add oauth_config_id column: %w", err)
 				}
 			}
 			// Set default value for auth_type column
@@ -6678,39 +6674,21 @@ func migrationAddPerUserOAuthTables(ctx context.Context, db *gorm.DB) error {
 		ID: "add_per_user_oauth_tables",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mg := tx.Migrator()
-			if !mg.HasTable(&tables.TablePerUserOAuthClient{}) {
-				if err := mg.CreateTable(&tables.TablePerUserOAuthClient{}); err != nil {
-					return fmt.Errorf("failed to create oauth_per_user_clients table: %w", err)
-				}
-			}
-			if !mg.HasTable(&tables.TablePerUserOAuthSession{}) {
-				if err := mg.CreateTable(&tables.TablePerUserOAuthSession{}); err != nil {
-					return fmt.Errorf("failed to create oauth_per_user_sessions table: %w", err)
-				}
-			}
-			if !mg.HasTable(&tables.TablePerUserOAuthCode{}) {
-				if err := mg.CreateTable(&tables.TablePerUserOAuthCode{}); err != nil {
-					return fmt.Errorf("failed to create oauth_per_user_codes table: %w", err)
-				}
-			}
-			if !mg.HasTable(&tables.TableOauthUserToken{}) {
-				if err := mg.CreateTable(&tables.TableOauthUserToken{}); err != nil {
-					return fmt.Errorf("failed to create oauth_user_tokens table: %w", err)
-				}
-			}
-			if !mg.HasTable(&tables.TableOauthUserSession{}) {
-				if err := mg.CreateTable(&tables.TableOauthUserSession{}); err != nil {
-					return fmt.Errorf("failed to create oauth_user_sessions table: %w", err)
-				}
-			}
-			if !mg.HasTable(&tables.TablePerUserOAuthPendingFlow{}) {
-				if err := mg.CreateTable(&tables.TablePerUserOAuthPendingFlow{}); err != nil {
-					return fmt.Errorf("failed to create oauth_per_user_pending_flows table: %w", err)
-				}
-			}
-
-			return nil
+			// Disable FK constraint creation during AutoMigrate so that table creation
+			// order is irrelevant — the clients ↔ sessions/pending_flows/codes tables
+			// have a circular relationship, and FK constraints are added afterwards
+			// by migrationAddOAuthRelationalConstraints.
+			orig := tx.Config.DisableForeignKeyConstraintWhenMigrating
+			tx.Config.DisableForeignKeyConstraintWhenMigrating = true
+			defer func() { tx.Config.DisableForeignKeyConstraintWhenMigrating = orig }()
+			return tx.AutoMigrate(
+				&tables.TablePerUserOAuthClient{},
+				&tables.TablePerUserOAuthSession{},
+				&tables.TablePerUserOAuthPendingFlow{},
+				&tables.TablePerUserOAuthCode{},
+				&tables.TableOauthUserToken{},
+				&tables.TableOauthUserSession{},
+			)
 		},
 		Rollback: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
@@ -7539,8 +7517,11 @@ func migrationUniqueTeamNames(ctx context.Context, db *gorm.DB) error {
 
 // migrationCleanupOAuthOrphans removes orphaned OAuth rows before FK constraints are added.
 // Runs first so the subsequent constraint migration never hits a foreign-key violation.
+// Uses the same SQLite FK pragma pattern as migrationAddOAuthRelationalConstraints so that
+// any backwards HasMany FK left on the clients table by AutoMigrate does not cause a
+// "foreign key mismatch" error when rows are deleted from the child tables.
 func migrationCleanupOAuthOrphans(ctx context.Context, db *gorm.DB) error {
-	return RunSingleMigration(ctx, db, &migrator.Migration{
+	m := migrator.New(db.WithContext(ctx), migrator.DefaultOptions, []*migrator.Migration{{
 		ID: "cleanup_oauth_orphans",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
@@ -7559,7 +7540,27 @@ func migrationCleanupOAuthOrphans(ctx context.Context, db *gorm.DB) error {
 			return nil
 		},
 		Rollback: func(tx *gorm.DB) error { return nil },
-	})
+	}})
+	if db.Dialector.Name() == "sqlite" {
+		sqlDB, err := db.DB()
+		if err != nil {
+			return fmt.Errorf("failed to get underlying sql.DB: %w", err)
+		}
+		sqlDB.SetMaxOpenConns(1)
+		defer sqlDB.SetMaxOpenConns(0)
+		if err := db.Exec("PRAGMA foreign_keys = OFF").Error; err != nil {
+			return fmt.Errorf("failed to disable SQLite foreign keys: %w", err)
+		}
+		defer func() {
+			if err := db.Exec("PRAGMA foreign_keys = ON").Error; err != nil {
+				log.Fatalf("[Migration] FATAL: failed to re-enable SQLite foreign keys: %v", err)
+			}
+		}()
+	}
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running cleanup_oauth_orphans migration: %s", err.Error())
+	}
+	return nil
 }
 
 // fkEntry pairs a GORM model with the relationship field name used by HasConstraint/CreateConstraint.
@@ -7590,17 +7591,21 @@ func migrationAddOAuthRelationalConstraints(ctx context.Context, db *gorm.DB) er
 				}
 			}
 
-			// Backfill config_mcp_client_id from the reverse pointer stored on config_mcp_clients
-			if err := tx.Exec(`
-				UPDATE oauth_configs
-				SET config_mcp_client_id = (
-					SELECT client_id FROM config_mcp_clients
-					WHERE config_mcp_clients.oauth_config_id = oauth_configs.id
-					LIMIT 1
-				)
-				WHERE config_mcp_client_id IS NULL
-			`).Error; err != nil {
-				return fmt.Errorf("backfill config_mcp_client_id: %w", err)
+			// Backfill config_mcp_client_id from the reverse pointer on config_mcp_clients
+			// (only possible on existing DBs that still have the oauth_config_id column;
+			// fresh DBs never had it, and handlers set config_mcp_client_id at insert time).
+			if mg.HasColumn(&tables.TableMCPClient{}, "oauth_config_id") {
+				if err := tx.Exec(`
+					UPDATE oauth_configs
+					SET config_mcp_client_id = (
+						SELECT client_id FROM config_mcp_clients
+						WHERE config_mcp_clients.oauth_config_id = oauth_configs.id
+						LIMIT 1
+					)
+					WHERE config_mcp_client_id IS NULL
+				`).Error; err != nil {
+					return fmt.Errorf("backfill config_mcp_client_id: %w", err)
+				}
 			}
 
 			// Backfill oauth_tokens.oauth_config_id from oauth_configs.token_id
@@ -7616,17 +7621,17 @@ func migrationAddOAuthRelationalConstraints(ctx context.Context, db *gorm.DB) er
 				return fmt.Errorf("backfill oauth_tokens.oauth_config_id: %w", err)
 			}
 
-			// Drop old (incorrect) CASCADE on config_mcp_clients.OauthConfig if it exists.
-			// That constraint deleted the MCP client when an oauth_config was deleted — backwards.
+			// The OauthConfig FK (oauth_configs → config_mcp_clients) is always dropped and
+			// recreated to ensure ON DELETE CASCADE is present — the constraint may have been
+			// created without it in an earlier run of this migration.
 			if mg.HasConstraint(&tables.TableMCPClient{}, "OauthConfig") {
 				if err := mg.DropConstraint(&tables.TableMCPClient{}, "OauthConfig"); err != nil {
-					return fmt.Errorf("drop old config_mcp_clients OauthConfig constraint: %w", err)
+					return fmt.Errorf("drop oauth_configs.config_mcp_client_id FK: %w", err)
 				}
 			}
 
-			// Create FK constraints in lifecycle order
 			for _, e := range []fkEntry{
-				{&tables.TableOauthConfig{}, "ConfigMCPClient", "oauth_configs → config_mcp_clients"},
+				{&tables.TableMCPClient{}, "OauthConfig", "oauth_configs → config_mcp_clients"},
 				{&tables.TableOauthToken{}, "OauthConfig", "oauth_tokens → oauth_configs"},
 				{&tables.TableOauthUserSession{}, "OauthConfig", "oauth_user_sessions → oauth_configs"},
 				{&tables.TableOauthUserToken{}, "OauthConfig", "oauth_user_tokens → oauth_configs"},
@@ -7639,6 +7644,14 @@ func migrationAddOAuthRelationalConstraints(ctx context.Context, db *gorm.DB) er
 					if err := mg.CreateConstraint(e.model, e.name); err != nil {
 						return fmt.Errorf("failed to create FK %s: %w", e.desc, err)
 					}
+				}
+			}
+
+			// Drop the orphaned reverse-pointer column from config_mcp_clients if it still
+			// exists (created by the old add_oauth_tables migration on pre-branch DBs).
+			if mg.HasColumn(&tables.TableMCPClient{}, "oauth_config_id") {
+				if err := mg.DropColumn(&tables.TableMCPClient{}, "oauth_config_id"); err != nil {
+					return fmt.Errorf("drop config_mcp_clients.oauth_config_id: %w", err)
 				}
 			}
 			return nil
@@ -7654,7 +7667,7 @@ func migrationAddOAuthRelationalConstraints(ctx context.Context, db *gorm.DB) er
 				{&tables.TableOauthUserToken{}, "OauthConfig", "oauth_user_tokens → oauth_configs"},
 				{&tables.TableOauthUserSession{}, "OauthConfig", "oauth_user_sessions → oauth_configs"},
 				{&tables.TableOauthToken{}, "OauthConfig", "oauth_tokens → oauth_configs"},
-				{&tables.TableOauthConfig{}, "ConfigMCPClient", "oauth_configs → config_mcp_clients"},
+				{&tables.TableMCPClient{}, "OauthConfig", "oauth_configs → config_mcp_clients"},
 			} {
 				if mg.HasConstraint(e.model, e.name) {
 					_ = mg.DropConstraint(e.model, e.name)

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1353,7 +1353,7 @@ func (s *RDBConfigStore) UpdateStatus(ctx context.Context, provider schemas.Mode
 func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, error) {
 	var dbMCPClients []tables.TableMCPClient
 	// Get all MCP clients
-	if err := s.DB().WithContext(ctx).Find(&dbMCPClients).Error; err != nil {
+	if err := s.DB().WithContext(ctx).Preload("OauthConfig").Find(&dbMCPClients).Error; err != nil {
 		return nil, err
 	}
 	var clientConfig tables.TableClientConfig
@@ -1371,7 +1371,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 					ConnectionString:          dbClient.ConnectionString,
 					StdioConfig:               dbClient.StdioConfig,
 					AuthType:                  schemas.MCPAuthType(dbClient.AuthType),
-					OauthConfigID:             dbClient.OauthConfigID,
+					OauthConfigID:             mcpClientOauthConfigID(&dbClient),
 					ToolsToExecute:            dbClient.ToolsToExecute,
 					ToolsToAutoExecute:        dbClient.ToolsToAutoExecute,
 					Headers:                   dbClient.Headers,
@@ -1411,7 +1411,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 			ConnectionString:          dbClient.ConnectionString,
 			StdioConfig:               dbClient.StdioConfig,
 			AuthType:                  schemas.MCPAuthType(dbClient.AuthType),
-			OauthConfigID:             dbClient.OauthConfigID,
+			OauthConfigID:             mcpClientOauthConfigID(&dbClient),
 			ToolsToExecute:            dbClient.ToolsToExecute,
 			ToolsToAutoExecute:        dbClient.ToolsToAutoExecute,
 			Headers:                   dbClient.Headers,
@@ -1460,6 +1460,7 @@ func (s *RDBConfigStore) GetMCPClientsPaginated(ctx context.Context, params MCPC
 
 	var clients []tables.TableMCPClient
 	if err := baseQuery.
+		Preload("OauthConfig").
 		Order("created_at ASC, client_id ASC").
 		Offset(offset).
 		Limit(limit).
@@ -1472,7 +1473,7 @@ func (s *RDBConfigStore) GetMCPClientsPaginated(ctx context.Context, params MCPC
 // GetMCPClientByID retrieves an MCP client by ID from the database.
 func (s *RDBConfigStore) GetMCPClientByID(ctx context.Context, id string) (*tables.TableMCPClient, error) {
 	var mcpClient tables.TableMCPClient
-	if err := s.DB().WithContext(ctx).Where("client_id = ?", id).First(&mcpClient).Error; err != nil {
+	if err := s.DB().WithContext(ctx).Preload("OauthConfig").Where("client_id = ?", id).First(&mcpClient).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -1496,7 +1497,7 @@ func (s *RDBConfigStore) GetMCPClientConfigByID(ctx context.Context, id string) 
 		ConnectionString:          dbClient.ConnectionString,
 		StdioConfig:               dbClient.StdioConfig,
 		AuthType:                  schemas.MCPAuthType(dbClient.AuthType),
-		OauthConfigID:             dbClient.OauthConfigID,
+		OauthConfigID:             mcpClientOauthConfigID(dbClient),
 		ToolsToExecute:            dbClient.ToolsToExecute,
 		ToolsToAutoExecute:        dbClient.ToolsToAutoExecute,
 		Headers:                   dbClient.Headers,
@@ -1549,7 +1550,6 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 		ConnectionString:      clientConfigCopy.ConnectionString,
 		StdioConfig:           clientConfigCopy.StdioConfig,
 		AuthType:              string(clientConfigCopy.AuthType),
-		OauthConfigID:         clientConfigCopy.OauthConfigID,
 		ToolsToExecute:        clientConfigCopy.ToolsToExecute,
 		ToolsToAutoExecute:    clientConfigCopy.ToolsToAutoExecute,
 		Headers:               clientConfigCopy.Headers,
@@ -1686,9 +1686,6 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 	if encrypt.IsEnabled() {
 		updates["encryption_status"] = encryptionStatusEncrypted
 	}
-	if clientConfigCopy.OauthConfigID != nil {
-		updates["oauth_config_id"] = clientConfigCopy.OauthConfigID
-	}
 	if discoveredToolsJSON != "" {
 		updates["discovered_tools_json"] = discoveredToolsJSON
 	}
@@ -1716,7 +1713,6 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 		updates["connection_string"] = connectionStringToPersist
 		updates["stdio_config_json"] = stdioConfigJSON
 		updates["auth_type"] = clientConfigCopy.AuthType
-		updates["oauth_config_id"] = clientConfigCopy.OauthConfigID
 	}
 
 	// Only update is_ping_available if explicitly provided (non-nil)
@@ -4552,9 +4548,14 @@ func (s *RDBConfigStore) DeleteOauthConfig(ctx context.Context, id string, tx ..
 	return nil
 }
 
-// UpdateOauthConfig updates an existing OAuth config
-func (s *RDBConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error {
-	result := s.DB().WithContext(ctx).Save(config)
+// UpdateOauthConfig updates an existing OAuth config.
+// An optional tx can be passed to run the update within an existing transaction.
+func (s *RDBConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig, tx ...*gorm.DB) error {
+	db := s.DB()
+	if len(tx) > 0 && tx[0] != nil {
+		db = tx[0]
+	}
+	result := db.WithContext(ctx).Save(config)
 	if result.Error != nil {
 		return fmt.Errorf("failed to update oauth config: %w", result.Error)
 	}
@@ -4602,6 +4603,28 @@ func (s *RDBConfigStore) GetOauthConfigByTokenID(ctx context.Context, tokenID st
 		return nil, fmt.Errorf("failed to get oauth config by token id: %w", result.Error)
 	}
 	return &config, nil
+}
+
+// GetOauthConfigByMCPClientID retrieves the OAuth config associated with a given MCP client.
+func (s *RDBConfigStore) GetOauthConfigByMCPClientID(ctx context.Context, mcpClientID string) (*tables.TableOauthConfig, error) {
+	var config tables.TableOauthConfig
+	result := s.DB().WithContext(ctx).Where("config_mcp_client_id = ?", mcpClientID).First(&config)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get oauth config by mcp client id: %w", result.Error)
+	}
+	return &config, nil
+}
+
+// mcpClientOauthConfigID returns the OAuth config ID from a preloaded TableMCPClient, or nil if none.
+func mcpClientOauthConfigID(c *tables.TableMCPClient) *string {
+	if c.OauthConfig == nil {
+		return nil
+	}
+	id := c.OauthConfig.ID
+	return &id
 }
 
 // ---------- Per-User OAuth Session CRUD ----------

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -300,8 +300,9 @@ type ConfigStore interface {
 	GetOauthConfigsByIDs(ctx context.Context, ids []string) (map[string]*tables.TableOauthConfig, error)
 	GetOauthConfigByState(ctx context.Context, state string) (*tables.TableOauthConfig, error)
 	GetOauthConfigByTokenID(ctx context.Context, tokenID string) (*tables.TableOauthConfig, error)
+	GetOauthConfigByMCPClientID(ctx context.Context, mcpClientID string) (*tables.TableOauthConfig, error)
 	CreateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error
-	UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error
+	UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig, tx ...*gorm.DB) error
 	DeleteOauthConfig(ctx context.Context, id string, tx ...*gorm.DB) error
 
 	// OAuth token CRUD

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -33,9 +33,8 @@ type TableMCPClient struct {
 	ToolNameMappingJSON       string `gorm:"type:text" json:"-"`                              // JSON serialized map[string]string
 
 	// OAuth authentication fields
-	AuthType      string            `gorm:"type:varchar(20);default:'headers'" json:"auth_type"`  // "none", "headers", "oauth"
-	OauthConfigID *string           `gorm:"type:varchar(255);index" json:"oauth_config_id"`       // Reference to oauth_configs.ID (no FK — cascade is handled via oauth_configs.config_mcp_client_id)
-	OauthConfig   *TableOauthConfig `gorm:"foreignKey:OauthConfigID;references:ID" json:"-"`      // Gorm relationship (no cascade — circular FK avoidance)
+	AuthType    string            `gorm:"type:varchar(20);default:'headers'" json:"auth_type"` // "none", "headers", "oauth"
+	OauthConfig *TableOauthConfig `gorm:"foreignKey:ConfigMCPClientID;references:ClientID;constraint:OnDelete:CASCADE" json:"-"` // HasOne; FK lives on oauth_configs.config_mcp_client_id → config_mcp_clients.client_id
 
 	AllowOnAllVirtualKeys bool `gorm:"default:false" json:"allow_on_all_virtual_keys"` // Whether to allow the MCP client to run on all virtual keys
 	Disabled              bool `gorm:"default:false" json:"disabled"`                  // Whether the client is intentionally disabled

--- a/framework/configstore/tables/oauth.go
+++ b/framework/configstore/tables/oauth.go
@@ -29,7 +29,7 @@ type TableOauthConfig struct {
 	UseDiscovery        bool            `gorm:"default:false" json:"use_discovery"`              // Flag to enable OAuth discovery
 	MCPClientConfigJSON *string         `gorm:"type:text" json:"-"`                              // JSON serialized MCPClientConfig for multi-instance support (pending MCP client waiting for OAuth completion)
 	ConfigMCPClientID   *string         `gorm:"type:varchar(255);index" json:"config_mcp_client_id,omitempty"`
-	ConfigMCPClient     *TableMCPClient `gorm:"foreignKey:ConfigMCPClientID;references:ClientID;constraint:OnDelete:CASCADE,OnUpdate:CASCADE" json:"-"`
+	ConfigMCPClient     *TableMCPClient `gorm:"foreignKey:ConfigMCPClientID;references:ClientID;constraint:OnDelete:CASCADE" json:"-"`
 	EncryptionStatus    string          `gorm:"type:varchar(20);default:'plain_text'" json:"-"`
 	CreatedAt           time.Time       `gorm:"index;not null" json:"created_at"`
 	UpdatedAt           time.Time       `gorm:"index;not null" json:"updated_at"`

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -333,9 +333,20 @@ func (p *OAuth2Provider) RemovePendingMCPClient(oauthConfigID string) error {
 	return nil
 }
 
-// InitiateOAuthFlow creates an OAuth config and returns the authorization URL
-// Supports OAuth discovery and PKCE
-func (p *OAuth2Provider) InitiateOAuthFlow(ctx context.Context, config *schemas.OAuth2Config) (*schemas.OAuth2FlowInitiation, error) {
+// PreparedOAuthFlow holds the result of PrepareOAuthFlow — all network work done,
+// nothing written to DB yet.
+type PreparedOAuthFlow struct {
+	// Record is the fully-populated oauth_config row ready to be inserted.
+	Record *tables.TableOauthConfig
+	// Initiation contains the authorization URL and metadata to return to the caller.
+	Initiation *schemas.OAuth2FlowInitiation
+}
+
+// PrepareOAuthFlow performs all network I/O (discovery, dynamic client registration, PKCE)
+// and builds the oauth_config record and flow initiation result, but does NOT write to the DB.
+// Call this before opening a DB transaction so the transaction only contains DB writes.
+// MCPClientID is optional. When set, it is stored as the FK on the oauth_config record.
+func (p *OAuth2Provider) PrepareOAuthFlow(ctx context.Context, config *schemas.OAuth2Config) (*PreparedOAuthFlow, error) {
 	// Generate state token for CSRF protection
 	state, err := generateSecureRandomString(32)
 	if err != nil {
@@ -478,14 +489,9 @@ func (p *OAuth2Provider) InitiateOAuthFlow(ctx context.Context, config *schemas.
 		ExpiresAt:       expiresAt,
 	}
 
-	if err := p.configStore.CreateOauthConfig(ctx, oauthConfigRecord); err != nil {
-		return nil, fmt.Errorf("failed to create oauth config: %w", err)
-	}
-
 	// Resolve env var reference to actual value for use in the authorize URL.
 	// The reference ("env.MY_VAR") is stored in DB; the resolved value is sent to the provider.
 	resolvedClientID := schemas.NewEnvVar(clientID).GetValue()
-
 	// Build authorize URL with PKCE (using dynamically registered or user-provided client_id)
 	authURL := p.buildAuthorizeURLWithPKCE(
 		authorizeURL,
@@ -496,14 +502,33 @@ func (p *OAuth2Provider) InitiateOAuthFlow(ctx context.Context, config *schemas.
 		scopes,
 	)
 
-	logger.Debug("OAuth flow initiated successfully: oauth_config_id: %s, client_id: %s", oauthConfigID, resolvedClientID)
+	logger.Debug("OAuth flow prepared: oauth_config_id: %s, client_id: %s", oauthConfigID, resolvedClientID)
 
-	return &schemas.OAuth2FlowInitiation{
-		OauthConfigID: oauthConfigID,
-		AuthorizeURL:  authURL,
-		State:         state,
-		ExpiresAt:     expiresAt,
+	return &PreparedOAuthFlow{
+		Record: oauthConfigRecord,
+		Initiation: &schemas.OAuth2FlowInitiation{
+			OauthConfigID: oauthConfigID,
+			AuthorizeURL:  authURL,
+			State:         state,
+			ExpiresAt:     expiresAt,
+		},
 	}, nil
+}
+
+// InitiateOAuthFlow creates an OAuth config and returns the authorization URL.
+// It calls PrepareOAuthFlow then persists the record. Use PrepareOAuthFlow directly
+// when you need to wrap the DB insert in a larger transaction.
+func (p *OAuth2Provider) InitiateOAuthFlow(ctx context.Context, config *schemas.OAuth2Config) (*schemas.OAuth2FlowInitiation, error) {
+	prepared, err := p.PrepareOAuthFlow(ctx, config)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.configStore.CreateOauthConfig(ctx, prepared.Record); err != nil {
+		return nil, fmt.Errorf("failed to create oauth config: %w", err)
+	}
+
+	return prepared.Initiation, nil
 }
 
 // CompleteOAuthFlow handles the OAuth callback and exchanges code for tokens

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -19,6 +19,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/oauth2"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 	"gorm.io/gorm"
@@ -304,26 +305,8 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, 
 		}
 	}
 
-	// Batch-fetch OAuth configs for clients that have one (avoids N+1 queries)
-	oauthConfigsByID := make(map[string]*configstoreTables.TableOauthConfig)
-	if h.store.ConfigStore != nil {
-		oauthIDs := make([]string, 0)
-		for _, c := range dbClients {
-			if c.OauthConfigID != nil && *c.OauthConfigID != "" {
-				oauthIDs = append(oauthIDs, *c.OauthConfigID)
-			}
-		}
-		if len(oauthIDs) > 0 {
-			fetched, err := h.store.ConfigStore.GetOauthConfigsByIDs(ctx, oauthIDs)
-			if err != nil {
-				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to fetch OAuth configs: %v", err))
-				return
-			}
-			oauthConfigsByID = fetched
-		}
-	}
-
 	// Convert DB rows to MCPClientConfig and merge with engine state
+	// OauthConfig is preloaded by GetMCPClientsPaginated — no extra queries needed.
 	clients := make([]MCPClientResponse, 0, len(dbClients))
 	for _, dbClient := range dbClients {
 		isPingAvailable := true
@@ -338,7 +321,7 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, 
 			ConnectionString:      dbClient.ConnectionString,
 			StdioConfig:           dbClient.StdioConfig,
 			AuthType:              schemas.MCPAuthType(dbClient.AuthType),
-			OauthConfigID:         dbClient.OauthConfigID,
+			OauthConfigID:         func() *string { if dbClient.OauthConfig != nil { id := dbClient.OauthConfig.ID; return &id }; return nil }(),
 			ToolsToExecute:        dbClient.ToolsToExecute,
 			ToolsToAutoExecute:    dbClient.ToolsToAutoExecute,
 			Headers:               dbClient.Headers,
@@ -349,12 +332,10 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, limitStr, 
 			AllowOnAllVirtualKeys: dbClient.AllowOnAllVirtualKeys,
 			Disabled:              dbClient.Disabled,
 		}
-		// Populate oauth client credentials from pre-fetched batch
-		if dbClient.OauthConfigID != nil {
-			if oauthCfg, ok := oauthConfigsByID[*dbClient.OauthConfigID]; ok {
-				clientConfig.OauthClientID = oauthCfg.ClientID
-				clientConfig.OauthClientSecret = oauthCfg.GetClientSecretAsEnvVar()
-			}
+		// Populate oauth client credentials from the preloaded OauthConfig
+		if dbClient.OauthConfig != nil {
+			clientConfig.OauthClientID = dbClient.OauthConfig.ClientID
+			clientConfig.OauthClientSecret = dbClient.OauthConfig.GetClientSecretAsEnvVar()
 		}
 		// Enrich VK assignments using the pre-fetched batch result (no extra DB call per client)
 		vkConfigs := []MCPVKConfigResponse{}
@@ -479,18 +460,16 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid request format: %v", err))
 		return
 	}
-
-	// Generate a unique client ID if not provided
+	// Generate a unique client ID if not provided.
 	if req.ClientID == "" {
 		req.ClientID = uuid.New().String()
 	}
 
+	// --- Validation ---
 	if err := validateToolsToExecute(req.ToolsToExecute); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid tools_to_execute: %v", err))
 		return
 	}
-	// Auto-clear tools_to_auto_execute if tools_to_execute is empty
-	// If no tools are allowed to execute, no tools can be auto-executed
 	if req.ToolsToExecute.IsEmpty() {
 		req.ToolsToAutoExecute = schemas.WhiteList{}
 	}
@@ -506,238 +485,110 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid allowed_extra_headers: %v", err))
 		return
 	}
-
-	// Handle per-user OAuth: admin does a test OAuth login to verify the configuration.
-	// Uses the same pending_oauth pattern as server-level OAuth, but on completion we
-	// verify the connection, discover tools, save the client, and discard the admin's token.
-	if req.AuthType == "per_user_oauth" {
+	isOAuth := schemas.MCPAuthType(req.AuthType) == schemas.MCPAuthTypeOauth || schemas.MCPAuthType(req.AuthType) == schemas.MCPAuthTypePerUserOauth
+	if isOAuth {
 		if req.OauthConfig == nil {
-			SendError(ctx, fasthttp.StatusBadRequest, "OAuth configuration is required when auth_type is 'per_user_oauth'")
+			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("OAuth configuration is required when auth_type is '%s'", req.AuthType))
 			return
 		}
-
 		if !req.OauthConfig.ClientID.IsSet() && req.ConnectionString.GetValue() == "" {
 			SendError(ctx, fasthttp.StatusBadRequest, "Either client_id must be provided, or server URL must be set for OAuth discovery and dynamic client registration")
 			return
 		}
-
-		redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
-
-		flowInitiation, err := h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
-			ClientID:        req.OauthConfig.ClientID,
-			ClientSecret:    req.OauthConfig.ClientSecret,
-			AuthorizeURL:    req.OauthConfig.AuthorizeURL,
-			TokenURL:        req.OauthConfig.TokenURL,
-			RegistrationURL: req.OauthConfig.RegistrationURL,
-			RedirectURI:     redirectURI,
-			Scopes:          req.OauthConfig.Scopes,
-			ServerURL:       req.ConnectionString.GetValue(),
-		})
-		if err != nil {
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initiate OAuth flow: %v", err))
-			return
-		}
-
-		toolSyncInterval := mcp.DefaultToolSyncInterval
-		if req.ToolSyncInterval != 0 {
-			toolSyncInterval = time.Duration(req.ToolSyncInterval) * time.Minute
-		} else {
-			config, err := h.store.ConfigStore.GetClientConfig(ctx)
-			if err == nil && config != nil {
-				toolSyncInterval = time.Duration(config.MCPToolSyncInterval) * time.Minute
-			}
-		}
-
-		isPingAvailable := true
-		if req.IsPingAvailable != nil {
-			isPingAvailable = *req.IsPingAvailable
-		}
-
-		pendingConfig := schemas.MCPClientConfig{
-			ID:                    req.ClientID,
-			Name:                  req.Name,
-			IsCodeModeClient:      req.IsCodeModeClient,
-			IsPingAvailable:       &isPingAvailable,
-			ToolSyncInterval:      toolSyncInterval,
-			ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
-			ConnectionString:      req.ConnectionString,
-			StdioConfig:           req.StdioConfig,
-			AuthType:              schemas.MCPAuthTypePerUserOauth,
-			OauthConfigID:         &flowInitiation.OauthConfigID,
-			ToolsToExecute:        req.ToolsToExecute,
-			ToolsToAutoExecute:    req.ToolsToAutoExecute,
-			ToolPricing:           req.ToolPricing,
-			Headers:               req.Headers,
-			AllowedExtraHeaders:   req.AllowedExtraHeaders,
-			AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
-		}
-
-		if err := h.oauthHandler.StorePendingMCPClient(flowInitiation.OauthConfigID, pendingConfig); err != nil {
-			logger.Error(fmt.Sprintf("[Add MCP Client] Failed to store pending MCP client: %v", err))
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to store pending MCP client: %v", err))
-			return
-		}
-
-		SendJSON(ctx, map[string]any{
-			"status":          "pending_oauth",
-			"message":         "Test OAuth configuration: please authorize to verify the setup. This login is only used to verify connectivity and discover available tools — it will not be saved.",
-			"oauth_config_id": flowInitiation.OauthConfigID,
-			"authorize_url":   flowInitiation.AuthorizeURL,
-			"expires_at":      flowInitiation.ExpiresAt,
-			"mcp_client_id":   req.ClientID,
-		})
-		return
-	}
-
-	// Check if server-level OAuth flow is needed
-	if req.AuthType == "oauth" {
-		if req.OauthConfig == nil {
-			SendError(ctx, fasthttp.StatusBadRequest, "OAuth configuration is required when auth_type is 'oauth'")
-			return
-		}
-
-		// Validate: Either client_id must be provided, OR we need a server URL for discovery + dynamic registration
-		// Client ID can be empty if the OAuth provider supports dynamic client registration (RFC 7591)
-		if !req.OauthConfig.ClientID.IsSet() {
-			// If no client_id, we need server URL for discovery
-			if req.ConnectionString.GetValue() == "" {
-				SendError(ctx, fasthttp.StatusBadRequest, "Either client_id must be provided, or server URL must be set for OAuth discovery and dynamic client registration")
-				return
-			}
-			// Note: The InitiateOAuthFlow will check if registration_endpoint is available
-			// and return a clear error if dynamic registration is not supported
-		}
-
-		// Build redirect URI - use Bifrost's own callback endpoint
-		redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
-
-		// Initiate OAuth flow
-		// ServerURL comes from ConnectionString (MCP server URL for OAuth discovery)
-		// ClientID is optional - will be obtained via dynamic registration if not provided
-		flowInitiation, err := h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
-			ClientID:        req.OauthConfig.ClientID,
-			ClientSecret:    req.OauthConfig.ClientSecret,
-			AuthorizeURL:    req.OauthConfig.AuthorizeURL,
-			TokenURL:        req.OauthConfig.TokenURL,
-			RegistrationURL: req.OauthConfig.RegistrationURL,
-			RedirectURI:     redirectURI,
-			Scopes:          req.OauthConfig.Scopes,
-			ServerURL:       req.ConnectionString.GetValue(),
-		})
-		if err != nil {
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initiate OAuth flow: %v", err))
-			return
-		}
-
-		toolSyncInterval := mcp.DefaultToolSyncInterval
-		if req.ToolSyncInterval != 0 {
-			toolSyncInterval = time.Duration(req.ToolSyncInterval) * time.Minute
-		} else {
-			config, err := h.store.ConfigStore.GetClientConfig(ctx)
-			if err != nil {
-				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get client config: %v", err))
-				return
-			}
-			if config != nil {
-				toolSyncInterval = time.Duration(config.MCPToolSyncInterval) * time.Minute
-			}
-		}
-
-		// Store MCP client config in OAuth provider memory (not in database)
-		// It will be stored in database only after OAuth completion
-		pendingConfig := schemas.MCPClientConfig{
-			ID:                    req.ClientID,
-			Name:                  req.Name,
-			IsCodeModeClient:      req.IsCodeModeClient,
-			IsPingAvailable:       req.IsPingAvailable,
-			ToolSyncInterval:      toolSyncInterval,
-			ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
-			ConnectionString:      req.ConnectionString,
-			StdioConfig:           req.StdioConfig,
-			AuthType:              schemas.MCPAuthType(req.AuthType),
-			OauthConfigID:         &flowInitiation.OauthConfigID,
-			ToolsToExecute:        req.ToolsToExecute,
-			ToolsToAutoExecute:    req.ToolsToAutoExecute,
-			Headers:               req.Headers,
-			AllowedExtraHeaders:   req.AllowedExtraHeaders,
-			ToolPricing:           req.ToolPricing,
-			AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
-		}
-
-		// Store pending config in database (associated with oauth_config_id for multi-instance support)
-		if err := h.oauthHandler.StorePendingMCPClient(flowInitiation.OauthConfigID, pendingConfig); err != nil {
-			logger.Error(fmt.Sprintf("[Add MCP Client] Failed to store pending MCP client: %v", err))
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to store pending MCP client: %v", err))
-			return
-		}
-
-		// Return OAuth flow initiation response with actionable next-step hints
-		// so API/CLI users know how to complete the flow without consulting docs.
-		completeURL := fmt.Sprintf("/api/mcp/client/%s/complete-oauth", flowInitiation.OauthConfigID)
-		statusURL := fmt.Sprintf("/api/oauth/config/%s/status", flowInitiation.OauthConfigID)
-		SendJSON(ctx, map[string]any{
-			"status":          "pending_oauth",
-			"message":         "OAuth authorization required",
-			"oauth_config_id": flowInitiation.OauthConfigID,
-			"authorize_url":   flowInitiation.AuthorizeURL,
-			"expires_at":      flowInitiation.ExpiresAt,
-			"mcp_client_id":   req.ClientID,
-			"complete_url":    completeURL,
-			"status_url":      statusURL,
-			"next_steps": []string{
-				"1. Open authorize_url in a browser to approve access",
-				"2. Poll status_url to check when status becomes 'authorized'",
-				"3. POST complete_url to activate the MCP client",
-			},
-		})
-		return
 	}
 
 	toolSyncInterval := mcp.DefaultToolSyncInterval
 	if req.ToolSyncInterval != 0 {
 		toolSyncInterval = time.Duration(req.ToolSyncInterval) * time.Minute
 	} else {
-		config, err := h.store.ConfigStore.GetClientConfig(ctx)
-		if err != nil {
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get client config: %v", err))
-			return
-		}
-		if config != nil {
+		if config, err := h.store.ConfigStore.GetClientConfig(ctx); err == nil && config != nil {
 			toolSyncInterval = time.Duration(config.MCPToolSyncInterval) * time.Minute
 		}
 	}
 
-	// Convert to schemas.MCPClientConfig for runtime bifrost client (without tool_pricing)
-	schemasConfig := &schemas.MCPClientConfig{
+	newClientConfig := &schemas.MCPClientConfig{
 		ID:                    req.ClientID,
 		Name:                  req.Name,
 		IsCodeModeClient:      req.IsCodeModeClient,
+		IsPingAvailable:       req.IsPingAvailable,
+		ToolSyncInterval:      toolSyncInterval,
 		ConnectionType:        schemas.MCPConnectionType(req.ConnectionType),
 		ConnectionString:      req.ConnectionString,
 		StdioConfig:           req.StdioConfig,
+		AuthType:              schemas.MCPAuthType(req.AuthType),
 		ToolsToExecute:        req.ToolsToExecute,
 		ToolsToAutoExecute:    req.ToolsToAutoExecute,
 		Headers:               req.Headers,
 		AllowedExtraHeaders:   req.AllowedExtraHeaders,
-		AuthType:              schemas.MCPAuthType(req.AuthType),
-		OauthConfigID:         req.OauthConfigID,
-		IsPingAvailable:       req.IsPingAvailable,
-		ToolSyncInterval:      toolSyncInterval,
 		ToolPricing:           req.ToolPricing,
 		AllowOnAllVirtualKeys: req.AllowOnAllVirtualKeys,
 	}
 
-	// Creating MCP client config in config store
-	if h.store.ConfigStore != nil {
-		if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, schemasConfig); err != nil {
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
+	// --- Network I/O (OAuth only, before any DB writes) ---
+	var prepared *oauth2.PreparedOAuthFlow
+	if isOAuth {
+		redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
+		p, err := h.oauthHandler.PrepareOAuthFlow(ctx, OAuthInitiationRequest{
+			ClientID:        req.OauthConfig.ClientID,
+			ClientSecret:    req.OauthConfig.ClientSecret,
+			AuthorizeURL:    req.OauthConfig.AuthorizeURL,
+			TokenURL:        req.OauthConfig.TokenURL,
+			RegistrationURL: req.OauthConfig.RegistrationURL,
+			RedirectURI:     redirectURI,
+			Scopes:          req.OauthConfig.Scopes,
+			ServerURL:       req.ConnectionString.GetValue(),
+		})
+		if err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to prepare OAuth flow: %v", err))
 			return
 		}
+		prepared = p
+		configJSON, err := json.Marshal(newClientConfig)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to marshal MCP client config: %v", err))
+			return
+		}
+		configStr := string(configJSON)
+		prepared.Record.MCPClientConfigJSON = &configStr
 	}
-	if err := h.mcpManager.AddMCPClient(ctx, schemasConfig); err != nil {
-		// Delete the created config from config store
+
+	// --- DB writes ---
+	if isOAuth {
+		if err := h.store.ConfigStore.CreateOauthConfig(ctx, prepared.Record); err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create OAuth config: %v", err))
+			return
+		}
+
+		resp := map[string]any{
+			"status":          "pending_oauth",
+			"oauth_config_id": prepared.Initiation.OauthConfigID,
+			"authorize_url":   prepared.Initiation.AuthorizeURL,
+			"expires_at":      prepared.Initiation.ExpiresAt,
+			"mcp_client_id":   req.ClientID,
+		}
+		if req.AuthType == string(schemas.MCPAuthTypePerUserOauth) {
+			resp["message"] = "Test OAuth configuration: please authorize to verify the setup. This login is only used to verify connectivity and discover available tools — it will not be saved."
+		} else {
+			resp["message"] = "OAuth authorization required"
+			resp["complete_url"] = fmt.Sprintf("/api/mcp/client/%s/complete-oauth", prepared.Initiation.OauthConfigID)
+			resp["status_url"] = fmt.Sprintf("/api/oauth/config/%s/status", prepared.Initiation.OauthConfigID)
+			resp["next_steps"] = []string{
+				"1. Open authorize_url in a browser to approve access",
+				"2. Poll status_url to check when status becomes 'authorized'",
+				"3. POST complete_url to activate the MCP client",
+			}
+		}
+		SendJSON(ctx, resp)
+		return
+	}
+
+	if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, newClientConfig); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
+		return
+	}
+	if err := h.mcpManager.AddMCPClient(ctx, newClientConfig); err != nil {
 		if h.store.ConfigStore != nil {
-			if err := h.store.ConfigStore.DeleteMCPClientConfig(ctx, schemasConfig.ID); err != nil {
+			if err := h.store.ConfigStore.DeleteMCPClientConfig(ctx, newClientConfig.ID); err != nil {
 				logger.Error(fmt.Sprintf("Failed to delete MCP client config from database: %v. please restart bifrost to keep core and database in sync", err))
 				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to delete MCP client config from database: %v. please restart bifrost to keep core and database in sync", err))
 				return
@@ -772,7 +623,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	}
 	req.ClientID = id
 
-	// Fetch existing config first — needed to resolve optional fields before validation.
+	// Fetch existing config — needed to resolve optional fields and enforce immutable constraints.
 	var existingConfig *schemas.MCPClientConfig
 	if h.store.MCPConfig != nil {
 		for i, client := range h.store.MCPConfig.ClientConfigs {
@@ -786,7 +637,9 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusNotFound, "MCP client not found")
 		return
 	}
-	// connection_type and auth_type and connection string are permanently immutable
+
+	// --- Validation ---
+	// connection_type, auth_type, connection_string, and stdio_config are permanently immutable
 	if req.ConnectionType != "" && req.ConnectionType != string(existingConfig.ConnectionType) {
 		SendError(ctx, fasthttp.StatusBadRequest, "connection_type cannot be changed for an existing MCP client")
 		return
@@ -816,17 +669,14 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		resolvedToolsToAutoExecute = *req.ToolsToAutoExecute
 	}
 
-	// Validate tools_to_execute
 	if err := validateToolsToExecute(resolvedToolsToExecute); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid tools_to_execute: %v", err))
 		return
 	}
-	// Validate tools_to_auto_execute
 	if err := validateToolsToAutoExecute(resolvedToolsToAutoExecute, resolvedToolsToExecute); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid tools_to_auto_execute: %v", err))
 		return
 	}
-	// Validate client name
 	if err := mcp.ValidateMCPClientName(req.Name); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid client name: %v", err))
 		return
@@ -835,110 +685,94 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid allowed_extra_headers: %v", err))
 		return
 	}
-
-	// OAuth credential rotation is temporarily disabled.
 	if req.OauthConfig != nil {
-		SendError(ctx, fasthttp.StatusBadRequest, "updating oauth_config is not supported")
+		if existingConfig.AuthType != schemas.MCPAuthTypeOauth && existingConfig.AuthType != schemas.MCPAuthTypePerUserOauth {
+			SendError(ctx, fasthttp.StatusBadRequest, "oauth_config can only be updated for MCP clients using auth_type 'oauth' or 'per_user_oauth'")
+			return
+		}
+		if req.Disabled {
+			SendError(ctx, fasthttp.StatusBadRequest, "oauth credentials cannot be rotated while disabling a client; send these as two separate requests")
+			return
+		}
+	}
+
+	// --- Network I/O (OAuth re-auth only) ---
+	// Initiates a fresh OAuth flow; the MCP client record is not changed until completeMCPClientOAuth is called.
+	if req.OauthConfig != nil {
+		var existingOauthConfig *configstoreTables.TableOauthConfig
+		if existingConfig.OauthConfigID != nil && *existingConfig.OauthConfigID != "" {
+			existingOauthConfig, err = h.store.ConfigStore.GetOauthConfigByID(ctx, *existingConfig.OauthConfigID)
+			if err != nil {
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get existing OAuth config: %v", err))
+				return
+			}
+		}
+
+		clientID, clientSecret, authorizeURL, tokenURL, registrationURL, scopes := resolveOAuthReauthParams(req.OauthConfig, existingOauthConfig)
+
+		redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
+		prepared, err := h.oauthHandler.PrepareOAuthFlow(ctx, OAuthInitiationRequest{
+			MCPClientID:     id,
+			ClientID:        clientID,
+			ClientSecret:    clientSecret,
+			AuthorizeURL:    authorizeURL,
+			TokenURL:        tokenURL,
+			RegistrationURL: registrationURL,
+			Scopes:          scopes,
+			ServerURL:       existingConfig.ConnectionString.GetValue(),
+			RedirectURI:     redirectURI,
+		})
+		if err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to prepare OAuth re-auth flow: %v", err))
+			return
+		}
+
+		// Embed the current client config (with the new OauthConfigID) so completeMCPClientOAuth can reconstruct it.
+		pendingConfig := *existingConfig
+		pendingConfig.OauthConfigID = &prepared.Initiation.OauthConfigID
+		configJSON, err := json.Marshal(pendingConfig)
+		if err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to marshal MCP client config: %v", err))
+			return
+		}
+		configStr := string(configJSON)
+		prepared.Record.MCPClientConfigJSON = &configStr
+
+		if err := h.store.ConfigStore.CreateOauthConfig(ctx, prepared.Record); err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create OAuth config for re-auth: %v", err))
+			return
+		}
+
+		SendJSON(ctx, map[string]any{
+			"status":          "pending_oauth",
+			"oauth_config_id": prepared.Initiation.OauthConfigID,
+			"authorize_url":   prepared.Initiation.AuthorizeURL,
+			"expires_at":      prepared.Initiation.ExpiresAt,
+			"mcp_client_id":   id,
+			"message":         "OAuth re-authorization required",
+			"complete_url":    fmt.Sprintf("/api/mcp/client/%s/complete-oauth", prepared.Initiation.OauthConfigID),
+			"status_url":      fmt.Sprintf("/api/oauth/config/%s/status", prepared.Initiation.OauthConfigID),
+		})
 		return
 	}
-	// shouldRotateOAuthConfig := req.OauthConfig != nil && (existingConfig.AuthType == schemas.MCPAuthTypeOauth || existingConfig.AuthType == schemas.MCPAuthTypePerUserOauth)
-	// var oauthClientID *schemas.EnvVar
-	// var oauthClientSecret *schemas.EnvVar
-	// oauthAuthorizeURL := ""
-	// oauthTokenURL := ""
-	// oauthRegistrationURL := ""
-	// oauthScopes := []string{}
-	// if req.OauthConfig != nil && !shouldRotateOAuthConfig {
-	// 	SendError(ctx, fasthttp.StatusBadRequest, "oauth_config can only be updated for MCP clients using auth_type 'oauth' or 'per_user_oauth'")
-	// 	return
-	// }
-	// if shouldRotateOAuthConfig && req.Disabled {
-	// 	SendError(ctx, fasthttp.StatusBadRequest, "oauth credentials cannot be rotated while disabling a client; send these as two separate requests")
-	// 	return
-	// }
-	// if shouldRotateOAuthConfig {
-	// 	if req.OauthConfig.ClientID.ShouldPreserveStored() && req.OauthConfig.ClientSecret.ShouldPreserveStored() {
-	// 		shouldRotateOAuthConfig = false
-	// 	}
-	// }
-	// if shouldRotateOAuthConfig {
-	// 	oauthClientID = req.OauthConfig.ClientID
-	// 	oauthClientSecret = req.OauthConfig.ClientSecret
-	// 	oauthAuthorizeURL = strings.TrimSpace(req.OauthConfig.AuthorizeURL)
-	// 	oauthTokenURL = strings.TrimSpace(req.OauthConfig.TokenURL)
-	// 	oauthRegistrationURL = strings.TrimSpace(req.OauthConfig.RegistrationURL)
-	// 	oauthScopes = req.OauthConfig.Scopes
-	// 	if !oauthClientID.IsSet() && !oauthClientSecret.IsSet() {
-	// 		SendError(ctx, fasthttp.StatusBadRequest, "oauth_config.client_id or oauth_config.client_secret is required when updating OAuth credentials")
-	// 		return
-	// 	}
-	// 	var existingOauthConfig *configstoreTables.TableOauthConfig
-	// 	if existingConfig.OauthConfigID != nil && *existingConfig.OauthConfigID != "" {
-	// 		existingOauthConfig, err = h.store.ConfigStore.GetOauthConfigByID(ctx, *existingConfig.OauthConfigID)
-	// 		if err != nil {
-	// 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get existing OAuth config: %v", err))
-	// 			return
-	// 		}
-	// 		if existingOauthConfig != nil {
-	// 			if oauthAuthorizeURL == "" {
-	// 				oauthAuthorizeURL = strings.TrimSpace(existingOauthConfig.AuthorizeURL)
-	// 			}
-	// 			if oauthTokenURL == "" {
-	// 				oauthTokenURL = strings.TrimSpace(existingOauthConfig.TokenURL)
-	// 			}
-	// 			if oauthRegistrationURL == "" && existingOauthConfig.RegistrationURL != nil {
-	// 				oauthRegistrationURL = strings.TrimSpace(*existingOauthConfig.RegistrationURL)
-	// 			}
-	// 			if len(oauthScopes) == 0 && strings.TrimSpace(existingOauthConfig.Scopes) != "" {
-	// 				var existingScopes []string
-	// 				if err := json.Unmarshal([]byte(existingOauthConfig.Scopes), &existingScopes); err != nil {
-	// 					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to parse existing OAuth scopes: %v", err))
-	// 					return
-	// 				}
-	// 				oauthScopes = existingScopes
-	// 			}
-	// 		}
-	// 	}
-	// 	if !oauthClientID.IsSet() || oauthClientID.ShouldPreserveStored() {
-	// 		if existingOauthConfig == nil || !existingOauthConfig.ClientID.IsSet() {
-	// 			SendError(ctx, fasthttp.StatusBadRequest, "existing OAuth client_id not found; provide oauth_config.client_id")
-	// 			return
-	// 		}
-	// 		oauthClientID = existingOauthConfig.ClientID // preserve env var reference
-	// 	}
-	// 	if !oauthClientSecret.IsSet() || oauthClientSecret.ShouldPreserveStored() {
-	// 		if existingOauthConfig != nil {
-	// 			oauthClientSecret = existingOauthConfig.ClientSecret // preserve stored secret
-	// 		}
-	// 	}
-	// 	requiresDiscoveryOrRegistration := !oauthClientID.IsSet() || oauthAuthorizeURL == "" || oauthTokenURL == ""
-	// 	if requiresDiscoveryOrRegistration && (existingConfig.ConnectionString == nil || existingConfig.ConnectionString.GetValue() == "") {
-	// 		SendError(ctx, fasthttp.StatusBadRequest, "existing connection_string is required when OAuth discovery or dynamic registration is needed")
-	// 		return
-	// 	}
-	// }
-	// Merge redacted values - preserve old values if incoming values are redacted and unchanged
+
+	// --- DB + runtime ---
+	// Merge redacted values — preserve old values if incoming values are redacted and unchanged
 	merged := mergeMCPRedactedValues(&req.TableMCPClient, existingConfig, h.store.RedactMCPClientConfig(existingConfig))
 	req.TableMCPClient = *merged
 
-	var oldDBConfig *configstoreTables.TableMCPClient
-	if h.store.ConfigStore != nil {
-		var err error
-		oldDBConfig, err = h.store.ConfigStore.GetMCPClientByID(ctx, id)
-		if err != nil {
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get existing mcp client config: %v", err))
-			return
-		}
+	oldDBConfig, err := h.store.ConfigStore.GetMCPClientByID(ctx, id)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get existing mcp client config: %v", err))
+		return
 	}
 
 	req.TableMCPClient.ToolsToExecute = resolvedToolsToExecute
 	req.TableMCPClient.ToolsToAutoExecute = resolvedToolsToAutoExecute
 	dbUpdateRecord := req.TableMCPClient
-	if h.store.ConfigStore != nil {
-		if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, id, &dbUpdateRecord); err != nil {
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to update mcp client config in store: %v", err))
-			return
-		}
+	if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, id, &dbUpdateRecord); err != nil {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to update mcp client config in store: %v", err))
+		return
 	}
 
 	toolSyncInterval := mcp.DefaultToolSyncInterval
@@ -954,6 +788,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 			toolSyncInterval = time.Duration(config.MCPToolSyncInterval) * time.Minute
 		}
 	}
+
 	// Convert to schemas.MCPClientConfig for runtime bifrost client (without tool_pricing)
 	schemasConfig := &schemas.MCPClientConfig{
 		ID:                    req.ClientID,
@@ -978,7 +813,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	// Update MCP client config in memory (always — applies name/tools/header changes,
 	if err := h.mcpManager.UpdateMCPClient(ctx, id, schemasConfig); err != nil {
 		// Rollback DB update to keep DB and memory in sync
-		if h.store.ConfigStore != nil && oldDBConfig != nil {
+		if oldDBConfig != nil {
 			if rollbackErr := h.store.ConfigStore.UpdateMCPClientConfig(ctx, id, oldDBConfig); rollbackErr != nil {
 				logger.Error(fmt.Sprintf("Failed to rollback MCP client DB update: %v. please restart bifrost to keep core and database in sync", rollbackErr))
 			}
@@ -989,7 +824,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	}
 
 	// Manage VK assignments if vk_configs was provided
-	if req.VKConfigs != nil && h.store.ConfigStore != nil {
+	if req.VKConfigs != nil {
 		current, err := h.store.ConfigStore.GetVirtualKeyMCPConfigsByMCPClientID(ctx, oldDBConfig.ID)
 		if err != nil {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get current VK MCP configs: %v", err))
@@ -1081,44 +916,6 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 			}
 		}
 	}
-
-	// if shouldRotateOAuthConfig {
-	// 	redirectURI := lib.BuildBaseURL(ctx, h.store.GetMCPExternalClientURL()) + "/api/oauth/callback"
-	// 	serverURL := ""
-	// 	if existingConfig.ConnectionString != nil {
-	// 		serverURL = existingConfig.ConnectionString.GetValue()
-	// 	}
-	// 	flowInitiation, err := h.oauthHandler.InitiateOAuthFlow(ctx, OAuthInitiationRequest{
-	// 		ClientID:        oauthClientID,
-	// 		ClientSecret:    oauthClientSecret,
-	// 		AuthorizeURL:    oauthAuthorizeURL,
-	// 		TokenURL:        oauthTokenURL,
-	// 		RegistrationURL: oauthRegistrationURL,
-	// 		RedirectURI:     redirectURI,
-	// 		Scopes:          oauthScopes,
-	// 		ServerURL:       serverURL,
-	// 	})
-	// 	if err != nil {
-	// 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to initiate OAuth flow: %v", err))
-	// 		return
-	// 	}
-	// 	pendingConfig := *schemasConfig
-	// 	pendingConfig.OauthConfigID = &flowInitiation.OauthConfigID
-	// 	pendingConfig.Headers = req.Headers
-	// 	if err := h.oauthHandler.StorePendingMCPClient(flowInitiation.OauthConfigID, pendingConfig); err != nil {
-	// 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to store pending MCP client update: %v", err))
-	// 		return
-	// 	}
-	// 	SendJSON(ctx, map[string]any{
-	// 		"status":          "pending_oauth",
-	// 		"message":         "MCP client updated. OAuth re-authorization is required to apply credential rotation.",
-	// 		"oauth_config_id": flowInitiation.OauthConfigID,
-	// 		"authorize_url":   flowInitiation.AuthorizeURL,
-	// 		"expires_at":      flowInitiation.ExpiresAt,
-	// 		"mcp_client_id":   req.ClientID,
-	// 	})
-	// 	return
-	// }
 
 	SendJSON(ctx, map[string]any{
 		"status":  "success",
@@ -1279,6 +1076,45 @@ func mergeMCPRedactedValues(incoming *configstoreTables.TableMCPClient, oldRaw, 
 	return merged
 }
 
+// resolveOAuthReauthParams merges request OAuth params with stored values,
+// using request values when provided and falling back to the existing oauth_config.
+func resolveOAuthReauthParams(req *OAuthConfigRequest, existing *configstoreTables.TableOauthConfig) (
+	clientID *schemas.EnvVar,
+	clientSecret *schemas.EnvVar,
+	authorizeURL, tokenURL, registrationURL string,
+	scopes []string,
+) {
+	clientID = req.ClientID
+	clientSecret = req.ClientSecret
+	authorizeURL = req.AuthorizeURL
+	tokenURL = req.TokenURL
+	registrationURL = req.RegistrationURL
+	scopes = req.Scopes
+
+	if existing == nil {
+		return
+	}
+	if clientID == nil || clientID.ShouldPreserveStored() {
+		clientID = existing.ClientID
+	}
+	if clientSecret == nil || clientSecret.ShouldPreserveStored() {
+		clientSecret = existing.ClientSecret
+	}
+	if authorizeURL == "" {
+		authorizeURL = existing.AuthorizeURL
+	}
+	if tokenURL == "" {
+		tokenURL = existing.TokenURL
+	}
+	if registrationURL == "" && existing.RegistrationURL != nil {
+		registrationURL = *existing.RegistrationURL
+	}
+	if len(scopes) == 0 && existing.Scopes != "" {
+		_ = json.Unmarshal([]byte(existing.Scopes), &scopes)
+	}
+	return
+}
+
 // updateMCPClientWithRetry calls mcpManager.UpdateMCPClient with a short retry loop
 func (h *MCPHandler) updateMCPClientWithRetry(ctx context.Context, id string, config *schemas.MCPClientConfig) error {
 	const maxAttempts = 3
@@ -1328,6 +1164,8 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP operations unavailable: config store is disabled")
 		return
 	}
+
+	// --- Setup & validation ---
 	oauthConfigID, err := getIDFromCtx(ctx)
 	if err != nil {
 		logger.Error(fmt.Sprintf("[OAuth Complete] Invalid oauth_config_id: %v", err))
@@ -1337,18 +1175,15 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 
 	logger.Debug(fmt.Sprintf("[OAuth Complete] Completing OAuth for oauth_config_id: %s", oauthConfigID))
 
-	// Check if OAuth flow is authorized
 	oauthConfig, err := h.store.ConfigStore.GetOauthConfigByID(ctx, oauthConfigID)
 	if err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get OAuth config: %v", err))
 		return
 	}
-
 	if oauthConfig == nil {
 		SendError(ctx, fasthttp.StatusNotFound, "OAuth config not found")
 		return
 	}
-
 	if oauthConfig.Status != "authorized" {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("OAuth not authorized yet. Current status: %s", oauthConfig.Status))
 		return
@@ -1365,22 +1200,22 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusNotFound, "MCP client not found in pending OAuth clients. The OAuth flow may have expired or already been completed.")
 		return
 	}
+	mcpClientConfig.OauthConfigID = &oauthConfigID
+	isOauthPerUser := mcpClientConfig.AuthType == schemas.MCPAuthTypePerUserOauth
 
-	// If pending config points to an existing client, this is an OAuth credential update.
 	var existingDBConfig *configstoreTables.TableMCPClient
-	if h.store.ConfigStore != nil {
-		existingDBConfig, err = h.store.ConfigStore.GetMCPClientByID(ctx, mcpClientConfig.ID)
-		if err != nil && !errors.Is(err, configstore.ErrNotFound) {
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get existing mcp client config: %v", err))
-			return
-		}
+	existingDBConfig, err = h.store.ConfigStore.GetMCPClientByID(ctx, mcpClientConfig.ID)
+	if err != nil && !errors.Is(err, configstore.ErrNotFound) {
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get existing mcp client config: %v", err))
+		return
 	}
 	isUpdateFlow := existingDBConfig != nil
 
-	// Handle per-user OAuth completion: verify connection with admin's temp token,
-	// discover tools, create client (without persistent connection), discard token.
-	if mcpClientConfig.AuthType == schemas.MCPAuthTypePerUserOauth {
-		// Get admin's temporary access token for verification
+	// --- Network (per_user_oauth only) ---
+	// Get admin's temp token, verify the connection, discover tools, then discard the token.
+	var tools map[string]schemas.ChatTool
+	var toolNameMapping map[string]string
+	if isOauthPerUser {
 		accessToken, err := h.oauthHandler.GetAccessToken(ctx, oauthConfigID)
 		if err != nil {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to get admin access token for verification: %v", err))
@@ -1391,77 +1226,113 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		defer h.oauthHandler.RemovePendingMCPClient(oauthConfigID)
 
 		// Verify connection and discover tools using admin's temp token
-		tools, toolNameMapping, err := h.mcpManager.VerifyPerUserOAuthConnection(ctx, mcpClientConfig, accessToken)
+		tools, toolNameMapping, err = h.mcpManager.VerifyPerUserOAuthConnection(ctx, mcpClientConfig, accessToken)
 		if err != nil {
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("OAuth configuration test failed: %v", err))
 			return
 		}
-
 		// Attach discovered tools before persisting so the DB row includes them from the start.
 		mcpClientConfig.DiscoveredTools = tools
 		mcpClientConfig.DiscoveredToolNameMapping = toolNameMapping
+	}
 
-		if isUpdateFlow {
-			oldDBConfig := *existingDBConfig
-			updateReq := &configstoreTables.TableMCPClient{
-				ClientID:                  mcpClientConfig.ID,
-				Name:                      mcpClientConfig.Name,
-				IsCodeModeClient:          mcpClientConfig.IsCodeModeClient,
-				ConnectionType:            string(mcpClientConfig.ConnectionType),
-				ConnectionString:          mcpClientConfig.ConnectionString,
-				StdioConfig:               mcpClientConfig.StdioConfig,
-				AuthType:                  string(mcpClientConfig.AuthType),
-				OauthConfigID:             mcpClientConfig.OauthConfigID,
-				ToolsToExecute:            mcpClientConfig.ToolsToExecute,
-				ToolsToAutoExecute:        mcpClientConfig.ToolsToAutoExecute,
-				Headers:                   mcpClientConfig.Headers,
-				AllowedExtraHeaders:       mcpClientConfig.AllowedExtraHeaders,
-				IsPingAvailable:           mcpClientConfig.IsPingAvailable,
-				ToolPricing:               mcpClientConfig.ToolPricing,
-				ToolSyncInterval:          int(mcpClientConfig.ToolSyncInterval / time.Second),
-				AllowOnAllVirtualKeys:     mcpClientConfig.AllowOnAllVirtualKeys,
-				DiscoveredTools:           mcpClientConfig.DiscoveredTools,
-				DiscoveredToolNameMapping: mcpClientConfig.DiscoveredToolNameMapping,
-				Disabled:                  mcpClientConfig.Disabled,
+	updateReq := &configstoreTables.TableMCPClient{
+		ClientID:                  mcpClientConfig.ID,
+		Name:                      mcpClientConfig.Name,
+		IsCodeModeClient:          mcpClientConfig.IsCodeModeClient,
+		ConnectionType:            string(mcpClientConfig.ConnectionType),
+		ConnectionString:          mcpClientConfig.ConnectionString,
+		StdioConfig:               mcpClientConfig.StdioConfig,
+		AuthType:                  string(mcpClientConfig.AuthType),
+		ToolsToExecute:            mcpClientConfig.ToolsToExecute,
+		ToolsToAutoExecute:        mcpClientConfig.ToolsToAutoExecute,
+		Headers:                   mcpClientConfig.Headers,
+		AllowedExtraHeaders:       mcpClientConfig.AllowedExtraHeaders,
+		IsPingAvailable:           mcpClientConfig.IsPingAvailable,
+		ToolPricing:               mcpClientConfig.ToolPricing,
+		ToolSyncInterval:          int(mcpClientConfig.ToolSyncInterval / time.Second),
+		AllowOnAllVirtualKeys:     mcpClientConfig.AllowOnAllVirtualKeys,
+		DiscoveredTools:           mcpClientConfig.DiscoveredTools,
+		DiscoveredToolNameMapping: mcpClientConfig.DiscoveredToolNameMapping,
+		Disabled:                  mcpClientConfig.Disabled,
+	}
+	if isUpdateFlow {
+		// Atomically persist the new config and purge stale credentials before touching the runtime.
+		// Cascades to oauth_tokens, oauth_user_sessions, and oauth_user_tokens.
+		oldOauthConfigID := ""
+		if existingDBConfig.OauthConfig != nil && existingDBConfig.OauthConfig.ID != "" &&
+			existingDBConfig.OauthConfig.ID != oauthConfigID {
+			oldOauthConfigID = existingDBConfig.OauthConfig.ID
+		}
+		if err := h.store.ConfigStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+			if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, mcpClientConfig.ID, updateReq, tx); err != nil {
+				return fmt.Errorf("update MCP client config: %w", err)
 			}
-			if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, mcpClientConfig.ID, updateReq); err != nil {
-				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to update MCP config: %v", err))
-				return
+			oauthConfig.ConfigMCPClientID = &mcpClientConfig.ID
+			if err := h.store.ConfigStore.UpdateOauthConfig(ctx, oauthConfig, tx); err != nil {
+				return fmt.Errorf("link new oauth config to mcp client: %w", err)
 			}
-			if err := h.updateMCPClientWithRetry(ctx, mcpClientConfig.ID, mcpClientConfig); err != nil {
-				if rollbackErr := h.store.ConfigStore.UpdateMCPClientConfig(ctx, mcpClientConfig.ID, &oldDBConfig); rollbackErr != nil {
-					logger.Error(fmt.Sprintf("Failed to rollback MCP client DB update: %v. please restart bifrost to keep core and database in sync", rollbackErr))
+			if oldOauthConfigID != "" {
+				if err := h.store.ConfigStore.DeleteOauthConfig(ctx, oldOauthConfigID, tx); err != nil {
+					return fmt.Errorf("delete old oauth config: %w", err)
 				}
-				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to update MCP client: %v", err))
-				return
 			}
-		} else {
-			// Persist MCP client config in config store (BeforeSave hook serializes DiscoveredTools)
-			if h.store.ConfigStore != nil {
-				if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, mcpClientConfig); err != nil {
-					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
-					return
-				}
-			}
-
-			// Add MCP client to manager (skips connection for per_user_oauth)
-			if err := h.mcpManager.AddMCPClient(ctx, mcpClientConfig); err != nil {
-				// Clean up DB entry on failure
-				if h.store.ConfigStore != nil {
-					if delErr := h.store.ConfigStore.DeleteMCPClientConfig(ctx, mcpClientConfig.ID); delErr != nil {
-						logger.Error(fmt.Sprintf("Failed to delete MCP client config from database: %v. please restart bifrost to keep core and database in sync", delErr))
-						SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to delete MCP client config from database: %v. please restart bifrost to keep core and database in sync", delErr))
-						return
-					}
-				}
-				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to register MCP client: %v", err))
-				return
-			}
+			return nil
+		}); err != nil {
+			logger.Error(fmt.Sprintf("[OAuth Complete] DB transaction failed for client %s: %v", mcpClientConfig.ID, err))
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to persist OAuth credential update: %v", err))
+			return
 		}
 
-		// Set discovered tools on the client
-		h.mcpManager.SetClientTools(mcpClientConfig.ID, tools, toolNameMapping)
+		// Runtime reconnect with new credentials.
+		// If this fails, DB is already correct — do not roll back. The client is in error state
+		// and will recover on the next reconnect attempt.
+		if isOauthPerUser {
+			err = h.updateMCPClientWithRetry(ctx, mcpClientConfig.ID, mcpClientConfig)
+		} else {
+			err = h.updateMCPClientConnectionWithRetry(ctx, mcpClientConfig.ID, mcpClientConfig)
+		}
+		if err != nil {
+			logger.Error(fmt.Sprintf("[OAuth Complete] Failed to reconnect MCP client after credential update for client %s: %v", mcpClientConfig.ID, err))
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("OAuth credentials updated but client reconnect failed: %v. The client will reconnect automatically.", err))
+			return
+		}
+	} else {
+		// New client — DB first, then add to runtime. Roll back DB if AddMCPClient fails.
+		if err := h.store.ConfigStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+			if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, mcpClientConfig, tx); err != nil {
+				return fmt.Errorf("create MCP client config: %w", err)
+			}
+			oauthConfig.ConfigMCPClientID = &mcpClientConfig.ID
+			if err := h.store.ConfigStore.UpdateOauthConfig(ctx, oauthConfig, tx); err != nil {
+				return fmt.Errorf("link oauth config to mcp client: %w", err)
+			}
+			return nil
+		}); err != nil {
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
+			return
+		}
+		if err := h.mcpManager.AddMCPClient(ctx, mcpClientConfig); err != nil {
+			if rbErr := h.store.ConfigStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+				if err := h.store.ConfigStore.DeleteMCPClientConfig(ctx, mcpClientConfig.ID, tx); err != nil {
+					return err
+				}
+				oauthConfig.ConfigMCPClientID = nil
+				return h.store.ConfigStore.UpdateOauthConfig(ctx, oauthConfig, tx)
+			}); rbErr != nil {
+				logger.Error(fmt.Sprintf("Failed to rollback MCP client create after connect failure: %v. please restart bifrost to keep core and database in sync", rbErr))
+				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to rollback MCP client create after connect failure: %v. please restart bifrost to keep core and database in sync", rbErr))
+				return
+			}
+			logger.Error(fmt.Sprintf("[OAuth Complete] Failed to connect MCP client: %v", err))
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to connect MCP client: %v", err))
+			return
+		}
+	}
 
+	// --- Cleanup & response ---
+	if isOauthPerUser {
+		h.mcpManager.SetClientTools(mcpClientConfig.ID, tools, toolNameMapping)
 		logger.Debug(fmt.Sprintf("[OAuth Complete] Per-user OAuth MCP client verified and created: %s (%d tools)", mcpClientConfig.ID, len(tools)))
 		message := fmt.Sprintf("OAuth configuration verified successfully. %d tools discovered. Each user will authenticate individually when using this MCP server.", len(tools))
 		if isUpdateFlow {
@@ -1471,64 +1342,6 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// Standard server-level OAuth completion
-	if isUpdateFlow {
-		oldDBConfig := *existingDBConfig
-		updateReq := &configstoreTables.TableMCPClient{
-			ClientID:                  mcpClientConfig.ID,
-			Name:                      mcpClientConfig.Name,
-			IsCodeModeClient:          mcpClientConfig.IsCodeModeClient,
-			ConnectionType:            string(mcpClientConfig.ConnectionType),
-			ConnectionString:          mcpClientConfig.ConnectionString,
-			StdioConfig:               mcpClientConfig.StdioConfig,
-			AuthType:                  string(mcpClientConfig.AuthType),
-			OauthConfigID:             mcpClientConfig.OauthConfigID,
-			ToolsToExecute:            mcpClientConfig.ToolsToExecute,
-			ToolsToAutoExecute:        mcpClientConfig.ToolsToAutoExecute,
-			Headers:                   mcpClientConfig.Headers,
-			AllowedExtraHeaders:       mcpClientConfig.AllowedExtraHeaders,
-			IsPingAvailable:           mcpClientConfig.IsPingAvailable,
-			ToolPricing:               mcpClientConfig.ToolPricing,
-			ToolSyncInterval:          int(mcpClientConfig.ToolSyncInterval / time.Second),
-			AllowOnAllVirtualKeys:     mcpClientConfig.AllowOnAllVirtualKeys,
-			DiscoveredTools:           mcpClientConfig.DiscoveredTools,
-			DiscoveredToolNameMapping: mcpClientConfig.DiscoveredToolNameMapping,
-			Disabled:                  mcpClientConfig.Disabled,
-		}
-		if err := h.store.ConfigStore.UpdateMCPClientConfig(ctx, mcpClientConfig.ID, updateReq); err != nil {
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to update MCP config: %v", err))
-			return
-		}
-		if err := h.updateMCPClientConnectionWithRetry(ctx, mcpClientConfig.ID, mcpClientConfig); err != nil {
-			if rollbackErr := h.store.ConfigStore.UpdateMCPClientConfig(ctx, mcpClientConfig.ID, &oldDBConfig); rollbackErr != nil {
-				logger.Error(fmt.Sprintf("Failed to rollback MCP client DB update: %v. please restart bifrost to keep core and database in sync", rollbackErr))
-			}
-			logger.Error(fmt.Sprintf("Failed to reconnect MCP client after OAuth DB update for client %s: %v", mcpClientConfig.ID, err))
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to reconnect MCP client with updated OAuth credentials: %v", err))
-			return
-		}
-	} else {
-		if h.store.ConfigStore != nil {
-			if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, mcpClientConfig); err != nil {
-				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
-				return
-			}
-		}
-
-		// Add MCP client to Bifrost and connect
-		if err := h.mcpManager.AddMCPClient(ctx, mcpClientConfig); err != nil {
-			if h.store.ConfigStore != nil {
-				if delErr := h.store.ConfigStore.DeleteMCPClientConfig(ctx, mcpClientConfig.ID); delErr != nil {
-					logger.Warn(fmt.Sprintf("Failed to rollback MCP client config after add failure: %v", delErr))
-				}
-			}
-			logger.Error(fmt.Sprintf("[OAuth Complete] Failed to connect MCP client: %v", err))
-			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to connect MCP client: %v", err))
-			return
-		}
-	}
-
-	// Clear pending MCP client config from oauth_config (cleanup)
 	if err := h.oauthHandler.RemovePendingMCPClient(oauthConfigID); err != nil {
 		logger.Warn(fmt.Sprintf("[OAuth Complete] Failed to clear pending MCP client config: %v", err))
 		// Don't fail the request - the MCP client was successfully created

--- a/transports/bifrost-http/handlers/oauth2.go
+++ b/transports/bifrost-http/handlers/oauth2.go
@@ -199,7 +199,43 @@ type OAuthInitiationRequest struct {
 	RegistrationURL string          `json:"registration_url"`
 	RedirectURI     string          `json:"redirect_uri"`
 	Scopes          []string        `json:"scopes"`
-	ServerURL       string          `json:"server_url"` // For OAuth discovery
+	ServerURL       string          `json:"server_url"`              // For OAuth discovery
+	MCPClientID     string          `json:"mcp_client_id,omitempty"` // MCP client ID to link at insert time
+}
+
+// PrepareOAuthFlow performs all network I/O (discovery, dynamic registration, PKCE) and
+// returns the prepared record + initiation result without writing to the DB.
+// Use this when you need to wrap the DB insert in a larger transaction.
+func (h *OAuthHandler) PrepareOAuthFlow(ctx context.Context, req OAuthInitiationRequest) (*oauth2.PreparedOAuthFlow, error) {
+	var registrationURL *string
+	if req.RegistrationURL != "" {
+		registrationURL = &req.RegistrationURL
+	}
+
+	clientID := ""
+	if req.ClientID != nil {
+		if v := req.ClientID.GetValue(); v != "" {
+			clientID = v
+		}
+	}
+	clientSecret := ""
+	if req.ClientSecret != nil {
+		if v := req.ClientSecret.GetValue(); v != "" {
+			clientSecret = v
+		}
+	}
+
+	return h.oauthProvider.PrepareOAuthFlow(ctx, &schemas.OAuth2Config{
+		ClientID:        clientID,
+		ClientSecret:    clientSecret,
+		AuthorizeURL:    req.AuthorizeURL,
+		TokenURL:        req.TokenURL,
+		RegistrationURL: registrationURL,
+		RedirectURI:     req.RedirectURI,
+		Scopes:          req.Scopes,
+		ServerURL:       req.ServerURL,
+		MCPClientID:     req.MCPClientID,
+	})
 }
 
 // InitiateOAuthFlow initiates an OAuth flow and returns the authorization URL
@@ -212,14 +248,14 @@ func (h *OAuthHandler) InitiateOAuthFlow(ctx context.Context, req OAuthInitiatio
 
 	clientID := ""
 	if req.ClientID != nil {
-		if v, _ := req.ClientID.Value(); v != nil {
-			clientID, _ = v.(string)
+		if v := req.ClientID.GetValue(); v != "" {
+			clientID = v
 		}
 	}
 	clientSecret := ""
 	if req.ClientSecret != nil {
-		if v, _ := req.ClientSecret.Value(); v != nil {
-			clientSecret, _ = v.(string)
+		if v := req.ClientSecret.GetValue(); v != "" {
+			clientSecret = v
 		}
 	}
 
@@ -232,6 +268,7 @@ func (h *OAuthHandler) InitiateOAuthFlow(ctx context.Context, req OAuthInitiatio
 		RedirectURI:     req.RedirectURI,
 		Scopes:          req.Scopes,
 		ServerURL:       req.ServerURL,
+		MCPClientID:     req.MCPClientID,
 	}
 
 	return h.oauthProvider.InitiateOAuthFlow(ctx, config)

--- a/transports/bifrost-http/handlers/oauth2_per_user.go
+++ b/transports/bifrost-http/handlers/oauth2_per_user.go
@@ -476,17 +476,11 @@ func (h *PerUserOAuthHandler) handleUpstreamAuthorize(ctx *fasthttp.RequestCtx) 
 		SendError(ctx, fasthttp.StatusBadRequest, "MCP client does not use per-user OAuth")
 		return
 	}
-	if mcpClient.OauthConfigID == nil || *mcpClient.OauthConfigID == "" {
+	if mcpClient.OauthConfig == nil || mcpClient.OauthConfig.ID == "" {
 		SendError(ctx, fasthttp.StatusBadRequest, "MCP client has no OAuth configuration")
 		return
 	}
-
-	// Load template OAuth config (has upstream authorize_url, client_id, etc.)
-	templateConfig, err := h.store.ConfigStore.GetOauthConfigByID(ctx, *mcpClient.OauthConfigID)
-	if err != nil || templateConfig == nil {
-		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to load OAuth template config")
-		return
-	}
+	templateConfig := mcpClient.OauthConfig
 
 	// Generate PKCE challenge for upstream.
 	codeVerifier, err := generateOpaqueToken(32)
@@ -518,7 +512,7 @@ func (h *PerUserOAuthHandler) handleUpstreamAuthorize(ctx *fasthttp.RequestCtx) 
 	upstreamSession := &tables.TableOauthUserSession{
 		ID:               uuid.New().String(),
 		MCPClientID:      mcpClientID,
-		OauthConfigID:    *mcpClient.OauthConfigID,
+		OauthConfigID:    mcpClient.OauthConfig.ID,
 		State:            state,
 		CodeVerifier:     codeVerifier,
 		SessionToken:     proxySessionToken, // "runtime:xxx" for runtime flow; "flow:xxx" for consent flow

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1312,7 +1312,6 @@ func mcpClientConfigToTable(clientConfig *schemas.MCPClientConfig) (configstoreT
 		ConnectionString:          clientConfig.ConnectionString,
 		StdioConfig:               clientConfig.StdioConfig,
 		AuthType:                  authType,
-		OauthConfigID:             clientConfig.OauthConfigID,
 		ToolsToExecute:            clientConfig.ToolsToExecute,
 		ToolsToAutoExecute:        clientConfig.ToolsToAutoExecute,
 		Headers:                   clientConfig.Headers,
@@ -4640,6 +4639,9 @@ func (c *Config) UpdateMCPClient(ctx context.Context, id string, updatedConfig *
 	c.MCPConfig.ClientConfigs[configIndex].ToolSyncInterval = updatedConfig.ToolSyncInterval
 	c.MCPConfig.ClientConfigs[configIndex].AllowOnAllVirtualKeys = updatedConfig.AllowOnAllVirtualKeys
 	c.MCPConfig.ClientConfigs[configIndex].Disabled = updatedConfig.Disabled
+	if updatedConfig.OauthConfigID != nil {
+		c.MCPConfig.ClientConfigs[configIndex].OauthConfigID = updatedConfig.OauthConfigID
+	}
 
 	// Handle disable/enable lifecycle when the Disabled flag toggles and the client
 	// is registered at runtime. We call the core bifrost methods directly (not the

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1150,7 +1150,7 @@ func (m *MockConfigStore) DeleteOauthConfig(ctx context.Context, id string, tx .
 	return nil
 }
 
-func (m *MockConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error {
+func (m *MockConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig, tx ...*gorm.DB) error {
 	return nil
 }
 

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -423,6 +423,13 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 
 									{(authType === "oauth" || authType === "per_user_oauth") && (
 										<>
+											{/* OAuth fields are locked once the flow has been initiated */}
+											{oauthFlow && (
+												<p className="text-muted-foreground rounded-md border px-3 py-2 text-sm">
+													OAuth authorization in progress — configuration is locked until the flow completes.
+												</p>
+											)}
+
 											{/* OAuth Client ID */}
 											<FormField
 												control={control}
@@ -494,6 +501,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 														<FormControl>
 															<Input
 																{...field}
+																disabled={!!oauthFlow}
 																value={field.value ?? ""}
 																onChange={(e) => {
 																	field.onChange(e);
@@ -519,6 +527,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 														<FormControl>
 															<Input
 																{...field}
+																disabled={!!oauthFlow}
 																value={field.value ?? ""}
 																onChange={(e) => {
 																	field.onChange(e);
@@ -543,6 +552,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 														<FormControl>
 															<Input
 																{...field}
+																disabled={!!oauthFlow}
 																value={field.value ?? ""}
 																onChange={(e) => {
 																	field.onChange(e);
@@ -562,7 +572,7 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 											{/* Scopes (local state, not RHF field) */}
 											<div className="space-y-2">
 												<Label>Scopes (optional, comma-separated)</Label>
-												<Input value={scopesText} onChange={(e) => setScopesText(e.target.value)} placeholder="read, write, admin" />
+												<Input disabled={!!oauthFlow} value={scopesText} onChange={(e) => setScopesText(e.target.value)} placeholder="read, write, admin" />
 												<p className="text-muted-foreground text-xs">Will be discovered from server if not provided</p>
 											</div>
 										</>

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -111,8 +111,7 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 		],
 		[allToolNames],
 	);
-	const supportsOAuthCredentialUpdate = false;
-	// mcpClient.config.auth_type === "oauth" || mcpClient.config.auth_type === "per_user_oauth";
+	const supportsOAuthCredentialUpdate = mcpClient.config.auth_type === "oauth" || mcpClient.config.auth_type === "per_user_oauth";
 
 	const addVKConfig = (vkId: string) => {
 		const name = vksData?.virtual_keys?.find((vk) => vk.id === vkId)?.name;
@@ -191,7 +190,18 @@ export default function MCPClientSheet({ mcpClient, onClose, onSubmitSuccess }: 
 			const oauthClientSecret = data.oauth_config?.client_secret;
 			// Only rotate when the user actually changed a credential field.
 			// dirtyFields tracks deep changes vs. the pre-populated default values.
-			const oauthDirty = !!(form.formState.dirtyFields.oauth_config?.client_id || form.formState.dirtyFields.oauth_config?.client_secret);
+			const oauthClientIDDirty = !!form.formState.dirtyFields.oauth_config?.client_id;
+			const oauthClientSecretDirty = !!form.formState.dirtyFields.oauth_config?.client_secret;
+
+			if (oauthClientIDDirty && !oauthClientSecretDirty) {
+				form.setError("oauth_config.client_secret", {
+					type: "manual",
+					message: "Client secret must also be updated when changing the client ID",
+				});
+				return;
+			}
+
+			const oauthDirty = !!(oauthClientIDDirty || oauthClientSecretDirty);
 			const shouldRotateOAuthCredentials = supportsOAuthCredentialUpdate && oauthDirty;
 			const response = await updateMCPClient({
 				id: mcpClient.config.client_id,


### PR DESCRIPTION
## Summary

This PR refactors the OAuth flow for MCP client creation and updates to eliminate race conditions and orphaned records. Previously, the MCP client record was only persisted after OAuth authorization completed, relying on in-memory "pending" state. Now, the MCP client is written to the database atomically alongside the `oauth_config` record at flow initiation time, and OAuth credential rotation (re-auth) is fully implemented for existing clients.

## Changes

- **Atomic DB writes on OAuth flow initiation**: `CreateMCPClientConfig` and `CreateOauthConfig` are now executed in a single transaction when adding an OAuth MCP client, so no orphaned records can exist if one insert fails.
- **`PrepareOAuthFlow` introduced**: Network I/O (discovery, dynamic client registration, PKCE) is separated from DB writes. `PrepareOAuthFlow` does all network work and returns a `PreparedOAuthFlow` struct without touching the DB, allowing callers to wrap the insert in a larger transaction.
- **`MCPClientID` added to `OAuth2Config`**: The MCP client FK is now set at insert time rather than in a post-completion linking step, removing the need for a deferred linking step.
- **OAuth credential rotation re-enabled**: The `updateMCPClient` handler now supports `oauth_config` updates for `oauth` and `per_user_oauth` clients. A new `oauth_config` row is created, the client is updated, and the old `oauth_config` (along with its cascaded tokens and sessions) is deleted — all in a single transaction.
- **`completeMCPClientOAuth` unified**: The per-user OAuth and server-level OAuth completion paths are merged. DB writes use `ExecuteTransaction` in both the create and update flows, with runtime reconnect attempted only after the transaction commits.
- **`resolveOAuthReauthParams` helper extracted**: Merges request OAuth params with stored values for re-auth flows, falling back to the existing `oauth_config` when fields are omitted.
- **`addMCPClient` deduplicated**: The separate `oauth` and `per_user_oauth` branches are collapsed into a single shared path, with auth-type-specific response fields applied after the common DB transaction.
- **`UpdateOauthConfig` accepts an optional transaction**: The method signature now accepts a variadic `*gorm.DB` parameter, consistent with `DeleteOauthConfig`, so it can participate in larger transactions.
- **UI: OAuth fields locked during pending flow**: All OAuth configuration inputs (client ID, secret, authorize URL, token URL, registration URL, scopes) are disabled once an OAuth flow has been initiated, with an explanatory message shown.
- **UI: OAuth credential update re-enabled**: `supportsOAuthCredentialUpdate` is now derived from the client's actual `auth_type` instead of being hardcoded to `false`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./...

# UI
cd ui
pnpm i
pnpm build
```

1. **Add an OAuth MCP client**: POST to `/api/mcp/client` with `auth_type: "oauth"` and valid OAuth config. Verify both the MCP client row and `oauth_config` row are created immediately (before completing the flow). Verify `oauth_config.config_mcp_client_id` is set to the new client ID.
2. **Complete the OAuth flow**: Open the `authorize_url`, complete authorization, then POST to the `complete_url`. Verify the client becomes active.
3. **Rotate OAuth credentials**: PATCH an existing OAuth MCP client with a new `oauth_config`. Verify a new `oauth_config` row is created, the old one (and its tokens) is deleted, and the client reconnects.
4. **Abort mid-flow**: Initiate an OAuth flow and do not complete it. Verify no orphaned MCP client or `oauth_config` records remain after expiry.
5. **UI**: Open the MCP client creation form, select `oauth` auth type, and begin the flow. Verify all OAuth fields become disabled and the lock message appears.
6. **UI**: Open an existing OAuth MCP client in the edit sheet and verify the OAuth credential update section is now accessible.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- Old `oauth_config` rows (including all associated tokens and user sessions) are hard-deleted when credentials are rotated, preventing stale token reuse.
- The `MCPClientID` FK is set at insert time, ensuring the cascade-on-delete relationship between MCP clients and their OAuth configs is established from the start rather than in a deferred linking step.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable