### PR TITLE
fix: send missing bedrock lifecycle events

### DIFF
--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -867,6 +867,44 @@ func (chunk *BedrockStreamEvent) ToBifrostResponsesStream(sequenceNumber int, st
 func FinalizeBedrockStream(state *BedrockResponsesStreamState, sequenceNumber int, usage *schemas.ResponsesResponseUsage) []*schemas.BifrostResponsesStreamResponse {
 	var responses []*schemas.BifrostResponsesStreamResponse
 
+	// Synthesize lifecycle events if Bedrock never sent a messageStart
+	if !state.HasEmittedCreated {
+		if state.MessageID == nil {
+			messageID := fmt.Sprintf("msg_%d", state.CreatedAt)
+			state.MessageID = &messageID
+		}
+		createdResponse := &schemas.BifrostResponsesResponse{
+			ID:        state.MessageID,
+			CreatedAt: state.CreatedAt,
+			Usage:     usage,
+		}
+		if state.Model != nil {
+			createdResponse.Model = *state.Model
+		}
+		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeCreated,
+			SequenceNumber: sequenceNumber + len(responses),
+			Response:       createdResponse,
+		})
+		state.HasEmittedCreated = true
+	}
+
+	if !state.HasEmittedInProgress {
+		inProgressResponse := &schemas.BifrostResponsesResponse{
+			ID:        state.MessageID,
+			CreatedAt: state.CreatedAt,
+		}
+		if state.Model != nil {
+			inProgressResponse.Model = *state.Model
+		}
+		responses = append(responses, &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeInProgress,
+			SequenceNumber: sequenceNumber + len(responses),
+			Response:       inProgressResponse,
+		})
+		state.HasEmittedInProgress = true
+	}
+
 	// Close any open items (text items and tool calls)
 	for contentIndex, outputIndex := range state.ContentIndexToOutputIndex {
 		// Skip reasoning blocks


### PR DESCRIPTION
## Summary

When Bedrock streams never emit a `messageStart` event, the `FinalizeBedrockStream` function would skip synthesizing the `created` and `in_progress` lifecycle events, resulting in an incomplete or malformed responses stream. This PR ensures those events are always emitted before the stream is finalized.

## Changes

- In `FinalizeBedrockStream`, added guards to synthesize a `response.created` event if `HasEmittedCreated` is false, generating a fallback message ID from `CreatedAt` if none exists.
- Added a corresponding guard to synthesize a `response.in_progress` event if `HasEmittedInProgress` is false.
- Both synthetic events are appended with correct sequential `SequenceNumber` values before any open content items are closed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger a Bedrock streaming response that does not emit a `messageStart` event and verify that the resulting stream includes both `response.created` and `response.in_progress` events before any content delta or completion events.

```sh
go test ./core/providers/bedrock/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. The fallback message ID is derived from a timestamp and does not expose any sensitive data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable