### PR TITLE
fix: return empty MCP config instead of `nil` when no clients found

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1246,9 +1246,6 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 	if err := s.DB().WithContext(ctx).Find(&dbMCPClients).Error; err != nil {
 		return nil, err
 	}
-	if len(dbMCPClients) == 0 {
-		return nil, nil
-	}
 	var clientConfig tables.TableClientConfig
 	if err := s.DB().WithContext(ctx).First(&clientConfig).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {


### PR DESCRIPTION
## Summary

When no MCP clients exist in the database, `GetMCPConfig` was returning `nil, nil` before attempting to fetch the client config. This caused the function to short-circuit and skip loading the client configuration entirely, even when a valid client config record may exist.

## Changes

- Removed the early return that skipped fetching `TableClientConfig` when no MCP clients were found, ensuring the client config is always retrieved regardless of whether any MCP client records exist.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Verify that `GetMCPConfig` returns a valid config when no MCP clients are present but a `TableClientConfig` record exists in the database.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable