### PR TITLE
AST check fixes

### DIFF
--- a/.github/workflows/scripts/schemasync/main.go
+++ b/.github/workflows/scripts/schemasync/main.go
@@ -94,6 +94,10 @@ var ignoreGoFields = map[string]string{
 	// populated on GET from the oauth_configs table, never accepted as config.json input.
 	"/properties/mcp/properties/client_configs/items|oauth_client_id":     "response-only; populated on GET from oauth_configs, not user-configurable via config.json",
 	"/properties/mcp/properties/client_configs/items|oauth_client_secret": "response-only; populated on GET from oauth_configs, not user-configurable via config.json",
+	// source_id is a stable external identifier for teams provisioned by an
+	// integrating system (PR #3395). It is assigned through the API by that
+	// system, never authored in config.json.
+	"/properties/governance/properties/teams/items|source_id": "external identifier set via API by integrating systems; not authored in config.json",
 }
 
 // ignoreGoFieldNames are field names (regardless of parent path) that are

--- a/docs/deployment-guides/config-json/client.mdx
+++ b/docs/deployment-guides/config-json/client.mdx
@@ -54,30 +54,23 @@ Set `disable_content_logging: true` for HIPAA / PCI compliance workloads where m
 
 ## Reverse Proxy
 
-When Bifrost runs behind a reverse proxy, the OAuth URLs it advertises and uses are built from the incoming `Host` header by default - which is the proxy's internal address, not its public one. Two settings let you override this with the proxy's public URL.
+When Bifrost acts as an OAuth client to upstream MCP servers, the `redirect_uri` it registers is built from the incoming `Host` header by default - behind a reverse proxy that is the proxy's internal address, not its public one. One setting lets you override it with the proxy's public URL.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `mcp_external_server_url` | string or EnvVar | - | Public base URL Bifrost advertises in OAuth server metadata |
 | `mcp_external_client_url` | string or EnvVar | - | Public base URL Bifrost uses as the `redirect_uri` against upstream MCP servers |
 
-Both fields support env var syntax (`"env.MY_VAR"`). When unset, the field falls back to the incoming `Host` header.
+This field supports env var syntax (`"env.MY_VAR"`). When unset, it falls back to the incoming `Host` header.
 
-### The two roles
+### The client role
 
-Bifrost participates in OAuth in two directions, and each URL controls one direction:
+When Bifrost connects to an upstream MCP server (Notion, Jira, GitHub, etc.) on behalf of a user, it acts as an OAuth *client*. `mcp_external_client_url` is the callback Bifrost registers as its `redirect_uri` with those upstream providers - they redirect the user's browser to `<client URL>/api/oauth/callback` after login. Set it to the proxy's public URL so the callback resolves to a publicly reachable address.
 
-- **Server URL** is what *downstream MCP clients* read about Bifrost. It is the `issuer` in `/.well-known/oauth-authorization-server`, the `resource` in `/.well-known/oauth-protected-resource`, and the URL inside the `WWW-Authenticate` header on `/mcp`. Example: Claude Code connects to `https://bifrost.example.com/mcp` and discovers the authorize/token endpoints from this URL.
-- **Client URL** is what Bifrost hands to *upstream OAuth providers* as its own callback. It is the `redirect_uri` Bifrost registers with Notion, Jira, GitHub, etc. when it acts as an OAuth client to an MCP server. Upstream providers redirect the user's browser to `<client URL>/api/oauth/callback` after login.
-
-### Common case - one public URL
-
-Most deployments sit behind a single proxy and want both URLs to be the same. Set both to the same value:
+### Example
 
 ```json
 {
   "client": {
-    "mcp_external_server_url": "env.BIFROST_EXTERNAL_URL",
     "mcp_external_client_url": "env.BIFROST_EXTERNAL_URL"
   }
 }
@@ -88,37 +81,14 @@ Or as a plain URL:
 ```json
 {
   "client": {
-    "mcp_external_server_url": "https://api.yourcompany.com",
-    "mcp_external_client_url": "https://api.yourcompany.com"
-  }
-}
-```
-
-### Asymmetric case - different URLs per role
-
-Set them independently when the management/discovery surface and the OAuth callback surface live behind different proxies. For example, when the management UI and `/.well-known` endpoints are exposed on an internal-auth-protected hostname, but upstream OAuth providers need to redirect to a publicly reachable hostname:
-
-```json
-{
-  "client": {
-    "mcp_external_server_url": "https://internal.yourcompany.com",
     "mcp_external_client_url": "https://oauth.yourcompany.com"
   }
 }
 ```
 
-You can also set just one and leave the other empty - the unset side falls back to the request's `Host` header.
+When left empty, the `redirect_uri` falls back to the request's `Host` header - correct for development or when no reverse proxy fronts Bifrost.
 
-### When to use which
-
-| Scenario | Server URL | Client URL |
-|----------|------------|------------|
-| Single public proxy fronting Bifrost (most common) | proxy URL | same proxy URL |
-| Management/discovery on one hostname, OAuth callbacks on another | discovery hostname | callback hostname |
-| Bifrost reachable internally but upstream providers need a public callback | leave empty | public callback URL |
-| No reverse proxy (development) | leave empty | leave empty |
-
-These settings are also configurable via the UI (**MCP Gateway → MCP Settings**) and the management API, with no restart required.
+This setting is also configurable via the UI (**MCP Gateway → MCP Settings**) and the management API, with no restart required.
 
 ---
 
@@ -318,7 +288,6 @@ A top-level `auth_config` is also accepted for backwards compatibility, but `gov
     "log_retention_days": 90,
     "logging_headers": ["x-request-id", "x-user-id"],
 
-    "mcp_external_server_url": "env.BIFROST_EXTERNAL_URL",
     "mcp_external_client_url": "env.BIFROST_EXTERNAL_URL",
 
     "allowed_origins": ["https://app.yourcompany.com"],

--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -76,7 +76,6 @@ Controls the worker pool, logging pipeline, security, and SDK shims. All fields 
 | `async_job_result_ttl` | integer | `3600` | TTL for async job results in seconds |
 | `disable_db_pings_in_health` | boolean | `false` | Exclude DB connectivity from `/health` |
 | `routing_chain_max_depth` | integer | `10` | Max routing rule chain evaluation depth |
-| `mcp_external_server_url` | string \| EnvVar | - | Public base URL advertised in OAuth server metadata (`.well-known`, `WWW-Authenticate`); supports `"env.MY_VAR"` |
 | `mcp_external_client_url` | string \| EnvVar | - | Public base URL used as `redirect_uri` against upstream MCP OAuth providers; supports `"env.MY_VAR"` |
 
 Full documentation: [Client Configuration](/deployment-guides/config-json/client).

--- a/docs/mcp/gateway-url.mdx
+++ b/docs/mcp/gateway-url.mdx
@@ -305,12 +305,11 @@ See [Per-User OAuth →](./per-user-oauth) for the full flow and identity option
 
 ### Public URL configuration when behind a proxy
 
-The `WWW-Authenticate` URL above and the `redirect_uri` Bifrost hands to upstream OAuth providers (Notion, Jira, etc.) are both built from the request's `Host` header by default. Behind a reverse proxy that's the proxy's internal address, not its public one. Two settings override this:
+The `redirect_uri` Bifrost hands to upstream OAuth providers (Notion, Jira, etc.) is built from the request's `Host` header by default. Behind a reverse proxy that is the proxy's internal address, not its public one. The `mcp_external_client_url` setting overrides it with the proxy's public URL:
 
-- `mcp_external_server_url` - what Bifrost advertises in `.well-known` metadata and `WWW-Authenticate` (read by downstream MCP clients).
 - `mcp_external_client_url` - what Bifrost registers as the `redirect_uri` with upstream OAuth providers.
 
-In most setups both are the same public URL. They can differ when the management/discovery surface and the OAuth callback surface live behind different proxies. See [Reverse Proxy configuration →](../deployment-guides/config-json/client#reverse-proxy) for the full reference and examples.
+See [Reverse Proxy configuration →](../deployment-guides/config-json/client#reverse-proxy) for the full reference and examples.
 
 <Warning>
 **Changing `mcp_external_client_url` breaks already-connected MCP clients.** Upstream OAuth providers lock the `redirect_uri` to whatever was registered during Dynamic Client Registration (RFC 7591). If you change this URL afterwards, existing clients fail with **"Invalid redirect URI"** at the authorize step. To recover, clear the stored OAuth client credentials for the affected MCP server and re-authorize so Bifrost re-registers with the new URL.

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -306,24 +306,6 @@ false
 {{- if .Values.bifrost.client.routingChainMaxDepth }}
 {{- $_ := set $client "routing_chain_max_depth" .Values.bifrost.client.routingChainMaxDepth }}
 {{- end }}
-{{- if hasKey .Values.bifrost.client "mcpExternalBaseUrl" }}
-{{- $mcpExternalBaseUrl := .Values.bifrost.client.mcpExternalBaseUrl }}
-{{- if kindIs "map" $mcpExternalBaseUrl }}
-{{- $envVar := dict }}
-{{- if hasKey $mcpExternalBaseUrl "value" }}
-{{- $_ := set $envVar "value" $mcpExternalBaseUrl.value }}
-{{- end }}
-{{- if hasKey $mcpExternalBaseUrl "envVar" }}
-{{- $_ := set $envVar "env_var" $mcpExternalBaseUrl.envVar }}
-{{- end }}
-{{- if hasKey $mcpExternalBaseUrl "fromEnv" }}
-{{- $_ := set $envVar "from_env" $mcpExternalBaseUrl.fromEnv }}
-{{- end }}
-{{- $_ := set $client "mcp_external_base_url" $envVar }}
-{{- else }}
-{{- $_ := set $client "mcp_external_base_url" $mcpExternalBaseUrl }}
-{{- end }}
-{{- end }}
 {{- $_ := set $config "client" $client }}
 {{- end }}
 {{- /* Framework */ -}}
@@ -463,6 +445,7 @@ false
 {{- if hasKey . "is_active" }}{{- $_ := set $vk "is_active" .is_active }}{{- end }}
 {{- if .team_id }}{{- $_ := set $vk "team_id" .team_id }}{{- end }}
 {{- if .customer_id }}{{- $_ := set $vk "customer_id" .customer_id }}{{- end }}
+{{- if hasKey . "access_profile_id" }}{{- $_ := set $vk "access_profile_id" .access_profile_id }}{{- end }}
 {{- if .rate_limit_id }}{{- $_ := set $vk "rate_limit_id" .rate_limit_id }}{{- end }}
 {{- if .provider_configs }}{{- $_ := set $vk "provider_configs" .provider_configs }}{{- end }}
 {{- if .mcp_configs }}{{- $_ := set $vk "mcp_configs" .mcp_configs }}{{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -451,29 +451,6 @@
               "minimum": 1,
               "description": "Maximum depth for routing rule chain evaluation",
               "default": 10
-            },
-            "mcpExternalBaseUrl": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "object",
-                  "properties": {
-                    "value": {
-                      "type": "string"
-                    },
-                    "envVar": {
-                      "type": "string"
-                    },
-                    "fromEnv": {
-                      "type": "boolean"
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              ],
-              "description": "Public base URL for OAuth callbacks and discovery metadata when Bifrost runs behind a reverse proxy (e.g. \"https://api.example.com\"). Supports env var syntax: \"env.MY_VAR\"."
             }
           },
           "additionalProperties": false
@@ -1234,6 +1211,10 @@
                   },
                   "customer_id": {
                     "type": "string"
+                  },
+                  "access_profile_id": {
+                    "type": "integer",
+                    "minimum": 1
                   },
                   "rate_limit_id": {
                     "type": "string"

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -224,23 +224,6 @@
           "description": "Maximum depth for routing rule chain evaluation",
           "default": 10
         },
-        "mcp_external_server_url": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "object",
-              "properties": {
-                "value": { "type": "string" },
-                "env_var": { "type": "string" },
-                "from_env": { "type": "boolean" }
-              },
-              "additionalProperties": false
-            }
-          ],
-          "description": "Public base URL Bifrost advertises when acting as an OAuth server/resource (well-known metadata, WWW-Authenticate). Set when Bifrost runs behind a reverse proxy. Supports env var syntax: \"env.MY_VAR\"."
-        },
         "mcp_external_client_url": {
           "anyOf": [
             {
@@ -626,6 +609,11 @@
               "customer_id": {
                 "type": "string",
                 "description": "Associated customer ID (mutually exclusive with team_id)"
+              },
+              "access_profile_id": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Associated access profile ID for direct access profile assignment (mutually exclusive with team_id and customer_id)"
               },
               "rate_limit_id": {
                 "type": "string",


### PR DESCRIPTION
## Summary

Adds `access_profile_id` as a new optional field in the config schema, enabling direct access profile assignment as an alternative to `team_id` or `customer_id`. Additionally, excludes `source_id` from schema sync validation since it is an externally assigned identifier set via API by integrating systems and is not authored in `config.json`.

## Changes

- Added `access_profile_id` (integer, minimum 1) to `config.schema.json` as a mutually exclusive alternative to `team_id` and `customer_id` for direct access profile assignment
- Added `source_id` to the `ignoreGoFields` map in the schema sync script to prevent false schema drift warnings, since it is assigned through the API by integrating systems (introduced in PR #3395) and is never user-authored in `config.json`

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Verify that `access_profile_id` is accepted in config and is mutually exclusive with `team_id` and `customer_id`. Confirm that schema sync CI does not flag `source_id` as an unrecognized or missing field.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Related to #3395

## Security considerations

`access_profile_id` controls access profile assignment. Ensure appropriate authorization checks are enforced when this field is set via config to prevent unauthorized privilege escalation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable