### PR TITLE
feat: replace routing rule action buttons with dropdown menu

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -490,7 +490,11 @@ export default function LogsPage() {
 		togglePin: toggleColumnPin,
 		reorder: reorderColumns,
 		reset: resetColumns,
-	} = useColumnConfig({ columnIds, paramName: "cols" });
+	} = useColumnConfig({
+		columnIds,
+		paramName: "cols",
+		fixedColumns: hasDeleteAccess ? { right: ["actions"] } : undefined,
+	});
 
 	// Navigation for log detail sheet
 	const logs = logsData?.logs ?? [];

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -5,6 +5,12 @@ import {
 } from "@/app/workspace/dashboard/utils/chartUtils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import {
   getProviderLabel,
@@ -22,7 +28,7 @@ import {
 import { cn } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
 import { format, formatDistanceToNow } from "date-fns";
-import { ArrowUpDown, Trash2 } from "lucide-react";
+import { ArrowUpDown, MoreHorizontal, Trash2 } from "lucide-react";
 
 function getAssistantToolCallSummary(log?: LogEntry): string {
   const toolCalls = log?.output_message?.tool_calls || [];
@@ -476,20 +482,40 @@ export const createColumns = (
     ? [
       {
         id: "actions",
-        size: 72,
+        header: "",
+        size: 56,
         cell: ({ row }) => {
           const log = row.original;
           return (
-            <Button
-              variant="outline"
-              size="icon"
-              data-testid="log-delete-btn"
-              aria-label="Delete log"
-              className="text-destructive/60 border-destructive/60 hover:text-destructive hover:bg-destructive/10"
-              onClick={() => onDelete(log)}
-            >
-              <Trash2 strokeWidth={1.5} />
-            </Button>
+            <div className="flex justify-center">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    data-testid="log-actions-btn"
+                    aria-label="Log actions"
+                    className="h-7 w-7"
+                  >
+                    <MoreHorizontal className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    variant="destructive"
+                    className="cursor-pointer"
+                    data-testid="log-delete-btn"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onDelete(log);
+                    }}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    Delete
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           );
         },
       },

--- a/ui/app/workspace/logs/views/logsTable.tsx
+++ b/ui/app/workspace/logs/views/logsTable.tsx
@@ -59,7 +59,7 @@ export function LogsDataTable({
 	const tableContainerRef = useRef<HTMLDivElement>(null);
 	const calculatedPageSize = useTablePageSize(tableContainerRef);
 
-	const fixedColumnIds = useMemo(() => new Set<string>([]), []);
+	const fixedColumnIds = useMemo(() => new Set<string>(["actions"]), []);
 
 	// Measure actual header cell widths for pixel-perfect pin offsets
 	const { headerCellRefs, setHeaderCellRef } = useHeaderCellRefs();

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -1,3 +1,4 @@
+import { LogsVolumeChart } from "@/app/workspace/logs/views/logsVolumeChart";
 import { MCPFilterSidebar } from "@/components/filters/mcpFilterSidebar";
 import FullPageLoader from "@/components/fullPageLoader";
 import { useColumnConfig } from "@/components/table";
@@ -10,7 +11,6 @@ import {
   useGetMCPLogsQuery,
   useGetMCPLogsStatsQuery,
 } from "@/lib/store";
-import { LogsVolumeChart } from "@/app/workspace/logs/views/logsVolumeChart";
 import { useLazyGetMCPLogsQuery } from "@/lib/store/apis/mcpLogsApi";
 import type {
   MCPToolLogEntry,
@@ -108,9 +108,9 @@ export default function MCPLogsPage() {
       ...(urlState.period
         ? { period: urlState.period }
         : {
-            start_time: dateUtils.toISOString(urlState.start_time),
-            end_time: dateUtils.toISOString(urlState.end_time),
-          }),
+          start_time: dateUtils.toISOString(urlState.start_time),
+          end_time: dateUtils.toISOString(urlState.end_time),
+        }),
     }),
     [
       urlState.tool_names,
@@ -396,17 +396,6 @@ export default function MCPLogsPage() {
     [columns],
   );
 
-  const MCP_COLUMN_LABELS: Record<string, string> = useMemo(
-    () => ({
-      timestamp: "Time",
-      tool_name: "Tool Name",
-      server_label: "Server",
-      latency: "Latency",
-      cost: "Cost",
-    }),
-    [],
-  );
-
   const {
     entries: columnEntries,
     columnOrder,
@@ -419,8 +408,19 @@ export default function MCPLogsPage() {
   } = useColumnConfig({
     columnIds,
     paramName: "mcp_cols",
-    fixedColumns: { left: [], right: [] },
+    fixedColumns: hasDeleteAccess ? { right: ["actions"] } : undefined,
   });
+
+  const MCP_COLUMN_LABELS: Record<string, string> = useMemo(
+    () => ({
+      timestamp: "Time",
+      tool_name: "Tool Name",
+      server_label: "Server",
+      latency: "Latency",
+      cost: "Cost",
+    }),
+    [],
+  );
 
   const selectedLogIndex = useMemo(
     () => (selectedLogId ? logs.findIndex((l) => l.id === selectedLogId) : -1),

--- a/ui/app/workspace/mcp-logs/views/columns.tsx
+++ b/ui/app/workspace/mcp-logs/views/columns.tsx
@@ -1,10 +1,11 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { Status, StatusBarColors, Statuses } from "@/lib/constants/logs";
 import type { MCPToolLogEntry } from "@/lib/types/logs";
 import { ColumnDef, Row } from "@tanstack/react-table";
 import { format, isValid } from "date-fns";
-import { ArrowUpDown, Trash2 } from "lucide-react";
+import { ArrowUpDown, MoreHorizontal, Trash2 } from "lucide-react";
 
 // Helper function to validate status and return a safe Status value
 const getValidatedStatus = (status: string): Status => {
@@ -99,20 +100,34 @@ export const createMCPColumns = (
 			? [
 				{
 					id: "actions",
-					size: 72,
+					header: "",
+					size: 56,
 					cell: ({ row }: { row: Row<MCPToolLogEntry> }) => {
 						const log = row.original;
 						return (
-							<Button
-								variant="outline"
-								size="icon"
-								data-testid="log-delete-btn"
-								aria-label="Delete log"
-								className="text-destructive/60 border-destructive/60 hover:text-destructive hover:bg-destructive/10"
-								onClick={() => void handleDelete(log)}
-							>
-								<Trash2 />
-							</Button>
+							<div className="flex justify-center">
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
+										<Button variant="ghost" size="icon" data-testid="log-actions-btn" aria-label="Log actions" className="h-7 w-7">
+											<MoreHorizontal className="h-4 w-4" />
+										</Button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align="end">
+										<DropdownMenuItem
+											variant="destructive"
+											className="cursor-pointer"
+											data-testid="log-delete-btn"
+											onClick={(event) => {
+												event.stopPropagation();
+												void handleDelete(log);
+											}}
+										>
+											<Trash2 className="h-4 w-4" />
+											Delete
+										</DropdownMenuItem>
+									</DropdownMenuContent>
+								</DropdownMenu>
+							</div>
 						);
 					},
 				},

--- a/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogsTable.tsx
@@ -56,7 +56,7 @@ export function MCPLogsDataTable({
 }: DataTableProps) {
 	const [sorting, setSorting] = useState<SortingState>([{ id: pagination.sort_by, desc: pagination.order === "desc" }]);
 
-	const fixedColumnIds = useMemo(() => new Set<string>([]), []);
+	const fixedColumnIds = useMemo(() => new Set<string>(["actions"]), []);
 
 	// Measure actual header cell widths for pixel-perfect pin offsets
 	const { headerCellRefs, setHeaderCellRef } = useHeaderCellRefs();
@@ -188,7 +188,7 @@ export function MCPLogsDataTable({
 													key={cell.id}
 													style={{ width: size, minWidth: size, maxWidth: size, ...buildPinStyle(cell.column, pinOffsets) }}
 													className={cn(
-														"overflow-hidden",
+														!pinned && "overflow-hidden",
 														pinned && "bg-card",
 														cell.column.id === lastLeftPinId && PIN_SHADOW_LEFT,
 														cell.column.id === firstRightPinId && PIN_SHADOW_RIGHT,

--- a/ui/app/workspace/model-catalog/views/modelCatalogTable.tsx
+++ b/ui/app/workspace/model-catalog/views/modelCatalogTable.tsx
@@ -92,7 +92,13 @@ export default function ModelCatalogTable({
 
 			{/* Table */}
 			<div className="rounded-sm border">
-				<Table>
+				<Table className="table-fixed">
+					<colgroup>
+						<col className="w-[26%]" />
+						<col className="w-[44%]" />
+						<col className="w-[16%]" />
+						<col className="w-[14%]" />
+					</colgroup>
 					<TableHeader>
 						<TableRow>
 							<TableHead>Provider</TableHead>
@@ -123,26 +129,26 @@ export default function ModelCatalogTable({
 						) : (
 							rows.map((row) => (
 								<TableRow key={row.providerName}>
-									<TableCell>
+									<TableCell className="overflow-hidden">
 										<div className="flex items-center gap-2">
 											<RenderProviderIcon
 												provider={(row.isCustom ? row.baseProviderType : row.providerName) as ProviderIconType}
 												size="sm"
 												className="h-4 w-4 shrink-0"
 											/>
-											<span className="font-medium">
+											<span className="truncate font-medium">
 												{row.isCustom
 													? row.providerName
 													: ProviderLabels[row.providerName as keyof typeof ProviderLabels] || row.providerName}
 											</span>
 											{row.isCustom && (
-												<Badge variant="secondary" className="text-muted-foreground px-1.5 py-0.5 text-[10px] font-bold">
+												<Badge variant="secondary" className="text-muted-foreground shrink-0 px-1.5 py-0.5 text-[10px] font-bold">
 													CUSTOM
 												</Badge>
 											)}
 										</div>
 									</TableCell>
-									<TableCell>
+									<TableCell className="overflow-hidden">
 										{isLoadingModels ? (
 											<div className="flex items-center gap-1">
 												<Skeleton className="h-5 w-24 rounded-full" />
@@ -179,7 +185,7 @@ function ModelsUsedCell({ models: rawModels }: { models: string[] }) {
 		<TooltipProvider>
 			<div className="flex flex-wrap items-center gap-1">
 				{visible.map((m) => (
-					<Badge key={m} variant="outline" className="text-xs font-normal">
+					<Badge key={m} variant="outline" className="max-w-[220px] truncate text-xs font-normal">
 						{m}
 					</Badge>
 				))}

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -7,10 +7,10 @@ import {
 	AlertDialogFooter,
 	AlertDialogHeader,
 	AlertDialogTitle,
-	AlertDialogTrigger,
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -23,7 +23,7 @@ import { ModelConfig } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
-import { ChevronLeft, ChevronRight, Edit, Plus, Search, Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import ModelLimitSheet from "./modelLimitSheet";
@@ -63,11 +63,16 @@ export default function ModelLimitsTable({
 }: ModelLimitsTableProps) {
 	const [showModelLimitSheet, setShowModelLimitSheet] = useState(false);
 	const [editingModelConfigId, setEditingModelConfigId] = useState<string | null>(null);
+	const [deleteModelConfigId, setDeleteModelConfigId] = useState<string | null>(null);
 
 	// Derive editingModelConfig from props so it stays in sync with RTK cache updates
 	const editingModelConfig = useMemo(
 		() => (editingModelConfigId ? (modelConfigs.find((mc) => mc.id === editingModelConfigId) ?? null) : null),
 		[editingModelConfigId, modelConfigs],
+	);
+	const deletingModelConfig = useMemo(
+		() => (deleteModelConfigId ? (modelConfigs.find((mc) => mc.id === deleteModelConfigId) ?? null) : null),
+		[deleteModelConfigId, modelConfigs],
 	);
 
 	const hasCreateAccess = useRbac(RbacResource.Governance, RbacOperation.Create);
@@ -80,6 +85,7 @@ export default function ModelLimitsTable({
 		try {
 			await deleteModelConfig(id).unwrap();
 			toast.success("Model limit deleted successfully");
+			setDeleteModelConfigId(null);
 		} catch (error) {
 			toast.error(getErrorMessage(error));
 		}
@@ -90,8 +96,7 @@ export default function ModelLimitsTable({
 		setShowModelLimitSheet(true);
 	};
 
-	const handleEditModelLimit = (config: ModelConfig, e: React.MouseEvent) => {
-		e.stopPropagation();
+	const handleEditModelLimit = (config: ModelConfig) => {
 		setEditingModelConfigId(config.id);
 		setShowModelLimitSheet(true);
 	};
@@ -120,6 +125,30 @@ export default function ModelLimitsTable({
 			{showModelLimitSheet && (
 				<ModelLimitSheet modelConfig={editingModelConfig} onSave={handleModelLimitSaved} onCancel={() => setShowModelLimitSheet(false)} />
 			)}
+			<AlertDialog open={!!deletingModelConfig} onOpenChange={(open) => !open && setDeleteModelConfigId(null)}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete Model Limit</AlertDialogTitle>
+						<AlertDialogDescription>
+							Are you sure you want to delete the limit for &quot;
+							{deletingModelConfig?.model_name && deletingModelConfig.model_name.length > 30
+								? `${deletingModelConfig.model_name.slice(0, 30)}...`
+								: deletingModelConfig?.model_name}
+							&quot;? This action cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => deletingModelConfig && handleDelete(deletingModelConfig.id)}
+							disabled={isDeleting}
+							className="bg-red-600 hover:bg-red-700"
+						>
+							{isDeleting ? "Deleting..." : "Delete"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 
 			<div className="space-y-4">
 				<div className="flex items-center justify-between">
@@ -341,53 +370,47 @@ export default function ModelLimitsTable({
 												)}
 											</TableCell>
 											<TableCell onClick={(e) => e.stopPropagation()}>
-												<div className="flex items-center justify-end gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
-													<Button
-														variant="ghost"
-														size="icon"
-														className="h-8 w-8"
-														onClick={(e) => handleEditModelLimit(config, e)}
-														disabled={!hasUpdateAccess}
-														aria-label={`Edit model limit for ${config.model_name}`}
-														data-testid={`model-limit-button-edit-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
-													>
-														<Edit className="h-4 w-4" />
-													</Button>
-													<AlertDialog>
-														<AlertDialogTrigger asChild>
+												<div className="flex items-center justify-end">
+													<DropdownMenu>
+														<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
 															<Button
 																variant="ghost"
 																size="icon"
-																className="h-8 w-8 text-red-500 hover:bg-red-500/10 hover:text-red-500"
-																onClick={(e) => e.stopPropagation()}
+																className="h-8 w-8"
+																aria-label={`Actions for model limit ${config.model_name}`}
+																data-testid={`model-limit-button-actions-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
+															>
+																<MoreHorizontal className="h-4 w-4" />
+															</Button>
+														</DropdownMenuTrigger>
+														<DropdownMenuContent align="end">
+															<DropdownMenuItem
+																className="cursor-pointer"
+																disabled={!hasUpdateAccess}
+																onClick={(e) => {
+																	e.stopPropagation();
+																	handleEditModelLimit(config);
+																}}
+																data-testid={`model-limit-button-edit-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
+															>
+																<Edit className="h-4 w-4" />
+																Edit
+															</DropdownMenuItem>
+															<DropdownMenuItem
+																variant="destructive"
+																className="cursor-pointer"
 																disabled={!hasDeleteAccess}
-																aria-label={`Delete model limit for ${config.model_name}`}
+																onClick={(e) => {
+																	e.stopPropagation();
+																	setDeleteModelConfigId(config.id);
+																}}
 																data-testid={`model-limit-button-delete-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
 															>
 																<Trash2 className="h-4 w-4" />
-															</Button>
-														</AlertDialogTrigger>
-														<AlertDialogContent>
-															<AlertDialogHeader>
-																<AlertDialogTitle>Delete Model Limit</AlertDialogTitle>
-																<AlertDialogDescription>
-																	Are you sure you want to delete the limit for &quot;
-																	{config.model_name.length > 30 ? `${config.model_name.slice(0, 30)}...` : config.model_name}
-																	&quot;? This action cannot be undone.
-																</AlertDialogDescription>
-															</AlertDialogHeader>
-															<AlertDialogFooter>
-																<AlertDialogCancel>Cancel</AlertDialogCancel>
-																<AlertDialogAction
-																	onClick={() => handleDelete(config.id)}
-																	disabled={isDeleting}
-																	className="bg-red-600 hover:bg-red-700"
-																>
-																	{isDeleting ? "Deleting..." : "Delete"}
-																</AlertDialogAction>
-															</AlertDialogFooter>
-														</AlertDialogContent>
-													</AlertDialog>
+																Delete
+															</DropdownMenuItem>
+														</DropdownMenuContent>
+													</DropdownMenu>
 												</div>
 											</TableCell>
 										</TableRow>

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -128,7 +128,13 @@ export default function ModelProviderKeysTableView({ provider, className, header
 				</div>
 			) : (
 				<div className="flex w-full flex-col gap-2 rounded-sm border">
-					<Table className="w-full" data-testid="keys-table">
+					<Table className="w-full table-fixed" data-testid="keys-table">
+						<colgroup>
+							<col className="w-[64%]" />
+							<col className="w-[12%]" />
+							<col className="w-[12%]" />
+							<col className="w-[12%]" />
+						</colgroup>
 						<TableHeader className="w-full">
 							<TableRow>
 								<TableHead>{isVLLM ? "Model" : isOllamaOrSGL ? "Server" : "API Key"}</TableHead>
@@ -154,8 +160,8 @@ export default function ModelProviderKeysTableView({ provider, className, header
 										className="text-sm transition-colors hover:bg-white"
 										onClick={() => { }}
 									>
-										<TableCell>
-											<div className="flex items-center space-x-2">
+										<TableCell className="overflow-hidden">
+											<div className="flex min-w-0 items-center space-x-2">
 												{key.status === "success" && (
 													<Tooltip>
 														<TooltipTrigger asChild>
@@ -218,7 +224,7 @@ export default function ModelProviderKeysTableView({ provider, className, header
 															</Tooltip>
 														);
 													})()}
-												<span className="font-mono text-sm">{key.name}</span>
+												<span className="truncate font-mono text-sm">{key.name}</span>
 											</div>
 										</TableCell>
 										<TableCell data-testid="key-weight-value">

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
@@ -24,7 +25,7 @@ import { getErrorMessage } from "@/lib/store";
 import { useDeleteRoutingRuleMutation, useUpdateRoutingRuleMutation } from "@/lib/store/apis/routingRulesApi";
 import { RoutingRule, RoutingTarget } from "@/lib/types/routingRules";
 import { getPriorityBadgeClass, getScopeLabel, truncateCELExpression } from "@/lib/utils/routingRules";
-import { ChevronLeft, ChevronRight, Edit, Search, Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Search, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -70,7 +71,7 @@ export function RoutingRulesTable({
 			await deleteRoutingRule(deleteRuleId).unwrap();
 			toast.success("Routing rule deleted successfully");
 			setDeleteRuleId(null);
-		} catch (error: any) {
+		} catch (error: unknown) {
 			toast.error(getErrorMessage(error));
 		}
 	};
@@ -190,29 +191,47 @@ export function RoutingRulesTable({
 										/>
 									</TableCell>
 									<TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
-										<div className="flex items-center justify-end gap-2">
-											{canUpdate && (
-												<Button
-													variant="ghost"
-													size="sm"
-													onClick={() => onEdit(rule)}
-													aria-label="Edit routing rule"
-													data-testid={`routing-rule-edit-${rule.id}-btn`}
-												>
-													<Edit className="h-4 w-4" />
-												</Button>
-											)}
-											{canDelete && (
-												<Button
-													variant="ghost"
-													size="sm"
-													onClick={() => setDeleteRuleId(rule.id)}
-													aria-label="Delete routing rule"
-													data-testid={`routing-rule-delete-${rule.id}-btn`}
-												>
-													<Trash2 className="h-4 w-4" />
-												</Button>
-											)}
+										<div className="flex items-center justify-end">
+											<DropdownMenu>
+												<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+													<Button
+														variant="ghost"
+														size="icon"
+														className="h-8 w-8"
+														aria-label={`Actions for routing rule ${rule.name}`}
+														data-testid={`routing-rule-actions-${rule.id}-btn`}
+													>
+														<MoreHorizontal className="h-4 w-4" />
+													</Button>
+												</DropdownMenuTrigger>
+												<DropdownMenuContent align="end">
+													<DropdownMenuItem
+														className="cursor-pointer"
+														disabled={!canUpdate}
+														onClick={(e) => {
+															e.stopPropagation();
+															onEdit(rule);
+														}}
+														data-testid={`routing-rule-edit-${rule.id}-btn`}
+													>
+														<Edit className="h-4 w-4" />
+														Edit
+													</DropdownMenuItem>
+													<DropdownMenuItem
+														variant="destructive"
+														className="cursor-pointer"
+														disabled={!canDelete}
+														onClick={(e) => {
+															e.stopPropagation();
+															setDeleteRuleId(rule.id);
+														}}
+														data-testid={`routing-rule-delete-${rule.id}-btn`}
+													>
+														<Trash2 className="h-4 w-4" />
+														Delete
+													</DropdownMenuItem>
+												</DropdownMenuContent>
+											</DropdownMenu>
 										</div>
 									</TableCell>
 								</TableRow>


### PR DESCRIPTION
## Summary

Replaces the individual Edit and Delete action buttons in the routing rules table with a consolidated `DropdownMenu` triggered by a `MoreHorizontal` icon. This reduces visual clutter in the actions column and provides a more consistent UX pattern for row-level actions.

## Changes

- Replaced separate Edit and Delete ghost buttons with a single `MoreHorizontal` icon button that opens a dropdown menu containing both actions
- Edit and Delete items within the dropdown remain gated by `canUpdate` and `canDelete` permissions respectively, now using the `disabled` prop instead of conditional rendering
- The Delete item uses the `destructive` variant to visually distinguish it from the Edit action
- Changed `catch (error: any)` to `catch (error: unknown)` for improved type safety
- Added a trailing newline to the end of the file

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the routing rules table and verify:
1. Each row displays a `MoreHorizontal` icon button in the actions column
2. Clicking the icon opens a dropdown with Edit and Delete options
3. Edit and Delete options are disabled when the user lacks the respective permissions
4. Selecting Edit opens the edit flow for the correct rule
5. Selecting Delete triggers the delete confirmation dialog for the correct rule
6. Row click propagation is not triggered when interacting with the dropdown

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Two separate icon buttons (pencil and trash) visible inline on each row.

After: A single `⋯` icon button per row that reveals Edit and Delete options in a dropdown, with Delete styled in red.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Permission checks (`canUpdate`, `canDelete`) are preserved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable