### PR TITLE
Add MCP log detail endpoint

### DIFF
--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -979,6 +979,11 @@ func (p *LoggerPlugin) GetLog(ctx context.Context, id string) (*logstore.Log, er
 	return p.store.FindByID(ctx, id)
 }
 
+// GetMCPToolLog retrieves a single MCP tool log entry by ID.
+func (p *LoggerPlugin) GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error) {
+	return p.store.FindMCPToolLog(ctx, id)
+}
+
 // GetStats calculates statistics for logs matching the given filters
 func (p *LoggerPlugin) GetStats(ctx context.Context, filters logstore.SearchFilters) (*logstore.SearchStats, error) {
 	return p.store.GetStats(ctx, filters)

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -122,6 +122,9 @@ type LogManager interface {
 	RecalculateCosts(ctx context.Context, filters *logstore.SearchFilters, limit int) (*RecalculateCostResult, error)
 
 	// MCP Tool Log methods
+	// GetMCPToolLog retrieves a single MCP tool log entry by ID.
+	GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error)
+
 	// SearchMCPToolLogs searches for MCP tool log entries based on filters and pagination
 	SearchMCPToolLogs(ctx context.Context, filters *logstore.MCPToolLogSearchFilters, pagination *logstore.PaginationOptions) (*logstore.MCPToolLogSearchResult, error)
 
@@ -364,6 +367,17 @@ func (p *PluginLogManager) RecalculateCosts(ctx context.Context, filters *logsto
 		return nil, fmt.Errorf("filters cannot be nil")
 	}
 	return p.plugin.RecalculateCosts(ctx, *filters, limit)
+}
+
+// GetMCPToolLog retrieves a single MCP tool log entry by ID.
+func (p *PluginLogManager) GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error) {
+	if p.plugin == nil || p.plugin.store == nil {
+		return nil, fmt.Errorf("log store not initialized")
+	}
+	if strings.TrimSpace(id) == "" {
+		return nil, fmt.Errorf("id cannot be empty")
+	}
+	return p.plugin.GetMCPToolLog(ctx, id)
 }
 
 // SearchMCPToolLogs searches for MCP tool log entries based on filters and pagination

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -96,6 +96,7 @@ func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas
 	r.GET("/api/mcp-logs/histogram", lib.ChainMiddlewares(h.getMCPHistogram, middlewares...))
 	r.GET("/api/mcp-logs/histogram/cost", lib.ChainMiddlewares(h.getMCPCostHistogram, middlewares...))
 	r.GET("/api/mcp-logs/histogram/top-tools", lib.ChainMiddlewares(h.getMCPTopTools, middlewares...))
+	r.GET("/api/mcp-logs/{id}", lib.ChainMiddlewares(h.getMCPLogByID, middlewares...))
 	r.DELETE("/api/mcp-logs", lib.ChainMiddlewares(h.deleteMCPLogs, middlewares...))
 }
 
@@ -1554,6 +1555,32 @@ func (h *LoggingHandler) getMCPLogs(ctx *fasthttp.RequestCtx) {
 	}
 
 	SendJSON(ctx, result)
+}
+
+// getMCPLogByID handles GET /api/mcp-logs/{id} - Get a single MCP tool log entry by ID.
+func (h *LoggingHandler) getMCPLogByID(ctx *fasthttp.RequestCtx) {
+	id, ok := ctx.UserValue("id").(string)
+	if !ok || strings.TrimSpace(id) == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "MCP log id is required")
+		return
+	}
+
+	log, err := h.logManager.GetMCPToolLog(ctx, id)
+	if err != nil {
+		if errors.Is(err, logstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "MCP log not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get MCP log: %v", err))
+		return
+	}
+
+	if log.VirtualKeyID != nil && log.VirtualKeyName != nil && *log.VirtualKeyID != "" && *log.VirtualKeyName != "" {
+		redactedVirtualKeys := h.redactedKeysManager.GetAllRedactedVirtualKeys(ctx, []string{*log.VirtualKeyID})
+		log.VirtualKey = findRedactedVirtualKey(redactedVirtualKeys, *log.VirtualKeyID, *log.VirtualKeyName)
+	}
+
+	SendJSON(ctx, log)
 }
 
 // getMCPLogsStats handles GET /api/mcp-logs/stats - Get statistics for MCP tool logs with filtering


### PR DESCRIPTION
## Summary

Adds a new endpoint to retrieve a single MCP tool log entry by its ID, filling a gap where only list/search functionality existed for MCP tool logs.

## Changes

- Added `GET /api/mcp-logs/{id}` HTTP endpoint that returns a single MCP tool log entry
- Added `GetMCPToolLog` method to the `LogManager` interface and `PluginLogManager` implementation, with validation for empty IDs and uninitialized store
- Added `GetMCPToolLog` method to `LoggerPlugin` delegating to the underlying store's `FindMCPToolLog`
- The handler resolves and attaches redacted virtual key information to the response when a virtual key is associated with the log entry, consistent with how other log endpoints handle virtual key data
- Returns `404` when the log entry is not found and `400` when no ID is provided

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...

# Start the server and create an MCP tool log entry, then retrieve it by ID:
curl -X GET http://localhost:8080/api/mcp-logs/<id>

# Verify 404 is returned for a non-existent ID:
curl -X GET http://localhost:8080/api/mcp-logs/nonexistent-id

# Verify 400 is returned when ID is empty (route should not match, but validate via direct handler test)
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Virtual key values associated with MCP log entries are redacted before being returned in the response, consistent with the existing pattern used across other log endpoints.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable