### PR TITLE
fix: decouple cache telemetry from write decision and guard no-op search paths in semantic cache

### DIFF
--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -360,6 +360,33 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 
 	performDirectSearch, performSemanticSearch := plugin.resolveCacheTypes(ctx)
 
+	// If neither search path can produce a lookup in the current plugin
+	// configuration, skip caching entirely (no read, no write). Concretely:
+	//   - x-bf-cache-type=semantic against a direct-only plugin (Provider="",
+	//     Dimension=1) — generateEmbedding would fail with "provider is
+	//     required", PostLLMHook would still write an orphan entry under a
+	//     random request UUID that no future read can find.
+	//   - x-bf-cache-type=direct against a misconfigured semantic-only plugin
+	//     where direct search is disabled.
+	//   - An unknown cache-type header value (resolveCacheTypes returns false
+	//     for both paths).
+	// The embedding executor alone isn't a sufficient gate — the framework
+	// wires it on every plugin, but the plugin's config decides whether
+	// semantic search is actually viable.
+	canDoSemanticSearch := plugin.embeddingRequestExecutor != nil &&
+		plugin.config.Provider != "" &&
+		plugin.config.EmbeddingModel != "" &&
+		plugin.config.Dimension > 1 &&
+		req.EmbeddingRequest == nil &&
+		req.TranscriptionRequest == nil
+	if !performDirectSearch && (!performSemanticSearch || !canDoSemanticSearch) {
+		plugin.clearCacheState(requestID)
+		msg := "skipping cache: no search path available for this request (cache_type narrowed to a path that the current plugin configuration cannot serve)"
+		plugin.logger.Warn(msg)
+		ctx.Log(schemas.LogLevelWarn, msg)
+		return req, nil, nil
+	}
+
 	// Compute metadata + paramsHash once and reuse across both search paths.
 	metadata, err := plugin.buildRequestMetadataForCaching(state, req)
 	if err != nil {
@@ -387,12 +414,11 @@ func (plugin *Plugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifro
 	}
 
 	if performSemanticSearch {
-		// Suppress semantic for ineligible cases (no executor, or request
-		// types whose input cannot itself be embedded).
-		semanticEligible := plugin.embeddingRequestExecutor != nil &&
-			req.EmbeddingRequest == nil &&
-			req.TranscriptionRequest == nil
-		if !semanticEligible {
+		// Reuse canDoSemanticSearch so the default cache-type path (both flags
+		// true) applies the same provider/model/dimension gate as the explicit
+		// semantic-only path — otherwise a misconfigured plugin wastes one
+		// generateEmbedding round-trip per request before failing downstream.
+		if !canDoSemanticSearch {
 			plugin.setZeroVectorIfRequired(state)
 		} else {
 			shortCircuit, err := plugin.performSemanticSearch(ctx, state, req, cacheKey, paramsHash)
@@ -486,10 +512,7 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 	// Final-chunk signaling for cache replays: stampCacheDebugForHit only
 	// stamps CacheDebug.CacheHit=true on the LAST replay chunk (see search.go).
 	// When we see that stamp, we set the stream-end indicator on the root ctx
-	// synchronously — same goroutine as the rest of the post-hook chain. This
-	// MUST run before shouldSkipCaching, otherwise we early-return without
-	// setting the indicator and downstream plugins (logging) never see
-	// isFinalChunk=true on the final replay chunk.
+	// synchronously — same goroutine as the rest of the post-hook chain.
 	//
 	// Why not set the indicator from the cache replay goroutine instead? It
 	// races: the producer can advance to its next iteration (and SetValue)
@@ -498,15 +521,11 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 	if bifrost.IsStreamRequestType(requestType) && cacheDebug != nil && cacheDebug.CacheHit {
 		ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
 	}
-	if plugin.shouldSkipCaching(ctx, res) {
-		// Clear state on the same condition the defer at the end of this
-		// function uses — otherwise the early return below leaks *cacheState
-		// (notably the ~6 KB Embeddings slice) until the periodic reaper
-		// runs. Non-final stream chunks of an in-flight short-circuit replay
-		// keep their state because they need it for later chunks.
-		if !bifrost.IsStreamRequestType(requestType) || bifrost.IsFinalChunk(ctx) {
-			plugin.clearCacheState(requestID)
-		}
+	// Cache hit replay: cache_debug was already stamped in PreLLMHook by
+	// stampCacheDebugForHit. There's nothing further to do here — no new
+	// telemetry to stamp, no write to perform.
+	if cacheDebug != nil && cacheDebug.CacheHit {
+		plugin.clearCacheState(requestID)
 		return res, nil, nil
 	}
 
@@ -523,8 +542,8 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 	if state == nil || state.ParamsHash == "" {
 		// PreLLMHook bailed before computing the params hash (unsupported
 		// request type, conversation-history threshold, metadata error,
-		// etc.). Caching now would write an entry without params_hash that
-		// no future lookup can match.
+		// no-search-path narrow, etc.). Without state we have no telemetry
+		// to stamp and no entry to write.
 		return res, nil, nil
 	}
 
@@ -536,19 +555,31 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 		}
 	}()
 
-	// PreLLMHook short-circuited from cache; chunks here are the cached
-	// replay, not a fresh upstream response. shouldSkipCaching only catches
-	// the FINAL chunk (the only one carrying CacheDebug.CacheHit=true via
-	// stampCacheDebugForHit) — without this guard the non-final chunks
-	// would slip into addStreamingResponse and trigger a duplicate write
-	// at the same directCacheID (Weaviate 422 "id already exists").
+	// PreLLMHook short-circuited from cache (non-final stream chunks of a
+	// replay land here). Telemetry is already stamped on the final chunk by
+	// stampCacheDebugForHit; non-final chunks have no telemetry to add.
+	// Without this guard non-final chunks would slip into addStreamingResponse
+	// and trigger a duplicate write at the same directCacheID
+	// (Weaviate 422 "id already exists").
 	if state.ShortCircuited {
 		return res, nil, nil
 	}
 
 	storageID, embedding, shouldStoreEmbeddings := plugin.resolveStorageIDAndEmbedding(ctx, state, requestID, requestType)
 
+	// Stamp cache_debug telemetry FIRST so callers can observe that the
+	// plugin ran a lookup, regardless of whether we then choose to skip
+	// writing the entry (no-store header, large-payload modes, etc.).
+	// Observability shouldn't depend on the write decision — that was
+	// previously the case and made the cache layer invisible to callers
+	// using no-store.
 	plugin.stampCacheDebugForMiss(state, extraFields, storageID, isStream, isFinalChunk)
+
+	// Now decide whether to actually write. Skipping the write still
+	// leaves cache_debug stamped above.
+	if plugin.shouldSkipCacheWrite(ctx) {
+		return res, nil, nil
+	}
 
 	cacheTTL := plugin.resolveTTL(ctx)
 	paramsHash := state.ParamsHash
@@ -579,17 +610,18 @@ func (plugin *Plugin) PostLLMHook(ctx *schemas.BifrostContext, res *schemas.Bifr
 	return res, nil, nil
 }
 
-// shouldSkipCaching returns true if the response cannot or should not be
-// written to the cache (large payload mode, cache hit replay, or explicit
-// no-store).
-func (plugin *Plugin) shouldSkipCaching(ctx *schemas.BifrostContext, res *schemas.BifrostResponse) bool {
+// shouldSkipCacheWrite returns true if the upstream response should NOT be
+// written to the cache store. Telemetry (cache_debug) is stamped before this
+// is consulted, so callers retain observability on misses even when no_store
+// or large-payload modes are in effect. The cache-hit-replay case is handled
+// separately as an early return in PostLLMHook because it must short-circuit
+// before stamping (cache_debug for hits is already populated by
+// stampCacheDebugForHit during PreLLMHook).
+func (plugin *Plugin) shouldSkipCacheWrite(ctx *schemas.BifrostContext) bool {
 	if isLargePayload, ok := ctx.Value(schemas.BifrostContextKeyLargePayloadMode).(bool); ok && isLargePayload {
 		return true
 	}
 	if isLargeResponse, ok := ctx.Value(schemas.BifrostContextKeyLargeResponseMode).(bool); ok && isLargeResponse {
-		return true
-	}
-	if cacheDebug := res.GetExtraFields().CacheDebug; cacheDebug != nil && cacheDebug.CacheHit {
 		return true
 	}
 	if noStore, ok := ctx.Value(CacheNoStoreKey).(bool); ok && noStore {
@@ -650,13 +682,21 @@ func (plugin *Plugin) stampCacheDebugForMiss(state *cacheState, extraFields *sch
 	}
 }
 
-// resolveTTL returns the per-request TTL override if present, else the plugin default.
+// resolveTTL returns the per-request TTL override if present, else the plugin
+// default. A non-positive override (0 or negative) is treated as "use default"
+// to mirror how Config.UnmarshalJSON + Init treat TTL=0 at construction time —
+// otherwise a header of "0s" would yield expires_at=now and silently kill the
+// cache write for the affected request, which is rarely what the caller wants.
 func (plugin *Plugin) resolveTTL(ctx *schemas.BifrostContext) time.Duration {
 	if v := ctx.Value(CacheTTLKey); v != nil {
 		if ttl, ok := v.(time.Duration); ok {
-			return ttl
+			if ttl > 0 {
+				return ttl
+			}
+			plugin.logger.Debug("ignoring non-positive per-request TTL override %v, falling back to plugin default", ttl)
+		} else {
+			plugin.logger.Warn("TTL is not a time.Duration, using default TTL")
 		}
-		plugin.logger.Warn("TTL is not a time.Duration, using default TTL")
 	}
 	return plugin.config.TTL
 }

--- a/plugins/semanticcache/plugin_paths_test.go
+++ b/plugins/semanticcache/plugin_paths_test.go
@@ -57,59 +57,51 @@ func TestPostLLMHook_SkipsOnBifrostError(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
-// shouldSkipCaching paths
+// shouldSkipCacheWrite paths
+//
+// shouldSkipCacheWrite gates only the cache WRITE — cache_debug telemetry is
+// stamped before this is consulted (see PostLLMHook). The cache-hit replay
+// case is handled separately as an early return in PostLLMHook and is not
+// exercised here.
 // -----------------------------------------------------------------------------
 
-func TestShouldSkipCaching_LargePayloadMode(t *testing.T) {
+func TestShouldSkipCacheWrite_LargePayloadMode(t *testing.T) {
 	plugin := newTestPlugin(t, newObservableStore())
 
 	ctx := newBaseTestContext()
 	ctx.SetValue(schemas.BifrostContextKeyLargePayloadMode, true)
-	res := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{}}
 
-	if !plugin.shouldSkipCaching(ctx, res) {
-		t.Fatal("expected LargePayloadMode to skip caching")
+	if !plugin.shouldSkipCacheWrite(ctx) {
+		t.Fatal("expected LargePayloadMode to skip the cache write")
 	}
 }
 
-func TestShouldSkipCaching_LargeResponseMode(t *testing.T) {
+func TestShouldSkipCacheWrite_LargeResponseMode(t *testing.T) {
 	plugin := newTestPlugin(t, newObservableStore())
 
 	ctx := newBaseTestContext()
 	ctx.SetValue(schemas.BifrostContextKeyLargeResponseMode, true)
-	res := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{}}
 
-	if !plugin.shouldSkipCaching(ctx, res) {
-		t.Fatal("expected LargeResponseMode to skip caching")
+	if !plugin.shouldSkipCacheWrite(ctx) {
+		t.Fatal("expected LargeResponseMode to skip the cache write")
 	}
 }
 
-func TestShouldSkipCaching_CacheHitReplay(t *testing.T) {
-	plugin := newTestPlugin(t, newObservableStore())
-
-	ctx := newBaseTestContext()
-	res := &schemas.BifrostResponse{
-		ChatResponse: &schemas.BifrostChatResponse{
-			ExtraFields: schemas.BifrostResponseExtraFields{
-				CacheDebug: &schemas.BifrostCacheDebug{CacheHit: true},
-			},
-		},
-	}
-
-	if !plugin.shouldSkipCaching(ctx, res) {
-		t.Fatal("expected cache-hit replay to skip re-caching")
-	}
-}
-
-func TestShouldSkipCaching_NoStoreFlag(t *testing.T) {
+func TestShouldSkipCacheWrite_NoStoreFlag(t *testing.T) {
 	plugin := newTestPlugin(t, newObservableStore())
 
 	ctx := newBaseTestContext()
 	ctx.SetValue(CacheNoStoreKey, true)
-	res := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{}}
 
-	if !plugin.shouldSkipCaching(ctx, res) {
-		t.Fatal("expected CacheNoStoreKey=true to skip caching")
+	if !plugin.shouldSkipCacheWrite(ctx) {
+		t.Fatal("expected CacheNoStoreKey=true to skip the cache write")
+	}
+}
+
+func TestShouldSkipCacheWrite_DefaultIsFalse(t *testing.T) {
+	plugin := newTestPlugin(t, newObservableStore())
+	if plugin.shouldSkipCacheWrite(newBaseTestContext()) {
+		t.Fatal("expected default context to allow the cache write")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes several correctness issues in the semantic cache plugin's `PostLLMHook` and related helpers: cache telemetry (`cache_debug`) was previously invisible to callers using `no-store`, cache-hit replay detection was fragile, non-positive per-request TTL overrides could silently kill cache writes, and requests with a `cache_type` header narrowed to a path the plugin cannot serve would still produce orphan cache entries.

## Changes

- **Early exit for unsupported search paths in `PreLLMHook`**: When `resolveCacheTypes` resolves to a path the plugin cannot actually serve (e.g. `x-bf-cache-type=semantic` against a direct-only plugin, or an unknown header value), the hook now clears cache state and returns early instead of proceeding to generate an embedding or write an orphan entry under a random request UUID that no future read can match.

- **Separated cache-hit replay handling from write-skip logic**: The `shouldSkipCaching` method (which conflated cache-hit detection with write-skip conditions) is replaced by `shouldSkipCacheWrite`. Cache-hit replay is now handled as a dedicated early return in `PostLLMHook` before any telemetry stamping, while `shouldSkipCacheWrite` gates only the write decision after telemetry is already stamped. This ensures `cache_debug` is always populated for callers using `no-store` or large-payload modes.

- **Telemetry stamped before write decision**: `stampCacheDebugForMiss` is now called before `shouldSkipCacheWrite` is consulted, so observability is not conditional on whether the entry is ultimately written.

- **Non-positive TTL overrides fall back to plugin default**: `resolveTTL` now treats a zero or negative per-request TTL override as "use default" rather than applying it, which would have set `expires_at=now` and silently discarded the cache write.

- **Cleaned up stale comments**: Removed an outdated ordering constraint comment in `PostLLMHook` that no longer applies after the restructuring.

- **Tests updated**: Test cases for `shouldSkipCaching` are renamed and updated to reflect the new `shouldSkipCacheWrite` contract. The cache-hit replay test case is removed from this suite (it is now an early return in `PostLLMHook`, not a condition inside the helper). A new default-is-false test is added.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/semanticcache/...
```

Validate the following scenarios:
- A request with `x-bf-cache-type=semantic` against a plugin configured with `Provider=""` or `Dimension=1` should log a warning and skip caching entirely — no orphan entry should appear in the store.
- A request with `Cache-Control: no-store` should still produce a populated `cache_debug` field in the response with `cache_hit=false`.
- A per-request TTL override of `0s` should fall back to the plugin's configured default TTL and not silently discard the cache write.

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable