### PR TITLE
feat: add `source_id` column and `GetTeamBySourceID` lookup to `governance_teams`

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -380,6 +380,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationTeamsTableUpdates(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddTeamSourceIDColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddKeyNameColumn(ctx, db); err != nil {
 		return err
 	}
@@ -7468,6 +7471,45 @@ func migrationAddMCPClientDisabledColumn(ctx context.Context, db *gorm.DB) error
 		return fmt.Errorf("error running add_mcp_client_disabled_column migration: %s", err.Error())
 	}
 	return nil
+}
+
+// migrationAddTeamSourceIDColumn adds optional source_id to governance_teams and
+// a unique index so non-null values do not collide (multiple NULLs remain allowed).
+func migrationAddTeamSourceIDColumn(ctx context.Context, db *gorm.DB) error {
+	const idxName = "idx_governance_teams_source_id"
+	return RunSingleMigration(ctx, db, &migrator.Migration{
+		ID: "add_team_source_id_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TableTeam{}, "source_id") {
+				if err := mg.AddColumn(&tables.TableTeam{}, "source_id"); err != nil {
+					return fmt.Errorf("add source_id column to governance_teams: %w", err)
+				}
+			}
+			if !mg.HasIndex(&tables.TableTeam{}, idxName) {
+				if err := mg.CreateIndex(&tables.TableTeam{}, "SourceID"); err != nil {
+					return fmt.Errorf("create unique index on governance_teams.source_id: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasIndex(&tables.TableTeam{}, idxName) {
+				if err := mg.DropIndex(&tables.TableTeam{}, idxName); err != nil {
+					return fmt.Errorf("drop unique index on governance_teams.source_id: %w", err)
+				}
+			}
+			if mg.HasColumn(&tables.TableTeam{}, "source_id") {
+				if err := mg.DropColumn(&tables.TableTeam{}, "source_id"); err != nil {
+					return fmt.Errorf("drop source_id column from governance_teams: %w", err)
+				}
+			}
+			return nil
+		},
+	})
 }
 
 // migrationUniqueTeamNames deduplicates governance_teams.name and adds a unique

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -2883,6 +2883,22 @@ func (s *RDBConfigStore) GetTeamByName(ctx context.Context, name string, custome
 	return &team, nil
 }
 
+// GetTeamBySourceID retrieves a team by its source ID.
+func (s *RDBConfigStore) GetTeamBySourceID(ctx context.Context, sourceID string) (*tables.TableTeam, error) {
+	var team tables.TableTeam
+	if err := s.DB().WithContext(ctx).
+		Select(teamSelectWithVKCount).
+		Preload("Customer").Preload("Budgets").Preload("RateLimit").
+		Where("source_id = ?", sourceID).
+		First(&team).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return &team, nil
+}
+
 // CreateTeam creates a new team in the database.
 func (s *RDBConfigStore) CreateTeam(ctx context.Context, team *tables.TableTeam, tx ...*gorm.DB) error {
 	var txDB *gorm.DB

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -174,6 +174,7 @@ type ConfigStore interface {
 	GetTeamsPaginated(ctx context.Context, params TeamsQueryParams) ([]tables.TableTeam, int64, error)
 	GetTeam(ctx context.Context, id string) (*tables.TableTeam, error)
 	GetTeamByName(ctx context.Context, name string, customerID string) (*tables.TableTeam, error)
+	GetTeamBySourceID(ctx context.Context, sourceID string) (*tables.TableTeam, error)
 	CreateTeam(ctx context.Context, team *tables.TableTeam, tx ...*gorm.DB) error
 	UpdateTeam(ctx context.Context, team *tables.TableTeam, tx ...*gorm.DB) error
 	DeleteTeam(ctx context.Context, id string) error

--- a/framework/configstore/tables/team.go
+++ b/framework/configstore/tables/team.go
@@ -13,6 +13,7 @@ type TableTeam struct {
 	Name        string  `gorm:"type:varchar(255);not null;uniqueIndex" json:"name"`
 	CustomerID  *string `gorm:"type:varchar(255);index" json:"customer_id,omitempty"` // A team can belong to a customer
 	RateLimitID *string `gorm:"type:varchar(255);index" json:"rate_limit_id,omitempty"`
+	SourceID    *string `gorm:"type:varchar(255);uniqueIndex" json:"source_id,omitempty"`
 
 	// Relationships
 	Customer    *TableCustomer    `gorm:"foreignKey:CustomerID" json:"customer,omitempty"`

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -766,6 +766,10 @@ func (m *MockConfigStore) GetTeamByName(ctx context.Context, name string, custom
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetTeamBySourceID(ctx context.Context, sourceID string) (*tables.TableTeam, error) {
+	return nil, nil
+}
+
 func (m *MockConfigStore) GetTeams(ctx context.Context, customerID string) ([]tables.TableTeam, error) {
 	return nil, nil
 }
@@ -1637,7 +1641,7 @@ func makeVirtualKey(id, name, value string) tables.TableVirtualKey {
 		Name:        name,
 		Description: "Test virtual key",
 		Value:       value,
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 	}
 }
 
@@ -1648,7 +1652,7 @@ func makeVirtualKeyWithTeam(id, name, value, teamID string) tables.TableVirtualK
 		Name:        name,
 		Description: "Test virtual key with team",
 		Value:       value,
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 }
@@ -1660,7 +1664,7 @@ func makeVirtualKeyWithCustomer(id, name, value, customerID string) tables.Table
 		Name:        name,
 		Description: "Test virtual key with customer",
 		Value:       value,
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		CustomerID:  &customerID,
 	}
 }
@@ -1672,7 +1676,7 @@ func makeVirtualKeyWithProviderConfigs(id, name, value string, providerConfigs [
 		Name:            name,
 		Description:     "Test virtual key with provider configs",
 		Value:           value,
-		IsActive: schemas.Ptr(true),
+		IsActive:        schemas.Ptr(true),
 		ProviderConfigs: providerConfigs,
 	}
 }
@@ -6612,7 +6616,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6632,7 +6636,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6651,7 +6655,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "different-name", // Different name
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6670,7 +6674,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_different", // Different value
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6689,7 +6693,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(false), // Different IsActive
+		IsActive:    schemas.Ptr(false), // Different IsActive
 		TeamID:      &teamID,
 	}
 
@@ -6709,7 +6713,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &differentTeamID, // Different TeamID
 	}
 
@@ -6728,7 +6732,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Different description", // Different description
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -6748,7 +6752,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		CustomerID:  &customerID, // CustomerID set
 	}
@@ -6769,7 +6773,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		CustomerID:  &differentCustomerID, // Different CustomerID
 	}
@@ -6790,7 +6794,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &rateLimitID, // RateLimitID set
 	}
@@ -6811,7 +6815,7 @@ func TestGenerateVirtualKeyHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &differentRateLimitID, // Different RateLimitID
 	}
@@ -6838,7 +6842,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -6870,7 +6874,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -6898,7 +6902,7 @@ func TestGenerateVirtualKeyHash_WithProviderConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -6933,7 +6937,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -6959,7 +6963,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -6985,7 +6989,7 @@ func TestGenerateVirtualKeyHash_WithMCPConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -7016,7 +7020,7 @@ func TestVirtualKeyHashComparison_MatchingHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7033,7 +7037,7 @@ func TestVirtualKeyHashComparison_MatchingHash(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &dbTeamID,
 		ConfigHash:  fileHash, // Same hash as file
 	}
@@ -7066,7 +7070,7 @@ func TestVirtualKeyHashComparison_DifferentHash(t *testing.T) {
 		Name:        "old-name", // Old name
 		Description: "Old description",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7083,7 +7087,7 @@ func TestVirtualKeyHashComparison_DifferentHash(t *testing.T) {
 		Name:        "new-name", // Updated name
 		Description: "New description",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &fileTeamID,
 	}
 
@@ -7114,7 +7118,7 @@ func TestVirtualKeyHashComparison_VirtualKeyOnlyInDB(t *testing.T) {
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
 		Value:       "vk_dashboard123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		CustomerID:  &customerID,
 		RateLimitID: &rateLimitID,
 	}
@@ -7132,7 +7136,7 @@ func TestVirtualKeyHashComparison_VirtualKeyOnlyInDB(t *testing.T) {
 			Name:        "file-vk",
 			Description: "From config.json",
 			Value:       "vk_file123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 		},
 	}
 
@@ -7162,7 +7166,7 @@ func TestVirtualKeyHashComparison_NewVirtualKey(t *testing.T) {
 		Name:        "new-vk",
 		Description: "New virtual key from config.json",
 		Value:       "vk_new123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7204,7 +7208,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Name:        "test-vk",
 		Description: "",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 	}
 
 	hashNoOptional, err := configstore.GenerateVirtualKeyHash(vkNoOptional)
@@ -7219,7 +7223,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Name:        "test-vk",
 		Description: "",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7239,7 +7243,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Name:        "test-vk",
 		Description: "",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		CustomerID:  &customerID,
 	}
 
@@ -7263,7 +7267,7 @@ func TestVirtualKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Name:        "test-vk",
 		Description: "",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		RateLimitID: &rateLimitID,
 	}
 
@@ -7289,7 +7293,7 @@ func TestVirtualKeyHashComparison_FieldValueChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Base description",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 	}
 
@@ -7352,7 +7356,7 @@ func TestVirtualKeyHashComparison_RoundTrip(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &teamID,
 		RateLimitID: &rateLimitID,
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
@@ -7382,7 +7386,7 @@ func TestVirtualKeyHashComparison_RoundTrip(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		TeamID:      &reloadTeamID,
 		RateLimitID: &reloadRateLimitID,
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
@@ -8069,7 +8073,7 @@ func TestSQLite_VirtualKey_HashMismatch_FileSync(t *testing.T) {
 			Name:        "modified-name",
 			Description: "Modified description",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 		},
 	}
 	configData2 := makeConfigDataWithVirtualKeysAndDir(providers, vks2, tempDir)
@@ -8122,7 +8126,7 @@ func TestSQLite_VirtualKey_DBOnlyVK_Preserved(t *testing.T) {
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
 		Value:       "vk_dashboard456",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 	}
 	dashboardHash, _ := configstore.GenerateVirtualKeyHash(dashboardVK)
 	dashboardVK.ConfigHash = dashboardHash
@@ -8171,7 +8175,7 @@ func TestSQLite_VirtualKey_WithProviderConfigs(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK with provider configs",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8209,7 +8213,7 @@ func TestSQLite_VirtualKey_WithProviderConfigs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "VK with provider configs",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8264,7 +8268,7 @@ func TestSQLite_VirtualKey_MergePath_WithProviderConfigs(t *testing.T) {
 			Name:        "vk-with-providers",
 			Description: "VK with provider configs added via merge",
 			Value:       "vk_providers456",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8377,7 +8381,7 @@ func TestSQLite_VirtualKey_MergePath_WithProviderConfigKeys(t *testing.T) {
 			Name:        "vk-with-provider-keys",
 			Description: "VK with provider configs referencing keys",
 			Value:       "vk_keys456",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8435,7 +8439,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8452,7 +8456,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8484,7 +8488,7 @@ func TestSQLite_VirtualKey_ProviderConfigKeyIDs(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8525,7 +8529,7 @@ func TestSQLite_VKProviderConfig_NewConfig(t *testing.T) {
 			Name:        "vk-with-provider-config",
 			Description: "VK with provider configs",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8596,7 +8600,7 @@ func TestSQLite_VKProviderConfig_KeyReference(t *testing.T) {
 			Name:        "vk-with-provider-ref",
 			Description: "VK with provider config",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -8648,7 +8652,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8666,7 +8670,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8698,7 +8702,7 @@ func TestSQLite_VKProviderConfig_HashChangesOnKeyIDChange(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider: "openai",
@@ -8731,7 +8735,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8747,7 +8751,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8763,7 +8767,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8806,7 +8810,7 @@ func TestSQLite_VKProviderConfig_WeightAndAllowedModels(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				Provider:      "openai",
@@ -8894,7 +8898,7 @@ func TestSQLite_FullLifecycle_InitialLoad(t *testing.T) {
 				Name:        "test-vk-1",
 				Description: "Test virtual key 1",
 				Value:       "vk_test123",
-				IsActive: schemas.Ptr(true),
+				IsActive:    schemas.Ptr(true),
 				RateLimitID: &rateLimitID,
 				ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 					{
@@ -8909,7 +8913,7 @@ func TestSQLite_FullLifecycle_InitialLoad(t *testing.T) {
 				Name:        "test-vk-2",
 				Description: "Test virtual key 2",
 				Value:       "vk_test456",
-				IsActive: schemas.Ptr(true),
+				IsActive:    schemas.Ptr(true),
 			},
 		},
 	}
@@ -9149,7 +9153,7 @@ func TestSQLite_FullLifecycle_DashboardEdits_ThenFileUnchanged(t *testing.T) {
 		Name:        "dashboard-vk",
 		Description: "Added via dashboard",
 		Value:       "vk_dashboard456",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 	}
 	dashboardHash, _ := configstore.GenerateVirtualKeyHash(dashboardVK)
 	dashboardVK.ConfigHash = dashboardHash
@@ -9212,7 +9216,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 	}
 
 	// VK with one MCP config
@@ -9221,7 +9225,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    1,
@@ -9236,7 +9240,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    2, // Different client
@@ -9251,7 +9255,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    1,
@@ -9266,7 +9270,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    1,
@@ -9330,7 +9334,7 @@ func TestGenerateVirtualKeyHash_MCPConfigChanges(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				MCPClientID:    1,
@@ -9371,7 +9375,7 @@ func TestSQLite_VirtualKey_WithMCPConfigs(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK with MCP config",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 		},
 	}
 
@@ -9460,7 +9464,7 @@ func TestSQLite_VKMCPConfig_Reconciliation(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for MCP reconciliation test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 		},
 	}
 
@@ -9531,7 +9535,7 @@ func TestSQLite_VKMCPConfig_Reconciliation(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for MCP reconciliation test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{
 					MCPClientID:    mcpClient2.ID, // Different MCP client - will be created
@@ -9627,7 +9631,7 @@ func TestSQLite_VirtualKey_DashboardProviderConfig_DeletedOnFileChange(t *testin
 			Name:        "test-vk",
 			Description: "VK for dashboard provider config preservation test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -9691,7 +9695,7 @@ func TestSQLite_VirtualKey_DashboardProviderConfig_DeletedOnFileChange(t *testin
 			Name:        "test-vk",
 			Description: "VK for dashboard provider config preservation test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -9782,7 +9786,7 @@ func TestSQLite_VirtualKey_DashboardMCPConfig_DeletedOnFileChange(t *testing.T) 
 			Name:        "test-vk",
 			Description: "VK for dashboard MCP config preservation test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 		},
 	}
 
@@ -9867,7 +9871,7 @@ func TestSQLite_VirtualKey_DashboardMCPConfig_DeletedOnFileChange(t *testing.T) 
 			Name:        "test-vk",
 			Description: "VK for dashboard MCP config preservation test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{
 					MCPClientID:    mcpClient1.ID,
@@ -9952,7 +9956,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 		},
 	}
 
@@ -9988,7 +9992,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient1.ID, ToolsToExecute: []string{"tool1"}},
 				{MCPClientID: mcpClient2.ID, ToolsToExecute: []string{"tool2"}},
@@ -10020,7 +10024,7 @@ func TestSQLite_VKMCPConfig_AddRemove(t *testing.T) {
 			Name:        "test-vk",
 			Description: "VK for add/remove test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient1.ID, ToolsToExecute: []string{"tool1"}},
 				// mcpClient2 removed from file
@@ -10097,7 +10101,7 @@ func TestSQLite_VKMCPConfig_UpdateTools(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test",
 		Value:       "vk_test123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{MCPClientID: mcpClient.ID, ToolsToExecute: []string{"tool1", "tool2"}},
 		},
@@ -10122,7 +10126,7 @@ func TestSQLite_VKMCPConfig_UpdateTools(t *testing.T) {
 			Name:        "test-vk",
 			Description: "Test",
 			Value:       "vk_test123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 				{MCPClientID: mcpClient.ID, ToolsToExecute: []string{"tool3", "tool4", "tool5"}}, // Different tools
 			},
@@ -10194,7 +10198,7 @@ func TestSQLite_VK_ProviderAndMCPConfigs_Combined(t *testing.T) {
 			Name:        "combined-vk",
 			Description: "VK with both provider and MCP configs",
 			Value:       "vk_combined123",
-			IsActive: schemas.Ptr(true),
+			IsActive:    schemas.Ptr(true),
 			ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 				{
 					Provider:      "openai",
@@ -10615,7 +10619,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10647,7 +10651,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            3,
@@ -10679,7 +10683,7 @@ func TestGenerateVirtualKeyHash_StableProviderConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            2,
@@ -10739,7 +10743,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10757,7 +10761,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10775,7 +10779,7 @@ func TestGenerateVirtualKeyHash_StableAllowedModelsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10821,7 +10825,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10844,7 +10848,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10867,7 +10871,7 @@ func TestGenerateVirtualKeyHash_StableKeyIDsOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -10918,7 +10922,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -10947,7 +10951,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             3,
@@ -10976,7 +10980,7 @@ func TestGenerateVirtualKeyHash_StableMCPConfigOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             2,
@@ -11033,7 +11037,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -11050,7 +11054,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -11067,7 +11071,7 @@ func TestGenerateVirtualKeyHash_StableToolsToExecuteOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		MCPConfigs: []tables.TableVirtualKeyMCPConfig{
 			{
 				ID:             1,
@@ -11112,7 +11116,7 @@ func TestGenerateVirtualKeyHash_StableCombinedOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            1,
@@ -11154,7 +11158,7 @@ func TestGenerateVirtualKeyHash_StableCombinedOrdering(t *testing.T) {
 		Name:        "test-vk",
 		Description: "Test virtual key",
 		Value:       "vk_abc123",
-		IsActive: schemas.Ptr(true),
+		IsActive:    schemas.Ptr(true),
 		ProviderConfigs: []tables.TableVirtualKeyProviderConfig{
 			{
 				ID:            2,


### PR DESCRIPTION
## Summary

Adds a `source_id` field to the `governance_teams` table to support external system references. This allows teams to be looked up by an opaque identifier assigned by an upstream source, enabling integrations that need to correlate internal teams with external entities.

## Changes

- Added an optional `SourceID` (`*string`) field to `TableTeam` with a `uniqueIndex` GORM tag, ensuring non-null values are unique while allowing multiple `NULL` entries
- Added a database migration (`migrationAddTeamSourceIDColumn`) that adds the `source_id` column and its unique index to `governance_teams`, with a full rollback path that drops both the index and column
- Added `GetTeamBySourceID` to the `ConfigStore` interface and its `RDBConfigStore` implementation, querying by `source_id` with full preloads (`Customer`, `Budgets`, `RateLimit`)
- Added a stub implementation of `GetTeamBySourceID` to the `MockConfigStore` used in HTTP transport tests

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
go test ./transports/bifrost-http/...
```

Verify that:
1. The migration runs cleanly on a fresh database and adds the `source_id` column with a unique index to `governance_teams`
2. Inserting two teams with the same non-null `source_id` is rejected
3. Inserting two teams with `NULL` `source_id` is allowed
4. `GetTeamBySourceID` returns the correct team when a matching record exists and returns `ErrNotFound` when it does not

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`source_id` values are treated as opaque strings. No PII is introduced. The unique index prevents duplicate external references from being silently accepted.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable