### PR TITLE
fix: replace unsafe inline jsonb cast with `bifrost_safe_jsonb` PL/pgSQL helper to prevent malformed JSON from aborting list queries

### DIFF
--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -324,6 +324,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddStopReasonColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddSafeJsonbFunction(ctx, db); err != nil {
+		return err
+	}
 	// migrationSplitFilterDataMatView is intentionally NOT invoked in this
 	// release. Dropping mv_logs_filterdata while old replicas are still
 	// serving /api/logs/filterdata from it would surface "relation does not
@@ -3035,6 +3038,67 @@ func migrationAddStopReasonColumn(ctx context.Context, db *gorm.DB) error {
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while adding stop_reason column: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddSafeJsonbFunction installs a PL/pgSQL helper that the
+// /api/logs list query uses to extract the last element of input_history /
+// responses_input_history without aborting the whole query on a single bad row.
+//
+// The previous inline guard (`left(btrim(x),1)='['`) only checked the first
+// character before casting to jsonb. Any row that looked array-shaped but
+// contained malformed JSON (unterminated structures, trailing commas, unpaired
+// UTF-16 surrogates, etc.) would fail the cast with 22P02 / 22P05 and abort the
+// entire list response. The helper wraps the cast in an EXCEPTION block and
+// returns the raw TEXT on any parse failure.
+//
+// Postgres-only; SQLite is guarded inline in listSelectColumns via json_valid().
+func migrationAddSafeJsonbFunction(ctx context.Context, db *gorm.DB) error {
+	if db.Dialector.Name() != "postgres" {
+		return nil
+	}
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "logs_add_safe_jsonb_function",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			const stmt = `
+CREATE OR REPLACE FUNCTION bifrost_safe_jsonb(t text) RETURNS text
+LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+    j jsonb;
+BEGIN
+    IF t IS NULL OR t = '' OR t = '[]' THEN
+        RETURN t;
+    END IF;
+    IF left(btrim(t), 1) <> '[' THEN
+        RETURN t;
+    END IF;
+    BEGIN
+        j := t::jsonb;
+    EXCEPTION WHEN invalid_text_representation OR untranslatable_character THEN
+        RETURN t;
+    END;
+    IF jsonb_typeof(j) <> 'array' OR jsonb_array_length(j) = 0 THEN
+        RETURN t;
+    END IF;
+    RETURN jsonb_build_array(j->-1)::text;
+END;
+$$;`
+			if err := tx.Exec(stmt).Error; err != nil {
+				return fmt.Errorf("failed to create bifrost_safe_jsonb: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return tx.Exec("DROP FUNCTION IF EXISTS bifrost_safe_jsonb(text)").Error
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding bifrost_safe_jsonb function: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -651,35 +651,35 @@ func (s *RDBLogStore) listSelectColumns() string {
 	var inputHistoryExpr, responsesInputExpr, outputMessageExpr string
 	switch s.db.Dialector.Name() {
 	case "postgres":
-		// Postgres jsonb cannot represent \u0000 (errcode 22P05) and rejects
-		// malformed JSON (22P02). A single bad row would otherwise abort the
-		// whole list query. Guard the cast: only attempt jsonb conversion
-		// when the TEXT looks like a JSON array and contains no \u0000
-		// escape; otherwise fall back to returning the raw TEXT.
+		// Postgres jsonb rejects malformed JSON (22P02), \u0000 escapes
+		// (22P05), and unpaired UTF-16 surrogates (22P05). A single bad row
+		// would otherwise abort the whole list query. bifrost_safe_jsonb
+		// wraps the cast in an EXCEPTION block and returns the raw TEXT on
+		// any parse failure; see migrationAddSafeJsonbFunction.
 		inputHistoryExpr = `CASE
 			WHEN object_type = 'realtime.turn' THEN input_history
-			WHEN input_history IS NOT NULL AND input_history != '' AND input_history != '[]'
-			     AND position('\u0000' in input_history) = 0
-			     AND left(btrim(input_history), 1) = '['
-			THEN jsonb_build_array(input_history::jsonb->-1)::text
-			ELSE input_history END AS input_history`
+			ELSE bifrost_safe_jsonb(input_history)
+			END AS input_history`
 		responsesInputExpr = `CASE
 			WHEN object_type = 'realtime.turn' THEN responses_input_history
-			WHEN responses_input_history IS NOT NULL AND responses_input_history != '' AND responses_input_history != '[]'
-			     AND position('\u0000' in responses_input_history) = 0
-			     AND left(btrim(responses_input_history), 1) = '['
-			THEN jsonb_build_array(responses_input_history::jsonb->-1)::text
-			ELSE responses_input_history END AS responses_input_history`
+			ELSE bifrost_safe_jsonb(responses_input_history)
+			END AS responses_input_history`
 		outputMessageExpr = `CASE WHEN object_type = 'realtime.turn' THEN output_message ELSE NULL END AS output_message`
 	default: // sqlite
 		inputHistoryExpr = `CASE
 			WHEN object_type = 'realtime.turn' THEN input_history
 			WHEN input_history IS NOT NULL AND input_history != '' AND input_history != '[]'
+			     AND json_valid(input_history) = 1
+			     AND json_type(input_history) = 'array'
+			     AND json_array_length(input_history) > 0
 			THEN json_array(json_extract(input_history, '$[' || (json_array_length(input_history) - 1) || ']'))
 			ELSE input_history END AS input_history`
 		responsesInputExpr = `CASE
 			WHEN object_type = 'realtime.turn' THEN responses_input_history
 			WHEN responses_input_history IS NOT NULL AND responses_input_history != '' AND responses_input_history != '[]'
+			     AND json_valid(responses_input_history) = 1
+			     AND json_type(responses_input_history) = 'array'
+			     AND json_array_length(responses_input_history) > 0
 			THEN json_array(json_extract(responses_input_history, '$[' || (json_array_length(responses_input_history) - 1) || ']'))
 			ELSE responses_input_history END AS responses_input_history`
 		outputMessageExpr = `CASE WHEN object_type = 'realtime.turn' THEN output_message ELSE NULL END AS output_message`

--- a/framework/logstore/safe_jsonb_test.go
+++ b/framework/logstore/safe_jsonb_test.go
@@ -1,0 +1,314 @@
+package logstore
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// malformedHistoryCase covers the scenarios that previously aborted /api/logs
+// via the unsafe input_history::jsonb cast (and the mirror cases on
+// responses_input_history). Each case exercises one shape of bad data; the
+// SearchLogs query must complete without error and return every row.
+type malformedHistoryCase struct {
+	name          string
+	objectType    string // defaults to "chat.completion"; set to "realtime.turn" to test passthrough branch
+	inputHistory  string // raw TEXT stored in logs.input_history
+	respHistory   string // raw TEXT stored in logs.responses_input_history
+	shouldCrashPG bool   // true if the row would have aborted the pre-fix Postgres list query
+}
+
+func malformedHistoryCases() []malformedHistoryCase {
+	// Built at runtime so the source file stays free of literal NUL bytes /
+	// lone surrogates that the Go parser would reject.
+	bs := "\\"
+	u0000 := bs + "u0000"
+	uD800 := bs + "uD800"
+	uDC00 := bs + "uDC00"
+
+	// Build a large but valid JSON array to exercise the happy path on inputs
+	// that wouldn't fit comfortably inline.
+	var big strings.Builder
+	big.WriteByte('[')
+	for i := 0; i < 1000; i++ {
+		if i > 0 {
+			big.WriteByte(',')
+		}
+		big.WriteString(`{"role":"user","content":"msg"}`)
+	}
+	big.WriteString(`,{"role":"assistant","content":"last"}]`)
+
+	return []malformedHistoryCase{
+		// ---------- malformed: jsonb cast failures (22P02) ----------
+		{
+			name:          "unterminated_object_in_array",
+			inputHistory:  `[{"role":"user","content":"hi"`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "garbage_after_bracket",
+			inputHistory:  `[abc, not json]`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "trailing_comma",
+			inputHistory:  `[{"role":"user","content":"hi"},]`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "unclosed_array_only",
+			inputHistory:  `[`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "open_bracket_then_brace_unclosed",
+			inputHistory:  `[{`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "nan_value_not_valid_json",
+			inputHistory:  `[NaN]`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "infinity_value_not_valid_json",
+			inputHistory:  `[Infinity]`,
+			shouldCrashPG: true,
+		},
+		// ---------- malformed: jsonb cast failures (22P05 character set) ----------
+		{
+			name:          "unpaired_high_surrogate",
+			inputHistory:  `[{"role":"user","content":"bad ` + uD800 + ` surrogate"}]`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "unpaired_low_surrogate",
+			inputHistory:  `[{"role":"user","content":"bad ` + uDC00 + ` low"}]`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "bad_surrogate_pair_high_then_ascii",
+			inputHistory:  `[{"role":"user","content":"` + uD800 + bs + `u0041"}]`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "u0000_escape_inside_string",
+			inputHistory:  `[{"role":"user","content":"null byte ` + u0000 + ` here"}]`,
+			shouldCrashPG: true,
+		},
+		// ---------- valid happy path: should pass through fast lane ----------
+		{
+			name:         "literal_backslash_u0000_valid_jsonb",
+			inputHistory: `[{"role":"user","content":"backslash-u-zero \\u0000 literal"}]`,
+		},
+		{
+			name:         "single_element_array",
+			inputHistory: `[{"role":"user","content":"only one"}]`,
+		},
+		{
+			name:         "array_of_primitives",
+			inputHistory: `[1,2,3]`,
+		},
+		{
+			name:         "array_with_null_last_element",
+			inputHistory: `[{"role":"user","content":"x"}, null]`,
+		},
+		{
+			name:         "deeply_nested_valid",
+			inputHistory: `[{"role":"user","content":{"nested":{"deep":{"value":42}}}}]`,
+		},
+		{
+			name:         "unicode_emoji_content",
+			inputHistory: `[{"role":"user","content":"hello 🎉 world ✨"}]`,
+		},
+		{
+			name:         "large_valid_array",
+			inputHistory: big.String(),
+		},
+		// ---------- valid non-array / structurally OK: fall through to raw ----------
+		{
+			name:         "leading_whitespace_then_array",
+			inputHistory: "   [\t{\"role\":\"user\",\"content\":\"ok\"}]",
+		},
+		{
+			name:         "top_level_object_not_array",
+			inputHistory: `{"not":"an array"}`,
+		},
+		{
+			name:         "null_literal",
+			inputHistory: `null`,
+		},
+		{
+			name:         "whitespace_only",
+			inputHistory: "   \t  ",
+		},
+		// ---------- realtime.turn passthrough: outer CASE bypasses safe function ----------
+		{
+			name:         "realtime_turn_malformed_passthrough",
+			objectType:   "realtime.turn",
+			inputHistory: `[{"role":"user"`, // malformed; must not crash even though safe fn is bypassed
+		},
+		// ---------- mirror column ----------
+		{
+			name:          "malformed_responses_input_history",
+			respHistory:   `[{"role":"user"`,
+			shouldCrashPG: true,
+		},
+		{
+			name:        "valid_responses_input_history",
+			respHistory: `[{"role":"user","content":"ok"},{"role":"assistant","content":"hi"}]`,
+		},
+	}
+}
+
+// insertMalformedLog inserts a logs row with the given raw input_history /
+// responses_input_history TEXT values, bypassing GORM serialization so the
+// exact byte sequence reaches the database.
+func insertMalformedLog(t *testing.T, db *gorm.DB, c malformedHistoryCase, ts time.Time) string {
+	t.Helper()
+	id := uuid.New().String()
+	objType := c.objectType
+	if objType == "" {
+		objType = "chat.completion"
+	}
+	err := db.Exec(`
+		INSERT INTO logs (id, timestamp, object_type, provider, model, status,
+			input_history, responses_input_history, created_at)
+		VALUES (?, ?, ?, 'openai', 'gpt-4', 'success', ?, ?, ?)
+	`, id, ts, objType, c.inputHistory, c.respHistory, ts).Error
+	require.NoError(t, err, "failed to insert row for case %q", c.name)
+	return id
+}
+
+// runMalformedHistorySuite exercises SearchLogs against each malformed case
+// and asserts the query completes successfully for every row. Reused by the
+// SQLite and Postgres entry points so both dialect branches of
+// listSelectColumns are covered.
+func runMalformedHistorySuite(t *testing.T, store *RDBLogStore, db *gorm.DB) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	cases := malformedHistoryCases()
+	expectedIDs := make(map[string]string, len(cases))
+	for i, c := range cases {
+		// Spread timestamps so the DESC sort is stable per-case.
+		id := insertMalformedLog(t, db, c, now.Add(-time.Duration(i)*time.Second))
+		expectedIDs[id] = c.name
+	}
+
+	result, err := store.SearchLogs(ctx, SearchFilters{}, PaginationOptions{Limit: 1000})
+	require.NoError(t, err, "SearchLogs must not fail on malformed input_history")
+	require.NotNil(t, result)
+
+	// Every inserted row must come back, regardless of payload shape.
+	gotIDs := make(map[string]bool, len(result.Logs))
+	for _, l := range result.Logs {
+		gotIDs[l.ID] = true
+	}
+	for id, name := range expectedIDs {
+		assert.True(t, gotIDs[id], "row for case %q (id=%s) missing from SearchLogs result", name, id)
+	}
+}
+
+// TestSearchLogs_MalformedInputHistory_SQLite exercises the SQLite branch of
+// listSelectColumns, which now gates json_extract on json_valid + json_type.
+func TestSearchLogs_MalformedInputHistory_SQLite(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	defer store.Close(context.Background())
+	runMalformedHistorySuite(t, store, store.db)
+}
+
+// TestSearchLogs_MalformedInputHistory_Postgres exercises the Postgres branch,
+// which now routes through the bifrost_safe_jsonb PL/pgSQL helper. Skipped
+// when Postgres is unavailable.
+func TestSearchLogs_MalformedInputHistory_Postgres(t *testing.T) {
+	store, db := setupPerfTestDB(t)
+	runMalformedHistorySuite(t, store, db)
+}
+
+// TestBifrostSafeJsonb_DirectInvocation exercises the PL/pgSQL helper in
+// isolation so a regression in the function body shows up here rather than
+// only at the list-query level. Each subtest asserts the exact TEXT the
+// function returns so we can also detect silent behaviour drift on the
+// happy path (e.g. canonical jsonb spacing changes between PG versions).
+func TestBifrostSafeJsonb_DirectInvocation(t *testing.T) {
+	_, db := setupPerfTestDB(t)
+
+	bs := "\\"
+	u0000 := bs + "u0000"
+	uD800 := bs + "uD800"
+	uDC00 := bs + "uDC00"
+
+	// Build large valid array — last element should be `{"last": true}`.
+	var big strings.Builder
+	big.WriteByte('[')
+	for i := 0; i < 500; i++ {
+		big.WriteString(`{"i":`)
+		big.WriteByte(byte('0' + (i % 10)))
+		big.WriteString(`},`)
+	}
+	big.WriteString(`{"last":true}]`)
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// fast-path bypasses
+		{name: "empty_string", in: "", want: ""},
+		{name: "empty_array", in: "[]", want: "[]"},
+
+		// happy path: last-element extraction
+		{name: "valid_two_element_array", in: `[{"a":1},{"b":2}]`, want: `[{"b": 2}]`},
+		{name: "single_element_array", in: `[{"a":1}]`, want: `[{"a": 1}]`},
+		{name: "array_of_primitives", in: `[1,2,3]`, want: `[3]`},
+		{name: "array_with_null_last", in: `[{"a":1},null]`, want: `[null]`},
+		{name: "nested_object_last", in: `[{"x":{"y":{"z":42}}}]`, want: `[{"x": {"y": {"z": 42}}}]`},
+		{name: "large_valid_array_last_only", in: big.String(), want: `[{"last": true}]`},
+
+		// non-array values: function returns raw TEXT unchanged
+		{name: "object_not_array_returns_raw", in: `{"x":1}`, want: `{"x":1}`},
+		{name: "null_literal_returns_raw", in: `null`, want: `null`},
+		{name: "number_literal_returns_raw", in: `42`, want: `42`},
+		{name: "string_literal_returns_raw", in: `"hello"`, want: `"hello"`},
+		{name: "whitespace_only_returns_raw", in: "   \t  ", want: "   \t  "},
+
+		// malformed: EXCEPTION branch catches, returns raw TEXT
+		{name: "unterminated_returns_raw", in: `[{"role":"user"`, want: `[{"role":"user"`},
+		{name: "garbage_after_bracket_returns_raw", in: `[abc]`, want: `[abc]`},
+		{name: "trailing_comma_returns_raw", in: `[1,2,]`, want: `[1,2,]`},
+		{name: "nan_returns_raw", in: `[NaN]`, want: `[NaN]`},
+		{name: "infinity_returns_raw", in: `[Infinity]`, want: `[Infinity]`},
+		{name: "high_surrogate_returns_raw", in: `[{"c":"` + uD800 + `"}]`, want: `[{"c":"` + uD800 + `"}]`},
+		{name: "low_surrogate_returns_raw", in: `[{"c":"` + uDC00 + `"}]`, want: `[{"c":"` + uDC00 + `"}]`},
+		{name: "bad_surrogate_pair_returns_raw", in: `[{"c":"` + uD800 + bs + `u0041"}]`, want: `[{"c":"` + uD800 + bs + `u0041"}]`},
+		{name: "u0000_escape_returns_raw", in: `[{"c":"x` + u0000 + `y"}]`, want: `[{"c":"x` + u0000 + `y"}]`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var got string
+			err := db.Raw("SELECT bifrost_safe_jsonb(?)", c.in).Scan(&got).Error
+			require.NoError(t, err, "bifrost_safe_jsonb must not propagate parse errors")
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+// TestBifrostSafeJsonb_NullInput verifies the function handles SQL NULL
+// (distinct from empty string) by returning NULL without erroring.
+func TestBifrostSafeJsonb_NullInput(t *testing.T) {
+	_, db := setupPerfTestDB(t)
+
+	var got *string
+	err := db.Raw("SELECT bifrost_safe_jsonb(NULL::text)").Scan(&got).Error
+	require.NoError(t, err, "bifrost_safe_jsonb(NULL) must not error")
+	assert.Nil(t, got, "bifrost_safe_jsonb(NULL) should return NULL")
+}


### PR DESCRIPTION
## Summary

The `/api/logs` list query was aborting entirely when a single row contained malformed JSON in `input_history` or `responses_input_history`. The previous inline guard only checked the first character before casting to `jsonb`, so rows that appeared array-shaped but contained malformed JSON (unterminated structures, trailing commas, unpaired UTF-16 surrogates, `\u0000` escapes, etc.) would trigger a `22P02`/`22P05` error and kill the entire response. This PR fixes that by introducing a PL/pgSQL helper function (`bifrost_safe_jsonb`) that wraps the cast in an `EXCEPTION` block and falls back to returning the raw text on any parse failure.

## Changes

- Added a new migration `migrationAddSafeJsonbFunction` that installs the `bifrost_safe_jsonb(text)` PL/pgSQL function on Postgres. The function validates the input, attempts the `jsonb` cast inside an `EXCEPTION` block, and returns the last array element on success or the raw text on any failure.
- Replaced the multi-condition inline `CASE` guards in `listSelectColumns` for Postgres with calls to `bifrost_safe_jsonb`, simplifying the SQL and correctly handling all malformed-JSON edge cases that the previous character-check approach missed.
- For SQLite, added `json_valid()`, `json_type()`, and `json_array_length()` guards to the `CASE` expressions to prevent extraction attempts on invalid or empty arrays.
- Added `safe_jsonb_test.go` covering both the SQLite and Postgres dialect branches of `listSelectColumns`, as well as direct invocation of `bifrost_safe_jsonb` across all relevant edge cases (malformed structures, surrogate pairs, `\u0000` escapes, non-array values, SQL `NULL`).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd framework && docker compose up -d postgres

go test ./framework/logstore/ -run 'MalformedInputHistory|BifrostSafeJsonb' -count=1 -v
```

Insert a row into the logs table with a malformed JSON value in `input_history` (e.g., `[{"key": "val"` — unterminated) and verify that a call to the list endpoint returns successfully without a 500 error, with the malformed row's `input_history` returned as raw text rather than aborting the query.

## Test Coverage

### `TestSearchLogs_MalformedInputHistory_{SQLite,Postgres}` — end-to-end list query

| # | Case | Column | Payload shape | Pre-fix behavior | Path exercised |
| --- | --- | --- | --- | --- | --- |
| 1 | `unterminated_object_in_array` | `input_history` | `[{"role":"user","content":"hi"` | 22P02 aborts query | EXCEPTION fallback |
| 2 | `garbage_after_bracket` | `input_history` | `[abc, not json]` | 22P02 aborts query | EXCEPTION fallback |
| 3 | `trailing_comma` | `input_history` | `[{"role":"user","content":"hi"},]` | 22P02 aborts query | EXCEPTION fallback |
| 4 | `unclosed_array_only` | `input_history` | `[` | 22P02 aborts query | EXCEPTION fallback |
| 5 | `open_bracket_then_brace_unclosed` | `input_history` | `[{` | 22P02 aborts query | EXCEPTION fallback |
| 6 | `nan_value_not_valid_json` | `input_history` | `[NaN]` | 22P02 aborts query | EXCEPTION fallback |
| 7 | `infinity_value_not_valid_json` | `input_history` | `[Infinity]` | 22P02 aborts query | EXCEPTION fallback |
| 8 | `unpaired_high_surrogate` | `input_history` | `[{"...":"bad \uD800 surrogate"}]` | 22P05 aborts query | EXCEPTION fallback |
| 9 | `unpaired_low_surrogate` | `input_history` | `[{"...":"bad \uDC00 low"}]` | 22P05 aborts query | EXCEPTION fallback |
| 10 | `bad_surrogate_pair_high_then_ascii` | `input_history` | `[{"c":"\uD800A"}]` | 22P05 aborts query | EXCEPTION fallback |
| 11 | `u0000_escape_inside_string` | `input_history` | `[{"...":"null byte � here"}]` | 22P05 aborts query | EXCEPTION fallback |
| 12 | `literal_backslash_u0000_valid_jsonb` | `input_history` | `[{"...":"... \\u0000 literal"}]` | OK (degraded to raw by old guard) | Fast path, last-element extraction |
| 13 | `single_element_array` | `input_history` | `[{"role":"user","content":"only one"}]` | OK | Fast path |
| 14 | `array_of_primitives` | `input_history` | `[1,2,3]` | OK | Fast path |
| 15 | `array_with_null_last_element` | `input_history` | `[{...}, null]` | OK | Fast path |
| 16 | `deeply_nested_valid` | `input_history` | `[{"role":"user","content":{"nested":{"deep":{"value":42}}}}]` | OK | Fast path |
| 17 | `unicode_emoji_content` | `input_history` | `[{"...":"hello 🎉 world ✨"}]` | OK | Fast path |
| 18 | `large_valid_array` | `input_history` | 1001-element array | OK | Fast path at scale |
| 19 | `leading_whitespace_then_array` | `input_history` | `   [\t{...}]` | OK | `btrim` + fast path |
| 20 | `top_level_object_not_array` | `input_history` | `{"not":"an array"}` | OK | Non-array fall-through |
| 21 | `null_literal` | `input_history` | `null` | OK | Non-array fall-through |
| 22 | `whitespace_only` | `input_history` | `"   \t  "` | OK | Empty-after-btrim fall-through |
| 23 | `realtime_turn_malformed_passthrough` | `input_history` (object_type=`realtime.turn`) | `[{"role":"user"` | OK (outer CASE bypassed safe fn) | Realtime-turn bypass branch |
| 24 | `malformed_responses_input_history` | `responses_input_history` | `[{"role":"user"` | 22P02 aborts query | Mirror column, EXCEPTION fallback |
| 25 | `valid_responses_input_history` | `responses_input_history` | `[{...},{...}]` | OK | Mirror column, fast path |

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

[https://github.com/maximhq/bifrost/issues/3255](https://github.com/maximhq/bifrost/issues/3255#issuecomment-4427506449)

## Security considerations

None. The function is `IMMUTABLE` and operates only on text values already stored in the database. No new inputs are exposed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable