### PR TITLE
migration fix for calendar aligned

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -161,7 +161,7 @@ type legacyBudgetVirtualKey struct {
 	BudgetID *string `gorm:"column:budget_id;type:varchar(255);index"`
 }
 
-// legacyBudgetVirtualKey holds the legacy budget virtual key model.
+// TableName returns the governance_virtual_keys table name for legacyBudgetVirtualKey.
 func (legacyBudgetVirtualKey) TableName() string { return "governance_virtual_keys" }
 
 // legacyBudgetVirtualKeyProviderConfig holds the legacy budget virtual key provider config model.
@@ -170,7 +170,7 @@ type legacyBudgetVirtualKeyProviderConfig struct {
 	BudgetID *string `gorm:"column:budget_id;type:varchar(255);index"`
 }
 
-// legacyBudgetVirtualKeyProviderConfig holds the legacy budget virtual key provider config model.
+// TableName returns the governance_virtual_key_provider_configs table name for legacyBudgetVirtualKeyProviderConfig.
 func (legacyBudgetVirtualKeyProviderConfig) TableName() string {
 	return "governance_virtual_key_provider_configs"
 }
@@ -181,7 +181,7 @@ type legacyBudgetTeam struct {
 	BudgetID *string `gorm:"column:budget_id;type:varchar(255);index"`
 }
 
-// legacyBudgetTeam holds the legacy budget team model.
+// TableName returns the governance_teams table name for legacyBudgetTeam.
 func (legacyBudgetTeam) TableName() string { return "governance_teams" }
 
 // sqliteColumnInfo holds the information about a SQLite column.
@@ -250,20 +250,21 @@ func sqliteTableHasColumn(tx *gorm.DB, tableName, columnName string) (bool, erro
 }
 
 // hasColumn checks if a table has a column with the given name.
-func hasColumn(tx *gorm.DB, table, column string) bool {
+// Returns the introspection error rather than collapsing it to false so callers
+// can distinguish "column missing" from "could not determine".
+func hasColumn(tx *gorm.DB, table, column string) (bool, error) {
 	var count int64
 	var q string
 	switch tx.Dialector.Name() {
 	case "sqlite":
 		q = `SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`
 	default:
-		q = `SELECT COUNT(*) FROM information_schema.columns WHERE table_name = ? AND
-  column_name = ?`
+		q = `SELECT COUNT(*) FROM information_schema.columns WHERE table_name = ? AND column_name = ? AND table_schema = current_schema()`
 	}
 	if err := tx.Raw(q, table, column).Scan(&count).Error; err != nil {
-		return false
+		return false, err
 	}
-	return count > 0
+	return count > 0, nil
 }
 
 // sqliteDropLegacyBudgetColumn removes the legacy budget_id column from a
@@ -7287,13 +7288,21 @@ func migrateCalendarAlignedToBudgetsAndRateLimitsTable(ctx context.Context, db *
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
 			// Adding columns first
-			if !hasColumn(tx, "governance_budgets", "calendar_aligned") {
+			budgetsHasCol, err := hasColumn(tx, "governance_budgets", "calendar_aligned")
+			if err != nil {
+				return fmt.Errorf("failed to introspect governance_budgets for calendar_aligned: %w", err)
+			}
+			if !budgetsHasCol {
 				if err := tx.Exec(`ALTER TABLE governance_budgets ADD COLUMN calendar_aligned BOOLEAN DEFAULT FALSE`).Error; err != nil {
 					return fmt.Errorf("failed to add calendar_aligned column to budgets: %w", err)
 				}
 			}
 			// Adding columns first
-			if !hasColumn(tx, "governance_rate_limits", "calendar_aligned") {
+			rateLimitsHasCol, err := hasColumn(tx, "governance_rate_limits", "calendar_aligned")
+			if err != nil {
+				return fmt.Errorf("failed to introspect governance_rate_limits for calendar_aligned: %w", err)
+			}
+			if !rateLimitsHasCol {
 				if err := tx.Exec(`ALTER TABLE governance_rate_limits ADD COLUMN calendar_aligned BOOLEAN DEFAULT FALSE`).Error; err != nil {
 					return fmt.Errorf("failed to add calendar_aligned column to rate_limits: %w", err)
 				}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -155,33 +155,41 @@ func RunSingleMigration(ctx context.Context, db *gorm.DB, migration *migrator.Mi
 	return m.Migrate()
 }
 
+// legacyBudgetVirtualKey holds the legacy budget virtual key model.
 type legacyBudgetVirtualKey struct {
 	tables.TableVirtualKey
 	BudgetID *string `gorm:"column:budget_id;type:varchar(255);index"`
 }
 
+// legacyBudgetVirtualKey holds the legacy budget virtual key model.
 func (legacyBudgetVirtualKey) TableName() string { return "governance_virtual_keys" }
 
+// legacyBudgetVirtualKeyProviderConfig holds the legacy budget virtual key provider config model.
 type legacyBudgetVirtualKeyProviderConfig struct {
 	tables.TableVirtualKeyProviderConfig
 	BudgetID *string `gorm:"column:budget_id;type:varchar(255);index"`
 }
 
+// legacyBudgetVirtualKeyProviderConfig holds the legacy budget virtual key provider config model.
 func (legacyBudgetVirtualKeyProviderConfig) TableName() string {
 	return "governance_virtual_key_provider_configs"
 }
 
+// legacyBudgetTeam holds the legacy budget team model.
 type legacyBudgetTeam struct {
 	tables.TableTeam
 	BudgetID *string `gorm:"column:budget_id;type:varchar(255);index"`
 }
 
+// legacyBudgetTeam holds the legacy budget team model.
 func (legacyBudgetTeam) TableName() string { return "governance_teams" }
 
+// sqliteColumnInfo holds the information about a SQLite column.
 type sqliteColumnInfo struct {
 	Name string `gorm:"column:name"`
 }
 
+// legacyBudgetColumnModel returns the legacy budget column model for a given table name.
 func legacyBudgetColumnModel(tableName string) (any, error) {
 	switch tableName {
 	case "governance_virtual_keys":
@@ -195,6 +203,7 @@ func legacyBudgetColumnModel(tableName string) (any, error) {
 	}
 }
 
+// currentBudgetOwnerModel returns the current budget owner model for a given table name.
 func currentBudgetOwnerModel(tableName string) (any, error) {
 	switch tableName {
 	case "governance_virtual_keys":
@@ -208,10 +217,12 @@ func currentBudgetOwnerModel(tableName string) (any, error) {
 	}
 }
 
+// quoteSQLiteIdentifier quotes a SQLite identifier, escaping any double quotes.
 func quoteSQLiteIdentifier(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
+// sqliteTableColumns returns the column names of a SQLite table.
 func sqliteTableColumns(tx *gorm.DB, tableName string) ([]string, error) {
 	var columns []sqliteColumnInfo
 	query := fmt.Sprintf("PRAGMA table_info(%s)", quoteSQLiteIdentifier(tableName))
@@ -226,6 +237,7 @@ func sqliteTableColumns(tx *gorm.DB, tableName string) ([]string, error) {
 	return result, nil
 }
 
+// sqliteTableHasColumn checks if a SQLite table has a column with the given name.
 func sqliteTableHasColumn(tx *gorm.DB, tableName, columnName string) (bool, error) {
 	columns, err := sqliteTableColumns(tx, tableName)
 	if err != nil {
@@ -235,6 +247,23 @@ func sqliteTableHasColumn(tx *gorm.DB, tableName, columnName string) (bool, erro
 		return true, nil
 	}
 	return false, nil
+}
+
+// hasColumn checks if a table has a column with the given name.
+func hasColumn(tx *gorm.DB, table, column string) bool {
+	var count int64
+	var q string
+	switch tx.Dialector.Name() {
+	case "sqlite":
+		q = `SELECT COUNT(*) FROM pragma_table_info(?) WHERE name = ?`
+	default:
+		q = `SELECT COUNT(*) FROM information_schema.columns WHERE table_name = ? AND
+  column_name = ?`
+	}
+	if err := tx.Raw(q, table, column).Scan(&count).Error; err != nil {
+		return false
+	}
+	return count > 0
 }
 
 // sqliteDropLegacyBudgetColumn removes the legacy budget_id column from a
@@ -7257,16 +7286,15 @@ func migrateCalendarAlignedToBudgetsAndRateLimitsTable(ctx context.Context, db *
 		ID: "migrate_calendar_aligned",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
-			mig := tx.Migrator()
 			// Adding columns first
-			if !mig.HasColumn(&tables.TableBudget{}, "calendar_aligned") {
-				if err := mig.AddColumn(&tables.TableBudget{}, "calendar_aligned"); err != nil {
+			if !hasColumn(tx, "governance_budgets", "calendar_aligned") {
+				if err := tx.Exec(`ALTER TABLE governance_budgets ADD COLUMN calendar_aligned BOOLEAN DEFAULT FALSE`).Error; err != nil {
 					return fmt.Errorf("failed to add calendar_aligned column to budgets: %w", err)
 				}
 			}
 			// Adding columns first
-			if !mig.HasColumn(&tables.TableRateLimit{}, "calendar_aligned") {
-				if err := mig.AddColumn(&tables.TableRateLimit{}, "calendar_aligned"); err != nil {
+			if !hasColumn(tx, "governance_rate_limits", "calendar_aligned") {
+				if err := tx.Exec(`ALTER TABLE governance_rate_limits ADD COLUMN calendar_aligned BOOLEAN DEFAULT FALSE`).Error; err != nil {
 					return fmt.Errorf("failed to add calendar_aligned column to rate_limits: %w", err)
 				}
 			}


### PR DESCRIPTION
## Summary

Replaces GORM's `Migrator.HasColumn` / `AddColumn` calls in the `migrate_calendar_aligned` migration with raw SQL, and adds doc comments to all legacy budget migration helpers. The GORM migrator approach was unreliable across dialects; the new `hasColumn` helper queries `pragma_table_info` (SQLite) or `information_schema.columns` (all other databases) directly, and column addition is done via a plain `ALTER TABLE ... ADD COLUMN` statement.

## Changes

- Added a `hasColumn` helper that checks for a column's existence using dialect-aware raw SQL instead of the GORM migrator API.
- Replaced `mig.HasColumn` / `mig.AddColumn` calls in `migrateCalendarAlignedToBudgetsAndRateLimitsTable` with `hasColumn` and raw `ALTER TABLE` statements for both `governance_budgets.calendar_aligned` and `governance_rate_limits.calendar_aligned`.
- Added doc comments to all legacy budget migration types and helper functions (`legacyBudgetVirtualKey`, `legacyBudgetVirtualKeyProviderConfig`, `legacyBudgetTeam`, `sqliteColumnInfo`, `legacyBudgetColumnModel`, `currentBudgetOwnerModel`, `quoteSQLiteIdentifier`, `sqliteTableColumns`, `sqliteTableHasColumn`).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
```

Run against both a SQLite and a supported relational database to confirm the `calendar_aligned` column is added correctly on a fresh migration and that re-running the migration is idempotent (column already exists case is skipped without error).

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No auth, secrets, or PII implications. Raw SQL identifiers in the new helper use parameterised queries, so there is no SQL injection risk.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable