### PR TITLE
[codex] surface routing rule aliases in model listings

### DIFF
--- a/plugins/governance/listmodels_routing_rules_test.go
+++ b/plugins/governance/listmodels_routing_rules_test.go
@@ -1,0 +1,195 @@
+package governance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterModelsForVirtualKeyAddsAllowedRoutingRuleModels(t *testing.T) {
+	logger := NewMockLogger()
+	vk := buildVirtualKeyWithProviders("vk-1", "sk-bf-test", "test", []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("openai", []string{"gpt-4o"}),
+	})
+	enabled := true
+	provider := "openai"
+	model := "gpt-4o"
+	rule := configstoreTables.TableRoutingRule{
+		ID:            "rule-1",
+		Name:          "route-deepseek-v4-pro",
+		Enabled:       &enabled,
+		CelExpression: `model == "deepseek-v4-pro" || model == "deepseek/deepseek-v4-pro"`,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: &provider, Model: &model, Weight: 1},
+		},
+		Scope: "global",
+	}
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*vk},
+		RoutingRules: []configstoreTables.TableRoutingRule{rule},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin := &GovernancePlugin{store: store, logger: logger}
+	models := plugin.filterModelsForVirtualKey(context.Background(), []schemas.Model{
+		{ID: "openai/gpt-4o"},
+	}, "sk-bf-test", schemas.OpenAI)
+
+	requireModelIDs(t, models, []string{
+		"deepseek-v4-pro",
+		"deepseek/deepseek-v4-pro",
+		"openai/gpt-4o",
+	})
+}
+
+func TestFilterModelsForVirtualKeySkipsRoutingRuleWithoutAllowedTarget(t *testing.T) {
+	logger := NewMockLogger()
+	vk := buildVirtualKeyWithProviders("vk-1", "sk-bf-test", "test", []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("openai", []string{"gpt-4o-mini"}),
+	})
+	enabled := true
+	provider := "nahcrof"
+	model := "deepseek-v4-pro-precision"
+	rule := configstoreTables.TableRoutingRule{
+		ID:            "rule-1",
+		Name:          "route-deepseek-v4-pro",
+		Enabled:       &enabled,
+		CelExpression: `model in ["deepseek-v4-pro", "deepseek/deepseek-v4-pro"]`,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: &provider, Model: &model, Weight: 1},
+		},
+		Scope: "global",
+	}
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*vk},
+		RoutingRules: []configstoreTables.TableRoutingRule{rule},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin := &GovernancePlugin{store: store, logger: logger}
+	models := plugin.filterModelsForVirtualKey(context.Background(), []schemas.Model{
+		{ID: "openai/gpt-4o-mini"},
+	}, "sk-bf-test", schemas.OpenAI)
+
+	requireModelIDs(t, models, []string{"openai/gpt-4o-mini"})
+}
+
+func TestFilterModelsForVirtualKeyAddsRoutingRuleModelsOnAllowedFallback(t *testing.T) {
+	logger := NewMockLogger()
+	vk := buildVirtualKeyWithProviders("vk-1", "sk-bf-test", "test", []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("openai", []string{"gpt-4o-mini"}),
+	})
+	enabled := true
+	blockedProvider := "anthropic"
+	blockedModel := "claude-sonnet-4-6"
+	rule := configstoreTables.TableRoutingRule{
+		ID:              "rule-1",
+		Name:            "route-fallback-only",
+		Enabled:         &enabled,
+		CelExpression:   `model == "best-model"`,
+		ParsedFallbacks: []string{"openai/gpt-4o-mini"},
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: &blockedProvider, Model: &blockedModel, Weight: 1},
+		},
+		Scope: "global",
+	}
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*vk},
+		RoutingRules: []configstoreTables.TableRoutingRule{rule},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin := &GovernancePlugin{store: store, logger: logger}
+	models := plugin.filterModelsForVirtualKey(context.Background(), []schemas.Model{
+		{ID: "openai/gpt-4o-mini"},
+	}, "sk-bf-test", schemas.OpenAI)
+
+	requireModelIDs(t, models, []string{"best-model", "openai/gpt-4o-mini"})
+}
+
+func TestFilterModelsForVirtualKeyAddsRoutingRuleModelsOnlyOnFirstAllowedFallback(t *testing.T) {
+	logger := NewMockLogger()
+	vk := buildVirtualKeyWithProviders("vk-1", "sk-bf-test", "test", []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("openai", []string{"gpt-4o-mini"}),
+		buildProviderConfig("anthropic", []string{"claude-sonnet-4-6"}),
+	})
+	enabled := true
+	blockedProvider := "nahcrof"
+	blockedModel := "deepseek-v4-pro-precision"
+	rule := configstoreTables.TableRoutingRule{
+		ID:              "rule-1",
+		Name:            "route-fallback-order",
+		Enabled:         &enabled,
+		CelExpression:   `model == "best-model"`,
+		ParsedFallbacks: []string{"openai/gpt-4o-mini", "anthropic/claude-sonnet-4-6"},
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Provider: &blockedProvider, Model: &blockedModel, Weight: 1},
+		},
+		Scope: "global",
+	}
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*vk},
+		RoutingRules: []configstoreTables.TableRoutingRule{rule},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin := &GovernancePlugin{store: store, logger: logger}
+	openAIModels := plugin.filterModelsForVirtualKey(context.Background(), []schemas.Model{
+		{ID: "openai/gpt-4o-mini"},
+	}, "sk-bf-test", schemas.OpenAI)
+	anthropicModels := plugin.filterModelsForVirtualKey(context.Background(), []schemas.Model{
+		{ID: "anthropic/claude-sonnet-4-6"},
+	}, "sk-bf-test", schemas.Anthropic)
+
+	requireModelIDs(t, openAIModels, []string{"best-model", "openai/gpt-4o-mini"})
+	requireModelIDs(t, anthropicModels, []string{"anthropic/claude-sonnet-4-6"})
+}
+
+func TestFilterModelsForVirtualKeyDoesNotLeakProviderlessTargetAcrossProviders(t *testing.T) {
+	logger := NewMockLogger()
+	vk := buildVirtualKeyWithProviders("vk-1", "sk-bf-test", "test", []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("openai", []string{"gpt-4o"}),
+		buildProviderConfig("anthropic", []string{"claude-sonnet-4-6"}),
+	})
+	enabled := true
+	model := "gpt-4o"
+	rule := configstoreTables.TableRoutingRule{
+		ID:            "rule-1",
+		Name:          "route-providerless",
+		Enabled:       &enabled,
+		CelExpression: `model == "best-model"`,
+		Targets: []configstoreTables.TableRoutingTarget{
+			{Model: &model, Weight: 1},
+		},
+		Scope: "global",
+	}
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys:  []configstoreTables.TableVirtualKey{*vk},
+		RoutingRules: []configstoreTables.TableRoutingRule{rule},
+	}, nil)
+	require.NoError(t, err)
+
+	plugin := &GovernancePlugin{store: store, logger: logger}
+	openAIModels := plugin.filterModelsForVirtualKey(context.Background(), []schemas.Model{
+		{ID: "openai/gpt-4o"},
+	}, "sk-bf-test", schemas.OpenAI)
+	anthropicModels := plugin.filterModelsForVirtualKey(context.Background(), []schemas.Model{
+		{ID: "anthropic/claude-sonnet-4-6"},
+	}, "sk-bf-test", schemas.Anthropic)
+
+	requireModelIDs(t, openAIModels, []string{"best-model", "openai/gpt-4o"})
+	requireModelIDs(t, anthropicModels, []string{"anthropic/claude-sonnet-4-6"})
+}
+
+func requireModelIDs(t *testing.T, models []schemas.Model, expected []string) {
+	t.Helper()
+	actual := make([]string, 0, len(models))
+	for _, model := range models {
+		actual = append(actual, model.ID)
+	}
+	require.Equal(t, expected, actual)
+}

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1380,7 +1380,7 @@ func (p *GovernancePlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 
 	if requestType == schemas.ListModelsRequest && result != nil && result.ListModelsResponse != nil && virtualKey != "" {
 		// filter models which are not supported on this virtual key
-		result.ListModelsResponse.Data = p.filterModelsForVirtualKey(ctx, result.ListModelsResponse.Data, virtualKey)
+		result.ListModelsResponse.Data = p.filterModelsForVirtualKey(ctx, result.ListModelsResponse.Data, virtualKey, provider)
 	}
 
 	isFinalChunk := bifrost.IsFinalChunk(ctx)

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -3,11 +3,20 @@ package governance
 
 import (
 	"context"
+	"regexp"
+	"sort"
 	"strings"
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/valyala/fasthttp"
+)
+
+var (
+	modelEqualsLiteralRegexp = regexp.MustCompile(`\bmodel\s*==\s*["']([^"']+)["']`)
+	modelInLiteralRegexp     = regexp.MustCompile(`\bmodel\s+in\s*\[([^\]]*)\]`)
+	stringLiteralRegexp      = regexp.MustCompile(`["']([^"']+)["']`)
 )
 
 // ParseVirtualKeyFromFastHTTPRequest parses the virtual key from FastHTTP request headers.
@@ -93,6 +102,7 @@ func (p *GovernancePlugin) filterModelsForVirtualKey(
 	ctx context.Context,
 	models []schemas.Model,
 	virtualKeyValue string,
+	currentProvider schemas.ModelProvider,
 ) []schemas.Model {
 	// Get virtual key configuration
 	vk, exists := p.store.GetVirtualKey(ctx, virtualKeyValue)
@@ -139,5 +149,151 @@ func (p *GovernancePlugin) filterModelsForVirtualKey(
 		}
 	}
 
+	filteredModels = p.appendRoutingRuleModelsForVirtualKey(ctx, filteredModels, vk, currentProvider)
+	sort.Slice(filteredModels, func(i, j int) bool {
+		return strings.ToLower(filteredModels[i].ID) < strings.ToLower(filteredModels[j].ID)
+	})
+
 	return filteredModels
+}
+
+func (p *GovernancePlugin) appendRoutingRuleModelsForVirtualKey(ctx context.Context, models []schemas.Model, vk *configstoreTables.TableVirtualKey, currentProvider schemas.ModelProvider) []schemas.Model {
+	if p.store == nil || vk == nil || currentProvider == "" || !p.store.HasRoutingRules(ctx) {
+		return models
+	}
+
+	seen := make(map[string]struct{}, len(models))
+	for _, model := range models {
+		seen[strings.ToLower(model.ID)] = struct{}{}
+	}
+
+	for _, scope := range buildScopeChain(vk) {
+		for _, rule := range p.store.GetScopedRoutingRules(ctx, scope.ScopeName, scope.ScopeID) {
+			if rule == nil || !rule.EnabledValue() || !p.routingRuleListsOnProvider(vk, rule, currentProvider) {
+				continue
+			}
+			for _, modelID := range routingRuleModelLiterals(rule.CelExpression) {
+				if strings.TrimSpace(modelID) == "" {
+					continue
+				}
+				key := strings.ToLower(modelID)
+				if _, ok := seen[key]; ok {
+					continue
+				}
+				models = append(models, schemas.Model{
+					ID:   modelID,
+					Name: schemas.Ptr(modelID),
+				})
+				seen[key] = struct{}{}
+			}
+		}
+	}
+
+	return models
+}
+
+func routingRuleModelLiterals(expression string) []string {
+	seen := map[string]struct{}{}
+	var models []string
+	add := func(model string) {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			return
+		}
+		key := strings.ToLower(model)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		models = append(models, model)
+	}
+
+	for _, match := range modelEqualsLiteralRegexp.FindAllStringSubmatch(expression, -1) {
+		add(match[1])
+	}
+	for _, match := range modelInLiteralRegexp.FindAllStringSubmatch(expression, -1) {
+		for _, literal := range stringLiteralRegexp.FindAllStringSubmatch(match[1], -1) {
+			add(literal[1])
+		}
+	}
+
+	sort.Slice(models, func(i, j int) bool {
+		return strings.ToLower(models[i]) < strings.ToLower(models[j])
+	})
+	return models
+}
+
+func (p *GovernancePlugin) routingRuleListsOnProvider(vk *configstoreTables.TableVirtualKey, rule *configstoreTables.TableRoutingRule, currentProvider schemas.ModelProvider) bool {
+	if provider := p.firstAllowedRoutingRulePrimaryProvider(vk, rule, currentProvider); provider != "" {
+		return strings.EqualFold(provider, string(currentProvider))
+	}
+	if provider := p.firstAllowedRoutingRuleFallbackProvider(vk, rule); provider != "" {
+		return strings.EqualFold(provider, string(currentProvider))
+	}
+	return false
+}
+
+func (p *GovernancePlugin) firstAllowedRoutingRulePrimaryProvider(vk *configstoreTables.TableVirtualKey, rule *configstoreTables.TableRoutingRule, currentProvider schemas.ModelProvider) string {
+	for _, target := range rule.Targets {
+		if target.Provider != nil {
+			if p.routingTargetAllowedForVirtualKey(vk, target.Provider, target.Model) {
+				return *target.Provider
+			}
+			continue
+		}
+
+		currentProviderString := string(currentProvider)
+		if currentProviderString == "" {
+			continue
+		}
+		if p.routingTargetAllowedForVirtualKey(vk, &currentProviderString, target.Model) {
+			return currentProviderString
+		}
+	}
+	return ""
+}
+
+func (p *GovernancePlugin) firstAllowedRoutingRuleFallbackProvider(vk *configstoreTables.TableVirtualKey, rule *configstoreTables.TableRoutingRule) string {
+	for _, fallback := range rule.ParsedFallbacks {
+		provider, model := schemas.ParseModelString(fallback, "")
+		providerString := string(provider)
+		if providerString == "" || model == "" {
+			continue
+		}
+		if p.routingTargetAllowedForVirtualKey(vk, &providerString, &model) {
+			return providerString
+		}
+	}
+	return ""
+}
+
+func (p *GovernancePlugin) routingTargetAllowedForVirtualKey(vk *configstoreTables.TableVirtualKey, provider *string, model *string) bool {
+	if vk == nil || len(vk.ProviderConfigs) == 0 {
+		return false
+	}
+
+	for _, pc := range vk.ProviderConfigs {
+		if provider != nil && !strings.EqualFold(pc.Provider, *provider) {
+			continue
+		}
+		if model == nil || strings.TrimSpace(*model) == "" {
+			return true
+		}
+		if p.modelCatalog != nil && p.inMemoryStore != nil {
+			providerConfig, ok := p.inMemoryStore.GetConfiguredProviders()[schemas.ModelProvider(pc.Provider)]
+			providerConfigPtr := &providerConfig
+			if !ok {
+				providerConfigPtr = nil
+			}
+			if p.modelCatalog.IsModelAllowedForProvider(schemas.ModelProvider(pc.Provider), *model, providerConfigPtr, pc.AllowedModels) {
+				return true
+			}
+			continue
+		}
+		if pc.AllowedModels.IsAllowed(*model) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -14,9 +14,9 @@ import (
 )
 
 var (
-	modelEqualsLiteralRegexp = regexp.MustCompile(`\bmodel\s*==\s*["']([^"']+)["']`)
+	modelEqualsLiteralRegexp = regexp.MustCompile(`\bmodel\s*==\s*(?:"([^"]+)"|'([^']+)')`)
 	modelInLiteralRegexp     = regexp.MustCompile(`\bmodel\s+in\s*\[([^\]]*)\]`)
-	stringLiteralRegexp      = regexp.MustCompile(`["']([^"']+)["']`)
+	stringLiteralRegexp      = regexp.MustCompile(`"([^"]+)"|'([^']+)'`)
 )
 
 // ParseVirtualKeyFromFastHTTPRequest parses the virtual key from FastHTTP request headers.


### PR DESCRIPTION
Fixes #2655.

### What changed

- Include reachable routing-rule model entrypoints in governance-filtered list-model responses for virtual keys.
- Parse simple routing-rule model literals from CEL expressions using:
  - `model == "..."`
  - `model in ["...", "..."]`
- Only append route aliases when the rule is enabled and the virtual key can actually reach an allowed primary target or, when no primary target is allowed, an allowed fallback on the current provider listing pass.
- Keep the existing virtual-key provider/model filtering for provider-returned models.
- Add governance tests for allowed primary targets, denied targets, and fallback-only reachability.

### Why

Routing rules are documented as the dynamic alias layer, and those aliases can work for inference. Before this change, `/v1/models` only returned provider/key-backed models after governance filtering, so clients that validate models from `/v1/models` could not discover valid routing-rule aliases such as `deepseek-v4-pro` or the `gemma4` style aliases described in #2655.

This keeps the maintainer concern from #2655 in mind: dynamic rules can be scoped and may not resolve for every caller. The list response is therefore augmented only after virtual-key governance filtering and only for rules whose target or fallback is reachable for the requesting virtual key/provider pass.

### Validation

```bash
cd plugins/governance
go test ./...
```