### PR TITLE
docs: remove fallback `ANTHROPIC_API_KEY` approach from Claude Code docs

### DIFF
--- a/docs/cli-agents/claude-code.mdx
+++ b/docs/cli-agents/claude-code.mdx
@@ -24,8 +24,7 @@ icon: "star-of-life"
 
 <Note>
 	All examples below use `ANTHROPIC_CUSTOM_HEADERS` to pass your Bifrost virtual key. This is the recommended approach and works across all
-	tested Claude Code versions. If you are on an older version that does not support custom headers, you can fall back to `ANTHROPIC_API_KEY`
-	instead.
+	tested Claude Code versions.
 </Note>
 
 ## Installing Claude Code
@@ -85,17 +84,6 @@ You will need to update the most granular `settings.json`.
 	The JSON snippets below show only the `env` key. Merge them into your existing `settings.json` top-level object - do not paste them as a
 	standalone file, or you will overwrite other settings like `permissions`, `model`, and `apiKeyHelper`.
 </Note>
-
-```json
-"env": {
-  "ANTHROPIC_BASE_URL": "http://localhost:8080/anthropic",
-  "ANTHROPIC_API_KEY": "your-virtual-key",
-  "ANTHROPIC_DEFAULT_HAIKU_MODEL": "haiku-model",
-  "ANTHROPIC_DEFAULT_SONNET_MODEL": "sonnet-model"
-}
-```
-
-For a more reliable approach, use the `ANTHROPIC_CUSTOM_HEADERS` environment variable as shown below.
 
 ```json
 "env": {


### PR DESCRIPTION
## Summary

Simplifies the Claude Code documentation by removing the fallback `ANTHROPIC_API_KEY` approach, keeping only the recommended `ANTHROPIC_CUSTOM_HEADERS` method for passing Bifrost virtual keys.

## Changes

- Removed the mention of falling back to `ANTHROPIC_API_KEY` for older Claude Code versions from the note callout
- Removed the `ANTHROPIC_API_KEY`-based JSON configuration example and the transitional text pointing users toward `ANTHROPIC_CUSTOM_HEADERS`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated `docs/cli-agents/claude-code.mdx` to confirm the note and configuration section only reference the `ANTHROPIC_CUSTOM_HEADERS` approach without any mention of the `ANTHROPIC_API_KEY` fallback.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable