### PR TITLE
fix: handle tool choice any in genai roundtrip, closes #3290

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -2986,3 +2986,87 @@ func TestGenAIFinishReasonMaxTokens_PersistsThroughBifrostRoundTrip(t *testing.T
 	require.Len(t, out.Candidates, 1)
 	assert.Equal(t, gemini.FinishReasonMaxTokens, out.Candidates[0].FinishReason)
 }
+
+// TestFunctionCallingConfigModeAny_RoundTrip verifies that FunctionCallingConfigMode.ANY and
+// AllowedFunctionNames survive the Gemini→Bifrost→Gemini round-trip on the GenAI passthrough path.
+// Regression: ANY was silently downgraded to AUTO (missing case in convertGeminiToolConfigToToolChoice)
+// and AllowedFunctionNames were dropped (ext.Tools not read in convertResponsesToolChoiceToGemini).
+func TestFunctionCallingConfigModeAny_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name                 string
+		mode                 gemini.FunctionCallingConfigMode
+		allowedFunctionNames []string
+		wantMode             gemini.FunctionCallingConfigMode
+		wantAllowedNames     []string
+	}{
+		{
+			name:                 "ANY_with_single_allowed_function",
+			mode:                 gemini.FunctionCallingConfigModeAny,
+			allowedFunctionNames: []string{"create_component"},
+			wantMode:             gemini.FunctionCallingConfigModeAny,
+			wantAllowedNames:     []string{"create_component"},
+		},
+		{
+			name:                 "ANY_with_multiple_allowed_functions",
+			mode:                 gemini.FunctionCallingConfigModeAny,
+			allowedFunctionNames: []string{"create_component", "delete_component"},
+			wantMode:             gemini.FunctionCallingConfigModeAny,
+			wantAllowedNames:     []string{"create_component", "delete_component"},
+		},
+		{
+			name:                 "ANY_without_allowed_functions",
+			mode:                 gemini.FunctionCallingConfigModeAny,
+			allowedFunctionNames: nil,
+			wantMode:             gemini.FunctionCallingConfigModeAny,
+			wantAllowedNames:     nil,
+		},
+		{
+			name:             "AUTO_unaffected",
+			mode:             gemini.FunctionCallingConfigModeAuto,
+			wantMode:         gemini.FunctionCallingConfigModeAuto,
+			wantAllowedNames: nil,
+		},
+		{
+			name:             "NONE_unaffected",
+			mode:             gemini.FunctionCallingConfigModeNone,
+			wantMode:         gemini.FunctionCallingConfigModeNone,
+			wantAllowedNames: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			geminiReq := &gemini.GeminiGenerationRequest{
+				Model: "gemini-2.5-flash",
+				Contents: []gemini.Content{
+					{Role: "user", Parts: []*gemini.Part{{Text: "call the function"}}},
+				},
+				Tools: []gemini.Tool{
+					{FunctionDeclarations: []*gemini.FunctionDeclaration{{Name: "create_component"}}},
+				},
+				ToolConfig: &gemini.ToolConfig{
+					FunctionCallingConfig: &gemini.FunctionCallingConfig{
+						Mode:                 tt.mode,
+						AllowedFunctionNames: tt.allowedFunctionNames,
+					},
+				},
+			}
+
+			bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			bifrostReq := geminiReq.ToBifrostResponsesRequest(bifrostCtx)
+			require.NotNil(t, bifrostReq)
+			require.NotNil(t, bifrostReq.Params)
+			require.NotNil(t, bifrostReq.Params.ToolChoice, "ToolChoice must be set")
+
+			roundTrip, err := gemini.ToGeminiResponsesRequest(bifrostReq)
+			require.NoError(t, err)
+			require.NotNil(t, roundTrip)
+			require.NotNil(t, roundTrip.ToolConfig)
+			require.NotNil(t, roundTrip.ToolConfig.FunctionCallingConfig)
+
+			got := roundTrip.ToolConfig.FunctionCallingConfig
+			assert.Equal(t, tt.wantMode, got.Mode, "FunctionCallingConfig.Mode must survive round-trip")
+			assert.Equal(t, tt.wantAllowedNames, got.AllowedFunctionNames, "AllowedFunctionNames must survive round-trip")
+		})
+	}
+}

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -2212,6 +2212,8 @@ func convertGeminiToolConfigToToolChoice(toolConfig *ToolConfig) *schemas.Respon
 	switch toolConfig.FunctionCallingConfig.Mode {
 	case FunctionCallingConfigModeAuto:
 		toolChoice.Mode = schemas.Ptr("auto")
+	case FunctionCallingConfigModeAny:
+		toolChoice.Mode = schemas.Ptr("required")
 	case FunctionCallingConfigModeNone:
 		toolChoice.Mode = schemas.Ptr("none")
 	default:
@@ -2857,8 +2859,21 @@ func convertResponsesToolChoiceToGemini(toolChoice *schemas.ResponsesToolChoice)
 		}
 
 		if ext.Name != nil {
-			funcConfig.Mode = FunctionCallingConfigModeAny
+			if ext.Mode == nil {
+				funcConfig.Mode = FunctionCallingConfigModeAny
+			}
 			funcConfig.AllowedFunctionNames = []string{*ext.Name}
+		}
+
+		if len(ext.Tools) > 0 {
+			if ext.Mode == nil {
+				funcConfig.Mode = FunctionCallingConfigModeAny
+			}
+			for _, tool := range ext.Tools {
+				if tool.Name != nil {
+					funcConfig.AllowedFunctionNames = append(funcConfig.AllowedFunctionNames, *tool.Name)
+				}
+			}
 		}
 
 		config.FunctionCallingConfig = funcConfig


### PR DESCRIPTION
## Summary

Fixes two bugs in the Gemini GenAI passthrough path where `FunctionCallingConfigMode.ANY` was silently downgraded to `AUTO`, and `AllowedFunctionNames` were dropped during the Gemini→Bifrost→Gemini round-trip.

## Changes

- Added a missing `FunctionCallingConfigModeAny` case in `convertGeminiToolConfigToToolChoice` that maps `ANY` to the `"required"` tool choice mode. Previously, the switch statement had no case for `ANY`, causing it to fall through to the default and lose the mode entirely.
- Fixed `convertResponsesToolChoiceToGemini` to read `ext.Tools` when reconstructing the Gemini `FunctionCallingConfig`, so that `AllowedFunctionNames` are correctly repopulated from the Bifrost representation on the return trip.
- Added `TestFunctionCallingConfigModeAny_RoundTrip` covering `ANY` with single, multiple, and no allowed function names, as well as confirming `AUTO` and `NONE` are unaffected.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/... -run TestFunctionCallingConfigModeAny_RoundTrip -v
```

Expected: all five sub-tests (`ANY_with_single_allowed_function`, `ANY_with_multiple_allowed_functions`, `ANY_without_allowed_functions`, `AUTO_unaffected`, `NONE_unaffected`) pass, confirming that `FunctionCallingConfig.Mode` and `AllowedFunctionNames` survive the round-trip intact.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only affects how tool-calling configuration is translated between Gemini and Bifrost internal representations.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable