### PR TITLE
harness updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1714,6 +1714,11 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 	VIEWER_PORT_VAL="$(or $(VIEWER_PORT),8090)"; \
 	STARTED_BY_US=0; \
 	cleanup() { \
+		if [ -f tmp/harness-monitor.pid ]; then \
+			MPID=$$(cat tmp/harness-monitor.pid); \
+			kill $$MPID 2>/dev/null; \
+			rm -f tmp/harness-monitor.pid; \
+		fi; \
 		if [ -f tmp/harness-viewer.pid ]; then \
 			VPID=$$(cat tmp/harness-viewer.pid); \
 			kill $$VPID 2>/dev/null; \
@@ -1744,6 +1749,25 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 		fi; \
 	}; \
 	trap cleanup EXIT INT TERM HUP; \
+	PICKED_FEATURES=""; \
+	if [ -t 0 ] && [ -t 1 ] && [ -z "$$CI" ] && [ -z "$(CI)" ] \
+	   && [ -z "$(PROVIDER)" ] && [ -z "$(FEATURE)" ] && [ -z "$(FOLDER)" ] \
+	   && [ -z "$(RERUN_FAILED)" ]; then \
+		$(USE_NODE); \
+		PICKED_FEATURES=$$(node tests/e2e/api/runners/pick-features.mjs); \
+		PICK_RC=$$?; \
+		case $$PICK_RC in \
+			0) ;; \
+			1) $(ECHO) "$(YELLOW)Cancelled.$(NC)"; exit 1 ;; \
+			2) ;; \
+			*) exit $$PICK_RC ;; \
+		esac; \
+		if [ -n "$$PICKED_FEATURES" ]; then \
+			$(ECHO) "$(GREEN)Modalities: $$PICKED_FEATURES$(NC)"; \
+		else \
+			$(ECHO) "$(GREEN)Modalities: all (no filter)$(NC)"; \
+		fi; \
+	fi; \
 	if curl -fsS --max-time 2 "$$BASE_URL_VAL/health" > /dev/null 2>&1; then \
 		$(ECHO) "$(GREEN)Bifrost already running at $$BASE_URL_VAL$(NC)"; \
 	else \
@@ -1764,13 +1788,16 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 		fi; \
 	fi; \
 	COLLECTION_FILE="tests/e2e/api/collections/provider-harness.json"; \
-	if [ -n "$(PROVIDER)" ] || [ -n "$(FEATURE)" ] || [ -n "$(RERUN_FAILED)" ]; then \
-		$(ECHO) "$(CYAN)Filtering collection (provider=$(PROVIDER), feature=$(FEATURE), rerun-failed=$(RERUN_FAILED))...$(NC)"; \
+	FEATURE_ANY_FLAG=""; \
+	if [ -n "$$PICKED_FEATURES" ]; then FEATURE_ANY_FLAG="--feature-any $$PICKED_FEATURES"; fi; \
+	if [ -n "$(PROVIDER)" ] || [ -n "$(FEATURE)" ] || [ -n "$(RERUN_FAILED)" ] || [ -n "$$PICKED_FEATURES" ]; then \
+		$(ECHO) "$(CYAN)Filtering collection (provider=$(PROVIDER), feature=$(FEATURE), feature-any=$$PICKED_FEATURES, rerun-failed=$(RERUN_FAILED))...$(NC)"; \
 		$(USE_NODE); node tests/e2e/api/runners/filter-collection.mjs \
 			--source tests/e2e/api/collections/provider-harness.json \
 			--out tmp/harness-filtered.json \
 			$(if $(PROVIDER),--provider $(PROVIDER),) \
 			$(if $(FEATURE),--feature "$(FEATURE)",) \
+			$$FEATURE_ANY_FLAG \
 			$(if $(RERUN_FAILED),--rerun-failed --report tmp/newman-report.json,) || { $(ECHO) "$(RED)Filter step failed$(NC)"; exit 1; }; \
 		COLLECTION_FILE="tmp/harness-filtered.json"; \
 	fi; \
@@ -1814,20 +1841,36 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 			$(ECHO) "$(RED)No provider runs were launched. Check PROVIDER/FEATURE/FOLDER filters.$(NC)"; \
 			exit 1; \
 		fi; \
+		if [ -t 1 ] && [ -z "$$CI" ] && [ -z "$(CI)" ]; then \
+			$(USE_NODE); node tests/e2e/api/runners/harness-monitor.mjs \
+				--mode parallel \
+				--providers "$$PROVIDERS" \
+				--tmp-dir tmp \
+				--status-file tmp/parallel-status \
+				--launched $$LAUNCHED \
+				< /dev/null > /dev/tty 2>&1 & \
+			echo $$! > tmp/harness-monitor.pid; \
+		fi; \
 		PFAILED=0; \
 		while read pidp; do \
 			pid="$${pidp%%:*}"; \
 			p="$${pidp#*:}"; \
 			if wait "$$pid"; then \
 				echo "$$p:pass" >> tmp/parallel-status; \
-				$(ECHO) "$(GREEN)[$$p] passed$(NC)"; \
+				if [ ! -f tmp/harness-monitor.pid ]; then $(ECHO) "$(GREEN)[$$p] passed$(NC)"; fi; \
 			else \
 				echo "$$p:fail" >> tmp/parallel-status; \
-				$(ECHO) "$(RED)[$$p] failed$(NC)"; \
+				if [ ! -f tmp/harness-monitor.pid ]; then $(ECHO) "$(RED)[$$p] failed$(NC)"; fi; \
 				PFAILED=$$((PFAILED+1)); \
 			fi; \
-			tail -n 20 "tmp/newman-cli-$$p.log" 2>/dev/null; \
+			if [ ! -f tmp/harness-monitor.pid ]; then tail -n 20 "tmp/newman-cli-$$p.log" 2>/dev/null; fi; \
 		done < tmp/parallel-pids; \
+		if [ -f tmp/harness-monitor.pid ]; then \
+			MPID=$$(cat tmp/harness-monitor.pid); \
+			kill -TERM $$MPID 2>/dev/null; \
+			wait $$MPID 2>/dev/null || true; \
+			rm -f tmp/harness-monitor.pid; \
+		fi; \
 		$(ECHO) "$(CYAN)Merging per-provider reports into tmp/newman-report.json...$(NC)"; \
 		if command -v jq >/dev/null 2>&1 && ls tmp/newman-report-*.json >/dev/null 2>&1; then \
 			jq -s '{collection: (.[0].collection // {}), environment: (.[0].environment // {}), run: {executions: [.[].run.executions[]?], failures: [.[].run.failures[]?], stats: {iterations: {total: 1, pending: 0, failed: 0}, items: {total: ([.[].run.stats.items.total // 0] | add)}, requests: {total: ([.[].run.stats.requests.total // 0] | add), failed: ([.[].run.stats.requests.failed // 0] | add)}}, timings: (.[0].run.timings // {})}}' tmp/newman-report-*.json > tmp/newman-report.json || $(ECHO) "$(YELLOW)Report merge failed; per-provider reports remain at tmp/newman-report-*.json$(NC)"; \
@@ -1847,18 +1890,49 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 		done < tmp/parallel-status; \
 		NEWMAN_EXIT=$$PFAILED; \
 	else \
-		newman run "$$COLLECTION_FILE" \
-			--env-var "baseUrl=$$BASE_URL_VAL" \
-			$(if $(filter 1 true TRUE yes YES y Y,$(INCLUDE_PREVIEW)),--env-var "include_preview=1",) \
-			$(if $(filter 1 true TRUE yes YES y Y,$(INCLUDE_SKIP)),--env-var "include_skip=1",) \
-			$(if $(ENV_FILE),--environment $(ENV_FILE),) \
-			$(if $(FOLDER),--folder "$(FOLDER)",) \
-			--reporters cli,json,htmlextra \
-			--reporter-json-export tmp/newman-report.json \
-			--reporter-htmlextra-export tmp/newman-report.html \
-			--reporter-htmlextra-title "Bifrost Provider Harness" \
-			--reporter-htmlextra-darkTheme 2>&1 | tee tmp/newman-cli.log; \
-		NEWMAN_EXIT=$$?; \
+		SEQ_PROVIDERS="$(PROVIDER)"; \
+		if [ -z "$$SEQ_PROVIDERS" ]; then SEQ_PROVIDERS="openai anthropic bedrock gemini vertex azure passthrough"; fi; \
+		if [ -t 1 ] && [ -z "$$CI" ] && [ -z "$(CI)" ]; then \
+			: > tmp/newman-cli.log; \
+			$(USE_NODE); node tests/e2e/api/runners/harness-monitor.mjs \
+				--mode sequential \
+				--providers "$$SEQ_PROVIDERS" \
+				--tmp-dir tmp \
+				--log tmp/newman-cli.log \
+				< /dev/null > /dev/tty 2>&1 & \
+			echo $$! > tmp/harness-monitor.pid; \
+			newman run "$$COLLECTION_FILE" \
+				--env-var "baseUrl=$$BASE_URL_VAL" \
+				$(if $(filter 1 true TRUE yes YES y Y,$(INCLUDE_PREVIEW)),--env-var "include_preview=1",) \
+				$(if $(filter 1 true TRUE yes YES y Y,$(INCLUDE_SKIP)),--env-var "include_skip=1",) \
+				$(if $(ENV_FILE),--environment $(ENV_FILE),) \
+				$(if $(FOLDER),--folder "$(FOLDER)",) \
+				--reporters cli,json,htmlextra \
+				--reporter-json-export tmp/newman-report.json \
+				--reporter-htmlextra-export tmp/newman-report.html \
+				--reporter-htmlextra-title "Bifrost Provider Harness" \
+				--reporter-htmlextra-darkTheme > tmp/newman-cli.log 2>&1; \
+			NEWMAN_EXIT=$$?; \
+			if [ -f tmp/harness-monitor.pid ]; then \
+				MPID=$$(cat tmp/harness-monitor.pid); \
+				kill -TERM $$MPID 2>/dev/null; \
+				wait $$MPID 2>/dev/null || true; \
+				rm -f tmp/harness-monitor.pid; \
+			fi; \
+		else \
+			newman run "$$COLLECTION_FILE" \
+				--env-var "baseUrl=$$BASE_URL_VAL" \
+				$(if $(filter 1 true TRUE yes YES y Y,$(INCLUDE_PREVIEW)),--env-var "include_preview=1",) \
+				$(if $(filter 1 true TRUE yes YES y Y,$(INCLUDE_SKIP)),--env-var "include_skip=1",) \
+				$(if $(ENV_FILE),--environment $(ENV_FILE),) \
+				$(if $(FOLDER),--folder "$(FOLDER)",) \
+				--reporters cli,json,htmlextra \
+				--reporter-json-export tmp/newman-report.json \
+				--reporter-htmlextra-export tmp/newman-report.html \
+				--reporter-htmlextra-title "Bifrost Provider Harness" \
+				--reporter-htmlextra-darkTheme 2>&1 | tee tmp/newman-cli.log; \
+			NEWMAN_EXIT=$$?; \
+		fi; \
 	fi; \
 	$(ECHO) "$(GREEN)Newman finished. Reports: tmp/newman-report.{json,html} + tmp/newman-cli.log$(NC)"; \
 	$(ECHO) "$(CYAN)Analyzing failures...$(NC)"; \

--- a/tests/e2e/api/runners/filter-collection.mjs
+++ b/tests/e2e/api/runners/filter-collection.mjs
@@ -29,6 +29,9 @@ const SOURCE = args.source;
 const OUT = args.out;
 const PROVIDER = (args.provider || "").toLowerCase();
 const FEATURE_PARTS = (args.feature || "").toLowerCase().split(",").map((s) => s.trim()).filter(Boolean);
+// --feature-any is the OR-of-keywords counterpart of --feature (which ANDs). Item passes
+// if it matches at least one keyword. Combines with --feature/--provider via AND.
+const FEATURE_ANY_PARTS = (args["feature-any"] || "").toLowerCase().split(",").map((s) => s.trim()).filter(Boolean);
 const RERUN_FAILED = args["rerun-failed"] === "true";
 const REPORT = args.report || "tmp/newman-report.json";
 
@@ -36,8 +39,8 @@ if (!SOURCE || !OUT) {
   console.error("[filter-collection] --source and --out are required");
   process.exit(2);
 }
-if (!PROVIDER && !FEATURE_PARTS.length && !RERUN_FAILED) {
-  console.error("[filter-collection] need at least one of: --provider, --feature, --rerun-failed");
+if (!PROVIDER && !FEATURE_PARTS.length && !FEATURE_ANY_PARTS.length && !RERUN_FAILED) {
+  console.error("[filter-collection] need at least one of: --provider, --feature, --feature-any, --rerun-failed");
   process.exit(2);
 }
 
@@ -93,6 +96,16 @@ const itemMatchesFeature = (item, ancestorNames) => {
   });
 };
 
+const itemMatchesFeatureAny = (item, ancestorNames) => {
+  if (!FEATURE_ANY_PARTS.length) return true;
+  const haystack = buildHaystack(item, ancestorNames);
+  return FEATURE_ANY_PARTS.some((p) => {
+    const structural = STRUCTURAL_KEYWORDS[p];
+    if (structural) return structural(item) || haystack.includes(p);
+    return haystack.includes(p);
+  });
+};
+
 let failedNames = null;
 const itemMatchesRerunFailed = (item) => {
   if (!RERUN_FAILED) return true;
@@ -115,7 +128,10 @@ const itemMatchesRerunFailed = (item) => {
 
 const passes = (item, ancestorNames) => {
   if (!item.request) return true; // folders pass; we filter their items below
-  return itemMatchesProvider(item, ancestorNames) && itemMatchesFeature(item, ancestorNames) && itemMatchesRerunFailed(item);
+  return itemMatchesProvider(item, ancestorNames) &&
+    itemMatchesFeature(item, ancestorNames) &&
+    itemMatchesFeatureAny(item, ancestorNames) &&
+    itemMatchesRerunFailed(item);
 };
 
 const filterTree = (items, ancestorNames = []) => {
@@ -135,4 +151,4 @@ const collection = JSON.parse(readFileSync(SOURCE, "utf8"));
 const filtered = { ...collection, item: filterTree(collection.item || []) };
 const totalAfter = JSON.stringify(filtered).match(/"request":/g)?.length || 0;
 writeFileSync(OUT, JSON.stringify(filtered, null, 2));
-console.error(`[filter-collection] wrote ${OUT} with ${totalAfter} requests after filter (provider=${PROVIDER || "-"}, feature=${FEATURE_PARTS.join("+") || "-"}, rerun-failed=${RERUN_FAILED})`);
+console.error(`[filter-collection] wrote ${OUT} with ${totalAfter} requests after filter (provider=${PROVIDER || "-"}, feature=${FEATURE_PARTS.join("+") || "-"}, feature-any=${FEATURE_ANY_PARTS.join("|") || "-"}, rerun-failed=${RERUN_FAILED})`);

--- a/tests/e2e/api/runners/harness-monitor.mjs
+++ b/tests/e2e/api/runners/harness-monitor.mjs
@@ -1,0 +1,561 @@
+#!/usr/bin/env node
+// Live terminal progress monitor for `make run-provider-harness-test`.
+//
+// Tails per-provider newman CLI logs (parallel mode) or the merged CLI log
+// (sequential mode), aggregates pass/fail/% per provider with folder breakdown,
+// elapsed time + ETA, and most-recent failure text. Renders an in-place table.
+//
+// Usage:
+//   node harness-monitor.mjs \
+//     --mode parallel \
+//     --providers "openai anthropic bedrock gemini vertex azure passthrough" \
+//     --tmp-dir tmp \
+//     --status-file tmp/parallel-status \
+//     --launched 7
+//
+//   node harness-monitor.mjs \
+//     --mode sequential \
+//     --providers "openai anthropic" \
+//     --tmp-dir tmp \
+//     --log tmp/newman-cli.log
+
+import { existsSync, readFileSync, statSync, openSync, readSync, closeSync } from "node:fs";
+import { join } from "node:path";
+
+const args = Object.fromEntries(
+  process.argv.slice(2).reduce((acc, cur, i, arr) => {
+    if (cur.startsWith("--")) {
+      const key = cur.slice(2);
+      const next = arr[i + 1];
+      acc.push([key, next && !next.startsWith("--") ? next : "true"]);
+    }
+    return acc;
+  }, [])
+);
+
+const MODE = args.mode === "sequential" ? "sequential" : "parallel";
+const PROVIDERS = (args.providers || "").trim().split(/\s+/).filter(Boolean);
+const TMP_DIR = args["tmp-dir"] || "tmp";
+const STATUS_FILE = args["status-file"] || join(TMP_DIR, "parallel-status");
+const LAUNCHED = parseInt(args.launched || String(PROVIDERS.length), 10);
+const SEQ_LOG = args.log || join(TMP_DIR, "newman-cli.log");
+const TAIL_INTERVAL_MS = 250;
+const RENDER_INTERVAL_MS = 1000;
+const IDLE_EXIT_MS = 3000;
+
+if (PROVIDERS.length === 0) {
+  console.error("[harness-monitor] --providers is required");
+  process.exit(2);
+}
+
+// Mirror filter-collection.mjs PROVIDER_KEYWORDS. Used only in sequential mode
+// to route folder/request lines (which lack a [provider] prefix) to a provider.
+const PROVIDER_KEYWORDS = {
+  openai: ["openai", "gpt-", "o3", "o1"],
+  anthropic: ["anthropic", "claude-"],
+  bedrock: ["bedrock"],
+  gemini: ["gemini", "genai", "googlesearch"],
+  vertex: ["vertex"],
+  azure: ["azure", "deployments"],
+  passthrough: ["_passthrough", "passthrough"],
+};
+
+const ANSI_RE = /\x1b\[[0-9;?]*[A-Za-z]/g;
+const stripAnsi = (s) => s.replace(ANSI_RE, "");
+
+// State per provider. status transitions: pending -> running -> pass/fail/skipped.
+const state = {
+  startedAt: Date.now(),
+  mode: MODE,
+  providers: Object.fromEntries(
+    PROVIDERS.map((p) => [
+      p,
+      {
+        status: "pending",
+        totalRequests: 0,
+        doneRequests: 0,
+        pass: 0,
+        fail: 0,
+        folders: {},
+        folderOrder: [],
+        currentFolder: null,
+        currentRequest: null,
+        currentRequestDone: false,
+        currentRequestHadFail: false,
+        currentRequestFolder: null,
+        lastFailure: null,
+      },
+    ])
+  ),
+};
+let lastByteAt = Date.now();
+let lastRenderLines = 0;
+
+// ----- Denominator: walk the filtered collection per provider. ----------------
+
+function countLeaves(items, perFolder, topFolder) {
+  if (!Array.isArray(items)) return 0;
+  let total = 0;
+  for (const node of items) {
+    if (Array.isArray(node.item)) {
+      const next = topFolder ?? node.name ?? "(root)";
+      total += countLeaves(node.item, perFolder, next);
+    } else if (node.request) {
+      total += 1;
+      const folder = topFolder ?? "(root)";
+      if (!perFolder[folder]) perFolder[folder] = { total: 0, pass: 0, fail: 0 };
+      perFolder[folder].total += 1;
+    }
+  }
+  return total;
+}
+
+function loadDenominators() {
+  for (const p of PROVIDERS) {
+    const ps = state.providers[p];
+    // Parallel mode writes tmp/harness-filtered-<p>.json per provider.
+    // Sequential mode writes tmp/harness-filtered.json once, or falls back to the source collection.
+    const candidates =
+      MODE === "parallel"
+        ? [join(TMP_DIR, `harness-filtered-${p}.json`)]
+        : [
+            join(TMP_DIR, "harness-filtered.json"),
+            "tests/e2e/api/collections/provider-harness.json",
+          ];
+    for (const path of candidates) {
+      if (!existsSync(path)) continue;
+      try {
+        const data = JSON.parse(readFileSync(path, "utf8"));
+        const folders = {};
+        const total = countLeaves(data.item || [], folders, null);
+        ps.totalRequests = total;
+        ps.folders = folders;
+        ps.folderOrder = Object.keys(folders);
+        break;
+      } catch {
+        // ignore - try next candidate
+      }
+    }
+  }
+}
+
+// ----- Tail: poll-based incremental read of newman CLI logs. ------------------
+
+const tails = new Map(); // path -> { provider, offset, buf }
+
+function ensureTail(path, provider) {
+  if (!tails.has(path)) tails.set(path, { provider, offset: 0, buf: "" });
+}
+
+function readNewBytes() {
+  for (const [path, h] of tails) {
+    let st;
+    try {
+      st = statSync(path);
+    } catch {
+      continue;
+    }
+    if (st.size <= h.offset) continue;
+    const len = st.size - h.offset;
+    const buf = Buffer.alloc(len);
+    let fd;
+    try {
+      fd = openSync(path, "r");
+      readSync(fd, buf, 0, len, h.offset);
+    } catch {
+      if (fd != null) try { closeSync(fd); } catch {}
+      continue;
+    }
+    closeSync(fd);
+    h.offset = st.size;
+    h.buf += buf.toString("utf8");
+    const lines = h.buf.split("\n");
+    h.buf = lines.pop();
+    for (const raw of lines) handleLine(stripAnsi(raw), h.provider);
+    lastByteAt = Date.now();
+  }
+}
+
+// ----- Parsing ----------------------------------------------------------------
+
+const RE_PREFIX = /^\[([a-z]+)\]\s?(.*)$/;
+const RE_FOLDER = /^❏\s+(.+?)\s*$/;
+const RE_REQUEST = /^↳\s+(.+?)\s*$/;
+const RE_REQUEST_DONE = /\[\s*\d+(?:\s+[A-Za-z]+)?,\s*[\d.]+\s*[kMG]?B,\s*[\d.]+\s*m?s\s*\]/;
+const RE_ASSERT_FAIL = /^\s*\d+\.\s+(.+?)$/;
+
+function inferProviderFromLine(line) {
+  const lower = line.toLowerCase();
+  for (const p of PROVIDERS) {
+    const kws = PROVIDER_KEYWORDS[p] || [p];
+    for (const k of kws) if (lower.includes(k)) return p;
+  }
+  return null;
+}
+
+// Newman emits per-request lines in this order: ↳ start, then the [size,duration]
+// summary, then ✓ pass-assertions, then numbered fail lines. So we can't commit
+// pass/fail at the summary line - we'd miss subsequent fail lines. Instead we
+// defer commit until the next ↳ / ❏ / finalizeAll().
+function finalizeRequest(ps) {
+  if (!ps.currentRequest) return;
+  if (ps.currentRequestDone) {
+    if (ps.currentRequestHadFail) ps.fail += 1;
+    else ps.pass += 1;
+    const f = ps.currentRequestFolder;
+    if (f && ps.folders[f]) {
+      if (ps.currentRequestHadFail) ps.folders[f].fail += 1;
+      else ps.folders[f].pass += 1;
+    }
+  }
+  ps.currentRequest = null;
+  ps.currentRequestDone = false;
+  ps.currentRequestHadFail = false;
+  ps.currentRequestFolder = null;
+}
+
+function finalizeAll() {
+  for (const p of PROVIDERS) finalizeRequest(state.providers[p]);
+}
+
+function handleLine(line, taggedProvider) {
+  let provider = taggedProvider;
+  let body = line;
+
+  if (MODE === "parallel") {
+    const m = line.match(RE_PREFIX);
+    if (m && state.providers[m[1]]) {
+      provider = m[1];
+      body = m[2];
+    } else if (!provider) {
+      return;
+    }
+  }
+
+  const ps = state.providers[provider];
+  if (!ps) return;
+  if (ps.status === "pending") ps.status = "running";
+
+  const trimmed = body.trimStart();
+
+  let m;
+  if ((m = trimmed.match(RE_FOLDER))) {
+    finalizeRequest(ps);
+    const folder = m[1].trim();
+    ps.currentFolder = folder;
+    if (!ps.folders[folder]) {
+      ps.folders[folder] = { total: 0, pass: 0, fail: 0 };
+      ps.folderOrder.push(folder);
+    }
+    return;
+  }
+  if ((m = trimmed.match(RE_REQUEST))) {
+    finalizeRequest(ps);
+    ps.currentRequest = m[1].trim();
+    ps.currentRequestDone = false;
+    ps.currentRequestHadFail = false;
+    ps.currentRequestFolder = ps.currentFolder;
+    return;
+  }
+  // Disambiguate request-done summary from assertion-fail; check done first.
+  if (RE_REQUEST_DONE.test(trimmed)) {
+    if (ps.currentRequest && !ps.currentRequestDone) {
+      ps.currentRequestDone = true;
+      ps.doneRequests += 1;
+    }
+    return;
+  }
+  if ((m = trimmed.match(RE_ASSERT_FAIL)) && ps.currentRequest) {
+    ps.currentRequestHadFail = true;
+    ps.lastFailure = { folder: ps.currentRequestFolder, text: m[1].trim() };
+    return;
+  }
+}
+
+// ----- Status file: pick up final pass/fail verdicts in parallel mode. --------
+
+function readStatusFile() {
+  if (MODE !== "parallel") return { lines: 0 };
+  if (!existsSync(STATUS_FILE)) return { lines: 0 };
+  let content;
+  try {
+    content = readFileSync(STATUS_FILE, "utf8");
+  } catch {
+    return { lines: 0 };
+  }
+  const lines = content.trim().split("\n").filter(Boolean);
+  for (const ln of lines) {
+    const [p, v] = ln.split(":");
+    const ps = state.providers[p];
+    if (!ps) continue;
+    if (v === "pass") ps.status = "pass";
+    else if (v === "fail") ps.status = "fail";
+  }
+  return { lines: lines.length };
+}
+
+// ----- Render -----------------------------------------------------------------
+
+const C = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  cyan: "\x1b[36m",
+  gray: "\x1b[90m",
+};
+
+function fmtDuration(ms) {
+  if (!isFinite(ms) || ms < 0) return "--:--";
+  const s = Math.floor(ms / 1000);
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `${String(m).padStart(2, "0")}:${String(r).padStart(2, "0")}`;
+}
+
+function truncate(s, n) {
+  if (!s) return "";
+  return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}
+
+function padRight(s, n) {
+  const str = String(s);
+  return str.length >= n ? str.slice(0, n) : str + " ".repeat(n - str.length);
+}
+function padLeft(s, n) {
+  const str = String(s);
+  return str.length >= n ? str.slice(0, n) : " ".repeat(n - str.length) + str;
+}
+
+function statusGlyph(status) {
+  switch (status) {
+    case "pass": return `${C.green}✓${C.reset}`;
+    case "fail": return `${C.red}✗${C.reset}`;
+    case "running": return `${C.cyan}●${C.reset}`;
+    case "skipped": return `${C.gray}-${C.reset}`;
+    default: return `${C.gray}·${C.reset}`;
+  }
+}
+
+function renderFrame() {
+  const cols = process.stdout.columns || 120;
+
+  // Aggregate totals.
+  let aggDone = 0, aggTotal = 0, aggPass = 0, aggFail = 0;
+  for (const p of PROVIDERS) {
+    const ps = state.providers[p];
+    aggDone += ps.doneRequests;
+    aggTotal += ps.totalRequests;
+    aggPass += ps.pass;
+    aggFail += ps.fail;
+  }
+  const elapsed = Date.now() - state.startedAt;
+  const eta =
+    aggDone > 0 && aggTotal > aggDone ? elapsed * (aggTotal / aggDone - 1) : NaN;
+
+  const out = [];
+  out.push(
+    `${C.bold}Bifrost Provider Harness - live${C.reset}` +
+      `   ${C.dim}Elapsed${C.reset} ${fmtDuration(elapsed)}` +
+      `   ${C.dim}ETA${C.reset} ${fmtDuration(eta)}` +
+      `   ${C.dim}Mode${C.reset} ${state.mode}`
+  );
+
+  // Table width math: each cell consumes (width + 3) chars (" content │"),
+  // plus 1 leading "│". So total = 1 + 3N + sum(widths). Compute the failure
+  // column from terminal width to guarantee no row wraps. Drop the column
+  // entirely if there isn't even 20 chars left for it.
+  const fixed = [1, 12, 9, 5, 5, 5];
+  const fixedSum = fixed.reduce((a, b) => a + b, 0);
+  const overheadWith7 = 1 + 3 * 7; // 22
+  const overheadWith6 = 1 + 3 * 6; // 19
+  const targetWidth = Math.max(40, cols - 1);
+  const failColWidth = targetWidth - overheadWith7 - fixedSum;
+  const showFailureCol = failColWidth >= 20;
+  const headers = showFailureCol
+    ? ["", "Provider", "Done", "Pass", "Fail", "%", "Last failure"]
+    : ["", "Provider", "Done", "Pass", "Fail", "%"];
+  const widths = showFailureCol ? [...fixed, failColWidth] : fixed;
+
+  const sep = (left, mid, right, fill = "─") => {
+    let line = left;
+    for (let i = 0; i < widths.length; i++) {
+      line += fill.repeat(widths[i] + 2);
+      line += i === widths.length - 1 ? right : mid;
+    }
+    return line;
+  };
+
+  const row = (cells) => {
+    let line = "│";
+    for (let i = 0; i < cells.length; i++) {
+      line += " " + padRight(cells[i], widths[i]) + " │";
+    }
+    return line;
+  };
+
+  out.push(sep("┌", "┬", "┐"));
+  out.push(row(headers));
+  out.push(sep("├", "┼", "┤"));
+
+  for (const p of PROVIDERS) {
+    const ps = state.providers[p];
+    const pct = ps.totalRequests ? Math.floor((100 * ps.doneRequests) / ps.totalRequests) : 0;
+    const doneCell = `${padLeft(ps.doneRequests, 3)}/${padRight(ps.totalRequests, 3)}`;
+    const failCellRaw = ps.fail > 0 ? `${C.red}${padLeft(ps.fail, widths[4])}${C.reset}` : padLeft(ps.fail, widths[4]);
+    const cells = [
+      statusGlyph(ps.status),
+      p,
+      doneCell,
+      padLeft(ps.pass, widths[3]),
+      // failCell: pre-padded so the row() pad-right is a no-op for this cell
+      failCellRaw,
+      `${pct}%`,
+    ];
+    if (showFailureCol) {
+      cells.push(truncate(ps.lastFailure?.text || (ps.currentRequest || "-"), widths[6]));
+    }
+    out.push(rowWithRawCells(cells, widths));
+  }
+
+  out.push(sep("├", "┼", "┤"));
+  const totalPct = aggTotal ? Math.floor((100 * aggDone) / aggTotal) : 0;
+  const totalCells = [
+    "",
+    `${C.bold}TOTAL${C.reset}`,
+    `${padLeft(aggDone, 3)}/${padRight(aggTotal, 3)}`,
+    padLeft(aggPass, widths[3]),
+    aggFail > 0 ? `${C.red}${padLeft(aggFail, widths[4])}${C.reset}` : padLeft(aggFail, widths[4]),
+    `${totalPct}%`,
+  ];
+  if (showFailureCol) totalCells.push("");
+  out.push(rowWithRawCells(totalCells, widths));
+  out.push(sep("└", "┴", "┘"));
+
+  // Folder breakdown: show each running provider's currentFolder + last few folders.
+  out.push("");
+  out.push(`${C.bold}Current folders${C.reset}`);
+  for (const p of PROVIDERS) {
+    const ps = state.providers[p];
+    if (ps.totalRequests === 0) continue;
+    const cur = ps.currentFolder;
+    if (!cur) {
+      out.push(`  ${padRight(p, 12)} ${C.gray}(waiting)${C.reset}`);
+      continue;
+    }
+    const f = ps.folders[cur] || { total: 0, pass: 0, fail: 0 };
+    const doneInFolder = f.pass + f.fail;
+    out.push(
+      `  ${padRight(p, 12)} ${C.cyan}${truncate(cur, 40)}${C.reset}  ` +
+        `${doneInFolder}/${f.total} ` +
+        `(${C.green}✓ ${f.pass}${C.reset}, ${f.fail > 0 ? C.red : C.dim}✗ ${f.fail}${C.reset})`
+    );
+  }
+
+  return out;
+}
+
+// Cell may contain ANSI escapes; padRight in row() would break alignment. So
+// compute visible length, then pad with spaces externally.
+function rowWithRawCells(cells, widths) {
+  let line = "│";
+  for (let i = 0; i < cells.length; i++) {
+    const raw = String(cells[i]);
+    const visible = raw.replace(ANSI_RE, "");
+    const w = widths[i];
+    const padded = visible.length >= w ? raw : raw + " ".repeat(w - visible.length);
+    line += " " + padded + " │";
+  }
+  return line;
+}
+
+function draw() {
+  const lines = renderFrame();
+  const rows = process.stdout.rows || lines.length;
+  // Clamp to terminal height so we don't push the title off the top.
+  const visible = lines.slice(0, Math.max(1, rows - 1));
+  let out = "\x1b[H"; // cursor home (alt screen, so this is the buffer origin)
+  for (const ln of visible) out += ln + "\x1b[K\n";
+  out += "\x1b[J"; // clear from cursor to end-of-screen (wipes prior taller frame's tail)
+  process.stdout.write(out);
+  lastRenderLines = visible.length;
+}
+
+// ----- Lifecycle --------------------------------------------------------------
+
+function setupTails() {
+  if (MODE === "parallel") {
+    for (const p of PROVIDERS) {
+      ensureTail(join(TMP_DIR, `newman-cli-${p}.log`), p);
+    }
+  } else {
+    // Sequential: one shared log, provider inferred per-line.
+    ensureTail(SEQ_LOG, null);
+  }
+}
+
+function shouldExit() {
+  if (MODE === "parallel") {
+    const { lines } = readStatusFile();
+    if (lines >= LAUNCHED && Date.now() - lastByteAt > IDLE_EXIT_MS) return true;
+  } else {
+    // Sequential mode: rely on signals from the Makefile. Also exit when the
+    // log shows the newman "failures" summary block AND we've been idle.
+    if (Date.now() - lastByteAt > IDLE_EXIT_MS * 2 && lastRenderLines > 0) {
+      const allDone = PROVIDERS.every(
+        (p) => state.providers[p].totalRequests === 0 ||
+               state.providers[p].doneRequests >= state.providers[p].totalRequests
+      );
+      if (allDone) return true;
+    }
+  }
+  return false;
+}
+
+function teardown(code = 0) {
+  // Drain any pending bytes the tail timer hasn't picked up yet, then commit
+  // the trailing in-flight request before the final frame.
+  readNewBytes();
+  finalizeAll();
+  draw();
+  // Snapshot the final frame to stderr so it persists on the main screen
+  // after we leave the alt buffer (otherwise the user sees the table vanish).
+  const finalLines = renderFrame();
+  // Leave alt screen, restore cursor, then print the persistent snapshot.
+  process.stdout.write("\x1b[?25h\x1b[?1049l");
+  process.stderr.write(finalLines.join("\n") + "\n");
+  process.exit(code);
+}
+
+process.on("SIGTERM", () => teardown(0));
+process.on("SIGINT", () => teardown(130));
+process.on("SIGHUP", () => teardown(0));
+
+// Enter alt screen buffer + hide cursor + clear it. This gives us a fresh
+// canvas with a known origin so cursor-home redraws are deterministic and
+// the preamble (boot logs, launch messages) is preserved on the main screen.
+process.stdout.write("\x1b[?1049h\x1b[H\x1b[2J\x1b[?25l");
+
+// Initial denominator pass; retry once a second until at least one provider has totals.
+loadDenominators();
+const denomTimer = setInterval(() => {
+  const haveAny = PROVIDERS.some((p) => state.providers[p].totalRequests > 0);
+  if (!haveAny) loadDenominators();
+  else clearInterval(denomTimer);
+}, 1000);
+
+setupTails();
+setInterval(() => {
+  readNewBytes();
+  readStatusFile();
+}, TAIL_INTERVAL_MS);
+
+setInterval(() => {
+  draw();
+  if (shouldExit()) teardown(0);
+}, RENDER_INTERVAL_MS);
+
+// Draw a first frame immediately so the user sees something.
+draw();

--- a/tests/e2e/api/runners/pick-features.mjs
+++ b/tests/e2e/api/runners/pick-features.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// Interactive multi-select picker for harness modalities (criss-cross matrix).
+//
+// Designed to be invoked via $(node pick-features.mjs) - we read keys from
+// stdin (raw mode), render the menu to stderr, and write only the final
+// selection (comma-separated, lowercase) to stdout so the Makefile can
+// capture it cleanly.
+//
+// Exit codes:
+//   0 - selection confirmed (stdout = comma-separated keywords; empty when all selected)
+//   1 - user cancelled (Esc / Ctrl+C / q)
+//   2 - not running on an interactive TTY (no menu shown; stdout empty)
+
+const FEATURES = [
+  { key: "chat", label: "Chat completions (text-only)" },
+  { key: "streaming", label: "Streaming responses (SSE)" },
+  { key: "embeddings", label: "Embeddings" },
+  { key: "audio", label: "Audio (speech / transcription)" },
+  { key: "image-gen", label: "Image generation" },
+  { key: "tools", label: "Tool / function calling" },
+  { key: "vision", label: "Vision (image input)" },
+  { key: "json", label: "Structured output (JSON mode / schema)" },
+  { key: "reasoning", label: "Reasoning / thinking" },
+];
+
+// Need a TTY on both stdin (for keys) and stderr (for menu render). stdout is
+// intentionally NOT required - it's the result channel, often piped via $(...).
+if (!process.stdin.isTTY || !process.stderr.isTTY) {
+  process.exit(2);
+}
+
+const writeUI = (s) => process.stderr.write(s);
+
+const selected = new Set(FEATURES.map((f) => f.key));
+let cursor = 0;
+let firstFrame = true;
+let lastLines = 0;
+
+const C = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  cyan: "\x1b[36m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  gray: "\x1b[90m",
+};
+
+function render() {
+  const lines = [];
+  lines.push(`${C.bold}Bifrost harness - pick modalities${C.reset}  ${C.dim}(space toggles, a=all, n=none, enter runs, q=cancel)${C.reset}`);
+  lines.push("");
+  for (let i = 0; i < FEATURES.length; i++) {
+    const f = FEATURES[i];
+    const box = selected.has(f.key) ? `${C.green}[x]${C.reset}` : "[ ]";
+    const arrow = i === cursor ? `${C.cyan}>${C.reset}` : " ";
+    const label = i === cursor ? `${C.bold}${f.label}${C.reset}` : f.label;
+    lines.push(`  ${arrow} ${box} ${label}  ${C.gray}${f.key}${C.reset}`);
+  }
+  lines.push("");
+  const n = selected.size;
+  const summary = n === FEATURES.length
+    ? `${C.dim}All modalities selected (no filter) - all providers will run${C.reset}`
+    : n === 0
+      ? `${C.yellow}No modalities selected - press space or 'a' to choose at least one${C.reset}`
+      : `${C.dim}${n} of ${FEATURES.length} selected: ${[...selected].join(", ")}${C.reset}`;
+  lines.push(summary);
+
+  let out = "";
+  if (firstFrame) {
+    writeUI("\x1b[?25l");
+    firstFrame = false;
+  } else if (lastLines > 0) {
+    out += `\x1b[${lastLines}A\x1b[0J`;
+  }
+  out += lines.join("\n") + "\n";
+  writeUI(out);
+  lastLines = lines.length;
+}
+
+function restoreTty() {
+  try { process.stdin.setRawMode(false); } catch {}
+  writeUI("\x1b[?25h");
+}
+
+function commit() {
+  restoreTty();
+  process.stdin.pause();
+  if (selected.size === 0) process.exit(1);
+  // Emit empty when all are selected so the Makefile takes the no-filter path.
+  if (selected.size < FEATURES.length) {
+    process.stdout.write([...selected].join(","));
+  }
+  process.exit(0);
+}
+
+function cancel() {
+  restoreTty();
+  process.stdin.pause();
+  process.stderr.write("\n[pick-features] cancelled\n");
+  process.exit(1);
+}
+
+process.on("SIGINT", cancel);
+process.on("SIGTERM", cancel);
+
+process.stdin.setRawMode(true);
+process.stdin.resume();
+process.stdin.setEncoding("utf8");
+
+process.stdin.on("data", (chunk) => {
+  for (const key of splitKeys(chunk)) handleKey(key);
+});
+
+function handleKey(key) {
+  if (key === "\x1b[A" || key === "k") {
+    cursor = (cursor - 1 + FEATURES.length) % FEATURES.length;
+    render();
+    return;
+  }
+  if (key === "\x1b[B" || key === "j") {
+    cursor = (cursor + 1) % FEATURES.length;
+    render();
+    return;
+  }
+  if (key === " ") {
+    const k = FEATURES[cursor].key;
+    if (selected.has(k)) selected.delete(k);
+    else selected.add(k);
+    render();
+    return;
+  }
+  if (key === "a") {
+    for (const f of FEATURES) selected.add(f.key);
+    render();
+    return;
+  }
+  if (key === "n") {
+    selected.clear();
+    render();
+    return;
+  }
+  if (key === "\r" || key === "\n") {
+    if (selected.size === 0) return;
+    commit();
+    return;
+  }
+  if (key === "\x1b" || key === "q" || key === "\x03") {
+    cancel();
+    return;
+  }
+}
+
+// Terminals batch fast keypresses into a single data chunk. Split on ESC
+// boundaries so an arrow-key escape sequence stays atomic.
+function splitKeys(chunk) {
+  const out = [];
+  let i = 0;
+  while (i < chunk.length) {
+    const ch = chunk[i];
+    if (ch === "\x1b") {
+      // CSI sequence: ESC [ <bytes> <final-letter>
+      if (chunk[i + 1] === "[") {
+        let j = i + 2;
+        while (j < chunk.length && !/[A-Za-z~]/.test(chunk[j])) j++;
+        out.push(chunk.slice(i, j + 1));
+        i = j + 1;
+        continue;
+      }
+      // bare ESC
+      out.push("\x1b");
+      i++;
+      continue;
+    }
+    out.push(ch);
+    i++;
+  }
+  return out;
+}
+
+render();


### PR DESCRIPTION
## Summary

Adds a live terminal progress monitor and an interactive modality picker to the `make run-provider-harness-test` workflow. When running locally in an interactive terminal, users can now select which test modalities to run before the suite starts, and watch real-time per-provider pass/fail progress in an in-place rendered table rather than scrolling raw newman output.

## Changes

- **`pick-features.mjs`**: New interactive multi-select TTY menu that lets users choose which modalities (chat, streaming, embeddings, tools, vision, etc.) to run before the harness starts. Renders to `/dev/tty`, supports arrow keys, space to toggle, `a`/`n` for all/none, and `Enter` to confirm. Outputs a comma-separated list of selected keywords to stdout for the Makefile to capture. Skipped automatically in CI or non-TTY environments.

- **`harness-monitor.mjs`**: New live progress monitor that tails per-provider newman CLI logs and renders an in-place terminal table showing per-provider status (pending/running/pass/fail), request counts, pass/fail totals, completion percentage, elapsed time, ETA, and most-recent failure text. Supports both parallel and sequential run modes. Suppresses the raw per-provider log tail output that previously scrolled during parallel runs.

- **`filter-collection.mjs`**: Added `--feature-any` flag as an OR-based counterpart to the existing AND-based `--feature` flag. Items pass if they match at least one of the provided keywords. The two flags combine via AND with each other and with `--provider`.

- **`Makefile`**: Wired up the new scripts into `run-provider-harness-test`. In interactive non-CI terminals, `pick-features.mjs` is invoked before the run to optionally filter by modality, and `harness-monitor.mjs` is launched as a background process for both parallel and sequential modes. The monitor PID is tracked and cleaned up in the `cleanup()` trap. In CI or non-TTY environments, behavior is unchanged.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Run the harness interactively to see the modality picker and live monitor
make run-provider-harness-test

# Verify the picker is skipped and monitor is not launched in CI mode
CI=1 make run-provider-harness-test

# Test feature-any filtering directly
node tests/e2e/api/runners/filter-collection.mjs \
  --source tests/e2e/api/collections/provider-harness.json \
  --out tmp/harness-filtered.json \
  --feature-any "chat,streaming"

# Run with an explicit provider to confirm picker is bypassed
make run-provider-harness-test PROVIDER=openai
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII involved. The monitor and picker operate entirely on local log files and TTY file descriptors.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable