### PR TITLE
compilation fix

### DIFF
--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -141,7 +141,6 @@ func isValidAudioBase64Payload(data string) bool {
 	decoded, err := decodeBase64StringToBytes(data)
 	return err == nil && len(decoded) > 0
 }
-}
 
 // supportsThinkingConfig returns true if the model supports ThinkingConfig.
 // Only specific Gemini models support thinking:


### PR DESCRIPTION
## Summary

Removes an extraneous closing brace `}` in `core/providers/gemini/utils.go` that was causing a syntax error in the `isValidAudioBase64Payload` function.

## Changes

- Removed a duplicate/orphaned closing brace after `isValidAudioBase64Payload` that did not belong to any enclosing block, which would have caused a compilation failure.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go build ./...
go test ./...
```

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable