### PR TITLE
chore(npx): bump @maximhq/bifrost to v1.6.3

### DIFF
--- a/npx/bifrost/package-lock.json
+++ b/npx/bifrost/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maximhq/bifrost",
-  "version": "1.0.6",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maximhq/bifrost",
-      "version": "1.0.4",
+      "version": "1.6.3",
       "license": "Apache-2.0",
       "bin": {
         "bifrost": "bin.js"

--- a/npx/bifrost/package.json
+++ b/npx/bifrost/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@maximhq/bifrost",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "High-performance AI gateway CLI - connect to 12+ providers through a single API",
-  "keywords": ["ai", "gateway", "openai", "anthropic", "cli", "bifrost"],
+  "keywords": [
+    "ai",
+    "gateway",
+    "openai",
+    "anthropic",
+    "cli",
+    "bifrost"
+  ],
   "homepage": "https://github.com/maximhq/bifrost",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump @maximhq/bifrost version from 1.6.2 to 1.6.3
- sync NPX lockfile version metadata

## Why
Trigger the NPX publish workflow after merge to main.