### PR TITLE
docs: adds release cadence updates

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -100,6 +100,13 @@
             ]
           },
           {
+            "group": "Release Cadence",
+            "icon": "calendar",
+            "pages": [
+              "release-cadence"
+            ]
+          },
+          {
             "group": "Migration Guides",
             "icon": "arrow-up-right-dots",
             "pages": [
@@ -244,6 +251,13 @@
             "icon": "building",
             "pages": [
               "enterprise/overview"
+            ]
+          },
+          {
+            "group": "Release Cadence",
+            "icon": "calendar",
+            "pages": [
+              "enterprise/release-cadence"
             ]
           },
           {

--- a/docs/enterprise/release-cadence.mdx
+++ b/docs/enterprise/release-cadence.mdx
@@ -1,0 +1,39 @@
+---
+title: "Release Cadence"
+description: "How Bifrost Enterprise releases are versioned and shipped"
+icon: "box-open"
+---
+
+Bifrost Enterprise follows standard [semantic versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`) on top of the OSS base. The cadence below describes when each release type ships, what it typically contains, and how to decide whether you need to upgrade.
+
+## Cadence at a glance
+
+| Release type | Frequency | Typical contents |
+|---|---|---|
+| **Patch** (`x.y.Z`) | Every 2 - 3 days | Bug fixes, CVE fixes, small feature previews |
+| **Minor** (`x.Y.0`) | Every 2 weeks | Rollup of the period's patches plus new non-breaking features |
+| **Major** (`X.0.0`) | When breaking changes land | Breaking API/schema changes, large architectural cuts |
+
+## Patch releases
+
+Patch versions ship every 2 - 3 days. A patch may include:
+
+- Bug fixes
+- CVE / security patches
+- Small feature previews (gated behind config flags where applicable)
+
+Each patch is independently installable, but every patch is also rolled into the next minor release, so deployments on the bi-weekly minor cadence pick them all up automatically.
+
+## Minor releases
+
+A minor version is cut **once every 2 weeks**. It consolidates every patch released since the previous minor, alongside any new non-breaking features that landed in that window. Picking up the latest minor gives you everything from the intervening patches in a single deploy.
+
+## Major releases
+
+Major versions are reserved for **breaking changes** or **major architectural cuts** (cluster transport changes, schema migrations, IdP behavior changes, etc.). Each major release is paired with a [migration guide](/enterprise/migration-guides/v1.4.0) listing every breaking change with before/after examples and a step-by-step checklist.
+
+## Do you need to upgrade every release?
+
+**No.** Patch and minor releases are cumulative, so skipping intermediate versions is safe - you can stay on whichever release line matches your deployment cadence.
+
+**Upgrade immediately only when the release notes explicitly say so.** That signal is reserved for high-severity CVEs, data-correctness fixes, or production-impacting regressions. Everything else can ride the regular cadence.

--- a/docs/release-cadence.mdx
+++ b/docs/release-cadence.mdx
@@ -1,0 +1,39 @@
+---
+title: "Release Cadence"
+description: "How Bifrost OSS releases are versioned and shipped"
+icon: "box-open"
+---
+
+Bifrost follows standard [semantic versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`). The cadence below describes when each release type ships, what it typically contains, and how to decide whether you need to upgrade.
+
+## Cadence at a glance
+
+| Release type | Frequency | Typical contents |
+|---|---|---|
+| **Patch** (`x.y.Z`) | Every 2 - 3 days | Bug fixes, CVE fixes, small feature previews |
+| **Minor** (`x.Y.0`) | Every 2 weeks | Rollup of the period's patches plus new non-breaking features |
+| **Major** (`X.0.0`) | When breaking changes land | Breaking API/schema changes, large architectural cuts |
+
+## Patch releases
+
+Patch versions ship every 2 - 3 days. A patch may include:
+
+- Bug fixes
+- CVE / security patches
+- Small feature previews (gated behind config flags where applicable)
+
+Each patch is independently installable, but every patch is also rolled into the next minor release, so deployments that follow the bi-weekly minor cadence pick them all up automatically.
+
+## Minor releases
+
+A minor version is cut **once every 2 weeks**. It consolidates every patch released since the previous minor, alongside any new non-breaking features that landed in that window. Picking up the latest minor gives you everything from the intervening patches in a single deploy.
+
+## Major releases
+
+Major versions are reserved for **breaking changes** or **major architectural cuts**. Each major release is paired with a [migration guide](/migration-guides/v1.5.0) listing every breaking change with before/after examples and a step-by-step checklist.
+
+## Do you need to upgrade every release?
+
+**No.** Patch and minor releases are cumulative, so skipping intermediate versions is safe - you can stay on whichever release line matches your deployment cadence.
+
+**Upgrade immediately only when the release notes explicitly say so.** That signal is reserved for high-severity CVEs, data-correctness fixes, or production-impacting regressions. Everything else can ride the regular cadence.


### PR DESCRIPTION
## Summary

Adds release cadence documentation for both Bifrost OSS and Bifrost Enterprise, giving users a clear reference for how versions are numbered, how frequently each release type ships, and when an immediate upgrade is required.

## Changes

- Added `docs/release-cadence.mdx` documenting the OSS release cadence (patch every 2–3 days, minor every 2 weeks, major on breaking changes)
- Added `docs/enterprise/release-cadence.mdx` with the same structure tailored to the Enterprise edition
- Registered both pages in `docs/docs.json` under a new "Release Cadence" group (with a calendar icon) in the OSS and Enterprise navigation sections respectively

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Navigate to the docs site and verify:
- The "Release Cadence" group appears in the OSS sidebar with the calendar icon, linking to `/release-cadence`
- The "Release Cadence" group appears in the Enterprise sidebar, linking to `/enterprise/release-cadence`
- Both pages render correctly with the cadence table and all sections

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable