### PR TITLE
Fix Gemini fallback propagation in GenAI integration

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -3127,6 +3127,21 @@ func TestGenAIUsageMetadata_IncludesZeroTokenCountInModalityDetails(t *testing.T
 	}
 }
 
+func TestGenAIFallbacks_PreservedInBifrostResponsesRequest(t *testing.T) {
+	geminiReq := &gemini.GeminiGenerationRequest{
+		Model:     "gemini/gemini-3-flash-preview",
+		Fallbacks: []string{"vertex/gemini-3-flash-preview"},
+	}
+
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostReq := geminiReq.ToBifrostResponsesRequest(bifrostCtx)
+
+	require.NotNil(t, bifrostReq)
+	require.Len(t, bifrostReq.Fallbacks, 1)
+	assert.Equal(t, schemas.Vertex, bifrostReq.Fallbacks[0].Provider)
+	assert.Equal(t, "gemini-3-flash-preview", bifrostReq.Fallbacks[0].Model)
+}
+
 // TestFunctionCallingConfigModeAny_RoundTrip verifies that FunctionCallingConfigMode.ANY and
 // AllowedFunctionNames survive the Gemini→Bifrost→Gemini round-trip on the GenAI passthrough path.
 // Regression: ANY was silently downgraded to AUTO (missing case in convertGeminiToolConfigToToolChoice)

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -22,8 +22,9 @@ func (request *GeminiGenerationRequest) ToBifrostResponsesRequest(ctx *schemas.B
 
 	// Create the BifrostResponsesRequest
 	bifrostReq := &schemas.BifrostResponsesRequest{
-		Provider: provider,
-		Model:    model,
+		Provider:  provider,
+		Model:     model,
+		Fallbacks: schemas.ParseFallbacks(request.Fallbacks),
 	}
 
 	params := request.convertGenerationConfigToResponsesParameters()

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -418,7 +418,7 @@ func (g *GenericRouter) extractFallbacksFromRequest(req interface{}) ([]string, 
 		return nil, nil
 	}
 
-	// Try to use reflection to find a "fallbacks" field
+	// Try to use reflection to find a fallbacks field.
 	reqValue := reflect.ValueOf(req)
 	if reqValue.Kind() == reflect.Ptr {
 		reqValue = reqValue.Elem()
@@ -428,10 +428,20 @@ func (g *GenericRouter) extractFallbacksFromRequest(req interface{}) ([]string, 
 		return nil, nil // Not a struct, no fallbacks
 	}
 
-	// Look for the "fallbacks" field
-	fallbacksField := reqValue.FieldByName("fallbacks")
+	fallbacksField := reqValue.FieldByName("Fallbacks")
 	if !fallbacksField.IsValid() {
-		return nil, nil // No fallbacks field found
+		reqType := reqValue.Type()
+		for i := 0; i < reqValue.NumField(); i++ {
+			field := reqType.Field(i)
+			jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
+			if jsonName == "fallbacks" {
+				fallbacksField = reqValue.Field(i)
+				break
+			}
+		}
+	}
+	if !fallbacksField.IsValid() {
+		return nil, nil
 	}
 
 	// Handle different types of fallbacks field

--- a/transports/bifrost-http/integrations/utils.go
+++ b/transports/bifrost-http/integrations/utils.go
@@ -430,6 +430,8 @@ func (g *GenericRouter) extractFallbacksFromRequest(req interface{}) ([]string, 
 
 	fallbacksField := reqValue.FieldByName("Fallbacks")
 	if !fallbacksField.IsValid() {
+		// Some integrations may expose the field under a different Go name, so
+		// fall back to the JSON wire name used in request payloads.
 		reqType := reqValue.Type()
 		for i := 0; i < reqValue.NumField(); i++ {
 			field := reqType.Field(i)

--- a/transports/bifrost-http/integrations/utils_test.go
+++ b/transports/bifrost-http/integrations/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/bedrock"
+	"github.com/maximhq/bifrost/core/providers/gemini"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,6 +45,28 @@ func newTestGenericRouter() *GenericRouter {
 
 func newTestBifrostContext() *schemas.BifrostContext {
 	return schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+}
+
+func TestExtractAndParseFallbacks_GeminiGenerationRequest(t *testing.T) {
+	router := newTestGenericRouter()
+	geminiReq := &gemini.GeminiGenerationRequest{
+		Model:     "gemini/gemini-3-flash-preview",
+		Fallbacks: []string{"vertex/gemini-3-flash-preview"},
+	}
+	bifrostReq := &schemas.BifrostRequest{
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Provider: schemas.Gemini,
+			Model:    "gemini-3-flash-preview",
+		},
+	}
+
+	err := router.extractAndParseFallbacks(geminiReq, bifrostReq)
+
+	require.NoError(t, err)
+	require.NotNil(t, bifrostReq.ResponsesRequest)
+	require.Len(t, bifrostReq.ResponsesRequest.Fallbacks, 1)
+	assert.Equal(t, schemas.Vertex, bifrostReq.ResponsesRequest.Fallbacks[0].Provider)
+	assert.Equal(t, "gemini-3-flash-preview", bifrostReq.ResponsesRequest.Fallbacks[0].Model)
 }
 
 // TestSendStreamError_PropagatesProviderStatusCode verifies that sendStreamError


### PR DESCRIPTION
## Summary
- preserve Gemini request fallbacks when converting GenAI generateContent requests into Bifrost Responses requests
- fix generic integration fallback extraction to read exported `Fallbacks` fields and `json:"fallbacks"` tags
- add regression coverage for Gemini fallback propagation through both conversion points

## Root cause
The GenAI/Gemini Responses conversion dropped `GeminiGenerationRequest.Fallbacks`, and the transport fallback extractor looked for a lowercase Go field name (`fallbacks`) that does not match exported request structs. That meant selected fallback candidates could be present on the integration request but never reach the core fallback runner.

## Tests
- `GOTOOLCHAIN=auto go test ./providers/gemini -count=1` from `core/`
- `GOTOOLCHAIN=auto go test ./bifrost-http/integrations -count=1` from `transports/`