### PR TITLE
update runsinglemigration to accept migration options

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -144,14 +144,18 @@ func (l *migrationLock) release(ctx context.Context) {
 // directly, so downstream consumers (bifrost-enterprise, plugins) can run
 // their migrations inside a MigrateOnFreshConnection callback without having
 // to reach the throwaway pool through the ConfigStore abstraction.
-func RunSingleMigration(ctx context.Context, db *gorm.DB, migration *migrator.Migration) error {
+func RunSingleMigration(ctx context.Context, options *migrator.Options, db *gorm.DB, migration *migrator.Migration) error {
 	if db == nil {
 		return fmt.Errorf("db cannot be nil")
 	}
 	if migration == nil {
 		return fmt.Errorf("migration cannot be nil")
 	}
-	m := migrator.New(db.WithContext(ctx), migrator.DefaultOptions, []*migrator.Migration{migration})
+	migrationOpts := migrator.DefaultOptions
+	if options != nil {
+		migrationOpts = options
+	}
+	m := migrator.New(db.WithContext(ctx), migrationOpts, []*migrator.Migration{migration})
 	return m.Migrate()
 }
 
@@ -1443,7 +1447,7 @@ func migrationAddFrameworkConfigsTable(ctx context.Context, db *gorm.DB) error {
 // migrationAddTeamSourceIDColumn adds optional source_id to governance_teams, with a unique index
 func migrationAddTeamSourceIDColumn(ctx context.Context, db *gorm.DB) error {
 	const idxName = "idx_governance_teams_source_id"
-	return RunSingleMigration(ctx, db, &migrator.Migration{
+	return RunSingleMigration(ctx, nil, db, &migrator.Migration{
 		ID: "add_team_source_id_column",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
@@ -7635,7 +7639,7 @@ func migrationAddMCPClientDisabledColumn(ctx context.Context, db *gorm.DB) error
 // appended so no data is lost. The struct tag uniqueIndex makes GORM enforce
 // this on new rows going forward.
 func migrationUniqueTeamNames(ctx context.Context, db *gorm.DB) error {
-	return RunSingleMigration(ctx, db, &migrator.Migration{
+	return RunSingleMigration(ctx, nil, db, &migrator.Migration{
 		ID: "gov_unique_team_names",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
@@ -7694,7 +7698,7 @@ func migrationUniqueTeamNames(ctx context.Context, db *gorm.DB) error {
 // oauth_user_tokens, and creates partial unique indexes (one per identity
 // dimension).
 func migrationAddOAuthAuthModeColumns(ctx context.Context, db *gorm.DB) error {
-	return RunSingleMigration(ctx, db, &migrator.Migration{
+	return RunSingleMigration(ctx, nil, db, &migrator.Migration{
 		ID: "add_oauth_auth_mode_columns",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
@@ -7970,7 +7974,7 @@ func migrationAddOAuthAuthModeColumns(ctx context.Context, db *gorm.DB) error {
 // No data backfill: existing rows are dev-only test data; production hasn't
 // landed yet.
 func migrationReplaceOauthSessionTokenWithSessionID(ctx context.Context, db *gorm.DB) error {
-	return RunSingleMigration(ctx, db, &migrator.Migration{
+	return RunSingleMigration(ctx, nil, db, &migrator.Migration{
 		ID: "replace_oauth_session_token_with_session_id",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
@@ -8097,7 +8101,7 @@ func migrationReplaceOauthSessionTokenWithSessionID(ctx context.Context, db *gor
 // Rollback recreates the tables empty (best-effort schema-only; original data
 // is gone).
 func migrationDropLegacyOAuthServerTables(ctx context.Context, db *gorm.DB) error {
-	return RunSingleMigration(ctx, db, &migrator.Migration{
+	return RunSingleMigration(ctx, nil, db, &migrator.Migration{
 		ID: "drop_legacy_oauth_server_tables",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
@@ -8150,7 +8154,7 @@ func migrationDropLegacyOAuthServerTables(ctx context.Context, db *gorm.DB) erro
 // Affected users / clients re-authenticate fresh — the alternative is carrying
 // forward dead state that surfaces in the sessions UI but can never refresh.
 func migrationDropNonVKOauthUserRows(ctx context.Context, db *gorm.DB) error {
-	return RunSingleMigration(ctx, db, &migrator.Migration{
+	return RunSingleMigration(ctx, nil, db, &migrator.Migration{
 		ID: "drop_non_vk_oauth_user_rows",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
@@ -8195,7 +8199,7 @@ func migrationDropNonVKOauthUserRows(ctx context.Context, db *gorm.DB) error {
 // as the redirect_uri base when Bifrost acts as an OAuth *client* to upstream
 // MCP servers.
 func migrationDropMCPExternalServerURL(ctx context.Context, db *gorm.DB) error {
-	return RunSingleMigration(ctx, db, &migrator.Migration{
+	return RunSingleMigration(ctx, nil, db, &migrator.Migration{
 		ID: "drop_mcp_external_server_url_column",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)
@@ -8228,7 +8232,7 @@ func migrationDropMCPExternalServerURL(ctx context.Context, db *gorm.DB) error {
 // config_client indefinitely on contended Postgres instances. See the same
 // split for migrationDropAllowDirectKeysColumn.
 func migrationRefreshConfigHashAfterMCPExternalServerURLRemoval(ctx context.Context, db *gorm.DB) error {
-	return RunSingleMigration(ctx, db, &migrator.Migration{
+	return RunSingleMigration(ctx, nil, db, &migrator.Migration{
 		ID: "refresh_config_hash_after_mcp_external_server_url_removal",
 		Migrate: func(tx *gorm.DB) error {
 			tx = tx.WithContext(ctx)


### PR DESCRIPTION
## Summary

`RunSingleMigration` previously always used `migrator.DefaultOptions`, making it impossible for callers to supply custom migrator options. This PR adds an optional `*migrator.Options` parameter so downstream consumers (e.g. bifrost-enterprise, plugins) can pass their own options when needed, while all existing internal callers pass `nil` to retain the default behavior.

## Changes

- Added an `options *migrator.Options` parameter to `RunSingleMigration`; when `nil` is passed, `migrator.DefaultOptions` is used as before
- Updated all internal call sites to pass `nil`, preserving existing behavior

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
```

Verify that all existing migrations continue to run successfully with `nil` options, and that a custom `*migrator.Options` value is correctly applied when provided.

## Breaking changes

- [x] Yes
- [ ] No

`RunSingleMigration` is a public function. Its signature has changed — callers outside this repository (e.g. bifrost-enterprise, plugins) must add a `nil` (or custom options) argument as the second parameter.

## Related issues

N/A

## Security considerations

None. This change only affects how migrator options are threaded through to the migration runner.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable