### PR TITLE
fix(mcp): remove stale stats from logs list response

### DIFF
--- a/docs/openapi/schemas/management/logging.yaml
+++ b/docs/openapi/schemas/management/logging.yaml
@@ -316,8 +316,6 @@ SearchMCPLogsResponse:
           type: integer
           format: int64
           description: Total number of items matching the query
-    stats:
-      $ref: '#/MCPToolLogStats'
     has_logs:
       type: boolean
       description: Whether any logs exist in the system

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -3291,9 +3291,6 @@ func (s *RDBLogStore) SearchMCPToolLogs(ctx context.Context, filters MCPToolLogS
 			return &MCPToolLogSearchResult{
 				Logs:       logs,
 				Pagination: pagination,
-				Stats: MCPToolLogStats{
-					TotalExecutions: totalCount,
-				},
 			}, nil
 		}
 		return nil, err
@@ -3321,10 +3318,7 @@ func (s *RDBLogStore) SearchMCPToolLogs(ctx context.Context, filters MCPToolLogS
 	return &MCPToolLogSearchResult{
 		Logs:       logs,
 		Pagination: pagination,
-		Stats: MCPToolLogStats{
-			TotalExecutions: totalCount,
-		},
-		HasLogs: hasLogs,
+		HasLogs:    hasLogs,
 	}, nil
 }
 

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -1030,7 +1030,6 @@ type MCPToolLogSearchFilters struct {
 type MCPToolLogSearchResult struct {
 	Logs       []MCPToolLog      `json:"logs"`
 	Pagination PaginationOptions `json:"pagination"`
-	Stats      MCPToolLogStats   `json:"stats"`
 	HasLogs    bool              `json:"has_logs"`
 }
 

--- a/ui/app/workspace/mcp-logs/page.tsx
+++ b/ui/app/workspace/mcp-logs/page.tsx
@@ -191,7 +191,7 @@ export default function MCPLogsPage() {
 
 	// Derive data directly from RTK
 	const logs = logsData?.logs ?? [];
-	const totalItems = logsData?.stats?.total_executions ?? 0;
+	const totalItems = logsData?.pagination?.total_count ?? 0;
 
 	const selectedLog = useMemo(() => (selectedLogId ? (logs.find((l) => l.id === selectedLogId) ?? null) : null), [selectedLogId, logs]);
 

--- a/ui/lib/store/apis/mcpLogsApi.ts
+++ b/ui/lib/store/apis/mcpLogsApi.ts
@@ -46,8 +46,7 @@ export const mcpLogsApi = baseApi.injectEndpoints({
 		getMCPLogs: builder.query<
 			{
 				logs: MCPToolLogEntry[];
-				pagination: Pagination;
-				stats: MCPToolLogStats;
+				pagination: Pagination & { total_count: number };
 				has_logs: boolean;
 			},
 			{

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -1077,8 +1077,7 @@ export interface MCPToolLogStats {
 // MCP Tool Log Search Response
 export interface MCPToolLogsResponse {
 	logs: MCPToolLogEntry[];
-	pagination: Pagination;
-	stats: MCPToolLogStats;
+	pagination: Pagination & { total_count: number };
 	has_logs: boolean;
 }
 


### PR DESCRIPTION
## Summary

Removes the stale top-level `stats` object from the MCP logs list response.

While testing MCP logs end-to-end, `/api/mcp-logs?limit=5` returned the correct log row with `status: success` and `cost: 0.5`, but the top-level `stats` object in the same response showed zero values for `success_rate`, `average_latency`, and `total_cost`.

The correct stats are already available from the dedicated `/api/mcp-logs/stats` endpoint, which is what the MCP Logs UI cards use.

## Changes

* Removed `stats` from the `/api/mcp-logs` list response.
* Kept log rows, pagination, and `has_logs` unchanged.
* Kept `/api/mcp-logs/stats` unchanged.
* Updated frontend response types.
* Updated MCP Logs pagination to use `pagination.total_count`.
* Updated the OpenAPI schema for the MCP logs list response.

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Refactor
* [x] Documentation
* [ ] Chore/CI

## Affected areas

* [x] Core (Go)
* [x] Transports (HTTP)
* [ ] Providers/Integrations
* [ ] Plugins
* [x] UI (React)
* [x] Docs

## How to test

Backend:

`go test ./framework/logstore/...`

`go test ./plugins/logging/...`

`go test ./transports/bifrost-http/handlers/...`

UI:

`cd ui`

`npm run build`

Runtime verification:

`curl -s "http://localhost:9090/api/mcp-logs?limit=5" | jq '{has_stats: has("stats"), log_preserved: (.logs[0] | {tool_name, server_label, status, cost})}'`

`curl -s "http://localhost:9090/api/mcp-logs/stats" | jq .`

Verified that:

* `/api/mcp-logs` returns `has_stats: false`
* MCP log row is still present with `tool_name`, `server_label`, `status`, and `cost`
* `/api/mcp-logs/stats` still returns correct stats
* MCP Logs UI still loads and shows the stat cards, log row, and details drawer correctly

## Screenshots/Recordings

Added screenshots for:

* API response showing `has_stats: false`
* Dedicated stats endpoint still returning correct values

<img width="1668" height="430" alt="Screenshot 2026-05-19 122713" src="https://github.com/user-attachments/assets/8893536c-775f-4307-a44f-a8960b749499" />



* MCP Logs UI showing correct cards and preserved log row
* MCP log details drawer showing arguments and result

<img width="1142" height="881" alt="Screenshot 2026-05-19 122758" src="https://github.com/user-attachments/assets/acbc3895-76e2-469b-a745-3e751a25df7e" />



## Breaking changes

* [x] Yes
* [ ] No

This removes the top-level `stats` field from the `/api/mcp-logs` list response.

Any consumer using that field should use the dedicated `/api/mcp-logs/stats` endpoint instead.

## Related issues

N/A

## Security considerations

No security impact. This does not change auth, secrets handling, log storage, or MCP tool execution behavior.

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [x] I added/updated tests where appropriate
* [x] I updated documentation where needed
* [x] I verified builds succeed (Go and UI)
* [x] I verified the CI pipeline passes locally if applicable
