### PR TITLE
fix: guard semantic cache `Cleanup` with `sync.Once` to prevent double-close panic

### DIFF
--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -157,6 +157,10 @@ type Plugin struct {
 	cleanupWg sync.WaitGroup
 	// stopCh is closed by Cleanup to signal the background reaper loops to exit.
 	stopCh chan struct{}
+	// cleanupOnce guards Cleanup so close(stopCh) doesn't panic if the harness
+	// invokes Cleanup more than once (e.g. plugin registered against multiple
+	// interface caches).
+	cleanupOnce sync.Once
 }
 
 // Plugin constants
@@ -714,15 +718,16 @@ func (plugin *Plugin) WaitForPendingOperations() {
 // the namespace — useful for ephemeral test environments. The default is to
 // leave entries in place so they can serve subsequent process restarts.
 func (plugin *Plugin) Cleanup() error {
-	close(plugin.stopCh)
-	plugin.writersWg.Wait()
-	plugin.cleanupWg.Wait()
+	plugin.cleanupOnce.Do(func() {
+		close(plugin.stopCh)
+		plugin.writersWg.Wait()
+		plugin.cleanupWg.Wait()
 
-	// Final sweep: the periodic reaper only fires once per streamCleanupInterval,
-	// so any abandoned accumulator added in the window between the last tick
-	// and stopCh is still in memory. This call evicts those before we return.
-	plugin.cleanupOldStreamAccumulators()
-
+		// Final sweep: the periodic reaper only fires once per streamCleanupInterval,
+		// so any abandoned accumulator added in the window between the last tick
+		// and stopCh is still in memory. This call evicts those before we return.
+		plugin.cleanupOldStreamAccumulators()
+	})
 	return nil
 }
 


### PR DESCRIPTION
## Summary

The `Cleanup` method on the semantic cache plugin could panic if called more than once, because `close(stopCh)` would be invoked on an already-closed channel. This happens when the plugin is registered against multiple interface caches, causing the harness to invoke `Cleanup` multiple times.

## Changes

- Introduced a `sync.Once` field (`cleanupOnce`) on the `Plugin` struct to guard the body of `Cleanup`, ensuring `close(stopCh)` and the subsequent wait/sweep logic execute exactly once regardless of how many times `Cleanup` is called.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Plugins

## How to test

Register the semantic cache plugin against multiple interface caches and trigger shutdown. Verify that `Cleanup` is called more than once without panicking.

```sh
go test ./plugins/semanticcache/...
```

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable