### PR TITLE
fix: remove fallbacks key from gemini requests

### DIFF
--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -48,7 +48,10 @@ func setGeminiRequestBody(req *fasthttp.Request, bodyReader io.Reader, bodySize 
 
 func normalizeRawGenerateContentBody(ctx *schemas.BifrostContext, body []byte) []byte {
 	if rawBody, ok := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); ok && rawBody {
-		return NormalizeRawGenerateContentRequestForCompatibility(body)
+		body = NormalizeRawGenerateContentRequestForCompatibility(body)
+	}
+	if updated, err := providerUtils.DeleteJSONField(body, "fallbacks"); err == nil {
+		body = updated
 	}
 	return body
 }
@@ -2218,6 +2221,8 @@ func (provider *GeminiProvider) VideoGeneration(ctx *schemas.BifrostContext, key
 		return nil, bifrostErr
 	}
 
+	jsonData = normalizeRawGenerateContentBody(ctx, jsonData)
+
 	// Create HTTP request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -2456,7 +2461,7 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 
 	var jsonData []byte
 	if rawBody, ok := providerUtils.CheckAndGetRawRequestBody(ctx, request); ok && len(rawBody) > 0 {
-		jsonData = rawBody
+		jsonData = NormalizeRawGenerateContentRequestForCompatibility(rawBody)
 	}
 
 	// Validate that either InputFileID or Requests is provided, but not both
@@ -2556,6 +2561,10 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 		if err != nil {
 			return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderRequestMarshal, err)
 		}
+	}
+
+	if updated, err := providerUtils.DeleteJSONField(jsonData, "fallbacks"); err == nil {
+		jsonData = updated
 	}
 
 	// Create HTTP request

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -3142,6 +3142,95 @@ func TestGenAIFallbacks_PreservedInBifrostResponsesRequest(t *testing.T) {
 	assert.Equal(t, "gemini-3-flash-preview", bifrostReq.Fallbacks[0].Model)
 }
 
+// TestNormalizeRawGenerateContentRequestForCompatibility tests that Bifrost-internal fields
+// (fallbacks) and provider-incompatible OpenAI fields (responseLogprobs, logprobs, presencePenalty,
+// frequencyPenalty) are stripped before the raw body is forwarded to the Gemini API.
+//
+// Regression: fallbacks was forwarded verbatim, causing Gemini to return 400
+// "Unknown name \"fallbacks\": Cannot find field."
+func TestNormalizeRawGenerateContentRequestForCompatibility(t *testing.T) {
+	parseBody := func(t *testing.T, b []byte) map[string]interface{} {
+		t.Helper()
+		var m map[string]interface{}
+		require.NoError(t, json.Unmarshal(b, &m))
+		return m
+	}
+	genConfig := func(m map[string]interface{}) map[string]interface{} {
+		gc, _ := m["generationConfig"].(map[string]interface{})
+		return gc
+	}
+
+	tests := []struct {
+		name     string
+		input    string
+		validate func(t *testing.T, result map[string]interface{})
+	}{
+		{
+			name:  "StripsFallbacksField",
+			input: `{"contents":[{"parts":[{"text":"Hello"}]}],"fallbacks":["openai/gpt-4o","vertex/gemini-2-flash"]}`,
+			validate: func(t *testing.T, m map[string]interface{}) {
+				assert.NotContains(t, m, "fallbacks", "fallbacks must not be forwarded to Gemini")
+				assert.Contains(t, m, "contents", "contents must be preserved")
+			},
+		},
+		{
+			name:  "StripsGenerationConfigCompatFields",
+			input: `{"contents":[{"parts":[{"text":"Hi"}]}],"generationConfig":{"temperature":0.7,"responseLogprobs":true,"logprobs":5,"presencePenalty":0.5,"frequencyPenalty":0.3}}`,
+			validate: func(t *testing.T, m map[string]interface{}) {
+				gc := genConfig(m)
+				require.NotNil(t, gc)
+				assert.NotContains(t, gc, "responseLogprobs")
+				assert.NotContains(t, gc, "logprobs")
+				assert.NotContains(t, gc, "presencePenalty")
+				assert.NotContains(t, gc, "frequencyPenalty")
+				assert.Contains(t, gc, "temperature", "valid fields must be preserved")
+			},
+		},
+		{
+			name:  "StripsFallbacksAlongsideCompatFields",
+			input: `{"contents":[{"parts":[{"text":"Hi"}]}],"fallbacks":["openai/gpt-4o"],"generationConfig":{"temperature":0.5,"presencePenalty":0.2}}`,
+			validate: func(t *testing.T, m map[string]interface{}) {
+				assert.NotContains(t, m, "fallbacks")
+				gc := genConfig(m)
+				require.NotNil(t, gc)
+				assert.NotContains(t, gc, "presencePenalty")
+				assert.Contains(t, gc, "temperature")
+			},
+		},
+		{
+			name:  "PreservesValidBodyWithNoStrippableFields",
+			input: `{"contents":[{"parts":[{"text":"Hi"}]}],"generationConfig":{"temperature":0.7,"maxOutputTokens":1000}}`,
+			validate: func(t *testing.T, m map[string]interface{}) {
+				assert.Contains(t, m, "contents")
+				gc := genConfig(m)
+				require.NotNil(t, gc)
+				assert.Contains(t, gc, "temperature")
+				assert.Contains(t, gc, "maxOutputTokens")
+			},
+		},
+		{
+			name:  "HandlesBodyWithOnlyFallbacks",
+			input: `{"fallbacks":["openai/gpt-4o"]}`,
+			validate: func(t *testing.T, m map[string]interface{}) {
+				assert.NotContains(t, m, "fallbacks")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := gemini.NormalizeRawGenerateContentRequestForCompatibility([]byte(tt.input))
+			require.NotEmpty(t, result)
+			tt.validate(t, parseBody(t, result))
+		})
+	}
+
+	t.Run("EmptyBodyReturnsEmpty", func(t *testing.T) {
+		assert.Empty(t, gemini.NormalizeRawGenerateContentRequestForCompatibility(nil))
+		assert.Empty(t, gemini.NormalizeRawGenerateContentRequestForCompatibility([]byte{}))
+	})
+}
+
 // TestFunctionCallingConfigModeAny_RoundTrip verifies that FunctionCallingConfigMode.ANY and
 // AllowedFunctionNames survive the Gemini→Bifrost→Gemini round-trip on the GenAI passthrough path.
 // Regression: ANY was silently downgraded to AUTO (missing case in convertGeminiToolConfigToToolChoice)

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -1166,6 +1166,7 @@ type GeminiEmbeddingRequest struct {
 	Title                *string                `json:"title,omitempty"`
 	OutputDimensionality *int                   `json:"outputDimensionality,omitempty"`
 	Model                string                 `json:"model,omitempty"`
+	Fallbacks            []string               `json:"fallbacks,omitempty"`
 	ExtraParams          map[string]interface{} `json:"-"` // Optional: Extra parameters
 }
 
@@ -2308,7 +2309,8 @@ type GeminiVideoGenerationRequest struct {
 	Model       string                          `json:"model,omitempty"` // Model field for explicit model specification
 	Instances   []GeminiVideoGenerationInstance `json:"instances"`
 	Parameters  *VideoGenerationParameters      `json:"parameters,omitempty"` // Optional parameters including reference images
-	ExtraParams map[string]interface{}          `json:"-"`                    // Optional: Extra parameters
+	Fallbacks   []string                        `json:"fallbacks,omitempty"`
+	ExtraParams map[string]interface{}          `json:"-"` // Optional: Extra parameters
 }
 
 func (r *GeminiVideoGenerationRequest) GetExtraParams() map[string]interface{} {

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -58,6 +58,7 @@ func NormalizeRawGenerateContentRequestForCompatibility(jsonBody []byte) []byte 
 		"generationConfig.logprobs",
 		"generationConfig.presencePenalty",
 		"generationConfig.frequencyPenalty",
+		"fallbacks",
 	} {
 		if providerUtils.JSONFieldExists(out, path) {
 			if updated, err := providerUtils.DeleteJSONField(out, path); err == nil {


### PR DESCRIPTION
## Summary

Ensures the `fallbacks` field is stripped from request bodies sent to the Gemini provider, preventing unrecognized fields from being forwarded to the Gemini API. Also applies raw body normalization to the `VideoGeneration` endpoint and normalizes raw bodies in `BatchCreate` before further processing.

## Changes

- `normalizeRawGenerateContentBody` now unconditionally removes the `fallbacks` field from the JSON body, regardless of whether raw body mode is active.
- `VideoGeneration` now calls `normalizeRawGenerateContentBody` before constructing the HTTP request, bringing it in line with other endpoints.
- `BatchCreate` applies `NormalizeRawGenerateContentRequestForCompatibility` to raw request bodies immediately upon extraction, and explicitly deletes the `fallbacks` field from the final `jsonData` before sending.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a request to the Gemini `VideoGeneration` or `BatchCreate` endpoints with a `fallbacks` field included in the request body and verify it is not forwarded to the Gemini API.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable