### PR TITLE
fix: attribute usage logs to governance IDs

### DIFF
--- a/framework/logstore/hybrid.go
+++ b/framework/logstore/hybrid.go
@@ -586,8 +586,8 @@ func (h *HybridLogStore) BulkUpdateCost(ctx context.Context, updates map[string]
 	return h.inner.BulkUpdateCost(ctx, updates)
 }
 
-func (h *HybridLogStore) GetNodeUsageSince(ctx context.Context, nodeID string, since time.Time) (*NodeUsageAggregate, error) {
-	return h.inner.GetNodeUsageSince(ctx, nodeID, since)
+func (h *HybridLogStore) GetNodeUsageAfter(ctx context.Context, nodeID string, cursor NodeUsageCursor) (*NodeUsageAggregate, error) {
+	return h.inner.GetNodeUsageAfter(ctx, nodeID, cursor)
 }
 
 func (h *HybridLogStore) Flush(ctx context.Context, since time.Time) error {

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -1697,7 +1697,7 @@ func migrationAddRequestIDColumnToMCPToolLogs(ctx context.Context, db *gorm.DB) 
           FROM batch
           WHERE mcp_tool_logs.ctid = batch.ctid
         `); err != nil {
-				return err
+					return err
 				}
 			} else {
 				result := tx.Exec("UPDATE mcp_tool_logs SET request_id = id WHERE request_id IS NULL OR request_id = ''")
@@ -2490,6 +2490,11 @@ var performanceIndexes = []performanceIndexDef{
 		table: "logs",
 		name:  "idx_logs_cluster_node_id",
 		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_cluster_node_id ON logs(cluster_node_id, timestamp) WHERE cluster_node_id IS NOT NULL",
+	},
+	{
+		table: "logs",
+		name:  "idx_logs_cluster_node_usage",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_cluster_node_usage ON logs(cluster_node_id, status, timestamp, id) WHERE cluster_node_id IS NOT NULL",
 	},
 }
 

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -352,26 +352,33 @@ func (s *RDBLogStore) BulkUpdateCost(ctx context.Context, updates map[string]flo
 	})
 }
 
-// GetNodeUsageSince returns per-budget cost and per-rate-limit request/token usage
-// for a specific cluster node from a given timestamp onwards. Usage is attributed
-// to the exact budget and rate-limit IDs stored in each log entry, so callers get
-// correctly scoped breakdowns rather than a single aggregate.
-func (s *RDBLogStore) GetNodeUsageSince(ctx context.Context, nodeID string, since time.Time) (*NodeUsageAggregate, error) {
-	// Fetch only the columns needed for attribution. The row count is bounded by
-	// the ghost node's activity since its LastMessageAt, typically a small window.
+// GetNodeUsageAfter returns per-budget cost and per-rate-limit request/token usage
+// for a specific cluster node after a stable composite cursor. Timestamp alone is
+// not unique, so once a cursor has a log ID, same-timestamp rows with greater IDs
+// are included to avoid skipping late async log writes.
+func (s *RDBLogStore) GetNodeUsageAfter(ctx context.Context, nodeID string, cursor NodeUsageCursor) (*NodeUsageAggregate, error) {
 	type logRow struct {
-		Cost         float64 `gorm:"column:cost"`
-		TotalTokens  int64   `gorm:"column:total_tokens"`
-		BudgetIDs    *string `gorm:"column:budget_ids"`
-		RateLimitIDs *string `gorm:"column:rate_limit_ids"`
+		ID           string    `gorm:"column:id"`
+		Timestamp    time.Time `gorm:"column:timestamp"`
+		Cost         float64   `gorm:"column:cost"`
+		TotalTokens  int64     `gorm:"column:total_tokens"`
+		BudgetIDs    *string   `gorm:"column:budget_ids"`
+		RateLimitIDs *string   `gorm:"column:rate_limit_ids"`
 	}
 	var rows []logRow
 
-	err := s.db.WithContext(ctx).Model(&Log{}).
+	query := s.db.WithContext(ctx).Model(&Log{}).
 		Where("cluster_node_id = ?", nodeID).
-		Where("timestamp >= ?", since).
-		Where("status = ?", "success").
-		Select("COALESCE(cost, 0) as cost, COALESCE(total_tokens, 0) as total_tokens, budget_ids, rate_limit_ids").
+		Where("status = ?", "success")
+	if cursor.LogID != "" {
+		query = query.Where("timestamp > ? OR (timestamp = ? AND id > ?)", cursor.Timestamp, cursor.Timestamp, cursor.LogID)
+	} else {
+		query = query.Where("timestamp > ?", cursor.Timestamp)
+	}
+
+	err := query.
+		Select("id, timestamp, COALESCE(cost, 0) as cost, COALESCE(total_tokens, 0) as total_tokens, budget_ids, rate_limit_ids").
+		Order("timestamp ASC, id ASC").
 		Find(&rows).Error
 	if err != nil {
 		return nil, fmt.Errorf("failed to get node usage aggregate: %w", err)
@@ -381,8 +388,12 @@ func (s *RDBLogStore) GetNodeUsageSince(ctx context.Context, nodeID string, sinc
 	rateLimitRequests := make(map[string]int64)
 	rateLimitTokens := make(map[string]int64)
 
+	maxCursor := cursor // preserve incoming cursor so zero rows don't rewind
 	for i := range rows {
 		row := &rows[i]
+		if row.Timestamp.After(maxCursor.Timestamp) || (row.Timestamp.Equal(maxCursor.Timestamp) && row.ID > maxCursor.LogID) {
+			maxCursor = NodeUsageCursor{Timestamp: row.Timestamp, LogID: row.ID}
+		}
 
 		// Attribute cost to each budget that governed this request.
 		if row.BudgetIDs != nil && *row.BudgetIDs != "" {
@@ -424,6 +435,10 @@ func (s *RDBLogStore) GetNodeUsageSince(ctx context.Context, nodeID string, sinc
 		BudgetCosts:       budgetCosts,
 		RateLimitRequests: rateLimitRequests,
 		RateLimitTokens:   rateLimitTokens,
+		RowCount:          len(rows),
+		MaxTimestamp:      maxCursor.Timestamp,
+		MaxLogID:          maxCursor.LogID,
+		NextCursor:        maxCursor,
 	}, nil
 }
 

--- a/framework/logstore/rdb_perf_test.go
+++ b/framework/logstore/rdb_perf_test.go
@@ -83,6 +83,184 @@ func TestLogCreateSerializesFields(t *testing.T) {
 	}
 }
 
+func TestGetNodeUsageSinceTracksMaxTimestampAndExclusiveCursor(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	nodeID := "node-ghost"
+	otherNodeID := "node-other"
+	budgetIDs := []string{"budget-1"}
+	rateLimitIDs := []string{"rl-1"}
+	base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	cost1 := 1.25
+	cost2 := 2.50
+	otherCost := 99.0
+
+	entries := []*Log{
+		{
+			ID:                 "usage-1",
+			Timestamp:          base.Add(time.Second),
+			Object:             "chat.completion",
+			Provider:           "openai",
+			Model:              "gpt-4o-mini",
+			Status:             "success",
+			ClusterNodeID:      &nodeID,
+			BudgetIDsParsed:    budgetIDs,
+			RateLimitIDsParsed: rateLimitIDs,
+			Cost:               &cost1,
+			TotalTokens:        10,
+		},
+		{
+			ID:                 "usage-2",
+			Timestamp:          base.Add(2 * time.Second),
+			Object:             "chat.completion",
+			Provider:           "openai",
+			Model:              "gpt-4o-mini",
+			Status:             "success",
+			ClusterNodeID:      &nodeID,
+			BudgetIDsParsed:    budgetIDs,
+			RateLimitIDsParsed: rateLimitIDs,
+			Cost:               &cost2,
+			TotalTokens:        20,
+		},
+		{
+			ID:                 "usage-other-node",
+			Timestamp:          base.Add(3 * time.Second),
+			Object:             "chat.completion",
+			Provider:           "openai",
+			Model:              "gpt-4o-mini",
+			Status:             "success",
+			ClusterNodeID:      &otherNodeID,
+			BudgetIDsParsed:    budgetIDs,
+			RateLimitIDsParsed: rateLimitIDs,
+			Cost:               &otherCost,
+			TotalTokens:        100,
+		},
+	}
+	for _, entry := range entries {
+		if err := store.Create(ctx, entry); err != nil {
+			t.Fatalf("Create(%s) error = %v", entry.ID, err)
+		}
+	}
+
+	usage, err := store.GetNodeUsageAfter(ctx, nodeID, NodeUsageCursor{Timestamp: base})
+	if err != nil {
+		t.Fatalf("GetNodeUsageSince() error = %v", err)
+	}
+	if usage.RowCount != 2 {
+		t.Fatalf("expected 2 rows, got %d", usage.RowCount)
+	}
+	if got := usage.BudgetCosts["budget-1"]; got != cost1+cost2 {
+		t.Fatalf("expected budget cost %.2f, got %.2f", cost1+cost2, got)
+	}
+	if got := usage.RateLimitRequests["rl-1"]; got != 2 {
+		t.Fatalf("expected 2 rate-limit requests, got %d", got)
+	}
+	if got := usage.RateLimitTokens["rl-1"]; got != 30 {
+		t.Fatalf("expected 30 rate-limit tokens, got %d", got)
+	}
+	if !usage.MaxTimestamp.Equal(base.Add(2 * time.Second)) {
+		t.Fatalf("expected max timestamp %s, got %s", base.Add(2*time.Second), usage.MaxTimestamp)
+	}
+	if usage.MaxLogID != "usage-2" {
+		t.Fatalf("expected max log ID usage-2, got %s", usage.MaxLogID)
+	}
+	if usage.NextCursor.Timestamp != usage.MaxTimestamp || usage.NextCursor.LogID != usage.MaxLogID {
+		t.Fatalf("expected next cursor to match max row, got %+v", usage.NextCursor)
+	}
+
+	usage, err = store.GetNodeUsageAfter(ctx, nodeID, usage.NextCursor)
+	if err != nil {
+		t.Fatalf("GetNodeUsageAfter(after max) error = %v", err)
+	}
+	if usage.RowCount != 0 {
+		t.Fatalf("expected no rows after exclusive cursor, got rows=%d", usage.RowCount)
+	}
+	// When no rows are returned, NextCursor should preserve the incoming cursor (not rewind).
+	if !usage.NextCursor.Timestamp.Equal(base.Add(2*time.Second)) || usage.NextCursor.LogID != "usage-2" {
+		t.Fatalf("expected cursor to be preserved when no rows returned, got %+v", usage.NextCursor)
+	}
+}
+
+func TestGetNodeUsageAfterIncludesSameTimestampGreaterLogIDs(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	ctx := context.Background()
+	nodeID := "node-ghost"
+	budgetIDs := []string{"budget-1"}
+	rateLimitIDs := []string{"rl-1"}
+	timestamp := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	cost1 := 1.0
+	cost2 := 2.0
+	cost3 := 4.0
+
+	entries := []*Log{
+		{
+			ID:                 "usage-1",
+			Timestamp:          timestamp,
+			Object:             "chat.completion",
+			Provider:           "openai",
+			Model:              "gpt-4o-mini",
+			Status:             "success",
+			ClusterNodeID:      &nodeID,
+			BudgetIDsParsed:    budgetIDs,
+			RateLimitIDsParsed: rateLimitIDs,
+			Cost:               &cost1,
+			TotalTokens:        10,
+		},
+		{
+			ID:                 "usage-2",
+			Timestamp:          timestamp,
+			Object:             "chat.completion",
+			Provider:           "openai",
+			Model:              "gpt-4o-mini",
+			Status:             "success",
+			ClusterNodeID:      &nodeID,
+			BudgetIDsParsed:    budgetIDs,
+			RateLimitIDsParsed: rateLimitIDs,
+			Cost:               &cost2,
+			TotalTokens:        20,
+		},
+		{
+			ID:                 "usage-3",
+			Timestamp:          timestamp,
+			Object:             "chat.completion",
+			Provider:           "openai",
+			Model:              "gpt-4o-mini",
+			Status:             "success",
+			ClusterNodeID:      &nodeID,
+			BudgetIDsParsed:    budgetIDs,
+			RateLimitIDsParsed: rateLimitIDs,
+			Cost:               &cost3,
+			TotalTokens:        40,
+		},
+	}
+	for _, entry := range entries {
+		if err := store.Create(ctx, entry); err != nil {
+			t.Fatalf("Create(%s) error = %v", entry.ID, err)
+		}
+	}
+
+	// Cursor after usage-1: should get usage-2 and usage-3 (same timestamp, greater IDs)
+	usage, err := store.GetNodeUsageAfter(ctx, nodeID, NodeUsageCursor{Timestamp: timestamp, LogID: "usage-1"})
+	if err != nil {
+		t.Fatalf("GetNodeUsageAfter() error = %v", err)
+	}
+	if usage.RowCount != 2 {
+		t.Fatalf("expected 2 same-timestamp rows after usage-1, got %d", usage.RowCount)
+	}
+	if got := usage.BudgetCosts["budget-1"]; got != cost2+cost3 {
+		t.Fatalf("expected budget cost %.2f, got %.2f", cost2+cost3, got)
+	}
+	if got := usage.RateLimitRequests["rl-1"]; got != 2 {
+		t.Fatalf("expected 2 rate-limit requests, got %d", got)
+	}
+	if got := usage.RateLimitTokens["rl-1"]; got != 60 {
+		t.Fatalf("expected 60 rate-limit tokens, got %d", got)
+	}
+	if !usage.MaxTimestamp.Equal(timestamp) || usage.MaxLogID != "usage-3" {
+		t.Fatalf("expected cursor %s/usage-3, got %s/%s", timestamp, usage.MaxTimestamp, usage.MaxLogID)
+	}
+}
+
 func TestMCPToolLogCreateSerializesFields(t *testing.T) {
 	store := newTestSQLiteStore(t)
 

--- a/framework/logstore/store.go
+++ b/framework/logstore/store.go
@@ -50,9 +50,10 @@ type LogStore interface {
 	GetDimensionTokenHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64, dimension HistogramDimension) (*DimensionTokenHistogramResult, error)
 	// GetDimensionLatencyHistogram returns time-bucketed latency percentiles grouped by the specified dimension.
 	GetDimensionLatencyHistogram(ctx context.Context, filters SearchFilters, bucketSizeSeconds int64, dimension HistogramDimension) (*DimensionLatencyHistogramResult, error)
-	// GetNodeUsageSince returns cumulative cost, successful request count, and token usage
-	// for a specific cluster node from a given timestamp onwards.
-	GetNodeUsageSince(ctx context.Context, nodeID string, since time.Time) (*NodeUsageAggregate, error)
+	// GetNodeUsageAfter returns cumulative usage for rows after the provided stable
+	// cursor. When the cursor has both timestamp and log ID, rows with the same
+	// timestamp but greater log ID are included to avoid skipping same-timestamp rows.
+	GetNodeUsageAfter(ctx context.Context, nodeID string, cursor NodeUsageCursor) (*NodeUsageAggregate, error)
 	Update(ctx context.Context, id string, entry any) error
 	BulkUpdateCost(ctx context.Context, updates map[string]float64) error
 	Flush(ctx context.Context, since time.Time) error

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -201,9 +201,9 @@ type Log struct {
 
 	// Cluster governance fields - attached by the logging plugin when running in a cluster
 	// so that leaders can recover disconnected node usage from the logs table.
-	ClusterNodeID  *string `gorm:"type:varchar(255)" json:"cluster_node_id,omitempty"`
-	BudgetIDs      *string `gorm:"type:text" json:"-"` // JSON serialized []string of budget IDs applicable to this request
-	RateLimitIDs   *string `gorm:"type:text" json:"-"` // JSON serialized []string of rate limit IDs applicable to this request
+	ClusterNodeID *string `gorm:"type:varchar(255)" json:"cluster_node_id,omitempty"`
+	BudgetIDs     *string `gorm:"type:text" json:"-"` // JSON serialized []string of budget IDs applicable to this request
+	RateLimitIDs  *string `gorm:"type:text" json:"-"` // JSON serialized []string of rate limit IDs applicable to this request
 
 	// Denormalized token fields for easier querying
 	PromptTokens     int `gorm:"default:0" json:"-"`
@@ -246,8 +246,8 @@ type Log struct {
 	VideoListOutputParsed       *schemas.BifrostVideoListResponse       `gorm:"-" json:"video_list_output,omitempty"`
 	VideoDeleteOutputParsed     *schemas.BifrostVideoDeleteResponse     `gorm:"-" json:"video_delete_output,omitempty"`
 	AttemptTrailParsed          []schemas.KeyAttemptRecord              `gorm:"-" json:"attempt_trail,omitempty"`
-	BudgetIDsParsed    []string `gorm:"-" json:"budget_ids,omitempty"`
-	RateLimitIDsParsed []string `gorm:"-" json:"rate_limit_ids,omitempty"`
+	BudgetIDsParsed             []string                                `gorm:"-" json:"budget_ids,omitempty"`
+	RateLimitIDsParsed          []string                                `gorm:"-" json:"rate_limit_ids,omitempty"`
 
 	// Populated in handlers after find using the virtual key id and key id
 	VirtualKey  *tables.TableVirtualKey  `gorm:"-" json:"virtual_key,omitempty"`  // redacted
@@ -553,7 +553,8 @@ func (l *Log) SerializeFields() error {
 			l.Metadata = nil
 			l.MetadataParsed = nil
 		} else {
-			l.Metadata = new(string(data))
+			metadata := string(data)
+			l.Metadata = &metadata
 		}
 	}
 
@@ -561,7 +562,8 @@ func (l *Log) SerializeFields() error {
 		if data, err := sonic.Marshal(l.BudgetIDsParsed); err != nil {
 			return err
 		} else {
-			l.BudgetIDs = new(string(data))
+			budgetIDs := string(data)
+			l.BudgetIDs = &budgetIDs
 		}
 	}
 
@@ -569,7 +571,8 @@ func (l *Log) SerializeFields() error {
 		if data, err := sonic.Marshal(l.RateLimitIDsParsed); err != nil {
 			return err
 		} else {
-			l.RateLimitIDs = new(string(data))
+			rateLimitIDs := string(data)
+			l.RateLimitIDs = &rateLimitIDs
 		}
 	}
 
@@ -1540,6 +1543,14 @@ type UserRankingResult struct {
 	Rankings []UserRankingWithTrend `json:"rankings"`
 }
 
+// NodeUsageCursor identifies the last log row included in a node usage scan.
+// Timestamp alone is not unique, so LogID is used as a stable tiebreaker once a
+// previous row has been processed.
+type NodeUsageCursor struct {
+	Timestamp time.Time `json:"timestamp"`
+	LogID     string    `json:"log_id"`
+}
+
 // NodeUsageAggregate represents aggregated usage for a specific node from the logs table,
 // broken down by the budget and rate-limit IDs that each log entry was tagged with.
 // This ensures usage is attributed to the correct governance resource rather than
@@ -1548,4 +1559,8 @@ type NodeUsageAggregate struct {
 	BudgetCosts       map[string]float64 `json:"budget_costs"`        // budget_id -> cumulative cost
 	RateLimitRequests map[string]int64   `json:"rate_limit_requests"` // rate_limit_id -> successful request count
 	RateLimitTokens   map[string]int64   `json:"rate_limit_tokens"`   // rate_limit_id -> total tokens
+	RowCount          int                `json:"row_count"`           // number of log rows included in the aggregate
+	MaxTimestamp      time.Time          `json:"max_timestamp"`       // highest log timestamp included in the aggregate
+	MaxLogID          string             `json:"max_log_id"`          // log ID tiebreaker for MaxTimestamp
+	NextCursor        NodeUsageCursor    `json:"next_cursor"`         // stable cursor for the next incremental query
 }

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1495,6 +1495,18 @@ func (p *GovernancePlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	// If effectiveVK is empty, it will be passed as empty string to postHookWorker
 	// The tracker will handle empty virtual keys gracefully by only updating provider-level and model-level usage
 	if requestedModel != "" {
+		// Collect the affected budget and rate-limit IDs synchronously (fast in-memory
+		// lookups) and attach them to the context. The logging plugin reads these keys
+		// when building the log entry, enabling ghost-node usage reconciliation to
+		// attribute cost/tokens to the correct governance entities.
+		budgetIDs, rateLimitIDs := p.store.CollectApplicableGovernanceIDs(ctx, effectiveVK, provider, requestedModel)
+		if len(budgetIDs) > 0 {
+			ctx.SetValue(schemas.BifrostContextKeyGovernanceBudgetIDs, budgetIDs)
+		}
+		if len(rateLimitIDs) > 0 {
+			ctx.SetValue(schemas.BifrostContextKeyGovernanceRateLimitIDs, rateLimitIDs)
+		}
+
 		p.wg.Add(1)
 		go func() {
 			defer p.wg.Done()

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -179,6 +179,12 @@ type GovernanceStore interface {
 	GetScopedRoutingRules(ctx context.Context, scope string, scopeID string) []*configstoreTables.TableRoutingRule
 	UpdateRoutingRuleInMemory(ctx context.Context, rule *configstoreTables.TableRoutingRule) error
 	DeleteRoutingRuleInMemory(ctx context.Context, id string) error
+	// CollectApplicableGovernanceIDs returns the budget and rate-limit IDs that
+	// govern a request for the given virtual key, provider, and model. The
+	// returned IDs are attached to log entries so that ghost-node usage
+	// reconciliation can attribute cost and tokens to the correct governance
+	// entities.
+	CollectApplicableGovernanceIDs(ctx context.Context, virtualKey string, provider schemas.ModelProvider, model string) (budgetIDs []string, rateLimitIDs []string)
 }
 
 // NewLocalGovernanceStore creates a new in-memory governance store
@@ -2247,6 +2253,83 @@ func (gs *LocalGovernanceStore) collectRateLimitIDsFromMemory(ctx context.Contex
 		}
 	}
 	return rateLimitIDs
+}
+
+// CollectApplicableGovernanceIDs returns the budget and rate-limit IDs that are
+// affected by a request with the given virtual key, provider, and model.
+// It combines provider-level, model-level, and VK-hierarchy (team/customer) IDs.
+// All lookups are fast in-memory sync.Map reads.
+func (gs *LocalGovernanceStore) CollectApplicableGovernanceIDs(ctx context.Context, virtualKey string, provider schemas.ModelProvider, model string) (budgetIDs []string, rateLimitIDs []string) {
+	seenBudgets := map[string]bool{}
+	seenRateLimits := map[string]bool{}
+
+	// --- Provider-level ---
+	if provider != "" {
+		providerKey := string(provider)
+		if value, exists := gs.providers.Load(providerKey); exists && value != nil {
+			if pt, ok := value.(*configstoreTables.TableProvider); ok && pt != nil {
+				if pt.BudgetID != nil && !seenBudgets[*pt.BudgetID] {
+					budgetIDs = append(budgetIDs, *pt.BudgetID)
+					seenBudgets[*pt.BudgetID] = true
+				}
+				if pt.RateLimitID != nil && !seenRateLimits[*pt.RateLimitID] {
+					rateLimitIDs = append(rateLimitIDs, *pt.RateLimitID)
+					seenRateLimits[*pt.RateLimitID] = true
+				}
+			}
+		}
+	}
+
+	// --- Model-level ---
+	if model != "" {
+		// model+provider specific config
+		if provider != "" {
+			key := fmt.Sprintf("%s:%s", model, string(provider))
+			if value, exists := gs.modelConfigs.Load(key); exists && value != nil {
+				if mc, ok := value.(*configstoreTables.TableModelConfig); ok && mc != nil {
+					if mc.BudgetID != nil && !seenBudgets[*mc.BudgetID] {
+						budgetIDs = append(budgetIDs, *mc.BudgetID)
+						seenBudgets[*mc.BudgetID] = true
+					}
+					if mc.RateLimitID != nil && !seenRateLimits[*mc.RateLimitID] {
+						rateLimitIDs = append(rateLimitIDs, *mc.RateLimitID)
+						seenRateLimits[*mc.RateLimitID] = true
+					}
+				}
+			}
+		}
+		// model-only config
+		if mc, _ := gs.findModelOnlyConfig(ctx, model); mc != nil {
+			if mc.BudgetID != nil && !seenBudgets[*mc.BudgetID] {
+				budgetIDs = append(budgetIDs, *mc.BudgetID)
+				seenBudgets[*mc.BudgetID] = true
+			}
+			if mc.RateLimitID != nil && !seenRateLimits[*mc.RateLimitID] {
+				rateLimitIDs = append(rateLimitIDs, *mc.RateLimitID)
+				seenRateLimits[*mc.RateLimitID] = true
+			}
+		}
+	}
+
+	// --- VK hierarchy (provider-config → VK → team → customer) ---
+	if virtualKey != "" {
+		if vk, exists := gs.GetVirtualKey(ctx, virtualKey); exists && vk != nil {
+			for _, id := range gs.collectBudgetIDsFromMemory(ctx, vk, provider) {
+				if !seenBudgets[id] {
+					budgetIDs = append(budgetIDs, id)
+					seenBudgets[id] = true
+				}
+			}
+			for _, id := range gs.collectRateLimitIDsFromMemory(ctx, vk, provider) {
+				if !seenRateLimits[id] {
+					rateLimitIDs = append(rateLimitIDs, id)
+					seenRateLimits[id] = true
+				}
+			}
+		}
+	}
+
+	return budgetIDs, rateLimitIDs
 }
 
 // PUBLIC API METHODS


### PR DESCRIPTION
## Summary

Improve governance usage attribution in logs by recording the affected budget
and rate-limit IDs for each request, and make node-usage aggregation cursor-safe
for asynchronous log writes.

## Changes

- Added governance ID collection for the exact budgets and rate limits affected
  by a request across provider, model, and virtual-key hierarchy scopes.
- Set affected budget and rate-limit IDs on request context during the
  governance post-LLM hook so the logging plugin can persist them into log rows.
- Changed node-usage log aggregation to use an exclusive timestamp cursor and
  return cursor metadata (`RowCount` and `MaxTimestamp`) so consumers can safely
  continue from the latest processed log row.
- Added focused logstore coverage for cursor advancement, node filtering, status
  filtering, and budget/rate-limit attribution.

Notable design decisions:

- Governance IDs are collected synchronously before async usage tracking starts,
  because logging reads the request context after plugin hooks complete.
- The governance ID collection reuses existing in-memory governance data and
  hierarchy helpers instead of duplicating attribution logic elsewhere.
- Node-usage aggregation now advances from the maximum timestamp actually
  returned by the log query rather than from wall-clock time, which is safer
  when log writes are batched or delayed.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run focused validation for the changed logstore and governance paths:

```sh
go test ./framework/logstore -run 'TestGetNodeUsageSinceTracksMaxTimestampAndExclusiveCursor|TestLogCreateSerializesFields'
go build ./plugins/governance/... ./framework/logstore/...
```

Expected outcomes:

- Logstore tests pass and confirm that `GetNodeUsageSince` only returns rows
  after the cursor, tracks the latest returned timestamp, filters by
  node/status, and attributes usage to persisted budget/rate-limit IDs.
- Governance and logstore packages build successfully.

Manual validation:

1. Send requests through a virtual key with budgets and/or rate limits
   configured.
2. Confirm new successful log rows include populated `budget_ids` and
   `rate_limit_ids` for the applicable governance entities.
3. Confirm `GetNodeUsageSince` returns attributed budget costs, rate-limit
   request counts, rate-limit token counts, row count, and max timestamp for the
   requested node after the supplied cursor.

If adding new configs or environment variables, document them here.

No new configs or environment variables were added.

## Screenshots/Recordings

No UI changes in this PR.

## Breaking changes

- [ ] Yes
- [x] No

If yes, describe impact and migration instructions.

N/A

## Related issues

N/A

## Security considerations

No new auth, secret, PII, or sandboxing behavior is introduced. This change only
persists governance entity IDs that already apply to the request so usage
aggregation can correctly attribute cost and token/request counts.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
