### PR TITLE
[fix]: openai provider - add usage to completed event in responses to chat completions fallback

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+[fix]: openai provider - add usage to completed event in responses to chat completions fallback [@kevinpdev](https://github.com/kevinpdev)

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1119,6 +1119,8 @@ func HandleOpenAIChatCompletionStreaming(
 		var modelName string
 		var created int
 		forwardedTerminalFinishReason := false
+		// Defer final completed/incomplete event until usage chunk arrives (fallback path only).
+		var pendingFinalEvent *schemas.BifrostResponsesStreamResponse
 
 		for {
 			// If context was cancelled/timed out, let defer handle it
@@ -1181,6 +1183,31 @@ func HandleOpenAIChatCompletionStreaming(
 			}
 
 			if isResponsesToChatCompletionsFallback {
+				// Accumulate usage across chunks; attached to final event below.
+				if response.Usage != nil {
+					if response.Usage.PromptTokens > usage.PromptTokens {
+						usage.PromptTokens = response.Usage.PromptTokens
+					}
+					if response.Usage.CompletionTokens > usage.CompletionTokens {
+						usage.CompletionTokens = response.Usage.CompletionTokens
+					}
+					if response.Usage.TotalTokens > usage.TotalTokens {
+						usage.TotalTokens = response.Usage.TotalTokens
+					}
+					if calculatedTotal := usage.PromptTokens + usage.CompletionTokens; calculatedTotal > usage.TotalTokens {
+						usage.TotalTokens = calculatedTotal
+					}
+					if response.Usage.PromptTokensDetails != nil {
+						usage.PromptTokensDetails = response.Usage.PromptTokensDetails
+					}
+					if response.Usage.CompletionTokensDetails != nil {
+						usage.CompletionTokensDetails = response.Usage.CompletionTokensDetails
+					}
+					if response.Usage.Cost != nil {
+						usage.Cost = response.Usage.Cost
+					}
+				}
+
 				spreadResponses := response.ToBifrostResponsesStreamResponse(responsesStreamState)
 				for _, response := range spreadResponses {
 					if response.Type == schemas.ResponsesStreamResponseTypeError {
@@ -1212,14 +1239,9 @@ func HandleOpenAIChatCompletionStreaming(
 					}
 
 					if response.Type == schemas.ResponsesStreamResponseTypeCompleted || response.Type == schemas.ResponsesStreamResponseTypeIncomplete {
-						// Set raw request if enabled
-						if sendBackRawRequest {
-							providerUtils.ParseAndSetRawRequest(&response.ExtraFields, jsonBody)
-						}
-						response.ExtraFields.Latency = time.Since(startTime).Milliseconds()
-						ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
-						providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, response, nil, nil, nil), responseChan, postHookSpanFinalizer)
-						return
+						// Defer sending until stream end so usage can be attached.
+						pendingFinalEvent = response
+						continue
 					}
 
 					response.ExtraFields.Latency = time.Since(lastChunkTime).Milliseconds()
@@ -1321,7 +1343,19 @@ func HandleOpenAIChatCompletionStreaming(
 			}
 		}
 
-		if !isResponsesToChatCompletionsFallback {
+		if isResponsesToChatCompletionsFallback {
+			if pendingFinalEvent != nil {
+				if pendingFinalEvent.Response != nil && pendingFinalEvent.Response.Usage == nil {
+					pendingFinalEvent.Response.Usage = usage.ToResponsesResponseUsage()
+				}
+				if sendBackRawRequest {
+					providerUtils.ParseAndSetRawRequest(&pendingFinalEvent.ExtraFields, jsonBody)
+				}
+				pendingFinalEvent.ExtraFields.Latency = time.Since(startTime).Milliseconds()
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+				providerUtils.ProcessAndSendResponse(ctx, postHookRunner, providerUtils.GetBifrostResponseForStreamResponse(nil, nil, pendingFinalEvent, nil, nil, nil), responseChan, postHookSpanFinalizer)
+			}
+		} else {
 			finalFinishReason := finishReason
 			if forwardedTerminalFinishReason {
 				finalFinishReason = nil

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1121,6 +1121,7 @@ func HandleOpenAIChatCompletionStreaming(
 		forwardedTerminalFinishReason := false
 		// Defer final completed/incomplete event until usage chunk arrives (fallback path only).
 		var pendingFinalEvent *schemas.BifrostResponsesStreamResponse
+		usageSeen := false
 
 		for {
 			// If context was cancelled/timed out, let defer handle it
@@ -1185,6 +1186,7 @@ func HandleOpenAIChatCompletionStreaming(
 			if isResponsesToChatCompletionsFallback {
 				// Accumulate usage across chunks; attached to final event below.
 				if response.Usage != nil {
+					usageSeen = true
 					if response.Usage.PromptTokens > usage.PromptTokens {
 						usage.PromptTokens = response.Usage.PromptTokens
 					}
@@ -1345,7 +1347,7 @@ func HandleOpenAIChatCompletionStreaming(
 
 		if isResponsesToChatCompletionsFallback {
 			if pendingFinalEvent != nil {
-				if pendingFinalEvent.Response != nil && pendingFinalEvent.Response.Usage == nil {
+				if usageSeen && pendingFinalEvent.Response != nil && pendingFinalEvent.Response.Usage == nil {
 					pendingFinalEvent.Response.Usage = usage.ToResponsesResponseUsage()
 				}
 				if sendBackRawRequest {

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -1347,7 +1347,7 @@ func HandleOpenAIChatCompletionStreaming(
 
 		if isResponsesToChatCompletionsFallback {
 			if pendingFinalEvent != nil {
-				if usageSeen && pendingFinalEvent.Response != nil && pendingFinalEvent.Response.Usage == nil {
+				if usageSeen && pendingFinalEvent.Response != nil {
 					pendingFinalEvent.Response.Usage = usage.ToResponsesResponseUsage()
 				}
 				if sendBackRawRequest {


### PR DESCRIPTION
## Summary

When a responses streaming request to bifrost falls back to chat completions, bifrost streams from the upstream provider (OpenAI, Azure Openai, etc.) and translates each chunk into a responses event for the caller.

While many providers emit usage data in the same chunk as the finish_reason, some providers emit a finish_reason first and then usage data one chunk later. Bifrost currenly forwards response.completed/response.incomplete as soon as finish_reason chunk arrives. This makes the caller's terminal event have usage unset if the usage chunk comes after.

This applies to azure foundry and also openai provider (when a model supports chat completions but not responses). This could also fix the bug in other providers if they have the same multiple-chunk behavior.

Upstream chunk order:
  ...content deltas...
  { ..., "finish_reason": "stop", "usage": null }   <- we sent terminal here (bug)
  { ..., "usage": {...} }                           <- arrives too late

Fix: accumulate usage from every chunk, hold the terminal event until the upstream stream ends, then attach usage before sending. Native chat-completion and Responses streaming paths are unchanged.

The fix is done on openai provider because this will fix any provider that relies on it, including any custom providers built on top of it.

## Changes

- `core/providers/openai/openai.go`: in the Responses->Chat Completions fallback path, defer the terminal
  `response.completed`/`response.incomplete` event until the upstream stream ends and attach accumulated usage
   before sending.
- `core/changelog.md`: changelog entry.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

The easiest reproduction for this is using an OSS model on azure foundry, and making your own custom provider for it. To reproduce you need to be on top of #3505 or you will run into other errors first.

Below is an example of using kimi-k2.6 on azure foundry. Azure foundry sends usage in a separate chunk after the response_completed = true chunk.

Request:
```
curl -sN http://localhost:8080/v1/responses \
    -H "content-type: application/json" \
    -d '{"model":"azure-foundry/kimi-k2.6","input":"Count from 1 to 10","stream":true}'
```

Provider:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/02f965f1-d5bc-4b85-bbc2-ea81c49691a5" />


Before (see usage field):
```
{
    "type": "response.completed",
    "sequence_number": 59,
    "response": {
        "id": "c68b48991033427a941b65a22d821120",
        "object": "",
        "created_at": 1778822303,
        "completed_at": null,
        "error": null,
        "incomplete_details": null,
        "instructions": null,
        "max_output_tokens": null,
        "max_tool_calls": null,
        "model": "Kimi-K2.6",
        "output": [
            {
                "id": "msg_c68b48991033427a941b65a22d821120_item_0",
                "type": "message",
                "status": "completed",
                "role": "assistant",
                "content": [
                    {
                        "type": "output_text",
                        "text": "1, 2, 3, 4, 5, 6, 7, 8, 9, 10.",
                        "annotations": [],
                        "logprobs": []
                    }
                ]
            }
        ],
        "previous_response_id": null,
        "prompt_cache_key": null,
        "reasoning": null,
        "safety_identifier": null,
        "service_tier": null,
        "status": "completed",
        "tools": null,
        "usage": null,
        "extra_fields": {
            "request_type": "",
            "latency": 0,
            "chunk_index": 0
        }
    },
    "item": null,
    "logprobs": null,
    "extra_fields": {
        "request_type": "responses_stream",
        "provider": "azure-foundry",
        "original_model_requested": "kimi-k2.6",
        "resolved_model_used": "Kimi-K2.6",
        "latency": 612,
        "chunk_index": 59
    }
}
```

After (see usage field):
```
{
    "type": "response.completed",
    "sequence_number": 78,
    "response": {
        "id": "59ec3c4a66844ff8a86a0a18d595ddbd",
        "object": "",
        "created_at": 1778822187,
        "completed_at": null,
        "error": null,
        "incomplete_details": null,
        "instructions": null,
        "max_output_tokens": null,
        "max_tool_calls": null,
        "model": "Kimi-K2.6",
        "output": [
            {
                "id": "msg_59ec3c4a66844ff8a86a0a18d595ddbd_item_0",
                "type": "message",
                "status": "completed",
                "role": "assistant",
                "content": [
                    {
                        "type": "output_text",
                        "text": "1, 2, 3, 4, 5, 6, 7, 8, 9, 10",
                        "annotations": [],
                        "logprobs": []
                    }
                ]
            }
        ],
        "previous_response_id": null,
        "prompt_cache_key": null,
        "reasoning": null,
        "safety_identifier": null,
        "service_tier": null,
        "status": "completed",
        "tools": null,
        "usage": {
            "input_tokens": 15,
            "input_tokens_details": {
                "cached_read_tokens": 2,
                "cached_write_tokens": 0,
                "cached_tokens": 2
            },
            "output_tokens": 196,
            "output_tokens_details": null,
            "total_tokens": 211
        },
        "extra_fields": {
            "request_type": "",
            "latency": 0,
            "chunk_index": 0
        }
    },
    "item": null,
    "logprobs": null,
    "extra_fields": {
        "request_type": "responses_stream",
        "provider": "azure-foundry",
        "original_model_requested": "kimi-k2.6",
        "resolved_model_used": "Kimi-K2.6",
        "latency": 154,
        "chunk_index": 78
    }
}
```

## Screenshots/Recordings

See above

## Breaking changes

- [ ] Yes
- [x] No

- The change only affects the Responses→Chat Completions fallback streaming path.
- Callers previously received a terminal event with usage: null; now they receive the same terminal event with usage populated (when the upstream provides it).

## Related issues

## Security considerations

No security considerations

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable


