### PR TITLE
test: update union type test to verify `parametersJsonSchema` passthrough instead of Gemini Schema conversion

### DIFF
--- a/core/providers/gemini/uniontype_test.go
+++ b/core/providers/gemini/uniontype_test.go
@@ -120,9 +120,8 @@ func TestConvertPropertyToSchema_UnionType(t *testing.T) {
 	}
 }
 
-// TestConvertBifrostToolsToGemini_UnionTypeProperty is the end-to-end test
-// that reproduces the Goose+Vertex bug: a tool parameter with
-// "type": ["integer", "null"] must produce a non-empty Gemini type field.
+// TestConvertBifrostToolsToGemini_UnionTypeProperty verifies that tool parameters
+// with JSON Schema union types are passed through unchanged in parametersJsonSchema.
 func TestConvertBifrostToolsToGemini_UnionTypeProperty(t *testing.T) {
 	toolJSON := `{
 		"type": "function",
@@ -149,28 +148,37 @@ func TestConvertBifrostToolsToGemini_UnionTypeProperty(t *testing.T) {
 	var chatTool schemas.ChatTool
 	require.NoError(t, json.Unmarshal([]byte(toolJSON), &chatTool))
 
-	geminiTools := convertBifrostToolsToGemini([]schemas.ChatTool{chatTool})
+	geminiTools, err := convertBifrostToolsToGemini([]schemas.ChatTool{chatTool})
+	require.NoError(t, err)
 	require.Len(t, geminiTools, 1)
 	require.Len(t, geminiTools[0].FunctionDeclarations, 1)
 
 	fd := geminiTools[0].FunctionDeclarations[0]
-	require.NotNil(t, fd.Parameters)
+	require.NotNil(t, fd.ParametersJSONSchema)
+	assert.Nil(t, fd.Parameters, "chat tools use parametersJsonSchema passthrough, not Gemini Schema")
 
-	timeoutSchema, ok := fd.Parameters.Properties["timeout_secs"]
+	raw, err := json.Marshal(fd.ParametersJSONSchema)
+	require.NoError(t, err)
+
+	var paramsSchema map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &paramsSchema))
+
+	properties, ok := paramsSchema["properties"].(map[string]interface{})
+	require.True(t, ok, "parameters must have properties")
+
+	timeoutProp, ok := properties["timeout_secs"].(map[string]interface{})
 	require.True(t, ok, "timeout_secs property must be present")
 
-	// Before the fix this was "" — Vertex AI rejected with
-	// "parameters.timeout_secs schema didn't specify the schema type field"
-	assert.NotEmpty(t, timeoutSchema.Type, "Type must not be empty for union-typed property")
-	assert.Equal(t, Type("integer"), timeoutSchema.Type)
-	require.NotNil(t, timeoutSchema.Nullable)
-	assert.True(t, *timeoutSchema.Nullable)
+	timeoutType, ok := timeoutProp["type"].([]interface{})
+	require.True(t, ok, "timeout_secs type must be a JSON Schema union array")
+	assert.Equal(t, "integer", timeoutType[0])
+	assert.Equal(t, "null", timeoutType[1])
+	assert.Equal(t, "Timeout in seconds", timeoutProp["description"])
 
-	// The non-union "command" property must be unaffected
-	commandSchema, ok := fd.Parameters.Properties["command"]
+	commandProp, ok := properties["command"].(map[string]interface{})
 	require.True(t, ok)
-	assert.Equal(t, Type("string"), commandSchema.Type)
-	assert.Nil(t, commandSchema.Nullable)
+	assert.Equal(t, "string", commandProp["type"])
+	assert.Equal(t, "Command to run", commandProp["description"])
 }
 
 func boolPtr(b bool) *bool { return &b }
@@ -321,7 +329,8 @@ func TestConvertBifrostToolsToGemini_WirePayload(t *testing.T) {
 			var chatTool schemas.ChatTool
 			require.NoError(t, json.Unmarshal([]byte(toolJSON), &chatTool))
 
-			geminiTools := convertBifrostToolsToGemini([]schemas.ChatTool{chatTool})
+			geminiTools, err := convertBifrostToolsToGemini([]schemas.ChatTool{chatTool})
+			require.NoError(t, err)
 			require.Len(t, geminiTools, 1)
 
 			// Serialize to the exact bytes that would be sent to Vertex


### PR DESCRIPTION
## Summary

Updates the Gemini tool conversion tests to reflect the shift from converting JSON Schema union types into Gemini-native `Schema` objects to passing them through unchanged via `parametersJsonSchema`. This aligns the tests with the current behavior where tool parameters with union types (e.g., `["integer", "null"]`) are preserved as raw JSON Schema rather than being transformed into Gemini's `Type`/`Nullable` representation.

## Changes

- Updated `TestConvertBifrostToolsToGemini_UnionTypeProperty` to assert that `fd.ParametersJSONSchema` is populated and `fd.Parameters` is nil, reflecting the passthrough approach.
- Replaced assertions checking for Gemini-native `Type` and `Nullable` fields with assertions that verify the original JSON Schema union array (`["integer", "null"]`) is preserved intact.
- Updated `TestConvertBifrostToolsToGemini_WirePayload` to handle the new `(tools, error)` return signature of `convertBifrostToolsToGemini`.
- Updated the test comment to accurately describe the current behavior rather than referencing the previous Goose+Vertex bug fix.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/...
```

Expected: all tests pass, including `TestConvertBifrostToolsToGemini_UnionTypeProperty` and `TestConvertBifrostToolsToGemini_WirePayload`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable