### PR TITLE
fix: propagate errors from Gemini tool parameter conversion and use `ParametersJSONSchema` instead of `Parameters`

### DIFF
--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -31,7 +31,10 @@ func ToGeminiChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*Gem
 		}
 		// Handle tool-related parameters
 		if len(bifrostReq.Params.Tools) > 0 {
-			geminiReq.Tools = convertBifrostToolsToGemini(bifrostReq.Params.Tools)
+			geminiReq.Tools, err = convertBifrostToolsToGemini(bifrostReq.Params.Tools)
+			if err != nil {
+				return nil, err
+			}
 
 			// Convert tool choice to tool config
 			if bifrostReq.Params.ToolChoice != nil {

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -93,7 +93,10 @@ func ToGeminiResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*Gem
 		geminiReq.ExtraParams = bifrostReq.Params.ExtraParams
 		// Handle tool-related parameters
 		if len(bifrostReq.Params.Tools) > 0 {
-			geminiReq.Tools = convertResponsesToolsToGemini(bifrostReq.Params.Tools)
+			geminiReq.Tools, err = convertResponsesToolsToGemini(bifrostReq.Params.Tools)
+			if err != nil {
+				return nil, err
+			}
 
 			// Convert tool choice if present
 			if bifrostReq.Params.ToolChoice != nil {
@@ -2191,6 +2194,16 @@ func convertGeminiToolsToResponsesTools(tools []Tool) []schemas.ResponsesTool {
 				if fn.Parameters != nil {
 					params := convertSchemaToFunctionParameters(fn.Parameters)
 					responsesTool.ResponsesToolFunction.Parameters = &params
+				} else if fn.ParametersJSONSchema != nil {
+					raw, err := providerUtils.MarshalSorted(fn.ParametersJSONSchema)
+					if err != nil {
+						continue
+					}
+					var params schemas.ToolFunctionParameters
+					if err := json.Unmarshal(raw, &params); err != nil {
+						continue
+					}
+					responsesTool.ResponsesToolFunction.Parameters = &params
 				}
 				responsesTools = append(responsesTools, responsesTool)
 			}
@@ -2779,7 +2792,7 @@ func (r *GeminiGenerationRequest) convertParamsToGenerationConfigResponses(param
 }
 
 // convertResponsesToolsToGemini converts Responses tools to Gemini tools
-func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) []Tool {
+func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) ([]Tool, error) {
 	geminiTool := Tool{}
 
 	hasWebSearchTool := false
@@ -2805,12 +2818,13 @@ func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) []Tool {
 							}
 							return ""
 						}(),
-						Parameters: func() *Schema {
-							if tool.ResponsesToolFunction.Parameters != nil {
-								return convertFunctionParametersToSchema(*tool.ResponsesToolFunction.Parameters)
-							}
-							return nil
-						}(),
+					}
+					if tool.ResponsesToolFunction.Parameters != nil {
+						raw, err := providerUtils.MarshalSorted(tool.ResponsesToolFunction.Parameters)
+						if err != nil {
+							return []Tool{}, fmt.Errorf("marshal tool %q parameters: %w", *tool.Name, err)
+						}
+						funcDecl.ParametersJSONSchema = json.RawMessage(raw)
 					}
 					geminiTool.FunctionDeclarations = append(geminiTool.FunctionDeclarations, funcDecl)
 				}
@@ -2833,9 +2847,9 @@ func convertResponsesToolsToGemini(tools []schemas.ResponsesTool) []Tool {
 	}
 
 	if len(geminiTool.FunctionDeclarations) > 0 || geminiTool.GoogleSearch != nil {
-		return []Tool{geminiTool}
+		return []Tool{geminiTool}, nil
 	}
-	return []Tool{}
+	return []Tool{}, nil
 }
 
 // convertResponsesToolChoiceToGemini converts Responses tool choice to Gemini tool config

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -1228,7 +1228,7 @@ func convertParamsToGenerationConfig(params *schemas.ChatParameters, responseMod
 }
 
 // convertBifrostToolsToGemini converts Bifrost tools to Gemini format
-func convertBifrostToolsToGemini(bifrostTools []schemas.ChatTool) []Tool {
+func convertBifrostToolsToGemini(bifrostTools []schemas.ChatTool) ([]Tool, error) {
 	geminiTool := Tool{}
 
 	for _, tool := range bifrostTools {
@@ -1240,7 +1240,11 @@ func convertBifrostToolsToGemini(bifrostTools []schemas.ChatTool) []Tool {
 				Name: tool.Function.Name,
 			}
 			if tool.Function.Parameters != nil {
-				fd.Parameters = convertFunctionParametersToSchema(*tool.Function.Parameters)
+				raw, err := providerUtils.MarshalSorted(tool.Function.Parameters)
+				if err != nil {
+					return nil, fmt.Errorf("marshal tool %q parameters: %w", tool.Function.Name, err)
+				}
+				fd.ParametersJSONSchema = json.RawMessage(raw)
 			}
 			if tool.Function.Description != nil {
 				fd.Description = *tool.Function.Description
@@ -1250,9 +1254,9 @@ func convertBifrostToolsToGemini(bifrostTools []schemas.ChatTool) []Tool {
 	}
 
 	if len(geminiTool.FunctionDeclarations) > 0 {
-		return []Tool{geminiTool}
+		return []Tool{geminiTool}, nil
 	}
-	return []Tool{}
+	return []Tool{}, nil
 }
 
 // convertFunctionParametersToSchema converts Bifrost function parameters to Gemini Schema


### PR DESCRIPTION
## Summary

Tool function parameters for the Gemini provider were being converted through an intermediate schema representation (`convertFunctionParametersToSchema`), which could lose fidelity for complex or non-standard JSON Schema structures. This PR switches to passing parameters as raw JSON (`ParametersJSONSchema`) to preserve the original schema exactly as provided.

## Changes

- `convertBifrostToolsToGemini` and `convertResponsesToolsToGemini` now marshal tool function parameters directly to `json.RawMessage` and assign them to `ParametersJSONSchema` instead of converting through the intermediate `Schema` struct.
- Both functions now return an `error` to propagate marshaling failures, and callers handle these errors appropriately.
- `convertGeminiToolsToResponsesTools` now handles the reverse direction: when `ParametersJSONSchema` is present and `Parameters` is nil, it unmarshals the raw JSON back into `ToolFunctionParameters`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Send a chat or responses request to the Gemini provider with tools that include complex or nested JSON Schema parameters (e.g., `anyOf`, `$ref`, or additional properties). Verify that the parameters are forwarded to Gemini without schema fields being dropped or transformed incorrectly.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Marshaling is performed on user-supplied tool schemas that are already trusted inputs within the request pipeline.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable