### PR TITLE
okta doc fixes, vulnarability fixes on test packages

### DIFF
--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -259,8 +259,6 @@ type ProxyConfig struct {
 	CACertPEM *EnvVar   `json:"ca_cert_pem"` // PEM-encoded CA certificate to trust for TLS connections through the proxy (supports env.*)
 }
 
-
-
 // Redacted returns a redacted copy of the proxy configuration.
 func (pc *ProxyConfig) Redacted() *ProxyConfig {
 	redactedConfig := ProxyConfig{Type: pc.Type}

--- a/docs/enterprise/release-cadence.mdx
+++ b/docs/enterprise/release-cadence.mdx
@@ -10,7 +10,7 @@ Bifrost Enterprise follows standard [semantic versioning](https://semver.org/) (
 
 | Release type | Frequency | Typical contents |
 |---|---|---|
-| **Patch** (`x.y.Z`) | Every 2 - 3 days | Bug fixes, CVE fixes, small feature previews |
+| **Patch** (`x.y.Z`) | Every 2 - 3 days (depending on reports) | Bug fixes, CVE fixes, small feature previews |
 | **Minor** (`x.Y.0`) | Every 3 - 4 weeks | Rollup of the period's patches plus new non-breaking features |
 | **Major** (`X.0.0`) | When breaking changes land | Breaking API/schema changes, large architectural cuts |
 

--- a/docs/enterprise/setting-up-entra.mdx
+++ b/docs/enterprise/setting-up-entra.mdx
@@ -168,26 +168,23 @@ Ensure your application has the necessary permissions.
    - `User.Read.All`
    - `GroupMember.Read.All`
    - `Group.Read.All`
-   - `Application.Read.All` — required for syncing app-role-based role mappings during user import. If you don't want to do bulk syncing, you can skip this permission.
-   - `AppRoleAssignment.ReadWrite.All` — required to read each user's app role assignments via Microsoft Graph
+   - `Application.Read.All` — required for verification and user provisioning. Bifrost reads the Enterprise Application service principal, its assigned users/groups, and the App Registration claim configuration.
 
 <Warning>
   Permission **type** matters: `openid`, `profile`, `email`, `offline_access`,
   and `User.Read` must be **Delegated**, while `User.Read.All`,
   `GroupMember.Read.All`, `Group.Read.All`, `Application.Read.All`, and
-  `AppRoleAssignment.ReadWrite.All` must be **Application**. The same name can
-  exist under both types — adding the wrong one will cause sign-in or sync
-  failures even though the permission appears granted.
+  any other Graph provisioning permissions must be **Application**. The same
+  name can exist under both types — adding the wrong one will cause sign-in or
+  sync failures even though the permission appears granted.
 </Warning>
 
 7. Click **Add permissions**
 8. Click **Grant admin consent for [Your Organization]** (this is required — without admin consent, Application permissions are not effective even though they appear in the list)
 
 <Note>
-	`Application.Read.All` and `AppRoleAssignment.ReadWrite.All` are only needed if you plan to use **app role based role mappings** (i.e.
-	mappings whose attribute is `roles`) during the bulk user sync. Login-time role mapping works from the JWT alone, but bulk sync from
-	Microsoft Graph needs these permissions to read each user's app-role assignments and resolve them to their role values (e.g. `admin`,
-	`developer`).
+	Provisioning is scoped to the Enterprise Application assignments from Step 7. If the app has no users assigned directly and no assigned
+	groups with enabled direct user members, verification and import will return no users even if the directory contains users.
 </Note>
 
 ---
@@ -220,6 +217,11 @@ By default, Entra includes the `roles` claim when app roles are assigned. To inc
 5. Select the appropriate role (Admin, Developer, or Viewer)
 6. Click **Assign**
 
+<Note>
+	Bifrost uses this **Users and groups** assignment list as the source of truth for provisioning. Directly assigned users are included, and
+	users inside assigned groups are included as long as they are enabled direct members of the group.
+</Note>
+
 <Warning>
 	You **must** select a role when assigning a user or group. Adding a user to the application without picking a role causes Entra to omit
 	the `roles` claim from the issued ID token, and login will be rejected with `Claim "roles" is not present in the token`. If you don't want
@@ -230,6 +232,11 @@ By default, Entra includes the `roles` claim when app roles are assigned. To inc
 <Tip>
 	You can assign roles to groups for easier management. All users in a group will inherit the assigned role. The group itself must be added
 	as an assignment with a role selected — adding users to a group that isn't assigned to the application will not propagate roles.
+</Tip>
+
+<Tip>
+	If you are not using app roles and instead map Bifrost roles or teams from the `groups` claim, assign the relevant groups to the
+	Enterprise Application here. The mapping value in Bifrost should be the group's Entra **Object ID**, not the display name.
 </Tip>
 
 ---
@@ -291,7 +298,9 @@ Restrict the `groups` claim to groups assigned to this application (recommended)
   Enterprise application — not every group the user belongs to tenant-wide.
   This keeps your team and role mappings predictable and avoids leaking
   unrelated group memberships into the token. Use `"SecurityGroup"` or
-  `"All"` only if you intentionally want broader group visibility.
+  `"All"` only if you intentionally want broader group visibility. Entra emits
+  group **Object IDs** in the token, so Bifrost `groups` mappings should match
+  those Object IDs.
 </Note>
 
 ## Step 9: Configure Bifrost
@@ -344,7 +353,7 @@ Attribute mappings let you translate Entra claim values into Bifrost roles, team
 - **`attributeTeamMappings`**: map a claim value to a Bifrost team
 - **`attributeBusinessUnitMappings`**: map a claim value to a Bifrost business unit
 
-These mappings work with any Entra claim - the `groups` claim from Step 6, the app-role `roles` claim from Step 3, or any other claim your authorization server includes in the token (e.g., `department`, `organization`).
+These mappings work with any Entra claim - the `groups` claim from Step 6, the app-role `roles` claim from Step 3, or any other claim your authorization server includes in the token (e.g., `department`, `organization`). For `groups` mappings, use the Entra group **Object ID** as the value, not the group display name.
 
 To configure attribute mappings:
 
@@ -435,8 +444,20 @@ If you don't want to use app roles at all, switch your Bifrost mappings to use t
 If users come in via **User Provisioning → Import users** and end up on the default role (Viewer) despite having a matching app-role-based mapping configured:
 
 - Confirm the user actually has the app role assigned in Entra (**Enterprise applications → Bifrost Enterprise → Users and groups**).
-- Confirm both `Application.Read.All` and `AppRoleAssignment.ReadWrite.All` are granted **with admin consent** in Step 5. Without these, Bifrost cannot read the app role catalog or per-user assignments via Microsoft Graph, so the synthetic `roles` claim used by the importer will be empty.
-- Server logs will contain `[ENTRA-ROLES] failed to fetch app role catalog: ... 403` if the permission is missing.
+- Confirm `Application.Read.All` is granted **with admin consent** in Step 5. Without it, Bifrost cannot read the Enterprise Application assignments or validate the App Registration claim configuration during verification.
+- Confirm the `roles` claim is present in the user's ID token. Import and login mappings are evaluated from the claims Entra emits; if the claim is missing, update the app-role assignment or token configuration above.
+
+### Verify or import finds no users when only groups are assigned
+
+Bifrost provisions users from **Enterprise applications → Bifrost Enterprise → Users and groups**. If you assign groups there, Bifrost
+expands those assigned groups to their enabled direct user members.
+
+Causes and fixes:
+
+- **No Enterprise Application assignments exist.** Add at least one user or group under **Users and groups**.
+- **Assigned groups have no enabled direct user members.** Add enabled users directly to the assigned group, or assign the users directly to the Enterprise Application.
+- **Missing Graph permissions.** Confirm `Application.Read.All`, `User.Read.All`, and `GroupMember.Read.All` are granted as **Application** permissions with admin consent.
+- **Mappings use group display names.** Entra emits group Object IDs in the `groups` claim; update Bifrost `groups` mappings to use Object IDs.
 
 ---
 

--- a/docs/enterprise/setting-up-okta.mdx
+++ b/docs/enterprise/setting-up-okta.mdx
@@ -174,7 +174,11 @@ Bifrost can automatically sync Okta groups for two purposes:
 
 ### Add Groups Claim to Tokens
 
-This approach adds the groups claim through your authorization server, providing more flexibility for complex configurations.
+The location of the groups claim depends on which authorization server you chose at the top of this guide.
+
+#### If you're using the **Custom Authorization Server** (`authServerType=custom`)
+
+This is the only option for Custom Auth Servers, because app-level Sign On Group Claims are NOT included in tokens issued by `/oauth2/<id>`.
 
 1. Navigate to **Security** → **API** → **Authorization Servers**
 2. Select your authorization server (e.g., **default**)
@@ -192,6 +196,26 @@ Configure the groups claim:
 | **Include in**            | Any scope                                                   |
 
 5. Click **Create**
+
+#### If you're using the **Org Authorization Server** (`authServerType=org`)
+
+The Org Authorization Server only honors **app-level Sign On Group Claims**; auth-server-level claims don't apply.
+
+1. Navigate to **Applications** → **\<your app\>** → **Sign On**
+2. In the **OpenID Connect ID Token** section, click **Edit**
+3. Set **Group claims type** to **Filter** (or **Expression**)
+4. Set **Group claim filter**:
+
+| Field        | Value                                                       |
+| ------------ | ----------------------------------------------------------- |
+| **Name**     | `groups`                                                    |
+| **Filter**   | Matches regex: `.*` (or specify a prefix like `bifrost-.*`) |
+
+5. Click **Save**
+
+<Note>
+The `groups` claim only contains groups the user belongs to AND that match the filter AND that are assigned to the application. Make sure your role/team groups are assigned to the app under **Assignments** (Step 6).
+</Note>
 
 ---
 
@@ -239,6 +263,29 @@ Now configure Bifrost to use Okta as the identity provider.
 
 ### Using the Bifrost UI
 
+
+## Choose your Authorization Server
+
+Okta exposes two authorization server flavors. Bifrost supports both; pick one before you start, because the rest of the setup (especially where you configure the `groups` claim) depends on this choice.
+
+| | **Org Authorization Server** | **Custom Authorization Server** |
+|---|---|---|
+| **Issuer URL** | `https://<your-domain>.okta.com` (bare) | `https://<your-domain>.okta.com/oauth2/default` (or another `/oauth2/<id>`) |
+| **Cost** | Free, available on every Okta tenant | Requires the **API Access Management** add-on (paid on most plans; included with Okta Developer Edition) |
+| **Where to configure the `groups` claim** | **Applications → \<your app\> → Sign On → OpenID Connect ID Token → Group Claims** (app-level) | **Security → API → Authorization Servers → \<id\> → Claims** (auth-server-level). App-level Sign On Group Claims are NOT emitted by Custom Auth Servers. |
+| **Custom claim expressions** (Okta EL) | Not supported | Supported |
+| **Custom audience** (e.g. `api://default`) | Not supported | Supported |
+| **Bifrost attribute-to-role/team/BU mappings** | Works (reads the `groups` claim) | Works (reads the `groups` claim) |
+| **`authServerType` value in Bifrost** | `org` | `custom` |
+
+**If you're not sure, start with Org Authorization Server.** It works on every Okta tenant and supports Bifrost's group-based role mappings via the OIDC app's Sign On Group Claims (the simplest path).
+
+<Warning>
+A common pitfall: configuring the `groups` claim under **Applications → Sign On → Group Claims** while Bifrost is pointed at `https://<tenant>.okta.com/oauth2/default`. Custom Authorization Servers do **not** inherit app-level Sign On claims, so the `groups` claim will be absent from the JWT and Bifrost will reject login with "no role resolvable from claims". Either move the claim to **Security → API → Authorization Servers → default → Claims**, or switch your Bifrost issuer to the bare org URL with `authServerType=org`.
+</Warning>
+
+---
+
 <Frame>
   <img src="/media/user-provisioning/okta-form.png" alt="Create token dialog in Okta" />
 </Frame>
@@ -247,12 +294,13 @@ Now configure Bifrost to use Okta as the identity provider.
 2. Select **Okta** as the SCIM Provider
 3. Enter the following configuration:
 
-| Field             | Value                                                                |
-| ----------------- | -------------------------------------------------------------------- |
-| **Client ID**     | Your Okta application Client ID                                      |
-| **Issuer URL**    | Issuer URL                                                           |
-| **Audience**      | Your API audience (e.g., `api://default` or custom)                  |
-| **Client Secret** | Your Okta application Client Secret (optional, for token revocation) |
+| Field                         | Value                                                                                                                                              |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Issuer URL**                | `https://<your-domain>.okta.com` for Org Authorization Server, or `https://<your-domain>.okta.com/oauth2/default` for Custom Authorization Server. |
+| **Authorization Server**      | `Org` (free, every tenant) or `Custom` (requires API Access Management). Must match the issuer URL; see "Choose your Authorization Server" above. |
+| **Client ID**                 | Your Okta application Client ID                                                                                                                    |
+| **Audience**                  | Only for Custom Authorization Server (e.g., `api://default`). Leave blank for Org Authorization Server.                                            |
+| **Client Secret**             | Your Okta application Client Secret (optional, for token revocation)                                                                               |
 
 4. **Verify** configuration and see if you get any errors. Make sure you get no errors/warnings.
 5. Toggle **Enabled** to activate the provider
@@ -314,15 +362,16 @@ You can also map any custom attributes to any entity (role, team or business uni
 
 ### Configuration Reference
 
-| Field                           | Required | Description                                                                         |
-| ------------------------------- | -------- | ----------------------------------------------------------------------------------- |
-| `issuerUrl`                     | Yes      | Okta authorization server URL (e.g., `https://your-domain.okta.com/oauth2/default`) |
-| `clientId`                      | Yes      | Application Client ID from Okta                                                     |
-| `clientSecret`                  | Yes       | Application Client Secret (enables token revocation)                                |
-| `audience`                      | Yes      | API audience identifier from your authorization server                              |
-| `attributeRoleMappings`         | Yes       | Ordered list of attribute→role mappings. First match wins.                           |
-| `attributeTeamMappings`         | No       | Attribute→team mappings (all matches apply).                                        |
-| `attributeBusinessUnitMappings` | No       | Attribute→business-unit mappings (all matches apply).                               |
+| Field                           | Required | Description                                                                                                                                                                                                                  |
+| ------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `issuerUrl`                     | Yes      | Bare org URL (`https://<your-domain>.okta.com`) for Org Authorization Server, or `https://<your-domain>.okta.com/oauth2/<id>` for Custom Authorization Server.                                                               |
+| `authServerType`                | Yes      | `"org"` or `"custom"`. Must match the issuer URL shape. Set automatically by the migration for upgraded installs; for new installs the form defaults to `"org"`.                                                            |
+| `clientId`                      | Yes      | Application Client ID from Okta                                                                                                                                                                                              |
+| `clientSecret`                  | No       | Application Client Secret (enables token revocation)                                                                                                                                                                         |
+| `audience`                      | No       | API audience identifier, only for Custom Authorization Server (typically `api://default`). Org Authorization Server does not support a custom audience; leave empty.                                                         |
+| `attributeRoleMappings`         | Yes      | Ordered list of attribute→role mappings. First match wins.                                                                                                                                                                   |
+| `attributeTeamMappings`         | No       | Attribute→team mappings (all matches apply).                                                                                                                                                                                 |
+| `attributeBusinessUnitMappings` | No       | Attribute→business-unit mappings (all matches apply).                                                                                                                                                                        |
 
 
 ---
@@ -349,6 +398,25 @@ You can also map any custom attributes to any entity (role, team or business uni
 ### Attribute mapping is not working
 
 - Verify that token configuration includes all the attributes used for mapping.
+
+### `groups` claim is missing from the JWT
+
+This is the most common Okta integration issue and almost always means the claim is configured in the wrong place for the authorization server you're using.
+
+- **If `authServerType` is `custom`** (issuer ends with `/oauth2/<id>`): the `groups` claim must be configured under **Security → API → Authorization Servers → \<id\> → Claims**. App-level Sign On Group Claims are silently dropped by Custom Authorization Servers.
+- **If `authServerType` is `org`** (bare issuer): the `groups` claim must be configured under **Applications → \<your app\> → Sign On → OpenID Connect ID Token → Group Claims**. Auth-server-level claims are not honored by the Org Authorization Server.
+
+To check what's actually in the token, look at the Bifrost server logs after a failed login. The diagnostic line shows the present claim keys and the auth server type:
+
+```
+rejecting login: no role resolvable from claims userID=... provider=okta authServerType=custom claimKeys=[aud email exp iat iss name preferred_username sub] ...
+```
+
+If the present `claimKeys` list does not include `groups`, fix the claim configuration above and re-test.
+
+### Bifrost upgrades to 1.4.0+: existing Okta provider unexpectedly switched to Org Authorization Server
+
+The 1.4.0 migration probes `/oauth2/default/.well-known/openid-configuration` against your Okta tenant to backfill the new `authServerType` field. If the probe fails (network blip, tenant temporarily unreachable), the field is left empty and Bifrost defaults to `org` at runtime; login keeps working but Custom-Auth-Server-only features (claim expressions, custom audience) stop. The migration retries automatically on the next boot. To force the correct value immediately, edit the SCIM provider in the UI and pick the matching **Authorization Server** option, then save.
 
 ### Token refresh failing
 

--- a/examples/mcps/edge-case-server/package-lock.json
+++ b/examples/mcps/edge-case-server/package-lock.json
@@ -578,9 +578,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/examples/mcps/edge-case-server/package.json
+++ b/examples/mcps/edge-case-server/package.json
@@ -19,6 +19,6 @@
     "typescript": "^5.3.3"
   },
   "overrides": {
-    "hono": "4.12.14"
+    "hono": "4.12.16"
   }
 }

--- a/examples/mcps/error-test-server/package-lock.json
+++ b/examples/mcps/error-test-server/package-lock.json
@@ -578,9 +578,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/examples/mcps/error-test-server/package.json
+++ b/examples/mcps/error-test-server/package.json
@@ -19,6 +19,6 @@
     "typescript": "^5.3.3"
   },
   "overrides": {
-    "hono": "4.12.14"
+    "hono": "4.12.16"
   }
 }

--- a/examples/mcps/parallel-test-server/package-lock.json
+++ b/examples/mcps/parallel-test-server/package-lock.json
@@ -578,9 +578,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/examples/mcps/parallel-test-server/package.json
+++ b/examples/mcps/parallel-test-server/package.json
@@ -19,6 +19,6 @@
     "typescript": "^5.3.3"
   },
   "overrides": {
-    "hono": "4.12.14"
+    "hono": "4.12.16"
   }
 }

--- a/examples/mcps/temperature/package-lock.json
+++ b/examples/mcps/temperature/package-lock.json
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/examples/mcps/temperature/package.json
+++ b/examples/mcps/temperature/package.json
@@ -18,6 +18,6 @@
     "typescript": "^5.0.0"
   },
   "overrides": {
-    "hono": "4.12.14"
+    "hono": "4.12.16"
   }
 }

--- a/examples/mcps/test-tools-server/package-lock.json
+++ b/examples/mcps/test-tools-server/package-lock.json
@@ -578,9 +578,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.16",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/examples/mcps/test-tools-server/package.json
+++ b/examples/mcps/test-tools-server/package.json
@@ -19,6 +19,6 @@
     "typescript": "^5.3.3"
   },
   "overrides": {
-    "hono": "4.12.14"
+    "hono": "4.12.16"
   }
 }

--- a/tests/integrations/python/uv.lock
+++ b/tests/integrations/python/uv.lock
@@ -4254,11 +4254,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501 }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847 },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254 },
 ]
 
 [[package]]

--- a/ui/app/workspace/governance/teams/page.tsx
+++ b/ui/app/workspace/governance/teams/page.tsx
@@ -1,5 +1,9 @@
-import { TeamsView } from "@enterprise/components/user-groups/teamsView"
+import { TeamsView } from "@enterprise/components/user-groups/teamsView";
 
 export default function GovernanceTeamsPage() {
-		return <TeamsView />
+  return (
+    <div className="mx-auto w-full max-w-7xl h-[calc(100dvh-50px)]">
+      <TeamsView />
+    </div>
+  );
 }

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -40,10 +40,14 @@ import {
   UserRoundCheck,
   Users,
   Wallet,
-  WalletCards
+  WalletCards,
 } from "lucide-react";
 
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import {
   Sidebar,
@@ -71,7 +75,11 @@ import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import type { UserInfo } from "@enterprise/lib/store/utils/tokenManager";
 import { getUserInfo } from "@enterprise/lib/store/utils/tokenManager";
-import { BooksIcon, DiscordLogoIcon, GithubLogoIcon } from "@phosphor-icons/react";
+import {
+  BooksIcon,
+  DiscordLogoIcon,
+  GithubLogoIcon,
+} from "@phosphor-icons/react";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { ChevronRight } from "lucide-react";
 import { useTheme } from "next-themes";
@@ -137,7 +145,8 @@ const productionSetupHelpCard = {
   title: "Need help with production setup?",
   description: (
     <>
-      We offer help with production setup including custom integrations and dedicated support.
+      We offer help with production setup including custom integrations and
+      dedicated support.
       <br />
       <br />
       Book a demo with our team{" "}
@@ -224,7 +233,8 @@ const SidebarItemView = ({
       if (flyoutCloseTimer.current) clearTimeout(flyoutCloseTimer.current);
     };
   }, []);
-  const hasSubItems = "subItems" in item && item.subItems && item.subItems.length > 0;
+  const hasSubItems =
+    "subItems" in item && item.subItems && item.subItems.length > 0;
   const isRouteMatch = (url: string) => {
     if (url === "/workspace/custom-pricing") return pathname === url;
     return pathname.startsWith(url);
@@ -253,14 +263,15 @@ const SidebarItemView = ({
 
   const isHighlighted = !hasSubItems && highlightedUrl === item.url;
 
-  const buttonClassName = `relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${isHighlighted
-    ? "bg-sidebar-accent text-accent-foreground border-primary/20"
-    : isActive || isAnySubItemActive
-      ? "bg-sidebar-accent text-primary border-primary/20"
-      : item.hasAccess
-        ? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
-        : "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-    } `;
+  const buttonClassName = `relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${
+    isHighlighted
+      ? "bg-sidebar-accent text-accent-foreground border-primary/20"
+      : isActive || isAnySubItemActive
+        ? "bg-sidebar-accent text-primary border-primary/20"
+        : item.hasAccess
+          ? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
+          : "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
+  } `;
 
   const innerContent = (
     <div className="flex w-full items-center justify-between">
@@ -317,19 +328,31 @@ const SidebarItemView = ({
     );
   } else if (!item.hasAccess) {
     menuButton = (
-      <SidebarMenuButton tooltip={item.title} data-nav-url={item.url} className={buttonClassName}>
+      <SidebarMenuButton
+        tooltip={item.title}
+        data-nav-url={item.url}
+        className={buttonClassName}
+      >
         {innerContent}
       </SidebarMenuButton>
     );
   } else if (isExternal) {
     menuButton = (
-      <SidebarMenuButton asChild tooltip={item.title} className={buttonClassName}>
+      <SidebarMenuButton
+        asChild
+        tooltip={item.title}
+        className={buttonClassName}
+      >
         <a
           href={item.url}
           target="_blank"
           rel="noopener noreferrer"
           data-nav-url={item.url}
-          onClick={isSidebarCollapsed ? (e: React.MouseEvent) => e.stopPropagation() : undefined}
+          onClick={
+            isSidebarCollapsed
+              ? (e: React.MouseEvent) => e.stopPropagation()
+              : undefined
+          }
         >
           {innerContent}
         </a>
@@ -337,12 +360,20 @@ const SidebarItemView = ({
     );
   } else {
     menuButton = (
-      <SidebarMenuButton asChild tooltip={item.title} className={buttonClassName}>
+      <SidebarMenuButton
+        asChild
+        tooltip={item.title}
+        className={buttonClassName}
+      >
         <Link
           to={item.url as any}
           preload="intent"
           data-nav-url={item.url}
-          onClick={isSidebarCollapsed ? (e: React.MouseEvent) => e.stopPropagation() : undefined}
+          onClick={
+            isSidebarCollapsed
+              ? (e: React.MouseEvent) => e.stopPropagation()
+              : undefined
+          }
         >
           {innerContent}
         </Link>
@@ -354,8 +385,14 @@ const SidebarItemView = ({
     <SidebarMenuItem key={item.title}>
       {isSidebarCollapsed && hasSubItems ? (
         <Popover open={flyoutOpen} onOpenChange={setFlyoutOpen}>
-          <PopoverTrigger asChild onMouseEnter={openFlyout} onMouseLeave={closeFlyout}>
-            <div data-testid={`sidebar-flyout-trigger-${slug(item.title)}`}>{menuButton}</div>
+          <PopoverTrigger
+            asChild
+            onMouseEnter={openFlyout}
+            onMouseLeave={closeFlyout}
+          >
+            <div data-testid={`sidebar-flyout-trigger-${slug(item.title)}`}>
+              {menuButton}
+            </div>
           </PopoverTrigger>
           <PopoverContent
             side="right"
@@ -389,7 +426,10 @@ const SidebarItemView = ({
                     {subItem.title}
                   </span>
                   {subItem.tag && (
-                    <Badge variant="secondary" className="text-muted-foreground ml-auto text-xs">
+                    <Badge
+                      variant="secondary"
+                      className="text-muted-foreground ml-auto text-xs"
+                    >
                       {subItem.tag}
                     </Badge>
                   )}
@@ -431,7 +471,10 @@ const SidebarItemView = ({
           {item.subItems?.map((subItem: SidebarItem) => {
             const baseHref = getSidebarItemHref(subItem);
             const subItemHref = (() => {
-              if (TIME_FILTER_PAGES.has(subItem.url) && TIME_FILTER_PAGES.has(pathname)) {
+              if (
+                TIME_FILTER_PAGES.has(subItem.url) &&
+                TIME_FILTER_PAGES.has(pathname)
+              ) {
                 const currentParams = new URLSearchParams(search);
                 const startTime = currentParams.get("start_time");
                 const endTime = currentParams.get("end_time");
@@ -455,14 +498,15 @@ const SidebarItemView = ({
               ? subItemHref.startsWith(highlightedUrl)
               : false;
             const SubItemIcon = subItem.icon;
-            const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${isSubItemHighlighted
-              ? "bg-sidebar-accent text-accent-foreground"
-              : isSubItemActive
-                ? "bg-sidebar-accent text-primary font-medium"
-                : subItem.hasAccess === false
-                  ? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-                  : "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
-              }`;
+            const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${
+              isSubItemHighlighted
+                ? "bg-sidebar-accent text-accent-foreground"
+                : isSubItemActive
+                  ? "bg-sidebar-accent text-primary font-medium"
+                  : subItem.hasAccess === false
+                    ? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
+                    : "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
+            }`;
             const subInner = (
               <div className="flex w-full items-center gap-2">
                 {SubItemIcon && (
@@ -470,11 +514,16 @@ const SidebarItemView = ({
                     className={`h-3.5 w-3.5 ${isSubItemActive ? "text-primary" : "text-muted-foreground"}`}
                   />
                 )}
-                <span className={`text-sm ${isSubItemActive ? "font-medium" : "font-normal"}`}>
+                <span
+                  className={`text-sm ${isSubItemActive ? "font-medium" : "font-normal"}`}
+                >
                   {subItem.title}
                 </span>
                 {subItem.tag && (
-                  <Badge variant="secondary" className="text-muted-foreground ml-auto text-xs">
+                  <Badge
+                    variant="secondary"
+                    className="text-muted-foreground ml-auto text-xs"
+                  >
                     {subItem.tag}
                   </Badge>
                 )}
@@ -483,12 +532,19 @@ const SidebarItemView = ({
             return (
               <SidebarMenuSubItem key={subItem.title}>
                 {subItem.hasAccess === false ? (
-                  <SidebarMenuSubButton data-nav-url={subItemHref} className={subItemClassName}>
+                  <SidebarMenuSubButton
+                    data-nav-url={subItemHref}
+                    className={subItemClassName}
+                  >
                     {subInner}
                   </SidebarMenuSubButton>
                 ) : (
                   <SidebarMenuSubButton asChild className={subItemClassName}>
-                    <Link to={subItemHref as any} preload="intent" data-nav-url={subItemHref}>
+                    <Link
+                      to={subItemHref as any}
+                      preload="intent"
+                      data-nav-url={subItemHref}
+                    >
                       {subInner}
                     </Link>
                   </SidebarMenuSubButton>
@@ -547,7 +603,10 @@ export default function AppSidebar() {
   const tsNavigate = useNavigate();
   // Wrapper that accepts arbitrary string URLs (TanStack Router's `to` is
   // strictly typed, but our sidebar items come from a runtime config).
-  const navigate = useCallback((url: string) => tsNavigate({ to: url as string }), [tsNavigate]);
+  const navigate = useCallback(
+    (url: string) => tsNavigate({ to: url as string }),
+    [tsNavigate],
+  );
   const [mounted, setMounted] = useState(false);
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
   const [areCardsEmpty, setAreCardsEmpty] = useState(false);
@@ -556,35 +615,81 @@ export default function AppSidebar() {
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [cookies, setCookie] = useCookies([PRODUCTION_SETUP_DISMISSED_COOKIE]);
-  const isProductionSetupDismissed = !!cookies[PRODUCTION_SETUP_DISMISSED_COOKIE];
+  const isProductionSetupDismissed =
+    !!cookies[PRODUCTION_SETUP_DISMISSED_COOKIE];
   const { data: latestRelease } = useGetLatestReleaseQuery(undefined, {
     skip: !mounted, // Only fetch after component is mounted
   });
   const hasLogsAccess = useRbac(RbacResource.Logs, RbacOperation.View);
-  const hasObservabilityAccess = useRbac(RbacResource.Observability, RbacOperation.View);
-  const hasModelProvidersAccess = useRbac(RbacResource.ModelProvider, RbacOperation.View);
-  const hasMCPGatewayAccess = useRbac(RbacResource.MCPGateway, RbacOperation.View);
+  const hasObservabilityAccess = useRbac(
+    RbacResource.Observability,
+    RbacOperation.View,
+  );
+  const hasModelProvidersAccess = useRbac(
+    RbacResource.ModelProvider,
+    RbacOperation.View,
+  );
+  const hasMCPGatewayAccess = useRbac(
+    RbacResource.MCPGateway,
+    RbacOperation.View,
+  );
   const hasPluginsAccess = useRbac(RbacResource.Plugins, RbacOperation.View);
   const hasUsersAccess = useRbac(RbacResource.Users, RbacOperation.View);
-  const hasUserProvisioningAccess = useRbac(RbacResource.UserProvisioning, RbacOperation.View);
-  const hasAuditLogsAccess = useRbac(RbacResource.AuditLogs, RbacOperation.View);
-  const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
+  const hasUserProvisioningAccess = useRbac(
+    RbacResource.UserProvisioning,
+    RbacOperation.View,
+  );
+  const hasAuditLogsAccess = useRbac(
+    RbacResource.AuditLogs,
+    RbacOperation.View,
+  );
+  const hasCustomersAccess = useRbac(
+    RbacResource.Customers,
+    RbacOperation.View,
+  );
   const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
-  const hasBusinessUnitsAccess = useRbac(RbacResource.UserProvisioning, RbacOperation.View);
+  const hasBusinessUnitsAccess = useRbac(
+    RbacResource.UserProvisioning,
+    RbacOperation.View,
+  );
   const hasRbacAccess = useRbac(RbacResource.RBAC, RbacOperation.View);
-  const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
-  const hasGovernanceLegacyAccess = useRbac(RbacResource.Governance, RbacOperation.View);
-  const hasRoutingRulesAccess = useRbac(RbacResource.RoutingRules, RbacOperation.View);
+  const hasVirtualKeysAccess = useRbac(
+    RbacResource.VirtualKeys,
+    RbacOperation.View,
+  );
+  const hasGovernanceLegacyAccess = useRbac(
+    RbacResource.Governance,
+    RbacOperation.View,
+  );
+  const hasRoutingRulesAccess = useRbac(
+    RbacResource.RoutingRules,
+    RbacOperation.View,
+  );
   const hasGuardrailsProvidersAccess = useRbac(
     RbacResource.GuardrailsProviders,
     RbacOperation.View,
   );
-  const hasGuardrailsConfigAccess = useRbac(RbacResource.GuardrailsConfig, RbacOperation.View);
-  const hasClusterConfigAccess = useRbac(RbacResource.Cluster, RbacOperation.View);
-  const isAdaptiveRoutingAllowed = useRbac(RbacResource.AdaptiveRouter, RbacOperation.View);
+  const hasGuardrailsConfigAccess = useRbac(
+    RbacResource.GuardrailsConfig,
+    RbacOperation.View,
+  );
+  const hasClusterConfigAccess = useRbac(
+    RbacResource.Cluster,
+    RbacOperation.View,
+  );
+  const isAdaptiveRoutingAllowed = useRbac(
+    RbacResource.AdaptiveRouter,
+    RbacOperation.View,
+  );
   const hasSettingsAccess = useRbac(RbacResource.Settings, RbacOperation.View);
-  const hasPromptRepositoryAccess = useRbac(RbacResource.PromptRepository, RbacOperation.View);
-  const hasAccessProfilesAccess = useRbac(RbacResource.AccessProfiles, RbacOperation.View);
+  const hasPromptRepositoryAccess = useRbac(
+    RbacResource.PromptRepository,
+    RbacOperation.View,
+  );
+  const hasAccessProfilesAccess = useRbac(
+    RbacResource.AccessProfiles,
+    RbacOperation.View,
+  );
   const hasAnyGovernanceAccess =
     hasVirtualKeysAccess ||
     hasTeamsAccess ||
@@ -842,14 +947,14 @@ export default function AppSidebar() {
       },
       ...(isDbConnected
         ? [
-          {
-            title: "Prompt Repository",
-            url: "/workspace/prompt-repo",
-            icon: FolderGit,
-            description: "Prompt repository",
-            hasAccess: hasPromptRepositoryAccess,
-          },
-        ]
+            {
+              title: "Prompt Repository",
+              url: "/workspace/prompt-repo",
+              icon: FolderGit,
+              description: "Prompt repository",
+              hasAccess: hasPromptRepositoryAccess,
+            },
+          ]
         : []),
       {
         title: "Evals",
@@ -864,7 +969,8 @@ export default function AppSidebar() {
         url: "/workspace/config",
         icon: Settings2Icon,
         description: "Bifrost settings",
-        hasAccess: hasSettingsAccess || hasAuditLogsAccess || hasUserProvisioningAccess,
+        hasAccess:
+          hasSettingsAccess || hasAuditLogsAccess || hasUserProvisioningAccess,
         subItems: [
           {
             title: "Client Settings",
@@ -896,14 +1002,14 @@ export default function AppSidebar() {
           },
           ...(IS_ENTERPRISE
             ? [
-              {
-                title: "Proxy",
-                url: "/workspace/config/proxy",
-                icon: Globe,
-                description: "Proxy configuration",
-                hasAccess: hasSettingsAccess,
-              },
-            ]
+                {
+                  title: "Proxy",
+                  url: "/workspace/config/proxy",
+                  icon: Globe,
+                  description: "Proxy configuration",
+                  hasAccess: hasSettingsAccess,
+                },
+              ]
             : []),
           {
             title: "API Keys",
@@ -1025,7 +1131,9 @@ export default function AppSidebar() {
       if (!item.subItems?.length) return;
       const parentMatches = item.title.toLowerCase().includes(query);
       if (parentMatches) return;
-      const hasMatchingChild = item.subItems.some((sub) => sub.title.toLowerCase().includes(query));
+      const hasMatchingChild = item.subItems.some((sub) =>
+        sub.title.toLowerCase().includes(query),
+      );
       if (hasMatchingChild) {
         toExpand.add(item.title);
       }
@@ -1061,7 +1169,8 @@ export default function AppSidebar() {
     }[] = [];
     for (const item of filteredItems) {
       if (item.isExternal) {
-        if (item.hasAccess) result.push({ title: item.title, url: item.url, isExternal: true });
+        if (item.hasAccess)
+          result.push({ title: item.title, url: item.url, isExternal: true });
         continue;
       }
       const hasSubItems = item.subItems && item.subItems.length > 0;
@@ -1091,7 +1200,9 @@ export default function AppSidebar() {
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        setFocusedIndex((prev) => Math.min(prev + 1, navigableItems.length - 1));
+        setFocusedIndex((prev) =>
+          Math.min(prev + 1, navigableItems.length - 1),
+        );
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         setFocusedIndex((prev) => Math.max(prev - 1, 0));
@@ -1146,7 +1257,10 @@ export default function AppSidebar() {
     // Avoid double-highlighting with "/workspace/custom-pricing/overrides"
     if (url === "/workspace/custom-pricing") return pathname === url;
     if (url !== "/" && pathname.startsWith(url)) {
-      if (url === "/workspace/config" && configExceptions.some((e) => pathname.startsWith(e))) {
+      if (
+        url === "/workspace/config" &&
+        configExceptions.some((e) => pathname.startsWith(e))
+      ) {
         return false;
       }
       return true;
@@ -1156,9 +1270,13 @@ export default function AppSidebar() {
 
   // Always render the light theme version for SSR to avoid hydration mismatch
   const logoSrc =
-    mounted && resolvedTheme === "dark" ? "/bifrost-logo-dark.webp" : "/bifrost-logo.webp";
+    mounted && resolvedTheme === "dark"
+      ? "/bifrost-logo-dark.webp"
+      : "/bifrost-logo.webp";
   const iconSrc =
-    mounted && resolvedTheme === "dark" ? "/bifrost-icon-dark.webp" : "/bifrost-icon.webp";
+    mounted && resolvedTheme === "dark"
+      ? "/bifrost-icon-dark.webp"
+      : "/bifrost-icon.webp";
 
   const { isConnected: isWebSocketConnected } = useWebSocket();
 
@@ -1192,7 +1310,11 @@ export default function AppSidebar() {
         title: `${latestRelease.name} is now available.`,
         description: (
           <div className="flex h-full flex-col gap-2">
-            <img src={newReleaseImage} alt="Bifrost" className="h-[95px] rounded-md object-cover" />
+            <img
+              src={newReleaseImage}
+              alt="Bifrost"
+              className="h-[95px] rounded-md object-cover"
+            />
             <a
               href={`https://docs.getbifrost.ai/changelogs/${latestRelease.name}`}
               target="_blank"
@@ -1230,7 +1352,9 @@ export default function AppSidebar() {
   const hasPromoCards = promoCards.length > 0 && !areCardsEmpty;
   // When cards are present: 13rem (header 3rem + bottom section ~10rem)
   // When no cards: 8rem (header 3rem + bottom section without cards ~5rem)
-  const sidebarGroupHeight = hasPromoCards ? "h-[calc(100vh-13rem)]" : "h-[calc(100vh-8rem)]";
+  const sidebarGroupHeight = hasPromoCards
+    ? "h-[calc(100vh-13rem)]"
+    : "h-[calc(100vh-8rem)]";
 
   const handleCardsEmpty = () => {
     setAreCardsEmpty(true);
@@ -1264,12 +1388,24 @@ export default function AppSidebar() {
   const { state: sidebarState, toggleSidebar } = useSidebar();
 
   return (
-    <Sidebar collapsible="icon" className="overflow-y-clip border-none bg-transparent">
+    <Sidebar
+      collapsible="icon"
+      className="overflow-y-clip border-none bg-transparent"
+    >
       <SidebarHeader className="mt-1 ml-2 flex justify-between px-0 group-data-[collapsible=icon]:ml-0 group-data-[collapsible=icon]:h-auto">
         {/* Expanded state: horizontal layout */}
         <div className="flex h-10 w-full items-center justify-between px-1.5 group-data-[collapsible=icon]:hidden">
-          <Link to="/workspace/logs" className="group flex items-center gap-2 pl-2">
-            <img className="h-[22px] w-auto" src={logoSrc} alt="Bifrost" width={70} height={70} />
+          <Link
+            to="/workspace/logs"
+            className="group flex items-center gap-2 pl-2"
+          >
+            <img
+              className="h-[22px] w-auto"
+              src={logoSrc}
+              alt="Bifrost"
+              width={70}
+              height={70}
+            />
           </Link>
           <button
             onClick={toggleSidebar}
@@ -1313,20 +1449,28 @@ export default function AppSidebar() {
             className="border-input text-foreground placeholder:text-shadow-muted-foreground focus:ring-ring h-8 w-full rounded-sm border bg-transparent pr-14 pl-8 text-sm outline-none focus:bg-transparent"
           />
           <kbd className="text-muted-foreground pointer-events-none absolute top-1/2 right-2 flex -translate-y-1/2 gap-0.5 text-[10px]">
-            <span className="border-border bg-muted rounded-sm px-1 font-mono shadow-sm">⌘</span>
-            <span className="border-border bg-muted rounded-sm px-1 font-mono shadow-sm">K</span>
+            <span className="border-border bg-muted rounded-sm px-1 font-mono shadow-sm">
+              ⌘
+            </span>
+            <span className="border-border bg-muted rounded-sm px-1 font-mono shadow-sm">
+              K
+            </span>
           </kbd>
         </div>
       </div>
       <SidebarContent className="overflow-hidden pb-4">
-        <SidebarGroup className={`custom-scrollbar ${sidebarGroupHeight} overflow-scroll`}>
+        <SidebarGroup
+          className={`custom-scrollbar ${sidebarGroupHeight} overflow-scroll`}
+        >
           <SidebarGroupContent>
             <SidebarMenu className="space-y-0.5">
               {filteredItems.map((item) => {
                 const isActive = isActiveRoute(item.url);
 
                 const highlightedUrl =
-                  focusedIndex >= 0 ? navigableItems[focusedIndex]?.url : undefined;
+                  focusedIndex >= 0
+                    ? navigableItems[focusedIndex]?.url
+                    : undefined;
                 return (
                   <SidebarItemView
                     key={item.title}
@@ -1377,8 +1521,13 @@ export default function AppSidebar() {
                 </a>
               ))}
               <ThemeToggle />
-              {IS_ENTERPRISE && userInfo && (userInfo.name || userInfo.email) ? (
-                <Popover open={userPopoverOpen} onOpenChange={setUserPopoverOpen}>
+              {IS_ENTERPRISE &&
+              userInfo &&
+              (userInfo.name || userInfo.email) ? (
+                <Popover
+                  open={userPopoverOpen}
+                  onOpenChange={setUserPopoverOpen}
+                >
                   <PopoverTrigger asChild>
                     <button
                       className="hover:text-primary text-muted-foreground flex cursor-pointer items-center space-x-3 p-0.5"


### PR DESCRIPTION
## Summary

Improves documentation accuracy for the Entra and Okta SSO integration guides, adds clarity around the Okta Org vs. Custom Authorization Server distinction, bumps `hono` to 4.12.16 across example MCP servers, and applies formatting/layout fixes to the UI sidebar and Teams page.

## Changes

- **Entra docs**: Removed `AppRoleAssignment.ReadWrite.All` as a required permission; clarified that `Application.Read.All` is used for verifying the Enterprise Application service principal and provisioning. Updated the permissions warning to be more general. Replaced the note about bulk sync permissions with a note explaining that provisioning is scoped to Enterprise Application assignments. Added a new note and tip in Step 7 clarifying that Bifrost uses the **Users and groups** assignment list as the provisioning source of truth, and that `groups` mappings must use Entra Object IDs (not display names). Added a new troubleshooting section for "Verify or import finds no users when only groups are assigned."
- **Okta docs**: Added a dedicated "Choose your Authorization Server" section explaining the difference between Org and Custom Authorization Servers, including a comparison table and a warning about the common misconfiguration of placing the `groups` claim in the wrong location. Split the "Add Groups Claim to Tokens" step into separate instructions for Custom and Org Authorization Servers. Added a new `authServerType` field to the configuration reference, corrected `clientSecret` and `audience` to be optional for Org Authorization Server, and updated the `issuerUrl` description. Added troubleshooting entries for missing `groups` claim and for the 1.4.0 migration backfill behavior.
- **Release cadence docs**: Clarified patch release frequency to "Every 2 - 3 days (depending on reports)."
- **`hono` bump**: Updated `hono` from 4.12.14 to 4.12.16 in all example MCP server packages.
- **Python test deps**: Added `python-multipart>=0.0.27` as a `uv` override dependency.
- **UI – Teams page**: Wrapped `TeamsView` in a constrained, full-height container (`max-w-7xl`, `h-[calc(100dvh-50px)]`).
- **UI – Sidebar**: Reformatted long lines and ternary expressions for readability; no behavioral changes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

1. Review the Entra setup guide and confirm the permissions table and troubleshooting sections are accurate for a tenant using only `Application.Read.All`.
2. Review the Okta setup guide and confirm the Org vs. Custom Authorization Server table and `groups` claim instructions are correct for both server types.
3. Verify the Teams page renders correctly and is constrained within the new container dimensions.
4. Confirm example MCP servers resolve `hono@4.12.16` without errors:

```sh
cd examples/mcps/edge-case-server && npm install
cd examples/mcps/error-test-server && npm install
cd examples/mcps/parallel-test-server && npm install
cd examples/mcps/temperature && npm install
cd examples/mcps/test-tools-server && npm install
```

```sh
cd ui
pnpm i
pnpm build
```

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

The removal of `AppRoleAssignment.ReadWrite.All` from the required Entra permissions reduces the scope of Graph API access requested by Bifrost Enterprise. Operators upgrading should review their existing app registrations and remove the permission if it was previously granted solely for bulk sync purposes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable