### PR TITLE
rotate vk backend chagnes

### DIFF
--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -2295,7 +2295,27 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 
 	// Do not update the current usage of the rate limit, as it will be updated by the usage tracker.
 	// But update if max limit or reset duration changes.
-	if existingVKValue, exists := gs.virtualKeys.Load(vk.Value); exists && existingVKValue != nil {
+	existingVKKey := vk.Value
+	existingVKValue, exists := gs.virtualKeys.Load(vk.Value)
+	if exists && existingVKValue != nil {
+		if existingVK, ok := existingVKValue.(*configstoreTables.TableVirtualKey); !ok || existingVK == nil || existingVK.ID != vk.ID {
+			exists = false
+			existingVKValue = nil
+		}
+	}
+	if !exists || existingVKValue == nil {
+		gs.virtualKeys.Range(func(key, value interface{}) bool {
+			existingVK, ok := value.(*configstoreTables.TableVirtualKey)
+			if !ok || existingVK == nil || existingVK.ID != vk.ID {
+				return true
+			}
+			existingVKKey, _ = key.(string)
+			existingVKValue = value
+			exists = true
+			return false
+		})
+	}
+	if exists && existingVKValue != nil {
 		existingVK, ok := existingVKValue.(*configstoreTables.TableVirtualKey)
 		if !ok || existingVK == nil {
 			return // Nothing to update
@@ -2438,6 +2458,9 @@ func (gs *LocalGovernanceStore) UpdateVirtualKeyInMemory(ctx context.Context, vk
 					}
 				}
 			}
+		}
+		if existingVKKey != "" && existingVKKey != vk.Value {
+			gs.virtualKeys.Delete(existingVKKey)
 		}
 		gs.virtualKeys.Store(vk.Value, &clone)
 	} else {

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -591,6 +591,33 @@ func TestGovernanceStore_MultiBudget_InMemoryCreateAndDelete(t *testing.T) {
 	assert.False(t, found, "VK should not be found after delete")
 }
 
+func TestGovernanceStore_UpdateVirtualKeyInMemory_RotatedValueRemovesOldLookup(t *testing.T) {
+	logger := NewMockLogger()
+	budget := buildBudgetWithUsage("budget1", 100.0, 25.0, "1d")
+	vk := buildVirtualKeyWithBudget("vk1", "sk-bf-old", "Test VK", budget)
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		Budgets:     []configstoreTables.TableBudget{*budget},
+	}, nil)
+	require.NoError(t, err)
+
+	updated := *vk
+	updated.Value = "sk-bf-new"
+	store.UpdateVirtualKeyInMemory(context.Background(), &updated, nil, nil, nil)
+
+	oldVK, oldFound := store.GetVirtualKey(context.Background(), "sk-bf-old")
+	assert.False(t, oldFound)
+	assert.Nil(t, oldVK)
+
+	newVK, newFound := store.GetVirtualKey(context.Background(), "sk-bf-new")
+	require.True(t, newFound)
+	require.NotNil(t, newVK)
+	assert.Equal(t, "vk1", newVK.ID)
+	require.Len(t, newVK.Budgets, 1)
+	assert.Equal(t, 25.0, newVK.Budgets[0].CurrentUsage)
+}
+
 // TestGovernanceStore_UpdateRateLimitUsage_TokensAndRequests tests atomic rate limit usage updates
 func TestGovernanceStore_UpdateRateLimitUsage_TokensAndRequests(t *testing.T) {
 	logger := NewMockLogger()

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -127,6 +127,10 @@ type UpdateVirtualKeyRequest struct {
 	CalendarAligned *bool                   `json:"calendar_aligned,omitempty"` // When true, all budgets reset at clean calendar boundaries
 }
 
+type BulkRotateVirtualKeysRequest struct {
+	IDs []string `json:"ids"`
+}
+
 // CreateBudgetRequest represents the request body for creating a budget
 type CreateBudgetRequest struct {
 	MaxLimit      float64 `json:"max_limit" validate:"required"`      // Maximum budget in dollars
@@ -287,8 +291,10 @@ func (h *GovernanceHandler) RegisterRoutes(r *router.Router, middlewares ...sche
 	// Virtual Key CRUD operations
 	r.GET("/api/governance/virtual-keys", lib.ChainMiddlewares(h.getVirtualKeys, middlewares...))
 	r.POST("/api/governance/virtual-keys", lib.ChainMiddlewares(h.createVirtualKey, middlewares...))
+	r.POST("/api/governance/virtual-keys/rotate", lib.ChainMiddlewares(h.rotateVirtualKeys, middlewares...))
 	r.GET("/api/governance/virtual-keys/{vk_id}", lib.ChainMiddlewares(h.getVirtualKey, middlewares...))
 	r.PUT("/api/governance/virtual-keys/{vk_id}", lib.ChainMiddlewares(h.updateVirtualKey, middlewares...))
+	r.POST("/api/governance/virtual-keys/{vk_id}/rotate", lib.ChainMiddlewares(h.rotateVirtualKey, middlewares...))
 	r.DELETE("/api/governance/virtual-keys/{vk_id}", lib.ChainMiddlewares(h.deleteVirtualKey, middlewares...))
 
 	// Team CRUD operations
@@ -1412,6 +1418,103 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 		"message":     "Virtual key updated successfully",
 		"virtual_key": preloadedVk,
 	})
+}
+
+func (h *GovernanceHandler) rotateVirtualKeyByID(ctx context.Context, vkID string) (*configstoreTables.TableVirtualKey, error) {
+	vk, err := h.configStore.GetVirtualKey(ctx, vkID)
+	if err != nil {
+		return nil, err
+	}
+	oldValue := vk.Value
+	vk.Value = governance.GenerateVirtualKey()
+	if vk.Value == oldValue {
+		return nil, fmt.Errorf("generated virtual key matched existing value")
+	}
+	if err := h.configStore.UpdateVirtualKey(ctx, vk); err != nil {
+		return nil, err
+	}
+	preloadedVk, err := h.governanceManager.ReloadVirtualKey(ctx, vk.ID)
+	if err != nil {
+		return nil, fmt.Errorf("virtual key rotated in database but failed to reload in-memory state: %w", err)
+	}
+	return preloadedVk, nil
+}
+
+// rotateVirtualKey handles POST /api/governance/virtual-keys/{vk_id}/rotate - Rotate only the virtual key value
+func (h *GovernanceHandler) rotateVirtualKey(ctx *fasthttp.RequestCtx) {
+	vkID := ctx.UserValue("vk_id").(string)
+	preloadedVk, err := h.rotateVirtualKeyByID(ctx, vkID)
+	if err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, 404, "Virtual key not found")
+			return
+		}
+		logger.Error("failed to rotate virtual key: %v", err)
+		SendError(ctx, 500, fmt.Sprintf("Failed to rotate virtual key: %v", err))
+		return
+	}
+	SendJSON(ctx, map[string]interface{}{
+		"message":     "Virtual key rotated successfully",
+		"virtual_key": preloadedVk,
+	})
+}
+
+// rotateVirtualKeys handles POST /api/governance/virtual-keys/rotate - Rotate multiple virtual key values
+func (h *GovernanceHandler) rotateVirtualKeys(ctx *fasthttp.RequestCtx) {
+	var req BulkRotateVirtualKeysRequest
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, 400, "Invalid JSON")
+		return
+	}
+	if len(req.IDs) == 0 {
+		SendError(ctx, 400, "At least one virtual key ID is required")
+		return
+	}
+
+	seen := make(map[string]struct{}, len(req.IDs))
+	ids := make([]string, 0, len(req.IDs))
+	for _, id := range req.IDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			SendError(ctx, 400, "Virtual key ID cannot be empty")
+			return
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	rotated := make([]*configstoreTables.TableVirtualKey, 0, len(ids))
+	failures := make(map[string]string)
+	for _, id := range ids {
+		vk, err := h.rotateVirtualKeyByID(ctx, id)
+		if err != nil {
+			if errors.Is(err, configstore.ErrNotFound) {
+				failures[id] = "virtual key not found"
+			} else {
+				failures[id] = err.Error()
+			}
+			logger.Error("failed to rotate virtual key %s: %v", id, err)
+			continue
+		}
+		rotated = append(rotated, vk)
+	}
+
+	response := map[string]interface{}{
+		"message":      "Virtual keys rotated successfully",
+		"virtual_keys": rotated,
+	}
+	if len(failures) > 0 {
+		response["errors"] = failures
+	}
+	if len(rotated) == 0 {
+		response["message"] = "Failed to rotate virtual keys"
+		SendJSONWithStatus(ctx, response, 500)
+		return
+	}
+	SendJSON(ctx, response)
 }
 
 // deleteVirtualKey handles DELETE /api/governance/virtual-keys/{vk_id} - Delete a virtual key

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -3,13 +3,17 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/plugins/governance"
 	"github.com/valyala/fasthttp"
+	"gorm.io/gorm"
 )
 
 // mockGovernanceManagerForVK embeds the interface so unimplemented methods panic.
@@ -34,6 +38,713 @@ func (m *mockConfigStoreForVK) GetVirtualKeysPaginated(_ context.Context, _ conf
 
 func (m *mockConfigStoreForVK) GetVirtualKeys(_ context.Context) ([]configstoreTables.TableVirtualKey, error) {
 	return nil, nil
+}
+
+type mockRotateConfigStore struct {
+	configstore.ConfigStore
+	virtualKeys map[string]*configstoreTables.TableVirtualKey
+	updates     int
+}
+
+func cloneTestVirtualKey(vk *configstoreTables.TableVirtualKey) *configstoreTables.TableVirtualKey {
+	if vk == nil {
+		return nil
+	}
+	clone := *vk
+	clone.Budgets = append([]configstoreTables.TableBudget(nil), vk.Budgets...)
+	clone.ProviderConfigs = append([]configstoreTables.TableVirtualKeyProviderConfig(nil), vk.ProviderConfigs...)
+	clone.MCPConfigs = append([]configstoreTables.TableVirtualKeyMCPConfig(nil), vk.MCPConfigs...)
+	return &clone
+}
+
+func (m *mockRotateConfigStore) GetVirtualKey(_ context.Context, id string) (*configstoreTables.TableVirtualKey, error) {
+	vk, ok := m.virtualKeys[id]
+	if !ok {
+		return nil, configstore.ErrNotFound
+	}
+	return cloneTestVirtualKey(vk), nil
+}
+
+func (m *mockRotateConfigStore) UpdateVirtualKey(_ context.Context, virtualKey *configstoreTables.TableVirtualKey, _ ...*gorm.DB) error {
+	existing, ok := m.virtualKeys[virtualKey.ID]
+	if !ok {
+		return configstore.ErrNotFound
+	}
+	updated := cloneTestVirtualKey(existing)
+	updated.Value = virtualKey.Value
+	m.virtualKeys[virtualKey.ID] = updated
+	m.updates++
+	return nil
+}
+
+type mockRotateGovernanceManager struct {
+	GovernanceManager
+	store     *mockRotateConfigStore
+	reloadIDs []string
+}
+
+func (m *mockRotateGovernanceManager) ReloadVirtualKey(ctx context.Context, id string) (*configstoreTables.TableVirtualKey, error) {
+	m.reloadIDs = append(m.reloadIDs, id)
+	return m.store.GetVirtualKey(ctx, id)
+}
+
+func TestFindExistingBudgetPrefersIDOverResetDuration(t *testing.T) {
+	monthlyBudget := configstoreTables.TableBudget{
+		ID:            "budget-monthly",
+		MaxLimit:      100,
+		ResetDuration: "1M",
+		CurrentUsage:  75,
+	}
+	dailyBudget := configstoreTables.TableBudget{
+		ID:            "budget-daily",
+		MaxLimit:      20,
+		ResetDuration: "1d",
+		CurrentUsage:  3,
+	}
+
+	byID, byDuration := buildBudgetLookup([]configstoreTables.TableBudget{monthlyBudget, dailyBudget})
+	matched, found, err := findExistingBudget(CreateBudgetRequest{
+		ID:            "budget-monthly",
+		MaxLimit:      120,
+		ResetDuration: "1d",
+	}, byID, byDuration)
+	if err != nil {
+		t.Fatalf("expected budget match, got error: %v", err)
+	}
+	if !found {
+		t.Fatal("expected budget to be found")
+	}
+	if matched.ID != monthlyBudget.ID || matched.CurrentUsage != monthlyBudget.CurrentUsage {
+		t.Fatalf("expected ID match to preserve the monthly budget, got %#v", matched)
+	}
+}
+
+func TestFindExistingBudgetRejectsUnknownID(t *testing.T) {
+	byID, byDuration := buildBudgetLookup([]configstoreTables.TableBudget{
+		{ID: "budget-1", ResetDuration: "1d"},
+	})
+
+	_, _, err := findExistingBudget(CreateBudgetRequest{
+		ID:            "missing-budget",
+		MaxLimit:      100,
+		ResetDuration: "1d",
+	}, byID, byDuration)
+	if err == nil {
+		t.Fatal("expected unknown budget ID to fail")
+	}
+}
+
+func TestResetBudgetUsageIfRequested(t *testing.T) {
+	originalLastReset := time.Now().Add(-24 * time.Hour)
+	budget := configstoreTables.TableBudget{
+		ID:            "budget-1",
+		MaxLimit:      100,
+		ResetDuration: "1d",
+		CurrentUsage:  42,
+		LastReset:     originalLastReset,
+	}
+
+	resetBudgetUsageIfRequested(&budget, false, false)
+	if budget.CurrentUsage != 42 || !budget.LastReset.Equal(originalLastReset) {
+		t.Fatalf("expected usage to be preserved when reset is false, got %#v", budget)
+	}
+
+	resetBudgetUsageIfRequested(&budget, true, false)
+	if budget.CurrentUsage != 0 {
+		t.Fatalf("expected usage to reset, got %#v", budget)
+	}
+	if !budget.LastReset.After(originalLastReset) {
+		t.Fatalf("expected last reset to advance, got %s", budget.LastReset)
+	}
+}
+
+func reconcileBudgetRequestsForTest(existing []configstoreTables.TableBudget, requests []CreateBudgetRequest, resetUsage bool) ([]configstoreTables.TableBudget, error) {
+	requestBudgets := append([]CreateBudgetRequest(nil), requests...)
+	sort.Slice(requestBudgets, func(i, j int) bool {
+		return compareBudgetRequestDurations(requestBudgets[i], requestBudgets[j])
+	})
+
+	byID, byDuration := buildBudgetLookup(existing)
+	reconciled := make([]configstoreTables.TableBudget, 0, len(requestBudgets))
+	for _, request := range requestBudgets {
+		budget, found, err := findExistingBudget(request, byID, byDuration)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			budget = configstoreTables.TableBudget{
+				ID:            "new-budget",
+				MaxLimit:      request.MaxLimit,
+				CurrentUsage:  0,
+				LastReset:     budgetLastReset(false, request.ResetDuration),
+				ResetDuration: request.ResetDuration,
+			}
+			if err := inheritUsageFromClosestShorterBudget(&budget, reconciled, resetUsage); err != nil {
+				return nil, err
+			}
+		}
+		configChanged := budget.MaxLimit != request.MaxLimit || budget.ResetDuration != request.ResetDuration
+		budget.MaxLimit = request.MaxLimit
+		budget.ResetDuration = request.ResetDuration
+		resetBudgetUsageIfRequested(&budget, resetUsage, false)
+		if found && configChanged {
+			if err := validatePreservedBudgetUsageWithinLimit(&budget, "preserved", "", resetUsage); err != nil {
+				return nil, err
+			}
+		}
+		reconciled = append(reconciled, budget)
+	}
+	return reconciled, nil
+}
+
+func TestVirtualKeyBudgetFrequencyChangePreservesUsageWhenRequested(t *testing.T) {
+	originalLastReset := time.Now().Add(-2 * time.Hour)
+	reconciled, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "vk-budget-1",
+				MaxLimit:      100,
+				ResetDuration: "1M",
+				CurrentUsage:  100,
+				LastReset:     originalLastReset,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "vk-budget-1",
+				MaxLimit:      150,
+				ResetDuration: "1d",
+			},
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed: %v", err)
+	}
+	if len(reconciled) != 1 {
+		t.Fatalf("expected one budget, got %d", len(reconciled))
+	}
+	if reconciled[0].ID != "vk-budget-1" || reconciled[0].ResetDuration != "1d" || reconciled[0].MaxLimit != 150 {
+		t.Fatalf("expected same budget to be updated, got %#v", reconciled[0])
+	}
+	if reconciled[0].CurrentUsage != 100 || !reconciled[0].LastReset.Equal(originalLastReset) {
+		t.Fatalf("expected usage and last reset to be preserved, got %#v", reconciled[0])
+	}
+}
+
+func TestProviderBudgetFrequencyChangePreservesUsageWhenRequested(t *testing.T) {
+	originalLastReset := time.Now().Add(-2 * time.Hour)
+	providerConfigID := uint(7)
+	reconciled, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:               "provider-budget-1",
+				MaxLimit:         100,
+				ResetDuration:    "1M",
+				CurrentUsage:     100,
+				LastReset:        originalLastReset,
+				ProviderConfigID: &providerConfigID,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "provider-budget-1",
+				MaxLimit:      150,
+				ResetDuration: "1d",
+			},
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed: %v", err)
+	}
+	if len(reconciled) != 1 {
+		t.Fatalf("expected one budget, got %d", len(reconciled))
+	}
+	if reconciled[0].ID != "provider-budget-1" || reconciled[0].ResetDuration != "1d" || reconciled[0].MaxLimit != 150 {
+		t.Fatalf("expected same provider budget to be updated, got %#v", reconciled[0])
+	}
+	if reconciled[0].CurrentUsage != 100 || !reconciled[0].LastReset.Equal(originalLastReset) {
+		t.Fatalf("expected provider usage and last reset to be preserved, got %#v", reconciled[0])
+	}
+}
+
+func TestBudgetFrequencyChangeResetsUsageWhenRequested(t *testing.T) {
+	originalLastReset := time.Now().Add(-2 * time.Hour)
+	reconciled, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "budget-1",
+				MaxLimit:      100,
+				ResetDuration: "1M",
+				CurrentUsage:  100,
+				LastReset:     originalLastReset,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "budget-1",
+				MaxLimit:      150,
+				ResetDuration: "1d",
+			},
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed: %v", err)
+	}
+	if reconciled[0].CurrentUsage != 0 {
+		t.Fatalf("expected usage to reset, got %#v", reconciled[0])
+	}
+	if !reconciled[0].LastReset.After(originalLastReset) {
+		t.Fatalf("expected last reset to advance, got %s", reconciled[0].LastReset)
+	}
+}
+
+func TestExistingVirtualKeyBudgetLoweredBelowPreservedUsageFails(t *testing.T) {
+	_, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "monthly-budget",
+				MaxLimit:      300,
+				ResetDuration: "1M",
+				CurrentUsage:  0.11,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "monthly-budget",
+				MaxLimit:      0.01,
+				ResetDuration: "1M",
+			},
+		},
+		false,
+	)
+	if err == nil {
+		t.Fatal("expected lowering budget below preserved usage to fail")
+	}
+	if !strings.Contains(err.Error(), "reset usage while setting up the budget or increase the budget limit") {
+		t.Fatalf("expected actionable error message, got %v", err)
+	}
+}
+
+func TestExistingProviderBudgetLoweredBelowPreservedUsageFails(t *testing.T) {
+	_, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "provider-monthly-budget",
+				MaxLimit:      300,
+				ResetDuration: "1M",
+				CurrentUsage:  0.11,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "provider-monthly-budget",
+				MaxLimit:      0.01,
+				ResetDuration: "1M",
+			},
+		},
+		false,
+	)
+	if err == nil {
+		t.Fatal("expected lowering provider budget below preserved usage to fail")
+	}
+	if !strings.Contains(err.Error(), "reset usage while setting up the budget or increase the budget limit") {
+		t.Fatalf("expected actionable error message, got %v", err)
+	}
+}
+
+func TestExistingBudgetLoweredBelowUsageSucceedsWhenResetRequested(t *testing.T) {
+	reconciled, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "monthly-budget",
+				MaxLimit:      300,
+				ResetDuration: "1M",
+				CurrentUsage:  0.11,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "monthly-budget",
+				MaxLimit:      0.01,
+				ResetDuration: "1M",
+			},
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expected reset usage to allow lower budget: %v", err)
+	}
+	if reconciled[0].CurrentUsage != 0 {
+		t.Fatalf("expected usage to reset, got %#v", reconciled[0])
+	}
+}
+
+func TestNewVirtualKeyBudgetInheritsClosestShorterUsage(t *testing.T) {
+	reconciled, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "weekly-budget",
+				MaxLimit:      100,
+				ResetDuration: "1w",
+				CurrentUsage:  100,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "weekly-budget",
+				MaxLimit:      100,
+				ResetDuration: "1w",
+			},
+			{
+				MaxLimit:      300,
+				ResetDuration: "1M",
+			},
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed: %v", err)
+	}
+	if len(reconciled) != 2 {
+		t.Fatalf("expected two budgets, got %d", len(reconciled))
+	}
+	monthly := reconciled[1]
+	if monthly.ResetDuration != "1M" || monthly.CurrentUsage != 100 {
+		t.Fatalf("expected monthly budget to inherit weekly usage, got %#v", monthly)
+	}
+}
+
+func TestNewProviderBudgetInheritsClosestShorterUsage(t *testing.T) {
+	reconciled, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "weekly-budget",
+				MaxLimit:      100,
+				ResetDuration: "1w",
+				CurrentUsage:  100,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "weekly-budget",
+				MaxLimit:      100,
+				ResetDuration: "1w",
+			},
+			{
+				MaxLimit:      300,
+				ResetDuration: "1M",
+			},
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed: %v", err)
+	}
+	monthly := reconciled[1]
+	if monthly.ResetDuration != "1M" || monthly.CurrentUsage != 100 {
+		t.Fatalf("expected provider monthly budget to inherit weekly usage, got %#v", monthly)
+	}
+}
+
+func TestNewVirtualKeyBudgetInheritanceFailsWhenUsageExceedsLimit(t *testing.T) {
+	_, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "weekly-budget",
+				MaxLimit:      300,
+				ResetDuration: "1w",
+				CurrentUsage:  100,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "weekly-budget",
+				MaxLimit:      300,
+				ResetDuration: "1w",
+			},
+			{
+				MaxLimit:      50,
+				ResetDuration: "1M",
+			},
+		},
+		false,
+	)
+	if err == nil {
+		t.Fatal("expected inherited usage above new budget limit to fail")
+	}
+	if !strings.Contains(err.Error(), "reset usage while setting up the budget or increase the budget limit") {
+		t.Fatalf("expected actionable error message, got %v", err)
+	}
+}
+
+func TestNewProviderBudgetInheritanceFailsWhenUsageExceedsLimit(t *testing.T) {
+	_, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "weekly-budget",
+				MaxLimit:      300,
+				ResetDuration: "1w",
+				CurrentUsage:  100,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "weekly-budget",
+				MaxLimit:      300,
+				ResetDuration: "1w",
+			},
+			{
+				MaxLimit:      100,
+				ResetDuration: "1M",
+			},
+		},
+		false,
+	)
+	if err == nil {
+		t.Fatal("expected inherited usage equal to new budget limit to fail")
+	}
+	if !strings.Contains(err.Error(), "reset usage while setting up the budget or increase the budget limit") {
+		t.Fatalf("expected actionable error message, got %v", err)
+	}
+}
+
+func TestNewShorterBudgetDoesNotInheritFromLongerUsage(t *testing.T) {
+	reconciled, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "monthly-budget",
+				MaxLimit:      300,
+				ResetDuration: "1M",
+				CurrentUsage:  100,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				MaxLimit:      100,
+				ResetDuration: "1w",
+			},
+			{
+				ID:            "monthly-budget",
+				MaxLimit:      300,
+				ResetDuration: "1M",
+			},
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed: %v", err)
+	}
+	if len(reconciled) != 2 {
+		t.Fatalf("expected two budgets, got %d", len(reconciled))
+	}
+	weekly := reconciled[0]
+	if weekly.ResetDuration != "1w" || weekly.CurrentUsage != 0 {
+		t.Fatalf("expected weekly budget to start at zero, got %#v", weekly)
+	}
+}
+
+func TestNewBudgetInheritsClosestShorterUsage(t *testing.T) {
+	reconciled, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "minute-budget",
+				MaxLimit:      10,
+				ResetDuration: "1m",
+				CurrentUsage:  5,
+			},
+			{
+				ID:            "weekly-budget",
+				MaxLimit:      100,
+				ResetDuration: "1w",
+				CurrentUsage:  75,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "minute-budget",
+				MaxLimit:      10,
+				ResetDuration: "1m",
+			},
+			{
+				ID:            "weekly-budget",
+				MaxLimit:      100,
+				ResetDuration: "1w",
+			},
+			{
+				MaxLimit:      300,
+				ResetDuration: "1M",
+			},
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed: %v", err)
+	}
+	monthly := reconciled[2]
+	if monthly.ResetDuration != "1M" || monthly.CurrentUsage != 75 {
+		t.Fatalf("expected monthly budget to inherit closest shorter weekly usage, got %#v", monthly)
+	}
+}
+
+func TestNewLongerBudgetDoesNotInheritUsageWhenResetRequested(t *testing.T) {
+	reconciled, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "weekly-budget",
+				MaxLimit:      100,
+				ResetDuration: "1w",
+				CurrentUsage:  100,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "weekly-budget",
+				MaxLimit:      100,
+				ResetDuration: "1w",
+			},
+			{
+				MaxLimit:      300,
+				ResetDuration: "1M",
+			},
+		},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed: %v", err)
+	}
+	monthly := reconciled[1]
+	if monthly.ResetDuration != "1M" || monthly.CurrentUsage != 0 {
+		t.Fatalf("expected monthly budget to start at zero when reset is requested, got %#v", monthly)
+	}
+}
+
+func TestRotateVirtualKey_OnlyChangesValueAndReloads(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	active := true
+	teamID := "team-1"
+	rateLimitID := "rate-limit-1"
+	store := &mockRotateConfigStore{
+		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
+			"vk-1": {
+				ID:          "vk-1",
+				Name:        "Production",
+				Value:       "sk-bf-old",
+				Description: "existing description",
+				TeamID:      &teamID,
+				RateLimitID: &rateLimitID,
+				IsActive:    &active,
+				Budgets: []configstoreTables.TableBudget{
+					{ID: "budget-1", MaxLimit: 100, CurrentUsage: 42, ResetDuration: "1d"},
+				},
+				ProviderConfigs: []configstoreTables.TableVirtualKeyProviderConfig{
+					{ID: 7, VirtualKeyID: "vk-1", Provider: "openai"},
+				},
+				MCPConfigs: []configstoreTables.TableVirtualKeyMCPConfig{
+					{ID: 9, VirtualKeyID: "vk-1", MCPClientID: 3},
+				},
+			},
+		},
+	}
+	manager := &mockRotateGovernanceManager{store: store}
+	h := &GovernanceHandler{configStore: store, governanceManager: manager}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("vk_id", "vk-1")
+
+	h.rotateVirtualKey(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if store.updates != 1 {
+		t.Fatalf("expected one update, got %d", store.updates)
+	}
+	if len(manager.reloadIDs) != 1 || manager.reloadIDs[0] != "vk-1" {
+		t.Fatalf("expected reload for vk-1, got %#v", manager.reloadIDs)
+	}
+
+	updated := store.virtualKeys["vk-1"]
+	if updated.Value == "sk-bf-old" {
+		t.Fatal("expected virtual key value to rotate")
+	}
+	if !strings.HasPrefix(updated.Value, governance.VirtualKeyPrefix) {
+		t.Fatalf("expected rotated value to use %q prefix, got %q", governance.VirtualKeyPrefix, updated.Value)
+	}
+	if updated.ID != "vk-1" || updated.Name != "Production" || updated.Description != "existing description" {
+		t.Fatalf("rotation changed non-value fields: %#v", updated)
+	}
+	if updated.TeamID == nil || *updated.TeamID != teamID || updated.RateLimitID == nil || *updated.RateLimitID != rateLimitID || updated.IsActive == nil || !*updated.IsActive {
+		t.Fatalf("rotation changed relationship/status fields: %#v", updated)
+	}
+	if len(updated.Budgets) != 1 || updated.Budgets[0].CurrentUsage != 42 {
+		t.Fatalf("rotation changed budgets: %#v", updated.Budgets)
+	}
+	if len(updated.ProviderConfigs) != 1 || updated.ProviderConfigs[0].ID != 7 {
+		t.Fatalf("rotation changed provider configs: %#v", updated.ProviderConfigs)
+	}
+	if len(updated.MCPConfigs) != 1 || updated.MCPConfigs[0].ID != 9 {
+		t.Fatalf("rotation changed MCP configs: %#v", updated.MCPConfigs)
+	}
+
+	var resp struct {
+		Message    string                            `json:"message"`
+		VirtualKey configstoreTables.TableVirtualKey `json:"virtual_key"`
+	}
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.VirtualKey.Value != updated.Value {
+		t.Fatalf("response value = %q, want %q", resp.VirtualKey.Value, updated.Value)
+	}
+}
+
+func TestRotateVirtualKeys_PartialSuccess(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	store := &mockRotateConfigStore{
+		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
+			"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old-1"},
+			"vk-2": {ID: "vk-2", Name: "Two", Value: "sk-bf-old-2"},
+		},
+	}
+	manager := &mockRotateGovernanceManager{store: store}
+	h := &GovernanceHandler{configStore: store, governanceManager: manager}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetBodyString(`{"ids":["vk-1","missing","vk-2","vk-1"]}`)
+
+	h.rotateVirtualKeys(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if store.updates != 2 {
+		t.Fatalf("expected two updates, got %d", store.updates)
+	}
+	if len(manager.reloadIDs) != 2 || manager.reloadIDs[0] != "vk-1" || manager.reloadIDs[1] != "vk-2" {
+		t.Fatalf("expected reloads for vk-1 and vk-2, got %#v", manager.reloadIDs)
+	}
+	if store.virtualKeys["vk-1"].Value == "sk-bf-old-1" || store.virtualKeys["vk-2"].Value == "sk-bf-old-2" {
+		t.Fatalf("expected successful IDs to rotate: %#v", store.virtualKeys)
+	}
+
+	var resp struct {
+		VirtualKeys []configstoreTables.TableVirtualKey `json:"virtual_keys"`
+		Errors      map[string]string                   `json:"errors"`
+	}
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(resp.VirtualKeys) != 2 {
+		t.Fatalf("expected two rotated keys in response, got %d", len(resp.VirtualKeys))
+	}
+	if resp.Errors["missing"] != "virtual key not found" {
+		t.Fatalf("expected missing error, got %#v", resp.Errors)
+	}
 }
 
 // TestGetVirtualKeys_PaginatedEndpoint_ResponseShape verifies the JSON response

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -358,6 +358,14 @@ func (s *BifrostHTTPServer) ReloadVirtualKey(ctx context.Context, id string) (*t
 	if err != nil {
 		return nil, err
 	}
+	if governanceData := governancePlugin.GetGovernanceStore().GetGovernanceData(ctx); governanceData != nil {
+		for _, existingVK := range governanceData.VirtualKeys {
+			if existingVK != nil && existingVK.ID == virtualKey.ID && existingVK.Value != "" && existingVK.Value != virtualKey.Value {
+				s.MCPServerHandler.DeleteVKMCPServer(existingVK.Value)
+				break
+			}
+		}
+	}
 	governancePlugin.GetGovernanceStore().UpdateVirtualKeyInMemory(ctx, virtualKey, nil, nil, nil)
 	s.MCPServerHandler.SyncVKMCPServer(virtualKey)
 	return virtualKey, nil


### PR DESCRIPTION
## Summary

This PR adds virtual key rotation endpoints that allow callers to regenerate the secret value of one or more virtual keys without touching any other fields (budgets, provider configs, MCP configs, team/rate-limit associations, etc.). It also fixes a bug where rotating a key's value left the old value as a stale entry in the in-memory store.

## Changes

- Added `POST /api/governance/virtual-keys/{vk_id}/rotate` to rotate a single virtual key's value.
- Added `POST /api/governance/virtual-keys/rotate` (bulk) accepting `{"ids": [...]}` to rotate multiple keys in one call; duplicate IDs are deduplicated, and partial failures are reported per-ID without aborting the whole batch.
- Added `rotateVirtualKeyByID` helper that generates a new value, persists it via `UpdateVirtualKey`, and reloads the in-memory state via `ReloadVirtualKey`.
- Fixed `UpdateVirtualKeyInMemory`: when a virtual key's `Value` changes (rotation), the old map entry was never removed. The fix scans the sync map by ID when the value-keyed lookup misses or returns a mismatched ID, then deletes the stale key before storing under the new value.
- Fixed `ReloadVirtualKey` in the HTTP server: when a key's value changes, the MCP server entry registered under the old value is now explicitly deleted before syncing the new value.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins

## How to test

```sh
go test ./plugins/governance/... ./transports/bifrost-http/handlers/... ./transports/bifrost-http/server/...
```

**Single key rotation:**
```sh
curl -X POST http://localhost:8080/api/governance/virtual-keys/{vk_id}/rotate
# Expect 200 with {"message":"Virtual key rotated successfully","virtual_key":{...}} where value has changed.
# Confirm the old value no longer authenticates requests.
```

**Bulk rotation:**
```sh
curl -X POST http://localhost:8080/api/governance/virtual-keys/rotate \
  -H 'Content-Type: application/json' \
  -d '{"ids":["vk-1","vk-2","nonexistent"]}'
# Expect 200 with rotated keys in virtual_keys and per-ID errors for any failures.
```

**Stale entry fix:** after rotating a key, verify that a lookup by the old value returns 404 and a lookup by the new value returns the correct key.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Rotated key values are generated using the existing `governance.GenerateVirtualKey()` function. The old value is immediately invalidated in-memory upon rotation, so any in-flight requests using the old value will fail after the reload completes. Callers should treat the new value as a secret and distribute it securely.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable