### PR TITLE
fix: remove `defaultFilterDataLimit` cap from filter data queries

### DIFF
--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -1628,7 +1628,6 @@ func (s *RDBLogStore) getDistinctModelsFromMatView(ctx context.Context) ([]strin
 	if err := s.db.WithContext(ctx).Table("mv_filter_models").
 		Distinct("model").
 		Where("model != ''").
-		Limit(defaultFilterDataLimit).
 		Pluck("model", &models).Error; err != nil {
 		return nil, err
 	}
@@ -1641,7 +1640,6 @@ func (s *RDBLogStore) getDistinctAliasesFromMatView(ctx context.Context) ([]stri
 	if err := s.db.WithContext(ctx).Table("mv_filter_aliases").
 		Distinct("alias").
 		Where("alias != ''").
-		Limit(defaultFilterDataLimit).
 		Pluck("alias", &aliases).Error; err != nil {
 		return nil, err
 	}
@@ -1654,7 +1652,6 @@ func (s *RDBLogStore) getDistinctStopReasonsFromMatView(ctx context.Context) ([]
 	if err := s.db.WithContext(ctx).Table("mv_filter_stop_reasons").
 		Distinct("stop_reason").
 		Where("stop_reason != ''").
-		Limit(defaultFilterDataLimit).
 		Pluck("stop_reason", &stopReasons).Error; err != nil {
 		return nil, err
 	}
@@ -1680,7 +1677,7 @@ func (s *RDBLogStore) getDistinctKeyPairsFromMatView(ctx context.Context, idCol,
 	}
 	if err := q.
 		Select("DISTINCT id, name").
-		Limit(defaultFilterDataLimit).
+		Order("name ASC").
 		Find(&results).Error; err != nil {
 		return nil, true, err
 	}
@@ -1695,7 +1692,6 @@ func (s *RDBLogStore) getDistinctRoutingEnginesFromMatView(ctx context.Context) 
 	if err := s.db.WithContext(ctx).Table("mv_filter_routing_engines").
 		Distinct("routing_engines_used").
 		Where("routing_engines_used != ''").
-		Limit(defaultFilterDataLimit).
 		Pluck("routing_engines_used", &rawValues).Error; err != nil {
 		return nil, err
 	}

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -41,8 +41,6 @@ const (
 	defaultMaxRankingsLimit = 100
 	// defaultFilterDataCutoffDays limits GetDistinct* filter-data queries to recent data.
 	defaultFilterDataCutoffDays = 30
-	// defaultFilterDataLimit caps the number of distinct values returned by filter-data queries.
-	defaultFilterDataLimit = 500
 )
 
 // RDBLogStore represents a log store that uses a SQLite database.
@@ -2763,7 +2761,7 @@ func (s *RDBLogStore) GetDistinctModels(ctx context.Context) ([]string, error) {
 	var models []string
 	err := s.db.WithContext(ctx).Model(&Log{}).
 		Where("model IS NOT NULL AND model != '' AND timestamp >= ?", cutoff).
-		Distinct("model").Limit(defaultFilterDataLimit).Pluck("model", &models).Error
+		Distinct("model").Pluck("model", &models).Error
 	if err != nil {
 		return nil, fmt.Errorf("failed to get distinct models: %w", err)
 	}
@@ -2780,7 +2778,7 @@ func (s *RDBLogStore) GetDistinctAliases(ctx context.Context) ([]string, error) 
 	var aliases []string
 	err := s.db.WithContext(ctx).Model(&Log{}).
 		Where("alias IS NOT NULL AND alias != '' AND timestamp >= ?", cutoff).
-		Distinct("alias").Limit(defaultFilterDataLimit).Pluck("alias", &aliases).Error
+		Distinct("alias").Pluck("alias", &aliases).Error
 	if err != nil {
 		return nil, fmt.Errorf("failed to get distinct aliases: %w", err)
 	}
@@ -2826,7 +2824,6 @@ func (s *RDBLogStore) GetDistinctKeyPairs(ctx context.Context, idCol, nameCol st
 	err := s.db.WithContext(ctx).Model(&Log{}).
 		Select(fmt.Sprintf("DISTINCT %s as id, %s as name", idCol, nameCol)).
 		Where(fmt.Sprintf("%s IS NOT NULL AND %s != '' AND %s IS NOT NULL AND %s != '' AND timestamp >= ?", idCol, idCol, nameCol, nameCol), cutoff).
-		Limit(defaultFilterDataLimit).
 		Find(&results).Error
 	if err != nil {
 		return nil, fmt.Errorf("failed to get distinct key pairs (%s, %s): %w", idCol, nameCol, err)
@@ -2844,7 +2841,7 @@ func (s *RDBLogStore) GetDistinctRoutingEngines(ctx context.Context) ([]string, 
 	var rawValues []string
 	err := s.db.WithContext(ctx).Model(&Log{}).
 		Where("routing_engines_used IS NOT NULL AND routing_engines_used != '' AND timestamp >= ?", cutoff).
-		Distinct("routing_engines_used").Limit(defaultFilterDataLimit).Pluck("routing_engines_used", &rawValues).Error
+		Distinct("routing_engines_used").Pluck("routing_engines_used", &rawValues).Error
 	if err != nil {
 		return nil, fmt.Errorf("failed to get distinct routing engines: %w", err)
 	}
@@ -2875,7 +2872,7 @@ func (s *RDBLogStore) GetDistinctStopReasons(ctx context.Context) ([]string, err
 	var stopReasons []string
 	err := s.db.WithContext(ctx).Model(&Log{}).
 		Where("stop_reason IS NOT NULL AND stop_reason != '' AND timestamp >= ?", cutoff).
-		Distinct("stop_reason").Limit(defaultFilterDataLimit).Pluck("stop_reason", &stopReasons).Error
+		Distinct("stop_reason").Pluck("stop_reason", &stopReasons).Error
 	if err != nil {
 		return nil, fmt.Errorf("failed to get distinct stop reasons: %w", err)
 	}
@@ -3362,7 +3359,7 @@ func (s *RDBLogStore) GetAvailableToolNames(ctx context.Context) ([]string, erro
 	var toolNames []string
 	result := s.db.WithContext(ctx).Model(&MCPToolLog{}).
 		Where("tool_name IS NOT NULL AND tool_name != '' AND timestamp >= ?", cutoff).
-		Distinct("tool_name").Limit(defaultFilterDataLimit).Pluck("tool_name", &toolNames)
+		Distinct("tool_name").Pluck("tool_name", &toolNames)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get available tool names: %w", result.Error)
 	}
@@ -3376,7 +3373,7 @@ func (s *RDBLogStore) GetAvailableServerLabels(ctx context.Context) ([]string, e
 	var serverLabels []string
 	result := s.db.WithContext(ctx).Model(&MCPToolLog{}).
 		Where("server_label IS NOT NULL AND server_label != '' AND timestamp >= ?", cutoff).
-		Distinct("server_label").Limit(defaultFilterDataLimit).Pluck("server_label", &serverLabels)
+		Distinct("server_label").Pluck("server_label", &serverLabels)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get available server labels: %w", result.Error)
 	}
@@ -3392,7 +3389,6 @@ func (s *RDBLogStore) GetAvailableMCPVirtualKeys(ctx context.Context) ([]MCPTool
 		Model(&MCPToolLog{}).
 		Select("DISTINCT virtual_key_id, virtual_key_name").
 		Where("virtual_key_id IS NOT NULL AND virtual_key_id != '' AND virtual_key_name IS NOT NULL AND virtual_key_name != '' AND timestamp >= ?", cutoff).
-		Limit(defaultFilterDataLimit).
 		Find(&logs)
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to get available virtual keys from MCP logs: %w", result.Error)


### PR DESCRIPTION
## Summary

Removes the `defaultFilterDataLimit` (500) cap that was previously applied to all `GetDistinct*` and `GetAvailable*` filter-data queries. This ensures that filter dropdowns and autocomplete fields return the full set of distinct values rather than silently truncating results at 500 entries.

## Changes

- Removed the `defaultFilterDataLimit = 500` constant and all `.Limit(defaultFilterDataLimit)` calls from both the materialized view query paths (`matviews.go`) and the direct RDB query paths (`rdb.go`).
- Affected queries: distinct models, aliases, stop reasons, routing engines, key pairs, tool names, server labels, and MCP virtual keys.
- The existing `defaultFilterDataCutoffDays = 30` time-based filter remains in place to keep queries scoped to recent data.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Verify that filter endpoints return more than 500 distinct values when the dataset contains them, and that no results are truncated.

```sh
go test ./framework/logstore/...
```

Seed a test database with more than 500 distinct models (or aliases, etc.) within the 30-day window and confirm all values are returned by the corresponding `GetDistinct*` method.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Removing the result cap means larger payloads may be returned by filter-data endpoints. Ensure that the 30-day cutoff and existing authentication/authorization controls are sufficient to prevent abuse or excessive memory usage in environments with very high cardinality data.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable