### PR TITLE
feat: add UBI9 amd64/arm64 Docker build and multi-arch manifest jobs to release pipeline

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1697,6 +1697,219 @@ jobs:
         run: |
           ./.github/workflows/scripts/create-docker-manifest.sh "${{ needs.detect-changes.outputs.transport-version }}"
 
+  # Docker build UBI9 amd64
+  docker-build-ubi9-amd64:
+    needs:
+      [
+        check-skip,
+        detect-changes,
+        test-core,
+        approve-flaky-test-core,
+        test-framework,
+        test-plugins,
+        test-bifrost-http,
+        test-migrations,
+        test-docker-image-amd64,
+        test-docker-image-arm64,
+        core-release,
+        framework-release,
+        plugins-release,
+        bifrost-http-release,
+      ]
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      REGISTRY: docker.io
+      ACCOUNT: maximhq
+      IMAGE_NAME: bifrost
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            auth.docker.io:443
+            dl-cdn.alpinelinux.org:443
+            fonts.googleapis.com:443
+            fonts.gstatic.com:443
+            github.com:443
+            production.cloudflare.docker.com:443
+            proxy.golang.org:443
+            registry-1.docker.io:443
+            registry.access.redhat.com:443
+            registry.npmjs.org:443
+            storage.googleapis.com:443
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Verify bifrost-http release
+        id: verify
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          ./.github/workflows/scripts/verify-bifrost-http-release.sh "${{ needs.detect-changes.outputs.transport-version }}" "${{ needs.detect-changes.outputs.bifrost-http-needs-release }}"
+          echo "verified=true" >> $GITHUB_OUTPUT
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Determine Docker tags
+        id: tags
+        run: |
+          git pull origin ${{ github.ref_name }}
+          VERSION="${{ needs.detect-changes.outputs.transport-version }}"
+          BASE_TAG="${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:v${VERSION}-ubi9-amd64"
+          echo "tags=${BASE_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Build and push UBI9 AMD64 Docker image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          build-args: |
+            VERSION=${{ needs.detect-changes.outputs.transport-version }}
+          file: ./transports/Dockerfile.redhat
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          platforms: linux/amd64
+          cache-from: type=gha,scope=docker-ubi9-amd64
+          cache-to: type=gha,mode=max,scope=docker-ubi9-amd64
+
+  # Docker build UBI9 arm64
+  docker-build-ubi9-arm64:
+    needs:
+      [
+        check-skip,
+        detect-changes,
+        test-core,
+        approve-flaky-test-core,
+        test-framework,
+        test-plugins,
+        test-bifrost-http,
+        test-migrations,
+        test-docker-image-amd64,
+        test-docker-image-arm64,
+        core-release,
+        framework-release,
+        plugins-release,
+        bifrost-http-release,
+      ]
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.detect-changes.outputs.docker-needs-release == 'true' && (needs.test-core.result == 'success' || needs.test-core.result == 'skipped' || (needs.test-core.result == 'failure' && needs.approve-flaky-test-core.result == 'success')) && (needs.test-framework.result == 'success' || needs.test-framework.result == 'skipped') && (needs.test-plugins.result == 'success' || needs.test-plugins.result == 'skipped') && (needs.test-bifrost-http.result == 'success' || needs.test-bifrost-http.result == 'skipped') && (needs.test-migrations.result == 'success' || needs.test-migrations.result == 'skipped') && (needs.test-docker-image-amd64.result == 'success' || needs.test-docker-image-amd64.result == 'skipped') && (needs.test-docker-image-arm64.result == 'success' || needs.test-docker-image-arm64.result == 'skipped') && (needs.detect-changes.outputs.core-needs-release == 'false' || needs.core-release.result == 'success' || needs.core-release.result == 'skipped') && (needs.detect-changes.outputs.framework-needs-release == 'false' || needs.framework-release.result == 'success' || needs.framework-release.result == 'skipped') && (needs.detect-changes.outputs.plugins-need-release == 'false' || needs.plugins-release.result == 'success' || needs.plugins-release.result == 'skipped') && (needs.detect-changes.outputs.bifrost-http-needs-release == 'false' || needs.bifrost-http-release.result == 'success' || needs.bifrost-http-release.result == 'skipped')"
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+    env:
+      REGISTRY: docker.io
+      ACCOUNT: maximhq
+      IMAGE_NAME: bifrost
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            auth.docker.io:443
+            dl-cdn.alpinelinux.org:443
+            fonts.googleapis.com:443
+            fonts.gstatic.com:443
+            github.com:443
+            production.cloudflare.docker.com:443
+            proxy.golang.org:443
+            registry-1.docker.io:443
+            registry.access.redhat.com:443
+            registry.npmjs.org:443
+            storage.googleapis.com:443
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Verify bifrost-http release
+        id: verify
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          ./.github/workflows/scripts/verify-bifrost-http-release.sh "${{ needs.detect-changes.outputs.transport-version }}" "${{ needs.detect-changes.outputs.bifrost-http-needs-release }}"
+          echo "verified=true" >> $GITHUB_OUTPUT
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Determine Docker tags
+        id: tags
+        run: |
+          git pull origin ${{ github.ref_name }}
+          VERSION="${{ needs.detect-changes.outputs.transport-version }}"
+          BASE_TAG="${{ env.REGISTRY }}/${{ env.ACCOUNT }}/${{ env.IMAGE_NAME }}:v${VERSION}-ubi9-arm64"
+          echo "tags=${BASE_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Build and push UBI9 ARM64 Docker image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: ./transports/Dockerfile.redhat
+          push: true
+          build-args: |
+            VERSION=${{ needs.detect-changes.outputs.transport-version }}
+          tags: ${{ steps.tags.outputs.tags }}
+          platforms: linux/arm64
+          cache-from: type=gha,scope=docker-ubi9-arm64
+          cache-to: type=gha,mode=max,scope=docker-ubi9-arm64
+
+  # Docker UBI9 manifest — merges amd64 + arm64 into a single multi-arch tag
+  docker-manifest-ubi9:
+    needs: [check-skip, detect-changes, docker-build-ubi9-amd64, docker-build-ubi9-arm64]
+    if: "always() && needs.check-skip.outputs.should-skip != 'true' && needs.docker-build-ubi9-amd64.result == 'success' && needs.docker-build-ubi9-arm64.result == 'success'"
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: docker.io
+      ACCOUNT: maximhq
+      IMAGE_NAME: bifrost
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            auth.docker.io:443
+            github.com:443
+            production.cloudflare.docker.com:443
+            registry-1.docker.io:443
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create and push UBI9 multi-arch manifest
+        run: |
+          ./.github/workflows/scripts/create-docker-manifest-ubi9.sh "${{ needs.detect-changes.outputs.transport-version }}"
+
   # Push Mintlify changelog
   push-mintlify-changelog:
     needs:
@@ -1757,6 +1970,7 @@ jobs:
         plugins-release,
         bifrost-http-release,
         docker-manifest,
+        docker-manifest-ubi9,
       ]
     if: "always() && needs.check-skip.outputs.should-skip != 'true'"
     runs-on: ubuntu-latest

--- a/.github/workflows/scripts/create-docker-manifest-ubi9.sh
+++ b/.github/workflows/scripts/create-docker-manifest-ubi9.sh
@@ -1,0 +1,32 @@
+if [ "${1:-}" = "" ]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+
+VERSION="$1"
+REGISTRY="docker.io"
+ACCOUNT="maximhq"
+IMAGE_NAME="bifrost"
+IMAGE="${REGISTRY}/${ACCOUNT}/${IMAGE_NAME}"
+
+AMD64_DIGEST=$(docker manifest inspect ${IMAGE}:v${VERSION}-ubi9-amd64 | jq -r '.manifests[0].digest')
+ARM64_DIGEST=$(docker manifest inspect ${IMAGE}:v${VERSION}-ubi9-arm64 | jq -r '.manifests[0].digest')
+
+echo "UBI9 AMD64 digest: ${AMD64_DIGEST}"
+echo "UBI9 ARM64 digest: ${ARM64_DIGEST}"
+
+docker manifest create \
+    ${IMAGE}:v${VERSION}-ubi9 \
+    ${IMAGE}@${AMD64_DIGEST} \
+    ${IMAGE}@${ARM64_DIGEST}
+
+docker manifest push ${IMAGE}:v${VERSION}-ubi9
+
+if [[ "$VERSION" != *-* ]]; then
+    docker manifest create \
+        ${IMAGE}:latest-ubi9 \
+        ${IMAGE}@${AMD64_DIGEST} \
+        ${IMAGE}@${ARM64_DIGEST}
+
+    docker manifest push ${IMAGE}:latest-ubi9
+fi

--- a/transports/Dockerfile.redhat
+++ b/transports/Dockerfile.redhat
@@ -1,0 +1,123 @@
+# --- UI Build Stage: Build the React + Vite frontend ---
+FROM node:25-alpine3.23@sha256:bdf2cca6fe3dabd014ea60163eca3f0f7015fbd5c7ee1b0e9ccb4ced6eb02ef4 AS ui-builder
+WORKDIR /app
+
+# Apply latest alpine security patches before installing packages
+RUN apk upgrade --no-cache
+
+# Copy UI package files and install dependencies
+COPY ui/package*.json ./
+RUN npm ci
+
+# Copy UI source code
+COPY ui/ ./
+
+# Build UI (skip the copy-build step)
+RUN npm run build-enterprise
+# Skip the copy-build step since we'll copy the files in the Go build stage
+
+# --- Go Build Stage: Compile the Go binary ---
+FROM golang:1.26.2-alpine3.23@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS builder
+WORKDIR /app
+
+# Install dependencies including gcc for CGO and sqlite (with latest security patches)
+RUN apk upgrade --no-cache && \
+  apk add --no-cache gcc musl-dev sqlite-dev binutils binutils-gold
+
+# Set environment for CGO-enabled build (required for go-sqlite3)
+ENV CGO_ENABLED=1 GOOS=linux
+
+COPY transports/go.mod transports/go.sum ./
+RUN go mod download
+
+# Copy source code and dependencies
+COPY transports/ ./
+
+COPY --from=ui-builder /app/out ./bifrost-http/ui
+
+# Build the binary with CGO enabled and static SQLite linking
+ENV GOWORK=off
+ARG VERSION=unknown
+RUN go build \
+  -ldflags="-w -s -X main.Version=v${VERSION} -extldflags '-static'" \
+  -a -trimpath \
+  -tags "sqlite_static" \
+  -o /app/main \
+  ./bifrost-http
+
+# Verify build succeeded
+RUN test -f /app/main || (echo "Build failed" && exit 1)
+  
+# --- Runtime Stage: Red Hat UBI 9 Minimal ---
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:b9b10f42d7eba7ad4a6d5ef26b7d34fdc892b2ffe59b8d0372ec884008569eb6
+
+# Redeclared here so it is in scope for the LABEL instruction below.
+ARG VERSION=unknown
+
+# Required labels for Red Hat Preflight certification.
+LABEL name="maximhq/bifrost" \
+      vendor="H3 Labs Inc" \
+      version="${VERSION}" \
+      release="1" \
+      summary="High-performance LLM gateway and proxy" \
+      maintainer="Maxim Engineering <engineering@getmaxim.ai>" \
+      description="Bifrost is an open-source LLM gateway providing a unified API for routing requests across AI providers with fallbacks, load balancing, and observability."
+
+WORKDIR /app
+
+# The binary is fully static, so no C runtime libraries are needed.
+# Only ca-certificates (HTTPS to LLM providers) and curl (health check) are required.
+RUN microdnf install -y ca-certificates && \
+    microdnf clean all
+
+# Required for Red Hat certification: license file must live under /licenses
+COPY LICENSE /licenses/LICENSE
+
+COPY --from=builder /app/main .
+COPY --from=builder /app/docker-entrypoint.sh .
+
+# Getting arguments
+ARG ARG_APP_PORT=8080
+ARG ARG_APP_HOST=0.0.0.0
+ARG ARG_LOG_LEVEL=info
+ARG ARG_LOG_STYLE=json
+ARG ARG_APP_DIR=/app/data
+
+# Environment variables with defaults (can be overridden at runtime)
+ENV APP_PORT=$ARG_APP_PORT \
+  APP_HOST=$ARG_APP_HOST \
+  LOG_LEVEL=$ARG_LOG_LEVEL \
+  LOG_STYLE=$ARG_LOG_STYLE \
+  APP_DIR=$ARG_APP_DIR
+
+# Go runtime performance tuning (override at runtime for your workload)
+# GOGC: GC target percentage. Higher = less frequent GC, more memory usage.
+#       Default: 100. For high-throughput with available memory, try 200-400.
+# GOMEMLIMIT: Soft memory limit for Go runtime. Set to ~90% of container memory limit.
+#             Example: "1800MiB" for a 2GB container, "3600MiB" for 4GB.
+# Note: GOMAXPROCS is automatically detected from cgroup CPU limits via automaxprocs.
+ENV GOGC="" \
+  GOMEMLIMIT=""
+
+# UID 1001 is the Red Hat recommended non-root numeric UID for certified containers.
+# We avoid creating a named user (adduser) since UBI minimal may not have useradd,
+# and Red Hat Preflight expects a numeric USER instruction.
+RUN mkdir -p $APP_DIR/logs && \
+  chown -R 1001:0 /app /licenses && \
+  chmod -R g=u /app /licenses && \
+  chmod +x /app/docker-entrypoint.sh
+
+USER 1001
+
+# Declare volume for data persistence
+VOLUME ["/app/data"]
+EXPOSE $APP_PORT
+
+# curl-minimal is pre-installed in ubi9-minimal and is a drop-in for curl.
+# start-period is raised to 15s to allow the Go service time to run migrations
+# before the first liveness probe fires.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+  CMD curl-minimal -f -s http://127.0.0.1:${APP_PORT}/health || exit 1
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["/app/main"]


### PR DESCRIPTION
## Summary

Adds Red Hat UBI9-based Docker images for Bifrost, enabling deployment on Red Hat certified container environments. This introduces a new `Dockerfile.redhat` using a UBI9 minimal runtime with a fully statically linked Go binary, and wires up the corresponding CI jobs to build, push, and merge multi-arch (amd64 + arm64) manifests as part of the release pipeline.

## Changes

- Added `transports/Dockerfile.redhat` with a three-stage build:
    - Node 22 Alpine for the React/Vite UI build
    - Go Alpine for a fully static CGO binary (using `sqlite_static` tags and `-extldflags '-static'`)
    - UBI9 minimal as the runtime, with required Red Hat Preflight certification labels, numeric UID 1001, `/licenses/LICENSE`, and `curl-minimal` for health checks
- Added `create-docker-manifest-ubi9.sh` to create and push a versioned `v{VERSION}-ubi9` multi-arch manifest, and a `latest-ubi9` tag for non-prerelease versions
- Added three new CI jobs to the release pipeline:
    - `docker-build-ubi9-amd64` — builds and pushes the UBI9 image for `linux/amd64`
    - `docker-build-ubi9-arm64` — builds and pushes the UBI9 image for `linux/arm64` on an ARM runner
    - `docker-manifest-ubi9` — merges the two platform-specific images into a single multi-arch manifest

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Build the UBI9 image locally and verify it starts correctly:

```sh
# Build the UBI9 image
docker build \
  --build-arg VERSION=0.0.0-test \
  -f transports/Dockerfile.redhat \
  -t bifrost:ubi9-test .

# Run and verify health
docker run --rm -p 8080:8080 bifrost:ubi9-test
curl -f http://localhost:8080/health
```

Verify the image runs as UID 1001 and the binary is statically linked:

```sh
docker run --rm bifrost:ubi9-test id
docker run --rm --entrypoint ldd bifrost:ubi9-test /app/main
# Expected: "not a dynamic executable"
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

- The runtime image uses Red Hat UBI9 minimal, reducing the attack surface compared to general-purpose base images.
- The container runs as numeric UID 1001 (non-root), as required by Red Hat Preflight certification.
- The Go binary is fully statically linked, eliminating shared library dependencies in the runtime layer.
- Harden Runner is applied to all new CI jobs with an egress allowlist, blocking unexpected outbound network access during the build.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicablecg