### PR TITLE
change minor release cadence

### DIFF
--- a/docs/enterprise/release-cadence.mdx
+++ b/docs/enterprise/release-cadence.mdx
@@ -11,7 +11,7 @@ Bifrost Enterprise follows standard [semantic versioning](https://semver.org/) (
 | Release type | Frequency | Typical contents |
 |---|---|---|
 | **Patch** (`x.y.Z`) | Every 2 - 3 days | Bug fixes, CVE fixes, small feature previews |
-| **Minor** (`x.Y.0`) | Every 2 weeks | Rollup of the period's patches plus new non-breaking features |
+| **Minor** (`x.Y.0`) | Every 3 - 4 weeks | Rollup of the period's patches plus new non-breaking features |
 | **Major** (`X.0.0`) | When breaking changes land | Breaking API/schema changes, large architectural cuts |
 
 ## Patch releases
@@ -22,11 +22,11 @@ Patch versions ship every 2 - 3 days. A patch may include:
 - CVE / security patches
 - Small feature previews (gated behind config flags where applicable)
 
-Each patch is independently installable, but every patch is also rolled into the next minor release, so deployments on the bi-weekly minor cadence pick them all up automatically.
+Each patch is independently installable, but every patch is also rolled into the next minor release, so deployments on the 3 - 4 week cadence pick them all up automatically.
 
 ## Minor releases
 
-A minor version is cut **once every 2 weeks**. It consolidates every patch released since the previous minor, alongside any new non-breaking features that landed in that window. Picking up the latest minor gives you everything from the intervening patches in a single deploy.
+A minor version is cut **once every 3 - 4 weeks**. It consolidates every patch released since the previous minor, alongside any new non-breaking features that landed in that window. Picking up the latest minor gives you everything from the intervening patches in a single deploy.
 
 ## Major releases
 

--- a/docs/release-cadence.mdx
+++ b/docs/release-cadence.mdx
@@ -10,8 +10,8 @@ Bifrost follows standard [semantic versioning](https://semver.org/) (`MAJOR.MINO
 
 | Release type | Frequency | Typical contents |
 |---|---|---|
-| **Patch** (`x.y.Z`) | Every 2 - 3 days | Bug fixes, CVE fixes, small feature previews |
-| **Minor** (`x.Y.0`) | Every 2 weeks | Rollup of the period's patches plus new non-breaking features |
+| **Patch** (`x.y.Z`) | Every 2 - 3 days (depending on reports) | Bug fixes, CVE fixes, small feature previews |
+| **Minor** (`x.Y.0`) | Every 3 - 4 weeks | Rollup of the period's patches plus new non-breaking features |
 | **Major** (`X.0.0`) | When breaking changes land | Breaking API/schema changes, large architectural cuts |
 
 ## Patch releases
@@ -22,11 +22,11 @@ Patch versions ship every 2 - 3 days. A patch may include:
 - CVE / security patches
 - Small feature previews (gated behind config flags where applicable)
 
-Each patch is independently installable, but every patch is also rolled into the next minor release, so deployments that follow the bi-weekly minor cadence pick them all up automatically.
+Each patch is independently installable, but every patch is also rolled into the next minor release, so deployments that follow the 3 - 4 week cadence pick them all up automatically.
 
 ## Minor releases
 
-A minor version is cut **once every 2 weeks**. It consolidates every patch released since the previous minor, alongside any new non-breaking features that landed in that window. Picking up the latest minor gives you everything from the intervening patches in a single deploy.
+A minor version is cut **once every 3 - 4 weeks**. It consolidates every patch released since the previous minor, alongside any new non-breaking features that landed in that window. Picking up the latest minor gives you everything from the intervening patches in a single deploy.
 
 ## Major releases
 


### PR DESCRIPTION
## Summary

Updates the documented minor release cadence from every 2 weeks to every 3 - 4 weeks, reflecting the actual shipping schedule. Also clarifies that patch releases ship every 2 - 3 days depending on incoming reports.

## Changes

- Minor release frequency updated from "every 2 weeks" to "every 3 - 4 weeks" in both the standard and enterprise release cadence docs
- Patch release frequency description updated to note it varies "depending on reports"
- References to "bi-weekly" cadence replaced with "3 - 4 week cadence" for consistency

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation pages for `docs/release-cadence.mdx` and `docs/enterprise/release-cadence.mdx` to confirm the updated cadence values display correctly.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable