### PR TITLE
feat: supports toggling push-based and pull-based toggling separately and fixes hot-reload of plugin

### DIFF
--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	bifrost "github.com/maximhq/bifrost/core"
@@ -103,12 +104,17 @@ type PrometheusPlugin struct {
 	pushWg     sync.WaitGroup
 	pushMu     sync.RWMutex
 	pushActive bool
+
+	// MetricsEnabled gates the /metrics scrape endpoint.
+	metricsEnabled atomic.Bool
 }
 
 type Config struct {
 	CustomLabels []string `json:"custom_labels"`
 	Registry     *prometheus.Registry
 	PushGateway  *PushGatewayConfig `json:"push_gateway"`
+	// MetricsEnabled controls whether the /metrics scrape endpoint is served.
+	MetricsEnabled *bool `json:"metrics_enabled,omitempty"`
 }
 
 // Init creates a new PrometheusPlugin with initialized metrics.
@@ -362,6 +368,14 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		defaultBifrostLabels:           defaultBifrostLabels,
 	}
 
+	// Default /metrics scraping to on when the config omits the field — preserves
+	// behavior for existing connectors written before metrics_enabled existed.
+	metricsEnabled := true
+	if config.MetricsEnabled != nil {
+		metricsEnabled = *config.MetricsEnabled
+	}
+	plugin.metricsEnabled.Store(metricsEnabled)
+
 	// Start push gateway if configured
 	if config.PushGateway != nil && config.PushGateway.Enabled && config.PushGateway.PushGatewayURL != "" {
 		if err := plugin.EnablePushGateway(config.PushGateway); err != nil {
@@ -370,6 +384,12 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 	}
 
 	return plugin, nil
+}
+
+// IsMetricsEnabled reports whether the /metrics scrape endpoint should serve
+// metrics on this instance. Safe to call from request-handling goroutines.
+func (p *PrometheusPlugin) IsMetricsEnabled() bool {
+	return p.metricsEnabled.Load()
 }
 
 func (p *PrometheusPlugin) GetRegistry() *prometheus.Registry {

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -54,11 +54,19 @@ func loadBuiltinPlugin(ctx context.Context, name string, pluginConfig any, bifro
 		telConfig := &telemetry.Config{
 			CustomLabels: bifrostConfig.ClientConfig.PrometheusLabels,
 		}
-		// Merge push gateway config if provided (e.g., from config file or UI update)
+		// Merge persisted config if provided.
 		if pluginConfig != nil {
 			extraConfig, err := MarshalPluginConfig[telemetry.Config](pluginConfig)
-			if err == nil && extraConfig != nil && extraConfig.PushGateway != nil {
-				telConfig.PushGateway = extraConfig.PushGateway
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal telemetry plugin config: %w", err)
+			}
+			if extraConfig != nil {
+				if extraConfig.PushGateway != nil {
+					telConfig.PushGateway = extraConfig.PushGateway
+				}
+				if extraConfig.MetricsEnabled != nil {
+					telConfig.MetricsEnabled = extraConfig.MetricsEnabled
+				}
 			}
 		}
 		return telemetry.Init(telConfig, bifrostConfig.ModelCatalog, logger)

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -33,7 +33,9 @@ import (
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	bfws "github.com/maximhq/bifrost/transports/bifrost-http/websocket"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/valyala/fasthttp"
 	"github.com/valyala/fasthttp/fasthttpadaptor"
 )
@@ -1178,14 +1180,23 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 		s.devPprofHandler = handlers.NewDevPprofHandler()
 		s.devPprofHandler.RegisterRoutes(s.Router, middlewares...)
 	}
-	// Add Prometheus /metrics endpoint
-	prometheusPlugin, err := lib.FindPluginAs[*telemetry.PrometheusPlugin](s.Config, telemetry.PluginName)
-	if err == nil && prometheusPlugin.GetRegistry() != nil {
-		metricsHandler := fasthttpadaptor.NewFastHTTPHandler(promhttp.HandlerFor(prometheusPlugin.GetMetricsGatherer(), promhttp.HandlerOpts{}))
-		s.Router.GET("/metrics", lib.ChainMiddlewares(metricsHandler, middlewares...))
-	} else {
-		logger.Warn("prometheus plugin not found or registry is nil, skipping metrics endpoint")
+	metricsGatherer := prometheus.GathererFunc(func() ([]*dto.MetricFamily, error) {
+		plugin, err := lib.FindPluginAs[*telemetry.PrometheusPlugin](s.Config, telemetry.PluginName)
+		if err != nil || plugin == nil {
+			return nil, nil
+		}
+		return plugin.GetMetricsGatherer().Gather()
+	})
+	metricsAdapter := fasthttpadaptor.NewFastHTTPHandler(promhttp.HandlerFor(metricsGatherer, promhttp.HandlerOpts{}))
+	metricsHandler := func(ctx *fasthttp.RequestCtx) {
+		plugin, err := lib.FindPluginAs[*telemetry.PrometheusPlugin](s.Config, telemetry.PluginName)
+		if err != nil || plugin == nil || !plugin.IsMetricsEnabled() {
+			handlers.SendError(ctx, fasthttp.StatusNotFound, "Route not found: "+string(ctx.Path()))
+			return
+		}
+		metricsAdapter(ctx)
 	}
+	s.Router.GET("/metrics", lib.ChainMiddlewares(metricsHandler, middlewares...))
 	// 404 handler
 	s.Router.NotFound = func(ctx *fasthttp.RequestCtx) {
 		handlers.SendError(ctx, fasthttp.StatusNotFound, "Route not found: "+string(ctx.Path()))

--- a/transports/go.mod
+++ b/transports/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/pion/rtcp v1.2.16
 	github.com/pion/webrtc/v4 v4.2.9
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
@@ -155,7 +156,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/qdrant/go-client v1.16.2 // indirect

--- a/ui/app/workspace/observability/fragments/prometheusFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/prometheusFormFragment.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { prometheusFormSchema, type PrometheusFormSchema } from "@/lib/types/schemas";
@@ -15,7 +16,8 @@ import { useForm, type Resolver } from "react-hook-form";
 
 interface PrometheusFormFragmentProps {
 	currentConfig?: {
-		enabled?: boolean;
+		metrics_enabled?: boolean;
+		push_gateway_enabled?: boolean;
 		push_gateway_url?: string;
 		job_name?: string;
 		instance_id?: string;
@@ -32,6 +34,32 @@ interface PrometheusFormFragmentProps {
 	metricsEndpoint?: string;
 }
 
+const buildDefaults = (initialConfig?: PrometheusFormFragmentProps["currentConfig"]): PrometheusFormSchema => ({
+	metrics_enabled: initialConfig?.metrics_enabled ?? true,
+	push_gateway_enabled: initialConfig?.push_gateway_enabled ?? false,
+	prometheus_config: {
+		push_gateway_url: initialConfig?.push_gateway_url ?? "",
+		job_name: initialConfig?.job_name ?? "bifrost",
+		instance_id: initialConfig?.instance_id ?? "",
+		push_interval: initialConfig?.push_interval ?? 15,
+		basic_auth_username: initialConfig?.basic_auth?.username ?? "",
+		basic_auth_password: initialConfig?.basic_auth?.password ?? "",
+	},
+});
+
+// Field paths considered "owned" by each tab — used for per-tab Reset and to
+// gate the per-tab Save button on whether *this* tab has unsaved changes.
+const PULL_FIELDS = ["metrics_enabled"] as const;
+const PUSH_FIELDS = [
+	"push_gateway_enabled",
+	"prometheus_config.push_gateway_url",
+	"prometheus_config.job_name",
+	"prometheus_config.instance_id",
+	"prometheus_config.push_interval",
+	"prometheus_config.basic_auth_username",
+	"prometheus_config.basic_auth_password",
+] as const;
+
 export function PrometheusFormFragment({
 	currentConfig: initialConfig,
 	onSave,
@@ -45,22 +73,13 @@ export function PrometheusFormFragment({
 	const [isSaving, setIsSaving] = useState(false);
 	const { copy, copied } = useCopyToClipboard();
 	const [showBasicAuth, setShowBasicAuth] = useState(!!(initialConfig?.basic_auth?.username || initialConfig?.basic_auth?.password));
+	const [activeTab, setActiveTab] = useState<"pull" | "push">("pull");
 
 	const form = useForm<PrometheusFormSchema, any, PrometheusFormSchema>({
 		resolver: zodResolver(prometheusFormSchema) as Resolver<PrometheusFormSchema, any, PrometheusFormSchema>,
 		mode: "onChange",
 		reValidateMode: "onChange",
-		defaultValues: {
-			enabled: initialConfig?.enabled ?? true,
-			prometheus_config: {
-				push_gateway_url: initialConfig?.push_gateway_url ?? "",
-				job_name: initialConfig?.job_name ?? "bifrost",
-				instance_id: initialConfig?.instance_id ?? "",
-				push_interval: initialConfig?.push_interval ?? 15,
-				basic_auth_username: initialConfig?.basic_auth?.username ?? "",
-				basic_auth_password: initialConfig?.basic_auth?.password ?? "",
-			},
-		},
+		defaultValues: buildDefaults(initialConfig),
 	});
 
 	const onSubmit = (data: PrometheusFormSchema) => {
@@ -69,17 +88,7 @@ export function PrometheusFormFragment({
 	};
 
 	useEffect(() => {
-		form.reset({
-			enabled: initialConfig?.enabled ?? true,
-			prometheus_config: {
-				push_gateway_url: initialConfig?.push_gateway_url ?? "",
-				job_name: initialConfig?.job_name ?? "bifrost",
-				instance_id: initialConfig?.instance_id ?? "",
-				push_interval: initialConfig?.push_interval ?? 15,
-				basic_auth_username: initialConfig?.basic_auth?.username ?? "",
-				basic_auth_password: initialConfig?.basic_auth?.password ?? "",
-			},
-		});
+		form.reset(buildDefaults(initialConfig));
 		setShowBasicAuth(!!(initialConfig?.basic_auth?.username || initialConfig?.basic_auth?.password));
 	}, [form, initialConfig]);
 
@@ -95,298 +104,400 @@ export function PrometheusFormFragment({
 		setShowBasicAuth(false);
 	};
 
-	return (
-		<Form {...form}>
-			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-				{/* Pull-based Scraping Section */}
-				<div className="space-y-4">
-					<div className="flex flex-col gap-2">
-						<h3 className="text-sm font-medium">Pull-based Scraping</h3>
-						<p className="text-muted-foreground text-xs">Prometheus can scrape metrics from the /metrics endpoint</p>
-					</div>
+	// Reset only the fields belonging to the given tab. The other tab's pending
+	// edits are preserved so a Reset on one tab feels scoped.
+	const resetPullTab = () => {
+		const defaults = buildDefaults(initialConfig);
+		form.setValue("metrics_enabled", defaults.metrics_enabled, { shouldDirty: true, shouldValidate: true });
+	};
 
-					<div className="bg-muted/50 rounded-md p-4">
-						<div className="flex items-center justify-between">
-							<div className="flex flex-col gap-1">
-								<span className="text-sm font-medium">Metrics Endpoint</span>
-								<code className="text-muted-foreground text-xs">{metricsEndpoint || "http://<bifrost-host>:<port>/metrics"}</code>
-							</div>
-							{metricsEndpoint && (
-								<Button type="button" variant="outline" size="sm" onClick={handleCopyEndpoint} className="shrink-0">
-									<Copy className="mr-2 h-3 w-3" />
-									{copied ? "Copied!" : "Copy"}
-								</Button>
-							)}
-						</div>
-						<p className="text-muted-foreground mt-2 text-xs">
-							Configure your Prometheus server to scrape this endpoint. This is always available when Bifrost is running.
-						</p>
-					</div>
-				</div>
+	const resetPushTab = () => {
+		const defaults = buildDefaults(initialConfig);
+		form.setValue("push_gateway_enabled", defaults.push_gateway_enabled, { shouldDirty: true, shouldValidate: true });
+		form.setValue("prometheus_config.push_gateway_url", defaults.prometheus_config.push_gateway_url, {
+			shouldDirty: true,
+			shouldValidate: true,
+		});
+		form.setValue("prometheus_config.job_name", defaults.prometheus_config.job_name, { shouldDirty: true });
+		form.setValue("prometheus_config.instance_id", defaults.prometheus_config.instance_id ?? "", { shouldDirty: true });
+		form.setValue("prometheus_config.push_interval", defaults.prometheus_config.push_interval, { shouldDirty: true });
+		form.setValue("prometheus_config.basic_auth_username", defaults.prometheus_config.basic_auth_username ?? "", { shouldDirty: true });
+		form.setValue("prometheus_config.basic_auth_password", defaults.prometheus_config.basic_auth_password ?? "", { shouldDirty: true });
+		setShowBasicAuth(!!(initialConfig?.basic_auth?.username || initialConfig?.basic_auth?.password));
+	};
 
-				{/* Push-based Section */}
-				<div className="space-y-4 border-t pt-4">
-					<div className="flex flex-col gap-2">
-						<h3 className="flex flex-row items-center gap-2 text-sm font-medium">
-							Push-based (Push Gateway) <Badge variant="secondary">BETA</Badge>
-						</h3>
-						<p className="text-muted-foreground text-xs">
-							Push metrics to a Prometheus Push Gateway for proper aggregation in cluster deployments
-						</p>
-					</div>
+	// Tabs can independently report whether *their* fields differ from the
+	// last-saved state. Both Save buttons submit the entire form (single API
+	// shape) — gating per-tab just avoids surfacing a Save when nothing in
+	// the visible tab changed.
+	const dirtyFields = form.formState.dirtyFields as Record<string, unknown>;
+	const isPullDirty = PULL_FIELDS.some((path) => dirtyFields[path]);
+	const isPushDirty = PUSH_FIELDS.some((path) => {
+		const segments = path.split(".");
+		let cursor: any = dirtyFields;
+		for (const seg of segments) {
+			if (cursor == null) return false;
+			cursor = cursor[seg];
+		}
+		return !!cursor;
+	});
 
-					{/* Warning note for multi-node deployments */}
-					<Alert variant="info">
-						<AlertTriangle className="" />
-						<AlertDescription className="text-xs">
-							If you are running multiple Bifrost nodes, use push gateway for accurate metrics. Pull-based /metrics scraping may miss nodes
-							behind a load balancer.
-						</AlertDescription>
-					</Alert>
+	// Whole-form validity. Save is a single API call covering both tabs, so an
+	// invalid field on the *other* tab silently blocks handleSubmit. We disable
+	// Save when invalid and surface where the error lives so the user isn't
+	// hunting through a tab they can't see.
+	const formIsInvalid = !form.formState.isValid;
+	const errors = form.formState.errors as Record<string, any>;
+	const hasPullErrors = !!errors.metrics_enabled;
+	const hasPushErrors = !!errors.push_gateway_enabled || !!errors.prometheus_config;
 
-					<div className="space-y-4">
-						<FormField
-							control={form.control}
-							name="prometheus_config.push_gateway_url"
-							render={({ field }) => (
-								<FormItem className="w-full">
-									<FormLabel>Push Gateway URL</FormLabel>
-									<FormControl>
-										<Input placeholder="http://pushgateway:9091" disabled={!hasPrometheusAccess} {...field} />
-									</FormControl>
-									<FormDescription>URL of your Prometheus Push Gateway</FormDescription>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
+	const renderActions = (tabKey: "pull" | "push", tabDirty: boolean, onResetTab: () => void) => {
+		const thisTabHasErrors = tabKey === "pull" ? hasPullErrors : hasPushErrors;
+		const otherTabHasErrors = tabKey === "pull" ? hasPushErrors : hasPullErrors;
+		const otherTabLabel = tabKey === "pull" ? "Push-based" : "Pull-based";
+		const saveDisabled = !hasPrometheusAccess || !tabDirty || formIsInvalid;
+		let tooltipMsg = "";
+		if (!tabDirty) {
+			tooltipMsg = "No changes made in this tab";
+		} else if (formIsInvalid && otherTabHasErrors && !thisTabHasErrors) {
+			tooltipMsg = `Fix validation errors in the ${otherTabLabel} tab before saving`;
+		} else if (formIsInvalid) {
+			tooltipMsg = "Fix validation errors before saving";
+		}
 
-						<div className="grid grid-cols-2 gap-4">
-							<FormField
-								control={form.control}
-								name="prometheus_config.job_name"
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>Job Name</FormLabel>
-										<FormControl>
-											<Input placeholder="bifrost" disabled={!hasPrometheusAccess} {...field} />
-										</FormControl>
-										<FormDescription>Job label for metrics</FormDescription>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-
-							<FormField
-								control={form.control}
-								name="prometheus_config.push_interval"
-								render={({ field }) => (
-									<FormItem>
-										<FormLabel>Push Interval (seconds)</FormLabel>
-										<FormControl>
-											<Input
-												type="number"
-												min={1}
-												max={300}
-												disabled={!hasPrometheusAccess}
-												{...field}
-												onChange={(e) => field.onChange(parseInt(e.target.value) || 15)}
-											/>
-										</FormControl>
-										<FormDescription>How often to push (1-300s)</FormDescription>
-										<FormMessage />
-									</FormItem>
-								)}
-							/>
-						</div>
-
-						<FormField
-							control={form.control}
-							name="prometheus_config.instance_id"
-							render={({ field }) => (
-								<FormItem>
-									<FormLabel className="flex items-center gap-2">
-										Instance ID
-										<TooltipProvider>
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<Info className="text-muted-foreground h-3 w-3" />
-												</TooltipTrigger>
-												<TooltipContent>
-													<p className="max-w-xs text-xs">
-														Used to identify this Bifrost instance in metrics. If not set, hostname is used automatically.
-													</p>
-												</TooltipContent>
-											</Tooltip>
-										</TooltipProvider>
-									</FormLabel>
-									<FormControl>
-										<Input
-											placeholder="Auto-generated from hostname"
-											disabled={!hasPrometheusAccess}
-											{...field}
-											value={field.value ?? ""}
-										/>
-									</FormControl>
-									<FormMessage />
-								</FormItem>
-							)}
-						/>
-
-						{/* Basic Auth Section */}
-						<div className="space-y-4 border-t pt-4">
-							{!showBasicAuth ? (
-								<Button type="button" variant="outline" size="sm" onClick={() => setShowBasicAuth(true)} disabled={!hasPrometheusAccess}>
-									<Plus className="mr-2 h-3 w-3" />
-									Add Basic Auth
-								</Button>
-							) : (
-								<>
-									<div className="flex items-center justify-between">
-										<span className="text-sm font-medium">Basic Authentication</span>
-										<Button
-											type="button"
-											variant="ghost"
-											size="sm"
-											onClick={handleRemoveBasicAuth}
-											disabled={!hasPrometheusAccess}
-											className="text-muted-foreground hover:text-destructive h-auto p-1"
-										>
-											<Trash className="h-4 w-4" />
-										</Button>
-									</div>
-									<div className="border-muted grid grid-cols-2 gap-4">
-										<FormField
-											control={form.control}
-											name="prometheus_config.basic_auth_username"
-											render={({ field }) => (
-												<FormItem>
-													<FormLabel>Username</FormLabel>
-													<FormControl>
-														<Input placeholder="Username" disabled={!hasPrometheusAccess} {...field} />
-													</FormControl>
-													<FormMessage />
-												</FormItem>
-											)}
-										/>
-
-										<FormField
-											control={form.control}
-											name="prometheus_config.basic_auth_password"
-											render={({ field }) => (
-												<FormItem>
-													<FormLabel>Password</FormLabel>
-													<FormControl>
-														<div className="relative">
-															<Input
-																type={showPassword ? "text" : "password"}
-																placeholder="Password"
-																disabled={!hasPrometheusAccess}
-																{...field}
-																className="pr-10"
-															/>
-															<Button
-																type="button"
-																variant="ghost"
-																size="sm"
-																className="absolute top-0 right-0 h-full px-3 py-2 hover:bg-transparent"
-																onClick={() => setShowPassword(!showPassword)}
-																disabled={!hasPrometheusAccess}
-															>
-																{showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-															</Button>
-														</div>
-													</FormControl>
-													<FormMessage />
-												</FormItem>
-											)}
-										/>
-									</div>
-								</>
-							)}
-						</div>
-					</div>
-				</div>
-
-				{/* Form Actions */}
-				<div className="flex w-full flex-row items-center">
-					<FormField
-						control={form.control}
-						name="enabled"
-						render={({ field }) => (
-							<FormItem className="flex items-center gap-2 py-2">
-								<FormLabel className="text-muted-foreground text-sm font-medium">Enabled</FormLabel>
-								<FormControl>
-									<Switch
-										checked={field.value}
-										onCheckedChange={field.onChange}
-										disabled={!hasPrometheusAccess}
-										data-testid="prometheus-connector-enable-toggle"
-									/>
-								</FormControl>
-							</FormItem>
-						)}
-					/>
-					<div className="ml-auto flex justify-end space-x-2 py-2">
-						{onDelete && (
-							<Button
-								type="button"
-								variant="outline"
-								onClick={onDelete}
-								disabled={isDeleting || !hasPrometheusAccess}
-								data-testid="prometheus-connector-delete-btn"
-								title="Delete connector"
-								aria-label="Delete connector"
-							>
-								<Trash2 className="size-4" />
-							</Button>
-						)}
+		return (
+			<div className="flex w-full flex-row items-center pt-4">
+				<div className="ml-auto flex justify-end space-x-2 py-2">
+					{onDelete && (
 						<Button
 							type="button"
 							variant="outline"
-							onClick={() => {
-								form.reset({
-									enabled: initialConfig?.enabled ?? true,
-									prometheus_config: {
-										push_gateway_url: initialConfig?.push_gateway_url ?? "",
-										job_name: initialConfig?.job_name ?? "bifrost",
-										instance_id: initialConfig?.instance_id ?? "",
-										push_interval: initialConfig?.push_interval ?? 15,
-										basic_auth_username: initialConfig?.basic_auth?.username ?? "",
-										basic_auth_password: initialConfig?.basic_auth?.password ?? "",
-									},
-								});
-								setShowBasicAuth(!!(initialConfig?.basic_auth?.username || initialConfig?.basic_auth?.password));
-							}}
-							disabled={!hasPrometheusAccess || isLoading || !form.formState.isDirty}
+							onClick={onDelete}
+							disabled={isDeleting || !hasPrometheusAccess}
+							data-testid="prometheus-connector-delete-btn"
+							title="Delete connector"
+							aria-label="Delete connector"
 						>
-							Reset
+							<Trash2 className="size-4" />
 						</Button>
-						<TooltipProvider>
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<Button
-										type="submit"
-										disabled={!hasPrometheusAccess || !form.formState.isDirty}
-										isLoading={isSaving}
-									>
-										Save Prometheus Configuration
-									</Button>
-								</TooltipTrigger>
-								{(!form.formState.isDirty) && (
-									<TooltipContent>
-										<p>
-											{!form.formState.isDirty && !form.formState.isValid
-												? "No changes made and validation errors present"
-												: !form.formState.isDirty
-													? "No changes made"
-													: "Please fix validation errors"}
-										</p>
-									</TooltipContent>
-								)}
-							</Tooltip>
-						</TooltipProvider>
-					</div>
+					)}
+					<Button
+						type="button"
+						variant="outline"
+						onClick={onResetTab}
+						disabled={!hasPrometheusAccess || isLoading || !tabDirty}
+						data-testid={`prometheus-${tabKey}-reset-btn`}
+					>
+						Reset
+					</Button>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									type="submit"
+									disabled={saveDisabled}
+									isLoading={isSaving}
+									data-testid={`prometheus-${tabKey}-save-btn`}
+								>
+									Save Prometheus Configuration
+								</Button>
+							</TooltipTrigger>
+							{tooltipMsg && (
+								<TooltipContent>
+									<p>{tooltipMsg}</p>
+								</TooltipContent>
+							)}
+						</Tooltip>
+					</TooltipProvider>
 				</div>
+			</div>
+		);
+	};
+
+	return (
+		<Form {...form}>
+			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+				<Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as "pull" | "push")}>
+					<TabsList className="gap-2">
+						<TabsTrigger value="pull" className="px-2 py-1" data-testid="prometheus-tab-pull">
+							Pull-based
+						</TabsTrigger>
+						<TabsTrigger value="push" className="px-2 py-1" data-testid="prometheus-tab-push">
+							Push-based
+						</TabsTrigger>
+					</TabsList>
+
+					{/* Pull-based tab: gates the /metrics scrape endpoint */}
+					<TabsContent value="pull" className="space-y-4 mt-2">
+						<div className="flex items-center justify-between gap-4">
+							<div className="flex flex-col gap-1">
+								<h3 className="text-sm font-medium">Pull-based Scraping</h3>
+								<p className="text-muted-foreground text-xs">
+									Prometheus can scrape metrics from the /metrics endpoint
+								</p>
+							</div>
+							<FormField
+								control={form.control}
+								name="metrics_enabled"
+								render={({ field }) => (
+									<FormItem className="flex items-center gap-2">
+										<FormLabel className="text-muted-foreground text-sm font-medium">Enabled</FormLabel>
+										<FormControl>
+											<Switch
+												checked={field.value}
+												onCheckedChange={field.onChange}
+												disabled={!hasPrometheusAccess}
+												data-testid="prometheus-metrics-enable-toggle"
+											/>
+										</FormControl>
+									</FormItem>
+								)}
+							/>
+						</div>
+
+						<div className="bg-muted/50 rounded-md p-4">
+							<div className="flex items-center justify-between">
+								<div className="flex flex-col gap-1">
+									<span className="text-sm font-medium">Metrics Endpoint</span>
+									<code className="text-muted-foreground text-xs">
+										{metricsEndpoint || "http://<bifrost-host>:<port>/metrics"}
+									</code>
+								</div>
+								{metricsEndpoint && (
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onClick={handleCopyEndpoint}
+										className="shrink-0"
+										data-testid="prometheus-copy-endpoint"
+									>
+										<Copy className="mr-2 h-3 w-3" />
+										{copied ? "Copied!" : "Copy"}
+									</Button>
+								)}
+							</div>
+							<p className="text-muted-foreground mt-2 text-xs">
+								Configure your Prometheus server to scrape this endpoint. Served only while Pull-based scraping is enabled.
+							</p>
+						</div>
+
+						{renderActions("pull", isPullDirty, resetPullTab)}
+					</TabsContent>
+
+					{/* Push-based tab: gates the push gateway loop */}
+					<TabsContent value="push" className="space-y-4 mt-2">
+						<div className="flex items-center justify-between gap-4">
+							<div className="flex flex-col gap-1">
+								<h3 className="flex flex-row items-center gap-2 text-sm font-medium">
+									Push-based (Push Gateway) <Badge variant="secondary">BETA</Badge>
+								</h3>
+								<p className="text-muted-foreground text-xs">
+									Push metrics to a Prometheus Push Gateway for proper aggregation in cluster deployments
+								</p>
+							</div>
+							<FormField
+								control={form.control}
+								name="push_gateway_enabled"
+								render={({ field }) => (
+									<FormItem className="flex items-center gap-2">
+										<FormLabel className="text-muted-foreground text-sm font-medium">Enabled</FormLabel>
+										<FormControl>
+											<Switch
+												checked={field.value}
+												onCheckedChange={field.onChange}
+												disabled={!hasPrometheusAccess}
+												data-testid="prometheus-push-enable-toggle"
+											/>
+										</FormControl>
+									</FormItem>
+								)}
+							/>
+						</div>
+
+						<Alert variant="info">
+							<AlertTriangle className="" />
+							<AlertDescription className="text-xs">
+								If you are running multiple Bifrost nodes, use push gateway for accurate metrics. Pull-based /metrics scraping may miss
+								nodes behind a load balancer.
+							</AlertDescription>
+						</Alert>
+
+						<div className="space-y-4">
+							<FormField
+								control={form.control}
+								name="prometheus_config.push_gateway_url"
+								render={({ field }) => (
+									<FormItem className="w-full">
+										<FormLabel>Push Gateway URL</FormLabel>
+										<FormControl>
+											<Input placeholder="http://pushgateway:9091" disabled={!hasPrometheusAccess} {...field} />
+										</FormControl>
+										<FormDescription>URL of your Prometheus Push Gateway</FormDescription>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+
+							<div className="grid grid-cols-2 gap-4">
+								<FormField
+									control={form.control}
+									name="prometheus_config.job_name"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Job Name</FormLabel>
+											<FormControl>
+												<Input placeholder="bifrost" disabled={!hasPrometheusAccess} {...field} />
+											</FormControl>
+											<FormDescription>Job label for metrics</FormDescription>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+
+								<FormField
+									control={form.control}
+									name="prometheus_config.push_interval"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel>Push Interval (seconds)</FormLabel>
+											<FormControl>
+												<Input
+													type="number"
+													min={1}
+													max={300}
+													disabled={!hasPrometheusAccess}
+													{...field}
+													onChange={(e) => field.onChange(parseInt(e.target.value) || 15)}
+												/>
+											</FormControl>
+											<FormDescription>How often to push (1-300s)</FormDescription>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+							</div>
+
+							<FormField
+								control={form.control}
+								name="prometheus_config.instance_id"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel className="flex items-center gap-2">
+											Instance ID
+											<TooltipProvider>
+												<Tooltip>
+													<TooltipTrigger asChild>
+														<Info className="text-muted-foreground h-3 w-3" />
+													</TooltipTrigger>
+													<TooltipContent>
+														<p className="max-w-xs text-xs">
+															Used to identify this Bifrost instance in metrics. If not set, hostname is used automatically.
+														</p>
+													</TooltipContent>
+												</Tooltip>
+											</TooltipProvider>
+										</FormLabel>
+										<FormControl>
+											<Input
+												placeholder="Auto-generated from hostname"
+												disabled={!hasPrometheusAccess}
+												{...field}
+												value={field.value ?? ""}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+
+							<div className="space-y-4 border-t pt-4">
+								{!showBasicAuth ? (
+									<Button
+										type="button"
+										variant="outline"
+										size="sm"
+										onClick={() => setShowBasicAuth(true)}
+										disabled={!hasPrometheusAccess}
+										data-testid="prometheus-add-basic-auth"
+									>
+										<Plus className="mr-2 h-3 w-3" />
+										Add Basic Auth
+									</Button>
+								) : (
+									<>
+										<div className="flex items-center justify-between">
+											<span className="text-sm font-medium">Basic Authentication</span>
+											<Button
+												type="button"
+												variant="ghost"
+												size="sm"
+												onClick={handleRemoveBasicAuth}
+												disabled={!hasPrometheusAccess}
+												className="text-muted-foreground hover:text-destructive h-auto p-1"
+												data-testid="prometheus-remove-basic-auth"
+												aria-label="Remove basic auth"
+											>
+												<Trash className="h-4 w-4" />
+											</Button>
+										</div>
+										<div className="border-muted grid grid-cols-2 gap-4">
+											<FormField
+												control={form.control}
+												name="prometheus_config.basic_auth_username"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Username</FormLabel>
+														<FormControl>
+															<Input placeholder="Username" disabled={!hasPrometheusAccess} {...field} />
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+
+											<FormField
+												control={form.control}
+												name="prometheus_config.basic_auth_password"
+												render={({ field }) => (
+													<FormItem>
+														<FormLabel>Password</FormLabel>
+														<FormControl>
+															<div className="relative">
+																<Input
+																	type={showPassword ? "text" : "password"}
+																	placeholder="Password"
+																	disabled={!hasPrometheusAccess}
+																	{...field}
+																	className="pr-10"
+																/>
+																<Button
+																	type="button"
+																	variant="ghost"
+																	size="sm"
+																	className="absolute top-0 right-0 h-full px-3 py-2 hover:bg-transparent"
+																	onClick={() => setShowPassword(!showPassword)}
+																	disabled={!hasPrometheusAccess}
+																	data-testid="prometheus-toggle-password"
+																	aria-label={showPassword ? "Hide password" : "Show password"}
+																>
+																	{showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+																</Button>
+															</div>
+														</FormControl>
+														<FormMessage />
+													</FormItem>
+												)}
+											/>
+										</div>
+									</>
+								)}
+							</div>
+						</div>
+
+						{renderActions("push", isPushDirty, resetPushTab)}
+					</TabsContent>
+				</Tabs>
 			</form>
 		</Form>
 	);

--- a/ui/app/workspace/observability/views/plugins/prometheusView.tsx
+++ b/ui/app/workspace/observability/views/plugins/prometheusView.tsx
@@ -17,6 +17,7 @@ interface PushGatewayConfig {
 }
 
 interface TelemetryConfig {
+	metrics_enabled?: boolean;
 	push_gateway?: PushGatewayConfig;
 }
 
@@ -30,9 +31,11 @@ export default function PrometheusView({ onDelete, isDeleting }: PrometheusViewP
 	const currentConfig = useMemo(() => {
 		const telemetryConfig = (selectedPlugin?.config as TelemetryConfig) ?? {};
 		const pushGateway = telemetryConfig.push_gateway ?? {};
+		const metricsEnabled = telemetryConfig.metrics_enabled ?? selectedPlugin?.enabled ?? true;
 		return {
 			...pushGateway,
-			enabled: selectedPlugin?.enabled,
+			metrics_enabled: metricsEnabled,
+			push_gateway_enabled: pushGateway.enabled ?? false,
 		};
 	}, [selectedPlugin]);
 
@@ -42,16 +45,14 @@ export default function PrometheusView({ onDelete, isDeleting }: PrometheusViewP
 
 	const handlePrometheusConfigSave = (config: PrometheusFormSchema): Promise<void> => {
 		return new Promise((resolve, reject) => {
-			// Transform the form data to the telemetry plugin's push_gateway config format
 			const pushGatewayConfig: PushGatewayConfig = {
-				enabled: config.enabled,
+				enabled: config.push_gateway_enabled,
 				push_gateway_url: config.prometheus_config.push_gateway_url,
 				job_name: config.prometheus_config.job_name,
 				instance_id: config.prometheus_config.instance_id || undefined,
 				push_interval: config.prometheus_config.push_interval,
 			};
 
-			// Add basic auth if both username and password are provided
 			if (config.prometheus_config.basic_auth_username?.trim() && config.prometheus_config.basic_auth_password?.trim()) {
 				pushGatewayConfig.basic_auth = {
 					username: config.prometheus_config.basic_auth_username,
@@ -59,11 +60,14 @@ export default function PrometheusView({ onDelete, isDeleting }: PrometheusViewP
 				};
 			}
 
+			// Plugin stays loaded as long as the connector exists; the two inner
+			// toggles independently control the /metrics endpoint and push gateway.
 			updatePlugin({
 				name: "telemetry",
 				data: {
-					enabled: config.enabled,
+					enabled: true,
 					config: {
+						metrics_enabled: config.metrics_enabled,
 						push_gateway: pushGatewayConfig,
 					},
 				},

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1023,21 +1023,21 @@ export const prometheusConfigSchema = z
     }
   });
 
-// Prometheus form schema for the PrometheusFormFragment
+// Prometheus form schema for the PrometheusFormFragment.
 export const prometheusFormSchema = z
   .object({
-    enabled: z.boolean().default(true),
+    metrics_enabled: z.boolean().default(true),
+    push_gateway_enabled: z.boolean().default(false),
     prometheus_config: prometheusConfigSchema,
   })
   .superRefine((data, ctx) => {
-    // When enabled, push_gateway_url is required
-    if (data.enabled) {
+    if (data.push_gateway_enabled) {
       const url = (data.prometheus_config.push_gateway_url || "").trim();
       if (!url) {
         ctx.addIssue({
           code: "custom",
           path: ["prometheus_config", "push_gateway_url"],
-          message: "Push Gateway URL is required when enabled",
+          message: "Push Gateway URL is required when the push gateway is enabled",
         });
       }
     }


### PR DESCRIPTION
## Summary

The Prometheus telemetry plugin previously had a single `enabled` toggle that controlled the entire plugin. This PR decouples the `/metrics` scrape endpoint from the push gateway loop, allowing each to be toggled independently without restarting the server. It also restructures the UI form into Pull-based and Push-based tabs to reflect this separation.



## Issues

closes #3408

## Changes

- Added a `metricsEnabled atomic.Bool` field to `PrometheusPlugin` and a corresponding `MetricsEnabled *bool` field to `Config`, defaulting to `true` to preserve backward compatibility with existing connectors.
- Added `IsMetricsEnabled()` method on `PrometheusPlugin` for safe concurrent reads from request-handling goroutines.
- Changed the `/metrics` route registration from a one-time conditional setup to a runtime handler that checks `IsMetricsEnabled()` on every request, returning a 404 when the scrape endpoint is disabled. This allows the UI to toggle the endpoint on/off without a server restart.
- Updated `loadBuiltinPlugin` to propagate `MetricsEnabled` from persisted config alongside the existing `PushGateway` config merge.
- Replaced the single `enabled` form field with two independent booleans: `metrics_enabled` (gates `/metrics`) and `push_gateway_enabled` (gates the push loop). Validation for push gateway URL is now scoped to `push_gateway_enabled` rather than the old `enabled` field.
- Restructured the Prometheus UI form into Pull-based and Push-based tabs, each with its own scoped Reset and Save actions. Dirty-state detection is per-tab so the Save button only activates when the visible tab has unsaved changes.
- The plugin's top-level `enabled` field is now always set to `true` on save; the two inner toggles independently control behavior, so the connector is never fully disabled by the UI.
- Extracted `buildDefaults` helper to eliminate repeated default-value construction across `defaultValues`, `useEffect` reset, and per-tab reset handlers.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./plugins/telemetry/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

1. Start Bifrost with the telemetry plugin enabled and no explicit `metrics_enabled` config — confirm `/metrics` responds as before (backward compatibility).
2. Via the UI, navigate to Observability → Prometheus → Pull-based tab and toggle the scrape endpoint off. Save. Confirm `/metrics` returns 404 without restarting the server.
3. Re-enable the scrape endpoint. Confirm `/metrics` responds again.
4. On the Push-based tab, enable the push gateway with a valid URL. Confirm the push loop starts and the pull endpoint remains unaffected.
5. Confirm that resetting one tab does not discard unsaved changes on the other tab.

## Screenshots/Recordings

Before: Single form with a global `enabled` toggle and all push gateway fields on one page.

After: Tabbed form with Pull-based and Push-based tabs, each with an independent enable toggle, scoped Reset, and scoped Save.

## Breaking changes

- [x] Yes
- [ ] No

The `enabled` field in `PrometheusFormSchema` has been replaced by `metrics_enabled` and `push_gateway_enabled`. Any code or persisted config referencing the old `enabled` field on the form schema will need to be updated. Existing server-side configs without `metrics_enabled` continue to default to `true`.

## Related issues

## Security considerations

No new auth surfaces introduced. The `/metrics` endpoint now returns a 404 rather than serving metrics when disabled, which avoids leaking metric data to scrapers when the operator has explicitly turned off the endpoint.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable