### PR TITLE
feat: migrate azure to v1 api

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -311,7 +311,6 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 				},
 				AzureKeyConfig: &schemas.AzureKeyConfig{
 					Endpoint:     *schemas.NewEnvVar("env.AZURE_ENDPOINT"),
-					APIVersion:   schemas.NewEnvVar("env.AZURE_API_VERSION"),
 					ClientID:     schemas.NewEnvVar("env.AZURE_CLIENT_ID"),
 					ClientSecret: schemas.NewEnvVar("env.AZURE_CLIENT_SECRET"),
 					TenantID:     schemas.NewEnvVar("env.AZURE_TENANT_ID"),
@@ -329,8 +328,7 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 					"gpt-4o-mini-audio-preview": "gpt-4o-mini-audio-preview",
 				},
 				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint:   *schemas.NewEnvVar("env.AZURE_ENDPOINT"),
-					APIVersion: schemas.NewEnvVar("env.AZURE_API_VERSION"),
+					Endpoint: *schemas.NewEnvVar("env.AZURE_ENDPOINT"),
 				},
 			},
 		}, nil

--- a/core/internal/llmtests/passthrough_api.go
+++ b/core/internal/llmtests/passthrough_api.go
@@ -66,9 +66,11 @@ func buildPassthroughChatReq(t *testing.T, provider schemas.ModelProvider, model
 		if err != nil {
 			t.Fatalf("azure: failed to marshal passthrough chat request: %v", err)
 		}
-		// Azure passthrough expects the deployment-based path; api-version is
-		// injected automatically by buildPassthroughURL from the key config.
-		return passthroughChatReq{path: fmt.Sprintf("/openai/deployments/%s/chat/completions", model), body: body}, true
+		return passthroughChatReq{
+			path:  fmt.Sprintf("/openai/deployments/%s/chat/completions", model),
+			body:  body,
+			query: "api-version=2025-04-01-preview",
+		}, true
 
 	case schemas.Anthropic:
 		nativeReq, err := anthropic.ToAnthropicChatRequest(ctx, bfReq)
@@ -158,9 +160,10 @@ func RunPassthroughAPITest(t *testing.T, client *bifrost.Bifrost, ctx context.Co
 			bfCtx := schemas.NewBifrostContext(ctx, schemas.NoDeadline)
 
 			resp, bifrostErr := client.Passthrough(bfCtx, testConfig.Provider, &schemas.BifrostPassthroughRequest{
-				Method: "POST",
-				Path:   req.path,
-				Body:   req.body,
+				Method:   "POST",
+				Path:     req.path,
+				Body:     req.body,
+				RawQuery: req.query,
 				SafeHeaders: map[string]string{
 					"content-type": "application/json",
 				},

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -265,15 +265,7 @@ func (provider *AzureProvider) completeRequest(
 			req.Header.Del(anthropic.AnthropicBetaHeader)
 		}
 	} else {
-		apiVersion := key.AzureKeyConfig.APIVersion
-		if apiVersion == nil {
-			apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-		}
-		if path == "openai/v1/responses" {
-			url = fmt.Sprintf("%s/%s?api-version=preview", endpoint, path)
-		} else {
-			url = fmt.Sprintf("%s/%s?api-version=%s", endpoint, path, apiVersion.GetValue())
-		}
+		url = fmt.Sprintf("%s/%s", endpoint, path)
 	}
 
 	req.SetRequestURI(url)
@@ -315,12 +307,6 @@ func (provider *AzureProvider) completeRequest(
 // listModelsByKey performs a list models request for a single key.
 // Returns the response and latency, or an error if the request fails.
 func (provider *AzureProvider) listModelsByKey(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	// Get API version
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-	}
-
 	// Create the request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -330,7 +316,7 @@ func (provider *AzureProvider) listModelsByKey(ctx *schemas.BifrostContext, key 
 	// Set any extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(key.AzureKeyConfig.Endpoint.GetValue() + providerUtils.GetPathFromContext(ctx, fmt.Sprintf("/openai/models?api-version=%s", apiVersion.GetValue())))
+	req.SetRequestURI(key.AzureKeyConfig.Endpoint.GetValue() + providerUtils.GetPathFromContext(ctx, "/openai/v1/models"))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 
@@ -425,7 +411,7 @@ func (provider *AzureProvider) TextCompletion(ctx *schemas.BifrostContext, key s
 	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(
 		ctx,
 		jsonData,
-		fmt.Sprintf("openai/deployments/%s/completions", request.Model),
+		"openai/v1/completions",
 		key,
 		request.Model,
 	)
@@ -474,12 +460,7 @@ func (provider *AzureProvider) TextCompletion(ctx *schemas.BifrostContext, key s
 // It formats the request, sends it to Azure, and processes the response.
 // Returns a channel of BifrostStreamChunk objects or an error if the request fails.
 func (provider *AzureProvider) TextCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostTextCompletionRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-	}
-
-	url := fmt.Sprintf("%s/openai/deployments/%s/completions?api-version=%s", key.AzureKeyConfig.Endpoint.GetValue(), request.Model, apiVersion.GetValue())
+	url := fmt.Sprintf("%s/openai/v1/completions", key.AzureKeyConfig.Endpoint.GetValue())
 
 	// Get Azure authentication headers
 	authHeader, err := provider.getAzureAuthHeaders(ctx, key, false)
@@ -537,7 +518,7 @@ func (provider *AzureProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 	if schemas.IsAnthropicModel(request.Model) {
 		path = "anthropic/v1/messages"
 	} else {
-		path = fmt.Sprintf("openai/deployments/%s/chat/completions", request.Model)
+		path = "openai/v1/chat/completions"
 	}
 
 	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(
@@ -656,11 +637,7 @@ func (provider *AzureProvider) ChatCompletionStream(ctx *schemas.BifrostContext,
 		if err != nil {
 			return nil, err
 		}
-		apiVersion := key.AzureKeyConfig.APIVersion
-		if apiVersion == nil {
-			apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-		}
-		url = fmt.Sprintf("%s/openai/deployments/%s/chat/completions?api-version=%s", key.AzureKeyConfig.Endpoint.GetValue(), request.Model, apiVersion.GetValue())
+		url = fmt.Sprintf("%s/openai/v1/chat/completions", key.AzureKeyConfig.Endpoint.GetValue())
 
 		// Use shared streaming logic from OpenAI
 		return openai.HandleOpenAIChatCompletionStreaming(
@@ -813,7 +790,7 @@ func (provider *AzureProvider) ResponsesStream(ctx *schemas.BifrostContext, post
 		if err != nil {
 			return nil, err
 		}
-		url = fmt.Sprintf("%s/openai/v1/responses?api-version=preview", key.AzureKeyConfig.Endpoint.GetValue())
+		url = fmt.Sprintf("%s/openai/v1/responses", key.AzureKeyConfig.Endpoint.GetValue())
 
 		// Use shared streaming logic from OpenAI
 		return openai.HandleOpenAIResponsesStreaming(
@@ -856,7 +833,7 @@ func (provider *AzureProvider) Embedding(ctx *schemas.BifrostContext, key schema
 	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(
 		ctx,
 		jsonData,
-		fmt.Sprintf("openai/deployments/%s/embeddings", request.Model),
+		"openai/v1/embeddings",
 		key,
 		request.Model,
 	)
@@ -904,17 +881,12 @@ func (provider *AzureProvider) Embedding(ctx *schemas.BifrostContext, key schema
 
 // Speech is not supported by the Azure provider.
 func (provider *AzureProvider) Speech(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostSpeechRequest) (*schemas.BifrostSpeechResponse, *schemas.BifrostError) {
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-	}
-
 	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
 
-	url := fmt.Sprintf("%s/openai/deployments/%s/audio/speech?api-version=%s", endpoint, request.Model, apiVersion.GetValue())
+	url := fmt.Sprintf("%s/openai/v1/audio/speech", endpoint)
 
 	response, err := openai.HandleOpenAISpeechRequest(
 		ctx,
@@ -956,11 +928,7 @@ func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHoo
 		return nil, err
 	}
 
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-	}
-	url := fmt.Sprintf("%s/openai/deployments/%s/audio/speech?api-version=%s", key.AzureKeyConfig.Endpoint.GetValue(), request.Model, apiVersion.GetValue())
+	url := fmt.Sprintf("%s/openai/v1/audio/speech", key.AzureKeyConfig.Endpoint.GetValue())
 
 	// Create HTTP request for streaming
 	req := fasthttp.AcquireRequest()
@@ -1241,12 +1209,7 @@ func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHoo
 
 // Transcription is not supported by the Azure provider.
 func (provider *AzureProvider) Transcription(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostTranscriptionRequest) (*schemas.BifrostTranscriptionResponse, *schemas.BifrostError) {
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-	}
-
-	url := fmt.Sprintf("%s/openai/deployments/%s/audio/transcriptions?api-version=%s", key.AzureKeyConfig.Endpoint.GetValue(), request.Model, apiVersion.GetValue())
+	url := fmt.Sprintf("%s/openai/v1/audio/transcriptions", key.AzureKeyConfig.Endpoint.GetValue())
 
 	response, err := openai.HandleOpenAITranscriptionRequest(
 		ctx,
@@ -1278,11 +1241,6 @@ func (provider *AzureProvider) TranscriptionStream(ctx *schemas.BifrostContext, 
 // Returns a BifrostResponse containing the bifrost response or an error if the request fails.
 func (provider *AzureProvider) ImageGeneration(ctx *schemas.BifrostContext, key schemas.Key,
 	request *schemas.BifrostImageGenerationRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil || apiVersion.GetValue() == "" {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-	}
-
 	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
@@ -1291,7 +1249,7 @@ func (provider *AzureProvider) ImageGeneration(ctx *schemas.BifrostContext, key 
 	response, err := openai.HandleOpenAIImageGenerationRequest(
 		ctx,
 		provider.client,
-		fmt.Sprintf("%s/openai/deployments/%s/images/generations?api-version=%s", endpoint, request.Model, apiVersion.GetValue()),
+		fmt.Sprintf("%s/openai/v1/images/generations", endpoint),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -1317,17 +1275,12 @@ func (provider *AzureProvider) ImageGenerationStream(
 	key schemas.Key,
 	request *schemas.BifrostImageGenerationRequest,
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil || apiVersion.GetValue() == "" {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-	}
-
 	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
 
-	url := fmt.Sprintf("%s/openai/deployments/%s/images/generations?api-version=%s", endpoint, request.Model, apiVersion.GetValue())
+	url := fmt.Sprintf("%s/openai/v1/images/generations", endpoint)
 
 	authHeader, err := provider.getAzureAuthHeaders(ctx, key, false)
 	if err != nil {
@@ -1358,17 +1311,12 @@ func (provider *AzureProvider) ImageGenerationStream(
 
 // ImageEdit performs an image edit request to Azure's API.
 func (provider *AzureProvider) ImageEdit(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostImageEditRequest) (*schemas.BifrostImageGenerationResponse, *schemas.BifrostError) {
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil || apiVersion.GetValue() == "" {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionImageEditDefault)
-	}
-
 	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
 
-	url := fmt.Sprintf("%s/openai/deployments/%s/images/edits?api-version=%s", endpoint, request.Model, apiVersion.GetValue())
+	url := fmt.Sprintf("%s/openai/v1/images/edits", endpoint)
 	response, err := openai.HandleOpenAIImageEditRequest(
 		ctx,
 		provider.client,
@@ -1390,17 +1338,12 @@ func (provider *AzureProvider) ImageEdit(ctx *schemas.BifrostContext, key schema
 
 // ImageEditStream performs a streaming image edit request to Azure's API.
 func (provider *AzureProvider) ImageEditStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostImageEditRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil || apiVersion.GetValue() == "" {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionImageEditDefault)
-	}
-
 	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
 	if endpoint == "" {
 		return nil, providerUtils.NewConfigurationError("endpoint not set")
 	}
 
-	url := fmt.Sprintf("%s/openai/deployments/%s/images/edits?api-version=%s", endpoint, request.Model, apiVersion.GetValue())
+	url := fmt.Sprintf("%s/openai/v1/images/edits", endpoint)
 
 	authHeader, err := provider.getAzureAuthHeaders(ctx, key, false)
 	if err != nil {
@@ -1653,12 +1596,6 @@ func (provider *AzureProvider) FileUpload(ctx *schemas.BifrostContext, key schem
 		return nil, providerUtils.NewBifrostOperationError("purpose is required", nil)
 	}
 
-	// Get API version
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-	}
-
 	// Create multipart form data
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
@@ -1691,11 +1628,8 @@ func (provider *AzureProvider) FileUpload(ctx *schemas.BifrostContext, key schem
 	defer fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(resp)
 
-	// Build URL with query params
-	baseURL := fmt.Sprintf("%s/openai/files", key.AzureKeyConfig.Endpoint.GetValue())
-	values := url.Values{}
-	values.Set("api-version", apiVersion.GetValue())
-	requestURL := baseURL + "?" + values.Encode()
+	// Build URL
+	requestURL := fmt.Sprintf("%s/openai/v1/files", key.AzureKeyConfig.Endpoint.GetValue())
 
 	// Set headers
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -1766,12 +1700,6 @@ func (provider *AzureProvider) FileList(ctx *schemas.BifrostContext, keys []sche
 		}, nil
 	}
 
-	// Get API version
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-	}
-
 	// Create request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -1779,9 +1707,8 @@ func (provider *AzureProvider) FileList(ctx *schemas.BifrostContext, keys []sche
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Build URL with query params
-	requestURL := fmt.Sprintf("%s/openai/files", key.AzureKeyConfig.Endpoint.GetValue())
+	requestURL := fmt.Sprintf("%s/openai/v1/files", key.AzureKeyConfig.Endpoint.GetValue())
 	values := url.Values{}
-	values.Set("api-version", apiVersion.GetValue())
 	if request.Purpose != "" {
 		values.Set("purpose", string(request.Purpose))
 	}
@@ -1876,21 +1803,12 @@ func (provider *AzureProvider) FileRetrieve(ctx *schemas.BifrostContext, keys []
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
-		// Get API version
-		apiVersion := key.AzureKeyConfig.APIVersion
-		if apiVersion == nil {
-			apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-		}
-
 		// Create request
 		req := fasthttp.AcquireRequest()
 		resp := fasthttp.AcquireResponse()
 
-		// Build URL with query params
-		baseURL := fmt.Sprintf("%s/openai/files/%s", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.FileID))
-		values := url.Values{}
-		values.Set("api-version", apiVersion.GetValue())
-		requestURL := baseURL + "?" + values.Encode()
+		// Build URL
+		requestURL := fmt.Sprintf("%s/openai/v1/files/%s", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.FileID))
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -1969,21 +1887,12 @@ func (provider *AzureProvider) FileDelete(ctx *schemas.BifrostContext, keys []sc
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
-		// Get API version
-		apiVersion := key.AzureKeyConfig.APIVersion
-		if apiVersion == nil {
-			apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-		}
-
 		// Create request
 		req := fasthttp.AcquireRequest()
 		resp := fasthttp.AcquireResponse()
 
-		// Build URL with query params
-		baseURL := fmt.Sprintf("%s/openai/files/%s", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.FileID))
-		values := url.Values{}
-		values.Set("api-version", apiVersion.GetValue())
-		requestURL := baseURL + "?" + values.Encode()
+		// Build URL
+		requestURL := fmt.Sprintf("%s/openai/v1/files/%s", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.FileID))
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -2091,21 +2000,12 @@ func (provider *AzureProvider) FileContent(ctx *schemas.BifrostContext, keys []s
 	var lastErr *schemas.BifrostError
 
 	for _, key := range keys {
-		// Get API version
-		apiVersion := key.AzureKeyConfig.APIVersion
-		if apiVersion == nil {
-			apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-		}
-
 		// Create request
 		req := fasthttp.AcquireRequest()
 		resp := fasthttp.AcquireResponse()
 
-		// Build URL with query params
-		baseURL := fmt.Sprintf("%s/openai/files/%s/content", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.FileID))
-		values := url.Values{}
-		values.Set("api-version", apiVersion.GetValue())
-		requestURL := baseURL + "?" + values.Encode()
+		// Build URL
+		requestURL := fmt.Sprintf("%s/openai/v1/files/%s/content", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.FileID))
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -2203,23 +2103,14 @@ func (provider *AzureProvider) BatchCreate(ctx *schemas.BifrostContext, key sche
 		return nil, providerUtils.NewBifrostOperationError("either input_file_id, input_blob, or requests array is required for Azure batch API", nil)
 	}
 
-	// Get API version
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-	}
-
 	// Create request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
 	defer fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(resp)
 
-	// Build URL with query params
-	baseURL := fmt.Sprintf("%s/openai/batches", key.AzureKeyConfig.Endpoint.GetValue())
-	values := url.Values{}
-	values.Set("api-version", apiVersion.GetValue())
-	requestURL := baseURL + "?" + values.Encode()
+	// Build URL
+	requestURL := fmt.Sprintf("%s/openai/v1/batches", key.AzureKeyConfig.Endpoint.GetValue())
 
 	// Set headers
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -2318,12 +2209,6 @@ func (provider *AzureProvider) BatchList(ctx *schemas.BifrostContext, keys []sch
 		}, nil
 	}
 
-	// Get API version
-	apiVersion := key.AzureKeyConfig.APIVersion
-	if apiVersion == nil {
-		apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-	}
-
 	// Create request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -2331,9 +2216,8 @@ func (provider *AzureProvider) BatchList(ctx *schemas.BifrostContext, keys []sch
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Build URL with query params
-	baseURL := fmt.Sprintf("%s/openai/batches", key.AzureKeyConfig.Endpoint.GetValue())
+	baseURL := fmt.Sprintf("%s/openai/v1/batches", key.AzureKeyConfig.Endpoint.GetValue())
 	values := url.Values{}
-	values.Set("api-version", apiVersion.GetValue())
 	if request.Limit > 0 {
 		values.Set("limit", fmt.Sprintf("%d", request.Limit))
 	}
@@ -2419,21 +2303,12 @@ func (provider *AzureProvider) BatchRetrieve(ctx *schemas.BifrostContext, keys [
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
-		// Get API version
-		apiVersion := key.AzureKeyConfig.APIVersion
-		if apiVersion == nil {
-			apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-		}
-
 		// Create request
 		req := fasthttp.AcquireRequest()
 		resp := fasthttp.AcquireResponse()
 
-		// Build URL with query params
-		baseURL := fmt.Sprintf("%s/openai/batches/%s", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.BatchID))
-		values := url.Values{}
-		values.Set("api-version", apiVersion.GetValue())
-		requestURL := baseURL + "?" + values.Encode()
+		// Build URL
+		requestURL := fmt.Sprintf("%s/openai/v1/batches/%s", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.BatchID))
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -2513,21 +2388,12 @@ func (provider *AzureProvider) BatchCancel(ctx *schemas.BifrostContext, keys []s
 
 	var lastErr *schemas.BifrostError
 	for _, key := range keys {
-		// Get API version
-		apiVersion := key.AzureKeyConfig.APIVersion
-		if apiVersion == nil {
-			apiVersion = schemas.NewEnvVar(AzureAPIVersionDefault)
-		}
-
 		// Create request
 		req := fasthttp.AcquireRequest()
 		resp := fasthttp.AcquireResponse()
 
-		// Build URL with query params
-		baseURL := fmt.Sprintf("%s/openai/batches/%s/cancel", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.BatchID))
-		values := url.Values{}
-		values.Set("api-version", apiVersion.GetValue())
-		requestURL := baseURL + "?" + values.Encode()
+		// Build URL
+		requestURL := fmt.Sprintf("%s/openai/v1/batches/%s/cancel", key.AzureKeyConfig.Endpoint.GetValue(), url.PathEscape(request.BatchID))
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -2815,7 +2681,7 @@ func (provider *AzureProvider) CountTokens(_ *schemas.BifrostContext, _ schemas.
 // Container endpoints are not per-deployment, so they use the openai/v1 prefix directly.
 func (provider *AzureProvider) buildContainerURL(key schemas.Key, path string) string {
 	endpoint := strings.TrimRight(key.AzureKeyConfig.Endpoint.GetValue(), "/")
-	return fmt.Sprintf("%s/openai/v1%s?api-version=%s", endpoint, path, AzureAPIVersionPreview)
+	return fmt.Sprintf("%s/openai/v1%s", endpoint, path)
 }
 
 // ContainerCreate creates a new container via Azure's OpenAI API.
@@ -3269,7 +3135,7 @@ func (provider *AzureProvider) ContainerFileList(ctx *schemas.BifrostContext, ke
 		queryParams.Set("order", *request.Order)
 	}
 	if len(queryParams) > 0 {
-		requestURL += "&" + queryParams.Encode()
+		requestURL += "?" + queryParams.Encode()
 	}
 
 	req := fasthttp.AcquireRequest()
@@ -3830,42 +3696,24 @@ func (provider *AzureProvider) PassthroughStream(
 func (provider *AzureProvider) buildPassthroughURL(key schemas.Key, path, rawQuery string) string {
 	endpoint := key.AzureKeyConfig.Endpoint.GetValue()
 
-	// Normalise the responses path emitted by the Azure SDK.
+	// Normalise paths emitted by the Azure SDK.
 	path = strings.Replace(path, "/openai/responses", "/openai/v1/responses", 1)
-
 	path = strings.Replace(path, "/openai/videos", "/openai/v1/videos", 1)
 
-	var apiVersion string
-	switch {
-	case strings.Contains(path, "openai/v1/responses"):
-		apiVersion = AzureAPIVersionPreview
-	case strings.HasPrefix(path, "/anthropic/"),
-		strings.HasPrefix(path, "/openai/v1/videos"):
-		apiVersion = ""
-	default:
-		if key.AzureKeyConfig.APIVersion != nil {
-			apiVersion = key.AzureKeyConfig.APIVersion.GetValue()
-		}
-		if apiVersion == "" {
-			if values, err := url.ParseQuery(rawQuery); err == nil {
-				apiVersion = values.Get("api-version")
-			}
+	// v1 routes and Anthropic routes do not accept api-version — strip it if
+	if rawQuery != "" &&
+		(strings.HasPrefix(path, "/anthropic/") ||
+			strings.Contains(path, "/openai/v1/responses") ||
+			strings.HasPrefix(path, "/openai/v1/videos")) {
+		if values, err := url.ParseQuery(rawQuery); err == nil {
+			values.Del("api-version")
+			rawQuery = values.Encode()
 		}
 	}
 
-	// Strip api-version from the client query to avoid duplicates.
-	queryValues, _ := url.ParseQuery(rawQuery)
-	queryValues.Del("api-version")
-	cleanQuery := queryValues.Encode()
-
 	fullURL := endpoint + path
-	switch {
-	case cleanQuery != "" && apiVersion != "":
-		fullURL += "?" + cleanQuery + "&api-version=" + apiVersion
-	case cleanQuery != "":
-		fullURL += "?" + cleanQuery
-	case apiVersion != "":
-		fullURL += "?api-version=" + apiVersion
+	if rawQuery != "" {
+		fullURL += "?" + rawQuery
 	}
 	return fullURL
 }

--- a/core/providers/azure/realtime.go
+++ b/core/providers/azure/realtime.go
@@ -34,10 +34,8 @@ func (provider *AzureProvider) RealtimeWebSocketURL(key schemas.Key, model strin
 	endpoint = strings.Replace(endpoint, "https://", "wss://", 1)
 	endpoint = strings.Replace(endpoint, "http://", "ws://", 1)
 
-	apiVersion := azureRealtimeAPIVersion(key)
-
-	return fmt.Sprintf("%s/openai/v1/realtime?model=%s&api-version=%s",
-		endpoint, url.QueryEscape(model), url.QueryEscape(apiVersion))
+	return fmt.Sprintf("%s/openai/v1/realtime?model=%s",
+		endpoint, url.QueryEscape(model))
 }
 
 func (provider *AzureProvider) RealtimeHeaders(ctx *schemas.BifrostContext, key schemas.Key) (map[string]string, *schemas.BifrostError) {
@@ -76,10 +74,9 @@ func (provider *AzureProvider) ExchangeRealtimeWebRTCSDP(
 	session json.RawMessage,
 ) (string, *schemas.BifrostError) {
 	endpoint := strings.TrimRight(key.AzureKeyConfig.Endpoint.GetValue(), "/")
-	apiVersion := azureRealtimeAPIVersion(key)
 
-	upstreamURL := fmt.Sprintf("%s/openai/v1/realtime?model=%s&api-version=%s",
-		endpoint, url.QueryEscape(model), url.QueryEscape(apiVersion))
+	upstreamURL := fmt.Sprintf("%s/openai/v1/realtime?model=%s",
+		endpoint, url.QueryEscape(model))
 
 	// Build multipart body: sdp + optional session
 	bodyBuf := &bytes.Buffer{}
@@ -222,9 +219,7 @@ func (provider *AzureProvider) CreateRealtimeClientSecret(
 	}
 
 	endpoint := strings.TrimRight(key.AzureKeyConfig.Endpoint.GetValue(), "/")
-	apiVersion := azureRealtimeAPIVersion(key)
-	upstreamURL := fmt.Sprintf("%s/openai/v1/realtime/client_secrets?api-version=%s",
-		endpoint, url.QueryEscape(apiVersion))
+	upstreamURL := fmt.Sprintf("%s/openai/v1/realtime/client_secrets", endpoint)
 
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -336,18 +331,6 @@ func newAzureRealtimeError(status int, errorType, message string, err error) *sc
 	return bifrostErr
 }
 
-// azureRealtimeAPIVersion returns the API version to use for realtime endpoints.
-// Realtime requires a preview API version. If the key has an explicit version
-// configured we honour it; otherwise we fall back to the preview version rather
-// than the stable default (which does not support realtime).
-func azureRealtimeAPIVersion(key schemas.Key) string {
-	if key.AzureKeyConfig != nil && key.AzureKeyConfig.APIVersion != nil {
-		if apiVersion := key.AzureKeyConfig.APIVersion.GetValue(); apiVersion != "" {
-			return apiVersion
-		}
-	}
-	return AzureAPIVersionPreview
-}
 
 func (provider *AzureProvider) parseRealtimeClientSecretError(ctx *schemas.BifrostContext, resp *fasthttp.Response) *schemas.BifrostError {
 	body, _ := providerUtils.CheckAndDecodeBody(resp)

--- a/core/providers/azure/types.go
+++ b/core/providers/azure/types.go
@@ -1,9 +1,5 @@
 package azure
 
-// AzureAPIVersionDefault is the default Azure API version to use when not specified.
-const AzureAPIVersionDefault = "2024-10-21"
-const AzureAPIVersionPreview = "preview"
-const AzureAPIVersionImageEditDefault = "2025-04-01-preview"
 const AzureAnthropicAPIVersionDefault = "2023-06-01"
 
 type AzureModelCapabilities struct {

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -193,8 +193,7 @@ const (
 // AzureKeyConfig represents the Azure-specific configuration.
 // It contains Azure-specific settings required for service access and deployment management.
 type AzureKeyConfig struct {
-	Endpoint   EnvVar  `json:"endpoint"`              // Azure service endpoint URL
-	APIVersion *EnvVar `json:"api_version,omitempty"` // Azure API version to use; defaults to "2024-10-21"
+	Endpoint EnvVar `json:"endpoint"` // Azure service endpoint URL
 
 	ClientID     *EnvVar  `json:"client_id,omitempty"`     // Azure client ID for authentication
 	ClientSecret *EnvVar  `json:"client_secret,omitempty"` // Azure client secret for authentication

--- a/docs/deployment-guides/config-json/providers.mdx
+++ b/docs/deployment-guides/config-json/providers.mdx
@@ -171,7 +171,7 @@ Supports multiple keys with weighted load balancing. Mark one key with `use_for_
 
 ### Azure OpenAI
 
-Azure requires `azure_key_config` on every key with `endpoint` and `api_version`. List your Azure deployment names in `models` - Bifrost routes requests using the model name as the deployment name. If your deployment names differ from the model names you use in requests, add an `aliases` map on the key.
+Azure requires `azure_key_config` on every key with `endpoint`. Bifrost uses the Azure OpenAI v1 API — no `api_version` needed. List your Azure deployment names in `models` - Bifrost routes requests using the model name as the deployment name. If your deployment names differ from the model names you use in requests, add an `aliases` map on the key.
 
 <Tabs>
 <Tab title="API Key">
@@ -187,8 +187,7 @@ Azure requires `azure_key_config` on every key with `endpoint` and `api_version`
           "models": ["gpt-4o", "gpt-4o-mini"],
           "weight": 1.0,
           "azure_key_config": {
-            "endpoint": "env.AZURE_ENDPOINT",
-            "api_version": "env.AZURE_API_VERSION"
+            "endpoint": "env.AZURE_ENDPOINT"
           }
         }
       ]
@@ -202,7 +201,6 @@ Set environment variables:
 ```bash
 export AZURE_API_KEY="your-azure-api-key"
 export AZURE_ENDPOINT="https://your-resource.openai.azure.com"
-export AZURE_API_VERSION="2024-10-21"
 ```
 
 </Tab>
@@ -221,8 +219,7 @@ When `value` is empty or omitted, Bifrost uses `DefaultAzureCredential` - which 
           "models": ["gpt-4o"],
           "weight": 1.0,
           "azure_key_config": {
-            "endpoint": "env.AZURE_ENDPOINT",
-            "api_version": "env.AZURE_API_VERSION"
+            "endpoint": "env.AZURE_ENDPOINT"
           }
         }
       ]
@@ -250,8 +247,7 @@ When `value` is empty or omitted, Bifrost uses `DefaultAzureCredential` - which 
             "gpt-4o": "gpt-4o-prod-deployment"
           },
           "azure_key_config": {
-            "endpoint": "env.AZURE_ENDPOINT",
-            "api_version": "env.AZURE_API_VERSION"
+            "endpoint": "env.AZURE_ENDPOINT"
           }
         }
       ]
@@ -273,8 +269,7 @@ When `value` is empty or omitted, Bifrost uses `DefaultAzureCredential` - which 
           "models": ["gpt-4o"],
           "weight": 1.0,
           "azure_key_config": {
-            "endpoint": "env.AZURE_ENDPOINT_EAST",
-            "api_version": "env.AZURE_API_VERSION"
+            "endpoint": "env.AZURE_ENDPOINT_EAST"
           }
         },
         {
@@ -283,8 +278,7 @@ When `value` is empty or omitted, Bifrost uses `DefaultAzureCredential` - which 
           "models": ["gpt-4o"],
           "weight": 1.0,
           "azure_key_config": {
-            "endpoint": "env.AZURE_ENDPOINT_WEST",
-            "api_version": "env.AZURE_API_VERSION"
+            "endpoint": "env.AZURE_ENDPOINT_WEST"
           }
         }
       ]

--- a/docs/integrations/passthrough.mdx
+++ b/docs/integrations/passthrough.mdx
@@ -47,9 +47,7 @@ When you use passthrough endpoints, the request still flows through Bifrost core
 ### Azure Passthrough
 
 - Uses `azure` as the default provider.
-- Requires an Azure key with `endpoint` configured. `api-version` is injected automatically:
-  - **Key config `api_version`** takes priority (consistent with how auth is handled).
-  - Falls back to any `api-version` the client supplied in the query string.
+- Requires an Azure key with `endpoint` configured. Query parameters (including any `api-version`) are forwarded as-is from the caller — Bifrost does not inject any version.
 
 ### GenAI Passthrough
 
@@ -151,7 +149,7 @@ from openai import AzureOpenAI
 client = AzureOpenAI(
     azure_endpoint="http://localhost:8080/azure_passthrough",
     api_key="dummy-key",
-    api_version="2024-10-21",  # overridden by key config api_version if set
+    api_version="2024-10-21",  # passed through as-is in the query string
 )
 
 response = client.chat.completions.create(

--- a/docs/providers/supported-providers/azure.mdx
+++ b/docs/providers/supported-providers/azure.mdx
@@ -12,7 +12,7 @@ Azure is a cloud provider offering access to OpenAI and Anthropic models through
 - **Authentication modes** - API key, Entra ID (Service Principal), or Managed Identity (DefaultAzureCredential) with
   automatic environment detection
 - **Model routing** - Automatic provider detection (OpenAI vs Anthropic) based on deployment
-- **API versioning** - Configurable API versions with preview support for Responses API
+- **v1 API** - Uses `/openai/v1/` endpoints with no `api-version` query parameter required
 - **Custom endpoints** - Full control over Azure endpoint configuration
 - **Multi-model support** - Unified interface for OpenAI, Anthropic (via Azure), and Gemini models
 - **Request/response pass-through** - Support for raw request/response bodies for advanced use cases
@@ -36,8 +36,7 @@ Azure is a cloud provider offering access to OpenAI and Anthropic models through
 
 <Note>
   **Azure-specific**: Batch operations and Text Completions are not supported by
-  Azure OpenAI Service. Responses API uses preview API version and is available
-  for both OpenAI and Anthropic models.
+  Azure OpenAI Service. Responses API is available for both OpenAI and Anthropic models.
 </Note>
 
 ---
@@ -81,9 +80,8 @@ This covers managed identity on Azure infrastructure, workload identity in AKS, 
 2. Click **"Add Key"** (or edit an existing key)
 3. Under **Authentication Method**, select **"Default Credential"**
 4. Set **Endpoint**: Your Azure OpenAI resource URL (e.g., `https://your-org.openai.azure.com`)
-5. Set **API Version** (Optional): e.g., `2024-10-21`
-6. Configure **Aliases**: Map model names to deployment IDs (e.g., `gpt-4o` → `my-gpt4o-deployment`)
-7. Save
+5. Configure **Aliases**: Map model names to deployment IDs (e.g., `gpt-4o` → `my-gpt4o-deployment`)
+6. Save
 
 Ensure the appropriate credential source is available - a managed identity attached to the Azure resource, `AZURE_CLIENT_ID`/`AZURE_CLIENT_SECRET`/`AZURE_TENANT_ID` env vars, or `az login` for local development.
 
@@ -110,8 +108,7 @@ curl -X POST http://localhost:8080/api/providers/azure/keys \
       "gpt-4o-mini": "my-mini-deployment"
     },
     "azure_key_config": {
-      "endpoint": "env.AZURE_ENDPOINT",
-      "api_version": "2024-10-21"
+      "endpoint": "env.AZURE_ENDPOINT"
     }
   }'
 ```
@@ -123,7 +120,6 @@ curl -X POST http://localhost:8080/api/providers/azure/keys \
 ```json
 "azure_key_config": {
   "endpoint": "env.AZURE_ENDPOINT",
-  "api_version": "2024-10-21",
   "deployments": {
     "gpt-4o": "my-gpt4o-deployment"
   }
@@ -150,8 +146,7 @@ curl -X POST http://localhost:8080/api/providers/azure/keys \
             "gpt-4o-mini": "my-mini-deployment"
           },
           "azure_key_config": {
-            "endpoint": "env.AZURE_ENDPOINT",
-            "api_version": "2024-10-21"
+            "endpoint": "env.AZURE_ENDPOINT"
           }
         }
       ]
@@ -183,8 +178,7 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                     "gpt-4o-mini": "my-mini-deployment",
                 },
                 AzureKeyConfig: &schemas.AzureKeyConfig{
-                    Endpoint:   *schemas.NewEnvVar(os.Getenv("AZURE_ENDPOINT")),
-                    APIVersion: schemas.NewEnvVar("2024-10-21"),
+                    Endpoint: *schemas.NewEnvVar(os.Getenv("AZURE_ENDPOINT")),
                 },
             },
         }, nil
@@ -219,8 +213,7 @@ Set `client_id`, `client_secret`, and `tenant_id` to authenticate with a Service
 5. Set **Client Secret**: Your Azure Entra ID client secret
 6. Set **Tenant ID**: Your Azure Entra ID tenant ID
 7. Set **Endpoint**: Your Azure OpenAI resource URL
-8. Set **API Version** (Optional): e.g., `2024-08-01-preview`
-9. Set **Scopes** (Optional): Override the default OAuth scope (`https://cognitiveservices.azure.com/.default`). Any configured scopes **replace** the default entirely - if you customize this field, you must include all required scopes (the default is not automatically added)
+8. Set **Scopes** (Optional): Override the default OAuth scope (`https://cognitiveservices.azure.com/.default`). Any configured scopes **replace** the default entirely - if you customize this field, you must include all required scopes (the default is not automatically added)
 10. Configure **Aliases**: Map model names to deployment IDs
 11. Save
 
@@ -252,8 +245,7 @@ curl -X POST http://localhost:8080/api/providers/azure/keys \
       "client_id": "env.AZURE_CLIENT_ID",
       "client_secret": "env.AZURE_CLIENT_SECRET",
       "tenant_id": "env.AZURE_TENANT_ID",
-      "scopes": ["https://cognitiveservices.azure.com/.default"],
-      "api_version": "2024-08-01-preview"
+      "scopes": ["https://cognitiveservices.azure.com/.default"]
     }
   }'
 ```
@@ -289,8 +281,7 @@ curl -X POST http://localhost:8080/api/providers/azure/keys \
             "client_id": "env.AZURE_CLIENT_ID",
             "client_secret": "env.AZURE_CLIENT_SECRET",
             "tenant_id": "env.AZURE_TENANT_ID",
-            "scopes": ["https://cognitiveservices.azure.com/.default"],
-            "api_version": "2024-08-01-preview"
+            "scopes": ["https://cognitiveservices.azure.com/.default"]
           }
         }
       ]
@@ -328,7 +319,6 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                     ClientSecret: schemas.NewEnvVar(os.Getenv("AZURE_CLIENT_SECRET")),
                     TenantID:     schemas.NewEnvVar(os.Getenv("AZURE_TENANT_ID")),
                     Scopes:       []string{"https://cognitiveservices.azure.com/.default"},
-                    APIVersion:   schemas.NewEnvVar("2024-08-01-preview"),
                 },
             },
         }, nil
@@ -366,9 +356,8 @@ Provide the Azure API key in the `value` field. Use this for simple setups witho
 3. Under **Authentication Method**, select **"API Key"**
 4. Set **API Key**: Your Azure API key
 5. Set **Endpoint**: Your Azure OpenAI resource URL
-6. Set **API Version** (Optional): e.g., `2024-10-21`
-7. Configure **Aliases**: Map model names to deployment IDs
-8. Save
+6. Configure **Aliases**: Map model names to deployment IDs
+7. Save
 
 </Tab>
 
@@ -393,8 +382,7 @@ curl -X POST http://localhost:8080/api/providers/azure/keys \
       "gpt-4o-mini": "my-mini-deployment"
     },
     "azure_key_config": {
-      "endpoint": "env.AZURE_ENDPOINT",
-      "api_version": "2024-10-21"
+      "endpoint": "env.AZURE_ENDPOINT"
     }
   }'
 ```
@@ -425,8 +413,7 @@ curl -X POST http://localhost:8080/api/providers/azure/keys \
             "gpt-4o-mini": "my-mini-deployment"
           },
           "azure_key_config": {
-            "endpoint": "env.AZURE_ENDPOINT",
-            "api_version": "2024-10-21"
+            "endpoint": "env.AZURE_ENDPOINT"
           }
         }
       ]
@@ -458,8 +445,7 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
                     "gpt-4o-mini": "my-mini-deployment",
                 },
                 AzureKeyConfig: &schemas.AzureKeyConfig{
-                    Endpoint:   *schemas.NewEnvVar(os.Getenv("AZURE_ENDPOINT")),
-                    APIVersion: schemas.NewEnvVar("2024-10-21"),
+                    Endpoint: *schemas.NewEnvVar(os.Getenv("AZURE_ENDPOINT")),
                 },
             },
         }, nil
@@ -483,7 +469,6 @@ func (a *MyAccount) GetKeysForProvider(ctx *context.Context, provider schemas.Mo
 | Field           | Required | Default                                            | Description                                     |
 | --------------- | -------- | -------------------------------------------------- | ----------------------------------------------- |
 | `endpoint`      | Yes      | -                                                  | Azure OpenAI resource endpoint URL              |
-| `api_version`   | No       | `2024-10-21`                                       | Azure API version                               |
 | `client_id`     | No       | -                                                  | Entra ID client ID (Service Principal auth)     |
 | `client_secret` | No       | -                                                  | Entra ID client secret (Service Principal auth) |
 | `tenant_id`     | No       | -                                                  | Entra ID tenant ID (Service Principal auth)     |
@@ -585,8 +570,7 @@ detects the auth environment.
     "gpt-4": "my-gpt4-deployment"
   },
   "azure_key_config": {
-    "endpoint": "https://your-org.openai.azure.com",
-    "api_version": "2024-10-21"
+    "endpoint": "https://your-org.openai.azure.com"
   }
 }
 ```
@@ -607,8 +591,7 @@ If you set `client_id`, `client_secret`, and `tenant_id`, Azure Entra ID authent
     "client_id": "your-client-id",
     "client_secret": "your-client-secret",
     "tenant_id": "your-tenant-id",
-    "scopes": ["https://cognitiveservices.azure.com/.default"],
-    "api_version": "2024-10-21"
+    "scopes": ["https://cognitiveservices.azure.com/.default"]
   }
 }
 ```
@@ -629,8 +612,7 @@ If you set `client_id`, `client_secret`, and `tenant_id`, Azure Entra ID authent
     "claude-3": "my-claude-deployment"
   },
   "azure_key_config": {
-    "endpoint": "https://your-org.openai.azure.com",
-    "api_version": "2024-10-21"
+    "endpoint": "https://your-org.openai.azure.com"
   }
 }
 ```
@@ -642,7 +624,6 @@ If you set `client_id`, `client_secret`, and `tenant_id`, Azure Entra ID authent
 - `client_secret` - Azure Entra ID client secret (optional, for Service Principal auth)
 - `tenant_id` - Azure Entra ID tenant ID (optional, for Service Principal auth)
 - `scopes` - OAuth scopes for token requests (default: `["https://cognitiveservices.azure.com/.default"]`)
-- `api_version` - API version to use (default: `2024-10-21`)
 - `aliases` - Map of model names to Azure deployment IDs (optional, set at key level)
 - `allowed_models` - List of allowed models to use from this key (optional)
 
@@ -694,14 +675,6 @@ Refer to [Anthropic documentation](/providers/supported-providers/anthropic) for
 - Authentication uses `x-api-key` header for Anthropic models
 - Minimum reasoning budget: 1024 tokens
 
-## API Versioning
-
-- **Default version**: `2024-10-21` (supports latest OpenAI features)
-- **Preview version**: `preview` (used for Responses API)
-- **Custom version**: Set via `api_version` in key config
-
-Different API versions may have different feature support. Bifrost automatically adjusts endpoint paths and parameters based on the configured version.
-
 ## Streaming
 
 Streaming uses OpenAI or Anthropic format depending on model type:
@@ -713,7 +686,7 @@ Streaming uses OpenAI or Anthropic format depending on model type:
 
 # 2. Responses API
 
-The Responses API is available for both OpenAI and Anthropic models on Azure and uses the preview API version.
+The Responses API is available for both OpenAI and Anthropic models on Azure using the `/openai/v1/responses` endpoint.
 
 ## Request Parameters
 
@@ -774,7 +747,7 @@ resp, err := client.ResponsesRequest(schemas.NewBifrostContext(ctx, schemas.NoDe
 
 ### Special Handling
 
-- Uses `/openai/v1/responses` endpoint with `preview` API version
+- Uses `/openai/v1/responses` endpoint
 - All request body conversions handled automatically
 - Supports raw request body passthrough for advanced cases
 
@@ -946,13 +919,11 @@ Image Edit is supported for OpenAI models on Azure and uses the OpenAI-compatibl
 Azure uses the same conversion as OpenAI (see [OpenAI Image Edit](/providers/supported-providers/openai#8-image-edit)):
 
 - **Request Conversion**: Uses `openai.HandleOpenAIImageEditRequest` with Azure-specific URL construction
-- **URL Format**: `{endpoint}/openai/deployments/{deployment}/images/edits?api-version={apiVersion}`
+- **URL Format**: `{endpoint}/openai/v1/images/edits`
 - **Authentication**: Azure API key or OAuth bearer token (via `getAzureAuthHeaders`)
 - **Deployment Mapping**: Model identifier mapped to Azure deployment ID
 - **Response Conversion**: Same as OpenAI - responses unmarshaled directly into `BifrostImageGenerationResponse`
 - **Streaming**: Supported via `openai.HandleOpenAIImageEditStreamRequest` with Azure-specific URL and authentication
-
-**Endpoint**: `/openai/deployments/{deployment}/images/edits?api-version={apiVersion}`
 
 ---
 
@@ -1000,15 +971,6 @@ Lists available models/deployments configured in the Azure key. Response include
   transparently **Code**: `azure.go:92-114`
 </Accordion>
 
-<Accordion title="Responses API Preview Version (including Anthropic)">
-  **Severity**: Medium **Behavior**: Responses API automatically uses preview
-  API version, which differs from Chat Completions API version. For Anthropic
-  models, Responses API specifically uses `preview` API version. **Impact**:
-  Different API version for Responses vs Chat Completions. Automatic version
-  override for Responses requests. **Code**: `azure.go:92-114`,
-  `azure.go:109-113`, `azure.go:694`
-</Accordion>
-
 <Accordion title="Version Matching for Deployments">
   **Severity**: Low **Behavior**: Model version differences ignored when
   matching to deployments **Impact**: `gpt-4` and `gpt-4-turbo` can map to same
@@ -1036,11 +998,11 @@ Azure routes video generation to OpenAI's Sora models via the Azure OpenAI-compa
 
 ## Configuration
 
-**HTTP Settings**: API Version `2024-10-21` (configurable) | Max Connections 5000 | Max Idle 60 seconds
+**HTTP Settings**: Max Connections 5000 | Max Idle 60 seconds
 
-**Endpoint Format**: `https://{resource-name}.openai.azure.com/openai/v1/{path}?api-version={version}`
+**Endpoint Format**: `https://{resource-name}.openai.azure.com/openai/v1/{path}`
 
-**Note**: Bifrost automatically constructs URLs using the endpoint from key configuration and the configured API version.
+**Note**: Bifrost uses the Azure OpenAI v1 API. No `api-version` query parameter is needed.
 
 ## Setup & Configuration
 

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -469,11 +469,6 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 		if key.AzureKeyConfig != nil {
 			azureConfig := &schemas.AzureKeyConfig{}
 			azureConfig.Endpoint = *key.AzureKeyConfig.Endpoint.Redacted()
-			if key.AzureKeyConfig.APIVersion != nil && key.AzureKeyConfig.APIVersion.IsFromEnv() {
-				azureConfig.APIVersion = key.AzureKeyConfig.APIVersion.Redacted()
-			} else {
-				azureConfig.APIVersion = key.AzureKeyConfig.APIVersion
-			}
 			if key.AzureKeyConfig.ClientID != nil {
 				azureConfig.ClientID = key.AzureKeyConfig.ClientID.Redacted()
 			}

--- a/framework/configstore/clientconfig_redaction_test.go
+++ b/framework/configstore/clientconfig_redaction_test.go
@@ -12,14 +12,14 @@ import (
 
 // TestProviderConfig_Redacted_AutoMasksEnvBackedFields verifies that env-backed
 // values in provider config fields are redacted in the JSON output of a Redacted()
-// ProviderConfig, including fields like Azure APIVersion.
+// ProviderConfig, including fields like Azure Endpoint.
 func TestProviderConfig_Redacted_AutoMasksEnvBackedFields(t *testing.T) {
-	t.Setenv("MY_AZURE_API_VERSION_SECRET", "2024-10-21-preview-secret")
+	t.Setenv("MY_AZURE_ENDPOINT_SECRET", "https://secret-resource.openai.azure.com")
 
-	apiVersion := schemas.NewEnvVar("env.MY_AZURE_API_VERSION_SECRET")
-	require.True(t, apiVersion.IsFromEnv(), "setup: APIVersion should be FromEnv")
-	require.Equal(t, "2024-10-21-preview-secret", apiVersion.GetValue(),
-		"setup: APIVersion should be resolved")
+	endpoint := schemas.NewEnvVar("env.MY_AZURE_ENDPOINT_SECRET")
+	require.True(t, endpoint.IsFromEnv(), "setup: Endpoint should be FromEnv")
+	require.Equal(t, "https://secret-resource.openai.azure.com", endpoint.GetValue(),
+		"setup: Endpoint should be resolved")
 
 	config := ProviderConfig{
 		Keys: []schemas.Key{{
@@ -27,8 +27,7 @@ func TestProviderConfig_Redacted_AutoMasksEnvBackedFields(t *testing.T) {
 			Name:  "test",
 			Value: schemas.EnvVar{Val: ""},
 			AzureKeyConfig: &schemas.AzureKeyConfig{
-				Endpoint:   *schemas.NewEnvVar("https://foo.openai.azure.com"),
-				APIVersion: apiVersion,
+				Endpoint: *endpoint,
 			},
 		}},
 	}
@@ -37,10 +36,9 @@ func TestProviderConfig_Redacted_AutoMasksEnvBackedFields(t *testing.T) {
 	require.NotNil(t, redacted)
 	require.Len(t, redacted.Keys, 1)
 	require.NotNil(t, redacted.Keys[0].AzureKeyConfig)
-	require.NotNil(t, redacted.Keys[0].AzureKeyConfig.APIVersion)
 
-	// Marshal the APIVersion field as it would be sent to the UI.
-	data, err := json.Marshal(redacted.Keys[0].AzureKeyConfig.APIVersion)
+	// Marshal the Endpoint field as it would be sent to the UI.
+	data, err := json.Marshal(redacted.Keys[0].AzureKeyConfig.Endpoint)
 	require.NoError(t, err)
 
 	var out struct {
@@ -50,16 +48,16 @@ func TestProviderConfig_Redacted_AutoMasksEnvBackedFields(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
 
-	assert.NotContains(t, out.Value, "preview-secret",
-		"resolved env value leaked through APIVersion JSON output: %q", out.Value)
-	assert.Equal(t, "env.MY_AZURE_API_VERSION_SECRET", out.EnvVar,
+	assert.NotContains(t, out.Value, "secret-resource",
+		"resolved env value leaked through Endpoint JSON output: %q", out.Value)
+	assert.Equal(t, "env.MY_AZURE_ENDPOINT_SECRET", out.EnvVar,
 		"env var reference must be preserved so the UI can show it")
 	assert.True(t, out.FromEnv, "from_env flag must be preserved")
 }
 
 // TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields verifies that the
-// auto-redaction does NOT touch plain (non-env-backed) values. A user-typed
-// api_version like "2024-10-21" must show as-is in the UI.
+// auto-redaction does NOT touch plain (non-env-backed) values. A plain endpoint
+// URL must show as-is in the UI.
 func TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields(t *testing.T) {
 	config := ProviderConfig{
 		Keys: []schemas.Key{{
@@ -67,8 +65,7 @@ func TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields(t *testing.T) {
 			Name:  "test",
 			Value: schemas.EnvVar{Val: ""},
 			AzureKeyConfig: &schemas.AzureKeyConfig{
-				Endpoint:   *schemas.NewEnvVar("https://foo.openai.azure.com"),
-				APIVersion: schemas.NewEnvVar("2024-10-21"),
+				Endpoint: *schemas.NewEnvVar("https://foo.openai.azure.com"),
 			},
 		}},
 	}
@@ -77,9 +74,8 @@ func TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields(t *testing.T) {
 	require.NotNil(t, redacted)
 	require.Len(t, redacted.Keys, 1)
 	require.NotNil(t, redacted.Keys[0].AzureKeyConfig)
-	require.NotNil(t, redacted.Keys[0].AzureKeyConfig.APIVersion)
 
-	data, err := json.Marshal(redacted.Keys[0].AzureKeyConfig.APIVersion)
+	data, err := json.Marshal(redacted.Keys[0].AzureKeyConfig.Endpoint)
 	require.NoError(t, err)
 
 	var out struct {
@@ -88,8 +84,8 @@ func TestProviderConfig_Redacted_DoesNotMaskPlainNonSecretFields(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal(data, &out))
 
-	assert.Equal(t, "2024-10-21", out.Value,
-		"plain APIVersion was incorrectly redacted")
+	assert.Equal(t, "https://foo.openai.azure.com", out.Value,
+		"plain Endpoint was incorrectly redacted")
 	assert.False(t, out.FromEnv)
 }
 
@@ -164,7 +160,6 @@ func TestProviderConfig_Redacted_DoesNotMutateOriginal(t *testing.T) {
 // redacted JSON.
 func TestProviderConfig_Redacted_FullJSONHasNoLeakedEnvSecrets(t *testing.T) {
 	t.Setenv("LEAK_TEST_AZURE_ENDPOINT", "https://leaked-azure.example.com")
-	t.Setenv("LEAK_TEST_AZURE_APIVER", "leaked-api-version-string")
 	t.Setenv("LEAK_TEST_VERTEX_PROJECT", "leaked-vertex-project-id")
 	t.Setenv("LEAK_TEST_BEDROCK_ACCESS", "AKIAIOSFODNN7LEAKED1")
 	t.Setenv("LEAK_TEST_OPENAI_KEY", "sk-leaked-openai-key-1234567890")
@@ -181,8 +176,7 @@ func TestProviderConfig_Redacted_FullJSONHasNoLeakedEnvSecrets(t *testing.T) {
 				Name:  "azure",
 				Value: schemas.EnvVar{Val: ""},
 				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint:   *schemas.NewEnvVar("env.LEAK_TEST_AZURE_ENDPOINT"),
-					APIVersion: schemas.NewEnvVar("env.LEAK_TEST_AZURE_APIVER"),
+					Endpoint: *schemas.NewEnvVar("env.LEAK_TEST_AZURE_ENDPOINT"),
 				},
 			},
 			{
@@ -213,7 +207,6 @@ func TestProviderConfig_Redacted_FullJSONHasNoLeakedEnvSecrets(t *testing.T) {
 
 	leakedSecrets := []string{
 		"https://leaked-azure.example.com",
-		"leaked-api-version-string",
 		"leaked-vertex-project-id",
 		"AKIAIOSFODNN7LEAKED1",
 		"sk-leaked-openai-key-1234567890",
@@ -227,7 +220,6 @@ func TestProviderConfig_Redacted_FullJSONHasNoLeakedEnvSecrets(t *testing.T) {
 	expectedRefs := []string{
 		"env.LEAK_TEST_OPENAI_KEY",
 		"env.LEAK_TEST_AZURE_ENDPOINT",
-		"env.LEAK_TEST_AZURE_APIVER",
 		"env.LEAK_TEST_VERTEX_PROJECT",
 		"env.LEAK_TEST_BEDROCK_ACCESS",
 	}

--- a/framework/configstore/encryption_test.go
+++ b/framework/configstore/encryption_test.go
@@ -650,11 +650,11 @@ func TestEncryptPlaintextKeys_AzureFields_EncryptsAndDecryptsCorrectly(t *testin
 	now := time.Now().UTC().Format("2006-01-02 15:04:05")
 
 	insertPlaintextRow(t, db,
-		`INSERT INTO config_keys (name, provider_id, provider, key_id, value, azure_endpoint, azure_client_id, azure_client_secret, azure_tenant_id, azure_api_version, encryption_status, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'plain_text', ?, ?)`,
+		`INSERT INTO config_keys (name, provider_id, provider, key_id, value, azure_endpoint, azure_client_id, azure_client_secret, azure_tenant_id, encryption_status, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'plain_text', ?, ?)`,
 		"azure-key", 1, "azure", "az-1", "sk-azure-key-value",
 		"https://myresource.openai.azure.com", "my-azure-client-id", "azure-super-secret-client",
-		"my-azure-tenant-id", "2024-10-21", now, now)
+		"my-azure-tenant-id", now, now)
 
 	count, err := store.encryptPlaintextKeys(ctx)
 	require.NoError(t, err)
@@ -669,7 +669,6 @@ func TestEncryptPlaintextKeys_AzureFields_EncryptsAndDecryptsCorrectly(t *testin
 	assert.NotEqual(t, "my-azure-client-id", raw["azure_client_id"])
 	assert.NotEqual(t, "azure-super-secret-client", raw["azure_client_secret"])
 	assert.NotEqual(t, "my-azure-tenant-id", raw["azure_tenant_id"])
-	assert.NotEqual(t, "2024-10-21", raw["azure_api_version"])
 
 	// GORM hooks should decrypt and reconstruct AzureKeyConfig
 	var found tables.TableKey
@@ -683,8 +682,6 @@ func TestEncryptPlaintextKeys_AzureFields_EncryptsAndDecryptsCorrectly(t *testin
 	assert.Equal(t, "azure-super-secret-client", found.AzureKeyConfig.ClientSecret.GetValue())
 	require.NotNil(t, found.AzureKeyConfig.TenantID)
 	assert.Equal(t, "my-azure-tenant-id", found.AzureKeyConfig.TenantID.GetValue())
-	require.NotNil(t, found.AzureKeyConfig.APIVersion)
-	assert.Equal(t, "2024-10-21", found.AzureKeyConfig.APIVersion.GetValue())
 }
 
 func TestEncryptPlaintextKeys_VertexFields_EncryptsAndDecryptsCorrectly(t *testing.T) {
@@ -854,10 +851,9 @@ func TestBeforeSave_DoesNotMutateSharedProviderConfigs(t *testing.T) {
 	// save it to DB, and verify the original config structs are not mutated by BeforeSave
 	// (encryption uses value-copies so shared pointers are never corrupted).
 	azureCfg := &schemas.AzureKeyConfig{
-		Endpoint:   *schemas.NewEnvVar("https://myresource.openai.azure.com"),
-		APIVersion: schemas.NewEnvVar("2024-10-21"),
-		ClientID:   schemas.NewEnvVar("my-azure-client-id"),
-		TenantID:   schemas.NewEnvVar("my-azure-tenant-id"),
+		Endpoint: *schemas.NewEnvVar("https://myresource.openai.azure.com"),
+		ClientID: schemas.NewEnvVar("my-azure-client-id"),
+		TenantID: schemas.NewEnvVar("my-azure-tenant-id"),
 	}
 	azureCfg.ClientSecret = schemas.NewEnvVar("azure-client-secret")
 
@@ -898,8 +894,6 @@ func TestBeforeSave_DoesNotMutateSharedProviderConfigs(t *testing.T) {
 		"BeforeSave must not mutate shared AzureKeyConfig.Endpoint")
 	assert.Equal(t, "azure-client-secret", azureCfg.ClientSecret.GetValue(),
 		"BeforeSave must not mutate shared AzureKeyConfig.ClientSecret")
-	assert.Equal(t, "2024-10-21", azureCfg.APIVersion.GetValue(),
-		"BeforeSave must not mutate shared AzureKeyConfig.APIVersion")
 	assert.Equal(t, "my-azure-client-id", azureCfg.ClientID.GetValue(),
 		"BeforeSave must not mutate shared AzureKeyConfig.ClientID")
 	assert.Equal(t, "my-azure-tenant-id", azureCfg.TenantID.GetValue(),
@@ -934,7 +928,6 @@ func TestBeforeSave_DoesNotMutateSharedProviderConfigs(t *testing.T) {
 	require.NotNil(t, found.AzureKeyConfig)
 	assert.Equal(t, "https://myresource.openai.azure.com", found.AzureKeyConfig.Endpoint.GetValue())
 	assert.Equal(t, "azure-client-secret", found.AzureKeyConfig.ClientSecret.GetValue())
-	assert.Equal(t, "2024-10-21", found.AzureKeyConfig.APIVersion.GetValue())
 	assert.Equal(t, "my-azure-client-id", found.AzureKeyConfig.ClientID.GetValue())
 	assert.Equal(t, "my-azure-tenant-id", found.AzureKeyConfig.TenantID.GetValue())
 	require.NotNil(t, found.VertexKeyConfig)
@@ -961,7 +954,6 @@ func TestBeforeSave_EnvVarBackedFields_NotEncrypted(t *testing.T) {
 	t.Setenv("TEST_AZURE_KEY", "sk-azure-from-env")
 	t.Setenv("TEST_AZURE_ENDPOINT", "https://env-resource.openai.azure.com")
 	t.Setenv("TEST_AZURE_SECRET", "env-azure-client-secret")
-	t.Setenv("TEST_AZURE_API_VER", "2024-10-21")
 	t.Setenv("TEST_AZURE_CLIENT_ID", "env-azure-client-id")
 	t.Setenv("TEST_AZURE_TENANT_ID", "env-azure-tenant-id")
 	t.Setenv("TEST_VERTEX_PROJECT", "env-vertex-project")
@@ -976,7 +968,6 @@ func TestBeforeSave_EnvVarBackedFields_NotEncrypted(t *testing.T) {
 	// Create EnvVars backed by environment variables
 	azureCfg := &schemas.AzureKeyConfig{
 		Endpoint:     *schemas.NewEnvVar("env.TEST_AZURE_ENDPOINT"),
-		APIVersion:   schemas.NewEnvVar("env.TEST_AZURE_API_VER"),
 		ClientID:     schemas.NewEnvVar("env.TEST_AZURE_CLIENT_ID"),
 		ClientSecret: schemas.NewEnvVar("env.TEST_AZURE_SECRET"),
 		TenantID:     schemas.NewEnvVar("env.TEST_AZURE_TENANT_ID"),
@@ -1048,8 +1039,6 @@ func TestBeforeSave_EnvVarBackedFields_NotEncrypted(t *testing.T) {
 	assert.True(t, found.AzureKeyConfig.Endpoint.IsFromEnv())
 	assert.Equal(t, "env-azure-client-secret", found.AzureKeyConfig.ClientSecret.GetValue())
 	assert.True(t, found.AzureKeyConfig.ClientSecret.IsFromEnv())
-	assert.Equal(t, "2024-10-21", found.AzureKeyConfig.APIVersion.GetValue())
-	assert.True(t, found.AzureKeyConfig.APIVersion.IsFromEnv())
 	assert.Equal(t, "env-azure-client-id", found.AzureKeyConfig.ClientID.GetValue())
 	assert.True(t, found.AzureKeyConfig.ClientID.IsFromEnv())
 	assert.Equal(t, "env-azure-tenant-id", found.AzureKeyConfig.TenantID.GetValue())

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -801,6 +801,9 @@ func triggerMigrations(ctx context.Context, db *gorm.DB) error {
 	if err := migrationRefreshConfigHashAfterMCPExternalServerURLRemoval(ctx, db); err != nil {
 		return err
 	}
+	if err := migrationDropAzureAPIVersionColumn(ctx, db); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -5130,9 +5133,16 @@ func migrationWidenEncryptedVarcharColumns(ctx context.Context, db *gorm.DB) err
 			if tx.Dialector.Name() != "postgres" {
 				return nil
 			}
+			// azure_api_version was removed in v1 API migration; only widen it if it
+			// still exists (existing DBs that haven't run the drop migration yet).
+			if tx.Migrator().HasColumn(&tables.TableKey{}, "azure_api_version") {
+				if err := tx.Exec("ALTER TABLE config_keys ALTER COLUMN azure_api_version TYPE TEXT").Error; err != nil {
+					return fmt.Errorf("failed to widen column azure_api_version: %w", err)
+				}
+			}
+
 			stmts := []string{
 				// config_keys table - all encrypted EnvVar fields
-				"ALTER TABLE config_keys ALTER COLUMN azure_api_version TYPE TEXT",
 				"ALTER TABLE config_keys ALTER COLUMN azure_client_id TYPE TEXT",
 				"ALTER TABLE config_keys ALTER COLUMN azure_tenant_id TYPE TEXT",
 				"ALTER TABLE config_keys ALTER COLUMN vertex_project_id TYPE TEXT",
@@ -8674,6 +8684,35 @@ func migrationAddCreatedByUserIDColumnForVirtualKeys(ctx context.Context, db *go
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running add_created_by_user_id_column_for_virtual_keys migration: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddCreatedByUserIDColumnForVirtualKeys adds the created_by_user_id column to the governance_virtual_keys table.
+func migrationDropAzureAPIVersionColumn(ctx context.Context, db *gorm.DB) error {
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: "drop_azure_api_version_column",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if tx.Migrator().HasColumn(&tables.TableKey{}, "azure_api_version") {
+				if err := tx.Exec("ALTER TABLE config_keys DROP COLUMN azure_api_version").Error; err != nil {
+					return fmt.Errorf("failed to drop azure_api_version column: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if !tx.Migrator().HasColumn(&tables.TableKey{}, "azure_api_version") {
+				if err := tx.Exec("ALTER TABLE config_keys ADD COLUMN azure_api_version TEXT").Error; err != nil {
+					return fmt.Errorf("failed to re-add azure_api_version column: %w", err)
+				}
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error running drop_azure_api_version_column migration: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -175,7 +175,6 @@ func tableKeyFromSchemaKey(provider tables.TableProvider, key schemas.Key) (tabl
 
 	if key.AzureKeyConfig != nil {
 		dbKey.AzureEndpoint = &key.AzureKeyConfig.Endpoint
-		dbKey.AzureAPIVersion = key.AzureKeyConfig.APIVersion
 	}
 
 	if key.VertexKeyConfig != nil {
@@ -698,8 +697,7 @@ func (s *RDBConfigStore) UpdateProvidersConfig(ctx context.Context, providers ma
 			// Handle Azure config
 			if key.AzureKeyConfig != nil {
 				dbKey.AzureEndpoint = &key.AzureKeyConfig.Endpoint
-				dbKey.AzureAPIVersion = key.AzureKeyConfig.APIVersion
-			}
+				}
 
 			// Handle Vertex config
 			if key.VertexKeyConfig != nil {
@@ -927,7 +925,6 @@ func (s *RDBConfigStore) UpdateProvider(ctx context.Context, provider schemas.Mo
 		// Handle Azure config
 		if key.AzureKeyConfig != nil {
 			dbKey.AzureEndpoint = &key.AzureKeyConfig.Endpoint
-			dbKey.AzureAPIVersion = key.AzureKeyConfig.APIVersion
 		}
 
 		// Handle Vertex config
@@ -1066,7 +1063,6 @@ func (s *RDBConfigStore) AddProvider(ctx context.Context, provider schemas.Model
 		// Handle Azure config
 		if key.AzureKeyConfig != nil {
 			dbKey.AzureEndpoint = &key.AzureKeyConfig.Endpoint
-			dbKey.AzureAPIVersion = key.AzureKeyConfig.APIVersion
 		}
 		// Handle Vertex config
 		if key.VertexKeyConfig != nil {

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -96,7 +96,6 @@ func TestTableKey_AzureFieldsEncryptDecrypt(t *testing.T) {
 
 	endpoint := schemas.NewEnvVar("https://my-azure.openai.azure.com")
 	clientSecret := schemas.NewEnvVar("azure-secret-123")
-	apiVersion := schemas.NewEnvVar("2024-10-21")
 
 	key := &TableKey{
 		Name:       "azure-key",
@@ -109,7 +108,6 @@ func TestTableKey_AzureFieldsEncryptDecrypt(t *testing.T) {
 			ClientID:     schemas.NewEnvVar("azure-client-id-123"),
 			ClientSecret: clientSecret,
 			TenantID:     schemas.NewEnvVar("azure-tenant-id-456"),
-			APIVersion:   apiVersion,
 		},
 	}
 
@@ -122,7 +120,6 @@ func TestTableKey_AzureFieldsEncryptDecrypt(t *testing.T) {
 	assert.NotEqual(t, "azure-client-id-123", raw["azure_client_id"])
 	assert.NotEqual(t, "azure-secret-123", raw["azure_client_secret"])
 	assert.NotEqual(t, "azure-tenant-id-456", raw["azure_tenant_id"])
-	assert.NotEqual(t, "2024-10-21", raw["azure_api_version"])
 
 	// Verify reading back decrypts and reconstructs AzureKeyConfig
 	var found TableKey
@@ -135,8 +132,6 @@ func TestTableKey_AzureFieldsEncryptDecrypt(t *testing.T) {
 	assert.Equal(t, "azure-secret-123", found.AzureKeyConfig.ClientSecret.GetValue())
 	require.NotNil(t, found.AzureKeyConfig.TenantID)
 	assert.Equal(t, "azure-tenant-id-456", found.AzureKeyConfig.TenantID.GetValue())
-	require.NotNil(t, found.AzureKeyConfig.APIVersion)
-	assert.Equal(t, "2024-10-21", found.AzureKeyConfig.APIVersion.GetValue())
 }
 
 func TestTableKey_VertexFieldsEncryptDecrypt(t *testing.T) {
@@ -1167,7 +1162,6 @@ func TestTableKey_AllProviderConfigs_EncryptDecrypt(t *testing.T) {
 			ClientID:     schemas.NewEnvVar("multi-azure-cid"),
 			ClientSecret: schemas.NewEnvVar("azure-cs"),
 			TenantID:     schemas.NewEnvVar("multi-azure-tid"),
-			APIVersion:   schemas.NewEnvVar("2024-10-21"),
 		},
 		VertexKeyConfig: &schemas.VertexKeyConfig{
 			AuthCredentials: *schemas.NewEnvVar(`{"type":"sa"}`),
@@ -1191,7 +1185,6 @@ func TestTableKey_AllProviderConfigs_EncryptDecrypt(t *testing.T) {
 	assert.Equal(t, "encrypted", raw["encryption_status"])
 	assert.NotEqual(t, "multi-azure-cid", raw["azure_client_id"])
 	assert.NotEqual(t, "multi-azure-tid", raw["azure_tenant_id"])
-	assert.NotEqual(t, "2024-10-21", raw["azure_api_version"])
 	assert.NotEqual(t, "proj-123", raw["vertex_project_id"])
 	assert.NotEqual(t, "987654321", raw["vertex_project_number"])
 	assert.NotEqual(t, "us-central1", raw["vertex_region"])
@@ -1221,8 +1214,6 @@ func TestTableKey_AllProviderConfigs_EncryptDecrypt(t *testing.T) {
 	assert.Equal(t, "azure-cs", found.AzureKeyConfig.ClientSecret.GetValue())
 	require.NotNil(t, found.AzureKeyConfig.TenantID)
 	assert.Equal(t, "multi-azure-tid", found.AzureKeyConfig.TenantID.GetValue())
-	require.NotNil(t, found.AzureKeyConfig.APIVersion)
-	assert.Equal(t, "2024-10-21", found.AzureKeyConfig.APIVersion.GetValue())
 
 	require.NotNil(t, found.VertexKeyConfig)
 	assert.Equal(t, `{"type":"sa"}`, found.VertexKeyConfig.AuthCredentials.GetValue())
@@ -1610,36 +1601,7 @@ func forEachDB(t *testing.T) []namedDB {
 // ============================================================================
 
 func TestEncryptedColumns_AzureAPIVersion_FitsAfterWidening(t *testing.T) {
-	// "2024-02-01-preview" is 18 chars — encrypts to ~62 chars.
-	// This overflowed the old varchar(50) column.
-	apiVersion := schemas.NewEnvVar("2024-02-01-preview")
-
-	for _, ndb := range forEachDB(t) {
-		ndb := ndb
-		t.Run(ndb.name, func(t *testing.T) {
-			providerID := createTestProvider(t, ndb.db, "azure-av-provider-"+ndb.name)
-			key := &TableKey{
-				Name:       "azure-apiversion-width-" + ndb.name,
-				ProviderID: providerID,
-				Provider:   "azure",
-				KeyID:      "az-av-width-" + ndb.name,
-				Value:      *schemas.NewEnvVar("sk-azure-key"),
-				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint:   *schemas.NewEnvVar("https://my-azure.openai.azure.com"),
-					APIVersion: apiVersion,
-				},
-			}
-
-			require.NoError(t, ndb.db.Create(key).Error,
-				"expected no overflow error — azure_api_version should be text")
-
-			var found TableKey
-			require.NoError(t, ndb.db.First(&found, key.ID).Error)
-			require.NotNil(t, found.AzureKeyConfig)
-			require.NotNil(t, found.AzureKeyConfig.APIVersion)
-			assert.Equal(t, "2024-02-01-preview", found.AzureKeyConfig.APIVersion.GetValue())
-		})
-	}
+	t.Skip("azure_api_version column has been removed from AzureKeyConfig")
 }
 
 func TestEncryptedColumns_VertexRegion_FitsAfterWidening(t *testing.T) {
@@ -1717,7 +1679,7 @@ func TestPostgres_EncryptedColumns_AreText(t *testing.T) {
 		DataType string `gorm:"column:data_type"`
 	}
 
-	columns := []string{"azure_api_version", "vertex_region", "bedrock_region"}
+	columns := []string{"vertex_region", "bedrock_region"}
 	for _, col := range columns {
 		col := col
 		t.Run(col, func(t *testing.T) {
@@ -1822,37 +1784,6 @@ func TestTableKey_AzureUnresolvedEnvVar_RoundTrip(t *testing.T) {
 		"env var reference for Endpoint lost on round-trip")
 	assert.True(t, found.AzureKeyConfig.Endpoint.FromEnv,
 		"FromEnv flag for Endpoint lost on round-trip")
-}
-
-// TestTableKey_AzureOnlyApiVersion_AfterFindReconstructs verifies that AzureKeyConfig
-// is reconstructed from the DB even when ONLY a non-endpoint Azure field is set.
-// Before the fix, AfterFind only checked AzureEndpoint != nil and would silently drop
-// the entire Azure config when only api_version (or any other Azure field) was present.
-func TestTableKey_AzureOnlyApiVersion_AfterFindReconstructs(t *testing.T) {
-	db := setupTestDB(t)
-
-	apiVersion := schemas.NewEnvVar("2024-10-21")
-	key := &TableKey{
-		Name:       "azure-only-apiversion",
-		ProviderID: 1,
-		Provider:   "azure",
-		KeyID:      "azure-apiver-uuid-1",
-		Value:      *schemas.NewEnvVar(""),
-		AzureKeyConfig: &schemas.AzureKeyConfig{
-			// No endpoint, no client id — only api_version.
-			APIVersion: apiVersion,
-		},
-	}
-
-	require.NoError(t, db.Create(key).Error)
-
-	var found TableKey
-	require.NoError(t, db.First(&found, key.ID).Error)
-
-	require.NotNil(t, found.AzureKeyConfig,
-		"AzureKeyConfig should be reconstructed when only api_version is present")
-	require.NotNil(t, found.AzureKeyConfig.APIVersion)
-	assert.Equal(t, "2024-10-21", found.AzureKeyConfig.APIVersion.GetValue())
 }
 
 // TestTableKey_BedrockUnresolvedEnvVar_RoundTrip verifies the same property for

--- a/framework/configstore/tables/key.go
+++ b/framework/configstore/tables/key.go
@@ -34,7 +34,6 @@ type TableKey struct {
 
 	// Azure config fields (embedded instead of separate table for simplicity)
 	AzureEndpoint     *schemas.EnvVar `gorm:"type:text" json:"azure_endpoint,omitempty"`
-	AzureAPIVersion   *schemas.EnvVar `gorm:"type:text" json:"azure_api_version,omitempty"`
 	AzureClientID     *schemas.EnvVar `gorm:"type:text" json:"azure_client_id,omitempty"`
 	AzureClientSecret *schemas.EnvVar `gorm:"type:text" json:"azure_client_secret,omitempty"`
 	AzureTenantID     *schemas.EnvVar `gorm:"type:text" json:"azure_tenant_id,omitempty"`
@@ -136,12 +135,6 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		} else {
 			k.AzureEndpoint = nil
 		}
-		if k.AzureKeyConfig.APIVersion != nil {
-			av := *k.AzureKeyConfig.APIVersion
-			k.AzureAPIVersion = &av
-		} else {
-			k.AzureAPIVersion = nil
-		}
 		if k.AzureKeyConfig.ClientID != nil {
 			cid := *k.AzureKeyConfig.ClientID
 			k.AzureClientID = &cid
@@ -172,7 +165,6 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		}
 	} else {
 		k.AzureEndpoint = nil
-		k.AzureAPIVersion = nil
 		k.AzureClientID = nil
 		k.AzureClientSecret = nil
 		k.AzureTenantID = nil
@@ -354,9 +346,6 @@ func (k *TableKey) BeforeSave(tx *gorm.DB) error {
 		if err := encryptEnvVarPtr(&k.AzureTenantID); err != nil {
 			return fmt.Errorf("failed to encrypt azure tenant id: %w", err)
 		}
-		if err := encryptEnvVarPtr(&k.AzureAPIVersion); err != nil {
-			return fmt.Errorf("failed to encrypt azure api version: %w", err)
-		}
 		// Vertex
 		if err := encryptEnvVarPtr(&k.VertexProjectID); err != nil {
 			return fmt.Errorf("failed to encrypt vertex project id: %w", err)
@@ -441,9 +430,6 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		if err := decryptEnvVarPtr(&k.AzureTenantID); err != nil {
 			return fmt.Errorf("failed to decrypt azure tenant id: %w", err)
 		}
-		if err := decryptEnvVarPtr(&k.AzureAPIVersion); err != nil {
-			return fmt.Errorf("failed to decrypt azure api version: %w", err)
-		}
 		// Vertex
 		if err := decryptEnvVarPtr(&k.VertexProjectID); err != nil {
 			return fmt.Errorf("failed to decrypt vertex project id: %w", err)
@@ -522,7 +508,7 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		k.UseForBatchAPI = &useForBatchAPI
 	}
 	// Reconstruct Azure config if fields are present
-	if k.AzureEndpoint != nil || k.AzureAPIVersion != nil || k.AzureClientID != nil || k.AzureClientSecret != nil || k.AzureTenantID != nil || (k.AzureScopesJSON != nil && *k.AzureScopesJSON != "") {
+	if k.AzureEndpoint != nil || k.AzureClientID != nil || k.AzureClientSecret != nil || k.AzureTenantID != nil || (k.AzureScopesJSON != nil && *k.AzureScopesJSON != "") {
 		var scopes []string
 		if k.AzureScopesJSON != nil && *k.AzureScopesJSON != "" {
 			if err := json.Unmarshal([]byte(*k.AzureScopesJSON), &scopes); err != nil {
@@ -531,7 +517,6 @@ func (k *TableKey) AfterFind(tx *gorm.DB) error {
 		}
 		azureConfig := &schemas.AzureKeyConfig{
 			Endpoint:     *schemas.NewEnvVar(""),
-			APIVersion:   k.AzureAPIVersion,
 			ClientID:     k.AzureClientID,
 			ClientSecret: k.AzureClientSecret,
 			TenantID:     k.AzureTenantID,

--- a/framework/configstore/tables/virtualkey.go
+++ b/framework/configstore/tables/virtualkey.go
@@ -126,7 +126,6 @@ func (pc *TableVirtualKeyProviderConfig) AfterFind(tx *gorm.DB) error {
 
 			// Clear all Azure-related sensitive fields
 			key.AzureEndpoint = nil
-			key.AzureAPIVersion = nil
 			key.AzureClientID = nil
 			key.AzureClientSecret = nil
 			key.AzureTenantID = nil

--- a/transports/bifrost-http/handlers/provider_keys.go
+++ b/transports/bifrost-http/handlers/provider_keys.go
@@ -326,13 +326,6 @@ func (h *ProviderHandler) mergeUpdatedKey(oldRawKey, oldRedactedKey, updateKey s
 			updateKey.AzureKeyConfig.Endpoint.Equals(&oldRedactedKey.AzureKeyConfig.Endpoint) {
 			mergedKey.AzureKeyConfig.Endpoint = oldRawKey.AzureKeyConfig.Endpoint
 		}
-		if updateKey.AzureKeyConfig.APIVersion != nil &&
-			oldRedactedKey.AzureKeyConfig.APIVersion != nil &&
-			oldRawKey.AzureKeyConfig != nil &&
-			updateKey.AzureKeyConfig.APIVersion.IsRedacted() &&
-			updateKey.AzureKeyConfig.APIVersion.Equals(oldRedactedKey.AzureKeyConfig.APIVersion) {
-			mergedKey.AzureKeyConfig.APIVersion = oldRawKey.AzureKeyConfig.APIVersion
-		}
 		if updateKey.AzureKeyConfig.ClientID != nil &&
 			oldRedactedKey.AzureKeyConfig.ClientID != nil &&
 			oldRawKey.AzureKeyConfig != nil &&

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -337,7 +337,7 @@ EXPECTED BEHAVIORS SUMMARY
    - Both fields are included in key hash for change detection
 
 5. PROVIDER-SPECIFIC CONFIGS:
-   - Azure: Endpoint, APIVersion, Deployments in AzureKeyConfig
+   - Azure: Endpoint, Deployments in AzureKeyConfig
    - Bedrock: Region, AuthCredentials, Deployments in BedrockKeyConfig
    - Vertex: ProjectID, Region, AuthCredentials, Deployments in VertexKeyConfig
    - All fields including Deployments maps affect key hash and must sync correctly
@@ -2494,7 +2494,6 @@ func TestGenerateKeyHash(t *testing.T) {
 	}
 
 	// AzureKeyConfig should produce different hash
-	apiVersion := "2024-10-21"
 	key6 := schemas.Key{
 		ID:     "key-1",
 		Name:   "test-key",
@@ -2502,8 +2501,7 @@ func TestGenerateKeyHash(t *testing.T) {
 		Models: []string{"gpt-4", "gpt-3.5-turbo"},
 		Weight: 1.5,
 		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint:   *schemas.NewEnvVar("https://my-azure.openai.azure.com"),
-			APIVersion: schemas.NewEnvVar(apiVersion),
+			Endpoint: *schemas.NewEnvVar("https://my-azure.openai.azure.com"),
 		},
 	}
 
@@ -2524,8 +2522,7 @@ func TestGenerateKeyHash(t *testing.T) {
 		Models: []string{"gpt-4", "gpt-3.5-turbo"},
 		Weight: 1.5,
 		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint:   *schemas.NewEnvVar("https://different-azure.openai.azure.com"), // Different endpoint
-			APIVersion: schemas.NewEnvVar(apiVersion),
+			Endpoint: *schemas.NewEnvVar("https://different-azure.openai.azure.com"), // Different endpoint
 		},
 	}
 
@@ -3190,8 +3187,7 @@ func TestKeyHashComparison_OptionalFieldsPresence(t *testing.T) {
 		Value:  *schemas.NewEnvVar("sk-123"),
 		Weight: 1,
 		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-			APIVersion: schemas.NewEnvVar("2024-02-01"),
+			Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 		},
 	}
 
@@ -3497,8 +3493,7 @@ func TestKeyHashComparison_FieldRemoved(t *testing.T) {
 		Models: []string{"gpt-4", "gpt-3.5-turbo"},
 		Weight: 1.5,
 		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-			APIVersion: schemas.NewEnvVar("2024-02-01"),
+			Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 		},
 	}
 
@@ -3512,8 +3507,7 @@ func TestKeyHashComparison_FieldRemoved(t *testing.T) {
 		// Models: nil (removed)
 		Weight: 1.5,
 		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-			APIVersion: schemas.NewEnvVar("2024-02-01"),
+			Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 		},
 	}
 
@@ -3547,8 +3541,7 @@ func TestKeyHashComparison_FieldRemoved(t *testing.T) {
 		Models: []string{"gpt-4", "gpt-3.5-turbo"},
 		Weight: 1.0, // Changed from 1.5
 		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-			APIVersion: schemas.NewEnvVar("2024-02-01"),
+			Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 		},
 	}
 
@@ -3566,8 +3559,7 @@ func TestKeyHashComparison_FieldRemoved(t *testing.T) {
 		Models: []string{"gpt-4"}, // gpt-3.5-turbo removed
 		Weight: 1.5,
 		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-			APIVersion: schemas.NewEnvVar("2024-02-01"),
+			Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 		},
 	}
 
@@ -3585,8 +3577,7 @@ func TestKeyHashComparison_FieldRemoved(t *testing.T) {
 		Models: []string{"gpt-4", "gpt-3.5-turbo"},
 		Weight: 1.5,
 		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint:   *schemas.NewEnvVar("https://different.openai.azure.com"), // Changed
-			APIVersion: schemas.NewEnvVar("2024-02-01"),
+			Endpoint: *schemas.NewEnvVar("https://different.openai.azure.com"), // Changed
 		},
 	}
 
@@ -3596,24 +3587,6 @@ func TestKeyHashComparison_FieldRemoved(t *testing.T) {
 		t.Error("Expected different hash when Azure endpoint is changed")
 	}
 
-	// Azure APIVersion removed
-	keyNoAPIVersion := schemas.Key{
-		ID:     "key-1",
-		Name:   "test-key",
-		Value:  *schemas.NewEnvVar("sk-123"),
-		Models: []string{"gpt-4", "gpt-3.5-turbo"},
-		Weight: 1.5,
-		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-			// APIVersion: nil (removed)
-		},
-	}
-
-	hashNoAPIVersion, _ := configstore.GenerateKeyHash(keyNoAPIVersion)
-
-	if originalHash == hashNoAPIVersion {
-		t.Error("Expected different hash when Azure APIVersion is removed")
-	}
 }
 
 // TestProviderHashComparison_PartialFieldChanges tests partial changes within nested structs
@@ -5006,8 +4979,7 @@ func TestKeyHashComparison_AzureConfigSyncScenarios(t *testing.T) {
 			Weight:  1,
 			Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
 			AzureKeyConfig: &schemas.AzureKeyConfig{
-				Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-				APIVersion: schemas.NewEnvVar("2024-02-01"),
+				Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 			},
 		}
 
@@ -5018,8 +4990,7 @@ func TestKeyHashComparison_AzureConfigSyncScenarios(t *testing.T) {
 			Weight:  1,
 			Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
 			AzureKeyConfig: &schemas.AzureKeyConfig{
-				Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-				APIVersion: schemas.NewEnvVar("2024-02-01"),
+				Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 			},
 		}
 
@@ -5041,8 +5012,7 @@ func TestKeyHashComparison_AzureConfigSyncScenarios(t *testing.T) {
 			Weight:  1,
 			Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
 			AzureKeyConfig: &schemas.AzureKeyConfig{
-				Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-				APIVersion: schemas.NewEnvVar("2024-02-01"),
+				Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 			},
 		}
 
@@ -5053,8 +5023,7 @@ func TestKeyHashComparison_AzureConfigSyncScenarios(t *testing.T) {
 			Weight:  1,
 			Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
 			AzureKeyConfig: &schemas.AzureKeyConfig{
-				Endpoint:   *schemas.NewEnvVar("https://different-azure.openai.azure.com"), // Changed!
-				APIVersion: schemas.NewEnvVar("2024-02-01"),
+				Endpoint: *schemas.NewEnvVar("https://different-azure.openai.azure.com"), // Changed!
 			},
 		}
 
@@ -5065,41 +5034,6 @@ func TestKeyHashComparison_AzureConfigSyncScenarios(t *testing.T) {
 			t.Error("Expected different hash when Azure endpoint changes")
 		}
 		t.Log("✓ Different Azure endpoint produces different hash - update triggered")
-	})
-
-	// === Scenario 3: Azure config in DB + different APIVersion in file -> hash differs ===
-	t.Run("DifferentAPIVersion_UpdateTriggered", func(t *testing.T) {
-		dbKey := schemas.Key{
-			ID:      "key-1",
-			Name:    "azure-key",
-			Value:   *schemas.NewEnvVar("azure-api-key-123"),
-			Weight:  1,
-			Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
-			AzureKeyConfig: &schemas.AzureKeyConfig{
-				Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-				APIVersion: schemas.NewEnvVar("2024-02-01"),
-			},
-		}
-
-		fileKey := schemas.Key{
-			ID:      "key-1",
-			Name:    "azure-key",
-			Value:   *schemas.NewEnvVar("azure-api-key-123"),
-			Weight:  1,
-			Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
-			AzureKeyConfig: &schemas.AzureKeyConfig{
-				Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-				APIVersion: schemas.NewEnvVar("2024-10-21"), // Changed!
-			},
-		}
-
-		dbHash, _ := configstore.GenerateKeyHash(dbKey)
-		fileHash, _ := configstore.GenerateKeyHash(fileKey)
-
-		if dbHash == fileHash {
-			t.Error("Expected different hash when Azure APIVersion changes")
-		}
-		t.Log("✓ Different Azure APIVersion produces different hash - update triggered")
 	})
 
 	// === Scenario 4: Azure config in DB + different Deployments map in file -> hash differs ===
@@ -5153,8 +5087,7 @@ func TestKeyHashComparison_AzureConfigSyncScenarios(t *testing.T) {
 			Value:  *schemas.NewEnvVar("azure-api-key-123"),
 			Weight: 1,
 			AzureKeyConfig: &schemas.AzureKeyConfig{
-				Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-				APIVersion: schemas.NewEnvVar("2024-02-01"),
+				Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 			},
 		}
 
@@ -5176,8 +5109,7 @@ func TestKeyHashComparison_AzureConfigSyncScenarios(t *testing.T) {
 			Value:  *schemas.NewEnvVar("azure-api-key-123"),
 			Weight: 1,
 			AzureKeyConfig: &schemas.AzureKeyConfig{
-				Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-				APIVersion: schemas.NewEnvVar("2024-02-01"),
+				Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 			},
 		}
 
@@ -5199,40 +5131,6 @@ func TestKeyHashComparison_AzureConfigSyncScenarios(t *testing.T) {
 		t.Log("✓ Azure config removed produces different hash - update triggered")
 	})
 
-	// === Scenario 7: APIVersion nil vs set -> hash differs ===
-	t.Run("APIVersionNilVsSet_UpdateTriggered", func(t *testing.T) {
-		dbKey := schemas.Key{
-			ID:      "key-1",
-			Name:    "azure-key",
-			Value:   *schemas.NewEnvVar("azure-api-key-123"),
-			Weight:  1,
-			Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
-			AzureKeyConfig: &schemas.AzureKeyConfig{
-				Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-				// APIVersion is nil (will use default)
-			},
-		}
-
-		fileKey := schemas.Key{
-			ID:      "key-1",
-			Name:    "azure-key",
-			Value:   *schemas.NewEnvVar("azure-api-key-123"),
-			Weight:  1,
-			Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
-			AzureKeyConfig: &schemas.AzureKeyConfig{
-				Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-				APIVersion: schemas.NewEnvVar("2024-02-01"), // Explicitly set
-			},
-		}
-
-		dbHash, _ := configstore.GenerateKeyHash(dbKey)
-		fileHash, _ := configstore.GenerateKeyHash(fileKey)
-
-		if dbHash == fileHash {
-			t.Error("Expected different hash when APIVersion goes from nil to set")
-		}
-		t.Log("✓ APIVersion nil vs set produces different hash - update triggered")
-	})
 }
 
 // TestKeyHashComparison_BedrockConfigSyncScenarios tests full lifecycle for Bedrock key configs
@@ -5616,8 +5514,7 @@ func TestProviderHashComparison_AzureProviderFullLifecycle(t *testing.T) {
 		Weight:  1,
 		Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
 		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-			APIVersion: schemas.NewEnvVar("2024-02-01"),
+			Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 		},
 	}
 
@@ -5651,8 +5548,7 @@ func TestProviderHashComparison_AzureProviderFullLifecycle(t *testing.T) {
 		Weight:  1,
 		Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
 		AzureKeyConfig: &schemas.AzureKeyConfig{
-			Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-			APIVersion: schemas.NewEnvVar("2024-02-01"),
+			Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 		},
 	}
 
@@ -5684,8 +5580,7 @@ func TestProviderHashComparison_AzureProviderFullLifecycle(t *testing.T) {
 				Weight:  1,
 				Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
 				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-					APIVersion: schemas.NewEnvVar("2024-02-01"),
+					Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 				},
 			},
 		},
@@ -5721,8 +5616,7 @@ func TestProviderHashComparison_AzureProviderFullLifecycle(t *testing.T) {
 				Weight:  1,
 				Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment", "gpt-4o": "gpt-4o-deployment"},
 				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint:   *schemas.NewEnvVar("https://new-azure.openai.azure.com"), // Changed!
-					APIVersion: schemas.NewEnvVar("2024-10-21"),                          // Changed!
+					Endpoint: *schemas.NewEnvVar("https://new-azure.openai.azure.com"), // Changed!
 				},
 			},
 		},
@@ -5810,9 +5704,6 @@ func TestProviderHashComparison_AzureProviderFullLifecycle(t *testing.T) {
 	}
 	if finalConfig.Keys[0].AzureKeyConfig.Endpoint.GetValue() != "https://new-azure.openai.azure.com" {
 		t.Errorf("Expected updated Azure endpoint, got %s", finalConfig.Keys[0].AzureKeyConfig.Endpoint.GetValue())
-	}
-	if finalConfig.Keys[0].AzureKeyConfig.APIVersion.GetValue() != "2024-10-21" {
-		t.Errorf("Expected updated APIVersion, got %s", finalConfig.Keys[0].AzureKeyConfig.APIVersion.GetValue())
 	}
 	if len(finalConfig.Keys[0].Aliases) != 2 {
 		t.Errorf("Expected 2 deployments, got %d", len(finalConfig.Keys[0].Aliases))
@@ -6103,8 +5994,7 @@ func TestProviderHashComparison_AzureNewProviderFromConfig(t *testing.T) {
 				Weight:  1,
 				Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
 				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-					APIVersion: schemas.NewEnvVar("2024-02-01"),
+					Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 				},
 			},
 		},
@@ -6239,8 +6129,7 @@ func TestProviderHashComparison_AzureDBValuePreservedWhenHashMatches(t *testing.
 				Weight:  1,
 				Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
 				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"),
-					APIVersion: schemas.NewEnvVar("2024-02-01"),
+					Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"),
 				},
 			},
 		},
@@ -6268,8 +6157,7 @@ func TestProviderHashComparison_AzureDBValuePreservedWhenHashMatches(t *testing.
 				Weight:  1,
 				Aliases: schemas.KeyAliases{"gpt-4": "gpt-4-deployment"},
 				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint:   *schemas.NewEnvVar("https://myazure.openai.azure.com"), // Same
-					APIVersion: schemas.NewEnvVar("2024-02-01"),                        // Same
+					Endpoint: *schemas.NewEnvVar("https://myazure.openai.azure.com"), // Same
 				},
 			},
 		},
@@ -6416,8 +6304,7 @@ func TestProviderHashComparison_AzureConfigChangedInFile(t *testing.T) {
 				Value:  *schemas.NewEnvVar("azure-api-key-123"),
 				Weight: 1,
 				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint:   *schemas.NewEnvVar("https://old-azure.openai.azure.com"),
-					APIVersion: schemas.NewEnvVar("2024-02-01"),
+					Endpoint: *schemas.NewEnvVar("https://old-azure.openai.azure.com"),
 				},
 			},
 		},
@@ -6434,7 +6321,7 @@ func TestProviderHashComparison_AzureConfigChangedInFile(t *testing.T) {
 		"azure": dbConfig,
 	}
 
-	// File has CHANGED Azure config (new endpoint, new API version)
+	// File has CHANGED Azure config (new endpoint)
 	fileConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{
 			{
@@ -6444,8 +6331,7 @@ func TestProviderHashComparison_AzureConfigChangedInFile(t *testing.T) {
 				Weight:  1,
 				Aliases: schemas.KeyAliases{"gpt-4o": "gpt-4o-deployment"},
 				AzureKeyConfig: &schemas.AzureKeyConfig{
-					Endpoint:   *schemas.NewEnvVar("https://NEW-azure.openai.azure.com"), // Changed!
-					APIVersion: schemas.NewEnvVar("2024-10-21"),                          // Changed!
+					Endpoint: *schemas.NewEnvVar("https://NEW-azure.openai.azure.com"), // Changed!
 				},
 			},
 		},
@@ -6477,9 +6363,6 @@ func TestProviderHashComparison_AzureConfigChangedInFile(t *testing.T) {
 	}
 	if updatedConfig.Keys[0].AzureKeyConfig.Endpoint.GetValue() != "https://NEW-azure.openai.azure.com" {
 		t.Errorf("Expected new Azure endpoint, got %v", updatedConfig.Keys[0].AzureKeyConfig.Endpoint)
-	}
-	if updatedConfig.Keys[0].AzureKeyConfig.APIVersion.GetValue() != "2024-10-21" {
-		t.Errorf("Expected new API version, got %v", *updatedConfig.Keys[0].AzureKeyConfig.APIVersion)
 	}
 	if !updatedConfig.SendBackRawResponse {
 		t.Error("Expected SendBackRawResponse to be updated to true")
@@ -13763,10 +13646,8 @@ func TestGenerateKeyHash_RuntimeVsMigrationParity(t *testing.T) {
 
 	// Test case 2: AzureKeyConfig
 	t.Run("AzureKeyConfig_GORMRoundTrip", func(t *testing.T) {
-		apiVersion := "2024-02-01"
 		azureConfig := &schemas.AzureKeyConfig{
-			Endpoint:   *schemas.NewEnvVar("https://myresource.openai.azure.com"),
-			APIVersion: schemas.NewEnvVar(apiVersion),
+			Endpoint: *schemas.NewEnvVar("https://myresource.openai.azure.com"),
 		}
 
 		keyToSave := tables.TableKey{

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2404,10 +2404,6 @@
                   "type": "string",
                   "description": "Azure endpoint (can use env. prefix)"
                 },
-                "api_version": {
-                  "type": "string",
-                  "description": "Azure API version"
-                },
                 "client_id": {
                   "type": "string",
                   "description": "Azure client ID for Entra authentication (can use env. prefix)"

--- a/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiKeysFormFragment.tsx
@@ -457,20 +457,6 @@ export function ApiKeyFormFragment({ control, providerName, form }: Props) {
 							</FormItem>
 						)}
 					/>
-					<FormField
-						control={control}
-						name={`key.azure_key_config.api_version`}
-						render={({ field }) => (
-							<FormItem>
-								<FormLabel>API Version (Optional)</FormLabel>
-								<FormControl>
-									<EnvVarInput placeholder="2024-02-01 or env.AZURE_API_VERSION" {...field} />
-								</FormControl>
-								<FormMessage />
-							</FormItem>
-						)}
-					/>
-
 					{azureAuthType === "entra_id" && (
 						<>
 							<FormField


### PR DESCRIPTION
## Summary

Removes the Azure-specific `api-version` query parameter and deployment-based URL patterns (`/openai/deployments/{model}/...`) from all Azure provider endpoints, replacing them with OpenAI-compatible `/openai/v1/...` paths. This aligns the Azure provider with a unified API routing approach where the endpoint itself is expected to handle versioning.

## Changes

- Replaced all `/openai/deployments/{model}/{operation}?api-version={version}` URL patterns with `/openai/v1/{operation}` across every operation: chat completions, text completions, embeddings, speech, transcription, image generation, image edits, files, batches, responses, and list models.
- Removed all `apiVersion` resolution logic (including fallback to `AzureAPIVersionDefault` and `AzureAPIVersionImageEditDefault`) throughout the provider since the version is no longer appended to URLs.
- Removed the hardcoded `?api-version=preview` suffix from the responses endpoint.
- Updated `buildContainerURL` to drop the `?api-version=` suffix, keeping the `/openai/v1{path}` format.
- The `BatchCancel` URL was also corrected to use the consistent `/openai/v1/batches/{id}/cancel` path.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

Validate that requests to each Azure operation (chat, completions, embeddings, speech, transcription, image generation, image edits, files, batches) are routed to the correct `/openai/v1/...` path without any `api-version` query parameter appended.

## Breaking changes

- [x] Yes
- [ ] No

Any Azure deployments relying on the `api-version` query parameter being automatically appended by Bifrost will no longer receive it. The configured Azure endpoint must now handle versioning independently (e.g., via an API gateway or proxy that injects the required `api-version`). The `AzureKeyConfig.APIVersion` field is no longer used by the provider.

## Related issues

## Security considerations

No auth or secrets handling changes. The removal of `api-version` from URLs has no direct security implications, but operators should ensure their Azure endpoint or gateway enforces the correct API version to avoid unintended access to preview or deprecated API surfaces.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable