### PR TITLE
fix: bedrock stop reason

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2738,9 +2738,8 @@ func (response *AnthropicMessageResponse) ToBifrostResponsesResponse(ctx *schema
 
 	bifrostResp.Model = response.Model
 
-	// Preserve stop reason from Anthropic response
 	if response.StopReason != "" {
-		bifrostResp.StopReason = schemas.Ptr(string(response.StopReason))
+		bifrostResp.StopReason = schemas.Ptr(ConvertAnthropicFinishReasonToBifrost(response.StopReason))
 	}
 
 	return bifrostResp

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -4069,9 +4069,9 @@ func TestBedrockStopReasonMapping(t *testing.T) {
 		{"MaxTokens", "max_tokens", "length"},
 		{"StopSequence", "stop_sequence", "stop"},
 		{"ToolUse", "tool_use", "tool_calls"},
-		{"GuardrailIntervened", "guardrail_intervened", "content_filter"},
+		{"GuardrailIntervened", "guardrail_intervened", "guardrail_intervened"}, // no clean mapping — passes through
 		{"ContentFiltered", "content_filtered", "content_filter"},
-		{"UnknownReason", "some_unknown_reason", "stop"},
+		{"UnknownReason", "some_unknown_reason", "some_unknown_reason"}, // no clean mapping — passes through
 	}
 
 	for _, tt := range tests {
@@ -4100,6 +4100,116 @@ func TestBedrockStopReasonMapping(t *testing.T) {
 			require.NotNil(t, bifrostResp.Choices[0].FinishReason)
 			assert.Equal(t, tt.expectedBifrost, *bifrostResp.Choices[0].FinishReason,
 				"Bedrock stop reason %q should map to %q", tt.bedrockStopReason, tt.expectedBifrost)
+		})
+	}
+}
+
+// TestBedrockStopReasonMappingResponsesPath tests stop reason normalisation for
+// the Responses API path (BedrockConverseResponse.ToBifrostResponsesResponse).
+func TestBedrockStopReasonMappingResponsesPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		bedrockReason   string
+		expectedBifrost string
+	}{
+		{"EndTurn", "end_turn", "stop"},
+		{"MaxTokens", "max_tokens", "length"},
+		{"StopSequence", "stop_sequence", "stop"},
+		{"ToolUse", "tool_use", "tool_calls"},
+		{"ContentFiltered", "content_filtered", "content_filter"},
+		{"GuardrailIntervened", "guardrail_intervened", "guardrail_intervened"}, // no clean mapping — passes through
+		{"UnknownReason", "some_unknown_reason", "some_unknown_reason"},         // no clean mapping — passes through
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := &bedrock.BedrockConverseResponse{
+				StopReason: tt.bedrockReason,
+				Output: &bedrock.BedrockConverseOutput{
+					Message: &bedrock.BedrockMessage{
+						Role: bedrock.BedrockMessageRoleAssistant,
+						Content: []bedrock.BedrockContentBlock{
+							{Text: schemas.Ptr("Response text")},
+						},
+					},
+				},
+			}
+
+			bifrostResp, err := response.ToBifrostResponsesResponse(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, bifrostResp)
+			require.NotNil(t, bifrostResp.StopReason, "StopReason should be set")
+			assert.Equal(t, tt.expectedBifrost, *bifrostResp.StopReason,
+				"Bedrock stop reason %q should map to %q in responses path", tt.bedrockReason, tt.expectedBifrost)
+		})
+	}
+}
+
+// TestBifrostToBedrockStopReasonReverseMapping tests the reverse conversion
+// (BifrostResponsesResponse.StopReason → BedrockConverseResponse.StopReason).
+func TestBifrostToBedrockStopReasonReverseMapping(t *testing.T) {
+	t.Parallel()
+
+	textOutput := []schemas.ResponsesMessage{
+		{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{
+					{
+						Type: schemas.ResponsesOutputMessageContentTypeText,
+						Text: schemas.Ptr("Hello"),
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		stopReason     *string
+		incompleteDetails *schemas.ResponsesResponseIncompleteDetails
+		expectedBedrock string
+	}{
+		{"Stop", schemas.Ptr("stop"), nil, "end_turn"},
+		{"Length", schemas.Ptr("length"), nil, "max_tokens"},
+		{"ToolCalls", schemas.Ptr("tool_calls"), nil, "tool_use"},
+		{"ContentFilter", schemas.Ptr("content_filter"), nil, "content_filtered"},
+		{"GuardrailIntervened", schemas.Ptr("guardrail_intervened"), nil, "guardrail_intervened"}, // passes through
+		{"UnknownPassthrough", schemas.Ptr("some_unknown_reason"), nil, "some_unknown_reason"},    // passes through
+		{
+			// StopReason takes priority over IncompleteDetails
+			name:            "StopReasonOverridesIncompleteDetails",
+			stopReason:      schemas.Ptr("stop"),
+			incompleteDetails: &schemas.ResponsesResponseIncompleteDetails{Reason: "max_tokens"},
+			expectedBedrock: "end_turn",
+		},
+		{
+			// IncompleteDetails is used when StopReason is nil
+			name:            "IncompleteDetailsFallback",
+			stopReason:      nil,
+			incompleteDetails: &schemas.ResponsesResponseIncompleteDetails{Reason: "max_tokens"},
+			expectedBedrock: "max_tokens",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := &schemas.BifrostResponsesResponse{
+				Output:            textOutput,
+				StopReason:        tt.stopReason,
+				IncompleteDetails: tt.incompleteDetails,
+			}
+
+			actual, err := bedrock.ToBedrockConverseResponse(input)
+			require.NoError(t, err)
+			require.NotNil(t, actual)
+			assert.Equal(t, tt.expectedBedrock, actual.StopReason,
+				"Bifrost stop reason %v should reverse-map to Bedrock %q", tt.stopReason, tt.expectedBedrock)
 		})
 	}
 }

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -844,17 +844,7 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 
 	case chunk.StopReason != nil:
 		// Stop reason - track it for the final response
-		var stopReason string
-		switch *chunk.StopReason {
-		case "tool_use":
-			stopReason = "tool_calls"
-		case "end_turn":
-			stopReason = "stop"
-		case "max_tokens":
-			stopReason = "length"
-		default:
-			stopReason = *chunk.StopReason
-		}
+		stopReason := convertBedrockStopReason(*chunk.StopReason)
 		state.StopReason = &stopReason
 		// Items should be closed explicitly when content blocks end
 		return nil, nil, false
@@ -2099,6 +2089,11 @@ func (response *BedrockConverseResponse) ToBifrostResponsesResponse(ctx *schemas
 		bifrostResp.ServiceTier = &response.ServiceTier.Type
 	}
 
+	if response.StopReason != "" {
+		stopReason := convertBedrockStopReason(response.StopReason)
+		bifrostResp.StopReason = &stopReason
+	}
+
 	return bifrostResp, nil
 }
 
@@ -2145,10 +2140,11 @@ func ToBedrockConverseResponse(bifrostResp *schemas.BifrostResponsesResponse) (*
 
 	bedrockResp.Output.Message = message
 
-	// Find stop reason from incomplete details or derive from response
-	// Priority: IncompleteDetails > tool_use detection > end_turn
+	// Derive stop reason: StopReason > IncompleteDetails > tool_use detection > end_turn
 	stopReason := "end_turn"
-	if bifrostResp.IncompleteDetails != nil {
+	if bifrostResp.StopReason != nil {
+		stopReason = convertBifrostToBedrockStopReason(*bifrostResp.StopReason)
+	} else if bifrostResp.IncompleteDetails != nil {
 		stopReason = bifrostResp.IncompleteDetails.Reason
 	} else if hasToolUse {
 		stopReason = "tool_use"

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -40,14 +40,21 @@ var (
 	multiSpaceRegex  = regexp.MustCompile(`\s{2,}`)
 
 	// bedrockFinishReasonToBifrost maps Bedrock Converse API stop reasons to Bifrost format.
-	// Bedrock has additional stop reasons beyond Anthropic (guardrail_intervened, content_filtered).
+	// Unmappable reasons (e.g. guardrail_intervened) are passed through as-is.
 	bedrockFinishReasonToBifrost = map[string]string{
-		"end_turn":             "stop",
-		"max_tokens":           "length",
-		"stop_sequence":        "stop",
-		"tool_use":             "tool_calls",
-		"guardrail_intervened": "content_filter",
-		"content_filtered":     "content_filter",
+		"end_turn":         "stop",
+		"max_tokens":       "length",
+		"stop_sequence":    "stop",
+		"tool_use":         "tool_calls",
+		"content_filtered": "content_filter",
+	}
+
+	// bifrostToBedrockStopReason is the reverse of bedrockFinishReasonToBifrost.
+	bifrostToBedrockStopReason = map[string]string{
+		"stop":           "end_turn",
+		"length":         "max_tokens",
+		"tool_calls":     "tool_use",
+		"content_filter": "content_filtered",
 	}
 )
 
@@ -56,7 +63,15 @@ func convertBedrockStopReason(stopReason string) string {
 	if reason, ok := bedrockFinishReasonToBifrost[stopReason]; ok {
 		return reason
 	}
-	return "stop"
+	return stopReason
+}
+
+// convertBifrostToBedrockStopReason converts a Bifrost stop reason back to Bedrock format.
+func convertBifrostToBedrockStopReason(bifrostReason string) string {
+	if reason, ok := bifrostToBedrockStopReason[bifrostReason]; ok {
+		return reason
+	}
+	return bifrostReason
 }
 
 // normalizeBedrockFilename normalizes a filename to meet Bedrock's requirements:


### PR DESCRIPTION
## Summary

Stop reason normalization was inconsistent across the Bedrock and Anthropic providers. Unknown or unmappable stop reasons (e.g. `guardrail_intervened`) were silently coerced to `"stop"`, and the Responses API path for Bedrock was not applying any stop reason conversion at all. This PR fixes both issues and adds a proper reverse mapping for converting Bifrost stop reasons back to Bedrock format.

## Changes

- `guardrail_intervened` no longer maps to `content_filter` — it passes through as-is since there is no clean semantic equivalent in the Bifrost format.
- Unknown stop reasons now pass through unchanged instead of defaulting to `"stop"`.
- Added `convertBifrostToBedrockStopReason` and a `bifrostToBedrockStopReason` reverse lookup map to support converting Bifrost stop reasons back to Bedrock format.
- `BedrockConverseResponse.ToBifrostResponsesResponse` now applies stop reason conversion via `convertBedrockStopReason`, which was previously missing.
- `ToBedrockConverseResponse` now prioritizes `StopReason` over `IncompleteDetails` when deriving the Bedrock stop reason.
- `AnthropicMessageResponse.ToBifrostResponsesResponse` now uses `ConvertAnthropicFinishReasonToBifrost` instead of passing the raw Anthropic stop reason string through.
- Added `TestBedrockStopReasonMappingResponsesPath` and `TestBifrostToBedrockStopReasonReverseMapping` to cover the Responses API path and reverse mapping behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... ./core/providers/anthropic/...
```

Expected: all existing and new tests pass, including `TestBedrockStopReasonMapping`, `TestBedrockStopReasonMappingResponsesPath`, and `TestBifrostToBedrockStopReasonReverseMapping`.

## Breaking changes

- [x] Yes
- [ ] No

`guardrail_intervened` previously mapped to `content_filter` in Bedrock stop reason normalization. It now passes through as `guardrail_intervened`. Consumers relying on the old mapping will need to handle this value explicitly.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable