### PR TITLE
feat: adds normalized_name parameter to the response of ListModels to give a normalized names

### DIFF
--- a/core/providers/utils/models.go
+++ b/core/providers/utils/models.go
@@ -41,6 +41,59 @@ func ToDisplayName(id string) string {
 	return strings.Join(parts, " ")
 }
 
+// NormalizeBaseModelSlug converts a datasheet base_model slug into a human-readable display name.
+// Unlike ToDisplayName, it merges consecutive all-digit tokens with "." to form version strings
+// and strips trailing "@..." date suffixes.
+//
+//	"claude-opus-4-6"            → "Claude Opus 4.6"
+//	"claude-sonnet-4-5"          → "Claude Sonnet 4.5"
+//	"claude-sonnet-4-5@20250929" → "Claude Sonnet 4.5"
+//	"claude-3-5-haiku"           → "Claude 3.5 Haiku"
+//	"gpt-4-turbo"                → "Gpt 4 Turbo"
+func NormalizeBaseModelSlug(slug string) string {
+	caser := cases.Title(language.English)
+
+	if idx := strings.Index(slug, "@"); idx >= 0 {
+		slug = slug[:idx]
+	}
+
+	parts := strings.FieldsFunc(slug, func(r rune) bool {
+		return r == '-' || r == '_'
+	})
+	if len(parts) == 0 {
+		return ""
+	}
+
+	result := make([]string, 0, len(parts))
+	for i := 0; i < len(parts); i++ {
+		if isDigitsOnly(parts[i]) && i+1 < len(parts) && isDigitsOnly(parts[i+1]) {
+			versionParts := []string{parts[i]}
+			for i+1 < len(parts) && isDigitsOnly(parts[i+1]) {
+				i++
+				versionParts = append(versionParts, parts[i])
+			}
+			result = append(result, strings.Join(versionParts, "."))
+		} else {
+			result = append(result, caser.String(strings.ToLower(parts[i])))
+		}
+	}
+
+	return strings.Join(result, " ")
+}
+
+// isDigitsOnly reports whether s is non-empty and contains only ASCII digits.
+func isDigitsOnly(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 // MatchFn reports whether two model ID strings should be treated as equivalent.
 // Functions are applied in order during every comparison — the first one that
 // returns true short-circuits the rest.

--- a/core/schemas/models.go
+++ b/core/schemas/models.go
@@ -138,6 +138,7 @@ type Model struct {
 	ID                  string             `json:"id"`
 	CanonicalSlug       *string            `json:"canonical_slug,omitempty"`
 	Name                *string            `json:"name,omitempty"`
+	NormalizedName      *string            `json:"normalized_name,omitempty"` // Human-readable name derived from the datasheet base_model (e.g. "Claude Sonnet 4.5")
 	Alias               *string            `json:"alias,omitempty"` // Provider API identifier this model alias maps to (e.g. Azure deployment name, Bedrock ARN)
 	Created             *int64             `json:"created,omitempty"`
 	ContextLength       *int               `json:"context_length,omitempty"`

--- a/docs/openapi/schemas/inference/models.yaml
+++ b/docs/openapi/schemas/inference/models.yaml
@@ -22,6 +22,9 @@ Model:
       type: string
     name:
       type: string
+    normalized_name:
+      type: string
+      description: Human-readable name derived from the Bifrost datasheet base model (e.g. "Claude Sonnet 4.5"). Only present when the model has a matching entry in the Bifrost pricing catalog.
     deployment:
       type: string
     created:

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -22,6 +22,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
@@ -852,24 +853,29 @@ func (h *CompletionHandler) listModels(ctx *fasthttp.RequestCtx) {
 				// Retry with alias
 				pricingEntry = h.config.ModelCatalog.GetPricingEntryForModel(*modelEntry.Alias, provider)
 			}
-			if pricingEntry != nil && modelEntry.Pricing == nil {
-				pricing := &schemas.Pricing{}
-				if pricingEntry.InputCostPerToken != nil {
-					pricing.Prompt = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.InputCostPerToken))
+			if pricingEntry != nil {
+				if pricingEntry.BaseModel != "" && resp.Data[i].NormalizedName == nil {
+					resp.Data[i].NormalizedName = bifrost.Ptr(providerUtils.NormalizeBaseModelSlug(pricingEntry.BaseModel))
 				}
-				if pricingEntry.OutputCostPerToken != nil {
-					pricing.Completion = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.OutputCostPerToken))
+				if modelEntry.Pricing == nil {
+					pricing := &schemas.Pricing{}
+					if pricingEntry.InputCostPerToken != nil {
+						pricing.Prompt = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.InputCostPerToken))
+					}
+					if pricingEntry.OutputCostPerToken != nil {
+						pricing.Completion = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.OutputCostPerToken))
+					}
+					if pricingEntry.InputCostPerImage != nil {
+						pricing.Image = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.InputCostPerImage))
+					}
+					if pricingEntry.CacheReadInputTokenCost != nil {
+						pricing.InputCacheRead = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.CacheReadInputTokenCost))
+					}
+					if pricingEntry.CacheCreationInputTokenCost != nil {
+						pricing.InputCacheWrite = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.CacheCreationInputTokenCost))
+					}
+					resp.Data[i].Pricing = pricing
 				}
-				if pricingEntry.InputCostPerImage != nil {
-					pricing.Image = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.InputCostPerImage))
-				}
-				if pricingEntry.CacheReadInputTokenCost != nil {
-					pricing.InputCacheRead = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.CacheReadInputTokenCost))
-				}
-				if pricingEntry.CacheCreationInputTokenCost != nil {
-					pricing.InputCacheWrite = bifrost.Ptr(fmt.Sprintf("%.10f", *pricingEntry.CacheCreationInputTokenCost))
-				}
-				resp.Data[i].Pricing = pricing
 			}
 		}
 	}

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -85,6 +85,7 @@ export interface Model {
 	id: string;
 	canonical_slug?: string;
 	name?: string;
+	normalized_name?: string;
 	alias?: string;
 	created?: number;
 	context_length?: number;


### PR DESCRIPTION
## Summary

Adds a `normalized_name` field to the `Model` schema that surfaces a human-readable display name derived from the Bifrost pricing catalog's `base_model` slug (e.g. `"claude-sonnet-4-5"` → `"Claude Sonnet 4.5"`). This gives API consumers and the UI a consistent, formatted model name without requiring client-side slug parsing.

## Changes

- Introduced `NormalizeBaseModelSlug` in `core/providers/utils/models.go` which converts hyphen/underscore-delimited slugs into title-cased display names, merges consecutive digit tokens with `.` to form version strings (e.g. `4-5` → `4.5`), and strips trailing `@<date>` suffixes.
- Added `NormalizedName *string` to the `Model` struct and the OpenAPI schema, populated during `listModels` when a matching pricing catalog entry with a non-empty `BaseModel` is found.
- The pricing population logic was restructured so that `normalized_name` is set independently of whether pricing data is already present on the model entry.
- Added `normalized_name` to the UI `Model` type.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./core/providers/utils/...
go test ./...

# Call the list models endpoint and verify normalized_name is present
# for models that have a matching entry in the pricing catalog
curl http://localhost:8080/v1/models | jq '.data[] | {id, normalized_name}'
# Expected: models with catalog entries show e.g. "Claude Sonnet 4.5"

# UI
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings![image.png](https://app.graphite.com/user-attachments/assets/123e9f61-ef0d-4537-9a41-4c69f7c0f10c.png)



## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. The field is derived purely from the existing pricing catalog data already available in the response.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable