### PR TITLE
feat: allow team reassignment when editing a virtual key, with confirmation dialog and locked assignment only on create

### DIFF
--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -59,8 +59,8 @@ interface VirtualKeySheetProps {
 	virtualKey?: VirtualKey | null;
 	teams: Team[];
 	customers: Customer[];
-	// When set and not editing, the new VK is created owned by this team and the sheet locks
-	// all fields except name/description (same treatment as access-profile-managed keys).
+	// When set, the new VK is created under this team. The entity assignment is pre-set
+	// and cannot be changed (but all other fields remain editable).
 	defaultTeamId?: string;
 	onSave: () => void;
 	onCancel: () => void;
@@ -167,12 +167,11 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 	// of assignees — directly-attached users don't imply an access-profile relation.
 	const { assignedUsers, isManagedByProfile: isManagedByProfileHook } = useVirtualKeyUsage(virtualKey);
 	const isManagedByProfile = isEditing && isManagedByProfileHook;
-	// Team attachment: when a VK already belongs to a team (edit) or will be created for one
-	// (create from team detail sheet via defaultTeamId), the team assignment is fixed — users
-	// can still edit providers/budgets/rate limits/MCP, but not reparent the VK.
+	// Team attachment: when creating from a team context (defaultTeamId provided), the entity
+	// assignment is pre-set and locked. When editing an existing VK the assignment can be changed.
 	const attachedTeamId = isEditing ? virtualKey?.team_id || "" : defaultTeamId || "";
 	const attachedTeam = attachedTeamId ? teams.find((t) => t.id === attachedTeamId) : undefined;
-	const isTeamLocked = !!attachedTeamId;
+	const isTeamLocked = !isEditing && !!defaultTeamId;
 
 	const handleClose = () => {
 		setIsOpen(false);
@@ -360,6 +359,8 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 	};
 
 	const [showCalendarAlignWarning, setShowCalendarAlignWarning] = useState(false);
+	const [showReassignTeamWarning, setShowReassignTeamWarning] = useState(false);
+	const [pendingTeamId, setPendingTeamId] = useState<string | null>(null);
 
 	const handleCalendarAlignedChange = (checked: boolean) => {
 		if (checked && isEditing) {
@@ -554,19 +555,9 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 								<Alert variant="info">
 									<Users className="h-4 w-4" />
 									<AlertDescription>
-										<p>
-											This virtual key is attached to team{" "}
-											<a
-												data-testid="vk-team-link"
-												href={`/workspace/governance/teams?team=${encodeURIComponent(attachedTeamId)}`}
-												target="_blank"
-												rel="noopener noreferrer"
-												className="font-medium underline underline-offset-2 hover:no-underline"
-											>
-												{attachedTeam?.name ?? virtualKey?.team?.name ?? attachedTeamId}
-											</a>
-											. The team assignment can't be changed here — all other fields remain editable.
-										</p>
+										Creating this virtual key under team{" "}
+										<span className="font-medium">{attachedTeam?.name ?? attachedTeamId}</span>
+										. Team assignment is pre-set — all other fields are editable.
 									</AlertDescription>
 								</Alert>
 							)}
@@ -1302,6 +1293,44 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 											</AlertDialogFooter>
 										</AlertDialogContent>
 									</AlertDialog>
+
+									{/* Reassign team confirmation dialog */}
+									<AlertDialog
+										open={showReassignTeamWarning}
+										onOpenChange={(open) => {
+											setShowReassignTeamWarning(open);
+											if (!open) {
+												setPendingTeamId(null);
+											}
+										}}
+									>
+										<AlertDialogContent>
+											<AlertDialogHeader>
+												<AlertDialogTitle>Reassign to a different team?</AlertDialogTitle>
+												<AlertDialogDescription>
+													This key is currently assigned to another team. Reassigning it will move budget tracking to this
+													team — future requests through this key will count against this team’s budget, not the previous one.
+												</AlertDialogDescription>
+											</AlertDialogHeader>
+											<AlertDialogFooter>
+												<AlertDialogCancel data-testid="virtual-key-reassign-cancel" onClick={() => setPendingTeamId(null)}>
+													Cancel
+												</AlertDialogCancel>
+												<AlertDialogAction
+													data-testid="virtual-key-reassign-confirm"
+													onClick={() => {
+														if (pendingTeamId !== null) {
+															form.setValue("teamId", pendingTeamId, { shouldDirty: true });
+														}
+														setPendingTeamId(null);
+														setShowReassignTeamWarning(false);
+													}}
+												>
+													Reassign
+												</AlertDialogAction>
+											</AlertDialogFooter>
+										</AlertDialogContent>
+									</AlertDialog>
 								</div>
 								{/* Rate Limiting Configuration */}
 								<div className="space-y-4">
@@ -1426,7 +1455,15 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 																		label: team.customer ? `${team.name} — ${team.customer.name}` : team.name,
 																	}))}
 																	value={field.value || null}
-																	onValueChange={(val) => field.onChange(val ?? "")}
+																	onValueChange={(val) => {
+																		const newVal = val ?? "";
+																		if (isEditing && virtualKey?.team_id && newVal && newVal !== virtualKey.team_id) {
+																			setPendingTeamId(newVal);
+																			setShowReassignTeamWarning(true);
+																		} else {
+																			field.onChange(newVal);
+																		}
+																	}}
 																	placeholder="Select a team"
 																	disabled={isTeamLocked}
 																	emptyMessage="No teams found."


### PR DESCRIPTION
## Summary

When editing an existing virtual key, the team assignment was incorrectly locked whenever a team was attached — even though reparenting should be allowed during edits. This PR fixes that behavior and adds a confirmation dialog when reassigning a key to a different team, warning the user that budget tracking will move to the new team.

## Changes

- `isTeamLocked` is now only `true` when creating a new key with a `defaultTeamId` (i.e., from a team context), not when editing an existing key that already belongs to a team.
- When editing, changing the team assignment to a different team now triggers a confirmation dialog explaining that budget tracking will shift to the newly selected team.
- The info alert shown when `defaultTeamId` is set has been simplified to reflect the create-only context — it no longer renders a link to the team governance page or implies the restriction applies during edits.
- The `defaultTeamId` prop comment has been updated to accurately describe the new behavior.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open an existing virtual key that belongs to a team.
2. Verify the team selector is now editable (not locked).
3. Change the team to a different team — confirm the reassignment warning dialog appears.
4. Click **Reassign** and verify the team field updates correctly.
5. Click **Cancel** and verify the team field reverts to the original value.
6. Navigate to a team detail sheet and create a new virtual key from there.
7. Verify the team field is pre-set and locked, and the info alert reflects the create-only context.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

_Before: Team field was locked when editing any key that had a team assigned._
_After: Team field is editable during edit; reassigning shows a confirmation dialog._

## Breaking changes

- [x] No

## Related issues

## Security considerations

None. This change only affects UI-level form behavior for team assignment on virtual keys.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable