### PR TITLE
migration guide docs update

### DIFF
--- a/docs/deployment-guides/helm/cluster.mdx
+++ b/docs/deployment-guides/helm/cluster.mdx
@@ -61,6 +61,8 @@ bifrost:
         timeoutSeconds: 10
         successThreshold: 3
         failureThreshold: 3
+    grpc:
+      port: 10102 # this is the default port if grpc is not mentioned, can be overridden
 
 # Spread replicas across nodes for true HA
 affinity:

--- a/docs/enterprise/migration-guides/v1.4.0.mdx
+++ b/docs/enterprise/migration-guides/v1.4.0.mdx
@@ -71,6 +71,10 @@ ports:
 
 Apply the same addition to your headless `Service`. See the updated [Clustering documentation](/enterprise/clustering) for full manifests.
 
+<Note>
+If you deploy via Helm, **upgrade to Bifrost chart `>= 2.1.14`** before rolling out v1.4.0. Earlier chart versions don't expose the `10102/TCP` gRPC port on the StatefulSet or headless `Service`, so cluster nodes won't be able to reach each other for counter-sync. The chart's [cluster values](/deployment-guides/helm/cluster) include the `grpc.port` field by default.
+</Note>
+
 **Optional `cluster_config.grpc` block** (defaults shown):
 ```json
 {
@@ -167,7 +171,7 @@ Work through the [OSS v1.5.0 Migration Guide](/migration-guides/v1.5.0) checklis
 </Step>
 
 <Step title="Open the gRPC cluster port (10102/TCP) on every node">
-Update Kubernetes StatefulSets/Deployments, headless Services, NetworkPolicies, and any cloud-level security groups or firewall rules to allow `10102/TCP` peer-to-peer between cluster nodes.
+Update Kubernetes StatefulSets/Deployments, headless Services, NetworkPolicies, and any cloud-level security groups or firewall rules to allow `10102/TCP` peer-to-peer between cluster nodes. **Helm users:** upgrade to Bifrost chart `>= 2.1.14`, which exposes this port automatically.
 </Step>
 
 <Step title="Verify SCIM group claims in tokens">


### PR DESCRIPTION
## Summary

Documents the requirement to upgrade to Bifrost chart `>= 2.1.14` before rolling out v1.4.0 when deploying via Helm, ensuring the `10102/TCP` gRPC port is properly exposed for cluster node communication.

## Changes

- Added a `grpc.port: 10102` field to the Helm cluster values example, clarifying the default port and that it can be overridden.
- Added a `<Note>` callout in the v1.4.0 migration guide warning Helm users to upgrade to Bifrost chart `>= 2.1.14` before deploying v1.4.0, since earlier chart versions do not expose the gRPC port on the StatefulSet or headless Service, which breaks counter-sync between cluster nodes.
- Updated the "Open the gRPC cluster port" migration step to explicitly call out that Helm users should upgrade to chart `>= 2.1.14` to have the port exposed automatically.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation pages:
- `/deployment-guides/helm/cluster` — confirm the `grpc.port` field appears in the cluster values example.
- `/enterprise/migration-guides/v1.4.0` — confirm the `<Note>` callout appears under the port configuration section and that the gRPC port step includes the Helm upgrade instruction.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Relates to the v1.4.0 release and Bifrost chart `2.1.14` rollout.

## Security considerations

None. This is a documentation-only change clarifying network port exposure requirements for cluster deployments.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable