### PR TITLE
fix: bedrock chat tool arguments

### DIFF
--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -1837,8 +1837,8 @@ func convertToolCallToContentBlock(toolCall schemas.ChatAssistantMessageToolCall
 		if err := json.Compact(&buf, []byte(args)); err == nil {
 			input = buf.Bytes()
 		} else {
-			// Preserve original payload instead of silently dropping args.
-			input = json.RawMessage([]byte(args))
+			// invalid json recieved
+			input = json.RawMessage("{}")
 		}
 	}
 


### PR DESCRIPTION
## Summary

When a tool call contains invalid JSON arguments, the Bedrock provider now falls back to an empty JSON object `{}` instead of forwarding the malformed payload. This prevents downstream errors caused by passing invalid JSON to the Bedrock API.

## Changes

- When `json.Compact` fails on tool call arguments, the input is now set to `{}` rather than preserving the raw (invalid) string. Forwarding invalid JSON to Bedrock would cause API errors, so discarding it in favor of a safe empty object is the correct behavior.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Construct a tool call with malformed JSON arguments and send it through the Bedrock provider. Verify that the request succeeds and the tool input is treated as an empty object rather than causing a serialization or API error.

```sh
go test ./core/providers/bedrock/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Invalid input is sanitized to an empty object rather than being forwarded.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable