### PR TITLE
fix(openrouter): preserve max_uses for Anthropic models routed via OpenRouter

### DIFF
--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -345,18 +345,26 @@ func (resp *OpenAIResponsesRequest) filterUnsupportedTools(model string) {
 					newWebSearch.MaxUses = tool.ResponsesToolWebSearch.MaxUses
 				}
 
-				// Handle Filters: OpenAI doesn't support BlockedDomains or TimeRangeFilter
+				// Handle Filters: OpenAI supports AllowedDomains only (no BlockedDomains or TimeRangeFilter).
+				// Anthropic also supports BlockedDomains (mutually exclusive with AllowedDomains),
+				// so preserve it for anthropic/ models routed via OpenRouter.
 				if tool.ResponsesToolWebSearch.Filters != nil {
+					isAnthropic := strings.HasPrefix(model, "anthropic/")
 					hasAllowedDomains := len(tool.ResponsesToolWebSearch.Filters.AllowedDomains) > 0
+					hasBlockedDomains := isAnthropic && len(tool.ResponsesToolWebSearch.Filters.BlockedDomains) > 0
 
-					if hasAllowedDomains {
-						// Keep only AllowedDomains (copy the slice to avoid sharing)
-						newWebSearch.Filters = &schemas.ResponsesToolWebSearchFilters{
-							AllowedDomains: append([]string(nil), tool.ResponsesToolWebSearch.Filters.AllowedDomains...),
-							// BlockedDomains and TimeRangeFilter are intentionally omitted - OpenAI doesn't support it
+					if hasAllowedDomains || hasBlockedDomains {
+						newFilters := &schemas.ResponsesToolWebSearchFilters{}
+						if hasAllowedDomains {
+							newFilters.AllowedDomains = append([]string(nil), tool.ResponsesToolWebSearch.Filters.AllowedDomains...)
 						}
+						if hasBlockedDomains {
+							// BlockedDomains: preserve for Anthropic models routed via OpenRouter; strip for native OpenAI.
+							newFilters.BlockedDomains = append([]string(nil), tool.ResponsesToolWebSearch.Filters.BlockedDomains...)
+						}
+						newWebSearch.Filters = newFilters
 					}
-					// If only blocked domains or both empty, Filters stays nil
+					// TimeRangeFilter is intentionally omitted - not supported by OpenAI or Anthropic via this path
 				}
 
 				if tool.ResponsesToolWebSearch.ExternalWebAccess != nil {

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -281,8 +281,10 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 			req.Tools = normalizedTools
 		}
 
-		// Filter out tools that OpenAI doesn't support
-		req.filterUnsupportedTools()
+		// Filter out tools that OpenAI doesn't support.
+		// Pass the model so provider-specific fields (e.g. max_uses for Anthropic)
+		// are preserved when routing through OpenRouter.
+		req.filterUnsupportedTools(bifrostReq.Model)
 	}
 
 	if bifrostReq.Params != nil {
@@ -291,8 +293,11 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 	return req
 }
 
-// filterUnsupportedTools removes tool types that OpenAI doesn't support
-func (resp *OpenAIResponsesRequest) filterUnsupportedTools() {
+// filterUnsupportedTools removes tool types that OpenAI doesn't support and strips
+// provider-specific fields that OpenAI does not accept (e.g. max_uses).
+// When model is an Anthropic model routed via OpenRouter (prefix "anthropic/"),
+// Anthropic-specific fields are preserved so OpenRouter can forward them correctly.
+func (resp *OpenAIResponsesRequest) filterUnsupportedTools(model string) {
 	if len(resp.Tools) == 0 {
 		return
 	}
@@ -335,7 +340,10 @@ func (resp *OpenAIResponsesRequest) filterUnsupportedTools() {
 				newTool := tool
 				newWebSearch := &schemas.ResponsesToolWebSearch{}
 
-				// MaxUses is intentionally omitted (nil) - OpenAI doesn't support it
+				// MaxUses: preserve for Anthropic models routed via OpenRouter; strip for native OpenAI.
+				if strings.HasPrefix(model, "anthropic/") && tool.ResponsesToolWebSearch.MaxUses != nil {
+					newWebSearch.MaxUses = tool.ResponsesToolWebSearch.MaxUses
+				}
 
 				// Handle Filters: OpenAI doesn't support BlockedDomains or TimeRangeFilter
 				if tool.ResponsesToolWebSearch.Filters != nil {

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -1797,6 +1797,69 @@ func TestToOpenAIResponsesRequest_PreservesNamespaceAndWebSearchFields(t *testin
 	}
 }
 
+func TestFilterUnsupportedTools_MaxUses(t *testing.T) {
+	maxUses := 1
+	tests := []struct {
+		name            string
+		model           string
+		expectMaxUses   bool
+	}{
+		{
+			name:          "anthropic model via OpenRouter preserves max_uses",
+			model:         "anthropic/claude-haiku-4-5-20251001",
+			expectMaxUses: true,
+		},
+		{
+			name:          "native OpenAI model strips max_uses",
+			model:         "gpt-5.4",
+			expectMaxUses: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bifrostReq := &schemas.BifrostResponsesRequest{
+				Model: tt.model,
+				Input: []schemas.ResponsesMessage{{
+					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hello")},
+				}},
+				Params: &schemas.ResponsesParameters{
+					Tools: []schemas.ResponsesTool{
+						{
+							Type: schemas.ResponsesToolTypeWebSearch,
+							ResponsesToolWebSearch: &schemas.ResponsesToolWebSearch{
+								MaxUses: &maxUses,
+							},
+						},
+					},
+				},
+			}
+
+			result := ToOpenAIResponsesRequest(bifrostReq)
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if len(result.Tools) != 1 {
+				t.Fatalf("expected 1 tool, got %d", len(result.Tools))
+			}
+			webSearch := result.Tools[0].ResponsesToolWebSearch
+			if webSearch == nil {
+				t.Fatal("expected ResponsesToolWebSearch to be set")
+			}
+			if tt.expectMaxUses {
+				if webSearch.MaxUses == nil || *webSearch.MaxUses != maxUses {
+					t.Errorf("expected MaxUses=%d to be preserved, got %v", maxUses, webSearch.MaxUses)
+				}
+			} else {
+				if webSearch.MaxUses != nil {
+					t.Errorf("expected MaxUses to be nil for native OpenAI model, got %v", *webSearch.MaxUses)
+				}
+			}
+		})
+	}
+}
+
 // =============================================================================
 // Helper Functions
 // =============================================================================

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -1860,6 +1860,112 @@ func TestFilterUnsupportedTools_MaxUses(t *testing.T) {
 	}
 }
 
+func TestFilterUnsupportedTools_BlockedDomains(t *testing.T) {
+	blocked := []string{"example.com", "spam.org"}
+	allowed := []string{"trusted.com"}
+
+	tests := []struct {
+		name                 string
+		model                string
+		filters              *schemas.ResponsesToolWebSearchFilters
+		expectBlockedDomains []string
+		expectAllowedDomains []string
+	}{
+		{
+			name:  "anthropic model via OpenRouter preserves blocked_domains",
+			model: "anthropic/claude-haiku-4-5-20251001",
+			filters: &schemas.ResponsesToolWebSearchFilters{
+				BlockedDomains: blocked,
+			},
+			expectBlockedDomains: blocked,
+			expectAllowedDomains: nil,
+		},
+		{
+			name:  "native OpenAI model strips blocked_domains",
+			model: "gpt-5.4",
+			filters: &schemas.ResponsesToolWebSearchFilters{
+				BlockedDomains: blocked,
+			},
+			expectBlockedDomains: nil,
+			expectAllowedDomains: nil,
+		},
+		{
+			name:  "anthropic model preserves allowed_domains",
+			model: "anthropic/claude-haiku-4-5-20251001",
+			filters: &schemas.ResponsesToolWebSearchFilters{
+				AllowedDomains: allowed,
+			},
+			expectBlockedDomains: nil,
+			expectAllowedDomains: allowed,
+		},
+		{
+			name:  "native OpenAI model preserves allowed_domains",
+			model: "gpt-5.4",
+			filters: &schemas.ResponsesToolWebSearchFilters{
+				AllowedDomains: allowed,
+			},
+			expectBlockedDomains: nil,
+			expectAllowedDomains: allowed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bifrostReq := &schemas.BifrostResponsesRequest{
+				Model: tt.model,
+				Input: []schemas.ResponsesMessage{{
+					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hello")},
+				}},
+				Params: &schemas.ResponsesParameters{
+					Tools: []schemas.ResponsesTool{
+						{
+							Type: schemas.ResponsesToolTypeWebSearch,
+							ResponsesToolWebSearch: &schemas.ResponsesToolWebSearch{
+								Filters: tt.filters,
+							},
+						},
+					},
+				},
+			}
+
+			result := ToOpenAIResponsesRequest(bifrostReq)
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if len(result.Tools) != 1 {
+				t.Fatalf("expected 1 tool, got %d", len(result.Tools))
+			}
+			webSearch := result.Tools[0].ResponsesToolWebSearch
+			if webSearch == nil {
+				t.Fatal("expected ResponsesToolWebSearch to be set")
+			}
+
+			// Check BlockedDomains
+			if tt.expectBlockedDomains != nil {
+				if webSearch.Filters == nil || len(webSearch.Filters.BlockedDomains) != len(tt.expectBlockedDomains) {
+					t.Errorf("expected BlockedDomains=%v, got %v", tt.expectBlockedDomains, webSearch.Filters)
+				}
+			} else {
+				if webSearch.Filters != nil && len(webSearch.Filters.BlockedDomains) > 0 {
+					t.Errorf("expected BlockedDomains to be nil/empty, got %v", webSearch.Filters.BlockedDomains)
+				}
+			}
+
+			// Check AllowedDomains
+			if tt.expectAllowedDomains != nil {
+				if webSearch.Filters == nil || len(webSearch.Filters.AllowedDomains) != len(tt.expectAllowedDomains) {
+					t.Errorf("expected AllowedDomains=%v, got %v", tt.expectAllowedDomains, webSearch.Filters)
+				}
+			} else {
+				if webSearch.Filters != nil && len(webSearch.Filters.AllowedDomains) > 0 {
+					t.Errorf("expected AllowedDomains to be nil/empty, got %v", webSearch.Filters.AllowedDomains)
+				}
+			}
+		})
+	}
+}
+
 // =============================================================================
 // Helper Functions
 // =============================================================================


### PR DESCRIPTION
## Problem

When an Anthropic model (e.g. `anthropic/claude-haiku-4-5-20251001`) is routed via OpenRouter, Bifrost delegates to `ToOpenAIResponsesRequest()` which calls `filterUnsupportedTools()`. This function was stripping `max_uses` from the `web_search` tool unconditionally, because OpenAI doesn't support it.

However, when the model prefix is `anthropic/`, the request goes to OpenRouter which forwards it natively to Anthropic's API — and Anthropic **does** support `max_uses` on `web_search_20250305`. Stripping it silently removed the cap, causing unbounded search calls and unexpected cost overruns in production.

## Fix

Pass the model string to `filterUnsupportedTools` and preserve `MaxUses` when `strings.HasPrefix(model, "anthropic/")`. No change for native OpenAI models.

```go
// Before
req.filterUnsupportedTools()

// After
req.filterUnsupportedTools(bifrostReq.Model)
```

```go
// MaxUses: preserve for Anthropic models routed via OpenRouter; strip for native OpenAI.
if strings.HasPrefix(model, "anthropic/") && tool.ResponsesToolWebSearch.MaxUses != nil {
    newWebSearch.MaxUses = tool.ResponsesToolWebSearch.MaxUses
}
```

## Testing

- `go build ./providers/openai/...` ✅
- `go test ./providers/openai/...` ✅ (all existing tests pass)
- Verified via live OpenRouter calls: `max_uses=1` now correctly limits Claude Haiku to 1 search per request