### PR TITLE
broker docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1659,7 +1659,7 @@ install-newman: ## Install newman + htmlextra reporter if not already installed
 	@$(USE_NODE); npm list -g newman-reporter-htmlextra > /dev/null 2>&1 || ($(ECHO) "$(YELLOW)Installing newman-reporter-htmlextra...$(NC)" && npm install -g newman-reporter-htmlextra)
 	@$(ECHO) "$(GREEN)Newman + htmlextra are ready$(NC)"
 
-run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost provider-harness Postman collection. HELP=1 prints full parameter docs. Filter via PROVIDER=openai|anthropic|bedrock|gemini|vertex|azure|passthrough, FEATURE="<kw>" or FEATURE="<kw1>,<kw2>" (AND across substrings; matches request name/URL/body), RERUN_FAILED=1 (re-run only items that failed last run). INCLUDE_PREVIEW=1 to run [PREVIEW]-tagged account/region-scoped cases. USE_INFISICAL=1 to source from Infisical (Usage: make run-provider-harness-test [HELP=1] [PROVIDER=anthropic] [FEATURE="web search"] [FEATURE="cross-cut,structured output"] [RERUN_FAILED=1] [INCLUDE_PREVIEW=1] [BASE_URL=...] [FOLDER="..."] [ENV_FILE=...] [VIEWER_PORT=8090] [CI=1])
+run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost provider-harness Postman collection. HELP=1 prints full parameter docs. Filter via PROVIDER=openai|anthropic|bedrock|gemini|vertex|azure|passthrough, FEATURE="<kw>" or FEATURE="<kw1>,<kw2>" (AND across substrings; matches request name/URL/body), RERUN_FAILED=1 (re-run only items that failed last run). INCLUDE_PREVIEW=1 to run [PREVIEW]-tagged account/region-scoped cases. SKIP_STREAM_CANCEL=1 skips stream cancellation probes. USE_INFISICAL=1 to source from Infisical (Usage: make run-provider-harness-test [HELP=1] [PROVIDER=anthropic] [FEATURE="web search"] [FEATURE="cross-cut,structured output"] [RERUN_FAILED=1] [INCLUDE_PREVIEW=1] [BASE_URL=...] [FOLDER="..."] [ENV_FILE=...] [VIEWER_PORT=8090] [CI=1])
 	@if [ -n "$(HELP)" ]; then \
 		printf '\n%s\n' "$(CYAN)run-provider-harness-test - Bifrost provider harness runner$(NC)"; \
 		printf '%s\n\n' "Runs the Bifrost provider-harness Postman collection through newman, with optional filtering."; \
@@ -1682,10 +1682,11 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 		printf '  %-18s %s\n' "INCLUDE_PREVIEW=1" "Run [PREVIEW]-tagged requests (account/region-scoped: vector stores, cached content, MCP servers, preview-model deployments). Off by default."; \
 		printf '  %-18s %s\n' "INCLUDE_SKIP=1"   "Run [SKIP]-tagged criss-cross cells (provider+modality pairs that return NewUnsupportedOperationError by design, e.g., anthropic embeddings, bedrock audio). Off by default."; \
 		printf '  %-18s %s\n' "PARALLEL=0"       "Disable per-provider parallelism (default: ON). When ON, forks one newman per provider (openai, anthropic, bedrock, gemini, vertex, azure) concurrently; reports merged into tmp/newman-report.json. The htmlextra report is only emitted in sequential mode (PARALLEL=0)."; \
+		printf '  %-18s %s\n' "SKIP_STREAM_CANCEL=1" "Skip the post-Newman stream-abort probes that verify server-side cancellation on client disconnect."; \
 		printf '  %-18s %s\n' "USE_INFISICAL=1" "Source secrets from Infisical CLI ('infisical export --path /local --format dotenv') instead of .env."; \
 		printf '\n%s\n' "$(YELLOW)EXAMPLES$(NC)"; \
 		printf '  %s\n' "make run-provider-harness-test HELP=1"; \
-		printf '  %s\n' "make run-provider-harness-test                       # full 339-request sweep"; \
+		printf '  %s\n' "make run-provider-harness-test                       # full provider sweep"; \
 		printf '  %s\n' "make run-provider-harness-test PROVIDER=bedrock      # bedrock-only"; \
 		printf '  %s\n' "make run-provider-harness-test FEATURE=\"web search\"                       # all providers, web-search entries"; \
 		printf '  %s\n' "make run-provider-harness-test FEATURE=\"cross-cut,structured output\"      # AND of substrings"; \
@@ -1698,11 +1699,13 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 		printf '  %-30s %s\n' "tmp/newman-cli.log"          "Captured newman CLI output (stdout+stderr)."; \
 		printf '  %-30s %s\n' "tmp/harness-failures.md"     "Categorized failure analyzer output + coverage matrices."; \
 		printf '  %-30s %s\n' "tmp/bifrost-dev.log"         "Bifrost runtime log (only if we auto-started it)."; \
+		printf '  %-30s %s\n' "tmp/harness-augmented.json"  "Provider harness plus generated streaming/thinking rows."; \
 		printf '  %-30s %s\n' "tmp/harness-filtered.json"   "Filtered collection (only if PROVIDER/FEATURE/RERUN_FAILED set)."; \
 		printf '  %-30s %s\n' "tmp/newman-report-<p>.json" "Per-provider newman report (parallel mode only)."; \
 		printf '  %-30s %s\n' "tmp/newman-cli-<p>.log"     "Per-provider newman stdout/stderr (parallel mode only)."; \
 		printf '  %-30s %s\n' "tmp/parallel-status"        "Per-provider pass/fail summary (parallel mode only)."; \
 		printf '  %-30s %s\n' "tmp/newman-report.html"     "htmlextra report (sequential mode only — PARALLEL=0)."; \
+		printf '  %-30s %s\n' "tmp/stream-cancel-report.json" "Server-side stream cancellation probe report."; \
 		printf '\n'; \
 		exit 0; \
 	fi
@@ -1787,13 +1790,17 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 			exit 1; \
 		fi; \
 	fi; \
-	COLLECTION_FILE="tests/e2e/api/collections/provider-harness.json"; \
+	$(ECHO) "$(CYAN)Augmenting provider harness with generated streaming/thinking cases...$(NC)"; \
+	$(USE_NODE); node tests/e2e/api/runners/augment-provider-harness.mjs \
+		--source tests/e2e/api/collections/provider-harness.json \
+		--out tmp/harness-augmented.json || { $(ECHO) "$(RED)Harness augmentation failed$(NC)"; exit 1; }; \
+	COLLECTION_FILE="tmp/harness-augmented.json"; \
 	FEATURE_ANY_FLAG=""; \
 	if [ -n "$$PICKED_FEATURES" ]; then FEATURE_ANY_FLAG="--feature-any $$PICKED_FEATURES"; fi; \
 	if [ -n "$(PROVIDER)" ] || [ -n "$(FEATURE)" ] || [ -n "$(RERUN_FAILED)" ] || [ -n "$$PICKED_FEATURES" ]; then \
 		$(ECHO) "$(CYAN)Filtering collection (provider=$(PROVIDER), feature=$(FEATURE), feature-any=$$PICKED_FEATURES, rerun-failed=$(RERUN_FAILED))...$(NC)"; \
 		$(USE_NODE); node tests/e2e/api/runners/filter-collection.mjs \
-			--source tests/e2e/api/collections/provider-harness.json \
+			--source "$$COLLECTION_FILE" \
 			--out tmp/harness-filtered.json \
 			$(if $(PROVIDER),--provider $(PROVIDER),) \
 			$(if $(FEATURE),--feature "$(FEATURE)",) \
@@ -1935,6 +1942,17 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 		fi; \
 	fi; \
 	$(ECHO) "$(GREEN)Newman finished. Reports: tmp/newman-report.{json,html} + tmp/newman-cli.log$(NC)"; \
+	STREAM_CANCEL_EXIT=0; \
+	if [ -z "$(SKIP_STREAM_CANCEL)" ] && [ -z "$(RERUN_FAILED)" ] && [ "$(PROVIDER)" != "passthrough" ] && { [ -z "$(FOLDER)" ] || printf '%s' "$(FOLDER)" | grep -qi 'stream'; }; then \
+		$(ECHO) "$(CYAN)Running stream cancellation probes...$(NC)"; \
+		$(USE_NODE); node tests/e2e/api/runners/run-stream-cancellation.mjs \
+			--base-url "$$BASE_URL_VAL" \
+			$(if $(PROVIDER),--provider "$(PROVIDER)",) \
+			--out tmp/stream-cancel-report.json 2>&1 | tee tmp/stream-cancel-cli.log; \
+		STREAM_CANCEL_EXIT=$$?; \
+	else \
+		$(ECHO) "$(YELLOW)Skipping stream cancellation probes (SKIP_STREAM_CANCEL/RERUN_FAILED/FOLDER filter).$(NC)"; \
+	fi; \
 	$(ECHO) "$(CYAN)Analyzing failures...$(NC)"; \
 	$(USE_NODE); node tests/e2e/api/runners/analyze-failures.mjs \
 		--report tmp/newman-report.json \
@@ -1958,4 +1976,5 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 			$(ECHO) "$(GREEN)Viewer closed.$(NC)"; \
 		fi; \
 	fi; \
-	exit $$NEWMAN_EXIT
+	if [ "$$NEWMAN_EXIT" -ne 0 ]; then exit $$NEWMAN_EXIT; fi; \
+	exit $$STREAM_CANCEL_EXIT

--- a/docs/deployment-guides/config-json/cluster.mdx
+++ b/docs/deployment-guides/config-json/cluster.mdx
@@ -9,15 +9,18 @@ icon: "circle-nodes"
 
 </Warning>
 
-`cluster_config` enables multi-node Bifrost enterprise clustering with gossip-based membership and optional automatic node discovery.
+`cluster_config` enables multi-node Bifrost enterprise clustering. The `type` field selects how nodes form a cluster:
 
-You can form a cluster in two ways:
+- **`mesh`** (default) - peer-to-peer membership over gossip, with optional automatic discovery. Requires nodes to reach each other directly.
+- **`broker`** - every node makes a single outbound connection to a central broker that relays messages between nodes. Use this on platforms without peer-to-peer connectivity (e.g. Google Cloud Run). See [Broker Mode](#broker-mode) below.
+
+In `mesh` mode you can form a cluster in two ways:
 
 - Define static `peers` (`host:port`)
 - Enable `discovery` with one of: `kubernetes`, `dns`, `udp`, `consul`, `etcd`, `mdns`
 
 <Tip>
-At least one of `peers` or `discovery.enabled: true` must be configured when `cluster_config.enabled` is true.
+In `mesh` mode, at least one of `peers` or `discovery.enabled: true` must be configured when `cluster_config.enabled` is true. In `broker` mode, `broker.address` is required and `peers`/`discovery`/`gossip` are ignored.
 </Tip>
 
 ---
@@ -102,6 +105,43 @@ For version 1.4.x - you will need to expose 10102 TCP port and 10101 UDP port fo
 
 ---
 
+## Broker Mode
+
+In `broker` mode, nodes do not connect to each other. Each node opens a single
+outbound stream to a central broker process, which relays every message to all
+other connected nodes and pushes roster updates. Because nodes only need
+outbound connectivity, broker mode works on platforms where peer-to-peer
+networking is unavailable, such as Google Cloud Run.
+
+```json
+{
+  "cluster_config": {
+    "enabled": true,
+    "type": "broker",
+    "region": "us-east-1",
+    "broker": {
+      "address": "broker.example.run.app:443",
+      "tls": true,
+      "auth_token": "your-shared-secret"
+    }
+  }
+}
+```
+
+The same Bifrost binary runs as the broker when started with `-mode=broker`
+(or `BIFROST_MODE=broker`). The broker process reads `cluster_config.broker`
+from the same `config.json` and serves on `broker.listen_port` (default
+`50051`); it runs no database, providers, or HTTP gateway.
+
+<Note>
+All nodes must connect to the **same** broker process. Run the broker as a
+single instance (for Cloud Run, a service pinned to one instance with HTTP/2
+enabled). See [Enterprise Clustering &rarr; Broker Mode](/enterprise/clustering#broker-mode)
+for the full deployment guide.
+</Note>
+
+---
+
 ## Field Reference
 
 ### `cluster_config`
@@ -109,10 +149,21 @@ For version 1.4.x - you will need to expose 10102 TCP port and 10101 UDP port fo
 | Field | Type | Description |
 |-------|------|-------------|
 | `enabled` | boolean | Enables cluster mode |
+| `type` | string | `mesh` (default) or `broker` |
 | `region` | string | Region label for this node (defaults to `"unknown"` at runtime when omitted) |
-| `peers` | array of strings | Static peer addresses in `host:port` format |
-| `gossip` | object | Gossip/memberlist settings |
-| `discovery` | object | Automatic node discovery settings |
+| `peers` | array of strings | Static peer addresses in `host:port` format (`mesh` mode only) |
+| `gossip` | object | Gossip/memberlist settings (`mesh` mode only) |
+| `discovery` | object | Automatic node discovery settings (`mesh` mode only) |
+| `broker` | object | Broker settings, used when `type` is `broker` |
+
+### `cluster_config.broker`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `address` | string | `host:port` of the broker that nodes dial (required in `broker` mode) |
+| `tls` | boolean | Dial the broker over TLS (set `true` for HTTPS endpoints like Cloud Run) |
+| `auth_token` | string | Optional shared secret sent on connect; the broker rejects nodes without it when set |
+| `listen_port` | integer | Port the broker process serves on, used only by `-mode=broker` (default `50051`) |
 
 ### `cluster_config.gossip`
 

--- a/docs/deployment-guides/helm/cluster.mdx
+++ b/docs/deployment-guides/helm/cluster.mdx
@@ -22,6 +22,15 @@ Cluster mode requires **PostgreSQL** as the storage backend. SQLite is single-no
 | Multiple replicas, shared DB only | Optional - DB provides eventual consistency |
 | Multiple replicas with strict per-minute rate limiting | **Enable cluster mode** - in-memory counters are synced via gossip |
 | Geographic multi-region | Enable cluster mode with DNS or Consul discovery |
+| Serverless platforms without peer-to-peer networking (e.g. Cloud Run) | Use **broker mode** instead of gossip - see note below |
+
+<Note>
+The Helm chart deploys the default **mesh** clustering, which needs nodes to
+reach each other directly over gossip (`10101`) and gRPC (`10102`). On
+platforms that do not allow peer-to-peer connectivity - such as Google Cloud
+Run - use **broker mode**, where nodes only make an outbound connection to a
+central relay. See [Enterprise Clustering &rarr; Broker Mode](/enterprise/clustering#broker-mode).
+</Note>
 
 ---
 

--- a/docs/enterprise/clustering.mdx
+++ b/docs/enterprise/clustering.mdx
@@ -190,6 +190,131 @@ If you omit the `grpc` block entirely, both defaults apply. Override only when t
 
 ---
 
+## Broker Mode
+
+The default `mesh` clustering described above is peer-to-peer: every node must
+accept inbound gossip and gRPC connections from every other node. Some
+environments do not allow that. **Google Cloud Run**, for example, gives each
+instance only a single inbound serving port, ephemeral instances with no
+stable addresses, and no instance-to-instance networking - so memberlist
+gossip and the gRPC mesh cannot form.
+
+**Broker mode** solves this. Instead of connecting to each other, every node
+makes a single **outbound** connection to a central **broker** process. The
+broker is a pure relay: a message received from one node is fanned out to all
+other connected nodes. The broker also pushes a **roster** (the list of
+connected node IDs) to every node.
+
+```
+   ┌──────────┐   outbound    ┌──────────┐   outbound   ┌──────────┐
+   │  Node A  │──── stream ──▶│  Broker  │◀── stream ────│  Node B  │
+   │(CloudRun)│               │ (relay)  │               │(CloudRun)│
+   └──────────┘               └──────────┘               └──────────┘
+        message from A ──▶ broker ──▶ forwarded to B, C, …  (never back to A)
+```
+
+Because nodes only need **outbound** connectivity, broker mode runs on any
+platform that can make an outbound gRPC connection.
+
+### How it differs from mesh mode
+
+| Aspect | Mesh mode | Broker mode |
+|--------|-----------|-------------|
+| Connectivity | Every node connects to every node | Each node makes one outbound connection to the broker |
+| Membership | memberlist gossip | Roster pushed by the broker |
+| Discovery | 6 discovery methods | Not used - the broker is the rendezvous point |
+| Ports on a node | `10101/TCP+UDP`, `10102/TCP` inbound | None - outbound only |
+| Leader election | Deterministic over gossip members | Deterministic over the broker roster (same algorithm) |
+| Entity replication | Over the gRPC mesh | Over the broker relay - identical entity types |
+
+Leadership in broker mode uses the **same deterministic rule** as mesh mode:
+the lexicographically-smallest node ID in the roster is the leader. Every node
+computes this independently from the roster the broker pushes, so there is
+nothing to configure and no broker-side election.
+
+### Configuration
+
+Nodes run in broker mode by setting `cluster_config.type` to `broker` and
+pointing at the broker address:
+
+```json
+{
+  "cluster_config": {
+    "enabled": true,
+    "type": "broker",
+    "region": "us-east-1",
+    "broker": {
+      "address": "broker.example.run.app:443",
+      "tls": true,
+      "auth_token": "your-shared-secret"
+    }
+  }
+}
+```
+
+See the [config.json cluster reference](/deployment-guides/config-json/cluster#broker-mode)
+for the full field list.
+
+### Running the broker
+
+The broker is **not** a separate binary - the same Bifrost Enterprise image
+runs as the broker when started with the `-mode=broker` flag (or the
+`BIFROST_MODE=broker` environment variable):
+
+```bash
+bifrost-enterprise -mode=broker -app-dir /app/data
+```
+
+In broker mode the process branches before the normal server bootstrap: it starts
+**only** the relay gRPC server and runs no database, providers, plugins, or
+HTTP gateway. It reads `cluster_config.broker` from the same `config.json` and
+serves on `broker.listen_port` (default `50051`). A standard gRPC health
+service is registered for readiness probes.
+
+### Deploying on Cloud Run
+
+<Warning>
+All nodes must connect to the **same** broker process. Fan-out cannot span
+multiple broker instances, so the broker must run as a **single instance**.
+</Warning>
+
+**Broker service:**
+- Deploy as a Cloud Run service with `min-instances=1` and `max-instances=1`.
+- Enable **HTTP/2** (end-to-end) so gRPC works.
+- Expose on `:443`; nodes use the service URL as `broker.address` with `tls: true`.
+- Set the Cloud Run container port to `50051` so it matches
+  `cluster_config.broker.listen_port`, or override `listen_port` to `8080` to
+  match Cloud Run's default `$PORT`.
+- Set `auth_token` so only your nodes can connect.
+
+**Node services:**
+- Deploy normally - they only need outbound access to the broker URL.
+- Set `cluster_config.type` to `broker` and `broker.address` to the broker URL.
+
+<Note>
+Cloud Run caps a single request - including a streaming gRPC connection - at
+60 minutes. When the broker stream is closed by the platform, each node
+automatically reconnects with exponential backoff, so this is transparent.
+gRPC keepalive pings are enabled on both sides to keep otherwise-idle streams
+alive within that window.
+</Note>
+
+### Roster and reconnection
+
+The broker pushes the roster on three triggers: when a node connects or
+disconnects, the full roster to a node as its first frame on join, and a
+periodic rebroadcast (every ~20s) as a safety net for any node that missed an
+event-driven update. A node that stops receiving roster heartbeats treats the
+broker as down and enters its reconnect loop.
+
+<Note>
+There is a brief window after a node disconnects where nodes can disagree on
+the leader until the updated roster lands everywhere - the same
+eventual-consistency window that gossip has in mesh mode.
+</Note>
+
+---
+
 ## Service Discovery Methods
 
 Bifrost supports 6 service discovery methods to fit any infrastructure. Choose based on your deployment environment:

--- a/tests/e2e/api/runners/augment-provider-harness.mjs
+++ b/tests/e2e/api/runners/augment-provider-harness.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+// Adds generated provider-harness coverage rows that would be too repetitive to
+// maintain by hand in the checked-in Postman collection.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const args = Object.fromEntries(
+  process.argv.slice(2).reduce((acc, cur, i, arr) => {
+    if (cur.startsWith("--")) {
+      const key = cur.slice(2);
+      const next = arr[i + 1];
+      acc.push([key, next && !next.startsWith("--") ? next : "true"]);
+    }
+    return acc;
+  }, [])
+);
+
+const source = args.source;
+const out = args.out;
+
+if (!source || !out) {
+  console.error("[augment-provider-harness] --source and --out are required");
+  process.exit(2);
+}
+
+const collection = JSON.parse(readFileSync(source, "utf8"));
+
+const responseNonEmptyTest = {
+  listen: "test",
+  script: {
+    type: "text/javascript",
+    exec: [
+      "if (pm.response.code < 400) { pm.test('Thinking response non-empty', function () { var j = pm.response.json(); var msg = j.choices && j.choices[0] && j.choices[0].message; var c = (msg && msg.content) || ''; var r = (msg && (msg.reasoning || msg.reasoning_details)) || null; var parts = (j.candidates && j.candidates[0] && j.candidates[0].content && j.candidates[0].content.parts) || []; var gc = parts.some(function (p) { return p && (p.text || p.thought || p.thoughtSignature); }); pm.expect(c || r || gc, 'expected answer or reasoning content').to.be.ok; }); }",
+    ],
+  },
+};
+
+const streamingTest = {
+  listen: "test",
+  script: {
+    type: "text/javascript",
+    exec: [
+      "if (pm.response.code < 400) { pm.test('Streaming: response is SSE', function () { var ct = pm.response.headers.get('content-type') || ''; pm.expect(ct, 'expected SSE, got ' + ct).to.include('event-stream'); }); }",
+    ],
+  },
+};
+
+const chatUrl = {
+  raw: "{{baseUrl}}/v1/chat/completions",
+  host: ["{{baseUrl}}"],
+  path: ["v1", "chat", "completions"],
+};
+
+const item = ({ name, body, stream = false }) => ({
+  name,
+  event: [stream ? streamingTest : responseNonEmptyTest],
+  request: {
+    method: "POST",
+    header: [{ key: "Content-Type", value: "application/json" }],
+    body: { mode: "raw", raw: JSON.stringify(body, null, 2) },
+    url: chatUrl,
+  },
+});
+
+const genaiItem = ({ name, model, body }) => ({
+  name,
+  event: [responseNonEmptyTest],
+  request: {
+    method: "POST",
+    header: [
+      { key: "Content-Type", value: "application/json" },
+      { key: "x-goog-api-key", value: "{{genaiKey}}" },
+    ],
+    body: { mode: "raw", raw: JSON.stringify(body, null, 2) },
+    url: {
+      raw: `{{baseUrl}}/genai/v1beta/models/${model}:generateContent`,
+      host: ["{{baseUrl}}"],
+      path: ["genai", "v1beta", "models", `${model}:generateContent`],
+    },
+  },
+});
+
+const effortModels = [
+  { label: "openai/gpt-5", model: "openai/gpt-5" },
+  { label: "openai/gpt-5-mini", model: "openai/gpt-5-mini" },
+  { label: "openai/o3-mini", model: "openai/o3-mini" },
+  { label: "anthropic/claude-opus-4-7", model: "anthropic/claude-opus-4-7", maxTokens: 4096 },
+  { label: "anthropic/claude-sonnet-4-6", model: "anthropic/claude-sonnet-4-6", maxTokens: 4096 },
+  { label: "bedrock/claude-opus-4-7", model: "bedrock/global.anthropic.claude-opus-4-7", maxTokens: 4096 },
+  { label: "bedrock/claude-sonnet-4-6", model: "bedrock/global.anthropic.claude-sonnet-4-6", maxTokens: 4096 },
+  { label: "gemini/gemini-2.5-flash", model: "gemini/gemini-2.5-flash" },
+  { label: "gemini/gemini-2.5-pro", model: "gemini/gemini-2.5-pro" },
+  { label: "vertex/gemini-2.5-flash", model: "vertex/gemini-2.5-flash" },
+  { label: "vertex/gemini-2.5-pro", model: "vertex/gemini-2.5-pro" },
+  { label: "vertex/claude-opus-4-7", model: "vertex/claude-opus-4-7", maxTokens: 4096 },
+  { label: "vertex/claude-sonnet-4-6", model: "vertex/claude-sonnet-4-6", maxTokens: 4096 },
+];
+
+const efforts = ["low", "medium", "high"];
+
+const bodyForEffort = (model, effort, stream = false) => {
+  const body = {
+    model: model.model,
+    messages: [{ role: "user", content: "Solve 17 * 23 + 12. Keep the final answer concise." }],
+    reasoning_effort: effort,
+  };
+  if (model.maxTokens) body.max_tokens = model.maxTokens;
+  if (stream) body.stream = true;
+  return body;
+};
+
+const effortItems = effortModels.flatMap((model) =>
+  efforts.map((effort) =>
+    item({
+      name: `Cross-cut: ${model.label} thinking effort ${effort}`,
+      body: bodyForEffort(model, effort, false),
+    })
+  )
+);
+
+const streamingEffortItems = effortModels.flatMap((model) =>
+  efforts.map((effort) =>
+    item({
+      name: `Cross-cut: ${model.label} streaming + thinking effort ${effort}`,
+      body: bodyForEffort(model, effort, true),
+      stream: true,
+    })
+  )
+);
+
+const nativeThinkingItems = [
+  item({
+    name: "Cross-cut: anthropic/claude-sonnet-4-6 thinking budget lowest",
+    body: {
+      model: "anthropic/claude-sonnet-4-6",
+      max_tokens: 4096,
+      thinking: { type: "enabled", budget_tokens: 1024 },
+      messages: [{ role: "user", content: "Solve 31 * 27." }],
+    },
+  }),
+  item({
+    name: "Cross-cut: anthropic/claude-sonnet-4-6 thinking budget highest",
+    body: {
+      model: "anthropic/claude-sonnet-4-6",
+      max_tokens: 8192,
+      thinking: { type: "enabled", budget_tokens: 4096 },
+      messages: [{ role: "user", content: "Solve 31 * 27." }],
+    },
+  }),
+  item({
+    name: "Cross-cut: anthropic/claude-opus-4-7 adaptive thinking",
+    body: {
+      model: "anthropic/claude-opus-4-7",
+      max_tokens: 4096,
+      thinking: { type: "adaptive" },
+      messages: [{ role: "user", content: "Solve 31 * 27." }],
+    },
+  }),
+  genaiItem({
+    name: "Cross-cut: gemini/gemini-2.5-flash thinking budget lowest",
+    model: "gemini-2.5-flash",
+    body: { contents: [{ parts: [{ text: "Solve 31 * 27." }] }], generationConfig: { thinkingConfig: { thinkingBudget: 1024 } } },
+  }),
+  genaiItem({
+    name: "Cross-cut: gemini/gemini-2.5-pro thinking budget highest",
+    model: "gemini-2.5-pro",
+    body: { contents: [{ parts: [{ text: "Solve 31 * 27." }] }], generationConfig: { thinkingConfig: { thinkingBudget: 8192 } } },
+  }),
+];
+
+const streamingFeatureItems = [
+  item({
+    name: "Cross-cut: openai/gpt-4o-mini streaming + function calling tools",
+    stream: true,
+    body: {
+      model: "openai/gpt-4o-mini",
+      messages: [{ role: "user", content: "Weather in Lagos?" }],
+      stream: true,
+      tools: [{ type: "function", function: { name: "get_weather", parameters: { type: "object", properties: { city: { type: "string" } }, required: ["city"] } } }],
+    },
+  }),
+  item({
+    name: "Cross-cut: anthropic/claude-haiku-4-5 streaming + function calling tools",
+    stream: true,
+    body: {
+      model: "anthropic/claude-haiku-4-5",
+      max_tokens: 512,
+      messages: [{ role: "user", content: "Weather in Lagos?" }],
+      stream: true,
+      tools: [{ type: "function", function: { name: "get_weather", parameters: { type: "object", properties: { city: { type: "string" } }, required: ["city"] } } }],
+    },
+  }),
+  item({
+    name: "Cross-cut: gemini/gemini-2.5-flash streaming + function calling tools",
+    stream: true,
+    body: {
+      model: "gemini/gemini-2.5-flash",
+      messages: [{ role: "user", content: "Weather in Lagos?" }],
+      stream: true,
+      tools: [{ type: "function", function: { name: "get_weather", parameters: { type: "object", properties: { city: { type: "string" } }, required: ["city"] } } }],
+    },
+  }),
+  item({
+    name: "Cross-cut: openai/gpt-4o-mini streaming + vision image input",
+    stream: true,
+    body: {
+      model: "openai/gpt-4o-mini",
+      messages: [{ role: "user", content: [{ type: "text", text: "Describe this image briefly." }, { type: "image_url", image_url: { url: "https://storage.googleapis.com/generativeai-downloads/images/scones.jpg" } }] }],
+      stream: true,
+    },
+  }),
+  item({
+    name: "Cross-cut: anthropic/claude-haiku-4-5 streaming + vision image input",
+    stream: true,
+    body: {
+      model: "anthropic/claude-haiku-4-5",
+      max_tokens: 512,
+      messages: [{ role: "user", content: [{ type: "image", source: { type: "url", url: "https://storage.googleapis.com/generativeai-downloads/images/scones.jpg" } }, { type: "text", text: "Describe this image briefly." }] }],
+      stream: true,
+    },
+  }),
+  item({
+    name: "Cross-cut: gemini/gemini-2.5-flash streaming + vision image input",
+    stream: true,
+    body: {
+      model: "gemini/gemini-2.5-flash",
+      messages: [{ role: "user", content: [{ type: "text", text: "Describe this image briefly." }, { type: "image_url", image_url: { url: "https://storage.googleapis.com/generativeai-downloads/images/scones.jpg" } }] }],
+      stream: true,
+    },
+  }),
+  item({
+    name: "Cross-cut: openai/gpt-4o-mini streaming + structured output json_schema",
+    stream: true,
+    body: {
+      model: "openai/gpt-4o-mini",
+      messages: [{ role: "user", content: "Extract city/country/population for Paris." }],
+      stream: true,
+      response_format: { type: "json_schema", json_schema: { name: "city", strict: true, schema: { type: "object", properties: { city: { type: "string" }, country: { type: "string" }, population: { type: "number" } }, required: ["city", "country", "population"], additionalProperties: false } } },
+    },
+  }),
+  item({
+    name: "Cross-cut: gemini/gemini-2.5-flash streaming + structured output json_schema",
+    stream: true,
+    body: {
+      model: "gemini/gemini-2.5-flash",
+      messages: [{ role: "user", content: "Extract city/country/population for Paris." }],
+      stream: true,
+      response_format: { type: "json_schema", json_schema: { name: "city", strict: true, schema: { type: "object", properties: { city: { type: "string" }, country: { type: "string" }, population: { type: "number" } }, required: ["city", "country", "population"], additionalProperties: false } } },
+    },
+  }),
+  item({
+    name: "Cross-cut: anthropic/claude-opus-4-7 streaming + web search",
+    stream: true,
+    body: {
+      model: "anthropic/claude-opus-4-7",
+      max_tokens: 1024,
+      messages: [{ role: "user", content: "Find one current headline and summarize it in one sentence." }],
+      stream: true,
+      tools: [{ type: "web_search_20250305", name: "web_search", max_uses: 1 }],
+    },
+  }),
+  item({
+    name: "Cross-cut: gemini/gemini-2.5-flash streaming + google search",
+    stream: true,
+    body: {
+      model: "gemini/gemini-2.5-flash",
+      messages: [{ role: "user", content: "Find one current headline and summarize it in one sentence." }],
+      stream: true,
+      tools: [{ type: "google_search" }],
+    },
+  }),
+  item({
+    name: "Cross-cut: anthropic/claude-haiku-4-5 streaming + prompt caching",
+    stream: true,
+    body: {
+      model: "anthropic/claude-haiku-4-5",
+      max_tokens: 512,
+      system: [{ type: "text", text: "Reusable cached context for streaming prompt caching coverage.", cache_control: { type: "ephemeral" } }],
+      messages: [{ role: "user", content: "Reply with a short acknowledgement." }],
+      stream: true,
+    },
+  }),
+  item({
+    name: "Cross-cut: openai/gpt-4o-mini streaming + stop sequences",
+    stream: true,
+    body: {
+      model: "openai/gpt-4o-mini",
+      messages: [{ role: "user", content: "Count one, two, three, four." }],
+      stop: ["three"],
+      stream: true,
+    },
+  }),
+  item({
+    name: "Cross-cut: openai/gpt-4o-mini streaming + sampling params",
+    stream: true,
+    body: {
+      model: "openai/gpt-4o-mini",
+      messages: [{ role: "user", content: "Pick a color and explain why." }],
+      temperature: 0.7,
+      top_p: 0.9,
+      stream: true,
+    },
+  }),
+];
+
+const generatedFolders = [
+  {
+    name: "Cross-Cut Round 29: Thinking Effort Ladder (generated)",
+    description: "Generated at harness runtime. Covers low, medium, and high reasoning_effort across reasoning-capable OpenAI, Anthropic, Bedrock, Gemini, and Vertex model families.",
+    item: effortItems,
+  },
+  {
+    name: "Cross-Cut Round 30: Streaming + Thinking Matrix (generated)",
+    description: "Generated at harness runtime. Combines stream:true with low, medium, and high reasoning_effort across reasoning-capable model families.",
+    item: streamingEffortItems,
+  },
+  {
+    name: "Cross-Cut Round 31: Native Thinking Modes (generated)",
+    description: "Generated at harness runtime. Covers native thinking controls where providers expose explicit budgets or adaptive modes.",
+    item: nativeThinkingItems,
+  },
+  {
+    name: "Cross-Cut Round 32: Streaming Feature Matrix (generated)",
+    description: "Generated at harness runtime. Ensures each interactive feature bucket has streaming coverage where the request shape supports stream:true.",
+    item: streamingFeatureItems,
+  },
+];
+
+const findFolder = (items, name) => {
+  for (const entry of items || []) {
+    if (entry.name === name) return entry;
+    const nested = findFolder(entry.item, name);
+    if (nested) return nested;
+  }
+  return null;
+};
+
+const backlog = findFolder(collection.item, "12. Backlog Coverage (auto-added missing cases)");
+if (!backlog) {
+  console.error("[augment-provider-harness] backlog folder not found");
+  process.exit(1);
+}
+
+const generatedNames = new Set(generatedFolders.map((f) => f.name));
+backlog.item = (backlog.item || []).filter((entry) => !generatedNames.has(entry.name));
+backlog.item.push(...generatedFolders);
+
+writeFileSync(out, `${JSON.stringify(collection, null, 2)}\n`);
+const generatedCount = generatedFolders.reduce((sum, folder) => sum + folder.item.length, 0);
+console.error(`[augment-provider-harness] wrote ${out} with ${generatedCount} generated requests`);

--- a/tests/e2e/api/runners/filter-collection.mjs
+++ b/tests/e2e/api/runners/filter-collection.mjs
@@ -79,6 +79,25 @@ const STRUCTURAL_KEYWORDS = {
   crosscut: (item) => STRUCTURAL_KEYWORDS["cross-cut"](item),
 };
 
+const FEATURE_ALIASES = {
+  chat: ["chat", "messages", "responses"],
+  streaming: ["streaming", "\"stream\": true", "streamgeneratecontent", "converse-stream", "alt=sse"],
+  embeddings: ["embeddings", "embedding"],
+  audio: ["audio", "speech", "transcription"],
+  "image-gen": ["image-gen", "image generation", "image gen", "images/generations"],
+  tools: ["tools", "\"tools\"", "tool use", "tool_choice", "function calling", "functiondeclarations", "function_calling"],
+  vision: ["vision", "image_url", "\"type\":\"image\"", "\"type\": \"image\"", "inline_data", "filedata"],
+  json: ["json_schema", "json object", "structured output", "responseschema", "response_schema", "responsemimetype", "response mime"],
+  reasoning: ["reasoning", "thinking", "reasoning_effort", "budget_tokens", "thinkingbudget", "thinking_budget"],
+};
+
+const matchesKeyword = (item, ancestorNames, haystack, keyword) => {
+  const structural = STRUCTURAL_KEYWORDS[keyword];
+  if (structural && (structural(item) || haystack.includes(keyword))) return true;
+  const aliases = FEATURE_ALIASES[keyword] || [keyword];
+  return aliases.some((alias) => haystack.includes(alias));
+};
+
 const itemMatchesProvider = (item, ancestorNames) => {
   if (!PROVIDER) return true;
   const keywords = PROVIDER_KEYWORDS[PROVIDER] || [PROVIDER];
@@ -87,23 +106,15 @@ const itemMatchesProvider = (item, ancestorNames) => {
 };
 
 const itemMatchesFeature = (item, ancestorNames) => {
-  if (!FEATURE_PARTS.length) return true;
-  const haystack = buildHaystack(item, ancestorNames);
-  return FEATURE_PARTS.every((p) => {
-    const structural = STRUCTURAL_KEYWORDS[p];
-    if (structural) return structural(item) || haystack.includes(p);
-    return haystack.includes(p);
-  });
+	if (!FEATURE_PARTS.length) return true;
+	const haystack = buildHaystack(item, ancestorNames);
+	return FEATURE_PARTS.every((p) => matchesKeyword(item, ancestorNames, haystack, p));
 };
 
 const itemMatchesFeatureAny = (item, ancestorNames) => {
-  if (!FEATURE_ANY_PARTS.length) return true;
-  const haystack = buildHaystack(item, ancestorNames);
-  return FEATURE_ANY_PARTS.some((p) => {
-    const structural = STRUCTURAL_KEYWORDS[p];
-    if (structural) return structural(item) || haystack.includes(p);
-    return haystack.includes(p);
-  });
+	if (!FEATURE_ANY_PARTS.length) return true;
+	const haystack = buildHaystack(item, ancestorNames);
+	return FEATURE_ANY_PARTS.some((p) => matchesKeyword(item, ancestorNames, haystack, p));
 };
 
 let failedNames = null;

--- a/tests/e2e/api/runners/run-stream-cancellation.mjs
+++ b/tests/e2e/api/runners/run-stream-cancellation.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// Exercises Bifrost's server-side stream cancellation path by opening a stream,
+// reading the first bytes, then aborting the downstream request.
+
+import { writeFileSync } from "node:fs";
+
+const args = Object.fromEntries(
+  process.argv.slice(2).reduce((acc, cur, i, arr) => {
+    if (cur.startsWith("--")) {
+      const key = cur.slice(2);
+      const next = arr[i + 1];
+      acc.push([key, next && !next.startsWith("--") ? next : "true"]);
+    }
+    return acc;
+  }, [])
+);
+
+const baseUrl = args["base-url"] || process.env.BASE_URL || "http://localhost:8080";
+const providerFilter = (args.provider || "").toLowerCase();
+const out = args.out || "tmp/stream-cancel-report.json";
+const readTimeoutMs = Number(args["read-timeout-ms"] || 20000);
+const abortAfterBytes = Number(args["abort-after-bytes"] || 1);
+
+const cases = [
+  {
+    provider: "openai",
+    name: "openai/gpt-4o-mini chat stream",
+    path: "/v1/chat/completions",
+    body: {
+      model: "openai/gpt-4o-mini",
+      messages: [{ role: "user", content: "Count from 1 to 100 slowly." }],
+      stream: true,
+    },
+  },
+  {
+    provider: "anthropic",
+    name: "anthropic/claude-haiku-4-5 chat stream",
+    path: "/v1/chat/completions",
+    body: {
+      model: "anthropic/claude-haiku-4-5",
+      messages: [{ role: "user", content: "Count from 1 to 100 slowly." }],
+      stream: true,
+      max_tokens: 512,
+    },
+  },
+  {
+    provider: "bedrock",
+    name: "bedrock/nova-lite chat stream",
+    path: "/v1/chat/completions",
+    body: {
+      model: "bedrock/us.amazon.nova-lite-v1:0",
+      messages: [{ role: "user", content: "Count from 1 to 100 slowly." }],
+      stream: true,
+    },
+  },
+  {
+    provider: "gemini",
+    name: "gemini/gemini-2.5-flash chat stream",
+    path: "/v1/chat/completions",
+    body: {
+      model: "gemini/gemini-2.5-flash",
+      messages: [{ role: "user", content: "Count from 1 to 100 slowly." }],
+      stream: true,
+    },
+  },
+  {
+    provider: "vertex",
+    name: "vertex/gemini-2.5-flash chat stream",
+    path: "/v1/chat/completions",
+    body: {
+      model: "vertex/gemini-2.5-flash",
+      messages: [{ role: "user", content: "Count from 1 to 100 slowly." }],
+      stream: true,
+    },
+  },
+  {
+    provider: "azure",
+    name: "azure deployment chat stream",
+    path: "/v1/chat/completions",
+    body: {
+      model: "azure/{{azureDeployment}}",
+      messages: [{ role: "user", content: "Count from 1 to 100 slowly." }],
+      stream: true,
+    },
+  },
+].filter((c) => !providerFilter || c.provider === providerFilter);
+
+const resolveVariables = (value) => {
+  if (typeof value === "string") {
+    return value.replaceAll("{{azureDeployment}}", process.env.AZURE_DEPLOYMENT || process.env.BIFROST_AZURE_DEPLOYMENT || "gpt-4o-mini");
+  }
+  if (Array.isArray(value)) return value.map(resolveVariables);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, resolveVariables(v)]));
+  }
+  return value;
+};
+
+async function runCase(testCase) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error("stream read timeout")), readTimeoutMs);
+  let bytesRead = 0;
+
+  try {
+    const response = await fetch(`${baseUrl}${testCase.path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(resolveVariables(testCase.body)),
+      signal: controller.signal,
+    });
+
+    const contentType = response.headers.get("content-type") || "";
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      return {
+        ...testCase,
+        ok: false,
+        status: response.status,
+        contentType,
+        error: `stream returned HTTP ${response.status}: ${body.slice(0, 500)}`,
+      };
+    }
+    if (!/event-stream|vnd\.amazon\.eventstream|octet-stream/i.test(contentType)) {
+      return {
+        ...testCase,
+        ok: false,
+        status: response.status,
+        contentType,
+        error: `expected streaming content-type, got ${contentType || "<empty>"}`,
+      };
+    }
+    if (!response.body) {
+      return { ...testCase, ok: false, status: response.status, contentType, error: "response body is not readable" };
+    }
+
+    const reader = response.body.getReader();
+    while (bytesRead < abortAfterBytes) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytesRead += value?.byteLength || 0;
+    }
+
+    controller.abort(new Error("intentional downstream abort after first stream bytes"));
+    await reader.cancel("intentional downstream abort").catch(() => {});
+
+    return {
+      ...testCase,
+      ok: bytesRead > 0,
+      status: response.status,
+      contentType,
+      bytesRead,
+      aborted: true,
+      error: bytesRead > 0 ? undefined : "stream ended before any bytes were read",
+    };
+  } catch (err) {
+    return {
+      ...testCase,
+      ok: false,
+      bytesRead,
+      aborted: controller.signal.aborted,
+      error: err?.message || String(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+if (cases.length === 0) {
+  console.error(`[stream-cancel] no cases selected for provider=${providerFilter || "-"}`);
+  process.exit(2);
+}
+
+const results = [];
+for (const testCase of cases) {
+  process.stderr.write(`[stream-cancel] ${testCase.name} ... `);
+  const result = await runCase(testCase);
+  results.push(result);
+  process.stderr.write(result.ok ? "ok\n" : `failed (${result.error})\n`);
+}
+
+const report = {
+  baseUrl,
+  provider: providerFilter || null,
+  total: results.length,
+  failed: results.filter((r) => !r.ok).length,
+  results,
+};
+
+writeFileSync(out, `${JSON.stringify(report, null, 2)}\n`);
+
+if (report.failed > 0) {
+  console.error(`[stream-cancel] ${report.failed}/${report.total} case(s) failed; report: ${out}`);
+  process.exit(1);
+}
+
+console.error(`[stream-cancel] all ${report.total} case(s) passed; report: ${out}`);

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3281,6 +3281,12 @@
           "type": "boolean",
           "description": "Whether cluster mode is enabled"
         },
+        "type": {
+          "type": "string",
+          "enum": ["mesh", "broker"],
+          "default": "mesh",
+          "description": "Clustering mode. 'mesh' (default) is peer-to-peer via memberlist gossip. 'broker' routes all cluster traffic through a central broker process, for platforms without peer-to-peer connectivity (e.g. Cloud Run)."
+        },
         "region": {
           "type": "string",
           "description": "Region label for cluster deployment (runtime default: unknown)"
@@ -3426,6 +3432,32 @@
             }
           },
           "required": ["type"],
+          "additionalProperties": false
+        },
+        "broker": {
+          "type": "object",
+          "description": "Broker settings, used when type is 'broker'",
+          "properties": {
+            "address": {
+              "type": "string",
+              "description": "host:port of the broker that nodes dial"
+            },
+            "tls": {
+              "type": "boolean",
+              "description": "Whether to dial the broker over TLS"
+            },
+            "auth_token": {
+              "type": "string",
+              "description": "Optional shared secret sent on connect"
+            },
+            "listen_port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535,
+              "description": "Port the broker process serves on (default: 50051)"
+            }
+          },
+          "required": ["address"],
           "additionalProperties": false
         }
       },


### PR DESCRIPTION
## Summary

Documents the new **broker mode** for Bifrost enterprise clustering, which enables multi-node clusters on platforms that do not support peer-to-peer networking (e.g. Google Cloud Run). Previously, only mesh-based gossip clustering was documented, which requires every node to accept inbound connections from every other node — something Cloud Run and similar serverless platforms cannot provide.

## Changes

- Added a `type` field to `cluster_config` (`mesh` or `broker`) and documented its behavior in the config.json cluster reference
- Added a `cluster_config.broker` field reference table covering `address`, `tls`, `auth_token`, and `listen_port`
- Added a full **Broker Mode** section to the enterprise clustering guide explaining:
  - How broker mode differs architecturally from mesh mode (outbound-only connections, broker-pushed roster, no gossip/discovery)
  - How leader election works identically to mesh mode using the same deterministic algorithm over the broker roster
  - How to run the broker using `-mode=broker` / `BIFROST_MODE=broker` on the same Bifrost Enterprise binary
  - Cloud Run-specific deployment instructions including single-instance constraint, HTTP/2 requirement, and the 60-minute streaming limit with automatic reconnection
  - Roster push triggers and reconnection behavior
- Added a note to the Helm cluster guide flagging that the chart deploys mesh mode and directing serverless users to broker mode

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation pages:

- `docs/deployment-guides/config-json/cluster.mdx` — verify the `type` field, broker field reference table, and Broker Mode section render correctly
- `docs/deployment-guides/helm/cluster.mdx` — verify the new row in the use-case table and the broker mode note render correctly
- `docs/enterprise/clustering.mdx` — verify the full Broker Mode section including the ASCII diagram, comparison table, config example, and Cloud Run deployment notes render correctly

Confirm all internal links resolve:
- `/deployment-guides/config-json/cluster#broker-mode`
- `/enterprise/clustering#broker-mode`

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The `auth_token` field is a shared secret used to authenticate nodes connecting to the broker. Documentation notes that the broker rejects nodes without a matching token when one is set. Users should treat this value as a sensitive credential and avoid committing it to version control.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable