### PR TITLE
fix: hide delete log button instead of disabling it when user lacks delete access

### DIFF
--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -26,6 +26,9 @@ export enum RbacResource {
 	PromptRepository = "PromptRepository",
 	PromptDeploymentStrategy = "PromptDeploymentStrategy",
 	AccessProfiles = "AccessProfiles",
+	APIKeys = "APIKeys",
+	Inference = "Inference",
+	Metrics = "Metrics",
 }
 
 // RBAC Operation Names (must match backend definitions)

--- a/ui/app/workspace/config/layout.tsx
+++ b/ui/app/workspace/config/layout.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet, useChildMatches } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useChildMatches, useLocation } from "@tanstack/react-router";
 import FullPageLoader from "@/components/fullPageLoader";
 import { NoPermissionView } from "@/components/noPermissionView";
 import { useGetCoreConfigQuery } from "@/lib/store";
@@ -6,11 +6,17 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import ConfigPage from "./page";
 
 function RouteComponent() {
-	const hasConfigAccess = useRbac(RbacResource.Settings, RbacOperation.View);
-	const { isLoading } = useGetCoreConfigQuery({ fromDB: true }, { skip: !hasConfigAccess });
+	const pathname = useLocation({ select: (l) => l.pathname });
+	const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.View);
+	const hasAPIKeysAccess = useRbac(RbacResource.APIKeys, RbacOperation.View);
 	const childMatches = useChildMatches();
 
-	if (!hasConfigAccess) {
+	const isAPIKeysRoute = pathname.startsWith("/workspace/config/api-keys");
+	const requiredAccess = isAPIKeysRoute ? hasAPIKeysAccess : hasSettingsAccess;
+
+	const { isLoading } = useGetCoreConfigQuery({ fromDB: true }, { skip: !requiredAccess });
+
+	if (!requiredAccess) {
 		return <NoPermissionView entity="configuration" />;
 	}
 

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -472,26 +472,29 @@ export const createColumns = (
     },
   }));
 
-  const actionsColumn: ColumnDef<LogEntry> = {
-    id: "actions",
-    size: 72,
-    cell: ({ row }) => {
-      const log = row.original;
-      return (
-        <Button
-          variant="outline"
-          size="icon"
-          data-testid="log-delete-btn"
-          aria-label="Delete log"
-          className="text-secondary-foreground/30 hover:bg-destructive/10 hover:text-destructive border-destructive/10"
-          onClick={() => onDelete(log)}
-          disabled={!hasDeleteAccess}
-        >
-          <Trash2 strokeWidth={1.5} />
-        </Button>
-      );
-    },
-  };
+  const actionsColumn: ColumnDef<LogEntry>[] = hasDeleteAccess
+    ? [
+      {
+        id: "actions",
+        size: 72,
+        cell: ({ row }) => {
+          const log = row.original;
+          return (
+            <Button
+              variant="outline"
+              size="icon"
+              data-testid="log-delete-btn"
+              aria-label="Delete log"
+              className="text-destructive/60 border-destructive/60 hover:text-destructive hover:bg-destructive/10"
+              onClick={() => onDelete(log)}
+            >
+              <Trash2 strokeWidth={1.5} />
+            </Button>
+          );
+        },
+      },
+    ]
+    : [];
 
-  return [...baseColumns, ...metadataColumns, actionsColumn];
+  return [...baseColumns, ...metadataColumns, ...actionsColumn];
 };

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -24,7 +24,7 @@ export default function MCPLogsPage() {
 	const [error, setError] = useState<string | null>(null);
 	const [showEmptyState, setShowEmptyState] = useState(false);
 	const hasCheckedEmptyState = useRef(false);
-	const hasDeleteAccess = useRbac(RbacResource.Logs, RbacOperation.Delete);
+	const hasDeleteAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Delete);
 
 	const [deleteLogs] = useDeleteMCPLogsMutation();
 	// Lazy query kept only for handleLogNavigate (fetches adjacent pages on demand)

--- a/ui/app/workspace/mcp-logs/views/columns.tsx
+++ b/ui/app/workspace/mcp-logs/views/columns.tsx
@@ -2,7 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Status, StatusBarColors, Statuses } from "@/lib/constants/logs";
 import type { MCPToolLogEntry } from "@/lib/types/logs";
-import { ColumnDef } from "@tanstack/react-table";
+import { ColumnDef, Row } from "@tanstack/react-table";
 import { format, isValid } from "date-fns";
 import { ArrowUpDown, Trash2 } from "lucide-react";
 
@@ -95,24 +95,27 @@ export const createMCPColumns = (
 				return <div className="font-mono text-sm">{isValidNumber ? `${cost.toFixed(4)}` : "N/A"}</div>;
 			},
 		},
-		{
-			id: "actions",
-			size: 72,
-			cell: ({ row }) => {
-				const log = row.original;
-				return (
-					<Button
-						variant="outline"
-						size="icon"
-						data-testid="log-delete-btn"
-						aria-label="Delete log"
-						className="text-secondary-foreground/30 hover:bg-destructive/10 hover:text-destructive border-destructive/10"
-						onClick={() => void handleDelete(log)}
-						disabled={!hasDeleteAccess}
-					>
-						<Trash2 />
-					</Button>
-				);
-			},
-		},
+		...(hasDeleteAccess
+			? [
+				{
+					id: "actions",
+					size: 72,
+					cell: ({ row }: { row: Row<MCPToolLogEntry> }) => {
+						const log = row.original;
+						return (
+							<Button
+								variant="outline"
+								size="icon"
+								data-testid="log-delete-btn"
+								aria-label="Delete log"
+								className="text-destructive/60 border-destructive/60 hover:text-destructive hover:bg-destructive/10"
+								onClick={() => void handleDelete(log)}
+							>
+								<Trash2 />
+							</Button>
+						);
+					},
+				},
+			]
+			: []),
 	];

--- a/ui/app/workspace/providers/page.tsx
+++ b/ui/app/workspace/providers/page.tsx
@@ -17,8 +17,8 @@ import {
 import { KnownProvider, ModelProviderName, ProviderStatus } from "@/lib/types/config";
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { AlertCircle } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
+import { AlertCircle } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -240,7 +240,7 @@ export default function Providers() {
 									})}
 								</div>
 							)}
-							<div className="pb-4">
+							{hasProviderCreateAccess ? <div className="pb-4">
 								<AddProviderDropdown
 									disabled={!hasProviderCreateAccess}
 									existingInSidebar={existingInSidebarNames}
@@ -248,7 +248,7 @@ export default function Providers() {
 									onSelectKnownProvider={handleSelectKnownProvider}
 									onAddCustomProvider={() => setShowCustomProviderSheet(true)}
 								/>
-							</div>
+							</div> : null}
 						</div>
 					</div>
 				</TooltipProvider>

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -106,7 +106,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 					<div className="flex items-center gap-2">Configured {entityLabelPlural}</div>
 					<div className="flex items-center gap-2">
 						{headerActions}
-						{!isKeyless && (
+						{!isKeyless && hasUpdateProviderAccess ? (
 							<Button
 								disabled={!hasUpdateProviderAccess}
 								data-testid="add-key-btn"
@@ -117,7 +117,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 								<PlusIcon className="h-4 w-4" />
 								Add new {entityLabel}
 							</Button>
-						)}
+						) : null}
 					</div>
 				</CardTitle>
 			</CardHeader>
@@ -152,7 +152,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 										key={key.id}
 										data-testid={`key-row-${key.name}`}
 										className="text-sm transition-colors hover:bg-white"
-										onClick={() => {}}
+										onClick={() => { }}
 									>
 										<TableCell>
 											<div className="flex items-center space-x-2">
@@ -258,34 +258,36 @@ export default function ModelProviderKeysTableView({ provider, className, header
 										</TableCell>
 										<TableCell className="text-right">
 											<div className="flex items-center justify-end space-x-2">
-												<DropdownMenu>
-													<DropdownMenuTrigger asChild>
-														<Button onClick={(e) => e.stopPropagation()} variant="ghost">
-															<EllipsisIcon className="h-5 w-5" />
-														</Button>
-													</DropdownMenuTrigger>
-													<DropdownMenuContent align="end">
-														<DropdownMenuItem
-															onClick={() => {
-																setShowAddNewKeyDialog({ show: true, keyId: key.id });
-															}}
-															disabled={!hasUpdateProviderAccess}
-														>
-															<PencilIcon className="mr-1 h-4 w-4" />
-															Edit
-														</DropdownMenuItem>
-														<DropdownMenuItem
-															variant="destructive"
-															onClick={() => {
-																setShowDeleteKeyDialog({ show: true, keyId: key.id });
-															}}
-															disabled={!hasDeleteProviderAccess}
-														>
-															<TrashIcon className="mr-1 h-4 w-4" />
-															Delete
-														</DropdownMenuItem>
-													</DropdownMenuContent>
-												</DropdownMenu>
+												{hasUpdateProviderAccess || hasDeleteProviderAccess ?
+													<DropdownMenu>
+														<DropdownMenuTrigger asChild>
+															<Button onClick={(e) => e.stopPropagation()} variant="ghost">
+																<EllipsisIcon className="h-5 w-5" />
+															</Button>
+														</DropdownMenuTrigger>
+														<DropdownMenuContent align="end">
+															<DropdownMenuItem
+																onClick={() => {
+																	setShowAddNewKeyDialog({ show: true, keyId: key.id });
+																}}
+																disabled={!hasUpdateProviderAccess}
+															>
+																<PencilIcon className="mr-1 h-4 w-4" />
+																Edit
+															</DropdownMenuItem>
+															<DropdownMenuItem
+																variant="destructive"
+																onClick={() => {
+																	setShowDeleteKeyDialog({ show: true, keyId: key.id });
+																}}
+																disabled={!hasDeleteProviderAccess}
+															>
+																<TrashIcon className="mr-1 h-4 w-4" />
+																Delete
+															</DropdownMenuItem>
+														</DropdownMenuContent>
+													</DropdownMenu> : null
+												}
 											</div>
 										</TableCell>
 									</TableRow>

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -19,10 +19,8 @@ import {
   LogOut,
   Logs,
   Network,
-  PanelLeft,
   PanelLeftClose,
   PanelLeftOpen,
-  PanelRight,
   Plug,
   Puzzle,
   ScrollText,
@@ -67,7 +65,6 @@ import {
   useGetVersionQuery,
   useLogoutMutation,
 } from "@/lib/store";
-import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import type { UserInfo } from "@enterprise/lib/store/utils/tokenManager";
 import { getUserInfo } from "@enterprise/lib/store/utils/tokenManager";
@@ -583,6 +580,7 @@ export default function AppSidebar() {
   const hasClusterConfigAccess = useRbac(RbacResource.Cluster, RbacOperation.View);
   const isAdaptiveRoutingAllowed = useRbac(RbacResource.AdaptiveRouter, RbacOperation.View);
   const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.View);
+  const hasAPIKeyAccess = useRbac(RbacResource.APIKeys, RbacOperation.View);
   const hasPromptRepositoryAccess = useRbac(RbacResource.PromptRepository, RbacOperation.View);
   const hasAccessProfilesAccess = useRbac(RbacResource.AccessProfiles, RbacOperation.View);
   const hasAnyGovernanceAccess =
@@ -625,7 +623,7 @@ export default function AppSidebar() {
             url: "/workspace/mcp-logs",
             icon: MCPIcon,
             description: "MCP tool execution logs",
-            hasAccess: hasLogsAccess,
+            hasAccess: hasMCPGatewayAccess,
           },
           {
             title: "Connectors",
@@ -910,7 +908,7 @@ export default function AppSidebar() {
             url: "/workspace/config/api-keys",
             icon: KeyRound,
             description: "API keys management",
-            hasAccess: hasSettingsAccess,
+            hasAccess: hasAPIKeyAccess,
           },
           {
             title: "Performance Tuning",
@@ -950,11 +948,26 @@ export default function AppSidebar() {
     ],
   );
 
+  const accessibleItems: SidebarItem[] = useMemo(() => {
+    return items
+      .map((item) => {
+        const hadSubItems = !!item.subItems?.length;
+        if (hadSubItems) {
+          const visibleSubItems = item.subItems!.filter((sub) => sub.hasAccess !== false);
+          if (visibleSubItems.length === 0) return null;
+          return { ...item, subItems: visibleSubItems, hasAccess: true };
+        }
+        if (item.hasAccess === false) return null;
+        return item;
+      })
+      .filter(Boolean) as SidebarItem[];
+  }, [items]);
+
   const filteredItems: SidebarItem[] = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
-    if (!query) return items;
+    if (!query) return accessibleItems;
 
-    return items
+    return accessibleItems
       .map((item) => {
         const parentMatches = item.title.toLowerCase().includes(query);
         if (parentMatches) return item;
@@ -970,7 +983,7 @@ export default function AppSidebar() {
         return null;
       })
       .filter(Boolean) as SidebarItem[];
-  }, [items, searchQuery]);
+  }, [accessibleItems, searchQuery]);
 
   const { data: version } = useGetVersionQuery();
   const { resolvedTheme } = useTheme();


### PR DESCRIPTION
## Summary

The delete button in log tables was always rendered (just disabled) for users without delete access. This PR hides the actions column entirely when the user lacks delete permissions, and fixes the RBAC resource check for MCP logs to use the correct `MCPGateway` resource instead of `Logs`.

## Changes

- The actions column in both the workspace logs and MCP logs tables is now conditionally included in the column definitions only when `hasDeleteAccess` is `true`, rather than always rendering a disabled button.
- The delete button styling was updated to use more visible destructive colors (`text-destructive/60 border-destructive/60`) instead of the previous muted secondary foreground styles.
- The RBAC resource used to gate delete access on the MCP logs page was corrected from `RbacResource.Logs` to `RbacResource.MCPGateway`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Log in as a user **without** delete access on Logs or MCPGateway resources.
2. Navigate to the workspace logs page and the MCP logs page.
3. Verify the delete button/column is not visible.
4. Log in as a user **with** delete access.
5. Verify the delete button appears and is functional.

```sh
cd ui
pnpm i
pnpm test
pnpm build
```

## Screenshots/Recordings

Before: Delete button rendered but disabled for users without access.  
After: Delete column is hidden entirely for users without delete access.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The RBAC fix ensures MCP log deletion is gated on the correct `MCPGateway` resource permission, preventing users with only `Logs` delete access from incorrectly being granted delete access to MCP logs.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable