### PR TITLE
fix: build fix for ent

### DIFF
--- a/ui/lib/utils/governance.ts
+++ b/ui/lib/utils/governance.ts
@@ -1,3 +1,7 @@
+import { formatCompactNumber } from "./numbers";
+
+export { formatCompactNumber };
+
 /**
  * Parses a duration string (e.g., "1m", "5m", "1h", "1d", "1w", "1M") into human readable format
  */
@@ -23,8 +27,6 @@ export function parseResetPeriod(duration: string): string {
 	const unitName = timeValue === 1 ? unit.singular : unit.plural;
 	return `${timeValue} ${unitName}`;
 }
-
-import { formatCompactNumber } from "./numbers";
 
 export function formatCurrency(dollars: number) {
 	return `$${dollars.toFixed(2)}`;


### PR DESCRIPTION
## Summary

Moves the `formatCompactNumber` import and re-export to the top of `governance.ts` to follow conventional module organization where imports and exports are declared before function definitions.

## Changes

- Relocated the `import { formatCompactNumber }` statement from mid-file to the top of `governance.ts`
- Added an explicit `export { formatCompactNumber }` re-export alongside the import, keeping the public API intact

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable