### PR TITLE
feat: adds preLaunch handling in Codex to pick correct VK if set during initialization

### DIFF
--- a/cli/internal/harness/harness.go
+++ b/cli/internal/harness/harness.go
@@ -93,6 +93,9 @@ var all = map[string]Harness{
 			}
 			return []string{"--model", model}
 		},
+		PreLaunch:         codexPreLaunch,
+		WriteNativeConfig: codexWriteNativeConfig,
+		NativeConfigPath:  "~/.codex/auth.json, ~/.codex/config.toml",
 	},
 	"gemini": {
 		ID:         "gemini",

--- a/cli/internal/harness/harness_test.go
+++ b/cli/internal/harness/harness_test.go
@@ -235,6 +235,180 @@ func TestOpencodeTUIConfigPathPrefersXDG(t *testing.T) {
 	}
 }
 
+func TestCodexWriteNativeConfigMergesAuthAndTOML(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir codex dir: %v", err)
+	}
+
+	authPath := filepath.Join(dir, "auth.json")
+	initialAuth := `{"auth_mode":"apikey","OPENAI_API_KEY":"stale-key","tokens":{"id_token":"keep-me"}}`
+	if err := os.WriteFile(authPath, []byte(initialAuth), 0o600); err != nil {
+		t.Fatalf("write initial auth: %v", err)
+	}
+
+	configPath := filepath.Join(dir, "config.toml")
+	initialTOML := `openai_base_url="http://old.example/openai/v1"
+env_key="stale-literal-key"
+model = "gpt-old"
+model_reasoning_effort = "medium"
+
+[projects."/Users/me/proj"]
+trust_level = "trusted"
+`
+	if err := os.WriteFile(configPath, []byte(initialTOML), 0o600); err != nil {
+		t.Fatalf("write initial config.toml: %v", err)
+	}
+
+	if err := codexWriteNativeConfig("http://localhost:8080/openai/v1", "sk-bf-new", "gpt-5.5"); err != nil {
+		t.Fatalf("codexWriteNativeConfig() error = %v", err)
+	}
+
+	// auth.json should keep tokens.id_token but flip OPENAI_API_KEY.
+	authBytes, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatalf("read auth.json: %v", err)
+	}
+	var auth map[string]any
+	if err := sonic.Unmarshal(authBytes, &auth); err != nil {
+		t.Fatalf("unmarshal auth.json: %v", err)
+	}
+	if got, _ := auth["OPENAI_API_KEY"].(string); got != "sk-bf-new" {
+		t.Fatalf("auth.OPENAI_API_KEY = %q, want %q", got, "sk-bf-new")
+	}
+	if got, _ := auth["auth_mode"].(string); got != "apikey" {
+		t.Fatalf("auth.auth_mode = %q, want %q", got, "apikey")
+	}
+	tokens, ok := auth["tokens"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected tokens map preserved, got %#v", auth["tokens"])
+	}
+	if got, _ := tokens["id_token"].(string); got != "keep-me" {
+		t.Fatalf("tokens.id_token = %q, want %q", got, "keep-me")
+	}
+
+	// config.toml should have new values for top-level keys, preserve
+	// model_reasoning_effort and the [projects.*] table.
+	tomlBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	got := string(tomlBytes)
+	for _, want := range []string{
+		`openai_base_url = "http://localhost:8080/openai/v1"`,
+		`env_key = "OPENAI_API_KEY"`,
+		`model = "gpt-5.5"`,
+		`model_reasoning_effort = "medium"`,
+		`[projects."/Users/me/proj"]`,
+		`trust_level = "trusted"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected config.toml to contain %q, got:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{
+		`"http://old.example/openai/v1"`,
+		`"stale-literal-key"`,
+		`"gpt-old"`,
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("expected config.toml to no longer contain %q, got:\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestCodexWriteNativeConfigCreatesFilesWhenMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := codexWriteNativeConfig("http://localhost:8080/openai/v1", "sk-bf-fresh", ""); err != nil {
+		t.Fatalf("codexWriteNativeConfig() error = %v", err)
+	}
+
+	authBytes, err := os.ReadFile(filepath.Join(home, ".codex", "auth.json"))
+	if err != nil {
+		t.Fatalf("read auth.json: %v", err)
+	}
+	var auth map[string]any
+	if err := sonic.Unmarshal(authBytes, &auth); err != nil {
+		t.Fatalf("unmarshal auth.json: %v", err)
+	}
+	if got, _ := auth["OPENAI_API_KEY"].(string); got != "sk-bf-fresh" {
+		t.Fatalf("auth.OPENAI_API_KEY = %q", got)
+	}
+
+	tomlBytes, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	got := string(tomlBytes)
+	for _, want := range []string{
+		`openai_base_url = "http://localhost:8080/openai/v1"`,
+		`env_key = "OPENAI_API_KEY"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected config.toml to contain %q, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, `model =`) {
+		t.Fatalf("did not expect model line when model is empty, got:\n%s", got)
+	}
+}
+
+func TestCodexWriteNativeConfigSkipsAuthForDummyKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := codexWriteNativeConfig("http://localhost:8080/openai/v1", "dummy-key", ""); err != nil {
+		t.Fatalf("codexWriteNativeConfig() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, ".codex", "auth.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected no auth.json for dummy key, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "config.toml")); err != nil {
+		t.Fatalf("expected config.toml to still be written, stat err=%v", err)
+	}
+}
+
+func TestSetTopLevelTOMLKeysAppendsBeforeFirstTable(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`# header comment
+model_reasoning_effort = "medium"
+
+[projects."x"]
+trust_level = "trusted"
+`)
+	out := string(setTopLevelTOMLKeys(input, map[string]string{
+		"openai_base_url": "http://localhost:8080/openai/v1",
+		"env_key":         "OPENAI_API_KEY",
+		"model":           "gpt-5.5",
+	}))
+
+	preTable, _, ok := strings.Cut(out, `[projects."x"]`)
+	if !ok {
+		t.Fatalf("expected [projects.\"x\"] header preserved, got:\n%s", out)
+	}
+	for _, want := range []string{
+		`# header comment`,
+		`model_reasoning_effort = "medium"`,
+		`openai_base_url = "http://localhost:8080/openai/v1"`,
+		`env_key = "OPENAI_API_KEY"`,
+		`model = "gpt-5.5"`,
+	} {
+		if !strings.Contains(preTable, want) {
+			t.Fatalf("expected pre-table section to contain %q, got:\n%s", want, preTable)
+		}
+	}
+	if !strings.Contains(out, `trust_level = "trusted"`) {
+		t.Fatalf("expected table body preserved, got:\n%s", out)
+	}
+}
+
 func envValue(env []string, key string) string {
 	prefix := key + "="
 	for _, entry := range env {

--- a/cli/internal/harness/native_config.go
+++ b/cli/internal/harness/native_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -95,4 +96,237 @@ func claudeTierModelEnvMap(model string) map[string]string {
 		"ANTHROPIC_DEFAULT_OPUS_MODEL":   model,
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  model,
 	}
+}
+
+// codexPreLaunch persists the bifrost endpoint and virtual key into Codex
+// CLI's native config files. Codex resolves its credentials from
+// ~/.codex/auth.json (which takes precedence over OPENAI_API_KEY in the
+// process env) and its endpoint from ~/.codex/config.toml, so a stale
+// auth.json from a prior run will otherwise shadow whatever Bifrost passes
+// via env vars. Returns no extra env (BuildEnv already exports the key) and
+// no cleanup — the writes are intentionally persistent so direct `codex`
+// launches outside Bifrost keep working too.
+func codexPreLaunch(baseURL, apiKey, model string) ([]string, func(), error) {
+	if err := codexWriteNativeConfig(baseURL, apiKey, model); err != nil {
+		return nil, nil, err
+	}
+	return nil, func() {}, nil
+}
+
+// codexWriteNativeConfig writes the bifrost endpoint, API key, and model
+// into Codex CLI's config files (~/.codex/auth.json and
+// ~/.codex/config.toml) so the same configuration is available when users
+// launch Codex directly.
+//
+// It merges into the existing files, preserving any user-defined settings.
+func codexWriteNativeConfig(baseURL, apiKey, model string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home dir: %w", err)
+	}
+
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create codex config dir: %w", err)
+	}
+
+	if apiKey = strings.TrimSpace(apiKey); apiKey != "" && apiKey != "dummy-key" {
+		if err := codexWriteAuth(filepath.Join(dir, "auth.json"), apiKey); err != nil {
+			return err
+		}
+	}
+	return codexWriteConfigTOML(filepath.Join(dir, "config.toml"), baseURL, model)
+}
+
+// codexWriteAuth merges the bifrost virtual key into Codex's auth.json,
+// preserving any other fields the user (or Codex itself) may have written.
+func codexWriteAuth(path, apiKey string) error {
+	auth := make(map[string]any)
+	if b, err := os.ReadFile(path); err == nil {
+		if err := sonic.Unmarshal(b, &auth); err != nil {
+			// Unparseable auth.json — overwrite rather than fail the launch,
+			// since the user can't easily recover from a corrupt file.
+			auth = make(map[string]any)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read codex auth: %w", err)
+	}
+
+	auth["auth_mode"] = "apikey"
+	auth["OPENAI_API_KEY"] = apiKey
+
+	b, err := sonic.MarshalIndent(auth, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal codex auth: %w", err)
+	}
+	return config.WriteAtomic(path, b, 0o600)
+}
+
+// codexWriteConfigTOML merges Bifrost's endpoint and (optionally) model into
+// the top-level section of Codex's config.toml. Existing top-level keys
+// (e.g. model_reasoning_effort) and tables (e.g. [projects.*], [tui.*]) are
+// preserved verbatim, including comments and ordering.
+func codexWriteConfigTOML(path, baseURL, model string) error {
+	var existing []byte
+	if b, err := os.ReadFile(path); err == nil {
+		existing = b
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read codex config: %w", err)
+	}
+
+	targets := map[string]string{
+		"openai_base_url": baseURL,
+		"env_key":         "OPENAI_API_KEY",
+	}
+	if m := strings.TrimSpace(model); m != "" {
+		targets["model"] = m
+	}
+
+	return config.WriteAtomic(path, setTopLevelTOMLKeys(existing, targets), 0o600)
+}
+
+// setTopLevelTOMLKeys returns data with each key in targets set to its
+// target value in the top-level section (above any [table] header). Keys
+// that already exist in the top-level section are replaced in place; keys
+// that don't are appended just before the first table header (or at EOF if
+// none). Everything else — table contents, comments, blank lines, ordering
+// — is preserved as-is.
+func setTopLevelTOMLKeys(data []byte, targets map[string]string) []byte {
+	if len(targets) == 0 {
+		return data
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		keys := make([]string, 0, len(targets))
+		for k := range targets {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var b strings.Builder
+		for _, k := range keys {
+			b.WriteString(k)
+			b.WriteString(" = ")
+			b.WriteString(tomlQuote(targets[k]))
+			b.WriteByte('\n')
+		}
+		return []byte(b.String())
+	}
+
+	hasTrailingNewline := strings.HasSuffix(string(data), "\n")
+	lines := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+
+	seen := make(map[string]bool, len(targets))
+	out := make([]string, 0, len(lines)+len(targets))
+	firstTableIdx := -1
+
+	for _, raw := range lines {
+		if firstTableIdx < 0 && isTOMLTableHeader(raw) {
+			firstTableIdx = len(out)
+		}
+		if firstTableIdx < 0 {
+			if key, ok := matchTopLevelTOMLKey(raw, targets); ok {
+				if seen[key] {
+					// Drop duplicate top-level definitions.
+					continue
+				}
+				out = append(out, key+" = "+tomlQuote(targets[key]))
+				seen[key] = true
+				continue
+			}
+		}
+		out = append(out, raw)
+	}
+
+	missing := make([]string, 0, len(targets))
+	for k := range targets {
+		if !seen[k] {
+			missing = append(missing, k+" = "+tomlQuote(targets[k]))
+		}
+	}
+	sort.Strings(missing)
+
+	if len(missing) > 0 {
+		if firstTableIdx < 0 {
+			for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
+				out = out[:len(out)-1]
+			}
+			out = append(out, missing...)
+		} else {
+			head := out[:firstTableIdx]
+			tail := append([]string{}, out[firstTableIdx:]...)
+			for len(head) > 0 && strings.TrimSpace(head[len(head)-1]) == "" {
+				head = head[:len(head)-1]
+			}
+			head = append(head, missing...)
+			head = append(head, "")
+			out = append(head, tail...)
+		}
+	}
+
+	result := strings.Join(out, "\n")
+	if hasTrailingNewline || len(missing) > 0 {
+		result += "\n"
+	}
+	return []byte(result)
+}
+
+// isTOMLTableHeader reports whether a line is a [table] or [[array]] header,
+// optionally followed by an inline comment.
+func isTOMLTableHeader(line string) bool {
+	t := strings.TrimSpace(line)
+	if !strings.HasPrefix(t, "[") {
+		return false
+	}
+	idx := strings.LastIndex(t, "]")
+	if idx < 0 {
+		return false
+	}
+	rest := strings.TrimSpace(t[idx+1:])
+	return rest == "" || strings.HasPrefix(rest, "#")
+}
+
+// matchTopLevelTOMLKey returns the target key name if line is a simple
+// `key = ...` assignment whose key appears in targets.
+func matchTopLevelTOMLKey(line string, targets map[string]string) (string, bool) {
+	t := strings.TrimSpace(line)
+	if t == "" || strings.HasPrefix(t, "#") {
+		return "", false
+	}
+	head, _, ok := strings.Cut(t, "=")
+	if !ok {
+		return "", false
+	}
+	name := strings.TrimSpace(head)
+	if _, ok := targets[name]; ok {
+		return name, true
+	}
+	return "", false
+}
+
+// tomlQuote returns a TOML basic string literal for s.
+func tomlQuote(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				fmt.Fprintf(&b, `\u%04x`, r)
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }


### PR DESCRIPTION
## Summary

Adds native config file support for the Codex CLI harness so that Bifrost's endpoint, virtual API key, and model selection are persisted into `~/.codex/auth.json` and `~/.codex/config.toml`. Without this, a stale `auth.json` from a prior Codex session shadows the credentials Bifrost injects via environment variables, causing authentication failures.

## Changes

- Wired `codexPreLaunch` and `codexWriteNativeConfig` into the Codex harness entry, along with a `NativeConfigPath` hint pointing to both config files.
- `codexPreLaunch` calls `codexWriteNativeConfig` at launch time and returns no cleanup — writes are intentionally persistent so direct `codex` invocations outside Bifrost continue to work.
- `codexWriteAuth` merges the Bifrost virtual key into `auth.json`, setting `auth_mode` to `apikey` and updating `OPENAI_API_KEY` while preserving all other fields (e.g. `tokens.id_token`). Skips writing entirely when the key is `dummy-key` or empty.
- `codexWriteConfigTOML` merges `openai_base_url`, `env_key`, and optionally `model` into the top-level section of `config.toml`, leaving all other top-level keys (e.g. `model_reasoning_effort`), table sections (e.g. `[projects.*]`), comments, and ordering intact.
- `setTopLevelTOMLKeys` implements a line-oriented TOML merge that replaces existing top-level key assignments in place and appends missing ones just before the first table header, without requiring a full TOML parse/re-serialize cycle that would destroy comments and formatting.
- Added `tomlQuote`, `isTOMLTableHeader`, and `matchTopLevelTOMLKey` as focused helpers.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./cli/internal/harness/...
```

The following test cases cover the new logic:

- `TestCodexWriteNativeConfigMergesAuthAndTOML` — verifies that existing `auth.json` fields (e.g. `tokens.id_token`) and `config.toml` entries (e.g. `model_reasoning_effort`, `[projects.*]` tables) are preserved while stale endpoint/key/model values are replaced.
- `TestCodexWriteNativeConfigCreatesFilesWhenMissing` — verifies both files are created from scratch when `~/.codex/` does not exist, and that no `model` line is written when model is empty.
- `TestCodexWriteNativeConfigSkipsAuthForDummyKey` — verifies `auth.json` is not written when the key is `dummy-key`, while `config.toml` is still written.
- `TestSetTopLevelTOMLKeysAppendsBeforeFirstTable` — verifies new keys are inserted before the first table header and existing keys/comments are preserved.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`auth.json` is written with mode `0600` and the `~/.codex/` directory is created with mode `0700`, restricting access to the owning user. The virtual API key is never logged. The `dummy-key` sentinel is explicitly excluded from being persisted to disk.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable