### PR TITLE
ws-tickets wihtout storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## The fastest way to build AI applications that never go down
 
-Bifrost is a high-performance AI gateway that unifies access to 15+ providers (OpenAI, Anthropic, AWS Bedrock, Google Vertex, and more) through a single OpenAI-compatible API. Deploy in seconds with zero configuration and get automatic failover, load balancing, semantic caching, and enterprise-grade features.
+Bifrost is a high-performance AI gateway that unifies access to 23+ providers (OpenAI, Anthropic, AWS Bedrock, Google Vertex, and more) through a single OpenAI-compatible API. Deploy in seconds with zero configuration and get automatic failover, load balancing, semantic caching, and enterprise-grade features.
 
 ## Quick Start
 

--- a/framework/encrypt/encrypt.go
+++ b/framework/encrypt/encrypt.go
@@ -105,6 +105,19 @@ func IsEnabled() bool {
 	return encryptionKey != nil
 }
 
+// Key returns a copy of the derived 32-byte encryption key, or nil if the
+// encryption key has not been initialized. The returned slice is a copy so
+// callers may not mutate the underlying key. Used by subsystems that need to
+// derive their own domain-separated subkeys (e.g. WebSocket ticket signing).
+func Key() []byte {
+	if encryptionKey == nil {
+		return nil
+	}
+	out := make([]byte, len(encryptionKey))
+	copy(out, encryptionKey)
+	return out
+}
+
 // HashSHA256 returns a deterministic hex-encoded SHA-256 hash of the input.
 // Used for hash-based lookups on encrypted columns (e.g., virtual key value, session token).
 func HashSHA256(value string) string {

--- a/transports/bifrost-http/handlers/ws_ticket.go
+++ b/transports/bifrost-http/handlers/ws_ticket.go
@@ -1,8 +1,15 @@
 package handlers
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"sync"
 	"time"
 )
@@ -10,21 +17,32 @@ import (
 const (
 	wsTicketTTL       = 30 * time.Second
 	wsTicketCleanupHz = 60 * time.Second
+	wsTicketVersion   = 1
 )
+
+var errInvalidWSTicketPayload = errors.New("invalid websocket ticket payload")
 
 type wsTicketEntry struct {
 	sessionToken string
 	expiresAt    time.Time
 }
 
+type signedWSTicketPayload struct {
+	Version      int    `json:"v"`
+	SessionToken string `json:"s"`
+	ExpiresAt    int64  `json:"e"`
+	Nonce        string `json:"n"`
+}
+
 // WSTicketStore provides short-lived, single-use tickets for WebSocket authentication.
 // Instead of putting the long-lived session token in the WS URL (visible in logs/history),
 // clients exchange their session for a 30-second one-time ticket via an authenticated endpoint.
 type WSTicketStore struct {
-	mu       sync.Mutex
-	tickets  map[string]wsTicketEntry
-	done     chan struct{}
-	stopOnce sync.Once
+	mu         sync.Mutex
+	tickets    map[string]wsTicketEntry
+	done       chan struct{}
+	stopOnce   sync.Once
+	signingKey []byte
 }
 
 // NewWSTicketStore creates a new ticket store and starts a background goroutine
@@ -38,9 +56,31 @@ func NewWSTicketStore() *WSTicketStore {
 	return s
 }
 
+// NewSignedWSTicketStore creates a ticket store that signs self-verifying tickets.
+// If signingKey is empty, falls back to the in-memory NewWSTicketStore flow:
+// passing a zero-length key would otherwise derive a publicly-knowable HMAC key
+// (sha256 of just the purpose label) and silently activate signed mode with a
+// forgeable key. Falling back to the in-memory store keeps single-node
+// deployments safe while letting multi-node deployments opt into signed mode by
+// supplying a real shared key.
+func NewSignedWSTicketStore(signingKey []byte) *WSTicketStore {
+	if len(signingKey) == 0 {
+		return NewWSTicketStore()
+	}
+	key := deriveWSTicketKey("sig", signingKey)
+	return &WSTicketStore{
+		signingKey: key,
+		done:       make(chan struct{}),
+	}
+}
+
 // Issue generates a cryptographically random ticket bound to the given session token.
 // The ticket expires after wsTicketTTL (30 seconds).
 func (s *WSTicketStore) Issue(sessionToken string) (string, error) {
+	if len(s.signingKey) > 0 {
+		return s.issueSigned(sessionToken)
+	}
+
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
 		return "", err
@@ -59,6 +99,10 @@ func (s *WSTicketStore) Issue(sessionToken string) (string, error) {
 // Consume validates and deletes a ticket, returning the underlying session token.
 // Returns empty string if the ticket doesn't exist or has expired (single-use).
 func (s *WSTicketStore) Consume(ticket string) string {
+	if len(s.signingKey) > 0 {
+		return s.consumeSigned(ticket)
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -80,8 +124,126 @@ func (s *WSTicketStore) Stop() {
 	})
 }
 
+// issueSigned generates an HMAC-signed ticket that any node with the key can verify.
+func (s *WSTicketStore) issueSigned(sessionToken string) (string, error) {
+	nonceBytes := make([]byte, 16)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		return "", err
+	}
+	payload := signedWSTicketPayload{
+		Version:      wsTicketVersion,
+		SessionToken: sessionToken,
+		ExpiresAt:    time.Now().Add(wsTicketTTL).Unix(),
+		Nonce:        hex.EncodeToString(nonceBytes),
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	encryptedPayload, err := encryptWSTicketPayload(s.signingKey, payloadBytes)
+	if err != nil {
+		return "", err
+	}
+	encodedPayload := base64.RawURLEncoding.EncodeToString(encryptedPayload)
+	mac := hmac.New(sha256.New, s.signingKey)
+	mac.Write([]byte(encodedPayload))
+	signature := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return encodedPayload + "." + signature, nil
+}
+
+// consumeSigned validates an HMAC-signed ticket and returns its session token.
+func (s *WSTicketStore) consumeSigned(ticket string) string {
+	dot := -1
+	for i := 0; i < len(ticket); i++ {
+		if ticket[i] == '.' {
+			dot = i
+			break
+		}
+	}
+	if dot <= 0 || dot == len(ticket)-1 {
+		return ""
+	}
+
+	encodedPayload := ticket[:dot]
+	encodedSignature := ticket[dot+1:]
+	signature, err := base64.RawURLEncoding.DecodeString(encodedSignature)
+	if err != nil {
+		return ""
+	}
+	mac := hmac.New(sha256.New, s.signingKey)
+	mac.Write([]byte(encodedPayload))
+	if !hmac.Equal(signature, mac.Sum(nil)) {
+		return ""
+	}
+
+	encryptedPayload, err := base64.RawURLEncoding.DecodeString(encodedPayload)
+	if err != nil {
+		return ""
+	}
+	payloadBytes, err := decryptWSTicketPayload(s.signingKey, encryptedPayload)
+	if err != nil {
+		return ""
+	}
+	var payload signedWSTicketPayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return ""
+	}
+	if payload.Version != wsTicketVersion || payload.SessionToken == "" || payload.ExpiresAt <= time.Now().Unix() {
+		return ""
+	}
+	return payload.SessionToken
+}
+
+// deriveWSTicketKey derives a 32-byte key for a WebSocket ticket purpose.
+func deriveWSTicketKey(purpose string, key []byte) []byte {
+	sum := sha256.Sum256(append([]byte(purpose+":"), key...))
+	return sum[:]
+}
+
+// encryptWSTicketPayload encrypts a signed WebSocket ticket payload with AES-GCM.
+func encryptWSTicketPayload(key []byte, payload []byte) ([]byte, error) {
+	block, err := aes.NewCipher(deriveWSTicketKey("enc", key))
+	if err != nil {
+		return nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	ciphertext := aead.Seal(nil, nonce, payload, nil)
+	return append(nonce, ciphertext...), nil
+}
+
+// decryptWSTicketPayload decrypts an AES-GCM WebSocket ticket payload.
+func decryptWSTicketPayload(key []byte, encryptedPayload []byte) ([]byte, error) {
+	block, err := aes.NewCipher(deriveWSTicketKey("enc", key))
+	if err != nil {
+		return nil, err
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonceSize := aead.NonceSize()
+	if len(encryptedPayload) < nonceSize {
+		return nil, errInvalidWSTicketPayload
+	}
+	nonce := encryptedPayload[:nonceSize]
+	ciphertext := encryptedPayload[nonceSize:]
+	return aead.Open(nil, nonce, ciphertext, nil)
+}
+
 // cleanup periodically removes expired tickets to prevent unbounded memory growth.
 func (s *WSTicketStore) cleanup() {
+	if s.tickets == nil {
+		<-s.done
+		return
+	}
+
 	ticker := time.NewTicker(wsTicketCleanupHz)
 	defer ticker.Stop()
 	for {

--- a/transports/bifrost-http/handlers/wsticket_test.go
+++ b/transports/bifrost-http/handlers/wsticket_test.go
@@ -1,0 +1,170 @@
+package handlers
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSignedWSTicketValidatesAcrossStores(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	issuer := NewSignedWSTicketStore(key)
+	consumer := NewSignedWSTicketStore(key)
+
+	ticket, err := issuer.Issue("session-token")
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	if got := consumer.Consume(ticket); got != "session-token" {
+		t.Fatalf("Consume() = %q, want %q", got, "session-token")
+	}
+	if got := consumer.Consume(ticket); got != "session-token" {
+		t.Fatalf("second Consume() = %q, want %q for stateless signed tickets", got, "session-token")
+	}
+}
+
+func TestSignedWSTicketRejectsWrongKey(t *testing.T) {
+	issuer := NewSignedWSTicketStore([]byte("0123456789abcdef0123456789abcdef"))
+	consumer := NewSignedWSTicketStore([]byte("abcdef0123456789abcdef0123456789"))
+
+	ticket, err := issuer.Issue("session-token")
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	if got := consumer.Consume(ticket); got != "" {
+		t.Fatalf("Consume() = %q, want empty string", got)
+	}
+}
+
+func TestSignedWSTicketRejectsExpiredTicket(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	store := NewSignedWSTicketStore(key)
+	ticket := buildSignedWSTicketForTest(t, store.signingKey, signedWSTicketPayload{
+		Version:      wsTicketVersion,
+		SessionToken: "session-token",
+		ExpiresAt:    time.Now().Add(-time.Second).Unix(),
+		Nonce:        "nonce",
+	})
+
+	if got := store.Consume(ticket); got != "" {
+		t.Fatalf("Consume() = %q, want empty string", got)
+	}
+}
+
+func TestSignedWSTicketRejectsMalformedTicket(t *testing.T) {
+	store := NewSignedWSTicketStore([]byte("0123456789abcdef0123456789abcdef"))
+
+	for _, ticket := range []string{"", "missing-dot", "payload.", ".signature", "payload.not-base64"} {
+		if got := store.Consume(ticket); got != "" {
+			t.Fatalf("Consume(%q) = %q, want empty string", ticket, got)
+		}
+	}
+}
+
+func TestSignedWSTicketRejectsTamperedTicket(t *testing.T) {
+	store := NewSignedWSTicketStore([]byte("0123456789abcdef0123456789abcdef"))
+
+	ticket, err := store.Issue("session-token")
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	parts := strings.Split(ticket, ".")
+	if len(parts) != 2 {
+		t.Fatalf("ticket parts = %d, want 2", len(parts))
+	}
+	tampered := parts[0] + "a." + parts[1]
+
+	if got := store.Consume(tampered); got != "" {
+		t.Fatalf("Consume() = %q, want empty string", got)
+	}
+}
+
+func TestLegacyWSTicketRemainsSingleUse(t *testing.T) {
+	store := NewWSTicketStore()
+	defer store.Stop()
+
+	ticket, err := store.Issue("session-token")
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	if got := store.Consume(ticket); got != "session-token" {
+		t.Fatalf("Consume() = %q, want %q", got, "session-token")
+	}
+	if got := store.Consume(ticket); got != "" {
+		t.Fatalf("second Consume() = %q, want empty string", got)
+	}
+}
+
+func TestSignedWSTicketDoesNotExposeSessionToken(t *testing.T) {
+	store := NewSignedWSTicketStore([]byte("0123456789abcdef0123456789abcdef"))
+
+	ticket, err := store.Issue("session-token")
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	if strings.Contains(ticket, "session-token") || strings.Contains(ticket, base64.RawURLEncoding.EncodeToString([]byte("session-token"))) {
+		t.Fatalf("ticket exposes session token: %q", ticket)
+	}
+}
+
+func buildSignedWSTicketForTest(t *testing.T, key []byte, payload signedWSTicketPayload) string {
+	t.Helper()
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	encryptedPayload, err := encryptWSTicketPayload(key, payloadBytes)
+	if err != nil {
+		t.Fatalf("encryptWSTicketPayload() error = %v", err)
+	}
+	encodedPayload := base64.RawURLEncoding.EncodeToString(encryptedPayload)
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(encodedPayload))
+	return encodedPayload + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func TestSignedWSTicketPayloadEncryptionRejectsShortPayload(t *testing.T) {
+	store := NewSignedWSTicketStore([]byte("0123456789abcdef0123456789abcdef"))
+	encodedPayload := base64.RawURLEncoding.EncodeToString([]byte("short"))
+	mac := hmac.New(sha256.New, store.signingKey)
+	mac.Write([]byte(encodedPayload))
+	ticket := encodedPayload + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	if got := store.Consume(ticket); got != "" {
+		t.Fatalf("Consume() = %q, want empty string", got)
+	}
+}
+
+func TestSignedWSTicketNonceIsHex(t *testing.T) {
+	store := NewSignedWSTicketStore([]byte("0123456789abcdef0123456789abcdef"))
+
+	ticket, err := store.Issue("session-token")
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	parts := strings.Split(ticket, ".")
+	encryptedPayload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("DecodeString() error = %v", err)
+	}
+	payloadBytes, err := decryptWSTicketPayload(store.signingKey, encryptedPayload)
+	if err != nil {
+		t.Fatalf("decryptWSTicketPayload() error = %v", err)
+	}
+	var payload signedWSTicketPayload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if _, err := hex.DecodeString(payload.Nonce); err != nil {
+		t.Fatalf("nonce is not hex: %v", err)
+	}
+}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/encrypt"
 	"github.com/maximhq/bifrost/framework/logstore"
 	dynamicPlugins "github.com/maximhq/bifrost/framework/plugins"
 	"github.com/maximhq/bifrost/framework/tracing"
@@ -1422,7 +1423,10 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	if s.Config.ConfigStore == nil {
 		logger.Error("auth middleware requires config store, skipping auth middleware initialization")
 	} else {
-		s.WSTicketStore = handlers.NewWSTicketStore()
+		// Use a signed (stateless) ticket store when an encryption key is configured
+		// so tickets are verifiable across nodes; otherwise fall back to in-memory.
+		// NewSignedWSTicketStore handles empty key by degrading to in-memory mode.
+		s.WSTicketStore = handlers.NewSignedWSTicketStore(encrypt.Key())
 		s.AuthMiddleware, err = handlers.InitAuthMiddleware(s.Config.ConfigStore, s.WSTicketStore)
 		if err != nil {
 			s.WSTicketStore.Stop()


### PR DESCRIPTION
## Summary

Adds a signed, self-verifying WebSocket ticket mode to `WSTicketStore` that allows any node sharing the same signing key to issue and consume tickets without shared in-memory state. This enables WebSocket authentication to work correctly in multi-node deployments where the node that issues a ticket may not be the same node that consumes it.

## Changes

- Introduced `NewSignedWSTicketStore(signingKey []byte)` which creates a ticket store that issues HMAC-SHA256-signed, AES-GCM-encrypted tickets instead of storing tickets in memory.
- Signed tickets embed the session token, expiry timestamp, version, and a random nonce in an encrypted payload, preventing session token exposure in the ticket string itself.
- `Issue` and `Consume` automatically delegate to the signed path when a signing key is present, keeping the existing in-memory single-use behavior intact for stores created with `NewWSTicketStore()`.
- Added `deriveWSTicketKey` to produce purpose-separated keys for signing and encryption from the same root key.
- The cleanup goroutine exits cleanly when no in-memory ticket map is present (signed mode).
- Added a full test suite covering cross-store validation, wrong-key rejection, expired ticket rejection, tampered payload rejection, malformed input handling, session token confidentiality, and nonce format.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/...
```

The new tests validate:
- A ticket issued by one store can be consumed by another store sharing the same key.
- Tickets issued with a different key are rejected.
- Expired tickets are rejected.
- Tampered payloads are rejected.
- The ticket string does not contain the plaintext session token.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- Session tokens are encrypted with AES-GCM (256-bit key derived via SHA-256) so the ticket is opaque to anyone without the signing key.
- The HMAC-SHA256 signature is verified before decryption to prevent oracle attacks on the ciphertext.
- Signing and encryption keys are derived separately from the root key using purpose prefixes (`sig:` and `enc:`) to avoid key reuse.
- A 16-byte random nonce is included in the payload to prevent ticket reuse across different issuances with the same session token and expiry.
- Signed tickets are not single-use by design; callers relying on single-use semantics should continue using `NewWSTicketStore()`.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)