### PR TITLE
fix: remove lowercase on image size in gemini image requests

### DIFF
--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -3127,3 +3127,122 @@ func TestFunctionCallingConfigModeAny_RoundTrip(t *testing.T) {
 		})
 	}
 }
+
+// TestImageSizeRoundtrip verifies that imageSize and aspectRatio survive the
+// GeminiGenerationRequest → BifrostImageGenerationRequest → GeminiGenerationRequest round-trip
+// and that the outbound imageSize is always uppercase ("2K" not "2k").
+func TestImageSizeRoundtrip(t *testing.T) {
+	tests := []struct {
+		name            string
+		inImageSize     string
+		inAspectRatio   string
+		wantSize        string // expected Bifrost WxH
+		wantImageSize   string // expected outbound Gemini imageSize
+		wantAspectRatio string
+	}{
+		{"1K_square", "1K", "1:1", "1024x1024", "1K", "1:1"},
+		{"2K_square", "2K", "1:1", "2048x2048", "2K", "1:1"},
+		{"4K_square", "4K", "1:1", "4096x4096", "4K", "1:1"},
+		{"2K_portrait", "2K", "3:4", "1536x2048", "2K", "3:4"},
+		{"2K_landscape", "2K", "4:3", "2048x1536", "2K", "4:3"},
+		{"lowercase_normalised", "2k", "1:1", "2048x2048", "2K", "1:1"},
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inReq := &gemini.GeminiGenerationRequest{
+				Model: "gemini-3.1-flash-image-preview",
+				GenerationConfig: gemini.GenerationConfig{
+					ResponseModalities: []gemini.Modality{gemini.ModalityImage},
+					ImageConfig: &gemini.GeminiImageConfig{
+						ImageSize:   tt.inImageSize,
+						AspectRatio: tt.inAspectRatio,
+					},
+				},
+				Contents: []gemini.Content{{
+					Role:  "user",
+					Parts: []*gemini.Part{{Text: "hello kitty"}},
+				}},
+			}
+
+			bifrostReq := inReq.ToBifrostImageGenerationRequest(ctx)
+			require.NotNil(t, bifrostReq)
+			require.NotNil(t, bifrostReq.Params.Size, "Size must be extracted from ImageConfig")
+			assert.Equal(t, tt.wantSize, *bifrostReq.Params.Size)
+
+			outReq := gemini.ToGeminiImageGenerationRequest(bifrostReq)
+			require.NotNil(t, outReq)
+			require.NotNil(t, outReq.GenerationConfig.ImageConfig, "ImageConfig must be set on outbound request")
+			assert.Equal(t, tt.wantImageSize, outReq.GenerationConfig.ImageConfig.ImageSize, "imageSize must be uppercase")
+			assert.Equal(t, tt.wantAspectRatio, outReq.GenerationConfig.ImageConfig.AspectRatio)
+		})
+	}
+}
+
+// TestImageEditSizeRoundtrip mirrors TestImageSizeRoundtrip for the image-edit path.
+func TestImageEditSizeRoundtrip(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	// minimal 1x1 PNG for inline image data
+	pngPixel, _ := base64.StdEncoding.DecodeString(
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+	)
+
+	inReq := &gemini.GeminiGenerationRequest{
+		Model: "gemini-3.1-flash-image-preview",
+		GenerationConfig: gemini.GenerationConfig{
+			ResponseModalities: []gemini.Modality{gemini.ModalityImage},
+			ImageConfig: &gemini.GeminiImageConfig{
+				ImageSize:   "2K",
+				AspectRatio: "1:1",
+			},
+		},
+		Contents: []gemini.Content{{
+			Role: "user",
+			Parts: []*gemini.Part{
+				{Text: "make it pop"},
+				{InlineData: &gemini.Blob{MIMEType: "image/png", Data: base64.StdEncoding.EncodeToString(pngPixel)}},
+			},
+		}},
+	}
+
+	bifrostReq := inReq.ToBifrostImageEditRequest(ctx)
+	require.NotNil(t, bifrostReq)
+	require.NotNil(t, bifrostReq.Params.Size, "Size must be extracted from ImageConfig in edit path")
+	assert.Equal(t, "2048x2048", *bifrostReq.Params.Size)
+
+	outReq := gemini.ToGeminiImageEditRequest(bifrostReq)
+	require.NotNil(t, outReq)
+	require.NotNil(t, outReq.GenerationConfig.ImageConfig, "ImageConfig must be set on outbound edit request")
+	assert.Equal(t, "2K", outReq.GenerationConfig.ImageConfig.ImageSize, "imageSize must be uppercase on edit path")
+	assert.Equal(t, "1:1", outReq.GenerationConfig.ImageConfig.AspectRatio)
+}
+
+// TestImagenImageSizeCasing verifies that the Imagen :predict path sends uppercase imageSize.
+func TestImagenImageSizeCasing(t *testing.T) {
+	tests := []struct {
+		wxh           string
+		wantImageSize string
+	}{
+		{"1024x1024", "1K"},
+		{"2048x2048", "2K"},
+		{"4096x4096", "4K"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.wantImageSize, func(t *testing.T) {
+			bifrostReq := &schemas.BifrostImageGenerationRequest{
+				Provider: schemas.Gemini,
+				Model:    "imagen-4.0-generate-preview-05-20",
+				Input:    &schemas.ImageGenerationInput{Prompt: "test"},
+				Params:   &schemas.ImageGenerationParameters{Size: &tt.wxh},
+			}
+			imagenReq := gemini.ToImagenImageGenerationRequest(bifrostReq)
+			require.NotNil(t, imagenReq)
+			require.NotNil(t, imagenReq.Parameters.SampleImageSize, "SampleImageSize must be set")
+			assert.Equal(t, tt.wantImageSize, *imagenReq.Parameters.SampleImageSize, "Imagen imageSize must be uppercase")
+		})
+	}
+}

--- a/core/providers/gemini/images.go
+++ b/core/providers/gemini/images.go
@@ -94,6 +94,16 @@ func (request *GeminiGenerationRequest) ToBifrostImageGenerationRequest(ctx *sch
 		}
 	}
 
+	if request.GenerationConfig.ImageConfig != nil {
+		ic := request.GenerationConfig.ImageConfig
+		if strings.TrimSpace(ic.ImageSize) != "" || strings.TrimSpace(ic.AspectRatio) != "" {
+			size := convertImagenFormatToSize(&ic.ImageSize, &ic.AspectRatio)
+			if size != "" {
+				bifrostReq.Params.Size = &size
+			}
+		}
+	}
+
 	return bifrostReq
 }
 
@@ -288,6 +298,16 @@ func (request *GeminiGenerationRequest) ToBifrostImageEditRequest(ctx *schemas.B
 		}
 	}
 
+	if request.GenerationConfig.ImageConfig != nil {
+		ic := request.GenerationConfig.ImageConfig
+		if strings.TrimSpace(ic.ImageSize) != "" || strings.TrimSpace(ic.AspectRatio) != "" {
+			size := convertImagenFormatToSize(&ic.ImageSize, &ic.AspectRatio)
+			if size != "" {
+				bifrostReq.Params.Size = &size
+			}
+		}
+	}
+
 	return bifrostReq
 }
 
@@ -413,7 +433,7 @@ func ToGeminiImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 			aspectRatio, imageSize := utils.ConvertSizeToAspectRatioAndResolution(*bifrostReq.Params.Size)
 			if imageSize != "" && aspectRatio != "" {
 				geminiReq.GenerationConfig.ImageConfig = &GeminiImageConfig{
-					ImageSize:   strings.ToLower(imageSize),
+					ImageSize:   imageSize,
 					AspectRatio: aspectRatio,
 				}
 			}
@@ -519,8 +539,7 @@ func ToImagenImageGenerationRequest(bifrostReq *schemas.BifrostImageGenerationRe
 		if bifrostReq.Params.Size != nil && strings.ToLower(*bifrostReq.Params.Size) != "auto" {
 			aspectRatio, imageSize := utils.ConvertSizeToAspectRatioAndResolution(*bifrostReq.Params.Size)
 			if imageSize != "" {
-				imageSizeLower := strings.ToLower(imageSize)
-				req.Parameters.SampleImageSize = &imageSizeLower
+				req.Parameters.SampleImageSize = &imageSize
 			}
 			if aspectRatio != "" {
 				req.Parameters.AspectRatio = &aspectRatio
@@ -749,6 +768,17 @@ func ToGeminiImageEditRequest(bifrostReq *schemas.BifrostImageEditRequest) *Gemi
 	// Convert parameters to generation config
 	if bifrostReq.Params != nil {
 		geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
+
+		// Handle size conversion
+		if bifrostReq.Params.Size != nil && strings.ToLower(*bifrostReq.Params.Size) != "auto" {
+			aspectRatio, imageSize := utils.ConvertSizeToAspectRatioAndResolution(*bifrostReq.Params.Size)
+			if imageSize != "" && aspectRatio != "" {
+				geminiReq.GenerationConfig.ImageConfig = &GeminiImageConfig{
+					ImageSize:   imageSize,
+					AspectRatio: aspectRatio,
+				}
+			}
+		}
 
 		// Handle extra parameters
 		if bifrostReq.Params.ExtraParams != nil {


### PR DESCRIPTION
## Summary

Fixes incorrect casing of `imageSize` values sent to Gemini and Imagen image generation endpoints. Previously, `imageSize` was being lowercased (e.g., `"2k"`) before being sent, but the Gemini API expects uppercase values (e.g., `"2K"`). Additionally, `imageSize` and `aspectRatio` from `GeminiImageConfig` were not being propagated into the Bifrost request `Size` field during the inbound conversion, and the edit path (`ToGeminiImageEditRequest`) was missing size/aspect-ratio conversion entirely.

## Changes

- Removed `strings.ToLower` calls in `ToGeminiImageGenerationRequest` and `ToImagenImageGenerationRequest` so that `imageSize` is preserved as uppercase (e.g., `"1K"`, `"2K"`, `"4K"`).
- Added `ImageConfig` → `Params.Size` extraction in `ToBifrostImageGenerationRequest` and `ToBifrostImageEditRequest` so that `imageSize` and `aspectRatio` survive the inbound round-trip.
- Added size conversion logic to `ToGeminiImageEditRequest` to populate `GeminiImageConfig` with the correct uppercase `imageSize` and `aspectRatio` on the outbound edit path.
- Added tests covering the full round-trip for image generation, image editing, and the Imagen `:predict` path, including a case verifying that lowercase input (e.g., `"2k"`) is normalised to uppercase (`"2K"`) on output.

## Type of change

- [x] Bug fix

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/... -run "TestImageSizeRoundtrip|TestImageEditSizeRoundtrip|TestImagenImageSizeCasing" -v
```

Expected: all three test functions pass, confirming that `imageSize` is uppercase in all outbound Gemini/Imagen requests and that `Size` is correctly populated on inbound conversion.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable