### PR TITLE
[fix]: add missing padding to provider api structure form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .vscode
 .DS_Store
+.tool-versions
 *_creds*
 **/venv/
 **/__pycache__/**

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,1 @@
+[fix]: add missing padding to provider API structure form [@delm](https://github.com/delm)

--- a/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
@@ -96,7 +96,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 
 	return (
 		<Form {...form}>
-			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 p-0">
+			<form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6 px-6 pb-6">
 				<div className="flex flex-col gap-4">
 					<FormField
 						control={form.control}


### PR DESCRIPTION
## Summary

Fixes the custom provider API Structure form layout so the form content has the same horizontal and bottom spacing as the surrounding provider configuration UI. This prevents the form controls from sitting flush against the sheet edges.

Also ignores local `.tool-versions` files so developer runtime metadata does not get committed accidentally.

## Changes

- Restored padding on the provider API Structure form by replacing `p-0` with `px-6 pb-6`.
- Added `.tool-versions` to `.gitignore` to keep local toolchain version files out of the repository.
- Kept the change scoped to presentation and local development metadata; no API, schema, or data model behavior changed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Validate manually in the UI:

1. Open the workspace Providers page.
2. Open a custom provider configuration.
3. Navigate to the API Structure configuration form.
4. Confirm the form content is padded consistently with the sheet and is not flush against the left, right, or bottom edges.

Optional verification:

```sh
cd ui
pnpm build || npm run build
```

Expected outcome: the UI build succeeds and the API Structure form spacing matches the rest of the provider configuration UI.

No new configs or environment variables were added.

## Screenshots/Recordings

Before:

<img width="820" height="931" alt="image" src="https://github.com/user-attachments/assets/c24d6c4e-0ff8-4f1d-8443-02028e322d92" />

After:

<img width="1263" height="962" alt="image" src="https://github.com/user-attachments/assets/6d8e420f-bda3-42f4-a80c-8d0d97751f9b" />

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

None linked.

## Security considerations

No auth, secrets, PII, or sandboxing behavior is affected. Adding `.tool-versions` to `.gitignore` reduces the chance of committing local environment metadata.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable