### PR TITLE
rotate vk ui chagnes

### DIFF
--- a/tests/e2e/core/actions/api.ts
+++ b/tests/e2e/core/actions/api.ts
@@ -106,6 +106,24 @@ export const virtualKeysApi = {
   },
 
   /**
+   * Rotate a virtual key value
+   */
+  async rotate(request: APIRequestContext, id: string) {
+    const response = await request.post(`${API_BASE}/governance/virtual-keys/${id}/rotate`)
+    return handleResponse(response, `Rotate virtual key ${id}`)
+  },
+
+  /**
+   * Rotate multiple virtual key values
+   */
+  async bulkRotate(request: APIRequestContext, ids: string[]) {
+    const response = await request.post(`${API_BASE}/governance/virtual-keys/rotate`, {
+      data: { ids },
+    })
+    return handleResponse(response, 'Bulk rotate virtual keys')
+  },
+
+  /**
    * Delete a virtual key
    */
   async delete(request: APIRequestContext, id: string) {

--- a/tests/e2e/features/virtual-keys/pages/virtual-keys.page.ts
+++ b/tests/e2e/features/virtual-keys/pages/virtual-keys.page.ts
@@ -623,6 +623,103 @@ export class VirtualKeysPage extends BasePage {
   }
 
   /**
+   * Reveal and read the displayed virtual key value from the table.
+   */
+  async getDisplayedVirtualKeyValue(name: string): Promise<string> {
+    await this.searchVirtualKeys(name);
+    const row = this.getVirtualKeyRow(name);
+    await expect(row).toBeVisible({ timeout: 10000 });
+    await row.scrollIntoViewIfNeeded();
+
+    if (!(await this.isKeyRevealed(name))) {
+      await this.toggleKeyVisibility(name);
+      await expect(row.getByTestId("vk-key-value")).not.toContainText("•", { timeout: 5000 });
+    }
+
+    return ((await row.getByTestId("vk-key-value").textContent()) ?? "").trim();
+  }
+
+  async waitForVirtualKeyValueToChange(name: string, oldValue: string): Promise<string> {
+    const deadline = Date.now() + 20000;
+    let currentValue = oldValue;
+
+    while (Date.now() < deadline) {
+      await this.page.waitForTimeout(500);
+      currentValue = await this.getDisplayedVirtualKeyValue(name);
+      if (currentValue && currentValue !== oldValue) {
+        return currentValue;
+      }
+    }
+
+    throw new Error(`Virtual key "${name}" value did not change after rotation`);
+  }
+
+  async rotateVirtualKey(name: string): Promise<void> {
+    await this.forceCloseToasts();
+    await this.openVirtualKeyEditor(name);
+
+    const rotateBtn = this.page.getByTestId("vk-rotate-btn");
+    await rotateBtn.waitFor({ state: "visible", timeout: 10000 });
+    await rotateBtn.click();
+
+    const confirmBtn = this.page.getByTestId("vk-rotate-confirm-btn");
+    await confirmBtn.waitFor({ state: "visible", timeout: 5000 });
+    await confirmBtn.click();
+
+    await this.waitForSuccessToast("rotated");
+    await this.closeSheet();
+    await this.goto();
+    await this.searchVirtualKeys(name);
+  }
+
+  async cancelRotateVirtualKey(name: string): Promise<void> {
+    await this.forceCloseToasts();
+    await this.openVirtualKeyEditor(name);
+
+    const rotateBtn = this.page.getByTestId("vk-rotate-btn");
+    await rotateBtn.waitFor({ state: "visible", timeout: 10000 });
+    await rotateBtn.click();
+
+    const cancelBtn = this.page.getByTestId("vk-rotate-cancel-btn");
+    await cancelBtn.waitFor({ state: "visible", timeout: 5000 });
+    await cancelBtn.click();
+    await expect(cancelBtn).not.toBeVisible({ timeout: 5000 }).catch(() => {});
+
+    await this.closeSheet();
+    await this.goto();
+    await this.searchVirtualKeys(name);
+  }
+
+  async selectVirtualKey(name: string): Promise<void> {
+    await this.searchVirtualKeys(name);
+    const row = this.getVirtualKeyRow(name);
+    await expect(row).toBeVisible({ timeout: 10000 });
+    const checkbox = this.page.getByTestId(`vk-select-checkbox-${name}`);
+    await checkbox.scrollIntoViewIfNeeded();
+    if ((await checkbox.getAttribute("data-state")) !== "checked") {
+      await checkbox.click();
+    }
+  }
+
+  async bulkRotateVirtualKeys(names: string[]): Promise<void> {
+    await this.forceCloseToasts();
+    for (const name of names) {
+      await this.selectVirtualKey(name);
+    }
+
+    const rotateBtn = this.page.getByTestId("vk-bulk-rotate-btn");
+    await rotateBtn.waitFor({ state: "visible", timeout: 10000 });
+    await rotateBtn.click();
+
+    const confirmBtn = this.page.getByTestId("vk-bulk-rotate-confirm-btn");
+    await confirmBtn.waitFor({ state: "visible", timeout: 5000 });
+    await confirmBtn.click();
+
+    await this.waitForSuccessToast("Rotated");
+    await this.goto();
+  }
+
+  /**
    * Close any open sheet/dialog
    */
   async closeSheet(): Promise<void> {

--- a/tests/e2e/features/virtual-keys/virtual-keys.spec.ts
+++ b/tests/e2e/features/virtual-keys/virtual-keys.spec.ts
@@ -1,4 +1,6 @@
 import { expect, test } from '../../core/fixtures/base.fixture'
+import { virtualKeysApi } from '../../core/actions/api'
+import type { VirtualKeysPage } from './pages/virtual-keys.page'
 import {
     createVirtualKeyData,
     createVirtualKeyWithBudget,
@@ -9,12 +11,39 @@ import {
     SAMPLE_RATE_LIMITS,
 } from './virtual-keys.data'
 
+type VirtualKeyApiResponse = {
+  virtual_key: {
+    id: string
+    name: string
+    value: string
+  }
+}
+
+type BulkRotateVirtualKeysApiResponse = {
+  virtual_keys: Array<{
+    id: string
+    name: string
+    value: string
+  }>
+  errors?: Record<string, string>
+}
+
+async function skipIfConfigStoreMissing(virtualKeysPage: VirtualKeysPage): Promise<void> {
+  const missingConfigStore = await virtualKeysPage.page
+    .getByText('Config store setup is missing.')
+    .isVisible({ timeout: 1000 })
+    .catch(() => false)
+
+  test.skip(missingConfigStore, 'Config store setup is missing; virtual-key E2E tests require a configured config store.')
+}
+
 // Track created VKs for cleanup
 const createdVKs: string[] = []
 
 test.describe('Virtual Keys', () => {
   test.beforeEach(async ({ virtualKeysPage }) => {
     await virtualKeysPage.goto()
+    await skipIfConfigStoreMissing(virtualKeysPage)
   })
 
   test.afterEach(async ({ virtualKeysPage }) => {
@@ -246,6 +275,7 @@ const managementVKs: string[] = []
 test.describe('Virtual Key Management', () => {
   test.beforeEach(async ({ virtualKeysPage }) => {
     await virtualKeysPage.goto()
+    await skipIfConfigStoreMissing(virtualKeysPage)
   })
 
   test.afterEach(async ({ virtualKeysPage }) => {
@@ -393,6 +423,119 @@ test.describe('Virtual Key Management', () => {
     isRevealed = await virtualKeysPage.isKeyRevealed(vkName)
     expect(isRevealed).toBe(false)
   })
+
+  test.describe('Virtual Key Rotation', () => {
+    test('should rotate a virtual key from the edit sheet', async ({ virtualKeysPage }) => {
+      const vkName = `Rotate VK ${Date.now()}`
+      const vkData = createVirtualKeyData({ name: vkName })
+
+      managementVKs.push(vkName)
+      await virtualKeysPage.createVirtualKey(vkData)
+
+      const oldValue = await virtualKeysPage.getDisplayedVirtualKeyValue(vkName)
+      expect(oldValue).toMatch(/^sk-bf-/)
+
+      await virtualKeysPage.rotateVirtualKey(vkName)
+
+      const newValue = await virtualKeysPage.waitForVirtualKeyValueToChange(vkName, oldValue)
+      expect(newValue).toMatch(/^sk-bf-/)
+      expect(newValue).not.toBe(oldValue)
+      expect(await virtualKeysPage.virtualKeyExists(vkName)).toBe(true)
+    })
+
+    test('should leave the virtual key unchanged when rotation is cancelled', async ({ virtualKeysPage }) => {
+      const vkName = `Cancel Rotate VK ${Date.now()}`
+      const vkData = createVirtualKeyData({ name: vkName })
+
+      managementVKs.push(vkName)
+      await virtualKeysPage.createVirtualKey(vkData)
+
+      const oldValue = await virtualKeysPage.getDisplayedVirtualKeyValue(vkName)
+
+      await virtualKeysPage.cancelRotateVirtualKey(vkName)
+
+      const currentValue = await virtualKeysPage.getDisplayedVirtualKeyValue(vkName)
+      expect(currentValue).toBe(oldValue)
+    })
+
+    test('should bulk rotate selected virtual keys only', async ({ virtualKeysPage }) => {
+      const selectedOne = `Bulk Rotate One ${Date.now()}`
+      const selectedTwo = `Bulk Rotate Two ${Date.now()}`
+      const unselected = `Bulk Rotate Unselected ${Date.now()}`
+
+      for (const name of [selectedOne, selectedTwo, unselected]) {
+        managementVKs.push(name)
+        await virtualKeysPage.createVirtualKey(createVirtualKeyData({ name }))
+      }
+
+      const oldSelectedOne = await virtualKeysPage.getDisplayedVirtualKeyValue(selectedOne)
+      const oldSelectedTwo = await virtualKeysPage.getDisplayedVirtualKeyValue(selectedTwo)
+      const oldUnselected = await virtualKeysPage.getDisplayedVirtualKeyValue(unselected)
+
+      await virtualKeysPage.bulkRotateVirtualKeys([selectedOne, selectedTwo])
+
+      const newSelectedOne = await virtualKeysPage.waitForVirtualKeyValueToChange(selectedOne, oldSelectedOne)
+      const newSelectedTwo = await virtualKeysPage.waitForVirtualKeyValueToChange(selectedTwo, oldSelectedTwo)
+      const currentUnselected = await virtualKeysPage.getDisplayedVirtualKeyValue(unselected)
+
+      expect(newSelectedOne).not.toBe(oldSelectedOne)
+      expect(newSelectedTwo).not.toBe(oldSelectedTwo)
+      expect(currentUnselected).toBe(oldUnselected)
+    })
+
+    test('should rotate a virtual key through the API', async ({ request }) => {
+      const vkName = `API Rotate VK ${Date.now()}`
+      const createResp = (await virtualKeysApi.create(request, {
+        name: vkName,
+        description: 'API rotation test',
+        is_active: true,
+      })) as VirtualKeyApiResponse
+
+      managementVKs.push(vkName)
+      const oldValue = createResp.virtual_key.value
+
+      const rotateResp = (await virtualKeysApi.rotate(request, createResp.virtual_key.id)) as VirtualKeyApiResponse
+      expect(rotateResp.virtual_key.value).toMatch(/^sk-bf-/)
+      expect(rotateResp.virtual_key.value).not.toBe(oldValue)
+
+      const getResp = (await virtualKeysApi.get(request, createResp.virtual_key.id)) as VirtualKeyApiResponse
+      expect(getResp.virtual_key.value).toBe(rotateResp.virtual_key.value)
+    })
+
+    test('should bulk rotate valid API IDs and report missing IDs', async ({ request }) => {
+      const firstName = `API Bulk Rotate One ${Date.now()}`
+      const secondName = `API Bulk Rotate Two ${Date.now()}`
+
+      const first = (await virtualKeysApi.create(request, {
+        name: firstName,
+        description: 'API bulk rotation test one',
+        is_active: true,
+      })) as VirtualKeyApiResponse
+      const second = (await virtualKeysApi.create(request, {
+        name: secondName,
+        description: 'API bulk rotation test two',
+        is_active: true,
+      })) as VirtualKeyApiResponse
+
+      managementVKs.push(firstName, secondName)
+
+      const bulkResp = (await virtualKeysApi.bulkRotate(request, [
+        first.virtual_key.id,
+        'missing-vk-id',
+        second.virtual_key.id,
+      ])) as BulkRotateVirtualKeysApiResponse
+
+      expect(bulkResp.virtual_keys.map((vk) => vk.id).sort()).toEqual([
+        first.virtual_key.id,
+        second.virtual_key.id,
+      ].sort())
+      expect(bulkResp.errors?.['missing-vk-id']).toBe('virtual key not found')
+
+      const rotatedByID = new Map(bulkResp.virtual_keys.map((vk) => [vk.id, vk.value]))
+      expect(rotatedByID.get(first.virtual_key.id)).not.toBe(first.virtual_key.value)
+      expect(rotatedByID.get(second.virtual_key.id)).not.toBe(second.virtual_key.value)
+    })
+  })
 })
 
 // Track VKs created in Virtual Keys Table tests for cleanup
@@ -401,6 +544,7 @@ const tableTestVKs: string[] = []
 test.describe('Virtual Keys Table', () => {
   test.beforeEach(async ({ virtualKeysPage }) => {
     await virtualKeysPage.goto()
+    await skipIfConfigStoreMissing(virtualKeysPage)
   })
 
   test.afterEach(async ({ virtualKeysPage }) => {
@@ -441,6 +585,7 @@ test.describe('Virtual Keys Table', () => {
 test.describe('Form Validation', () => {
   test.beforeEach(async ({ virtualKeysPage }) => {
     await virtualKeysPage.goto()
+    await skipIfConfigStoreMissing(virtualKeysPage)
   })
 
   test.afterEach(async ({ virtualKeysPage }) => {
@@ -486,6 +631,7 @@ const providerVKs: string[] = []
 test.describe('Provider Management', () => {
   test.beforeEach(async ({ virtualKeysPage }) => {
     await virtualKeysPage.goto()
+    await skipIfConfigStoreMissing(virtualKeysPage)
   })
 
   test.afterEach(async ({ virtualKeysPage }) => {

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -118,13 +118,14 @@ type UpdateVirtualKeyRequest struct {
 		MCPClientName  string            `json:"mcp_client_name" validate:"required"`
 		ToolsToExecute schemas.WhiteList `json:"tools_to_execute,omitempty"`
 	} `json:"mcp_configs,omitempty"`
-	TeamID          *string                 `json:"team_id,omitempty"`
-	CustomerID      *string                 `json:"customer_id,omitempty"`
-	AccessProfileID *uint                   `json:"access_profile_id,omitempty"`
-	Budgets         []CreateBudgetRequest   `json:"budgets,omitempty"` // Multi-budget: replaces all VK-level budgets
-	RateLimit       *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
-	IsActive        *bool                   `json:"is_active,omitempty"`
-	CalendarAligned *bool                   `json:"calendar_aligned,omitempty"` // When true, all budgets reset at clean calendar boundaries
+	TeamID           *string                 `json:"team_id,omitempty"`
+	CustomerID       *string                 `json:"customer_id,omitempty"`
+	AccessProfileID  *uint                   `json:"access_profile_id,omitempty"`
+	Budgets          []CreateBudgetRequest   `json:"budgets,omitempty"` // Multi-budget: replaces all VK-level budgets
+	RateLimit        *UpdateRateLimitRequest `json:"rate_limit,omitempty"`
+	IsActive         *bool                   `json:"is_active,omitempty"`
+	CalendarAligned  *bool                   `json:"calendar_aligned,omitempty"` // When true, all budgets reset at clean calendar boundaries
+	ResetBudgetUsage *bool                   `json:"reset_budget_usage,omitempty"`
 }
 
 type BulkRotateVirtualKeysRequest struct {
@@ -133,6 +134,7 @@ type BulkRotateVirtualKeysRequest struct {
 
 // CreateBudgetRequest represents the request body for creating a budget
 type CreateBudgetRequest struct {
+	ID            string  `json:"id,omitempty"`
 	MaxLimit      float64 `json:"max_limit" validate:"required"`      // Maximum budget in dollars
 	ResetDuration string  `json:"reset_duration" validate:"required"` // e.g., "30s", "5m", "1h", "1d", "1w", "1M"
 }
@@ -211,6 +213,99 @@ func budgetLastReset(calendarAligned bool, resetDuration string) time.Time {
 		return configstoreTables.GetCalendarPeriodStart(resetDuration, time.Now())
 	}
 	return time.Now()
+}
+
+func resetBudgetUsageIfRequested(budget *configstoreTables.TableBudget, reset bool, calendarAligned bool) {
+	if !reset {
+		return
+	}
+	budget.CurrentUsage = 0
+	budget.LastReset = budgetLastReset(calendarAligned, budget.ResetDuration)
+}
+
+func compareBudgetRequestDurations(left, right CreateBudgetRequest) bool {
+	leftDuration, leftErr := configstoreTables.ParseDuration(left.ResetDuration)
+	rightDuration, rightErr := configstoreTables.ParseDuration(right.ResetDuration)
+	if leftErr == nil && rightErr == nil && leftDuration != rightDuration {
+		return leftDuration < rightDuration
+	}
+	return left.ResetDuration < right.ResetDuration
+}
+
+func inheritUsageFromClosestShorterBudget(budget *configstoreTables.TableBudget, existing []configstoreTables.TableBudget, reset bool) {
+	if reset {
+		return
+	}
+	targetDuration, err := configstoreTables.ParseDuration(budget.ResetDuration)
+	if err != nil {
+		return
+	}
+
+	var closest *configstoreTables.TableBudget
+	var closestDuration time.Duration
+	for i := range existing {
+		candidate := &existing[i]
+		candidateDuration, err := configstoreTables.ParseDuration(candidate.ResetDuration)
+		if err != nil || candidateDuration >= targetDuration {
+			continue
+		}
+		if closest == nil || candidateDuration > closestDuration {
+			closest = candidate
+			closestDuration = candidateDuration
+		}
+	}
+	if closest == nil {
+		return
+	}
+	budget.CurrentUsage = closest.CurrentUsage
+}
+
+// buildBudgetLookup builds ID- and duration-keyed maps of existing budgets for
+// the reconciliation pass. Rows whose ID is explicitly claimed by an
+// ID-specified entry in requests are omitted from byDuration so a
+// duration-only entry that sorts earlier cannot steal the row reserved for an
+// ID-based rename (e.g. payload [{new 1d}, {ID:X→1w}] against existing
+// {ID:X, "1d"}).
+func buildBudgetLookup(existing []configstoreTables.TableBudget, requests []CreateBudgetRequest) (map[string]configstoreTables.TableBudget, map[string]configstoreTables.TableBudget) {
+	claimedIDs := make(map[string]struct{}, len(requests))
+	for _, r := range requests {
+		if r.ID != "" {
+			claimedIDs[r.ID] = struct{}{}
+		}
+	}
+	byID := make(map[string]configstoreTables.TableBudget, len(existing))
+	byDuration := make(map[string]configstoreTables.TableBudget, len(existing))
+	for _, budget := range existing {
+		if budget.ID != "" {
+			byID[budget.ID] = budget
+		}
+		if _, claimed := claimedIDs[budget.ID]; claimed {
+			continue
+		}
+		byDuration[budget.ResetDuration] = budget
+	}
+	return byID, byDuration
+}
+
+func findExistingBudget(request CreateBudgetRequest, byID map[string]configstoreTables.TableBudget, byDuration map[string]configstoreTables.TableBudget) (configstoreTables.TableBudget, bool, error) {
+	if request.ID != "" {
+		existing, found := byID[request.ID]
+		if !found {
+			return configstoreTables.TableBudget{}, false, &badRequestError{err: fmt.Errorf("budget %s does not belong to this entity", request.ID)}
+		}
+		// Consume the matched row from both maps so a later iteration cannot
+		// reuse it (e.g. renaming an existing budget by ID while the same
+		// payload adds a new budget with the old duration).
+		delete(byID, existing.ID)
+		delete(byDuration, existing.ResetDuration)
+		return existing, true, nil
+	}
+	existing, found := byDuration[request.ResetDuration]
+	if found {
+		delete(byID, existing.ID)
+		delete(byDuration, existing.ResetDuration)
+	}
+	return existing, found, nil
 }
 
 func isRateLimitRemovalRequest(req *UpdateRateLimitRequest) bool {
@@ -861,7 +956,7 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 			seenDurations := make(map[string]bool)
 			requestBudgets := append([]CreateBudgetRequest(nil), req.Budgets...)
 			sort.Slice(requestBudgets, func(i, j int) bool {
-				return requestBudgets[i].ResetDuration < requestBudgets[j].ResetDuration
+				return compareBudgetRequestDurations(requestBudgets[i], requestBudgets[j])
 			})
 			for _, b := range requestBudgets {
 				if b.MaxLimit < 0 {
@@ -876,19 +971,19 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 				seenDurations[b.ResetDuration] = true
 			}
 
-			// Build map of existing budgets by reset_duration for matching
-			existingByDuration := make(map[string]configstoreTables.TableBudget)
-			for _, existing := range vk.Budgets {
-				existingByDuration[existing.ResetDuration] = existing
-			}
-
-			// Reconcile: preserve existing budgets where possible, create new ones where needed
+			existingByID, existingByDuration := buildBudgetLookup(vk.Budgets, requestBudgets)
+			resetBudgetUsage := req.ResetBudgetUsage != nil && *req.ResetBudgetUsage
 			var reconciledBudgets []configstoreTables.TableBudget
 			matchedIDs := make(map[string]bool)
 			for _, b := range requestBudgets {
-				if existing, found := existingByDuration[b.ResetDuration]; found {
-					// Budget with same duration exists — update max_limit, preserve usage
+				existing, found, err := findExistingBudget(b, existingByID, existingByDuration)
+				if err != nil {
+					return err
+				}
+				if found {
 					existing.MaxLimit = b.MaxLimit
+					existing.ResetDuration = b.ResetDuration
+					resetBudgetUsageIfRequested(&existing, resetBudgetUsage, vk.CalendarAligned)
 					if err := validateBudget(&existing); err != nil {
 						return err
 					}
@@ -907,6 +1002,7 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 						CurrentUsage:  0,
 						VirtualKeyID:  &vk.ID,
 					}
+					inheritUsageFromClosestShorterBudget(&budget, vk.Budgets, resetBudgetUsage)
 					if err := validateBudget(&budget); err != nil {
 						return err
 					}
@@ -1085,7 +1181,7 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 						seenDurations := make(map[string]bool)
 						pcBudgets := append([]CreateBudgetRequest(nil), pc.Budgets...)
 						sort.Slice(pcBudgets, func(i, j int) bool {
-							return pcBudgets[i].ResetDuration < pcBudgets[j].ResetDuration
+							return compareBudgetRequestDurations(pcBudgets[i], pcBudgets[j])
 						})
 						for _, b := range pcBudgets {
 							if seenDurations[b.ResetDuration] {
@@ -1149,7 +1245,7 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 						seenDurations := make(map[string]bool)
 						pcBudgets := append([]CreateBudgetRequest(nil), pc.Budgets...)
 						sort.Slice(pcBudgets, func(i, j int) bool {
-							return pcBudgets[i].ResetDuration < pcBudgets[j].ResetDuration
+							return compareBudgetRequestDurations(pcBudgets[i], pcBudgets[j])
 						})
 						for _, b := range pcBudgets {
 							if b.MaxLimit < 0 {
@@ -1164,25 +1260,26 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 							seenDurations[b.ResetDuration] = true
 						}
 
-						// Build map of existing budgets by reset_duration for matching
-						pcExistingByDuration := make(map[string]configstoreTables.TableBudget)
 						sort.Slice(existing.Budgets, func(i, j int) bool {
 							if existing.Budgets[i].ResetDuration == existing.Budgets[j].ResetDuration {
 								return existing.Budgets[i].ID < existing.Budgets[j].ID
 							}
 							return existing.Budgets[i].ResetDuration < existing.Budgets[j].ResetDuration
 						})
-						for _, eb := range existing.Budgets {
-							pcExistingByDuration[eb.ResetDuration] = eb
-						}
 
-						// Reconcile: preserve existing budgets where possible
+						pcExistingByID, pcExistingByDuration := buildBudgetLookup(existing.Budgets, pcBudgets)
+						resetBudgetUsage := req.ResetBudgetUsage != nil && *req.ResetBudgetUsage
 						var pcReconciledBudgets []configstoreTables.TableBudget
 						pcMatchedIDs := make(map[string]bool)
 						for _, b := range pcBudgets {
-							if eb, found := pcExistingByDuration[b.ResetDuration]; found {
-								// Budget with same duration exists — update max_limit, preserve usage
+							eb, found, err := findExistingBudget(b, pcExistingByID, pcExistingByDuration)
+							if err != nil {
+								return err
+							}
+							if found {
 								eb.MaxLimit = b.MaxLimit
+								eb.ResetDuration = b.ResetDuration
+								resetBudgetUsageIfRequested(&eb, resetBudgetUsage, vk.CalendarAligned)
 								if err := validateBudget(&eb); err != nil {
 									return err
 								}
@@ -1201,6 +1298,7 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 									CurrentUsage:     0,
 									ProviderConfigID: &existing.ID,
 								}
+								inheritUsageFromClosestShorterBudget(&budget, existing.Budgets, resetBudgetUsage)
 								if err := validateBudget(&budget); err != nil {
 									return err
 								}

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sort"
 	"strings"
 	"testing"
@@ -44,6 +45,7 @@ type mockRotateConfigStore struct {
 	configstore.ConfigStore
 	virtualKeys map[string]*configstoreTables.TableVirtualKey
 	updates     int
+	updateErr   error
 }
 
 func cloneTestVirtualKey(vk *configstoreTables.TableVirtualKey) *configstoreTables.TableVirtualKey {
@@ -66,6 +68,9 @@ func (m *mockRotateConfigStore) GetVirtualKey(_ context.Context, id string) (*co
 }
 
 func (m *mockRotateConfigStore) UpdateVirtualKey(_ context.Context, virtualKey *configstoreTables.TableVirtualKey, _ ...*gorm.DB) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
 	existing, ok := m.virtualKeys[virtualKey.ID]
 	if !ok {
 		return configstore.ErrNotFound
@@ -81,10 +86,14 @@ type mockRotateGovernanceManager struct {
 	GovernanceManager
 	store     *mockRotateConfigStore
 	reloadIDs []string
+	reloadErr error
 }
 
 func (m *mockRotateGovernanceManager) ReloadVirtualKey(ctx context.Context, id string) (*configstoreTables.TableVirtualKey, error) {
 	m.reloadIDs = append(m.reloadIDs, id)
+	if m.reloadErr != nil {
+		return nil, m.reloadErr
+	}
 	return m.store.GetVirtualKey(ctx, id)
 }
 
@@ -102,12 +111,13 @@ func TestFindExistingBudgetPrefersIDOverResetDuration(t *testing.T) {
 		CurrentUsage:  3,
 	}
 
-	byID, byDuration := buildBudgetLookup([]configstoreTables.TableBudget{monthlyBudget, dailyBudget})
-	matched, found, err := findExistingBudget(CreateBudgetRequest{
+	request := CreateBudgetRequest{
 		ID:            "budget-monthly",
 		MaxLimit:      120,
 		ResetDuration: "1d",
-	}, byID, byDuration)
+	}
+	byID, byDuration := buildBudgetLookup([]configstoreTables.TableBudget{monthlyBudget, dailyBudget}, []CreateBudgetRequest{request})
+	matched, found, err := findExistingBudget(request, byID, byDuration)
 	if err != nil {
 		t.Fatalf("expected budget match, got error: %v", err)
 	}
@@ -120,17 +130,112 @@ func TestFindExistingBudgetPrefersIDOverResetDuration(t *testing.T) {
 }
 
 func TestFindExistingBudgetRejectsUnknownID(t *testing.T) {
-	byID, byDuration := buildBudgetLookup([]configstoreTables.TableBudget{
-		{ID: "budget-1", ResetDuration: "1d"},
-	})
-
-	_, _, err := findExistingBudget(CreateBudgetRequest{
+	request := CreateBudgetRequest{
 		ID:            "missing-budget",
 		MaxLimit:      100,
 		ResetDuration: "1d",
-	}, byID, byDuration)
+	}
+	byID, byDuration := buildBudgetLookup([]configstoreTables.TableBudget{
+		{ID: "budget-1", ResetDuration: "1d"},
+	}, []CreateBudgetRequest{request})
+
+	_, _, err := findExistingBudget(request, byID, byDuration)
 	if err == nil {
 		t.Fatal("expected unknown budget ID to fail")
+	}
+}
+
+// TestBudgetFrequencyReplaceInheritsUsageFromOriginalBudgets exercises the
+// scenario where the only existing shorter-duration budget is replaced (not
+// renamed by ID) by a longer-duration budget in the same request. The usage
+// from the original shorter budget must be inherited; if the inheritance
+// source were the partially-built reconciled slice, it would be empty here
+// (the shorter budget is being deleted, not reconciled) and usage would be
+// lost.
+func TestBudgetFrequencyReplaceInheritsUsageFromOriginalBudgets(t *testing.T) {
+	originalLastReset := time.Now().Add(-3 * time.Hour)
+	reconciled, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "vk-budget-daily",
+				MaxLimit:      100,
+				ResetDuration: "1d",
+				CurrentUsage:  42,
+				LastReset:     originalLastReset,
+			},
+		},
+		[]CreateBudgetRequest{
+			{MaxLimit: 500, ResetDuration: "1w"},
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed: %v", err)
+	}
+	if len(reconciled) != 1 {
+		t.Fatalf("expected one reconciled budget, got %d: %#v", len(reconciled), reconciled)
+	}
+	if reconciled[0].ResetDuration != "1w" || reconciled[0].MaxLimit != 500 {
+		t.Fatalf("expected new weekly@500 budget, got %#v", reconciled[0])
+	}
+	if reconciled[0].CurrentUsage != 42 {
+		t.Fatalf("expected usage to be inherited from the daily budget (42), got %v", reconciled[0].CurrentUsage)
+	}
+}
+
+// TestBudgetLookupConsumesMatchedRowsForDurationSwap exercises the scenario
+// where the request renames an existing budget by ID to a longer duration
+// while also adding a new budget reusing the old duration. The lookup must
+// reserve the renamed row for the ID-specified entry so the duration-only
+// entry creates a fresh budget instead of stealing the row.
+func TestBudgetLookupConsumesMatchedRowsForDurationSwap(t *testing.T) {
+	originalLastReset := time.Now().Add(-2 * time.Hour)
+	reconciled, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "vk-budget-1",
+				MaxLimit:      100,
+				ResetDuration: "1d",
+				CurrentUsage:  42,
+				LastReset:     originalLastReset,
+			},
+		},
+		[]CreateBudgetRequest{
+			{ID: "vk-budget-1", MaxLimit: 200, ResetDuration: "1w"},
+			{MaxLimit: 50, ResetDuration: "1d"},
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed: %v", err)
+	}
+	if len(reconciled) != 2 {
+		t.Fatalf("expected two reconciled budgets, got %d: %#v", len(reconciled), reconciled)
+	}
+
+	var rename, fresh *configstoreTables.TableBudget
+	for i := range reconciled {
+		b := &reconciled[i]
+		if b.ID == "vk-budget-1" {
+			rename = b
+		} else {
+			fresh = b
+		}
+	}
+	if rename == nil {
+		t.Fatal("expected renamed budget to retain vk-budget-1 ID")
+	}
+	if rename.ResetDuration != "1w" || rename.MaxLimit != 200 {
+		t.Fatalf("expected vk-budget-1 to become weekly@200, got %#v", rename)
+	}
+	if rename.CurrentUsage != 42 {
+		t.Fatalf("expected rename to preserve usage 42, got %#v", rename)
+	}
+	if fresh == nil {
+		t.Fatal("expected a new daily budget to be created alongside the rename")
+	}
+	if fresh.ResetDuration != "1d" || fresh.MaxLimit != 50 {
+		t.Fatalf("expected fresh daily@50, got %#v", fresh)
 	}
 }
 
@@ -164,7 +269,7 @@ func reconcileBudgetRequestsForTest(existing []configstoreTables.TableBudget, re
 		return compareBudgetRequestDurations(requestBudgets[i], requestBudgets[j])
 	})
 
-	byID, byDuration := buildBudgetLookup(existing)
+	byID, byDuration := buildBudgetLookup(existing, requestBudgets)
 	reconciled := make([]configstoreTables.TableBudget, 0, len(requestBudgets))
 	for _, request := range requestBudgets {
 		budget, found, err := findExistingBudget(request, byID, byDuration)
@@ -179,19 +284,11 @@ func reconcileBudgetRequestsForTest(existing []configstoreTables.TableBudget, re
 				LastReset:     budgetLastReset(false, request.ResetDuration),
 				ResetDuration: request.ResetDuration,
 			}
-			if err := inheritUsageFromClosestShorterBudget(&budget, reconciled, resetUsage); err != nil {
-				return nil, err
-			}
+			inheritUsageFromClosestShorterBudget(&budget, existing, resetUsage)
 		}
-		configChanged := budget.MaxLimit != request.MaxLimit || budget.ResetDuration != request.ResetDuration
 		budget.MaxLimit = request.MaxLimit
 		budget.ResetDuration = request.ResetDuration
 		resetBudgetUsageIfRequested(&budget, resetUsage, false)
-		if found && configChanged {
-			if err := validatePreservedBudgetUsageWithinLimit(&budget, "preserved", "", resetUsage); err != nil {
-				return nil, err
-			}
-		}
 		reconciled = append(reconciled, budget)
 	}
 	return reconciled, nil
@@ -301,8 +398,8 @@ func TestBudgetFrequencyChangeResetsUsageWhenRequested(t *testing.T) {
 	}
 }
 
-func TestExistingVirtualKeyBudgetLoweredBelowPreservedUsageFails(t *testing.T) {
-	_, err := reconcileBudgetRequestsForTest(
+func TestExistingVirtualKeyBudgetLoweredBelowPreservedUsageIsAllowed(t *testing.T) {
+	reconciled, err := reconcileBudgetRequestsForTest(
 		[]configstoreTables.TableBudget{
 			{
 				ID:            "monthly-budget",
@@ -320,16 +417,16 @@ func TestExistingVirtualKeyBudgetLoweredBelowPreservedUsageFails(t *testing.T) {
 		},
 		false,
 	)
-	if err == nil {
-		t.Fatal("expected lowering budget below preserved usage to fail")
+	if err != nil {
+		t.Fatalf("expected preserving usage above lowered budget to be allowed: %v", err)
 	}
-	if !strings.Contains(err.Error(), "reset usage while setting up the budget or increase the budget limit") {
-		t.Fatalf("expected actionable error message, got %v", err)
+	if reconciled[0].CurrentUsage != 0.11 || reconciled[0].MaxLimit != 0.01 {
+		t.Fatalf("expected usage to be preserved above lowered budget, got %#v", reconciled[0])
 	}
 }
 
-func TestExistingProviderBudgetLoweredBelowPreservedUsageFails(t *testing.T) {
-	_, err := reconcileBudgetRequestsForTest(
+func TestExistingProviderBudgetLoweredBelowPreservedUsageIsAllowed(t *testing.T) {
+	reconciled, err := reconcileBudgetRequestsForTest(
 		[]configstoreTables.TableBudget{
 			{
 				ID:            "provider-monthly-budget",
@@ -347,11 +444,11 @@ func TestExistingProviderBudgetLoweredBelowPreservedUsageFails(t *testing.T) {
 		},
 		false,
 	)
-	if err == nil {
-		t.Fatal("expected lowering provider budget below preserved usage to fail")
+	if err != nil {
+		t.Fatalf("expected preserving provider usage above lowered budget to be allowed: %v", err)
 	}
-	if !strings.Contains(err.Error(), "reset usage while setting up the budget or increase the budget limit") {
-		t.Fatalf("expected actionable error message, got %v", err)
+	if reconciled[0].CurrentUsage != 0.11 || reconciled[0].MaxLimit != 0.01 {
+		t.Fatalf("expected provider usage to be preserved above lowered budget, got %#v", reconciled[0])
 	}
 }
 
@@ -449,8 +546,8 @@ func TestNewProviderBudgetInheritsClosestShorterUsage(t *testing.T) {
 	}
 }
 
-func TestNewVirtualKeyBudgetInheritanceFailsWhenUsageExceedsLimit(t *testing.T) {
-	_, err := reconcileBudgetRequestsForTest(
+func TestNewVirtualKeyBudgetInheritanceAboveLimitIsAllowed(t *testing.T) {
+	reconciled, err := reconcileBudgetRequestsForTest(
 		[]configstoreTables.TableBudget{
 			{
 				ID:            "weekly-budget",
@@ -472,16 +569,17 @@ func TestNewVirtualKeyBudgetInheritanceFailsWhenUsageExceedsLimit(t *testing.T) 
 		},
 		false,
 	)
-	if err == nil {
-		t.Fatal("expected inherited usage above new budget limit to fail")
+	if err != nil {
+		t.Fatalf("expected inherited usage above new budget limit to be allowed: %v", err)
 	}
-	if !strings.Contains(err.Error(), "reset usage while setting up the budget or increase the budget limit") {
-		t.Fatalf("expected actionable error message, got %v", err)
+	monthly := reconciled[1]
+	if monthly.CurrentUsage != 100 || monthly.MaxLimit != 50 {
+		t.Fatalf("expected inherited usage above new budget limit, got %#v", monthly)
 	}
 }
 
-func TestNewProviderBudgetInheritanceFailsWhenUsageExceedsLimit(t *testing.T) {
-	_, err := reconcileBudgetRequestsForTest(
+func TestNewProviderBudgetInheritanceAtLimitIsAllowed(t *testing.T) {
+	reconciled, err := reconcileBudgetRequestsForTest(
 		[]configstoreTables.TableBudget{
 			{
 				ID:            "weekly-budget",
@@ -503,11 +601,12 @@ func TestNewProviderBudgetInheritanceFailsWhenUsageExceedsLimit(t *testing.T) {
 		},
 		false,
 	)
-	if err == nil {
-		t.Fatal("expected inherited usage equal to new budget limit to fail")
+	if err != nil {
+		t.Fatalf("expected inherited provider usage equal to new budget limit to be allowed: %v", err)
 	}
-	if !strings.Contains(err.Error(), "reset usage while setting up the budget or increase the budget limit") {
-		t.Fatalf("expected actionable error message, got %v", err)
+	monthly := reconciled[1]
+	if monthly.CurrentUsage != 100 || monthly.MaxLimit != 100 {
+		t.Fatalf("expected inherited provider usage at new budget limit, got %#v", monthly)
 	}
 }
 
@@ -702,6 +801,90 @@ func TestRotateVirtualKey_OnlyChangesValueAndReloads(t *testing.T) {
 	}
 }
 
+func TestRotateVirtualKey_NotFound(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	store := &mockRotateConfigStore{virtualKeys: map[string]*configstoreTables.TableVirtualKey{}}
+	manager := &mockRotateGovernanceManager{store: store}
+	h := &GovernanceHandler{configStore: store, governanceManager: manager}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("vk_id", "missing")
+
+	h.rotateVirtualKey(ctx)
+
+	if ctx.Response.StatusCode() != 404 {
+		t.Fatalf("expected status 404, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if store.updates != 0 {
+		t.Fatalf("expected no updates, got %d", store.updates)
+	}
+	if len(manager.reloadIDs) != 0 {
+		t.Fatalf("expected no reloads, got %#v", manager.reloadIDs)
+	}
+}
+
+func TestRotateVirtualKey_UpdateFailureDoesNotReload(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	store := &mockRotateConfigStore{
+		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
+			"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old"},
+		},
+		updateErr: errors.New("database unavailable"),
+	}
+	manager := &mockRotateGovernanceManager{store: store}
+	h := &GovernanceHandler{configStore: store, governanceManager: manager}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("vk_id", "vk-1")
+
+	h.rotateVirtualKey(ctx)
+
+	if ctx.Response.StatusCode() != 500 {
+		t.Fatalf("expected status 500, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if store.virtualKeys["vk-1"].Value != "sk-bf-old" {
+		t.Fatalf("expected value to remain unchanged, got %q", store.virtualKeys["vk-1"].Value)
+	}
+	if len(manager.reloadIDs) != 0 {
+		t.Fatalf("expected no reloads, got %#v", manager.reloadIDs)
+	}
+}
+
+func TestRotateVirtualKey_ReloadFailureReturnsErrorAfterUpdate(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	store := &mockRotateConfigStore{
+		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
+			"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old"},
+		},
+	}
+	manager := &mockRotateGovernanceManager{store: store, reloadErr: errors.New("reload failed")}
+	h := &GovernanceHandler{configStore: store, governanceManager: manager}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue("vk_id", "vk-1")
+
+	h.rotateVirtualKey(ctx)
+
+	if ctx.Response.StatusCode() != 500 {
+		t.Fatalf("expected status 500, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if store.updates != 1 {
+		t.Fatalf("expected one update, got %d", store.updates)
+	}
+	if store.virtualKeys["vk-1"].Value == "sk-bf-old" {
+		t.Fatal("expected value to rotate before reload failure")
+	}
+	if len(manager.reloadIDs) != 1 || manager.reloadIDs[0] != "vk-1" {
+		t.Fatalf("expected reload for vk-1, got %#v", manager.reloadIDs)
+	}
+	if !strings.Contains(string(ctx.Response.Body()), "failed to reload in-memory state") {
+		t.Fatalf("expected reload failure in response, got %s", string(ctx.Response.Body()))
+	}
+}
+
 func TestRotateVirtualKeys_PartialSuccess(t *testing.T) {
 	SetLogger(&mockLogger{})
 
@@ -744,6 +927,116 @@ func TestRotateVirtualKeys_PartialSuccess(t *testing.T) {
 	}
 	if resp.Errors["missing"] != "virtual key not found" {
 		t.Fatalf("expected missing error, got %#v", resp.Errors)
+	}
+}
+
+func TestRotateVirtualKeys_RejectsInvalidRequests(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "invalid JSON", body: `{`, want: "Invalid JSON"},
+		{name: "empty IDs", body: `{"ids":[]}`, want: "At least one virtual key ID is required"},
+		{name: "blank ID", body: `{"ids":["vk-1"," "]}`, want: "Virtual key ID cannot be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &mockRotateConfigStore{
+				virtualKeys: map[string]*configstoreTables.TableVirtualKey{
+					"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old-1"},
+				},
+			}
+			manager := &mockRotateGovernanceManager{store: store}
+			h := &GovernanceHandler{configStore: store, governanceManager: manager}
+
+			ctx := &fasthttp.RequestCtx{}
+			ctx.Request.SetBodyString(tt.body)
+
+			h.rotateVirtualKeys(ctx)
+
+			if ctx.Response.StatusCode() != 400 {
+				t.Fatalf("expected status 400, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+			}
+			if store.updates != 0 {
+				t.Fatalf("expected no updates, got %d", store.updates)
+			}
+			if len(manager.reloadIDs) != 0 {
+				t.Fatalf("expected no reloads, got %#v", manager.reloadIDs)
+			}
+			if !strings.Contains(string(ctx.Response.Body()), tt.want) {
+				t.Fatalf("expected response to contain %q, got %s", tt.want, string(ctx.Response.Body()))
+			}
+		})
+	}
+}
+
+func TestRotateVirtualKeys_TrimsAndDeduplicatesIDs(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	store := &mockRotateConfigStore{
+		virtualKeys: map[string]*configstoreTables.TableVirtualKey{
+			"vk-1": {ID: "vk-1", Name: "One", Value: "sk-bf-old-1"},
+			"vk-2": {ID: "vk-2", Name: "Two", Value: "sk-bf-old-2"},
+		},
+	}
+	manager := &mockRotateGovernanceManager{store: store}
+	h := &GovernanceHandler{configStore: store, governanceManager: manager}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetBodyString(`{"ids":[" vk-1 ","vk-1","vk-2"]}`)
+
+	h.rotateVirtualKeys(ctx)
+
+	if ctx.Response.StatusCode() != 200 {
+		t.Fatalf("expected status 200, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if store.updates != 2 {
+		t.Fatalf("expected two updates, got %d", store.updates)
+	}
+	if len(manager.reloadIDs) != 2 || manager.reloadIDs[0] != "vk-1" || manager.reloadIDs[1] != "vk-2" {
+		t.Fatalf("expected reloads for vk-1 and vk-2, got %#v", manager.reloadIDs)
+	}
+}
+
+func TestRotateVirtualKeys_AllFailuresReturnsServerError(t *testing.T) {
+	SetLogger(&mockLogger{})
+
+	store := &mockRotateConfigStore{virtualKeys: map[string]*configstoreTables.TableVirtualKey{}}
+	manager := &mockRotateGovernanceManager{store: store}
+	h := &GovernanceHandler{configStore: store, governanceManager: manager}
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetBodyString(`{"ids":["missing-1","missing-2"]}`)
+
+	h.rotateVirtualKeys(ctx)
+
+	if ctx.Response.StatusCode() != 500 {
+		t.Fatalf("expected status 500, got %d: %s", ctx.Response.StatusCode(), string(ctx.Response.Body()))
+	}
+	if store.updates != 0 {
+		t.Fatalf("expected no updates, got %d", store.updates)
+	}
+
+	var resp struct {
+		Message     string                              `json:"message"`
+		VirtualKeys []configstoreTables.TableVirtualKey `json:"virtual_keys"`
+		Errors      map[string]string                   `json:"errors"`
+	}
+	if err := json.Unmarshal(ctx.Response.Body(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp.Message != "Failed to rotate virtual keys" {
+		t.Fatalf("expected failure message, got %q", resp.Message)
+	}
+	if len(resp.VirtualKeys) != 0 {
+		t.Fatalf("expected no rotated keys, got %#v", resp.VirtualKeys)
+	}
+	if resp.Errors["missing-1"] != "virtual key not found" || resp.Errors["missing-2"] != "virtual key not found" {
+		t.Fatalf("expected not found errors, got %#v", resp.Errors)
 	}
 }
 

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -41,6 +41,7 @@ import {
 	useGetAllKeysQuery,
 	useGetMCPClientsQuery,
 	useGetProvidersQuery,
+	useRotateVirtualKeyMutation,
 	useUpdateVirtualKeyMutation,
 } from "@/lib/store";
 import { KnownProvider } from "@/lib/types/config";
@@ -81,6 +82,7 @@ const providerConfigSchema = z.object({
 	budgets: z
 		.array(
 			z.object({
+				id: z.string().optional(),
 				max_limit: z.number().nonnegative().optional(),
 				reset_duration: z.string().optional(),
 			}),
@@ -120,6 +122,7 @@ const formSchema = z
 		budgets: z
 			.array(
 				z.object({
+					id: z.string().optional(),
 					max_limit: z.number().nonnegative().optional(),
 					reset_duration: z.string(),
 				}),
@@ -155,6 +158,12 @@ const formSchema = z
 	);
 
 type FormData = z.infer<typeof formSchema>;
+type BudgetComparisonEntry = {
+	id?: string;
+	max_limit?: number;
+	reset_duration?: string;
+	current_usage?: number;
+};
 
 type VirtualKeyType = {
 	label: string;
@@ -163,7 +172,15 @@ type VirtualKeyType = {
 	provider: string;
 };
 
-export default function VirtualKeySheet({ virtualKey, teams, customers, defaultTeamId, defaultAccessProfileId, onSave, onCancel }: VirtualKeySheetProps) {
+export default function VirtualKeySheet({
+	virtualKey,
+	teams,
+	customers,
+	defaultTeamId,
+	defaultAccessProfileId,
+	onSave,
+	onCancel,
+}: VirtualKeySheetProps) {
 	const [isOpen, setIsOpen] = useState(true);
 	const navigate = useNavigate();
 	const isEditing = !!virtualKey;
@@ -195,11 +212,12 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 	const { data: keysData, error: keysError } = useGetAllKeysQuery();
 	const [createVirtualKey, { isLoading: isCreating }] = useCreateVirtualKeyMutation();
 	const [updateVirtualKey, { isLoading: isUpdating }] = useUpdateVirtualKeyMutation();
+	const [rotateVirtualKey, { isLoading: isRotating }] = useRotateVirtualKeyMutation();
 	const { data: mcpClientsResponse, error: mcpClientsError } = useGetMCPClientsQuery();
 	const { data: accessProfilesData } = useGetAccessProfilesQuery({ limit: 100 });
 	const accessProfiles = accessProfilesData?.access_profiles ?? [];
 	const mcpClientsData = mcpClientsResponse?.clients || [];
-	const isLoading = isCreating || isUpdating;
+	const isLoading = isCreating || isUpdating || isRotating;
 
 	const availableKeys = keysData || [];
 	const availableProviders = providersData || [];
@@ -218,6 +236,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 					allowed_models: config.allowed_models,
 					key_ids: config.allow_all_keys ? ["*"] : config.keys?.map((key) => key.key_id) || [],
 					budgets: config.budgets?.map((b) => ({
+						id: b.id,
 						max_limit: b.max_limit,
 						reset_duration: b.reset_duration,
 					})),
@@ -236,12 +255,17 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 					mcp_client_name: config.mcp_client?.name || "",
 					tools_to_execute: config.tools_to_execute || [],
 				})) || [],
-			entityType: virtualKey?.team_id ? "team"
-				: virtualKey?.customer_id ? "customer"
-				: virtualKey?.access_profile_id ? "access_profile"
-				: !isEditing && defaultTeamId ? "team"
-				: !isEditing && defaultAccessProfileId ? "access_profile"
-				: "none",
+			entityType: virtualKey?.team_id
+				? "team"
+				: virtualKey?.customer_id
+					? "customer"
+					: virtualKey?.access_profile_id
+						? "access_profile"
+						: !isEditing && defaultTeamId
+							? "team"
+							: !isEditing && defaultAccessProfileId
+								? "access_profile"
+								: "none",
 			teamId: virtualKey?.team_id || (!isEditing ? defaultTeamId || "" : ""),
 			customerId: virtualKey?.customer_id || "",
 			accessProfileId: virtualKey?.access_profile_id
@@ -252,7 +276,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 			isActive: virtualKey?.is_active ?? true,
 			budgets:
 				virtualKey?.budgets && virtualKey.budgets.length > 0
-					? virtualKey.budgets.map((b) => ({ max_limit: b.max_limit, reset_duration: b.reset_duration ?? "1M" }))
+					? virtualKey.budgets.map((b) => ({ id: b.id, max_limit: b.max_limit, reset_duration: b.reset_duration ?? "1M" }))
 					: [],
 			budgetCalendarAligned: virtualKey?.calendar_aligned ?? false,
 			tokenMaxLimit: virtualKey?.rate_limit?.token_max_limit ?? undefined,
@@ -330,7 +354,9 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 		watchedBudgets.some((b) => b.max_limit !== undefined && b.max_limit !== null && supportsCalendarAlignment(b.reset_duration || "1M"));
 	const hasAnyAlignableRateLimit =
 		(watchedTokenMaxLimit !== undefined && watchedTokenMaxLimit !== null && supportsCalendarAlignment(watchedTokenResetDuration || "1h")) ||
-		(watchedRequestMaxLimit !== undefined && watchedRequestMaxLimit !== null && supportsCalendarAlignment(watchedRequestResetDuration || "1h"));
+		(watchedRequestMaxLimit !== undefined &&
+			watchedRequestMaxLimit !== null &&
+			supportsCalendarAlignment(watchedRequestResetDuration || "1h"));
 	const showCalendarAlignToggle = hasAnyAlignableBudget || hasAnyAlignableRateLimit;
 
 	// Handle adding a new provider configuration
@@ -400,6 +426,10 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 	const [pendingAccessProfileId, setPendingAccessProfileId] = useState<string | null>(null);
 	const [showReassignTypeWarning, setShowReassignTypeWarning] = useState(false);
 	const [pendingEntityType, setPendingEntityType] = useState<"team" | "customer" | "access_profile" | "none" | null>(null);
+	const [showRotateWarning, setShowRotateWarning] = useState(false);
+	const [showBudgetResetPrompt, setShowBudgetResetPrompt] = useState(false);
+	const [pendingBudgetResetData, setPendingBudgetResetData] = useState<FormData | null>(null);
+	const [pendingBudgetUsageWarning, setPendingBudgetUsageWarning] = useState<string | null>(null);
 
 	const currentAssignmentLabel = useMemo(() => {
 		if (!isEditing) return null;
@@ -442,7 +472,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 	const normalizeProviderConfigs = (configs: typeof providerConfigs, existingConfigs?: VirtualKey["provider_configs"]): any[] => {
 		return configs.map((config) => ({
 			...config,
-			budgets: config.budgets?.filter((b): b is { max_limit: number; reset_duration: string } => b.max_limit !== undefined),
+			budgets: config.budgets?.filter((b): b is { id?: string; max_limit: number; reset_duration: string } => b.max_limit !== undefined),
 			weight: config.weight ?? null,
 			rate_limit: (() => {
 				const hasTokenMaxLimit = config.rate_limit?.token_max_limit !== undefined;
@@ -466,8 +496,171 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 		}));
 	};
 
-	// Handle form submission
-	const onSubmit = async (data: FormData) => {
+	const budgetSignature = (budgets?: BudgetComparisonEntry[]) =>
+		(budgets || [])
+			.filter((budget) => budget.max_limit !== undefined)
+			.map((budget) => `${budget.id ?? ""}:${budget.max_limit}:${budget.reset_duration ?? ""}`)
+			.sort()
+			.join("|");
+
+	const parseResetDurationMs = (duration?: string) => {
+		if (!duration) return null;
+		const match = duration.match(/^(\d+(?:\.\d+)?)(ms|s|m|h|d|w|M|Y)$/);
+		if (!match) return null;
+		const amount = Number(match[1]);
+		const unit = match[2];
+		const multipliers: Record<string, number> = {
+			ms: 1,
+			s: 1000,
+			m: 60 * 1000,
+			h: 60 * 60 * 1000,
+			d: 24 * 60 * 60 * 1000,
+			w: 7 * 24 * 60 * 60 * 1000,
+			M: 30 * 24 * 60 * 60 * 1000,
+			Y: 365 * 24 * 60 * 60 * 1000,
+		};
+		return amount * multipliers[unit];
+	};
+
+	const formatBudgetAmount = (value: number) =>
+		new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 }).format(value);
+
+	const findBudgetUsageWarning = (
+		currentBudgets: BudgetComparisonEntry[] | undefined,
+		existingBudgets: BudgetComparisonEntry[] | undefined,
+		scopeLabel: string,
+	) => {
+		const current = (currentBudgets || [])
+			.filter((budget): budget is BudgetComparisonEntry & { max_limit: number; reset_duration: string } => {
+				return budget.max_limit !== undefined && !!budget.reset_duration;
+			})
+			.sort((left, right) => (parseResetDurationMs(left.reset_duration) ?? 0) - (parseResetDurationMs(right.reset_duration) ?? 0));
+		const existingByID = new Map((existingBudgets || []).filter((budget) => budget.id).map((budget) => [budget.id, budget]));
+		const existingByDuration = new Map((existingBudgets || []).map((budget) => [budget.reset_duration, budget]));
+		const reconciled: BudgetComparisonEntry[] = [];
+
+		for (const budget of current) {
+			const existing = budget.id ? existingByID.get(budget.id) : existingByDuration.get(budget.reset_duration);
+			if (existing) {
+				const configChanged = existing.max_limit !== budget.max_limit || existing.reset_duration !== budget.reset_duration;
+				const usage = existing.current_usage ?? 0;
+				if (configChanged && usage >= budget.max_limit) {
+					return `${scopeLabel} ${budget.reset_duration} budget has ${formatBudgetAmount(usage)} usage, which meets or exceeds the new ${formatBudgetAmount(budget.max_limit)} limit.`;
+				}
+				reconciled.push({ ...budget, current_usage: usage });
+				continue;
+			}
+
+			const targetDuration = parseResetDurationMs(budget.reset_duration);
+			const closestShorter = reconciled.reduce<BudgetComparisonEntry | null>((closest, candidate) => {
+				const candidateDuration = parseResetDurationMs(candidate.reset_duration);
+				const closestDuration = parseResetDurationMs(closest?.reset_duration);
+				if (targetDuration === null || candidateDuration === null || candidateDuration >= targetDuration) {
+					return closest;
+				}
+				if (closest === null || closestDuration === null || candidateDuration > closestDuration) {
+					return candidate;
+				}
+				return closest;
+			}, null);
+			const inheritedUsage = closestShorter?.current_usage ?? 0;
+			if (inheritedUsage >= budget.max_limit) {
+				return `${scopeLabel} ${budget.reset_duration} budget will inherit ${formatBudgetAmount(inheritedUsage)} from the ${closestShorter?.reset_duration} budget, which meets or exceeds the new ${formatBudgetAmount(budget.max_limit)} limit.`;
+			}
+			reconciled.push({ ...budget, current_usage: inheritedUsage });
+		}
+
+		return null;
+	};
+
+	const getBudgetUsageWarning = (data: FormData) => {
+		if (!isEditing || !virtualKey || isManagedByProfile) {
+			return null;
+		}
+
+		const vkWarning = findBudgetUsageWarning(data.budgets, virtualKey.budgets, "Virtual key");
+		if (vkWarning) {
+			return vkWarning;
+		}
+
+		const existingProviderConfigs = new Map<string, NonNullable<VirtualKey["provider_configs"]>[number]>();
+		(virtualKey.provider_configs || []).forEach((config) => {
+			existingProviderConfigs.set(String(config.id ?? config.provider), config);
+		});
+		for (const config of data.providerConfigs || []) {
+			const existingConfig = existingProviderConfigs.get(String(config.id ?? config.provider));
+			const providerLabel = ProviderLabels[config.provider as ProviderName] ?? config.provider;
+			const warning = findBudgetUsageWarning(config.budgets, existingConfig?.budgets, `${providerLabel} provider`);
+			if (warning) {
+				return warning;
+			}
+		}
+
+		return null;
+	};
+
+	const hasBudgetResetRelevantChanges = (data: FormData) => {
+		if (!isEditing || !virtualKey || isManagedByProfile) {
+			return false;
+		}
+
+		const currentBudgets = (data.budgets || []).filter(
+			(budget): budget is { id?: string; max_limit: number; reset_duration: string } => budget.max_limit !== undefined,
+		);
+		const existingBudgets = virtualKey.budgets || [];
+		const hasBudgetFields =
+			currentBudgets.length > 0 ||
+			existingBudgets.length > 0 ||
+			(data.providerConfigs || []).some((config) => (config.budgets || []).some((budget) => budget.max_limit !== undefined)) ||
+			(virtualKey.provider_configs || []).some((config) => (config.budgets || []).length > 0);
+
+		if (budgetSignature(currentBudgets) !== budgetSignature(existingBudgets)) {
+			return true;
+		}
+
+		if (hasBudgetFields && data.budgetCalendarAligned !== (virtualKey.calendar_aligned ?? false)) {
+			return true;
+		}
+
+		const existingProviderConfigs = new Map<string, NonNullable<VirtualKey["provider_configs"]>[number]>();
+		(virtualKey.provider_configs || []).forEach((config) => {
+			existingProviderConfigs.set(String(config.id ?? config.provider), config);
+		});
+
+		const currentProviderConfigs = new Map<string, NonNullable<FormData["providerConfigs"]>[number]>();
+		(data.providerConfigs || []).forEach((config) => {
+			currentProviderConfigs.set(String(config.id ?? config.provider), config);
+		});
+
+		const providerConfigKeys = new Set([...existingProviderConfigs.keys(), ...currentProviderConfigs.keys()]);
+		for (const key of providerConfigKeys) {
+			const currentSignature = budgetSignature(currentProviderConfigs.get(key)?.budgets);
+			const existingSignature = budgetSignature(existingProviderConfigs.get(key)?.budgets);
+			if (currentSignature !== existingSignature) {
+				return true;
+			}
+		}
+
+		return false;
+	};
+
+	const handleRotateVirtualKey = async () => {
+		if (!virtualKey) return;
+		if (!hasUpdateAccess) {
+			toast.error("You don't have permission to perform this action");
+			return;
+		}
+		try {
+			await rotateVirtualKey(virtualKey.id).unwrap();
+			toast.success("Virtual key rotated successfully");
+			setShowRotateWarning(false);
+			onSave();
+		} catch (error) {
+			toast.error(getErrorMessage(error));
+		}
+	};
+
+	const submitVirtualKeyForm = async (data: FormData, resetBudgetUsage = false) => {
 		if (!canSubmit) {
 			toast.error("You don't have permission to perform this action");
 			return;
@@ -500,14 +693,18 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 					mcp_configs: data.mcpConfigs,
 					team_id: data.entityType === "team" && data.teamId && data.teamId.trim() !== "" ? data.teamId : undefined,
 					customer_id: data.entityType === "customer" && data.customerId && data.customerId.trim() !== "" ? data.customerId : undefined,
-					access_profile_id: data.entityType === "access_profile" && data.accessProfileId && data.accessProfileId.trim() !== "" ? Number(data.accessProfileId) : undefined,
+					access_profile_id:
+						data.entityType === "access_profile" && data.accessProfileId && data.accessProfileId.trim() !== ""
+							? Number(data.accessProfileId)
+							: undefined,
 					is_active: data.isActive,
 					calendar_aligned: data.budgetCalendarAligned,
+					reset_budget_usage: resetBudgetUsage,
 				};
 
 				// Add budgets if enabled
 				const validBudgets = (data.budgets || []).filter(
-					(b): b is { max_limit: number; reset_duration: string } => b.max_limit !== undefined,
+					(b): b is { id?: string; max_limit: number; reset_duration: string } => b.max_limit !== undefined,
 				);
 				const hadBudget = virtualKey.budgets && virtualKey.budgets.length > 0;
 				if (validBudgets.length > 0) {
@@ -543,7 +740,10 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 					mcp_configs: data.mcpConfigs,
 					team_id: data.entityType === "team" && data.teamId && data.teamId.trim() !== "" ? data.teamId : undefined,
 					customer_id: data.entityType === "customer" && data.customerId && data.customerId.trim() !== "" ? data.customerId : undefined,
-					access_profile_id: data.entityType === "access_profile" && data.accessProfileId && data.accessProfileId.trim() !== "" ? Number(data.accessProfileId) : undefined,
+					access_profile_id:
+						data.entityType === "access_profile" && data.accessProfileId && data.accessProfileId.trim() !== ""
+							? Number(data.accessProfileId)
+							: undefined,
 					is_active: data.isActive,
 					// VK-level setting that governs both budget and rate-limit calendar alignment.
 					calendar_aligned: data.budgetCalendarAligned,
@@ -551,7 +751,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 
 				// Add budgets if enabled
 				const validBudgets = (data.budgets || []).filter(
-					(b): b is { max_limit: number; reset_duration: string } => b.max_limit !== undefined,
+					(b): b is { id?: string; max_limit: number; reset_duration: string } => b.max_limit !== undefined,
 				);
 				if (validBudgets.length > 0) {
 					createData.budgets = validBudgets;
@@ -577,6 +777,27 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 		} catch (error) {
 			toast.error(getErrorMessage(error));
 		}
+	};
+
+	// Handle form submission
+	const onSubmit = async (data: FormData) => {
+		if (hasBudgetResetRelevantChanges(data)) {
+			setPendingBudgetResetData(data);
+			setPendingBudgetUsageWarning(getBudgetUsageWarning(data));
+			setShowBudgetResetPrompt(true);
+			return;
+		}
+
+		await submitVirtualKeyForm(data, false);
+	};
+
+	const handleBudgetResetChoice = async (resetBudgetUsage: boolean) => {
+		if (!pendingBudgetResetData) return;
+		const data = pendingBudgetResetData;
+		setPendingBudgetResetData(null);
+		setPendingBudgetUsageWarning(null);
+		setShowBudgetResetPrompt(false);
+		await submitVirtualKeyForm(data, resetBudgetUsage);
 	};
 
 	return (
@@ -1011,6 +1232,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 																	lines={
 																		config.budgets && config.budgets.length > 0
 																			? config.budgets.map((b) => ({
+																					id: b.id,
 																					max_limit: b.max_limit,
 																					reset_duration: b.reset_duration || "1M",
 																				}))
@@ -1021,6 +1243,7 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 																		updatedConfigs[index] = {
 																			...updatedConfigs[index],
 																			budgets: lines.map((l) => ({
+																				id: l.id,
 																				max_limit: l.max_limit,
 																				reset_duration: l.reset_duration,
 																			})),
@@ -1339,98 +1562,102 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 										</AlertDialogContent>
 									</AlertDialog>
 
-								<AlertDialog
-									open={showReassignAPWarning}
-									onOpenChange={(open) => {
-										setShowReassignAPWarning(open);
-										if (!open) {
-											setPendingAccessProfileId(null);
-										}
-									}}
-								>
-									<AlertDialogContent>
-										<AlertDialogHeader>
-											<AlertDialogTitle>Reassign to a different access profile?</AlertDialogTitle>
-											<AlertDialogDescription>
-												This key is currently assigned to another access profile. Reassigning it will move budget tracking to this access profile — future requests through this key will count against this profile's budget, not the previous one.
-											</AlertDialogDescription>
-										</AlertDialogHeader>
-										<AlertDialogFooter>
-											<AlertDialogCancel data-testid="reassign-ap-cancel" onClick={() => setPendingAccessProfileId(null)}>
-												Cancel
-											</AlertDialogCancel>
-											<AlertDialogAction
-												data-testid="reassign-ap-confirm"
-												onClick={() => {
-													if (pendingAccessProfileId !== null) {
-														form.setValue("accessProfileId", pendingAccessProfileId, { shouldDirty: true });
-													}
-													setPendingAccessProfileId(null);
-													setShowReassignAPWarning(false);
-												}}
-											>
-												Reassign
-											</AlertDialogAction>
-										</AlertDialogFooter>
-									</AlertDialogContent>
-								</AlertDialog>
-
-								{/* Cross-type assignment warning */}
-								<AlertDialog
-									open={showReassignTypeWarning}
-									onOpenChange={(open) => {
-										if (!open) setPendingEntityType(null);
-										setShowReassignTypeWarning(open);
-									}}
-								>
-									<AlertDialogContent>
-										<AlertDialogHeader>
-											<AlertDialogTitle>Change assignment?</AlertDialogTitle>
-											<AlertDialogDescription>
-												This key is currently assigned to {currentAssignmentLabel}. Changing the assignment type will move budget
-												tracking — future requests will count against the new entity, not the previous one.
-											</AlertDialogDescription>
-										</AlertDialogHeader>
-										<AlertDialogFooter>
-											<AlertDialogCancel data-testid="reassign-type-cancel" onClick={() => setPendingEntityType(null)}>
-												Cancel
-											</AlertDialogCancel>
-											<AlertDialogAction
-												data-testid="reassign-type-confirm"
-												onClick={async () => {
-													if (pendingEntityType) {
-														form.setValue("entityType", pendingEntityType, { shouldDirty: true });
-														if (pendingEntityType === "team" && teams?.length > 0) {
-															form.setValue("teamId", teams[0].id, { shouldDirty: true, shouldValidate: true });
-															form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
-															form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
-														} else if (pendingEntityType === "customer" && customers?.length > 0) {
-															form.setValue("customerId", customers[0].id, { shouldDirty: true, shouldValidate: true });
-															form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
-															form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
-														} else if (pendingEntityType === "access_profile") {
-															const apId = accessProfiles?.length > 0
-																? String(accessProfiles[0].id)
-																: virtualKey?.access_profile_id ? String(virtualKey.access_profile_id) : "";
-															form.setValue("accessProfileId", apId, { shouldDirty: true, shouldValidate: true });
-															form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
-															form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
-														} else {
-															form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
-															form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
-															form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
+									<AlertDialog
+										open={showReassignAPWarning}
+										onOpenChange={(open) => {
+											setShowReassignAPWarning(open);
+											if (!open) {
+												setPendingAccessProfileId(null);
+											}
+										}}
+									>
+										<AlertDialogContent>
+											<AlertDialogHeader>
+												<AlertDialogTitle>Reassign to a different access profile?</AlertDialogTitle>
+												<AlertDialogDescription>
+													This key is currently assigned to another access profile. Reassigning it will move budget tracking to this access
+													profile — future requests through this key will count against this profile's budget, not the previous one.
+												</AlertDialogDescription>
+											</AlertDialogHeader>
+											<AlertDialogFooter>
+												<AlertDialogCancel data-testid="reassign-ap-cancel" onClick={() => setPendingAccessProfileId(null)}>
+													Cancel
+												</AlertDialogCancel>
+												<AlertDialogAction
+													data-testid="reassign-ap-confirm"
+													onClick={() => {
+														if (pendingAccessProfileId !== null) {
+															form.setValue("accessProfileId", pendingAccessProfileId, { shouldDirty: true });
 														}
-														await form.trigger(["teamId", "customerId", "accessProfileId", "entityType"]);
-													}
-													setPendingEntityType(null);
-													setShowReassignTypeWarning(false);
-												}}
-											>
-												Change Assignment
-											</AlertDialogAction>
-										</AlertDialogFooter>
-									</AlertDialogContent>
-								</AlertDialog>
+														setPendingAccessProfileId(null);
+														setShowReassignAPWarning(false);
+													}}
+												>
+													Reassign
+												</AlertDialogAction>
+											</AlertDialogFooter>
+										</AlertDialogContent>
+									</AlertDialog>
+
+									{/* Cross-type assignment warning */}
+									<AlertDialog
+										open={showReassignTypeWarning}
+										onOpenChange={(open) => {
+											if (!open) setPendingEntityType(null);
+											setShowReassignTypeWarning(open);
+										}}
+									>
+										<AlertDialogContent>
+											<AlertDialogHeader>
+												<AlertDialogTitle>Change assignment?</AlertDialogTitle>
+												<AlertDialogDescription>
+													This key is currently assigned to {currentAssignmentLabel}. Changing the assignment type will move budget tracking
+													— future requests will count against the new entity, not the previous one.
+												</AlertDialogDescription>
+											</AlertDialogHeader>
+											<AlertDialogFooter>
+												<AlertDialogCancel data-testid="reassign-type-cancel" onClick={() => setPendingEntityType(null)}>
+													Cancel
+												</AlertDialogCancel>
+												<AlertDialogAction
+													data-testid="reassign-type-confirm"
+													onClick={async () => {
+														if (pendingEntityType) {
+															form.setValue("entityType", pendingEntityType, { shouldDirty: true });
+															if (pendingEntityType === "team" && teams?.length > 0) {
+																form.setValue("teamId", teams[0].id, { shouldDirty: true, shouldValidate: true });
+																form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
+																form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
+															} else if (pendingEntityType === "customer" && customers?.length > 0) {
+																form.setValue("customerId", customers[0].id, { shouldDirty: true, shouldValidate: true });
+																form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
+																form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
+															} else if (pendingEntityType === "access_profile") {
+																const apId =
+																	accessProfiles?.length > 0
+																		? String(accessProfiles[0].id)
+																		: virtualKey?.access_profile_id
+																			? String(virtualKey.access_profile_id)
+																			: "";
+																form.setValue("accessProfileId", apId, { shouldDirty: true, shouldValidate: true });
+																form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
+																form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
+															} else {
+																form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
+																form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
+																form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
+															}
+															await form.trigger(["teamId", "customerId", "accessProfileId", "entityType"]);
+														}
+														setPendingEntityType(null);
+														setShowReassignTypeWarning(false);
+													}}
+												>
+													Change Assignment
+												</AlertDialogAction>
+											</AlertDialogFooter>
+										</AlertDialogContent>
+									</AlertDialog>
 								</div>
 								{/* Rate Limiting Configuration */}
 								<div className="space-y-4">
@@ -1502,8 +1729,8 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 												Align to calendar cycle
 											</Label>
 											<p id="vk-budget-calendar-aligned-description" className="text-muted-foreground text-xs">
-												Reset budgets and rate limits at the start of each period (e.g. 1st of month) instead of rolling from creation
-												date. Applies to durations of a day or longer.
+												Reset budgets and rate limits at the start of each period (e.g. 1st of month) instead of rolling from creation date.
+												Applies to durations of a day or longer.
 											</p>
 										</div>
 										<Switch
@@ -1524,8 +1751,8 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 											<AlertDialogDescription>
 												Enabling calendar alignment will reset budget usage to <span className="font-semibold">$0.00</span> and
 												token/request rate-limit counters to <span className="font-semibold">0</span> for this virtual key, then snap each
-												reset date to the start of its current period (e.g. start of day, week, month, or year). The usage reset cannot
-												be undone, but calendar alignment can be turned off later. This will take effect when you save.
+												reset date to the start of its current period (e.g. start of day, week, month, or year). The usage reset cannot be
+												undone, but calendar alignment can be turned off later. This will take effect when you save.
 											</AlertDialogDescription>
 										</AlertDialogHeader>
 										<AlertDialogFooter>
@@ -1542,7 +1769,11 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 										</AlertDialogFooter>
 									</AlertDialogContent>
 								</AlertDialog>
-								{(teams?.length > 0 || customers?.length > 0 || accessProfiles?.length > 0 || !!virtualKey?.access_profile_id || !!defaultAccessProfileId) && (
+								{(teams?.length > 0 ||
+									customers?.length > 0 ||
+									accessProfiles?.length > 0 ||
+									!!virtualKey?.access_profile_id ||
+									!!defaultAccessProfileId) && (
 									<>
 										<DottedSeparator className="my-6" />
 
@@ -1562,15 +1793,20 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 																	{ value: "none", label: "No Assignment" },
 																	...(teams?.length > 0 ? [{ value: "team", label: "Assign to Team" }] : []),
 																	...(customers?.length > 0 ? [{ value: "customer", label: "Assign to Customer" }] : []),
-																	...(accessProfiles?.length > 0 || virtualKey?.access_profile_id || defaultAccessProfileId ? [{ value: "access_profile", label: "Assign to Access Profile" }] : []),
+																	...(accessProfiles?.length > 0 || virtualKey?.access_profile_id || defaultAccessProfileId
+																		? [{ value: "access_profile", label: "Assign to Access Profile" }]
+																		: []),
 																]}
 																value={field.value}
 																onValueChange={async (value) => {
 																	const val = value ?? "none";
-																	const originalType = virtualKey?.team_id ? "team"
-																		: virtualKey?.customer_id ? "customer"
-																		: virtualKey?.access_profile_id ? "access_profile"
-																		: "none";
+																	const originalType = virtualKey?.team_id
+																		? "team"
+																		: virtualKey?.customer_id
+																			? "customer"
+																			: virtualKey?.access_profile_id
+																				? "access_profile"
+																				: "none";
 																	if (isEditing && currentAssignmentLabel && val !== "none" && val !== originalType) {
 																		setPendingEntityType(val as "team" | "customer" | "access_profile");
 																		setShowReassignTypeWarning(true);
@@ -1588,9 +1824,12 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 																		form.setValue("accessProfileId", "", { shouldDirty: true, shouldValidate: true });
 																		await form.trigger(["teamId", "customerId", "accessProfileId", "entityType"]);
 																	} else if (val === "access_profile") {
-																		const apId = accessProfiles?.length > 0
-																			? String(accessProfiles[0].id)
-																			: virtualKey?.access_profile_id ? String(virtualKey.access_profile_id) : "";
+																		const apId =
+																			accessProfiles?.length > 0
+																				? String(accessProfiles[0].id)
+																				: virtualKey?.access_profile_id
+																					? String(virtualKey.access_profile_id)
+																					: "";
 																		form.setValue("accessProfileId", apId, { shouldDirty: true, shouldValidate: true });
 																		form.setValue("teamId", "", { shouldDirty: true, shouldValidate: true });
 																		form.setValue("customerId", "", { shouldDirty: true, shouldValidate: true });
@@ -1668,42 +1907,85 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 													/>
 												)}
 
-											{form.watch("entityType") === "access_profile" && (accessProfiles?.length > 0 || virtualKey?.access_profile_id || defaultAccessProfileId) && (
-												<FormField
-													control={form.control}
-													name="accessProfileId"
-													render={({ field }) => (
-														<FormItem>
-															<FormLabel className="font-normal">Select Access Profile</FormLabel>
-															<ComboboxSelect
-																data-testid="access-profile-selector"
-																options={accessProfiles.map((ap) => ({ value: String(ap.id), label: ap.name }))}
-																value={field.value || null}
-																onValueChange={(val) => {
-																	const newVal = val ?? "";
-																	if (isEditing && virtualKey?.access_profile_id && newVal && newVal !== String(virtualKey.access_profile_id)) {
-																		setPendingAccessProfileId(newVal);
-																		setShowReassignAPWarning(true);
-																	} else {
-																		field.onChange(newVal);
-																	}
-																}}
-																placeholder="Select an access profile"
-																disabled={isAPLocked}
-																emptyMessage="No access profiles found."
-																className="h-9"
-															/>
-															<FormMessage />
-														</FormItem>
+												{form.watch("entityType") === "access_profile" &&
+													(accessProfiles?.length > 0 || virtualKey?.access_profile_id || defaultAccessProfileId) && (
+														<FormField
+															control={form.control}
+															name="accessProfileId"
+															render={({ field }) => (
+																<FormItem>
+																	<FormLabel className="font-normal">Select Access Profile</FormLabel>
+																	<ComboboxSelect
+																		data-testid="access-profile-selector"
+																		options={accessProfiles.map((ap) => ({ value: String(ap.id), label: ap.name }))}
+																		value={field.value || null}
+																		onValueChange={(val) => {
+																			const newVal = val ?? "";
+																			if (
+																				isEditing &&
+																				virtualKey?.access_profile_id &&
+																				newVal &&
+																				newVal !== String(virtualKey.access_profile_id)
+																			) {
+																				setPendingAccessProfileId(newVal);
+																				setShowReassignAPWarning(true);
+																			} else {
+																				field.onChange(newVal);
+																			}
+																		}}
+																		placeholder="Select an access profile"
+																		disabled={isAPLocked}
+																		emptyMessage="No access profiles found."
+																		className="h-9"
+																	/>
+																	<FormMessage />
+																</FormItem>
+															)}
+														/>
 													)}
-												/>
-											)}
 											</div>
 										</div>
 									</>
 								)}
 							</fieldset>
 						</div>
+						<AlertDialog open={showRotateWarning} onOpenChange={setShowRotateWarning}>
+							<AlertDialogContent>
+								<AlertDialogHeader>
+									<AlertDialogTitle>Rotate virtual key?</AlertDialogTitle>
+									<AlertDialogDescription>
+										This will replace the secret value for &quot;{virtualKey?.name}&quot;. The key ID, budgets, rate limits, provider
+										permissions, MCP access, and assignments stay the same. The previous key value will stop working immediately.
+									</AlertDialogDescription>
+								</AlertDialogHeader>
+								<AlertDialogFooter>
+									<AlertDialogCancel data-testid="vk-rotate-cancel-btn">Cancel</AlertDialogCancel>
+									<AlertDialogAction onClick={handleRotateVirtualKey} disabled={isRotating} data-testid="vk-rotate-confirm-btn">
+										{isRotating ? "Rotating..." : "Rotate Key"}
+									</AlertDialogAction>
+								</AlertDialogFooter>
+							</AlertDialogContent>
+						</AlertDialog>
+						<AlertDialog open={showBudgetResetPrompt} onOpenChange={setShowBudgetResetPrompt}>
+							<AlertDialogContent data-testid="vk-budget-reset-dialog">
+								<AlertDialogHeader>
+									<AlertDialogTitle>{pendingBudgetUsageWarning ? "Preserve over-limit usage?" : "Reset budget usage?"}</AlertDialogTitle>
+									<AlertDialogDescription>
+										{pendingBudgetUsageWarning
+											? `${pendingBudgetUsageWarning} You can preserve usage anyway, or reset usage to 0.`
+											: "You changed a budget amount, reset frequency, or calendar alignment. Reset current budget usage to 0, or preserve the existing usage counters."}
+									</AlertDialogDescription>
+								</AlertDialogHeader>
+								<AlertDialogFooter>
+									<AlertDialogCancel onClick={() => handleBudgetResetChoice(false)} data-testid="vk-budget-reset-preserve-btn">
+										{pendingBudgetUsageWarning ? "Preserve Anyway" : "Preserve Usage"}
+									</AlertDialogCancel>
+									<AlertDialogAction onClick={() => handleBudgetResetChoice(true)} data-testid="vk-budget-reset-confirm-btn">
+										Reset Usage
+									</AlertDialogAction>
+								</AlertDialogFooter>
+							</AlertDialogContent>
+						</AlertDialog>
 						{isEditing && virtualKey?.config_hash && (
 							<div className="px-8">
 								<ConfigSyncAlert className="mt-2" />
@@ -1711,34 +1993,50 @@ export default function VirtualKeySheet({ virtualKey, teams, customers, defaultT
 						)}
 						{/* Form Footer */}
 						<div className="border-border bg-card sticky bottom-0 z-10 border-t px-8 py-4">
-							<div className="flex justify-end gap-2">
-								<Button type="button" variant="outline" onClick={handleClose} data-testid="vk-cancel-btn">
-									Cancel
-								</Button>
-								<TooltipProvider>
-									<Tooltip>
-										<TooltipTrigger asChild>
-											<span className="inline-block">
-												<Button type="submit" disabled={isLoading || !form.formState.isDirty || !canSubmit} data-testid="vk-save-btn">
-													{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
-												</Button>
-											</span>
-										</TooltipTrigger>
-										{(isLoading || !form.formState.isDirty || !canSubmit) && (
-											<TooltipContent>
-												<p>
-													{!canSubmit
-														? "You don't have permission to perform this action"
-														: isLoading
-															? "Saving..."
-															: !form.formState.isDirty
-																? "No changes made"
-																: ""}
-												</p>
-											</TooltipContent>
-										)}
-									</Tooltip>
-								</TooltipProvider>
+							<div className="flex items-center justify-between gap-2">
+								{isEditing ? (
+									<Button
+										type="button"
+										variant="outline"
+										onClick={() => setShowRotateWarning(true)}
+										disabled={!hasUpdateAccess || isRotating}
+										data-testid="vk-rotate-btn"
+									>
+										<RotateCcw className="h-4 w-4" />
+										{isRotating ? "Rotating..." : "Rotate Key"}
+									</Button>
+								) : (
+									<span />
+								)}
+								<div className="flex justify-end gap-2">
+									<Button type="button" variant="outline" onClick={handleClose} data-testid="vk-cancel-btn">
+										Cancel
+									</Button>
+									<TooltipProvider>
+										<Tooltip>
+											<TooltipTrigger asChild>
+												<span className="inline-block">
+													<Button type="submit" disabled={isLoading || !form.formState.isDirty || !canSubmit} data-testid="vk-save-btn">
+														{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
+													</Button>
+												</span>
+											</TooltipTrigger>
+											{(isLoading || !form.formState.isDirty || !canSubmit) && (
+												<TooltipContent>
+													<p>
+														{!canSubmit
+															? "You don't have permission to perform this action"
+															: isLoading
+																? "Saving..."
+																: !form.formState.isDirty
+																	? "No changes made"
+																	: ""}
+													</p>
+												</TooltipContent>
+											)}
+										</Tooltip>
+									</TooltipProvider>
+								</div>
 							</div>
 						</div>
 					</form>

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -12,39 +12,19 @@ import {
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { ComboboxSelect } from "@/components/ui/combobox";
-import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdownMenu";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdownMenu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-} from "@/components/ui/table";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
-import {
-	resetDurationLabels,
-	supportsCalendarAlignment,
-} from "@/lib/constants/governance";
+import { resetDurationLabels, supportsCalendarAlignment } from "@/lib/constants/governance";
 import {
 	getErrorMessage,
+	useBulkRotateVirtualKeysMutation,
 	useDeleteVirtualKeyMutation,
 	useLazyGetVirtualKeysQuery,
 	useUpdateVirtualKeyMutation,
@@ -68,890 +48,846 @@ import {
 	Loader2,
 	MoreHorizontal,
 	Plus,
+	RotateCcw,
 	Search,
 	ShieldCheck,
 	Trash2,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useVirtualKeyUsage } from "../hooks/useVirtualKeyUsage";
 import VirtualKeyDetailSheet from "./virtualKeyDetailsSheet";
 import { VirtualKeysEmptyState } from "./virtualKeysEmptyState";
 import VirtualKeySheet from "./virtualKeySheet";
 
-const formatResetDuration = (duration: string) =>
-  resetDurationLabels[duration] || duration;
+const formatResetDuration = (duration: string) => resetDurationLabels[duration] || duration;
 
 type ExportScope = "current_page" | "all";
 
 function virtualKeysToCSV(vks: VirtualKey[], accessProfileNames: Record<number, string> = {}): string {
-  const headers = [
-    "Name",
-    "Status",
-    "Assigned To",
-    "Budget Limit",
-    "Budget Spent",
-    "Budget Reset",
-    "Description",
-    "Created At",
-  ];
-  const rows = vks.map((vk) => {
-    const isExhausted =
-      vk.budgets?.some((b) => b.current_usage >= b.max_limit) ||
-      (vk.rate_limit?.token_current_usage &&
-        vk.rate_limit?.token_max_limit &&
-        vk.rate_limit.token_current_usage >= vk.rate_limit.token_max_limit) ||
-      (vk.rate_limit?.request_current_usage &&
-        vk.rate_limit?.request_max_limit &&
-        vk.rate_limit.request_current_usage >= vk.rate_limit.request_max_limit);
-    const status = vk.is_active
-      ? isExhausted
-        ? "Exhausted"
-        : "Active"
-      : "Inactive";
-    const assignedTo = vk.team
-      ? `Team: ${vk.team.name}`
-      : vk.customer
-        ? `Customer: ${vk.customer.name}`
-        : vk.access_profile_id
-          ? `Access Profile: ${accessProfileNames[vk.access_profile_id] ?? vk.access_profile_id}`
-          : "";
-    const budgetLimit = vk.budgets?.length
-      ? vk.budgets.map((b) => formatCurrency(b.max_limit)).join("; ")
-      : "";
-    const budgetSpent = vk.budgets?.length
-      ? vk.budgets.map((b) => formatCurrency(b.current_usage)).join("; ")
-      : "";
-    const budgetReset = vk.budgets?.length
-      ? vk.budgets.map((b) => formatResetDuration(b.reset_duration)).join("; ")
-      : "";
-    return [
-      vk.name,
-      status,
-      assignedTo,
-      budgetLimit,
-      budgetSpent,
-      budgetReset,
-      vk.description || "",
-      vk.created_at,
-    ];
-  });
-  return [headers, ...rows]
-    .map((row) =>
-      row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","),
-    )
-    .join("\n");
+	const headers = ["Name", "Status", "Assigned To", "Budget Limit", "Budget Spent", "Budget Reset", "Description", "Created At"];
+	const rows = vks.map((vk) => {
+		const isExhausted =
+			vk.budgets?.some((b) => b.current_usage >= b.max_limit) ||
+			(vk.rate_limit?.token_current_usage &&
+				vk.rate_limit?.token_max_limit &&
+				vk.rate_limit.token_current_usage >= vk.rate_limit.token_max_limit) ||
+			(vk.rate_limit?.request_current_usage &&
+				vk.rate_limit?.request_max_limit &&
+				vk.rate_limit.request_current_usage >= vk.rate_limit.request_max_limit);
+		const status = vk.is_active ? (isExhausted ? "Exhausted" : "Active") : "Inactive";
+		const assignedTo = vk.team
+			? `Team: ${vk.team.name}`
+			: vk.customer
+				? `Customer: ${vk.customer.name}`
+				: vk.access_profile_id
+					? `Access Profile: ${accessProfileNames[vk.access_profile_id] ?? vk.access_profile_id}`
+					: "";
+		const budgetLimit = vk.budgets?.length ? vk.budgets.map((b) => formatCurrency(b.max_limit)).join("; ") : "";
+		const budgetSpent = vk.budgets?.length ? vk.budgets.map((b) => formatCurrency(b.current_usage)).join("; ") : "";
+		const budgetReset = vk.budgets?.length ? vk.budgets.map((b) => formatResetDuration(b.reset_duration)).join("; ") : "";
+		return [vk.name, status, assignedTo, budgetLimit, budgetSpent, budgetReset, vk.description || "", vk.created_at];
+	});
+	return [headers, ...rows].map((row) => row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(",")).join("\n");
 }
 
 function downloadCSV(content: string) {
-  const blob = new Blob([content], { type: "text/csv;charset=utf-8;" });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = `virtual-keys-${new Date().toISOString().split("T")[0]}.csv`;
-  link.click();
-  URL.revokeObjectURL(url);
+	const blob = new Blob([content], { type: "text/csv;charset=utf-8;" });
+	const url = URL.createObjectURL(blob);
+	const link = document.createElement("a");
+	link.href = url;
+	link.download = `virtual-keys-${new Date().toISOString().split("T")[0]}.csv`;
+	link.click();
+	URL.revokeObjectURL(url);
 }
 
 function VKBudgetCell({ vk }: { vk: VirtualKey }) {
-  const { displayBudgets } = useVirtualKeyUsage(vk);
+	const { displayBudgets } = useVirtualKeyUsage(vk);
 
-  if (!displayBudgets || displayBudgets.length === 0) {
-    return <span className="text-muted-foreground text-sm">-</span>;
-  }
+	if (!displayBudgets || displayBudgets.length === 0) {
+		return <span className="text-muted-foreground text-sm">-</span>;
+	}
 
-  return (
-    <div className="flex flex-col gap-0.5">
-      {displayBudgets.map((b, idx) => (
-        <div key={idx} className="flex flex-col">
-          <span
-            className={cn(
-              "font-mono text-sm",
-              b.current_usage >= b.max_limit && "text-red-400",
-            )}
-          >
-            {formatCurrency(b.current_usage)} / {formatCurrency(b.max_limit)}
-          </span>
-          <span className="text-muted-foreground text-xs">
-            Resets {formatResetDuration(b.reset_duration)}
-            {vk.calendar_aligned &&
-              supportsCalendarAlignment(b.reset_duration) &&
-              " (calendar)"}
-          </span>
-        </div>
-      ))}
-    </div>
-  );
+	return (
+		<div className="flex flex-col gap-0.5">
+			{displayBudgets.map((b, idx) => (
+				<div key={idx} className="flex flex-col">
+					<span className={cn("font-mono text-sm", b.current_usage >= b.max_limit && "text-red-400")}>
+						{formatCurrency(b.current_usage)} / {formatCurrency(b.max_limit)}
+					</span>
+					<span className="text-muted-foreground text-xs">
+						Resets {formatResetDuration(b.reset_duration)}
+						{vk.calendar_aligned && supportsCalendarAlignment(b.reset_duration) && " (calendar)"}
+					</span>
+				</div>
+			))}
+		</div>
+	);
 }
 
 function VKRateLimitCell({ vk }: { vk: VirtualKey }) {
-  const { displayRateLimit } = useVirtualKeyUsage(vk);
-  return (
-    <RateLimitDisplay
-      rateLimits={displayRateLimit}
-      calendarAligned={vk.calendar_aligned}
-    />
-  );
+	const { displayRateLimit } = useVirtualKeyUsage(vk);
+	return <RateLimitDisplay rateLimits={displayRateLimit} calendarAligned={vk.calendar_aligned} />;
 }
 
 function VKActiveSwitch({
-  vk,
-  hasUpdateAccess,
-  onToggle,
+	vk,
+	hasUpdateAccess,
+	onToggle,
 }: {
-  vk: VirtualKey;
-  hasUpdateAccess: boolean;
-  onToggle: (vk: VirtualKey, checked: boolean) => Promise<void>;
+	vk: VirtualKey;
+	hasUpdateAccess: boolean;
+	onToggle: (vk: VirtualKey, checked: boolean) => Promise<void>;
 }) {
-  const { isManagedByProfile } = useVirtualKeyUsage(vk);
+	const { isManagedByProfile } = useVirtualKeyUsage(vk);
 
-  return (
-    <Switch
-      checked={vk.is_active}
-      disabled={!hasUpdateAccess || isManagedByProfile}
-      aria-label={`${vk.is_active ? "Disable" : "Enable"} virtual key ${vk.name}`}
-      data-testid={`vk-active-switch-${vk.name}`}
-      title={
-        isManagedByProfile
-          ? "This virtual key is managed by an access profile."
-          : undefined
-      }
-      onAsyncCheckedChange={(checked) => onToggle(vk, checked)}
-    />
-  );
+	return (
+		<Switch
+			checked={vk.is_active}
+			disabled={!hasUpdateAccess || isManagedByProfile}
+			aria-label={`${vk.is_active ? "Disable" : "Enable"} virtual key ${vk.name}`}
+			data-testid={`vk-active-switch-${vk.name}`}
+			title={isManagedByProfile ? "This virtual key is managed by an access profile." : undefined}
+			onAsyncCheckedChange={(checked) => onToggle(vk, checked)}
+		/>
+	);
 }
 
 function VKActionsMenu({
-  vk,
-  hasUpdateAccess,
-  hasDeleteAccess,
-  isDeleting,
-  onEdit,
-  onDelete,
+	vk,
+	hasUpdateAccess,
+	hasDeleteAccess,
+	isDeleting,
+	onEdit,
+	onDelete,
 }: {
-  vk: VirtualKey;
-  hasUpdateAccess: boolean;
-  hasDeleteAccess: boolean;
-  isDeleting: boolean;
-  onEdit: (vk: VirtualKey) => void;
-  onDelete: (vkId: string) => void;
+	vk: VirtualKey;
+	hasUpdateAccess: boolean;
+	hasDeleteAccess: boolean;
+	isDeleting: boolean;
+	onEdit: (vk: VirtualKey) => void;
+	onDelete: (vkId: string) => void;
 }) {
-  const { isManagedByProfile } = useVirtualKeyUsage(vk);
-  const [deleteOpen, setDeleteOpen] = useState(false);
+	const { isManagedByProfile } = useVirtualKeyUsage(vk);
+	const [deleteOpen, setDeleteOpen] = useState(false);
 
-  return (
-    <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8"
-            aria-label="Virtual key actions"
-            data-testid={`vk-actions-btn-${vk.name}`}
-          >
-            <MoreHorizontal className="h-4 w-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            className="cursor-pointer"
-            disabled={!hasUpdateAccess}
-            data-testid={`vk-edit-btn-${vk.name}`}
-            onSelect={(e) => {
-              e.preventDefault();
-              onEdit(vk);
-            }}
-          >
-            <Edit className="h-4 w-4" />
-            Edit
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            variant="destructive"
-            className="cursor-pointer"
-            disabled={!hasDeleteAccess || isManagedByProfile}
-            data-testid={`vk-delete-btn-${vk.name}`}
-            title={
-              isManagedByProfile
-                ? "This virtual key is managed by an access profile and can't be deleted here."
-                : undefined
-            }
-            onSelect={(e) => {
-              e.preventDefault();
-              setDeleteOpen(true);
-            }}
-          >
-            <Trash2 className="h-4 w-4" />
-            Delete
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete Virtual Key</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to delete &quot;
-              {vk.name.length > 20 ? `${vk.name.slice(0, 20)}...` : vk.name}
-              &quot;? This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel data-testid={`vk-delete-cancel-${vk.name}`}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => onDelete(vk.id)}
-              disabled={isDeleting}
-              className="bg-destructive hover:bg-destructive/90"
-              data-testid={`vk-delete-confirm-${vk.name}`}
-            >
-              {isDeleting ? "Deleting..." : "Delete"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-    </>
-  );
+	return (
+		<>
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button
+						variant="ghost"
+						size="icon"
+						className="h-8 w-8"
+						aria-label="Virtual key actions"
+						data-testid={`vk-actions-btn-${vk.name}`}
+					>
+						<MoreHorizontal className="h-4 w-4" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end">
+					<DropdownMenuItem
+						className="cursor-pointer"
+						disabled={!hasUpdateAccess}
+						data-testid={`vk-edit-btn-${vk.name}`}
+						onSelect={(e) => {
+							e.preventDefault();
+							onEdit(vk);
+						}}
+					>
+						<Edit className="h-4 w-4" />
+						Edit
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						variant="destructive"
+						className="cursor-pointer"
+						disabled={!hasDeleteAccess || isManagedByProfile}
+						data-testid={`vk-delete-btn-${vk.name}`}
+						title={isManagedByProfile ? "This virtual key is managed by an access profile and can't be deleted here." : undefined}
+						onSelect={(e) => {
+							e.preventDefault();
+							setDeleteOpen(true);
+						}}
+					>
+						<Trash2 className="h-4 w-4" />
+						Delete
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+			<AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete Virtual Key</AlertDialogTitle>
+						<AlertDialogDescription>
+							Are you sure you want to delete &quot;
+							{vk.name.length > 20 ? `${vk.name.slice(0, 20)}...` : vk.name}
+							&quot;? This action cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel data-testid={`vk-delete-cancel-${vk.name}`}>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={() => onDelete(vk.id)}
+							disabled={isDeleting}
+							className="bg-destructive hover:bg-destructive/90"
+							data-testid={`vk-delete-confirm-${vk.name}`}
+						>
+							{isDeleting ? "Deleting..." : "Delete"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</>
+	);
 }
 
 interface VirtualKeysTableProps {
-  virtualKeys: VirtualKey[];
-  totalCount: number;
-  teams: Team[];
-  customers: Customer[];
-  search: string;
-  debouncedSearch: string;
-  onSearchChange: (value: string) => void;
-  customerFilter: string;
-  onCustomerFilterChange: (value: string) => void;
-  teamFilter: string;
-  onTeamFilterChange: (value: string) => void;
-  offset: number;
-  limit: number;
-  onOffsetChange: (offset: number) => void;
-  sortBy?: string;
-  order?: string;
-  onSortChange: (sortBy: string, order: string) => void;
+	virtualKeys: VirtualKey[];
+	totalCount: number;
+	teams: Team[];
+	customers: Customer[];
+	search: string;
+	debouncedSearch: string;
+	onSearchChange: (value: string) => void;
+	customerFilter: string;
+	onCustomerFilterChange: (value: string) => void;
+	teamFilter: string;
+	onTeamFilterChange: (value: string) => void;
+	offset: number;
+	limit: number;
+	onOffsetChange: (offset: number) => void;
+	sortBy?: string;
+	order?: string;
+	onSortChange: (sortBy: string, order: string) => void;
 }
 
 export default function VirtualKeysTable({
-  virtualKeys,
-  totalCount,
-  teams,
-  customers,
-  search,
-  debouncedSearch,
-  onSearchChange,
-  customerFilter,
-  onCustomerFilterChange,
-  teamFilter,
-  onTeamFilterChange,
-  offset,
-  limit,
-  onOffsetChange,
-  sortBy,
-  order,
-  onSortChange,
+	virtualKeys,
+	totalCount,
+	teams,
+	customers,
+	search,
+	debouncedSearch,
+	onSearchChange,
+	customerFilter,
+	onCustomerFilterChange,
+	teamFilter,
+	onTeamFilterChange,
+	offset,
+	limit,
+	onOffsetChange,
+	sortBy,
+	order,
+	onSortChange,
 }: VirtualKeysTableProps) {
-  const [showVirtualKeySheet, setShowVirtualKeySheet] = useState(false);
-  const [editingVirtualKeyId, setEditingVirtualKeyId] = useState<string | null>(
-    null,
-  );
-  const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set());
-  const [selectedVirtualKeyId, setSelectedVirtualKeyId] = useState<
-    string | null
-  >(null);
-  const [showDetailSheet, setShowDetailSheet] = useState(false);
-  const [showExportDialog, setShowExportDialog] = useState(false);
-  const [exportScope, setExportScope] = useState<ExportScope>("current_page");
-  const [exportMaxLimit, setExportMaxLimit] = useState("");
-  const [fetchVirtualKeys, { isFetching: isExporting }] =
-    useLazyGetVirtualKeysQuery();
+	const [showVirtualKeySheet, setShowVirtualKeySheet] = useState(false);
+	const [editingVirtualKeyId, setEditingVirtualKeyId] = useState<string | null>(null);
+	const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set());
+	const [selectedVirtualKeyId, setSelectedVirtualKeyId] = useState<string | null>(null);
+	const [showDetailSheet, setShowDetailSheet] = useState(false);
+	const [showExportDialog, setShowExportDialog] = useState(false);
+	const [exportScope, setExportScope] = useState<ExportScope>("current_page");
+	const [exportMaxLimit, setExportMaxLimit] = useState("");
+	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+	const [showBulkRotateDialog, setShowBulkRotateDialog] = useState(false);
+	const [fetchVirtualKeys, { isFetching: isExporting }] = useLazyGetVirtualKeysQuery();
 
-  const { data: accessProfilesData } = useGetAccessProfilesQuery({ limit: 100 });
-  const accessProfileNames = useMemo(() => {
-    const map: Record<number, string> = {};
-    for (const ap of accessProfilesData?.access_profiles ?? []) {
-      map[ap.id] = ap.name;
-    }
-    return map;
-  }, [accessProfilesData]);
+	const { data: accessProfilesData } = useGetAccessProfilesQuery({ limit: 100 });
+	const accessProfileNames = useMemo(() => {
+		const map: Record<number, string> = {};
+		for (const ap of accessProfilesData?.access_profiles ?? []) {
+			map[ap.id] = ap.name;
+		}
+		return map;
+	}, [accessProfilesData]);
 
-  // Derive objects from props so they stay in sync with RTK cache updates
-  const editingVirtualKey = useMemo(
-    () =>
-      editingVirtualKeyId
-        ? (virtualKeys.find((vk) => vk.id === editingVirtualKeyId) ?? null)
-        : null,
-    [editingVirtualKeyId, virtualKeys],
-  );
-  const selectedVirtualKey = useMemo(
-    () =>
-      selectedVirtualKeyId
-        ? (virtualKeys.find((vk) => vk.id === selectedVirtualKeyId) ?? null)
-        : null,
-    [selectedVirtualKeyId, virtualKeys],
-  );
+	// Derive objects from props so they stay in sync with RTK cache updates
+	const editingVirtualKey = useMemo(
+		() => (editingVirtualKeyId ? (virtualKeys.find((vk) => vk.id === editingVirtualKeyId) ?? null) : null),
+		[editingVirtualKeyId, virtualKeys],
+	);
+	const selectedVirtualKey = useMemo(
+		() => (selectedVirtualKeyId ? (virtualKeys.find((vk) => vk.id === selectedVirtualKeyId) ?? null) : null),
+		[selectedVirtualKeyId, virtualKeys],
+	);
 
-  const hasCreateAccess = useRbac(
-    RbacResource.VirtualKeys,
-    RbacOperation.Create,
-  );
-  const hasUpdateAccess = useRbac(
-    RbacResource.VirtualKeys,
-    RbacOperation.Update,
-  );
-  const hasDeleteAccess = useRbac(
-    RbacResource.VirtualKeys,
-    RbacOperation.Delete,
-  );
+	const hasCreateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Create);
+	const hasUpdateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Update);
+	const hasDeleteAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Delete);
 
-  const [deleteVirtualKey, { isLoading: isDeleting }] =
-    useDeleteVirtualKeyMutation();
-  const [updateVirtualKey] = useUpdateVirtualKeyMutation();
+	const [deleteVirtualKey, { isLoading: isDeleting }] = useDeleteVirtualKeyMutation();
+	const [updateVirtualKey] = useUpdateVirtualKeyMutation();
+	const [bulkRotateVirtualKeys, { isLoading: isBulkRotating }] = useBulkRotateVirtualKeysMutation();
 
-  const handleDelete = async (vkId: string) => {
-    try {
-      await deleteVirtualKey(vkId).unwrap();
-      toast.success("Virtual key deleted successfully");
-    } catch (error) {
-      toast.error(getErrorMessage(error));
-    }
-  };
+	const visibleIds = useMemo(() => virtualKeys.map((vk) => vk.id), [virtualKeys]);
+	const selectedVisibleIds = useMemo(() => visibleIds.filter((id) => selectedIds.has(id)), [selectedIds, visibleIds]);
+	const selectedCount = selectedIds.size;
+	const allVisibleSelected = visibleIds.length > 0 && selectedVisibleIds.length === visibleIds.length;
+	const someVisibleSelected = selectedVisibleIds.length > 0 && selectedVisibleIds.length < visibleIds.length;
 
-  const handleToggleActive = async (vk: VirtualKey, checked: boolean) => {
-    try {
-      await updateVirtualKey({
-        vkId: vk.id,
-        data: { is_active: checked },
-      }).unwrap();
-      toast.success(`Virtual key ${checked ? "enabled" : "disabled"}`);
-    } catch (error) {
-      toast.error(getErrorMessage(error));
-      throw error;
-    }
-  };
+	useEffect(() => {
+		setSelectedIds((prev) => {
+			const visible = new Set(visibleIds);
+			const next = new Set([...prev].filter((id) => visible.has(id)));
+			return next.size === prev.size ? prev : next;
+		});
+	}, [visibleIds]);
 
-  const handleAddVirtualKey = () => {
-    setEditingVirtualKeyId(null);
-    setShowVirtualKeySheet(true);
-  };
+	const toggleSelectAllVisible = (checked: boolean) => {
+		setSelectedIds((prev) => {
+			const next = new Set(prev);
+			for (const id of visibleIds) {
+				if (checked) {
+					next.add(id);
+				} else {
+					next.delete(id);
+				}
+			}
+			return next;
+		});
+	};
 
-  const handleEditVirtualKey = (vk: VirtualKey) => {
-    setEditingVirtualKeyId(vk.id);
-    setShowVirtualKeySheet(true);
-  };
+	const toggleSelectVirtualKey = (vkId: string, checked: boolean) => {
+		setSelectedIds((prev) => {
+			const next = new Set(prev);
+			if (checked) {
+				next.add(vkId);
+			} else {
+				next.delete(vkId);
+			}
+			return next;
+		});
+	};
 
-  const handleVirtualKeySaved = () => {
-    setShowVirtualKeySheet(false);
-    setEditingVirtualKeyId(null);
-  };
+	const handleDelete = async (vkId: string) => {
+		try {
+			await deleteVirtualKey(vkId).unwrap();
+			toast.success("Virtual key deleted successfully");
+		} catch (error) {
+			toast.error(getErrorMessage(error));
+		}
+	};
 
-  const handleRowClick = (vk: VirtualKey) => {
-    setSelectedVirtualKeyId(vk.id);
-    setShowDetailSheet(true);
-  };
+	const handleToggleActive = async (vk: VirtualKey, checked: boolean) => {
+		try {
+			await updateVirtualKey({
+				vkId: vk.id,
+				data: { is_active: checked },
+			}).unwrap();
+			toast.success(`Virtual key ${checked ? "enabled" : "disabled"}`);
+		} catch (error) {
+			toast.error(getErrorMessage(error));
+			throw error;
+		}
+	};
 
-  const handleDetailSheetClose = () => {
-    setShowDetailSheet(false);
-    setSelectedVirtualKeyId(null);
-  };
+	const handleBulkRotate = async () => {
+		const ids = Array.from(selectedIds);
+		if (ids.length === 0) return;
 
-  const toggleKeyVisibility = (vkId: string) => {
-    const newRevealed = new Set(revealedKeys);
-    if (newRevealed.has(vkId)) {
-      newRevealed.delete(vkId);
-    } else {
-      newRevealed.add(vkId);
-    }
-    setRevealedKeys(newRevealed);
-  };
+		try {
+			const result = await bulkRotateVirtualKeys({ ids }).unwrap();
+			const rotatedIds = new Set(result.virtual_keys.map((vk) => vk.id));
+			setSelectedIds((prev) => {
+				const next = new Set(prev);
+				for (const id of rotatedIds) {
+					next.delete(id);
+				}
+				return next;
+			});
+			setRevealedKeys((prev) => {
+				const next = new Set(prev);
+				for (const id of rotatedIds) {
+					next.delete(id);
+				}
+				return next;
+			});
+			setShowBulkRotateDialog(false);
 
-  const maskKey = (key: string, revealed: boolean) => {
-    if (revealed) return key;
-    return key.substring(0, 8) + "•".repeat(Math.max(0, key.length - 8));
-  };
+			const failureCount = result.errors ? Object.keys(result.errors).length : 0;
+			if (failureCount > 0) {
+				toast.warning(`Rotated ${result.virtual_keys.length} virtual keys. ${failureCount} failed.`);
+			} else {
+				toast.success(`Rotated ${result.virtual_keys.length} virtual keys`);
+			}
+		} catch (error) {
+			toast.error(getErrorMessage(error));
+		}
+	};
 
-  const { copy: copyToClipboard } = useCopyToClipboard();
+	const handleAddVirtualKey = () => {
+		setEditingVirtualKeyId(null);
+		setShowVirtualKeySheet(true);
+	};
 
-  const hasActiveFilters = debouncedSearch || customerFilter || teamFilter;
+	const handleEditVirtualKey = (vk: VirtualKey) => {
+		setEditingVirtualKeyId(vk.id);
+		setShowVirtualKeySheet(true);
+	};
 
-  const toggleSort = (column: string) => {
-    if (sortBy === column) {
-      if (order === "asc") {
-        onSortChange(column, "desc");
-      } else {
-        // Clicking again clears sort
-        onSortChange("", "");
-      }
-    } else {
-      onSortChange(column, "asc");
-    }
-  };
+	const handleVirtualKeySaved = () => {
+		setShowVirtualKeySheet(false);
+		setEditingVirtualKeyId(null);
+	};
 
-  const handleExportCSV = async () => {
-    if (exportScope === "current_page") {
-      downloadCSV(virtualKeysToCSV(virtualKeys, accessProfileNames));
-      toast.success(`Exported ${virtualKeys.length} virtual keys`);
-      setShowExportDialog(false);
-      return;
-    }
+	const handleRowClick = (vk: VirtualKey) => {
+		setSelectedVirtualKeyId(vk.id);
+		setShowDetailSheet(true);
+	};
 
-    // Fetch all with same filters/sort applied
-    const maxLimit = exportMaxLimit ? parseInt(exportMaxLimit, 10) : undefined;
-    const fetchLimit = maxLimit && maxLimit > 0 ? maxLimit : 10000;
+	const handleDetailSheetClose = () => {
+		setShowDetailSheet(false);
+		setSelectedVirtualKeyId(null);
+	};
 
-    try {
-      const result = await fetchVirtualKeys({
-        limit: fetchLimit,
-        offset: 0,
-        search: debouncedSearch || undefined,
-        customer_id: customerFilter || undefined,
-        team_id: teamFilter || undefined,
-        sort_by:
-          (sortBy as "name" | "budget_spent" | "created_at" | "status") ||
-          undefined,
-        order: (order as "asc" | "desc") || undefined,
-        export: true,
-      }).unwrap();
+	const toggleKeyVisibility = (vkId: string) => {
+		const newRevealed = new Set(revealedKeys);
+		if (newRevealed.has(vkId)) {
+			newRevealed.delete(vkId);
+		} else {
+			newRevealed.add(vkId);
+		}
+		setRevealedKeys(newRevealed);
+	};
 
-      downloadCSV(virtualKeysToCSV(result.virtual_keys, accessProfileNames));
-      toast.success(`Exported ${result.virtual_keys.length} virtual keys`);
-      setShowExportDialog(false);
-    } catch (error) {
-      toast.error(`Export failed: ${getErrorMessage(error)}`);
-    }
-  };
+	const maskKey = (key: string, revealed: boolean) => {
+		if (revealed) return key;
+		return key.substring(0, 8) + "•".repeat(Math.max(0, key.length - 8));
+	};
 
-  const openExportDialog = () => {
-    setExportScope("current_page");
-    setExportMaxLimit("");
-    setShowExportDialog(true);
-  };
+	const { copy: copyToClipboard } = useCopyToClipboard();
 
-  const SortableHeader = ({
-    column,
-    label,
-  }: {
-    column: string;
-    label: string;
-  }) => {
-    const isActive = sortBy === column;
-    const Icon = isActive
-      ? order === "desc"
-        ? ArrowDown
-        : ArrowUp
-      : ArrowUpDown;
-    return (
-      <Button
-        variant="ghost"
-        onClick={() => toggleSort(column)}
-        data-testid={`vk-sort-${column}`}
-        className="!px-0"
-      >
-        {label}
-        <Icon className={cn("ml-2 h-4 w-4", isActive && "text-foreground")} />
-      </Button>
-    );
-  };
+	const hasActiveFilters = debouncedSearch || customerFilter || teamFilter;
 
-  // True empty state: no VKs at all (not just filtered to zero)
-  if (totalCount === 0 && !hasActiveFilters) {
-    return (
-      <>
-        {showVirtualKeySheet && (
-          <VirtualKeySheet
-            virtualKey={editingVirtualKey}
-            teams={teams}
-            customers={customers}
-            onSave={handleVirtualKeySaved}
-            onCancel={() => setShowVirtualKeySheet(false)}
-          />
-        )}
-        <VirtualKeysEmptyState
-          onAddClick={handleAddVirtualKey}
-          canCreate={hasCreateAccess}
-        />
-      </>
-    );
-  }
+	const toggleSort = (column: string) => {
+		if (sortBy === column) {
+			if (order === "asc") {
+				onSortChange(column, "desc");
+			} else {
+				// Clicking again clears sort
+				onSortChange("", "");
+			}
+		} else {
+			onSortChange(column, "asc");
+		}
+	};
 
-  return (
-    <>
-      {showVirtualKeySheet && (
-        <VirtualKeySheet
-          virtualKey={editingVirtualKey}
-          teams={teams}
-          customers={customers}
-          onSave={handleVirtualKeySaved}
-          onCancel={() => setShowVirtualKeySheet(false)}
-        />
-      )}
+	const handleExportCSV = async () => {
+		if (exportScope === "current_page") {
+			downloadCSV(virtualKeysToCSV(virtualKeys, accessProfileNames));
+			toast.success(`Exported ${virtualKeys.length} virtual keys`);
+			setShowExportDialog(false);
+			return;
+		}
 
-      {showDetailSheet && selectedVirtualKey && (
-        <VirtualKeyDetailSheet
-          virtualKey={selectedVirtualKey}
-          onClose={handleDetailSheetClose}
-        />
-      )}
+		// Fetch all with same filters/sort applied
+		const maxLimit = exportMaxLimit ? parseInt(exportMaxLimit, 10) : undefined;
+		const fetchLimit = maxLimit && maxLimit > 0 ? maxLimit : 10000;
 
-      {/* Export Dialog */}
-      <Dialog open={showExportDialog} onOpenChange={setShowExportDialog}>
-        <DialogContent className="sm:max-w-[425px]">
-          <DialogHeader className="pb-0">
-            <DialogTitle>Export Virtual Keys</DialogTitle>
-            <DialogDescription>
-              Download as CSV with current filters and sorting applied.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label className="text-sm">Export scope</Label>
-              <div
-                className="grid grid-cols-2 gap-2"
-                data-testid="vk-export-scope"
-              >
-                <button
-                  type="button"
-                  onClick={() => setExportScope("current_page")}
-                  className={cn(
-                    "flex cursor-pointer flex-col items-center gap-1 rounded-md border px-3 py-3 text-sm transition-colors",
-                    exportScope === "current_page"
-                      ? "border-primary bg-primary/5 text-foreground"
-                      : "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground",
-                  )}
-                >
-                  <span className="font-medium">Current page</span>
-                  <span className="text-muted-foreground text-xs">
-                    {virtualKeys.length} entries
-                  </span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setExportScope("all")}
-                  className={cn(
-                    "flex cursor-pointer flex-col items-center gap-1 rounded-md border px-3 py-3 text-sm transition-colors",
-                    exportScope === "all"
-                      ? "border-primary bg-primary/5 text-foreground"
-                      : "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground",
-                  )}
-                >
-                  <span className="font-medium">All entries</span>
-                  <span className="text-muted-foreground text-xs">
-                    {totalCount} total
-                  </span>
-                </button>
-              </div>
-            </div>
+		try {
+			const result = await fetchVirtualKeys({
+				limit: fetchLimit,
+				offset: 0,
+				search: debouncedSearch || undefined,
+				customer_id: customerFilter || undefined,
+				team_id: teamFilter || undefined,
+				sort_by: (sortBy as "name" | "budget_spent" | "created_at" | "status") || undefined,
+				order: (order as "asc" | "desc") || undefined,
+				export: true,
+			}).unwrap();
 
-            {exportScope === "all" && (
-              <div className="space-y-2">
-                <Label htmlFor="export-max-limit" className="text-sm">
-                  Max entries{" "}
-                  <span className="text-muted-foreground font-normal">
-                    (optional)
-                  </span>
-                </Label>
-                <Input
-                  id="export-max-limit"
-                  type="number"
-                  min="1"
-                  placeholder={`Leave blank for all ${totalCount}`}
-                  value={exportMaxLimit}
-                  onChange={(e) => setExportMaxLimit(e.target.value)}
-                  data-testid="vk-export-max-limit"
-                />
-              </div>
-            )}
+			downloadCSV(virtualKeysToCSV(result.virtual_keys, accessProfileNames));
+			toast.success(`Exported ${result.virtual_keys.length} virtual keys`);
+			setShowExportDialog(false);
+		} catch (error) {
+			toast.error(`Export failed: ${getErrorMessage(error)}`);
+		}
+	};
 
-            {hasActiveFilters && (
-              <p className="text-muted-foreground text-xs">
-                Filters applied:{" "}
-                {[
-                  debouncedSearch && `search "${debouncedSearch}"`,
-                  customerFilter && "customer filter",
-                  teamFilter && "team filter",
-                ]
-                  .filter(Boolean)
-                  .join(", ")}
-              </p>
-            )}
+	const openExportDialog = () => {
+		setExportScope("current_page");
+		setExportMaxLimit("");
+		setShowExportDialog(true);
+	};
 
-            <div className="text-muted-foreground flex items-center gap-2">
-              <ShieldCheck className="h-3.5 w-3.5 shrink-0" />
-              <p className="text-xs">
-                API tokens are excluded from the export.
-              </p>
-            </div>
-          </div>
-          <DialogFooter className="pt-0">
-            <Button
-              variant="outline"
-              onClick={() => setShowExportDialog(false)}
-              disabled={isExporting}
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={handleExportCSV}
-              disabled={isExporting}
-              data-testid="vk-export-confirm-btn"
-            >
-              {isExporting ? (
-                <>
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Exporting...
-                </>
-              ) : (
-                <>
-                  <Download className="h-4 w-4" />
-                  Export CSV
-                </>
-              )}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+	const SortableHeader = ({ column, label }: { column: string; label: string }) => {
+		const isActive = sortBy === column;
+		const Icon = isActive ? (order === "desc" ? ArrowDown : ArrowUp) : ArrowUpDown;
+		return (
+			<Button variant="ghost" onClick={() => toggleSort(column)} data-testid={`vk-sort-${column}`} className="!px-0">
+				{label}
+				<Icon className={cn("ml-2 h-4 w-4", isActive && "text-foreground")} />
+			</Button>
+		);
+	};
 
-      <div className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-lg font-semibold">Virtual Keys</h2>
-            <p className="text-muted-foreground text-sm">
-              Manage virtual keys, their permissions, budgets, and rate limits.
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              onClick={openExportDialog}
-              disabled={virtualKeys.length === 0}
-              data-testid="vk-export-btn"
-            >
-              <Download className="h-4 w-4" />
-              Export CSV
-            </Button>
-            <Button
-              onClick={handleAddVirtualKey}
-              disabled={!hasCreateAccess}
-              data-testid="create-vk-btn"
-            >
-              <Plus className="h-4 w-4" />
-              Add Virtual Key
-            </Button>
-          </div>
-        </div>
+	// True empty state: no VKs at all (not just filtered to zero)
+	if (totalCount === 0 && !hasActiveFilters) {
+		return (
+			<>
+				{showVirtualKeySheet && (
+					<VirtualKeySheet
+						virtualKey={editingVirtualKey}
+						teams={teams}
+						customers={customers}
+						onSave={handleVirtualKeySaved}
+						onCancel={() => setShowVirtualKeySheet(false)}
+					/>
+				)}
+				<VirtualKeysEmptyState onAddClick={handleAddVirtualKey} canCreate={hasCreateAccess} />
+			</>
+		);
+	}
 
-        {/* Toolbar: Search + Filters */}
-        <div className="flex items-center gap-3">
-          <div className="relative max-w-sm flex-1">
-            <Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-            <Input
-              aria-label="Search virtual keys by name"
-              placeholder="Search by name..."
-              value={search}
-              onChange={(e) => onSearchChange(e.target.value)}
-              className="pl-9"
-              data-testid="vk-search-input"
-            />
-          </div>
-          <ComboboxSelect
-            data-testid="vk-customer-filter"
-            options={customers.map((c) => ({ label: c.name, value: c.id }))}
-            value={customerFilter || null}
-            onValueChange={(val) => onCustomerFilterChange(val ?? "")}
-            placeholder="All Customers"
-            className="h-9 w-[180px]"
-          />
-          {customerFilter && teamFilter && (
-            <span className="text-muted-foreground text-xs font-medium">
-              or
-            </span>
-          )}
-          <ComboboxSelect
-            data-testid="vk-team-filter"
-            options={teams.map((t) => ({ label: t.name, value: t.id }))}
-            value={teamFilter || null}
-            onValueChange={(val) => onTeamFilterChange(val ?? "")}
-            placeholder="All Teams"
-            className="h-9 w-[180px]"
-          />
-        </div>
+	return (
+		<>
+			{showVirtualKeySheet && (
+				<VirtualKeySheet
+					virtualKey={editingVirtualKey}
+					teams={teams}
+					customers={customers}
+					onSave={handleVirtualKeySaved}
+					onCancel={() => setShowVirtualKeySheet(false)}
+				/>
+			)}
 
-        <div className="rounded-sm border">
-          <Table
-            className="w-full min-w-[1480px] table-fixed"
-            data-testid="vk-table"
-          >
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-[250px]">
-                  <SortableHeader column="name" label="Name" />
-                </TableHead>
-                <TableHead className="w-[160px]">Assigned To</TableHead>
-                <TableHead className="w-[440px]">Key</TableHead>
-                <TableHead className="w-[200px]">
-                  <SortableHeader column="budget_spent" label="Budget" />
-                </TableHead>
-                <TableHead className="w-[200px]">Rate Limits</TableHead>
-                <TableHead className="w-[120px]">
-                  <SortableHeader column="status" label="Status" />
-                </TableHead>
-                <TableHead
-                  className={`bg-muted sticky right-0 z-10 w-[56px] text-right ${PIN_SHADOW_RIGHT}`}
-                ></TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {virtualKeys.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={7} className="h-24 text-center">
-                    <span className="text-muted-foreground text-sm">
-                      No matching virtual keys found.
-                    </span>
-                  </TableCell>
-                </TableRow>
-              ) : (
-                virtualKeys.map((vk) => {
-                  const isRevealed = revealedKeys.has(vk.id);
+			{showDetailSheet && selectedVirtualKey && <VirtualKeyDetailSheet virtualKey={selectedVirtualKey} onClose={handleDetailSheetClose} />}
 
-                  return (
-                    <TableRow
-                      key={vk.id}
-                      data-testid={`vk-row-${vk.name}`}
-                      className="group hover:bg-muted/50 cursor-pointer transition-colors"
-                      onClick={() => handleRowClick(vk)}
-                    >
-                      <TableCell className="max-w-[200px]">
-                        <div className="truncate font-medium">{vk.name}</div>
-                      </TableCell>
-                      <TableCell>
-                        {vk.team ? (
-                          <Badge
-                            variant="outline"
-                            className="block max-w-full truncate text-left"
-                          >
-                            Team: {vk.team.name}
-                          </Badge>
-                        ) : vk.customer ? (
-                          <Badge
-                            variant="outline"
-                            className="block max-w-full truncate text-left"
-                          >
-                            Customer: {vk.customer.name}
-                          </Badge>
-                        ) : vk.access_profile_id ? (
-                          <Badge
-                            variant="outline"
-                            className="block max-w-full truncate text-left"
-                          >
-                            AP: {accessProfileNames[vk.access_profile_id] ?? vk.access_profile_id}
-                          </Badge>
-                        ) : (
-                          <span className="text-muted-foreground max-w-full truncate text-left text-sm">
-                            -
-                          </span>
-                        )}
-                      </TableCell>
-                      <TableCell onClick={(e) => e.stopPropagation()}>
-                        <div className="flex items-center gap-2">
-                          <code
-                            className="cursor-default py-1 font-mono text-sm"
-                            data-testid="vk-key-value"
-                          >
-                            {maskKey(vk.value, isRevealed)}
-                          </code>
-                          <div className="flex items-center">
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => toggleKeyVisibility(vk.id)}
-                              data-testid={`vk-visibility-btn-${vk.name}`}
-                            >
-                              {isRevealed ? (
-                                <EyeOff className="h-4 w-4" />
-                              ) : (
-                                <Eye className="h-4 w-4" />
-                              )}
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => copyToClipboard(vk.value)}
-                              data-testid={`vk-copy-btn-${vk.name}`}
-                            >
-                              <Copy className="h-4 w-4" />
-                            </Button>
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <VKBudgetCell vk={vk} />
-                      </TableCell>
-                      <TableCell>
-                        <VKRateLimitCell vk={vk} />
-                      </TableCell>
-                      <TableCell onClick={(e) => e.stopPropagation()}>
-                        <VKActiveSwitch
-                          vk={vk}
-                          hasUpdateAccess={hasUpdateAccess}
-                          onToggle={handleToggleActive}
-                        />
-                      </TableCell>
-                      <TableCell
-                        className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-10 bg-white text-right ${PIN_SHADOW_RIGHT}`}
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <VKActionsMenu
-                          vk={vk}
-                          hasUpdateAccess={hasUpdateAccess}
-                          hasDeleteAccess={hasDeleteAccess}
-                          isDeleting={isDeleting}
-                          onEdit={handleEditVirtualKey}
-                          onDelete={handleDelete}
-                        />
-                      </TableCell>
-                    </TableRow>
-                  );
-                })
-              )}
-            </TableBody>
-          </Table>
-        </div>
+			{/* Export Dialog */}
+			<Dialog open={showExportDialog} onOpenChange={setShowExportDialog}>
+				<DialogContent className="sm:max-w-[425px]">
+					<DialogHeader className="pb-0">
+						<DialogTitle>Export Virtual Keys</DialogTitle>
+						<DialogDescription>Download as CSV with current filters and sorting applied.</DialogDescription>
+					</DialogHeader>
+					<div className="space-y-4">
+						<div className="space-y-2">
+							<Label className="text-sm">Export scope</Label>
+							<div className="grid grid-cols-2 gap-2" data-testid="vk-export-scope">
+								<button
+									type="button"
+									onClick={() => setExportScope("current_page")}
+									className={cn(
+										"flex cursor-pointer flex-col items-center gap-1 rounded-md border px-3 py-3 text-sm transition-colors",
+										exportScope === "current_page"
+											? "border-primary bg-primary/5 text-foreground"
+											: "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground",
+									)}
+								>
+									<span className="font-medium">Current page</span>
+									<span className="text-muted-foreground text-xs">{virtualKeys.length} entries</span>
+								</button>
+								<button
+									type="button"
+									onClick={() => setExportScope("all")}
+									className={cn(
+										"flex cursor-pointer flex-col items-center gap-1 rounded-md border px-3 py-3 text-sm transition-colors",
+										exportScope === "all"
+											? "border-primary bg-primary/5 text-foreground"
+											: "border-border text-muted-foreground hover:border-primary/50 hover:text-foreground",
+									)}
+								>
+									<span className="font-medium">All entries</span>
+									<span className="text-muted-foreground text-xs">{totalCount} total</span>
+								</button>
+							</div>
+						</div>
 
-        {/* Pagination */}
-        {totalCount > 0 && (
-          <div className="flex items-center justify-between px-2">
-            <p className="text-muted-foreground text-sm">
-              Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of{" "}
-              {totalCount}
-            </p>
-            <div className="flex gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={offset === 0}
-                onClick={() => onOffsetChange(Math.max(0, offset - limit))}
-                data-testid="vk-pagination-prev-btn"
-              >
-                <ChevronLeft className="mr-1 h-4 w-4" />
-                Previous
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={offset + limit >= totalCount}
-                onClick={() => onOffsetChange(offset + limit)}
-                data-testid="vk-pagination-next-btn"
-              >
-                Next
-                <ChevronRight className="ml-1 h-4 w-4" />
-              </Button>
-            </div>
-          </div>
-        )}
-      </div>
-    </>
-  );
+						{exportScope === "all" && (
+							<div className="space-y-2">
+								<Label htmlFor="export-max-limit" className="text-sm">
+									Max entries <span className="text-muted-foreground font-normal">(optional)</span>
+								</Label>
+								<Input
+									id="export-max-limit"
+									type="number"
+									min="1"
+									placeholder={`Leave blank for all ${totalCount}`}
+									value={exportMaxLimit}
+									onChange={(e) => setExportMaxLimit(e.target.value)}
+									data-testid="vk-export-max-limit"
+								/>
+							</div>
+						)}
+
+						{hasActiveFilters && (
+							<p className="text-muted-foreground text-xs">
+								Filters applied:{" "}
+								{[debouncedSearch && `search "${debouncedSearch}"`, customerFilter && "customer filter", teamFilter && "team filter"]
+									.filter(Boolean)
+									.join(", ")}
+							</p>
+						)}
+
+						<div className="text-muted-foreground flex items-center gap-2">
+							<ShieldCheck className="h-3.5 w-3.5 shrink-0" />
+							<p className="text-xs">API tokens are excluded from the export.</p>
+						</div>
+					</div>
+					<DialogFooter className="pt-0">
+						<Button variant="outline" onClick={() => setShowExportDialog(false)} disabled={isExporting}>
+							Cancel
+						</Button>
+						<Button onClick={handleExportCSV} disabled={isExporting} data-testid="vk-export-confirm-btn">
+							{isExporting ? (
+								<>
+									<Loader2 className="h-4 w-4 animate-spin" />
+									Exporting...
+								</>
+							) : (
+								<>
+									<Download className="h-4 w-4" />
+									Export CSV
+								</>
+							)}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			<AlertDialog open={showBulkRotateDialog} onOpenChange={setShowBulkRotateDialog}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Rotate selected virtual keys?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This will replace the secret value for {selectedCount} selected virtual {selectedCount === 1 ? "key" : "keys"}. IDs, budgets,
+							rate limits, provider permissions, MCP access, and assignments stay the same. Previous key values will stop working
+							immediately.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel data-testid="vk-bulk-rotate-cancel-btn">Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleBulkRotate}
+							disabled={isBulkRotating || selectedCount === 0}
+							data-testid="vk-bulk-rotate-confirm-btn"
+						>
+							{isBulkRotating ? "Rotating..." : "Rotate Selected"}
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<div className="space-y-4">
+				<div className="flex items-center justify-between">
+					<div>
+						<h2 className="text-lg font-semibold">Virtual Keys</h2>
+						<p className="text-muted-foreground text-sm">Manage virtual keys, their permissions, budgets, and rate limits.</p>
+					</div>
+					<div className="flex items-center gap-2">
+						{selectedCount > 0 && (
+							<Button
+								variant="outline"
+								onClick={() => setShowBulkRotateDialog(true)}
+								disabled={!hasUpdateAccess || isBulkRotating}
+								data-testid="vk-bulk-rotate-btn"
+							>
+								<RotateCcw className="h-4 w-4" />
+								Rotate selected ({selectedCount})
+							</Button>
+						)}
+						<Button variant="outline" onClick={openExportDialog} disabled={virtualKeys.length === 0} data-testid="vk-export-btn">
+							<Download className="h-4 w-4" />
+							Export CSV
+						</Button>
+						<Button onClick={handleAddVirtualKey} disabled={!hasCreateAccess} data-testid="create-vk-btn">
+							<Plus className="h-4 w-4" />
+							Add Virtual Key
+						</Button>
+					</div>
+				</div>
+
+				{/* Toolbar: Search + Filters */}
+				<div className="flex items-center gap-3">
+					<div className="relative max-w-sm flex-1">
+						<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+						<Input
+							aria-label="Search virtual keys by name"
+							placeholder="Search by name..."
+							value={search}
+							onChange={(e) => onSearchChange(e.target.value)}
+							className="pl-9"
+							data-testid="vk-search-input"
+						/>
+					</div>
+					<ComboboxSelect
+						data-testid="vk-customer-filter"
+						options={customers.map((c) => ({ label: c.name, value: c.id }))}
+						value={customerFilter || null}
+						onValueChange={(val) => onCustomerFilterChange(val ?? "")}
+						placeholder="All Customers"
+						className="h-9 w-[180px]"
+					/>
+					{customerFilter && teamFilter && <span className="text-muted-foreground text-xs font-medium">or</span>}
+					<ComboboxSelect
+						data-testid="vk-team-filter"
+						options={teams.map((t) => ({ label: t.name, value: t.id }))}
+						value={teamFilter || null}
+						onValueChange={(val) => onTeamFilterChange(val ?? "")}
+						placeholder="All Teams"
+						className="h-9 w-[180px]"
+					/>
+				</div>
+
+				<div className="rounded-sm border">
+					<Table className="w-full min-w-[1528px] table-fixed" data-testid="vk-table">
+						<TableHeader>
+							<TableRow>
+								<TableHead className="w-[48px]">
+									<Checkbox
+										checked={allVisibleSelected || (someVisibleSelected ? "indeterminate" : false)}
+										onCheckedChange={(checked) => toggleSelectAllVisible(checked === true)}
+										aria-label="Select all virtual keys on this page"
+										data-testid="vk-select-all-checkbox"
+									/>
+								</TableHead>
+								<TableHead className="w-[250px]">
+									<SortableHeader column="name" label="Name" />
+								</TableHead>
+								<TableHead className="w-[160px]">Assigned To</TableHead>
+								<TableHead className="w-[440px]">Key</TableHead>
+								<TableHead className="w-[200px]">
+									<SortableHeader column="budget_spent" label="Budget" />
+								</TableHead>
+								<TableHead className="w-[200px]">Rate Limits</TableHead>
+								<TableHead className="w-[120px]">
+									<SortableHeader column="status" label="Status" />
+								</TableHead>
+								<TableHead className={`bg-muted sticky right-0 z-10 w-[56px] text-right ${PIN_SHADOW_RIGHT}`}></TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{virtualKeys.length === 0 ? (
+								<TableRow>
+									<TableCell colSpan={8} className="h-24 text-center">
+										<span className="text-muted-foreground text-sm">No matching virtual keys found.</span>
+									</TableCell>
+								</TableRow>
+							) : (
+								virtualKeys.map((vk) => {
+									const isRevealed = revealedKeys.has(vk.id);
+
+									return (
+										<TableRow
+											key={vk.id}
+											data-testid={`vk-row-${vk.name}`}
+											className="group hover:bg-muted/50 cursor-pointer transition-colors"
+											onClick={() => handleRowClick(vk)}
+										>
+											<TableCell onClick={(e) => e.stopPropagation()}>
+												<Checkbox
+													checked={selectedIds.has(vk.id)}
+													onCheckedChange={(checked) => toggleSelectVirtualKey(vk.id, checked === true)}
+													aria-label={`Select virtual key ${vk.name}`}
+													data-testid={`vk-select-checkbox-${vk.name}`}
+												/>
+											</TableCell>
+											<TableCell className="max-w-[200px]">
+												<div className="truncate font-medium">{vk.name}</div>
+											</TableCell>
+											<TableCell>
+												{vk.team ? (
+													<Badge variant="outline" className="block max-w-full truncate text-left">
+														Team: {vk.team.name}
+													</Badge>
+												) : vk.customer ? (
+													<Badge variant="outline" className="block max-w-full truncate text-left">
+														Customer: {vk.customer.name}
+													</Badge>
+												) : vk.access_profile_id ? (
+													<Badge variant="outline" className="block max-w-full truncate text-left">
+														AP: {accessProfileNames[vk.access_profile_id] ?? vk.access_profile_id}
+													</Badge>
+												) : (
+													<span className="text-muted-foreground max-w-full truncate text-left text-sm">-</span>
+												)}
+											</TableCell>
+											<TableCell onClick={(e) => e.stopPropagation()}>
+												<div className="flex items-center gap-2">
+													<code className="cursor-default py-1 font-mono text-sm" data-testid="vk-key-value">
+														{maskKey(vk.value, isRevealed)}
+													</code>
+													<div className="flex items-center">
+														<Button
+															variant="ghost"
+															size="sm"
+															onClick={() => toggleKeyVisibility(vk.id)}
+															data-testid={`vk-visibility-btn-${vk.name}`}
+														>
+															{isRevealed ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+														</Button>
+														<Button
+															variant="ghost"
+															size="sm"
+															onClick={() => copyToClipboard(vk.value)}
+															data-testid={`vk-copy-btn-${vk.name}`}
+														>
+															<Copy className="h-4 w-4" />
+														</Button>
+													</div>
+												</div>
+											</TableCell>
+											<TableCell>
+												<VKBudgetCell vk={vk} />
+											</TableCell>
+											<TableCell>
+												<VKRateLimitCell vk={vk} />
+											</TableCell>
+											<TableCell onClick={(e) => e.stopPropagation()}>
+												<VKActiveSwitch vk={vk} hasUpdateAccess={hasUpdateAccess} onToggle={handleToggleActive} />
+											</TableCell>
+											<TableCell
+												className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-10 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+												onClick={(e) => e.stopPropagation()}
+											>
+												<VKActionsMenu
+													vk={vk}
+													hasUpdateAccess={hasUpdateAccess}
+													hasDeleteAccess={hasDeleteAccess}
+													isDeleting={isDeleting}
+													onEdit={handleEditVirtualKey}
+													onDelete={handleDelete}
+												/>
+											</TableCell>
+										</TableRow>
+									);
+								})
+							)}
+						</TableBody>
+					</Table>
+				</div>
+
+				{/* Pagination */}
+				{totalCount > 0 && (
+					<div className="flex items-center justify-between px-2">
+						<p className="text-muted-foreground text-sm">
+							Showing {offset + 1}-{Math.min(offset + limit, totalCount)} of {totalCount}
+						</p>
+						<div className="flex gap-2">
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={offset === 0}
+								onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+								data-testid="vk-pagination-prev-btn"
+							>
+								<ChevronLeft className="mr-1 h-4 w-4" />
+								Previous
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								disabled={offset + limit >= totalCount}
+								onClick={() => onOffsetChange(offset + limit)}
+								data-testid="vk-pagination-next-btn"
+							>
+								Next
+								<ChevronRight className="ml-1 h-4 w-4" />
+							</Button>
+						</div>
+					</div>
+				)}
+			</div>
+		</>
+	);
 }

--- a/ui/components/ui/multibudgets.tsx
+++ b/ui/components/ui/multibudgets.tsx
@@ -6,6 +6,7 @@ import { Plus, RotateCcw, Trash2 } from "lucide-react";
 import { useMemo } from "react";
 
 export interface BudgetLineEntry {
+	id?: string;
 	max_limit?: number;
 	reset_duration: string;
 }
@@ -97,7 +98,7 @@ export default function MultiBudgetLines({
 							<div className="flex-1">
 								<NumberAndSelect
 									id={`${testId}-${index}`}
-                                    dataTestId={`${testId}-amount-${index}`}
+									dataTestId={`${testId}-amount-${index}`}
 									labelClassName="font-normal"
 									label="Maximum Spend (USD)"
 									value={line.max_limit}

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -1,5 +1,7 @@
 import {
 	Budget,
+	BulkRotateVirtualKeysRequest,
+	BulkRotateVirtualKeysResponse,
 	CreateCustomerRequest,
 	CreateModelConfigRequest,
 	CreatePricingOverrideRequest,
@@ -91,6 +93,23 @@ export const governanceApi = baseApi.injectEndpoints({
 			query: ({ vkId, data }) => ({
 				url: `/governance/virtual-keys/${vkId}`,
 				method: "PUT",
+				body: data,
+			}),
+			invalidatesTags: ["VirtualKeys"],
+		}),
+
+		rotateVirtualKey: builder.mutation<{ message: string; virtual_key: VirtualKey }, string>({
+			query: (vkId) => ({
+				url: `/governance/virtual-keys/${vkId}/rotate`,
+				method: "POST",
+			}),
+			invalidatesTags: ["VirtualKeys"],
+		}),
+
+		bulkRotateVirtualKeys: builder.mutation<BulkRotateVirtualKeysResponse, BulkRotateVirtualKeysRequest>({
+			query: (data) => ({
+				url: "/governance/virtual-keys/rotate",
+				method: "POST",
 				body: data,
 			}),
 			invalidatesTags: ["VirtualKeys"],
@@ -788,6 +807,8 @@ export const {
 	useGetVirtualKeyQuery,
 	useCreateVirtualKeyMutation,
 	useUpdateVirtualKeyMutation,
+	useRotateVirtualKeyMutation,
+	useBulkRotateVirtualKeysMutation,
 	useDeleteVirtualKeyMutation,
 
 	// Teams

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -177,6 +177,17 @@ export interface UpdateVirtualKeyRequest {
 	rate_limit?: UpdateRateLimitRequest;
 	is_active?: boolean;
 	calendar_aligned?: boolean;
+	reset_budget_usage?: boolean;
+}
+
+export interface BulkRotateVirtualKeysRequest {
+	ids: string[];
+}
+
+export interface BulkRotateVirtualKeysResponse {
+	message: string;
+	virtual_keys: VirtualKey[];
+	errors?: Record<string, string>;
 }
 
 export interface CreateTeamRequest {
@@ -208,6 +219,7 @@ export interface UpdateCustomerRequest {
 }
 
 export interface CreateBudgetRequest {
+	id?: string;
 	max_limit: number; // In dollars
 	reset_duration: string; // e.g., "30s", "5m", "1h", "1d", "1w", "1M"
 }


### PR DESCRIPTION
## Summary

This PR adds virtual key rotation (single and bulk) and improves budget reconciliation when updating virtual keys. Previously, lowering a budget below its current usage or inheriting usage above a new budget's limit would fail with an error. Now these cases are allowed, and users are prompted to either preserve or reset usage when budget-relevant changes are detected.

## Changes

- Added a `reset_budget_usage` field to `UpdateVirtualKeyRequest` so callers can explicitly reset all budget usage counters to zero on update
- Added an `id` field to `CreateBudgetRequest` so existing budgets can be matched by ID rather than only by reset duration, enabling stable reconciliation when durations change
- Replaced the inline budget-by-duration lookup with `buildBudgetLookup`, `findExistingBudget`, `resetBudgetUsageIfRequested`, and `inheritUsageFromClosestShorterBudget` helpers for cleaner, reusable reconciliation logic
- Budget sort order now uses parsed duration values (`compareBudgetRequestDurations`) rather than raw string comparison, so durations like `"1M"` and `"1d"` sort correctly
- Removed the validation that rejected budget updates where preserved usage exceeded the new limit — usage above the limit is now allowed and surfaced as a warning in the UI instead
- Added a `rotateVirtualKey` mutation (single) and `bulkRotateVirtualKeys` mutation to the governance API, with corresponding TypeScript types (`BulkRotateVirtualKeysRequest`, `BulkRotateVirtualKeysResponse`)
- Added a **Rotate Key** button to the virtual key edit sheet with a confirmation dialog
- Added per-row checkboxes and a select-all checkbox to the virtual keys table, with a **Rotate selected (N)** bulk action button that appears when keys are selected
- When saving a virtual key with budget-relevant changes (limit, duration, or calendar alignment), the UI now intercepts the submit and shows a dialog asking whether to preserve or reset usage; if the preserved usage would meet or exceed the new limit, a contextual warning is shown
- `BudgetLineEntry` and related form schemas now carry the budget `id` through the UI so it is sent back on update

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Transports
go test ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i
pnpm build
```

**Single key rotation:**
1. Open the edit sheet for any virtual key.
2. Click **Rotate Key** in the footer.
3. Confirm in the dialog — the key value should change and the previous value should stop working.

**Bulk rotation:**
1. Select one or more virtual keys using the row checkboxes.
2. Click **Rotate selected (N)** in the table header.
3. Confirm — all selected keys should be rotated and deselected.

**Budget reset prompt:**
1. Edit a virtual key that has an existing budget with non-zero usage.
2. Change the budget limit or reset duration and click **Update**.
3. A dialog should appear asking to preserve or reset usage.
4. If the preserved usage would meet or exceed the new limit, the dialog should show a warning message before the choice.

**Budget ID matching:**
1. Update a virtual key's budget by sending the existing budget `id` with a different `reset_duration` — the existing budget record should be updated in place rather than deleted and recreated.

## Screenshots/Recordings

_Add before/after screenshots of the Rotate Key button, bulk rotate action, and budget reset dialog._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Rotation replaces the secret value of a virtual key immediately; the previous value stops working as soon as the rotation completes. Bulk rotation applies the same guarantee to all selected keys atomically per key. No secrets are logged or returned beyond the standard virtual key response payload.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable