### PR TITLE
feat: add tooltip with full precision values to chart card totals and consolidate number formatting utilities

### DIFF
--- a/ui/app/workspace/dashboard/components/charts/chartCard.tsx
+++ b/ui/app/workspace/dashboard/components/charts/chartCard.tsx
@@ -1,5 +1,6 @@
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { ReactNode } from "react";
 
@@ -13,10 +14,21 @@ interface ChartCardProps {
 	className?: string;
 	total?: ReactNode;
 	totalLabel?: string;
+	totalTooltip?: ReactNode;
 }
 
-function TotalChip({ total, totalLabel, testId }: { total: ReactNode; totalLabel?: string; testId?: string }) {
-	return (
+function TotalChip({
+	total,
+	totalLabel,
+	totalTooltip,
+	testId,
+}: {
+	total: ReactNode;
+	totalLabel?: string;
+	totalTooltip?: ReactNode;
+	testId?: string;
+}) {
+	const chip = (
 		<span
 			className="text-muted-foreground flex shrink-0 items-baseline gap-1 pl-2 text-xs"
 			data-testid={testId ? `${testId}-total` : undefined}
@@ -24,6 +36,21 @@ function TotalChip({ total, totalLabel, testId }: { total: ReactNode; totalLabel
 			{totalLabel && <span>{totalLabel}</span>}
 			<span className="text-primary text-sm font-semibold tabular-nums">{total}</span>
 		</span>
+	);
+
+	if (totalTooltip === undefined || totalTooltip === null) {
+		return chip;
+	}
+
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<span tabIndex={0} data-testid={testId ? `${testId}-total-trigger` : undefined}>
+					{chip}
+				</span>
+			</TooltipTrigger>
+			<TooltipContent data-testid={testId ? `${testId}-total-tooltip` : undefined}>{totalTooltip}</TooltipContent>
+		</Tooltip>
 	);
 }
 
@@ -33,6 +60,7 @@ function Header({
 	legend,
 	total,
 	totalLabel,
+	totalTooltip,
 	testId,
 }: {
 	title: string;
@@ -40,6 +68,7 @@ function Header({
 	legend?: ReactNode;
 	total?: ReactNode;
 	totalLabel?: string;
+	totalTooltip?: ReactNode;
 	testId?: string;
 }) {
 	const hasTotal = total !== undefined && total !== null;
@@ -51,7 +80,11 @@ function Header({
 			</div>
 			{hasActionRow && (
 				<div className="flex h-7 w-full min-w-0 items-center justify-between gap-3" data-testid={testId ? `${testId}-actions` : undefined}>
-					{hasTotal ? <TotalChip total={total} totalLabel={totalLabel} testId={testId} /> : <span className="shrink-0" />}
+					{hasTotal ? (
+						<TotalChip total={total} totalLabel={totalLabel} totalTooltip={totalTooltip} testId={testId} />
+					) : (
+						<span className="shrink-0" />
+					)}
 					{controls && <div className="flex shrink-0 items-center gap-2">{controls}</div>}
 				</div>
 			)}
@@ -60,11 +93,30 @@ function Header({
 	);
 }
 
-export function ChartCard({ title, children, controls, legend, loading, testId, className, total, totalLabel }: ChartCardProps) {
+export function ChartCard({
+	title,
+	children,
+	controls,
+	legend,
+	loading,
+	testId,
+	className,
+	total,
+	totalLabel,
+	totalTooltip,
+}: ChartCardProps) {
 	if (loading) {
 		return (
 			<Card className={cn("min-w-0 rounded-sm p-2 shadow-none h-[330px]", className)} data-testid={testId}>
-				<Header title={title} controls={controls} legend={legend} total={total} totalLabel={totalLabel} testId={testId} />
+				<Header
+					title={title}
+					controls={controls}
+					legend={legend}
+					total={total}
+					totalLabel={totalLabel}
+					totalTooltip={totalTooltip}
+					testId={testId}
+				/>
 				<div className="grow" data-testid={testId ? `${testId}-chart-skeleton` : undefined}>
 					<Skeleton className="h-full w-full" />
 				</div>
@@ -74,7 +126,15 @@ export function ChartCard({ title, children, controls, legend, loading, testId, 
 
 	return (
 		<Card className={cn("min-w-0 rounded-sm p-2 shadow-none h-[330px]", className)} data-testid={testId}>
-			<Header title={title} controls={controls} legend={legend} total={total} totalLabel={totalLabel} testId={testId} />
+			<Header
+				title={title}
+				controls={controls}
+				legend={legend}
+				total={total}
+				totalLabel={totalLabel}
+				totalTooltip={totalTooltip}
+				testId={testId}
+			/>
 			<div className="grow">{children}</div>
 		</Card>
 	);

--- a/ui/app/workspace/dashboard/components/charts/costChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/costChart.tsx
@@ -1,4 +1,5 @@
 import type { CostHistogramResponse } from "@/lib/types/logs";
+import { formatCurrencyNumber } from "@/lib/utils/numbers";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
@@ -136,7 +137,7 @@ function CostChartImpl({ data, chartType, startTime, endTime, selectedModel }: C
 							tickLine={false}
 							axisLine={false}
 							width={50}
-							tickFormatter={(v) => formatCost(v)}
+							tickFormatter={(v) => formatCurrencyNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 0.01)]}
 							allowDataOverflow={false}
 						/>
@@ -172,7 +173,7 @@ function CostChartImpl({ data, chartType, startTime, endTime, selectedModel }: C
 							tickLine={false}
 							axisLine={false}
 							width={50}
-							tickFormatter={(v) => formatCost(v)}
+							tickFormatter={(v) => formatCurrencyNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 0.01)]}
 							allowDataOverflow={false}
 						/>

--- a/ui/app/workspace/dashboard/components/charts/externalCacheTokenMeterChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/externalCacheTokenMeterChart.tsx
@@ -1,5 +1,6 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { TokenHistogramResponse } from "@/lib/types/logs";
+import { formatCompactNumber } from "@/lib/utils/numbers";
 import { Info } from "lucide-react";
 import { memo, useMemo } from "react";
 import { Cell, Pie, PieChart, ResponsiveContainer } from "recharts";
@@ -11,12 +12,6 @@ interface ExternalCacheTokenMeterChartProps {
 }
 
 const METER_COLORS = { cached: "#06b6d4", input: "#3b82f6" };
-
-const formatTokenCount = (count: number): string => {
-	if (count >= 1000000) return `${(count / 1000000).toFixed(1)}M`;
-	if (count >= 1000) return `${(count / 1000).toFixed(1)}K`;
-	return count.toLocaleString();
-};
 
 function ExternalCacheTokenMeterChartImpl({ data }: ExternalCacheTokenMeterChartProps) {
 	const { ref, width, height } = useGaugeSize();
@@ -101,11 +96,11 @@ function ExternalCacheTokenMeterChartImpl({ data }: ExternalCacheTokenMeterChart
 						<div className="flex shrink-0 flex-wrap items-center justify-center gap-x-4 gap-y-1 pt-2 text-[11px] leading-none">
 							<span className="flex items-center gap-1.5">
 								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: METER_COLORS.cached }} />
-								<span className="text-primary">Cached: {formatTokenCount(totalCachedRead)}</span>
+								<span className="text-primary">Cached: {formatCompactNumber(totalCachedRead)}</span>
 							</span>
 							<span className="flex items-center gap-1.5">
 								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: METER_COLORS.input }} />
-								<span className="text-muted-foreground">Input: {formatTokenCount(totalPromptTokens)}</span>
+								<span className="text-muted-foreground">Input: {formatCompactNumber(totalPromptTokens)}</span>
 							</span>
 						</div>
 					</div>

--- a/ui/app/workspace/dashboard/components/charts/logVolumeChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/logVolumeChart.tsx
@@ -1,7 +1,8 @@
 import type { LogsHistogramResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { CHART_COLORS, formatFullTimestamp, formatTimestamp, formatTokens } from "../../utils/chartUtils";
+import { formatCompactNumber } from "@/lib/utils/numbers";
+import { CHART_COLORS, formatFullTimestamp, formatTimestamp } from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -98,7 +99,7 @@ function LogVolumeChartImpl({ data, chartType, startTime, endTime }: LogVolumeCh
 							tickLine={false}
 							axisLine={false}
 							width={44}
-							tickFormatter={formatTokens}
+							tickFormatter={(v) => formatCompactNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>
@@ -140,7 +141,7 @@ function LogVolumeChartImpl({ data, chartType, startTime, endTime }: LogVolumeCh
 							tickLine={false}
 							axisLine={false}
 							width={44}
-							tickFormatter={formatTokens}
+							tickFormatter={(v) => formatCompactNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>

--- a/ui/app/workspace/dashboard/components/charts/mcpTopToolsChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/mcpTopToolsChart.tsx
@@ -1,7 +1,8 @@
 import type { MCPTopToolsResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { formatCost, formatTokens, getModelColor } from "../../utils/chartUtils";
+import { formatCompactNumber } from "@/lib/utils/numbers";
+import { formatCost, getModelColor } from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 
 interface MCPTopToolsChartProps {
@@ -54,7 +55,7 @@ function MCPTopToolsChartImpl({ data }: MCPTopToolsChartProps) {
 						tick={{ fontSize: 11, className: "fill-zinc-500" }}
 						tickLine={false}
 						axisLine={false}
-						tickFormatter={formatTokens}
+						tickFormatter={(v) => formatCompactNumber(v)}
 						domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 						allowDataOverflow={false}
 					/>

--- a/ui/app/workspace/dashboard/components/charts/mcpVolumeChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/mcpVolumeChart.tsx
@@ -1,7 +1,8 @@
 import type { MCPHistogramResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { CHART_COLORS, formatFullTimestamp, formatTimestamp, formatTokens } from "../../utils/chartUtils";
+import { formatCompactNumber } from "@/lib/utils/numbers";
+import { CHART_COLORS, formatFullTimestamp, formatTimestamp } from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -88,7 +89,7 @@ function MCPVolumeChartImpl({ data, chartType, startTime, endTime }: MCPVolumeCh
 							tickLine={false}
 							axisLine={false}
 							width={44}
-							tickFormatter={formatTokens}
+							tickFormatter={(v) => formatCompactNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>
@@ -130,7 +131,7 @@ function MCPVolumeChartImpl({ data, chartType, startTime, endTime }: MCPVolumeCh
 							tickLine={false}
 							axisLine={false}
 							width={44}
-							tickFormatter={formatTokens}
+							tickFormatter={(v) => formatCompactNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>

--- a/ui/app/workspace/dashboard/components/charts/modelUsageChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/modelUsageChart.tsx
@@ -1,11 +1,11 @@
 import type { ModelHistogramResponse } from "@/lib/types/logs";
+import { formatCompactNumber } from "@/lib/utils/numbers";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
 	CHART_COLORS,
 	formatFullTimestamp,
 	formatTimestamp,
-	formatTokens,
 	getModelColor,
 	OTHER_SERIES_COLOR,
 	OTHER_SERIES_KEY,
@@ -163,7 +163,7 @@ function ModelUsageChartImpl({ data, chartType, startTime, endTime, selectedMode
 							tickLine={false}
 							axisLine={false}
 							width={44}
-							tickFormatter={formatTokens}
+							tickFormatter={(v) => formatCompactNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>
@@ -222,7 +222,7 @@ function ModelUsageChartImpl({ data, chartType, startTime, endTime, selectedMode
 							tickLine={false}
 							axisLine={false}
 							width={44}
-							tickFormatter={formatTokens}
+							tickFormatter={(v) => formatCompactNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>

--- a/ui/app/workspace/dashboard/components/charts/providerCostChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/providerCostChart.tsx
@@ -1,4 +1,5 @@
 import type { ProviderCostHistogramResponse } from "@/lib/types/logs";
+import { formatCurrencyNumber } from "@/lib/utils/numbers";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
@@ -138,7 +139,7 @@ function ProviderCostChartImpl({ data, chartType, startTime, endTime, selectedPr
 							tickLine={false}
 							axisLine={false}
 							width={50}
-							tickFormatter={(v) => formatCost(v)}
+							tickFormatter={(v) => formatCurrencyNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 0.01)]}
 							allowDataOverflow={false}
 						/>

--- a/ui/app/workspace/dashboard/components/charts/providerTokenChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/providerTokenChart.tsx
@@ -1,11 +1,11 @@
 import type { ProviderTokenHistogramResponse } from "@/lib/types/logs";
+import { formatCompactNumber } from "@/lib/utils/numbers";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import {
 	CHART_COLORS,
 	formatFullTimestamp,
 	formatTimestamp,
-	formatTokens,
 	getModelColor,
 	OTHER_SERIES_COLOR,
 	OTHER_SERIES_KEY,
@@ -43,7 +43,7 @@ function AllProvidersTooltip({ active, payload, displayProviders }: any) {
 								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: isOther ? OTHER_SERIES_COLOR : getModelColor(idx) }} />
 								<span className="max-w-[120px] truncate text-zinc-600 dark:text-zinc-400">{isOther ? OTHER_SERIES_LABEL : provider}</span>
 							</span>
-							<span className="font-medium">{formatTokens(tokens)}</span>
+							<span className="font-medium">{formatCompactNumber(tokens)}</span>
 						</div>
 					);
 				})}
@@ -70,18 +70,18 @@ function SingleProviderTooltip({ active, payload, provider }: any) {
 						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.promptTokens }} />
 						<span className="text-zinc-600 dark:text-zinc-400">Input</span>
 					</span>
-					<span className="font-medium">{formatTokens(stats.prompt_tokens || 0)}</span>
+					<span className="font-medium">{formatCompactNumber(stats.prompt_tokens || 0)}</span>
 				</div>
 				<div className="flex items-center justify-between gap-4">
 					<span className="flex items-center gap-1.5">
 						<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.completionTokens }} />
 						<span className="text-zinc-600 dark:text-zinc-400">Output</span>
 					</span>
-					<span className="font-medium">{formatTokens(stats.completion_tokens || 0)}</span>
+					<span className="font-medium">{formatCompactNumber(stats.completion_tokens || 0)}</span>
 				</div>
 				<div className="flex items-center justify-between gap-4 border-t border-zinc-200 pt-1 dark:border-zinc-700">
 					<span className="text-zinc-600 dark:text-zinc-400">Total</span>
-					<span className="font-medium">{formatTokens(stats.total_tokens || 0)}</span>
+					<span className="font-medium">{formatCompactNumber(stats.total_tokens || 0)}</span>
 				</div>
 			</div>
 		</div>
@@ -167,7 +167,7 @@ function ProviderTokenChartImpl({ data, chartType, startTime, endTime, selectedP
 							tickLine={false}
 							axisLine={false}
 							width={50}
-							tickFormatter={formatTokens}
+							tickFormatter={(v) => formatCompactNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>
@@ -232,7 +232,7 @@ function ProviderTokenChartImpl({ data, chartType, startTime, endTime, selectedP
 							tickLine={false}
 							axisLine={false}
 							width={50}
-							tickFormatter={formatTokens}
+							tickFormatter={(v) => formatCompactNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>

--- a/ui/app/workspace/dashboard/components/charts/tokenUsageChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/tokenUsageChart.tsx
@@ -1,7 +1,8 @@
 import type { TokenHistogramResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { CHART_COLORS, formatFullTimestamp, formatTimestamp, formatTokens } from "../../utils/chartUtils";
+import { formatCompactNumber } from "@/lib/utils/numbers";
+import { CHART_COLORS, formatFullTimestamp, formatTimestamp } from "../../utils/chartUtils";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -98,7 +99,7 @@ function TokenUsageChartImpl({ data, chartType, startTime, endTime }: TokenUsage
 							tickLine={false}
 							axisLine={false}
 							width={50}
-							tickFormatter={formatTokens}
+							tickFormatter={(v) => formatCompactNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>
@@ -149,7 +150,7 @@ function TokenUsageChartImpl({ data, chartType, startTime, endTime }: TokenUsage
 							tickLine={false}
 							axisLine={false}
 							width={50}
-							tickFormatter={formatTokens}
+							tickFormatter={(v) => formatCompactNumber(v)}
 							domain={[0, (dataMax: number) => Math.max(dataMax, 1)]}
 							allowDataOverflow={false}
 						/>

--- a/ui/app/workspace/dashboard/components/mcpTab.tsx
+++ b/ui/app/workspace/dashboard/components/mcpTab.tsx
@@ -71,6 +71,7 @@ function MCPTabImpl({
 				testId="chart-mcp-volume"
 				totalLabel="Total"
 				total={mcpVolumeTotal !== null ? <NumberFlow value={mcpVolumeTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+				totalTooltip={mcpVolumeTotal !== null ? mcpVolumeTotal.toLocaleString("en-US") : undefined}
 				legend={
 					<div className={CHART_HEADER_LEGEND_CLASS}>
 						<span className="flex items-center gap-1">
@@ -105,6 +106,11 @@ function MCPTabImpl({
 						<NumberFlow value={mcpCostTotal} format={{ ...COMPACT_NUMBER_FORMAT, style: "currency", currency: "USD" }} />
 					) : undefined
 				}
+				totalTooltip={
+					mcpCostTotal !== null
+						? mcpCostTotal.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 6 })
+						: undefined
+				}
 				legend={
 					<div className={CHART_HEADER_LEGEND_CLASS}>
 						<span className="flex items-center gap-1">
@@ -113,7 +119,9 @@ function MCPTabImpl({
 						</span>
 					</div>
 				}
-				controls={<ChartTypeToggle chartType={mcpCostChartType} onToggle={onMcpCostChartToggle} data-testid="dashboard-mcp-cost-chart-toggle" />}
+				controls={
+					<ChartTypeToggle chartType={mcpCostChartType} onToggle={onMcpCostChartToggle} data-testid="dashboard-mcp-cost-chart-toggle" />
+				}
 			>
 				<MCPCostChart data={mcpCostData} chartType={mcpCostChartType} startTime={startTime} endTime={endTime} />
 			</ChartCard>
@@ -125,6 +133,7 @@ function MCPTabImpl({
 				testId="chart-mcp-top-tools"
 				totalLabel="Total"
 				total={mcpTopToolsTotal !== null ? <NumberFlow value={mcpTopToolsTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+				totalTooltip={mcpTopToolsTotal !== null ? mcpTopToolsTotal.toLocaleString("en-US") : undefined}
 			>
 				<MCPTopToolsChart data={mcpTopToolsData} />
 			</ChartCard>

--- a/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
+++ b/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
@@ -3,8 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import ProviderIcons, { type ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import type { ModelHistogramResponse, ModelRankingEntry, ModelRankingsResponse } from "@/lib/types/logs";
-import { formatCompactNumber as formatNumber } from "@/lib/utils/governance";
-import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
+import { COMPACT_NUMBER_FORMAT, formatCompactNumber as formatNumber } from "@/lib/utils/numbers";
 import NumberFlow from "@number-flow/react";
 import { ArrowDown, ArrowUp, ArrowUpDown, Minus } from "lucide-react";
 import { memo, useCallback, useMemo, useState } from "react";
@@ -233,6 +232,7 @@ function TopModelsChart({
 			className="z-[1] h-full"
 			totalLabel="Total"
 			total={grandTotal !== null ? <NumberFlow value={grandTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+			totalTooltip={grandTotal !== null ? grandTotal.toLocaleString("en-US") : undefined}
 		>
 			<div style={{ height: 200, marginBottom: 6 }}>
 				{chartData.length > 0 ? (

--- a/ui/app/workspace/dashboard/components/overviewTab.tsx
+++ b/ui/app/workspace/dashboard/components/overviewTab.tsx
@@ -1,6 +1,4 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
-import NumberFlow from "@number-flow/react";
 import type {
 	CostHistogramResponse,
 	LatencyHistogramResponse,
@@ -9,6 +7,8 @@ import type {
 	ModelHistogramResponse,
 	TokenHistogramResponse,
 } from "@/lib/types/logs";
+import { COMPACT_NUMBER_FORMAT } from "@/lib/utils/numbers";
+import NumberFlow from "@number-flow/react";
 import { memo, useMemo } from "react";
 import { CHART_COLORS, CHART_HEADER_LEGEND_CLASS, LATENCY_COLORS, getModelColor } from "../utils/chartUtils";
 import { ChartCard } from "./charts/chartCard";
@@ -159,6 +159,7 @@ function OverviewTabImpl({
 					testId="chart-log-volume"
 					totalLabel="Total"
 					total={volumeTotal !== null ? <NumberFlow value={volumeTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+					totalTooltip={volumeTotal !== null ? volumeTotal.toLocaleString("en-US") : undefined}
 					legend={
 						<div className={CHART_HEADER_LEGEND_CLASS}>
 							<span className="flex items-center gap-1">
@@ -171,7 +172,9 @@ function OverviewTabImpl({
 							</span>
 						</div>
 					}
-					controls={<ChartTypeToggle chartType={volumeChartType} onToggle={onVolumeChartToggle} data-testid="dashboard-volume-chart-toggle" />}
+					controls={
+						<ChartTypeToggle chartType={volumeChartType} onToggle={onVolumeChartToggle} data-testid="dashboard-volume-chart-toggle" />
+					}
 				>
 					<LogVolumeChart data={histogramData} chartType={volumeChartType} startTime={startTime} endTime={endTime} />
 				</ChartCard>
@@ -183,6 +186,7 @@ function OverviewTabImpl({
 					testId="chart-token-usage"
 					totalLabel="Total"
 					total={tokenTotal !== null ? <NumberFlow value={tokenTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+					totalTooltip={tokenTotal !== null ? tokenTotal.toLocaleString("en-US") : undefined}
 					legend={
 						<div className={CHART_HEADER_LEGEND_CLASS}>
 							<span className="flex items-center gap-1">
@@ -224,6 +228,11 @@ function OverviewTabImpl({
 						costTotal !== null ? (
 							<NumberFlow value={costTotal} format={{ ...COMPACT_NUMBER_FORMAT, style: "currency", currency: "USD" }} />
 						) : undefined
+					}
+					totalTooltip={
+						costTotal !== null
+							? costTotal.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 6 })
+							: undefined
 					}
 					legend={
 						<div className={CHART_HEADER_LEGEND_CLASS}>
@@ -300,6 +309,7 @@ function OverviewTabImpl({
 					testId="chart-model-usage"
 					totalLabel="Total"
 					total={modelUsageTotal !== null ? <NumberFlow value={modelUsageTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+					totalTooltip={modelUsageTotal !== null ? modelUsageTotal.toLocaleString("en-US") : undefined}
 					legend={
 						<div className={CHART_HEADER_LEGEND_CLASS}>
 							{usageModel === "all" ? (
@@ -380,6 +390,7 @@ function OverviewTabImpl({
 							<NumberFlow value={latencyAvg} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="ms" />
 						) : undefined
 					}
+					totalTooltip={latencyAvg !== null ? `${latencyAvg.toLocaleString("en-US", { maximumFractionDigits: 6 })}ms` : undefined}
 					legend={
 						<div className={CHART_HEADER_LEGEND_CLASS}>
 							<span className="flex items-center gap-1">
@@ -401,11 +412,7 @@ function OverviewTabImpl({
 						</div>
 					}
 					controls={
-						<ChartTypeToggle
-							chartType={latencyChartType}
-							onToggle={onLatencyChartToggle}
-							data-testid="dashboard-latency-chart-toggle"
-						/>
+						<ChartTypeToggle chartType={latencyChartType} onToggle={onLatencyChartToggle} data-testid="dashboard-latency-chart-toggle" />
 					}
 				>
 					<LatencyChart data={latencyData} chartType={latencyChartType} startTime={startTime} endTime={endTime} />

--- a/ui/app/workspace/dashboard/components/providerUsageTab.tsx
+++ b/ui/app/workspace/dashboard/components/providerUsageTab.tsx
@@ -131,6 +131,11 @@ function ProviderUsageTabImpl({
 						<NumberFlow value={providerCostTotal} format={{ ...COMPACT_NUMBER_FORMAT, style: "currency", currency: "USD" }} />
 					) : undefined
 				}
+				totalTooltip={
+					providerCostTotal !== null
+						? providerCostTotal.toLocaleString("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 6 })
+						: undefined
+				}
 				legend={
 					<div className={CHART_HEADER_LEGEND_CLASS}>
 						{providerCostProvider === "all" ? (
@@ -215,6 +220,7 @@ function ProviderUsageTabImpl({
 				testId="chart-provider-tokens"
 				totalLabel="Total"
 				total={providerTokenTotal !== null ? <NumberFlow value={providerTokenTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+				totalTooltip={providerTokenTotal !== null ? providerTokenTotal.toLocaleString("en-US") : undefined}
 				legend={
 					<div className={CHART_HEADER_LEGEND_CLASS}>
 						{providerTokenProvider === "all" ? (
@@ -303,6 +309,9 @@ function ProviderUsageTabImpl({
 					providerLatencyAvg !== null ? (
 						<NumberFlow value={providerLatencyAvg} format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }} suffix="ms" />
 					) : undefined
+				}
+				totalTooltip={
+					providerLatencyAvg !== null ? `${providerLatencyAvg.toLocaleString("en-US", { maximumFractionDigits: 6 })}ms` : undefined
 				}
 				legend={
 					<div className={CHART_HEADER_LEGEND_CLASS}>

--- a/ui/app/workspace/dashboard/utils/chartUtils.ts
+++ b/ui/app/workspace/dashboard/utils/chartUtils.ts
@@ -30,21 +30,13 @@ export function formatFullTimestamp(timestamp: string): string {
 
 // Format cost values
 export function formatCost(cost: number): string {
+	if (cost === 0) {
+		return `$0`;
+	}
 	if (cost < 0.01) {
 		return `$${cost.toFixed(4)}`;
 	}
 	return `$${cost.toFixed(2)}`;
-}
-
-// Format token values
-export function formatTokens(tokens: number): string {
-	if (tokens >= 1000000) {
-		return `${(tokens / 1000000).toFixed(1)}M`;
-	}
-	if (tokens >= 1000) {
-		return `${(tokens / 1000).toFixed(1)}K`;
-	}
-	return tokens.toLocaleString();
 }
 
 // Color palette for models. Length governs TOP_SERIES_LIMIT (top-N rollup cap),

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -1,4 +1,5 @@
-import { formatCost, formatLatency, formatTokens } from "@/app/workspace/dashboard/utils/chartUtils";
+import { formatCost, formatLatency } from "@/app/workspace/dashboard/utils/chartUtils";
+import { formatCompactNumber } from "@/lib/utils/numbers";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -764,14 +765,14 @@ export function LogDetailView({
 						mono
 						value={
 							log.token_usage
-								? `${formatTokens(log.token_usage.prompt_tokens ?? 0)} / ${formatTokens(log.token_usage.completion_tokens ?? 0)}`
+								? `${formatCompactNumber(log.token_usage.prompt_tokens ?? 0)} / ${formatCompactNumber(log.token_usage.completion_tokens ?? 0)}`
 								: "—"
 						}
 						sub={
 							log.token_usage
-								? `total ${formatTokens(log.token_usage.total_tokens ?? 0)}${
+								? `total ${formatCompactNumber(log.token_usage.total_tokens ?? 0)}${
 										log.token_usage.completion_tokens_details?.reasoning_tokens
-											? ` · reasoning ${formatTokens(log.token_usage.completion_tokens_details.reasoning_tokens)}`
+											? ` · reasoning ${formatCompactNumber(log.token_usage.completion_tokens_details.reasoning_tokens)}`
 											: ""
 									}`
 								: "—"

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -1,4 +1,5 @@
-import { formatCost, formatLatency, formatTokens } from "@/app/workspace/dashboard/utils/chartUtils";
+import { formatCost, formatLatency } from "@/app/workspace/dashboard/utils/chartUtils";
+import { formatCompactNumber } from "@/lib/utils/numbers";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
@@ -295,7 +296,7 @@ export const createColumns = (
 				return (
 					<div className="flex flex-col items-start gap-0.5 pl-4 leading-tight">
 						<div className="flex items-center gap-2">
-							<span className="font-mono text-[12px] tabular-nums">{formatTokens(total)}</span>
+							<span className="font-mono text-[12px] tabular-nums">{formatCompactNumber(total)}</span>
 							{hasSplit && (
 								<div className="flex h-1.5 w-[64px] overflow-hidden rounded-sm">
 									<div className="bg-blue-400" style={{ width: `${inPct}%` }} />
@@ -305,9 +306,9 @@ export const createColumns = (
 						</div>
 						{hasSplit && (
 							<div className="text-muted-foreground font-mono text-[10.5px] tabular-nums">
-								<span className="text-blue-500">{formatTokens(prompt)}</span>
+								<span className="text-blue-500">{formatCompactNumber(prompt)}</span>
 								<span> / </span>
-								<span className="text-violet-500">{formatTokens(completion)}</span>
+								<span className="text-violet-500">{formatCompactNumber(completion)}</span>
 							</div>
 						)}
 					</div>

--- a/ui/components/rateLimitDisplay.tsx
+++ b/ui/components/rateLimitDisplay.tsx
@@ -2,7 +2,7 @@ import { Progress } from "@/components/ui/progress";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { resetDurationLabels } from "@/lib/constants/governance";
 import { cn } from "@/lib/utils";
-import { formatCompactNumber } from "@/lib/utils/governance";
+import { formatCompactNumber } from "@/lib/utils/numbers";
 
 interface RateLimitShape {
 	token_max_limit?: number | null;

--- a/ui/lib/utils/governance.ts
+++ b/ui/lib/utils/governance.ts
@@ -24,23 +24,10 @@ export function parseResetPeriod(duration: string): string {
 	return `${timeValue} ${unitName}`;
 }
 
+import { formatCompactNumber } from "./numbers";
+
 export function formatCurrency(dollars: number) {
 	return `$${dollars.toFixed(2)}`;
-}
-
-/**
- * Formats a number compactly (e.g. 10000 → "10K", 1500000 → "1.5M").
- * Uses Intl.NumberFormat so boundary values promote correctly (999,950 → "1M", not "1000K")
- * and trailing zeros are dropped (10,000 → "10K", not "10.0K").
- */
-const compactNumberFormatter = new Intl.NumberFormat(undefined, {
-	notation: "compact",
-	maximumFractionDigits: 1,
-});
-
-export function formatCompactNumber(n: number): string {
-	if (Math.abs(n) >= 1_000) return compactNumberFormatter.format(n);
-	return n.toLocaleString();
 }
 
 const shortDurationLabels: Record<string, string> = {

--- a/ui/lib/utils/numbers.ts
+++ b/ui/lib/utils/numbers.ts
@@ -11,3 +11,16 @@ export function formatCompactNumber(value: number, maximumFractionDigits = 2): s
 		maximumFractionDigits,
 	}).format(value);
 }
+
+export function formatCurrencyNumber(value: number, maximumFractionDigits = 2): string {
+	if (!Number.isFinite(value)) return "$0";
+	if (value !== 0 && Math.abs(value) < 0.01) {
+		return `$${value.toFixed(4)}`;
+	}
+	return new Intl.NumberFormat("en-US", {
+		...COMPACT_NUMBER_FORMAT,
+		style: "currency",
+		currency: "USD",
+		maximumFractionDigits,
+	}).format(value);
+}


### PR DESCRIPTION
## Summary

Consolidates number formatting utilities across the dashboard and logs UI, and adds tooltip support to chart card totals so users can see the full unrounded value on hover.

## Changes

- Added a `totalTooltip` prop to `ChartCard` (and its internal `TotalChip`/`Header` components) that, when provided, wraps the total chip in a `Tooltip` so hovering reveals the precise value. All chart tabs (Overview, MCP, Provider Usage, Model Rankings) now pass full-precision tooltips for token counts, costs, and latency averages.
- Removed the local `formatTokens` function from `chartUtils.ts` and replaced all usages across chart components (`tokenUsageChart`, `modelUsageChart`, `logVolumeChart`, `mcpVolumeChart`, `mcpTopToolsChart`, `providerTokenChart`) with the shared `formatCompactNumber` from `lib/utils/numbers`.
- Added `formatCurrencyNumber` to `lib/utils/numbers` and replaced the ad-hoc `formatCost` calls used as Y-axis tick formatters in `costChart` and `providerCostChart` with it.
- Removed the duplicate `formatCompactNumber` implementation from `lib/utils/governance.ts`, replacing it with a re-export from `lib/utils/numbers`. Updated `rateLimitDisplay` and `modelRankingsTab` to import from the canonical location.
- Fixed a missing `$0` case in `formatCost` for zero values.
- Token display in the logs table columns and log detail view now uses `formatCompactNumber` instead of the removed `formatTokens`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

1. Open the dashboard and navigate to the Overview, MCP, Provider Usage, and Model Rankings tabs.
2. Hover over any chart card's total chip (e.g. "Total 1.2M") — a tooltip should appear showing the full unrounded number (e.g. "1,234,567").
3. For cost totals, the tooltip should show the full currency value with up to 6 decimal places.
4. For latency averages, the tooltip should show the value in milliseconds with up to 6 decimal places.
5. Verify Y-axis tick labels on token and cost charts render correctly.
6. Verify token counts in the logs table and log detail sheet display correctly.

## Screenshots/Recordings

Before: Chart card totals show compact numbers with no way to see the exact value.
After: Hovering the total chip reveals a tooltip with the full-precision number.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable