### PR TITLE
refactor: move auth check from login component to route loader with redirect

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/login/loginView.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { getErrorMessage, useIsAuthEnabledQuery, useLoginMutation } from "@/lib/store/apis";
+import { getErrorMessage, useLoginMutation } from "@/lib/store/apis";
 import { BooksIcon, DiscordLogoIcon, GithubLogoIcon } from "@phosphor-icons/react";
 import { useNavigate } from "@tanstack/react-router";
 import { Eye, EyeOff } from "lucide-react";
@@ -34,34 +34,13 @@ export default function LoginView() {
 	const [password, setPassword] = useState("");
 	const [showPassword, setShowPassword] = useState(false);
 	const [errorMessage, setErrorMessage] = useState("");
-	const [isCheckingAuth, setIsCheckingAuth] = useState(true);
 	const navigate = useNavigate();
 	const [isLoading, setIsLoading] = useState(false);
-	const { data: isAuthEnabledData, isLoading: isLoadingIsAuthEnabled, error: isAuthEnabledError } = useIsAuthEnabledQuery();
-	const isAuthEnabled = isAuthEnabledData?.is_auth_enabled || false;
-	const hasValidToken = isAuthEnabledData?.has_valid_token || false;
 	const [login, { isLoading: isLoggingIn }] = useLoginMutation();
 
 	useEffect(() => {
 		setMounted(true);
 	}, []);
-
-	// Check auth status on component mount
-	useEffect(() => {
-		if (isLoadingIsAuthEnabled) {
-			return;
-		}
-		if (isAuthEnabledError) {
-			setErrorMessage("Unable to verify authentication status. Please retry.");
-			return;
-		}
-		if (!isAuthEnabled || hasValidToken) {
-			navigate({ to: "/workspace" });
-			return;
-		}
-		// Auth is enabled but user is not logged in, show login form
-		setIsCheckingAuth(false);
-	}, [isLoadingIsAuthEnabled]);
 
 	const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
 		setIsLoading(true);
@@ -69,7 +48,6 @@ export default function LoginView() {
 		setErrorMessage("");
 		try {
 			await login({ username, password }).unwrap();
-			// Cookie is set automatically by the server response — just navigate
 			navigate({ to: "/workspace" });
 		} catch (error) {
 			const message = getErrorMessage(error);
@@ -79,26 +57,7 @@ export default function LoginView() {
 		}
 	};
 
-	// Use light logo for SSR to avoid hydration mismatch
 	const logoSrc = mounted && resolvedTheme === "dark" ? "/bifrost-logo-dark.webp" : "/bifrost-logo.webp";
-
-	// Show loading state while checking auth
-	if (isCheckingAuth || isLoadingIsAuthEnabled) {
-		return (
-			<div className="flex min-h-screen items-center justify-center p-4">
-				<div className="w-full max-w-md">
-					<div className="border-border bg-card w-full space-y-6 rounded-sm border p-8">
-						<div className="flex items-center justify-center">
-							<img src={logoSrc} alt="Bifrost" width={160} height={26} className="" />
-						</div>
-						<div className="flex items-center justify-center py-8">
-							<div className="text-muted-foreground text-sm">Checking authentication...</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		);
-	}
 
 	return (
 		<div className="flex min-h-screen items-center justify-center p-4">

--- a/ui/app/login/layout.tsx
+++ b/ui/app/login/layout.tsx
@@ -1,6 +1,7 @@
 import { ThemeProvider } from "@/components/themeProvider";
 import { ReduxProvider } from "@/lib/store/provider";
-import { createFileRoute } from "@tanstack/react-router";
+import { getApiBaseUrl } from "@/lib/utils/port";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { NuqsAdapter } from "nuqs/adapters/tanstack-router";
 import LoginPage from "./page";
 
@@ -18,6 +19,43 @@ function RouteComponent() {
 	);
 }
 
+function PendingComponent() {
+	return (
+		<ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+			<div className="flex min-h-screen items-center justify-center p-4">
+				<div className="w-full max-w-md">
+					<div className="border-border bg-card w-full space-y-6 rounded-sm border p-8">
+						<div className="flex items-center justify-center">
+							<img src="/bifrost-logo.webp" alt="Bifrost" width={160} height={26} />
+						</div>
+						<div className="flex items-center justify-center py-6">
+							<div className="text-muted-foreground text-sm">Checking authentication...</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</ThemeProvider>
+	);
+}
+
 export const Route = createFileRoute("/login")({
+	loader: async () => {
+		let data: { is_auth_enabled: boolean; has_valid_token: boolean } | null = null;
+		try {
+			const res = await fetch(`${getApiBaseUrl()}/session/is-auth-enabled`, {
+				credentials: "include",
+			});
+			if (res.ok) {
+				data = await res.json();
+			}
+		} catch {
+			// Fetch failed — fall through to login page
+		}
+		if (data && (!data.is_auth_enabled || data.has_valid_token)) {
+			throw redirect({ to: "/workspace" });
+		}
+	},
+	pendingComponent: PendingComponent,
+	pendingMs: 0,
 	component: RouteComponent,
 });

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -188,6 +188,29 @@ const TimeFilterPages = new Set([
   "/workspace/mcp-logs",
 ]);
 
+const preserveTimeFilters = (
+  baseHref: string,
+  subItemUrl: string,
+  pathname: string,
+  search: string,
+): string => {
+  if (TimeFilterPages.has(subItemUrl) && TimeFilterPages.has(pathname)) {
+    const currentParams = new URLSearchParams(search);
+    const startTime = currentParams.get("start_time");
+    const endTime = currentParams.get("end_time");
+    const period = currentParams.get("period");
+    if ((startTime && endTime) || period) {
+      const params = new URLSearchParams();
+      if (startTime) params.set("start_time", startTime);
+      if (endTime) params.set("end_time", endTime);
+      if (period) params.set("period", period);
+      const sep = baseHref.includes("?") ? "&" : "?";
+      return `${baseHref}${sep}${params.toString()}`;
+    }
+  }
+  return baseHref;
+};
+
 const SidebarItemView = ({
   item,
   isActive,
@@ -405,7 +428,8 @@ const SidebarItemView = ({
               {item.title}
             </div>
             {item.subItems?.map((subItem) => {
-              const href = getSidebarItemHref(subItem);
+              const baseHref = getSidebarItemHref(subItem);
+              const href = preserveTimeFilters(baseHref, subItem.url, pathname, search);
               const isSubItemActive = subItem.queryParam
                 ? pathname === subItem.url
                 : isRouteMatch(subItem.url);
@@ -468,26 +492,7 @@ const SidebarItemView = ({
         <SidebarMenuSub className="border-sidebar-border mt-1 ml-4 space-y-0.5 border-l pl-2">
           {item.subItems?.map((subItem: SidebarItem) => {
             const baseHref = getSidebarItemHref(subItem);
-            const subItemHref = (() => {
-              if (
-                TimeFilterPages.has(subItem.url) &&
-                TimeFilterPages.has(pathname)
-              ) {
-                const currentParams = new URLSearchParams(search);
-                const startTime = currentParams.get("start_time");
-                const endTime = currentParams.get("end_time");
-                const period = currentParams.get("period");
-                if ((startTime && endTime) || period) {
-                  const params = new URLSearchParams();
-                  if (startTime) params.set("start_time", startTime);
-                  if (endTime) params.set("end_time", endTime);
-                  if (period) params.set("period", period);
-                  const sep = baseHref.includes("?") ? "&" : "?";
-                  return `${baseHref}${sep}${params.toString()}`;
-                }
-              }
-              return baseHref;
-            })();
+            const subItemHref = preserveTimeFilters(baseHref, subItem.url, pathname, search);
             // For query param based subitems, check if tab matches
             const isSubItemActive = subItem.queryParam
               ? pathname === subItem.url

--- a/ui/lib/store/apis/sessionApi.ts
+++ b/ui/lib/store/apis/sessionApi.ts
@@ -27,6 +27,7 @@ export const sessionApi = baseApi.injectEndpoints({
 				url: "/session/is-auth-enabled",
 				method: "GET",
 			}),
+			providesTags: ["Sessions"],
 		}),
 		// Login endpoint
 		login: builder.mutation<LoginResponse, LoginRequest>({
@@ -35,7 +36,7 @@ export const sessionApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: credentials,
 			}),
-			invalidatesTags: [],
+			invalidatesTags: ["Sessions"],
 		}),
 
 		// Logout endpoint
@@ -53,7 +54,7 @@ export const sessionApi = baseApi.injectEndpoints({
 					clearAuthStorage();
 				}
 			},
-			invalidatesTags: ["Config", "Providers", "Logs", "VirtualKeys", "Teams", "Customers", "Budgets", "RateLimits"],
+			invalidatesTags: ["Sessions", "Config", "Providers", "Logs", "VirtualKeys", "Teams", "Customers", "Budgets", "RateLimits"],
 		}),
 	}),
 });


### PR DESCRIPTION
## Summary

Auth status checking on the login route was previously handled inside the `LoginView` component using a Redux query, causing a flash of "Checking authentication..." UI within the already-rendered login page. This moves the auth check to a TanStack Router route loader so the redirect to `/workspace` happens before the login page renders, and the pending state is handled cleanly by a dedicated `PendingComponent`.

## Changes

- Moved the `is-auth-enabled` auth check from `LoginView` into the `/login` route loader. If auth is disabled or the user already has a valid token, the loader throws a redirect to `/workspace` before the component mounts.
- Removed `useIsAuthEnabledQuery`, the `isCheckingAuth` state, and the inline loading UI from `LoginView`, simplifying the component significantly.
- Added a `PendingComponent` to the `/login` route that displays the "Checking authentication..." screen while the loader is in flight, with `pendingMs: 0` to show it immediately.
- Added `providesTags: ["Sessions"]` to `useIsAuthEnabledQuery` and updated `login` to `invalidatesTags: ["Sessions"]` so session state is properly invalidated after login. Also added `"Sessions"` to the logout invalidation list.

## Type of change

- [x] Refactor

## Affected areas

- [x] UI (React)

## How to test

1. Navigate to `/login` while unauthenticated — the "Checking authentication..." pending screen should appear briefly, then the login form should render.
2. Navigate to `/login` while already authenticated (valid session cookie) — you should be immediately redirected to `/workspace` without seeing the login form.
3. Navigate to `/login` when auth is disabled — you should be redirected to `/workspace`.
4. Submit valid credentials on the login form — you should be redirected to `/workspace`.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues  
https://github.com/maximhq/bifrost/issues/3546

## Security considerations

The auth check now uses `credentials: "include"` in a plain `fetch` call within the route loader, ensuring the session cookie is sent. If the fetch fails, the login page is shown as a safe fallback rather than silently redirecting.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable