### PR TITLE
fix: adds prefill message handling for responses in bedrock

### DIFF
--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1665,7 +1665,16 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 
 	// map bifrost messages to bedrock messages using the new conversion method
 	if bifrostReq.Input != nil {
-		messages, systemMessages, err := ConvertBifrostMessagesToBedrockMessages(ctx, bifrostReq.Input)
+		input := bifrostReq.Input
+		if schemas.IsAnthropicModel(bifrostReq.Model) && ctx.Value(schemas.BifrostContextKeySupportsAssistantPrefill) == false {
+			trimmed := len(input)
+			for trimmed > 0 && input[trimmed-1].Role != nil && *input[trimmed-1].Role == schemas.ResponsesInputMessageRoleAssistant {
+				trimmed--
+			}
+			input = input[:trimmed]
+		}
+
+		messages, systemMessages, err := ConvertBifrostMessagesToBedrockMessages(ctx, input)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert Responses messages: %w", err)
 		}


### PR DESCRIPTION
## Summary

When using Anthropic models via the Bedrock Responses API, trailing assistant-role messages are stripped from the input when the model does not support assistant prefill. This prevents request failures caused by sending assistant-prefill content to models that cannot handle it.

## Changes

- Before converting Bifrost messages to Bedrock messages, trailing assistant-role messages are removed from the input slice when the model is an Anthropic model and the `BifrostContextKeySupportsAssistantPrefill` context value is `false`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a Responses API request to an Anthropic model via Bedrock where the input includes a trailing assistant message and the context indicates prefill is not supported. Verify the request succeeds and the trailing assistant message is not forwarded to Bedrock.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable