### PR TITLE
fix: core test fixes

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -491,7 +491,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 		return []schemas.Key{
 			{
 				Value:          *schemas.NewEnvVar("env.FIREWORKS_API_KEY"),
-				Models:         []string{},
+				Models:         []string{"*"},
 				Weight:         1.0,
 				UseForBatchAPI: bifrost.Ptr(true),
 			},

--- a/core/internal/llmtests/chat_completion_stream.go
+++ b/core/internal/llmtests/chat_completion_stream.go
@@ -80,7 +80,7 @@ func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx cont
 			Model:    testConfig.ChatModel,
 			Input:    messages,
 			Params: &schemas.ChatParameters{
-				MaxCompletionTokens: bifrost.Ptr(150),
+				MaxCompletionTokens: bifrost.Ptr(300),
 			},
 			Fallbacks: testConfig.Fallbacks,
 		}
@@ -311,7 +311,7 @@ func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx cont
 				Model:    testConfig.ChatModel,
 				Input:    messages,
 				Params: &schemas.ChatParameters{
-					MaxCompletionTokens: bifrost.Ptr(150),
+					MaxCompletionTokens: bifrost.Ptr(300),
 					Tools:               []schemas.ChatTool{*tool},
 				},
 				Fallbacks: testConfig.Fallbacks,

--- a/core/internal/llmtests/eager_input_streaming.go
+++ b/core/internal/llmtests/eager_input_streaming.go
@@ -51,7 +51,7 @@ func RunEagerInputStreamingTest(t *testing.T, client *bifrost.Bifrost, ctx conte
 			Model:    testConfig.ChatModel,
 			Input:    chatMessages,
 			Params: &schemas.ChatParameters{
-				MaxCompletionTokens: bifrost.Ptr(200),
+				MaxCompletionTokens: bifrost.Ptr(300),
 				Tools:               []schemas.ChatTool{*chatTool},
 			},
 			Fallbacks: testConfig.Fallbacks,

--- a/core/internal/llmtests/responses_stream.go
+++ b/core/internal/llmtests/responses_stream.go
@@ -38,7 +38,7 @@ func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 			Model:    testConfig.ChatModel,
 			Input:    messages,
 			Params: &schemas.ResponsesParameters{
-				MaxOutputTokens: bifrost.Ptr(150),
+				MaxOutputTokens: bifrost.Ptr(300),
 			},
 			Fallbacks: testConfig.Fallbacks,
 		}
@@ -362,7 +362,7 @@ func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 				Model:    testConfig.ChatModel,
 				Input:    messages,
 				Params: &schemas.ResponsesParameters{
-					MaxOutputTokens: bifrost.Ptr(150),
+					MaxOutputTokens: bifrost.Ptr(300),
 					Tools:           []schemas.ResponsesTool{*tool},
 				},
 				Fallbacks: testConfig.Fallbacks,
@@ -689,7 +689,7 @@ func RunResponsesStreamTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 			Model:    testConfig.ChatModel,
 			Input:    messages,
 			Params: &schemas.ResponsesParameters{
-				MaxOutputTokens: bifrost.Ptr(50),
+				MaxOutputTokens: bifrost.Ptr(500),
 			},
 			Fallbacks: testConfig.Fallbacks,
 		}

--- a/core/providers/fireworks/fireworks_test.go
+++ b/core/providers/fireworks/fireworks_test.go
@@ -28,21 +28,19 @@ func TestFireworks(t *testing.T) {
 	defer cancel()
 	defer client.Shutdown()
 
-	chatModel, textModel, embeddingModel := resolveFireworksModels(t, client, ctx)
-
 	testConfig := llmtests.ComprehensiveTestConfig{
 		Provider:                schemas.Fireworks,
-		ChatModel:               chatModel,
+		ChatModel:               "accounts/fireworks/models/deepseek-v4-pro",
 		Fallbacks:               []schemas.Fallback{},
-		TextModel:               textModel,
+		TextModel:               "accounts/fireworks/models/deepseek-v4-pro",
 		TextCompletionFallbacks: []schemas.Fallback{},
-		EmbeddingModel:          embeddingModel,
+		EmbeddingModel:          "fireworks/qwen3-embedding-8b",
 		ReasoningModel:          "",
 		TranscriptionModel:      "",
 		SpeechSynthesisModel:    "",
 		Scenarios: llmtests.TestScenarios{
-			TextCompletion:        textModel != "",
-			TextCompletionStream:  textModel != "",
+			TextCompletion:        true,
+			TextCompletionStream:  true,
 			SimpleChat:            true,
 			CompletionStream:      true,
 			MultiTurnConversation: true,
@@ -57,7 +55,7 @@ func TestFireworks(t *testing.T) {
 			FileBase64:            false,
 			FileURL:               false,
 			CompleteEnd2End:       true,
-			Embedding:             embeddingModel != "",
+			Embedding:             true,
 			ListModels:            true,
 			Reasoning:             false,
 			Transcription:         false,


### PR DESCRIPTION
## Summary

Fixes flaky Fireworks provider tests by hardcoding model names and increasing token limits to prevent truncation-related test failures.

## Changes

- Replaced dynamic model resolution (`resolveFireworksModels`) with hardcoded model names (`deepseek-v4-pro` for chat/text, `qwen3-embedding-8b` for embeddings) in the Fireworks test suite, removing the dependency on runtime model discovery
- Set text completion and embedding test scenarios to always enabled (`true`) since models are now statically defined
- Updated the Fireworks key configuration to use `"*"` as the model wildcard instead of an empty slice, ensuring the key applies to all models
- Increased `MaxCompletionTokens` / `MaxOutputTokens` limits across streaming tests (150→300, 200→300, 50→500) to reduce the likelihood of responses being cut off mid-stream, which was causing assertion failures

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./providers/fireworks/... -v -run TestFireworks
go test ./internal/llmtests/... -v
```

Expected: all Fireworks provider tests pass without flakiness related to model resolution or truncated streaming responses.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. No secrets or auth changes introduced; the `"*"` wildcard applies only to internal key-to-model routing logic.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable