### PR TITLE
feat(governance): add virtual key blocked models

### DIFF
--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -796,6 +796,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationRefreshConfigHashAfterMCPExternalServerURLRemoval(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationAddVirtualKeyBlacklistedModelsColumn(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -8536,6 +8539,63 @@ func migrationAddTempTokensTable(ctx context.Context, db *gorm.DB) error {
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_temp_tokens_table migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddVirtualKeyBlacklistedModelsColumn adds the blacklisted_models JSON column
+// to governance_virtual_key_provider_configs, matching the provider-key blacklist pattern.
+func migrationAddVirtualKeyBlacklistedModelsColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "add_vk_provider_config_blacklisted_models_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if !mg.HasColumn(&tables.TableVirtualKeyProviderConfig{}, "blacklisted_models") {
+				if err := mg.AddColumn(&tables.TableVirtualKeyProviderConfig{}, "blacklisted_models"); err != nil {
+					return fmt.Errorf("failed to add blacklisted_models column: %w", err)
+				}
+				// Backfill empty arrays for existing rows (only when column is newly added)
+				if err := tx.Exec("UPDATE governance_virtual_key_provider_configs SET blacklisted_models = '[]' WHERE blacklisted_models IS NULL OR blacklisted_models = ''").Error; err != nil {
+					return fmt.Errorf("failed to backfill blacklisted_models: %w", err)
+				}
+				// Recompute config_hash for all VKs affected by the backfill so they
+				// do not appear stale after upgrade (same pattern as allow_all_keys migration).
+				var virtualKeys []tables.TableVirtualKey
+				if err := tx.
+					Preload("ProviderConfigs").
+					Preload("ProviderConfigs.Keys").
+					Preload("MCPConfigs").
+					Find(&virtualKeys).Error; err != nil {
+					return fmt.Errorf("failed to fetch virtual keys for hash recomputation: %w", err)
+				}
+				for _, vk := range virtualKeys {
+					newHash, err := GenerateVirtualKeyHash(vk)
+					if err != nil {
+						return fmt.Errorf("failed to generate hash for VK %s: %w", vk.ID, err)
+					}
+					if err := tx.Model(&tables.TableVirtualKey{}).
+						Where("id = ?", vk.ID).
+						Update("config_hash", newHash).Error; err != nil {
+						return fmt.Errorf("failed to update config_hash for VK %s: %w", vk.ID, err)
+					}
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			mg := tx.Migrator()
+			if mg.HasColumn(&tables.TableVirtualKeyProviderConfig{}, "blacklisted_models") {
+				if err := mg.DropColumn(&tables.TableVirtualKeyProviderConfig{}, "blacklisted_models"); err != nil {
+					return fmt.Errorf("failed to drop blacklisted_models column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running add_vk_provider_config_blacklisted_models_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -24,12 +24,13 @@ func (TableVirtualKeyProviderConfigKey) TableName() string {
 
 // TableVirtualKeyProviderConfig represents a provider configuration for a virtual key
 type TableVirtualKeyProviderConfig struct {
-	ID            uint              `gorm:"primaryKey;autoIncrement" json:"id"`
-	VirtualKeyID  string            `gorm:"type:varchar(255);not null" json:"virtual_key_id"`
-	Provider      string            `gorm:"type:varchar(50);not null" json:"provider"`
-	Weight        *float64          `json:"weight"`
-	AllowedModels schemas.WhiteList `gorm:"type:text;serializer:json" json:"allowed_models"` // ["*"] allows all models; empty denies all (deny-by-default)
-	AllowAllKeys  bool              `gorm:"default:false" json:"allow_all_keys"`             // True means all keys allowed; false with empty Keys means no keys allowed (deny-by-default)
+	ID                uint                `gorm:"primaryKey;autoIncrement" json:"id"`
+	VirtualKeyID      string              `gorm:"type:varchar(255);not null" json:"virtual_key_id"`
+	Provider          string              `gorm:"type:varchar(50);not null" json:"provider"`
+	Weight            *float64            `json:"weight"`
+	AllowedModels     schemas.WhiteList   `gorm:"type:text;serializer:json" json:"allowed_models"`         // ["*"] allows all models; empty denies all (deny-by-default)
+	BlacklistedModels schemas.BlackList   `gorm:"type:text;serializer:json" json:"blacklisted_models"`     // ["*"] blocks all models; empty blocks none
+	AllowAllKeys      bool                `gorm:"default:false" json:"allow_all_keys"`                     // True means all keys allowed; false with empty Keys means no keys allowed (deny-by-default)
 	RateLimitID   *string           `gorm:"type:varchar(255);index" json:"rate_limit_id,omitempty"`
 
 	// Relationships
@@ -77,30 +78,39 @@ func (pc *TableVirtualKeyProviderConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// BeforeSave validates WhiteList fields before GORM persists the record.
+// BeforeSave validates WhiteList and BlackList fields before GORM persists the record.
 func (pc *TableVirtualKeyProviderConfig) BeforeSave(tx *gorm.DB) error {
 	if err := pc.AllowedModels.Validate(); err != nil {
 		return fmt.Errorf("invalid allowed_models: %w", err)
 	}
+	if err := pc.BlacklistedModels.Validate(); err != nil {
+		return fmt.Errorf("invalid blacklisted_models: %w", err)
+	}
 	return nil
 }
 
-// MarshalJSON custom marshaller to ensure AllowedModels is always an array (never null)
+// MarshalJSON custom marshaller to ensure AllowedModels and BlacklistedModels are always arrays (never null)
 func (pc TableVirtualKeyProviderConfig) MarshalJSON() ([]byte, error) {
 	type Alias TableVirtualKeyProviderConfig
 
-	// Ensure AllowedModels is an empty slice instead of nil
+	// Ensure arrays are empty slices instead of nil
 	allowedModels := pc.AllowedModels
 	if allowedModels == nil {
 		allowedModels = []string{}
 	}
+	blacklistedModels := pc.BlacklistedModels
+	if blacklistedModels == nil {
+		blacklistedModels = []string{}
+	}
 
 	return json.Marshal(&struct {
 		Alias
-		AllowedModels []string `json:"allowed_models"`
+		AllowedModels     []string `json:"allowed_models"`
+		BlacklistedModels []string `json:"blacklisted_models"`
 	}{
-		Alias:         Alias(pc),
-		AllowedModels: allowedModels,
+		Alias:             Alias(pc),
+		AllowedModels:     allowedModels,
+		BlacklistedModels: blacklistedModels,
 	})
 }
 

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -767,8 +767,22 @@ func (p *GovernancePlugin) loadBalanceProvider(ctx *schemas.BifrostContext, req 
 	p.logger.Debug("[Governance] Virtual key has %d provider configs: %v", len(providerConfigs), configuredProviders)
 	ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelInfo, fmt.Sprintf("Load balancing model %s across %d configured providers: %v", modelStr, len(providerConfigs), configuredProviders))
 
+	// Pre-pass: if any config for a provider blacklists the model, that provider is fully blocked.
+	blacklistedProviders := make(map[string]bool)
+	for _, config := range providerConfigs {
+		if config.BlacklistedModels.IsBlocked(modelStr) {
+			blacklistedProviders[config.Provider] = true
+		}
+	}
+
 	allowedProviderConfigs := make([]configstoreTables.TableVirtualKeyProviderConfig, 0)
 	for _, config := range providerConfigs {
+		// Blacklist check wins over allowlist (same as provider-key enforcement)
+		if blacklistedProviders[config.Provider] {
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelInfo, fmt.Sprintf("Provider %s excluded: model %s is blacklisted", config.Provider, modelStr))
+			continue
+		}
+
 		// Delegate model allowance check to model catalog
 		// This handles all cross-provider logic (OpenRouter, Vertex, Groq, Bedrock)
 		// and provider-prefixed allowed_models entries

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -322,29 +322,37 @@ func (r *BudgetResolver) EvaluateVirtualKeyRequest(ctx *schemas.BifrostContext, 
 	}
 }
 
-// isModelAllowed checks if the requested model is allowed for this VK
+// isModelAllowed checks if the requested model is allowed for this VK.
+// Blacklisted models win over allowed models (same semantics as provider-key enforcement).
+// Two-pass: blacklist scan across all matching configs first, then allowlist scan.
 func (r *BudgetResolver) isModelAllowed(vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, model string) bool {
 	// Empty ProviderConfigs means no models are allowed (deny-by-default)
 	if len(vk.ProviderConfigs) == 0 {
 		return false
 	}
 
+	// Pass 1: if any matching provider config blacklists the model, block immediately.
+	for _, pc := range vk.ProviderConfigs {
+		if pc.Provider == string(provider) && pc.BlacklistedModels.IsBlocked(model) {
+			return false
+		}
+	}
+
+	// Pass 2: allowlist check — model is allowed if any matching config permits it.
 	for _, pc := range vk.ProviderConfigs {
 		if pc.Provider == string(provider) {
-			// Delegate model allowance check to model catalog
-			// This handles all cross-provider logic (OpenRouter, Vertex, Groq, Bedrock)
-			// and provider-prefixed allowed_models entries
 			if r.modelCatalog != nil && r.governanceInMemoryStore != nil {
 				providerConfig, ok := r.governanceInMemoryStore.GetConfiguredProviders()[provider]
 				providerConfigPtr := &providerConfig
 				if !ok {
 					providerConfigPtr = nil
 				}
-				return r.modelCatalog.IsModelAllowedForProvider(provider, model, providerConfigPtr, pc.AllowedModels)
+				if r.modelCatalog.IsModelAllowedForProvider(provider, model, providerConfigPtr, pc.AllowedModels) {
+					return true
+				}
+			} else if pc.AllowedModels.IsAllowed(model) {
+				return true
 			}
-			// Fallback when model catalog is not available: simple string matching
-			// ["*"] = allow all models; [] = deny all models
-			return pc.AllowedModels.IsAllowed(model)
 		}
 	}
 

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -111,7 +111,19 @@ func (p *GovernancePlugin) filterModelsForVirtualKey(
 	for _, model := range models {
 		provider, modelName := schemas.ParseModelString(model.ID, "")
 
-		// Check if this provider/model combination is allowed
+		// Pre-pass: if any matching config blacklists the model, block it entirely.
+		isBlocked := false
+		for _, pc := range vk.ProviderConfigs {
+			if pc.Provider == string(provider) && pc.BlacklistedModels.IsBlocked(modelName) {
+				isBlocked = true
+				break
+			}
+		}
+		if isBlocked {
+			continue
+		}
+
+		// Allowlist check — model is allowed if any matching config permits it.
 		isAllowed := false
 		for _, pc := range vk.ProviderConfigs {
 			if pc.Provider == string(provider) {

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -80,12 +80,13 @@ type CreateVirtualKeyRequest struct {
 	Name            string `json:"name" validate:"required"`
 	Description     string `json:"description,omitempty"`
 	ProviderConfigs []struct {
-		Provider      string                  `json:"provider" validate:"required"`
-		Weight        *float64                `json:"weight,omitempty"`
-		AllowedModels schemas.WhiteList       `json:"allowed_models,omitempty"` // ["*"] allows all models; empty denies all
-		Budgets       []CreateBudgetRequest   `json:"budgets,omitempty"`        // Multi-budget for provider config
-		RateLimit     *CreateRateLimitRequest `json:"rate_limit,omitempty"`     // Provider-level rate limit
-		KeyIDs        schemas.WhiteList       `json:"key_ids,omitempty"`        // List of DBKey UUIDs to associate with this provider config
+		Provider          string                  `json:"provider" validate:"required"`
+		Weight            *float64                `json:"weight,omitempty"`
+		AllowedModels     schemas.WhiteList       `json:"allowed_models,omitempty"`     // ["*"] allows all models; empty denies all
+		BlacklistedModels schemas.BlackList       `json:"blacklisted_models,omitempty"` // ["*"] blocks all models; empty blocks none
+		Budgets           []CreateBudgetRequest   `json:"budgets,omitempty"`            // Multi-budget for provider config
+		RateLimit         *CreateRateLimitRequest `json:"rate_limit,omitempty"`         // Provider-level rate limit
+		KeyIDs            schemas.WhiteList       `json:"key_ids,omitempty"`            // List of DBKey UUIDs to associate with this provider config
 	} `json:"provider_configs,omitempty"` // Empty means no providers allowed (deny-by-default)
 	MCPConfigs []struct {
 		MCPClientName  string            `json:"mcp_client_name" validate:"required"`
@@ -105,13 +106,14 @@ type UpdateVirtualKeyRequest struct {
 	Name            *string `json:"name,omitempty"`
 	Description     *string `json:"description,omitempty"`
 	ProviderConfigs []struct {
-		ID            *uint                   `json:"id,omitempty"` // null for new entries
-		Provider      string                  `json:"provider" validate:"required"`
-		Weight        *float64                `json:"weight,omitempty"`
-		AllowedModels schemas.WhiteList       `json:"allowed_models,omitempty"` // ["*"] allows all models; empty denies all
-		Budgets       []CreateBudgetRequest   `json:"budgets,omitempty"`        // Multi-budget for provider config
-		RateLimit     *UpdateRateLimitRequest `json:"rate_limit,omitempty"`     // Provider-level rate limit
-		KeyIDs        schemas.WhiteList       `json:"key_ids,omitempty"`        // List of DBKey UUIDs to associate with this provider config
+		ID                *uint                   `json:"id,omitempty"` // null for new entries
+		Provider          string                  `json:"provider" validate:"required"`
+		Weight            *float64                `json:"weight,omitempty"`
+		AllowedModels     schemas.WhiteList       `json:"allowed_models,omitempty"`     // ["*"] allows all models; empty denies all
+		BlacklistedModels schemas.BlackList       `json:"blacklisted_models,omitempty"` // ["*"] blocks all models; empty blocks none
+		Budgets           []CreateBudgetRequest   `json:"budgets,omitempty"`            // Multi-budget for provider config
+		RateLimit         *UpdateRateLimitRequest `json:"rate_limit,omitempty"`         // Provider-level rate limit
+		KeyIDs            schemas.WhiteList       `json:"key_ids,omitempty"`            // List of DBKey UUIDs to associate with this provider config
 	} `json:"provider_configs,omitempty"`
 	MCPConfigs []struct {
 		ID             *uint             `json:"id,omitempty"` // null for new entries
@@ -692,6 +694,9 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 				if err := pc.AllowedModels.Validate(); err != nil {
 					return &badRequestError{err: fmt.Errorf("invalid allowed_models for provider %s: %w", pc.Provider, err)}
 				}
+				if err := pc.BlacklistedModels.Validate(); err != nil {
+					return &badRequestError{err: fmt.Errorf("invalid blacklisted_models for provider %s: %w", pc.Provider, err)}
+				}
 				if err := pc.KeyIDs.Validate(); err != nil {
 					return &badRequestError{err: fmt.Errorf("invalid key_ids for provider %s: %w", pc.Provider, err)}
 				}
@@ -713,12 +718,13 @@ func (h *GovernanceHandler) createVirtualKey(ctx *fasthttp.RequestCtx) {
 				}
 
 				providerConfig := &configstoreTables.TableVirtualKeyProviderConfig{
-					VirtualKeyID:  vk.ID,
-					Provider:      string(providerName),
-					Weight:        pc.Weight,
-					AllowedModels: pc.AllowedModels,
-					AllowAllKeys:  allowAllKeys,
-					Keys:          keys,
+					VirtualKeyID:      vk.ID,
+					Provider:          string(providerName),
+					Weight:            pc.Weight,
+					AllowedModels:     pc.AllowedModels,
+					BlacklistedModels: pc.BlacklistedModels,
+					AllowAllKeys:      allowAllKeys,
+					Keys:              keys,
 				}
 
 				// Create rate limit for provider config if provided
@@ -1125,6 +1131,9 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 					if err := pc.AllowedModels.Validate(); err != nil {
 						return &badRequestError{err: fmt.Errorf("invalid allowed_models for provider %s: %w", pc.Provider, err)}
 					}
+					if err := pc.BlacklistedModels.Validate(); err != nil {
+						return &badRequestError{err: fmt.Errorf("invalid blacklisted_models for provider %s: %w", pc.Provider, err)}
+					}
 					if err := pc.KeyIDs.Validate(); err != nil {
 						return &badRequestError{err: fmt.Errorf("invalid key_ids for provider %s: %w", pc.Provider, err)}
 					}
@@ -1147,12 +1156,13 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 
 					// Create new provider config
 					providerConfig := &configstoreTables.TableVirtualKeyProviderConfig{
-						VirtualKeyID:  vk.ID,
-						Provider:      string(providerName),
-						Weight:        pc.Weight,
-						AllowedModels: pc.AllowedModels,
-						AllowAllKeys:  allowAllKeys,
-						Keys:          keys,
+						VirtualKeyID:      vk.ID,
+						Provider:          string(providerName),
+						Weight:            pc.Weight,
+						AllowedModels:     pc.AllowedModels,
+						BlacklistedModels: pc.BlacklistedModels,
+						AllowAllKeys:      allowAllKeys,
+						Keys:              keys,
 					}
 					// Create rate limit for provider config if provided
 					if pc.RateLimit != nil {
@@ -1214,12 +1224,16 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 					if err := pc.AllowedModels.Validate(); err != nil {
 						return &badRequestError{err: fmt.Errorf("invalid allowed_models for provider %s: %w", pc.Provider, err)}
 					}
+					if err := pc.BlacklistedModels.Validate(); err != nil {
+						return &badRequestError{err: fmt.Errorf("invalid blacklisted_models for provider %s: %w", pc.Provider, err)}
+					}
 					if err := pc.KeyIDs.Validate(); err != nil {
 						return &badRequestError{err: fmt.Errorf("invalid key_ids for provider %s: %w", pc.Provider, err)}
 					}
 					existing.Provider = string(providerName)
 					existing.Weight = pc.Weight
 					existing.AllowedModels = pc.AllowedModels
+					existing.BlacklistedModels = pc.BlacklistedModels
 
 					// Get keys for this provider config if specified
 					var keys []configstoreTables.TableKey

--- a/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeyDetailsSheet.tsx
@@ -191,6 +191,29 @@ export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKe
 												</div>
 
 												<div className="grid grid-cols-3 items-start gap-4">
+													<span className="text-muted-foreground pt-0.5 text-sm font-medium">Blocked Models</span>
+													<div className="col-span-2">
+														{config.blacklisted_models?.includes("*") ? (
+															<Badge variant="destructive" className="text-xs">
+																All Models Blocked
+															</Badge>
+														) : config.blacklisted_models && config.blacklisted_models.length > 0 ? (
+															<div className="flex flex-wrap gap-1">
+																{config.blacklisted_models.map((model) => (
+																	<Badge key={model} variant="destructive" className="text-xs">
+																		{model}
+																	</Badge>
+																))}
+															</div>
+														) : (
+															<Badge variant="secondary" className="text-xs">
+																No models blocked
+															</Badge>
+														)}
+													</div>
+												</div>
+
+												<div className="grid grid-cols-3 items-start gap-4">
 													<span className="text-muted-foreground pt-0.5 text-sm font-medium">Allowed Keys</span>
 													<div className="col-span-2">
 														{config.allow_all_keys ? (
@@ -255,11 +278,11 @@ export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKe
 																	/>
 																	<div className="text-muted-foreground flex items-center justify-between text-xs">
 																		<span>
-																				Resets {parseResetPeriod(config.rate_limit.token_reset_duration || "")}
-																				{virtualKey.calendar_aligned &&
-																					supportsCalendarAlignment(config.rate_limit.token_reset_duration || "") &&
-																					" (calendar)"}
-																			</span>
+																			Resets {parseResetPeriod(config.rate_limit.token_reset_duration || "")}
+																			{virtualKey.calendar_aligned &&
+																				supportsCalendarAlignment(config.rate_limit.token_reset_duration || "") &&
+																				" (calendar)"}
+																		</span>
 																		{config.rate_limit.token_last_reset ? (
 																			<span>
 																				Last reset {formatDistanceToNow(new Date(config.rate_limit.token_last_reset), { addSuffix: true })}
@@ -280,11 +303,11 @@ export default function VirtualKeyDetailSheet({ virtualKey, onClose }: VirtualKe
 																	/>
 																	<div className="text-muted-foreground flex items-center justify-between text-xs">
 																		<span>
-																				Resets {parseResetPeriod(config.rate_limit.request_reset_duration || "")}
-																				{virtualKey.calendar_aligned &&
-																					supportsCalendarAlignment(config.rate_limit.request_reset_duration || "") &&
-																					" (calendar)"}
-																			</span>
+																			Resets {parseResetPeriod(config.rate_limit.request_reset_duration || "")}
+																			{virtualKey.calendar_aligned &&
+																				supportsCalendarAlignment(config.rate_limit.request_reset_duration || "") &&
+																				" (calendar)"}
+																		</span>
 																		{config.rate_limit.request_last_reset ? (
 																			<span>
 																				Last reset{" "}

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -77,6 +77,7 @@ const providerConfigSchema = z.object({
 	provider: z.string().min(1, "Provider is required"),
 	weight: z.number().min(0, "Weight must be at least 0").max(1, "Weight must be at most 1").optional(),
 	allowed_models: z.array(z.string()).optional(),
+	blacklisted_models: z.array(z.string()).optional(),
 	key_ids: z.array(z.string()).optional(), // Keys associated with this provider config
 	// Provider-level budget
 	budgets: z
@@ -234,6 +235,7 @@ export default function VirtualKeySheet({
 					provider: config.provider,
 					weight: config.weight ?? undefined,
 					allowed_models: config.allowed_models,
+					blacklisted_models: config.blacklisted_models,
 					key_ids: config.allow_all_keys ? ["*"] : config.keys?.map((key) => key.key_id) || [],
 					budgets: config.budgets?.map((b) => ({
 						id: b.id,
@@ -371,6 +373,7 @@ export default function VirtualKeySheet({
 			provider: provider,
 			weight: undefined as number | undefined, // undefined = excluded from weighted routing until user sets a weight
 			allowed_models: ["*"],
+			blacklisted_models: [],
 			key_ids: ["*"],
 		};
 
@@ -1094,8 +1097,73 @@ export default function VirtualKeySheet({
 																			);
 																		})()}
 																		<p className="text-muted-foreground text-xs">
-																			Select specific models or choose “Allow All Models” to allow all. Leave empty to deny all.
+																			Select specific models or choose "Allow All Models" to allow all. Leave empty to deny all.
 																		</p>
+																	</div>
+																</div>
+
+																<div className="flex w-full items-start gap-2">
+																	<div className="w-1/4" />
+																	<div className="w-3/4 space-y-2">
+																		<div className="flex items-center gap-2">
+																			<Label className="text-sm font-medium">Blocked Models</Label>
+																			<TooltipProvider>
+																				<Tooltip>
+																					<TooltipTrigger asChild>
+																						<span>
+																							<Info className="text-muted-foreground h-3 w-3" />
+																						</span>
+																					</TooltipTrigger>
+																					<TooltipContent className="max-w-sm">
+																						<p>
+																							Models this VK must never serve. The denylist always wins - if a model appears in both Allowed
+																							Models and here, it is blocked. Select "All Models" to block every model on this VK.
+																						</p>
+																					</TooltipContent>
+																				</Tooltip>
+																			</TooltipProvider>
+																		</div>
+																		{(() => {
+																			const hasWildcardBlocked = (config.blacklisted_models || []).includes("*");
+																			return (
+																				<ModelMultiselect
+																					data-testid={`vk-models-blocked-multiselect-${index}`}
+																					provider={config.provider}
+																					keys={(() => {
+																						const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
+																						const configKeyIds = config.key_ids || [];
+																						return configKeyIds.includes("*")
+																							? providerKeys.map((key) => key.key_id)
+																							: providerKeys.filter((key) => configKeyIds.includes(key.key_id)).map((key) => key.key_id);
+																					})()}
+																					allowAllOption={true}
+																					value={hasWildcardBlocked ? ["*"] : config.blacklisted_models || []}
+																					onChange={(models: string[]) => {
+																						const hadStar = (config.blacklisted_models || []).includes("*");
+																						const hasStar = models.includes("*");
+																						if (!hadStar && hasStar) {
+																							handleUpdateProviderConfig(index, "blacklisted_models", ["*"]);
+																						} else if (hadStar && hasStar && models.length > 1) {
+																							handleUpdateProviderConfig(
+																								index,
+																								"blacklisted_models",
+																								models.filter((m) => m !== "*"),
+																							);
+																						} else {
+																							handleUpdateProviderConfig(index, "blacklisted_models", models);
+																						}
+																					}}
+																					placeholder={
+																						hasWildcardBlocked
+																							? "All models blocked"
+																							: (config.blacklisted_models || []).length === 0
+																								? "No models blocked"
+																								: "Search models..."
+																					}
+																					className="min-h-10 max-w-[500px] min-w-[200px]"
+																				/>
+																			);
+																		})()}
 																	</div>
 																</div>
 

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -91,6 +91,7 @@ export interface VirtualKeyProviderConfig {
 	provider: string;
 	weight: number | null;
 	allowed_models: string[];
+	blacklisted_models: string[];
 	allow_all_keys: boolean; // True means all keys allowed; false with empty keys means no keys allowed
 	budgets?: Budget[];
 	rate_limit?: RateLimit;
@@ -135,6 +136,7 @@ export interface VirtualKeyProviderConfigRequest {
 	provider: string;
 	weight?: number | null;
 	allowed_models?: string[];
+	blacklisted_models?: string[];
 	budgets?: CreateBudgetRequest[];
 	rate_limit?: CreateRateLimitRequest;
 	key_ids?: string[]; // List of DBKey UUIDs to associate with this provider config
@@ -145,6 +147,7 @@ export interface VirtualKeyProviderConfigUpdateRequest {
 	provider: string;
 	weight?: number | null;
 	allowed_models?: string[];
+	blacklisted_models?: string[];
 	budgets?: CreateBudgetRequest[];
 	rate_limit?: UpdateRateLimitRequest;
 	key_ids?: string[]; // List of DBKey UUIDs to associate with this provider config


### PR DESCRIPTION
## Summary

Adds blocked model support for virtual key provider configurations.

Provider keys already supported both allowed and blocked models, but virtual key provider configs only supported allowed models. This PR adds the missing blocked model flow for virtual keys, so specific models can be denied at the VK provider-config level.

## Changes

* Added `blacklisted_models` to virtual key provider configs.
* Added a configstore migration for the new `blacklisted_models` column.
* Updated virtual key create/update handlers to validate, persist, and return blocked models.
* Added governance checks to reject virtual key requests when the requested model is blocked.
* Made blocked models take priority over allowed models.
* Updated virtual key model filtering to respect blocked models.
* Added `Blocked Models` UI under provider configurations in the virtual key create/edit sheet.
* Added blocked model display in the virtual key details sheet.
* Updated frontend governance types for virtual key provider configs.

This follows the existing provider-key blocked model behavior instead of introducing a separate flow.

Behavior:

* Empty `blacklisted_models` means no models are blocked.
* `["*"]` blocks all models for that VK provider config.
* If the same model exists in both allowed and blocked models, the blocked list wins.

## Type of change

* [ ] Bug fix
* [x] Feature
* [ ] Refactor
* [ ] Documentation
* [ ] Chore/CI

## Affected areas

* [x] Core (Go)
* [x] Transports (HTTP)
* [ ] Providers/Integrations
* [x] Plugins
* [x] UI (React)
* [ ] Docs

## How to test

Local UI flow:

Start Bifrost locally with embedded UI on port `9090`, then open:

`http://localhost:9090/workspace/governance/virtual-keys`

Steps tested:

1. Open Virtual Keys.
2. Create or edit a virtual key.
3. Expand a provider config.
4. Confirm `Blocked Models` appears below `Allowed Models`.
5. Select a blocked model and save.
6. Reopen the virtual key and confirm the blocked model is still shown.
7. Refresh the page and confirm the value persists.

Runtime validation:

1. Configure a VK provider config with `allowed_models: ["*"]` and `blacklisted_models: ["<model-to-block>"]`.
2. Send a request through that virtual key using the blocked model.

Expected: request is rejected.

3. Send a request through the same virtual key using a model not present in `blacklisted_models`.

Expected: request succeeds.

4. Configure the same model in both `allowed_models` and `blacklisted_models`.

Expected: request is rejected because blocked models take priority.

5. Configure `blacklisted_models: []`.

Expected: existing virtual key behavior remains unchanged.

Sanity checks:

`go test ./framework/configstore/... ./plugins/governance/... ./transports/bifrost-http/handlers/...`

UI check:

`cd ui && pnpm build`

## Screenshots/Recordings

Added a recording showing the new `Blocked Models` field in the virtual key provider configuration flow.



https://github.com/user-attachments/assets/64efca01-0366-491c-b9e7-95dfa08eb0bc




## Breaking changes

* [ ] Yes
* [x] No

## Related issues

BF-896

## Security considerations

This change improves virtual-key governance by allowing specific models to be denied for a VK provider config.

No provider secrets, customer keys, auth tokens, or PII are exposed or stored by this change. Existing provider-key behavior is unchanged.

## Checklist

* [x] I read `docs/contributing/README.md` and followed the guidelines
* [ ] I added/updated tests where appropriate
* [ ] I updated documentation where needed
* [x] I verified builds succeed (Go and UI)
* [x] I verified the CI pipeline passes locally if applicable.
