### PR TITLE
fix: don't clear `oauthFlow` on OAuth error

### DIFF
--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -677,7 +677,6 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 					}}
 					onError={(error) => {
 						toast({ title: "OAuth Error", description: error, variant: "destructive" });
-						setOauthFlow(null);
 					}}
 					authorizeUrl={oauthFlow.authorizeUrl}
 					oauthConfigId={oauthFlow.oauthConfigId}


### PR DESCRIPTION
## Summary

When an OAuth error occurs during MCP client configuration, the OAuth flow state was being cleared (`setOauthFlow(null)`), which dismissed the OAuth UI and prevented users from retrying or seeing the context of the failure. This fix retains the OAuth flow state on error so the user experience is not abruptly interrupted.

## Changes

- Removed the `setOauthFlow(null)` call from the `onError` handler in the OAuth flow component, so the flow remains active when an error is encountered rather than being torn down and is able to show retry

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the MCP Registry and open the client configuration form.
2. Initiate an OAuth flow that results in an error (e.g., use an invalid or misconfigured OAuth config).
3. Verify that the OAuth UI remains visible after the error toast appears, rather than being dismissed.
4. Confirm the error toast still displays with the correct message.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. This change only affects UI state management during OAuth error handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable