### PR TITLE
fix: fallback to native converters for claude code in case of output format in messages api of vertex

### DIFF
--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -100,7 +100,8 @@ func createAnthropicMessagesRouteConfig(pathPrefix string, logger schemas.Logger
 				return nil, errors.New("invalid request type")
 			},
 			ResponsesResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponsesResponse) (interface{}, error) {
-				if isClaudeModel(resp.ExtraFields.OriginalModelRequested, resp.ExtraFields.ResolvedModelUsed, string(resp.ExtraFields.Provider)) {
+				soToolName, _ := ctx.Value(schemas.BifrostContextKeyStructuredOutputToolName).(string)
+				if soToolName == "" && isClaudeModel(resp.ExtraFields.OriginalModelRequested, resp.ExtraFields.ResolvedModelUsed, string(resp.ExtraFields.Provider)) {
 					if resp.ExtraFields.RawResponse != nil {
 						return resp.ExtraFields.RawResponse, nil
 					}
@@ -128,7 +129,8 @@ func createAnthropicMessagesRouteConfig(pathPrefix string, logger schemas.Logger
 			},
 			StreamConfig: &StreamConfig{
 				ResponsesStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponsesStreamResponse) (string, interface{}, error) {
-					if shouldUsePassthrough(ctx, resp.ExtraFields.Provider, resp.ExtraFields.OriginalModelRequested, resp.ExtraFields.ResolvedModelUsed) {
+					soToolName, _ := ctx.Value(schemas.BifrostContextKeyStructuredOutputToolName).(string)
+					if soToolName == "" && shouldUsePassthrough(ctx, resp.ExtraFields.Provider, resp.ExtraFields.OriginalModelRequested, resp.ExtraFields.ResolvedModelUsed) {
 						// Skip passthrough for ContentPartAdded: it's a synthetic bifrost event whose
 						// RawResponse carries the parent content_block_start already emitted by OutputItemAdded.
 						// Passing through here would produce a duplicate content_block_start that causes
@@ -215,6 +217,18 @@ func hasFastModeBetaHeader(headers map[string][]string) bool {
 		}
 	}
 	return false
+}
+
+// hasOutputConfigFormat reports whether the parsed request contains output_config.format
+func hasOutputConfigFormat(req any) bool {
+	r, ok := req.(*anthropic.AnthropicMessageRequest)
+	if !ok {
+		return false
+	}
+	if r.OutputConfig != nil && len(r.OutputConfig.Format) > 0 {
+		return true
+	}
+	return len(r.OutputFormat) > 0
 }
 
 // extractPassthroughHeaders filters headers to only include those in the safe whitelist.
@@ -346,7 +360,7 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 				bifrostCtx.SetValue(schemas.BifrostContextKeyExtraHeaders, passthroughHeaders)
 			}
 		}
-		if provider == schemas.Vertex && (hasPromptCachingScopeBetaHeader(headers) || hasFastModeBetaHeader(headers)) {
+		if provider == schemas.Vertex && (hasPromptCachingScopeBetaHeader(headers) || hasFastModeBetaHeader(headers) || hasOutputConfigFormat(req)) {
 			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
 			return nil
 		}


### PR DESCRIPTION
## Summary

Fixes incorrect passthrough behavior when structured output (via tool use) is active on the Anthropic integration. When a structured output tool name is present in the Bifrost context, the response and stream converters were incorrectly falling through to the raw passthrough path, bypassing the necessary response transformation. Additionally, requests using `output_config.format` on Vertex now correctly disable raw request body passthrough to ensure proper request handling.

## Changes

- In both the non-streaming and streaming Anthropic response converters, passthrough/raw-response logic is now skipped when a structured output tool name (`BifrostContextKeyStructuredOutputToolName`) is set in the context.
- Added `hasOutputConfigFormat` helper to detect whether a parsed `AnthropicMessageRequest` contains `output_config.format` or `output_format` fields.
- Extended the Vertex passthrough override condition to also disable raw request body usage when `output_config.format` is present, alongside the existing prompt caching and fast mode beta header checks.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a structured output request (one that sets `BifrostContextKeyStructuredOutputToolName`) through the Anthropic HTTP transport and verify the response is properly transformed rather than passed through as a raw response.

Send a request with `output_config.format` set to a Vertex-backed Claude model and verify it does not use the raw request body path.

```sh
go test ./transports/bifrost-http/...
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Changes are scoped to request/response routing logic within the Anthropic integration.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable