### PR TITLE
feat: add Bedrock Mantle inference engine support for `gpt-oss` models via OpenAI-compatible SSE endpoint

### DIFF
--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -28,17 +28,20 @@ import (
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
 )
 
 // BedrockProvider implements the Provider interface for AWS Bedrock.
 type BedrockProvider struct {
-	logger               schemas.Logger                // Logger for provider operations
-	client               *http.Client                  // HTTP client for unary API requests (Client.Timeout bounds overall response)
-	streamingClient      *http.Client                  // HTTP client for streaming API requests (no Timeout; idle governed by NewIdleTimeoutReader)
-	networkConfig        schemas.NetworkConfig         // Network configuration including extra headers
-	customProviderConfig *schemas.CustomProviderConfig // Custom provider config
-	sendBackRawRequest   bool                          // Whether to include raw request in BifrostResponse
-	sendBackRawResponse  bool                          // Whether to include raw response in BifrostResponse
+	logger                schemas.Logger                // Logger for provider operations
+	client                *http.Client                  // HTTP client for unary API requests (Client.Timeout bounds overall response)
+	streamingClient       *http.Client                  // HTTP client for streaming API requests (no Timeout; idle governed by NewIdleTimeoutReader)
+	mantleClient          *fasthttp.Client              // fasthttp client for Bedrock Mantle (OpenAI-compatible) requests
+	mantleStreamingClient *fasthttp.Client              // fasthttp streaming client for Bedrock Mantle streaming requests
+	networkConfig         schemas.NetworkConfig         // Network configuration including extra headers
+	customProviderConfig  *schemas.CustomProviderConfig // Custom provider config
+	sendBackRawRequest    bool                          // Whether to include raw request in BifrostResponse
+	sendBackRawResponse   bool                          // Whether to include raw response in BifrostResponse
 }
 
 // assumeRoleCredsCache caches *aws.CredentialsCache instances keyed by the
@@ -121,19 +124,36 @@ func NewBedrockProvider(config *schemas.ProviderConfig, logger schemas.Logger) (
 	client := &http.Client{Transport: transport, Timeout: requestTimeout}
 	streamingClient := providerUtils.BuildStreamingHTTPClient(client)
 
+	// fasthttp clients for Bedrock Mantle (OpenAI-compatible endpoint)
+	mantleFasthttpClient := &fasthttp.Client{
+		ReadTimeout:         requestTimeout,
+		WriteTimeout:        requestTimeout,
+		MaxConnsPerHost:     config.NetworkConfig.MaxConnsPerHost,
+		MaxIdleConnDuration: 30 * time.Second,
+		MaxConnWaitTimeout:  requestTimeout,
+		MaxConnDuration:     time.Second * time.Duration(schemas.DefaultMaxConnDurationInSeconds),
+		ConnPoolStrategy:    fasthttp.FIFO,
+	}
+	mantleFasthttpClient = providerUtils.ConfigureProxy(mantleFasthttpClient, config.ProxyConfig, logger)
+	mantleFasthttpClient = providerUtils.ConfigureDialer(mantleFasthttpClient)
+	mantleFasthttpClient = providerUtils.ConfigureTLS(mantleFasthttpClient, config.NetworkConfig, logger)
+	mantleStreamingFasthttpClient := providerUtils.BuildStreamingClient(mantleFasthttpClient)
+
 	// Pre-warm response pools
 	for i := 0; i < config.ConcurrencyAndBufferSize.Concurrency; i++ {
 		bedrockChatResponsePool.Put(&BedrockConverseResponse{})
 	}
 
 	return &BedrockProvider{
-		logger:               logger,
-		client:               client,
-		streamingClient:      streamingClient,
-		networkConfig:        config.NetworkConfig,
-		customProviderConfig: config.CustomProviderConfig,
-		sendBackRawRequest:   config.SendBackRawRequest,
-		sendBackRawResponse:  config.SendBackRawResponse,
+		logger:                logger,
+		client:                client,
+		streamingClient:       streamingClient,
+		mantleClient:          mantleFasthttpClient,
+		mantleStreamingClient: mantleStreamingFasthttpClient,
+		networkConfig:         config.NetworkConfig,
+		customProviderConfig:  config.CustomProviderConfig,
+		sendBackRawRequest:    config.SendBackRawRequest,
+		sendBackRawResponse:   config.SendBackRawResponse,
 	}, nil
 }
 
@@ -502,6 +522,30 @@ func (provider *BedrockProvider) makeStreamingRequest(ctx *schemas.BifrostContex
 // It is used in providers like Bedrock.
 // It sets required headers, calculates the request body hash, and signs the request
 // using the provided AWS credentials.
+// signAWSRequestFromKey is a convenience wrapper around signAWSRequest that reads
+// credentials from a BedrockKeyConfig. When cfg is nil (no explicit key configured),
+// all credential fields are zero-valued, causing signAWSRequest to fall back to the
+// default AWS credential chain (IAM role, env vars, instance profile, etc.).
+func signAWSRequestFromKey(
+	ctx *schemas.BifrostContext,
+	req *http.Request,
+	cfg *schemas.BedrockKeyConfig,
+	region, service string,
+) *schemas.BifrostError {
+	if cfg != nil {
+		return signAWSRequest(ctx, req,
+			cfg.AccessKey, cfg.SecretKey,
+			cfg.SessionToken, cfg.RoleARN,
+			cfg.ExternalID, cfg.RoleSessionName,
+			region, service)
+	}
+	// No config: pass zero EnvVar values so signAWSRequest uses the default chain.
+	return signAWSRequest(ctx, req,
+		schemas.EnvVar{}, schemas.EnvVar{},
+		nil, nil, nil, nil,
+		region, service)
+}
+
 // Returns a BifrostError if signing fails.
 func signAWSRequest(
 	ctx *schemas.BifrostContext,
@@ -1028,6 +1072,10 @@ func (provider *BedrockProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 		return nil, err
 	}
 
+	if isMantleModel(request.Model) {
+		return provider.chatCompletionViaMantle(ctx, key, request)
+	}
+
 	// Use centralized Bedrock converter
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
@@ -1103,6 +1151,11 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 	if err := providerUtils.CheckOperationAllowed(schemas.Bedrock, provider.customProviderConfig, schemas.ChatCompletionStreamRequest); err != nil {
 		return nil, err
 	}
+
+	if isMantleModel(request.Model) {
+		return provider.chatCompletionStreamViaMantle(ctx, postHookRunner, postHookSpanFinalizer, key, request)
+	}
+
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
 		request,
@@ -1407,6 +1460,10 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 		return nil, err
 	}
 
+	if isMantleModel(request.Model) {
+		return provider.responsesViaMantle(ctx, key, request)
+	}
+
 	// Use centralized Bedrock converter
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
 		ctx,
@@ -1473,6 +1530,10 @@ func (provider *BedrockProvider) Responses(ctx *schemas.BifrostContext, key sche
 func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.Bedrock, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
 		return nil, err
+	}
+
+	if isMantleModel(request.Model) {
+		return provider.responsesStreamViaMantle(ctx, postHookRunner, postHookSpanFinalizer, key, request)
 	}
 
 	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(

--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -1,0 +1,254 @@
+package bedrock
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"maps"
+	"net/http"
+	"strings"
+
+	openai "github.com/maximhq/bifrost/core/providers/openai"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// isMantleModel reports whether a model should be routed via the Bedrock Mantle endpoint.
+// Accepts "gpt-oss-120b", "openai.gpt-oss-120b", or region-prefixed variants.
+func isMantleModel(model string) bool {
+	return strings.Contains(model, "gpt-oss")
+}
+
+// mantleURL builds the Bedrock Mantle endpoint URL for the given region and API path.
+func mantleURL(region, path string) string {
+	return fmt.Sprintf("https://bedrock-mantle.%s.api.aws/v1/%s", region, path)
+}
+
+// mantleSigV4Headers computes SigV4 auth headers for a mantle request by signing a dummy
+// net/http.Request. jsonData must be the exact bytes that will be sent. accept must match
+// the Accept header the actual request will send, since SigV4 signs all request headers.
+func (provider *BedrockProvider) mantleSigV4Headers(
+	ctx *schemas.BifrostContext,
+	jsonData []byte,
+	requestURL, accept string,
+	key schemas.Key,
+	region string,
+) (map[string]string, *schemas.BifrostError) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, bytes.NewReader(jsonData))
+	if err != nil {
+		return nil, providerUtils.NewBifrostOperationError("failed to create signing request", err)
+	}
+	req.Header.Set("Accept", accept)
+	if bifrostErr := signAWSRequestFromKey(ctx, req, key.BedrockKeyConfig, region, bedrockMantleSigningService); bifrostErr != nil {
+		return nil, bifrostErr
+	}
+	headers := map[string]string{
+		"Authorization":        req.Header.Get("Authorization"),
+		"X-Amz-Date":           req.Header.Get("X-Amz-Date"),
+		"x-amz-content-sha256": req.Header.Get("x-amz-content-sha256"),
+		"Accept":               accept,
+	}
+	if token := req.Header.Get("X-Amz-Security-Token"); token != "" {
+		headers["X-Amz-Security-Token"] = token
+	}
+	return headers, nil
+}
+
+// chatCompletionViaMantle handles non-streaming chat completions for mantle (gpt-oss) models.
+func (provider *BedrockProvider) chatCompletionViaMantle(
+	ctx *schemas.BifrostContext,
+	key schemas.Key,
+	request *schemas.BifrostChatRequest,
+) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
+	region := resolveBedrockRegion(key, request.Model)
+	url := mantleURL(region, "chat/completions")
+
+	// Build extraHeaders: always start with network-config headers, then overlay SigV4 if needed.
+	// Allocate explicitly so maps.Copy never writes into a nil map.
+	extraHeaders := make(map[string]string, len(provider.networkConfig.ExtraHeaders))
+	maps.Copy(extraHeaders, provider.networkConfig.ExtraHeaders)
+	if key.Value.GetValue() == "" {
+		// SigV4: pre-build body for signing. HandleOpenAIChatCompletionRequest rebuilds the
+		// same bytes (deterministic marshaling), so the signature stays valid.
+		jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(ctx, request, func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return openai.ToOpenAIChatRequest(ctx, request), nil
+		})
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+		sigHeaders, bifrostErr := provider.mantleSigV4Headers(ctx, jsonData, url, "application/json", key, region)
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+		maps.Copy(extraHeaders, sigHeaders)
+	}
+
+	return openai.HandleOpenAIChatCompletionRequest(
+		ctx,
+		provider.mantleClient,
+		url,
+		request,
+		key,
+		extraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
+		nil, nil,
+		provider.logger,
+	)
+}
+
+// chatCompletionStreamViaMantle handles streaming chat completions for mantle (gpt-oss) models.
+func (provider *BedrockProvider) chatCompletionStreamViaMantle(
+	ctx *schemas.BifrostContext,
+	postHookRunner schemas.PostHookRunner,
+	postHookSpanFinalizer func(context.Context),
+	key schemas.Key,
+	request *schemas.BifrostChatRequest,
+) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	region := resolveBedrockRegion(key, request.Model)
+	url := mantleURL(region, "chat/completions")
+
+	// Bearer: identical to Groq / any OpenAI-compatible provider.
+	if key.Value.GetValue() != "" {
+		authHeader := map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
+		return openai.HandleOpenAIChatCompletionStreaming(
+			ctx, provider.mantleStreamingClient, url, request,
+			authHeader, provider.networkConfig.ExtraHeaders,
+			provider.networkConfig.StreamIdleTimeoutInSeconds,
+			providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+			provider.GetProviderKey(), postHookRunner,
+			nil, nil, nil, nil, nil,
+			provider.logger, postHookSpanFinalizer,
+		)
+	}
+
+	// SigV4: pre-build body to sign, then pass it via customRequestConverter so the handler
+	// sends the exact same bytes we signed.
+	openaiReq := openai.ToOpenAIChatRequest(ctx, request)
+	openaiReq.Stream = schemas.Ptr(true)
+	openaiReq.StreamOptions = &schemas.ChatStreamOptions{IncludeUsage: schemas.Ptr(true)}
+
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(ctx, request, func() (providerUtils.RequestBodyWithExtraParams, error) {
+		return openaiReq, nil
+	})
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+	authHeader, bifrostErr := provider.mantleSigV4Headers(ctx, jsonData, url, "text/event-stream", key, region)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	return openai.HandleOpenAIChatCompletionStreaming(
+		ctx, provider.mantleStreamingClient, url, request,
+		authHeader, provider.networkConfig.ExtraHeaders,
+		provider.networkConfig.StreamIdleTimeoutInSeconds,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(), postHookRunner,
+		func(_ *schemas.BifrostChatRequest) (providerUtils.RequestBodyWithExtraParams, error) {
+			return openaiReq, nil
+		},
+		nil, nil, nil, nil,
+		provider.logger, postHookSpanFinalizer,
+	)
+}
+
+// responsesViaMantle handles non-streaming Responses API requests for mantle (gpt-oss) models.
+func (provider *BedrockProvider) responsesViaMantle(
+	ctx *schemas.BifrostContext,
+	key schemas.Key,
+	request *schemas.BifrostResponsesRequest,
+) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+	region := resolveBedrockRegion(key, request.Model)
+	url := mantleURL(region, "responses")
+
+	extraHeaders := make(map[string]string, len(provider.networkConfig.ExtraHeaders))
+	maps.Copy(extraHeaders, provider.networkConfig.ExtraHeaders)
+	if key.Value.GetValue() == "" {
+		jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(ctx, request, func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return openai.ToOpenAIResponsesRequest(request), nil
+		})
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+		sigHeaders, bifrostErr := provider.mantleSigV4Headers(ctx, jsonData, url, "application/json", key, region)
+		if bifrostErr != nil {
+			return nil, bifrostErr
+		}
+		maps.Copy(extraHeaders, sigHeaders)
+	}
+
+	return openai.HandleOpenAIResponsesRequest(
+		ctx,
+		provider.mantleClient,
+		url,
+		request,
+		key,
+		extraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
+		nil, nil,
+		provider.logger,
+	)
+}
+
+// responsesStreamViaMantle handles streaming Responses API requests for mantle (gpt-oss) models.
+func (provider *BedrockProvider) responsesStreamViaMantle(
+	ctx *schemas.BifrostContext,
+	postHookRunner schemas.PostHookRunner,
+	postHookSpanFinalizer func(context.Context),
+	key schemas.Key,
+	request *schemas.BifrostResponsesRequest,
+) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	region := resolveBedrockRegion(key, request.Model)
+	url := mantleURL(region, "responses")
+
+	// Bearer: identical to Groq / any OpenAI-compatible provider.
+	if key.Value.GetValue() != "" {
+		authHeader := map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
+		return openai.HandleOpenAIResponsesStreaming(
+			ctx, provider.mantleStreamingClient, url, request,
+			authHeader, provider.networkConfig.ExtraHeaders,
+			provider.networkConfig.StreamIdleTimeoutInSeconds,
+			providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+			providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+			provider.GetProviderKey(), postHookRunner,
+			nil, nil, nil, nil,
+			provider.logger, postHookSpanFinalizer,
+		)
+	}
+
+	// SigV4: pre-build body to sign.
+	openaiReq := openai.ToOpenAIResponsesRequest(request)
+	openaiReq.Stream = schemas.Ptr(true)
+
+	jsonData, bifrostErr := providerUtils.CheckContextAndGetRequestBody(ctx, request, func() (providerUtils.RequestBodyWithExtraParams, error) {
+		return openaiReq, nil
+	})
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+	authHeader, bifrostErr := provider.mantleSigV4Headers(ctx, jsonData, url, "text/event-stream", key, region)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+
+	return openai.HandleOpenAIResponsesStreaming(
+		ctx, provider.mantleStreamingClient, url, request,
+		authHeader, provider.networkConfig.ExtraHeaders,
+		provider.networkConfig.StreamIdleTimeoutInSeconds,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(), postHookRunner,
+		nil, nil,
+		func(_ *openai.OpenAIResponsesRequest) *openai.OpenAIResponsesRequest {
+			return openaiReq
+		},
+		nil,
+		provider.logger, postHookSpanFinalizer,
+	)
+}

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -11,10 +11,14 @@ import (
 // DefaultBedrockRegion is the default region for Bedrock
 const DefaultBedrockRegion = "us-east-1"
 
-// bedrockSigningService is the SigV4 service name used when signing all Bedrock
-// API requests. AWS requires "bedrock" as the credential scope service for both
-// bedrock-runtime and bedrock-agent-runtime endpoints.
+// bedrockSigningService is the SigV4 service name for the standard Bedrock endpoints
+// (bedrock-runtime, bedrock-agent-runtime).
 const bedrockSigningService = "bedrock"
+
+// bedrockMantleSigningService is the SigV4 service name for the Bedrock Mantle endpoint
+// (bedrock-mantle.{region}.api.aws). AWS requires a distinct service name in the
+// credential scope; using "bedrock" will cause signature verification failures.
+const bedrockMantleSigningService = "bedrock-mantle"
 
 const MinimumReasoningMaxTokens = 1
 const DefaultCompletionMaxTokens = 4096 // Only used for relative reasoning max token calculation - not passed in body by default


### PR DESCRIPTION
## Summary

Adds support for routing `gpt-oss` model requests through the AWS Bedrock Mantle inference endpoint (`bedrock-mantle.{region}.api.aws`). These are OpenAI-compatible models hosted on Bedrock that require a different endpoint and request/response format than standard Bedrock models.

## Changes

- Added `isMantleModel` and `mantleModelID` helpers to detect and transform `gpt-oss` model identifiers for the Mantle endpoint.
- Added `signAWSRequestFromKey` as a convenience wrapper around `signAWSRequest` that reads credentials from a `BedrockKeyConfig`, falling back to the default AWS credential chain when no config is provided.
- Added `completeMantleRequest` and `makeMantleStreamingRequest` to handle non-streaming and SSE streaming HTTP requests to the Mantle endpoint. Both support Bearer token auth (via `key.Value`) or SigV4 signing as a fallback.
- Added `chatCompletionViaMantle`, `chatCompletionStreamViaMantle`, `responsesViaMantle`, and `responsesStreamViaMantle` to convert Bifrost requests into OpenAI-compatible payloads and route them to the Mantle endpoint.
- Injected Mantle routing checks at the top of `ChatCompletion`, `ChatCompletionStream`, `Responses`, and `ResponsesStream` so that any `gpt-oss` model is transparently redirected before the standard Bedrock path executes.
- Mantle streaming uses SSE (`text/event-stream`) rather than AWS EventStream binary framing, with full support for idle timeouts, cancellation, usage accumulation, and terminal chunk emission.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/...
```

To validate end-to-end, configure a Bedrock key and send a request with a `gpt-oss` model (e.g. `gpt-oss-mini`). Verify the request is routed to `bedrock-mantle.{region}.api.aws/v1/chat/completions` and that both streaming and non-streaming responses are returned correctly.

For SigV4 auth, omit `key.Value` and ensure `BedrockKeyConfig` credentials or the default AWS credential chain (env vars, IAM role, instance profile) are available.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

- SigV4 request signing is applied to Mantle requests when no Bearer token is present, using the same credential resolution path as standard Bedrock requests.
- When `BedrockKeyConfig` is `nil`, signing falls back to the default AWS credential chain, which may pick up ambient credentials (env vars, instance profile). This is intentional and consistent with existing Bedrock behavior.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable