### PR TITLE
updates context.SetTraceAttribut flow for all plugins

### DIFF
--- a/core/schemas/context.go
+++ b/core/schemas/context.go
@@ -454,8 +454,7 @@ func (bc *BifrostContext) ReleasePluginScope() {
 	bc.pluginLogs.Store(nil)
 }
 
-// AddSpanAttribute adds an attribute to the span.
-// For scoped contexts, delegates to the root context via valueDelegate.
+// SetTraceAttribute adds an attribute to the root span for the current trace.
 // This is thread-safe and can be called concurrently.
 func (bc *BifrostContext) SetTraceAttribute(key string, value any) {
 	tr, _ := bc.Value(BifrostContextKeyTracer).(Tracer)
@@ -463,7 +462,11 @@ func (bc *BifrostContext) SetTraceAttribute(key string, value any) {
 	if tr == nil || tid == "" {
 		return
 	}
-	tr.SetAttribute(tid, key, value)
+	handle := tr.GetSpanHandleByID(tid, nil)
+	if handle == nil {
+		return
+	}
+	tr.SetAttribute(handle, key, value)
 }
 
 // Log appends a structured log entry for the current plugin scope.

--- a/core/schemas/context_test.go
+++ b/core/schemas/context_test.go
@@ -7,6 +7,52 @@ import (
 	"time"
 )
 
+type traceAttributeTestTracer struct {
+	NoOpTracer
+	gotTraceID string
+	gotSpanID  *string
+	gotHandle  SpanHandle
+	gotKey     string
+	gotValue   any
+}
+
+func (t *traceAttributeTestTracer) GetSpanHandleByID(traceID string, spanID *string) SpanHandle {
+	t.gotTraceID = traceID
+	t.gotSpanID = spanID
+	t.gotHandle = struct{}{}
+	return t.gotHandle
+}
+
+func (t *traceAttributeTestTracer) SetAttribute(handle SpanHandle, key string, value any) {
+	if handle != t.gotHandle {
+		return
+	}
+	t.gotKey = key
+	t.gotValue = value
+}
+
+func TestBifrostContext_SetTraceAttribute_UsesRootSpanHandle(t *testing.T) {
+	tracer := &traceAttributeTestTracer{}
+	ctx := NewBifrostContext(context.Background(), NoDeadline)
+	ctx.SetValue(BifrostContextKeyTracer, tracer)
+	ctx.SetValue(BifrostContextKeyTraceID, "trace-123")
+
+	ctx.SetTraceAttribute("custom.root_attr", "root-value")
+
+	if tracer.gotTraceID != "trace-123" {
+		t.Fatalf("trace ID = %q, want trace-123", tracer.gotTraceID)
+	}
+	if tracer.gotSpanID != nil {
+		t.Fatalf("span ID = %v, want nil for root span lookup", tracer.gotSpanID)
+	}
+	if tracer.gotKey != "custom.root_attr" {
+		t.Fatalf("attribute key = %q, want custom.root_attr", tracer.gotKey)
+	}
+	if tracer.gotValue != "root-value" {
+		t.Fatalf("attribute value = %v, want root-value", tracer.gotValue)
+	}
+}
+
 func TestNewBifrostContext_NoGoroutineLeakWithBackgroundAndNoDeadline(t *testing.T) {
 	// Get baseline goroutine count
 	runtime.GC()

--- a/core/schemas/tracer.go
+++ b/core/schemas/tracer.go
@@ -62,6 +62,10 @@ type Tracer interface {
 	// Attributes provide additional context about the operation.
 	SetAttribute(handle SpanHandle, key string, value any)
 
+	// GetSpanHandleByID retrieves a span handle for the given trace and span ID.
+	// If spanID is nil, returns a handle for the trace's root span.
+	GetSpanHandleByID(traceID string, spanID *string) SpanHandle
+
 	// AddEvent adds a timestamped event to the span.
 	// Events represent discrete occurrences during the span's lifetime.
 	AddEvent(handle SpanHandle, name string, attrs map[string]any)
@@ -148,6 +152,9 @@ func (n *NoOpTracer) EndSpan(_ SpanHandle, _ SpanStatus, _ string) {}
 
 // SetAttribute does nothing.
 func (n *NoOpTracer) SetAttribute(_ SpanHandle, _ string, _ any) {}
+
+// GetSpanHandleByID returns nil.
+func (n *NoOpTracer) GetSpanHandleByID(_ string, _ *string) SpanHandle { return nil }
 
 // AddEvent does nothing.
 func (n *NoOpTracer) AddEvent(_ SpanHandle, _ string, _ map[string]any) {}

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -139,6 +139,28 @@ func (t *Tracer) SetAttribute(handle schemas.SpanHandle, key string, value any) 
 	}
 }
 
+// GetSpanHandleByID retrieves a span handle for the given trace and span ID.
+// If spanID is nil, it returns a handle for the trace's root span.
+func (t *Tracer) GetSpanHandleByID(traceID string, spanID *string) schemas.SpanHandle {
+	if traceID == "" {
+		return nil
+	}
+	trace := t.store.GetTrace(traceID)
+	if trace == nil {
+		return nil
+	}
+	if spanID == nil {
+		if trace.RootSpan == nil {
+			return nil
+		}
+		return &spanHandle{traceID: traceID, spanID: trace.RootSpan.SpanID}
+	}
+	if *spanID == "" || trace.GetSpan(*spanID) == nil {
+		return nil
+	}
+	return &spanHandle{traceID: traceID, spanID: *spanID}
+}
+
 // AddEvent adds a timestamped event to the span identified by the handle.
 func (t *Tracer) AddEvent(handle schemas.SpanHandle, name string, attrs map[string]any) {
 	h, ok := handle.(*spanHandle)

--- a/framework/tracing/tracer_test.go
+++ b/framework/tracing/tracer_test.go
@@ -308,6 +308,106 @@ func TestTracer_SetAttribute(t *testing.T) {
 	}
 }
 
+func TestTracer_GetSpanHandleByID_RootSpan(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+
+	traceID := tracer.CreateTrace("")
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+
+	rootCtx, rootHandle := tracer.StartSpan(ctx, "http-request", schemas.SpanKindHTTPRequest)
+	_, childHandle := tracer.StartSpan(rootCtx, "llm-call", schemas.SpanKindLLMCall)
+
+	tracer.SetAttribute(childHandle, "child.attr", "child-value")
+
+	handle := tracer.GetSpanHandleByID(traceID, nil)
+	if handle == nil {
+		t.Fatal("GetSpanHandleByID(traceID, nil) returned nil")
+	}
+	tracer.SetAttribute(handle, "custom.root_attr", "root-value")
+
+	trace := store.GetTrace(traceID)
+	if trace.RootSpan.Attributes["custom.root_attr"] != "root-value" {
+		t.Fatalf("root span custom attr = %v, want root-value", trace.RootSpan.Attributes["custom.root_attr"])
+	}
+	if trace.RootSpan.Attributes["child.attr"] != nil {
+		t.Fatalf("child attr leaked to root span: %v", trace.RootSpan.Attributes["child.attr"])
+	}
+
+	childSpanID := childHandle.(*spanHandle).spanID
+	childSpan := trace.GetSpan(childSpanID)
+	if childSpan.Attributes["custom.root_attr"] != nil {
+		t.Fatalf("root attr leaked to child span: %v", childSpan.Attributes["custom.root_attr"])
+	}
+
+	if rootHandle.(*spanHandle).spanID != trace.RootSpan.SpanID {
+		t.Fatalf("root handle span ID = %q, want %q", rootHandle.(*spanHandle).spanID, trace.RootSpan.SpanID)
+	}
+}
+
+func TestTracer_GetSpanHandleByID_ExplicitSpan(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+
+	traceID := tracer.CreateTrace("")
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyTraceID, traceID)
+
+	rootCtx, _ := tracer.StartSpan(ctx, "http-request", schemas.SpanKindHTTPRequest)
+	_, childHandle := tracer.StartSpan(rootCtx, "llm-call", schemas.SpanKindLLMCall)
+	childSpanID := childHandle.(*spanHandle).spanID
+
+	handle := tracer.GetSpanHandleByID(traceID, &childSpanID)
+	if handle == nil {
+		t.Fatal("GetSpanHandleByID(traceID, childSpanID) returned nil")
+	}
+	tracer.SetAttribute(handle, "custom.child_attr", "child-value")
+
+	trace := store.GetTrace(traceID)
+	childSpan := trace.GetSpan(childSpanID)
+	if childSpan.Attributes["custom.child_attr"] != "child-value" {
+		t.Fatalf("child span custom attr = %v, want child-value", childSpan.Attributes["custom.child_attr"])
+	}
+	if trace.RootSpan.Attributes["custom.child_attr"] != nil {
+		t.Fatalf("child attr leaked to root span: %v", trace.RootSpan.Attributes["custom.child_attr"])
+	}
+}
+
+func TestTracer_GetSpanHandleByID_MissingInputs(t *testing.T) {
+	store := NewTraceStore(5*time.Minute, nil)
+	defer store.Stop()
+
+	tracer := NewTracer(store, nil, nil)
+	defer tracer.Stop()
+
+	if handle := tracer.GetSpanHandleByID("", nil); handle != nil {
+		t.Fatalf("empty trace ID handle = %v, want nil", handle)
+	}
+	if handle := tracer.GetSpanHandleByID("missing-trace", nil); handle != nil {
+		t.Fatalf("missing trace handle = %v, want nil", handle)
+	}
+
+	traceID := tracer.CreateTrace("")
+	if handle := tracer.GetSpanHandleByID(traceID, nil); handle != nil {
+		t.Fatalf("trace with no root span handle = %v, want nil", handle)
+	}
+
+	missingSpanID := "missing-span"
+	if handle := tracer.GetSpanHandleByID(traceID, &missingSpanID); handle != nil {
+		t.Fatalf("missing span handle = %v, want nil", handle)
+	}
+
+	emptySpanID := ""
+	if handle := tracer.GetSpanHandleByID(traceID, &emptySpanID); handle != nil {
+		t.Fatalf("empty span ID handle = %v, want nil", handle)
+	}
+}
+
 func TestTracer_AddEvent(t *testing.T) {
 	store := NewTraceStore(5*time.Minute, nil)
 	defer store.Stop()


### PR DESCRIPTION
## Summary

`SetTraceAttribute` previously called `tr.SetAttribute` with a raw trace ID string, which did not match the `SpanHandle`-based API. This PR fixes the implementation to first resolve the root span handle via a new `GetSpanHandleByID` method before setting attributes, ensuring attributes are correctly applied to the root span of the current trace.

## Changes

- Added `GetSpanHandleByID(traceID string, spanID *string) SpanHandle` to the `Tracer` interface, which returns a handle for a specific span or the trace's root span when `spanID` is `nil`.
- Updated `SetTraceAttribute` in `BifrostContext` to resolve the root span handle via `GetSpanHandleByID` before calling `SetAttribute`, rather than passing the trace ID directly.
- Added a no-op implementation of `GetSpanHandleByID` to `NoOpTracer`.
- Implemented `GetSpanHandleByID` in the framework tracer, with nil-safe handling for missing traces, missing root spans, empty trace IDs, and unknown span IDs.
- Added tests covering root span lookup, explicit span lookup, and all nil/missing input edge cases.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./core/schemas/... ./framework/tracing/...
```

- `TestBifrostContext_SetTraceAttribute_UsesRootSpanHandle` verifies that `SetTraceAttribute` resolves the root span handle and applies the attribute correctly.
- `TestTracer_GetSpanHandleByID_RootSpan` verifies that passing `nil` as the span ID returns a handle for the root span and that attributes do not leak to child spans.
- `TestTracer_GetSpanHandleByID_ExplicitSpan` verifies that passing an explicit span ID returns a handle for that span without affecting the root span.
- `TestTracer_GetSpanHandleByID_MissingInputs` verifies that empty trace IDs, missing traces, traces without a root span, missing span IDs, and empty span IDs all return `nil`.

## Screenshots/Recordings

N/A

## Breaking changes

- [x] Yes

`GetSpanHandleByID` is a new required method on the `Tracer` interface. Any external implementations of `Tracer` must add this method.

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable