### PR TITLE
feat: add volume histogram chart to MCP logs page and fix drag-select bar click suppression

### DIFF
--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -324,6 +324,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddStopReasonColumn(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddSafeJsonbFunction(ctx, db); err != nil {
+		return err
+	}
 	// migrationSplitFilterDataMatView is intentionally NOT invoked in this
 	// release. Dropping mv_logs_filterdata while old replicas are still
 	// serving /api/logs/filterdata from it would surface "relation does not
@@ -3035,6 +3038,67 @@ func migrationAddStopReasonColumn(ctx context.Context, db *gorm.DB) error {
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while adding stop_reason column: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddSafeJsonbFunction installs a PL/pgSQL helper that the
+// /api/logs list query uses to extract the last element of input_history /
+// responses_input_history without aborting the whole query on a single bad row.
+//
+// The previous inline guard (`left(btrim(x),1)='['`) only checked the first
+// character before casting to jsonb. Any row that looked array-shaped but
+// contained malformed JSON (unterminated structures, trailing commas, unpaired
+// UTF-16 surrogates, etc.) would fail the cast with 22P02 / 22P05 and abort the
+// entire list response. The helper wraps the cast in an EXCEPTION block and
+// returns the raw TEXT on any parse failure.
+//
+// Postgres-only; SQLite is guarded inline in listSelectColumns via json_valid().
+func migrationAddSafeJsonbFunction(ctx context.Context, db *gorm.DB) error {
+	if db.Dialector.Name() != "postgres" {
+		return nil
+	}
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "logs_add_safe_jsonb_function",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			const stmt = `
+CREATE OR REPLACE FUNCTION bifrost_safe_jsonb(t text) RETURNS text
+LANGUAGE plpgsql IMMUTABLE AS $$
+DECLARE
+    j jsonb;
+BEGIN
+    IF t IS NULL OR t = '' OR t = '[]' THEN
+        RETURN t;
+    END IF;
+    IF left(btrim(t), 1) <> '[' THEN
+        RETURN t;
+    END IF;
+    BEGIN
+        j := t::jsonb;
+    EXCEPTION WHEN invalid_text_representation OR untranslatable_character THEN
+        RETURN t;
+    END;
+    IF jsonb_typeof(j) <> 'array' OR jsonb_array_length(j) = 0 THEN
+        RETURN t;
+    END IF;
+    RETURN jsonb_build_array(j->-1)::text;
+END;
+$$;`
+			if err := tx.Exec(stmt).Error; err != nil {
+				return fmt.Errorf("failed to create bifrost_safe_jsonb: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return tx.Exec("DROP FUNCTION IF EXISTS bifrost_safe_jsonb(text)").Error
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding bifrost_safe_jsonb function: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -651,35 +651,35 @@ func (s *RDBLogStore) listSelectColumns() string {
 	var inputHistoryExpr, responsesInputExpr, outputMessageExpr string
 	switch s.db.Dialector.Name() {
 	case "postgres":
-		// Postgres jsonb cannot represent \u0000 (errcode 22P05) and rejects
-		// malformed JSON (22P02). A single bad row would otherwise abort the
-		// whole list query. Guard the cast: only attempt jsonb conversion
-		// when the TEXT looks like a JSON array and contains no \u0000
-		// escape; otherwise fall back to returning the raw TEXT.
+		// Postgres jsonb rejects malformed JSON (22P02), \u0000 escapes
+		// (22P05), and unpaired UTF-16 surrogates (22P05). A single bad row
+		// would otherwise abort the whole list query. bifrost_safe_jsonb
+		// wraps the cast in an EXCEPTION block and returns the raw TEXT on
+		// any parse failure; see migrationAddSafeJsonbFunction.
 		inputHistoryExpr = `CASE
 			WHEN object_type = 'realtime.turn' THEN input_history
-			WHEN input_history IS NOT NULL AND input_history != '' AND input_history != '[]'
-			     AND position('\u0000' in input_history) = 0
-			     AND left(btrim(input_history), 1) = '['
-			THEN jsonb_build_array(input_history::jsonb->-1)::text
-			ELSE input_history END AS input_history`
+			ELSE bifrost_safe_jsonb(input_history)
+			END AS input_history`
 		responsesInputExpr = `CASE
 			WHEN object_type = 'realtime.turn' THEN responses_input_history
-			WHEN responses_input_history IS NOT NULL AND responses_input_history != '' AND responses_input_history != '[]'
-			     AND position('\u0000' in responses_input_history) = 0
-			     AND left(btrim(responses_input_history), 1) = '['
-			THEN jsonb_build_array(responses_input_history::jsonb->-1)::text
-			ELSE responses_input_history END AS responses_input_history`
+			ELSE bifrost_safe_jsonb(responses_input_history)
+			END AS responses_input_history`
 		outputMessageExpr = `CASE WHEN object_type = 'realtime.turn' THEN output_message ELSE NULL END AS output_message`
 	default: // sqlite
 		inputHistoryExpr = `CASE
 			WHEN object_type = 'realtime.turn' THEN input_history
 			WHEN input_history IS NOT NULL AND input_history != '' AND input_history != '[]'
+			     AND json_valid(input_history) = 1
+			     AND json_type(input_history) = 'array'
+			     AND json_array_length(input_history) > 0
 			THEN json_array(json_extract(input_history, '$[' || (json_array_length(input_history) - 1) || ']'))
 			ELSE input_history END AS input_history`
 		responsesInputExpr = `CASE
 			WHEN object_type = 'realtime.turn' THEN responses_input_history
 			WHEN responses_input_history IS NOT NULL AND responses_input_history != '' AND responses_input_history != '[]'
+			     AND json_valid(responses_input_history) = 1
+			     AND json_type(responses_input_history) = 'array'
+			     AND json_array_length(responses_input_history) > 0
 			THEN json_array(json_extract(responses_input_history, '$[' || (json_array_length(responses_input_history) - 1) || ']'))
 			ELSE responses_input_history END AS responses_input_history`
 		outputMessageExpr = `CASE WHEN object_type = 'realtime.turn' THEN output_message ELSE NULL END AS output_message`

--- a/framework/logstore/safe_jsonb_test.go
+++ b/framework/logstore/safe_jsonb_test.go
@@ -1,0 +1,314 @@
+package logstore
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// malformedHistoryCase covers the scenarios that previously aborted /api/logs
+// via the unsafe input_history::jsonb cast (and the mirror cases on
+// responses_input_history). Each case exercises one shape of bad data; the
+// SearchLogs query must complete without error and return every row.
+type malformedHistoryCase struct {
+	name          string
+	objectType    string // defaults to "chat.completion"; set to "realtime.turn" to test passthrough branch
+	inputHistory  string // raw TEXT stored in logs.input_history
+	respHistory   string // raw TEXT stored in logs.responses_input_history
+	shouldCrashPG bool   // true if the row would have aborted the pre-fix Postgres list query
+}
+
+func malformedHistoryCases() []malformedHistoryCase {
+	// Built at runtime so the source file stays free of literal NUL bytes /
+	// lone surrogates that the Go parser would reject.
+	bs := "\\"
+	u0000 := bs + "u0000"
+	uD800 := bs + "uD800"
+	uDC00 := bs + "uDC00"
+
+	// Build a large but valid JSON array to exercise the happy path on inputs
+	// that wouldn't fit comfortably inline.
+	var big strings.Builder
+	big.WriteByte('[')
+	for i := 0; i < 1000; i++ {
+		if i > 0 {
+			big.WriteByte(',')
+		}
+		big.WriteString(`{"role":"user","content":"msg"}`)
+	}
+	big.WriteString(`,{"role":"assistant","content":"last"}]`)
+
+	return []malformedHistoryCase{
+		// ---------- malformed: jsonb cast failures (22P02) ----------
+		{
+			name:          "unterminated_object_in_array",
+			inputHistory:  `[{"role":"user","content":"hi"`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "garbage_after_bracket",
+			inputHistory:  `[abc, not json]`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "trailing_comma",
+			inputHistory:  `[{"role":"user","content":"hi"},]`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "unclosed_array_only",
+			inputHistory:  `[`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "open_bracket_then_brace_unclosed",
+			inputHistory:  `[{`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "nan_value_not_valid_json",
+			inputHistory:  `[NaN]`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "infinity_value_not_valid_json",
+			inputHistory:  `[Infinity]`,
+			shouldCrashPG: true,
+		},
+		// ---------- malformed: jsonb cast failures (22P05 character set) ----------
+		{
+			name:          "unpaired_high_surrogate",
+			inputHistory:  `[{"role":"user","content":"bad ` + uD800 + ` surrogate"}]`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "unpaired_low_surrogate",
+			inputHistory:  `[{"role":"user","content":"bad ` + uDC00 + ` low"}]`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "bad_surrogate_pair_high_then_ascii",
+			inputHistory:  `[{"role":"user","content":"` + uD800 + bs + `u0041"}]`,
+			shouldCrashPG: true,
+		},
+		{
+			name:          "u0000_escape_inside_string",
+			inputHistory:  `[{"role":"user","content":"null byte ` + u0000 + ` here"}]`,
+			shouldCrashPG: true,
+		},
+		// ---------- valid happy path: should pass through fast lane ----------
+		{
+			name:         "literal_backslash_u0000_valid_jsonb",
+			inputHistory: `[{"role":"user","content":"backslash-u-zero \\u0000 literal"}]`,
+		},
+		{
+			name:         "single_element_array",
+			inputHistory: `[{"role":"user","content":"only one"}]`,
+		},
+		{
+			name:         "array_of_primitives",
+			inputHistory: `[1,2,3]`,
+		},
+		{
+			name:         "array_with_null_last_element",
+			inputHistory: `[{"role":"user","content":"x"}, null]`,
+		},
+		{
+			name:         "deeply_nested_valid",
+			inputHistory: `[{"role":"user","content":{"nested":{"deep":{"value":42}}}}]`,
+		},
+		{
+			name:         "unicode_emoji_content",
+			inputHistory: `[{"role":"user","content":"hello 🎉 world ✨"}]`,
+		},
+		{
+			name:         "large_valid_array",
+			inputHistory: big.String(),
+		},
+		// ---------- valid non-array / structurally OK: fall through to raw ----------
+		{
+			name:         "leading_whitespace_then_array",
+			inputHistory: "   [\t{\"role\":\"user\",\"content\":\"ok\"}]",
+		},
+		{
+			name:         "top_level_object_not_array",
+			inputHistory: `{"not":"an array"}`,
+		},
+		{
+			name:         "null_literal",
+			inputHistory: `null`,
+		},
+		{
+			name:         "whitespace_only",
+			inputHistory: "   \t  ",
+		},
+		// ---------- realtime.turn passthrough: outer CASE bypasses safe function ----------
+		{
+			name:         "realtime_turn_malformed_passthrough",
+			objectType:   "realtime.turn",
+			inputHistory: `[{"role":"user"`, // malformed; must not crash even though safe fn is bypassed
+		},
+		// ---------- mirror column ----------
+		{
+			name:          "malformed_responses_input_history",
+			respHistory:   `[{"role":"user"`,
+			shouldCrashPG: true,
+		},
+		{
+			name:        "valid_responses_input_history",
+			respHistory: `[{"role":"user","content":"ok"},{"role":"assistant","content":"hi"}]`,
+		},
+	}
+}
+
+// insertMalformedLog inserts a logs row with the given raw input_history /
+// responses_input_history TEXT values, bypassing GORM serialization so the
+// exact byte sequence reaches the database.
+func insertMalformedLog(t *testing.T, db *gorm.DB, c malformedHistoryCase, ts time.Time) string {
+	t.Helper()
+	id := uuid.New().String()
+	objType := c.objectType
+	if objType == "" {
+		objType = "chat.completion"
+	}
+	err := db.Exec(`
+		INSERT INTO logs (id, timestamp, object_type, provider, model, status,
+			input_history, responses_input_history, created_at)
+		VALUES (?, ?, ?, 'openai', 'gpt-4', 'success', ?, ?, ?)
+	`, id, ts, objType, c.inputHistory, c.respHistory, ts).Error
+	require.NoError(t, err, "failed to insert row for case %q", c.name)
+	return id
+}
+
+// runMalformedHistorySuite exercises SearchLogs against each malformed case
+// and asserts the query completes successfully for every row. Reused by the
+// SQLite and Postgres entry points so both dialect branches of
+// listSelectColumns are covered.
+func runMalformedHistorySuite(t *testing.T, store *RDBLogStore, db *gorm.DB) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	cases := malformedHistoryCases()
+	expectedIDs := make(map[string]string, len(cases))
+	for i, c := range cases {
+		// Spread timestamps so the DESC sort is stable per-case.
+		id := insertMalformedLog(t, db, c, now.Add(-time.Duration(i)*time.Second))
+		expectedIDs[id] = c.name
+	}
+
+	result, err := store.SearchLogs(ctx, SearchFilters{}, PaginationOptions{Limit: 1000})
+	require.NoError(t, err, "SearchLogs must not fail on malformed input_history")
+	require.NotNil(t, result)
+
+	// Every inserted row must come back, regardless of payload shape.
+	gotIDs := make(map[string]bool, len(result.Logs))
+	for _, l := range result.Logs {
+		gotIDs[l.ID] = true
+	}
+	for id, name := range expectedIDs {
+		assert.True(t, gotIDs[id], "row for case %q (id=%s) missing from SearchLogs result", name, id)
+	}
+}
+
+// TestSearchLogs_MalformedInputHistory_SQLite exercises the SQLite branch of
+// listSelectColumns, which now gates json_extract on json_valid + json_type.
+func TestSearchLogs_MalformedInputHistory_SQLite(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	defer store.Close(context.Background())
+	runMalformedHistorySuite(t, store, store.db)
+}
+
+// TestSearchLogs_MalformedInputHistory_Postgres exercises the Postgres branch,
+// which now routes through the bifrost_safe_jsonb PL/pgSQL helper. Skipped
+// when Postgres is unavailable.
+func TestSearchLogs_MalformedInputHistory_Postgres(t *testing.T) {
+	store, db := setupPerfTestDB(t)
+	runMalformedHistorySuite(t, store, db)
+}
+
+// TestBifrostSafeJsonb_DirectInvocation exercises the PL/pgSQL helper in
+// isolation so a regression in the function body shows up here rather than
+// only at the list-query level. Each subtest asserts the exact TEXT the
+// function returns so we can also detect silent behaviour drift on the
+// happy path (e.g. canonical jsonb spacing changes between PG versions).
+func TestBifrostSafeJsonb_DirectInvocation(t *testing.T) {
+	_, db := setupPerfTestDB(t)
+
+	bs := "\\"
+	u0000 := bs + "u0000"
+	uD800 := bs + "uD800"
+	uDC00 := bs + "uDC00"
+
+	// Build large valid array — last element should be `{"last": true}`.
+	var big strings.Builder
+	big.WriteByte('[')
+	for i := 0; i < 500; i++ {
+		big.WriteString(`{"i":`)
+		big.WriteByte(byte('0' + (i % 10)))
+		big.WriteString(`},`)
+	}
+	big.WriteString(`{"last":true}]`)
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// fast-path bypasses
+		{name: "empty_string", in: "", want: ""},
+		{name: "empty_array", in: "[]", want: "[]"},
+
+		// happy path: last-element extraction
+		{name: "valid_two_element_array", in: `[{"a":1},{"b":2}]`, want: `[{"b": 2}]`},
+		{name: "single_element_array", in: `[{"a":1}]`, want: `[{"a": 1}]`},
+		{name: "array_of_primitives", in: `[1,2,3]`, want: `[3]`},
+		{name: "array_with_null_last", in: `[{"a":1},null]`, want: `[null]`},
+		{name: "nested_object_last", in: `[{"x":{"y":{"z":42}}}]`, want: `[{"x": {"y": {"z": 42}}}]`},
+		{name: "large_valid_array_last_only", in: big.String(), want: `[{"last": true}]`},
+
+		// non-array values: function returns raw TEXT unchanged
+		{name: "object_not_array_returns_raw", in: `{"x":1}`, want: `{"x":1}`},
+		{name: "null_literal_returns_raw", in: `null`, want: `null`},
+		{name: "number_literal_returns_raw", in: `42`, want: `42`},
+		{name: "string_literal_returns_raw", in: `"hello"`, want: `"hello"`},
+		{name: "whitespace_only_returns_raw", in: "   \t  ", want: "   \t  "},
+
+		// malformed: EXCEPTION branch catches, returns raw TEXT
+		{name: "unterminated_returns_raw", in: `[{"role":"user"`, want: `[{"role":"user"`},
+		{name: "garbage_after_bracket_returns_raw", in: `[abc]`, want: `[abc]`},
+		{name: "trailing_comma_returns_raw", in: `[1,2,]`, want: `[1,2,]`},
+		{name: "nan_returns_raw", in: `[NaN]`, want: `[NaN]`},
+		{name: "infinity_returns_raw", in: `[Infinity]`, want: `[Infinity]`},
+		{name: "high_surrogate_returns_raw", in: `[{"c":"` + uD800 + `"}]`, want: `[{"c":"` + uD800 + `"}]`},
+		{name: "low_surrogate_returns_raw", in: `[{"c":"` + uDC00 + `"}]`, want: `[{"c":"` + uDC00 + `"}]`},
+		{name: "bad_surrogate_pair_returns_raw", in: `[{"c":"` + uD800 + bs + `u0041"}]`, want: `[{"c":"` + uD800 + bs + `u0041"}]`},
+		{name: "u0000_escape_returns_raw", in: `[{"c":"x` + u0000 + `y"}]`, want: `[{"c":"x` + u0000 + `y"}]`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var got string
+			err := db.Raw("SELECT bifrost_safe_jsonb(?)", c.in).Scan(&got).Error
+			require.NoError(t, err, "bifrost_safe_jsonb must not propagate parse errors")
+			assert.Equal(t, c.want, got)
+		})
+	}
+}
+
+// TestBifrostSafeJsonb_NullInput verifies the function handles SQL NULL
+// (distinct from empty string) by returning NULL without erroring.
+func TestBifrostSafeJsonb_NullInput(t *testing.T) {
+	_, db := setupPerfTestDB(t)
+
+	var got *string
+	err := db.Raw("SELECT bifrost_safe_jsonb(NULL::text)").Scan(&got).Error
+	require.NoError(t, err, "bifrost_safe_jsonb(NULL) must not error")
+	assert.Nil(t, got, "bifrost_safe_jsonb(NULL) should return NULL")
+}

--- a/npx/bifrost/package-lock.json
+++ b/npx/bifrost/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maximhq/bifrost",
-  "version": "1.0.6",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maximhq/bifrost",
-      "version": "1.0.4",
+      "version": "1.6.3",
       "license": "Apache-2.0",
       "bin": {
         "bifrost": "bin.js"

--- a/npx/bifrost/package.json
+++ b/npx/bifrost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maximhq/bifrost",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "High-performance AI gateway CLI - connect to 12+ providers through a single API",
   "keywords": ["ai", "gateway", "openai", "anthropic", "cli", "bifrost"],
   "homepage": "https://github.com/maximhq/bifrost",

--- a/plugins/prompts/go.mod
+++ b/plugins/prompts/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
+	github.com/jackc/pgx/v5 v5.9.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect

--- a/plugins/prompts/go.sum
+++ b/plugins/prompts/go.sum
@@ -90,8 +90,7 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.1 h1:uwrxJXBnx76nyISkhr33kQLlUqjv7et7b9FjCen/tdc=
-github.com/jackc/pgx/v5 v5.9.1/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -413,7 +413,11 @@ func (h *GovernanceHandler) getVirtualKeys(ctx *fasthttp.RequestCtx) {
 			params.Offset = n
 		}
 
-		params.Limit, params.Offset = ClampPaginationParams(params.Limit, params.Offset)
+		if !params.Export {
+			params.Limit, params.Offset = ClampPaginationParams(params.Limit, params.Offset)
+		} else if params.Offset < 0 {
+			params.Offset = 0
+		}
 		virtualKeys, totalCount, err := h.configStore.GetVirtualKeysPaginated(ctx, params)
 		if err != nil {
 			logger.Error("failed to retrieve virtual keys: %v", err)

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -253,19 +253,22 @@ export default function LogsPage() {
 		const now = Math.floor(Date.now() / 1000);
 		const oneHour = now - 1 * 60 * 60;
 		setUrlState({
+			period: "1h",
 			start_time: oneHour,
 			end_time: now,
 			offset: 0,
+			polling: true,
 		});
 	}, [setUrlState]);
 
-	// Check if user has zoomed (time range is different from default 1h)
+	// Zoomed only when a custom absolute range is active (period cleared) and
+	// the range is meaningfully narrower than 1h.
 	const isZoomed = useMemo(() => {
+		if (urlState.period) return false;
 		const currentRange = urlState.end_time - urlState.start_time;
-		const defaultRange = 1 * 60 * 60; // 1 hours in seconds
-		// Consider zoomed if range is less than 90% of default (to account for minor differences)
+		const defaultRange = 1 * 60 * 60;
 		return currentRange < defaultRange * 0.9;
-	}, [urlState.start_time, urlState.end_time]);
+	}, [urlState.start_time, urlState.end_time, urlState.period]);
 
 	const {
 		data: logsData,

--- a/ui/app/workspace/logs/views/logsVolumeChart.tsx
+++ b/ui/app/workspace/logs/views/logsVolumeChart.tsx
@@ -5,7 +5,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Skeleton } from "@/components/ui/skeleton";
-import type { HistogramBucket, LogsHistogramResponse } from "@/lib/types/logs";
+import type { HistogramBucket, LogsHistogramResponse, MCPHistogramResponse } from "@/lib/types/logs";
 import { getUnixRangeForPeriod } from "@/lib/utils/timeRange";
 import { ChevronDown, RotateCcw } from "lucide-react";
 import {
@@ -14,6 +14,7 @@ import {
   type ReactNode,
   useCallback,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
@@ -107,7 +108,7 @@ class ChartErrorBoundary extends Component<
 }
 
 interface LogsVolumeChartProps {
-  data: LogsHistogramResponse | null;
+  data: LogsHistogramResponse | MCPHistogramResponse | null;
   loading?: boolean;
   onTimeRangeChange: (startTime: number, endTime: number) => void;
   onResetZoom?: () => void;
@@ -226,6 +227,9 @@ export function LogsVolumeChart({
   const [refAreaLeft, setRefAreaLeft] = useState<number | null>(null);
   const [refAreaRight, setRefAreaRight] = useState<number | null>(null);
   const [isSelecting, setIsSelecting] = useState(false);
+  // Suppress the Bar onClick that fires immediately after a drag-select mouseUp,
+  // otherwise Recharts overwrites the dragged range with a single-bucket zoom.
+  const suppressNextBarClickRef = useRef(false);
 
   const effectingTimeRange = useMemo(() => {
     if (period) {
@@ -391,8 +395,14 @@ export function LogsVolumeChart({
       const selectionEnd =
         Math.max(leftTime, rightTime) + data.bucket_size_seconds;
 
-      // Only trigger if selection spans at least one bucket
-      if (selectionEnd - selectionStart >= data.bucket_size_seconds) {
+      // Only trigger a range change for real drags (more than one bucket).
+      // For single-bucket gestures, let the trailing Bar onClick own the zoom
+      // so we don't fire onTimeRangeChange twice with the same range.
+      if (
+        refAreaLeft !== refAreaRight &&
+        selectionEnd - selectionStart >= data.bucket_size_seconds
+      ) {
+        suppressNextBarClickRef.current = true;
         onTimeRangeChange(selectionStart, selectionEnd);
       }
     }
@@ -405,6 +415,10 @@ export function LogsVolumeChart({
   // Handle click on a bar (zoom into that bucket)
   const handleBarClick = useCallback(
     (barData: LogVolumeDataPoint | undefined) => {
+      if (suppressNextBarClickRef.current) {
+        suppressNextBarClickRef.current = false;
+        return;
+      }
       if (!data || !barData?.timestamp) return;
 
       const startTime = new Date(barData.timestamp).getTime() / 1000;

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -3,7 +3,8 @@ import FullPageLoader from "@/components/fullPageLoader";
 import { useColumnConfig } from "@/components/table";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Card, CardContent } from "@/components/ui/card";
-import { getErrorMessage, useDeleteMCPLogsMutation, useGetMCPLogsQuery, useGetMCPLogsStatsQuery } from "@/lib/store";
+import { getErrorMessage, useDeleteMCPLogsMutation, useGetMCPHistogramQuery, useGetMCPLogsQuery, useGetMCPLogsStatsQuery } from "@/lib/store";
+import { LogsVolumeChart } from "@/app/workspace/logs/views/logsVolumeChart";
 import { useLazyGetMCPLogsQuery } from "@/lib/store/apis/mcpLogsApi";
 import type { MCPToolLogEntry, MCPToolLogFilters, Pagination } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
@@ -64,6 +65,7 @@ export default function MCPLogsPage() {
 
 	const selectedLogId = urlState.selected_log || null;
 	const polling = urlState.polling;
+	const [isChartOpen, setIsChartOpen] = useState(true);
 
 
 	// Convert URL state to filters and pagination for API calls.
@@ -131,10 +133,56 @@ export default function MCPLogsPage() {
 		},
 	);
 
+	const {
+		data: histogram,
+		isLoading: histogramIsLoading,
+		refetch: refetchHistogram,
+	} = useGetMCPHistogramQuery(
+		{ filters },
+		{
+			pollingInterval: polling ? 10000 : 0,
+			skipPollingIfUnfocused: true,
+		},
+	);
+
 	const refreshAllData = useCallback(() => {
 		refetchLogs();
 		refetchStats();
-	}, [refetchLogs, refetchStats]);
+		refetchHistogram();
+	}, [refetchLogs, refetchStats, refetchHistogram]);
+
+	const handleTimeRangeChange = useCallback(
+		(startTime: number, endTime: number) => {
+			userModifiedTimeRange.current = true;
+			setUrlState({
+				period: "",
+				start_time: startTime,
+				end_time: endTime,
+				offset: 0,
+				polling: false,
+			});
+		},
+		[setUrlState],
+	);
+
+	const handleResetZoom = useCallback(() => {
+		const now = Math.floor(Date.now() / 1000);
+		const oneHour = now - 1 * 60 * 60;
+		setUrlState({
+			period: "1h",
+			start_time: oneHour,
+			end_time: now,
+			offset: 0,
+			polling: true,
+		});
+	}, [setUrlState]);
+
+	const isZoomed = useMemo(() => {
+		if (urlState.period) return false;
+		const currentRange = urlState.end_time - urlState.start_time;
+		const defaultRange = 1 * 60 * 60;
+		return currentRange < defaultRange * 0.9;
+	}, [urlState.start_time, urlState.end_time, urlState.period]);
 
 	// Derive data directly from RTK
 	const logs = logsData?.logs ?? [];
@@ -401,6 +449,21 @@ export default function MCPLogsPage() {
 										</CardContent>
 									</Card>
 								))}
+							</div>
+
+							<div className="mt-2">
+								<LogsVolumeChart
+									data={histogram ?? null}
+									loading={histogramIsLoading}
+									onTimeRangeChange={handleTimeRangeChange}
+									onResetZoom={handleResetZoom}
+									isZoomed={isZoomed}
+									startTime={urlState.start_time}
+									endTime={urlState.end_time}
+									period={urlState.period}
+									isOpen={isChartOpen}
+									onOpenChange={setIsChartOpen}
+								/>
 							</div>
 
 							{displayError && (

--- a/ui/components/prompts/context.tsx
+++ b/ui/components/prompts/context.tsx
@@ -1,5 +1,6 @@
 import { extractVariablesFromMessages, mergeVariables, Message, MessageRole, MessageType, type VariableMap } from "@/lib/message";
 import { getErrorMessage } from "@/lib/store";
+import { useGetCoreConfigQuery } from "@/lib/store/apis/configApi";
 import {
 	useDeleteFolderMutation,
 	useDeletePromptMutation,
@@ -55,6 +56,11 @@ interface PromptContextValue {
 	// Jinja2 variables
 	variables: VariableMap;
 	setVariables: React.Dispatch<React.SetStateAction<VariableMap>>;
+
+	// Custom request headers (used to satisfy server-configured required headers)
+	customHeaders: Record<string, string>;
+	setCustomHeaders: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+	requiredHeaders: string[];
 
 	// Sheet states
 	folderSheet: { open: boolean; folder?: Folder };
@@ -155,6 +161,33 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 	const [isStreaming, setIsStreaming] = useState(false);
 	const activeRunRef = useRef<symbol | null>(null);
 	const [variables, setVariables] = useState<VariableMap>({});
+	const [customHeaders, setCustomHeaders] = useState<Record<string, string>>({});
+
+	// Sync customHeaders keys with the server-configured required_headers list.
+	// Adds new keys (empty), removes keys no longer required, preserves user-entered values.
+	const { data: coreConfig } = useGetCoreConfigQuery({});
+	const requiredHeaders = useMemo<string[]>(() => {
+		const raw = coreConfig?.client_config?.required_headers;
+		if (!Array.isArray(raw)) return [];
+		return raw.map((item) => String(item)).filter((s) => s.length > 0);
+	}, [coreConfig]);
+	useEffect(() => {
+		setCustomHeaders((prev) => {
+			if (requiredHeaders.length === 0) {
+				return Object.keys(prev).length > 0 ? {} : prev;
+			}
+			const next: Record<string, string> = {};
+			let changed = false;
+			for (const name of requiredHeaders) {
+				next[name] = prev[name] ?? "";
+				if (!(name in prev)) changed = true;
+			}
+			for (const name of Object.keys(prev)) {
+				if (!requiredHeaders.includes(name)) changed = true;
+			}
+			return changed ? next : prev;
+		});
+	}, [requiredHeaders]);
 
 	// Fetch model datasheet for capabilities
 	const { data: datasheetData } = useGetModelParametersQuery(model, { skip: !model });
@@ -430,7 +463,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			await executePrompt(
 				messages,
 				pendingMessage,
-				{ provider, model, modelParams, apiKeyId, variables },
+				{ provider, model, modelParams, apiKeyId, variables, customHeaders },
 				{
 					onStreamingStart: (allMessages, placeholder) => {
 						if (!isActive()) return;
@@ -481,7 +514,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 				},
 			);
 		},
-		[messages, provider, model, modelParams, apiKeyId, variables],
+		[messages, provider, model, modelParams, apiKeyId, variables, customHeaders],
 	);
 
 	const handleSubmitToolResult = useCallback(
@@ -509,7 +542,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 			await executePrompt(
 				newMessages,
 				undefined,
-				{ provider, model, modelParams, apiKeyId, variables },
+				{ provider, model, modelParams, apiKeyId, variables, customHeaders },
 				{
 					onStreamingStart: (allMessages, placeholder) => {
 						if (!isActive()) return;
@@ -560,7 +593,7 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 				},
 			);
 		},
-		[messages, provider, model, modelParams, apiKeyId, variables],
+		[messages, provider, model, modelParams, apiKeyId, variables, customHeaders],
 	);
 
 	const value: PromptContextValue = {
@@ -592,6 +625,9 @@ export function PromptProvider({ children }: { children: ReactNode }) {
 		setApiKeyId,
 		variables,
 		setVariables,
+		customHeaders,
+		setCustomHeaders,
+		requiredHeaders,
 		folderSheet,
 		setFolderSheet,
 		promptSheet,

--- a/ui/components/prompts/fragments/settingsPanel.tsx
+++ b/ui/components/prompts/fragments/settingsPanel.tsx
@@ -6,6 +6,7 @@ import { ModelMultiselect } from "@/components/ui/modelMultiselect";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getProviderLabel } from "@/lib/constants/logs";
+import { Input } from "@/components/ui/input";
 import { useGetVirtualKeysQuery } from "@/lib/store";
 import { useGetAllKeysQuery, useGetProvidersQuery } from "@/lib/store/apis/providersApi";
 import { ModelProviderName } from "@/lib/types/config";
@@ -29,6 +30,9 @@ export function SettingsPanel() {
 		setApiKeyId,
 		variables,
 		setVariables,
+		customHeaders,
+		setCustomHeaders,
+		requiredHeaders,
 		selectedPromptId,
 	} = usePromptContext();
 
@@ -210,6 +214,36 @@ export function SettingsPanel() {
 									<>
 										<Separator />
 										<VariablesTableView variables={variables} onChange={setVariables} />
+									</>
+								)}
+
+								{requiredHeaders.length > 0 && (
+									<>
+										<Separator />
+										<div className="flex flex-col gap-2" data-testid="settings-required-headers">
+											<Label className="text-muted-foreground text-xs font-medium uppercase">Required Headers</Label>
+											<p className="text-muted-foreground text-xs">
+												These headers are required by the server. Provide a value for each to send requests from the playground.
+											</p>
+											<div className="flex flex-col gap-2">
+												{requiredHeaders.map((name) => (
+													<div key={name} className="flex items-center gap-2">
+														<Label htmlFor={`required-header-${name}`} className="w-40 shrink-0 truncate text-xs font-mono">
+															{name}
+														</Label>
+														<Input
+															id={`required-header-${name}`}
+															value={customHeaders[name] ?? ""}
+															onChange={(e) =>
+																setCustomHeaders((prev) => ({ ...prev, [name]: e.target.value }))
+															}
+															placeholder="value"
+															className="h-8 flex-1"
+														/>
+													</div>
+												))}
+											</div>
+										</div>
 									</>
 								)}
 

--- a/ui/components/prompts/utils/executor.ts
+++ b/ui/components/prompts/utils/executor.ts
@@ -8,6 +8,7 @@ export interface ExecutionConfig {
 	modelParams: ModelParams;
 	apiKeyId: string;
 	variables?: VariableMap;
+	customHeaders?: Record<string, string>;
 }
 
 function getBaseUrl() {
@@ -54,6 +55,21 @@ export async function executePrompt(
 				headers["Authorization"] = `Bearer ${config.apiKeyId}`;
 			} else {
 				headers["x-bf-api-key-id"] = config.apiKeyId;
+			}
+		}
+		if (config.customHeaders) {
+			// System headers we set above; custom headers must not overwrite them — doing
+			// so would break JSON parsing (Content-Type) or silently swap auth credentials.
+			const reserved = new Set(["content-type", "authorization", "x-bf-api-key-id"]);
+			for (const [name, value] of Object.entries(config.customHeaders)) {
+				const trimmedName = name.trim();
+				const trimmedValue = value.trim();
+				if (!trimmedName || !trimmedValue) continue;
+				if (reserved.has(trimmedName.toLowerCase())) {
+					console.warn(`Ignoring custom header "${trimmedName}" — reserved by the playground.`);
+					continue;
+				}
+				headers[trimmedName] = trimmedValue;
 			}
 		}
 

--- a/ui/lib/store/apis/mcpLogsApi.ts
+++ b/ui/lib/store/apis/mcpLogsApi.ts
@@ -208,6 +208,7 @@ export const {
 	useLazyGetMCPLogByIdQuery,
 	useLazyGetMCPLogsStatsQuery,
 	useLazyGetMCPAvailableFilterDataQuery,
+	useGetMCPHistogramQuery,
 	useLazyGetMCPHistogramQuery,
 	useLazyGetMCPCostHistogramQuery,
 	useLazyGetMCPTopToolsQuery,


### PR DESCRIPTION
## Summary

Adds a log volume histogram chart to the MCP Logs page, matching the existing chart behavior on the main Logs page. Also fixes a bug where clicking a bar immediately after a drag-select would overwrite the dragged time range with a single-bucket zoom.

## Changes

- Added `useGetMCPHistogramQuery` to the MCP Logs page to fetch histogram data with optional polling, and rendered the `LogsVolumeChart` component in the MCP Logs view.
- Added `handleTimeRangeChange`, `handleResetZoom`, and `isZoomed` logic to the MCP Logs page, mirroring the behavior already present on the main Logs page.
- Fixed `isZoomed` on the main Logs page to return `false` when a named `period` (e.g. `"1h"`) is active, so resetting zoom correctly clears the zoomed state.
- When resetting zoom, `period: "1h"` and `polling: true` are now explicitly set in URL state to ensure the page returns to a live-polling relative range.
- Fixed a race condition in `LogsVolumeChart` where Recharts fires a Bar `onClick` event immediately after a drag-select `mouseUp`, which was overwriting the dragged range with a single-bucket zoom. A `suppressNextBarClickRef` ref is set during drag completion and cleared on the next bar click to suppress the spurious event.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] UI (React)

## How to test

1. Navigate to the MCP Logs page and confirm the log volume histogram chart renders and updates with polling.
2. Click a bar in the histogram and confirm the time range zooms into that bucket.
3. Drag-select a range on the histogram and confirm the time range updates to the dragged selection without immediately snapping to a single bucket.
4. Click "Reset Zoom" and confirm the chart returns to the default 1-hour live-polling view.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

Before: MCP Logs page had no histogram chart.
After: MCP Logs page displays the log volume histogram with zoom, drag-select, and reset zoom functionality identical to the main Logs page.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable