### PR TITLE
feat: implements calendar align feature at team level

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -710,6 +710,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationDropAllowDirectKeysColumnDDL(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddTeamCalendarAlignedColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationDropLegacyCalendarAlignedColumns(ctx, db); err != nil {
 		return err
 	}
@@ -7560,6 +7563,64 @@ func migrationDropLegacyCalendarAlignedColumns(ctx context.Context, db *gorm.DB)
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running drop_legacy_calendar_aligned_columns migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddTeamCalendarAlignedColumn adds calendar_aligned to governance_teams so
+// team-level calendar alignment (governing all team budgets and the team rate limit)
+// can be persisted.
+func migrationAddTeamCalendarAlignedColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_team_calendar_aligned_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if !mig.HasColumn(&tables.TableTeam{}, "calendar_aligned") {
+				if err := mig.AddColumn(&tables.TableTeam{}, "CalendarAligned"); err != nil {
+					return fmt.Errorf("failed to add calendar_aligned column to governance_teams: %w", err)
+				}
+			}
+			// Backfill from legacy per-budget / per-rate-limit flags before the
+			// drop migration removes them. Any team-owned budget with
+			// calendar_aligned=true, or a team rate-limit with calendar_aligned=true,
+			// promotes the team to calendar-aligned so behavior is preserved across upgrade.
+			if mig.HasColumn(&tables.TableBudget{}, "calendar_aligned") {
+				if err := tx.Exec(`
+					UPDATE governance_teams t
+					SET calendar_aligned = TRUE
+					WHERE EXISTS (
+						SELECT 1 FROM governance_budgets b
+						WHERE b.team_id = t.id AND b.calendar_aligned = TRUE
+					)
+				`).Error; err != nil {
+					return fmt.Errorf("failed to backfill team calendar_aligned from budgets: %w", err)
+				}
+			}
+			if mig.HasColumn(&tables.TableRateLimit{}, "calendar_aligned") {
+				if err := tx.Exec(`
+					UPDATE governance_teams t
+					SET calendar_aligned = TRUE
+					WHERE t.rate_limit_id IN (
+						SELECT id FROM governance_rate_limits WHERE calendar_aligned = TRUE
+					)
+				`).Error; err != nil {
+					return fmt.Errorf("failed to backfill team calendar_aligned from rate limits: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if mig.HasColumn(&tables.TableTeam{}, "calendar_aligned") {
+				return mig.DropColumn(&tables.TableTeam{}, "calendar_aligned")
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_team_calendar_aligned_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -20,6 +20,19 @@ type TableBudget struct {
 	VirtualKeyID     *string `gorm:"type:varchar(255);index" json:"virtual_key_id,omitempty"`
 	ProviderConfigID *uint   `gorm:"index" json:"provider_config_id,omitempty"`
 
+	// Deprecated: set calendar_aligned on the parent access profile / VK / team
+	// instead. Kept for backward compatibility with older config.json files;
+	// the OSS applyV1Compat path and the enterprise access-profile reconciler
+	// promote any true value here to the owner's top-level CalendarAligned at
+	// load time.
+	CalendarAlignedInput *bool `gorm:"-" json:"calendar_aligned,omitempty"`
+
+	// Derived from the owning entity (VK / PC's parent VK / Team). Populated by
+	// the owner's AfterFind hook on cold load and by the governance store's
+	// Create/Update *InMemory methods on write. Never persisted; consumed by
+	// the reset path to decide rolling vs. calendar-aligned window.
+	IsCalendarAligned bool `gorm:"-" json:"-"`
+
 	// Config hash is used to detect the changes synced from config.json file
 	// Every time we sync the config.json file, we will update the config hash
 	ConfigHash string `gorm:"type:varchar(255);null" json:"config_hash"`

--- a/framework/configstore/tables/ratelimit.go
+++ b/framework/configstore/tables/ratelimit.go
@@ -23,6 +23,16 @@ type TableRateLimit struct {
 	RequestCurrentUsage  int64     `gorm:"default:0" json:"request_current_usage"`                   // Current request usage
 	RequestLastReset     time.Time `gorm:"index" json:"request_last_reset"`                          // Last time request counter was reset
 
+	// Deprecated: set calendar_aligned on the parent access profile / VK / team
+	// instead. Kept for backward compatibility with older config.json files;
+	// the OSS applyV1Compat path and the enterprise access-profile reconciler
+	// promote any true value here to the owner's top-level CalendarAligned at
+	// load time.
+	CalendarAlignedInput *bool `gorm:"-" json:"calendar_aligned,omitempty"`
+
+	// Derived from the owning entity. See TableBudget.IsCalendarAligned.
+	IsCalendarAligned bool `gorm:"-" json:"-"`
+
 	// Config hash is used to detect the changes synced from config.json file
 	// Every time we sync the config.json file, we will update the config hash
 	ConfigHash string `gorm:"type:varchar(255);null" json:"config_hash"`

--- a/framework/configstore/tables/team.go
+++ b/framework/configstore/tables/team.go
@@ -32,8 +32,7 @@ type TableTeam struct {
 	Claims       *string        `gorm:"type:text" json:"-"`
 	ParsedClaims map[string]any `gorm:"-" json:"claims"`
 
-	// IsBudgetCalendarAligned indicates whether the team's budget is calendar-aligned
-	CalendarAligned bool `gorm:"-" json:"calendar_aligned"`
+	CalendarAligned bool `gorm:"default:false" json:"calendar_aligned"`
 
 	// Config hash is used to detect the changes synced from config.json file
 	// Every time we sync the config.json file, we will update the config hash
@@ -78,7 +77,10 @@ func (t *TableTeam) BeforeSave(tx *gorm.DB) error {
 	return nil
 }
 
-// AfterFind hook for TableTeam to deserialize JSON fields
+// AfterFind hook for TableTeam to deserialize JSON fields and propagate
+// calendar_aligned down to owned budgets / rate_limit. The reset path reads
+// the stamped value off the budget / rate_limit; the governance store's
+// Update*InMemory paths re-stamp on every team update.
 func (t *TableTeam) AfterFind(tx *gorm.DB) error {
 	if t.Profile != nil {
 		if err := json.Unmarshal([]byte(*t.Profile), &t.ParsedProfile); err != nil {
@@ -94,6 +96,12 @@ func (t *TableTeam) AfterFind(tx *gorm.DB) error {
 		if err := json.Unmarshal([]byte(*t.Claims), &t.ParsedClaims); err != nil {
 			return err
 		}
+	}
+	for i := range t.Budgets {
+		t.Budgets[i].IsCalendarAligned = t.CalendarAligned
+	}
+	if t.RateLimit != nil {
+		t.RateLimit.IsCalendarAligned = t.CalendarAligned
 	}
 	return nil
 }

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -210,11 +210,7 @@ type TableVirtualKey struct {
 	CustomerID  *string `gorm:"type:varchar(255);index" json:"customer_id,omitempty"`
 	RateLimitID *string `gorm:"type:varchar(255);index" json:"rate_limit_id,omitempty"`
 
-	// Deprecated
-	// Calendar aligned is not the property of virtual key but its property of the budget and ratelimit
-	// So in the migration we will move this to the budget/ratelimit table
-	// And this won't be referred
-	CalendarAligned bool `gorm:"default:false" json:"calendar_aligned"` // When true, all budgets under this VK reset at clean calendar boundaries
+	CalendarAligned bool `gorm:"default:false" json:"calendar_aligned"`
 
 	// Relationships
 	Team      *TableTeam      `gorm:"foreignKey:TeamID" json:"team,omitempty"`
@@ -269,11 +265,30 @@ func (vk *TableVirtualKey) BeforeSave(tx *gorm.DB) error {
 	return nil
 }
 
-// AfterFind is a GORM hook that decrypts the virtual key value after reading from the database.
+// AfterFind is a GORM hook that decrypts the virtual key value after reading
+// from the database and propagates VK-level calendar_aligned down to owned
+// budgets / rate_limit and to each provider config's budgets / rate_limit.
+// The reset path reads the stamped value; Update*InMemory paths re-stamp on
+// every VK update.
 func (vk *TableVirtualKey) AfterFind(tx *gorm.DB) error {
 	if vk.EncryptionStatus == EncryptionStatusEncrypted {
 		if err := decryptString(&vk.Value); err != nil {
 			return fmt.Errorf("failed to decrypt virtual key value: %w", err)
+		}
+	}
+	for i := range vk.Budgets {
+		vk.Budgets[i].IsCalendarAligned = vk.CalendarAligned
+	}
+	if vk.RateLimit != nil {
+		vk.RateLimit.IsCalendarAligned = vk.CalendarAligned
+	}
+	for i := range vk.ProviderConfigs {
+		pc := &vk.ProviderConfigs[i]
+		for j := range pc.Budgets {
+			pc.Budgets[j].IsCalendarAligned = vk.CalendarAligned
+		}
+		if pc.RateLimit != nil {
+			pc.RateLimit.IsCalendarAligned = vk.CalendarAligned
 		}
 	}
 	return nil

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1373,14 +1373,7 @@ func (gs *LocalGovernanceStore) ResetExpiredBudgetsInMemory(ctx context.Context)
 		if !ok || budget == nil {
 			return true
 		}
-		// Find if the budget is calendar aligned on the virtualkey attached to this budget
-		calendarAligned := false
-		if budget.VirtualKeyID != nil {
-			virtualKey, ok := gs.virtualKeys.Load(*budget.VirtualKeyID)
-			if ok {
-				calendarAligned = virtualKey.(*configstoreTables.TableVirtualKey).CalendarAligned
-			}
-		}
+		calendarAligned := budget.IsCalendarAligned
 		var shouldReset bool
 		var newLastReset time.Time
 		if calendarAligned {
@@ -1454,32 +1447,12 @@ func (gs *LocalGovernanceStore) ResetExpiredRateLimitsInMemory(ctx context.Conte
 		}
 		return nil
 	}
-	// Build reverse map from rate_limit ID to the owning VK's CalendarAligned
-	// setting. Rate limits attach to either a VK (vk.RateLimitID) or a provider
-	// config (pc.RateLimitID) which itself belongs to a VK. Rate limits not
-	// reachable from any VK (e.g. team-attached) remain non-aligned.
-	rateLimitCalendarAligned := make(map[string]bool)
-	gs.virtualKeys.Range(func(_, v any) bool {
-		vk, ok := v.(*configstoreTables.TableVirtualKey)
-		if !ok || vk == nil {
-			return true
-		}
-		if vk.RateLimitID != nil {
-			rateLimitCalendarAligned[*vk.RateLimitID] = vk.CalendarAligned
-		}
-		for i := range vk.ProviderConfigs {
-			if pc := &vk.ProviderConfigs[i]; pc.RateLimitID != nil {
-				rateLimitCalendarAligned[*pc.RateLimitID] = vk.CalendarAligned
-			}
-		}
-		return true
-	})
 	gs.rateLimits.Range(func(key, value any) bool {
 		rateLimit, ok := value.(*configstoreTables.TableRateLimit)
 		if !ok || rateLimit == nil {
 			return true
 		}
-		calendarAligned := rateLimitCalendarAligned[rateLimit.ID]
+		calendarAligned := rateLimit.IsCalendarAligned
 		tokenNewLastReset := resolvePeriodStart(rateLimit.TokenResetDuration, calendarAligned, rateLimit.TokenLastReset)
 		requestNewLastReset := resolvePeriodStart(rateLimit.RequestResetDuration, calendarAligned, rateLimit.RequestLastReset)
 		if tokenNewLastReset == nil && requestNewLastReset == nil {
@@ -2286,21 +2259,26 @@ func (gs *LocalGovernanceStore) CreateVirtualKeyInMemory(ctx context.Context, vk
 
 	// Store budgets
 	for i := range vk.Budgets {
+		vk.Budgets[i].IsCalendarAligned = vk.CalendarAligned
 		gs.budgets.Store(vk.Budgets[i].ID, &vk.Budgets[i])
 	}
 
 	// Create associated rate limit if exists
 	if vk.RateLimit != nil {
+		vk.RateLimit.IsCalendarAligned = vk.CalendarAligned
 		gs.rateLimits.Store(vk.RateLimit.ID, vk.RateLimit)
 	}
 
 	// Create provider config budgets and rate limits if they exist
 	if vk.ProviderConfigs != nil {
-		for _, pc := range vk.ProviderConfigs {
-			for i := range pc.Budgets {
-				gs.budgets.Store(pc.Budgets[i].ID, &pc.Budgets[i])
+		for i := range vk.ProviderConfigs {
+			pc := &vk.ProviderConfigs[i]
+			for j := range pc.Budgets {
+				pc.Budgets[j].IsCalendarAligned = vk.CalendarAligned
+				gs.budgets.Store(pc.Budgets[j].ID, &pc.Budgets[j])
 			}
 			if pc.RateLimit != nil {
+				pc.RateLimit.IsCalendarAligned = vk.CalendarAligned
 				gs.rateLimits.Store(pc.RateLimit.ID, pc.RateLimit)
 			}
 		}
@@ -2347,6 +2325,7 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 					clone.Budgets[i].LastReset = existingBudget.LastReset
 				}
 			}
+			clone.Budgets[i].IsCalendarAligned = clone.CalendarAligned
 			gs.budgets.Store(clone.Budgets[i].ID, &clone.Budgets[i])
 		}
 		// Delete removed multi-budgets
@@ -2369,6 +2348,7 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 					clone.RateLimit.RequestLastReset = existingRateLimit.RequestLastReset
 				}
 			}
+			clone.RateLimit.IsCalendarAligned = clone.CalendarAligned
 			// Update the rate limit in the main rateLimits sync.Map
 			gs.rateLimits.Store(clone.RateLimit.ID, clone.RateLimit)
 			// Clean up old rate limit if ID changed (e.g., after AP propagation
@@ -2414,6 +2394,7 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 							clone.ProviderConfigs[i].RateLimit.RequestLastReset = existingRateLimit.RequestLastReset
 						}
 					}
+					clone.ProviderConfigs[i].RateLimit.IsCalendarAligned = clone.CalendarAligned
 					gs.rateLimits.Store(clone.ProviderConfigs[i].RateLimit.ID, clone.ProviderConfigs[i].RateLimit)
 				} else {
 					// Rate limit was removed from provider config, delete it from memory if it existed
@@ -2431,6 +2412,7 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 							b.LastReset = existingBudget.LastReset
 						}
 					}
+					b.IsCalendarAligned = clone.CalendarAligned
 					gs.budgets.Store(b.ID, b)
 				}
 				// Delete removed multi-budgets for this provider config
@@ -2515,12 +2497,14 @@ func (gs *LocalGovernanceStore) CreateTeamInMemory(ctx context.Context, team *co
 
 	// Create associated budgets if they exist
 	for i := range team.Budgets {
+		team.Budgets[i].IsCalendarAligned = team.CalendarAligned
 		b := team.Budgets[i]
 		gs.budgets.Store(b.ID, &b)
 	}
 
 	// Create associated rate limit if exists
 	if team.RateLimit != nil {
+		team.RateLimit.IsCalendarAligned = team.CalendarAligned
 		gs.rateLimits.Store(team.RateLimit.ID, team.RateLimit)
 	}
 
@@ -2561,6 +2545,7 @@ func (gs *LocalGovernanceStore) UpdateTeamInMemory(ctx context.Context, team *co
 					b.LastReset = lb.LastReset
 				}
 			}
+			b.IsCalendarAligned = clone.CalendarAligned
 			gs.budgets.Store(b.ID, b)
 		}
 		for id := range existingBudgetIDs {
@@ -2581,6 +2566,7 @@ func (gs *LocalGovernanceStore) UpdateTeamInMemory(ctx context.Context, team *co
 					clone.RateLimit.RequestLastReset = existingRateLimit.RequestLastReset
 				}
 			}
+			clone.RateLimit.IsCalendarAligned = clone.CalendarAligned
 			gs.rateLimits.Store(clone.RateLimit.ID, clone.RateLimit)
 			// Clean up old rate limit if ID changed (e.g., UUID rotation on propagation)
 			if existingTeam.RateLimit != nil && existingTeam.RateLimit.ID != clone.RateLimit.ID {

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -127,16 +127,14 @@ type UpdateVirtualKeyRequest struct {
 
 // CreateBudgetRequest represents the request body for creating a budget
 type CreateBudgetRequest struct {
-	MaxLimit        float64 `json:"max_limit" validate:"required"`      // Maximum budget in dollars
-	ResetDuration   string  `json:"reset_duration" validate:"required"` // e.g., "30s", "5m", "1h", "1d", "1w", "1M"
-	CalendarAligned bool    `json:"calendar_aligned,omitempty"`         // Snap resets to calendar boundaries (day/week/month/year)
+	MaxLimit      float64 `json:"max_limit" validate:"required"`      // Maximum budget in dollars
+	ResetDuration string  `json:"reset_duration" validate:"required"` // e.g., "30s", "5m", "1h", "1d", "1w", "1M"
 }
 
 // UpdateBudgetRequest represents the request body for updating a budget
 type UpdateBudgetRequest struct {
-	MaxLimit        *float64 `json:"max_limit,omitempty"`
-	ResetDuration   *string  `json:"reset_duration,omitempty"`
-	CalendarAligned *bool    `json:"calendar_aligned,omitempty"` // When switching to true, current usage is reset to 0
+	MaxLimit      *float64 `json:"max_limit,omitempty"`
+	ResetDuration *string  `json:"reset_duration,omitempty"`
 }
 
 // RoutingTarget represents a single weighted routing target within a rule.
@@ -230,18 +228,20 @@ func collectProviderConfigDeleteIDs(
 
 // CreateTeamRequest represents the request body for creating a team
 type CreateTeamRequest struct {
-	Name       string                  `json:"name" validate:"required"`
-	CustomerID *string                 `json:"customer_id,omitempty"` // Team can belong to a customer
-	Budgets    []CreateBudgetRequest   `json:"budgets,omitempty"`     // Multi-budget: each must have a unique reset_duration
-	RateLimit  *CreateRateLimitRequest `json:"rate_limit,omitempty"`  // Team can have its own rate limit
+	Name            string                  `json:"name" validate:"required"`
+	CustomerID      *string                 `json:"customer_id,omitempty"`      // Team can belong to a customer
+	Budgets         []CreateBudgetRequest   `json:"budgets,omitempty"`          // Multi-budget: each must have a unique reset_duration
+	RateLimit       *CreateRateLimitRequest `json:"rate_limit,omitempty"`       // Team can have its own rate limit
+	CalendarAligned bool                    `json:"calendar_aligned,omitempty"` // Team-wide: snap all team budgets and rate-limit resets to calendar boundaries
 }
 
 // UpdateTeamRequest represents the request body for updating a team
 type UpdateTeamRequest struct {
-	Name       *string                 `json:"name,omitempty"`
-	CustomerID *string                 `json:"customer_id,omitempty"`
-	Budgets    []CreateBudgetRequest   `json:"budgets,omitempty"` // Multi-budget: replaces all team budgets
-	RateLimit  *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
+	Name            *string                 `json:"name,omitempty"`
+	CustomerID      *string                 `json:"customer_id,omitempty"`
+	Budgets         []CreateBudgetRequest   `json:"budgets,omitempty"` // Multi-budget: replaces all team budgets
+	RateLimit       *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
+	CalendarAligned *bool                   `json:"calendar_aligned,omitempty"` // Team-wide setting; nil means "leave unchanged"
 }
 
 // CreateCustomerRequest represents the request body for creating a customer
@@ -1514,9 +1514,10 @@ func (h *GovernanceHandler) createTeam(ctx *fasthttp.RequestCtx) {
 	var team configstoreTables.TableTeam
 	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 		team = configstoreTables.TableTeam{
-			ID:         uuid.NewString(),
-			Name:       req.Name,
-			CustomerID: req.CustomerID,
+			ID:              uuid.NewString(),
+			Name:            req.Name,
+			CustomerID:      req.CustomerID,
+			CalendarAligned: req.CalendarAligned,
 		}
 		if req.RateLimit != nil {
 			rateLimit := configstoreTables.TableRateLimit{
@@ -1554,7 +1555,7 @@ func (h *GovernanceHandler) createTeam(ctx *fasthttp.RequestCtx) {
 				ID:            uuid.NewString(),
 				MaxLimit:      b.MaxLimit,
 				ResetDuration: b.ResetDuration,
-				LastReset:     budgetLastReset(b.CalendarAligned, b.ResetDuration),
+				LastReset:     budgetLastReset(team.CalendarAligned, b.ResetDuration),
 				CurrentUsage:  0,
 				TeamID:        &team.ID,
 			}
@@ -1659,6 +1660,18 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 				team.CustomerID = req.CustomerID
 			}
 		}
+		// Resolve team-level calendar alignment for this update:
+		//   - explicit team-level field wins (req.CalendarAligned != nil)
+		//   - else leave existing team.CalendarAligned untouched
+		wasCalendarAligned := team.CalendarAligned
+		if req.CalendarAligned != nil {
+			team.CalendarAligned = *req.CalendarAligned
+		}
+		calendarAlignmentJustEnabled := !wasCalendarAligned && team.CalendarAligned
+		// Snap-to-calendar-period happens after budget/rate-limit reconciliation
+		// below, so combined `calendar_aligned + budgets/rate_limit` updates see
+		// the final persisted state.
+
 		// Multi-budget reconciliation: match by reset_duration, preserve usage on update,
 		// create new budgets for new durations, delete unmatched existing budgets.
 		// Mirrors VK multi-budget handling above.
@@ -1688,14 +1701,9 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 			for _, b := range req.Budgets {
 				if existing, found := existingByDuration[b.ResetDuration]; found {
 					existing.MaxLimit = b.MaxLimit
-					// Match the UI's calendar-alignment confirmation promise: on the
-					// false → true transition, snap LastReset to the current period
-					// start and zero out CurrentUsage now, instead of lazily waiting
-					// for the next period boundary in ResetExpiredBudgetsInMemory.
-					if b.CalendarAligned {
-						existing.LastReset = configstoreTables.GetCalendarPeriodStart(b.ResetDuration, time.Now())
-						existing.CurrentUsage = 0
-					}
+					// LastReset / CurrentUsage are preserved on update; if calendar
+					// alignment was just enabled in this request, the post-reconciliation
+					// snap block below resets them.
 					if err := validateBudget(&existing); err != nil {
 						return err
 					}
@@ -1709,7 +1717,7 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 						ID:            uuid.NewString(),
 						MaxLimit:      b.MaxLimit,
 						ResetDuration: b.ResetDuration,
-						LastReset:     budgetLastReset(b.CalendarAligned, b.ResetDuration),
+						LastReset:     budgetLastReset(team.CalendarAligned, b.ResetDuration),
 						CurrentUsage:  0,
 						TeamID:        &team.ID,
 					}
@@ -1779,6 +1787,44 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 				}
 				team.RateLimitID = &rateLimit.ID
 				team.RateLimit = &rateLimit
+			}
+		}
+		// Snap budgets and rate limit to the current calendar period when calendar
+		// alignment transitions false -> true in this request. Runs after budget/
+		// rate-limit reconciliation so both the standalone-toggle and the combined
+		// (toggle + budgets/rate_limit in the same request) cases are covered, and
+		// only fires once per transition.
+		if calendarAlignmentJustEnabled {
+			now := time.Now()
+			for i := range team.Budgets {
+				b := &team.Budgets[i]
+				if !configstoreTables.IsCalendarAlignableDuration(b.ResetDuration) {
+					continue
+				}
+				b.LastReset = configstoreTables.GetCalendarPeriodStart(b.ResetDuration, now)
+				b.CurrentUsage = 0
+				if err := h.configStore.UpdateBudget(ctx, b, tx); err != nil {
+					return fmt.Errorf("failed to snap team budget %s on calendar-align enable: %w", b.ID, err)
+				}
+			}
+			if team.RateLimit != nil {
+				rl := team.RateLimit
+				snapped := false
+				if rl.TokenResetDuration != nil && configstoreTables.IsCalendarAlignableDuration(*rl.TokenResetDuration) {
+					rl.TokenLastReset = configstoreTables.GetCalendarPeriodStart(*rl.TokenResetDuration, now)
+					rl.TokenCurrentUsage = 0
+					snapped = true
+				}
+				if rl.RequestResetDuration != nil && configstoreTables.IsCalendarAlignableDuration(*rl.RequestResetDuration) {
+					rl.RequestLastReset = configstoreTables.GetCalendarPeriodStart(*rl.RequestResetDuration, now)
+					rl.RequestCurrentUsage = 0
+					snapped = true
+				}
+				if snapped {
+					if err := h.configStore.UpdateRateLimit(ctx, rl, tx); err != nil {
+						return fmt.Errorf("failed to snap team rate limit on calendar-align enable: %w", err)
+					}
+				}
 			}
 		}
 		if err := h.configStore.UpdateTeam(ctx, team, tx); err != nil {

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -196,11 +196,6 @@ func TestBudgetRemovalRequestDetection(t *testing.T) {
 			req:  &UpdateBudgetRequest{ResetDuration: schemas.Ptr("1h")},
 			want: false,
 		},
-		{
-			name: "calendar aligned only is treated as removal",
-			req:  &UpdateBudgetRequest{CalendarAligned: schemas.Ptr(true)},
-			want: true,
-		},
 	}
 
 	for _, tt := range tests {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -418,6 +418,48 @@ func applyV1Compat(configData *ConfigData) {
 	}
 }
 
+// promoteDeprecatedCalendarAligned lifts the legacy per-budget / per-rate-limit
+// calendar_aligned input to the owning VK or Team. Owner wins if already true;
+// otherwise OR across descendants (own budgets/rate-limit + every provider
+// config's budgets/rate-limit). Inner pointers are always cleared. Mirrors the
+// enterprise promoteDeprecatedAccessProfileCalendarAligned at the access
+// profile level. Runs on every load regardless of config version
+func promoteDeprecatedCalendarAligned(configData *ConfigData) {
+	if configData == nil || configData.Governance == nil {
+		return
+	}
+	for i := range configData.Governance.VirtualKeys {
+		vk := &configData.Governance.VirtualKeys[i]
+		promoteCalendarAligned(&vk.CalendarAligned, vk.Budgets, vk.RateLimit)
+		for j := range vk.ProviderConfigs {
+			pc := &vk.ProviderConfigs[j]
+			promoteCalendarAligned(&vk.CalendarAligned, pc.Budgets, pc.RateLimit)
+		}
+	}
+	for i := range configData.Governance.Teams {
+		team := &configData.Governance.Teams[i]
+		promoteCalendarAligned(&team.CalendarAligned, team.Budgets, team.RateLimit)
+	}
+}
+
+// promoteCalendarAligned ORs each child's legacy calendar_aligned input into
+// the owner's flag and clears the child field. Treats a nil child pointer as
+// "not set" — only explicit true contributes.
+func promoteCalendarAligned(owner *bool, budgets []configstoreTables.TableBudget, rateLimit *configstoreTables.TableRateLimit) {
+	for i := range budgets {
+		if budgets[i].CalendarAlignedInput != nil && *budgets[i].CalendarAlignedInput {
+			*owner = true
+		}
+		budgets[i].CalendarAlignedInput = nil
+	}
+	if rateLimit != nil && rateLimit.CalendarAlignedInput != nil {
+		if *rateLimit.CalendarAlignedInput {
+			*owner = true
+		}
+		rateLimit.CalendarAlignedInput = nil
+	}
+}
+
 // LoadConfig loads initial configuration from a JSON config file into memory
 // with full preprocessing including environment variable resolution and key config parsing.
 // All processing is done upfront to ensure zero latency when retrieving data.
@@ -504,6 +546,10 @@ func LoadConfig(ctx context.Context, configDirPath string) (*Config, error) {
 			return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 		}
 		logger.Info("loading configuration from: %s", absConfigFilePath)
+		// Promote deprecated per-budget / per-rate-limit calendar_aligned to the
+		// owning VK / Team. Independent of config version — the deprecation
+		// predates the v1/v2 allow-list split.
+		promoteDeprecatedCalendarAligned(&configData)
 		// If version is 1, apply v1.4.x compatibility: empty allow-list arrays mean "allow all"
 		if configData.Version == 1 {
 			logger.Info("config version 1 detected, applying v1.4.x compatibility semantics (empty arrays = allow all)")

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -392,7 +392,7 @@
               },
               "calendar_aligned": {
                 "type": "boolean",
-                "description": "Snap reset windows to clean calendar boundaries (day, week, month, year)",
+                "description": "Deprecated: set calendar_aligned on the owner (team / virtual key / access profile) instead. Kept for backward compatibility with older config.json files; ignored unless a reconciler promotes it to its owner.",
                 "default": false
               }
             },
@@ -448,7 +448,7 @@
               },
               "calendar_aligned": {
                 "type": "boolean",
-                "description": "Snap reset windows to clean calendar boundaries (day, week, month, year)",
+                "description": "Deprecated: set calendar_aligned on the owner (team / virtual key / access profile) instead. Kept for backward compatibility with older config.json files; ignored unless a reconciler promotes it to its owner.",
                 "default": false
               }
             },
@@ -524,6 +524,11 @@
               "claims": {
                 "type": "object",
                 "description": "Team claims data"
+              },
+              "calendar_aligned": {
+                "type": "boolean",
+                "description": "Snap the team's budget and rate-limit reset windows to clean calendar boundaries (day, week, month, year)",
+                "default": false
               },
               "virtual_key_count": {
                 "type": "integer",
@@ -3889,6 +3894,11 @@
         "reset_duration": {
           "type": "string",
           "description": "Reset window, e.g. \"1M\", \"1h\""
+        },
+        "calendar_aligned": {
+          "type": "boolean",
+          "description": "Deprecated: set calendar_aligned on the parent access profile instead. Kept for backward compatibility with older config.json files; the access-profile reconciler promotes any true value here to the profile's top-level calendar_aligned at load time.",
+          "default": false
         }
       },
       "required": ["id", "max_limit", "reset_duration"],
@@ -3916,6 +3926,11 @@
         "request_reset_duration": {
           "type": "string",
           "description": "Request reset window, e.g. \"1M\", \"1h\""
+        },
+        "calendar_aligned": {
+          "type": "boolean",
+          "description": "Deprecated: set calendar_aligned on the parent access profile instead. Kept for backward compatibility with older config.json files; the access-profile reconciler promotes any true value here to the profile's top-level calendar_aligned at load time.",
+          "default": false
         }
       },
       "required": ["id"],
@@ -3953,6 +3968,11 @@
         },
         "rate_limit": {
           "$ref": "#/$defs/rate_limit_line"
+        },
+        "calendar_aligned": {
+          "type": "boolean",
+          "description": "Snap budget and rate-limit reset windows to clean calendar boundaries (day, week, month, year) for this profile",
+          "default": false
         },
         "provider_configs": {
           "type": "array",

--- a/ui/app/workspace/governance/views/teamDialog.tsx
+++ b/ui/app/workspace/governance/views/teamDialog.tsx
@@ -1,24 +1,48 @@
 import FormFooter from "@/components/formFooter";
 import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants/governance";
-import { getErrorMessage, useCreateTeamMutation, useUpdateTeamMutation } from "@/lib/store";
-import { CreateTeamRequest, Customer, Team, UpdateTeamRequest } from "@/lib/types/governance";
+import {
+  resetDurationOptions,
+  supportsCalendarAlignment,
+} from "@/lib/constants/governance";
+import {
+  getErrorMessage,
+  useCreateTeamMutation,
+  useUpdateTeamMutation,
+} from "@/lib/store";
+import {
+  CreateTeamRequest,
+  Customer,
+  Team,
+  UpdateTeamRequest,
+} from "@/lib/types/governance";
 import { formatCurrency } from "@/lib/utils/governance";
 import { Validator } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -29,10 +53,10 @@ import { toast } from "sonner";
 import { v4 as uuid } from "uuid";
 
 interface TeamDialogProps {
-	team?: Team | null;
-	customers: Customer[];
-	onSave: () => void;
-	onCancel: () => void;
+  team?: Team | null;
+  customers: Customer[];
+  onSave: () => void;
+  onCancel: () => void;
 }
 
 // One editable budget row; teams own multiple, each keyed by reset_duration
@@ -41,550 +65,688 @@ interface TeamDialogProps {
 // used as the React key and for matching against `team.budgets` when we need
 // to distinguish "already persisted" from "just added in the form".
 interface TeamBudgetRow {
-	id: string;
-	maxLimit: number | undefined;
-	resetDuration: string;
-	calendarAligned: boolean;
+  id: string;
+  maxLimit: number | undefined;
+  resetDuration: string;
 }
 
 interface TeamFormData {
-	name: string;
-	customerId: string;
-	// Multi-budget: each row has a unique reset_duration on submit
-	budgets: TeamBudgetRow[];
-	// Rate Limit
-	tokenMaxLimit: number | undefined;
-	tokenResetDuration: string;
-	requestMaxLimit: number | undefined;
-	requestResetDuration: string;
-	isDirty: boolean;
+  name: string;
+  customerId: string;
+  // Multi-budget: each row has a unique reset_duration on submit
+  budgets: TeamBudgetRow[];
+  // Rate Limit
+  tokenMaxLimit: number | undefined;
+  tokenResetDuration: string;
+  requestMaxLimit: number | undefined;
+  requestResetDuration: string;
+  // Team-wide: applies to all team budgets and the team rate limit
+  calendarAligned: boolean;
+  isDirty: boolean;
 }
 
 // Helper function to create initial state
-const createInitialState = (team?: Team | null): Omit<TeamFormData, "isDirty"> => {
-	return {
-		name: team?.name || "",
-		customerId: team?.customer_id || "",
-		budgets:
-			team?.budgets?.map((b) => ({
-				id: b.id,
-				maxLimit: b.max_limit,
-				resetDuration: b.reset_duration,
-				calendarAligned: b.calendar_aligned ?? false,
-			})) ?? [],
-		// Rate Limit
-		tokenMaxLimit: team?.rate_limit?.token_max_limit ?? undefined,
-		tokenResetDuration: team?.rate_limit?.token_reset_duration || "1h",
-		requestMaxLimit: team?.rate_limit?.request_max_limit ?? undefined,
-		requestResetDuration: team?.rate_limit?.request_reset_duration || "1h",
-	};
+const createInitialState = (
+  team?: Team | null,
+): Omit<TeamFormData, "isDirty"> => {
+  return {
+    name: team?.name || "",
+    customerId: team?.customer_id || "",
+    budgets:
+      team?.budgets?.map((b) => ({
+        id: b.id,
+        maxLimit: b.max_limit,
+        resetDuration: b.reset_duration,
+      })) ?? [],
+    // Rate Limit
+    tokenMaxLimit: team?.rate_limit?.token_max_limit ?? undefined,
+    tokenResetDuration: team?.rate_limit?.token_reset_duration || "1h",
+    requestMaxLimit: team?.rate_limit?.request_max_limit ?? undefined,
+    requestResetDuration: team?.rate_limit?.request_reset_duration || "1h",
+    calendarAligned: team?.calendar_aligned ?? false,
+  };
 };
 
-export default function TeamDialog({ team, customers, onSave, onCancel }: TeamDialogProps) {
-	const isEditing = !!team;
-	const [initialState, setInitialState] = useState<Omit<TeamFormData, "isDirty">>(createInitialState(team));
-	const [formData, setFormData] = useState<TeamFormData>({
-		...initialState,
-		isDirty: false,
-	});
+export default function TeamDialog({
+  team,
+  customers,
+  onSave,
+  onCancel,
+}: TeamDialogProps) {
+  const isEditing = !!team;
+  const [initialState, setInitialState] = useState<
+    Omit<TeamFormData, "isDirty">
+  >(createInitialState(team));
+  const [formData, setFormData] = useState<TeamFormData>({
+    ...initialState,
+    isDirty: false,
+  });
 
-	useEffect(() => {
-		const nextInitial = createInitialState(team);
-		setInitialState(nextInitial);
-		setFormData({ ...nextInitial, isDirty: false });
-		setPendingCalendarAlignIdx(null);
-	}, [team]);
+  useEffect(() => {
+    const nextInitial = createInitialState(team);
+    setInitialState(nextInitial);
+    setFormData({ ...nextInitial, isDirty: false });
+    setShowCalendarAlignWarning(false);
+  }, [team]);
 
-	const hasCreateAccess = useRbac(RbacResource.Teams, RbacOperation.Create);
-	const hasUpdateAccess = useRbac(RbacResource.Teams, RbacOperation.Update);
-	const hasPermission = isEditing ? hasUpdateAccess : hasCreateAccess;
+  const hasCreateAccess = useRbac(RbacResource.Teams, RbacOperation.Create);
+  const hasUpdateAccess = useRbac(RbacResource.Teams, RbacOperation.Update);
+  const hasPermission = isEditing ? hasUpdateAccess : hasCreateAccess;
 
-	// RTK Query hooks
-	const [createTeam, { isLoading: isCreating }] = useCreateTeamMutation();
-	const [updateTeam, { isLoading: isUpdating }] = useUpdateTeamMutation();
-	const loading = isCreating || isUpdating;
+  // RTK Query hooks
+  const [createTeam, { isLoading: isCreating }] = useCreateTeamMutation();
+  const [updateTeam, { isLoading: isUpdating }] = useUpdateTeamMutation();
+  const loading = isCreating || isUpdating;
 
-	// Tracks which row (by index) is awaiting calendar-align confirmation.
-	const [pendingCalendarAlignIdx, setPendingCalendarAlignIdx] = useState<number | null>(null);
-	const showCalendarAlignWarning = pendingCalendarAlignIdx !== null;
+  // Team-wide calendar-align toggle: confirmation only fires on the off→on
+  // transition for an existing team (mirrors the VK sheet behavior).
+  const [showCalendarAlignWarning, setShowCalendarAlignWarning] =
+    useState(false);
 
-	const updateBudgetRow = (idx: number, patch: Partial<TeamBudgetRow>) => {
-		setFormData((prev) => {
-			const next = prev.budgets.map((row, i) => (i === idx ? { ...row, ...patch } : row));
-			return { ...prev, budgets: next };
-		});
-	};
+  const updateBudgetRow = (idx: number, patch: Partial<TeamBudgetRow>) => {
+    setFormData((prev) => {
+      const next = prev.budgets.map((row, i) =>
+        i === idx ? { ...row, ...patch } : row,
+      );
+      return { ...prev, budgets: next };
+    });
+  };
 
-	const addBudgetRow = () => {
-		setFormData((prev) => ({
-			...prev,
-			budgets: [
-				...prev.budgets,
-				{
-					id: uuid(),
-					maxLimit: undefined,
-					resetDuration: "1M",
-					calendarAligned: false,
-				},
-			],
-		}));
-	};
+  const addBudgetRow = () => {
+    setFormData((prev) => ({
+      ...prev,
+      budgets: [
+        ...prev.budgets,
+        {
+          id: uuid(),
+          maxLimit: undefined,
+          resetDuration: "1M",
+        },
+      ],
+    }));
+  };
 
-	const removeBudgetRow = (idx: number) => {
-		setFormData((prev) => ({
-			...prev,
-			budgets: prev.budgets.filter((_, i) => i !== idx),
-		}));
-	};
+  const removeBudgetRow = (idx: number) => {
+    setFormData((prev) => ({
+      ...prev,
+      budgets: prev.budgets.filter((_, i) => i !== idx),
+    }));
+  };
 
-	const handleCalendarAlignedChange = (idx: number, checked: boolean) => {
-		// Match the persisted budget by stable row id — for seeded rows this equals
-		// the server-side budget id; for newly-added rows it's a client-only UUID
-		// that won't match anything in team.budgets (correctly: no warning for new rows).
-		// Avoids the reset_duration-duplicate ambiguity before validation resolves.
-		const rowId = formData.budgets[idx]?.id;
-		const existingBudget = team?.budgets?.find((b) => b.id === rowId);
-		if (checked && isEditing && existingBudget && !existingBudget.calendar_aligned) {
-			setPendingCalendarAlignIdx(idx);
-		} else {
-			updateBudgetRow(idx, { calendarAligned: checked });
-		}
-	};
+  const handleCalendarAlignedChange = (checked: boolean) => {
+    // Warn only on the persisted false→true transition. Toggling off then
+    // back on within the same edit session doesn't reset on save (the backend
+    // snap also runs only on the persisted transition), so no warning needed.
+    if (checked && isEditing && !initialState.calendarAligned) {
+      setShowCalendarAlignWarning(true);
+    } else {
+      updateField("calendarAligned", checked);
+    }
+  };
 
-	// Track isDirty state
-	useEffect(() => {
-		const currentData: Omit<TeamFormData, "isDirty"> = {
-			name: formData.name,
-			customerId: formData.customerId,
-			budgets: formData.budgets,
-			tokenMaxLimit: formData.tokenMaxLimit,
-			tokenResetDuration: formData.tokenResetDuration,
-			requestMaxLimit: formData.requestMaxLimit,
-			requestResetDuration: formData.requestResetDuration,
-		};
-		setFormData((prev) => ({
-			...prev,
-			isDirty: !isEqual(initialState, currentData),
-		}));
-	}, [
-		formData.name,
-		formData.customerId,
-		formData.budgets,
-		formData.tokenMaxLimit,
-		formData.tokenResetDuration,
-		formData.requestMaxLimit,
-		formData.requestResetDuration,
-		initialState,
-	]);
+  // Track isDirty state
+  useEffect(() => {
+    const currentData: Omit<TeamFormData, "isDirty"> = {
+      name: formData.name,
+      customerId: formData.customerId,
+      budgets: formData.budgets,
+      tokenMaxLimit: formData.tokenMaxLimit,
+      tokenResetDuration: formData.tokenResetDuration,
+      requestMaxLimit: formData.requestMaxLimit,
+      requestResetDuration: formData.requestResetDuration,
+      calendarAligned: formData.calendarAligned,
+    };
+    setFormData((prev) => ({
+      ...prev,
+      isDirty: !isEqual(initialState, currentData),
+    }));
+  }, [
+    formData.name,
+    formData.customerId,
+    formData.budgets,
+    formData.tokenMaxLimit,
+    formData.tokenResetDuration,
+    formData.requestMaxLimit,
+    formData.requestResetDuration,
+    formData.calendarAligned,
+    initialState,
+  ]);
 
-	const tokenMaxLimitNum = formData.tokenMaxLimit;
-	const requestMaxLimitNum = formData.requestMaxLimit;
+  const tokenMaxLimitNum = formData.tokenMaxLimit;
+  const requestMaxLimitNum = formData.requestMaxLimit;
 
-	// Validation
-	const validator = useMemo(() => {
-		// Per-row budget validation plus cross-row uniqueness on reset_duration.
-		const budgetValidators = formData.budgets.flatMap((row, idx) => {
-			if (row.maxLimit === undefined || row.maxLimit === null) return [];
-			return [
-				Validator.minValue(row.maxLimit, 0.01, `Budget #${idx + 1} max limit must be greater than $0.01`),
-				Validator.required(row.resetDuration, `Budget #${idx + 1} reset duration is required`),
-			];
-		});
-		const populatedDurations = formData.budgets.filter((r) => r.maxLimit !== undefined && r.maxLimit !== null).map((r) => r.resetDuration);
-		const uniqueDurations = new Set(populatedDurations).size;
+  // Validation
+  const validator = useMemo(() => {
+    // Per-row budget validation plus cross-row uniqueness on reset_duration.
+    const budgetValidators = formData.budgets.flatMap((row, idx) => {
+      if (row.maxLimit === undefined || row.maxLimit === null) return [];
+      return [
+        Validator.minValue(
+          row.maxLimit,
+          0.01,
+          `Budget #${idx + 1} max limit must be greater than $0.01`,
+        ),
+        Validator.required(
+          row.resetDuration,
+          `Budget #${idx + 1} reset duration is required`,
+        ),
+      ];
+    });
+    const populatedDurations = formData.budgets
+      .filter((r) => r.maxLimit !== undefined && r.maxLimit !== null)
+      .map((r) => r.resetDuration);
+    const uniqueDurations = new Set(populatedDurations).size;
 
-		return new Validator([
-			Validator.required(formData.name.trim(), "Team name is required"),
-			Validator.custom(formData.isDirty, "No changes to save"),
-			...budgetValidators,
-			Validator.custom(uniqueDurations === populatedDurations.length, "Each budget must have a distinct reset duration"),
+    return new Validator([
+      Validator.required(formData.name.trim(), "Team name is required"),
+      Validator.custom(formData.isDirty, "No changes to save"),
+      ...budgetValidators,
+      Validator.custom(
+        uniqueDurations === populatedDurations.length,
+        "Each budget must have a distinct reset duration",
+      ),
 
-			// Rate limit validation - token limits
-			...(formData.tokenMaxLimit !== undefined && formData.tokenMaxLimit !== null
-				? [
-						Validator.minValue(tokenMaxLimitNum || 0, 1, "Token max limit must be at least 1"),
-						Validator.required(formData.tokenResetDuration, "Token reset duration is required"),
-					]
-				: []),
+      // Rate limit validation - token limits
+      ...(formData.tokenMaxLimit !== undefined &&
+      formData.tokenMaxLimit !== null
+        ? [
+            Validator.minValue(
+              tokenMaxLimitNum || 0,
+              1,
+              "Token max limit must be at least 1",
+            ),
+            Validator.required(
+              formData.tokenResetDuration,
+              "Token reset duration is required",
+            ),
+          ]
+        : []),
 
-			// Rate limit validation - request limits
-			...(formData.requestMaxLimit !== undefined && formData.requestMaxLimit !== null
-				? [
-						Validator.minValue(requestMaxLimitNum || 0, 1, "Request max limit must be at least 1"),
-						Validator.required(formData.requestResetDuration, "Request reset duration is required"),
-					]
-				: []),
-		]);
-	}, [formData, tokenMaxLimitNum, requestMaxLimitNum]);
+      // Rate limit validation - request limits
+      ...(formData.requestMaxLimit !== undefined &&
+      formData.requestMaxLimit !== null
+        ? [
+            Validator.minValue(
+              requestMaxLimitNum || 0,
+              1,
+              "Request max limit must be at least 1",
+            ),
+            Validator.required(
+              formData.requestResetDuration,
+              "Request reset duration is required",
+            ),
+          ]
+        : []),
+    ]);
+  }, [formData, tokenMaxLimitNum, requestMaxLimitNum]);
 
-	const updateField = <K extends keyof TeamFormData>(field: K, value: TeamFormData[K]) => {
-		setFormData((prev) => ({ ...prev, [field]: value }));
-	};
+  const updateField = <K extends keyof TeamFormData>(
+    field: K,
+    value: TeamFormData[K],
+  ) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
 
-	const handleSubmit = async (e: React.FormEvent) => {
-		e.preventDefault();
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
 
-		if (!validator.isValid()) {
-			toast.error(validator.getFirstError());
-			return;
-		}
+    if (!validator.isValid()) {
+      toast.error(validator.getFirstError());
+      return;
+    }
 
-		// Serialize budget rows whose max_limit was filled in — rows left blank
-		// are silently dropped (the backend treats the slice as authoritative).
-		const submittableBudgets = formData.budgets
-			.filter((r) => r.maxLimit !== undefined && r.maxLimit !== null)
-			.map((r) => ({
-				max_limit: r.maxLimit as number,
-				reset_duration: r.resetDuration,
-				calendar_aligned: r.calendarAligned,
-			}));
+    // Serialize budget rows whose max_limit was filled in — rows left blank
+    // are silently dropped (the backend treats the slice as authoritative).
+    const submittableBudgets = formData.budgets
+      .filter((r) => r.maxLimit !== undefined && r.maxLimit !== null)
+      .map((r) => ({
+        max_limit: r.maxLimit as number,
+        reset_duration: r.resetDuration,
+      }));
 
-		try {
-			if (isEditing && team) {
-				// Update existing team
-				const updateData: UpdateTeamRequest = {
-					name: formData.name,
-					customer_id: formData.customerId || undefined,
-					// Always send: backend treats `budgets` as a full replacement.
-					budgets: submittableBudgets,
-				};
+    try {
+      if (isEditing && team) {
+        // Update existing team
+        const updateData: UpdateTeamRequest = {
+          name: formData.name,
+          customer_id: formData.customerId || undefined,
+          // Always send: backend treats `budgets` as a full replacement.
+          budgets: submittableBudgets,
+          // Team-wide setting that governs both team budgets and the team rate limit.
+          calendar_aligned: formData.calendarAligned,
+        };
 
-				// Detect rate limit changes using had/has pattern
-				const hadRateLimit = !!team.rate_limit;
-				const hasRateLimit =
-					(tokenMaxLimitNum !== undefined && tokenMaxLimitNum !== null) ||
-					(requestMaxLimitNum !== undefined && requestMaxLimitNum !== null);
-				if (hasRateLimit) {
-					updateData.rate_limit = {
-						token_max_limit: tokenMaxLimitNum,
-						token_reset_duration: tokenMaxLimitNum !== undefined && tokenMaxLimitNum !== null ? formData.tokenResetDuration : undefined,
-						request_max_limit: requestMaxLimitNum,
-						request_reset_duration:
-							requestMaxLimitNum !== undefined && requestMaxLimitNum !== null ? formData.requestResetDuration : undefined,
-					};
-				} else if (hadRateLimit) {
-					updateData.rate_limit = {} as UpdateTeamRequest["rate_limit"];
-				}
+        // Detect rate limit changes using had/has pattern
+        const hadRateLimit = !!team.rate_limit;
+        const hasRateLimit =
+          (tokenMaxLimitNum !== undefined && tokenMaxLimitNum !== null) ||
+          (requestMaxLimitNum !== undefined && requestMaxLimitNum !== null);
+        if (hasRateLimit) {
+          updateData.rate_limit = {
+            token_max_limit: tokenMaxLimitNum,
+            token_reset_duration:
+              tokenMaxLimitNum !== undefined && tokenMaxLimitNum !== null
+                ? formData.tokenResetDuration
+                : undefined,
+            request_max_limit: requestMaxLimitNum,
+            request_reset_duration:
+              requestMaxLimitNum !== undefined && requestMaxLimitNum !== null
+                ? formData.requestResetDuration
+                : undefined,
+          };
+        } else if (hadRateLimit) {
+          updateData.rate_limit = {} as UpdateTeamRequest["rate_limit"];
+        }
 
-				await updateTeam({ teamId: team.id, data: updateData }).unwrap();
-				toast.success("Team updated successfully");
-			} else {
-				// Create new team
-				const createData: CreateTeamRequest = {
-					name: formData.name,
-					customer_id: formData.customerId || undefined,
-					budgets: submittableBudgets.length > 0 ? submittableBudgets : undefined,
-				};
+        await updateTeam({ teamId: team.id, data: updateData }).unwrap();
+        toast.success("Team updated successfully");
+      } else {
+        // Create new team
+        const createData: CreateTeamRequest = {
+          name: formData.name,
+          customer_id: formData.customerId || undefined,
+          budgets:
+            submittableBudgets.length > 0 ? submittableBudgets : undefined,
+          // Team-wide setting that governs both team budgets and the team rate limit.
+          calendar_aligned: formData.calendarAligned,
+        };
 
-				// Add rate limit if enabled (token or request limits)
-				if (
-					(tokenMaxLimitNum !== undefined && tokenMaxLimitNum !== null) ||
-					(requestMaxLimitNum !== undefined && requestMaxLimitNum !== null)
-				) {
-					createData.rate_limit = {
-						token_max_limit: tokenMaxLimitNum,
-						token_reset_duration: tokenMaxLimitNum !== undefined && tokenMaxLimitNum !== null ? formData.tokenResetDuration : undefined,
-						request_max_limit: requestMaxLimitNum,
-						request_reset_duration:
-							requestMaxLimitNum !== undefined && requestMaxLimitNum !== null ? formData.requestResetDuration : undefined,
-					};
-				}
+        // Add rate limit if enabled (token or request limits)
+        if (
+          (tokenMaxLimitNum !== undefined && tokenMaxLimitNum !== null) ||
+          (requestMaxLimitNum !== undefined && requestMaxLimitNum !== null)
+        ) {
+          createData.rate_limit = {
+            token_max_limit: tokenMaxLimitNum,
+            token_reset_duration:
+              tokenMaxLimitNum !== undefined && tokenMaxLimitNum !== null
+                ? formData.tokenResetDuration
+                : undefined,
+            request_max_limit: requestMaxLimitNum,
+            request_reset_duration:
+              requestMaxLimitNum !== undefined && requestMaxLimitNum !== null
+                ? formData.requestResetDuration
+                : undefined,
+          };
+        }
 
-				await createTeam(createData).unwrap();
-				toast.success("Team created successfully");
-			}
+        await createTeam(createData).unwrap();
+        toast.success("Team created successfully");
+      }
 
-			onSave();
-		} catch (error) {
-			toast.error(getErrorMessage(error));
-		}
-	};
+      onSave();
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+    }
+  };
 
-	return (
-		<Dialog open onOpenChange={onCancel}>
-			<DialogContent className="sm:max-w-2xl" data-testid="team-dialog-content">
-				<DialogHeader>
-					<DialogTitle className="flex items-center gap-2">{isEditing ? "Edit Team" : "Create Team"}</DialogTitle>
-					<DialogDescription>
-						{isEditing ? "Update the team information and settings." : "Create a new team to organize users and manage shared resources."}
-					</DialogDescription>
-				</DialogHeader>
+  return (
+    <Dialog open onOpenChange={onCancel}>
+      <DialogContent className="sm:max-w-2xl" data-testid="team-dialog-content">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {isEditing ? "Edit Team" : "Create Team"}
+          </DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? "Update the team information and settings."
+              : "Create a new team to organize users and manage shared resources."}
+          </DialogDescription>
+        </DialogHeader>
 
-				<form onSubmit={handleSubmit} className="">
-					<div className="space-y-6">
-						{/* Basic Information */}
-						<div className="">
-							<div className="space-y-2">
-								<Label htmlFor="name">Team Name *</Label>
-								<Input
-									id="name"
-									placeholder="e.g., Engineering Team"
-									value={formData.name}
-									maxLength={50}
-									onChange={(e) => updateField("name", e.target.value)}
-									data-testid="team-name-input"
-								/>
-							</div>
+        <form onSubmit={handleSubmit} className="">
+          <div className="space-y-6">
+            {/* Basic Information */}
+            <div className="">
+              <div className="space-y-2">
+                <Label htmlFor="name">Team Name *</Label>
+                <Input
+                  id="name"
+                  placeholder="e.g., Engineering Team"
+                  value={formData.name}
+                  maxLength={50}
+                  onChange={(e) => updateField("name", e.target.value)}
+                  data-testid="team-name-input"
+                />
+              </div>
 
-							{/* Customer Assignment */}
-							{customers?.length > 0 && (
-								<div className="space-y-2">
-									<Label htmlFor="customer">Customer (optional)</Label>
-									<Select
-										value={formData.customerId || "__none__"}
-										onValueChange={(value) => updateField("customerId", value === "__none__" ? "" : value)}
-									>
-										<SelectTrigger id="customer" className="w-full" data-testid="team-customer-select-trigger">
-											<SelectValue placeholder="Select a customer" />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="__none__" data-testid="team-customer-option-none">
-												None
-											</SelectItem>
-											{customers.map((customer) => (
-												<SelectItem key={customer.id} value={customer.id} data-testid={`team-customer-option-${customer.id}`}>
-													{customer.name}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-									<p className="text-muted-foreground text-sm">Assign to a customer or leave independent.</p>
-								</div>
-							)}
-						</div>
+              {/* Customer Assignment */}
+              {customers?.length > 0 && (
+                <div className="space-y-2">
+                  <Label htmlFor="customer">Customer (optional)</Label>
+                  <Select
+                    value={formData.customerId || "__none__"}
+                    onValueChange={(value) =>
+                      updateField(
+                        "customerId",
+                        value === "__none__" ? "" : value,
+                      )
+                    }
+                  >
+                    <SelectTrigger
+                      id="customer"
+                      className="w-full"
+                      data-testid="team-customer-select-trigger"
+                    >
+                      <SelectValue placeholder="Select a customer" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem
+                        value="__none__"
+                        data-testid="team-customer-option-none"
+                      >
+                        None
+                      </SelectItem>
+                      {customers.map((customer) => (
+                        <SelectItem
+                          key={customer.id}
+                          value={customer.id}
+                          data-testid={`team-customer-option-${customer.id}`}
+                        >
+                          {customer.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-muted-foreground text-sm">
+                    Assign to a customer or leave independent.
+                  </p>
+                </div>
+              )}
+            </div>
 
-						{/* Multi-budget configuration: one row per budget, each keyed by reset_duration */}
-						<div className="space-y-3">
-							<div className="flex items-center justify-between">
-								<Label>Budgets</Label>
-								<button
-									type="button"
-									onClick={addBudgetRow}
-									className="text-primary text-xs font-medium hover:underline"
-									data-testid="team-add-budget-btn"
-								>
-									+ Add budget
-								</button>
-							</div>
-							{formData.budgets.length === 0 && (
-								<p className="text-muted-foreground text-xs">No budgets. Click "Add budget" to enforce a spend limit.</p>
-							)}
-							{formData.budgets.map((row, idx) => (
-								<div key={row.id} className="space-y-2 rounded-md border p-3" data-testid={`team-budget-row-${idx}`}>
-									<div className="flex items-start gap-2">
-										<div className="flex-1">
-											<NumberAndSelect
-												id={`budgetMaxLimit-${idx}`}
-												label={`Budget #${idx + 1} — Maximum Spend (USD)`}
-												value={row.maxLimit}
-												selectValue={row.resetDuration}
-												onChangeNumber={(value) => updateBudgetRow(idx, { maxLimit: value })}
-												onChangeSelect={(value) => {
-													const patch: Partial<TeamBudgetRow> = {
-														resetDuration: value,
-													};
-													if (!supportsCalendarAlignment(value)) {
-														patch.calendarAligned = false;
-													}
-													updateBudgetRow(idx, patch);
-												}}
-												options={resetDurationOptions}
-												dataTestId={`budget-max-limit-input-${idx}`}
-											/>
-										</div>
-										<button
-											type="button"
-											onClick={() => removeBudgetRow(idx)}
-											className="text-muted-foreground hover:text-destructive mt-6 text-xs font-medium"
-											data-testid={`team-remove-budget-btn-${idx}`}
-										>
-											Remove
-										</button>
-									</div>
+            {/* Multi-budget configuration: one row per budget, each keyed by reset_duration */}
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <Label>Budgets</Label>
+                <button
+                  type="button"
+                  onClick={addBudgetRow}
+                  className="text-primary text-xs font-medium hover:underline"
+                  data-testid="team-add-budget-btn"
+                >
+                  + Add budget
+                </button>
+              </div>
+              {formData.budgets.length === 0 && (
+                <p className="text-muted-foreground text-xs">
+                  No budgets. Click "Add budget" to enforce a spend limit.
+                </p>
+              )}
+              {formData.budgets.map((row, idx) => (
+                <div
+                  key={row.id}
+                  className="space-y-2 rounded-md border p-3"
+                  data-testid={`team-budget-row-${idx}`}
+                >
+                  <div className="flex items-start gap-2">
+                    <div className="flex-1">
+                      <NumberAndSelect
+                        id={`budgetMaxLimit-${idx}`}
+                        label={`Budget #${idx + 1} — Maximum Spend (USD)`}
+                        value={row.maxLimit}
+                        selectValue={row.resetDuration}
+                        onChangeNumber={(value) =>
+                          updateBudgetRow(idx, { maxLimit: value })
+                        }
+                        onChangeSelect={(value) =>
+                          updateBudgetRow(idx, { resetDuration: value })
+                        }
+                        options={resetDurationOptions}
+                        dataTestId={`budget-max-limit-input-${idx}`}
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => removeBudgetRow(idx)}
+                      className="text-muted-foreground hover:text-destructive mt-6 text-xs font-medium"
+                      data-testid={`team-remove-budget-btn-${idx}`}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
 
-									{row.maxLimit !== undefined && supportsCalendarAlignment(row.resetDuration) && (
-										<div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
-											<div className="space-y-0.5">
-												<Label htmlFor={`team-budget-calendar-aligned-toggle-${idx}`} className="text-sm font-normal">
-													Align to calendar cycle
-												</Label>
-												<p className="text-muted-foreground text-xs">
-													Reset at the start of each period (e.g. 1st of month) instead of rolling from creation date
-												</p>
-											</div>
-											<Switch
-												id={`team-budget-calendar-aligned-toggle-${idx}`}
-												checked={row.calendarAligned}
-												onCheckedChange={(checked) => handleCalendarAlignedChange(idx, checked)}
-												data-testid={`team-budget-calendar-aligned-toggle-${idx}`}
-											/>
-										</div>
-									)}
-								</div>
-							))}
-						</div>
+            {/* Rate Limit Configuration - Token Limits */}
+            <NumberAndSelect
+              id="tokenMaxLimit"
+              label="Maximum Tokens"
+              value={formData.tokenMaxLimit}
+              selectValue={formData.tokenResetDuration}
+              onChangeNumber={(value) => updateField("tokenMaxLimit", value)}
+              onChangeSelect={(value) =>
+                updateField("tokenResetDuration", value)
+              }
+              options={resetDurationOptions}
+            />
 
-						{/* Warning dialog shown when enabling calendar alignment on an existing budget */}
-						<AlertDialog
-							open={showCalendarAlignWarning}
-							onOpenChange={(open) => {
-								if (!open) setPendingCalendarAlignIdx(null);
-							}}
-						>
-							<AlertDialogContent>
-								<AlertDialogHeader>
-									<AlertDialogTitle>Reset budget usage?</AlertDialogTitle>
-									<AlertDialogDescription>
-										Enabling calendar alignment will reset this budget&apos;s current usage to <span className="font-semibold">$0.00</span>{" "}
-										and snap the reset date to the start of the current{" "}
-										{pendingCalendarAlignIdx !== null && formData.budgets[pendingCalendarAlignIdx]?.resetDuration === "1d"
-											? "day"
-											: pendingCalendarAlignIdx !== null && formData.budgets[pendingCalendarAlignIdx]?.resetDuration === "1w"
-												? "week"
-												: pendingCalendarAlignIdx !== null && formData.budgets[pendingCalendarAlignIdx]?.resetDuration === "1M"
-													? "month"
-													: pendingCalendarAlignIdx !== null && formData.budgets[pendingCalendarAlignIdx]?.resetDuration === "1Y"
-														? "year"
-														: "period"}
-										. The usage reset to $0.00 cannot be undone, but calendar alignment can be turned off later. This will take effect when
-										you save.
-									</AlertDialogDescription>
-								</AlertDialogHeader>
-								<AlertDialogFooter>
-									<AlertDialogCancel data-testid="team-calendar-align-cancel-btn" onClick={() => setPendingCalendarAlignIdx(null)}>
-										Cancel
-									</AlertDialogCancel>
-									<AlertDialogAction
-										data-testid="team-calendar-align-enable-btn"
-										onClick={() => {
-											if (pendingCalendarAlignIdx !== null) {
-												updateBudgetRow(pendingCalendarAlignIdx, {
-													calendarAligned: true,
-												});
-											}
-											setPendingCalendarAlignIdx(null);
-										}}
-									>
-										Enable Calendar Alignment
-									</AlertDialogAction>
-								</AlertDialogFooter>
-							</AlertDialogContent>
-						</AlertDialog>
+            {/* Rate Limit Configuration - Request Limits */}
+            <NumberAndSelect
+              id="requestMaxLimit"
+              label="Maximum Requests"
+              value={formData.requestMaxLimit}
+              selectValue={formData.requestResetDuration}
+              onChangeNumber={(value) => updateField("requestMaxLimit", value)}
+              onChangeSelect={(value) =>
+                updateField("requestResetDuration", value)
+              }
+              options={resetDurationOptions}
+            />
 
-						{/* Rate Limit Configuration - Token Limits */}
-						<NumberAndSelect
-							id="tokenMaxLimit"
-							label="Maximum Tokens"
-							value={formData.tokenMaxLimit}
-							selectValue={formData.tokenResetDuration}
-							onChangeNumber={(value) => updateField("tokenMaxLimit", value)}
-							onChangeSelect={(value) => updateField("tokenResetDuration", value)}
-							options={resetDurationOptions}
-						/>
+            {/* Calendar alignment — team-wide setting that applies to all team budgets and the team rate limit */}
+            {(() => {
+              const hasAlignableBudget = formData.budgets.some(
+                (b) =>
+                  b.maxLimit !== undefined &&
+                  b.maxLimit !== null &&
+                  supportsCalendarAlignment(b.resetDuration),
+              );
+              const hasAlignableRateLimit =
+                (formData.tokenMaxLimit !== undefined &&
+                  formData.tokenMaxLimit !== null &&
+                  supportsCalendarAlignment(formData.tokenResetDuration)) ||
+                (formData.requestMaxLimit !== undefined &&
+                  formData.requestMaxLimit !== null &&
+                  supportsCalendarAlignment(formData.requestResetDuration));
+              if (!hasAlignableBudget && !hasAlignableRateLimit) return null;
+              return (
+                <div className="flex items-center justify-between gap-4 rounded-md border px-3 py-2">
+                  <div className="space-y-0.5">
+                    <Label
+                      htmlFor="team-calendar-aligned-toggle"
+                      className="text-sm font-normal"
+                    >
+                      Align to calendar cycle
+                    </Label>
+                    <p className="text-muted-foreground text-xs">
+                      Reset budgets and rate limits at the start of each period
+                      (e.g. 1st of month) instead of rolling from creation date.
+                      Applies to durations of a day or longer.
+                    </p>
+                  </div>
+                  <Switch
+                    id="team-calendar-aligned-toggle"
+                    checked={formData.calendarAligned}
+                    onCheckedChange={handleCalendarAlignedChange}
+                    data-testid="team-calendar-aligned-toggle"
+                  />
+                </div>
+              );
+            })()}
 
-						{/* Rate Limit Configuration - Request Limits */}
-						<NumberAndSelect
-							id="requestMaxLimit"
-							label="Maximum Requests"
-							value={formData.requestMaxLimit}
-							selectValue={formData.requestResetDuration}
-							onChangeNumber={(value) => updateField("requestMaxLimit", value)}
-							onChangeSelect={(value) => updateField("requestResetDuration", value)}
-							options={resetDurationOptions}
-						/>
+            {/* Warning dialog shown when enabling calendar alignment on an existing team */}
+            <AlertDialog
+              open={showCalendarAlignWarning}
+              onOpenChange={setShowCalendarAlignWarning}
+            >
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    Reset budget and rate-limit usage?
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Enabling calendar alignment will reset budget usage to{" "}
+                    <span className="font-semibold">$0.00</span> and
+                    token/request rate-limit counters to{" "}
+                    <span className="font-semibold">0</span> for this team, then
+                    snap each reset date to the start of its current period
+                    (e.g. start of day, week, month, or year). The usage reset
+                    cannot be undone, but calendar alignment can be turned off
+                    later. This will take effect when you save.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel data-testid="team-calendar-align-cancel-btn">
+                    Cancel
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    data-testid="team-calendar-align-enable-btn"
+                    onClick={() => {
+                      updateField("calendarAligned", true);
+                      setShowCalendarAlignWarning(false);
+                    }}
+                  >
+                    Enable Calendar Alignment
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
 
-						{/* Current Usage Section (only shown when editing with existing limits) */}
-						{isEditing && ((team?.budgets && team.budgets.length > 0) || team?.rate_limit) && (
-							<div className="bg-muted/50 space-y-4 rounded-lg border p-4">
-								<p className="text-sm font-medium">Current Usage</p>
-								<div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-									{team?.budgets?.map((b) => (
-										<div key={b.id} className="space-y-1">
-											<p className="text-muted-foreground text-xs">Budget ({b.reset_duration})</p>
-											<div className="flex items-center gap-2">
-												<span className="font-mono text-sm">
-													{formatCurrency(b.current_usage)} / {formatCurrency(b.max_limit)}
-												</span>
-												<Badge variant={b.max_limit > 0 && b.current_usage >= b.max_limit ? "destructive" : "default"} className="text-xs">
-													{b.max_limit > 0 ? Math.round((b.current_usage / b.max_limit) * 100) : 0}%
-												</Badge>
-											</div>
-											<p className="text-muted-foreground text-xs">
-												Last Reset:{" "}
-												{formatDistanceToNow(new Date(b.last_reset), {
-													addSuffix: true,
-												})}
-											</p>
-										</div>
-									))}
-									{team?.rate_limit?.token_max_limit && (
-										<div className="space-y-1">
-											<p className="text-muted-foreground text-xs">Tokens</p>
-											<div className="flex items-center gap-2">
-												<span className="font-mono text-sm">
-													{team.rate_limit.token_current_usage.toLocaleString()} / {team.rate_limit.token_max_limit.toLocaleString()}
-												</span>
-												<Badge
-													variant={
-														team.rate_limit.token_max_limit > 0 && team.rate_limit.token_current_usage >= team.rate_limit.token_max_limit
-															? "destructive"
-															: "default"
-													}
-													className="text-xs"
-												>
-													{team.rate_limit.token_max_limit > 0
-														? Math.round((team.rate_limit.token_current_usage / team.rate_limit.token_max_limit) * 100)
-														: 0}
-													%
-												</Badge>
-											</div>
-											<p className="text-muted-foreground text-xs">
-												Last Reset: {formatDistanceToNow(new Date(team.rate_limit.token_last_reset), { addSuffix: true })}
-											</p>
-										</div>
-									)}
-									{team?.rate_limit?.request_max_limit && (
-										<div className="space-y-1">
-											<p className="text-muted-foreground text-xs">Requests</p>
-											<div className="flex items-center gap-2">
-												<span className="font-mono text-sm">
-													{team.rate_limit.request_current_usage.toLocaleString()} / {team.rate_limit.request_max_limit.toLocaleString()}
-												</span>
-												<Badge
-													variant={
-														team.rate_limit.request_max_limit > 0 &&
-														team.rate_limit.request_current_usage >= team.rate_limit.request_max_limit
-															? "destructive"
-															: "default"
-													}
-													className="text-xs"
-												>
-													{team.rate_limit.request_max_limit > 0
-														? Math.round((team.rate_limit.request_current_usage / team.rate_limit.request_max_limit) * 100)
-														: 0}
-													%
-												</Badge>
-											</div>
-											<p className="text-muted-foreground text-xs">
-												Last Reset: {formatDistanceToNow(new Date(team.rate_limit.request_last_reset), { addSuffix: true })}
-											</p>
-										</div>
-									)}
-								</div>
-							</div>
-						)}
-					</div>
+            {/* Current Usage Section (only shown when editing with existing limits) */}
+            {isEditing &&
+              ((team?.budgets && team.budgets.length > 0) ||
+                team?.rate_limit) && (
+                <div className="bg-muted/50 space-y-4 rounded-lg border p-4">
+                  <p className="text-sm font-medium">Current Usage</p>
+                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                    {team?.budgets?.map((b) => (
+                      <div key={b.id} className="space-y-1">
+                        <p className="text-muted-foreground text-xs">
+                          Budget ({b.reset_duration})
+                        </p>
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono text-sm">
+                            {formatCurrency(b.current_usage)} /{" "}
+                            {formatCurrency(b.max_limit)}
+                          </span>
+                          <Badge
+                            variant={
+                              b.max_limit > 0 && b.current_usage >= b.max_limit
+                                ? "destructive"
+                                : "default"
+                            }
+                            className="text-xs"
+                          >
+                            {b.max_limit > 0
+                              ? Math.round(
+                                  (b.current_usage / b.max_limit) * 100,
+                                )
+                              : 0}
+                            %
+                          </Badge>
+                        </div>
+                        <p className="text-muted-foreground text-xs">
+                          Last Reset:{" "}
+                          {formatDistanceToNow(new Date(b.last_reset), {
+                            addSuffix: true,
+                          })}
+                        </p>
+                      </div>
+                    ))}
+                    {team?.rate_limit?.token_max_limit && (
+                      <div className="space-y-1">
+                        <p className="text-muted-foreground text-xs">Tokens</p>
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono text-sm">
+                            {team.rate_limit.token_current_usage.toLocaleString()}{" "}
+                            / {team.rate_limit.token_max_limit.toLocaleString()}
+                          </span>
+                          <Badge
+                            variant={
+                              team.rate_limit.token_max_limit > 0 &&
+                              team.rate_limit.token_current_usage >=
+                                team.rate_limit.token_max_limit
+                                ? "destructive"
+                                : "default"
+                            }
+                            className="text-xs"
+                          >
+                            {team.rate_limit.token_max_limit > 0
+                              ? Math.round(
+                                  (team.rate_limit.token_current_usage /
+                                    team.rate_limit.token_max_limit) *
+                                    100,
+                                )
+                              : 0}
+                            %
+                          </Badge>
+                        </div>
+                        <p className="text-muted-foreground text-xs">
+                          Last Reset:{" "}
+                          {formatDistanceToNow(
+                            new Date(team.rate_limit.token_last_reset),
+                            { addSuffix: true },
+                          )}
+                        </p>
+                      </div>
+                    )}
+                    {team?.rate_limit?.request_max_limit && (
+                      <div className="space-y-1">
+                        <p className="text-muted-foreground text-xs">
+                          Requests
+                        </p>
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono text-sm">
+                            {team.rate_limit.request_current_usage.toLocaleString()}{" "}
+                            /{" "}
+                            {team.rate_limit.request_max_limit.toLocaleString()}
+                          </span>
+                          <Badge
+                            variant={
+                              team.rate_limit.request_max_limit > 0 &&
+                              team.rate_limit.request_current_usage >=
+                                team.rate_limit.request_max_limit
+                                ? "destructive"
+                                : "default"
+                            }
+                            className="text-xs"
+                          >
+                            {team.rate_limit.request_max_limit > 0
+                              ? Math.round(
+                                  (team.rate_limit.request_current_usage /
+                                    team.rate_limit.request_max_limit) *
+                                    100,
+                                )
+                              : 0}
+                            %
+                          </Badge>
+                        </div>
+                        <p className="text-muted-foreground text-xs">
+                          Last Reset:{" "}
+                          {formatDistanceToNow(
+                            new Date(team.rate_limit.request_last_reset),
+                            { addSuffix: true },
+                          )}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+          </div>
 
-					<FormFooter
-						validator={validator}
-						label="Team"
-						onCancel={onCancel}
-						isLoading={loading}
-						isEditing={isEditing}
-						hasPermission={hasPermission}
-					/>
-				</form>
-			</DialogContent>
-		</Dialog>
-	);
+          <FormFooter
+            validator={validator}
+            label="Team"
+            onCancel={onCancel}
+            isLoading={loading}
+            isEditing={isEditing}
+            hasPermission={hasPermission}
+          />
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
 }

--- a/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
@@ -9,6 +9,7 @@ import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { VirtualKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
+import { supportsCalendarAlignment } from "@/lib/constants/governance";
 import { calculateUsagePercentage, formatCurrency, parseResetPeriod } from "@/lib/utils/governance";
 import { formatDistanceToNow } from "date-fns";
 import { Lock, Users } from "lucide-react";
@@ -224,7 +225,7 @@ export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKe
 																	<div className="text-muted-foreground flex items-center justify-between text-xs">
 																		<span>
 																			Resets {parseResetPeriod(b.reset_duration)}
-																			{virtualKey.calendar_aligned && " (calendar)"}
+																			{virtualKey.calendar_aligned && supportsCalendarAlignment(b.reset_duration) && " (calendar)"}
 																		</span>
 																		{b.last_reset ? (
 																			<span>Last reset {formatDistanceToNow(new Date(b.last_reset), { addSuffix: true })}</span>
@@ -253,7 +254,12 @@ export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKe
 																		format={(n) => n.toLocaleString()}
 																	/>
 																	<div className="text-muted-foreground flex items-center justify-between text-xs">
-																		<span>Resets {parseResetPeriod(config.rate_limit.token_reset_duration || "")}</span>
+																		<span>
+																				Resets {parseResetPeriod(config.rate_limit.token_reset_duration || "")}
+																				{virtualKey.calendar_aligned &&
+																					supportsCalendarAlignment(config.rate_limit.token_reset_duration || "") &&
+																					" (calendar)"}
+																			</span>
 																		{config.rate_limit.token_last_reset ? (
 																			<span>
 																				Last reset {formatDistanceToNow(new Date(config.rate_limit.token_last_reset), { addSuffix: true })}
@@ -273,7 +279,12 @@ export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKe
 																		format={(n) => n.toLocaleString()}
 																	/>
 																	<div className="text-muted-foreground flex items-center justify-between text-xs">
-																		<span>Resets {parseResetPeriod(config.rate_limit.request_reset_duration || "")}</span>
+																		<span>
+																				Resets {parseResetPeriod(config.rate_limit.request_reset_duration || "")}
+																				{virtualKey.calendar_aligned &&
+																					supportsCalendarAlignment(config.rate_limit.request_reset_duration || "") &&
+																					" (calendar)"}
+																			</span>
 																		{config.rate_limit.request_last_reset ? (
 																			<span>
 																				Last reset{" "}
@@ -365,7 +376,7 @@ export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKe
 										<div className="text-muted-foreground flex items-center justify-between text-xs">
 											<span>
 												Resets {parseResetPeriod(b.reset_duration)}
-												{virtualKey.calendar_aligned && " (calendar)"}
+												{virtualKey.calendar_aligned && supportsCalendarAlignment(b.reset_duration) && " (calendar)"}
 											</span>
 											{b.last_reset ? <span>Last reset {formatDistanceToNow(new Date(b.last_reset), { addSuffix: true })}</span> : null}
 										</div>
@@ -398,7 +409,12 @@ export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKe
 											format={(n) => n.toLocaleString()}
 										/>
 										<div className="text-muted-foreground flex items-center justify-between text-xs">
-											<span>Resets {parseResetPeriod(displayRateLimit.token_reset_duration || "")}</span>
+											<span>
+												Resets {parseResetPeriod(displayRateLimit.token_reset_duration || "")}
+												{virtualKey.calendar_aligned &&
+													supportsCalendarAlignment(displayRateLimit.token_reset_duration || "") &&
+													" (calendar)"}
+											</span>
 											{displayRateLimit.token_last_reset ? (
 												<span>Last reset {formatDistanceToNow(new Date(displayRateLimit.token_last_reset), { addSuffix: true })}</span>
 											) : null}
@@ -416,7 +432,12 @@ export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKe
 											format={(n) => n.toLocaleString()}
 										/>
 										<div className="text-muted-foreground flex items-center justify-between text-xs">
-											<span>Resets {parseResetPeriod(displayRateLimit.request_reset_duration || "")}</span>
+											<span>
+												Resets {parseResetPeriod(displayRateLimit.request_reset_duration || "")}
+												{virtualKey.calendar_aligned &&
+													supportsCalendarAlignment(displayRateLimit.request_reset_duration || "") &&
+													" (calendar)"}
+											</span>
 											{displayRateLimit.request_last_reset ? (
 												<span>Last reset {formatDistanceToNow(new Date(displayRateLimit.request_last_reset), { addSuffix: true })}</span>
 											) : null}

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -452,6 +452,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 					team_id: data.entityType === "team" && data.teamId && data.teamId.trim() !== "" ? data.teamId : undefined,
 					customer_id: data.entityType === "customer" && data.customerId && data.customerId.trim() !== "" ? data.customerId : undefined,
 					is_active: data.isActive,
+					calendar_aligned: data.budgetCalendarAligned,
 				};
 
 				// Add budgets if enabled
@@ -461,10 +462,8 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 				const hadBudget = virtualKey.budgets && virtualKey.budgets.length > 0;
 				if (validBudgets.length > 0) {
 					updateData.budgets = validBudgets;
-					updateData.calendar_aligned = data.budgetCalendarAligned;
 				} else if (hadBudget) {
 					updateData.budgets = [];
-					updateData.calendar_aligned = false;
 				}
 
 				// Add rate limit if enabled
@@ -495,6 +494,8 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 					team_id: data.entityType === "team" && data.teamId && data.teamId.trim() !== "" ? data.teamId : undefined,
 					customer_id: data.entityType === "customer" && data.customerId && data.customerId.trim() !== "" ? data.customerId : undefined,
 					is_active: data.isActive,
+					// VK-level setting that governs both budget and rate-limit calendar alignment.
+					calendar_aligned: data.budgetCalendarAligned,
 				};
 
 				// Add budgets if enabled
@@ -503,7 +504,6 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 				);
 				if (validBudgets.length > 0) {
 					createData.budgets = validBudgets;
-					createData.calendar_aligned = data.budgetCalendarAligned;
 				}
 
 				// Add rate limit if enabled

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -13,15 +13,42 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ComboboxSelect } from "@/components/ui/combobox";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
-import { resetDurationLabels } from "@/lib/constants/governance";
-import { getErrorMessage, useDeleteVirtualKeyMutation, useLazyGetVirtualKeysQuery, useUpdateVirtualKeyMutation } from "@/lib/store";
+import {
+	resetDurationLabels,
+	supportsCalendarAlignment,
+} from "@/lib/constants/governance";
+import {
+	getErrorMessage,
+	useDeleteVirtualKeyMutation,
+	useLazyGetVirtualKeysQuery,
+	useUpdateVirtualKeyMutation,
+} from "@/lib/store";
 import { Customer, Team, VirtualKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
@@ -51,684 +78,861 @@ import VirtualKeyDetailSheet from "./virtualKeyDetailsSheet";
 import { VirtualKeysEmptyState } from "./virtualKeysEmptyState";
 import VirtualKeySheet from "./virtualKeySheet";
 
-const formatResetDuration = (duration: string) => resetDurationLabels[duration] || duration;
+const formatResetDuration = (duration: string) =>
+  resetDurationLabels[duration] || duration;
 
 type ExportScope = "current_page" | "all";
 
 function virtualKeysToCSV(vks: VirtualKey[]): string {
-	const headers = ["Name", "Status", "Assigned To", "Budget Limit", "Budget Spent", "Budget Reset", "Description", "Created At"];
-	const rows = vks.map((vk) => {
-		const isExhausted =
-			vk.budgets?.some((b) => b.current_usage >= b.max_limit) ||
-			(vk.rate_limit?.token_current_usage &&
-				vk.rate_limit?.token_max_limit &&
-				vk.rate_limit.token_current_usage >= vk.rate_limit.token_max_limit) ||
-			(vk.rate_limit?.request_current_usage &&
-				vk.rate_limit?.request_max_limit &&
-				vk.rate_limit.request_current_usage >= vk.rate_limit.request_max_limit);
-		const status = vk.is_active ? (isExhausted ? "Exhausted" : "Active") : "Inactive";
-		const assignedTo = vk.team ? `Team: ${vk.team.name}` : vk.customer ? `Customer: ${vk.customer.name}` : "";
-		const budgetLimit = vk.budgets?.length ? vk.budgets.map((b) => formatCurrency(b.max_limit)).join("; ") : "";
-		const budgetSpent = vk.budgets?.length ? vk.budgets.map((b) => formatCurrency(b.current_usage)).join("; ") : "";
-		const budgetReset = vk.budgets?.length ? vk.budgets.map((b) => formatResetDuration(b.reset_duration)).join("; ") : "";
-		return [vk.name, status, assignedTo, budgetLimit, budgetSpent, budgetReset, vk.description || "", vk.created_at];
-	});
-	return [headers, ...rows].map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(",")).join("\n");
+  const headers = [
+    "Name",
+    "Status",
+    "Assigned To",
+    "Budget Limit",
+    "Budget Spent",
+    "Budget Reset",
+    "Description",
+    "Created At",
+  ];
+  const rows = vks.map((vk) => {
+    const isExhausted =
+      vk.budgets?.some((b) => b.current_usage >= b.max_limit) ||
+      (vk.rate_limit?.token_current_usage &&
+        vk.rate_limit?.token_max_limit &&
+        vk.rate_limit.token_current_usage >= vk.rate_limit.token_max_limit) ||
+      (vk.rate_limit?.request_current_usage &&
+        vk.rate_limit?.request_max_limit &&
+        vk.rate_limit.request_current_usage >= vk.rate_limit.request_max_limit);
+    const status = vk.is_active
+      ? isExhausted
+        ? "Exhausted"
+        : "Active"
+      : "Inactive";
+    const assignedTo = vk.team
+      ? `Team: ${vk.team.name}`
+      : vk.customer
+        ? `Customer: ${vk.customer.name}`
+        : "";
+    const budgetLimit = vk.budgets?.length
+      ? vk.budgets.map((b) => formatCurrency(b.max_limit)).join("; ")
+      : "";
+    const budgetSpent = vk.budgets?.length
+      ? vk.budgets.map((b) => formatCurrency(b.current_usage)).join("; ")
+      : "";
+    const budgetReset = vk.budgets?.length
+      ? vk.budgets.map((b) => formatResetDuration(b.reset_duration)).join("; ")
+      : "";
+    return [
+      vk.name,
+      status,
+      assignedTo,
+      budgetLimit,
+      budgetSpent,
+      budgetReset,
+      vk.description || "",
+      vk.created_at,
+    ];
+  });
+  return [headers, ...rows]
+    .map((row) =>
+      row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","),
+    )
+    .join("\n");
 }
 
 function downloadCSV(content: string) {
-	const blob = new Blob([content], { type: "text/csv;charset=utf-8;" });
-	const url = URL.createObjectURL(blob);
-	const link = document.createElement("a");
-	link.href = url;
-	link.download = `virtual-keys-${new Date().toISOString().split("T")[0]}.csv`;
-	link.click();
-	URL.revokeObjectURL(url);
+  const blob = new Blob([content], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `virtual-keys-${new Date().toISOString().split("T")[0]}.csv`;
+  link.click();
+  URL.revokeObjectURL(url);
 }
 
 function VKBudgetCell({ vk }: { vk: VirtualKey }) {
-	const { displayBudgets } = useVirtualKeyUsage(vk);
+  const { displayBudgets } = useVirtualKeyUsage(vk);
 
-	if (!displayBudgets || displayBudgets.length === 0) {
-		return <span className="text-muted-foreground text-sm">-</span>;
-	}
+  if (!displayBudgets || displayBudgets.length === 0) {
+    return <span className="text-muted-foreground text-sm">-</span>;
+  }
 
-	return (
-		<div className="flex flex-col gap-0.5">
-			{displayBudgets.map((b, idx) => (
-				<div key={idx} className="flex flex-col">
-					<span className={cn("font-mono text-sm", b.current_usage >= b.max_limit && "text-red-400")}>
-						{formatCurrency(b.current_usage)} / {formatCurrency(b.max_limit)}
-					</span>
-					<span className="text-muted-foreground text-xs">
-						Resets {formatResetDuration(b.reset_duration)}
-						{vk.calendar_aligned && " (calendar)"}
-					</span>
-				</div>
-			))}
-		</div>
-	);
+  return (
+    <div className="flex flex-col gap-0.5">
+      {displayBudgets.map((b, idx) => (
+        <div key={idx} className="flex flex-col">
+          <span
+            className={cn(
+              "font-mono text-sm",
+              b.current_usage >= b.max_limit && "text-red-400",
+            )}
+          >
+            {formatCurrency(b.current_usage)} / {formatCurrency(b.max_limit)}
+          </span>
+          <span className="text-muted-foreground text-xs">
+            Resets {formatResetDuration(b.reset_duration)}
+            {vk.calendar_aligned &&
+              supportsCalendarAlignment(b.reset_duration) &&
+              " (calendar)"}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 function VKRateLimitCell({ vk }: { vk: VirtualKey }) {
-	const { displayRateLimit } = useVirtualKeyUsage(vk);
-	return <RateLimitDisplay rateLimits={displayRateLimit} />;
+  const { displayRateLimit } = useVirtualKeyUsage(vk);
+  return (
+    <RateLimitDisplay
+      rateLimits={displayRateLimit}
+      calendarAligned={vk.calendar_aligned}
+    />
+  );
 }
 
 function VKActiveSwitch({
-	vk,
-	hasUpdateAccess,
-	onToggle,
+  vk,
+  hasUpdateAccess,
+  onToggle,
 }: {
-	vk: VirtualKey;
-	hasUpdateAccess: boolean;
-	onToggle: (vk: VirtualKey, checked: boolean) => Promise<void>;
+  vk: VirtualKey;
+  hasUpdateAccess: boolean;
+  onToggle: (vk: VirtualKey, checked: boolean) => Promise<void>;
 }) {
-	const { isManagedByProfile } = useVirtualKeyUsage(vk);
+  const { isManagedByProfile } = useVirtualKeyUsage(vk);
 
-	return (
-		<Switch
-			checked={vk.is_active}
-			disabled={!hasUpdateAccess || isManagedByProfile}
-			aria-label={`${vk.is_active ? "Disable" : "Enable"} virtual key ${vk.name}`}
-			data-testid={`vk-active-switch-${vk.name}`}
-			title={isManagedByProfile ? "This virtual key is managed by an access profile." : undefined}
-			onAsyncCheckedChange={(checked) => onToggle(vk, checked)}
-		/>
-	);
+  return (
+    <Switch
+      checked={vk.is_active}
+      disabled={!hasUpdateAccess || isManagedByProfile}
+      aria-label={`${vk.is_active ? "Disable" : "Enable"} virtual key ${vk.name}`}
+      data-testid={`vk-active-switch-${vk.name}`}
+      title={
+        isManagedByProfile
+          ? "This virtual key is managed by an access profile."
+          : undefined
+      }
+      onAsyncCheckedChange={(checked) => onToggle(vk, checked)}
+    />
+  );
 }
 
 function VKActionsMenu({
-	vk,
-	hasUpdateAccess,
-	hasDeleteAccess,
-	isDeleting,
-	onEdit,
-	onDelete,
+  vk,
+  hasUpdateAccess,
+  hasDeleteAccess,
+  isDeleting,
+  onEdit,
+  onDelete,
 }: {
-	vk: VirtualKey;
-	hasUpdateAccess: boolean;
-	hasDeleteAccess: boolean;
-	isDeleting: boolean;
-	onEdit: (vk: VirtualKey) => void;
-	onDelete: (vkId: string) => void;
+  vk: VirtualKey;
+  hasUpdateAccess: boolean;
+  hasDeleteAccess: boolean;
+  isDeleting: boolean;
+  onEdit: (vk: VirtualKey) => void;
+  onDelete: (vkId: string) => void;
 }) {
-	const { isManagedByProfile } = useVirtualKeyUsage(vk);
-	const [deleteOpen, setDeleteOpen] = useState(false);
+  const { isManagedByProfile } = useVirtualKeyUsage(vk);
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
-	return (
-		<>
-			<DropdownMenu>
-				<DropdownMenuTrigger asChild>
-					<Button
-						variant="ghost"
-						size="icon"
-						className="h-8 w-8"
-						aria-label="Virtual key actions"
-						data-testid={`vk-actions-btn-${vk.name}`}
-					>
-						<MoreHorizontal className="h-4 w-4" />
-					</Button>
-				</DropdownMenuTrigger>
-				<DropdownMenuContent align="end">
-					<DropdownMenuItem
-						className="cursor-pointer"
-						disabled={!hasUpdateAccess}
-						data-testid={`vk-edit-btn-${vk.name}`}
-						onSelect={(e) => {
-							e.preventDefault();
-							onEdit(vk);
-						}}
-					>
-						<Edit className="h-4 w-4" />
-						Edit
-					</DropdownMenuItem>
-					<DropdownMenuItem
-						variant="destructive"
-						className="cursor-pointer"
-						disabled={!hasDeleteAccess || isManagedByProfile}
-						data-testid={`vk-delete-btn-${vk.name}`}
-						title={isManagedByProfile ? "This virtual key is managed by an access profile and can't be deleted here." : undefined}
-						onSelect={(e) => {
-							e.preventDefault();
-							setDeleteOpen(true);
-						}}
-					>
-						<Trash2 className="h-4 w-4" />
-						Delete
-					</DropdownMenuItem>
-				</DropdownMenuContent>
-			</DropdownMenu>
-			<AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-				<AlertDialogContent>
-					<AlertDialogHeader>
-						<AlertDialogTitle>Delete Virtual Key</AlertDialogTitle>
-						<AlertDialogDescription>
-							Are you sure you want to delete &quot;{vk.name.length > 20 ? `${vk.name.slice(0, 20)}...` : vk.name}&quot;? This action cannot
-							be undone.
-						</AlertDialogDescription>
-					</AlertDialogHeader>
-					<AlertDialogFooter>
-						<AlertDialogCancel data-testid={`vk-delete-cancel-${vk.name}`}>Cancel</AlertDialogCancel>
-						<AlertDialogAction
-							onClick={() => onDelete(vk.id)}
-							disabled={isDeleting}
-							className="bg-destructive hover:bg-destructive/90"
-							data-testid={`vk-delete-confirm-${vk.name}`}
-						>
-							{isDeleting ? "Deleting..." : "Delete"}
-						</AlertDialogAction>
-					</AlertDialogFooter>
-				</AlertDialogContent>
-			</AlertDialog>
-		</>
-	);
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label="Virtual key actions"
+            data-testid={`vk-actions-btn-${vk.name}`}
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            className="cursor-pointer"
+            disabled={!hasUpdateAccess}
+            data-testid={`vk-edit-btn-${vk.name}`}
+            onSelect={(e) => {
+              e.preventDefault();
+              onEdit(vk);
+            }}
+          >
+            <Edit className="h-4 w-4" />
+            Edit
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            variant="destructive"
+            className="cursor-pointer"
+            disabled={!hasDeleteAccess || isManagedByProfile}
+            data-testid={`vk-delete-btn-${vk.name}`}
+            title={
+              isManagedByProfile
+                ? "This virtual key is managed by an access profile and can't be deleted here."
+                : undefined
+            }
+            onSelect={(e) => {
+              e.preventDefault();
+              setDeleteOpen(true);
+            }}
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Virtual Key</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete &quot;
+              {vk.name.length > 20 ? `${vk.name.slice(0, 20)}...` : vk.name}
+              &quot;? This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel data-testid={`vk-delete-cancel-${vk.name}`}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => onDelete(vk.id)}
+              disabled={isDeleting}
+              className="bg-destructive hover:bg-destructive/90"
+              data-testid={`vk-delete-confirm-${vk.name}`}
+            >
+              {isDeleting ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
 }
 
 interface VirtualKeysTableProps {
-	virtualKeys: VirtualKey[];
-	totalCount: number;
-	teams: Team[];
-	customers: Customer[];
-	search: string;
-	debouncedSearch: string;
-	onSearchChange: (value: string) => void;
-	customerFilter: string;
-	onCustomerFilterChange: (value: string) => void;
-	teamFilter: string;
-	onTeamFilterChange: (value: string) => void;
-	offset: number;
-	limit: number;
-	onOffsetChange: (offset: number) => void;
-	sortBy?: string;
-	order?: string;
-	onSortChange: (sortBy: string, order: string) => void;
+  virtualKeys: VirtualKey[];
+  totalCount: number;
+  teams: Team[];
+  customers: Customer[];
+  search: string;
+  debouncedSearch: string;
+  onSearchChange: (value: string) => void;
+  customerFilter: string;
+  onCustomerFilterChange: (value: string) => void;
+  teamFilter: string;
+  onTeamFilterChange: (value: string) => void;
+  offset: number;
+  limit: number;
+  onOffsetChange: (offset: number) => void;
+  sortBy?: string;
+  order?: string;
+  onSortChange: (sortBy: string, order: string) => void;
 }
 
 export default function VirtualKeysTable({
-	virtualKeys,
-	totalCount,
-	teams,
-	customers,
-	search,
-	debouncedSearch,
-	onSearchChange,
-	customerFilter,
-	onCustomerFilterChange,
-	teamFilter,
-	onTeamFilterChange,
-	offset,
-	limit,
-	onOffsetChange,
-	sortBy,
-	order,
-	onSortChange,
+  virtualKeys,
+  totalCount,
+  teams,
+  customers,
+  search,
+  debouncedSearch,
+  onSearchChange,
+  customerFilter,
+  onCustomerFilterChange,
+  teamFilter,
+  onTeamFilterChange,
+  offset,
+  limit,
+  onOffsetChange,
+  sortBy,
+  order,
+  onSortChange,
 }: VirtualKeysTableProps) {
-	const [showVirtualKeySheet, setShowVirtualKeySheet] = useState(false);
-	const [editingVirtualKeyId, setEditingVirtualKeyId] = useState<string | null>(null);
-	const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set());
-	const [selectedVirtualKeyId, setSelectedVirtualKeyId] = useState<string | null>(null);
-	const [showDetailSheet, setShowDetailSheet] = useState(false);
-	const [showExportDialog, setShowExportDialog] = useState(false);
-	const [exportScope, setExportScope] = useState<ExportScope>("current_page");
-	const [exportMaxLimit, setExportMaxLimit] = useState("");
-	const [fetchVirtualKeys, { isFetching: isExporting }] = useLazyGetVirtualKeysQuery();
+  const [showVirtualKeySheet, setShowVirtualKeySheet] = useState(false);
+  const [editingVirtualKeyId, setEditingVirtualKeyId] = useState<string | null>(
+    null,
+  );
+  const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set());
+  const [selectedVirtualKeyId, setSelectedVirtualKeyId] = useState<
+    string | null
+  >(null);
+  const [showDetailSheet, setShowDetailSheet] = useState(false);
+  const [showExportDialog, setShowExportDialog] = useState(false);
+  const [exportScope, setExportScope] = useState<ExportScope>("current_page");
+  const [exportMaxLimit, setExportMaxLimit] = useState("");
+  const [fetchVirtualKeys, { isFetching: isExporting }] =
+    useLazyGetVirtualKeysQuery();
 
-	// Derive objects from props so they stay in sync with RTK cache updates
-	const editingVirtualKey = useMemo(
-		() => (editingVirtualKeyId ? (virtualKeys.find((vk) => vk.id === editingVirtualKeyId) ?? null) : null),
-		[editingVirtualKeyId, virtualKeys],
-	);
-	const selectedVirtualKey = useMemo(
-		() => (selectedVirtualKeyId ? (virtualKeys.find((vk) => vk.id === selectedVirtualKeyId) ?? null) : null),
-		[selectedVirtualKeyId, virtualKeys],
-	);
+  // Derive objects from props so they stay in sync with RTK cache updates
+  const editingVirtualKey = useMemo(
+    () =>
+      editingVirtualKeyId
+        ? (virtualKeys.find((vk) => vk.id === editingVirtualKeyId) ?? null)
+        : null,
+    [editingVirtualKeyId, virtualKeys],
+  );
+  const selectedVirtualKey = useMemo(
+    () =>
+      selectedVirtualKeyId
+        ? (virtualKeys.find((vk) => vk.id === selectedVirtualKeyId) ?? null)
+        : null,
+    [selectedVirtualKeyId, virtualKeys],
+  );
 
-	const hasCreateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Create);
-	const hasUpdateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Update);
-	const hasDeleteAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Delete);
+  const hasCreateAccess = useRbac(
+    RbacResource.VirtualKeys,
+    RbacOperation.Create,
+  );
+  const hasUpdateAccess = useRbac(
+    RbacResource.VirtualKeys,
+    RbacOperation.Update,
+  );
+  const hasDeleteAccess = useRbac(
+    RbacResource.VirtualKeys,
+    RbacOperation.Delete,
+  );
 
-	const [deleteVirtualKey, { isLoading: isDeleting }] = useDeleteVirtualKeyMutation();
-	const [updateVirtualKey] = useUpdateVirtualKeyMutation();
+  const [deleteVirtualKey, { isLoading: isDeleting }] =
+    useDeleteVirtualKeyMutation();
+  const [updateVirtualKey] = useUpdateVirtualKeyMutation();
 
-	const handleDelete = async (vkId: string) => {
-		try {
-			await deleteVirtualKey(vkId).unwrap();
-			toast.success("Virtual key deleted successfully");
-		} catch (error) {
-			toast.error(getErrorMessage(error));
-		}
-	};
+  const handleDelete = async (vkId: string) => {
+    try {
+      await deleteVirtualKey(vkId).unwrap();
+      toast.success("Virtual key deleted successfully");
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+    }
+  };
 
-	const handleToggleActive = async (vk: VirtualKey, checked: boolean) => {
-		try {
-			await updateVirtualKey({ vkId: vk.id, data: { is_active: checked } }).unwrap();
-			toast.success(`Virtual key ${checked ? "enabled" : "disabled"}`);
-		} catch (error) {
-			toast.error(getErrorMessage(error));
-			throw error;
-		}
-	};
+  const handleToggleActive = async (vk: VirtualKey, checked: boolean) => {
+    try {
+      await updateVirtualKey({
+        vkId: vk.id,
+        data: { is_active: checked },
+      }).unwrap();
+      toast.success(`Virtual key ${checked ? "enabled" : "disabled"}`);
+    } catch (error) {
+      toast.error(getErrorMessage(error));
+      throw error;
+    }
+  };
 
-	const handleAddVirtualKey = () => {
-		setEditingVirtualKeyId(null);
-		setShowVirtualKeySheet(true);
-	};
+  const handleAddVirtualKey = () => {
+    setEditingVirtualKeyId(null);
+    setShowVirtualKeySheet(true);
+  };
 
-	const handleEditVirtualKey = (vk: VirtualKey) => {
-		setEditingVirtualKeyId(vk.id);
-		setShowVirtualKeySheet(true);
-	};
+  const handleEditVirtualKey = (vk: VirtualKey) => {
+    setEditingVirtualKeyId(vk.id);
+    setShowVirtualKeySheet(true);
+  };
 
-	const handleVirtualKeySaved = () => {
-		setShowVirtualKeySheet(false);
-		setEditingVirtualKeyId(null);
-	};
+  const handleVirtualKeySaved = () => {
+    setShowVirtualKeySheet(false);
+    setEditingVirtualKeyId(null);
+  };
 
-	const handleRowClick = (vk: VirtualKey) => {
-		setSelectedVirtualKeyId(vk.id);
-		setShowDetailSheet(true);
-	};
+  const handleRowClick = (vk: VirtualKey) => {
+    setSelectedVirtualKeyId(vk.id);
+    setShowDetailSheet(true);
+  };
 
-	const handleDetailSheetClose = () => {
-		setShowDetailSheet(false);
-		setSelectedVirtualKeyId(null);
-	};
+  const handleDetailSheetClose = () => {
+    setShowDetailSheet(false);
+    setSelectedVirtualKeyId(null);
+  };
 
-	const toggleKeyVisibility = (vkId: string) => {
-		const newRevealed = new Set(revealedKeys);
-		if (newRevealed.has(vkId)) {
-			newRevealed.delete(vkId);
-		} else {
-			newRevealed.add(vkId);
-		}
-		setRevealedKeys(newRevealed);
-	};
+  const toggleKeyVisibility = (vkId: string) => {
+    const newRevealed = new Set(revealedKeys);
+    if (newRevealed.has(vkId)) {
+      newRevealed.delete(vkId);
+    } else {
+      newRevealed.add(vkId);
+    }
+    setRevealedKeys(newRevealed);
+  };
 
-	const maskKey = (key: string, revealed: boolean) => {
-		if (revealed) return key;
-		return key.substring(0, 8) + "•".repeat(Math.max(0, key.length - 8));
-	};
+  const maskKey = (key: string, revealed: boolean) => {
+    if (revealed) return key;
+    return key.substring(0, 8) + "•".repeat(Math.max(0, key.length - 8));
+  };
 
-	const { copy: copyToClipboard } = useCopyToClipboard();
+  const { copy: copyToClipboard } = useCopyToClipboard();
 
-	const hasActiveFilters = debouncedSearch || customerFilter || teamFilter;
+  const hasActiveFilters = debouncedSearch || customerFilter || teamFilter;
 
-	const toggleSort = (column: string) => {
-		if (sortBy === column) {
-			if (order === "asc") {
-				onSortChange(column, "desc");
-			} else {
-				// Clicking again clears sort
-				onSortChange("", "");
-			}
-		} else {
-			onSortChange(column, "asc");
-		}
-	};
+  const toggleSort = (column: string) => {
+    if (sortBy === column) {
+      if (order === "asc") {
+        onSortChange(column, "desc");
+      } else {
+        // Clicking again clears sort
+        onSortChange("", "");
+      }
+    } else {
+      onSortChange(column, "asc");
+    }
+  };
 
-	const handleExportCSV = async () => {
-		if (exportScope === "current_page") {
-			downloadCSV(virtualKeysToCSV(virtualKeys));
-			toast.success(`Exported ${virtualKeys.length} virtual keys`);
-			setShowExportDialog(false);
-			return;
-		}
+  const handleExportCSV = async () => {
+    if (exportScope === "current_page") {
+      downloadCSV(virtualKeysToCSV(virtualKeys));
+      toast.success(`Exported ${virtualKeys.length} virtual keys`);
+      setShowExportDialog(false);
+      return;
+    }
 
-		// Fetch all with same filters/sort applied
-		const maxLimit = exportMaxLimit ? parseInt(exportMaxLimit, 10) : undefined;
-		const fetchLimit = maxLimit && maxLimit > 0 ? maxLimit : 10000;
+    // Fetch all with same filters/sort applied
+    const maxLimit = exportMaxLimit ? parseInt(exportMaxLimit, 10) : undefined;
+    const fetchLimit = maxLimit && maxLimit > 0 ? maxLimit : 10000;
 
-		try {
-			const result = await fetchVirtualKeys({
-				limit: fetchLimit,
-				offset: 0,
-				search: debouncedSearch || undefined,
-				customer_id: customerFilter || undefined,
-				team_id: teamFilter || undefined,
-				sort_by: (sortBy as "name" | "budget_spent" | "created_at" | "status") || undefined,
-				order: (order as "asc" | "desc") || undefined,
-				export: true,
-			}).unwrap();
+    try {
+      const result = await fetchVirtualKeys({
+        limit: fetchLimit,
+        offset: 0,
+        search: debouncedSearch || undefined,
+        customer_id: customerFilter || undefined,
+        team_id: teamFilter || undefined,
+        sort_by:
+          (sortBy as "name" | "budget_spent" | "created_at" | "status") ||
+          undefined,
+        order: (order as "asc" | "desc") || undefined,
+        export: true,
+      }).unwrap();
 
-			downloadCSV(virtualKeysToCSV(result.virtual_keys));
-			toast.success(`Exported ${result.virtual_keys.length} virtual keys`);
-			setShowExportDialog(false);
-		} catch (error) {
-			toast.error(`Export failed: ${getErrorMessage(error)}`);
-		}
-	};
+      downloadCSV(virtualKeysToCSV(result.virtual_keys));
+      toast.success(`Exported ${result.virtual_keys.length} virtual keys`);
+      setShowExportDialog(false);
+    } catch (error) {
+      toast.error(`Export failed: ${getErrorMessage(error)}`);
+    }
+  };
 
-	const openExportDialog = () => {
-		setExportScope("current_page");
-		setExportMaxLimit("");
-		setShowExportDialog(true);
-	};
+  const openExportDialog = () => {
+    setExportScope("current_page");
+    setExportMaxLimit("");
+    setShowExportDialog(true);
+  };
 
-	const SortableHeader = ({ column, label }: { column: string; label: string }) => {
-		const isActive = sortBy === column;
-		const Icon = isActive ? (order === "desc" ? ArrowDown : ArrowUp) : ArrowUpDown;
-		return (
-			<Button variant="ghost" onClick={() => toggleSort(column)} data-testid={`vk-sort-${column}`} className="!px-0">
-				{label}
-				<Icon className={cn("ml-2 h-4 w-4", isActive && "text-foreground")} />
-			</Button>
-		);
-	};
+  const SortableHeader = ({
+    column,
+    label,
+  }: {
+    column: string;
+    label: string;
+  }) => {
+    const isActive = sortBy === column;
+    const Icon = isActive
+      ? order === "desc"
+        ? ArrowDown
+        : ArrowUp
+      : ArrowUpDown;
+    return (
+      <Button
+        variant="ghost"
+        onClick={() => toggleSort(column)}
+        data-testid={`vk-sort-${column}`}
+        className="!px-0"
+      >
+        {label}
+        <Icon className={cn("ml-2 h-4 w-4", isActive && "text-foreground")} />
+      </Button>
+    );
+  };
 
-	// True empty state: no VKs at all (not just filtered to zero)
-	if (totalCount === 0 && !hasActiveFilters) {
-		return (
-			<>
-				{showVirtualKeySheet && (
-					<VirtualKeySheet
-						virtualKey={editingVirtualKey}
-						teams={teams}
-						customers={customers}
-						onSave={handleVirtualKeySaved}
-						onCancel={() => setShowVirtualKeySheet(false)}
-					/>
-				)}
-				<VirtualKeysEmptyState onAddClick={handleAddVirtualKey} canCreate={hasCreateAccess} />
-			</>
-		);
-	}
+  // True empty state: no VKs at all (not just filtered to zero)
+  if (totalCount === 0 && !hasActiveFilters) {
+    return (
+      <>
+        {showVirtualKeySheet && (
+          <VirtualKeySheet
+            virtualKey={editingVirtualKey}
+            teams={teams}
+            customers={customers}
+            onSave={handleVirtualKeySaved}
+            onCancel={() => setShowVirtualKeySheet(false)}
+          />
+        )}
+        <VirtualKeysEmptyState
+          onAddClick={handleAddVirtualKey}
+          canCreate={hasCreateAccess}
+        />
+      </>
+    );
+  }
 
-	return (
-		<>
-			{showVirtualKeySheet && (
-				<VirtualKeySheet
-					virtualKey={editingVirtualKey}
-					teams={teams}
-					customers={customers}
-					onSave={handleVirtualKeySaved}
-					onCancel={() => setShowVirtualKeySheet(false)}
-				/>
-			)}
+  return (
+    <>
+      {showVirtualKeySheet && (
+        <VirtualKeySheet
+          virtualKey={editingVirtualKey}
+          teams={teams}
+          customers={customers}
+          onSave={handleVirtualKeySaved}
+          onCancel={() => setShowVirtualKeySheet(false)}
+        />
+      )}
 
-			{showDetailSheet && selectedVirtualKey && <VirtualKeyDetailSheet virtualKey={selectedVirtualKey} onClose={handleDetailSheetClose} />}
+      {showDetailSheet && selectedVirtualKey && (
+        <VirtualKeyDetailSheet
+          virtualKey={selectedVirtualKey}
+          onClose={handleDetailSheetClose}
+        />
+      )}
 
-			{/* Export Dialog */}
-			<Dialog open={showExportDialog} onOpenChange={setShowExportDialog}>
-				<DialogContent className="sm:max-w-[425px]">
-					<DialogHeader className="pb-0">
-						<DialogTitle>Export Virtual Keys</DialogTitle>
-						<DialogDescription>Download as CSV with current filters and sorting applied.</DialogDescription>
-					</DialogHeader>
-					<div className="space-y-4">
-						<div className="space-y-2">
-							<Label className="text-sm">Export scope</Label>
-							<div className="grid grid-cols-2 gap-2" data-testid="vk-export-scope">
-								<button
-									type="button"
-									onClick={() => setExportScope("current_page")}
-									className={cn(
-										"flex cursor-pointer flex-col items-center gap-1 rounded-md border px-3 py-3 text-sm transition-colors",
-										exportScope === "current_page"
-											? "border-primary bg-primary/5 text-foreground"
-											: "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground",
-									)}
-								>
-									<span className="font-medium">Current page</span>
-									<span className="text-muted-foreground text-xs">{virtualKeys.length} entries</span>
-								</button>
-								<button
-									type="button"
-									onClick={() => setExportScope("all")}
-									className={cn(
-										"flex cursor-pointer flex-col items-center gap-1 rounded-md border px-3 py-3 text-sm transition-colors",
-										exportScope === "all"
-											? "border-primary bg-primary/5 text-foreground"
-											: "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground",
-									)}
-								>
-									<span className="font-medium">All entries</span>
-									<span className="text-muted-foreground text-xs">{totalCount} total</span>
-								</button>
-							</div>
-						</div>
+      {/* Export Dialog */}
+      <Dialog open={showExportDialog} onOpenChange={setShowExportDialog}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader className="pb-0">
+            <DialogTitle>Export Virtual Keys</DialogTitle>
+            <DialogDescription>
+              Download as CSV with current filters and sorting applied.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label className="text-sm">Export scope</Label>
+              <div
+                className="grid grid-cols-2 gap-2"
+                data-testid="vk-export-scope"
+              >
+                <button
+                  type="button"
+                  onClick={() => setExportScope("current_page")}
+                  className={cn(
+                    "flex cursor-pointer flex-col items-center gap-1 rounded-md border px-3 py-3 text-sm transition-colors",
+                    exportScope === "current_page"
+                      ? "border-primary bg-primary/5 text-foreground"
+                      : "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground",
+                  )}
+                >
+                  <span className="font-medium">Current page</span>
+                  <span className="text-muted-foreground text-xs">
+                    {virtualKeys.length} entries
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setExportScope("all")}
+                  className={cn(
+                    "flex cursor-pointer flex-col items-center gap-1 rounded-md border px-3 py-3 text-sm transition-colors",
+                    exportScope === "all"
+                      ? "border-primary bg-primary/5 text-foreground"
+                      : "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground",
+                  )}
+                >
+                  <span className="font-medium">All entries</span>
+                  <span className="text-muted-foreground text-xs">
+                    {totalCount} total
+                  </span>
+                </button>
+              </div>
+            </div>
 
-						{exportScope === "all" && (
-							<div className="space-y-2">
-								<Label htmlFor="export-max-limit" className="text-sm">
-									Max entries <span className="text-muted-foreground font-normal">(optional)</span>
-								</Label>
-								<Input
-									id="export-max-limit"
-									type="number"
-									min="1"
-									placeholder={`Leave blank for all ${totalCount}`}
-									value={exportMaxLimit}
-									onChange={(e) => setExportMaxLimit(e.target.value)}
-									data-testid="vk-export-max-limit"
-								/>
-							</div>
-						)}
+            {exportScope === "all" && (
+              <div className="space-y-2">
+                <Label htmlFor="export-max-limit" className="text-sm">
+                  Max entries{" "}
+                  <span className="text-muted-foreground font-normal">
+                    (optional)
+                  </span>
+                </Label>
+                <Input
+                  id="export-max-limit"
+                  type="number"
+                  min="1"
+                  placeholder={`Leave blank for all ${totalCount}`}
+                  value={exportMaxLimit}
+                  onChange={(e) => setExportMaxLimit(e.target.value)}
+                  data-testid="vk-export-max-limit"
+                />
+              </div>
+            )}
 
-						{hasActiveFilters && (
-							<p className="text-muted-foreground text-xs">
-								Filters applied:{" "}
-								{[debouncedSearch && `search "${debouncedSearch}"`, customerFilter && "customer filter", teamFilter && "team filter"]
-									.filter(Boolean)
-									.join(", ")}
-							</p>
-						)}
+            {hasActiveFilters && (
+              <p className="text-muted-foreground text-xs">
+                Filters applied:{" "}
+                {[
+                  debouncedSearch && `search "${debouncedSearch}"`,
+                  customerFilter && "customer filter",
+                  teamFilter && "team filter",
+                ]
+                  .filter(Boolean)
+                  .join(", ")}
+              </p>
+            )}
 
-						<div className="text-muted-foreground flex items-center gap-2">
-							<ShieldCheck className="h-3.5 w-3.5 shrink-0" />
-							<p className="text-xs">API tokens are excluded from the export.</p>
-						</div>
-					</div>
-					<DialogFooter className="pt-0">
-						<Button variant="outline" onClick={() => setShowExportDialog(false)} disabled={isExporting}>
-							Cancel
-						</Button>
-						<Button onClick={handleExportCSV} disabled={isExporting} data-testid="vk-export-confirm-btn">
-							{isExporting ? (
-								<>
-									<Loader2 className="h-4 w-4 animate-spin" />
-									Exporting...
-								</>
-							) : (
-								<>
-									<Download className="h-4 w-4" />
-									Export CSV
-								</>
-							)}
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
+            <div className="text-muted-foreground flex items-center gap-2">
+              <ShieldCheck className="h-3.5 w-3.5 shrink-0" />
+              <p className="text-xs">
+                API tokens are excluded from the export.
+              </p>
+            </div>
+          </div>
+          <DialogFooter className="pt-0">
+            <Button
+              variant="outline"
+              onClick={() => setShowExportDialog(false)}
+              disabled={isExporting}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleExportCSV}
+              disabled={isExporting}
+              data-testid="vk-export-confirm-btn"
+            >
+              {isExporting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Exporting...
+                </>
+              ) : (
+                <>
+                  <Download className="h-4 w-4" />
+                  Export CSV
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
-			<div className="space-y-4">
-				<div className="flex items-center justify-between">
-					<div>
-						<h2 className="text-lg font-semibold">Virtual Keys</h2>
-						<p className="text-muted-foreground text-sm">Manage virtual keys, their permissions, budgets, and rate limits.</p>
-					</div>
-					<div className="flex items-center gap-2">
-						<Button variant="outline" onClick={openExportDialog} disabled={virtualKeys.length === 0} data-testid="vk-export-btn">
-							<Download className="h-4 w-4" />
-							Export CSV
-						</Button>
-						<Button onClick={handleAddVirtualKey} disabled={!hasCreateAccess} data-testid="create-vk-btn">
-							<Plus className="h-4 w-4" />
-							Add Virtual Key
-						</Button>
-					</div>
-				</div>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-lg font-semibold">Virtual Keys</h2>
+            <p className="text-muted-foreground text-sm">
+              Manage virtual keys, their permissions, budgets, and rate limits.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={openExportDialog}
+              disabled={virtualKeys.length === 0}
+              data-testid="vk-export-btn"
+            >
+              <Download className="h-4 w-4" />
+              Export CSV
+            </Button>
+            <Button
+              onClick={handleAddVirtualKey}
+              disabled={!hasCreateAccess}
+              data-testid="create-vk-btn"
+            >
+              <Plus className="h-4 w-4" />
+              Add Virtual Key
+            </Button>
+          </div>
+        </div>
 
-				{/* Toolbar: Search + Filters */}
-				<div className="flex items-center gap-3">
-					<div className="relative max-w-sm flex-1">
-						<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-						<Input
-							aria-label="Search virtual keys by name"
-							placeholder="Search by name..."
-							value={search}
-							onChange={(e) => onSearchChange(e.target.value)}
-							className="pl-9"
-							data-testid="vk-search-input"
-						/>
-					</div>
-					<ComboboxSelect
-						data-testid="vk-customer-filter"
-						options={customers.map((c) => ({ label: c.name, value: c.id }))}
-						value={customerFilter || null}
-						onValueChange={(val) => onCustomerFilterChange(val ?? "")}
-						placeholder="All Customers"
-						className="h-9 w-[180px]"
-					/>
-					{customerFilter && teamFilter && <span className="text-muted-foreground text-xs font-medium">or</span>}
-					<ComboboxSelect
-						data-testid="vk-team-filter"
-						options={teams.map((t) => ({ label: t.name, value: t.id }))}
-						value={teamFilter || null}
-						onValueChange={(val) => onTeamFilterChange(val ?? "")}
-						placeholder="All Teams"
-						className="h-9 w-[180px]"
-					/>
-				</div>
+        {/* Toolbar: Search + Filters */}
+        <div className="flex items-center gap-3">
+          <div className="relative max-w-sm flex-1">
+            <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+            <Input
+              aria-label="Search virtual keys by name"
+              placeholder="Search by name..."
+              value={search}
+              onChange={(e) => onSearchChange(e.target.value)}
+              className="pl-9"
+              data-testid="vk-search-input"
+            />
+          </div>
+          <ComboboxSelect
+            data-testid="vk-customer-filter"
+            options={customers.map((c) => ({ label: c.name, value: c.id }))}
+            value={customerFilter || null}
+            onValueChange={(val) => onCustomerFilterChange(val ?? "")}
+            placeholder="All Customers"
+            className="h-9 w-[180px]"
+          />
+          {customerFilter && teamFilter && (
+            <span className="text-muted-foreground text-xs font-medium">
+              or
+            </span>
+          )}
+          <ComboboxSelect
+            data-testid="vk-team-filter"
+            options={teams.map((t) => ({ label: t.name, value: t.id }))}
+            value={teamFilter || null}
+            onValueChange={(val) => onTeamFilterChange(val ?? "")}
+            placeholder="All Teams"
+            className="h-9 w-[180px]"
+          />
+        </div>
 
-				<div className="rounded-sm border">
-					<Table className="w-full min-w-[1480px] table-fixed" data-testid="vk-table">
-						<TableHeader>
-							<TableRow>
-								<TableHead className="w-[250px]">
-									<SortableHeader column="name" label="Name" />
-								</TableHead>
-								<TableHead className="w-[160px]">Assigned To</TableHead>
-								<TableHead className="w-[440px]">Key</TableHead>
-								<TableHead className="w-[200px]">
-									<SortableHeader column="budget_spent" label="Budget" />
-								</TableHead>
-								<TableHead className="w-[200px]">Rate Limits</TableHead>
-								<TableHead className="w-[120px]">
-									<SortableHeader column="status" label="Status" />
-								</TableHead>
-								<TableHead className={`bg-muted sticky right-0 z-10 w-[56px] text-right ${PIN_SHADOW_RIGHT}`}></TableHead>
-							</TableRow>
-						</TableHeader>
-						<TableBody>
-							{virtualKeys.length === 0 ? (
-								<TableRow>
-									<TableCell colSpan={7} className="h-24 text-center">
-										<span className="text-muted-foreground text-sm">No matching virtual keys found.</span>
-									</TableCell>
-								</TableRow>
-							) : (
-								virtualKeys.map((vk) => {
-									const isRevealed = revealedKeys.has(vk.id);
+        <div className="rounded-sm border">
+          <Table
+            className="w-full min-w-[1480px] table-fixed"
+            data-testid="vk-table"
+          >
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[250px]">
+                  <SortableHeader column="name" label="Name" />
+                </TableHead>
+                <TableHead className="w-[160px]">Assigned To</TableHead>
+                <TableHead className="w-[440px]">Key</TableHead>
+                <TableHead className="w-[200px]">
+                  <SortableHeader column="budget_spent" label="Budget" />
+                </TableHead>
+                <TableHead className="w-[200px]">Rate Limits</TableHead>
+                <TableHead className="w-[120px]">
+                  <SortableHeader column="status" label="Status" />
+                </TableHead>
+                <TableHead
+                  className={`bg-muted sticky right-0 z-10 w-[56px] text-right ${PIN_SHADOW_RIGHT}`}
+                ></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {virtualKeys.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="h-24 text-center">
+                    <span className="text-muted-foreground text-sm">
+                      No matching virtual keys found.
+                    </span>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                virtualKeys.map((vk) => {
+                  const isRevealed = revealedKeys.has(vk.id);
 
-									return (
-										<TableRow
-											key={vk.id}
-											data-testid={`vk-row-${vk.name}`}
-											className="group hover:bg-muted/50 cursor-pointer transition-colors"
-											onClick={() => handleRowClick(vk)}
-										>
-											<TableCell className="max-w-[200px]">
-												<div className="truncate font-medium">{vk.name}</div>
-											</TableCell>
-											<TableCell>
-												{vk.team ? (
-													<Badge variant="outline" className="block max-w-full truncate text-left">
-														Team: {vk.team.name}
-													</Badge>
-												) : vk.customer ? (
-													<Badge variant="outline" className="block max-w-full truncate text-left">
-														Customer: {vk.customer.name}
-													</Badge>
-												) : (
-													<span className="text-muted-foreground max-w-full truncate text-left text-sm">-</span>
-												)}
-											</TableCell>
-											<TableCell onClick={(e) => e.stopPropagation()}>
-												<div className="flex items-center gap-2">
-													<code className="cursor-default py-1 font-mono text-sm" data-testid="vk-key-value">
-														{maskKey(vk.value, isRevealed)}
-													</code>
-													<div className="flex items-center">
-														<Button
-															variant="ghost"
-															size="sm"
-															onClick={() => toggleKeyVisibility(vk.id)}
-															data-testid={`vk-visibility-btn-${vk.name}`}
-														>
-															{isRevealed ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-														</Button>
-														<Button
-															variant="ghost"
-															size="sm"
-															onClick={() => copyToClipboard(vk.value)}
-															data-testid={`vk-copy-btn-${vk.name}`}
-														>
-															<Copy className="h-4 w-4" />
-														</Button>
-													</div>
-												</div>
-											</TableCell>
-											<TableCell>
-												<VKBudgetCell vk={vk} />
-											</TableCell>
-											<TableCell>
-												<VKRateLimitCell vk={vk} />
-											</TableCell>
-											<TableCell onClick={(e) => e.stopPropagation()}>
-												<VKActiveSwitch vk={vk} hasUpdateAccess={hasUpdateAccess} onToggle={handleToggleActive} />
-											</TableCell>
-											<TableCell
-												className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-10 bg-white text-right ${PIN_SHADOW_RIGHT}`}
-												onClick={(e) => e.stopPropagation()}
-											>
-												<VKActionsMenu
-													vk={vk}
-													hasUpdateAccess={hasUpdateAccess}
-													hasDeleteAccess={hasDeleteAccess}
-													isDeleting={isDeleting}
-													onEdit={handleEditVirtualKey}
-													onDelete={handleDelete}
-												/>
-											</TableCell>
-										</TableRow>
-									);
-								})
-							)}
-						</TableBody>
-					</Table>
-				</div>
+                  return (
+                    <TableRow
+                      key={vk.id}
+                      data-testid={`vk-row-${vk.name}`}
+                      className="group hover:bg-muted/50 cursor-pointer transition-colors"
+                      onClick={() => handleRowClick(vk)}
+                    >
+                      <TableCell className="max-w-[200px]">
+                        <div className="truncate font-medium">{vk.name}</div>
+                      </TableCell>
+                      <TableCell>
+                        {vk.team ? (
+                          <Badge
+                            variant="outline"
+                            className="block max-w-full truncate text-left"
+                          >
+                            Team: {vk.team.name}
+                          </Badge>
+                        ) : vk.customer ? (
+                          <Badge
+                            variant="outline"
+                            className="block max-w-full truncate text-left"
+                          >
+                            Customer: {vk.customer.name}
+                          </Badge>
+                        ) : (
+                          <span className="text-muted-foreground max-w-full truncate text-left text-sm">
+                            -
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <div className="flex items-center gap-2">
+                          <code
+                            className="cursor-default py-1 font-mono text-sm"
+                            data-testid="vk-key-value"
+                          >
+                            {maskKey(vk.value, isRevealed)}
+                          </code>
+                          <div className="flex items-center">
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => toggleKeyVisibility(vk.id)}
+                              data-testid={`vk-visibility-btn-${vk.name}`}
+                            >
+                              {isRevealed ? (
+                                <EyeOff className="h-4 w-4" />
+                              ) : (
+                                <Eye className="h-4 w-4" />
+                              )}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => copyToClipboard(vk.value)}
+                              data-testid={`vk-copy-btn-${vk.name}`}
+                            >
+                              <Copy className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <VKBudgetCell vk={vk} />
+                      </TableCell>
+                      <TableCell>
+                        <VKRateLimitCell vk={vk} />
+                      </TableCell>
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <VKActiveSwitch
+                          vk={vk}
+                          hasUpdateAccess={hasUpdateAccess}
+                          onToggle={handleToggleActive}
+                        />
+                      </TableCell>
+                      <TableCell
+                        className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-10 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <VKActionsMenu
+                          vk={vk}
+                          hasUpdateAccess={hasUpdateAccess}
+                          hasDeleteAccess={hasDeleteAccess}
+                          isDeleting={isDeleting}
+                          onEdit={handleEditVirtualKey}
+                          onDelete={handleDelete}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })
+              )}
+            </TableBody>
+          </Table>
+        </div>
 
-				{/* Pagination */}
-				{totalCount > 0 && (
-					<div className="flex items-center justify-between px-2">
-						<p className="text-muted-foreground text-sm">
-							Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of {totalCount}
-						</p>
-						<div className="flex gap-2">
-							<Button
-								variant="outline"
-								size="sm"
-								disabled={offset === 0}
-								onClick={() => onOffsetChange(Math.max(0, offset - limit))}
-								data-testid="vk-pagination-prev-btn"
-							>
-								<ChevronLeft className="mr-1 h-4 w-4" />
-								Previous
-							</Button>
-							<Button
-								variant="outline"
-								size="sm"
-								disabled={offset + limit >= totalCount}
-								onClick={() => onOffsetChange(offset + limit)}
-								data-testid="vk-pagination-next-btn"
-							>
-								Next
-								<ChevronRight className="ml-1 h-4 w-4" />
-							</Button>
-						</div>
-					</div>
-				)}
-			</div>
-		</>
-	);
+        {/* Pagination */}
+        {totalCount > 0 && (
+          <div className="flex items-center justify-between px-2">
+            <p className="text-muted-foreground text-sm">
+              Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of{" "}
+              {totalCount}
+            </p>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={offset === 0}
+                onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+                data-testid="vk-pagination-prev-btn"
+              >
+                <ChevronLeft className="mr-1 h-4 w-4" />
+                Previous
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={offset + limit >= totalCount}
+                onClick={() => onOffsetChange(offset + limit)}
+                data-testid="vk-pagination-next-btn"
+              >
+                Next
+                <ChevronRight className="ml-1 h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
 }

--- a/ui/components/rateLimitDisplay.tsx
+++ b/ui/components/rateLimitDisplay.tsx
@@ -1,122 +1,190 @@
 import { Progress } from "@/components/ui/progress";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { resetDurationLabels } from "@/lib/constants/governance";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  resetDurationLabels,
+  supportsCalendarAlignment,
+} from "@/lib/constants/governance";
 import { cn } from "@/lib/utils";
 import { formatCompactNumber } from "@/lib/utils/numbers";
 
 interface RateLimitShape {
-	token_max_limit?: number | null;
-	token_reset_duration?: string | null;
-	token_current_usage?: number | null;
-	request_max_limit?: number | null;
-	request_reset_duration?: string | null;
-	request_current_usage?: number | null;
+  token_max_limit?: number | null;
+  token_reset_duration?: string | null;
+  token_current_usage?: number | null;
+  request_max_limit?: number | null;
+  request_reset_duration?: string | null;
+  request_current_usage?: number | null;
 }
 
 interface RateLimitDisplayProps {
-	rateLimits: RateLimitShape | null | undefined;
-	/** Compact mode for narrow cells — still renders bars, just tighter */
-	compact?: boolean;
-	/** Render limit + reset period only (no usage bar). Use for template entities like access profiles. */
-	limitOnly?: boolean;
+  rateLimits: RateLimitShape | null | undefined;
+  /** Compact mode for narrow cells — still renders bars, just tighter */
+  compact?: boolean;
+  /** Render limit + reset period only (no usage bar). Use for template entities like access profiles. */
+  limitOnly?: boolean;
+  /** When true, alignable durations (day/week/month/year) get a "(calendar)" suffix to
+   * mirror the budget cell. Sourced from the owning VK's calendar_aligned flag. */
+  calendarAligned?: boolean;
 }
 
-const formatResetDuration = (duration?: string | null) => {
-	if (!duration) return "";
-	return resetDurationLabels[duration] || duration;
+const formatResetDuration = (
+  duration?: string | null,
+  calendarAligned?: boolean,
+) => {
+  if (!duration) return "";
+  const label = resetDurationLabels[duration] || duration;
+  return calendarAligned && supportsCalendarAlignment(duration)
+    ? `${label} (calendar)`
+    : label;
 };
 
-function LimitText({ label, max, resetDuration }: { label: string; max: number; resetDuration?: string | null }) {
-	return (
-		<div className="flex items-center justify-between gap-4 text-xs">
-			<span className="font-mono">
-				{formatCompactNumber(max)} {label}
-			</span>
-			<span className="text-muted-foreground">{formatResetDuration(resetDuration)}</span>
-		</div>
-	);
+function LimitText({
+  label,
+  max,
+  resetDuration,
+  calendarAligned,
+}: {
+  label: string;
+  max: number;
+  resetDuration?: string | null;
+  calendarAligned?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 text-xs">
+      <span className="font-mono">
+        {formatCompactNumber(max)} {label}
+      </span>
+      <span className="text-muted-foreground">
+        {formatResetDuration(resetDuration, calendarAligned)}
+      </span>
+    </div>
+  );
 }
 
 function Bar({
-	label,
-	current,
-	max,
-	resetDuration,
-	compact,
+  label,
+  current,
+  max,
+  resetDuration,
+  compact,
+  calendarAligned,
 }: {
-	label: string;
-	current: number;
-	max: number;
-	resetDuration?: string | null;
-	compact?: boolean;
+  label: string;
+  current: number;
+  max: number;
+  resetDuration?: string | null;
+  compact?: boolean;
+  calendarAligned?: boolean;
 }) {
-	const pct = max > 0 ? Math.min((current / max) * 100, 100) : 0;
-	const isExhausted = max > 0 && current >= max;
-	const barClass = isExhausted ? "[&>div]:bg-red-500/70" : pct > 80 ? "[&>div]:bg-amber-500/70" : "[&>div]:bg-emerald-500/70";
+  const pct = max > 0 ? Math.min((current / max) * 100, 100) : 0;
+  const isExhausted = max > 0 && current >= max;
+  const barClass = isExhausted
+    ? "[&>div]:bg-red-500/70"
+    : pct > 80
+      ? "[&>div]:bg-amber-500/70"
+      : "[&>div]:bg-emerald-500/70";
 
-	return (
-		<Tooltip>
-			<TooltipTrigger asChild>
-				<div className={cn("space-y-1.5", compact && "space-y-1")}>
-					<div className="flex items-center justify-between gap-4 text-xs">
-						<span className="font-medium">
-							{formatCompactNumber(max)} {label}
-						</span>
-						<span className="text-muted-foreground">{formatResetDuration(resetDuration)}</span>
-					</div>
-					<Progress value={pct} className={cn("bg-muted/70 dark:bg-muted/30 h-1", barClass)} />
-				</div>
-			</TooltipTrigger>
-			<TooltipContent>
-				<p className="font-medium">
-					{current.toLocaleString()} / {max.toLocaleString()} {label}
-				</p>
-				{resetDuration ? <p className="text-primary-foreground/80 text-xs">Resets {formatResetDuration(resetDuration)}</p> : null}
-			</TooltipContent>
-		</Tooltip>
-	);
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className={cn("space-y-1.5", compact && "space-y-1")}>
+          <div className="flex items-center justify-between gap-4 text-xs">
+            <span className="font-medium">
+              {formatCompactNumber(max)} {label}
+            </span>
+            <span className="text-muted-foreground">
+              {formatResetDuration(resetDuration, calendarAligned)}
+            </span>
+          </div>
+          <Progress
+            value={pct}
+            className={cn("bg-muted/70 dark:bg-muted/30 h-1", barClass)}
+          />
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p className="font-medium">
+          {current.toLocaleString()} / {max.toLocaleString()} {label}
+        </p>
+        {resetDuration ? (
+          <p className="text-primary-foreground/80 text-xs">
+            Resets {formatResetDuration(resetDuration, calendarAligned)}
+          </p>
+        ) : null}
+      </TooltipContent>
+    </Tooltip>
+  );
 }
 
-export function RateLimitDisplay({ rateLimits, compact, limitOnly }: RateLimitDisplayProps) {
-	if (!rateLimits) {
-		return <span className="text-muted-foreground text-sm">-</span>;
-	}
+export function RateLimitDisplay({
+  rateLimits,
+  compact,
+  limitOnly,
+  calendarAligned,
+}: RateLimitDisplayProps) {
+  if (!rateLimits) {
+    return <span className="text-muted-foreground text-sm">-</span>;
+  }
 
-	const hasTokens = rateLimits.token_max_limit != null && rateLimits.token_max_limit > 0;
-	const hasRequests = rateLimits.request_max_limit != null && rateLimits.request_max_limit > 0;
+  const hasTokens =
+    rateLimits.token_max_limit != null && rateLimits.token_max_limit > 0;
+  const hasRequests =
+    rateLimits.request_max_limit != null && rateLimits.request_max_limit > 0;
 
-	if (!hasTokens && !hasRequests) {
-		return <span className="text-muted-foreground text-sm">-</span>;
-	}
+  if (!hasTokens && !hasRequests) {
+    return <span className="text-muted-foreground text-sm">-</span>;
+  }
 
-	return (
-		<div className={cn("space-y-2.5 min-w-[160px]", compact && "space-y-2", limitOnly && "space-y-1")}>
-			{hasTokens ? (
-				limitOnly ? (
-					<LimitText label="tokens" max={rateLimits.token_max_limit!} resetDuration={rateLimits.token_reset_duration} />
-				) : (
-					<Bar
-						label="tokens"
-						current={rateLimits.token_current_usage ?? 0}
-						max={rateLimits.token_max_limit!}
-						resetDuration={rateLimits.token_reset_duration}
-						compact={compact}
-					/>
-				)
-			) : null}
-			{hasRequests ? (
-				limitOnly ? (
-					<LimitText label="req" max={rateLimits.request_max_limit!} resetDuration={rateLimits.request_reset_duration} />
-				) : (
-					<Bar
-						label="req"
-						current={rateLimits.request_current_usage ?? 0}
-						max={rateLimits.request_max_limit!}
-						resetDuration={rateLimits.request_reset_duration}
-						compact={compact}
-					/>
-				)
-			) : null}
-		</div>
-	);
+  return (
+    <div
+      className={cn(
+        "space-y-2.5 min-w-[160px]",
+        compact && "space-y-2",
+        limitOnly && "space-y-1",
+      )}
+    >
+      {hasTokens ? (
+        limitOnly ? (
+          <LimitText
+            label="tokens"
+            max={rateLimits.token_max_limit!}
+            resetDuration={rateLimits.token_reset_duration}
+            calendarAligned={calendarAligned}
+          />
+        ) : (
+          <Bar
+            label="tokens"
+            current={rateLimits.token_current_usage ?? 0}
+            max={rateLimits.token_max_limit!}
+            resetDuration={rateLimits.token_reset_duration}
+            compact={compact}
+            calendarAligned={calendarAligned}
+          />
+        )
+      ) : null}
+      {hasRequests ? (
+        limitOnly ? (
+          <LimitText
+            label="req"
+            max={rateLimits.request_max_limit!}
+            resetDuration={rateLimits.request_reset_duration}
+            calendarAligned={calendarAligned}
+          />
+        ) : (
+          <Bar
+            label="req"
+            current={rateLimits.request_current_usage ?? 0}
+            max={rateLimits.request_max_limit!}
+            resetDuration={rateLimits.request_reset_duration}
+            compact={compact}
+            calendarAligned={calendarAligned}
+          />
+        )
+      ) : null}
+    </div>
+  );
 }

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -8,7 +8,6 @@ export interface Budget {
 	reset_duration: string; // e.g., "30s", "5m", "1h", "1d", "1w", "1M"
 	current_usage: number; // In dollars
 	last_reset: string; // ISO timestamp
-	calendar_aligned?: boolean; // When true, resets at clean calendar boundaries (day/week/month/year start)
 }
 
 export interface RateLimit {
@@ -30,6 +29,8 @@ export interface Team {
 	name: string;
 	customer_id?: string;
 	rate_limit_id?: string;
+	// Team-wide: applies to all team budgets and the team rate limit
+	calendar_aligned?: boolean;
 	// Populated relationships
 	customer?: Customer;
 	budgets?: Budget[]; // Multi-budget: each with a distinct reset_duration
@@ -84,16 +85,13 @@ export interface VirtualKey {
 	config_hash?: string; // Present when config is synced from config.json
 }
 
-// Provider config budgets don't have calendar_aligned (it's a VK-level field)
-export type ProviderConfigBudget = Omit<Budget, "calendar_aligned">;
-
 export interface VirtualKeyProviderConfig {
 	id?: number;
 	provider: string;
 	weight: number | null;
 	allowed_models: string[];
 	allow_all_keys: boolean; // True means all keys allowed; false with empty keys means no keys allowed
-	budgets?: ProviderConfigBudget[];
+	budgets?: Budget[];
 	rate_limit?: RateLimit;
 	keys?: DBKey[]; // Associated database keys for this provider (only used when allow_all_keys is false)
 }
@@ -136,7 +134,7 @@ export interface VirtualKeyProviderConfigRequest {
 	provider: string;
 	weight?: number | null;
 	allowed_models?: string[];
-	budgets?: ProviderConfigBudgetRequest[];
+	budgets?: CreateBudgetRequest[];
 	rate_limit?: CreateRateLimitRequest;
 	key_ids?: string[]; // List of DBKey UUIDs to associate with this provider config
 }
@@ -146,13 +144,10 @@ export interface VirtualKeyProviderConfigUpdateRequest {
 	provider: string;
 	weight?: number | null;
 	allowed_models?: string[];
-	budgets?: ProviderConfigBudgetRequest[];
+	budgets?: CreateBudgetRequest[];
 	rate_limit?: UpdateRateLimitRequest;
 	key_ids?: string[]; // List of DBKey UUIDs to associate with this provider config
 }
-
-// VK-level budgets don't include calendar_aligned (it's a VK-level field, not per-budget)
-export type VirtualKeyBudgetRequest = Omit<CreateBudgetRequest, "calendar_aligned">;
 
 // Request types for API calls
 export interface CreateVirtualKeyRequest {
@@ -162,7 +157,7 @@ export interface CreateVirtualKeyRequest {
 	mcp_configs?: VirtualKeyMCPConfigRequest[];
 	team_id?: string;
 	customer_id?: string;
-	budgets?: VirtualKeyBudgetRequest[];
+	budgets?: CreateBudgetRequest[];
 	rate_limit?: CreateRateLimitRequest;
 	is_active?: boolean;
 	calendar_aligned?: boolean;
@@ -175,7 +170,7 @@ export interface UpdateVirtualKeyRequest {
 	mcp_configs?: VirtualKeyMCPConfigRequest[];
 	team_id?: string;
 	customer_id?: string;
-	budgets?: VirtualKeyBudgetRequest[];
+	budgets?: CreateBudgetRequest[];
 	rate_limit?: UpdateRateLimitRequest;
 	is_active?: boolean;
 	calendar_aligned?: boolean;
@@ -186,6 +181,7 @@ export interface CreateTeamRequest {
 	customer_id?: string;
 	budgets?: CreateBudgetRequest[]; // Multi-budget: each must have a unique reset_duration
 	rate_limit?: CreateRateLimitRequest;
+	calendar_aligned?: boolean; // Team-wide: applies to all team budgets and the team rate limit
 }
 
 export interface UpdateTeamRequest {
@@ -193,6 +189,7 @@ export interface UpdateTeamRequest {
 	customer_id?: string;
 	budgets?: CreateBudgetRequest[]; // Replaces all team budgets; empty array clears
 	rate_limit?: UpdateRateLimitRequest;
+	calendar_aligned?: boolean;
 }
 
 export interface CreateCustomerRequest {
@@ -210,16 +207,11 @@ export interface UpdateCustomerRequest {
 export interface CreateBudgetRequest {
 	max_limit: number; // In dollars
 	reset_duration: string; // e.g., "30s", "5m", "1h", "1d", "1w", "1M"
-	calendar_aligned?: boolean; // Snap resets to calendar boundaries (day/week/month/year)
 }
-
-// Provider config budget requests don't include calendar_aligned (it's a VK-level field)
-export type ProviderConfigBudgetRequest = Omit<CreateBudgetRequest, "calendar_aligned">;
 
 export interface UpdateBudgetRequest {
 	max_limit?: number;
 	reset_duration?: string;
-	calendar_aligned?: boolean; // When switching to true, current usage is reset to 0
 }
 
 export interface CreateRateLimitRequest {


### PR DESCRIPTION
## Summary

Calendar alignment for teams was previously tracked per-budget row, which meant the setting was scattered across individual budgets and did not apply to the team's rate limit. This PR promotes calendar alignment to a team-level property, persisted in a new `calendar_aligned` column on `governance_teams`, so a single toggle governs all team budgets and the team rate limit simultaneously.

## Changes

- Added a database migration (`migrationAddTeamCalendarAlignedColumn`) to add `calendar_aligned` to `governance_teams`, and changed `TableTeam.CalendarAligned` from a transient (`gorm:"-"`) field to a persisted one.
- Removed `calendar_aligned` from `CreateBudgetRequest`, `UpdateBudgetRequest`, and the `Budget` type. Calendar alignment is now owned by the entity (VK or Team), not the budget row.
- Added an `AfterFind` hook on `TableBudget` that subqueries the owning VK or Team to populate a transient `IsCalendarAligned` field, so budget reset logic can read alignment without joining at the call site.
- `ResetExpiredBudgetsInMemory` now reads `budget.IsCalendarAligned` directly instead of looking up the owning VK.
- `ResetExpiredRateLimitsInMemory` now includes team rate limits in the `rateLimitCalendarAligned` reverse map, enabling calendar-aligned resets for team-attached rate limits.
- `CreateTeamRequest` and `UpdateTeamRequest` now accept a top-level `calendar_aligned` field. On enable, existing team budgets and the team rate limit are immediately snapped to the current calendar period start and their usage counters are zeroed.
- The team dialog UI replaces per-budget calendar-align toggles with a single team-wide toggle. The confirmation warning dialog now describes the reset of both budget usage and rate-limit counters. The toggle is only rendered when at least one alignable budget or rate limit exists.
- The VK details sheet and VKs table now guard the `(calendar)` label behind `supportsCalendarAlignment(duration)`, so short durations (e.g. hours) never show the label even when the VK flag is set.
- `RateLimitDisplay` accepts a new `calendarAligned` prop and appends `(calendar)` to alignable durations in all display contexts (bar, tooltip, limit-only).
- Removed the now-redundant `ProviderConfigBudget`, `ProviderConfigBudgetRequest`, and `VirtualKeyBudgetRequest` type aliases; all budget request sites use `CreateBudgetRequest` directly.
- VK sheet now always sends `calendar_aligned` at the top level of the update/create payload rather than conditionally inside the budgets block.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Create a team with budgets and/or a rate limit using alignable durations (1d, 1w, 1M, 1Y). Enable `calendar_aligned: true` on creation and verify `last_reset` is snapped to the current period start.
2. Update an existing team to set `calendar_aligned: true`. Confirm existing budget `current_usage` is zeroed and `last_reset` is snapped, and the team rate limit counters are also zeroed and snapped.
3. Verify that toggling `calendar_aligned` off does not reset usage and that subsequent resets roll from the last reset time rather than calendar boundaries.
4. Confirm the team dialog shows a single calendar-align toggle (not per-budget toggles), and that the confirmation dialog appears only when enabling on an existing team.
5. Confirm the `(calendar)` label does not appear on budgets or rate limits with sub-day durations even when the VK or team has `calendar_aligned: true`.

```sh
go test ./framework/configstore/... ./plugins/governance/... ./transports/bifrost-http/...

cd ui
pnpm i
pnpm test
pnpm build
```

## Breaking changes

- [x] Yes
- [ ] No

`calendar_aligned` has been removed from `CreateBudgetRequest`, `UpdateBudgetRequest`, and the `Budget` response type. Any API clients sending `calendar_aligned` on individual budget objects will have the field silently ignored. Clients reading `budget.calendar_aligned` from responses will no longer receive it; they should read `calendar_aligned` from the owning team or VK instead.

## Related issues

## Security considerations

No new auth surfaces or secrets handling. The migration is additive (new nullable column with a default). No PII is involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable