### PR TITLE
feat: add animated totals/averages to dashboard chart card headers

### DIFF
--- a/ui/app/workspace/dashboard/components/charts/chartCard.tsx
+++ b/ui/app/workspace/dashboard/components/charts/chartCard.tsx
@@ -6,24 +6,65 @@ import type { ReactNode } from "react";
 interface ChartCardProps {
 	title: string;
 	children: ReactNode;
-	headerActions?: ReactNode;
+	controls?: ReactNode;
+	legend?: ReactNode;
 	loading?: boolean;
 	testId?: string;
 	className?: string;
+	total?: ReactNode;
+	totalLabel?: string;
 }
 
-export function ChartCard({ title, children, headerActions, loading, testId, className }: ChartCardProps) {
+function TotalChip({ total, totalLabel, testId }: { total: ReactNode; totalLabel?: string; testId?: string }) {
+	return (
+		<span
+			className="text-muted-foreground flex shrink-0 items-baseline gap-1 pl-2 text-xs"
+			data-testid={testId ? `${testId}-total` : undefined}
+		>
+			{totalLabel && <span>{totalLabel}</span>}
+			<span className="text-primary text-sm font-semibold tabular-nums">{total}</span>
+		</span>
+	);
+}
+
+function Header({
+	title,
+	controls,
+	legend,
+	total,
+	totalLabel,
+	testId,
+}: {
+	title: string;
+	controls?: ReactNode;
+	legend?: ReactNode;
+	total?: ReactNode;
+	totalLabel?: string;
+	testId?: string;
+}) {
+	const hasTotal = total !== undefined && total !== null;
+	const hasActionRow = hasTotal || controls;
+	return (
+		<div className="shrink-0 space-y-2">
+			<div className="pr-1 pl-2">
+				<span className="text-primary text-sm font-medium">{title}</span>
+			</div>
+			{hasActionRow && (
+				<div className="flex h-7 w-full min-w-0 items-center justify-between gap-3" data-testid={testId ? `${testId}-actions` : undefined}>
+					{hasTotal ? <TotalChip total={total} totalLabel={totalLabel} testId={testId} /> : <span className="shrink-0" />}
+					{controls && <div className="flex shrink-0 items-center gap-2">{controls}</div>}
+				</div>
+			)}
+			{legend && <div className="w-full min-w-0">{legend}</div>}
+		</div>
+	);
+}
+
+export function ChartCard({ title, children, controls, legend, loading, testId, className, total, totalLabel }: ChartCardProps) {
 	if (loading) {
 		return (
 			<Card className={cn("min-w-0 rounded-sm p-2 shadow-none h-[330px]", className)} data-testid={testId}>
-				<div className="shrink-0 space-y-2">
-					<span className="text-primary pl-2 text-sm font-medium">{title}</span>
-					{headerActions && (
-						<div className="w-full min-w-0" data-testid={testId ? `${testId}-actions` : undefined}>
-							{headerActions}
-						</div>
-					)}
-				</div>
+				<Header title={title} controls={controls} legend={legend} total={total} totalLabel={totalLabel} testId={testId} />
 				<div className="grow" data-testid={testId ? `${testId}-chart-skeleton` : undefined}>
 					<Skeleton className="h-full w-full" />
 				</div>
@@ -33,14 +74,7 @@ export function ChartCard({ title, children, headerActions, loading, testId, cla
 
 	return (
 		<Card className={cn("min-w-0 rounded-sm p-2 shadow-none h-[330px]", className)} data-testid={testId}>
-			<div className="shrink-0 space-y-2">
-				<span className="text-primary pl-2 text-sm font-medium">{title}</span>
-				{headerActions && (
-					<div className="w-full min-w-0" data-testid={testId ? `${testId}-actions` : undefined}>
-						{headerActions}
-					</div>
-				)}
-			</div>
+			<Header title={title} controls={controls} legend={legend} total={total} totalLabel={totalLabel} testId={testId} />
 			<div className="grow">{children}</div>
 		</Card>
 	);

--- a/ui/app/workspace/dashboard/components/charts/logVolumeChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/logVolumeChart.tsx
@@ -1,7 +1,7 @@
 import type { LogsHistogramResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { CHART_COLORS, formatFullTimestamp, formatTimestamp } from "../../utils/chartUtils";
+import { CHART_COLORS, formatFullTimestamp, formatTimestamp, formatTokens } from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -97,8 +97,8 @@ function LogVolumeChartImpl({ data, chartType, startTime, endTime }: LogVolumeCh
 							tick={{ fontSize: 11, className: "fill-zinc-500" }}
 							tickLine={false}
 							axisLine={false}
-							width={56}
-							tickFormatter={(v) => v.toLocaleString()}
+							width={44}
+							tickFormatter={formatTokens}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>
@@ -139,8 +139,8 @@ function LogVolumeChartImpl({ data, chartType, startTime, endTime }: LogVolumeCh
 							tick={{ fontSize: 11, className: "fill-zinc-500" }}
 							tickLine={false}
 							axisLine={false}
-							width={56}
-							tickFormatter={(v) => v.toLocaleString()}
+							width={44}
+							tickFormatter={formatTokens}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>

--- a/ui/app/workspace/dashboard/components/charts/mcpTopToolsChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/mcpTopToolsChart.tsx
@@ -1,7 +1,7 @@
 import type { MCPTopToolsResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { formatCost, getModelColor } from "../../utils/chartUtils";
+import { formatCost, formatTokens, getModelColor } from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 
 interface MCPTopToolsChartProps {
@@ -54,7 +54,7 @@ function MCPTopToolsChartImpl({ data }: MCPTopToolsChartProps) {
 						tick={{ fontSize: 11, className: "fill-zinc-500" }}
 						tickLine={false}
 						axisLine={false}
-						tickFormatter={(v) => v.toLocaleString()}
+						tickFormatter={formatTokens}
 						domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 						allowDataOverflow={false}
 					/>

--- a/ui/app/workspace/dashboard/components/charts/mcpVolumeChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/mcpVolumeChart.tsx
@@ -1,7 +1,7 @@
 import type { MCPHistogramResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { CHART_COLORS, formatFullTimestamp, formatTimestamp } from "../../utils/chartUtils";
+import { CHART_COLORS, formatFullTimestamp, formatTimestamp, formatTokens } from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -87,8 +87,8 @@ function MCPVolumeChartImpl({ data, chartType, startTime, endTime }: MCPVolumeCh
 							tick={{ fontSize: 11, className: "fill-zinc-500" }}
 							tickLine={false}
 							axisLine={false}
-							width={40}
-							tickFormatter={(v) => v.toLocaleString()}
+							width={44}
+							tickFormatter={formatTokens}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>
@@ -129,8 +129,8 @@ function MCPVolumeChartImpl({ data, chartType, startTime, endTime }: MCPVolumeCh
 							tick={{ fontSize: 11, className: "fill-zinc-500" }}
 							tickLine={false}
 							axisLine={false}
-							width={40}
-							tickFormatter={(v) => v.toLocaleString()}
+							width={44}
+							tickFormatter={formatTokens}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>

--- a/ui/app/workspace/dashboard/components/charts/modelUsageChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/modelUsageChart.tsx
@@ -5,6 +5,7 @@ import {
 	CHART_COLORS,
 	formatFullTimestamp,
 	formatTimestamp,
+	formatTokens,
 	getModelColor,
 	OTHER_SERIES_COLOR,
 	OTHER_SERIES_KEY,
@@ -161,8 +162,8 @@ function ModelUsageChartImpl({ data, chartType, startTime, endTime, selectedMode
 							tick={{ fontSize: 11, className: "fill-zinc-500" }}
 							tickLine={false}
 							axisLine={false}
-							width={40}
-							tickFormatter={(v) => v.toLocaleString()}
+							width={44}
+							tickFormatter={formatTokens}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>
@@ -220,8 +221,8 @@ function ModelUsageChartImpl({ data, chartType, startTime, endTime, selectedMode
 							tick={{ fontSize: 11, className: "fill-zinc-500" }}
 							tickLine={false}
 							axisLine={false}
-							width={40}
-							tickFormatter={(v) => v.toLocaleString()}
+							width={44}
+							tickFormatter={formatTokens}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>

--- a/ui/app/workspace/dashboard/components/mcpTab.tsx
+++ b/ui/app/workspace/dashboard/components/mcpTab.tsx
@@ -1,6 +1,8 @@
 import type { MCPCostHistogramResponse, MCPHistogramResponse, MCPTopToolsResponse } from "@/lib/types/logs";
-import { memo } from "react";
-import { CHART_COLORS, CHART_HEADER_ACTIONS_CLASS, CHART_HEADER_CONTROLS_CLASS, CHART_HEADER_LEGEND_CLASS } from "../utils/chartUtils";
+import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
+import NumberFlow from "@number-flow/react";
+import { memo, useMemo } from "react";
+import { CHART_COLORS, CHART_HEADER_LEGEND_CLASS } from "../utils/chartUtils";
 import { ChartCard } from "./charts/chartCard";
 import { type ChartType, ChartTypeToggle } from "./charts/chartTypeToggle";
 import { MCPCostChart } from "./charts/mcpCostChart";
@@ -45,6 +47,21 @@ function MCPTabImpl({
 	onMcpVolumeChartToggle,
 	onMcpCostChartToggle,
 }: MCPTabProps) {
+	const mcpVolumeTotal = useMemo(() => {
+		if (!mcpHistogramData?.buckets) return null;
+		return mcpHistogramData.buckets.reduce((sum, b) => sum + (b.count ?? 0), 0);
+	}, [mcpHistogramData]);
+
+	const mcpCostTotal = useMemo(() => {
+		if (!mcpCostData?.buckets) return null;
+		return mcpCostData.buckets.reduce((sum, b) => sum + (b.total_cost ?? 0), 0);
+	}, [mcpCostData]);
+
+	const mcpTopToolsTotal = useMemo(() => {
+		if (!mcpTopToolsData?.tools) return null;
+		return mcpTopToolsData.tools.reduce((sum, t) => sum + (t.count ?? 0), 0);
+	}, [mcpTopToolsData]);
+
 	return (
 		<div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
 			{/* MCP Tool Calls Volume */}
@@ -52,26 +69,26 @@ function MCPTabImpl({
 				title="MCP Tool Calls"
 				loading={loadingMcpHistogram}
 				testId="chart-mcp-volume"
-				headerActions={
-					<div className={CHART_HEADER_ACTIONS_CLASS}>
-						<div className={CHART_HEADER_LEGEND_CLASS}>
-							<span className="flex items-center gap-1">
-								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.success }} />
-								<span className="text-muted-foreground">Success</span>
-							</span>
-							<span className="flex items-center gap-1">
-								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.error }} />
-								<span className="text-muted-foreground">Error</span>
-							</span>
-						</div>
-						<div className={CHART_HEADER_CONTROLS_CLASS}>
-							<ChartTypeToggle
-								chartType={mcpVolumeChartType}
-								onToggle={onMcpVolumeChartToggle}
-								data-testid="dashboard-mcp-volume-chart-toggle"
-							/>
-						</div>
+				totalLabel="Total"
+				total={mcpVolumeTotal !== null ? <NumberFlow value={mcpVolumeTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+				legend={
+					<div className={CHART_HEADER_LEGEND_CLASS}>
+						<span className="flex items-center gap-1">
+							<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.success }} />
+							<span className="text-muted-foreground">Success</span>
+						</span>
+						<span className="flex items-center gap-1">
+							<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.error }} />
+							<span className="text-muted-foreground">Error</span>
+						</span>
 					</div>
+				}
+				controls={
+					<ChartTypeToggle
+						chartType={mcpVolumeChartType}
+						onToggle={onMcpVolumeChartToggle}
+						data-testid="dashboard-mcp-volume-chart-toggle"
+					/>
 				}
 			>
 				<MCPVolumeChart data={mcpHistogramData} chartType={mcpVolumeChartType} startTime={startTime} endTime={endTime} />
@@ -82,25 +99,33 @@ function MCPTabImpl({
 				title="MCP Cost"
 				loading={loadingMcpCost}
 				testId="chart-mcp-cost"
-				headerActions={
-					<div className={CHART_HEADER_ACTIONS_CLASS}>
-						<div className={CHART_HEADER_LEGEND_CLASS}>
-							<span className="flex items-center gap-1">
-								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.cost }} />
-								<span className="text-muted-foreground">Cost</span>
-							</span>
-						</div>
-						<div className={CHART_HEADER_CONTROLS_CLASS}>
-							<ChartTypeToggle chartType={mcpCostChartType} onToggle={onMcpCostChartToggle} data-testid="dashboard-mcp-cost-chart-toggle" />
-						</div>
+				totalLabel="Total"
+				total={
+					mcpCostTotal !== null ? (
+						<NumberFlow value={mcpCostTotal} format={{ ...COMPACT_NUMBER_FORMAT, style: "currency", currency: "USD" }} />
+					) : undefined
+				}
+				legend={
+					<div className={CHART_HEADER_LEGEND_CLASS}>
+						<span className="flex items-center gap-1">
+							<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.cost }} />
+							<span className="text-muted-foreground">Cost</span>
+						</span>
 					</div>
 				}
+				controls={<ChartTypeToggle chartType={mcpCostChartType} onToggle={onMcpCostChartToggle} data-testid="dashboard-mcp-cost-chart-toggle" />}
 			>
 				<MCPCostChart data={mcpCostData} chartType={mcpCostChartType} startTime={startTime} endTime={endTime} />
 			</ChartCard>
 
 			{/* Top 10 MCP Tools */}
-			<ChartCard title="Top 10 MCP Tools" loading={loadingMcpTopTools} testId="chart-mcp-top-tools">
+			<ChartCard
+				title="Top 10 MCP Tools"
+				loading={loadingMcpTopTools}
+				testId="chart-mcp-top-tools"
+				totalLabel="Total"
+				total={mcpTopToolsTotal !== null ? <NumberFlow value={mcpTopToolsTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+			>
 				<MCPTopToolsChart data={mcpTopToolsData} />
 			</ChartCard>
 		</div>

--- a/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
+++ b/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
@@ -4,6 +4,8 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import ProviderIcons, { type ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import type { ModelHistogramResponse, ModelRankingEntry, ModelRankingsResponse } from "@/lib/types/logs";
 import { formatCompactNumber as formatNumber } from "@/lib/utils/governance";
+import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
+import NumberFlow from "@number-flow/react";
 import { ArrowDown, ArrowUp, ArrowUpDown, Minus } from "lucide-react";
 import { memo, useCallback, useMemo, useState } from "react";
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
@@ -193,6 +195,17 @@ function TopModelsChart({
 		return { chartData: processed, displayModels: models };
 	}, [modelData]);
 
+	const grandTotal = useMemo(() => {
+		if (!modelData?.buckets) return null;
+		let sum = 0;
+		const models = modelData.models || [];
+		for (const b of modelData.buckets) {
+			if (!b.by_model) continue;
+			for (const m of models) sum += b.by_model[m]?.total ?? 0;
+		}
+		return sum;
+	}, [modelData]);
+
 	// Compute totals per model for the ranked legend (aggregate across providers)
 	const modelTotals = useMemo(() => {
 		if (!rankingsData?.rankings) return [];
@@ -213,7 +226,14 @@ function TopModelsChart({
 	}, [rankingsData, displayModels]);
 
 	return (
-		<ChartCard title="Top Models" loading={loadingModels} testId="dashboard-rankings-top-models" className="z-[1] h-full">
+		<ChartCard
+			title="Top Models"
+			loading={loadingModels}
+			testId="dashboard-rankings-top-models"
+			className="z-[1] h-full"
+			totalLabel="Total"
+			total={grandTotal !== null ? <NumberFlow value={grandTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+		>
 			<div style={{ height: 200, marginBottom: 6 }}>
 				{chartData.length > 0 ? (
 					<ChartErrorBoundary resetKey={`${startTime}-${endTime}-${chartData.length}`}>

--- a/ui/app/workspace/dashboard/components/overviewTab.tsx
+++ b/ui/app/workspace/dashboard/components/overviewTab.tsx
@@ -1,5 +1,6 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { memo } from "react";
+import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
+import NumberFlow from "@number-flow/react";
 import type {
 	CostHistogramResponse,
 	LatencyHistogramResponse,
@@ -8,20 +9,14 @@ import type {
 	ModelHistogramResponse,
 	TokenHistogramResponse,
 } from "@/lib/types/logs";
-import {
-	CHART_COLORS,
-	CHART_HEADER_ACTIONS_CLASS,
-	CHART_HEADER_CONTROLS_CLASS,
-	CHART_HEADER_LEGEND_CLASS,
-	LATENCY_COLORS,
-	getModelColor,
-} from "../utils/chartUtils";
-import ExternalCacheTokenMeterChart from "./charts/externalCacheTokenMeterChart";
-import LocalCacheTokenMeterChart from "./charts/localCacheTokenMeterChart";
+import { memo, useMemo } from "react";
+import { CHART_COLORS, CHART_HEADER_LEGEND_CLASS, LATENCY_COLORS, getModelColor } from "../utils/chartUtils";
 import { ChartCard } from "./charts/chartCard";
 import { type ChartType, ChartTypeToggle } from "./charts/chartTypeToggle";
 import { CostChart } from "./charts/costChart";
+import ExternalCacheTokenMeterChart from "./charts/externalCacheTokenMeterChart";
 import { LatencyChart } from "./charts/latencyChart";
+import LocalCacheTokenMeterChart from "./charts/localCacheTokenMeterChart";
 import { LogVolumeChart } from "./charts/logVolumeChart";
 import { ModelFilterSelect } from "./charts/modelFilterSelect";
 import { ModelUsageChart } from "./charts/modelUsageChart";
@@ -109,6 +104,50 @@ function OverviewTabImpl({
 	onCostModelChange,
 	onUsageModelChange,
 }: OverviewTabProps) {
+	const volumeTotal = useMemo(() => {
+		if (!histogramData?.buckets) return null;
+		return histogramData.buckets.reduce((sum, b) => sum + (b.count ?? 0), 0);
+	}, [histogramData]);
+
+	const tokenTotal = useMemo(() => {
+		if (!tokenData?.buckets) return null;
+		return tokenData.buckets.reduce((sum, b) => sum + (b.total_tokens ?? 0), 0);
+	}, [tokenData]);
+
+	const costTotal = useMemo(() => {
+		if (!costData?.buckets) return null;
+		if (costModel === "all") {
+			return costData.buckets.reduce((sum, b) => sum + (b.total_cost ?? 0), 0);
+		}
+		return costData.buckets.reduce((sum, b) => sum + (b.by_model?.[costModel] ?? 0), 0);
+	}, [costData, costModel]);
+
+	const modelUsageTotal = useMemo(() => {
+		if (!modelData?.buckets) return null;
+		if (usageModel === "all") {
+			let sum = 0;
+			for (const b of modelData.buckets) {
+				if (!b.by_model) continue;
+				for (const m of modelData.models) sum += b.by_model[m]?.total ?? 0;
+			}
+			return sum;
+		}
+		return modelData.buckets.reduce((sum, b) => sum + (b.by_model?.[usageModel]?.total ?? 0), 0);
+	}, [modelData, usageModel]);
+
+	const latencyAvg = useMemo(() => {
+		if (!latencyData?.buckets || latencyData.buckets.length === 0) return null;
+		let weighted = 0;
+		let count = 0;
+		for (const b of latencyData.buckets) {
+			const reqs = b.total_requests ?? 0;
+			if (reqs === 0) continue;
+			weighted += (b.avg_latency ?? 0) * reqs;
+			count += reqs;
+		}
+		return count > 0 ? weighted / count : null;
+	}, [latencyData]);
+
 	return (
 		<>
 			{/* Charts Grid */}
@@ -118,23 +157,21 @@ function OverviewTabImpl({
 					title="Request Volume"
 					loading={loadingHistogram}
 					testId="chart-log-volume"
-					headerActions={
-						<div className={CHART_HEADER_ACTIONS_CLASS}>
-							<div className={CHART_HEADER_LEGEND_CLASS}>
-								<span className="flex items-center gap-1">
-									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.success }} />
-									<span className="text-muted-foreground">Success</span>
-								</span>
-								<span className="flex items-center gap-1">
-									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.error }} />
-									<span className="text-muted-foreground">Error</span>
-								</span>
-							</div>
-							<div className={CHART_HEADER_CONTROLS_CLASS}>
-								<ChartTypeToggle chartType={volumeChartType} onToggle={onVolumeChartToggle} data-testid="dashboard-volume-chart-toggle" />
-							</div>
+					totalLabel="Total"
+					total={volumeTotal !== null ? <NumberFlow value={volumeTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+					legend={
+						<div className={CHART_HEADER_LEGEND_CLASS}>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.success }} />
+								<span className="text-muted-foreground">Success</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.error }} />
+								<span className="text-muted-foreground">Error</span>
+							</span>
 						</div>
 					}
+					controls={<ChartTypeToggle chartType={volumeChartType} onToggle={onVolumeChartToggle} data-testid="dashboard-volume-chart-toggle" />}
 				>
 					<LogVolumeChart data={histogramData} chartType={volumeChartType} startTime={startTime} endTime={endTime} />
 				</ChartCard>
@@ -144,27 +181,25 @@ function OverviewTabImpl({
 					title="Token Usage"
 					loading={loadingTokens}
 					testId="chart-token-usage"
-					headerActions={
-						<div className={CHART_HEADER_ACTIONS_CLASS}>
-							<div className={CHART_HEADER_LEGEND_CLASS}>
-								<span className="flex items-center gap-1">
-									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.promptTokens }} />
-									<span className="text-muted-foreground">Input</span>
-								</span>
-								<span className="flex items-center gap-1">
-									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.completionTokens }} />
-									<span className="text-muted-foreground">Output</span>
-								</span>
-								<span className="flex items-center gap-1">
-									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.cachedReadTokens }} />
-									<span className="text-muted-foreground">Cached</span>
-								</span>
-							</div>
-							<div className={CHART_HEADER_CONTROLS_CLASS}>
-								<ChartTypeToggle chartType={tokenChartType} onToggle={onTokenChartToggle} data-testid="dashboard-token-chart-toggle" />
-							</div>
+					totalLabel="Total"
+					total={tokenTotal !== null ? <NumberFlow value={tokenTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+					legend={
+						<div className={CHART_HEADER_LEGEND_CLASS}>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.promptTokens }} />
+								<span className="text-muted-foreground">Input</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.completionTokens }} />
+								<span className="text-muted-foreground">Output</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.cachedReadTokens }} />
+								<span className="text-muted-foreground">Cached</span>
+							</span>
 						</div>
 					}
+					controls={<ChartTypeToggle chartType={tokenChartType} onToggle={onTokenChartToggle} data-testid="dashboard-token-chart-toggle" />}
 				>
 					<TokenUsageChart data={tokenData} chartType={tokenChartType} startTime={startTime} endTime={endTime} />
 				</ChartCard>
@@ -184,69 +219,75 @@ function OverviewTabImpl({
 					title="Cost"
 					loading={loadingCost}
 					testId="chart-cost-total"
-					headerActions={
-						<div className={CHART_HEADER_ACTIONS_CLASS}>
-							<div className={CHART_HEADER_LEGEND_CLASS}>
-								{costModel === "all" ? (
-									costModels.length > 0 && (
-										<>
+					totalLabel="Total"
+					total={
+						costTotal !== null ? (
+							<NumberFlow value={costTotal} format={{ ...COMPACT_NUMBER_FORMAT, style: "currency", currency: "USD" }} />
+						) : undefined
+					}
+					legend={
+						<div className={CHART_HEADER_LEGEND_CLASS}>
+							{costModel === "all" ? (
+								costModels.length > 0 && (
+									<>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<span tabIndex={0} data-testid="cost-legend-trigger" className="flex items-center gap-1">
+													<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
+													<span className="text-muted-foreground max-w-[100px] truncate">{costModels[0]}</span>
+												</span>
+											</TooltipTrigger>
+											<TooltipContent>{costModels[0]}</TooltipContent>
+										</Tooltip>
+										{costModels.length > 1 && (
 											<Tooltip>
 												<TooltipTrigger asChild>
-													<span tabIndex={0} data-testid="cost-legend-trigger" className="flex items-center gap-1">
-														<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
-														<span className="text-muted-foreground max-w-[100px] truncate">{costModels[0]}</span>
+													<span tabIndex={0} data-testid="cost-legend-more-trigger" className="text-muted-foreground cursor-default">
+														+{costModels.length - 1} more
 													</span>
 												</TooltipTrigger>
-												<TooltipContent>{costModels[0]}</TooltipContent>
+												<TooltipContent>
+													<div className="flex flex-col gap-1">
+														{costModels.slice(1).map((model, idx) => (
+															<span key={model} className="flex items-center gap-1">
+																<span
+																	className="h-2 w-2 shrink-0 rounded-full"
+																	style={{
+																		backgroundColor: getModelColor(idx + 1),
+																	}}
+																/>
+																{model}
+															</span>
+														))}
+													</div>
+												</TooltipContent>
 											</Tooltip>
-											{costModels.length > 1 && (
-												<Tooltip>
-													<TooltipTrigger asChild>
-														<span tabIndex={0} data-testid="cost-legend-more-trigger" className="text-muted-foreground cursor-default">
-															+{costModels.length - 1} more
-														</span>
-													</TooltipTrigger>
-													<TooltipContent>
-														<div className="flex flex-col gap-1">
-															{costModels.slice(1).map((model, idx) => (
-																<span key={model} className="flex items-center gap-1">
-																	<span
-																		className="h-2 w-2 shrink-0 rounded-full"
-																		style={{
-																			backgroundColor: getModelColor(idx + 1),
-																		}}
-																	/>
-																	{model}
-																</span>
-															))}
-														</div>
-													</TooltipContent>
-												</Tooltip>
-											)}
-										</>
-									)
-								) : (
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<span tabIndex={0} data-testid="cost-legend-single-trigger" className="flex items-center gap-1">
-												<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
-												<span className="text-muted-foreground max-w-[100px] truncate">{costModel}</span>
-											</span>
-										</TooltipTrigger>
-										<TooltipContent>{costModel}</TooltipContent>
-									</Tooltip>
-								)}
-							</div>
-							<div className={CHART_HEADER_CONTROLS_CLASS}>
-								<ModelFilterSelect
-									models={availableModels}
-									selectedModel={costModel}
-									onModelChange={onCostModelChange}
-									data-testid="dashboard-cost-model-filter"
-								/>
-								<ChartTypeToggle chartType={costChartType} onToggle={onCostChartToggle} data-testid="dashboard-cost-chart-toggle" />
-							</div>
+										)}
+									</>
+								)
+							) : (
+								<Tooltip>
+									<TooltipTrigger asChild>
+										<span tabIndex={0} data-testid="cost-legend-single-trigger" className="flex items-center gap-1">
+											<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
+											<span className="text-muted-foreground max-w-[100px] truncate">{costModel}</span>
+										</span>
+									</TooltipTrigger>
+									<TooltipContent>{costModel}</TooltipContent>
+								</Tooltip>
+							)}
 						</div>
+					}
+					controls={
+						<>
+							<ModelFilterSelect
+								models={availableModels}
+								selectedModel={costModel}
+								onModelChange={onCostModelChange}
+								data-testid="dashboard-cost-model-filter"
+							/>
+							<ChartTypeToggle chartType={costChartType} onToggle={onCostChartToggle} data-testid="dashboard-cost-chart-toggle" />
+						</>
 					}
 				>
 					<CostChart data={costData} chartType={costChartType} startTime={startTime} endTime={endTime} selectedModel={costModel} />
@@ -257,70 +298,72 @@ function OverviewTabImpl({
 					title="Model Usage"
 					loading={loadingModels}
 					testId="chart-model-usage"
-					headerActions={
-						<div className={CHART_HEADER_ACTIONS_CLASS}>
-							<div className={CHART_HEADER_LEGEND_CLASS}>
-								{usageModel === "all" ? (
-									usageModels.length > 0 && (
-										<>
+					totalLabel="Total"
+					total={modelUsageTotal !== null ? <NumberFlow value={modelUsageTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+					legend={
+						<div className={CHART_HEADER_LEGEND_CLASS}>
+							{usageModel === "all" ? (
+								usageModels.length > 0 && (
+									<>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<span tabIndex={0} data-testid="usage-legend-trigger" className="flex items-center gap-1">
+													<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
+													<span className="text-muted-foreground max-w-[100px] truncate">{usageModels[0]}</span>
+												</span>
+											</TooltipTrigger>
+											<TooltipContent>{usageModels[0]}</TooltipContent>
+										</Tooltip>
+										{usageModels.length > 1 && (
 											<Tooltip>
 												<TooltipTrigger asChild>
-													<span tabIndex={0} data-testid="usage-legend-trigger" className="flex items-center gap-1">
-														<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
-														<span className="text-muted-foreground max-w-[100px] truncate">{usageModels[0]}</span>
+													<span tabIndex={0} data-testid="usage-legend-more-trigger" className="text-muted-foreground cursor-default">
+														+{usageModels.length - 1} more
 													</span>
 												</TooltipTrigger>
-												<TooltipContent>{usageModels[0]}</TooltipContent>
+												<TooltipContent>
+													<div className="flex flex-col gap-1">
+														{usageModels.slice(1).map((model, idx) => (
+															<span key={model} className="flex items-center gap-1">
+																<span
+																	className="h-2 w-2 shrink-0 rounded-full"
+																	style={{
+																		backgroundColor: getModelColor(idx + 1),
+																	}}
+																/>
+																{model}
+															</span>
+														))}
+													</div>
+												</TooltipContent>
 											</Tooltip>
-											{usageModels.length > 1 && (
-												<Tooltip>
-													<TooltipTrigger asChild>
-														<span tabIndex={0} data-testid="usage-legend-more-trigger" className="text-muted-foreground cursor-default">
-															+{usageModels.length - 1} more
-														</span>
-													</TooltipTrigger>
-													<TooltipContent>
-														<div className="flex flex-col gap-1">
-															{usageModels.slice(1).map((model, idx) => (
-																<span key={model} className="flex items-center gap-1">
-																	<span
-																		className="h-2 w-2 shrink-0 rounded-full"
-																		style={{
-																			backgroundColor: getModelColor(idx + 1),
-																		}}
-																	/>
-																	{model}
-																</span>
-															))}
-														</div>
-													</TooltipContent>
-												</Tooltip>
-											)}
-										</>
-									)
-								) : (
-									<>
-										<span className="flex items-center gap-1">
-											<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: CHART_COLORS.success }} />
-											<span className="text-muted-foreground">Success</span>
-										</span>
-										<span className="flex items-center gap-1">
-											<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: CHART_COLORS.error }} />
-											<span className="text-muted-foreground">Error</span>
-										</span>
+										)}
 									</>
-								)}
-							</div>
-							<div className={CHART_HEADER_CONTROLS_CLASS}>
-								<ModelFilterSelect
-									models={availableModels}
-									selectedModel={usageModel}
-									onModelChange={onUsageModelChange}
-									data-testid="dashboard-usage-model-filter"
-								/>
-								<ChartTypeToggle chartType={modelChartType} onToggle={onModelChartToggle} data-testid="dashboard-usage-chart-toggle" />
-							</div>
+								)
+							) : (
+								<>
+									<span className="flex items-center gap-1">
+										<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: CHART_COLORS.success }} />
+										<span className="text-muted-foreground">Success</span>
+									</span>
+									<span className="flex items-center gap-1">
+										<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: CHART_COLORS.error }} />
+										<span className="text-muted-foreground">Error</span>
+									</span>
+								</>
+							)}
 						</div>
+					}
+					controls={
+						<>
+							<ModelFilterSelect
+								models={availableModels}
+								selectedModel={usageModel}
+								onModelChange={onUsageModelChange}
+								data-testid="dashboard-usage-model-filter"
+							/>
+							<ChartTypeToggle chartType={modelChartType} onToggle={onModelChartToggle} data-testid="dashboard-usage-chart-toggle" />
+						</>
 					}
 				>
 					<ModelUsageChart data={modelData} chartType={modelChartType} startTime={startTime} endTime={endTime} selectedModel={usageModel} />
@@ -331,34 +374,38 @@ function OverviewTabImpl({
 					title="Latency"
 					loading={loadingLatency}
 					testId="chart-latency"
-					headerActions={
-						<div className={CHART_HEADER_ACTIONS_CLASS}>
-							<div className={CHART_HEADER_LEGEND_CLASS}>
-								<span className="flex items-center gap-1">
-									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.avg }} />
-									<span className="text-muted-foreground">Avg</span>
-								</span>
-								<span className="flex items-center gap-1">
-									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p90 }} />
-									<span className="text-muted-foreground">P90</span>
-								</span>
-								<span className="flex items-center gap-1">
-									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p95 }} />
-									<span className="text-muted-foreground">P95</span>
-								</span>
-								<span className="flex items-center gap-1">
-									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p99 }} />
-									<span className="text-muted-foreground">P99</span>
-								</span>
-							</div>
-							<div className={CHART_HEADER_CONTROLS_CLASS}>
-								<ChartTypeToggle
-									chartType={latencyChartType}
-									onToggle={onLatencyChartToggle}
-									data-testid="dashboard-latency-chart-toggle"
-								/>
-							</div>
+					totalLabel="Avg"
+					total={
+						latencyAvg !== null ? (
+							<NumberFlow value={latencyAvg} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="ms" />
+						) : undefined
+					}
+					legend={
+						<div className={CHART_HEADER_LEGEND_CLASS}>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.avg }} />
+								<span className="text-muted-foreground">Avg</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p90 }} />
+								<span className="text-muted-foreground">P90</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p95 }} />
+								<span className="text-muted-foreground">P95</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p99 }} />
+								<span className="text-muted-foreground">P99</span>
+							</span>
 						</div>
+					}
+					controls={
+						<ChartTypeToggle
+							chartType={latencyChartType}
+							onToggle={onLatencyChartToggle}
+							data-testid="dashboard-latency-chart-toggle"
+						/>
 					}
 				>
 					<LatencyChart data={latencyData} chartType={latencyChartType} startTime={startTime} endTime={endTime} />

--- a/ui/app/workspace/dashboard/components/providerUsageTab.tsx
+++ b/ui/app/workspace/dashboard/components/providerUsageTab.tsx
@@ -1,14 +1,9 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { memo } from "react";
+import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
+import NumberFlow from "@number-flow/react";
+import { memo, useMemo } from "react";
 import type { ProviderCostHistogramResponse, ProviderLatencyHistogramResponse, ProviderTokenHistogramResponse } from "@/lib/types/logs";
-import {
-	CHART_COLORS,
-	CHART_HEADER_ACTIONS_CLASS,
-	CHART_HEADER_CONTROLS_CLASS,
-	CHART_HEADER_LEGEND_CLASS,
-	LATENCY_COLORS,
-	getModelColor,
-} from "../utils/chartUtils";
+import { CHART_COLORS, CHART_HEADER_LEGEND_CLASS, LATENCY_COLORS, getModelColor } from "../utils/chartUtils";
 import { ChartCard } from "./charts/chartCard";
 import { type ChartType, ChartTypeToggle } from "./charts/chartTypeToggle";
 import { ProviderCostChart } from "./charts/providerCostChart";
@@ -84,6 +79,45 @@ function ProviderUsageTabImpl({
 	onProviderTokenProviderChange,
 	onProviderLatencyProviderChange,
 }: ProviderUsageTabProps) {
+	const providerCostTotal = useMemo(() => {
+		if (!providerCostData?.buckets) return null;
+		if (providerCostProvider === "all") {
+			return providerCostData.buckets.reduce((sum, b) => sum + (b.total_cost ?? 0), 0);
+		}
+		return providerCostData.buckets.reduce((sum, b) => sum + (b.by_provider?.[providerCostProvider] ?? 0), 0);
+	}, [providerCostData, providerCostProvider]);
+
+	const providerTokenTotal = useMemo(() => {
+		if (!providerTokenData?.buckets) return null;
+		let sum = 0;
+		for (const b of providerTokenData.buckets) {
+			if (!b.by_provider) continue;
+			if (providerTokenProvider === "all") {
+				for (const p of providerTokenData.providers) sum += b.by_provider[p]?.total_tokens ?? 0;
+			} else {
+				sum += b.by_provider[providerTokenProvider]?.total_tokens ?? 0;
+			}
+		}
+		return sum;
+	}, [providerTokenData, providerTokenProvider]);
+
+	const providerLatencyAvg = useMemo(() => {
+		if (!providerLatencyData?.buckets) return null;
+		let weighted = 0;
+		let count = 0;
+		for (const b of providerLatencyData.buckets) {
+			if (!b.by_provider) continue;
+			const providers = providerLatencyProvider === "all" ? providerLatencyData.providers : [providerLatencyProvider];
+			for (const p of providers) {
+				const s = b.by_provider[p];
+				if (!s || !s.total_requests) continue;
+				weighted += (s.avg_latency ?? 0) * s.total_requests;
+				count += s.total_requests;
+			}
+		}
+		return count > 0 ? weighted / count : null;
+	}, [providerLatencyData, providerLatencyProvider]);
+
 	return (
 		<div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
 			{/* Provider Cost Chart */}
@@ -91,72 +125,78 @@ function ProviderUsageTabImpl({
 				title="Provider Cost"
 				loading={loadingProviderCost}
 				testId="chart-provider-cost"
-				headerActions={
-					<div className={CHART_HEADER_ACTIONS_CLASS}>
-						<div className={CHART_HEADER_LEGEND_CLASS}>
-							{providerCostProvider === "all" ? (
-								providerCostProviders.length > 0 && (
-									<>
+				totalLabel="Total"
+				total={
+					providerCostTotal !== null ? (
+						<NumberFlow value={providerCostTotal} format={{ ...COMPACT_NUMBER_FORMAT, style: "currency", currency: "USD" }} />
+					) : undefined
+				}
+				legend={
+					<div className={CHART_HEADER_LEGEND_CLASS}>
+						{providerCostProvider === "all" ? (
+							providerCostProviders.length > 0 && (
+								<>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span data-testid="provider-cost-legend-trigger" className="flex items-center gap-1">
+												<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
+												<span className="text-muted-foreground max-w-[100px] truncate">{providerCostProviders[0]}</span>
+											</span>
+										</TooltipTrigger>
+										<TooltipContent>{providerCostProviders[0]}</TooltipContent>
+									</Tooltip>
+									{providerCostProviders.length > 1 && (
 										<Tooltip>
 											<TooltipTrigger asChild>
-												<span data-testid="provider-cost-legend-trigger" className="flex items-center gap-1">
-													<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
-													<span className="text-muted-foreground max-w-[100px] truncate">{providerCostProviders[0]}</span>
-												</span>
+												<button
+													type="button"
+													data-testid="provider-cost-legend-more-trigger"
+													className="text-muted-foreground cursor-default"
+												>
+													+{providerCostProviders.length - 1} more
+												</button>
 											</TooltipTrigger>
-											<TooltipContent>{providerCostProviders[0]}</TooltipContent>
+											<TooltipContent>
+												<div className="flex flex-col gap-1">
+													{providerCostProviders.slice(1).map((provider, idx) => (
+														<span key={provider} className="flex items-center gap-1">
+															<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(idx + 1) }} />
+															{provider}
+														</span>
+													))}
+												</div>
+											</TooltipContent>
 										</Tooltip>
-										{providerCostProviders.length > 1 && (
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<button
-														type="button"
-														data-testid="provider-cost-legend-more-trigger"
-														className="text-muted-foreground cursor-default"
-													>
-														+{providerCostProviders.length - 1} more
-													</button>
-												</TooltipTrigger>
-												<TooltipContent>
-													<div className="flex flex-col gap-1">
-														{providerCostProviders.slice(1).map((provider, idx) => (
-															<span key={provider} className="flex items-center gap-1">
-																<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(idx + 1) }} />
-																{provider}
-															</span>
-														))}
-													</div>
-												</TooltipContent>
-											</Tooltip>
-										)}
-									</>
-								)
-							) : (
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<span data-testid="provider-cost-legend-single-trigger" className="flex items-center gap-1">
-											<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
-											<span className="text-muted-foreground max-w-[100px] truncate">{providerCostProvider}</span>
-										</span>
-									</TooltipTrigger>
-									<TooltipContent>{providerCostProvider}</TooltipContent>
-								</Tooltip>
-							)}
-						</div>
-						<div className={CHART_HEADER_CONTROLS_CLASS}>
-							<ProviderFilterSelect
-								providers={availableProviders}
-								selectedProvider={providerCostProvider}
-								onProviderChange={onProviderCostProviderChange}
-								data-testid="dashboard-provider-cost-filter"
-							/>
-							<ChartTypeToggle
-								chartType={providerCostChartType}
-								onToggle={onProviderCostChartToggle}
-								data-testid="dashboard-provider-cost-chart-toggle"
-							/>
-						</div>
+									)}
+								</>
+							)
+						) : (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<span data-testid="provider-cost-legend-single-trigger" className="flex items-center gap-1">
+										<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
+										<span className="text-muted-foreground max-w-[100px] truncate">{providerCostProvider}</span>
+									</span>
+								</TooltipTrigger>
+								<TooltipContent>{providerCostProvider}</TooltipContent>
+							</Tooltip>
+						)}
 					</div>
+				}
+				controls={
+					<>
+						<ProviderFilterSelect
+							providers={availableProviders}
+							selectedProvider={providerCostProvider}
+							onProviderChange={onProviderCostProviderChange}
+							data-testid="dashboard-provider-cost-filter"
+						/>
+						<ChartTypeToggle
+							chartType={providerCostChartType}
+							onToggle={onProviderCostChartToggle}
+							data-testid="dashboard-provider-cost-chart-toggle"
+						/>
+					</>
 				}
 			>
 				<ProviderCostChart
@@ -173,73 +213,75 @@ function ProviderUsageTabImpl({
 				title="Provider Token Usage"
 				loading={loadingProviderTokens}
 				testId="chart-provider-tokens"
-				headerActions={
-					<div className={CHART_HEADER_ACTIONS_CLASS}>
-						<div className={CHART_HEADER_LEGEND_CLASS}>
-							{providerTokenProvider === "all" ? (
-								providerTokenProviders.length > 0 && (
-									<>
+				totalLabel="Total"
+				total={providerTokenTotal !== null ? <NumberFlow value={providerTokenTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+				legend={
+					<div className={CHART_HEADER_LEGEND_CLASS}>
+						{providerTokenProvider === "all" ? (
+							providerTokenProviders.length > 0 && (
+								<>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span data-testid="provider-token-legend-trigger" className="flex items-center gap-1">
+												<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
+												<span className="text-muted-foreground max-w-[100px] truncate">{providerTokenProviders[0]}</span>
+											</span>
+										</TooltipTrigger>
+										<TooltipContent>{providerTokenProviders[0]}</TooltipContent>
+									</Tooltip>
+									{providerTokenProviders.length > 1 && (
 										<Tooltip>
 											<TooltipTrigger asChild>
-												<span data-testid="provider-token-legend-trigger" className="flex items-center gap-1">
-													<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
-													<span className="text-muted-foreground max-w-[100px] truncate">{providerTokenProviders[0]}</span>
-												</span>
+												<button
+													type="button"
+													data-testid="provider-token-legend-more-trigger"
+													className="text-muted-foreground cursor-default"
+												>
+													+{providerTokenProviders.length - 1} more
+												</button>
 											</TooltipTrigger>
-											<TooltipContent>{providerTokenProviders[0]}</TooltipContent>
+											<TooltipContent>
+												<div className="flex flex-col gap-1">
+													{providerTokenProviders.slice(1).map((provider, idx) => (
+														<span key={provider} className="flex items-center gap-1">
+															<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(idx + 1) }} />
+															{provider}
+														</span>
+													))}
+												</div>
+											</TooltipContent>
 										</Tooltip>
-										{providerTokenProviders.length > 1 && (
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<button
-														type="button"
-														data-testid="provider-token-legend-more-trigger"
-														className="text-muted-foreground cursor-default"
-													>
-														+{providerTokenProviders.length - 1} more
-													</button>
-												</TooltipTrigger>
-												<TooltipContent>
-													<div className="flex flex-col gap-1">
-														{providerTokenProviders.slice(1).map((provider, idx) => (
-															<span key={provider} className="flex items-center gap-1">
-																<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(idx + 1) }} />
-																{provider}
-															</span>
-														))}
-													</div>
-												</TooltipContent>
-											</Tooltip>
-										)}
-									</>
-								)
-							) : (
-								<>
-									<span className="flex items-center gap-1">
-										<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: CHART_COLORS.promptTokens }} />
-										<span className="text-muted-foreground">Input</span>
-									</span>
-									<span className="flex items-center gap-1">
-										<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: CHART_COLORS.completionTokens }} />
-										<span className="text-muted-foreground">Output</span>
-									</span>
+									)}
 								</>
-							)}
-						</div>
-						<div className={CHART_HEADER_CONTROLS_CLASS}>
-							<ProviderFilterSelect
-								providers={availableProviders}
-								selectedProvider={providerTokenProvider}
-								onProviderChange={onProviderTokenProviderChange}
-								data-testid="dashboard-provider-token-filter"
-							/>
-							<ChartTypeToggle
-								chartType={providerTokenChartType}
-								onToggle={onProviderTokenChartToggle}
-								data-testid="dashboard-provider-token-chart-toggle"
-							/>
-						</div>
+							)
+						) : (
+							<>
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: CHART_COLORS.promptTokens }} />
+									<span className="text-muted-foreground">Input</span>
+								</span>
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: CHART_COLORS.completionTokens }} />
+									<span className="text-muted-foreground">Output</span>
+								</span>
+							</>
+						)}
 					</div>
+				}
+				controls={
+					<>
+						<ProviderFilterSelect
+							providers={availableProviders}
+							selectedProvider={providerTokenProvider}
+							onProviderChange={onProviderTokenProviderChange}
+							data-testid="dashboard-provider-token-filter"
+						/>
+						<ChartTypeToggle
+							chartType={providerTokenChartType}
+							onToggle={onProviderTokenChartToggle}
+							data-testid="dashboard-provider-token-chart-toggle"
+						/>
+					</>
 				}
 			>
 				<ProviderTokenChart
@@ -256,81 +298,87 @@ function ProviderUsageTabImpl({
 				title="Provider Latency"
 				loading={loadingProviderLatency}
 				testId="chart-provider-latency"
-				headerActions={
-					<div className={CHART_HEADER_ACTIONS_CLASS}>
-						<div className={CHART_HEADER_LEGEND_CLASS}>
-							{providerLatencyProvider === "all" ? (
-								providerLatencyProviders.length > 0 && (
-									<>
+				totalLabel="Avg"
+				total={
+					providerLatencyAvg !== null ? (
+						<NumberFlow value={providerLatencyAvg} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="ms" />
+					) : undefined
+				}
+				legend={
+					<div className={CHART_HEADER_LEGEND_CLASS}>
+						{providerLatencyProvider === "all" ? (
+							providerLatencyProviders.length > 0 && (
+								<>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span data-testid="provider-latency-legend-trigger" className="flex items-center gap-1">
+												<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
+												<span className="text-muted-foreground max-w-[100px] truncate">{providerLatencyProviders[0]}</span>
+											</span>
+										</TooltipTrigger>
+										<TooltipContent>{providerLatencyProviders[0]}</TooltipContent>
+									</Tooltip>
+									{providerLatencyProviders.length > 1 && (
 										<Tooltip>
 											<TooltipTrigger asChild>
-												<span data-testid="provider-latency-legend-trigger" className="flex items-center gap-1">
-													<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(0) }} />
-													<span className="text-muted-foreground max-w-[100px] truncate">{providerLatencyProviders[0]}</span>
-												</span>
+												<button
+													type="button"
+													data-testid="provider-latency-legend-more-trigger"
+													className="text-muted-foreground cursor-default"
+												>
+													+{providerLatencyProviders.length - 1} more
+												</button>
 											</TooltipTrigger>
-											<TooltipContent>{providerLatencyProviders[0]}</TooltipContent>
+											<TooltipContent>
+												<div className="flex flex-col gap-1">
+													{providerLatencyProviders.slice(1).map((provider, idx) => (
+														<span key={provider} className="flex items-center gap-1">
+															<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(idx + 1) }} />
+															{provider}
+														</span>
+													))}
+												</div>
+											</TooltipContent>
 										</Tooltip>
-										{providerLatencyProviders.length > 1 && (
-											<Tooltip>
-												<TooltipTrigger asChild>
-													<button
-														type="button"
-														data-testid="provider-latency-legend-more-trigger"
-														className="text-muted-foreground cursor-default"
-													>
-														+{providerLatencyProviders.length - 1} more
-													</button>
-												</TooltipTrigger>
-												<TooltipContent>
-													<div className="flex flex-col gap-1">
-														{providerLatencyProviders.slice(1).map((provider, idx) => (
-															<span key={provider} className="flex items-center gap-1">
-																<span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(idx + 1) }} />
-																{provider}
-															</span>
-														))}
-													</div>
-												</TooltipContent>
-											</Tooltip>
-										)}
-									</>
-								)
-							) : (
-								<>
-									<span className="flex items-center gap-1">
-										<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.avg }} />
-										<span className="text-muted-foreground">Avg</span>
-									</span>
-									<span className="flex items-center gap-1">
-										<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p90 }} />
-										<span className="text-muted-foreground">P90</span>
-									</span>
-									<span className="flex items-center gap-1">
-										<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p95 }} />
-										<span className="text-muted-foreground">P95</span>
-									</span>
-									<span className="flex items-center gap-1">
-										<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p99 }} />
-										<span className="text-muted-foreground">P99</span>
-									</span>
+									)}
 								</>
-							)}
-						</div>
-						<div className={CHART_HEADER_CONTROLS_CLASS}>
-							<ProviderFilterSelect
-								providers={availableProviders}
-								selectedProvider={providerLatencyProvider}
-								onProviderChange={onProviderLatencyProviderChange}
-								data-testid="dashboard-provider-latency-filter"
-							/>
-							<ChartTypeToggle
-								chartType={providerLatencyChartType}
-								onToggle={onProviderLatencyChartToggle}
-								data-testid="dashboard-provider-latency-chart-toggle"
-							/>
-						</div>
+							)
+						) : (
+							<>
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.avg }} />
+									<span className="text-muted-foreground">Avg</span>
+								</span>
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p90 }} />
+									<span className="text-muted-foreground">P90</span>
+								</span>
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p95 }} />
+									<span className="text-muted-foreground">P95</span>
+								</span>
+								<span className="flex items-center gap-1">
+									<span className="h-2 w-2 rounded-full" style={{ backgroundColor: LATENCY_COLORS.p99 }} />
+									<span className="text-muted-foreground">P99</span>
+								</span>
+							</>
+						)}
 					</div>
+				}
+				controls={
+					<>
+						<ProviderFilterSelect
+							providers={availableProviders}
+							selectedProvider={providerLatencyProvider}
+							onProviderChange={onProviderLatencyProviderChange}
+							data-testid="dashboard-provider-latency-filter"
+						/>
+						<ChartTypeToggle
+							chartType={providerLatencyChartType}
+							onToggle={onProviderLatencyChartToggle}
+							data-testid="dashboard-provider-latency-chart-toggle"
+						/>
+					</>
 				}
 			>
 				<ProviderLatencyChart


### PR DESCRIPTION
## Summary

Adds aggregate totals and a weighted average latency metric to each dashboard chart card header, giving users an at-a-glance summary of the data currently displayed in each chart.

## Changes

- Replaced the single `headerActions` prop on `ChartCard` with separate `controls`, `legend`, and `total`/`totalLabel` props, and extracted a `Header` sub-component and `TotalChip` sub-component to render them in a structured layout (title row → total + controls row → legend row).
- Each dashboard tab (Overview, MCP, Provider Usage, Model Rankings) now computes its own aggregate value via `useMemo`:
    - Request Volume, Token Usage, Model Usage, MCP Tool Calls, MCP Top Tools, Provider Token Usage → sum of counts/tokens across all buckets.
    - Cost (MCP, Overview, Provider) → sum of `total_cost` across buckets, respecting the active model/provider filter.
    - Latency (Overview, Provider) → request-count-weighted average of `avg_latency` across buckets.
- Totals are rendered using `NumberFlow` with `COMPACT_NUMBER_FORMAT` for counts, currency formatting for costs, and a fixed two-decimal `ms` suffix for latency averages.
- Y-axis tick formatters across `logVolumeChart`, `mcpVolumeChart`, `mcpTopToolsChart`, and `modelUsageChart` switched from `v.toLocaleString()` to the shared `formatTokens` utility, and axis widths were normalised to 44px.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm build
```

1. Open the dashboard and navigate to the Overview, MCP, Provider Usage, and Model Rankings tabs.
2. Verify each chart card header shows a labelled total (e.g. "Total 1.2k", "Total $0.04", "Avg 312.50ms").
3. Change the model or provider filter on Cost / Model Usage / Provider charts and confirm the displayed total updates to reflect the filtered data.
4. Toggle between bar and area chart types and confirm the total remains consistent.
5. Verify the loading skeleton state still renders correctly without the total chip.

## Screenshots/Recordings

[Screen Recording 2026-05-14 at 6.52.34 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/24c91fe3-6582-42b0-8d98-1aa46f80607c.mov" />](https://app.graphite.com/user-attachments/video/24c91fe3-6582-42b0-8d98-1aa46f80607c.mov)



## Breaking changes

- [x] No

The `headerActions` prop on `ChartCard` has been removed and replaced with `controls`, `legend`, `total`, and `totalLabel`. Any consumers outside this PR that pass `headerActions` will need to be updated.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable