### PR TITLE
feat: fields for azure blob storage in batch api

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -1866,11 +1866,12 @@ func (bifrost *Bifrost) BatchCreateRequest(ctx *schemas.BifrostContext, req *sch
 			},
 		}
 	}
-	if req.InputFileID == "" && len(req.Requests) == 0 {
+	hasInputBlob := req.InputBlob != nil && strings.TrimSpace(*req.InputBlob) != ""
+	if req.InputFileID == "" && len(req.Requests) == 0 && !hasInputBlob {
 		return nil, &schemas.BifrostError{
 			IsBifrostError: false,
 			Error: &schemas.ErrorField{
-				Message: "either input_file_id or requests is required for batch create request",
+				Message: "either input_file_id, input_blob, or requests is required for batch create request",
 			},
 		}
 	}

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -2188,9 +2188,10 @@ func (provider *AzureProvider) BatchCreate(ctx *schemas.BifrostContext, key sche
 		inputFileID = uploadResp.ID
 	}
 
+
 	// Validate that we have a file ID (either provided or uploaded)
-	if inputFileID == "" {
-		return nil, providerUtils.NewBifrostOperationError("either input_file_id or requests array is required for Azure batch API", nil)
+	if inputFileID == "" && request.InputBlob == nil {
+		return nil, providerUtils.NewBifrostOperationError("either input_file_id, input_blob, or requests array is required for Azure batch API", nil)
 	}
 
 	// Get API version
@@ -2224,10 +2225,21 @@ func (provider *AzureProvider) BatchCreate(ctx *schemas.BifrostContext, key sche
 
 	// Build request body
 	openAIReq := &openai.OpenAIBatchRequest{
-		InputFileID:      inputFileID,
 		Endpoint:         string(request.Endpoint),
 		CompletionWindow: request.CompletionWindow,
 		Metadata:         request.Metadata,
+	}
+
+	// Azure requires either input_file_id OR (input_blob + output_folder), not both.
+	if inputFileID != "" {
+		openAIReq.InputFileID = schemas.Ptr(inputFileID)
+	} else {
+		if request.InputBlob != nil {
+			openAIReq.InputBlob = request.InputBlob
+		}
+		if request.OutputFolder != nil {
+			openAIReq.OutputFolder = request.OutputFolder
+		}
 	}
 
 	// Set default completion window if not provided
@@ -2250,7 +2262,7 @@ func (provider *AzureProvider) BatchCreate(ctx *schemas.BifrostContext, key sche
 
 	// Handle error response
 	if resp.StatusCode() != fasthttp.StatusOK && resp.StatusCode() != fasthttp.StatusCreated {
-		return nil, openai.ParseOpenAIError(resp)
+		return nil, providerUtils.EnrichError(ctx, openai.ParseOpenAIError(resp), jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
 	}
 
 	body, err := providerUtils.CheckAndDecodeBody(resp)

--- a/core/providers/openai/batch.go
+++ b/core/providers/openai/batch.go
@@ -10,11 +10,14 @@ import (
 
 // OpenAIBatchRequest represents the request body for creating a batch.
 type OpenAIBatchRequest struct {
-	InputFileID        string                     `json:"input_file_id"`
+	InputFileID        *string                    `json:"input_file_id,omitempty"`
 	Endpoint           string                     `json:"endpoint"`
 	CompletionWindow   string                     `json:"completion_window"`
 	Metadata           map[string]string          `json:"metadata,omitempty"`
 	OutputExpiresAfter *schemas.BatchExpiresAfter `json:"output_expires_after,omitempty"`
+
+	InputBlob    *string                    `json:"input_blob,omitempty"` // azure blob storage
+	OutputFolder *schemas.BatchOutputFolder `json:"output_folder,omitempty"`
 }
 
 // OpenAIBatchResponse represents an OpenAI batch response.

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -5361,7 +5361,7 @@ func (provider *OpenAIProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 
 	// Build request body
 	openAIReq := &OpenAIBatchRequest{
-		InputFileID:        inputFileID,
+		InputFileID:        schemas.Ptr(inputFileID),
 		Endpoint:           string(request.Endpoint),
 		CompletionWindow:   request.CompletionWindow,
 		Metadata:           request.Metadata,

--- a/core/schemas/batch.go
+++ b/core/schemas/batch.go
@@ -74,6 +74,10 @@ type BifrostBatchCreateRequest struct {
 	// Anthropic-style: inline requests
 	Requests []BatchRequestItem `json:"requests,omitempty"` // Inline request items
 
+	// Azure-style: Blob storage input and output folder
+	InputBlob    *string            `json:"input_blob,omitempty"`
+	OutputFolder *BatchOutputFolder `json:"output_folder,omitempty"`
+
 	// Common fields
 	Endpoint           BatchEndpoint      `json:"endpoint,omitempty"`             // Target endpoint for batch requests
 	CompletionWindow   string             `json:"completion_window,omitempty"`    // Time window (e.g., "24h")
@@ -82,6 +86,10 @@ type BifrostBatchCreateRequest struct {
 
 	// Extra parameters for provider-specific features
 	ExtraParams map[string]interface{} `json:"-"`
+}
+
+type BatchOutputFolder struct {
+	URL string `json:"url"`
 }
 
 // BatchExpiresAfter represents an expiration configuration for batch output.

--- a/tests/integrations/python/config.yml
+++ b/tests/integrations/python/config.yml
@@ -77,10 +77,10 @@ providers:
     embeddings: "text-embedding-3-small"
     image_generation: "gpt-image-1"
     thinking: "o1"
-    batch_file_upload: "gpt-4o-batch"
-    batch_list: "gpt-4o-batch"
-    batch_retrieve: "gpt-4o-batch"
-    batch_cancel: "gpt-4o-batch"
+    batch_file_upload: "gpt-4o-2"
+    batch_list: "gpt-4o-2"
+    batch_retrieve: "gpt-4o-2"
+    batch_cancel: "gpt-4o-2"
     file_upload: "gpt-4o"
     file_list: "gpt-4o"
     file_retrieve: "gpt-4o"
@@ -310,7 +310,7 @@ provider_scenarios:
     pydantic_structured_output: false
     pydanticai_streaming: false
     batch_file_upload: true
-    batch_create: false
+    batch_create: true
     batch_list: true
     batch_retrieve: true
     batch_cancel: true

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -339,6 +339,8 @@ var transcriptionParamsKnownFields = map[string]bool{
 var batchCreateParamsKnownFields = map[string]bool{
 	"model":             true,
 	"input_file_id":     true,
+	"input_blob":        true,
+	"output_folder":     true,
 	"requests":          true,
 	"endpoint":          true,
 	"completion_window": true,
@@ -560,6 +562,8 @@ type BatchCreateRequest struct {
 	Model            string                     `json:"model"`                       // Model in "provider/model" format
 	InputFileID      string                     `json:"input_file_id,omitempty"`     // OpenAI-style file ID
 	Requests         []schemas.BatchRequestItem `json:"requests,omitempty"`          // Anthropic-style inline requests
+	InputBlob        *string                    `json:"input_blob,omitempty"`        // Azure-style blob storage input
+	OutputFolder     *schemas.BatchOutputFolder `json:"output_folder,omitempty"`     // Azure-style output destination
 	Endpoint         string                     `json:"endpoint,omitempty"`          // e.g., "/v1/chat/completions"
 	CompletionWindow string                     `json:"completion_window,omitempty"` // e.g., "24h"
 	Metadata         map[string]string          `json:"metadata,omitempty"`
@@ -2629,9 +2633,10 @@ func (h *CompletionHandler) batchCreate(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	// Validate that at least one of InputFileID or Requests is provided
-	if req.InputFileID == "" && len(req.Requests) == 0 {
-		SendError(ctx, fasthttp.StatusBadRequest, "either input_file_id or requests is required")
+	// Validate that at least one of InputFileID or InputBlob or Requests is provided
+	hasInputBlob := req.InputBlob != nil && strings.TrimSpace(*req.InputBlob) != ""
+	if req.InputFileID == "" && len(req.Requests) == 0 && !hasInputBlob {
+		SendError(ctx, fasthttp.StatusBadRequest, "either input_file_id, input_blob, or requests is required")
 		return
 	}
 
@@ -2651,6 +2656,8 @@ func (h *CompletionHandler) batchCreate(ctx *fasthttp.RequestCtx) {
 		Provider:         schemas.ModelProvider(provider),
 		Model:            model,
 		InputFileID:      req.InputFileID,
+		InputBlob:        req.InputBlob,
+		OutputFolder:     req.OutputFolder,
 		Requests:         req.Requests,
 		Endpoint:         schemas.BatchEndpoint(req.Endpoint),
 		CompletionWindow: req.CompletionWindow,

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -1492,6 +1492,26 @@ func CreateOpenAIBatchRouteConfigs(pathPrefix string, handlerStore lib.HandlerSt
 							}
 						}
 					}
+
+					// For Azure, extract inline requests from raw body
+					if createReq.Provider == schemas.Azure {
+						var extraFields map[string]interface{}
+						if err := json.Unmarshal(ctx.Request.Body(), &extraFields); err == nil {
+							// Extract requests array for inline batching
+							if inputBlob, ok := extraFields["input_blob"].(string); ok {
+								createReq.InputBlob = &inputBlob
+							}
+							if outputFolder, ok := extraFields["output_folder"].(map[string]interface{}); ok {
+								outputURL, ok := outputFolder["url"].(string)
+								if !ok || strings.TrimSpace(outputURL) == "" {
+									return errors.New("output_folder.url must be a non-empty string")
+								}
+								createReq.OutputFolder = &schemas.BatchOutputFolder{
+									URL: outputURL,
+								}
+							}
+						}
+					}
 				}
 				return nil
 			},

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -134,10 +134,10 @@ type ContainerFileRequest struct {
 type CachedContentRequest struct {
 	Type            schemas.RequestType
 	CreateRequest   *schemas.BifrostCachedContentCreateRequest
-	ListRequest    *schemas.BifrostCachedContentListRequest
+	ListRequest     *schemas.BifrostCachedContentListRequest
 	RetrieveRequest *schemas.BifrostCachedContentRetrieveRequest
-	UpdateRequest  *schemas.BifrostCachedContentUpdateRequest
-	DeleteRequest  *schemas.BifrostCachedContentDeleteRequest
+	UpdateRequest   *schemas.BifrostCachedContentUpdateRequest
+	DeleteRequest   *schemas.BifrostCachedContentDeleteRequest
 }
 
 // BatchRequestConverter is a function that converts integration-specific batch requests to Bifrost format.


### PR DESCRIPTION
## Summary

Adds support for Azure Blob Storage as an input source for batch requests. Previously, batch creation required either an `input_file_id` (OpenAI-style) or an inline `requests` array (Anthropic-style). This PR introduces `input_blob` and `output_folder` fields to support Azure's blob-based batch workflow.

## Changes

- Added `InputBlob *string` and `OutputFolder *BatchOutputFolder` fields to `BifrostBatchCreateRequest` schema and the HTTP transport's `BatchCreateRequest`
- Added `BatchOutputFolder` struct with a `URL` field to `core/schemas/batch.go`
- Updated validation logic in `core/bifrost.go`, the Azure provider, and the HTTP handler to allow `input_blob` as a valid alternative to `input_file_id` or `requests`
- Changed `InputFileID` in `OpenAIBatchRequest` from `string` to `*string` with `omitempty` so it is excluded from the serialized request body when not provided
- Added `InputBlob` and `OutputFolder` fields to `OpenAIBatchRequest` for Azure-specific serialization
- Updated the Azure `BatchCreate` implementation to conditionally set `InputFileID`, `InputBlob`, and `OutputFolder` on the outgoing request, and to skip the file ID requirement when `InputBlob` is provided
- Added extraction of `input_blob` and `output_folder` from the raw request body in the OpenAI integration router for Azure provider requests
- Improved error enrichment on Azure batch error responses using `providerUtils.EnrichError`
- Fixed alignment of struct fields in `CachedContentRequest`

> **Note:** Debug `fmt.Println` statements were included in the Azure provider changes and should be removed before merging.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a batch create request targeting the Azure provider using `input_blob` instead of `input_file_id`:

```sh
curl -X POST http://localhost:8080/v1/batches \
  -H "Content-Type: application/json" \
  -d '{
    "model": "azure/gpt-4o",
    "input_blob": "https://<storage-account>.blob.core.windows.net/<container>/<file>",
    "output_folder": { "url": "https://<storage-account>.blob.core.windows.net/<container>/output" },
    "endpoint": "/v1/chat/completions",
    "completion_window": "24h"
  }'
```

Verify that:
- The request is accepted without an `input_file_id` or `requests` array
- The Azure API receives `input_blob` and `output_folder` in the request body and `input_file_id` is absent
- Requests that omit all three fields (`input_file_id`, `input_blob`, `requests`) are rejected with the updated error message

```sh
go test ./...
```

## Breaking changes

- [x] Yes
- [ ] No

`OpenAIBatchRequest.InputFileID` changed from `string` to `*string`. Any code directly constructing this struct outside of Bifrost will need to use a pointer value. Within Bifrost, all call sites have been updated.

## Related issues

## Security considerations

`input_blob` and `output_folder` URLs are passed through to the Azure API as provided. Ensure that access controls on the blob storage URLs are managed by the caller and that no credentials are embedded in URLs logged by the debug statements (which should be removed before release).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable