### PR TITLE
fix: use `isRedacted` check instead of `from_env`/`env_var` prefix for proxy URL validation bypass

### DIFF
--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1,4 +1,5 @@
 import { KnownProvidersNames } from "@/lib/constants/logs";
+import { isRedacted } from "@/lib/utils/validation";
 import { z } from "zod";
 
 // Global error map - turns Zod's default messages into readable, human-friendly ones.
@@ -416,7 +417,7 @@ export const proxyConfigSchema = z
 	.refine(
 		(data) => {
 			if ((data.type === "http" || data.type === "socks5") && data.url?.value?.trim()) {
-				if (data.url.from_env || data.url.env_var?.startsWith("env.")) {
+				if (isRedacted(data.url.value)) {
 					return true;
 				}
 				try {
@@ -466,7 +467,7 @@ export const proxyFormConfigSchema = z
 		(data) => {
 			// URL must be valid format when provided and proxy type requires it
 			if ((data.type === "http" || data.type === "socks5") && data.url?.value && data.url.value.trim().length > 0) {
-				if (data.url.from_env || data.url.env_var?.startsWith("env.")) {
+				if (isRedacted(data.url.value)) {
 					return true;
 				}
 				try {


### PR DESCRIPTION
## Summary

Replaces the inline env-variable heuristic used to skip URL validation in proxy config schemas with a shared `isRedacted` utility function, ensuring consistent redaction detection across both `proxyConfigSchema` and `proxyFormConfigSchema`.

## Changes

- Replaced the condition `data.url.from_env || data.url.env_var?.startsWith("env.")` with `isRedacted(data.url.value)` in both proxy schema refinements
- Imported `isRedacted` from `@/lib/utils/validation` to centralize the logic for detecting redacted/env-sourced values

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Verify that proxy configurations using environment variable-sourced URLs still pass validation without triggering URL format errors, and that invalid URLs are still correctly rejected.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security impact. This change only affects client-side form validation logic for proxy URL fields.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable