### PR TITLE
fix: reasoning display short hand and set display summarized in responses bedrock

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2446,10 +2446,13 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 			}
 			if anthropicReq.Thinking != nil && anthropicReq.Thinking.Type != "disabled" {
 				if bifrostReq.Params.Reasoning != nil &&
-					bifrostReq.Params.Reasoning.Summary != nil && *bifrostReq.Params.Reasoning.Summary == "none" {
-					anthropicReq.Thinking.Display = schemas.Ptr("omitted")
-				} else {
-					// Default to "summarized" to preserve visible thinking output
+					bifrostReq.Params.Reasoning.Summary != nil {
+					if *bifrostReq.Params.Reasoning.Summary == "none" {
+						anthropicReq.Thinking.Display = schemas.Ptr("omitted")
+					} else {
+						anthropicReq.Thinking.Display = schemas.Ptr("summarized")
+					}
+				} else if IsOpus47(bifrostReq.Model) {
 					anthropicReq.Thinking.Display = schemas.Ptr("summarized")
 				}
 			}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1780,9 +1780,20 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 						if anthropic.SupportsAdaptiveThinking(bifrostReq.Model) {
 							// Opus 4.6+: adaptive thinking + output_config.effort
 							effort := anthropic.MapBifrostEffortToAnthropic(*bifrostReq.Params.Reasoning.Effort)
-							bedrockReq.AdditionalModelRequestFields.Set("thinking", map[string]any{
+							thinkingConfig := map[string]any{
 								"type": "adaptive",
-							})
+							}
+							// default to "summarized" for Opus 4.7+ where omitting is the provider default.
+							if bifrostReq.Params.Reasoning.Summary != nil {
+								if *bifrostReq.Params.Reasoning.Summary == "none" {
+									thinkingConfig["display"] = "omitted"
+								} else {
+									thinkingConfig["display"] = "summarized"
+								}
+							} else if anthropic.IsOpus47(bifrostReq.Model) {
+								thinkingConfig["display"] = "summarized"
+							}
+							bedrockReq.AdditionalModelRequestFields.Set("thinking", thinkingConfig)
 							setOutputConfigField(bedrockReq.AdditionalModelRequestFields, "effort", effort)
 						} else {
 							// Opus 4.5 and older Anthropic models: budget_tokens thinking

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -241,11 +241,12 @@ func (cp *ChatParameters) UnmarshalJSON(data []byte) error {
 	// Alias to avoid recursion
 	type Alias ChatParameters
 
-	// Aux struct adds reasoning_effort for decoding
+	// Aux struct adds flat reasoning_* shorthands for decoding
 	var aux struct {
 		*Alias
 		ReasoningEffort    *string `json:"reasoning_effort"` // only for input
 		ReasoningMaxTokens *int    `json:"reasoning_max_tokens"`
+		ReasoningDisplay   *string `json:"reasoning_display"`
 	}
 
 	aux.Alias = (*Alias)(cp)
@@ -264,8 +265,11 @@ func (cp *ChatParameters) UnmarshalJSON(data []byte) error {
 	if aux.ReasoningMaxTokens != nil && aux.Reasoning != nil && aux.Reasoning.MaxTokens != nil {
 		return fmt.Errorf("both reasoning_max_tokens and reasoning.max_tokens cannot be present at the same time")
 	}
+	if aux.ReasoningDisplay != nil && aux.Reasoning != nil && aux.Reasoning.Display != nil {
+		return fmt.Errorf("both reasoning_display and reasoning.display cannot be present at the same time")
+	}
 
-	if aux.ReasoningEffort != nil || aux.ReasoningMaxTokens != nil {
+	if aux.ReasoningEffort != nil || aux.ReasoningMaxTokens != nil || aux.ReasoningDisplay != nil {
 		if cp.Reasoning == nil {
 			cp.Reasoning = &ChatReasoning{}
 		}
@@ -275,6 +279,9 @@ func (cp *ChatParameters) UnmarshalJSON(data []byte) error {
 		}
 		if aux.ReasoningMaxTokens != nil {
 			cp.Reasoning.MaxTokens = aux.ReasoningMaxTokens
+		}
+		if aux.ReasoningDisplay != nil {
+			cp.Reasoning.Display = aux.ReasoningDisplay
 		}
 	}
 	// ExtraParams etc. are already handled by the alias
@@ -1673,13 +1680,13 @@ type ChatCompletionTokensDetails struct {
 }
 
 type BifrostCost struct {
-	InputTokensCost             float64 `json:"input_tokens_cost,omitempty"`
-	OutputTokensCost            float64 `json:"output_tokens_cost,omitempty"`
-	ReasoningTokensCost         float64 `json:"reasoning_tokens_cost,omitempty"`
-	CitationTokensCost          float64 `json:"citation_tokens_cost,omitempty"`
-	SearchQueriesCost           float64 `json:"search_queries_cost,omitempty"`
-	RequestCost                 float64 `json:"request_cost,omitempty"`
-	TotalCost                   float64 `json:"total_cost,omitempty"`
+	InputTokensCost     float64 `json:"input_tokens_cost,omitempty"`
+	OutputTokensCost    float64 `json:"output_tokens_cost,omitempty"`
+	ReasoningTokensCost float64 `json:"reasoning_tokens_cost,omitempty"`
+	CitationTokensCost  float64 `json:"citation_tokens_cost,omitempty"`
+	SearchQueriesCost   float64 `json:"search_queries_cost,omitempty"`
+	RequestCost         float64 `json:"request_cost,omitempty"`
+	TotalCost           float64 `json:"total_cost,omitempty"`
 }
 
 // UnmarshalJSON implements custom JSON unmarshalling for BifrostCost.


### PR DESCRIPTION
## Summary

Adds support for a `reasoning_display` flat shorthand parameter (mirroring the existing `reasoning_effort` and `reasoning_max_tokens` shorthands) and wires the `display` field through to the Bedrock Anthropic provider's adaptive thinking configuration.

## Changes

- Added `reasoning_display` as a top-level flat shorthand in `ChatParameters.UnmarshalJSON`, which maps into `Reasoning.Display` — with a conflict check preventing simultaneous use of both `reasoning_display` and `reasoning.display`
- Updated the Bedrock responses builder to populate the `display` field on the adaptive thinking config: passes `"omitted"` when `Summary` is `"none"`, `"summarized"` otherwise, and defaults to `"summarized"` for Opus 4.7+ models even when no explicit value is provided

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a request with `reasoning_display: "none"` or `reasoning_display: "summarized"` at the top level and verify the Bedrock adaptive thinking config includes the correct `display` value. Also verify that providing both `reasoning_display` and `reasoning.display` simultaneously returns a conflict error.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable