### PR TITLE
feat: add `mcp_client_id` to `OAuth2Config`, support optional `tx` in MCP/OAuth CRUD methods, and migrate orphaned `oauth_configs`

### DIFF
--- a/core/schemas/oauth.go
+++ b/core/schemas/oauth.go
@@ -57,6 +57,7 @@ type OAuth2Config struct {
 	Scopes          []string `json:"scopes,omitempty"`           // Optional: Can be discovered
 	ServerURL       string   `json:"server_url"`                 // MCP server URL for OAuth discovery (required if URLs not provided)
 	UseDiscovery    bool     `json:"use_discovery,omitempty"`    // Deprecated: Discovery now happens automatically when URLs are missing
+	MCPClientID     string   `json:"mcp_client_id,omitempty"`    // MCP client this oauth config belongs to (set at insert time)
 }
 
 // OauthToken represents OAuth access and refresh tokens

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -716,6 +716,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddOAuthRelationalConstraints(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationDeleteOrphanedOAuthConfigs(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -7600,6 +7603,15 @@ func migrationAddOAuthRelationalConstraints(ctx context.Context, db *gorm.DB) er
 				return fmt.Errorf("backfill config_mcp_client_id: %w", err)
 			}
 
+			// Delete oauth_configs that still have no parent MCP client after the backfill —
+			// these are truly orphaned (no config_mcp_clients row points to them).
+			if err := tx.Exec(`
+				DELETE FROM oauth_configs
+				WHERE config_mcp_client_id IS NULL
+			`).Error; err != nil {
+				return fmt.Errorf("delete orphaned oauth_configs: %w", err)
+			}
+
 			// Backfill oauth_tokens.oauth_config_id from oauth_configs.token_id
 			if err := tx.Exec(`
 				UPDATE oauth_tokens
@@ -7661,5 +7673,19 @@ func migrationAddOAuthRelationalConstraints(ctx context.Context, db *gorm.DB) er
 			_ = mg.DropColumn(&tables.TableOauthConfig{}, "ConfigMCPClientID")
 			return nil
 		},
+	})
+}
+
+// migrationDeleteOrphanedOAuthConfigs removes oauth_configs rows where config_mcp_client_id is null
+func migrationDeleteOrphanedOAuthConfigs(ctx context.Context, db *gorm.DB) error {
+	return RunSingleMigration(ctx, db, &migrator.Migration{
+		ID: "delete_orphaned_oauth_configs",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.WithContext(ctx).Exec(`
+				DELETE FROM oauth_configs
+				WHERE config_mcp_client_id IS NULL
+			`).Error
+		},
+		Rollback: func(tx *gorm.DB) error { return nil },
 	})
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1417,8 +1417,14 @@ func (s *RDBConfigStore) GetMCPClientByName(ctx context.Context, name string) (*
 }
 
 // CreateMCPClientConfig creates a new MCP client configuration in the database.
-func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig) error {
-	return s.DB().Transaction(func(tx *gorm.DB) error {
+func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig, tx ...*gorm.DB) error {
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.DB()
+	}
+	return txDB.Transaction(func(tx *gorm.DB) error {
 		// Check if a client with the same name already exists
 		if _, err := s.GetMCPClientByName(ctx, clientConfig.Name); err == nil {
 			return fmt.Errorf("MCP client with name '%s' already exists", clientConfig.Name)
@@ -1462,9 +1468,161 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 }
 
 // UpdateMCPClientConfig updates an existing MCP client configuration in the database.
-func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, clientConfig *tables.TableMCPClient) error {
-	return s.DB().Transaction(func(tx *gorm.DB) error {
-		// Find existing client
+// An optional tx can be passed to run the update within an existing transaction.
+func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, clientConfig *tables.TableMCPClient, tx ...*gorm.DB) error {
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.DB()
+	}
+
+	// Create a deep copy to avoid modifying the original
+	clientConfigCopy, err := deepCopy(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	// Serialize the virtual fields to JSON before updating
+	// This is normally done in BeforeSave hook, but we need to do it manually for map updates
+	// Normalize nil slices/maps to avoid storing JSON "null"
+	if clientConfigCopy.ToolsToExecute == nil {
+		clientConfigCopy.ToolsToExecute = []string{}
+	}
+	toolsToExecuteJSON, err := json.Marshal(clientConfigCopy.ToolsToExecute)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tools_to_execute: %w", err)
+	}
+	if clientConfigCopy.ToolsToAutoExecute == nil {
+		clientConfigCopy.ToolsToAutoExecute = []string{}
+	}
+	toolsToAutoExecuteJSON, err := json.Marshal(clientConfigCopy.ToolsToAutoExecute)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tools_to_auto_execute: %w", err)
+	}
+	// Serialize headers to map[string]string matching BeforeSave logic
+	headersToSerialize := make(map[string]string)
+	if clientConfigCopy.Headers != nil {
+		for key, value := range clientConfigCopy.Headers {
+			if value.IsFromEnv() {
+				headersToSerialize[key] = value.EnvVar
+			} else {
+				headersToSerialize[key] = value.GetValue()
+			}
+		}
+	}
+	headersJSON, err := json.Marshal(headersToSerialize)
+	if err != nil {
+		return fmt.Errorf("failed to marshal headers: %w", err)
+	}
+	if clientConfigCopy.AllowedExtraHeaders == nil {
+		clientConfigCopy.AllowedExtraHeaders = []string{}
+	}
+	allowedExtraHeadersJSON, err := json.Marshal(clientConfigCopy.AllowedExtraHeaders)
+	if err != nil {
+		return fmt.Errorf("failed to marshal allowed_extra_headers: %w", err)
+	}
+	var stdioConfigJSON *string
+	if clientConfigCopy.StdioConfig != nil {
+		stdioData, marshalErr := json.Marshal(clientConfigCopy.StdioConfig)
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal stdio_config: %w", marshalErr)
+		}
+		stdioStr := string(stdioData)
+		stdioConfigJSON = &stdioStr
+	}
+
+	if clientConfigCopy.ToolPricing == nil {
+		clientConfigCopy.ToolPricing = map[string]float64{}
+	}
+	toolPricingJSON, err := json.Marshal(clientConfigCopy.ToolPricing)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tool_pricing: %w", err)
+	}
+	discoveredToolsJSON := ""
+	if clientConfig.DiscoveredTools != nil {
+		data, marshalErr := json.Marshal(clientConfig.DiscoveredTools)
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal discovered_tools: %w", marshalErr)
+		}
+		discoveredToolsJSON = string(data)
+	}
+	toolNameMappingJSON := ""
+	if clientConfig.DiscoveredToolNameMapping != nil {
+		data, marshalErr := json.Marshal(clientConfig.DiscoveredToolNameMapping)
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal tool_name_mapping: %w", marshalErr)
+		}
+		toolNameMappingJSON = string(data)
+	}
+
+	headersJSONStr := string(headersJSON)
+	if encrypt.IsEnabled() && headersJSONStr != "" && headersJSONStr != "{}" {
+		encrypted, encErr := encrypt.Encrypt(headersJSONStr)
+		if encErr != nil {
+			return fmt.Errorf("failed to encrypt mcp headers: %w", encErr)
+		}
+		headersJSONStr = encrypted
+	}
+
+	// Update only editable fields using a map to avoid updating connection info
+	// Connection info (ConnectionType, ConnectionString, StdioConfig) is read-only and should not be modified via API
+	updates := map[string]interface{}{
+		"name":                       clientConfigCopy.Name,
+		"is_code_mode_client":        clientConfigCopy.IsCodeModeClient,
+		"tools_to_execute_json":      string(toolsToExecuteJSON),
+		"tools_to_auto_execute_json": string(toolsToAutoExecuteJSON),
+		"headers_json":               headersJSONStr,
+		"allowed_extra_headers_json": string(allowedExtraHeadersJSON),
+		"tool_pricing_json":          string(toolPricingJSON),
+		"tool_sync_interval":         clientConfigCopy.ToolSyncInterval,
+		"allow_on_all_virtual_keys":  clientConfigCopy.AllowOnAllVirtualKeys,
+		"disabled":                   clientConfigCopy.Disabled,
+		"updated_at":                 time.Now(),
+	}
+	if encrypt.IsEnabled() {
+		updates["encryption_status"] = encryptionStatusEncrypted
+	}
+	if clientConfigCopy.OauthConfigID != nil {
+		updates["oauth_config_id"] = clientConfigCopy.OauthConfigID
+	}
+	if discoveredToolsJSON != "" {
+		updates["discovered_tools_json"] = discoveredToolsJSON
+	}
+	if toolNameMappingJSON != "" {
+		updates["tool_name_mapping_json"] = toolNameMappingJSON
+	}
+	// Config-file driven reconciliation passes ConfigHash. In this mode we should
+	// also sync connection/auth metadata from config.json and persist the hash.
+	if clientConfigCopy.ConfigHash != "" {
+		connectionStringToPersist := clientConfigCopy.ConnectionString
+		if encrypt.IsEnabled() && connectionStringToPersist != nil &&
+			!connectionStringToPersist.IsFromEnv() && connectionStringToPersist.GetValue() != "" {
+			// Mirror TableMCPClient.BeforeSave behavior for map-based Updates.
+			cs := *connectionStringToPersist
+			encryptedConnString, encErr := encrypt.Encrypt(cs.Val)
+			if encErr != nil {
+				return fmt.Errorf("failed to encrypt mcp connection string: %w", encErr)
+			}
+			cs.Val = encryptedConnString
+			connectionStringToPersist = &cs
+		}
+
+		updates["config_hash"] = clientConfigCopy.ConfigHash
+		updates["connection_type"] = clientConfigCopy.ConnectionType
+		updates["connection_string"] = connectionStringToPersist
+		updates["stdio_config_json"] = stdioConfigJSON
+		updates["auth_type"] = clientConfigCopy.AuthType
+		updates["oauth_config_id"] = clientConfigCopy.OauthConfigID
+	}
+
+	// Only update is_ping_available if explicitly provided (non-nil)
+	// This preserves the existing DB value when the request omits the field
+	if clientConfigCopy.IsPingAvailable != nil {
+		updates["is_ping_available"] = *clientConfigCopy.IsPingAvailable
+	}
+
+	return txDB.Transaction(func(tx *gorm.DB) error {
 		var existingClient tables.TableMCPClient
 		if err := tx.WithContext(ctx).Where("client_id = ?", id).First(&existingClient).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -1472,152 +1630,6 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 			}
 			return err
 		}
-
-		// Create a deep copy to avoid modifying the original
-		clientConfigCopy, err := deepCopy(clientConfig)
-		if err != nil {
-			return err
-		}
-
-		// Serialize the virtual fields to JSON before updating
-		// This is normally done in BeforeSave hook, but we need to do it manually for map updates
-		// Normalize nil slices/maps to avoid storing JSON "null"
-		if clientConfigCopy.ToolsToExecute == nil {
-			clientConfigCopy.ToolsToExecute = []string{}
-		}
-		toolsToExecuteJSON, err := json.Marshal(clientConfigCopy.ToolsToExecute)
-		if err != nil {
-			return fmt.Errorf("failed to marshal tools_to_execute: %w", err)
-		}
-		if clientConfigCopy.ToolsToAutoExecute == nil {
-			clientConfigCopy.ToolsToAutoExecute = []string{}
-		}
-		toolsToAutoExecuteJSON, err := json.Marshal(clientConfigCopy.ToolsToAutoExecute)
-		if err != nil {
-			return fmt.Errorf("failed to marshal tools_to_auto_execute: %w", err)
-		}
-		// Serialize headers to map[string]string matching BeforeSave logic
-		headersToSerialize := make(map[string]string)
-		if clientConfigCopy.Headers != nil {
-			for key, value := range clientConfigCopy.Headers {
-				if value.IsFromEnv() {
-					headersToSerialize[key] = value.EnvVar
-				} else {
-					headersToSerialize[key] = value.GetValue()
-				}
-			}
-		}
-		headersJSON, err := json.Marshal(headersToSerialize)
-		if err != nil {
-			return fmt.Errorf("failed to marshal headers: %w", err)
-		}
-		if clientConfigCopy.AllowedExtraHeaders == nil {
-			clientConfigCopy.AllowedExtraHeaders = []string{}
-		}
-		allowedExtraHeadersJSON, err := json.Marshal(clientConfigCopy.AllowedExtraHeaders)
-		if err != nil {
-			return fmt.Errorf("failed to marshal allowed_extra_headers: %w", err)
-		}
-		var stdioConfigJSON *string
-		if clientConfigCopy.StdioConfig != nil {
-			stdioData, marshalErr := json.Marshal(clientConfigCopy.StdioConfig)
-			if marshalErr != nil {
-				return fmt.Errorf("failed to marshal stdio_config: %w", marshalErr)
-			}
-			stdioStr := string(stdioData)
-			stdioConfigJSON = &stdioStr
-		}
-
-		if clientConfigCopy.ToolPricing == nil {
-			clientConfigCopy.ToolPricing = map[string]float64{}
-		}
-		toolPricingJSON, err := json.Marshal(clientConfigCopy.ToolPricing)
-		if err != nil {
-			return fmt.Errorf("failed to marshal tool_pricing: %w", err)
-		}
-		discoveredToolsJSON := ""
-		if clientConfig.DiscoveredTools != nil {
-			data, marshalErr := json.Marshal(clientConfig.DiscoveredTools)
-			if marshalErr != nil {
-				return fmt.Errorf("failed to marshal discovered_tools: %w", marshalErr)
-			}
-			discoveredToolsJSON = string(data)
-		}
-		toolNameMappingJSON := ""
-		if clientConfig.DiscoveredToolNameMapping != nil {
-			data, marshalErr := json.Marshal(clientConfig.DiscoveredToolNameMapping)
-			if marshalErr != nil {
-				return fmt.Errorf("failed to marshal tool_name_mapping: %w", marshalErr)
-			}
-			toolNameMappingJSON = string(data)
-		}
-
-		headersJSONStr := string(headersJSON)
-		if encrypt.IsEnabled() && headersJSONStr != "" && headersJSONStr != "{}" {
-			encrypted, encErr := encrypt.Encrypt(headersJSONStr)
-			if encErr != nil {
-				return fmt.Errorf("failed to encrypt mcp headers: %w", encErr)
-			}
-			headersJSONStr = encrypted
-		}
-
-		// Update only editable fields using a map to avoid updating connection info
-		// Connection info (ConnectionType, ConnectionString, StdioConfig) is read-only and should not be modified via API
-		updates := map[string]interface{}{
-			"name":                       clientConfigCopy.Name,
-			"is_code_mode_client":        clientConfigCopy.IsCodeModeClient,
-			"tools_to_execute_json":      string(toolsToExecuteJSON),
-			"tools_to_auto_execute_json": string(toolsToAutoExecuteJSON),
-			"headers_json":               headersJSONStr,
-			"allowed_extra_headers_json": string(allowedExtraHeadersJSON),
-			"tool_pricing_json":          string(toolPricingJSON),
-			"tool_sync_interval":         clientConfigCopy.ToolSyncInterval,
-			"allow_on_all_virtual_keys":  clientConfigCopy.AllowOnAllVirtualKeys,
-			"disabled":                   clientConfigCopy.Disabled,
-			"updated_at":                 time.Now(),
-		}
-		if encrypt.IsEnabled() {
-			updates["encryption_status"] = encryptionStatusEncrypted
-		}
-		if clientConfigCopy.OauthConfigID != nil {
-			updates["oauth_config_id"] = clientConfigCopy.OauthConfigID
-		}
-		if discoveredToolsJSON != "" {
-			updates["discovered_tools_json"] = discoveredToolsJSON
-		}
-		if toolNameMappingJSON != "" {
-			updates["tool_name_mapping_json"] = toolNameMappingJSON
-		}
-		// Config-file driven reconciliation passes ConfigHash. In this mode we should
-		// also sync connection/auth metadata from config.json and persist the hash.
-		if clientConfigCopy.ConfigHash != "" {
-			connectionStringToPersist := clientConfigCopy.ConnectionString
-			if encrypt.IsEnabled() && connectionStringToPersist != nil &&
-				!connectionStringToPersist.IsFromEnv() && connectionStringToPersist.GetValue() != "" {
-				// Mirror TableMCPClient.BeforeSave behavior for map-based Updates.
-				cs := *connectionStringToPersist
-				encryptedConnString, encErr := encrypt.Encrypt(cs.Val)
-				if encErr != nil {
-					return fmt.Errorf("failed to encrypt mcp connection string: %w", encErr)
-				}
-				cs.Val = encryptedConnString
-				connectionStringToPersist = &cs
-			}
-
-			updates["config_hash"] = clientConfigCopy.ConfigHash
-			updates["connection_type"] = clientConfigCopy.ConnectionType
-			updates["connection_string"] = connectionStringToPersist
-			updates["stdio_config_json"] = stdioConfigJSON
-			updates["auth_type"] = clientConfigCopy.AuthType
-			updates["oauth_config_id"] = clientConfigCopy.OauthConfigID
-		}
-
-		// Only update is_ping_available if explicitly provided (non-nil)
-		// This preserves the existing DB value when the request omits the field
-		if clientConfigCopy.IsPingAvailable != nil {
-			updates["is_ping_available"] = *clientConfigCopy.IsPingAvailable
-		}
-
 		if err := tx.WithContext(ctx).Model(&existingClient).Updates(updates).Error; err != nil {
 			return s.parseGormError(err)
 		}
@@ -1626,8 +1638,14 @@ func (s *RDBConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, c
 }
 
 // DeleteMCPClientConfig deletes an MCP client configuration from the database.
-func (s *RDBConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) error {
-	return s.DB().Transaction(func(tx *gorm.DB) error {
+func (s *RDBConfigStore) DeleteMCPClientConfig(ctx context.Context, id string, tx ...*gorm.DB) error {
+	var txDB *gorm.DB
+	if len(tx) > 0 {
+		txDB = tx[0]
+	} else {
+		txDB = s.DB()
+	}
+	return txDB.Transaction(func(tx *gorm.DB) error {
 		// Find existing client
 		var existingClient tables.TableMCPClient
 		if err := tx.WithContext(ctx).Where("client_id = ?", id).First(&existingClient).Error; err != nil {
@@ -4265,6 +4283,21 @@ func (s *RDBConfigStore) CreateOauthToken(ctx context.Context, token *tables.Tab
 	result := s.DB().WithContext(ctx).Create(token)
 	if result.Error != nil {
 		return fmt.Errorf("failed to create oauth token: %w", result.Error)
+	}
+	return nil
+}
+
+// DeleteOauthConfig deletes an OAuth config by ID.
+// Cascades to oauth_tokens, oauth_user_sessions, and oauth_user_tokens via FK constraints.
+// An optional tx can be passed to run the delete within an existing transaction.
+func (s *RDBConfigStore) DeleteOauthConfig(ctx context.Context, id string, tx ...*gorm.DB) error {
+	db := s.DB()
+	if len(tx) > 0 && tx[0] != nil {
+		db = tx[0]
+	}
+	result := db.WithContext(ctx).Delete(&tables.TableOauthConfig{}, "id = ?", id)
+	if result.Error != nil {
+		return fmt.Errorf("failed to delete oauth config: %w", result.Error)
 	}
 	return nil
 }

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -119,9 +119,9 @@ type ConfigStore interface {
 	GetMCPClientConfigByID(ctx context.Context, id string) (*schemas.MCPClientConfig, error)
 	GetMCPClientByName(ctx context.Context, name string) (*tables.TableMCPClient, error)
 	GetMCPClientsPaginated(ctx context.Context, params MCPClientsQueryParams) ([]tables.TableMCPClient, int64, error)
-	CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig) error
-	UpdateMCPClientConfig(ctx context.Context, id string, clientConfig *tables.TableMCPClient) error
-	DeleteMCPClientConfig(ctx context.Context, id string) error
+	CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig, tx ...*gorm.DB) error
+	UpdateMCPClientConfig(ctx context.Context, id string, clientConfig *tables.TableMCPClient, tx ...*gorm.DB) error
+	DeleteMCPClientConfig(ctx context.Context, id string, tx ...*gorm.DB) error
 
 	// Vector store config CRUD
 	UpdateVectorStoreConfig(ctx context.Context, config *vectorstore.Config) error
@@ -302,6 +302,7 @@ type ConfigStore interface {
 	GetOauthConfigByTokenID(ctx context.Context, tokenID string) (*tables.TableOauthConfig, error)
 	CreateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error
 	UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error
+	DeleteOauthConfig(ctx context.Context, id string, tx ...*gorm.DB) error
 
 	// OAuth token CRUD
 	GetOauthTokenByID(ctx context.Context, id string) (*tables.TableOauthToken, error)

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -563,13 +563,13 @@ func (m *MockConfigStore) GetMCPClientByName(ctx context.Context, name string) (
 	return nil, nil
 }
 
-func (m *MockConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig) error {
+func (m *MockConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig, tx ...*gorm.DB) error {
 	m.mcpConfig.ClientConfigs = append(m.mcpConfig.ClientConfigs, clientConfig)
 	m.mcpConfigsCreated = append(m.mcpConfigsCreated, clientConfig)
 	return nil
 }
 
-func (m *MockConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, clientConfig *tables.TableMCPClient) error {
+func (m *MockConfigStore) UpdateMCPClientConfig(ctx context.Context, id string, clientConfig *tables.TableMCPClient, tx ...*gorm.DB) error {
 	m.mcpClientConfigUpdates = append(m.mcpClientConfigUpdates, struct {
 		ID     string
 		Config tables.TableMCPClient
@@ -625,7 +625,7 @@ func (m *MockConfigStore) GetMCPClientsPaginated(ctx context.Context, params con
 	return nil, 0, nil
 }
 
-func (m *MockConfigStore) DeleteMCPClientConfig(ctx context.Context, id string) error {
+func (m *MockConfigStore) DeleteMCPClientConfig(ctx context.Context, id string, tx ...*gorm.DB) error {
 	return nil
 }
 
@@ -1146,6 +1146,10 @@ func (m *MockConfigStore) CreateOauthConfig(ctx context.Context, config *tables.
 	return nil
 }
 
+func (m *MockConfigStore) DeleteOauthConfig(ctx context.Context, id string, tx ...*gorm.DB) error {
+	return nil
+}
+
 func (m *MockConfigStore) UpdateOauthConfig(ctx context.Context, config *tables.TableOauthConfig) error {
 	return nil
 }
@@ -1637,7 +1641,7 @@ func makeVirtualKey(id, name, value string) tables.TableVirtualKey {
 		Name:        name,
 		Description: "Test virtual key",
 		Value:       value,
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 	}
 }
 
@@ -1648,7 +1652,7 @@ func makeVirtualKeyWithTeam(id, name, value, teamID string) tables.TableVirtualK
 		Name:        name,
 		Description: "Test virtual key with team",
 		Value:       value,
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 }
@@ -1660,7 +1664,7 @@ func makeVirtualKeyWithCustomer(id, name, value, customerID string) tables.Table
 		Name:        name,
 		Description: "Test virtual key with customer",
 		Value:       value,
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		CustomerID:  &customerID,
 	}
 }
@@ -1672,7 +1676,7 @@ func makeVirtualKeyWithProviderConfigs(id, name, value string, providerConfigs [
 		Name:            name,
 		Description:     "Test virtual key with provider configs",
 		Value:           value,
-		IsActive: schemas.Ptr(true),
+		IsActive:        schemas.Ptr(true),
 		ProviderConfigs: providerConfigs,
 	}
 }
@@ -6612,7 +6616,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6632,7 +6636,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6651,7 +6655,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "different-name", // Different name
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6670,7 +6674,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_different", // Different value
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6689,7 +6693,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(false), // Different IsActive
+		IsActive:    schemas.Ptr(false), // Different IsActive
 		TeamID:      &teamID,
 	}
 
@@ -6709,7 +6713,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &differentTeamID, // Different TeamID
 	}
 
@@ -6728,7 +6732,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Different description", // Different description
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6748,7 +6752,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		CustomerID:  &customerID, // CustomerID set
 	}
@@ -6769,7 +6773,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		CustomerID:  &differentCustomerID, // Different CustomerID
 	}
@@ -6790,7 +6794,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &rateLimitID, // RateLimitID set
 	}
@@ -6811,7 +6815,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &differentRateLimitID, // Different RateLimitID
 	}
@@ -6838,7 +6842,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -6870,7 +6874,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -6898,7 +6902,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -6933,7 +6937,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -6959,7 +6963,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -6985,7 +6989,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -7016,7 +7020,7 @@ func TestVirtualKeyHashComparison_MatchingHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7033,7 +7037,7 @@ func TestVirtualKeyHashComparison_MatchingHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &dbTeamID,
 		ConfigHash:  fileHash, // Same hash as file
 	}
@@ -7066,7 +7070,7 @@ func TestVirtualKeyHashComparison_DifferentHash(t *testing.T) {
 		Name:        "old-name", // Old name
 		Description: "Old description",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7083,7 +7087,7 @@ func TestVirtualKeyHashComparison_DifferentHash(t *testing.T) {
 		Name:        "new-name", // Updated name
 		Description: "New description",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &fileTeamID,
 	}
 
@@ -7114,7 +7118,7 @@ func TestVirtualKeyHashComparison_VirtualKeyOnlyInDB(t *testing.T) {
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
 		Value:       "vk_dashboard123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		CustomerID:  &customerID,
 		RateLimitID: &rateLimitID,
 	}
@@ -7132,7 +7136,7 @@ func TestVirtualKeyHashComparison_VirtualKeyOnlyInDB(t *testing.T) {
 			Name:        "file-vk",
 			Description: "From config.json",
 			Value:       "vk_file123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 		},
 	}
 
@@ -7162,7 +7166,7 @@ func TestVirtualKeyHashComparison_NewVirtualKey(t *testing.T) {
 		Name:        "new-vk",
 		Description: "New virtual key from config.json",
 		Value:       "vk_new123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7204,7 +7208,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Name:        "test-vk",
 		Description: "",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 	}
 
 	hashNoOptional, err := configstore.GenerateVirtualKeyHash(vkNoOptional)
@@ -7219,7 +7223,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Name:        "test-vk",
 		Description: "",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7239,7 +7243,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Name:        "test-vk",
 		Description: "",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		CustomerID:  &customerID,
 	}
 
@@ -7263,7 +7267,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Name:        "test-vk",
 		Description: "",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		RateLimitID: &rateLimitID,
 	}
 
@@ -7289,7 +7293,7 @@ func TestVirtualKeyHashComparison_FieldValueChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Base description",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7352,7 +7356,7 @@ func TestVirtualKeyHashComparison_RoundTrip(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &rateLimitID,
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
@@ -7382,7 +7386,7 @@ func TestVirtualKeyHashComparison_RoundTrip(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &reloadTeamID,
 		RateLimitID: &reloadRateLimitID,
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
@@ -8069,7 +8073,7 @@ func TestSQLite_VirtualKey_HashMismatch_FileSync(t *testing.T) {
 			Name:        "modified-name",
 			Description: "Modified description",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 		},
 	}
 	configData2 := makeConfigDataWithVirtualKeysAndDir(providers, vks2, tempDir)
@@ -8122,7 +8126,7 @@ func TestSQLite_VirtualKey_DBOnlyVK_Preserved(t *testing.T) {
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
 		Value:       "vk_dashboard456",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 	}
 	dashboardHash, _ := configstore.GenerateVirtualKeyHash(dashboardVK)
 	dashboardVK.ConfigHash = dashboardHash
@@ -8171,7 +8175,7 @@ func TestSQLite_VirtualKey_WithProviderConfigs(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK with provider configs",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8209,7 +8213,7 @@ func TestSQLite_VirtualKey_WithProviderConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "VK with provider configs",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8264,7 +8268,7 @@ func TestSQLite_VirtualKey_MergePath_WithProviderConfigs(t *testing.T) {
 			Name:        "vk-with-providers",
 			Description: "VK with provider configs added via merge",
 			Value:       "vk_providers456",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8377,7 +8381,7 @@ func TestSQLite_VirtualKey_MergePath_WithProviderConfigKeys(t *testing.T) {
 			Name:        "vk-with-provider-keys",
 			Description: "VK with provider configs referencing keys",
 			Value:       "vk_keys456",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8435,7 +8439,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8452,7 +8456,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8484,7 +8488,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8525,7 +8529,7 @@ func TestSQLite_VKProviderConfig_NewConfig(t *testing.T) {
 			Name:        "vk-with-provider-config",
 			Description: "VK with provider configs",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8596,7 +8600,7 @@ func TestSQLite_VKProviderConfig_KeyReference(t *testing.T) {
 			Name:        "vk-with-provider-ref",
 			Description: "VK with provider config",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8648,7 +8652,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8666,7 +8670,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8698,7 +8702,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8731,7 +8735,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8747,7 +8751,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8763,7 +8767,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8806,7 +8810,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8894,7 +8898,7 @@ func TestSQLite_FullLifecycle_InitialLoad(t *testing.T) {
 				Name:        "test-vk-1",
 				Description: "Test virtual key 1",
 				Value:       "vk_test123",
-				IsActive: schemas.Ptr(true),
+				IsActive:    schemas.Ptr(true),
 				RateLimitID: &rateLimitID,
 				ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 					{
@@ -8909,7 +8913,7 @@ func TestSQLite_FullLifecycle_InitialLoad(t *testing.T) {
 				Name:        "test-vk-2",
 				Description: "Test virtual key 2",
 				Value:       "vk_test456",
-				IsActive: schemas.Ptr(true),
+				IsActive:    schemas.Ptr(true),
 			},
 		},
 	}
@@ -9149,7 +9153,7 @@ func TestSQLite_FullLifecycle_DashboardEdits_ThenFileUnchanged(t *testing.T) {
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
 		Value:       "vk_dashboard456",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 	}
 	dashboardHash, _ := configstore.GenerateVirtualKeyHash(dashboardVK)
 	dashboardVK.ConfigHash = dashboardHash
@@ -9212,7 +9216,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 	}
 
 	// VK with one MCP config
@@ -9221,7 +9225,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    1,
@@ -9236,7 +9240,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    2, // Different client
@@ -9251,7 +9255,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    1,
@@ -9266,7 +9270,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    1,
@@ -9330,7 +9334,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    1,
@@ -9371,7 +9375,7 @@ func TestSQLite_VirtualKey_WithMCPConfigs(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK with MCP config",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 		},
 	}
 
@@ -9460,7 +9464,7 @@ func TestSQLite_VKMCPConfig_Reconciliation(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for MCP reconciliation test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 		},
 	}
 
@@ -9531,7 +9535,7 @@ func TestSQLite_VKMCPConfig_Reconciliation(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for MCP reconciliation test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{
 					MCPClientID:    mcpClient2.ID, // Different MCP client - will be created
@@ -9627,7 +9631,7 @@ func TestSQLite_VirtualKey_DashboardProviderConfig_DeletedOnFileChange(t *testin
 			Name:        "test-vk",
 			Description: "VK for dashboard provider config preservation test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -9691,7 +9695,7 @@ func TestSQLite_VirtualKey_DashboardProviderConfig_DeletedOnFileChange(t *testin
 			Name:        "test-vk",
 			Description: "VK for dashboard provider config preservation test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -9782,7 +9786,7 @@ func TestSQLite_VirtualKey_DashboardMCPConfig_DeletedOnFileChange(t *testing.T) 
 			Name:        "test-vk",
 			Description: "VK for dashboard MCP config preservation test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 		},
 	}
 
@@ -9867,7 +9871,7 @@ func TestSQLite_VirtualKey_DashboardMCPConfig_DeletedOnFileChange(t *testing.T) 
 			Name:        "test-vk",
 			Description: "VK for dashboard MCP config preservation test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{
 					MCPClientID:    mcpClient1.ID,
@@ -9952,7 +9956,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 		},
 	}
 
@@ -9988,7 +9992,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient1.ID, ToolsToExecute: []string{"tool1"}},
 				{MCPClientID: mcpClient2.ID, ToolsToExecute: []string{"tool2"}},
@@ -10020,7 +10024,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient1.ID, ToolsToExecute: []string{"tool1"}},
 				// mcpClient2 removed from file
@@ -10097,7 +10101,7 @@ func TestSQLite_VKMCPConfig_UpdateTools(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{MCPClientID: mcpClient.ID, ToolsToExecute: []string{"tool1", "tool2"}},
 		},
@@ -10122,7 +10126,7 @@ func TestSQLite_VKMCPConfig_UpdateTools(t *testing.T) {
 			Name:        "test-vk",
 			Description: "Test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient.ID, ToolsToExecute: []string{"tool3", "tool4", "tool5"}}, // Different tools
 			},
@@ -10194,7 +10198,7 @@ func TestSQLite_VK_ProviderAndMCPConfigs_Combined(t *testing.T) {
 			Name:        "combined-vk",
 			Description: "VK with both provider and MCP configs",
 			Value:       "vk_combined123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -10615,7 +10619,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10647,7 +10651,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            3,
@@ -10679,7 +10683,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            2,
@@ -10739,7 +10743,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10757,7 +10761,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10775,7 +10779,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10821,7 +10825,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10844,7 +10848,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10867,7 +10871,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10918,7 +10922,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -10947,7 +10951,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             3,
@@ -10976,7 +10980,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             2,
@@ -11033,7 +11037,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -11050,7 +11054,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -11067,7 +11071,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -11112,7 +11116,7 @@ func TestGenerateVirtualKeyHash_StableCombinedOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -11154,7 +11158,7 @@ func TestGenerateVirtualKeyHash_StableCombinedOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            2,


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


