### PR TITLE
feat: service tier mappings for gemini and anthropic

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -565,7 +565,10 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 		}
 
 		// Convert service tier
-		anthropicReq.ServiceTier = bifrostReq.Params.ServiceTier
+		if bifrostReq.Params.ServiceTier != nil {
+			mapped := MapBifrostServiceTierToAnthropicRequest(*bifrostReq.Params.ServiceTier)
+			anthropicReq.ServiceTier = &mapped
+		}
 	}
 
 	// Convert messages - group consecutive tool messages into single user messages
@@ -939,7 +942,8 @@ func (response *AnthropicMessageResponse) ToBifrostChatResponse(ctx *schemas.Bif
 		bifrostResponse.Usage.TotalTokens = bifrostResponse.Usage.PromptTokens + bifrostResponse.Usage.CompletionTokens
 		// Forward service tier from usage to response
 		if response.Usage.ServiceTier != nil {
-			bifrostResponse.ServiceTier = response.Usage.ServiceTier
+			mapped := MapAnthropicServiceTierToBifrost(*response.Usage.ServiceTier)
+			bifrostResponse.ServiceTier = &mapped
 		}
 	}
 
@@ -985,7 +989,8 @@ func ToAnthropicChatResponse(bifrostResp *schemas.BifrostChatResponse) *Anthropi
 		}
 		// Forward service tier
 		if bifrostResp.ServiceTier != nil {
-			anthropicResp.Usage.ServiceTier = bifrostResp.ServiceTier
+			mapped := MapBifrostServiceTierToAnthropicResponse(*bifrostResp.ServiceTier)
+			anthropicResp.Usage.ServiceTier = &mapped
 		}
 	}
 

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -2214,6 +2214,10 @@ func (req *AnthropicMessageRequest) ToBifrostResponsesRequest(ctx *schemas.Bifro
 	if include, ok := schemas.SafeExtractStringSlice(req.ExtraParams["include"]); ok {
 		params.Include = include
 	}
+	if req.ServiceTier != nil {
+		mapped := MapAnthropicRequestServiceTierToBifrost(*req.ServiceTier)
+		params.ServiceTier = &mapped
+	}
 
 	// Add truncation parameter if computer tool is being used
 	if provider == schemas.OpenAI && req.Tools != nil {
@@ -2457,7 +2461,10 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 			}
 		}
 		// Convert service tier
-		anthropicReq.ServiceTier = bifrostReq.Params.ServiceTier
+		if bifrostReq.Params.ServiceTier != nil {
+			mapped := MapBifrostServiceTierToAnthropicRequest(*bifrostReq.Params.ServiceTier)
+			anthropicReq.ServiceTier = &mapped
+		}
 
 		if bifrostReq.Params.ExtraParams != nil {
 			anthropicReq.ExtraParams = make(map[string]interface{}, len(bifrostReq.Params.ExtraParams))
@@ -2742,6 +2749,11 @@ func (response *AnthropicMessageResponse) ToBifrostResponsesResponse(ctx *schema
 		bifrostResp.StopReason = schemas.Ptr(ConvertAnthropicFinishReasonToBifrost(response.StopReason))
 	}
 
+	if response.Usage != nil && response.Usage.ServiceTier != nil {
+		mapped := MapAnthropicServiceTierToBifrost(*response.Usage.ServiceTier)
+		bifrostResp.ServiceTier = &mapped
+	}
+
 	return bifrostResp
 }
 
@@ -2795,6 +2807,14 @@ func ToAnthropicResponsesResponse(ctx *schemas.BifrostContext, bifrostResp *sche
 	}
 
 	anthropicResp.Model = bifrostResp.Model
+
+	if bifrostResp.ServiceTier != nil {
+		if anthropicResp.Usage == nil {
+			anthropicResp.Usage = &AnthropicUsage{}
+		}
+		mapped := MapBifrostServiceTierToAnthropicResponse(*bifrostResp.ServiceTier)
+		anthropicResp.Usage.ServiceTier = &mapped
+	}
 
 	return anthropicResp
 }

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -132,6 +132,7 @@ type ProviderFeatureSupport struct {
 	AdvisorTool            bool // advisor_tool_result block — Anthropic only (cite: Advisor-excl)
 	FileSearch             bool // file_search server tool (OpenAI-only)
 	ImageGeneration        bool // image_generation server tool (OpenAI-only)
+	ServiceTier            bool // service_tier request field — strip when false (Vertex uses headers instead)
 }
 
 // ProviderFeatures maps each provider to its supported Anthropic features.
@@ -149,6 +150,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		InterleavedThinking: true, Skills: true, ContainerBasic: true, Context1M: true,
 		FastMode: true, RedactThinking: true, TaskBudgets: true,
 		InferenceGeo: true, EagerInputStreaming: true, AdvisorTool: true,
+		ServiceTier: true,
 	},
 	// Google Vertex AI — cite: A (overview table) and V-platform.
 	// Notably NOT supported: MCP (MCP-excl), Skills/container.skills,
@@ -204,6 +206,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		// AdvancedToolUse intentionally OFF on Bedrock. The bundle header
 		// (advanced-tool-use-2025-11-20) is not listed in B-header; only the
 		// narrow tool-examples-2025-10-29 header is, gated via InputExamples above.
+		ServiceTier: true, // Bedrock handles service_tier via its own typed conversion
 	},
 	// Microsoft Azure AI Foundry — cite: A (most features azureAiBeta) +
 	// Az-platform ("supports most of Claude's features"). Excluded per
@@ -220,6 +223,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		RedactThinking:      true,
 		EagerInputStreaming: true,
 		// FastMode, InferenceGeo, AdvisorTool, TaskBudgets — not documented on Az-platform; leave off.
+		ServiceTier: true,
 	},
 }
 

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -231,6 +231,9 @@ func stripUnsupportedAnthropicFields(req *AnthropicMessageRequest, provider sche
 	if req.InferenceGeo != nil && !features.InferenceGeo {
 		req.InferenceGeo = nil
 	}
+	if req.ServiceTier != nil && !features.ServiceTier {
+		req.ServiceTier = nil
+	}
 	// cache_control.scope — strip on providers without PromptCachingScope
 	// support at every slot scope can live: top-level request, tools, system
 	// blocks, and message content blocks. Vertex additionally uses the
@@ -384,6 +387,14 @@ func StripUnsupportedFieldsFromRawBody(jsonBody []byte, provider schemas.ModelPr
 		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "inference_geo")
 		if err != nil {
 			return nil, fmt.Errorf("strip raw inference_geo: %w", err)
+		}
+	}
+
+	// service_tier — Vertex uses HTTP headers instead of a request body field
+	if !features.ServiceTier && providerUtils.JSONFieldExists(jsonBody, "service_tier") {
+		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "service_tier")
+		if err != nil {
+			return nil, fmt.Errorf("strip raw service_tier: %w", err)
 		}
 	}
 
@@ -1846,6 +1857,60 @@ func convertMapToToolFunctionParameters(m map[string]interface{}) *schemas.ToolF
 }
 
 // ConvertAnthropicFinishReasonToBifrost converts provider finish reasons to Bifrost format
+// MapAnthropicRequestServiceTierToBifrost maps Anthropic request service_tier values back to Bifrost/OpenAI values.
+// Anthropic request values: "auto" or "standard_only".
+func MapAnthropicRequestServiceTierToBifrost(tier string) schemas.BifrostServiceTier {
+	switch tier {
+	case "standard_only":
+		return schemas.BifrostServiceTierDefault
+	case "auto":
+		return schemas.BifrostServiceTierAuto
+	default:
+		return schemas.BifrostServiceTierAuto
+	}
+}
+
+// MapBifrostServiceTierToAnthropicRequest maps OpenAI-compatible service_tier request values to Anthropic's two allowed values.
+// Anthropic only supports "auto" (use priority if available) or "standard_only" (always standard).
+func MapBifrostServiceTierToAnthropicRequest(tier schemas.BifrostServiceTier) string {
+	switch tier {
+	case schemas.BifrostServiceTierAuto, schemas.BifrostServiceTierPriority:
+		return "auto"
+	case schemas.BifrostServiceTierDefault, schemas.BifrostServiceTierFlex:
+		return "standard_only"
+	default:
+		return "auto"
+	}
+}
+
+// MapAnthropicServiceTierToBifrost maps Anthropic response service_tier values to OpenAI-compatible Bifrost values.
+// Anthropic response values: "standard", "priority", "batch".
+func MapAnthropicServiceTierToBifrost(tier string) schemas.BifrostServiceTier {
+	switch tier {
+	case "standard":
+		return schemas.BifrostServiceTierDefault
+	case "priority":
+		return schemas.BifrostServiceTierPriority
+	default:
+		return schemas.BifrostServiceTier(tier)
+	}
+}
+
+// MapBifrostServiceTierToAnthropicResponse maps Bifrost/OpenAI response service_tier values back to Anthropic wire format.
+// Used when re-encoding a Bifrost response into Anthropic format.
+func MapBifrostServiceTierToAnthropicResponse(tier schemas.BifrostServiceTier) string {
+	switch tier {
+	case schemas.BifrostServiceTierDefault:
+		return "standard"
+	case schemas.BifrostServiceTierPriority:
+		return "priority"
+	case schemas.BifrostServiceTierAuto, schemas.BifrostServiceTierFlex:
+		return "standard"
+	default:
+		return string(tier)
+	}
+}
+
 func ConvertAnthropicFinishReasonToBifrost(providerReason AnthropicStopReason) string {
 	if bifrostReason, ok := anthropicFinishReasonToBifrost[providerReason]; ok {
 		return bifrostReason

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -362,7 +362,7 @@ func TestBifrostToBedrockRequestConversion(t *testing.T) {
 	stop := testStop
 	trace := testTrace
 	latency := testLatency
-	serviceTier := "priority"
+	serviceTier := schemas.BifrostServiceTierPriority
 	props := testProps
 
 	tests := []struct {
@@ -514,7 +514,7 @@ func TestBifrostToBedrockRequestConversion(t *testing.T) {
 				},
 				InferenceConfig: &bedrock.BedrockInferenceConfig{},
 				ServiceTier: &bedrock.BedrockServiceTier{
-					Type: serviceTier,
+					Type: bedrock.BedrockServiceTierTypePriority,
 				},
 			},
 		},
@@ -4142,10 +4142,10 @@ func TestBifrostToBedrockStopReasonReverseMapping(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		stopReason     *string
+		name              string
+		stopReason        *string
 		incompleteDetails *schemas.ResponsesResponseIncompleteDetails
-		expectedBedrock string
+		expectedBedrock   string
 	}{
 		{"Stop", schemas.Ptr("stop"), nil, "end_turn"},
 		{"Length", schemas.Ptr("length"), nil, "max_tokens"},
@@ -4155,17 +4155,17 @@ func TestBifrostToBedrockStopReasonReverseMapping(t *testing.T) {
 		{"UnknownPassthrough", schemas.Ptr("some_unknown_reason"), nil, "some_unknown_reason"},    // passes through
 		{
 			// StopReason takes priority over IncompleteDetails
-			name:            "StopReasonOverridesIncompleteDetails",
-			stopReason:      schemas.Ptr("stop"),
+			name:              "StopReasonOverridesIncompleteDetails",
+			stopReason:        schemas.Ptr("stop"),
 			incompleteDetails: &schemas.ResponsesResponseIncompleteDetails{Reason: "max_tokens"},
-			expectedBedrock: "end_turn",
+			expectedBedrock:   "end_turn",
 		},
 		{
 			// IncompleteDetails is used when StopReason is nil
-			name:            "IncompleteDetailsFallback",
-			stopReason:      nil,
+			name:              "IncompleteDetailsFallback",
+			stopReason:        nil,
 			incompleteDetails: &schemas.ResponsesResponseIncompleteDetails{Reason: "max_tokens"},
-			expectedBedrock: "max_tokens",
+			expectedBedrock:   "max_tokens",
 		},
 	}
 

--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -286,7 +286,8 @@ func (response *BedrockConverseResponse) ToBifrostChatResponse(ctx context.Conte
 	}
 
 	if response.ServiceTier != nil && response.ServiceTier.Type != "" {
-		bifrostResponse.ServiceTier = &response.ServiceTier.Type
+		tier := mapBedrockServiceTierToBifrost(response.ServiceTier.Type)
+		bifrostResponse.ServiceTier = &tier
 	}
 
 	return bifrostResponse, nil

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2312,7 +2312,7 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 
 		if bifrostReq.Params.ServiceTier != nil {
 			bedrockReq.ServiceTier = &BedrockServiceTier{
-				Type: *bifrostReq.Params.ServiceTier,
+				Type: mapBifrostServiceTierToBedrock(*bifrostReq.Params.ServiceTier),
 			}
 		}
 	}
@@ -2502,7 +2502,8 @@ func (response *BedrockConverseResponse) ToBifrostResponsesResponse(ctx *schemas
 	}
 
 	if response.ServiceTier != nil && response.ServiceTier.Type != "" {
-		bifrostResp.ServiceTier = &response.ServiceTier.Type
+		tier := mapBedrockServiceTierToBifrost(response.ServiceTier.Type)
+		bifrostResp.ServiceTier = &tier
 	}
 
 	if response.StopReason != "" {

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -64,8 +64,19 @@ func (r *BedrockTextCompletionRequest) IsStreamingRequested() bool {
 	return r.Stream
 }
 
+// BedrockServiceTierType represents the processing tier for a Bedrock request.
+// See https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ServiceTier.html
+type BedrockServiceTierType string
+
+const (
+	BedrockServiceTierTypePriority BedrockServiceTierType = "priority"
+	BedrockServiceTierTypeDefault  BedrockServiceTierType = "default"
+	BedrockServiceTierTypeFlex     BedrockServiceTierType = "flex"
+	BedrockServiceTierTypeReserved BedrockServiceTierType = "reserved"
+)
+
 type BedrockServiceTier struct {
-	Type string `json:"type"` // Service tier type: "reserved" | "priority" | "default" | "flex"
+	Type BedrockServiceTierType `json:"type"`
 }
 
 // BedrockConverseRequest represents a Bedrock Converse API request

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -74,6 +74,35 @@ func convertBifrostToBedrockStopReason(bifrostReason string) string {
 	return bifrostReason
 }
 
+// mapBifrostServiceTierToBedrock maps a BifrostServiceTier to a BedrockServiceTierType.
+func mapBifrostServiceTierToBedrock(tier schemas.BifrostServiceTier) BedrockServiceTierType {
+	switch tier {
+	case schemas.BifrostServiceTierPriority:
+		return BedrockServiceTierTypePriority
+	case schemas.BifrostServiceTierFlex:
+		return BedrockServiceTierTypeFlex
+	case schemas.BifrostServiceTierDefault, schemas.BifrostServiceTierAuto:
+		return BedrockServiceTierTypeDefault
+	default:
+		return BedrockServiceTierType(tier)
+	}
+}
+
+// mapBedrockServiceTierToBifrost maps a BedrockServiceTierType to a BifrostServiceTier.
+// "reserved" maps to priority as it represents pre-purchased priority capacity.
+func mapBedrockServiceTierToBifrost(tier BedrockServiceTierType) schemas.BifrostServiceTier {
+	switch tier {
+	case BedrockServiceTierTypePriority:
+		return schemas.BifrostServiceTierPriority
+	case BedrockServiceTierTypeFlex:
+		return schemas.BifrostServiceTierFlex
+	case BedrockServiceTierTypeDefault:
+		return schemas.BifrostServiceTierDefault
+	default:
+		return schemas.BifrostServiceTier(tier)
+	}
+}
+
 // normalizeBedrockFilename normalizes a filename to meet Bedrock's requirements:
 // - Only alphanumeric characters, whitespace, hyphens, parentheses, and square brackets
 // - No more than one consecutive whitespace character
@@ -335,7 +364,7 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 	}
 	if bifrostReq.Params.ServiceTier != nil {
 		bedrockReq.ServiceTier = &BedrockServiceTier{
-			Type: *bifrostReq.Params.ServiceTier,
+			Type: mapBifrostServiceTierToBedrock(*bifrostReq.Params.ServiceTier),
 		}
 	}
 	// Add extra parameters

--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -42,6 +42,10 @@ func ToGeminiChatCompletionRequest(bifrostReq *schemas.BifrostChatRequest) (*Gem
 			}
 		}
 
+		if bifrostReq.Params.ServiceTier != nil {
+			geminiReq.ServiceTier = mapBifrostServiceTierToGemini(*bifrostReq.Params.ServiceTier)
+		}
+
 		// Handle extra parameters
 		if bifrostReq.Params.ExtraParams != nil {
 			// Safety settings
@@ -277,6 +281,11 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 	// Set usage information
 	bifrostResp.Usage = ConvertGeminiUsageMetadataToChatUsage(response.UsageMetadata)
 
+	if response.UsageMetadata != nil && response.UsageMetadata.ServiceTier != "" {
+		tier := mapGeminiServiceTierToBifrost(response.UsageMetadata.ServiceTier)
+		bifrostResp.ServiceTier = &tier
+	}
+
 	return bifrostResp
 }
 
@@ -495,6 +504,10 @@ func (response *GenerateContentResponse) ToBifrostChatCompletionStream(state *Ge
 	// Add usage information if this is the last chunk
 	if isLastChunk && response.UsageMetadata != nil {
 		streamResponse.Usage = ConvertGeminiUsageMetadataToChatUsage(response.UsageMetadata)
+		if response.UsageMetadata.ServiceTier != "" {
+			tier := mapGeminiServiceTierToBifrost(response.UsageMetadata.ServiceTier)
+			streamResponse.ServiceTier = &tier
+		}
 	}
 
 	return streamResponse, nil, isLastChunk

--- a/core/providers/gemini/gemini_test.go
+++ b/core/providers/gemini/gemini_test.go
@@ -1409,6 +1409,164 @@ func TestResponsesStructuredOutputConversion(t *testing.T) {
 	}
 }
 
+func TestServiceTierMappingChat(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputTier      *schemas.BifrostServiceTier
+		expectedGemini gemini.ServiceTier
+	}{
+		{
+			name:           "flex maps to flex",
+			inputTier:      schemas.Ptr(schemas.BifrostServiceTierFlex),
+			expectedGemini: gemini.ServiceTierFlex,
+		},
+		{
+			name:           "priority maps to priority",
+			inputTier:      schemas.Ptr(schemas.BifrostServiceTierPriority),
+			expectedGemini: gemini.ServiceTierPriority,
+		},
+		{
+			name:           "default maps to standard",
+			inputTier:      schemas.Ptr(schemas.BifrostServiceTierDefault),
+			expectedGemini: gemini.ServiceTierStandard,
+		},
+		{
+			name:           "auto maps to unspecified",
+			inputTier:      schemas.Ptr(schemas.BifrostServiceTierAuto),
+			expectedGemini: gemini.ServiceTierUnspecified,
+		},
+		{
+			name:           "nil leaves service tier unset",
+			inputTier:      nil,
+			expectedGemini: gemini.ServiceTier(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &schemas.BifrostChatRequest{
+				Model: "gemini-2.0-flash",
+				Input: []schemas.ChatMessage{
+					{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hello")}},
+				},
+				Params: &schemas.ChatParameters{
+					ServiceTier: tt.inputTier,
+				},
+			}
+			result, err := gemini.ToGeminiChatCompletionRequest(req)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedGemini, result.ServiceTier)
+		})
+	}
+}
+
+func TestServiceTierMappingResponses(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputTier      *schemas.BifrostServiceTier
+		expectedGemini gemini.ServiceTier
+	}{
+		{
+			name:           "flex maps to flex",
+			inputTier:      schemas.Ptr(schemas.BifrostServiceTierFlex),
+			expectedGemini: gemini.ServiceTierFlex,
+		},
+		{
+			name:           "priority maps to priority",
+			inputTier:      schemas.Ptr(schemas.BifrostServiceTierPriority),
+			expectedGemini: gemini.ServiceTierPriority,
+		},
+		{
+			name:           "default maps to standard",
+			inputTier:      schemas.Ptr(schemas.BifrostServiceTierDefault),
+			expectedGemini: gemini.ServiceTierStandard,
+		},
+		{
+			name:           "auto maps to unspecified",
+			inputTier:      schemas.Ptr(schemas.BifrostServiceTierAuto),
+			expectedGemini: gemini.ServiceTierUnspecified,
+		},
+		{
+			name:           "nil leaves service tier unset",
+			inputTier:      nil,
+			expectedGemini: gemini.ServiceTier(""),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &schemas.BifrostResponsesRequest{
+				Provider: schemas.Gemini,
+				Model:    "gemini-2.0-flash",
+				Input: []schemas.ResponsesMessage{
+					{
+						Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+						Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+						Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hello")},
+					},
+				},
+				Params: &schemas.ResponsesParameters{
+					ServiceTier: tt.inputTier,
+				},
+			}
+			result, err := gemini.ToGeminiResponsesRequest(req)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedGemini, result.ServiceTier)
+		})
+	}
+}
+
+func TestServiceTierReverseMapping(t *testing.T) {
+	tests := []struct {
+		name         string
+		geminiTier   gemini.ServiceTier
+		expectedTier *schemas.BifrostServiceTier
+	}{
+		{
+			name:         "standard maps to default",
+			geminiTier:   gemini.ServiceTierStandard,
+			expectedTier: schemas.Ptr(schemas.BifrostServiceTierDefault),
+		},
+		{
+			name:         "flex maps to flex",
+			geminiTier:   gemini.ServiceTierFlex,
+			expectedTier: schemas.Ptr(schemas.BifrostServiceTierFlex),
+		},
+		{
+			name:         "priority maps to priority",
+			geminiTier:   gemini.ServiceTierPriority,
+			expectedTier: schemas.Ptr(schemas.BifrostServiceTierPriority),
+		},
+		{
+			name:         "unspecified maps to auto",
+			geminiTier:   gemini.ServiceTierUnspecified,
+			expectedTier: schemas.Ptr(schemas.BifrostServiceTierAuto),
+		},
+		{
+			name:         "empty leaves service tier nil",
+			geminiTier:   gemini.ServiceTier(""),
+			expectedTier: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			geminiReq := &gemini.GeminiGenerationRequest{
+				Model: "gemini-2.0-flash",
+				Contents: []gemini.Content{
+					{Role: "user", Parts: []*gemini.Part{{Text: "hello"}}},
+				},
+				ServiceTier: tt.geminiTier,
+			}
+			ctx := &schemas.BifrostContext{}
+			bifrostReq := geminiReq.ToBifrostResponsesRequest(ctx)
+			require.NotNil(t, bifrostReq)
+			require.NotNil(t, bifrostReq.Params)
+			assert.Equal(t, tt.expectedTier, bifrostReq.Params.ServiceTier)
+		})
+	}
+}
+
 // TestParallelFunctionCallingConversion tests that multiple consecutive tool responses are properly grouped
 func TestParallelFunctionCallingConversion(t *testing.T) {
 	tests := []struct {

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -62,6 +62,11 @@ func (request *GeminiGenerationRequest) ToBifrostResponsesRequest(ctx *schemas.B
 		params.ExtraParams["safety_settings"] = request.SafetySettings
 	}
 
+	if request.ServiceTier != "" {
+		mapped := mapGeminiServiceTierToBifrost(request.ServiceTier)
+		params.ServiceTier = &mapped
+	}
+
 	if request.CachedContent != "" {
 		params.ExtraParams["cached_content"] = request.CachedContent
 	}
@@ -102,6 +107,10 @@ func ToGeminiResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) (*Gem
 			if bifrostReq.Params.ToolChoice != nil {
 				geminiReq.ToolConfig = convertResponsesToolChoiceToGemini(bifrostReq.Params.ToolChoice)
 			}
+		}
+
+		if bifrostReq.Params.ServiceTier != nil {
+			geminiReq.ServiceTier = mapBifrostServiceTierToGemini(*bifrostReq.Params.ServiceTier)
 		}
 	}
 
@@ -162,6 +171,11 @@ func (response *GenerateContentResponse) ToResponsesBifrostResponsesResponse() *
 
 	// Convert usage information
 	bifrostResp.Usage = ConvertGeminiUsageMetadataToResponsesUsage(response.UsageMetadata)
+
+	if response.UsageMetadata != nil && response.UsageMetadata.ServiceTier != "" {
+		tier := mapGeminiServiceTierToBifrost(response.UsageMetadata.ServiceTier)
+		bifrostResp.ServiceTier = &tier
+	}
 
 	// Convert candidates to Responses output messages
 	if len(response.Candidates) > 0 {
@@ -469,6 +483,12 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 	if bifrostResp.Usage != nil {
 		geminiResp.UsageMetadata = ConvertBifrostResponsesUsageToGeminiUsageMetadata(bifrostResp.Usage)
 	}
+	if bifrostResp.ServiceTier != nil {
+		if geminiResp.UsageMetadata == nil {
+			geminiResp.UsageMetadata = &GenerateContentResponseUsageMetadata{}
+		}
+		geminiResp.UsageMetadata.ServiceTier = mapBifrostServiceTierToGemini(*bifrostResp.ServiceTier)
+	}
 
 	return geminiResp
 }
@@ -721,6 +741,12 @@ func ToGeminiResponsesStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 			// Convert usage metadata if available
 			if bifrostResp.Response.Usage != nil {
 				streamResp.UsageMetadata = ConvertBifrostResponsesUsageToGeminiUsageMetadata(bifrostResp.Response.Usage)
+			}
+			if bifrostResp.Response.ServiceTier != nil {
+				if streamResp.UsageMetadata == nil {
+					streamResp.UsageMetadata = &GenerateContentResponseUsageMetadata{}
+				}
+				streamResp.UsageMetadata.ServiceTier = mapBifrostServiceTierToGemini(*bifrostResp.Response.ServiceTier)
 			}
 
 			// Derive finish reason from StopReason when present
@@ -1810,6 +1836,10 @@ func closeGeminiOpenItems(state *GeminiResponsesStreamState, groundingMetadata *
 		ID:        state.MessageID,
 		CreatedAt: state.CreatedAt,
 		Usage:     bifrostUsage,
+	}
+	if usage != nil && usage.ServiceTier != "" {
+		tier := mapGeminiServiceTierToBifrost(usage.ServiceTier)
+		completedResp.ServiceTier = &tier
 	}
 	if state.Model != nil {
 		completedResp.Model = *state.Model

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -111,13 +111,15 @@ type GeminiGenerationRequest struct {
 	ToolConfig        *ToolConfig              `json:"toolConfig,omitempty"`
 	Labels            map[string]string        `json:"labels,omitempty"`
 	CachedContent     string                   `json:"cachedContent,omitempty"`
-	Stream            bool                     `json:"-"` // Internal field to track streaming requests
-	IsEmbedding       bool                     `json:"-"` // Internal field to track if this is an embedding request
-	IsTranscription   bool                     `json:"-"` // Internal field to track if this is a transcription request
-	IsSpeech          bool                     `json:"-"` // Internal field to track if this is a speech request
-	IsImageGeneration bool                     `json:"-"` // Internal field to track if this is an image generation request
-	IsImageEdit       bool                     `json:"-"` // Internal field to track if this is an image edit request
-	IsCountTokens     bool                     `json:"-"` // Internal field to track if this is a count tokens request
+	// Optional. The service tier to use for the request. For example, ServiceTier.FLEX.
+	ServiceTier       ServiceTier `json:"serviceTier,omitempty"`
+	Stream            bool        `json:"-"` // Internal field to track streaming requests
+	IsEmbedding       bool        `json:"-"` // Internal field to track if this is an embedding request
+	IsTranscription   bool        `json:"-"` // Internal field to track if this is a transcription request
+	IsSpeech          bool        `json:"-"` // Internal field to track if this is a speech request
+	IsImageGeneration bool        `json:"-"` // Internal field to track if this is an image generation request
+	IsImageEdit       bool        `json:"-"` // Internal field to track if this is an image edit request
+	IsCountTokens     bool        `json:"-"` // Internal field to track if this is a count tokens request
 
 	// Imagen-specific fields for :predict endpoint
 	Instances  []ImagenInstance        `json:"instances,omitempty"`
@@ -810,6 +812,20 @@ func (t *Tool) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+// Pricing and performance service tier.
+type ServiceTier string
+
+const (
+	// Default service tier, which is standard.
+	ServiceTierUnspecified ServiceTier = "unspecified"
+	// Flex service tier.
+	ServiceTierFlex ServiceTier = "flex"
+	// Standard service tier.
+	ServiceTierStandard ServiceTier = "standard"
+	// Priority service tier.
+	ServiceTierPriority ServiceTier = "priority"
+)
 
 // GenerationConfig represents generation configuration. You can find API default values and more details at https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig
 // and https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/content-generation-parameters.
@@ -1900,6 +1916,8 @@ type GenerateContentResponseUsageMetadata struct {
 	// Output only. Traffic type. This shows whether a request consumes Pay-As-You-Go or
 	// Provisioned Throughput quota.
 	TrafficType string `json:"trafficType,omitempty"`
+	// Output only. The service tier used to serve the request.
+	ServiceTier ServiceTier `json:"serviceTier,omitempty"`
 }
 
 // GenerateContentResponse represents response message for PredictionService.GenerateContent.

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -353,6 +353,20 @@ func (r *GeminiGenerationRequest) convertGenerationConfigToResponsesParameters()
 	return params
 }
 
+// mapGeminiServiceTierToBifrost converts a Gemini ServiceTier to an OpenAI-compatible BifrostServiceTier.
+func mapGeminiServiceTierToBifrost(tier ServiceTier) schemas.BifrostServiceTier {
+	switch tier {
+	case ServiceTierStandard:
+		return schemas.BifrostServiceTierDefault
+	case ServiceTierFlex:
+		return schemas.BifrostServiceTierFlex
+	case ServiceTierPriority:
+		return schemas.BifrostServiceTierPriority
+	default:
+		return schemas.BifrostServiceTierAuto
+	}
+}
+
 // convertSchemaToFunctionParameters converts genai.Schema to schemas.FunctionParameters
 func convertSchemaToFunctionParameters(schema *Schema) schemas.ToolFunctionParameters {
 	params := schemas.ToolFunctionParameters{
@@ -1226,6 +1240,20 @@ func convertParamsToGenerationConfig(params *schemas.ChatParameters, responseMod
 		}
 	}
 	return config, nil
+}
+
+// mapBifrostServiceTierToGemini converts a BifrostServiceTier to a Gemini ServiceTier.
+func mapBifrostServiceTierToGemini(tier schemas.BifrostServiceTier) ServiceTier {
+	switch tier {
+	case schemas.BifrostServiceTierDefault:
+		return ServiceTierStandard
+	case schemas.BifrostServiceTierFlex:
+		return ServiceTierFlex
+	case schemas.BifrostServiceTierPriority:
+		return ServiceTierPriority
+	default:
+		return ServiceTierUnspecified
+	}
 }
 
 // convertBifrostToolsToGemini converts Bifrost tools to Gemini format

--- a/core/providers/vertex/types.go
+++ b/core/providers/vertex/types.go
@@ -10,6 +10,9 @@ import (
 
 const (
 	DefaultVertexAnthropicVersion = "vertex-2023-10-16"
+
+	// VertexServiceTierHeader is the HTTP header used to request priority or flex processing on the global endpoint.
+	VertexServiceTierHeader = "X-Vertex-AI-LLM-Shared-Request-Type"
 )
 
 // PhoneticEncoding represents the phonetic encoding of a phrase.

--- a/core/providers/vertex/utils.go
+++ b/core/providers/vertex/utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/gemini"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
-	"github.com/maximhq/bifrost/core/schemas"
+	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
 // getRequestBodyForAnthropicResponses serializes a BifrostResponsesRequest into the Anthropic wire format for Vertex AI.
@@ -173,6 +173,71 @@ func getCompleteURLForGeminiEndpoint(deployment string, region string, projectID
 
 	// Gemini models use projectID
 	return getVertexPublisherModelURL(region, "v1", projectID, "google", deployment, method)
+}
+
+// vertexPriorityModels lists model name prefixes that support Priority PayGo on Vertex.
+// Source: https://cloud.google.com/vertex-ai/generative-ai/docs/priority-paygo
+var vertexPriorityModels = []string{
+	"gemini-2.5-pro",
+	"gemini-2.5-flash",
+	"gemini-2.5-flash-lite",
+	"gemini-3-flash-preview",
+	"gemini-3.1-pro-preview",
+	"gemini-3.1-flash-lite",
+}
+
+// vertexFlexModels lists model name prefixes that support Flex PayGo on Vertex.
+// Source: https://cloud.google.com/vertex-ai/generative-ai/docs/flex-paygo
+var vertexFlexModels = []string{
+	"gemini-3.1-flash-lite",
+	"gemini-3.1-flash-image-preview",
+	"gemini-3.1-pro-preview",
+	"gemini-3-flash-preview",
+	"gemini-3-pro-image-preview",
+}
+
+// isVertexModelSupportedForTier reports whether a model supports the given service tier.
+// Custom/fine-tuned models (all-digits IDs) are passed through without restriction since
+// their base model cannot be determined from the ID alone.
+func isVertexModelSupportedForTier(model string, tier schemas.BifrostServiceTier) bool {
+	if schemas.IsAllDigitsASCII(model) {
+		return true
+	}
+	normalized := gemini.NormalizeModelName(model)
+	var prefixes []string
+	switch tier {
+	case schemas.BifrostServiceTierPriority:
+		prefixes = vertexPriorityModels
+	case schemas.BifrostServiceTierFlex:
+		prefixes = vertexFlexModels
+	default:
+		return false
+	}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(normalized, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// vertexServiceTierHeaderValue returns the value for the X-Vertex-AI-LLM-Shared-Request-Type header,
+// or "" if no header should be set. Requires the global endpoint and a supported model.
+func vertexServiceTierHeaderValue(region string, model string, tier schemas.BifrostServiceTier) string {
+	if region != "global" {
+		return ""
+	}
+	if !isVertexModelSupportedForTier(model, tier) {
+		return ""
+	}
+	switch tier {
+	case schemas.BifrostServiceTierPriority:
+		return "priority"
+	case schemas.BifrostServiceTierFlex:
+		return "flex"
+	default:
+		return ""
+	}
 }
 
 // buildResponseFromConfig builds a list models response from configured deployments and allowedModels.

--- a/core/providers/vertex/vertex.go
+++ b/core/providers/vertex/vertex.go
@@ -585,6 +585,12 @@ func (provider *VertexProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
+	if (schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model)) &&
+		request.Params != nil && request.Params.ServiceTier != nil {
+		if v := vertexServiceTierHeaderValue(region, request.Model, *request.Params.ServiceTier); v != "" {
+			req.Header.Set(VertexServiceTierHeader, v)
+		}
+	}
 	// Skip anthropic-beta from context headers — Anthropic models on Vertex use the
 	// anthropic_beta body field instead, and other model families don't use it.
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, []string{anthropic.AnthropicBetaHeader})
@@ -904,6 +910,16 @@ func (provider *VertexProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 			"Cache-Control": "no-cache",
 		}
 
+		if (schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model)) {
+			if _, overridden := provider.networkConfig.ExtraHeaders[VertexServiceTierHeader]; !overridden {
+				if request.Params != nil && request.Params.ServiceTier != nil {
+					if v := vertexServiceTierHeaderValue(region, request.Model, *request.Params.ServiceTier); v != "" {
+						headers[VertexServiceTierHeader] = v
+					}
+				}
+			}
+		}
+
 		// If no auth query, use OAuth2 token
 		if authQuery == "" {
 			tokenSource, err := getAuthTokenSource(key)
@@ -1169,6 +1185,13 @@ func (provider *VertexProvider) Responses(ctx *schemas.BifrostContext, key schem
 
 		req.Header.SetMethod(http.MethodPost)
 		req.Header.SetContentType("application/json")
+		if (schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model)) &&
+			request.Params != nil && request.Params.ServiceTier != nil {
+			if v := vertexServiceTierHeaderValue(region, request.Model, *request.Params.ServiceTier); v != "" {
+				req.Header.Set(VertexServiceTierHeader, v)
+			}
+		}
+
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 		// If auth query is set, add it to the URL
@@ -1378,6 +1401,16 @@ func (provider *VertexProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 		headers := map[string]string{
 			"Accept":        "text/event-stream",
 			"Cache-Control": "no-cache",
+		}
+
+		if schemas.IsGeminiModel(request.Model) || schemas.IsAllDigitsASCII(request.Model) {
+			if _, overridden := provider.networkConfig.ExtraHeaders[VertexServiceTierHeader]; !overridden {
+				if request.Params != nil && request.Params.ServiceTier != nil {
+					if v := vertexServiceTierHeaderValue(region, request.Model, *request.Params.ServiceTier); v != "" {
+						headers[VertexServiceTierHeader] = v
+					}
+				}
+			}
 		}
 
 		// If no auth query, use OAuth2 token
@@ -2518,6 +2551,8 @@ func (provider *VertexProvider) VideoRemix(_ *schemas.BifrostContext, _ schemas.
 // stripVertexGeminiUnsupportedFields removes fields that are not supported by Vertex AI's Gemini API.
 // Specifically, it removes the "id" field from function_call and function_response objects in contents.
 func stripVertexGeminiUnsupportedFields(requestBody *gemini.GeminiGenerationRequest) {
+	// Strip service tier — Vertex uses HTTP headers for this, not the request body.
+	requestBody.ServiceTier = ""
 	for _, content := range requestBody.Contents {
 		for _, part := range content.Parts {
 			// Remove id from function_call
@@ -2568,6 +2603,13 @@ func stripVertexGeminiUnsupportedFieldsRaw(jsonBody []byte) []byte {
 		contentIndex++
 		return true
 	})
+
+	// Strip top-level serviceTier — Vertex uses HTTP headers for this, not the request body.
+	if providerUtils.JSONFieldExists(out, "serviceTier") {
+		if updated, err := providerUtils.DeleteJSONField(out, "serviceTier"); err == nil {
+			out = updated
+		}
+	}
 
 	return out
 }

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -39,7 +39,7 @@ type BifrostChatResponse struct {
 	Created           int                        `json:"created"` // The Unix timestamp (in seconds).
 	Model             string                     `json:"model"`
 	Object            string                     `json:"object"` // "chat.completion" or "chat.completion.chunk"
-	ServiceTier       *string                    `json:"service_tier,omitempty"`
+	ServiceTier       *BifrostServiceTier        `json:"service_tier,omitempty"`
 	SystemFingerprint string                     `json:"system_fingerprint"`
 	Usage             *BifrostLLMUsage           `json:"usage"`
 	ExtraFields       BifrostResponseExtraFields `json:"extra_fields"`
@@ -205,7 +205,7 @@ type ChatParameters struct {
 	ResponseFormat       *interface{}          `json:"response_format,omitempty"`        // Format for the response
 	SafetyIdentifier     *string               `json:"safety_identifier,omitempty"`      // Safety identifier
 	Seed                 *int                  `json:"seed,omitempty"`
-	ServiceTier          *string               `json:"service_tier,omitempty"`
+	ServiceTier          *BifrostServiceTier   `json:"service_tier,omitempty"`
 	StreamOptions        *ChatStreamOptions    `json:"stream_options,omitempty"`
 	Stop                 []string              `json:"stop,omitempty"`
 	Store                *bool                 `json:"store,omitempty"`
@@ -1480,6 +1480,17 @@ const (
 	BifrostFinishReasonStop      BifrostFinishReason = "stop"
 	BifrostFinishReasonLength    BifrostFinishReason = "length"
 	BifrostFinishReasonToolCalls BifrostFinishReason = "tool_calls"
+)
+
+// BifrostServiceTier represents the service tier for a request/response.
+type BifrostServiceTier string
+
+// BifrostServiceTier values
+const (
+	BifrostServiceTierAuto     BifrostServiceTier = "auto"
+	BifrostServiceTierDefault  BifrostServiceTier = "default"
+	BifrostServiceTierFlex     BifrostServiceTier = "flex"
+	BifrostServiceTierPriority BifrostServiceTier = "priority"
 )
 
 type BifrostReasoningDetailsType string

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -71,7 +71,7 @@ type BifrostResponsesResponse struct {
 	FrequencyPenalty   *float64                            `json:"frequency_penalty,omitempty"`
 	Reasoning          *ResponsesParametersReasoning       `json:"reasoning"`         // Configuration options for reasoning models
 	SafetyIdentifier   *string                             `json:"safety_identifier"` // Safety identifier
-	ServiceTier        *string                             `json:"service_tier"`
+	ServiceTier        *BifrostServiceTier                 `json:"service_tier"`
 	Status             *string                             `json:"status,omitempty"` // completed, failed, in_progress, cancelled, queued, or incomplete
 	StreamOptions      *ResponsesStreamOptions             `json:"stream_options,omitempty"`
 	StopReason         *string                             `json:"stop_reason,omitempty"` // Not in OpenAI's spec, but sent by other providers
@@ -175,7 +175,17 @@ func (resp *BifrostResponsesResponse) WithDefaults() *BifrostResponsesResponse {
 	// Response configuration - defaults: standard behavior
 	result.Store = orDefault(resp.Store, true)
 	result.Background = orDefault(resp.Background, false)
-	result.ServiceTier = orDefault(resp.ServiceTier, "auto")
+
+	if resp.ServiceTier != nil {
+		switch *resp.ServiceTier {
+		case BifrostServiceTierAuto, BifrostServiceTierDefault, BifrostServiceTierFlex, BifrostServiceTierPriority:
+			result.ServiceTier = resp.ServiceTier
+		default:
+			result.ServiceTier = new(BifrostServiceTierAuto)
+		}
+	} else {
+		result.ServiceTier = new(BifrostServiceTierAuto)
+	}
 	result.Truncation = orDefault(resp.Truncation, "disabled")
 	result.ParallelToolCalls = orDefault(resp.ParallelToolCalls, true)
 
@@ -255,7 +265,7 @@ type ResponsesParameters struct {
 	PromptCacheKey     *string                       `json:"prompt_cache_key,omitempty"`  // Prompt cache key
 	Reasoning          *ResponsesParametersReasoning `json:"reasoning,omitempty"`         // Configuration options for reasoning models
 	SafetyIdentifier   *string                       `json:"safety_identifier,omitempty"` // Safety identifier
-	ServiceTier        *string                       `json:"service_tier,omitempty"`
+	ServiceTier        *BifrostServiceTier           `json:"service_tier,omitempty"`
 	StreamOptions      *ResponsesStreamOptions       `json:"stream_options,omitempty"`
 	Store              *bool                         `json:"store,omitempty"`
 	Temperature        *float64                      `json:"temperature,omitempty"`

--- a/framework/modelcatalog/pricing.go
+++ b/framework/modelcatalog/pricing.go
@@ -892,14 +892,14 @@ func computeOCRCost(pricing *configstoreTables.TableModelPricing, ocrProcessedPa
 // ---------------------------------------------------------------------------
 
 // tierFromString constructs a serviceTier from an OpenAI service_tier response value.
-func tierFromString(s *string) serviceTier {
+func tierFromString(s *schemas.BifrostServiceTier) serviceTier {
 	if s == nil {
 		return serviceTier{}
 	}
 	switch *s {
-	case "priority":
+	case schemas.BifrostServiceTierPriority:
 		return serviceTier{isPriority: true}
-	case "flex":
+	case schemas.BifrostServiceTierFlex:
 		return serviceTier{isFlex: true}
 	default:
 		return serviceTier{}

--- a/framework/modelcatalog/pricing_test.go
+++ b/framework/modelcatalog/pricing_test.go
@@ -1856,7 +1856,7 @@ func TestComputeTextCost_PriorityCacheReadRate(t *testing.T) {
 }
 
 func TestCalculateCost_PriorityTier_EndToEnd(t *testing.T) {
-	tierStr := "priority"
+	tier := schemas.BifrostServiceTierPriority
 	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("gpt-4o", "openai", "chat"): {
 			Model:                      "gpt-4o",
@@ -1871,7 +1871,7 @@ func TestCalculateCost_PriorityTier_EndToEnd(t *testing.T) {
 
 	resp := &schemas.BifrostResponse{
 		ChatResponse: &schemas.BifrostChatResponse{
-			ServiceTier: &tierStr,
+			ServiceTier: &tier,
 			Usage: &schemas.BifrostLLMUsage{
 				PromptTokens:     1000,
 				CompletionTokens: 500,
@@ -1892,7 +1892,7 @@ func TestCalculateCost_PriorityTier_EndToEnd(t *testing.T) {
 }
 
 func TestCalculateCost_NonPriorityServiceTier_UsesBaseRate(t *testing.T) {
-	tierStr := "auto"
+	tier := schemas.BifrostServiceTierAuto
 	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("gpt-4o", "openai", "chat"): {
 			Model:                      "gpt-4o",
@@ -1907,7 +1907,7 @@ func TestCalculateCost_NonPriorityServiceTier_UsesBaseRate(t *testing.T) {
 
 	resp := &schemas.BifrostResponse{
 		ChatResponse: &schemas.BifrostChatResponse{
-			ServiceTier: &tierStr,
+			ServiceTier: &tier,
 			Usage: &schemas.BifrostLLMUsage{
 				PromptTokens:     1000,
 				CompletionTokens: 500,
@@ -2010,21 +2010,21 @@ func TestTieredCacheReadRate_FallbackOrder(t *testing.T) {
 // =========================================================================
 
 func TestTierFromString_Priority(t *testing.T) {
-	s := "priority"
+	s := schemas.BifrostServiceTierPriority
 	tier := tierFromString(&s)
 	assert.True(t, tier.isPriority)
 	assert.False(t, tier.isFlex)
 }
 
 func TestTierFromString_Flex(t *testing.T) {
-	s := "flex"
+	s := schemas.BifrostServiceTierFlex
 	tier := tierFromString(&s)
 	assert.False(t, tier.isPriority)
 	assert.True(t, tier.isFlex)
 }
 
 func TestTierFromString_Default(t *testing.T) {
-	for _, s := range []string{"auto", "default", "", "unknown"} {
+	for _, s := range []schemas.BifrostServiceTier{schemas.BifrostServiceTierAuto, schemas.BifrostServiceTierDefault, ""} {
 		tier := tierFromString(&s)
 		assert.False(t, tier.isPriority, "expected no priority for %q", s)
 		assert.False(t, tier.isFlex, "expected no flex for %q", s)
@@ -2137,7 +2137,7 @@ func TestComputeTextCost_FlexFallsBackToBaseWhenNoFlexRate(t *testing.T) {
 }
 
 func TestCalculateCost_FlexTier_EndToEnd(t *testing.T) {
-	tierStr := "flex"
+	tier := schemas.BifrostServiceTierFlex
 	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("gpt-4o", "openai", "chat"): {
 			Model:                  "gpt-4o",
@@ -2152,7 +2152,7 @@ func TestCalculateCost_FlexTier_EndToEnd(t *testing.T) {
 
 	resp := &schemas.BifrostResponse{
 		ChatResponse: &schemas.BifrostChatResponse{
-			ServiceTier: &tierStr,
+			ServiceTier: &tier,
 			Usage: &schemas.BifrostLLMUsage{
 				PromptTokens:     1000,
 				CompletionTokens: 500,
@@ -2173,14 +2173,14 @@ func TestCalculateCost_FlexTier_EndToEnd(t *testing.T) {
 }
 
 func TestCalculateCost_FlexTier_FallsBackToBaseWhenNoFlexRate(t *testing.T) {
-	tierStr := "flex"
+	tier := schemas.BifrostServiceTierFlex
 	mc := testCatalogWithPricing(map[string]configstoreTables.TableModelPricing{
 		makeKey("gpt-4o", "openai", "chat"): chatPricing(0.000005, 0.000015),
 	})
 
 	resp := &schemas.BifrostResponse{
 		ChatResponse: &schemas.BifrostChatResponse{
-			ServiceTier: &tierStr,
+			ServiceTier: &tier,
 			Usage: &schemas.BifrostLLMUsage{
 				PromptTokens:     1000,
 				CompletionTokens: 500,

--- a/plugins/semanticcache/plugin_responses_test.go
+++ b/plugins/semanticcache/plugin_responses_test.go
@@ -436,11 +436,12 @@ func TestResponsesAPIComplexParameters(t *testing.T) {
 	ctx := CreateContextWithCacheKey(t, "test-responses-complex-params")
 
 	// Create request with various complex parameters
+	serviceTier := schemas.BifrostServiceTierDefault
 	request := CreateBasicResponsesRequest("Test complex parameters", 0.8, 500)
 	request.Params.TopP = PtrFloat64(0.9)
 	request.Params.Background = &[]bool{true}[0]
 	request.Params.ParallelToolCalls = &[]bool{false}[0]
-	request.Params.ServiceTier = &[]string{"default"}[0]
+	request.Params.ServiceTier = &serviceTier
 	request.Params.Store = &[]bool{true}[0]
 
 	t.Log("Making first Responses request with complex parameters...")
@@ -457,7 +458,7 @@ func TestResponsesAPIComplexParameters(t *testing.T) {
 	request2.Params.TopP = PtrFloat64(0.9)
 	request2.Params.Background = &[]bool{true}[0]
 	request2.Params.ParallelToolCalls = &[]bool{false}[0]
-	request2.Params.ServiceTier = &[]string{"default"}[0]
+	request2.Params.ServiceTier = &serviceTier
 	request2.Params.Store = &[]bool{true}[0]
 
 	t.Log("Making second identical Responses request with complex parameters...")


### PR DESCRIPTION
## Summary

Adds proper `service_tier` translation between Bifrost's OpenAI-compatible values and the native wire formats for Anthropic and Gemini providers, rather than passing the raw string through unchanged.

## Changes

- Introduced four mapping helpers in the Anthropic provider (`MapBifrostServiceTierToAnthropicRequest`, `MapAnthropicRequestServiceTierToBifrost`, `MapAnthropicServiceTierToBifrost`, `MapBifrostServiceTierToAnthropicResponse`) to translate between Bifrost values (`auto`, `default`, `priority`, `flex`) and Anthropic's request values (`auto`, `standard_only`) and response values (`standard`, `priority`, `batch`).
- Applied these mappers in both the chat and responses conversion paths for Anthropic, covering request encoding and response decoding in both directions.
- Added a `ServiceTier` typed string and constants (`unspecified`, `flex`, `standard`, `priority`) to the Gemini types, along with a `ServiceTier` field on `GenerationConfig`.
- Introduced `mapBifrostServiceTierToGemini` and `mapGeminiServiceTierToBifrost` helpers and wired them into both the chat and responses parameter conversion paths for Gemini.
- Added tests covering forward and reverse service tier mapping for Gemini chat, responses, and the reverse-mapping path from a `GeminiGenerationRequest` back to a `BifrostResponsesRequest`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/anthropic/...
go test ./core/providers/gemini/...
```

The new Gemini tests (`TestServiceTierMappingChat`, `TestServiceTierMappingResponses`, `TestServiceTierReverseMapping`) exercise all tier values in both directions. Verify that:
- Bifrost `"default"` → Anthropic request `"standard_only"`, Gemini `"standard"`
- Bifrost `"auto"` / `"priority"` → Anthropic request `"auto"`
- Anthropic response `"standard"` → Bifrost `"default"`
- Gemini `"flex"` / `"priority"` round-trip correctly through Bifrost

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable