### PR TITLE
feat(helm): add optional HTTPRoute template for Gateway API

### DIFF
--- a/helm-charts/bifrost/templates/httproute.yaml
+++ b/helm-charts/bifrost/templates/httproute.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.httproute.enabled }}
+apiVersion: {{ .Values.httproute.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: HTTPRoute
+metadata:
+  name: {{ include "bifrost.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "bifrost.labels" . | nindent 4 }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httproute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  hostnames:
+    {{- toYaml .Values.httproute.hostnames | nindent 4 }}
+  rules:
+    - backendRefs:
+        - name: {{ include "bifrost.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/helm-charts/bifrost/templates/httproute.yaml
+++ b/helm-charts/bifrost/templates/httproute.yaml
@@ -15,8 +15,10 @@ spec:
   parentRefs:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.httproute.hostnames }}
   hostnames:
-    {{- toYaml .Values.httproute.hostnames | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   rules:
     - backendRefs:
         - name: {{ include "bifrost.fullname" . }}

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -86,6 +86,17 @@ ingress:
           pathType: Prefix
   tls: []
 
+httproute:
+  # Enable HTTPRoute for Gateway API (e.g., Istio, Contour, Traefik)
+  enabled: false
+  # apiVersion: gateway.networking.k8s.io/v1
+  # parentRefs:
+  #   - name: shared-gateway
+  #     namespace: default
+  # hostnames:
+  #   - bifrost.example.com
+  # annotations: {}
+
 resources:
   limits:
     cpu: 2000m


### PR DESCRIPTION
## Summary

Adds a new `httproute.yaml` template to the Helm chart that renders a Gateway API **HTTPRoute** when `httproute.enabled=true`. This allows deploying Bifrost behind Gateway API ingress controllers (e.g., Istio, Contour, Traefik) without needing the standard k8s Ingress resource.

## Changes

- **`templates/httproute.yaml`** — New template, nil-safe (only renders when `httproute.enabled=true`, hostnames/parentRefs guarded with nil-safe `with` blocks)
- **`values.yaml`** — New `httproute` section with all fields commented out, disabled by default

## Usage

```yaml
httproute:
  enabled: true
  parentRefs:
    - name: shared-gateway
      namespace: default
  hostnames:
    - bifrost.example.com
```

## Backward Compatibility

✅ Fully backward compatible — `httproute.enabled=false` by default, existing users see zero diff.
✅ No breaking changes to any existing value or template.
✅ All optional fields (`hostnames`, `parentRefs`, `annotations`) are nil-safe — omitting them gracefully omits the field from the rendered manifest.

## Testing

- `helm lint` ✅
- `helm template` with `httproute.enabled=true` + hostnames — renders valid HTTPRoute
- `helm template` with `httproute.enabled=true` without hostnames — omits hostnames block (nil-safe)
- `helm template` with defaults — no HTTPRoute rendered