### PR TITLE
feat: add close button to Sonner toaster and position it top-right

### DIFF
--- a/ui/app/clientLayout.tsx
+++ b/ui/app/clientLayout.tsx
@@ -73,7 +73,7 @@ export function ClientLayout({ children }: { children: React.ReactNode }) {
 	return (
 		<ProgressProvider>
 			<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-				<Toaster />
+				<Toaster closeButton />
 				<ReduxProvider>
 					<NuqsAdapter>
 						<RbacProvider>

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -389,3 +389,17 @@ div.content-container:has(.no-border-parent) #trial-notification-banner {
 [data-streamdown="code-block-body"] {
 	@apply rounded-sm!;
 }
+
+/* Move Sonner toast close button to top-right */
+[data-sonner-toaster][dir="ltr"],
+[data-sonner-toaster] {
+	--toast-close-button-start: unset !important;
+	--toast-close-button-end: 0 !important;
+	--toast-close-button-transform: translate(35%, -35%) !important;
+}
+
+[data-sonner-toast][data-styled="true"] [data-close-button] {
+	left: auto !important;
+	right: 0 !important;
+	transform: translate(35%, -35%) !important;
+}

--- a/ui/app/pprof/layout.tsx
+++ b/ui/app/pprof/layout.tsx
@@ -13,7 +13,7 @@ function PprofLayout({ children }: { children: React.ReactNode }) {
 
 	return (
 		<ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
-			<Toaster />
+			<Toaster closeButton />
 			<ReduxProvider>
 				<div className="min-h-screen bg-zinc-950 text-zinc-100">{children}</div>
 			</ReduxProvider>


### PR DESCRIPTION
## Summary

Adds a close button to Sonner toast notifications and repositions it to the top-right corner of each toast for a more conventional UX.

## Changes

- Enabled the `closeButton` prop on the `Toaster` component in both the main client layout and the pprof layout
- Added CSS overrides to reposition the Sonner close button from its default top-left position to the top-right, using CSS custom properties and direct property overrides to handle both LTR and styled toast variants

## Type of change

- [x] Feature

## Affected areas

- [x] UI (React)

## How to test

1. Trigger any toast notification in the UI (e.g., perform an action that produces a success or error toast)
2. Verify a close (×) button appears in the top-right corner of the toast
3. Click the close button and confirm the toast dismisses

## Screenshots/Recordings

Before: No close button on toasts
After: Close button visible in the top-right corner of each toast

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable