### PR TITLE
Fix cross-provider key name collision in fallback lookup

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -631,8 +631,11 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 					return s.parseGormError(err)
 				}
 			} else if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-				// KeyID not found, try fallback lookup by Name (handles config reload with new UUID)
-				result = txDB.WithContext(ctx).Where("name = ?", dbKey.Name).First(&existingKey)
+				// KeyID not found, try fallback lookup by Name scoped to this provider
+				// (handles config reload with new UUID). The composite unique index
+				// (provider_id, name) guarantees names are unique per-provider, so we
+				// must scope the lookup to avoid matching a key from a different provider.
+				result = txDB.WithContext(ctx).Where("name = ? AND provider_id = ?", dbKey.Name, dbProvider.ID).First(&existingKey)
 				if result.Error == nil {
 					// Found by name - update existing key, preserve original KeyID
 					dbKey.ID = existingKey.ID                             // Keep the same database ID

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -208,6 +208,64 @@ func TestUpdateProvidersConfig_MultipleKeys(t *testing.T) {
 	assert.Len(t, result["anthropic"].Keys, 1)
 }
 
+func TestUpdateProvidersConfig_CrossProviderSameKeyName(t *testing.T) {
+	// This test verifies that two providers can each have a key with the same name
+	// without one provider's key being overwritten by the other.
+	// This was broken before the fix: the name fallback in UpdateProvidersConfig
+	// used a global lookup ("name = ?") which matched keys across providers,
+	// causing data corruption.
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	providers := map[schemas.ModelProvider]ProviderConfig{
+		"openai": {
+			Keys: []schemas.Key{
+				{ID: "openai-uuid-1", Name: "default", Value: *schemas.NewEnvVar("sk-openai-key"), Weight: 1.0},
+			},
+		},
+		"anthropic": {
+			Keys: []schemas.Key{
+				{ID: "anthropic-uuid-1", Name: "default", Value: *schemas.NewEnvVar("sk-anthropic-key"), Weight: 1.0},
+			},
+		},
+	}
+
+	err := store.UpdateProvidersConfig(ctx, providers)
+	require.NoError(t, err, "Should handle duplicate key names across different providers")
+
+	// Verify both providers exist and each has exactly one key
+	result, err := store.GetProvidersConfig(ctx)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	// openai should have its "default" key intact
+	openaiCfg, ok := result["openai"]
+	require.True(t, ok, "openai provider should exist")
+	require.Len(t, openaiCfg.Keys, 1, "openai should have 1 key")
+	assert.Equal(t, "openai-uuid-1", openaiCfg.Keys[0].ID, "openai key ID should be preserved")
+	assert.Equal(t, "default", openaiCfg.Keys[0].Name, "openai key name should be 'default'")
+	assert.Equal(t, "sk-openai-key", openaiCfg.Keys[0].Value.Val, "openai key value should be preserved")
+
+	// anthropic should have its "default" key intact
+	anthropicCfg, ok := result["anthropic"]
+	require.True(t, ok, "anthropic provider should exist")
+	require.Len(t, anthropicCfg.Keys, 1, "anthropic should have 1 key")
+	assert.Equal(t, "anthropic-uuid-1", anthropicCfg.Keys[0].ID, "anthropic key ID should be preserved")
+	assert.Equal(t, "default", anthropicCfg.Keys[0].Name, "anthropic key name should be 'default'")
+	assert.Equal(t, "sk-anthropic-key", anthropicCfg.Keys[0].Value.Val, "anthropic key value should be preserved")
+
+	// Verify the keys are distinct (not the same row) by checking provider association
+	openaiProviderCfg, err := store.GetProviderConfig(ctx, "openai")
+	require.NoError(t, err)
+	anthropicProviderCfg, err := store.GetProviderConfig(ctx, "anthropic")
+	require.NoError(t, err)
+
+	assert.Len(t, openaiProviderCfg.Keys, 1, "openai should still have 1 key")
+	assert.Len(t, anthropicProviderCfg.Keys, 1, "anthropic should still have 1 key")
+	assert.Equal(t, "sk-openai-key", openaiProviderCfg.Keys[0].Value.Val, "openai value not overwritten")
+	assert.Equal(t, "sk-anthropic-key", anthropicProviderCfg.Keys[0].Value.Val, "anthropic value not overwritten")
+}
+
 func TestProviderKeyCRUD(t *testing.T) {
 	store := setupRDBTestStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fixes the startup sync (`UpdateProvidersConfig`) to scope key name lookups by `provider_id`. Previously, when the sync encountered a key whose UUID didn't match any existing row, it fell back to a global name lookup (`Where("name = ?")`) that could match a key belonging to a *different* provider, silently overwriting it.

The fix adds `AND provider_id = ?` to the name fallback query, ensuring it only matches keys within the same provider. This aligns with the new composite unique index `(provider_id, name)` introduced in the sibling PR, where key names are unique per-provider rather than globally.

## Changes

- **rdb.go**: Changed the name fallback lookup in `UpdateProvidersConfig` from `Where("name = ?")` (global) to `Where("name = ? AND provider_id = ?")` (scoped to the current provider)
- **rdb_test.go**: Added `TestUpdateProvidersConfig_CrossProviderSameKeyName` regression test that creates two providers each with a key named `"default"` and verifies both keys are preserved after the sync

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

The regression test directly validates the fix:

```sh
cd framework/configstore && go test -run TestUpdateProvidersConfig_CrossProviderSameKeyName -v
```

On the old (buggy) code, this test fails with `"[] should have 1 item(s), but has 0"` for the first provider. On the fixed code, it passes.

All existing tests still pass:
```sh
cd framework/configstore && go test ./...
```

## Screenshots/Recordings

N/A — No UI changes.

## Breaking changes

- [ ] Yes
- [x] No

The fix only changes the startup sync behavior from "wrong" (global lookup, data-corrupting) to "right" (scoped lookup). No API or schema changes.

## Related issues

Fixes the root cause of the HTTP 500 error on provider update: the startup sync was corrupting key ownership between providers, and the subsequent single-provider update couldn't create a new key because the name was already taken globally.

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

## Why this matters
Before this change, API key names had to be unique across all providers. If you had two providers - say OpenAI and Anthropic - they could not both have an API key named "default". The second one would collide with the first and fail with an error.

After this change, key names only need to be unique per provider. Each provider can independently have a "default" key (or any other name) without conflict.