### PR TITLE
change matviews migration to concurrently vs taking entire lock

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -2,6 +2,7 @@ package logstore
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"sort"
 	"strings"
@@ -54,7 +55,7 @@ GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
 
 // mvLogsHourlyUniqueIdx is required for REFRESH MATERIALIZED VIEW CONCURRENTLY.
 const mvLogsHourlyUniqueIdx = `
-CREATE UNIQUE INDEX IF NOT EXISTS mv_logs_hourly_uniq
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS mv_logs_hourly_uniq
 ON mv_logs_hourly (hour, provider, model, status, object_type, selected_key_id, virtual_key_id, routing_rule_id, user_id, team_id, customer_id, business_unit_id)
 `
 
@@ -88,9 +89,63 @@ WHERE timestamp >= NOW() - INTERVAL '60 days'
 // mvLogsFilterdataUniqueIdx is required for REFRESH MATERIALIZED VIEW CONCURRENTLY.
 // Includes both ID and name columns so renamed keys don't cause duplicate violations.
 const mvLogsFilterdataUniqueIdx = `
-CREATE UNIQUE INDEX IF NOT EXISTS mv_logs_filterdata_uniq
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS mv_logs_filterdata_uniq
 ON mv_logs_filterdata (model, provider, selected_key_id, selected_key_name, virtual_key_id, virtual_key_name, routing_rule_id, routing_rule_name, routing_engines_used, user_id, team_id, team_name, customer_id, customer_name, business_unit_id, business_unit_name)
 `
+
+type matviewUniqueIndexDef struct {
+	view string
+	name string
+	sql  string
+}
+
+var matviewUniqueIndexes = []matviewUniqueIndexDef{
+	{
+		view: "mv_logs_hourly",
+		name: "mv_logs_hourly_uniq",
+		sql:  mvLogsHourlyUniqueIdx,
+	},
+	{
+		view: "mv_logs_filterdata",
+		name: "mv_logs_filterdata_uniq",
+		sql:  mvLogsFilterdataUniqueIdx,
+	},
+}
+
+var matviewRequiredColumns = map[string][]string{
+	"mv_logs_hourly": {
+		"hour",
+		"provider",
+		"model",
+		"status",
+		"object_type",
+		"selected_key_id",
+		"virtual_key_id",
+		"routing_rule_id",
+		"user_id",
+		"team_id",
+		"customer_id",
+		"business_unit_id",
+	},
+	"mv_logs_filterdata": {
+		"model",
+		"provider",
+		"selected_key_id",
+		"selected_key_name",
+		"virtual_key_id",
+		"virtual_key_name",
+		"routing_rule_id",
+		"routing_rule_name",
+		"routing_engines_used",
+		"user_id",
+		"team_id",
+		"team_name",
+		"customer_id",
+		"customer_name",
+		"business_unit_id",
+		"business_unit_name",
+	},
+}
 
 // ---------------------------------------------------------------------------
 // View lifecycle
