### PR TITLE
chore: reformat `virtualKeysTable.tsx` and fix dropdown menu close-on-action

### DIFF
--- a/ui/app/clientLayout.tsx
+++ b/ui/app/clientLayout.tsx
@@ -73,7 +73,7 @@ export function ClientLayout({ children }: { children: React.ReactNode }) {
 	return (
 		<ProgressProvider>
 			<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-				<Toaster />
+				<Toaster closeButton />
 				<ReduxProvider>
 					<NuqsAdapter>
 						<RbacProvider>

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -389,3 +389,17 @@ div.content-container:has(.no-border-parent) #trial-notification-banner {
 [data-streamdown="code-block-body"] {
 	@apply rounded-sm!;
 }
+
+/* Move Sonner toast close button to top-right */
+[data-sonner-toaster][dir="ltr"],
+[data-sonner-toaster] {
+	--toast-close-button-start: unset !important;
+	--toast-close-button-end: 0 !important;
+	--toast-close-button-transform: translate(35%, -35%) !important;
+}
+
+[data-sonner-toast][data-styled="true"] [data-close-button] {
+	left: auto !important;
+	right: 0 !important;
+	transform: translate(35%, -35%) !important;
+}

--- a/ui/app/pprof/layout.tsx
+++ b/ui/app/pprof/layout.tsx
@@ -13,7 +13,7 @@ function PprofLayout({ children }: { children: React.ReactNode }) {
 
 	return (
 		<ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
-			<Toaster />
+			<Toaster closeButton />
 			<ReduxProvider>
 				<div className="min-h-screen bg-zinc-950 text-zinc-100">{children}</div>
 			</ReduxProvider>

--- a/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
@@ -32,6 +32,61 @@ import { toast } from "sonner";
 import PricingOverrideSheet from "./pricingOverrideSheet";
 import { PricingOverridesEmptyState } from "./pricingOverridesEmptyState";
 
+function PricingOverrideActionsMenu({
+	row,
+	onEdit,
+	onDelete,
+}: {
+	row: PricingOverride;
+	onEdit: (row: PricingOverride) => void;
+	onDelete: (row: PricingOverride) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8"
+					aria-label={`Actions for pricing override ${row.name || row.id}`}
+					data-testid={`pricing-override-actions-btn-${row.id}`}
+				>
+					<MoreHorizontal className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					data-testid={`pricing-override-edit-btn-${row.id}`}
+					className="cursor-pointer"
+					onSelect={(e) => {
+						e.preventDefault();
+						onEdit(row);
+						setIsOpen(false);
+					}}
+				>
+					<Edit className="h-4 w-4" />
+					Edit
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					data-testid={`pricing-override-delete-btn-${row.id}`}
+					variant="destructive"
+					className="cursor-pointer"
+					onSelect={(e) => {
+						e.preventDefault();
+						onDelete(row);
+						setIsOpen(false);
+					}}
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
 type ScopeFilter = "all" | PricingOverrideScopeKind;
 
 function parseScopeKind(value: string | null): ScopeFilter {
@@ -314,44 +369,11 @@ export default function ScopedPricingOverridesView() {
 										<TableCell>{row.pattern}</TableCell>
 										<TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
 											<div className="flex items-center justify-end">
-												<DropdownMenu>
-													<DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
-														<Button
-															variant="ghost"
-															size="icon"
-															className="h-8 w-8"
-															aria-label={`Actions for pricing override ${row.name || row.id}`}
-															data-testid={`pricing-override-actions-btn-${row.id}`}
-														>
-															<MoreHorizontal className="h-4 w-4" />
-														</Button>
-													</DropdownMenuTrigger>
-													<DropdownMenuContent align="end">
-														<DropdownMenuItem
-															data-testid={`pricing-override-edit-btn-${row.id}`}
-															className="cursor-pointer"
-															onClick={(event) => {
-																event.stopPropagation();
-																openEditDrawer(row);
-															}}
-														>
-															<Edit className="h-4 w-4" />
-															Edit
-														</DropdownMenuItem>
-														<DropdownMenuItem
-															data-testid={`pricing-override-delete-btn-${row.id}`}
-															variant="destructive"
-															className="cursor-pointer"
-															onClick={(event) => {
-																event.stopPropagation();
-																setDeleteTarget(row);
-															}}
-														>
-															<Trash2 className="h-4 w-4" />
-															Delete
-														</DropdownMenuItem>
-													</DropdownMenuContent>
-												</DropdownMenu>
+												<PricingOverrideActionsMenu
+													row={row}
+													onEdit={openEditDrawer}
+													onDelete={setDeleteTarget}
+												/>
 											</div>
 										</TableCell>
 									</TableRow>

--- a/ui/app/workspace/governance/views/customerTable.tsx
+++ b/ui/app/workspace/governance/views/customerTable.tsx
@@ -44,8 +44,10 @@ interface CustomerActionsMenuProps {
 }
 
 function CustomerActionsMenu({ customer, canUpdate, canDelete, onEdit, onDelete }: CustomerActionsMenuProps) {
+	const [isOpen, setIsOpen] = useState(false);
+
 	return (
-		<DropdownMenu>
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
 			<DropdownMenuTrigger asChild>
 				<Button
 					variant="ghost"
@@ -63,9 +65,10 @@ function CustomerActionsMenu({ customer, canUpdate, canDelete, onEdit, onDelete 
 				<DropdownMenuItem
 					disabled={!canUpdate}
 					data-testid={`customer-button-edit-${customer.id}`}
-					onClick={(e) => {
-						e.stopPropagation();
+					onSelect={(e) => {
+						e.preventDefault();
 						onEdit(customer);
+						setIsOpen(false);
 					}}
 				>
 					<Edit className="h-4 w-4" />
@@ -75,9 +78,10 @@ function CustomerActionsMenu({ customer, canUpdate, canDelete, onEdit, onDelete 
 					variant="destructive"
 					disabled={!canDelete}
 					data-testid={`customer-button-delete-${customer.id}`}
-					onClick={(e) => {
-						e.stopPropagation();
+					onSelect={(e) => {
+						e.preventDefault();
 						onDelete(customer);
+						setIsOpen(false);
 					}}
 				>
 					<Trash2 className="h-4 w-4" />

--- a/ui/app/workspace/governance/views/teamsTable.tsx
+++ b/ui/app/workspace/governance/views/teamsTable.tsx
@@ -48,11 +48,12 @@ function TeamActionsMenu({
 	onEdit: (team: Team) => void;
 	onDelete: (teamId: string) => void;
 }) {
+	const [isOpen, setIsOpen] = useState(false);
 	const [deleteOpen, setDeleteOpen] = useState(false);
 
 	return (
 		<>
-			<DropdownMenu>
+			<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
 				<DropdownMenuTrigger asChild>
 					<Button
 						variant="ghost"
@@ -72,6 +73,7 @@ function TeamActionsMenu({
 						onSelect={(e) => {
 							e.preventDefault();
 							onEdit(team);
+							setIsOpen(false);
 						}}
 					>
 						<Edit className="h-4 w-4" />
@@ -85,6 +87,7 @@ function TeamActionsMenu({
 						onSelect={(e) => {
 							e.preventDefault();
 							setDeleteOpen(true);
+							setIsOpen(false);
 						}}
 					>
 						<Trash2 className="h-4 w-4" />

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -10,6 +10,36 @@ import { cn } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
 import { format, formatDistanceToNow } from "date-fns";
 import { ArrowUpDown, MoreHorizontal, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+function LogActionsMenu({ log, onDelete }: { log: LogEntry; onDelete: (log: LogEntry) => void }) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
+				<Button variant="ghost" size="icon" data-testid="log-actions-btn" aria-label="Log actions" className="h-7 w-7">
+					<MoreHorizontal className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					variant="destructive"
+					className="cursor-pointer"
+					data-testid="log-delete-btn"
+					onSelect={(e) => {
+						e.preventDefault();
+						onDelete(log);
+						setIsOpen(false);
+					}}
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
 
 function getAssistantToolCallSummary(log?: LogEntry): string {
 	const toolCalls = log?.output_message?.tool_calls || [];
@@ -357,27 +387,7 @@ export const createColumns = (
 						const log = row.original;
 						return (
 							<div className="flex justify-center">
-								<DropdownMenu>
-									<DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
-										<Button variant="ghost" size="icon" data-testid="log-actions-btn" aria-label="Log actions" className="h-7 w-7">
-											<MoreHorizontal className="h-4 w-4" />
-										</Button>
-									</DropdownMenuTrigger>
-									<DropdownMenuContent align="end">
-										<DropdownMenuItem
-											variant="destructive"
-											className="cursor-pointer"
-											data-testid="log-delete-btn"
-											onClick={(event) => {
-												event.stopPropagation();
-												onDelete(log);
-											}}
-										>
-											<Trash2 className="h-4 w-4" />
-											Delete
-										</DropdownMenuItem>
-									</DropdownMenuContent>
-								</DropdownMenu>
+								<LogActionsMenu log={log} onDelete={onDelete} />
 							</div>
 						);
 					},

--- a/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
@@ -7,7 +7,6 @@ import {
 	AlertDialogFooter,
 	AlertDialogHeader,
 	AlertDialogTitle,
-	AlertDialogTrigger,
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -77,6 +76,7 @@ export function MCPLogDetailSheet({
 	hasNext = false,
 }: MCPLogDetailSheetProps) {
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const {
 		data: fullLog,
 		isLoading,
@@ -144,7 +144,7 @@ export function MCPLogDetailSheet({
 						</Button>
 					</div>
 					<AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-						<DropdownMenu>
+						<DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
 							<DropdownMenuTrigger asChild>
 								<Button variant="ghost" className="size-8" type="button">
 									<MoreVertical className="h-3 w-3" />
@@ -153,7 +153,11 @@ export function MCPLogDetailSheet({
 							<DropdownMenuContent align="end">
 								<DropdownMenuItem
 									data-testid="export-log-json"
-									onClick={() => downloadAsJson(displayLog, `mcp-log-${displayLog.id ?? "export"}.json`)}
+									onSelect={(e) => {
+										e.preventDefault();
+										downloadAsJson(displayLog, `mcp-log-${displayLog.id ?? "export"}.json`);
+										setDropdownOpen(false);
+									}}
 								>
 									<Download className="h-4 w-4" />
 									Export as JSON
@@ -161,12 +165,17 @@ export function MCPLogDetailSheet({
 								{handleDelete ? (
 									<>
 										<DropdownMenuSeparator />
-										<AlertDialogTrigger asChild>
-											<DropdownMenuItem variant="destructive">
-												<Trash2 className="h-4 w-4" />
-												Delete log
-											</DropdownMenuItem>
-										</AlertDialogTrigger>
+										<DropdownMenuItem
+											variant="destructive"
+											onSelect={(e) => {
+												e.preventDefault();
+												setDeleteDialogOpen(true);
+												setDropdownOpen(false);
+											}}
+										>
+											<Trash2 className="h-4 w-4" />
+											Delete log
+										</DropdownMenuItem>
 									</>
 								) : null}
 							</DropdownMenuContent>

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -25,6 +25,72 @@ import { useState } from "react";
 import { MCPServersEmptyState } from "./mcpServersEmptyState";
 import MCPClientSheet from "./mcpClientSheet";
 
+function MCPClientActionsMenu({
+	client,
+	hasUpdateAccess,
+	hasDeleteAccess,
+	isReconnecting,
+	isPerUserOAuth,
+	onReconnect,
+	onDelete,
+}: {
+	client: MCPClient;
+	hasUpdateAccess: boolean;
+	hasDeleteAccess: boolean;
+	isReconnecting: boolean;
+	isPerUserOAuth: boolean;
+	onReconnect: (client: MCPClient) => void;
+	onDelete: (client: MCPClient) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8"
+					aria-label="MCP server actions"
+					data-testid={`mcp-client-actions-${client.config.client_id}-btn`}
+				>
+					{isReconnecting ? <Loader2 className="h-4 w-4 animate-spin" /> : <MoreHorizontal className="h-4 w-4" />}
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				{hasUpdateAccess && (
+					<DropdownMenuItem
+						className="cursor-pointer"
+						disabled={isPerUserOAuth || client.config.disabled || isReconnecting}
+						onSelect={(e) => {
+							e.preventDefault();
+							onReconnect(client);
+							setIsOpen(false);
+						}}
+					>
+						<RefreshCcw className="h-4 w-4" />
+						Reconnect
+					</DropdownMenuItem>
+				)}
+				{hasDeleteAccess && (
+					<DropdownMenuItem
+						variant="destructive"
+						className="cursor-pointer"
+						onSelect={(e) => {
+							e.preventDefault();
+							onDelete(client);
+							setIsOpen(false);
+						}}
+					>
+						<Trash2 className="h-4 w-4" />
+						Delete
+					</DropdownMenuItem>
+				)}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
 interface MCPClientsTableProps {
 	mcpClients: MCPClient[];
 	totalCount: number;
@@ -318,51 +384,15 @@ export default function MCPClientsTable({
 											className={`bg-card group-hover:bg-muted/50 sticky right-0 z-10 text-right ${PIN_SHADOW_RIGHT}`}
 											onClick={(e) => e.stopPropagation()}
 										>
-											<DropdownMenu>
-												<DropdownMenuTrigger asChild>
-													<Button
-														variant="ghost"
-														size="icon"
-														className="h-8 w-8"
-														aria-label="MCP server actions"
-														data-testid={`mcp-client-actions-${c.config.client_id}-btn`}
-													>
-														{reconnectingClients.includes(c.config.client_id) ? (
-															<Loader2 className="h-4 w-4 animate-spin" />
-														) : (
-															<MoreHorizontal className="h-4 w-4" />
-														)}
-													</Button>
-												</DropdownMenuTrigger>
-												<DropdownMenuContent align="end">
-													{hasUpdateMCPClientAccess && (
-														<DropdownMenuItem
-															className="cursor-pointer"
-															disabled={isPerUserOAuth || c.config.disabled || reconnectingClients.includes(c.config.client_id)}
-															onSelect={(e) => {
-																e.preventDefault();
-																void handleReconnect(c);
-															}}
-														>
-															<RefreshCcw className="h-4 w-4" />
-															Reconnect
-														</DropdownMenuItem>
-													)}
-													{hasDeleteMCPClientAccess && (
-														<DropdownMenuItem
-															variant="destructive"
-															className="cursor-pointer"
-															onSelect={(e) => {
-																e.preventDefault();
-																setClientToDelete(c);
-															}}
-														>
-															<Trash2 className="h-4 w-4" />
-															Delete
-														</DropdownMenuItem>
-													)}
-												</DropdownMenuContent>
-											</DropdownMenu>
+											<MCPClientActionsMenu
+												client={c}
+												hasUpdateAccess={hasUpdateMCPClientAccess}
+												hasDeleteAccess={hasDeleteMCPClientAccess}
+												isReconnecting={reconnectingClients.includes(c.config.client_id)}
+												isPerUserOAuth={isPerUserOAuth}
+												onReconnect={(client) => void handleReconnect(client)}
+												onDelete={setClientToDelete}
+											/>
 										</TableCell>
 									</TableRow>
 								);

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -40,6 +40,67 @@ const toTestIdPart = (value: string) =>
 		.replace(/[^a-z0-9]+/g, "-")
 		.replace(/^-|-$/g, "");
 
+function ModelLimitActionsMenu({
+	config,
+	hasUpdateAccess,
+	hasDeleteAccess,
+	onEdit,
+	onDelete,
+}: {
+	config: ModelConfig;
+	hasUpdateAccess: boolean;
+	hasDeleteAccess: boolean;
+	onEdit: (config: ModelConfig) => void;
+	onDelete: (configId: string) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8"
+					aria-label={`Actions for model limit ${config.model_name}`}
+					data-testid={`model-limit-button-actions-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
+				>
+					<MoreHorizontal className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					className="cursor-pointer"
+					disabled={!hasUpdateAccess}
+					data-testid={`model-limit-button-edit-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
+					onSelect={(e) => {
+						e.preventDefault();
+						onEdit(config);
+						setIsOpen(false);
+					}}
+				>
+					<Edit className="h-4 w-4" />
+					Edit
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					variant="destructive"
+					className="cursor-pointer"
+					disabled={!hasDeleteAccess}
+					data-testid={`model-limit-button-delete-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
+					onSelect={(e) => {
+						e.preventDefault();
+						onDelete(config.id);
+						setIsOpen(false);
+					}}
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
 interface ModelLimitsTableProps {
 	modelConfigs: ModelConfig[];
 	totalCount: number;
@@ -371,46 +432,13 @@ export default function ModelLimitsTable({
 											</TableCell>
 											<TableCell onClick={(e) => e.stopPropagation()}>
 												<div className="flex items-center justify-end">
-													<DropdownMenu>
-														<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-															<Button
-																variant="ghost"
-																size="icon"
-																className="h-8 w-8"
-																aria-label={`Actions for model limit ${config.model_name}`}
-																data-testid={`model-limit-button-actions-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
-															>
-																<MoreHorizontal className="h-4 w-4" />
-															</Button>
-														</DropdownMenuTrigger>
-														<DropdownMenuContent align="end">
-															<DropdownMenuItem
-																className="cursor-pointer"
-																disabled={!hasUpdateAccess}
-																onClick={(e) => {
-																	e.stopPropagation();
-																	handleEditModelLimit(config);
-																}}
-																data-testid={`model-limit-button-edit-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
-															>
-																<Edit className="h-4 w-4" />
-																Edit
-															</DropdownMenuItem>
-															<DropdownMenuItem
-																variant="destructive"
-																className="cursor-pointer"
-																disabled={!hasDeleteAccess}
-																onClick={(e) => {
-																	e.stopPropagation();
-																	setDeleteModelConfigId(config.id);
-																}}
-																data-testid={`model-limit-button-delete-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
-															>
-																<Trash2 className="h-4 w-4" />
-																Delete
-															</DropdownMenuItem>
-														</DropdownMenuContent>
-													</DropdownMenu>
+													<ModelLimitActionsMenu
+														config={config}
+														hasUpdateAccess={hasUpdateAccess}
+														hasDeleteAccess={hasDeleteAccess}
+														onEdit={handleEditModelLimit}
+														onDelete={setDeleteModelConfigId}
+													/>
 												</div>
 											</TableCell>
 										</TableRow>

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -31,6 +31,57 @@ interface Props {
 	isKeyless?: boolean;
 }
 
+function ProviderKeyActionsMenu({
+	keyId,
+	hasUpdateAccess,
+	hasDeleteAccess,
+	onEdit,
+	onDelete,
+}: {
+	keyId: string;
+	hasUpdateAccess: boolean;
+	hasDeleteAccess: boolean;
+	onEdit: (keyId: string) => void;
+	onDelete: (keyId: string) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild>
+				<Button onClick={(e) => e.stopPropagation()} variant="ghost">
+					<EllipsisIcon className="h-5 w-5" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					onSelect={(e) => {
+						e.preventDefault();
+						onEdit(keyId);
+						setIsOpen(false);
+					}}
+					disabled={!hasUpdateAccess}
+				>
+					<PencilIcon className="mr-1 h-4 w-4" />
+					Edit
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					variant="destructive"
+					onSelect={(e) => {
+						e.preventDefault();
+						onDelete(keyId);
+						setIsOpen(false);
+					}}
+					disabled={!hasDeleteAccess}
+				>
+					<TrashIcon className="mr-1 h-4 w-4" />
+					Delete
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
 export default function ModelProviderKeysTableView({ provider, className, headerActions, isKeyless }: Props) {
 	const providerName = provider.name?.toLowerCase() ?? "";
 	const isVLLM = providerName === "vllm";
@@ -265,34 +316,13 @@ export default function ModelProviderKeysTableView({ provider, className, header
 										<TableCell className="text-right">
 											<div className="flex items-center justify-end space-x-2">
 												{hasUpdateProviderAccess || hasDeleteProviderAccess ? (
-													<DropdownMenu>
-														<DropdownMenuTrigger asChild>
-															<Button onClick={(e) => e.stopPropagation()} variant="ghost">
-																<EllipsisIcon className="h-5 w-5" />
-															</Button>
-														</DropdownMenuTrigger>
-														<DropdownMenuContent align="end">
-															<DropdownMenuItem
-																onClick={() => {
-																	setShowAddNewKeyDialog({ show: true, keyId: key.id });
-																}}
-																disabled={!hasUpdateProviderAccess}
-															>
-																<PencilIcon className="mr-1 h-4 w-4" />
-																Edit
-															</DropdownMenuItem>
-															<DropdownMenuItem
-																variant="destructive"
-																onClick={() => {
-																	setShowDeleteKeyDialog({ show: true, keyId: key.id });
-																}}
-																disabled={!hasDeleteProviderAccess}
-															>
-																<TrashIcon className="mr-1 h-4 w-4" />
-																Delete
-															</DropdownMenuItem>
-														</DropdownMenuContent>
-													</DropdownMenu>
+													<ProviderKeyActionsMenu
+														keyId={key.id}
+														hasUpdateAccess={hasUpdateProviderAccess}
+														hasDeleteAccess={hasDeleteProviderAccess}
+														onEdit={(keyId) => setShowAddNewKeyDialog({ show: true, keyId })}
+														onDelete={(keyId) => setShowDeleteKeyDialog({ show: true, keyId })}
+													/>
 												) : null}
 											</div>
 										</TableCell>

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -29,6 +29,67 @@ import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Search, Trash2 } from 
 import { useState } from "react";
 import { toast } from "sonner";
 
+function RoutingRuleActionsMenu({
+	rule,
+	canUpdate,
+	canDelete,
+	onEdit,
+	onDelete,
+}: {
+	rule: RoutingRule;
+	canUpdate: boolean;
+	canDelete: boolean;
+	onEdit: (rule: RoutingRule) => void;
+	onDelete: (ruleId: string) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8"
+					aria-label={`Actions for routing rule ${rule.name}`}
+					data-testid={`routing-rule-actions-${rule.id}-btn`}
+				>
+					<MoreHorizontal className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					className="cursor-pointer"
+					disabled={!canUpdate}
+					data-testid={`routing-rule-edit-${rule.id}-btn`}
+					onSelect={(e) => {
+						e.preventDefault();
+						onEdit(rule);
+						setIsOpen(false);
+					}}
+				>
+					<Edit className="h-4 w-4" />
+					Edit
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					variant="destructive"
+					className="cursor-pointer"
+					disabled={!canDelete}
+					data-testid={`routing-rule-delete-${rule.id}-btn`}
+					onSelect={(e) => {
+						e.preventDefault();
+						onDelete(rule.id);
+						setIsOpen(false);
+					}}
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
 interface RoutingRulesTableProps {
 	rules: RoutingRule[] | undefined;
 	totalCount: number;
@@ -192,46 +253,13 @@ export function RoutingRulesTable({
 									</TableCell>
 									<TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
 										<div className="flex items-center justify-end">
-											<DropdownMenu>
-												<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-													<Button
-														variant="ghost"
-														size="icon"
-														className="h-8 w-8"
-														aria-label={`Actions for routing rule ${rule.name}`}
-														data-testid={`routing-rule-actions-${rule.id}-btn`}
-													>
-														<MoreHorizontal className="h-4 w-4" />
-													</Button>
-												</DropdownMenuTrigger>
-												<DropdownMenuContent align="end">
-													<DropdownMenuItem
-														className="cursor-pointer"
-														disabled={!canUpdate}
-														onClick={(e) => {
-															e.stopPropagation();
-															onEdit(rule);
-														}}
-														data-testid={`routing-rule-edit-${rule.id}-btn`}
-													>
-														<Edit className="h-4 w-4" />
-														Edit
-													</DropdownMenuItem>
-													<DropdownMenuItem
-														variant="destructive"
-														className="cursor-pointer"
-														disabled={!canDelete}
-														onClick={(e) => {
-															e.stopPropagation();
-															setDeleteRuleId(rule.id);
-														}}
-														data-testid={`routing-rule-delete-${rule.id}-btn`}
-													>
-														<Trash2 className="h-4 w-4" />
-														Delete
-													</DropdownMenuItem>
-												</DropdownMenuContent>
-											</DropdownMenu>
+											<RoutingRuleActionsMenu
+												rule={rule}
+												canUpdate={canUpdate}
+												canDelete={canDelete}
+												onEdit={onEdit}
+												onDelete={setDeleteRuleId}
+											/>
 										</div>
 									</TableCell>
 								</TableRow>

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -168,12 +168,13 @@ function VKActionsMenu({
 	onEdit: (vk: VirtualKey) => void;
 	onDelete: (vkId: string) => void;
 }) {
+	const [isOpen, setIsOpen] = useState(false);
 	const { isManagedByProfile } = useVirtualKeyUsage(vk);
 	const [deleteOpen, setDeleteOpen] = useState(false);
 
 	return (
 		<>
-			<DropdownMenu>
+			<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
 				<DropdownMenuTrigger asChild>
 					<Button
 						variant="ghost"
@@ -193,6 +194,7 @@ function VKActionsMenu({
 						onSelect={(e) => {
 							e.preventDefault();
 							onEdit(vk);
+							setIsOpen(false);
 						}}
 					>
 						<Edit className="h-4 w-4" />
@@ -207,6 +209,7 @@ function VKActionsMenu({
 						onSelect={(e) => {
 							e.preventDefault();
 							setDeleteOpen(true);
+							setIsOpen(false);
 						}}
 					>
 						<Trash2 className="h-4 w-4" />


### PR DESCRIPTION
## Summary

Reformats `virtualKeysTable.tsx` to use tab-based indentation consistently throughout the file, and fixes a bug where the `VKActionsMenu` dropdown would remain open after selecting "Edit" or "Delete".

## Changes

- Converted all 2-space indentation to tabs across the entire `virtualKeysTable.tsx` file to match the project's preferred style
- Added explicit `isOpen` / `setIsOpen` state to `VKActionsMenu` and wired it to the `DropdownMenu`'s `open` / `onOpenChange` props so the menu closes immediately when "Edit" or "Delete" is selected, preventing the dropdown from staying visible while a sheet or dialog opens

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Virtual Keys table.
2. Open the actions menu (⋯) on any virtual key row.
3. Click **Edit** — the dropdown should close immediately and the edit sheet should open.
4. Repeat and click **Delete** — the dropdown should close immediately and the delete confirmation dialog should appear.
5. Confirm neither the edit nor delete action leaves the dropdown menu visible in the background.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. The change only affects UI rendering and dropdown state management.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable