### PR TITLE
feat: add `triggered_rotation` to `KeyAttemptRecord` and tighten `bifrost_key_rotation_events_total` semantics

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5274,6 +5274,9 @@ func executeRequestWithRetries[T any](
 	var currentKey schemas.Key
 	var usedKeyIDs map[string]bool
 	lastWasRateLimit := false
+	// Index in BifrostContextKeyAttemptTrail of an attempt that hit a rate limit and is waiting
+	// to learn whether the *next* key selection actually picks a different key. -1 = no pending.
+	pendingRotationAttemptIdx := -1
 
 	for attempts = 0; attempts <= config.NetworkConfig.MaxRetries; attempts++ {
 		ctx.SetValue(schemas.BifrostContextKeyNumberOfRetries, attempts)
@@ -5330,6 +5333,19 @@ func executeRequestWithRetries[T any](
 			currentKey = selectedKey
 			ctx.SetValue(schemas.BifrostContextKeySelectedKeyID, currentKey.ID)
 			ctx.SetValue(schemas.BifrostContextKeySelectedKeyName, currentKey.Name)
+
+			// Resolve any pending rotation marker from the previous failed attempt. Only mark
+			// TriggeredRotation=true if the newly selected key differs from the failed one —
+			// fixed-key paths return the same key, in which case no rotation actually happened.
+			if pendingRotationAttemptIdx >= 0 {
+				if trail, ok := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord); ok &&
+					pendingRotationAttemptIdx < len(trail) &&
+					trail[pendingRotationAttemptIdx].KeyID != currentKey.ID {
+					trail[pendingRotationAttemptIdx].TriggeredRotation = true
+					ctx.SetValue(schemas.BifrostContextKeyAttemptTrail, trail)
+				}
+				pendingRotationAttemptIdx = -1
+			}
 		}
 
 		// Append a trail record for every attempt (key rotation and same-key retries alike).
@@ -5596,6 +5612,17 @@ func executeRequestWithRetries[T any](
 			usedKeyIDs[currentKey.ID] = true
 		}
 		lastWasRateLimit = isRateLimit
+
+		// Record the just-failed attempt as a *candidate* for rotation. The next iteration will
+		// confirm it (and set TriggeredRotation=true) only if key selection actually picks a
+		// different key — this avoids false positives for fixed-key providers whose keyProvider
+		// is non-nil but returns the same key. Network-error retries reuse the same key, and
+		// terminal attempts (attempts == MaxRetries) won't run another iteration.
+		if isRateLimit && keyProvider != nil && attempts < config.NetworkConfig.MaxRetries {
+			if trail, ok := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord); ok && len(trail) > 0 {
+				pendingRotationAttemptIdx = len(trail) - 1
+			}
+		}
 	}
 
 	// Add retry information to error

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5243,6 +5243,9 @@ func executeRequestWithRetries[T any](
 	var currentKey schemas.Key
 	var usedKeyIDs map[string]bool
 	lastWasRateLimit := false
+	// Index in BifrostContextKeyAttemptTrail of an attempt that hit a rate limit and is waiting
+	// to learn whether the *next* key selection actually picks a different key. -1 = no pending.
+	pendingRotationAttemptIdx := -1
 
 	for attempts = 0; attempts <= config.NetworkConfig.MaxRetries; attempts++ {
 		ctx.SetValue(schemas.BifrostContextKeyNumberOfRetries, attempts)
@@ -5298,6 +5301,19 @@ func executeRequestWithRetries[T any](
 			currentKey = selectedKey
 			ctx.SetValue(schemas.BifrostContextKeySelectedKeyID, currentKey.ID)
 			ctx.SetValue(schemas.BifrostContextKeySelectedKeyName, currentKey.Name)
+
+			// Resolve any pending rotation marker from the previous failed attempt. Only mark
+			// TriggeredRotation=true if the newly selected key differs from the failed one —
+			// fixed-key paths return the same key, in which case no rotation actually happened.
+			if pendingRotationAttemptIdx >= 0 {
+				if trail, ok := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord); ok &&
+					pendingRotationAttemptIdx < len(trail) &&
+					trail[pendingRotationAttemptIdx].KeyID != currentKey.ID {
+					trail[pendingRotationAttemptIdx].TriggeredRotation = true
+					ctx.SetValue(schemas.BifrostContextKeyAttemptTrail, trail)
+				}
+				pendingRotationAttemptIdx = -1
+			}
 		}
 
 		// Append a trail record for every attempt (key rotation and same-key retries alike).
@@ -5522,6 +5538,17 @@ func executeRequestWithRetries[T any](
 			usedKeyIDs[currentKey.ID] = true
 		}
 		lastWasRateLimit = isRateLimit
+
+		// Record the just-failed attempt as a *candidate* for rotation. The next iteration will
+		// confirm it (and set TriggeredRotation=true) only if key selection actually picks a
+		// different key — this avoids false positives for fixed-key providers whose keyProvider
+		// is non-nil but returns the same key. Network-error retries reuse the same key, and
+		// terminal attempts (attempts == MaxRetries) won't run another iteration.
+		if isRateLimit && keyProvider != nil && attempts < config.NetworkConfig.MaxRetries {
+			if trail, ok := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord); ok && len(trail) > 0 {
+				pendingRotationAttemptIdx = len(trail) - 1
+			}
+		}
 	}
 
 	// Add retry information to error

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -350,14 +350,24 @@ const (
 
 // KeyAttemptRecord captures the outcome of a single request attempt within executeRequestWithRetries.
 // One record is appended per attempt regardless of whether the key changed between attempts.
-// FailReason is supplementary retry metadata: it is populated only when another retry will be
-// attempted (i.e. a non-terminal attempt), and is nil on any terminal attempt — including success,
-// non-retryable failure, or a retryable error when no retries remain.
+//
+// FailReason is populated on every failed attempt (retryable or terminal), and is nil only on a
+// successful attempt. Use it to inspect what went wrong on a given try.
+//
+// TriggeredRotation is true iff this attempt's failure caused the next attempt to rotate to a
+// different key — i.e. a rate-limit error with retries remaining. It is false on:
+//   - the final (terminal) attempt of a request, regardless of outcome,
+//   - any successful attempt,
+//   - network-error retries (same key is reused on transient 5xx),
+//   - non-retryable failures.
+//
+// Use this (not FailReason) to count actual key rotations.
 type KeyAttemptRecord struct {
-	Attempt    int     `json:"attempt"`
-	KeyID      string  `json:"key_id"`
-	KeyName    string  `json:"key_name"`
-	FailReason *string `json:"fail_reason,omitempty"`
+	Attempt           int     `json:"attempt"`
+	KeyID             string  `json:"key_id"`
+	KeyName           string  `json:"key_name"`
+	FailReason        *string `json:"fail_reason,omitempty"`
+	TriggeredRotation bool    `json:"triggered_rotation"`
 }
 
 // RoutingEngineLogEntry represents a log entry from a routing engine

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -349,14 +349,24 @@ const (
 
 // KeyAttemptRecord captures the outcome of a single request attempt within executeRequestWithRetries.
 // One record is appended per attempt regardless of whether the key changed between attempts.
-// FailReason is supplementary retry metadata: it is populated only when another retry will be
-// attempted (i.e. a non-terminal attempt), and is nil on any terminal attempt — including success,
-// non-retryable failure, or a retryable error when no retries remain.
+//
+// FailReason is populated on every failed attempt (retryable or terminal), and is nil only on a
+// successful attempt. Use it to inspect what went wrong on a given try.
+//
+// TriggeredRotation is true iff this attempt's failure caused the next attempt to rotate to a
+// different key — i.e. a rate-limit error with retries remaining. It is false on:
+//   - the final (terminal) attempt of a request, regardless of outcome,
+//   - any successful attempt,
+//   - network-error retries (same key is reused on transient 5xx),
+//   - non-retryable failures.
+//
+// Use this (not FailReason) to count actual key rotations.
 type KeyAttemptRecord struct {
-	Attempt    int     `json:"attempt"`
-	KeyID      string  `json:"key_id"`
-	KeyName    string  `json:"key_name"`
-	FailReason *string `json:"fail_reason,omitempty"`
+	Attempt           int     `json:"attempt"`
+	KeyID             string  `json:"key_id"`
+	KeyName           string  `json:"key_name"`
+	FailReason        *string `json:"fail_reason,omitempty"`
+	TriggeredRotation bool    `json:"triggered_rotation"`
 }
 
 // RoutingEngineLogEntry represents a log entry from a routing engine

--- a/docs/features/observability/default.mdx
+++ b/docs/features/observability/default.mdx
@@ -39,25 +39,33 @@ When Bifrost retries a request (rate-limit or network error) the following field
 |-------|---------|
 | `selected_key_id` / `selected_key_name` | The API key that **successfully** served the request. `null` when all attempts failed - use `attempt_trail` to see which keys were tried. |
 | `number_of_retries` | Total number of attempts minus one. **Does not indicate which key was used on each attempt.** |
-| `attempt_trail` | Ordered array of every attempt, with key used and failure reason. `fail_reason` is `null` on the final attempt. |
+| `attempt_trail` | Ordered array of every attempt. Each entry contains `attempt`, `key_id`, `key_name`, `fail_reason` (set on every failed attempt — including the terminal one — and omitted from the JSON on a successful attempt), and `triggered_rotation` (always present; `true` only when this attempt's rate-limit failure caused the next retry to switch to a different key, `false` otherwise). |
 
 **Example `attempt_trail`** - two rate-limit rotations then success on a third key:
 
 ```json
 "attempt_trail": [
-  { "attempt": 0, "key_id": "key-a", "key_name": "Key A", "fail_reason": "rate_limit_error" },
-  { "attempt": 1, "key_id": "key-b", "key_name": "Key B", "fail_reason": "rate_limit_error" },
-  { "attempt": 2, "key_id": "key-c", "key_name": "Key C", "fail_reason": null }
+  { "attempt": 0, "key_id": "key-a", "key_name": "Key A", "fail_reason": "rate_limit_error", "triggered_rotation": true },
+  { "attempt": 1, "key_id": "key-b", "key_name": "Key B", "fail_reason": "rate_limit_error", "triggered_rotation": true },
+  { "attempt": 2, "key_id": "key-c", "key_name": "Key C", "triggered_rotation": false }
 ]
 ```
 
-Network-error retries reuse the same key; only rate-limit errors rotate to a different key:
+Network-error retries reuse the same key; only rate-limit errors rotate to a different key. `triggered_rotation` is therefore `false` on network-error attempts even when a retry follows:
 
 ```json
 "attempt_trail": [
-  { "attempt": 0, "key_id": "key-a", "key_name": "Key A", "fail_reason": "network_error" },
-  { "attempt": 1, "key_id": "key-a", "key_name": "Key A", "fail_reason": "rate_limit_error" },
-  { "attempt": 2, "key_id": "key-b", "key_name": "Key B", "fail_reason": null }
+  { "attempt": 0, "key_id": "key-a", "key_name": "Key A", "fail_reason": "network_error", "triggered_rotation": false },
+  { "attempt": 1, "key_id": "key-a", "key_name": "Key A", "fail_reason": "rate_limit_error", "triggered_rotation": true },
+  { "attempt": 2, "key_id": "key-b", "key_name": "Key B", "triggered_rotation": false }
+]
+```
+
+For terminal failures (no retry happens, including `max_retries = 0` and non-retryable errors), the trail has a single entry with `fail_reason` set and `triggered_rotation` `false`:
+
+```json
+"attempt_trail": [
+  { "attempt": 0, "key_id": "key-a", "key_name": "Key A", "fail_reason": "invalid_request_error", "triggered_rotation": false }
 ]
 ```
 

--- a/docs/features/observability/prometheus.mdx
+++ b/docs/features/observability/prometheus.mdx
@@ -206,49 +206,62 @@ The following metrics are available from both the `/metrics` endpoint and Push G
 | `bifrost_cache_hits_total` | Counter | Cache hits by type |
 | `bifrost_stream_first_token_latency_seconds` | Histogram | Time to first token (streaming) |
 | `bifrost_stream_inter_token_latency_seconds` | Histogram | Inter-token latency (streaming) |
-| `bifrost_key_rotation_events_total` | Counter | Per-attempt retry/rotation events with key identifiers (see below) <sup>v1.5.0-prerelease4+</sup> |
+| `bifrost_active_requests` | Gauge | LLM requests currently in-flight (labeled by `method` only) |
+| `bifrost_provider_key_up` | Gauge | Per-key health. `1` after a successful attempt, `0` after a failed attempt. Labels: `provider`, `key_id`, `key_name`. |
+| `bifrost_key_rotation_events_total` | Counter | Key rotations triggered by rate-limit failures (see below) <sup>v1.5.0-prerelease4+</sup> |
+| `bifrost_request_retries` | Histogram | Number of retries used per request (observed once per request; buckets `0,1,2,3,5,10`). |
 
 ### Default Labels
 
-All Bifrost metrics include these labels:
+Most request-level Bifrost LLM metrics include these labels (the `bifrost_key_rotation_events_total` counter is an exception — see [Key Rotation Events](#key-rotation-events) below for its narrower label set):
 
 - `provider` - LLM provider name
 - `model` - Model identifier
+- `alias` - Alias resolved to this model (empty if none)
 - `method` - Request type (chat, completion, embedding, etc.)
 - `virtual_key_id` / `virtual_key_name` - Virtual key identifiers
+- `routing_engine_used` - Comma-separated list of routing engines that contributed to the decision (e.g. `governance`, `routing-rule`, `loadbalancing`, `model-catalog`)
+- `routing_rule_id` / `routing_rule_name` - Routing rule that matched the request
 - `selected_key_id` / `selected_key_name` - API key that successfully served the request (`""` when all attempts failed)
-- `number_of_retries` - Total attempts minus one (across all keys)
 - `fallback_index` - Fallback position
-- `team_id` / `team_name` - Team identifiers (if governance enabled)
-- `customer_id` / `customer_name` - Customer identifiers (if governance enabled)
+- `team_id` / `team_name` - Team identifiers (empty when governance is not used)
+- `customer_id` / `customer_name` - Customer identifiers (empty when governance is not used)
 
 <Note>
-  **v1.5.0-prerelease4+**: `selected_key_id` / `selected_key_name` are only populated when the request succeeds. On final errors both are empty - use `bifrost_key_rotation_events_total` or the `attempt_trail` log field to see which keys were tried.
+  **v1.5.0-prerelease4+**: `selected_key_id` / `selected_key_name` are only populated when the request succeeds. On final errors both are empty — use the `attempt_trail` log field to see which keys were tried.
 </Note>
 
 ### Key Rotation Events <sup>v1.5.0-prerelease4+</sup>
 
-`bifrost_key_rotation_events_total` is incremented once per **failed attempt** (not per request), giving you time-series visibility into retry pressure:
+`bifrost_key_rotation_events_total` is incremented once per **actual key rotation** — i.e. when a rate-limit failure causes the next retry to switch to a different key. It is **not** incremented for:
+
+- terminal failures (no retry happens, including `max_retries = 0`),
+- same-key retries on transient network errors,
+- non-retryable failures.
+
+Labels are attributed to the key that failed and triggered the rotation:
 
 | Label | Values | Description |
 |-------|--------|-------------|
 | `provider` | e.g. `openai` | LLM provider |
 | `requested_model` | e.g. `gpt-4o` | Model as requested (before any alias resolution) |
-| `key_id` | UUID | The provider API key that failed on this attempt |
+| `key_id` | UUID | The provider API key that hit a rate limit and was rotated away from |
 | `key_name` | string | Human-readable name of the provider API key |
-| `fail_reason` | error type string | Provider error type (e.g. `rate_limit_error`, `network_error`) |
+| `fail_reason` | error type string | Provider error type that triggered the rotation (typically `rate_limit_error`) |
+
+To inspect every attempted key on a failed request (including terminal failures that did not rotate), read the `attempt_trail` field on the corresponding log entry instead.
 
 **Example queries:**
 
 ```promql
-# Rate-limit events per provider over time
-sum by (provider, fail_reason) (
+# Rate of key rotations per provider
+sum by (provider) (
   rate(bifrost_key_rotation_events_total[5m])
 )
 
 # Which specific keys are hitting rate limits most often
-topk(5, sum by (provider, key_name, fail_reason) (
-  rate(bifrost_key_rotation_events_total{fail_reason="rate_limit_error"}[1h])
+topk(5, sum by (provider, key_name) (
+  rate(bifrost_key_rotation_events_total[1h])
 ))
 ```
 

--- a/docs/features/observability/prometheus.mdx
+++ b/docs/features/observability/prometheus.mdx
@@ -178,49 +178,62 @@ The following metrics are available from both the `/metrics` endpoint and Push G
 | `bifrost_cache_hits_total` | Counter | Cache hits by type |
 | `bifrost_stream_first_token_latency_seconds` | Histogram | Time to first token (streaming) |
 | `bifrost_stream_inter_token_latency_seconds` | Histogram | Inter-token latency (streaming) |
-| `bifrost_key_rotation_events_total` | Counter | Per-attempt retry/rotation events with key identifiers (see below) <sup>v1.5.0-prerelease4+</sup> |
+| `bifrost_active_requests` | Gauge | LLM requests currently in-flight (labeled by `method` only) |
+| `bifrost_provider_key_up` | Gauge | Per-key health. `1` after a successful attempt, `0` after a failed attempt. Labels: `provider`, `key_id`, `key_name`. |
+| `bifrost_key_rotation_events_total` | Counter | Key rotations triggered by rate-limit failures (see below) <sup>v1.5.0-prerelease4+</sup> |
+| `bifrost_request_retries` | Histogram | Number of retries used per request (observed once per request; buckets `0,1,2,3,5,10`). |
 
 ### Default Labels
 
-All Bifrost metrics include these labels:
+Most request-level Bifrost LLM metrics include these labels (the `bifrost_key_rotation_events_total` counter is an exception — see [Key Rotation Events](#key-rotation-events) below for its narrower label set):
 
 - `provider` - LLM provider name
 - `model` - Model identifier
+- `alias` - Alias resolved to this model (empty if none)
 - `method` - Request type (chat, completion, embedding, etc.)
 - `virtual_key_id` / `virtual_key_name` - Virtual key identifiers
+- `routing_engine_used` - Comma-separated list of routing engines that contributed to the decision (e.g. `governance`, `routing-rule`, `loadbalancing`, `model-catalog`)
+- `routing_rule_id` / `routing_rule_name` - Routing rule that matched the request
 - `selected_key_id` / `selected_key_name` - API key that successfully served the request (`""` when all attempts failed)
-- `number_of_retries` - Total attempts minus one (across all keys)
 - `fallback_index` - Fallback position
-- `team_id` / `team_name` - Team identifiers (if governance enabled)
-- `customer_id` / `customer_name` - Customer identifiers (if governance enabled)
+- `team_id` / `team_name` - Team identifiers (empty when governance is not used)
+- `customer_id` / `customer_name` - Customer identifiers (empty when governance is not used)
 
 <Note>
-  **v1.5.0-prerelease4+**: `selected_key_id` / `selected_key_name` are only populated when the request succeeds. On final errors both are empty - use `bifrost_key_rotation_events_total` or the `attempt_trail` log field to see which keys were tried.
+  **v1.5.0-prerelease4+**: `selected_key_id` / `selected_key_name` are only populated when the request succeeds. On final errors both are empty — use the `attempt_trail` log field to see which keys were tried.
 </Note>
 
 ### Key Rotation Events <sup>v1.5.0-prerelease4+</sup>
 
-`bifrost_key_rotation_events_total` is incremented once per **failed attempt** (not per request), giving you time-series visibility into retry pressure:
+`bifrost_key_rotation_events_total` is incremented once per **actual key rotation** — i.e. when a rate-limit failure causes the next retry to switch to a different key. It is **not** incremented for:
+
+- terminal failures (no retry happens, including `max_retries = 0`),
+- same-key retries on transient network errors,
+- non-retryable failures.
+
+Labels are attributed to the key that failed and triggered the rotation:
 
 | Label | Values | Description |
 |-------|--------|-------------|
 | `provider` | e.g. `openai` | LLM provider |
 | `requested_model` | e.g. `gpt-4o` | Model as requested (before any alias resolution) |
-| `key_id` | UUID | The provider API key that failed on this attempt |
+| `key_id` | UUID | The provider API key that hit a rate limit and was rotated away from |
 | `key_name` | string | Human-readable name of the provider API key |
-| `fail_reason` | error type string | Provider error type (e.g. `rate_limit_error`, `network_error`) |
+| `fail_reason` | error type string | Provider error type that triggered the rotation (typically `rate_limit_error`) |
+
+To inspect every attempted key on a failed request (including terminal failures that did not rotate), read the `attempt_trail` field on the corresponding log entry instead.
 
 **Example queries:**
 
 ```promql
-# Rate-limit events per provider over time
-sum by (provider, fail_reason) (
+# Rate of key rotations per provider
+sum by (provider) (
   rate(bifrost_key_rotation_events_total[5m])
 )
 
 # Which specific keys are hitting rate limits most often
-topk(5, sum by (provider, key_name, fail_reason) (
-  rate(bifrost_key_rotation_events_total{fail_reason="rate_limit_error"}[1h])
+topk(5, sum by (provider, key_name) (
+  rate(bifrost_key_rotation_events_total[1h])
 ))
 ```
 

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -47,31 +47,37 @@ Labels:
 
 These metrics track requests forwarded to AI providers:
 
-| Metric                             | Type      | Description                                          | Labels                                    |
-| ---------------------------------- | --------- | ---------------------------------------------------- | ----------------------------------------- |
-| `bifrost_upstream_requests_total`  | Counter   | Total requests forwarded to upstream providers       | Base Labels, custom labels                |
-| `bifrost_success_requests_total`   | Counter   | Total successful requests to upstream providers      | Base Labels, custom labels                |
-| `bifrost_error_requests_total`     | Counter   | Total failed requests to upstream providers          | Base Labels, `status_code`, custom labels |
-| `bifrost_upstream_latency_seconds` | Histogram | Latency of upstream provider requests                | Base Labels, `is_success`, custom labels  |
-| `bifrost_input_tokens_total`       | Counter   | Total input tokens sent to upstream providers        | Base Labels, custom labels                |
-| `bifrost_output_tokens_total`      | Counter   | Total output tokens received from upstream providers | Base Labels, custom labels                |
-| `bifrost_cache_hits_total`         | Counter   | Total cache hits by type (direct/semantic)           | Base Labels, `cache_type`, custom labels  |
-| `bifrost_cost_total`               | Counter   | Total cost in USD for upstream provider requests     | Base Labels, custom labels                |
+| Metric                             | Type      | Description                                                       | Labels                                                |
+| ---------------------------------- | --------- | ----------------------------------------------------------------- | ----------------------------------------------------- |
+| `bifrost_upstream_requests_total`  | Counter   | Total requests forwarded to upstream providers                    | Base Labels, custom labels                            |
+| `bifrost_success_requests_total`   | Counter   | Total successful requests to upstream providers                   | Base Labels, custom labels                            |
+| `bifrost_error_requests_total`     | Counter   | Total failed requests to upstream providers                       | Base Labels, `status_code`, custom labels             |
+| `bifrost_upstream_latency_seconds` | Histogram | Latency of upstream provider requests                             | Base Labels, `is_success`, custom labels              |
+| `bifrost_input_tokens_total`       | Counter   | Total input tokens sent to upstream providers                     | Base Labels, custom labels                            |
+| `bifrost_output_tokens_total`      | Counter   | Total output tokens received from upstream providers              | Base Labels, custom labels                            |
+| `bifrost_cache_hits_total`         | Counter   | Total cache hits by type (direct/semantic)                        | Base Labels, `cache_type`, custom labels              |
+| `bifrost_cost_total`               | Counter   | Total cost in USD for upstream provider requests                  | Base Labels, custom labels                            |
+| `bifrost_active_requests`          | Gauge     | LLM requests currently in-flight                                  | `method`                                              |
+| `bifrost_provider_key_up`          | Gauge     | Per-key health: `1` after a successful attempt, `0` after a failure | `provider`, `key_id`, `key_name`                    |
+| `bifrost_key_rotation_events_total`| Counter   | Key rotations triggered by rate-limit failures (one per actual swap) | `provider`, `requested_model`, `key_id`, `key_name`, `fail_reason` |
+| `bifrost_request_retries`          | Histogram | Number of retries used per request (observed once per request; buckets `0,1,2,3,5,10`). | Base Labels |
 
 Base Labels:
 
 - `provider`: AI provider name (e.g., `openai`, `anthropic`, `azure`)
 - `model`: Model name (e.g., `gpt-4o-mini`, `claude-3-sonnet`)
+- `alias`: Alias resolved to this model (empty if none)
 - `method`: Request type (`chat`, `text`, `embedding`, `speech`, `transcription`)
 - `virtual_key_id`: Virtual key ID
 - `virtual_key_name`: Virtual key name
-- `routing_engines_used`: Comma-separated routing engines used ("routing-rule", "governance", "loadbalancing", "model-catalog")
+- `routing_engine_used`: Comma-separated routing engines used (`routing-rule`, `governance`, `loadbalancing`, `model-catalog`)
 - `routing_rule_id`: Routing rule ID that matched the request
 - `routing_rule_name`: Routing rule name that matched the request
-- `selected_key_id`: ID of the key that successfully served the request (`null` on final errors)
-- `selected_key_name`: Name of the key that successfully served the request (`null` on final errors)
-- `number_of_retries`: Number of retries
+- `selected_key_id`: ID of the key that successfully served the request (empty string `""` on final errors)
+- `selected_key_name`: Name of the key that successfully served the request (empty string `""` on final errors)
 - `fallback_index`: Fallback index (0 for first attempt, 1 for second attempt, etc.)
+- `team_id` / `team_name`: Team identifiers (empty when governance is not used)
+- `customer_id` / `customer_name`: Customer identifiers (empty when governance is not used)
 - custom labels: Custom labels configured in the Bifrost configuration
 
 ### Streaming Metrics

--- a/docs/migration-guides/v1.5.0.mdx
+++ b/docs/migration-guides/v1.5.0.mdx
@@ -557,7 +557,7 @@ The `attempt_trail` is now the authoritative record of every key tried and why e
 |---|---|---|
 | `selected_key_id` | Always set, even on error | Empty string when all retries exhausted |
 | `selected_key_name` | Always set, even on error | Empty string when all retries exhausted |
-| `attempt_trail` | Not present | Array of `{ key_id, key_name, fail_reason }` per attempt |
+| `attempt_trail` | Not present | Array of `{ attempt, key_id, key_name, fail_reason, triggered_rotation }` per attempt. `fail_reason` is set on every failed attempt; `triggered_rotation` is true when this attempt's rate-limit failure caused the next retry to switch keys. |
 
 ### Impact on logging and telemetry plugins
 

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -250,6 +250,7 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 	if err := systemRegistry.Register(goCollector); err != nil {
 		return nil, fmt.Errorf("failed to register Go collector: %v", err)
 	}
+
 	processCollector := collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})
 	if err := systemRegistry.Register(processCollector); err != nil {
 		return nil, fmt.Errorf("failed to register process collector: %v", err)
@@ -453,13 +454,15 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		append(defaultBifrostLabels, filteredCustomLabels...),
 	)
 
-	// bifrostKeyRotationEventsTotal counts individual retry/rotation events from the attempt trail.
-	// One observation is emitted per failed attempt (where fail_reason is non-nil), not per request.
-	// Use this to track rate-limit pressure and network-error frequency per provider/key.
+	// bifrostKeyRotationEventsTotal counts key-swap events from the attempt trail.
+	// One observation is emitted only when a failed attempt triggered rotation to a different key
+	// on the next retry (TriggeredRotation == true, fail_reason non-nil). Use this to track actual
+	// key-rotation pressure per provider/key/failure reason.
+
 	bifrostKeyRotationEventsTotal := factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "bifrost_key_rotation_events_total",
-			Help: "Number of key retry/rotation events, broken down by provider, key, and failure reason. One increment per failed attempt.",
+			Help: "Number of key rotations, broken down by provider, key, and failure reason. One increment per rate-limit failure that triggered a switch to a different key on the next retry.",
 		},
 		[]string{"provider", "requested_model", "key_id", "key_name", "fail_reason"},
 	)
@@ -791,13 +794,16 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 			cost = p.pricingManager.CalculateCost(result, pricingScopes)
 		}
 
-		// Emit one counter increment per failed attempt in the trail (fail_reason != nil).
-		// This decouples per-attempt retry visibility from the per-request metrics above.
+		// Emit one rotation counter increment per attempt that actually caused a key swap on the
+		// next try (rate-limit failure with retries remaining). Mark the key unhealthy on any
+		// failure, since key health is per-failure not per-rotation.
 		for _, record := range attemptTrail {
-			if record.FailReason != nil {
+			if record.TriggeredRotation && record.FailReason != nil {
 				p.KeyRotationEventsTotal.WithLabelValues(
 					string(provider), originalModel, record.KeyID, record.KeyName, *record.FailReason,
 				).Inc()
+			}
+			if record.FailReason != nil {
 				p.ProviderKeyUp.WithLabelValues(string(provider), record.KeyID, record.KeyName).Set(0)
 			}
 		}

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -168,6 +168,7 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 	if err := systemRegistry.Register(goCollector); err != nil {
 		return nil, fmt.Errorf("failed to register Go collector: %v", err)
 	}
+
 	processCollector := collectors.NewProcessCollector(collectors.ProcessCollectorOpts{})
 	if err := systemRegistry.Register(processCollector); err != nil {
 		return nil, fmt.Errorf("failed to register process collector: %v", err)
@@ -337,13 +338,15 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		append(defaultBifrostLabels, filteredCustomLabels...),
 	)
 
-	// bifrostKeyRotationEventsTotal counts individual retry/rotation events from the attempt trail.
-	// One observation is emitted per failed attempt (where fail_reason is non-nil), not per request.
-	// Use this to track rate-limit pressure and network-error frequency per provider/key.
+	// bifrostKeyRotationEventsTotal counts key-swap events from the attempt trail.
+	// One observation is emitted only when a failed attempt triggered rotation to a different key
+	// on the next retry (TriggeredRotation == true, fail_reason non-nil). Use this to track actual
+	// key-rotation pressure per provider/key/failure reason.
+
 	bifrostKeyRotationEventsTotal := factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "bifrost_key_rotation_events_total",
-			Help: "Number of key retry/rotation events, broken down by provider, key, and failure reason. One increment per failed attempt.",
+			Help: "Number of key rotations, broken down by provider, key, and failure reason. One increment per rate-limit failure that triggered a switch to a different key on the next retry.",
 		},
 		[]string{"provider", "requested_model", "key_id", "key_name", "fail_reason"},
 	)
@@ -594,13 +597,16 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 			cost = p.pricingManager.CalculateCost(result, pricingScopes)
 		}
 
-		// Emit one counter increment per failed attempt in the trail (fail_reason != nil).
-		// This decouples per-attempt retry visibility from the per-request metrics above.
+		// Emit one rotation counter increment per attempt that actually caused a key swap on the
+		// next try (rate-limit failure with retries remaining). Mark the key unhealthy on any
+		// failure, since key health is per-failure not per-rotation.
 		for _, record := range attemptTrail {
-			if record.FailReason != nil {
+			if record.TriggeredRotation && record.FailReason != nil {
 				p.KeyRotationEventsTotal.WithLabelValues(
 					string(provider), originalModel, record.KeyID, record.KeyName, *record.FailReason,
 				).Inc()
+			}
+			if record.FailReason != nil {
 				p.ProviderKeyUp.WithLabelValues(string(provider), record.KeyID, record.KeyName).Set(0)
 			}
 		}


### PR DESCRIPTION
## Summary

`KeyAttemptRecord` previously set `fail_reason` only on non-terminal retryable attempts, leaving the final failed attempt with no failure information. Additionally, `bifrost_key_rotation_events_total` was incremented for every failed attempt — including terminal failures and same-key network-error retries — making it impossible to distinguish actual key rotations from other failure types. This PR fixes both issues by introducing a `TriggeredRotation` field on `KeyAttemptRecord` and tightening the semantics of the rotation counter to reflect only genuine key swaps.

## Changes

- Added `TriggeredRotation bool` to `KeyAttemptRecord`. It is set to `true` only when a rate-limit failure causes the next retry to switch to a different key (i.e. not on terminal attempts, network-error retries, or non-retryable failures).
- `fail_reason` is now populated on every failed attempt, including the terminal one, rather than being nil on terminal attempts. This makes the trail a complete failure record regardless of retry outcome.
- `bifrost_key_rotation_events_total` is now incremented only when `TriggeredRotation` is true, so the counter reflects actual key rotations rather than all failed attempts.
- `bifrost_provider_key_up` health gauge is now updated on any failure (not gated on `TriggeredRotation`), preserving per-key health tracking independent of rotation semantics.
- Updated the `bifrost_key_rotation_events_total` help text and documentation to clarify it counts key swaps, not all failed attempts.
- Updated observability and telemetry documentation with corrected `attempt_trail` semantics, new field descriptions, revised example JSON snippets, and updated PromQL example queries.
- Updated the v1.5.0 migration guide to reflect the new `attempt_trail` shape including the `triggered_rotation` field.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./...
```

- Make a request that exhausts multiple keys via rate-limit errors and verify `attempt_trail` shows `triggered_rotation: true` on all but the last entry, and `fail_reason` set on every failed entry including the terminal one.
- Confirm `bifrost_key_rotation_events_total` increments only for rate-limit failures that caused a key swap, not for terminal failures or network-error retries.
- Confirm `bifrost_provider_key_up` reflects `0` after any failure and `1` after a successful attempt on the selected key.
- Verify that a fixed-key provider (where `keyProvider` returns the same key on every call) does not set `triggered_rotation: true` even on rate-limit failures.

## Breaking changes

- [x] Yes
- [ ] No

The semantics of `bifrost_key_rotation_events_total` have changed — it no longer counts all failed attempts, only actual key rotations. Existing dashboards or alerts using this counter as a proxy for all retry failures will under-count and must be updated.

The `fail_reason` field in `attempt_trail` is now populated on terminal failed attempts (previously it was `null`). Consumers that relied on a `null` `fail_reason` to detect the terminal attempt should switch to checking `triggered_rotation` instead.

## Related issues

## Security considerations

No auth, secrets, PII, or sandboxing changes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable