### PR TITLE
Offload MCP logs to object storage

### DIFF
--- a/framework/logstore/hybrid.go
+++ b/framework/logstore/hybrid.go
@@ -24,6 +24,9 @@ const (
 type uploadWork struct {
 	logID     string
 	timestamp time.Time
+	key       string
+	mcp       bool
+	status    string
 	payload   []byte // JSON-encoded payload
 	tags      map[string]string
 }
@@ -99,11 +102,25 @@ func (h *HybridLogStore) processUpload(work *uploadWork) {
 		}
 	}()
 
-	key := ObjectKey(h.prefix, work.timestamp, work.logID)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if err := h.objects.Put(ctx, key, work.payload, work.tags); err != nil {
+	if work.mcp {
+		current, err := h.inner.FindMCPToolLog(ctx, work.logID)
+		if err != nil {
+			h.logger.Warn("objectstore: failed to check MCP tool log %s before upload: %v", work.logID, err)
+			h.droppedUploads.Add(1)
+			return
+		}
+		// Status is the only monotonic-ish signal available on MCP log rows today.
+		// If stricter upload ordering is needed, add an updated_at/version column
+		// and compare it here alongside status.
+		if work.status != "" && current.Status != work.status {
+			return
+		}
+	}
+
+	if err := h.objects.Put(ctx, work.key, work.payload, work.tags); err != nil {
 		h.logger.Warn("objectstore: failed to upload log %s: %v", work.logID, err)
 		h.droppedUploads.Add(1)
 		return
@@ -114,7 +131,12 @@ func (h *HybridLogStore) processUpload(work *uploadWork) {
 	// with exponential backoff to avoid orphaning the uploaded object.
 	for attempt := 0; attempt < 3; attempt++ {
 		dbCtx, dbCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		err := h.inner.Update(dbCtx, work.logID, map[string]interface{}{"has_object": true})
+		var err error
+		if work.mcp {
+			err = h.inner.UpdateMCPToolLog(dbCtx, work.logID, map[string]interface{}{"has_object": true})
+		} else {
+			err = h.inner.Update(dbCtx, work.logID, map[string]interface{}{"has_object": true})
+		}
 		dbCancel()
 		if err == nil {
 			return
@@ -160,6 +182,18 @@ func (h *HybridLogStore) enqueueUpload(logID string, timestamp time.Time, payloa
 		h.droppedUploads.Add(1)
 		return
 	}
+	h.enqueueRawUpload(logID, timestamp, ObjectKey(h.prefix, timestamp, logID), false, "", data, tags)
+}
+
+func (h *HybridLogStore) enqueueRawUpload(logID string, timestamp time.Time, key string, mcp bool, status string, data []byte, tags map[string]string) {
+	if h.closed.Load() || len(data) == 0 {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			h.droppedUploads.Add(1)
+		}
+	}()
 	if h.pendingBytes.Load()+int64(len(data)) > defaultMaxUploadQueueBytes {
 		h.droppedUploads.Add(1)
 		h.logger.Warn("objectstore: upload queue memory limit reached, dropping upload for log %s", logID)
@@ -169,6 +203,9 @@ func (h *HybridLogStore) enqueueUpload(logID string, timestamp time.Time, payloa
 	case h.uploadQueue <- &uploadWork{
 		logID:     logID,
 		timestamp: timestamp,
+		key:       key,
+		mcp:       mcp,
+		status:    status,
 		payload:   data,
 		tags:      tags,
 	}:
@@ -319,6 +356,28 @@ func (h *HybridLogStore) hydrateLog(ctx context.Context, log *Log, requestedFiel
 		return
 	}
 	pruneUnrequestedPayloadFields(log, requestedFields)
+}
+
+func (h *HybridLogStore) hydrateMCPToolLog(ctx context.Context, log *MCPToolLog) error {
+	if log == nil || !log.HasObject {
+		return nil
+	}
+	return h.hydrateMCPToolLogFromObject(ctx, log)
+}
+
+func (h *HybridLogStore) hydrateMCPToolLogFromObject(ctx context.Context, log *MCPToolLog) error {
+	if log == nil {
+		return nil
+	}
+	key := MCPToolObjectKey(h.prefix, log.Timestamp, log.ID)
+	data, err := h.objects.Get(ctx, key)
+	if err != nil {
+		return fmt.Errorf("objectstore: fetch MCP tool log payload for %s: %w", log.ID, err)
+	}
+	if mergeErr := MergeMCPToolLogPayloadFromJSON(log, data); mergeErr != nil {
+		return fmt.Errorf("objectstore: merge MCP tool log payload for %s: %w", log.ID, mergeErr)
+	}
+	return nil
 }
 
 func (h *HybridLogStore) Update(ctx context.Context, id string, entry any) error {
@@ -548,7 +607,8 @@ func (h *HybridLogStore) GetDistinctMetadataKeys(ctx context.Context) (map[strin
 	return h.inner.GetDistinctMetadataKeys(ctx)
 }
 
-// MCP Tool Log methods — delegated directly.
+// MCP Tool Log analytics methods are delegated directly. Detail/write paths
+// below offload full MCP log objects while keeping DB rows lightweight.
 
 func (h *HybridLogStore) GetMCPHistogram(ctx context.Context, filters MCPToolLogSearchFilters, bucketSizeSeconds int64) (*MCPHistogramResult, error) {
 	return h.inner.GetMCPHistogram(ctx, filters, bucketSizeSeconds)
@@ -562,16 +622,306 @@ func (h *HybridLogStore) GetMCPTopTools(ctx context.Context, filters MCPToolLogS
 	return h.inner.GetMCPTopTools(ctx, filters, limit)
 }
 
+func applyMCPToolLogUpdate(target *MCPToolLog, entry any) error {
+	switch v := entry.(type) {
+	case map[string]interface{}:
+		return applyMCPToolLogUpdateMap(target, v)
+	case *MCPToolLog:
+		if v == nil {
+			return nil
+		}
+		update := *v
+		if err := update.SerializeFields(); err != nil {
+			return err
+		}
+		return applyMCPToolLogUpdateStruct(target, &update)
+	case MCPToolLog:
+		update := v
+		if err := update.SerializeFields(); err != nil {
+			return err
+		}
+		return applyMCPToolLogUpdateStruct(target, &update)
+	default:
+		return nil
+	}
+}
+
+func applyMCPToolLogUpdateMap(target *MCPToolLog, updates map[string]interface{}) error {
+	for key, value := range updates {
+		switch key {
+		case "request_id":
+			if v, ok := value.(string); ok {
+				target.RequestID = v
+			}
+		case "llm_request_id":
+			if v, ok := value.(string); ok {
+				target.LLMRequestID = &v
+			}
+		case "tool_name":
+			if v, ok := value.(string); ok {
+				target.ToolName = v
+			}
+		case "server_label":
+			if v, ok := value.(string); ok {
+				target.ServerLabel = v
+			}
+		case "virtual_key_id":
+			if v, ok := value.(string); ok {
+				target.VirtualKeyID = &v
+			}
+		case "virtual_key_name":
+			if v, ok := value.(string); ok {
+				target.VirtualKeyName = &v
+			}
+		case "arguments":
+			if v, ok := value.(string); ok {
+				target.Arguments = v
+				target.ArgumentsParsed = nil
+			}
+		case "result":
+			if v, ok := value.(string); ok {
+				target.Result = v
+				target.ResultParsed = nil
+			}
+		case "error_details":
+			if v, ok := value.(string); ok {
+				target.ErrorDetails = v
+				target.ErrorDetailsParsed = nil
+			}
+		case "metadata":
+			if v, ok := value.(string); ok {
+				target.Metadata = v
+				target.MetadataParsed = nil
+			}
+		case "latency":
+			if v, ok := numericToFloat64(value); ok {
+				target.Latency = &v
+			}
+		case "cost":
+			if v, ok := numericToFloat64(value); ok {
+				target.Cost = &v
+			}
+		case "status":
+			if v, ok := value.(string); ok {
+				target.Status = v
+			}
+		}
+	}
+	return target.DeserializeFields()
+}
+
+func applyMCPToolLogUpdateStruct(target *MCPToolLog, update *MCPToolLog) error {
+	if update.RequestID != "" {
+		target.RequestID = update.RequestID
+	}
+	if update.LLMRequestID != nil {
+		target.LLMRequestID = update.LLMRequestID
+	}
+	if !update.Timestamp.IsZero() {
+		target.Timestamp = update.Timestamp
+	}
+	if update.ToolName != "" {
+		target.ToolName = update.ToolName
+	}
+	if update.ServerLabel != "" {
+		target.ServerLabel = update.ServerLabel
+	}
+	if update.VirtualKeyID != nil {
+		target.VirtualKeyID = update.VirtualKeyID
+	}
+	if update.VirtualKeyName != nil {
+		target.VirtualKeyName = update.VirtualKeyName
+	}
+	if update.Arguments != "" {
+		target.Arguments = update.Arguments
+		target.ArgumentsParsed = nil
+	}
+	if update.Result != "" {
+		target.Result = update.Result
+		target.ResultParsed = nil
+	}
+	if update.ErrorDetails != "" {
+		target.ErrorDetails = update.ErrorDetails
+		target.ErrorDetailsParsed = nil
+	}
+	if update.Latency != nil {
+		target.Latency = update.Latency
+	}
+	if update.Cost != nil {
+		target.Cost = update.Cost
+	}
+	if update.Status != "" {
+		target.Status = update.Status
+	}
+	if update.Metadata != "" {
+		target.Metadata = update.Metadata
+		target.MetadataParsed = nil
+	}
+	if !update.CreatedAt.IsZero() {
+		target.CreatedAt = update.CreatedAt
+	}
+	return target.DeserializeFields()
+}
+
+func prepareMCPToolLogDBUpdates(entry any) (map[string]interface{}, error) {
+	switch v := entry.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(v))
+		for key, value := range v {
+			switch key {
+			case "has_object":
+				continue
+			case "result", "error_details":
+				out[key] = ""
+			case "arguments":
+				if s, ok := value.(string); ok {
+					out[key] = marshalMCPPreviewString(truncateRunes(s, maxMCPToolInputPreviewRunes))
+				}
+			default:
+				out[key] = value
+			}
+		}
+		return out, nil
+	case *MCPToolLog:
+		if v == nil {
+			return nil, nil
+		}
+		return prepareMCPToolLogDBUpdatesFromStruct(*v)
+	case MCPToolLog:
+		return prepareMCPToolLogDBUpdatesFromStruct(v)
+	default:
+		return nil, nil
+	}
+}
+
+func prepareMCPToolLogDBUpdatesFromStruct(update MCPToolLog) (map[string]interface{}, error) {
+	if err := update.SerializeFields(); err != nil {
+		return nil, err
+	}
+	PrepareMCPToolDBEntry(&update)
+	out := make(map[string]interface{})
+	if update.RequestID != "" {
+		out["request_id"] = update.RequestID
+	}
+	if update.LLMRequestID != nil {
+		out["llm_request_id"] = *update.LLMRequestID
+	}
+	if !update.Timestamp.IsZero() {
+		out["timestamp"] = update.Timestamp
+	}
+	if update.ToolName != "" {
+		out["tool_name"] = update.ToolName
+	}
+	if update.ServerLabel != "" {
+		out["server_label"] = update.ServerLabel
+	}
+	if update.VirtualKeyID != nil {
+		out["virtual_key_id"] = *update.VirtualKeyID
+	}
+	if update.VirtualKeyName != nil {
+		out["virtual_key_name"] = *update.VirtualKeyName
+	}
+	if update.Arguments != "" {
+		out["arguments"] = update.Arguments
+	}
+	if update.Latency != nil {
+		out["latency"] = *update.Latency
+	}
+	if update.Cost != nil {
+		out["cost"] = *update.Cost
+	}
+	if update.Status != "" {
+		out["status"] = update.Status
+	}
+	if update.Metadata != "" {
+		out["metadata"] = update.Metadata
+	}
+	if !update.CreatedAt.IsZero() {
+		out["created_at"] = update.CreatedAt
+	}
+	return out, nil
+}
+
+func numericToFloat64(value interface{}) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}
+
+func marshalMCPPreviewString(s string) string {
+	data, err := sonic.Marshal(s)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
 func (h *HybridLogStore) CreateMCPToolLog(ctx context.Context, entry *MCPToolLog) error {
-	return h.inner.CreateMCPToolLog(ctx, entry)
+	payload, err := MarshalMCPToolLogPayload(entry)
+	if err != nil {
+		return fmt.Errorf("logstore: serialize MCP tool log before offload: %w", err)
+	}
+	tags := BuildMCPToolTags(entry)
+
+	dbEntry := *entry
+	PrepareMCPToolDBEntry(&dbEntry)
+	if err := h.inner.CreateMCPToolLog(ctx, &dbEntry); err != nil {
+		return err
+	}
+	h.enqueueRawUpload(entry.ID, entry.Timestamp, MCPToolObjectKey(h.prefix, entry.Timestamp, entry.ID), true, entry.Status, payload, tags)
+	return nil
 }
 
 func (h *HybridLogStore) FindMCPToolLog(ctx context.Context, id string) (*MCPToolLog, error) {
-	return h.inner.FindMCPToolLog(ctx, id)
+	log, err := h.inner.FindMCPToolLog(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := h.hydrateMCPToolLog(ctx, log); err != nil {
+		h.logger.Warn("%v", err)
+	}
+	return log, nil
 }
 
 func (h *HybridLogStore) UpdateMCPToolLog(ctx context.Context, id string, entry any) error {
-	return h.inner.UpdateMCPToolLog(ctx, id, entry)
+	current, err := h.inner.FindMCPToolLog(ctx, id)
+	if err != nil {
+		return err
+	}
+	if err := h.hydrateMCPToolLogFromObject(ctx, current); err != nil {
+		return err
+	}
+	if err := applyMCPToolLogUpdate(current, entry); err != nil {
+		return err
+	}
+
+	dbUpdates, err := prepareMCPToolLogDBUpdates(entry)
+	if err != nil {
+		return err
+	}
+	if len(dbUpdates) > 0 {
+		if err := h.inner.UpdateMCPToolLog(ctx, id, dbUpdates); err != nil {
+			return err
+		}
+	}
+
+	payload, err := MarshalMCPToolLogPayload(current)
+	if err != nil {
+		return fmt.Errorf("logstore: serialize MCP tool log update before offload: %w", err)
+	}
+	h.enqueueRawUpload(current.ID, current.Timestamp, MCPToolObjectKey(h.prefix, current.Timestamp, current.ID), true, current.Status, payload, BuildMCPToolTags(current))
+	return nil
 }
 
 func (h *HybridLogStore) SearchMCPToolLogs(ctx context.Context, filters MCPToolLogSearchFilters, pagination PaginationOptions) (*MCPToolLogSearchResult, error) {
@@ -587,7 +937,25 @@ func (h *HybridLogStore) HasMCPToolLogs(ctx context.Context) (bool, error) {
 }
 
 func (h *HybridLogStore) DeleteMCPToolLogs(ctx context.Context, ids []string) error {
-	return h.inner.DeleteMCPToolLogs(ctx, ids)
+	var keys []string
+	for _, id := range ids {
+		log, findErr := h.inner.FindMCPToolLog(ctx, id)
+		if findErr != nil && !errors.Is(findErr, ErrNotFound) {
+			return findErr
+		}
+		if log != nil && log.HasObject {
+			keys = append(keys, MCPToolObjectKey(h.prefix, log.Timestamp, log.ID))
+		}
+	}
+	if err := h.inner.DeleteMCPToolLogs(ctx, ids); err != nil {
+		return err
+	}
+	if len(keys) > 0 {
+		if delErr := h.objects.DeleteBatch(ctx, keys); delErr != nil {
+			h.logger.Warn("objectstore: failed to batch delete %d MCP tool log objects: %v", len(keys), delErr)
+		}
+	}
+	return nil
 }
 
 func (h *HybridLogStore) FlushMCPToolLogs(ctx context.Context, since time.Time) error {

--- a/framework/logstore/hybrid_test.go
+++ b/framework/logstore/hybrid_test.go
@@ -2,6 +2,7 @@ package logstore
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -13,13 +14,13 @@ import (
 
 type hybridTestLogger struct{}
 
-func (hybridTestLogger) Debug(string, ...any)                                  {}
-func (hybridTestLogger) Info(string, ...any)                                   {}
-func (hybridTestLogger) Warn(string, ...any)                                   {}
-func (hybridTestLogger) Error(string, ...any)                                  {}
-func (hybridTestLogger) Fatal(string, ...any)                                  {}
-func (hybridTestLogger) SetLevel(schemas.LogLevel)                             {}
-func (hybridTestLogger) SetOutputType(schemas.LoggerOutputType)                {}
+func (hybridTestLogger) Debug(string, ...any)                   {}
+func (hybridTestLogger) Info(string, ...any)                    {}
+func (hybridTestLogger) Warn(string, ...any)                    {}
+func (hybridTestLogger) Error(string, ...any)                   {}
+func (hybridTestLogger) Fatal(string, ...any)                   {}
+func (hybridTestLogger) SetLevel(schemas.LogLevel)              {}
+func (hybridTestLogger) SetOutputType(schemas.LoggerOutputType) {}
 func (hybridTestLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
 	return schemas.NoopLogEvent
 }
@@ -28,8 +29,9 @@ func newTestHybrid(t *testing.T) (*HybridLogStore, LogStore, *objectstore.InMemo
 	t.Helper()
 	ctx := context.Background()
 
-	// Create SQLite inner store.
-	inner, err := newSqliteLogStore(ctx, &SQLiteConfig{Path: ":memory:"}, hybridTestLogger{})
+	// Use a temp file instead of :memory: so async upload workers that use a
+	// separate DB connection see the same schema.
+	inner, err := newSqliteLogStore(ctx, &SQLiteConfig{Path: filepath.Join(t.TempDir(), "hybrid.db")}, hybridTestLogger{})
 	require.NoError(t, err)
 
 	objStore := objectstore.NewInMemoryObjectStore()
@@ -204,6 +206,226 @@ func TestHybrid_FindByID_GracefulDegradation(t *testing.T) {
 	assert.Empty(t, found.OutputMessage, "output should be empty when S3 fails")
 }
 
+func TestHybrid_CreateAndFindMCPToolLog(t *testing.T) {
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	longInput := ""
+	for i := 0; i < 260; i++ {
+		longInput += "a"
+	}
+	entry := &MCPToolLog{
+		ID:          "mcp-1",
+		RequestID:   "req-1",
+		Timestamp:   time.Now().UTC(),
+		ToolName:    "echo",
+		ServerLabel: "local",
+		Status:      "success",
+		ArgumentsParsed: map[string]any{
+			"input": longInput,
+		},
+		ResultParsed: map[string]any{
+			"ok": true,
+		},
+	}
+
+	require.NoError(t, hybrid.CreateMCPToolLog(ctx, entry))
+	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+
+	dbOnly, err := inner.FindMCPToolLog(ctx, "mcp-1")
+	require.NoError(t, err)
+	assert.True(t, dbOnly.HasObject)
+	assert.Empty(t, dbOnly.Result)
+	assert.Nil(t, dbOnly.ResultParsed)
+	preview, ok := dbOnly.ArgumentsParsed.(string)
+	require.True(t, ok)
+	assert.Len(t, []rune(preview), 200)
+
+	found, err := hybrid.FindMCPToolLog(ctx, "mcp-1")
+	require.NoError(t, err)
+	assert.True(t, found.HasObject)
+	assert.Equal(t, longInput, found.ArgumentsParsed.(map[string]interface{})["input"])
+	assert.Equal(t, true, found.ResultParsed.(map[string]interface{})["ok"])
+}
+
+func TestHybrid_UpdateMCPToolLogOffloadsFullLog(t *testing.T) {
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	entry := &MCPToolLog{
+		ID:          "mcp-update",
+		RequestID:   "req-update",
+		Timestamp:   time.Now().UTC(),
+		ToolName:    "search",
+		ServerLabel: "docs",
+		Status:      "processing",
+		ArgumentsParsed: map[string]any{
+			"query": "find this",
+		},
+	}
+	require.NoError(t, hybrid.CreateMCPToolLog(ctx, entry))
+	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+
+	require.NoError(t, hybrid.UpdateMCPToolLog(ctx, entry.ID, MCPToolLog{
+		Status: "success",
+		ResultParsed: map[string]any{
+			"answer": "done",
+		},
+	}))
+
+	waitForUploads(t, func() bool {
+		found, err := hybrid.FindMCPToolLog(ctx, entry.ID)
+		if err != nil || found.ResultParsed == nil {
+			return false
+		}
+		result, ok := found.ResultParsed.(map[string]interface{})
+		return ok && result["answer"] == "done"
+	})
+
+	dbOnly, err := inner.FindMCPToolLog(ctx, entry.ID)
+	require.NoError(t, err)
+	assert.True(t, dbOnly.HasObject)
+	assert.Equal(t, "success", dbOnly.Status)
+	assert.Empty(t, dbOnly.Result)
+	assert.Nil(t, dbOnly.ResultParsed)
+
+	found, err := hybrid.FindMCPToolLog(ctx, entry.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "find this", found.ArgumentsParsed.(map[string]interface{})["query"])
+	assert.Equal(t, "done", found.ResultParsed.(map[string]interface{})["answer"])
+}
+
+func TestHybrid_UpdateMCPToolLogRequiresObjectHydration(t *testing.T) {
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	entry := &MCPToolLog{
+		ID:          "mcp-hydration-fail",
+		RequestID:   "req-hydration-fail",
+		Timestamp:   time.Now().UTC(),
+		ToolName:    "search",
+		ServerLabel: "docs",
+		Status:      "success",
+		ArgumentsParsed: map[string]any{
+			"query": "full input",
+		},
+		ResultParsed: map[string]any{
+			"answer": "original",
+		},
+	}
+	require.NoError(t, hybrid.CreateMCPToolLog(ctx, entry))
+	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+
+	objStore.GetErr = assert.AnError
+	err := hybrid.UpdateMCPToolLog(ctx, entry.ID, MCPToolLog{
+		Status: "success",
+		ResultParsed: map[string]any{
+			"answer": "updated",
+		},
+	})
+	require.Error(t, err)
+	objStore.GetErr = nil
+
+	found, err := hybrid.FindMCPToolLog(ctx, entry.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "full input", found.ArgumentsParsed.(map[string]interface{})["query"])
+	assert.Equal(t, "original", found.ResultParsed.(map[string]interface{})["answer"])
+
+	dbOnly, err := inner.FindMCPToolLog(ctx, entry.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "success", dbOnly.Status)
+}
+
+func TestHybrid_UpdateMCPToolLogHydratesObjectBeforeHasObjectMarker(t *testing.T) {
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	longInput := ""
+	for i := 0; i < 260; i++ {
+		longInput += "q"
+	}
+	entry := &MCPToolLog{
+		ID:          "mcp-has-object-false",
+		RequestID:   "req-has-object-false",
+		Timestamp:   time.Now().UTC(),
+		ToolName:    "search",
+		ServerLabel: "docs",
+		Status:      "processing",
+		ArgumentsParsed: map[string]any{
+			"query": longInput,
+		},
+	}
+	payload, err := MarshalMCPToolLogPayload(entry)
+	require.NoError(t, err)
+	dbEntry := *entry
+	PrepareMCPToolDBEntry(&dbEntry)
+	require.NoError(t, inner.CreateMCPToolLog(ctx, &dbEntry))
+	require.NoError(t, objStore.Put(ctx, MCPToolObjectKey(hybrid.prefix, entry.Timestamp, entry.ID), payload, BuildMCPToolTags(entry)))
+
+	require.NoError(t, hybrid.UpdateMCPToolLog(ctx, entry.ID, MCPToolLog{
+		Status: "success",
+		ResultParsed: map[string]any{
+			"answer": "done",
+		},
+	}))
+	waitForUploads(t, func() bool {
+		found, err := hybrid.FindMCPToolLog(ctx, entry.ID)
+		if err != nil || found.ResultParsed == nil {
+			return false
+		}
+		result, ok := found.ResultParsed.(map[string]interface{})
+		return ok && result["answer"] == "done"
+	})
+
+	found, err := hybrid.FindMCPToolLog(ctx, entry.ID)
+	require.NoError(t, err)
+	assert.Equal(t, longInput, found.ArgumentsParsed.(map[string]interface{})["query"])
+	assert.Equal(t, "done", found.ResultParsed.(map[string]interface{})["answer"])
+}
+
+func TestHybrid_ProcessMCPUploadSkipsMissingRowsWithEmptyStatus(t *testing.T) {
+	hybrid, _, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+
+	hybrid.processUpload(&uploadWork{
+		logID:     "mcp-missing-row",
+		timestamp: time.Now().UTC(),
+		key:       MCPToolObjectKey(hybrid.prefix, time.Now().UTC(), "mcp-missing-row"),
+		mcp:       true,
+		payload:   []byte(`{"id":"mcp-missing-row"}`),
+	})
+
+	assert.Equal(t, 0, objStore.Len())
+	assert.Equal(t, int64(1), hybrid.DroppedUploads())
+}
+
+func TestHybrid_DeleteMCPToolLogsDeletesObjects(t *testing.T) {
+	hybrid, _, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	entry := &MCPToolLog{
+		ID:          "mcp-delete",
+		RequestID:   "req-delete",
+		Timestamp:   time.Now().UTC(),
+		ToolName:    "echo",
+		ServerLabel: "local",
+		Status:      "success",
+		ArgumentsParsed: map[string]any{
+			"input": "delete me",
+		},
+	}
+	require.NoError(t, hybrid.CreateMCPToolLog(ctx, entry))
+	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+
+	require.NoError(t, hybrid.DeleteMCPToolLogs(ctx, []string{entry.ID}))
+	assert.Equal(t, 0, objStore.Len())
+}
+
 func TestHybrid_PutFailureDropsUpload(t *testing.T) {
 	hybrid, _, objStore := newTestHybrid(t)
 	defer hybrid.Close(context.Background())
@@ -335,7 +557,7 @@ func TestHybrid_ContentSummaryIsInputOnly(t *testing.T) {
 func newTestHybridWithExclude(t *testing.T, excludeFields []string) (*HybridLogStore, LogStore, *objectstore.InMemoryObjectStore) {
 	t.Helper()
 	ctx := context.Background()
-	inner, err := newSqliteLogStore(ctx, &SQLiteConfig{Path: ":memory:"}, hybridTestLogger{})
+	inner, err := newSqliteLogStore(ctx, &SQLiteConfig{Path: filepath.Join(t.TempDir(), "hybrid.db")}, hybridTestLogger{})
 	require.NoError(t, err)
 	objStore := objectstore.NewInMemoryObjectStore()
 	hybrid := newHybridLogStore(inner, objStore, "test", hybridTestLogger{}, excludeFields)

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -298,6 +298,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddHasObjectColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddHasObjectColumnToMCPToolLogs(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddAttemptTrailColumn(ctx, db); err != nil {
 		return err
 	}
@@ -2411,6 +2414,41 @@ func migrationAddHasObjectColumn(ctx context.Context, db *gorm.DB) error {
 	return nil
 }
 
+// migrationAddHasObjectColumnToMCPToolLogs adds the has_object boolean column to the mcp_tool_logs table.
+// Used by the hybrid log store to track whether an MCP tool log's payload is stored in object storage.
+func migrationAddHasObjectColumnToMCPToolLogs(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "mcp_tool_logs_add_has_object_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mgr := tx.Migrator()
+			if !mgr.HasColumn(&MCPToolLog{}, "has_object") {
+				if err := mgr.AddColumn(&MCPToolLog{}, "has_object"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mgr := tx.Migrator()
+			if mgr.HasColumn(&MCPToolLog{}, "has_object") {
+				if err := mgr.DropColumn(&MCPToolLog{}, "has_object"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding has_object column to mcp_tool_logs: %s", err.Error())
+	}
+	return nil
+}
+
 // migrationAddImageVariationInputColumn adds the image_variation_input column to the logs table.
 func migrationAddImageVariationInputColumn(ctx context.Context, db *gorm.DB) error {
 	opts := *migrator.DefaultOptions
@@ -2731,4 +2769,3 @@ func migrationAddStopReasonColumn(ctx context.Context, db *gorm.DB) error {
 	}
 	return nil
 }
-

--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -509,6 +509,30 @@ func BuildTags(l *Log) map[string]string {
 	return tags
 }
 
+// BuildMCPToolTags creates the object tag map from an MCP tool log's index
+// fields. S3 allows max 10 tags per object.
+func BuildMCPToolTags(l *MCPToolLog) map[string]string {
+	tags := make(map[string]string, 6)
+	if l.ToolName != "" {
+		tags["tool_name"] = truncateTag(l.ToolName, 256)
+	}
+	if l.ServerLabel != "" {
+		tags["server_label"] = truncateTag(l.ServerLabel, 256)
+	}
+	if l.Status != "" {
+		tags["status"] = l.Status
+	}
+	if l.VirtualKeyID != nil && *l.VirtualKeyID != "" {
+		tags["virtual_key_id"] = truncateTag(*l.VirtualKeyID, 256)
+	}
+	tags["has_error"] = "false"
+	if l.Status == "error" {
+		tags["has_error"] = "true"
+	}
+	tags["date"] = l.Timestamp.UTC().Format("2006-01-02")
+	return tags
+}
+
 // ObjectKey constructs the S3 object key for a log entry.
 func ObjectKey(prefix string, timestamp time.Time, logID string) string {
 	ts := timestamp.UTC()

--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -9,6 +9,8 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
+const maxMCPToolInputPreviewRunes = 200
+
 // payloadFields lists the DB column names of large TEXT fields that are
 // offloaded to object storage in hybrid mode. These fields are never needed
 // for analytics queries (histograms, search, rankings) — only for individual
@@ -311,6 +313,64 @@ func MarshalPayload(payload map[string]string) ([]byte, error) {
 	return sonic.Marshal(payload)
 }
 
+// MarshalMCPToolLogPayload serializes a full MCP tool log for object storage.
+// The object-store copy is intentionally complete; the DB row is only a
+// lightweight index plus a short input preview.
+func MarshalMCPToolLogPayload(l *MCPToolLog) ([]byte, error) {
+	payload := *l
+	if err := payload.SerializeFields(); err != nil {
+		return nil, err
+	}
+	_ = payload.DeserializeFields()
+	return sonic.Marshal(&payload)
+}
+
+// MergeMCPToolLogPayloadFromJSON replaces an MCP tool log with the full object
+// storage copy while preserving DB-local hydration state.
+func MergeMCPToolLogPayloadFromJSON(l *MCPToolLog, data []byte) error {
+	hasObject := l.HasObject
+	virtualKey := l.VirtualKey
+
+	var payload MCPToolLog
+	if err := sonic.Unmarshal(data, &payload); err != nil {
+		return fmt.Errorf("logstore: unmarshal MCP tool log payload: %w", err)
+	}
+	if err := payload.SerializeFields(); err != nil {
+		return err
+	}
+	*l = payload
+	l.HasObject = hasObject
+	l.VirtualKey = virtualKey
+	return nil
+}
+
+// PrepareMCPToolDBEntry converts an MCP tool log to the lightweight DB form
+// used by hybrid storage. It preserves indexed/display fields and metadata,
+// keeps only a 200-character JSON-string argument preview, and clears result
+// and error payloads.
+func PrepareMCPToolDBEntry(l *MCPToolLog) {
+	preview := buildMCPToolInputPreview(l)
+	l.ArgumentsParsed = preview
+	l.Arguments = ""
+	l.Result = ""
+	l.ErrorDetails = ""
+	l.ResultParsed = nil
+	l.ErrorDetailsParsed = nil
+	_ = l.SerializeFields()
+}
+
+func buildMCPToolInputPreview(l *MCPToolLog) string {
+	if l.ArgumentsParsed != nil {
+		if data, err := sonic.Marshal(l.ArgumentsParsed); err == nil {
+			return truncateRunes(string(data), maxMCPToolInputPreviewRunes)
+		}
+	}
+	if l.Arguments != "" {
+		return truncateRunes(l.Arguments, maxMCPToolInputPreviewRunes)
+	}
+	return ""
+}
+
 // BuildInputContentSummary extracts the last user message text from input fields.
 // This is used in hybrid mode for the content_summary column, which powers
 // full-text search and serves as a display fallback in the log list table.
@@ -453,6 +513,16 @@ func BuildTags(l *Log) map[string]string {
 func ObjectKey(prefix string, timestamp time.Time, logID string) string {
 	ts := timestamp.UTC()
 	return fmt.Sprintf("%s/logs/%04d/%02d/%02d/%02d/%s.json.gz",
+		prefix,
+		ts.Year(), ts.Month(), ts.Day(), ts.Hour(),
+		logID,
+	)
+}
+
+// MCPToolObjectKey constructs the S3 object key for an MCP tool log entry.
+func MCPToolObjectKey(prefix string, timestamp time.Time, logID string) string {
+	ts := timestamp.UTC()
+	return fmt.Sprintf("%s/mcp-logs/%04d/%02d/%02d/%02d/%s.json.gz",
 		prefix,
 		ts.Year(), ts.Month(), ts.Day(), ts.Hour(),
 		logID,
@@ -643,4 +713,17 @@ func truncateTag(s string, maxLen int) string {
 		byteLen += rl
 	}
 	return s[:byteLen]
+}
+
+func truncateRunes(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	for i := range s {
+		if maxRunes == 0 {
+			return s[:i]
+		}
+		maxRunes--
+	}
+	return s
 }

--- a/framework/logstore/payload_test.go
+++ b/framework/logstore/payload_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -141,6 +142,113 @@ func TestObjectKey(t *testing.T) {
 	ts := time.Date(2026, 4, 3, 14, 0, 0, 0, time.UTC)
 	key := ObjectKey("bifrost", ts, "req_abc123")
 	assert.Equal(t, "bifrost/logs/2026/04/03/14/req_abc123.json.gz", key)
+}
+
+func TestMCPToolObjectKey(t *testing.T) {
+	ts := time.Date(2026, 4, 3, 14, 0, 0, 0, time.UTC)
+	key := MCPToolObjectKey("bifrost", ts, "mcp_abc123")
+	assert.Equal(t, "bifrost/mcp-logs/2026/04/03/14/mcp_abc123.json.gz", key)
+}
+
+func TestMCPToolLogPayload_RoundTripFullLog(t *testing.T) {
+	vkID := "vk_123"
+	cost := 0.01
+	latency := 42.5
+	entry := &MCPToolLog{
+		ID:             "mcp-1",
+		RequestID:      "req-1",
+		LLMRequestID:   strPtr("llm-1"),
+		Timestamp:      time.Date(2026, 4, 3, 14, 0, 0, 0, time.UTC),
+		ToolName:       "search",
+		ServerLabel:    "docs",
+		VirtualKeyID:   &vkID,
+		VirtualKeyName: strPtr("prod-key"),
+		Latency:        &latency,
+		Cost:           &cost,
+		Status:         "success",
+		CreatedAt:      time.Date(2026, 4, 3, 14, 0, 1, 0, time.UTC),
+		ArgumentsParsed: map[string]any{
+			"query": "full input",
+		},
+		ResultParsed: map[string]any{
+			"ok": true,
+		},
+		ErrorDetailsParsed: &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: &schemas.ErrorField{
+				Message: "stored for round trip",
+			},
+		},
+		MetadataParsed: map[string]interface{}{
+			"trace": "abc",
+		},
+	}
+
+	data, err := MarshalMCPToolLogPayload(entry)
+	require.NoError(t, err)
+
+	dbEntry := &MCPToolLog{HasObject: true}
+	err = MergeMCPToolLogPayloadFromJSON(dbEntry, data)
+	require.NoError(t, err)
+
+	assert.True(t, dbEntry.HasObject)
+	assert.Equal(t, entry.ID, dbEntry.ID)
+	assert.Equal(t, entry.RequestID, dbEntry.RequestID)
+	assert.Equal(t, entry.ToolName, dbEntry.ToolName)
+	assert.Equal(t, entry.ServerLabel, dbEntry.ServerLabel)
+	assert.Equal(t, entry.Status, dbEntry.Status)
+	assert.Equal(t, "full input", dbEntry.ArgumentsParsed.(map[string]interface{})["query"])
+	assert.Equal(t, true, dbEntry.ResultParsed.(map[string]interface{})["ok"])
+	assert.Equal(t, "stored for round trip", dbEntry.ErrorDetailsParsed.Error.Message)
+	assert.Equal(t, "abc", dbEntry.MetadataParsed["trace"])
+}
+
+func TestPrepareMCPToolDBEntry_KeepsOnlyInputPreview(t *testing.T) {
+	longInput := ""
+	for i := 0; i < 260; i++ {
+		longInput += "a"
+	}
+	entry := &MCPToolLog{
+		ID:          "mcp-preview",
+		RequestID:   "req-preview",
+		Timestamp:   time.Date(2026, 4, 3, 14, 0, 0, 0, time.UTC),
+		ToolName:    "echo",
+		ServerLabel: "local",
+		Status:      "success",
+		ArgumentsParsed: map[string]any{
+			"input": longInput,
+		},
+		ResultParsed: map[string]any{
+			"secret": "large result",
+		},
+		ErrorDetailsParsed: &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: &schemas.ErrorField{
+				Message: "large error",
+			},
+		},
+		MetadataParsed: map[string]interface{}{
+			"trace": "abc",
+		},
+	}
+
+	PrepareMCPToolDBEntry(entry)
+
+	assert.Equal(t, "mcp-preview", entry.ID)
+	assert.Equal(t, "req-preview", entry.RequestID)
+	assert.Equal(t, "echo", entry.ToolName)
+	assert.Equal(t, "local", entry.ServerLabel)
+	assert.Empty(t, entry.Result)
+	assert.Empty(t, entry.ErrorDetails)
+	assert.Nil(t, entry.ResultParsed)
+	assert.Nil(t, entry.ErrorDetailsParsed)
+	assert.NotEmpty(t, entry.Arguments)
+	assert.NotEmpty(t, entry.Metadata)
+
+	var preview string
+	require.NoError(t, sonic.Unmarshal([]byte(entry.Arguments), &preview))
+	assert.Len(t, []rune(preview), 200)
+	assert.Contains(t, preview, `"input":`)
 }
 
 func TestPayloadFieldNames(t *testing.T) {

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -785,6 +785,7 @@ type MCPToolLog struct {
 	Cost           *float64  `gorm:"index:idx_mcp_logs_cost" json:"cost,omitempty"`                     // Cost in dollars (per execution cost)
 	Status         string    `gorm:"type:varchar(50);index:idx_mcp_logs_status;not null" json:"status"` // "processing", "success", or "error"
 	Metadata       string    `gorm:"type:text" json:"-"`                                                // JSON serialized map[string]interface{}
+	HasObject      bool      `gorm:"default:false" json:"-"`                                            // True when payload is stored in object storage
 	CreatedAt      time.Time `gorm:"index;not null" json:"created_at"`
 
 	// Virtual fields for JSON output - populated when needed

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -979,6 +979,11 @@ func (p *LoggerPlugin) GetLog(ctx context.Context, id string) (*logstore.Log, er
 	return p.store.FindByID(ctx, id)
 }
 
+// GetMCPToolLog retrieves a single MCP tool log entry by ID.
+func (p *LoggerPlugin) GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error) {
+	return p.store.FindMCPToolLog(ctx, id)
+}
+
 // GetStats calculates statistics for logs matching the given filters
 func (p *LoggerPlugin) GetStats(ctx context.Context, filters logstore.SearchFilters) (*logstore.SearchStats, error) {
 	return p.store.GetStats(ctx, filters)

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -122,6 +122,9 @@ type LogManager interface {
 	RecalculateCosts(ctx context.Context, filters *logstore.SearchFilters, limit int) (*RecalculateCostResult, error)
 
 	// MCP Tool Log methods
+	// GetMCPToolLog retrieves a single MCP tool log entry by ID.
+	GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error)
+
 	// SearchMCPToolLogs searches for MCP tool log entries based on filters and pagination
 	SearchMCPToolLogs(ctx context.Context, filters *logstore.MCPToolLogSearchFilters, pagination *logstore.PaginationOptions) (*logstore.MCPToolLogSearchResult, error)
 
@@ -364,6 +367,17 @@ func (p *PluginLogManager) RecalculateCosts(ctx context.Context, filters *logsto
 		return nil, fmt.Errorf("filters cannot be nil")
 	}
 	return p.plugin.RecalculateCosts(ctx, *filters, limit)
+}
+
+// GetMCPToolLog retrieves a single MCP tool log entry by ID.
+func (p *PluginLogManager) GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error) {
+	if p.plugin == nil || p.plugin.store == nil {
+		return nil, fmt.Errorf("log store not initialized")
+	}
+	if strings.TrimSpace(id) == "" {
+		return nil, fmt.Errorf("id cannot be empty")
+	}
+	return p.plugin.GetMCPToolLog(ctx, id)
 }
 
 // SearchMCPToolLogs searches for MCP tool log entries based on filters and pagination

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -96,6 +96,7 @@ func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas
 	r.GET("/api/mcp-logs/histogram", lib.ChainMiddlewares(h.getMCPHistogram, middlewares...))
 	r.GET("/api/mcp-logs/histogram/cost", lib.ChainMiddlewares(h.getMCPCostHistogram, middlewares...))
 	r.GET("/api/mcp-logs/histogram/top-tools", lib.ChainMiddlewares(h.getMCPTopTools, middlewares...))
+	r.GET("/api/mcp-logs/{id}", lib.ChainMiddlewares(h.getMCPLogByID, middlewares...))
 	r.DELETE("/api/mcp-logs", lib.ChainMiddlewares(h.deleteMCPLogs, middlewares...))
 }
 
@@ -1554,6 +1555,32 @@ func (h *LoggingHandler) getMCPLogs(ctx *fasthttp.RequestCtx) {
 	}
 
 	SendJSON(ctx, result)
+}
+
+// getMCPLogByID handles GET /api/mcp-logs/{id} - Get a single MCP tool log entry by ID.
+func (h *LoggingHandler) getMCPLogByID(ctx *fasthttp.RequestCtx) {
+	id, ok := ctx.UserValue("id").(string)
+	if !ok || strings.TrimSpace(id) == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "MCP log id is required")
+		return
+	}
+
+	log, err := h.logManager.GetMCPToolLog(ctx, id)
+	if err != nil {
+		if errors.Is(err, logstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "MCP log not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get MCP log: %v", err))
+		return
+	}
+
+	if log.VirtualKeyID != nil && log.VirtualKeyName != nil && *log.VirtualKeyID != "" && *log.VirtualKeyName != "" {
+		redactedVirtualKeys := h.redactedKeysManager.GetAllRedactedVirtualKeys(ctx, []string{*log.VirtualKeyID})
+		log.VirtualKey = findRedactedVirtualKey(redactedVirtualKeys, *log.VirtualKeyID, *log.VirtualKeyName)
+	}
+
+	SendJSON(ctx, log)
 }
 
 // getMCPLogsStats handles GET /api/mcp-logs/stats - Get statistics for MCP tool logs with filtering

--- a/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
@@ -12,14 +12,21 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CodeEditor } from "@/components/ui/codeEditor";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Status, StatusColors, Statuses } from "@/lib/constants/logs";
+import { useGetMCPLogByIdQuery } from "@/lib/store";
 import type { MCPToolLogEntry } from "@/lib/types/logs";
 import { downloadAsJson } from "@/lib/utils/browser-download";
 import { addMilliseconds, format, isValid } from "date-fns";
-import { ChevronDown, ChevronUp, Download, MoreVertical, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, Download, Loader2, MoreVertical, Trash2 } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { toast } from "sonner";
@@ -70,6 +77,13 @@ export function MCPLogDetailSheet({
 	hasNext = false,
 }: MCPLogDetailSheetProps) {
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const {
+		data: fullLog,
+		isLoading,
+		isError,
+	} = useGetMCPLogByIdQuery(log?.id ?? "", {
+		skip: !open || !log?.id,
+	});
 
 	// Keyboard navigation: arrow up/down to navigate between logs
 	useHotkeys("up", () => onNavigate?.("prev"), { enabled: open && hasPrev, preventDefault: true });
@@ -77,15 +91,31 @@ export function MCPLogDetailSheet({
 
 	if (!log) return null;
 
+	const isFullDataReady = isError || (fullLog?.id === log.id && !isLoading);
+	const displayLog = isFullDataReady && fullLog ? fullLog : log;
+
+	if (!isFullDataReady) {
+		return (
+			<Sheet open={open} onOpenChange={onOpenChange}>
+				<SheetContent className="flex w-full flex-col gap-4 overflow-x-hidden p-8 sm:max-w-[60%]">
+					<div className="flex h-full items-center justify-center">
+						<SheetTitle className="sr-only">Loading MCP log details</SheetTitle>
+						<Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+					</div>
+				</SheetContent>
+			</Sheet>
+		);
+	}
+
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="flex w-full flex-col gap-4 overflow-x-hidden p-8 sm:max-w-[60%]">
 				<SheetHeader className="flex flex-row items-center px-0">
 					<div className="flex w-full items-center justify-between">
 						<SheetTitle className="flex w-fit items-center gap-2 font-medium">
-							{log.id && <p className="text-md max-w-full truncate">Request ID: {log.id}</p>}
-							<Badge variant="outline" className={`${StatusColors[getValidatedStatus(log.status)]} uppercase`}>
-								{log.status}
+							{displayLog.id && <p className="text-md max-w-full truncate">Request ID: {displayLog.id}</p>}
+							<Badge variant="outline" className={`${StatusColors[getValidatedStatus(displayLog.status)]} uppercase`}>
+								{displayLog.status}
 							</Badge>
 						</SheetTitle>
 					</div>
@@ -123,20 +153,22 @@ export function MCPLogDetailSheet({
 							<DropdownMenuContent align="end">
 								<DropdownMenuItem
 									data-testid="export-log-json"
-									onClick={() => downloadAsJson(log, `mcp-log-${log.id ?? "export"}.json`)}
+									onClick={() => downloadAsJson(displayLog, `mcp-log-${displayLog.id ?? "export"}.json`)}
 								>
 									<Download className="h-4 w-4" />
 									Export as JSON
 								</DropdownMenuItem>
-								{handleDelete ? <>
-									<DropdownMenuSeparator />
-									<AlertDialogTrigger asChild>
-										<DropdownMenuItem variant="destructive">
-											<Trash2 className="h-4 w-4" />
-											Delete log
-										</DropdownMenuItem>
-									</AlertDialogTrigger>
-								</> : null}
+								{handleDelete ? (
+									<>
+										<DropdownMenuSeparator />
+										<AlertDialogTrigger asChild>
+											<DropdownMenuItem variant="destructive">
+												<Trash2 className="h-4 w-4" />
+												Delete log
+											</DropdownMenuItem>
+										</AlertDialogTrigger>
+									</>
+								) : null}
 							</DropdownMenuContent>
 						</DropdownMenu>
 						<AlertDialogContent>
@@ -151,7 +183,7 @@ export function MCPLogDetailSheet({
 										e.preventDefault();
 										if (!handleDelete) return;
 										try {
-											await handleDelete(log);
+											await handleDelete(displayLog);
 											setDeleteDialogOpen(false);
 											onOpenChange(false);
 										} catch (err) {
@@ -174,18 +206,26 @@ export function MCPLogDetailSheet({
 							<LogEntryDetailsView
 								className="w-full"
 								label="Start Timestamp"
-								value={isValid(new Date(log.timestamp)) ? format(new Date(log.timestamp), "yyyy-MM-dd hh:mm:ss aa") : "Invalid date"}
+								value={
+									isValid(new Date(displayLog.timestamp))
+										? format(new Date(displayLog.timestamp), "yyyy-MM-dd hh:mm:ss aa")
+										: "Invalid date"
+								}
 							/>
 							<LogEntryDetailsView
 								className="w-full"
 								label="End Timestamp"
 								value={
-									isValid(new Date(log.timestamp))
-										? format(addMilliseconds(new Date(log.timestamp), log.latency || 0), "yyyy-MM-dd hh:mm:ss aa")
+									isValid(new Date(displayLog.timestamp))
+										? format(addMilliseconds(new Date(displayLog.timestamp), displayLog.latency || 0), "yyyy-MM-dd hh:mm:ss aa")
 										: "Invalid date"
 								}
 							/>
-							<LogEntryDetailsView className="w-full" label="Latency" value={log.latency ? `${log.latency.toFixed(2)}ms` : "NA"} />
+							<LogEntryDetailsView
+								className="w-full"
+								label="Latency"
+								value={displayLog.latency ? `${displayLog.latency.toFixed(2)}ms` : "NA"}
+							/>
 						</div>
 					</div>
 					<DottedSeparator />
@@ -195,27 +235,27 @@ export function MCPLogDetailSheet({
 							<LogEntryDetailsView
 								className="col-span-2 w-full"
 								label="Tool Name"
-								value={<span className="font-mono text-sm">{log.tool_name}</span>}
+								value={<span className="font-mono text-sm">{displayLog.tool_name}</span>}
 							/>
 							<LogEntryDetailsView
 								className="w-full"
 								label="Server"
 								value={
-									log.server_label ? (
+									displayLog.server_label ? (
 										<Badge variant="secondary" className="font-mono">
-											{log.server_label}
+											{displayLog.server_label}
 										</Badge>
 									) : (
 										"-"
 									)
 								}
 							/>
-							{log.virtual_key && <LogEntryDetailsView className="w-full" label="Virtual Key" value={log.virtual_key.name} />}
-							{log.llm_request_id && (
+							{displayLog.virtual_key && <LogEntryDetailsView className="w-full" label="Virtual Key" value={displayLog.virtual_key.name} />}
+							{displayLog.llm_request_id && (
 								<LogEntryDetailsView
 									className="col-span-3 w-full"
 									label="LLM Request ID"
-									value={<span className="font-mono text-xs">{log.llm_request_id}</span>}
+									value={<span className="font-mono text-xs">{displayLog.llm_request_id}</span>}
 								/>
 							)}
 						</div>
@@ -223,7 +263,7 @@ export function MCPLogDetailSheet({
 				</div>
 
 				{/* Arguments */}
-				{log.arguments && (
+				{displayLog.arguments && (
 					<div className="w-full rounded-sm border">
 						<div className="border-b px-6 py-2 text-sm font-medium">Arguments</div>
 						<CodeEditor
@@ -231,7 +271,11 @@ export function MCPLogDetailSheet({
 							shouldAdjustInitialHeight={true}
 							maxHeight={250}
 							wrap={true}
-							code={typeof log.arguments === "string" ? log.arguments : JSON.stringify(log.arguments as Record<string, unknown>, null, 2)}
+							code={
+								typeof displayLog.arguments === "string"
+									? displayLog.arguments
+									: JSON.stringify(displayLog.arguments as Record<string, unknown>, null, 2)
+							}
 							lang="json"
 							readonly={true}
 							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
@@ -240,7 +284,7 @@ export function MCPLogDetailSheet({
 				)}
 
 				{/* Result */}
-				{log.result && log.status !== "processing" && (
+				{displayLog.result && displayLog.status !== "processing" && (
 					<div className="w-full rounded-sm border">
 						<div className="border-b px-6 py-2 text-sm font-medium">Result</div>
 						<CodeEditor
@@ -248,7 +292,7 @@ export function MCPLogDetailSheet({
 							shouldAdjustInitialHeight={true}
 							maxHeight={350}
 							wrap={true}
-							code={typeof log.result === "string" ? log.result : JSON.stringify(log.result, null, 2)}
+							code={typeof displayLog.result === "string" ? displayLog.result : JSON.stringify(displayLog.result, null, 2)}
 							lang="json"
 							readonly={true}
 							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
@@ -257,11 +301,11 @@ export function MCPLogDetailSheet({
 				)}
 
 				{/* Metadata */}
-				{log.metadata && Object.keys(log.metadata).length > 0 && (
+				{displayLog.metadata && Object.keys(displayLog.metadata).length > 0 && (
 					<div className="space-y-4 rounded-sm border px-6 py-4">
 						<BlockHeader title="Metadata" />
 						<div className="grid w-full grid-cols-3 items-start justify-between gap-4">
-							{Object.entries(log.metadata).map(([key, value]) => (
+							{Object.entries(displayLog.metadata).map(([key, value]) => (
 								<LogEntryDetailsView key={key} className="w-full" label={key} value={String(value)} />
 							))}
 						</div>
@@ -269,7 +313,7 @@ export function MCPLogDetailSheet({
 				)}
 
 				{/* Error Details */}
-				{log.error_details && (
+				{displayLog.error_details && (
 					<div className="border-destructive/50 w-full rounded-sm border">
 						<div className="border-destructive/50 text-destructive border-b px-6 py-2 text-sm font-medium">Error Details</div>
 						<CodeEditor
@@ -277,7 +321,7 @@ export function MCPLogDetailSheet({
 							shouldAdjustInitialHeight={true}
 							maxHeight={250}
 							wrap={true}
-							code={JSON.stringify(log.error_details, null, 2)}
+							code={JSON.stringify(displayLog.error_details, null, 2)}
 							lang="json"
 							readonly={true}
 							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}

--- a/ui/lib/store/apis/mcpLogsApi.ts
+++ b/ui/lib/store/apis/mcpLogsApi.ts
@@ -97,6 +97,12 @@ export const mcpLogsApi = baseApi.injectEndpoints({
 			providesTags: ["MCPLogs"],
 		}),
 
+		// Get a single MCP tool log entry by ID
+		getMCPLogById: builder.query<MCPToolLogEntry, string>({
+			query: (id) => `/mcp-logs/${encodeURIComponent(id)}`,
+			providesTags: (result, error, id) => [{ type: "MCPLogs", id }],
+		}),
+
 		// Get MCP tool logs statistics with filters
 		getMCPLogsStats: builder.query<
 			MCPToolLogStats,
@@ -188,10 +194,12 @@ export const mcpLogsApi = baseApi.injectEndpoints({
 
 export const {
 	useGetMCPLogsQuery,
+	useGetMCPLogByIdQuery,
 	useGetMCPLogsStatsQuery,
 	useGetMCPAvailableFilterDataQuery,
 	useGetMCPAvailableFilterDataQuery: useGetMCPLogsFilterDataQuery,
 	useLazyGetMCPLogsQuery,
+	useLazyGetMCPLogByIdQuery,
 	useLazyGetMCPLogsStatsQuery,
 	useLazyGetMCPAvailableFilterDataQuery,
 	useLazyGetMCPHistogramQuery,


### PR DESCRIPTION
## Summary

MCP tool logs were previously delegated directly to the inner (database) store without offloading large payloads to object storage. This PR extends the `HybridLogStore` to handle MCP tool logs the same way regular logs are handled: full payloads (arguments, results, error details) are offloaded to object storage, while the database row is kept lightweight with only index/preview fields.

## Changes

- `CreateMCPToolLog` now serializes the full MCP tool log payload to object storage and stores a stripped-down row in the DB via `PrepareMCPToolDBEntry`. Arguments are truncated to a preview in the DB; result and error fields are cleared.
- `FindMCPToolLog` hydrates the returned log from object storage when `has_object` is set, merging the full payload back into the struct.
- `UpdateMCPToolLog` fetches and merges the current state, writes a DB-only update with index fields, then re-offloads the full merged payload to object storage.
- `DeleteMCPToolLogs` resolves object keys before deleting DB rows, then batch-deletes the corresponding objects from the store.
- A status consistency check was added to `processUpload`: if the upload is for an MCP log and the log's status has changed since the work was enqueued, the upload is skipped to avoid overwriting a newer state.
- `enqueueUpload` was refactored into a lower-level `enqueueRawUpload` that accepts an explicit object key, MCP flag, and status, allowing both regular and MCP upload paths to share the same queue and worker logic.
- `BuildMCPToolTags` was added to construct S3 object tags from MCP tool log index fields (tool name, server label, status, virtual key ID, error flag, date).
- Helper functions `applyMCPToolLogUpdate`, `applyMCPToolLogUpdateMap`, `applyMCPToolLogUpdateStruct`, `prepareMCPToolLogDBUpdates`, and `prepareMCPToolLogDBUpdatesFromStruct` were added to cleanly separate in-memory state merging from DB update preparation.
- Tests were updated to use a temp-file SQLite DB instead of `:memory:` so that async upload workers operating on a separate connection see the same schema. New tests cover create-and-hydrate, update-and-offload, and delete-with-object-cleanup for MCP tool logs.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/...
```

The new tests `TestHybrid_CreateAndFindMCPToolLog`, `TestHybrid_UpdateMCPToolLogOffloadsFullLog`, and `TestHybrid_DeleteMCPToolLogsDeletesObjects` exercise the full create → upload → hydrate, update → re-upload, and delete → object cleanup paths respectively.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

MCP tool log payloads (arguments, results, error details) are now stored in object storage. Ensure that the configured object store bucket has appropriate access controls, as these fields may contain sensitive tool input/output data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable