### PR TITLE
fix: always include tokenCount in Gemini modality usage details

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -2993,11 +2993,12 @@ func TestGenAIUsageMetadata_IncludesZeroTokenCountInModalityDetails(t *testing.T
 	bifrostResp := &schemas.BifrostResponsesResponse{
 		Model: "google/gemini-2.5-flash",
 		Usage: &schemas.ResponsesResponseUsage{
-			InputTokens:  2,
+			InputTokens:  0,
 			OutputTokens: 0,
-			TotalTokens:  2,
+			TotalTokens:  0,
 			InputTokensDetails: &schemas.ResponsesResponseInputTokens{
-				TextTokens: 2,
+				TextTokens:  0,
+				AudioTokens: 0,
 			},
 			OutputTokensDetails: &schemas.ResponsesResponseOutputTokens{
 				TextTokens: 0,
@@ -3028,6 +3029,19 @@ func TestGenAIUsageMetadata_IncludesZeroTokenCountInModalityDetails(t *testing.T
 	tokenCount, exists := firstDetail["tokenCount"]
 	require.True(t, exists, "tokenCount should be present even when zero")
 	assert.Equal(t, float64(0), tokenCount)
+
+	promptTokensDetails, ok := usageMetadata["promptTokensDetails"].([]any)
+	require.True(t, ok, "promptTokensDetails should be present")
+	require.NotEmpty(t, promptTokensDetails, "promptTokensDetails should not be empty")
+
+	for i, detail := range promptTokensDetails {
+		detailObj, ok := detail.(map[string]any)
+		require.True(t, ok, "promptTokensDetails entry %d should be an object", i)
+
+		promptTokenCount, exists := detailObj["tokenCount"]
+		require.True(t, exists, "promptTokensDetails entry %d should include tokenCount", i)
+		assert.Equal(t, float64(0), promptTokenCount)
+	}
 }
 
 // TestFunctionCallingConfigModeAny_RoundTrip verifies that FunctionCallingConfigMode.ANY and

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -2987,6 +2987,49 @@ func TestGenAIFinishReasonMaxTokens_PersistsThroughBifrostRoundTrip(t *testing.T
 	assert.Equal(t, gemini.FinishReasonMaxTokens, out.Candidates[0].FinishReason)
 }
 
+// Regression: GenAI usageMetadata modality details must include tokenCount even when zero.
+// Some clients (e.g. @ai-sdk/google) validate tokenCount as required and reject missing fields.
+func TestGenAIUsageMetadata_IncludesZeroTokenCountInModalityDetails(t *testing.T) {
+	bifrostResp := &schemas.BifrostResponsesResponse{
+		Model: "google/gemini-2.5-flash",
+		Usage: &schemas.ResponsesResponseUsage{
+			InputTokens:  2,
+			OutputTokens: 0,
+			TotalTokens:  2,
+			InputTokensDetails: &schemas.ResponsesResponseInputTokens{
+				TextTokens: 2,
+			},
+			OutputTokensDetails: &schemas.ResponsesResponseOutputTokens{
+				TextTokens: 0,
+			},``
+		},
+	}
+
+	out := gemini.ToGeminiResponsesResponse(bifrostResp)
+	require.NotNil(t, out)
+	require.NotNil(t, out.UsageMetadata)
+
+	encoded, err := json.Marshal(out)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(encoded, &payload))
+
+	usageMetadata, ok := payload["usageMetadata"].(map[string]any)
+	require.True(t, ok, "usageMetadata should be present")
+
+	candidatesTokensDetails, ok := usageMetadata["candidatesTokensDetails"].([]any)
+	require.True(t, ok, "candidatesTokensDetails should be present")
+	require.NotEmpty(t, candidatesTokensDetails, "candidatesTokensDetails should not be empty")
+
+	firstDetail, ok := candidatesTokensDetails[0].(map[string]any)
+	require.True(t, ok, "first candidatesTokensDetails entry should be an object")
+
+	tokenCount, exists := firstDetail["tokenCount"]
+	require.True(t, exists, "tokenCount should be present even when zero")
+	assert.Equal(t, float64(0), tokenCount)
+}
+
 // TestFunctionCallingConfigModeAny_RoundTrip verifies that FunctionCallingConfigMode.ANY and
 // AllowedFunctionNames survive the Gemini→Bifrost→Gemini round-trip on the GenAI passthrough path.
 // Regression: ANY was silently downgraded to AUTO (missing case in convertGeminiToolConfigToToolChoice)

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -3001,7 +3001,7 @@ func TestGenAIUsageMetadata_IncludesZeroTokenCountInModalityDetails(t *testing.T
 			},
 			OutputTokensDetails: &schemas.ResponsesResponseOutputTokens{
 				TextTokens: 0,
-			},``
+			},
 		},
 	}
 

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -1870,7 +1870,7 @@ type ModalityTokenCount struct {
 	// Optional. The modality associated with this token count.
 	Modality Modality `json:"modality,omitempty"`
 	// Number of tokens.
-	TokenCount int32 `json:"tokenCount,omitempty"`
+	TokenCount int32 `json:"tokenCount"`
 }
 
 // GenerateContentResponseUsageMetadata represents usage metadata about response(s).


### PR DESCRIPTION
## Summary

This PR fixes Gemini GenAI response compatibility by ensuring `usageMetadata.*TokensDetails[].tokenCount` is always present in JSON, including when the value is `0`.

This resolves [#3300](https://github.com/maximhq/bifrost/issues/3300), where strict clients (e.g. `@ai-sdk/google`) reject responses when `tokenCount` is omitted.

## Investigation and reasoning path

This is how I traced the issue through the full request/response path:

1. Setup Bifrost with Gemini API keys to reproduce. 
2. Reproduced the runtime issue on `/genai/v1beta/models/{model}`.
3. Traced conversion flow in `core/providers/gemini/responses.go` to `ConvertBifrostResponsesUsageToGeminiUsageMetadata`.
4. Confirmed in `core/providers/gemini/utils.go` that modality detail objects are created even when token values are `0` (so object creation was not the issue, it's just that the type was omitting it because there was nothing to inlclude).
5. Identified serializer behavior in `core/providers/gemini/types.go`: `ModalityTokenCount.TokenCount` used `json:"tokenCount,omitempty"`, which drops zero values.
6. Reviewed git history for any explicit intent to omit `tokenCount` in the past. I didn't find any explicit reason to having `omitEmpty` for this.
7. Removed `omitempty` for `ModalityTokenCount.TokenCount`, and add a regression test to assert `tokenCount: 0` serialization.
8. Validated with unit tests, integration tests, and live endpoint checks.

## Changes

- Changed `ModalityTokenCount.TokenCount` in `core/providers/gemini/types.go`:
  - from `json:"tokenCount,omitempty"`
  - to `json:"tokenCount"`
- Added regression test `TestGenAIUsageMetadata_IncludesZeroTokenCountInModalityDetails` in `core/providers/gemini/gemini_test.go`.
- Verified behavior live against local GenAI endpoint (`:generateContent`) and through targeted test suites.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

1. Start Bifrost with a Gemini key configured.
2. Run this request:

```
curl -sS -X POST "http://localhost:8080/genai/v1beta/models/google/gemini-2.5-flash:generateContent" \
  -H "content-type: application/json" \
  -d '{"contents":[{"role":"user","parts":[{"text":"hi"}]}]}' \
  | jq '.usageMetadata.candidatesTokensDetails[0]'
```

To run the regressions test:
```
cd core
go test ./providers/gemini -run TestGenAIUsageMetadata_IncludesZeroTokenCountInModalityDetails -count=1
```

Expected outcomes:
- All test commands pass.
- Regression test confirms `tokenCount` is serialized even when zero.
- `usageMetadata.candidatesTokensDetails[0].tokenCount` is present (should be 0 in this repro path).

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Closes [#3300](https://github.com/maximhq/bifrost/issues/3300)

## Security considerations

This update only changes JSON serialization behavior for Gemini usage metadata token details. No expected security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


