### PR TITLE
fix: resolve cache plugin at request time to support post-boot loads and plugin reloads

### DIFF
--- a/transports/bifrost-http/handlers/cache.go
+++ b/transports/bifrost-http/handlers/cache.go
@@ -3,32 +3,36 @@ package handlers
 import (
 	"github.com/fasthttp/router"
 	"github.com/maximhq/bifrost/core/schemas"
-	"github.com/maximhq/bifrost/plugins/semanticcache"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/valyala/fasthttp"
 )
 
-// cacheClearer is the minimal contract the handler needs from the semantic
-// cache plugin. Defined here (rather than imported) so tests can substitute
-// a fake without spinning up a real vector store.
-type cacheClearer interface {
+// CacheClearer is the minimal contract the handler needs from the semantic
+// cache plugin. Exported so the server wiring can supply a resolver without
+// pulling in the plugin's concrete type and so tests can substitute a fake.
+type CacheClearer interface {
 	ClearCacheForCacheID(cacheID string) error
 	ClearCacheForKey(cacheKey string) error
 }
 
+// CacheClearerResolver returns the currently-loaded cache plugin or nil if
+// none is loaded. Called on every cache-clear request so plugin lifecycle
+// (POST/PUT/DELETE /api/plugins) is honored — without this, the handler
+// would hold a stale pointer after a plugin reload and the routes would
+// silently misbehave (or never exist at all if the plugin was loaded
+// post-boot rather than at startup).
+type CacheClearerResolver func() CacheClearer
+
 type CacheHandler struct {
-	plugin cacheClearer
+	resolve CacheClearerResolver
 }
 
-func NewCacheHandler(plugin schemas.LLMPlugin) *CacheHandler {
-	semanticCachePlugin, ok := plugin.(*semanticcache.Plugin)
-	if !ok {
-		logger.Fatal("Cache handler requires a semantic cache plugin")
-	}
-
-	return &CacheHandler{
-		plugin: semanticCachePlugin,
-	}
+// NewCacheHandler returns a CacheHandler that resolves the current plugin
+// at request time. The handler is safe to wire unconditionally — when no
+// plugin is loaded, each cache-clear request returns HTTP 400 with a clear
+// message rather than the route being absent (HTTP 405).
+func NewCacheHandler(resolve CacheClearerResolver) *CacheHandler {
+	return &CacheHandler{resolve: resolve}
 }
 
 func (h *CacheHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
@@ -37,12 +41,17 @@ func (h *CacheHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.B
 }
 
 func (h *CacheHandler) clearCache(ctx *fasthttp.RequestCtx) {
+	plugin := h.resolve()
+	if plugin == nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "semantic_cache plugin is not loaded")
+		return
+	}
 	cacheID, ok := ctx.UserValue("cacheId").(string)
 	if !ok || cacheID == "" {
 		SendError(ctx, fasthttp.StatusBadRequest, "Invalid cache ID")
 		return
 	}
-	if err := h.plugin.ClearCacheForCacheID(cacheID); err != nil {
+	if err := plugin.ClearCacheForCacheID(cacheID); err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to clear cache")
 		return
 	}
@@ -53,12 +62,17 @@ func (h *CacheHandler) clearCache(ctx *fasthttp.RequestCtx) {
 }
 
 func (h *CacheHandler) clearCacheByKey(ctx *fasthttp.RequestCtx) {
+	plugin := h.resolve()
+	if plugin == nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "semantic_cache plugin is not loaded")
+		return
+	}
 	cacheKey, ok := ctx.UserValue("cacheKey").(string)
 	if !ok {
 		SendError(ctx, fasthttp.StatusBadRequest, "Invalid cache key")
 		return
 	}
-	if err := h.plugin.ClearCacheForKey(cacheKey); err != nil {
+	if err := plugin.ClearCacheForKey(cacheKey); err != nil {
 		SendError(ctx, fasthttp.StatusInternalServerError, "Failed to clear cache")
 		return
 	}

--- a/transports/bifrost-http/handlers/cache_test.go
+++ b/transports/bifrost-http/handlers/cache_test.go
@@ -11,10 +11,10 @@ import (
 // fakeCacheClearer records calls and returns configured errors so the handler
 // branches can be exercised without a real semantic cache plugin.
 type fakeCacheClearer struct {
-	clearByID    func(string) error
-	clearByKey   func(string) error
-	idCalls      []string
-	keyCalls     []string
+	clearByID  func(string) error
+	clearByKey func(string) error
+	idCalls    []string
+	keyCalls   []string
 }
 
 func (f *fakeCacheClearer) ClearCacheForCacheID(id string) error {
@@ -41,13 +41,19 @@ func newCacheCtx(userKey, userVal string) *fasthttp.RequestCtx {
 	return ctx
 }
 
+// newCacheHandler builds a CacheHandler whose resolver always returns the
+// given fake — mimics a steady-state "plugin loaded" environment.
+func newCacheHandler(clearer CacheClearer) *CacheHandler {
+	return NewCacheHandler(func() CacheClearer { return clearer })
+}
+
 // -----------------------------------------------------------------------------
 // clearCache (DELETE /api/cache/clear/{cacheId})
 // -----------------------------------------------------------------------------
 
 func TestClearCache_OK(t *testing.T) {
 	clearer := &fakeCacheClearer{}
-	h := &CacheHandler{plugin: clearer}
+	h := newCacheHandler(clearer)
 
 	ctx := newCacheCtx("cacheId", "abc-123")
 	h.clearCache(ctx)
@@ -62,7 +68,7 @@ func TestClearCache_OK(t *testing.T) {
 
 func TestClearCache_RejectsEmptyID(t *testing.T) {
 	clearer := &fakeCacheClearer{}
-	h := &CacheHandler{plugin: clearer}
+	h := newCacheHandler(clearer)
 
 	ctx := newCacheCtx("cacheId", "")
 	h.clearCache(ctx)
@@ -77,7 +83,7 @@ func TestClearCache_RejectsEmptyID(t *testing.T) {
 
 func TestClearCache_MissingUserValue(t *testing.T) {
 	clearer := &fakeCacheClearer{}
-	h := &CacheHandler{plugin: clearer}
+	h := newCacheHandler(clearer)
 
 	// No user value set at all (simulates a routing misconfiguration).
 	ctx := &fasthttp.RequestCtx{}
@@ -92,7 +98,7 @@ func TestClearCache_PluginErrorReturns500(t *testing.T) {
 	clearer := &fakeCacheClearer{
 		clearByID: func(string) error { return errors.New("store unavailable") },
 	}
-	h := &CacheHandler{plugin: clearer}
+	h := newCacheHandler(clearer)
 
 	ctx := newCacheCtx("cacheId", "abc-123")
 	h.clearCache(ctx)
@@ -105,13 +111,30 @@ func TestClearCache_PluginErrorReturns500(t *testing.T) {
 	}
 }
 
+// TestClearCache_PluginNotLoaded covers the regression where the handler
+// would 405 (route absent) or panic on a nil pointer when the plugin
+// wasn't loaded at boot. The new resolver-based handler must return 400.
+func TestClearCache_PluginNotLoaded(t *testing.T) {
+	h := NewCacheHandler(func() CacheClearer { return nil })
+
+	ctx := newCacheCtx("cacheId", "abc-123")
+	h.clearCache(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusBadRequest {
+		t.Fatalf("expected 400 when plugin not loaded, got %d", got)
+	}
+	if !strings.Contains(string(ctx.Response.Body()), "semantic_cache plugin is not loaded") {
+		t.Fatalf("expected plugin-not-loaded message, got %s", ctx.Response.Body())
+	}
+}
+
 // -----------------------------------------------------------------------------
 // clearCacheByKey (DELETE /api/cache/clear-by-key/{cacheKey})
 // -----------------------------------------------------------------------------
 
 func TestClearCacheByKey_OK(t *testing.T) {
 	clearer := &fakeCacheClearer{}
-	h := &CacheHandler{plugin: clearer}
+	h := newCacheHandler(clearer)
 
 	ctx := newCacheCtx("cacheKey", "session-42")
 	h.clearCacheByKey(ctx)
@@ -128,12 +151,26 @@ func TestClearCacheByKey_PluginErrorReturns500(t *testing.T) {
 	clearer := &fakeCacheClearer{
 		clearByKey: func(string) error { return errors.New("vector store down") },
 	}
-	h := &CacheHandler{plugin: clearer}
+	h := newCacheHandler(clearer)
 
 	ctx := newCacheCtx("cacheKey", "session-42")
 	h.clearCacheByKey(ctx)
 
 	if got := ctx.Response.StatusCode(); got != fasthttp.StatusInternalServerError {
 		t.Fatalf("expected 500 on plugin error, got %d", got)
+	}
+}
+
+func TestClearCacheByKey_PluginNotLoaded(t *testing.T) {
+	h := NewCacheHandler(func() CacheClearer { return nil })
+
+	ctx := newCacheCtx("cacheKey", "session-42")
+	h.clearCacheByKey(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusBadRequest {
+		t.Fatalf("expected 400 when plugin not loaded, got %d", got)
+	}
+	if !strings.Contains(string(ctx.Response.Body()), "semantic_cache plugin is not loaded") {
+		t.Fatalf("expected plugin-not-loaded message, got %s", ctx.Response.Body())
 	}
 }

--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -226,7 +226,10 @@ func (h *PluginsHandler) getPlugin(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 500, "Failed to retrieve plugin")
 		return
 	}
-	SendJSON(ctx, plugin)
+	// Return the same shape as list/create/update — with runtime status
+	// merged in — so the UI doesn't see an empty status when refetching a
+	// single plugin via useGetPluginQuery.
+	SendJSON(ctx, h.buildPluginResponse(ctx, plugin))
 }
 
 // createPlugin creates a new plugin

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1103,11 +1103,18 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 			return fmt.Errorf("failed to initialize governance handler: %v", err)
 		}
 	}
-	var cacheHandler *handlers.CacheHandler
-	semanticCachePlugin, _ := lib.FindPluginAs[*semanticcache.Plugin](s.Config, semanticcache.PluginName)
-	if semanticCachePlugin != nil {
-		cacheHandler = handlers.NewCacheHandler(semanticCachePlugin)
-	}
+	// Resolve the semantic_cache plugin per request so plugin reloads via
+	// /api/plugins are honored — the previous boot-time capture left stale
+	// references and (worse) skipped route registration entirely when the
+	// plugin wasn't in config.json at startup, causing 405 on all cache-clear
+	// endpoints for the process lifetime.
+	cacheHandler := handlers.NewCacheHandler(func() handlers.CacheClearer {
+		p, err := lib.FindPluginAs[*semanticcache.Plugin](s.Config, semanticcache.PluginName)
+		if err != nil || p == nil {
+			return nil
+		}
+		return p
+	})
 	var promptsReloader handlers.PromptCacheReloader
 	if promptsPlugin, err := lib.FindPluginAs[handlers.PromptCacheReloader](s.Config, s.getPromptsPluginName()); err == nil && promptsPlugin != nil {
 		promptsReloader = promptsPlugin
@@ -1152,9 +1159,7 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	if promptsHandler != nil {
 		promptsHandler.RegisterRoutes(s.Router, middlewares...)
 	}
-	if cacheHandler != nil {
-		cacheHandler.RegisterRoutes(s.Router, middlewares...)
-	}
+	cacheHandler.RegisterRoutes(s.Router, middlewares...)
 	if governanceHandler != nil {
 		governanceHandler.RegisterRoutes(s.Router, middlewares...)
 	}


### PR DESCRIPTION
## Summary

The `CacheHandler` previously captured a reference to the `semantic_cache` plugin at boot time. This caused two bugs: (1) if the plugin was not present in `config.json` at startup, cache-clear routes were never registered, resulting in HTTP 405 for the entire process lifetime; (2) if the plugin was loaded or reloaded via `/api/plugins` after boot, the handler held a stale (or nil) pointer and would silently misbehave. Additionally, `GET /api/plugins/:name` was returning the raw plugin config without runtime status, causing the UI to see an empty status when refetching a single plugin.

## Changes

- `CacheHandler` now accepts a `CacheClearerResolver` function instead of a concrete plugin pointer. The resolver is called on every cache-clear request, so plugin lifecycle changes via `/api/plugins` are always honored.
- `CacheClearer` and `CacheClearerResolver` are exported so server wiring can supply the resolver without importing the plugin's concrete type.
- Cache routes are registered unconditionally at startup. When no plugin is loaded, requests return HTTP 400 with a descriptive message instead of HTTP 405.
- The server wiring in `RegisterAPIRoutes` uses a closure over `lib.FindPluginAs` to resolve the plugin per request, replacing the boot-time capture.
- `getPlugin` now returns the same response shape as list/create/update (with runtime status merged in), fixing the empty status seen by `useGetPluginQuery` in the UI.
- Tests cover the new "plugin not loaded" path for both `clearCache` and `clearCacheByKey`, and existing tests are updated to use the resolver-based constructor.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/...
go test ./transports/bifrost-http/...
```

1. Start the server **without** `semantic_cache` in `config.json`. Issue `DELETE /api/cache/clear/{cacheId}` — expect HTTP 400 with `"semantic_cache plugin is not loaded"` (previously HTTP 405).
2. Load the `semantic_cache` plugin via `POST /api/plugins`. Repeat the request — expect the cache-clear to succeed.
3. Reload or remove the plugin via `PUT`/`DELETE /api/plugins`. Verify the handler reflects the new state on the next request without a server restart.
4. Issue `GET /api/plugins/{name}` for a loaded plugin and confirm the response includes runtime status fields, matching the shape returned by the list endpoint.

## Breaking changes

- [x] Yes
- [ ] No

`NewCacheHandler` now accepts a `CacheClearerResolver` function instead of a `schemas.LLMPlugin`. Any caller constructing a `CacheHandler` directly must be updated to pass a resolver.

## Related issues

## Security considerations

None. The change does not affect authentication, secrets, or PII handling.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable