### PR TITLE
fix: clear governanceRejectedContextKey on decision allow of governance req so that fallbacks account for budgets/rate limits


### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1313,6 +1313,13 @@ func (p *GovernancePlugin) EvaluateGovernanceRequest(ctx *schemas.BifrostContext
 	// Handle decision
 	switch result.Decision {
 	case DecisionAllow:
+		// Clear any prior rejection flag (e.g. from a failed primary attempt
+		// before a fallback retry). Without this, PostLLMHook would see the
+		// stale flag and skip budget/rate-limit ID collection for the
+		// successful fallback attempt.
+		if ctx != nil {
+			ctx.ClearValue(governanceRejectedContextKey)
+		}
 		return result, nil
 
 	case DecisionVirtualKeyNotFound, DecisionVirtualKeyBlocked, DecisionModelBlocked, DecisionProviderBlocked:


### PR DESCRIPTION
## Summary

When a primary LLM request fails and a fallback retry succeeds, the governance
plugin was leaving a stale rejection flag in the context. This caused
`PostLLMHook` to skip budget and rate-limit ID collection for the successful
fallback attempt, as it incorrectly treated the request as rejected.

## Changes

- Clear the `governanceRejectedContextKey` flag from the context whenever a
  `DecisionAllow` result is reached, ensuring that any rejection flag set during
  a prior failed attempt does not persist into a successful fallback retry.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Plugins

## How to test

Trigger a scenario where a primary provider attempt fails governance and a
fallback attempt succeeds. Verify that `PostLLMHook` correctly collects budget
and rate-limit IDs for the successful fallback response rather than skipping
collection due to the stale rejection flag.

```sh
go test ./plugins/governance/...
```

## Breaking changes

- [x] No

## Security considerations

No security implications. This fix ensures accurate budget and rate-limit
tracking, which could prevent unintended bypasses of usage accounting on
fallback paths.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

