### PR TITLE
fix: broaden Red Hat registry allowlist from `registry.access.redhat.com` to `*.redhat.com`

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1771,7 +1771,7 @@ jobs:
             production.cloudflare.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
-            registry.access.redhat.com:443
+            *.redhat.com:443
             *.quay.io:443
             registry.npmjs.org:443
             storage.googleapis.com:443
@@ -1862,7 +1862,7 @@ jobs:
             production.cloudflare.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
-            registry.access.redhat.com:443
+            *.redhat.com:443
             *.quay.io:443
             registry.npmjs.org:443
             storage.googleapis.com:443


### PR DESCRIPTION
## Summary

Broadens the Red Hat registry allowlist in the release pipeline's egress rules to support additional Red Hat subdomains beyond just `registry.access.redhat.com`.

## Changes

- Replaced `registry.access.redhat.com:443` with `*.redhat.com:443` in two jobs within the release pipeline workflow to allow traffic to any Red Hat subdomain, accommodating registry redirects or additional Red Hat endpoints that may be encountered during the build process.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger the release pipeline and verify that Red Hat registry pulls succeed without egress policy violations.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The wildcard `*.redhat.com` egress rule is broader than the previous specific hostname. This is intentional to handle Red Hat infrastructure redirects, but it does expand the set of allowed outbound destinations to any Red Hat subdomain during the release pipeline run.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable