### PR TITLE
feat: add `MCPLogs` RBAC resource and enforce access control on MCP logs route and sidebar

### DIFF
--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -15,6 +15,7 @@ export enum RbacResource {
 	ModelProvider = "ModelProvider",
 	Plugins = "Plugins",
 	MCPGateway = "MCPGateway",
+	MCPLogs = "MCPLogs",
 	AdaptiveRouter = "AdaptiveRouter",
 	AuditLogs = "AuditLogs",
 	Customers = "Customers",

--- a/ui/app/workspace/mcp-logs/layout.tsx
+++ b/ui/app/workspace/mcp-logs/layout.tsx
@@ -1,6 +1,16 @@
+import { NoPermissionView } from "@/components/noPermissionView";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { createFileRoute } from "@tanstack/react-router";
 import MCPLogsPage from "./page";
 
+function RouteComponent() {
+	const hasViewMCPLogsAccess = useRbac(RbacResource.MCPLogs, RbacOperation.View);
+	if (!hasViewMCPLogsAccess) {
+		return <NoPermissionView entity="mcp logs" />;
+	}
+	return <MCPLogsPage />;
+}
+
 export const Route = createFileRoute("/workspace/mcp-logs")({
-	component: MCPLogsPage,
+	component: RouteComponent,
 });

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -24,7 +24,7 @@ export default function MCPLogsPage() {
 	const [error, setError] = useState<string | null>(null);
 	const [showEmptyState, setShowEmptyState] = useState(false);
 	const hasCheckedEmptyState = useRef(false);
-	const hasDeleteAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Delete);
+	const hasDeleteAccess = useRbac(RbacResource.MCPLogs, RbacOperation.Delete);
 
 	const [deleteLogs] = useDeleteMCPLogsMutation();
 	// Lazy query kept only for handleLogNavigate (fetches adjacent pages on demand)

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -561,6 +561,7 @@ export default function AppSidebar() {
   const hasObservabilityAccess = useRbac(RbacResource.Observability, RbacOperation.View);
   const hasModelProvidersAccess = useRbac(RbacResource.ModelProvider, RbacOperation.View);
   const hasMCPGatewayAccess = useRbac(RbacResource.MCPGateway, RbacOperation.View);
+  const hasMCPLogsAccess = useRbac(RbacResource.MCPLogs, RbacOperation.View);
   const hasPluginsAccess = useRbac(RbacResource.Plugins, RbacOperation.View);
   const hasUsersAccess = useRbac(RbacResource.Users, RbacOperation.View);
   const hasUserProvisioningAccess = useRbac(RbacResource.UserProvisioning, RbacOperation.View);
@@ -623,7 +624,7 @@ export default function AppSidebar() {
             url: "/workspace/mcp-logs",
             icon: MCPIcon,
             description: "MCP tool execution logs",
-            hasAccess: hasMCPGatewayAccess,
+            hasAccess: hasMCPLogsAccess,
           },
           {
             title: "Connectors",
@@ -921,11 +922,12 @@ export default function AppSidebar() {
       },
     ],
     [
-      hasLogsAccess,
-      hasObservabilityAccess,
-      hasModelProvidersAccess,
-      hasMCPGatewayAccess,
-      hasPluginsAccess,
+        hasLogsAccess,
+        hasObservabilityAccess,
+        hasModelProvidersAccess,
+        hasMCPGatewayAccess,
+        hasMCPLogsAccess,
+        hasPluginsAccess,
       hasUsersAccess,
       hasUserProvisioningAccess,
       hasAuditLogsAccess,


### PR DESCRIPTION
## Summary

Introduces a dedicated `MCPLogs` RBAC resource, decoupling MCP log access control from the `MCPGateway` resource. This allows permissions for viewing and deleting MCP logs to be managed independently from gateway-level permissions.

## Changes

- Added `MCPLogs` as a new `RbacResource` enum value in the fallback RBAC context.
- The MCP Logs route now checks `MCPLogs` view permission and renders a `NoPermissionView` when access is denied, rather than rendering the page unconditionally.
- Delete access on the MCP Logs page now checks `RbacResource.MCPLogs` instead of `RbacResource.MCPGateway`.
- The sidebar MCP Logs entry now uses `hasMCPLogsAccess` (derived from `RbacResource.MCPLogs`) to control visibility, rather than reusing `hasMCPGatewayAccess`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure a role that has `MCPGateway` access but **no** `MCPLogs` access.
2. Log in as a user with that role and navigate to the MCP Logs page — the `NoPermissionView` should be displayed and the sidebar entry should be hidden.
3. Grant the role `MCPLogs` view access and confirm the page and sidebar entry become accessible.
4. Verify that delete functionality on the MCP Logs page is gated by `MCPLogs` delete permission independently of `MCPGateway` delete permission.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes
- [ ] No

Any role configuration that previously relied on `MCPGateway` permissions to grant access to MCP Logs will need to be updated to explicitly grant `MCPLogs` permissions.

## Related issues

N/A

## Security considerations

Access to MCP log data (which may contain sensitive tool execution details) is now enforced by a dedicated RBAC resource, reducing the risk of unintended access through overly broad `MCPGateway` permissions.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable