### PR TITLE
langfuse public url fix in otel docs

### DIFF
--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -558,7 +558,7 @@ Configure the OTel plugin with the following settings:
 
 | Field | Value |
 |-------|-------|
-| **Collector URL** | `https://cloud.langfuse.com/api/public/otel` (EU) or `https://us.cloud.langfuse.com/api/public/otel` (US) |
+| **Collector URL** | `https://cloud.langfuse.com/api/public/otel/v1/traces` (EU) or `https://us.cloud.langfuse.com/api/public/otel/v1/traces` (US) |
 | **Trace Type** | `genai_extension` |
 | **Protocol** | `http` (required - Langfuse does not support gRPC) |
 | **Headers** | `Authorization`: `env.LANGFUSE_AUTH` |


### PR DESCRIPTION
## Summary

Updates the Langfuse OTel collector URL in the documentation to include the full `/v1/traces` path, ensuring users configure the correct endpoint when integrating with the OTel plugin.

## Issues

Closes #3497

## Changes

- Updated the collector URL from `/api/public/otel` to `/api/public/otel/v1/traces` for both EU (`cloud.langfuse.com`) and US (`us.cloud.langfuse.com`) regions in the OTel observability docs.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the updated collector URL is reachable and accepts trace data:

```sh
curl -X POST https://cloud.langfuse.com/api/public/otel/v1/traces \
  -H "Authorization: Basic <base64-encoded-credentials>" \
  -H "Content-Type: application/json" \
  -d '{}'
```

Expected: A valid HTTP response (e.g., 200 or 400 with a structured error), confirming the endpoint exists.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. This is a documentation-only change updating a public API endpoint path.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable