### PR TITLE
[feat]: use chat completions for openai custom providers that disable responses

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+[feat]: use chat completions for openai custom providers that disable responses [@kevinpdev](https://github.com/kevinpdev)

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1345,6 +1345,14 @@ func HandleOpenAIChatCompletionStreaming(
 
 // Responses performs a responses request to the OpenAI API.
 func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
+	if provider.shouldFallbackResponsesToChat(schemas.ResponsesRequest, schemas.ChatCompletionRequest) {
+		chatResponse, err := provider.ChatCompletion(ctx, key, request.ToChatRequest())
+		if err != nil {
+			return nil, err
+		}
+		return chatResponse.ToBifrostResponsesResponse(), nil
+	}
+
 	// Check if chat completion is allowed for this provider
 	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ResponsesRequest); err != nil {
 		return nil, err
@@ -1508,6 +1516,11 @@ func HandleOpenAIResponsesRequest(
 
 // ResponsesStream performs a streaming responses request to the OpenAI API.
 func (provider *OpenAIProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+	if provider.shouldFallbackResponsesToChat(schemas.ResponsesStreamRequest, schemas.ChatCompletionStreamRequest) {
+		ctx.SetValue(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback, true)
+		return provider.ChatCompletionStream(ctx, postHookRunner, postHookSpanFinalizer, key, request.ToChatRequest())
+	}
+
 	// Check if chat completion stream is allowed for this provider
 	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.ResponsesStreamRequest); err != nil {
 		return nil, err
@@ -1979,6 +1992,17 @@ func HandleOpenAIEmbeddingRequest(
 	}
 
 	return response, nil
+}
+
+// shouldFallbackResponsesToChat reports whether a Responses call should be
+// transparently translated into Chat Completions. This applies when a custom
+// provider disables the Responses operation but still allows Chat Completions.
+func (provider *OpenAIProvider) shouldFallbackResponsesToChat(responsesOp, chatOp schemas.RequestType) bool {
+	cfg := provider.customProviderConfig
+	if cfg == nil || cfg.AllowedRequests == nil {
+		return false
+	}
+	return !cfg.IsOperationAllowed(responsesOp) && cfg.IsOperationAllowed(chatOp)
 }
 
 // Speech handles non-streaming speech synthesis requests.


### PR DESCRIPTION
## Summary

The OpenAI provider in Bifrost can be reused as a base for OpenAI compatible custom providers. 

Some providers of openai compatible OSS models do not support the the responses api, only chat completions. Before this PR, calling responses against such a provider would error out.

One example of this is open source models in Azure AI Foundry like kimi k2, minimax, glm, etc...

The request flow that was initially broken that this PR now fixes is one like the following
```
claude code -> bifrost via anthropic integration -> azure foundry OSS model (chat completions only)
```

## Changes

When a custom provider has responses disabled but chat_completions allowed in its config, translate the Responses request into a Chat Completions call and convert the result back into the Responses shape, so a client calling Bifrost's Responses API still gets a valid Responses-shaped reply, even when the upstream provider only supports chat completions.


## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Setup a custom provider that points to an openai compatible model that only supports chat completions:

<img width="800"  alt="image" src="https://github.com/user-attachments/assets/8ac49d67-d519-4dbf-8cc0-db59eade6d5a" />


Then run claude code and point it at that model with that provider
```
ANTHROPIC_BASE_URL=http://localhost:<bifrost_port>/anthropic ANTHROPIC_MODEL="kimi-k2.6" ANTHROPIC_SMALL_FAST_MODEL="kimi-k2.6" claude
```

Before this PR we see these logs:
```
bifrost-1  | {"level":"debug","time":"2026-05-14T05:39:11Z","message":"attempting responses_stream request for provider azure-foundry"}
bifrost-1  | {"level":"debug","time":"2026-05-14T05:39:11Z","message":"request responses_stream for provider azure-foundry completed"}
bifrost-1  | {"level":"debug","time":"2026-05-14T05:39:11Z","message":"error while executing stream request: responses_stream is not supported by azure-foundry provider"}
```

<img width="900" alt="image" src="https://github.com/user-attachments/assets/38fd4ffb-2b72-4d1f-8264-a0050d35fd8f" />


After this PR we do not see those errors and we are succesful


<img width="900" alt="image" src="https://github.com/user-attachments/assets/671f5af4-f096-4d26-ada8-613ce5e70602" />


## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

## Related issues

Related to #2826 

## Security considerations

No security considerations

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


