### PR TITLE
feat: add `access_profile_id` support to bifrost helm chart virtual key schema and helpers

### DIFF
--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -463,6 +463,7 @@ false
 {{- if hasKey . "is_active" }}{{- $_ := set $vk "is_active" .is_active }}{{- end }}
 {{- if .team_id }}{{- $_ := set $vk "team_id" .team_id }}{{- end }}
 {{- if .customer_id }}{{- $_ := set $vk "customer_id" .customer_id }}{{- end }}
+{{- if .access_profile_id }}{{- $_ := set $vk "access_profile_id" .access_profile_id }}{{- end }}
 {{- if .rate_limit_id }}{{- $_ := set $vk "rate_limit_id" .rate_limit_id }}{{- end }}
 {{- if .provider_configs }}{{- $_ := set $vk "provider_configs" .provider_configs }}{{- end }}
 {{- if .mcp_configs }}{{- $_ := set $vk "mcp_configs" .mcp_configs }}{{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1230,10 +1230,16 @@
                     "type": "boolean"
                   },
                   "team_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Assign this virtual key to a team (mutually exclusive with customer_id and access_profile_id)"
                   },
                   "customer_id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Assign this virtual key to a customer (mutually exclusive with team_id and access_profile_id)"
+                  },
+                  "access_profile_id": {
+                    "type": "integer",
+                    "description": "Assign this virtual key to an access profile template (mutually exclusive with team_id and customer_id; enterprise only)"
                   },
                   "rate_limit_id": {
                     "type": "string"
@@ -1267,6 +1273,13 @@
                       }
                     }
                   }
+                },
+                "not": {
+                  "anyOf": [
+                    { "required": ["team_id", "customer_id"] },
+                    { "required": ["team_id", "access_profile_id"] },
+                    { "required": ["customer_id", "access_profile_id"] }
+                  ]
                 },
                 "required": ["id", "name"]
               }

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -513,8 +513,9 @@ bifrost:
       #   description: "Virtual key description"
       #   value: "sk-bf-..."           # Optional - auto-generated if omitted
       #   is_active: true
-      #   team_id: "team-1"        # Mutually exclusive with customer_id
-      #   customer_id: ""          # Mutually exclusive with team_id
+      #   team_id: "team-1"        # Mutually exclusive with customer_id and access_profile_id
+      #   customer_id: ""          # Mutually exclusive with team_id and access_profile_id
+      #   access_profile_id: 1    # Mutually exclusive with team_id and customer_id (enterprise)
       #   rate_limit_id: "rate-limit-1"
       #   # Provider-specific configurations (empty means all providers allowed)
       #   provider_configs:


### PR DESCRIPTION
## Summary

Adds support for `access_profile_id` as a virtual key assignment option in the Bifrost Helm chart, enabling enterprise users to associate virtual keys with access profile templates.

## Changes

- Added `access_profile_id` field handling in the `_helpers.tpl` template so the value is included when constructing virtual key configurations
- Added `access_profile_id` to the JSON schema as an integer type with a description noting it is enterprise-only and mutually exclusive with `team_id` and `customer_id`
- Updated `team_id` and `customer_id` schema descriptions to reflect that they are also mutually exclusive with `access_profile_id`
- Updated `values.yaml` comments to document the new field and the mutual exclusivity constraints across all three assignment options

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Deploy the Helm chart with a virtual key configured using `access_profile_id`:

```yaml
bifrost:
  virtualKeys:
    - name: "test-key"
      access_profile_id: 1
```

Verify the rendered template includes `access_profile_id` in the virtual key configuration:

```sh
helm template ./helm-charts/bifrost --debug
```

Confirm that the schema validates correctly and rejects configurations where `access_profile_id` is used alongside `team_id` or `customer_id`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`access_profile_id` is an enterprise-only field that controls access profile assignment for virtual keys. Ensure that only authorized users can set this field, as it governs access control boundaries for the associated key.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable