### PR TITLE
feat: enable MCP support for Bedrock provider

### DIFF
--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -184,7 +184,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 	// InferenceGeo, RedactThinking, AdvancedToolUse (full), PromptCachingScope.
 	schemas.Bedrock: {
 		ComputerUse: true, Bash: true, Memory: true, TextEditor: true, ToolSearch: true,
-		ContainerBasic: true,
+		MCP: true, ContainerBasic: true,
 		// StructuredOutputs: kept true to match pre-existing behavior and the
 		// provider_feature_support_test.go assertion, but NEITHER B-header
 		// NOR B-platform upstream docs document strict tool validation /
@@ -1200,18 +1200,18 @@ const (
 type AnthropicToolName string
 
 const (
-	AnthropicToolNameComputer        AnthropicToolName = "computer"
-	AnthropicToolNameWebSearch       AnthropicToolName = "web_search"
-	AnthropicToolNameWebFetch        AnthropicToolName = "web_fetch"
-	AnthropicToolNameBash            AnthropicToolName = "bash"
-	AnthropicToolNameTextEditor      AnthropicToolName = "str_replace_based_edit_tool"
+	AnthropicToolNameComputer   AnthropicToolName = "computer"
+	AnthropicToolNameWebSearch  AnthropicToolName = "web_search"
+	AnthropicToolNameWebFetch   AnthropicToolName = "web_fetch"
+	AnthropicToolNameBash       AnthropicToolName = "bash"
+	AnthropicToolNameTextEditor AnthropicToolName = "str_replace_based_edit_tool"
 	// AnthropicToolNameTextEditorLegacy is the name required for text_editor_20250124
 	// and text_editor_20250429. Newer text_editor_20250728+ use AnthropicToolNameTextEditor.
 	AnthropicToolNameTextEditorLegacy AnthropicToolName = "str_replace_editor"
-	AnthropicToolNameCodeExecution   AnthropicToolName = "code_execution"
-	AnthropicToolNameMemory          AnthropicToolName = "memory"
-	AnthropicToolNameToolSearchBM25  AnthropicToolName = "tool_search_tool_bm25"
-	AnthropicToolNameToolSearchRegex AnthropicToolName = "tool_search_tool_regex"
+	AnthropicToolNameCodeExecution    AnthropicToolName = "code_execution"
+	AnthropicToolNameMemory           AnthropicToolName = "memory"
+	AnthropicToolNameToolSearchBM25   AnthropicToolName = "tool_search_tool_bm25"
+	AnthropicToolNameToolSearchRegex  AnthropicToolName = "tool_search_tool_regex"
 )
 
 type AnthropicToolComputerUse struct {


### PR DESCRIPTION
## Summary

Enables MCP (Model Context Protocol) support for the Bedrock provider by adding `MCP: true` to its `ProviderFeatureSupport` entry, bringing it in line with other providers that already have this capability.

## Changes

- Added `MCP: true` to the Bedrock provider's feature support flags, enabling MCP functionality for Bedrock-backed Anthropic models.
- Minor alignment fixes to constant declarations in `AnthropicToolName` for consistency.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/...
```

Verify that Bedrock-backed models now report MCP as a supported feature and that MCP-dependent functionality (e.g., MCP tool routing) works correctly when using the Bedrock provider.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No new security implications. MCP support follows the same sandboxing and auth patterns already established for other providers.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable