### PR TITLE
feat: rotate keys on 401/402/403 and return `502 upstream_credentials_exhausted` when all keys are permanently dead

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5,6 +5,7 @@ package bifrost
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -5247,20 +5248,32 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 	}
 }
 
+// errAllKeysDead is returned by a keyProvider closure when every key in the configured pool
+// has been marked permanently dead via deadKeyIDs (or, for a fixed/sticky key, when that key
+// is itself dead). executeRequestWithRetries detects this via errors.Is and surfaces it as a
+// synthetic 502 upstream_credentials_exhausted, rather than bubbling the raw 401/403 which
+// would falsely suggest the *caller's* Bifrost API key is bad. Any other error from the
+// keyProvider (custom selector failure, etc.) is propagated unchanged.
+var errAllKeysDead = errors.New("all configured keys returned permanent per-key errors (401/402/403)")
+
 // executeRequestWithRetries is a generic function that handles common request processing logic.
 // It consolidates retry logic, backoff calculation, error handling, and key rotation.
 // It is not a bifrost method because interface methods in go cannot be generic.
 //
-// keyProvider, when non-nil, is called on the first attempt and again whenever a rate-limit error
-// triggers a key rotation. It receives the set of key IDs already used in the current rotation
-// cycle so it can exclude them; when the pool is exhausted the provider resets the set and starts
-// a fresh weighted round. Network errors (5xx) reuse the same key since they are transient server
-// issues rather than per-key capacity problems.
+// keyProvider, when non-nil, is called on the first attempt and again whenever a per-key error
+// triggers a rotation. It receives two sets of key IDs to exclude:
+//   - usedKeyIDs: keys that hit a transient per-key failure (429). When the pool is exhausted of
+//     non-dead keys, the provider resets this set and starts a fresh weighted round — a previously
+//     rate-limited key may have free quota by then.
+//   - deadKeyIDs: keys that hit a permanent per-key failure (401/402/403). These are NEVER reset
+//     within a single request — a bad credential will not become valid by waiting.
+//
+// Network/5xx errors reuse the same key since they are transient server issues, not per-key.
 func executeRequestWithRetries[T any](
 	ctx *schemas.BifrostContext,
 	config *schemas.ProviderConfig,
 	requestHandler func(key schemas.Key) (T, *schemas.BifrostError),
-	keyProvider func(usedKeyIDs map[string]bool) (schemas.Key, error),
+	keyProvider func(usedKeyIDs, deadKeyIDs map[string]bool) (schemas.Key, error),
 	requestType schemas.RequestType,
 	providerKey schemas.ModelProvider,
 	model string,
@@ -5273,7 +5286,17 @@ func executeRequestWithRetries[T any](
 
 	var currentKey schemas.Key
 	var usedKeyIDs map[string]bool
-	lastWasRateLimit := false
+	var deadKeyIDs map[string]bool
+	lastWasPerKeyFailure := false
+	// True iff the previous attempt failed with a *permanent* per-key error (401/402/403).
+	// Used to suppress backoff on the next attempt only when we genuinely rotated to a
+	// different credential — a dead key gains nothing from waiting. 429 rotations stay
+	// subject to backoff because account-level rate limits share quota across keys.
+	lastWasPermanentKeyFailure := false
+	// ID of the key used on the previous attempt. Compared against the freshly selected
+	// key to confirm an actual credential swap happened before suppressing backoff —
+	// after a 429 pool reset, the selector can legitimately re-pick the same key.
+	previousKeyID := ""
 	// Index in BifrostContextKeyAttemptTrail of an attempt that hit a rate limit and is waiting
 	// to learn whether the *next* key selection actually picks a different key. -1 = no pending.
 	pendingRotationAttemptIdx := -1
@@ -5287,9 +5310,10 @@ func executeRequestWithRetries[T any](
 			ctx.SetValue(schemas.BifrostContextKeyAttemptTrail, []schemas.KeyAttemptRecord{})
 		}
 
-		// Select / rotate key: always on attempt 0, and again when the previous failure was a
-		// rate-limit (different key may have remaining capacity). Network errors keep the same key.
-		if keyProvider != nil && (attempts == 0 || lastWasRateLimit) {
+		// Select / rotate key: always on attempt 0, and again when the previous failure was
+		// tied to the key itself (rate-limit, auth, billing, or permission error). Transient
+		// server errors (5xx, network) keep the same key since they're not per-key problems.
+		if keyProvider != nil && (attempts == 0 || lastWasPerKeyFailure) {
 			if usedKeyIDs == nil {
 				usedKeyIDs = make(map[string]bool)
 			}
@@ -5310,7 +5334,7 @@ func executeRequestWithRetries[T any](
 				}
 			}
 
-			selectedKey, err := keyProvider(usedKeyIDs)
+			selectedKey, err := keyProvider(usedKeyIDs, deadKeyIDs)
 
 			if keyTracer != nil {
 				if err != nil {
@@ -5328,6 +5352,30 @@ func executeRequestWithRetries[T any](
 
 			if err != nil {
 				var zero T
+				// Clear any selected_key_* set by a *previous* attempt: this early return
+				// skips the terminal cleanup at the end of the function, and the invariant
+				// is that selected_key_id / selected_key_name are populated only on a
+				// successful response. Use attempt_trail for failure attribution.
+				ctx.SetValue(schemas.BifrostContextKeySelectedKeyID, "")
+				ctx.SetValue(schemas.BifrostContextKeySelectedKeyName, "")
+				// Only collapse into 502 upstream_credentials_exhausted when keyProvider
+				// explicitly signals "every key is dead" via the errAllKeysDead sentinel.
+				// Any other error (custom selector failure, etc.) propagates unchanged so
+				// that a stray selector error doesn't get misreported as exhausted just
+				// because *some* keys happened to be dead.
+				if errors.Is(err, errAllKeysDead) {
+					statusCode := 502
+					errType := "upstream_credentials_exhausted"
+					return zero, &schemas.BifrostError{
+						IsBifrostError: false,
+						StatusCode:     &statusCode,
+						Type:           &errType,
+						Error: &schemas.ErrorField{
+							Type:    &errType,
+							Message: err.Error(),
+						},
+					}
+				}
 				return zero, newBifrostErrorFromMsg(err.Error())
 			}
 			currentKey = selectedKey
@@ -5372,11 +5420,22 @@ func executeRequestWithRetries[T any](
 			}
 			logger.Debug("retrying request (attempt %d/%d) for model %s: %s", attempts, config.NetworkConfig.MaxRetries, model, retryMsg)
 
-			// Calculate and apply backoff
-			backoff := calculateBackoff(attempts-1, config)
-			logger.Debug("sleeping for %s before retry", backoff)
-
-			time.Sleep(backoff)
+			// Skip backoff only when (a) we genuinely rotated to a different credential AND
+			// (b) the previous failure was a *permanent* per-key error (401/402/403) where
+			// waiting offers nothing against a dead key.
+			//
+			// Backoff is preserved in every other case:
+			//   - 5xx / network retries (same key) — transient upstream issue, classic backoff.
+			//   - 429 rotations — account-level rate limits share quota across keys, so the
+			//     new key may not have fresh capacity; the backoff lets the quota window slide.
+			//   - 429 pool reset that re-picks the same key — no rotation actually happened.
+			//   - keyless providers — currentKey.ID stays empty, so keyChanged is false.
+			keyChanged := keyProvider != nil && currentKey.ID != previousKeyID
+			if !(lastWasPermanentKeyFailure && keyChanged) {
+				backoff := calculateBackoff(attempts-1, config)
+				logger.Debug("sleeping for %s before retry", backoff)
+				time.Sleep(backoff)
+			}
 		}
 
 		logger.Debug("attempting %s request for provider %s", requestType, providerKey)
@@ -5566,9 +5625,14 @@ func executeRequestWithRetries[T any](
 			break
 		}
 
-		// Check if we should retry based on status code or error message
+		// Classify the failure to decide whether to retry and whether to rotate the key.
+		//
+		// isPerKeyFailure: failure is bound to this specific key/account (401/402/403/429, or a
+		//   rate-limit error surfaced via message text instead of a 429 status). The same key
+		//   won't help — try a different one.
+		// retryable 5xx / network errors: transient server issues — retry with the same key.
 		shouldRetry := false
-		isRateLimit := (bifrostError.StatusCode != nil && *bifrostError.StatusCode == 429) ||
+		isPerKeyFailure := (bifrostError.StatusCode != nil && perKeyFailureStatusCodes[*bifrostError.StatusCode]) ||
 			(bifrostError.Error != nil &&
 				(IsRateLimitErrorMessage(bifrostError.Error.Message) ||
 					(bifrostError.Error.Type != nil && IsRateLimitErrorMessage(*bifrostError.Error.Type)) ||
@@ -5581,19 +5645,28 @@ func executeRequestWithRetries[T any](
 				bifrostError.Error.Message == schemas.ErrProviderNetworkError) {
 			shouldRetry = true
 			logger.Debug("detected request HTTP/network error, will retry: %s", errMessage)
-		} else if (bifrostError.StatusCode != nil && retryableStatusCodes[*bifrostError.StatusCode]) || isRateLimit {
+		} else if (bifrostError.StatusCode != nil && transientServerStatusCodes[*bifrostError.StatusCode]) || isPerKeyFailure {
 			shouldRetry = true
 			logger.Debug("encountered error that should be retried: %s", errMessage)
 		}
 
-		// Fill FailReason on any failed attempt (retryable or terminal).
-		// Use the provider error type when present; fall back to "unknown".
+		// Fill FailReason on any failed attempt (retryable or terminal). The trail field
+		// answers "why was this key skipped?", so for rotation-triggering status codes the
+		// status itself is the truthful answer — provider Type labels can be misleading
+		// (e.g. OpenAI returns Type="invalid_request_error" for 401 invalid_api_key, which
+		// describes the request, not the rotation reason). Fall back to provider Type for
+		// non-rotation failures, then "unknown".
 		if trail, ok := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord); ok && len(trail) > 0 {
 			reason := "unknown"
-			if bifrostError.Error != nil && bifrostError.Error.Type != nil && *bifrostError.Error.Type != "" {
-				reason = *bifrostError.Error.Type
-			} else if isRateLimit {
+			switch {
+			case bifrostError.StatusCode != nil && *bifrostError.StatusCode == 429:
 				reason = "rate_limit_error"
+			case bifrostError.StatusCode != nil && (*bifrostError.StatusCode == 401 || *bifrostError.StatusCode == 403):
+				reason = "authentication_error"
+			case bifrostError.StatusCode != nil && *bifrostError.StatusCode == 402:
+				reason = "billing_error"
+			case bifrostError.Error != nil && bifrostError.Error.Type != nil && *bifrostError.Error.Type != "":
+				reason = *bifrostError.Error.Type
 			}
 			trail[len(trail)-1].FailReason = &reason
 			ctx.SetValue(schemas.BifrostContextKeyAttemptTrail, trail)
@@ -5603,22 +5676,40 @@ func executeRequestWithRetries[T any](
 			break
 		}
 
-		// Mark current key as used so the next selection excludes it (rate-limit only).
-		// Network errors keep the same key — they are transient server issues, not per-key.
-		if isRateLimit && keyProvider != nil {
-			if usedKeyIDs == nil {
-				usedKeyIDs = make(map[string]bool)
+		// Track key state so the next keyProvider call excludes this key. Permanent
+		// per-key failures (401/402/403) go into deadKeyIDs which is never reset within
+		// this request — a bad credential won't become valid by waiting. Transient
+		// per-key failures (429) go into usedKeyIDs which the keyProvider may reset
+		// once all keys are exhausted, since a rate-limited key may have free quota by
+		// the time we come back to it.
+		isPermanentKeyFailure := false
+		if isPerKeyFailure && keyProvider != nil {
+			isPermanentKeyFailure = bifrostError.StatusCode != nil &&
+				(*bifrostError.StatusCode == 401 || *bifrostError.StatusCode == 402 || *bifrostError.StatusCode == 403)
+			if isPermanentKeyFailure {
+				if deadKeyIDs == nil {
+					deadKeyIDs = make(map[string]bool)
+				}
+				deadKeyIDs[currentKey.ID] = true
+			} else {
+				if usedKeyIDs == nil {
+					usedKeyIDs = make(map[string]bool)
+				}
+				usedKeyIDs[currentKey.ID] = true
 			}
-			usedKeyIDs[currentKey.ID] = true
 		}
-		lastWasRateLimit = isRateLimit
+		lastWasPerKeyFailure = isPerKeyFailure
+		lastWasPermanentKeyFailure = isPermanentKeyFailure
+		// Remember the key used on this attempt so the next iteration's backoff check
+		// can detect whether key selection genuinely picked a different credential.
+		previousKeyID = currentKey.ID
 
 		// Record the just-failed attempt as a *candidate* for rotation. The next iteration will
 		// confirm it (and set TriggeredRotation=true) only if key selection actually picks a
 		// different key — this avoids false positives for fixed-key providers whose keyProvider
 		// is non-nil but returns the same key. Network-error retries reuse the same key, and
 		// terminal attempts (attempts == MaxRetries) won't run another iteration.
-		if isRateLimit && keyProvider != nil && attempts < config.NetworkConfig.MaxRetries {
+		if lastWasPerKeyFailure && keyProvider != nil && attempts < config.NetworkConfig.MaxRetries {
 			if trail, ok := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord); ok && len(trail) > 0 {
 				pendingRotationAttemptIdx = len(trail) - 1
 			}
@@ -5757,7 +5848,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		// keyProvider is passed to executeRequestWithRetries to manage key selection and rotation.
 		// It is nil when no key is required (e.g. providerRequiresKey=false) or for multi-key
 		// batch/file/container operations that manage their own key lists.
-		var keyProvider func(usedKeyIDs map[string]bool) (schemas.Key, error)
+		var keyProvider func(usedKeyIDs, deadKeyIDs map[string]bool) (schemas.Key, error)
 
 		if providerRequiresKey(config.CustomProviderConfig) {
 			// ListModels needs all enabled/supported keys so providers can aggregate
@@ -5839,9 +5930,15 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 						// SkipKeySelection path — keyProvider stays nil, zero Key is used.
 					} else if !canRotate {
 						// Fixed key (explicit ID/name, session stickiness): always
-						// return the same key regardless of usedKeyIDs.
+						// return the same key — *unless* it has been marked permanently
+						// dead this request, in which case surface errAllKeysDead so the
+						// caller emits 502 upstream_credentials_exhausted instead of
+						// burning the remaining retries on the same bad credential.
 						fixedKey := supportedKeys[0]
-						keyProvider = func(_ map[string]bool) (schemas.Key, error) {
+						keyProvider = func(_, deadKeyIDs map[string]bool) (schemas.Key, error) {
+							if deadKeyIDs[fixedKey.ID] {
+								return schemas.Key{}, errAllKeysDead
+							}
 							return fixedKey, nil
 						}
 					} else {
@@ -5850,19 +5947,31 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 						pool := supportedKeys
 						provKey := provider.GetProviderKey()
 						mdl := model
-						keyProvider = func(usedKeyIDs map[string]bool) (schemas.Key, error) {
+						keyProvider = func(usedKeyIDs, deadKeyIDs map[string]bool) (schemas.Key, error) {
 							available := make([]schemas.Key, 0, len(pool))
 							for _, k := range pool {
-								if !usedKeyIDs[k.ID] {
-									available = append(available, k)
+								if deadKeyIDs[k.ID] || usedKeyIDs[k.ID] {
+									continue
 								}
+								available = append(available, k)
 							}
 							if len(available) == 0 {
-								// All keys exhausted — start a fresh weighted round.
+								// No non-dead keys remain in this cycle. If every key has been
+								// marked permanently dead, give up — retrying won't help.
+								// Otherwise reset usedKeyIDs and start a fresh weighted round
+								// across the still-live (non-dead) keys; a previously
+								// rate-limited key may have free quota by now.
+								for _, k := range pool {
+									if !deadKeyIDs[k.ID] {
+										available = append(available, k)
+									}
+								}
+								if len(available) == 0 {
+									return schemas.Key{}, fmt.Errorf("%w: provider %s", errAllKeysDead, provKey)
+								}
 								for id := range usedKeyIDs {
 									delete(usedKeyIDs, id)
 								}
-								available = pool
 							}
 							return bifrost.keySelector(req.Context, available, provKey, mdl)
 						}

--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5,6 +5,7 @@ package bifrost
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -5216,20 +5217,32 @@ func (bifrost *Bifrost) tryStreamRequest(ctx *schemas.BifrostContext, req *schem
 	}
 }
 
+// errAllKeysDead is returned by a keyProvider closure when every key in the configured pool
+// has been marked permanently dead via deadKeyIDs (or, for a fixed/sticky key, when that key
+// is itself dead). executeRequestWithRetries detects this via errors.Is and surfaces it as a
+// synthetic 502 upstream_credentials_exhausted, rather than bubbling the raw 401/403 which
+// would falsely suggest the *caller's* Bifrost API key is bad. Any other error from the
+// keyProvider (custom selector failure, etc.) is propagated unchanged.
+var errAllKeysDead = errors.New("all configured keys returned permanent per-key errors (401/402/403)")
+
 // executeRequestWithRetries is a generic function that handles common request processing logic.
 // It consolidates retry logic, backoff calculation, error handling, and key rotation.
 // It is not a bifrost method because interface methods in go cannot be generic.
 //
-// keyProvider, when non-nil, is called on the first attempt and again whenever a rate-limit error
-// triggers a key rotation. It receives the set of key IDs already used in the current rotation
-// cycle so it can exclude them; when the pool is exhausted the provider resets the set and starts
-// a fresh weighted round. Network errors (5xx) reuse the same key since they are transient server
-// issues rather than per-key capacity problems.
+// keyProvider, when non-nil, is called on the first attempt and again whenever a per-key error
+// triggers a rotation. It receives two sets of key IDs to exclude:
+//   - usedKeyIDs: keys that hit a transient per-key failure (429). When the pool is exhausted of
+//     non-dead keys, the provider resets this set and starts a fresh weighted round — a previously
+//     rate-limited key may have free quota by then.
+//   - deadKeyIDs: keys that hit a permanent per-key failure (401/402/403). These are NEVER reset
+//     within a single request — a bad credential will not become valid by waiting.
+//
+// Network/5xx errors reuse the same key since they are transient server issues, not per-key.
 func executeRequestWithRetries[T any](
 	ctx *schemas.BifrostContext,
 	config *schemas.ProviderConfig,
 	requestHandler func(key schemas.Key) (T, *schemas.BifrostError),
-	keyProvider func(usedKeyIDs map[string]bool) (schemas.Key, error),
+	keyProvider func(usedKeyIDs, deadKeyIDs map[string]bool) (schemas.Key, error),
 	requestType schemas.RequestType,
 	providerKey schemas.ModelProvider,
 	model string,
@@ -5242,7 +5255,17 @@ func executeRequestWithRetries[T any](
 
 	var currentKey schemas.Key
 	var usedKeyIDs map[string]bool
-	lastWasRateLimit := false
+	var deadKeyIDs map[string]bool
+	lastWasPerKeyFailure := false
+	// True iff the previous attempt failed with a *permanent* per-key error (401/402/403).
+	// Used to suppress backoff on the next attempt only when we genuinely rotated to a
+	// different credential — a dead key gains nothing from waiting. 429 rotations stay
+	// subject to backoff because account-level rate limits share quota across keys.
+	lastWasPermanentKeyFailure := false
+	// ID of the key used on the previous attempt. Compared against the freshly selected
+	// key to confirm an actual credential swap happened before suppressing backoff —
+	// after a 429 pool reset, the selector can legitimately re-pick the same key.
+	previousKeyID := ""
 	// Index in BifrostContextKeyAttemptTrail of an attempt that hit a rate limit and is waiting
 	// to learn whether the *next* key selection actually picks a different key. -1 = no pending.
 	pendingRotationAttemptIdx := -1
@@ -5256,9 +5279,10 @@ func executeRequestWithRetries[T any](
 			ctx.SetValue(schemas.BifrostContextKeyAttemptTrail, []schemas.KeyAttemptRecord{})
 		}
 
-		// Select / rotate key: always on attempt 0, and again when the previous failure was a
-		// rate-limit (different key may have remaining capacity). Network errors keep the same key.
-		if keyProvider != nil && (attempts == 0 || lastWasRateLimit) {
+		// Select / rotate key: always on attempt 0, and again when the previous failure was
+		// tied to the key itself (rate-limit, auth, billing, or permission error). Transient
+		// server errors (5xx, network) keep the same key since they're not per-key problems.
+		if keyProvider != nil && (attempts == 0 || lastWasPerKeyFailure) {
 			if usedKeyIDs == nil {
 				usedKeyIDs = make(map[string]bool)
 			}
@@ -5278,7 +5302,7 @@ func executeRequestWithRetries[T any](
 				}
 			}
 
-			selectedKey, err := keyProvider(usedKeyIDs)
+			selectedKey, err := keyProvider(usedKeyIDs, deadKeyIDs)
 
 			if keyTracer != nil {
 				if err != nil {
@@ -5296,6 +5320,30 @@ func executeRequestWithRetries[T any](
 
 			if err != nil {
 				var zero T
+				// Clear any selected_key_* set by a *previous* attempt: this early return
+				// skips the terminal cleanup at the end of the function, and the invariant
+				// is that selected_key_id / selected_key_name are populated only on a
+				// successful response. Use attempt_trail for failure attribution.
+				ctx.SetValue(schemas.BifrostContextKeySelectedKeyID, "")
+				ctx.SetValue(schemas.BifrostContextKeySelectedKeyName, "")
+				// Only collapse into 502 upstream_credentials_exhausted when keyProvider
+				// explicitly signals "every key is dead" via the errAllKeysDead sentinel.
+				// Any other error (custom selector failure, etc.) propagates unchanged so
+				// that a stray selector error doesn't get misreported as exhausted just
+				// because *some* keys happened to be dead.
+				if errors.Is(err, errAllKeysDead) {
+					statusCode := 502
+					errType := "upstream_credentials_exhausted"
+					return zero, &schemas.BifrostError{
+						IsBifrostError: false,
+						StatusCode:     &statusCode,
+						Type:           &errType,
+						Error: &schemas.ErrorField{
+							Type:    &errType,
+							Message: err.Error(),
+						},
+					}
+				}
 				return zero, newBifrostErrorFromMsg(err.Error())
 			}
 			currentKey = selectedKey
@@ -5340,11 +5388,22 @@ func executeRequestWithRetries[T any](
 			}
 			logger.Debug("retrying request (attempt %d/%d) for model %s: %s", attempts, config.NetworkConfig.MaxRetries, model, retryMsg)
 
-			// Calculate and apply backoff
-			backoff := calculateBackoff(attempts-1, config)
-			logger.Debug("sleeping for %s before retry", backoff)
-
-			time.Sleep(backoff)
+			// Skip backoff only when (a) we genuinely rotated to a different credential AND
+			// (b) the previous failure was a *permanent* per-key error (401/402/403) where
+			// waiting offers nothing against a dead key.
+			//
+			// Backoff is preserved in every other case:
+			//   - 5xx / network retries (same key) — transient upstream issue, classic backoff.
+			//   - 429 rotations — account-level rate limits share quota across keys, so the
+			//     new key may not have fresh capacity; the backoff lets the quota window slide.
+			//   - 429 pool reset that re-picks the same key — no rotation actually happened.
+			//   - keyless providers — currentKey.ID stays empty, so keyChanged is false.
+			keyChanged := keyProvider != nil && currentKey.ID != previousKeyID
+			if !(lastWasPermanentKeyFailure && keyChanged) {
+				backoff := calculateBackoff(attempts-1, config)
+				logger.Debug("sleeping for %s before retry", backoff)
+				time.Sleep(backoff)
+			}
 		}
 
 		logger.Debug("attempting %s request for provider %s", requestType, providerKey)
@@ -5492,9 +5551,14 @@ func executeRequestWithRetries[T any](
 			break
 		}
 
-		// Check if we should retry based on status code or error message
+		// Classify the failure to decide whether to retry and whether to rotate the key.
+		//
+		// isPerKeyFailure: failure is bound to this specific key/account (401/402/403/429, or a
+		//   rate-limit error surfaced via message text instead of a 429 status). The same key
+		//   won't help — try a different one.
+		// retryable 5xx / network errors: transient server issues — retry with the same key.
 		shouldRetry := false
-		isRateLimit := (bifrostError.StatusCode != nil && *bifrostError.StatusCode == 429) ||
+		isPerKeyFailure := (bifrostError.StatusCode != nil && perKeyFailureStatusCodes[*bifrostError.StatusCode]) ||
 			(bifrostError.Error != nil &&
 				(IsRateLimitErrorMessage(bifrostError.Error.Message) ||
 					(bifrostError.Error.Type != nil && IsRateLimitErrorMessage(*bifrostError.Error.Type)) ||
@@ -5507,19 +5571,28 @@ func executeRequestWithRetries[T any](
 				bifrostError.Error.Message == schemas.ErrProviderNetworkError) {
 			shouldRetry = true
 			logger.Debug("detected request HTTP/network error, will retry: %s", errMessage)
-		} else if (bifrostError.StatusCode != nil && retryableStatusCodes[*bifrostError.StatusCode]) || isRateLimit {
+		} else if (bifrostError.StatusCode != nil && transientServerStatusCodes[*bifrostError.StatusCode]) || isPerKeyFailure {
 			shouldRetry = true
 			logger.Debug("encountered error that should be retried: %s", errMessage)
 		}
 
-		// Fill FailReason on any failed attempt (retryable or terminal).
-		// Use the provider error type when present; fall back to "unknown".
+		// Fill FailReason on any failed attempt (retryable or terminal). The trail field
+		// answers "why was this key skipped?", so for rotation-triggering status codes the
+		// status itself is the truthful answer — provider Type labels can be misleading
+		// (e.g. OpenAI returns Type="invalid_request_error" for 401 invalid_api_key, which
+		// describes the request, not the rotation reason). Fall back to provider Type for
+		// non-rotation failures, then "unknown".
 		if trail, ok := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord); ok && len(trail) > 0 {
 			reason := "unknown"
-			if bifrostError.Error != nil && bifrostError.Error.Type != nil && *bifrostError.Error.Type != "" {
-				reason = *bifrostError.Error.Type
-			} else if isRateLimit {
+			switch {
+			case bifrostError.StatusCode != nil && *bifrostError.StatusCode == 429:
 				reason = "rate_limit_error"
+			case bifrostError.StatusCode != nil && (*bifrostError.StatusCode == 401 || *bifrostError.StatusCode == 403):
+				reason = "authentication_error"
+			case bifrostError.StatusCode != nil && *bifrostError.StatusCode == 402:
+				reason = "billing_error"
+			case bifrostError.Error != nil && bifrostError.Error.Type != nil && *bifrostError.Error.Type != "":
+				reason = *bifrostError.Error.Type
 			}
 			trail[len(trail)-1].FailReason = &reason
 			ctx.SetValue(schemas.BifrostContextKeyAttemptTrail, trail)
@@ -5529,22 +5602,40 @@ func executeRequestWithRetries[T any](
 			break
 		}
 
-		// Mark current key as used so the next selection excludes it (rate-limit only).
-		// Network errors keep the same key — they are transient server issues, not per-key.
-		if isRateLimit && keyProvider != nil {
-			if usedKeyIDs == nil {
-				usedKeyIDs = make(map[string]bool)
+		// Track key state so the next keyProvider call excludes this key. Permanent
+		// per-key failures (401/402/403) go into deadKeyIDs which is never reset within
+		// this request — a bad credential won't become valid by waiting. Transient
+		// per-key failures (429) go into usedKeyIDs which the keyProvider may reset
+		// once all keys are exhausted, since a rate-limited key may have free quota by
+		// the time we come back to it.
+		isPermanentKeyFailure := false
+		if isPerKeyFailure && keyProvider != nil {
+			isPermanentKeyFailure = bifrostError.StatusCode != nil &&
+				(*bifrostError.StatusCode == 401 || *bifrostError.StatusCode == 402 || *bifrostError.StatusCode == 403)
+			if isPermanentKeyFailure {
+				if deadKeyIDs == nil {
+					deadKeyIDs = make(map[string]bool)
+				}
+				deadKeyIDs[currentKey.ID] = true
+			} else {
+				if usedKeyIDs == nil {
+					usedKeyIDs = make(map[string]bool)
+				}
+				usedKeyIDs[currentKey.ID] = true
 			}
-			usedKeyIDs[currentKey.ID] = true
 		}
-		lastWasRateLimit = isRateLimit
+		lastWasPerKeyFailure = isPerKeyFailure
+		lastWasPermanentKeyFailure = isPermanentKeyFailure
+		// Remember the key used on this attempt so the next iteration's backoff check
+		// can detect whether key selection genuinely picked a different credential.
+		previousKeyID = currentKey.ID
 
 		// Record the just-failed attempt as a *candidate* for rotation. The next iteration will
 		// confirm it (and set TriggeredRotation=true) only if key selection actually picks a
 		// different key — this avoids false positives for fixed-key providers whose keyProvider
 		// is non-nil but returns the same key. Network-error retries reuse the same key, and
 		// terminal attempts (attempts == MaxRetries) won't run another iteration.
-		if isRateLimit && keyProvider != nil && attempts < config.NetworkConfig.MaxRetries {
+		if lastWasPerKeyFailure && keyProvider != nil && attempts < config.NetworkConfig.MaxRetries {
 			if trail, ok := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord); ok && len(trail) > 0 {
 				pendingRotationAttemptIdx = len(trail) - 1
 			}
@@ -5683,7 +5774,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		// keyProvider is passed to executeRequestWithRetries to manage key selection and rotation.
 		// It is nil when no key is required (e.g. providerRequiresKey=false) or for multi-key
 		// batch/file/container operations that manage their own key lists.
-		var keyProvider func(usedKeyIDs map[string]bool) (schemas.Key, error)
+		var keyProvider func(usedKeyIDs, deadKeyIDs map[string]bool) (schemas.Key, error)
 
 		if providerRequiresKey(config.CustomProviderConfig) {
 			// ListModels needs all enabled/supported keys so providers can aggregate
@@ -5765,9 +5856,15 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 						// SkipKeySelection path — keyProvider stays nil, zero Key is used.
 					} else if !canRotate {
 						// Fixed key (explicit ID/name, session stickiness): always
-						// return the same key regardless of usedKeyIDs.
+						// return the same key — *unless* it has been marked permanently
+						// dead this request, in which case surface errAllKeysDead so the
+						// caller emits 502 upstream_credentials_exhausted instead of
+						// burning the remaining retries on the same bad credential.
 						fixedKey := supportedKeys[0]
-						keyProvider = func(_ map[string]bool) (schemas.Key, error) {
+						keyProvider = func(_, deadKeyIDs map[string]bool) (schemas.Key, error) {
+							if deadKeyIDs[fixedKey.ID] {
+								return schemas.Key{}, errAllKeysDead
+							}
 							return fixedKey, nil
 						}
 					} else {
@@ -5776,19 +5873,31 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 						pool := supportedKeys
 						provKey := provider.GetProviderKey()
 						mdl := model
-						keyProvider = func(usedKeyIDs map[string]bool) (schemas.Key, error) {
+						keyProvider = func(usedKeyIDs, deadKeyIDs map[string]bool) (schemas.Key, error) {
 							available := make([]schemas.Key, 0, len(pool))
 							for _, k := range pool {
-								if !usedKeyIDs[k.ID] {
-									available = append(available, k)
+								if deadKeyIDs[k.ID] || usedKeyIDs[k.ID] {
+									continue
 								}
+								available = append(available, k)
 							}
 							if len(available) == 0 {
-								// All keys exhausted — start a fresh weighted round.
+								// No non-dead keys remain in this cycle. If every key has been
+								// marked permanently dead, give up — retrying won't help.
+								// Otherwise reset usedKeyIDs and start a fresh weighted round
+								// across the still-live (non-dead) keys; a previously
+								// rate-limited key may have free quota by now.
+								for _, k := range pool {
+									if !deadKeyIDs[k.ID] {
+										available = append(available, k)
+									}
+								}
+								if len(available) == 0 {
+									return schemas.Key{}, fmt.Errorf("%w: provider %s", errAllKeysDead, provKey)
+								}
 								for id := range usedKeyIDs {
 									delete(usedKeyIDs, id)
 								}
-								available = pool
 							}
 							return bifrost.keySelector(req.Context, available, provKey, mdl)
 						}

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -618,27 +618,42 @@ func TestHandleProviderRequest_OCROperationNotAllowed(t *testing.T) {
 	}
 }
 
-// Test that retryableStatusCodes are properly defined
-func TestRetryableStatusCodes(t *testing.T) {
-	expectedCodes := map[int]bool{
-		500: true, // Internal Server Error
-		502: true, // Bad Gateway
-		503: true, // Service Unavailable
-		504: true, // Gateway Timeout
-		429: true, // Too Many Requests
-	}
-
-	for code, expected := range expectedCodes {
-		if retryableStatusCodes[code] != expected {
-			t.Errorf("Status code %d should be retryable=%v, got %v", code, expected, retryableStatusCodes[code])
+// Test that transientServerStatusCodes are properly defined.
+// These are upstream-side failures unrelated to the credential — the same key is retried.
+func TestTransientServerStatusCodes(t *testing.T) {
+	expected := []int{500, 502, 503, 504}
+	for _, code := range expected {
+		if !transientServerStatusCodes[code] {
+			t.Errorf("status code %d should be in transientServerStatusCodes", code)
 		}
 	}
 
-	// Test non-retryable codes
-	nonRetryableCodes := []int{200, 201, 400, 401, 403, 404, 422}
-	for _, code := range nonRetryableCodes {
-		if retryableStatusCodes[code] {
-			t.Errorf("Status code %d should not be retryable", code)
+	// Codes that must NOT be in transientServerStatusCodes: per-key codes (rotated, not
+	// retried-same-key), success codes, and request-bound 4xx (terminal).
+	notTransient := []int{200, 201, 400, 401, 402, 403, 404, 422, 429}
+	for _, code := range notTransient {
+		if transientServerStatusCodes[code] {
+			t.Errorf("status code %d should not be in transientServerStatusCodes", code)
+		}
+	}
+}
+
+// Test that perKeyFailureStatusCodes are properly defined.
+// These are credential/account-bound failures — rotate to the next key instead of retrying
+// the same one.
+func TestPerKeyFailureStatusCodes(t *testing.T) {
+	expected := []int{401, 402, 403, 429}
+	for _, code := range expected {
+		if !perKeyFailureStatusCodes[code] {
+			t.Errorf("status code %d should be in perKeyFailureStatusCodes", code)
+		}
+	}
+
+	// Request-bound 4xx, success codes, and transient-server 5xx must not trigger rotation.
+	notPerKey := []int{200, 201, 400, 404, 422, 500, 502, 503, 504}
+	for _, code := range notPerKey {
+		if perKeyFailureStatusCodes[code] {
+			t.Errorf("status code %d should not be in perKeyFailureStatusCodes", code)
 		}
 	}
 }
@@ -1041,7 +1056,7 @@ func TestSelectKeyFromProviderForModel_SessionStickinessNoRotation(t *testing.T)
 	}
 
 	fixedKey := pool[0]
-	keyProvider := func(_ map[string]bool) (schemas.Key, error) { return fixedKey, nil }
+	keyProvider := func(_, _ map[string]bool) (schemas.Key, error) { return fixedKey, nil }
 
 	// Simulate 3 rate-limit failures then success; all attempts must use key-a.
 	var usedKeyIDs []string
@@ -1146,7 +1161,7 @@ func TestExecuteRequestWithRetries_KeyRotation(t *testing.T) {
 
 	t.Run("RotatesKeyOnRateLimitRetry", func(t *testing.T) {
 		var selectedKeyIDs []string
-		keyProvider := func(usedKeyIDs map[string]bool) (schemas.Key, error) {
+		keyProvider := func(usedKeyIDs, _ map[string]bool) (schemas.Key, error) {
 			for _, k := range keys {
 				if !usedKeyIDs[k.ID] {
 					return k, nil
@@ -1193,7 +1208,7 @@ func TestExecuteRequestWithRetries_KeyRotation(t *testing.T) {
 	t.Run("SameKeyOnNetworkError", func(t *testing.T) {
 		var selectedKeyIDs []string
 		keyProviderCalls := 0
-		keyProvider := func(usedKeyIDs map[string]bool) (schemas.Key, error) {
+		keyProvider := func(usedKeyIDs, _ map[string]bool) (schemas.Key, error) {
 			keyProviderCalls++
 			for _, k := range keys {
 				if !usedKeyIDs[k.ID] {
@@ -1243,7 +1258,7 @@ func TestExecuteRequestWithRetries_KeyRotation(t *testing.T) {
 		var selectedKeyIDs []string
 		// 3 keys, 6 retries — should cycle through all 3 keys twice
 		config6 := createTestConfig(5, 0, 0) // 5 retries = 6 total attempts
-		keyProvider := func(usedKeyIDs map[string]bool) (schemas.Key, error) {
+		keyProvider := func(usedKeyIDs, _ map[string]bool) (schemas.Key, error) {
 			available := make([]schemas.Key, 0)
 			for _, k := range keys {
 				if !usedKeyIDs[k.ID] {

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -191,7 +191,8 @@ func isStreamTransportError(err error) bool {
 // retryableBedrockExceptions maps AWS Bedrock EventStream exception types to
 // their HTTP status code equivalents. These exceptions are transient and should
 // be retried — the retry gate in executeRequestWithRetries checks StatusCode
-// against retryableStatusCodes (429, 500, 502, 503, 504).
+// against transientServerStatusCodes (500, 502, 503, 504) for same-key retries
+// and perKeyFailureStatusCodes (429) for rotation-triggered retries.
 var retryableBedrockExceptions = map[string]int{
 	"throttlingException":         429,
 	"serviceUnavailableException": 503,
@@ -1020,7 +1021,7 @@ func (provider *BedrockProvider) TextCompletionStream(ctx *schemas.BifrostContex
 						// Retryable AWS exceptions must not set IsBifrostError:true — that would
 						// bypass the retry gate in executeRequestWithRetries. Instead emit
 						// IsBifrostError:false with the equivalent HTTP status code so the existing
-						// retryableStatusCodes gate handles the retry.
+						// retry gate (transientServerStatusCodes / perKeyFailureStatusCodes) handles the retry.
 						if statusCode, ok := retryableBedrockExceptions[excType]; ok {
 							providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &schemas.BifrostError{
 								IsBifrostError: false,
@@ -1272,7 +1273,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 						// Retryable AWS exceptions must not set IsBifrostError:true — that would
 						// bypass the retry gate in executeRequestWithRetries. Instead emit
 						// IsBifrostError:false with the equivalent HTTP status code so the existing
-						// retryableStatusCodes gate handles the retry.
+						// retry gate (transientServerStatusCodes / perKeyFailureStatusCodes) handles the retry.
 						if statusCode, ok := retryableBedrockExceptions[excType]; ok {
 							providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &schemas.BifrostError{
 								IsBifrostError: false,
@@ -1675,7 +1676,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 						// Retryable AWS exceptions must not set IsBifrostError:true — that would
 						// bypass the retry gate in executeRequestWithRetries. Instead emit
 						// IsBifrostError:false with the equivalent HTTP status code so the existing
-						// retryableStatusCodes gate handles the retry.
+						// retry gate (transientServerStatusCodes / perKeyFailureStatusCodes) handles the retry.
 						if statusCode, ok := retryableBedrockExceptions[excType]; ok {
 							providerUtils.ProcessAndSendBifrostError(ctx, postHookRunner, &schemas.BifrostError{
 								IsBifrostError: false,

--- a/core/providers/bedrock/transport_test.go
+++ b/core/providers/bedrock/transport_test.go
@@ -350,7 +350,7 @@ func TestChatCompletionStream_RetryableException_ChunkIsRetryable(t *testing.T) 
 			assert.False(t, errChunk.BifrostError.IsBifrostError,
 				"%s must be IsBifrostError:false so retry gate can retry it", tc.excType)
 			require.NotNil(t, errChunk.BifrostError.StatusCode,
-				"%s must carry a StatusCode for the retryableStatusCodes gate", tc.excType)
+				"%s must carry a StatusCode for the retry gate", tc.excType)
 			assert.Equal(t, tc.expectedStatus, *errChunk.BifrostError.StatusCode,
 				"%s must map to HTTP %d", tc.excType, tc.expectedStatus)
 		})
@@ -445,7 +445,7 @@ func assertRetryableExceptionChunk(t *testing.T, streamChan chan *schemas.Bifros
 	assert.False(t, errChunk.BifrostError.IsBifrostError,
 		"%s must be IsBifrostError:false so retry gate can retry it", excType)
 	require.NotNil(t, errChunk.BifrostError.StatusCode,
-		"%s must carry a StatusCode for the retryableStatusCodes gate", excType)
+		"%s must carry a StatusCode for the retry gate", excType)
 	assert.Equal(t, expectedStatus, *errChunk.BifrostError.StatusCode,
 		"%s must map to HTTP %d", excType, expectedStatus)
 }

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -351,15 +351,18 @@ const (
 // KeyAttemptRecord captures the outcome of a single request attempt within executeRequestWithRetries.
 // One record is appended per attempt regardless of whether the key changed between attempts.
 //
-// FailReason is populated on every failed attempt (retryable or terminal), and is nil only on a
-// successful attempt. Use it to inspect what went wrong on a given try.
+// FailReason is populated on every failed attempt (retryable or terminal) and is nil only on a
+// successful attempt. Status-derived values are: `rate_limit_error` (429), `authentication_error`
+// (401/403), `billing_error` (402); otherwise the provider's error Type is used, falling back to
+// `unknown`. Use it to inspect what went wrong on a given try.
 //
-// TriggeredRotation is true iff this attempt's failure caused the next attempt to rotate to a
-// different key — i.e. a rate-limit error with retries remaining. It is false on:
+// TriggeredRotation is true iff this attempt's per-key failure caused the next attempt to actually
+// rotate to a *different* key. It is false on:
 //   - the final (terminal) attempt of a request, regardless of outcome,
 //   - any successful attempt,
-//   - network-error retries (same key is reused on transient 5xx),
-//   - non-retryable failures.
+//   - same-key retries (transient 5xx / network errors keep the same key),
+//   - non-retryable failures,
+//   - fixed-key paths and 429 pool-resets that re-pick the same key (no rotation actually happened).
 //
 // Use this (not FailReason) to count actual key rotations.
 type KeyAttemptRecord struct {

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -350,15 +350,18 @@ const (
 // KeyAttemptRecord captures the outcome of a single request attempt within executeRequestWithRetries.
 // One record is appended per attempt regardless of whether the key changed between attempts.
 //
-// FailReason is populated on every failed attempt (retryable or terminal), and is nil only on a
-// successful attempt. Use it to inspect what went wrong on a given try.
+// FailReason is populated on every failed attempt (retryable or terminal) and is nil only on a
+// successful attempt. Status-derived values are: `rate_limit_error` (429), `authentication_error`
+// (401/403), `billing_error` (402); otherwise the provider's error Type is used, falling back to
+// `unknown`. Use it to inspect what went wrong on a given try.
 //
-// TriggeredRotation is true iff this attempt's failure caused the next attempt to rotate to a
-// different key — i.e. a rate-limit error with retries remaining. It is false on:
+// TriggeredRotation is true iff this attempt's per-key failure caused the next attempt to actually
+// rotate to a *different* key. It is false on:
 //   - the final (terminal) attempt of a request, regardless of outcome,
 //   - any successful attempt,
-//   - network-error retries (same key is reused on transient 5xx),
-//   - non-retryable failures.
+//   - same-key retries (transient 5xx / network errors keep the same key),
+//   - non-retryable failures,
+//   - fixed-key paths and 429 pool-resets that re-pick the same key (no rotation actually happened).
 //
 // Use this (not FailReason) to count actual key rotations.
 type KeyAttemptRecord struct {

--- a/core/utils.go
+++ b/core/utils.go
@@ -19,13 +19,30 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// Define a set of retryable status codes
-var retryableStatusCodes = map[int]bool{
+// transientServerStatusCodes are upstream-side failures unrelated to the credential —
+// retried with the *same* key (a different credential gains nothing against a flaky
+// server). Distinct from perKeyFailureStatusCodes which trigger key rotation.
+var transientServerStatusCodes = map[int]bool{
 	500: true, // Internal Server Error
 	502: true, // Bad Gateway
 	503: true, // Service Unavailable
 	504: true, // Gateway Timeout
-	429: true, // Too Many Requests
+}
+
+// perKeyFailureStatusCodes are failures bound to the specific key/account rather than
+// the request. On these, executeRequestWithRetries rotates to the next available key
+// (if any) instead of retrying the same key. Request-bound 4xx (400/404/422/...) are
+// intentionally excluded — rotating would just burn every key on the same bad request.
+//
+// Split further inside the retry loop:
+//   - 429 → transient per-key (rate limit) → tracked in usedKeyIDs, may be retried later
+//   - 401/402/403 → permanent per-key (auth/billing/permission) → tracked in deadKeyIDs,
+//     never retried within the same request.
+var perKeyFailureStatusCodes = map[int]bool{
+	401: true, // Unauthorized — bad / revoked API key
+	402: true, // Payment Required — billing issue on this key's account
+	403: true, // Forbidden — key lacks permission or is org-level blocked
+	429: true, // Too Many Requests — this key is rate-limited, another may have capacity
 }
 
 // Define rate limit error message patterns (case-insensitive)

--- a/docs/features/observability/default.mdx
+++ b/docs/features/observability/default.mdx
@@ -33,15 +33,15 @@ Bifrost traces comprehensive information for every request, without any changes 
 
 ### **Retry & Key Selection** <sup>v1.5.0-prerelease4+</sup>
 
-When Bifrost retries a request (rate-limit or network error) the following fields are recorded:
+When Bifrost retries a request (per-key failure or transient network/5xx error) the following fields are recorded:
 
 | Field | Meaning |
 |-------|---------|
 | `selected_key_id` / `selected_key_name` | The API key that **successfully** served the request. `null` when all attempts failed - use `attempt_trail` to see which keys were tried. |
 | `number_of_retries` | Total number of attempts minus one. **Does not indicate which key was used on each attempt.** |
-| `attempt_trail` | Ordered array of every attempt. Each entry contains `attempt`, `key_id`, `key_name`, `fail_reason` (set on every failed attempt — including the terminal one — and omitted from the JSON on a successful attempt), and `triggered_rotation` (always present; `true` only when this attempt's rate-limit failure caused the next retry to switch to a different key, `false` otherwise). |
+| `attempt_trail` | Ordered array of every attempt. Each entry contains `attempt`, `key_id`, `key_name`, `fail_reason` (set on every failed attempt — including the terminal one — and omitted from the JSON on a successful attempt), and `triggered_rotation` (always present; `true` only when this attempt's per-key failure — rate-limit (429), auth (401/403), or billing (402) — caused the next retry to switch to a different key, `false` otherwise). |
 
-**Example `attempt_trail`** - two rate-limit rotations then success on a third key:
+**Example `attempt_trail`** — two rate-limit rotations then success on a third key:
 
 ```json
 "attempt_trail": [
@@ -51,7 +51,16 @@ When Bifrost retries a request (rate-limit or network error) the following field
 ]
 ```
 
-Network-error retries reuse the same key; only rate-limit errors rotate to a different key. `triggered_rotation` is therefore `false` on network-error attempts even when a retry follows:
+Auth and billing failures (401/402/403) also rotate to a different key, since the failure is bound to the credential. `fail_reason` is `authentication_error` (401/403) or `billing_error` (402):
+
+```json
+"attempt_trail": [
+  { "attempt": 0, "key_id": "key-a", "key_name": "Key A", "fail_reason": "authentication_error", "triggered_rotation": true },
+  { "attempt": 1, "key_id": "key-b", "key_name": "Key B", "triggered_rotation": false }
+]
+```
+
+Network/5xx retries reuse the same key — they are transient server issues, not per-key problems. `triggered_rotation` is therefore `false` on network-error attempts even when a retry follows:
 
 ```json
 "attempt_trail": [

--- a/docs/features/observability/prometheus.mdx
+++ b/docs/features/observability/prometheus.mdx
@@ -208,7 +208,7 @@ The following metrics are available from both the `/metrics` endpoint and Push G
 | `bifrost_stream_inter_token_latency_seconds` | Histogram | Inter-token latency (streaming) |
 | `bifrost_active_requests` | Gauge | LLM requests currently in-flight (labeled by `method` only) |
 | `bifrost_provider_key_up` | Gauge | Per-key health. `1` after a successful attempt, `0` after a failed attempt. Labels: `provider`, `key_id`, `key_name`. |
-| `bifrost_key_rotation_events_total` | Counter | Key rotations triggered by rate-limit failures (see below) <sup>v1.5.0-prerelease4+</sup> |
+| `bifrost_key_rotation_events_total` | Counter | Key rotations triggered by per-key failures — rate-limit (429), auth (401/403), or billing (402) — see below <sup>v1.5.0-prerelease4+</sup> |
 | `bifrost_request_retries` | Histogram | Number of retries used per request (observed once per request; buckets `0,1,2,3,5,10`). |
 
 ### Default Labels
@@ -233,11 +233,17 @@ Most request-level Bifrost LLM metrics include these labels (the `bifrost_key_ro
 
 ### Key Rotation Events <sup>v1.5.0-prerelease4+</sup>
 
-`bifrost_key_rotation_events_total` is incremented once per **actual key rotation** — i.e. when a rate-limit failure causes the next retry to switch to a different key. It is **not** incremented for:
+`bifrost_key_rotation_events_total` is incremented once per **actual key rotation** — i.e. when a per-key failure causes the next retry to switch to a different key. Rotation-triggering failures are bound to the specific key/account rather than the request:
 
-- terminal failures (no retry happens, including `max_retries = 0`),
-- same-key retries on transient network errors,
-- non-retryable failures.
+- `429 Too Many Requests` — this key is rate-limited; another may have capacity.
+- `401 Unauthorized` / `403 Forbidden` — bad / revoked key, or key lacks permission.
+- `402 Payment Required` — billing issue on this key's account.
+
+It is **not** incremented for:
+
+- terminal failures (no retry happens, including `max_retries = 0` or every key permanently dead),
+- same-key retries on transient 5xx / network errors,
+- non-retryable request-bound 4xx (400/404/422/...).
 
 Labels are attributed to the key that failed and triggered the rotation:
 
@@ -245,9 +251,9 @@ Labels are attributed to the key that failed and triggered the rotation:
 |-------|--------|-------------|
 | `provider` | e.g. `openai` | LLM provider |
 | `requested_model` | e.g. `gpt-4o` | Model as requested (before any alias resolution) |
-| `key_id` | UUID | The provider API key that hit a rate limit and was rotated away from |
+| `key_id` | UUID | The provider API key that failed and was rotated away from |
 | `key_name` | string | Human-readable name of the provider API key |
-| `fail_reason` | error type string | Provider error type that triggered the rotation (typically `rate_limit_error`) |
+| `fail_reason` | error type string | Reason the rotation fired: `rate_limit_error` (429), `authentication_error` (401/403), `billing_error` (402), or a provider-supplied error type for non-status-coded rate-limit messages |
 
 To inspect every attempted key on a failed request (including terminal failures that did not rotate), read the `attempt_trail` field on the corresponding log entry instead.
 

--- a/docs/features/observability/prometheus.mdx
+++ b/docs/features/observability/prometheus.mdx
@@ -180,7 +180,7 @@ The following metrics are available from both the `/metrics` endpoint and Push G
 | `bifrost_stream_inter_token_latency_seconds` | Histogram | Inter-token latency (streaming) |
 | `bifrost_active_requests` | Gauge | LLM requests currently in-flight (labeled by `method` only) |
 | `bifrost_provider_key_up` | Gauge | Per-key health. `1` after a successful attempt, `0` after a failed attempt. Labels: `provider`, `key_id`, `key_name`. |
-| `bifrost_key_rotation_events_total` | Counter | Key rotations triggered by rate-limit failures (see below) <sup>v1.5.0-prerelease4+</sup> |
+| `bifrost_key_rotation_events_total` | Counter | Key rotations triggered by per-key failures — rate-limit (429), auth (401/403), or billing (402) — see below <sup>v1.5.0-prerelease4+</sup> |
 | `bifrost_request_retries` | Histogram | Number of retries used per request (observed once per request; buckets `0,1,2,3,5,10`). |
 
 ### Default Labels
@@ -205,11 +205,17 @@ Most request-level Bifrost LLM metrics include these labels (the `bifrost_key_ro
 
 ### Key Rotation Events <sup>v1.5.0-prerelease4+</sup>
 
-`bifrost_key_rotation_events_total` is incremented once per **actual key rotation** — i.e. when a rate-limit failure causes the next retry to switch to a different key. It is **not** incremented for:
+`bifrost_key_rotation_events_total` is incremented once per **actual key rotation** — i.e. when a per-key failure causes the next retry to switch to a different key. Rotation-triggering failures are bound to the specific key/account rather than the request:
 
-- terminal failures (no retry happens, including `max_retries = 0`),
-- same-key retries on transient network errors,
-- non-retryable failures.
+- `429 Too Many Requests` — this key is rate-limited; another may have capacity.
+- `401 Unauthorized` / `403 Forbidden` — bad / revoked key, or key lacks permission.
+- `402 Payment Required` — billing issue on this key's account.
+
+It is **not** incremented for:
+
+- terminal failures (no retry happens, including `max_retries = 0` or every key permanently dead),
+- same-key retries on transient 5xx / network errors,
+- non-retryable request-bound 4xx (400/404/422/...).
 
 Labels are attributed to the key that failed and triggered the rotation:
 
@@ -217,9 +223,9 @@ Labels are attributed to the key that failed and triggered the rotation:
 |-------|--------|-------------|
 | `provider` | e.g. `openai` | LLM provider |
 | `requested_model` | e.g. `gpt-4o` | Model as requested (before any alias resolution) |
-| `key_id` | UUID | The provider API key that hit a rate limit and was rotated away from |
+| `key_id` | UUID | The provider API key that failed and was rotated away from |
 | `key_name` | string | Human-readable name of the provider API key |
-| `fail_reason` | error type string | Provider error type that triggered the rotation (typically `rate_limit_error`) |
+| `fail_reason` | error type string | Reason the rotation fired: `rate_limit_error` (429), `authentication_error` (401/403), `billing_error` (402), or a provider-supplied error type for non-status-coded rate-limit messages |
 
 To inspect every attempted key on a failed request (including terminal failures that did not rotate), read the `attempt_trail` field on the corresponding log entry instead.
 

--- a/docs/features/retries-and-fallbacks.mdx
+++ b/docs/features/retries-and-fallbacks.mdx
@@ -8,7 +8,7 @@ icon: "list-check"
 
 Bifrost provides two complementary layers of resilience:
 
-- **Retries** - When a provider returns a transient error (network issue, rate limit, 5xx), Bifrost automatically retries the same request against the same provider with exponential backoff. On rate-limit errors, it can also rotate to a different API key from your pool.
+- **Retries** - When a provider returns a transient server error (network issue, 5xx) or a per-key failure (`429` rate-limit, `401`/`403` auth, `402` billing), Bifrost automatically retries the same request against the same provider. Transient-server retries reuse the same key with exponential backoff; per-key failures rotate to a different API key from your pool. Backoff is skipped only when rotating away from a *permanent* per-key failure (`401`/`402`/`403`) where waiting offers nothing — for `429` rotations a backoff is still applied to let account-level quota windows slide.
 - **Fallbacks** - When the primary provider fails after exhausting all retries, Bifrost moves on to the next provider in your fallback chain. Each fallback provider gets its own full retry budget.
 
 Together, they let you build LLM-powered applications that stay up through rate limits, transient outages, and even full provider failures - with no changes required in your application code.
@@ -21,13 +21,16 @@ Together, they let you build LLM-powered applications that stay up through rate 
 
 When a request fails with a retryable error, Bifrost:
 
-1. Waits using **exponential backoff with jitter** before the next attempt
-2. Retries the request against the same provider
-3. On **rate-limit errors** (`429`): rotates to a different API key from the pool (if multiple keys are configured) so fresh capacity is used
-4. On **network/server errors** (`5xx`, DNS, connection refused): reuses the same key - these are transient server issues, not per-key capacity problems
-5. Continues until the request succeeds or `max_retries` is exhausted
+1. Classifies the failure as either a **per-key failure** (the credential / account is the problem — status `401`/`402`/`403`/`429`) or a **transient server failure** (the upstream is the problem — `5xx` / network / DNS).
+2. On **per-key failures**, rotates to a different API key from the pool (if multiple keys are configured). Two sub-cases:
+    - **Permanent per-key failure** (`401`/`402`/`403`): mark the key dead for the remainder of the request and rotate immediately — **no backoff**, since waiting can't revive a bad credential.
+    - **Transient per-key failure** (`429` rate-limit): mark the key as used-this-cycle and rotate, but **still apply backoff** — providers often enforce account-level quotas shared across keys, so the new key may not have fresh capacity until the window slides.
+3. On **transient server failures** (`5xx`, DNS, connection refused): reuse the same key and wait using **exponential backoff with jitter** before the next attempt.
+4. Continues until the request succeeds, `max_retries` is exhausted, or every key is permanently dead (in which case Bifrost returns `502 upstream_credentials_exhausted` rather than the raw `4xx`, to make it clear the caller's Bifrost API key is fine — the configured provider credentials are not).
 
 ### Backoff formula
+
+Backoff applies to **same-key retries** (transient server 5xx / network errors) and to **`429` rate-limit rotations** (since account-level quotas can be shared across keys). It is skipped only when rotating away from a **permanent per-key failure** (`401`/`402`/`403`) to a genuinely different credential — a dead key gains nothing from waiting.
 
 ```
 backoff = min(retry_backoff_initial × 2^attempt, retry_backoff_max) × jitter(0.8–1.2)
@@ -45,14 +48,16 @@ With the defaults of `retry_backoff_initial = 500ms` and `retry_backoff_max = 50
 
 ### What triggers a retry
 
-| Condition | Retried? | Key rotation? |
-|-----------|----------|---------------|
-| Network error (DNS, connection refused) | Yes | No - same key reused |
-| `5xx` server errors (500, 502, 503, 504) | Yes | No - same key reused |
-| Rate limit (`429` or rate-limit message pattern) | Yes | Yes - next key from pool |
-| Request validation error | No | - |
-| Plugin-enforced block | No | - |
-| Cancelled request | No | - |
+| Condition | Retried? | Key rotation? | Backoff before next attempt? |
+|-----------|----------|---------------|-------------------------------|
+| Network error (DNS, connection refused) | Yes | No - same key reused | Yes |
+| `5xx` server errors (500, 502, 503, 504) | Yes | No - same key reused | Yes |
+| Rate limit (`429` or rate-limit message pattern) | Yes | Yes - rate-limited key may be retried later in the cycle | Yes - account-level quotas may be shared across keys |
+| Auth failure (`401`, `403`) | Yes | Yes - failing key marked **permanently dead** for this request | No - waiting can't revive a bad credential |
+| Billing failure (`402`) | Yes | Yes - failing key marked **permanently dead** for this request | No - waiting can't revive a bad credential |
+| Request validation error (`400`/`404`/`422`/...) | No | - | - |
+| Plugin-enforced block | No | - | - |
+| Cancelled request | No | - | - |
 
 ### Configuring retries
 
@@ -147,13 +152,17 @@ func (a *MyAccount) GetConfigForProvider(provider schemas.ModelProvider) (*schem
 </Tab>
 </Tabs>
 
-### Key rotation on rate limits
+### Key rotation on per-key failures
 
 <Note>
-Key rotation on retries requires **v1.5.0-prerelease4 or later**.
+Key rotation on retries requires **v1.5.0-prerelease4 or later**. Rotation on auth (401/403) and billing (402) errors (in addition to rate limits) requires the retry-logic-enhancements release.
 </Note>
 
-When you configure multiple API keys for a provider, Bifrost automatically rotates to a fresh key when a rate-limit error is encountered - so retries are not wasted repeating a request with a key that has already hit its limit.
+When you configure multiple API keys for a provider, Bifrost automatically rotates to a fresh key when the failure is bound to the credential rather than the request:
+
+- **`429 Too Many Requests`** — this key is rate-limited; another may have spare quota.
+- **`401 Unauthorized` / `403 Forbidden`** — bad / revoked key, or key lacks permission.
+- **`402 Payment Required`** — billing issue on this key's account.
 
 ```json
 {
@@ -172,10 +181,12 @@ When you configure multiple API keys for a provider, Bifrost automatically rotat
 }
 ```
 
-With 3 keys and `max_retries: 5`, Bifrost cycles through all three keys twice before giving up. Once all keys in the pool have been tried, it resets and starts a fresh weighted round.
+**Rate-limited keys** are tracked in a per-request `used` set. Once all keys in the pool have been tried, Bifrost resets that set and starts a fresh weighted round — a previously rate-limited key may have free quota by then. With 3 keys and `max_retries: 5`, Bifrost can cycle through all three keys twice before giving up.
+
+**Auth and billing failures** (401/402/403) are different: the failing key is marked **permanently dead** for the remainder of the request and is never reset. A bad credential won't become valid by waiting. If every configured key ends up permanently dead, Bifrost returns `502 upstream_credentials_exhausted` and skips any remaining retries.
 
 <Note>
-Key rotation on rate limits only applies when `max_retries > 0` and more than one key is configured for the provider. With a single key, all retries reuse that key.
+Key rotation on retries only applies when `max_retries > 0` and more than one key is configured for the provider. With a single key, all retries reuse that key (and a permanent per-key failure terminates immediately with `502`).
 </Note>
 
 ---
@@ -323,12 +334,15 @@ sequenceDiagram
     rect rgb(220, 235, 250)
         note over Bifrost,Primary: Primary provider attempt (with retries)
         Bifrost->>Primary: Attempt 1
+        Primary-->>Bifrost: 401 Unauthorized
+        note over Bifrost: Key marked dead, rotate (no backoff)
+        Bifrost->>Primary: Attempt 2 (different key)
         Primary-->>Bifrost: 429 Rate Limit
         note over Bifrost: Backoff + rotate key
-        Bifrost->>Primary: Attempt 2 (different key)
+        Bifrost->>Primary: Attempt 3 (different key)
         Primary-->>Bifrost: 503 Unavailable
-        note over Bifrost: Backoff
-        Bifrost->>Primary: Attempt 3
+        note over Bifrost: Backoff (same key)
+        Bifrost->>Primary: Attempt 4
         Primary-->>Bifrost: 503 Unavailable
         note over Bifrost: max_retries exhausted
     end
@@ -370,6 +384,10 @@ Both primary and first fallback are down. Bifrost works through each provider's 
 **Scenario 4: Cost-sensitive fallback**
 
 Primary: a premium model for quality. Fallback: a cost-effective alternative. Governance rules can trigger a budget-exceeded error on the primary, which cascades into the fallback chain.
+
+**Scenario 5: Revoked credential**
+
+OpenAI key 1 was rotated out-of-band and now returns `401`. Bifrost marks key 1 permanently dead for this request and immediately rotates to key 2 (no backoff), which succeeds. Future requests will retry key 1 again — the dead-key set is per-request, not persistent. If every configured key was revoked, Bifrost would return `502 upstream_credentials_exhausted` instead of bubbling up the raw `401` (which would falsely suggest the *caller's* Bifrost API key is the problem).
 
 ---
 

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -59,7 +59,7 @@ These metrics track requests forwarded to AI providers:
 | `bifrost_cost_total`               | Counter   | Total cost in USD for upstream provider requests                  | Base Labels, custom labels                            |
 | `bifrost_active_requests`          | Gauge     | LLM requests currently in-flight                                  | `method`                                              |
 | `bifrost_provider_key_up`          | Gauge     | Per-key health: `1` after a successful attempt, `0` after a failure | `provider`, `key_id`, `key_name`                    |
-| `bifrost_key_rotation_events_total`| Counter   | Key rotations triggered by rate-limit failures (one per actual swap) | `provider`, `requested_model`, `key_id`, `key_name`, `fail_reason` |
+| `bifrost_key_rotation_events_total`| Counter   | Key rotations triggered by per-key failures — rate-limit (429), auth (401/403), or billing (402) — one increment per actual swap | `provider`, `requested_model`, `key_id`, `key_name`, `fail_reason` |
 | `bifrost_request_retries`          | Histogram | Number of retries used per request (observed once per request; buckets `0,1,2,3,5,10`). | Base Labels |
 
 Base Labels:

--- a/docs/migration-guides/v1.5.0.mdx
+++ b/docs/migration-guides/v1.5.0.mdx
@@ -557,7 +557,7 @@ The `attempt_trail` is now the authoritative record of every key tried and why e
 |---|---|---|
 | `selected_key_id` | Always set, even on error | Empty string when all retries exhausted |
 | `selected_key_name` | Always set, even on error | Empty string when all retries exhausted |
-| `attempt_trail` | Not present | Array of `{ attempt, key_id, key_name, fail_reason, triggered_rotation }` per attempt. `fail_reason` is set on every failed attempt; `triggered_rotation` is true when this attempt's rate-limit failure caused the next retry to switch keys. |
+| `attempt_trail` | Not present | Array of `{ attempt, key_id, key_name, fail_reason, triggered_rotation }` per attempt. `fail_reason` is set on every failed attempt; `triggered_rotation` is always present, set to `true` only when this attempt's per-key failure (rate-limit (429), auth (401/403), or billing (402)) caused the next retry to switch keys, `false` otherwise. |
 
 ### Impact on logging and telemetry plugins
 

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -462,7 +462,7 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 	bifrostKeyRotationEventsTotal := factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "bifrost_key_rotation_events_total",
-			Help: "Number of key rotations, broken down by provider, key, and failure reason. One increment per rate-limit failure that triggered a switch to a different key on the next retry.",
+			Help: "Number of key rotations, broken down by provider, key, and failure reason. One increment per per-key failure (rate-limit/auth/billing/permission) that triggered a switch to a different key on the next retry.",
 		},
 		[]string{"provider", "requested_model", "key_id", "key_name", "fail_reason"},
 	)
@@ -795,8 +795,8 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		}
 
 		// Emit one rotation counter increment per attempt that actually caused a key swap on the
-		// next try (rate-limit failure with retries remaining). Mark the key unhealthy on any
-		// failure, since key health is per-failure not per-rotation.
+		// next try (per-key failure — rate-limit/auth/billing/permission — with retries remaining).
+		// Mark the key unhealthy on any failure, since key health is per-failure not per-rotation.
 		for _, record := range attemptTrail {
 			if record.TriggeredRotation && record.FailReason != nil {
 				p.KeyRotationEventsTotal.WithLabelValues(

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -346,7 +346,7 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 	bifrostKeyRotationEventsTotal := factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "bifrost_key_rotation_events_total",
-			Help: "Number of key rotations, broken down by provider, key, and failure reason. One increment per rate-limit failure that triggered a switch to a different key on the next retry.",
+			Help: "Number of key rotations, broken down by provider, key, and failure reason. One increment per per-key failure (rate-limit/auth/billing/permission) that triggered a switch to a different key on the next retry.",
 		},
 		[]string{"provider", "requested_model", "key_id", "key_name", "fail_reason"},
 	)
@@ -598,8 +598,8 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		}
 
 		// Emit one rotation counter increment per attempt that actually caused a key swap on the
-		// next try (rate-limit failure with retries remaining). Mark the key unhealthy on any
-		// failure, since key health is per-failure not per-rotation.
+		// next try (per-key failure — rate-limit/auth/billing/permission — with retries remaining).
+		// Mark the key unhealthy on any failure, since key health is per-failure not per-rotation.
 		for _, record := range attemptTrail {
 			if record.TriggeredRotation && record.FailReason != nil {
 				p.KeyRotationEventsTotal.WithLabelValues(


### PR DESCRIPTION
## Summary

Key rotation during retries previously treated all per-key failures the same way. This PR distinguishes between **permanent** per-key failures (401/402/403 — bad credentials, billing issues, missing permissions) and **transient** per-key failures (429 — rate limits). Keys that fail permanently are tracked in a separate `deadKeyIDs` set that is never reset within a single request, preventing Bifrost from cycling back to a broken credential. Keys that hit a rate limit continue to be tracked in `usedKeyIDs`, which can be reset once all non-dead keys are exhausted, since a previously rate-limited key may have recovered by then.

Additionally, backoff sleep is now skipped when rotating to a different key — waiting before trying a fresh credential provides no benefit.

## Changes

- Introduced `keyRotateStatusCodes` (401, 402, 403, 429) as a distinct set from `retryableStatusCodes` (500–504), and removed 429 from `retryableStatusCodes`.
- Added a `deadKeyIDs` parameter to `keyProvider` alongside the existing `usedKeyIDs`. Dead keys are never reconsidered within a request; used (rate-limited) keys may be reconsidered after a full rotation cycle.
- When `keyProvider` exhausts all keys and every remaining key is in `deadKeyIDs`, the error is surfaced as a `502 upstream_credentials_exhausted` rather than a raw 401/403, which would falsely imply the caller's Bifrost API key is invalid.
- Backoff is only applied when retrying the same key against a transient server error. Key-rotation retries skip the sleep.
- Attempt trail `FailReason` now uses explicit status-code-derived labels (`rate_limit_error`, `authentication_error`, `billing_error`) for rotation-triggering codes rather than the provider's error type string, which can be misleading (e.g. OpenAI returns `invalid_request_error` for a 401).
- Updated tests to cover `keyRotateStatusCodes`, verify 429 is absent from `retryableStatusCodes`, and align `keyProvider` signatures.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

Scenarios to validate manually:
- A pool of keys where one has a revoked credential (401): that key should never be retried, and the request should succeed on a valid key without delay.
- A pool where all keys return 401/403: the response should be `502 upstream_credentials_exhausted`, not a 401.
- A pool where keys are rate-limited (429): rotation should cycle through all keys, reset, and retry without treating any key as permanently dead.
- A 500 from the provider: the same key should be reused with backoff applied.

## Breaking changes

- [x] Yes
- [ ] No

The `keyProvider` function signature has changed from `func(usedKeyIDs map[string]bool)` to `func(usedKeyIDs, deadKeyIDs map[string]bool)`. Any custom `keyProvider` implementations outside this codebase will need to be updated to accept the second parameter.

## Security considerations

Permanent credential failures (401/402/403) are now isolated immediately and never retried, reducing unnecessary exposure of invalid credentials to upstream providers.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable