### PR TITLE
updated budgets and limits documentation to indicate the multi-node limitation for oss

### DIFF
--- a/.github/workflows/scripts/validate-helm-config-fields.sh
+++ b/.github/workflows/scripts/validate-helm-config-fields.sh
@@ -869,7 +869,7 @@ assert_field_value 'cluster_config.discovery.k8s_label_selector' '.cluster_confi
 # Gap 7: Cluster region
 assert_field_value 'cluster_config.region' '.cluster_config.region' '"us-east-1"'
 
-# SCIM - Okta
+# SCIM - Okta (baseline + attribute mappings)
 cat > "$TMPDIR/values-scim-okta.yaml" << 'VALS'
 image:
   tag: v1.0.0
@@ -886,6 +886,18 @@ bifrost:
       userIdField: "sub"
       teamIdsField: "groups"
       rolesField: "roles"
+      attributeRoleMappings:
+        - attribute: "groups"
+          value: "bifrost-admins"
+          role: "admin"
+      attributeTeamMappings:
+        - attribute: "groups"
+          value: "*"
+          team: ""
+      attributeBusinessUnitMappings:
+        - attribute: "department"
+          value: "platform"
+          business_unit: "Platform"
 VALS
 
 render_config "$TMPDIR/values-scim-okta.yaml"
@@ -894,7 +906,14 @@ assert_field_value 'scim_config.provider' '.scim_config.provider' '"okta"'
 assert_field 'scim_config.config' '.scim_config.config'
 assert_field 'scim_config.config.apiToken' '.scim_config.config.apiToken'
 assert_field 'scim_config.config.clientSecret' '.scim_config.config.clientSecret'
-# SCIM - Entra
+assert_field_value 'scim_config (okta) attributeRoleMappings[0].attribute' '.scim_config.config.attributeRoleMappings.[0].attribute' '"groups"'
+assert_field_value 'scim_config (okta) attributeRoleMappings[0].value' '.scim_config.config.attributeRoleMappings.[0].value' '"bifrost-admins"'
+assert_field_value 'scim_config (okta) attributeRoleMappings[0].role' '.scim_config.config.attributeRoleMappings.[0].role' '"admin"'
+assert_field_value 'scim_config (okta) attributeTeamMappings[0].attribute' '.scim_config.config.attributeTeamMappings.[0].attribute' '"groups"'
+assert_field_value 'scim_config (okta) attributeTeamMappings[0].value' '.scim_config.config.attributeTeamMappings.[0].value' '"*"'
+assert_field_value 'scim_config (okta) attributeBusinessUnitMappings[0].business_unit' '.scim_config.config.attributeBusinessUnitMappings.[0].business_unit' '"Platform"'
+
+# SCIM - Entra (baseline + attribute mappings)
 cat > "$TMPDIR/values-scim-entra.yaml" << 'VALS'
 image:
   tag: v1.0.0
@@ -911,6 +930,18 @@ bifrost:
       userIdField: "oid"
       teamIdsField: "groups"
       rolesField: "roles"
+      attributeRoleMappings:
+        - attribute: "roles"
+          value: "BifrostAdmin"
+          role: "admin"
+      attributeTeamMappings:
+        - attribute: "groups"
+          value: "11111111-2222-3333-4444-555555555555"
+          team: "platform-team"
+      attributeBusinessUnitMappings:
+        - attribute: "department"
+          value: "Platform"
+          business_unit: "Platform BU"
 VALS
 
 render_config "$TMPDIR/values-scim-entra.yaml"
@@ -919,6 +950,131 @@ assert_field 'scim_config (entra) config' '.scim_config.config'
 assert_field_value 'scim_config (entra) enabled' '.scim_config.enabled' 'true'
 assert_field 'scim_config (entra) config.tenantId' '.scim_config.config.tenantId'
 assert_field 'scim_config (entra) config.clientId' '.scim_config.config.clientId'
+assert_field_value 'scim_config (entra) attributeRoleMappings[0].role' '.scim_config.config.attributeRoleMappings.[0].role' '"admin"'
+assert_field_value 'scim_config (entra) attributeTeamMappings[0].team' '.scim_config.config.attributeTeamMappings.[0].team' '"platform-team"'
+assert_field_value 'scim_config (entra) attributeBusinessUnitMappings[0].business_unit' '.scim_config.config.attributeBusinessUnitMappings.[0].business_unit' '"Platform BU"'
+
+# SCIM - Keycloak (baseline + attribute mappings)
+cat > "$TMPDIR/values-scim-keycloak.yaml" << 'VALS'
+image:
+  tag: v1.0.0
+bifrost:
+  scim:
+    enabled: true
+    provider: "keycloak"
+    config:
+      serverUrl: "https://keycloak.example.com"
+      realm: "bifrost-prod"
+      clientId: "bifrost"
+      clientSecret: "kc-secret"
+      audience: "bifrost"
+      userIdField: "sub"
+      teamIdsField: "groups"
+      rolesField: "roles"
+      attributeRoleMappings:
+        - attribute: "realm_access.roles"
+          value: "bifrost-admin"
+          role: "admin"
+      attributeTeamMappings:
+        - attribute: "groups"
+          value: "platform"
+          team: "platform-team"
+      attributeBusinessUnitMappings:
+        - attribute: "department"
+          value: "platform"
+          business_unit: "Platform"
+VALS
+
+render_config "$TMPDIR/values-scim-keycloak.yaml"
+assert_field_value 'scim_config (keycloak) provider' '.scim_config.provider' '"keycloak"'
+assert_field_value 'scim_config (keycloak) serverUrl' '.scim_config.config.serverUrl' '"https://keycloak.example.com"'
+assert_field_value 'scim_config (keycloak) realm' '.scim_config.config.realm' '"bifrost-prod"'
+assert_field_value 'scim_config (keycloak) attributeRoleMappings[0].attribute' '.scim_config.config.attributeRoleMappings.[0].attribute' '"realm_access.roles"'
+assert_field_value 'scim_config (keycloak) attributeRoleMappings[0].role' '.scim_config.config.attributeRoleMappings.[0].role' '"admin"'
+assert_field_value 'scim_config (keycloak) attributeTeamMappings[0].team' '.scim_config.config.attributeTeamMappings.[0].team' '"platform-team"'
+assert_field_value 'scim_config (keycloak) attributeBusinessUnitMappings[0].business_unit' '.scim_config.config.attributeBusinessUnitMappings.[0].business_unit' '"Platform"'
+
+# SCIM - Zitadel (baseline + attribute mappings)
+cat > "$TMPDIR/values-scim-zitadel.yaml" << 'VALS'
+image:
+  tag: v1.0.0
+bifrost:
+  scim:
+    enabled: true
+    provider: "zitadel"
+    config:
+      domain: "my-instance.zitadel.cloud"
+      clientId: "zitadel-client-id"
+      clientSecret: "zitadel-secret"
+      projectId: "project-uuid"
+      audience: "zitadel-client-id"
+      serviceAccountClientId: "sa-client-id"
+      serviceAccountClientSecret: "sa-client-secret"
+      teamIdsField: "groups"
+      attributeRoleMappings:
+        - attribute: "urn:zitadel:iam:org:project:roles"
+          value: "admin"
+          role: "admin"
+      attributeTeamMappings:
+        - attribute: "groups"
+          value: "platform"
+          team: "platform-team"
+      attributeBusinessUnitMappings:
+        - attribute: "department"
+          value: "Engineering"
+          business_unit: "Engineering"
+VALS
+
+render_config "$TMPDIR/values-scim-zitadel.yaml"
+assert_field_value 'scim_config (zitadel) provider' '.scim_config.provider' '"zitadel"'
+assert_field_value 'scim_config (zitadel) domain' '.scim_config.config.domain' '"my-instance.zitadel.cloud"'
+assert_field 'scim_config (zitadel) clientId' '.scim_config.config.clientId'
+assert_field 'scim_config (zitadel) serviceAccountClientId' '.scim_config.config.serviceAccountClientId'
+assert_field_value 'scim_config (zitadel) attributeRoleMappings[0].attribute' '.scim_config.config.attributeRoleMappings.[0].attribute' '"urn:zitadel:iam:org:project:roles"'
+assert_field_value 'scim_config (zitadel) attributeRoleMappings[0].role' '.scim_config.config.attributeRoleMappings.[0].role' '"admin"'
+assert_field_value 'scim_config (zitadel) attributeTeamMappings[0].team' '.scim_config.config.attributeTeamMappings.[0].team' '"platform-team"'
+assert_field_value 'scim_config (zitadel) attributeBusinessUnitMappings[0].business_unit' '.scim_config.config.attributeBusinessUnitMappings.[0].business_unit' '"Engineering"'
+
+# SCIM - Google Workspace (baseline + attribute mappings)
+cat > "$TMPDIR/values-scim-google.yaml" << 'VALS'
+image:
+  tag: v1.0.0
+bifrost:
+  scim:
+    enabled: true
+    provider: "google"
+    config:
+      domain: "example.com"
+      clientId: "google-client-id"
+      clientSecret: "google-secret"
+      credentialMode: "env"
+      serviceAccountEnvVar: "env.GOOGLE_SA_JSON"
+      adminEmail: "admin@example.com"
+      audience: "google-client-id"
+      teamIdsField: "groups"
+      attributeRoleMappings:
+        - attribute: "groups"
+          value: "bifrost-admins@example.com"
+          role: "admin"
+      attributeTeamMappings:
+        - attribute: "groups"
+          value: "*"
+          team: ""
+      attributeBusinessUnitMappings:
+        - attribute: "department"
+          value: "Engineering"
+          business_unit: "Engineering"
+VALS
+
+render_config "$TMPDIR/values-scim-google.yaml"
+assert_field_value 'scim_config (google) provider' '.scim_config.provider' '"google"'
+assert_field_value 'scim_config (google) domain' '.scim_config.config.domain' '"example.com"'
+assert_field_value 'scim_config (google) credentialMode' '.scim_config.config.credentialMode' '"env"'
+assert_field 'scim_config (google) serviceAccountEnvVar' '.scim_config.config.serviceAccountEnvVar'
+assert_field 'scim_config (google) adminEmail' '.scim_config.config.adminEmail'
+assert_field_value 'scim_config (google) attributeRoleMappings[0].role' '.scim_config.config.attributeRoleMappings.[0].role' '"admin"'
+assert_field_value 'scim_config (google) attributeTeamMappings[0].value' '.scim_config.config.attributeTeamMappings.[0].value' '"*"'
+assert_field_value 'scim_config (google) attributeBusinessUnitMappings[0].business_unit' '.scim_config.config.attributeBusinessUnitMappings.[0].business_unit' '"Engineering"'
 
 # Load Balancer
 cat > "$TMPDIR/values-lb.yaml" << 'VALS'

--- a/.github/workflows/scripts/validate-helm-schema.sh
+++ b/.github/workflows/scripts/validate-helm-schema.sh
@@ -443,7 +443,7 @@ echo "🔍 Checking required fields in SAML/SCIM config..."
 
 # Check okta_config required fields
 CONFIG_OKTA_REQUIRED=$(jq -r '."$defs".okta_config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
-HELM_OKTA_REQUIRED=$(jq -r '.properties.bifrost.properties.scim.allOf[0].then.properties.config.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+HELM_OKTA_REQUIRED=$(jq -r '.properties.bifrost.properties.scim.allOf[] | select(.if.properties.provider.const == "okta") | .then.properties.config.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
 
 if [ "$CONFIG_OKTA_REQUIRED" != "$HELM_OKTA_REQUIRED" ]; then
   echo "❌ Okta config required fields mismatch:"
@@ -456,7 +456,7 @@ fi
 
 # Check entra_config required fields
 CONFIG_ENTRA_REQUIRED=$(jq -r '."$defs".entra_config.required // [] | sort | join(",")' "$CONFIG_SCHEMA" 2>/dev/null || echo "")
-HELM_ENTRA_REQUIRED=$(jq -r '.properties.bifrost.properties.scim.allOf[1].then.properties.config.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
+HELM_ENTRA_REQUIRED=$(jq -r '.properties.bifrost.properties.scim.allOf[] | select(.if.properties.provider.const == "entra") | .then.properties.config.required // [] | sort | join(",")' "$HELM_SCHEMA" 2>/dev/null || echo "")
 
 if [ "$CONFIG_ENTRA_REQUIRED" != "$HELM_ENTRA_REQUIRED" ]; then
   echo "❌ Entra config required fields mismatch:"

--- a/docs/features/governance/budget-and-limits.mdx
+++ b/docs/features/governance/budget-and-limits.mdx
@@ -6,6 +6,19 @@ icon: "money-bills"
 
 ## Overview
 
+<Warning>
+  Running multiple OSS Bifrost nodes with a Postgres backend is not supported.
+  
+  Here is the short technical explanation:
+  
+  - Bifrost is designed to keep all critical information in memory, including provider configs, API keys, budgets, usage, and traffic distribution.
+  - Once a node is initialized, it does not read this information back from the database.
+  - In the Enterprise version, we use a slightly modified version of RAFT to synchronize this state in real time across nodes, while the database acts only as a dumb store.
+  - Based on our current view, OSS is sufficient for startups and medium-scale teams, and can easily handle around 3,000–5,000 RPS on a single instance.
+  - If you need high availability and enterprise capabilities such as real-time synchronization, the Enterprise plan is the right fit. 
+  - And yes, that is part of how we draw the OSS vs Enterprise line 💰.
+</Warning>
+
 Budgeting and rate limiting are a core feature of Bifrost's governance system managed through [Virtual Keys](./virtual-keys).
 
 Bifrost's budget management system provides comprehensive cost control and financial governance for enterprise AI deployments. It operates through a **hierarchical budget structure** that enables granular cost management, usage tracking, and financial oversight across your entire organization.

--- a/docs/features/governance/budget-and-limits.mdx
+++ b/docs/features/governance/budget-and-limits.mdx
@@ -15,7 +15,7 @@ icon: "money-bills"
   - Once a node is initialized, it does not read this information back from the database.
   - In the Enterprise version, we use a slightly modified version of RAFT to synchronize this state in real time across nodes, while the database acts only as a dumb store.
   - Based on our current view, OSS is sufficient for startups and medium-scale teams, and can easily handle around 3,000–5,000 RPS on a single instance.
-  - If you need high availability and enterprise capabilities such as real-time synchronization, the Enterprise plan is the right fit. 
+  - If you need high availability and enterprise capabilities such as real-time synchronization, the Enterprise plan is the right fit.
   - And yes, that is part of how we draw the OSS vs Enterprise line 💰.
 </Warning>
 

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -11,6 +11,24 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 ### 2.1.17
 
 - Added `max_turns_to_send` to guardrail rules. The integer caps how many historical conversation turns are sent to the guardrail provider on apply; the latest message is always included on top, and `0` (default) sends all turns. Wired into `values.schema.json`, `config.schema.json`, and `templates/_helpers.tpl` so it renders into `guardrails_config.guardrail_rules[].max_turns_to_send`.
+- Extended SCIM/SSO support so attribute mappings work for every supported provider, not just Keycloak:
+  - Added `attributeRoleMappings`, `attributeTeamMappings`, and `attributeBusinessUnitMappings` to `bifrost.scim.config` for the Okta and Entra (Azure AD) provider branches. Previously these fields were rejected by `additionalProperties: false` even though the enterprise runtime renders them into `config.json`.
+  - Tightened the existing Keycloak mapping items from the placeholder `{type: object}` to a strict shape (`attribute`, `value`, plus `role`/`team`/`business_unit`, `additionalProperties: false`) so typos surface at `helm template` time. The same strict item shape is applied to Okta, Entra, Zitadel, and Google.
+  - Added two more SCIM providers to the schema enum and provided full config blocks for them: `zitadel` (`domain`, `clientId`, optional `clientSecret`/`projectId`/`audience`, plus service-account fields for Management API access) and `google` (Google Workspace OIDC with `domain`, `clientId`, `credentialMode`, service-account sources, and `adminEmail` for domain-wide delegation).
+  - Added matching `helm template`-time validation in `_helpers.tpl` for Zitadel (requires `domain`, `clientId`) and Google Workspace (requires `domain`, `clientId`).
+  - Documented every new field as commented examples under `bifrost.scim.config` in `values.yaml`.
+
+### 2.1.16
+
+- Widened `bifrost.mcp.toolManagerConfig.toolExecutionTimeout` in `values.schema.json` from `integer` to `["integer", "string"]` so a Go duration string like `"30s"` or `"2m"` is accepted alongside the legacy bare integer. Updated the description to clarify "integer = seconds, string = Go duration" and recommend the string form, and changed the default from `30` to `"30s"`.
+- Updated the `values.yaml` example to use `toolExecutionTimeout: "30s"` instead of `toolExecutionTimeout: 30`, matching the new recommended form.
+- Paired with the upstream runtime fix (PR #3432) that reinterprets bare integers on this field as seconds rather than nanoseconds, and includes `mcp.tool_manager_config` in the client config hash so file-level changes survive the hash-based reconciliation pipeline on restart.
+
+### 2.1.15
+
+- Added `storage.logsStore.matviewRefreshInterval` to `values.yaml` and `values.schema.json`, letting operators control how often PostgreSQL materialized views are refreshed in the logs store (e.g. `"30s"`, `"5m"`, `"1h"`; minimum `5s`).
+- Wired `matviewRefreshInterval` through `_helpers.tpl` so it renders into the generated PostgreSQL `logs_store.matview_refresh_interval` field when set, and is omitted when not.
+- Bumped `appVersion` from `1.5.0-prerelease7` to `1.5.0` (first chart release pinned to the stable `1.5.0` app image).
 
 ### 2.1.14
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1376,6 +1376,22 @@ Call this template at the beginning of deployment/stateful templates
 {{- fail "ERROR: bifrost.scim.config.clientSecret is required when SCIM provider is Keycloak." }}
 {{- end }}
 {{- end }}
+{{- if eq $scimValidation.provider "zitadel" }}
+{{- if not $scimValidation.config.domain }}
+{{- fail "ERROR: bifrost.scim.config.domain is required when SCIM provider is Zitadel. Example: my-instance.zitadel.cloud (no scheme)." }}
+{{- end }}
+{{- if not $scimValidation.config.clientId }}
+{{- fail "ERROR: bifrost.scim.config.clientId is required when SCIM provider is Zitadel." }}
+{{- end }}
+{{- end }}
+{{- if eq $scimValidation.provider "google" }}
+{{- if not $scimValidation.config.domain }}
+{{- fail "ERROR: bifrost.scim.config.domain is required when SCIM provider is Google Workspace. Example: company.com" }}
+{{- end }}
+{{- if not $scimValidation.config.clientId }}
+{{- fail "ERROR: bifrost.scim.config.clientId is required when SCIM provider is Google Workspace." }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/* Validate cluster config when enabled */}}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1699,7 +1699,7 @@
             },
             "provider": {
               "type": "string",
-              "enum": ["", "okta", "entra", "keycloak"],
+              "enum": ["", "okta", "entra", "keycloak", "zitadel", "google"],
               "description": "SCIM/SSO provider type (empty when not configured)"
             },
             "config": {
@@ -1710,6 +1710,20 @@
           "required": ["enabled"],
           "additionalProperties": false,
           "allOf": [
+            {
+              "if": {
+                "properties": { "enabled": { "const": true } },
+                "required": ["enabled"]
+              },
+              "then": {
+                "properties": {
+                  "provider": {
+                    "enum": ["okta", "entra", "keycloak", "zitadel", "google"]
+                  }
+                },
+                "required": ["provider"]
+              }
+            },
             {
               "if": {
                 "properties": {
@@ -1763,6 +1777,48 @@
                         "type": "string",
                         "description": "JWT claim field for roles (default: 'roles')",
                         "default": "roles"
+                      },
+                      "attributeRoleMappings": {
+                        "type": "array",
+                        "description": "Ordered list of attribute -> role mappings (first match wins). Requires an Okta Custom Authorization Server; the free Org Authorization Server does not support claim expressions.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string", "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')" },
+                            "value": { "type": "string", "description": "Claim value to match (case-insensitive)" },
+                            "role": { "type": "string", "description": "Bifrost role to assign on match" }
+                          },
+                          "required": ["attribute", "value", "role"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "attributeTeamMappings": {
+                        "type": "array",
+                        "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through (every claim value becomes a team name).",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" },
+                            "team": { "type": "string" }
+                          },
+                          "required": ["attribute", "value", "team"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "attributeBusinessUnitMappings": {
+                        "type": "array",
+                        "description": "Attribute -> business-unit mappings (all matches apply).",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" },
+                            "business_unit": { "type": "string" }
+                          },
+                          "required": ["attribute", "value", "business_unit"],
+                          "additionalProperties": false
+                        }
                       }
                     },
                     "required": [
@@ -1835,6 +1891,48 @@
                         "type": "string",
                         "description": "JWT claim field for roles (default: 'roles')",
                         "default": "roles"
+                      },
+                      "attributeRoleMappings": {
+                        "type": "array",
+                        "description": "Ordered list of attribute -> role mappings (first match wins).",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string", "description": "JWT claim name (supports dot paths)" },
+                            "value": { "type": "string", "description": "Claim value to match (case-insensitive)" },
+                            "role": { "type": "string", "description": "Bifrost role to assign on match" }
+                          },
+                          "required": ["attribute", "value", "role"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "attributeTeamMappings": {
+                        "type": "array",
+                        "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through (every claim value becomes a team name).",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" },
+                            "team": { "type": "string" }
+                          },
+                          "required": ["attribute", "value", "team"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "attributeBusinessUnitMappings": {
+                        "type": "array",
+                        "description": "Attribute -> business-unit mappings (all matches apply).",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" },
+                            "business_unit": { "type": "string" }
+                          },
+                          "required": ["attribute", "value", "business_unit"],
+                          "additionalProperties": false
+                        }
                       }
                     },
                     "required": ["tenantId", "clientId"],
@@ -1899,23 +1997,44 @@
                       },
                       "attributeRoleMappings": {
                         "type": "array",
-                        "description": "Ordered list of attribute -> role mappings",
+                        "description": "Ordered list of attribute -> role mappings (first match wins).",
                         "items": {
-                          "type": "object"
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string", "description": "JWT claim name (supports dot paths, e.g. 'realm_access.roles')" },
+                            "value": { "type": "string", "description": "Claim value to match (case-insensitive)" },
+                            "role": { "type": "string", "description": "Bifrost role to assign on match" }
+                          },
+                          "required": ["attribute", "value", "role"],
+                          "additionalProperties": false
                         }
                       },
                       "attributeTeamMappings": {
                         "type": "array",
-                        "description": "Attribute -> team mappings (all matches apply)",
+                        "description": "Attribute -> team mappings (all matches apply). Use value '*' for pass-through (every claim value becomes a team name).",
                         "items": {
-                          "type": "object"
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" },
+                            "team": { "type": "string" }
+                          },
+                          "required": ["attribute", "value", "team"],
+                          "additionalProperties": false
                         }
                       },
                       "attributeBusinessUnitMappings": {
                         "type": "array",
-                        "description": "Attribute -> business-unit mappings (all matches apply)",
+                        "description": "Attribute -> business-unit mappings (all matches apply).",
                         "items": {
-                          "type": "object"
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" },
+                            "business_unit": { "type": "string" }
+                          },
+                          "required": ["attribute", "value", "business_unit"],
+                          "additionalProperties": false
                         }
                       }
                     },
@@ -1926,6 +2045,249 @@
                       "clientSecret"
                     ],
                     "additionalProperties": false
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  },
+                  "provider": {
+                    "const": "zitadel"
+                  }
+                },
+                "required": ["enabled", "provider"]
+              },
+              "then": {
+                "properties": {
+                  "config": {
+                    "type": "object",
+                    "description": "Zitadel OIDC authentication configuration",
+                    "properties": {
+                      "domain": {
+                        "type": "string",
+                        "format": "hostname",
+                        "pattern": "^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$",
+                        "description": "Zitadel instance domain (e.g., 'my-instance.zitadel.cloud' or 'auth.company.com'). Bare host only - do NOT include the scheme, port, or path."
+                      },
+                      "clientId": {
+                        "type": "string",
+                        "description": "Zitadel application client ID"
+                      },
+                      "clientSecret": {
+                        "type": "string",
+                        "description": "Zitadel client secret (optional, required for confidential clients and token revocation)"
+                      },
+                      "projectId": {
+                        "type": "string",
+                        "description": "Optional Zitadel project ID for project-scoped role claims"
+                      },
+                      "audience": {
+                        "type": "string",
+                        "description": "Access-token audience override (default: clientId)"
+                      },
+                      "serviceAccountClientId": {
+                        "type": "string",
+                        "description": "Service account client ID for Zitadel Management API (required for user provisioning - web apps cannot use client_credentials)"
+                      },
+                      "serviceAccountClientSecret": {
+                        "type": "string",
+                        "description": "Service account client secret for Zitadel Management API"
+                      },
+                      "teamIdsField": {
+                        "type": "string",
+                        "description": "JWT claim field for team/group IDs (default: 'groups')",
+                        "default": "groups"
+                      },
+                      "attributeRoleMappings": {
+                        "type": "array",
+                        "description": "Ordered list of attribute -> role mappings (first match wins).",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" },
+                            "role": { "type": "string" }
+                          },
+                          "required": ["attribute", "value", "role"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "attributeTeamMappings": {
+                        "type": "array",
+                        "description": "Attribute -> team mappings (all matches apply).",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" },
+                            "team": { "type": "string" }
+                          },
+                          "required": ["attribute", "value", "team"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "attributeBusinessUnitMappings": {
+                        "type": "array",
+                        "description": "Attribute -> business-unit mappings (all matches apply).",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" },
+                            "business_unit": { "type": "string" }
+                          },
+                          "required": ["attribute", "value", "business_unit"],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "required": ["domain", "clientId"],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            },
+            {
+              "if": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  },
+                  "provider": {
+                    "const": "google"
+                  }
+                },
+                "required": ["enabled", "provider"]
+              },
+              "then": {
+                "properties": {
+                  "config": {
+                    "type": "object",
+                    "description": "Google Workspace OIDC authentication configuration",
+                    "properties": {
+                      "domain": {
+                        "type": "string",
+                        "format": "hostname",
+                        "pattern": "^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$",
+                        "description": "Google Workspace primary domain (e.g., 'company.com'). Bare host only - do NOT include the scheme, port, or path."
+                      },
+                      "clientId": {
+                        "type": "string",
+                        "description": "Google OAuth2 client ID"
+                      },
+                      "clientSecret": {
+                        "type": "string",
+                        "description": "Google client secret (optional, used for token revocation)"
+                      },
+                      "credentialMode": {
+                        "type": "string",
+                        "enum": ["", "inherit", "env", "file"],
+                        "description": "How Directory API credentials are sourced. 'inherit' uses Application Default Credentials; 'env' uses serviceAccountEnvVar; 'file' uses serviceAccountFile."
+                      },
+                      "serviceAccountEnvVar": {
+                        "type": "string",
+                        "description": "Name of the environment variable containing the service account JSON (used when credentialMode is 'env'). Required for Directory API access without ADC."
+                      },
+                      "serviceAccountFile": {
+                        "type": "string",
+                        "description": "Filesystem path to the service account JSON key file (used when credentialMode is 'file')."
+                      },
+                      "adminEmail": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "Admin email for domain-wide delegation. Required whenever Directory API access is configured."
+                      },
+                      "impersonateServiceAccount": {
+                        "type": "string",
+                        "description": "GCP service account email to impersonate when using ADC (Workload Identity); must have domain-wide delegation configured."
+                      },
+                      "audience": {
+                        "type": "string",
+                        "description": "JWT audience override (default: clientId)"
+                      },
+                      "teamIdsField": {
+                        "type": "string",
+                        "description": "Claim field for team/group IDs (default: 'groups')",
+                        "default": "groups"
+                      },
+                      "attributeRoleMappings": {
+                        "type": "array",
+                        "description": "Ordered list of attribute -> role mappings (first match wins).",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" },
+                            "role": { "type": "string" }
+                          },
+                          "required": ["attribute", "value", "role"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "attributeTeamMappings": {
+                        "type": "array",
+                        "description": "Attribute -> team mappings (all matches apply).",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" },
+                            "team": { "type": "string" }
+                          },
+                          "required": ["attribute", "value", "team"],
+                          "additionalProperties": false
+                        }
+                      },
+                      "attributeBusinessUnitMappings": {
+                        "type": "array",
+                        "description": "Attribute -> business-unit mappings (all matches apply).",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "attribute": { "type": "string" },
+                            "value": { "type": "string" },
+                            "business_unit": { "type": "string" }
+                          },
+                          "required": ["attribute", "value", "business_unit"],
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "required": ["domain", "clientId"],
+                    "additionalProperties": false,
+                    "allOf": [
+                      {
+                        "if": {
+                          "properties": { "credentialMode": { "const": "env" } },
+                          "required": ["credentialMode"]
+                        },
+                        "then": {
+                          "required": ["serviceAccountEnvVar"]
+                        }
+                      },
+                      {
+                        "if": {
+                          "properties": { "credentialMode": { "const": "file" } },
+                          "required": ["credentialMode"]
+                        },
+                        "then": {
+                          "required": ["serviceAccountFile"]
+                        }
+                      },
+                      {
+                        "if": {
+                          "properties": { "credentialMode": { "enum": ["inherit", "env", "file"] } },
+                          "required": ["credentialMode"]
+                        },
+                        "then": {
+                          "required": ["adminEmail"]
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -597,7 +597,7 @@ bifrost:
   # SCIM/SSO configuration for enterprise SSO
   scim:
     enabled: false
-    # Provider: okta, entra, keycloak
+    # Provider: okta, entra, keycloak, zitadel, google
     provider: ""
     config: {}
       # Okta configuration:
@@ -609,6 +609,20 @@ bifrost:
       # userIdField: "sub"
       # teamIdsField: "groups"
       # rolesField: "roles"
+      # # Attribute -> role/team/business-unit mappings (requires Custom Authorization Server;
+      # # the free Org Auth Server does not support claim expressions).
+      # attributeRoleMappings:
+      #   - attribute: "groups"
+      #     value: "bifrost-admins"
+      #     role: "admin"
+      # attributeTeamMappings:
+      #   - attribute: "groups"
+      #     value: "*"            # pass-through: every group becomes a team
+      #     team: ""              # ignored when value is "*"
+      # attributeBusinessUnitMappings:
+      #   - attribute: "department"
+      #     value: "platform"
+      #     business_unit: "Platform"
       #
       # Entra (Azure AD) configuration:
       # tenantId: ""
@@ -620,6 +634,15 @@ bifrost:
       # userIdField: "oid"
       # teamIdsField: "groups"
       # rolesField: "roles"
+      # attributeRoleMappings:
+      #   - attribute: "roles"
+      #     value: "BifrostAdmin"
+      #     role: "admin"
+      # attributeTeamMappings:
+      #   - attribute: "groups"
+      #     value: "<group-object-id>"
+      #     team: "platform-team"
+      # attributeBusinessUnitMappings: []
       #
       # Keycloak configuration:
       # serverUrl: "https://keycloak.company.com"  # base URL, must NOT include /realms/{realm}
@@ -630,6 +653,40 @@ bifrost:
       # userIdField: "sub"
       # teamIdsField: "groups"
       # rolesField: "roles"
+      # attributeRoleMappings:
+      #   - attribute: "realm_access.roles"
+      #     value: "bifrost-admin"
+      #     role: "admin"
+      # attributeTeamMappings: []
+      # attributeBusinessUnitMappings: []
+      #
+      # Zitadel configuration:
+      # domain: "my-instance.zitadel.cloud"      # no scheme
+      # clientId: ""
+      # clientSecret: ""                          # optional, for confidential clients
+      # projectId: ""                             # optional, for project-scoped role claims
+      # audience: ""
+      # serviceAccountClientId: ""                # required for user provisioning
+      # serviceAccountClientSecret: ""
+      # teamIdsField: "groups"
+      # attributeRoleMappings: []
+      # attributeTeamMappings: []
+      # attributeBusinessUnitMappings: []
+      #
+      # Google Workspace configuration:
+      # domain: "company.com"
+      # clientId: ""
+      # clientSecret: ""
+      # credentialMode: "inherit"                 # "inherit" (ADC), "env", or "file"
+      # serviceAccountEnvVar: "GOOGLE_SA_JSON"    # required when credentialMode is "env"
+      # serviceAccountFile: "/etc/bifrost/sa.json" # required when credentialMode is "file"
+      # adminEmail: "admin@company.com"           # required for Directory API (domain-wide delegation)
+      # impersonateServiceAccount: ""             # optional, for Workload Identity
+      # audience: ""
+      # teamIdsField: "groups"
+      # attributeRoleMappings: []
+      # attributeTeamMappings: []
+      # attributeBusinessUnitMappings: []
 
   # Load balancer configuration for intelligent request routing
   loadBalancer:

--- a/helm-charts/index.yaml
+++ b/helm-charts/index.yaml
@@ -3,9 +3,10 @@ entries:
   bifrost:
   - apiVersion: v2
     appVersion: 1.5.0
-    created: "2026-05-14T00:00:00Z"
+    created: "2026-05-17T14:30:00.000000+05:30"
     description: A Helm chart for deploying Bifrost - AI Gateway with unified interface
       for multiple providers
+    digest: 8e887afbbc89f079595200570b40267c18dcc50f0ac188cff2116358555a8c15
     home: https://www.getmaxim.ai/bifrost
     icon: https://www.getbifrost.ai/favicon.png
     keywords:
@@ -915,4 +916,4 @@ entries:
     urls:
     - https://maximhq.github.io/bifrost/helm-charts/bifrost-1.3.36.tgz
     version: 1.3.36
-generated: "2026-05-14T00:00:00Z"
+generated: "2026-05-17T14:30:00.000000+05:30"


### PR DESCRIPTION
## Summary

Adds a warning to the budget and limits documentation clarifying that running multiple OSS Bifrost nodes with a Postgres backend is not supported, and explains why this is an intentional architectural boundary between the OSS and Enterprise offerings.

## Issues

closes #3547

## Changes

- Added a `<Warning>` block to `budget-and-limits.mdx` explaining that Bifrost keeps all critical state (provider configs, API keys, budgets, usage, traffic distribution) in memory and does not re-read it from the database after initialization.
- Documents that multi-node synchronization is handled in the Enterprise version via a modified RAFT consensus mechanism, while the database serves only as a passive store.
- Sets expectations for OSS users (~3,000–5,000 RPS on a single instance) and directs high-availability needs toward the Enterprise plan.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation to confirm the warning block displays correctly and the content is accurate.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable