### PR TITLE
fix: anthropic stream tool call translation

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2,9 +2,12 @@ package anthropic
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -83,11 +86,44 @@ type anthropicToResponsesStreamState struct {
 	// webSearchItemIDs tracks item IDs for WebSearch tools so their argument deltas
 	// can be skipped and regenerated synthetically (with sanitization) at output_item.done.
 	webSearchItemIDs map[string]bool
+
+	// openContentBlockIndices tracks Anthropic content blocks that have started
+	// but have not emitted content_block_stop yet. Anthropic clients expect blocks
+	// to be strictly nested as start -> deltas -> stop, with no overlap.
+	openContentBlockIndices   map[int]bool
+	closedContentBlockIndices map[int]bool
+	openToolBlockIndices      map[int]bool
+	sawToolUse                bool
+
+	// currentMessageID scopes generated Anthropic-safe tool IDs for streaming.
+	// Some OpenAI-compatible providers reuse raw IDs like functions.Bash:0 across
+	// turns, but Anthropic clients expect each streamed tool_use ID to be unique.
+	currentMessageID string
+	streamToolUseIDs map[string]string
 }
 
 type anthropicToResponsesStreamStateKeyType struct{}
 
 var anthropicToResponsesStreamStateKey = anthropicToResponsesStreamStateKeyType{}
+
+const anthropicToolUseIDPrefix = "toolu_"
+
+func normalizeAnthropicToolUseID(id *string, scope *string) *string {
+	if id == nil || *id == "" || strings.HasPrefix(*id, anthropicToolUseIDPrefix) {
+		return id
+	}
+
+	seed := *id
+	if scope != nil && *scope != "" {
+		seed = *scope + ":" + seed
+	}
+
+	sum := sha256.Sum256([]byte(seed))
+	encoded := hex.EncodeToString(sum[:])
+	normalized := anthropicToolUseIDPrefix + encoded[:24]
+
+	return &normalized
+}
 
 // getOrCreateAnthropicToResponsesStreamState returns the per-request conversion state,
 // creating and storing it in ctx on first access.
@@ -98,6 +134,162 @@ func getOrCreateAnthropicToResponsesStreamState(ctx *schemas.BifrostContext) *an
 	state := &anthropicToResponsesStreamState{}
 	ctx.SetValue(anthropicToResponsesStreamStateKey, state)
 	return state
+}
+
+func (state *anthropicToResponsesStreamState) resetForMessage(messageID *string) {
+	if state == nil {
+		return
+	}
+	if state.webSearchItemIDs != nil {
+		clear(state.webSearchItemIDs)
+	}
+	if state.openContentBlockIndices != nil {
+		clear(state.openContentBlockIndices)
+	}
+	if state.closedContentBlockIndices != nil {
+		clear(state.closedContentBlockIndices)
+	}
+	if state.openToolBlockIndices != nil {
+		clear(state.openToolBlockIndices)
+	}
+	if state.streamToolUseIDs != nil {
+		clear(state.streamToolUseIDs)
+	}
+	state.sawToolUse = false
+	state.currentMessageID = ""
+	if messageID != nil {
+		state.currentMessageID = *messageID
+	}
+}
+
+func (state *anthropicToResponsesStreamState) normalizeStreamToolUseID(id *string, outputIndex *int) *string {
+	if id == nil || *id == "" || strings.HasPrefix(*id, anthropicToolUseIDPrefix) {
+		return id
+	}
+	if state == nil {
+		return normalizeAnthropicToolUseID(id, nil)
+	}
+	if state.streamToolUseIDs == nil {
+		state.streamToolUseIDs = make(map[string]string)
+	}
+
+	key := *id
+	if outputIndex != nil {
+		key = fmt.Sprintf("%s:%d", key, *outputIndex)
+	}
+	if normalized, ok := state.streamToolUseIDs[key]; ok {
+		return &normalized
+	}
+
+	seed := *id
+	if state.currentMessageID != "" {
+		seed = state.currentMessageID + ":" + seed
+	}
+	if outputIndex != nil {
+		seed = fmt.Sprintf("%s:%d", seed, *outputIndex)
+	}
+	normalized := normalizeAnthropicToolUseID(&seed, nil)
+	if normalized == nil {
+		return nil
+	}
+	state.streamToolUseIDs[key] = *normalized
+	return normalized
+}
+
+func (state *anthropicToResponsesStreamState) trackOpenContentBlock(index *int, isToolBlock bool) {
+	if state == nil || index == nil {
+		return
+	}
+	if state.openContentBlockIndices == nil {
+		state.openContentBlockIndices = make(map[int]bool)
+	}
+	if state.closedContentBlockIndices == nil {
+		state.closedContentBlockIndices = make(map[int]bool)
+	}
+	state.openContentBlockIndices[*index] = true
+	delete(state.closedContentBlockIndices, *index)
+
+	if !isToolBlock {
+		return
+	}
+	if state.openToolBlockIndices == nil {
+		state.openToolBlockIndices = make(map[int]bool)
+	}
+	state.openToolBlockIndices[*index] = true
+	state.sawToolUse = true
+}
+
+func (state *anthropicToResponsesStreamState) markContentBlockClosed(index *int) {
+	if state == nil || index == nil {
+		return
+	}
+	if state.openContentBlockIndices != nil {
+		delete(state.openContentBlockIndices, *index)
+	}
+	if state.openToolBlockIndices != nil {
+		delete(state.openToolBlockIndices, *index)
+	}
+	if state.closedContentBlockIndices == nil {
+		state.closedContentBlockIndices = make(map[int]bool)
+	}
+	state.closedContentBlockIndices[*index] = true
+}
+
+func (state *anthropicToResponsesStreamState) closeContentBlockEvent(index *int) []*AnthropicStreamEvent {
+	if state == nil || index == nil {
+		return nil
+	}
+	if state.closedContentBlockIndices != nil && state.closedContentBlockIndices[*index] {
+		return nil
+	}
+	if state.openContentBlockIndices == nil || !state.openContentBlockIndices[*index] {
+		return nil
+	}
+	state.markContentBlockClosed(index)
+	idx := *index
+	return []*AnthropicStreamEvent{{
+		Type:  AnthropicStreamEventTypeContentBlockStop,
+		Index: &idx,
+	}}
+}
+
+func (state *anthropicToResponsesStreamState) flushOpenContentBlockStops() []*AnthropicStreamEvent {
+	return state.flushOpenContentBlockStopsBefore(nil)
+}
+
+func (state *anthropicToResponsesStreamState) flushOpenContentBlockStopsBefore(nextIndex *int) []*AnthropicStreamEvent {
+	if state == nil || len(state.openContentBlockIndices) == 0 {
+		return nil
+	}
+	indices := make([]int, 0, len(state.openContentBlockIndices))
+	for index := range state.openContentBlockIndices {
+		if nextIndex != nil && index == *nextIndex {
+			continue
+		}
+		indices = append(indices, index)
+	}
+	if len(indices) == 0 {
+		return nil
+	}
+	sort.Ints(indices)
+
+	events := make([]*AnthropicStreamEvent, 0, len(indices))
+	for _, index := range indices {
+		idx := index
+		events = append(events, &AnthropicStreamEvent{
+			Type:  AnthropicStreamEventTypeContentBlockStop,
+			Index: &idx,
+		})
+		delete(state.openContentBlockIndices, index)
+		if state.openToolBlockIndices != nil {
+			delete(state.openToolBlockIndices, index)
+		}
+		if state.closedContentBlockIndices == nil {
+			state.closedContentBlockIndices = make(map[int]bool)
+		}
+		state.closedContentBlockIndices[index] = true
+	}
+	return events
 }
 
 // acquireAnthropicResponsesStreamState gets an Anthropic responses stream state from the pool.
@@ -1425,7 +1617,9 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 	case schemas.ResponsesStreamResponseTypeCreated:
 		// Only convert response.created back to message_start (not response.in_progress to avoid duplicates)
 		streamResp.Type = AnthropicStreamEventTypeMessageStart
+		streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
 		if bifrostResp.Response != nil {
+			streamState.resetForMessage(bifrostResp.Response.ID)
 			// Use actual usage if available (forwarded from upstream message_start),
 			// otherwise fall back to zeros for non-Anthropic providers
 			var messageUsage *AnthropicUsage
@@ -1461,6 +1655,8 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				streamMessage.Model = bifrostResp.ExtraFields.OriginalModelRequested
 			}
 			streamResp.Message = streamMessage
+		} else {
+			streamState.resetForMessage(nil)
 		}
 	case schemas.ResponsesStreamResponseTypeInProgress:
 		// Skip converting response.in_progress back to avoid duplicate message_start events
@@ -1484,10 +1680,11 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 			// Build the content_block as tool_use
 			// Note: Computer tool calls should not be converted to thinking blocks
+			streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
 			contentBlock := &AnthropicContentBlock{
 				Type: AnthropicContentBlockTypeToolUse,
-				ID:   bifrostResp.Item.ID,                            // The tool use ID
-				Name: schemas.Ptr(string(AnthropicToolNameComputer)), // "computer"
+				ID:   streamState.normalizeStreamToolUseID(bifrostResp.Item.ID, bifrostResp.OutputIndex), // The tool use ID
+				Name: schemas.Ptr(string(AnthropicToolNameComputer)),                                     // "computer"
 			}
 
 			// Always start with empty input for streaming compatibility
@@ -1597,7 +1794,8 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 							} else {
 								contentBlock.Type = AnthropicContentBlockTypeToolUse
 								if bifrostResp.Item.ResponsesToolMessage != nil {
-									contentBlock.ID = bifrostResp.Item.ResponsesToolMessage.CallID
+									streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+									contentBlock.ID = streamState.normalizeStreamToolUseID(bifrostResp.Item.ResponsesToolMessage.CallID, bifrostResp.OutputIndex)
 									contentBlock.Name = bifrostResp.Item.ResponsesToolMessage.Name
 									// Always start with empty input for streaming compatibility
 									contentBlock.Input = json.RawMessage("{}")
@@ -1637,7 +1835,18 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 		// Generate synthetic input_json_delta events for tool calls with arguments
 		var events []*AnthropicStreamEvent
+		if streamResp.Type == AnthropicStreamEventTypeContentBlockStart && streamResp.ContentBlock != nil {
+			streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+			events = append(events, streamState.flushOpenContentBlockStopsBefore(streamResp.Index)...)
+		}
 		events = append(events, streamResp)
+		if streamResp.Type == AnthropicStreamEventTypeContentBlockStart && streamResp.ContentBlock != nil {
+			streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+			isToolBlock := streamResp.ContentBlock.Type == AnthropicContentBlockTypeToolUse ||
+				streamResp.ContentBlock.Type == AnthropicContentBlockTypeMCPToolUse ||
+				streamResp.ContentBlock.Type == AnthropicContentBlockTypeServerToolUse
+			streamState.trackOpenContentBlock(streamResp.Index, isToolBlock)
+		}
 
 		// Generate compaction_delta event for compaction items
 		if isCompactionItem(bifrostResp.Item) {
@@ -1697,7 +1906,6 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				events = append(events, deltaEvents...)
 			}
 		}
-
 		return events
 	case schemas.ResponsesStreamResponseTypeContentPartAdded:
 		return nil
@@ -1789,8 +1997,15 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			}
 		}
 
-	case schemas.ResponsesStreamResponseTypeContentPartDone:
-		return nil
+	case schemas.ResponsesStreamResponseTypeOutputTextDone,
+		schemas.ResponsesStreamResponseTypeReasoningSummaryTextDone,
+		schemas.ResponsesStreamResponseTypeContentPartDone:
+		indexToUse := bifrostResp.OutputIndex
+		if indexToUse == nil {
+			indexToUse = bifrostResp.ContentIndex
+		}
+		streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+		return streamState.closeContentBlockEvent(indexToUse)
 
 	case schemas.ResponsesStreamResponseTypeOutputItemDone:
 		// Handle WebSearch tool completion with sanitization and synthetic delta generation
@@ -1826,10 +2041,11 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				Index: indexToUse,
 			}
 			events = append(events, stopEvent)
+			streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+			streamState.markContentBlockClosed(indexToUse)
 
 			// Clean up the tracking for this WebSearch item
 			if bifrostResp.Item.ID != nil {
-				streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
 				delete(streamState.webSearchItemIDs, *bifrostResp.Item.ID)
 			}
 
@@ -1914,6 +2130,8 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				stopEvent.Index = bifrostResp.OutputIndex
 			}
 			events = append(events, stopEvent)
+			streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+			streamState.markContentBlockClosed(stopEvent.Index)
 
 			// 2. Extract sources and create web_search_tool_result block if sources exist
 			if bifrostResp.Item.ResponsesToolMessage != nil &&
@@ -1976,13 +2194,10 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			(*bifrostResp.Item.Type == schemas.ResponsesMessageTypeFunctionCall ||
 				*bifrostResp.Item.Type == schemas.ResponsesMessageTypeMCPCall) {
 
-			// Function call or MCP call complete - just emit content_block_stop
-			streamResp.Type = AnthropicStreamEventTypeContentBlockStop
-			if bifrostResp.ContentIndex != nil {
-				streamResp.Index = bifrostResp.ContentIndex
-			} else if bifrostResp.OutputIndex != nil {
-				streamResp.Index = bifrostResp.OutputIndex
-			}
+			// Some OpenAI-compatible providers emit output_item.done before all
+			// argument deltas. Close regular tool blocks at response.completed
+			// instead, after all deltas have been rendered.
+			return nil
 		} else {
 			// For text blocks and other content blocks, emit content_block_stop
 			streamResp.Type = AnthropicStreamEventTypeContentBlockStop
@@ -1992,6 +2207,8 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			} else if bifrostResp.ContentIndex != nil {
 				streamResp.Index = bifrostResp.ContentIndex
 			}
+			streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+			return streamState.closeContentBlockEvent(streamResp.Index)
 		}
 	case schemas.ResponsesStreamResponseTypeWebSearchCallInProgress,
 		schemas.ResponsesStreamResponseTypeWebSearchCallSearching,
@@ -2005,10 +2222,12 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 	case schemas.ResponsesStreamResponseTypeCompleted:
 		streamResp.Type = AnthropicStreamEventTypeMessageStop
+		streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+		pendingContentBlockStops := streamState.flushOpenContentBlockStops()
 		// If a message_delta was already emitted from the upstream event, only emit message_stop
 		// to avoid sending a duplicate message_delta to the client.
 		if alreadyEmitted, ok := ctx.Value(schemas.BifrostContextKeyHasEmittedMessageDelta).(bool); ok && alreadyEmitted {
-			return []*AnthropicStreamEvent{streamResp}
+			return append(pendingContentBlockStops, streamResp)
 		}
 		anthropicContentDeltaEvent := &AnthropicStreamEvent{
 			Type: AnthropicStreamEventTypeMessageDelta,
@@ -2020,14 +2239,19 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 		// Convert usage from Bifrost to Anthropic
 		if bifrostResp.Response != nil {
 			anthropicContentDeltaEvent.Usage = ConvertBifrostUsageToAnthropicUsage(bifrostResp.Response.Usage)
+			stopReason := AnthropicStopReasonEndTurn
 			if bifrostResp.Response.StopReason != nil {
-				anthropicContentDeltaEvent.Delta = &AnthropicStreamDelta{
-					StopReason:   schemas.Ptr(ConvertBifrostFinishReasonToAnthropic(*bifrostResp.Response.StopReason)),
-					StopSequence: nil,
-				}
+				stopReason = ConvertBifrostFinishReasonToAnthropic(*bifrostResp.Response.StopReason)
+			}
+			if streamState.sawToolUse && stopReason == AnthropicStopReasonEndTurn {
+				stopReason = AnthropicStopReasonToolUse
+			}
+			anthropicContentDeltaEvent.Delta = &AnthropicStreamDelta{
+				StopReason:   schemas.Ptr(stopReason),
+				StopSequence: nil,
 			}
 		}
-		return []*AnthropicStreamEvent{anthropicContentDeltaEvent, streamResp}
+		return append(pendingContentBlockStops, anthropicContentDeltaEvent, streamResp)
 
 	case schemas.ResponsesStreamResponseTypeMCPCallArgumentsDelta:
 		// MCP call arguments delta - convert to content_block_delta with input_json
@@ -2053,13 +2277,14 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 	case schemas.ResponsesStreamResponseTypeMCPCallCompleted:
 		// MCP call completed - emit content_block_stop
-		streamResp.Type = AnthropicStreamEventTypeContentBlockStop
 		// Use OutputIndex for global Anthropic indexing
 		if bifrostResp.OutputIndex != nil {
 			streamResp.Index = bifrostResp.OutputIndex
 		} else if bifrostResp.ContentIndex != nil {
 			streamResp.Index = bifrostResp.ContentIndex
 		}
+		streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+		return streamState.closeContentBlockEvent(streamResp.Index)
 
 	case schemas.ResponsesStreamResponseTypeMCPCallFailed:
 		// MCP call failed - emit error event
@@ -2852,6 +3077,36 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 	var pendingReasoningContentBlocks []AnthropicContentBlock
 	var currentAssistantMessage *AnthropicMessage
 
+	normalizedToolUseIDsByCallID := make(map[string][]string)
+	toolUseIDScope := func(index int, msg *schemas.ResponsesMessage) *string {
+		if msg != nil && msg.ID != nil && *msg.ID != "" {
+			return schemas.Ptr(fmt.Sprintf("%d:%s", index, *msg.ID))
+		}
+		return schemas.Ptr(fmt.Sprintf("%d", index))
+	}
+	recordNormalizedToolUseID := func(callID *string, normalizedID *string) {
+		if callID == nil || *callID == "" || normalizedID == nil || *normalizedID == "" {
+			return
+		}
+		normalizedToolUseIDsByCallID[*callID] = append(normalizedToolUseIDsByCallID[*callID], *normalizedID)
+	}
+	nextNormalizedToolUseID := func(callID *string) *string {
+		if callID == nil || *callID == "" {
+			return nil
+		}
+		ids := normalizedToolUseIDsByCallID[*callID]
+		if len(ids) == 0 {
+			return normalizeAnthropicToolUseID(callID, nil)
+		}
+		normalized := ids[0]
+		if len(ids) == 1 {
+			delete(normalizedToolUseIDsByCallID, *callID)
+		} else {
+			normalizedToolUseIDsByCallID[*callID] = ids[1:]
+		}
+		return &normalized
+	}
+
 	// Track tool call IDs for each assistant turn to properly match tool results
 	// Each assistant turn that contains tool_use blocks should have its tool results
 	// grouped in a corresponding user message
@@ -3039,8 +3294,11 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 				pendingReasoningContentBlocks = nil
 			}
 
-			toolUseBlock := convertBifrostFunctionCallToAnthropicToolUse(ctx, &msg)
+			toolUseBlock := convertBifrostFunctionCallToAnthropicToolUse(ctx, &msg, toolUseIDScope(i, &msg))
 			if toolUseBlock != nil {
+				if msg.ResponsesToolMessage != nil {
+					recordNormalizedToolUseID(msg.ResponsesToolMessage.CallID, toolUseBlock.ID)
+				}
 				// If there was a previous assistant message (text only) that was just added,
 				// and we have no pending tool calls yet, we should merge the tool call into it.
 				// This handles the case where an assistant text message precedes tool calls.
@@ -3099,7 +3357,11 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 			// Accumulate tool result blocks - they will be merged into a single user message
 			// This is required because Anthropic/Bedrock expect all tool results for parallel
 			// tool calls to be in the same user message, in the same order as the tool calls
-			toolResultBlock := convertBifrostFunctionCallOutputToAnthropicToolResultBlock(&msg)
+			var normalizedToolUseID *string
+			if msg.ResponsesToolMessage != nil {
+				normalizedToolUseID = nextNormalizedToolUseID(msg.ResponsesToolMessage.CallID)
+			}
+			toolResultBlock := convertBifrostFunctionCallOutputToAnthropicToolResultBlock(&msg, normalizedToolUseID)
 			if toolResultBlock != nil {
 				pendingToolResultBlocks = append(pendingToolResultBlocks, *toolResultBlock)
 			}
@@ -3133,8 +3395,11 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 				pendingReasoningContentBlocks = nil
 			}
 
-			computerToolUseBlock := convertBifrostComputerCallToAnthropicToolUse(&msg)
+			computerToolUseBlock := convertBifrostComputerCallToAnthropicToolUse(&msg, toolUseIDScope(i, &msg))
 			if computerToolUseBlock != nil {
+				if msg.ResponsesToolMessage != nil {
+					recordNormalizedToolUseID(msg.ResponsesToolMessage.CallID, computerToolUseBlock.ID)
+				}
 				pendingToolCalls = append(pendingToolCalls, *computerToolUseBlock)
 
 				// Track the tool call ID for matching with tool results
@@ -3319,7 +3584,11 @@ func ConvertBifrostMessagesToAnthropicMessages(ctx *schemas.BifrostContext, bifr
 			flushPendingToolCallsWithTracking()
 
 			// Accumulate computer call output with other tool results
-			computerResultBlock := convertBifrostComputerCallOutputToAnthropicToolResultBlock(&msg)
+			var normalizedToolUseID *string
+			if msg.ResponsesToolMessage != nil {
+				normalizedToolUseID = nextNormalizedToolUseID(msg.ResponsesToolMessage.CallID)
+			}
+			computerResultBlock := convertBifrostComputerCallOutputToAnthropicToolResultBlock(&msg, normalizedToolUseID)
 			if computerResultBlock != nil {
 				pendingToolResultBlocks = append(pendingToolResultBlocks, *computerResultBlock)
 			}
@@ -4253,16 +4522,14 @@ func convertBifrostReasoningToAnthropicThinking(msg *schemas.ResponsesMessage) [
 }
 
 // convertBifrostFunctionCallToAnthropicToolUse converts a Bifrost function call to Anthropic tool use
-func convertBifrostFunctionCallToAnthropicToolUse(ctx *schemas.BifrostContext, msg *schemas.ResponsesMessage) *AnthropicContentBlock {
+func convertBifrostFunctionCallToAnthropicToolUse(ctx *schemas.BifrostContext, msg *schemas.ResponsesMessage, toolUseIDScope *string) *AnthropicContentBlock {
 	if msg.ResponsesToolMessage != nil {
 		toolUseBlock := AnthropicContentBlock{
 			Type:         AnthropicContentBlockTypeToolUse,
 			CacheControl: msg.CacheControl,
 		}
 
-		if msg.ResponsesToolMessage.CallID != nil {
-			toolUseBlock.ID = msg.ResponsesToolMessage.CallID
-		}
+		toolUseBlock.ID = normalizeAnthropicToolUseID(msg.ResponsesToolMessage.CallID, toolUseIDScope)
 		if msg.ResponsesToolMessage.Name != nil {
 			toolUseBlock.Name = msg.ResponsesToolMessage.Name
 		}
@@ -4291,11 +4558,14 @@ func convertBifrostFunctionCallToAnthropicToolUse(ctx *schemas.BifrostContext, m
 
 // convertBifrostFunctionCallOutputToAnthropicToolResultBlock converts a Bifrost function call output to a single tool result block
 // This is used to accumulate multiple tool results into a single user message
-func convertBifrostFunctionCallOutputToAnthropicToolResultBlock(msg *schemas.ResponsesMessage) *AnthropicContentBlock {
+func convertBifrostFunctionCallOutputToAnthropicToolResultBlock(msg *schemas.ResponsesMessage, toolUseID *string) *AnthropicContentBlock {
 	if msg.ResponsesToolMessage != nil {
+		if toolUseID == nil {
+			toolUseID = normalizeAnthropicToolUseID(msg.ResponsesToolMessage.CallID, nil)
+		}
 		toolResultBlock := AnthropicContentBlock{
 			Type:         AnthropicContentBlockTypeToolResult,
-			ToolUseID:    msg.ResponsesToolMessage.CallID,
+			ToolUseID:    toolUseID,
 			CacheControl: msg.CacheControl,
 		}
 
@@ -4322,11 +4592,14 @@ func convertBifrostFunctionCallOutputToAnthropicToolResultBlock(msg *schemas.Res
 
 // convertBifrostComputerCallOutputToAnthropicToolResultBlock converts a Bifrost computer call output to a single tool result block
 // This is used to accumulate multiple tool results into a single user message
-func convertBifrostComputerCallOutputToAnthropicToolResultBlock(msg *schemas.ResponsesMessage) *AnthropicContentBlock {
+func convertBifrostComputerCallOutputToAnthropicToolResultBlock(msg *schemas.ResponsesMessage, toolUseID *string) *AnthropicContentBlock {
 	if msg.ResponsesToolMessage != nil && msg.ResponsesToolMessage.CallID != nil {
+		if toolUseID == nil {
+			toolUseID = normalizeAnthropicToolUseID(msg.ResponsesToolMessage.CallID, nil)
+		}
 		toolResultBlock := AnthropicContentBlock{
 			Type:      AnthropicContentBlockTypeToolResult,
-			ToolUseID: msg.ResponsesToolMessage.CallID,
+			ToolUseID: toolUseID,
 		}
 
 		// Handle output
@@ -4405,15 +4678,13 @@ func convertBifrostItemReferenceToAnthropicMessage(msg *schemas.ResponsesMessage
 }
 
 // convertBifrostComputerCallToAnthropicToolUse converts a Bifrost computer call to Anthropic tool use
-func convertBifrostComputerCallToAnthropicToolUse(msg *schemas.ResponsesMessage) *AnthropicContentBlock {
+func convertBifrostComputerCallToAnthropicToolUse(msg *schemas.ResponsesMessage, toolUseIDScope *string) *AnthropicContentBlock {
 	if msg.ResponsesToolMessage != nil {
 		toolUseBlock := AnthropicContentBlock{
 			Type: AnthropicContentBlockTypeToolUse,
 			Name: schemas.Ptr(string(AnthropicToolNameComputer)),
 		}
-		if msg.ResponsesToolMessage.CallID != nil {
-			toolUseBlock.ID = msg.ResponsesToolMessage.CallID
-		}
+		toolUseBlock.ID = normalizeAnthropicToolUseID(msg.ResponsesToolMessage.CallID, toolUseIDScope)
 		if msg.ResponsesToolMessage.Name != nil {
 			toolUseBlock.Name = msg.ResponsesToolMessage.Name
 		}
@@ -4603,7 +4874,7 @@ func convertBifrostComputerCallOutputToAnthropicMessage(msg *schemas.ResponsesMe
 	if msg.ResponsesToolMessage != nil {
 		toolResultBlock := AnthropicContentBlock{
 			Type:      AnthropicContentBlockTypeToolResult,
-			ToolUseID: msg.ResponsesToolMessage.CallID,
+			ToolUseID: normalizeAnthropicToolUseID(msg.ResponsesToolMessage.CallID, nil),
 		}
 
 		if msg.ResponsesToolMessage.Output != nil {

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -93,6 +93,9 @@ type anthropicToResponsesStreamState struct {
 	openContentBlockIndices   map[int]bool
 	closedContentBlockIndices map[int]bool
 	openToolBlockIndices      map[int]bool
+	completedToolBlockIndices map[int]bool
+	toolArgumentDeltaQueues   map[int][]*AnthropicStreamEvent
+	pendingContentBlockStarts []pendingAnthropicContentBlockStart
 	sawToolUse                bool
 
 	// currentMessageID scopes generated Anthropic-safe tool IDs for streaming.
@@ -100,6 +103,11 @@ type anthropicToResponsesStreamState struct {
 	// turns, but Anthropic clients expect each streamed tool_use ID to be unique.
 	currentMessageID string
 	streamToolUseIDs map[string]string
+}
+
+type pendingAnthropicContentBlockStart struct {
+	event       *AnthropicStreamEvent
+	isToolBlock bool
 }
 
 type anthropicToResponsesStreamStateKeyType struct{}
@@ -152,9 +160,16 @@ func (state *anthropicToResponsesStreamState) resetForMessage(messageID *string)
 	if state.openToolBlockIndices != nil {
 		clear(state.openToolBlockIndices)
 	}
+	if state.completedToolBlockIndices != nil {
+		clear(state.completedToolBlockIndices)
+	}
+	if state.toolArgumentDeltaQueues != nil {
+		clear(state.toolArgumentDeltaQueues)
+	}
 	if state.streamToolUseIDs != nil {
 		clear(state.streamToolUseIDs)
 	}
+	state.pendingContentBlockStarts = state.pendingContentBlockStarts[:0]
 	state.sawToolUse = false
 	state.currentMessageID = ""
 	if messageID != nil {
@@ -233,6 +248,12 @@ func (state *anthropicToResponsesStreamState) markContentBlockClosed(index *int)
 		state.closedContentBlockIndices = make(map[int]bool)
 	}
 	state.closedContentBlockIndices[*index] = true
+	if state.completedToolBlockIndices != nil {
+		delete(state.completedToolBlockIndices, *index)
+	}
+	if state.toolArgumentDeltaQueues != nil {
+		delete(state.toolArgumentDeltaQueues, *index)
+	}
 }
 
 func (state *anthropicToResponsesStreamState) closeContentBlockEvent(index *int) []*AnthropicStreamEvent {
@@ -254,10 +275,20 @@ func (state *anthropicToResponsesStreamState) closeContentBlockEvent(index *int)
 }
 
 func (state *anthropicToResponsesStreamState) flushOpenContentBlockStops() []*AnthropicStreamEvent {
-	return state.flushOpenContentBlockStopsBefore(nil)
+	if state == nil {
+		return nil
+	}
+	events := state.flushOpenContentBlockStopsBeforeInternal(nil, true)
+	events = append(events, state.emitPendingContentBlockStarts(true)...)
+	events = append(events, state.flushOpenContentBlockStopsBeforeInternal(nil, true)...)
+	return events
 }
 
 func (state *anthropicToResponsesStreamState) flushOpenContentBlockStopsBefore(nextIndex *int) []*AnthropicStreamEvent {
+	return state.flushOpenContentBlockStopsBeforeInternal(nextIndex, false)
+}
+
+func (state *anthropicToResponsesStreamState) flushOpenContentBlockStopsBeforeInternal(nextIndex *int, forceToolStops bool) []*AnthropicStreamEvent {
 	if state == nil || len(state.openContentBlockIndices) == 0 {
 		return nil
 	}
@@ -275,6 +306,17 @@ func (state *anthropicToResponsesStreamState) flushOpenContentBlockStopsBefore(n
 
 	events := make([]*AnthropicStreamEvent, 0, len(indices))
 	for _, index := range indices {
+		if state.openToolBlockIndices != nil && state.openToolBlockIndices[index] {
+			if !forceToolStops && !state.isToolBlockComplete(index) {
+				continue
+			}
+			if forceToolStops {
+				state.markToolBlockCompleteOnly(index)
+			}
+			idx := index
+			events = append(events, state.drainCompletedToolBlock(&idx)...)
+			continue
+		}
 		idx := index
 		events = append(events, &AnthropicStreamEvent{
 			Type:  AnthropicStreamEventTypeContentBlockStop,
@@ -289,6 +331,129 @@ func (state *anthropicToResponsesStreamState) flushOpenContentBlockStopsBefore(n
 		}
 		state.closedContentBlockIndices[index] = true
 	}
+	return events
+}
+
+func (state *anthropicToResponsesStreamState) queueToolArgumentDelta(event *AnthropicStreamEvent) bool {
+	if state == nil || event == nil || event.Index == nil || event.Delta == nil {
+		return false
+	}
+	if state.toolArgumentDeltaQueues == nil {
+		state.toolArgumentDeltaQueues = make(map[int][]*AnthropicStreamEvent)
+	}
+	index := *event.Index
+	state.toolArgumentDeltaQueues[index] = append(state.toolArgumentDeltaQueues[index], event)
+	return true
+}
+
+func (state *anthropicToResponsesStreamState) queueToolArgumentDeltas(events []*AnthropicStreamEvent) {
+	for _, event := range events {
+		state.queueToolArgumentDelta(event)
+	}
+}
+
+func (state *anthropicToResponsesStreamState) hasQueuedToolArgumentDeltas(index *int) bool {
+	if state == nil || index == nil || state.toolArgumentDeltaQueues == nil {
+		return false
+	}
+	return len(state.toolArgumentDeltaQueues[*index]) > 0
+}
+
+func (state *anthropicToResponsesStreamState) markToolBlockCompleteOnly(index int) {
+	if state == nil {
+		return
+	}
+	if state.completedToolBlockIndices == nil {
+		state.completedToolBlockIndices = make(map[int]bool)
+	}
+	state.completedToolBlockIndices[index] = true
+}
+
+func (state *anthropicToResponsesStreamState) markToolBlockComplete(index *int) []*AnthropicStreamEvent {
+	if state == nil || index == nil {
+		return nil
+	}
+	state.markToolBlockCompleteOnly(*index)
+	events := state.drainCompletedToolBlock(index)
+	events = append(events, state.emitPendingContentBlockStarts(false)...)
+	return events
+}
+
+func (state *anthropicToResponsesStreamState) isToolBlockComplete(index int) bool {
+	return state != nil && state.completedToolBlockIndices != nil && state.completedToolBlockIndices[index]
+}
+
+func (state *anthropicToResponsesStreamState) hasBlockingOpenToolBlock(nextIndex *int) bool {
+	if state == nil || len(state.openToolBlockIndices) == 0 {
+		return false
+	}
+	for index := range state.openToolBlockIndices {
+		if nextIndex != nil && index == *nextIndex {
+			continue
+		}
+		if state.openContentBlockIndices != nil && state.openContentBlockIndices[index] && !state.isToolBlockComplete(index) {
+			return true
+		}
+	}
+	return false
+}
+
+func (state *anthropicToResponsesStreamState) queuePendingContentBlockStart(event *AnthropicStreamEvent, isToolBlock bool) {
+	if state == nil || event == nil || event.Index == nil {
+		return
+	}
+	for _, pending := range state.pendingContentBlockStarts {
+		if pending.event != nil && pending.event.Index != nil && *pending.event.Index == *event.Index {
+			return
+		}
+	}
+	state.pendingContentBlockStarts = append(state.pendingContentBlockStarts, pendingAnthropicContentBlockStart{
+		event:       event,
+		isToolBlock: isToolBlock,
+	})
+}
+
+func (state *anthropicToResponsesStreamState) emitPendingContentBlockStarts(forceToolStops bool) []*AnthropicStreamEvent {
+	if state == nil || len(state.pendingContentBlockStarts) == 0 {
+		return nil
+	}
+
+	var events []*AnthropicStreamEvent
+	for len(state.pendingContentBlockStarts) > 0 {
+		pending := state.pendingContentBlockStarts[0]
+		events = append(events, state.flushOpenContentBlockStopsBeforeInternal(pending.event.Index, forceToolStops)...)
+		if state.hasBlockingOpenToolBlock(pending.event.Index) {
+			break
+		}
+
+		state.pendingContentBlockStarts = state.pendingContentBlockStarts[1:]
+		events = append(events, pending.event)
+		state.trackOpenContentBlock(pending.event.Index, pending.isToolBlock)
+		if pending.isToolBlock {
+			if forceToolStops && pending.event.Index != nil {
+				state.markToolBlockCompleteOnly(*pending.event.Index)
+			}
+			if pending.event.Index != nil && state.isToolBlockComplete(*pending.event.Index) {
+				events = append(events, state.drainCompletedToolBlock(pending.event.Index)...)
+			}
+		}
+	}
+	return events
+}
+
+func (state *anthropicToResponsesStreamState) drainCompletedToolBlock(index *int) []*AnthropicStreamEvent {
+	if state == nil || index == nil {
+		return nil
+	}
+	if state.openContentBlockIndices == nil || !state.openContentBlockIndices[*index] {
+		return nil
+	}
+
+	var events []*AnthropicStreamEvent
+	if state.toolArgumentDeltaQueues != nil {
+		events = append(events, state.toolArgumentDeltaQueues[*index]...)
+	}
+	events = append(events, state.closeContentBlockEvent(index)...)
 	return events
 }
 
@@ -1835,17 +2000,22 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 
 		// Generate synthetic input_json_delta events for tool calls with arguments
 		var events []*AnthropicStreamEvent
+		var streamState *anthropicToResponsesStreamState
+		var isToolBlock bool
 		if streamResp.Type == AnthropicStreamEventTypeContentBlockStart && streamResp.ContentBlock != nil {
-			streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+			streamState = getOrCreateAnthropicToResponsesStreamState(ctx)
 			events = append(events, streamState.flushOpenContentBlockStopsBefore(streamResp.Index)...)
-		}
-		events = append(events, streamResp)
-		if streamResp.Type == AnthropicStreamEventTypeContentBlockStart && streamResp.ContentBlock != nil {
-			streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
-			isToolBlock := streamResp.ContentBlock.Type == AnthropicContentBlockTypeToolUse ||
+			isToolBlock = streamResp.ContentBlock.Type == AnthropicContentBlockTypeToolUse ||
 				streamResp.ContentBlock.Type == AnthropicContentBlockTypeMCPToolUse ||
 				streamResp.ContentBlock.Type == AnthropicContentBlockTypeServerToolUse
-			streamState.trackOpenContentBlock(streamResp.Index, isToolBlock)
+			if streamState.hasBlockingOpenToolBlock(streamResp.Index) {
+				streamState.queuePendingContentBlockStart(streamResp, isToolBlock)
+			} else {
+				events = append(events, streamResp)
+				streamState.trackOpenContentBlock(streamResp.Index, isToolBlock)
+			}
+		} else {
+			events = append(events, streamResp)
 		}
 
 		// Generate compaction_delta event for compaction items
@@ -1903,7 +2073,11 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 					indexToUse = bifrostResp.ContentIndex
 				}
 				deltaEvents := generateSyntheticInputJSONDeltas(argumentsJSON, indexToUse)
-				events = append(events, deltaEvents...)
+				if isToolBlock && streamState != nil {
+					streamState.queueToolArgumentDeltas(deltaEvents)
+				} else {
+					events = append(events, deltaEvents...)
+				}
 			}
 		}
 		return events
@@ -1954,6 +2128,11 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				PartialJSON: bifrostResp.Delta,
 			}
 		}
+		if streamResp.Delta != nil {
+			streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+			streamState.queueToolArgumentDelta(streamResp)
+		}
+		return nil
 
 	case schemas.ResponsesStreamResponseTypeReasoningSummaryTextDelta:
 		streamResp.Type = AnthropicStreamEventTypeContentBlockDelta
@@ -2210,6 +2389,18 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
 			return streamState.closeContentBlockEvent(streamResp.Index)
 		}
+	case schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDone,
+		schemas.ResponsesStreamResponseTypeMCPCallArgumentsDone:
+		indexToUse := bifrostResp.OutputIndex
+		if indexToUse == nil {
+			indexToUse = bifrostResp.ContentIndex
+		}
+		streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+		if !streamState.hasQueuedToolArgumentDeltas(indexToUse) && bifrostResp.Arguments != nil && *bifrostResp.Arguments != "" {
+			streamState.queueToolArgumentDeltas(generateSyntheticInputJSONDeltas(*bifrostResp.Arguments, indexToUse))
+		}
+		return streamState.markToolBlockComplete(indexToUse)
+
 	case schemas.ResponsesStreamResponseTypeWebSearchCallInProgress,
 		schemas.ResponsesStreamResponseTypeWebSearchCallSearching,
 		schemas.ResponsesStreamResponseTypeWebSearchCallCompleted:
@@ -2274,6 +2465,11 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 				PartialJSON: bifrostResp.Arguments,
 			}
 		}
+		if streamResp.Delta != nil {
+			streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
+			streamState.queueToolArgumentDelta(streamResp)
+		}
+		return nil
 
 	case schemas.ResponsesStreamResponseTypeMCPCallCompleted:
 		// MCP call completed - emit content_block_stop
@@ -2284,7 +2480,7 @@ func ToAnthropicResponsesStreamResponse(ctx *schemas.BifrostContext, bifrostResp
 			streamResp.Index = bifrostResp.ContentIndex
 		}
 		streamState := getOrCreateAnthropicToResponsesStreamState(ctx)
-		return streamState.closeContentBlockEvent(streamResp.Index)
+		return streamState.markToolBlockComplete(streamResp.Index)
 
 	case schemas.ResponsesStreamResponseTypeMCPCallFailed:
 		// MCP call failed - emit error event

--- a/core/providers/anthropic/responsesstream_test.go
+++ b/core/providers/anthropic/responsesstream_test.go
@@ -1,0 +1,735 @@
+package anthropic
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestOpenAIChatToolStreamFallbackToAnthropicClosesToolBlock(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	state := schemas.AcquireChatToResponsesStreamState()
+	defer schemas.ReleaseChatToResponsesStreamState(state)
+
+	role := string(schemas.ChatMessageRoleAssistant)
+	toolCallID := "call_abc123"
+	toolName := "get_weather"
+	finishReason := string(schemas.BifrostFinishReasonToolCalls)
+
+	chunks := []*schemas.BifrostChatResponse{
+		{
+			ID:    "chatcmpl-test",
+			Model: "test-model",
+			Choices: []schemas.BifrostResponseChoice{{
+				ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+					Delta: &schemas.ChatStreamResponseChoiceDelta{Role: &role},
+				},
+			}},
+		},
+		{
+			ID:    "chatcmpl-test",
+			Model: "test-model",
+			Choices: []schemas.BifrostResponseChoice{{
+				ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+					Delta: &schemas.ChatStreamResponseChoiceDelta{
+						ToolCalls: []schemas.ChatAssistantMessageToolCall{{
+							Index: 0,
+							ID:    &toolCallID,
+							Function: schemas.ChatAssistantMessageToolCallFunction{
+								Name:      &toolName,
+								Arguments: `{"city":`,
+							},
+						}},
+					},
+				},
+			}},
+		},
+		{
+			ID:    "chatcmpl-test",
+			Model: "test-model",
+			Choices: []schemas.BifrostResponseChoice{{
+				ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+					Delta: &schemas.ChatStreamResponseChoiceDelta{
+						ToolCalls: []schemas.ChatAssistantMessageToolCall{{
+							Index:    0,
+							Function: schemas.ChatAssistantMessageToolCallFunction{Arguments: `"Paris"}`},
+						}},
+					},
+				},
+			}},
+		},
+		{
+			ID:    "chatcmpl-test",
+			Model: "test-model",
+			Choices: []schemas.BifrostResponseChoice{{
+				FinishReason: &finishReason,
+				ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+					Delta: &schemas.ChatStreamResponseChoiceDelta{},
+				},
+			}},
+		},
+	}
+
+	var events []*AnthropicStreamEvent
+	for _, chunk := range chunks {
+		for _, responseEvent := range chunk.ToBifrostResponsesStreamResponse(state) {
+			events = append(events, ToAnthropicResponsesStreamResponse(ctx, responseEvent)...)
+		}
+	}
+
+	var toolStart, toolStop, messageDelta bool
+	var toolInputJSON string
+	for _, event := range events {
+		switch event.Type {
+		case AnthropicStreamEventTypeContentBlockStart:
+			if event.ContentBlock != nil && event.ContentBlock.Type == AnthropicContentBlockTypeToolUse {
+				toolStart = true
+				if event.Index == nil {
+					t.Fatal("tool_use content_block_start missing index")
+				}
+				if *event.Index != 0 {
+					t.Fatalf("tool_use content_block_start index = %d, want 0", *event.Index)
+				}
+				if event.ContentBlock.ID == nil {
+					t.Fatal("tool_use id is nil")
+				}
+				if !strings.HasPrefix(*event.ContentBlock.ID, "toolu_") {
+					t.Fatalf("tool_use id = %q, want toolu_ prefix", *event.ContentBlock.ID)
+				}
+				if *event.ContentBlock.ID == toolCallID {
+					t.Fatalf("tool_use id = %q, want normalized Anthropic-safe id", *event.ContentBlock.ID)
+				}
+				if event.ContentBlock.Name == nil || *event.ContentBlock.Name != toolName {
+					t.Fatalf("tool_use name = %v, want %q", event.ContentBlock.Name, toolName)
+				}
+			}
+		case AnthropicStreamEventTypeContentBlockStop:
+			if event.Index != nil && *event.Index == 0 {
+				toolStop = true
+			}
+		case AnthropicStreamEventTypeContentBlockDelta:
+			if event.Index != nil && *event.Index == 0 && event.Delta != nil && event.Delta.PartialJSON != nil {
+				toolInputJSON += *event.Delta.PartialJSON
+			}
+		case AnthropicStreamEventTypeMessageDelta:
+			messageDelta = true
+			if event.Delta == nil || event.Delta.StopReason == nil {
+				t.Fatal("message_delta missing stop_reason")
+			}
+			if *event.Delta.StopReason != AnthropicStopReasonToolUse {
+				t.Fatalf("message_delta stop_reason = %q, want %q", *event.Delta.StopReason, AnthropicStopReasonToolUse)
+			}
+		}
+	}
+
+	if !toolStart {
+		t.Fatal("expected tool_use content_block_start")
+	}
+	if !toolStop {
+		t.Fatal("expected tool_use content_block_stop for index 0")
+	}
+	if toolInputJSON != `{"city":"Paris"}` {
+		t.Fatalf("tool_use input_json_delta = %q, want %q", toolInputJSON, `{"city":"Paris"}`)
+	}
+	if !messageDelta {
+		t.Fatal("expected message_delta")
+	}
+}
+
+func TestNormalizeAnthropicToolUseID(t *testing.T) {
+	t.Parallel()
+
+	rawID := "functions.Read:0"
+	normalized := normalizeAnthropicToolUseID(&rawID, nil)
+	if normalized == nil {
+		t.Fatal("normalized id is nil")
+	}
+	if !strings.HasPrefix(*normalized, "toolu_") {
+		t.Fatalf("normalized id = %q, want toolu_ prefix", *normalized)
+	}
+	if *normalized == rawID {
+		t.Fatalf("normalized id = %q, want different id", *normalized)
+	}
+
+	normalizedAgain := normalizeAnthropicToolUseID(&rawID, nil)
+	if normalizedAgain == nil || *normalizedAgain != *normalized {
+		t.Fatalf("normalization is not stable: first=%v second=%v", normalized, normalizedAgain)
+	}
+
+	scope := "turn-1"
+	scoped := normalizeAnthropicToolUseID(&rawID, &scope)
+	if scoped == nil {
+		t.Fatal("scoped normalized id is nil")
+	}
+	if *scoped == *normalized {
+		t.Fatalf("scoped normalized id = %q, want distinct from unscoped %q", *scoped, *normalized)
+	}
+	scopedAgain := normalizeAnthropicToolUseID(&rawID, &scope)
+	if scopedAgain == nil || *scopedAgain != *scoped {
+		t.Fatalf("scoped normalization is not stable: first=%v second=%v", scoped, scopedAgain)
+	}
+
+	anthropicID := "toolu_native123"
+	preserved := normalizeAnthropicToolUseID(&anthropicID, &scope)
+	if preserved == nil || *preserved != anthropicID {
+		t.Fatalf("native Anthropic id was not preserved: %v", preserved)
+	}
+
+	toolResultBlock := convertBifrostFunctionCallOutputToAnthropicToolResultBlock(&schemas.ResponsesMessage{
+		ResponsesToolMessage: &schemas.ResponsesToolMessage{
+			CallID: &rawID,
+		},
+	}, normalized)
+	if toolResultBlock == nil || toolResultBlock.ToolUseID == nil || *toolResultBlock.ToolUseID != *normalized {
+		t.Fatalf("tool result id = %v, want matching normalized id %q", toolResultBlock, *normalized)
+	}
+}
+
+func TestConvertBifrostMessagesToAnthropicMessagesScopesRepeatedToolIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	rawID := "functions.Bash:0"
+	firstMsgID := "fc_first"
+	secondMsgID := "fc_second"
+	toolName := "Bash"
+	arguments := "{}"
+	output := "ok"
+	msgTypeFunctionCall := schemas.ResponsesMessageTypeFunctionCall
+	msgTypeFunctionCallOutput := schemas.ResponsesMessageTypeFunctionCallOutput
+
+	messages := []schemas.ResponsesMessage{
+		{
+			ID:   &firstMsgID,
+			Type: &msgTypeFunctionCall,
+			ResponsesToolMessage: &schemas.ResponsesToolMessage{
+				CallID:    &rawID,
+				Name:      &toolName,
+				Arguments: &arguments,
+			},
+		},
+		{
+			Type: &msgTypeFunctionCallOutput,
+			ResponsesToolMessage: &schemas.ResponsesToolMessage{
+				CallID: &rawID,
+				Output: &schemas.ResponsesToolMessageOutputStruct{
+					ResponsesToolCallOutputStr: &output,
+				},
+			},
+		},
+		{
+			ID:   &secondMsgID,
+			Type: &msgTypeFunctionCall,
+			ResponsesToolMessage: &schemas.ResponsesToolMessage{
+				CallID:    &rawID,
+				Name:      &toolName,
+				Arguments: &arguments,
+			},
+		},
+		{
+			Type: &msgTypeFunctionCallOutput,
+			ResponsesToolMessage: &schemas.ResponsesToolMessage{
+				CallID: &rawID,
+				Output: &schemas.ResponsesToolMessageOutputStruct{
+					ResponsesToolCallOutputStr: &output,
+				},
+			},
+		},
+	}
+
+	anthropicMessages, _ := ConvertBifrostMessagesToAnthropicMessages(ctx, messages, true)
+
+	var toolUseIDs []string
+	var toolResultIDs []string
+	for _, msg := range anthropicMessages {
+		for _, block := range msg.Content.ContentBlocks {
+			switch block.Type {
+			case AnthropicContentBlockTypeToolUse:
+				if block.ID != nil {
+					toolUseIDs = append(toolUseIDs, *block.ID)
+				}
+			case AnthropicContentBlockTypeToolResult:
+				if block.ToolUseID != nil {
+					toolResultIDs = append(toolResultIDs, *block.ToolUseID)
+				}
+			}
+		}
+	}
+
+	if len(toolUseIDs) != 2 {
+		t.Fatalf("tool use ids = %v, want 2 ids", toolUseIDs)
+	}
+	if len(toolResultIDs) != 2 {
+		t.Fatalf("tool result ids = %v, want 2 ids", toolResultIDs)
+	}
+	if toolUseIDs[0] == toolUseIDs[1] {
+		t.Fatalf("repeated call id normalized to duplicate Anthropic id %q", toolUseIDs[0])
+	}
+	for i, id := range toolUseIDs {
+		if !strings.HasPrefix(id, "toolu_") {
+			t.Fatalf("tool use id %d = %q, want toolu_ prefix", i, id)
+		}
+		if id == rawID {
+			t.Fatalf("tool use id %d = %q, want normalized id", i, id)
+		}
+		if toolResultIDs[i] != id {
+			t.Fatalf("tool result id %d = %q, want matching tool use id %q", i, toolResultIDs[i], id)
+		}
+	}
+}
+
+func TestOpenAIChatToolStreamFallbackToAnthropicClosesMultipleToolBlocks(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	state := schemas.AcquireChatToResponsesStreamState()
+	defer schemas.ReleaseChatToResponsesStreamState(state)
+
+	role := string(schemas.ChatMessageRoleAssistant)
+	firstToolCallID := "call_weather"
+	firstToolName := "get_weather"
+	secondToolCallID := "call_time"
+	secondToolName := "get_time"
+	finishReason := string(schemas.BifrostFinishReasonToolCalls)
+
+	chunks := []*schemas.BifrostChatResponse{
+		{
+			ID:    "chatcmpl-test",
+			Model: "test-model",
+			Choices: []schemas.BifrostResponseChoice{{
+				ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+					Delta: &schemas.ChatStreamResponseChoiceDelta{Role: &role},
+				},
+			}},
+		},
+		{
+			ID:    "chatcmpl-test",
+			Model: "test-model",
+			Choices: []schemas.BifrostResponseChoice{{
+				ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+					Delta: &schemas.ChatStreamResponseChoiceDelta{
+						ToolCalls: []schemas.ChatAssistantMessageToolCall{
+							{
+								Index: 0,
+								ID:    &firstToolCallID,
+								Function: schemas.ChatAssistantMessageToolCallFunction{
+									Name:      &firstToolName,
+									Arguments: `{"city":"Paris"}`,
+								},
+							},
+							{
+								Index: 1,
+								ID:    &secondToolCallID,
+								Function: schemas.ChatAssistantMessageToolCallFunction{
+									Name: &secondToolName,
+								},
+							},
+						},
+					},
+				},
+			}},
+		},
+		{
+			ID:    "chatcmpl-test",
+			Model: "test-model",
+			Choices: []schemas.BifrostResponseChoice{{
+				FinishReason: &finishReason,
+				ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+					Delta: &schemas.ChatStreamResponseChoiceDelta{},
+				},
+			}},
+		},
+	}
+
+	var events []*AnthropicStreamEvent
+	for _, chunk := range chunks {
+		for _, responseEvent := range chunk.ToBifrostResponsesStreamResponse(state) {
+			events = append(events, ToAnthropicResponsesStreamResponse(ctx, responseEvent)...)
+		}
+	}
+
+	started := map[int]string{}
+	stopped := map[int]bool{}
+	firstStopPosition := -1
+	secondStartPosition := -1
+	for i, event := range events {
+		switch event.Type {
+		case AnthropicStreamEventTypeContentBlockStart:
+			if event.ContentBlock != nil && event.ContentBlock.Type == AnthropicContentBlockTypeToolUse {
+				if event.Index == nil {
+					t.Fatal("tool_use content_block_start missing index")
+				}
+				if event.ContentBlock.ID == nil {
+					t.Fatal("tool_use content_block_start missing id")
+				}
+				started[*event.Index] = *event.ContentBlock.ID
+				if *event.Index == 1 {
+					secondStartPosition = i
+				}
+			}
+		case AnthropicStreamEventTypeContentBlockStop:
+			if event.Index != nil {
+				stopped[*event.Index] = true
+				if *event.Index == 0 {
+					firstStopPosition = i
+				}
+			}
+		}
+	}
+
+	if !strings.HasPrefix(started[0], "toolu_") || started[0] == firstToolCallID {
+		t.Fatalf("tool block 0 id = %q, want normalized toolu_ id", started[0])
+	}
+	if !strings.HasPrefix(started[1], "toolu_") || started[1] == secondToolCallID {
+		t.Fatalf("tool block 1 id = %q, want normalized toolu_ id", started[1])
+	}
+	if started[0] == started[1] {
+		t.Fatalf("normalized tool IDs must be distinct, got %q", started[0])
+	}
+	if !stopped[0] {
+		t.Fatal("expected first tool_use content_block_stop for index 0")
+	}
+	if !stopped[1] {
+		t.Fatal("expected second tool_use content_block_stop for index 1")
+	}
+	if firstStopPosition == -1 || secondStartPosition == -1 {
+		t.Fatalf("expected first stop and second start positions, got stop=%d start=%d", firstStopPosition, secondStartPosition)
+	}
+	if firstStopPosition > secondStartPosition {
+		t.Fatalf("first content_block_stop position = %d, want before second content_block_start position %d", firstStopPosition, secondStartPosition)
+	}
+}
+
+func TestToAnthropicResponsesStreamResponse_DelaysToolStopUntilAfterLateArgumentDeltas(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	toolCallID := "functions.Read:0"
+	toolName := "Read"
+	outputIndex := 0
+	emptyArgs := ""
+	firstArgs := `{"file_path": "/`
+	secondArgs := `Users/delm/config.json"}`
+
+	stream := []*schemas.BifrostResponsesStreamResponse{
+		{
+			Type:        schemas.ResponsesStreamResponseTypeOutputItemAdded,
+			OutputIndex: &outputIndex,
+			Item: &schemas.ResponsesMessage{
+				ID:   &toolCallID,
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    &toolCallID,
+					Name:      &toolName,
+					Arguments: &emptyArgs,
+				},
+			},
+		},
+		{
+			Type:        schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
+			OutputIndex: &outputIndex,
+			ItemID:      &toolCallID,
+			Arguments:   &emptyArgs,
+		},
+		{
+			Type:        schemas.ResponsesStreamResponseTypeOutputItemDone,
+			OutputIndex: &outputIndex,
+			Item: &schemas.ResponsesMessage{
+				ID:   &toolCallID,
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    &toolCallID,
+					Name:      &toolName,
+					Arguments: &emptyArgs,
+				},
+			},
+		},
+		{
+			Type:        schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
+			OutputIndex: &outputIndex,
+			ItemID:      &toolCallID,
+			Arguments:   &firstArgs,
+		},
+		{
+			Type:        schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
+			OutputIndex: &outputIndex,
+			ItemID:      &toolCallID,
+			Arguments:   &secondArgs,
+		},
+		{
+			Type: schemas.ResponsesStreamResponseTypeCompleted,
+			Response: &schemas.BifrostResponsesResponse{
+				StopReason: schemas.Ptr(string(schemas.BifrostFinishReasonStop)),
+			},
+		},
+	}
+
+	var events []*AnthropicStreamEvent
+	for _, responseEvent := range stream {
+		events = append(events, ToAnthropicResponsesStreamResponse(ctx, responseEvent)...)
+	}
+
+	var stopPosition = -1
+	var lastArgumentDeltaPosition = -1
+	var messageDelta *AnthropicStreamEvent
+	for i, event := range events {
+		switch event.Type {
+		case AnthropicStreamEventTypeContentBlockDelta:
+			if event.Index != nil && *event.Index == outputIndex &&
+				event.Delta != nil && event.Delta.Type == AnthropicStreamDeltaTypeInputJSON {
+				lastArgumentDeltaPosition = i
+			}
+		case AnthropicStreamEventTypeContentBlockStop:
+			if event.Index != nil && *event.Index == outputIndex {
+				stopPosition = i
+			}
+		case AnthropicStreamEventTypeMessageDelta:
+			messageDelta = event
+		}
+	}
+
+	if stopPosition == -1 {
+		t.Fatal("expected tool_use content_block_stop")
+	}
+	if lastArgumentDeltaPosition == -1 {
+		t.Fatal("expected input_json_delta events")
+	}
+	if stopPosition < lastArgumentDeltaPosition {
+		t.Fatalf("content_block_stop position = %d, want after last argument delta position %d", stopPosition, lastArgumentDeltaPosition)
+	}
+	if messageDelta == nil || messageDelta.Delta == nil || messageDelta.Delta.StopReason == nil {
+		t.Fatal("expected message_delta stop_reason")
+	}
+	if *messageDelta.Delta.StopReason != AnthropicStopReasonToolUse {
+		t.Fatalf("message_delta stop_reason = %q, want %q", *messageDelta.Delta.StopReason, AnthropicStopReasonToolUse)
+	}
+}
+
+func TestToAnthropicResponsesStreamResponse_ClosesTextBeforeStartingToolFromResponsesEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	textIndex := 0
+	toolIndex := 1
+	textItemID := "msg_item_0"
+	toolCallID := "functions.Bash:0"
+	toolName := "Bash"
+	text := "I'll inspect the repo."
+	toolArgs := `{"command":"ls -la","description":"List files"}`
+
+	stream := []*schemas.BifrostResponsesStreamResponse{
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputItemAdded,
+			OutputIndex:  &textIndex,
+			ContentIndex: &textIndex,
+			Item: &schemas.ResponsesMessage{
+				ID:   &textItemID,
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			},
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputTextDelta,
+			OutputIndex:  &textIndex,
+			ContentIndex: &textIndex,
+			ItemID:       &textItemID,
+			Delta:        &text,
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputTextDone,
+			OutputIndex:  &textIndex,
+			ContentIndex: &textIndex,
+			ItemID:       &textItemID,
+			Text:         &text,
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeContentPartDone,
+			OutputIndex:  &textIndex,
+			ContentIndex: &textIndex,
+			ItemID:       &textItemID,
+			Part: &schemas.ResponsesMessageContentBlock{
+				Type: schemas.ResponsesOutputMessageContentTypeText,
+				Text: &text,
+			},
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputItemAdded,
+			OutputIndex:  &toolIndex,
+			ContentIndex: &toolIndex,
+			Item: &schemas.ResponsesMessage{
+				ID:   &toolCallID,
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    &toolCallID,
+					Name:      &toolName,
+					Arguments: schemas.Ptr(""),
+				},
+			},
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
+			OutputIndex:  &toolIndex,
+			ContentIndex: &toolIndex,
+			ItemID:       &toolCallID,
+			Arguments:    &toolArgs,
+		},
+		{
+			Type: schemas.ResponsesStreamResponseTypeCompleted,
+			Response: &schemas.BifrostResponsesResponse{
+				StopReason: schemas.Ptr(string(schemas.BifrostFinishReasonToolCalls)),
+			},
+		},
+	}
+
+	var events []*AnthropicStreamEvent
+	for _, responseEvent := range stream {
+		events = append(events, ToAnthropicResponsesStreamResponse(ctx, responseEvent)...)
+	}
+
+	assertAnthropicStreamBlocksDoNotOverlap(t, events)
+
+	textStopPosition := eventPosition(events, AnthropicStreamEventTypeContentBlockStop, textIndex)
+	toolStartPosition := eventPosition(events, AnthropicStreamEventTypeContentBlockStart, toolIndex)
+	if textStopPosition == -1 {
+		t.Fatal("expected text content_block_stop before tool start")
+	}
+	if toolStartPosition == -1 {
+		t.Fatal("expected tool content_block_start")
+	}
+	if textStopPosition > toolStartPosition {
+		t.Fatalf("text content_block_stop position = %d, want before tool content_block_start position %d", textStopPosition, toolStartPosition)
+	}
+	if countEvents(events, AnthropicStreamEventTypeContentBlockStop, textIndex) != 1 {
+		t.Fatalf("text content block should stop exactly once, got %d stops", countEvents(events, AnthropicStreamEventTypeContentBlockStop, textIndex))
+	}
+}
+
+func TestToAnthropicResponsesStreamResponse_NormalizesRepeatedProviderToolIDsPerMessage(t *testing.T) {
+	t.Parallel()
+
+	firstToolID := streamedToolUseIDForMessage(t, "resp_first", "functions.Bash:0", 0)
+	secondToolID := streamedToolUseIDForMessage(t, "resp_second", "functions.Bash:0", 0)
+
+	if firstToolID == "functions.Bash:0" || secondToolID == "functions.Bash:0" {
+		t.Fatalf("tool IDs should be Anthropic-safe, got first=%q second=%q", firstToolID, secondToolID)
+	}
+	if !strings.HasPrefix(firstToolID, "toolu_") || !strings.HasPrefix(secondToolID, "toolu_") {
+		t.Fatalf("tool IDs should use toolu_ prefix, got first=%q second=%q", firstToolID, secondToolID)
+	}
+	if firstToolID == secondToolID {
+		t.Fatalf("repeated provider tool IDs should normalize differently per message, got %q", firstToolID)
+	}
+}
+
+func streamedToolUseIDForMessage(t *testing.T, messageID string, rawToolID string, outputIndex int) string {
+	t.Helper()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	toolName := "Bash"
+	stream := []*schemas.BifrostResponsesStreamResponse{
+		{
+			Type: schemas.ResponsesStreamResponseTypeCreated,
+			Response: &schemas.BifrostResponsesResponse{
+				ID: &messageID,
+			},
+		},
+		{
+			Type:         schemas.ResponsesStreamResponseTypeOutputItemAdded,
+			OutputIndex:  &outputIndex,
+			ContentIndex: &outputIndex,
+			Item: &schemas.ResponsesMessage{
+				ID:   &rawToolID,
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    &rawToolID,
+					Name:      &toolName,
+					Arguments: schemas.Ptr(""),
+				},
+			},
+		},
+	}
+
+	var events []*AnthropicStreamEvent
+	for _, responseEvent := range stream {
+		events = append(events, ToAnthropicResponsesStreamResponse(ctx, responseEvent)...)
+	}
+
+	for _, event := range events {
+		if event.Type == AnthropicStreamEventTypeContentBlockStart &&
+			event.ContentBlock != nil &&
+			event.ContentBlock.Type == AnthropicContentBlockTypeToolUse &&
+			event.ContentBlock.ID != nil {
+			return *event.ContentBlock.ID
+		}
+	}
+
+	t.Fatal("expected tool_use content_block_start")
+	return ""
+}
+
+func assertAnthropicStreamBlocksDoNotOverlap(t *testing.T, events []*AnthropicStreamEvent) {
+	t.Helper()
+
+	var openIndex *int
+	for position, event := range events {
+		switch event.Type {
+		case AnthropicStreamEventTypeContentBlockStart:
+			if event.Index == nil {
+				t.Fatalf("content_block_start at position %d missing index", position)
+			}
+			if openIndex != nil {
+				t.Fatalf("content_block_start index %d at position %d before content_block_stop for index %d", *event.Index, position, *openIndex)
+			}
+			index := *event.Index
+			openIndex = &index
+		case AnthropicStreamEventTypeContentBlockStop:
+			if event.Index == nil {
+				t.Fatalf("content_block_stop at position %d missing index", position)
+			}
+			if openIndex == nil {
+				t.Fatalf("content_block_stop index %d at position %d without open content block", *event.Index, position)
+			}
+			if *event.Index != *openIndex {
+				t.Fatalf("content_block_stop index %d at position %d while index %d is open", *event.Index, position, *openIndex)
+			}
+			openIndex = nil
+		}
+	}
+	if openIndex != nil {
+		t.Fatalf("content block index %d was not stopped", *openIndex)
+	}
+}
+
+func eventPosition(events []*AnthropicStreamEvent, eventType AnthropicStreamEventType, index int) int {
+	for i, event := range events {
+		if event.Type == eventType && event.Index != nil && *event.Index == index {
+			return i
+		}
+	}
+	return -1
+}
+
+func countEvents(events []*AnthropicStreamEvent, eventType AnthropicStreamEventType, index int) int {
+	count := 0
+	for _, event := range events {
+		if event.Type == eventType && event.Index != nil && *event.Index == index {
+			count++
+		}
+	}
+	return count
+}

--- a/core/providers/anthropic/responsesstream_test.go
+++ b/core/providers/anthropic/responsesstream_test.go
@@ -517,6 +517,136 @@ func TestToAnthropicResponsesStreamResponse_DelaysToolStopUntilAfterLateArgument
 	}
 }
 
+func TestToAnthropicResponsesStreamResponse_BuffersInterleavedToolArgumentDeltasByOutputIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	firstToolCallID := "functions.Read:0"
+	firstToolName := "Read"
+	secondToolCallID := "functions.Bash:1"
+	secondToolName := "Bash"
+	firstIndex := 0
+	secondIndex := 1
+	emptyArgs := ""
+	firstArgsPartOne := `{"file_path":"/`
+	firstArgsPartTwo := `tmp/config.json"}`
+	secondArgs := `{"command":"pwd"}`
+	firstArgsFull := firstArgsPartOne + firstArgsPartTwo
+
+	stream := []*schemas.BifrostResponsesStreamResponse{
+		{
+			Type:        schemas.ResponsesStreamResponseTypeOutputItemAdded,
+			OutputIndex: &firstIndex,
+			Item: &schemas.ResponsesMessage{
+				ID:   &firstToolCallID,
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    &firstToolCallID,
+					Name:      &firstToolName,
+					Arguments: &emptyArgs,
+				},
+			},
+		},
+		{
+			Type:        schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
+			OutputIndex: &firstIndex,
+			ItemID:      &firstToolCallID,
+			Arguments:   &firstArgsPartOne,
+		},
+		{
+			Type:        schemas.ResponsesStreamResponseTypeOutputItemAdded,
+			OutputIndex: &secondIndex,
+			Item: &schemas.ResponsesMessage{
+				ID:   &secondToolCallID,
+				Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+				ResponsesToolMessage: &schemas.ResponsesToolMessage{
+					CallID:    &secondToolCallID,
+					Name:      &secondToolName,
+					Arguments: &emptyArgs,
+				},
+			},
+		},
+		{
+			Type:        schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
+			OutputIndex: &secondIndex,
+			ItemID:      &secondToolCallID,
+			Arguments:   &secondArgs,
+		},
+		{
+			Type:        schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
+			OutputIndex: &firstIndex,
+			ItemID:      &firstToolCallID,
+			Arguments:   &firstArgsPartTwo,
+		},
+		{
+			Type:        schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDone,
+			OutputIndex: &firstIndex,
+			ItemID:      &firstToolCallID,
+			Arguments:   &firstArgsFull,
+		},
+		{
+			Type:        schemas.ResponsesStreamResponseTypeFunctionCallArgumentsDone,
+			OutputIndex: &secondIndex,
+			ItemID:      &secondToolCallID,
+			Arguments:   &secondArgs,
+		},
+		{
+			Type: schemas.ResponsesStreamResponseTypeCompleted,
+			Response: &schemas.BifrostResponsesResponse{
+				StopReason: schemas.Ptr(string(schemas.BifrostFinishReasonToolCalls)),
+			},
+		},
+	}
+
+	var events []*AnthropicStreamEvent
+	for _, responseEvent := range stream {
+		events = append(events, ToAnthropicResponsesStreamResponse(ctx, responseEvent)...)
+	}
+
+	assertAnthropicStreamBlocksDoNotOverlap(t, events)
+
+	firstStopPosition := eventPosition(events, AnthropicStreamEventTypeContentBlockStop, firstIndex)
+	secondStartPosition := eventPosition(events, AnthropicStreamEventTypeContentBlockStart, secondIndex)
+	if firstStopPosition == -1 {
+		t.Fatal("expected first tool content_block_stop")
+	}
+	if secondStartPosition == -1 {
+		t.Fatal("expected second tool content_block_start")
+	}
+	if secondStartPosition < firstStopPosition {
+		t.Fatalf("second tool start position = %d, want after first tool stop position %d", secondStartPosition, firstStopPosition)
+	}
+
+	accumulated := map[int]string{}
+	lastDeltaPosition := map[int]int{}
+	for i, event := range events {
+		if event.Type != AnthropicStreamEventTypeContentBlockDelta ||
+			event.Index == nil ||
+			event.Delta == nil ||
+			event.Delta.Type != AnthropicStreamDeltaTypeInputJSON ||
+			event.Delta.PartialJSON == nil {
+			continue
+		}
+		accumulated[*event.Index] += *event.Delta.PartialJSON
+		lastDeltaPosition[*event.Index] = i
+	}
+
+	if accumulated[firstIndex] != firstArgsFull {
+		t.Fatalf("first tool arguments = %q, want %q", accumulated[firstIndex], firstArgsFull)
+	}
+	if accumulated[secondIndex] != secondArgs {
+		t.Fatalf("second tool arguments = %q, want %q", accumulated[secondIndex], secondArgs)
+	}
+	if lastDeltaPosition[firstIndex] > firstStopPosition {
+		t.Fatalf("first tool last delta position = %d, want before stop position %d", lastDeltaPosition[firstIndex], firstStopPosition)
+	}
+	if lastDeltaPosition[secondIndex] < secondStartPosition {
+		t.Fatalf("second tool first delta position = %d, want after start position %d", lastDeltaPosition[secondIndex], secondStartPosition)
+	}
+}
+
 func TestToAnthropicResponsesStreamResponse_ClosesTextBeforeStartingToolFromResponsesEvents(t *testing.T) {
 	t.Parallel()
 

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -1480,7 +1480,7 @@ type AnthropicStreamDelta struct {
 	Signature    *string                  `json:"signature,omitempty"`
 	Citation     *AnthropicTextCitation   `json:"citation,omitempty"`    // For citations_delta
 	StopReason   *AnthropicStopReason     `json:"stop_reason,omitempty"` // only not present in "message_start" events
-	StopSequence *string                  `json:"stop_sequence"`
+	StopSequence *string                  `json:"stop_sequence,omitempty"`
 }
 
 // ==================== MODEL TYPES ====================

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -1578,165 +1578,170 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 
 	if len(delta.ToolCalls) > 0 {
 		// Tool call delta - handle function call arguments
-		toolCall := delta.ToolCalls[0] // Take first tool call
-		contentIndex := 1              // Tool calls use content_index:1
-
-		// Determine tool call ID: use ID if present, otherwise look up by index
-		var toolCallID string
-		if toolCall.ID != nil && *toolCall.ID != "" {
-			toolCallID = *toolCall.ID
-		} else {
-			// Look up ID by index for subsequent chunks that don't include the ID
-			if id, exists := state.ToolCallIndexToID[toolCall.Index]; exists {
-				toolCallID = id
+		for _, toolCall := range delta.ToolCalls {
+			// Determine tool call ID: use ID if present, otherwise look up by index
+			var toolCallID string
+			if toolCall.ID != nil && *toolCall.ID != "" {
+				toolCallID = *toolCall.ID
 			} else {
-				// No ID and no mapping found - skip this chunk
-				// This can happen if the stream is malformed or out of order
-				return responses
+				// Look up ID by index for subsequent chunks that don't include the ID
+				if id, exists := state.ToolCallIndexToID[toolCall.Index]; exists {
+					toolCallID = id
+				} else {
+					// No ID and no mapping found - skip this tool call
+					// This can happen if the stream is malformed or out of order
+					continue
+				}
 			}
-		}
 
-		// Check if this is a new tool call (only when ID is present)
-		if toolCall.ID != nil && *toolCall.ID != "" {
-			if _, exists := state.ToolCallOutputIndices[toolCallID]; !exists {
-				// Close text item if still open and has content
-				if state.TextItemAdded && !state.TextItemClosed && state.TextItemHasContent {
-					outputIndex := 0
-					itemID := state.ItemIDs["text"]
+			// Check if this is a new tool call (only when ID is present)
+			if toolCall.ID != nil && *toolCall.ID != "" {
+				if _, exists := state.ToolCallOutputIndices[toolCallID]; !exists {
+					// Close text item if still open and has content
+					if state.TextItemAdded && !state.TextItemClosed && state.TextItemHasContent {
+						outputIndex := 0
+						itemID := state.ItemIDs["text"]
 
-					finalText := state.TextBuffer.String()
-					responses = append(responses, &BifrostResponsesStreamResponse{
-						Type:           ResponsesStreamResponseTypeOutputTextDone,
-						SequenceNumber: state.SequenceNumber,
-						OutputIndex:    Ptr(outputIndex),
-						ContentIndex:   Ptr(0),
-						ItemID:         &itemID,
-						Text:           &finalText,
-						LogProbs:       []ResponsesOutputMessageContentTextLogProb{},
-						ExtraFields:    cr.ExtraFields,
-					})
-					state.SequenceNumber++
+						finalText := state.TextBuffer.String()
+						responses = append(responses, &BifrostResponsesStreamResponse{
+							Type:           ResponsesStreamResponseTypeOutputTextDone,
+							SequenceNumber: state.SequenceNumber,
+							OutputIndex:    Ptr(outputIndex),
+							ContentIndex:   Ptr(0),
+							ItemID:         &itemID,
+							Text:           &finalText,
+							LogProbs:       []ResponsesOutputMessageContentTextLogProb{},
+							ExtraFields:    cr.ExtraFields,
+						})
+						state.SequenceNumber++
 
-					// Emit content_part.done
-					part := &ResponsesMessageContentBlock{
-						Type: ResponsesOutputMessageContentTypeText,
-						Text: &finalText,
-						ResponsesOutputMessageContentText: &ResponsesOutputMessageContentText{
-							LogProbs:    []ResponsesOutputMessageContentTextLogProb{},
-							Annotations: []ResponsesOutputMessageContentTextAnnotation{},
-						},
-					}
-					responses = append(responses, &BifrostResponsesStreamResponse{
-						Type:           ResponsesStreamResponseTypeContentPartDone,
-						SequenceNumber: state.SequenceNumber,
-						OutputIndex:    Ptr(outputIndex),
-						ContentIndex:   Ptr(0),
-						ItemID:         &itemID,
-						Part:           part,
-						ExtraFields:    cr.ExtraFields,
-					})
-					state.SequenceNumber++
+						// Emit content_part.done
+						part := &ResponsesMessageContentBlock{
+							Type: ResponsesOutputMessageContentTypeText,
+							Text: &finalText,
+							ResponsesOutputMessageContentText: &ResponsesOutputMessageContentText{
+								LogProbs:    []ResponsesOutputMessageContentTextLogProb{},
+								Annotations: []ResponsesOutputMessageContentTextAnnotation{},
+							},
+						}
+						responses = append(responses, &BifrostResponsesStreamResponse{
+							Type:           ResponsesStreamResponseTypeContentPartDone,
+							SequenceNumber: state.SequenceNumber,
+							OutputIndex:    Ptr(outputIndex),
+							ContentIndex:   Ptr(0),
+							ItemID:         &itemID,
+							Part:           part,
+							ExtraFields:    cr.ExtraFields,
+						})
+						state.SequenceNumber++
 
-					// Emit output_item.done
-					statusCompleted := "completed"
-					messageType := ResponsesMessageTypeMessage
-					role := ResponsesInputMessageRoleAssistant
-					textType := ResponsesOutputMessageContentTypeText
-					doneItem := &ResponsesMessage{
-						Type:   &messageType,
-						Role:   &role,
-						Status: &statusCompleted,
-						Content: &ResponsesMessageContent{
-							ContentBlocks: []ResponsesMessageContentBlock{
-								{
-									Type: textType,
-									Text: &finalText,
-									ResponsesOutputMessageContentText: &ResponsesOutputMessageContentText{
-										LogProbs:    []ResponsesOutputMessageContentTextLogProb{},
-										Annotations: []ResponsesOutputMessageContentTextAnnotation{},
+						// Emit output_item.done
+						statusCompleted := "completed"
+						messageType := ResponsesMessageTypeMessage
+						role := ResponsesInputMessageRoleAssistant
+						textType := ResponsesOutputMessageContentTypeText
+						doneItem := &ResponsesMessage{
+							Type:   &messageType,
+							Role:   &role,
+							Status: &statusCompleted,
+							Content: &ResponsesMessageContent{
+								ContentBlocks: []ResponsesMessageContentBlock{
+									{
+										Type: textType,
+										Text: &finalText,
+										ResponsesOutputMessageContentText: &ResponsesOutputMessageContentText{
+											LogProbs:    []ResponsesOutputMessageContentTextLogProb{},
+											Annotations: []ResponsesOutputMessageContentTextAnnotation{},
+										},
 									},
 								},
 							},
+						}
+						if itemID != "" {
+							doneItem.ID = &itemID
+						}
+						responses = append(responses, &BifrostResponsesStreamResponse{
+							Type:           ResponsesStreamResponseTypeOutputItemDone,
+							SequenceNumber: state.SequenceNumber,
+							OutputIndex:    Ptr(outputIndex),
+							ContentIndex:   Ptr(0),
+							Item:           doneItem,
+							ExtraFields:    cr.ExtraFields,
+						})
+						state.SequenceNumber++
+						state.TextItemClosed = true
+					}
+
+					// Assign new output index for tool call
+					outputIndex := state.CurrentOutputIndex
+					if outputIndex == 0 && state.TextItemAdded {
+						outputIndex = 1 // Skip 0 only when a text block already owns it
+					}
+					state.CurrentOutputIndex = outputIndex + 1
+					state.ToolCallOutputIndices[toolCallID] = outputIndex
+
+					// Store tool call info and index mapping
+					state.ItemIDs[toolCallID] = toolCallID
+					state.ToolCallIndexToID[toolCall.Index] = toolCallID
+					if toolCall.Function.Name != nil {
+						state.ToolCallNames[toolCallID] = *toolCall.Function.Name
+					}
+
+					// Initialize argument buffer
+					state.ToolArgumentBuffers[toolCallID] = ""
+
+					// Emit output_item.added for function call
+					statusInProgress := "in_progress"
+					item := &ResponsesMessage{
+						ID:     &toolCallID,
+						Type:   Ptr(ResponsesMessageTypeFunctionCall),
+						Status: &statusInProgress,
+						ResponsesToolMessage: &ResponsesToolMessage{
+							CallID:    &toolCallID,
+							Name:      toolCall.Function.Name,
+							Arguments: Ptr(""), // Arguments will be filled by deltas
 						},
 					}
-					if itemID != "" {
-						doneItem.ID = &itemID
-					}
+
 					responses = append(responses, &BifrostResponsesStreamResponse{
-						Type:           ResponsesStreamResponseTypeOutputItemDone,
+						Type:           ResponsesStreamResponseTypeOutputItemAdded,
 						SequenceNumber: state.SequenceNumber,
 						OutputIndex:    Ptr(outputIndex),
-						ContentIndex:   Ptr(0),
-						Item:           doneItem,
+						ContentIndex:   Ptr(outputIndex),
+						Item:           item,
 						ExtraFields:    cr.ExtraFields,
 					})
 					state.SequenceNumber++
-					state.TextItemClosed = true
 				}
+			}
+			if toolCall.Function.Name != nil && *toolCall.Function.Name != "" {
+				state.ToolCallNames[toolCallID] = *toolCall.Function.Name
+			}
 
-				// Assign new output index for tool call
-				outputIndex := state.CurrentOutputIndex
-				if outputIndex == 0 {
-					outputIndex = 1 // Skip 0 if text is using it
+			// Accumulate and emit function call arguments delta
+			// This works for both chunks with ID and chunks without ID (using looked-up ID)
+			if toolCall.Function.Arguments != "" {
+				outputIndex, exists := state.ToolCallOutputIndices[toolCallID]
+				if !exists {
+					continue
 				}
-				state.CurrentOutputIndex = outputIndex + 1
-				state.ToolCallOutputIndices[toolCallID] = outputIndex
+				state.ToolArgumentBuffers[toolCallID] += toolCall.Function.Arguments
 
-				// Store tool call info and index mapping
-				state.ItemIDs[toolCallID] = toolCallID
-				state.ToolCallIndexToID[toolCall.Index] = toolCallID
-				if toolCall.Function.Name != nil {
-					state.ToolCallNames[toolCallID] = *toolCall.Function.Name
-				}
-
-				// Initialize argument buffer
-				state.ToolArgumentBuffers[toolCallID] = ""
-
-				// Emit output_item.added for function call
-				statusInProgress := "in_progress"
-				item := &ResponsesMessage{
-					ID:     &toolCallID,
-					Type:   Ptr(ResponsesMessageTypeFunctionCall),
-					Status: &statusInProgress,
-					ResponsesToolMessage: &ResponsesToolMessage{
-						CallID:    &toolCallID,
-						Name:      toolCall.Function.Name,
-						Arguments: Ptr(""), // Arguments will be filled by deltas
-					},
-				}
-
-				responses = append(responses, &BifrostResponsesStreamResponse{
-					Type:           ResponsesStreamResponseTypeOutputItemAdded,
+				itemID := state.ItemIDs[toolCallID]
+				response := &BifrostResponsesStreamResponse{
+					Type:           ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
 					SequenceNumber: state.SequenceNumber,
 					OutputIndex:    Ptr(outputIndex),
-					ContentIndex:   Ptr(contentIndex),
-					Item:           item,
+					ContentIndex:   Ptr(outputIndex),
+					Delta:          &toolCall.Function.Arguments,
 					ExtraFields:    cr.ExtraFields,
-				})
+				}
+				if itemID != "" {
+					response.ItemID = &itemID
+				}
+				responses = append(responses, response)
 				state.SequenceNumber++
 			}
-		}
-
-		// Accumulate and emit function call arguments delta
-		// This works for both chunks with ID and chunks without ID (using looked-up ID)
-		if toolCall.Function.Arguments != "" {
-			outputIndex := state.ToolCallOutputIndices[toolCallID]
-			state.ToolArgumentBuffers[toolCallID] += toolCall.Function.Arguments
-
-			itemID := state.ItemIDs[toolCallID]
-			response := &BifrostResponsesStreamResponse{
-				Type:           ResponsesStreamResponseTypeFunctionCallArgumentsDelta,
-				SequenceNumber: state.SequenceNumber,
-				OutputIndex:    Ptr(outputIndex),
-				ContentIndex:   Ptr(contentIndex),
-				Delta:          &toolCall.Function.Arguments,
-				ExtraFields:    cr.ExtraFields,
-			}
-			if itemID != "" {
-				response.ItemID = &itemID
-			}
-			responses = append(responses, response)
-			state.SequenceNumber++
 		}
 	}
 
@@ -1846,58 +1851,70 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 		}
 
 		// Close any open tool call items and emit function_call_arguments.done
-		for toolCallID, args := range state.ToolArgumentBuffers {
-			if args != "" {
-				outputIndex := state.ToolCallOutputIndices[toolCallID]
-				itemID := state.ItemIDs[toolCallID]
-				contentIndex := 1 // Tool calls use content_index:1
-				argsCopy := args
-				// Emit function_call_arguments.done with full arguments (no item field, just item_id and arguments)
-				response := &BifrostResponsesStreamResponse{
-					Type:           ResponsesStreamResponseTypeFunctionCallArgumentsDone,
-					SequenceNumber: state.SequenceNumber,
-					OutputIndex:    Ptr(outputIndex),
-					ContentIndex:   Ptr(contentIndex),
-					Arguments:      &argsCopy,
-					ExtraFields:    cr.ExtraFields,
-				}
-				if itemID != "" {
-					response.ItemID = &itemID
-				}
-				responses = append(responses, response)
-				state.SequenceNumber++
-
-				// Emit output_item.done for function call
-				statusFinal := terminalStatus
-				messageType := ResponsesMessageTypeFunctionCall
-				callName, hasName := state.ToolCallNames[toolCallID]
-				var callNamePtr *string
-				if hasName && callName != "" {
-					callNamePtr = &callName
-				}
-				argsValue := args
-				outputItemDone := &ResponsesMessage{
-					Type:   &messageType,
-					Status: &statusFinal,
-					ResponsesToolMessage: &ResponsesToolMessage{
-						CallID:    &toolCallID,
-						Name:      callNamePtr,
-						Arguments: &argsValue,
-					},
-				}
-				if itemID != "" {
-					outputItemDone.ID = &itemID
-				}
-				responses = append(responses, &BifrostResponsesStreamResponse{
-					Type:           ResponsesStreamResponseTypeOutputItemDone,
-					SequenceNumber: state.SequenceNumber,
-					OutputIndex:    Ptr(outputIndex),
-					ContentIndex:   Ptr(contentIndex),
-					Item:           outputItemDone,
-					ExtraFields:    cr.ExtraFields,
-				})
-				state.SequenceNumber++
+		type pendingToolCallEntry struct {
+			toolCallID  string
+			outputIndex int
+		}
+		var pendingToolCallEntries []pendingToolCallEntry
+		for toolCallID, outputIndex := range state.ToolCallOutputIndices {
+			if _, exists := state.ToolArgumentBuffers[toolCallID]; exists {
+				pendingToolCallEntries = append(pendingToolCallEntries, pendingToolCallEntry{toolCallID: toolCallID, outputIndex: outputIndex})
 			}
+		}
+		sort.Slice(pendingToolCallEntries, func(i, j int) bool {
+			return pendingToolCallEntries[i].outputIndex < pendingToolCallEntries[j].outputIndex
+		})
+		for _, entry := range pendingToolCallEntries {
+			toolCallID := entry.toolCallID
+			args := state.ToolArgumentBuffers[toolCallID]
+			outputIndex := entry.outputIndex
+			itemID := state.ItemIDs[toolCallID]
+			argsCopy := args
+			// Emit function_call_arguments.done with full arguments (no item field, just item_id and arguments)
+			response := &BifrostResponsesStreamResponse{
+				Type:           ResponsesStreamResponseTypeFunctionCallArgumentsDone,
+				SequenceNumber: state.SequenceNumber,
+				OutputIndex:    Ptr(outputIndex),
+				ContentIndex:   Ptr(outputIndex),
+				Arguments:      &argsCopy,
+				ExtraFields:    cr.ExtraFields,
+			}
+			if itemID != "" {
+				response.ItemID = &itemID
+			}
+			responses = append(responses, response)
+			state.SequenceNumber++
+
+			// Emit output_item.done for function call
+			statusFinal := terminalStatus
+			messageType := ResponsesMessageTypeFunctionCall
+			callName, hasName := state.ToolCallNames[toolCallID]
+			var callNamePtr *string
+			if hasName && callName != "" {
+				callNamePtr = &callName
+			}
+			argsValue := args
+			outputItemDone := &ResponsesMessage{
+				Type:   &messageType,
+				Status: &statusFinal,
+				ResponsesToolMessage: &ResponsesToolMessage{
+					CallID:    &toolCallID,
+					Name:      callNamePtr,
+					Arguments: &argsValue,
+				},
+			}
+			if itemID != "" {
+				outputItemDone.ID = &itemID
+			}
+			responses = append(responses, &BifrostResponsesStreamResponse{
+				Type:           ResponsesStreamResponseTypeOutputItemDone,
+				SequenceNumber: state.SequenceNumber,
+				OutputIndex:    Ptr(outputIndex),
+				ContentIndex:   Ptr(outputIndex),
+				Item:           outputItemDone,
+				ExtraFields:    cr.ExtraFields,
+			})
+			state.SequenceNumber++
 		}
 
 		// Emit terminal response event.
@@ -1914,6 +1931,10 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			Usage:             usage,
 			Status:            &responseStatus,
 			IncompleteDetails: terminalIncompleteDetails,
+		}
+
+		if choice.FinishReason != nil && *choice.FinishReason != "" {
+			response.StopReason = choice.FinishReason
 		}
 
 		if state.Model != nil {


### PR DESCRIPTION
## Summary

Fixes several Anthropic-compatible streaming response translation issues when requests to `/anthropic/v1/messages` are routed to OpenAI-compatible providers. The changes make streamed tool calls emit valid Anthropic SSE sequences by preventing overlapping content blocks, preserving tool-call stop reasons, closing tool blocks after their streamed arguments, and normalizing provider-specific tool IDs.

## Steps to Reproduce

1. Start Bifrost
2. Configure an OpenAI compatible provider that supports OSS models such as Kimi K2.6, e.g., Baseten
3. Configure a routing rule to send requests to that provider (e.g., `model == 'moonshotai/Kimi-K2.6'`)
4. Use Bifrost with Claude Code (you may also need to set the API key if you're not logged in):
```bash
ANTHROPIC_BASE_URL=http://localhost:8080/anthropic ANTHROPIC_MODEL="moonshotai/Kimi-K2.6" ANTHROPIC_SMALL_FAST_MODEL="moonshotai/Kimi-K2.6" claude
```
5. Send a message that triggers tool calls, e.g., `Explore this code base in depth`

## Changes

- Fixed chat-completions-to-responses stream conversion to process all streamed OpenAI tool calls, not only the first one.
- Ensured tool-only streams start at Anthropic content block index `0`, while mixed text + tool streams reserve index `0` for text and place tools after it.
- Ensured every started tool call emits a matching done event, including zero-argument tool calls.
- Preserved `finish_reason: "tool_calls"` through the internal Responses stream event so the Anthropic response emits `stop_reason: "tool_use"`.
- Updated Anthropic stream rendering so tool-call `content_block_stop` uses the same output index as the corresponding start and delta events.
- Normalized OpenAI-compatible tool call IDs into Anthropic-safe `toolu_...` IDs while preserving native Anthropic IDs.
- Added stream-state tracking so Anthropic content blocks are emitted as non-overlapping `content_block_start` → deltas → `content_block_stop` sequences.
- Closed text/reasoning blocks from Responses stream completion events before starting subsequent tool blocks, while avoiding duplicate stop events when `output_item.done` arrives later.
- Scoped generated stream `toolu_...` IDs by assistant message/output index so providers that reuse raw IDs like `functions.Bash:0` do not produce repeated Anthropic tool-use IDs across turns.
- Omitted `stop_sequence` from content deltas when nil to better match Anthropic streaming payloads.
- Added regression tests covering single tool calls, streamed tool JSON, multiple tool calls, zero-argument tools, ID normalization, per-message stream tool IDs, block closure, non-overlapping text/tool block ordering, and final Anthropic stop reason.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the focused regression tests:

```sh
go test github.com/maximhq/bifrost/core/providers/anthropic -run 'Test(NormalizeAnthropicToolUseID|OpenAIChatToolStreamFallbackToAnthropicCloses(ToolBlock|MultipleToolBlocks)|ToAnthropicResponsesStreamResponse_(DelaysToolStopUntilAfterLateArgumentDeltas|ClosesTextBeforeStartingToolFromResponsesEvents|NormalizesRepeatedProviderToolIDsPerMessage))' -count=1
```

Expected outcome: tests pass.

Run the Anthropic provider unit tests:

```sh
go test github.com/maximhq/bifrost/core/providers/anthropic -count=1
```

Current local note: this package-level command currently fails on an unrelated existing panic in `TestToAnthropicChatRequest_ServerTools` where the test calls `ToAnthropicChatRequest(nil, ...)`. The focused stream regression suite above passes.

Run the affected schema conversion tests:

```sh
go test ./core/schemas -count=1
```

Expected outcome: tests pass.

Run the Anthropic provider test harness:

```sh
make test-core PROVIDER=anthropic
```

Expected outcome: Anthropic provider tests run through the standard core provider test harness.

Manual validation note:

- A captured Claude Code request with repeated `Read` calls showed each repeated tool call had a fresh Anthropic `toolu_...` ID and a matching `tool_result`.

No new configs or environment variables were added.

## Screenshots/Recordings

N/A. No UI changes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No new security implications. This change only adjusts streaming response translation and adds regression coverage; it does not affect auth, secrets, PII handling, sandboxing, or permission boundaries.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable