### PR TITLE
fix(openrouter): preserve max_uses for Anthropic models in filterUnsu…

### DIFF
--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -281,8 +281,10 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 			req.Tools = normalizedTools
 		}
 
-		// Filter out tools that OpenAI doesn't support
-		req.filterUnsupportedTools()
+		// Filter out tools that OpenAI doesn't support.
+		// Pass the model so provider-specific fields (e.g. max_uses for Anthropic)
+		// are preserved when routing through OpenRouter.
+		req.filterUnsupportedTools(bifrostReq.Model)
 	}
 
 	if bifrostReq.Params != nil {
@@ -291,8 +293,11 @@ func ToOpenAIResponsesRequest(bifrostReq *schemas.BifrostResponsesRequest) *Open
 	return req
 }
 
-// filterUnsupportedTools removes tool types that OpenAI doesn't support
-func (resp *OpenAIResponsesRequest) filterUnsupportedTools() {
+// filterUnsupportedTools removes tool types that OpenAI doesn't support and strips
+// provider-specific fields that OpenAI does not accept (e.g. max_uses).
+// When model is an Anthropic model routed via OpenRouter (prefix "anthropic/"),
+// Anthropic-specific fields are preserved so OpenRouter can forward them correctly.
+func (resp *OpenAIResponsesRequest) filterUnsupportedTools(model string) {
 	if len(resp.Tools) == 0 {
 		return
 	}
@@ -335,7 +340,10 @@ func (resp *OpenAIResponsesRequest) filterUnsupportedTools() {
 				newTool := tool
 				newWebSearch := &schemas.ResponsesToolWebSearch{}
 
-				// MaxUses is intentionally omitted (nil) - OpenAI doesn't support it
+				// MaxUses: preserve for Anthropic models routed via OpenRouter; strip for native OpenAI.
+				if strings.HasPrefix(model, "anthropic/") && tool.ResponsesToolWebSearch.MaxUses != nil {
+					newWebSearch.MaxUses = tool.ResponsesToolWebSearch.MaxUses
+				}
 
 				// Handle Filters: OpenAI doesn't support BlockedDomains or TimeRangeFilter
 				if tool.ResponsesToolWebSearch.Filters != nil {

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -1797,6 +1797,69 @@ func TestToOpenAIResponsesRequest_PreservesNamespaceAndWebSearchFields(t *testin
 	}
 }
 
+func TestFilterUnsupportedTools_MaxUses(t *testing.T) {
+	maxUses := 1
+	tests := []struct {
+		name            string
+		model           string
+		expectMaxUses   bool
+	}{
+		{
+			name:          "anthropic model via OpenRouter preserves max_uses",
+			model:         "anthropic/claude-haiku-4-5-20251001",
+			expectMaxUses: true,
+		},
+		{
+			name:          "native OpenAI model strips max_uses",
+			model:         "gpt-5.4",
+			expectMaxUses: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bifrostReq := &schemas.BifrostResponsesRequest{
+				Model: tt.model,
+				Input: []schemas.ResponsesMessage{{
+					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hello")},
+				}},
+				Params: &schemas.ResponsesParameters{
+					Tools: []schemas.ResponsesTool{
+						{
+							Type: schemas.ResponsesToolTypeWebSearch,
+							ResponsesToolWebSearch: &schemas.ResponsesToolWebSearch{
+								MaxUses: &maxUses,
+							},
+						},
+					},
+				},
+			}
+
+			result := ToOpenAIResponsesRequest(bifrostReq)
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if len(result.Tools) != 1 {
+				t.Fatalf("expected 1 tool, got %d", len(result.Tools))
+			}
+			webSearch := result.Tools[0].ResponsesToolWebSearch
+			if webSearch == nil {
+				t.Fatal("expected ResponsesToolWebSearch to be set")
+			}
+			if tt.expectMaxUses {
+				if webSearch.MaxUses == nil || *webSearch.MaxUses != maxUses {
+					t.Errorf("expected MaxUses=%d to be preserved, got %v", maxUses, webSearch.MaxUses)
+				}
+			} else {
+				if webSearch.MaxUses != nil {
+					t.Errorf("expected MaxUses to be nil for native OpenAI model, got %v", *webSearch.MaxUses)
+				}
+			}
+		})
+	}
+}
+
 // =============================================================================
 // Helper Functions
 // =============================================================================


### PR DESCRIPTION
When an Anthropic model (e.g. anthropic/claude-haiku-4-5-20251001) is routed via OpenRouter, Bifrost delegates to the OpenAI transformer which calls filterUnsupportedTools(). Previously, this function stripped max_uses from the web_search tool unconditionally because OpenAI doesn't support it.

However, when the model prefix is "anthropic/", the request goes to OpenRouter which forwards it to Anthropic's API — and Anthropic does support max_uses on web_search_20250305. Stripping it silently removed the cap, causing unbounded search calls and unexpected cost overruns.

Fix: pass the model to filterUnsupportedTools and preserve MaxUses when strings.HasPrefix(model, "anthropic/"). No change for native OpenAI models.

## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


