### PR TITLE
update mcp logs for dac

### DIFF
--- a/framework/cmd/e2eseed/main.go
+++ b/framework/cmd/e2eseed/main.go
@@ -30,7 +30,7 @@ func run(ctx context.Context, args []string) error {
 	fs.StringVar(&opts.ConfigDSN, "config-db-dsn", opts.ConfigDSN, "config DB DSN")
 	fs.StringVar(&opts.LogsDialect, "logs-db-dialect", opts.LogsDialect, "logs DB dialect: postgres or sqlite")
 	fs.StringVar(&opts.LogsDSN, "logs-db-dsn", opts.LogsDSN, "logs DB DSN")
-	fs.IntVar(&opts.LogRows, "logs", opts.LogRows, "number of log rows to seed")
+	fs.IntVar(&opts.LogRowsPerShape, "logs-per-shape", opts.LogRowsPerShape, "number of log rows to seed per DAC ownership shape (applied to both logs and mcp_tool_logs)")
 	fs.IntVar(&opts.BatchSize, "batch-size", opts.BatchSize, "log insert batch size")
 	fs.StringVar(&opts.OutputEnvPath, "output-env", opts.OutputEnvPath, "path for generated environment values")
 	fs.StringVar(&summaryPath, "summary", "", "optional JSON summary path")
@@ -68,6 +68,6 @@ func run(ctx context.Context, args []string) error {
 			return err
 		}
 	}
-	fmt.Printf("seeded OSS API e2e data prefix=%s logs=%d env=%s\n", summary.Prefix, summary.LogRows, opts.OutputEnvPath)
+	fmt.Printf("seeded OSS API e2e data prefix=%s logs_per_shape=%d shapes=%d env=%s\n", summary.Prefix, summary.LogRowsPerShape, len(summary.Expected.Shapes), opts.OutputEnvPath)
 	return nil
 }

--- a/framework/e2eseed/seed.go
+++ b/framework/e2eseed/seed.go
@@ -25,17 +25,17 @@ import (
 
 // Options controls the shared seed dataset.
 type Options struct {
-	Prefix        string
-	ConfigPath    string
-	EncryptionKey string
-	ConfigDialect string
-	ConfigDSN     string
-	LogsDialect   string
-	LogsDSN       string
-	LogRows       int
-	BatchSize     int
-	OutputEnvPath string
-	DryRun        bool
+	Prefix          string
+	ConfigPath      string
+	EncryptionKey   string
+	ConfigDialect   string
+	ConfigDSN       string
+	LogsDialect     string
+	LogsDSN         string
+	LogRowsPerShape int
+	BatchSize       int
+	OutputEnvPath   string
+	DryRun          bool
 }
 
 // Shape describes one DAC ownership combination.
@@ -52,21 +52,22 @@ type Shape struct {
 
 // ExpectedManifest records seeded IDs and expected DAC visibility.
 type ExpectedManifest struct {
-	Prefix   string              `json:"prefix"`
-	Personas map[string]string   `json:"personas"`
-	Shapes   []Shape             `json:"shapes"`
-	LogIDs   map[string][]string `json:"log_ids"`
+	Prefix    string              `json:"prefix"`
+	Personas  map[string]string   `json:"personas"`
+	Shapes    []Shape             `json:"shapes"`
+	LogIDs    map[string][]string `json:"log_ids"`
+	MCPLogIDs map[string][]string `json:"mcp_log_ids"`
 }
 
 // Summary is returned after a seed run.
 type Summary struct {
-	Prefix      string            `json:"prefix"`
-	LogRows     int               `json:"log_rows"`
-	SeedEnv     map[string]string `json:"seed_env"`
-	Expected    ExpectedManifest  `json:"expected"`
-	TableCounts map[string]int64  `json:"table_counts"`
-	DryRun      bool              `json:"dry_run"`
-	GeneratedAt time.Time         `json:"generated_at"`
+	Prefix          string            `json:"prefix"`
+	LogRowsPerShape int               `json:"log_rows_per_shape"`
+	SeedEnv         map[string]string `json:"seed_env"`
+	Expected        ExpectedManifest  `json:"expected"`
+	TableCounts     map[string]int64  `json:"table_counts"`
+	DryRun          bool              `json:"dry_run"`
+	GeneratedAt     time.Time         `json:"generated_at"`
 }
 
 // seedBaseTime is the per-run anchor timestamp for seeded log rows. We set it
@@ -78,12 +79,12 @@ var seedBaseTime = time.Now().UTC()
 // DefaultOptions returns defaults for local e2e seeding.
 func DefaultOptions() Options {
 	return Options{
-		Prefix:        "e2e-seed",
-		ConfigDialect: "postgres",
-		LogsDialect:   "postgres",
-		LogRows:       100000,
-		BatchSize:     1000,
-		OutputEnvPath: "tmp/e2e-seed.env",
+		Prefix:          "e2e-seed",
+		ConfigDialect:   "postgres",
+		LogsDialect:     "postgres",
+		LogRowsPerShape: 30,
+		BatchSize:       1000,
+		OutputEnvPath:   "tmp/e2e-seed.env",
 	}
 }
 
@@ -129,8 +130,8 @@ func NormalizeOptions(opts Options) (Options, error) {
 	if opts.LogsDSN == "" {
 		opts.LogsDSN = "postgres://bifrost:bifrost_password@localhost:5432/bifrost?sslmode=disable"
 	}
-	if opts.LogRows <= 0 {
-		opts.LogRows = def.LogRows
+	if opts.LogRowsPerShape <= 0 {
+		opts.LogRowsPerShape = def.LogRowsPerShape
 	}
 	if opts.BatchSize <= 0 {
 		opts.BatchSize = def.BatchSize
@@ -258,15 +259,15 @@ func SeedBase(ctx context.Context, configDB, logsDB *gorm.DB, opts Options) (*Su
 	}
 	InitEncryption(opts)
 	env := SeedEnv(opts.Prefix)
-	manifest := BuildExpectedManifest(opts.Prefix, opts.LogRows)
+	manifest := BuildExpectedManifest(opts.Prefix, opts.LogRowsPerShape)
 	summary := &Summary{
-		Prefix:      opts.Prefix,
-		LogRows:     opts.LogRows,
-		SeedEnv:     env,
-		Expected:    manifest,
-		TableCounts: map[string]int64{},
-		DryRun:      opts.DryRun,
-		GeneratedAt: time.Now().UTC(),
+		Prefix:          opts.Prefix,
+		LogRowsPerShape: opts.LogRowsPerShape,
+		SeedEnv:         env,
+		Expected:        manifest,
+		TableCounts:     map[string]int64{},
+		DryRun:          opts.DryRun,
+		GeneratedAt:     time.Now().UTC(),
 	}
 	if opts.DryRun {
 		return summary, nil
@@ -305,6 +306,22 @@ func SeedEnv(prefix string) map[string]string {
 }
 
 // BuildShapes returns the DAC ownership matrix.
+//
+// The set is built by enumerating all 15 non-empty subsets of the four DAC
+// dimensions {VirtualKey, UserID, TeamID, BusinessUnitID}, all flavoured with
+// tiggings-side values so the tiggings-flavoured personas see them, plus
+// three appended shapes for negative coverage:
+//   - user-not-in-tiggings: outside user + BU (cross-team isolation)
+//   - outside-team-virtual-key: outside user + team + BU + VK
+//   - legacy-unowned: no DAC dimensions (fail-closed for non-admin)
+//
+// CustomerID is set together with BusinessUnitID when the B dimension is
+// present; the two columns are conceptually paired in the seeded dataset.
+//
+// The VirtualKey value for each tiggings shape is teamVK when the team
+// dimension is present without a user, so the team-only VK ownership path
+// (governance_virtual_keys.team_id) gets exercised. Every other VK-bearing
+// shape uses userVK so the user-attached VK ownership path is exercised too.
 func BuildShapes(prefix string) []Shape {
 	tiggingsUser := prefix + "-user-tiggings"
 	outsideUser := prefix + "-user-outside"
@@ -317,28 +334,145 @@ func BuildShapes(prefix string) []Shape {
 	userVK := prefix + "-vk-user-team"
 	teamVK := prefix + "-vk-team-only"
 	outsideVK := prefix + "-vk-outside"
-	return []Shape{
-		{Name: "user-in-tiggings", UserID: tiggingsUser, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, Marker: prefix + "-shape-user-in-tiggings", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin"}},
-		{Name: "user-not-in-tiggings", UserID: outsideUser, CustomerID: outsideCustomer, BusinessUnitID: outsideBU, Marker: prefix + "-shape-user-not-in-tiggings", VisibleTo: []string{"own_reader_outside", "team_reader_outside", "all_data_admin"}},
-		{Name: "only-user", UserID: tiggingsUser, Marker: prefix + "-shape-only-user", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin"}},
-		{Name: "only-team", TeamID: tiggingsTeam, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, Marker: prefix + "-shape-only-team", VisibleTo: []string{"team_reader_tiggings", "all_data_admin", "vk_team_owned"}},
-		{Name: "only-virtual-key", VirtualKeyID: userVK, Marker: prefix + "-shape-only-vk", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin", "vk_user_owned"}},
-		{Name: "user-team", UserID: tiggingsUser, TeamID: tiggingsTeam, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, Marker: prefix + "-shape-user-team", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin"}},
-		{Name: "user-virtual-key", UserID: tiggingsUser, VirtualKeyID: userVK, Marker: prefix + "-shape-user-vk", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin", "vk_user_owned"}},
-		{Name: "team-virtual-key", TeamID: tiggingsTeam, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, VirtualKeyID: teamVK, Marker: prefix + "-shape-team-vk", VisibleTo: []string{"team_reader_tiggings", "all_data_admin", "vk_team_owned"}},
-		{Name: "user-team-virtual-key", UserID: tiggingsUser, TeamID: tiggingsTeam, CustomerID: tiggingsCustomer, BusinessUnitID: tiggingsBU, VirtualKeyID: userVK, Marker: prefix + "-shape-user-team-vk", VisibleTo: []string{"own_reader_tiggings", "team_reader_tiggings", "all_data_admin", "vk_user_owned"}},
-		{Name: "outside-team-virtual-key", UserID: outsideUser, TeamID: outsideTeam, CustomerID: outsideCustomer, BusinessUnitID: outsideBU, VirtualKeyID: outsideVK, Marker: prefix + "-shape-outside-team-vk", VisibleTo: []string{"own_reader_outside", "team_reader_outside", "all_data_admin"}},
-		{Name: "legacy-unowned", Marker: prefix + "-shape-legacy-unowned", VisibleTo: []string{"all_data_admin"}},
+
+	shapes := make([]Shape, 0, 18)
+	for mask := 1; mask <= 15; mask++ {
+		hasVK := mask&0x1 != 0
+		hasU := mask&0x2 != 0
+		hasT := mask&0x4 != 0
+		hasB := mask&0x8 != 0
+
+		shape := Shape{Name: shapeNameFromDims(hasVK, hasU, hasT, hasB)}
+		if hasVK {
+			if hasT && !hasU {
+				shape.VirtualKeyID = teamVK
+			} else {
+				shape.VirtualKeyID = userVK
+			}
+		}
+		if hasU {
+			shape.UserID = tiggingsUser
+		}
+		if hasT {
+			shape.TeamID = tiggingsTeam
+		}
+		if hasB {
+			shape.BusinessUnitID = tiggingsBU
+			shape.CustomerID = tiggingsCustomer
+		}
+		shape.Marker = prefix + "-shape-" + shape.Name
+		shape.VisibleTo = computeVisibleTo(shape, tiggingsUser, outsideUser, tiggingsTeam, outsideTeam, userVK, teamVK, outsideVK)
+		shapes = append(shapes, shape)
 	}
+
+	shapes = append(shapes,
+		Shape{
+			Name:           "user-not-in-tiggings",
+			UserID:         outsideUser,
+			CustomerID:     outsideCustomer,
+			BusinessUnitID: outsideBU,
+			Marker:         prefix + "-shape-user-not-in-tiggings",
+			VisibleTo:      []string{"all_data_admin", "own_reader_outside", "team_reader_outside"},
+		},
+		Shape{
+			Name:           "outside-team-virtual-key",
+			UserID:         outsideUser,
+			TeamID:         outsideTeam,
+			CustomerID:     outsideCustomer,
+			BusinessUnitID: outsideBU,
+			VirtualKeyID:   outsideVK,
+			Marker:         prefix + "-shape-outside-team-vk",
+			VisibleTo:      []string{"all_data_admin", "own_reader_outside", "team_reader_outside"},
+		},
+		Shape{
+			Name:      "legacy-unowned",
+			Marker:    prefix + "-shape-legacy-unowned",
+			VisibleTo: []string{"all_data_admin"},
+		},
+	)
+	return shapes
 }
 
-// BuildExpectedManifest returns the expected DAC visibility document.
-func BuildExpectedManifest(prefix string, logRows int) ExpectedManifest {
+// shapeNameFromDims returns a deterministic kebab-case name for the given
+// dimension presence flags. Single-dimension shapes are prefixed with "only-"
+// so the matrix reads naturally in the manifest.
+func shapeNameFromDims(hasVK, hasU, hasT, hasB bool) string {
+	var parts []string
+	if hasVK {
+		parts = append(parts, "virtual-key")
+	}
+	if hasU {
+		parts = append(parts, "user")
+	}
+	if hasT {
+		parts = append(parts, "team")
+	}
+	if hasB {
+		parts = append(parts, "business-unit")
+	}
+	if len(parts) == 1 {
+		return "only-" + parts[0]
+	}
+	return strings.Join(parts, "-")
+}
+
+// computeVisibleTo returns the sorted set of personas that can see rows of the
+// given shape, derived directly from the shape's DAC dimensions and the
+// well-known seeded principal/VK values.
+func computeVisibleTo(s Shape, tigU, outU, tigT, outT, userVK, teamVK, outVK string) []string {
+	set := map[string]struct{}{"all_data_admin": {}}
+
+	switch s.UserID {
+	case tigU:
+		set["own_reader_tiggings"] = struct{}{}
+		set["team_reader_tiggings"] = struct{}{}
+	case outU:
+		set["own_reader_outside"] = struct{}{}
+		set["team_reader_outside"] = struct{}{}
+	}
+
+	switch s.TeamID {
+	case tigT:
+		set["team_reader_tiggings"] = struct{}{}
+	case outT:
+		set["team_reader_outside"] = struct{}{}
+	}
+
+	switch s.VirtualKeyID {
+	case userVK:
+		set["vk_user_owned"] = struct{}{}
+		set["own_reader_tiggings"] = struct{}{}
+		set["team_reader_tiggings"] = struct{}{}
+	case teamVK:
+		set["vk_team_owned"] = struct{}{}
+		set["team_reader_tiggings"] = struct{}{}
+	case outVK:
+		set["own_reader_outside"] = struct{}{}
+		set["team_reader_outside"] = struct{}{}
+	}
+
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// BuildExpectedManifest returns the expected DAC visibility document. Each
+// shape gets logRowsPerShape contiguous log IDs and an equal number of MCP
+// log IDs so visibility tests can assert exact set membership for either
+// table.
+func BuildExpectedManifest(prefix string, logRowsPerShape int) ExpectedManifest {
 	shapes := BuildShapes(prefix)
 	logIDs := make(map[string][]string, len(shapes))
-	for i := 0; i < logRows; i++ {
-		shape := shapes[i%len(shapes)]
-		logIDs[shape.Name] = append(logIDs[shape.Name], fmt.Sprintf("%s-log-%06d", prefix, i))
+	mcpLogIDs := make(map[string][]string, len(shapes))
+	for shapeIdx, shape := range shapes {
+		for j := 0; j < logRowsPerShape; j++ {
+			i := shapeIdx*logRowsPerShape + j
+			logIDs[shape.Name] = append(logIDs[shape.Name], fmt.Sprintf("%s-log-%06d", prefix, i))
+			mcpLogIDs[shape.Name] = append(mcpLogIDs[shape.Name], fmt.Sprintf("%s-mcp-log-%06d", prefix, i))
+		}
 	}
 	return ExpectedManifest{
 		Prefix: prefix,
@@ -351,8 +485,9 @@ func BuildExpectedManifest(prefix string, logRows int) ExpectedManifest {
 			"vk_user_owned":        prefix + "-vk-user-team",
 			"vk_team_owned":        prefix + "-vk-team-only",
 		},
-		Shapes: shapes,
-		LogIDs: logIDs,
+		Shapes:    shapes,
+		LogIDs:    logIDs,
+		MCPLogIDs: mcpLogIDs,
 	}
 }
 
@@ -520,21 +655,25 @@ func seedMCP(ctx context.Context, db *gorm.DB, prefix string, now time.Time) err
 	return db.WithContext(ctx).Where("client_id = ?", client.ClientID).Assign(client).FirstOrCreate(&client).Error
 }
 
-// seedLogs writes the DAC matrix logs.
+// seedLogs writes the DAC matrix LLM logs. Each shape gets exactly
+// opts.LogRowsPerShape rows, so admin sees len(shapes) * LogRowsPerShape
+// total.
 func seedLogs(ctx context.Context, db *gorm.DB, opts Options, manifest ExpectedManifest) error {
 	if db == nil {
 		return fmt.Errorf("logs db is required")
 	}
 	shapes := manifest.Shapes
 	batch := make([]logstore.Log, 0, opts.BatchSize)
-	for i := 0; i < opts.LogRows; i++ {
-		shape := shapes[i%len(shapes)]
-		batch = append(batch, buildLog(opts.Prefix, shape, i))
-		if len(batch) == opts.BatchSize {
-			if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
-				return err
+	for shapeIdx, shape := range shapes {
+		for j := 0; j < opts.LogRowsPerShape; j++ {
+			i := shapeIdx*opts.LogRowsPerShape + j
+			batch = append(batch, buildLog(opts.Prefix, shape, i))
+			if len(batch) == opts.BatchSize {
+				if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
+					return err
+				}
+				batch = batch[:0]
 			}
-			batch = batch[:0]
 		}
 	}
 	if len(batch) > 0 {
@@ -542,22 +681,83 @@ func seedLogs(ctx context.Context, db *gorm.DB, opts Options, manifest ExpectedM
 			return err
 		}
 	}
-	return seedLogCompanions(ctx, db, opts.Prefix)
-}
-
-// seedLogCompanions writes one MCP log and one async job for log-adjacent APIs.
-func seedLogCompanions(ctx context.Context, db *gorm.DB, prefix string) error {
-	now := seedBaseTime
-	vk := prefix + "-vk-user-team"
-	latency := float64(25)
-	cost := 0.001
-	mcp := logstore.MCPToolLog{ID: prefix + "-mcp-log", RequestID: prefix + "-request", Timestamp: now, ToolName: "e2e-tool", ServerLabel: "e2e-mcp", VirtualKeyID: &vk, VirtualKeyName: ptr("E2E User Team VK"), ArgumentsParsed: map[string]any{"seed": prefix}, ResultParsed: map[string]any{"ok": true}, Latency: &latency, Cost: &cost, Status: "success", MetadataParsed: map[string]any{"seed_prefix": prefix}}
-	if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&mcp).Error; err != nil {
+	if err := seedMCPLogs(ctx, db, opts, manifest); err != nil {
 		return err
 	}
+	return seedAsyncJobCompanion(ctx, db, opts.Prefix)
+}
+
+// seedMCPLogs writes the DAC matrix MCP tool logs in the same shape and
+// volume as the LLM logs so MCP visibility tests can assert against the
+// expected.mcp_log_ids manifest the same way the LLM tests do.
+func seedMCPLogs(ctx context.Context, db *gorm.DB, opts Options, manifest ExpectedManifest) error {
+	shapes := manifest.Shapes
+	batch := make([]logstore.MCPToolLog, 0, opts.BatchSize)
+	for shapeIdx, shape := range shapes {
+		for j := 0; j < opts.LogRowsPerShape; j++ {
+			i := shapeIdx*opts.LogRowsPerShape + j
+			batch = append(batch, buildMCPLog(opts.Prefix, shape, i))
+			if len(batch) == opts.BatchSize {
+				if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
+					return err
+				}
+				batch = batch[:0]
+			}
+		}
+	}
+	if len(batch) > 0 {
+		if err := db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&batch).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// seedAsyncJobCompanion writes one async-job row tied to the seeded user VK
+// so the /api/async-jobs CRUD coverage has a deterministic fixture to read.
+func seedAsyncJobCompanion(ctx context.Context, db *gorm.DB, prefix string) error {
+	now := seedBaseTime
+	vk := prefix + "-vk-user-team"
 	completed := now
 	job := logstore.AsyncJob{ID: prefix + "-async-job", Status: schemas.AsyncJobStatusCompleted, RequestType: schemas.ChatCompletionRequest, Response: `{}`, StatusCode: 200, VirtualKeyID: &vk, ResultTTL: 3600, CreatedAt: now, CompletedAt: &completed}
 	return db.WithContext(ctx).Clauses(clause.OnConflict{UpdateAll: true}).Create(&job).Error
+}
+
+// buildMCPLog returns one deterministic MCP tool log row mirroring the DAC
+// dimensions of the shape so the same persona/visibility logic that drives
+// LLM log tests applies here.
+func buildMCPLog(prefix string, shape Shape, index int) logstore.MCPToolLog {
+	timestamp := seedBaseTime.Add(-time.Duration(index) * time.Second)
+	vkName := ""
+	if shape.VirtualKeyID != "" {
+		vkName = "E2E " + shape.VirtualKeyID
+	}
+	latency := float64(20 + index%200)
+	cost := float64(1+index%50) / 100000
+	status := "success"
+	if index%19 == 0 {
+		status = "error"
+	}
+	return logstore.MCPToolLog{
+		ID:              fmt.Sprintf("%s-mcp-log-%06d", prefix, index),
+		RequestID:       fmt.Sprintf("%s-mcp-req-%06d", prefix, index),
+		Timestamp:       timestamp,
+		ToolName:        "e2e-tool",
+		ServerLabel:     "e2e-mcp",
+		VirtualKeyID:    emptyPtr(shape.VirtualKeyID),
+		VirtualKeyName:  emptyPtr(vkName),
+		UserID:          emptyPtr(shape.UserID),
+		TeamID:          emptyPtr(shape.TeamID),
+		CustomerID:      emptyPtr(shape.CustomerID),
+		BusinessUnitID:  emptyPtr(shape.BusinessUnitID),
+		ArgumentsParsed: map[string]any{"seed_prefix": prefix, "shape": shape.Name, "marker": shape.Marker, "index": index},
+		ResultParsed:    map[string]any{"ok": true},
+		Latency:         &latency,
+		Cost:            &cost,
+		Status:          status,
+		MetadataParsed:  map[string]any{"seed_prefix": prefix, "shape": shape.Name, "marker": shape.Marker},
+		CreatedAt:       timestamp,
+	}
 }
 
 // buildLog returns one deterministic log row.

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -327,6 +327,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationAddSafeJsonbFunction(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddDACColumnsToMCPToolLogs(ctx, db); err != nil {
+		return err
+	}
 	// migrationSplitFilterDataMatView is intentionally NOT invoked in this
 	// release. Dropping mv_logs_filterdata while old replicas are still
 	// serving /api/logs/filterdata from it would surface "relation does not
@@ -2460,6 +2463,26 @@ var performanceIndexes = []performanceIndexDef{
 		name:  "idx_logs_stop_reason",
 		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_stop_reason ON logs(stop_reason)",
 	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_user_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_user_id ON mcp_tool_logs(user_id)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_team_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_team_id ON mcp_tool_logs(team_id)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_customer_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_customer_id ON mcp_tool_logs(customer_id)",
+	},
+	{
+		table: "mcp_tool_logs",
+		name:  "idx_mcp_logs_business_unit_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_business_unit_id ON mcp_tool_logs(business_unit_id)",
+	},
 }
 
 // ensurePerformanceIndexes checks whether each performance GIN index exists and is
@@ -3099,6 +3122,52 @@ $$;`
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while adding bifrost_safe_jsonb function: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddDACColumnsToMCPToolLogs adds user_id, team_id, customer_id,
+// and business_unit_id columns to mcp_tool_logs so DAC scope can apply the
+// same ownership predicates it does on the logs table. The columns are
+// nullable; pre-existing rows stay NULL and the DAC resolver fails closed
+// for non-admin principals against them.
+//
+// Indexes are built CONCURRENTLY by ensurePerformanceIndexes (entries appended
+// to performanceIndexes) so adding them does not block writes on a populated
+// table.
+func migrationAddDACColumnsToMCPToolLogs(ctx context.Context, db *gorm.DB) error {
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: "mcp_tool_logs_add_dac_columns",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+
+			for _, col := range []string{"user_id", "team_id", "customer_id", "business_unit_id"} {
+				if !mg.HasColumn(&MCPToolLog{}, col) {
+					if err := mg.AddColumn(&MCPToolLog{}, col); err != nil {
+						return fmt.Errorf("failed to add %s column to mcp_tool_logs: %w", col, err)
+					}
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			for _, col := range []string{"business_unit_id", "customer_id", "team_id", "user_id"} {
+				if mg.HasColumn(&MCPToolLog{}, col) {
+					if err := mg.DropColumn(&MCPToolLog{}, col); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding DAC columns to mcp_tool_logs: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -794,6 +794,10 @@ type MCPToolLog struct {
 	ServerLabel    string    `gorm:"type:varchar(255);index:idx_mcp_logs_server_label" json:"server_label,omitempty"` // MCP server that provided the tool
 	VirtualKeyID   *string   `gorm:"type:varchar(255);index:idx_mcp_logs_virtual_key_id" json:"virtual_key_id"`
 	VirtualKeyName *string   `gorm:"type:varchar(255)" json:"virtual_key_name"`
+	UserID         *string   `gorm:"type:varchar(255);index:idx_mcp_logs_user_id" json:"user_id"`
+	TeamID         *string   `gorm:"type:varchar(255);index:idx_mcp_logs_team_id" json:"team_id"`
+	CustomerID     *string   `gorm:"type:varchar(255);index:idx_mcp_logs_customer_id" json:"customer_id"`
+	BusinessUnitID *string   `gorm:"type:varchar(255);index:idx_mcp_logs_business_unit_id" json:"business_unit_id"`
 	Arguments      string    `gorm:"type:text" json:"-"`                                                // JSON serialized tool arguments
 	Result         string    `gorm:"type:text" json:"-"`                                                // JSON serialized tool result
 	ErrorDetails   string    `gorm:"type:text" json:"-"`                                                // JSON serialized *schemas.BifrostError

--- a/ui/app/workspace/governance/virtual-keys/page.tsx
+++ b/ui/app/workspace/governance/virtual-keys/page.tsx
@@ -1,7 +1,12 @@
 import VirtualKeysTable from "@/app/workspace/virtual-keys/views/virtualKeysTable";
 import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
-import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery, useGetVirtualKeysQuery } from "@/lib/store";
+import {
+  getErrorMessage,
+  useGetCustomersQuery,
+  useGetTeamsQuery,
+  useGetVirtualKeysQuery,
+} from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { parseAsInteger, parseAsString, useQueryStates } from "nuqs";
 import { useEffect, useRef } from "react";
@@ -11,135 +16,158 @@ const POLLING_INTERVAL = 5000;
 const PAGE_SIZE = 25;
 
 export default function GovernanceVirtualKeysPage() {
-	const hasVirtualKeysAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.View);
-	const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
-	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
-	const shownErrorsRef = useRef(new Set<string>());
+  const hasVirtualKeysAccess = useRbac(
+    RbacResource.VirtualKeys,
+    RbacOperation.View,
+  );
+  const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
+  const hasCustomersAccess = useRbac(
+    RbacResource.Customers,
+    RbacOperation.View,
+  );
+  const shownErrorsRef = useRef(new Set<string>());
 
-	const [urlState, setUrlState] = useQueryStates(
-		{
-			search: parseAsString.withDefault(""),
-			customer_id: parseAsString.withDefault(""),
-			team_id: parseAsString.withDefault(""),
-			offset: parseAsInteger.withDefault(0),
-			sort_by: parseAsString.withDefault(""),
-			order: parseAsString.withDefault(""),
-		},
-		{ history: "push" },
-	);
+  const [urlState, setUrlState] = useQueryStates(
+    {
+      search: parseAsString.withDefault(""),
+      customer_id: parseAsString.withDefault(""),
+      team_id: parseAsString.withDefault(""),
+      offset: parseAsInteger.withDefault(0),
+      sort_by: parseAsString.withDefault(""),
+      order: parseAsString.withDefault(""),
+    },
+    { history: "push" },
+  );
 
-	const debouncedSearch = useDebouncedValue(urlState.search, 300);
+  const debouncedSearch = useDebouncedValue(urlState.search, 300);
 
-	const {
-		data: virtualKeysData,
-		error: vkError,
-		isLoading: vkLoading,
-	} = useGetVirtualKeysQuery(
-		{
-			limit: PAGE_SIZE,
-			offset: urlState.offset,
-			search: debouncedSearch || undefined,
-			customer_id: urlState.customer_id || undefined,
-			team_id: urlState.team_id || undefined,
-			sort_by: (urlState.sort_by as "name" | "budget_spent" | "created_at" | "status") || undefined,
-			order: (urlState.order as "asc" | "desc") || undefined,
-		},
-		{
-			skip: !hasVirtualKeysAccess,
-			pollingInterval: POLLING_INTERVAL,
-		},
-	);
+  const {
+    data: virtualKeysData,
+    error: vkError,
+    isLoading: vkLoading,
+  } = useGetVirtualKeysQuery(
+    {
+      limit: PAGE_SIZE,
+      offset: urlState.offset,
+      search: debouncedSearch || undefined,
+      customer_id: urlState.customer_id || undefined,
+      team_id: urlState.team_id || undefined,
+      sort_by:
+        (urlState.sort_by as
+          | "name"
+          | "budget_spent"
+          | "created_at"
+          | "status") || undefined,
+      order: (urlState.order as "asc" | "desc") || undefined,
+    },
+    {
+      skip: !hasVirtualKeysAccess,
+      pollingInterval: POLLING_INTERVAL,
+    },
+  );
 
-	const {
-		data: teamsData,
-		error: teamsError,
-		isLoading: teamsLoading,
-	} = useGetTeamsQuery(undefined, {
-		skip: !hasTeamsAccess,
-		pollingInterval: POLLING_INTERVAL,
-	});
+  const {
+    data: teamsData,
+    error: teamsError,
+    isLoading: teamsLoading,
+  } = useGetTeamsQuery(undefined, {
+    skip: !hasTeamsAccess,
+    pollingInterval: POLLING_INTERVAL,
+  });
 
-	const {
-		data: customersData,
-		error: customersError,
-		isLoading: customersLoading,
-	} = useGetCustomersQuery(undefined, {
-		skip: !hasCustomersAccess,
-		pollingInterval: POLLING_INTERVAL,
-	});
+  const {
+    data: customersData,
+    error: customersError,
+    isLoading: customersLoading,
+  } = useGetCustomersQuery(undefined, {
+    skip: !hasCustomersAccess,
+    pollingInterval: POLLING_INTERVAL,
+  });
 
-	const vkTotal = virtualKeysData?.total_count ?? 0;
+  const vkTotal = virtualKeysData?.total_count ?? 0;
 
-	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
-	useEffect(() => {
-		if (!virtualKeysData || urlState.offset < vkTotal) return;
-		setUrlState({ offset: vkTotal === 0 ? 0 : Math.floor((vkTotal - 1) / PAGE_SIZE) * PAGE_SIZE });
-	}, [vkTotal, urlState.offset]);
+  // Snap offset back when total shrinks past current page (e.g. delete last item on last page)
+  useEffect(() => {
+    if (!virtualKeysData || urlState.offset < vkTotal) return;
+    setUrlState({
+      offset:
+        vkTotal === 0 ? 0 : Math.floor((vkTotal - 1) / PAGE_SIZE) * PAGE_SIZE,
+    });
+  }, [vkTotal, urlState.offset]);
 
-	const isLoading = vkLoading || teamsLoading || customersLoading;
+  const isLoading = vkLoading || teamsLoading || customersLoading;
 
-	useEffect(() => {
-		if (!vkError && !teamsError && !customersError) {
-			shownErrorsRef.current.clear();
-			return;
-		}
-		const errorKey = `${!!vkError}-${!!teamsError}-${!!customersError}`;
-		if (shownErrorsRef.current.has(errorKey)) return;
-		shownErrorsRef.current.add(errorKey);
-		if (vkError && teamsError && customersError) {
-			toast.error("Failed to load governance data.");
-		} else {
-			if (vkError) toast.error(`Failed to load virtual keys: ${getErrorMessage(vkError)}`);
-			if (teamsError) toast.error(`Failed to load teams: ${getErrorMessage(teamsError)}`);
-			if (customersError) toast.error(`Failed to load customers: ${getErrorMessage(customersError)}`);
-		}
-	}, [vkError, teamsError, customersError]);
+  useEffect(() => {
+    if (!vkError && !teamsError && !customersError) {
+      shownErrorsRef.current.clear();
+      return;
+    }
+    const errorKey = `${!!vkError}-${!!teamsError}-${!!customersError}`;
+    if (shownErrorsRef.current.has(errorKey)) return;
+    shownErrorsRef.current.add(errorKey);
+    if (vkError && teamsError && customersError) {
+      toast.error("Failed to load governance data.");
+    } else {
+      if (vkError)
+        toast.error(`Failed to load virtual keys: ${getErrorMessage(vkError)}`);
+      if (teamsError)
+        toast.error(`Failed to load teams: ${getErrorMessage(teamsError)}`);
+      if (customersError)
+        toast.error(
+          `Failed to load customers: ${getErrorMessage(customersError)}`,
+        );
+    }
+  }, [vkError, teamsError, customersError]);
 
-	if (isLoading) {
-		return <FullPageLoader />;
-	}
+  if (isLoading) {
+    return <FullPageLoader />;
+  }
 
-	const handleSearchChange = (value: string) => {
-		setUrlState({ search: value || null, offset: 0 });
-	};
+  const handleSearchChange = (value: string) => {
+    setUrlState({ search: value || null, offset: 0 });
+  };
 
-	const handleCustomerFilterChange = (value: string) => {
-		setUrlState({ customer_id: value || null, offset: 0 });
-	};
+  const handleCustomerFilterChange = (value: string) => {
+    setUrlState({ customer_id: value || null, offset: 0 });
+  };
 
-	const handleTeamFilterChange = (value: string) => {
-		setUrlState({ team_id: value || null, offset: 0 });
-	};
+  const handleTeamFilterChange = (value: string) => {
+    setUrlState({ team_id: value || null, offset: 0 });
+  };
 
-	const handleOffsetChange = (newOffset: number) => {
-		setUrlState({ offset: newOffset });
-	};
+  const handleOffsetChange = (newOffset: number) => {
+    setUrlState({ offset: newOffset });
+  };
 
-	const handleSortChange = (newSortBy: string, newOrder: string) => {
-		setUrlState({ sort_by: newSortBy || null, order: newOrder || null, offset: 0 });
-	};
+  const handleSortChange = (newSortBy: string, newOrder: string) => {
+    setUrlState({
+      sort_by: newSortBy || null,
+      order: newOrder || null,
+      offset: 0,
+    });
+  };
 
-	return (
-		<div className="mx-auto w-full">
-			<VirtualKeysTable
-				virtualKeys={virtualKeysData?.virtual_keys || []}
-				totalCount={virtualKeysData?.total_count || 0}
-				teams={teamsData?.teams || []}
-				customers={customersData?.customers || []}
-				search={urlState.search}
-				debouncedSearch={debouncedSearch}
-				onSearchChange={handleSearchChange}
-				customerFilter={urlState.customer_id}
-				onCustomerFilterChange={handleCustomerFilterChange}
-				teamFilter={urlState.team_id}
-				onTeamFilterChange={handleTeamFilterChange}
-				offset={urlState.offset}
-				limit={PAGE_SIZE}
-				onOffsetChange={handleOffsetChange}
-				sortBy={urlState.sort_by}
-				order={urlState.order}
-				onSortChange={handleSortChange}
-			/>
-		</div>
-	);
+  return (
+    <div className="mx-auto w-full max-w-7xl">
+      <VirtualKeysTable
+        virtualKeys={virtualKeysData?.virtual_keys || []}
+        totalCount={virtualKeysData?.total_count || 0}
+        teams={teamsData?.teams || []}
+        customers={customersData?.customers || []}
+        search={urlState.search}
+        debouncedSearch={debouncedSearch}
+        onSearchChange={handleSearchChange}
+        customerFilter={urlState.customer_id}
+        onCustomerFilterChange={handleCustomerFilterChange}
+        teamFilter={urlState.team_id}
+        onTeamFilterChange={handleTeamFilterChange}
+        offset={urlState.offset}
+        limit={PAGE_SIZE}
+        onOffsetChange={handleOffsetChange}
+        sortBy={urlState.sort_by}
+        order={urlState.order}
+        onSortChange={handleSortChange}
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

Extends DAC (Data Access Control) ownership to the `mcp_tool_logs` table by adding `user_id`, `team_id`, `customer_id`, and `business_unit_id` columns, and updates the e2e seed infrastructure to generate a structured per-shape dataset for both LLM logs and MCP tool logs so visibility tests can assert exact set membership against either table.

## Changes

- Added `UserID`, `TeamID`, `CustomerID`, and `BusinessUnitID` nullable columns to the `MCPToolLog` struct and corresponding GORM model, mirroring the ownership dimensions already present on the `logs` table.
- Added a new migration `mcp_tool_logs_add_dac_columns` that idempotently adds the four DAC columns to `mcp_tool_logs`, with a rollback path. Concurrent indexes for each column are registered in `performanceIndexes` so they are built without blocking writes.
- Replaced the round-robin log distribution strategy (`i % len(shapes)`) with a per-shape contiguous block allocation (`shapeIdx * LogRowsPerShape + j`). This ensures each shape receives exactly `LogRowsPerShape` rows with deterministic, non-overlapping IDs in both the `logs` and `mcp_tool_logs` tables.
- Renamed `LogRows` → `LogRowsPerShape` (option, summary field, CLI flag `--logs` → `--logs-per-shape`) to reflect the new per-shape semantics. The default changed from 100,000 total rows to 30 rows per shape.
- Replaced the hardcoded 11-entry `BuildShapes` slice with a programmatic enumeration of all 15 non-empty subsets of the four DAC dimensions `{VirtualKey, UserID, TeamID, BusinessUnitID}`, plus three appended shapes for negative/cross-team coverage (`user-not-in-tiggings`, `outside-team-virtual-key`, `legacy-unowned`). `VisibleTo` is now derived by `computeVisibleTo` rather than being hardcoded per shape.
- Extracted `seedMCPLogs` from `seedLogCompanions`. MCP logs are now seeded in the same shape/volume as LLM logs. The single companion MCP log row is removed; async-job seeding is retained in `seedAsyncJobCompanion`.
- Added `MCPLogIDs` to `ExpectedManifest` so tests can assert exact MCP log visibility per persona.
- The seed completion message now prints `logs_per_shape` and `shapes` count instead of a single total row count.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/e2eseed/... ./framework/logstore/...

# Run the seeder against a local Postgres instance
go run ./framework/cmd/e2eseed \
  --logs-per-shape 30 \
  --batch-size 500 \
  --output-env tmp/e2e-seed.env

# Expected output:
# seeded OSS API e2e data prefix=e2e-seed logs_per_shape=30 shapes=18 env=tmp/e2e-seed.env
```

Verify that `mcp_tool_logs` rows carry the correct `user_id`, `team_id`, `customer_id`, and `business_unit_id` values matching their shape, and that the generated `tmp/e2e-seed.env` manifest contains a populated `mcp_log_ids` map alongside `log_ids`.

## Breaking changes

- [x] Yes
- [ ] No

The CLI flag `--logs` is renamed to `--logs-per-shape` and its semantics change from total row count to per-shape row count. Any scripts or CI jobs passing `--logs` must be updated. The `Summary.LogRows` JSON field is renamed to `log_rows_per_shape`; consumers of the seed summary JSON will need to update their field references.

## Related issues

## Security considerations

The new DAC columns on `mcp_tool_logs` are nullable. Pre-existing rows remain `NULL` and the DAC resolver fails closed for non-admin principals against them, consistent with the existing `legacy-unowned` shape behaviour.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable