### PR TITLE
docs: update env var syntax from `${VAR}` to `env.VAR` across enterprise and observability docs

### DIFF
--- a/docs/enterprise/audit-logs.mdx
+++ b/docs/enterprise/audit-logs.mdx
@@ -226,7 +226,7 @@ curl -X POST http://localhost:8080/api/audit-logs/query \
         "splunk": {
           "enabled": true,
           "hec_endpoint": "https://splunk.company.com:8088/services/collector",
-          "hec_token": "${SPLUNK_HEC_TOKEN}",
+          "hec_token": "env.SPLUNK_HEC_TOKEN",
           "source_type": "bifrost:audit",
           "index": "security",
           "batch_size": 100,
@@ -245,7 +245,7 @@ curl -X POST http://localhost:8080/api/audit-logs/query \
         "siem_integration": {
         "datadog": {
                 "enabled": true,
-                "api_key": "${DATADOG_API_KEY}",
+                "api_key": "env.DATADOG_API_KEY",
                 "site": "datadoghq.com",
                 "service": "bifrost",
                 "tags": ["env:production", "team:security"]
@@ -264,7 +264,7 @@ curl -X POST http://localhost:8080/api/audit-logs/query \
         "elastic": {
           "enabled": true,
           "endpoint": "https://elastic.company.com:9200",
-          "api_key": "${ELASTIC_API_KEY}",
+          "api_key": "env.ELASTIC_API_KEY",
           "index": "bifrost-audit-logs",
           "pipeline": "security-enrichment"
         }
@@ -286,7 +286,7 @@ curl -X POST http://localhost:8080/api/audit-logs/query \
             "url": "https://security.company.com/webhooks/audit",
             "auth": {
               "type": "bearer",
-              "token": "${WEBHOOK_AUTH_TOKEN}"
+              "token": "env.WEBHOOK_AUTH_TOKEN"
             },
             "filters": {
               "event_types": ["security_incident"],

--- a/docs/enterprise/guardrails.mdx
+++ b/docs/enterprise/guardrails.mdx
@@ -421,8 +421,8 @@ curl -X POST http://localhost:8080/api/enterprise/guardrails/providers \
     "policy_name": "PII Detection Profile",
     "enabled": true,
     "config": {
-      "access_key": "${AWS_ACCESS_KEY_ID}",
-      "secret_key": "${AWS_SECRET_ACCESS_KEY}",
+      "access_key": "env.AWS_ACCESS_KEY_ID",
+      "secret_key": "env.AWS_SECRET_ACCESS_KEY",
       "guardrail_arn": "arn:aws:bedrock:us-east-1:123456789:guardrail/abc123",
       "guardrail_version": "1",
       "region": "us-east-1"
@@ -502,8 +502,8 @@ curl -X DELETE http://localhost:8080/api/enterprise/guardrails/providers/1
           "policy_name": "PII Detection Profile",
           "enabled": true,
           "config": {
-            "access_key": "${AWS_ACCESS_KEY_ID}",
-            "secret_key": "${AWS_SECRET_ACCESS_KEY}",
+            "access_key": "env.AWS_ACCESS_KEY_ID",
+            "secret_key": "env.AWS_SECRET_ACCESS_KEY",
             "guardrail_arn": "arn:aws:bedrock:us-east-1:123456789:guardrail/abc123",
             "guardrail_version": "1",
             "region": "us-east-1"
@@ -516,7 +516,7 @@ curl -X DELETE http://localhost:8080/api/enterprise/guardrails/providers/1
           "enabled": true,
           "config": {
             "endpoint": "https://your-resource.cognitiveservices.azure.com/",
-            "api_key": "${AZURE_CONTENT_SAFETY_API_KEY}",
+            "api_key": "env.AZURE_CONTENT_SAFETY_API_KEY",
             "analyze_enabled": true,
             "analyze_severity_threshold": "medium",
             "jailbreak_shield_enabled": true,
@@ -529,7 +529,7 @@ curl -X DELETE http://localhost:8080/api/enterprise/guardrails/providers/1
           "policy_name": "Custom Safety Rules",
           "enabled": true,
           "config": {
-            "api_key": "${GRAYSWAN_API_KEY}",
+            "api_key": "env.GRAYSWAN_API_KEY",
             "violation_threshold": 0.5,
             "reasoning_mode": "hybrid",
             "rules": {
@@ -544,7 +544,7 @@ curl -X DELETE http://localhost:8080/api/enterprise/guardrails/providers/1
           "policy_name": "Hallucination Detection",
           "enabled": true,
           "config": {
-            "api_key": "${PATRONUS_API_KEY}",
+            "api_key": "env.PATRONUS_API_KEY",
             "api_endpoint": "https://api.patronus.ai/v1"
           }
         }
@@ -588,8 +588,8 @@ guardrails_config:
         region: "us-east-1"
         # AWS Authentication (choose one method):
         # Option 1: Explicit credentials
-        access_key: "${AWS_ACCESS_KEY_ID}"
-        secret_key: "${AWS_SECRET_ACCESS_KEY}"
+        access_key: "env.AWS_ACCESS_KEY_ID"
+        secret_key: "env.AWS_SECRET_ACCESS_KEY"
         # Option 2: IAM Role - omit access_key and secret_key
         # (Bifrost will use IAM credentials from the environment)
     - id: 4
@@ -598,7 +598,7 @@ guardrails_config:
       enabled: true
       config:
         endpoint: "https://your-resource.cognitiveservices.azure.com/"
-        api_key: "${AZURE_CONTENT_SAFETY_API_KEY}"
+        api_key: "env.AZURE_CONTENT_SAFETY_API_KEY"
         analyze_enabled: true
         analyze_severity_threshold: "medium"
         jailbreak_shield_enabled: true
@@ -607,7 +607,7 @@ guardrails_config:
       policy_name: "Custom Safety Rules"
       enabled: true
       config:
-        api_key: "${GRAYSWAN_API_KEY}"
+        api_key: "env.GRAYSWAN_API_KEY"
         violation_threshold: 0.5
         reasoning_mode: "hybrid"
         rules:

--- a/docs/enterprise/log-exports.mdx
+++ b/docs/enterprise/log-exports.mdx
@@ -31,8 +31,8 @@ The log export system enables:
       "region": "us-west-2",
       "prefix": "logs/{year}/{month}/{day}/",
       "credentials": {
-        "access_key_id": "${AWS_ACCESS_KEY_ID}",
-        "secret_access_key": "${AWS_SECRET_ACCESS_KEY}"
+        "access_key_id": "env.AWS_ACCESS_KEY_ID",
+        "secret_access_key": "env.AWS_SECRET_ACCESS_KEY"
       }
     }
   }
@@ -48,7 +48,7 @@ The log export system enables:
       "bucket": "bifrost-logs",
       "prefix": "logs/{year}/{month}/{day}/",
       "credentials": {
-        "service_account_key": "${GCP_SERVICE_ACCOUNT_KEY}"
+        "service_account_key": "env.GCP_SERVICE_ACCOUNT_KEY"
       }
     }
   }
@@ -62,8 +62,8 @@ The log export system enables:
     "destination": "azure_blob",
     "config": {
       "container": "bifrost-logs",
-      "account_name": "${AZURE_ACCOUNT_NAME}",
-      "account_key": "${AZURE_ACCOUNT_KEY}",
+      "account_name": "env.AZURE_ACCOUNT_NAME",
+      "account_key": "env.AZURE_ACCOUNT_KEY",
       "prefix": "logs/{year}/{month}/{day}/"
     }
   }
@@ -84,8 +84,8 @@ The log export system enables:
       "table": "request_logs",
       "warehouse": "COMPUTE_WH",
       "credentials": {
-        "username": "${SNOWFLAKE_USERNAME}",
-        "password": "${SNOWFLAKE_PASSWORD}"
+        "username": "env.SNOWFLAKE_USERNAME",
+        "password": "env.SNOWFLAKE_PASSWORD"
       }
     }
   }
@@ -104,8 +104,8 @@ The log export system enables:
       "table": "request_logs",
       "region": "us-west-2",
       "credentials": {
-        "username": "${REDSHIFT_USERNAME}",
-        "password": "${REDSHIFT_PASSWORD}"
+        "username": "env.REDSHIFT_USERNAME",
+        "password": "env.REDSHIFT_PASSWORD"
       }
     }
   }
@@ -122,7 +122,7 @@ The log export system enables:
       "dataset": "bifrost_logs",
       "table": "request_logs",
       "credentials": {
-        "service_account_key": "${GCP_SERVICE_ACCOUNT_KEY}"
+        "service_account_key": "env.GCP_SERVICE_ACCOUNT_KEY"
       }
     }
   }
@@ -190,8 +190,8 @@ The log export system enables:
             "region": "us-west-2",
             "prefix": "daily-exports/{year}/{month}/{day}/",
             "credentials": {
-              "access_key_id": "${AWS_ACCESS_KEY_ID}",
-              "secret_access_key": "${AWS_SECRET_ACCESS_KEY}"
+              "access_key_id": "env.AWS_ACCESS_KEY_ID",
+              "secret_access_key": "env.AWS_SECRET_ACCESS_KEY"
             }
           }
         },
@@ -225,7 +225,7 @@ The log export system enables:
             "dataset": "bifrost_analytics",
             "table": "weekly_logs",
             "credentials": {
-              "service_account_key": "${GCP_SERVICE_ACCOUNT_KEY}"
+              "service_account_key": "env.GCP_SERVICE_ACCOUNT_KEY"
             }
           }
         },
@@ -339,8 +339,8 @@ message log_record {
     {
       "type": "enrich",
       "add_fields": {
-        "export_timestamp": "${EXPORT_TIMESTAMP}",
-        "export_version": "${EXPORT_VERSION}"
+        "export_timestamp": "env.EXPORT_TIMESTAMP",
+        "export_version": "env.EXPORT_VERSION"
       }
     }
   ]

--- a/docs/enterprise/setting-up-google-workspace.mdx
+++ b/docs/enterprise/setting-up-google-workspace.mdx
@@ -146,7 +146,7 @@ https://www.googleapis.com/auth/admin.directory.group.member.readonly
     "config": {
       "domain": "company.com",
       "clientId": "123-abc.apps.googleusercontent.com",
-      "clientSecret": "${GOOGLE_WORKSPACE_CLIENT_SECRET}",
+      "clientSecret": "env.GOOGLE_WORKSPACE_CLIENT_SECRET",
       "adminEmail": "sso-admin@company.com",
       "serviceAccountEnvVar": "GOOGLE_SA_JSON",
       "teamIdsField": "groups"

--- a/docs/enterprise/setting-up-keycloak.mdx
+++ b/docs/enterprise/setting-up-keycloak.mdx
@@ -170,7 +170,7 @@ Create the roles and groups you plan to map into Bifrost.
       "serverUrl": "https://keycloak.company.com",
       "realm": "bifrost-prod",
       "clientId": "bifrost",
-      "clientSecret": "${KEYCLOAK_CLIENT_SECRET}",
+      "clientSecret": "env.KEYCLOAK_CLIENT_SECRET",
       "teamIdsField": "groups"
     }
   }

--- a/docs/enterprise/setting-up-zitadel.mdx
+++ b/docs/enterprise/setting-up-zitadel.mdx
@@ -171,9 +171,9 @@ Web apps in Zitadel cannot use the `client_credentials` grant. Bifrost needs a d
       "domain": "my-instance.zitadel.cloud",
       "projectId": "123456789012345678",
       "clientId": "123456789012345678@my-project",
-      "clientSecret": "${ZITADEL_CLIENT_SECRET}",
+      "clientSecret": "env.ZITADEL_CLIENT_SECRET",
       "serviceAccountClientId": "987654321098765432@my-project",
-      "serviceAccountClientSecret": "${ZITADEL_SA_CLIENT_SECRET}",
+      "serviceAccountClientSecret": "env.ZITADEL_SA_CLIENT_SECRET",
       "teamIdsField": "groups"
     }
   }


### PR DESCRIPTION
## Summary

Updates environment variable reference syntax across enterprise documentation from `${VAR_NAME}` to `env.VAR_NAME` to match the actual format expected by Bifrost configuration.

## Changes

- Replaced all `${VAR_NAME}` style environment variable references with `env.VAR_NAME` across audit logs, guardrails, log exports, SSO provider setup guides (Google Workspace, Keycloak, Zitadel), and OpenTelemetry observability docs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated documentation examples to confirm all environment variable references use the `env.VAR_NAME` format consistently. Validate against a running Bifrost instance by using one of the updated config snippets (e.g., a guardrails provider config with `"api_key": "env.GRAYSWAN_API_KEY"`) and confirming the value is correctly resolved from the environment.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Correcting the env var syntax ensures credentials are properly resolved at runtime rather than being passed as literal strings, which is relevant to secrets handling across SIEM integrations, cloud storage credentials, and SSO client secrets.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable