### PR TITLE
Use MCP log detail endpoint in UI

### DIFF
--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -979,6 +979,11 @@ func (p *LoggerPlugin) GetLog(ctx context.Context, id string) (*logstore.Log, er
 	return p.store.FindByID(ctx, id)
 }
 
+// GetMCPToolLog retrieves a single MCP tool log entry by ID.
+func (p *LoggerPlugin) GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error) {
+	return p.store.FindMCPToolLog(ctx, id)
+}
+
 // GetStats calculates statistics for logs matching the given filters
 func (p *LoggerPlugin) GetStats(ctx context.Context, filters logstore.SearchFilters) (*logstore.SearchStats, error) {
 	return p.store.GetStats(ctx, filters)

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -122,6 +122,9 @@ type LogManager interface {
 	RecalculateCosts(ctx context.Context, filters *logstore.SearchFilters, limit int) (*RecalculateCostResult, error)
 
 	// MCP Tool Log methods
+	// GetMCPToolLog retrieves a single MCP tool log entry by ID.
+	GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error)
+
 	// SearchMCPToolLogs searches for MCP tool log entries based on filters and pagination
 	SearchMCPToolLogs(ctx context.Context, filters *logstore.MCPToolLogSearchFilters, pagination *logstore.PaginationOptions) (*logstore.MCPToolLogSearchResult, error)
 
@@ -364,6 +367,17 @@ func (p *PluginLogManager) RecalculateCosts(ctx context.Context, filters *logsto
 		return nil, fmt.Errorf("filters cannot be nil")
 	}
 	return p.plugin.RecalculateCosts(ctx, *filters, limit)
+}
+
+// GetMCPToolLog retrieves a single MCP tool log entry by ID.
+func (p *PluginLogManager) GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error) {
+	if p.plugin == nil || p.plugin.store == nil {
+		return nil, fmt.Errorf("log store not initialized")
+	}
+	if strings.TrimSpace(id) == "" {
+		return nil, fmt.Errorf("id cannot be empty")
+	}
+	return p.plugin.GetMCPToolLog(ctx, id)
 }
 
 // SearchMCPToolLogs searches for MCP tool log entries based on filters and pagination

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -96,6 +96,7 @@ func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas
 	r.GET("/api/mcp-logs/histogram", lib.ChainMiddlewares(h.getMCPHistogram, middlewares...))
 	r.GET("/api/mcp-logs/histogram/cost", lib.ChainMiddlewares(h.getMCPCostHistogram, middlewares...))
 	r.GET("/api/mcp-logs/histogram/top-tools", lib.ChainMiddlewares(h.getMCPTopTools, middlewares...))
+	r.GET("/api/mcp-logs/{id}", lib.ChainMiddlewares(h.getMCPLogByID, middlewares...))
 	r.DELETE("/api/mcp-logs", lib.ChainMiddlewares(h.deleteMCPLogs, middlewares...))
 }
 
@@ -1554,6 +1555,32 @@ func (h *LoggingHandler) getMCPLogs(ctx *fasthttp.RequestCtx) {
 	}
 
 	SendJSON(ctx, result)
+}
+
+// getMCPLogByID handles GET /api/mcp-logs/{id} - Get a single MCP tool log entry by ID.
+func (h *LoggingHandler) getMCPLogByID(ctx *fasthttp.RequestCtx) {
+	id, ok := ctx.UserValue("id").(string)
+	if !ok || strings.TrimSpace(id) == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "MCP log id is required")
+		return
+	}
+
+	log, err := h.logManager.GetMCPToolLog(ctx, id)
+	if err != nil {
+		if errors.Is(err, logstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "MCP log not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get MCP log: %v", err))
+		return
+	}
+
+	if log.VirtualKeyID != nil && log.VirtualKeyName != nil && *log.VirtualKeyID != "" && *log.VirtualKeyName != "" {
+		redactedVirtualKeys := h.redactedKeysManager.GetAllRedactedVirtualKeys(ctx, []string{*log.VirtualKeyID})
+		log.VirtualKey = findRedactedVirtualKey(redactedVirtualKeys, *log.VirtualKeyID, *log.VirtualKeyName)
+	}
+
+	SendJSON(ctx, log)
 }
 
 // getMCPLogsStats handles GET /api/mcp-logs/stats - Get statistics for MCP tool logs with filtering

--- a/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
@@ -12,14 +12,21 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CodeEditor } from "@/components/ui/codeEditor";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Status, StatusColors, Statuses } from "@/lib/constants/logs";
+import { useGetMCPLogByIdQuery } from "@/lib/store";
 import type { MCPToolLogEntry } from "@/lib/types/logs";
 import { downloadAsJson } from "@/lib/utils/browser-download";
 import { addMilliseconds, format, isValid } from "date-fns";
-import { ChevronDown, ChevronUp, Download, MoreVertical, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, Download, Loader2, MoreVertical, Trash2 } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { toast } from "sonner";
@@ -70,6 +77,13 @@ export function MCPLogDetailSheet({
 	hasNext = false,
 }: MCPLogDetailSheetProps) {
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const {
+		data: fullLog,
+		isLoading,
+		isError,
+	} = useGetMCPLogByIdQuery(log?.id ?? "", {
+		skip: !open || !log?.id,
+	});
 
 	// Keyboard navigation: arrow up/down to navigate between logs
 	useHotkeys("up", () => onNavigate?.("prev"), { enabled: open && hasPrev, preventDefault: true });
@@ -77,15 +91,31 @@ export function MCPLogDetailSheet({
 
 	if (!log) return null;
 
+	const isFullDataReady = isError || (fullLog?.id === log.id && !isLoading);
+	const displayLog = isFullDataReady && fullLog ? fullLog : log;
+
+	if (!isFullDataReady) {
+		return (
+			<Sheet open={open} onOpenChange={onOpenChange}>
+				<SheetContent className="flex w-full flex-col gap-4 overflow-x-hidden p-8 sm:max-w-[60%]">
+					<div className="flex h-full items-center justify-center">
+						<SheetTitle className="sr-only">Loading MCP log details</SheetTitle>
+						<Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+					</div>
+				</SheetContent>
+			</Sheet>
+		);
+	}
+
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="flex w-full flex-col gap-4 overflow-x-hidden p-8 sm:max-w-[60%]">
 				<SheetHeader className="flex flex-row items-center px-0">
 					<div className="flex w-full items-center justify-between">
 						<SheetTitle className="flex w-fit items-center gap-2 font-medium">
-							{log.id && <p className="text-md max-w-full truncate">Request ID: {log.id}</p>}
-							<Badge variant="outline" className={`${StatusColors[getValidatedStatus(log.status)]} uppercase`}>
-								{log.status}
+							{displayLog.id && <p className="text-md max-w-full truncate">Request ID: {displayLog.id}</p>}
+							<Badge variant="outline" className={`${StatusColors[getValidatedStatus(displayLog.status)]} uppercase`}>
+								{displayLog.status}
 							</Badge>
 						</SheetTitle>
 					</div>
@@ -123,20 +153,22 @@ export function MCPLogDetailSheet({
 							<DropdownMenuContent align="end">
 								<DropdownMenuItem
 									data-testid="export-log-json"
-									onClick={() => downloadAsJson(log, `mcp-log-${log.id ?? "export"}.json`)}
+									onClick={() => downloadAsJson(displayLog, `mcp-log-${displayLog.id ?? "export"}.json`)}
 								>
 									<Download className="h-4 w-4" />
 									Export as JSON
 								</DropdownMenuItem>
-								{handleDelete ? <>
-									<DropdownMenuSeparator />
-									<AlertDialogTrigger asChild>
-										<DropdownMenuItem variant="destructive">
-											<Trash2 className="h-4 w-4" />
-											Delete log
-										</DropdownMenuItem>
-									</AlertDialogTrigger>
-								</> : null}
+								{handleDelete ? (
+									<>
+										<DropdownMenuSeparator />
+										<AlertDialogTrigger asChild>
+											<DropdownMenuItem variant="destructive">
+												<Trash2 className="h-4 w-4" />
+												Delete log
+											</DropdownMenuItem>
+										</AlertDialogTrigger>
+									</>
+								) : null}
 							</DropdownMenuContent>
 						</DropdownMenu>
 						<AlertDialogContent>
@@ -151,7 +183,7 @@ export function MCPLogDetailSheet({
 										e.preventDefault();
 										if (!handleDelete) return;
 										try {
-											await handleDelete(log);
+											await handleDelete(displayLog);
 											setDeleteDialogOpen(false);
 											onOpenChange(false);
 										} catch (err) {
@@ -174,18 +206,26 @@ export function MCPLogDetailSheet({
 							<LogEntryDetailsView
 								className="w-full"
 								label="Start Timestamp"
-								value={isValid(new Date(log.timestamp)) ? format(new Date(log.timestamp), "yyyy-MM-dd hh:mm:ss aa") : "Invalid date"}
+								value={
+									isValid(new Date(displayLog.timestamp))
+										? format(new Date(displayLog.timestamp), "yyyy-MM-dd hh:mm:ss aa")
+										: "Invalid date"
+								}
 							/>
 							<LogEntryDetailsView
 								className="w-full"
 								label="End Timestamp"
 								value={
-									isValid(new Date(log.timestamp))
-										? format(addMilliseconds(new Date(log.timestamp), log.latency || 0), "yyyy-MM-dd hh:mm:ss aa")
+									isValid(new Date(displayLog.timestamp))
+										? format(addMilliseconds(new Date(displayLog.timestamp), displayLog.latency || 0), "yyyy-MM-dd hh:mm:ss aa")
 										: "Invalid date"
 								}
 							/>
-							<LogEntryDetailsView className="w-full" label="Latency" value={log.latency ? `${log.latency.toFixed(2)}ms` : "NA"} />
+							<LogEntryDetailsView
+								className="w-full"
+								label="Latency"
+								value={displayLog.latency ? `${displayLog.latency.toFixed(2)}ms` : "NA"}
+							/>
 						</div>
 					</div>
 					<DottedSeparator />
@@ -195,27 +235,27 @@ export function MCPLogDetailSheet({
 							<LogEntryDetailsView
 								className="col-span-2 w-full"
 								label="Tool Name"
-								value={<span className="font-mono text-sm">{log.tool_name}</span>}
+								value={<span className="font-mono text-sm">{displayLog.tool_name}</span>}
 							/>
 							<LogEntryDetailsView
 								className="w-full"
 								label="Server"
 								value={
-									log.server_label ? (
+									displayLog.server_label ? (
 										<Badge variant="secondary" className="font-mono">
-											{log.server_label}
+											{displayLog.server_label}
 										</Badge>
 									) : (
 										"-"
 									)
 								}
 							/>
-							{log.virtual_key && <LogEntryDetailsView className="w-full" label="Virtual Key" value={log.virtual_key.name} />}
-							{log.llm_request_id && (
+							{displayLog.virtual_key && <LogEntryDetailsView className="w-full" label="Virtual Key" value={displayLog.virtual_key.name} />}
+							{displayLog.llm_request_id && (
 								<LogEntryDetailsView
 									className="col-span-3 w-full"
 									label="LLM Request ID"
-									value={<span className="font-mono text-xs">{log.llm_request_id}</span>}
+									value={<span className="font-mono text-xs">{displayLog.llm_request_id}</span>}
 								/>
 							)}
 						</div>
@@ -223,7 +263,7 @@ export function MCPLogDetailSheet({
 				</div>
 
 				{/* Arguments */}
-				{log.arguments && (
+				{displayLog.arguments && (
 					<div className="w-full rounded-sm border">
 						<div className="border-b px-6 py-2 text-sm font-medium">Arguments</div>
 						<CodeEditor
@@ -231,7 +271,11 @@ export function MCPLogDetailSheet({
 							shouldAdjustInitialHeight={true}
 							maxHeight={250}
 							wrap={true}
-							code={typeof log.arguments === "string" ? log.arguments : JSON.stringify(log.arguments as Record<string, unknown>, null, 2)}
+							code={
+								typeof displayLog.arguments === "string"
+									? displayLog.arguments
+									: JSON.stringify(displayLog.arguments as Record<string, unknown>, null, 2)
+							}
 							lang="json"
 							readonly={true}
 							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
@@ -240,7 +284,7 @@ export function MCPLogDetailSheet({
 				)}
 
 				{/* Result */}
-				{log.result && log.status !== "processing" && (
+				{displayLog.result && displayLog.status !== "processing" && (
 					<div className="w-full rounded-sm border">
 						<div className="border-b px-6 py-2 text-sm font-medium">Result</div>
 						<CodeEditor
@@ -248,7 +292,7 @@ export function MCPLogDetailSheet({
 							shouldAdjustInitialHeight={true}
 							maxHeight={350}
 							wrap={true}
-							code={typeof log.result === "string" ? log.result : JSON.stringify(log.result, null, 2)}
+							code={typeof displayLog.result === "string" ? displayLog.result : JSON.stringify(displayLog.result, null, 2)}
 							lang="json"
 							readonly={true}
 							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
@@ -257,11 +301,11 @@ export function MCPLogDetailSheet({
 				)}
 
 				{/* Metadata */}
-				{log.metadata && Object.keys(log.metadata).length > 0 && (
+				{displayLog.metadata && Object.keys(displayLog.metadata).length > 0 && (
 					<div className="space-y-4 rounded-sm border px-6 py-4">
 						<BlockHeader title="Metadata" />
 						<div className="grid w-full grid-cols-3 items-start justify-between gap-4">
-							{Object.entries(log.metadata).map(([key, value]) => (
+							{Object.entries(displayLog.metadata).map(([key, value]) => (
 								<LogEntryDetailsView key={key} className="w-full" label={key} value={String(value)} />
 							))}
 						</div>
@@ -269,7 +313,7 @@ export function MCPLogDetailSheet({
 				)}
 
 				{/* Error Details */}
-				{log.error_details && (
+				{displayLog.error_details && (
 					<div className="border-destructive/50 w-full rounded-sm border">
 						<div className="border-destructive/50 text-destructive border-b px-6 py-2 text-sm font-medium">Error Details</div>
 						<CodeEditor
@@ -277,7 +321,7 @@ export function MCPLogDetailSheet({
 							shouldAdjustInitialHeight={true}
 							maxHeight={250}
 							wrap={true}
-							code={JSON.stringify(log.error_details, null, 2)}
+							code={JSON.stringify(displayLog.error_details, null, 2)}
 							lang="json"
 							readonly={true}
 							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}

--- a/ui/lib/store/apis/mcpLogsApi.ts
+++ b/ui/lib/store/apis/mcpLogsApi.ts
@@ -97,6 +97,12 @@ export const mcpLogsApi = baseApi.injectEndpoints({
 			providesTags: ["MCPLogs"],
 		}),
 
+		// Get a single MCP tool log entry by ID
+		getMCPLogById: builder.query<MCPToolLogEntry, string>({
+			query: (id) => `/mcp-logs/${encodeURIComponent(id)}`,
+			providesTags: (result, error, id) => [{ type: "MCPLogs", id }],
+		}),
+
 		// Get MCP tool logs statistics with filters
 		getMCPLogsStats: builder.query<
 			MCPToolLogStats,
@@ -188,10 +194,12 @@ export const mcpLogsApi = baseApi.injectEndpoints({
 
 export const {
 	useGetMCPLogsQuery,
+	useGetMCPLogByIdQuery,
 	useGetMCPLogsStatsQuery,
 	useGetMCPAvailableFilterDataQuery,
 	useGetMCPAvailableFilterDataQuery: useGetMCPLogsFilterDataQuery,
 	useLazyGetMCPLogsQuery,
+	useLazyGetMCPLogByIdQuery,
 	useLazyGetMCPLogsStatsQuery,
 	useLazyGetMCPAvailableFilterDataQuery,
 	useLazyGetMCPHistogramQuery,


### PR DESCRIPTION
## Summary

When opening an MCP log detail sheet, only the summary-level data available in the list view was being displayed. This PR fetches the full log entry by ID when the sheet is opened, ensuring all available fields (arguments, result, metadata, error details, etc.) are shown with complete data.

## Changes

- Added a `getMCPLogById` RTK Query endpoint that fetches a single MCP log entry by ID from `/mcp-logs/:id`
- When the detail sheet opens, it queries the full log by ID and shows a centered spinner while loading
- Once the full log is fetched, it is used as the display source (`displayLog`); if the fetch errors, it falls back gracefully to the partial log data already available from the list
- Exported `useGetMCPLogByIdQuery` and `useLazyGetMCPLogByIdQuery` hooks for use elsewhere

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the MCP Logs page in the workspace.
2. Click on any log entry to open the detail sheet.
3. Verify a loading spinner appears briefly while the full log is fetched.
4. Confirm the sheet renders complete log details including arguments, result, metadata, and error details.
5. Verify that exporting as JSON and deleting a log still work correctly.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Detail sheet displayed only the partial data available from the list response.  
After: Detail sheet shows a loading spinner, then renders the full log entry fetched by ID.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth, secrets, or PII handling introduced. The endpoint uses the existing authenticated base API client.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable