### PR TITLE
fix: default to display summarized in opus 4.7 reasoning

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -545,10 +545,14 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 			// nothing to display", per the extended-thinking doc). We attach
 			// on non-disabled modes and let the upstream provider enforce
 			// model-level support.
-			if bifrostReq.Params.Reasoning.Display != nil &&
-				anthropicReq.Thinking != nil &&
-				anthropicReq.Thinking.Type != "disabled" {
-				anthropicReq.Thinking.Display = bifrostReq.Params.Reasoning.Display
+			// Opus 4.7+ omits reasoning text by default; default to "summarized"
+			// so the text is visible unless the caller explicitly requests "omitted".
+			if anthropicReq.Thinking != nil && anthropicReq.Thinking.Type != "disabled" {
+				if bifrostReq.Params.Reasoning.Display != nil {
+					anthropicReq.Thinking.Display = bifrostReq.Params.Reasoning.Display
+				} else if IsOpus47(bifrostReq.Model) {
+					anthropicReq.Thinking.Display = schemas.Ptr("summarized")
+				}
 			}
 		}
 

--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -684,6 +684,9 @@ func TestToAnthropicChatRequest_Opus47_ReasoningMaxTokens_AdaptiveOnly(t *testin
 	if result.Thinking.BudgetTokens != nil {
 		t.Errorf("expected BudgetTokens to be nil for Opus 4.7, got %v", result.Thinking.BudgetTokens)
 	}
+	if result.Thinking.Display == nil || *result.Thinking.Display != "summarized" {
+		t.Errorf("expected Display to default to 'summarized' for Opus 4.7, got %v", result.Thinking.Display)
+	}
 }
 
 func TestToAnthropicChatRequest_NonOpus47_ReasoningMaxTokens_EnabledWithBudget(t *testing.T) {
@@ -749,5 +752,96 @@ func TestToAnthropicChatRequest_Opus47_ReasoningEffort_AdaptiveWithEffort(t *tes
 	}
 	if result.OutputConfig == nil || result.OutputConfig.Effort == nil {
 		t.Error("expected OutputConfig.Effort to be set for Opus 4.7 effort-based reasoning")
+	}
+}
+
+func TestToAnthropicChatRequest_Opus47_DefaultsDisplayToSummarized(t *testing.T) {
+	effort := "high"
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-opus-4-7-20260401",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: new("think")}},
+		},
+		Params: &schemas.ChatParameters{
+			MaxCompletionTokens: new(8192),
+			Reasoning:           &schemas.ChatReasoning{Effort: &effort},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+	result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Thinking == nil {
+		t.Fatal("expected Thinking to be set")
+	}
+	if result.Thinking.Display == nil || *result.Thinking.Display != "summarized" {
+		t.Errorf("expected Display to default to 'summarized' for Opus 4.7, got %v", result.Thinking.Display)
+	}
+}
+
+func TestToAnthropicChatRequest_Opus47_RespectsExplicitDisplayOmitted(t *testing.T) {
+	effort := "high"
+	display := "omitted"
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-opus-4-7-20260401",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: new("think")}},
+		},
+		Params: &schemas.ChatParameters{
+			MaxCompletionTokens: new(8192),
+			Reasoning:           &schemas.ChatReasoning{Effort: &effort, Display: &display},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+	result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Thinking == nil {
+		t.Fatal("expected Thinking to be set")
+	}
+	if result.Thinking.Display == nil || *result.Thinking.Display != "omitted" {
+		t.Errorf("expected Display to be 'omitted' when explicitly set, got %v", result.Thinking.Display)
+	}
+}
+
+func TestToAnthropicChatRequest_NonOpus47_NoDefaultDisplay(t *testing.T) {
+	maxTok := 2048
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-opus-4-6-20250514",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: new("think")}},
+		},
+		Params: &schemas.ChatParameters{
+			MaxCompletionTokens: new(8192),
+			Reasoning:           &schemas.ChatReasoning{MaxTokens: &maxTok},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+	result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Thinking == nil {
+		t.Fatal("expected Thinking to be set")
+	}
+	if result.Thinking.Display != nil {
+		t.Errorf("expected Display to be nil for non-Opus 4.7, got %q", *result.Thinking.Display)
 	}
 }

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -252,9 +252,16 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 				if anthropic.SupportsAdaptiveThinking(bifrostReq.Model) {
 					// Opus 4.6+: adaptive thinking + output_config.effort
 					effort := anthropic.MapBifrostEffortToAnthropic(*bifrostReq.Params.Reasoning.Effort)
-					bedrockReq.AdditionalModelRequestFields.Set("thinking", map[string]any{
+					thinkingConfig := map[string]any{
 						"type": "adaptive",
-					})
+					}
+					if bifrostReq.Params.Reasoning.Display != nil {
+						thinkingConfig["display"] = *bifrostReq.Params.Reasoning.Display
+					} else if anthropic.IsOpus47(bifrostReq.Model) {
+						// Opus 4.7+ omits reasoning text by default; default to "summarized"
+						thinkingConfig["display"] = "summarized"
+					}
+					bedrockReq.AdditionalModelRequestFields.Set("thinking", thinkingConfig)
 					setOutputConfigField(bedrockReq.AdditionalModelRequestFields, "effort", effort)
 				} else {
 					// Opus 4.5 and older models: budget_tokens thinking


### PR DESCRIPTION
## Summary

Claude Opus 4.7+ omits reasoning text by default, which means extended thinking output is invisible unless the caller explicitly configures the `display` field. This PR defaults the `display` field to `"summarized"` for Opus 4.7 models when no explicit value is provided, ensuring reasoning text is visible out of the box. Callers can still override this by explicitly setting `display` to `"omitted"` or any other supported value.

## Changes

- For Opus 4.7 models, when `thinking` is enabled and no `display` value is explicitly set, `display` is automatically defaulted to `"summarized"` in both the Anthropic and Bedrock providers.
- Explicit caller-provided `display` values are always respected and take precedence over the default.
- Non-Opus 4.7 models retain their existing behavior with no default `display` value applied.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/...
go test ./core/providers/bedrock/...
```

- Sending a request to an Opus 4.7 model with reasoning enabled and no `display` field set should result in `display: "summarized"` being forwarded to the provider.
- Sending a request with `display: "omitted"` explicitly set should forward `"omitted"` unchanged.
- Sending a request to a non-Opus 4.7 model with reasoning enabled should not include any `display` field.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable