### PR TITLE
fix: fixes the start time setting for correct ttft metric value

### DIFF
--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -631,6 +631,7 @@ func HandleAnthropicChatCompletionStreaming(
 	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
 	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
 
+	startTime := time.Now()
 	// Make the request
 	err := activeClient.Do(req, resp)
 	if usedLargePayloadBody {
@@ -713,7 +714,6 @@ func HandleAnthropicChatCompletionStreaming(
 
 		chunkIndex := 0
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		// Track minimal state needed for response format
@@ -1103,6 +1103,7 @@ func HandleAnthropicResponsesStream(
 	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
 	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
 
+	startTime := time.Now()
 	// Make the request
 	err := activeClient.Do(req, resp)
 	if usedLargePayloadBody {
@@ -1186,7 +1187,6 @@ func HandleAnthropicResponsesStream(
 		sseReader := providerUtils.GetSSEEventReader(ctx, reader)
 		chunkIndex := 0
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		// Track minimal state needed for response format

--- a/core/providers/azure/azure.go
+++ b/core/providers/azure/azure.go
@@ -1011,6 +1011,7 @@ func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHoo
 		req.SetBody(jsonBody)
 	}
 
+	startTime := time.Now()
 	// Make the request
 	requestErr := provider.client.Do(req, resp)
 	if requestErr != nil {
@@ -1073,7 +1074,6 @@ func (provider *AzureProvider) SpeechStream(ctx *schemas.BifrostContext, postHoo
 		defer stopCancellation()
 
 		chunkIndex := -1
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		// Read SSE events manually to handle binary data with embedded newlines

--- a/core/providers/bedrock/bedrock.go
+++ b/core/providers/bedrock/bedrock.go
@@ -930,6 +930,7 @@ func (provider *BedrockProvider) TextCompletionStream(ctx *schemas.BifrostContex
 		return nil, bifrostErr
 	}
 
+	startTime := time.Now()
 	resp, bifrostErr := provider.makeStreamingRequest(ctx, jsonData, key, request.Model, "invoke-with-response-stream")
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
@@ -964,7 +965,6 @@ func (provider *BedrockProvider) TextCompletionStream(ctx *schemas.BifrostContex
 		defer stopCancellation()
 
 		// Process AWS Event Stream format
-		startTime := time.Now()
 		decoder := eventstream.NewDecoder()
 		payloadBuf := make([]byte, 0, 1024*1024) // 1MB payload buffer
 
@@ -1166,6 +1166,7 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 		return nil, bifrostErr
 	}
 
+	startTime := time.Now()
 	resp, bifrostErr := provider.makeStreamingRequest(ctx, jsonData, key, request.Model, "converse-stream")
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
@@ -1204,7 +1205,6 @@ func (provider *BedrockProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 		chunkIndex := 0
 
 		// Process AWS Event Stream format using proper decoder
-		startTime := time.Now()
 		lastChunkTime := startTime
 		decoder := eventstream.NewDecoder()
 		payloadBuf := make([]byte, 0, 1024*1024) // 1MB payload buffer
@@ -1546,6 +1546,7 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 		return nil, bifrostErr
 	}
 
+	startTime := time.Now()
 	resp, bifrostErr := provider.makeStreamingRequest(ctx, jsonData, key, request.Model, "converse-stream")
 	if bifrostErr != nil {
 		return nil, providerUtils.EnrichError(ctx, bifrostErr, jsonData, nil, provider.sendBackRawRequest, provider.sendBackRawResponse)
@@ -1598,7 +1599,6 @@ func (provider *BedrockProvider) ResponsesStream(ctx *schemas.BifrostContext, po
 		var isAccumulatingStructuredOutput bool
 
 		// Process AWS Event Stream format using proper decoder
-		startTime := time.Now()
 		lastChunkTime := startTime
 		decoder := eventstream.NewDecoder()
 		payloadBuf := make([]byte, 0, 1024*1024) // 1MB payload buffer

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -454,6 +454,7 @@ func (provider *CohereProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 		req.SetBody(jsonBody)
 	}
 
+	startTime := time.Now()
 	// Make the request
 	err := provider.streamingClient.Do(req, resp)
 	if usedLargePayloadBody {
@@ -525,7 +526,6 @@ func (provider *CohereProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 		chunkIndex := 0
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		var responseID string
@@ -719,6 +719,7 @@ func (provider *CohereProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 		req.SetBody(jsonBody)
 	}
 
+	startTime := time.Now()
 	// Make the request
 	err := provider.streamingClient.Do(req, resp)
 	if usedLargePayloadBody {
@@ -792,7 +793,6 @@ func (provider *CohereProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 
 		chunkIndex := 0
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		// Create stream state for stateful conversions (outside loop to persist across events)

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -425,6 +425,7 @@ func HandleGeminiChatCompletionStream(
 		req.SetBody(jsonBody)
 	}
 
+	startTime := time.Now()
 	// Make the request — caller is responsible for passing a streaming-configured client.
 	doErr := client.Do(req, resp)
 	if doErr != nil {
@@ -511,7 +512,6 @@ func HandleGeminiChatCompletionStream(
 		}
 
 		chunkIndex := 0
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		var responseID string
@@ -925,6 +925,7 @@ func HandleGeminiResponsesStream(
 		req.SetBody(jsonBody)
 	}
 
+	startTime := time.Now()
 	// Make the request — caller is responsible for passing a streaming-configured client.
 	doErr := client.Do(req, resp)
 	if doErr != nil {
@@ -1019,7 +1020,6 @@ func HandleGeminiResponsesStream(
 
 		chunkIndex := 0
 		sequenceNumber := 0 // Track sequence across all events
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		// Initialize stream state for responses lifecycle management
@@ -1414,6 +1414,7 @@ func (provider *GeminiProvider) SpeechStream(ctx *schemas.BifrostContext, postHo
 		req.SetBody(jsonBody)
 	}
 
+	startTime := time.Now()
 	// Make the request
 	err := provider.streamingClient.Do(req, resp)
 	if err != nil {
@@ -1485,7 +1486,6 @@ func (provider *GeminiProvider) SpeechStream(ctx *schemas.BifrostContext, postHo
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 		chunkIndex := -1
 		usage := &schemas.SpeechUsage{}
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		for {
@@ -1704,6 +1704,7 @@ func (provider *GeminiProvider) TranscriptionStream(ctx *schemas.BifrostContext,
 		req.SetBody(jsonBody)
 	}
 
+	startTime := time.Now()
 	// Make the request
 	err := provider.streamingClient.Do(req, resp)
 	if err != nil {
@@ -1773,7 +1774,6 @@ func (provider *GeminiProvider) TranscriptionStream(ctx *schemas.BifrostContext,
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 		chunkIndex := -1
 		usage := &schemas.TranscriptionUsage{}
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		var fullTranscriptionText string

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -1061,6 +1061,7 @@ func (provider *HuggingFaceProvider) ImageGenerationStream(ctx *schemas.BifrostC
 		req.SetBody(jsonBody)
 	}
 
+	startTime := time.Now()
 	// Make the request
 	err := provider.streamingClient.Do(req, resp)
 	if err != nil {
@@ -1132,8 +1133,7 @@ func (provider *HuggingFaceProvider) ImageGenerationStream(ctx *schemas.BifrostC
 
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 
-		// Initialize latency timers post-handshake so chunk latency reflects pure streaming time.
-		startTime := time.Now()
+		// Seed lastChunkTime with startTime (captured before Do) so the first chunk's latency reflects TTFT, including request/network time.
 		lastChunkTime := startTime
 		chunkIndex := 0
 		var lastB64Data, lastURLData, lastJsonData string
@@ -1440,6 +1440,7 @@ func (provider *HuggingFaceProvider) ImageEditStream(ctx *schemas.BifrostContext
 		req.SetBody(jsonBody)
 	}
 
+	startTime := time.Now()
 	// Make the request
 	err := provider.streamingClient.Do(req, resp)
 	if err != nil {
@@ -1511,8 +1512,7 @@ func (provider *HuggingFaceProvider) ImageEditStream(ctx *schemas.BifrostContext
 
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 
-		// Initialize latency timers post-handshake so chunk latency reflects pure streaming time.
-		startTime := time.Now()
+		// Seed lastChunkTime with startTime (captured before Do) so the first chunk's latency reflects TTFT, including request/network time.
 		lastChunkTime := startTime
 		chunkIndex := 0
 		var lastB64Data, lastURLData, lastJsonData string

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -424,6 +424,7 @@ func (provider *MistralProvider) TranscriptionStream(ctx *schemas.BifrostContext
 
 	req.SetBody(body.Bytes())
 
+	startTime := time.Now()
 	// Make the request
 	err := provider.streamingClient.Do(req, resp)
 	if err != nil {
@@ -493,7 +494,6 @@ func (provider *MistralProvider) TranscriptionStream(ctx *schemas.BifrostContext
 		sseReader := providerUtils.GetSSEEventReader(ctx, reader)
 		chunkIndex := -1
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		for {

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -487,6 +487,7 @@ func HandleOpenAITextCompletionStreaming(
 	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
 	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
 
+	startTime := time.Now()
 	// Make the request
 	err := activeClient.Do(req, resp)
 	if err != nil {
@@ -570,7 +571,6 @@ func HandleOpenAITextCompletionStreaming(
 
 		var finishReason *string
 		var messageID string
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		for {
@@ -1028,6 +1028,7 @@ func HandleOpenAIChatCompletionStreaming(
 	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
 	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
 
+	startTime := time.Now()
 	// Make the request
 	err := activeClient.Do(req, resp)
 	if err != nil {
@@ -1111,7 +1112,6 @@ func HandleOpenAIChatCompletionStreaming(
 		chunkIndex := -1
 		usage := &schemas.BifrostLLMUsage{}
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		var finishReason *string
@@ -1669,6 +1669,7 @@ func HandleOpenAIResponsesStreaming(
 	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
 	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
 
+	startTime := time.Now()
 	// Make the request
 	err := activeClient.Do(req, resp)
 	if err != nil {
@@ -1747,7 +1748,6 @@ func HandleOpenAIResponsesStreaming(
 
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		for {
@@ -2282,6 +2282,7 @@ func HandleOpenAISpeechStreamRequest(
 	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
 	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
 
+	startTime := time.Now()
 	// Make the request
 	err := activeClient.Do(req, resp)
 	if err != nil {
@@ -2358,7 +2359,6 @@ func HandleOpenAISpeechStreamRequest(
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 		chunkIndex := -1
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 
 		for {
@@ -2723,6 +2723,7 @@ func HandleOpenAITranscriptionStreamRequest(
 
 	req.SetBody(body.Bytes())
 
+	startTime := time.Now()
 	// Make the request
 	err := client.Do(req, resp)
 	if err != nil {
@@ -2799,7 +2800,6 @@ func HandleOpenAITranscriptionStreamRequest(
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 		chunkIndex := -1
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 		var fullTranscriptionText string
 
@@ -3161,6 +3161,7 @@ func HandleOpenAIImageGenerationStreaming(
 	// MaxResponseBodySize > 0 so ErrBodyTooLarge triggers StreamBody for Content-Length responses.
 	activeClient := providerUtils.PrepareResponseStreaming(ctx, client, resp)
 
+	startTime := time.Now()
 	// Make the request
 	err := activeClient.Do(req, resp)
 	if err != nil {
@@ -3236,7 +3237,6 @@ func HandleOpenAIImageGenerationStreaming(
 
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 		var collectedUsage *schemas.ImageUsage
 		// Track chunk indices per image - similar to how speech/transcription track chunkIndex
@@ -4400,6 +4400,7 @@ func HandleOpenAIImageEditStreamRequest(
 
 	req.SetBody(body.Bytes())
 
+	startTime := time.Now()
 	// Make the request
 	err := client.Do(req, resp)
 	if err != nil {
@@ -4474,7 +4475,6 @@ func HandleOpenAIImageEditStreamRequest(
 
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 		var collectedUsage *schemas.ImageUsage
 		// Track chunk indices per image - similar to how speech/transcription track chunkIndex

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -534,6 +534,7 @@ func (provider *ReplicateProvider) TextCompletionStream(ctx *schemas.BifrostCont
 		useDeploymentsEndpoint(key),
 	)
 
+	startTime := time.Now()
 	// Create prediction
 	prediction, _, _, _, err := createPrediction(
 		ctx,
@@ -608,7 +609,6 @@ func (provider *ReplicateProvider) TextCompletionStream(ctx *schemas.BifrostCont
 		stopCancellation := providerUtils.SetupStreamCancellation(ctx, resp.BodyStream(), provider.logger)
 		defer stopCancellation()
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 		chunkIndex := 0
 
@@ -873,6 +873,7 @@ func (provider *ReplicateProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 		useDeploymentsEndpoint(key),
 	)
 
+	startTime := time.Now()
 	// Create prediction
 	prediction, _, _, _, err := createPrediction(
 		ctx,
@@ -947,7 +948,6 @@ func (provider *ReplicateProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 		stopCancellation := providerUtils.SetupStreamCancellation(ctx, resp.BodyStream(), provider.logger)
 		defer stopCancellation()
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 		chunkIndex := 0
 
@@ -1225,6 +1225,7 @@ func (provider *ReplicateProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 		useDeploymentsEndpoint(key),
 	)
 
+	startTime := time.Now()
 	// Create prediction
 	prediction, _, _, _, err := createPrediction(
 		ctx,
@@ -1351,7 +1352,6 @@ func (provider *ReplicateProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 		defer stopCancellation()
 
 		sseReader := providerUtils.GetSSEEventReader(ctx, reader)
-		startTime := time.Now()
 		sequenceNumber := 0
 		messageID := prediction.ID
 		// Generate a unique item ID for the message (needed for accumulator to track deltas)
@@ -1840,6 +1840,7 @@ func (provider *ReplicateProvider) ImageGenerationStream(ctx *schemas.BifrostCon
 		schemas.ImageGenerationStreamRequest,
 		useDeploymentsEndpoint(key),
 	)
+	startTime := time.Now()
 	// Create prediction
 	prediction, _, _, _, err := createPrediction(
 		ctx,
@@ -1921,7 +1922,6 @@ func (provider *ReplicateProvider) ImageGenerationStream(ctx *schemas.BifrostCon
 		stopCancellation := providerUtils.SetupStreamCancellation(ctx, resp.BodyStream(), provider.logger)
 		defer stopCancellation()
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 		chunkIndex := 0
 
@@ -2246,6 +2246,7 @@ func (provider *ReplicateProvider) ImageEditStream(ctx *schemas.BifrostContext, 
 		useDeploymentsEndpoint(key),
 	)
 
+	startTime := time.Now()
 	// Create prediction
 	prediction, _, _, _, err := createPrediction(
 		ctx,
@@ -2327,7 +2328,6 @@ func (provider *ReplicateProvider) ImageEditStream(ctx *schemas.BifrostContext, 
 		stopCancellation := providerUtils.SetupStreamCancellation(ctx, resp.BodyStream(), provider.logger)
 		defer stopCancellation()
 
-		startTime := time.Now()
 		lastChunkTime := startTime
 		chunkIndex := 0
 

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -486,6 +486,7 @@ func (provider *VLLMProvider) TranscriptionStream(ctx *schemas.BifrostContext, p
 
 		req.SetBody(body.Bytes())
 
+		startTime := time.Now()
 		// Make the request
 		err := provider.streamingClient.Do(req, resp)
 		if err != nil {
@@ -555,7 +556,6 @@ func (provider *VLLMProvider) TranscriptionStream(ctx *schemas.BifrostContext, p
 			sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 			chunkIndex := -1
 
-			startTime := time.Now()
 			lastChunkTime := startTime
 			var fullTranscriptionText strings.Builder
 


### PR DESCRIPTION
## Summary

`startTime` was being captured inside the goroutine that processes stream chunks, meaning it reflected the time after the HTTP connection was established rather than when the request was actually initiated. This caused time-to-first-chunk and inter-chunk latency metrics to be measured from an incorrect baseline.

## Changes

- Moved `startTime := time.Now()` to just before the `client.Do(req, resp)` call in every streaming handler across all providers (Anthropic, Azure, Bedrock, Cohere, Gemini, HuggingFace, Mistral, OpenAI, Replicate, vLLM).
- `lastChunkTime` is initialized from `startTime` as before, so relative chunk-to-chunk latency calculations are unaffected — only the absolute start anchor is now correct.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

Run the full test suite and exercise any streaming endpoint. Verify that reported time-to-first-chunk values now include network round-trip time to the upstream provider rather than starting the clock only after the connection is fully established.

```sh
go test ./...
```

## Breaking changes

- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable