### PR TITLE
fix(anthropic): normalize tool call continuation deltas

### DIFF
--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -1152,6 +1152,14 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.Bi
 			case AnthropicStreamDeltaTypeInputJSON:
 				// Handle tool use streaming - accumulate partial JSON
 				if chunk.Delta.PartialJSON != nil {
+					if *chunk.Delta.PartialJSON == "" {
+						// Anthropic may emit an empty partial_json marker immediately after
+						// tool_use starts. OpenAI-style chat tool deltas should keep that
+						// initialization folded into the first tool_call chunk instead of
+						// emitting a second empty arguments delta.
+						return nil, nil, false
+					}
+
 					if structuredOutputToolName != "" {
 						// Structured output: stream JSON as content
 						streamResponse := &schemas.BifrostChatResponse{
@@ -1184,7 +1192,6 @@ func (chunk *AnthropicStreamEvent) ToBifrostChatCompletionStream(ctx *schemas.Bi
 										ToolCalls: []schemas.ChatAssistantMessageToolCall{
 											{
 												Index: uint16(toolCallIdx),
-												Type:  schemas.Ptr(string(schemas.ChatToolTypeFunction)),
 												Function: schemas.ChatAssistantMessageToolCallFunction{
 													Arguments: *chunk.Delta.PartialJSON,
 												},

--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -845,3 +845,128 @@ func TestToAnthropicChatRequest_NonOpus47_NoDefaultDisplay(t *testing.T) {
 		t.Errorf("expected Display to be nil for non-Opus 4.7, got %q", *result.Thinking.Display)
 	}
 }
+
+func TestToBifrostChatCompletionStream_ToolUseStartEmitsOpenAIFirstChunk(t *testing.T) {
+	state := NewAnthropicStreamState()
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	chunk := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockStart,
+		Index: schemas.Ptr(1),
+		ContentBlock: &AnthropicContentBlock{
+			Type: AnthropicContentBlockTypeToolUse,
+			ID:   schemas.Ptr("toolu_123"),
+			Name: schemas.Ptr("get_weather"),
+		},
+	}
+
+	resp, bifrostErr, isLast := chunk.ToBifrostChatCompletionStream(ctx, "", state)
+	if bifrostErr != nil {
+		t.Fatalf("unexpected error: %v", bifrostErr)
+	}
+	if isLast {
+		t.Fatal("expected non-terminal chunk")
+	}
+	if resp == nil || len(resp.Choices) != 1 {
+		t.Fatalf("expected one streaming response choice, got %#v", resp)
+	}
+
+	delta := resp.Choices[0].ChatStreamResponseChoice.Delta
+	if delta == nil || len(delta.ToolCalls) != 1 {
+		t.Fatalf("expected one tool call delta, got %#v", delta)
+	}
+
+	toolCall := delta.ToolCalls[0]
+	if toolCall.Index != 0 {
+		t.Fatalf("expected first tool call index 0, got %d", toolCall.Index)
+	}
+	if toolCall.Type == nil || *toolCall.Type != string(schemas.ChatToolTypeFunction) {
+		t.Fatalf("expected tool call type=function on first delta, got %#v", toolCall.Type)
+	}
+	if toolCall.ID == nil || *toolCall.ID != "toolu_123" {
+		t.Fatalf("expected tool call id to be preserved, got %#v", toolCall.ID)
+	}
+	if toolCall.Function.Name == nil || *toolCall.Function.Name != "get_weather" {
+		t.Fatalf("expected tool call name to be preserved, got %#v", toolCall.Function.Name)
+	}
+	if toolCall.Function.Arguments != "" {
+		t.Fatalf("expected initial arguments chunk to be empty, got %q", toolCall.Function.Arguments)
+	}
+}
+
+func TestToBifrostChatCompletionStream_EmptyToolInputDeltaIsSuppressed(t *testing.T) {
+	state := NewAnthropicStreamState()
+	state.contentBlockToToolCallIdx[4] = 0
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	chunk := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockDelta,
+		Index: schemas.Ptr(4),
+		Delta: &AnthropicStreamDelta{
+			Type:        AnthropicStreamDeltaTypeInputJSON,
+			PartialJSON: schemas.Ptr(""),
+		},
+	}
+
+	resp, bifrostErr, isLast := chunk.ToBifrostChatCompletionStream(ctx, "", state)
+	if bifrostErr != nil {
+		t.Fatalf("unexpected error: %v", bifrostErr)
+	}
+	if isLast {
+		t.Fatal("expected non-terminal chunk")
+	}
+	if resp != nil {
+		t.Fatalf("expected empty partial_json delta to be suppressed, got %#v", resp)
+	}
+}
+
+func TestToBifrostChatCompletionStream_ToolInputDeltaOmitsRepeatedMetadata(t *testing.T) {
+	state := NewAnthropicStreamState()
+	state.contentBlockToToolCallIdx[7] = 2
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	chunk := &AnthropicStreamEvent{
+		Type:  AnthropicStreamEventTypeContentBlockDelta,
+		Index: schemas.Ptr(7),
+		Delta: &AnthropicStreamDelta{
+			Type:        AnthropicStreamDeltaTypeInputJSON,
+			PartialJSON: schemas.Ptr("{\"loc"),
+		},
+	}
+
+	resp, bifrostErr, isLast := chunk.ToBifrostChatCompletionStream(ctx, "", state)
+	if bifrostErr != nil {
+		t.Fatalf("unexpected error: %v", bifrostErr)
+	}
+	if isLast {
+		t.Fatal("expected non-terminal chunk")
+	}
+	if resp == nil || len(resp.Choices) != 1 {
+		t.Fatalf("expected one streaming response choice, got %#v", resp)
+	}
+
+	delta := resp.Choices[0].ChatStreamResponseChoice.Delta
+	if delta == nil || len(delta.ToolCalls) != 1 {
+		t.Fatalf("expected one tool call delta, got %#v", delta)
+	}
+
+	toolCall := delta.ToolCalls[0]
+	if toolCall.Index != 2 {
+		t.Fatalf("expected mapped tool call index 2, got %d", toolCall.Index)
+	}
+	if toolCall.Type != nil {
+		t.Fatalf("expected continuation delta to omit type, got %#v", toolCall.Type)
+	}
+	if toolCall.ID != nil {
+		t.Fatalf("expected continuation delta to omit id, got %#v", toolCall.ID)
+	}
+	if toolCall.Function.Name != nil {
+		t.Fatalf("expected continuation delta to omit function name, got %#v", toolCall.Function.Name)
+	}
+	if toolCall.Function.Arguments != "{\"loc" {
+		t.Fatalf("expected arguments chunk to be preserved, got %q", toolCall.Function.Arguments)
+	}
+}


### PR DESCRIPTION
## Summary
- suppress empty Anthropic tool input deltas when converting to OpenAI chat-completions streams
- omit repeated `tool_calls[].type` metadata on continuation argument chunks
- add regression coverage for first-chunk metadata, empty delta suppression, and continuation chunk semantics

## Testing
- Focused pass:
  - `docker run --rm -v /Users/punyslokdutta/Desktop/git-projects/bifrost:/workspace -w /workspace/core golang:1.26.2-alpine3.23 sh -lc '/usr/local/go/bin/go test ./providers/anthropic -run "TestToBifrostChatCompletionStream_|TestToAnthropicChatRequest_"'

## Notes
- `go test ./providers/anthropic ./providers/vertex` still shows unrelated existing `anthropic` package failures that also reproduce on clean `origin/main`; this PR does not touch those areas.

Closes #3443.
