### PR TITLE
[fix]: align scim_config schema with documented keycloak provider

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1361,6 +1361,20 @@ Call this template at the beginning of deployment/stateful templates
 {{- fail "ERROR: bifrost.scim.config.clientId is required when SCIM provider is Entra (Azure AD)." }}
 {{- end }}
 {{- end }}
+{{- if eq $scimValidation.provider "keycloak" }}
+{{- if not $scimValidation.config.serverUrl }}
+{{- fail "ERROR: bifrost.scim.config.serverUrl is required when SCIM provider is Keycloak. Example: https://keycloak.company.com (must NOT include /realms/{realm})." }}
+{{- end }}
+{{- if not $scimValidation.config.realm }}
+{{- fail "ERROR: bifrost.scim.config.realm is required when SCIM provider is Keycloak." }}
+{{- end }}
+{{- if not $scimValidation.config.clientId }}
+{{- fail "ERROR: bifrost.scim.config.clientId is required when SCIM provider is Keycloak." }}
+{{- end }}
+{{- if not $scimValidation.config.clientSecret }}
+{{- fail "ERROR: bifrost.scim.config.clientSecret is required when SCIM provider is Keycloak." }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/* Validate cluster config when enabled */}}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1703,7 +1703,7 @@
             },
             "provider": {
               "type": "string",
-              "enum": ["", "okta", "entra"],
+              "enum": ["", "okta", "entra", "keycloak"],
               "description": "SCIM/SSO provider type (empty when not configured)"
             },
             "config": {
@@ -1842,6 +1842,93 @@
                       }
                     },
                     "required": ["tenantId", "clientId"],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  },
+                  "provider": {
+                    "const": "keycloak"
+                  }
+                },
+                "required": ["enabled", "provider"]
+              },
+              "then": {
+                "properties": {
+                  "config": {
+                    "type": "object",
+                    "description": "Keycloak OIDC/SCIM authentication configuration",
+                    "properties": {
+                      "serverUrl": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "Base URL of the Keycloak server (e.g., https://keycloak.company.com). Must NOT include the /realms/{realm} suffix."
+                      },
+                      "realm": {
+                        "type": "string",
+                        "description": "Keycloak realm name (e.g., 'bifrost-prod')"
+                      },
+                      "clientId": {
+                        "type": "string",
+                        "description": "Keycloak client ID for the confidential client used by Bifrost"
+                      },
+                      "clientSecret": {
+                        "type": "string",
+                        "description": "Keycloak client secret. Supports env. prefix for environment variable references (e.g., 'env.KEYCLOAK_CLIENT_SECRET')"
+                      },
+                      "audience": {
+                        "type": "string",
+                        "description": "Expected JWT audience (default: clientId)"
+                      },
+                      "userIdField": {
+                        "type": "string",
+                        "description": "JWT claim field for user ID (default: 'sub')",
+                        "default": "sub"
+                      },
+                      "teamIdsField": {
+                        "type": "string",
+                        "description": "JWT claim field for team IDs (default: 'groups')",
+                        "default": "groups"
+                      },
+                      "rolesField": {
+                        "type": "string",
+                        "description": "JWT claim field for roles (default: 'roles')",
+                        "default": "roles"
+                      },
+                      "attributeRoleMappings": {
+                        "type": "array",
+                        "description": "Ordered list of attribute -> role mappings",
+                        "items": {
+                          "type": "object"
+                        }
+                      },
+                      "attributeTeamMappings": {
+                        "type": "array",
+                        "description": "Attribute -> team mappings (all matches apply)",
+                        "items": {
+                          "type": "object"
+                        }
+                      },
+                      "attributeBusinessUnitMappings": {
+                        "type": "array",
+                        "description": "Attribute -> business-unit mappings (all matches apply)",
+                        "items": {
+                          "type": "object"
+                        }
+                      }
+                    },
+                    "required": [
+                      "serverUrl",
+                      "realm",
+                      "clientId",
+                      "clientSecret"
+                    ],
                     "additionalProperties": false
                   }
                 }

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -628,6 +628,7 @@ bifrost:
       # clientId: "bifrost"
       # clientSecret: "env.KEYCLOAK_CLIENT_SECRET"  # supports env. prefix
       # audience: ""
+      # userIdField: "sub"
       # teamIdsField: "groups"
       # rolesField: "roles"
 

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -598,7 +598,7 @@ bifrost:
   # SCIM/SSO configuration for enterprise SSO
   scim:
     enabled: false
-    # Provider: okta, entra
+    # Provider: okta, entra, keycloak
     provider: ""
     config: {}
       # Okta configuration:
@@ -619,6 +619,15 @@ bifrost:
       # audience: ""
       # appIdUri: ""
       # userIdField: "oid"
+      # teamIdsField: "groups"
+      # rolesField: "roles"
+      #
+      # Keycloak configuration:
+      # serverUrl: "https://keycloak.company.com"  # base URL, must NOT include /realms/{realm}
+      # realm: "bifrost-prod"
+      # clientId: "bifrost"
+      # clientSecret: "env.KEYCLOAK_CLIENT_SECRET"  # supports env. prefix
+      # audience: ""
       # teamIdsField: "groups"
       # rolesField: "roles"
 

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+[fix]: align scim_config schema with documented keycloak provider [@lornest](https://github.com/lornest)

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3424,7 +3424,7 @@
         },
         "provider": {
           "type": "string",
-          "enum": ["okta", "entra"],
+          "enum": ["okta", "entra", "keycloak"],
           "description": "SCIM provider type"
         },
         "config": {
@@ -3438,10 +3438,14 @@
         {
           "if": {
             "properties": {
+              "enabled": {
+                "const": true
+              },
               "provider": {
                 "const": "okta"
               }
-            }
+            },
+            "required": ["enabled", "provider"]
           },
           "then": {
             "properties": {
@@ -3454,15 +3458,39 @@
         {
           "if": {
             "properties": {
+              "enabled": {
+                "const": true
+              },
               "provider": {
                 "const": "entra"
               }
-            }
+            },
+            "required": ["enabled", "provider"]
           },
           "then": {
             "properties": {
               "config": {
                 "$ref": "#/$defs/entra_config"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "enabled": {
+                "const": true
+              },
+              "provider": {
+                "const": "keycloak"
+              }
+            },
+            "required": ["enabled", "provider"]
+          },
+          "then": {
+            "properties": {
+              "config": {
+                "$ref": "#/$defs/keycloak_config"
               }
             }
           }
@@ -3561,6 +3589,71 @@
         }
       },
       "required": ["tenantId", "clientId"],
+      "additionalProperties": false
+    },
+    "keycloak_config": {
+      "type": "object",
+      "description": "Keycloak OIDC/SCIM authentication configuration",
+      "properties": {
+        "serverUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Base URL of the Keycloak server (e.g., https://keycloak.company.com). Must NOT include the /realms/{realm} suffix."
+        },
+        "realm": {
+          "type": "string",
+          "description": "Keycloak realm name (e.g., 'bifrost-prod')"
+        },
+        "clientId": {
+          "type": "string",
+          "description": "Keycloak client ID for the confidential client used by Bifrost"
+        },
+        "clientSecret": {
+          "type": "string",
+          "description": "Keycloak client secret. Supports env. prefix for environment variable references (e.g., 'env.KEYCLOAK_CLIENT_SECRET')"
+        },
+        "audience": {
+          "type": "string",
+          "description": "Expected JWT audience (default: clientId)"
+        },
+        "userIdField": {
+          "type": "string",
+          "description": "JWT claim field for user ID (default: 'sub')",
+          "default": "sub"
+        },
+        "teamIdsField": {
+          "type": "string",
+          "description": "JWT claim field for team IDs (default: 'groups')",
+          "default": "groups"
+        },
+        "rolesField": {
+          "type": "string",
+          "description": "JWT claim field for roles (default: 'roles')",
+          "default": "roles"
+        },
+        "attributeRoleMappings": {
+          "type": "array",
+          "description": "Ordered list of attribute -> role mappings",
+          "items": {
+            "type": "object"
+          }
+        },
+        "attributeTeamMappings": {
+          "type": "array",
+          "description": "Attribute -> team mappings (all matches apply)",
+          "items": {
+            "type": "object"
+          }
+        },
+        "attributeBusinessUnitMappings": {
+          "type": "array",
+          "description": "Attribute -> business-unit mappings (all matches apply)",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "required": ["serverUrl", "realm", "clientId", "clientSecret"],
       "additionalProperties": false
     },
     "load_balancer_config": {

--- a/transports/schema_test/config_schema_test.go
+++ b/transports/schema_test/config_schema_test.go
@@ -165,6 +165,71 @@ func validateConfig(t *testing.T, schema *jsonschema.Schema, configJSON string) 
 	return schema.Validate(v)
 }
 
+func TestSchemaSCIMConfigValidation(t *testing.T) {
+	compiled := compileSchema(t)
+
+	tests := []struct {
+		name      string
+		config    string
+		wantError bool
+	}{
+		{
+			name:   "disabled okta with empty config is valid",
+			config: `{"scim_config":{"enabled":false,"provider":"okta","config":{}}}`,
+		},
+		{
+			name:   "disabled entra with empty config is valid",
+			config: `{"scim_config":{"enabled":false,"provider":"entra","config":{}}}`,
+		},
+		{
+			name:   "disabled keycloak with empty config is valid",
+			config: `{"scim_config":{"enabled":false,"provider":"keycloak","config":{}}}`,
+		},
+		{
+			name:      "enabled okta with empty config is invalid",
+			config:    `{"scim_config":{"enabled":true,"provider":"okta","config":{}}}`,
+			wantError: true,
+		},
+		{
+			name:      "enabled entra with empty config is invalid",
+			config:    `{"scim_config":{"enabled":true,"provider":"entra","config":{}}}`,
+			wantError: true,
+		},
+		{
+			name:      "enabled keycloak with empty config is invalid",
+			config:    `{"scim_config":{"enabled":true,"provider":"keycloak","config":{}}}`,
+			wantError: true,
+		},
+		{
+			name: "enabled keycloak with required config is valid",
+			config: `{
+				"scim_config": {
+					"enabled": true,
+					"provider": "keycloak",
+					"config": {
+						"serverUrl": "https://keycloak.company.com",
+						"realm": "bifrost-prod",
+						"clientId": "bifrost",
+						"clientSecret": "env.KEYCLOAK_CLIENT_SECRET"
+					}
+				}
+			}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfig(t, compiled, tt.config)
+			if tt.wantError && err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("expected config to validate, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestSchemaKeyAliases(t *testing.T) {
 	schema := loadSchema(t)
 


### PR DESCRIPTION
## Description

The Bifrost enterprise binary already implements Keycloak as a SCIM/SSO provider, and `docs/enterprise/setting-up-keycloak.mdx` documents the `config.json` shape. But both the chart's `values.schema.json` and the runtime `transports/config.schema.json` only enum `["", "okta", "entra"]`, so a user following the docs is rejected at parse time:

```
at '/bifrost/scim/provider': value must be one of '', 'okta', 'entra'
```

…and at runtime the validator (`transports/bifrost-http/lib/validator.go:40-60`) logs the same mismatch against the published schema at `https://www.getbifrost.ai/schema`. The schemas are out of sync with the docs and with the binary's actual capabilities; this PR aligns them.

While doing so I noticed each provider's `allOf` `if/then` gate fired purely on `provider` matching, so a config with `enabled: false, provider: "okta"` still demanded the full `okta_config` required-field set. Tightened all three gates (`okta`, `entra`, `keycloak`) to also require `enabled: true` before enforcing required fields. Behavior for `enabled: true` users is unchanged; behavior for `enabled: false` users is now sensible (the disabled config block is no longer required to be populated).

### Why both schemas?

Both files describe the same `scim_config` block but are consumed at different times. Patching only one would leave the other still rejecting the documented config:

- `helm-charts/bifrost/values.schema.json` — consumed by `helm template`/`helm install` at chart-render time.
- `transports/config.schema.json` — consumed at runtime by `transports/bifrost-http/lib/validator.go`, which loads it either from the local source checkout or from `https://www.getbifrost.ai/schema` (the published copy of this same file).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Affected Packages

- `helm-charts/bifrost/values.schema.json`
- `helm-charts/bifrost/templates/_helpers.tpl`
- `helm-charts/bifrost/values.yaml`
- `transports/config.schema.json`
- `transports/schema_test/config_schema_test.go`
- `transports/changelog.md`

## Changes Made

- `helm-charts/bifrost/values.schema.json`: add `"keycloak"` to the `scim.provider` enum; add a conditional `if/then` block requiring `serverUrl`, `realm`, `clientId`, `clientSecret`, with optional `audience`, `userIdField`, `teamIdsField`, `rolesField`, and the three attribute-mapping arrays from the docs.
- `helm-charts/bifrost/templates/_helpers.tpl`: add a `if eq $scimValidation.provider "keycloak"` validation branch alongside okta/entra, asserting the same four required fields with friendly `fail` messages.
- `helm-charts/bifrost/values.yaml`: extend the `# Provider:` comment to mention keycloak and add a Keycloak example block under `scim.config`.
- `transports/config.schema.json`: add `"keycloak"` to the runtime `scim_config.provider` enum, add a conditional `if/then` `\$ref` to `keycloak_config`, and add the `keycloak_config` `\$def` mirroring the helm-side shape. Also tighten the okta, entra, and keycloak `if/then` gates to require `enabled: true` alongside the `provider` match, so disabled providers aren't forced to populate their config block.
- `transports/schema_test/config_schema_test.go`: add `TestSchemaSCIMConfigValidation`, a table-driven test covering disabled-with-empty-config (valid), enabled-with-empty-config (invalid for missing required fields), and the keycloak happy path. Plus a trailing-newline fix on the file.
- `transports/changelog.md`: top-of-file changelog entry per `docs/contributing/raising-a-pr.mdx`.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] Manual testing completed

### \`go test ./transports/schema_test/...\`

\`\`\`
=== RUN   TestSchemaSCIMConfigValidation
=== RUN   TestSchemaSCIMConfigValidation/disabled_okta_with_empty_config_is_valid
=== RUN   TestSchemaSCIMConfigValidation/disabled_entra_with_empty_config_is_valid
=== RUN   TestSchemaSCIMConfigValidation/disabled_keycloak_with_empty_config_is_valid
=== RUN   TestSchemaSCIMConfigValidation/enabled_okta_with_empty_config_is_invalid
=== RUN   TestSchemaSCIMConfigValidation/enabled_entra_with_empty_config_is_invalid
=== RUN   TestSchemaSCIMConfigValidation/enabled_keycloak_with_empty_config_is_invalid
=== RUN   TestSchemaSCIMConfigValidation/enabled_keycloak_with_required_config_is_valid
--- PASS: TestSchemaSCIMConfigValidation (0.02s)
PASS
ok  	github.com/maximhq/bifrost/transports/schema_test	0.483s
\`\`\`

7 subtests, all passing. The pre-existing schema_test suite continues to pass too.

### \`helm template\` matrix

| Scenario | Expected | Result |
|---|---|---|
| \`provider: keycloak\` (valid) | renders documented \`scim_config\` JSON | ✓ — config matches the docs example byte-for-byte |
| \`provider: keycloak\`, \`realm\` omitted | schema rejects | ✓ — \`at '/bifrost/scim/config': missing property 'realm'\` |
| \`provider: auth0\` | schema rejects | ✓ — \`value must be one of '', 'okta', 'entra', 'keycloak'\` |
| \`provider: okta\` (regression) | unchanged behavior | ✓ — renders existing \`scim_config\` shape |
| \`provider: entra\` (regression) | unchanged behavior | ✓ — renders existing \`scim_config\` shape |
| \`enabled: false, provider: okta\`, empty config | now valid (was previously demanding required fields) | ✓ — disabled provider no longer forces required-field enforcement |

### Real Kind cluster test

Stood up a \`kind v0.31.0\` cluster and ran \`helm install bifrost ./helm-charts/bifrost -f values.yaml -n bifrost --create-namespace\` against the OSS image \`maximhq/bifrost:v1.5.0\` with \`provider: keycloak\` and dummy Keycloak config. **No \`--skip-schema-validation\` flag.** Install succeeded; pod reached \`1/1 Ready\`; configmap rendered \`scim_config\` exactly as documented.

The runtime validator currently fetches the **published** schema from \`https://www.getbifrost.ai/schema\` (since CWD has no local copy) and logs:

\`\`\`
config validation failed: schema validation failed:
jsonschema validation failed with 'file:///app/config.schema.json#'
- at '/scim_config/provider' [S#/\$defs/scim_config/properties/provider/enum]:
  value must be one of 'okta', 'entra'.
  You can find the official schema at https://www.getbifrost.ai/schema.
  Some features may not work as expected unless you fix the config file.
\`\`\`

This confirms (a) the runtime really does consume \`transports/config.schema.json\` (via the publish endpoint), so this part of the patch is doing real work, and (b) the binary soft-fails — it logs the schema mismatch and continues. After this PR merges and the published schema picks up \`keycloak\`, the warning goes away for enterprise users running with \`provider: keycloak\`.

### What I did *not* run

- \`make test-all\` end-to-end (heavy; needs provider keys for the core/test-core targets). The schema-relevant subset (\`transports/schema_test\`) passes.
- \`make fmt\` / \`make lint\` are Go-only; the four schema/template files in this PR are JSON / YAML / .tpl, and the new Go test is \`gofmt\`-clean.

## Checklist

- [x] Code follows the project's code style
- [ ] Tests are passing locally (\`make test-all\`) — only ran the schema subset; see Testing
- [x] Documentation is updated if needed (the Keycloak setup guide already documented the format; no docs change needed)
- [x] No breaking changes (additive — existing okta/entra users with \`enabled: true\` are unaffected; the \`enabled: false\` gate-tightening relaxes a previous over-strict validation)
- [x] Commit messages follow the format: \`[type]: description\`
- [x] All affected packages are mentioned in commit messages

## Related Issues

Closes #3345