### PR TITLE
onboarding widget backend changes

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -755,6 +755,41 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
   if err := migrationAddFeatureFlagsTable(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddClientConfigMetadataColumn(ctx, db); err != nil {
+		return err
+	}
+	return nil
+}
+
+// migrationAddClientConfigMetadataColumn adds the metadata_json column to
+// config_client. The column stores a JSON blob of UI/admin preferences (e.g.
+// onboarding_dismissed) and is deliberately not part of the ClientConfig API
+// struct, so config.json sync cannot overwrite it.
+func migrationAddClientConfigMetadataColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_client_config_metadata_json_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if !migrator.HasColumn(&tables.TableClientConfig{}, "metadata_json") {
+				if err := migrator.AddColumn(&tables.TableClientConfig{}, "metadata_json"); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			migrator := tx.Migrator()
+			if err := migrator.DropColumn(&tables.TableClientConfig{}, "metadata_json"); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running db migration: %s", err.Error())
+	}
 	return nil
 }
 

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/encrypt"
@@ -258,8 +259,18 @@ func (s *RDBConfigStore) UpdateClientConfig(ctx context.Context, config *ClientC
 		AllowPerRequestRawOverride:            config.AllowPerRequestRawOverride,
 		ConfigHash:                            config.ConfigHash,
 	}
-	// Delete existing client config and create new one in a transaction
+	// Delete existing client config and create new one in a transaction.
+	// MetadataJSON is preserved here because Metadata is a UI/admin-preferences
+	// blob that is NOT part of the API-facing ClientConfig (so config.json sync
+	// can never set it). Reading it inside the transaction before DELETE keeps
+	// callers from clobbering UI prefs on every config write.
 	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing tables.TableClientConfig
+		if err := dbForUpdate(tx.Select("metadata_json")).First(&existing).Error; err == nil {
+			dbConfig.MetadataJSON = existing.MetadataJSON
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
 		if err := tx.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&tables.TableClientConfig{}).Error; err != nil {
 			return err
 		}
@@ -511,6 +522,78 @@ func (s *RDBConfigStore) GetClientConfig(ctx context.Context) (*ClientConfig, er
 		AllowPerRequestRawOverride:            dbConfig.AllowPerRequestRawOverride,
 		ConfigHash:                            dbConfig.ConfigHash,
 	}, nil
+}
+
+// GetClientMetadata returns the UI/admin-preferences blob stored on config_client.
+// Returns an empty (non-nil) map if no row exists yet or the blob is unset, so
+// callers can read keys without nil-checking.
+func (s *RDBConfigStore) GetClientMetadata(ctx context.Context) (map[string]any, error) {
+	var dbConfig tables.TableClientConfig
+	if err := s.DB().WithContext(ctx).First(&dbConfig).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return map[string]any{}, nil
+		}
+		return nil, err
+	}
+	if dbConfig.Metadata == nil {
+		return map[string]any{}, nil
+	}
+	return dbConfig.Metadata, nil
+}
+
+// mergeMetadataPatch applies patch into dst following JSON Merge Patch
+// semantics (RFC 7386): a nil patch value deletes the key; when both the
+// existing value and the patch value are objects they are merged recursively;
+// any other value replaces the existing one. dst is mutated in place.
+func mergeMetadataPatch(dst, patch map[string]any) {
+	for k, v := range patch {
+		if v == nil {
+			delete(dst, k)
+			continue
+		}
+		patchObj, patchIsObj := v.(map[string]any)
+		dstObj, dstIsObj := dst[k].(map[string]any)
+		if patchIsObj && dstIsObj {
+			mergeMetadataPatch(dstObj, patchObj)
+			continue
+		}
+		dst[k] = v
+	}
+}
+
+// UpdateClientMetadata merges patch into the existing metadata blob and writes
+// it back via a targeted UPDATE on metadata_json only — no DELETE+CREATE, no
+// risk of clobbering other ClientConfig columns. The merge follows JSON Merge
+// Patch semantics (RFC 7386): nested objects are merged recursively, and keys
+// with a nil value in patch are removed from the blob (callers can pass
+// {"key": nil} to clear, including nested keys).
+func (s *RDBConfigStore) UpdateClientMetadata(ctx context.Context, patch map[string]any) error {
+	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var existing tables.TableClientConfig
+		if err := dbForUpdate(tx).First(&existing).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("%w: client config must be initialized before metadata can be updated", ErrNotFound)
+			}
+			return err
+		}
+		merged := existing.Metadata
+		if merged == nil {
+			merged = map[string]any{}
+		}
+		mergeMetadataPatch(merged, patch)
+		data, mErr := providerUtils.MarshalSorted(merged)
+		if mErr != nil {
+			return mErr
+		}
+		result := tx.Model(&tables.TableClientConfig{}).Where("id = ?", existing.ID).Update("metadata_json", string(data))
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return fmt.Errorf("client config metadata update affected no rows")
+		}
+		return nil
+	})
 }
 
 // UpdateProvidersConfig updates the client configuration in the database.

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -872,6 +872,123 @@ func TestUpdateClientConfig(t *testing.T) {
 	assert.Equal(t, 100, result.InitialPoolSize)
 }
 
+func TestUpdateClientMetadata(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	err := store.UpdateClientConfig(ctx, &ClientConfig{
+		EnableLogging:        new(true),
+		InitialPoolSize:      100,
+		LogRetentionDays:     30,
+		MaxRequestBodySizeMB: 50,
+	})
+	require.NoError(t, err)
+
+	err = store.UpdateClientMetadata(ctx, map[string]any{
+		"onboarding_dismissed": true,
+		"theme":                "dark",
+	})
+	require.NoError(t, err)
+
+	err = store.UpdateClientMetadata(ctx, map[string]any{
+		"theme": "light",
+		"stale": nil,
+	})
+	require.NoError(t, err)
+
+	metadata, err := store.GetClientMetadata(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, true, metadata["onboarding_dismissed"])
+	assert.Equal(t, "light", metadata["theme"])
+	assert.NotContains(t, metadata, "stale")
+
+	err = store.UpdateClientMetadata(ctx, map[string]any{"theme": nil})
+	require.NoError(t, err)
+
+	metadata, err = store.GetClientMetadata(ctx)
+	require.NoError(t, err)
+	assert.NotContains(t, metadata, "theme")
+	assert.Equal(t, true, metadata["onboarding_dismissed"])
+
+	// Nested objects must be merged recursively (RFC 7386), not replaced
+	// wholesale, so sibling keys survive a partial nested patch.
+	err = store.UpdateClientMetadata(ctx, map[string]any{
+		"onboarding": map[string]any{"dismissed": true, "step": "a"},
+	})
+	require.NoError(t, err)
+
+	err = store.UpdateClientMetadata(ctx, map[string]any{
+		"onboarding": map[string]any{"step": "b"},
+	})
+	require.NoError(t, err)
+
+	metadata, err = store.GetClientMetadata(ctx)
+	require.NoError(t, err)
+	onboarding, ok := metadata["onboarding"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, onboarding["dismissed"], "sibling key must survive nested patch")
+	assert.Equal(t, "b", onboarding["step"])
+
+	// A nil nested value deletes just that nested key.
+	err = store.UpdateClientMetadata(ctx, map[string]any{
+		"onboarding": map[string]any{"dismissed": nil},
+	})
+	require.NoError(t, err)
+
+	metadata, err = store.GetClientMetadata(ctx)
+	require.NoError(t, err)
+	onboarding, ok = metadata["onboarding"].(map[string]any)
+	require.True(t, ok)
+	assert.NotContains(t, onboarding, "dismissed")
+	assert.Equal(t, "b", onboarding["step"])
+}
+
+func TestUpdateClientMetadataRequiresClientConfig(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	err := store.UpdateClientMetadata(ctx, map[string]any{"onboarding_dismissed": true})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNotFound)
+
+	var count int64
+	err = store.DB().WithContext(ctx).Model(&tables.TableClientConfig{}).Count(&count).Error
+	require.NoError(t, err)
+	assert.Zero(t, count)
+}
+
+func TestUpdateClientConfigPreservesMetadata(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	err := store.UpdateClientConfig(ctx, &ClientConfig{
+		EnableLogging:        new(true),
+		InitialPoolSize:      100,
+		LogRetentionDays:     30,
+		MaxRequestBodySizeMB: 50,
+	})
+	require.NoError(t, err)
+
+	err = store.UpdateClientMetadata(ctx, map[string]any{"onboarding_dismissed": true})
+	require.NoError(t, err)
+
+	err = store.UpdateClientConfig(ctx, &ClientConfig{
+		EnableLogging:        new(true),
+		InitialPoolSize:      200,
+		LogRetentionDays:     60,
+		MaxRequestBodySizeMB: 100,
+	})
+	require.NoError(t, err)
+
+	config, err := store.GetClientConfig(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 200, config.InitialPoolSize)
+
+	metadata, err := store.GetClientMetadata(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, true, metadata["onboarding_dismissed"])
+}
+
 // =============================================================================
 // Transaction Tests
 // =============================================================================

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -93,6 +93,9 @@ type ConfigStore interface {
 	// Client config CRUD
 	UpdateClientConfig(ctx context.Context, config *ClientConfig) error
 	GetClientConfig(ctx context.Context) (*ClientConfig, error)
+	// Client config metadata (UI/admin preferences blob — bypasses config.json sync)
+	GetClientMetadata(ctx context.Context) (map[string]any, error)
+	UpdateClientMetadata(ctx context.Context, patch map[string]any) error
 
 	// Framework config CRUD
 	UpdateFrameworkConfig(ctx context.Context, config *tables.TableFrameworkConfig) error

--- a/framework/configstore/tables/clientconfig.go
+++ b/framework/configstore/tables/clientconfig.go
@@ -15,6 +15,7 @@ type TableClientConfig struct {
 	AllowedOriginsJSON                    string `gorm:"type:text" json:"-"` // JSON serialized []string
 	AllowedHeadersJSON                    string `gorm:"type:text" json:"-"` // JSON serialized []string
 	HeaderFilterConfigJSON                string `gorm:"type:text" json:"-"` // JSON serialized GlobalHeaderFilterConfig
+	MetadataJSON                          string `gorm:"type:text" json:"-"` // JSON serialized map[string]any for UI/admin preferences (e.g. onboarding_dismissed). Bypasses config.json sync.
 	InitialPoolSize                       int    `gorm:"default:300" json:"initial_pool_size"`
 	EnableLogging                         *bool  `gorm:"default:true" json:"enable_logging"`
 	DisableContentLogging                 bool   `gorm:"default:false" json:"disable_content_logging"` // DisableContentLogging controls whether sensitive content (inputs, outputs, embeddings, etc.) is logged
@@ -61,6 +62,7 @@ type TableClientConfig struct {
 	LoggingHeaders     []string                  `gorm:"-" json:"logging_headers,omitempty"`
 	WhitelistedRoutes  []string                  `gorm:"-" json:"whitelisted_routes,omitempty"`
 	HeaderFilterConfig *GlobalHeaderFilterConfig `gorm:"-" json:"header_filter_config,omitempty"`
+	Metadata           map[string]any            `gorm:"-" json:"metadata,omitempty"`
 }
 
 // TableName sets the table name for each model
@@ -137,6 +139,18 @@ func (cc *TableClientConfig) BeforeSave(tx *gorm.DB) error {
 		cc.HeaderFilterConfigJSON = ""
 	}
 
+	// Metadata is preserved when nil — callers that DELETE+CREATE through
+	// UpdateClientConfig must carry MetadataJSON forward explicitly, since the
+	// API ClientConfig does not expose Metadata. A nil Metadata here means
+	// "leave whatever MetadataJSON the caller set untouched."
+	if cc.Metadata != nil {
+		data, err := json.Marshal(cc.Metadata)
+		if err != nil {
+			return err
+		}
+		cc.MetadataJSON = string(data)
+	}
+
 	return nil
 }
 
@@ -184,6 +198,16 @@ func (cc *TableClientConfig) AfterFind(tx *gorm.DB) error {
 			return err
 		}
 		cc.HeaderFilterConfig = &headerFilterConfig
+	}
+
+	if cc.MetadataJSON != "" {
+		var metadata map[string]any
+		if err := json.Unmarshal([]byte(cc.MetadataJSON), &metadata); err != nil {
+			return err
+		}
+		cc.Metadata = metadata
+	} else {
+		cc.Metadata = nil
 	}
 
 	return nil

--- a/framework/configstore/tables/clientconfig_test.go
+++ b/framework/configstore/tables/clientconfig_test.go
@@ -1,0 +1,34 @@
+package tables
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableClientConfigAfterFindReplacesMetadata(t *testing.T) {
+	config := &TableClientConfig{
+		MetadataJSON: `{"theme":"light"}`,
+		Metadata: map[string]any{
+			"stale": "value",
+			"theme": "dark",
+		},
+	}
+
+	require.NoError(t, config.AfterFind(nil))
+
+	assert.Equal(t, map[string]any{"theme": "light"}, config.Metadata)
+}
+
+func TestTableClientConfigAfterFindClearsMetadataWhenEmpty(t *testing.T) {
+	config := &TableClientConfig{
+		Metadata: map[string]any{
+			"stale": "value",
+		},
+	}
+
+	require.NoError(t, config.AfterFind(nil))
+
+	assert.Nil(t, config.Metadata)
+}

--- a/framework/configstore/tables/config.go
+++ b/framework/configstore/tables/config.go
@@ -12,6 +12,12 @@ const (
 	ConfigHeaderFilterKey           = "header_filter_config"
 )
 
+// Keys for the ClientConfig.MetadataJSON blob.
+// These live inside the metadata JSON map on config_client, not as governance_config rows.
+const (
+	MetadataKeyOnboardingDismissed = "onboarding_dismissed"
+)
+
 // RestartRequiredConfig represents the restart required configuration
 // This is set when a config change requires a server restart to take effect
 type RestartRequiredConfig struct {

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -75,6 +75,7 @@ func NewConfigHandler(configManager ConfigManager, store *lib.Config) *ConfigHan
 func (h *ConfigHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
 	r.GET("/api/config", lib.ChainMiddlewares(h.getConfig, middlewares...))
 	r.PUT("/api/config", lib.ChainMiddlewares(h.updateConfig, middlewares...))
+	r.POST("/api/config/metadata", lib.ChainMiddlewares(h.updateMetadata, middlewares...))
 	r.GET("/api/version", lib.ChainMiddlewares(h.getVersion, middlewares...))
 	r.GET("/api/proxy-config", lib.ChainMiddlewares(h.getProxyConfig, middlewares...))
 	r.PUT("/api/proxy-config", lib.ChainMiddlewares(h.updateProxyConfig, middlewares...))
@@ -190,8 +191,46 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 		} else if restartConfig != nil {
 			mapConfig["restart_required"] = restartConfig
 		}
+		// Fetching UI/admin metadata blob (onboarding_dismissed, etc.).
+		// This is a free-form key/value store that bypasses config.json sync.
+		if metadata, err := h.store.ConfigStore.GetClientMetadata(ctx); err != nil {
+			if !errors.Is(err, configstore.ErrNotFound) {
+				logger.Warn("failed to get client metadata from store: %v", err)
+			}
+		} else if len(metadata) > 0 {
+			mapConfig["metadata"] = metadata
+		}
 	}
 	SendJSON(ctx, mapConfig)
+}
+
+// updateMetadata handles POST /api/config/metadata - merges a JSON object of
+// key/value pairs into the ClientConfig metadata blob. Keys with a nil value
+// are removed. Intended for UI/admin preferences (onboarding state, dismissed
+// tooltips, etc.) and is auth-gated by the same middleware as the rest of /api/config.
+func (h *ConfigHandler) updateMetadata(ctx *fasthttp.RequestCtx) {
+	if h.store.ConfigStore == nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, "config store not available")
+		return
+	}
+	var patch map[string]any
+	if err := json.Unmarshal(ctx.PostBody(), &patch); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("invalid request format: %v", err))
+		return
+	}
+	if len(patch) == 0 {
+		SendError(ctx, fasthttp.StatusBadRequest, "patch body must contain at least one key")
+		return
+	}
+	if err := h.store.ConfigStore.UpdateClientMetadata(ctx, patch); err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusConflict, fmt.Sprintf("failed to update metadata: %v", err))
+			return
+		}
+		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to update metadata: %v", err))
+		return
+	}
+	SendJSON(ctx, map[string]any{"success": true})
 }
 
 // updateConfig updates the core configuration settings.

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -460,6 +460,14 @@ func (m *MockConfigStore) GetClientConfig(ctx context.Context) (*configstore.Cli
 	return m.clientConfig, nil
 }
 
+func (m *MockConfigStore) GetClientMetadata(ctx context.Context) (map[string]any, error) {
+	return map[string]any{}, nil
+}
+
+func (m *MockConfigStore) UpdateClientMetadata(ctx context.Context, patch map[string]any) error {
+	return nil
+}
+
 // Provider config
 func (m *MockConfigStore) UpdateProvidersConfig(ctx context.Context, providers map[schemas.ModelProvider]configstore.ProviderConfig, tx ...*gorm.DB) error {
 	m.providers = providers

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -463,6 +463,7 @@ export interface BifrostConfig {
 	is_cache_connected: boolean;
 	is_logs_connected: boolean;
 	auth_token?: string;
+	metadata?: Record<string, unknown>;
 }
 
 export interface CompatConfig {


### PR DESCRIPTION
## Summary

Adds a `metadata_json` column to `config_client` that stores a free-form JSON blob of UI/admin preferences (e.g. `onboarding_dismissed`). This blob is intentionally excluded from the `ClientConfig` API struct so that `config.json` sync can never overwrite it. A new `POST /api/config/metadata` endpoint allows callers to merge patches into the blob, and `GET /api/config` now includes the metadata in its response.

## Changes

- Added `migrationAddClientConfigMetadataColumn` to create the `metadata_json` column on `config_client` with a rollback path.
- Added `MetadataJSON` (persisted) and `Metadata` (virtual) fields to `TableClientConfig`, with `BeforeSave`/`AfterFind` hooks to marshal/unmarshal the JSON blob.
- `UpdateClientConfig` now reads and preserves `MetadataJSON` inside its DELETE+CREATE transaction so config writes never clobber UI preferences.
- Added `GetClientMetadata` and `UpdateClientMetadata` to `RDBConfigStore`. `UpdateClientMetadata` performs a targeted `UPDATE` on `metadata_json` only, merging the patch and removing keys whose value is `nil`.
- Exposed both methods on the `ConfigStore` interface.
- Registered `POST /api/config/metadata` in the HTTP transport; `GET /api/config` now appends the metadata blob to the response when non-empty.
- Added `MetadataKeyOnboardingDismissed` constant as the first typed key in the metadata blob.
- Added `metadata` field to the `BifrostConfig` TypeScript type.
- Added stub implementations of `GetClientMetadata` and `UpdateClientMetadata` to `MockConfigStore` in tests.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./transports/bifrost-http/...

# Verify migration runs cleanly on a fresh or existing DB by starting the server
# and confirming the metadata_json column exists on config_client.

# Set a metadata key
curl -X POST http://localhost:8080/api/config/metadata \
  -H "Content-Type: application/json" \
  -d '{"onboarding_dismissed": true}'
# Expected: {"success": true}

# Read it back
curl http://localhost:8080/api/config
# Expected: response includes "metadata": {"onboarding_dismissed": true}

# Clear a key by passing null
curl -X POST http://localhost:8080/api/config/metadata \
  -H "Content-Type: application/json" \
  -d '{"onboarding_dismissed": null}'
# Expected: {"success": true}, metadata key removed

# UI
cd ui
pnpm i
pnpm build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `POST /api/config/metadata` endpoint is gated by the same middleware chain as the rest of `/api/config`, so it inherits existing auth controls. The metadata blob is a free-form store; callers should avoid writing secrets or PII into it, as it is returned in plaintext via `GET /api/config`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable