### PR TITLE
feat: add configurable `model_parameters_url` to framework config

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -755,6 +755,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
   if err := migrationAddFeatureFlagsTable(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddModelParametersURLColumn(ctx, db); err != nil {
+		return err
+	}
 	if err := migrationAddClientConfigMetadataColumn(ctx, db); err != nil {
 		return err
 	}
@@ -7797,6 +7800,34 @@ func migrationAddVKAccessProfileIDColumn(ctx context.Context, db *gorm.DB) error
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_vk_access_profile_id_column migration: %s", err.Error())
+	}
+	return nil
+}
+
+func migrationAddModelParametersURLColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_model_parameters_url_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if !mig.HasColumn(&tables.TableFrameworkConfig{}, "model_parameters_url") {
+				if err := mig.AddColumn(&tables.TableFrameworkConfig{}, "ModelParametersURL"); err != nil {
+					return fmt.Errorf("failed to add model_parameters_url column to framework_configs: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mig := tx.Migrator()
+			if mig.HasColumn(&tables.TableFrameworkConfig{}, "model_parameters_url") {
+				return mig.DropColumn(&tables.TableFrameworkConfig{}, "model_parameters_url")
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_model_parameters_url_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/tables/framework.go
+++ b/framework/configstore/tables/framework.go
@@ -6,6 +6,7 @@ type TableFrameworkConfig struct {
 	ID                  uint    `gorm:"primaryKey;autoIncrement" json:"id"`
 	PricingURL          *string `gorm:"type:text" json:"pricing_url"`
 	PricingSyncInterval *int64  `gorm:"" json:"pricing_sync_interval"`
+	ModelParametersURL  *string `gorm:"type:text" json:"model_parameters_url"`
 }
 
 // TableName sets the table name for each model

--- a/framework/modelcatalog/config.go
+++ b/framework/modelcatalog/config.go
@@ -26,4 +26,5 @@ const (
 type Config struct {
 	PricingURL          *string `json:"pricing_url,omitempty"`
 	PricingSyncInterval *int64  `json:"pricing_sync_interval,omitempty"` // seconds
+	ModelParametersURL  *string `json:"model_parameters_url,omitempty"`
 }

--- a/framework/modelcatalog/main.go
+++ b/framework/modelcatalog/main.go
@@ -22,10 +22,11 @@ type ModelCatalog struct {
 	logger schemas.Logger
 
 	// Configuration fields (protected by syncMu)
-	pricingURL   string
-	syncInterval time.Duration
-	lastSyncedAt time.Time
-	syncMu       sync.RWMutex
+	pricingURL         string
+	modelParametersURL string
+	syncInterval       time.Duration
+	lastSyncedAt       time.Time
+	syncMu             sync.RWMutex
 
 	shouldSyncGate func(ctx context.Context) bool
 	afterSyncHook  func(ctx context.Context)
@@ -69,6 +70,10 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 	if config.PricingURL != nil {
 		pricingURL = *config.PricingURL
 	}
+	modelParametersURL := DefaultModelParametersURL
+	if config.ModelParametersURL != nil && *config.ModelParametersURL != "" {
+		modelParametersURL = *config.ModelParametersURL
+	}
 	syncInterval := DefaultSyncInterval
 	if config.PricingSyncInterval != nil {
 		syncInterval = time.Duration(*config.PricingSyncInterval) * time.Second
@@ -81,6 +86,7 @@ func Init(ctx context.Context, config *Config, configStore configstore.ConfigSto
 
 	mc := &ModelCatalog{
 		pricingURL:             pricingURL,
+		modelParametersURL:     modelParametersURL,
 		syncInterval:           syncInterval,
 		configStore:            configStore,
 		logger:                 logger,
@@ -272,6 +278,11 @@ func (mc *ModelCatalog) UpdateSyncConfig(ctx context.Context, config *Config) er
 		mc.pricingURL = *config.PricingURL
 	}
 
+	mc.modelParametersURL = DefaultModelParametersURL
+	if config.ModelParametersURL != nil && *config.ModelParametersURL != "" {
+		mc.modelParametersURL = *config.ModelParametersURL
+	}
+
 	mc.syncInterval = DefaultSyncInterval
 	if config.PricingSyncInterval != nil {
 		mc.syncInterval = time.Duration(*config.PricingSyncInterval) * time.Second
@@ -352,6 +363,12 @@ func (mc *ModelCatalog) getPricingURL() string {
 	mc.syncMu.RLock()
 	defer mc.syncMu.RUnlock()
 	return mc.pricingURL
+}
+
+func (mc *ModelCatalog) getModelParametersURL() string {
+	mc.syncMu.RLock()
+	defer mc.syncMu.RUnlock()
+	return mc.modelParametersURL
 }
 
 // IsRequestTypeSupported checks if a model supports chat completion.

--- a/framework/modelcatalog/sync.go
+++ b/framework/modelcatalog/sync.go
@@ -477,7 +477,7 @@ func (mc *ModelCatalog) syncModelParameters(ctx context.Context) error {
 func (mc *ModelCatalog) loadModelParametersFromURL(ctx context.Context) (map[string]json.RawMessage, error) {
 	client := &http.Client{}
 	client.Timeout = DefaultModelParametersTimeout
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, DefaultModelParametersURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, mc.getModelParametersURL(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
 	}

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -282,6 +282,21 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			return
 		}
 	}
+	if payload.FrameworkConfig.ModelParametersURL != nil && *payload.FrameworkConfig.ModelParametersURL != "" && *payload.FrameworkConfig.ModelParametersURL != modelcatalog.DefaultModelParametersURL {
+		urlCheckClient := &http.Client{Timeout: 60 * time.Second}
+		resp, err := urlCheckClient.Get(*payload.FrameworkConfig.ModelParametersURL)
+		if err != nil {
+			logger.Warn("failed to check the accessibility of the model parameters URL: %v", err)
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to check the accessibility of the model parameters URL: %v", err))
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			logger.Warn("failed to check the accessibility of the model parameters URL: %v", resp.StatusCode)
+			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to check the accessibility of the model parameters URL: %v", resp.StatusCode))
+			return
+		}
+	}
 
 	// Checking the pricing sync interval
 	if payload.FrameworkConfig.PricingSyncInterval != nil && *payload.FrameworkConfig.PricingSyncInterval <= 0 {
@@ -535,6 +550,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			ID:                  0,
 			PricingURL:          bifrost.Ptr(modelcatalog.DefaultPricingURL),
 			PricingSyncInterval: bifrost.Ptr(int64(modelcatalog.DefaultSyncInterval.Seconds())),
+			ModelParametersURL:  bifrost.Ptr(modelcatalog.DefaultModelParametersURL),
 		}
 	}
 	// Handling individual nil cases
@@ -543,6 +559,9 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 	}
 	if frameworkConfig.PricingSyncInterval == nil {
 		frameworkConfig.PricingSyncInterval = bifrost.Ptr(int64(modelcatalog.DefaultSyncInterval.Seconds()))
+	}
+	if frameworkConfig.ModelParametersURL == nil {
+		frameworkConfig.ModelParametersURL = bifrost.Ptr(modelcatalog.DefaultModelParametersURL)
 	}
 	// Updating framework config
 	shouldReloadFrameworkConfig := false
@@ -570,6 +589,31 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			shouldReloadFrameworkConfig = true
 		}
 	}
+	if payload.FrameworkConfig.ModelParametersURL != nil {
+		effectiveModelParamsURL := *payload.FrameworkConfig.ModelParametersURL
+		if effectiveModelParamsURL == "" {
+			effectiveModelParamsURL = modelcatalog.DefaultModelParametersURL
+		}
+		if effectiveModelParamsURL != *frameworkConfig.ModelParametersURL {
+			if effectiveModelParamsURL != modelcatalog.DefaultModelParametersURL {
+				urlCheckClient := &http.Client{Timeout: 60 * time.Second}
+				resp, err := urlCheckClient.Get(effectiveModelParamsURL)
+				if err != nil {
+					logger.Warn("failed to check the accessibility of the model parameters URL: %v", err)
+					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to check the accessibility of the model parameters URL: %v", err))
+					return
+				}
+				defer resp.Body.Close()
+				if resp.StatusCode != http.StatusOK {
+					logger.Warn("failed to check the accessibility of the model parameters URL: %v", resp.StatusCode)
+					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to check the accessibility of the model parameters URL: %v", resp.StatusCode))
+					return
+				}
+			}
+			frameworkConfig.ModelParametersURL = &effectiveModelParamsURL
+			shouldReloadFrameworkConfig = true
+		}
+	}
 	// Reload config if required
 	if shouldReloadFrameworkConfig {
 		var syncSeconds int64
@@ -582,6 +626,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			Pricing: &modelcatalog.Config{
 				PricingURL:          frameworkConfig.PricingURL,
 				PricingSyncInterval: &syncSeconds,
+				ModelParametersURL:  frameworkConfig.ModelParametersURL,
 			},
 		}
 		// Saving framework config

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3004,31 +3004,24 @@ func ResolveFrameworkPricingConfig(
 	fileConfig *framework.FrameworkConfig,
 ) (*configstoreTables.TableFrameworkConfig, *modelcatalog.Config, bool) {
 	defaultPricingURL := modelcatalog.DefaultPricingURL
+	defaultModelParametersURL := modelcatalog.DefaultModelParametersURL
 	defaultSyncSeconds := int64(modelcatalog.DefaultSyncInterval.Seconds())
 
 	// --- Phase 1: parse and validate file config ---
 
 	filePricingURL := (*string)(nil)
+	fileModelParametersURL := (*string)(nil)
 	fileSyncSeconds := (*int64)(nil)
-	skipURLBackfill := false // prevent DB backfill of unresolved env references
+	skipURLBackfill := false              // prevent DB backfill of unresolved env references
+	skipModelParamsURLBackfill := false
 	if fileConfig != nil && fileConfig.Pricing != nil {
 		if fileConfig.Pricing.PricingURL != nil {
 			raw := *fileConfig.Pricing.PricingURL
-			// Explicitly check for the "env." prefix before invoking the env lookup.
-			// This makes the substitution contract unambiguous: a URL that does not
-			// begin with "env." is always used verbatim, regardless of what
-			// envutils.ProcessEnvValue might do internally in the future.
 			if strings.HasPrefix(raw, "env.") {
 				resolvedURL, err := envutils.ProcessEnvValue(raw)
 				if err != nil {
-					// Named env variable not found — preserve the original "env.VAR"
-					// string so the downstream HTTP fetch fails visibly rather than
-					// silently falling back to the built-in default URL.
 					logger.Warn("pricing_url: env variable not found (%v); keeping original value %q", err, raw)
 					filePricingURL = fileConfig.Pricing.PricingURL
-					// Do NOT persist the unresolved "env.VAR" literal to DB.
-					// If we did, a later restart would read the literal from DB
-					// (which is authoritative) and never attempt env resolution again.
 					skipURLBackfill = true
 				} else {
 					filePricingURL = &resolvedURL
@@ -3037,14 +3030,32 @@ func ResolveFrameworkPricingConfig(
 				filePricingURL = &raw
 			}
 		}
+		if fileConfig.Pricing.ModelParametersURL != nil {
+			raw := strings.TrimSpace(*fileConfig.Pricing.ModelParametersURL)
+			if raw == "" {
+				// Blank is treated as "not set"; fall back to default.
+			} else if strings.HasPrefix(raw, "env.") {
+				resolvedURL, err := envutils.ProcessEnvValue(raw)
+				if err != nil {
+					logger.Warn("model_parameters_url: env variable not found (%v); keeping original value %q", err, raw)
+					fileModelParametersURL = fileConfig.Pricing.ModelParametersURL
+					skipModelParamsURLBackfill = true
+				} else {
+					resolved := strings.TrimSpace(resolvedURL)
+					if resolved != "" {
+						fileModelParametersURL = &resolved
+					}
+				}
+			} else {
+				fileModelParametersURL = &raw
+			}
+		}
 		if fileConfig.Pricing.PricingSyncInterval != nil {
 			val := *fileConfig.Pricing.PricingSyncInterval
 			switch {
 			case val <= 0:
-				// Zero or negative values are meaningless for a sync eligibility threshold.
 				logger.Warn("pricing_sync_interval in config.json is invalid (%d seconds), ignoring — using default (%d seconds)", val, defaultSyncSeconds)
 			case val < modelcatalog.MinimumPricingSyncIntervalSec:
-				// Accept but clamp to the schema-declared minimum of 3600 s (1 hour).
 				clamped := modelcatalog.MinimumPricingSyncIntervalSec
 				logger.Warn("pricing_sync_interval in config.json is below minimum (%d seconds), clamping to %d seconds", val, clamped)
 				fileSyncSeconds = &clamped
@@ -3057,11 +3068,16 @@ func ResolveFrameworkPricingConfig(
 	// --- Phase 2: apply file config over defaults ---
 
 	resolvedPricingURL := &defaultPricingURL
+	resolvedModelParametersURL := &defaultModelParametersURL
 	resolvedSyncSeconds := &defaultSyncSeconds
 
 	if filePricingURL != nil {
 		resolvedPricingURL = filePricingURL
 		logger.Debug("pricing_url resolved from file")
+	}
+	if fileModelParametersURL != nil {
+		resolvedModelParametersURL = fileModelParametersURL
+		logger.Debug("model_parameters_url resolved from file")
 	}
 	if fileSyncSeconds != nil {
 		resolvedSyncSeconds = fileSyncSeconds
@@ -3077,21 +3093,19 @@ func ResolveFrameworkPricingConfig(
 		if dbConfig.PricingURL != nil {
 			resolvedPricingURL = dbConfig.PricingURL
 		} else if !skipURLBackfill {
-			// DB row exists but URL field is NULL — backfill with resolved value.
-			// Skip backfill when the resolved URL is an unresolved env reference
-			// to prevent persisting "env.VAR" literals into the DB.
+			needsDBUpdate = true
+		}
+		if dbConfig.ModelParametersURL != nil && *dbConfig.ModelParametersURL != "" {
+			resolvedModelParametersURL = dbConfig.ModelParametersURL
+		} else if !skipModelParamsURLBackfill {
 			needsDBUpdate = true
 		}
 		if dbConfig.PricingSyncInterval != nil {
 			val := *dbConfig.PricingSyncInterval
 			if val <= 0 {
-				// Corrupted or legacy zero written by the pre-fix bug.
-				// Ignore and backfill the DB with the correctly resolved value.
 				logger.Warn("pricing_sync_interval in DB is corrupted (%d seconds), ignoring — backfilling with %d seconds", val, *resolvedSyncSeconds)
 				needsDBUpdate = true
 			} else if val < modelcatalog.MinimumPricingSyncIntervalSec {
-				// DB has a positive value below the minimum — clamp and backfill,
-				// consistent with the file-path validation in Phase 1.
 				logger.Warn("pricing_sync_interval in DB is below minimum (%d seconds), clamping to %d seconds — backfilling", val, modelcatalog.MinimumPricingSyncIntervalSec)
 				clamped := modelcatalog.MinimumPricingSyncIntervalSec
 				resolvedSyncSeconds = &clamped
@@ -3103,22 +3117,18 @@ func ResolveFrameworkPricingConfig(
 				resolvedSyncSeconds = dbConfig.PricingSyncInterval
 			}
 		} else {
-			// DB row exists but interval field is NULL — backfill.
 			needsDBUpdate = true
 		}
 	}
 
 	// --- Phase 4: invariant assertion ---
-	//
-	// resolvedPricingURL and resolvedSyncSeconds are initialised to non-nil local
-	// variable addresses in Phase 2 and only ever reassigned from non-nil DB/file
-	// pointers. They cannot be nil here under any reachable code path.
-	// The checks below are a last-resort safety net for future refactors that
-	// might break that guarantee. If they fire, it is a programming error, not a
-	// runtime condition — hence the explicit "invariant violation" message.
 	if resolvedPricingURL == nil {
 		logger.Warn("invariant violation: pricing_url resolved to nil — falling back to default %q", defaultPricingURL)
 		resolvedPricingURL = &defaultPricingURL
+	}
+	if resolvedModelParametersURL == nil {
+		logger.Warn("invariant violation: model_parameters_url resolved to nil — falling back to default %q", defaultModelParametersURL)
+		resolvedModelParametersURL = &defaultModelParametersURL
 	}
 	if resolvedSyncSeconds == nil {
 		logger.Warn("invariant violation: pricing_sync_interval resolved to nil — falling back to default %d seconds", defaultSyncSeconds)
@@ -3129,9 +3139,11 @@ func ResolveFrameworkPricingConfig(
 			ID:                  configID,
 			PricingURL:          resolvedPricingURL,
 			PricingSyncInterval: resolvedSyncSeconds,
+			ModelParametersURL:  resolvedModelParametersURL,
 		}, &modelcatalog.Config{
 			PricingURL:          resolvedPricingURL,
 			PricingSyncInterval: resolvedSyncSeconds,
+			ModelParametersURL:  resolvedModelParametersURL,
 		}, needsDBUpdate
 }
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -16181,6 +16181,7 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 	initTestLogger()
 	defaultURL := modelcatalog.DefaultPricingURL
 	defaultSyncSeconds := int64(modelcatalog.DefaultSyncInterval.Seconds())
+	defaultModelParamsURL := modelcatalog.DefaultModelParametersURL
 	fileURL := "https://example.com/pricing.json"
 	fileSyncSeconds := int64((12 * time.Hour).Seconds())
 	dbURL := "https://db.example.com/pricing.json"
@@ -16191,6 +16192,7 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 			ID:                  7,
 			PricingURL:          &dbURL,
 			PricingSyncInterval: &dbSyncSeconds,
+			ModelParametersURL:  &defaultModelParamsURL,
 		}
 		fileConfig := &framework.FrameworkConfig{
 			Pricing: &modelcatalog.Config{
@@ -16380,9 +16382,11 @@ func TestResolveFrameworkPricingConfig(t *testing.T) {
 			require.NotNil(t, tableOut, "TableFrameworkConfig must never be nil")
 			require.NotNil(t, tableOut.PricingURL, "PricingURL must never be nil")
 			require.NotNil(t, tableOut.PricingSyncInterval, "PricingSyncInterval must never be nil")
+			require.NotNil(t, tableOut.ModelParametersURL, "ModelParametersURL must never be nil")
 			require.NotNil(t, catalogOut, "modelcatalog.Config must never be nil")
 			require.NotNil(t, catalogOut.PricingURL, "Config.PricingURL must never be nil")
 			require.NotNil(t, catalogOut.PricingSyncInterval, "Config.PricingSyncInterval must never be nil")
+			require.NotNil(t, catalogOut.ModelParametersURL, "Config.ModelParametersURL must never be nil")
 		}
 	})
 

--- a/ui/app/clientLayout.tsx
+++ b/ui/app/clientLayout.tsx
@@ -73,7 +73,7 @@ export function ClientLayout({ children }: { children: React.ReactNode }) {
 	return (
 		<ProgressProvider>
 			<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-				<Toaster />
+				<Toaster closeButton />
 				<ReduxProvider>
 					<NuqsAdapter>
 						<RbacProvider>

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -389,3 +389,17 @@ div.content-container:has(.no-border-parent) #trial-notification-banner {
 [data-streamdown="code-block-body"] {
 	@apply rounded-sm!;
 }
+
+/* Move Sonner toast close button to top-right */
+[data-sonner-toaster][dir="ltr"],
+[data-sonner-toaster] {
+	--toast-close-button-start: unset !important;
+	--toast-close-button-end: 0 !important;
+	--toast-close-button-transform: translate(35%, -35%) !important;
+}
+
+[data-sonner-toast][data-styled="true"] [data-close-button] {
+	left: auto !important;
+	right: 0 !important;
+	transform: translate(35%, -35%) !important;
+}

--- a/ui/app/pprof/layout.tsx
+++ b/ui/app/pprof/layout.tsx
@@ -13,7 +13,7 @@ function PprofLayout({ children }: { children: React.ReactNode }) {
 
 	return (
 		<ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
-			<Toaster />
+			<Toaster closeButton />
 			<ReduxProvider>
 				<div className="min-h-screen bg-zinc-950 text-zinc-100">{children}</div>
 			</ReduxProvider>

--- a/ui/app/workspace/config/views/modelSettingsView.tsx
+++ b/ui/app/workspace/config/views/modelSettingsView.tsx
@@ -11,6 +11,7 @@ import { toast } from "sonner";
 interface ModelSettingsFormData {
 	pricing_datasheet_url: string;
 	pricing_sync_interval_hours: number;
+	model_parameters_url: string;
 	routing_chain_max_depth: number;
 }
 
@@ -32,6 +33,7 @@ export default function ModelSettingsView() {
 		defaultValues: {
 			pricing_datasheet_url: "",
 			pricing_sync_interval_hours: 24,
+			model_parameters_url: "",
 			routing_chain_max_depth: DefaultCoreConfig.routing_chain_max_depth,
 		},
 	});
@@ -43,18 +45,21 @@ export default function ModelSettingsView() {
 		reset({
 			pricing_datasheet_url: frameworkConfig?.pricing_url || "",
 			pricing_sync_interval_hours: Math.round((frameworkConfig?.pricing_sync_interval ?? 0) / 3600) || 24,
+			model_parameters_url: frameworkConfig?.model_parameters_url || "",
 			routing_chain_max_depth: clientConfig?.routing_chain_max_depth ?? DefaultCoreConfig.routing_chain_max_depth,
 		});
-	}, [frameworkConfig?.pricing_url, frameworkConfig?.pricing_sync_interval, clientConfig?.routing_chain_max_depth, isDirty, reset]);
+	}, [frameworkConfig?.pricing_url, frameworkConfig?.pricing_sync_interval, frameworkConfig?.model_parameters_url, clientConfig?.routing_chain_max_depth, isDirty, reset]);
 
 	const hasChanges = useMemo(() => {
 		if (!bifrostConfig || !isDirty) return false;
 		const serverUrl = frameworkConfig?.pricing_url || "";
 		const serverInterval = Math.round((frameworkConfig?.pricing_sync_interval ?? 0) / 3600);
+		const serverModelParamsUrl = frameworkConfig?.model_parameters_url || "";
 		const serverDepth = clientConfig?.routing_chain_max_depth ?? DefaultCoreConfig.routing_chain_max_depth;
 		return (
 			formValues.pricing_datasheet_url !== serverUrl ||
 			formValues.pricing_sync_interval_hours !== serverInterval ||
+			formValues.model_parameters_url !== serverModelParamsUrl ||
 			formValues.routing_chain_max_depth !== serverDepth
 		);
 	}, [bifrostConfig, frameworkConfig, clientConfig, formValues, isDirty]);
@@ -68,6 +73,7 @@ export default function ModelSettingsView() {
 					id: bifrostConfig?.framework_config.id || 0,
 					pricing_url: data.pricing_datasheet_url,
 					pricing_sync_interval: data.pricing_sync_interval_hours * 3600,
+					model_parameters_url: data.model_parameters_url,
 				},
 				client_config: {
 					...clientConfig!,
@@ -125,6 +131,34 @@ export default function ModelSettingsView() {
 							className={errors.pricing_datasheet_url ? "border-destructive" : ""}
 						/>
 						{errors.pricing_datasheet_url && <p className="text-destructive text-sm">{errors.pricing_datasheet_url.message}</p>}
+					</div>
+
+					{/* Model Parameters URL */}
+					<div className="space-y-2 rounded-sm border p-4">
+						<div className="space-y-0.5">
+							<Label htmlFor="model-parameters-url">Model Parameters URL</Label>
+							<p className="text-muted-foreground text-sm">URL to a custom model parameters datasheet. Leave empty to use default.</p>
+						</div>
+						<Input
+							id="model-parameters-url"
+							type="text"
+							placeholder="https://example.com/model-parameters.json"
+							data-testid="model-parameters-url-input"
+							{...register("model_parameters_url", {
+								pattern: {
+									value: /^(https?:\/\/)?((localhost|(\d{1,3}\.){3}\d{1,3})(:\d+)?|([\da-z\.-]+)\.([a-z\.]{2,6}))[\/\w \.-]*\/?$/,
+									message: "Please enter a valid URL.",
+								},
+								validate: {
+									checkIfHttp: (value) => {
+										if (!value) return true;
+										return value.startsWith("http://") || value.startsWith("https://") || "URL must start with http:// or https://";
+									},
+								},
+							})}
+							className={errors.model_parameters_url ? "border-destructive" : ""}
+						/>
+						{errors.model_parameters_url && <p className="text-destructive text-sm">{errors.model_parameters_url.message}</p>}
 					</div>
 
 					{/* Pricing Sync Interval */}

--- a/ui/app/workspace/config/views/pricingConfigView.tsx
+++ b/ui/app/workspace/config/views/pricingConfigView.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 interface PricingFormData {
 	pricing_datasheet_url: string;
 	pricing_sync_interval_hours: number;
+	model_parameters_url: string;
 }
 
 export default function PricingConfigView() {
@@ -29,6 +30,7 @@ export default function PricingConfigView() {
 		defaultValues: {
 			pricing_datasheet_url: "",
 			pricing_sync_interval_hours: 24,
+			model_parameters_url: "",
 		},
 	});
 
@@ -39,6 +41,7 @@ export default function PricingConfigView() {
 			reset({
 				pricing_datasheet_url: config.pricing_url || "",
 				pricing_sync_interval_hours: Math.round(config.pricing_sync_interval / 3600) || 24,
+				model_parameters_url: config.model_parameters_url || "",
 			});
 		}
 	}, [config, bifrostConfig, reset]);
@@ -47,7 +50,12 @@ export default function PricingConfigView() {
 		if (!config || !isDirty) return false;
 		const serverUrl = config.pricing_url || "";
 		const serverInterval = Math.round(config.pricing_sync_interval / 3600);
-		return formValues.pricing_datasheet_url !== serverUrl || formValues.pricing_sync_interval_hours !== serverInterval;
+		const serverModelParamsUrl = config.model_parameters_url || "";
+		return (
+			formValues.pricing_datasheet_url !== serverUrl ||
+			formValues.pricing_sync_interval_hours !== serverInterval ||
+			formValues.model_parameters_url !== serverModelParamsUrl
+		);
 	}, [config, formValues, isDirty]);
 
 	const onSubmit = async (data: PricingFormData) => {
@@ -59,6 +67,7 @@ export default function PricingConfigView() {
 					id: bifrostConfig?.framework_config.id || 0,
 					pricing_url: data.pricing_datasheet_url,
 					pricing_sync_interval: data.pricing_sync_interval_hours * 3600,
+					model_parameters_url: data.model_parameters_url,
 				},
 			}).unwrap();
 			toast.success("Pricing configuration updated successfully.");
@@ -112,6 +121,34 @@ export default function PricingConfigView() {
 							className={errors.pricing_datasheet_url ? "border-destructive" : ""}
 						/>
 						{errors.pricing_datasheet_url && <p className="text-destructive text-sm">{errors.pricing_datasheet_url.message}</p>}
+					</div>
+
+					{/* Model Parameters URL */}
+					<div className="space-y-2 rounded-sm border p-4">
+						<div className="space-y-0.5">
+							<Label htmlFor="model-parameters-url">Model Parameters URL</Label>
+							<p className="text-muted-foreground text-sm">URL to a custom model parameters datasheet. Leave empty to use default.</p>
+						</div>
+						<Input
+							id="model-parameters-url"
+							type="text"
+							placeholder="https://example.com/model-parameters.json"
+							data-testid="model-parameters-url-input"
+							{...register("model_parameters_url", {
+								pattern: {
+									value: /^(https?:\/\/)?((localhost|(\d{1,3}\.){3}\d{1,3})(:\d+)?|([\da-z\.-]+)\.([a-z\.]{2,6}))([\/\w \.-]*)*\/?$/,
+									message: "Please enter a valid URL.",
+								},
+								validate: {
+									checkIfHttp: (value) => {
+										if (!value) return true;
+										return value.startsWith("http://") || value.startsWith("https://") || "URL must start with http:// or https://";
+									},
+								},
+							})}
+							className={errors.model_parameters_url ? "border-destructive" : ""}
+						/>
+						{errors.model_parameters_url && <p className="text-destructive text-sm">{errors.model_parameters_url.message}</p>}
 					</div>
 
 					{/* Pricing Sync Interval */}

--- a/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/scopedPricingOverridesView.tsx
@@ -32,6 +32,61 @@ import { toast } from "sonner";
 import PricingOverrideSheet from "./pricingOverrideSheet";
 import { PricingOverridesEmptyState } from "./pricingOverridesEmptyState";
 
+function PricingOverrideActionsMenu({
+	row,
+	onEdit,
+	onDelete,
+}: {
+	row: PricingOverride;
+	onEdit: (row: PricingOverride) => void;
+	onDelete: (row: PricingOverride) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8"
+					aria-label={`Actions for pricing override ${row.name || row.id}`}
+					data-testid={`pricing-override-actions-btn-${row.id}`}
+				>
+					<MoreHorizontal className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					data-testid={`pricing-override-edit-btn-${row.id}`}
+					className="cursor-pointer"
+					onSelect={(e) => {
+						e.preventDefault();
+						onEdit(row);
+						setIsOpen(false);
+					}}
+				>
+					<Edit className="h-4 w-4" />
+					Edit
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					data-testid={`pricing-override-delete-btn-${row.id}`}
+					variant="destructive"
+					className="cursor-pointer"
+					onSelect={(e) => {
+						e.preventDefault();
+						onDelete(row);
+						setIsOpen(false);
+					}}
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
 type ScopeFilter = "all" | PricingOverrideScopeKind;
 
 function parseScopeKind(value: string | null): ScopeFilter {
@@ -314,44 +369,11 @@ export default function ScopedPricingOverridesView() {
 										<TableCell>{row.pattern}</TableCell>
 										<TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
 											<div className="flex items-center justify-end">
-												<DropdownMenu>
-													<DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
-														<Button
-															variant="ghost"
-															size="icon"
-															className="h-8 w-8"
-															aria-label={`Actions for pricing override ${row.name || row.id}`}
-															data-testid={`pricing-override-actions-btn-${row.id}`}
-														>
-															<MoreHorizontal className="h-4 w-4" />
-														</Button>
-													</DropdownMenuTrigger>
-													<DropdownMenuContent align="end">
-														<DropdownMenuItem
-															data-testid={`pricing-override-edit-btn-${row.id}`}
-															className="cursor-pointer"
-															onClick={(event) => {
-																event.stopPropagation();
-																openEditDrawer(row);
-															}}
-														>
-															<Edit className="h-4 w-4" />
-															Edit
-														</DropdownMenuItem>
-														<DropdownMenuItem
-															data-testid={`pricing-override-delete-btn-${row.id}`}
-															variant="destructive"
-															className="cursor-pointer"
-															onClick={(event) => {
-																event.stopPropagation();
-																setDeleteTarget(row);
-															}}
-														>
-															<Trash2 className="h-4 w-4" />
-															Delete
-														</DropdownMenuItem>
-													</DropdownMenuContent>
-												</DropdownMenu>
+												<PricingOverrideActionsMenu
+													row={row}
+													onEdit={openEditDrawer}
+													onDelete={setDeleteTarget}
+												/>
 											</div>
 										</TableCell>
 									</TableRow>

--- a/ui/app/workspace/governance/views/customerTable.tsx
+++ b/ui/app/workspace/governance/views/customerTable.tsx
@@ -44,8 +44,10 @@ interface CustomerActionsMenuProps {
 }
 
 function CustomerActionsMenu({ customer, canUpdate, canDelete, onEdit, onDelete }: CustomerActionsMenuProps) {
+	const [isOpen, setIsOpen] = useState(false);
+
 	return (
-		<DropdownMenu>
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
 			<DropdownMenuTrigger asChild>
 				<Button
 					variant="ghost"
@@ -63,9 +65,10 @@ function CustomerActionsMenu({ customer, canUpdate, canDelete, onEdit, onDelete 
 				<DropdownMenuItem
 					disabled={!canUpdate}
 					data-testid={`customer-button-edit-${customer.id}`}
-					onClick={(e) => {
-						e.stopPropagation();
+					onSelect={(e) => {
+						e.preventDefault();
 						onEdit(customer);
+						setIsOpen(false);
 					}}
 				>
 					<Edit className="h-4 w-4" />
@@ -75,9 +78,10 @@ function CustomerActionsMenu({ customer, canUpdate, canDelete, onEdit, onDelete 
 					variant="destructive"
 					disabled={!canDelete}
 					data-testid={`customer-button-delete-${customer.id}`}
-					onClick={(e) => {
-						e.stopPropagation();
+					onSelect={(e) => {
+						e.preventDefault();
 						onDelete(customer);
+						setIsOpen(false);
 					}}
 				>
 					<Trash2 className="h-4 w-4" />

--- a/ui/app/workspace/governance/views/teamsTable.tsx
+++ b/ui/app/workspace/governance/views/teamsTable.tsx
@@ -48,11 +48,12 @@ function TeamActionsMenu({
 	onEdit: (team: Team) => void;
 	onDelete: (teamId: string) => void;
 }) {
+	const [isOpen, setIsOpen] = useState(false);
 	const [deleteOpen, setDeleteOpen] = useState(false);
 
 	return (
 		<>
-			<DropdownMenu>
+			<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
 				<DropdownMenuTrigger asChild>
 					<Button
 						variant="ghost"
@@ -72,6 +73,7 @@ function TeamActionsMenu({
 						onSelect={(e) => {
 							e.preventDefault();
 							onEdit(team);
+							setIsOpen(false);
 						}}
 					>
 						<Edit className="h-4 w-4" />
@@ -85,6 +87,7 @@ function TeamActionsMenu({
 						onSelect={(e) => {
 							e.preventDefault();
 							setDeleteOpen(true);
+							setIsOpen(false);
 						}}
 					>
 						<Trash2 className="h-4 w-4" />

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -10,6 +10,36 @@ import { cn } from "@/lib/utils";
 import { ColumnDef } from "@tanstack/react-table";
 import { format, formatDistanceToNow } from "date-fns";
 import { ArrowUpDown, MoreHorizontal, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+function LogActionsMenu({ log, onDelete }: { log: LogEntry; onDelete: (log: LogEntry) => void }) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
+				<Button variant="ghost" size="icon" data-testid="log-actions-btn" aria-label="Log actions" className="h-7 w-7">
+					<MoreHorizontal className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					variant="destructive"
+					className="cursor-pointer"
+					data-testid="log-delete-btn"
+					onSelect={(e) => {
+						e.preventDefault();
+						onDelete(log);
+						setIsOpen(false);
+					}}
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
 
 function getAssistantToolCallSummary(log?: LogEntry): string {
 	const toolCalls = log?.output_message?.tool_calls || [];
@@ -357,27 +387,7 @@ export const createColumns = (
 						const log = row.original;
 						return (
 							<div className="flex justify-center">
-								<DropdownMenu>
-									<DropdownMenuTrigger asChild onClick={(event) => event.stopPropagation()}>
-										<Button variant="ghost" size="icon" data-testid="log-actions-btn" aria-label="Log actions" className="h-7 w-7">
-											<MoreHorizontal className="h-4 w-4" />
-										</Button>
-									</DropdownMenuTrigger>
-									<DropdownMenuContent align="end">
-										<DropdownMenuItem
-											variant="destructive"
-											className="cursor-pointer"
-											data-testid="log-delete-btn"
-											onClick={(event) => {
-												event.stopPropagation();
-												onDelete(log);
-											}}
-										>
-											<Trash2 className="h-4 w-4" />
-											Delete
-										</DropdownMenuItem>
-									</DropdownMenuContent>
-								</DropdownMenu>
+								<LogActionsMenu log={log} onDelete={onDelete} />
 							</div>
 						);
 					},

--- a/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
+++ b/ui/app/workspace/mcp-logs/views/mcpLogDetailsSheet.tsx
@@ -7,7 +7,6 @@ import {
 	AlertDialogFooter,
 	AlertDialogHeader,
 	AlertDialogTitle,
-	AlertDialogTrigger,
 } from "@/components/ui/alertDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -77,6 +76,7 @@ export function MCPLogDetailSheet({
 	hasNext = false,
 }: MCPLogDetailSheetProps) {
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const [dropdownOpen, setDropdownOpen] = useState(false);
 	const {
 		data: fullLog,
 		isLoading,
@@ -144,7 +144,7 @@ export function MCPLogDetailSheet({
 						</Button>
 					</div>
 					<AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-						<DropdownMenu>
+						<DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
 							<DropdownMenuTrigger asChild>
 								<Button variant="ghost" className="size-8" type="button">
 									<MoreVertical className="h-3 w-3" />
@@ -153,7 +153,11 @@ export function MCPLogDetailSheet({
 							<DropdownMenuContent align="end">
 								<DropdownMenuItem
 									data-testid="export-log-json"
-									onClick={() => downloadAsJson(displayLog, `mcp-log-${displayLog.id ?? "export"}.json`)}
+									onSelect={(e) => {
+										e.preventDefault();
+										downloadAsJson(displayLog, `mcp-log-${displayLog.id ?? "export"}.json`);
+										setDropdownOpen(false);
+									}}
 								>
 									<Download className="h-4 w-4" />
 									Export as JSON
@@ -161,12 +165,17 @@ export function MCPLogDetailSheet({
 								{handleDelete ? (
 									<>
 										<DropdownMenuSeparator />
-										<AlertDialogTrigger asChild>
-											<DropdownMenuItem variant="destructive">
-												<Trash2 className="h-4 w-4" />
-												Delete log
-											</DropdownMenuItem>
-										</AlertDialogTrigger>
+										<DropdownMenuItem
+											variant="destructive"
+											onSelect={(e) => {
+												e.preventDefault();
+												setDeleteDialogOpen(true);
+												setDropdownOpen(false);
+											}}
+										>
+											<Trash2 className="h-4 w-4" />
+											Delete log
+										</DropdownMenuItem>
 									</>
 								) : null}
 							</DropdownMenuContent>

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -25,6 +25,72 @@ import { useState } from "react";
 import { MCPServersEmptyState } from "./mcpServersEmptyState";
 import MCPClientSheet from "./mcpClientSheet";
 
+function MCPClientActionsMenu({
+	client,
+	hasUpdateAccess,
+	hasDeleteAccess,
+	isReconnecting,
+	isPerUserOAuth,
+	onReconnect,
+	onDelete,
+}: {
+	client: MCPClient;
+	hasUpdateAccess: boolean;
+	hasDeleteAccess: boolean;
+	isReconnecting: boolean;
+	isPerUserOAuth: boolean;
+	onReconnect: (client: MCPClient) => void;
+	onDelete: (client: MCPClient) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8"
+					aria-label="MCP server actions"
+					data-testid={`mcp-client-actions-${client.config.client_id}-btn`}
+				>
+					{isReconnecting ? <Loader2 className="h-4 w-4 animate-spin" /> : <MoreHorizontal className="h-4 w-4" />}
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				{hasUpdateAccess && (
+					<DropdownMenuItem
+						className="cursor-pointer"
+						disabled={isPerUserOAuth || client.config.disabled || isReconnecting}
+						onSelect={(e) => {
+							e.preventDefault();
+							onReconnect(client);
+							setIsOpen(false);
+						}}
+					>
+						<RefreshCcw className="h-4 w-4" />
+						Reconnect
+					</DropdownMenuItem>
+				)}
+				{hasDeleteAccess && (
+					<DropdownMenuItem
+						variant="destructive"
+						className="cursor-pointer"
+						onSelect={(e) => {
+							e.preventDefault();
+							onDelete(client);
+							setIsOpen(false);
+						}}
+					>
+						<Trash2 className="h-4 w-4" />
+						Delete
+					</DropdownMenuItem>
+				)}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
 interface MCPClientsTableProps {
 	mcpClients: MCPClient[];
 	totalCount: number;
@@ -318,51 +384,15 @@ export default function MCPClientsTable({
 											className={`bg-card group-hover:bg-muted/50 sticky right-0 z-10 text-right ${PIN_SHADOW_RIGHT}`}
 											onClick={(e) => e.stopPropagation()}
 										>
-											<DropdownMenu>
-												<DropdownMenuTrigger asChild>
-													<Button
-														variant="ghost"
-														size="icon"
-														className="h-8 w-8"
-														aria-label="MCP server actions"
-														data-testid={`mcp-client-actions-${c.config.client_id}-btn`}
-													>
-														{reconnectingClients.includes(c.config.client_id) ? (
-															<Loader2 className="h-4 w-4 animate-spin" />
-														) : (
-															<MoreHorizontal className="h-4 w-4" />
-														)}
-													</Button>
-												</DropdownMenuTrigger>
-												<DropdownMenuContent align="end">
-													{hasUpdateMCPClientAccess && (
-														<DropdownMenuItem
-															className="cursor-pointer"
-															disabled={isPerUserOAuth || c.config.disabled || reconnectingClients.includes(c.config.client_id)}
-															onSelect={(e) => {
-																e.preventDefault();
-																void handleReconnect(c);
-															}}
-														>
-															<RefreshCcw className="h-4 w-4" />
-															Reconnect
-														</DropdownMenuItem>
-													)}
-													{hasDeleteMCPClientAccess && (
-														<DropdownMenuItem
-															variant="destructive"
-															className="cursor-pointer"
-															onSelect={(e) => {
-																e.preventDefault();
-																setClientToDelete(c);
-															}}
-														>
-															<Trash2 className="h-4 w-4" />
-															Delete
-														</DropdownMenuItem>
-													)}
-												</DropdownMenuContent>
-											</DropdownMenu>
+											<MCPClientActionsMenu
+												client={c}
+												hasUpdateAccess={hasUpdateMCPClientAccess}
+												hasDeleteAccess={hasDeleteMCPClientAccess}
+												isReconnecting={reconnectingClients.includes(c.config.client_id)}
+												isPerUserOAuth={isPerUserOAuth}
+												onReconnect={(client) => void handleReconnect(client)}
+												onDelete={setClientToDelete}
+											/>
 										</TableCell>
 									</TableRow>
 								);

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -40,6 +40,67 @@ const toTestIdPart = (value: string) =>
 		.replace(/[^a-z0-9]+/g, "-")
 		.replace(/^-|-$/g, "");
 
+function ModelLimitActionsMenu({
+	config,
+	hasUpdateAccess,
+	hasDeleteAccess,
+	onEdit,
+	onDelete,
+}: {
+	config: ModelConfig;
+	hasUpdateAccess: boolean;
+	hasDeleteAccess: boolean;
+	onEdit: (config: ModelConfig) => void;
+	onDelete: (configId: string) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8"
+					aria-label={`Actions for model limit ${config.model_name}`}
+					data-testid={`model-limit-button-actions-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
+				>
+					<MoreHorizontal className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					className="cursor-pointer"
+					disabled={!hasUpdateAccess}
+					data-testid={`model-limit-button-edit-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
+					onSelect={(e) => {
+						e.preventDefault();
+						onEdit(config);
+						setIsOpen(false);
+					}}
+				>
+					<Edit className="h-4 w-4" />
+					Edit
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					variant="destructive"
+					className="cursor-pointer"
+					disabled={!hasDeleteAccess}
+					data-testid={`model-limit-button-delete-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
+					onSelect={(e) => {
+						e.preventDefault();
+						onDelete(config.id);
+						setIsOpen(false);
+					}}
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
 interface ModelLimitsTableProps {
 	modelConfigs: ModelConfig[];
 	totalCount: number;
@@ -371,46 +432,13 @@ export default function ModelLimitsTable({
 											</TableCell>
 											<TableCell onClick={(e) => e.stopPropagation()}>
 												<div className="flex items-center justify-end">
-													<DropdownMenu>
-														<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-															<Button
-																variant="ghost"
-																size="icon"
-																className="h-8 w-8"
-																aria-label={`Actions for model limit ${config.model_name}`}
-																data-testid={`model-limit-button-actions-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
-															>
-																<MoreHorizontal className="h-4 w-4" />
-															</Button>
-														</DropdownMenuTrigger>
-														<DropdownMenuContent align="end">
-															<DropdownMenuItem
-																className="cursor-pointer"
-																disabled={!hasUpdateAccess}
-																onClick={(e) => {
-																	e.stopPropagation();
-																	handleEditModelLimit(config);
-																}}
-																data-testid={`model-limit-button-edit-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
-															>
-																<Edit className="h-4 w-4" />
-																Edit
-															</DropdownMenuItem>
-															<DropdownMenuItem
-																variant="destructive"
-																className="cursor-pointer"
-																disabled={!hasDeleteAccess}
-																onClick={(e) => {
-																	e.stopPropagation();
-																	setDeleteModelConfigId(config.id);
-																}}
-																data-testid={`model-limit-button-delete-${toTestIdPart(config.model_name)}-${toTestIdPart(config.provider || "all")}`}
-															>
-																<Trash2 className="h-4 w-4" />
-																Delete
-															</DropdownMenuItem>
-														</DropdownMenuContent>
-													</DropdownMenu>
+													<ModelLimitActionsMenu
+														config={config}
+														hasUpdateAccess={hasUpdateAccess}
+														hasDeleteAccess={hasDeleteAccess}
+														onEdit={handleEditModelLimit}
+														onDelete={setDeleteModelConfigId}
+													/>
 												</div>
 											</TableCell>
 										</TableRow>

--- a/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
+++ b/ui/app/workspace/providers/views/modelProviderKeysTableView.tsx
@@ -31,6 +31,57 @@ interface Props {
 	isKeyless?: boolean;
 }
 
+function ProviderKeyActionsMenu({
+	keyId,
+	hasUpdateAccess,
+	hasDeleteAccess,
+	onEdit,
+	onDelete,
+}: {
+	keyId: string;
+	hasUpdateAccess: boolean;
+	hasDeleteAccess: boolean;
+	onEdit: (keyId: string) => void;
+	onDelete: (keyId: string) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild>
+				<Button onClick={(e) => e.stopPropagation()} variant="ghost">
+					<EllipsisIcon className="h-5 w-5" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					onSelect={(e) => {
+						e.preventDefault();
+						onEdit(keyId);
+						setIsOpen(false);
+					}}
+					disabled={!hasUpdateAccess}
+				>
+					<PencilIcon className="mr-1 h-4 w-4" />
+					Edit
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					variant="destructive"
+					onSelect={(e) => {
+						e.preventDefault();
+						onDelete(keyId);
+						setIsOpen(false);
+					}}
+					disabled={!hasDeleteAccess}
+				>
+					<TrashIcon className="mr-1 h-4 w-4" />
+					Delete
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
 export default function ModelProviderKeysTableView({ provider, className, headerActions, isKeyless }: Props) {
 	const providerName = provider.name?.toLowerCase() ?? "";
 	const isVLLM = providerName === "vllm";
@@ -265,34 +316,13 @@ export default function ModelProviderKeysTableView({ provider, className, header
 										<TableCell className="text-right">
 											<div className="flex items-center justify-end space-x-2">
 												{hasUpdateProviderAccess || hasDeleteProviderAccess ? (
-													<DropdownMenu>
-														<DropdownMenuTrigger asChild>
-															<Button onClick={(e) => e.stopPropagation()} variant="ghost">
-																<EllipsisIcon className="h-5 w-5" />
-															</Button>
-														</DropdownMenuTrigger>
-														<DropdownMenuContent align="end">
-															<DropdownMenuItem
-																onClick={() => {
-																	setShowAddNewKeyDialog({ show: true, keyId: key.id });
-																}}
-																disabled={!hasUpdateProviderAccess}
-															>
-																<PencilIcon className="mr-1 h-4 w-4" />
-																Edit
-															</DropdownMenuItem>
-															<DropdownMenuItem
-																variant="destructive"
-																onClick={() => {
-																	setShowDeleteKeyDialog({ show: true, keyId: key.id });
-																}}
-																disabled={!hasDeleteProviderAccess}
-															>
-																<TrashIcon className="mr-1 h-4 w-4" />
-																Delete
-															</DropdownMenuItem>
-														</DropdownMenuContent>
-													</DropdownMenu>
+													<ProviderKeyActionsMenu
+														keyId={key.id}
+														hasUpdateAccess={hasUpdateProviderAccess}
+														hasDeleteAccess={hasDeleteProviderAccess}
+														onEdit={(keyId) => setShowAddNewKeyDialog({ show: true, keyId })}
+														onDelete={(keyId) => setShowDeleteKeyDialog({ show: true, keyId })}
+													/>
 												) : null}
 											</div>
 										</TableCell>

--- a/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRulesTable.tsx
@@ -29,6 +29,67 @@ import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Search, Trash2 } from 
 import { useState } from "react";
 import { toast } from "sonner";
 
+function RoutingRuleActionsMenu({
+	rule,
+	canUpdate,
+	canDelete,
+	onEdit,
+	onDelete,
+}: {
+	rule: RoutingRule;
+	canUpdate: boolean;
+	canDelete: boolean;
+	onEdit: (rule: RoutingRule) => void;
+	onDelete: (ruleId: string) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+			<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+				<Button
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8"
+					aria-label={`Actions for routing rule ${rule.name}`}
+					data-testid={`routing-rule-actions-${rule.id}-btn`}
+				>
+					<MoreHorizontal className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem
+					className="cursor-pointer"
+					disabled={!canUpdate}
+					data-testid={`routing-rule-edit-${rule.id}-btn`}
+					onSelect={(e) => {
+						e.preventDefault();
+						onEdit(rule);
+						setIsOpen(false);
+					}}
+				>
+					<Edit className="h-4 w-4" />
+					Edit
+				</DropdownMenuItem>
+				<DropdownMenuItem
+					variant="destructive"
+					className="cursor-pointer"
+					disabled={!canDelete}
+					data-testid={`routing-rule-delete-${rule.id}-btn`}
+					onSelect={(e) => {
+						e.preventDefault();
+						onDelete(rule.id);
+						setIsOpen(false);
+					}}
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
 interface RoutingRulesTableProps {
 	rules: RoutingRule[] | undefined;
 	totalCount: number;
@@ -192,46 +253,13 @@ export function RoutingRulesTable({
 									</TableCell>
 									<TableCell className="text-right" onClick={(e) => e.stopPropagation()}>
 										<div className="flex items-center justify-end">
-											<DropdownMenu>
-												<DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
-													<Button
-														variant="ghost"
-														size="icon"
-														className="h-8 w-8"
-														aria-label={`Actions for routing rule ${rule.name}`}
-														data-testid={`routing-rule-actions-${rule.id}-btn`}
-													>
-														<MoreHorizontal className="h-4 w-4" />
-													</Button>
-												</DropdownMenuTrigger>
-												<DropdownMenuContent align="end">
-													<DropdownMenuItem
-														className="cursor-pointer"
-														disabled={!canUpdate}
-														onClick={(e) => {
-															e.stopPropagation();
-															onEdit(rule);
-														}}
-														data-testid={`routing-rule-edit-${rule.id}-btn`}
-													>
-														<Edit className="h-4 w-4" />
-														Edit
-													</DropdownMenuItem>
-													<DropdownMenuItem
-														variant="destructive"
-														className="cursor-pointer"
-														disabled={!canDelete}
-														onClick={(e) => {
-															e.stopPropagation();
-															setDeleteRuleId(rule.id);
-														}}
-														data-testid={`routing-rule-delete-${rule.id}-btn`}
-													>
-														<Trash2 className="h-4 w-4" />
-														Delete
-													</DropdownMenuItem>
-												</DropdownMenuContent>
-											</DropdownMenu>
+											<RoutingRuleActionsMenu
+												rule={rule}
+												canUpdate={canUpdate}
+												canDelete={canDelete}
+												onEdit={onEdit}
+												onDelete={setDeleteRuleId}
+											/>
 										</div>
 									</TableCell>
 								</TableRow>

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -168,12 +168,13 @@ function VKActionsMenu({
 	onEdit: (vk: VirtualKey) => void;
 	onDelete: (vkId: string) => void;
 }) {
+	const [isOpen, setIsOpen] = useState(false);
 	const { isManagedByProfile } = useVirtualKeyUsage(vk);
 	const [deleteOpen, setDeleteOpen] = useState(false);
 
 	return (
 		<>
-			<DropdownMenu>
+			<DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
 				<DropdownMenuTrigger asChild>
 					<Button
 						variant="ghost"
@@ -193,6 +194,7 @@ function VKActionsMenu({
 						onSelect={(e) => {
 							e.preventDefault();
 							onEdit(vk);
+							setIsOpen(false);
 						}}
 					>
 						<Edit className="h-4 w-4" />
@@ -207,6 +209,7 @@ function VKActionsMenu({
 						onSelect={(e) => {
 							e.preventDefault();
 							setDeleteOpen(true);
+							setIsOpen(false);
 						}}
 					>
 						<Trash2 className="h-4 w-4" />

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -382,6 +382,7 @@ export interface FrameworkConfig {
 	id: number;
 	pricing_url: string;
 	pricing_sync_interval: number;
+	model_parameters_url: string;
 }
 
 // Auth config


### PR DESCRIPTION
## Summary

Adds support for a configurable `model_parameters_url` field, allowing users to specify a custom URL for the model parameters datasheet instead of always using the built-in default. This mirrors the existing `pricing_url` configuration pattern end-to-end, from the database layer through to the UI.

## Changes

- Added `ModelParametersURL` column to `TableFrameworkConfig` via a new database migration (`add_model_parameters_url_column`)
- Added `ModelParametersURL` field to the `modelcatalog.Config` struct and wired it through `Init` and `UpdateSyncConfig` so the catalog uses the configured URL when fetching model parameters
- Extended `ResolveFrameworkPricingConfig` to resolve `model_parameters_url` from file config (including `env.` prefix substitution) and the database, with the same backfill and invariant-assertion logic used for `pricing_url`
- Added URL accessibility validation in the HTTP config handler when `model_parameters_url` is set to a non-default value, consistent with how `pricing_url` is validated
- Added `model_parameters_url` input fields to both `PricingConfigView` and `ModelSettingsView` in the UI, with URL format validation and dirty-state tracking
- Extended `FrameworkConfig` TypeScript type to include `model_parameters_url`
- Updated tests to assert that `ModelParametersURL` is never nil in resolved config output

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./framework/modelcatalog/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

1. Start the service and navigate to the Pricing or Model Settings configuration view.
2. Enter a custom URL in the **Model Parameters URL** field and save.
3. Verify the value is persisted and returned in subsequent config reads.
4. Enter an invalid or inaccessible URL and confirm the appropriate validation error is shown.
5. Leave the field empty and confirm the default model parameters URL is used.

**New config field:**

| Field | Type | Default |
|---|---|---|
| `model_parameters_url` | `string` (optional) | `DefaultModelParametersURL` |

Supports `env.VAR_NAME` substitution in file-based config, consistent with `pricing_url`.

## Screenshots/Recordings

A new **Model Parameters URL** input field appears in both the Pricing Config and Model Settings views, styled and validated identically to the existing Pricing Datasheet URL field.

## Breaking changes

- [x] No

## Related issues
https://github.com/maximhq/bifrost/issues/3238

## Security considerations

The HTTP config handler performs an outbound GET request to validate the accessibility of any non-default `model_parameters_url` before persisting it. Operators should ensure the service has network access to any custom URL provided. No credentials or sensitive data are transmitted in the validation request.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable