### PR TITLE
enterprise docs updates

### DIFF
--- a/docs/changelogs/ent-v1.4.0.mdx
+++ b/docs/changelogs/ent-v1.4.0.mdx
@@ -5,6 +5,10 @@ description: "Enterprise v1.4.0"
 
 <Update label="Bifrost Enterprise" description="v1.4.0">
 
+<Warning>
+  **Breaking changes in v1.4.0.** See the [v1.4.0 Migration Guide](/enterprise/migration-guides/v1.4.0) for full before/after examples, automatic migration details, and a step-by-step checklist before upgrading.
+</Warning>
+
 ## Changelog
 
 This release unifies the API authentication path so password-mode admin and API-key auth share the OSS `AuthMiddleware`/RBAC pipeline, splits SCIM provider configuration into per-provider forms, keeps governance usage snapshots alive across idle periods, and pulls in OSS base `transports/v1.5.0-prerelease8` with `objectStorageExcludeFields`, MCP server/client URL split, and a stack of provider correctness fixes (Anthropic routing, Bedrock structured-output streaming, SGL extra-params passthrough).

--- a/docs/changelogs/ent-v1.4.1.mdx
+++ b/docs/changelogs/ent-v1.4.1.mdx
@@ -5,6 +5,10 @@ description: "Enterprise v1.4.1"
 
 <Update label="Bifrost Enterprise" description="v1.4.1">
 
+<Warning>
+  **Breaking changes in v1.4.0.** See the [v1.4.0 Migration Guide](/enterprise/migration-guides/v1.4.0) for full before/after examples, automatic migration details, and a step-by-step checklist before upgrading.
+</Warning>
+
 ## Changelog
 
 A focused follow-up to v1.4.0. Headline items: a new Gitleaks-backed **Secrets Detection guardrail**, a **PII Detection** template under the custom-regex guardrail, **finer-grained RBAC** (MCP Tool Groups, MCP Logs, API Keys, Inference, Guardrail Rules), and two paired clustered-governance correctness fixes (ghost nodes + leader-based state sync) that eliminate any possibility of budget and rate-limit drift across pod restarts, scale events, leader changes, and rolling deploys. Picks up the OSS `transports/v1.5.1` base (Azure Entra auth, per-dimension matviews and dimension-scoped filter sidebars, MCP log detail with object-storage offload, `x-bifrost-*` routed-identity response headers, and a wide set of provider/streaming fixes).


### PR DESCRIPTION
## Summary

Adds a breaking change warning banner to the v1.4.0 and v1.4.1 changelog pages, directing users to the v1.4.0 Migration Guide before upgrading.

## Changes

- Added a `<Warning>` callout to both `ent-v1.4.0.mdx` and `ent-v1.4.1.mdx` that highlights the breaking changes introduced in v1.4.0 and links to the migration guide with before/after examples, automatic migration details, and an upgrade checklist.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the warning banner renders correctly on both changelog pages and that the link to `/enterprise/migration-guides/v1.4.0` resolves without a 404.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Related to the v1.4.0 breaking changes and the corresponding migration guide.

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable