### PR TITLE
fix: fixes forwarding of reasoning content while conversion of Responses to Chat

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2415,6 +2415,10 @@ func ProviderIsResponsesAPINative(providerName schemas.ModelProvider) bool {
 
 // ReleaseStreamingResponse releases a streaming response by draining the body stream and releasing the response.
 func ReleaseStreamingResponse(ctx *schemas.BifrostContext, resp *fasthttp.Response) {
+	// Skip drain + ReleaseResponse if the stream was already closed (e.g. by SetupStreamCancellation); fasthttp.ReleaseResponse would re-Close and nil-deref the TCP conn — leaking to GC is the intentional trade-off, so keep the defer below this check.
+	if closed, ok := ctx.Value(schemas.BifrostContextKeyConnectionClosed).(bool); ok && closed {
+		return
+	}
 	defer func() {
 		if r := recover(); r != nil {
 			getLogger().Debug("stream already closed before drain in ReleaseStreamingResponse: %v\n", r)
@@ -2422,11 +2426,6 @@ func ReleaseStreamingResponse(ctx *schemas.BifrostContext, resp *fasthttp.Respon
 		// Always release the response to prevent leaks, even after a panic
 		fasthttp.ReleaseResponse(resp)
 	}()
-	// First we will check if the connection is already closed
-	// In that case we won't drain the body stream, as it is already closed
-	if closed, ok := ctx.Value(schemas.BifrostContextKeyConnectionClosed).(bool); ok && closed {
-		return
-	}
 	// Drain any remaining data from the body stream before releasing.
 	// This prevents "whitespace in header" errors when the connection is reused
 	// (see: https://github.com/valyala/fasthttp/issues/1743).
@@ -2438,6 +2437,12 @@ func ReleaseStreamingResponse(ctx *schemas.BifrostContext, resp *fasthttp.Respon
 			if err := closer.Close(); err != nil {
 				getLogger().Warn("failed to close streaming response body: %v", err)
 			}
+			ctx.SetValue(schemas.BifrostContextKeyConnectionClosed, true)
+		} else if wce, ok := bodyStream.(streamCloserWithError); ok {
+			if err := wce.CloseWithError(ctx.Err()); err != nil {
+				getLogger().Debug(fmt.Sprintf("Error closing body stream on context done: %v", err))
+			}
+			ctx.SetValue(schemas.BifrostContextKeyConnectionClosed, true)
 		}
 	}
 }

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -395,6 +395,77 @@ func (cm *ChatMessage) ToResponsesMessages() []ResponsesMessage {
 
 	var messages []ResponsesMessage
 
+	// Emit reasoning first so chat->responses->anthropic preserves reasoning content
+	// (Anthropic signatures, OpenAI encrypted/summary entries) for clients to echo back; see symmetric ToChatMessages buffering.
+	if cm.Role == ChatMessageRoleAssistant && cm.ChatAssistantMessage != nil {
+		am := cm.ChatAssistantMessage
+		if len(am.ReasoningDetails) > 0 {
+			var contentBlocks []ResponsesMessageContentBlock
+			var summaries []ResponsesReasoningSummary
+			var encryptedContent *string
+			for _, d := range am.ReasoningDetails {
+				switch d.Type {
+				case BifrostReasoningDetailsTypeText:
+					if d.Text != nil && *d.Text != "" {
+						contentBlocks = append(contentBlocks, ResponsesMessageContentBlock{
+							Type:      ResponsesOutputMessageContentTypeReasoning,
+							Text:      d.Text,
+							Signature: d.Signature,
+						})
+					}
+				case BifrostReasoningDetailsTypeSummary:
+					if d.Summary != nil {
+						summaries = append(summaries, ResponsesReasoningSummary{
+							Type: ResponsesReasoningContentBlockTypeSummaryText,
+							Text: *d.Summary,
+						})
+					}
+				case BifrostReasoningDetailsTypeEncrypted:
+					if d.Data != nil {
+						encryptedContent = d.Data
+					}
+				}
+			}
+			if len(contentBlocks) > 0 || len(summaries) > 0 || encryptedContent != nil {
+				reasoningType := ResponsesMessageTypeReasoning
+				reasoningRole := ResponsesInputMessageRoleAssistant
+				rm := ResponsesMessage{
+					ID:   Ptr("rs_" + GetRandomString(50)),
+					Type: &reasoningType,
+					Role: &reasoningRole,
+				}
+				if len(contentBlocks) > 0 {
+					rm.Content = &ResponsesMessageContent{ContentBlocks: contentBlocks}
+				}
+				if len(summaries) > 0 || encryptedContent != nil {
+					rm.ResponsesReasoning = &ResponsesReasoning{
+						Summary:          summaries,
+						EncryptedContent: encryptedContent,
+					}
+				}
+				messages = append(messages, rm)
+			}
+		} else if am.Reasoning != nil && *am.Reasoning != "" {
+			// Fallback for providers that surface plain reasoning text only (e.g. DeepSeek).
+			reasoningType := ResponsesMessageTypeReasoning
+			reasoningRole := ResponsesInputMessageRoleAssistant
+			reasoningText := *am.Reasoning
+			messages = append(messages, ResponsesMessage{
+				ID:   Ptr("rs_" + GetRandomString(50)),
+				Type: &reasoningType,
+				Role: &reasoningRole,
+				Content: &ResponsesMessageContent{
+					ContentBlocks: []ResponsesMessageContentBlock{
+						{
+							Type: ResponsesOutputMessageContentTypeReasoning,
+							Text: &reasoningText,
+						},
+					},
+				},
+			})
+		}
+	}
+
 	// Check if this is an assistant message with multiple tool calls that need expansion
 	if cm.ChatAssistantMessage != nil && cm.ChatAssistantMessage.ToolCalls != nil && len(cm.ChatAssistantMessage.ToolCalls) > 0 {
 		// Expand multiple tool calls into separate function_call items
@@ -641,9 +712,61 @@ func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 
 	var chatMessages []ChatMessage
 	var currentToolCalls []ChatAssistantMessageToolCall
+	var pendingReasoning strings.Builder
+	var pendingReasoningDetails []ChatReasoningDetails
+
+	// attachPendingReasoning carries the buffered reasoning onto the next assistant turn so multi-turn flows via the Responses→Chat fallback don't 400 on DeepSeek thinking mode.
+	attachPendingReasoning := func(msg *ChatAssistantMessage) {
+		if pendingReasoning.Len() == 0 && len(pendingReasoningDetails) == 0 {
+			return
+		}
+		if msg.Reasoning == nil && pendingReasoning.Len() > 0 {
+			text := pendingReasoning.String()
+			msg.Reasoning = &text
+		}
+		if len(pendingReasoningDetails) > 0 {
+			msg.ReasoningDetails = append(msg.ReasoningDetails, pendingReasoningDetails...)
+		}
+		pendingReasoning.Reset()
+		pendingReasoningDetails = nil
+	}
 
 	for _, rm := range rms {
 		if rm.Type != nil && *rm.Type == ResponsesMessageTypeReasoning {
+			// Buffer reasoning so it attaches to the next assistant message.
+			if rm.Content != nil {
+				for _, block := range rm.Content.ContentBlocks {
+					if block.Type == ResponsesOutputMessageContentTypeReasoning && block.Text != nil {
+						if pendingReasoning.Len() > 0 {
+							pendingReasoning.WriteByte('\n')
+						}
+						pendingReasoning.WriteString(*block.Text)
+						pendingReasoningDetails = append(pendingReasoningDetails, ChatReasoningDetails{
+							Index:     len(pendingReasoningDetails),
+							Type:      BifrostReasoningDetailsTypeText,
+							Text:      block.Text,
+							Signature: block.Signature,
+						})
+					}
+				}
+			}
+			if rm.ResponsesReasoning != nil {
+				for _, summary := range rm.ResponsesReasoning.Summary {
+					summaryText := summary.Text
+					pendingReasoningDetails = append(pendingReasoningDetails, ChatReasoningDetails{
+						Index:   len(pendingReasoningDetails),
+						Type:    BifrostReasoningDetailsTypeSummary,
+						Summary: &summaryText,
+					})
+				}
+				if rm.ResponsesReasoning.EncryptedContent != nil {
+					pendingReasoningDetails = append(pendingReasoningDetails, ChatReasoningDetails{
+						Index: len(pendingReasoningDetails),
+						Type:  BifrostReasoningDetailsTypeEncrypted,
+						Data:  rm.ResponsesReasoning.EncryptedContent,
+					})
+				}
+			}
 			continue
 		}
 
@@ -675,11 +798,13 @@ func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 		if len(currentToolCalls) > 0 {
 			// Create a copy of the slice to avoid shared slice header issues
 			toolCallsCopy := append([]ChatAssistantMessageToolCall(nil), currentToolCalls...)
+			assistant := &ChatAssistantMessage{
+				ToolCalls: toolCallsCopy,
+			}
+			attachPendingReasoning(assistant)
 			chatMessages = append(chatMessages, ChatMessage{
-				Role: ChatMessageRoleAssistant,
-				ChatAssistantMessage: &ChatAssistantMessage{
-					ToolCalls: toolCallsCopy,
-				},
+				Role:                 ChatMessageRoleAssistant,
+				ChatAssistantMessage: assistant,
 			})
 			currentToolCalls = nil // Reset for next batch
 		}
@@ -818,6 +943,15 @@ func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 			}
 		}
 
+		// Attach any buffered reasoning to assistant turns (regardless of
+		// whether they also carry tool calls or just text content).
+		if cm.Role == ChatMessageRoleAssistant && (pendingReasoning.Len() > 0 || len(pendingReasoningDetails) > 0) {
+			if cm.ChatAssistantMessage == nil {
+				cm.ChatAssistantMessage = &ChatAssistantMessage{}
+			}
+			attachPendingReasoning(cm.ChatAssistantMessage)
+		}
+
 		chatMessages = append(chatMessages, cm)
 	}
 
@@ -825,11 +959,13 @@ func ToChatMessages(rms []ResponsesMessage) []ChatMessage {
 	if len(currentToolCalls) > 0 {
 		// Create a copy of the slice to avoid shared slice header issues
 		toolCallsCopy := append([]ChatAssistantMessageToolCall(nil), currentToolCalls...)
+		assistant := &ChatAssistantMessage{
+			ToolCalls: toolCallsCopy,
+		}
+		attachPendingReasoning(assistant)
 		chatMessages = append(chatMessages, ChatMessage{
-			Role: ChatMessageRoleAssistant,
-			ChatAssistantMessage: &ChatAssistantMessage{
-				ToolCalls: toolCallsCopy,
-			},
+			Role:                 ChatMessageRoleAssistant,
+			ChatAssistantMessage: assistant,
 		})
 	}
 

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -82,6 +82,160 @@ func TestToChatMessages_LeavesExistingSupportedRolesUnchanged(t *testing.T) {
 	}
 }
 
+func TestToChatMessages_AttachesReasoningToNextAssistantMessage(t *testing.T) {
+	reasoningText := "Let me think about this step by step."
+	signature := "sig_abc"
+
+	messages := []ResponsesMessage{
+		{Role: Ptr(ResponsesInputMessageRoleUser), Content: &ResponsesMessageContent{ContentStr: Ptr("hi")}},
+		{
+			Type: Ptr(ResponsesMessageTypeReasoning),
+			Role: Ptr(ResponsesInputMessageRoleAssistant),
+			Content: &ResponsesMessageContent{
+				ContentBlocks: []ResponsesMessageContentBlock{
+					{
+						Type:      ResponsesOutputMessageContentTypeReasoning,
+						Text:      &reasoningText,
+						Signature: &signature,
+					},
+				},
+			},
+		},
+		{
+			Role:    Ptr(ResponsesInputMessageRoleAssistant),
+			Content: &ResponsesMessageContent{ContentStr: Ptr("Hello!")},
+		},
+	}
+
+	chatMessages := ToChatMessages(messages)
+	if len(chatMessages) != 2 {
+		t.Fatalf("expected 2 chat messages (reasoning absorbed into assistant), got %d", len(chatMessages))
+	}
+	assistant := chatMessages[1]
+	if assistant.Role != ChatMessageRoleAssistant {
+		t.Fatalf("expected assistant role, got %q", assistant.Role)
+	}
+	if assistant.ChatAssistantMessage == nil {
+		t.Fatal("expected ChatAssistantMessage attached to carry reasoning")
+	}
+	if assistant.ChatAssistantMessage.Reasoning == nil || *assistant.ChatAssistantMessage.Reasoning != reasoningText {
+		t.Fatalf("expected reasoning %q, got %#v", reasoningText, assistant.ChatAssistantMessage.Reasoning)
+	}
+	if len(assistant.ChatAssistantMessage.ReasoningDetails) != 1 {
+		t.Fatalf("expected 1 reasoning detail, got %d", len(assistant.ChatAssistantMessage.ReasoningDetails))
+	}
+	if assistant.ChatAssistantMessage.ReasoningDetails[0].Signature == nil || *assistant.ChatAssistantMessage.ReasoningDetails[0].Signature != signature {
+		t.Fatalf("expected signature %q preserved, got %#v", signature, assistant.ChatAssistantMessage.ReasoningDetails[0].Signature)
+	}
+}
+
+func TestToChatMessages_AttachesReasoningToToolCallAssistantMessage(t *testing.T) {
+	reasoningText := "I need to call the search tool."
+
+	messages := []ResponsesMessage{
+		{
+			Type: Ptr(ResponsesMessageTypeReasoning),
+			Role: Ptr(ResponsesInputMessageRoleAssistant),
+			Content: &ResponsesMessageContent{
+				ContentBlocks: []ResponsesMessageContentBlock{
+					{Type: ResponsesOutputMessageContentTypeReasoning, Text: &reasoningText},
+				},
+			},
+		},
+		{
+			Type: Ptr(ResponsesMessageTypeFunctionCall),
+			Role: Ptr(ResponsesInputMessageRoleAssistant),
+			ResponsesToolMessage: &ResponsesToolMessage{
+				CallID:    Ptr("call_1"),
+				Name:      Ptr("search"),
+				Arguments: Ptr(`{"q":"x"}`),
+			},
+		},
+		{
+			Type: Ptr(ResponsesMessageTypeFunctionCallOutput),
+			ResponsesToolMessage: &ResponsesToolMessage{
+				CallID: Ptr("call_1"),
+				Output: &ResponsesToolMessageOutputStruct{ResponsesToolCallOutputStr: Ptr("done")},
+			},
+		},
+	}
+
+	chatMessages := ToChatMessages(messages)
+	if len(chatMessages) != 2 {
+		t.Fatalf("expected 2 chat messages (tool-call assistant + tool result), got %d", len(chatMessages))
+	}
+	assistant := chatMessages[0]
+	if assistant.ChatAssistantMessage == nil {
+		t.Fatal("expected tool-call assistant message")
+	}
+	if len(assistant.ChatAssistantMessage.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(assistant.ChatAssistantMessage.ToolCalls))
+	}
+	if assistant.ChatAssistantMessage.Reasoning == nil || *assistant.ChatAssistantMessage.Reasoning != reasoningText {
+		t.Fatalf("expected reasoning %q on tool-call assistant, got %#v", reasoningText, assistant.ChatAssistantMessage.Reasoning)
+	}
+}
+
+func TestToResponsesMessages_EmitsReasoningMessageBeforeToolCalls(t *testing.T) {
+	reasoning := "I should call Bash to list the directory."
+	cm := &ChatMessage{
+		Role: ChatMessageRoleAssistant,
+		ChatAssistantMessage: &ChatAssistantMessage{
+			Reasoning: &reasoning,
+			ToolCalls: []ChatAssistantMessageToolCall{
+				{
+					ID:   Ptr("call_1"),
+					Type: Ptr("function"),
+					Function: ChatAssistantMessageToolCallFunction{
+						Name: Ptr("Bash"),
+					},
+				},
+			},
+		},
+	}
+
+	out := cm.ToResponsesMessages()
+	if len(out) != 2 {
+		t.Fatalf("expected 2 messages (reasoning + function_call), got %d", len(out))
+	}
+	if out[0].Type == nil || *out[0].Type != ResponsesMessageTypeReasoning {
+		t.Fatalf("expected first message to be reasoning, got %#v", out[0].Type)
+	}
+	if out[0].Content == nil || len(out[0].Content.ContentBlocks) != 1 {
+		t.Fatal("expected reasoning message to carry a single content block")
+	}
+	if out[0].Content.ContentBlocks[0].Text == nil || *out[0].Content.ContentBlocks[0].Text != reasoning {
+		t.Fatalf("expected reasoning text %q, got %#v", reasoning, out[0].Content.ContentBlocks[0].Text)
+	}
+	if out[1].Type == nil || *out[1].Type != ResponsesMessageTypeFunctionCall {
+		t.Fatalf("expected second message to be function_call, got %#v", out[1].Type)
+	}
+}
+
+func TestToResponsesMessages_EmitsReasoningMessageBeforeTextContent(t *testing.T) {
+	reasoning := "Thinking about how to summarize."
+	cm := &ChatMessage{
+		Role: ChatMessageRoleAssistant,
+		Content: &ChatMessageContent{
+			ContentStr: Ptr("Here's the summary."),
+		},
+		ChatAssistantMessage: &ChatAssistantMessage{
+			Reasoning: &reasoning,
+		},
+	}
+
+	out := cm.ToResponsesMessages()
+	if len(out) != 2 {
+		t.Fatalf("expected 2 messages (reasoning + assistant text), got %d", len(out))
+	}
+	if out[0].Type == nil || *out[0].Type != ResponsesMessageTypeReasoning {
+		t.Fatalf("expected first message to be reasoning, got %#v", out[0].Type)
+	}
+	if out[1].Type == nil || *out[1].Type != ResponsesMessageTypeMessage {
+		t.Fatalf("expected second message to be a regular assistant message, got %#v", out[1].Type)
+	}
+}
+
 func TestToChatRequest_FiltersUnsupportedResponsesToolsForFallback(t *testing.T) {
 	validName := "valid_tool"
 	invalidName := "  "

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -2169,6 +2169,7 @@ export function LogDetailView({
               <div className="bg-card rounded-sm border p-5">
                 {(visibleRoles.size < allRoles.length
                   ? log.input_history?.filter((m) => {
+                      if (!m) return false;
                       const mainRole = ((m.role as string) ||
                         "user") as MessageRole;
                       const hasReasoning = !!extractChatReasoning(m);
@@ -2177,7 +2178,7 @@ export function LogDetailView({
                         (hasReasoning && visibleRoles.has("reasoning"))
                       );
                     })
-                  : log.input_history
+                  : log.input_history?.filter(Boolean)
                 )?.flatMap((message, index) => {
                   const role = ((message.role as string) ||
                     "user") as MessageRole;

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -84,10 +84,14 @@ export function getMessage(log?: LogEntry) {
 		return "";
 	}
 	if (log?.input_history && log.input_history.length > 0) {
-		return getMessageFromContent(log.input_history[log.input_history.length - 1].content);
+		const lastInput = log.input_history[log.input_history.length - 1];
+		return getMessageFromContent(lastInput?.content);
 	} else if (log?.responses_input_history && log.responses_input_history.length > 0) {
 		let lastMessage = log.responses_input_history[log.responses_input_history.length - 1];
-		let lastMessageContent = lastMessage.content;
+		let lastMessageContent = lastMessage?.content;
+		if (!lastMessage) {
+			return "";
+		}
 		if (typeof lastMessageContent === "string") {
 			return lastMessageContent;
 		}


### PR DESCRIPTION
## Summary

Reasoning content (e.g. from DeepSeek thinking mode or Anthropic extended thinking) was being silently dropped when converting between the Responses and Chat message formats. This caused multi-turn flows that route through the Responses→Chat fallback path to 400 on providers that require reasoning content to be echoed back. This PR fixes the bidirectional conversion so reasoning is preserved across both directions.

## Changes

- **`ToResponsesMessages`**: Reasoning content on an assistant `ChatMessage` is now emitted as a `reasoning`-typed `ResponsesMessage` *before* any tool calls or text content, matching the order providers expect and allowing clients to echo it back correctly.
- **`ToChatMessages`**: Reasoning messages are no longer silently skipped. Instead, they are buffered and attached to the next assistant turn (whether that turn carries text content or tool calls), populating both `Reasoning` and `ReasoningDetails` fields including signatures, summaries, and encrypted content.
- Null-safety guards were added in the UI log detail view and column helpers to prevent crashes when `input_history` contains `null`/`undefined` entries (which can occur when reasoning messages are injected into history).

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./...
```

Specific test cases added:
- `TestToChatMessages_AttachesReasoningToNextAssistantMessage` — verifies reasoning is buffered and attached to the following assistant text message, including signature preservation.
- `TestToChatMessages_AttachesReasoningToToolCallAssistantMessage` — verifies reasoning is attached to tool-call assistant messages.
- `TestToResponsesMessages_EmitsReasoningMessageBeforeToolCalls` — verifies reasoning is emitted first when an assistant message has both reasoning and tool calls.
- `TestToResponsesMessages_EmitsReasoningMessageBeforeTextContent` — verifies reasoning is emitted first when an assistant message has both reasoning and text content.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Fixes multi-turn DeepSeek thinking mode and Anthropic extended thinking flows that were returning 400 errors due to missing reasoning content in echoed history.

## Security considerations

No auth, secrets, PII, or sandboxing implications. Reasoning content is treated the same as other message content.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable