### PR TITLE
remove budget level calendar alignemnt

### DIFF
--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -20,8 +20,6 @@ type TableBudget struct {
 	VirtualKeyID     *string `gorm:"type:varchar(255);index" json:"virtual_key_id,omitempty"`
 	ProviderConfigID *uint   `gorm:"index" json:"provider_config_id,omitempty"`
 
-	CalendarAligned bool `gorm:"default:false" json:"calendar_aligned"` // When true, all budgets under this VK reset at clean calendar boundaries
-
 	// Config hash is used to detect the changes synced from config.json file
 	// Every time we sync the config.json file, we will update the config hash
 	ConfigHash string `gorm:"type:varchar(255);null" json:"config_hash"`

--- a/framework/configstore/tables/team.go
+++ b/framework/configstore/tables/team.go
@@ -32,6 +32,9 @@ type TableTeam struct {
 	Claims       *string        `gorm:"type:text" json:"-"`
 	ParsedClaims map[string]any `gorm:"-" json:"claims"`
 
+	// IsBudgetCalendarAligned indicates whether the team's budget is calendar-aligned
+	CalendarAligned bool `gorm:"-" json:"calendar_aligned"`
+
 	// Config hash is used to detect the changes synced from config.json file
 	// Every time we sync the config.json file, we will update the config hash
 	ConfigHash string `gorm:"type:varchar(255);null" json:"config_hash"`

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1373,9 +1373,17 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context)
 		if !ok || budget == nil {
 			return true
 		}
+		// Find if the budget is calendar aligned on the virtualkey attached to this budget
+		calendarAligned := false
+		if budget.VirtualKeyID != nil {
+			virtualKey, ok := gs.virtualKeys.Load(*budget.VirtualKeyID)
+			if ok {
+				calendarAligned = virtualKey.(*configstoreTables.TableVirtualKey).CalendarAligned
+			}
+		}
 		var shouldReset bool
 		var newLastReset time.Time
-		if budget.CalendarAligned {
+		if calendarAligned {
 			currentPeriodStart := configstoreTables.GetCalendarPeriodStart(budget.ResetDuration, now)
 			if currentPeriodStart.After(budget.LastReset) {
 				shouldReset = true

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1551,13 +1551,12 @@ func (h *GovernanceHandler) createTeam(ctx *fasthttp.RequestCtx) {
 			}
 			seenDurations[b.ResetDuration] = true
 			budget := configstoreTables.TableBudget{
-				ID:              uuid.NewString(),
-				MaxLimit:        b.MaxLimit,
-				ResetDuration:   b.ResetDuration,
-				LastReset:       budgetLastReset(b.CalendarAligned, b.ResetDuration),
-				CurrentUsage:    0,
-				CalendarAligned: b.CalendarAligned,
-				TeamID:          &team.ID,
+				ID:            uuid.NewString(),
+				MaxLimit:      b.MaxLimit,
+				ResetDuration: b.ResetDuration,
+				LastReset:     budgetLastReset(b.CalendarAligned, b.ResetDuration),
+				CurrentUsage:  0,
+				TeamID:        &team.ID,
 			}
 			if err := validateBudget(&budget); err != nil {
 				return err
@@ -1688,14 +1687,12 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 			matchedIDs := make(map[string]bool)
 			for _, b := range req.Budgets {
 				if existing, found := existingByDuration[b.ResetDuration]; found {
-					wasCalendarAligned := existing.CalendarAligned
 					existing.MaxLimit = b.MaxLimit
-					existing.CalendarAligned = b.CalendarAligned
 					// Match the UI's calendar-alignment confirmation promise: on the
 					// false → true transition, snap LastReset to the current period
 					// start and zero out CurrentUsage now, instead of lazily waiting
 					// for the next period boundary in ResetExpiredBudgetsInMemory.
-					if b.CalendarAligned && !wasCalendarAligned {
+					if b.CalendarAligned {
 						existing.LastReset = configstoreTables.GetCalendarPeriodStart(b.ResetDuration, time.Now())
 						existing.CurrentUsage = 0
 					}
@@ -1709,13 +1706,12 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 					matchedIDs[existing.ID] = true
 				} else {
 					budget := configstoreTables.TableBudget{
-						ID:              uuid.NewString(),
-						MaxLimit:        b.MaxLimit,
-						ResetDuration:   b.ResetDuration,
-						LastReset:       budgetLastReset(b.CalendarAligned, b.ResetDuration),
-						CurrentUsage:    0,
-						CalendarAligned: b.CalendarAligned,
-						TeamID:          &team.ID,
+						ID:            uuid.NewString(),
+						MaxLimit:      b.MaxLimit,
+						ResetDuration: b.ResetDuration,
+						LastReset:     budgetLastReset(b.CalendarAligned, b.ResetDuration),
+						CurrentUsage:  0,
+						TeamID:        &team.ID,
 					}
 					if err := validateBudget(&budget); err != nil {
 						return err


### PR DESCRIPTION
## Summary

The `CalendarAligned` field has been moved from `TableBudget` to `TableVirtualKey`. Previously, each budget row stored its own `calendar_aligned` flag, but this caused redundancy since calendar alignment is a property of the virtual key, not individual budgets. Budget reset logic now looks up the virtual key associated with a budget to determine whether calendar alignment applies.

## Changes

- Removed the `CalendarAligned` field from `TableBudget` and its associated database column.
- Updated `ResetExpiredBudgetsInMemory` to resolve calendar alignment by loading the virtual key linked to the budget and reading `CalendarAligned` from there.
- Removed `CalendarAligned` from budget struct literals in `createTeam` and `updateTeam` handlers, since it is no longer a budget-level property.
- Simplified the `updateTeam` calendar-alignment transition logic: the previous `false → true` guard is no longer needed since the flag is no longer stored on the budget itself.
- Bumped `github.com/jackc/pgx/v5` from `v5.9.1` to `v5.9.2` in the prompts plugin.

## Type of change

- [ ] Bug fix
- [x] Refactor
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

1. Create a virtual key with `calendar_aligned: true`.
2. Attach a budget to that virtual key.
3. Trigger `ResetExpiredBudgetsInMemory` and confirm the budget resets at the correct calendar boundary.
4. Confirm budgets attached to virtual keys without `calendar_aligned` reset on a rolling interval as before.

## Breaking changes

- [x] Yes
- [ ] No

The `calendar_aligned` column is removed from the `budgets` table. A database migration dropping this column is required. Any existing data in that column will be lost; ensure virtual keys are configured with the correct `CalendarAligned` value before migrating.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable