### PR TITLE
fix: remove 100-item upper limit on paginated teams query

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2830,8 +2830,6 @@ func (s *RDBConfigStore) GetTeamsPaginated(ctx context.Context, params TeamsQuer
 	offset := params.Offset
 	if limit <= 0 {
 		limit = 25
-	} else if limit > 100 {
-		limit = 100
 	}
 	if offset < 0 {
 		offset = 0

--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -15,6 +15,7 @@ export enum RbacResource {
 	ModelProvider = "ModelProvider",
 	Plugins = "Plugins",
 	MCPGateway = "MCPGateway",
+	MCPLogs = "MCPLogs",
 	AdaptiveRouter = "AdaptiveRouter",
 	AuditLogs = "AuditLogs",
 	Customers = "Customers",

--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -26,6 +26,9 @@ export enum RbacResource {
 	PromptRepository = "PromptRepository",
 	PromptDeploymentStrategy = "PromptDeploymentStrategy",
 	AccessProfiles = "AccessProfiles",
+	APIKeys = "APIKeys",
+	Inference = "Inference",
+	Metrics = "Metrics",
 }
 
 // RBAC Operation Names (must match backend definitions)

--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -15,6 +15,7 @@ export enum RbacResource {
 	ModelProvider = "ModelProvider",
 	Plugins = "Plugins",
 	MCPGateway = "MCPGateway",
+	MCPToolGroups = "MCPToolGroups",
 	MCPLogs = "MCPLogs",
 	AdaptiveRouter = "AdaptiveRouter",
 	AuditLogs = "AuditLogs",

--- a/ui/app/workspace/config/layout.tsx
+++ b/ui/app/workspace/config/layout.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet, useChildMatches } from "@tanstack/react-router";
+import { createFileRoute, Outlet, useChildMatches, useLocation } from "@tanstack/react-router";
 import FullPageLoader from "@/components/fullPageLoader";
 import { NoPermissionView } from "@/components/noPermissionView";
 import { useGetCoreConfigQuery } from "@/lib/store";
@@ -6,11 +6,17 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import ConfigPage from "./page";
 
 function RouteComponent() {
-	const hasConfigAccess = useRbac(RbacResource.Settings, RbacOperation.View);
-	const { isLoading } = useGetCoreConfigQuery({ fromDB: true }, { skip: !hasConfigAccess });
+	const pathname = useLocation({ select: (l) => l.pathname });
+	const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.View);
+	const hasAPIKeysAccess = useRbac(RbacResource.APIKeys, RbacOperation.View);
 	const childMatches = useChildMatches();
 
-	if (!hasConfigAccess) {
+	const isAPIKeysRoute = pathname.startsWith("/workspace/config/api-keys");
+	const requiredAccess = isAPIKeysRoute ? hasAPIKeysAccess : hasSettingsAccess;
+
+	const { isLoading } = useGetCoreConfigQuery({ fromDB: true }, { skip: !requiredAccess });
+
+	if (!requiredAccess) {
 		return <NoPermissionView entity="configuration" />;
 	}
 

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -472,26 +472,29 @@ export const createColumns = (
     },
   }));
 
-  const actionsColumn: ColumnDef<LogEntry> = {
-    id: "actions",
-    size: 72,
-    cell: ({ row }) => {
-      const log = row.original;
-      return (
-        <Button
-          variant="outline"
-          size="icon"
-          data-testid="log-delete-btn"
-          aria-label="Delete log"
-          className="text-secondary-foreground/30 hover:bg-destructive/10 hover:text-destructive border-destructive/10"
-          onClick={() => onDelete(log)}
-          disabled={!hasDeleteAccess}
-        >
-          <Trash2 strokeWidth={1.5} />
-        </Button>
-      );
-    },
-  };
+  const actionsColumn: ColumnDef<LogEntry>[] = hasDeleteAccess
+    ? [
+      {
+        id: "actions",
+        size: 72,
+        cell: ({ row }) => {
+          const log = row.original;
+          return (
+            <Button
+              variant="outline"
+              size="icon"
+              data-testid="log-delete-btn"
+              aria-label="Delete log"
+              className="text-destructive/60 border-destructive/60 hover:text-destructive hover:bg-destructive/10"
+              onClick={() => onDelete(log)}
+            >
+              <Trash2 strokeWidth={1.5} />
+            </Button>
+          );
+        },
+      },
+    ]
+    : [];
 
-  return [...baseColumns, ...metadataColumns, actionsColumn];
+  return [...baseColumns, ...metadataColumns, ...actionsColumn];
 };

--- a/ui/app/workspace/mcp-logs/layout.tsx
+++ b/ui/app/workspace/mcp-logs/layout.tsx
@@ -1,6 +1,16 @@
+import { NoPermissionView } from "@/components/noPermissionView";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { createFileRoute } from "@tanstack/react-router";
 import MCPLogsPage from "./page";
 
+function RouteComponent() {
+	const hasViewMCPLogsAccess = useRbac(RbacResource.MCPLogs, RbacOperation.View);
+	if (!hasViewMCPLogsAccess) {
+		return <NoPermissionView entity="mcp logs" />;
+	}
+	return <MCPLogsPage />;
+}
+
 export const Route = createFileRoute("/workspace/mcp-logs")({
-	component: MCPLogsPage,
+	component: RouteComponent,
 });

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -24,7 +24,7 @@ export default function MCPLogsPage() {
 	const [error, setError] = useState<string | null>(null);
 	const [showEmptyState, setShowEmptyState] = useState(false);
 	const hasCheckedEmptyState = useRef(false);
-	const hasDeleteAccess = useRbac(RbacResource.Logs, RbacOperation.Delete);
+	const hasDeleteAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Delete);
 
 	const [deleteLogs] = useDeleteMCPLogsMutation();
 	// Lazy query kept only for handleLogNavigate (fetches adjacent pages on demand)

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -24,7 +24,7 @@ export default function MCPLogsPage() {
 	const [error, setError] = useState<string | null>(null);
 	const [showEmptyState, setShowEmptyState] = useState(false);
 	const hasCheckedEmptyState = useRef(false);
-	const hasDeleteAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Delete);
+	const hasDeleteAccess = useRbac(RbacResource.MCPLogs, RbacOperation.Delete);
 
 	const [deleteLogs] = useDeleteMCPLogsMutation();
 	// Lazy query kept only for handleLogNavigate (fetches adjacent pages on demand)

--- a/ui/app/workspace/mcp-logs/views/columns.tsx
+++ b/ui/app/workspace/mcp-logs/views/columns.tsx
@@ -2,7 +2,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Status, StatusBarColors, Statuses } from "@/lib/constants/logs";
 import type { MCPToolLogEntry } from "@/lib/types/logs";
-import { ColumnDef } from "@tanstack/react-table";
+import { ColumnDef, Row } from "@tanstack/react-table";
 import { format, isValid } from "date-fns";
 import { ArrowUpDown, Trash2 } from "lucide-react";
 
@@ -95,24 +95,27 @@ export const createMCPColumns = (
 				return <div className="font-mono text-sm">{isValidNumber ? `${cost.toFixed(4)}` : "N/A"}</div>;
 			},
 		},
-		{
-			id: "actions",
-			size: 72,
-			cell: ({ row }) => {
-				const log = row.original;
-				return (
-					<Button
-						variant="outline"
-						size="icon"
-						data-testid="log-delete-btn"
-						aria-label="Delete log"
-						className="text-secondary-foreground/30 hover:bg-destructive/10 hover:text-destructive border-destructive/10"
-						onClick={() => void handleDelete(log)}
-						disabled={!hasDeleteAccess}
-					>
-						<Trash2 />
-					</Button>
-				);
-			},
-		},
+		...(hasDeleteAccess
+			? [
+				{
+					id: "actions",
+					size: 72,
+					cell: ({ row }: { row: Row<MCPToolLogEntry> }) => {
+						const log = row.original;
+						return (
+							<Button
+								variant="outline"
+								size="icon"
+								data-testid="log-delete-btn"
+								aria-label="Delete log"
+								className="text-destructive/60 border-destructive/60 hover:text-destructive hover:bg-destructive/10"
+								onClick={() => void handleDelete(log)}
+							>
+								<Trash2 />
+							</Button>
+						);
+					},
+				},
+			]
+			: []),
 	];

--- a/ui/app/workspace/mcp-tool-groups/layout.tsx
+++ b/ui/app/workspace/mcp-tool-groups/layout.tsx
@@ -4,8 +4,8 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import MCPToolGroupsPage from "./page";
 
 function RouteComponent() {
-	const hasMCPGatewayAccess = useRbac(RbacResource.MCPGateway, RbacOperation.View);
-	if (!hasMCPGatewayAccess) {
+	const hasMCPToolGroupsAccess = useRbac(RbacResource.MCPToolGroups, RbacOperation.View);
+	if (!hasMCPToolGroupsAccess) {
 		return <NoPermissionView entity="MCP tool groups" />;
 	}
 	return <MCPToolGroupsPage />;

--- a/ui/app/workspace/providers/page.tsx
+++ b/ui/app/workspace/providers/page.tsx
@@ -17,8 +17,8 @@ import {
 import { KnownProvider, ModelProviderName, ProviderStatus } from "@/lib/types/config";
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { AlertCircle } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
+import { AlertCircle } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -240,7 +240,7 @@ export default function Providers() {
 									})}
 								</div>
 							)}
-							<div className="pb-4">
+							{hasProviderCreateAccess ? <div className="pb-4">
 								<AddProviderDropdown
 									disabled={!hasProviderCreateAccess}
 									existingInSidebar={existingInSidebarNames}
@@ -248,7 +248,7 @@ export default function Providers() {
 									onSelectKnownProvider={handleSelectKnownProvider}
 									onAddCustomProvider={() => setShowCustomProviderSheet(true)}
 								/>
-							</div>
+							</div> : null}
 						</div>
 					</div>
 				</TooltipProvider>

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -106,7 +106,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 					<div className="flex items-center gap-2">Configured {entityLabelPlural}</div>
 					<div className="flex items-center gap-2">
 						{headerActions}
-						{!isKeyless && (
+						{!isKeyless && hasUpdateProviderAccess ? (
 							<Button
 								disabled={!hasUpdateProviderAccess}
 								data-testid="add-key-btn"
@@ -117,7 +117,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 								<PlusIcon className="h-4 w-4" />
 								Add new {entityLabel}
 							</Button>
-						)}
+						) : null}
 					</div>
 				</CardTitle>
 			</CardHeader>
@@ -152,7 +152,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 										key={key.id}
 										data-testid={`key-row-${key.name}`}
 										className="text-sm transition-colors hover:bg-white"
-										onClick={() => {}}
+										onClick={() => { }}
 									>
 										<TableCell>
 											<div className="flex items-center space-x-2">
@@ -258,34 +258,36 @@ export default function ModelProviderKeysTableView({ provider, className, header
 										</TableCell>
 										<TableCell className="text-right">
 											<div className="flex items-center justify-end space-x-2">
-												<DropdownMenu>
-													<DropdownMenuTrigger asChild>
-														<Button onClick={(e) => e.stopPropagation()} variant="ghost">
-															<EllipsisIcon className="h-5 w-5" />
-														</Button>
-													</DropdownMenuTrigger>
-													<DropdownMenuContent align="end">
-														<DropdownMenuItem
-															onClick={() => {
-																setShowAddNewKeyDialog({ show: true, keyId: key.id });
-															}}
-															disabled={!hasUpdateProviderAccess}
-														>
-															<PencilIcon className="mr-1 h-4 w-4" />
-															Edit
-														</DropdownMenuItem>
-														<DropdownMenuItem
-															variant="destructive"
-															onClick={() => {
-																setShowDeleteKeyDialog({ show: true, keyId: key.id });
-															}}
-															disabled={!hasDeleteProviderAccess}
-														>
-															<TrashIcon className="mr-1 h-4 w-4" />
-															Delete
-														</DropdownMenuItem>
-													</DropdownMenuContent>
-												</DropdownMenu>
+												{hasUpdateProviderAccess || hasDeleteProviderAccess ?
+													<DropdownMenu>
+														<DropdownMenuTrigger asChild>
+															<Button onClick={(e) => e.stopPropagation()} variant="ghost">
+																<EllipsisIcon className="h-5 w-5" />
+															</Button>
+														</DropdownMenuTrigger>
+														<DropdownMenuContent align="end">
+															<DropdownMenuItem
+																onClick={() => {
+																	setShowAddNewKeyDialog({ show: true, keyId: key.id });
+																}}
+																disabled={!hasUpdateProviderAccess}
+															>
+																<PencilIcon className="mr-1 h-4 w-4" />
+																Edit
+															</DropdownMenuItem>
+															<DropdownMenuItem
+																variant="destructive"
+																onClick={() => {
+																	setShowDeleteKeyDialog({ show: true, keyId: key.id });
+																}}
+																disabled={!hasDeleteProviderAccess}
+															>
+																<TrashIcon className="mr-1 h-4 w-4" />
+																Delete
+															</DropdownMenuItem>
+														</DropdownMenuContent>
+													</DropdownMenu> : null
+												}
 											</div>
 										</TableCell>
 									</TableRow>

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -19,10 +19,8 @@ import {
   LogOut,
   Logs,
   Network,
-  PanelLeft,
   PanelLeftClose,
   PanelLeftOpen,
-  PanelRight,
   Plug,
   Puzzle,
   ScrollText,
@@ -67,7 +65,6 @@ import {
   useGetVersionQuery,
   useLogoutMutation,
 } from "@/lib/store";
-import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import type { UserInfo } from "@enterprise/lib/store/utils/tokenManager";
 import { getUserInfo } from "@enterprise/lib/store/utils/tokenManager";
@@ -583,6 +580,7 @@ export default function AppSidebar() {
   const hasClusterConfigAccess = useRbac(RbacResource.Cluster, RbacOperation.View);
   const isAdaptiveRoutingAllowed = useRbac(RbacResource.AdaptiveRouter, RbacOperation.View);
   const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.View);
+  const hasAPIKeyAccess = useRbac(RbacResource.APIKeys, RbacOperation.View);
   const hasPromptRepositoryAccess = useRbac(RbacResource.PromptRepository, RbacOperation.View);
   const hasAccessProfilesAccess = useRbac(RbacResource.AccessProfiles, RbacOperation.View);
   const hasAnyGovernanceAccess =
@@ -625,7 +623,7 @@ export default function AppSidebar() {
             url: "/workspace/mcp-logs",
             icon: MCPIcon,
             description: "MCP tool execution logs",
-            hasAccess: hasLogsAccess,
+            hasAccess: hasMCPGatewayAccess,
           },
           {
             title: "Connectors",
@@ -910,7 +908,7 @@ export default function AppSidebar() {
             url: "/workspace/config/api-keys",
             icon: KeyRound,
             description: "API keys management",
-            hasAccess: hasSettingsAccess,
+            hasAccess: hasAPIKeyAccess,
           },
           {
             title: "Performance Tuning",
@@ -950,11 +948,26 @@ export default function AppSidebar() {
     ],
   );
 
+  const accessibleItems: SidebarItem[] = useMemo(() => {
+    return items
+      .map((item) => {
+        const hadSubItems = !!item.subItems?.length;
+        if (hadSubItems) {
+          const visibleSubItems = item.subItems!.filter((sub) => sub.hasAccess !== false);
+          if (visibleSubItems.length === 0) return null;
+          return { ...item, subItems: visibleSubItems, hasAccess: true };
+        }
+        if (item.hasAccess === false) return null;
+        return item;
+      })
+      .filter(Boolean) as SidebarItem[];
+  }, [items]);
+
   const filteredItems: SidebarItem[] = useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
-    if (!query) return items;
+    if (!query) return accessibleItems;
 
-    return items
+    return accessibleItems
       .map((item) => {
         const parentMatches = item.title.toLowerCase().includes(query);
         if (parentMatches) return item;
@@ -970,7 +983,7 @@ export default function AppSidebar() {
         return null;
       })
       .filter(Boolean) as SidebarItem[];
-  }, [items, searchQuery]);
+  }, [accessibleItems, searchQuery]);
 
   const { data: version } = useGetVersionQuery();
   const { resolvedTheme } = useTheme();

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -561,6 +561,7 @@ export default function AppSidebar() {
   const hasObservabilityAccess = useRbac(RbacResource.Observability, RbacOperation.View);
   const hasModelProvidersAccess = useRbac(RbacResource.ModelProvider, RbacOperation.View);
   const hasMCPGatewayAccess = useRbac(RbacResource.MCPGateway, RbacOperation.View);
+  const hasMCPLogsAccess = useRbac(RbacResource.MCPLogs, RbacOperation.View);
   const hasPluginsAccess = useRbac(RbacResource.Plugins, RbacOperation.View);
   const hasUsersAccess = useRbac(RbacResource.Users, RbacOperation.View);
   const hasUserProvisioningAccess = useRbac(RbacResource.UserProvisioning, RbacOperation.View);
@@ -623,7 +624,7 @@ export default function AppSidebar() {
             url: "/workspace/mcp-logs",
             icon: MCPIcon,
             description: "MCP tool execution logs",
-            hasAccess: hasMCPGatewayAccess,
+            hasAccess: hasMCPLogsAccess,
           },
           {
             title: "Connectors",
@@ -921,11 +922,12 @@ export default function AppSidebar() {
       },
     ],
     [
-      hasLogsAccess,
-      hasObservabilityAccess,
-      hasModelProvidersAccess,
-      hasMCPGatewayAccess,
-      hasPluginsAccess,
+        hasLogsAccess,
+        hasObservabilityAccess,
+        hasModelProvidersAccess,
+        hasMCPGatewayAccess,
+        hasMCPLogsAccess,
+        hasPluginsAccess,
       hasUsersAccess,
       hasUserProvisioningAccess,
       hasAuditLogsAccess,

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -561,6 +561,7 @@ export default function AppSidebar() {
   const hasObservabilityAccess = useRbac(RbacResource.Observability, RbacOperation.View);
   const hasModelProvidersAccess = useRbac(RbacResource.ModelProvider, RbacOperation.View);
   const hasMCPGatewayAccess = useRbac(RbacResource.MCPGateway, RbacOperation.View);
+  const hasMCPToolGroupsAccess = useRbac(RbacResource.MCPToolGroups, RbacOperation.View);
   const hasMCPLogsAccess = useRbac(RbacResource.MCPLogs, RbacOperation.View);
   const hasPluginsAccess = useRbac(RbacResource.Plugins, RbacOperation.View);
   const hasUsersAccess = useRbac(RbacResource.Users, RbacOperation.View);
@@ -698,7 +699,7 @@ export default function AppSidebar() {
         icon: MCPIcon,
         description: "MCP configuration",
         url: "/workspace/mcp-gateway",
-        hasAccess: hasMCPGatewayAccess,
+        hasAccess: hasMCPGatewayAccess || hasMCPToolGroupsAccess,
         subItems: [
           {
             title: "MCP Catalog",
@@ -712,7 +713,7 @@ export default function AppSidebar() {
             url: "/workspace/mcp-tool-groups",
             icon: ToolCase,
             description: "Tool Groups",
-            hasAccess: hasMCPGatewayAccess,
+            hasAccess: hasMCPToolGroupsAccess,
           },
           {
             title: "MCP Settings",
@@ -926,6 +927,7 @@ export default function AppSidebar() {
         hasObservabilityAccess,
         hasModelProvidersAccess,
         hasMCPGatewayAccess,
+        hasMCPToolGroupsAccess,
         hasMCPLogsAccess,
         hasPluginsAccess,
       hasUsersAccess,


### PR DESCRIPTION
## Summary

Removes the upper bound limit cap of 100 on paginated team queries, allowing callers to request more than 100 teams per page.

## Changes

- Removed the `limit > 100` guard in `GetTeamsPaginated` that was silently capping the page size to 100. This allows consumers to specify larger page sizes when needed.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Verify that a call to `GetTeamsPaginated` with a `limit` greater than 100 returns the expected number of results rather than being silently truncated to 100.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Removing the page size cap could allow large queries that put additional load on the database. Callers should ensure reasonable limits are enforced at the API layer if unbounded queries are a concern.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable