### PR TITLE
fix: preserve OpenAI responses stream metadata

### DIFF
--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -786,6 +786,7 @@ type ResponsesMessage struct {
 	ID     *string               `json:"id,omitempty"` // Common ID field for most item types
 	Type   *ResponsesMessageType `json:"type,omitempty"`
 	Status *string               `json:"status,omitempty"` // "in_progress" | "completed" | "incomplete" | "interpreting" | "failed"
+	Phase  *string               `json:"phase,omitempty"`  // OpenAI emits this for multi-phase message items, e.g. "final_answer"
 
 	Role    *ResponsesMessageRoleType `json:"role,omitempty"`
 	Content *ResponsesMessageContent  `json:"content,omitempty"`
@@ -2475,16 +2476,18 @@ type BifrostResponsesStreamResponse struct {
 
 	Response *BifrostResponsesResponse `json:"response,omitempty"`
 
-	OutputIndex *int              `json:"output_index,omitempty"`
-	Item        *ResponsesMessage `json:"item"`
+	OutputIndex  *int              `json:"output_index,omitempty"`
+	Item         *ResponsesMessage `json:"item"`
+	SummaryIndex *int              `json:"summary_index,omitempty"`
 
 	ContentIndex *int                          `json:"content_index,omitempty"`
 	ItemID       *string                       `json:"item_id,omitempty"`
 	Part         *ResponsesMessageContentBlock `json:"part,omitempty"`
 
-	Delta     *string                                    `json:"delta,omitempty"`
-	Signature *string                                    `json:"signature,omitempty"` // Not in OpenAI's spec, but sent by other providers
-	LogProbs  []ResponsesOutputMessageContentTextLogProb `json:"logprobs"`
+	Delta       *string                                    `json:"delta,omitempty"`
+	Signature   *string                                    `json:"signature,omitempty"` // Not in OpenAI's spec, but sent by other providers
+	Obfuscation *string                                    `json:"obfuscation,omitempty"`
+	LogProbs    []ResponsesOutputMessageContentTextLogProb `json:"logprobs"`
 
 	Text *string `json:"text,omitempty"` // Full text of the output item, comes with event "response.output_text.done"
 
@@ -2531,11 +2534,13 @@ func (resp *BifrostResponsesStreamResponse) WithDefaults() *BifrostResponsesStre
 	// Copy all streaming-specific fields
 	result.OutputIndex = resp.OutputIndex
 	result.Item = resp.Item
+	result.SummaryIndex = resp.SummaryIndex
 	result.ContentIndex = resp.ContentIndex
 	result.ItemID = resp.ItemID
 	result.Part = resp.Part
 	result.Delta = resp.Delta
 	result.Signature = resp.Signature
+	result.Obfuscation = resp.Obfuscation
 	result.Text = resp.Text
 	result.Refusal = resp.Refusal
 	result.Arguments = resp.Arguments

--- a/core/schemas/responses_test.go
+++ b/core/schemas/responses_test.go
@@ -1,0 +1,73 @@
+package schemas
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBifrostResponsesStreamResponsePreservesOpenAIStreamMetadata(t *testing.T) {
+	raw := []byte(`{"type":"response.reasoning_summary_text.delta","delta":"thinking","item_id":"rs_123","obfuscation":"opaque","output_index":0,"sequence_number":4,"summary_index":0}`)
+
+	var resp BifrostResponsesStreamResponse
+	if err := Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("unmarshal response stream chunk: %v", err)
+	}
+
+	if resp.SummaryIndex == nil || *resp.SummaryIndex != 0 {
+		t.Fatalf("expected summary_index to survive unmarshal, got %#v", resp.SummaryIndex)
+	}
+	if resp.Obfuscation == nil || *resp.Obfuscation != "opaque" {
+		t.Fatalf("expected obfuscation to survive unmarshal, got %#v", resp.Obfuscation)
+	}
+
+	defaulted := resp.WithDefaults()
+	if defaulted.SummaryIndex == nil || *defaulted.SummaryIndex != 0 {
+		t.Fatalf("expected summary_index to survive WithDefaults, got %#v", defaulted.SummaryIndex)
+	}
+	if defaulted.Obfuscation == nil || *defaulted.Obfuscation != "opaque" {
+		t.Fatalf("expected obfuscation to survive WithDefaults, got %#v", defaulted.Obfuscation)
+	}
+
+	encoded, err := MarshalSorted(defaulted)
+	if err != nil {
+		t.Fatalf("marshal defaulted response stream chunk: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"summary_index":0`) {
+		t.Fatalf("expected encoded chunk to contain summary_index, got %s", encoded)
+	}
+	if !strings.Contains(string(encoded), `"obfuscation":"opaque"`) {
+		t.Fatalf("expected encoded chunk to contain obfuscation, got %s", encoded)
+	}
+
+	encodedChunk, err := MarshalSorted(BifrostStreamChunk{BifrostResponsesStreamResponse: defaulted})
+	if err != nil {
+		t.Fatalf("marshal response stream chunk wrapper: %v", err)
+	}
+	if !strings.Contains(string(encodedChunk), `"summary_index":0`) {
+		t.Fatalf("expected encoded stream chunk to contain summary_index, got %s", encodedChunk)
+	}
+	if !strings.Contains(string(encodedChunk), `"obfuscation":"opaque"`) {
+		t.Fatalf("expected encoded stream chunk to contain obfuscation, got %s", encodedChunk)
+	}
+}
+
+func TestResponsesMessagePreservesOpenAIPhase(t *testing.T) {
+	raw := []byte(`{"id":"msg_123","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"}`)
+
+	var msg ResponsesMessage
+	if err := Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal responses message: %v", err)
+	}
+
+	if msg.Phase == nil || *msg.Phase != "final_answer" {
+		t.Fatalf("expected phase to survive unmarshal, got %#v", msg.Phase)
+	}
+
+	encoded, err := MarshalSorted(msg)
+	if err != nil {
+		t.Fatalf("marshal responses message: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"phase":"final_answer"`) {
+		t.Fatalf("expected encoded message to contain phase, got %s", encoded)
+	}
+}

--- a/framework/streaming/responses.go
+++ b/framework/streaming/responses.go
@@ -51,6 +51,11 @@ func deepCopyResponsesStreamResponse(original *schemas.BifrostResponsesStreamRes
 		copy.OutputIndex = &copyOutputIndex
 	}
 
+	if original.SummaryIndex != nil {
+		copySummaryIndex := *original.SummaryIndex
+		copy.SummaryIndex = &copySummaryIndex
+	}
+
 	if original.Item != nil {
 		copyItem := deepCopyResponsesMessage(*original.Item)
 		copy.Item = &copyItem
@@ -74,6 +79,16 @@ func deepCopyResponsesStreamResponse(original *schemas.BifrostResponsesStreamRes
 	if original.Delta != nil {
 		copyDelta := *original.Delta
 		copy.Delta = &copyDelta
+	}
+
+	if original.Signature != nil {
+		copySignature := *original.Signature
+		copy.Signature = &copySignature
+	}
+
+	if original.Obfuscation != nil {
+		copyObfuscation := *original.Obfuscation
+		copy.Obfuscation = &copyObfuscation
 	}
 
 	// Deep copy LogProbs slice if present
@@ -171,6 +186,16 @@ func deepCopyResponsesMessage(original schemas.ResponsesMessage) schemas.Respons
 	if original.Type != nil {
 		copyType := *original.Type
 		copy.Type = &copyType
+	}
+
+	if original.Status != nil {
+		copyStatus := *original.Status
+		copy.Status = &copyStatus
+	}
+
+	if original.Phase != nil {
+		copyPhase := *original.Phase
+		copy.Phase = &copyPhase
 	}
 
 	if original.Role != nil {


### PR DESCRIPTION
## Summary

Preserve missing OpenAI Responses stream metadata so Bifrost does not drop reasoning-summary and multi-phase message fields during normal streaming.

## Changes

- add `summary_index` and `obfuscation` to `BifrostResponsesStreamResponse`
- add `phase` to `ResponsesMessage`
- preserve these fields in `WithDefaults()` and streaming deep-copy helpers
- add regression tests covering unmarshal, defaulting, and marshal paths

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas
go test ./framework/streaming
```

Expected outcome: both test commands pass, and the regression tests confirm `summary_index`, `obfuscation`, and `phase` survive unmarshal, defaulting, deep-copy, and re-serialization.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Related to reasoning summary metadata loss in OpenAI Responses streaming.

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable