### PR TITLE
fix: max tokens and thinking budget value

### DIFF
--- a/core/providers/anthropic/utils_test.go
+++ b/core/providers/anthropic/utils_test.go
@@ -2828,3 +2828,56 @@ func TestIsClaudeCodeRequest(t *testing.T) {
 		})
 	}
 }
+
+// TestBudgetTokensNeverExceedsMaxTokens verifies the strict budget_tokens < max_tokens
+// invariant required by both Anthropic and Bedrock for all effort levels.
+func TestBudgetTokensNeverExceedsMaxTokens(t *testing.T) {
+	const minBudget = MinimumReasoningMaxTokens // 1024
+	maxTokensValues := []int{1025, 4096, 16000, 32000, 64000, 128000}
+	efforts := []string{"minimal", "low", "medium", "high", "xhigh", "max"}
+
+	for _, maxTok := range maxTokensValues {
+		for _, effort := range efforts {
+			t.Run(fmt.Sprintf("effort=%s/maxTokens=%d", effort, maxTok), func(t *testing.T) {
+				budget, err := providerUtils.GetBudgetTokensFromReasoningEffort(effort, minBudget, maxTok)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if budget >= maxTok {
+					t.Errorf("effort=%q maxTokens=%d: budget_tokens=%d violates strict budget_tokens < max_tokens",
+						effort, maxTok, budget)
+				}
+			})
+		}
+	}
+}
+
+// TestBudgetTokensMaxEffortCapsBelowMaxTokens specifically pins the "max" effort
+// behavior: ratio=1.0 would produce budget==maxTokens without the cap, which both
+// Anthropic and Bedrock reject ("max_tokens must be greater than thinking.budget_tokens").
+func TestBudgetTokensMaxEffortCapsBelowMaxTokens(t *testing.T) {
+	const minBudget = MinimumReasoningMaxTokens
+
+	cases := []struct {
+		maxTokens    int
+		wantBudget   int
+	}{
+		{maxTokens: 16000, wantBudget: 15999},
+		{maxTokens: 32000, wantBudget: 31999},
+		{maxTokens: 64000, wantBudget: 63999},
+		{maxTokens: 128000, wantBudget: 127999},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("maxTokens=%d", tc.maxTokens), func(t *testing.T) {
+			budget, err := providerUtils.GetBudgetTokensFromReasoningEffort("max", minBudget, tc.maxTokens)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if budget != tc.wantBudget {
+				t.Errorf("max effort with maxTokens=%d: got budget=%d, want %d",
+					tc.maxTokens, budget, tc.wantBudget)
+			}
+		})
+	}
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2729,6 +2729,11 @@ func GetBudgetTokensFromReasoningEffort(
 
 	budget := minBudgetTokens + int(ratio*float64(maxTokens-minBudgetTokens))
 
+	// Both Anthropic and Bedrock require budget_tokens < max_tokens (strict).
+	if budget >= maxTokens {
+		budget = maxTokens - 1
+	}
+
 	return budget, nil
 }
 

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -1439,3 +1439,106 @@ func TestShouldSendBackRawResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestGetBudgetTokensFromReasoningEffort(t *testing.T) {
+	const min = 1024
+	const max = 16000
+
+	tests := []struct {
+		effort  string
+		wantErr bool
+		check   func(t *testing.T, budget int)
+	}{
+		{
+			effort: "none",
+			check:  func(t *testing.T, budget int) { assertEqual(t, 0, budget, "none effort") },
+		},
+		{
+			effort: "minimal",
+			check: func(t *testing.T, budget int) {
+				assertRange(t, min, max-1, budget, "minimal")
+			},
+		},
+		{
+			effort: "low",
+			check: func(t *testing.T, budget int) {
+				assertRange(t, min, max-1, budget, "low")
+			},
+		},
+		{
+			effort: "medium",
+			check: func(t *testing.T, budget int) {
+				assertRange(t, min, max-1, budget, "medium")
+			},
+		},
+		{
+			effort: "high",
+			check: func(t *testing.T, budget int) {
+				assertRange(t, min, max-1, budget, "high")
+			},
+		},
+		{
+			effort: "xhigh",
+			check: func(t *testing.T, budget int) {
+				assertRange(t, min, max-1, budget, "xhigh")
+			},
+		},
+		{
+			// "max" with ratio=1.0 would produce budget==maxTokens without the cap.
+			// Bedrock and Anthropic both require budget_tokens < max_tokens (strict).
+			effort: "max",
+			check: func(t *testing.T, budget int) {
+				if budget >= max {
+					t.Errorf("max effort: budget %d must be < maxTokens %d", budget, max)
+				}
+				assertEqual(t, max-1, budget, "max effort caps at maxTokens-1")
+			},
+		},
+		{
+			effort: "unknown",
+			check: func(t *testing.T, budget int) {
+				assertRange(t, min, max-1, budget, "unknown effort uses safe default")
+			},
+		},
+		{
+			// minBudgetTokens > maxTokens — always an error
+			effort:  "high",
+			wantErr: true,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d_%s", i, tt.effort), func(t *testing.T) {
+			maxTokens := max
+			minTokens := min
+			if tt.wantErr {
+				minTokens = max + 1
+			}
+			budget, err := GetBudgetTokensFromReasoningEffort(tt.effort, minTokens, maxTokens)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error when minBudgetTokens > maxTokens, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			tt.check(t, budget)
+		})
+	}
+}
+
+func assertEqual(t *testing.T, want, got int, label string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s: got %d, want %d", label, got, want)
+	}
+}
+
+func assertRange(t *testing.T, low, high, got int, label string) {
+	t.Helper()
+	if got < low || got > high {
+		t.Errorf("%s: got %d, want in [%d, %d]", label, got, low, high)
+	}
+}


### PR DESCRIPTION
## Summary

Both Anthropic and Bedrock enforce a strict `budget_tokens < max_tokens` requirement for extended thinking. Previously, when reasoning effort was set to `"max"` (ratio = 1.0), the calculated budget could equal `max_tokens`, causing API rejections with the error `"max_tokens must be greater than thinking.budget_tokens"`. This PR adds a cap to ensure `budget_tokens` is always strictly less than `max_tokens`.

## Changes

- Added a guard in `GetBudgetTokensFromReasoningEffort` that clamps the computed budget to `maxTokens - 1` whenever it would otherwise equal or exceed `maxTokens`.
- Added `TestGetBudgetTokensFromReasoningEffort` in `utils_test.go` covering all effort levels, the error case where `minBudgetTokens > maxTokens`, and the specific `"max"` effort cap behavior.
- Added `TestBudgetTokensNeverExceedsMaxTokens` and `TestBudgetTokensMaxEffortCapsBelowMaxTokens` in the Anthropic provider test file to verify the invariant holds across all effort levels and a range of `max_tokens` values.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/utils/...
go test ./core/providers/anthropic/...
```

Expected: all tests pass, including the new `TestBudgetTokensNeverExceedsMaxTokens` and `TestBudgetTokensMaxEffortCapsBelowMaxTokens` cases confirming that `budget_tokens` is always strictly less than `max_tokens` for every effort level.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable