### PR TITLE
feat: add `MCPToolGroups` RBAC resource and separate access control from `MCPGateway`

### DIFF
--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -15,6 +15,7 @@ export enum RbacResource {
 	ModelProvider = "ModelProvider",
 	Plugins = "Plugins",
 	MCPGateway = "MCPGateway",
+	MCPToolGroups = "MCPToolGroups",
 	MCPLogs = "MCPLogs",
 	AdaptiveRouter = "AdaptiveRouter",
 	AuditLogs = "AuditLogs",

--- a/ui/app/workspace/mcp-tool-groups/layout.tsx
+++ b/ui/app/workspace/mcp-tool-groups/layout.tsx
@@ -4,8 +4,8 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import MCPToolGroupsPage from "./page";
 
 function RouteComponent() {
-	const hasMCPGatewayAccess = useRbac(RbacResource.MCPGateway, RbacOperation.View);
-	if (!hasMCPGatewayAccess) {
+	const hasMCPToolGroupsAccess = useRbac(RbacResource.MCPToolGroups, RbacOperation.View);
+	if (!hasMCPToolGroupsAccess) {
 		return <NoPermissionView entity="MCP tool groups" />;
 	}
 	return <MCPToolGroupsPage />;

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -561,6 +561,7 @@ export default function AppSidebar() {
   const hasObservabilityAccess = useRbac(RbacResource.Observability, RbacOperation.View);
   const hasModelProvidersAccess = useRbac(RbacResource.ModelProvider, RbacOperation.View);
   const hasMCPGatewayAccess = useRbac(RbacResource.MCPGateway, RbacOperation.View);
+  const hasMCPToolGroupsAccess = useRbac(RbacResource.MCPToolGroups, RbacOperation.View);
   const hasMCPLogsAccess = useRbac(RbacResource.MCPLogs, RbacOperation.View);
   const hasPluginsAccess = useRbac(RbacResource.Plugins, RbacOperation.View);
   const hasUsersAccess = useRbac(RbacResource.Users, RbacOperation.View);
@@ -698,7 +699,7 @@ export default function AppSidebar() {
         icon: MCPIcon,
         description: "MCP configuration",
         url: "/workspace/mcp-gateway",
-        hasAccess: hasMCPGatewayAccess,
+        hasAccess: hasMCPGatewayAccess || hasMCPToolGroupsAccess,
         subItems: [
           {
             title: "MCP Catalog",
@@ -712,7 +713,7 @@ export default function AppSidebar() {
             url: "/workspace/mcp-tool-groups",
             icon: ToolCase,
             description: "Tool Groups",
-            hasAccess: hasMCPGatewayAccess,
+            hasAccess: hasMCPToolGroupsAccess,
           },
           {
             title: "MCP Settings",
@@ -926,6 +927,7 @@ export default function AppSidebar() {
         hasObservabilityAccess,
         hasModelProvidersAccess,
         hasMCPGatewayAccess,
+        hasMCPToolGroupsAccess,
         hasMCPLogsAccess,
         hasPluginsAccess,
       hasUsersAccess,


### PR DESCRIPTION
## Summary

Introduces a dedicated `MCPToolGroups` RBAC resource to allow fine-grained access control over the MCP Tool Groups section, independent of the broader `MCPGateway` resource.

## Changes

- Added `MCPToolGroups` as a new `RbacResource` enum value in the fallback RBAC context.
- Updated the MCP Tool Groups route layout to check `MCPToolGroups` view permission instead of `MCPGateway`.
- Updated the sidebar so the "Tool Groups" sub-item uses `hasMCPToolGroupsAccess`, while the parent MCP nav item remains visible if the user has access to either `MCPGateway` or `MCPToolGroups`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure a role that has access to `MCPGateway` but not `MCPToolGroups`. Verify the "Tool Groups" sidebar item is hidden and navigating to `/workspace/mcp-tool-groups` shows the no-permission view.
2. Configure a role with access to `MCPToolGroups` but not `MCPGateway`. Verify the "Tool Groups" sidebar item is visible and accessible, while other MCP Gateway sections remain restricted.
3. Configure a role with access to both. Verify all MCP sub-items are visible and accessible.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Access to the MCP Tool Groups page is now governed by its own RBAC resource (`MCPToolGroups`), allowing enterprise deployments to restrict tool group management independently from MCP Gateway configuration.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable