### PR TITLE
feat: adds mouse scrolling and fixes window resizing

### DIFF
--- a/cli/internal/runtime/scrollback.go
+++ b/cli/internal/runtime/scrollback.go
@@ -16,10 +16,10 @@ const defaultScrollbackCap = 5000
 // vt10x.WithOnScrollUp and read by the renderer when the user enters
 // scroll mode.
 //
-// Consecutive identical rows are deduplicated. This is a cheap heuristic
-// to absorb cases where a TUI emits a run of blank-line LFs at the bottom
-// of the screen (e.g. clearing trailing rows by scrolling them off), which
-// would otherwise produce many useless blank rows in history.
+// Consecutive blank rows are deduplicated so a TUI emitting a run of
+// blank-line LFs at the bottom of the screen (e.g. clearing trailing
+// rows by scrolling them off) doesn't bloat history. Non-blank repeats
+// are kept as-is because they often represent real user-visible output.
 type scrollback struct {
 	mu   sync.Mutex
 	rows [][]vt10x.Glyph // newest at the tail
@@ -41,13 +41,16 @@ func newScrollback(capRows int) *scrollback {
 // WithOnScrollUp already hands us defensive copies, so we don't copy
 // again. Consecutive blank rows are deduplicated so trailing blank-line
 // LFs from TUIs don't bloat history; non-blank repeats are preserved
-// because they often represent real user-visible output.
-func (s *scrollback) push(rows [][]vt10x.Glyph, _ bool) {
+// because they often represent real user-visible output. Returns the
+// number of rows actually added — the caller needs this to keep a
+// viewer's scroll position stable across evictions.
+func (s *scrollback) push(rows [][]vt10x.Glyph, _ bool) int {
 	if len(rows) == 0 {
-		return
+		return 0
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	added := 0
 	for _, row := range rows {
 		if len(s.rows) > 0 &&
 			isBlankRow(s.rows[len(s.rows)-1]) &&
@@ -62,7 +65,9 @@ func (s *scrollback) push(rows [][]vt10x.Glyph, _ bool) {
 			s.rows = s.rows[:len(s.rows)-1]
 		}
 		s.rows = append(s.rows, row)
+		added++
 	}
+	return added
 }
 
 // length returns the number of rows currently in scrollback.
@@ -145,8 +150,8 @@ func composeScrollbackView(sbRows [][]vt10x.Glyph, liveRows [][]vt10x.Glyph, col
 		offset = 0
 	}
 
-	bottomIdx := totalAvail - offset    // exclusive
-	topIdx := bottomIdx - contentRows   // can be negative
+	bottomIdx := totalAvail - offset  // exclusive
+	topIdx := bottomIdx - contentRows // can be negative
 	padTop := 0
 	if topIdx < 0 {
 		padTop = -topIdx
@@ -200,13 +205,32 @@ func snapshotLiveGrid(vt vt10x.View, cols, rows int) [][]vt10x.Glyph {
 }
 
 // writeRowGlyphs emits one row of glyphs with style-diffed SGR sequences,
-// padding to cols with default-style spaces when the row is shorter.
+// padding to cols with default-style spaces when the row is shorter than
+// the current display width, or truncating with a "…" indicator when
+// it's wider. Trailing default-style padding cells are stripped before
+// width comparison so resize-grow doesn't show absurd trailing whitespace
+// from when the original grid was narrower.
 func writeRowGlyphs(b *strings.Builder, row []vt10x.Glyph, cols int) {
+	effectiveLen := effectiveRowLen(row)
+
 	var prevFG, prevBG vt10x.Color
 	var prevMode int16
 	firstCell := true
+
+	// If the stored row is wider than the display, truncate at cols-1 and
+	// emit "…" so the user knows content was clipped by a resize-shrink.
+	truncate := effectiveLen > cols
+	contentEnd := effectiveLen
+	if truncate {
+		contentEnd = cols - 1
+		if contentEnd < 0 {
+			contentEnd = 0
+		}
+	}
+
 	for x := 0; x < cols; x++ {
-		if x < len(row) {
+		switch {
+		case x < contentEnd:
 			g := row[x]
 			if firstCell || g.FG != prevFG || g.BG != prevBG || g.Mode != prevMode {
 				writeStyleSequence(b, g)
@@ -218,7 +242,14 @@ func writeRowGlyphs(b *strings.Builder, row []vt10x.Glyph, cols int) {
 				ch = ' '
 			}
 			b.WriteRune(ch)
-		} else {
+		case truncate && x == cols-1:
+			if firstCell || prevFG != vt10x.DefaultFG || prevBG != vt10x.DefaultBG || prevMode != 0 {
+				b.WriteString("\x1b[0m\x1b[2m")
+				prevFG, prevBG, prevMode = vt10x.DefaultFG, vt10x.DefaultBG, 0
+				firstCell = false
+			}
+			b.WriteRune('…')
+		default:
 			if firstCell || prevFG != vt10x.DefaultFG || prevBG != vt10x.DefaultBG || prevMode != 0 {
 				b.WriteString("\x1b[0m")
 				prevFG, prevBG, prevMode = vt10x.DefaultFG, vt10x.DefaultBG, 0
@@ -227,6 +258,22 @@ func writeRowGlyphs(b *strings.Builder, row []vt10x.Glyph, cols int) {
 			b.WriteByte(' ')
 		}
 	}
+}
+
+// effectiveRowLen returns the row index just past the last cell that
+// carries visible content. A "padding" cell is one with the default fg/bg
+// and no attributes and either a NUL or space character — the state a
+// vt10x grid leaves untouched cells in.
+func effectiveRowLen(row []vt10x.Glyph) int {
+	for i := len(row) - 1; i >= 0; i-- {
+		g := row[i]
+		isPadChar := g.Char == 0 || g.Char == ' '
+		if isPadChar && g.FG == vt10x.DefaultFG && g.BG == vt10x.DefaultBG && g.Mode == 0 {
+			continue
+		}
+		return i + 1
+	}
+	return 0
 }
 
 func writeBlankRow(b *strings.Builder, cols int) {

--- a/cli/internal/runtime/scrollback_test.go
+++ b/cli/internal/runtime/scrollback_test.go
@@ -47,6 +47,147 @@ func TestScrollbackPushKeepsConsecutiveNonBlankRepeats(t *testing.T) {
 	}
 }
 
+func TestHandleWheelEventEntersScrollModeOnWheelUp(t *testing.T) {
+	tab := &Tab{sb: newScrollback(20)}
+	// Seed scrollback so the offset has somewhere to go.
+	for i := 0; i < 10; i++ {
+		tab.sb.push([][]vt10x.Glyph{glyphRow(string(rune('a'+i)), 1)}, false)
+	}
+	tm := &TabManager{
+		tabs:      []*Tab{tab},
+		activeIdx: 0,
+		rows:      24,
+		cols:      80,
+	}
+
+	consumed := tm.handleWheelEvent(mouseEvent{wheel: true, button: 0, press: true})
+	if !consumed {
+		t.Fatalf("wheel-up should be consumed by host scroll, got !consumed")
+	}
+	if !tm.scrollMode {
+		t.Fatalf("wheel-up should enter scroll mode")
+	}
+	if tm.scrollOffset != wheelLinesPerNotch {
+		t.Fatalf("wheel-up offset = %d, want %d", tm.scrollOffset, wheelLinesPerNotch)
+	}
+}
+
+func TestHandleWheelEventExitsScrollModeAtBottom(t *testing.T) {
+	tab := &Tab{sb: newScrollback(20)}
+	for i := 0; i < 5; i++ {
+		tab.sb.push([][]vt10x.Glyph{glyphRow(string(rune('a'+i)), 1)}, false)
+	}
+	tm := &TabManager{
+		tabs:         []*Tab{tab},
+		activeIdx:    0,
+		rows:         24,
+		cols:         80,
+		scrollMode:   true,
+		scrollOffset: 5, // > wheelLinesPerNotch so two notches are needed to exit
+	}
+
+	tm.handleWheelEvent(mouseEvent{wheel: true, button: 1, press: true})
+	if !tm.scrollMode {
+		t.Fatalf("after first wheel-down offset should still be > 0, got %d", tm.scrollOffset)
+	}
+	if tm.scrollOffset != 5-wheelLinesPerNotch {
+		t.Fatalf("after first wheel-down offset = %d, want %d", tm.scrollOffset, 5-wheelLinesPerNotch)
+	}
+	tm.handleWheelEvent(mouseEvent{wheel: true, button: 1, press: true})
+	if tm.scrollMode {
+		t.Fatalf("after reaching bottom, scroll mode should exit; offset=%d", tm.scrollOffset)
+	}
+}
+
+func TestHandleWheelEventIgnoresWheelDownWhenNotScrolling(t *testing.T) {
+	tab := &Tab{sb: newScrollback(20)}
+	tm := &TabManager{tabs: []*Tab{tab}, activeIdx: 0, rows: 24, cols: 80}
+
+	consumed := tm.handleWheelEvent(mouseEvent{wheel: true, button: 1, press: true})
+	if !consumed {
+		t.Fatalf("wheel-down outside scroll mode should be consumed (not forwarded)")
+	}
+	if tm.scrollMode {
+		t.Fatalf("wheel-down should never enter scroll mode")
+	}
+	if tm.scrollOffset != 0 {
+		t.Fatalf("wheel-down outside scroll mode should not move offset, got %d", tm.scrollOffset)
+	}
+}
+
+func TestHandleWheelEventIgnoresReleaseEvents(t *testing.T) {
+	tab := &Tab{sb: newScrollback(20)}
+	tm := &TabManager{tabs: []*Tab{tab}, activeIdx: 0, rows: 24, cols: 80}
+
+	// SGR mouse releases come with press=false. We still mark them as
+	// consumed (so the harness doesn't see them when host owns mouse),
+	// but they must not move the scroll offset.
+	tm.handleWheelEvent(mouseEvent{wheel: true, button: 0, press: false})
+	if tm.scrollMode || tm.scrollOffset != 0 {
+		t.Fatalf("wheel release moved state: scrollMode=%v offset=%d", tm.scrollMode, tm.scrollOffset)
+	}
+}
+
+func TestOnScrollbackGrowBumpsOffsetForActiveScrollingTab(t *testing.T) {
+	tab := &Tab{sb: newScrollback(20)}
+	other := &Tab{sb: newScrollback(20)}
+	// Pre-fill both scrollbacks so the active-tab bump isn't clipped by
+	// the sbLen clamp added in onScrollbackGrow.
+	for i := 0; i < 10; i++ {
+		tab.sb.push([][]vt10x.Glyph{glyphRow(string(rune('a'+i)), 1)}, false)
+		other.sb.push([][]vt10x.Glyph{glyphRow(string(rune('a'+i)), 1)}, false)
+	}
+	tm := &TabManager{
+		tabs:         []*Tab{tab, other},
+		activeIdx:    0,
+		scrollMode:   true,
+		scrollOffset: 5,
+		rows:         24,
+		cols:         80,
+	}
+
+	tm.onScrollbackGrow(tab, 3)
+	if tm.scrollOffset != 8 {
+		t.Fatalf("active scroll-mode tab: scrollOffset=%d, want 8", tm.scrollOffset)
+	}
+
+	// Eviction on a non-active tab must not move the offset.
+	tm.onScrollbackGrow(other, 10)
+	if tm.scrollOffset != 8 {
+		t.Fatalf("non-active tab evicted: scrollOffset=%d, want 8 unchanged", tm.scrollOffset)
+	}
+
+	// Not in scroll mode → no bump.
+	tm.scrollMode = false
+	tm.onScrollbackGrow(tab, 4)
+	if tm.scrollOffset != 8 {
+		t.Fatalf("scroll mode off: scrollOffset=%d, want 8 unchanged", tm.scrollOffset)
+	}
+}
+
+func TestOnScrollbackGrowClampsOffsetToScrollbackLength(t *testing.T) {
+	tab := &Tab{sb: newScrollback(20)}
+	// 3 rows in scrollback; an inflated scrollOffset+added must be
+	// clamped back to len so adjustScrollOffset doesn't have to unwind
+	// phantom scroll distance before exiting scroll mode.
+	for i := 0; i < 3; i++ {
+		tab.sb.push([][]vt10x.Glyph{glyphRow(string(rune('a'+i)), 1)}, false)
+	}
+	tm := &TabManager{
+		tabs:         []*Tab{tab},
+		activeIdx:    0,
+		scrollMode:   true,
+		scrollOffset: 2,
+		rows:         24,
+		cols:         80,
+	}
+
+	tm.onScrollbackGrow(tab, 5)
+	if tm.scrollOffset != 3 {
+		t.Fatalf("scrollOffset should be clamped to sbLen=3, got %d", tm.scrollOffset)
+	}
+}
+
 func TestScrollbackPushKeepsDistinctRowsAndEvictsAtCap(t *testing.T) {
 	sb := newScrollback(3)
 	for i := 0; i < 5; i++ {
@@ -75,6 +216,53 @@ func TestSnapshotTailReturnsAllRowsWhenNExceedsLength(t *testing.T) {
 	tail := sb.snapshotTail(100)
 	if len(tail) != 3 {
 		t.Fatalf("expected all 3 rows back, got %d", len(tail))
+	}
+}
+
+func TestWriteRowGlyphsTruncatesWithEllipsisOnShrink(t *testing.T) {
+	row := glyphRow("the quick brown fox", 19) // 19 visible cells
+	var b strings.Builder
+	writeRowGlyphs(&b, row, 10) // shrink to 10 cols
+	got := b.String()
+
+	if !strings.Contains(got, "…") {
+		t.Fatalf("expected ellipsis indicator when row > cols, got %q", got)
+	}
+	// First 9 chars of original content should still be present.
+	if !strings.Contains(got, "the quick") {
+		t.Fatalf("expected truncated row to start with %q, got %q", "the quick", got)
+	}
+	// "brown fox" should be clipped away.
+	if strings.Contains(got, "brown") {
+		t.Fatalf("expected clipped content to be removed, got %q", got)
+	}
+}
+
+func TestWriteRowGlyphsTrimsPaddingOnGrow(t *testing.T) {
+	// Build a 10-col row whose visible content is just "hi"; the other 8
+	// cells are default-style spaces (what vt10x leaves in unfilled cells).
+	row := glyphRow("hi", 10)
+	var b strings.Builder
+	writeRowGlyphs(&b, row, 40) // grow to 40 cols
+	got := b.String()
+
+	if !strings.Contains(got, "hi") {
+		t.Fatalf("expected content preserved on grow, got %q", got)
+	}
+	// No ellipsis indicator should appear on grow.
+	if strings.Contains(got, "…") {
+		t.Fatalf("did not expect ellipsis on grow, got %q", got)
+	}
+}
+
+func TestEffectiveRowLenIgnoresTrailingPadding(t *testing.T) {
+	row := glyphRow("ab", 20)
+	if got := effectiveRowLen(row); got != 2 {
+		t.Fatalf("effectiveRowLen with 2 chars + padding = %d, want 2", got)
+	}
+	empty := glyphRow("", 10)
+	if got := effectiveRowLen(empty); got != 0 {
+		t.Fatalf("effectiveRowLen on all-padding row = %d, want 0", got)
 	}
 }
 

--- a/cli/internal/runtime/tabmgr.go
+++ b/cli/internal/runtime/tabmgr.go
@@ -320,7 +320,12 @@ func (tm *TabManager) createTab(ctx context.Context, spec LaunchSpec) (*Tab, err
 	tab.vt = vt10x.New(
 		vt10x.WithWriter(ptmx),
 		vt10x.WithSize(int(cols), int(contentRows)),
-		vt10x.WithOnScrollUp(tab.sb.push),
+		vt10x.WithOnScrollUp(func(rows [][]vt10x.Glyph, altScreen bool) {
+			added := tab.sb.push(rows, altScreen)
+			if added > 0 {
+				tm.onScrollbackGrow(tab, added)
+			}
+		}),
 	)
 	tab.cursorVisible.Store(true)
 	tm.nextID++
@@ -545,6 +550,37 @@ func (tm *TabManager) inputLoop(ctx context.Context, newTabFn NewTabFunc, termSt
 				continue
 			}
 
+			// Mouse events must run before the scroll-mode catch-all so
+			// wheel notches reach handleWheelEvent instead of being
+			// swallowed by handleScrollKey as an unknown CSI sequence.
+			if ev, ok := parseMouseEvent(token); ok {
+				if tm.handleTabBarMouseEvent(ev) {
+					if tm.isScrollMode() {
+						tm.exitScrollMode()
+					}
+					continue
+				}
+				if ev.wheel && (tm.isScrollMode() || tm.hostOwnsMouse()) {
+					if tm.handleWheelEvent(ev) {
+						continue
+					}
+				}
+				if tm.isCommandMode() {
+					continue
+				}
+				if tm.isScrollMode() {
+					// Non-wheel mouse activity while browsing scrollback
+					// shouldn't reach the harness or jump the view.
+					continue
+				}
+				if tm.hostOwnsMouse() {
+					// Host enabled mouse capture for tab-bar/wheel use,
+					// but the harness never asked for it — don't forward
+					// stray click/motion bytes it isn't equipped to parse.
+					continue
+				}
+			}
+
 			if tm.isScrollMode() {
 				tm.handleScrollKey(token)
 				continue
@@ -577,15 +613,6 @@ func (tm *TabManager) inputLoop(ctx context.Context, newTabFn NewTabFunc, termSt
 				}
 				tm.cycleTab()
 				continue
-			}
-
-			if ev, ok := parseMouseEvent(token); ok {
-				if tm.handleTabBarMouseEvent(ev) {
-					continue
-				}
-				if tm.isCommandMode() {
-					continue
-				}
 			}
 
 			if tm.isCommandMode() {
@@ -1076,6 +1103,60 @@ func (tm *TabManager) isScrollMode() bool {
 	return tm.scrollMode
 }
 
+// hostOwnsMouse reports whether the active harness has *not* requested
+// mouse reporting. When it hasn't, the host is free to consume mouse
+// events (e.g. wheel-up to enter scrollback) without breaking the
+// harness's interactive mouse handling.
+func (tm *TabManager) hostOwnsMouse() bool {
+	tm.mu.Lock()
+	if tm.activeIdx >= len(tm.tabs) {
+		tm.mu.Unlock()
+		return true
+	}
+	tab := tm.tabs[tm.activeIdx]
+	tm.mu.Unlock()
+	if tab == nil || tab.vt == nil {
+		return true
+	}
+	tab.vt.Lock()
+	mode := tab.vt.Mode()
+	tab.vt.Unlock()
+	return mode&vt10x.ModeMouseMask == 0
+}
+
+// wheelLinesPerNotch is how many lines a single wheel notch scrolls in
+// scrollback. Matches common defaults across terminal emulators.
+const wheelLinesPerNotch = 3
+
+// handleWheelEvent maps wheel-up/wheel-down to scroll-offset changes.
+// Returns true if the event was consumed by host-side scrolling and
+// should not be forwarded to the harness PTY.
+func (tm *TabManager) handleWheelEvent(ev mouseEvent) bool {
+	if !ev.wheel || !ev.press {
+		// Wheel-release events under SGR encoding are noise to us.
+		return ev.wheel
+	}
+
+	switch ev.button {
+	case 0: // wheel up
+		if !tm.isScrollMode() {
+			tm.enterScrollMode()
+		}
+		tm.adjustScrollOffset(wheelLinesPerNotch)
+		return true
+	case 1: // wheel down
+		if tm.isScrollMode() {
+			tm.adjustScrollOffset(-wheelLinesPerNotch)
+			return true
+		}
+		// Not scrolling and host owns the wheel — swallow rather than
+		// forwarding, so the harness doesn't see phantom mouse traffic
+		// it never asked for.
+		return true
+	}
+	return false
+}
+
 // enterScrollMode freezes the active tab's view at the current frame and
 // switches input handling into scrollback browsing. Caller should not
 // already hold tm.mu.
@@ -1099,6 +1180,30 @@ func (tm *TabManager) exitScrollMode() {
 	tm.scrollOffset = 0
 	tm.needsRender = true
 	tm.mu.Unlock()
+}
+
+// onScrollbackGrow is invoked by the vt10x scroll-up callback after rows
+// have been appended to a tab's scrollback. When the user is currently
+// browsing that tab in scroll mode, we bump scrollOffset by the same
+// amount so the visible window stays anchored on the same content rows
+// instead of drifting upward as new evictions push the stream forward.
+// Called with neither tm.mu nor the vt10x lock held by us — vt10x holds
+// its own lock when invoking the callback, so we must not call back into
+// vt10x from here.
+func (tm *TabManager) onScrollbackGrow(tab *Tab, added int) {
+	if added <= 0 {
+		return
+	}
+	tm.mu.Lock()
+	defer tm.mu.Unlock()
+	if !tm.scrollMode || tm.activeIdx >= len(tm.tabs) || tm.tabs[tm.activeIdx] != tab {
+		return
+	}
+	tm.scrollOffset += added
+	if sbLen := tab.sb.length(); tm.scrollOffset > sbLen {
+		tm.scrollOffset = sbLen
+	}
+	tm.needsRender = true
 }
 
 // adjustScrollOffset shifts the scrollback view by delta lines (positive =
@@ -1972,8 +2077,13 @@ func (tm *TabManager) renderFrame() {
 		cursor.X, cursor.Y, vtCursorVisible, tab.cursorVisible.Load(),
 		tab.cursorSavedValid.Load(), tab.cursorSavedX.Load(), tab.cursorSavedY.Load(),
 		curX, curY, showCursor)
-	if tm.isCommandMode() && vtMode&vt10x.ModeMouseMask == 0 {
-		vtMode |= vt10x.ModeMouseX10
+	if vtMode&vt10x.ModeMouseMask == 0 {
+		// Harness hasn't asked for mouse reporting, so the host owns the
+		// mouse. Enable SGR-encoded button reporting so we can capture
+		// tab-bar clicks and wheel events (for scrollback) from the real
+		// terminal — without that, mouse escapes never reach bifrost at
+		// all and host-side wheel scrolling is impossible.
+		vtMode |= vt10x.ModeMouseButton | vt10x.ModeMouseSgr
 	}
 
 	tabBar := tm.buildTabBarString()


### PR DESCRIPTION
## Summary

This PR adds mouse-wheel scrollback browsing to the terminal tab manager. Previously, users could only navigate scrollback history via keyboard. Now, scrolling the mouse wheel up enters scroll mode and scrolls through history, while scrolling down exits scroll mode when the bottom is reached. It also fixes scroll position drift — when new rows are evicted into scrollback while the user is browsing, the view offset is bumped to keep the same content rows visible.

Additionally, this PR improves scrollback rendering when the terminal is resized: rows wider than the current display are truncated with a `…` indicator, and trailing default-style padding cells are stripped so resize-grow doesn't show absurd trailing whitespace from when the grid was narrower.

## Changes

- `scrollback.push` now returns the number of rows actually added, enabling callers to compensate scroll offsets when evictions occur.
- `onScrollbackGrow` is wired into the vt10x scroll-up callback to bump `scrollOffset` by the number of newly evicted rows when the user is actively browsing that tab's scrollback, keeping the view anchored.
- `handleWheelEvent` maps wheel-up to entering scroll mode and incrementing the offset by `wheelLinesPerNotch` (3), and wheel-down to decrementing and exiting scroll mode at the bottom. Wheel-release events (SGR noise) are consumed but ignored.
- Mouse event parsing is moved before the scroll-mode catch-all in `inputLoop` so wheel notches reach `handleWheelEvent` instead of being swallowed as unknown CSI sequences.
- `hostOwnsMouse` detects when the active harness has not requested mouse reporting, allowing the host to consume wheel and tab-bar click events without interfering with harness mouse handling.
- When the harness hasn't requested mouse reporting, SGR button mouse mode is now always enabled (not just in command mode) so wheel events and tab-bar clicks actually reach bifrost from the real terminal.
- `writeRowGlyphs` now computes `effectiveRowLen` to strip trailing default-style padding before comparing against the display width. Rows wider than the display are truncated at `cols-1` with a dim `…` appended; rows narrower are padded normally without phantom whitespace.
- `effectiveRowLen` walks the row in reverse, skipping NUL/space cells with default style, returning the index past the last content cell.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./cli/internal/runtime/...
```

Key scenarios to validate manually:
1. Open a tab with output that fills more than one screen of scrollback.
2. Scroll the mouse wheel up — the view should enter scroll mode and scroll up through history.
3. Scroll the mouse wheel down — the offset should decrease and scroll mode should exit when the bottom is reached.
4. While in scroll mode, produce new output in the terminal. The view should stay anchored on the same content rows rather than drifting upward.
5. Resize the terminal narrower than a stored scrollback row — the row should be truncated with a `…` at the right edge.
6. Resize the terminal wider than a stored scrollback row — no trailing whitespace or ellipsis should appear.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None. Changes are confined to terminal rendering and input routing within the local tab manager.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable