### PR TITLE
fix: include `mcp.tool_manager_config` in client config hash and sync tool manager settings on reload

### DIFF
--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -119,12 +119,47 @@ func (c *MCPConfig) UnmarshalJSON(data []byte) error {
 }
 
 type MCPToolManagerConfig struct {
-	// ToolExecutionTimeout accepts a Go duration string (e.g. "30s", "2m") or an
-	// integer nanosecond value for backward compatibility.
+	// ToolExecutionTimeout accepts a Go duration string (e.g. "30s", "2m") or a
+	// bare integer treated as seconds (e.g. 30 → 30s). This intentionally differs
+	// from schemas.Duration, which treats bare integers as nanoseconds.
 	ToolExecutionTimeout  Duration             `json:"tool_execution_timeout"`
 	MaxAgentDepth         int                  `json:"max_agent_depth"`
 	CodeModeBindingLevel  CodeModeBindingLevel `json:"code_mode_binding_level,omitempty"`  // How tools are exposed in VFS: "server" or "tool"
 	DisableAutoToolInject bool                 `json:"disable_auto_tool_inject,omitempty"` // When true, MCP tools are not injected into requests by default
+}
+
+// UnmarshalJSON implements json.Unmarshaler so that tool_execution_timeout treats
+// bare integers as seconds (matching the schema description and user expectation)
+// rather than the nanosecond interpretation used by the underlying Duration type.
+func (c *MCPToolManagerConfig) UnmarshalJSON(data []byte) error {
+	// Use an alias to avoid infinite recursion, then fix up ToolExecutionTimeout.
+	type alias MCPToolManagerConfig
+	aux := &struct {
+		ToolExecutionTimeout *json.RawMessage `json:"tool_execution_timeout,omitempty"`
+		*alias
+	}{alias: (*alias)(c)}
+
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	if aux.ToolExecutionTimeout == nil {
+		return nil
+	}
+
+	raw := *aux.ToolExecutionTimeout
+	// If it's a quoted string, delegate to the normal Duration parser ("30s", "2m", etc.)
+	if len(raw) > 0 && raw[0] == '"' {
+		return json.Unmarshal(raw, &c.ToolExecutionTimeout)
+	}
+
+	// Bare integer: treat as seconds (not nanoseconds).
+	var n int64
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return fmt.Errorf("invalid tool_execution_timeout: expected a duration string (e.g. \"30s\") or integer seconds: %w", err)
+	}
+	c.ToolExecutionTimeout = Duration(time.Duration(n) * time.Second)
+	return nil
 }
 
 const (

--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -70,7 +70,7 @@ Controls the worker pool, logging pipeline, security, and SDK shims. All fields 
 | `prometheus_labels` | array | `[]` | Custom labels for all Prometheus metrics |
 | `compat` | object | - | SDK compatibility shims (`should_drop_params`, `convert_text_to_chat`, etc.) |
 | `mcp_agent_depth` | integer | `10` | Max tool-call recursion depth |
-| `mcp_tool_execution_timeout` | integer | `30` | Per-tool execution timeout in seconds |
+| `mcp_tool_execution_timeout` | integer or string | `30` | Per-tool execution timeout in seconds (integer = seconds, string = Go duration like "30s", "2m") |
 | `mcp_tool_sync_interval` | integer | `10` | Tool sync interval in minutes (`0` = disabled) |
 | `mcp_disable_auto_tool_inject` | boolean | `false` | Disable automatic MCP tool injection |
 | `async_job_result_ttl` | integer | `3600` | TTL for async job results in seconds |

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"hash"
 	"maps"
+	"math"
 	"sort"
 	"strconv"
 
@@ -362,6 +363,27 @@ func (c *ClientConfig) GenerateClientConfigHash() (string, error) {
 	}
 
 	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+// GenerateClientConfigHashWithToolManager extends GenerateClientConfigHash to also cover
+// the mcp.tool_manager_config file section. When tm is nil it returns the same value as
+// GenerateClientConfigHash, so it is safe to call unconditionally.
+func (c *ClientConfig) GenerateClientConfigHashWithToolManager(tm *schemas.MCPToolManagerConfig) (string, error) {
+	base, err := c.GenerateClientConfigHash()
+	if err != nil || tm == nil {
+		return base, err
+	}
+	h := sha256.New()
+	h.Write([]byte(base))
+	h.Write([]byte("toolMgrAgentDepth:" + strconv.Itoa(tm.MaxAgentDepth)))
+	h.Write([]byte("toolMgrTimeout:" + strconv.FormatInt(int64(math.Ceil(tm.ToolExecutionTimeout.D().Seconds())), 10)))
+	h.Write([]byte("toolMgrCodeMode:" + string(tm.CodeModeBindingLevel)))
+	if tm.DisableAutoToolInject {
+		h.Write([]byte("toolMgrDisableAutoInject:true"))
+	} else {
+		h.Write([]byte("toolMgrDisableAutoInject:false"))
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 // Redacted returns a copy of ClientConfig with any env-backed EnvVar fields masked.

--- a/helm-charts/bifrost/Chart.yaml
+++ b/helm-charts/bifrost/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: bifrost
 description: A Helm chart for deploying Bifrost - AI Gateway with unified interface for multiple providers
 type: application
-version: 2.1.15
+version: 2.1.16
 appVersion: "1.5.0"
 keywords:
   - ai

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -563,7 +563,7 @@ bifrost:
 |-----------|-------------|---------|
 | `bifrost.mcp.enabled` | Enable MCP (Model Context Protocol) | `false` |
 | `bifrost.mcp.clientConfigs` | Array of MCP client configurations | `[]` |
-| `bifrost.mcp.toolManagerConfig.toolExecutionTimeout` | Tool execution timeout in seconds | `30` |
+| `bifrost.mcp.toolManagerConfig.toolExecutionTimeout` | Tool execution timeout. Integer = seconds, string = Go duration (e.g. `"30s"`, `"2m"`). Prefer the string form. | `"30s"` |
 | `bifrost.mcp.toolManagerConfig.maxAgentDepth` | Maximum agent depth | `10` |
 | `bifrost.mcp.toolManagerConfig.codeModeBindingLevel` | Code mode binding level (`server` or `tool`) | `server` |
 | `bifrost.mcp.toolManagerConfig.disableAutoToolInject` | Disable automatic MCP tool injection | `false` |

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -541,10 +541,9 @@
               "type": "object",
               "properties": {
                 "toolExecutionTimeout": {
-                  "type": "integer",
-                  "description": "Tool execution timeout in seconds",
-                  "minimum": 1,
-                  "default": 30
+                  "type": ["integer", "string"],
+                  "description": "Tool execution timeout. Integer = seconds (e.g. 30), string = Go duration (e.g. \"30s\", \"2m\"). Prefer the string form.",
+                  "default": "30s"
                 },
                 "maxAgentDepth": {
                   "type": "integer",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -355,7 +355,7 @@ bifrost:
     # toolSyncInterval: "10m"   # Global tool sync interval (Go duration string, e.g. "10m", "1h", "0s")
     # Tool manager configuration
     toolManagerConfig:
-      toolExecutionTimeout: 30
+      toolExecutionTimeout: "30s"
       maxAgentDepth: 10
       # codeModeBindingLevel: "server"  # Code mode binding level (server or tool)
       # disableAutoToolInject: false    # Disable automatic MCP tool injection

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,6 +3,30 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.5.0
+    created: "2026-05-12T19:31:15.185424+05:30"
+    description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
+      for multiple providers
+    digest: 5bca59decc109f5a57d8a6c739bacd2108a8dc7ce70d66721c9f734fa8ac8645
+    home: https://www.getmaxim.ai/bifrost
+    icon: https://www.getbifrost.ai/favicon.png
+    keywords:
+    - ai
+    - gateway
+    - llm
+    - openai
+    - anthropic
+    maintainers:
+    - email: support@getbifrost.ai
+      name: Bifrost Team
+    name: bifrost
+    sources:
+    - https://github.com/maximhq/bifrost
+    type: application
+    urls:
+    - https://maximhq.github.io/bifrost/helm-charts/bifrost-2.1.16.tgz
+    version: 2.1.16
+  - apiVersion: v2
+    appVersion: 1.5.0
     created: "2026-05-11T19:50:28.71576+05:30"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers
@@ -868,4 +892,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-05-11T19:50:28.712935+05:30"
+generated: "2026-05-12T19:31:15.183068+05:30"

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -710,7 +710,9 @@ func sanitizeMCPExternalOAuthURLs(client *configstore.ClientConfig) {
 	}
 }
 
-// loadClientConfig loads and merges client config from file with store using hash-based reconciliation
+// loadClientConfig loads and merges client config from file with store using hash-based reconciliation.
+// The hash covers both the client section and mcp.tool_manager_config so that UI changes to either
+// survive restarts when the file is unchanged.
 func loadClientConfig(ctx context.Context, config *Config, configData *ConfigData) {
 	var clientConfig *configstore.ClientConfig
 	var err error
@@ -720,6 +722,13 @@ func loadClientConfig(ctx context.Context, config *Config, configData *ConfigDat
 			logger.Warn("failed to get client config from store: %v", err)
 		}
 	}
+
+	// toolManagerFromFile returns the mcp.tool_manager_config section of the file, or nil.
+	var toolManagerFromFile *schemas.MCPToolManagerConfig
+	if configData.MCP != nil {
+		toolManagerFromFile = configData.MCP.ToolManagerConfig
+	}
+
 	// Case 1: No config in DB - use file config (or defaults)
 	if clientConfig == nil {
 		logger.Debug("client config not found in store, using config file")
@@ -727,8 +736,8 @@ func loadClientConfig(ctx context.Context, config *Config, configData *ConfigDat
 			sanitizeMCPExternalOAuthURLs(configData.Client)
 			config.ClientConfig = configData.Client
 			applyClientConfigDefaults(config.ClientConfig)
-			// Generate hash for the file config
-			fileHash, hashErr := configData.Client.GenerateClientConfigHash()
+			applyToolManagerToClientConfig(config.ClientConfig, toolManagerFromFile)
+			fileHash, hashErr := configData.Client.GenerateClientConfigHashWithToolManager(toolManagerFromFile)
 			if hashErr != nil {
 				logger.Warn("failed to generate client config hash: %v", hashErr)
 			} else {
@@ -736,8 +745,8 @@ func loadClientConfig(ctx context.Context, config *Config, configData *ConfigDat
 			}
 		} else {
 			config.ClientConfig = new(DefaultClientConfig)
-			// Generate hash for default config
-			defaultHash, hashErr := config.ClientConfig.GenerateClientConfigHash()
+			applyToolManagerToClientConfig(config.ClientConfig, toolManagerFromFile)
+			defaultHash, hashErr := config.ClientConfig.GenerateClientConfigHashWithToolManager(toolManagerFromFile)
 			if hashErr != nil {
 				logger.Warn("failed to generate default client config hash: %v", hashErr)
 			} else {
@@ -760,30 +769,71 @@ func loadClientConfig(ctx context.Context, config *Config, configData *ConfigDat
 		logger.Debug("no client config in file, using DB config")
 		return
 	}
-	// Case 2b: Both DB and file config exist - use hash-based reconciliation
-	fileHash, hashErr := configData.Client.GenerateClientConfigHash()
+	// Case 2b: Both DB and file config exist - use hash-based reconciliation.
+	// The hash covers both the client section and mcp.tool_manager_config so a change
+	// in either section triggers a file-wins sync.
+	fileHash, hashErr := configData.Client.GenerateClientConfigHashWithToolManager(toolManagerFromFile)
 	if hashErr != nil {
 		logger.Warn("failed to generate client config hash from file: %v", hashErr)
 		return
 	}
-	if clientConfig.ConfigHash != fileHash {
-		// Hash mismatch - config.json was changed, sync from file
+	if clientConfig.ConfigHash == fileHash {
+		// Hash matches - keep DB config (preserves UI changes to both client and tool manager settings)
+		logger.Debug("client config hash matches, keeping DB config")
+	} else if baseHash, baseErr := configData.Client.GenerateClientConfigHash(); baseErr == nil &&
+		clientConfig.ConfigHash == baseHash && toolManagerFromFile != nil {
+		// Legacy hash match (pre-upgrade): the stored hash covers only the client section and
+		// matches the file, meaning the client section is unchanged. Only apply the tool manager
+		// settings from the file so that client-section UI changes survive the upgrade.
+		logger.Info("upgrading config hash to include mcp.tool_manager_config; applying tool manager settings from file, client config preserved from DB")
+		applyToolManagerToClientConfig(config.ClientConfig, toolManagerFromFile)
+		config.ClientConfig.ConfigHash = fileHash
+		if config.ConfigStore != nil {
+			if err = config.ConfigStore.UpdateClientConfig(ctx, config.ClientConfig); err != nil {
+				logger.Warn("failed to update client config: %v", err)
+			}
+		}
+	} else {
+		// Full hash mismatch - file changed, sync from file (file takes precedence)
 		logger.Info("client config was updated in config.json, syncing. Note that: file config takes precedence.")
 		sanitizeMCPExternalOAuthURLs(configData.Client)
 		config.ClientConfig = configData.Client
 		config.ClientConfig.ConfigHash = fileHash
 		applyClientConfigDefaults(config.ClientConfig)
-		// Update store with file config
+		applyToolManagerToClientConfig(config.ClientConfig, toolManagerFromFile)
 		if config.ConfigStore != nil {
 			logger.Debug("updating client config in store from file")
 			if err = config.ConfigStore.UpdateClientConfig(ctx, config.ClientConfig); err != nil {
 				logger.Warn("failed to update client config: %v", err)
 			}
 		}
-	} else {
-		// Hash matches - keep DB config (preserves UI changes)
-		logger.Debug("client config hash matches, keeping DB config")
 	}
+}
+
+// applyToolManagerToClientConfig copies tool manager settings from the file into ClientConfig.
+// Only called when the file has changed (hash mismatch) or on first startup.
+// Zero/empty file values reset the field to its default so users can remove a setting
+// from the file and have it revert to the default rather than being silently preserved.
+func applyToolManagerToClientConfig(cc *configstore.ClientConfig, tm *schemas.MCPToolManagerConfig) {
+	if tm == nil {
+		return
+	}
+	if tm.MaxAgentDepth > 0 {
+		cc.MCPAgentDepth = tm.MaxAgentDepth
+	} else {
+		cc.MCPAgentDepth = DefaultClientConfig.MCPAgentDepth
+	}
+	if d := tm.ToolExecutionTimeout.D(); d > 0 {
+		cc.MCPToolExecutionTimeout = int(math.Ceil(d.Seconds()))
+	} else {
+		cc.MCPToolExecutionTimeout = DefaultClientConfig.MCPToolExecutionTimeout
+	}
+	if tm.CodeModeBindingLevel != "" {
+		cc.MCPCodeModeBindingLevel = string(tm.CodeModeBindingLevel)
+	} else {
+		cc.MCPCodeModeBindingLevel = DefaultClientConfig.MCPCodeModeBindingLevel
+	}
+	cc.MCPDisableAutoToolInject = tm.DisableAutoToolInject
 }
 
 // loadProviders loads and merges providers from file with store using hash reconciliation
@@ -1195,33 +1245,24 @@ func applyMCPGlobalSettingsToClientConfig(ctx context.Context, config *Config, m
 		return
 	}
 
-	changed := false
-	if mcpCfg.ToolManagerConfig != nil {
-		if mcpCfg.ToolManagerConfig.MaxAgentDepth > 0 && config.ClientConfig.MCPAgentDepth != mcpCfg.ToolManagerConfig.MaxAgentDepth {
-			config.ClientConfig.MCPAgentDepth = mcpCfg.ToolManagerConfig.MaxAgentDepth
-			changed = true
-		}
-		if d := mcpCfg.ToolManagerConfig.ToolExecutionTimeout.D(); d > 0 {
-			// Ceiling-round to whole seconds: any sub-second value (e.g. 500ms) becomes 1s
-			// rather than being truncated to 0 and silently treated as "unset".
-			toolTimeoutSec := int(math.Ceil(d.Seconds()))
-			if config.ClientConfig.MCPToolExecutionTimeout != toolTimeoutSec {
-				config.ClientConfig.MCPToolExecutionTimeout = toolTimeoutSec
-				changed = true
-			}
-		}
-		if mcpCfg.ToolManagerConfig.CodeModeBindingLevel != "" {
-			codeModeLevel := string(mcpCfg.ToolManagerConfig.CodeModeBindingLevel)
-			if config.ClientConfig.MCPCodeModeBindingLevel != codeModeLevel {
-				config.ClientConfig.MCPCodeModeBindingLevel = codeModeLevel
-				changed = true
-			}
-		}
-		if config.ClientConfig.MCPDisableAutoToolInject != mcpCfg.ToolManagerConfig.DisableAutoToolInject {
-			config.ClientConfig.MCPDisableAutoToolInject = mcpCfg.ToolManagerConfig.DisableAutoToolInject
-			changed = true
-		}
+	// Backfill MCPConfig.ToolManagerConfig from ClientConfig so bifrost.Init always receives
+	// the authoritative values (which may be DB values preserved by hash reconciliation in
+	// loadClientConfig, or file values applied there on hash mismatch).
+	// Allocate if absent so bifrost.Init never falls back to hardcoded defaults.
+	if mcpCfg.ToolManagerConfig == nil {
+		mcpCfg.ToolManagerConfig = &schemas.MCPToolManagerConfig{}
 	}
+	mcpCfg.ToolManagerConfig.MaxAgentDepth = config.ClientConfig.MCPAgentDepth
+	mcpCfg.ToolManagerConfig.ToolExecutionTimeout = schemas.Duration(
+		time.Duration(config.ClientConfig.MCPToolExecutionTimeout) * time.Second,
+	)
+	mcpCfg.ToolManagerConfig.CodeModeBindingLevel = schemas.CodeModeBindingLevel(
+		config.ClientConfig.MCPCodeModeBindingLevel,
+	)
+	mcpCfg.ToolManagerConfig.DisableAutoToolInject = config.ClientConfig.MCPDisableAutoToolInject
+
+	// ToolSyncInterval lives only in MCPConfig (not a ClientConfig field), so reconcile separately.
+	changed := false
 	if mcpCfg.ToolSyncInterval == 0 {
 		if config.ClientConfig.MCPToolSyncInterval != 0 {
 			config.ClientConfig.MCPToolSyncInterval = 0

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -751,6 +751,14 @@ func (s *BifrostHTTPServer) ReloadClientConfigFromConfigStore(ctx context.Contex
 			MCPConfig:          mcpConfig,
 			Logger:             logger,
 		})
+		if err := s.Client.UpdateToolManagerConfig(
+			s.Config.ClientConfig.MCPAgentDepth,
+			s.Config.ClientConfig.MCPToolExecutionTimeout,
+			s.Config.ClientConfig.MCPCodeModeBindingLevel,
+			s.Config.ClientConfig.MCPDisableAutoToolInject,
+		); err != nil {
+			logger.Warn("failed to sync MCP tool manager config during client config reload: %v", err)
+		}
 	}
 	return nil
 }

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2925,8 +2925,8 @@
       "type": "object",
       "properties": {
         "tool_execution_timeout": {
-          "type": "integer",
-          "description": "Tool execution timeout in seconds",
+          "type": ["integer", "string"],
+          "description": "Tool execution timeout. Accepts a duration string (e.g. \"30s\", \"2m\") or an integer number of seconds (e.g. 30 means 30 seconds).",
           "minimum": 1,
           "default": 30
         },

--- a/transports/schema_test/config_schema_test.go
+++ b/transports/schema_test/config_schema_test.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
@@ -518,6 +520,18 @@ func TestSchemaMCPToolManagerCodeMode(t *testing.T) {
 		}`
 		if err := validateConfig(t, compiled, config); err != nil {
 			t.Errorf("tool_manager_config with code_mode_binding_level should be valid, got: %v", err)
+		}
+		var root struct {
+			MCP schemas.MCPConfig `json:"mcp"`
+		}
+		if err := json.Unmarshal([]byte(config), &root); err != nil {
+			t.Errorf("failed to unmarshal mcp config: %v", err)
+		}
+		if root.MCP.ToolManagerConfig == nil {
+			t.Fatal("tool_manager_config missing after unmarshal")
+		}
+		if root.MCP.ToolManagerConfig.ToolExecutionTimeout.D() != 30*time.Second {
+			t.Errorf("tool_execution_timeout should be 30 seconds, got: %v", root.MCP.ToolManagerConfig.ToolExecutionTimeout.D())
 		}
 	})
 }


### PR DESCRIPTION
## Summary

`tool_execution_timeout` in `mcp.tool_manager_config` previously inherited the `Duration` type's bare-integer-as-nanoseconds behaviour, meaning a config value of `30` was silently interpreted as 30 nanoseconds instead of 30 seconds. This PR fixes the interpretation so bare integers are treated as seconds, aligns the JSON schema to accept both integers and duration strings, and ensures tool manager settings are correctly propagated through the hash-based config reconciliation pipeline so UI changes survive restarts.

## Changes

- Added a custom `UnmarshalJSON` on `MCPToolManagerConfig` that treats bare integer values for `tool_execution_timeout` as seconds rather than nanoseconds, while still accepting quoted duration strings (e.g. `"30s"`, `"2m"`).
- Added `GenerateClientConfigHashWithToolManager` to include `mcp.tool_manager_config` fields (`MaxAgentDepth`, `ToolExecutionTimeout`, `CodeModeBindingLevel`, `DisableAutoToolInject`) in the config hash, so file-level changes to those fields trigger a file-wins sync.
- Added `applyToolManagerToClientConfig` to copy tool manager settings from the file config into `ClientConfig` on first startup or when a hash mismatch is detected, replacing the previous logic in `applyMCPGlobalSettingsToClientConfig` that wrote in the opposite direction.
- Reversed the data-flow in `applyMCPGlobalSettingsToClientConfig`: instead of pushing file values into `ClientConfig`, it now backfills `MCPConfig.ToolManagerConfig` from `ClientConfig` (which holds the authoritative values after reconciliation), so `bifrost.Init` always receives the correct settings.
- Added a legacy hash upgrade path: when the stored hash matches only the client section (pre-upgrade), tool manager settings are applied from the file without overwriting client-section UI changes, and the hash is updated to the new format.
- Added a call to `UpdateToolManagerConfig` during `ReloadClientConfigFromConfigStore` so live reloads propagate tool manager settings to the running client.
- Updated `config.schema.json` to allow `tool_execution_timeout` to be either an integer (seconds) or a duration string.
- Added an unmarshal assertion to the existing schema test to verify that an integer `30` round-trips to `30 * time.Second`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./framework/configstore/... ./transports/schema_test/...
```

Set `tool_execution_timeout: 30` (bare integer) in `mcp.tool_manager_config` and confirm the effective timeout is 30 seconds, not 30 nanoseconds. Verify that changing `tool_execution_timeout` in `config.json` while a DB config exists causes a hash mismatch and the file value wins on next startup. Verify that on first startup after upgrading, the stored hash is updated to the new format without overwriting client-section UI changes.

## Breaking changes

- [x] No

Bare integer values that were previously (incorrectly) interpreted as nanoseconds are now interpreted as seconds. Any config relying on the nanosecond interpretation would need to be updated to use an explicit duration string (e.g. `"30ns"`), but such a configuration would have been non-functional in practice.

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable