### PR TITLE
extend e2e API tests for DAC

### DIFF
--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -266,6 +266,7 @@ const (
 	BifrostContextKeyVisibilityFilterProvider            BifrostContextKey = "bifrost-visibility-filter-provider" // DEPRECATED: replaced by BifrostContextKeyQueryScope. Will be removed once all callers migrate.
 	BifrostContextKeyTargetUserID                        BifrostContextKey = "target_user_id"
 	BifrostContextKeyIsAzureUserAgent                    BifrostContextKey = "bifrost-is-azure-user-agent" // bool (set by bifrost - DO NOT SET THIS MANUALLY)) - whether the request is an Azure user agent (only used in gateway)
+	BifrostContextKeyUserRoleID                          BifrostContextKey = "bifrost-user-role-id"
 	BifrostContextKeyVideoOutputRequested                BifrostContextKey = "bifrost-video-output-requested"
 	BifrostContextKeyValidateKeys                        BifrostContextKey = "bifrost-validate-keys"                         // bool (triggers additional key validation during provider add/update)
 	BifrostContextKeyProviderResponseHeaders             BifrostContextKey = "bifrost-provider-response-headers"             // map[string]string (set by provider handlers for response header forwarding)

--- a/framework/cmd/e2eseed/main.go
+++ b/framework/cmd/e2eseed/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/maximhq/bifrost/framework/e2eseed"
+)
+
+// main runs the OSS API e2e seed command.
+func main() {
+	if err := run(context.Background(), os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e seed failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run parses flags, connects to the target stores, and writes seed fixtures.
+func run(ctx context.Context, args []string) error {
+	opts := e2eseed.DefaultOptions()
+	summaryPath := ""
+
+	fs := flag.NewFlagSet("e2eseed", flag.ContinueOnError)
+	fs.StringVar(&opts.Prefix, "prefix", opts.Prefix, "stable prefix for all seeded rows")
+	fs.StringVar(&opts.ConfigDialect, "config-db-dialect", opts.ConfigDialect, "config DB dialect: postgres or sqlite")
+	fs.StringVar(&opts.ConfigDSN, "config-db-dsn", opts.ConfigDSN, "config DB DSN")
+	fs.StringVar(&opts.LogsDialect, "logs-db-dialect", opts.LogsDialect, "logs DB dialect: postgres or sqlite")
+	fs.StringVar(&opts.LogsDSN, "logs-db-dsn", opts.LogsDSN, "logs DB DSN")
+	fs.IntVar(&opts.LogRows, "logs", opts.LogRows, "number of log rows to seed")
+	fs.IntVar(&opts.BatchSize, "batch-size", opts.BatchSize, "log insert batch size")
+	fs.StringVar(&opts.OutputEnvPath, "output-env", opts.OutputEnvPath, "path for generated environment values")
+	fs.StringVar(&summaryPath, "summary", "", "optional JSON summary path")
+	fs.BoolVar(&opts.DryRun, "dry-run", opts.DryRun, "build the manifest without writing rows")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	opts = e2eseed.NormalizeOptions(opts)
+	configDB, err := e2eseed.OpenDB(opts.ConfigDialect, opts.ConfigDSN)
+	if err != nil {
+		return fmt.Errorf("open config DB: %w", err)
+	}
+	logsDB, err := e2eseed.OpenDB(opts.LogsDialect, opts.LogsDSN)
+	if err != nil {
+		return fmt.Errorf("open logs DB: %w", err)
+	}
+
+	summary, err := e2eseed.SeedBase(ctx, configDB, logsDB, opts)
+	if err != nil {
+		return err
+	}
+	if summaryPath != "" {
+		if err := e2eseed.WriteJSONFile(summaryPath, summary); err != nil {
+			return err
+		}
+	}
+	fmt.Printf("seeded OSS API e2e data prefix=%s logs=%d env=%s\n", summary.Prefix, summary.LogRows, opts.OutputEnvPath)
+	return nil
+}

--- a/framework/cmd/e2eseed/main.go
+++ b/framework/cmd/e2eseed/main.go
@@ -30,7 +30,7 @@ func run(ctx context.Context, args []string) error {
 	fs.StringVar(&opts.ConfigDSN, "config-db-dsn", opts.ConfigDSN, "config DB DSN")
 	fs.StringVar(&opts.LogsDialect, "logs-db-dialect", opts.LogsDialect, "logs DB dialect: postgres or sqlite")
 	fs.StringVar(&opts.LogsDSN, "logs-db-dsn", opts.LogsDSN, "logs DB DSN")
-	fs.IntVar(&opts.LogRows, "logs", opts.LogRows, "number of log rows to seed")
+	fs.IntVar(&opts.LogRowsPerShape, "logs-per-shape", opts.LogRowsPerShape, "number of log rows to seed per DAC ownership shape (applied to both logs and mcp_tool_logs)")
 	fs.IntVar(&opts.BatchSize, "batch-size", opts.BatchSize, "log insert batch size")
 	fs.StringVar(&opts.OutputEnvPath, "output-env", opts.OutputEnvPath, "path for generated environment values")
 	fs.StringVar(&summaryPath, "summary", "", "optional JSON summary path")
@@ -68,6 +68,6 @@ func run(ctx context.Context, args []string) error {
 			return err
 		}
 	}
-	fmt.Printf("seeded OSS API e2e data prefix=%s logs=%d env=%s\n", summary.Prefix, summary.LogRows, opts.OutputEnvPath)
+	fmt.Printf("seeded OSS API e2e data prefix=%s logs_per_shape=%d shapes=%d env=%s\n", summary.Prefix, summary.LogRowsPerShape, len(summary.Expected.Shapes), opts.OutputEnvPath)
 	return nil
 }

--- a/framework/cmd/e2eseed/main.go
+++ b/framework/cmd/e2eseed/main.go
@@ -24,6 +24,8 @@ func run(ctx context.Context, args []string) error {
 
 	fs := flag.NewFlagSet("e2eseed", flag.ContinueOnError)
 	fs.StringVar(&opts.Prefix, "prefix", opts.Prefix, "stable prefix for all seeded rows")
+	fs.StringVar(&opts.ConfigPath, "config-path", opts.ConfigPath, "optional Bifrost config.json path used to derive DB settings")
+	fs.StringVar(&opts.EncryptionKey, "encryption-key", opts.EncryptionKey, "optional Bifrost encryption key for encrypted config rows")
 	fs.StringVar(&opts.ConfigDialect, "config-db-dialect", opts.ConfigDialect, "config DB dialect: postgres or sqlite")
 	fs.StringVar(&opts.ConfigDSN, "config-db-dsn", opts.ConfigDSN, "config DB DSN")
 	fs.StringVar(&opts.LogsDialect, "logs-db-dialect", opts.LogsDialect, "logs DB dialect: postgres or sqlite")
@@ -37,14 +39,24 @@ func run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	opts = e2eseed.NormalizeOptions(opts)
+	opts, err := e2eseed.NormalizeOptions(opts)
+	if err != nil {
+		return err
+	}
+	e2eseed.InitEncryption(opts)
 	configDB, err := e2eseed.OpenDB(opts.ConfigDialect, opts.ConfigDSN)
 	if err != nil {
 		return fmt.Errorf("open config DB: %w", err)
 	}
+	if sqlDB, dbErr := configDB.DB(); dbErr == nil {
+		defer sqlDB.Close()
+	}
 	logsDB, err := e2eseed.OpenDB(opts.LogsDialect, opts.LogsDSN)
 	if err != nil {
 		return fmt.Errorf("open logs DB: %w", err)
+	}
+	if sqlDB, dbErr := logsDB.DB(); dbErr == nil {
+		defer sqlDB.Close()
 	}
 
 	summary, err := e2eseed.SeedBase(ctx, configDB, logsDB, opts)

--- a/framework/e2eseed/seed.go
+++ b/framework/e2eseed/seed.go
@@ -25,17 +25,17 @@ import (
 
 // Options controls the shared seed dataset.
 type Options struct {
-	Prefix        string
-	ConfigPath    string
-	EncryptionKey string
-	ConfigDialect string
-	ConfigDSN     string
-	LogsDialect   string
-	LogsDSN       string
-	LogRows       int
-	BatchSize     int
-	OutputEnvPath string
-	DryRun        bool
+	Prefix          string
+	ConfigPath      string
+	EncryptionKey   string
+	ConfigDialect   string
+	ConfigDSN       string
+	LogsDialect     string
+	LogsDSN         string
+	LogRowsPerShape int
+	BatchSize       int
+	OutputEnvPath   string
+	DryRun          bool
 }
 
 // Shape describes one DAC ownership combination.
@@ -52,21 +52,22 @@ type Shape struct {
 
 // ExpectedManifest records seeded IDs and expected DAC visibility.
 type ExpectedManifest struct {
-	Prefix   string              `json:"prefix"`
-	Personas map[string]string   `json:"personas"`
-	Shapes   []Shape             `json:"shapes"`
-	LogIDs   map[string][]string `json:"log_ids"`
+	Prefix    string              `json:"prefix"`
+	Personas  map[string]string   `json:"personas"`
+	Shapes    []Shape             `json:"shapes"`
+	LogIDs    map[string][]string `json:"log_ids"`
+	MCPLogIDs map[string][]string `json:"mcp_log_ids"`
 }
 
 // Summary is returned after a seed run.
 type Summary struct {
-	Prefix      string            `json:"prefix"`
-	LogRows     int               `json:"log_rows"`
-	SeedEnv     map[string]string `json:"seed_env"`
-	Expected    ExpectedManifest  `json:"expected"`
-	TableCounts map[string]int64  `json:"table_counts"`
-	DryRun      bool              `json:"dry_run"`
-	GeneratedAt time.Time         `json:"generated_at"`
+	Prefix          string            `json:"prefix"`
+	LogRowsPerShape int               `json:"log_rows_per_shape"`
+	SeedEnv         map[string]string `json:"seed_env"`
+	Expected        ExpectedManifest  `json:"expected"`
+	TableCounts     map[string]int64  `json:"table_counts"`
+	DryRun          bool              `json:"dry_run"`
+	GeneratedAt     time.Time         `json:"generated_at"`
 }
 
 // seedBaseTime is the per-run anchor timestamp for seeded log rows. We set it
@@ -78,12 +79,12 @@ var seedBaseTime = time.Now().UTC()
 // DefaultOptions returns defaults for local e2e seeding.
 func DefaultOptions() Options {
 	return Options{
-		Prefix:        "e2e-seed",
-		ConfigDialect: "postgres",
-		LogsDialect:   "postgres",
-		LogRows:       100000,
-		BatchSize:     1000,
-		OutputEnvPath: "tmp/e2e-seed.env",
+		Prefix:          "e2e-seed",
+		ConfigDialect:   "postgres",
+		LogsDialect:     "postgres",
+		LogRowsPerShape: 30,
+		BatchSize:       1000,
+		OutputEnvPath:   "tmp/e2e-seed.env",
 	}
 }
 
@@ -129,8 +130,8 @@ func NormalizeOptions(opts Options) (Options, error) {
 	if opts.LogsDSN == "" {
 		opts.LogsDSN = "postgres://bifrost:bifrost_password@localhost:5432/bifrost?sslmode=disable"
 	}
-	if opts.LogRows <= 0 {
-		opts.LogRows = def.LogRows
+	if opts.LogRowsPerShape <= 0 {
+		opts.LogRowsPerShape = def.LogRowsPerShape
 	}
 	if opts.BatchSize <= 0 {
 		opts.BatchSize = def.BatchSize
@@ -258,15 +259,15 @@ func SeedBase(ctx context.Context, configDB, logsDB *gorm.DB, opts Options) (*Su
 	}
 	InitEncryption(opts)
 	env := SeedEnv(opts.Prefix)
-	manifest := BuildExpectedManifest(opts.Prefix, opts.LogRows)
+	manifest := BuildExpectedManifest(opts.Prefix, opts.LogRowsPerShape)
 	summary := &Summary{
-		Prefix:      opts.Prefix,
-		LogRows:     opts.LogRows,
-		SeedEnv:     env,
-		Expected:    manifest,
-		TableCounts: map[string]int64{},
-		DryRun:      opts.DryRun,
-		GeneratedAt: time.Now().UTC(),
+		Prefix:          opts.Prefix,
+		LogRowsPerShape: opts.LogRowsPerShape,
+		SeedEnv:         env,
+		Expected:        manifest,
+		TableCounts:     map[string]int64{},
+		DryRun:          opts.DryRun,
+		GeneratedAt:     time.Now().UTC(),
 	}
 	if opts.DryRun {
 		return summary, nil
@@ -305,6 +306,22 @@ func SeedEnv(prefix string) map[string]string {
 }
 
 // BuildShapes returns the DAC ownership matrix.
+//
+// The set is built by enumerating all 15 non-empty subsets of the four DAC
+// dimensions {VirtualKey, UserID, TeamID, BusinessUnitID}, all flavoured with
+// tiggings-side values so the tiggings-flavoured personas see them, plus
+// three appended shapes for negative coverage:
+//   - user-not-in-tiggings: outside user + BU (cross-team isolation)
+//   - outside-team-virtual-key: outside user + team + BU + VK
+//   - legacy-unowned: no DAC dimensions (fail-closed for non-admin)
+//
+// CustomerID is set together with BusinessUnitID when the B dimension is
+// present; the two columns are conceptually paired in the seeded dataset.
+//
+// The VirtualKey value for each tiggings shape is teamVK when the team
+// dimension is present without a user, so the team-only VK ownership path
+// (governance_virtual_keys.team_id) gets exercised. Every other VK-bearing
+// shape uses userVK so the user-attached VK ownership path is exercised too.
 func BuildShapes(prefix string) []Shape {
 	tiggingsUser := prefix + "-user-tiggings"
 	outsideUser := prefix + "-user-outside"
@@ -317,28 +334,145 @@ func BuildShapes(prefix string) []Shape {
 	userVK := prefix + "-vk-user-team"
 	teamVK := prefix + "-vk-team-only"
 	outsideVK := prefix + "-vk-outside"
-	return []Shape{
-		{Name: "user-in-tiggings", UserID: tiggingsUser, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, Marker: prefix + "-shape-user-in-tiggings", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin"}},
-		{Name: "user-not-in-tiggings", UserID: outsideUser, CustomerID: outsideCustomer, BusinessUnitID: outsideBU, Marker: prefix + "-shape-user-not-in-tiggings", VisibleTo: []string{"own_reader_outside", "team_reader_outside", "all_data_admin"}},
-		{Name: "only-user", UserID: tiggingsUser, Marker: prefix + "-shape-only-user", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin"}},
-		{Name: "only-team", TeamID: tiggingsTeam, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, Marker: prefix + "-shape-only-team", VisibleTo: []string{"team_reader_tiggings", "all_data_admin", "vk_team_owned"}},
-		{Name: "only-virtual-key", VirtualKeyID: userVK, Marker: prefix + "-shape-only-vk", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin", "vk_user_owned"}},
-		{Name: "user-team", UserID: tiggingsUser, TeamID: tiggingsTeam, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, Marker: prefix + "-shape-user-team", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin"}},
-		{Name: "user-virtual-key", UserID: tiggingsUser, VirtualKeyID: userVK, Marker: prefix + "-shape-user-vk", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin", "vk_user_owned"}},
-		{Name: "team-virtual-key", TeamID: tiggingsTeam, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, VirtualKeyID: teamVK, Marker: prefix + "-shape-team-vk", VisibleTo: []string{"team_reader_tiggings", "all_data_admin", "vk_team_owned"}},
-		{Name: "user-team-virtual-key", UserID: tiggingsUser, TeamID: tiggingsTeam, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, VirtualKeyID: userVK, Marker: prefix + "-shape-user-team-vk", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin", "vk_user_owned"}},
-		{Name: "outside-team-virtual-key", UserID: outsideUser, TeamID: outsideTeam, CustomerID: outsideCustomer, BusinessUnitID: outsideBU, VirtualKeyID: outsideVK, Marker: prefix + "-shape-outside-team-vk", VisibleTo: []string{"own_reader_outside", "team_reader_outside", "all_data_admin"}},
-		{Name: "legacy-unowned", Marker: prefix + "-shape-legacy-unowned", VisibleTo: []string{"all_data_admin"}},
+
+	shapes := make([]Shape, 0, 18)
+	for mask := 1; mask <= 15; mask++ {
+		hasVK := mask&0x1 != 0
+		hasU := mask&0x2 != 0
+		hasT := mask&0x4 != 0
+		hasB := mask&0x8 != 0
+
+		shape := Shape{Name: shapeNameFromDims(hasVK, hasU, hasT, hasB)}
+		if hasVK {
+			if hasT && !hasU {
+				shape.VirtualKeyID = teamVK
+			} else {
+				shape.VirtualKeyID = userVK
+			}
+		}
+		if hasU {
+			shape.UserID = tiggingsUser
+		}
+		if hasT {
+			shape.TeamID = tiggingsTeam
+		}
+		if hasB {
+			shape.BusinessUnitID = tiggingsBU
+			shape.CustomerID = tiggingsCustomer
+		}
+		shape.Marker = prefix + "-shape-" + shape.Name
+		shape.VisibleTo = computeVisibleTo(shape, tiggingsUser, outsideUser, tiggingsTeam, outsideTeam, userVK, teamVK, outsideVK)
+		shapes = append(shapes, shape)
 	}
+
+	shapes = append(shapes,
+		Shape{
+			Name:           "user-not-in-tiggings",
+			UserID:         outsideUser,
+			CustomerID:     outsideCustomer,
+			BusinessUnitID: outsideBU,
+			Marker:         prefix + "-shape-user-not-in-tiggings",
+			VisibleTo:      []string{"all_data_admin", "own_reader_outside", "team_reader_outside"},
+		},
+		Shape{
+			Name:           "outside-team-virtual-key",
+			UserID:         outsideUser,
+			TeamID:         outsideTeam,
+			CustomerID:     outsideCustomer,
+			BusinessUnitID: outsideBU,
+			VirtualKeyID:   outsideVK,
+			Marker:         prefix + "-shape-outside-team-vk",
+			VisibleTo:      []string{"all_data_admin", "own_reader_outside", "team_reader_outside"},
+		},
+		Shape{
+			Name:      "legacy-unowned",
+			Marker:    prefix + "-shape-legacy-unowned",
+			VisibleTo: []string{"all_data_admin"},
+		},
+	)
+	return shapes
 }
 
-// BuildExpectedManifest returns the expected DAC visibility document.
-func BuildExpectedManifest(prefix string, logRows int) ExpectedManifest {
+// shapeNameFromDims returns a deterministic kebab-case name for the given
+// dimension presence flags. Single-dimension shapes are prefixed with "only-"
+// so the matrix reads naturally in the manifest.
+func shapeNameFromDims(hasVK, hasU, hasT, hasB bool) string {
+	var parts []string
+	if hasVK {
+		parts = append(parts, "virtual-key")
+	}
+	if hasU {
+		parts = append(parts, "user")
+	}
+	if hasT {
+		parts = append(parts, "team")
+	}
+	if hasB {
+		parts = append(parts, "business-unit")
+	}
+	if len(parts) == 1 {
+		return "only-" + parts[0]
+	}
+	return strings.Join(parts, "-")
+}
+
+// computeVisibleTo returns the sorted set of personas that can see rows of the
+// given shape, derived directly from the shape's DAC dimensions and the
+// well-known seeded principal/VK values.
+func computeVisibleTo(s Shape, tigU, outU, tigT, outT, userVK, teamVK, outVK string) []string {
+	set := map[string]struct{}{"all_data_admin": {}}
+
+	switch s.UserID {
+	case tigU:
+		set["own_reader_tiggings"] = struct{}{}
+		set["team_reader_tiggings"] = struct{}{}
+	case outU:
+		set["own_reader_outside"] = struct{}{}
+		set["team_reader_outside"] = struct{}{}
+	}
+
+	switch s.TeamID {
+	case tigT:
+		set["team_reader_tiggings"] = struct{}{}
+	case outT:
+		set["team_reader_outside"] = struct{}{}
+	}
+
+	switch s.VirtualKeyID {
+	case userVK:
+		set["vk_user_owned"] = struct{}{}
+		set["own_reader_tiggings"] = struct{}{}
+		set["team_reader_tiggings"] = struct{}{}
+	case teamVK:
+		set["vk_team_owned"] = struct{}{}
+		set["team_reader_tiggings"] = struct{}{}
+	case outVK:
+		set["own_reader_outside"] = struct{}{}
+		set["team_reader_outside"] = struct{}{}
+	}
+
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// BuildExpectedManifest returns the expected DAC visibility document. Each
+// shape gets logRowsPerShape contiguous log IDs and an equal number of MCP
+// log IDs so visibility tests can assert exact set membership for either
+// table.
+func BuildExpectedManifest(prefix string, logRowsPerShape int) ExpectedManifest {
 	shapes := BuildShapes(prefix)
 	logIDs := make(map[string][]string, len(shapes))
-	for i := 0; i < logRows; i++ {
-		shape := shapes[i%len(shapes)]
-		logIDs[shape.Name] = append(logIDs[shape.Name], fmt.Sprintf("%s-log-%06d", prefix, i))
+	mcpLogIDs := make(map[string][]string, len(shapes))
+	for shapeIdx, shape := range shapes {
+		for j := 0; j < logRowsPerShape; j++ {
+			i := shapeIdx*logRowsPerShape + j
+			logIDs[shape.Name] = append(logIDs[shape.Name], fmt.Sprintf("%s-log-%06d", prefix, i))
+			mcpLogIDs[shape.Name] = append(mcpLogIDs[shape.Name], fmt.Sprintf("%s-mcp-log-%06d", prefix, i))
+		}
 	}
 	return ExpectedManifest{
 		Prefix: prefix,
@@ -351,8 +485,9 @@ func BuildExpectedManifest(prefix string, logRows int) ExpectedManifest {
 			"vk_user_owned":        prefix + "-vk-user-team",
 			"vk_team_owned":        prefix + "-vk-team-only",
 		},
-		Shapes: shapes,
-		LogIDs: logIDs,
+		Shapes:    shapes,
+		LogIDs:    logIDs,
+		MCPLogIDs: mcpLogIDs,
 	}
 }
 
@@ -520,21 +655,25 @@ func seedMCP(ctx context.Context, db *gorm.DB, prefix string, now time.Time) err
 	return db.WithContext(ctx).Where("client_id = ?", client.ClientID).Assign(client).FirstOrCreate(&client).Error
 }
 
-// seedLogs writes the DAC matrix logs.
+// seedLogs writes the DAC matrix LLM logs. Each shape gets exactly
+// opts.LogRowsPerShape rows, so admin sees len(shapes) * LogRowsPerShape
+// total.
 func seedLogs(ctx context.Context, db *gorm.DB, opts Options, manifest ExpectedManifest) error {
 	if db == nil {
 		return fmt.Errorf("logs db is required")
 	}
 	shapes := manifest.Shapes
 	batch := make([]logstore.Log, 0, opts.BatchSize)
-	for i := 0; i < opts.LogRows; i++ {
-		shape := shapes[i%len(shapes)]
-		batch = append(batch, buildLog(opts.Prefix, shape, i))
-		if len(batch) == opts.BatchSize {
-			if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
-				return err
+	for shapeIdx, shape := range shapes {
+		for j := 0; j < opts.LogRowsPerShape; j++ {
+			i := shapeIdx*opts.LogRowsPerShape + j
+			batch = append(batch, buildLog(opts.Prefix, shape, i))
+			if len(batch) == opts.BatchSize {
+				if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
+					return err
+				}
+				batch = batch[:0]
 			}
-			batch = batch[:0]
 		}
 	}
 	if len(batch) > 0 {
@@ -542,22 +681,83 @@ func seedLogs(ctx context.Context, db *gorm.DB, opts Options, manifest ExpectedM
 			return err
 		}
 	}
-	return seedLogCompanions(ctx, db, opts.Prefix)
-}
-
-// seedLogCompanions writes one MCP log and one async job for log-adjacent APIs.
-func seedLogCompanions(ctx context.Context, db *gorm.DB, prefix string) error {
-	now := seedBaseTime
-	vk := prefix + "-vk-user-team"
-	latency := float64(25)
-	cost := 0.001
-	mcp := logstore.MCPToolLog{ID: prefix + "-mcp-log", RequestID: prefix + "-request", Timestamp: now, ToolName: "e2e-tool", ServerLabel: "e2e-mcp", VirtualKeyID: &vk, VirtualKeyName: ptr("E2E User Team VK"), ArgumentsParsed: map[string]any{"seed": prefix}, ResultParsed: map[string]any{"ok": true}, Latency: &latency, Cost: &cost, Status: "success", MetadataParsed: map[string]any{"seed_prefix": prefix}}
-	if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&mcp).Error; err != nil {
+	if err := seedMCPLogs(ctx, db, opts, manifest); err != nil {
 		return err
 	}
+	return seedAsyncJobCompanion(ctx, db, opts.Prefix)
+}
+
+// seedMCPLogs writes the DAC matrix MCP tool logs in the same shape and
+// volume as the LLM logs so MCP visibility tests can assert against the
+// expected.mcp_log_ids manifest the same way the LLM tests do.
+func seedMCPLogs(ctx context.Context, db *gorm.DB, opts Options, manifest ExpectedManifest) error {
+	shapes := manifest.Shapes
+	batch := make([]logstore.MCPToolLog, 0, opts.BatchSize)
+	for shapeIdx, shape := range shapes {
+		for j := 0; j < opts.LogRowsPerShape; j++ {
+			i := shapeIdx*opts.LogRowsPerShape + j
+			batch = append(batch, buildMCPLog(opts.Prefix, shape, i))
+			if len(batch) == opts.BatchSize {
+				if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
+					return err
+				}
+				batch = batch[:0]
+			}
+		}
+	}
+	if len(batch) > 0 {
+		if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// seedAsyncJobCompanion writes one async-job row tied to the seeded user VK
+// so the /api/async-jobs CRUD coverage has a deterministic fixture to read.
+func seedAsyncJobCompanion(ctx context.Context, db *gorm.DB, prefix string) error {
+	now := seedBaseTime
+	vk := prefix + "-vk-user-team"
 	completed := now
 	job := logstore.AsyncJob{ID: prefix + "-async-job", Status: schemas.AsyncJobStatusCompleted, RequestType: schemas.ChatCompletionRequest, Response: `{}`, StatusCode: 200, VirtualKeyID: &vk, ResultTTL: 3600, CreatedAt: now, CompletedAt: &completed}
 	return db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&job).Error
+}
+
+// buildMCPLog returns one deterministic MCP tool log row mirroring the DAC
+// dimensions of the shape so the same persona/visibility logic that drives
+// LLM log tests applies here.
+func buildMCPLog(prefix string, shape Shape, index int) logstore.MCPToolLog {
+	timestamp := seedBaseTime.Add(-time.Duration(index) * time.Second)
+	vkName := ""
+	if shape.VirtualKeyID != "" {
+		vkName = "E2E " + shape.VirtualKeyID
+	}
+	latency := float64(20 + index%200)
+	cost := float64(1+index%50) / 100000
+	status := "success"
+	if index%19 == 0 {
+		status = "error"
+	}
+	return logstore.MCPToolLog{
+		ID:              fmt.Sprintf("%s-mcp-log-%06d", prefix, index),
+		RequestID:       fmt.Sprintf("%s-mcp-req-%06d", prefix, index),
+		Timestamp:       timestamp,
+		ToolName:        "e2e-tool",
+		ServerLabel:     "e2e-mcp",
+		VirtualKeyID:    emptyPtr(shape.VirtualKeyID),
+		VirtualKeyName:  emptyPtr(vkName),
+		UserID:          emptyPtr(shape.UserID),
+		TeamID:          emptyPtr(shape.TeamID),
+		CustomerID:      emptyPtr(shape.CustomerID),
+		BusinessUnitID:  emptyPtr(shape.BusinessUnitID),
+		ArgumentsParsed: map[string]any{"seed_prefix": prefix, "shape": shape.Name, "marker": shape.Marker, "index": index},
+		ResultParsed:    map[string]any{"ok": true},
+		Latency:         &latency,
+		Cost:            &cost,
+		Status:          status,
+		MetadataParsed:  map[string]any{"seed_prefix": prefix, "shape": shape.Name, "marker": shape.Marker},
+		CreatedAt:       timestamp,
+	}
 }
 
 // buildLog returns one deterministic log row.

--- a/framework/e2eseed/seed.go
+++ b/framework/e2eseed/seed.go
@@ -5,14 +5,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/encrypt"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
@@ -23,6 +26,8 @@ import (
 // Options controls the shared seed dataset.
 type Options struct {
 	Prefix        string
+	ConfigPath    string
+	EncryptionKey string
 	ConfigDialect string
 	ConfigDSN     string
 	LogsDialect   string
@@ -64,14 +69,18 @@ type Summary struct {
 	GeneratedAt time.Time         `json:"generated_at"`
 }
 
+// seedBaseTime is the per-run anchor timestamp for seeded log rows. We set it
+// to "now" on every seed invocation so the rows land inside the dashboard's
+// default time-range filters (Last hour / Last day) instead of being frozen
+// at a fixed date that the UI would filter out.
+var seedBaseTime = time.Now().UTC()
+
 // DefaultOptions returns defaults for local e2e seeding.
 func DefaultOptions() Options {
 	return Options{
 		Prefix:        "e2e-seed",
 		ConfigDialect: "postgres",
-		ConfigDSN:     "postgres://bifrost:bifrost_password@localhost:5432/bifrost?sslmode=disable",
 		LogsDialect:   "postgres",
-		LogsDSN:       "postgres://bifrost:bifrost_password@localhost:5432/bifrost?sslmode=disable",
 		LogRows:       100000,
 		BatchSize:     1000,
 		OutputEnvPath: "tmp/e2e-seed.env",
@@ -79,16 +88,46 @@ func DefaultOptions() Options {
 }
 
 // NormalizeOptions applies default values to unset options.
-func NormalizeOptions(opts Options) Options {
+func NormalizeOptions(opts Options) (Options, error) {
 	def := DefaultOptions()
 	if opts.Prefix == "" {
 		opts.Prefix = def.Prefix
 	}
+	if opts.ConfigPath != "" {
+		resolved, err := optionsFromConfigFile(opts.ConfigPath)
+		if err != nil {
+			return Options{}, fmt.Errorf("load config path %q: %w", opts.ConfigPath, err)
+		}
+		if opts.EncryptionKey == "" {
+			opts.EncryptionKey = resolved.EncryptionKey
+		}
+		if opts.ConfigDialect == "" && resolved.ConfigDialect != "" {
+			opts.ConfigDialect = resolved.ConfigDialect
+		}
+		if opts.ConfigDSN == "" && resolved.ConfigDSN != "" {
+			opts.ConfigDSN = resolved.ConfigDSN
+		}
+		if opts.LogsDialect == "" && resolved.LogsDialect != "" {
+			opts.LogsDialect = resolved.LogsDialect
+		}
+		if opts.LogsDSN == "" && resolved.LogsDSN != "" {
+			opts.LogsDSN = resolved.LogsDSN
+		}
+	}
 	if opts.ConfigDialect == "" {
 		opts.ConfigDialect = def.ConfigDialect
 	}
+	if opts.EncryptionKey == "" {
+		opts.EncryptionKey = os.Getenv("BIFROST_ENCRYPTION_KEY")
+	}
+	if opts.ConfigDSN == "" {
+		opts.ConfigDSN = "postgres://bifrost:bifrost_password@localhost:5432/bifrost?sslmode=disable"
+	}
 	if opts.LogsDialect == "" {
 		opts.LogsDialect = def.LogsDialect
+	}
+	if opts.LogsDSN == "" {
+		opts.LogsDSN = "postgres://bifrost:bifrost_password@localhost:5432/bifrost?sslmode=disable"
 	}
 	if opts.LogRows <= 0 {
 		opts.LogRows = def.LogRows
@@ -99,7 +138,98 @@ func NormalizeOptions(opts Options) Options {
 	if opts.OutputEnvPath == "" {
 		opts.OutputEnvPath = def.OutputEnvPath
 	}
-	return opts
+	return opts, nil
+}
+
+// InitEncryption initializes Bifrost field encryption for DBs containing encrypted rows.
+func InitEncryption(opts Options) {
+	if opts.EncryptionKey == "" {
+		return
+	}
+	encrypt.Init(opts.EncryptionKey, bifrost.NewDefaultLogger(schemas.LogLevelWarn))
+}
+
+// optionsFromConfigFile extracts config/log store connection settings from a Bifrost config.json.
+func optionsFromConfigFile(path string) (Options, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Options{}, err
+	}
+	var cfg struct {
+		EncryptionKey json.RawMessage `json:"encryption_key"`
+		ConfigStore   storeConfig     `json:"config_store"`
+		LogsStore     storeConfig     `json:"logs_store"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return Options{}, err
+	}
+	out := Options{}
+	out.EncryptionKey = rawConfigValue(cfg.EncryptionKey)
+	configDialect, configDSN, err := dsnFromStoreConfig(cfg.ConfigStore)
+	if err != nil {
+		return Options{}, err
+	}
+	out.ConfigDialect = configDialect
+	out.ConfigDSN = configDSN
+	logsDialect, logsDSN, err := dsnFromStoreConfig(cfg.LogsStore)
+	if err != nil {
+		return Options{}, err
+	}
+	out.LogsDialect = logsDialect
+	out.LogsDSN = logsDSN
+	return out, nil
+}
+
+// storeConfig is the subset of config.json needed to locate a DB-backed store.
+type storeConfig struct {
+	Enabled bool                       `json:"enabled"`
+	Type    string                     `json:"type"`
+	Config  map[string]json.RawMessage `json:"config"`
+}
+
+// dsnFromStoreConfig converts a raw store config into the dialect and DSN used by gorm.
+func dsnFromStoreConfig(store storeConfig) (string, string, error) {
+	if !store.Enabled {
+		return "", "", nil
+	}
+	switch store.Type {
+	case "postgres":
+		host := configValue(store.Config, "host")
+		port := configValue(store.Config, "port")
+		user := configValue(store.Config, "user")
+		password := configValue(store.Config, "password")
+		dbName := configValue(store.Config, "db_name")
+		sslMode := configValue(store.Config, "ssl_mode")
+		if sslMode == "" {
+			sslMode = "disable"
+		}
+		return "postgres", fmt.Sprintf("postgres://%s:%s@%s:%s/%s?sslmode=%s", url.QueryEscape(user), url.QueryEscape(password), host, port, dbName, sslMode), nil
+	case "sqlite":
+		return "sqlite", configValue(store.Config, "path"), nil
+	default:
+		return "", "", fmt.Errorf("unsupported store type %q", store.Type)
+	}
+}
+
+// configValue returns a raw JSON config value, resolving Bifrost env-var wrappers.
+func configValue(config map[string]json.RawMessage, key string) string {
+	return rawConfigValue(config[key])
+}
+
+// rawConfigValue returns a raw JSON config value, resolving Bifrost env-var wrappers.
+func rawConfigValue(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var text string
+	if err := json.Unmarshal(raw, &text); err == nil {
+		return schemas.NewEnvVar(text).GetValue()
+	}
+	var env schemas.EnvVar
+	if err := json.Unmarshal(raw, &env); err == nil {
+		return env.GetValue()
+	}
+	return strings.Trim(string(raw), `"`)
 }
 
 // OpenDB opens a supported GORM database.
@@ -122,7 +252,11 @@ func OpenDB(dialect, dsn string) (*gorm.DB, error) {
 
 // SeedBase writes the OSS-owned seed graph.
 func SeedBase(ctx context.Context, configDB, logsDB *gorm.DB, opts Options) (*Summary, error) {
-	opts = NormalizeOptions(opts)
+	opts, err := NormalizeOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+	InitEncryption(opts)
 	env := SeedEnv(opts.Prefix)
 	manifest := BuildExpectedManifest(opts.Prefix, opts.LogRows)
 	summary := &Summary{
@@ -262,12 +396,16 @@ func CountKnownTables(ctx context.Context, configDB, logsDB *gorm.DB) (map[strin
 	out := map[string]int64{}
 	for _, table := range []string{"config_providers", "config_keys", "config_models", "governance_customers", "governance_teams", "governance_virtual_keys", "governance_virtual_key_provider_configs", "governance_budgets", "governance_rate_limits", "folders", "prompts", "prompt_versions", "config_mcp_clients"} {
 		var count int64
-		_ = configDB.WithContext(ctx).Table(table).Count(&count).Error
+		if err := configDB.WithContext(ctx).Table(table).Count(&count).Error; err != nil {
+			return nil, fmt.Errorf("count table %s: %w", table, err)
+		}
 		out[table] = count
 	}
 	for _, table := range []string{"logs", "mcp_tool_logs", "async_jobs"} {
 		var count int64
-		_ = logsDB.WithContext(ctx).Table(table).Count(&count).Error
+		if err := logsDB.WithContext(ctx).Table(table).Count(&count).Error; err != nil {
+			return nil, fmt.Errorf("count table %s: %w", table, err)
+		}
 		out[table] = count
 	}
 	return out, nil
@@ -278,7 +416,7 @@ func seedConfig(ctx context.Context, db *gorm.DB, opts Options) error {
 	if db == nil {
 		return fmt.Errorf("config db is required")
 	}
-	now := time.Now().UTC()
+	now := seedBaseTime
 	if err := seedProviders(ctx, db, opts.Prefix, now); err != nil {
 		return err
 	}
@@ -409,7 +547,7 @@ func seedLogs(ctx context.Context, db *gorm.DB, opts Options, manifest ExpectedM
 
 // seedLogCompanions writes one MCP log and one async job for log-adjacent APIs.
 func seedLogCompanions(ctx context.Context, db *gorm.DB, prefix string) error {
-	now := time.Now().UTC()
+	now := seedBaseTime
 	vk := prefix + "-vk-user-team"
 	latency := float64(25)
 	cost := 0.001
@@ -424,13 +562,15 @@ func seedLogCompanions(ctx context.Context, db *gorm.DB, prefix string) error {
 
 // buildLog returns one deterministic log row.
 func buildLog(prefix string, shape Shape, index int) logstore.Log {
-	timestamp := time.Now().UTC().Add(-time.Duration(index) * time.Second)
+	timestamp := seedBaseTime.Add(-time.Duration(index) * time.Second)
 	vkName := ""
 	if shape.VirtualKeyID != "" {
 		vkName = "E2E " + shape.VirtualKeyID
 	}
 	latency := float64(100 + index%500)
 	cost := float64(1+index%100) / 100000
+	promptTokens := 10 + index%30
+	completionTokens := 5 + index%20
 	status := "success"
 	if index%17 == 0 {
 		status = "error"
@@ -463,9 +603,9 @@ func buildLog(prefix string, shape Shape, index int) logstore.Log {
 		Status:              status,
 		ContentSummary:      shape.Marker,
 		MetadataParsed:      map[string]any{"seed_prefix": prefix, "shape": shape.Name, "marker": shape.Marker},
-		PromptTokens:        10 + index%30,
-		CompletionTokens:    5 + index%20,
-		TotalTokens:         15 + index%50,
+		PromptTokens:        promptTokens,
+		CompletionTokens:    completionTokens,
+		TotalTokens:         promptTokens + completionTokens,
 		RoutingEnginesUsed:  []string{"governance"},
 		CreatedAt:           timestamp,
 	}

--- a/framework/e2eseed/seed.go
+++ b/framework/e2eseed/seed.go
@@ -1,0 +1,510 @@
+// Package e2eseed creates deterministic OSS fixtures for API and DAC tests.
+package e2eseed
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
+	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Options controls the shared seed dataset.
+type Options struct {
+	Prefix        string
+	ConfigDialect string
+	ConfigDSN     string
+	LogsDialect   string
+	LogsDSN       string
+	LogRows       int
+	BatchSize     int
+	OutputEnvPath string
+	DryRun        bool
+}
+
+// Shape describes one DAC ownership combination.
+type Shape struct {
+	Name           string   `json:"name"`
+	UserID         string   `json:"user_id,omitempty"`
+	TeamID         string   `json:"team_id,omitempty"`
+	CustomerID     string   `json:"customer_id,omitempty"`
+	BusinessUnitID string   `json:"business_unit_id,omitempty"`
+	VirtualKeyID   string   `json:"virtual_key_id,omitempty"`
+	Marker         string   `json:"marker"`
+	VisibleTo      []string `json:"visible_to"`
+}
+
+// ExpectedManifest records seeded IDs and expected DAC visibility.
+type ExpectedManifest struct {
+	Prefix   string              `json:"prefix"`
+	Personas map[string]string   `json:"personas"`
+	Shapes   []Shape             `json:"shapes"`
+	LogIDs   map[string][]string `json:"log_ids"`
+}
+
+// Summary is returned after a seed run.
+type Summary struct {
+	Prefix      string            `json:"prefix"`
+	LogRows     int               `json:"log_rows"`
+	SeedEnv     map[string]string `json:"seed_env"`
+	Expected    ExpectedManifest  `json:"expected"`
+	TableCounts map[string]int64  `json:"table_counts"`
+	DryRun      bool              `json:"dry_run"`
+	GeneratedAt time.Time         `json:"generated_at"`
+}
+
+// DefaultOptions returns defaults for local e2e seeding.
+func DefaultOptions() Options {
+	return Options{
+		Prefix:        "e2e-seed",
+		ConfigDialect: "postgres",
+		ConfigDSN:     "postgres://bifrost:bifrost_password@localhost:5432/bifrost?sslmode=disable",
+		LogsDialect:   "postgres",
+		LogsDSN:       "postgres://bifrost:bifrost_password@localhost:5432/bifrost?sslmode=disable",
+		LogRows:       100000,
+		BatchSize:     1000,
+		OutputEnvPath: "tmp/e2e-seed.env",
+	}
+}
+
+// NormalizeOptions applies default values to unset options.
+func NormalizeOptions(opts Options) Options {
+	def := DefaultOptions()
+	if opts.Prefix == "" {
+		opts.Prefix = def.Prefix
+	}
+	if opts.ConfigDialect == "" {
+		opts.ConfigDialect = def.ConfigDialect
+	}
+	if opts.LogsDialect == "" {
+		opts.LogsDialect = def.LogsDialect
+	}
+	if opts.LogRows <= 0 {
+		opts.LogRows = def.LogRows
+	}
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = def.BatchSize
+	}
+	if opts.OutputEnvPath == "" {
+		opts.OutputEnvPath = def.OutputEnvPath
+	}
+	return opts
+}
+
+// OpenDB opens a supported GORM database.
+func OpenDB(dialect, dsn string) (*gorm.DB, error) {
+	switch strings.ToLower(strings.TrimSpace(dialect)) {
+	case "postgres", "postgresql":
+		if dsn == "" {
+			return nil, fmt.Errorf("postgres dsn is required")
+		}
+		return gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	case "sqlite":
+		if dsn == "" {
+			return nil, fmt.Errorf("sqlite dsn is required")
+		}
+		return gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	default:
+		return nil, fmt.Errorf("unsupported db dialect %q", dialect)
+	}
+}
+
+// SeedBase writes the OSS-owned seed graph.
+func SeedBase(ctx context.Context, configDB, logsDB *gorm.DB, opts Options) (*Summary, error) {
+	opts = NormalizeOptions(opts)
+	env := SeedEnv(opts.Prefix)
+	manifest := BuildExpectedManifest(opts.Prefix, opts.LogRows)
+	summary := &Summary{
+		Prefix:      opts.Prefix,
+		LogRows:     opts.LogRows,
+		SeedEnv:     env,
+		Expected:    manifest,
+		TableCounts: map[string]int64{},
+		DryRun:      opts.DryRun,
+		GeneratedAt: time.Now().UTC(),
+	}
+	if opts.DryRun {
+		return summary, nil
+	}
+	if err := seedConfig(ctx, configDB, opts); err != nil {
+		return nil, err
+	}
+	if err := seedLogs(ctx, logsDB, opts, manifest); err != nil {
+		return nil, err
+	}
+	if err := WriteEnvFile(opts.OutputEnvPath, env); err != nil {
+		return nil, err
+	}
+	counts, err := CountKnownTables(ctx, configDB, logsDB)
+	if err != nil {
+		return nil, err
+	}
+	summary.TableCounts = counts
+	return summary, nil
+}
+
+// SeedEnv returns deterministic values shared by seeders and tests.
+func SeedEnv(prefix string) map[string]string {
+	return map[string]string{
+		"e2e_seed_prefix":                    prefix,
+		"enterprise_dac_model":               "openai/gpt-4o-mini",
+		"enterprise_dac_visible_virtual_key": prefix + "-vk-user-team-secret",
+		"enterprise_dac_hidden_virtual_key":  prefix + "-vk-outside-secret",
+		"e2e_seed_team_tiggings":             prefix + "-team-tiggings",
+		"e2e_seed_team_outside":              prefix + "-team-outside",
+		"e2e_seed_user_tiggings":             prefix + "-user-tiggings",
+		"e2e_seed_user_outside":              prefix + "-user-outside",
+		"e2e_seed_vk_user_team":              prefix + "-vk-user-team",
+		"e2e_seed_vk_outside":                prefix + "-vk-outside",
+	}
+}
+
+// BuildShapes returns the DAC ownership matrix.
+func BuildShapes(prefix string) []Shape {
+	tiggingsUser := prefix + "-user-tiggings"
+	outsideUser := prefix + "-user-outside"
+	tiggingsTeam := prefix + "-team-tiggings"
+	outsideTeam := prefix + "-team-outside"
+	tiggingsCustomer := prefix + "-customer-tiggings"
+	outsideCustomer := prefix + "-customer-outside"
+	tiggingsBU := prefix + "-bu-tiggings"
+	outsideBU := prefix + "-bu-outside"
+	userVK := prefix + "-vk-user-team"
+	teamVK := prefix + "-vk-team-only"
+	outsideVK := prefix + "-vk-outside"
+	return []Shape{
+		{Name: "user-in-tiggings", UserID: tiggingsUser, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, Marker: prefix + "-shape-user-in-tiggings", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin"}},
+		{Name: "user-not-in-tiggings", UserID: outsideUser, CustomerID: outsideCustomer, BusinessUnitID: outsideBU, Marker: prefix + "-shape-user-not-in-tiggings", VisibleTo: []string{"own_reader_outside", "team_reader_outside", "all_data_admin"}},
+		{Name: "only-user", UserID: tiggingsUser, Marker: prefix + "-shape-only-user", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin"}},
+		{Name: "only-team", TeamID: tiggingsTeam, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, Marker: prefix + "-shape-only-team", VisibleTo: []string{"team_reader_tiggings", "all_data_admin", "vk_team_owned"}},
+		{Name: "only-virtual-key", VirtualKeyID: userVK, Marker: prefix + "-shape-only-vk", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin", "vk_user_owned"}},
+		{Name: "user-team", UserID: tiggingsUser, TeamID: tiggingsTeam, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, Marker: prefix + "-shape-user-team", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin"}},
+		{Name: "user-virtual-key", UserID: tiggingsUser, VirtualKeyID: userVK, Marker: prefix + "-shape-user-vk", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin", "vk_user_owned"}},
+		{Name: "team-virtual-key", TeamID: tiggingsTeam, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, VirtualKeyID: teamVK, Marker: prefix + "-shape-team-vk", VisibleTo: []string{"team_reader_tiggings", "all_data_admin", "vk_team_owned"}},
+		{Name: "user-team-virtual-key", UserID: tiggingsUser, TeamID: tiggingsTeam, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, VirtualKeyID: userVK, Marker: prefix + "-shape-user-team-vk", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin", "vk_user_owned"}},
+		{Name: "outside-team-virtual-key", UserID: outsideUser, TeamID: outsideTeam, CustomerID: outsideCustomer, BusinessUnitID: outsideBU, VirtualKeyID: outsideVK, Marker: prefix + "-shape-outside-team-vk", VisibleTo: []string{"own_reader_outside", "team_reader_outside", "all_data_admin"}},
+		{Name: "legacy-unowned", Marker: prefix + "-shape-legacy-unowned", VisibleTo: []string{"all_data_admin"}},
+	}
+}
+
+// BuildExpectedManifest returns the expected DAC visibility document.
+func BuildExpectedManifest(prefix string, logRows int) ExpectedManifest {
+	shapes := BuildShapes(prefix)
+	logIDs := make(map[string][]string, len(shapes))
+	for i := 0; i < logRows; i++ {
+		shape := shapes[i%len(shapes)]
+		logIDs[shape.Name] = append(logIDs[shape.Name], fmt.Sprintf("%s-log-%06d", prefix, i))
+	}
+	return ExpectedManifest{
+		Prefix: prefix,
+		Personas: map[string]string{
+			"own_reader_tiggings":  prefix + "-apikey-own-tiggings",
+			"team_reader_tiggings": prefix + "-apikey-team-tiggings",
+			"own_reader_outside":   prefix + "-apikey-own-outside",
+			"team_reader_outside":  prefix + "-apikey-team-outside",
+			"all_data_admin":       prefix + "-apikey-admin",
+			"vk_user_owned":        prefix + "-vk-user-team",
+			"vk_team_owned":        prefix + "-vk-team-only",
+		},
+		Shapes: shapes,
+		LogIDs: logIDs,
+	}
+}
+
+// WriteEnvFile writes deterministic environment values.
+func WriteEnvFile(path string, env map[string]string) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	keys := make([]string, 0, len(env))
+	for key := range env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	lines := make([]string, 0, len(keys))
+	for _, key := range keys {
+		lines = append(lines, fmt.Sprintf("%s=%s", key, quoteEnv(env[key])))
+	}
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600)
+}
+
+// WriteJSONFile writes a pretty JSON file.
+func WriteJSONFile(path string, value any) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o600)
+}
+
+// CountKnownTables returns row counts for tables touched by the shared seed.
+func CountKnownTables(ctx context.Context, configDB, logsDB *gorm.DB) (map[string]int64, error) {
+	out := map[string]int64{}
+	for _, table := range []string{"config_providers", "config_keys", "config_models", "governance_customers", "governance_teams", "governance_virtual_keys", "governance_virtual_key_provider_configs", "governance_budgets", "governance_rate_limits", "folders", "prompts", "prompt_versions", "config_mcp_clients"} {
+		var count int64
+		_ = configDB.WithContext(ctx).Table(table).Count(&count).Error
+		out[table] = count
+	}
+	for _, table := range []string{"logs", "mcp_tool_logs", "async_jobs"} {
+		var count int64
+		_ = logsDB.WithContext(ctx).Table(table).Count(&count).Error
+		out[table] = count
+	}
+	return out, nil
+}
+
+// seedConfig writes OSS-owned relational fixtures.
+func seedConfig(ctx context.Context, db *gorm.DB, opts Options) error {
+	if db == nil {
+		return fmt.Errorf("config db is required")
+	}
+	now := time.Now().UTC()
+	if err := seedProviders(ctx, db, opts.Prefix, now); err != nil {
+		return err
+	}
+	if err := seedGovernance(ctx, db, opts.Prefix, now); err != nil {
+		return err
+	}
+	if err := seedPrompts(ctx, db, opts.Prefix, now); err != nil {
+		return err
+	}
+	return seedMCP(ctx, db, opts.Prefix, now)
+}
+
+// seedProviders writes providers, keys, and models.
+func seedProviders(ctx context.Context, db *gorm.DB, prefix string, now time.Time) error {
+	for _, providerName := range []string{"openai", "anthropic", "gemini"} {
+		provider := tables.TableProvider{Name: providerName, Status: "active", Description: "e2e seeded provider", CreatedAt: now, UpdatedAt: now}
+		if err := db.WithContext(ctx).Where("name = ?", providerName).Assign(provider).FirstOrCreate(&provider).Error; err != nil {
+			return err
+		}
+		key := tables.TableKey{
+			Name:        prefix + "-" + providerName + "-key",
+			ProviderID:  provider.ID,
+			Provider:    providerName,
+			KeyID:       prefix + "-" + providerName + "-key",
+			Value:       *schemas.NewEnvVar(strings.ToUpper(providerName) + "_API_KEY"),
+			Models:      schemas.WhiteList{"*"},
+			Status:      "active",
+			Description: "e2e seeded provider key",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		if err := db.WithContext(ctx).Where("key_id = ?", key.KeyID).Assign(key).FirstOrCreate(&key).Error; err != nil {
+			return err
+		}
+		model := tables.TableModel{ID: prefix + "-" + providerName + "-model", ProviderID: provider.ID, Name: defaultModel(providerName), CreatedAt: now, UpdatedAt: now}
+		if err := db.WithContext(ctx).Where("id = ?", model.ID).Assign(model).FirstOrCreate(&model).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// seedGovernance writes customers, teams, budgets, rate limits, VKs, and VK provider configs.
+func seedGovernance(ctx context.Context, db *gorm.DB, prefix string, now time.Time) error {
+	active := true
+	tiggingsCustomer := prefix + "-customer-tiggings"
+	outsideCustomer := prefix + "-customer-outside"
+	tiggingsTeam := prefix + "-team-tiggings"
+	outsideTeam := prefix + "-team-outside"
+	for _, customer := range []tables.TableCustomer{{ID: tiggingsCustomer, Name: "Tiggings Customer", CreatedAt: now, UpdatedAt: now}, {ID: outsideCustomer, Name: "Outside Customer", CreatedAt: now, UpdatedAt: now}} {
+		if err := db.WithContext(ctx).Where("id = ?", customer.ID).Assign(customer).FirstOrCreate(&customer).Error; err != nil {
+			return err
+		}
+	}
+	for _, team := range []tables.TableTeam{{ID: tiggingsTeam, Name: "Tiggings", CustomerID: &tiggingsCustomer, CreatedAt: now, UpdatedAt: now}, {ID: outsideTeam, Name: "Outside Team", CustomerID: &outsideCustomer, CreatedAt: now, UpdatedAt: now}} {
+		if err := db.WithContext(ctx).Where("id = ?", team.ID).Assign(team).FirstOrCreate(&team).Error; err != nil {
+			return err
+		}
+	}
+	for _, vk := range []tables.TableVirtualKey{
+		{ID: prefix + "-vk-user-team", Name: "E2E User Team VK", Value: prefix + "-vk-user-team-secret", IsActive: &active, TeamID: &tiggingsTeam, CreatedAt: now, UpdatedAt: now},
+		{ID: prefix + "-vk-team-only", Name: "E2E Team Only VK", Value: prefix + "-vk-team-only-secret", IsActive: &active, TeamID: &tiggingsTeam, CreatedAt: now, UpdatedAt: now},
+		{ID: prefix + "-vk-outside", Name: "E2E Outside VK", Value: prefix + "-vk-outside-secret", IsActive: &active, TeamID: &outsideTeam, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := db.WithContext(ctx).Where("id = ?", vk.ID).Assign(vk).FirstOrCreate(&vk).Error; err != nil {
+			return err
+		}
+		pc := tables.TableVirtualKeyProviderConfig{VirtualKeyID: vk.ID, Provider: "openai", AllowedModels: schemas.WhiteList{"*"}, AllowAllKeys: true}
+		if err := db.WithContext(ctx).Where("virtual_key_id = ? AND provider = ?", vk.ID, "openai").Assign(pc).FirstOrCreate(&pc).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// seedPrompts writes a folder, prompt, and prompt version.
+func seedPrompts(ctx context.Context, db *gorm.DB, prefix string, now time.Time) error {
+	folder := tables.TableFolder{ID: prefix + "-folder", Name: "E2E Seed Folder", CreatedAt: now, UpdatedAt: now}
+	if err := db.WithContext(ctx).Where("id = ?", folder.ID).Assign(folder).FirstOrCreate(&folder).Error; err != nil {
+		return err
+	}
+	prompt := tables.TablePrompt{ID: prefix + "-prompt", Name: "E2E Seed Prompt", FolderID: &folder.ID, CreatedAt: now, UpdatedAt: now}
+	if err := db.WithContext(ctx).Where("id = ?", prompt.ID).Assign(prompt).FirstOrCreate(&prompt).Error; err != nil {
+		return err
+	}
+	version := tables.TablePromptVersion{PromptID: prompt.ID, VersionNumber: 1, CommitMessage: "seed", Provider: "openai", Model: "gpt-4o-mini", IsLatest: true, CreatedAt: now}
+	return db.WithContext(ctx).Where("prompt_id = ? AND version_number = ?", prompt.ID, 1).Assign(version).FirstOrCreate(&version).Error
+}
+
+// seedMCP writes a minimal MCP client.
+func seedMCP(ctx context.Context, db *gorm.DB, prefix string, now time.Time) error {
+	client := tables.TableMCPClient{
+		ClientID:         prefix + "-mcp-client",
+		Name:             "E2E Seed MCP",
+		ConnectionType:   "sse",
+		ConnectionString: schemas.NewEnvVar("https://mcp.e2e.local/sse"),
+		ToolsToExecute:   schemas.WhiteList{"*"},
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	return db.WithContext(ctx).Where("client_id = ?", client.ClientID).Assign(client).FirstOrCreate(&client).Error
+}
+
+// seedLogs writes the DAC matrix logs.
+func seedLogs(ctx context.Context, db *gorm.DB, opts Options, manifest ExpectedManifest) error {
+	if db == nil {
+		return fmt.Errorf("logs db is required")
+	}
+	shapes := manifest.Shapes
+	batch := make([]logstore.Log, 0, opts.BatchSize)
+	for i := 0; i < opts.LogRows; i++ {
+		shape := shapes[i%len(shapes)]
+		batch = append(batch, buildLog(opts.Prefix, shape, i))
+		if len(batch) == opts.BatchSize {
+			if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
+				return err
+			}
+			batch = batch[:0]
+		}
+	}
+	if len(batch) > 0 {
+		if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
+			return err
+		}
+	}
+	return seedLogCompanions(ctx, db, opts.Prefix)
+}
+
+// seedLogCompanions writes one MCP log and one async job for log-adjacent APIs.
+func seedLogCompanions(ctx context.Context, db *gorm.DB, prefix string) error {
+	now := time.Now().UTC()
+	vk := prefix + "-vk-user-team"
+	latency := float64(25)
+	cost := 0.001
+	mcp := logstore.MCPToolLog{ID: prefix + "-mcp-log", RequestID: prefix + "-request", Timestamp: now, ToolName: "e2e-tool", ServerLabel: "e2e-mcp", VirtualKeyID: &vk, VirtualKeyName: ptr("E2E User Team VK"), ArgumentsParsed: map[string]any{"seed": prefix}, ResultParsed: map[string]any{"ok": true}, Latency: &latency, Cost: &cost, Status: "success", MetadataParsed: map[string]any{"seed_prefix": prefix}}
+	if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&mcp).Error; err != nil {
+		return err
+	}
+	completed := now
+	job := logstore.AsyncJob{ID: prefix + "-async-job", Status: schemas.AsyncJobStatusCompleted, RequestType: schemas.ChatCompletionRequest, Response: `{}`, StatusCode: 200, VirtualKeyID: &vk, ResultTTL: 3600, CreatedAt: now, CompletedAt: &completed}
+	return db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&job).Error
+}
+
+// buildLog returns one deterministic log row.
+func buildLog(prefix string, shape Shape, index int) logstore.Log {
+	timestamp := time.Now().UTC().Add(-time.Duration(index) * time.Second)
+	vkName := ""
+	if shape.VirtualKeyID != "" {
+		vkName = "E2E " + shape.VirtualKeyID
+	}
+	latency := float64(100 + index%500)
+	cost := float64(1+index%100) / 100000
+	status := "success"
+	if index%17 == 0 {
+		status = "error"
+	}
+	return logstore.Log{
+		ID:               fmt.Sprintf("%s-log-%06d", prefix, index),
+		Timestamp:        timestamp,
+		Object:           "chat.completion",
+		Provider:         "openai",
+		Model:            "gpt-4o-mini",
+		SelectedKeyID:    prefix + "-openai-key",
+		SelectedKeyName:  "E2E OpenAI Key",
+		VirtualKeyID:     emptyPtr(shape.VirtualKeyID),
+		VirtualKeyName:   emptyPtr(vkName),
+		UserID:           emptyPtr(shape.UserID),
+		UserName:         emptyPtr(nameFromID(shape.UserID)),
+		TeamID:           emptyPtr(shape.TeamID),
+		TeamName:         emptyPtr(nameFromID(shape.TeamID)),
+		CustomerID:       emptyPtr(shape.CustomerID),
+		CustomerName:     emptyPtr(nameFromID(shape.CustomerID)),
+		BusinessUnitID:   emptyPtr(shape.BusinessUnitID),
+		BusinessUnitName: emptyPtr(nameFromID(shape.BusinessUnitID)),
+		InputHistoryParsed: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: ptr(shape.Marker + " prompt")},
+		}},
+		OutputMessageParsed: &schemas.ChatMessage{Role: schemas.ChatMessageRoleAssistant, Content: &schemas.ChatMessageContent{ContentStr: ptr("seeded response")}},
+		Latency:             &latency,
+		Cost:                &cost,
+		Status:              status,
+		ContentSummary:      shape.Marker,
+		MetadataParsed:      map[string]any{"seed_prefix": prefix, "shape": shape.Name, "marker": shape.Marker},
+		PromptTokens:        10 + index%30,
+		CompletionTokens:    5 + index%20,
+		TotalTokens:         15 + index%50,
+		RoutingEnginesUsed:  []string{"governance"},
+		CreatedAt:           timestamp,
+	}
+}
+
+// defaultModel returns a model for a provider.
+func defaultModel(provider string) string {
+	switch provider {
+	case "anthropic":
+		return "claude-3-5-haiku"
+	case "gemini":
+		return "gemini-1.5-flash"
+	default:
+		return "gpt-4o-mini"
+	}
+}
+
+// emptyPtr returns nil for empty strings.
+func emptyPtr(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+// ptr returns a string pointer.
+func ptr(value string) *string {
+	return &value
+}
+
+// nameFromID derives a display name from an id.
+func nameFromID(id string) string {
+	if id == "" {
+		return ""
+	}
+	return strings.Title(strings.ReplaceAll(id, "-", " "))
+}
+
+// quoteEnv returns a shell-safe env value.
+func quoteEnv(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -327,6 +327,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddSafeJsonbFunction(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddDACColumnsToMCPToolLogs(ctx, db); err != nil {
+		return err
+	}
 	// migrationSplitFilterDataMatView is intentionally NOT invoked in this
 	// release. Dropping mv_logs_filterdata while old replicas are still
 	// serving /api/logs/filterdata from it would surface "relation does not
@@ -2460,6 +2463,26 @@ var performanceIndexes = []performanceIndexDef{
 		name:  "idx_logs_stop_reason",
 		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_stop_reason ON logs(stop_reason)",
 	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_user_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_user_id ON mcp_tool_logs(user_id)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_team_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_team_id ON mcp_tool_logs(team_id)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_customer_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_customer_id ON mcp_tool_logs(customer_id)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_business_unit_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_business_unit_id ON mcp_tool_logs(business_unit_id)",
+	},
 }
 
 // ensurePerformanceIndexes checks whether each performance GIN index exists and is
@@ -3099,6 +3122,52 @@ $$;`
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while adding bifrost_safe_jsonb function: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddDACColumnsToMCPToolLogs adds user_id, team_id, customer_id,
+// and business_unit_id columns to mcp_tool_logs so DAC scope can apply the
+// same ownership predicates it does on the logs table. The columns are
+// nullable; pre-existing rows stay NULL and the DAC resolver fails closed
+// for non-admin principals against them.
+//
+// Indexes are built CONCURRENTLY by ensurePerformanceIndexes (entries appended
+// to performanceIndexes) so adding them does not block writes on a populated
+// table.
+func migrationAddDACColumnsToMCPToolLogs(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "mcp_tool_logs_add_dac_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			for _, col := range []string{"user_id", "team_id", "customer_id", "business_unit_id"} {
+				if !mg.HasColumn(&MCPToolLog{}, col) {
+					if err := mg.AddColumn(&MCPToolLog{}, col); err != nil {
+						return fmt.Errorf("failed to add %s column to mcp_tool_logs: %w", col, err)
+					}
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			for _, col := range []string{"business_unit_id", "customer_id", "team_id", "user_id"} {
+				if mg.HasColumn(&MCPToolLog{}, col) {
+					if err := mg.DropColumn(&MCPToolLog{}, col); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding DAC columns to mcp_tool_logs: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -794,6 +794,10 @@ type MCPToolLog struct {
 	ServerLabel    string    `gorm:"type:varchar(255);index:idx_mcp_logs_server_label" json:"server_label,omitempty"` // MCP server that provided the tool
 	VirtualKeyID   *string   `gorm:"type:varchar(255);index:idx_mcp_logs_virtual_key_id" json:"virtual_key_id"`
 	VirtualKeyName *string   `gorm:"type:varchar(255)" json:"virtual_key_name"`
+	UserID         *string   `gorm:"type:varchar(255);index:idx_mcp_logs_user_id" json:"user_id"`
+	TeamID         *string   `gorm:"type:varchar(255);index:idx_mcp_logs_team_id" json:"team_id"`
+	CustomerID     *string   `gorm:"type:varchar(255);index:idx_mcp_logs_customer_id" json:"customer_id"`
+	BusinessUnitID *string   `gorm:"type:varchar(255);index:idx_mcp_logs_business_unit_id" json:"business_unit_id"`
 	Arguments      string    `gorm:"type:text" json:"-"`                                                // JSON serialized tool arguments
 	Result         string    `gorm:"type:text" json:"-"`                                                // JSON serialized tool result
 	ErrorDetails   string    `gorm:"type:text" json:"-"`                                                // JSON serialized *schemas.BifrostError

--- a/tests/e2e/api/README.md
+++ b/tests/e2e/api/README.md
@@ -89,6 +89,13 @@ them into OSS:
 ./runners/run-newman-api-tests.sh --extra-collection /path/to/enterprise.postman_collection.json
 ```
 
+You can also pass extensions via environment variable:
+
+```bash
+BIFROST_API_EXTRA_COLLECTION=/path/to/enterprise.postman_collection.json \
+  ./runners/run-newman-api-tests.sh
+```
+
 The default OSS run does not load extra collections. Enterprise should pass its
 collection from the enterprise repo, so shared management requests stay in OSS and
 DAC-specific assertions stay out of OSS.

--- a/tests/e2e/api/README.md
+++ b/tests/e2e/api/README.md
@@ -80,6 +80,19 @@ From this directory (`tests/e2e/api`):
 ./runners/run-newman-inference-tests.sh --html --verbose
 ```
 
+### API Management Extensions
+
+The API management runner can merge enterprise-only Postman folders without checking
+them into OSS:
+
+```bash
+./runners/run-newman-api-tests.sh --extra-collection /path/to/enterprise.postman_collection.json
+```
+
+The default OSS run does not load extra collections. Enterprise should pass its
+collection from the enterprise repo, so shared management requests stay in OSS and
+DAC-specific assertions stay out of OSS.
+
 **Retry logic (CI)**
 When `CI=1` or `CI=true` is set (case-insensitive), each failing request in the V1 collection is retried up to 3 times before moving to the next request. This helps with flaky tests in CI. The runner passes the value through to Newman when the environment variable is set (e.g. `CI=1 ./runners/run-newman-inference-tests.sh --env openai` or `CI=true ./runners/run-newman-inference-tests.sh --env openai`). Retry attempts are logged to the console as `[RETRY] Request "..." failed (attempt n/3). Retrying...`.
 

--- a/tests/e2e/api/runners/merge-collections.mjs
+++ b/tests/e2e/api/runners/merge-collections.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// Merges extension Postman collections into a base API e2e collection.
+
+import { readFileSync, writeFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+const extras = [];
+let source = "";
+let out = "";
+
+for (let i = 0; i < args.length; i += 1) {
+  const arg = args[i];
+  if (arg === "--source") {
+    source = args[++i] || "";
+  } else if (arg === "--out") {
+    out = args[++i] || "";
+  } else if (arg === "--extra") {
+    extras.push(args[++i] || "");
+  } else {
+    console.error(`[merge-collections] unknown argument: ${arg}`);
+    process.exit(2);
+  }
+}
+
+if (!source || !out || extras.length === 0 || extras.some((extra) => !extra)) {
+  console.error("[merge-collections] --source, --out, and at least one --extra are required");
+  process.exit(2);
+}
+
+const normalizeItems = (extension, path) => {
+  if (Array.isArray(extension)) return extension;
+  if (Array.isArray(extension.item)) return extension.item;
+  if (extension.request || extension.item) return [extension];
+  console.error(`[merge-collections] extension ${path} did not contain any Postman items`);
+  process.exit(1);
+};
+
+const base = JSON.parse(readFileSync(source, "utf8"));
+let requestCount = 0;
+
+for (const extra of extras) {
+  const extension = JSON.parse(readFileSync(extra, "utf8"));
+  const items = normalizeItems(extension, extra);
+  requestCount += JSON.stringify(items).match(/"request":/g)?.length || 0;
+  base.item = base.item || [];
+  base.item.push({
+    name: extension.info?.name || extension.name || "External API E2E Extension",
+    description: `Loaded from ${extra}. This folder is only present when the API runner receives --extra-collection.`,
+    item: items,
+  });
+}
+
+writeFileSync(out, `${JSON.stringify(base, null, 2)}\n`);
+console.error(`[merge-collections] wrote ${out} with ${requestCount} extension requests`);

--- a/tests/e2e/api/runners/merge-collections.mjs
+++ b/tests/e2e/api/runners/merge-collections.mjs
@@ -36,13 +36,18 @@ const normalizeItems = (extension, path) => {
 };
 
 const base = JSON.parse(readFileSync(source, "utf8"));
+if (base.item == null) {
+  base.item = [];
+} else if (!Array.isArray(base.item)) {
+  console.error(`[merge-collections] base collection ${source} has non-array "item"`);
+  process.exit(1);
+}
 let requestCount = 0;
 
 for (const extra of extras) {
   const extension = JSON.parse(readFileSync(extra, "utf8"));
   const items = normalizeItems(extension, extra);
   requestCount += JSON.stringify(items).match(/"request":/g)?.length || 0;
-  base.item = base.item || [];
   base.item.push({
     name: extension.info?.name || extension.name || "External API E2E Extension",
     description: `Loaded from ${extra}. This folder is only present when the API runner receives --extra-collection.`,

--- a/tests/e2e/api/runners/run-newman-api-tests.sh
+++ b/tests/e2e/api/runners/run-newman-api-tests.sh
@@ -51,6 +51,9 @@ DB_VERIFY=""
 DB_URL="${BIFROST_DB_URL:-}"
 LOGS_DB_URL="${BIFROST_LOGS_DB_URL:-}"
 DB_CONFIG_PATH=""
+SEED_ENV_PATH="${BIFROST_E2E_SEED_ENV:-}"
+EXPECTED_PATH="${BIFROST_E2E_SEED_EXPECTED:-}"
+EXTRA_COLLECTIONS=()
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -94,6 +97,18 @@ while [[ $# -gt 0 ]]; do
             DB_CONFIG_PATH="$2"
             shift 2
             ;;
+        --extra-collection)
+            EXTRA_COLLECTIONS+=("$2")
+            shift 2
+            ;;
+        --seed-env)
+            SEED_ENV_PATH="$2"
+            shift 2
+            ;;
+        --expected)
+            EXPECTED_PATH="$2"
+            shift 2
+            ;;
         --help)
             echo "Usage: $0 [OPTIONS]"
             echo ""
@@ -111,6 +126,11 @@ while [[ $# -gt 0 ]]; do
             echo "                      SQLite:     sqlite:///path/to/file.db"
             echo "  --config-path <p>   Path to Bifrost config.json for auto DB detection"
             echo "                      (default: ./config.json; also reads BIFROST_CONFIG_PATH env)"
+            echo "  --extra-collection <p>"
+            echo "                      Merge an additional Postman collection into this API run."
+            echo "                      Intended for enterprise-only API e2e coverage from another repo."
+            echo "  --seed-env <p>      Load generated seed dotenv values and pass them to Newman."
+            echo "  --expected <p>      Load generated DAC expected-manifest JSON for assertions."
             echo "  --help              Show this help message"
             echo ""
             echo "Examples:"
@@ -127,6 +147,18 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [ -n "${BIFROST_API_EXTRA_COLLECTION:-}" ]; then
+    EXTRA_COLLECTIONS+=("$BIFROST_API_EXTRA_COLLECTION")
+fi
+
+if [ -z "$SEED_ENV_PATH" ] && [ -f "$API_DIR/generated/seed.env" ]; then
+    SEED_ENV_PATH="$API_DIR/generated/seed.env"
+fi
+
+if [ -z "$EXPECTED_PATH" ] && [ -f "$API_DIR/generated/dac-expected.json" ]; then
+    EXPECTED_PATH="$API_DIR/generated/dac-expected.json"
+fi
 
 if { [ "${GITHUB_ACTIONS:-}" = "true" ] || [ "${CI:-0}" = "1" ]; } && [[ "$REPORTERS" != *"htmlextra"* ]]; then
     REPORTERS="${REPORTERS},htmlextra"
@@ -156,6 +188,15 @@ echo -e "Configuration:"
 echo -e "  Collection: ${YELLOW}$COLLECTION${NC}"
 echo -e "  Reports:    ${YELLOW}$REPORT_DIR${NC}"
 echo -e "  Verbose:    ${YELLOW}$([ -n "$VERBOSE" ] && echo "enabled" || echo "disabled")${NC}"
+if [ ${#EXTRA_COLLECTIONS[@]} -gt 0 ]; then
+    echo -e "  Extensions: ${YELLOW}${EXTRA_COLLECTIONS[*]}${NC}"
+fi
+if [ -n "$SEED_ENV_PATH" ]; then
+    echo -e "  Seed Env:   ${YELLOW}$SEED_ENV_PATH${NC}"
+fi
+if [ -n "$EXPECTED_PATH" ]; then
+    echo -e "  Expected:   ${YELLOW}$EXPECTED_PATH${NC}"
+fi
 if [ -n "$DB_VERIFY" ]; then
     if [ -n "$DB_URL" ]; then
         echo -e "  DB Verify:  ${YELLOW}enabled (url: $DB_URL)${NC}"
@@ -245,6 +286,20 @@ echo ""
 echo -e "${GREEN}Running tests...${NC}"
 echo ""
 
+if [ ${#EXTRA_COLLECTIONS[@]} -gt 0 ]; then
+    MERGED_COLLECTION="$REPORT_DIR/api-management-with-extensions.postman_collection.json"
+    merge_cmd=(node "$SCRIPT_DIR/merge-collections.mjs" --source "$COLLECTION" --out "$MERGED_COLLECTION")
+    for extra_collection in "${EXTRA_COLLECTIONS[@]}"; do
+        if [ ! -f "$extra_collection" ]; then
+            echo -e "${RED}Error: Extra collection file not found: $extra_collection${NC}"
+            exit 1
+        fi
+        merge_cmd+=(--extra "$extra_collection")
+    done
+    "${merge_cmd[@]}"
+    COLLECTION="$MERGED_COLLECTION"
+fi
+
 # Add dbverify reporter if requested
 if [ -n "$DB_VERIFY" ]; then
     REPORTERS="$REPORTERS,dbverify"
@@ -261,6 +316,52 @@ fi
 
 # Build Newman command
 cmd=(newman run "$COLLECTION" --timeout-script 120000 --timeout 900000 -r "$REPORTERS")
+
+if [ -n "$SEED_ENV_PATH" ]; then
+    if [ ! -f "$SEED_ENV_PATH" ]; then
+        echo -e "${RED}Error: seed env file not found: $SEED_ENV_PATH${NC}"
+        exit 1
+    fi
+    set -a
+    # shellcheck disable=SC1090
+    . "$SEED_ENV_PATH"
+    set +a
+fi
+
+add_env_var_if_set() {
+    local name="$1"
+    local value="${!name:-}"
+    if [ -n "$value" ]; then
+        cmd+=(--env-var "$name=$value")
+    fi
+}
+
+for seed_var in \
+    e2e_seed_prefix \
+    enterprise_dac_model \
+    enterprise_dac_visible_virtual_key \
+    enterprise_dac_hidden_virtual_key \
+    enterprise_dac_reader_api_key \
+    enterprise_dac_all_api_key \
+    enterprise_dac_own_api_key \
+    enterprise_dac_outside_api_key \
+    e2e_seed_team_tiggings \
+    e2e_seed_team_outside \
+    e2e_seed_user_tiggings \
+    e2e_seed_user_outside \
+    e2e_seed_vk_user_team \
+    e2e_seed_vk_outside; do
+    add_env_var_if_set "$seed_var"
+done
+
+if [ -n "$EXPECTED_PATH" ]; then
+    if [ ! -f "$EXPECTED_PATH" ]; then
+        echo -e "${RED}Error: expected manifest file not found: $EXPECTED_PATH${NC}"
+        exit 1
+    fi
+    EXPECTED_JSON="$(node -e 'const fs=require("fs"); const p=process.argv[1]; process.stdout.write(JSON.stringify(JSON.parse(fs.readFileSync(p,"utf8"))));' "$EXPECTED_PATH")"
+    cmd+=(--env-var "e2e_seed_expected=$EXPECTED_JSON")
+fi
 
 # Override plugin_path with resolved absolute path so Create Plugin / Get Plugin use the built .so
 # env-var takes precedence over collection variables in Newman's resolution order

--- a/tests/e2e/api/runners/run-newman-api-tests.sh
+++ b/tests/e2e/api/runners/run-newman-api-tests.sh
@@ -86,26 +86,50 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --db-url)
+            if [ $# -lt 2 ] || [[ "$2" == --* ]]; then
+                echo -e "${RED}Error: --db-url requires a value${NC}"
+                exit 1
+            fi
             DB_URL="$2"
             shift 2
             ;;
         --logs-db-url)
+            if [ $# -lt 2 ] || [[ "$2" == --* ]]; then
+                echo -e "${RED}Error: --logs-db-url requires a value${NC}"
+                exit 1
+            fi
             LOGS_DB_URL="$2"
             shift 2
             ;;
         --config-path)
+            if [ $# -lt 2 ] || [[ "$2" == --* ]]; then
+                echo -e "${RED}Error: --config-path requires a value${NC}"
+                exit 1
+            fi
             DB_CONFIG_PATH="$2"
             shift 2
             ;;
         --extra-collection)
+            if [ $# -lt 2 ] || [[ "$2" == --* ]]; then
+                echo -e "${RED}Error: --extra-collection requires a path${NC}"
+                exit 1
+            fi
             EXTRA_COLLECTIONS+=("$2")
             shift 2
             ;;
         --seed-env)
+            if [ $# -lt 2 ] || [[ "$2" == --* ]]; then
+                echo -e "${RED}Error: --seed-env requires a path${NC}"
+                exit 1
+            fi
             SEED_ENV_PATH="$2"
             shift 2
             ;;
         --expected)
+            if [ $# -lt 2 ] || [[ "$2" == --* ]]; then
+                echo -e "${RED}Error: --expected requires a path${NC}"
+                exit 1
+            fi
             EXPECTED_PATH="$2"
             shift 2
             ;;
@@ -322,6 +346,10 @@ if [ -n "$SEED_ENV_PATH" ]; then
         echo -e "${RED}Error: seed env file not found: $SEED_ENV_PATH${NC}"
         exit 1
     fi
+    if grep -Ev '^[[:space:]]*(#|$|[A-Za-z_][A-Za-z0-9_]*=)' "$SEED_ENV_PATH" >/dev/null; then
+        echo -e "${RED}Error: seed env file contains non-assignment lines: $SEED_ENV_PATH${NC}"
+        exit 1
+    fi
     set -a
     # shellcheck disable=SC1090
     . "$SEED_ENV_PATH"
@@ -350,7 +378,10 @@ for seed_var in \
     e2e_seed_user_tiggings \
     e2e_seed_user_outside \
     e2e_seed_vk_user_team \
-    e2e_seed_vk_outside; do
+    e2e_seed_vk_outside \
+    e2e_seed_enterprise_users \
+    e2e_seed_access_profiles \
+    e2e_seed_access_profile_budgets; do
     add_env_var_if_set "$seed_var"
 done
 

--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -1,7 +1,12 @@
 import VirtualKeysTable from "@/app/workspace/virtual-keys/views/virtualKeysTable";
 import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
-import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store";
+import {
+  getErrorMessage,
+  useGetCustomersQuery,
+  useGetTeamsQuery,
+  useGetVirtualKeysQuery,
+} from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useRef } from "react";
@@ -11,135 +16,158 @@ const POLLING_INTERVAL = 5000;
 const PAGE_SIZE = 25;
 
 export default function GovernanceVirtualKeysPage() {
-	const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
-	const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
-	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
-	const shownErrorsRef = useRef(new Set<string>());
+  const hasVirtualKeysAccess = useRbac(
+    RbacResource.VirtualKeys,
+    RbacOperation.View,
+  );
+  const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
+  const hasCustomersAccess = useRbac(
+    RbacResource.Customers,
+    RbacOperation.View,
+  );
+  const shownErrorsRef = useRef(new Set<string>());
 
-	const [urlState, setUrlState] = useQueryStates(
-		{
-			search: parseAsString.withDefault(""),
-			customer_id: parseAsString.withDefault(""),
-			team_id: parseAsString.withDefault(""),
-			offset: parseAsInteger.withDefault(0),
-			sort_by: parseAsString.withDefault(""),
-			order: parseAsString.withDefault(""),
-		},
-		{ history: "push" },
-	);
+  const [urlState, setUrlState] = useQueryStates(
+    {
+      search: parseAsString.withDefault(""),
+      customer_id: parseAsString.withDefault(""),
+      team_id: parseAsString.withDefault(""),
+      offset: parseAsInteger.withDefault(0),
+      sort_by: parseAsString.withDefault(""),
+      order: parseAsString.withDefault(""),
+    },
+    { history: "push" },
+  );
 
-	const debouncedSearch = useDebouncedValue(urlState.search, 300);
+  const debouncedSearch = useDebouncedValue(urlState.search, 300);
 
-	const {
-		data: virtualKeysData,
-		error: vkError,
-		isLoading: vkLoading,
-	} = useGetVirtualKeysQuery(
-		{
-			limit: PAGE_SIZE,
-			offset: urlState.offset,
-			search: debouncedSearch || undefined,
-			customer_id: urlState.customer_id || undefined,
-			team_id: urlState.team_id || undefined,
-			sort_by: (urlState.sort_by as "name" | "budget_spent" | "created_at" | "status") || undefined,
-			order: (urlState.order as "asc" | "desc") || undefined,
-		},
-		{
-			skip: !hasVirtualKeysAccess,
-			pollingInterval: POLLING_INTERVAL,
-		},
-	);
+  const {
+    data: virtualKeysData,
+    error: vkError,
+    isLoading: vkLoading,
+  } = useGetVirtualKeysQuery(
+    {
+      limit: PAGE_SIZE,
+      offset: urlState.offset,
+      search: debouncedSearch || undefined,
+      customer_id: urlState.customer_id || undefined,
+      team_id: urlState.team_id || undefined,
+      sort_by:
+        (urlState.sort_by as
+          | "name"
+          | "budget_spent"
+          | "created_at"
+          | "status") || undefined,
+      order: (urlState.order as "asc" | "desc") || undefined,
+    },
+    {
+      skip: !hasVirtualKeysAccess,
+      pollingInterval: POLLING_INTERVAL,
+    },
+  );
 
-	const {
-		data: teamsData,
-		error: teamsError,
-		isLoading: teamsLoading,
-	} = useGetTeamsQuery(undefined, {
-		skip: !hasTeamsAccess,
-		pollingInterval: POLLING_INTERVAL,
-	});
+  const {
+    data: teamsData,
+    error: teamsError,
+    isLoading: teamsLoading,
+  } = useGetTeamsQuery(undefined, {
+    skip: !hasTeamsAccess,
+    pollingInterval: POLLING_INTERVAL,
+  });
 
-	const {
-		data: customersData,
-		error: customersError,
-		isLoading: customersLoading,
-	} = useGetCustomersQuery(undefined, {
-		skip: !hasCustomersAccess,
-		pollingInterval: POLLING_INTERVAL,
-	});
+  const {
+    data: customersData,
+    error: customersError,
+    isLoading: customersLoading,
+  } = useGetCustomersQuery(undefined, {
+    skip: !hasCustomersAccess,
+    pollingInterval: POLLING_INTERVAL,
+  });
 
-	const vkTotal = virtualKeysData?.total_count ?? 0;
+  const vkTotal = virtualKeysData?.total_count ?? 0;
 
-	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
-	useEffect(() => {
-		if (!virtualKeysData || urlState.offset < vkTotal) return;
-		setUrlState({ offset: vkTotal === 0 ? 0 : Math.floor((vkTotal - 1) / PAGE_SIZE) * PAGE_SIZE });
-	}, [vkTotal, urlState.offset]);
+  // Snap offset back when total shrinks past current page (e.g. delete last item on last page)
+  useEffect(() => {
+    if (!virtualKeysData || urlState.offset < vkTotal) return;
+    setUrlState({
+      offset:
+        vkTotal === 0 ? 0 : Math.floor((vkTotal - 1) / PAGE_SIZE) * PAGE_SIZE,
+    });
+  }, [vkTotal, urlState.offset]);
 
-	const isLoading = vkLoading || teamsLoading || customersLoading;
+  const isLoading = vkLoading || teamsLoading || customersLoading;
 
-	useEffect(() => {
-		if (!vkError && !teamsError && !customersError) {
-			shownErrorsRef.current.clear();
-			return;
-		}
-		const errorKey = `${!!vkError}-${!!teamsError}-${!!customersError}`;
-		if (shownErrorsRef.current.has(errorKey)) return;
-		shownErrorsRef.current.add(errorKey);
-		if (vkError && teamsError && customersError) {
-			toast.error("Failed to load governance data.");
-		} else {
-			if (vkError) toast.error(`Failed to load virtual keys: ${getErrorMessage(vkError)}`);
-			if (teamsError) toast.error(`Failed to load teams: ${getErrorMessage(teamsError)}`);
-			if (customersError) toast.error(`Failed to load customers: ${getErrorMessage(customersError)}`);
-		}
-	}, [vkError, teamsError, customersError]);
+  useEffect(() => {
+    if (!vkError && !teamsError && !customersError) {
+      shownErrorsRef.current.clear();
+      return;
+    }
+    const errorKey = `${!!vkError}-${!!teamsError}-${!!customersError}`;
+    if (shownErrorsRef.current.has(errorKey)) return;
+    shownErrorsRef.current.add(errorKey);
+    if (vkError && teamsError && customersError) {
+      toast.error("Failed to load governance data.");
+    } else {
+      if (vkError)
+        toast.error(`Failed to load virtual keys: ${getErrorMessage(vkError)}`);
+      if (teamsError)
+        toast.error(`Failed to load teams: ${getErrorMessage(teamsError)}`);
+      if (customersError)
+        toast.error(
+          `Failed to load customers: ${getErrorMessage(customersError)}`,
+        );
+    }
+  }, [vkError, teamsError, customersError]);
 
-	if (isLoading) {
-		return <FullPageLoader />;
-	}
+  if (isLoading) {
+    return <FullPageLoader />;
+  }
 
-	const handleSearchChange = (value: string) => {
-		setUrlState({ search: value || null, offset: 0 });
-	};
+  const handleSearchChange = (value: string) => {
+    setUrlState({ search: value || null, offset: 0 });
+  };
 
-	const handleCustomerFilterChange = (value: string) => {
-		setUrlState({ customer_id: value || null, offset: 0 });
-	};
+  const handleCustomerFilterChange = (value: string) => {
+    setUrlState({ customer_id: value || null, offset: 0 });
+  };
 
-	const handleTeamFilterChange = (value: string) => {
-		setUrlState({ team_id: value || null, offset: 0 });
-	};
+  const handleTeamFilterChange = (value: string) => {
+    setUrlState({ team_id: value || null, offset: 0 });
+  };
 
-	const handleOffsetChange = (newOffset: number) => {
-		setUrlState({ offset: newOffset });
-	};
+  const handleOffsetChange = (newOffset: number) => {
+    setUrlState({ offset: newOffset });
+  };
 
-	const handleSortChange = (newSortBy: string, newOrder: string) => {
-		setUrlState({ sort_by: newSortBy || null, order: newOrder || null, offset: 0 });
-	};
+  const handleSortChange = (newSortBy: string, newOrder: string) => {
+    setUrlState({
+      sort_by: newSortBy || null,
+      order: newOrder || null,
+      offset: 0,
+    });
+  };
 
-	return (
-		<div className="mx-auto w-full">
-			<VirtualKeysTable
-				virtualKeys={virtualKeysData?.virtual_keys || []}
-				totalCount={virtualKeysData?.total_count || 0}
-				teams={teamsData?.teams || []}
-				customers={customersData?.customers || []}
-				search={urlState.search}
-				debouncedSearch={debouncedSearch}
-				onSearchChange={handleSearchChange}
-				customerFilter={urlState.customer_id}
-				onCustomerFilterChange={handleCustomerFilterChange}
-				teamFilter={urlState.team_id}
-				onTeamFilterChange={handleTeamFilterChange}
-				offset={urlState.offset}
-				limit={PAGE_SIZE}
-				onOffsetChange={handleOffsetChange}
-				sortBy={urlState.sort_by}
-				order={urlState.order}
-				onSortChange={handleSortChange}
-			/>
-		</div>
-	);
+  return (
+    <div className="mx-auto w-full max-w-7xl">
+      <VirtualKeysTable
+        virtualKeys={virtualKeysData?.virtual_keys || []}
+        totalCount={virtualKeysData?.total_count || 0}
+        teams={teamsData?.teams || []}
+        customers={customersData?.customers || []}
+        search={urlState.search}
+        debouncedSearch={debouncedSearch}
+        onSearchChange={handleSearchChange}
+        customerFilter={urlState.customer_id}
+        onCustomerFilterChange={handleCustomerFilterChange}
+        teamFilter={urlState.team_id}
+        onTeamFilterChange={handleTeamFilterChange}
+        offset={urlState.offset}
+        limit={PAGE_SIZE}
+        onOffsetChange={handleOffsetChange}
+        sortBy={urlState.sort_by}
+        order={urlState.order}
+        onSortChange={handleSortChange}
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

Adds support for merging enterprise-only Postman collections into the API management e2e test runner without committing them to OSS. This allows enterprise repos to supply additional API test coverage (e.g. DAC-specific assertions) that runs alongside the shared OSS management requests.

## Changes

- Added `merge-collections.mjs`, a Node.js script that merges one or more extension Postman collections into a base collection, wrapping each extension's items in a named folder and writing the result to a temporary output file.
- Added `--extra-collection <path>` flag to `run-newman-api-tests.sh`, which can be specified multiple times. When present, the runner invokes `merge-collections.mjs` to produce a merged collection before passing it to Newman.
- Added support for a `BIFROST_API_EXTRA_COLLECTION` environment variable as an alternative to the CLI flag.
- Updated the README to document the `--extra-collection` flag and the intended OSS/enterprise split.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the API management tests with an extra enterprise collection:

```sh
cd tests/e2e/api
./runners/run-newman-api-tests.sh --extra-collection /path/to/enterprise.postman_collection.json
```

Verify that the merged collection file is written to the report directory as `api-management-with-extensions.postman_collection.json` and that Newman runs against it.

Run without `--extra-collection` to confirm the default OSS behavior is unchanged.

The `BIFROST_API_EXTRA_COLLECTION` environment variable can also be used in place of the flag:

```sh
BIFROST_API_EXTRA_COLLECTION=/path/to/enterprise.postman_collection.json ./runners/run-newman-api-tests.sh
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Extra collection paths are validated to exist on disk before merging. No secrets or credentials are introduced; the feature only affects which Postman items are included in a test run.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable