### PR TITLE
refactor: introduce `MCPCredentialStore` abstraction in MCP credential resolution

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -19,6 +19,7 @@ import (
 	"github.com/maximhq/bifrost/core/keyselectors"
 	"github.com/maximhq/bifrost/core/mcp"
 	"github.com/maximhq/bifrost/core/mcp/codemode/starlark"
+	"github.com/maximhq/bifrost/core/mcp/credstore"
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/azure"
 	"github.com/maximhq/bifrost/core/providers/bedrock"
@@ -78,10 +79,10 @@ type Bifrost struct {
 	responseStreamPool  sync.Pool                           // Pool for response stream channels, initial pool size is set in Init
 	pluginPipelinePool  sync.Pool                           // Pool for PluginPipeline objects
 	bifrostRequestPool  sync.Pool                           // Pool for BifrostRequest objects
-	oauth2Provider      schemas.OAuth2Provider              // OAuth provider instance
 	logger              schemas.Logger                      // logger instance, default logger is used if not provided
 	tracer              atomic.Value                        // tracer for distributed tracing (stores schemas.Tracer, NoOpTracer if not configured)
 	MCPManager          mcp.MCPManagerInterface             // MCP integration manager (nil if MCP not configured)
+	mcpCredStore        schemas.MCPCredentialStore          // Per-call credential resolver for MCP tool execution (wraps oauth2Provider for OAuth-flavored auth types)
 	mcpInitOnce         sync.Once                           // Ensures MCP manager is initialized only once
 	dropExcessRequests  atomic.Bool                         // If true, in cases where the queue is full, requests will not wait for the queue to be empty and will be dropped instead.
 	keySelector         schemas.KeySelector                 // Custom key selector function
@@ -224,17 +225,17 @@ func Init(ctx context.Context, config schemas.BifrostConfig) (*Bifrost, error) {
 
 	bifrostCtx, cancel := schemas.NewBifrostContextWithCancel(ctx)
 	bifrost := &Bifrost{
-		ctx:            bifrostCtx,
-		cancel:         cancel,
-		account:        config.Account,
-		llmPlugins:     atomic.Pointer[[]schemas.LLMPlugin]{},
-		mcpPlugins:     atomic.Pointer[[]schemas.MCPPlugin]{},
-		requestQueues:  sync.Map{},
-		waitGroups:     sync.Map{},
-		keySelector:    config.KeySelector,
-		oauth2Provider: config.OAuth2Provider,
-		logger:         config.Logger,
-		kvStore:        config.KVStore,
+		ctx:           bifrostCtx,
+		cancel:        cancel,
+		account:       config.Account,
+		llmPlugins:    atomic.Pointer[[]schemas.LLMPlugin]{},
+		mcpPlugins:    atomic.Pointer[[]schemas.MCPPlugin]{},
+		requestQueues: sync.Map{},
+		waitGroups:    sync.Map{},
+		keySelector:   config.KeySelector,
+		mcpCredStore:  credstore.NewCredStore(config.OAuth2Provider, config.Logger),
+		logger:        config.Logger,
+		kvStore:       config.KVStore,
 	}
 	bifrost.tracer.Store(&tracerWrapper{tracer: tracer})
 	if config.LLMPlugins == nil {
@@ -331,7 +332,7 @@ func Init(ctx context.Context, config schemas.BifrostConfig) (*Bifrost, error) {
 				}
 			}
 			codeMode := starlark.NewStarlarkCodeMode(codeModeConfig, bifrost.logger)
-			bifrost.MCPManager = mcp.NewMCPManager(bifrostCtx, mcpConfig, bifrost.oauth2Provider, bifrost.logger, codeMode)
+			bifrost.MCPManager = mcp.NewMCPManager(bifrostCtx, mcpConfig, bifrost.mcpCredStore, bifrost.logger, codeMode)
 			bifrost.logger.Info("MCP integration initialized successfully")
 		})
 	}
@@ -3664,7 +3665,7 @@ func (bifrost *Bifrost) AddMCPClient(config *schemas.MCPClientConfig) error {
 			}
 			// Create Starlark CodeMode for code execution (with default config)
 			codeMode := starlark.NewStarlarkCodeMode(nil, bifrost.logger)
-			bifrost.MCPManager = mcp.NewMCPManager(bifrost.ctx, mcpConfig, bifrost.oauth2Provider, bifrost.logger, codeMode)
+			bifrost.MCPManager = mcp.NewMCPManager(bifrost.ctx, mcpConfig, bifrost.mcpCredStore, bifrost.logger, codeMode)
 		})
 	}
 
@@ -3814,7 +3815,7 @@ func (bifrost *Bifrost) VerifyPerUserOAuthConnection(ctx context.Context, config
 				}
 			}
 			codeMode := starlark.NewStarlarkCodeMode(nil, bifrost.logger)
-			bifrost.MCPManager = mcp.NewMCPManager(bifrost.ctx, mcpConfig, bifrost.oauth2Provider, bifrost.logger, codeMode)
+			bifrost.MCPManager = mcp.NewMCPManager(bifrost.ctx, mcpConfig, bifrost.mcpCredStore, bifrost.logger, codeMode)
 		})
 	}
 	if bifrost.MCPManager == nil {

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/maximhq/bifrost/core/mcp/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -60,11 +61,12 @@ func (m *MCPManager) ReconnectClient(id string) error {
 		m.mu.Unlock()
 		return fmt.Errorf("client %s not found", id)
 	}
-	// Per-user OAuth clients do not maintain a persistent upstream connection.
-	// Reconnect is not applicable because auth is resolved per request/user identity.
-	if client.ExecutionConfig != nil && client.ExecutionConfig.AuthType == schemas.MCPAuthTypePerUserOauth {
+	// Per-user auth types do not maintain a persistent upstream connection —
+	// auth is resolved per request/user identity, so there's nothing to
+	// reconnect.
+	if client.ExecutionConfig != nil && m.credStore.RequiresPerCallConnection(client.ExecutionConfig) {
 		m.mu.Unlock()
-		return fmt.Errorf("per-user OAuth clients do not maintain a shared upstream connection (each user manages their own auth): %w", schemas.ErrMCPReconnectNotApplicable)
+		return fmt.Errorf("per-user auth clients do not maintain a shared upstream connection (each user manages their own auth): %w", schemas.ErrMCPReconnectNotApplicable)
 	}
 	config := client.ExecutionConfig
 	m.mu.Unlock()
@@ -118,8 +120,8 @@ func (m *MCPManager) AddClient(config *schemas.MCPClientConfig) error {
 			ToolNameMapping: make(map[string]string),
 			ConnectionInfo:  &schemas.MCPClientConnectionInfo{Type: config.ConnectionType},
 		}
-		// Persisted tools for per_user_oauth survive restarts in ExecutionConfig.
-		if config.AuthType == schemas.MCPAuthTypePerUserOauth && len(config.DiscoveredTools) > 0 {
+		// Persisted tools for per-user auth types survive restarts in ExecutionConfig.
+		if m.credStore.RequiresPerCallConnection(config) && len(config.DiscoveredTools) > 0 {
 			for toolName, tool := range config.DiscoveredTools {
 				clientState.ToolMap[toolName] = tool
 			}
@@ -150,10 +152,10 @@ func (m *MCPManager) AddClient(config *schemas.MCPClientConfig) error {
 	// This is to avoid deadlocks when the connection attempt is made
 	m.mu.Unlock()
 
-	// Per-user OAuth: skip persistent connection. Auth is per-request at runtime.
-	// The admin verifies the configuration via a sample login before this is called,
-	// and tools are populated separately via SetClientTools().
-	if configCopy.AuthType == schemas.MCPAuthTypePerUserOauth {
+	// Per-user auth types: skip persistent connection. Auth is per-request at
+	// runtime. The admin verifies the configuration via a sample login before
+	// this is called, and tools are populated separately via SetClientTools().
+	if m.credStore.RequiresPerCallConnection(configCopy) {
 		m.mu.Lock()
 		if client, exists := m.clientMap[config.ID]; exists {
 			if config.ConnectionString != nil {
@@ -451,10 +453,11 @@ func (m *MCPManager) DisableClient(id string) error {
 		clientState.Conn = nil
 	}
 
-	// Per-user OAuth clients have no persistent connection — their ToolMap holds
-	// tools discovered via OAuth that can only be recovered by re-running the OAuth
-	// flow. Preserve the ToolMap so re-enabling restores tools immediately.
-	if clientState.ExecutionConfig.AuthType != schemas.MCPAuthTypePerUserOauth {
+	// Per-user auth clients have no persistent connection — their ToolMap
+	// holds tools discovered via the admin verification step that can only
+	// be recovered by re-running it. Preserve the ToolMap so re-enabling
+	// restores tools immediately.
+	if !m.credStore.RequiresPerCallConnection(clientState.ExecutionConfig) {
 		clientState.ToolMap = make(map[string]schemas.ChatTool)
 		clientState.ToolNameMapping = make(map[string]string)
 	}
@@ -490,10 +493,10 @@ func (m *MCPManager) EnableClient(id string) error {
 
 	m.logger.Debug("%s Enabling MCP client '%s'", MCPLogPrefix, configCopy.Name)
 
-	// Per-user OAuth clients have no persistent connection — auth is per-request.
-	// Mirror the AddClient early-return path: just restore the runtime state based
-	// on whether tools were previously discovered.
-	if configCopy.AuthType == schemas.MCPAuthTypePerUserOauth {
+	// Per-user auth clients have no persistent connection — auth is per-request.
+	// Mirror the AddClient early-return path: just restore the runtime state
+	// based on whether tools were previously discovered.
+	if m.credStore.RequiresPerCallConnection(configCopy) {
 		m.mu.Lock()
 		if cs, exists := m.clientMap[id]; exists {
 			if len(cs.ToolMap) > 0 {
@@ -503,7 +506,7 @@ func (m *MCPManager) EnableClient(id string) error {
 			}
 		}
 		m.mu.Unlock()
-		m.logger.Debug("%s Per-user OAuth MCP client '%s' enabled (no persistent connection)", MCPLogPrefix, configCopy.Name)
+		m.logger.Debug("%s Per-user auth MCP client '%s' enabled (no persistent connection)", MCPLogPrefix, configCopy.Name)
 		return nil
 	}
 
@@ -694,10 +697,10 @@ func (m *MCPManager) UpdateClientConnection(id string, newConfig *schemas.MCPCli
 		m.mu.RUnlock()
 		return fmt.Errorf("client %s not found", id)
 	}
-	// Per-user OAuth clients have no persistent connection — reconnect is not applicable.
-	if client.ExecutionConfig != nil && client.ExecutionConfig.AuthType == schemas.MCPAuthTypePerUserOauth {
+	// Per-user auth clients have no persistent connection — reconnect/update is not applicable.
+	if client.ExecutionConfig != nil && m.credStore.RequiresPerCallConnection(client.ExecutionConfig) {
 		m.mu.RUnlock()
-		return fmt.Errorf("connection update is not supported for per_user_oauth clients")
+		return fmt.Errorf("connection update is not supported for per-user auth clients")
 	}
 	if client.ExecutionConfig == nil {
 		m.mu.RUnlock()
@@ -936,12 +939,19 @@ func (m *MCPManager) connectToMCPClient(config *schemas.MCPClientConfig) error {
 	}
 	var authHeader string // captured for re-injection after PreHooks
 	if config.ConnectionType == schemas.MCPConnectionTypeHTTP || config.ConnectionType == schemas.MCPConnectionTypeSSE {
-		if h, hErr := config.HttpHeaders(m.ctx, m.oauth2Provider); hErr == nil {
-			if auth, ok := h["Authorization"]; ok {
+		// Connection-time has no caller identity; wrap m.ctx into a synthetic
+		// BifrostContext so the CredentialStore can be invoked uniformly.
+		// Shared resolvers ignore identity; per-user resolvers won't be
+		// called here because the per-user code path skips persistent
+		// connections entirely (RequiresPerCallConnection).
+		bfCtx := schemas.NewBifrostContext(m.ctx, schemas.NoDeadline)
+		if h, hErr := m.credStore.ConnectionHeaders(bfCtx, config); hErr == nil {
+			flat := utils.FlattenHeaders(h)
+			if auth, ok := flat["Authorization"]; ok {
 				authHeader = auth
-				delete(h, "Authorization")
+				delete(flat, "Authorization")
 			}
-			connectReq.Headers = h
+			connectReq.Headers = flat
 		}
 	}
 	if config.StdioConfig != nil {
@@ -1243,11 +1253,12 @@ func (m *MCPManager) createHTTPConnection(ctx context.Context, config *schemas.M
 	if overrides != nil && overrides.Headers != nil {
 		headers = overrides.Headers
 	} else {
-		h, err := config.HttpHeaders(ctx, m.oauth2Provider)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		h, err := m.credStore.ConnectionHeaders(bfCtx, config)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get HTTP headers: %w", err)
 		}
-		headers = h
+		headers = utils.FlattenHeaders(h)
 	}
 
 	// Create StreamableHTTP transport
@@ -1319,11 +1330,12 @@ func (m *MCPManager) createSSEConnection(ctx context.Context, config *schemas.MC
 	if overrides != nil && overrides.Headers != nil {
 		headers = overrides.Headers
 	} else {
-		h, err := config.HttpHeaders(ctx, m.oauth2Provider)
+		bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+		h, err := m.credStore.ConnectionHeaders(bfCtx, config)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to get HTTP headers: %w", err)
 		}
-		headers = h
+		headers = utils.FlattenHeaders(h)
 	}
 
 	sseTransport, err := transport.NewSSE(url, transport.WithHeaders(headers))

--- a/core/mcp/codemode.go
+++ b/core/mcp/codemode.go
@@ -67,8 +67,9 @@ type CodeModeDependencies struct {
 	// LogMutex protects concurrent access to logs during code execution
 	LogMutex *sync.Mutex
 
-	// OAuth2Provider handles per-user OAuth token lookup and flow initiation
-	OAuth2Provider schemas.OAuth2Provider
+	// CredentialStore resolves per-call credentials (Bearer tokens, headers)
+	// and signals whether a client requires an ephemeral upstream connection.
+	CredentialStore schemas.MCPCredentialStore
 }
 
 // DefaultCodeModeConfig returns the default configuration for CodeMode.

--- a/core/mcp/codemode/starlark/executecode.go
+++ b/core/mcp/codemode/starlark/executecode.go
@@ -12,7 +12,6 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 
 	codemcp "github.com/maximhq/bifrost/core/mcp"
-	"github.com/maximhq/bifrost/core/mcp/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
@@ -522,17 +521,6 @@ func (s *StarlarkCodeMode) callMCPTool(ctx *schemas.BifrostContext, clientName, 
 	startTime := time.Now()
 	toolNameToCall := originalToolName
 
-	callRequest := mcp.CallToolRequest{
-		Request: mcp.Request{
-			Method: string(mcp.MethodToolsCall),
-		},
-		Params: mcp.CallToolParams{
-			Name:      toolNameToCall,
-			Arguments: args,
-		},
-		Header: utils.GetHeadersForToolExecution(nestedCtx, client),
-	}
-
 	toolExecutionTimeout := s.getToolExecutionTimeout()
 	toolCtx, cancel := context.WithTimeout(nestedCtx, toolExecutionTimeout)
 	defer cancel()
@@ -540,24 +528,34 @@ func (s *StarlarkCodeMode) callMCPTool(ctx *schemas.BifrostContext, clientName, 
 	var toolResponse *mcp.CallToolResult
 	var callErr error
 
-	if client.ExecutionConfig.AuthType == schemas.MCPAuthTypePerUserOauth {
-		accessToken, err := utils.ResolvePerUserOAuthToken(nestedCtx, client, s.oauth2Provider)
+	if s.credStore.RequiresPerCallConnection(client.ExecutionConfig) {
+		// Per-user auth types: ephemeral upstream connection per call carries
+		// the full credential set (static + extras + per-user auth).
+		connHeaders, err := s.credStore.ConnectionHeaders(nestedCtx, client.ExecutionConfig)
 		if err != nil {
 			return nil, err
 		}
-
-		if client.Conn == nil {
-			// Per-user OAuth with no persistent connection — use a temporary connection.
-			// Assign to outer toolResponse/callErr so the shared logging + post-hooks path runs.
-			toolResponse, callErr = codemcp.ExecuteToolWithUserToken(toolCtx, client.ExecutionConfig, toolNameToCall, args, accessToken, s.logger)
-			if callErr != nil && toolCtx.Err() == context.DeadlineExceeded {
-				callErr = fmt.Errorf("MCP tool call timed out after %v: %s", toolExecutionTimeout, toolName)
-			}
-		} else {
-			callRequest.Header = utils.BuildPerUserOAuthHeaders(callRequest.Header, accessToken)
-			toolResponse, callErr = client.Conn.CallTool(toolCtx, callRequest)
+		toolResponse, callErr = codemcp.OpenConnectionAndExecuteTool(toolCtx, client.ExecutionConfig, toolNameToCall, args, connHeaders)
+		if callErr != nil && toolCtx.Err() == context.DeadlineExceeded {
+			callErr = fmt.Errorf("MCP tool call timed out after %v: %s", toolExecutionTimeout, toolName)
 		}
 	} else {
+		// Shared persistent connection — admin credentials are on the
+		// transport; the per-call request only carries filtered extras.
+		reqHeaders, err := s.credStore.RequestHeaders(nestedCtx, client.ExecutionConfig)
+		if err != nil {
+			return nil, err
+		}
+		callRequest := mcp.CallToolRequest{
+			Request: mcp.Request{
+				Method: string(mcp.MethodToolsCall),
+			},
+			Params: mcp.CallToolParams{
+				Name:      toolNameToCall,
+				Arguments: args,
+			},
+			Header: reqHeaders,
+		}
 		toolResponse, callErr = client.Conn.CallTool(toolCtx, callRequest)
 	}
 

--- a/core/mcp/codemode/starlark/starlark.go
+++ b/core/mcp/codemode/starlark/starlark.go
@@ -25,7 +25,7 @@ type StarlarkCodeMode struct {
 	// Dependencies
 	clientManager         mcp.ClientManager
 	fetchNewRequestIDFunc func(ctx *schemas.BifrostContext) string
-	oauth2Provider        schemas.OAuth2Provider
+	credStore             schemas.MCPCredentialStore
 
 	// Logger for this instance
 	logger schemas.Logger
@@ -83,7 +83,7 @@ func (s *StarlarkCodeMode) SetDependencies(deps *mcp.CodeModeDependencies) {
 	if deps != nil {
 		s.clientManager = deps.ClientManager
 		s.fetchNewRequestIDFunc = deps.FetchNewRequestIDFunc
-		s.oauth2Provider = deps.OAuth2Provider
+		s.credStore = deps.CredentialStore
 	}
 }
 

--- a/core/mcp/credstore/credstore.go
+++ b/core/mcp/credstore/credstore.go
@@ -1,0 +1,95 @@
+// Package credstore implements schemas.CredentialStore: it routes credential
+// resolution for MCP tool execution by auth type. Each MCPAuthType has a
+// dedicated resolver; the Store dispatches based on MCPClientConfig.AuthType.
+//
+// The store knows nothing about storage lifecycle (orphaning, cascade) — that
+// stays in the configstore layer where transactional atomicity holds.
+package credstore
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/maximhq/bifrost/core/mcp/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// resolver is the internal interface each auth-type-specific resolver
+// implements. RequestHeaders is identical across all auth types (extras only)
+// and lives on CredStore directly, not here.
+type resolver interface {
+	ConnectionHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error)
+	RequiresPerCallConnection() bool
+}
+
+// CredStore routes credential resolution by MCPAuthType. Implements
+// schemas.MCPCredentialStore.
+type CredStore struct {
+	resolvers map[schemas.MCPAuthType]resolver
+	logger    schemas.Logger
+}
+
+// NewCredStore constructs the canonical MCPCredentialStore with one resolver
+// per known MCPAuthType. The oauth2Provider is injected into the OAuth-
+// flavored resolvers only; the None and StaticHeaders resolvers are stateless.
+func NewCredStore(oauth2Provider schemas.OAuth2Provider, logger schemas.Logger) *CredStore {
+	return &CredStore{
+		resolvers: map[schemas.MCPAuthType]resolver{
+			schemas.MCPAuthTypeNone:         &noneResolver{},
+			schemas.MCPAuthTypeHeaders:      &staticHeadersResolver{},
+			schemas.MCPAuthTypeOauth:        &serverOAuthResolver{provider: oauth2Provider},
+			schemas.MCPAuthTypePerUserOauth: &perUserOAuthResolver{provider: oauth2Provider},
+		},
+		logger: logger,
+	}
+}
+
+// ConnectionHeaders implements schemas.MCPCredentialStore.
+func (s *CredStore) ConnectionHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
+	r, err := s.resolverFor(config)
+	if err != nil {
+		return nil, err
+	}
+	return r.ConnectionHeaders(ctx, config)
+}
+
+// RequestHeaders implements schemas.MCPCredentialStore. Identical across auth
+// types: just the filtered per-call context-extras. The auth-type lookup
+// still runs so an unknown type errors loudly here too, instead of silently
+// returning empty.
+func (s *CredStore) RequestHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
+	if _, err := s.resolverFor(config); err != nil {
+		return nil, err
+	}
+	return utils.ExtractFilteredExtras(ctx, config), nil
+}
+
+// RequiresPerCallConnection implements schemas.MCPCredentialStore. For
+// unknown auth types it returns false (safe shared-mode default); the next
+// ConnectionHeaders / RequestHeaders call from the caller will surface the
+// actual "unsupported auth type" error.
+func (s *CredStore) RequiresPerCallConnection(config *schemas.MCPClientConfig) bool {
+	if config == nil {
+		return false
+	}
+	r, ok := s.resolvers[config.AuthType]
+	if !ok {
+		return false
+	}
+	return r.RequiresPerCallConnection()
+}
+
+// resolverFor returns the resolver matching config.AuthType, or an error if
+// the type is unknown / config is nil. The DB layer defaults AuthType to
+// 'headers' (see TableMCPClient.AuthType default), so this should only fire
+// on programmatically-constructed configs that bypass persistence — a sign
+// of a real configuration bug worth surfacing.
+func (s *CredStore) resolverFor(config *schemas.MCPClientConfig) (resolver, error) {
+	if config == nil {
+		return nil, fmt.Errorf("MCP client config is nil")
+	}
+	if r, ok := s.resolvers[config.AuthType]; ok {
+		return r, nil
+	}
+	return nil, fmt.Errorf("unsupported MCP auth type %q for client %q", config.AuthType, config.Name)
+}

--- a/core/mcp/credstore/none.go
+++ b/core/mcp/credstore/none.go
@@ -1,0 +1,19 @@
+package credstore
+
+import (
+	"net/http"
+
+	"github.com/maximhq/bifrost/core/mcp/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// noneResolver handles MCPAuthTypeNone — no auth credentials, but the
+// transport still gets any static config headers + filtered context-extras
+// the caller passes in via BifrostContext.
+type noneResolver struct{}
+
+func (r *noneResolver) ConnectionHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
+	return utils.GetHeadersForToolExecution(ctx, config), nil
+}
+
+func (r *noneResolver) RequiresPerCallConnection() bool { return false }

--- a/core/mcp/credstore/per_user_oauth.go
+++ b/core/mcp/credstore/per_user_oauth.go
@@ -1,0 +1,99 @@
+package credstore
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/maximhq/bifrost/core/mcp/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// perUserOAuthResolver handles MCPAuthTypePerUserOauth — each caller's
+// upstream token is keyed by (auth_mode, identity, mcp_client). On miss or
+// expiry, an OAuth flow is initiated and a *MCPUserOAuthRequiredError is
+// raised so the caller can complete authentication.
+//
+// RequiresPerCallConnection is true: per-user OAuth clients never hold a
+// persistent upstream connection (clientmanager skips Connect for them); each
+// invocation builds an ephemeral HTTP transport with the resolved Bearer +
+// any static config + context-extras.
+type perUserOAuthResolver struct {
+	provider schemas.OAuth2Provider
+}
+
+func (r *perUserOAuthResolver) ConnectionHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
+	if r.provider == nil {
+		return nil, fmt.Errorf("per-user OAuth requires an OAuth2Provider but none is configured")
+	}
+
+	mode := ctx.MCPAuthMode()
+	identity := identityForMCPAuthMode(ctx, mode)
+	if identity == "" {
+		return nil, fmt.Errorf(
+			"per-user OAuth for %s requires an identity: send a Virtual Key (x-bf-vk), authenticate as a user, or set x-bf-mcp-session-id to any opaque string you'll re-send on subsequent calls",
+			config.Name,
+		)
+	}
+
+	accessToken, err := r.provider.GetUserAccessTokenByMode(ctx, mode, identity, config.ID)
+	// Both sentinels mean "this user must re-authenticate":
+	//   - ErrOAuth2TokenNotFound: row missing (never authed, or purged after permanent refresh failure)
+	//   - ErrOAuth2TokenExpired:  row present but tokens unusable (access expired + no refresh available)
+	// Either way, fall through to the re-auth branch below to surface an inline auth URL.
+	if err != nil && !errors.Is(err, schemas.ErrOAuth2TokenNotFound) && !errors.Is(err, schemas.ErrOAuth2TokenExpired) {
+		return nil, fmt.Errorf("failed to get user access token for MCP server %s: %w", config.Name, err)
+	}
+	if err != nil {
+		if config.OauthConfigID == nil || *config.OauthConfigID == "" {
+			return nil, fmt.Errorf("per-user OAuth requires an OAuth config but MCP client %s has none", config.Name)
+		}
+		redirectURI := utils.BuildRedirectURIFromContext(ctx)
+		if redirectURI == "" {
+			return nil, fmt.Errorf("per-user OAuth requires a redirect URI but none is available in context")
+		}
+		flowInitiation, sessionID, flowErr := r.provider.InitiateUserOAuthFlow(ctx, *config.OauthConfigID, config.ID, redirectURI, mode)
+		if flowErr != nil {
+			return nil, fmt.Errorf("failed to initiate per-user OAuth flow for %s: %w", config.Name, flowErr)
+		}
+		return nil, &schemas.MCPUserOAuthRequiredError{
+			MCPClientID:   config.ID,
+			MCPClientName: config.Name,
+			AuthorizeURL:  flowInitiation.AuthorizeURL,
+			SessionID:     sessionID,
+			// Include the URL in the message itself — plain-text clients
+			// (curl, basic SDK wrappers) won't parse extra_fields, and a
+			// "please visit the authorize URL" hint with no URL is useless
+			// to them. The URL is already exposed via
+			// extra_fields.mcp_auth_required.authorize_url, so embedding it
+			// here doesn't widen the surface.
+			Message: fmt.Sprintf("Authentication required for %s. Visit %s to connect your account.", config.Name, flowInitiation.AuthorizeURL),
+		}
+	}
+
+	headers := utils.GetHeadersForToolExecution(ctx, config)
+	headers.Set("Authorization", "Bearer "+accessToken)
+	return headers, nil
+}
+
+func (r *perUserOAuthResolver) RequiresPerCallConnection() bool { return true }
+
+// identityForMCPAuthMode returns the identity string to look up by, given the
+// derived mode. Mirrors the priority used by ctx.MCPAuthMode().
+func identityForMCPAuthMode(ctx *schemas.BifrostContext, mode schemas.MCPAuthMode) string {
+	switch mode {
+	case schemas.MCPAuthModeUser:
+		if v, _ := ctx.Value(schemas.BifrostContextKeyUserID).(string); v != "" {
+			return v
+		}
+	case schemas.MCPAuthModeVK:
+		if v, _ := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID).(string); v != "" {
+			return v
+		}
+	case schemas.MCPAuthModeSession:
+		if v, _ := ctx.Value(schemas.BifrostContextKeyMCPSessionID).(string); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/core/mcp/credstore/server_oauth.go
+++ b/core/mcp/credstore/server_oauth.go
@@ -1,0 +1,54 @@
+package credstore
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/maximhq/bifrost/core/mcp/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// serverOAuthResolver handles MCPAuthTypeOauth — admin-once OAuth where the
+// upstream token is shared across all callers. The token is fetched from the
+// OAuth2Provider's cache (kept fresh by the background sync worker) and added
+// as a Bearer header on top of static config headers + any context-extras.
+type serverOAuthResolver struct {
+	provider schemas.OAuth2Provider
+}
+
+func (r *serverOAuthResolver) ConnectionHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
+	headers := utils.GetHeadersForToolExecution(ctx, config)
+
+	if config == nil {
+		return headers, nil
+	}
+	// Reject nil OR empty IDs at the resolver boundary so the caller gets
+	// the explicit ErrOAuth2ConfigNotFound rather than a less clear
+	// lookup-miss error from GetAccessToken downstream. The ID itself is a
+	// server-generated UUID (oauth2/main.go), so whitespace-only values
+	// aren't reachable today; only the empty case is worth guarding.
+	if config.OauthConfigID == nil || *config.OauthConfigID == "" {
+		return nil, schemas.ErrOAuth2ConfigNotFound
+	}
+	if r.provider == nil {
+		return nil, schemas.ErrOAuth2ProviderNotAvailable
+	}
+	accessToken, err := r.provider.GetAccessToken(ctx, *config.OauthConfigID)
+	if err != nil {
+		return nil, err
+	}
+	// Validate token format — trim whitespace and reject control characters.
+	// Preserves the legacy MCPClientConfig.HttpHeaders behavior.
+	accessToken = strings.TrimSpace(accessToken)
+	if accessToken == "" {
+		return nil, errors.New("access token is empty")
+	}
+	if strings.ContainsAny(accessToken, "\n\r\t") {
+		return nil, errors.New("access token contains invalid characters")
+	}
+	headers.Set("Authorization", "Bearer "+accessToken)
+	return headers, nil
+}
+
+func (r *serverOAuthResolver) RequiresPerCallConnection() bool { return false }

--- a/core/mcp/credstore/static_headers.go
+++ b/core/mcp/credstore/static_headers.go
@@ -1,0 +1,20 @@
+package credstore
+
+import (
+	"net/http"
+
+	"github.com/maximhq/bifrost/core/mcp/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// staticHeadersResolver handles MCPAuthTypeHeaders — admin-configured static
+// headers, merged with any context-extras present in the BifrostContext. Also
+// serves as the fallback for empty/unrecognized AuthType (matches the
+// existing "empty AuthType means headers" normalization in UpdateClient).
+type staticHeadersResolver struct{}
+
+func (r *staticHeadersResolver) ConnectionHeaders(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) (http.Header, error) {
+	return utils.GetHeadersForToolExecution(ctx, config), nil
+}
+
+func (r *staticHeadersResolver) RequiresPerCallConnection() bool { return false }

--- a/core/mcp/mcp.go
+++ b/core/mcp/mcp.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/maximhq/bifrost/core/mcp/credstore"
 	"github.com/maximhq/bifrost/core/schemas"
 
 	"github.com/mark3labs/mcp-go/server"
@@ -33,7 +34,7 @@ const (
 type MCPManager struct {
 	ctx                  context.Context
 	logger               schemas.Logger                     // Logger instance for this manager
-	oauth2Provider       schemas.OAuth2Provider             // Provider for OAuth2 functionality
+	credStore            schemas.MCPCredentialStore         // Resolves credentials per-call for MCP tool execution
 	toolsManager         *ToolsManager                      // Handler for MCP tools
 	server               *server.MCPServer                  // Local MCP server instance for hosting tools (STDIO-based)
 	clientMap            map[string]*schemas.MCPClientState // Map of MCP client names to their configurations
@@ -63,7 +64,10 @@ type MCPToolFunction[T any] func(args T) (string, error)
 // Parameters:
 //   - ctx: Context for the MCP manager
 //   - config: MCP configuration including server port and client configs
-//   - oauth2Provider: OAuth2 provider for authentication
+//   - credStore: CredentialStore that resolves per-call credentials (Bearer
+//     tokens, static headers, user-submitted headers) and signals whether
+//     each client requires an ephemeral upstream connection. Pass nil only
+//     in tests where credential resolution is irrelevant.
 //   - logger: Logger instance for structured logging (uses default if nil)
 //   - codeMode: Optional CodeMode implementation for code execution (e.g., Starlark).
 //     Pass nil if code mode is not needed. The CodeMode's dependencies will be
@@ -71,9 +75,15 @@ type MCPToolFunction[T any] func(args T) (string, error)
 //
 // Returns:
 //   - *MCPManager: Initialized manager instance
-func NewMCPManager(ctx context.Context, config schemas.MCPConfig, oauth2Provider schemas.OAuth2Provider, logger schemas.Logger, codeMode CodeMode) *MCPManager {
+func NewMCPManager(ctx context.Context, config schemas.MCPConfig, credStore schemas.MCPCredentialStore, logger schemas.Logger, codeMode CodeMode) *MCPManager {
 	if logger == nil {
 		logger = defaultLogger
+	}
+	// Default to an OAuth-less CredentialStore so tests (and callers that
+	// don't wire OAuth) get a working store: static/headers/none resolvers
+	// stay functional, OAuth-flavored resolvers cleanly error on use.
+	if credStore == nil {
+		credStore = credstore.NewCredStore(nil, logger)
 	}
 	// Set default values
 	if config.ToolManagerConfig == nil {
@@ -89,7 +99,7 @@ func NewMCPManager(ctx context.Context, config schemas.MCPConfig, oauth2Provider
 		clientMap:            make(map[string]*schemas.MCPClientState),
 		healthMonitorManager: NewHealthMonitorManager(),
 		toolSyncManager:      NewToolSyncManager(config.ToolSyncInterval),
-		oauth2Provider:       oauth2Provider,
+		credStore:            credStore,
 	}
 	// Convert plugin pipeline provider functions to the interface expected by ToolsManager
 	var pluginPipelineProvider func() PluginPipeline
@@ -111,7 +121,7 @@ func NewMCPManager(ctx context.Context, config schemas.MCPConfig, oauth2Provider
 
 	manager.pluginPipelineProvider = pluginPipelineProvider
 	manager.releasePluginPipeline = releasePluginPipeline
-	manager.toolsManager = NewToolsManager(config.ToolManagerConfig, manager, config.FetchNewRequestIDFunc, oauth2Provider, logger)
+	manager.toolsManager = NewToolsManager(config.ToolManagerConfig, manager, config.FetchNewRequestIDFunc, credStore, logger)
 
 	// Set up CodeMode if provided - inject dependencies after manager is created
 	if codeMode != nil {

--- a/core/mcp/toolmanager.go
+++ b/core/mcp/toolmanager.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/maximhq/bifrost/core/mcp/credstore"
 	"github.com/maximhq/bifrost/core/mcp/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
@@ -49,8 +51,9 @@ type ToolsManager struct {
 	logger                schemas.Logger
 	agentModeExecutor     *AgentModeExecutor
 
-	// OAuth2Provider for per-user OAuth token management
-	oauth2Provider schemas.OAuth2Provider
+	// CredentialStore resolves per-call credentials (headers, Bearer tokens)
+	// and signals whether a client needs an ephemeral upstream connection.
+	credStore schemas.MCPCredentialStore
 
 	// CodeMode implementation for code execution (Starlark by default)
 	codeMode CodeMode
@@ -77,7 +80,7 @@ func NewToolsManager(
 	config *schemas.MCPToolManagerConfig,
 	clientManager ClientManager,
 	fetchNewRequestIDFunc func(ctx *schemas.BifrostContext) string,
-	oauth2Provider schemas.OAuth2Provider,
+	credStore schemas.MCPCredentialStore,
 	logger schemas.Logger,
 ) *ToolsManager {
 	return NewToolsManagerWithCodeMode(
@@ -85,7 +88,7 @@ func NewToolsManager(
 		clientManager,
 		fetchNewRequestIDFunc,
 		nil, // Use default code mode (will be set later via SetCodeMode)
-		oauth2Provider,
+		credStore,
 		logger,
 	)
 }
@@ -106,7 +109,7 @@ func NewToolsManagerWithCodeMode(
 	clientManager ClientManager,
 	fetchNewRequestIDFunc func(ctx *schemas.BifrostContext) string,
 	codeMode CodeMode,
-	oauth2Provider schemas.OAuth2Provider,
+	credStore schemas.MCPCredentialStore,
 	logger schemas.Logger,
 ) *ToolsManager {
 	if config == nil {
@@ -131,6 +134,17 @@ func NewToolsManagerWithCodeMode(
 		logger = defaultLogger
 	}
 
+	// Default nil credStore to a fresh CredStore with no OAuth provider —
+	// mirrors NewMCPManager's safety net (mcp.go:85-86) so direct callers
+	// of NewToolsManager / NewToolsManagerWithCodeMode (Go SDK consumers
+	// that bypass NewMCPManager) don't hit a panic on the first tool call
+	// when executeToolInternal dereferences m.credStore. The default works
+	// transparently for None / StaticHeaders auth and surfaces a clear
+	// "OAuth2 provider not available" error for OAuth-flavored clients.
+	if credStore == nil {
+		credStore = credstore.NewCredStore(nil, logger)
+	}
+
 	agentModeExecutor := &AgentModeExecutor{
 		logger: logger,
 	}
@@ -141,7 +155,7 @@ func NewToolsManagerWithCodeMode(
 		codeMode:              codeMode,
 		logger:                logger,
 		agentModeExecutor:     agentModeExecutor,
-		oauth2Provider:        oauth2Provider,
+		credStore:             credStore,
 	}
 
 	// Initialize atomic values
@@ -170,7 +184,7 @@ func (m *ToolsManager) GetCodeModeDependencies() *CodeModeDependencies {
 	return &CodeModeDependencies{
 		ClientManager:         m.clientManager,
 		FetchNewRequestIDFunc: m.fetchNewRequestIDFunc,
-		OAuth2Provider:        m.oauth2Provider,
+		CredentialStore:       m.credStore,
 	}
 }
 
@@ -647,7 +661,36 @@ func (m *ToolsManager) executeToolInternal(ctx *schemas.BifrostContext, toolCall
 	sanitizedToolName := stripClientPrefix(toolName, client.ExecutionConfig.Name)
 	originalMCPToolName := getOriginalToolName(sanitizedToolName, client)
 
-	// Call the tool via MCP client -> MCP server
+	// Create timeout context for tool execution
+	toolExecutionTimeout := m.toolExecutionTimeout.Load().(time.Duration)
+	toolCtx, cancel := context.WithTimeout(ctx, toolExecutionTimeout)
+	defer cancel()
+
+	// Per-user auth types open an ephemeral transport per call with the
+	// caller's full set of credentials (static + extras + per-user auth).
+	if m.credStore.RequiresPerCallConnection(client.ExecutionConfig) {
+		connHeaders, err := m.credStore.ConnectionHeaders(ctx, client.ExecutionConfig)
+		if err != nil {
+			return nil, "", "", err
+		}
+		toolResponse, callErr := OpenConnectionAndExecuteTool(toolCtx, client.ExecutionConfig, originalMCPToolName, arguments, connHeaders)
+		if callErr != nil {
+			if toolCtx.Err() == context.DeadlineExceeded {
+				return nil, "", "", fmt.Errorf("MCP tool call timed out after %v: %s", toolExecutionTimeout, toolName)
+			}
+			m.logger.Error("%s Tool execution failed for %s via client %s: %v", MCPLogPrefix, toolName, client.ExecutionConfig.Name, callErr)
+			return nil, "", "", fmt.Errorf("MCP tool call failed: %v", callErr)
+		}
+		responseText := extractTextFromMCPResponse(toolResponse, toolName)
+		return createToolResponseMessage(*toolCall, responseText), client.ExecutionConfig.Name, sanitizedToolName, nil
+	}
+
+	// Shared persistent connection path — admin-level credentials are already
+	// on the transport; per-call only carries filtered context-extras.
+	reqHeaders, err := m.credStore.RequestHeaders(ctx, client.ExecutionConfig)
+	if err != nil {
+		return nil, "", "", err
+	}
 	callRequest := mcp.CallToolRequest{
 		Request: mcp.Request{
 			Method: string(mcp.MethodToolsCall),
@@ -656,41 +699,8 @@ func (m *ToolsManager) executeToolInternal(ctx *schemas.BifrostContext, toolCall
 			Name:      originalMCPToolName,
 			Arguments: arguments,
 		},
-		Header: utils.GetHeadersForToolExecution(ctx, client),
+		Header: reqHeaders,
 	}
-
-	// Handle per-user OAuth: inject user-specific Authorization header
-	if client.ExecutionConfig.AuthType == schemas.MCPAuthTypePerUserOauth {
-		accessToken, err := utils.ResolvePerUserOAuthToken(ctx, client, m.oauth2Provider)
-		if err != nil {
-			return nil, "", "", err
-		}
-
-		if client.Conn == nil {
-			// No persistent connection — create temporary connection with user's token
-			toolExecutionTimeout := m.toolExecutionTimeout.Load().(time.Duration)
-			toolCtx, cancel := context.WithTimeout(ctx, toolExecutionTimeout)
-			defer cancel()
-
-			toolResponse, callErr := ExecuteToolWithUserToken(toolCtx, client.ExecutionConfig, originalMCPToolName, arguments, accessToken, m.logger)
-			if callErr != nil {
-				if toolCtx.Err() == context.DeadlineExceeded {
-					return nil, "", "", fmt.Errorf("MCP tool call timed out after %v: %s", toolExecutionTimeout, toolName)
-				}
-				m.logger.Error("%s Tool execution failed for %s via client %s: %v", MCPLogPrefix, toolName, client.ExecutionConfig.Name, callErr)
-				return nil, "", "", fmt.Errorf("MCP tool call failed: %v", callErr)
-			}
-			responseText := extractTextFromMCPResponse(toolResponse, toolName)
-			return createToolResponseMessage(*toolCall, responseText), client.ExecutionConfig.Name, sanitizedToolName, nil
-		}
-
-		callRequest.Header = utils.BuildPerUserOAuthHeaders(callRequest.Header, accessToken)
-	}
-
-	// Create timeout context for tool execution
-	toolExecutionTimeout := m.toolExecutionTimeout.Load().(time.Duration)
-	toolCtx, cancel := context.WithTimeout(ctx, toolExecutionTimeout)
-	defer cancel()
 
 	toolResponse, callErr := client.Conn.CallTool(toolCtx, callRequest)
 	if callErr != nil {
@@ -786,37 +796,39 @@ func (m *ToolsManager) UpdateConfig(config *schemas.MCPToolManagerConfig) {
 	m.logger.Info("%s tool manager configuration updated with tool execution timeout: %v, max agent depth: %d, and code mode binding level: %s", MCPLogPrefix, config.ToolExecutionTimeout.D(), config.MaxAgentDepth, config.CodeModeBindingLevel)
 }
 
-// executeToolWithUserToken creates a temporary MCP connection using the user's
-// OAuth access token, calls the specified tool, and closes the connection.
-// This is used for per_user_oauth clients which have no persistent connection —
-// each tool call gets its own short-lived connection authenticated with the
-// requesting user's token.
+// OpenConnectionAndExecuteTool opens an ephemeral HTTP MCP connection to the
+// configured server using the provided headers, performs the Initialize
+// handshake, calls the named tool, and closes. Used for per-user auth types
+// where credentials vary by caller and no persistent upstream connection is
+// maintained.
 //
 // Parameters:
-//   - ctx: context with timeout for the entire operation
-//   - config: MCP client configuration (connection URL, name)
-//   - toolName: original MCP tool name to call
-//   - arguments: tool call arguments
-//   - accessToken: user's OAuth access token
-//   - logger: logger instance
+//   - ctx: cancellable context (caller usually wraps with the tool execution timeout)
+//   - config: MCP client config (provides ConnectionString + Name)
+//   - toolName: original MCP tool name (with hyphens; not the sanitized form)
+//   - arguments: tool arguments
+//   - headers: complete header set for opening the transport (Authorization +
+//     static + extras). Typically obtained from CredentialStore.ConnectionHeaders.
+//   - logger: optional logger (reserved for future trace logs)
 //
 // Returns:
 //   - *mcp.CallToolResult: tool execution result
 //   - error: any error during connection or execution
-func ExecuteToolWithUserToken(ctx context.Context, config *schemas.MCPClientConfig, toolName string, arguments map[string]interface{}, accessToken string, logger schemas.Logger) (*mcp.CallToolResult, error) {
+func OpenConnectionAndExecuteTool(
+	ctx context.Context,
+	config *schemas.MCPClientConfig,
+	toolName string,
+	arguments map[string]any,
+	headers http.Header,
+) (*mcp.CallToolResult, error) {
+	if config == nil {
+		return nil, fmt.Errorf("config is required for ephemeral MCP tool execution")
+	}
 	if config.ConnectionString == nil || config.ConnectionString.GetValue() == "" {
-		return nil, fmt.Errorf("connection URL is required for per-user OAuth tool execution")
+		return nil, fmt.Errorf("connection URL is required for ephemeral MCP tool execution")
 	}
 
-	// Create HTTP transport with the user's Bearer token, preserving configured headers
-	headers := make(map[string]string)
-	if config.Headers != nil {
-		for key, value := range config.Headers {
-			headers[key] = value.GetValue()
-		}
-	}
-	headers["Authorization"] = "Bearer " + accessToken
-	httpTransport, err := transport.NewStreamableHTTP(config.ConnectionString.GetValue(), transport.WithHTTPHeaders(headers))
+	httpTransport, err := transport.NewStreamableHTTP(config.ConnectionString.GetValue(), transport.WithHTTPHeaders(utils.FlattenHeaders(headers)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create HTTP transport: %w", err)
 	}

--- a/core/mcp/utils/utils.go
+++ b/core/mcp/utils/utils.go
@@ -1,101 +1,28 @@
 package utils
 
 import (
-	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// ResolvePerUserOAuthToken looks up the per-user OAuth access token for the given client.
-// If no token exists yet, it initiates an OAuth flow and returns an MCPUserOAuthRequiredError.
-//
-// Mode-strict: derives AuthMode from context state
-// and looks up exactly one identity column. No fallback chain.
-func ResolvePerUserOAuthToken(ctx *schemas.BifrostContext, client *schemas.MCPClientState, oauth2Provider schemas.OAuth2Provider) (string, error) {
-	if oauth2Provider == nil {
-		return "", fmt.Errorf("per-user OAuth requires an OAuth2Provider but none is configured")
+// FlattenHeaders converts an http.Header into a map[string]string suitable
+// for mcp-go's transport.WithHTTPHeaders, which is the API used for both
+// the persistent shared upstream connection (in clientmanager) and the
+// ephemeral per-call connection (in OpenConnectionAndExecuteTool).
+// Multi-value headers collapse to their first value — matching the legacy
+// MCPClientConfig.HttpHeaders / ExecuteToolWithUserToken behavior, which
+// built map[string]string directly from config.Headers with a single value
+// per key.
+func FlattenHeaders(h http.Header) map[string]string {
+	out := make(map[string]string, len(h))
+	for k, v := range h {
+		if len(v) == 0 {
+			continue
+		}
+		out[k] = v[0]
 	}
-
-	mode := ctx.MCPAuthMode()
-	identity := identityForMCPAuthMode(ctx, mode)
-
-	if identity == "" {
-		// No identity column populated for the derived mode. We can neither
-		// look up an existing token nor mint a flow whose result would be
-		// findable on subsequent calls, so refuse early with actionable copy.
-		return "", fmt.Errorf(
-			"per-user OAuth for %s requires an identity: send a Virtual Key (x-bf-vk), authenticate as a user, or set x-bf-mcp-session-id to any opaque string you'll re-send on subsequent calls",
-			client.ExecutionConfig.Name,
-		)
-	}
-
-	accessToken, err := oauth2Provider.GetUserAccessTokenByMode(ctx, mode, identity, client.ExecutionConfig.ID)
-	// Both sentinels mean "this user must re-authenticate":
-	//   - ErrOAuth2TokenNotFound: row missing (never authed, or purged after permanent refresh failure)
-	//   - ErrOAuth2TokenExpired:  row present but tokens unusable (access expired + no refresh available)
-	// Either way, fall through to the re-auth branch below to surface an inline auth URL.
-	if err != nil && !errors.Is(err, schemas.ErrOAuth2TokenNotFound) && !errors.Is(err, schemas.ErrOAuth2TokenExpired) {
-		return "", fmt.Errorf("failed to get user access token for MCP server %s: %w", client.ExecutionConfig.Name, err)
-	}
-	if err != nil {
-		if client.ExecutionConfig.OauthConfigID == nil || *client.ExecutionConfig.OauthConfigID == "" {
-			return "", fmt.Errorf("per-user OAuth requires an OAuth config but MCP client %s has none", client.ExecutionConfig.Name)
-		}
-		redirectURI := BuildRedirectURIFromContext(ctx)
-		if redirectURI == "" {
-			return "", fmt.Errorf("per-user OAuth requires a redirect URI but none is available in context")
-		}
-		flowInitiation, sessionID, flowErr := oauth2Provider.InitiateUserOAuthFlow(ctx, *client.ExecutionConfig.OauthConfigID, client.ExecutionConfig.ID, redirectURI, mode)
-		if flowErr != nil {
-			return "", fmt.Errorf("failed to initiate per-user OAuth flow for %s: %w", client.ExecutionConfig.Name, flowErr)
-		}
-		return "", &schemas.MCPUserOAuthRequiredError{
-			MCPClientID:   client.ExecutionConfig.ID,
-			MCPClientName: client.ExecutionConfig.Name,
-			AuthorizeURL:  flowInitiation.AuthorizeURL,
-			SessionID:     sessionID,
-			// Include the URL in the message itself — plain-text clients
-			// (curl, basic SDK wrappers) won't parse extra_fields, and a
-			// "please visit the authorize URL" hint with no URL is
-			// useless to them. The URL is already exposed on the same
-			// response via extra_fields.mcp_auth_required.authorize_url,
-			// so embedding it here doesn't widen the surface.
-			Message: fmt.Sprintf("Authentication required for %s. Visit %s to connect your account.", client.ExecutionConfig.Name, flowInitiation.AuthorizeURL),
-		}
-	}
-
-	return accessToken, nil
-}
-
-// identityForMode returns the identity string to look up by, given the derived
-// mode. Mirrors the priority used by ctx.AuthMode(): UserID for user mode,
-// resolved VK ID for vk mode, session ID for session mode.
-func identityForMCPAuthMode(ctx *schemas.BifrostContext, mode schemas.MCPAuthMode) string {
-	switch mode {
-	case schemas.MCPAuthModeUser:
-		if v, _ := ctx.Value(schemas.BifrostContextKeyUserID).(string); v != "" {
-			return v
-		}
-	case schemas.MCPAuthModeVK:
-		if v, _ := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID).(string); v != "" {
-			return v
-		}
-	case schemas.MCPAuthModeSession:
-		if v, _ := ctx.Value(schemas.BifrostContextKeyMCPSessionID).(string); v != "" {
-			return v
-		}
-	}
-	return ""
-}
-
-// BuildPerUserOAuthHeaders clones the provided headers and adds the Bearer token,
-// preserving any request-scoped extra headers already present.
-func BuildPerUserOAuthHeaders(headers http.Header, accessToken string) http.Header {
-	h := headers.Clone()
-	h.Set("Authorization", "Bearer "+accessToken)
-	return h
+	return out
 }
 
 // BuildRedirectURIFromContext extracts the OAuth redirect URI from context.
@@ -106,42 +33,57 @@ func BuildRedirectURIFromContext(ctx *schemas.BifrostContext) string {
 	return ""
 }
 
-// GetHeadersForToolExecution sets additional headers for tool execution.
-// It returns the headers for the tool execution.
-func GetHeadersForToolExecution(ctx *schemas.BifrostContext, client *schemas.MCPClientState) http.Header {
-	if ctx == nil || client == nil || client.ExecutionConfig == nil {
+// ExtractFilteredExtras returns just the per-request "extra" headers carried
+// in the BifrostContext (BifrostContextKeyMCPExtraHeaders), scoped by the
+// client's AllowedExtraHeaders. Static config headers are NOT included here —
+// those live on the upstream transport and apply automatically to every
+// message it carries. This function exists for the per-message
+// CredentialStore.RequestHeaders path on shared connections.
+func ExtractFilteredExtras(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) http.Header {
+	headers := make(http.Header)
+	if ctx == nil || config == nil {
+		return headers
+	}
+	extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyMCPExtraHeaders).(map[string][]string)
+	if !ok {
+		return headers
+	}
+	for key, values := range extraHeaders {
+		if !config.AllowedExtraHeaders.IsAllowed(key) {
+			continue
+		}
+		for i, value := range values {
+			if i == 0 {
+				headers.Set(key, value)
+			} else {
+				headers.Add(key, value)
+			}
+		}
+	}
+	return headers
+}
+
+// GetHeadersForToolExecution returns the union of the client's static config
+// headers and the filtered per-request extras carried in the BifrostContext.
+// Used by CredentialStore resolvers to assemble the "stable + per-call" base
+// before adding any auth-specific headers (e.g. a Bearer token).
+func GetHeadersForToolExecution(ctx *schemas.BifrostContext, config *schemas.MCPClientConfig) http.Header {
+	if ctx == nil || config == nil {
 		return make(http.Header)
 	}
 	headers := make(http.Header)
-	if client.ExecutionConfig.Headers != nil {
-		for key, value := range client.ExecutionConfig.Headers {
+	if config.Headers != nil {
+		for key, value := range config.Headers {
 			headers.Add(key, value.GetValue())
 		}
 	}
-	// Give priority to extra headers in the context
-	if extraHeaders, ok := ctx.Value(schemas.BifrostContextKeyMCPExtraHeaders).(map[string][]string); ok {
-		filteredHeaders := make(http.Header)
-		for key, values := range extraHeaders {
-			if client.ExecutionConfig.AllowedExtraHeaders.IsAllowed(key) {
-				for i, value := range values {
-					if i == 0 {
-						filteredHeaders.Set(key, value)
-					} else {
-						filteredHeaders.Add(key, value)
-					}
-				}
-			}
-		}
-		// Add the filtered headers to the headers
-		if len(filteredHeaders) > 0 {
-			for k, values := range filteredHeaders {
-				for i, v := range values {
-					if i == 0 {
-						headers.Set(k, v)
-					} else {
-						headers.Add(k, v)
-					}
-				}
+	// Layer per-request extras on top.
+	for key, values := range ExtractFilteredExtras(ctx, config) {
+		for i, v := range values {
+			if i == 0 {
+				headers.Set(key, v)
+			} else {
+				headers.Add(key, v)
 			}
 		}
 	}

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -21,15 +22,15 @@ import (
 
 // OAuth-related errors
 var (
-	ErrOAuth2ConfigNotFound           = errors.New("oauth2 config not found")
-	ErrOAuth2ProviderNotAvailable     = errors.New("oauth2 provider not available")
-	ErrOAuth2TokenExpired             = errors.New("oauth2 token expired")
-	ErrOAuth2TokenInvalid             = errors.New("oauth2 token invalid")
-	ErrOAuth2RefreshFailed            = errors.New("oauth2 token refresh failed")
-	ErrOAuth2NotPerUserSession        = errors.New("state does not match a per-user oauth session")
-	ErrOAuth2TokenNotFound            = errors.New("per-user oauth token not found for this identity and mcp server")
-	ErrOAuth2FlowNotPending           = errors.New("oauth flow is not in pending state")
-	ErrOAuth2FlowExpired              = errors.New("oauth flow has expired")
+	ErrOAuth2ConfigNotFound       = errors.New("oauth2 config not found")
+	ErrOAuth2ProviderNotAvailable = errors.New("oauth2 provider not available")
+	ErrOAuth2TokenExpired         = errors.New("oauth2 token expired")
+	ErrOAuth2TokenInvalid         = errors.New("oauth2 token invalid")
+	ErrOAuth2RefreshFailed        = errors.New("oauth2 token refresh failed")
+	ErrOAuth2NotPerUserSession    = errors.New("state does not match a per-user oauth session")
+	ErrOAuth2TokenNotFound        = errors.New("per-user oauth token not found for this identity and mcp server")
+	ErrOAuth2FlowNotPending       = errors.New("oauth flow is not in pending state")
+	ErrOAuth2FlowExpired          = errors.New("oauth flow has expired")
 	// ErrMCPReconnectNotApplicable signals that the reconnect operation is not
 	// meaningful for this client type — e.g. per-user OAuth clients, where
 	// each user manages their own auth and there is no shared upstream
@@ -49,6 +50,53 @@ type MCPUserOAuthRequiredError struct {
 
 func (e *MCPUserOAuthRequiredError) Error() string {
 	return e.Message
+}
+
+// MCPCredentialStore is the single source of truth for MCP credential resolution.
+// It exposes three predicates that MCPManager consumes uniformly:
+//
+//   - ConnectionHeaders         — headers attached to opening an upstream transport
+//   - RequestHeaders            — per-message headers on an already-open transport
+//   - RequiresPerCallConnection — whether each call needs an ephemeral transport
+//
+// Storage lifecycle (orphaning on VK reassignment, cascade on client delete)
+// is NOT part of this interface — those concerns stay in the configstore
+// layer where transactional atomicity is preserved.
+type MCPCredentialStore interface {
+	// ConnectionHeaders returns the headers to attach when opening an upstream
+	// transport. Called from two sites:
+	//
+	//  1. At AddClient / Reconnect / UpdateClientConnection for shared-
+	//     connection auth types (none, headers, server_oauth). The caller
+	//     wraps the Bifrost lifecycle context into a synthetic BifrostContext
+	//     with no identity, so the resolver returns admin-level headers
+	//     (static config + admin Bearer for server_oauth).
+	//
+	//  2. Per call inside the ephemeral-transport path for per-user auth
+	//     types. The caller passes the real request BifrostContext, and the
+	//     resolver returns the caller's full set (static + filtered
+	//     context-extras + per-user auth).
+	//
+	// May return *MCPUserOAuthRequiredError when a per-user credential is
+	// missing and the caller must complete an auth flow before retrying.
+	ConnectionHeaders(ctx *BifrostContext, config *MCPClientConfig) (http.Header, error)
+
+	// RequestHeaders returns the per-message headers attached to each
+	// CallTool / ListTools / Ping that flows over an already-open
+	// transport — currently just the filtered context-extras
+	// (BifrostContextKeyMCPExtraHeaders, scoped by config.AllowedExtraHeaders).
+	//
+	// Only meaningful when the connection is shared
+	// (RequiresPerCallConnection is false). Per-user types embed all
+	// caller-specific headers in the ephemeral transport itself via
+	// ConnectionHeaders; the caller skips RequestHeaders in that path.
+	RequestHeaders(ctx *BifrostContext, config *MCPClientConfig) (http.Header, error)
+
+	// RequiresPerCallConnection reports whether each tool invocation needs a
+	// freshly-built ephemeral upstream connection (rather than reusing a
+	// shared persistent one). True for per-user auth types; false for
+	// shared (none, headers, oauth-server-level).
+	RequiresPerCallConnection(config *MCPClientConfig) bool
 }
 
 // MCPConfig represents the configuration for MCP integration in Bifrost.
@@ -334,50 +382,6 @@ func NewMCPClientConfigFromMap(configMap map[string]any) *MCPClientConfig {
 		return nil
 	}
 	return &config
-}
-
-// HttpHeaders returns the HTTP headers for the MCP client config.
-func (c *MCPClientConfig) HttpHeaders(ctx context.Context, oauth2Provider OAuth2Provider) (map[string]string, error) {
-	headers := make(map[string]string)
-
-	switch c.AuthType {
-	case MCPAuthTypeOauth:
-		if c.OauthConfigID == nil {
-			return nil, ErrOAuth2ConfigNotFound
-		}
-		if oauth2Provider == nil {
-			return nil, ErrOAuth2ProviderNotAvailable
-		}
-		accessToken, err := oauth2Provider.GetAccessToken(ctx, *c.OauthConfigID)
-		if err != nil {
-			return nil, err
-		}
-		// Validate token format - trim whitespace and check for invalid characters
-		accessToken = strings.TrimSpace(accessToken)
-		if accessToken == "" {
-			return nil, errors.New("access token is empty")
-		}
-		if strings.ContainsAny(accessToken, "\n\r\t") {
-			return nil, errors.New("access token contains invalid characters")
-		}
-		headers["Authorization"] = "Bearer " + accessToken
-	case MCPAuthTypeHeaders:
-		for key, value := range c.Headers {
-			headers[key] = value.GetValue()
-		}
-	case MCPAuthTypePerUserOauth:
-		// Per-user OAuth: headers are injected per-call in executeToolInternal, not at connection level
-		return headers, nil
-	case MCPAuthTypeNone:
-		// No headers to add
-	default:
-		// Default to headers behavior for backward compatibility
-		for key, value := range c.Headers {
-			headers[key] = value.GetValue()
-		}
-	}
-
-	return headers, nil
 }
 
 // MCPConnectionType defines the communication protocol for MCP connections


### PR DESCRIPTION
## Summary

Replaces the scattered `oauth2Provider` field and ad-hoc `MCPClientConfig.HttpHeaders()` method with a unified `MCPCredentialStore` interface and a concrete `credstore` package. Previously, credential resolution for MCP tool execution was split across `utils.ResolvePerUserOAuthToken`, `BuildPerUserOAuthHeaders`, `MCPClientConfig.HttpHeaders`, and inline `AuthType` switch statements spread across `toolmanager.go`, `clientmanager.go`, and the Starlark code mode. This made it difficult to add new auth types and caused the per-user OAuth path to be inconsistently handled depending on whether a persistent connection existed.

## Changes

- Introduced `schemas.MCPCredentialStore` interface with three methods: `ConnectionHeaders`, `RequestHeaders`, and `RequiresPerCallConnection`. This replaces all direct `AuthType` comparisons and the `oauth2Provider` field throughout the MCP stack.
- Created `core/mcp/credstore` package with a `CredStore` dispatcher and four auth-type-specific resolvers: `noneResolver`, `staticHeadersResolver`, `serverOAuthResolver`, and `perUserOAuthResolver`. Each resolver encapsulates the credential logic previously inlined at call sites.
- Removed `MCPClientConfig.HttpHeaders()` from `schemas/mcp.go` and replaced all call sites with `credStore.ConnectionHeaders()`.
- Removed `utils.ResolvePerUserOAuthToken`, `BuildPerUserOAuthHeaders`, and `identityForMCPAuthMode` from `core/mcp/utils/utils.go`; this logic now lives in `credstore/per_user_oauth.go`.
- Renamed `ExecuteToolWithUserToken` to `OpenConnectionAndExecuteTool` and changed its signature to accept `http.Header` instead of a raw access token string, decoupling it from OAuth specifics.
- Added `utils.FlattenHeaders` to convert `http.Header` to `map[string]string` for mcp-go transport APIs, and `utils.ExtractFilteredExtras` to isolate the per-request extras path used by `RequestHeaders`.
- Replaced `oauth2Provider` fields in `MCPManager`, `ToolsManager`, `StarlarkCodeMode`, and `CodeModeDependencies` with `credStore`/`CredentialStore`.
- `NewMCPManager` now defaults to an OAuth-less `CredStore` when `nil` is passed, so tests and callers that don't wire OAuth still get a functional store for static/headers/none auth types.
- Connection-time header resolution in `clientmanager.go` now wraps the lifecycle context into a synthetic `BifrostContext` so `CredentialStore` can be invoked uniformly at both connection time and per-call time.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go version
go test ./...
```

Verify that MCP tool execution works end-to-end for all four auth types (`none`, `headers`, `oauth`, `per_user_oauth`). Confirm that per-user OAuth clients still surface `MCPUserOAuthRequiredError` when no token exists, and that shared-connection clients (none, headers, server OAuth) continue to connect and execute tools without regression.

## Breaking changes

- [x] Yes
- [ ] No

`MCPClientConfig.HttpHeaders()` has been removed. Any code calling this method directly must be updated to use `MCPCredentialStore.ConnectionHeaders()` instead. The `NewMCPManager`, `NewToolsManager`, and `NewToolsManagerWithCodeMode` signatures now accept `schemas.MCPCredentialStore` in place of `schemas.OAuth2Provider`. `ExecuteToolWithUserToken` has been renamed to `OpenConnectionAndExecuteTool` with a different signature.

## Security considerations

Per-user OAuth token resolution and flow initiation are now fully contained within `credstore/per_user_oauth.go`. The `serverOAuthResolver` preserves the existing token validation (whitespace trimming, control character rejection) from the removed `HttpHeaders` method. No new credential surfaces are introduced; the `RequiresPerCallConnection` predicate ensures per-user credentials are never placed on a shared persistent transport.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable