### PR TITLE
[fix]: align Docker volume with app directory

### DIFF
--- a/docs/plugins/building-dynamic-binary.mdx
+++ b/docs/plugins/building-dynamic-binary.mdx
@@ -171,14 +171,14 @@ ENV APP_PORT=$ARG_APP_PORT \
     LOG_STYLE=$ARG_LOG_STYLE \
     APP_DIR=$ARG_APP_DIR
 
-RUN mkdir -p $APP_DIR/logs && \
+RUN mkdir -p "$APP_DIR/logs" && \
     adduser -D -s /bin/sh appuser && \
-    chown -R appuser:appuser /app && \
+    chown -R appuser:appuser /app "$APP_DIR" && \
     chmod +x /app/docker-entrypoint.sh
 USER appuser
 
 # Declare volume for data persistence
-VOLUME ["/app/data"]
+VOLUME ["${APP_DIR}"]
 EXPOSE $APP_PORT
 
 # Health check for container status monitoring
@@ -293,14 +293,14 @@ ENV APP_PORT=$ARG_APP_PORT \
     LOG_STYLE=$ARG_LOG_STYLE \
     APP_DIR=$ARG_APP_DIR
 
-RUN mkdir -p $APP_DIR/logs && \
+RUN mkdir -p "$APP_DIR/logs" && \
     useradd -m -s /bin/sh appuser && \
-    chown -R appuser:appuser /app && \
+    chown -R appuser:appuser /app "$APP_DIR" && \
     chmod +x /app/docker-entrypoint.sh
 USER appuser
 
 # Declare volume for data persistence
-VOLUME ["/app/data"]
+VOLUME ["${APP_DIR}"]
 EXPOSE $APP_PORT
 
 # Health check for container status monitoring
@@ -702,4 +702,3 @@ Now that you have a dynamically linked Bifrost binary:
 <Note>
 For questions or issues with dynamic builds and plugins, visit our [GitHub Discussions](https://github.com/maximhq/bifrost/discussions) or [Discord community](https://discord.gg/exN5KAydbU).
 </Note>
-

--- a/docs/plugins/building-dynamic-binary.mdx
+++ b/docs/plugins/building-dynamic-binary.mdx
@@ -173,7 +173,8 @@ ENV APP_PORT=$ARG_APP_PORT \
 
 RUN mkdir -p "$APP_DIR/logs" && \
     adduser -D -s /bin/sh appuser && \
-    chown -R appuser:appuser /app "$APP_DIR" && \
+    chown -R appuser:appuser /app && \
+    { [ "$APP_DIR" = "/app" ] || [ "${APP_DIR#/app/}" != "$APP_DIR" ] || chown -R appuser:appuser "$APP_DIR"; } && \
     chmod +x /app/docker-entrypoint.sh
 USER appuser
 
@@ -295,7 +296,8 @@ ENV APP_PORT=$ARG_APP_PORT \
 
 RUN mkdir -p "$APP_DIR/logs" && \
     useradd -m -s /bin/sh appuser && \
-    chown -R appuser:appuser /app "$APP_DIR" && \
+    chown -R appuser:appuser /app && \
+    { [ "$APP_DIR" = "/app" ] || [ "${APP_DIR#/app/}" != "$APP_DIR" ] || chown -R appuser:appuser "$APP_DIR"; } && \
     chmod +x /app/docker-entrypoint.sh
 USER appuser
 

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -92,7 +92,8 @@
   
   RUN mkdir -p "$APP_DIR/logs" && \
     adduser -D -s /bin/sh appuser && \
-    chown -R appuser:appuser /app "$APP_DIR" && \
+    chown -R appuser:appuser /app && \
+    { [ "$APP_DIR" = "/app" ] || [ "${APP_DIR#/app/}" != "$APP_DIR" ] || chown -R appuser:appuser "$APP_DIR"; } && \
     chmod +x /app/docker-entrypoint.sh
   USER appuser
   

--- a/transports/Dockerfile
+++ b/transports/Dockerfile
@@ -90,15 +90,15 @@
     GOMEMLIMIT=""
   
   
-  RUN mkdir -p $APP_DIR/logs && \
+  RUN mkdir -p "$APP_DIR/logs" && \
     adduser -D -s /bin/sh appuser && \
-    chown -R appuser:appuser /app && \
+    chown -R appuser:appuser /app "$APP_DIR" && \
     chmod +x /app/docker-entrypoint.sh
   USER appuser
   
   
   # Declare volume for data persistence
-  VOLUME ["/app/data"]
+  VOLUME ["${APP_DIR}"]
   EXPOSE $APP_PORT
   
   # Health check for container status monitoring

--- a/transports/Dockerfile.local
+++ b/transports/Dockerfile.local
@@ -93,15 +93,15 @@
     APP_DIR=$ARG_APP_DIR
 
 
-  RUN mkdir -p $APP_DIR/logs && \
+  RUN mkdir -p "$APP_DIR/logs" && \
     adduser -D -s /bin/sh appuser && \
-    chown -R appuser:appuser /app && \
+    chown -R appuser:appuser /app "$APP_DIR" && \
     chmod +x /app/docker-entrypoint.sh
   USER appuser
 
 
   # Declare volume for data persistence
-  VOLUME ["/app/data"]
+  VOLUME ["${APP_DIR}"]
   EXPOSE $APP_PORT
 
   # Health check for container status monitoring

--- a/transports/Dockerfile.local
+++ b/transports/Dockerfile.local
@@ -95,7 +95,8 @@
 
   RUN mkdir -p "$APP_DIR/logs" && \
     adduser -D -s /bin/sh appuser && \
-    chown -R appuser:appuser /app "$APP_DIR" && \
+    chown -R appuser:appuser /app && \
+    { [ "$APP_DIR" = "/app" ] || [ "${APP_DIR#/app/}" != "$APP_DIR" ] || chown -R appuser:appuser "$APP_DIR"; } && \
     chmod +x /app/docker-entrypoint.sh
   USER appuser
 

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+[fix]: align Docker volume with configured app directory [@EzgiTastan](https://github.com/EzgiTastan)

--- a/transports/docker-entrypoint.sh
+++ b/transports/docker-entrypoint.sh
@@ -5,6 +5,9 @@ APP_DIR=${APP_DIR:-/app/data}
 
 # Function to fix permissions on mounted volumes
 fix_permissions() {
+    # Ensure runtime APP_DIR overrides exist before ownership checks
+    mkdir -p "$APP_DIR" 2>/dev/null || true
+
     # Check if APP_DIR exists and fix ownership if needed
     if [ -d "$APP_DIR" ]; then
         # Get current user info

--- a/transports/docker-entrypoint.sh
+++ b/transports/docker-entrypoint.sh
@@ -1,35 +1,37 @@
 #!/bin/sh
 set -e
 
+APP_DIR=${APP_DIR:-/app/data}
+
 # Function to fix permissions on mounted volumes
 fix_permissions() {
-    # Check if /app/data exists and fix ownership if needed
-    if [ -d "/app/data" ]; then
+    # Check if APP_DIR exists and fix ownership if needed
+    if [ -d "$APP_DIR" ]; then
         # Get current user info
         CURRENT_UID=$(id -u)
         CURRENT_GID=$(id -g)
         
         # Get directory ownership
-        DATA_UID=$(stat -c '%u' /app/data 2>/dev/null || echo "0")
-        DATA_GID=$(stat -c '%g' /app/data 2>/dev/null || echo "0")
+        DATA_UID=$(stat -c '%u' "$APP_DIR" 2>/dev/null || echo "0")
+        DATA_GID=$(stat -c '%g' "$APP_DIR" 2>/dev/null || echo "0")
         
         # If ownership doesn't match current user, try to fix it
         if [ "$DATA_UID" != "$CURRENT_UID" ] || [ "$DATA_GID" != "$CURRENT_GID" ]; then
-            echo "Fixing permissions on /app/data (was $DATA_UID:$DATA_GID, setting to $CURRENT_UID:$CURRENT_GID)"
+            echo "Fixing permissions on $APP_DIR (was $DATA_UID:$DATA_GID, setting to $CURRENT_UID:$CURRENT_GID)"
             
             # Try to change ownership (will work if running as root or if user has permission)
-            if chown -R "$CURRENT_UID:$CURRENT_GID" /app/data 2>/dev/null; then
-                echo "Successfully updated permissions on /app/data"
+            if chown -R "$CURRENT_UID:$CURRENT_GID" "$APP_DIR" 2>/dev/null; then
+                echo "Successfully updated permissions on $APP_DIR"
             else
-                echo "Warning: Could not change ownership of /app/data. You may need to run:"
+                echo "Warning: Could not change ownership of $APP_DIR. You may need to run:"
                 echo "  docker run --user \$(id -u):\$(id -g) ..."
                 echo "  or ensure the host directory is owned by UID:GID $CURRENT_UID:$CURRENT_GID"
             fi
         fi
         
         # Ensure logs subdirectory exists with correct permissions
-        mkdir -p /app/data/logs
-        chmod 755 /app/data/logs 2>/dev/null || true
+        mkdir -p "$APP_DIR/logs"
+        chmod 755 "$APP_DIR/logs" 2>/dev/null || true
     fi
 }
 


### PR DESCRIPTION
 ## Summary
  Fix Docker image persistence when ARG_APP_DIR is set to a non-default path.

  ## Changes
  - Align Docker VOLUME, directory ownership, and entrypoint paths with APP_DIR.
  - Update dynamic binary Dockerfile examples.

  ## Type of change
  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [x] Documentation
  - [ ] Chore/CI

  ## Affected areas
  - [ ] Core (Go)
  - [x] Transports (HTTP)
  - [ ] Providers/Integrations
  - [ ] Plugins
  - [ ] UI (React)
  - [x] Docs

  ## How to test
  - `git diff --check upstream/main...HEAD`
  - `sh -n transports/docker-entrypoint.sh`
  - `docker build --check -f transports/Dockerfile .`
  - `docker build --check -f transports/Dockerfile.local .`
  - Built both Dockerfiles with ARG_APP_DIR=/data; image volume was {"/data":{}}; write probe
  returned ok.

  ## Breaking changes
  - [ ] Yes
  - [x] No

  ## Related issues
  Fixes #2620
  Refs #2621

  ## Security considerations
  No auth, secret, or PII changes.