@@ -99,16 +154,145 @@ ON mv_logs_filterdata (model, provider, selected_key_id, selected_key_name, virt
 // ensureMatViews creates materialized views and their unique indexes if they
 // don't already exist. Called once on startup.
 func ensureMatViews(ctx context.Context, db *gorm.DB) error {
-	for _, ddl := range []string{
-		mvLogsHourlyDDL,
-		mvLogsHourlyUniqueIdx,
-		mvLogsFilterdataDDL,
-		mvLogsFilterdataUniqueIdx,
-	} {
-		if err := db.WithContext(ctx).Exec(ddl).Error; err != nil {
+	if db.Dialector.Name() != "postgres" {
+		return nil
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		return fmt.Errorf("failed to get sql.DB for matview creation: %w", err)
+	}
+
+	// Use a dedicated connection so the advisory lock and CONCURRENTLY DDL run
+	// on the same session, outside any migration transaction.
+	conn, err := sqlDB.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get dedicated connection for matview creation: %w", err)
+	}
+	defer conn.Close()
+
+	var acquired bool
+	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", matviewRefreshAdvisoryLockKey).Scan(&acquired); err != nil {
+		return fmt.Errorf("failed to try advisory lock for matview creation: %w", err)
+	}
+	if !acquired {
+		return nil
+	}
+	defer func() {
+		_, _ = conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", matviewRefreshAdvisoryLockKey)
+	}()
+
+	if err := repairMatViewShapes(ctx, conn); err != nil {
+		return err
+	}
+
+	for _, ddl := range []string{mvLogsHourlyDDL, mvLogsFilterdataDDL} {
+		if _, err := conn.ExecContext(ctx, ddl); err != nil {
 			return fmt.Errorf("failed to create materialized view: %w", err)
 		}
 	}
+
+	if err := ensureMatViewUniqueIndexes(ctx, conn); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func repairMatViewShapes(ctx context.Context, conn *sql.Conn) error {
+	for view, columns := range matviewRequiredColumns {
+		needsRebuild, err := matViewNeedsRebuild(ctx, conn, view, columns)
+		if err != nil {
+			return err
+		}
+		if !needsRebuild {
+			continue
+		}
+		if _, err := conn.ExecContext(ctx, "DROP MATERIALIZED VIEW IF EXISTS "+view+" CASCADE"); err != nil {
+			return fmt.Errorf("failed to drop old-shape matview %s: %w", view, err)
+		}
+	}
+	return nil
+}
+
+func matViewNeedsRebuild(ctx context.Context, conn *sql.Conn, view string, requiredColumns []string) (bool, error) {
+	var exists bool
+	if err := conn.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_class
+			WHERE relkind = 'm'
+			  AND relname = $1
+		)
+	`, view).Scan(&exists); err != nil {
+		return false, fmt.Errorf("failed to check matview %s existence: %w", view, err)
+	}
+	if !exists {
+		return false, nil
+	}
+
+	rows, err := conn.QueryContext(ctx, `
+		SELECT a.attname
+		FROM pg_class c
+		JOIN pg_attribute a ON a.attrelid = c.oid
+		WHERE c.relkind = 'm'
+		  AND c.relname = $1
+		  AND a.attnum > 0
+		  AND NOT a.attisdropped
+	`, view)
+	if err != nil {
+		return false, fmt.Errorf("failed to inspect matview %s columns: %w", view, err)
+	}
+	defer rows.Close()
+
+	actual := make(map[string]struct{}, len(requiredColumns))
+	for rows.Next() {
+		var column string
+		if err := rows.Scan(&column); err != nil {
+			return false, fmt.Errorf("failed to scan matview %s column: %w", view, err)
+		}
+		actual[column] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("failed to inspect matview %s columns: %w", view, err)
+	}
+
+	for _, column := range requiredColumns {
+		if _, ok := actual[column]; !ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func ensureMatViewUniqueIndexes(ctx context.Context, conn *sql.Conn) error {
+	_, _ = conn.ExecContext(ctx, "SET maintenance_work_mem = '512MB'")
+	_, _ = conn.ExecContext(ctx, "SET max_parallel_maintenance_workers = 4")
+
+	for _, idx := range matviewUniqueIndexes {
+		var indexReady bool
+		if err := conn.QueryRowContext(ctx, `
+			SELECT COALESCE(bool_and(pi.indisvalid AND pi.indisunique), false)
+			FROM pg_class pc
+			JOIN pg_index pi ON pi.indrelid = pc.oid
+			JOIN pg_class ic ON ic.oid = pi.indexrelid
+			WHERE pc.relname = $1
+			  AND ic.relname = $2
+		`, idx.view, idx.name).Scan(&indexReady); err != nil {
+			return fmt.Errorf("failed to check matview index %s validity: %w", idx.name, err)
+		}
+		if indexReady {
+			continue
+		}
+
+		if _, err := conn.ExecContext(ctx, "DROP INDEX CONCURRENTLY IF EXISTS "+idx.name); err != nil {
+			return fmt.Errorf("failed to drop invalid matview index %s: %w", idx.name, err)
+		}
+		if _, err := conn.ExecContext(ctx, idx.sql); err != nil {
+			return fmt.Errorf("failed to create matview index %s: %w", idx.name, err)
+		}
+	}
+
 	return nil
 }
 

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -41,6 +41,10 @@ const (
 	// advisoryLockTimeout is the maximum time to wait for an advisory lock
 	// before giving up with actionable operator guidance.
 	advisoryLockTimeout = 5 * time.Minute
+
+	// maintenanceUpdateBatchSize bounds background data cleanups so they don't
+	// lock or rewrite very large log tables in one transaction.
+	maintenanceUpdateBatchSize = 10_000
 )
 
 // advisoryLock holds a dedicated connection and the advisory lock key.
@@ -354,37 +358,45 @@ func migrationInit(ctx context.Context, db *gorm.DB) error {
 // migrationUpdateObjectColumnValues normalizes legacy object_type string values on the logs table.
 func migrationUpdateObjectColumnValues(ctx context.Context, db *gorm.DB) error {
 	opts := *migrator.DefaultOptions
-	opts.UseTransaction = true
+	opts.UseTransaction = false
 	m := migrator.New(db, &opts, []*migrator.Migration{{
 		ID: "logs_init_update_object_column_values",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
 
 			updateSQL := `
+				WITH batch AS (
+					SELECT ctid,
+						CASE object_type
+							WHEN 'chat.completion' THEN 'chat_completion'
+							WHEN 'text.completion' THEN 'text_completion'
+							WHEN 'list' THEN 'embedding'
+							WHEN 'audio.speech' THEN 'speech'
+							WHEN 'audio.transcription' THEN 'transcription'
+							WHEN 'chat.completion.chunk' THEN 'chat_completion_stream'
+							WHEN 'audio.speech.chunk' THEN 'speech_stream'
+							WHEN 'audio.transcription.chunk' THEN 'transcription_stream'
+							WHEN 'response' THEN 'responses'
+							WHEN 'response.completion.chunk' THEN 'responses_stream'
+							ELSE object_type
+						END AS normalized_object_type
+					FROM logs
+					WHERE object_type IN (
+						'chat.completion', 'text.completion', 'list',
+						'audio.speech', 'audio.transcription', 'chat.completion.chunk',
+						'audio.speech.chunk', 'audio.transcription.chunk',
+						'response', 'response.completion.chunk'
+					)
+					LIMIT ?
+					FOR UPDATE SKIP LOCKED
+				)
 				UPDATE logs
-				SET object_type = CASE object_type
-					WHEN 'chat.completion' THEN 'chat_completion'
-					WHEN 'text.completion' THEN 'text_completion'
-					WHEN 'list' THEN 'embedding'
-					WHEN 'audio.speech' THEN 'speech'
-					WHEN 'audio.transcription' THEN 'transcription'
-					WHEN 'chat.completion.chunk' THEN 'chat_completion_stream'
-					WHEN 'audio.speech.chunk' THEN 'speech_stream'
-					WHEN 'audio.transcription.chunk' THEN 'transcription_stream'
-					WHEN 'response' THEN 'responses'
-					WHEN 'response.completion.chunk' THEN 'responses_stream'
-					ELSE object_type
-				END
-				WHERE object_type IN (
-					'chat.completion', 'text.completion', 'list',
-					'audio.speech', 'audio.transcription', 'chat.completion.chunk',
-					'audio.speech.chunk', 'audio.transcription.chunk',
-					'response', 'response.completion.chunk'
-				)`
+				SET object_type = batch.normalized_object_type
+				FROM batch
+				WHERE logs.ctid = batch.ctid`
 
-			result := tx.Exec(updateSQL)
-			if result.Error != nil {
-				return fmt.Errorf("failed to update object_type values: %w", result.Error)
+			if err := execBatchedGormMaintenanceUpdate(tx, "object_type normalization", updateSQL); err != nil {
+				return err
 			}
 
 			return nil
@@ -679,6 +691,9 @@ func migrationAddPerformanceIndexes(ctx context.Context, db *gorm.DB) error {
 	m := migrator.New(db, &opts, []*migrator.Migration{{
 		ID: "logs_add_performance_indexes",
 		Migrate: func(tx *gorm.DB) error {
+			if tx.Dialector.Name() == "postgres" {
+				return nil
+			}
 			tx = tx.WithContext(ctx)
 			migrator := tx.Migrator()
 
@@ -755,6 +770,9 @@ func migrationAddPerformanceIndexesV2(ctx context.Context, db *gorm.DB) error {
 	m := migrator.New(db, &opts, []*migrator.Migration{{
 		ID: "logs_add_performance_indexes_v2",
 		Migrate: func(tx *gorm.DB) error {
+			if tx.Dialector.Name() == "postgres" {
+				return nil
+			}
 			tx = tx.WithContext(ctx)
 			migrator := tx.Migrator()
 
@@ -963,10 +981,14 @@ func migrationCreateMCPToolLogsTable(ctx context.Context, db *gorm.DB) error {
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
 			migrator := tx.Migrator()
-			if !migrator.HasTable(&MCPToolLog{}) {
+			tableExists := migrator.HasTable(&MCPToolLog{})
+			if !tableExists {
 				if err := migrator.CreateTable(&MCPToolLog{}); err != nil {
 					return err
 				}
+			}
+			if tx.Dialector.Name() == "postgres" && tableExists {
+				return nil
 			}
 
 			// Explicitly create indexes as declared in struct tags
@@ -1036,7 +1058,7 @@ func migrationAddCostColumnToMCPToolLogs(ctx context.Context, db *gorm.DB) error
 			}
 
 			// Create index on cost column
-			if !migrator.HasIndex(&MCPToolLog{}, "idx_mcp_logs_cost") {
+			if tx.Dialector.Name() != "postgres" && !migrator.HasIndex(&MCPToolLog{}, "idx_mcp_logs_cost") {
 				if err := migrator.CreateIndex(&MCPToolLog{}, "idx_mcp_logs_cost"); err != nil {
 					return fmt.Errorf("failed to create index on cost: %w", err)
 				}
@@ -1209,7 +1231,7 @@ func migrationAddVirtualKeyColumnsToMCPToolLogs(ctx context.Context, db *gorm.DB
 			}
 
 			// Create index on virtual_key_id column
-			if !migrator.HasIndex(&MCPToolLog{}, "idx_mcp_logs_virtual_key_id") {
+			if tx.Dialector.Name() != "postgres" && !migrator.HasIndex(&MCPToolLog{}, "idx_mcp_logs_virtual_key_id") {
 				if err := migrator.CreateIndex(&MCPToolLog{}, "idx_mcp_logs_virtual_key_id"); err != nil {
 					return fmt.Errorf("failed to create index on virtual_key_id: %w", err)
 				}
@@ -1603,7 +1625,7 @@ func migrationAddMetadataColumnToMCPToolLogs(ctx context.Context, db *gorm.DB) e
 // enabling correct logging of parallel tool calls that share the same request ID.
 func migrationAddRequestIDColumnToMCPToolLogs(ctx context.Context, db *gorm.DB) error {
 	opts := *migrator.DefaultOptions
-	opts.UseTransaction = true
+	opts.UseTransaction = false
 	m := migrator.New(db, &opts, []*migrator.Migration{{
 		ID: "mcp_tool_logs_add_request_id_column",
 		Migrate: func(tx *gorm.DB) error {
@@ -1614,12 +1636,22 @@ func migrationAddRequestIDColumnToMCPToolLogs(ctx context.Context, db *gorm.DB) 
 					return err
 				}
 			}
-			if err := tx.Exec(
-				"UPDATE mcp_tool_logs SET request_id = id WHERE request_id IS NULL OR request_id = ''",
-			).Error; err != nil {
-				return fmt.Errorf("failed to backfill request_id: %w", err)
+			if err := execBatchedGormMaintenanceUpdate(tx, "mcp request_id backfill", `
+				WITH batch AS (
+					SELECT ctid
+					FROM mcp_tool_logs
+					WHERE request_id IS NULL OR request_id = ''
+					LIMIT ?
+					FOR UPDATE SKIP LOCKED
+				)
+				UPDATE mcp_tool_logs
+				SET request_id = id
+				FROM batch
+				WHERE mcp_tool_logs.ctid = batch.ctid
+			`); err != nil {
+				return err
 			}
-			if !migrator.HasIndex(&MCPToolLog{}, "idx_mcp_logs_request_id") {
+			if tx.Dialector.Name() != "postgres" && !migrator.HasIndex(&MCPToolLog{}, "idx_mcp_logs_request_id") {
 				if err := migrator.CreateIndex(&MCPToolLog{}, "idx_mcp_logs_request_id"); err != nil {
 					return err
 				}
@@ -1661,6 +1693,9 @@ func migrationAddHistogramCompositeIndexes(ctx context.Context, db *gorm.DB) err
 	m := migrator.New(db, &opts, []*migrator.Migration{{
 		ID: "logs_add_histogram_composite_indexes",
 		Migrate: func(tx *gorm.DB) error {
+			if tx.Dialector.Name() == "postgres" {
+				return nil
+			}
 			tx = tx.WithContext(ctx)
 			migrator := tx.Migrator()
 
@@ -1937,16 +1972,8 @@ func ensureMetadataGINIndex(ctx context.Context, conn *sql.Conn) error {
 	}
 
 	if indexValid {
-		// Defensively clean up any invalid metadata values written after index creation.
-		// Use EXISTS + LIMIT 1 to avoid a full sequential scan when (the common case) no invalid rows exist.
-		var hasInvalid bool
-		if err := conn.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM logs WHERE metadata IS NOT NULL AND metadata IS NOT JSON OBJECT LIMIT 1)").Scan(&hasInvalid); err != nil {
-			return fmt.Errorf("failed to query invalid metadata values: %w", err)
-		}
-		if hasInvalid {
-			if _, err := conn.ExecContext(ctx, "UPDATE logs SET metadata = NULL WHERE metadata IS NOT NULL AND metadata IS NOT JSON OBJECT"); err != nil {
-				return fmt.Errorf("failed to clean invalid metadata values: %w", err)
-			}
+		if err := cleanupInvalidLogMetadata(ctx, conn); err != nil {
+			return err
 		}
 		return nil
 	}
@@ -1964,16 +1991,10 @@ func ensureMetadataGINIndex(ctx context.Context, conn *sql.Conn) error {
 	// Non-fatal: falls back to a single worker on older versions.
 	_, _ = conn.ExecContext(ctx, "SET max_parallel_maintenance_workers = 4")
 
-	// Defensively clean up any invalid metadata values before building the index.
-	// Use EXISTS + LIMIT 1 to short-circuit when no invalid rows exist.
-	var hasInvalid bool
-	if err := conn.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM logs WHERE metadata IS NOT NULL AND metadata IS NOT JSON OBJECT LIMIT 1)").Scan(&hasInvalid); err != nil {
-		return fmt.Errorf("failed to query invalid metadata values: %w", err)
-	}
-	if hasInvalid {
-		if _, err := conn.ExecContext(ctx, "UPDATE logs SET metadata = NULL WHERE metadata IS NOT NULL AND metadata IS NOT JSON OBJECT"); err != nil {
-			return fmt.Errorf("failed to clean invalid metadata values: %w", err)
-		}
+	// Defensively clean up invalid metadata values before building the index.
+	// This runs in small autocommitted batches to avoid one massive row-lock/WAL event.
+	if err := cleanupInvalidLogMetadata(ctx, conn); err != nil {
+		return err
 	}
 
 	// CONCURRENTLY takes only a ShareUpdateExclusiveLock, which is compatible with
@@ -1991,6 +2012,23 @@ func ensureMetadataGINIndex(ctx context.Context, conn *sql.Conn) error {
 		return fmt.Errorf("failed to create metadata GIN index: %w", err)
 	}
 	return nil
+}
+
+func cleanupInvalidLogMetadata(ctx context.Context, conn *sql.Conn) error {
+	return execBatchedMaintenanceUpdate(ctx, conn, "invalid metadata cleanup", `
+		WITH batch AS (
+			SELECT ctid
+			FROM logs
+			WHERE metadata IS NOT NULL
+			  AND metadata IS NOT JSON OBJECT
+			LIMIT $1
+			FOR UPDATE SKIP LOCKED
+		)
+		UPDATE logs
+		SET metadata = NULL
+		FROM batch
+		WHERE logs.ctid = batch.ctid
+	`)
 }
 
 // migrationAddDashboardEnhancements adds cached_read_tokens column to logs table.
@@ -2042,14 +2080,8 @@ func ensureDashboardEnhancements(ctx context.Context, conn *sql.Conn) error {
 	// The extra `AND cached_read_tokens = 0` plus `AND COALESCE(...) > 0` makes
 	// re-runs cheap: rows already backfilled have non-zero values (skipped),
 	// and rows with genuinely zero cached tokens are also skipped (correct as-is).
-	backfillSQL := `UPDATE logs SET
-		cached_read_tokens = (token_usage::jsonb->'prompt_tokens_details'->>'cached_read_tokens')::int
-		WHERE cached_read_tokens = 0
-		AND token_usage IS NOT NULL AND token_usage != '' AND token_usage != 'null'
-		AND token_usage ~ '^\s*\{.*\}\s*$'
-		AND COALESCE((token_usage::jsonb->'prompt_tokens_details'->>'cached_read_tokens')::int, 0) > 0`
-	if _, err := conn.ExecContext(ctx, backfillSQL); err != nil {
-		return fmt.Errorf("failed to backfill cached_read_tokens: %w", err)
+	if err := backfillCachedReadTokens(ctx, conn); err != nil {
+		return err
 	}
 
 	// Rebuild histogram covering index with cached_read_tokens included,
@@ -2106,6 +2138,55 @@ func ensureDashboardEnhancements(ctx context.Context, conn *sql.Conn) error {
 	return nil
 }
 
+func backfillCachedReadTokens(ctx context.Context, conn *sql.Conn) error {
+	return execBatchedMaintenanceUpdate(ctx, conn, "cached_read_tokens backfill", `
+		WITH batch AS (
+			SELECT ctid
+			FROM logs
+			WHERE cached_read_tokens = 0
+			  AND token_usage IS NOT NULL
+			  AND token_usage != ''
+			  AND token_usage != 'null'
+			  AND token_usage ~ '^\s*\{.*\}\s*$'
+			  AND COALESCE((token_usage::jsonb->'prompt_tokens_details'->>'cached_read_tokens')::int, 0) > 0
+			LIMIT $1
+			FOR UPDATE SKIP LOCKED
+		)
+		UPDATE logs
+		SET cached_read_tokens = (token_usage::jsonb->'prompt_tokens_details'->>'cached_read_tokens')::int
+		FROM batch
+		WHERE logs.ctid = batch.ctid
+	`)
+}
+
+func execBatchedMaintenanceUpdate(ctx context.Context, conn *sql.Conn, label string, query string) error {
+	for {
+		result, err := conn.ExecContext(ctx, query, maintenanceUpdateBatchSize)
+		if err != nil {
+			return fmt.Errorf("failed to run %s batch: %w", label, err)
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to read %s batch rows affected: %w", label, err)
+		}
+		if rowsAffected == 0 {
+			return nil
+		}
+	}
+}
+
+func execBatchedGormMaintenanceUpdate(tx *gorm.DB, label string, query string) error {
+	for {
+		result := tx.Exec(query, maintenanceUpdateBatchSize)
+		if result.Error != nil {
+			return fmt.Errorf("failed to run %s batch: %w", label, result.Error)
+		}
+		if result.RowsAffected == 0 {
+			return nil
+		}
+	}
+}
+
 // migrationAddLogsAndDashboardPerformanceIndexes records the migration version for the performance
 // indexes. Actual index creation is deferred to ensurePerformanceIndexes (called
 // post-startup in a background goroutine) because CREATE INDEX CONCURRENTLY cannot
@@ -2155,6 +2236,111 @@ type performanceIndexDef struct {
 // performanceIndexes is the set of full-text and GIN indexes built by ensurePerformanceIndexes.
 // Each statement uses CREATE INDEX CONCURRENTLY to avoid blocking writes.
 var performanceIndexes = []performanceIndexDef{
+	{
+		table: "logs",
+		name:  "idx_logs_latency",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_latency ON logs(latency)",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_total_tokens",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_total_tokens ON logs(total_tokens)",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_selected_key_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_selected_key_id ON logs(selected_key_id)",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_virtual_key_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_virtual_key_id ON logs(virtual_key_id)",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_timestamp",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_timestamp ON logs(timestamp)",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_status",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_status ON logs(status)",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_created_at",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_created_at ON logs(created_at)",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_provider",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_provider ON logs(provider)",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_model",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_model ON logs(model)",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_object_type",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_object_type ON logs(object_type)",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_cost",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_cost ON logs(cost)",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_status_timestamp",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_status_timestamp ON logs(status, timestamp)",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_status_created_at",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_status_created_at ON logs(status, created_at)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_llm_request_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_llm_request_id ON mcp_tool_logs(llm_request_id)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_tool_name",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_tool_name ON mcp_tool_logs(tool_name)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_server_label",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_server_label ON mcp_tool_logs(server_label)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_latency",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_latency ON mcp_tool_logs(latency)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_status",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_status ON mcp_tool_logs(status)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_cost",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_cost ON mcp_tool_logs(cost)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_virtual_key_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_virtual_key_id ON mcp_tool_logs(virtual_key_id)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_request_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_request_id ON mcp_tool_logs(request_id)",
+	},
 	{
 		table: "logs",
 		name:  "idx_logs_content_summary_fts",
@@ -2561,7 +2747,9 @@ func migrationAddGovernanceContextColumns(ctx context.Context, db *gorm.DB) erro
 
 // migrationRecreateMatViewsWithGovernanceColumns drops and recreates materialized views
 // so they include the new governance context columns (user_id, team_id, customer_id, business_unit_id).
-// The views are recreated by ensureMatViews on startup, so we just need to drop the old ones.
+// The actual rebuild is deferred to ensureMatViews, which runs after startup on
+// a dedicated connection. Dropping materialized views inline in this migration
+// can queue heavy locks during rolling deploys on large log tables.
 func migrationRecreateMatViewsWithGovernanceColumns(ctx context.Context, db *gorm.DB) error {
 	// Materialized views are PostgreSQL-only; skip on other dialects
 	if db.Dialector.Name() != "postgres" {
@@ -2572,12 +2760,6 @@ func migrationRecreateMatViewsWithGovernanceColumns(ctx context.Context, db *gor
 	m := migrator.New(db, &opts, []*migrator.Migration{{
 		ID: "logs_recreate_matviews_with_governance_columns",
 		Migrate: func(tx *gorm.DB) error {
-			tx = tx.WithContext(ctx)
-			for _, view := range []string{"mv_logs_hourly", "mv_logs_filterdata"} {
-				if err := tx.Exec("DROP MATERIALIZED VIEW IF EXISTS " + view + " CASCADE").Error; err != nil {
-					return fmt.Errorf("failed to drop %s: %w", view, err)
-				}
-			}
 			return nil
 		},
 		Rollback: func(tx *gorm.DB) error {

--- a/framework/logstore/migrations_scale_test.go
+++ b/framework/logstore/migrations_scale_test.go
@@ -1,0 +1,389 @@
+package logstore
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+const (
+	scaleMigrationTestEnv     = "BIFROST_SCALE_MIGRATION_TEST"
+	scaleMigrationRowsEnv     = "BIFROST_SCALE_MIGRATION_ROWS"
+	scaleMigrationDefaultRows = 10_000_000
+)
+
+type lockWaitSample struct {
+	ObservedAt      time.Time
+	WaitingPID      int
+	WaitingDuration time.Duration
+	WaitingQuery    string
+	BlockingPIDs    string
+}
+
+func TestScalePostgresLogstoreMigrations(t *testing.T) {
+	if os.Getenv(scaleMigrationTestEnv) != "1" {
+		t.Skipf("set %s=1 to run the destructive large Postgres migration test", scaleMigrationTestEnv)
+	}
+
+	rows := scaleMigrationDefaultRows
+	if raw := os.Getenv(scaleMigrationRowsEnv); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		require.NoError(t, err, "invalid %s", scaleMigrationRowsEnv)
+		require.Positive(t, parsed, "%s must be positive", scaleMigrationRowsEnv)
+		rows = parsed
+	}
+
+	db := trySetupPostgresDB(t)
+	require.NotNil(t, db, "Postgres must be reachable on %s", postgresDSN)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Hour)
+	defer cancel()
+
+	resetScaleMigrationDB(t, ctx, db)
+	createScaleMigrationTables(t, ctx, db)
+	populateScaleMigrationTables(t, ctx, db, rows)
+	createOldShapeScaleMatViews(t, ctx, db)
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	monitorCtx, stopMonitor := context.WithCancel(ctx)
+	var sampleMu sync.Mutex
+	var samples []lockWaitSample
+	var monitorWG sync.WaitGroup
+	monitorWG.Add(1)
+	go func() {
+		defer monitorWG.Done()
+		monitorScaleMigrationLocks(monitorCtx, t, sqlDB, &sampleMu, &samples)
+	}()
+
+	start := time.Now()
+	require.NoError(t, triggerMigrations(ctx, db), "logstore migrations should complete at scale")
+	migrationElapsed := time.Since(start)
+
+	conn := acquireScaleMigrationConn(t, ctx, sqlDB)
+	defer conn.Close()
+
+	start = time.Now()
+	require.NoError(t, ensureMetadataGINIndex(ctx, conn), "metadata GIN index should be maintained at scale")
+	require.NoError(t, ensureDashboardEnhancements(ctx, conn), "dashboard enhancements should be maintained at scale")
+	require.NoError(t, ensurePerformanceIndexes(ctx, conn), "performance indexes should be maintained at scale")
+	indexElapsed := time.Since(start)
+
+	start = time.Now()
+	require.NoError(t, ensureMatViews(ctx, db), "matviews should be maintained at scale")
+	matviewElapsed := time.Since(start)
+
+	stopMonitor()
+	monitorWG.Wait()
+
+	t.Logf("scale rows per table: %d", rows)
+	t.Logf("migration elapsed: %s", migrationElapsed)
+	t.Logf("index/background maintenance elapsed: %s", indexElapsed)
+	t.Logf("matview maintenance elapsed: %s", matviewElapsed)
+
+	sampleMu.Lock()
+	defer sampleMu.Unlock()
+	if len(samples) == 0 {
+		t.Log("no lock waits observed by sampler")
+		return
+	}
+	t.Logf("observed %d lock-wait samples", len(samples))
+	for i, sample := range samples {
+		if i >= 20 {
+			t.Logf("... %d additional lock-wait samples omitted", len(samples)-i)
+			break
+		}
+		t.Logf(
+			"lock wait at %s pid=%d duration=%s blockers=%s query=%q",
+			sample.ObservedAt.Format(time.RFC3339),
+			sample.WaitingPID,
+			sample.WaitingDuration,
+			sample.BlockingPIDs,
+			sample.WaitingQuery,
+		)
+	}
+}
+
+func resetScaleMigrationDB(t *testing.T, ctx context.Context, db *gorm.DB) {
+	t.Helper()
+	statements := []string{
+		"DROP MATERIALIZED VIEW IF EXISTS mv_logs_hourly CASCADE",
+		"DROP MATERIALIZED VIEW IF EXISTS mv_logs_filterdata CASCADE",
+		"DROP TABLE IF EXISTS mcp_tool_logs CASCADE",
+		"DROP TABLE IF EXISTS async_jobs CASCADE",
+		"DROP TABLE IF EXISTS logs CASCADE",
+		"CREATE TABLE IF NOT EXISTS migrations (id VARCHAR(255) PRIMARY KEY)",
+		"DELETE FROM migrations",
+	}
+	for _, stmt := range statements {
+		require.NoError(t, db.WithContext(ctx).Exec(stmt).Error, stmt)
+	}
+}
+
+func createScaleMigrationTables(t *testing.T, ctx context.Context, db *gorm.DB) {
+	t.Helper()
+	logsSQL := `
+CREATE UNLOGGED TABLE logs (
+	id VARCHAR(255) NOT NULL,
+	parent_request_id VARCHAR(255),
+	timestamp TIMESTAMP NOT NULL,
+	object_type VARCHAR(255) NOT NULL,
+	provider VARCHAR(255) NOT NULL,
+	model VARCHAR(255) NOT NULL,
+	number_of_retries INTEGER DEFAULT 0,
+	fallback_index INTEGER DEFAULT 0,
+	selected_key_id VARCHAR(255),
+	selected_key_name VARCHAR(255),
+	virtual_key_id VARCHAR(255),
+	virtual_key_name VARCHAR(255),
+	routing_engines_used VARCHAR(255),
+	routing_rule_id VARCHAR(255),
+	routing_rule_name VARCHAR(255),
+	input_history TEXT,
+	responses_input_history TEXT,
+	output_message TEXT,
+	responses_output TEXT,
+	embedding_output TEXT,
+	rerank_output TEXT,
+	ocr_output TEXT,
+	params TEXT,
+	tools TEXT,
+	tool_calls TEXT,
+	speech_input TEXT,
+	transcription_input TEXT,
+	image_generation_input TEXT,
+	speech_output TEXT,
+	transcription_output TEXT,
+	image_generation_output TEXT,
+	list_models_output TEXT,
+	cache_debug TEXT,
+	latency DOUBLE PRECISION,
+	token_usage TEXT,
+	cost DOUBLE PRECISION,
+	status VARCHAR(50) NOT NULL,
+	error_details TEXT,
+	stream BOOLEAN DEFAULT FALSE,
+	content_summary TEXT,
+	raw_request TEXT,
+	raw_response TEXT,
+	passthrough_request_body TEXT,
+	passthrough_response_body TEXT,
+	routing_engine_logs TEXT,
+	metadata TEXT,
+	is_large_payload_request BOOLEAN DEFAULT FALSE,
+	is_large_payload_response BOOLEAN DEFAULT FALSE,
+	prompt_tokens INTEGER DEFAULT 0,
+	completion_tokens INTEGER DEFAULT 0,
+	total_tokens INTEGER DEFAULT 0,
+	cached_read_tokens INTEGER DEFAULT 0,
+	created_at TIMESTAMP NOT NULL
+)`
+	require.NoError(t, db.WithContext(ctx).Exec(logsSQL).Error)
+
+	mcpSQL := `
+CREATE UNLOGGED TABLE mcp_tool_logs (
+	id VARCHAR(255) NOT NULL,
+	request_id VARCHAR(255),
+	llm_request_id VARCHAR(255),
+	timestamp TIMESTAMP NOT NULL,
+	tool_name VARCHAR(255) NOT NULL,
+	server_label VARCHAR(255),
+	virtual_key_id VARCHAR(255),
+	virtual_key_name VARCHAR(255),
+	arguments TEXT,
+	result TEXT,
+	error_details TEXT,
+	latency DOUBLE PRECISION,
+	cost DOUBLE PRECISION,
+	status VARCHAR(50) NOT NULL,
+	metadata TEXT,
+	has_object BOOLEAN DEFAULT FALSE,
+	created_at TIMESTAMP NOT NULL
+)`
+	require.NoError(t, db.WithContext(ctx).Exec(mcpSQL).Error)
+}
+
+func populateScaleMigrationTables(t *testing.T, ctx context.Context, db *gorm.DB, rows int) {
+	t.Helper()
+	t.Logf("populating %d logs and %d mcp_tool_logs rows", rows, rows)
+	require.NoError(t, db.WithContext(ctx).Exec("SET synchronous_commit = off").Error)
+
+	insertLogsSQL := `
+INSERT INTO logs (
+	id, timestamp, object_type, provider, model,
+	parent_request_id, selected_key_id, selected_key_name, virtual_key_id, virtual_key_name,
+	routing_engines_used, routing_rule_id, routing_rule_name,
+	latency, token_usage, cost, status, stream, content_summary, metadata,
+	prompt_tokens, completion_tokens, total_tokens, cached_read_tokens, created_at
+)
+SELECT
+	'log-' || gs,
+	NOW() - ((gs % 129600) * INTERVAL '1 minute'),
+	CASE gs % 8
+		WHEN 0 THEN 'chat.completion'
+		WHEN 1 THEN 'chat_completion'
+		WHEN 2 THEN 'text.completion'
+		WHEN 3 THEN 'responses'
+		WHEN 4 THEN 'embedding'
+		WHEN 5 THEN 'audio.speech'
+		WHEN 6 THEN 'chat.completion.chunk'
+		ELSE 'chat_completion_stream'
+	END,
+	CASE gs % 4 WHEN 0 THEN 'openai' WHEN 1 THEN 'anthropic' WHEN 2 THEN 'bedrock' ELSE 'gemini' END,
+	CASE gs % 5 WHEN 0 THEN 'gpt-4o' WHEN 1 THEN 'claude-3-5-sonnet' WHEN 2 THEN 'nova-pro' WHEN 3 THEN 'gemini-1.5-pro' ELSE 'gpt-4o-mini' END,
+	CASE WHEN gs % 10 = 0 THEN 'parent-' || (gs / 10) ELSE NULL END,
+	'key-' || (gs % 1000),
+	'key-name-' || (gs % 1000),
+	'vk-' || (gs % 10000),
+	'vk-name-' || (gs % 10000),
+	CASE WHEN gs % 3 = 0 THEN 'routing-rule,governance' ELSE 'loadbalancing' END,
+	'rule-' || (gs % 500),
+	'rule-name-' || (gs % 500),
+	(gs % 20000)::DOUBLE PRECISION / 10.0,
+	CASE WHEN gs % 7 = 0 THEN '{"prompt_tokens_details":{"cached_read_tokens":12}}' ELSE '{}' END,
+	(gs % 1000)::DOUBLE PRECISION / 100000.0,
+	CASE WHEN gs % 11 = 0 THEN 'error' ELSE 'success' END,
+	(gs % 2 = 0),
+	CASE WHEN gs % 13 = 0 THEN repeat('summary ', 8) ELSE NULL END,
+	CASE WHEN gs % 17 = 0 THEN 'not-json' ELSE '{"tenant":"scale"}' END,
+	(gs % 4000)::INTEGER,
+	(gs % 2000)::INTEGER,
+	(gs % 6000)::INTEGER,
+	0,
+	NOW() - ((gs % 129600) * INTERVAL '1 minute')
+FROM generate_series(1, ?) AS gs`
+	require.NoError(t, db.WithContext(ctx).Exec(insertLogsSQL, rows).Error)
+
+	insertMCPSQL := `
+INSERT INTO mcp_tool_logs (
+	id, request_id, llm_request_id, timestamp, tool_name, server_label,
+	virtual_key_id, virtual_key_name, arguments, result, latency, cost, status, metadata, created_at
+)
+SELECT
+	'mcp-' || gs,
+	CASE WHEN gs % 2 = 0 THEN '' ELSE NULL END,
+	'log-' || gs,
+	NOW() - ((gs % 129600) * INTERVAL '1 minute'),
+	'tool-' || (gs % 250),
+	'server-' || (gs % 50),
+	'vk-' || (gs % 10000),
+	'vk-name-' || (gs % 10000),
+	'{"x":1}',
+	'{"ok":true}',
+	(gs % 5000)::DOUBLE PRECISION / 10.0,
+	(gs % 500)::DOUBLE PRECISION / 100000.0,
+	CASE WHEN gs % 19 = 0 THEN 'error' ELSE 'success' END,
+	'{"tenant":"scale"}',
+	NOW() - ((gs % 129600) * INTERVAL '1 minute')
+FROM generate_series(1, ?) AS gs`
+	require.NoError(t, db.WithContext(ctx).Exec(insertMCPSQL, rows).Error)
+}
+
+func createOldShapeScaleMatViews(t *testing.T, ctx context.Context, db *gorm.DB) {
+	t.Helper()
+	oldHourlySQL := `
+CREATE MATERIALIZED VIEW mv_logs_hourly AS
+SELECT
+	date_trunc('hour', timestamp) AS hour,
+	provider,
+	model,
+	status,
+	object_type,
+	selected_key_id,
+	COALESCE(virtual_key_id, '') AS virtual_key_id,
+	COALESCE(routing_rule_id, '') AS routing_rule_id,
+	COUNT(*) AS count,
+	SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS success_count,
+	SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) AS error_count,
+	COALESCE(AVG(latency), 0) AS avg_latency,
+	COALESCE(percentile_cont(0.90) WITHIN GROUP (ORDER BY latency), 0) AS p90_latency,
+	COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY latency), 0) AS p95_latency,
+	COALESCE(percentile_cont(0.99) WITHIN GROUP (ORDER BY latency), 0) AS p99_latency,
+	COALESCE(SUM(prompt_tokens), 0) AS total_prompt_tokens,
+	COALESCE(SUM(completion_tokens), 0) AS total_completion_tokens,
+	COALESCE(SUM(total_tokens), 0) AS total_tokens,
+	COALESCE(SUM(cached_read_tokens), 0) AS total_cached_read_tokens,
+	COALESCE(SUM(cost), 0) AS total_cost
+FROM logs
+WHERE status IN ('success', 'error')
+GROUP BY 1, 2, 3, 4, 5, 6, 7, 8`
+	require.NoError(t, db.WithContext(ctx).Exec(oldHourlySQL).Error)
+
+	oldFilterDataSQL := `
+CREATE MATERIALIZED VIEW mv_logs_filterdata AS
+SELECT DISTINCT
+	model,
+	provider,
+	selected_key_id,
+	selected_key_name,
+	COALESCE(virtual_key_id, '') AS virtual_key_id,
+	COALESCE(virtual_key_name, '') AS virtual_key_name,
+	COALESCE(routing_rule_id, '') AS routing_rule_id,
+	COALESCE(routing_rule_name, '') AS routing_rule_name,
+	COALESCE(routing_engines_used, '') AS routing_engines_used
+FROM logs
+WHERE timestamp >= NOW() - INTERVAL '60 days'
+	AND model IS NOT NULL AND model != ''`
+	require.NoError(t, db.WithContext(ctx).Exec(oldFilterDataSQL).Error)
+}
+
+func acquireScaleMigrationConn(t *testing.T, ctx context.Context, sqlDB *sql.DB) *sql.Conn {
+	t.Helper()
+	conn, err := sqlDB.Conn(ctx)
+	require.NoError(t, err)
+	return conn
+}
+
+func monitorScaleMigrationLocks(ctx context.Context, t *testing.T, db *sql.DB, mu *sync.Mutex, samples *[]lockWaitSample) {
+	t.Helper()
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			rows, err := db.QueryContext(ctx, `
+				SELECT
+					a.pid,
+					EXTRACT(EPOCH FROM (now() - COALESCE(a.query_start, now())))::float8,
+					LEFT(a.query, 500),
+					array_to_string(pg_blocking_pids(a.pid), ',')
+				FROM pg_stat_activity a
+				WHERE cardinality(pg_blocking_pids(a.pid)) > 0
+				  AND a.datname = current_database()
+				ORDER BY now() - COALESCE(a.query_start, now()) DESC
+			`)
+			if err != nil {
+				t.Logf("lock monitor query failed: %v", err)
+				continue
+			}
+			for rows.Next() {
+				var sample lockWaitSample
+				var waitingSeconds float64
+				if err := rows.Scan(&sample.WaitingPID, &waitingSeconds, &sample.WaitingQuery, &sample.BlockingPIDs); err != nil {
+					t.Logf("lock monitor scan failed: %v", err)
+					continue
+				}
+				sample.ObservedAt = time.Now()
+				sample.WaitingDuration = time.Duration(waitingSeconds * float64(time.Second))
+				mu.Lock()
+				*samples = append(*samples, sample)
+				mu.Unlock()
+			}
+			if err := rows.Err(); err != nil {
+				t.Logf("lock monitor rows failed: %v", err)
+			}
+			_ = rows.Close()
+		}
+	}
+}

--- a/framework/logstore/migrations_test.go
+++ b/framework/logstore/migrations_test.go
@@ -47,6 +47,8 @@ func setupLogsTableForGINIndexTest(t *testing.T, db *gorm.DB) {
 
 	// Drop existing tables and migration tracking in the correct order.
 	// Preserve the shared migrations table — only clear its rows.
+	db.Exec("DROP MATERIALIZED VIEW IF EXISTS mv_logs_hourly CASCADE")
+	db.Exec("DROP MATERIALIZED VIEW IF EXISTS mv_logs_filterdata CASCADE")
 	db.Exec("DROP INDEX IF EXISTS idx_logs_metadata_gin")
 	db.Exec("DROP TABLE IF EXISTS logs")
 	db.Exec("CREATE TABLE IF NOT EXISTS migrations (id VARCHAR(255) PRIMARY KEY)")
@@ -71,6 +73,8 @@ func setupLogsTableForGINIndexTest(t *testing.T, db *gorm.DB) {
 
 	// Clean up tables after the test
 	t.Cleanup(func() {
+		db.Exec("DROP MATERIALIZED VIEW IF EXISTS mv_logs_hourly CASCADE")
+		db.Exec("DROP MATERIALIZED VIEW IF EXISTS mv_logs_filterdata CASCADE")
 		db.Exec("DROP INDEX IF EXISTS idx_logs_metadata_gin")
 		db.Exec("DROP TABLE IF EXISTS logs")
 		db.Exec("DELETE FROM migrations")
@@ -307,7 +311,6 @@ func TestMigrationAddMetadataGINIndex_Idempotent(t *testing.T) {
 	// Run the migration (cleanup only) then ensure the index is built.
 	err := migrationAddMetadataGINIndex(ctx, db)
 	require.NoError(t, err, "First migration should succeed")
-
 
 	sqlDB, err := db.DB()
 	if err != nil {

--- a/framework/logstore/rdb_postgres_perf_test.go
+++ b/framework/logstore/rdb_postgres_perf_test.go
@@ -66,6 +66,42 @@ func acquirePerfTestSQLConn(t *testing.T, ctx context.Context, db *gorm.DB) *sql
 	return conn
 }
 
+func matviewIndexReady(t *testing.T, db *gorm.DB, viewName, indexName string) bool {
+	t.Helper()
+	var ready bool
+	err := db.Raw(`
+		SELECT COALESCE(bool_and(pi.indisvalid AND pi.indisunique), false)
+		FROM pg_class pc
+		JOIN pg_index pi ON pi.indrelid = pc.oid
+		JOIN pg_class ic ON ic.oid = pi.indexrelid
+		WHERE pc.relname = ?
+		  AND ic.relname = ?
+	`, viewName, indexName).Scan(&ready).Error
+	require.NoError(t, err, "Failed to check matview index readiness")
+	return ready
+}
+
+func TestEnsureMatViewsCreatesUniqueIndexes(t *testing.T) {
+	_, db := setupPerfTestDB(t)
+
+	assert.True(t, matviewIndexReady(t, db, "mv_logs_hourly", "mv_logs_hourly_uniq"), "hourly matview unique index should be valid")
+	assert.True(t, matviewIndexReady(t, db, "mv_logs_filterdata", "mv_logs_filterdata_uniq"), "filterdata matview unique index should be valid")
+}
+
+func TestEnsureMatViewsRebuildsBadSameNameIndex(t *testing.T) {
+	_, db := setupPerfTestDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.Exec("DROP INDEX IF EXISTS mv_logs_hourly_uniq").Error)
+	require.NoError(t, db.Exec("CREATE INDEX mv_logs_hourly_uniq ON mv_logs_hourly(hour)").Error)
+	require.False(t, matviewIndexReady(t, db, "mv_logs_hourly", "mv_logs_hourly_uniq"), "same-name non-unique index should not be considered ready")
+
+	require.NoError(t, ensureMatViews(ctx, db))
+
+	assert.True(t, matviewIndexReady(t, db, "mv_logs_hourly", "mv_logs_hourly_uniq"), "ensureMatViews should rebuild the required unique index")
+	assert.True(t, matviewIndexReady(t, db, "mv_logs_filterdata", "mv_logs_filterdata_uniq"), "filterdata matview unique index should remain valid")
+}
+
 type logOpts struct {
 	Model              string
 	Provider           string


### PR DESCRIPTION
## Summary

Materialized view unique indexes were being created inside a transaction using a non-concurrent `CREATE UNIQUE INDEX`, which can block and fail in production environments. This PR fixes the index creation to use `CREATE UNIQUE INDEX CONCURRENTLY` on a dedicated connection outside any transaction, and adds validation logic to detect and rebuild invalid or non-unique same-name indexes on startup.

## Changes

- Changed `CREATE UNIQUE INDEX IF NOT EXISTS` to `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS` for both `mv_logs_hourly_uniq` and `mv_logs_filterdata_uniq` to avoid table locks during index creation.
- Extracted index definitions into a `matviewUniqueIndexDef` struct and a `matviewUniqueIndexes` slice to allow programmatic iteration and validation.
- Refactored `ensureMatViews` to acquire a dedicated `sql.Conn` and an advisory lock before running DDL, since `CONCURRENTLY` operations cannot run inside a transaction.
- Added `ensureMatViewUniqueIndexes` which checks `pg_index` to verify each required unique index is both valid (`indisvalid`) and unique (`indisunique`). If an index exists but fails either check (e.g. a same-name non-unique index was created manually), it is dropped with `DROP INDEX CONCURRENTLY` and rebuilt.
- Set `maintenance_work_mem` and `max_parallel_maintenance_workers` on the dedicated connection to speed up concurrent index builds.
- Added `TestEnsureMatViewsCreatesUniqueIndexes` to assert both unique indexes are valid after setup.
- Added `TestEnsureMatViewsRebuildsBadSameNameIndex` to assert that a same-name non-unique index is detected and replaced with the correct unique index.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/logstore/... -run TestEnsureMatViews -v
```

Both `TestEnsureMatViewsCreatesUniqueIndexes` and `TestEnsureMatViewsRebuildsBadSameNameIndex` should pass against a live Postgres instance. The latter test manually creates a non-unique index with the expected name and verifies that `ensureMatViews` detects and replaces it with the correct unique index.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The advisory lock (`matviewRefreshAdvisoryLockKey`) ensures only one instance performs matview DDL at a time, preventing race conditions in multi-replica deployments.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable