### PR TITLE
fix: add `*.quay.io:443` to release pipeline egress allowlist

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1865,6 +1865,7 @@ jobs:
             proxy.golang.org:443
             registry-1.docker.io:443
             registry.access.redhat.com:443
+            *.quay.io:443
             registry.npmjs.org:443
             storage.googleapis.com:443
 
@@ -1955,6 +1956,7 @@ jobs:
             proxy.golang.org:443
             registry-1.docker.io:443
             registry.access.redhat.com:443
+            *.quay.io:443
             registry.npmjs.org:443
             storage.googleapis.com:443
 


### PR DESCRIPTION
## Summary

Adds `*.quay.io:443` to the network egress allowlist in two jobs within the release pipeline to allow pulling images hosted on Quay.io.

## Changes

- Added `*.quay.io:443` to the egress allowlist in two release pipeline jobs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Verify the release pipeline jobs that pull images from Quay.io complete successfully without egress-related failures.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The wildcard `*.quay.io:443` entry permits outbound HTTPS traffic to any Quay.io subdomain. This should be scoped further if only specific Quay.io registries are required.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable