### PR TITLE
docs: update Claude Code install instructions and add `ANTHROPIC_CUSTOM_HEADERS` virtual key config

### DIFF
--- a/docs/cli-agents/claude-code.mdx
+++ b/docs/cli-agents/claude-code.mdx
@@ -10,32 +10,41 @@ icon: "star-of-life"
 
 | Version | Released   |
 | ------- | ---------- |
+| 2.1.143 | 2026-05-15 |
 | 2.1.132 | 2026-05-06 |
 | 2.1.131 | 2026-05-06 |
 | 2.1.129 | 2026-05-05 |
 | 2.1.128 | 2026-05-04 |
 
 <Note>
-  If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost
-  with Claude Code, try switching to `*` or adding the specific headers required by your client. By default, Bifrost
-  whitelists: `Content-Type`, `Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
+	If your Allowed Headers are already set to `*`, you can skip this note. If not and you face issues integrating Bifrost with Claude Code,
+	try switching to `*` or adding the specific headers required by your client. By default, Bifrost whitelists: `Content-Type`,
+	`Authorization`, `X-Requested-With`, `X-Stainless-Timeout`, and `X-Api-Key`.
 </Note>
 
-## To install Claude code
+<Note>
+	All examples below use `ANTHROPIC_CUSTOM_HEADERS` to pass your Bifrost virtual key. This is the recommended approach and works across all
+	tested Claude Code versions. If you are on an older version that does not support custom headers, you can fall back to `ANTHROPIC_API_KEY`
+	instead.
+</Note>
+
+## Installing Claude Code
 
 ```bash
-npm install -g @anthropic-ai/claude-code
+curl -fsSL https://claude.ai/install.sh | bash
 ```
+
+For platform-specific instructions, visit https://code.claude.com/docs/en/overview.
 
 ## Configuring Claude Code to work with Bifrost
 
 <Note>
-  **To avoid getting into different caching issues of Claude code** - 
-  - Ensure there is no `model` field in `settings.json`. If it's present remove it. This overwrites the `env` model selection. 
-  - Once you update the `settings.json`, start claude, and execute /logout. And restart - select use API key even if its not recommended.
-    <Frame>
-      <img src="/media/cli/select-api-claude-code.png" alt="Claude cli API selection"/>
-    </Frame>
+	**To avoid getting into different caching issues of Claude code** - - Ensure there is no `model` field in `settings.json`. If it's present
+	remove it. This overwrites the `env` model selection. - Once you update the `settings.json`, start claude, and execute /logout. And
+	restart - select use API key even if its not recommended.
+	<Frame>
+		<img src="/media/cli/select-api-claude-code.png" alt="Claude cli API selection" />
+	</Frame>
 </Note>
 
 Claude Code supports multiple authentication methods. Choose the one that matches your account type.
@@ -49,8 +58,7 @@ Global `settings.json` is placed in your home folder.
 - Project-Specific: `.claude/settings.json` (located within your individual project's root directory)
 - Local Overrides: `.claude/settings.local.json` (also in the project root, used for personal preferences that aren't shared via Git)
 
-You will need to update the most granular `settings.json`. 
-
+You will need to update the most granular `settings.json`.
 
 ### 1. Using alias
 
@@ -64,25 +72,35 @@ You will need to update the most granular `settings.json`.
 - And then you can map this model to any model you want. In the configuration given - we are using `vertex/claude-sonnet-4-6`.
 
 <Frame>
-<img src="/media/cli/sonnet-model-mapping.png" alt="sonnet-model routing example"/>
+	<img src="/media/cli/sonnet-model-mapping.png" alt="sonnet-model routing example" />
 </Frame>
 
 **`haiku-model` route**
-- Repeat the above steps by replacing `sonnet-model` with `haiku-model`.
 
+- Repeat the above steps by replacing `sonnet-model` with `haiku-model`.
 
 2. Update `settings.json`
 
 <Note>
-  The JSON snippets below show only the `env` key. Merge them into your existing `settings.json` top-level
-  object - do not paste them as a standalone file, or you will overwrite other settings like `permissions`,
-  `model`, and `apiKeyHelper`.
+	The JSON snippets below show only the `env` key. Merge them into your existing `settings.json` top-level object - do not paste them as a
+	standalone file, or you will overwrite other settings like `permissions`, `model`, and `apiKeyHelper`.
 </Note>
 
 ```json
 "env": {
   "ANTHROPIC_BASE_URL": "http://localhost:8080/anthropic",
   "ANTHROPIC_API_KEY": "your-virtual-key",
+  "ANTHROPIC_DEFAULT_HAIKU_MODEL": "haiku-model",
+  "ANTHROPIC_DEFAULT_SONNET_MODEL": "sonnet-model"
+}
+```
+
+For a more reliable approach, use the `ANTHROPIC_CUSTOM_HEADERS` environment variable as shown below.
+
+```json
+"env": {
+  "ANTHROPIC_BASE_URL": "http://localhost:8080/anthropic",
+  "ANTHROPIC_CUSTOM_HEADERS": "x-bf-vk: your-virtual-key",
   "ANTHROPIC_DEFAULT_HAIKU_MODEL": "haiku-model",
   "ANTHROPIC_DEFAULT_SONNET_MODEL": "sonnet-model"
 }
@@ -97,7 +115,7 @@ Update `settings.json` to pick Anthropic models. For Anthropic models, you don't
 ```json
 "env": {
   "ANTHROPIC_BASE_URL": "http://localhost:8080/anthropic",
-  "ANTHROPIC_API_KEY": "your-virtual-key",
+  "ANTHROPIC_CUSTOM_HEADERS": "x-bf-vk: your-virtual-key",
   "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-6",
   "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6"
 }
@@ -105,12 +123,12 @@ Update `settings.json` to pick Anthropic models. For Anthropic models, you don't
 
 #### Bedrock
 
-Update `settings.json` to pick Anthropic models on Bedrock. 
+Update `settings.json` to pick Anthropic models on Bedrock.
 
 ```json
 "env": {
   "ANTHROPIC_BASE_URL": "http://localhost:8080/anthropic",
-  "ANTHROPIC_API_KEY": "your-virtual-key",
+  "ANTHROPIC_CUSTOM_HEADERS": "x-bf-vk: your-virtual-key",
   "ANTHROPIC_DEFAULT_HAIKU_MODEL": "bedrock/global.anthropic.claude-haiku-4-6",
   "ANTHROPIC_DEFAULT_SONNET_MODEL": "bedrock/global.anthropic.claude-sonnet-4-6"
 }
@@ -119,17 +137,17 @@ Update `settings.json` to pick Anthropic models on Bedrock.
 If you don't pin using CLI - you can pin these in UI. Go to Dashboard > Models > Model Providers > AWS Bedrock > Key. And add deployments
 
 <Frame>
-  <img src="/media/cli/claude-bedrock-pinning.png" alt="Claude bedrock pinning" />
+	<img src="/media/cli/claude-bedrock-pinning.png" alt="Claude bedrock pinning" />
 </Frame>
 
 #### Vertex
 
-Update `settings.json` to pick Anthropic models on Vertex. 
+Update `settings.json` to pick Anthropic models on Vertex.
 
 ```json
 "env": {
   "ANTHROPIC_BASE_URL": "http://localhost:8080/anthropic",
-  "ANTHROPIC_API_KEY": "your-virtual-key",
+  "ANTHROPIC_CUSTOM_HEADERS": "x-bf-vk: your-virtual-key",
   "ANTHROPIC_DEFAULT_HAIKU_MODEL": "vertex/claude-haiku-4-6",
   "ANTHROPIC_DEFAULT_SONNET_MODEL": "vertex/claude-sonnet-4-6"
 }
@@ -137,26 +155,25 @@ Update `settings.json` to pick Anthropic models on Vertex.
 
 #### Azure
 
-Update `settings.json` to pick Anthropic models on Azure. 
+Update `settings.json` to pick Anthropic models on Azure.
 
 ```json
 "env": {
   "ANTHROPIC_BASE_URL": "http://localhost:8080/anthropic",
-  "ANTHROPIC_API_KEY": "your-virtual-key",
+  "ANTHROPIC_CUSTOM_HEADERS": "x-bf-vk: your-virtual-key",
   "ANTHROPIC_DEFAULT_HAIKU_MODEL": "azure/claude-haiku-4-6",
   "ANTHROPIC_DEFAULT_SONNET_MODEL": "azure/claude-sonnet-4-6"
 }
 ```
 
 <Frame>
-  <img src="/media/cli/claude-azure-pinning.png" alt="Azure model  pinning" />
+	<img src="/media/cli/claude-azure-pinning.png" alt="Azure model  pinning" />
 </Frame>
 
 <Warning>
-  Azure-hosted models must support **tool use capabilities** for Claude Code to function properly. Verify tool calling
-  support before configuring Azure models.
+	Azure-hosted models must support **tool use capabilities** for Claude Code to function properly. Verify tool calling support before
+	configuring Azure models.
 </Warning>
-
 
 ## Model Configuration
 
@@ -190,14 +207,13 @@ Use the `/model` command to switch models during an active session:
 ```
 
 <Tip>
-  Run `/model` without arguments to check your current model. The switch is instantaneous and Claude Code seamlessly
-  continues your conversation context with the new model.
+	Run `/model` without arguments to check your current model. The switch is instantaneous and Claude Code seamlessly continues your
+	conversation context with the new model.
 </Tip>
 
 <Warning>
-  If you use Claude-specific features like **web search**, **computer use**, or **citations**, ensure the model you
-  switch to also supports these capabilities. Non-Claude models or Claude models on certain providers may not support
-  all features.
+	If you use Claude-specific features like **web search**, **computer use**, or **citations**, ensure the model you switch to also supports
+	these capabilities. Non-Claude models or Claude models on certain providers may not support all features.
 </Warning>
 
 ## Provider Compatibility
@@ -216,16 +232,16 @@ If you experience issues with tool calls not executing properly, try switching t
 
 ## Checklist
 
-1. Ensure the model selected is same as you configured in the `settings.json`. 
-<Frame>
-  <img src="/media/cli/claude-cli-model-selection.png" alt="Selected model in Claude cli"/>
-</Frame>
-If this is not the case - 
-  1. Select model using /config
-    1. Execute `/config`
-    2. Search for model
-    3. Select the correct model
-    <Frame>
-      <img src="/media/cli/claude-code-config-model-selection.png" alt="Claude code model selection using /config"/>
-    </Frame>
-  2. Or pass the model using `/model <model_name>` e.g., `/model sonnet-model`
+1. Ensure the model selected is same as you configured in the `settings.json`.
+   <Frame>
+   	<img src="/media/cli/claude-cli-model-selection.png" alt="Selected model in Claude cli" />
+   </Frame>
+   If this is not the case -
+1. Select model using /config
+1. Execute `/config`
+1. Search for model
+1. Select the correct model
+   <Frame>
+   	<img src="/media/cli/claude-code-config-model-selection.png" alt="Claude code model selection using /config" />
+   </Frame>
+1. Or pass the model using `/model <model_name>` e.g., `/model sonnet-model`


### PR DESCRIPTION
## Summary

Updates the Claude Code integration documentation to reflect installation changes and a more reliable authentication method using `ANTHROPIC_CUSTOM_HEADERS` instead of `ANTHROPIC_API_KEY`.

## Changes

- Replaced the `npm install -g @anthropic-ai/claude-code` install command with the official `curl` installer and a link to the Claude Code docs for platform-specific instructions
- Added a note warning that `ANTHROPIC_API_KEY` may not work in later versions of Claude Code and recommending `ANTHROPIC_CUSTOM_HEADERS` as the preferred approach for passing virtual keys
- Added a `settings.json` example using `ANTHROPIC_CUSTOM_HEADERS` to pass the virtual key (`x-bf-vk`) alongside `ANTHROPIC_BASE_URL` and model pinning variables

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated Claude Code documentation page and verify:
1. The install command reflects the current recommended method
2. The `ANTHROPIC_CUSTOM_HEADERS` configuration example is accurate and functional when tested against a running Bifrost instance

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. The change documents passing virtual keys via a custom header rather than the standard API key environment variable, which is consistent with existing Bifrost authentication patterns.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable