### PR TITLE
updates to the contributions guideline

### DIFF
--- a/docs/contributing/raising-a-pr.mdx
+++ b/docs/contributing/raising-a-pr.mdx
@@ -7,7 +7,7 @@ icon: "code-pull-request"
 ## Before You Start
 
 1. **Create an issue first** (if one doesn't exist) - Discuss the change with the maintainers
-2. **Fork the repository** and create a feature branch
+2. **Fork the repository** and create a feature branch from `dev` (the default development branch; `main` is reserved for releases). Target `dev` when opening your PR.
 3. **Set up your development environment** using [these instructions](/contributing/setting-up-repo)
 4. **Run tests locally** to ensure everything works
 
@@ -431,7 +431,7 @@ Before requesting review, ensure:
 Once approved:
 - The maintainer will handle the merge
 - Your commits will be preserved in the history
-- Ensure your branch is up-to-date with `main` before final approval
+- Ensure your branch is up-to-date with `dev` before final approval
 
 ## Common Pitfalls to Avoid
 


### PR DESCRIPTION
## Summary

Updates the contributing documentation to clarify that `dev` is the default development branch and that `main` is reserved for releases. Contributors should branch from and target `dev` when opening pull requests.

## Changes

- Updated the "Fork the repository" step to specify branching from `dev` and targeting `dev` when opening a PR
- Updated the merge instructions to reference keeping branches up-to-date with `dev` instead of `main`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated `docs/contributing/raising-a-pr.mdx` to confirm the branch references are accurate and consistent.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable