### PR TITLE
fix: build fix for Windows CLI

### DIFF
--- a/cli/internal/runtime/scrollback.go
+++ b/cli/internal/runtime/scrollback.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package runtime
 
 import (

--- a/cli/internal/runtime/scrollback_test.go
+++ b/cli/internal/runtime/scrollback_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package runtime
 
 import (


### PR DESCRIPTION
## Summary

Excludes `scrollback.go` and its corresponding test file from Windows builds by adding `//go:build !windows` build constraints. This prevents compilation errors or unsupported functionality from being included on Windows platforms.

## Changes

- Added `//go:build !windows` build tag to `scrollback.go` to skip compilation on Windows
- Added `//go:build !windows` build tag to `scrollback_test.go` to skip the associated tests on Windows

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Verify the build succeeds on Windows without scrollback
GOOS=windows go build ./cli/internal/runtime/...

# Verify tests pass on non-Windows platforms
go test ./cli/internal/runtime/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable