### PR TITLE
feat: preserve time filter params when navigating between sidebar items

### DIFF
--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -188,6 +188,29 @@ const TimeFilterPages = new Set([
   "/workspace/mcp-logs",
 ]);
 
+const preserveTimeFilters = (
+  baseHref: string,
+  subItemUrl: string,
+  pathname: string,
+  search: string,
+): string => {
+  if (TimeFilterPages.has(subItemUrl) && TimeFilterPages.has(pathname)) {
+    const currentParams = new URLSearchParams(search);
+    const startTime = currentParams.get("start_time");
+    const endTime = currentParams.get("end_time");
+    const period = currentParams.get("period");
+    if ((startTime && endTime) || period) {
+      const params = new URLSearchParams();
+      if (startTime) params.set("start_time", startTime);
+      if (endTime) params.set("end_time", endTime);
+      if (period) params.set("period", period);
+      const sep = baseHref.includes("?") ? "&" : "?";
+      return `${baseHref}${sep}${params.toString()}`;
+    }
+  }
+  return baseHref;
+};
+
 const SidebarItemView = ({
   item,
   isActive,
@@ -405,7 +428,8 @@ const SidebarItemView = ({
               {item.title}
             </div>
             {item.subItems?.map((subItem) => {
-              const href = getSidebarItemHref(subItem);
+              const baseHref = getSidebarItemHref(subItem);
+              const href = preserveTimeFilters(baseHref, subItem.url, pathname, search);
               const isSubItemActive = subItem.queryParam
                 ? pathname === subItem.url
                 : isRouteMatch(subItem.url);
@@ -468,26 +492,7 @@ const SidebarItemView = ({
         <SidebarMenuSub className="border-sidebar-border mt-1 ml-4 space-y-0.5 border-l pl-2">
           {item.subItems?.map((subItem: SidebarItem) => {
             const baseHref = getSidebarItemHref(subItem);
-            const subItemHref = (() => {
-              if (
-                TimeFilterPages.has(subItem.url) &&
-                TimeFilterPages.has(pathname)
-              ) {
-                const currentParams = new URLSearchParams(search);
-                const startTime = currentParams.get("start_time");
-                const endTime = currentParams.get("end_time");
-                const period = currentParams.get("period");
-                if ((startTime && endTime) || period) {
-                  const params = new URLSearchParams();
-                  if (startTime) params.set("start_time", startTime);
-                  if (endTime) params.set("end_time", endTime);
-                  if (period) params.set("period", period);
-                  const sep = baseHref.includes("?") ? "&" : "?";
-                  return `${baseHref}${sep}${params.toString()}`;
-                }
-              }
-              return baseHref;
-            })();
+            const subItemHref = preserveTimeFilters(baseHref, subItem.url, pathname, search);
             // For query param based subitems, check if tab matches
             const isSubItemActive = subItem.queryParam
               ? pathname === subItem.url


### PR DESCRIPTION
## Summary

When navigating between sidebar pages that support time filtering, the selected time range (start/end time or period) is lost. This PR preserves the active time filter parameters when clicking sidebar sub-items, so users don't have to re-select their time range after switching between time-filter-enabled pages.

## Changes

- When navigating from one `TimeFilterPages` page to another via a sidebar sub-item, the current `start_time`, `end_time`, and `period` query parameters are carried over to the destination URL.
- If the current or destination page is not in `TimeFilterPages`, navigation behaves as before with no parameter forwarding.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to a page that supports time filtering (e.g., a metrics or logs page).
2. Set a custom time range or period using the time filter.
3. Click a different sidebar sub-item that also supports time filtering.
4. Verify the time range is preserved in the URL and the view reflects the same time window.
5. Navigate to a sidebar sub-item that does **not** support time filtering and verify no time parameters are appended.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications. Only query parameters already present in the current URL are forwarded.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable