### PR TITLE
fix: map vertex trrafic type to bifrost service tier

### DIFF
--- a/core/providers/gemini/chat.go
+++ b/core/providers/gemini/chat.go
@@ -281,9 +281,13 @@ func (response *GenerateContentResponse) ToBifrostChatResponse() *schemas.Bifros
 	// Set usage information
 	bifrostResp.Usage = ConvertGeminiUsageMetadataToChatUsage(response.UsageMetadata)
 
-	if response.UsageMetadata != nil && response.UsageMetadata.ServiceTier != "" {
-		tier := mapGeminiServiceTierToBifrost(response.UsageMetadata.ServiceTier)
-		bifrostResp.ServiceTier = &tier
+	if response.UsageMetadata != nil {
+		if t := mapGeminiTrafficTypeToBifrost(response.UsageMetadata.TrafficType); t != nil {
+			bifrostResp.ServiceTier = t
+		} else if response.UsageMetadata.ServiceTier != "" {
+			tier := mapGeminiServiceTierToBifrost(response.UsageMetadata.ServiceTier)
+			bifrostResp.ServiceTier = &tier
+		}
 	}
 
 	return bifrostResp
@@ -504,7 +508,9 @@ func (response *GenerateContentResponse) ToBifrostChatCompletionStream(state *Ge
 	// Add usage information if this is the last chunk
 	if isLastChunk && response.UsageMetadata != nil {
 		streamResponse.Usage = ConvertGeminiUsageMetadataToChatUsage(response.UsageMetadata)
-		if response.UsageMetadata.ServiceTier != "" {
+		if t := mapGeminiTrafficTypeToBifrost(response.UsageMetadata.TrafficType); t != nil {
+			streamResponse.ServiceTier = t
+		} else if response.UsageMetadata.ServiceTier != "" {
 			tier := mapGeminiServiceTierToBifrost(response.UsageMetadata.ServiceTier)
 			streamResponse.ServiceTier = &tier
 		}

--- a/core/providers/gemini/responses.go
+++ b/core/providers/gemini/responses.go
@@ -172,9 +172,13 @@ func (response *GenerateContentResponse) ToResponsesBifrostResponsesResponse() *
 	// Convert usage information
 	bifrostResp.Usage = ConvertGeminiUsageMetadataToResponsesUsage(response.UsageMetadata)
 
-	if response.UsageMetadata != nil && response.UsageMetadata.ServiceTier != "" {
-		tier := mapGeminiServiceTierToBifrost(response.UsageMetadata.ServiceTier)
-		bifrostResp.ServiceTier = &tier
+	if response.UsageMetadata != nil {
+		if t := mapGeminiTrafficTypeToBifrost(response.UsageMetadata.TrafficType); t != nil {
+			bifrostResp.ServiceTier = t
+		} else if response.UsageMetadata.ServiceTier != "" {
+			tier := mapGeminiServiceTierToBifrost(response.UsageMetadata.ServiceTier)
+			bifrostResp.ServiceTier = &tier
+		}
 	}
 
 	// Convert candidates to Responses output messages
@@ -487,7 +491,11 @@ func ToGeminiResponsesResponse(bifrostResp *schemas.BifrostResponsesResponse) *G
 		if geminiResp.UsageMetadata == nil {
 			geminiResp.UsageMetadata = &GenerateContentResponseUsageMetadata{}
 		}
-		geminiResp.UsageMetadata.ServiceTier = mapBifrostServiceTierToGemini(*bifrostResp.ServiceTier)
+		if bifrostResp.ExtraFields.Provider == schemas.Vertex {
+			geminiResp.UsageMetadata.TrafficType = mapBifrostServiceTierToVertexTrafficType(*bifrostResp.ServiceTier)
+		} else {
+			geminiResp.UsageMetadata.ServiceTier = mapBifrostServiceTierToGemini(*bifrostResp.ServiceTier)
+		}
 	}
 
 	return geminiResp
@@ -746,7 +754,11 @@ func ToGeminiResponsesStreamResponse(bifrostResp *schemas.BifrostResponsesStream
 				if streamResp.UsageMetadata == nil {
 					streamResp.UsageMetadata = &GenerateContentResponseUsageMetadata{}
 				}
-				streamResp.UsageMetadata.ServiceTier = mapBifrostServiceTierToGemini(*bifrostResp.Response.ServiceTier)
+				if bifrostResp.Response.ExtraFields.Provider == schemas.Vertex {
+					streamResp.UsageMetadata.TrafficType = mapBifrostServiceTierToVertexTrafficType(*bifrostResp.Response.ServiceTier)
+				} else {
+					streamResp.UsageMetadata.ServiceTier = mapBifrostServiceTierToGemini(*bifrostResp.Response.ServiceTier)
+				}
 			}
 
 			// Derive finish reason from StopReason when present
@@ -1837,9 +1849,13 @@ func closeGeminiOpenItems(state *GeminiResponsesStreamState, groundingMetadata *
 		CreatedAt: state.CreatedAt,
 		Usage:     bifrostUsage,
 	}
-	if usage != nil && usage.ServiceTier != "" {
-		tier := mapGeminiServiceTierToBifrost(usage.ServiceTier)
-		completedResp.ServiceTier = &tier
+	if usage != nil {
+		if t := mapGeminiTrafficTypeToBifrost(usage.TrafficType); t != nil {
+			completedResp.ServiceTier = t
+		} else if usage.ServiceTier != "" {
+			tier := mapGeminiServiceTierToBifrost(usage.ServiceTier)
+			completedResp.ServiceTier = &tier
+		}
 	}
 	if state.Model != nil {
 		completedResp.Model = *state.Model

--- a/core/providers/gemini/types.go
+++ b/core/providers/gemini/types.go
@@ -827,6 +827,16 @@ const (
 	ServiceTierPriority ServiceTier = "priority"
 )
 
+type TrafficType string
+
+const (
+	TrafficTypeUnspecified          TrafficType = "TRAFFIC_TYPE_UNSPECIFIED"
+	TrafficTypeOnDemand             TrafficType = "ON_DEMAND"
+	TrafficTypeOnDemandPriority     TrafficType = "ON_DEMAND_PRIORITY"
+	TrafficTypeOnDemandFlex         TrafficType = "ON_DEMAND_FLEX"
+	TrafficTypeProvisionedThroughput TrafficType = "PROVISIONED_THROUGHPUT"
+)
+
 // GenerationConfig represents generation configuration. You can find API default values and more details at https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/inference#generationconfig
 // and https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/content-generation-parameters.
 type GenerationConfig struct {
@@ -1920,7 +1930,7 @@ type GenerateContentResponseUsageMetadata struct {
 	TotalTokenCount int32 `json:"totalTokenCount,omitempty"`
 	// Output only. Traffic type. This shows whether a request consumes Pay-As-You-Go or
 	// Provisioned Throughput quota.
-	TrafficType string `json:"trafficType,omitempty"`
+	TrafficType TrafficType `json:"trafficType,omitempty"`
 	// Output only. The service tier used to serve the request.
 	ServiceTier ServiceTier `json:"serviceTier,omitempty"`
 }

--- a/core/providers/gemini/utils.go
+++ b/core/providers/gemini/utils.go
@@ -367,6 +367,42 @@ func mapGeminiServiceTierToBifrost(tier ServiceTier) schemas.BifrostServiceTier 
 	}
 }
 
+// mapGeminiTrafficTypeToBifrost converts a Vertex AI usageMetadata.trafficType to a BifrostServiceTier.
+// Returns nil for empty or unrecognised values.
+func mapGeminiTrafficTypeToBifrost(trafficType TrafficType) *schemas.BifrostServiceTier {
+	var tier schemas.BifrostServiceTier
+	switch trafficType {
+	case TrafficTypeOnDemand:
+		tier = schemas.BifrostServiceTierDefault
+	case TrafficTypeOnDemandPriority:
+		tier = schemas.BifrostServiceTierPriority
+	case TrafficTypeOnDemandFlex:
+		tier = schemas.BifrostServiceTierFlex
+	case TrafficTypeProvisionedThroughput:
+		tier = schemas.BifrostServiceTierProvisioned
+	default:
+		return nil
+	}
+	return &tier
+}
+
+// mapBifrostServiceTierToVertexTrafficType converts a BifrostServiceTier to a Vertex AI trafficType string.
+// Returns "" for auto (unresolved) since the actual traffic type cannot be determined.
+func mapBifrostServiceTierToVertexTrafficType(tier schemas.BifrostServiceTier) TrafficType {
+	switch tier {
+	case schemas.BifrostServiceTierDefault:
+		return TrafficTypeOnDemand
+	case schemas.BifrostServiceTierPriority:
+		return TrafficTypeOnDemandPriority
+	case schemas.BifrostServiceTierFlex:
+		return TrafficTypeOnDemandFlex
+	case schemas.BifrostServiceTierProvisioned:
+		return TrafficTypeProvisionedThroughput
+	default:
+		return ""
+	}
+}
+
 // convertSchemaToFunctionParameters converts genai.Schema to schemas.FunctionParameters
 func convertSchemaToFunctionParameters(schema *Schema) schemas.ToolFunctionParameters {
 	params := schemas.ToolFunctionParameters{

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1487,10 +1487,11 @@ type BifrostServiceTier string
 
 // BifrostServiceTier values
 const (
-	BifrostServiceTierAuto     BifrostServiceTier = "auto"
-	BifrostServiceTierDefault  BifrostServiceTier = "default"
-	BifrostServiceTierFlex     BifrostServiceTier = "flex"
-	BifrostServiceTierPriority BifrostServiceTier = "priority"
+	BifrostServiceTierAuto        BifrostServiceTier = "auto"
+	BifrostServiceTierDefault     BifrostServiceTier = "default"
+	BifrostServiceTierFlex        BifrostServiceTier = "flex"
+	BifrostServiceTierPriority    BifrostServiceTier = "priority"
+	BifrostServiceTierProvisioned BifrostServiceTier = "provisioned"
 )
 
 type BifrostReasoningDetailsType string


### PR DESCRIPTION
## Summary

Adds support for Vertex AI's `trafficType` field in `usageMetadata` responses, mapping it to the Bifrost `ServiceTier` abstraction. Previously, only the `serviceTier` field was used, which is specific to the Gemini API. Vertex AI uses a separate `trafficType` field to indicate quota consumption (e.g., on-demand, provisioned throughput). This PR introduces proper handling for both fields and adds a new `provisioned` service tier value.

## Changes

- Introduced a typed `TrafficType` constant set covering `ON_DEMAND`, `ON_DEMAND_PRIORITY`, `ON_DEMAND_FLEX`, and `PROVISIONED_THROUGHPUT` values, replacing the previous untyped `string` field on `GenerateContentResponseUsageMetadata`.
- Added `mapGeminiTrafficTypeToBifrost` to convert Vertex AI `trafficType` values to `BifrostServiceTier`, returning `nil` for unrecognised or empty values.
- Added `mapBifrostServiceTierToVertexTrafficType` to convert `BifrostServiceTier` back to a Vertex AI `TrafficType` for round-trip serialisation.
- Updated `ServiceTier` resolution in chat, responses, and streaming paths to prefer `trafficType` over `serviceTier`, falling back to `serviceTier` when `trafficType` is absent or unrecognised.
- When serialising back to Gemini/Vertex format, the provider is now checked: Vertex responses use `trafficType`, while Gemini responses continue to use `serviceTier`.
- Added `BifrostServiceTierProvisioned` as a new canonical service tier value.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./...
```

- Send a request through the Vertex AI provider and verify that the returned `ServiceTier` reflects the `trafficType` in the response metadata (e.g., `ON_DEMAND` → `default`, `PROVISIONED_THROUGHPUT` → `provisioned`).
- Send a request through the standard Gemini provider and verify that `serviceTier` is still used when `trafficType` is absent.
- Verify streaming responses also populate `ServiceTier` correctly on the final chunk.

## Breaking changes

- [x] Yes
- [ ] No

`BifrostServiceTierProvisioned` is a new enum value. Consumers performing exhaustive switches over `BifrostServiceTier` should add a case for `"provisioned"`.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable