### PR TITLE
feat: uses responses api for vllm

### DIFF
--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -248,25 +248,58 @@ func (provider *VLLMProvider) Embedding(ctx *schemas.BifrostContext, key schemas
 	)
 }
 
-// Responses performs a responses request to vLLM's API (via chat completion).
+// Responses performs a responses request to vLLM's API
 func (provider *VLLMProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
-	chatResponse, err := provider.ChatCompletion(ctx, key, request.ToChatRequest())
-	if err != nil {
-		return nil, err
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
 	}
-	response := chatResponse.ToBifrostResponsesResponse()
-	return response, nil
+	return openai.HandleOpenAIResponsesRequest(
+		ctx,
+		provider.client,
+		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
+		request,
+		key,
+		provider.networkConfig.ExtraHeaders,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
+		HandleVLLMResponse,
+		nil,
+		provider.logger,
+	)
 }
 
-// ResponsesStream performs a streaming responses request to vLLM's API (via chat completion stream).
+// ResponsesStream performs a streaming responses request to vLLM's API
 func (provider *VLLMProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	ctx.SetValue(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback, true)
-	return provider.ChatCompletionStream(
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+	baseURL, bifrostErr := provider.baseURLOrError(key)
+	if bifrostErr != nil {
+		return nil, bifrostErr
+	}
+	var authHeader map[string]string
+	if key.Value.GetValue() != "" {
+		authHeader = map[string]string{"Authorization": "Bearer " + key.Value.GetValue()}
+	}
+	return openai.HandleOpenAIResponsesStreaming(
 		ctx,
+		provider.streamingClient,
+		baseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
+		request,
+		authHeader,
+		provider.networkConfig.ExtraHeaders,
+		provider.networkConfig.StreamIdleTimeoutInSeconds,
+		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
+		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
+		provider.GetProviderKey(),
 		postHookRunner,
+		HandleVLLMResponse,
+		nil,
+		nil,
+		nil,
+		provider.logger,
 		postHookSpanFinalizer,
-		key,
-		request.ToChatRequest(),
 	)
 }
 


### PR DESCRIPTION
## Summary

The vLLM provider's `Responses` and `ResponsesStream` methods previously fell back to chat completion endpoints as a workaround. This PR replaces that fallback with direct calls to vLLM's native `/v1/responses` endpoint using the shared OpenAI responses handlers.

## Changes

- `Responses` now calls `openai.HandleOpenAIResponsesRequest` directly against `/v1/responses` instead of converting the request to a chat completion and back.
- `ResponsesStream` now calls `openai.HandleOpenAIResponsesStreaming` directly against `/v1/responses` instead of delegating to `ChatCompletionStream` with the `BifrostContextKeyIsResponsesToChatCompletionFallback` flag.
- Both methods set `BifrostContextKeyPassthroughExtraParams` to ensure extra parameters are forwarded as-is to the vLLM endpoint.
- The `BifrostContextKeyIsResponsesToChatCompletionFallback` context key is no longer needed for vLLM.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## Testing Checklist

:white_check_mark: Existing VLLM test passing

```
make test-core PROVIDER=vllm
```

---

Manually tested cases:

```
model: Qwen/Qwen2.5-1.5B-Instruct
```

```
// basic input
{
  "input": "Hello"
}


// input in content blocks
{
  "input": [
    {
      "role": "system",
      "content": "You are a helpful assistant"
    },
    {
      "role": "user",
      "content": "What is 2+2? Return only the number."
    }
  ]
}

// instructions-param
{
  "instructions": "Answer in JSON only.",
  "input": "Return an object with key color and value blue."
}

// sampling and token limits
{
  "input": "Write one short sentence about API gateways.",
  "temperature": 0.2,
  "top_p": 0.9,
  "max_output_tokens": 48
}

// stream
{
  "input": "Count from 1 to 5, one number per token if possible.",
  "stream": true,
  "max_output_tokens": 64
}

// stream with include usage
{
  "input": "Say hello, then stop.",
  "stream": true,
  "stream_options": {
    "include_usage": true
  }
}

// text json object format
{
  "input": "Return JSON for a city named Paris with country France.",
  "text": {
    "format": {
      "type": "json_object"
    }
  }
}

// text json schema format
{
  "input": "Return a weather report for Bengaluru.",
  "text": {
    "format": {
      "type": "json_schema",
      "name": "weather_report",
      "strict": true,
      "schema": {
        "type": "object",
        "additionalProperties": false,
        "properties": {
          "city": { "type": "string" },
          "condition": { "type": "string" },
          "temperature_c": { "type": "number" }
        },
        "required": ["city", "condition", "temperature_c"]
      }
    }
  }
}

// function tool auto
{
  "input": "Use the tool to add 7 and 8.",
  "tools": [
    {
      "type": "function",
      "name": "add",
      "description": "Add two integers.",
      "parameters": {
        "type": "object",
        "additionalProperties": false,
        "properties": {
          "a": { "type": "integer" },
          "b": { "type": "integer" }
        },
        "required": ["a", "b"]
      }
    }
  ],
  "tool_choice": "auto"
}

// function tool required
{
  "input": "Call the add tool with a=10 and b=32.",
  "tools": [
    {
      "type": "function",
      "name": "add",
      "description": "Add two integers.",
      "parameters": {
        "type": "object",
        "properties": {
          "a": { "type": "integer" },
          "b": { "type": "integer" }
        },
        "required": ["a", "b"]
      }
    }
  ],
  "tool_choice": {
    "type": "function",
    "name": "add"
  }
}

// reasoning param
{
  "input": "Answer with the final number only: 19 * 3.",
  "reasoning": {
    "effort": "low"
  },
  "max_output_tokens": 64
}

// metadata store and user fields
{
  "input": "Say metadata ok.",
  "store": false,
  "metadata": {
    "abc": "123"
  },
  "safety_identifier": "hello"
}

// extra params passthrough vllm
{
  "input": "Return exactly one word.",
  "max_output_tokens": 16,
  "top_k": 20,
  "repetition_penalty": 1.05,
  "min_p": 0.0
}
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No new auth mechanisms introduced. The streaming path constructs a `Bearer` token header from the key value, consistent with how other OpenAI-compatible providers handle authentication.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable