### PR TITLE
fix e2e pr

### DIFF
--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -176,7 +176,7 @@ Storage backends. Each has `enabled` (boolean), `type` (string), and `config` (o
 | Store | Types |
 |-------|-------|
 | `config_store` | `"sqlite"`, `"postgres"` |
-| `logs_store` | `"sqlite"`, `"postgres"` (+ optional `object_storage`) |
+| `logs_store` | `"sqlite"`, `"postgres"` (+ optional `object_storage` for LLM and MCP logs) |
 | `vector_store` | `"weaviate"`, `"redis"`, `"qdrant"`, `"pinecone"` (`"redis"` also covers Valkey-compatible endpoints) |
 
 Full documentation: [Storage](/deployment-guides/config-json/storage).

--- a/docs/deployment-guides/config-json/storage.mdx
+++ b/docs/deployment-guides/config-json/storage.mdx
@@ -210,7 +210,7 @@ Set `retention_days` to automatically purge old log entries. `0` disables retent
 
 ### Object Storage for Logs
 
-Offload large request/response payloads from the database to S3 or GCS. The database retains only lightweight index records; payloads are fetched on demand.
+Offload LLM request/response logs and MCP tool logs from the database to S3 or GCS. The database retains lightweight index records and fetches full payloads on demand. For MCP logs, the full tool log is stored in object storage and the database keeps dashboard/table fields plus a 200-character input preview.
 
 <Tabs>
 <Tab title="AWS S3">

--- a/docs/deployment-guides/helm/storage.mdx
+++ b/docs/deployment-guides/helm/storage.mdx
@@ -325,7 +325,7 @@ bifrost:
       envVar: "S3_SECRET_ACCESS_KEY"
 ```
 
-`storage.logsStore.objectStorageExcludeFields` keeps selected payload fields in Postgres while still offloading the rest to object storage. Use DB payload field names such as `output_message`, `input_history`, `raw_request`, or `raw_response`.
+`storage.logsStore.objectStorageExcludeFields` keeps selected LLM log payload fields in Postgres while still offloading the rest to object storage. Use DB payload field names such as `output_message`, `input_history`, `raw_request`, or `raw_response`. MCP logs always offload the full tool log and keep dashboard/table fields plus a 200-character input preview in Postgres.
 
 **Using IAM role (IRSA / instance profile) instead of static keys:**
 

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -38665,6 +38665,146 @@
         }
       }
     },
+    "/api/mcp-logs/{id}": {
+      "get": {
+        "operationId": "getMCPLogById",
+        "summary": "Get MCP tool log by ID",
+        "description": "Retrieves a single MCP tool execution log by ID, including hydrated object-storage payloads when configured.",
+        "tags": [
+          "Logging"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "MCP tool log ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "MCP tool log found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "MCP tool execution log entry",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier for the log entry"
+                    },
+                    "llm_request_id": {
+                      "type": "string",
+                      "description": "Links to the LLM request that triggered this tool call"
+                    },
+                    "timestamp": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "When the tool execution started"
+                    },
+                    "tool_name": {
+                      "type": "string",
+                      "description": "Name of the MCP tool that was executed"
+                    },
+                    "server_label": {
+                      "type": "string",
+                      "description": "Label of the MCP server that provided the tool"
+                    },
+                    "virtual_key_id": {
+                      "type": "string",
+                      "description": "ID of the virtual key used for this tool execution"
+                    },
+                    "virtual_key_name": {
+                      "type": "string",
+                      "description": "Name of the virtual key used for this tool execution"
+                    },
+                    "arguments": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Tool execution arguments"
+                    },
+                    "result": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Tool execution result"
+                    },
+                    "error_details": {
+                      "$ref": "#/components/schemas/BifrostError"
+                    },
+                    "latency": {
+                      "type": "number",
+                      "description": "Execution time in milliseconds"
+                    },
+                    "cost": {
+                      "type": "number",
+                      "description": "Cost in dollars for this tool execution"
+                    },
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "processing",
+                        "success",
+                        "error"
+                      ],
+                      "description": "Execution status"
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Custom metadata captured from request headers (configured via logging_headers or x-bf-lh-* prefix)"
+                    },
+                    "created_at": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "When the log entry was created"
+                    },
+                    "virtual_key": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Full virtual key object (populated when virtual_key_id is set)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/mcp-logs/stats": {
       "get": {
         "operationId": "getMCPLogsStats",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -758,6 +758,8 @@ paths:
   # MCP Logs
   /api/mcp-logs:
     $ref: './paths/management/logging.yaml#/mcp-logs'
+  /api/mcp-logs/{id}:
+    $ref: './paths/management/logging.yaml#/mcp-logs-by-id'
   /api/mcp-logs/stats:
     $ref: './paths/management/logging.yaml#/mcp-logs-stats'
   /api/mcp-logs/filterdata:

--- a/docs/openapi/paths/management/logging.yaml
+++ b/docs/openapi/paths/management/logging.yaml
@@ -906,6 +906,34 @@ mcp-logs:
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 
+mcp-logs-by-id:
+  get:
+    operationId: getMCPLogById
+    summary: Get MCP tool log by ID
+    description: Retrieves a single MCP tool execution log by ID, including hydrated object-storage payloads when configured.
+    tags:
+      - Logging
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: MCP tool log ID
+        schema:
+          type: string
+    responses:
+      '200':
+        description: MCP tool log found
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/logging.yaml#/MCPToolLogEntry'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '404':
+        $ref: '../../openapi.yaml#/components/responses/NotFound'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
 mcp-logs-stats:
   get:
     operationId: getMCPLogsStats

--- a/framework/logstore/hybrid.go
+++ b/framework/logstore/hybrid.go
@@ -285,6 +285,9 @@ func (h *HybridLogStore) CreateIfNotExists(ctx context.Context, entry *Log) erro
 }
 
 func (h *HybridLogStore) BatchCreateIfNotExists(ctx context.Context, entries []*Log) error {
+	if len(entries) == 0 {
+		return nil
+	}
 	type pendingUpload struct {
 		logID     string
 		timestamp time.Time
@@ -293,8 +296,12 @@ func (h *HybridLogStore) BatchCreateIfNotExists(ctx context.Context, entries []*
 	}
 	var uploads []pendingUpload
 
-	dbEntries := make([]*Log, len(entries))
-	for i, entry := range entries {
+	dbEntries := make([]*Log, 0, len(entries))
+	origEntries := make([]*Log, 0, len(entries))
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
 		if err := entry.SerializeFields(); err != nil {
 			return fmt.Errorf("logstore: serialize before extract: %w", err)
 		}
@@ -303,7 +310,8 @@ func (h *HybridLogStore) BatchCreateIfNotExists(ctx context.Context, entries []*
 		// Work on a shallow copy so the caller's entries are preserved on DB failure.
 		dbEntry := *entry
 		prepareDBEntry(&dbEntry, h.excludedPayloadFields)
-		dbEntries[i] = &dbEntry
+		dbEntries = append(dbEntries, &dbEntry)
+		origEntries = append(origEntries, entry)
 		uploads = append(uploads, pendingUpload{
 			logID:     entry.ID,
 			timestamp: entry.Timestamp,
@@ -312,11 +320,14 @@ func (h *HybridLogStore) BatchCreateIfNotExists(ctx context.Context, entries []*
 		})
 	}
 
+	if len(dbEntries) == 0 {
+		return nil
+	}
 	if err := h.inner.BatchCreateIfNotExists(ctx, dbEntries); err != nil {
 		return err
 	}
 
-	for i, entry := range entries {
+	for i, entry := range origEntries {
 		entry.ContentSummary = dbEntries[i].ContentSummary
 	}
 
@@ -880,6 +891,53 @@ func (h *HybridLogStore) CreateMCPToolLog(ctx context.Context, entry *MCPToolLog
 		return err
 	}
 	h.enqueueRawUpload(entry.ID, entry.Timestamp, MCPToolObjectKey(h.prefix, entry.Timestamp, entry.ID), true, entry.Status, payload, tags)
+	return nil
+}
+
+func (h *HybridLogStore) BatchCreateMCPToolLogsIfNotExists(ctx context.Context, entries []*MCPToolLog) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	type pendingUpload struct {
+		logID     string
+		timestamp time.Time
+		status    string
+		payload   []byte
+		tags      map[string]string
+	}
+	var uploads []pendingUpload
+
+	dbEntries := make([]*MCPToolLog, 0, len(entries))
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		payload, err := MarshalMCPToolLogPayload(entry)
+		if err != nil {
+			return fmt.Errorf("logstore: serialize MCP tool log before offload: %w", err)
+		}
+		dbEntry := *entry
+		PrepareMCPToolDBEntry(&dbEntry)
+		dbEntries = append(dbEntries, &dbEntry)
+		uploads = append(uploads, pendingUpload{
+			logID:     entry.ID,
+			timestamp: entry.Timestamp,
+			status:    entry.Status,
+			payload:   payload,
+			tags:      BuildMCPToolTags(entry),
+		})
+	}
+
+	if len(dbEntries) == 0 {
+		return nil
+	}
+	if err := h.inner.BatchCreateMCPToolLogsIfNotExists(ctx, dbEntries); err != nil {
+		return err
+	}
+
+	for _, u := range uploads {
+		h.enqueueRawUpload(u.logID, u.timestamp, MCPToolObjectKey(h.prefix, u.timestamp, u.logID), true, u.status, u.payload, u.tags)
+	}
 	return nil
 }
 

--- a/framework/logstore/hybrid.go
+++ b/framework/logstore/hybrid.go
@@ -24,6 +24,9 @@ const (
 type uploadWork struct {
 	logID     string
 	timestamp time.Time
+	key       string
+	mcp       bool
+	status    string
 	payload   []byte // JSON-encoded payload
 	tags      map[string]string
 }
@@ -99,11 +102,25 @@ func (h *HybridLogStore) processUpload(work *uploadWork) {
 		}
 	}()
 
-	key := ObjectKey(h.prefix, work.timestamp, work.logID)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if err := h.objects.Put(ctx, key, work.payload, work.tags); err != nil {
+	if work.mcp {
+		current, err := h.inner.FindMCPToolLog(ctx, work.logID)
+		if err != nil {
+			h.logger.Warn("objectstore: failed to check MCP tool log %s before upload: %v", work.logID, err)
+			h.droppedUploads.Add(1)
+			return
+		}
+		// Status is the only monotonic-ish signal available on MCP log rows today.
+		// If stricter upload ordering is needed, add an updated_at/version column
+		// and compare it here alongside status.
+		if work.status != "" && current.Status != work.status {
+			return
+		}
+	}
+
+	if err := h.objects.Put(ctx, work.key, work.payload, work.tags); err != nil {
 		h.logger.Warn("objectstore: failed to upload log %s: %v", work.logID, err)
 		h.droppedUploads.Add(1)
 		return
@@ -114,7 +131,12 @@ func (h *HybridLogStore) processUpload(work *uploadWork) {
 	// with exponential backoff to avoid orphaning the uploaded object.
 	for attempt := 0; attempt < 3; attempt++ {
 		dbCtx, dbCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		err := h.inner.Update(dbCtx, work.logID, map[string]interface{}{"has_object": true})
+		var err error
+		if work.mcp {
+			err = h.inner.UpdateMCPToolLog(dbCtx, work.logID, map[string]interface{}{"has_object": true})
+		} else {
+			err = h.inner.Update(dbCtx, work.logID, map[string]interface{}{"has_object": true})
+		}
 		dbCancel()
 		if err == nil {
 			return
@@ -160,6 +182,18 @@ func (h *HybridLogStore) enqueueUpload(logID string, timestamp time.Time, payloa
 		h.droppedUploads.Add(1)
 		return
 	}
+	h.enqueueRawUpload(logID, timestamp, ObjectKey(h.prefix, timestamp, logID), false, "", data, tags)
+}
+
+func (h *HybridLogStore) enqueueRawUpload(logID string, timestamp time.Time, key string, mcp bool, status string, data []byte, tags map[string]string) {
+	if h.closed.Load() || len(data) == 0 {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			h.droppedUploads.Add(1)
+		}
+	}()
 	if h.pendingBytes.Load()+int64(len(data)) > defaultMaxUploadQueueBytes {
 		h.droppedUploads.Add(1)
 		h.logger.Warn("objectstore: upload queue memory limit reached, dropping upload for log %s", logID)
@@ -169,6 +203,9 @@ func (h *HybridLogStore) enqueueUpload(logID string, timestamp time.Time, payloa
 	case h.uploadQueue <- &uploadWork{
 		logID:     logID,
 		timestamp: timestamp,
+		key:       key,
+		mcp:       mcp,
+		status:    status,
 		payload:   data,
 		tags:      tags,
 	}:
@@ -319,6 +356,28 @@ func (h *HybridLogStore) hydrateLog(ctx context.Context, log *Log, requestedFiel
 		return
 	}
 	pruneUnrequestedPayloadFields(log, requestedFields)
+}
+
+func (h *HybridLogStore) hydrateMCPToolLog(ctx context.Context, log *MCPToolLog) error {
+	if log == nil || !log.HasObject {
+		return nil
+	}
+	return h.hydrateMCPToolLogFromObject(ctx, log)
+}
+
+func (h *HybridLogStore) hydrateMCPToolLogFromObject(ctx context.Context, log *MCPToolLog) error {
+	if log == nil {
+		return nil
+	}
+	key := MCPToolObjectKey(h.prefix, log.Timestamp, log.ID)
+	data, err := h.objects.Get(ctx, key)
+	if err != nil {
+		return fmt.Errorf("objectstore: fetch MCP tool log payload for %s: %w", log.ID, err)
+	}
+	if mergeErr := MergeMCPToolLogPayloadFromJSON(log, data); mergeErr != nil {
+		return fmt.Errorf("objectstore: merge MCP tool log payload for %s: %w", log.ID, mergeErr)
+	}
+	return nil
 }
 
 func (h *HybridLogStore) Update(ctx context.Context, id string, entry any) error {
@@ -548,7 +607,8 @@ func (h *HybridLogStore) GetDistinctMetadataKeys(ctx context.Context) (map[strin
 	return h.inner.GetDistinctMetadataKeys(ctx)
 }
 
-// MCP Tool Log methods — delegated directly.
+// MCP Tool Log analytics methods are delegated directly. Detail/write paths
+// below offload full MCP log objects while keeping DB rows lightweight.
 
 func (h *HybridLogStore) GetMCPHistogram(ctx context.Context, filters MCPToolLogSearchFilters, bucketSizeSeconds int64) (*MCPHistogramResult, error) {
 	return h.inner.GetMCPHistogram(ctx, filters, bucketSizeSeconds)
@@ -562,16 +622,306 @@ func (h *HybridLogStore) GetMCPTopTools(ctx context.Context, filters MCPToolLogS
 	return h.inner.GetMCPTopTools(ctx, filters, limit)
 }
 
+func applyMCPToolLogUpdate(target *MCPToolLog, entry any) error {
+	switch v := entry.(type) {
+	case map[string]interface{}:
+		return applyMCPToolLogUpdateMap(target, v)
+	case *MCPToolLog:
+		if v == nil {
+			return nil
+		}
+		update := *v
+		if err := update.SerializeFields(); err != nil {
+			return err
+		}
+		return applyMCPToolLogUpdateStruct(target, &update)
+	case MCPToolLog:
+		update := v
+		if err := update.SerializeFields(); err != nil {
+			return err
+		}
+		return applyMCPToolLogUpdateStruct(target, &update)
+	default:
+		return nil
+	}
+}
+
+func applyMCPToolLogUpdateMap(target *MCPToolLog, updates map[string]interface{}) error {
+	for key, value := range updates {
+		switch key {
+		case "request_id":
+			if v, ok := value.(string); ok {
+				target.RequestID = v
+			}
+		case "llm_request_id":
+			if v, ok := value.(string); ok {
+				target.LLMRequestID = &v
+			}
+		case "tool_name":
+			if v, ok := value.(string); ok {
+				target.ToolName = v
+			}
+		case "server_label":
+			if v, ok := value.(string); ok {
+				target.ServerLabel = v
+			}
+		case "virtual_key_id":
+			if v, ok := value.(string); ok {
+				target.VirtualKeyID = &v
+			}
+		case "virtual_key_name":
+			if v, ok := value.(string); ok {
+				target.VirtualKeyName = &v
+			}
+		case "arguments":
+			if v, ok := value.(string); ok {
+				target.Arguments = v
+				target.ArgumentsParsed = nil
+			}
+		case "result":
+			if v, ok := value.(string); ok {
+				target.Result = v
+				target.ResultParsed = nil
+			}
+		case "error_details":
+			if v, ok := value.(string); ok {
+				target.ErrorDetails = v
+				target.ErrorDetailsParsed = nil
+			}
+		case "metadata":
+			if v, ok := value.(string); ok {
+				target.Metadata = v
+				target.MetadataParsed = nil
+			}
+		case "latency":
+			if v, ok := numericToFloat64(value); ok {
+				target.Latency = &v
+			}
+		case "cost":
+			if v, ok := numericToFloat64(value); ok {
+				target.Cost = &v
+			}
+		case "status":
+			if v, ok := value.(string); ok {
+				target.Status = v
+			}
+		}
+	}
+	return target.DeserializeFields()
+}
+
+func applyMCPToolLogUpdateStruct(target *MCPToolLog, update *MCPToolLog) error {
+	if update.RequestID != "" {
+		target.RequestID = update.RequestID
+	}
+	if update.LLMRequestID != nil {
+		target.LLMRequestID = update.LLMRequestID
+	}
+	if !update.Timestamp.IsZero() {
+		target.Timestamp = update.Timestamp
+	}
+	if update.ToolName != "" {
+		target.ToolName = update.ToolName
+	}
+	if update.ServerLabel != "" {
+		target.ServerLabel = update.ServerLabel
+	}
+	if update.VirtualKeyID != nil {
+		target.VirtualKeyID = update.VirtualKeyID
+	}
+	if update.VirtualKeyName != nil {
+		target.VirtualKeyName = update.VirtualKeyName
+	}
+	if update.Arguments != "" {
+		target.Arguments = update.Arguments
+		target.ArgumentsParsed = nil
+	}
+	if update.Result != "" {
+		target.Result = update.Result
+		target.ResultParsed = nil
+	}
+	if update.ErrorDetails != "" {
+		target.ErrorDetails = update.ErrorDetails
+		target.ErrorDetailsParsed = nil
+	}
+	if update.Latency != nil {
+		target.Latency = update.Latency
+	}
+	if update.Cost != nil {
+		target.Cost = update.Cost
+	}
+	if update.Status != "" {
+		target.Status = update.Status
+	}
+	if update.Metadata != "" {
+		target.Metadata = update.Metadata
+		target.MetadataParsed = nil
+	}
+	if !update.CreatedAt.IsZero() {
+		target.CreatedAt = update.CreatedAt
+	}
+	return target.DeserializeFields()
+}
+
+func prepareMCPToolLogDBUpdates(entry any) (map[string]interface{}, error) {
+	switch v := entry.(type) {
+	case map[string]interface{}:
+		out := make(map[string]interface{}, len(v))
+		for key, value := range v {
+			switch key {
+			case "has_object":
+				continue
+			case "result", "error_details":
+				out[key] = ""
+			case "arguments":
+				if s, ok := value.(string); ok {
+					out[key] = marshalMCPPreviewString(truncateRunes(s, maxMCPToolInputPreviewRunes))
+				}
+			default:
+				out[key] = value
+			}
+		}
+		return out, nil
+	case *MCPToolLog:
+		if v == nil {
+			return nil, nil
+		}
+		return prepareMCPToolLogDBUpdatesFromStruct(*v)
+	case MCPToolLog:
+		return prepareMCPToolLogDBUpdatesFromStruct(v)
+	default:
+		return nil, nil
+	}
+}
+
+func prepareMCPToolLogDBUpdatesFromStruct(update MCPToolLog) (map[string]interface{}, error) {
+	if err := update.SerializeFields(); err != nil {
+		return nil, err
+	}
+	PrepareMCPToolDBEntry(&update)
+	out := make(map[string]interface{})
+	if update.RequestID != "" {
+		out["request_id"] = update.RequestID
+	}
+	if update.LLMRequestID != nil {
+		out["llm_request_id"] = *update.LLMRequestID
+	}
+	if !update.Timestamp.IsZero() {
+		out["timestamp"] = update.Timestamp
+	}
+	if update.ToolName != "" {
+		out["tool_name"] = update.ToolName
+	}
+	if update.ServerLabel != "" {
+		out["server_label"] = update.ServerLabel
+	}
+	if update.VirtualKeyID != nil {
+		out["virtual_key_id"] = *update.VirtualKeyID
+	}
+	if update.VirtualKeyName != nil {
+		out["virtual_key_name"] = *update.VirtualKeyName
+	}
+	if update.Arguments != "" {
+		out["arguments"] = update.Arguments
+	}
+	if update.Latency != nil {
+		out["latency"] = *update.Latency
+	}
+	if update.Cost != nil {
+		out["cost"] = *update.Cost
+	}
+	if update.Status != "" {
+		out["status"] = update.Status
+	}
+	if update.Metadata != "" {
+		out["metadata"] = update.Metadata
+	}
+	if !update.CreatedAt.IsZero() {
+		out["created_at"] = update.CreatedAt
+	}
+	return out, nil
+}
+
+func numericToFloat64(value interface{}) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}
+
+func marshalMCPPreviewString(s string) string {
+	data, err := sonic.Marshal(s)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
 func (h *HybridLogStore) CreateMCPToolLog(ctx context.Context, entry *MCPToolLog) error {
-	return h.inner.CreateMCPToolLog(ctx, entry)
+	payload, err := MarshalMCPToolLogPayload(entry)
+	if err != nil {
+		return fmt.Errorf("logstore: serialize MCP tool log before offload: %w", err)
+	}
+	tags := BuildMCPToolTags(entry)
+
+	dbEntry := *entry
+	PrepareMCPToolDBEntry(&dbEntry)
+	if err := h.inner.CreateMCPToolLog(ctx, &dbEntry); err != nil {
+		return err
+	}
+	h.enqueueRawUpload(entry.ID, entry.Timestamp, MCPToolObjectKey(h.prefix, entry.Timestamp, entry.ID), true, entry.Status, payload, tags)
+	return nil
 }
 
 func (h *HybridLogStore) FindMCPToolLog(ctx context.Context, id string) (*MCPToolLog, error) {
-	return h.inner.FindMCPToolLog(ctx, id)
+	log, err := h.inner.FindMCPToolLog(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := h.hydrateMCPToolLog(ctx, log); err != nil {
+		h.logger.Warn("%v", err)
+	}
+	return log, nil
 }
 
 func (h *HybridLogStore) UpdateMCPToolLog(ctx context.Context, id string, entry any) error {
-	return h.inner.UpdateMCPToolLog(ctx, id, entry)
+	current, err := h.inner.FindMCPToolLog(ctx, id)
+	if err != nil {
+		return err
+	}
+	if err := h.hydrateMCPToolLogFromObject(ctx, current); err != nil {
+		return err
+	}
+	if err := applyMCPToolLogUpdate(current, entry); err != nil {
+		return err
+	}
+
+	dbUpdates, err := prepareMCPToolLogDBUpdates(entry)
+	if err != nil {
+		return err
+	}
+	if len(dbUpdates) > 0 {
+		if err := h.inner.UpdateMCPToolLog(ctx, id, dbUpdates); err != nil {
+			return err
+		}
+	}
+
+	payload, err := MarshalMCPToolLogPayload(current)
+	if err != nil {
+		return fmt.Errorf("logstore: serialize MCP tool log update before offload: %w", err)
+	}
+	h.enqueueRawUpload(current.ID, current.Timestamp, MCPToolObjectKey(h.prefix, current.Timestamp, current.ID), true, current.Status, payload, BuildMCPToolTags(current))
+	return nil
 }
 
 func (h *HybridLogStore) SearchMCPToolLogs(ctx context.Context, filters MCPToolLogSearchFilters, pagination PaginationOptions) (*MCPToolLogSearchResult, error) {
@@ -587,7 +937,25 @@ func (h *HybridLogStore) HasMCPToolLogs(ctx context.Context) (bool, error) {
 }
 
 func (h *HybridLogStore) DeleteMCPToolLogs(ctx context.Context, ids []string) error {
-	return h.inner.DeleteMCPToolLogs(ctx, ids)
+	var keys []string
+	for _, id := range ids {
+		log, findErr := h.inner.FindMCPToolLog(ctx, id)
+		if findErr != nil && !errors.Is(findErr, ErrNotFound) {
+			return findErr
+		}
+		if log != nil && log.HasObject {
+			keys = append(keys, MCPToolObjectKey(h.prefix, log.Timestamp, log.ID))
+		}
+	}
+	if err := h.inner.DeleteMCPToolLogs(ctx, ids); err != nil {
+		return err
+	}
+	if len(keys) > 0 {
+		if delErr := h.objects.DeleteBatch(ctx, keys); delErr != nil {
+			h.logger.Warn("objectstore: failed to batch delete %d MCP tool log objects: %v", len(keys), delErr)
+		}
+	}
+	return nil
 }
 
 func (h *HybridLogStore) FlushMCPToolLogs(ctx context.Context, since time.Time) error {

--- a/framework/logstore/hybrid_test.go
+++ b/framework/logstore/hybrid_test.go
@@ -249,6 +249,77 @@ func TestHybrid_CreateAndFindMCPToolLog(t *testing.T) {
 	assert.Equal(t, true, found.ResultParsed.(map[string]interface{})["ok"])
 }
 
+func TestHybrid_BatchCreateMCPToolLogsIfNotExists(t *testing.T) {
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	longInput := ""
+	for i := 0; i < 260; i++ {
+		longInput += "b"
+	}
+	entries := []*MCPToolLog{
+		{
+			ID:          "mcp-batch-1",
+			RequestID:   "req-batch-1",
+			Timestamp:   time.Now().UTC(),
+			ToolName:    "search",
+			ServerLabel: "docs",
+			Status:      "success",
+			ArgumentsParsed: map[string]any{
+				"query": longInput,
+			},
+			ResultParsed: map[string]any{
+				"answer": "done",
+			},
+		},
+		{
+			ID:          "mcp-batch-2",
+			RequestID:   "req-batch-2",
+			Timestamp:   time.Now().UTC(),
+			ToolName:    "echo",
+			ServerLabel: "local",
+			Status:      "error",
+			ArgumentsParsed: map[string]any{
+				"input": "short",
+			},
+			ErrorDetailsParsed: &schemas.BifrostError{
+				IsBifrostError: true,
+				Error: &schemas.ErrorField{
+					Message: "failed",
+				},
+			},
+		},
+	}
+
+	require.NoError(t, hybrid.BatchCreateMCPToolLogsIfNotExists(ctx, entries))
+	waitForUploads(t, func() bool { return objStore.Len() == 2 })
+
+	dbOnly, err := inner.FindMCPToolLog(ctx, "mcp-batch-1")
+	require.NoError(t, err)
+	assert.True(t, dbOnly.HasObject)
+	assert.Empty(t, dbOnly.Result)
+	assert.Empty(t, dbOnly.ErrorDetails)
+	preview, ok := dbOnly.ArgumentsParsed.(string)
+	require.True(t, ok)
+	assert.Len(t, []rune(preview), 200)
+
+	found, err := hybrid.FindMCPToolLog(ctx, "mcp-batch-1")
+	require.NoError(t, err)
+	assert.Equal(t, longInput, found.ArgumentsParsed.(map[string]interface{})["query"])
+	assert.Equal(t, "done", found.ResultParsed.(map[string]interface{})["answer"])
+
+	foundError, err := hybrid.FindMCPToolLog(ctx, "mcp-batch-2")
+	require.NoError(t, err)
+	require.NotNil(t, foundError.ErrorDetailsParsed)
+	assert.Equal(t, "failed", foundError.ErrorDetailsParsed.Error.Message)
+
+	require.NoError(t, hybrid.BatchCreateMCPToolLogsIfNotExists(ctx, entries))
+	var count int64
+	require.NoError(t, inner.(*RDBLogStore).db.WithContext(ctx).Model(&MCPToolLog{}).Where("id IN ?", []string{"mcp-batch-1", "mcp-batch-2"}).Count(&count).Error)
+	assert.Equal(t, int64(2), count)
+}
+
 func TestHybrid_UpdateMCPToolLogOffloadsFullLog(t *testing.T) {
 	hybrid, inner, objStore := newTestHybrid(t)
 	defer hybrid.Close(context.Background())

--- a/framework/logstore/hybrid_test.go
+++ b/framework/logstore/hybrid_test.go
@@ -2,6 +2,7 @@ package logstore
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -13,13 +14,13 @@ import (
 
 type hybridTestLogger struct{}
 
-func (hybridTestLogger) Debug(string, ...any)                                  {}
-func (hybridTestLogger) Info(string, ...any)                                   {}
-func (hybridTestLogger) Warn(string, ...any)                                   {}
-func (hybridTestLogger) Error(string, ...any)                                  {}
-func (hybridTestLogger) Fatal(string, ...any)                                  {}
-func (hybridTestLogger) SetLevel(schemas.LogLevel)                             {}
-func (hybridTestLogger) SetOutputType(schemas.LoggerOutputType)                {}
+func (hybridTestLogger) Debug(string, ...any)                   {}
+func (hybridTestLogger) Info(string, ...any)                    {}
+func (hybridTestLogger) Warn(string, ...any)                    {}
+func (hybridTestLogger) Error(string, ...any)                   {}
+func (hybridTestLogger) Fatal(string, ...any)                   {}
+func (hybridTestLogger) SetLevel(schemas.LogLevel)              {}
+func (hybridTestLogger) SetOutputType(schemas.LoggerOutputType) {}
 func (hybridTestLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBuilder {
 	return schemas.NoopLogEvent
 }
@@ -28,8 +29,9 @@ func newTestHybrid(t *testing.T) (*HybridLogStore, LogStore, *objectstore.InMemo
 	t.Helper()
 	ctx := context.Background()
 
-	// Create SQLite inner store.
-	inner, err := newSqliteLogStore(ctx, &SQLiteConfig{Path: ":memory:"}, hybridTestLogger{})
+	// Use a temp file instead of :memory: so async upload workers that use a
+	// separate DB connection see the same schema.
+	inner, err := newSqliteLogStore(ctx, &SQLiteConfig{Path: filepath.Join(t.TempDir(), "hybrid.db")}, hybridTestLogger{})
 	require.NoError(t, err)
 
 	objStore := objectstore.NewInMemoryObjectStore()
@@ -204,6 +206,226 @@ func TestHybrid_FindByID_GracefulDegradation(t *testing.T) {
 	assert.Empty(t, found.OutputMessage, "output should be empty when S3 fails")
 }
 
+func TestHybrid_CreateAndFindMCPToolLog(t *testing.T) {
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	longInput := ""
+	for i := 0; i < 260; i++ {
+		longInput += "a"
+	}
+	entry := &MCPToolLog{
+		ID:          "mcp-1",
+		RequestID:   "req-1",
+		Timestamp:   time.Now().UTC(),
+		ToolName:    "echo",
+		ServerLabel: "local",
+		Status:      "success",
+		ArgumentsParsed: map[string]any{
+			"input": longInput,
+		},
+		ResultParsed: map[string]any{
+			"ok": true,
+		},
+	}
+
+	require.NoError(t, hybrid.CreateMCPToolLog(ctx, entry))
+	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+
+	dbOnly, err := inner.FindMCPToolLog(ctx, "mcp-1")
+	require.NoError(t, err)
+	assert.True(t, dbOnly.HasObject)
+	assert.Empty(t, dbOnly.Result)
+	assert.Nil(t, dbOnly.ResultParsed)
+	preview, ok := dbOnly.ArgumentsParsed.(string)
+	require.True(t, ok)
+	assert.Len(t, []rune(preview), 200)
+
+	found, err := hybrid.FindMCPToolLog(ctx, "mcp-1")
+	require.NoError(t, err)
+	assert.True(t, found.HasObject)
+	assert.Equal(t, longInput, found.ArgumentsParsed.(map[string]interface{})["input"])
+	assert.Equal(t, true, found.ResultParsed.(map[string]interface{})["ok"])
+}
+
+func TestHybrid_UpdateMCPToolLogOffloadsFullLog(t *testing.T) {
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	entry := &MCPToolLog{
+		ID:          "mcp-update",
+		RequestID:   "req-update",
+		Timestamp:   time.Now().UTC(),
+		ToolName:    "search",
+		ServerLabel: "docs",
+		Status:      "processing",
+		ArgumentsParsed: map[string]any{
+			"query": "find this",
+		},
+	}
+	require.NoError(t, hybrid.CreateMCPToolLog(ctx, entry))
+	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+
+	require.NoError(t, hybrid.UpdateMCPToolLog(ctx, entry.ID, MCPToolLog{
+		Status: "success",
+		ResultParsed: map[string]any{
+			"answer": "done",
+		},
+	}))
+
+	waitForUploads(t, func() bool {
+		found, err := hybrid.FindMCPToolLog(ctx, entry.ID)
+		if err != nil || found.ResultParsed == nil {
+			return false
+		}
+		result, ok := found.ResultParsed.(map[string]interface{})
+		return ok && result["answer"] == "done"
+	})
+
+	dbOnly, err := inner.FindMCPToolLog(ctx, entry.ID)
+	require.NoError(t, err)
+	assert.True(t, dbOnly.HasObject)
+	assert.Equal(t, "success", dbOnly.Status)
+	assert.Empty(t, dbOnly.Result)
+	assert.Nil(t, dbOnly.ResultParsed)
+
+	found, err := hybrid.FindMCPToolLog(ctx, entry.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "find this", found.ArgumentsParsed.(map[string]interface{})["query"])
+	assert.Equal(t, "done", found.ResultParsed.(map[string]interface{})["answer"])
+}
+
+func TestHybrid_UpdateMCPToolLogRequiresObjectHydration(t *testing.T) {
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	entry := &MCPToolLog{
+		ID:          "mcp-hydration-fail",
+		RequestID:   "req-hydration-fail",
+		Timestamp:   time.Now().UTC(),
+		ToolName:    "search",
+		ServerLabel: "docs",
+		Status:      "success",
+		ArgumentsParsed: map[string]any{
+			"query": "full input",
+		},
+		ResultParsed: map[string]any{
+			"answer": "original",
+		},
+	}
+	require.NoError(t, hybrid.CreateMCPToolLog(ctx, entry))
+	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+
+	objStore.GetErr = assert.AnError
+	err := hybrid.UpdateMCPToolLog(ctx, entry.ID, MCPToolLog{
+		Status: "success",
+		ResultParsed: map[string]any{
+			"answer": "updated",
+		},
+	})
+	require.Error(t, err)
+	objStore.GetErr = nil
+
+	found, err := hybrid.FindMCPToolLog(ctx, entry.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "full input", found.ArgumentsParsed.(map[string]interface{})["query"])
+	assert.Equal(t, "original", found.ResultParsed.(map[string]interface{})["answer"])
+
+	dbOnly, err := inner.FindMCPToolLog(ctx, entry.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "success", dbOnly.Status)
+}
+
+func TestHybrid_UpdateMCPToolLogHydratesObjectBeforeHasObjectMarker(t *testing.T) {
+	hybrid, inner, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	longInput := ""
+	for i := 0; i < 260; i++ {
+		longInput += "q"
+	}
+	entry := &MCPToolLog{
+		ID:          "mcp-has-object-false",
+		RequestID:   "req-has-object-false",
+		Timestamp:   time.Now().UTC(),
+		ToolName:    "search",
+		ServerLabel: "docs",
+		Status:      "processing",
+		ArgumentsParsed: map[string]any{
+			"query": longInput,
+		},
+	}
+	payload, err := MarshalMCPToolLogPayload(entry)
+	require.NoError(t, err)
+	dbEntry := *entry
+	PrepareMCPToolDBEntry(&dbEntry)
+	require.NoError(t, inner.CreateMCPToolLog(ctx, &dbEntry))
+	require.NoError(t, objStore.Put(ctx, MCPToolObjectKey(hybrid.prefix, entry.Timestamp, entry.ID), payload, BuildMCPToolTags(entry)))
+
+	require.NoError(t, hybrid.UpdateMCPToolLog(ctx, entry.ID, MCPToolLog{
+		Status: "success",
+		ResultParsed: map[string]any{
+			"answer": "done",
+		},
+	}))
+	waitForUploads(t, func() bool {
+		found, err := hybrid.FindMCPToolLog(ctx, entry.ID)
+		if err != nil || found.ResultParsed == nil {
+			return false
+		}
+		result, ok := found.ResultParsed.(map[string]interface{})
+		return ok && result["answer"] == "done"
+	})
+
+	found, err := hybrid.FindMCPToolLog(ctx, entry.ID)
+	require.NoError(t, err)
+	assert.Equal(t, longInput, found.ArgumentsParsed.(map[string]interface{})["query"])
+	assert.Equal(t, "done", found.ResultParsed.(map[string]interface{})["answer"])
+}
+
+func TestHybrid_ProcessMCPUploadSkipsMissingRowsWithEmptyStatus(t *testing.T) {
+	hybrid, _, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+
+	hybrid.processUpload(&uploadWork{
+		logID:     "mcp-missing-row",
+		timestamp: time.Now().UTC(),
+		key:       MCPToolObjectKey(hybrid.prefix, time.Now().UTC(), "mcp-missing-row"),
+		mcp:       true,
+		payload:   []byte(`{"id":"mcp-missing-row"}`),
+	})
+
+	assert.Equal(t, 0, objStore.Len())
+	assert.Equal(t, int64(1), hybrid.DroppedUploads())
+}
+
+func TestHybrid_DeleteMCPToolLogsDeletesObjects(t *testing.T) {
+	hybrid, _, objStore := newTestHybrid(t)
+	defer hybrid.Close(context.Background())
+	ctx := context.Background()
+
+	entry := &MCPToolLog{
+		ID:          "mcp-delete",
+		RequestID:   "req-delete",
+		Timestamp:   time.Now().UTC(),
+		ToolName:    "echo",
+		ServerLabel: "local",
+		Status:      "success",
+		ArgumentsParsed: map[string]any{
+			"input": "delete me",
+		},
+	}
+	require.NoError(t, hybrid.CreateMCPToolLog(ctx, entry))
+	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+
+	require.NoError(t, hybrid.DeleteMCPToolLogs(ctx, []string{entry.ID}))
+	assert.Equal(t, 0, objStore.Len())
+}
+
 func TestHybrid_PutFailureDropsUpload(t *testing.T) {
 	hybrid, _, objStore := newTestHybrid(t)
 	defer hybrid.Close(context.Background())
@@ -335,7 +557,7 @@ func TestHybrid_ContentSummaryIsInputOnly(t *testing.T) {
 func newTestHybridWithExclude(t *testing.T, excludeFields []string) (*HybridLogStore, LogStore, *objectstore.InMemoryObjectStore) {
 	t.Helper()
 	ctx := context.Background()
-	inner, err := newSqliteLogStore(ctx, &SQLiteConfig{Path: ":memory:"}, hybridTestLogger{})
+	inner, err := newSqliteLogStore(ctx, &SQLiteConfig{Path: filepath.Join(t.TempDir(), "hybrid.db")}, hybridTestLogger{})
 	require.NoError(t, err)
 	objStore := objectstore.NewInMemoryObjectStore()
 	hybrid := newHybridLogStore(inner, objStore, "test", hybridTestLogger{}, excludeFields)

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -298,6 +298,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddHasObjectColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddHasObjectColumnToMCPToolLogs(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddAttemptTrailColumn(ctx, db); err != nil {
 		return err
 	}
@@ -2411,6 +2414,41 @@ func migrationAddHasObjectColumn(ctx context.Context, db *gorm.DB) error {
 	return nil
 }
 
+// migrationAddHasObjectColumnToMCPToolLogs adds the has_object boolean column to the mcp_tool_logs table.
+// Used by the hybrid log store to track whether an MCP tool log's payload is stored in object storage.
+func migrationAddHasObjectColumnToMCPToolLogs(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "mcp_tool_logs_add_has_object_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mgr := tx.Migrator()
+			if !mgr.HasColumn(&MCPToolLog{}, "has_object") {
+				if err := mgr.AddColumn(&MCPToolLog{}, "has_object"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mgr := tx.Migrator()
+			if mgr.HasColumn(&MCPToolLog{}, "has_object") {
+				if err := mgr.DropColumn(&MCPToolLog{}, "has_object"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	}})
+	err := m.Migrate()
+	if err != nil {
+		return fmt.Errorf("error while adding has_object column to mcp_tool_logs: %s", err.Error())
+	}
+	return nil
+}
+
 // migrationAddImageVariationInputColumn adds the image_variation_input column to the logs table.
 func migrationAddImageVariationInputColumn(ctx context.Context, db *gorm.DB) error {
 	opts := *migrator.DefaultOptions
@@ -2731,4 +2769,3 @@ func migrationAddStopReasonColumn(ctx context.Context, db *gorm.DB) error {
 	}
 	return nil
 }
-

--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -509,6 +509,30 @@ func BuildTags(l *Log) map[string]string {
 	return tags
 }
 
+// BuildMCPToolTags creates the object tag map from an MCP tool log's index
+// fields. S3 allows max 10 tags per object.
+func BuildMCPToolTags(l *MCPToolLog) map[string]string {
+	tags := make(map[string]string, 6)
+	if l.ToolName != "" {
+		tags["tool_name"] = truncateTag(l.ToolName, 256)
+	}
+	if l.ServerLabel != "" {
+		tags["server_label"] = truncateTag(l.ServerLabel, 256)
+	}
+	if l.Status != "" {
+		tags["status"] = l.Status
+	}
+	if l.VirtualKeyID != nil && *l.VirtualKeyID != "" {
+		tags["virtual_key_id"] = truncateTag(*l.VirtualKeyID, 256)
+	}
+	tags["has_error"] = "false"
+	if l.Status == "error" {
+		tags["has_error"] = "true"
+	}
+	tags["date"] = l.Timestamp.UTC().Format("2006-01-02")
+	return tags
+}
+
 // ObjectKey constructs the S3 object key for a log entry.
 func ObjectKey(prefix string, timestamp time.Time, logID string) string {
 	ts := timestamp.UTC()

--- a/framework/logstore/payload.go
+++ b/framework/logstore/payload.go
@@ -9,6 +9,8 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
+const maxMCPToolInputPreviewRunes = 200
+
 // payloadFields lists the DB column names of large TEXT fields that are
 // offloaded to object storage in hybrid mode. These fields are never needed
 // for analytics queries (histograms, search, rankings) — only for individual
@@ -311,6 +313,64 @@ func MarshalPayload(payload map[string]string) ([]byte, error) {
 	return sonic.Marshal(payload)
 }
 
+// MarshalMCPToolLogPayload serializes a full MCP tool log for object storage.
+// The object-store copy is intentionally complete; the DB row is only a
+// lightweight index plus a short input preview.
+func MarshalMCPToolLogPayload(l *MCPToolLog) ([]byte, error) {
+	payload := *l
+	if err := payload.SerializeFields(); err != nil {
+		return nil, err
+	}
+	_ = payload.DeserializeFields()
+	return sonic.Marshal(&payload)
+}
+
+// MergeMCPToolLogPayloadFromJSON replaces an MCP tool log with the full object
+// storage copy while preserving DB-local hydration state.
+func MergeMCPToolLogPayloadFromJSON(l *MCPToolLog, data []byte) error {
+	hasObject := l.HasObject
+	virtualKey := l.VirtualKey
+
+	var payload MCPToolLog
+	if err := sonic.Unmarshal(data, &payload); err != nil {
+		return fmt.Errorf("logstore: unmarshal MCP tool log payload: %w", err)
+	}
+	if err := payload.SerializeFields(); err != nil {
+		return err
+	}
+	*l = payload
+	l.HasObject = hasObject
+	l.VirtualKey = virtualKey
+	return nil
+}
+
+// PrepareMCPToolDBEntry converts an MCP tool log to the lightweight DB form
+// used by hybrid storage. It preserves indexed/display fields and metadata,
+// keeps only a 200-character JSON-string argument preview, and clears result
+// and error payloads.
+func PrepareMCPToolDBEntry(l *MCPToolLog) {
+	preview := buildMCPToolInputPreview(l)
+	l.ArgumentsParsed = preview
+	l.Arguments = ""
+	l.Result = ""
+	l.ErrorDetails = ""
+	l.ResultParsed = nil
+	l.ErrorDetailsParsed = nil
+	_ = l.SerializeFields()
+}
+
+func buildMCPToolInputPreview(l *MCPToolLog) string {
+	if l.ArgumentsParsed != nil {
+		if data, err := sonic.Marshal(l.ArgumentsParsed); err == nil {
+			return truncateRunes(string(data), maxMCPToolInputPreviewRunes)
+		}
+	}
+	if l.Arguments != "" {
+		return truncateRunes(l.Arguments, maxMCPToolInputPreviewRunes)
+	}
+	return ""
+}
+
 // BuildInputContentSummary extracts the last user message text from input fields.
 // This is used in hybrid mode for the content_summary column, which powers
 // full-text search and serves as a display fallback in the log list table.
@@ -453,6 +513,16 @@ func BuildTags(l *Log) map[string]string {
 func ObjectKey(prefix string, timestamp time.Time, logID string) string {
 	ts := timestamp.UTC()
 	return fmt.Sprintf("%s/logs/%04d/%02d/%02d/%02d/%s.json.gz",
+		prefix,
+		ts.Year(), ts.Month(), ts.Day(), ts.Hour(),
+		logID,
+	)
+}
+
+// MCPToolObjectKey constructs the S3 object key for an MCP tool log entry.
+func MCPToolObjectKey(prefix string, timestamp time.Time, logID string) string {
+	ts := timestamp.UTC()
+	return fmt.Sprintf("%s/mcp-logs/%04d/%02d/%02d/%02d/%s.json.gz",
 		prefix,
 		ts.Year(), ts.Month(), ts.Day(), ts.Hour(),
 		logID,
@@ -643,4 +713,17 @@ func truncateTag(s string, maxLen int) string {
 		byteLen += rl
 	}
 	return s[:byteLen]
+}
+
+func truncateRunes(s string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	for i := range s {
+		if maxRunes == 0 {
+			return s[:i]
+		}
+		maxRunes--
+	}
+	return s
 }

--- a/framework/logstore/payload_test.go
+++ b/framework/logstore/payload_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -141,6 +142,113 @@ func TestObjectKey(t *testing.T) {
 	ts := time.Date(2026, 4, 3, 14, 0, 0, 0, time.UTC)
 	key := ObjectKey("bifrost", ts, "req_abc123")
 	assert.Equal(t, "bifrost/logs/2026/04/03/14/req_abc123.json.gz", key)
+}
+
+func TestMCPToolObjectKey(t *testing.T) {
+	ts := time.Date(2026, 4, 3, 14, 0, 0, 0, time.UTC)
+	key := MCPToolObjectKey("bifrost", ts, "mcp_abc123")
+	assert.Equal(t, "bifrost/mcp-logs/2026/04/03/14/mcp_abc123.json.gz", key)
+}
+
+func TestMCPToolLogPayload_RoundTripFullLog(t *testing.T) {
+	vkID := "vk_123"
+	cost := 0.01
+	latency := 42.5
+	entry := &MCPToolLog{
+		ID:             "mcp-1",
+		RequestID:      "req-1",
+		LLMRequestID:   strPtr("llm-1"),
+		Timestamp:      time.Date(2026, 4, 3, 14, 0, 0, 0, time.UTC),
+		ToolName:       "search",
+		ServerLabel:    "docs",
+		VirtualKeyID:   &vkID,
+		VirtualKeyName: strPtr("prod-key"),
+		Latency:        &latency,
+		Cost:           &cost,
+		Status:         "success",
+		CreatedAt:      time.Date(2026, 4, 3, 14, 0, 1, 0, time.UTC),
+		ArgumentsParsed: map[string]any{
+			"query": "full input",
+		},
+		ResultParsed: map[string]any{
+			"ok": true,
+		},
+		ErrorDetailsParsed: &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: &schemas.ErrorField{
+				Message: "stored for round trip",
+			},
+		},
+		MetadataParsed: map[string]interface{}{
+			"trace": "abc",
+		},
+	}
+
+	data, err := MarshalMCPToolLogPayload(entry)
+	require.NoError(t, err)
+
+	dbEntry := &MCPToolLog{HasObject: true}
+	err = MergeMCPToolLogPayloadFromJSON(dbEntry, data)
+	require.NoError(t, err)
+
+	assert.True(t, dbEntry.HasObject)
+	assert.Equal(t, entry.ID, dbEntry.ID)
+	assert.Equal(t, entry.RequestID, dbEntry.RequestID)
+	assert.Equal(t, entry.ToolName, dbEntry.ToolName)
+	assert.Equal(t, entry.ServerLabel, dbEntry.ServerLabel)
+	assert.Equal(t, entry.Status, dbEntry.Status)
+	assert.Equal(t, "full input", dbEntry.ArgumentsParsed.(map[string]interface{})["query"])
+	assert.Equal(t, true, dbEntry.ResultParsed.(map[string]interface{})["ok"])
+	assert.Equal(t, "stored for round trip", dbEntry.ErrorDetailsParsed.Error.Message)
+	assert.Equal(t, "abc", dbEntry.MetadataParsed["trace"])
+}
+
+func TestPrepareMCPToolDBEntry_KeepsOnlyInputPreview(t *testing.T) {
+	longInput := ""
+	for i := 0; i < 260; i++ {
+		longInput += "a"
+	}
+	entry := &MCPToolLog{
+		ID:          "mcp-preview",
+		RequestID:   "req-preview",
+		Timestamp:   time.Date(2026, 4, 3, 14, 0, 0, 0, time.UTC),
+		ToolName:    "echo",
+		ServerLabel: "local",
+		Status:      "success",
+		ArgumentsParsed: map[string]any{
+			"input": longInput,
+		},
+		ResultParsed: map[string]any{
+			"secret": "large result",
+		},
+		ErrorDetailsParsed: &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: &schemas.ErrorField{
+				Message: "large error",
+			},
+		},
+		MetadataParsed: map[string]interface{}{
+			"trace": "abc",
+		},
+	}
+
+	PrepareMCPToolDBEntry(entry)
+
+	assert.Equal(t, "mcp-preview", entry.ID)
+	assert.Equal(t, "req-preview", entry.RequestID)
+	assert.Equal(t, "echo", entry.ToolName)
+	assert.Equal(t, "local", entry.ServerLabel)
+	assert.Empty(t, entry.Result)
+	assert.Empty(t, entry.ErrorDetails)
+	assert.Nil(t, entry.ResultParsed)
+	assert.Nil(t, entry.ErrorDetailsParsed)
+	assert.NotEmpty(t, entry.Arguments)
+	assert.NotEmpty(t, entry.Metadata)
+
+	var preview string
+	require.NoError(t, sonic.Unmarshal([]byte(entry.Arguments), &preview))
+	assert.Len(t, []rune(preview), 200)
+	assert.Contains(t, preview, `"input":`)
 }
 
 func TestPayloadFieldNames(t *testing.T) {

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -3069,6 +3069,18 @@ func (s *RDBLogStore) CreateMCPToolLog(ctx context.Context, entry *MCPToolLog) e
 	return s.db.WithContext(ctx).Create(entry).Error
 }
 
+// BatchCreateMCPToolLogsIfNotExists inserts multiple MCP tool log entries in a single transaction.
+// Uses ON CONFLICT DO NOTHING for idempotency.
+func (s *RDBLogStore) BatchCreateMCPToolLogsIfNotExists(ctx context.Context, entries []*MCPToolLog) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	return s.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoNothing: true,
+	}).Create(&entries).Error
+}
+
 // FindMCPToolLog retrieves a single MCP tool log entry by its ID.
 func (s *RDBLogStore) FindMCPToolLog(ctx context.Context, id string) (*MCPToolLog, error) {
 	var log MCPToolLog

--- a/framework/logstore/store.go
+++ b/framework/logstore/store.go
@@ -73,6 +73,7 @@ type LogStore interface {
 
 	// MCP Tool Log methods
 	CreateMCPToolLog(ctx context.Context, entry *MCPToolLog) error
+	BatchCreateMCPToolLogsIfNotExists(ctx context.Context, entries []*MCPToolLog) error
 	FindMCPToolLog(ctx context.Context, id string) (*MCPToolLog, error)
 	UpdateMCPToolLog(ctx context.Context, id string, entry any) error
 	SearchMCPToolLogs(ctx context.Context, filters MCPToolLogSearchFilters, pagination PaginationOptions) (*MCPToolLogSearchResult, error)

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -785,6 +785,7 @@ type MCPToolLog struct {
 	Cost           *float64  `gorm:"index:idx_mcp_logs_cost" json:"cost,omitempty"`                     // Cost in dollars (per execution cost)
 	Status         string    `gorm:"type:varchar(50);index:idx_mcp_logs_status;not null" json:"status"` // "processing", "success", or "error"
 	Metadata       string    `gorm:"type:text" json:"-"`                                                // JSON serialized map[string]interface{}
+	HasObject      bool      `gorm:"default:false" json:"-"`                                            // True when payload is stored in object storage
 	CreatedAt      time.Time `gorm:"index;not null" json:"created_at"`
 
 	// Virtual fields for JSON output - populated when needed

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -269,28 +269,29 @@ type Config struct {
 
 // LoggerPlugin implements the schemas.LLMPlugin and schemas.MCPPlugin interfaces
 type LoggerPlugin struct {
-	ctx                   context.Context
-	store                 logstore.LogStore
-	disableContentLogging *bool
-	loggingHeaders        *[]string // Pointer to live config slice for headers to capture in metadata
-	pricingManager        *modelcatalog.ModelCatalog
-	mcpCatalog            *mcpcatalog.MCPCatalog // MCP catalog for tool cost calculation
-	mu                    sync.Mutex
-	done                  chan struct{}
-	cleanupOnce           sync.Once // Ensures cleanup only runs once
-	wg                    sync.WaitGroup
-	logger                schemas.Logger
-	logCallback           LogCallback
-	mcpToolLogCallback    MCPToolLogCallback // Callback for MCP tool log entries
-	droppedRequests       atomic.Int64
-	cleanupTicker         *time.Ticker          // Ticker for cleaning up old processing logs
-	logMsgPool            sync.Pool             // Pool for reusing LogMessage structs
-	updateDataPool        sync.Pool             // Pool for reusing UpdateLogData structs
-	pendingLogsEntries    sync.Map              // Maps requestID -> *PendingLogData (PreLLMHook input data awaiting PostLLMHook)
-	pendingLogsToInject   sync.Map              // Maps traceID -> *pendingInjectEntries (log entries to inject, supports multiple per trace)
-	writeQueue            chan *writeQueueEntry // Buffered channel for batch write queue
-	closed                atomic.Bool           // Set during cleanup to prevent sends on closed writeQueue
-	deferredUsageSem      chan struct{}         // Limits concurrent deferred usage DB updates
+	ctx                    context.Context
+	store                  logstore.LogStore
+	disableContentLogging  *bool
+	loggingHeaders         *[]string // Pointer to live config slice for headers to capture in metadata
+	pricingManager         *modelcatalog.ModelCatalog
+	mcpCatalog             *mcpcatalog.MCPCatalog // MCP catalog for tool cost calculation
+	mu                     sync.Mutex
+	done                   chan struct{}
+	cleanupOnce            sync.Once // Ensures cleanup only runs once
+	wg                     sync.WaitGroup
+	logger                 schemas.Logger
+	logCallback            LogCallback
+	mcpToolLogCallback     MCPToolLogCallback // Callback for MCP tool log entries
+	droppedRequests        atomic.Int64
+	cleanupTicker          *time.Ticker          // Ticker for cleaning up old processing logs
+	logMsgPool             sync.Pool             // Pool for reusing LogMessage structs
+	updateDataPool         sync.Pool             // Pool for reusing UpdateLogData structs
+	pendingLogsEntries     sync.Map              // Maps requestID -> *PendingLogData (PreLLMHook input data awaiting PostLLMHook)
+	pendingLogsToInject    sync.Map              // Maps traceID -> *pendingInjectEntries (log entries to inject, supports multiple per trace)
+	pendingMCPLogsToInject sync.Map              // Maps mcpLogID -> *logstore.MCPToolLog (PreMCPHook input data awaiting PostMCPHook)
+	writeQueue             chan *writeQueueEntry // Buffered channel for batch write queue
+	closed                 atomic.Bool           // Set during cleanup to prevent sends on closed writeQueue
+	deferredUsageSem       chan struct{}         // Limits concurrent deferred usage DB updates
 }
 
 // Init creates new logger plugin with given log store
@@ -1196,49 +1197,43 @@ func (p *LoggerPlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 		mcpLogID = requestID
 	}
 
-	go func() {
-		entry := &logstore.MCPToolLog{
-			ID:          mcpLogID,
-			RequestID:   requestID,
-			Timestamp:   createdTimestamp,
-			ToolName:    toolName,
-			ServerLabel: serverLabel,
-			Status:      "processing",
-			CreatedAt:   createdTimestamp,
-		}
+	entry := &logstore.MCPToolLog{
+		ID:          mcpLogID,
+		RequestID:   requestID,
+		Timestamp:   createdTimestamp,
+		ToolName:    toolName,
+		ServerLabel: serverLabel,
+		Status:      "processing",
+		CreatedAt:   createdTimestamp,
+	}
 
-		if parentRequestID != "" {
-			entry.LLMRequestID = &parentRequestID
-		}
+	if parentRequestID != "" {
+		entry.LLMRequestID = &parentRequestID
+	}
 
-		if virtualKeyID != "" {
-			entry.VirtualKeyID = &virtualKeyID
-		}
-		if virtualKeyName != "" {
-			entry.VirtualKeyName = &virtualKeyName
-		}
+	if virtualKeyID != "" {
+		entry.VirtualKeyID = &virtualKeyID
+	}
+	if virtualKeyName != "" {
+		entry.VirtualKeyName = &virtualKeyName
+	}
 
-		// Set arguments if content logging is enabled
-		if p.contentLoggingEnabled(ctx) {
-			entry.ArgumentsParsed = arguments
-		}
+	// Set arguments if content logging is enabled
+	if p.contentLoggingEnabled(ctx) {
+		entry.ArgumentsParsed = arguments
+	}
 
-		// Capture configured logging headers and x-bf-lh-* headers into metadata
-		entry.MetadataParsed = p.captureLoggingHeaders(ctx)
+	// Capture configured logging headers and x-bf-lh-* headers into metadata
+	entry.MetadataParsed = p.captureLoggingHeaders(ctx)
 
-		if err := p.store.CreateMCPToolLog(p.ctx, entry); err != nil {
-			p.logger.Warn("Failed to insert initial MCP tool log entry for request %s: %v", requestID, err)
-		} else {
-			// Capture callback under lock, then call it outside the critical section
-			p.mu.Lock()
-			callback := p.mcpToolLogCallback
-			p.mu.Unlock()
+	p.pendingMCPLogsToInject.Store(mcpLogID, entry)
 
-			if callback != nil {
-				callback(entry)
-			}
-		}
-	}()
+	p.mu.Lock()
+	callback := p.mcpToolLogCallback
+	p.mu.Unlock()
+	if callback != nil {
+		callback(entry)
+	}
 
 	return req, nil, nil
 }
@@ -1281,107 +1276,83 @@ func (p *LoggerPlugin) PostMCPHook(ctx *schemas.BifrostContext, resp *schemas.Bi
 	virtualKeyID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyID)
 	virtualKeyName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceVirtualKeyName)
 
-	go func() {
-		updates := make(map[string]interface{})
-
-		// Update virtual key ID and name if they are set (from governance plugin)
-		if virtualKeyID != "" {
-			updates["virtual_key_id"] = virtualKeyID
+	pendingVal, hasPending := p.pendingMCPLogsToInject.LoadAndDelete(mcpLogID)
+	var entry *logstore.MCPToolLog
+	if hasPending {
+		if pending, ok := pendingVal.(*logstore.MCPToolLog); ok {
+			entry = pending
 		}
-		if virtualKeyName != "" {
-			updates["virtual_key_name"] = virtualKeyName
+	}
+	if entry == nil {
+		entry = &logstore.MCPToolLog{
+			ID:        mcpLogID,
+			RequestID: requestID,
+			Timestamp: time.Now().UTC(),
+			Status:    "processing",
+			CreatedAt: time.Now().UTC(),
 		}
+	}
 
-		// Get latency from response ExtraFields
-		if resp != nil {
-			updates["latency"] = float64(resp.ExtraFields.Latency)
+	if virtualKeyID != "" {
+		entry.VirtualKeyID = &virtualKeyID
+	}
+	if virtualKeyName != "" {
+		entry.VirtualKeyName = &virtualKeyName
+	}
+	if resp != nil {
+		latency := float64(resp.ExtraFields.Latency)
+		entry.Latency = &latency
+	}
+
+	success := resp != nil && bifrostErr == nil
+	if success && p.mcpCatalog != nil && resp.ExtraFields.ClientName != "" && resp.ExtraFields.ToolName != "" {
+		if pricingEntry, ok := p.mcpCatalog.GetPricingData(resp.ExtraFields.ClientName, resp.ExtraFields.ToolName); ok {
+			toolCost := pricingEntry.CostPerExecution
+			entry.Cost = &toolCost
+			p.logger.Debug("MCP tool cost for %s.%s: $%.6f", resp.ExtraFields.ClientName, resp.ExtraFields.ToolName, toolCost)
 		}
+	}
 
-		// Calculate MCP tool cost from catalog if available
-		var toolCost float64
-		success := (resp != nil && bifrostErr == nil)
-		if success && resp != nil && p.mcpCatalog != nil && resp.ExtraFields.ClientName != "" && resp.ExtraFields.ToolName != "" {
-			// Use separate client name and tool name fields
-			if pricingEntry, ok := p.mcpCatalog.GetPricingData(resp.ExtraFields.ClientName, resp.ExtraFields.ToolName); ok {
-				toolCost = pricingEntry.CostPerExecution
-				updates["cost"] = toolCost
-				p.logger.Debug("MCP tool cost for %s.%s: $%.6f", resp.ExtraFields.ClientName, resp.ExtraFields.ToolName, toolCost)
-			}
-		}
-
-		if bifrostErr != nil {
-			updates["status"] = "error"
-			// Serialize error details
-			tempEntry := &logstore.MCPToolLog{}
-			tempEntry.ErrorDetailsParsed = bifrostErr
-			if err := tempEntry.SerializeFields(); err == nil {
-				updates["error_details"] = tempEntry.ErrorDetails
-			}
-		} else if resp != nil {
-			updates["status"] = "success"
-			// Store result if content logging is enabled
-			if p.contentLoggingEnabled(ctx) {
-				var result interface{}
-				if resp.ChatMessage != nil {
-					// For ChatMessage, try to parse the content as JSON if it's a string
-					if resp.ChatMessage.Content != nil && resp.ChatMessage.Content.ContentStr != nil {
-						contentStr := *resp.ChatMessage.Content.ContentStr
-						var parsedContent interface{}
-						if err := sonic.Unmarshal([]byte(contentStr), &parsedContent); err == nil {
-							// Content is valid JSON, use parsed version
-							result = parsedContent
-						} else {
-							// Content is not valid JSON or failed to parse, store the whole message
-							result = resp.ChatMessage
-						}
+	if bifrostErr != nil {
+		entry.Status = "error"
+		entry.ErrorDetailsParsed = bifrostErr
+	} else if resp != nil {
+		entry.Status = "success"
+		if p.contentLoggingEnabled(ctx) {
+			var result interface{}
+			if resp.ChatMessage != nil {
+				if resp.ChatMessage.Content != nil && resp.ChatMessage.Content.ContentStr != nil {
+					contentStr := *resp.ChatMessage.Content.ContentStr
+					var parsedContent interface{}
+					if err := sonic.Unmarshal([]byte(contentStr), &parsedContent); err == nil {
+						result = parsedContent
 					} else {
 						result = resp.ChatMessage
 					}
-				} else if resp.ResponsesMessage != nil {
-					result = resp.ResponsesMessage
-				}
-				if result != nil {
-					tempEntry := &logstore.MCPToolLog{}
-					tempEntry.ResultParsed = result
-					if err := tempEntry.SerializeFields(); err == nil {
-						updates["result"] = tempEntry.Result
-					}
-				}
-			}
-		} else {
-			updates["status"] = "error"
-			tempEntry := &logstore.MCPToolLog{}
-			tempEntry.ErrorDetailsParsed = &schemas.BifrostError{
-				IsBifrostError: true,
-				Error: &schemas.ErrorField{
-					Message: "MCP tool execution returned nil response",
-				},
-			}
-			if err := tempEntry.SerializeFields(); err == nil {
-				updates["error_details"] = tempEntry.ErrorDetails
-			}
-		}
-
-		processingErr := retryOnNotFound(p.ctx, func() error {
-			return p.store.UpdateMCPToolLog(p.ctx, mcpLogID, updates)
-		})
-		if processingErr != nil {
-			p.logger.Warn("failed to process MCP tool log update for request %s: %v", requestID, processingErr)
-		} else {
-			// Capture callback under lock, then perform DB I/O and invoke callback outside critical section
-			p.mu.Lock()
-			callback := p.mcpToolLogCallback
-			p.mu.Unlock()
-
-			if callback != nil {
-				if updatedEntry, getErr := p.store.FindMCPToolLog(p.ctx, mcpLogID); getErr == nil {
-					callback(updatedEntry)
 				} else {
-					p.logger.Warn("failed to find updated entry for callback: %v", getErr)
+					result = resp.ChatMessage
 				}
+			} else if resp.ResponsesMessage != nil {
+				result = resp.ResponsesMessage
+			}
+			if result != nil {
+				entry.ResultParsed = result
 			}
 		}
-	}()
+	} else {
+		entry.Status = "error"
+		entry.ErrorDetailsParsed = &schemas.BifrostError{
+			IsBifrostError: true,
+			Error: &schemas.ErrorField{
+				Message: "MCP tool execution returned nil response",
+			},
+		}
+	}
+
+	p.mu.Lock()
+	callback := p.mcpToolLogCallback
+	p.mu.Unlock()
+	p.enqueueMCPToolLogEntry(entry, callback)
 
 	return resp, bifrostErr, nil
 }

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -979,6 +979,11 @@ func (p *LoggerPlugin) GetLog(ctx context.Context, id string) (*logstore.Log, er
 	return p.store.FindByID(ctx, id)
 }
 
+// GetMCPToolLog retrieves a single MCP tool log entry by ID.
+func (p *LoggerPlugin) GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error) {
+	return p.store.FindMCPToolLog(ctx, id)
+}
+
 // GetStats calculates statistics for logs matching the given filters
 func (p *LoggerPlugin) GetStats(ctx context.Context, filters logstore.SearchFilters) (*logstore.SearchStats, error) {
 	return p.store.GetStats(ctx, filters)

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -38,6 +39,132 @@ func newTestStore(t *testing.T) logstore.LogStore {
 		t.Fatalf("NewLogStore() error = %v", err)
 	}
 	return store
+}
+
+// TestMCPHooksDeferDBWriteUntilPostHookBatch verifies MCP logs are kept in
+// memory after PreMCPHook and persisted by the batch writer after PostMCPHook.
+func TestMCPHooksDeferDBWriteUntilPostHookBatch(t *testing.T) {
+	store := newTestStore(t)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeyRequestID, "req-mcp-batch")
+	ctx.SetValue(schemas.BifrostContextKeyMCPLogID, "mcp-batch-flow")
+
+	toolName := "docs-search"
+	_, _, err = plugin.PreMCPHook(ctx, &schemas.BifrostMCPRequest{
+		RequestType: schemas.MCPRequestTypeChatToolCall,
+		ChatAssistantMessageToolCall: &schemas.ChatAssistantMessageToolCall{
+			Function: schemas.ChatAssistantMessageToolCallFunction{
+				Name:      &toolName,
+				Arguments: `{"query":"find this"}`,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PreMCPHook() error = %v", err)
+	}
+
+	if _, err := store.FindMCPToolLog(context.Background(), "mcp-batch-flow"); !errors.Is(err, logstore.ErrNotFound) {
+		t.Fatalf("expected MCP log to stay in memory before PostMCPHook, got err=%v", err)
+	}
+
+	result := `{"answer":"done"}`
+	_, _, err = plugin.PostMCPHook(ctx, &schemas.BifrostMCPResponse{
+		ChatMessage: &schemas.ChatMessage{
+			Role:    schemas.ChatMessageRoleTool,
+			Content: &schemas.ChatMessageContent{ContentStr: &result},
+		},
+		ExtraFields: schemas.BifrostMCPResponseExtraFields{
+			ClientName: "docs",
+			ToolName:   "search",
+			Latency:    42,
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("PostMCPHook() error = %v", err)
+	}
+
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	logEntry, err := store.FindMCPToolLog(context.Background(), "mcp-batch-flow")
+	if err != nil {
+		t.Fatalf("FindMCPToolLog() error = %v", err)
+	}
+	if logEntry.Status != "success" {
+		t.Fatalf("expected status success, got %q", logEntry.Status)
+	}
+	if logEntry.ArgumentsParsed == nil {
+		t.Fatalf("expected arguments to be persisted")
+	}
+	resultMap, ok := logEntry.ResultParsed.(map[string]interface{})
+	if !ok || resultMap["answer"] != "done" {
+		t.Fatalf("expected parsed result to be persisted, got %#v", logEntry.ResultParsed)
+	}
+	if logEntry.Latency == nil || *logEntry.Latency != 42 {
+		t.Fatalf("expected latency 42, got %#v", logEntry.Latency)
+	}
+}
+
+// TestCleanupStalePendingMCPLogsPersistsErrorFallback verifies stale pending
+// MCP logs are committed as terminal errors instead of being silently dropped.
+func TestCleanupStalePendingMCPLogsPersistsErrorFallback(t *testing.T) {
+	store := newTestStore(t)
+	plugin, err := Init(context.Background(), &Config{}, testLogger{}, store, nil, nil)
+	if err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	staleCreatedAt := time.Now().Add(-pendingLogTTL - time.Minute)
+	plugin.pendingMCPLogsToInject.Store("mcp-stale", &logstore.MCPToolLog{
+		ID:          "mcp-stale",
+		RequestID:   "req-stale",
+		Timestamp:   staleCreatedAt,
+		ToolName:    "search",
+		ServerLabel: "docs",
+		Status:      "processing",
+		CreatedAt:   staleCreatedAt,
+		ArgumentsParsed: map[string]interface{}{
+			"query": "stale input",
+		},
+	})
+
+	plugin.cleanupStalePendingLogs()
+
+	if _, ok := plugin.pendingMCPLogsToInject.Load("mcp-stale"); ok {
+		t.Fatal("expected stale MCP pending log to be removed from memory")
+	}
+	if _, err := store.FindMCPToolLog(context.Background(), "mcp-stale"); !errors.Is(err, logstore.ErrNotFound) {
+		t.Fatalf("expected stale MCP log to be queued before batch flush, got err=%v", err)
+	}
+	if err := plugin.Cleanup(); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	logEntry, err := store.FindMCPToolLog(context.Background(), "mcp-stale")
+	if err != nil {
+		t.Fatalf("FindMCPToolLog() error = %v", err)
+	}
+	if logEntry.Status != "error" {
+		t.Fatalf("expected status error, got %q", logEntry.Status)
+	}
+	if logEntry.ArgumentsParsed == nil {
+		t.Fatal("expected stale MCP input arguments to be persisted")
+	}
+	if logEntry.ResultParsed != nil || logEntry.Result != "" {
+		t.Fatalf("expected stale MCP log to have no result, got parsed=%#v raw=%q", logEntry.ResultParsed, logEntry.Result)
+	}
+	if logEntry.ErrorDetailsParsed == nil || logEntry.ErrorDetailsParsed.Error == nil {
+		t.Fatalf("expected stale MCP error details, got %#v", logEntry.ErrorDetailsParsed)
+	}
+	if !strings.Contains(logEntry.ErrorDetailsParsed.Error.Message, "pending log TTL") {
+		t.Fatalf("expected stale MCP timeout message, got %q", logEntry.ErrorDetailsParsed.Error.Message)
+	}
 }
 
 func TestUpdateLogEntryPreservesResponsesInputContentSummary(t *testing.T) {
@@ -647,10 +774,10 @@ func TestContentLoggingEnabledHelper(t *testing.T) {
 	boolPtr := func(b bool) *bool { return &b }
 
 	tests := []struct {
-		name                  string
-		globalDisable         *bool
-		ctxOverride           *bool // nil = don't set the key
-		want                  bool
+		name          string
+		globalDisable *bool
+		ctxOverride   *bool // nil = don't set the key
+		want          bool
 	}{
 		{"no config no override → enabled", nil, nil, true},
 		{"global disable=false no override → enabled", boolPtr(false), nil, true},

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -122,6 +122,9 @@ type LogManager interface {
 	RecalculateCosts(ctx context.Context, filters *logstore.SearchFilters, limit int) (*RecalculateCostResult, error)
 
 	// MCP Tool Log methods
+	// GetMCPToolLog retrieves a single MCP tool log entry by ID.
+	GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error)
+
 	// SearchMCPToolLogs searches for MCP tool log entries based on filters and pagination
 	SearchMCPToolLogs(ctx context.Context, filters *logstore.MCPToolLogSearchFilters, pagination *logstore.PaginationOptions) (*logstore.MCPToolLogSearchResult, error)
 
@@ -364,6 +367,17 @@ func (p *PluginLogManager) RecalculateCosts(ctx context.Context, filters *logsto
 		return nil, fmt.Errorf("filters cannot be nil")
 	}
 	return p.plugin.RecalculateCosts(ctx, *filters, limit)
+}
+
+// GetMCPToolLog retrieves a single MCP tool log entry by ID.
+func (p *PluginLogManager) GetMCPToolLog(ctx context.Context, id string) (*logstore.MCPToolLog, error) {
+	if p.plugin == nil || p.plugin.store == nil {
+		return nil, fmt.Errorf("log store not initialized")
+	}
+	if strings.TrimSpace(id) == "" {
+		return nil, fmt.Errorf("id cannot be empty")
+	}
+	return p.plugin.GetMCPToolLog(ctx, id)
 }
 
 // SearchMCPToolLogs searches for MCP tool log entries based on filters and pagination

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -48,8 +48,10 @@ type pendingInjectEntries struct {
 
 // writeQueueEntry is an entry pushed to the batch write queue.
 type writeQueueEntry struct {
-	log      *logstore.Log             // Complete log entry ready for INSERT
-	callback func(entry *logstore.Log) // Post-commit callback receives the inserted entry (no DB re-read needed)
+	log         *logstore.Log
+	mcpLog      *logstore.MCPToolLog
+	callback    func(entry *logstore.Log)
+	mcpCallback func(entry *logstore.MCPToolLog)
 }
 
 // batchWriter is the single writer goroutine that drains the write queue
@@ -88,7 +90,7 @@ func (p *LoggerPlugin) batchWriter() {
 				return
 			}
 			batch = append(batch, entry)
-			batchBytes += estimateLogEntrySize(entry.log)
+			batchBytes += estimateWriteQueueEntrySize(entry)
 			if len(batch) >= maxBatchSize || batchBytes >= maxBatchBytes {
 				flush()
 			} else if !timerRunning {
@@ -125,9 +127,13 @@ func (p *LoggerPlugin) processBatch(batch []*writeQueueEntry) {
 
 	// Collect all log entries for batch insert
 	logs := make([]*logstore.Log, 0, len(batch))
+	mcpLogs := make([]*logstore.MCPToolLog, 0, len(batch))
 	for _, entry := range batch {
 		if entry.log != nil {
 			logs = append(logs, entry.log)
+		}
+		if entry.mcpLog != nil {
+			mcpLogs = append(mcpLogs, entry.mcpLog)
 		}
 	}
 
@@ -143,6 +149,17 @@ func (p *LoggerPlugin) processBatch(batch []*writeQueueEntry) {
 			}
 		}
 	}
+	if len(mcpLogs) > 0 {
+		if err := p.store.BatchCreateMCPToolLogsIfNotExists(p.ctx, mcpLogs); err != nil {
+			p.logger.Warn("batch insert failed for %d MCP tool logs, falling back to individual inserts: %v", len(mcpLogs), err)
+			for _, log := range mcpLogs {
+				if err := p.store.BatchCreateMCPToolLogsIfNotExists(p.ctx, []*logstore.MCPToolLog{log}); err != nil {
+					p.logger.Warn("individual insert failed for MCP tool log %s: %v", log.ID, err)
+					p.droppedRequests.Add(1)
+				}
+			}
+		}
+	}
 
 	// Collect callbacks that need to fire, then run them in a single goroutine.
 	// This avoids blocking the batch writer (synchronous was causing 1+ second stalls
@@ -152,14 +169,22 @@ func (p *LoggerPlugin) processBatch(batch []*writeQueueEntry) {
 		cb  func(*logstore.Log)
 		log *logstore.Log
 	}
+	type mcpCbPair struct {
+		cb  func(*logstore.MCPToolLog)
+		log *logstore.MCPToolLog
+	}
 	var callbacks []cbPair
+	var mcpCallbacks []mcpCbPair
 	for _, entry := range batch {
 		if entry.callback != nil {
 			callbacks = append(callbacks, cbPair{cb: entry.callback, log: entry.log})
 		}
+		if entry.mcpCallback != nil {
+			mcpCallbacks = append(mcpCallbacks, mcpCbPair{cb: entry.mcpCallback, log: entry.mcpLog})
+		}
 	}
-	if len(callbacks) > 0 {
-		go func(callbacks []cbPair) {
+	if len(callbacks) > 0 || len(mcpCallbacks) > 0 {
+		go func(callbacks []cbPair, mcpCallbacks []mcpCbPair) {
 			defer func() {
 				if r := recover(); r != nil {
 					p.logger.Warn("log callback panicked: %v", r)
@@ -168,13 +193,17 @@ func (p *LoggerPlugin) processBatch(batch []*writeQueueEntry) {
 			for _, pair := range callbacks {
 				pair.cb(pair.log)
 			}
-		}(callbacks)
+			for _, pair := range mcpCallbacks {
+				pair.cb(pair.log)
+			}
+		}(callbacks, mcpCallbacks)
 	}
 }
 
-// cleanupStalePendingLogs removes entries from pendingLogs that have been
-// waiting longer than pendingLogTTL. This handles cases where PostLLMHook
-// never fires for a request (e.g., request was cancelled before reaching the provider).
+// cleanupStalePendingLogs removes stale in-memory pending log state.
+// Pending LLM entries are dropped to prevent unbounded memory growth. Pending
+// MCP entries are converted into terminal error rows and queued for persistence,
+// because PreMCPHook does not write a processing row to the database.
 func (p *LoggerPlugin) cleanupStalePendingLogs() {
 	cutoff := time.Now().Add(-pendingLogTTL)
 	p.pendingLogsEntries.Range(func(key, value any) bool {
@@ -189,6 +218,26 @@ func (p *LoggerPlugin) cleanupStalePendingLogs() {
 		if pending, ok := value.(*pendingInjectEntries); ok {
 			if pending.createdAt.Before(cutoff) {
 				p.pendingLogsToInject.Delete(key)
+			}
+		}
+		return true
+	})
+	p.pendingMCPLogsToInject.Range(func(key, value any) bool {
+		if pending, ok := value.(*logstore.MCPToolLog); ok {
+			if pending.CreatedAt.Before(cutoff) {
+				actual, loaded := p.pendingMCPLogsToInject.LoadAndDelete(key)
+				if !loaded {
+					return true
+				}
+				stalePending, ok := actual.(*logstore.MCPToolLog)
+				if !ok || stalePending == nil {
+					return true
+				}
+
+				p.mu.Lock()
+				callback := p.mcpToolLogCallback
+				p.mu.Unlock()
+				p.enqueueMCPToolLogEntry(buildStaleMCPToolLogEntry(stalePending), callback)
 			}
 		}
 		return true
@@ -215,6 +264,38 @@ func (p *LoggerPlugin) enqueueLogEntry(entry *logstore.Log, callback func(entry 
 		p.droppedRequests.Add(1)
 		p.logger.Warn("log write queue full, dropping log entry %s", entry.ID)
 	}
+}
+
+// enqueueMCPToolLogEntry pushes a complete MCP tool log entry to the write queue.
+// If the queue is full, the entry is dropped to prevent store slowness from
+// cascading into request handling goroutines.
+func (p *LoggerPlugin) enqueueMCPToolLogEntry(entry *logstore.MCPToolLog, callback func(entry *logstore.MCPToolLog)) {
+	if p.closed.Load() {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			p.droppedRequests.Add(1)
+		}
+	}()
+	select {
+	case p.writeQueue <- &writeQueueEntry{mcpLog: entry, mcpCallback: callback}:
+	default:
+		p.droppedRequests.Add(1)
+		p.logger.Warn("log write queue full, dropping MCP tool log entry %s", entry.ID)
+	}
+}
+
+// estimateWriteQueueEntrySize returns the estimated serialized payload size for
+// the log entry carried by a write queue item.
+func estimateWriteQueueEntrySize(entry *writeQueueEntry) int {
+	if entry == nil {
+		return 0
+	}
+	if entry.mcpLog != nil {
+		return estimateMCPToolLogEntrySize(entry.mcpLog)
+	}
+	return estimateLogEntrySize(entry.log)
 }
 
 // estimateLogEntrySize returns a rough byte-size estimate for a log entry
@@ -267,6 +348,32 @@ func estimateLogEntrySize(log *logstore.Log) int {
 		len(log.RoutingEngineLogs)
 	// Baseline for fixed-width columns and struct overhead
 	return n + 512
+}
+
+// estimateMCPToolLogEntrySize returns a rough byte-size estimate for an MCP
+// tool log entry based on its serialized text fields.
+func estimateMCPToolLogEntrySize(log *logstore.MCPToolLog) int {
+	if log == nil {
+		return 0
+	}
+	return len(log.Arguments) + len(log.Result) + len(log.ErrorDetails) + len(log.Metadata) + 512
+}
+
+// buildStaleMCPToolLogEntry converts a pending MCP processing row into a
+// terminal error entry suitable for the batch writer.
+func buildStaleMCPToolLogEntry(pending *logstore.MCPToolLog) *logstore.MCPToolLog {
+	entry := *pending
+	entry.Status = "error"
+	entry.Result = ""
+	entry.ResultParsed = nil
+	entry.ErrorDetails = ""
+	entry.ErrorDetailsParsed = &schemas.BifrostError{
+		IsBifrostError: true,
+		Error: &schemas.ErrorField{
+			Message: "MCP tool execution did not complete before pending log TTL",
+		},
+	}
+	return &entry
 }
 
 // buildInitialLogEntry constructs a logstore.Log from PendingLogData (input)

--- a/tests/e2e/features/mcp-logs/mcp-logs-detail.spec.ts
+++ b/tests/e2e/features/mcp-logs/mcp-logs-detail.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test } from '../../core/fixtures/base.fixture'
+
+const listLog = {
+  id: 'mcp-detail-e2e',
+  request_id: 'req-mcp-detail-e2e',
+  llm_request_id: 'llm-mcp-detail-e2e',
+  timestamp: '2026-05-10T10:00:00Z',
+  tool_name: 'search_docs',
+  server_label: 'docs',
+  arguments: 'preview-only',
+  latency: 42,
+  cost: 0.001,
+  status: 'success',
+  metadata: {
+    source: 'e2e-list',
+  },
+  created_at: '2026-05-10T10:00:00Z',
+}
+
+const detailLog = {
+  ...listLog,
+  arguments: {
+    query: 'hydrated-search-term',
+    limit: 5,
+  },
+  result: {
+    answer: 'hydrated-result-value',
+    citations: ['doc-1'],
+  },
+  metadata: {
+    source: 'e2e-detail',
+  },
+}
+
+test.describe('MCP Log Detail Hydration', () => {
+  test('opens a row through the detail endpoint and renders hydrated arguments and result', async ({ mcpLogsPage, page }) => {
+    let detailRequestCount = 0
+
+    await page.route('**/api/mcp-logs**', async (route) => {
+      const requestUrl = new URL(route.request().url())
+      const pathname = requestUrl.pathname
+
+      if (pathname === '/api/mcp-logs/mcp-detail-e2e') {
+        detailRequestCount += 1
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(detailLog),
+        })
+        return
+      }
+
+      if (pathname === '/api/mcp-logs/stats') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            total_executions: 1,
+            success_rate: 100,
+            average_latency: 42,
+            total_cost: 0.001,
+          }),
+        })
+        return
+      }
+
+      if (pathname === '/api/mcp-logs/filterdata') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            tool_names: ['search_docs'],
+            server_labels: ['docs'],
+            virtual_keys: [],
+          }),
+        })
+        return
+      }
+
+      if (pathname === '/api/mcp-logs') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            logs: [listLog],
+            pagination: {
+              limit: 50,
+              offset: 0,
+              sort_by: 'timestamp',
+              order: 'desc',
+              total_count: 1,
+            },
+            stats: {
+              total_executions: 1,
+              success_rate: 100,
+              average_latency: 42,
+              total_cost: 0.001,
+            },
+            has_logs: true,
+          }),
+        })
+        return
+      }
+
+      await route.continue()
+    })
+
+    await mcpLogsPage.goto()
+    await expect(mcpLogsPage.logsTable).toBeVisible()
+    await expect(page.getByText('search_docs')).toBeVisible()
+
+    await mcpLogsPage.viewLogDetails(0)
+
+    await expect
+      .poll(() => detailRequestCount, { timeout: 5000, intervals: [100, 200, 500] })
+      .toBeGreaterThan(0)
+    await expect(mcpLogsPage.logDetailSheet.getByText('Arguments')).toBeVisible()
+    await expect(mcpLogsPage.logDetailSheet.getByText('Result')).toBeVisible()
+    await expect(page.getByText('hydrated-search-term')).toBeVisible()
+    await expect(page.getByText('hydrated-result-value')).toBeVisible()
+  })
+})

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -96,6 +96,7 @@ func (h *LoggingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas
 	r.GET("/api/mcp-logs/histogram", lib.ChainMiddlewares(h.getMCPHistogram, middlewares...))
 	r.GET("/api/mcp-logs/histogram/cost", lib.ChainMiddlewares(h.getMCPCostHistogram, middlewares...))
 	r.GET("/api/mcp-logs/histogram/top-tools", lib.ChainMiddlewares(h.getMCPTopTools, middlewares...))
+	r.GET("/api/mcp-logs/{id}", lib.ChainMiddlewares(h.getMCPLogByID, middlewares...))
 	r.DELETE("/api/mcp-logs", lib.ChainMiddlewares(h.deleteMCPLogs, middlewares...))
 }
 
@@ -1554,6 +1555,32 @@ func (h *LoggingHandler) getMCPLogs(ctx *fasthttp.RequestCtx) {
 	}
 
 	SendJSON(ctx, result)
+}
+
+// getMCPLogByID handles GET /api/mcp-logs/{id} - Get a single MCP tool log entry by ID.
+func (h *LoggingHandler) getMCPLogByID(ctx *fasthttp.RequestCtx) {
+	id, ok := ctx.UserValue("id").(string)
+	if !ok || strings.TrimSpace(id) == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "MCP log id is required")
+		return
+	}
+
+	log, err := h.logManager.GetMCPToolLog(ctx, id)
+	if err != nil {
+		if errors.Is(err, logstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "MCP log not found")
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to get MCP log: %v", err))
+		return
+	}
+
+	if log.VirtualKeyID != nil && log.VirtualKeyName != nil && *log.VirtualKeyID != "" && *log.VirtualKeyName != "" {
+		redactedVirtualKeys := h.redactedKeysManager.GetAllRedactedVirtualKeys(ctx, []string{*log.VirtualKeyID})
+		log.VirtualKey = findRedactedVirtualKey(redactedVirtualKeys, *log.VirtualKeyID, *log.VirtualKeyName)
+	}
+
+	SendJSON(ctx, log)
 }
 
 // getMCPLogsStats handles GET /api/mcp-logs/stats - Get statistics for MCP tool logs with filtering

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1053,7 +1053,7 @@
         },
         "object_storage": {
           "type": "object",
-          "description": "Optional object storage for offloading log payloads. When configured, large request/response payloads are stored in S3/GCS while the DB keeps only lightweight index data.",
+          "description": "Optional object storage for offloading LLM and MCP log payloads. When configured, full payloads are stored in S3/GCS while the DB keeps lightweight index data. MCP log rows keep dashboard/table fields plus a 200-character input preview.",
           "properties": {
             "type": {
               "type": "string",
@@ -1151,7 +1151,7 @@
         },
         "object_storage_exclude_fields": {
           "type": "array",
-          "description": "Payload field DB column names that should NOT be offloaded to object storage and must remain in the database (e.g. output_message, input_history, raw_request, raw_response). Unknown names are ignored.",
+          "description": "LLM log payload field DB column names that should NOT be offloaded to object storage and must remain in the database (e.g. output_message, input_history, raw_request, raw_response). Unknown names are ignored. MCP logs always offload the full log and keep dashboard/table fields plus a 200-character input preview in the database.",
           "items": {
             "type": "string"
           }

--- a/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
@@ -12,14 +12,21 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CodeEditor } from "@/components/ui/codeEditor";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Status, StatusColors, Statuses } from "@/lib/constants/logs";
+import { useGetMCPLogByIdQuery } from "@/lib/store";
 import type { MCPToolLogEntry } from "@/lib/types/logs";
 import { downloadAsJson } from "@/lib/utils/browser-download";
 import { addMilliseconds, format, isValid } from "date-fns";
-import { ChevronDown, ChevronUp, Download, MoreVertical, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronUp, Download, Loader2, MoreVertical, Trash2 } from "lucide-react";
 import { useState, type ReactNode } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { toast } from "sonner";
@@ -70,6 +77,13 @@ export function MCPLogDetailSheet({
 	hasNext = false,
 }: MCPLogDetailSheetProps) {
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const {
+		data: fullLog,
+		isLoading,
+		isError,
+	} = useGetMCPLogByIdQuery(log?.id ?? "", {
+		skip: !open || !log?.id,
+	});
 
 	// Keyboard navigation: arrow up/down to navigate between logs
 	useHotkeys("up", () => onNavigate?.("prev"), { enabled: open && hasPrev, preventDefault: true });
@@ -77,15 +91,31 @@ export function MCPLogDetailSheet({
 
 	if (!log) return null;
 
+	const isFullDataReady = isError || (fullLog?.id === log.id && !isLoading);
+	const displayLog = isFullDataReady && fullLog ? fullLog : log;
+
+	if (!isFullDataReady) {
+		return (
+			<Sheet open={open} onOpenChange={onOpenChange}>
+				<SheetContent className="flex w-full flex-col gap-4 overflow-x-hidden p-8 sm:max-w-[60%]">
+					<div className="flex h-full items-center justify-center">
+						<SheetTitle className="sr-only">Loading MCP log details</SheetTitle>
+						<Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
+					</div>
+				</SheetContent>
+			</Sheet>
+		);
+	}
+
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="flex w-full flex-col gap-4 overflow-x-hidden p-8 sm:max-w-[60%]">
 				<SheetHeader className="flex flex-row items-center px-0">
 					<div className="flex w-full items-center justify-between">
 						<SheetTitle className="flex w-fit items-center gap-2 font-medium">
-							{log.id && <p className="text-md max-w-full truncate">Request ID: {log.id}</p>}
-							<Badge variant="outline" className={`${StatusColors[getValidatedStatus(log.status)]} uppercase`}>
-								{log.status}
+							{displayLog.id && <p className="text-md max-w-full truncate">Request ID: {displayLog.id}</p>}
+							<Badge variant="outline" className={`${StatusColors[getValidatedStatus(displayLog.status)]} uppercase`}>
+								{displayLog.status}
 							</Badge>
 						</SheetTitle>
 					</div>
@@ -123,20 +153,22 @@ export function MCPLogDetailSheet({
 							<DropdownMenuContent align="end">
 								<DropdownMenuItem
 									data-testid="export-log-json"
-									onClick={() => downloadAsJson(log, `mcp-log-${log.id ?? "export"}.json`)}
+									onClick={() => downloadAsJson(displayLog, `mcp-log-${displayLog.id ?? "export"}.json`)}
 								>
 									<Download className="h-4 w-4" />
 									Export as JSON
 								</DropdownMenuItem>
-								{handleDelete ? <>
-									<DropdownMenuSeparator />
-									<AlertDialogTrigger asChild>
-										<DropdownMenuItem variant="destructive">
-											<Trash2 className="h-4 w-4" />
-											Delete log
-										</DropdownMenuItem>
-									</AlertDialogTrigger>
-								</> : null}
+								{handleDelete ? (
+									<>
+										<DropdownMenuSeparator />
+										<AlertDialogTrigger asChild>
+											<DropdownMenuItem variant="destructive">
+												<Trash2 className="h-4 w-4" />
+												Delete log
+											</DropdownMenuItem>
+										</AlertDialogTrigger>
+									</>
+								) : null}
 							</DropdownMenuContent>
 						</DropdownMenu>
 						<AlertDialogContent>
@@ -151,7 +183,7 @@ export function MCPLogDetailSheet({
 										e.preventDefault();
 										if (!handleDelete) return;
 										try {
-											await handleDelete(log);
+											await handleDelete(displayLog);
 											setDeleteDialogOpen(false);
 											onOpenChange(false);
 										} catch (err) {
@@ -174,18 +206,26 @@ export function MCPLogDetailSheet({
 							<LogEntryDetailsView
 								className="w-full"
 								label="Start Timestamp"
-								value={isValid(new Date(log.timestamp)) ? format(new Date(log.timestamp), "yyyy-MM-dd hh:mm:ss aa") : "Invalid date"}
+								value={
+									isValid(new Date(displayLog.timestamp))
+										? format(new Date(displayLog.timestamp), "yyyy-MM-dd hh:mm:ss aa")
+										: "Invalid date"
+								}
 							/>
 							<LogEntryDetailsView
 								className="w-full"
 								label="End Timestamp"
 								value={
-									isValid(new Date(log.timestamp))
-										? format(addMilliseconds(new Date(log.timestamp), log.latency || 0), "yyyy-MM-dd hh:mm:ss aa")
+									isValid(new Date(displayLog.timestamp))
+										? format(addMilliseconds(new Date(displayLog.timestamp), displayLog.latency || 0), "yyyy-MM-dd hh:mm:ss aa")
 										: "Invalid date"
 								}
 							/>
-							<LogEntryDetailsView className="w-full" label="Latency" value={log.latency ? `${log.latency.toFixed(2)}ms` : "NA"} />
+							<LogEntryDetailsView
+								className="w-full"
+								label="Latency"
+								value={displayLog.latency ? `${displayLog.latency.toFixed(2)}ms` : "NA"}
+							/>
 						</div>
 					</div>
 					<DottedSeparator />
@@ -195,27 +235,27 @@ export function MCPLogDetailSheet({
 							<LogEntryDetailsView
 								className="col-span-2 w-full"
 								label="Tool Name"
-								value={<span className="font-mono text-sm">{log.tool_name}</span>}
+								value={<span className="font-mono text-sm">{displayLog.tool_name}</span>}
 							/>
 							<LogEntryDetailsView
 								className="w-full"
 								label="Server"
 								value={
-									log.server_label ? (
+									displayLog.server_label ? (
 										<Badge variant="secondary" className="font-mono">
-											{log.server_label}
+											{displayLog.server_label}
 										</Badge>
 									) : (
 										"-"
 									)
 								}
 							/>
-							{log.virtual_key && <LogEntryDetailsView className="w-full" label="Virtual Key" value={log.virtual_key.name} />}
-							{log.llm_request_id && (
+							{displayLog.virtual_key && <LogEntryDetailsView className="w-full" label="Virtual Key" value={displayLog.virtual_key.name} />}
+							{displayLog.llm_request_id && (
 								<LogEntryDetailsView
 									className="col-span-3 w-full"
 									label="LLM Request ID"
-									value={<span className="font-mono text-xs">{log.llm_request_id}</span>}
+									value={<span className="font-mono text-xs">{displayLog.llm_request_id}</span>}
 								/>
 							)}
 						</div>
@@ -223,7 +263,7 @@ export function MCPLogDetailSheet({
 				</div>
 
 				{/* Arguments */}
-				{log.arguments && (
+				{displayLog.arguments && (
 					<div className="w-full rounded-sm border">
 						<div className="border-b px-6 py-2 text-sm font-medium">Arguments</div>
 						<CodeEditor
@@ -231,7 +271,11 @@ export function MCPLogDetailSheet({
 							shouldAdjustInitialHeight={true}
 							maxHeight={250}
 							wrap={true}
-							code={typeof log.arguments === "string" ? log.arguments : JSON.stringify(log.arguments as Record<string, unknown>, null, 2)}
+							code={
+								typeof displayLog.arguments === "string"
+									? displayLog.arguments
+									: JSON.stringify(displayLog.arguments as Record<string, unknown>, null, 2)
+							}
 							lang="json"
 							readonly={true}
 							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
@@ -240,7 +284,7 @@ export function MCPLogDetailSheet({
 				)}
 
 				{/* Result */}
-				{log.result && log.status !== "processing" && (
+				{displayLog.result && displayLog.status !== "processing" && (
 					<div className="w-full rounded-sm border">
 						<div className="border-b px-6 py-2 text-sm font-medium">Result</div>
 						<CodeEditor
@@ -248,7 +292,7 @@ export function MCPLogDetailSheet({
 							shouldAdjustInitialHeight={true}
 							maxHeight={350}
 							wrap={true}
-							code={typeof log.result === "string" ? log.result : JSON.stringify(log.result, null, 2)}
+							code={typeof displayLog.result === "string" ? displayLog.result : JSON.stringify(displayLog.result, null, 2)}
 							lang="json"
 							readonly={true}
 							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}
@@ -257,11 +301,11 @@ export function MCPLogDetailSheet({
 				)}
 
 				{/* Metadata */}
-				{log.metadata && Object.keys(log.metadata).length > 0 && (
+				{displayLog.metadata && Object.keys(displayLog.metadata).length > 0 && (
 					<div className="space-y-4 rounded-sm border px-6 py-4">
 						<BlockHeader title="Metadata" />
 						<div className="grid w-full grid-cols-3 items-start justify-between gap-4">
-							{Object.entries(log.metadata).map(([key, value]) => (
+							{Object.entries(displayLog.metadata).map(([key, value]) => (
 								<LogEntryDetailsView key={key} className="w-full" label={key} value={String(value)} />
 							))}
 						</div>
@@ -269,7 +313,7 @@ export function MCPLogDetailSheet({
 				)}
 
 				{/* Error Details */}
-				{log.error_details && (
+				{displayLog.error_details && (
 					<div className="border-destructive/50 w-full rounded-sm border">
 						<div className="border-destructive/50 text-destructive border-b px-6 py-2 text-sm font-medium">Error Details</div>
 						<CodeEditor
@@ -277,7 +321,7 @@ export function MCPLogDetailSheet({
 							shouldAdjustInitialHeight={true}
 							maxHeight={250}
 							wrap={true}
-							code={JSON.stringify(log.error_details, null, 2)}
+							code={JSON.stringify(displayLog.error_details, null, 2)}
 							lang="json"
 							readonly={true}
 							options={{ scrollBeyondLastLine: false, collapsibleBlocks: true, lineNumbers: "off", alwaysConsumeMouseWheel: false }}

--- a/ui/lib/store/apis/mcpLogsApi.ts
+++ b/ui/lib/store/apis/mcpLogsApi.ts
@@ -97,6 +97,12 @@ export const mcpLogsApi = baseApi.injectEndpoints({
 			providesTags: ["MCPLogs"],
 		}),
 
+		// Get a single MCP tool log entry by ID
+		getMCPLogById: builder.query<MCPToolLogEntry, string>({
+			query: (id) => `/mcp-logs/${encodeURIComponent(id)}`,
+			providesTags: (result, error, id) => [{ type: "MCPLogs", id }],
+		}),
+
 		// Get MCP tool logs statistics with filters
 		getMCPLogsStats: builder.query<
 			MCPToolLogStats,
@@ -188,10 +194,12 @@ export const mcpLogsApi = baseApi.injectEndpoints({
 
 export const {
 	useGetMCPLogsQuery,
+	useGetMCPLogByIdQuery,
 	useGetMCPLogsStatsQuery,
 	useGetMCPAvailableFilterDataQuery,
 	useGetMCPAvailableFilterDataQuery: useGetMCPLogsFilterDataQuery,
 	useLazyGetMCPLogsQuery,
+	useLazyGetMCPLogByIdQuery,
 	useLazyGetMCPLogsStatsQuery,
 	useLazyGetMCPAvailableFilterDataQuery,
 	useLazyGetMCPHistogramQuery,


### PR DESCRIPTION
## Summary

Adds an end-to-end test that verifies the MCP log detail hydration flow — specifically that clicking a log row triggers a fetch to the individual log detail endpoint and renders the hydrated `arguments` and `result` fields in the detail sheet.

## Changes

- Added `mcp-logs-detail.spec.ts` with a test that intercepts all `/api/mcp-logs**` routes, serving a lightweight list payload and a richer hydrated detail payload for a specific log ID.
- The test asserts that the detail endpoint is called at least once after opening a row, and that hydrated values (`hydrated-search-term`, `hydrated-result-value`) appear in the detail sheet alongside the `Arguments` and `Result` section headers.
- Separate route handlers are included for `/api/mcp-logs/stats` and `/api/mcp-logs/filterdata` to prevent those requests from falling through and causing noise.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm exec playwright test tests/e2e/features/mcp-logs/mcp-logs-detail.spec.ts
```

The test should pass with all assertions green, confirming that the detail sheet renders hydrated data fetched from the individual log endpoint.

## Screenshots/Recordings

N/A — this is a test-only change with no visible UI modifications.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. All network requests in this test are intercepted and fulfilled with mock data; no real credentials or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable