### PR TITLE
fix: preserve tool call stop reason in Anthropic streaming fallback

### DIFF
--- a/core/providers/anthropic/compaction_test.go
+++ b/core/providers/anthropic/compaction_test.go
@@ -701,3 +701,87 @@ func TestToAnthropicResponsesStreamResponse_CompletedWithCompactionStopReason(t 
 		t.Errorf("event[1] type = %v, want message_stop", messageStop.Type)
 	}
 }
+
+func TestMixedTextThenToolCallsStreamMapsStopReasonToToolUse(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	state := schemas.AcquireChatToResponsesStreamState()
+	defer schemas.ReleaseChatToResponsesStreamState(state)
+
+	content := "\n\nNow let me fetch the source branch:"
+	toolCallID := "chatcmpl-tool-123"
+	toolName := "Bash"
+	toolType := "function"
+	arguments := `{"command":"git fetch origin feat-IGPS-15746-controller-health-endpoint"}`
+	finishReason := string(schemas.BifrostFinishReasonToolCalls)
+
+	chatChunks := []*schemas.BifrostChatResponse{
+		{
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					Index: 0,
+					ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+						Delta: &schemas.ChatStreamResponseChoiceDelta{Content: &content},
+					},
+				},
+			},
+		},
+		{
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					Index: 0,
+					ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+						Delta: &schemas.ChatStreamResponseChoiceDelta{
+							ToolCalls: []schemas.ChatAssistantMessageToolCall{
+								{
+									Index: 0,
+									ID:    &toolCallID,
+									Type:  &toolType,
+									Function: schemas.ChatAssistantMessageToolCallFunction{
+										Name:      &toolName,
+										Arguments: arguments,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Choices: []schemas.BifrostResponseChoice{
+				{
+					Index:        0,
+					FinishReason: &finishReason,
+					ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+						Delta: &schemas.ChatStreamResponseChoiceDelta{},
+					},
+				},
+			},
+		},
+	}
+
+	var events []*AnthropicStreamEvent
+	for _, chunk := range chatChunks {
+		for _, responseEvent := range chunk.ToBifrostResponsesStreamResponse(state) {
+			events = append(events, ToAnthropicResponsesStreamResponse(ctx, responseEvent)...)
+		}
+	}
+
+	var messageDelta *AnthropicStreamEvent
+	for _, event := range events {
+		if event.Type == AnthropicStreamEventTypeMessageDelta {
+			messageDelta = event
+		}
+	}
+
+	if messageDelta == nil || messageDelta.Delta == nil || messageDelta.Delta.StopReason == nil {
+		t.Fatalf("expected message_delta stop_reason in events: %#v", events)
+	}
+	if *messageDelta.Delta.StopReason != AnthropicStopReasonToolUse {
+		t.Fatalf("message_delta stop_reason = %q, want %q", *messageDelta.Delta.StopReason, AnthropicStopReasonToolUse)
+	}
+}

--- a/core/providers/anthropic/compaction_test.go
+++ b/core/providers/anthropic/compaction_test.go
@@ -772,9 +772,13 @@ func TestMixedTextThenToolCallsStreamMapsStopReasonToToolUse(t *testing.T) {
 	}
 
 	var messageDelta *AnthropicStreamEvent
+	var hasMessageStop bool
 	for _, event := range events {
 		if event.Type == AnthropicStreamEventTypeMessageDelta {
 			messageDelta = event
+		}
+		if event.Type == AnthropicStreamEventTypeMessageStop {
+			hasMessageStop = true
 		}
 	}
 
@@ -783,5 +787,8 @@ func TestMixedTextThenToolCallsStreamMapsStopReasonToToolUse(t *testing.T) {
 	}
 	if *messageDelta.Delta.StopReason != AnthropicStopReasonToolUse {
 		t.Fatalf("message_delta stop_reason = %q, want %q", *messageDelta.Delta.StopReason, AnthropicStopReasonToolUse)
+	}
+	if !hasMessageStop {
+		t.Fatal("expected message_stop event in mixed text+tool_use stream")
 	}
 }

--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -1347,6 +1347,16 @@ func responsesStatusFromChatFinishReason(finishReason string) (status string, in
 	}
 }
 
+func responsesStopReasonFromChatFinishReason(finishReason *string) *string {
+	if finishReason == nil || *finishReason == "" {
+		return nil
+	}
+	if _, _, mapped := responsesStatusFromChatFinishReason(*finishReason); !mapped {
+		return nil
+	}
+	return Ptr(*finishReason)
+}
+
 func responsesTerminalFromChatFinishReason(finishReason *string) (eventType ResponsesStreamResponseType, status string, incompleteDetails *ResponsesResponseIncompleteDetails) {
 	// Unknown/empty finish reasons preserve prior behavior: treat as completed.
 	eventType = ResponsesStreamResponseTypeCompleted
@@ -1418,8 +1428,12 @@ func (cr *BifrostChatResponse) ToBifrostResponsesResponse() *BifrostResponsesRes
 		if status == "incomplete" {
 			responsesResp.Status = Ptr(status)
 			responsesResp.IncompleteDetails = incompleteDetails
+			responsesResp.StopReason = responsesStopReasonFromChatFinishReason(choice.FinishReason)
 			hasCompletedFinishReason = false
 			break
+		}
+		if responsesResp.StopReason == nil {
+			responsesResp.StopReason = responsesStopReasonFromChatFinishReason(choice.FinishReason)
 		}
 		hasCompletedFinishReason = true
 	}
@@ -2106,6 +2120,7 @@ func (cr *BifrostChatResponse) ToBifrostResponsesStreamResponse(state *ChatToRes
 			CreatedAt:         state.CreatedAt,
 			Usage:             usage,
 			Status:            &responseStatus,
+			StopReason:        responsesStopReasonFromChatFinishReason(choice.FinishReason),
 			IncompleteDetails: terminalIncompleteDetails,
 		}
 

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -497,6 +497,9 @@ func TestToBifrostResponsesResponse_MapsLengthToIncomplete(t *testing.T) {
 	if resp.IncompleteDetails.Reason != "max_output_tokens" {
 		t.Fatalf("expected incomplete_details.reason %q, got %q", "max_output_tokens", resp.IncompleteDetails.Reason)
 	}
+	if resp.StopReason == nil || *resp.StopReason != length {
+		t.Fatalf("expected stop_reason %q, got %v", length, resp.StopReason)
+	}
 }
 
 func TestToBifrostResponsesResponse_MapsToolCallsToCompleted(t *testing.T) {
@@ -515,6 +518,9 @@ func TestToBifrostResponsesResponse_MapsToolCallsToCompleted(t *testing.T) {
 	}
 	if resp.IncompleteDetails != nil {
 		t.Fatal("expected incomplete_details to be nil")
+	}
+	if resp.StopReason == nil || *resp.StopReason != toolCalls {
+		t.Fatalf("expected stop_reason %q, got %v", toolCalls, resp.StopReason)
 	}
 }
 
@@ -555,6 +561,9 @@ func TestToBifrostResponsesResponse_UnknownFinishReasonLeavesStatusUnset(t *test
 	}
 	if resp.IncompleteDetails != nil {
 		t.Fatal("expected incomplete_details to be nil")
+	}
+	if resp.StopReason != nil {
+		t.Fatalf("expected stop_reason to be nil, got %q", *resp.StopReason)
 	}
 }
 
@@ -664,6 +673,9 @@ func TestToBifrostResponsesStreamResponse_IncludesFunctionCallsInCompletedOutput
 
 	if completed == nil || completed.Response == nil {
 		t.Fatal("expected response.completed event")
+	}
+	if completed.Response.StopReason == nil || *completed.Response.StopReason != toolCallsFinish {
+		t.Fatalf("expected completed stop_reason %q, got %v", toolCallsFinish, completed.Response.StopReason)
 	}
 
 	output := completed.Response.Output
@@ -855,6 +867,9 @@ func TestToBifrostResponsesStreamResponse_MapsLengthToIncompleteEvent(t *testing
 	}
 	if incomplete.Response.IncompleteDetails == nil || incomplete.Response.IncompleteDetails.Reason != "max_output_tokens" {
 		t.Fatal("expected incomplete_details.reason to be max_output_tokens")
+	}
+	if incomplete.Response.StopReason == nil || *incomplete.Response.StopReason != length {
+		t.Fatalf("expected stop_reason %q, got %v", length, incomplete.Response.StopReason)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #3638.

When OpenAI-compatible chat streaming is converted into Bifrost Responses stream events, the terminal event now preserves recognized chat `finish_reason` values as `Response.StopReason`.

That lets the Anthropic serializer map a mixed text + tool-call stream ending with `finish_reason: "tool_calls"` to:

```json
{"stop_reason":"tool_use"}
```

instead of falling back to `end_turn`.

## What changed

- Preserve mapped chat finish reasons (`stop`, `tool_calls`, `length`) on non-stream Responses conversion.
- Preserve the same stop reason on terminal streaming Responses events.
- Keep the existing status mapping behavior separate:
  - `stop` / `tool_calls` -> `completed`
  - `length` -> `incomplete` with `max_output_tokens`
  - unknown finish reasons remain unset.
- Add regression coverage for the mixed text + tool-call Anthropic stream case.

## Tests

```text
go test ./schemas -run 'TestToBifrostResponses(StreamResponse|Response)_' -count=1
ok  github.com/maximhq/bifrost/core/schemas  0.491s

go test ./providers/anthropic -run 'TestMixedTextThenToolCallsStreamMapsStopReasonToToolUse|TestToAnthropicResponsesResponse_StopReasonFromBifrost|TestToAnthropicResponsesStreamResponse_CompletedWithCompactionStopReason' -count=1
ok  github.com/maximhq/bifrost/core/providers/anthropic  0.533s
```
