### PR TITLE
feat: replace inline action buttons with pinned dropdown menus and add active toggle switch in teams and virtual keys tables

### DIFF
--- a/ui/app/workspace/governance/views/customerTable.tsx
+++ b/ui/app/workspace/governance/views/customerTable.tsx
@@ -1,3 +1,4 @@
+import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -7,10 +8,10 @@ import {
 	AlertDialogFooter,
 	AlertDialogHeader,
 	AlertDialogTitle,
-	AlertDialogTrigger,
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -21,7 +22,7 @@ import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Input } from "@/components/ui/input";
-import { ChevronLeft, ChevronRight, Edit, Plus, Search, Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import CustomerDialog from "./customerDialog";
@@ -31,6 +32,61 @@ import { CustomersEmptyState } from "./customersEmptyState";
 const formatResetDuration = (duration: string) => {
 	return resetDurationLabels[duration] || duration;
 };
+
+const ACTIONS_COLUMN_CLASS = `sticky right-0 z-10 w-[56px] min-w-[56px] text-right ${PIN_SHADOW_RIGHT}`;
+
+interface CustomerActionsMenuProps {
+	customer: Customer;
+	canUpdate: boolean;
+	canDelete: boolean;
+	onEdit: (customer: Customer) => void;
+	onDelete: (customer: Customer) => void;
+}
+
+function CustomerActionsMenu({ customer, canUpdate, canDelete, onEdit, onDelete }: CustomerActionsMenuProps) {
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8"
+					aria-label={`Customer actions ${customer.name}`}
+					data-testid={`customer-actions-btn-${customer.id}`}
+					onClick={(e) => e.stopPropagation()}
+					onPointerDown={(e) => e.stopPropagation()}
+				>
+					<MoreHorizontal className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					disabled={!canUpdate}
+					data-testid={`customer-button-edit-${customer.id}`}
+					onClick={(e) => {
+						e.stopPropagation();
+						onEdit(customer);
+					}}
+				>
+					<Edit className="h-4 w-4" />
+					Edit
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					variant="destructive"
+					disabled={!canDelete}
+					data-testid={`customer-button-delete-${customer.id}`}
+					onClick={(e) => {
+						e.stopPropagation();
+						onDelete(customer);
+					}}
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
 
 interface CustomersTableProps {
 	customers: Customer[];
@@ -59,6 +115,7 @@ export default function CustomersTable({
 }: CustomersTableProps) {
 	const [showCustomerDialog, setShowCustomerDialog] = useState(false);
 	const [editingCustomer, setEditingCustomer] = useState<Customer | null>(null);
+	const [confirmDeleteCustomer, setConfirmDeleteCustomer] = useState<Customer | null>(null);
 
 	const hasCreateAccess = useRbac(RbacResource.Customers, RbacOperation.Create);
 	const hasUpdateAccess = useRbac(RbacResource.Customers, RbacOperation.Update);
@@ -72,6 +129,8 @@ export default function CustomersTable({
 			toast.success("Customer deleted successfully");
 		} catch (error) {
 			toast.error(getErrorMessage(error));
+		} finally {
+			setConfirmDeleteCustomer(null);
 		}
 	};
 
@@ -147,8 +206,8 @@ export default function CustomersTable({
 						</div>
 					</div>
 
-					<div className="overflow-hidden rounded-sm border" data-testid="customer-table-container">
-						<Table>
+					<div className="overflow-auto rounded-sm border" data-testid="customer-table-container">
+						<Table className="min-w-[1100px]">
 							<TableHeader>
 								<TableRow>
 									<TableHead>Name</TableHead>
@@ -156,7 +215,7 @@ export default function CustomersTable({
 									<TableHead>Budget</TableHead>
 									<TableHead>Rate Limit</TableHead>
 									<TableHead>Virtual Keys</TableHead>
-									<TableHead className="text-right"></TableHead>
+									<TableHead className={`bg-muted ${ACTIONS_COLUMN_CLASS}`}></TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
@@ -363,54 +422,20 @@ export default function CustomersTable({
 														<span className="text-muted-foreground text-sm">-</span>
 													)}
 												</TableCell>
-												<TableCell className="text-right">
-													<div className="flex items-center justify-end gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
-														<Button
-															variant="ghost"
-															size="icon"
-															className="h-8 w-8"
-															onClick={() => handleEditCustomer(customer)}
-															disabled={!hasUpdateAccess}
-															aria-label={`Edit customer ${customer.name}`}
-															data-testid={`customer-button-edit-${customer.id}`}
-														>
-															<Edit className="h-4 w-4" />
-														</Button>
-														<AlertDialog>
-															<AlertDialogTrigger asChild>
-																<Button
-																	variant="ghost"
-																	size="icon"
-																	className="h-8 w-8 text-red-500 hover:bg-red-500/10 hover:text-red-500"
-																	disabled={!hasDeleteAccess}
-																	aria-label={`Delete customer ${customer.name}`}
-																	data-testid={`customer-button-delete-${customer.id}`}
-																>
-																	<Trash2 className="h-4 w-4" />
-																</Button>
-															</AlertDialogTrigger>
-															<AlertDialogContent>
-																<AlertDialogHeader>
-																	<AlertDialogTitle>Delete Customer</AlertDialogTitle>
-																	<AlertDialogDescription>
-																		Are you sure you want to delete &quot;{customer.name}&quot;? This will also delete all associated teams
-																		and unassign any virtual keys. This action cannot be undone.
-																	</AlertDialogDescription>
-																</AlertDialogHeader>
-																<AlertDialogFooter>
-																	<AlertDialogCancel data-testid="customer-button-delete-cancel">Cancel</AlertDialogCancel>
-																	<AlertDialogAction
-																		data-testid="customer-button-delete-confirm"
-																		onClick={() => handleDelete(customer.id)}
-																		disabled={isDeleting}
-																		className="bg-red-600 hover:bg-red-700"
-																	>
-																		{isDeleting ? "Deleting..." : "Delete"}
-																	</AlertDialogAction>
-																</AlertDialogFooter>
-															</AlertDialogContent>
-														</AlertDialog>
-													</div>
+												<TableCell
+													className={cn(
+														"dark:bg-card dark:group-hover:bg-muted",
+														isExhausted ? "bg-red-500/5 group-hover:bg-red-500/10" : "bg-white group-hover:bg-muted",
+														ACTIONS_COLUMN_CLASS,
+													)}
+												>
+													<CustomerActionsMenu
+														customer={customer}
+														canUpdate={hasUpdateAccess}
+														canDelete={hasDeleteAccess}
+														onEdit={handleEditCustomer}
+														onDelete={setConfirmDeleteCustomer}
+													/>
 												</TableCell>
 											</TableRow>
 										);
@@ -449,6 +474,29 @@ export default function CustomersTable({
 						</div>
 					)}
 				</div>
+
+				<AlertDialog open={!!confirmDeleteCustomer} onOpenChange={(open) => !open && setConfirmDeleteCustomer(null)}>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>Delete Customer</AlertDialogTitle>
+							<AlertDialogDescription>
+								Are you sure you want to delete &quot;{confirmDeleteCustomer?.name}&quot;? This will also delete all associated teams and
+								unassign any virtual keys. This action cannot be undone.
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel data-testid="customer-button-delete-cancel">Cancel</AlertDialogCancel>
+							<AlertDialogAction
+								data-testid="customer-button-delete-confirm"
+								onClick={() => confirmDeleteCustomer && handleDelete(confirmDeleteCustomer.id)}
+								disabled={isDeleting}
+								className="bg-red-600 hover:bg-red-700"
+							>
+								{isDeleting ? "Deleting..." : "Delete"}
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
 			</TooltipProvider>
 		</>
 	);

--- a/ui/app/workspace/governance/views/teamsTable.tsx
+++ b/ui/app/workspace/governance/views/teamsTable.tsx
@@ -7,10 +7,16 @@ import {
 	AlertDialogFooter,
 	AlertDialogHeader,
 	AlertDialogTitle,
-	AlertDialogTrigger,
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
 import { Progress } from "@/components/ui/progress";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -21,8 +27,8 @@ import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Input } from "@/components/ui/input";
-import { ChevronLeft, ChevronRight, Edit, Plus, Search, Trash2 } from "lucide-react";
-import { useEffect } from "react";
+import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, Search, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import TeamDialog from "./teamDialog";
 import { TeamsEmptyState } from "./teamsEmptyState";
@@ -31,6 +37,89 @@ import { TeamsEmptyState } from "./teamsEmptyState";
 const formatResetDuration = (duration: string) => {
 	return resetDurationLabels[duration] || duration;
 };
+
+function TeamActionsMenu({
+	team,
+	hasUpdateAccess,
+	hasDeleteAccess,
+	isDeleting,
+	onEdit,
+	onDelete,
+}: {
+	team: Team;
+	hasUpdateAccess: boolean;
+	hasDeleteAccess: boolean;
+	isDeleting: boolean;
+	onEdit: (team: Team) => void;
+	onDelete: (teamId: string) => void;
+}) {
+	const [deleteOpen, setDeleteOpen] = useState(false);
+
+	return (
+		<>
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button
+						variant="ghost"
+						size="icon"
+						className="h-8 w-8"
+						aria-label={`Team actions for ${team.name}`}
+						data-testid={`team-actions-btn-${team.name}`}
+					>
+						<MoreHorizontal className="h-4 w-4" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end">
+					<DropdownMenuItem
+						className="cursor-pointer"
+						disabled={!hasUpdateAccess}
+						data-testid={`team-edit-btn-${team.name}`}
+						onSelect={(e) => {
+							e.preventDefault();
+							onEdit(team);
+						}}
+					>
+						<Edit className="h-4 w-4" />
+						Edit
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						variant="destructive"
+						className="cursor-pointer"
+						disabled={!hasDeleteAccess}
+						data-testid={`team-delete-btn-${team.name}`}
+						onSelect={(e) => {
+							e.preventDefault();
+							setDeleteOpen(true);
+						}}
+					>
+						<Trash2 className="h-4 w-4" />
+						Delete
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+			<AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete Team</AlertDialogTitle>
+						<AlertDialogDescription>
+							Are you sure you want to delete &quot;{team.name}&quot;? This will also unassign any virtual keys from this team. This action cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => onDelete(team.id)}
+							disabled={isDeleting}
+							className="bg-red-600 hover:bg-red-700"
+						>
+							{isDeleting ? "Deleting..." : "Delete"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</>
+	);
+}
 
 interface TeamsTableProps {
 	teams: Team[];
@@ -164,8 +253,8 @@ export default function TeamsTable({
 						</div>
 					</div>
 
-					<div className="overflow-hidden rounded-sm border" data-testid="teams-table">
-						<Table>
+					<div className="overflow-auto rounded-sm border" data-testid="teams-table">
+						<Table className="min-w-[1100px]">
 							<TableHeader>
 								<TableRow>
 									<TableHead>Name</TableHead>
@@ -173,7 +262,7 @@ export default function TeamsTable({
 									<TableHead>Budget</TableHead>
 									<TableHead>Rate Limit</TableHead>
 									<TableHead>Virtual Keys</TableHead>
-									<TableHead className="text-right"></TableHead>
+									<TableHead className={`bg-muted sticky right-0 z-10 w-[56px] text-right ${PIN_SHADOW_RIGHT}`}></TableHead>
 								</TableRow>
 							</TableHeader>
 							<TableBody>
@@ -374,53 +463,15 @@ export default function TeamsTable({
 														<span className="text-muted-foreground text-sm">-</span>
 													)}
 												</TableCell>
-												<TableCell className="text-right">
-													<div className="flex items-center justify-end gap-1 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
-														<Button
-															variant="ghost"
-															size="icon"
-															className="h-8 w-8"
-															onClick={() => handleEditTeam(team)}
-															disabled={!hasUpdateAccess}
-															aria-label={`Edit team ${team.name}`}
-															data-testid={`team-edit-btn-${team.name}`}
-														>
-															<Edit className="h-4 w-4" />
-														</Button>
-														<AlertDialog>
-															<AlertDialogTrigger asChild>
-																<Button
-																	variant="ghost"
-																	size="icon"
-																	className="h-8 w-8 text-red-500 hover:bg-red-500/10 hover:text-red-500"
-																	disabled={!hasDeleteAccess}
-																	aria-label={`Delete team ${team.name}`}
-																	data-testid={`team-delete-btn-${team.name}`}
-																>
-																	<Trash2 className="h-4 w-4" />
-																</Button>
-															</AlertDialogTrigger>
-															<AlertDialogContent>
-																<AlertDialogHeader>
-																	<AlertDialogTitle>Delete Team</AlertDialogTitle>
-																	<AlertDialogDescription>
-																		Are you sure you want to delete &quot;{team.name}&quot;? This will also unassign any virtual keys from
-																		this team. This action cannot be undone.
-																	</AlertDialogDescription>
-																</AlertDialogHeader>
-																<AlertDialogFooter>
-																	<AlertDialogCancel>Cancel</AlertDialogCancel>
-																	<AlertDialogAction
-																		onClick={() => handleDelete(team.id)}
-																		disabled={isDeleting}
-																		className="bg-red-600 hover:bg-red-700"
-																	>
-																		{isDeleting ? "Deleting..." : "Delete"}
-																	</AlertDialogAction>
-																</AlertDialogFooter>
-															</AlertDialogContent>
-														</AlertDialog>
-													</div>
+												<TableCell className={`bg-white group-hover:bg-muted sticky right-0 z-10 text-right dark:bg-card dark:group-hover:bg-muted ${PIN_SHADOW_RIGHT}`}>
+													<TeamActionsMenu
+														team={team}
+														hasUpdateAccess={hasUpdateAccess}
+														hasDeleteAccess={hasDeleteAccess}
+														isDeleting={isDeleting}
+														onEdit={handleEditTeam}
+														onDelete={handleDelete}
+													/>
 												</TableCell>
 											</TableRow>
 										);

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -1,4 +1,5 @@
 import { RateLimitDisplay } from "@/components/rateLimitDisplay";
+import { PIN_SHADOW_RIGHT } from "@/components/table/columnPinning";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -8,19 +9,24 @@ import {
 	AlertDialogFooter,
 	AlertDialogHeader,
 	AlertDialogTitle,
-	AlertDialogTrigger,
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ComboboxSelect } from "@/components/ui/combobox";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdownMenu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { resetDurationLabels } from "@/lib/constants/governance";
-import { getErrorMessage, useDeleteVirtualKeyMutation, useLazyGetVirtualKeysQuery } from "@/lib/store";
+import { getErrorMessage, useDeleteVirtualKeyMutation, useLazyGetVirtualKeysQuery, useUpdateVirtualKeyMutation } from "@/lib/store";
 import { Customer, Team, VirtualKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/utils/governance";
@@ -37,6 +43,7 @@ import {
 	Eye,
 	EyeOff,
 	Loader2,
+	MoreHorizontal,
 	Plus,
 	Search,
 	ShieldCheck,
@@ -113,96 +120,110 @@ function VKRateLimitCell({ vk }: { vk: VirtualKey }) {
 	return <RateLimitDisplay rateLimits={displayRateLimit} />;
 }
 
-// Status badge derives exhaustion from the same AP-backed source as the budget/rate-limit cells
-// so managed keys don't show "Active" next to an exhausted-looking bar.
-function VKStatusBadge({ vk }: { vk: VirtualKey }) {
-	const { isExhausted } = useVirtualKeyUsage(vk);
-	return (
-		<Badge variant={vk.is_active ? (isExhausted ? "destructive" : "default") : "secondary"}>
-			{vk.is_active ? (isExhausted ? "Exhausted" : "Active") : "Inactive"}
-		</Badge>
-	);
-}
-
-// Per-row delete button. Calls useVirtualKeyUsage (same cached query as the budget/
-// rate-limit cells — RTK dedupes) to detect managed-by-AP VKs and swap the normal
-// delete AlertDialog for a disabled button + tooltip so users aren't lured into a
-// confirm-then-403 loop.
-function VKDeleteButton({
+function VKActiveSwitch({
 	vk,
-	hasDeleteAccess,
-	isDeleting,
-	onDelete,
+	hasUpdateAccess,
+	onToggle,
 }: {
 	vk: VirtualKey;
-	hasDeleteAccess: boolean;
-	isDeleting: boolean;
-	onDelete: (vkId: string) => void;
+	hasUpdateAccess: boolean;
+	onToggle: (vk: VirtualKey, checked: boolean) => Promise<void>;
 }) {
 	const { isManagedByProfile } = useVirtualKeyUsage(vk);
 
-	if (isManagedByProfile) {
-		return (
-			<TooltipProvider>
-				<Tooltip delayDuration={300}>
-					<TooltipTrigger asChild>
-						<span className="inline-block cursor-not-allowed">
-							<Button
-								variant="ghost"
-								size="sm"
-								className="text-destructive border-destructive/30"
-								disabled
-								data-testid={`vk-delete-btn-${vk.name}`}
-							>
-								<Trash2 className="h-4 w-4" />
-							</Button>
-						</span>
-					</TooltipTrigger>
-					<TooltipContent side="top" className="max-w-[260px]">
-						<p className="text-xs">
-							This virtual key is managed by an access profile and can&apos;t be deleted here. Detach the profile from the user or delete it
-							from the access profile settings.
-						</p>
-					</TooltipContent>
-				</Tooltip>
-			</TooltipProvider>
-		);
-	}
+	return (
+		<Switch
+			checked={vk.is_active}
+			disabled={!hasUpdateAccess || isManagedByProfile}
+			aria-label={`${vk.is_active ? "Disable" : "Enable"} virtual key ${vk.name}`}
+			data-testid={`vk-active-switch-${vk.name}`}
+			title={isManagedByProfile ? "This virtual key is managed by an access profile." : undefined}
+			onAsyncCheckedChange={(checked) => onToggle(vk, checked)}
+		/>
+	);
+}
+
+function VKActionsMenu({
+	vk,
+	hasUpdateAccess,
+	hasDeleteAccess,
+	isDeleting,
+	onEdit,
+	onDelete,
+}: {
+	vk: VirtualKey;
+	hasUpdateAccess: boolean;
+	hasDeleteAccess: boolean;
+	isDeleting: boolean;
+	onEdit: (vk: VirtualKey) => void;
+	onDelete: (vkId: string) => void;
+}) {
+	const { isManagedByProfile } = useVirtualKeyUsage(vk);
+	const [deleteOpen, setDeleteOpen] = useState(false);
 
 	return (
-		<AlertDialog>
-			<AlertDialogTrigger asChild>
-				<Button
-					variant="ghost"
-					size="sm"
-					className="text-destructive hover:bg-destructive/10 hover:text-destructive border-destructive/30"
-					onClick={(e) => e.stopPropagation()}
-					disabled={!hasDeleteAccess}
-					data-testid={`vk-delete-btn-${vk.name}`}
-				>
-					<Trash2 className="h-4 w-4" />
-				</Button>
-			</AlertDialogTrigger>
-			<AlertDialogContent>
-				<AlertDialogHeader>
-					<AlertDialogTitle>Delete Virtual Key</AlertDialogTitle>
-					<AlertDialogDescription>
-						Are you sure you want to delete &quot;{vk.name.length > 20 ? `${vk.name.slice(0, 20)}...` : vk.name}&quot;? This action cannot be undone.
-					</AlertDialogDescription>
-				</AlertDialogHeader>
-				<AlertDialogFooter>
-					<AlertDialogCancel data-testid={`vk-delete-cancel-${vk.name}`}>Cancel</AlertDialogCancel>
-					<AlertDialogAction
-						onClick={() => onDelete(vk.id)}
-						disabled={isDeleting}
-						className="bg-destructive hover:bg-destructive/90"
-						data-testid={`vk-delete-confirm-${vk.name}`}
+		<>
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Virtual key actions" data-testid={`vk-actions-btn-${vk.name}`}>
+						<MoreHorizontal className="h-4 w-4" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end">
+					<DropdownMenuItem
+						className="cursor-pointer"
+						disabled={!hasUpdateAccess}
+						data-testid={`vk-edit-btn-${vk.name}`}
+						onSelect={(e) => {
+							e.preventDefault();
+							onEdit(vk);
+						}}
 					>
-						{isDeleting ? "Deleting..." : "Delete"}
-					</AlertDialogAction>
-				</AlertDialogFooter>
-			</AlertDialogContent>
-		</AlertDialog>
+						<Edit className="h-4 w-4" />
+						Edit
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						variant="destructive"
+						className="cursor-pointer"
+						disabled={!hasDeleteAccess || isManagedByProfile}
+						data-testid={`vk-delete-btn-${vk.name}`}
+						title={
+							isManagedByProfile
+								? "This virtual key is managed by an access profile and can't be deleted here."
+								: undefined
+						}
+						onSelect={(e) => {
+							e.preventDefault();
+							setDeleteOpen(true);
+						}}
+					>
+						<Trash2 className="h-4 w-4" />
+						Delete
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+			<AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete Virtual Key</AlertDialogTitle>
+						<AlertDialogDescription>
+							Are you sure you want to delete &quot;{vk.name.length > 20 ? `${vk.name.slice(0, 20)}...` : vk.name}&quot;? This action cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel data-testid={`vk-delete-cancel-${vk.name}`}>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => onDelete(vk.id)}
+							disabled={isDeleting}
+							className="bg-destructive hover:bg-destructive/90"
+							data-testid={`vk-delete-confirm-${vk.name}`}
+						>
+							{isDeleting ? "Deleting..." : "Delete"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</>
 	);
 }
 
@@ -270,6 +291,7 @@ export default function VirtualKeysTable({
 	const hasDeleteAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Delete);
 
 	const [deleteVirtualKey, { isLoading: isDeleting }] = useDeleteVirtualKeyMutation();
+	const [updateVirtualKey] = useUpdateVirtualKeyMutation();
 
 	const handleDelete = async (vkId: string) => {
 		try {
@@ -280,13 +302,22 @@ export default function VirtualKeysTable({
 		}
 	};
 
+	const handleToggleActive = async (vk: VirtualKey, checked: boolean) => {
+		try {
+			await updateVirtualKey({ vkId: vk.id, data: { is_active: checked } }).unwrap();
+			toast.success(`Virtual key ${checked ? "enabled" : "disabled"}`);
+		} catch (error) {
+			toast.error(getErrorMessage(error));
+			throw error;
+		}
+	};
+
 	const handleAddVirtualKey = () => {
 		setEditingVirtualKeyId(null);
 		setShowVirtualKeySheet(true);
 	};
 
-	const handleEditVirtualKey = (vk: VirtualKey, e: React.MouseEvent) => {
-		e.stopPropagation(); // Prevent row click
+	const handleEditVirtualKey = (vk: VirtualKey) => {
 		setEditingVirtualKeyId(vk.id);
 		setShowVirtualKeySheet(true);
 	};
@@ -563,7 +594,7 @@ export default function VirtualKeysTable({
 				</div>
 
 				<div className="rounded-sm border">
-					<Table className="table-fixed w-full" data-testid="vk-table">
+					<Table className="table-fixed min-w-[1480px] w-full" data-testid="vk-table">
 						<TableHeader>
 							<TableRow>
 								<TableHead className="w-[250px]">
@@ -578,7 +609,7 @@ export default function VirtualKeysTable({
 								<TableHead className="w-[120px]">
 									<SortableHeader column="status" label="Status" />
 								</TableHead>
-								<TableHead className="w-[110px] text-right"></TableHead>
+								<TableHead className={`bg-muted sticky right-0 z-10 w-[56px] text-right ${PIN_SHADOW_RIGHT}`}></TableHead>
 							</TableRow>
 						</TableHeader>
 						<TableBody>
@@ -596,7 +627,7 @@ export default function VirtualKeysTable({
 										<TableRow
 											key={vk.id}
 											data-testid={`vk-row-${vk.name}`}
-											className="hover:bg-muted/50 cursor-pointer transition-colors"
+											className="group hover:bg-muted/50 cursor-pointer transition-colors"
 											onClick={() => handleRowClick(vk)}
 										>
 											<TableCell className="max-w-[200px]">
@@ -642,22 +673,21 @@ export default function VirtualKeysTable({
 											<TableCell>
 												<VKRateLimitCell vk={vk} />
 											</TableCell>
-											<TableCell>
-												<VKStatusBadge vk={vk} />
+											<TableCell onClick={(e) => e.stopPropagation()}>
+												<VKActiveSwitch vk={vk} hasUpdateAccess={hasUpdateAccess} onToggle={handleToggleActive} />
 											</TableCell>
-											<TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
-												<div className="flex items-center justify-end gap-2">
-													<Button
-														variant="ghost"
-														size="sm"
-														onClick={(e) => handleEditVirtualKey(vk, e)}
-														disabled={!hasUpdateAccess}
-														data-testid={`vk-edit-btn-${vk.name}`}
-													>
-														<Edit className="h-4 w-4" />
-													</Button>
-													<VKDeleteButton vk={vk} hasDeleteAccess={hasDeleteAccess} isDeleting={isDeleting} onDelete={handleDelete} />
-												</div>
+											<TableCell
+												className={`bg-white group-hover:bg-muted sticky right-0 z-10 text-right dark:bg-card dark:group-hover:bg-muted ${PIN_SHADOW_RIGHT}`}
+												onClick={(e) => e.stopPropagation()}
+											>
+												<VKActionsMenu
+													vk={vk}
+													hasUpdateAccess={hasUpdateAccess}
+													hasDeleteAccess={hasDeleteAccess}
+													isDeleting={isDeleting}
+													onEdit={handleEditVirtualKey}
+													onDelete={handleDelete}
+												/>
 											</TableCell>
 										</TableRow>
 									);


### PR DESCRIPTION
## Summary

Replaces the inline edit/delete action buttons in the Teams and Virtual Keys tables with a consolidated `MoreHorizontal` dropdown menu per row. The actions column is now sticky-pinned to the right edge of the table so it remains visible when the table scrolls horizontally. The Virtual Keys table also replaces the status badge with an inline active/inactive toggle switch.

## Changes

- Extracted `TeamActionsMenu` and `VKActionsMenu` components that render a `DropdownMenu` containing Edit and Delete items, with the delete confirmation `AlertDialog` controlled via local state rather than being triggered directly from an `AlertDialogTrigger`.
- Removed the hover-only opacity animation on action buttons in favor of always-visible dropdown triggers.
- The actions `TableHead` and `TableCell` are now sticky (`sticky right-0 z-10`) with `PIN_SHADOW_RIGHT` applied and background colors that match the row hover state, keeping the pinned column visually consistent.
- Tables are given a `min-w` value and their container uses `overflow-auto` to support horizontal scrolling without breaking the sticky column.
- `VKStatusBadge` is replaced by `VKActiveSwitch`, which renders a `Switch` component and calls `useUpdateVirtualKeyMutation` to toggle `is_active` inline. Managed-by-profile keys disable the switch and show a tooltip title.
- The managed-by-profile delete tooltip/disabled-button pattern is replaced by a disabled destructive `DropdownMenuItem` with a `title` attribute.
- `handleEditVirtualKey` no longer requires a `MouseEvent` argument since click propagation is handled at the cell level.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the **Governance → Teams** page.
   - Verify the actions column stays pinned to the right when scrolling horizontally.
   - Click the `MoreHorizontal` button on a row and confirm Edit and Delete items appear.
   - Confirm the delete confirmation dialog opens from the dropdown and completes successfully.
2. Navigate to the **Virtual Keys** page.
   - Verify the active toggle switch reflects the current `is_active` state and toggling it updates the key immediately with a success toast.
   - Confirm keys managed by an access profile show a disabled switch and a disabled Delete item in the dropdown.
   - Verify the sticky actions column behaves correctly on horizontal scroll.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Add before/after screenshots showing the dropdown menu and sticky column behavior._

## Breaking changes

- [x] No

## Related issues

## Security considerations

No new auth surfaces introduced. RBAC checks (`hasUpdateAccess`, `hasDeleteAccess`) are preserved on all action items.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable