### PR TITLE
dashboard access rbac ui changes

### DIFF
--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3006,8 +3006,6 @@ func ResolveFrameworkPricingConfig(
 	defaultPricingURL := modelcatalog.DefaultPricingURL
 	defaultSyncSeconds := int64(modelcatalog.DefaultSyncInterval.Seconds())
 
-	// --- Phase 1: parse and validate file config ---
-
 	filePricingURL := (*string)(nil)
 	fileSyncSeconds := (*int64)(nil)
 	skipURLBackfill := false // prevent DB backfill of unresolved env references

--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -11,6 +11,7 @@ export enum RbacResource {
 	Users = "Users",
 	Logs = "Logs",
 	Observability = "Observability",
+	Dashboard = "Dashboard",
 	VirtualKeys = "VirtualKeys",
 	ModelProvider = "ModelProvider",
 	Plugins = "Plugins",

--- a/ui/app/workspace/dashboard/layout.tsx
+++ b/ui/app/workspace/dashboard/layout.tsx
@@ -4,8 +4,8 @@ import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import DashboardPage from "./page";
 
 function RouteComponent() {
-	const hasObservabilityAccess = useRbac(RbacResource.Observability, RbacOperation.View);
-	if (!hasObservabilityAccess) {
+	const hasDashboardAccess = useRbac(RbacResource.Dashboard, RbacOperation.View);
+	if (!hasDashboardAccess) {
 		return <NoPermissionView entity="dashboard" />;
 	}
 	return <DashboardPage />;

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -623,6 +623,10 @@ export default function AppSidebar() {
     RbacResource.Observability,
     RbacOperation.View,
   );
+  const hasDashboardAccess = useRbac(
+    RbacResource.Dashboard,
+    RbacOperation.View,
+  );
   const hasModelProvidersAccess = useRbac(
     RbacResource.ModelProvider,
     RbacOperation.View,
@@ -721,7 +725,7 @@ export default function AppSidebar() {
             url: "/workspace/dashboard",
             icon: ChartColumnBig,
             description: "Dashboard",
-            hasAccess: hasObservabilityAccess,
+            hasAccess: hasDashboardAccess,
           },
           {
             title: "LLM Logs",
@@ -1044,6 +1048,7 @@ export default function AppSidebar() {
       hasLogsAccess,
       hasAPIKeyAccess,
       hasObservabilityAccess,
+      hasDashboardAccess,
       hasModelProvidersAccess,
       hasMCPGatewayAccess,
       hasMCPToolGroupsAccess,


### PR DESCRIPTION
## Summary

This PR fixes the RBAC permission check on the dashboard route to use the correct `Dashboard` resource instead of `Observability`, and removes a stale inline comment in the pricing config resolver.

## Changes

- The dashboard layout was checking `RbacResource.Observability` to gate access to the dashboard view. This has been corrected to use `RbacResource.Dashboard`, ensuring the permission check reflects the actual resource being accessed.
- A leftover phase label comment (`// --- Phase 1: parse and validate file config ---`) was removed from `ResolveFrameworkPricingConfig` as it no longer served a meaningful purpose.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

1. Log in as a user who has `Dashboard` view access but **not** `Observability` view access.
2. Navigate to the dashboard route.
3. Confirm the dashboard renders correctly instead of showing a "No Permission" view.
4. Log in as a user without `Dashboard` view access and confirm the "No Permission" view is shown.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The corrected RBAC check ensures users are gated on the appropriate `Dashboard` resource. Previously, users with `Observability` access but without `Dashboard` access (or vice versa) would have been incorrectly granted or denied access to the dashboard view.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable