### PR TITLE
fix: llm tests tokens

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -767,7 +767,7 @@ func (account *ComprehensiveTestAccount) GetConfigForProvider(providerKey schema
 	case schemas.OpenRouter:
 		return &schemas.ProviderConfig{
 			NetworkConfig: schemas.NetworkConfig{
-				DefaultRequestTimeoutInSeconds: 120,
+				DefaultRequestTimeoutInSeconds: 300,
 				MaxRetries:                     10, // OpenRouter can be variable (proxy service)
 				RetryBackoffInitial:            1 * time.Second,
 				RetryBackoffMax:                12 * time.Second,

--- a/core/internal/llmtests/chat_completion_stream.go
+++ b/core/internal/llmtests/chat_completion_stream.go
@@ -80,7 +80,7 @@ func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx cont
 			Model:    testConfig.ChatModel,
 			Input:    messages,
 			Params: &schemas.ChatParameters{
-				MaxCompletionTokens: bifrost.Ptr(300),
+				MaxCompletionTokens: bifrost.Ptr(1000),
 			},
 			Fallbacks: testConfig.Fallbacks,
 		}
@@ -311,7 +311,7 @@ func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx cont
 				Model:    testConfig.ChatModel,
 				Input:    messages,
 				Params: &schemas.ChatParameters{
-					MaxCompletionTokens: bifrost.Ptr(300),
+					MaxCompletionTokens: bifrost.Ptr(1000),
 					Tools:               []schemas.ChatTool{*tool},
 				},
 				Fallbacks: testConfig.Fallbacks,

--- a/core/internal/llmtests/complete_end_to_end.go
+++ b/core/internal/llmtests/complete_end_to_end.go
@@ -70,7 +70,7 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 					ToolChoice: &schemas.ChatToolChoice{
 						ChatToolChoiceStr: bifrost.Ptr(string(schemas.ChatToolChoiceTypeRequired)),
 					},
-					MaxCompletionTokens: bifrost.Ptr(400),
+					MaxCompletionTokens: bifrost.Ptr(500),
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
@@ -88,7 +88,7 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 					ToolChoice: &schemas.ResponsesToolChoice{
 						ResponsesToolChoiceStr: bifrost.Ptr(string(schemas.ResponsesToolChoiceTypeRequired)),
 					},
-					MaxOutputTokens: bifrost.Ptr(400),
+					MaxOutputTokens: bifrost.Ptr(500),
 				},
 			}
 			return client.ResponsesRequest(bfCtx, responsesReq)
@@ -205,7 +205,7 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 				Model:    testConfig.ChatModel,
 				Input:    chatConversationHistory,
 				Params: &schemas.ChatParameters{
-					MaxCompletionTokens: bifrost.Ptr(400),
+					MaxCompletionTokens: bifrost.Ptr(500),
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
@@ -343,7 +343,7 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 				Model:    model,
 				Input:    chatConversationHistory,
 				Params: &schemas.ChatParameters{
-					MaxCompletionTokens: bifrost.Ptr(400),
+					MaxCompletionTokens: bifrost.Ptr(600),
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
@@ -357,7 +357,7 @@ func RunCompleteEnd2EndTest(t *testing.T, client *bifrost.Bifrost, ctx context.C
 				Model:    model,
 				Input:    responsesConversationHistory,
 				Params: &schemas.ResponsesParameters{
-					MaxOutputTokens: bifrost.Ptr(400),
+					MaxOutputTokens: bifrost.Ptr(600),
 				},
 			}
 			return client.ResponsesRequest(bfCtx, responsesReq)

--- a/core/internal/llmtests/end_to_end_tool_calling.go
+++ b/core/internal/llmtests/end_to_end_tool_calling.go
@@ -65,7 +65,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 				Input:    []schemas.ChatMessage{chatUserMessage},
 				Params: &schemas.ChatParameters{
 					Tools:               []schemas.ChatTool{*chatTool},
-					MaxCompletionTokens: bifrost.Ptr(150),
+					MaxCompletionTokens: bifrost.Ptr(500),
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
@@ -182,7 +182,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 				Model:    testConfig.ChatModel,
 				Input:    chatConversationMessages,
 				Params: &schemas.ChatParameters{
-					MaxCompletionTokens: bifrost.Ptr(200),
+					MaxCompletionTokens: bifrost.Ptr(500),
 				},
 				Fallbacks: testConfig.Fallbacks,
 			}
@@ -196,7 +196,7 @@ func RunEnd2EndToolCallingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 				Model:    testConfig.ChatModel,
 				Input:    responsesConversationMessages,
 				Params: &schemas.ResponsesParameters{
-					MaxOutputTokens: bifrost.Ptr(200),
+					MaxOutputTokens: bifrost.Ptr(500),
 				},
 			}
 			return client.ResponsesRequest(bfCtx, responsesReq)

--- a/core/internal/llmtests/tool_calls_streaming.go
+++ b/core/internal/llmtests/tool_calls_streaming.go
@@ -246,7 +246,7 @@ func RunToolCallsStreamingTest(t *testing.T, client *bifrost.Bifrost, ctx contex
 			Model:    testConfig.ChatModel,
 			Input:    chatMessages,
 			Params: &schemas.ChatParameters{
-				MaxCompletionTokens: bifrost.Ptr(150),
+				MaxCompletionTokens: bifrost.Ptr(500),
 				Tools:               []schemas.ChatTool{*chatTool},
 			},
 			Fallbacks: testConfig.Fallbacks,

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -3032,7 +3032,7 @@ func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessag
 		if len(pendingFunctionResponseParts) > 0 && !isFunctionOutput {
 			contents = append(contents, Content{
 				Parts: pendingFunctionResponseParts,
-				Role:  "model", // Function responses use "model" role in Gemini
+				Role:  "user", // Function responses use "user" role in Gemini
 			})
 			pendingFunctionResponseParts = nil
 		}
@@ -3190,7 +3190,7 @@ func convertResponsesMessagesToGeminiContents(messages []schemas.ResponsesMessag
 					if i == len(messages)-1 && len(pendingFunctionResponseParts) > 0 {
 						contents = append(contents, Content{
 							Parts: pendingFunctionResponseParts,
-							Role:  "model",
+							Role:  "user",
 						})
 						pendingFunctionResponseParts = nil
 					}

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -1814,7 +1814,7 @@ func convertBifrostMessagesToGemini(messages []schemas.ChatMessage) ([]Content, 
 		if len(pendingToolResponseParts) > 0 && !isToolResponse {
 			contents = append(contents, Content{
 				Parts: pendingToolResponseParts,
-				Role:  "model", // Tool responses use "model" role in Gemini
+				Role:  "user", // Function responses use "user" role in Gemini
 			})
 			pendingToolResponseParts = nil
 		}
@@ -1888,7 +1888,7 @@ func convertBifrostMessagesToGemini(messages []schemas.ChatMessage) ([]Content, 
 			if i == len(messages)-1 && len(pendingToolResponseParts) > 0 {
 				contents = append(contents, Content{
 					Parts: pendingToolResponseParts,
-					Role:  "model",
+					Role:  "user",
 				})
 				pendingToolResponseParts = nil
 			}

--- a/core/providers/huggingface/huggingface_test.go
+++ b/core/providers/huggingface/huggingface_test.go
@@ -69,10 +69,10 @@ func TestHuggingface(t *testing.T) {
 			FileDelete:            false,
 			FileContent:           false,
 			FileBatchInput:        false,
-			ImageGeneration:       true,
-			ImageGenerationStream: true,
-			ImageEdit:             true,
-			ImageEditStream:       true,
+			ImageGeneration:       false,
+			ImageGenerationStream: false,
+			ImageEdit:             false,
+			ImageEditStream:       false,
 		},
 	}
 

--- a/core/providers/openai/openai_test.go
+++ b/core/providers/openai/openai_test.go
@@ -43,7 +43,7 @@ func TestOpenAI(t *testing.T) {
 		ImageEditModel:       "gpt-image-1",
 		ImageVariationModel:  "", // dall-e-2 is deprecated and no other OpenAI model supports image variations
 		VideoGenerationModel: "sora-2",
-		ChatAudioModel:       "gpt-4o-mini-audio-preview",
+		ChatAudioModel:       "gpt-audio-mini",
 		PassthroughModel:     "gpt-4o",
 		Scenarios: llmtests.TestScenarios{
 			TextCompletion:             true,

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -2049,6 +2049,9 @@ func SetupStreamCancellation(ctx *schemas.BifrostContext, bodyStream io.Reader, 
 		defer close(closed)
 		select {
 		case <-ctx.Done():
+			if connClosed, ok := ctx.Value(schemas.BifrostContextKeyConnectionClosed).(bool); ok && connClosed {
+				return
+			}
 			// Context cancelled or deadline exceeded - close the body stream to unblock reads
 			if closer, ok := bodyStream.(io.Closer); ok {
 				if err := closer.Close(); err != nil {
@@ -2070,6 +2073,9 @@ func SetupStreamCancellation(ctx *schemas.BifrostContext, bodyStream io.Reader, 
 			// ctx.Done branch above) so ReleaseStreamingResponse skips a second CloseWithError.
 			// A second close against an already-pooled conn nil-derefs in fasthttp's connsCleaner.
 			if ctx.Err() != nil {
+				if connClosed, ok := ctx.Value(schemas.BifrostContextKeyConnectionClosed).(bool); ok && connClosed {
+					return
+				}
 				if closer, ok := bodyStream.(io.Closer); ok {
 					if err := closer.Close(); err != nil {
 						getLogger().Debug(fmt.Sprintf("Error closing body stream on done with cancelled context: %v", err))


### PR DESCRIPTION
## Summary

This PR addresses several reliability issues in LLM integration tests and fixes an incorrect role assignment for Gemini function/tool responses. It also resolves a stream cancellation race condition and updates stale test configuration values.

## Changes

- **Gemini role fix**: Corrected the role assigned to pending function/tool response parts from `"model"` to `"user"` in both the chat completions (`utils.go`) and responses (`responses.go`) Gemini converters. Gemini requires function responses to be sent under the `"user"` role, not `"model"`.
- **Token limit increases**: Raised `MaxCompletionTokens` and `MaxOutputTokens` across streaming, tool calling, and end-to-end tests to prevent responses from being truncated before completion, which was causing intermittent test failures.
- **OpenRouter timeout increase**: Increased the default request timeout for OpenRouter from 120s to 300s to account for its variability as a proxy service.
- **Stream cancellation guard**: Added a check for `BifrostContextKeyConnectionClosed` before attempting to close the body stream on context cancellation, preventing a nil-dereference in fasthttp's connection cleaner when the connection is already closed.
- **OpenAI audio model update**: Updated the `ChatAudioModel` in the OpenAI test config from `gpt-4o-mini-audio-preview` to `gpt-audio-mini`.
- **HuggingFace image tests disabled**: Disabled image generation and image edit test scenarios for HuggingFace as they are not currently supported.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/gemini/...
go test ./core/providers/openai/...
go test ./core/providers/huggingface/...
go test ./core/internal/llmtests/...
go test ./core/providers/utils/...
```

Run the end-to-end and streaming tests against OpenRouter and Gemini providers and verify that tool call conversations complete without truncation errors and that stream cancellation no longer causes nil-dereference panics.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable