### PR TITLE
fix: updates e2e ui tests for virtual keys management

### DIFF
--- a/tests/e2e/core/fixtures/base.fixture.ts
+++ b/tests/e2e/core/fixtures/base.fixture.ts
@@ -1,123 +1,140 @@
-import { test as base, expect } from '@playwright/test'
-import { SidebarPage } from '../pages/sidebar.page'
-import { ProvidersPage } from '../../features/providers/pages/providers.page'
-import { VirtualKeysPage } from '../../features/virtual-keys/pages/virtual-keys.page'
-import { DashboardPage } from '../../features/dashboard/pages/dashboard.page'
-import { LogsPage } from '../../features/logs/pages/logs.page'
-import { MCPLogsPage } from '../../features/mcp-logs/pages/mcp-logs.page'
-import { RoutingRulesPage } from '../../features/routing-rules/pages/routing-rules.page'
-import { MCPRegistryPage } from '../../features/mcp-registry/pages/mcp-registry.page'
-import { PluginsPage } from '../../features/plugins/pages/plugins.page'
-import { ObservabilityPage } from '../../features/observability/pages/observability.page'
-import { ConfigSettingsPage } from '../../features/config/pages/config-settings.page'
-import { GovernancePage } from '../../features/governance/pages/governance.page'
-import { MCPAuthConfigPage } from '../../features/mcp-auth-config/pages/mcp-auth-config.page'
-import { MCPSettingsPage } from '../../features/mcp-settings/pages/mcp-settings.page'
-import { MCPToolGroupsPage } from '../../features/mcp-tool-groups/pages/mcp-tool-groups.page'
-import { ModelLimitsPage } from '../../features/model-limits/pages/model-limits.page'
+import { test as base, expect } from "@playwright/test";
+import { SidebarPage } from "../pages/sidebar.page";
+import { ProvidersPage } from "../../features/providers/pages/providers.page";
+import { VirtualKeysPage } from "../../features/virtual-keys/pages/virtual-keys.page";
+import { DashboardPage } from "../../features/dashboard/pages/dashboard.page";
+import { LogsPage } from "../../features/logs/pages/logs.page";
+import { MCPLogsPage } from "../../features/mcp-logs/pages/mcp-logs.page";
+import { RoutingRulesPage } from "../../features/routing-rules/pages/routing-rules.page";
+import { MCPRegistryPage } from "../../features/mcp-registry/pages/mcp-registry.page";
+import { PluginsPage } from "../../features/plugins/pages/plugins.page";
+import { ObservabilityPage } from "../../features/observability/pages/observability.page";
+import { ConfigSettingsPage } from "../../features/config/pages/config-settings.page";
+import { GovernancePage } from "../../features/governance/pages/governance.page";
+import { MCPAuthConfigPage } from "../../features/mcp-auth-config/pages/mcp-auth-config.page";
+import { MCPSettingsPage } from "../../features/mcp-settings/pages/mcp-settings.page";
+import { MCPToolGroupsPage } from "../../features/mcp-tool-groups/pages/mcp-tool-groups.page";
+import { ModelLimitsPage } from "../../features/model-limits/pages/model-limits.page";
 
 /**
  * Custom test fixtures type
  */
 type BifrostFixtures = {
-  closeDevProfiler: void
-  sidebarPage: SidebarPage
-  providersPage: ProvidersPage
-  virtualKeysPage: VirtualKeysPage
-  dashboardPage: DashboardPage
-  logsPage: LogsPage
-  mcpLogsPage: MCPLogsPage
-  routingRulesPage: RoutingRulesPage
-  mcpRegistryPage: MCPRegistryPage
-  pluginsPage: PluginsPage
-  observabilityPage: ObservabilityPage
-  configSettingsPage: ConfigSettingsPage
-  governancePage: GovernancePage
-  modelLimitsPage: ModelLimitsPage
-  mcpSettingsPage: MCPSettingsPage
-  mcpToolGroupsPage: MCPToolGroupsPage
-  mcpAuthConfigPage: MCPAuthConfigPage
-}
+	closeDevProfiler: void;
+	sidebarPage: SidebarPage;
+	providersPage: ProvidersPage;
+	virtualKeysPage: VirtualKeysPage;
+	dashboardPage: DashboardPage;
+	logsPage: LogsPage;
+	mcpLogsPage: MCPLogsPage;
+	routingRulesPage: RoutingRulesPage;
+	mcpRegistryPage: MCPRegistryPage;
+	pluginsPage: PluginsPage;
+	observabilityPage: ObservabilityPage;
+	configSettingsPage: ConfigSettingsPage;
+	governancePage: GovernancePage;
+	modelLimitsPage: ModelLimitsPage;
+	mcpSettingsPage: MCPSettingsPage;
+	mcpToolGroupsPage: MCPToolGroupsPage;
+	mcpAuthConfigPage: MCPAuthConfigPage;
+};
 
 /**
  * Extended test with Bifrost-specific fixtures
  */
 export const test = base.extend<BifrostFixtures>({
-  closeDevProfiler: [async ({ page }, use) => {
-    // Automatically dismiss the Dev Profiler overlay whenever it appears.
-    // Uses addLocatorHandler so it triggers before any test action if the profiler is visible.
-    await page.addLocatorHandler(
-      page.getByText('Dev Profiler', { exact: true }),
-      async () => {
-        await page.locator('button[title="Dismiss"]').click({ force: true })
-      }
-    )
-    await use()
-  }, { auto: true }],
+	closeDevProfiler: [
+		async ({ page }, use) => {
+			// Keep the development profiler from stealing focus or blocking assertions when
+			// tests reuse a manually started dev server that was not launched with
+			// BIFROST_DISABLE_PROFILER=1.
+			await page.addInitScript(() => {
+				window.localStorage.setItem("devProfiler.isVisible", "false");
+				window.localStorage.setItem("devProfiler.isExpanded", "false");
+			});
 
-  sidebarPage: async ({ page }, use) => {
-    await use(new SidebarPage(page))
-  },
+			await page.addLocatorHandler(
+				page.getByText("Dev Profiler", { exact: true }),
+				async () => {
+					await page.evaluate(() => {
+						window.localStorage.setItem("devProfiler.isVisible", "false");
+						window.localStorage.setItem("devProfiler.isExpanded", "false");
+					});
+					await page
+						.locator('button[title="Dismiss"]')
+						.click({ force: true, timeout: 1000 })
+						.catch(() => {});
+				},
+				{ noWaitAfter: true },
+			);
+			await use();
+		},
+		{ auto: true },
+	],
 
-  providersPage: async ({ page }, use) => {
-    await use(new ProvidersPage(page))
-  },
+	sidebarPage: async ({ page }, use) => {
+		await use(new SidebarPage(page));
+	},
 
-  virtualKeysPage: async ({ page }, use) => {
-    await use(new VirtualKeysPage(page))
-  },
+	providersPage: async ({ page }, use) => {
+		await use(new ProvidersPage(page));
+	},
 
-  dashboardPage: async ({ page }, use) => {
-    await use(new DashboardPage(page))
-  },
+	virtualKeysPage: async ({ page }, use) => {
+		await use(new VirtualKeysPage(page));
+	},
 
-  logsPage: async ({ page }, use) => {
-    await use(new LogsPage(page))
-  },
+	dashboardPage: async ({ page }, use) => {
+		await use(new DashboardPage(page));
+	},
 
-  mcpLogsPage: async ({ page }, use) => {
-    await use(new MCPLogsPage(page))
-  },
+	logsPage: async ({ page }, use) => {
+		await use(new LogsPage(page));
+	},
 
-  routingRulesPage: async ({ page }, use) => {
-    await use(new RoutingRulesPage(page))
-  },
+	mcpLogsPage: async ({ page }, use) => {
+		await use(new MCPLogsPage(page));
+	},
 
-  mcpRegistryPage: async ({ page }, use) => {
-    await use(new MCPRegistryPage(page))
-  },
+	routingRulesPage: async ({ page }, use) => {
+		await use(new RoutingRulesPage(page));
+	},
 
-  pluginsPage: async ({ page }, use) => {
-    await use(new PluginsPage(page))
-  },
+	mcpRegistryPage: async ({ page }, use) => {
+		await use(new MCPRegistryPage(page));
+	},
 
-  observabilityPage: async ({ page }, use) => {
-    await use(new ObservabilityPage(page))
-  },
+	pluginsPage: async ({ page }, use) => {
+		await use(new PluginsPage(page));
+	},
 
-  configSettingsPage: async ({ page }, use) => {
-    await use(new ConfigSettingsPage(page))
-  },
+	observabilityPage: async ({ page }, use) => {
+		await use(new ObservabilityPage(page));
+	},
 
-  governancePage: async ({ page }, use) => {
-    await use(new GovernancePage(page))
-  },
+	configSettingsPage: async ({ page }, use) => {
+		await use(new ConfigSettingsPage(page));
+	},
 
-  modelLimitsPage: async ({ page }, use) => {
-    await use(new ModelLimitsPage(page))
-  },
+	governancePage: async ({ page }, use) => {
+		await use(new GovernancePage(page));
+	},
 
-  mcpSettingsPage: async ({ page }, use) => {
-    await use(new MCPSettingsPage(page))
-  },
+	modelLimitsPage: async ({ page }, use) => {
+		await use(new ModelLimitsPage(page));
+	},
 
-  mcpToolGroupsPage: async ({ page }, use) => {
-    await use(new MCPToolGroupsPage(page))
-  },
+	mcpSettingsPage: async ({ page }, use) => {
+		await use(new MCPSettingsPage(page));
+	},
 
-  mcpAuthConfigPage: async ({ page }, use) => {
-    await use(new MCPAuthConfigPage(page))
-  },
-})
+	mcpToolGroupsPage: async ({ page }, use) => {
+		await use(new MCPToolGroupsPage(page));
+	},
 
-export { expect }
+	mcpAuthConfigPage: async ({ page }, use) => {
+		await use(new MCPAuthConfigPage(page));
+	},
+});
+
+export { expect };

--- a/tests/e2e/core/utils/selectors.ts
+++ b/tests/e2e/core/utils/selectors.ts
@@ -12,7 +12,8 @@ export const Selectors = {
   providers: {
     // Sidebar list
     providerList: '[data-testid="provider-list"]',
-    providerItem: (name: string) => `[data-testid="provider-item-${name.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}"]`,
+    providerItem: (name: string) =>
+      `[data-testid="provider-item-${name.replace(/[^a-z0-9]+/gi, "-").toLowerCase()}"]`,
     addProviderBtn: '[data-testid="add-provider-btn"]',
     /** Add New Provider dropdown > Custom provider... (opens custom provider sheet) */
     addProviderOptionCustom: '[data-testid="add-provider-option-custom"]',
@@ -22,7 +23,7 @@ export const Selectors = {
     addKeyBtn: '[data-testid="add-key-btn"]',
     keysTable: '[data-testid="keys-table"]',
     keyRow: (name: string) => `[data-testid="key-row-${name}"]`,
-    
+
     // Key form
     keyForm: {
       container: '[data-testid="key-form"]',
@@ -33,7 +34,7 @@ export const Selectors = {
       saveBtn: '[data-testid="key-save-btn"]',
       cancelBtn: '[data-testid="key-cancel-btn"]',
     },
-    
+
     // Custom provider sheet
     customProviderSheet: {
       container: '[data-testid="custom-provider-sheet"]',
@@ -51,14 +52,14 @@ export const Selectors = {
     table: '[data-testid="vk-table"]',
     row: (name: string) => `[data-testid="vk-row-${name}"]`,
     createBtn: '[data-testid="create-vk-btn"]',
-    
+
     // Sheet/Form
     sheet: {
-      container: '[data-testid="vk-sheet"]',
+      container: '[data-testid="vk-sheet-content"]',
       nameInput: '[data-testid="vk-name-input"]',
       descriptionInput: '[data-testid="vk-description-input"]',
       isActiveToggle: '[data-testid="vk-is-active-toggle"]',
-      
+
       // Provider configs
       providerSelect: '[data-testid="vk-provider-select"]',
 
@@ -66,7 +67,7 @@ export const Selectors = {
       entityTypeSelect: '[data-testid="vk-entity-type-select"]',
       teamSelect: '[data-testid="vk-team-select"]',
       customerSelect: '[data-testid="vk-customer-select"]',
-      
+
       // Actions
       saveBtn: '[data-testid="vk-save-btn"]',
       cancelBtn: '[data-testid="vk-cancel-btn"]',
@@ -99,4 +100,4 @@ export const Selectors = {
     confirmBtn: '[data-testid="dialog-confirm-btn"]',
     cancelBtn: '[data-testid="dialog-cancel-btn"]',
   },
-}
+};

--- a/tests/e2e/features/model-limits/pages/model-limits.page.ts
+++ b/tests/e2e/features/model-limits/pages/model-limits.page.ts
@@ -41,7 +41,35 @@ export class ModelLimitsPage extends BasePage {
 
   async modelLimitExists(modelName: string, provider: string = 'all'): Promise<boolean> {
     const row = this.getModelLimitRow(modelName, provider)
-    return (await row.count()) > 0
+    return await row.isVisible({ timeout: 5000 }).catch(() => false)
+  }
+
+  private async openModelLimitActions(modelName: string, provider: string = 'all'): Promise<void> {
+    const row = this.getModelLimitRow(modelName, provider)
+    await expect(row).toBeVisible({ timeout: 10000 })
+    await row.scrollIntoViewIfNeeded()
+
+    const actionsBtn = this.page.getByTestId(
+      `model-limit-button-actions-${toTestIdPart(modelName)}-${toTestIdPart(provider)}`
+    )
+    await actionsBtn.waitFor({ state: 'visible', timeout: 10000 })
+    await actionsBtn.scrollIntoViewIfNeeded()
+    await actionsBtn.click()
+  }
+
+  private async waitForSheetClosedAfterSave(): Promise<void> {
+    const closed = await expect(this.sheet)
+      .not.toBeVisible({ timeout: 5000 })
+      .then(() => true)
+      .catch(() => false)
+    if (!closed) {
+      await this.page.keyboard.press('Escape')
+      await expect(this.sheet).not.toBeVisible({ timeout: 5000 })
+    }
+
+    await expect(this.page.locator('html'))
+      .not.toHaveClass(/bprogress-busy/, { timeout: 10000 })
+      .catch(() => {})
   }
 
   /**
@@ -84,14 +112,17 @@ export class ModelLimitsPage extends BasePage {
     }
 
     const saveBtn = this.page.getByRole('button', { name: /Create Limit/i })
+    await expect(saveBtn).toBeEnabled({ timeout: 10000 })
     await saveBtn.click()
-    await this.waitForSuccessToast()
-    await expect(this.sheet).not.toBeVisible({ timeout: 10000 })
+    await this.waitForSheetClosedAfterSave()
+    await expect(this.getModelLimitRow(selectedModelName, config.provider)).toBeVisible({ timeout: 15000 })
     return selectedModelName
   }
 
   async editModelLimit(modelName: string, provider: string, updates: Partial<ModelLimitConfig>): Promise<void> {
+    await this.openModelLimitActions(modelName, provider)
     const editBtn = this.page.getByTestId(`model-limit-button-edit-${toTestIdPart(modelName)}-${toTestIdPart(provider)}`)
+    await editBtn.waitFor({ state: 'visible', timeout: 10000 })
     await editBtn.click()
     await expect(this.sheet).toBeVisible({ timeout: 5000 })
     await this.waitForSheetAnimation()
@@ -114,19 +145,24 @@ export class ModelLimitsPage extends BasePage {
     }
 
     const saveBtn = this.page.getByRole('button', { name: /Save Changes|Create Limit/i })
+    await expect(saveBtn).toBeEnabled({ timeout: 10000 })
     await saveBtn.click()
-    await this.waitForSuccessToast()
-    await expect(this.sheet).not.toBeVisible({ timeout: 10000 })
+    await this.waitForSheetClosedAfterSave()
+    await expect(this.getModelLimitRow(modelName, provider)).toBeVisible({ timeout: 15000 })
   }
 
   async deleteModelLimit(modelName: string, provider: string = 'all'): Promise<void> {
+    const exists = await this.modelLimitExists(modelName, provider)
+    if (!exists) return
+
+    await this.openModelLimitActions(modelName, provider)
     const deleteBtn = this.page.getByTestId(`model-limit-button-delete-${toTestIdPart(modelName)}-${toTestIdPart(provider)}`)
+    await deleteBtn.waitFor({ state: 'visible', timeout: 10000 })
     await deleteBtn.click()
 
     const confirmDialog = this.page.locator('[role="alertdialog"]')
     await confirmDialog.getByRole('button', { name: /Delete/i }).click()
-    await this.waitForSuccessToast()
-    await this.page.waitForTimeout(1000)
+    await expect(this.getModelLimitRow(modelName, provider)).not.toBeVisible({ timeout: 15000 })
   }
 
   async closeSheet(): Promise<void> {

--- a/tests/e2e/features/virtual-keys/pages/virtual-keys.page.ts
+++ b/tests/e2e/features/virtual-keys/pages/virtual-keys.page.ts
@@ -1,83 +1,83 @@
-import { Locator, Page, expect } from '@playwright/test'
-import { BasePage } from '../../../core/pages/base.page'
-import { fillSelect, waitForNetworkIdle } from '../../../core/utils/test-helpers'
+import { Locator, Page, expect } from "@playwright/test";
+import { BasePage } from "../../../core/pages/base.page";
+import { fillSelect, waitForNetworkIdle } from "../../../core/utils/test-helpers";
 
 /**
  * Provider display names mapping - matches the UI's ProviderLabels
  * Used for exact matching when selecting providers in dropdowns
  */
 const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-  openai: 'OpenAI',
-  anthropic: 'Anthropic',
-  azure: 'Azure',
-  bedrock: 'AWS Bedrock',
-  cohere: 'Cohere',
-  vertex: 'Vertex AI',
-  mistral: 'Mistral AI',
-  ollama: 'Ollama',
-  groq: 'Groq',
-  gemini: 'Gemini',
-  openrouter: 'OpenRouter',
-  huggingface: 'HuggingFace',
-  cerebras: 'Cerebras',
-  perplexity: 'Perplexity',
-  elevenlabs: 'Elevenlabs',
-  parasail: 'Parasail',
-  sgl: 'SGLang',
-  nebius: 'Nebius Token Factory',
-  xai: 'xAI',
-}
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+  azure: "Azure",
+  bedrock: "AWS Bedrock",
+  cohere: "Cohere",
+  vertex: "Vertex AI",
+  mistral: "Mistral AI",
+  ollama: "Ollama",
+  groq: "Groq",
+  gemini: "Gemini",
+  openrouter: "OpenRouter",
+  huggingface: "HuggingFace",
+  cerebras: "Cerebras",
+  perplexity: "Perplexity",
+  elevenlabs: "Elevenlabs",
+  parasail: "Parasail",
+  sgl: "SGLang",
+  nebius: "Nebius Token Factory",
+  xai: "xAI",
+};
 
 /**
  * Escape regex special characters in a string
  */
 function escapeRegExp(string: string): string {
-  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**
  * Budget configuration
  */
 export interface BudgetConfig {
-  maxLimit: number
-  resetDuration?: string
+  maxLimit: number;
+  resetDuration?: string; // e.g. "1d", "1m", "1M" — see resetDurationOptions
 }
 
 /**
  * Rate limit configuration
  */
 export interface RateLimitConfig {
-  tokenMaxLimit?: number
-  tokenResetDuration?: string
-  requestMaxLimit?: number
-  requestResetDuration?: string
+  tokenMaxLimit?: number;
+  tokenResetDuration?: string;
+  requestMaxLimit?: number;
+  requestResetDuration?: string;
 }
 
 /**
  * Provider configuration for virtual key
  */
 export interface ProviderConfig {
-  provider: string
-  weight?: number
-  allowedModels?: string[]
-  keyIds?: string[]
-  budget?: BudgetConfig
-  rateLimit?: RateLimitConfig
+  provider: string;
+  weight?: number;
+  allowedModels?: string[];
+  keyIds?: string[];
+  budget?: BudgetConfig;
+  rateLimit?: RateLimitConfig;
 }
 
 /**
  * Virtual key configuration
  */
 export interface VirtualKeyConfig {
-  name: string
-  description?: string
-  isActive?: boolean
-  providerConfigs?: ProviderConfig[]
-  budget?: BudgetConfig
-  rateLimit?: RateLimitConfig
-  entityType?: 'none' | 'team' | 'customer'
-  teamId?: string
-  customerId?: string
+  name: string;
+  description?: string;
+  isActive?: boolean;
+  providerConfigs?: ProviderConfig[];
+  budgets?: BudgetConfig[];
+  rateLimit?: RateLimitConfig;
+  entityType?: "none" | "team" | "customer";
+  teamId?: string;
+  customerId?: string;
 }
 
 /**
@@ -85,60 +85,141 @@ export interface VirtualKeyConfig {
  */
 export class VirtualKeysPage extends BasePage {
   // Main page elements
-  readonly createBtn: Locator
-  readonly table: Locator
-  readonly emptyState: Locator
+  readonly createBtn: Locator;
+  readonly table: Locator;
+  readonly emptyState: Locator;
 
   // Virtual key sheet elements
-  readonly sheet: Locator
-  readonly nameInput: Locator
-  readonly descriptionInput: Locator
-  readonly isActiveToggle: Locator
-  readonly providerSelect: Locator
-  readonly saveBtn: Locator
-  readonly cancelBtn: Locator
+  readonly sheet: Locator;
+  readonly nameInput: Locator;
+  readonly descriptionInput: Locator;
+  readonly isActiveToggle: Locator;
+  readonly providerSelect: Locator;
+  readonly saveBtn: Locator;
+  readonly cancelBtn: Locator;
 
   constructor(page: Page) {
-    super(page)
+    super(page);
 
     // Main page elements
-    this.createBtn = page.getByTestId('create-vk-btn')
-    this.table = page.getByTestId('vk-table')
-    this.emptyState = page.getByTestId('virtual-keys-empty-state')
+    this.createBtn = page.getByTestId("create-vk-btn");
+    this.table = page.getByTestId("vk-table");
+    this.emptyState = page.getByTestId("virtual-keys-empty-state");
 
     // Virtual key sheet elements
-    this.sheet = page.getByTestId('vk-sheet')
-    this.nameInput = page.getByTestId('vk-name-input')
-    this.descriptionInput = page.getByTestId('vk-description-input')
-    this.isActiveToggle = page.getByTestId('vk-is-active-toggle')
-    this.providerSelect = page.getByTestId('vk-provider-select')
-    this.saveBtn = page.getByTestId('vk-save-btn')
-    this.cancelBtn = page.getByTestId('vk-cancel-btn')
+    this.sheet = page.getByTestId("vk-sheet-content");
+    this.nameInput = page.getByTestId("vk-name-input");
+    this.descriptionInput = page.getByTestId("vk-description-input");
+    this.isActiveToggle = page.getByTestId("vk-is-active-toggle");
+    this.providerSelect = page.getByTestId("vk-provider-select");
+    this.saveBtn = page.getByTestId("vk-save-btn");
+    this.cancelBtn = page.getByTestId("vk-cancel-btn");
   }
 
   /**
    * Navigate to the virtual keys page
    */
   async goto(): Promise<void> {
-    await this.page.goto('/workspace/virtual-keys')
-    await waitForNetworkIdle(this.page)
+    await this.page.goto("/workspace/governance/virtual-keys");
+    await waitForNetworkIdle(this.page);
+  }
+
+  /**
+   * Search the virtual keys table by name.
+   */
+  async searchVirtualKeys(name: string): Promise<void> {
+    const searchInput = this.page.getByTestId("vk-search-input");
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await searchInput.fill("", { force: true });
+      await expect(searchInput)
+        .toHaveValue("", { timeout: 2000 })
+        .catch(() => {});
+
+      await searchInput.fill(name, { force: true });
+      const matched = await expect(searchInput)
+        .toHaveValue(name, { timeout: 2000 })
+        .then(() => true)
+        .catch(() => false);
+      if (matched) break;
+
+      await this.page.waitForTimeout(500);
+    }
+
+    await expect(searchInput)
+      .toHaveValue(name, { timeout: 10000 })
+      .catch(() => {});
+    await this.page.waitForTimeout(350);
+  }
+
+  /**
+   * Clear table filters that can hide newly created or cleanup-target rows.
+   */
+  async clearTableFilters(): Promise<void> {
+    const searchInput = this.page.getByTestId("vk-search-input");
+    if (await searchInput.isVisible().catch(() => false)) {
+      await searchInput.fill("");
+    }
+    await this.page.waitForTimeout(350);
   }
 
   /**
    * Get virtual key row locator by name
    */
   getVirtualKeyRow(name: string): Locator {
-    return this.page.getByTestId(`vk-row-${name}`)
+    return this.page.getByTestId(`vk-row-${name}`);
+  }
+
+  /**
+   * Open the row actions dropdown and click Edit.
+   */
+  private async openVirtualKeyEditor(name: string): Promise<void> {
+    await this.searchVirtualKeys(name);
+
+    const row = this.getVirtualKeyRow(name);
+    await expect(row).toBeVisible({ timeout: 10000 });
+    await row.scrollIntoViewIfNeeded();
+
+    const actionsBtn = this.page.getByTestId(`vk-actions-btn-${name}`);
+    await actionsBtn.waitFor({ state: "visible", timeout: 10000 });
+    await actionsBtn.scrollIntoViewIfNeeded();
+    await actionsBtn.click();
+
+    const editBtn = this.page.getByTestId(`vk-edit-btn-${name}`);
+    await editBtn.waitFor({ state: "visible", timeout: 10000 });
+    await editBtn.click();
+
+    await expect(this.sheet).toBeVisible({ timeout: 10000 });
+    await this.waitForSheetAnimation();
+    await expect(this.nameInput).toHaveValue(name, { timeout: 10000 });
+  }
+
+  /**
+   * Wait for the sheet to close after a save. If it stays open, close it without
+   * racing a button that may already be detaching during the save animation.
+   */
+  private async waitForSheetClosedAfterSave(): Promise<void> {
+    const closed = await expect(this.sheet)
+      .not.toBeVisible({ timeout: 5000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!closed) {
+      await this.page.keyboard.press("Escape");
+      await expect(this.sheet).not.toBeVisible({ timeout: 5000 });
+    }
+
+    await expect(this.page.locator("html"))
+      .not.toHaveClass(/bprogress-busy/, { timeout: 10000 })
+      .catch(() => {});
   }
 
   /**
    * Check if a virtual key exists in the table
    */
   async virtualKeyExists(name: string): Promise<boolean> {
-    const row = this.getVirtualKeyRow(name)
-    // Use count() to check if element exists in DOM (doesn't require visibility)
-    const count = await row.count()
-    return count > 0
+    await this.searchVirtualKeys(name).catch(() => {});
+    const row = this.getVirtualKeyRow(name);
+    return await row.isVisible({ timeout: 5000 }).catch(() => false);
   }
 
   /**
@@ -146,12 +227,12 @@ export class VirtualKeysPage extends BasePage {
    * When masked, the display shows bullets (•); when revealed, it shows the full key.
    */
   async isKeyRevealed(name: string): Promise<boolean> {
-    const row = this.getVirtualKeyRow(name)
-    const keyCell = row.getByTestId('vk-key-value')
-    await keyCell.waitFor({ state: 'visible', timeout: 5000 })
-    const text = (await keyCell.textContent())?.trim() ?? ''
+    const row = this.getVirtualKeyRow(name);
+    const keyCell = row.getByTestId("vk-key-value");
+    await keyCell.waitFor({ state: "visible", timeout: 5000 });
+    const text = (await keyCell.textContent())?.trim() ?? "";
     // Masked keys contain bullet character; revealed keys do not
-    return text.length > 0 && !text.includes('•')
+    return text.length > 0 && !text.includes("•");
   }
 
   /**
@@ -159,65 +240,64 @@ export class VirtualKeysPage extends BasePage {
    */
   async createVirtualKey(config: VirtualKeyConfig): Promise<void> {
     // Click create button
-    await this.createBtn.click()
+    await this.createBtn.click();
 
     // Wait for sheet to appear and animation to complete
-    await expect(this.sheet).toBeVisible()
-    await this.waitForSheetAnimation()
+    await expect(this.sheet).toBeVisible();
+    await this.waitForSheetAnimation();
 
     // Fill basic information using keyboard navigation
-    await this.nameInput.focus()
-    await this.page.keyboard.type(config.name)
+    await this.nameInput.focus();
+    await this.page.keyboard.type(config.name);
 
     if (config.description) {
-      await this.page.keyboard.press('Tab') // Move to description
-      await this.page.keyboard.type(config.description)
+      await this.page.keyboard.press("Tab"); // Move to description
+      await this.page.keyboard.type(config.description);
     }
 
     // Set active state if specified (default is true, so only toggle if we want inactive)
     if (config.isActive === false) {
-      await this.isActiveToggle.focus()
-      await this.page.keyboard.press('Space') // Toggle the switch
+      await this.isActiveToggle.focus();
+      await this.page.keyboard.press("Space"); // Toggle the switch
     }
 
     // Add provider configurations
     if (config.providerConfigs && config.providerConfigs.length > 0) {
       for (const providerConfig of config.providerConfigs) {
-        await this.addProviderConfig(providerConfig)
+        await this.addProviderConfig(providerConfig);
       }
     }
 
     // Set budget if specified
-    if (config.budget) {
-      await this.setBudget(config.budget)
+    if (config.budgets && config.budgets.length > 0) {
+      await this.setBudgets(config.budgets);
     }
 
     // Set rate limits if specified
     if (config.rateLimit) {
-      await this.setRateLimit(config.rateLimit)
+      await this.setRateLimit(config.rateLimit);
     }
 
     // Set entity assignment if specified
-    if (config.entityType && config.entityType !== 'none') {
-      await this.setEntityAssignment(config.entityType, config.teamId, config.customerId)
+    if (config.entityType && config.entityType !== "none") {
+      await this.setEntityAssignment(config.entityType, config.teamId, config.customerId);
     }
 
+    await expect(this.saveBtn).toBeEnabled({ timeout: 10000 });
+
     // Save the virtual key by clicking the save button
-    await this.saveBtn.click()
+    await this.saveBtn.click();
 
-    // Wait for success toast
-    await this.waitForSuccessToast()
+    // Wait for the new row to appear in the table. This is a stronger success
+    // signal than sonner toasts, which can overlap between tests and animations.
+    await this.searchVirtualKeys(config.name);
+    const row = this.getVirtualKeyRow(config.name);
+    await row.waitFor({ state: "visible", timeout: 15000 });
+    await row.scrollIntoViewIfNeeded();
 
-    // Wait for toasts to disappear before continuing
-    await this.dismissToasts()
-
-    // Wait for sheet to close
-    await expect(this.sheet).not.toBeVisible({ timeout: 5000 })
-
-    // Wait for the new row to appear in the table (ensures table has refreshed)
-    const row = this.getVirtualKeyRow(config.name)
-    await row.waitFor({ state: 'attached', timeout: 10000 })
-    await row.scrollIntoViewIfNeeded()
+    await expect(this.sheet)
+      .not.toBeVisible({ timeout: 5000 })
+      .catch(() => {});
   }
 
   /**
@@ -225,47 +305,77 @@ export class VirtualKeysPage extends BasePage {
    */
   private async addProviderConfig(config: ProviderConfig): Promise<void> {
     // Click the provider select dropdown
-    await this.providerSelect.click()
+    await this.providerSelect.click();
 
     // Wait for dropdown content
-    await this.page.waitForSelector('[role="listbox"]', { timeout: 5000 })
+    await this.page.waitForSelector('[role="listbox"]', { timeout: 5000 });
 
     // Get display name - use mapping for known providers, otherwise use exact name
-    const displayName = PROVIDER_DISPLAY_NAMES[config.provider.toLowerCase()] || config.provider
+    const displayName = PROVIDER_DISPLAY_NAMES[config.provider.toLowerCase()] || config.provider;
 
     // First try exact match for base providers (e.g., "OpenAI", "Anthropic")
-    let option = this.page.getByRole('option', { name: displayName, exact: true })
+    let option = this.page.getByRole("option", { name: displayName, exact: true });
 
-    if (await option.count() === 0) {
+    if ((await option.count()) === 0) {
       // Fallback: try partial match for custom providers (contains provider name)
       // This handles custom providers like "test-anthropic-1234567890"
-      option = this.page.getByRole('option').filter({
-        hasText: new RegExp(escapeRegExp(config.provider), 'i')
-      }).first()
+      option = this.page
+        .getByRole("option")
+        .filter({
+          hasText: new RegExp(escapeRegExp(config.provider), "i"),
+        })
+        .first();
     }
 
     // Verify we found a matching option
-    const optionCount = await option.count()
+    const optionCount = await option.count();
     if (optionCount === 0) {
-      throw new Error(`No provider option found matching "${config.provider}" (display name: "${displayName}")`)
+      throw new Error(
+        `No provider option found matching "${config.provider}" (display name: "${displayName}")`,
+      );
     }
 
-    await option.click()
+    await option.click();
 
     // Wait for dropdown to close after selection
-    await this.page.waitForSelector('[role="listbox"]', { state: 'hidden', timeout: 5000 })
+    await this.page.waitForSelector('[role="listbox"]', { state: "hidden", timeout: 5000 });
   }
 
   /**
-   * Set budget configuration in the form
+   * Set budget lines in the MultiBudgetLines component.
+   * Clicks "Add Budget" for each entry, fills the amount input,
+   * and selects the reset period.
    */
-  private async setBudget(budget: BudgetConfig): Promise<void> {
-    // Find budget max limit input and fill (fill() clears and sets atomically)
-    const budgetInput = this.page.locator('#budgetMaxLimit')
-    await budgetInput.fill(String(budget.maxLimit))
+  private async setBudgets(budgets: BudgetConfig[]): Promise<void> {
+    for (let i = 0; i < budgets.length; i++) {
+      const budget = budgets[i];
+      // Click "Add Budget" button to add a new budget line
+      await this.page.getByTestId("vk-budget-lines-add-btn").click();
+      const amountInput = this.page.getByTestId(`vk-budget-lines-amount-${i}`);
+      await amountInput.fill(String(budget.maxLimit));
+      // Select reset period if specified
+      if (budget.resetDuration) {
+        await this.page.getByTestId(`vk-budget-lines-line-${i}`).getByRole("combobox").click();
+        await this.page
+          .getByRole("option", { name: this.resetDurationLabel(budget.resetDuration), exact: true })
+          .click();
+      }
+    }
+  }
 
-    // Set reset duration if specified - skip for now as default is fine
-    // The reset duration select is complex and default "Monthly" is usually correct
+  private resetDurationLabel(value: string): string {
+    const labels: Record<string, string> = {
+      "1m": "Every Minute",
+      "5m": "Every 5 Minutes",
+      "15m": "Every 15 Minutes",
+      "30m": "Every 30 Minutes",
+      "1h": "Hourly",
+      "6h": "Every 6 Hours",
+      "1d": "Daily",
+      "1w": "Weekly",
+      "1M": "Monthly",
+    };
+    return labels[value] ?? value;
   }
 
   /**
@@ -274,14 +384,14 @@ export class VirtualKeysPage extends BasePage {
   private async setRateLimit(rateLimit: RateLimitConfig): Promise<void> {
     // Set token limits (fill() clears and sets atomically)
     if (rateLimit.tokenMaxLimit !== undefined) {
-      const tokenInput = this.page.locator('#tokenMaxLimit')
-      await tokenInput.fill(String(rateLimit.tokenMaxLimit))
+      const tokenInput = this.page.locator("#tokenMaxLimit");
+      await tokenInput.fill(String(rateLimit.tokenMaxLimit));
     }
 
     // Set request limits (fill() clears and sets atomically)
     if (rateLimit.requestMaxLimit !== undefined) {
-      const requestInput = this.page.locator('#requestMaxLimit')
-      await requestInput.fill(String(rateLimit.requestMaxLimit))
+      const requestInput = this.page.locator("#requestMaxLimit");
+      await requestInput.fill(String(rateLimit.requestMaxLimit));
     }
   }
 
@@ -289,29 +399,29 @@ export class VirtualKeysPage extends BasePage {
    * Set entity assignment (team or customer)
    */
   private async setEntityAssignment(
-    entityType: 'team' | 'customer',
+    entityType: "team" | "customer",
     teamId?: string,
-    customerId?: string
+    customerId?: string,
   ): Promise<void> {
     // Find and click entity type select
-    const entityTypeSelect = this.page.locator('[data-testid="vk-entity-type-select"]')
+    const entityTypeSelect = this.page.locator('[data-testid="vk-entity-type-select"]');
     if (await entityTypeSelect.isVisible()) {
       await fillSelect(
         this.page,
         '[data-testid="vk-entity-type-select"]',
-        entityType === 'team' ? 'Assign to Team' : 'Assign to Customer'
-      )
+        entityType === "team" ? "Assign to Team" : "Assign to Customer",
+      );
 
       // Select team or customer
-      if (entityType === 'team' && teamId) {
-        const teamSelect = this.page.locator('[data-testid="vk-team-select"]')
+      if (entityType === "team" && teamId) {
+        const teamSelect = this.page.locator('[data-testid="vk-team-select"]');
         if (await teamSelect.isVisible()) {
-          await fillSelect(this.page, '[data-testid="vk-team-select"]', teamId)
+          await fillSelect(this.page, '[data-testid="vk-team-select"]', teamId);
         }
-      } else if (entityType === 'customer' && customerId) {
-        const customerSelect = this.page.locator('[data-testid="vk-customer-select"]')
+      } else if (entityType === "customer" && customerId) {
+        const customerSelect = this.page.locator('[data-testid="vk-customer-select"]');
         if (await customerSelect.isVisible()) {
-          await fillSelect(this.page, '[data-testid="vk-customer-select"]', customerId)
+          await fillSelect(this.page, '[data-testid="vk-customer-select"]', customerId);
         }
       }
     }
@@ -322,70 +432,54 @@ export class VirtualKeysPage extends BasePage {
    */
   async editVirtualKey(name: string, updates: Partial<VirtualKeyConfig>): Promise<void> {
     // Wait for any existing toasts to disappear
-    await this.forceCloseToasts()
-
-    // Find and click the edit button using data-testid
-    const editBtn = this.page.getByTestId(`vk-edit-btn-${name}`)
-    await editBtn.waitFor({ state: 'visible', timeout: 10000 })
-    await editBtn.scrollIntoViewIfNeeded()
-    await editBtn.click()
-
-    // Wait for sheet to appear and animation to complete
-    await expect(this.sheet).toBeVisible()
-    await this.waitForSheetAnimation()
+    await this.forceCloseToasts();
+    await this.openVirtualKeyEditor(name);
 
     // Update name using clear() and fill() for cross-platform compatibility
     if (updates.name) {
-      await this.nameInput.clear()
-      await this.nameInput.fill(updates.name)
+      await this.nameInput.clear();
+      await this.nameInput.fill(updates.name);
     }
 
     // Update description using clear() and fill() for cross-platform compatibility
     if (updates.description !== undefined) {
-      await this.descriptionInput.clear()
+      await this.descriptionInput.clear();
       if (updates.description) {
-        await this.descriptionInput.fill(updates.description)
+        await this.descriptionInput.fill(updates.description);
       }
     }
 
     // Update toggle using click() and data-state attribute for reliability
     if (updates.isActive !== undefined) {
       // Check current state using data-state attribute (Radix Switch)
-      const isCurrentlyChecked = await this.isActiveToggle.getAttribute('data-state') === 'checked'
+      const isCurrentlyChecked =
+        (await this.isActiveToggle.getAttribute("data-state")) === "checked";
       if (isCurrentlyChecked !== updates.isActive) {
-        await this.isActiveToggle.click()
+        await this.isActiveToggle.click();
       }
     }
 
-    if (updates.budget) {
-      await this.setBudget(updates.budget)
+    if (updates.budgets && updates.budgets.length > 0) {
+      await this.setBudgets(updates.budgets);
     }
 
     if (updates.rateLimit) {
-      await this.setRateLimit(updates.rateLimit)
+      await this.setRateLimit(updates.rateLimit);
     }
+
+    await expect(this.saveBtn).toBeEnabled({ timeout: 10000 });
 
     // Save changes by clicking the save button
-    await this.saveBtn.click()
+    await this.saveBtn.click();
 
-    // Wait for success toast
-    await this.waitForSuccessToast()
+    await this.waitForSheetClosedAfterSave();
 
-    // Wait for toasts to disappear before continuing
-    await this.dismissToasts()
-
-    // Check if sheet is still visible - it may not auto-close
-    const isSheetVisible = await this.sheet.isVisible().catch(() => false)
-    if (isSheetVisible) {
-      // Try clicking the close button or pressing Escape
-      const closeBtn = this.sheet.locator('button[aria-label*="close"], button:has(svg.lucide-x)').first()
-      if (await closeBtn.isVisible().catch(() => false)) {
-        await closeBtn.click()
-      } else {
-        await this.page.keyboard.press('Escape')
-      }
-      await expect(this.sheet).not.toBeVisible({ timeout: 5000 })
+    const targetName = updates.name ?? name;
+    if (updates.name) {
+      await this.goto();
     }
+    await this.searchVirtualKeys(targetName);
+    await expect(this.getVirtualKeyRow(targetName)).toBeVisible({ timeout: 10000 });
   }
 
   /**
@@ -393,89 +487,86 @@ export class VirtualKeysPage extends BasePage {
    * Polls so we don't rely on a stale locator.
    */
   async waitForVirtualKeyGone(name: string, timeoutMs: number): Promise<boolean> {
-    const deadline = Date.now() + timeoutMs
+    const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-      if ((await this.getVirtualKeyRow(name).count()) === 0) return true
-      await this.page.waitForTimeout(500)
+      if ((await this.getVirtualKeyRow(name).count()) === 0) return true;
+      await this.page.waitForTimeout(500);
     }
-    return false
+    return false;
   }
 
   async deleteVirtualKey(name: string, options?: { requireToast?: boolean }): Promise<void> {
     // Check if virtual key exists first
-    const exists = await this.virtualKeyExists(name)
+    const exists = await this.virtualKeyExists(name);
     if (!exists) {
       // Already deleted or doesn't exist, nothing to do
-      return
+      return;
     }
 
     // Wait for any existing toasts to disappear
-    await this.forceCloseToasts()
+    await this.forceCloseToasts();
 
     // Find the delete button using data-testid (scroll row into view in case table just loaded)
-    const row = this.getVirtualKeyRow(name)
-    await row.scrollIntoViewIfNeeded().catch(() => {})
-    await this.page.waitForTimeout(300)
+    const row = this.getVirtualKeyRow(name);
+    await row.scrollIntoViewIfNeeded().catch(() => {});
+    await this.page.waitForTimeout(300);
 
-    const deleteBtn = this.page.getByTestId(`vk-delete-btn-${name}`)
+    await this.searchVirtualKeys(name).catch(() => {});
+    await expect(row).toBeVisible({ timeout: 10000 });
+
+    const actionsBtn = this.page.getByTestId(`vk-actions-btn-${name}`);
+    await actionsBtn.waitFor({ state: "visible", timeout: 10000 });
+    await actionsBtn.scrollIntoViewIfNeeded();
+    await actionsBtn.click();
+
+    const deleteBtn = this.page.getByTestId(`vk-delete-btn-${name}`);
 
     // Check if button exists; if not, give table a moment and re-check once
-    let btnCount = await deleteBtn.count()
+    let btnCount = await deleteBtn.count();
     if (btnCount === 0) {
-      await this.page.waitForTimeout(800)
-      btnCount = await deleteBtn.count()
+      await this.page.waitForTimeout(800);
+      btnCount = await deleteBtn.count();
     }
     if (btnCount === 0) {
-      const stillExists = await this.virtualKeyExists(name)
-      if (!stillExists) return
-      throw new Error(`Delete button not found for virtual key: ${name}`)
+      const stillExists = await this.virtualKeyExists(name);
+      if (!stillExists) return;
+      throw new Error(`Delete button not found for virtual key: ${name}`);
     }
 
     // Check if button is disabled
-    const isDisabled = await deleteBtn.isDisabled().catch(() => false)
+    const isDisabled = await deleteBtn.isDisabled().catch(() => false);
     if (isDisabled) {
-      throw new Error(`Delete button is disabled for virtual key: ${name} (likely due to RBAC permissions)`)
+      throw new Error(
+        `Delete button is disabled for virtual key: ${name} (likely due to RBAC permissions)`,
+      );
     }
 
-    await deleteBtn.waitFor({ state: 'visible', timeout: 10000 })
-    await deleteBtn.scrollIntoViewIfNeeded()
-    await deleteBtn.click()
+    await deleteBtn.waitFor({ state: "visible", timeout: 10000 });
+    await deleteBtn.scrollIntoViewIfNeeded();
+    await deleteBtn.click();
 
     // Wait for confirmation dialog and confirm deletion (match "Delete" or "Deleting...")
-    const confirmDialog = this.page.locator('[role="alertdialog"]')
-    await confirmDialog.waitFor({ state: 'visible', timeout: 5000 })
-    const confirmBtn = confirmDialog.getByRole('button', { name: /Delete/i })
-    await confirmBtn.waitFor({ state: 'visible', timeout: 2000 })
+    const confirmDialog = this.page.locator('[role="alertdialog"]');
+    await confirmDialog.waitFor({ state: "visible", timeout: 5000 });
+    const confirmBtn = confirmDialog.getByRole("button", { name: /Delete/i });
+    await confirmBtn.waitFor({ state: "visible", timeout: 2000 });
 
-    // Wait for DELETE API response
-    const deleteResponsePromise = this.page.waitForResponse(
-      (response) => {
-        const url = response.url()
-        return url.includes('/api/virtual-keys/') && response.request().method() === 'DELETE'
-      },
-      { timeout: 15000 }
-    )
-    await confirmBtn.click()
-    const deleteResponse = await deleteResponsePromise.catch((err) => {
-      console.warn(`[deleteVirtualKey] No DELETE response captured for "${name}": ${err}`)
-      return null
-    })
-    if (deleteResponse && !deleteResponse.ok()) {
-      console.warn(`[deleteVirtualKey] DELETE responded with ${deleteResponse.status()} for "${name}"`)
-    }
+    await confirmBtn.click();
 
     // Wait for table to refetch and row to disappear (poll fresh locator; avoid stale row reference)
-    const gone = await this.waitForVirtualKeyGone(name, 20000)
+    const gone = await this.waitForVirtualKeyGone(name, 20000);
     if (!gone) {
-      throw new Error(`Virtual key "${name}" still visible after delete`)
+      throw new Error(`Virtual key "${name}" still visible after delete`);
     }
 
     // Optionally wait for success toast (skip in cleanup to avoid false failures)
     if (options?.requireToast !== false) {
-      await this.getToast().waitFor({ state: 'visible', timeout: 5000 }).catch(() => {})
+      await this.getToast()
+        .waitFor({ state: "visible", timeout: 5000 })
+        .catch(() => {});
     }
 
-    await this.dismissToasts()
+    await this.dismissToasts().catch(() => {});
   }
 
   /**
@@ -483,36 +574,28 @@ export class VirtualKeysPage extends BasePage {
    */
   async viewVirtualKey(name: string): Promise<void> {
     // Wait for any existing toasts to disappear
-    await this.forceCloseToasts()
-
-    // Use the edit button to open the detail sheet
-    const editBtn = this.page.getByTestId(`vk-edit-btn-${name}`)
-    await editBtn.waitFor({ state: 'visible', timeout: 10000 })
-    await editBtn.scrollIntoViewIfNeeded()
-    await editBtn.click()
-
-    // Wait for detail sheet to appear
-    await expect(this.sheet).toBeVisible({ timeout: 5000 })
+    await this.forceCloseToasts();
+    await this.openVirtualKeyEditor(name);
   }
 
   /**
    * Get the count of virtual keys in the table
    */
   async getVirtualKeyCount(): Promise<number> {
-    const rows = this.table.locator('tbody tr')
-    const count = await rows.count()
+    const rows = this.table.locator("tbody tr");
+    const count = await rows.count();
 
     if (count === 0) {
-      return 0
+      return 0;
     }
 
     // Check if it's the empty state row
-    const firstRowText = await rows.first().textContent()
-    if (firstRowText?.includes('No virtual keys found')) {
-      return 0
+    const firstRowText = await rows.first().textContent();
+    if (firstRowText?.includes("No virtual keys found")) {
+      return 0;
     }
 
-    return count
+    return count;
   }
 
   /**
@@ -520,12 +603,12 @@ export class VirtualKeysPage extends BasePage {
    */
   async copyVirtualKeyValue(name: string): Promise<void> {
     // Find and click the copy button using data-testid
-    const copyBtn = this.page.getByTestId(`vk-copy-btn-${name}`)
-    await copyBtn.waitFor({ state: 'attached', timeout: 10000 })
-    await copyBtn.scrollIntoViewIfNeeded()
-    await copyBtn.click()
+    const copyBtn = this.page.getByTestId(`vk-copy-btn-${name}`);
+    await copyBtn.waitFor({ state: "attached", timeout: 10000 });
+    await copyBtn.scrollIntoViewIfNeeded();
+    await copyBtn.click();
 
-    await this.waitForSuccessToast('Copied')
+    await this.waitForSuccessToast("Copied");
   }
 
   /**
@@ -533,26 +616,30 @@ export class VirtualKeysPage extends BasePage {
    */
   async toggleKeyVisibility(name: string): Promise<void> {
     // Find and click the visibility toggle button using data-testid
-    const toggleBtn = this.page.getByTestId(`vk-visibility-btn-${name}`)
-    await toggleBtn.waitFor({ state: 'attached', timeout: 10000 })
-    await toggleBtn.scrollIntoViewIfNeeded()
-    await toggleBtn.click()
+    const toggleBtn = this.page.getByTestId(`vk-visibility-btn-${name}`);
+    await toggleBtn.waitFor({ state: "attached", timeout: 10000 });
+    await toggleBtn.scrollIntoViewIfNeeded();
+    await toggleBtn.click();
   }
 
   /**
    * Close any open sheet/dialog
    */
   async closeSheet(): Promise<void> {
-    const isSheetVisible = await this.sheet.isVisible().catch(() => false)
+    const isSheetVisible = await this.sheet.isVisible().catch(() => false);
     if (isSheetVisible) {
       // We have to click on the close button to close the sheet
-      const closeBtn = this.sheet.locator('button[aria-label*="close"], button:has(svg.lucide-x)').first()
+      const closeBtn = this.sheet
+        .locator('button[aria-label*="close"], button:has(svg.lucide-x)')
+        .first();
       if (await closeBtn.isVisible().catch(() => false)) {
-        await closeBtn.click()
+        await closeBtn.click();
       } else {
-        await this.page.keyboard.press('Escape')
+        await this.page.keyboard.press("Escape");
       }
-      await expect(this.sheet).not.toBeVisible({ timeout: 5000 }).catch(() => {})
+      await expect(this.sheet)
+        .not.toBeVisible({ timeout: 5000 })
+        .catch(() => {});
     }
   }
 
@@ -560,25 +647,25 @@ export class VirtualKeysPage extends BasePage {
    * Get all virtual key names from the table
    */
   async getAllVirtualKeyNames(): Promise<string[]> {
-    const names: string[] = []
-    const count = await this.getVirtualKeyCount()
+    const names: string[] = [];
+    const count = await this.getVirtualKeyCount();
 
-    if (count === 0) return names
+    if (count === 0) return names;
 
     // Find all delete buttons which have the VK name in their test-id
-    const deleteButtons = this.page.locator('[data-testid^="vk-delete-btn-"]')
-    const buttonCount = await deleteButtons.count()
+    const deleteButtons = this.page.locator('[data-testid^="vk-delete-btn-"]');
+    const buttonCount = await deleteButtons.count();
 
     for (let i = 0; i < buttonCount; i++) {
-      const testId = await deleteButtons.nth(i).getAttribute('data-testid')
+      const testId = await deleteButtons.nth(i).getAttribute("data-testid");
       if (testId) {
         // Extract name from test-id: "vk-delete-btn-{name}"
-        const name = testId.replace('vk-delete-btn-', '')
-        names.push(name)
+        const name = testId.replace("vk-delete-btn-", "");
+        names.push(name);
       }
     }
 
-    return names
+    return names;
   }
 
   /**
@@ -586,59 +673,61 @@ export class VirtualKeysPage extends BasePage {
    */
   async cleanupAllVirtualKeys(): Promise<void> {
     // First close any open sheet
-    await this.closeSheet()
+    await this.closeSheet();
 
     // Wait for any toasts to clear
-    await this.dismissToasts()
+    await this.dismissToasts();
 
     // Keep trying until no more VKs exist
-    let attempts = 0
-    const maxAttempts = 10 // Prevent infinite loops
+    let attempts = 0;
+    const maxAttempts = 10; // Prevent infinite loops
 
     while (attempts < maxAttempts) {
       // Get current VK names (refresh the list each iteration)
-      const names = await this.getAllVirtualKeyNames()
+      const names = await this.getAllVirtualKeyNames();
 
       if (names.length === 0) {
         // No more VKs to delete
-        break
+        break;
       }
 
       // Delete each one
       for (const name of names) {
         try {
           // Check if VK still exists before trying to delete
-          const exists = await this.virtualKeyExists(name)
+          const exists = await this.virtualKeyExists(name);
           if (!exists) {
             // Already deleted, skip
-            continue
+            continue;
           }
 
           // Make sure sheet is closed before each delete
-          await this.closeSheet()
-          await this.deleteVirtualKey(name)
+          await this.closeSheet();
+          await this.deleteVirtualKey(name);
 
           // Wait a bit for table to refresh
-          await this.page.waitForTimeout(500)
+          await this.page.waitForTimeout(500);
         } catch (error) {
           // If delete fails, try to close sheet and continue
-          await this.closeSheet()
-          const errorMsg = error instanceof Error ? error.message : String(error)
-          console.log(`Failed to delete virtual key: ${name} - ${errorMsg}`)
+          await this.closeSheet();
+          const errorMsg = error instanceof Error ? error.message : String(error);
+          console.log(`Failed to delete virtual key: ${name} - ${errorMsg}`);
           // Continue with next VK
         }
       }
 
-      attempts++
+      attempts++;
 
       // Wait a bit before next iteration to allow table to refresh
-      await this.page.waitForTimeout(1000)
+      await this.page.waitForTimeout(1000);
     }
 
     if (attempts >= maxAttempts) {
-      const remainingNames = await this.getAllVirtualKeyNames()
+      const remainingNames = await this.getAllVirtualKeyNames();
       if (remainingNames.length > 0) {
-        console.log(`Warning: Could not delete all virtual keys after ${maxAttempts} attempts. Remaining: ${remainingNames.join(', ')}`)
+        console.log(
+          `Warning: Could not delete all virtual keys after ${maxAttempts} attempts. Remaining: ${remainingNames.join(", ")}`,
+        );
       }
     }
   }
@@ -647,35 +736,34 @@ export class VirtualKeysPage extends BasePage {
    * Clean up specific virtual keys by name
    */
   async cleanupVirtualKeys(names: string[]): Promise<void> {
-    if (names.length === 0) return
+    if (names.length === 0) return;
 
     // Ensure we're on the virtual keys list with a fresh load so table is ready
-    await this.goto()
-    await this.closeSheet()
-    await this.dismissToasts()
-    await this.table.waitFor({ state: 'visible', timeout: 10000 }).catch(() => {})
-    await this.page.waitForTimeout(500)
+    await this.goto();
+    await this.closeSheet();
+    await this.dismissToasts().catch(() => {});
+    await this.table.waitFor({ state: "visible", timeout: 10000 }).catch(() => {});
 
     for (const name of names) {
       const tryDelete = async (): Promise<void> => {
-        const exists = await this.virtualKeyExists(name)
-        if (!exists) return
-        await this.closeSheet()
-        await this.deleteVirtualKey(name, { requireToast: false })
-      }
+        const exists = await this.virtualKeyExists(name);
+        if (!exists) return;
+        await this.closeSheet();
+        await this.deleteVirtualKey(name, { requireToast: false });
+      };
 
       try {
-        await tryDelete()
+        await tryDelete();
       } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error)
-        console.error(`[CLEANUP ERROR] Failed to delete virtual key: ${name} - ${errorMsg}`)
-        await this.closeSheet()
-        await this.page.waitForTimeout(1000)
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        console.error(`[CLEANUP ERROR] Failed to delete virtual key: ${name} - ${errorMsg}`);
+        await this.closeSheet();
+        await this.page.waitForTimeout(1000);
         try {
-          await tryDelete()
+          await tryDelete();
         } catch (retryError) {
-          const retryMsg = retryError instanceof Error ? retryError.message : String(retryError)
-          console.error(`[CLEANUP ERROR] Retry failed for virtual key: ${name} - ${retryMsg}`)
+          const retryMsg = retryError instanceof Error ? retryError.message : String(retryError);
+          console.error(`[CLEANUP ERROR] Retry failed for virtual key: ${name} - ${retryMsg}`);
         }
       }
     }

--- a/tests/e2e/features/virtual-keys/virtual-keys.data.ts
+++ b/tests/e2e/features/virtual-keys/virtual-keys.data.ts
@@ -39,10 +39,10 @@ export function createVirtualKeyWithProvider(
 }
 
 /**
- * Factory function to create virtual key with budget
+ * Factory function to create virtual key with one or more budget lines
  */
 export function createVirtualKeyWithBudget(
-  budget: BudgetConfig,
+  budgets: BudgetConfig[],
   vkOverrides: Partial<VirtualKeyConfig> = {}
 ): VirtualKeyConfig {
   const timestamp = Date.now()
@@ -50,7 +50,7 @@ export function createVirtualKeyWithBudget(
     name: `Test VK Budget ${timestamp}`,
     description: 'Virtual key with budget configuration',
     isActive: true,
-    budget,
+    budgets,
     ...vkOverrides,
   }
 }
@@ -132,6 +132,10 @@ export const SAMPLE_BUDGETS: Record<string, BudgetConfig> = {
   weekly: {
     maxLimit: 200,
     resetDuration: '1w',
+  },
+  everyMinute: {
+    maxLimit: 5,
+    resetDuration: '1m',
   },
 }
 

--- a/tests/e2e/features/virtual-keys/virtual-keys.spec.ts
+++ b/tests/e2e/features/virtual-keys/virtual-keys.spec.ts
@@ -104,9 +104,9 @@ test.describe('Virtual Keys', () => {
   })
 
   test.describe('Virtual Key with Budget', () => {
-    test('should create virtual key with small budget', async ({ virtualKeysPage }) => {
-      const vkData = createVirtualKeyWithBudget(SAMPLE_BUDGETS.small, {
-        name: `Small Budget VK ${Date.now()}`,
+    test('should create virtual key with daily budget', async ({ virtualKeysPage }) => {
+      const vkData = createVirtualKeyWithBudget([SAMPLE_BUDGETS.daily], {
+        name: `Daily Budget VK ${Date.now()}`,
       })
 
       createdVKs.push(vkData.name)
@@ -118,14 +118,14 @@ test.describe('Virtual Keys', () => {
       // Verify budget was saved correctly
       await virtualKeysPage.viewVirtualKey(vkData.name)
       await virtualKeysPage.waitForSheetAnimation()
-      const budgetInput = virtualKeysPage.page.locator('#budgetMaxLimit')
-      await expect(budgetInput).toHaveValue(String(SAMPLE_BUDGETS.small.maxLimit))
+      const amountInput = virtualKeysPage.page.getByTestId('vk-budget-lines-amount-0')
+      await expect(amountInput).toHaveValue(String(SAMPLE_BUDGETS.daily.maxLimit))
       await virtualKeysPage.closeSheet()
     })
 
-    test('should create virtual key with medium budget', async ({ virtualKeysPage }) => {
-      const vkData = createVirtualKeyWithBudget(SAMPLE_BUDGETS.medium, {
-        name: `Medium Budget VK ${Date.now()}`,
+    test('should create virtual key with every-minute budget', async ({ virtualKeysPage }) => {
+      const vkData = createVirtualKeyWithBudget([SAMPLE_BUDGETS.everyMinute], {
+        name: `Minute Budget VK ${Date.now()}`,
       })
 
       createdVKs.push(vkData.name)
@@ -133,18 +133,32 @@ test.describe('Virtual Keys', () => {
 
       const vkExists = await virtualKeysPage.virtualKeyExists(vkData.name)
       expect(vkExists).toBe(true)
+
+      // Verify budget was saved correctly
+      await virtualKeysPage.viewVirtualKey(vkData.name)
+      await virtualKeysPage.waitForSheetAnimation()
+      const amountInput = virtualKeysPage.page.getByTestId('vk-budget-lines-amount-0')
+      await expect(amountInput).toHaveValue(String(SAMPLE_BUDGETS.everyMinute.maxLimit))
+      await virtualKeysPage.closeSheet()
     })
 
-    test('should create virtual key with daily budget', async ({ virtualKeysPage }) => {
-      const vkData = createVirtualKeyWithBudget(SAMPLE_BUDGETS.daily, {
-        name: `Daily Budget VK ${Date.now()}`,
-      })
+    test('should create virtual key with multiple budgets', async ({ virtualKeysPage }) => {
+      const vkData = createVirtualKeyWithBudget(
+        [SAMPLE_BUDGETS.daily, SAMPLE_BUDGETS.everyMinute],
+        { name: `Multi Budget VK ${Date.now()}` }
+      )
 
       createdVKs.push(vkData.name)
       await virtualKeysPage.createVirtualKey(vkData)
 
       const vkExists = await virtualKeysPage.virtualKeyExists(vkData.name)
       expect(vkExists).toBe(true)
+
+      await virtualKeysPage.viewVirtualKey(vkData.name)
+      await virtualKeysPage.waitForSheetAnimation()
+      await expect(virtualKeysPage.page.getByTestId('vk-budget-lines-amount-0')).toHaveValue(String(SAMPLE_BUDGETS.daily.maxLimit))
+      await expect(virtualKeysPage.page.getByTestId('vk-budget-lines-amount-1')).toHaveValue(String(SAMPLE_BUDGETS.everyMinute.maxLimit))
+      await virtualKeysPage.closeSheet()
     })
   })
 
@@ -213,7 +227,7 @@ test.describe('Virtual Keys', () => {
         name: `Full Config VK ${Date.now()}`,
         description: 'Virtual key with all configurations',
         isActive: true,
-        budget: SAMPLE_BUDGETS.medium,
+        budgets: [SAMPLE_BUDGETS.medium],
         rateLimit: SAMPLE_RATE_LIMITS.moderate,
       })
 
@@ -455,8 +469,9 @@ test.describe('Form Validation', () => {
     // Fill name (required field)
     await virtualKeysPage.nameInput.fill(`Valid Budget Test ${Date.now()}`)
 
-    // Fill budget
-    const budgetInput = virtualKeysPage.page.locator('#budgetMaxLimit')
+    // Add a budget line and fill amount
+    await virtualKeysPage.page.getByTestId('vk-budget-lines-add-btn').click()
+    const budgetInput = virtualKeysPage.page.getByTestId('vk-budget-lines-amount-0')
     await expect(budgetInput).toBeVisible({ timeout: 5000 })
     await budgetInput.fill('100')
 
@@ -539,7 +554,7 @@ test.describe('Provider Management', () => {
     const vkName = `Provider Budget VK ${Date.now()}`
     const vkData = createVirtualKeyWithProvider('openai', {
       name: vkName,
-      budget: SAMPLE_BUDGETS.small,
+      budgets: [SAMPLE_BUDGETS.small],
     })
 
     providerVKs.push(vkName)
@@ -547,7 +562,7 @@ test.describe('Provider Management', () => {
 
     // Edit the virtual key
     await virtualKeysPage.editVirtualKey(vkName, {
-      budget: SAMPLE_BUDGETS.large,
+      budgets: [SAMPLE_BUDGETS.large],
     })
 
     // Verify it still exists

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,12 +1,48 @@
-import { defineConfig, devices } from '@playwright/test'
+import { defineConfig, devices, type PlaywrightTestConfig } from '@playwright/test'
+import { existsSync } from 'fs'
+import { resolve } from 'path'
+
+const enterpriseFeaturesDir = resolve(__dirname, '../../../bifrost-enterprise/e2e/features')
+const includeEnterprise = process.env.BIFROST_E2E_INCLUDE_ENTERPRISE === '1' && existsSync(enterpriseFeaturesDir)
+
+const projects: NonNullable<PlaywrightTestConfig['projects']> = [
+  {
+    name: 'chromium',
+    testDir: './features',
+    use: { ...devices['Desktop Chrome'] },
+    testIgnore: ['**/config/**', '**/plugins/**', '**/virtual-keys/**', '**/mcp-registry/**', '**/model-limits/**', '**/providers/**'],
+  },
+  {
+    name: 'chromium-serial',
+    testDir: './features',
+    use: { ...devices['Desktop Chrome'] },
+    testMatch: ['**/plugins/**/*.spec.ts', '**/virtual-keys/**/*.spec.ts', '**/mcp-registry/**/*.spec.ts', '**/model-limits/**/*.spec.ts', '**/providers/**/*.spec.ts'],
+    fullyParallel: false,
+  },
+  {
+    name: 'chromium-config',
+    testDir: './features',
+    use: { ...devices['Desktop Chrome'] },
+    testMatch: ['**/config/**/*.spec.ts'],
+    dependencies: ['chromium', 'chromium-serial'],
+  },
+]
+
+if (includeEnterprise) {
+  projects.push({
+    name: 'chromium-enterprise',
+    testDir: enterpriseFeaturesDir,
+    use: { ...devices['Desktop Chrome'] },
+    testMatch: ['**/*.spec.ts'],
+  })
+}
 
 /**
  * Playwright configuration for Bifrost E2E tests
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
-  // Look for test files in the features directory
-  testDir: './features',
+  testDir: '.',
 
   // Run tests in files in parallel
   fullyParallel: true,
@@ -53,6 +89,9 @@ export default defineConfig({
 
     // Timeout for navigation
     navigationTimeout: 30000,
+
+    // Grant clipboard permissions so copy-to-clipboard tests work on localhost
+    permissions: ['clipboard-read', 'clipboard-write'],
   },
 
   // Global timeout for each test
@@ -63,35 +102,8 @@ export default defineConfig({
     timeout: 10000,
   },
 
-  // Configure projects: run all tests first, then config last (via dependency order)
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-      testIgnore: ['**/config/**', '**/plugins/**', '**/virtual-keys/**', '**/mcp-registry/**', '**/model-limits/**', '**/providers/**'],
-    },
-    {
-      name: 'chromium-serial',
-      use: { ...devices['Desktop Chrome'] },
-      testMatch: ['**/plugins/**/*.spec.ts', '**/virtual-keys/**/*.spec.ts', '**/mcp-registry/**/*.spec.ts', '**/model-limits/**/*.spec.ts', '**/providers/**/*.spec.ts'],
-      fullyParallel: false,
-    },
-    {
-      name: 'chromium-config',
-      use: { ...devices['Desktop Chrome'] },
-      testMatch: ['**/config/**/*.spec.ts'],
-      dependencies: ['chromium', 'chromium-serial'],
-    },
-    // Uncomment for additional browser testing
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] },
-    // },
-    // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] },
-    // },
-  ],
+  // Configure projects: run all tests first, then config last (via dependency order).
+  projects,
 
   // Run local dev server before starting tests 
   // Set SKIP_WEB_SERVER=1 to skip auto-starting the dev server

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -948,7 +948,6 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 
 																{/* Provider Budget Configuration */}
 																<MultiBudgetLines
-																	id={`providerBudget-${index}`}
 																	data-testid={`vk-provider-budget-${index}`}
 																	label="Provider Budget"
 																	lines={
@@ -1234,7 +1233,6 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 								{/* Budget Configuration */}
 								<div className="space-y-4">
 									<MultiBudgetLines
-										id="vkBudget"
 										data-testid="vk-budget-lines"
 										label="Budget Configuration"
 										lines={form.watch("budgets") ?? []}

--- a/ui/components/ui/multibudgets.tsx
+++ b/ui/components/ui/multibudgets.tsx
@@ -11,7 +11,6 @@ export interface BudgetLineEntry {
 }
 
 interface MultiBudgetLinesProps {
-	id?: string;
 	"data-testid"?: string;
 	label?: string;
 	lines: BudgetLineEntry[];
@@ -22,7 +21,6 @@ interface MultiBudgetLinesProps {
 }
 
 export default function MultiBudgetLines({
-	id,
 	"data-testid": testId,
 	label = "Budget Configuration",
 	lines,
@@ -75,12 +73,12 @@ export default function MultiBudgetLines({
 				<Label className="text-sm font-medium">{label}</Label>
 				<div className="flex items-center gap-2">
 					{onReset && (showReset ?? true) && (
-						<Button data-testid={`${id}-reset-btn`} type="button" variant="ghost" size="sm" onClick={onReset}>
+						<Button data-testid={`${testId}-reset-btn`} type="button" variant="ghost" size="sm" onClick={onReset}>
 							<RotateCcw className="mr-1 h-3 w-3" />
 							Reset
 						</Button>
 					)}
-					<Button data-testid={`${id}-add-btn`} variant="outline" size="sm" type="button" onClick={addLine}>
+					<Button data-testid={`${testId}-add-btn`} variant="outline" size="sm" type="button" onClick={addLine}>
 						<Plus className="mr-1 h-3 w-3" />
 						Add Budget
 					</Button>
@@ -94,11 +92,12 @@ export default function MultiBudgetLines({
 			{lines.map((line, index) => {
 				const isDuplicate = (usedDurations.get(line.reset_duration) || 0) > 1;
 				return (
-					<div key={index} className="space-y-1">
+					<div key={index} className="space-y-1" data-testid={`${testId}-line-${index}`}>
 						<div className="flex items-end gap-2">
 							<div className="flex-1">
 								<NumberAndSelect
-									id={`${id}-${index}`}
+									id={`${testId}-${index}`}
+                                    dataTestId={`${testId}-amount-${index}`}
 									labelClassName="font-normal"
 									label="Maximum Spend (USD)"
 									value={line.max_limit}
@@ -109,7 +108,7 @@ export default function MultiBudgetLines({
 								/>
 							</div>
 							<Button
-								data-testid={`${id}-remove-${index}`}
+								data-testid={`${testId}-remove-${index}`}
 								aria-label={`Remove budget ${index + 1}`}
 								variant="ghost"
 								size="icon"


### PR DESCRIPTION
## Summary

Updates the virtual keys E2E test suite to align with a refactored `MultiBudgetLines` component that supports multiple budget lines per virtual key, and fixes several test selector and navigation issues.

## Changes

- Replaced the single `budget: BudgetConfig` field on `VirtualKeyConfig` with `budgets: BudgetConfig[]` to support multiple budget lines, updating all test data factories, specs, and page object methods accordingly
- Replaced the `setBudget` page method with `setBudgets`, which iterates over budget entries, clicks "Add Budget" for each, fills the amount input, and selects the reset period via a `resetDurationLabel` lookup map
- Updated the virtual key sheet selector from `vk-sheet` to `vk-sheet-content` in both `selectors.ts` and the page object constructor
- Fixed the navigation path in `goto()` from `/workspace/virtual-keys` to `/workspace/governance/virtual-keys`
- Added `data-testid` attributes to individual budget line containers (`${testId}-line-${index}`) and amount inputs (`${testId}-amount-${index}`) in `MultiBudgetLines`, and made `data-testid` the authoritative prop (removing the optional `id` prop)
- Removed the `id` prop from `MultiBudgetLines` usages in `virtualKeySheet.tsx`, switching all button and input test IDs to derive from `data-testid`
- Added a new `everyMinute` sample budget and updated budget tests to cover daily, every-minute, and multi-budget scenarios
- Replaced toast-based success signals with DOM-state assertions (row visibility, sheet closure) to make tests more resilient to animation timing
- Added `openVirtualKeyEditor` and `openModelLimitActions` helpers that open row action dropdowns before clicking edit/delete, reflecting a UI change where those buttons are now nested in a dropdown menu
- Added `searchVirtualKeys` and `clearTableFilters` helpers to scope table interactions to the target row before acting on it
- Standardized quote style from single to double quotes throughout the virtual keys page object

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs
- [x] Tests

## How to test

```sh
cd tests/e2e
npx playwright test features/virtual-keys/virtual-keys.spec.ts
```

Verify that all virtual key budget tests pass, including the new multi-budget test, and that the sheet opens and closes correctly using the updated `vk-sheet-content` selector.

## Breaking changes

- [ ] Yes
- [x] No

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable