### PR TITLE
fix: vk and provider key level pricing overrides for streaming

### DIFF
--- a/core/schemas/tracer.go
+++ b/core/schemas/tracer.go
@@ -117,7 +117,7 @@ type Tracer interface {
 	// Returns the accumulated result. IsFinal will be true when the stream is complete.
 	// This method is used by plugins to access accumulated streaming data.
 	// The ctx parameter must contain the stream end indicator for proper final chunk detection.
-	ProcessStreamingChunk(traceID string, isFinalChunk bool, result *BifrostResponse, err *BifrostError) *StreamAccumulatorResult
+	ProcessStreamingChunk(ctx *BifrostContext, traceID string, isFinalChunk bool, result *BifrostResponse, err *BifrostError) *StreamAccumulatorResult
 
 	// AttachPluginLogs appends plugin log entries to the trace identified by traceID.
 	// Thread-safe. Should be called after plugin hooks complete, before trace completion.
@@ -191,7 +191,7 @@ func (n *NoOpTracer) CreateStreamAccumulator(_ string, _ time.Time) {}
 func (n *NoOpTracer) CleanupStreamAccumulator(_ string) {}
 
 // ProcessStreamingChunk returns nil.
-func (n *NoOpTracer) ProcessStreamingChunk(_ string, _ bool, _ *BifrostResponse, _ *BifrostError) *StreamAccumulatorResult {
+func (n *NoOpTracer) ProcessStreamingChunk(_ *BifrostContext, _ string, _ bool, _ *BifrostResponse, _ *BifrostError) *StreamAccumulatorResult {
 	return nil
 }
 

--- a/framework/tracing/tracer.go
+++ b/framework/tracing/tracer.go
@@ -380,10 +380,11 @@ func (t *Tracer) CleanupStreamAccumulator(traceID string) {
 }
 
 // ProcessStreamingChunk processes a streaming chunk and accumulates it.
-// Returns the accumulated result. IsFinal will be true when the stream is complete.
+// Returns the accumulated result when isFinalChunk is true and the stream is complete;
+// returns nil for non-final chunks.
 // This method is used by plugins to access accumulated streaming data.
-// The ctx parameter must contain the stream end indicator for proper final chunk detection.
-func (t *Tracer) ProcessStreamingChunk(traceID string, isFinalChunk bool, result *schemas.BifrostResponse, err *schemas.BifrostError) *schemas.StreamAccumulatorResult {
+// Set isFinalChunk to indicate whether the current chunk is the last in the stream.
+func (t *Tracer) ProcessStreamingChunk(ctx *schemas.BifrostContext, traceID string, isFinalChunk bool, result *schemas.BifrostResponse, err *schemas.BifrostError) *schemas.StreamAccumulatorResult {
 	if traceID == "" || t.accumulator == nil {
 		return nil
 	}
@@ -392,6 +393,12 @@ func (t *Tracer) ProcessStreamingChunk(traceID string, isFinalChunk bool, result
 	accumCtx := schemas.NewBifrostContext(context.Background(), time.Time{})
 	accumCtx.SetValue(schemas.BifrostContextKeyAccumulatorID, traceID)
 	accumCtx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, isFinalChunk)
+
+	// Forward relevant context values to the new context
+	if ctx != nil {
+		accumCtx.SetValue(schemas.BifrostContextKeySelectedKeyID, ctx.Value(schemas.BifrostContextKeySelectedKeyID))
+		accumCtx.SetValue(schemas.BifrostContextKeyGovernanceVirtualKeyID, ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID))
+	}
 
 	processedResp, processErr := t.accumulator.ProcessStreamingResponse(accumCtx, result, err)
 	if processErr != nil || processedResp == nil {

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -835,7 +835,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	// responses need a DB write.
 	if bifrost.IsStreamRequestType(requestType) && requestType != schemas.RealtimeRequest && !isFinalChunk && result != nil && bifrostErr == nil {
 		if tracer != nil && traceID != "" {
-			tracer.ProcessStreamingChunk(traceID, false, result, bifrostErr)
+			tracer.ProcessStreamingChunk(ctx, traceID, false, result, bifrostErr)
 		}
 		return result, bifrostErr, nil
 	}
@@ -895,7 +895,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			requestType != schemas.RealtimeRequest &&
 			tracer != nil &&
 			traceID != "" {
-			if accResult := tracer.ProcessStreamingChunk(traceID, true, result, bifrostErr); accResult != nil {
+			if accResult := tracer.ProcessStreamingChunk(ctx, traceID, true, result, bifrostErr); accResult != nil {
 				if streamResponse := convertToProcessedStreamResponse(accResult, requestType); streamResponse != nil {
 					p.applyStreamingOutputToEntry(entry, streamResponse, shouldStoreRaw, contentLoggingEnabled)
 				}
@@ -935,7 +935,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	if bifrost.IsStreamRequestType(requestType) && requestType != schemas.RealtimeRequest {
 		var streamResponse *streaming.ProcessedStreamResponse
 		if tracer != nil && traceID != "" {
-			accResult := tracer.ProcessStreamingChunk(traceID, isFinalChunk, result, bifrostErr)
+			accResult := tracer.ProcessStreamingChunk(ctx, traceID, isFinalChunk, result, bifrostErr)
 			if accResult != nil {
 				streamResponse = convertToProcessedStreamResponse(accResult, requestType)
 			}

--- a/plugins/maxim/main.go
+++ b/plugins/maxim/main.go
@@ -569,7 +569,7 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.B
 			// Use central tracer's accumulator
 			tracer, bifrostTraceID, err := bifrost.GetTracerFromContext(ctx)
 			if err == nil && tracer != nil && bifrostTraceID != "" {
-				accResult := tracer.ProcessStreamingChunk(bifrostTraceID, isFinalChunk, result, bifrostErr)
+				accResult := tracer.ProcessStreamingChunk(ctx, bifrostTraceID, isFinalChunk, result, bifrostErr)
 				if accResult != nil {
 					streamResponse = convertAccResultToProcessedStreamResponse(accResult)
 				}


### PR DESCRIPTION
## Summary

`ProcessStreamingChunk` previously lacked access to the originating `BifrostContext`, which meant key context values such as the selected key ID and governance virtual key ID were not forwarded to the stream accumulator context. These values are used in `PricingLookupScopesFromContext` to enforce scoped pricing overrides.

## Changes

- Added `ctx *BifrostContext` as the first parameter to `ProcessStreamingChunk` in the `Tracer` interface, `NoOpTracer`, and the concrete `Tracer` implementation.
- Inside `ProcessStreamingChunk`, `BifrostContextKeySelectedKeyID` and `BifrostContextKeyGovernanceVirtualKeyID` are now explicitly forwarded from the incoming context to the accumulator context.
- Updated all call sites in the logging and maxim plugins to pass the context through.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Verify that streaming requests correctly propagate key ID and governance virtual key ID through to the accumulator by inspecting trace/log entries for streamed responses and confirming those fields are populated.

## Breaking changes

- [x] Yes
- [ ] No

The signature of `ProcessStreamingChunk` in the `Tracer` interface has changed. Any external implementations of the `Tracer` interface must add the `ctx *BifrostContext` parameter to their `ProcessStreamingChunk` method.

## Related issues

## Security considerations

The forwarded context values (`BifrostContextKeySelectedKeyID`, `BifrostContextKeyGovernanceVirtualKeyID`) are internal identifiers used for key selection and governance. Ensuring they are correctly propagated prevents potential misattribution of usage or bypassing of governance controls during streaming.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable