### PR TITLE
adds cloudfront to allowed domains for dockerx

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -756,6 +756,7 @@ jobs:
             openrouter.ai:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             registry.npmjs.org:443
@@ -865,6 +866,7 @@ jobs:
             openrouter.ai:443
             pkg-containers.githubusercontent.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             registry.npmjs.org:443
@@ -1568,6 +1570,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             registry.npmjs.org:443
@@ -1655,6 +1658,7 @@ jobs:
             fonts.gstatic.com:443
             github.com:443
             production.cloudflare.docker.com:443
+            production.cloudfront.docker.com:443
             proxy.golang.org:443
             registry-1.docker.io:443
             registry.npmjs.org:443


### PR DESCRIPTION
## Summary

Adds `production.cloudfront.docker.com:443` to the allowlist of permitted outbound network endpoints in the release pipeline, resolving potential Docker image pull failures caused by missing egress access to this CDN endpoint.

## Changes

- Added `production.cloudfront.docker.com:443` to the network egress allowlist in four separate release pipeline jobs where `production.cloudflare.docker.com:443` was already permitted, ensuring Docker registry traffic routed through CloudFront is not blocked.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Trigger the release pipeline and verify that Docker image pulls succeed without network egress errors in the affected jobs.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The added endpoint (`production.cloudfront.docker.com`) is an official Docker Hub CDN domain used to serve container image layers. Allowlisting it is consistent with the existing `production.cloudflare.docker.com` entry and does not introduce any new trust boundaries beyond what is already permitted for Docker registry access.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable