### PR TITLE
fix: emit role chunk from anthropic message start in chat stream

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -1090,6 +1090,23 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.Bi
 
 	switch chunk.Type {
 	case AnthropicStreamEventTypeMessageStart:
+		if chunk.Message != nil && chunk.Message.Role != "" {
+			role := chunk.Message.Role
+			streamResponse := &schemas.BifrostChatResponse{
+				Object: "chat.completion.chunk",
+				Choices: []schemas.BifrostResponseChoice{
+					{
+						Index: 0,
+						ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+							Delta: &schemas.ChatStreamResponseChoiceDelta{
+								Role: &role,
+							},
+						},
+					},
+				},
+			}
+			return streamResponse, nil, false
+		}
 		return nil, nil, false
 
 	case AnthropicStreamEventTypeMessageStop:


### PR DESCRIPTION
## Summary

When processing Anthropic streaming events, the `message_start` event was previously discarded entirely. This meant the assistant role information included in the initial message event was never forwarded to the caller, resulting in incomplete stream chunks.

## Changes

- When a `message_start` event contains a non-empty role on the message, a `chat.completion.chunk` stream response is now returned with the role populated in the delta, rather than returning `nil` and silently dropping it.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a streaming chat completion request through the Anthropic provider and verify that the first chunk in the stream includes the assistant role in the delta.

```sh
go test ./core/providers/anthropic/...
```

Confirm the first streamed chunk contains:
```json
{
  "object": "chat.completion.chunk",
  "choices": [
    {
      "index": 0,
      "delta": {
        "role": "assistant"
      }
    }
  ]
}
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable