### PR TITLE
fixes migration-test-script

### DIFF
--- a/.github/workflows/scripts/run-migration-tests.sh
+++ b/.github/workflows/scripts/run-migration-tests.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 #   VERSIONS_TO_TEST  - Number of previous versions to test (default: 3)
 
 # Pull all the tags available
-# git fetch --tags
+git fetch --tags
 
 # Get the absolute path of the script directory
 if command -v readlink >/dev/null 2>&1 && readlink -f "$0" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

The `git fetch --tags` command in the migration test script was commented out, preventing the script from pulling available tags needed to determine which versions to test. This re-enables the command so migration tests can correctly resolve previous versions.

## Changes

- Re-enabled `git fetch --tags` in `run-migration-tests.sh`, which was previously commented out, restoring the ability to fetch remote tags before running migration version comparisons.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the migration test script in a repository with remote tags and verify it correctly identifies and tests the expected number of previous versions.

```sh
bash .github/workflows/scripts/run-migration-tests.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This change only affects CI tag resolution behavior.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable