### PR TITLE
fix: bedrock mantle fixes

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2395,8 +2395,8 @@ func GetProviderName(defaultProvider schemas.ModelProvider, customConfig *schema
 // after sending the finish_reason. This function helps determine the correct stream termination logic.
 func ProviderSendsDoneMarker(providerName schemas.ModelProvider) bool {
 	switch providerName {
-	case schemas.Cerebras, schemas.Perplexity, schemas.HuggingFace:
-		// Cerebras, Perplexity, and HuggingFace don't send [DONE] marker, ends stream after finish_reason
+	case schemas.Cerebras, schemas.Perplexity, schemas.HuggingFace, schemas.Bedrock:
+		// Cerebras, Perplexity, HuggingFace, and Bedrock mantle don't send [DONE] marker, ends stream after finish_reason
 		return false
 	default:
 		// Default to expecting [DONE] marker for safety

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bytedance/sonic"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -90,6 +91,27 @@ type BifrostResponsesResponse struct {
 	SearchResults []SearchResult `json:"search_results,omitempty"`
 	Videos        []VideoResult  `json:"videos,omitempty"`
 	Citations     []string       `json:"citations,omitempty"`
+}
+
+// UnmarshalJSON handles providers that return created_at/completed_at as floats (e.g. Bedrock mantle).
+func (r *BifrostResponsesResponse) UnmarshalJSON(data []byte) error {
+	type Alias BifrostResponsesResponse
+	aux := &struct {
+		CreatedAt   float64  `json:"created_at"`
+		CompletedAt *float64 `json:"completed_at"`
+		*Alias
+	}{
+		Alias: (*Alias)(r),
+	}
+	if err := sonic.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	r.CreatedAt = int(aux.CreatedAt)
+	if aux.CompletedAt != nil {
+		v := int(*aux.CompletedAt)
+		r.CompletedAt = &v
+	}
+	return nil
 }
 
 // BackfillParams populates response fields from the request that are needed

--- a/core/schemas/responses_test.go
+++ b/core/schemas/responses_test.go
@@ -51,6 +51,66 @@ func TestBifrostResponsesStreamResponsePreservesOpenAIStreamMetadata(t *testing.
 	}
 }
 
+func TestBifrostResponsesResponseUnmarshalTimestamps(t *testing.T) {
+	t.Run("float created_at is truncated to int", func(t *testing.T) {
+		raw := []byte(`{"object":"response","model":"m","created_at":1716000000.5,"output":[]}`)
+		var r BifrostResponsesResponse
+		if err := Unmarshal(raw, &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if r.CreatedAt != 1716000000 {
+			t.Fatalf("expected CreatedAt 1716000000, got %d", r.CreatedAt)
+		}
+		if r.CompletedAt != nil {
+			t.Fatalf("expected CompletedAt nil, got %v", r.CompletedAt)
+		}
+	})
+
+	t.Run("integer created_at is preserved", func(t *testing.T) {
+		raw := []byte(`{"object":"response","model":"m","created_at":1716000000,"output":[]}`)
+		var r BifrostResponsesResponse
+		if err := Unmarshal(raw, &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if r.CreatedAt != 1716000000 {
+			t.Fatalf("expected CreatedAt 1716000000, got %d", r.CreatedAt)
+		}
+	})
+
+	t.Run("null completed_at leaves field nil", func(t *testing.T) {
+		raw := []byte(`{"object":"response","model":"m","created_at":1716000000,"completed_at":null,"output":[]}`)
+		var r BifrostResponsesResponse
+		if err := Unmarshal(raw, &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if r.CompletedAt != nil {
+			t.Fatalf("expected CompletedAt nil, got %v", r.CompletedAt)
+		}
+	})
+
+	t.Run("absent completed_at leaves field nil", func(t *testing.T) {
+		raw := []byte(`{"object":"response","model":"m","created_at":1716000000,"output":[]}`)
+		var r BifrostResponsesResponse
+		if err := Unmarshal(raw, &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if r.CompletedAt != nil {
+			t.Fatalf("expected CompletedAt nil, got %v", r.CompletedAt)
+		}
+	})
+
+	t.Run("float completed_at is truncated to int", func(t *testing.T) {
+		raw := []byte(`{"object":"response","model":"m","created_at":1716000000,"completed_at":1716000099.9,"output":[]}`)
+		var r BifrostResponsesResponse
+		if err := Unmarshal(raw, &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if r.CompletedAt == nil || *r.CompletedAt != 1716000099 {
+			t.Fatalf("expected CompletedAt 1716000099, got %v", r.CompletedAt)
+		}
+	})
+}
+
 func TestResponsesMessagePreservesOpenAIPhase(t *testing.T) {
 	raw := []byte(`{"id":"msg_123","type":"message","status":"in_progress","content":[],"phase":"final_answer","role":"assistant"}`)
 


### PR DESCRIPTION
## Summary

Adds Bedrock mantle provider support for stream termination handling and fixes JSON unmarshalling of `created_at`/`completed_at` fields that Bedrock returns as floats instead of integers.

## Changes

- Added `schemas.Bedrock` to the `ProviderSendsDoneMarker` switch case so that Bedrock streams are correctly terminated after `finish_reason` rather than waiting for a `[DONE]` marker that never arrives.
- Added a custom `UnmarshalJSON` method on `BifrostResponsesResponse` to handle Bedrock's float-typed `created_at` and `completed_at` timestamp fields, converting them to `int` as expected by the struct.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a streaming request through the Bedrock provider and verify the stream terminates correctly after `finish_reason` without hanging. Also verify that responses with float-typed `created_at`/`completed_at` fields are correctly parsed.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable