### PR TITLE
feat: add `ConfigMarshallerPlugin` interface and `EnvVar` support for OTEL and Prometheus plugin configs

### DIFF
--- a/core/schemas/plugin.go
+++ b/core/schemas/plugin.go
@@ -331,6 +331,24 @@ type PluginConfig struct {
 	Order     *int             `json:"order,omitempty"`     // Position within placement group. Lower = earlier. Default: 0
 }
 
+// ConfigMarshallerPlugin is optionally implemented by plugins that need custom
+// config serialization. If a loaded plugin implements this interface, the server
+// calls MarshalConfigForStorage before writing config to the DB, and RedactConfig
+// when building API responses. Plugins that don't implement it are passed through
+// unchanged — no registration or factory required.
+type ConfigMarshallerPlugin interface {
+	BasePlugin
+
+	// MarshalConfigForStorage converts the raw config map (as received from the API)
+	// into the canonical DB-storage format (e.g. *EnvVar fields as plain strings).
+	MarshalConfigForStorage(config map[string]any) (map[string]any, error)
+	// RedactConfig converts a stored config map into the API-response format,
+	// masking sensitive literal values.
+	// Returns an error if the config cannot be safely redacted; callers must not
+	// return the raw map on error (fail-closed).
+	RedactConfig(config map[string]any) (map[string]any, error)
+}
+
 // ObservabilityPlugin is an interface for plugins that receive completed traces
 // for forwarding to observability backends (e.g., OTEL collectors, Datadog, etc.)
 //

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -60,22 +60,92 @@ type PluginSpanFilter struct {
 }
 
 type Config struct {
-	ServiceName  string            `json:"service_name"`
-	CollectorURL string            `json:"collector_url"`
-	Headers      map[string]string `json:"headers"`
-	TraceType    TraceType         `json:"trace_type"`
-	Protocol     Protocol          `json:"protocol"`
-	TLSCACert    string            `json:"tls_ca_cert"`
-	Insecure     bool              `json:"insecure"` // Skip TLS when true; ignored if TLSCACert is set. Defaults to true when omitted.
+	ServiceName  string                     `json:"service_name"`
+	CollectorURL *schemas.EnvVar            `json:"collector_url"`
+	Headers      map[string]*schemas.EnvVar `json:"headers"`
+	TraceType    TraceType                  `json:"trace_type"`
+	Protocol     Protocol                   `json:"protocol"`
+	TLSCACert    string                     `json:"tls_ca_cert"`
+	Insecure     bool                       `json:"insecure"` // Skip TLS when true; ignored if TLSCACert is set. Defaults to true when omitted.
 
 	// Metrics push configuration
-	MetricsEnabled      bool   `json:"metrics_enabled"`
-	MetricsEndpoint     string `json:"metrics_endpoint"`
-	MetricsPushInterval int    `json:"metrics_push_interval"` // in seconds, default 15
+	MetricsEnabled      bool            `json:"metrics_enabled"`
+	MetricsEndpoint     *schemas.EnvVar `json:"metrics_endpoint"`
+	MetricsPushInterval int             `json:"metrics_push_interval"` // in seconds, default 15
 
 	// PluginSpanFilter is the DB-stored fallback when otel_plugin_span_filter is absent in config.json.
 	// The top-level config.json field takes precedence and is passed via Init's pluginSpanFilter param.
 	PluginSpanFilter *PluginSpanFilter `json:"plugin_span_filter,omitempty"`
+}
+
+// MarshalForStorage serializes Config to JSON with *EnvVar fields as plain strings
+// ("env.VAR_NAME" or the literal value) for database/config-file persistence.
+// For HTTP API responses use json.Marshal directly so clients receive full EnvVar objects.
+func (c *Config) MarshalForStorage() ([]byte, error) {
+	type alias struct {
+		ServiceName         string            `json:"service_name"`
+		CollectorURL        string            `json:"collector_url"`
+		Headers             map[string]string `json:"headers,omitempty"`
+		TraceType           TraceType         `json:"trace_type"`
+		Protocol            Protocol          `json:"protocol"`
+		TLSCACert           string            `json:"tls_ca_cert,omitempty"`
+		Insecure            bool              `json:"insecure"`
+		MetricsEnabled      bool              `json:"metrics_enabled"`
+		MetricsEndpoint     string            `json:"metrics_endpoint,omitempty"`
+		MetricsPushInterval int               `json:"metrics_push_interval,omitempty"`
+		PluginSpanFilter    *PluginSpanFilter `json:"plugin_span_filter,omitempty"`
+	}
+	a := alias{
+		ServiceName:         c.ServiceName,
+		CollectorURL:        schemas.EnvVarAsString(c.CollectorURL),
+		TraceType:           c.TraceType,
+		Protocol:            c.Protocol,
+		TLSCACert:           c.TLSCACert,
+		Insecure:            c.Insecure,
+		MetricsEnabled:      c.MetricsEnabled,
+		MetricsEndpoint:     schemas.EnvVarAsString(c.MetricsEndpoint),
+		MetricsPushInterval: c.MetricsPushInterval,
+		PluginSpanFilter:    c.PluginSpanFilter,
+	}
+	if c.Headers != nil {
+		a.Headers = make(map[string]string, len(c.Headers))
+		for k, v := range c.Headers {
+			a.Headers[k] = schemas.EnvVarAsString(v)
+		}
+	}
+	return sonic.Marshal(a)
+}
+
+// Redacted returns a copy of the config with sensitive EnvVar fields redacted for API responses.
+// URLs (CollectorURL, MetricsEndpoint) are not secrets and are returned unchanged so the UI
+// can display and re-submit them without failing URL validation. For env var references on
+// those fields, only the resolved value is hidden; the env_var name is preserved.
+// Header values may carry auth tokens and are masked.
+func (c *Config) Redacted() *Config {
+	if c == nil {
+		return nil
+	}
+	redacted := *c
+	redacted.CollectorURL = hideResolvedEnvValue(c.CollectorURL)
+	redacted.MetricsEndpoint = hideResolvedEnvValue(c.MetricsEndpoint)
+	if c.Headers != nil {
+		redacted.Headers = make(map[string]*schemas.EnvVar, len(c.Headers))
+		for k, v := range c.Headers {
+			redacted.Headers[k] = v.Redacted()
+		}
+	}
+	return &redacted
+}
+
+// hideResolvedEnvValue returns v unchanged for literal values (URLs are not secrets).
+// For env var references it replaces a resolved Val with a redaction marker so API
+// consumers can tell the value exists without leaking env content. Unresolved env
+// references keep an empty Val, while preserving env_var for round-trip edits.
+func hideResolvedEnvValue(v *schemas.EnvVar) *schemas.EnvVar {
+	if v == nil || !v.IsFromEnv() {
+		return v
+	}
+	return v.Redacted()
 }
 
 // UnmarshalJSON applies field defaults that the zero-value wouldn't capture.
@@ -138,18 +208,6 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 		logger.Warn("otel plugin requires model catalog to calculate cost, all cost calculations will be skipped.")
 	}
 	var err error
-	// If headers are present, and any of them start with env., we will replace the value with the environment variable
-	if config.Headers != nil {
-		for key, value := range config.Headers {
-			if newValue, ok := strings.CutPrefix(value, "env."); ok {
-				config.Headers[key] = os.Getenv(newValue)
-				if config.Headers[key] == "" {
-					logger.Warn("environment variable %s not found", newValue)
-					return nil, fmt.Errorf("environment variable %s not found", newValue)
-				}
-			}
-		}
-	}
 	if config.PluginSpanFilter != nil {
 		switch config.PluginSpanFilter.Mode {
 		case PluginSpanFilterModeInclude, PluginSpanFilterModeExclude:
@@ -190,25 +248,25 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 	// Preparing the plugin
 	p := &OtelPlugin{
 		serviceName:               config.ServiceName,
-		url:                       config.CollectorURL,
+		url:                       config.CollectorURL.GetValue(),
 		traceType:                 config.TraceType,
-		headers:                   config.Headers,
+		headers:                   resolveHeaders(config.Headers),
 		protocol:                  config.Protocol,
 		pricingManager:            pricingManager,
 		bifrostVersion:            bifrostVersion,
 		attributesFromEnvironment: attributesFromEnvironment,
 		instanceAttrs:             instanceAttrs,
-		pluginSpanFilter: config.PluginSpanFilter,
+		pluginSpanFilter:          config.PluginSpanFilter,
 	}
 	p.ctx, p.cancel = context.WithCancel(ctx)
 	if config.Protocol == ProtocolGRPC {
-		p.client, err = NewOtelClientGRPC(config.CollectorURL, config.Headers, config.TLSCACert, config.Insecure)
+		p.client, err = NewOtelClientGRPC(config.CollectorURL.GetValue(), p.headers, config.TLSCACert, config.Insecure)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if config.Protocol == ProtocolHTTP {
-		p.client, err = NewOtelClientHTTP(config.CollectorURL, config.Headers, config.TLSCACert, config.Insecure)
+		p.client, err = NewOtelClientHTTP(config.CollectorURL.GetValue(), p.headers, config.TLSCACert, config.Insecure)
 		if err != nil {
 			return nil, err
 		}
@@ -219,7 +277,7 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 
 	// Initialize metrics exporter if enabled
 	if config.MetricsEnabled {
-		if config.MetricsEndpoint == "" {
+		if config.MetricsEndpoint.GetValue() == "" {
 			return nil, fmt.Errorf("metrics_endpoint is required when metrics_enabled is true")
 		}
 		pushInterval := config.MetricsPushInterval
@@ -230,8 +288,8 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 		}
 		metricsConfig := &MetricsConfig{
 			ServiceName:  config.ServiceName,
-			Endpoint:     config.MetricsEndpoint,
-			Headers:      config.Headers,
+			Endpoint:     config.MetricsEndpoint.GetValue(),
+			Headers:      p.headers,
 			Protocol:     config.Protocol,
 			TLSCACert:    config.TLSCACert,
 			Insecure:     config.Insecure,
@@ -245,7 +303,7 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 			}
 			return nil, fmt.Errorf("failed to initialize metrics exporter: %w", err)
 		}
-		logger.Info("OTEL metrics push enabled, pushing to %s every %d seconds", config.MetricsEndpoint, pushInterval)
+		logger.Info("OTEL metrics push enabled, pushing to %s every %d seconds", config.MetricsEndpoint.GetValue(), pushInterval)
 	}
 
 	return p, nil
@@ -254,6 +312,48 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 // GetName function for the OTEL plugin
 func (p *OtelPlugin) GetName() string {
 	return PluginName
+}
+
+// MarshalConfigForStorage implements schemas.ConfigMarshallerPlugin.
+func (p *OtelPlugin) MarshalConfigForStorage(raw map[string]any) (map[string]any, error) {
+	b, err := sonic.Marshal(raw)
+	if err != nil {
+		return raw, err
+	}
+	var c Config
+	if err := sonic.Unmarshal(b, &c); err != nil {
+		return raw, err
+	}
+	normalized, err := c.MarshalForStorage()
+	if err != nil {
+		return raw, err
+	}
+	var out map[string]any
+	if err := sonic.Unmarshal(normalized, &out); err != nil {
+		return raw, err
+	}
+	return out, nil
+}
+
+// RedactConfig implements schemas.ConfigMarshallerPlugin.
+func (p *OtelPlugin) RedactConfig(raw map[string]any) (map[string]any, error) {
+	b, err := sonic.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var c Config
+	if err := sonic.Unmarshal(b, &c); err != nil {
+		return nil, err
+	}
+	out, err := sonic.Marshal(c.Redacted())
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	if err := sonic.Unmarshal(out, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // HTTPTransportPreHook is not used for this plugin
@@ -295,7 +395,7 @@ func (p *OtelPlugin) ValidateConfig(config any) (*Config, error) {
 		otelConfig = *config
 	}
 	// Validating fields
-	if otelConfig.CollectorURL == "" {
+	if otelConfig.CollectorURL == nil || otelConfig.CollectorURL.GetValue() == "" {
 		return nil, fmt.Errorf("collector url is required")
 	}
 	if otelConfig.TraceType == "" {
@@ -519,6 +619,18 @@ func (p *OtelPlugin) Cleanup() error {
 // GetMetricsExporter returns the metrics exporter for external use (e.g., by telemetry plugin)
 func (p *OtelPlugin) GetMetricsExporter() *MetricsExporter {
 	return p.metricsExporter
+}
+
+// resolveHeaders converts a map of EnvVar header values to plain strings for use in HTTP/gRPC clients.
+func resolveHeaders(in map[string]*schemas.EnvVar) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v.GetValue()
+	}
+	return out
 }
 
 // firstNonEmpty returns the first non-empty string from the provided values.

--- a/plugins/telemetry/go.mod
+++ b/plugins/telemetry/go.mod
@@ -3,6 +3,7 @@ module github.com/maximhq/bifrost/plugins/telemetry
 go 1.26.2
 
 require (
+	github.com/bytedance/sonic v1.15.0
 	github.com/maximhq/bifrost/core v1.5.12
 	github.com/maximhq/bifrost/framework v1.3.12
 	github.com/prometheus/client_golang v1.23.2
@@ -50,7 +51,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -13,6 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/bytedance/sonic"
 	bifrost "github.com/maximhq/bifrost/core"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
@@ -38,8 +39,8 @@ const (
 type PushGatewayConfig struct {
 	// Enabled controls whether pushing metrics to the Push Gateway is active
 	Enabled bool `json:"enabled"`
-	// PushGatewayURL is the URL of the Prometheus Push Gateway (e.g., http://pushgateway:9091)
-	PushGatewayURL string `json:"push_gateway_url"`
+	// PushGatewayURL is the URL of the Prometheus Push Gateway (e.g., http://pushgateway:9091). Supports env.VAR_NAME.
+	PushGatewayURL *schemas.EnvVar `json:"push_gateway_url"`
 	// JobName is the job label for pushed metrics (default: "bifrost")
 	JobName string `json:"job_name"`
 	// InstanceID is the instance label for grouping metrics. If empty, hostname is used.
@@ -52,8 +53,85 @@ type PushGatewayConfig struct {
 
 // BasicAuthConfig holds basic authentication credentials for the Push Gateway
 type BasicAuthConfig struct {
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Username *schemas.EnvVar `json:"username"`
+	Password *schemas.EnvVar `json:"password"`
+}
+
+// MarshalForStorage serializes Config to JSON with *EnvVar fields as plain strings
+// ("env.VAR_NAME" or the literal value) for database/config-file persistence.
+// For HTTP API responses use json.Marshal directly so clients receive full EnvVar objects.
+func (c *Config) MarshalForStorage() ([]byte, error) {
+	type basicAuthStorage struct {
+		Username string `json:"username,omitempty"`
+		Password string `json:"password,omitempty"`
+	}
+	type pushGatewayStorage struct {
+		Enabled        bool              `json:"enabled"`
+		PushGatewayURL string            `json:"push_gateway_url,omitempty"`
+		JobName        string            `json:"job_name,omitempty"`
+		InstanceID     string            `json:"instance_id,omitempty"`
+		PushInterval   int               `json:"push_interval,omitempty"`
+		BasicAuth      *basicAuthStorage `json:"basic_auth,omitempty"`
+	}
+	type configStorage struct {
+		CustomLabels   []string            `json:"custom_labels,omitempty"`
+		MetricsEnabled *bool               `json:"metrics_enabled,omitempty"`
+		PushGateway    *pushGatewayStorage `json:"push_gateway,omitempty"`
+	}
+	storage := configStorage{
+		CustomLabels:   c.CustomLabels,
+		MetricsEnabled: c.MetricsEnabled,
+	}
+	if c.PushGateway != nil {
+		pgw := &pushGatewayStorage{
+			Enabled:        c.PushGateway.Enabled,
+			PushGatewayURL: schemas.EnvVarAsString(c.PushGateway.PushGatewayURL),
+			JobName:        c.PushGateway.JobName,
+			InstanceID:     c.PushGateway.InstanceID,
+			PushInterval:   c.PushGateway.PushInterval,
+		}
+		if c.PushGateway.BasicAuth != nil {
+			pgw.BasicAuth = &basicAuthStorage{
+				Username: schemas.EnvVarAsString(c.PushGateway.BasicAuth.Username),
+				Password: schemas.EnvVarAsString(c.PushGateway.BasicAuth.Password),
+			}
+		}
+		storage.PushGateway = pgw
+	}
+	return sonic.Marshal(storage)
+}
+
+// Redacted returns a copy of the config with sensitive EnvVar fields redacted for API responses.
+// PushGatewayURL is not a secret and is returned unchanged so the UI can display and re-submit
+// it without failing URL validation. For env var references on that field, only the resolved
+// value is hidden; the env_var name is preserved. Basic auth credentials are masked.
+func (c *Config) Redacted() *Config {
+	if c == nil {
+		return nil
+	}
+	redacted := *c
+	if c.PushGateway != nil {
+		pg := *c.PushGateway
+		pg.PushGatewayURL = hideResolvedEnvValue(c.PushGateway.PushGatewayURL)
+		if c.PushGateway.BasicAuth != nil {
+			ba := *c.PushGateway.BasicAuth
+			ba.Username = c.PushGateway.BasicAuth.Username.Redacted()
+			ba.Password = c.PushGateway.BasicAuth.Password.FullyRedacted()
+			pg.BasicAuth = &ba
+		}
+		redacted.PushGateway = &pg
+	}
+	return &redacted
+}
+
+// hideResolvedEnvValue returns v unchanged for literal values (URLs are not secrets).
+// For env var references it zeroes out the resolved Val so the actual env content is
+// not leaked in API responses, while keeping the env_var name for round-trip edits.
+func hideResolvedEnvValue(v *schemas.EnvVar) *schemas.EnvVar {
+	if v == nil || !v.IsFromEnv() {
+		return v
+	}
+	return v.Redacted()
 }
 
 // PrometheusPlugin implements the schemas.LLMPlugin interface for Prometheus metrics.
@@ -403,7 +481,7 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 	plugin.metricsEnabled.Store(metricsEnabled)
 
 	// Start push gateway if configured
-	if config.PushGateway != nil && config.PushGateway.Enabled && config.PushGateway.PushGatewayURL != "" {
+	if config.PushGateway != nil && config.PushGateway.Enabled && config.PushGateway.PushGatewayURL.IsSet() {
 		if err := plugin.EnablePushGateway(config.PushGateway); err != nil {
 			return nil, fmt.Errorf("failed to start push gateway: %w", err)
 		}
@@ -431,6 +509,48 @@ func (p *PrometheusPlugin) GetMetricsGatherer() prometheus.Gatherer {
 // GetName returns the name of the plugin.
 func (p *PrometheusPlugin) GetName() string {
 	return PluginName
+}
+
+// MarshalConfigForStorage implements schemas.ConfigMarshallerPlugin.
+func (p *PrometheusPlugin) MarshalConfigForStorage(raw map[string]any) (map[string]any, error) {
+	b, err := sonic.Marshal(raw)
+	if err != nil {
+		return raw, err
+	}
+	var c Config
+	if err := sonic.Unmarshal(b, &c); err != nil {
+		return raw, err
+	}
+	normalized, err := c.MarshalForStorage()
+	if err != nil {
+		return raw, err
+	}
+	var out map[string]any
+	if err := sonic.Unmarshal(normalized, &out); err != nil {
+		return raw, err
+	}
+	return out, nil
+}
+
+// RedactConfig implements schemas.ConfigMarshallerPlugin.
+func (p *PrometheusPlugin) RedactConfig(raw map[string]any) (map[string]any, error) {
+	b, err := sonic.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var c Config
+	if err := sonic.Unmarshal(b, &c); err != nil {
+		return nil, err
+	}
+	out, err := sonic.Marshal(c.Redacted())
+	if err != nil {
+		return nil, err
+	}
+	var result map[string]any
+	if err := sonic.Unmarshal(out, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // HTTPTransportPreHook is not used for this plugin
@@ -754,7 +874,7 @@ func (p *PrometheusPlugin) HTTPMiddleware(handler fasthttp.RequestHandler) fasth
 // EnablePushGateway starts pushing metrics to a Prometheus Push Gateway.
 // If push gateway is already active, it stops the existing one first.
 func (p *PrometheusPlugin) EnablePushGateway(config *PushGatewayConfig) error {
-	if config == nil || config.PushGatewayURL == "" {
+	if config == nil || config.PushGatewayURL.GetValue() == "" {
 		return fmt.Errorf("push_gateway_url is required")
 	}
 
@@ -778,12 +898,12 @@ func (p *PrometheusPlugin) EnablePushGateway(config *PushGatewayConfig) error {
 	}
 
 	// Create the pusher with the registry
-	pusher := push.New(config.PushGatewayURL, config.JobName).
+	pusher := push.New(config.PushGatewayURL.GetValue(), config.JobName).
 		Gatherer(p.registry).
 		Grouping("instance", config.InstanceID)
 
-	if config.BasicAuth != nil && config.BasicAuth.Username != "" {
-		pusher = pusher.BasicAuth(config.BasicAuth.Username, config.BasicAuth.Password)
+	if config.BasicAuth != nil && config.BasicAuth.Username.IsSet() && config.BasicAuth.Password.IsSet() {
+		pusher = pusher.BasicAuth(config.BasicAuth.Username.GetValue(), config.BasicAuth.Password.GetValue())
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -800,7 +920,7 @@ func (p *PrometheusPlugin) EnablePushGateway(config *PushGatewayConfig) error {
 	go p.pushLoop()
 
 	p.logger.Info("push gateway started, pushing to %s every %d seconds",
-		config.PushGatewayURL, config.PushInterval)
+		config.PushGatewayURL.GetValue(), config.PushInterval)
 
 	return nil
 }

--- a/transports/bifrost-http/handlers/plugins.go
+++ b/transports/bifrost-http/handlers/plugins.go
@@ -20,6 +20,14 @@ type PluginsLoader interface {
 	GetPluginStatus(ctx context.Context) map[string]schemas.PluginStatus
 	ReloadPlugin(ctx context.Context, name string, path *string, pluginConfig any, placement *schemas.PluginPlacement, order *int) error
 	RemovePlugin(ctx context.Context, name string) error
+	// NormalizePluginConfig converts a raw config map to DB-storage format using
+	// the loaded plugin instance if it implements ConfigMarshallerPlugin.
+	// Returns nil when the plugin is not loaded or does not implement the interface.
+	NormalizePluginConfig(name string, config map[string]any) (map[string]any, error)
+	// ExpandPluginConfigForAPI converts a stored config map to API-response format
+	// using the loaded plugin instance if it implements ConfigMarshallerPlugin.
+	// Returns nil, nil when the plugin is not loaded or does not implement the interface.
+	ExpandPluginConfigForAPI(name string, config map[string]any) (map[string]any, error)
 }
 
 // PluginsHandler is the handler for the plugins API
@@ -55,6 +63,34 @@ type UpdatePluginRequest struct {
 	Order     *int                     `json:"order,omitempty"`
 }
 
+// normalizePluginConfig calls the loaded plugin's MarshalConfigForStorage if it
+// implements ConfigMarshallerPlugin. Returns config unchanged if the plugin is not
+// loaded or does not implement the interface. Returns an error if marshalling fails.
+func (h *PluginsHandler) normalizePluginConfig(name string, config map[string]any) (map[string]any, error) {
+	out, err := h.pluginsLoader.NormalizePluginConfig(name, config)
+	if err != nil {
+		return nil, err
+	}
+	if out != nil {
+		return out, nil
+	}
+	return config, nil
+}
+
+// expandPluginConfigForAPI calls the loaded plugin's RedactConfig if it implements
+// ConfigMarshallerPlugin. Returns config unchanged if the plugin is not loaded or
+// does not implement the interface. Returns an error if redaction fails.
+func (h *PluginsHandler) expandPluginConfigForAPI(name string, config map[string]any) (map[string]any, error) {
+	out, err := h.pluginsLoader.ExpandPluginConfigForAPI(name, config)
+	if err != nil {
+		return nil, err
+	}
+	if out != nil {
+		return out, nil
+	}
+	return config, nil
+}
+
 // RegisterRoutes registers the routes for the PluginsHandler
 func (h *PluginsHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
 	r.GET("/api/plugins", lib.ChainMiddlewares(h.getPlugins, middlewares...))
@@ -77,8 +113,14 @@ type PluginResponse struct {
 	Status     schemas.PluginStatus     `json:"status"`
 }
 
-// buildPluginResponse constructs a PluginResponse with status for a given TablePlugin.
+// buildPluginResponse constructs a PluginResponse, fetching plugin statuses once.
 func (h *PluginsHandler) buildPluginResponse(ctx context.Context, plugin *configstoreTables.TablePlugin) PluginResponse {
+	return h.buildPluginResponseWithStatuses(plugin, h.pluginsLoader.GetPluginStatus(ctx))
+}
+
+// buildPluginResponseWithStatuses constructs a PluginResponse using pre-fetched statuses.
+// Use this in list endpoints to avoid calling GetPluginStatus once per plugin.
+func (h *PluginsHandler) buildPluginResponseWithStatuses(plugin *configstoreTables.TablePlugin, pluginStatuses map[string]schemas.PluginStatus) PluginResponse {
 	pluginStatus := schemas.PluginStatus{
 		Name:   plugin.Name,
 		Status: schemas.PluginStatusUninitialized,
@@ -86,19 +128,28 @@ func (h *PluginsHandler) buildPluginResponse(ctx context.Context, plugin *config
 	}
 	if !plugin.Enabled {
 		pluginStatus.Status = schemas.PluginStatusDisabled
-	} else {
-		for _, status := range h.pluginsLoader.GetPluginStatus(ctx) {
-			if plugin.Name == status.Name {
-				pluginStatus = status
-				break
-			}
+	}
+	for _, status := range pluginStatuses {
+		if plugin.Name == status.Name {
+			pluginStatus = status
+			break
+		}
+	}
+	config := plugin.Config
+	if configMap, ok := plugin.Config.(map[string]any); ok {
+		redacted, err := h.expandPluginConfigForAPI(plugin.Name, configMap)
+		if err != nil {
+			logger.Warn("failed to redact config for plugin %s: %v", plugin.Name, err)
+			config = map[string]any{}
+		} else {
+			config = redacted
 		}
 	}
 	return PluginResponse{
 		Name:       plugin.Name,
 		ActualName: pluginStatus.Name,
 		Enabled:    plugin.Enabled,
-		Config:     plugin.Config,
+		Config:     config,
 		IsCustom:   plugin.IsCustom,
 		Path:       plugin.Path,
 		Placement:  plugin.Placement,
@@ -142,38 +193,10 @@ func (h *PluginsHandler) getPlugins(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, 500, "Failed to retrieve plugins")
 		return
 	}
-	// Fetching status
 	pluginStatuses := h.pluginsLoader.GetPluginStatus(ctx)
-	// Creating ephemeral struct for the plugins
 	finalPlugins := []PluginResponse{}
-
-	// Iterating over plugin status to get the plugin info
 	for _, plugin := range plugins {
-		pluginStatus := schemas.PluginStatus{
-			Name:   plugin.Name,
-			Status: schemas.PluginStatusUninitialized,
-			Logs:   []string{},
-		}
-		if !plugin.Enabled {
-			pluginStatus.Status = schemas.PluginStatusDisabled
-		}
-		for _, status := range pluginStatuses {
-			if plugin.Name == status.Name {
-				pluginStatus = status
-				break
-			}
-		}
-		finalPlugins = append(finalPlugins, PluginResponse{
-			Name:       plugin.Name,
-			ActualName: pluginStatus.Name,
-			Enabled:    plugin.Enabled,
-			Config:     plugin.Config,
-			IsCustom:   plugin.IsCustom,
-			Path:       plugin.Path,
-			Placement:  plugin.Placement,
-			Order:      plugin.Order,
-			Status:     pluginStatus,
-		})
+		finalPlugins = append(finalPlugins, h.buildPluginResponseWithStatuses(plugin, pluginStatuses))
 	}
 	// Creating ephemeral struct
 	SendJSON(ctx, map[string]any{
@@ -284,11 +307,17 @@ func (h *PluginsHandler) createPlugin(ctx *fasthttp.RequestCtx) {
 	if isBuiltin && request.Path != nil {
 		request.Path = nil
 	}
+	// Normalize before DB write so EnvVar fields are stored as plain strings.
+	normalizedConfig, err := h.normalizePluginConfig(request.Name, request.Config)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid plugin configuration: %v", err))
+		return
+	}
 	// Create DB entry first to avoid orphaned in-memory state if DB write fails
 	if err := h.configStore.CreatePlugin(ctx, &configstoreTables.TablePlugin{
 		Name:      request.Name,
 		Enabled:   request.Enabled,
-		Config:    request.Config,
+		Config:    normalizedConfig,
 		Path:      request.Path,
 		IsCustom:  !isBuiltin,
 		Placement: request.Placement,
@@ -301,7 +330,7 @@ func (h *PluginsHandler) createPlugin(ctx *fasthttp.RequestCtx) {
 
 	// Reload the plugin into memory if it's enabled
 	if request.Enabled {
-		if err := h.pluginsLoader.ReloadPlugin(ctx, request.Name, request.Path, request.Config, request.Placement, request.Order); err != nil {
+		if err := h.pluginsLoader.ReloadPlugin(ctx, request.Name, request.Path, normalizedConfig, request.Placement, request.Order); err != nil {
 			logger.Error("failed to load plugin: %v", err)
 			if rbErr := h.configStore.DeletePlugin(ctx, request.Name); rbErr != nil {
 				logger.Error("failed to rollback plugin creation: %v", rbErr)
@@ -412,8 +441,18 @@ func (h *PluginsHandler) updatePlugin(ctx *fasthttp.RequestCtx) {
 		if existingCfg, ok := existingPlugin.Config.(map[string]any); ok && len(existingCfg) > 0 {
 			mergedConfig = make(map[string]any, len(existingCfg)+len(request.Config))
 			maps.Copy(mergedConfig, existingCfg)
-			maps.Copy(mergedConfig, request.Config)
+			// Before overwriting, substitute any redacted EnvVar placeholders in the
+			// incoming config with the existing stored value so credentials are not
+			// replaced by "***" or similar client-side redaction markers.
+			incoming := restoreRedactedFromExisting(request.Config, existingCfg)
+			maps.Copy(mergedConfig, incoming)
 		}
+	}
+	// Normalize through the typed plugin config so custom MarshalJSON (e.g. EnvVar → string) runs.
+	mergedConfig, err = h.normalizePluginConfig(name, mergedConfig)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid plugin configuration: %v", err))
+		return
 	}
 	// Updating the plugin
 	if err := h.configStore.UpdatePlugin(ctx, &configstoreTables.TablePlugin{
@@ -509,4 +548,57 @@ func (h *PluginsHandler) deletePlugin(ctx *fasthttp.RequestCtx) {
 	SendJSON(ctx, map[string]interface{}{
 		"message": "Plugin deleted successfully",
 	})
+}
+
+// restoreRedactedFromExisting walks the incoming config map and, for any field that
+// looks like an EnvVar object whose value ShouldPreserveStored (i.e. it is a redacted
+// placeholder like "***"), replaces the value with the corresponding field from the
+// existing DB config. This mirrors the mergeUpdatedKey pattern used by provider keys.
+func restoreRedactedFromExisting(incoming, existing map[string]any) map[string]any {
+	if len(incoming) == 0 {
+		return incoming
+	}
+	result := make(map[string]any, len(incoming))
+	for k, v := range incoming {
+		switch val := v.(type) {
+		case map[string]any:
+			if isEnvVarObject(val) {
+				ev := schemas.NewEnvVar(marshalEnvVarObject(val))
+				if ev.ShouldPreserveStored() {
+					if existingVal, ok := existing[k]; ok {
+						result[k] = existingVal
+						continue
+					}
+				}
+			} else if existingNested, ok := existing[k].(map[string]any); ok {
+				result[k] = restoreRedactedFromExisting(val, existingNested)
+				continue
+			}
+			result[k] = val
+		default:
+			result[k] = v
+		}
+	}
+	return result
+}
+
+// isEnvVarObject returns true if m has exactly the shape of a serialised EnvVar:
+// keys "value", "env_var", and "from_env".
+func isEnvVarObject(m map[string]any) bool {
+	_, hasValue := m["value"]
+	_, hasEnvVar := m["env_var"]
+	_, hasFromEnv := m["from_env"]
+	return hasValue && hasEnvVar && hasFromEnv
+}
+
+// marshalEnvVarObject serialises an EnvVar-shaped map back to the JSON string that
+// schemas.NewEnvVar expects so we can call ShouldPreserveStored on it.
+func marshalEnvVarObject(m map[string]any) string {
+	value, _ := m["value"].(string)
+	envVar, _ := m["env_var"].(string)
+	fromEnv, _ := m["from_env"].(bool)
+	if fromEnv {
+		return fmt.Sprintf(`{"value":%q,"env_var":%q,"from_env":true}`, value, envVar)
+	}
+	return fmt.Sprintf(`{"value":%q,"env_var":%q,"from_env":false}`, value, envVar)
 }

--- a/transports/bifrost-http/handlers/plugins_test.go
+++ b/transports/bifrost-http/handlers/plugins_test.go
@@ -51,6 +51,12 @@ func (noopPluginsLoader) RemovePlugin(_ context.Context, _ string) error { retur
 func (noopPluginsLoader) GetPluginStatus(_ context.Context) map[string]schemas.PluginStatus {
 	return nil
 }
+func (noopPluginsLoader) NormalizePluginConfig(_ string, _ map[string]any) (map[string]any, error) {
+	return nil, nil
+}
+func (noopPluginsLoader) ExpandPluginConfigForAPI(_ string, _ map[string]any) (map[string]any, error) {
+	return nil, nil
+}
 
 // buildUpdateRequest creates a PUT /api/plugins/{name} fasthttp context.
 func buildUpdateRequest(t *testing.T, body any) *fasthttp.RequestCtx {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -333,12 +333,13 @@ type Config struct {
 	// All plugins are stored in BasePlugins. Interface-specific caches are
 	// derived views rebuilt automatically on any plugin change.
 	// Lock-free reads via atomic.Pointer for hot-path performance.
-	pluginsMu            sync.Mutex                                    // Protects structural changes to BasePlugins
-	pluginOrderMap       map[string]pluginOrderInfo                    // Plugin ordering metadata (protected by pluginsMu)
-	BasePlugins          atomic.Pointer[[]schemas.BasePlugin]          // Master list of all plugins
-	LLMPlugins           atomic.Pointer[[]schemas.LLMPlugin]           // Derived cache (auto-rebuilt)
-	MCPPlugins           atomic.Pointer[[]schemas.MCPPlugin]           // Derived cache (auto-rebuilt)
-	HTTPTransportPlugins atomic.Pointer[[]schemas.HTTPTransportPlugin] // Derived cache (auto-rebuilt)
+	pluginsMu            sync.Mutex                                                // Protects structural changes to BasePlugins
+	pluginOrderMap       map[string]pluginOrderInfo                                // Plugin ordering metadata (protected by pluginsMu)
+	BasePlugins          atomic.Pointer[[]schemas.BasePlugin]                      // Master list of all plugins
+	LLMPlugins           atomic.Pointer[[]schemas.LLMPlugin]                       // Derived cache (auto-rebuilt)
+	MCPPlugins           atomic.Pointer[[]schemas.MCPPlugin]                       // Derived cache (auto-rebuilt)
+	HTTPTransportPlugins atomic.Pointer[[]schemas.HTTPTransportPlugin]             // Derived cache (auto-rebuilt)
+	ConfigMarshallers    atomic.Pointer[map[string]schemas.ConfigMarshallerPlugin] // Derived cache (auto-rebuilt)
 	PluginLoader         plugins.PluginLoader
 
 	// Plugin metadata from config file/database
@@ -3782,11 +3783,10 @@ func (c *Config) GetLoadedHTTPTransportPlugins() []schemas.HTTPTransportPlugin {
 func (c *Config) rebuildInterfaceCaches() {
 	basePlugins := c.BasePlugins.Load()
 	if basePlugins == nil {
-		// Clear all caches atomically
+		// Clear all caches atomically, except ConfigMarshallers which are preserved.
 		emptyLLM := []schemas.LLMPlugin{}
 		emptyMCP := []schemas.MCPPlugin{}
 		emptyHTTP := []schemas.HTTPTransportPlugin{}
-
 		c.LLMPlugins.Store(&emptyLLM)
 		c.MCPPlugins.Store(&emptyMCP)
 		c.HTTPTransportPlugins.Store(&emptyHTTP)
@@ -3808,12 +3808,49 @@ func (c *Config) rebuildInterfaceCaches() {
 		if httpPlugin, ok := p.(schemas.HTTPTransportPlugin); ok {
 			httpTransport = append(httpTransport, httpPlugin)
 		}
+		if cm, ok := p.(schemas.ConfigMarshallerPlugin); ok {
+			// RegisterConfigMarshaller adds/updates atomically without clearing other entries
+			c.RegisterConfigMarshaller(p.GetName(), cm)
+		}
 	}
 
-	// Atomic stores of all caches
 	c.LLMPlugins.Store(&llm)
 	c.MCPPlugins.Store(&mcp)
 	c.HTTPTransportPlugins.Store(&httpTransport)
+}
+
+// RegisterConfigMarshaller registers a config marshaller for a plugin by name without
+// adding the plugin to BasePlugins. Use this to register marshallers for disabled plugins
+// at startup so their stored configs can still be redacted/expanded via the API.
+func (c *Config) RegisterConfigMarshaller(name string, cm schemas.ConfigMarshallerPlugin) {
+	for {
+		old := c.ConfigMarshallers.Load()
+		newMap := make(map[string]schemas.ConfigMarshallerPlugin)
+		if old != nil {
+			maps.Copy(newMap, *old)
+		}
+		newMap[name] = cm
+		if c.ConfigMarshallers.CompareAndSwap(old, &newMap) {
+			return
+		}
+	}
+}
+
+// RemoveConfigMarshaller explicitly removes a plugin's config marshaller.
+// Call this only when a plugin is permanently deleted, not when it is disabled.
+func (c *Config) RemoveConfigMarshaller(name string) {
+	for {
+		old := c.ConfigMarshallers.Load()
+		if old == nil {
+			return
+		}
+		newMap := make(map[string]schemas.ConfigMarshallerPlugin, len(*old))
+		maps.Copy(newMap, *old)
+		delete(newMap, name)
+		if c.ConfigMarshallers.CompareAndSwap(old, &newMap) {
+			return
+		}
+	}
 }
 
 // IsPluginLoaded checks if a plugin with the given name is currently loaded.

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -60,6 +60,8 @@ type ServerCallbacks interface {
 	ReloadPlugin(ctx context.Context, name string, path *string, pluginConfig any, placement *schemas.PluginPlacement, order *int) error
 	RemovePlugin(ctx context.Context, name string) error
 	GetPluginStatus(ctx context.Context) map[string]schemas.PluginStatus
+	NormalizePluginConfig(name string, config map[string]any) (map[string]any, error)
+	ExpandPluginConfigForAPI(name string, config map[string]any) (map[string]any, error)
 	// Auth related callbacks
 	UpdateAuthConfig(ctx context.Context, authConfig *configstore.AuthConfig) error
 	ReloadClientConfigFromConfigStore(ctx context.Context) error
@@ -984,6 +986,30 @@ func (s *BifrostHTTPServer) GetPluginStatus(ctx context.Context) map[string]sche
 	return s.Config.GetPluginStatus()
 }
 
+// NormalizePluginConfig implements handlers.PluginsLoader. It looks up the plugin
+// by name in the ConfigMarshallers cache and calls MarshalConfigForStorage if found.
+// Returns nil, nil when the plugin is not loaded or does not implement ConfigMarshallerPlugin.
+func (s *BifrostHTTPServer) NormalizePluginConfig(name string, config map[string]any) (map[string]any, error) {
+	if m := s.Config.ConfigMarshallers.Load(); m != nil {
+		if cm, ok := (*m)[name]; ok {
+			return cm.MarshalConfigForStorage(config)
+		}
+	}
+	return nil, nil
+}
+
+// ExpandPluginConfigForAPI implements handlers.PluginsLoader. It looks up the plugin
+// by name in the ConfigMarshallers cache and calls RedactConfig if found.
+// Returns nil, nil when the plugin is not loaded or does not implement ConfigMarshallerPlugin.
+func (s *BifrostHTTPServer) ExpandPluginConfigForAPI(name string, config map[string]any) (map[string]any, error) {
+	if m := s.Config.ConfigMarshallers.Load(); m != nil {
+		if cm, ok := (*m)[name]; ok {
+			return cm.RedactConfig(config)
+		}
+	}
+	return nil, nil
+}
+
 // Helper to update error status
 // Uses UpdatePluginOverallStatus to create the status entry if it doesn't exist,
 // ensuring plugins that were never loaded can still have their error status tracked.
@@ -1068,11 +1094,13 @@ func (s *BifrostHTTPServer) RemovePlugin(ctx context.Context, displayName string
 		s.reloadObservabilityPlugins()
 	}
 
-	// 4. Update status
+	// 4. Update status and marshaller
 	if isDisabled, _ := ctx.Value(handlers.PluginDisabledKey).(bool); isDisabled {
 		s.markPluginDisabled(name)
 	} else {
 		s.Config.DeletePluginOverallStatus(name)
+		// Plugin is being permanently deleted: remove its config marshaller too.
+		s.Config.RemoveConfigMarshaller(name)
 	}
 
 	return nil

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -1,12 +1,14 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { EnvVarInput } from "@/components/ui/envVarInput";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { HeadersTable } from "@/components/ui/headersTable";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { otelFormSchema, type OtelFormSchema } from "@/lib/types/schemas";
+import { otelFormSchema, type EnvVar, type OtelFormSchema } from "@/lib/types/schemas";
+import { toEnvVarFormValue, toEnvVarMapFormValue } from "@/lib/utils/envVarForm";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Trash2 } from "lucide-react";
@@ -17,8 +19,8 @@ interface OtelFormFragmentProps {
 	currentConfig?: {
 		enabled?: boolean;
 		service_name?: string;
-		collector_url?: string;
-		headers?: Record<string, string>;
+		collector_url?: string | EnvVar;
+		headers?: Record<string, string | EnvVar>;
 		trace_type?: "genai_extension" | "vercel" | "open_inference";
 		protocol?: "http" | "grpc";
 		// TLS configuration
@@ -26,7 +28,7 @@ interface OtelFormFragmentProps {
 		insecure?: boolean;
 		// Metrics push configuration
 		metrics_enabled?: boolean;
-		metrics_endpoint?: string;
+		metrics_endpoint?: string | EnvVar;
 		metrics_push_interval?: number;
 	};
 	onSave: (config: OtelFormSchema) => Promise<void>;
@@ -34,6 +36,22 @@ interface OtelFormFragmentProps {
 	isDeleting?: boolean;
 	isLoading?: boolean;
 }
+
+const buildDefaults = (initialConfig?: OtelFormFragmentProps["currentConfig"]): OtelFormSchema => ({
+	enabled: initialConfig?.enabled ?? true,
+	otel_config: {
+		service_name: initialConfig?.service_name ?? "bifrost",
+		collector_url: toEnvVarFormValue(initialConfig?.collector_url),
+		headers: toEnvVarMapFormValue(initialConfig?.headers),
+		trace_type: initialConfig?.trace_type ?? "genai_extension",
+		protocol: initialConfig?.protocol ?? "http",
+		tls_ca_cert: initialConfig?.tls_ca_cert ?? "",
+		insecure: initialConfig?.insecure ?? true,
+		metrics_enabled: initialConfig?.metrics_enabled ?? false,
+		metrics_endpoint: toEnvVarFormValue(initialConfig?.metrics_endpoint),
+		metrics_push_interval: initialConfig?.metrics_push_interval ?? 15,
+	},
+});
 
 export function OtelFormFragment({
 	currentConfig: initialConfig,
@@ -48,21 +66,7 @@ export function OtelFormFragment({
 		resolver: zodResolver(otelFormSchema) as Resolver<OtelFormSchema, any, OtelFormSchema>,
 		mode: "onChange",
 		reValidateMode: "onChange",
-		defaultValues: {
-			enabled: initialConfig?.enabled ?? true,
-			otel_config: {
-				service_name: initialConfig?.service_name ?? "bifrost",
-				collector_url: initialConfig?.collector_url ?? "",
-				headers: initialConfig?.headers ?? {},
-				trace_type: initialConfig?.trace_type ?? "genai_extension",
-				protocol: initialConfig?.protocol ?? "http",
-				tls_ca_cert: initialConfig?.tls_ca_cert ?? "",
-				insecure: initialConfig?.insecure ?? true,
-				metrics_enabled: initialConfig?.metrics_enabled ?? false,
-				metrics_endpoint: initialConfig?.metrics_endpoint ?? "",
-				metrics_push_interval: initialConfig?.metrics_push_interval ?? 15,
-			},
-		},
+		defaultValues: buildDefaults(initialConfig),
 	});
 
 	const onSubmit = (data: OtelFormSchema) => {
@@ -91,22 +95,7 @@ export function OtelFormFragment({
 	}, [metricsEnabled, form]);
 
 	useEffect(() => {
-		// Reset form with new initial config when it changes
-		form.reset({
-			enabled: initialConfig?.enabled ?? true,
-			otel_config: {
-				service_name: initialConfig?.service_name ?? "bifrost",
-				collector_url: initialConfig?.collector_url || "",
-				headers: initialConfig?.headers || {},
-				trace_type: initialConfig?.trace_type || "genai_extension",
-				protocol: initialConfig?.protocol || "http",
-				tls_ca_cert: initialConfig?.tls_ca_cert ?? "",
-				insecure: initialConfig?.insecure ?? true,
-				metrics_enabled: initialConfig?.metrics_enabled ?? false,
-				metrics_endpoint: initialConfig?.metrics_endpoint ?? "",
-				metrics_push_interval: initialConfig?.metrics_push_interval ?? 15,
-			},
-		});
+		form.reset(buildDefaults(initialConfig));
 	}, [form, initialConfig]);
 
 	const traceTypeOptions: { value: string; label: string; disabled?: boolean; disabledReason?: string }[] = [
@@ -149,11 +138,11 @@ export function OtelFormFragment({
 										<code>{form.watch("otel_config.protocol") === "http" ? "http(s)://<host>:<port>/v1/traces" : "<host>:<port>"}</code>
 									</div>
 									<FormControl>
-										<Input
+										<EnvVarInput
 											placeholder={
 												form.watch("otel_config.protocol") === "http"
-													? "https://otel-collector.example.com:4318/v1/traces"
-													: "otel-collector.example.com:4317"
+													? "https://otel-collector.example.com:4318/v1/traces or env.OTEL_COLLECTOR_URL"
+													: "otel-collector.example.com:4317 or env.OTEL_COLLECTOR_URL"
 											}
 											disabled={!hasOtelAccess}
 											{...field}
@@ -169,7 +158,7 @@ export function OtelFormFragment({
 							render={({ field }) => (
 								<FormItem className="w-full">
 									<FormControl>
-										<HeadersTable value={field.value || {}} onChange={field.onChange} disabled={!hasOtelAccess} />
+										<HeadersTable value={field.value || {}} onChange={field.onChange} disabled={!hasOtelAccess} useEnvVarInput />
 									</FormControl>
 									<FormMessage />
 								</FormItem>
@@ -330,9 +319,11 @@ export function OtelFormFragment({
 											<code>{form.watch("otel_config.protocol") === "http" ? "http(s)://<host>:<port>/v1/metrics" : "<host>:<port>"}</code>
 										</div>
 										<FormControl>
-											<Input
+											<EnvVarInput
 												placeholder={
-													form.watch("otel_config.protocol") === "http" ? "https://otel-collector:4318/v1/metrics" : "otel-collector:4317"
+													form.watch("otel_config.protocol") === "http"
+														? "https://otel-collector:4318/v1/metrics or env.OTEL_METRICS_ENDPOINT"
+														: "otel-collector:4317 or env.OTEL_METRICS_ENDPOINT"
 												}
 												disabled={!hasOtelAccess}
 												{...field}
@@ -406,21 +397,7 @@ export function OtelFormFragment({
 							type="button"
 							variant="outline"
 							onClick={() => {
-								form.reset({
-									enabled: initialConfig?.enabled ?? true,
-									otel_config: {
-										service_name: initialConfig?.service_name ?? "bifrost",
-										collector_url: initialConfig?.collector_url ?? "",
-										headers: initialConfig?.headers ?? {},
-										trace_type: initialConfig?.trace_type ?? "genai_extension",
-										protocol: initialConfig?.protocol ?? "http",
-										tls_ca_cert: initialConfig?.tls_ca_cert ?? "",
-										insecure: initialConfig?.insecure ?? true,
-										metrics_enabled: initialConfig?.metrics_enabled ?? false,
-										metrics_endpoint: initialConfig?.metrics_endpoint ?? "",
-										metrics_push_interval: initialConfig?.metrics_push_interval ?? 15,
-									},
-								});
+								form.reset(buildDefaults(initialConfig));
 							}}
 							disabled={!hasOtelAccess || isLoading || !form.formState.isDirty}
 						>

--- a/ui/app/workspace/observability/fragments/prometheusFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/prometheusFormFragment.tsx
@@ -1,16 +1,18 @@
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { EnvVarInput } from "@/components/ui/envVarInput";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
-import { prometheusFormSchema, type PrometheusFormSchema } from "@/lib/types/schemas";
+import { prometheusFormSchema, type EnvVar, type PrometheusFormSchema } from "@/lib/types/schemas";
+import { emptyEnvVar, toEnvVarFormValue } from "@/lib/utils/envVarForm";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { AlertTriangle, Copy, Eye, EyeOff, Info, Plus, Trash, Trash2 } from "lucide-react";
+import { AlertTriangle, Copy, Info, Plus, Trash, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm, type Resolver } from "react-hook-form";
 
@@ -18,13 +20,13 @@ interface PrometheusFormFragmentProps {
 	currentConfig?: {
 		metrics_enabled?: boolean;
 		push_gateway_enabled?: boolean;
-		push_gateway_url?: string;
+		push_gateway_url?: string | EnvVar;
 		job_name?: string;
 		instance_id?: string;
 		push_interval?: number;
 		basic_auth?: {
-			username?: string;
-			password?: string;
+			username?: string | EnvVar;
+			password?: string | EnvVar;
 		};
 	};
 	onSave: (config: PrometheusFormSchema) => Promise<void>;
@@ -34,16 +36,19 @@ interface PrometheusFormFragmentProps {
 	metricsEndpoint?: string;
 }
 
+const hasAuth = (v?: string | EnvVar): boolean =>
+	typeof v === "string" ? !!v.trim() : !!(v?.value?.trim() || (v?.from_env && !!v?.env_var?.trim()));
+
 const buildDefaults = (initialConfig?: PrometheusFormFragmentProps["currentConfig"]): PrometheusFormSchema => ({
 	metrics_enabled: initialConfig?.metrics_enabled ?? true,
 	push_gateway_enabled: initialConfig?.push_gateway_enabled ?? false,
 	prometheus_config: {
-		push_gateway_url: initialConfig?.push_gateway_url ?? "",
+		push_gateway_url: toEnvVarFormValue(initialConfig?.push_gateway_url),
 		job_name: initialConfig?.job_name ?? "bifrost",
 		instance_id: initialConfig?.instance_id ?? "",
 		push_interval: initialConfig?.push_interval ?? 15,
-		basic_auth_username: initialConfig?.basic_auth?.username ?? "",
-		basic_auth_password: initialConfig?.basic_auth?.password ?? "",
+		basic_auth_username: toEnvVarFormValue(initialConfig?.basic_auth?.username),
+		basic_auth_password: toEnvVarFormValue(initialConfig?.basic_auth?.password),
 	},
 });
 
@@ -69,10 +74,9 @@ export function PrometheusFormFragment({
 	metricsEndpoint,
 }: PrometheusFormFragmentProps) {
 	const hasPrometheusAccess = useRbac(RbacResource.Observability, RbacOperation.Update);
-	const [showPassword, setShowPassword] = useState(false);
 	const [isSaving, setIsSaving] = useState(false);
 	const { copy, copied } = useCopyToClipboard();
-	const [showBasicAuth, setShowBasicAuth] = useState(!!(initialConfig?.basic_auth?.username || initialConfig?.basic_auth?.password));
+	const [showBasicAuth, setShowBasicAuth] = useState(hasAuth(initialConfig?.basic_auth?.username) || hasAuth(initialConfig?.basic_auth?.password));
 	const [activeTab, setActiveTab] = useState<"pull" | "push">("pull");
 
 	const form = useForm<PrometheusFormSchema, any, PrometheusFormSchema>({
@@ -93,7 +97,7 @@ export function PrometheusFormFragment({
 
 	useEffect(() => {
 		form.reset(buildDefaults(initialConfig));
-		setShowBasicAuth(!!(initialConfig?.basic_auth?.username || initialConfig?.basic_auth?.password));
+		setShowBasicAuth(hasAuth(initialConfig?.basic_auth?.username) || hasAuth(initialConfig?.basic_auth?.password));
 	}, [form, initialConfig]);
 
 	const handleCopyEndpoint = () => {
@@ -103,11 +107,11 @@ export function PrometheusFormFragment({
 	};
 
 	const handleRemoveBasicAuth = () => {
-		form.setValue("prometheus_config.basic_auth_username", "", {
+		form.setValue("prometheus_config.basic_auth_username", emptyEnvVar(), {
 			shouldDirty: true,
 			shouldValidate: true,
 		});
-		form.setValue("prometheus_config.basic_auth_password", "", {
+		form.setValue("prometheus_config.basic_auth_password", emptyEnvVar(), {
 			shouldDirty: true,
 			shouldValidate: true,
 		});
@@ -140,15 +144,15 @@ export function PrometheusFormFragment({
 			shouldValidate: true,
 		});
 		form.setValue("prometheus_config.push_interval", defaults.prometheus_config.push_interval, { shouldDirty: true, shouldValidate: true });
-		form.setValue("prometheus_config.basic_auth_username", defaults.prometheus_config.basic_auth_username ?? "", {
+		form.setValue("prometheus_config.basic_auth_username", defaults.prometheus_config.basic_auth_username ?? emptyEnvVar(), {
 			shouldDirty: true,
 			shouldValidate: true,
 		});
-		form.setValue("prometheus_config.basic_auth_password", defaults.prometheus_config.basic_auth_password ?? "", {
+		form.setValue("prometheus_config.basic_auth_password", defaults.prometheus_config.basic_auth_password ?? emptyEnvVar(), {
 			shouldDirty: true,
 			shouldValidate: true,
 		});
-		setShowBasicAuth(!!(initialConfig?.basic_auth?.username || initialConfig?.basic_auth?.password));
+		setShowBasicAuth(hasAuth(initialConfig?.basic_auth?.username) || hasAuth(initialConfig?.basic_auth?.password));
 	};
 
 	// Tabs can independently report whether *their* fields differ from the
@@ -347,8 +351,8 @@ export function PrometheusFormFragment({
 									<FormItem className="w-full">
 										<FormLabel>Push Gateway URL</FormLabel>
 										<FormControl>
-											<Input
-												placeholder="http://pushgateway:9091"
+											<EnvVarInput
+												placeholder="http://pushgateway:9091 or env.PUSHGATEWAY_URL"
 												disabled={!hasPrometheusAccess}
 												data-testid="prometheus-push-gateway-url"
 												{...field}
@@ -472,8 +476,8 @@ export function PrometheusFormFragment({
 													<FormItem>
 														<FormLabel>Username</FormLabel>
 														<FormControl>
-															<Input
-																placeholder="Username"
+															<EnvVarInput
+																placeholder="Username or env.PG_USER"
 																disabled={!hasPrometheusAccess}
 																data-testid="prometheus-basic-auth-username"
 																{...field}
@@ -491,28 +495,15 @@ export function PrometheusFormFragment({
 													<FormItem>
 														<FormLabel>Password</FormLabel>
 														<FormControl>
-															<div className="relative">
-																<Input
-																	type={showPassword ? "text" : "password"}
-																	placeholder="Password"
-																	disabled={!hasPrometheusAccess}
-																	data-testid="prometheus-basic-auth-password"
-																	{...field}
-																	className="pr-10"
-																/>
-																<Button
-																	type="button"
-																	variant="ghost"
-																	size="sm"
-																	className="absolute top-0 right-0 h-full px-3 py-2 hover:bg-transparent"
-																	onClick={() => setShowPassword(!showPassword)}
-																	disabled={!hasPrometheusAccess}
-																	data-testid="prometheus-toggle-password"
-																	aria-label={showPassword ? "Hide password" : "Show password"}
-																>
-																	{showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-																</Button>
-															</div>
+															<EnvVarInput
+																type="password"
+																placeholder="Password or env.PG_PASS"
+																disabled={!hasPrometheusAccess}
+																hideValueWhenEnv
+																redactNonEnvValue
+																data-testid="prometheus-basic-auth-password"
+																{...field}
+															/>
 														</FormControl>
 														<FormMessage />
 													</FormItem>

--- a/ui/app/workspace/observability/views/plugins/prometheusView.tsx
+++ b/ui/app/workspace/observability/views/plugins/prometheusView.tsx
@@ -1,18 +1,19 @@
 import { getErrorMessage, useAppSelector, useUpdatePluginMutation } from "@/lib/store";
-import { PrometheusFormSchema } from "@/lib/types/schemas";
+import { type EnvVar, PrometheusFormSchema } from "@/lib/types/schemas";
+import { toOptionalEnvVarPayload } from "@/lib/utils/envVarForm";
 import { useMemo } from "react";
 import { toast } from "sonner";
 import { PrometheusFormFragment } from "../../fragments/prometheusFormFragment";
 
 interface PushGatewayConfig {
 	enabled?: boolean;
-	push_gateway_url?: string;
+	push_gateway_url?: string | EnvVar;
 	job_name?: string;
 	instance_id?: string;
 	push_interval?: number;
 	basic_auth?: {
-		username?: string;
-		password?: string;
+		username?: string | EnvVar;
+		password?: string | EnvVar;
 	};
 }
 
@@ -53,11 +54,10 @@ export default function PrometheusView({ onDelete, isDeleting }: PrometheusViewP
 				push_interval: config.prometheus_config.push_interval,
 			};
 
-			if (config.prometheus_config.basic_auth_username?.trim() && config.prometheus_config.basic_auth_password?.trim()) {
-				pushGatewayConfig.basic_auth = {
-					username: config.prometheus_config.basic_auth_username,
-					password: config.prometheus_config.basic_auth_password,
-				};
+			const username = toOptionalEnvVarPayload(config.prometheus_config.basic_auth_username);
+			const password = toOptionalEnvVarPayload(config.prometheus_config.basic_auth_password);
+			if (username && password) {
+				pushGatewayConfig.basic_auth = { username, password };
 			}
 
 			// Plugin stays loaded as long as the connector exists; the two inner

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -741,13 +741,13 @@ export type BetaHeadersFormSchema = z.infer<typeof betaHeadersFormSchema>;
 export const otelConfigSchema = z
 	.object({
 		service_name: z.string().optional(),
-		collector_url: z.string().default(""),
+		collector_url: envVarSchema.default({ value: "", env_var: "", from_env: false }),
 		trace_type: z
 			.enum(["genai_extension", "vercel", "open_inference"], {
 				message: "Please select a trace type",
 			})
 			.default("genai_extension"),
-		headers: z.record(z.string(), z.string()).optional(),
+		headers: z.record(z.string(), envVarSchema).optional(),
 		protocol: z
 			.enum(["http", "grpc"], {
 				message: "Please select a protocol",
@@ -758,7 +758,7 @@ export const otelConfigSchema = z
 		insecure: z.boolean().default(true),
 		// Metrics push configuration
 		metrics_enabled: z.boolean().default(false),
-		metrics_endpoint: z.string().optional(),
+		metrics_endpoint: envVarSchema.optional(),
 		metrics_push_interval: z.number().int().min(1).max(300).default(15),
 	})
 	.superRefine((data, ctx) => {
@@ -811,26 +811,26 @@ export const otelConfigSchema = z
 			return true;
 		};
 
-		// Validate collector_url format (emptiness check is at form level, gated by enabled)
-		const collectorUrl = (data.collector_url || "").trim();
-		if (collectorUrl && protocol === "http") {
+		// Validate collector_url format — skip format check for env var references
+		const collectorUrl = (data.collector_url?.value || "").trim();
+		if (collectorUrl && !data.collector_url?.from_env && protocol === "http") {
 			validateHttpUrl(collectorUrl, ["collector_url"]);
-		} else if (collectorUrl && protocol === "grpc") {
+		} else if (collectorUrl && !data.collector_url?.from_env && protocol === "grpc") {
 			validateHostPort(collectorUrl, ["collector_url"], "otel-collector:4317");
 		}
 
 		// Validate metrics_endpoint when metrics_enabled is true
 		if (data.metrics_enabled) {
-			const metricsEndpoint = (data.metrics_endpoint || "").trim();
-			if (!metricsEndpoint) {
+			const metricsEndpoint = (data.metrics_endpoint?.value || "").trim();
+			if (!isEnvVarSet(data.metrics_endpoint)) {
 				ctx.addIssue({
 					code: "custom",
 					path: ["metrics_endpoint"],
 					message: "Metrics endpoint is required when metrics push is enabled",
 				});
-			} else if (protocol === "http") {
+			} else if (metricsEndpoint && !data.metrics_endpoint?.from_env && protocol === "http") {
 				validateHttpUrl(metricsEndpoint, ["metrics_endpoint"]);
-			} else if (protocol === "grpc") {
+			} else if (metricsEndpoint && !data.metrics_endpoint?.from_env && protocol === "grpc") {
 				validateHostPort(metricsEndpoint, ["metrics_endpoint"], "otel-collector:4317");
 			}
 		}
@@ -844,8 +844,7 @@ export const otelFormSchema = z
 	})
 	.superRefine((data, ctx) => {
 		if (data.enabled) {
-			const collectorUrl = (data.otel_config.collector_url || "").trim();
-			if (!collectorUrl) {
+			if (!isEnvVarSet(data.otel_config.collector_url)) {
 				ctx.addIssue({
 					code: "custom",
 					path: ["otel_config", "collector_url"],
@@ -889,17 +888,17 @@ export const maximFormSchema = z
 // Prometheus Push Gateway Configuration Schema
 export const prometheusConfigSchema = z
 	.object({
-		push_gateway_url: z.string().optional(),
+		push_gateway_url: envVarSchema.optional(),
 		job_name: z.string().default("bifrost"),
 		instance_id: z.string().optional(),
 		push_interval: z.number().min(1).max(300).default(15),
-		basic_auth_username: z.string().optional(),
-		basic_auth_password: z.string().optional(),
+		basic_auth_username: envVarSchema.optional(),
+		basic_auth_password: envVarSchema.optional(),
 	})
 	.superRefine((data, ctx) => {
-		// Validate push_gateway_url format
-		const url = (data.push_gateway_url || "").trim();
-		if (url) {
+		// Validate push_gateway_url format — skip for env var references
+		const url = (data.push_gateway_url?.value || "").trim();
+		if (url && !data.push_gateway_url?.from_env) {
 			try {
 				const u = new URL(url);
 				if (!(u.protocol === "http:" || u.protocol === "https:")) {
@@ -919,8 +918,8 @@ export const prometheusConfigSchema = z
 		}
 
 		// Validate basic auth: if one credential is provided, both must be provided
-		const hasUsername = !!data.basic_auth_username?.trim();
-		const hasPassword = !!data.basic_auth_password?.trim();
+		const hasUsername = isEnvVarSet(data.basic_auth_username);
+		const hasPassword = isEnvVarSet(data.basic_auth_password);
 		if (hasUsername && !hasPassword) {
 			ctx.addIssue({
 				code: "custom",
@@ -946,8 +945,8 @@ export const prometheusFormSchema = z
 	})
 	.superRefine((data, ctx) => {
 		if (data.push_gateway_enabled) {
-			const url = (data.prometheus_config.push_gateway_url || "").trim();
-			if (!url) {
+			const urlIsSet = isEnvVarSet(data.prometheus_config.push_gateway_url);
+			if (!urlIsSet) {
 				ctx.addIssue({
 					code: "custom",
 					path: ["prometheus_config", "push_gateway_url"],

--- a/ui/lib/utils/envVarForm.ts
+++ b/ui/lib/utils/envVarForm.ts
@@ -9,7 +9,7 @@ export const toEnvVarFormValue = (field?: EnvVar | string): EnvVar => {
 		if (!value) return emptyEnvVar();
 		const isEnvRef = value.startsWith("env.");
 		return {
-			value,
+			value: isEnvRef ? "" : value,
 			env_var: isEnvRef ? value : "",
 			from_env: isEnvRef,
 		};
@@ -19,6 +19,11 @@ export const toEnvVarFormValue = (field?: EnvVar | string): EnvVar => {
 		env_var: field.env_var || "",
 		from_env: field.from_env ?? false,
 	};
+};
+
+export const toEnvVarMapFormValue = (map?: Record<string, string | EnvVar>): Record<string, EnvVar> => {
+	if (!map) return {};
+	return Object.fromEntries(Object.entries(map).map(([k, v]) => [k, toEnvVarFormValue(v)]));
 };
 
 export const toOptionalEnvVarPayload = (field?: { value?: string; env_var?: string; from_env?: boolean }) => {


### PR DESCRIPTION
## Summary

This PR introduces `EnvVar`-typed fields for sensitive and configurable URL/credential values in the OpenTelemetry and Prometheus (telemetry) plugins, replacing raw `string` fields. This allows users to reference environment variables (e.g., `env.OTEL_COLLECTOR_URL`) instead of embedding literal values in stored configuration, improving secret management and deployment flexibility.

## Changes

- **`plugins/otel`**: `CollectorURL`, `MetricsEndpoint`, and `Headers` values in `Config` are now `*schemas.EnvVar` instead of `string`/`map[string]string`. Added `MarshalForStorage()` to serialize back to plain strings for DB persistence, `Redacted()` for safe API responses, and `resolveHeaders()` to convert `EnvVar` header maps to plain strings at runtime. Removed the inline `env.` prefix resolution loop from `Init` in favor of `EnvVar.GetValue()`.
- **`plugins/telemetry`**: `PushGatewayURL`, `BasicAuth.Username`, and `BasicAuth.Password` in `PushGatewayConfig`/`BasicAuthConfig` are now `*schemas.EnvVar`. Added `MarshalForStorage()` and `Redacted()` to `Config` with the same storage/API separation pattern.
- **`core/schemas`**: Introduced the `ConfigMarshallerPlugin` interface, optionally implemented by plugins that need custom config serialization. The server calls `MarshalConfigForStorage` before writing config to the DB and `RedactConfig` when building API responses. Both the OTEL and telemetry plugins implement this interface.
- **`transports/bifrost-http/handlers/plugins.go`**: Added `normalizePluginConfig()` to round-trip plugin configs through their typed structs before DB writes (ensuring `EnvVar` → plain string serialization), and `expandPluginConfigForAPI()` to expand stored plain strings back into full `EnvVar` objects with redaction for API responses. Refactored `getPlugins` to use `buildPluginResponseWithStatuses` to avoid redundant status fetches per plugin.
- **`transports/bifrost-http/lib/config.go`**: Added a `ConfigMarshallers` atomic cache derived from `BasePlugins`, rebuilt alongside the other interface caches on any plugin change.
- **`transports/bifrost-http/server/server.go`**: Implemented `NormalizePluginConfig` and `ExpandPluginConfigForAPI` on `BifrostHTTPServer`, backed by the `ConfigMarshallers` cache.
- **UI schemas (`ui/lib/types/schemas.ts`)**: Updated `otelConfigSchema` and `prometheusConfigSchema` to use `envVarSchema` for URL and credential fields. Validation logic now skips format checks for env var references (`from_env: true`) and checks `value` or `from_env` presence instead of raw string truthiness.
- **UI forms**: Replaced plain `<Input>` components with `<EnvVarInput>` for collector URL, metrics endpoint, push gateway URL, and basic auth fields in the OTEL and Prometheus form fragments. The password field now uses `EnvVarInput` with `hideValueWhenEnv` and `redactNonEnvValue` props, removing the manual show/hide toggle. `HeadersTable` now uses `useEnvVarInput` mode.
- **`ui/lib/utils/envVarForm.ts`**: Fixed `toEnvVarFormValue` to clear `value` when the input is an env reference string. Added `toEnvVarMapFormValue` to convert header maps of mixed `string | EnvVar` values into typed `EnvVar` form values.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./plugins/otel/... ./plugins/telemetry/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
pnpm test
```

**Manual validation:**
1. Configure the OTEL plugin with `collector_url` set to `env.OTEL_COLLECTOR_URL` and verify the environment variable is resolved at runtime.
2. Set a literal URL and confirm it is stored and returned correctly.
3. Configure Prometheus push gateway with `env.PUSHGATEWAY_URL` and basic auth credentials via env vars; verify metrics are pushed correctly.
4. Confirm API responses show full `EnvVar` objects with sensitive values redacted.
5. Confirm DB-stored configs contain plain strings (`env.FOO` or literal values), not JSON objects.

## Breaking changes

- [x] Yes
- [ ] No

The `Config` structs for the OTEL and telemetry plugins have changed field types from `string` to `*schemas.EnvVar`. Any code directly constructing these structs (e.g., in tests or custom integrations) must be updated to wrap values using `schemas.NewEnvVar(...)` or equivalent. Configs already stored in the database as plain strings will be transparently upgraded on read via `EnvVar.UnmarshalJSON`.

## Security considerations

Sensitive fields (collector URLs, push gateway URLs, basic auth credentials, and OTEL headers) are now redacted in API responses via the `Redacted()` methods. Credentials are never stored as resolved values — only as `env.VAR_NAME` references or literal strings as provided by the user. The `FullyRedacted()` method is applied to passwords specifically.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable