### PR TITLE
feat: add instance-wide global governance (budget + rate limit) with DB migration, API endpoints, and UI

### DIFF
--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -1368,6 +1368,7 @@ type ConfigMap map[schemas.ModelProvider]ProviderConfig
 
 // GovernanceConfig contains governance entities loaded from the config store or
 // reconciled from config.json.
+// Instance-wide (global) budgets and rate limits live in Budgets/RateLimits with IsGlobal=true.
 type GovernanceConfig struct {
 	VirtualKeys      []tables.TableVirtualKey      `json:"virtual_keys"`
 	Teams            []tables.TableTeam            `json:"teams"`

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -796,6 +796,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationRefreshConfigHashAfterMCPExternalServerURLRemoval(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddGlobalGovernanceColumns(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -8538,4 +8541,65 @@ func migrationAddTempTokensTable(ctx context.Context, db *gorm.DB) error {
 		return fmt.Errorf("error running add_temp_tokens_table migration: %s", err.Error())
 	}
 	return nil
+}
+
+// migrationAddGlobalGovernanceColumns adds is_global to governance_budgets and
+// governance_rate_limits so a single instance-wide cap can be stored without a
+// new table, and installs a partial unique index on governance_rate_limits so
+// the DB enforces "at most one global rate limit" under concurrency. Without
+// the index, two simultaneous UpsertGlobalGovernance transactions at READ
+// COMMITTED can both pass through DELETE-WHERE-is_global (when empty) and both
+// INSERT, leaving two global rows. SQLite and Postgres both support partial
+// unique indexes with `WHERE is_global` (boolean column in Postgres, truthy
+// integer in SQLite); MySQL doesn't, but configstore only wires up
+// sqlite/postgres so no dialect guard is needed here.
+func migrationAddGlobalGovernanceColumns(ctx context.Context, db *gorm.DB) error {
+	return RunSingleMigration(ctx, db, &migrator.Migration{
+		ID: "add_global_governance_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TableBudget{}, "is_global") {
+				if err := mg.AddColumn(&tables.TableBudget{}, "is_global"); err != nil {
+					return fmt.Errorf("add is_global to governance_budgets: %w", err)
+				}
+			}
+			if !mg.HasColumn(&tables.TableRateLimit{}, "is_global") {
+				if err := mg.AddColumn(&tables.TableRateLimit{}, "is_global"); err != nil {
+					return fmt.Errorf("add is_global to governance_rate_limits: %w", err)
+				}
+			}
+			// Column is brand-new in this migration so no pre-existing rows can
+			// have is_global=true — dedup is unnecessary, just install the index.
+			if err := tx.Exec(`
+				CREATE UNIQUE INDEX IF NOT EXISTS idx_governance_rate_limits_global
+				ON governance_rate_limits (is_global)
+				WHERE is_global
+			`).Error; err != nil {
+				return fmt.Errorf("create partial unique index on governance_rate_limits.is_global: %w", err)
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			// Drop the index first; Postgres rejects DROP COLUMN on a column
+			// referenced by an index, and SQLite quietly does the same via
+			// table rewrite.
+			if err := tx.Exec(`DROP INDEX IF EXISTS idx_governance_rate_limits_global`).Error; err != nil {
+				return fmt.Errorf("drop partial unique index on governance_rate_limits.is_global: %w", err)
+			}
+			if mg.HasColumn(&tables.TableBudget{}, "is_global") {
+				if err := mg.DropColumn(&tables.TableBudget{}, "is_global"); err != nil {
+					return fmt.Errorf("failed to drop is_global column: %w", err)
+				}
+			}
+			if mg.HasColumn(&tables.TableRateLimit{}, "is_global") {
+				if err := mg.DropColumn(&tables.TableRateLimit{}, "is_global"); err != nil {
+					return fmt.Errorf("failed to drop is_global column: %w", err)
+				}
+			}
+			return nil
+		},
+	})
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3698,6 +3698,77 @@ func (s *RDBConfigStore) UpdateRateLimitUsage(ctx context.Context, id string, to
 	return nil
 }
 
+// GetGlobalBudgets returns all budgets flagged as instance-wide (is_global=true).
+func (s *RDBConfigStore) GetGlobalBudgets(ctx context.Context) ([]tables.TableBudget, error) {
+	var budgets []tables.TableBudget
+	if err := s.DB().WithContext(ctx).Where("is_global = ?", true).Order("created_at ASC").Find(&budgets).Error; err != nil {
+		return nil, err
+	}
+	return budgets, nil
+}
+
+// GetGlobalRateLimit returns the single instance-wide rate limit row (is_global=true), or nil if none is set.
+func (s *RDBConfigStore) GetGlobalRateLimit(ctx context.Context) (*tables.TableRateLimit, error) {
+	var rl tables.TableRateLimit
+	if err := s.DB().WithContext(ctx).Where("is_global = ?", true).First(&rl).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &rl, nil
+}
+
+// UpsertGlobalGovernance replaces all global budgets and the global rate limit in a single transaction.
+// Budgets are matched by reset_duration; the rate limit is replaced wholesale.
+// Rejects duplicate ResetDuration values up-front so we never commit an inconsistent
+// global budget set (no DB-level unique index covers this).
+func (s *RDBConfigStore) UpsertGlobalGovernance(ctx context.Context, budgets []tables.TableBudget, rateLimit *tables.TableRateLimit) error {
+	seenDurations := make(map[string]struct{}, len(budgets))
+	for i := range budgets {
+		if _, ok := seenDurations[budgets[i].ResetDuration]; ok {
+			return fmt.Errorf("duplicate reset_duration in global budgets: %s", budgets[i].ResetDuration)
+		}
+		seenDurations[budgets[i].ResetDuration] = struct{}{}
+	}
+	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Replace global budgets: delete existing then insert new ones.
+		if err := tx.Where("is_global = ?", true).Delete(&tables.TableBudget{}).Error; err != nil {
+			return fmt.Errorf("delete existing global budgets: %w", err)
+		}
+		for i := range budgets {
+			budgets[i].IsGlobal = true
+			if err := tx.Create(&budgets[i]).Error; err != nil {
+				return fmt.Errorf("create global budget (reset_duration=%s): %w", budgets[i].ResetDuration, err)
+			}
+		}
+		// Replace global rate limit.
+		if err := tx.Where("is_global = ?", true).Delete(&tables.TableRateLimit{}).Error; err != nil {
+			return fmt.Errorf("delete existing global rate limit: %w", err)
+		}
+		if rateLimit != nil {
+			rateLimit.IsGlobal = true
+			if err := tx.Create(rateLimit).Error; err != nil {
+				return s.parseGormError(err)
+			}
+		}
+		return nil
+	})
+}
+
+// DeleteGlobalGovernance removes all is_global=true rows from both governance tables.
+func (s *RDBConfigStore) DeleteGlobalGovernance(ctx context.Context) error {
+	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("is_global = ?", true).Delete(&tables.TableBudget{}).Error; err != nil {
+			return fmt.Errorf("delete global budgets: %w", err)
+		}
+		if err := tx.Where("is_global = ?", true).Delete(&tables.TableRateLimit{}).Error; err != nil {
+			return fmt.Errorf("delete global rate limit: %w", err)
+		}
+		return nil
+	})
+}
+
 // loadRoutingRulesOrdered loads routing rules with Targets preloaded, using consistent ordering:
 // rules by priority ASC, created_at DESC, id ASC; targets by weight DESC for deterministic ordering.
 func (s *RDBConfigStore) loadRoutingRulesOrdered(ctx context.Context, dest *[]tables.TableRoutingRule, scopes ...func(*gorm.DB) *gorm.DB) error {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -216,6 +216,12 @@ type ConfigStore interface {
 	UpdateBudgetUsage(ctx context.Context, id string, currentUsage float64) error
 	UpdateRateLimitUsage(ctx context.Context, id string, tokenCurrentUsage int64, requestCurrentUsage int64) error
 
+	// Global governance CRUD (instance-wide cap stored as is_global=true rows)
+	GetGlobalBudgets(ctx context.Context) ([]tables.TableBudget, error)
+	GetGlobalRateLimit(ctx context.Context) (*tables.TableRateLimit, error)
+	UpsertGlobalGovernance(ctx context.Context, budgets []tables.TableBudget, rateLimit *tables.TableRateLimit) error
+	DeleteGlobalGovernance(ctx context.Context) error
+
 	// Routing Rules CRUD
 	GetRoutingRules(ctx context.Context) ([]tables.TableRoutingRule, error)
 	GetRoutingRulesByScope(ctx context.Context, scope string, scopeID string) ([]tables.TableRoutingRule, error)

--- a/framework/configstore/tables/budget.go
+++ b/framework/configstore/tables/budget.go
@@ -15,7 +15,9 @@ type TableBudget struct {
 	LastReset     time.Time `gorm:"index" json:"last_reset"`                         // Last time budget was reset
 	CurrentUsage  float64   `gorm:"default:0" json:"current_usage"`                  // Current usage in dollars
 
-	// Owner FKs: a budget belongs to at most one Team, one VK, or one ProviderConfig
+	// Owner FKs: a budget belongs to at most one Team, one VK, or one ProviderConfig.
+	// When IsGlobal=true all owner FKs must be nil — this is the instance-wide budget.
+	IsGlobal         bool    `gorm:"index;default:false" json:"is_global"`
 	TeamID           *string `gorm:"type:varchar(255);index" json:"team_id,omitempty"`
 	VirtualKeyID     *string `gorm:"type:varchar(255);index" json:"virtual_key_id,omitempty"`
 	ProviderConfigID *uint   `gorm:"index" json:"provider_config_id,omitempty"`
@@ -57,7 +59,11 @@ func (b *TableBudget) BeforeSave(tx *gorm.DB) error {
 	if b.ProviderConfigID != nil {
 		owners++
 	}
-	if owners > 1 {
+	if b.IsGlobal {
+		if owners != 0 {
+			return fmt.Errorf("global budget must not have an owner (team/virtual key/provider config)")
+		}
+	} else if owners > 1 {
 		return fmt.Errorf("budget cannot have more than one owner (team/virtual key/provider config)")
 	}
 	// Validate that ResetDuration is in correct format (e.g., "30s", "5m", "1h", "1d", "1w", "1M", "1Y")

--- a/framework/configstore/tables/ratelimit.go
+++ b/framework/configstore/tables/ratelimit.go
@@ -29,6 +29,8 @@ type TableRateLimit struct {
 	// promote any true value here to the owner's top-level CalendarAligned at
 	// load time.
 	CalendarAlignedInput *bool `gorm:"-" json:"calendar_aligned,omitempty"`
+	// IsGlobal marks this as the instance-wide rate limit. Only one row can have is_global=true,
+	IsGlobal        bool `gorm:"index;default:false" json:"is_global"`
 
 	// Derived from the owning entity. See TableBudget.IsCalendarAligned.
 	IsCalendarAligned bool `gorm:"-" json:"-"`

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1203,8 +1203,21 @@ func (p *GovernancePlugin) EvaluateGovernanceRequest(ctx *schemas.BifrostContext
 	}
 	p.cfgMutex.RUnlock()
 
+	// Read-only metadata calls (e.g. list models) set this flag to skip budget/rate-limit
+	// checks while still enforcing VK identity (existence, active status, provider/model filtering).
+	skipBudgetsAndRateLimits := bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipBudgetAndRateLimits)
+
+	// Step 0: Global limits — instance-wide cap evaluated before any other tier.
+	// When no global limits are configured EvaluateGlobalRequest returns DecisionAllow immediately.
+	var result *EvaluationResult
+	if !skipBudgetsAndRateLimits {
+		result = p.resolver.EvaluateGlobalRequest(ctx)
+	}
+
 	// First evaluate model and provider checks (applies even when virtual keys are disabled or not present)
-	result := p.resolver.EvaluateModelAndProviderRequest(ctx, evaluationRequest.Provider, evaluationRequest.Model)
+	if result == nil || result.Decision == DecisionAllow {
+		result = p.resolver.EvaluateModelAndProviderRequest(ctx, evaluationRequest.Provider, evaluationRequest.Model)
+	}
 
 	// The flow for governance checks is:
 	//   VK (identity + VK-level budget/rate-limit) -> Customer -> Team -> User
@@ -1221,10 +1234,6 @@ func (p *GovernancePlugin) EvaluateGovernanceRequest(ctx *schemas.BifrostContext
 			hierarchyVK = vk
 		}
 	}
-
-	// Read-only metadata calls (e.g. list models) set this flag to skip budget/rate-limit
-	// checks while still enforcing VK identity (existence, active status, provider/model filtering).
-	skipBudgetsAndRateLimits := bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipBudgetAndRateLimits)
 
 	// Step 1: Evaluate virtual key (identity + VK-level budget/rate-limit hierarchy).
 	// Short-circuits with VirtualKeyBlocked / ProviderBlocked / ModelBlocked before

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -78,6 +78,28 @@ func NewBudgetResolver(store GovernanceStore, modelCatalog *modelcatalog.ModelCa
 	}
 }
 
+// EvaluateGlobalRequest checks the instance-wide rate limit and budgets (step 0 of governance).
+// It runs before any provider/model/VK/team/customer/user check. When no global limits are
+// configured it returns DecisionAllow immediately with zero overhead.
+func (r *BudgetResolver) EvaluateGlobalRequest(ctx *schemas.BifrostContext) *EvaluationResult {
+	if decision, err := r.store.CheckGlobalRateLimit(ctx, nil, nil); err != nil || isRateLimitViolation(decision) {
+		return &EvaluationResult{
+			Decision: decision,
+			Reason:   fmt.Sprintf("Global rate limit exceeded: %s", reasonFromErr(err, decision)),
+		}
+	}
+	if decision, err := r.store.CheckGlobalBudget(ctx, nil); err != nil || isBudgetViolation(decision) {
+		return &EvaluationResult{
+			Decision: decision,
+			Reason:   fmt.Sprintf("Global budget exceeded: %s", reasonFromErr(err, decision)),
+		}
+	}
+	return &EvaluationResult{
+		Decision: DecisionAllow,
+		Reason:   "Global checks passed",
+	}
+}
+
 // EvaluateModelAndProviderRequest evaluates provider-level and model-level rate limits and budgets
 // This applies even when virtual keys are disabled or not present
 func (r *BudgetResolver) EvaluateModelAndProviderRequest(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string) *EvaluationResult {

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/cel-go/cel"
@@ -40,6 +41,12 @@ type LocalGovernanceStore struct {
 	LastDBUsagesBudgets              map[string]float64 // Map for last DB usages for budgets
 	LastDBUsagesRequestsRateLimits   map[string]int64   // Map for last DB usages for rate limits requests
 	LastDBUsagesTokensRateLimits     map[string]int64   // Map for last DB usages for rate limits tokens
+
+	// Global governance: instance-wide budget IDs and rate limit ID.
+	// These IDs are keys into the existing gs.budgets / gs.rateLimits maps so
+	// all existing Reset/Dump/Bump machinery handles them automatically.
+	globalBudgetIDs   atomic.Pointer[[]string]
+	globalRateLimitID atomic.Pointer[string]
 
 	// CEL caching layer for routing rules
 	compiledRoutingPrograms sync.Map // string -> cel.Program (key: ruleID -> compiled CEL program)
@@ -185,6 +192,13 @@ type GovernanceStore interface {
 	// reconciliation can attribute cost and tokens to the correct governance
 	// entities.
 	CollectApplicableGovernanceIDs(ctx context.Context, virtualKey string, provider schemas.ModelProvider, model string) (budgetIDs []string, rateLimitIDs []string)
+	// Global governance (instance-wide cap evaluated before all other tiers)
+	CheckGlobalBudget(ctx context.Context, baselines map[string]float64) (Decision, error)
+	CheckGlobalRateLimit(ctx context.Context, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error)
+	UpdateGlobalBudgetUsageInMemory(ctx context.Context, cost float64) error
+	UpdateGlobalRateLimitUsageInMemory(ctx context.Context, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error
+	UpsertGlobalGovernanceInMemory(ctx context.Context, budgets []*configstoreTables.TableBudget, rateLimit *configstoreTables.TableRateLimit)
+	DeleteGlobalGovernanceInMemory(ctx context.Context)
 }
 
 // NewLocalGovernanceStore creates a new in-memory governance store
@@ -1367,6 +1381,139 @@ func (gs *LocalGovernanceStore) UpdateUserRateLimitUsageInMemory(ctx context.Con
 	return nil
 }
 
+// CheckGlobalBudget checks the instance-wide budgets against the current usage.
+// Returns DecisionAllow when no global budgets are configured.
+func (gs *LocalGovernanceStore) CheckGlobalBudget(ctx context.Context, baselines map[string]float64) (Decision, error) {
+	ids := gs.globalBudgetIDs.Load()
+	if ids == nil || len(*ids) == 0 {
+		return DecisionAllow, nil
+	}
+	if baselines == nil {
+		baselines = map[string]float64{}
+	}
+	var budgets []*configstoreTables.TableBudget
+	for _, id := range *ids {
+		if b := gs.LoadBudget(ctx, id); b != nil {
+			budgets = append(budgets, b)
+		}
+	}
+	if len(budgets) == 0 {
+		return DecisionAllow, nil
+	}
+	return gs.CheckBudget(ctx, EntityWiseBudgets{"global": budgets}, baselines)
+}
+
+// CheckGlobalRateLimit checks the instance-wide rate limit against current usage.
+// Returns DecisionAllow when no global rate limit is configured.
+func (gs *LocalGovernanceStore) CheckGlobalRateLimit(ctx context.Context, tokensBaselines map[string]int64, requestsBaselines map[string]int64) (Decision, error) {
+	idPtr := gs.globalRateLimitID.Load()
+	if idPtr == nil || *idPtr == "" {
+		return DecisionAllow, nil
+	}
+	rl := gs.LoadRateLimit(ctx, *idPtr)
+	if rl == nil {
+		return DecisionAllow, nil
+	}
+	return gs.CheckRateLimit(ctx, EntityWiseRateLimits{"global": []*configstoreTables.TableRateLimit{rl}}, tokensBaselines, requestsBaselines)
+}
+
+// UpdateGlobalBudgetUsageInMemory increments the usage counter for all global budgets.
+func (gs *LocalGovernanceStore) UpdateGlobalBudgetUsageInMemory(ctx context.Context, cost float64) error {
+	ids := gs.globalBudgetIDs.Load()
+	if ids == nil {
+		return nil
+	}
+	for _, id := range *ids {
+		if err := gs.BumpBudgetUsage(ctx, id, cost); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UpdateGlobalRateLimitUsageInMemory increments the usage counters for the global rate limit.
+func (gs *LocalGovernanceStore) UpdateGlobalRateLimitUsageInMemory(ctx context.Context, tokensUsed int64, shouldUpdateTokens bool, shouldUpdateRequests bool) error {
+	idPtr := gs.globalRateLimitID.Load()
+	if idPtr == nil || *idPtr == "" {
+		return nil
+	}
+	return gs.BumpRateLimitUsage(ctx, *idPtr, tokensUsed, shouldUpdateTokens, shouldUpdateRequests)
+}
+
+// UpsertGlobalGovernanceInMemory replaces the in-memory global budgets and rate
+// limit. New entries are published before old ones are pruned so that:
+//
+//  1. Concurrent CheckGlobalBudget / CheckGlobalRateLimit readers never observe
+//     an empty global set (the previous delete-then-insert order opened a
+//     window where readers fell through to DecisionAllow).
+//  2. UpsertBudgetConfig / UpsertRateLimitConfig retain their CAS-based
+//     counter preservation for IDs carried over across the update (the HTTP
+//     handler reuses existing IDs by reset_duration so usage survives).
+//
+// Only IDs that disappear from the new set are deleted.
+func (gs *LocalGovernanceStore) UpsertGlobalGovernanceInMemory(ctx context.Context, budgets []*configstoreTables.TableBudget, rateLimit *configstoreTables.TableRateLimit) {
+	// Snapshot previous ID sets first so the prune step below knows which
+	// entries are no longer part of the global set.
+	var oldBudgetIDs []string
+	if old := gs.globalBudgetIDs.Load(); old != nil {
+		oldBudgetIDs = *old
+	}
+	var oldRateLimitID string
+	if old := gs.globalRateLimitID.Load(); old != nil {
+		oldRateLimitID = *old
+	}
+
+	// Publish new budgets. UpsertBudgetConfig CAS-preserves CurrentUsage /
+	// LastReset for IDs that already exist; brand-new IDs are inserted via
+	// LoadOrStore. Either way readers can immediately resolve them.
+	newBudgetIDs := make([]string, 0, len(budgets))
+	newBudgetIDSet := make(map[string]struct{}, len(budgets))
+	for _, b := range budgets {
+		gs.UpsertBudgetConfig(ctx, b.ID, b)
+		newBudgetIDs = append(newBudgetIDs, b.ID)
+		newBudgetIDSet[b.ID] = struct{}{}
+	}
+	gs.globalBudgetIDs.Store(&newBudgetIDs)
+
+	// Publish (or clear) the new rate limit before pruning the previous one.
+	// Counter preservation is the same contract as budgets above.
+	var newRateLimitID string
+	if rateLimit != nil {
+		gs.UpsertRateLimitConfig(ctx, rateLimit.ID, rateLimit)
+		newRateLimitID = rateLimit.ID
+	}
+	gs.globalRateLimitID.Store(&newRateLimitID)
+
+	// Prune entries that left the global set. Skip IDs still in use so the
+	// state preservation done above isn't undone by a redundant DeleteBudget
+	// (which would also wipe LastDBUsages baselines).
+	for _, id := range oldBudgetIDs {
+		if _, kept := newBudgetIDSet[id]; !kept {
+			gs.DeleteBudget(ctx, id)
+		}
+	}
+	if oldRateLimitID != "" && oldRateLimitID != newRateLimitID {
+		gs.DeleteRateLimit(ctx, oldRateLimitID)
+	}
+}
+
+// DeleteGlobalGovernanceInMemory removes all global governance entries from memory.
+func (gs *LocalGovernanceStore) DeleteGlobalGovernanceInMemory(ctx context.Context) {
+	if ids := gs.globalBudgetIDs.Load(); ids != nil {
+		for _, id := range *ids {
+			gs.DeleteBudget(ctx, id)
+		}
+	}
+	empty := make([]string, 0)
+	gs.globalBudgetIDs.Store(&empty)
+
+	if idPtr := gs.globalRateLimitID.Load(); idPtr != nil && *idPtr != "" {
+		gs.DeleteRateLimit(ctx, *idPtr)
+	}
+	emptyStr := ""
+	gs.globalRateLimitID.Store(&emptyStr)
+}
+
 // ResetExpiredBudgetsInMemory checks and resets budgets that have exceeded their reset duration.
 // Decision of whether to reset is computed per-budget from the snapshot observed via Range; the
 // actual CAS is delegated to ResetBudgetAt, which skips already-reset snapshots and never drops
@@ -1767,6 +1914,44 @@ func (gs *LocalGovernanceStore) loadFromDatabase(ctx context.Context) error {
 	// Rebuild in-memory structures (lock-free)
 	gs.rebuildInMemoryStructures(ctx, customers, teams, virtualKeys, budgets, rateLimits, modelConfigs, providers, routingRules)
 
+	// Load global governance after the main structures are populated.
+	if err := gs.loadGlobalGovernanceFromDatabase(ctx); err != nil {
+		return fmt.Errorf("failed to load global governance: %w", err)
+	}
+
+	return nil
+}
+
+// loadGlobalGovernanceFromDatabase reads is_global rows from the DB and registers them in the
+// existing gs.budgets / gs.rateLimits maps, then stores their IDs for fast CheckGlobal* lookup.
+func (gs *LocalGovernanceStore) loadGlobalGovernanceFromDatabase(ctx context.Context) error {
+	if gs.configStore == nil {
+		return nil
+	}
+	globalBudgets, err := gs.configStore.GetGlobalBudgets(ctx)
+	if err != nil {
+		return fmt.Errorf("get global budgets: %w", err)
+	}
+	ids := make([]string, 0, len(globalBudgets))
+	for i := range globalBudgets {
+		b := &globalBudgets[i]
+		gs.UpsertBudgetConfig(ctx, b.ID, b)
+		ids = append(ids, b.ID)
+	}
+	gs.globalBudgetIDs.Store(&ids)
+
+	globalRL, err := gs.configStore.GetGlobalRateLimit(ctx)
+	if err != nil {
+		return fmt.Errorf("get global rate limit: %w", err)
+	}
+	if globalRL != nil {
+		gs.UpsertRateLimitConfig(ctx, globalRL.ID, globalRL)
+		id := globalRL.ID
+		gs.globalRateLimitID.Store(&id)
+	} else {
+		empty := ""
+		gs.globalRateLimitID.Store(&empty)
+	}
 	return nil
 }
 

--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -79,6 +79,16 @@ func (t *UsageTracker) UpdateUsage(ctx context.Context, update *UsageUpdate) {
 	shouldUpdateRequests := !update.IsStreaming || (update.IsStreaming && update.IsFinalChunk)
 	shouldUpdateBudget := !update.IsStreaming || (update.IsStreaming && update.HasUsageData)
 
+	// 0. Update global (instance-wide) usage before any per-entity updates.
+	if err := t.store.UpdateGlobalRateLimitUsageInMemory(ctx, update.TokensUsed, shouldUpdateTokens, shouldUpdateRequests); err != nil {
+		t.logger.Error("failed to update global rate limit usage: %v", err)
+	}
+	if shouldUpdateBudget && update.Cost > 0 {
+		if err := t.store.UpdateGlobalBudgetUsageInMemory(ctx, update.Cost); err != nil {
+			t.logger.Error("failed to update global budget usage: %v", err)
+		}
+	}
+
 	// 1. Update rate limit usage for both provider-level and model-level
 	// This applies even when virtual keys are disabled or not present
 	// Guard: only update when both Provider and Model are set (MCP paths may not have these)

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -53,6 +53,8 @@ type GovernanceManager interface {
 	RemoveRoutingRule(ctx context.Context, id string) error
 	UpsertPricingOverride(ctx context.Context, override *configstoreTables.TablePricingOverride) error
 	DeletePricingOverride(ctx context.Context, id string) error
+	UpsertGlobalGovernance(ctx context.Context, budgets []*configstoreTables.TableBudget, rateLimit *configstoreTables.TableRateLimit) error
+	DeleteGlobalGovernance(ctx context.Context) error
 }
 
 // GovernanceHandler manages HTTP requests for governance operations
@@ -375,6 +377,13 @@ type UpdateModelConfigRequest struct {
 	RateLimit *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
 }
 
+// UpsertGlobalGovernanceRequest is the request body for PUT /api/governance/global.
+// Replaces all global budgets and the global rate limit atomically.
+type UpsertGlobalGovernanceRequest struct {
+	Budgets   []CreateBudgetRequest   `json:"budgets,omitempty"`
+	RateLimit *CreateRateLimitRequest `json:"rate_limit,omitempty"`
+}
+
 // UpdateProviderGovernanceRequest represents the request body for updating provider governance
 type UpdateProviderGovernanceRequest struct {
 	Budget    *UpdateBudgetRequest    `json:"budget,omitempty"`
@@ -428,6 +437,11 @@ func (h *GovernanceHandler) RegisterRoutes(r *router.Router, middlewares ...sche
 	r.GET("/api/governance/providers", lib.ChainMiddlewares(h.getProviderGovernance, middlewares...))
 	r.PUT("/api/governance/providers/{provider_name}", lib.ChainMiddlewares(h.updateProviderGovernance, middlewares...))
 	r.DELETE("/api/governance/providers/{provider_name}", lib.ChainMiddlewares(h.deleteProviderGovernance, middlewares...))
+
+	// Global Governance operations (instance-wide cap)
+	r.GET("/api/governance/global", lib.ChainMiddlewares(h.getGlobalGovernance, middlewares...))
+	r.PUT("/api/governance/global", lib.ChainMiddlewares(h.upsertGlobalGovernance, middlewares...))
+	r.DELETE("/api/governance/global", lib.ChainMiddlewares(h.deleteGlobalGovernance, middlewares...))
 
 	// Pricing override operations
 	r.GET("/api/governance/pricing-overrides", lib.ChainMiddlewares(h.getPricingOverrides, middlewares...))
@@ -4249,4 +4263,197 @@ func (h *GovernanceHandler) getVirtualKeyQuota(ctx *fasthttp.RequestCtx) {
 		"budgets":          vk.Budgets,
 		"rate_limit":       vk.RateLimit,
 	})
+}
+
+// Global Governance Handlers
+
+// getGlobalGovernance handles GET /api/governance/global
+func (h *GovernanceHandler) getGlobalGovernance(ctx *fasthttp.RequestCtx) {
+	budgets, err := h.configStore.GetGlobalBudgets(ctx)
+	if err != nil {
+		SendError(ctx, 500, "Failed to retrieve global budgets")
+		return
+	}
+	rateLimit, err := h.configStore.GetGlobalRateLimit(ctx)
+	if err != nil {
+		SendError(ctx, 500, "Failed to retrieve global rate limit")
+		return
+	}
+	SendJSON(ctx, map[string]interface{}{
+		"budgets":    budgets,
+		"rate_limit": rateLimit,
+	})
+}
+
+// upsertGlobalGovernance handles PUT /api/governance/global
+func (h *GovernanceHandler) upsertGlobalGovernance(ctx *fasthttp.RequestCtx) {
+	var req UpsertGlobalGovernanceRequest
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, 400, "Invalid JSON")
+		return
+	}
+
+	// Validate budgets before opening the transaction.
+	seenDurations := make(map[string]bool)
+	for _, b := range req.Budgets {
+		if b.MaxLimit <= 0 {
+			SendError(ctx, 400, fmt.Sprintf("budget max_limit must be greater than 0: %.2f", b.MaxLimit))
+			return
+		}
+		if seenDurations[b.ResetDuration] {
+			SendError(ctx, 400, fmt.Sprintf("duplicate reset_duration in budgets: %s", b.ResetDuration))
+			return
+		}
+		seenDurations[b.ResetDuration] = true
+	}
+
+	if err := h.configStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
+		// Load existing global budgets and reconcile by reset_duration — same pattern
+		// as VK/team budget updates so that changing max_limit preserves current_usage.
+		existingBudgets, err := h.configStore.GetGlobalBudgets(ctx)
+		if err != nil {
+			return fmt.Errorf("load existing global budgets: %w", err)
+		}
+		existingByDuration := make(map[string]configstoreTables.TableBudget, len(existingBudgets))
+		for _, b := range existingBudgets {
+			existingByDuration[b.ResetDuration] = b
+		}
+
+		matchedIDs := make(map[string]bool)
+		for _, b := range req.Budgets {
+			if existing, found := existingByDuration[b.ResetDuration]; found {
+				// Same duration — update max_limit in place, usage is preserved.
+				existing.MaxLimit = b.MaxLimit
+				existing.CalendarAligned = b.CalendarAligned
+				if err := validateBudget(&existing); err != nil {
+					return &badRequestError{err: err}
+				}
+				if err := h.configStore.UpdateBudget(ctx, &existing, tx); err != nil {
+					return err
+				}
+				matchedIDs[existing.ID] = true
+			} else {
+				// New duration — create a fresh row with zero usage.
+				budget := configstoreTables.TableBudget{
+					ID:              uuid.NewString(),
+					MaxLimit:        b.MaxLimit,
+					ResetDuration:   b.ResetDuration,
+					CalendarAligned: b.CalendarAligned,
+					LastReset:       budgetLastReset(b.CalendarAligned, b.ResetDuration),
+					IsGlobal:        true,
+				}
+				if err := validateBudget(&budget); err != nil {
+					return &badRequestError{err: err}
+				}
+				if err := h.configStore.CreateBudget(ctx, &budget, tx); err != nil {
+					return err
+				}
+			}
+		}
+		// Delete budgets whose duration is no longer in the request.
+		for _, existing := range existingBudgets {
+			if !matchedIDs[existing.ID] {
+				if err := h.configStore.DeleteBudget(ctx, existing.ID, tx); err != nil {
+					return fmt.Errorf("delete removed global budget: %w", err)
+				}
+			}
+		}
+
+		// Reconcile rate limit — update in place if one exists (preserves usage),
+		// create if new, delete if req.RateLimit is nil.
+		existingRL, err := h.configStore.GetGlobalRateLimit(ctx)
+		if err != nil {
+			return fmt.Errorf("load existing global rate limit: %w", err)
+		}
+		if req.RateLimit == nil {
+			if existingRL != nil {
+				if err := h.configStore.DeleteRateLimit(ctx, existingRL.ID, tx); err != nil {
+					return fmt.Errorf("delete global rate limit: %w", err)
+				}
+			}
+		} else if existingRL != nil {
+			// Update in place — token/request usage counters are untouched.
+			existingRL.TokenMaxLimit = req.RateLimit.TokenMaxLimit
+			existingRL.TokenResetDuration = req.RateLimit.TokenResetDuration
+			existingRL.RequestMaxLimit = req.RateLimit.RequestMaxLimit
+			existingRL.RequestResetDuration = req.RateLimit.RequestResetDuration
+			if err := validateRateLimit(existingRL); err != nil {
+				return &badRequestError{err: err}
+			}
+			if err := h.configStore.UpdateRateLimit(ctx, existingRL, tx); err != nil {
+				return err
+			}
+		} else {
+			rl := &configstoreTables.TableRateLimit{
+				ID:                   uuid.NewString(),
+				TokenMaxLimit:        req.RateLimit.TokenMaxLimit,
+				TokenResetDuration:   req.RateLimit.TokenResetDuration,
+				TokenLastReset:       time.Now(),
+				RequestMaxLimit:      req.RateLimit.RequestMaxLimit,
+				RequestResetDuration: req.RateLimit.RequestResetDuration,
+				RequestLastReset:     time.Now(),
+				IsGlobal:             true,
+			}
+			if err := validateRateLimit(rl); err != nil {
+				return &badRequestError{err: err}
+			}
+			if err := h.configStore.CreateRateLimit(ctx, rl, tx); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		var badReq *badRequestError
+		if errors.As(err, &badReq) {
+			SendError(ctx, 400, badReq.Error())
+		} else {
+			SendError(ctx, 500, fmt.Sprintf("Failed to save global governance: %s", err.Error()))
+		}
+		return
+	}
+
+	// Reload the final state so the caller sees IDs and preserved usage.
+	savedBudgets, err := h.configStore.GetGlobalBudgets(ctx)
+	if err != nil {
+		SendError(ctx, 500, "Failed to read back global budgets")
+		return
+	}
+	savedRL, err := h.configStore.GetGlobalRateLimit(ctx)
+	if err != nil {
+		SendError(ctx, 500, "Failed to read back global rate limit")
+		return
+	}
+
+	budgetPtrs := make([]*configstoreTables.TableBudget, len(savedBudgets))
+	for i := range savedBudgets {
+		budgetPtrs[i] = &savedBudgets[i]
+	}
+	if err := h.governanceManager.UpsertGlobalGovernance(ctx, budgetPtrs, savedRL); err != nil {
+		// DB is already committed by ExecuteTransaction above. If the in-memory
+		// publish fails, the engine keeps enforcing the previous global caps
+		// until the next reload — surface that split-brain as a 500 instead of
+		// silently returning 200 with the new state echoed back. Mirrors
+		// updateVirtualKey's "updated in database but failed to reload
+		// in-memory state" handling.
+		logger.Error("failed to upsert global governance in memory: %v", err)
+		SendError(ctx, 500, "Global governance updated in database but failed to sync in-memory state")
+		return
+	}
+
+	SendJSON(ctx, map[string]interface{}{
+		"budgets":    savedBudgets,
+		"rate_limit": savedRL,
+	})
+}
+
+// deleteGlobalGovernance handles DELETE /api/governance/global
+func (h *GovernanceHandler) deleteGlobalGovernance(ctx *fasthttp.RequestCtx) {
+	if err := h.configStore.DeleteGlobalGovernance(ctx); err != nil {
+		SendError(ctx, 500, fmt.Sprintf("Failed to delete global governance: %s", err.Error()))
+		return
+	}
+	if err := h.governanceManager.DeleteGlobalGovernance(ctx); err != nil {
+		logger.Error("failed to delete global governance from memory: %v", err)
+	}
+	ctx.SetStatusCode(204)
 }

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -1988,6 +1988,34 @@ func mergeGovernanceConfig(ctx context.Context, config *Config, configData *Conf
 			logger.Fatal("failed to sync governance config: %v", err)
 		}
 	}
+	// Sync global governance from config.json whenever the file is reloaded.
+	// Global entries are items in Governance.Budgets / Governance.RateLimits with IsGlobal=true.
+	// UpsertGlobalGovernance is idempotent (delete-then-insert) so this is safe to call every cycle.
+	if config.ConfigStore != nil && configData.Governance != nil {
+		var globalBudgets []configstoreTables.TableBudget
+		for _, b := range configData.Governance.Budgets {
+			if !b.IsGlobal {
+				continue
+			}
+			if b.ID == "" {
+				b.ID = uuid.NewString()
+			}
+			globalBudgets = append(globalBudgets, b)
+		}
+		var globalRateLimit *configstoreTables.TableRateLimit
+		for i := range configData.Governance.RateLimits {
+			if configData.Governance.RateLimits[i].IsGlobal {
+				globalRateLimit = &configData.Governance.RateLimits[i]
+				break
+			}
+		}
+		if len(globalBudgets) > 0 || globalRateLimit != nil {
+			if err := config.ConfigStore.UpsertGlobalGovernance(ctx, globalBudgets, globalRateLimit); err != nil {
+				logger.Error("failed to sync global governance during merge: %v", err)
+			}
+		}
+	}
+
 	// Sync pricing overrides into the model catalog in one batch to avoid
 	// rebuilding the lookup map on every iteration.
 	if config.ModelCatalog != nil {
@@ -2640,6 +2668,31 @@ func createGovernanceConfigInStore(ctx context.Context, config *Config) {
 		for _, budget := range pendingProviderConfigBudgets {
 			if err := createBudget(budget); err != nil {
 				return err
+			}
+		}
+
+		// Sync global governance from config.json (instance-wide budget + rate limit).
+		// Global entries are items in GovernanceConfig.Budgets / GovernanceConfig.RateLimits with IsGlobal=true.
+		var globalBudgets []configstoreTables.TableBudget
+		for _, b := range config.GovernanceConfig.Budgets {
+			if !b.IsGlobal {
+				continue
+			}
+			if b.ID == "" {
+				b.ID = uuid.NewString()
+			}
+			globalBudgets = append(globalBudgets, b)
+		}
+		var globalRateLimit *configstoreTables.TableRateLimit
+		for i := range config.GovernanceConfig.RateLimits {
+			if config.GovernanceConfig.RateLimits[i].IsGlobal {
+				globalRateLimit = &config.GovernanceConfig.RateLimits[i]
+				break
+			}
+		}
+		if len(globalBudgets) > 0 || globalRateLimit != nil {
+			if err := config.ConfigStore.UpsertGlobalGovernance(ctx, globalBudgets, globalRateLimit); err != nil {
+				return fmt.Errorf("failed to sync global governance: %w", err)
 			}
 		}
 

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -105,6 +105,9 @@ type ServerCallbacks interface {
 	ReconnectMCPClient(ctx context.Context, id string) error
 	DisableMCPClient(ctx context.Context, id string) error
 	EnableMCPClient(ctx context.Context, id string) error
+	// Global governance callbacks
+	UpsertGlobalGovernance(ctx context.Context, budgets []*tables.TableBudget, rateLimit *tables.TableRateLimit) error
+	DeleteGlobalGovernance(ctx context.Context) error
 }
 
 // BifrostHTTPServer represents a HTTP server instance.
@@ -928,6 +931,26 @@ func (s *BifrostHTTPServer) DeletePricingOverride(ctx context.Context, id string
 		return fmt.Errorf("pricing manager not found")
 	}
 	s.Config.ModelCatalog.DeletePricingOverride(id)
+	return nil
+}
+
+// UpsertGlobalGovernance replaces the in-memory global budgets and rate limit.
+func (s *BifrostHTTPServer) UpsertGlobalGovernance(ctx context.Context, budgets []*tables.TableBudget, rateLimit *tables.TableRateLimit) error {
+	governancePlugin, err := s.getGovernancePlugin()
+	if err != nil {
+		return err
+	}
+	governancePlugin.GetGovernanceStore().UpsertGlobalGovernanceInMemory(ctx, budgets, rateLimit)
+	return nil
+}
+
+// DeleteGlobalGovernance removes all global governance from the in-memory store.
+func (s *BifrostHTTPServer) DeleteGlobalGovernance(ctx context.Context) error {
+	governancePlugin, err := s.getGovernancePlugin()
+	if err != nil {
+		return err
+	}
+	governancePlugin.GetGovernanceStore().DeleteGlobalGovernanceInMemory(ctx)
 	return nil
 }
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -377,6 +377,11 @@
                 "type": "boolean",
                 "description": "Deprecated: set calendar_aligned on the owner (team / virtual key / access profile) instead. Kept for backward compatibility with older config.json files; ignored unless a reconciler promotes it to its owner.",
                 "default": false
+              },
+              "is_global": {
+                "type": "boolean",
+                "description": "When true, this budget is an instance-wide cap enforced before any per-entity checks",
+                "default": false
               }
             },
             "required": ["id", "max_limit", "reset_duration"],
@@ -432,6 +437,11 @@
               "calendar_aligned": {
                 "type": "boolean",
                 "description": "Deprecated: set calendar_aligned on the owner (team / virtual key / access profile) instead. Kept for backward compatibility with older config.json files; ignored unless a reconciler promotes it to its owner.",
+                "default": false
+              },
+              "is_global": {
+                "type": "boolean",
+                "description": "When true, this rate limit is an instance-wide cap enforced before any per-entity checks",
                 "default": false
               }
             },

--- a/ui/app/workspace/governance/global-limits/layout.tsx
+++ b/ui/app/workspace/governance/global-limits/layout.tsx
@@ -1,0 +1,16 @@
+import { NoPermissionView } from "@/components/noPermissionView";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { createFileRoute } from "@tanstack/react-router";
+import GlobalLimitsPage from "./page";
+
+function RouteComponent() {
+	const hasGovernanceAccess = useRbac(RbacResource.Governance, RbacOperation.View);
+	if (!hasGovernanceAccess) {
+		return <NoPermissionView entity="global budget" />;
+	}
+	return <GlobalLimitsPage />;
+}
+
+export const Route = createFileRoute("/workspace/governance/global-limits")({
+	component: RouteComponent,
+});

--- a/ui/app/workspace/governance/global-limits/page.tsx
+++ b/ui/app/workspace/governance/global-limits/page.tsx
@@ -1,0 +1,9 @@
+import GlobalLimitsForm from "./views/globalLimitsForm";
+
+export default function GlobalLimitsPage() {
+	return (
+		<div className="mx-auto w-full max-w-3xl">
+			<GlobalLimitsForm />
+		</div>
+	);
+}

--- a/ui/app/workspace/governance/global-limits/views/globalLimitsForm.tsx
+++ b/ui/app/workspace/governance/global-limits/views/globalLimitsForm.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import MultiBudgetLines, { BudgetLineEntry } from "@/components/ui/multibudgets";
+import NumberAndSelect from "@/components/ui/numberAndSelect";
+import { DottedSeparator } from "@/components/ui/separator";
+import { resetDurationOptions } from "@/lib/constants/governance";
+import {
+	getErrorMessage,
+	useDeleteGlobalGovernanceMutation,
+	useGetGlobalGovernanceQuery,
+	useUpsertGlobalGovernanceMutation,
+} from "@/lib/store";
+import { formatCurrency } from "@/lib/utils/governance";
+import { formatDistanceToNow } from "date-fns";
+import isEqual from "lodash.isequal";
+import { Globe } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { z } from "zod";
+
+const POLLING_INTERVAL = 5000;
+
+const budgetLineSchema = z.object({
+	max_limit: z.number().positive("Budget max limit must be greater than 0").optional(),
+	reset_duration: z.string().min(1, "Reset duration is required"),
+});
+
+const formSchema = z.object({
+	budgets: z.array(budgetLineSchema).superRefine((budgets, ctx) => {
+		const seen = new Set<string>();
+		budgets.forEach((b, i) => {
+			if (seen.has(b.reset_duration)) {
+				ctx.addIssue({
+					code: "custom",
+					message: `Duplicate budget window "${b.reset_duration}" — each reset duration can only appear once`,
+					path: [i, "reset_duration"],
+				});
+			}
+			seen.add(b.reset_duration);
+		});
+	}),
+	tokenMaxLimit: z.number().int().positive("Token max limit must be greater than 0").optional(),
+	tokenResetDuration: z.string(),
+	requestMaxLimit: z.number().int().positive("Request max limit must be greater than 0").optional(),
+	requestResetDuration: z.string(),
+});
+
+interface FormState {
+	budgets: BudgetLineEntry[];
+	tokenMaxLimit: number | undefined;
+	tokenResetDuration: string;
+	requestMaxLimit: number | undefined;
+	requestResetDuration: string;
+}
+
+function emptyForm(): FormState {
+	return {
+		budgets: [],
+		tokenMaxLimit: undefined,
+		tokenResetDuration: "1h",
+		requestMaxLimit: undefined,
+		requestResetDuration: "1h",
+	};
+}
+
+function formFromData(data: { budgets?: any[]; rate_limit?: any } | undefined): FormState {
+	if (!data) return emptyForm();
+	return {
+		budgets: (data.budgets ?? []).map((b: any) => ({
+			max_limit: b.max_limit,
+			reset_duration: b.reset_duration,
+		})),
+		tokenMaxLimit: data.rate_limit?.token_max_limit ?? undefined,
+		tokenResetDuration: data.rate_limit?.token_reset_duration ?? "1h",
+		requestMaxLimit: data.rate_limit?.request_max_limit ?? undefined,
+		requestResetDuration: data.rate_limit?.request_reset_duration ?? "1h",
+	};
+}
+
+export default function GlobalLimitsForm() {
+	const { data, isLoading, error } = useGetGlobalGovernanceQuery(undefined, {
+		pollingInterval: POLLING_INTERVAL,
+	});
+
+	const [upsert, { isLoading: isSaving }] = useUpsertGlobalGovernanceMutation();
+	const [deleteAll, { isLoading: isDeleting }] = useDeleteGlobalGovernanceMutation();
+
+	const [savedForm, setSavedForm] = useState<FormState>(emptyForm());
+	const [form, setForm] = useState<FormState>(emptyForm());
+
+	const formRef = useRef(form);
+	const savedFormRef = useRef(savedForm);
+	useEffect(() => {
+		formRef.current = form;
+		savedFormRef.current = savedForm;
+	}, [form, savedForm]);
+
+	useEffect(() => {
+		const next = formFromData(data);
+		setSavedForm(next);
+		if (isEqual(formRef.current, savedFormRef.current)) {
+			setForm(next);
+		}
+	}, [data]);
+
+	const isDirty = useMemo(() => !isEqual(form, savedForm), [form, savedForm]);
+
+	const validation = useMemo(() => formSchema.safeParse(form), [form]);
+	const hasValidationErrors = !validation.success;
+
+	function updateField<K extends keyof FormState>(key: K, value: FormState[K]) {
+		setForm((prev) => ({ ...prev, [key]: value }));
+	}
+
+	async function handleSave() {
+		const parsed = formSchema.safeParse(form);
+		if (!parsed.success) {
+			toast.error(parsed.error.issues[0]?.message ?? "Invalid global limits configuration");
+			return;
+		}
+		const { budgets, tokenMaxLimit, tokenResetDuration, requestMaxLimit, requestResetDuration } = parsed.data;
+		try {
+			const validBudgets = budgets.filter((b): b is { max_limit: number; reset_duration: string } => b.max_limit !== undefined);
+			const hasRateLimit = tokenMaxLimit !== undefined || requestMaxLimit !== undefined;
+
+			await upsert({
+				budgets: validBudgets.map((b) => ({
+					max_limit: b.max_limit,
+					reset_duration: b.reset_duration,
+				})),
+				rate_limit: hasRateLimit
+					? {
+							token_max_limit: tokenMaxLimit,
+							token_reset_duration: tokenMaxLimit !== undefined ? tokenResetDuration : undefined,
+							request_max_limit: requestMaxLimit,
+							request_reset_duration: requestMaxLimit !== undefined ? requestResetDuration : undefined,
+						}
+					: null,
+			}).unwrap();
+
+			toast.success("Global limits saved.");
+		} catch (err) {
+			toast.error(getErrorMessage(err));
+		}
+	}
+
+	async function handleClear() {
+		try {
+			await deleteAll().unwrap();
+			toast.success("Global limits cleared.");
+		} catch (err) {
+			toast.error(getErrorMessage(err));
+		}
+	}
+
+	if (isLoading) {
+		return (
+			<div className="flex h-64 items-center justify-center">
+				<p className="text-muted-foreground text-sm">Loading global limits…</p>
+			</div>
+		);
+	}
+
+	if (error) {
+		return (
+			<div className="flex h-64 items-center justify-center">
+				<p className="text-destructive text-sm">{getErrorMessage(error)}</p>
+			</div>
+		);
+	}
+
+	const hasExisting = (data?.budgets?.length ?? 0) > 0 || data?.rate_limit != null;
+
+	return (
+		<div className="space-y-6">
+			{/* Header */}
+			<div className="flex items-start justify-between">
+				<div className="flex items-center gap-3">
+					<Globe className="text-muted-foreground h-6 w-6" />
+					<div>
+						<h1 className="text-xl font-semibold">Global Limits</h1>
+						<p className="text-muted-foreground text-sm">
+							Instance-wide budget and rate limits enforced before provider, model, VK, team, and customer checks.
+						</p>
+					</div>
+				</div>
+			</div>
+
+			<Card>
+				<CardHeader className="pb-3">
+					<CardTitle className="text-sm font-medium">Configuration</CardTitle>
+					<CardDescription>Set multi-window budget limits and token/request rate limits. Changes take effect immediately.</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-6">
+					{/* Budget limits */}
+					<div className="space-y-4">
+						<Label className="text-sm font-medium">Budget Limits</Label>
+						<MultiBudgetLines
+							id="global-budgets"
+							data-testid="global-budgets"
+							lines={form.budgets}
+							onChange={(lines) => updateField("budgets", lines)}
+						/>
+					</div>
+
+					<DottedSeparator />
+
+					{/* Rate limits */}
+					<div className="space-y-4">
+						<Label className="text-sm font-medium">Rate Limiting</Label>
+						<NumberAndSelect
+							id="global-token-max-limit"
+							dataTestId="global-token-max-limit-input"
+							label="Maximum Tokens"
+							value={form.tokenMaxLimit}
+							selectValue={form.tokenResetDuration}
+							onChangeNumber={(v) => updateField("tokenMaxLimit", v)}
+							onChangeSelect={(v) => updateField("tokenResetDuration", v)}
+							options={resetDurationOptions}
+						/>
+						<NumberAndSelect
+							id="global-request-max-limit"
+							dataTestId="global-request-max-limit-input"
+							label="Maximum Requests"
+							value={form.requestMaxLimit}
+							selectValue={form.requestResetDuration}
+							onChangeNumber={(v) => updateField("requestMaxLimit", v)}
+							onChangeSelect={(v) => updateField("requestResetDuration", v)}
+							options={resetDurationOptions}
+						/>
+					</div>
+
+					{/* Current usage */}
+					{hasExisting && (
+						<>
+							<DottedSeparator />
+							<div className="space-y-4">
+								<Label className="text-sm font-medium">Current Usage</Label>
+								<div className="bg-muted/50 grid grid-cols-2 gap-4 rounded-lg p-4">
+									{(data?.budgets ?? []).map((b) => (
+										<div key={b.id} className="space-y-1">
+											<p className="text-muted-foreground text-xs">Budget ({b.reset_duration})</p>
+											<p className="text-sm font-medium">
+												{formatCurrency(b.current_usage)} / {formatCurrency(b.max_limit)}
+											</p>
+											<p className="text-muted-foreground text-xs">
+												Last Reset: {formatDistanceToNow(new Date(b.last_reset), { addSuffix: true })}
+											</p>
+										</div>
+									))}
+									{data?.rate_limit?.token_max_limit != null && (
+										<div className="space-y-1">
+											<p className="text-muted-foreground text-xs">Token Usage</p>
+											<p className="text-sm font-medium">
+												{(data.rate_limit.token_current_usage ?? 0).toLocaleString()} / {data.rate_limit.token_max_limit.toLocaleString()}
+											</p>
+											<p className="text-muted-foreground text-xs">
+												Last Reset: {formatDistanceToNow(new Date(data.rate_limit.token_last_reset), { addSuffix: true })}
+											</p>
+										</div>
+									)}
+									{data?.rate_limit?.request_max_limit != null && (
+										<div className="space-y-1">
+											<p className="text-muted-foreground text-xs">Request Usage</p>
+											<p className="text-sm font-medium">
+												{(data.rate_limit.request_current_usage ?? 0).toLocaleString()} /{" "}
+												{data.rate_limit.request_max_limit.toLocaleString()}
+											</p>
+											<p className="text-muted-foreground text-xs">
+												Last Reset: {formatDistanceToNow(new Date(data.rate_limit.request_last_reset), { addSuffix: true })}
+											</p>
+										</div>
+									)}
+								</div>
+							</div>
+						</>
+					)}
+
+					{/* Actions */}
+					<div className="flex justify-end gap-2">
+						<Button
+							data-testid="global-limits-remove-btn"
+							variant="outline"
+							onClick={handleClear}
+							disabled={isDeleting || !hasExisting}
+							className="text-destructive"
+						>
+							Remove configuration
+						</Button>
+						<Button data-testid="global-limits-save-btn" onClick={handleSave} disabled={isSaving || !isDirty || hasValidationErrors}>
+							{isSaving ? "Saving…" : "Save Global Limits"}
+						</Button>
+					</div>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/ui/app/workspace/governance/layout.tsx
+++ b/ui/app/workspace/governance/layout.tsx
@@ -11,6 +11,7 @@ function RouteComponent() {
 	const hasBusinessUnitsAccess = useRbac(RbacResource.UserProvisioning, RbacOperation.View);
 	const hasRbacAccess = useRbac(RbacResource.RBAC, RbacOperation.View);
 	const hasAccessProfilesAccess = useRbac(RbacResource.AccessProfiles, RbacOperation.View);
+	const hasGovernanceLegacyAccess = useRbac(RbacResource.Governance, RbacOperation.View);
 
 	const hasAnyGovernanceAccess =
 		hasVirtualKeysAccess ||
@@ -19,7 +20,8 @@ function RouteComponent() {
 		hasCustomersAccess ||
 		hasBusinessUnitsAccess ||
 		hasRbacAccess ||
-		hasAccessProfilesAccess;
+		hasAccessProfilesAccess ||
+		hasGovernanceLegacyAccess;
 
 	const childMatches = useChildMatches();
 	if (!hasAnyGovernanceAccess) {

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -867,6 +867,13 @@ export default function AppSidebar() {
             hasAccess: hasVirtualKeysAccess,
           },
           {
+            title: "Global Budget",
+            url: "/workspace/governance/global-limits",
+            icon: Globe,
+            description: "Instance-wide budget and rate limits",
+            hasAccess: hasGovernanceLegacyAccess,
+          },
+          {
             title: "Users",
             url: "/workspace/governance/users",
             icon: Users,

--- a/ui/lib/store/apis/baseApi.ts
+++ b/ui/lib/store/apis/baseApi.ts
@@ -178,6 +178,7 @@ export const baseApi = createApi({
     "MCPToolGroups",
     "AuditLogs",
     "UserGovernance",
+		"GlobalGovernance",
     "LargePayloadConfig",
     "Folders",
     "Prompts",

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -23,6 +23,7 @@ import {
 	GetUsageStatsResponse,
 	GetVirtualKeysParams,
 	GetVirtualKeysResponse,
+	GlobalGovernance,
 	HealthCheckResponse,
 	ModelConfig,
 	ProviderGovernance,
@@ -37,6 +38,7 @@ import {
 	UpdateRateLimitRequest,
 	UpdateTeamRequest,
 	UpdateVirtualKeyRequest,
+	UpsertGlobalGovernanceRequest,
 	VirtualKey,
 } from "@/lib/types/governance";
 import { baseApi } from "./baseApi";
@@ -798,6 +800,48 @@ export const governanceApi = baseApi.injectEndpoints({
 				}
 			},
 		}),
+
+		// Global governance
+		getGlobalGovernance: builder.query<GlobalGovernance, void>({
+			query: () => ({ url: "/governance/global" }),
+			providesTags: ["GlobalGovernance"],
+		}),
+
+		upsertGlobalGovernance: builder.mutation<GlobalGovernance, UpsertGlobalGovernanceRequest>({
+			query: (data) => ({
+				url: "/governance/global",
+				method: "PUT",
+				body: data,
+			}),
+			async onQueryStarted(_, { dispatch, queryFulfilled }) {
+				try {
+					const { data } = await queryFulfilled;
+					dispatch(governanceApi.util.updateQueryData("getGlobalGovernance", undefined, () => data));
+				} catch {
+					// Mutation failed
+				}
+			},
+		}),
+
+		deleteGlobalGovernance: builder.mutation<void, void>({
+			query: () => ({
+				url: "/governance/global",
+				method: "DELETE",
+			}),
+			async onQueryStarted(_, { dispatch, queryFulfilled }) {
+				try {
+					await queryFulfilled;
+					dispatch(
+						governanceApi.util.updateQueryData("getGlobalGovernance", undefined, (draft) => {
+							draft.budgets = [];
+							draft.rate_limit = null;
+						}),
+					);
+				} catch {
+					// Mutation failed
+				}
+			},
+		}),
 	}),
 });
 
@@ -860,6 +904,11 @@ export const {
 	useGetProviderGovernanceQuery,
 	useUpdateProviderGovernanceMutation,
 	useDeleteProviderGovernanceMutation,
+
+	// Global governance
+	useGetGlobalGovernanceQuery,
+	useUpsertGlobalGovernanceMutation,
+	useDeleteGlobalGovernanceMutation,
 
 	// Lazy queries
 	useLazyGetVirtualKeysQuery,

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -535,3 +535,24 @@ export interface GetProviderGovernanceResponse {
 	providers: ProviderGovernance[];
 	count: number;
 }
+
+// Global governance — instance-wide budget and rate limit enforced before all other tiers.
+export interface GlobalGovernance {
+	budgets: Budget[];
+	rate_limit: RateLimit | null;
+}
+
+export interface UpsertGlobalGovernanceRequest {
+	budgets?: Array<{
+		max_limit: number;
+		reset_duration: string;
+		calendar_aligned?: boolean;
+	}>;
+	rate_limit?: {
+		token_max_limit?: number;
+		token_reset_duration?: string;
+		request_max_limit?: number;
+		request_reset_duration?: string;
+		calendar_aligned?: boolean;
+	} | null;
+}


### PR DESCRIPTION
## Summary

Adds instance-wide (global) governance — a single budget and rate limit tier that is evaluated before any provider, model, virtual key, team, customer, or user check. This allows operators to cap total spend and throughput across the entire Bifrost instance without needing to attach limits to individual entities.

## Changes

- Added `is_global` boolean column to `governance_budgets` and `governance_rate_limits` via a new DB migration (`migrationAddGlobalGovernanceColumns`). Rows with `is_global=true` represent the instance-wide cap.
- Extended `TableBudget.BeforeSave` to enforce that a global budget must have no owner FK set.
- Added `GetGlobalBudgets`, `GetGlobalRateLimit`, `UpsertGlobalGovernance`, and `DeleteGlobalGovernance` to `RDBConfigStore` and the `ConfigStore` interface.
- Added `globalBudgetIDs` and `globalRateLimitID` atomic pointers to `LocalGovernanceStore` so global rows are tracked separately but reuse all existing budget/rate-limit reset, dump, and bump machinery.
- Added `CheckGlobalBudget`, `CheckGlobalRateLimit`, `UpdateGlobalBudgetUsageInMemory`, `UpdateGlobalRateLimitUsageInMemory`, `UpsertGlobalGovernanceInMemory`, and `DeleteGlobalGovernanceInMemory` to `GovernanceStore` and its implementation.
- Added `EvaluateGlobalRequest` to `BudgetResolver`, called as step 0 in `EvaluateGovernanceRequest` before provider/model checks. Skipped when `SkipBudgetAndRateLimits` context flag is set.
- Global usage counters are incremented in `UsageTracker.UpdateUsage` before all per-entity updates.
- Global governance is loaded from the DB on startup via `loadGlobalGovernanceFromDatabase` and synced from `config.json` during both initial load and hot-reload in `createGovernanceConfigInStore` / `mergeGovernanceConfig`. Items in `Governance.Budgets` / `Governance.RateLimits` with `is_global: true` are treated as the instance-wide cap.
- Added REST endpoints `GET /api/governance/global`, `PUT /api/governance/global`, and `DELETE /api/governance/global` with corresponding handler methods and `UpsertGlobalGovernanceRequest` type.
- Wired `UpsertGlobalGovernance` and `DeleteGlobalGovernance` through `ServerCallbacks` and `GovernanceManager` so HTTP handlers can update both the DB and in-memory store atomically.
- Updated `config.schema.json` to document the new `is_global` field on budget and rate limit objects.
- Added a `GlobalLimitsForm` UI page at `/workspace/governance/global-limits` with live usage polling, multi-window budget configuration, token/request rate limit fields, and a clear-all action.
- Added `GlobalGovernance` and `UpsertGlobalGovernanceRequest` TypeScript types, three new RTK Query endpoints (`getGlobalGovernance`, `upsertGlobalGovernance`, `deleteGlobalGovernance`), and a `GlobalGovernance` cache tag.
- Added a "Global Limits" entry to the sidebar under Governance.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./plugins/governance/... ./transports/bifrost-http/...

# Start the server and exercise the new endpoints
# Create global limits
curl -X PUT http://localhost:8080/api/governance/global \
  -H "Content-Type: application/json" \
  -d '{"budgets":[{"max_limit":100,"reset_duration":"1d"}],"rate_limit":{"token_max_limit":1000000,"token_reset_duration":"1h"}}'

# Read them back
curl http://localhost:8080/api/governance/global

# Delete them
curl -X DELETE http://localhost:8080/api/governance/global

# UI
cd ui
pnpm i
pnpm build
```

To test via `config.json`, add an entry with `"is_global": true` to the `budgets` or `rate_limits` array under `governance` and reload the server. The instance-wide cap should be enforced on the next request.

## Breaking changes

- [ ] Yes
- [x] No

The migration is additive (new nullable columns with defaults). Existing rows are unaffected.

## Security considerations

Global limits are enforced at the earliest point in the governance pipeline, before any VK identity check. Operators should be aware that misconfiguring a very low global budget or rate limit will block all traffic instance-wide, including internal metadata calls that do not set `SkipBudgetAndRateLimits`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable