### PR TITLE
feat: adds scrollback handling in Bifrost CLI

### DIFF
--- a/cli/internal/harness/harness.go
+++ b/cli/internal/harness/harness.go
@@ -93,6 +93,9 @@ var all = map[string]Harness{
 			}
 			return []string{"--model", model}
 		},
+		PreLaunch:         codexPreLaunch,
+		WriteNativeConfig: codexWriteNativeConfig,
+		NativeConfigPath:  "~/.codex/auth.json, ~/.codex/config.toml",
 	},
 	"gemini": {
 		ID:         "gemini",

--- a/cli/internal/harness/harness_test.go
+++ b/cli/internal/harness/harness_test.go
@@ -235,6 +235,180 @@ func TestOpencodeTUIConfigPathPrefersXDG(t *testing.T) {
 	}
 }
 
+func TestCodexWriteNativeConfigMergesAuthAndTOML(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir codex dir: %v", err)
+	}
+
+	authPath := filepath.Join(dir, "auth.json")
+	initialAuth := `{"auth_mode":"apikey","OPENAI_API_KEY":"stale-key","tokens":{"id_token":"keep-me"}}`
+	if err := os.WriteFile(authPath, []byte(initialAuth), 0o600); err != nil {
+		t.Fatalf("write initial auth: %v", err)
+	}
+
+	configPath := filepath.Join(dir, "config.toml")
+	initialTOML := `openai_base_url="http://old.example/openai/v1"
+env_key="stale-literal-key"
+model = "gpt-old"
+model_reasoning_effort = "medium"
+
+[projects."/Users/me/proj"]
+trust_level = "trusted"
+`
+	if err := os.WriteFile(configPath, []byte(initialTOML), 0o600); err != nil {
+		t.Fatalf("write initial config.toml: %v", err)
+	}
+
+	if err := codexWriteNativeConfig("http://localhost:8080/openai/v1", "sk-bf-new", "gpt-5.5"); err != nil {
+		t.Fatalf("codexWriteNativeConfig() error = %v", err)
+	}
+
+	// auth.json should keep tokens.id_token but flip OPENAI_API_KEY.
+	authBytes, err := os.ReadFile(authPath)
+	if err != nil {
+		t.Fatalf("read auth.json: %v", err)
+	}
+	var auth map[string]any
+	if err := sonic.Unmarshal(authBytes, &auth); err != nil {
+		t.Fatalf("unmarshal auth.json: %v", err)
+	}
+	if got, _ := auth["OPENAI_API_KEY"].(string); got != "sk-bf-new" {
+		t.Fatalf("auth.OPENAI_API_KEY = %q, want %q", got, "sk-bf-new")
+	}
+	if got, _ := auth["auth_mode"].(string); got != "apikey" {
+		t.Fatalf("auth.auth_mode = %q, want %q", got, "apikey")
+	}
+	tokens, ok := auth["tokens"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected tokens map preserved, got %#v", auth["tokens"])
+	}
+	if got, _ := tokens["id_token"].(string); got != "keep-me" {
+		t.Fatalf("tokens.id_token = %q, want %q", got, "keep-me")
+	}
+
+	// config.toml should have new values for top-level keys, preserve
+	// model_reasoning_effort and the [projects.*] table.
+	tomlBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	got := string(tomlBytes)
+	for _, want := range []string{
+		`openai_base_url = "http://localhost:8080/openai/v1"`,
+		`env_key = "OPENAI_API_KEY"`,
+		`model = "gpt-5.5"`,
+		`model_reasoning_effort = "medium"`,
+		`[projects."/Users/me/proj"]`,
+		`trust_level = "trusted"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected config.toml to contain %q, got:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{
+		`"http://old.example/openai/v1"`,
+		`"stale-literal-key"`,
+		`"gpt-old"`,
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("expected config.toml to no longer contain %q, got:\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestCodexWriteNativeConfigCreatesFilesWhenMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := codexWriteNativeConfig("http://localhost:8080/openai/v1", "sk-bf-fresh", ""); err != nil {
+		t.Fatalf("codexWriteNativeConfig() error = %v", err)
+	}
+
+	authBytes, err := os.ReadFile(filepath.Join(home, ".codex", "auth.json"))
+	if err != nil {
+		t.Fatalf("read auth.json: %v", err)
+	}
+	var auth map[string]any
+	if err := sonic.Unmarshal(authBytes, &auth); err != nil {
+		t.Fatalf("unmarshal auth.json: %v", err)
+	}
+	if got, _ := auth["OPENAI_API_KEY"].(string); got != "sk-bf-fresh" {
+		t.Fatalf("auth.OPENAI_API_KEY = %q", got)
+	}
+
+	tomlBytes, err := os.ReadFile(filepath.Join(home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	got := string(tomlBytes)
+	for _, want := range []string{
+		`openai_base_url = "http://localhost:8080/openai/v1"`,
+		`env_key = "OPENAI_API_KEY"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected config.toml to contain %q, got:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, `model =`) {
+		t.Fatalf("did not expect model line when model is empty, got:\n%s", got)
+	}
+}
+
+func TestCodexWriteNativeConfigSkipsAuthForDummyKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if err := codexWriteNativeConfig("http://localhost:8080/openai/v1", "dummy-key", ""); err != nil {
+		t.Fatalf("codexWriteNativeConfig() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, ".codex", "auth.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected no auth.json for dummy key, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "config.toml")); err != nil {
+		t.Fatalf("expected config.toml to still be written, stat err=%v", err)
+	}
+}
+
+func TestSetTopLevelTOMLKeysAppendsBeforeFirstTable(t *testing.T) {
+	t.Parallel()
+
+	input := []byte(`# header comment
+model_reasoning_effort = "medium"
+
+[projects."x"]
+trust_level = "trusted"
+`)
+	out := string(setTopLevelTOMLKeys(input, map[string]string{
+		"openai_base_url": "http://localhost:8080/openai/v1",
+		"env_key":         "OPENAI_API_KEY",
+		"model":           "gpt-5.5",
+	}))
+
+	preTable, _, ok := strings.Cut(out, `[projects."x"]`)
+	if !ok {
+		t.Fatalf("expected [projects.\"x\"] header preserved, got:\n%s", out)
+	}
+	for _, want := range []string{
+		`# header comment`,
+		`model_reasoning_effort = "medium"`,
+		`openai_base_url = "http://localhost:8080/openai/v1"`,
+		`env_key = "OPENAI_API_KEY"`,
+		`model = "gpt-5.5"`,
+	} {
+		if !strings.Contains(preTable, want) {
+			t.Fatalf("expected pre-table section to contain %q, got:\n%s", want, preTable)
+		}
+	}
+	if !strings.Contains(out, `trust_level = "trusted"`) {
+		t.Fatalf("expected table body preserved, got:\n%s", out)
+	}
+}
+
 func envValue(env []string, key string) string {
 	prefix := key + "="
 	for _, entry := range env {

--- a/cli/internal/harness/native_config.go
+++ b/cli/internal/harness/native_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -95,4 +96,237 @@ func claudeTierModelEnvMap(model string) map[string]string {
 		"ANTHROPIC_DEFAULT_OPUS_MODEL":   model,
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL":  model,
 	}
+}
+
+// codexPreLaunch persists the bifrost endpoint and virtual key into Codex
+// CLI's native config files. Codex resolves its credentials from
+// ~/.codex/auth.json (which takes precedence over OPENAI_API_KEY in the
+// process env) and its endpoint from ~/.codex/config.toml, so a stale
+// auth.json from a prior run will otherwise shadow whatever Bifrost passes
+// via env vars. Returns no extra env (BuildEnv already exports the key) and
+// no cleanup — the writes are intentionally persistent so direct `codex`
+// launches outside Bifrost keep working too.
+func codexPreLaunch(baseURL, apiKey, model string) ([]string, func(), error) {
+	if err := codexWriteNativeConfig(baseURL, apiKey, model); err != nil {
+		return nil, nil, err
+	}
+	return nil, func() {}, nil
+}
+
+// codexWriteNativeConfig writes the bifrost endpoint, API key, and model
+// into Codex CLI's config files (~/.codex/auth.json and
+// ~/.codex/config.toml) so the same configuration is available when users
+// launch Codex directly.
+//
+// It merges into the existing files, preserving any user-defined settings.
+func codexWriteNativeConfig(baseURL, apiKey, model string) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve home dir: %w", err)
+	}
+
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create codex config dir: %w", err)
+	}
+
+	if apiKey = strings.TrimSpace(apiKey); apiKey != "" && apiKey != "dummy-key" {
+		if err := codexWriteAuth(filepath.Join(dir, "auth.json"), apiKey); err != nil {
+			return err
+		}
+	}
+	return codexWriteConfigTOML(filepath.Join(dir, "config.toml"), baseURL, model)
+}
+
+// codexWriteAuth merges the bifrost virtual key into Codex's auth.json,
+// preserving any other fields the user (or Codex itself) may have written.
+func codexWriteAuth(path, apiKey string) error {
+	auth := make(map[string]any)
+	if b, err := os.ReadFile(path); err == nil {
+		if err := sonic.Unmarshal(b, &auth); err != nil {
+			// Unparseable auth.json — overwrite rather than fail the launch,
+			// since the user can't easily recover from a corrupt file.
+			auth = make(map[string]any)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read codex auth: %w", err)
+	}
+
+	auth["auth_mode"] = "apikey"
+	auth["OPENAI_API_KEY"] = apiKey
+
+	b, err := sonic.MarshalIndent(auth, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal codex auth: %w", err)
+	}
+	return config.WriteAtomic(path, b, 0o600)
+}
+
+// codexWriteConfigTOML merges Bifrost's endpoint and (optionally) model into
+// the top-level section of Codex's config.toml. Existing top-level keys
+// (e.g. model_reasoning_effort) and tables (e.g. [projects.*], [tui.*]) are
+// preserved verbatim, including comments and ordering.
+func codexWriteConfigTOML(path, baseURL, model string) error {
+	var existing []byte
+	if b, err := os.ReadFile(path); err == nil {
+		existing = b
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read codex config: %w", err)
+	}
+
+	targets := map[string]string{
+		"openai_base_url": baseURL,
+		"env_key":         "OPENAI_API_KEY",
+	}
+	if m := strings.TrimSpace(model); m != "" {
+		targets["model"] = m
+	}
+
+	return config.WriteAtomic(path, setTopLevelTOMLKeys(existing, targets), 0o600)
+}
+
+// setTopLevelTOMLKeys returns data with each key in targets set to its
+// target value in the top-level section (above any [table] header). Keys
+// that already exist in the top-level section are replaced in place; keys
+// that don't are appended just before the first table header (or at EOF if
+// none). Everything else — table contents, comments, blank lines, ordering
+// — is preserved as-is.
+func setTopLevelTOMLKeys(data []byte, targets map[string]string) []byte {
+	if len(targets) == 0 {
+		return data
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		keys := make([]string, 0, len(targets))
+		for k := range targets {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var b strings.Builder
+		for _, k := range keys {
+			b.WriteString(k)
+			b.WriteString(" = ")
+			b.WriteString(tomlQuote(targets[k]))
+			b.WriteByte('\n')
+		}
+		return []byte(b.String())
+	}
+
+	hasTrailingNewline := strings.HasSuffix(string(data), "\n")
+	lines := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+
+	seen := make(map[string]bool, len(targets))
+	out := make([]string, 0, len(lines)+len(targets))
+	firstTableIdx := -1
+
+	for _, raw := range lines {
+		if firstTableIdx < 0 && isTOMLTableHeader(raw) {
+			firstTableIdx = len(out)
+		}
+		if firstTableIdx < 0 {
+			if key, ok := matchTopLevelTOMLKey(raw, targets); ok {
+				if seen[key] {
+					// Drop duplicate top-level definitions.
+					continue
+				}
+				out = append(out, key+" = "+tomlQuote(targets[key]))
+				seen[key] = true
+				continue
+			}
+		}
+		out = append(out, raw)
+	}
+
+	missing := make([]string, 0, len(targets))
+	for k := range targets {
+		if !seen[k] {
+			missing = append(missing, k+" = "+tomlQuote(targets[k]))
+		}
+	}
+	sort.Strings(missing)
+
+	if len(missing) > 0 {
+		if firstTableIdx < 0 {
+			for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
+				out = out[:len(out)-1]
+			}
+			out = append(out, missing...)
+		} else {
+			head := out[:firstTableIdx]
+			tail := append([]string{}, out[firstTableIdx:]...)
+			for len(head) > 0 && strings.TrimSpace(head[len(head)-1]) == "" {
+				head = head[:len(head)-1]
+			}
+			head = append(head, missing...)
+			head = append(head, "")
+			out = append(head, tail...)
+		}
+	}
+
+	result := strings.Join(out, "\n")
+	if hasTrailingNewline || len(missing) > 0 {
+		result += "\n"
+	}
+	return []byte(result)
+}
+
+// isTOMLTableHeader reports whether a line is a [table] or [[array]] header,
+// optionally followed by an inline comment.
+func isTOMLTableHeader(line string) bool {
+	t := strings.TrimSpace(line)
+	if !strings.HasPrefix(t, "[") {
+		return false
+	}
+	idx := strings.LastIndex(t, "]")
+	if idx < 0 {
+		return false
+	}
+	rest := strings.TrimSpace(t[idx+1:])
+	return rest == "" || strings.HasPrefix(rest, "#")
+}
+
+// matchTopLevelTOMLKey returns the target key name if line is a simple
+// `key = ...` assignment whose key appears in targets.
+func matchTopLevelTOMLKey(line string, targets map[string]string) (string, bool) {
+	t := strings.TrimSpace(line)
+	if t == "" || strings.HasPrefix(t, "#") {
+		return "", false
+	}
+	head, _, ok := strings.Cut(t, "=")
+	if !ok {
+		return "", false
+	}
+	name := strings.TrimSpace(head)
+	if _, ok := targets[name]; ok {
+		return name, true
+	}
+	return "", false
+}
+
+// tomlQuote returns a TOML basic string literal for s.
+func tomlQuote(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				fmt.Fprintf(&b, `\u%04x`, r)
+			} else {
+				b.WriteRune(r)
+			}
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
 }

--- a/cli/internal/runtime/scrollback.go
+++ b/cli/internal/runtime/scrollback.go
@@ -1,0 +1,237 @@
+package runtime
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/maximhq/vt10x"
+)
+
+// defaultScrollbackCap is the per-tab maximum number of rows retained in
+// scrollback. At 200 cols and ~16 B/glyph this caps memory at ~16 MB/tab.
+const defaultScrollbackCap = 5000
+
+// scrollback is a fixed-capacity, append-only ring of evicted VT rows that
+// powers the tab manager's scroll-mode history view. It's fed by
+// vt10x.WithOnScrollUp and read by the renderer when the user enters
+// scroll mode.
+//
+// Consecutive identical rows are deduplicated. This is a cheap heuristic
+// to absorb cases where a TUI emits a run of blank-line LFs at the bottom
+// of the screen (e.g. clearing trailing rows by scrolling them off), which
+// would otherwise produce many useless blank rows in history.
+type scrollback struct {
+	mu   sync.Mutex
+	rows [][]vt10x.Glyph // newest at the tail
+	cap  int
+}
+
+func newScrollback(capRows int) *scrollback {
+	if capRows <= 0 {
+		capRows = defaultScrollbackCap
+	}
+	return &scrollback{
+		rows: make([][]vt10x.Glyph, 0, capRows),
+		cap:  capRows,
+	}
+}
+
+// push appends the given rows to the ring, dropping the oldest entries
+// when the cap is exceeded. Each row is appended by reference; vt10x's
+// WithOnScrollUp already hands us defensive copies, so we don't copy
+// again. Consecutive blank rows are deduplicated so trailing blank-line
+// LFs from TUIs don't bloat history; non-blank repeats are preserved
+// because they often represent real user-visible output.
+func (s *scrollback) push(rows [][]vt10x.Glyph, _ bool) {
+	if len(rows) == 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, row := range rows {
+		if len(s.rows) > 0 &&
+			isBlankRow(s.rows[len(s.rows)-1]) &&
+			isBlankRow(row) &&
+			rowsEqual(s.rows[len(s.rows)-1], row) {
+			continue
+		}
+		if len(s.rows) >= s.cap {
+			// Drop oldest via O(n) slice shift; acceptable because the cap
+			// is bounded at ~5000 rows and terminal scroll rates are low.
+			copy(s.rows, s.rows[1:])
+			s.rows = s.rows[:len(s.rows)-1]
+		}
+		s.rows = append(s.rows, row)
+	}
+}
+
+// length returns the number of rows currently in scrollback.
+func (s *scrollback) length() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.rows)
+}
+
+// snapshotTail returns the last n rows in top-to-bottom order, or all rows
+// if there are fewer than n. The returned slice is a fresh shallow copy
+// safe to read without holding the scrollback lock.
+func (s *scrollback) snapshotTail(n int) [][]vt10x.Glyph {
+	if n <= 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.rows) == 0 {
+		return nil
+	}
+	if n > len(s.rows) {
+		n = len(s.rows)
+	}
+	out := make([][]vt10x.Glyph, n)
+	copy(out, s.rows[len(s.rows)-n:])
+	return out
+}
+
+// isBlankRow reports whether every cell in row is whitespace (NUL or space).
+// Used to gate dedup so we only drop runs of empty rows, not legitimately
+// repeated output.
+func isBlankRow(row []vt10x.Glyph) bool {
+	for _, g := range row {
+		if g.Char != 0 && g.Char != ' ' {
+			return false
+		}
+	}
+	return true
+}
+
+// rowsEqual returns true if two glyph rows have identical content,
+// attributes, and colors. Cheap O(cols) compare used for dedup.
+func rowsEqual(a, b []vt10x.Glyph) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// composeScrollbackView renders the active scroll-mode view into ANSI
+// bytes. The visible window of contentRows is taken from the virtual
+// stream (scrollback ++ liveRows), positioned so that offset == 0 shows
+// the live grid at the bottom and offset > 0 shifts the window upward by
+// that many lines.
+//
+// liveRows is the current vt10x grid snapshot (one glyph row per terminal
+// row). scrollLen is the current scrollback length; we don't take rows
+// from the scrollback directly to keep this function lock-free — callers
+// pass a pre-snapped scrollback tail in sbRows.
+//
+// The window is clamped so it never positions above the top of
+// scrollback. Rows that would fall above the available stream are emitted
+// as blank.
+func composeScrollbackView(sbRows [][]vt10x.Glyph, liveRows [][]vt10x.Glyph, cols, contentRows, offset int) string {
+	totalAvail := len(sbRows) + len(liveRows)
+	maxOffset := totalAvail - contentRows
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+	if offset > maxOffset {
+		offset = maxOffset
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	bottomIdx := totalAvail - offset    // exclusive
+	topIdx := bottomIdx - contentRows   // can be negative
+	padTop := 0
+	if topIdx < 0 {
+		padTop = -topIdx
+		topIdx = 0
+	}
+
+	var b strings.Builder
+	b.Grow(cols * contentRows * 3)
+
+	for y := 0; y < contentRows; y++ {
+		if y > 0 {
+			b.WriteString("\x1b[0m\r\n")
+		}
+		if y < padTop {
+			writeBlankRow(&b, cols)
+			continue
+		}
+		idx := topIdx + (y - padTop)
+		var row []vt10x.Glyph
+		if idx < len(sbRows) {
+			row = sbRows[idx]
+		} else {
+			row = liveRows[idx-len(sbRows)]
+		}
+		writeRowGlyphs(&b, row, cols)
+	}
+	b.WriteString("\x1b[0m")
+	return b.String()
+}
+
+// snapshotLiveGrid extracts the current vt10x grid into a glyph matrix
+// suitable for feeding composeScrollbackView. Caller must hold vt.Lock().
+func snapshotLiveGrid(vt vt10x.View, cols, rows int) [][]vt10x.Glyph {
+	vtCols, vtRows := vt.Size()
+	out := make([][]vt10x.Glyph, rows)
+	for y := 0; y < rows; y++ {
+		rowWidth := cols
+		if vtCols < rowWidth {
+			rowWidth = vtCols
+		}
+		var row []vt10x.Glyph
+		if y < vtRows && rowWidth > 0 {
+			row = make([]vt10x.Glyph, rowWidth)
+			for x := 0; x < rowWidth; x++ {
+				row[x] = vt.Cell(x, y)
+			}
+		}
+		out[y] = row
+	}
+	return out
+}
+
+// writeRowGlyphs emits one row of glyphs with style-diffed SGR sequences,
+// padding to cols with default-style spaces when the row is shorter.
+func writeRowGlyphs(b *strings.Builder, row []vt10x.Glyph, cols int) {
+	var prevFG, prevBG vt10x.Color
+	var prevMode int16
+	firstCell := true
+	for x := 0; x < cols; x++ {
+		if x < len(row) {
+			g := row[x]
+			if firstCell || g.FG != prevFG || g.BG != prevBG || g.Mode != prevMode {
+				writeStyleSequence(b, g)
+				prevFG, prevBG, prevMode = g.FG, g.BG, g.Mode
+				firstCell = false
+			}
+			ch := g.Char
+			if ch == 0 {
+				ch = ' '
+			}
+			b.WriteRune(ch)
+		} else {
+			if firstCell || prevFG != vt10x.DefaultFG || prevBG != vt10x.DefaultBG || prevMode != 0 {
+				b.WriteString("\x1b[0m")
+				prevFG, prevBG, prevMode = vt10x.DefaultFG, vt10x.DefaultBG, 0
+				firstCell = false
+			}
+			b.WriteByte(' ')
+		}
+	}
+}
+
+func writeBlankRow(b *strings.Builder, cols int) {
+	b.WriteString("\x1b[0m")
+	for x := 0; x < cols; x++ {
+		b.WriteByte(' ')
+	}
+}

--- a/cli/internal/runtime/scrollback_test.go
+++ b/cli/internal/runtime/scrollback_test.go
@@ -1,0 +1,117 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maximhq/vt10x"
+)
+
+// glyphRow is a tiny helper to build a row of glyphs with default style
+// from a string. Used by tests below.
+func glyphRow(s string, cols int) []vt10x.Glyph {
+	row := make([]vt10x.Glyph, cols)
+	for i, r := range s {
+		if i >= cols {
+			break
+		}
+		row[i] = vt10x.Glyph{Char: r, FG: vt10x.DefaultFG, BG: vt10x.DefaultBG}
+	}
+	for i := len([]rune(s)); i < cols; i++ {
+		row[i] = vt10x.Glyph{Char: ' ', FG: vt10x.DefaultFG, BG: vt10x.DefaultBG}
+	}
+	return row
+}
+
+func TestScrollbackPushDedupsConsecutiveBlankRows(t *testing.T) {
+	sb := newScrollback(10)
+	blank := glyphRow("", 5)
+	sb.push([][]vt10x.Glyph{blank}, false)
+	sb.push([][]vt10x.Glyph{blank}, false)
+	sb.push([][]vt10x.Glyph{blank}, false)
+
+	if got := sb.length(); got != 1 {
+		t.Fatalf("expected blank-row dedup to collapse to 1, got %d", got)
+	}
+}
+
+func TestScrollbackPushKeepsConsecutiveNonBlankRepeats(t *testing.T) {
+	sb := newScrollback(10)
+	row := glyphRow("hello", 5)
+	sb.push([][]vt10x.Glyph{row}, false)
+	sb.push([][]vt10x.Glyph{row}, false)
+	sb.push([][]vt10x.Glyph{row}, false)
+
+	if got := sb.length(); got != 3 {
+		t.Fatalf("expected non-blank repeats to be preserved, got %d", got)
+	}
+}
+
+func TestScrollbackPushKeepsDistinctRowsAndEvictsAtCap(t *testing.T) {
+	sb := newScrollback(3)
+	for i := 0; i < 5; i++ {
+		row := glyphRow(string(rune('a'+i)), 1)
+		sb.push([][]vt10x.Glyph{row}, false)
+	}
+
+	if got := sb.length(); got != 3 {
+		t.Fatalf("expected cap=3 to hold 3 rows, got %d", got)
+	}
+
+	tail := sb.snapshotTail(3)
+	want := []rune{'c', 'd', 'e'}
+	for i, r := range want {
+		if tail[i][0].Char != r {
+			t.Fatalf("tail[%d] = %q, want %q", i, tail[i][0].Char, r)
+		}
+	}
+}
+
+func TestSnapshotTailReturnsAllRowsWhenNExceedsLength(t *testing.T) {
+	sb := newScrollback(10)
+	for i := 0; i < 3; i++ {
+		sb.push([][]vt10x.Glyph{glyphRow(string(rune('x'+i)), 1)}, false)
+	}
+	tail := sb.snapshotTail(100)
+	if len(tail) != 3 {
+		t.Fatalf("expected all 3 rows back, got %d", len(tail))
+	}
+}
+
+func TestComposeScrollbackViewClampsAndPositionsWindow(t *testing.T) {
+	sb := [][]vt10x.Glyph{
+		glyphRow("OLD-1", 5),
+		glyphRow("OLD-2", 5),
+		glyphRow("OLD-3", 5),
+		glyphRow("OLD-4", 5),
+	}
+	live := [][]vt10x.Glyph{
+		glyphRow("LIVE1", 5),
+		glyphRow("LIVE2", 5),
+	}
+
+	// offset = 0 -> bottom of stream visible: last 3 rows = OLD-4, LIVE1, LIVE2
+	got := composeScrollbackView(sb, live, 5, 3, 0)
+	if !strings.Contains(got, "OLD-4") || !strings.Contains(got, "LIVE1") || !strings.Contains(got, "LIVE2") {
+		t.Fatalf("offset=0 expected to show OLD-4/LIVE1/LIVE2, got: %q", got)
+	}
+	if strings.Contains(got, "OLD-1") || strings.Contains(got, "OLD-2") {
+		t.Fatalf("offset=0 should not show OLD-1/OLD-2, got: %q", got)
+	}
+
+	// offset = 2 -> window shifted 2 up: OLD-2, OLD-3, OLD-4
+	got = composeScrollbackView(sb, live, 5, 3, 2)
+	if !strings.Contains(got, "OLD-2") || !strings.Contains(got, "OLD-3") || !strings.Contains(got, "OLD-4") {
+		t.Fatalf("offset=2 expected OLD-2/OLD-3/OLD-4, got: %q", got)
+	}
+	if strings.Contains(got, "LIVE1") {
+		t.Fatalf("offset=2 should not show LIVE1, got: %q", got)
+	}
+
+	// offset > maxOffset (4 scrollback rows + 2 live - 3 view = 3) should
+	// clamp at 3 -> top of scrollback visible plus one row pad above.
+	got = composeScrollbackView(sb, live, 5, 3, 100)
+	if !strings.Contains(got, "OLD-1") {
+		t.Fatalf("offset=clamped expected OLD-1 visible, got: %q", got)
+	}
+}

--- a/cli/internal/runtime/tabmgr.go
+++ b/cli/internal/runtime/tabmgr.go
@@ -64,6 +64,7 @@ type Tab struct {
 	prevScreenChange time.Time
 	lastUserInputAt  atomic.Int64
 	bellState        belParserState
+	sb               *scrollback // history of evicted VT rows; fed by vt10x.WithOnScrollUp
 }
 
 type mouseEvent struct {
@@ -105,6 +106,8 @@ type TabManager struct {
 	cols         uint16
 	paused       bool // true while chooser overlay is active
 	commandMode  bool // true while the tab-mode overlay owns the terminal
+	scrollMode   bool // true while the active tab's scrollback view is frozen for browsing
+	scrollOffset int  // lines scrolled up from the bottom of the (scrollback ++ live grid) stream
 	needsRender  bool // set by readPTY/switchTab/resize, cleared by renderFrame
 	lastCtrlCAt  time.Time
 	hostVTMode   vt10x.ModeFlag
@@ -312,11 +315,13 @@ func (tm *TabManager) createTab(ctx context.Context, spec LaunchSpec) (*Tab, err
 		cmd:       p,
 		done:      make(chan struct{}),
 		startedAt: time.Now(),
-		vt: vt10x.New(
-			vt10x.WithWriter(ptmx),
-			vt10x.WithSize(int(cols), int(contentRows)),
-		),
+		sb:        newScrollback(defaultScrollbackCap),
 	}
+	tab.vt = vt10x.New(
+		vt10x.WithWriter(ptmx),
+		vt10x.WithSize(int(cols), int(contentRows)),
+		vt10x.WithOnScrollUp(tab.sb.push),
+	)
 	tab.cursorVisible.Store(true)
 	tm.nextID++
 
@@ -537,6 +542,11 @@ func (tm *TabManager) inputLoop(ctx context.Context, newTabFn NewTabFunc, termSt
 			pending = pending[consumed:]
 
 			if isTerminalResponse(token) {
+				continue
+			}
+
+			if tm.isScrollMode() {
+				tm.handleScrollKey(token)
 				continue
 			}
 
@@ -1060,6 +1070,146 @@ func (tm *TabManager) isCommandMode() bool {
 	return tm.commandMode
 }
 
+func (tm *TabManager) isScrollMode() bool {
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	return tm.scrollMode
+}
+
+// enterScrollMode freezes the active tab's view at the current frame and
+// switches input handling into scrollback browsing. Caller should not
+// already hold tm.mu.
+func (tm *TabManager) enterScrollMode() {
+	tm.mu.Lock()
+	if len(tm.tabs) == 0 || tm.activeIdx >= len(tm.tabs) {
+		tm.mu.Unlock()
+		return
+	}
+	tm.commandMode = false
+	tm.scrollMode = true
+	tm.scrollOffset = 0
+	tm.needsRender = true
+	tm.mu.Unlock()
+}
+
+// exitScrollMode returns to live-follow rendering of the active tab.
+func (tm *TabManager) exitScrollMode() {
+	tm.mu.Lock()
+	tm.scrollMode = false
+	tm.scrollOffset = 0
+	tm.needsRender = true
+	tm.mu.Unlock()
+}
+
+// adjustScrollOffset shifts the scrollback view by delta lines (positive =
+// scroll up into history, negative = scroll back toward live). Clamps to
+// the valid range and exits scroll mode when the user reaches the bottom
+// by scrolling down. Caller should not already hold tm.mu.
+func (tm *TabManager) adjustScrollOffset(delta int) {
+	tm.mu.Lock()
+	if !tm.scrollMode || tm.activeIdx >= len(tm.tabs) {
+		tm.mu.Unlock()
+		return
+	}
+	tab := tm.tabs[tm.activeIdx]
+	tm.mu.Unlock()
+
+	sbLen := 0
+	if tab.sb != nil {
+		sbLen = tab.sb.length()
+	}
+	maxOffset := sbLen // can scroll up until the top of scrollback reaches the top of the view
+	if maxOffset < 0 {
+		maxOffset = 0
+	}
+
+	tm.mu.Lock()
+	newOffset := tm.scrollOffset + delta
+	if newOffset <= 0 {
+		// Scrolled down past live — exit scroll mode entirely.
+		tm.scrollMode = false
+		tm.scrollOffset = 0
+	} else {
+		if newOffset > maxOffset {
+			newOffset = maxOffset
+		}
+		tm.scrollOffset = newOffset
+	}
+	tm.needsRender = true
+	tm.mu.Unlock()
+}
+
+// handleScrollKey dispatches a token while in scroll mode. Returns true
+// when the token was consumed (i.e. not to be forwarded). Any unknown key
+// exits scroll mode without consuming further input.
+func (tm *TabManager) handleScrollKey(token []byte) bool {
+	if len(token) == 0 {
+		return true
+	}
+
+	tm.mu.Lock()
+	contentRows := int(tm.rows) - 1
+	tm.mu.Unlock()
+	if contentRows < 1 {
+		contentRows = 1
+	}
+	page := contentRows - 1
+	if page < 1 {
+		page = 1
+	}
+
+	// Single-byte tokens.
+	if len(token) == 1 {
+		switch token[0] {
+		case 'q', 0x1b, '\r', '\n':
+			tm.exitScrollMode()
+			return true
+		case 'k':
+			tm.adjustScrollOffset(1)
+			return true
+		case 'j':
+			tm.adjustScrollOffset(-1)
+			return true
+		case 'b', 0x15: // Ctrl+U
+			tm.adjustScrollOffset(page)
+			return true
+		case ' ', 0x04: // Ctrl+D
+			tm.adjustScrollOffset(-page)
+			return true
+		case 'g':
+			tm.adjustScrollOffset(1 << 30)
+			return true
+		case 'G':
+			tm.exitScrollMode()
+			return true
+		}
+		return true // swallow anything else while in scroll mode
+	}
+
+	// Multi-byte CSI tokens.
+	switch string(token) {
+	case "\x1b[A": // Up arrow
+		tm.adjustScrollOffset(1)
+		return true
+	case "\x1b[B": // Down arrow
+		tm.adjustScrollOffset(-1)
+		return true
+	case "\x1b[5~": // PageUp
+		tm.adjustScrollOffset(page)
+		return true
+	case "\x1b[6~": // PageDown
+		tm.adjustScrollOffset(-page)
+		return true
+	case "\x1b[H", "\x1b[1~": // Home
+		tm.adjustScrollOffset(1 << 30)
+		return true
+	case "\x1b[F", "\x1b[4~": // End
+		tm.exitScrollMode()
+		return true
+	}
+	return true
+}
+
 func (tm *TabManager) shouldExitWithoutTabs() bool {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
@@ -1199,6 +1349,8 @@ func (tm *TabManager) handleCommandKey(ctx context.Context, newTabFn NewTabFunc,
 			return ErrUpdateRequested
 		}
 		tm.emitNotice(TabNoticeInfo, "already up to date")
+	case b == '[':
+		tm.enterScrollMode()
 	}
 	return nil
 }
@@ -1785,12 +1937,29 @@ func (tm *TabManager) renderFrame() {
 	// intended cursor location (after CUP + \x1b[?25h). We'll use this
 	// saved position for rendering even when a subsequent hide+content
 	// write has moved the live cursor to end-of-content.
+	scrollMode := tm.isScrollMode()
+	tm.mu.Lock()
+	scrollOffset := tm.scrollOffset
+	tm.mu.Unlock()
+
 	tab.vt.Lock()
-	screenContent := renderVTScreen(tab.vt, cols, contentRows)
+	var screenContent string
+	var liveGridSnap [][]vt10x.Glyph
+	if scrollMode {
+		liveGridSnap = snapshotLiveGrid(tab.vt, cols, contentRows)
+	} else {
+		screenContent = renderVTScreen(tab.vt, cols, contentRows)
+	}
 	cursor := tab.vt.Cursor()
 	vtCursorVisible := tab.vt.CursorVisible()
 	vtMode := tab.vt.Mode()
 	tab.vt.Unlock()
+
+	if scrollMode {
+		sbTail := tab.sb.snapshotTail(scrollOffset + contentRows)
+		screenContent = composeScrollbackView(sbTail, liveGridSnap, cols, contentRows, scrollOffset)
+		vtCursorVisible = false
+	}
 
 	curX, curY, showCursor := resolveRenderCursor(
 		tab,
@@ -2090,6 +2259,8 @@ func (tm *TabManager) buildTabBarString() string {
 	active := tm.activeIdx
 	cols := int(tm.cols)
 	cmdMode := tm.commandMode
+	scrollMode := tm.scrollMode
+	scrollOffset := tm.scrollOffset
 	noticeText := tm.noticeText
 	noticeLevel := tm.noticeLevel
 	tm.mu.Unlock()
@@ -2151,8 +2322,14 @@ func (tm *TabManager) buildTabBarString() string {
 		} else {
 			hint = " " + noticeText + " "
 		}
+	} else if scrollMode {
+		sbLen := 0
+		if active < len(tabs) && tabs[active] != nil && tabs[active].sb != nil {
+			sbLen = tabs[active].sb.length()
+		}
+		hint = fmt.Sprintf(" SCROLL -%d/%d  j/k PgUp/PgDn g  q:exit ", scrollOffset, sbLen)
 	} else if cmdMode {
-		hint = " n:new e:edit session x:close h/l:move 1-9:jump"
+		hint = " n:new e:edit session x:close h/l:move 1-9:jump [:scroll"
 		if tm.updateVersion != "" {
 			hint += " u:update"
 		}


### PR DESCRIPTION
## Summary

Adds a scrollback history buffer to the terminal tab manager, allowing users to freeze the active tab's view and browse previously scrolled-off output without leaving the session.

## Changes

- Introduced a `scrollback` ring buffer (`scrollback.go`) that captures VT rows evicted from the terminal via `vt10x.WithOnScrollUp`. The buffer is capped at 5,000 rows per tab and deduplicates consecutive identical rows to avoid accumulating runs of blank lines emitted by TUIs during screen clears.
- Added `composeScrollbackView` to render a scrollable window over the combined `scrollback ++ live grid` stream into ANSI bytes, with correct offset clamping and blank-row padding when the window extends above available history.
- Added `snapshotLiveGrid` to capture the current vt10x grid into a glyph matrix while holding the VT lock, keeping the compose function lock-free.
- Each `Tab` now owns a `*scrollback` instance wired to its VT emulator at creation time.
- `TabManager` gains `scrollMode` and `scrollOffset` state. Entering scroll mode (`[` in command mode) freezes rendering to the scrollback view; exiting (`q`, `Esc`, `Enter`, `G`, End key, or scrolling past the bottom) returns to live-follow rendering.
- `handleScrollKey` dispatches vi-style (`j`/`k`/`b`/`Space`/`g`/`G`) and arrow/page key bindings while in scroll mode.
- The tab bar hint updates to show `SCROLL -<offset>/<sbLen>` with key hints when in scroll mode, and the command-mode hint now includes `[:scroll`.
- The cursor is hidden while in scroll mode.
- Added unit tests covering deduplication, cap eviction, snapshot behavior, and window positioning/clamping in `composeScrollbackView`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./cli/internal/runtime/...
```

To validate interactively:
1. Start a session with a tab running a command that produces scrollable output (e.g. `cat /var/log/syslog` or a long-running build).
2. Press the command prefix key followed by `[` to enter scroll mode.
3. Use `j`/`k`, arrow keys, `PgUp`/`PgDn`, `g` (top), and `G`/`q` (exit) to navigate history.
4. Confirm the tab bar shows `SCROLL -<offset>/<total>` and the cursor is hidden.
5. Scroll past the bottom or press `q` to confirm live rendering resumes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. Scrollback data is held in process memory only, subject to the per-tab 5,000-row cap (~16 MB/tab at 200 columns).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable