### PR TITLE
feat: adds support for custom selection of plugins for otel trace span exports

### DIFF
--- a/docs/deployment-guides/config-json/plugins.mdx
+++ b/docs/deployment-guides/config-json/plugins.mdx
@@ -132,6 +132,7 @@ Exports distributed traces to any OTel-compatible collector (Jaeger, Zipkin, Tem
 | `config.headers` | No | - | Custom headers for the collector (supports `env.` prefix) |
 | `config.insecure` | No | `false` | Skip TLS verification |
 | `config.tls_ca_cert` | No | - | Path to TLS CA certificate |
+| `config.plugin_span_filter` | No | - | Filter which plugin hook spans are exported. See [Filtering Plugin Spans](/features/observability/otel#filtering-plugin-spans) |
 
 ```json
 {

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -903,6 +903,49 @@ Sensitive credentials never appear in config files:
 
 The plugin reads `OTEL_API_KEY` from the environment at runtime.
 
+### Filtering Plugin Spans
+
+By default every plugin's pre- and post-hook execution generates a span, which can bloat traces when many plugins are active (e.g. 8 built-in plugins × 2 hooks = 16 plugin spans per request). Use `plugin_span_filter` inside the OTEL plugin config to control which plugin spans are exported.
+
+**Via config.json** (inside the OTEL plugin config):
+
+```json
+{
+  "plugins": [
+    {
+      "name": "otel",
+      "enabled": true,
+      "config": {
+        "collector_url": "...",
+        "trace_type": "genai_extension",
+        "protocol": "http",
+        "plugin_span_filter": {
+          "mode": "exclude",
+          "plugins": ["logging", "compat", "telemetry", "otel"]
+        }
+      }
+    }
+  ]
+}
+```
+
+**Via the UI**: Open the Plugins page and click **Configure Plugin Tracing**. Toggle individual plugins on or off and save. UI-saved settings persist across restarts unless `plugin_span_filter` is set in config.json with a higher `version` value.
+
+**Filter modes:**
+
+| Mode | Behaviour |
+|------|-----------|
+| `exclude` | Export spans for all plugins **except** those listed |
+| `include` | Export spans **only** for the listed plugins |
+
+**Built-in plugin names** (for reference): `telemetry`, `prompts`, `logging`, `governance`, `otel`, `semantic_cache`, `compat`, `maxim`.
+
+When a plugin span is filtered out, its children are automatically re-parented to the nearest exported ancestor so the trace hierarchy stays connected.
+
+<Note>
+  `plugin_span_filter` follows the standard plugin config precedence rules. To make a config.json value override UI-saved DB settings on restart, set a higher `version` on the OTEL plugin entry (e.g. `"version": 2`). See [Plugin Versioning](/deployment-guides/config-json/plugins) for details.
+</Note>
+
 ---
 
 ## When to Use

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -3,6 +3,7 @@ package otel
 import (
 	"encoding/hex"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -69,11 +70,81 @@ func hexToBytes(hexStr string, length int) []byte {
 	return bytes
 }
 
+// shouldExportSpan reports whether a span should be included in the export.
+// Non-plugin spans are always exported. Plugin spans are checked against pluginSpanFilter.
+func (p *OtelPlugin) shouldExportSpan(span *schemas.Span) bool {
+	if span.Kind != schemas.SpanKindPlugin || p.pluginSpanFilter == nil {
+		return true
+	}
+	// Span names follow the pattern "plugin.<name>.prehook" / "plugin.<name>.posthook".
+	parts := strings.SplitN(span.Name, ".", 3)
+	if len(parts) < 2 {
+		return true
+	}
+	pluginName := parts[1]
+
+	inList := slices.Contains(p.pluginSpanFilter.Plugins, pluginName)
+
+	if p.pluginSpanFilter.Mode == PluginSpanFilterModeInclude {
+		return inList
+	}
+	return !inList // exclude mode
+}
+
+// buildReparentMap returns a map of filteredSpanID → effective ancestor spanID for all
+// spans that will be skipped. When plugin spans are chained (each span's parent is the
+// previous plugin's span), removing a span from the middle would leave its children with
+// a dangling parent ID. The map lets us rewrite those parent IDs to the nearest exported
+// ancestor, handling consecutive filtered spans in a chain.
+func (p *OtelPlugin) buildReparentMap(spans []*schemas.Span) map[string]string {
+	if p.pluginSpanFilter == nil {
+		return nil
+	}
+	// First pass: record direct parent ID for every filtered span.
+	filtered := make(map[string]string) // spanID -> parentID
+	for _, span := range spans {
+		if !p.shouldExportSpan(span) {
+			filtered[span.SpanID] = span.ParentID
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	// Second pass: resolve chains so each filtered span maps to its first exported ancestor.
+	// Cap the walk at len(filtered) to break out of any cycle caused by malformed span data.
+	maxHops := len(filtered)
+	for spanID := range filtered {
+		parentID := filtered[spanID]
+		for range maxHops {
+			grandParentID, isFiltered := filtered[parentID]
+			if !isFiltered {
+				break
+			}
+			parentID = grandParentID
+		}
+		filtered[spanID] = parentID
+	}
+	return filtered
+}
+
 // convertTraceToResourceSpan converts a Bifrost trace to OTEL ResourceSpan
 func (p *OtelPlugin) convertTraceToResourceSpan(trace *schemas.Trace) *ResourceSpan {
+	reparent := p.buildReparentMap(trace.Spans)
 	otelSpans := make([]*Span, 0, len(trace.Spans))
 	for _, span := range trace.Spans {
+		if !p.shouldExportSpan(span) {
+			continue
+		}
 		otelSpan := p.convertSpanToOTELSpan(trace.TraceID, span)
+		// If the span's direct parent was filtered, rewrite its parent ID to the
+		// nearest exported ancestor so the hierarchy stays connected.
+		if effectiveParent, ok := reparent[span.ParentID]; ok {
+			if effectiveParent == "" {
+				otelSpan.ParentSpanId = nil
+			} else {
+				otelSpan.ParentSpanId = hexToBytes(effectiveParent, 8)
+			}
+		}
 		if span == trace.RootSpan {
 			if requestID := trace.GetRequestID(); requestID != "" {
 				otelSpan.Attributes = append(otelSpan.Attributes, kvStr(schemas.AttrRequestID, requestID))

--- a/plugins/otel/converter_test.go
+++ b/plugins/otel/converter_test.go
@@ -1,0 +1,178 @@
+package otel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func makeSpan(id, parentID, name string, kind schemas.SpanKind) *schemas.Span {
+	return &schemas.Span{
+		SpanID:    id,
+		ParentID:  parentID,
+		Name:      name,
+		Kind:      kind,
+		StartTime: time.Now(),
+		EndTime:   time.Now(),
+	}
+}
+
+func TestShouldExportSpan(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter *PluginSpanFilter
+		span   *schemas.Span
+		want   bool
+	}{
+		{
+			name:   "nil filter exports everything",
+			filter: nil,
+			span:   makeSpan("1", "", "plugin.logging.prehook", schemas.SpanKindPlugin),
+			want:   true,
+		},
+		{
+			name:   "non-plugin span always exported regardless of filter",
+			filter: &PluginSpanFilter{Mode: PluginSpanFilterModeExclude, Plugins: []string{"logging"}},
+			span:   makeSpan("1", "", "llm.call", schemas.SpanKindLLMCall),
+			want:   true,
+		},
+		{
+			name:   "exclude mode: plugin in list is suppressed",
+			filter: &PluginSpanFilter{Mode: PluginSpanFilterModeExclude, Plugins: []string{"logging", "compat"}},
+			span:   makeSpan("1", "", "plugin.logging.prehook", schemas.SpanKindPlugin),
+			want:   false,
+		},
+		{
+			name:   "exclude mode: plugin not in list is exported",
+			filter: &PluginSpanFilter{Mode: PluginSpanFilterModeExclude, Plugins: []string{"logging"}},
+			span:   makeSpan("1", "", "plugin.governance.posthook", schemas.SpanKindPlugin),
+			want:   true,
+		},
+		{
+			name:   "exclude mode: posthook variant suppressed the same as prehook",
+			filter: &PluginSpanFilter{Mode: PluginSpanFilterModeExclude, Plugins: []string{"logging"}},
+			span:   makeSpan("1", "", "plugin.logging.posthook", schemas.SpanKindPlugin),
+			want:   false,
+		},
+		{
+			name:   "include mode: plugin in list is exported",
+			filter: &PluginSpanFilter{Mode: PluginSpanFilterModeInclude, Plugins: []string{"guardrails"}},
+			span:   makeSpan("1", "", "plugin.guardrails.prehook", schemas.SpanKindPlugin),
+			want:   true,
+		},
+		{
+			name:   "include mode: plugin not in list is suppressed",
+			filter: &PluginSpanFilter{Mode: PluginSpanFilterModeInclude, Plugins: []string{"guardrails"}},
+			span:   makeSpan("1", "", "plugin.logging.prehook", schemas.SpanKindPlugin),
+			want:   false,
+		},
+		{
+			name:   "exclude mode: empty list suppresses nothing",
+			filter: &PluginSpanFilter{Mode: PluginSpanFilterModeExclude, Plugins: []string{}},
+			span:   makeSpan("1", "", "plugin.logging.prehook", schemas.SpanKindPlugin),
+			want:   true,
+		},
+		{
+			name:   "include mode: empty list suppresses everything",
+			filter: &PluginSpanFilter{Mode: PluginSpanFilterModeInclude, Plugins: []string{}},
+			span:   makeSpan("1", "", "plugin.logging.prehook", schemas.SpanKindPlugin),
+			want:   false,
+		},
+		{
+			name:   "span name without dots passes through",
+			filter: &PluginSpanFilter{Mode: PluginSpanFilterModeExclude, Plugins: []string{"logging"}},
+			span:   makeSpan("1", "", "nodots", schemas.SpanKindPlugin),
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &OtelPlugin{pluginSpanFilter: tt.filter}
+			if got := p.shouldExportSpan(tt.span); got != tt.want {
+				t.Errorf("shouldExportSpan() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildReparentMap(t *testing.T) {
+	excludeLogging := &PluginSpanFilter{Mode: PluginSpanFilterModeExclude, Plugins: []string{"logging"}}
+
+	t.Run("nil filter returns nil map", func(t *testing.T) {
+		p := &OtelPlugin{pluginSpanFilter: nil}
+		spans := []*schemas.Span{makeSpan("a", "root", "plugin.logging.prehook", schemas.SpanKindPlugin)}
+		if m := p.buildReparentMap(spans); m != nil {
+			t.Errorf("expected nil, got %v", m)
+		}
+	})
+
+	t.Run("no filtered spans returns nil map", func(t *testing.T) {
+		p := &OtelPlugin{pluginSpanFilter: excludeLogging}
+		spans := []*schemas.Span{
+			makeSpan("a", "root", "plugin.governance.prehook", schemas.SpanKindPlugin),
+		}
+		if m := p.buildReparentMap(spans); m != nil {
+			t.Errorf("expected nil, got %v", m)
+		}
+	})
+
+	t.Run("single filtered span maps to its direct parent", func(t *testing.T) {
+		p := &OtelPlugin{pluginSpanFilter: excludeLogging}
+		// root -> logging (filtered) -> governance
+		spans := []*schemas.Span{
+			makeSpan("root", "", "request", schemas.SpanKindInternal),
+			makeSpan("log-pre", "root", "plugin.logging.prehook", schemas.SpanKindPlugin),
+			makeSpan("gov-pre", "log-pre", "plugin.governance.prehook", schemas.SpanKindPlugin),
+		}
+		m := p.buildReparentMap(spans)
+		if m == nil {
+			t.Fatal("expected non-nil map")
+		}
+		if got := m["log-pre"]; got != "root" {
+			t.Errorf("filtered span should map to parent 'root', got %q", got)
+		}
+	})
+
+	t.Run("chain of filtered spans resolves to nearest exported ancestor", func(t *testing.T) {
+		// root -> telemetry (filtered) -> logging (filtered) -> governance
+		p := &OtelPlugin{pluginSpanFilter: &PluginSpanFilter{
+			Mode:    PluginSpanFilterModeExclude,
+			Plugins: []string{"telemetry", "logging"},
+		}}
+		spans := []*schemas.Span{
+			makeSpan("root", "", "request", schemas.SpanKindInternal),
+			makeSpan("tel-pre", "root", "plugin.telemetry.prehook", schemas.SpanKindPlugin),
+			makeSpan("log-pre", "tel-pre", "plugin.logging.prehook", schemas.SpanKindPlugin),
+			makeSpan("gov-pre", "log-pre", "plugin.governance.prehook", schemas.SpanKindPlugin),
+		}
+		m := p.buildReparentMap(spans)
+		if m == nil {
+			t.Fatal("expected non-nil map")
+		}
+		// Both filtered spans must resolve to "root" so governance.prehook re-parents there.
+		if got := m["tel-pre"]; got != "root" {
+			t.Errorf("tel-pre should resolve to 'root', got %q", got)
+		}
+		if got := m["log-pre"]; got != "root" {
+			t.Errorf("log-pre should skip the chain and resolve to 'root', got %q", got)
+		}
+	})
+
+	t.Run("filtered span with no parent resolves to empty string", func(t *testing.T) {
+		p := &OtelPlugin{pluginSpanFilter: excludeLogging}
+		spans := []*schemas.Span{
+			// logging span has no parent (root of trace)
+			makeSpan("log-pre", "", "plugin.logging.prehook", schemas.SpanKindPlugin),
+			makeSpan("gov-pre", "log-pre", "plugin.governance.prehook", schemas.SpanKindPlugin),
+		}
+		m := p.buildReparentMap(spans)
+		if m == nil {
+			t.Fatal("expected non-nil map")
+		}
+		if got := m["log-pre"]; got != "" {
+			t.Errorf("root-level filtered span should resolve to empty string, got %q", got)
+		}
+	})
+}

--- a/plugins/otel/filter_test.go
+++ b/plugins/otel/filter_test.go
@@ -1,0 +1,98 @@
+package otel
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestPluginSpanFilterUnmarshal verifies that plugin_span_filter round-trips
+// through JSON correctly, including when embedded in a full Config.
+func TestPluginSpanFilterUnmarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		wantMode PluginSpanFilterMode
+		wantList []string
+	}{
+		{
+			name:     "exclude mode",
+			raw:      `{"mode":"exclude","plugins":["logging","compat"]}`,
+			wantMode: PluginSpanFilterModeExclude,
+			wantList: []string{"logging", "compat"},
+		},
+		{
+			name:     "include mode",
+			raw:      `{"mode":"include","plugins":["guardrails"]}`,
+			wantMode: PluginSpanFilterModeInclude,
+			wantList: []string{"guardrails"},
+		},
+		{
+			name:     "empty plugins list",
+			raw:      `{"mode":"exclude","plugins":[]}`,
+			wantMode: PluginSpanFilterModeExclude,
+			wantList: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var f PluginSpanFilter
+			if err := json.Unmarshal([]byte(tt.raw), &f); err != nil {
+				t.Fatalf("unexpected unmarshal error: %v", err)
+			}
+			if f.Mode != tt.wantMode {
+				t.Errorf("Mode = %q, want %q", f.Mode, tt.wantMode)
+			}
+			if len(f.Plugins) != len(tt.wantList) {
+				t.Errorf("Plugins length = %d, want %d", len(f.Plugins), len(tt.wantList))
+				return
+			}
+			for i, p := range tt.wantList {
+				if f.Plugins[i] != p {
+					t.Errorf("Plugins[%d] = %q, want %q", i, f.Plugins[i], p)
+				}
+			}
+		})
+	}
+}
+
+// TestConfigPluginSpanFilterField verifies that plugin_span_filter is correctly
+// parsed when present inside a full Config JSON blob.
+func TestConfigPluginSpanFilterField(t *testing.T) {
+	raw := `{
+		"collector_url": "localhost:4317",
+		"trace_type": "genai_extension",
+		"protocol": "grpc",
+		"plugin_span_filter": {
+			"mode": "exclude",
+			"plugins": ["logging", "telemetry"]
+		}
+	}`
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if cfg.PluginSpanFilter == nil {
+		t.Fatal("expected PluginSpanFilter to be set")
+	}
+	if cfg.PluginSpanFilter.Mode != PluginSpanFilterModeExclude {
+		t.Errorf("Mode = %q, want %q", cfg.PluginSpanFilter.Mode, PluginSpanFilterModeExclude)
+	}
+	if len(cfg.PluginSpanFilter.Plugins) != 2 {
+		t.Errorf("Plugins length = %d, want 2", len(cfg.PluginSpanFilter.Plugins))
+	}
+}
+
+// TestConfigPluginSpanFilterAbsent verifies that omitting plugin_span_filter
+// leaves Config.PluginSpanFilter as nil (no default applied).
+func TestConfigPluginSpanFilterAbsent(t *testing.T) {
+	raw := `{"collector_url":"localhost:4317","trace_type":"genai_extension","protocol":"grpc"}`
+	var cfg Config
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	if cfg.PluginSpanFilter != nil {
+		t.Errorf("expected PluginSpanFilter to be nil when absent, got %+v", cfg.PluginSpanFilter)
+	}
+}

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -44,6 +44,21 @@ const ProtocolHTTP Protocol = "http"
 // ProtocolGRPC is the second protocol
 const ProtocolGRPC Protocol = "grpc"
 
+// PluginSpanFilterMode controls whether the plugins list is an allowlist or denylist.
+type PluginSpanFilterMode string
+
+const (
+	PluginSpanFilterModeInclude PluginSpanFilterMode = "include"
+	PluginSpanFilterModeExclude PluginSpanFilterMode = "exclude"
+)
+
+// PluginSpanFilter configures which plugin spans are exported to the OTEL collector.
+// Mode "include" exports only the listed plugins; mode "exclude" exports everything except them.
+type PluginSpanFilter struct {
+	Mode    PluginSpanFilterMode `json:"mode"`
+	Plugins []string             `json:"plugins"`
+}
+
 type Config struct {
 	ServiceName  string            `json:"service_name"`
 	CollectorURL string            `json:"collector_url"`
@@ -57,6 +72,10 @@ type Config struct {
 	MetricsEnabled      bool   `json:"metrics_enabled"`
 	MetricsEndpoint     string `json:"metrics_endpoint"`
 	MetricsPushInterval int    `json:"metrics_push_interval"` // in seconds, default 15
+
+	// PluginSpanFilter is the DB-stored fallback when otel_plugin_span_filter is absent in config.json.
+	// The top-level config.json field takes precedence and is passed via Init's pluginSpanFilter param.
+	PluginSpanFilter *PluginSpanFilter `json:"plugin_span_filter,omitempty"`
 }
 
 // UnmarshalJSON applies field defaults that the zero-value wouldn't capture.
@@ -105,6 +124,8 @@ type OtelPlugin struct {
 
 	// Metrics push support
 	metricsExporter *MetricsExporter
+
+	pluginSpanFilter *PluginSpanFilter
 }
 
 // Init function for the OTEL plugin
@@ -127,6 +148,14 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 					return nil, fmt.Errorf("environment variable %s not found", newValue)
 				}
 			}
+		}
+	}
+	if config.PluginSpanFilter != nil {
+		switch config.PluginSpanFilter.Mode {
+		case PluginSpanFilterModeInclude, PluginSpanFilterModeExclude:
+		default:
+			return nil, fmt.Errorf("plugin_span_filter.mode %q is invalid: must be %q or %q",
+				config.PluginSpanFilter.Mode, PluginSpanFilterModeInclude, PluginSpanFilterModeExclude)
 		}
 	}
 	if config.ServiceName == "" {
@@ -169,6 +198,7 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 		bifrostVersion:            bifrostVersion,
 		attributesFromEnvironment: attributesFromEnvironment,
 		instanceAttrs:             instanceAttrs,
+		pluginSpanFilter: config.PluginSpanFilter,
 	}
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	if config.Protocol == ProtocolGRPC {
@@ -273,6 +303,14 @@ func (p *OtelPlugin) ValidateConfig(config any) (*Config, error) {
 	}
 	if otelConfig.Protocol == "" {
 		return nil, fmt.Errorf("protocol is required")
+	}
+	if otelConfig.PluginSpanFilter != nil {
+		switch otelConfig.PluginSpanFilter.Mode {
+		case PluginSpanFilterModeInclude, PluginSpanFilterModeExclude:
+		default:
+			return nil, fmt.Errorf("plugin_span_filter.mode %q is invalid: must be %q or %q",
+				otelConfig.PluginSpanFilter.Mode, PluginSpanFilterModeInclude, PluginSpanFilterModeExclude)
+		}
 	}
 	return &otelConfig, nil
 }

--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 
 	"github.com/fasthttp/router"
 	"github.com/maximhq/bifrost/core/schemas"
@@ -57,6 +58,7 @@ type UpdatePluginRequest struct {
 // RegisterRoutes registers the routes for the PluginsHandler
 func (h *PluginsHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
 	r.GET("/api/plugins", lib.ChainMiddlewares(h.getPlugins, middlewares...))
+	r.GET("/api/plugins/builtins", lib.ChainMiddlewares(h.getBuiltinPlugins, middlewares...))
 	r.GET("/api/plugins/{name}", lib.ChainMiddlewares(h.getPlugin, middlewares...))
 	r.POST("/api/plugins", lib.ChainMiddlewares(h.createPlugin, middlewares...))
 	r.PUT("/api/plugins/{name}", lib.ChainMiddlewares(h.updatePlugin, middlewares...))
@@ -103,6 +105,13 @@ func (h *PluginsHandler) buildPluginResponse(ctx context.Context, plugin *config
 		Order:      plugin.Order,
 		Status:     pluginStatus,
 	}
+}
+
+// getBuiltinPlugins returns the canonical list of built-in plugin names
+func (h *PluginsHandler) getBuiltinPlugins(ctx *fasthttp.RequestCtx) {
+	SendJSON(ctx, map[string]any{
+		"plugins": lib.GetBuiltinPluginNames(),
+	})
 }
 
 // getPlugins gets all plugins
@@ -344,8 +353,9 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 	}
 	var plugin *configstoreTables.TablePlugin
 	var err error
-	// Check if plugin exists
-	_, err = h.configStore.GetPlugin(ctx, name)
+	// Fetch the existing plugin to enable config merging below.
+	var existingPlugin *configstoreTables.TablePlugin
+	existingPlugin, err = h.configStore.GetPlugin(ctx, name)
 	if err != nil {
 		// If doesn't exist, create it
 		if errors.Is(err, configstore.ErrNotFound) {
@@ -395,11 +405,21 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 	if isBuiltin && request.Path != nil {
 		request.Path = nil
 	}
+	// Merge incoming config over the existing DB config so fields unknown to the
+	// calling form (e.g. plugin_span_filter set by a separate UI sheet) are not wiped.
+	mergedConfig := request.Config
+	if existingPlugin != nil {
+		if existingCfg, ok := existingPlugin.Config.(map[string]any); ok && len(existingCfg) > 0 {
+			mergedConfig = make(map[string]any, len(existingCfg)+len(request.Config))
+			maps.Copy(mergedConfig, existingCfg)
+			maps.Copy(mergedConfig, request.Config)
+		}
+	}
 	// Updating the plugin
 	if err := h.configStore.UpdatePlugin(ctx, &configstoreTables.TablePlugin{
 		Name:      name,
 		Enabled:   request.Enabled,
-		Config:    request.Config,
+		Config:    mergedConfig,
 		Path:      request.Path,
 		IsCustom:  !isBuiltin,
 		Placement: request.Placement,
@@ -421,7 +441,7 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 	}
 	// We reload the plugin if its enabled, otherwise we stop it
 	if request.Enabled {
-		if err := h.pluginsLoader.ReloadPlugin(ctx, name, request.Path, request.Config, request.Placement, request.Order); err != nil {
+		if err := h.pluginsLoader.ReloadPlugin(ctx, name, request.Path, mergedConfig, request.Placement, request.Order); err != nil {
 			logger.Error("failed to load plugin: %v", err)
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Plugin updated in database but failed to load: %v", err))
 			return

--- a/transports/bifrost-http/handlers/plugins_test.go
+++ b/transports/bifrost-http/handlers/plugins_test.go
@@ -1,0 +1,159 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/valyala/fasthttp"
+	"gorm.io/gorm"
+)
+
+// capturePluginsStore records the last config passed to UpdatePlugin so tests
+// can assert that config merging occurred correctly.
+type capturePluginsStore struct {
+	configstore.ConfigStore
+	existingPlugin  *configstoreTables.TablePlugin
+	capturedConfig  map[string]any
+	capturedEnabled bool
+}
+
+func (s *capturePluginsStore) GetPlugin(_ context.Context, name string) (*configstoreTables.TablePlugin, error) {
+	if s.existingPlugin != nil && s.existingPlugin.Name == name {
+		return s.existingPlugin, nil
+	}
+	return nil, configstore.ErrNotFound
+}
+
+func (s *capturePluginsStore) UpdatePlugin(_ context.Context, plugin *configstoreTables.TablePlugin, _ ...*gorm.DB) error {
+	if cfg, ok := plugin.Config.(map[string]any); ok {
+		s.capturedConfig = cfg
+	}
+	s.capturedEnabled = plugin.Enabled
+	return nil
+}
+
+func (s *capturePluginsStore) CreatePlugin(_ context.Context, plugin *configstoreTables.TablePlugin, _ ...*gorm.DB) error {
+	s.existingPlugin = plugin
+	return nil
+}
+
+// noopPluginsLoader satisfies the PluginsLoader interface without doing anything.
+type noopPluginsLoader struct{}
+
+func (noopPluginsLoader) ReloadPlugin(_ context.Context, _ string, _ *string, _ any, _ *schemas.PluginPlacement, _ *int) error {
+	return nil
+}
+func (noopPluginsLoader) RemovePlugin(_ context.Context, _ string) error { return nil }
+func (noopPluginsLoader) GetPluginStatus(_ context.Context) map[string]schemas.PluginStatus {
+	return nil
+}
+
+// buildUpdateRequest creates a PUT /api/plugins/{name} fasthttp context.
+func buildUpdateRequest(t *testing.T, body any) *fasthttp.RequestCtx {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request body: %v", err)
+	}
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.Header.SetMethod("PUT")
+	ctx.Request.SetBody(raw)
+	ctx.SetUserValue("name", "otel")
+	return ctx
+}
+
+// TestUpdatePlugin_ConfigMerge verifies that updatePlugin merges the incoming
+// config over the existing DB config, preserving fields the caller did not send.
+// This is critical for the plugin_span_filter field: the OTEL config form in the
+// UI does not send plugin_span_filter, so it must survive a save without being wiped.
+func TestUpdatePlugin_ConfigMerge(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	spanFilter := map[string]any{
+		"mode":    "exclude",
+		"plugins": []any{"logging", "compat"},
+	}
+	existingConfig := map[string]any{
+		"collector_url":    "localhost:4317",
+		"trace_type":       "genai_extension",
+		"protocol":         "grpc",
+		"plugin_span_filter": spanFilter,
+	}
+
+	store := &capturePluginsStore{
+		existingPlugin: &configstoreTables.TablePlugin{
+			Name:    "otel",
+			Enabled: true,
+			Config:  existingConfig,
+		},
+	}
+
+	h := &PluginsHandler{
+		pluginsLoader: noopPluginsLoader{},
+		configStore:   store,
+	}
+
+	// The UI OTEL form sends only the base fields — no plugin_span_filter.
+	reqBody := map[string]any{
+		"enabled": true,
+		"config": map[string]any{
+			"collector_url": "new-collector:4317",
+			"trace_type":    "open_inference",
+			"protocol":      "grpc",
+		},
+	}
+
+	ctx := buildUpdateRequest(t, reqBody)
+	h.updatePlugin(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+
+	// The merged config must contain both the updated base fields AND the preserved filter.
+	if store.capturedConfig == nil {
+		t.Fatal("UpdatePlugin was not called")
+	}
+	if got := store.capturedConfig["collector_url"]; got != "new-collector:4317" {
+		t.Errorf("collector_url = %v, want new-collector:4317", got)
+	}
+	if got := store.capturedConfig["trace_type"]; got != "open_inference" {
+		t.Errorf("trace_type = %v, want open_inference", got)
+	}
+	if _, ok := store.capturedConfig["plugin_span_filter"]; !ok {
+		t.Error("plugin_span_filter was wiped from the config; merge logic is broken")
+	}
+}
+
+// TestUpdatePlugin_ConfigMerge_NewPlugin verifies that when no existing plugin
+// is found in the DB (first save), the incoming config is used as-is.
+func TestUpdatePlugin_ConfigMerge_NewPlugin(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	store := &capturePluginsStore{existingPlugin: nil}
+	h := &PluginsHandler{
+		pluginsLoader: noopPluginsLoader{},
+		configStore:   store,
+	}
+
+	reqBody := map[string]any{
+		"enabled": true,
+		"config": map[string]any{
+			"collector_url": "localhost:4317",
+			"trace_type":    "genai_extension",
+			"protocol":      "grpc",
+		},
+	}
+
+	ctx := buildUpdateRequest(t, reqBody)
+	h.updatePlugin(ctx)
+
+	// Should succeed even when no existing plugin is found (creates then updates).
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d: %s", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -111,16 +111,26 @@ func getWeight(w *float64) float64 {
 	return *w
 }
 
+// BuiltinPluginNames is the canonical list of built-in plugin names.
+// It is the single source of truth — update here when adding or removing a built-in plugin.
+var builtinPluginNames = []string{
+	telemetry.PluginName,
+	prompts.PluginName,
+	logging.PluginName,
+	governance.PluginName,
+	otel.PluginName,
+	semanticcache.PluginName,
+	compat.PluginName,
+	maxim.PluginName,
+}
+
+func GetBuiltinPluginNames() []string {
+	return slices.Clone(builtinPluginNames)
+}
+
 // IsBuiltinPlugin checks if a plugin is a built-in plugin
 func IsBuiltinPlugin(name string) bool {
-	return name == telemetry.PluginName ||
-		name == prompts.PluginName ||
-		name == logging.PluginName ||
-		name == governance.PluginName ||
-		name == compat.PluginName ||
-		name == maxim.PluginName ||
-		name == semanticcache.PluginName ||
-		name == otel.PluginName
+	return slices.Contains(builtinPluginNames, name)
 }
 
 // pluginOrderInfo stores ordering metadata for a plugin.

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -374,6 +374,7 @@ import (
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/framework/vectorstore"
+	otelPlugin "github.com/maximhq/bifrost/plugins/otel"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -18186,4 +18187,56 @@ func TestVersionField_Version2_NoCompat(t *testing.T) {
 	require.Len(t, anthropicCfg.Keys, 1)
 	require.Empty(t, anthropicCfg.Keys[0].Models,
 		"v2 semantics: empty models must NOT be normalised")
+}
+
+// =============================================================================
+// OtelPluginSpanFilter seeding tests
+// =============================================================================
+
+// TestLoadPlugins_OtelPluginSpanFilterPassthrough verifies that plugin_span_filter
+// set directly inside the OTEL plugin config (the standard config.json location)
+// is preserved unchanged through loadPlugins — no special handling needed.
+func TestLoadPlugins_OtelPluginSpanFilterPassthrough(t *testing.T) {
+	initTestLogger()
+	ctx := context.Background()
+
+	otelCfg := map[string]any{
+		"collector_url": "localhost:4317",
+		"trace_type":    "genai_extension",
+		"protocol":      "grpc",
+		"plugin_span_filter": map[string]any{
+			"mode":    "exclude",
+			"plugins": []any{"logging", "compat"},
+		},
+	}
+	configData := &ConfigData{
+		Plugins: []*schemas.PluginConfig{
+			{Name: otelPlugin.PluginName, Enabled: true, Config: otelCfg},
+		},
+	}
+
+	cfg := &Config{}
+	loadPlugins(ctx, cfg, configData)
+
+	var found *schemas.PluginConfig
+	for _, pc := range cfg.PluginConfigs {
+		if pc.Name == otelPlugin.PluginName {
+			found = pc
+			break
+		}
+	}
+	require.NotNil(t, found, "OTEL plugin should be present in PluginConfigs after loadPlugins")
+
+	pluginCfg, ok := found.Config.(map[string]any)
+	require.True(t, ok, "OTEL plugin Config should be map[string]any")
+
+	raw, ok := pluginCfg["plugin_span_filter"]
+	require.True(t, ok, "plugin_span_filter should be preserved in OTEL plugin config")
+
+	filterMap, ok := raw.(map[string]any)
+	require.True(t, ok, "plugin_span_filter should be a map")
+	require.Equal(t, "exclude", filterMap["mode"])
+	plugins, ok := filterMap["plugins"].([]any)
+	require.True(t, ok, "plugin_span_filter.plugins should be an array")
+	require.ElementsMatch(t, []any{"logging", "compat"}, plugins)
 }

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1608,6 +1608,22 @@
                     "insecure": {
                       "type": "boolean",
                       "description": "Skip TLS verification (ignored if tls_ca_cert is set)"
+                    },
+                    "plugin_span_filter": {
+                      "type": "object",
+                      "description": "Controls which plugin hook spans are exported to the OTEL collector. Omit to export all plugin spans.",
+                      "properties": {
+                        "mode": {
+                          "type": "string",
+                          "enum": ["include", "exclude"]
+                        },
+                        "plugins": {
+                          "type": "array",
+                          "items": { "type": "string" }
+                        }
+                      },
+                      "required": ["mode", "plugins"],
+                      "additionalProperties": false
                     }
                   },
                   "required": ["collector_url", "trace_type", "protocol"],

--- a/ui/app/workspace/plugins/page.tsx
+++ b/ui/app/workspace/plugins/page.tsx
@@ -2,11 +2,12 @@ import { Button } from "@/components/ui/button";
 import { setSelectedPlugin, useAppDispatch, useAppSelector, useGetPluginsQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { ListOrdered, PlusIcon, Puzzle } from "lucide-react";
+import { Activity, ListOrdered, PlusIcon, Puzzle } from "lucide-react";
 import { useQueryState } from "nuqs";
 import { useEffect, useMemo, useState } from "react";
 import AddNewPluginSheet from "./sheets/addNewPluginSheet";
 import PluginSequenceSheet from "./sheets/pluginSequenceSheet";
+import PluginTracingSheet from "./sheets/pluginTracingSheet";
 import { PluginsEmptyState } from "./views/pluginsEmptyState";
 import PluginsView from "./views/pluginsView";
 
@@ -20,6 +21,7 @@ export default function PluginsPage() {
 	const customPlugins = useMemo(() => plugins?.filter((plugin) => plugin.isCustom), [plugins]);
 	const [isSheetOpen, setIsSheetOpen] = useState(false);
 	const [isSequenceSheetOpen, setIsSequenceSheetOpen] = useState(false);
+	const [isTracingSheetOpen, setIsTracingSheetOpen] = useState(false);
 
 	const handleAddNew = () => {
 		setIsSheetOpen(true);
@@ -49,7 +51,12 @@ export default function PluginsPage() {
 	if (customPlugins?.length === 0 && !isLoading) {
 		return (
 			<div className="mx-auto w-full max-w-7xl">
-				<PluginsEmptyState onCreateClick={handleAddNew} canCreate={hasCreatePluginAccess} />
+				<PluginsEmptyState
+					onCreateClick={handleAddNew}
+					canCreate={hasCreatePluginAccess}
+					onConfigureTracingClick={() => setIsTracingSheetOpen(true)}
+					canConfigureTracing={hasUpdatePluginAccess}
+				/>
 				<AddNewPluginSheet
 					open={isSheetOpen}
 					onClose={handleCloseSheet}
@@ -57,6 +64,7 @@ export default function PluginsPage() {
 						setSelectedPluginId(pluginName);
 					}}
 				/>
+				<PluginTracingSheet open={isTracingSheetOpen} onClose={() => setIsTracingSheetOpen(false)} />
 			</div>
 		);
 	}
@@ -125,6 +133,17 @@ export default function PluginsPage() {
 										<div className="text-xs">Edit Plugin Sequence</div>
 									</Button>
 								)}
+								<Button
+									variant="outline"
+									size="sm"
+									className="w-full justify-start"
+									disabled={!hasUpdatePluginAccess}
+									onClick={() => setIsTracingSheetOpen(true)}
+									data-testid="plugins-tracing-button"
+								>
+									<Activity className="h-4 w-4" />
+									<div className="text-xs">Configure Plugin Tracing</div>
+								</Button>
 							</div>
 						</div>
 					</div>
@@ -146,6 +165,7 @@ export default function PluginsPage() {
 				}}
 			/>
 			<PluginSequenceSheet open={isSequenceSheetOpen} onClose={() => setIsSequenceSheetOpen(false)} plugins={plugins ?? []} />
+			<PluginTracingSheet open={isTracingSheetOpen} onClose={() => setIsTracingSheetOpen(false)} />
 		</div>
 	);
 }

--- a/ui/app/workspace/plugins/sheets/pluginTracingSheet.tsx
+++ b/ui/app/workspace/plugins/sheets/pluginTracingSheet.tsx
@@ -1,0 +1,186 @@
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Switch } from "@/components/ui/switch";
+import { TriStateCheckbox } from "@/components/ui/tristateCheckbox";
+import { getErrorMessage, useGetBuiltinPluginsQuery, useGetPluginQuery, useGetPluginsQuery, useUpdatePluginMutation } from "@/lib/store";
+import { PluginSpanFilter } from "@/lib/types/config";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+interface PluginTracingSheetProps {
+	open: boolean;
+	onClose: () => void;
+}
+
+function resolveToggleState(filter: PluginSpanFilter | null | undefined, allPlugins: string[]): Record<string, boolean> {
+	const state: Record<string, boolean> = {};
+	for (const name of allPlugins) {
+		state[name] = true;
+	}
+	if (!filter) return state;
+
+	if (filter.mode === "exclude") {
+		for (const name of filter.plugins) {
+			state[name] = false;
+		}
+	} else {
+		for (const name of allPlugins) {
+			state[name] = filter.plugins.includes(name);
+		}
+	}
+	return state;
+}
+
+function buildFilter(toggles: Record<string, boolean>): PluginSpanFilter | null {
+	const excluded = Object.entries(toggles)
+		.filter(([, on]) => !on)
+		.map(([name]) => name);
+	if (excluded.length === 0) return null;
+	return { mode: "exclude", plugins: excluded };
+}
+
+function PluginRow({ name, checked, onChange }: { name: string; checked: boolean; onChange: (v: boolean) => void }) {
+	return (
+		<div className="flex items-center justify-between rounded-md border px-3 py-2.5">
+			<span className="text-sm font-mono">{name}</span>
+			<div className="flex items-center gap-2">
+				<Switch checked={checked} onCheckedChange={onChange} data-testid={`plugin-tracing-toggle-${name}`} />
+			</div>
+		</div>
+	);
+}
+
+export default function PluginTracingSheet({ open, onClose }: PluginTracingSheetProps) {
+	const { data: builtinPluginNames = [] } = useGetBuiltinPluginsQuery();
+	const { data: allPluginsData } = useGetPluginsQuery();
+	const customPluginNames = (allPluginsData ?? []).filter((p) => p.isCustom).map((p) => p.name);
+	const allPlugins = [...builtinPluginNames, ...customPluginNames];
+	const { data: otelPlugin } = useGetPluginQuery("otel");
+	const [updatePlugin, { isLoading }] = useUpdatePluginMutation();
+	const [toggles, setToggles] = useState<Record<string, boolean>>({});
+	const wasOpenRef = useRef(false);
+
+	useEffect(() => {
+		if (open && !wasOpenRef.current) {
+			if (!otelPlugin) return; // wait until persisted config is available
+			const filter = (otelPlugin.config?.plugin_span_filter as PluginSpanFilter | undefined) ?? null;
+			setToggles(resolveToggleState(filter, allPlugins));
+			wasOpenRef.current = true;
+		}
+		if (!open) wasOpenRef.current = false;
+	}, [open, otelPlugin, allPlugins]);
+
+	const setToggle = useCallback((name: string, value: boolean) => {
+		setToggles((prev) => ({ ...prev, [name]: value }));
+	}, []);
+
+	const handleSave = useCallback(async () => {
+		if (!otelPlugin) {
+			toast.error("OTEL plugin not found");
+			return;
+		}
+		const filter = buildFilter(toggles);
+		try {
+			await updatePlugin({
+				name: "otel",
+				data: {
+					enabled: otelPlugin.enabled,
+					config: { plugin_span_filter: filter },
+				},
+			}).unwrap();
+			toast.success("Plugin tracing configuration saved");
+			onClose();
+		} catch (error) {
+			toast.error(getErrorMessage(error));
+		}
+	}, [toggles, otelPlugin, updatePlugin, onClose]);
+
+	return (
+		<Sheet open={open} onOpenChange={onClose}>
+			<SheetContent className="flex w-full flex-col overflow-hidden p-8">
+				<SheetHeader className="flex flex-col items-start p-0">
+					<SheetTitle>Configure Plugin Tracing</SheetTitle>
+					<SheetDescription>
+						Choose which plugin hook spans are exported to the OTEL collector. Disabling a plugin removes its spans from traces without
+						affecting execution.
+					</SheetDescription>
+				</SheetHeader>
+
+				<div className="mt-4 flex-1 overflow-y-auto">
+					<div className="flex flex-col gap-4">
+						<div>
+							<div className="mb-2 flex items-center justify-between">
+								<p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Built-in Plugins</p>
+								<TriStateCheckbox
+									allIds={builtinPluginNames}
+									selectedIds={builtinPluginNames.filter((n) => toggles[n] ?? true)}
+									onChange={(next) => {
+										const nextSet = new Set(next);
+										setToggles((prev) => {
+											const updated = { ...prev };
+											for (const n of builtinPluginNames) updated[n] = nextSet.has(n);
+											return updated;
+										});
+									}}
+									ariaLabel="Toggle all built-in plugin tracing"
+									data-testid="plugin-tracing-select-all-builtins"
+								/>
+							</div>
+							<div className="flex flex-col gap-1.5">
+								{builtinPluginNames.map((name) => (
+									<PluginRow key={name} name={name} checked={toggles[name] ?? true} onChange={(v) => setToggle(name, v)} />
+								))}
+							</div>
+						</div>
+
+						{customPluginNames.length > 0 && (
+							<div>
+								<div className="mb-2 flex items-center justify-between">
+									<p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Custom Plugins</p>
+									<TriStateCheckbox
+										allIds={customPluginNames}
+										selectedIds={customPluginNames.filter((n) => toggles[n] ?? true)}
+										onChange={(next) => {
+											const nextSet = new Set(next);
+											setToggles((prev) => {
+												const updated = { ...prev };
+												for (const n of customPluginNames) updated[n] = nextSet.has(n);
+												return updated;
+											});
+										}}
+										ariaLabel="Toggle all custom plugin tracing"
+										data-testid="plugin-tracing-select-all-custom"
+									/>
+								</div>
+								<div className="flex flex-col gap-1.5">
+									{customPluginNames.map((name) => (
+										<PluginRow key={name} name={name} checked={toggles[name] ?? true} onChange={(v) => setToggle(name, v)} />
+									))}
+								</div>
+							</div>
+						)}
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-2 pt-4">
+					<Alert variant="info">
+						<AlertDescription>
+							<span>
+								If <strong className="inline">plugin_span_filter</strong> is set inside the OTEL plugin config in config.json, it takes precedence over these settings after restarting Bifrost.
+							</span>
+						</AlertDescription>
+					</Alert>
+					<div className="flex justify-end gap-2 pt-2">
+						<Button type="button" variant="outline" onClick={onClose} disabled={isLoading} data-testid="plugin-tracing-cancel-button">
+							Cancel
+						</Button>
+						<Button onClick={handleSave} disabled={isLoading} isLoading={isLoading} data-testid="plugin-tracing-save-button" type="button">
+							Save
+						</Button>
+					</div>
+				</div>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/ui/app/workspace/plugins/views/pluginsEmptyState.tsx
+++ b/ui/app/workspace/plugins/views/pluginsEmptyState.tsx
@@ -1,15 +1,16 @@
 import { Button } from "@/components/ui/button";
-import { Puzzle } from "lucide-react";
-import { ArrowUpRight } from "lucide-react";
+import { Activity, ArrowUpRight, Puzzle } from "lucide-react";
 
 const CUSTOM_PLUGINS_DOCS_URL = "https://docs.getbifrost.ai/plugins";
 
 interface PluginsEmptyStateProps {
 	onCreateClick: () => void;
 	canCreate?: boolean;
+	onConfigureTracingClick?: () => void;
+	canConfigureTracing?: boolean;
 }
 
-export function PluginsEmptyState({ onCreateClick, canCreate = true }: PluginsEmptyStateProps) {
+export function PluginsEmptyState({ onCreateClick, canCreate = true, onConfigureTracingClick, canConfigureTracing = true }: PluginsEmptyStateProps) {
 	return (
 		<div
 			className="flex min-h-[80vh] w-full flex-col items-center justify-center gap-4 py-16 text-center"
@@ -34,6 +35,18 @@ export function PluginsEmptyState({ onCreateClick, canCreate = true }: PluginsEm
 					>
 						Read more <ArrowUpRight className="text-muted-foreground h-3 w-3" />
 					</Button>
+					{onConfigureTracingClick && (
+						<Button
+							variant="outline"
+							aria-label="Configure plugin tracing"
+							data-testid="plugins-button-configure-tracing"
+							onClick={onConfigureTracingClick}
+							disabled={!canConfigureTracing}
+						>
+							<Activity className="h-4 w-4" />
+							Configure Plugin Tracing
+						</Button>
+					)}
 					<Button
 						aria-label="Create your first plugin"
 						data-testid="plugins-button-install-new"

--- a/ui/components/ui/tristateCheckbox.tsx
+++ b/ui/components/ui/tristateCheckbox.tsx
@@ -24,6 +24,9 @@ export interface TriStateCheckboxProps {
 
 	/** Accessible name for icon-only checkbox (e.g. when label is rendered elsewhere) */
 	ariaLabel?: string;
+
+	/** Test identifier for E2E targeting */
+	"data-testid"?: string;
 }
 
 export const TriStateCheckbox: React.FC<TriStateCheckboxProps> = ({
@@ -34,6 +37,7 @@ export const TriStateCheckbox: React.FC<TriStateCheckboxProps> = ({
 	disabled = false,
 	className = "",
 	ariaLabel,
+	"data-testid": dataTestId,
 }) => {
 	const state: TriState = useMemo(() => {
 		if (!allIds.length) return "none";
@@ -80,6 +84,7 @@ export const TriStateCheckbox: React.FC<TriStateCheckboxProps> = ({
 			role="checkbox"
 			aria-checked={ariaChecked}
 			aria-label={ariaLabel}
+			data-testid={dataTestId}
 			className={cn(
 				"inline-flex items-center gap-2 focus:outline-none",
 				"focus-visible:ring-ring focus-visible:ring-offset-background focus-visible:ring-2 focus-visible:ring-offset-2",

--- a/ui/lib/store/apis/pluginsApi.ts
+++ b/ui/lib/store/apis/pluginsApi.ts
@@ -3,6 +3,13 @@ import { baseApi } from "./baseApi";
 
 export const pluginsApi = baseApi.injectEndpoints({
 	endpoints: (builder) => ({
+		// Get builtin plugin names
+		getBuiltinPlugins: builder.query<string[], void>({
+			query: () => "/plugins/builtins",
+			providesTags: ["Plugins"],
+			transformResponse: (response: { plugins: string[] }) => response.plugins || [],
+		}),
+
 		// Get all plugins
 		getPlugins: builder.query<Plugin[], void>({
 			query: () => "/plugins",
@@ -89,6 +96,7 @@ export const pluginsApi = baseApi.injectEndpoints({
 });
 
 export const {
+	useGetBuiltinPluginsQuery,
 	useGetPluginsQuery,
 	useGetPluginQuery,
 	useCreatePluginMutation,

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -446,6 +446,13 @@ export interface RestartRequiredConfig {
 }
 
 // Bifrost Config
+export type PluginSpanFilterMode = "include" | "exclude";
+
+export interface PluginSpanFilter {
+	mode: PluginSpanFilterMode;
+	plugins: string[];
+}
+
 export interface BifrostConfig {
 	client_config: CoreConfig;
 	framework_config: FrameworkConfig;


### PR DESCRIPTION
## Summary

Adds a `plugin_span_filter` feature to the OTEL plugin that lets operators control which plugin hook spans are exported to the OTEL collector. Without filtering, every plugin generates two spans per request (pre- and post-hook), which can produce 16+ plugin spans per request with the default set of built-in plugins. This change introduces a `plugin_span_filter` field inside the OTEL plugin config (both config.json and DB) and a UI sheet ("Configure Plugin Tracing") for managing this at runtime.

## Changes

- **`plugins/otel`**: Added `PluginSpanFilter` type with `include`/`exclude` modes. `shouldExportSpan` checks each span against the filter; `buildReparentMap` resolves chains of consecutive filtered spans so their children are re-parented to the nearest exported ancestor, keeping the trace hierarchy intact. `Init` and `ValidateConfig` both validate that `plugin_span_filter.mode` is a recognized value.
- **`transports/bifrost-http/handlers/plugins.go`**: `updatePlugin` now fetches the existing plugin before saving and merges the incoming config over the existing DB config using `maps.Copy`, so fields like `plugin_span_filter` that are not sent by the OTEL config form are not silently wiped on save.
- **UI**: Added `PluginTracingSheet` — a side sheet accessible via a new "Configure Plugin Tracing" button on the Plugins page (and on the empty state). It renders per-plugin toggles (built-in and custom) with tri-state select-all checkboxes, reads the current filter from the OTEL plugin's DB config, and saves only `plugin_span_filter` into the OTEL plugin config via `updatePlugin`. Added `PluginSpanFilter` and `PluginSpanFilterMode` types to the UI type definitions.
- **Docs**: Added a "Filtering Plugin Spans" section to the OTEL observability page and a `config.plugin_span_filter` row to the plugins config reference.
- **Schema**: Added `plugin_span_filter` inside the OTEL plugin config object to `config.schema.json`.
- **Tests**: Added `converter_test.go` (unit tests for `shouldExportSpan` and `buildReparentMap`), `filter_test.go` (JSON round-trip tests for `PluginSpanFilter` and `Config`), `plugins_test.go` in the handlers package (config merge behavior), and passthrough tests in `config_test.go`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Backend
go test ./plugins/otel/...
go test ./transports/bifrost-http/handlers/...
go test ./transports/bifrost-http/lib/...

# UI
cd ui
pnpm i
pnpm build
```

**config.json (inside the OTEL plugin config):**
```json
{
  "plugins": [
    {
      "name": "otel",
      "enabled": true,
      "config": {
        "collector_url": "...",
        "trace_type": "genai_extension",
        "protocol": "http",
        "plugin_span_filter": {
          "mode": "exclude",
          "plugins": ["logging", "compat", "telemetry", "otel"]
        }
      }
    }
  ]
}
```
Restart Bifrost and verify that traces no longer contain spans for the listed plugins, and that child spans of filtered plugins are re-parented to the nearest exported ancestor.

**UI flow:** Navigate to Plugins → click "Configure Plugin Tracing" → toggle individual plugins off → Save. Verify the OTEL plugin's DB config contains `plugin_span_filter` and that subsequent saves of the OTEL config form do not wipe the filter.

**Precedence:** Set `plugin_span_filter` in config.json with a higher `version` value and a different value via the UI. Restart and confirm the config.json value takes effect.

## Breaking changes

- [x] No

## Security considerations

No new secrets or PII are introduced. The filter configuration contains only plugin names and a mode string.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)