### PR TITLE
fixes alias in migration for team calendar aligned fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,7 @@ ui/app/routeTree.gen.ts
 .next
 
 .infisical
+
+# e2e test artifacts
+examples/mcps/auth-demo-server/auth-demo-server
+examples/mcps/oauth-demo-server/oauth-demo-server

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -7587,11 +7587,11 @@ func migrationAddTeamCalendarAlignedColumn(ctx context.Context, db *gorm.DB) err
 			// promotes the team to calendar-aligned so behavior is preserved across upgrade.
 			if mig.HasColumn(&tables.TableBudget{}, "calendar_aligned") {
 				if err := tx.Exec(`
-					UPDATE governance_teams t
+					UPDATE governance_teams
 					SET calendar_aligned = TRUE
 					WHERE EXISTS (
 						SELECT 1 FROM governance_budgets b
-						WHERE b.team_id = t.id AND b.calendar_aligned = TRUE
+						WHERE b.team_id = governance_teams.id AND b.calendar_aligned = TRUE
 					)
 				`).Error; err != nil {
 					return fmt.Errorf("failed to backfill team calendar_aligned from budgets: %w", err)
@@ -7599,9 +7599,9 @@ func migrationAddTeamCalendarAlignedColumn(ctx context.Context, db *gorm.DB) err
 			}
 			if mig.HasColumn(&tables.TableRateLimit{}, "calendar_aligned") {
 				if err := tx.Exec(`
-					UPDATE governance_teams t
+					UPDATE governance_teams
 					SET calendar_aligned = TRUE
-					WHERE t.rate_limit_id IN (
+					WHERE rate_limit_id IN (
 						SELECT id FROM governance_rate_limits WHERE calendar_aligned = TRUE
 					)
 				`).Error; err != nil {


### PR DESCRIPTION
## Summary

Fixes invalid SQL table alias usage in the `migrationAddTeamCalendarAlignedColumn` migration and adds build artifacts from e2e test demo servers to `.gitignore`.

## Changes

- Removed table aliases (`t`) from `UPDATE` statements in the calendar-aligned backfill migration, replacing them with direct table name references. Some databases (e.g., PostgreSQL) do not support aliases in `UPDATE` statements in this form, which would cause the migration to fail.
- Added compiled binaries for `auth-demo-server` and `oauth-demo-server` under `examples/mcps/` to `.gitignore` to prevent e2e test build artifacts from being accidentally committed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the migration against a fresh or existing database and verify it completes without error:

```sh
go test ./framework/configstore/...
```

Confirm that building the e2e demo servers does not produce tracked files in git:

```sh
cd examples/mcps/auth-demo-server && go build .
cd examples/mcps/oauth-demo-server && go build .
git status  # binaries should not appear as untracked files
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. The SQL fix removes table aliases that could cause migration failures; no auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable