### PR TITLE
feat: add search icon and fetching spinner to filter sidebar search inputs

### DIFF
--- a/ui/components/filters/logsFilterSidebar.tsx
+++ b/ui/components/filters/logsFilterSidebar.tsx
@@ -8,7 +8,7 @@ import { RequestTypeLabels, RequestTypes, RoutingEngineUsedLabels, Statuses } fr
 import { useGetAvailableFilterDataQuery, useGetProvidersQuery } from "@/lib/store";
 import type { LogFilters } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import { ChevronDown, PanelLeftClose, PanelLeftOpen, Plus, RotateCcw } from "lucide-react";
+import { ChevronDown, LoaderCircle, PanelLeftClose, PanelLeftOpen, Plus, RotateCcw, Search } from "lucide-react";
 import { Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const COLLAPSE_STORAGE_KEY = "logs-filter-sidebar-collapsed";
@@ -186,7 +186,6 @@ function FilterSection({
 }) {
 	const [open, setOpen] = useState(defaultOpen);
 
-	// Force open when defaultOpen flips to true (e.g. a filter in this section becomes active)
 	useEffect(() => {
 		if (defaultOpen) setOpen(true);
 	}, [defaultOpen]);
@@ -259,6 +258,7 @@ function SearchableCheckboxList({
 	testIdPrefix,
 	allowCustom = false,
 	onSearch,
+	fetching,
 }: {
 	items: { key: string; label: string }[];
 	isSelected: (key: string) => boolean;
@@ -266,12 +266,9 @@ function SearchableCheckboxList({
 	placeholder?: string;
 	inputRef?: Ref<HTMLInputElement>;
 	testIdPrefix?: string;
-	// When true, lets users add the typed search string as a filter value if it
-	// doesn't exactly match any existing item. Only safe for filters where the
-	// stored value equals the displayed string (models, aliases, stop reasons) —
-	// not for ID-backed filters where the visible label is a name.
 	allowCustom?: boolean;
 	onSearch?: (query: string) => void;
+	fetching?: boolean;
 }) {
 	const [query, setQuery] = useState("");
 	const normalized = query.trim().toLowerCase();
@@ -296,7 +293,12 @@ function SearchableCheckboxList({
 
 	return (
 		<>
-			<div className="border-b">
+			<div className="relative border-b">
+				{fetching ? (
+					<LoaderCircle className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 animate-spin" />
+				) : (
+					<Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+				)}
 				<Input
 					ref={inputRef}
 					value={query}
@@ -308,7 +310,7 @@ function SearchableCheckboxList({
 						}
 					}}
 					placeholder={placeholder}
-					className="h-8 border-0 text-xs"
+					className="h-8 border-0 pl-8 text-xs"
 					data-testid={testIdPrefix ? `${testIdPrefix}-search` : undefined}
 				/>
 			</div>
@@ -380,6 +382,7 @@ function StopReasonFilter({ filters, onFiltersChange, defaultOpen }: FilterCompo
 		data: filterData,
 		isUninitialized,
 		isLoading,
+		isFetching,
 	} = useGetAvailableFilterDataQuery({ dimensions: ["stop_reasons"], q: searchQuery || undefined }, { skip: !opened && !hasActive });
 	const availableStopReasons = filterData?.stop_reasons || [];
 	const items = useMemo(() => {
@@ -410,6 +413,7 @@ function StopReasonFilter({ filters, onFiltersChange, defaultOpen }: FilterCompo
 					onFiltersChange({ ...filters, stop_reasons: next });
 				}}
 				onSearch={setSearchQuery}
+				fetching={isFetching}
 				testIdPrefix="stop-reason-filter"
 			/>
 		</FilterSection>
@@ -495,6 +499,7 @@ function ModelsFilter({ filters, onFiltersChange, defaultOpen }: FilterComponent
 		data: filterData,
 		isUninitialized,
 		isLoading,
+		isFetching,
 	} = useGetAvailableFilterDataQuery({ dimensions: ["models"], q: searchQuery || undefined }, { skip: !opened && !hasActive });
 	const availableModels = filterData?.models || [];
 	const items = useMemo(() => {
@@ -525,6 +530,7 @@ function ModelsFilter({ filters, onFiltersChange, defaultOpen }: FilterComponent
 					onFiltersChange({ ...filters, models: next });
 				}}
 				onSearch={setSearchQuery}
+				fetching={isFetching}
 				testIdPrefix="models-filter"
 			/>
 		</FilterSection>
@@ -544,6 +550,7 @@ function AliasesFilter({ filters, onFiltersChange, defaultOpen }: FilterComponen
 		data: filterData,
 		isUninitialized,
 		isLoading,
+		isFetching,
 	} = useGetAvailableFilterDataQuery({ dimensions: ["aliases"], q: searchQuery || undefined }, { skip: !opened && !hasActive });
 	const availableAliases = filterData?.aliases || [];
 	const items = useMemo(() => {
@@ -574,6 +581,7 @@ function AliasesFilter({ filters, onFiltersChange, defaultOpen }: FilterComponen
 					onFiltersChange({ ...filters, aliases: next });
 				}}
 				onSearch={setSearchQuery}
+				fetching={isFetching}
 				testIdPrefix="aliases-filter"
 			/>
 		</FilterSection>
@@ -593,6 +601,7 @@ function SelectedKeysFilter({ filters, onFiltersChange, defaultOpen }: FilterCom
 		data: filterData,
 		isUninitialized,
 		isLoading,
+		isFetching,
 	} = useGetAvailableFilterDataQuery({ dimensions: ["selected_keys"], q: searchQuery || undefined }, { skip: !opened && !hasActive });
 	const availableSelectedKeys = filterData?.selected_keys || [];
 	const nameToIds = useMemo(() => groupByName(availableSelectedKeys), [availableSelectedKeys]);
@@ -630,6 +639,7 @@ function SelectedKeysFilter({ filters, onFiltersChange, defaultOpen }: FilterCom
 				isSelected={isSelected}
 				onToggle={toggle}
 				onSearch={setSearchQuery}
+				fetching={isFetching}
 				testIdPrefix="selected-keys-filter"
 			/>
 		</FilterSection>
@@ -649,6 +659,7 @@ function VirtualKeysFilter({ filters, onFiltersChange, defaultOpen }: FilterComp
 		data: filterData,
 		isUninitialized,
 		isLoading,
+		isFetching,
 	} = useGetAvailableFilterDataQuery({ dimensions: ["virtual_keys"], q: searchQuery || undefined }, { skip: !opened && !hasActive });
 	const availableVirtualKeys = filterData?.virtual_keys || [];
 	const nameToIds = useMemo(() => groupByName(availableVirtualKeys), [availableVirtualKeys]);
@@ -686,6 +697,7 @@ function VirtualKeysFilter({ filters, onFiltersChange, defaultOpen }: FilterComp
 				isSelected={isSelected}
 				onToggle={toggle}
 				onSearch={setSearchQuery}
+				fetching={isFetching}
 				testIdPrefix="virtual-keys-filter"
 			/>
 		</FilterSection>
@@ -705,6 +717,7 @@ function RoutingEnginesFilter({ filters, onFiltersChange, defaultOpen }: FilterC
 		data: filterData,
 		isUninitialized,
 		isLoading,
+		isFetching,
 	} = useGetAvailableFilterDataQuery({ dimensions: ["routing_engines"], q: searchQuery || undefined }, { skip: !opened && !hasActive });
 	const availableRoutingEngines = filterData?.routing_engines || [];
 
@@ -733,6 +746,7 @@ function RoutingEnginesFilter({ filters, onFiltersChange, defaultOpen }: FilterC
 				}}
 				testIdPrefix="routing-engines-filter"
 				onSearch={setSearchQuery}
+				fetching={isFetching}
 			/>
 		</FilterSection>
 	);
@@ -751,6 +765,7 @@ function RoutingRulesFilter({ filters, onFiltersChange, defaultOpen }: FilterCom
 		data: filterData,
 		isUninitialized,
 		isLoading,
+		isFetching,
 	} = useGetAvailableFilterDataQuery({ dimensions: ["routing_rules"], q: searchQuery || undefined }, { skip: !opened && !hasActive });
 	const availableRoutingRules = filterData?.routing_rules || [];
 	const nameToIds = useMemo(() => groupByName(availableRoutingRules), [availableRoutingRules]);
@@ -788,6 +803,7 @@ function RoutingRulesFilter({ filters, onFiltersChange, defaultOpen }: FilterCom
 				isSelected={isSelected}
 				onToggle={toggle}
 				onSearch={setSearchQuery}
+				fetching={isFetching}
 				testIdPrefix="routing-rules-filter"
 			/>
 		</FilterSection>
@@ -802,14 +818,17 @@ function SessionFilter({ filters, onFiltersChange, defaultOpen }: FilterComponen
 	const hasActive = !!filters.parent_request_id;
 	return (
 		<FilterSection title="Session" defaultOpen={defaultOpen || hasActive} testId="session-filter-toggle">
-			<Input
-				value={filters.parent_request_id || ""}
-				onChange={(e) => onFiltersChange({ ...filters, parent_request_id: e.target.value })}
-				placeholder="Parent request ID"
-				className="h-8 border-0 text-sm"
-				data-testid="session-filter-input"
-				autoFocus
-			/>
+			<div className="relative">
+				<Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+				<Input
+					value={filters.parent_request_id || ""}
+					onChange={(e) => onFiltersChange({ ...filters, parent_request_id: e.target.value })}
+					placeholder="Parent request ID"
+					className="h-8 border-0 pl-8 text-sm"
+					data-testid="session-filter-input"
+					autoFocus
+				/>
+			</div>
 		</FilterSection>
 	);
 }
@@ -822,13 +841,16 @@ function UserFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentPr
 	const hasActive = !!filters.user_ids?.length;
 	return (
 		<FilterSection title="User" defaultOpen={defaultOpen || hasActive} testId="user-filter-toggle">
-			<Input
-				value={filters.user_ids?.[0] || ""}
-				onChange={(e) => onFiltersChange({ ...filters, user_ids: e.target.value ? [e.target.value] : [] })}
-				placeholder="User ID"
-				className="h-8 border-0 text-sm"
-				data-testid="user-id-filter-input"
-			/>
+			<div className="relative">
+				<Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+				<Input
+					value={filters.user_ids?.[0] || ""}
+					onChange={(e) => onFiltersChange({ ...filters, user_ids: e.target.value ? [e.target.value] : [] })}
+					placeholder="User ID"
+					className="h-8 border-0 pl-8 text-sm"
+					data-testid="user-id-filter-input"
+				/>
+			</div>
 		</FilterSection>
 	);
 }
@@ -900,6 +922,7 @@ function MetadataFilters({ filters, onFiltersChange, defaultOpen }: FilterCompon
 		data: filterData,
 		isUninitialized,
 		isLoading,
+		isFetching,
 	} = useGetAvailableFilterDataQuery({ dimensions: ["metadata_keys"], q: debouncedQuery || undefined }, { skip: !opened && !hasActive });
 	const availableMetadataKeys = filterData?.metadata_keys || {};
 	const [customInputs, setCustomInputs] = useState<Record<string, string>>({});
@@ -921,7 +944,7 @@ function MetadataFilters({ filters, onFiltersChange, defaultOpen }: FilterCompon
 	);
 
 	const entries = Object.entries(availableMetadataKeys);
-	const isEmpty = !isUninitialized && !isLoading && entries.length === 0 && !hasActive;
+	const isEmpty = !isUninitialized && !isLoading && entries.length === 0 && !hasActive && !searchQuery;
 
 	return (
 		<FilterSection
@@ -935,56 +958,64 @@ function MetadataFilters({ filters, onFiltersChange, defaultOpen }: FilterCompon
 				<div className="text-muted-foreground px-3 py-2 text-xs">No metadata keys</div>
 			) : (
 				<>
-					<div className="border-b">
+					<div className="relative border-b">
+						{isFetching ? (
+							<LoaderCircle className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 animate-spin" />
+						) : (
+							<Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+						)}
 						<Input
 							value={searchQuery}
 							onChange={(e) => setSearchQuery(e.target.value)}
 							placeholder="Search metadata..."
-							className="h-8 border-0 text-xs"
+							className="h-8 border-0 pl-8 text-xs"
 							data-testid="metadata-search-input"
 						/>
 					</div>
+					{entries.length === 0 && !isFetching && (
+						<div className="text-muted-foreground flex h-9 items-center px-3 text-xs">No results</div>
+					)}
 					{entries.map(([metadataKey, values]) => (
-					<div key={metadataKey} data-testid={`metadata-${metadataKey}-filter-group`}>
-						<div className="text-muted-foreground px-3 pt-2 pb-1 text-xs font-medium">{metadataKey}</div>
-						{values.map((value: string) => (
-							<CheckboxFilterItem
-								key={value}
-								label={value}
-								checked={filters.metadata_filters?.[metadataKey] === value}
-								onCheckedChange={() => {
-									const currentValue = filters.metadata_filters?.[metadataKey];
-									handleChange(metadataKey, currentValue === value ? undefined : value);
-								}}
-								testId={`metadata-${metadataKey}-filter-checkbox-${value}`}
-							/>
-						))}
-						<div className="px-3 py-2.5">
-							<Input
-								className="placeholder:text-muted-foreground h-7 w-full rounded border bg-transparent px-2 text-sm"
-								placeholder="Custom value..."
-								value={
-									customInputs[metadataKey] ??
-									(filters.metadata_filters?.[metadataKey] && !values.includes(filters.metadata_filters[metadataKey])
-										? filters.metadata_filters[metadataKey]
-										: "")
-								}
-								onChange={(e) => {
-									const newVal = e.target.value;
-									setCustomInputs((prev) => ({ ...prev, [metadataKey]: newVal }));
-									if (newVal === "" && filters.metadata_filters?.[metadataKey]) {
-										handleChange(metadataKey, undefined);
+						<div key={metadataKey} data-testid={`metadata-${metadataKey}-filter-group`}>
+							<div className="text-muted-foreground px-3 pt-2 pb-1 text-xs font-medium">{metadataKey}</div>
+							{values.map((value: string) => (
+								<CheckboxFilterItem
+									key={value}
+									label={value}
+									checked={filters.metadata_filters?.[metadataKey] === value}
+									onCheckedChange={() => {
+										const currentValue = filters.metadata_filters?.[metadataKey];
+										handleChange(metadataKey, currentValue === value ? undefined : value);
+									}}
+									testId={`metadata-${metadataKey}-filter-checkbox-${value}`}
+								/>
+							))}
+							<div className="px-3 py-2.5">
+								<Input
+									className="placeholder:text-muted-foreground h-7 w-full rounded border bg-transparent px-2 text-sm"
+									placeholder="Custom value..."
+									value={
+										customInputs[metadataKey] ??
+										(filters.metadata_filters?.[metadataKey] && !values.includes(filters.metadata_filters[metadataKey])
+											? filters.metadata_filters[metadataKey]
+											: "")
 									}
-								}}
-								onKeyDown={(e) => {
-									if (e.key === "Enter" && customInputs[metadataKey]?.trim()) {
-										handleChange(metadataKey, customInputs[metadataKey].trim());
-									}
-								}}
-								data-testid={`metadata-${metadataKey}-filter-custom-input`}
-							/>
+									onChange={(e) => {
+										const newVal = e.target.value;
+										setCustomInputs((prev) => ({ ...prev, [metadataKey]: newVal }));
+										if (newVal === "" && filters.metadata_filters?.[metadataKey]) {
+											handleChange(metadataKey, undefined);
+										}
+									}}
+									onKeyDown={(e) => {
+										if (e.key === "Enter" && customInputs[metadataKey]?.trim()) {
+											handleChange(metadataKey, customInputs[metadataKey].trim());
+										}
+									}}
+									data-testid={`metadata-${metadataKey}-filter-custom-input`}
+								/>
+							</div>
 						</div>
-					</div>
 					))}
 				</>
 			)}

--- a/ui/components/filters/mcpFilterSidebar.tsx
+++ b/ui/components/filters/mcpFilterSidebar.tsx
@@ -8,7 +8,7 @@ import { Statuses } from "@/lib/constants/logs";
 import { useGetMCPLogsFilterDataQuery } from "@/lib/store";
 import type { MCPToolLogFilters } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import { ChevronDown, PanelLeftClose, PanelLeftOpen, Plus, RotateCcw } from "lucide-react";
+import { ChevronDown, LoaderCircle, PanelLeftClose, PanelLeftOpen, Plus, RotateCcw, Search } from "lucide-react";
 import { Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const COLLAPSE_STORAGE_KEY = "mcp-filter-sidebar-collapsed";
@@ -221,16 +221,16 @@ function SearchableCheckboxList({
 	inputRef,
 	allowCustom = false,
 	onSearch,
+	fetching,
 }: {
 	items: { key: string; label: string }[];
 	isSelected: (key: string) => boolean;
 	onToggle: (key: string) => void;
 	placeholder?: string;
 	inputRef?: Ref<HTMLInputElement>;
-	// See note in logsFilterSidebar.tsx: opt-in for filters whose stored value
-	// equals the displayed string. Not safe for ID-backed (KeyPair) filters.
 	allowCustom?: boolean;
 	onSearch?: (query: string) => void;
+	fetching?: boolean;
 }) {
 	const [query, setQuery] = useState("");
 	const normalized = query.trim().toLowerCase();
@@ -255,7 +255,12 @@ function SearchableCheckboxList({
 
 	return (
 		<>
-			<div className="border-b">
+			<div className="relative border-b">
+				{fetching ? (
+					<LoaderCircle className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2 animate-spin" />
+				) : (
+					<Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+				)}
 				<Input
 					ref={inputRef}
 					value={query}
@@ -267,7 +272,7 @@ function SearchableCheckboxList({
 						}
 					}}
 					placeholder={placeholder}
-					className="h-8 border-0 text-xs"
+					className="h-8 border-0 pl-8 text-xs"
 				/>
 			</div>
 			{filtered.map((item) => (
@@ -331,6 +336,7 @@ function ToolNamesFilter({ filters, onFiltersChange, defaultOpen }: FilterCompon
 		data: filterData,
 		isUninitialized,
 		isLoading,
+		isFetching,
 	} = useGetMCPLogsFilterDataQuery({ dimensions: ["tool_names"], q: searchQuery || undefined }, { skip: !opened && !hasActive });
 	const availableToolNames = filterData?.tool_names || [];
 	const items = useMemo(() => {
@@ -339,7 +345,7 @@ function ToolNamesFilter({ filters, onFiltersChange, defaultOpen }: FilterCompon
 		return [...availableToolNames, ...extras].map((n) => ({ key: n, label: n }));
 	}, [availableToolNames, filters.tool_names]);
 
-	if (!isUninitialized && !isLoading && availableToolNames.length === 0 && !hasActive) return null;
+	if (!isUninitialized && !isLoading && availableToolNames.length === 0 && !hasActive && !opened) return null;
 
 	return (
 		<FilterSection title="Tool Names" defaultOpen={defaultOpen || hasActive} loading={isLoading} onOpenChange={setOpened}>
@@ -355,6 +361,7 @@ function ToolNamesFilter({ filters, onFiltersChange, defaultOpen }: FilterCompon
 					onFiltersChange({ ...filters, tool_names: next });
 				}}
 				onSearch={setSearchQuery}
+				fetching={isFetching}
 			/>
 		</FilterSection>
 	);
@@ -373,6 +380,7 @@ function ServersFilter({ filters, onFiltersChange, defaultOpen }: FilterComponen
 		data: filterData,
 		isUninitialized,
 		isLoading,
+		isFetching,
 	} = useGetMCPLogsFilterDataQuery({ dimensions: ["server_labels"], q: searchQuery || undefined }, { skip: !opened && !hasActive });
 	const availableServerLabels = filterData?.server_labels || [];
 	const items = useMemo(() => {
@@ -381,7 +389,7 @@ function ServersFilter({ filters, onFiltersChange, defaultOpen }: FilterComponen
 		return [...availableServerLabels, ...extras].map((l) => ({ key: l, label: l }));
 	}, [availableServerLabels, filters.server_labels]);
 
-	if (!isUninitialized && !isLoading && availableServerLabels.length === 0 && !hasActive) return null;
+	if (!isUninitialized && !isLoading && availableServerLabels.length === 0 && !hasActive && !opened) return null;
 
 	return (
 		<FilterSection title="Servers" defaultOpen={defaultOpen || hasActive} loading={isLoading} onOpenChange={setOpened}>
@@ -397,6 +405,7 @@ function ServersFilter({ filters, onFiltersChange, defaultOpen }: FilterComponen
 					onFiltersChange({ ...filters, server_labels: next });
 				}}
 				onSearch={setSearchQuery}
+				fetching={isFetching}
 			/>
 		</FilterSection>
 	);
@@ -415,11 +424,12 @@ function VirtualKeysFilter({ filters, onFiltersChange, defaultOpen }: FilterComp
 		data: filterData,
 		isUninitialized,
 		isLoading,
+		isFetching,
 	} = useGetMCPLogsFilterDataQuery({ dimensions: ["virtual_keys"], q: searchQuery || undefined }, { skip: !opened && !hasActive });
 	const availableVirtualKeys = filterData?.virtual_keys || [];
 	const nameToId = useMemo(() => new Map(availableVirtualKeys.map((key) => [key.name, key.id])), [availableVirtualKeys]);
 
-	if (!isUninitialized && !isLoading && availableVirtualKeys.length === 0 && !hasActive) return null;
+	if (!isUninitialized && !isLoading && availableVirtualKeys.length === 0 && !hasActive && !opened) return null;
 
 	const isSelected = (name: string) => {
 		const id = nameToId.get(name) || name;
@@ -442,6 +452,7 @@ function VirtualKeysFilter({ filters, onFiltersChange, defaultOpen }: FilterComp
 				isSelected={isSelected}
 				onToggle={toggle}
 				onSearch={setSearchQuery}
+				fetching={isFetching}
 			/>
 		</FilterSection>
 	);


### PR DESCRIPTION
## Summary

Adds a search icon and a loading spinner to the search inputs in the logs and MCP filter sidebars. When a filter list is actively fetching data, the search icon is replaced with an animated spinner to give users visual feedback. When idle, a static search icon is shown instead of a bare input field.

## Changes

- Added a `Search` icon inside the search input for all `SearchableCheckboxList` filter sections in both `logsFilterSidebar.tsx` and `mcpFilterSidebar.tsx`, positioned absolutely on the left side of the input with appropriate padding adjustments.
- Added a `LoaderCircle` spinner that replaces the `Search` icon while `isFetching` is true, providing real-time feedback during server-side search queries.
- Exposed `isFetching` from `useGetAvailableFilterDataQuery` and `useGetMCPLogsFilterDataQuery` in all filter components (Stop Reason, Models, Aliases, Selected Keys, Virtual Keys, Routing Engines, Routing Rules, Metadata, Tool Names, Servers) and passed it down as a `fetching` prop to `SearchableCheckboxList`.
- Added the `Search` icon to the Session and User plain text inputs, which previously had no icon.
- Fixed indentation in the metadata filter entries block.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the logs or MCP logs page with the filter sidebar visible.
2. Expand any searchable filter section (e.g., Models, Aliases, Virtual Keys).
3. Verify a search icon appears on the left side of the search input.
4. Type a query and observe the spinner replacing the search icon while results are being fetched, then reverting to the search icon once the fetch completes.
5. Check the Session and User filter inputs also display the search icon.

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

Before: Search inputs had no icon and no loading indicator.

After: Search inputs display a `Search` icon at rest and an animated `LoaderCircle` spinner while fetching filter options.

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable