### PR TITLE
chore: bump Red Hat UBI9 minimal base image digest

### DIFF
--- a/transports/Dockerfile.redhat
+++ b/transports/Dockerfile.redhat
@@ -49,7 +49,7 @@ RUN go build \
 RUN test -f /app/main || (echo "Build failed" && exit 1)
   
 # --- Runtime Stage: Red Hat UBI 9 Minimal ---
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:b9b10f42d7eba7ad4a6d5ef26b7d34fdc892b2ffe59b8d0372ec884008569eb6
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:24650313873554b6ba16c1a1b6b9f9142604f6ab735113e1695faf2dd07fdede
 
 # Redeclared here so it is in scope for the LABEL instruction below.
 ARG VERSION=unknown


### PR DESCRIPTION
## Summary

Updates the Red Hat UBI 9 Minimal base image digest used in the transports runtime stage to the latest available version.

## Changes

- Bumped the `ubi9/ubi-minimal` image digest from `sha256:b9b10f42d7eba7ad4a6d5ef26b7d34fdc892b2ffe59b8d0372ec884008569eb6` to `sha256:24650313873554b6ba16c1a1b6b9f9142604f6ab735113e1695faf2dd07fdede` to pick up the latest upstream patches and security fixes.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Build the transports Docker image and verify it starts successfully:

```sh
docker build -f transports/Dockerfile.redhat transports/
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

This update pulls in the latest UBI 9 Minimal image, which may include upstream OS-level security patches and CVE fixes.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable