### PR TITLE
feat: updates playwright config to support enterprise ui tests and allow clipboard

### DIFF
--- a/tests/e2e/core/fixtures/base.fixture.ts
+++ b/tests/e2e/core/fixtures/base.fixture.ts
@@ -1,123 +1,140 @@
-import { test as base, expect } from '@playwright/test'
-import { SidebarPage } from '../pages/sidebar.page'
-import { ProvidersPage } from '../../features/providers/pages/providers.page'
-import { VirtualKeysPage } from '../../features/virtual-keys/pages/virtual-keys.page'
-import { DashboardPage } from '../../features/dashboard/pages/dashboard.page'
-import { LogsPage } from '../../features/logs/pages/logs.page'
-import { MCPLogsPage } from '../../features/mcp-logs/pages/mcp-logs.page'
-import { RoutingRulesPage } from '../../features/routing-rules/pages/routing-rules.page'
-import { MCPRegistryPage } from '../../features/mcp-registry/pages/mcp-registry.page'
-import { PluginsPage } from '../../features/plugins/pages/plugins.page'
-import { ObservabilityPage } from '../../features/observability/pages/observability.page'
-import { ConfigSettingsPage } from '../../features/config/pages/config-settings.page'
-import { GovernancePage } from '../../features/governance/pages/governance.page'
-import { MCPAuthConfigPage } from '../../features/mcp-auth-config/pages/mcp-auth-config.page'
-import { MCPSettingsPage } from '../../features/mcp-settings/pages/mcp-settings.page'
-import { MCPToolGroupsPage } from '../../features/mcp-tool-groups/pages/mcp-tool-groups.page'
-import { ModelLimitsPage } from '../../features/model-limits/pages/model-limits.page'
+import { test as base, expect } from "@playwright/test";
+import { SidebarPage } from "../pages/sidebar.page";
+import { ProvidersPage } from "../../features/providers/pages/providers.page";
+import { VirtualKeysPage } from "../../features/virtual-keys/pages/virtual-keys.page";
+import { DashboardPage } from "../../features/dashboard/pages/dashboard.page";
+import { LogsPage } from "../../features/logs/pages/logs.page";
+import { MCPLogsPage } from "../../features/mcp-logs/pages/mcp-logs.page";
+import { RoutingRulesPage } from "../../features/routing-rules/pages/routing-rules.page";
+import { MCPRegistryPage } from "../../features/mcp-registry/pages/mcp-registry.page";
+import { PluginsPage } from "../../features/plugins/pages/plugins.page";
+import { ObservabilityPage } from "../../features/observability/pages/observability.page";
+import { ConfigSettingsPage } from "../../features/config/pages/config-settings.page";
+import { GovernancePage } from "../../features/governance/pages/governance.page";
+import { MCPAuthConfigPage } from "../../features/mcp-auth-config/pages/mcp-auth-config.page";
+import { MCPSettingsPage } from "../../features/mcp-settings/pages/mcp-settings.page";
+import { MCPToolGroupsPage } from "../../features/mcp-tool-groups/pages/mcp-tool-groups.page";
+import { ModelLimitsPage } from "../../features/model-limits/pages/model-limits.page";
 
 /**
  * Custom test fixtures type
  */
 type BifrostFixtures = {
-  closeDevProfiler: void
-  sidebarPage: SidebarPage
-  providersPage: ProvidersPage
-  virtualKeysPage: VirtualKeysPage
-  dashboardPage: DashboardPage
-  logsPage: LogsPage
-  mcpLogsPage: MCPLogsPage
-  routingRulesPage: RoutingRulesPage
-  mcpRegistryPage: MCPRegistryPage
-  pluginsPage: PluginsPage
-  observabilityPage: ObservabilityPage
-  configSettingsPage: ConfigSettingsPage
-  governancePage: GovernancePage
-  modelLimitsPage: ModelLimitsPage
-  mcpSettingsPage: MCPSettingsPage
-  mcpToolGroupsPage: MCPToolGroupsPage
-  mcpAuthConfigPage: MCPAuthConfigPage
-}
+	closeDevProfiler: void;
+	sidebarPage: SidebarPage;
+	providersPage: ProvidersPage;
+	virtualKeysPage: VirtualKeysPage;
+	dashboardPage: DashboardPage;
+	logsPage: LogsPage;
+	mcpLogsPage: MCPLogsPage;
+	routingRulesPage: RoutingRulesPage;
+	mcpRegistryPage: MCPRegistryPage;
+	pluginsPage: PluginsPage;
+	observabilityPage: ObservabilityPage;
+	configSettingsPage: ConfigSettingsPage;
+	governancePage: GovernancePage;
+	modelLimitsPage: ModelLimitsPage;
+	mcpSettingsPage: MCPSettingsPage;
+	mcpToolGroupsPage: MCPToolGroupsPage;
+	mcpAuthConfigPage: MCPAuthConfigPage;
+};
 
 /**
  * Extended test with Bifrost-specific fixtures
  */
 export const test = base.extend<BifrostFixtures>({
-  closeDevProfiler: [async ({ page }, use) => {
-    // Automatically dismiss the Dev Profiler overlay whenever it appears.
-    // Uses addLocatorHandler so it triggers before any test action if the profiler is visible.
-    await page.addLocatorHandler(
-      page.getByText('Dev Profiler', { exact: true }),
-      async () => {
-        await page.locator('button[title="Dismiss"]').click({ force: true })
-      }
-    )
-    await use()
-  }, { auto: true }],
+	closeDevProfiler: [
+		async ({ page }, use) => {
+			// Keep the development profiler from stealing focus or blocking assertions when
+			// tests reuse a manually started dev server that was not launched with
+			// BIFROST_DISABLE_PROFILER=1.
+			await page.addInitScript(() => {
+				window.localStorage.setItem("devProfiler.isVisible", "false");
+				window.localStorage.setItem("devProfiler.isExpanded", "false");
+			});
 
-  sidebarPage: async ({ page }, use) => {
-    await use(new SidebarPage(page))
-  },
+			await page.addLocatorHandler(
+				page.getByText("Dev Profiler", { exact: true }),
+				async () => {
+					await page.evaluate(() => {
+						window.localStorage.setItem("devProfiler.isVisible", "false");
+						window.localStorage.setItem("devProfiler.isExpanded", "false");
+					});
+					await page
+						.locator('button[title="Dismiss"]')
+						.click({ force: true, timeout: 1000 })
+						.catch(() => {});
+				},
+				{ noWaitAfter: true },
+			);
+			await use();
+		},
+		{ auto: true },
+	],
 
-  providersPage: async ({ page }, use) => {
-    await use(new ProvidersPage(page))
-  },
+	sidebarPage: async ({ page }, use) => {
+		await use(new SidebarPage(page));
+	},
 
-  virtualKeysPage: async ({ page }, use) => {
-    await use(new VirtualKeysPage(page))
-  },
+	providersPage: async ({ page }, use) => {
+		await use(new ProvidersPage(page));
+	},
 
-  dashboardPage: async ({ page }, use) => {
-    await use(new DashboardPage(page))
-  },
+	virtualKeysPage: async ({ page }, use) => {
+		await use(new VirtualKeysPage(page));
+	},
 
-  logsPage: async ({ page }, use) => {
-    await use(new LogsPage(page))
-  },
+	dashboardPage: async ({ page }, use) => {
+		await use(new DashboardPage(page));
+	},
 
-  mcpLogsPage: async ({ page }, use) => {
-    await use(new MCPLogsPage(page))
-  },
+	logsPage: async ({ page }, use) => {
+		await use(new LogsPage(page));
+	},
 
-  routingRulesPage: async ({ page }, use) => {
-    await use(new RoutingRulesPage(page))
-  },
+	mcpLogsPage: async ({ page }, use) => {
+		await use(new MCPLogsPage(page));
+	},
 
-  mcpRegistryPage: async ({ page }, use) => {
-    await use(new MCPRegistryPage(page))
-  },
+	routingRulesPage: async ({ page }, use) => {
+		await use(new RoutingRulesPage(page));
+	},
 
-  pluginsPage: async ({ page }, use) => {
-    await use(new PluginsPage(page))
-  },
+	mcpRegistryPage: async ({ page }, use) => {
+		await use(new MCPRegistryPage(page));
+	},
 
-  observabilityPage: async ({ page }, use) => {
-    await use(new ObservabilityPage(page))
-  },
+	pluginsPage: async ({ page }, use) => {
+		await use(new PluginsPage(page));
+	},
 
-  configSettingsPage: async ({ page }, use) => {
-    await use(new ConfigSettingsPage(page))
-  },
+	observabilityPage: async ({ page }, use) => {
+		await use(new ObservabilityPage(page));
+	},
 
-  governancePage: async ({ page }, use) => {
-    await use(new GovernancePage(page))
-  },
+	configSettingsPage: async ({ page }, use) => {
+		await use(new ConfigSettingsPage(page));
+	},
 
-  modelLimitsPage: async ({ page }, use) => {
-    await use(new ModelLimitsPage(page))
-  },
+	governancePage: async ({ page }, use) => {
+		await use(new GovernancePage(page));
+	},
 
-  mcpSettingsPage: async ({ page }, use) => {
-    await use(new MCPSettingsPage(page))
-  },
+	modelLimitsPage: async ({ page }, use) => {
+		await use(new ModelLimitsPage(page));
+	},
 
-  mcpToolGroupsPage: async ({ page }, use) => {
-    await use(new MCPToolGroupsPage(page))
-  },
+	mcpSettingsPage: async ({ page }, use) => {
+		await use(new MCPSettingsPage(page));
+	},
 
-  mcpAuthConfigPage: async ({ page }, use) => {
-    await use(new MCPAuthConfigPage(page))
-  },
-})
+	mcpToolGroupsPage: async ({ page }, use) => {
+		await use(new MCPToolGroupsPage(page));
+	},
 
-export { expect }
+	mcpAuthConfigPage: async ({ page }, use) => {
+		await use(new MCPAuthConfigPage(page));
+	},
+});
+
+export { expect };

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,12 +1,48 @@
-import { defineConfig, devices } from '@playwright/test'
+import { defineConfig, devices, type PlaywrightTestConfig } from '@playwright/test'
+import { existsSync } from 'fs'
+import { resolve } from 'path'
+
+const enterpriseFeaturesDir = resolve(__dirname, '../../../bifrost-enterprise/e2e/features')
+const includeEnterprise = process.env.BIFROST_E2E_INCLUDE_ENTERPRISE === '1' && existsSync(enterpriseFeaturesDir)
+
+const projects: NonNullable<PlaywrightTestConfig['projects']> = [
+  {
+    name: 'chromium',
+    testDir: './features',
+    use: { ...devices['Desktop Chrome'] },
+    testIgnore: ['**/config/**', '**/plugins/**', '**/virtual-keys/**', '**/mcp-registry/**', '**/model-limits/**', '**/providers/**'],
+  },
+  {
+    name: 'chromium-serial',
+    testDir: './features',
+    use: { ...devices['Desktop Chrome'] },
+    testMatch: ['**/plugins/**/*.spec.ts', '**/virtual-keys/**/*.spec.ts', '**/mcp-registry/**/*.spec.ts', '**/model-limits/**/*.spec.ts', '**/providers/**/*.spec.ts'],
+    fullyParallel: false,
+  },
+  {
+    name: 'chromium-config',
+    testDir: './features',
+    use: { ...devices['Desktop Chrome'] },
+    testMatch: ['**/config/**/*.spec.ts'],
+    dependencies: ['chromium', 'chromium-serial'],
+  },
+]
+
+if (includeEnterprise) {
+  projects.push({
+    name: 'chromium-enterprise',
+    testDir: enterpriseFeaturesDir,
+    use: { ...devices['Desktop Chrome'] },
+    testMatch: ['**/*.spec.ts'],
+  })
+}
 
 /**
  * Playwright configuration for Bifrost E2E tests
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
-  // Look for test files in the features directory
-  testDir: './features',
+  testDir: '.',
 
   // Run tests in files in parallel
   fullyParallel: true,
@@ -53,6 +89,9 @@ export default defineConfig({
 
     // Timeout for navigation
     navigationTimeout: 30000,
+
+    // Grant clipboard permissions so copy-to-clipboard tests work on localhost
+    permissions: ['clipboard-read', 'clipboard-write'],
   },
 
   // Global timeout for each test
@@ -63,35 +102,8 @@ export default defineConfig({
     timeout: 10000,
   },
 
-  // Configure projects: run all tests first, then config last (via dependency order)
-  projects: [
-    {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
-      testIgnore: ['**/config/**', '**/plugins/**', '**/virtual-keys/**', '**/mcp-registry/**', '**/model-limits/**', '**/providers/**'],
-    },
-    {
-      name: 'chromium-serial',
-      use: { ...devices['Desktop Chrome'] },
-      testMatch: ['**/plugins/**/*.spec.ts', '**/virtual-keys/**/*.spec.ts', '**/mcp-registry/**/*.spec.ts', '**/model-limits/**/*.spec.ts', '**/providers/**/*.spec.ts'],
-      fullyParallel: false,
-    },
-    {
-      name: 'chromium-config',
-      use: { ...devices['Desktop Chrome'] },
-      testMatch: ['**/config/**/*.spec.ts'],
-      dependencies: ['chromium', 'chromium-serial'],
-    },
-    // Uncomment for additional browser testing
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] },
-    // },
-    // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] },
-    // },
-  ],
+  // Configure projects: run all tests first, then config last (via dependency order).
+  projects,
 
   // Run local dev server before starting tests 
   // Set SKIP_WEB_SERVER=1 to skip auto-starting the dev server


### PR DESCRIPTION
## Summary

Improves the reliability of the Dev Profiler dismissal logic in the base E2E fixture and adds support for optionally including enterprise E2E feature tests when running the Playwright test suite, controlled via an environment variable. Also grants clipboard permissions to the browser context so copy-to-clipboard tests work correctly on localhost.

## Changes

- Replaced the Dev Profiler dismissal approach with an `addInitScript` call that sets `devProfiler.isVisible` and `devProfiler.isExpanded` to `false` in `localStorage` before the page loads, preventing the profiler from appearing at all rather than reactively dismissing it
- The `addLocatorHandler` fallback is retained but now also writes to `localStorage` and uses a short timeout with a silent catch on the dismiss button click to avoid flakiness
- Introduced a conditional `chromium-enterprise` Playwright project that is included when `BIFROST_E2E_INCLUDE_ENTERPRISE=1` is set, pointing to the `bifrost-enterprise/e2e/features` directory resolved relative to the repo
- Moved project definitions into a mutable `projects` array so the enterprise project can be pushed conditionally before being passed to `defineConfig`
- Added explicit `testDir` to each project definition (pointing to `./features`) to support the top-level `testDir` being set to `'.'`, which allows the enterprise test directory outside the current tree to be resolved correctly
- Added `clipboard-read` and `clipboard-write` browser permissions to the shared `use` context so clipboard-related assertions pass on localhost

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs
- [x] Tests

## How to test

Run the standard E2E suite to confirm existing behaviour is unchanged:

```sh
cd tests/e2e
pnpm test
```

Run with enterprise features included (requires `bifrost-enterprise` checked out at the expected relative path):

```sh
BIFROST_E2E_INCLUDE_ENTERPRISE=1 pnpm test
```

Confirm the `chromium-enterprise` project appears in the Playwright project list and its tests are executed. When the directory does not exist or the env var is unset, the project should not appear.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. The clipboard permissions granted are scoped to the browser context used during testing only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable