### PR TITLE
fix(images): passthrough extra params

### DIFF
--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -1887,6 +1887,7 @@ func (h *CompletionHandler) imageGeneration(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, "Failed to convert context")
 		return
 	}
+	bifrostCtx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
 
 	// Handle streaming image generation
 	if req.BifrostParams.Stream != nil && *req.BifrostParams.Stream {


### PR DESCRIPTION
## Summary

Fixes image-generation ExtraParams passthrough for `/v1/images/generations`.

Typed image-generation params were already being decoded and forwarded, but unknown/provider-specific params were captured into `ImageGenerationParameters.ExtraParams` and then dropped before reaching the downstream provider payload. This change enables the existing ExtraParams passthrough path for image-generation requests.

## Changes

* Enabled `schemas.BifrostContextKeyPassthroughExtraParams` in the image-generation handler.


## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

## Affected areas

* [ ] Core (Go)
* [x] Transports (HTTP)
* [x] Providers/Integrations
* [ ] Plugins
* [ ] UI (React)
* [ ] Docs

## How to test

Validated locally on port `9090` with real Gemini/Imagen provider dispatch.


Start Bifrost with Gemini configured:

```sh
GEMINI_API_KEY="$(tr -d '\r\n' < transports/bifrost-http/tmp/env.GEMINI_API_KEY)" setsid ./tmp/bifrost-http \
  -host 127.0.0.1 \
  -port 9090 \
  -log-style json \
  -log-level debug \
  -app-dir /tmp/bifrost-gemini-image-validation-app \
  > /tmp/bifrost9090.log 
```

Health/UI checks:

```sh
curl -sS -o /tmp/bifrost-health.txt -w "%{http_code}\n" http://127.0.0.1:9090/health
curl -sS -o /tmp/bifrost-root.html -w "%{http_code}\n" http://127.0.0.1:9090/
curl -sS -o /tmp/bifrost-observability.html -w "%{http_code}\n" http://127.0.0.1:9090/observability
curl -sS http://127.0.0.1:9090/v1/models | grep "imagen-4.0-generate-001"
```

Runtime validation request:

```sh
curl -sS -w '\nHTTP_STATUS:%{http_code}\n' \
  -X POST http://127.0.0.1:9090/v1/images/generations \
  -H 'Content-Type: application/json' \
  --data @/tmp/gemini-image-request-with-unknown.json
```

Before/after validation:

Before the fix:

* Temporarily removed the one-line passthrough flag.
* Rebuilt and restarted Bifrost.
* Sent the same Gemini image-generation request.
* Response returned `400`.
* `extra_param_test` was not present in the provider error.
* This showed the unknown ExtraParam was dropped before reaching Gemini.

After the fix:

* Restored the passthrough flag.
* Rebuilt and restarted Bifrost.
* Sent the same request again.
* Response returned `400`.
* Gemini returned:

```text
Invalid JSON payload received. Unknown name "extra_param_test": Cannot find field.
```

This proves `extra_param_test` reached the real Gemini API after the fix. The validation proves provider dispatch and ExtraParams forwarding. It does not claim successful image generation, since Imagen may still fail due to provider validation or account/plan restrictions.

No new configs or environment variables are introduced by this PR.

## Screenshots/Recordings

<img width="1170" height="270" alt="Screenshot 2026-05-18 173149" src="https://github.com/user-attachments/assets/23e1beb9-6a97-419b-ab85-ce0466b9272d" />


## Breaking changes

* [ ] Yes
* [x] No

## Related issues

Closes BF-565

## Security considerations

No 

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [ ] I added/updated tests where appropriate
* [ ] I updated documentation where needed
* [x] I verified builds succeed (Go and UI)
* [ ] I verified the CI pipeline passes locally if applicable
