### PR TITLE
fix: map supports_response_schema to response_format and text params, add Chat↔Responses format conversion

### DIFF
--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -983,6 +983,40 @@ func (cr *BifrostChatRequest) ToResponsesRequest() *BifrostResponsesRequest {
 			}
 		}
 
+		if cr.Params.ResponseFormat != nil {
+			if rfMap, ok := (*cr.Params.ResponseFormat).(map[string]interface{}); ok {
+				if fmtType, ok := rfMap["type"].(string); ok {
+					if brr.Params.Text == nil {
+						brr.Params.Text = &ResponsesTextConfig{}
+					}
+					format := &ResponsesTextConfigFormat{Type: fmtType}
+					validFormat := true
+					if fmtType == "json_schema" {
+						jsObj, ok := rfMap["json_schema"].(map[string]interface{})
+						if !ok {
+							validFormat = false
+						} else {
+							if name, ok := jsObj["name"].(string); ok {
+								format.Name = &name
+							}
+							if desc, ok := jsObj["description"].(string); ok {
+								format.Description = &desc
+							}
+							if strict, ok := jsObj["strict"].(bool); ok {
+								format.Strict = &strict
+							}
+							if schema, ok := jsObj["schema"]; ok {
+								format.JSONSchema = JSONSchemaFromMap(schema)
+							}
+						}
+					}
+					if validFormat {
+						brr.Params.Text.Format = format
+					}
+				}
+			}
+		}
+
 		// Handle Verbosity
 		if cr.Params.Verbosity != nil {
 			if brr.Params.Text == nil {
@@ -1055,6 +1089,29 @@ func (brr *BifrostResponsesRequest) ToChatRequest() *BifrostChatRequest {
 				Effort:    brr.Params.Reasoning.Effort,
 				MaxTokens: brr.Params.Reasoning.MaxTokens,
 			}
+		}
+
+		if brr.Params.Text != nil && brr.Params.Text.Format != nil {
+			f := brr.Params.Text.Format
+			rfMap := map[string]interface{}{"type": f.Type}
+			if f.Type == "json_schema" {
+				jsObj := map[string]interface{}{}
+				if f.Name != nil {
+					jsObj["name"] = *f.Name
+				}
+				if f.Description != nil {
+					jsObj["description"] = *f.Description
+				}
+				if f.Strict != nil {
+					jsObj["strict"] = *f.Strict
+				}
+				if schemaMap := f.JSONSchema.ToMap(); schemaMap != nil {
+					jsObj["schema"] = schemaMap
+				}
+				rfMap["json_schema"] = jsObj
+			}
+			var rf interface{} = rfMap
+			bcr.Params.ResponseFormat = &rf
 		}
 
 		// Handle Verbosity from Text config

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -1,6 +1,9 @@
 package schemas
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestToChatMessages_PreservesDeveloperRole(t *testing.T) {
 	messages := []ResponsesMessage{
@@ -698,5 +701,338 @@ func TestToBifrostResponsesStreamResponse_MapsLengthToIncompleteEvent(t *testing
 	}
 	if incomplete.Response.IncompleteDetails == nil || incomplete.Response.IncompleteDetails.Reason != "max_output_tokens" {
 		t.Fatal("expected incomplete_details.reason to be max_output_tokens")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// response_format ↔ text.format conversion tests
+// ---------------------------------------------------------------------------
+
+func makeJSONSchemaResponseFormat(name, description string, strict bool, schema interface{}) interface{} {
+	jsObj := map[string]interface{}{
+		"name":   name,
+		"strict": strict,
+		"schema": schema,
+	}
+	if description != "" {
+		jsObj["description"] = description
+	}
+	return map[string]interface{}{
+		"type":        "json_schema",
+		"json_schema": jsObj,
+	}
+}
+
+func TestToResponsesRequest_ResponseFormat_JSONSchema(t *testing.T) {
+	schema := map[string]interface{}{
+		"type":       "object",
+		"properties": map[string]interface{}{"name": map[string]interface{}{"type": "string"}},
+		"required":   []interface{}{"name"},
+	}
+	rf := makeJSONSchemaResponseFormat("CityInfo", "City schema", true, schema)
+	chatReq := &BifrostChatRequest{
+		Params: &ChatParameters{ResponseFormat: &rf},
+	}
+
+	rr := chatReq.ToResponsesRequest()
+	if rr.Params == nil || rr.Params.Text == nil || rr.Params.Text.Format == nil {
+		t.Fatal("expected Text.Format to be set")
+	}
+	f := rr.Params.Text.Format
+	if f.Type != "json_schema" {
+		t.Fatalf("expected type json_schema, got %q", f.Type)
+	}
+	if f.Name == nil || *f.Name != "CityInfo" {
+		t.Fatalf("expected Name=CityInfo, got %v", f.Name)
+	}
+	if f.Description == nil || *f.Description != "City schema" {
+		t.Fatalf("expected Description='City schema', got %v", f.Description)
+	}
+	if f.Strict == nil || !*f.Strict {
+		t.Fatal("expected Strict=true")
+	}
+	// JSONSchemaFromMap populates typed fields, not the raw Schema *any blob.
+	if f.JSONSchema == nil {
+		t.Fatal("expected JSONSchema to be set")
+	}
+	if f.JSONSchema.Type == nil || *f.JSONSchema.Type != "object" {
+		t.Fatalf("expected JSONSchema.Type=object, got %v", f.JSONSchema.Type)
+	}
+	if f.JSONSchema.Properties == nil {
+		t.Fatal("expected JSONSchema.Properties to be set")
+	}
+	if len(f.JSONSchema.Required) == 0 {
+		t.Fatal("expected JSONSchema.Required to be set")
+	}
+}
+
+func TestToResponsesRequest_ResponseFormat_JSONObject(t *testing.T) {
+	rf := interface{}(map[string]interface{}{"type": "json_object"})
+	chatReq := &BifrostChatRequest{
+		Params: &ChatParameters{ResponseFormat: &rf},
+	}
+
+	rr := chatReq.ToResponsesRequest()
+	if rr.Params == nil || rr.Params.Text == nil || rr.Params.Text.Format == nil {
+		t.Fatal("expected Text.Format to be set")
+	}
+	if rr.Params.Text.Format.Type != "json_object" {
+		t.Fatalf("expected type json_object, got %q", rr.Params.Text.Format.Type)
+	}
+}
+
+func TestToResponsesRequest_ResponseFormat_Text(t *testing.T) {
+	rf := interface{}(map[string]interface{}{"type": "text"})
+	chatReq := &BifrostChatRequest{
+		Params: &ChatParameters{ResponseFormat: &rf},
+	}
+
+	rr := chatReq.ToResponsesRequest()
+	if rr.Params == nil || rr.Params.Text == nil || rr.Params.Text.Format == nil {
+		t.Fatal("expected Text.Format to be set")
+	}
+	if rr.Params.Text.Format.Type != "text" {
+		t.Fatalf("expected type text, got %q", rr.Params.Text.Format.Type)
+	}
+}
+
+func TestToResponsesRequest_NoResponseFormat(t *testing.T) {
+	chatReq := &BifrostChatRequest{
+		Params: &ChatParameters{},
+	}
+	rr := chatReq.ToResponsesRequest()
+	if rr.Params != nil && rr.Params.Text != nil && rr.Params.Text.Format != nil {
+		t.Fatal("expected Text.Format to be nil when no response_format set")
+	}
+}
+
+func TestToChatRequest_TextFormat_JSONSchema(t *testing.T) {
+	schema := map[string]interface{}{
+		"type":     "object",
+		"required": []interface{}{"country"},
+	}
+	rr := &BifrostResponsesRequest{
+		Params: &ResponsesParameters{
+			Text: &ResponsesTextConfig{
+				Format: &ResponsesTextConfigFormat{
+					Type:        "json_schema",
+					Name:        Ptr("CityInfo"),
+					Description: Ptr("City schema"),
+					Strict:      Ptr(true),
+					JSONSchema:  &ResponsesTextConfigFormatJSONSchema{Schema: func() *any { v := any(schema); return &v }()},
+				},
+			},
+		},
+	}
+
+	cr := rr.ToChatRequest()
+	if cr.Params == nil || cr.Params.ResponseFormat == nil {
+		t.Fatal("expected ResponseFormat to be set")
+	}
+	rfMap, ok := (*cr.Params.ResponseFormat).(map[string]interface{})
+	if !ok {
+		t.Fatal("expected ResponseFormat to be map[string]interface{}")
+	}
+	if rfMap["type"] != "json_schema" {
+		t.Fatalf("expected type json_schema, got %v", rfMap["type"])
+	}
+	jsObj, ok := rfMap["json_schema"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected json_schema inner object")
+	}
+	if jsObj["name"] != "CityInfo" {
+		t.Fatalf("expected name=CityInfo, got %v", jsObj["name"])
+	}
+	if jsObj["description"] != "City schema" {
+		t.Fatalf("expected description='City schema', got %v", jsObj["description"])
+	}
+	if jsObj["strict"] != true {
+		t.Fatalf("expected strict=true, got %v", jsObj["strict"])
+	}
+	if jsObj["schema"] == nil {
+		t.Fatal("expected schema to be set")
+	}
+}
+
+func TestToChatRequest_TextFormat_JSONObject(t *testing.T) {
+	rr := &BifrostResponsesRequest{
+		Params: &ResponsesParameters{
+			Text: &ResponsesTextConfig{
+				Format: &ResponsesTextConfigFormat{Type: "json_object"},
+			},
+		},
+	}
+
+	cr := rr.ToChatRequest()
+	if cr.Params == nil || cr.Params.ResponseFormat == nil {
+		t.Fatal("expected ResponseFormat to be set")
+	}
+	rfMap, ok := (*cr.Params.ResponseFormat).(map[string]interface{})
+	if !ok {
+		t.Fatal("expected ResponseFormat to be map[string]interface{}")
+	}
+	if rfMap["type"] != "json_object" {
+		t.Fatalf("expected type json_object, got %v", rfMap["type"])
+	}
+	if _, hasJS := rfMap["json_schema"]; hasJS {
+		t.Fatal("json_schema key should not be present for json_object type")
+	}
+}
+
+func TestToChatRequest_NoTextFormat(t *testing.T) {
+	rr := &BifrostResponsesRequest{
+		Params: &ResponsesParameters{},
+	}
+	cr := rr.ToChatRequest()
+	if cr.Params != nil && cr.Params.ResponseFormat != nil {
+		t.Fatal("expected ResponseFormat to be nil when no text.format set")
+	}
+}
+
+func TestResponseFormatRoundTrip_ChatToResponsesAndBack(t *testing.T) {
+	schema := map[string]interface{}{
+		"type":       "object",
+		"properties": map[string]interface{}{"city": map[string]interface{}{"type": "string"}},
+	}
+	rf := makeJSONSchemaResponseFormat("CityInfo", "City schema", true, schema)
+	chatReq := &BifrostChatRequest{
+		Params: &ChatParameters{ResponseFormat: &rf},
+	}
+
+	// Chat → Responses → Chat
+	rr := chatReq.ToResponsesRequest()
+	cr := rr.ToChatRequest()
+
+	if cr.Params == nil || cr.Params.ResponseFormat == nil {
+		t.Fatal("expected ResponseFormat to survive round-trip")
+	}
+	rfMap, ok := (*cr.Params.ResponseFormat).(map[string]interface{})
+	if !ok {
+		t.Fatal("expected ResponseFormat to be map after round-trip")
+	}
+	if rfMap["type"] != "json_schema" {
+		t.Fatalf("type did not survive round-trip: got %v", rfMap["type"])
+	}
+	jsObj, ok := rfMap["json_schema"].(map[string]interface{})
+	if !ok {
+		t.Fatal("json_schema inner object missing after round-trip")
+	}
+	if jsObj["name"] != "CityInfo" {
+		t.Fatalf("name did not survive round-trip: got %v", jsObj["name"])
+	}
+	if jsObj["description"] != "City schema" {
+		t.Fatalf("description did not survive round-trip: got %v", jsObj["description"])
+	}
+	if jsObj["strict"] != true {
+		t.Fatalf("strict did not survive round-trip: got %v", jsObj["strict"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSON wire-format tests (catch serialization bugs, not just struct values)
+// ---------------------------------------------------------------------------
+
+// TestToResponsesRequest_JSONSchema_NoDoubleNesting verifies that the json_schema
+// body serializes as "schema": {...} and NOT "schema": {"schema": {...}}.
+func TestToResponsesRequest_JSONSchema_NoDoubleNesting(t *testing.T) {
+	schema := map[string]interface{}{
+		"type":       "object",
+		"properties": map[string]interface{}{"name": map[string]interface{}{"type": "string"}},
+		"required":   []interface{}{"name"},
+	}
+	rf := makeJSONSchemaResponseFormat("CityInfo", "", true, schema)
+	chatReq := &BifrostChatRequest{
+		Params: &ChatParameters{ResponseFormat: &rf},
+	}
+
+	rr := chatReq.ToResponsesRequest()
+	if rr.Params == nil || rr.Params.Text == nil || rr.Params.Text.Format == nil {
+		t.Fatal("expected Text.Format to be set")
+	}
+
+	// Marshal to JSON and inspect the wire shape
+	b, err := json.Marshal(rr.Params.Text.Format)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var wire map[string]interface{}
+	if err := json.Unmarshal(b, &wire); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	schemaVal, ok := wire["schema"]
+	if !ok {
+		t.Fatalf("expected 'schema' key in wire format, got: %s", string(b))
+	}
+
+	schemaMap, ok := schemaVal.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected schema to be an object, got: %T — wire: %s", schemaVal, string(b))
+	}
+
+	// Must NOT have a nested "schema" key (double-nesting bug)
+	if _, nested := schemaMap["schema"]; nested {
+		t.Fatalf("double-nested schema detected: wire=%s", string(b))
+	}
+
+	// Must have the actual schema fields at the top level
+	if schemaMap["type"] != "object" {
+		t.Fatalf("expected schema.type=object, wire=%s", string(b))
+	}
+}
+
+// TestToChatRequest_TextFormat_TypedFields verifies that when a Responses API
+// request has schema fields spread across the typed fields of
+// ResponsesTextConfigFormatJSONSchema (Schema==nil), ToChatRequest still
+// produces a valid response_format with a non-empty json_schema.schema body.
+func TestToChatRequest_TextFormat_TypedFields(t *testing.T) {
+	props := map[string]any{"name": map[string]any{"type": "string"}}
+	rr := &BifrostResponsesRequest{
+		Params: &ResponsesParameters{
+			Text: &ResponsesTextConfig{
+				Format: &ResponsesTextConfigFormat{
+					Type:   "json_schema",
+					Name:   Ptr("CityInfo"),
+					Strict: Ptr(true),
+					// Schema is nil — fields are spread across typed fields (direct client path)
+					JSONSchema: &ResponsesTextConfigFormatJSONSchema{
+						Type:       Ptr("object"),
+						Properties: &props,
+						Required:   []string{"name"},
+						// Schema *any is intentionally nil here
+					},
+				},
+			},
+		},
+	}
+
+	cr := rr.ToChatRequest()
+	if cr.Params == nil || cr.Params.ResponseFormat == nil {
+		t.Fatal("expected ResponseFormat to be set")
+	}
+
+	rfMap, ok := (*cr.Params.ResponseFormat).(map[string]interface{})
+	if !ok {
+		t.Fatal("expected ResponseFormat to be a map")
+	}
+
+	jsObj, ok := rfMap["json_schema"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected json_schema inner object")
+	}
+
+	// Schema body must be present and non-empty
+	schemaVal, ok := jsObj["schema"]
+	if !ok {
+		t.Fatalf("schema body silently dropped: json_schema=%v", jsObj)
+	}
+
+	schemaMap, ok := schemaVal.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected schema to be a map, got %T", schemaVal)
+	}
+	if schemaMap["type"] != "object" {
+		t.Fatalf("expected schema.type=object, got %v", schemaMap["type"])
 	}
 }

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -281,10 +281,11 @@ type ResponsesTextConfig struct {
 }
 
 type ResponsesTextConfigFormat struct {
-	Type       string                               `json:"type"`             // "text" | "json_schema" | "json_object"
-	Name       *string                              `json:"name,omitempty"`   // Name of the format
-	JSONSchema *ResponsesTextConfigFormatJSONSchema `json:"schema,omitempty"` // when type == "json_schema"
-	Strict     *bool                                `json:"strict,omitempty"`
+	Type        string                               `json:"type"`                  // "text" | "json_schema" | "json_object"
+	Name        *string                              `json:"name,omitempty"`        // Name of the format
+	Description *string                              `json:"description,omitempty"` // Description of the schema
+	JSONSchema  *ResponsesTextConfigFormatJSONSchema `json:"schema,omitempty"`      // when type == "json_schema"
+	Strict      *bool                                `json:"strict,omitempty"`
 }
 
 // ResponsesTextConfigFormatJSONSchema represents a JSON schema specification
@@ -330,6 +331,227 @@ type ResponsesTextConfigFormatJSONSchema struct {
 	Nullable         *bool       `json:"nullable,omitempty"`         // Nullable indicator (OpenAPI 3.0 style)
 	Enum             []string    `json:"enum,omitempty"`             // Enum values
 	PropertyOrdering []string    `json:"propertyOrdering,omitempty"` // Ordering of properties, specific to Gemini
+}
+
+// JSONSchemaFromMap builds a ResponsesTextConfigFormatJSONSchema from a raw interface{}
+func JSONSchemaFromMap(v interface{}) *ResponsesTextConfigFormatJSONSchema {
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	s := &ResponsesTextConfigFormatJSONSchema{}
+	if t, ok := m["type"].(string); ok {
+		s.Type = Ptr(t)
+	}
+	if props, ok := m["properties"].(map[string]interface{}); ok {
+		p := map[string]any(props)
+		s.Properties = &p
+	}
+	if req, ok := m["required"].([]interface{}); ok {
+		strs := make([]string, 0, len(req))
+		for _, r := range req {
+			if str, ok := r.(string); ok {
+				strs = append(strs, str)
+			}
+		}
+		s.Required = strs
+	} else if req, ok := m["required"].([]string); ok {
+		s.Required = req
+	}
+	if desc, ok := m["description"].(string); ok {
+		s.Description = Ptr(desc)
+	}
+	if title, ok := m["title"].(string); ok {
+		s.Title = Ptr(title)
+	}
+	if ref, ok := m["$ref"].(string); ok {
+		s.Ref = Ptr(ref)
+	}
+	if defs, ok := m["$defs"].(map[string]interface{}); ok {
+		d := map[string]any(defs)
+		s.Defs = &d
+	}
+	if defs, ok := m["definitions"].(map[string]interface{}); ok {
+		d := map[string]any(defs)
+		s.Definitions = &d
+	}
+	if items, ok := m["items"].(map[string]interface{}); ok {
+		it := map[string]any(items)
+		s.Items = &it
+	}
+	if b, ok := m["additionalProperties"].(bool); ok {
+		s.AdditionalProperties = &AdditionalPropertiesStruct{AdditionalPropertiesBool: Ptr(b)}
+	} else if ap, ok := m["additionalProperties"].(map[string]interface{}); ok {
+		s.AdditionalProperties = &AdditionalPropertiesStruct{AdditionalPropertiesMap: OrderedMapFromMap(ap)}
+	}
+	if f, ok := m["format"].(string); ok {
+		s.Format = Ptr(f)
+	}
+	if p, ok := m["pattern"].(string); ok {
+		s.Pattern = Ptr(p)
+	}
+	if enums, ok := m["enum"].([]interface{}); ok {
+		strs := make([]string, 0, len(enums))
+		for _, e := range enums {
+			if str, ok := e.(string); ok {
+				strs = append(strs, str)
+			}
+		}
+		s.Enum = strs
+	}
+	if n, ok := m["nullable"].(bool); ok {
+		s.Nullable = Ptr(n)
+	}
+	if extractSliceOfMaps := func(key string) []map[string]any {
+		raw, ok := m[key].([]interface{})
+		if !ok {
+			return nil
+		}
+		out := make([]map[string]any, 0, len(raw))
+		for _, item := range raw {
+			if mp, ok := item.(map[string]interface{}); ok {
+				out = append(out, mp)
+			}
+		}
+		return out
+	}; true {
+		if ao := extractSliceOfMaps("anyOf"); len(ao) > 0 {
+			s.AnyOf = ao
+		}
+		if oo := extractSliceOfMaps("oneOf"); len(oo) > 0 {
+			s.OneOf = oo
+		}
+		if ao := extractSliceOfMaps("allOf"); len(ao) > 0 {
+			s.AllOf = ao
+		}
+	}
+
+	if n, ok := m["minItems"].(float64); ok {
+		x := int64(n)
+		s.MinItems = Ptr(x)
+	}
+	if n, ok := m["maxItems"].(float64); ok {
+		x := int64(n)
+		s.MaxItems = Ptr(x)
+	}
+	if n, ok := m["minimum"].(float64); ok {
+		s.Minimum = Ptr(n)
+	}
+	if n, ok := m["maximum"].(float64); ok {
+		s.Maximum = Ptr(n)
+	}
+	if n, ok := m["minLength"].(float64); ok {
+		x := int64(n)
+		s.MinLength = Ptr(x)
+	}
+	if n, ok := m["maxLength"].(float64); ok {
+		x := int64(n)
+		s.MaxLength = Ptr(x)
+	}
+	if d, ok := m["default"]; ok {
+		s.Default = d
+	}
+	if po, ok := m["propertyOrdering"].([]interface{}); ok {
+		strs := make([]string, 0, len(po))
+		for _, v := range po {
+			if str, ok := v.(string); ok {
+				strs = append(strs, str)
+			}
+		}
+		s.PropertyOrdering = strs
+	}
+	return s
+}
+
+// ToMap reconstructs the raw schema map from a ResponsesTextConfigFormatJSONSchema.
+func (s *ResponsesTextConfigFormatJSONSchema) ToMap() interface{} {
+	if s == nil {
+		return nil
+	}
+	if s.Schema != nil {
+		return *s.Schema
+	}
+	m := make(map[string]interface{})
+	if s.Type != nil {
+		m["type"] = *s.Type
+	}
+	if s.Properties != nil {
+		m["properties"] = *s.Properties
+	}
+	if len(s.Required) > 0 {
+		m["required"] = s.Required
+	}
+	if s.Description != nil {
+		m["description"] = *s.Description
+	}
+	if s.Title != nil {
+		m["title"] = *s.Title
+	}
+	if s.Ref != nil {
+		m["$ref"] = *s.Ref
+	}
+	if s.Defs != nil {
+		m["$defs"] = *s.Defs
+	}
+	if s.Definitions != nil {
+		m["definitions"] = *s.Definitions
+	}
+	if s.Items != nil {
+		m["items"] = *s.Items
+	}
+	if s.AdditionalProperties != nil {
+		if s.AdditionalProperties.AdditionalPropertiesBool != nil {
+			m["additionalProperties"] = *s.AdditionalProperties.AdditionalPropertiesBool
+		} else if s.AdditionalProperties.AdditionalPropertiesMap != nil {
+			m["additionalProperties"] = s.AdditionalProperties.AdditionalPropertiesMap
+		}
+	}
+	if s.Format != nil {
+		m["format"] = *s.Format
+	}
+	if s.Pattern != nil {
+		m["pattern"] = *s.Pattern
+	}
+	if len(s.Enum) > 0 {
+		m["enum"] = s.Enum
+	}
+	if s.Nullable != nil {
+		m["nullable"] = *s.Nullable
+	}
+	if s.Default != nil {
+		m["default"] = s.Default
+	}
+	if len(s.AnyOf) > 0 {
+		m["anyOf"] = s.AnyOf
+	}
+	if len(s.OneOf) > 0 {
+		m["oneOf"] = s.OneOf
+	}
+	if len(s.AllOf) > 0 {
+		m["allOf"] = s.AllOf
+	}
+	if s.MinItems != nil {
+		m["minItems"] = *s.MinItems
+	}
+	if s.MaxItems != nil {
+		m["maxItems"] = *s.MaxItems
+	}
+	if s.Minimum != nil {
+		m["minimum"] = *s.Minimum
+	}
+	if s.Maximum != nil {
+		m["maximum"] = *s.Maximum
+	}
+	if s.MinLength != nil {
+		m["minLength"] = *s.MinLength
+	}
+	if s.MaxLength != nil {
+		m["maxLength"] = *s.MaxLength
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 type ResponsesResponseConversation struct {
@@ -743,8 +965,8 @@ type ResponsesOutputMessageContentRefusal struct {
 }
 
 type ResponsesToolMessage struct {
-	CallID    *string                           `json:"call_id,omitempty"` // Common call ID for tool calls and outputs
-	Name      *string                           `json:"name,omitempty"`    // Common name field for tool calls
+	CallID    *string                           `json:"call_id,omitempty"`   // Common call ID for tool calls and outputs
+	Name      *string                           `json:"name,omitempty"`      // Common name field for tool calls
 	Namespace *string                           `json:"namespace,omitempty"` // Namespace for function_call items (set by OpenAI when namespace tools are used)
 	Arguments *string                           `json:"arguments,omitempty"`
 	Output    *ResponsesToolMessageOutputStruct `json:"output,omitempty"`

--- a/framework/modelcatalog/utils.go
+++ b/framework/modelcatalog/utils.go
@@ -391,6 +391,7 @@ type modelParametersParseResult struct {
 	SupportsParallelFunctionCalling *bool `json:"supports_parallel_function_calling,omitempty"`
 	SupportsToolChoice              *bool `json:"supports_tool_choice,omitempty"`
 	SupportsReasoning               *bool `json:"supports_reasoning,omitempty"`
+	SupportsResponseSchema          *bool `json:"supports_response_schema,omitempty"`
 	SupportsServiceTier             *bool `json:"supports_service_tier,omitempty"`
 	SupportsPromptCaching           *bool `json:"supports_prompt_caching,omitempty"`
 	VertexMultiRegionOnly           *bool `json:"vertex_multi_region_only,omitempty"`
@@ -437,6 +438,10 @@ func extractSupportedParams(parsed *modelParametersParseResult) []string {
 	}
 	if parsed.SupportsReasoning != nil && *parsed.SupportsReasoning {
 		addParam("reasoning")
+	}
+	if parsed.SupportsResponseSchema != nil && *parsed.SupportsResponseSchema {
+		addParam("response_format")
+		addParam("text")
 	}
 	if parsed.SupportsServiceTier != nil && *parsed.SupportsServiceTier {
 		addParam("service_tier")


### PR DESCRIPTION
## Summary

This PR adds bidirectional conversion of `response_format` between the Chat and Responses API request schemas, and introduces a `supports_response_schema` capability flag for the model catalog. Previously, `response_format` was silently dropped when converting between the two request types, causing structured output configurations to be lost.

## Changes

- Added `response_format` → `text.format` mapping in `ToResponsesRequest()`, handling `json_object`, `text`, and `json_schema` types (including full `json_schema` field extraction: `name`, `description`, `strict`, and `schema`).
- Added `text.format` → `response_format` mapping in `ToChatRequest()` for the reverse direction.
- Added a `Description` field to `ResponsesTextConfigFormat` to align with the full JSON schema spec.
- Added a `SupportsResponseSchema` flag to `modelParametersParseResult` in the model catalog; when set, it registers both `response_format` and `text` as supported parameters.
- Added comprehensive tests covering `json_schema`, `json_object`, and `text` format types in both conversion directions, including a full Chat → Responses → Chat round-trip test.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./framework/modelcatalog/...
```

Expected: all tests pass, including the new `response_format` round-trip and directional conversion tests in `mux_test.go`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. Schema fields are passed through as-is without evaluation or execution.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable